### PR TITLE
Fix assigned issue sweep regressions

### DIFF
--- a/packages/client/.instructions.md
+++ b/packages/client/.instructions.md
@@ -244,14 +244,10 @@ await api.upload("/avatars", formData);
 // File download (triggers save dialog)
 await api.download(`/characters/${id}/export`, "character.json");
 
-// SSE streaming (tokens only)
-for await (const token of api.stream("/generate", body)) {
-  buffer += token;
-}
-
-// SSE streaming (all event types)
-for await (const event of api.streamEvents("/generate", body)) {
+// SSE streaming (all event types, preferred for generation)
+for await (const event of api.streamEvents("/generate", body, abortController.signal)) {
   // event: { type: "token" | "agent_update" | "game_state" | "done" | "error", data, ... }
+  if (event.type === "token") buffer += String(event.data ?? "");
 }
 ```
 

--- a/packages/client/src/components/agents/AgentEditor.tsx
+++ b/packages/client/src/components/agents/AgentEditor.tsx
@@ -400,6 +400,43 @@ export function AgentEditor() {
   const createAgent = useCreateAgent();
   const qc = useQueryClient();
   const deleteAgent = useDeleteAgent();
+  const connectionIndexRef = useRef<{
+    loaded: boolean;
+    llmIds: Set<string>;
+    imageIds: Set<string>;
+  }>({ loaded: false, llmIds: new Set(), imageIds: new Set() });
+
+  useEffect(() => {
+    const rows =
+      (connections as
+        | Array<{
+            id: string;
+            provider: string;
+          }>
+        | undefined) ?? [];
+    connectionIndexRef.current = {
+      loaded: Array.isArray(connections),
+      llmIds: new Set(rows.filter((connection) => connection.provider !== "image_generation").map((connection) => connection.id)),
+      imageIds: new Set(rows.filter((connection) => connection.provider === "image_generation").map((connection) => connection.id)),
+    };
+  }, [connections]);
+
+  const normalizeTextConnectionOverride = useCallback((connectionId: unknown): string => {
+    if (typeof connectionId !== "string" || !connectionId.trim()) return "";
+    if (connectionId === LOCAL_SIDECAR_CONNECTION_ID) {
+      return import.meta.env.VITE_MARINARA_LITE === "true" ? "" : connectionId;
+    }
+    const index = connectionIndexRef.current;
+    if (!index.loaded) return connectionId;
+    return index.llmIds.has(connectionId) ? connectionId : "";
+  }, []);
+
+  const normalizeImageConnectionOverride = useCallback((connectionId: unknown): string => {
+    if (typeof connectionId !== "string" || !connectionId.trim()) return "";
+    const index = connectionIndexRef.current;
+    if (!index.loaded) return connectionId;
+    return index.imageIds.has(connectionId) ? connectionId : "";
+  }, []);
 
   // Find built-in meta (null for custom agents)
   const builtIn = useMemo(() => BUILT_IN_AGENTS.find((a) => a.id === agentDetailId) ?? null, [agentDetailId]);
@@ -504,7 +541,7 @@ export function AgentEditor() {
       setLocalDescription(dbConfig.description);
       setLocalPhase(normalizeAgentPhaseForType(agentType, dbConfig.phase));
       setLocalAgentEnabled(dbConfig.enabled !== "false");
-      setLocalConnectionId(dbConfig.connectionId ?? "");
+      setLocalConnectionId(normalizeTextConnectionOverride(dbConfig.connectionId));
       const settings = mergeBuiltInAgentSettings(agentType, dbConfig.settings);
       const promptTemplateSource = settings.promptTemplates ?? defaultSettings.promptTemplates;
       setLocalAuthor(
@@ -513,7 +550,7 @@ export function AgentEditor() {
       setLocalPromptTemplates(normalizeAgentPromptTemplateOptions(promptTemplateSource));
       setLocalContextSize(normalizeOptionalNumber(settings.contextSize));
       setLocalMaxTokens(normalizeOptionalNumber(settings.maxTokens) || (defaultSettings.maxTokens as number) || "");
-      setLocalImageConnectionId((settings.imageConnectionId as string) ?? "");
+      setLocalImageConnectionId(normalizeImageConnectionOverride(settings.imageConnectionId));
       setLocalRunInterval(
         (settings.runInterval as number | undefined) ?? (defaultSettings.runInterval as number) ?? "",
       );
@@ -690,7 +727,15 @@ export function AgentEditor() {
     }
     setDirty(false);
     setSaveError(null);
-  }, [agentDetailId, dbConfig, builtIn, connections, customRunIntervalMeta?.defaultValue, isCustomAgent]);
+  }, [
+    agentDetailId,
+    dbConfig,
+    builtIn,
+    customRunIntervalMeta?.defaultValue,
+    isCustomAgent,
+    normalizeTextConnectionOverride,
+    normalizeImageConnectionOverride,
+  ]);
 
   // Fetch music connection status when viewing Music DJ.
   const isSpotifyAgent = agentDetailId === "spotify" || dbConfig?.type === "spotify";
@@ -893,13 +938,15 @@ export function AgentEditor() {
     ]) {
       if (currentSettings[key] !== undefined) preservedSpotifyFields[key] = currentSettings[key];
     }
+    const savedConnectionId = normalizeTextConnectionOverride(localConnectionId);
+    const savedImageConnectionId = normalizeImageConnectionOverride(localImageConnectionId);
 
     const payload = {
       name: localName,
       description: localDescription,
       phase: savedPhase,
       enabled: localAgentEnabled,
-      connectionId: localConnectionId || null,
+      connectionId: savedConnectionId || null,
       promptTemplate: localPrompt,
       settings: {
         ...preservedSpotifyFields,
@@ -934,7 +981,7 @@ export function AgentEditor() {
         // Retrieval to Router would leave behind stale file IDs the user can no
         // longer see or remove via the UI.
         ...(isKnowledgeRetrievalAgent && localSourceFileIds.length > 0 ? { sourceFileIds: localSourceFileIds } : {}),
-        ...(localImageConnectionId ? { imageConnectionId: localImageConnectionId } : {}),
+        ...(savedImageConnectionId ? { imageConnectionId: savedImageConnectionId } : {}),
         ...(localAutoGenerateAvatars ? { autoGenerateAvatars: true } : {}),
         ...(localAutoGenerateBackgrounds ? { autoGenerateBackgrounds: true } : {}),
         ...(isIllustratorAgent
@@ -1042,6 +1089,8 @@ export function AgentEditor() {
     updateAgent,
     createAgent,
     openAgentDetail,
+    normalizeTextConnectionOverride,
+    normalizeImageConnectionOverride,
   ]);
 
   const handleExportAgent = () => {

--- a/packages/client/src/components/chat/ChatInput.tsx
+++ b/packages/client/src/components/chat/ChatInput.tsx
@@ -1563,7 +1563,9 @@ export const ChatInput = memo(function ChatInput({
         {/* Send / Stop button */}
 
         <button
-          onClick={isStreaming ? () => useChatStore.getState().stopGeneration() : handleSend}
+          onClick={
+            isStreaming ? () => useChatStore.getState().stopGeneration(activeChatId ?? undefined) : handleSend
+          }
           disabled={
             (!isStreaming && isReadingAttachments) ||
             (!hasInput && !attachments.length && !isStreaming && !canRetry && !canContinue) ||

--- a/packages/client/src/components/chat/ChatRoleplaySurface.tsx
+++ b/packages/client/src/components/chat/ChatRoleplaySurface.tsx
@@ -14,6 +14,9 @@ import {
 } from "react";
 import {
   type ChatSummaryEntry,
+  type MarkerConfig,
+  type PromptGroup,
+  type PromptSection,
   type SceneForkMode,
   type SpritePlacement,
   type SpriteSide,
@@ -38,7 +41,7 @@ import { useUIStore } from "../../stores/ui.store";
 import { useChatStore } from "../../stores/chat.store";
 import { useGameStateStore } from "../../stores/game-state.store";
 import { useActiveLorebookEntries, useLorebooks } from "../../hooks/use-lorebooks";
-import { usePresets } from "../../hooks/use-presets";
+import { usePresetFull, usePresets } from "../../hooks/use-presets";
 import { ChatMessage } from "./ChatMessage";
 import { ChatInput } from "./ChatInput";
 import { CyoaChoices } from "./CyoaChoices";
@@ -315,6 +318,59 @@ function readStringArray(value: unknown): string[] {
     : [];
 }
 
+function promptEnabled(value: unknown): boolean {
+  return value !== false && value !== "false";
+}
+
+function readMarkerConfig(value: unknown): MarkerConfig | null {
+  if (!value) return null;
+  if (typeof value === "string") {
+    try {
+      return JSON.parse(value) as MarkerConfig;
+    } catch {
+      return null;
+    }
+  }
+  return typeof value === "object" ? (value as MarkerConfig) : null;
+}
+
+function groupPathEnabled(groupId: string | null, groupsById: Map<string, PromptGroup>): boolean {
+  let currentId = groupId;
+  const seen = new Set<string>();
+  while (currentId) {
+    if (seen.has(currentId)) return true;
+    seen.add(currentId);
+    const group = groupsById.get(currentId);
+    if (!group) return true;
+    if (!promptEnabled(group.enabled)) return false;
+    currentId = group.parentGroupId;
+  }
+  return true;
+}
+
+function resolveChatSummaryInjectionHint(
+  presetFull: { sections: PromptSection[]; groups: PromptGroup[] } | null | undefined,
+): string | null {
+  if (!presetFull) return null;
+
+  const groupsById = new Map(presetFull.groups.map((group) => [group.id, group]));
+  const summarySections = presetFull.sections.filter((section) => {
+    const isMarker = (section.isMarker as unknown) === true || (section.isMarker as unknown) === "true";
+    return isMarker && readMarkerConfig(section.markerConfig)?.type === "chat_summary";
+  });
+
+  if (summarySections.length === 0) {
+    return "Active preset has no Chat Summary marker, so enabled summaries will not be inserted.";
+  }
+  if (!summarySections.some((section) => promptEnabled(section.enabled))) {
+    return "Chat Summary section is disabled in the active preset.";
+  }
+  if (!summarySections.some((section) => promptEnabled(section.enabled) && groupPathEnabled(section.groupId, groupsById))) {
+    return "Chat Summary section is inside a disabled preset group.";
+  }
+  return null;
+}
+
 function ActiveContextLinksButton({
   chat,
   chatMeta,
@@ -561,6 +617,7 @@ function SummaryButton({
   summaryRunInterval,
   automaticSummariesAvailable,
   totalMessageCount,
+  promptPresetId,
 }: {
   chatId: string | null;
   summary: string | null;
@@ -573,11 +630,14 @@ function SummaryButton({
   summaryRunInterval?: number;
   automaticSummariesAvailable: boolean;
   totalMessageCount: number;
+  promptPresetId?: string | null;
 }) {
   const [open, setOpen] = useState(false);
   const buttonRef = useRef<HTMLButtonElement>(null);
   const [anchor, setAnchor] = useState<ComponentProps<typeof SummaryPopover>["anchor"]>(null);
   const compact = useUIStore((s) => s.centerCompact);
+  const { data: presetFull } = usePresetFull(promptPresetId ?? null);
+  const summaryInjectionHint = useMemo(() => resolveChatSummaryInjectionHint(presetFull), [presetFull]);
 
   useLayoutEffect(() => {
     if (!open || !buttonRef.current) return;
@@ -639,6 +699,7 @@ function SummaryButton({
             summaryRunInterval={summaryRunInterval}
             automaticSummariesAvailable={automaticSummariesAvailable}
             totalMessageCount={totalMessageCount}
+            summaryInjectionHint={summaryInjectionHint}
             anchor={anchor}
             onClose={() => setOpen(false)}
           />
@@ -1223,6 +1284,7 @@ export function ChatRoleplaySurface({
                       summaryRunInterval={summaryRunInterval}
                       automaticSummariesAvailable={chatMode === "roleplay"}
                       totalMessageCount={totalMessageCount}
+                      promptPresetId={typeof chat?.promptPresetId === "string" ? chat.promptPresetId : null}
                     />
                     <ActiveContextLinksButton
                       chat={chat}
@@ -1313,6 +1375,7 @@ export function ChatRoleplaySurface({
                           summaryRunInterval={summaryRunInterval}
                           automaticSummariesAvailable={chatMode === "roleplay"}
                           totalMessageCount={totalMessageCount}
+                          promptPresetId={typeof chat?.promptPresetId === "string" ? chat.promptPresetId : null}
                         />
                         <ActiveContextLinksButton
                           chat={chat}
@@ -1370,6 +1433,7 @@ export function ChatRoleplaySurface({
                         summaryRunInterval={summaryRunInterval}
                         automaticSummariesAvailable={chatMode === "roleplay"}
                         totalMessageCount={totalMessageCount}
+                        promptPresetId={typeof chat?.promptPresetId === "string" ? chat.promptPresetId : null}
                       />
                       <ActiveContextLinksButton
                         chat={chat}

--- a/packages/client/src/components/chat/ChatSettingsDrawer.tsx
+++ b/packages/client/src/components/chat/ChatSettingsDrawer.tsx
@@ -422,6 +422,8 @@ const CHAT_SETTINGS_ORDER = {
   gamePrompt: 0,
 } as const;
 
+const CHAT_PRESET_UNAPPLIED_SELECT_VALUE = "__chat_preset_unapplied__";
+
 type AvailableAgent = {
   id: string;
   name: string;
@@ -2147,13 +2149,16 @@ export function ChatSettingsDrawer({
   const setActiveChatPreset = useSetActiveChatPreset();
   const presetList = useMemo(() => (chatPresets ?? []) as ChatPreset[], [chatPresets]);
   const appliedPresetId = (metadata.appliedChatPresetId as string | undefined) ?? null;
-  const selectedChatPreset = useMemo(() => {
-    if (appliedPresetId) {
-      const match = presetList.find((p) => p.id === appliedPresetId);
-      if (match) return match;
-    }
-    return presetList.find((p) => p.isDefault) ?? null;
+  const appliedChatPreset = useMemo(() => {
+    if (!appliedPresetId) return null;
+    return presetList.find((p) => p.id === appliedPresetId) ?? null;
   }, [presetList, appliedPresetId]);
+  const selectedChatPreset = useMemo(() => {
+    if (appliedChatPreset) return appliedChatPreset;
+    return presetList.find((p) => p.isDefault) ?? null;
+  }, [presetList, appliedChatPreset]);
+  const chatPresetSelectValue =
+    appliedChatPreset?.id ?? (presetList.length > 0 ? CHAT_PRESET_UNAPPLIED_SELECT_VALUE : "");
   const [renamingPreset, setRenamingPreset] = useState(false);
   const [renamePresetVal, setRenamePresetVal] = useState("");
   const presetFileInputRef = useRef<HTMLInputElement | null>(null);
@@ -2399,7 +2404,7 @@ export function ChatSettingsDrawer({
   }, [chat.connectionId, chat.promptPresetId, isConversation, metadata]);
 
   const handleSelectPreset = (id: string) => {
-    if (!id || id === selectedChatPreset?.id) return;
+    if (!id || id === CHAT_PRESET_UNAPPLIED_SELECT_VALUE || id === appliedChatPreset?.id) return;
     applyChatPreset.mutate({ presetId: id, chatId: chat.id });
   };
 
@@ -2748,12 +2753,17 @@ export function ChatSettingsDrawer({
                   />
                 ) : (
                   <select
-                    value={selectedChatPreset?.id ?? ""}
+                    value={chatPresetSelectValue}
                     onChange={(e) => handleSelectPreset(e.target.value)}
                     title="Apply a chat-settings preset to this chat"
                     className="flex-1 min-w-0 rounded-lg bg-[var(--secondary)] px-3 py-2 text-xs outline-none ring-1 ring-transparent transition-shadow focus:ring-[var(--primary)]/40"
                   >
                     {presetList.length === 0 && <option value="">Loading…</option>}
+                    {!appliedChatPreset && presetList.length > 0 && (
+                      <option value={CHAT_PRESET_UNAPPLIED_SELECT_VALUE}>
+                        {appliedPresetId ? "Missing preset - choose a preset" : "Custom settings - choose a preset"}
+                      </option>
+                    )}
                     {presetList.map((p) => (
                       <option key={p.id} value={p.id}>
                         {p.isDefault ? "Default" : p.name}

--- a/packages/client/src/components/chat/ConversationInput.tsx
+++ b/packages/client/src/components/chat/ConversationInput.tsx
@@ -2061,7 +2061,11 @@ export function ConversationInput({
           )}
 
           <button
-            onClick={isActuallyGenerating ? () => useChatStore.getState().stopGeneration() : handleSend}
+            onClick={
+              isActuallyGenerating
+                ? () => useChatStore.getState().stopGeneration(activeChatId ?? undefined)
+                : handleSend
+            }
             disabled={!isActuallyGenerating && (isReadingAttachments || !activeChatId || !canSubmit)}
             aria-label={sendButtonTitle}
             className={cn(

--- a/packages/client/src/components/chat/SummaryPopover.tsx
+++ b/packages/client/src/components/chat/SummaryPopover.tsx
@@ -20,7 +20,20 @@ import {
   useUpdateChatMetadata,
   useUpdateSummaryEntry,
 } from "../../hooks/use-chats";
-import { Check, ChevronRight, Copy, Loader2, PenLine, Plus, Save, ScrollText, Sparkles, Trash2, X } from "lucide-react";
+import {
+  AlertTriangle,
+  Check,
+  ChevronRight,
+  Copy,
+  Loader2,
+  PenLine,
+  Plus,
+  Save,
+  ScrollText,
+  Sparkles,
+  Trash2,
+  X,
+} from "lucide-react";
 import { toast } from "sonner";
 import { cn, generateClientId } from "../../lib/utils";
 import { useUIStore } from "../../stores/ui.store";
@@ -51,6 +64,7 @@ interface SummaryPopoverProps {
   summaryRunInterval?: number;
   automaticSummariesAvailable?: boolean;
   totalMessageCount: number;
+  summaryInjectionHint?: string | null;
   anchor?: SummaryPopoverAnchor | null;
   onClose: () => void;
 }
@@ -201,6 +215,7 @@ export function SummaryPopover({
   summaryRunInterval,
   automaticSummariesAvailable = true,
   totalMessageCount,
+  summaryInjectionHint = null,
   anchor = null,
   onClose,
 }: SummaryPopoverProps) {
@@ -356,6 +371,7 @@ export function SummaryPopover({
   const hasEntries = visibleEntries.length > 0;
   const allVisibleEntriesHidden = hasPersistedEntries && !hasEntries;
   const allEntriesDisabled = hasPersistedEntries && enabledEntryCount === 0;
+  const showSummaryInjectionHint = enabledEntryCount > 0 && !!summaryInjectionHint;
   const tokenWarning = enabledTokenEstimate > SUMMARY_TOKEN_WARNING_THRESHOLD;
   const entryMutationPending =
     updateSummaryEntry.isPending || deleteSummaryEntry.isPending || toggleSummaryEntry.isPending;
@@ -775,6 +791,13 @@ export function SummaryPopover({
                 />
               </div>
             </div>
+
+            {showSummaryInjectionHint && (
+              <div className="flex items-start gap-2 rounded-lg border border-amber-400/25 bg-amber-400/10 px-2.5 py-2 text-[0.6875rem] leading-snug text-amber-100">
+                <AlertTriangle size="0.75rem" className="mt-0.5 shrink-0" />
+                <span>{summaryInjectionHint}</span>
+              </div>
+            )}
 
             <div className="grid gap-2 sm:grid-cols-2">
               {automaticSummariesAvailable && (

--- a/packages/client/src/components/connections/ConnectionEditor.tsx
+++ b/packages/client/src/components/connections/ConnectionEditor.tsx
@@ -109,6 +109,19 @@ const MAX_CACHING_AT_DEPTH = 100;
 const DEFAULT_MAX_PARALLEL_JOBS = 1;
 const MAX_PARALLEL_JOBS = 16;
 
+function normalizeEndpointUrlInput(raw: string, label: string): { value: string; error: string | null } {
+  const trimmed = raw.trim();
+  if (!trimmed) return { value: "", error: null };
+
+  const value = /^[a-z][a-z\d+.-]*:\/\//i.test(trimmed) ? trimmed : `http://${trimmed}`;
+  try {
+    new URL(value);
+  } catch {
+    return { value: trimmed, error: `${label} must be a valid URL, like http://localhost:11434/v1.` };
+  }
+  return { value, error: null };
+}
+
 function canProviderTreatAsLocalEndpoint(provider: APIProvider): boolean {
   return provider !== "image_generation" && provider !== "claude_subscription" && provider !== "openai_chatgpt";
 }
@@ -159,6 +172,7 @@ export function ConnectionEditor() {
   const [localProvider, setLocalProvider] = useState<APIProvider>("openai");
   const [localBaseUrl, setLocalBaseUrl] = useState("");
   const [localApiKey, setLocalApiKey] = useState("");
+  const [clearStoredApiKeyOnSave, setClearStoredApiKeyOnSave] = useState(false);
   const [localModel, setLocalModel] = useState("");
   const [localMaxContext, setLocalMaxContext] = useState(128000);
   const [localMaxParallelJobs, setLocalMaxParallelJobs] = useState(DEFAULT_MAX_PARALLEL_JOBS);
@@ -210,6 +224,14 @@ export function ConnectionEditor() {
   // Remote models fetched from provider API
   const [remoteModels, setRemoteModels] = useState<RemoteConnectionModel[]>([]);
   const [fetchError, setFetchError] = useState<string | null>(null);
+  const baseUrlValidation = useMemo(
+    () => normalizeEndpointUrlInput(localBaseUrl, "Base URL"),
+    [localBaseUrl],
+  );
+  const embeddingBaseUrlValidation = useMemo(
+    () => normalizeEndpointUrlInput(localEmbeddingBaseUrl, "Embedding endpoint URL"),
+    [localEmbeddingBaseUrl],
+  );
 
   // Populate from server
   useEffect(() => {
@@ -219,6 +241,7 @@ export function ConnectionEditor() {
     setLocalProvider((c.provider as APIProvider) ?? "openai");
     setLocalBaseUrl((c.baseUrl as string) ?? "");
     setLocalApiKey(""); // never pre-fill (it's masked)
+    setClearStoredApiKeyOnSave(false);
     setLocalModel((c.model as string) ?? "");
     setLocalMaxContext(Number(c.maxContext) || 128000);
     setLocalMaxParallelJobs(normalizeMaxParallelJobs(c.maxParallelJobs));
@@ -379,12 +402,20 @@ export function ConnectionEditor() {
   const handleSave = useCallback(async () => {
     if (!connectionDetailId) return;
     setSaveError(null);
+    if (baseUrlValidation.error) {
+      setSaveError(baseUrlValidation.error);
+      throw new Error(baseUrlValidation.error);
+    }
+    if (embeddingBaseUrlValidation.error) {
+      setSaveError(embeddingBaseUrlValidation.error);
+      throw new Error(embeddingBaseUrlValidation.error);
+    }
     const canTreatAsLocalEndpoint = canProviderTreatAsLocalEndpoint(localProvider);
     const payload: Record<string, unknown> = {
       id: connectionDetailId,
       name: localName,
       provider: localProvider,
-      baseUrl: localBaseUrl,
+      baseUrl: baseUrlValidation.value,
       model: localModel,
       maxContext: localMaxContext,
       maxParallelJobs: localMaxParallelJobs,
@@ -392,7 +423,7 @@ export function ConnectionEditor() {
       cachingAtDepth: localCachingAtDepth,
       defaultForAgents: localDefaultForAgents,
       embeddingModel: localEmbeddingModel,
-      embeddingBaseUrl: localEmbeddingBaseUrl,
+      embeddingBaseUrl: embeddingBaseUrlValidation.value,
       embeddingConnectionId: localEmbeddingConnectionId || null,
       promptPresetId: localProvider !== "image_generation" ? localPromptPresetId || null : null,
       openrouterProvider: localOpenrouterProvider || null,
@@ -412,6 +443,8 @@ export function ConnectionEditor() {
     // Only send API key if user typed a new one
     if (localApiKey.trim()) {
       payload.apiKey = localApiKey;
+    } else if (clearStoredApiKeyOnSave) {
+      payload.apiKey = "";
     }
     try {
       await updateConnection.mutateAsync(payload as { id: string } & Record<string, unknown>);
@@ -433,18 +466,29 @@ export function ConnectionEditor() {
           ),
         });
       }
+      if (baseUrlValidation.value !== localBaseUrl.trim()) {
+        setLocalBaseUrl(baseUrlValidation.value);
+      }
+      if (embeddingBaseUrlValidation.value !== localEmbeddingBaseUrl.trim()) {
+        setLocalEmbeddingBaseUrl(embeddingBaseUrlValidation.value);
+      }
       setDirty(false);
+      setClearStoredApiKeyOnSave(false);
       setSavedFlash(true);
       setTimeout(() => setSavedFlash(false), 1500);
     } catch (err) {
-      setSaveError(err instanceof Error ? err.message : "Failed to save connection");
+      const message = err instanceof Error ? err.message : "Failed to save connection";
+      setSaveError(message);
+      throw err instanceof Error ? err : new Error(message);
     }
   }, [
     connectionDetailId,
     localName,
     localProvider,
     localBaseUrl,
+    baseUrlValidation,
     localApiKey,
+    clearStoredApiKeyOnSave,
     localModel,
     localMaxContext,
     localMaxParallelJobs,
@@ -453,6 +497,7 @@ export function ConnectionEditor() {
     localDefaultForAgents,
     localEmbeddingModel,
     localEmbeddingBaseUrl,
+    embeddingBaseUrlValidation,
     localEmbeddingConnectionId,
     localPromptPresetId,
     localOpenrouterProvider,
@@ -717,6 +762,15 @@ export function ConnectionEditor() {
 
   const markDirty = useCallback(() => setDirty(true), []);
 
+  const handleManualModelChange = useCallback(
+    (model: string) => {
+      setLocalModel(model);
+      setLocalMaxTokensOverride(null);
+      markDirty();
+    },
+    [markDirty],
+  );
+
   const handleJumpToJsonError = useCallback(() => {
     const ta = comfyWorkflowTextareaRef.current;
     if (!ta || !comfyWorkflowValidation || !comfyWorkflowValidation.parseError) return;
@@ -829,8 +883,12 @@ export function ConnectionEditor() {
             </button>
             <button
               onClick={async () => {
-                await handleSave();
-                closeConnectionDetail();
+                try {
+                  await handleSave();
+                  closeConnectionDetail();
+                } catch {
+                  // Keep the editor open so the user can fix the failed save.
+                }
               }}
               className="rounded-lg bg-amber-500/20 px-3 py-1 hover:bg-amber-500/30"
             >
@@ -882,6 +940,7 @@ export function ConnectionEditor() {
                 <button
                   key={key}
                   onClick={() => {
+                    if (key === localProvider) return;
                     const defaultModel = MODEL_LISTS[key]?.[0];
                     setLocalProvider(key);
                     // Auto-fill base URL
@@ -889,17 +948,14 @@ export function ConnectionEditor() {
                     // Clear model when switching providers, except xAI where
                     // we can seed the newest supported Grok model.
                     setLocalModel(key === "xai" ? (defaultModel?.id ?? "grok-4.3") : "");
+                    setLocalMaxContext(Number(defaultModel?.context) || 128000);
                     setLocalMaxTokensOverride(null);
                     setLocalDefaultParametersEnabled(false);
                     setLocalDefaultParameters(ROLEPLAY_PARAMETER_DEFAULTS);
-                    if (key === "xai" && defaultModel?.context) {
-                      setLocalMaxContext(defaultModel.context);
-                    }
-                    // Local subscription/session providers ignore the API key
-                    // field, so clear stale keys from other providers.
-                    if (key === "claude_subscription" || key === "openai_chatgpt") {
-                      setLocalApiKey("");
-                    }
+                    // Provider switches must not keep an encrypted key from
+                    // the previous provider under the new provider identity.
+                    setLocalApiKey("");
+                    setClearStoredApiKeyOnSave(true);
                     markDirty();
                   }}
                   className={cn(
@@ -1089,7 +1145,10 @@ export function ConnectionEditor() {
                 setLocalBaseUrl(e.target.value);
                 markDirty();
               }}
-              className="w-full rounded-xl bg-[var(--secondary)] px-3 py-2.5 text-sm font-mono ring-1 ring-[var(--border)] placeholder:text-[var(--muted-foreground)] focus:outline-none focus:ring-2 focus:ring-[var(--ring)] disabled:cursor-not-allowed disabled:opacity-70"
+              className={cn(
+                "w-full rounded-xl bg-[var(--secondary)] px-3 py-2.5 text-sm font-mono ring-1 placeholder:text-[var(--muted-foreground)] focus:outline-none focus:ring-2 focus:ring-[var(--ring)] disabled:cursor-not-allowed disabled:opacity-70",
+                baseUrlValidation.error ? "ring-[var(--destructive)]" : "ring-[var(--border)]",
+              )}
               placeholder={
                 isClaudeSubscriptionProvider
                   ? "Not used — managed by the Claude Agent SDK"
@@ -1102,6 +1161,14 @@ export function ConnectionEditor() {
             {providerDef?.defaultBaseUrl && !localBaseUrl && !isLocalAuthProvider && (
               <p className="mt-1 text-[0.625rem] text-[var(--muted-foreground)]">
                 Default: {providerDef.defaultBaseUrl}
+              </p>
+            )}
+            {baseUrlValidation.error && (
+              <p className="mt-1 text-[0.625rem] text-[var(--destructive)]">{baseUrlValidation.error}</p>
+            )}
+            {!baseUrlValidation.error && baseUrlValidation.value !== localBaseUrl.trim() && (
+              <p className="mt-1 text-[0.625rem] text-[var(--muted-foreground)]">
+                Will save as {baseUrlValidation.value}
               </p>
             )}
             {localProvider === "claude_subscription" && (
@@ -1302,8 +1369,7 @@ export function ConnectionEditor() {
                         <input
                           value={localModel}
                           onChange={(e) => {
-                            setLocalModel(e.target.value);
-                            markDirty();
+                            handleManualModelChange(e.target.value);
                           }}
                           className="w-full rounded-lg bg-[var(--secondary)] px-3 py-2 text-sm ring-1 ring-[var(--border)] focus:outline-none focus:ring-sky-400/50"
                           placeholder="model-name-or-path"
@@ -1356,8 +1422,7 @@ export function ConnectionEditor() {
                         <input
                           value={localModel}
                           onChange={(e) => {
-                            setLocalModel(e.target.value);
-                            markDirty();
+                            handleManualModelChange(e.target.value);
                           }}
                           className="mt-2 w-full rounded-lg bg-[var(--secondary)] px-3 py-2 text-sm ring-1 ring-[var(--border)] focus:outline-none focus:ring-sky-400/50"
                           placeholder="Custom model ID…"
@@ -1409,8 +1474,7 @@ export function ConnectionEditor() {
                 <input
                   value={localModel}
                   onChange={(e) => {
-                    setLocalModel(e.target.value);
-                    markDirty();
+                    handleManualModelChange(e.target.value);
                   }}
                   className="flex-1 rounded-lg bg-[var(--secondary)] px-3 py-2 text-xs ring-1 ring-[var(--border)] focus:outline-none focus:ring-[var(--ring)]"
                   placeholder="Or type model ID directly…"
@@ -1555,7 +1619,7 @@ export function ConnectionEditor() {
               <div className="flex items-center gap-3">
                 <DraftNumberInput
                   value={localMaxContext}
-                  min={0}
+                  min={1}
                   selectOnFocus
                   onCommit={(nextValue) => {
                     setLocalMaxContext(nextValue);
@@ -1878,9 +1942,23 @@ export function ConnectionEditor() {
                     setLocalEmbeddingBaseUrl(e.target.value);
                     markDirty();
                   }}
-                  className="w-full rounded-xl bg-[var(--secondary)] px-3 py-2.5 text-sm font-mono ring-1 ring-[var(--border)] placeholder:text-[var(--muted-foreground)] focus:outline-none focus:ring-2 focus:ring-[var(--ring)]"
+                  className={cn(
+                    "w-full rounded-xl bg-[var(--secondary)] px-3 py-2.5 text-sm font-mono ring-1 placeholder:text-[var(--muted-foreground)] focus:outline-none focus:ring-2 focus:ring-[var(--ring)]",
+                    embeddingBaseUrlValidation.error ? "ring-[var(--destructive)]" : "ring-[var(--border)]",
+                  )}
                   placeholder="e.g. http://localhost:5002/v1"
                 />
+                {embeddingBaseUrlValidation.error && (
+                  <p className="mt-1 text-[0.625rem] text-[var(--destructive)]">
+                    {embeddingBaseUrlValidation.error}
+                  </p>
+                )}
+                {!embeddingBaseUrlValidation.error &&
+                  embeddingBaseUrlValidation.value !== localEmbeddingBaseUrl.trim() && (
+                    <p className="mt-1 text-[0.625rem] text-[var(--muted-foreground)]">
+                      Will save as {embeddingBaseUrlValidation.value}
+                    </p>
+                  )}
                 <p className="mt-1 text-[0.625rem] text-[var(--muted-foreground)]">
                   Optional. A separate base URL for your embedding backend. Useful when running two instances of
                   llama.cpp on different ports — one for chat, one for embeddings. Leave empty to use the

--- a/packages/client/src/components/game-assets/AssetGrid.tsx
+++ b/packages/client/src/components/game-assets/AssetGrid.tsx
@@ -1,13 +1,16 @@
 // ──────────────────────────────────────────────
 // File Browser — Asset grid / list view (with multi-select checkboxes)
 // ──────────────────────────────────────────────
-import { Check, Folder, FolderOpen, Minus, MoreHorizontal } from "lucide-react";
+import { useEffect, useState } from "react";
+import { Check, FileImage, Folder, FolderOpen, Minus, MoreHorizontal } from "lucide-react";
 import type { TreeNode } from "../../hooks/use-game-assets";
 import type { GameAssetSelectionStatus } from "../../lib/game-asset-selection";
 import { formatBytes, formatDate } from "../../lib/format";
 import { gameAssetFileUrl } from "../../lib/game-asset-urls";
 import { CATEGORY_ICONS } from "./constants";
 import { FileIcon, isImage } from "./utils";
+
+const ASSET_GRID_PAGE_SIZE = 240;
 
 /**
  * Props for the AssetGrid component.
@@ -61,6 +64,10 @@ function FolderSelectionMark({ status }: { status: GameAssetSelectionStatus }) {
   return null;
 }
 
+function BrokenImageFallback({ className }: { className?: string }) {
+  return <FileImage className={className ?? "h-8 w-8 text-[var(--foreground)]/80"} />;
+}
+
 /**
  * Render a grid or list of asset nodes with multi-select checkboxes.
  *
@@ -80,6 +87,15 @@ export function AssetGrid({
   getFolderSelectionStatus,
   onOpenFolderSelection,
 }: AssetGridProps) {
+  const [visibleCount, setVisibleCount] = useState(ASSET_GRID_PAGE_SIZE);
+  const [failedThumbnails, setFailedThumbnails] = useState<Set<string>>(() => new Set());
+  const nodesSignature = `${nodes.length}:${nodes[0]?.path ?? ""}:${nodes[nodes.length - 1]?.path ?? ""}`;
+
+  useEffect(() => {
+    setVisibleCount(ASSET_GRID_PAGE_SIZE);
+    setFailedThumbnails(new Set());
+  }, [nodesSignature]);
+
   if (nodes.length === 0) {
     return (
       <div className="flex flex-1 flex-col items-center justify-center gap-3 pt-8 text-[var(--muted-foreground)]">
@@ -91,98 +107,127 @@ export function AssetGrid({
   }
 
   const gridColsClass = listGridCols(listColumns);
+  const visibleNodes = nodes.slice(0, visibleCount);
+  const hasMoreNodes = visibleNodes.length < nodes.length;
+  const markThumbnailFailed = (path: string) => {
+    setFailedThumbnails((prev) => {
+      if (prev.has(path)) return prev;
+      const next = new Set(prev);
+      next.add(path);
+      return next;
+    });
+  };
+  const loadMore = () => setVisibleCount((count) => Math.min(nodes.length, count + ASSET_GRID_PAGE_SIZE));
+  const paginationFooter = hasMoreNodes ? (
+    <div className="flex items-center justify-center gap-3 px-3 py-3 text-xs text-[var(--muted-foreground)]">
+      <span>
+        Showing {visibleNodes.length} of {nodes.length}
+      </span>
+      <button type="button" onClick={loadMore} className="mari-chrome-control mari-chrome-control--small text-xs">
+        Load more
+      </button>
+    </div>
+  ) : null;
 
   if (viewMode === "grid") {
     return (
-      <div className="grid grid-cols-[repeat(auto-fill,minmax(clamp(6.75rem,18vmin,10rem),1fr))] gap-[clamp(0.5rem,1.4vmin,0.875rem)] p-[clamp(0.5rem,1.6vmin,0.875rem)]">
-        {nodes.map((node) => {
-          const isSelected = selectedPaths.has(node.path);
-          const isFile = node.type === "file";
-          const folderSelectionStatus =
-            !isFile && assetSelectionMode ? (getFolderSelectionStatus?.(node) ?? "included") : null;
-          return (
-            <div
-              key={node.path}
-              onContextMenu={(e) => onContextMenu(e, node)}
-              onClick={() => {
-                if (node.type === "folder") onNavigateFolder(node.path);
-                else onSelectFile(node);
-              }}
-              className={
-                "group relative flex flex-col items-center gap-2 rounded-xl border bg-[var(--card)] p-[clamp(0.5rem,1.3vmin,0.875rem)] transition-all hover:border-[var(--foreground)]/25 hover:shadow-sm " +
-                (isSelected
-                  ? "border-[var(--foreground)]/30 ring-2 ring-[var(--foreground)]/20"
-                  : "border-[var(--border)]")
-              }
-            >
-              {/* Checkbox — files only, always visible */}
-              {isFile && (
-                <label
-                  onClick={(e) => e.stopPropagation()}
-                  className="absolute left-1.5 top-1.5 z-10 flex h-5 w-5 cursor-pointer items-center justify-center rounded border border-[var(--border)] bg-[var(--background)] shadow-sm transition-colors hover:border-[var(--foreground)]/30"
-                >
-                  <input
-                    type="checkbox"
-                    checked={isSelected}
-                    onChange={() => onToggleSelect(node)}
-                    className="h-3.5 w-3.5 accent-[var(--foreground)]"
-                  />
-                </label>
-              )}
-              {folderSelectionStatus && (
+      <>
+        <div className="grid grid-cols-[repeat(auto-fill,minmax(clamp(6.75rem,18vmin,10rem),1fr))] gap-[clamp(0.5rem,1.4vmin,0.875rem)] p-[clamp(0.5rem,1.6vmin,0.875rem)]">
+          {visibleNodes.map((node) => {
+            const isSelected = selectedPaths.has(node.path);
+            const isFile = node.type === "file";
+            const thumbnailUrl =
+              isFile && isImage(node.ext) && !failedThumbnails.has(node.path) ? gameAssetFileUrl(node.path) : null;
+            const folderSelectionStatus =
+              !isFile && assetSelectionMode ? (getFolderSelectionStatus?.(node) ?? "included") : null;
+            return (
+              <div
+                key={node.path}
+                onContextMenu={(e) => onContextMenu(e, node)}
+                onClick={() => {
+                  if (node.type === "folder") onNavigateFolder(node.path);
+                  else onSelectFile(node);
+                }}
+                className={
+                  "group relative flex flex-col items-center gap-2 rounded-xl border bg-[var(--card)] p-[clamp(0.5rem,1.3vmin,0.875rem)] transition-all hover:border-[var(--foreground)]/25 hover:shadow-sm " +
+                  (isSelected
+                    ? "border-[var(--foreground)]/30 ring-2 ring-[var(--foreground)]/20"
+                    : "border-[var(--border)]")
+                }
+              >
+                {/* Checkbox — files only, always visible */}
+                {isFile && (
+                  <label
+                    onClick={(e) => e.stopPropagation()}
+                    className="absolute left-1.5 top-1.5 z-10 flex h-5 w-5 cursor-pointer items-center justify-center rounded border border-[var(--border)] bg-[var(--background)] shadow-sm transition-colors hover:border-[var(--foreground)]/30"
+                  >
+                    <input
+                      type="checkbox"
+                      checked={isSelected}
+                      onChange={() => onToggleSelect(node)}
+                      className="h-3.5 w-3.5 accent-[var(--foreground)]"
+                    />
+                  </label>
+                )}
+                {folderSelectionStatus && (
+                  <button
+                    type="button"
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      onOpenFolderSelection?.(node, e.currentTarget);
+                    }}
+                    className={
+                      "absolute left-1.5 top-1.5 z-10 flex h-6 w-6 items-center justify-center rounded-full border shadow-sm transition-colors " +
+                      (folderSelectionStatus === "excluded"
+                        ? "border-[var(--border)] bg-[var(--background)] text-[var(--muted-foreground)] hover:border-[var(--foreground)]/30"
+                        : "border-[var(--foreground)]/25 bg-[var(--foreground)]/10 text-[var(--foreground)] hover:bg-[var(--foreground)]/15")
+                    }
+                    title="Select assets for this game"
+                    aria-label={`Select ${node.name} assets for this game`}
+                  >
+                    <FolderSelectionMark status={folderSelectionStatus} />
+                  </button>
+                )}
+
                 <button
-                  type="button"
                   onClick={(e) => {
                     e.stopPropagation();
-                    onOpenFolderSelection?.(node, e.currentTarget);
+                    onOpenActionMenu(node, e.currentTarget);
                   }}
-                  className={
-                    "absolute left-1.5 top-1.5 z-10 flex h-6 w-6 items-center justify-center rounded-full border shadow-sm transition-colors " +
-                    (folderSelectionStatus === "excluded"
-                      ? "border-[var(--border)] bg-[var(--background)] text-[var(--muted-foreground)] hover:border-[var(--foreground)]/30"
-                      : "border-[var(--foreground)]/25 bg-[var(--foreground)]/10 text-[var(--foreground)] hover:bg-[var(--foreground)]/15")
-                  }
-                  title="Select assets for this game"
-                  aria-label={`Select ${node.name} assets for this game`}
+                  className="absolute right-1.5 top-1.5 rounded-md p-1 text-[var(--muted-foreground)] transition-colors hover:bg-[var(--accent)] hover:text-[var(--foreground)]"
                 >
-                  <FolderSelectionMark status={folderSelectionStatus} />
+                  <MoreHorizontal size="0.875rem" />
                 </button>
-              )}
 
-              <button
-                onClick={(e) => {
-                  e.stopPropagation();
-                  onOpenActionMenu(node, e.currentTarget);
-                }}
-                className="absolute right-1.5 top-1.5 rounded-md p-1 text-[var(--muted-foreground)] transition-colors hover:bg-[var(--accent)] hover:text-[var(--foreground)]"
-              >
-                <MoreHorizontal size="0.875rem" />
-              </button>
-
-              <div className="flex aspect-square w-[clamp(3.5rem,13vmin,6.75rem)] max-w-full shrink-0 items-center justify-center overflow-hidden rounded-lg bg-[var(--accent)]">
-                {node.type === "folder" ? (
-                  (() => {
-                    const CategoryIcon = CATEGORY_ICONS[node.name] || Folder;
-                    return (
-                      <CategoryIcon className="h-[52%] min-h-8 w-[52%] min-w-8 max-h-16 max-w-16 text-[var(--foreground)]/80" />
-                    );
-                  })()
-                ) : isImage(node.ext) ? (
-                  <img
-                    src={gameAssetFileUrl(node.path) ?? ""}
-                    alt={node.name}
-                    className="h-full w-full object-cover"
-                    loading="lazy"
-                  />
-                ) : (
-                  <FileIcon ext={node.ext} className="h-8 w-8 text-[var(--foreground)]/80" />
-                )}
+                <div className="flex aspect-square w-[clamp(3.5rem,13vmin,6.75rem)] max-w-full shrink-0 items-center justify-center overflow-hidden rounded-lg bg-[var(--accent)]">
+                  {node.type === "folder" ? (
+                    (() => {
+                      const CategoryIcon = CATEGORY_ICONS[node.name] || Folder;
+                      return (
+                        <CategoryIcon className="h-[52%] min-h-8 w-[52%] min-w-8 max-h-16 max-w-16 text-[var(--foreground)]/80" />
+                      );
+                    })()
+                  ) : thumbnailUrl ? (
+                    <img
+                      src={thumbnailUrl}
+                      alt={node.name}
+                      className="h-full w-full object-cover"
+                      loading="lazy"
+                      onError={() => markThumbnailFailed(node.path)}
+                    />
+                  ) : isImage(node.ext) ? (
+                    <BrokenImageFallback />
+                  ) : (
+                    <FileIcon ext={node.ext} className="h-8 w-8 text-[var(--foreground)]/80" />
+                  )}
+                </div>
+                <span className="w-full truncate text-center text-xs text-[var(--foreground)]">{node.name}</span>
               </div>
-              <span className="w-full truncate text-center text-xs text-[var(--foreground)]">{node.name}</span>
-            </div>
-          );
-        })}
-      </div>
+            );
+          })}
+        </div>
+        {paginationFooter}
+      </>
     );
   }
 
@@ -198,9 +243,11 @@ export function AssetGrid({
         {listColumns.modified && <span className="text-right">Modified</span>}
         <span></span>
       </div>
-      {nodes.map((node) => {
+      {visibleNodes.map((node) => {
         const isSelected = selectedPaths.has(node.path);
         const isFile = node.type === "file";
+        const thumbnailUrl =
+          isFile && isImage(node.ext) && !failedThumbnails.has(node.path) ? gameAssetFileUrl(node.path) : null;
         const folderSelectionStatus =
           !isFile && assetSelectionMode ? (getFolderSelectionStatus?.(node) ?? "included") : null;
         return (
@@ -252,14 +299,19 @@ export function AssetGrid({
                 const CategoryIcon = CATEGORY_ICONS[node.name] || Folder;
                 return <CategoryIcon size="1rem" className="shrink-0 text-[var(--foreground)]/80" />;
               })()
-            ) : isImage(node.ext) ? (
+            ) : thumbnailUrl ? (
               <div className="flex h-6 w-6 shrink-0 items-center justify-center overflow-hidden rounded bg-[var(--accent)]">
                 <img
-                  src={gameAssetFileUrl(node.path) ?? ""}
+                  src={thumbnailUrl}
                   alt=""
                   className="h-full w-full object-cover"
                   loading="lazy"
+                  onError={() => markThumbnailFailed(node.path)}
                 />
+              </div>
+            ) : isImage(node.ext) ? (
+              <div className="flex h-6 w-6 shrink-0 items-center justify-center rounded bg-[var(--accent)]">
+                <BrokenImageFallback className="h-4 w-4 text-[var(--foreground)]/70" />
               </div>
             ) : (
               <FileIcon ext={node.ext} className="shrink-0 text-[var(--muted-foreground)]" size="1rem" />
@@ -283,6 +335,7 @@ export function AssetGrid({
           </div>
         );
       })}
+      {paginationFooter}
     </div>
   );
 }

--- a/packages/client/src/components/game/GameNarration.tsx
+++ b/packages/client/src/components/game/GameNarration.tsx
@@ -271,6 +271,13 @@ type GameSegmentVoiceEntry =
   | { status: "ready"; speaker?: string; tone?: string; voice?: string; chunks: string[]; urls: string[] }
   | { status: "error"; speaker?: string; tone?: string; voice?: string; chunks: string[] };
 
+const GAME_VOICE_CACHE_MAX_ENTRIES = 80;
+
+function revokeGameVoiceEntry(entry: GameSegmentVoiceEntry | undefined): void {
+  if (entry?.status !== "ready") return;
+  for (const url of entry.urls) URL.revokeObjectURL(url);
+}
+
 interface GameSegmentVoiceRequest {
   speaker?: string;
   tone?: string;
@@ -664,23 +671,44 @@ function waitForGameTTSRetry(ms: number, signal: AbortSignal): Promise<void> {
   });
 }
 
+function waitForGameTTSBlob(promise: Promise<Blob>, signal: AbortSignal): Promise<Blob> {
+  if (signal.aborted) return Promise.reject(new DOMException("TTS request aborted", "AbortError"));
+  return new Promise((resolve, reject) => {
+    const onAbort = () => {
+      signal.removeEventListener("abort", onAbort);
+      reject(new DOMException("TTS request aborted", "AbortError"));
+    };
+    signal.addEventListener("abort", onAbort, { once: true });
+    promise.then(
+      (blob) => {
+        signal.removeEventListener("abort", onAbort);
+        resolve(blob);
+      },
+      (error) => {
+        signal.removeEventListener("abort", onAbort);
+        reject(error);
+      },
+    );
+  });
+}
+
 async function generateGameVoiceJobBlob(job: GameVoiceAudioJob, controller: AbortController): Promise<Blob> {
   let lastError: unknown;
 
   for (let attempt = 1; attempt <= GAME_TTS_CHUNK_ATTEMPTS; attempt += 1) {
     if (controller.signal.aborted) throw new DOMException("TTS request aborted", "AbortError");
     try {
-      return await getOrCreateCachedTTSAudioBlob(
+      const sharedPromise = getOrCreateCachedTTSAudioBlob(
         job.cacheKey,
         () =>
           ttsService.generateAudio(job.chunk, {
             speaker: job.speaker,
             tone: job.tone,
             voice: job.voice,
-            signal: controller.signal,
           }),
         [job.textCacheKey],
       );
+      return await waitForGameTTSBlob(sharedPromise, controller.signal);
     } catch (err) {
       if (controller.signal.aborted || (err instanceof Error && err.name === "AbortError")) throw err;
       lastError = err;
@@ -1755,6 +1783,32 @@ export function GameNarration({
   const normalizedGameVoiceVolume = Math.max(0, Math.min(1, gameVoiceVolume));
   const gameVoicePlaybackBlocked = voicePlaybackBlocked ?? autoPlayBlocked;
 
+  const cacheGameVoiceEntry = useCallback(
+    (key: string, entry: GameSegmentVoiceEntry) => {
+      const cache = gameVoiceCacheRef.current;
+      revokeGameVoiceEntry(cache.get(key));
+      cache.delete(key);
+      cache.set(key, entry);
+
+      const protectedKeys = new Set([gameVoicePlayingKey, gameVoicePausedKey].filter((value): value is string => !!value));
+      let guard = 0;
+      while (cache.size > GAME_VOICE_CACHE_MAX_ENTRIES && guard < cache.size) {
+        const oldestKey = cache.keys().next().value;
+        if (!oldestKey) break;
+        const oldestEntry = cache.get(oldestKey);
+        if (protectedKeys.has(oldestKey) && oldestEntry) {
+          cache.delete(oldestKey);
+          cache.set(oldestKey, oldestEntry);
+          guard += 1;
+          continue;
+        }
+        cache.delete(oldestKey);
+        revokeGameVoiceEntry(oldestEntry);
+      }
+    },
+    [gameVoicePausedKey, gameVoicePlayingKey],
+  );
+
   const queueLogScrollTopRestore = useCallback(() => {
     const scrollTop = logScrollContainerRef.current?.scrollTop;
     if (scrollTop != null) {
@@ -2762,7 +2816,7 @@ export function GameNarration({
 
       const controller = new AbortController();
       gameVoicePendingRef.current.set(key, controller);
-      gameVoiceCacheRef.current.set(key, {
+      cacheGameVoiceEntry(key, {
         status: "loading",
         chunks: audioJobs.map((job) => job.chunk),
         speaker: audioJobs[0]?.speaker,
@@ -2813,7 +2867,7 @@ export function GameNarration({
           if (controller.signal.aborted) return;
           const urls = blobs.map((blob) => URL.createObjectURL(blob));
           if (!failed && urls.length === audioJobs.length) {
-            gameVoiceCacheRef.current.set(key, {
+            cacheGameVoiceEntry(key, {
               status: "ready",
               chunks: audioJobs.map((job) => job.chunk),
               speaker: audioJobs[0]?.speaker,
@@ -2823,7 +2877,7 @@ export function GameNarration({
             });
           } else {
             for (const url of urls) URL.revokeObjectURL(url);
-            gameVoiceCacheRef.current.set(key, {
+            cacheGameVoiceEntry(key, {
               status: "error",
               chunks: audioJobs.map((job) => job.chunk),
               speaker: audioJobs[0]?.speaker,
@@ -2843,6 +2897,7 @@ export function GameNarration({
     gameVoiceGenerationTailRef.current = gameVoiceGenerationTailRef.current.catch(() => undefined).then(runPlans);
     void gameVoiceGenerationTailRef.current;
   }, [
+    cacheGameVoiceEntry,
     gameNpcs,
     gameVoiceConfigSignature,
     gameVoiceEnabled,

--- a/packages/client/src/components/game/GameSurface.tsx
+++ b/packages/client/src/components/game/GameSurface.tsx
@@ -81,6 +81,7 @@ import { useSceneAnalysis } from "../../hooks/use-scene-analysis";
 import { useSidecarStore } from "../../stores/sidecar.store";
 import { parsePartyDialogue } from "../../lib/party-dialogue-parser";
 import { dispatchSpotifySceneTrackChange } from "../../lib/spotify-playback-events";
+import { ttsService } from "../../lib/tts-service";
 import { ActiveLorebookEntriesButton, ActiveLorebookEntriesModal } from "../chat/ActiveLorebookEntriesButton";
 import type {
   PartyDialogueLine,
@@ -1100,10 +1101,6 @@ function interactiveCommandKey(chatId: string, messageId: string): string {
 }
 
 function backgroundAssetUrl(entry: { path: string }): string {
-  if (entry.path.startsWith("__user_bg__/")) {
-    const filename = entry.path.replace("__user_bg__/", "");
-    return `/api/backgrounds/file/${encodeURIComponent(filename)}`;
-  }
   return gameAssetFileUrl(entry.path) ?? "";
 }
 
@@ -1823,6 +1820,12 @@ export function GameSurface({
 }: GameSurfaceProps) {
   // Sync game metadata → store
   useSyncGameState(activeChatId, chatMeta);
+
+  useEffect(() => {
+    return () => {
+      ttsService.stop();
+    };
+  }, [activeChatId]);
 
   const {
     gameState,
@@ -5760,13 +5763,13 @@ export function GameSurface({
         setInterruptModalOpen(false);
         return;
       }
-      useChatStore.getState().stopGeneration();
+      useChatStore.getState().stopGeneration(activeChatId ?? undefined);
       setPendingInterrupt({ ...interruptCandidate, mode });
       setInterruptModalOpen(false);
       setInterruptCandidate(null);
       setGameInputFocusToken((t) => t + 1);
     },
-    [interruptCandidate],
+    [activeChatId, interruptCandidate],
   );
 
   // If the assistant message changes (new GM turn arrived) or the player switches chats,

--- a/packages/client/src/components/modals/ImportConnectionModal.tsx
+++ b/packages/client/src/components/modals/ImportConnectionModal.tsx
@@ -6,6 +6,7 @@ import { CheckCircle, Download, FileJson, Loader2, XCircle } from "lucide-react"
 import { Modal } from "../ui/Modal";
 import { useCreateConnection, useSaveConnectionDefaults } from "../../hooks/use-connections";
 import { getConnectionImportEntries, normalizeImportedConnectionEntry } from "../../lib/connection-transfer";
+import { api } from "../../lib/api-client";
 
 interface Props {
   open: boolean;
@@ -40,26 +41,41 @@ export function ImportConnectionModal({ open, onClose }: Props) {
         if (entries.length === 0) throw new Error("No connection data found");
 
         let imported = 0;
+        let failed = 0;
         for (const entry of entries) {
-          const normalized = normalizeImportedConnectionEntry(entry);
-          if (!normalized) continue;
+          let createdConnectionId: string | null = null;
+          try {
+            const normalized = normalizeImportedConnectionEntry(entry);
+            if (!normalized) {
+              failed += 1;
+              continue;
+            }
 
-          const result = await createConnection.mutateAsync(normalized.connection);
-          const connectionId = (result as { id?: string } | null)?.id;
-          if (connectionId && normalized.hasDefaultParameters) {
-            await saveConnectionDefaults.mutateAsync({
-              id: connectionId,
-              params: normalized.defaultParameters,
-            });
+            const result = await createConnection.mutateAsync(normalized.connection);
+            const connectionId = (result as { id?: string } | null)?.id;
+            createdConnectionId = connectionId ?? null;
+            if (connectionId && normalized.hasDefaultParameters) {
+              await saveConnectionDefaults.mutateAsync({
+                id: connectionId,
+                params: normalized.defaultParameters,
+              });
+            }
+            imported += 1;
+          } catch {
+            if (createdConnectionId) {
+              await api.delete(`/connections/${createdConnectionId}`).catch(() => undefined);
+            }
+            failed += 1;
           }
-          imported += 1;
         }
 
         if (imported === 0) throw new Error("No supported connection entries found");
         nextResults.push({
           filename: file.name,
           success: true,
-          message: `Imported ${imported} connection${imported === 1 ? "" : "s"} without API keys`,
+          message: `Imported ${imported} connection${imported === 1 ? "" : "s"} without API keys${
+            failed > 0 ? ` (${failed} skipped)` : ""
+          }`,
         });
       } catch (error) {
         nextResults.push({

--- a/packages/client/src/components/panels/settings/TTSConfigCard.tsx
+++ b/packages/client/src/components/panels/settings/TTSConfigCard.tsx
@@ -99,6 +99,17 @@ type VoiceOption = {
   labels?: Record<string, string | number | boolean | null> | null;
 };
 
+function addSavedVoiceOption(options: VoiceOption[], voiceId: string): VoiceOption[] {
+  const id = voiceId.trim();
+  if (!id || options.some((option) => option.id === id)) return options;
+  return [...options, { id, name: id, category: "saved" }];
+}
+
+function formatVoiceOptionLabel(option: VoiceOption): string {
+  if (option.category === "saved") return `${option.id} (saved; not in current voice list)`;
+  return option.name === option.id ? option.id : `${option.name} (${option.id})`;
+}
+
 const ELEVENLABS_DEFAULT_MALE_VOICE_NAMES = new Set([
   "adam",
   "antoni",
@@ -269,7 +280,7 @@ function NpcDefaultVoicePool({
                 onChange={(e) => onToggle(option.id, e.target.checked)}
                 className="h-3 w-3 shrink-0 rounded border-[var(--border)] accent-[var(--primary)]"
               />
-              <span className="truncate">{option.name === option.id ? option.id : option.name}</span>
+              <span className="truncate">{formatVoiceOptionLabel(option)}</span>
             </label>
           ))}
         </div>
@@ -316,6 +327,7 @@ export function TTSConfigCard() {
   const [expanded, setExpanded] = useState(false);
   const [saveStatus, setSaveStatus] = useState<"idle" | "saving" | "saved" | "error">("idle");
   const saveTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const statusTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const [ttsState, setTTSState] = useState(ttsService.getState());
   const [previewError, setPreviewError] = useState<string | null>(null);
 
@@ -375,6 +387,7 @@ export function TTSConfigCard() {
   useEffect(
     () => () => {
       if (saveTimerRef.current) clearTimeout(saveTimerRef.current);
+      if (statusTimerRef.current) clearTimeout(statusTimerRef.current);
     },
     [],
   );
@@ -414,7 +427,11 @@ export function TTSConfigCard() {
     setSaveStatus("saving");
     await updateConfig.mutateAsync(payload);
     setSaveStatus("saved");
-    setTimeout(() => setSaveStatus((s) => (s === "saved" ? "idle" : s)), 2000);
+    if (statusTimerRef.current) clearTimeout(statusTimerRef.current);
+    statusTimerRef.current = setTimeout(() => {
+      setSaveStatus((s) => (s === "saved" ? "idle" : s));
+      statusTimerRef.current = null;
+    }, 2000);
   };
 
   const mark = (overrides?: Partial<TTSConfig>) => {
@@ -503,7 +520,20 @@ export function TTSConfigCard() {
   };
 
   const voices = voicesData?.voices ?? [];
-  const voiceOptions = voicesData?.voiceOptions ?? voices.map((v) => ({ id: v, name: v }));
+  const fetchedVoiceOptions = voicesData?.voiceOptions ?? voices.map((v) => ({ id: v, name: v }));
+  const voiceOptions = useMemo(() => {
+    let nextOptions = fetchedVoiceOptions;
+    for (const savedVoice of [
+      voice,
+      narratorVoice,
+      ...voiceAssignments.map((assignment) => assignment.voice),
+      ...npcDefaultMaleVoices,
+      ...npcDefaultFemaleVoices,
+    ]) {
+      nextOptions = addSavedVoiceOption(nextOptions, savedVoice);
+    }
+    return nextOptions;
+  }, [fetchedVoiceOptions, narratorVoice, npcDefaultFemaleVoices, npcDefaultMaleVoices, voice, voiceAssignments]);
   const voicesFromProvider = voicesData?.fromProvider ?? false;
   const elevenLabsMatchedMaleVoiceOptions = useMemo(
     () =>
@@ -517,10 +547,20 @@ export function TTSConfigCard() {
       ),
     [voiceOptions],
   );
-  const elevenLabsNpcMaleVoiceOptions =
-    elevenLabsMatchedMaleVoiceOptions.length > 0 ? elevenLabsMatchedMaleVoiceOptions : voiceOptions;
-  const elevenLabsNpcFemaleVoiceOptions =
-    elevenLabsMatchedFemaleVoiceOptions.length > 0 ? elevenLabsMatchedFemaleVoiceOptions : voiceOptions;
+  const elevenLabsNpcMaleVoiceOptions = useMemo(() => {
+    let options = elevenLabsMatchedMaleVoiceOptions.length > 0 ? elevenLabsMatchedMaleVoiceOptions : voiceOptions;
+    for (const savedVoice of npcDefaultMaleVoices) {
+      options = addSavedVoiceOption(options, savedVoice);
+    }
+    return options;
+  }, [elevenLabsMatchedMaleVoiceOptions, npcDefaultMaleVoices, voiceOptions]);
+  const elevenLabsNpcFemaleVoiceOptions = useMemo(() => {
+    let options = elevenLabsMatchedFemaleVoiceOptions.length > 0 ? elevenLabsMatchedFemaleVoiceOptions : voiceOptions;
+    for (const savedVoice of npcDefaultFemaleVoices) {
+      options = addSavedVoiceOption(options, savedVoice);
+    }
+    return options;
+  }, [elevenLabsMatchedFemaleVoiceOptions, npcDefaultFemaleVoices, voiceOptions]);
   const maleNpcVoiceFallbackNote =
     voiceOptions.length > 0 && elevenLabsMatchedMaleVoiceOptions.length === 0
       ? "No male-labeled defaults were detected, so choose male voices manually here."
@@ -568,6 +608,17 @@ export function TTSConfigCard() {
   const selectedLanguage =
     ELEVENLABS_TTS_LANGUAGE_OPTIONS.find((option) => option.code === elevenLabsLanguageCode) ??
     ELEVENLABS_TTS_LANGUAGE_OPTIONS[0];
+  const speedMin = source === "elevenlabs" ? 0.7 : 0.25;
+  const speedMax = source === "elevenlabs" ? 1.2 : 4.0;
+  const speedHelp =
+    source === "elevenlabs"
+      ? "Playback speed. ElevenLabs supports 0.7×–1.2×; wider saved values are clamped when spoken."
+      : "Playback speed. 1.0 is normal; range is 0.25×–4.0×.";
+  const speedSliderValue = Math.min(speedMax, Math.max(speedMin, speed));
+  const speedLabel =
+    source === "elevenlabs" && speedSliderValue !== speed
+      ? `Speed — ${speedSliderValue.toFixed(2)}× (clamped from ${speed.toFixed(2)}×)`
+      : `Speed — ${speed.toFixed(2)}×`;
   const previewDisabled = !enabled || ttsState === "loading" || (source === "elevenlabs" && !previewVoice);
   const previewTitle =
     source === "elevenlabs" && !previewVoice
@@ -893,7 +944,7 @@ export function TTSConfigCard() {
                     {!fetchingVoices && voicesError && <option value="">Could not load voices</option>}
                     {voiceOptions.map((option) => (
                       <option key={option.id} value={option.id}>
-                        {option.name === option.id ? option.id : `${option.name} (${option.id})`}
+                        {formatVoiceOptionLabel(option)}
                       </option>
                     ))}
                   </select>
@@ -968,7 +1019,7 @@ export function TTSConfigCard() {
                       {source === "elevenlabs" && <option value="">Select voice</option>}
                       {voiceOptions.map((option) => (
                         <option key={option.id} value={option.id}>
-                          {option.name === option.id ? option.id : `${option.name} (${option.id})`}
+                          {formatVoiceOptionLabel(option)}
                         </option>
                       ))}
                     </select>
@@ -1046,7 +1097,7 @@ export function TTSConfigCard() {
                       {!fetchingVoices && voicesError && <option value="">Could not load voices</option>}
                       {voiceOptions.map((option) => (
                         <option key={option.id} value={option.id}>
-                          {option.name === option.id ? option.id : `${option.name} (${option.id})`}
+                          {formatVoiceOptionLabel(option)}
                         </option>
                       ))}
                     </select>
@@ -1132,13 +1183,13 @@ export function TTSConfigCard() {
           )}
 
           {/* Speed */}
-          <FieldRow label={`Speed — ${speed.toFixed(2)}×`} help="Playback speed. 1.0 is normal; range is 0.25×–4.0×.">
+          <FieldRow label={speedLabel} help={speedHelp}>
             <input
               type="range"
-              min={0.25}
-              max={4.0}
+              min={speedMin}
+              max={speedMax}
               step={0.05}
-              value={speed}
+              value={speedSliderValue}
               onChange={(e) => {
                 setSpeed(parseFloat(e.target.value));
                 mark({ speed: parseFloat(e.target.value) });
@@ -1146,9 +1197,9 @@ export function TTSConfigCard() {
               className="w-full accent-[var(--primary)]"
             />
             <div className="flex justify-between text-[0.6rem] text-[var(--muted-foreground)]">
-              <span>0.25×</span>
+              <span>{speedMin.toFixed(2)}×</span>
               <span>1.0×</span>
-              <span>4.0×</span>
+              <span>{speedMax.toFixed(2)}×</span>
             </div>
           </FieldRow>
 

--- a/packages/client/src/components/presets/PresetEditor.tsx
+++ b/packages/client/src/components/presets/PresetEditor.tsx
@@ -209,22 +209,33 @@ export function PresetEditor() {
   const [localWrapFormat, setLocalWrapFormat] = useState<WrapFormat>("xml");
   const [localAuthor, setLocalAuthor] = useState("");
   const [localParams, setLocalParams] = useState<Record<string, unknown>>({});
+  const [localParamsParseFailed, setLocalParamsParseFailed] = useState(false);
+  const hydratedPresetIdRef = useRef<string | null>(null);
+  const dirtyRef = useRef(false);
   const formatQuotes = useQuoteFormatter();
+
+  useEffect(() => {
+    dirtyRef.current = dirty;
+  }, [dirty]);
 
   // Populate local state when data loads
   useEffect(() => {
-    if (!data) return;
+    if (!data || !presetDetailId) return;
+    if (dirtyRef.current && hydratedPresetIdRef.current === presetDetailId) return;
     const p = data.preset as any;
+    hydratedPresetIdRef.current = presetDetailId;
     setLocalName(p.name ?? "");
     setLocalDescription(p.description ?? "");
     setLocalWrapFormat((p.wrapFormat ?? "xml") as WrapFormat);
     setLocalAuthor(p.author ?? "");
     try {
       setLocalParams(typeof p.parameters === "string" ? JSON.parse(p.parameters) : (p.parameters ?? {}));
+      setLocalParamsParseFailed(false);
     } catch {
       setLocalParams({});
+      setLocalParamsParseFailed(true);
     }
-  }, [data]);
+  }, [data, presetDetailId]);
 
   const handleClose = useCallback(() => {
     if (dirty) {
@@ -234,26 +245,60 @@ export function PresetEditor() {
     closePresetDetail();
   }, [dirty, closePresetDetail]);
 
-  const handleSave = useCallback(() => {
+  const handleSave = useCallback(async () => {
     if (!presetDetailId) return;
-    updatePreset.mutate(
-      {
-        id: presetDetailId,
-        name: localName,
-        description: localDescription,
-        wrapFormat: localWrapFormat,
-        author: localAuthor,
-        parameters: localParams,
-      },
-      {
-        onSuccess: () => {
-          setDirty(false);
-          setShowSaved(true);
-          setTimeout(() => setShowSaved(false), 1500);
-        },
-      },
-    );
-  }, [presetDetailId, localName, localDescription, localWrapFormat, localAuthor, localParams, updatePreset]);
+    if (!localName.trim()) {
+      const error = new Error("Preset name is required.");
+      toast.error(error.message);
+      throw error;
+    }
+    const payload: {
+      id: string;
+      name: string;
+      description: string;
+      wrapFormat: WrapFormat;
+      author: string;
+      parameters?: Record<string, unknown>;
+    } = {
+      id: presetDetailId,
+      name: localName,
+      description: localDescription,
+      wrapFormat: localWrapFormat,
+      author: localAuthor,
+    };
+    if (!localParamsParseFailed) payload.parameters = localParams;
+    await updatePreset.mutateAsync(payload);
+    setDirty(false);
+    setShowSaved(true);
+    setTimeout(() => setShowSaved(false), 1500);
+  }, [
+    presetDetailId,
+    localName,
+    localDescription,
+    localWrapFormat,
+    localAuthor,
+    localParamsParseFailed,
+    localParams,
+    updatePreset,
+  ]);
+
+  const handleExportPreset = useCallback(async () => {
+    if (!presetDetailId) return;
+    if (dirty) {
+      const shouldSave = await showConfirmDialog({
+        title: "Save Before Export",
+        message: "Exports use the saved preset. Save your current edits before exporting?",
+        confirmLabel: "Save & export",
+      });
+      if (!shouldSave) return;
+      try {
+        await handleSave();
+      } catch {
+        return;
+      }
+    }
+    api.download(`/prompts/${presetDetailId}/export`);
+  }, [dirty, handleSave, presetDetailId]);
 
   const handleDelete = useCallback(async () => {
     if (!presetDetailId) return;
@@ -379,9 +424,9 @@ export function PresetEditor() {
             <Save size="0.8125rem" /> Save
           </button>
           <button
-            onClick={() => api.download(`/prompts/${presetDetailId}/export`)}
+            onClick={handleExportPreset}
             className="mari-editor-action inline-flex"
-            title="Export preset"
+            title={dirty ? "Save current edits before exporting" : "Export preset"}
           >
             <svg
               width="0.9375rem"
@@ -434,9 +479,13 @@ export function PresetEditor() {
               Discard
             </button>
             <button
-              onClick={() => {
-                handleSave();
-                closePresetDetail();
+              onClick={async () => {
+                try {
+                  await handleSave();
+                  closePresetDetail();
+                } catch {
+                  // Keep the editor open so the user can fix the failed save.
+                }
               }}
               className="rounded-lg bg-amber-500/20 px-3 py-1 hover:bg-amber-500/30"
             >
@@ -1569,12 +1618,13 @@ function VariableCard({
   isReordering: boolean;
 }) {
   // Parse options
-  let opts: VariableOptionDraft[] = [];
-  try {
-    opts = typeof variable.options === "string" ? JSON.parse(variable.options) : (variable.options ?? []);
-  } catch {
-    /* empty */
-  }
+  const opts = useMemo<VariableOptionDraft[]>(() => {
+    try {
+      return typeof variable.options === "string" ? JSON.parse(variable.options) : (variable.options ?? []);
+    } catch {
+      return [];
+    }
+  }, [variable.options]);
 
   const varName = variable.variableName ?? variable.variable_name ?? "";
   const question = variable.question ?? "";
@@ -1585,18 +1635,31 @@ function VariableCard({
   const optionSort = readChoiceOptionSort(variable.optionSort ?? variable.option_sort);
   const optionOrderIsAlphabetical = optionSort === "alphabetical";
 
-  // Track which option is expanded in the big editor (index or null)
-  const [expandedOptIdx, setExpandedOptIdx] = useState<number | null>(null);
+  // Track which option is expanded in the big editor.
+  const [expandedOptId, setExpandedOptId] = useState<string | null>(null);
   const [draggingOptIdx, setDraggingOptIdx] = useState<number | null>(null);
   const [dropOptIdx, setDropOptIdx] = useState<number | null>(null);
   const [dragReadyOptIdx, setDragReadyOptIdx] = useState<number | null>(null);
+  const optsRef = useRef<VariableOptionDraft[]>(opts);
+  const expandedOpt = expandedOptId ? (opts.find((opt) => opt.id === expandedOptId) ?? null) : null;
+
+  useEffect(() => {
+    if (!onUpdateVariable.isPending) optsRef.current = opts;
+  }, [onUpdateVariable.isPending, opts]);
 
   const update = (data: Record<string, unknown>) => {
     onUpdateVariable.mutate({ presetId, variableId: variable.id, ...data });
   };
 
   const updateOpts = (newOpts: VariableOptionDraft[]) => {
+    optsRef.current = newOpts;
     update({ options: newOpts });
+  };
+
+  const currentOpts = () => (optsRef.current.length > 0 ? optsRef.current : opts);
+
+  const updateOptionField = (optionId: string, field: "label" | "value", value: string) => {
+    updateOpts(currentOpts().map((opt) => (opt.id === optionId ? { ...opt, [field]: value } : opt)));
   };
 
   const calcOptionDropIdx = (optionIdx: number, e: React.DragEvent) => {
@@ -1812,10 +1875,9 @@ function VariableCard({
                       <label className="shrink-0 text-[0.625rem] font-medium text-[var(--muted-foreground)]">
                         Separator
                       </label>
-                      <input
+                      <OptionFieldInput
                         value={separatorValue}
-                        onFocus={(e) => e.target.select()}
-                        onChange={(e) => update({ separator: e.target.value })}
+                        onCommit={(value) => update({ separator: value })}
                         className="w-20 rounded bg-[var(--background)] px-1.5 py-0.5 text-center font-mono text-xs ring-1 ring-[var(--border)] focus:outline-none focus:ring-1 focus:ring-[var(--marinara-chat-chrome-input-border-focus)]"
                         placeholder=", "
                       />
@@ -1966,21 +2028,13 @@ function VariableCard({
                     <span className="shrink-0 text-[0.625rem] font-medium text-amber-400">{oi + 1}.</span>
                     <OptionFieldInput
                       value={opt.label}
-                      onCommit={(v) => {
-                        const next = [...opts];
-                        next[oi] = { ...next[oi], label: v };
-                        updateOpts(next);
-                      }}
+                      onCommit={(v) => updateOptionField(opt.id, "label", v)}
                       className="flex-1 rounded bg-[var(--background)] px-1.5 py-0.5 text-xs focus:outline-none focus:ring-1 focus:ring-amber-400/50"
                       placeholder="Label…"
                     />
                     <OptionFieldInput
                       value={opt.value}
-                      onCommit={(v) => {
-                        const next = [...opts];
-                        next[oi] = { ...next[oi], value: v };
-                        updateOpts(next);
-                      }}
+                      onCommit={(v) => updateOptionField(opt.id, "value", v)}
                       className={cn(
                         "flex-1 rounded px-1.5 py-0.5 font-mono text-xs focus:outline-none focus:ring-1",
                         valueBlank
@@ -1990,7 +2044,7 @@ function VariableCard({
                       placeholder="Value…"
                     />
                     <button
-                      onClick={() => setExpandedOptIdx(oi)}
+                      onClick={() => setExpandedOptId(opt.id)}
                       className="shrink-0 rounded p-0.5 text-[var(--muted-foreground)] hover:bg-[var(--accent)] hover:text-[var(--foreground)]"
                       title="Expand value editor"
                     >
@@ -1998,8 +2052,8 @@ function VariableCard({
                     </button>
                     <button
                       onClick={() => {
-                        if (opts.length <= 1) return toast.error("A variable needs at least 1 option.");
-                        updateOpts(opts.filter((_, i) => i !== oi));
+                        if (currentOpts().length <= 1) return toast.error("A variable needs at least 1 option.");
+                        updateOpts(currentOpts().filter((option) => option.id !== opt.id));
                       }}
                       className="shrink-0 rounded p-0.5 hover:bg-[var(--destructive)]/15"
                       title="Remove option"
@@ -2018,10 +2072,10 @@ function VariableCard({
               onClick={() => {
                 const newOpt = {
                   id: `opt_${Date.now()}`,
-                  label: `Option ${String.fromCharCode(65 + opts.length)}`,
+                  label: `Option ${String.fromCharCode(65 + currentOpts().length)}`,
                   value: "",
                 };
-                updateOpts([...opts, newOpt]);
+                updateOpts([...currentOpts(), newOpt]);
               }}
               className="flex items-center gap-1 rounded-lg px-2 py-1 text-[0.625rem] font-medium text-amber-400 hover:bg-amber-400/10 active:scale-[0.98]"
             >
@@ -2030,16 +2084,12 @@ function VariableCard({
           </div>
 
           {/* Expanded value editor for a single option */}
-          {expandedOptIdx !== null && opts[expandedOptIdx] && (
+          {expandedOpt && (
             <ExpandedEditorModal
-              title={`Edit Value: ${opts[expandedOptIdx].label || `Option ${expandedOptIdx + 1}`}`}
-              value={opts[expandedOptIdx].value}
-              onChange={(v) => {
-                const next = [...opts];
-                next[expandedOptIdx] = { ...next[expandedOptIdx], value: v };
-                updateOpts(next);
-              }}
-              onClose={() => setExpandedOptIdx(null)}
+              title={`Edit Value: ${expandedOpt.label || "Option"}`}
+              value={expandedOpt.value}
+              onChange={(v) => updateOptionField(expandedOpt.id, "value", v)}
+              onClose={() => setExpandedOptId(null)}
             />
           )}
         </div>

--- a/packages/client/src/components/presets/PresetEditor.tsx
+++ b/packages/client/src/components/presets/PresetEditor.tsx
@@ -1260,7 +1260,9 @@ function SectionsTab({
                             <div className="mari-chrome-text rounded-lg bg-[var(--marinara-chat-chrome-highlight-bg)] p-3 text-xs">
                               Marker type: <strong>{MARKER_LABELS[mc.type as MarkerType] ?? "Unknown"}</strong>
                               <p className="mt-1 text-[var(--muted-foreground)]">
-                                Content is auto-generated at assembly time from your characters, lorebooks, etc.
+                                {mc.type === "chat_summary"
+                                  ? "Renders the compiled Chat Summary for this chat, including enabled manual and automated summary entries."
+                                  : "Content is auto-generated at assembly time from your characters, lorebooks, etc."}
                               </p>
                               {["lorebook", "world_info_before", "world_info_after"].includes(mc.type) && (
                                 <p className="mt-1 text-amber-200">

--- a/packages/client/src/components/ui/GenerationParametersEditor.tsx
+++ b/packages/client/src/components/ui/GenerationParametersEditor.tsx
@@ -551,6 +551,7 @@ function ParamInput({
         ? `Enter a value of ${min.toLocaleString()} or higher.`
         : `Enter a value from ${min.toLocaleString()} to ${max.toLocaleString()}.`,
     );
+    setDraft(String(value));
   };
 
   return (

--- a/packages/client/src/components/ui/SpeechToTextButton.tsx
+++ b/packages/client/src/components/ui/SpeechToTextButton.tsx
@@ -69,6 +69,7 @@ export function SpeechToTextButton({ disabled, onTranscript, className, iconSize
   const [supported, setSupported] = useState(false);
   const [listening, setListening] = useState(false);
   const recognitionRef = useRef<SpeechRecognitionLike | null>(null);
+  const disabledRef = useRef(Boolean(disabled));
 
   useEffect(() => {
     setSupported(Boolean(getSpeechRecognitionCtor()));
@@ -78,16 +79,25 @@ export function SpeechToTextButton({ disabled, onTranscript, className, iconSize
     };
   }, []);
 
+  useEffect(() => {
+    disabledRef.current = Boolean(disabled);
+    if (disabled && recognitionRef.current) {
+      recognitionRef.current.abort();
+      recognitionRef.current = null;
+      setListening(false);
+    }
+  }, [disabled]);
+
   const stopListening = useCallback(() => {
     recognitionRef.current?.stop();
   }, []);
 
   const startListening = useCallback(() => {
-    if (disabled) return;
-    if (listening) {
+    if (listening || recognitionRef.current) {
       stopListening();
       return;
     }
+    if (disabledRef.current) return;
 
     const Recognition = getSpeechRecognitionCtor();
     if (!Recognition) {
@@ -119,7 +129,7 @@ export function SpeechToTextButton({ disabled, onTranscript, className, iconSize
     recognition.onend = () => {
       recognitionRef.current = null;
       setListening(false);
-      if (finalTranscript.trim()) {
+      if (!disabledRef.current && finalTranscript.trim()) {
         onTranscript(finalTranscript.trim());
       }
     };
@@ -133,7 +143,7 @@ export function SpeechToTextButton({ disabled, onTranscript, className, iconSize
       setListening(false);
       toast.error("Could not start speech recognition.");
     }
-  }, [disabled, listening, onTranscript, stopListening]);
+  }, [listening, onTranscript, stopListening]);
 
   return (
     <button

--- a/packages/client/src/components/ui/SpriteGenerationModal.tsx
+++ b/packages/client/src/components/ui/SpriteGenerationModal.tsx
@@ -117,6 +117,17 @@ function isSpritePromptReviewCancelled(error: unknown): error is SpritePromptRev
   return error instanceof SpritePromptReviewCancelledError;
 }
 
+class SpriteGenerationAbortedError extends Error {
+  constructor() {
+    super("Sprite generation cancelled");
+    this.name = "SpriteGenerationAbortedError";
+  }
+}
+
+function isSpriteGenerationAborted(error: unknown): error is SpriteGenerationAbortedError {
+  return error instanceof SpriteGenerationAbortedError;
+}
+
 // ── Constants ──
 
 const EXPRESSION_PRESETS = {
@@ -363,27 +374,44 @@ function getGenerationErrorMessage(err: unknown): string {
 }
 
 function isAbortError(err: unknown): boolean {
-  return err instanceof DOMException && err.name === "AbortError";
+  return (
+    (err instanceof DOMException && err.name === "AbortError") ||
+    (!!err && typeof err === "object" && "name" in err && err.name === "AbortError")
+  );
 }
 
 function isDefaultImageConnection(connection: ImageConnectionOption): boolean {
   return connection.defaultForAgents === true || connection.defaultForAgents === "true";
 }
 
-async function postSpriteGenerationRequest<T>(body: unknown): Promise<T> {
+async function postSpriteGenerationRequest<T>(body: unknown, signal?: AbortSignal): Promise<T> {
   const controller = new AbortController();
-  const timeout = window.setTimeout(() => controller.abort(), SPRITE_GENERATION_REQUEST_TIMEOUT_MS);
+  let timedOut = false;
+  const abortFromParent = () => controller.abort(signal?.reason);
+  if (signal?.aborted) {
+    controller.abort(signal.reason);
+  } else {
+    signal?.addEventListener("abort", abortFromParent, { once: true });
+  }
+  const timeout = window.setTimeout(() => {
+    timedOut = true;
+    controller.abort();
+  }, SPRITE_GENERATION_REQUEST_TIMEOUT_MS);
 
   try {
     return await api.post<T>("/sprites/generate-sheet", body, { signal: controller.signal });
   } catch (err) {
     if (isAbortError(err)) {
+      if (!timedOut && signal?.aborted) {
+        throw new SpriteGenerationAbortedError();
+      }
       throw new Error(
         "Sprite generation timed out after about 5 minutes. The image provider may still be busy; try again or use a faster image connection.",
       );
     }
     throw err;
   } finally {
+    signal?.removeEventListener("abort", abortFromParent);
     window.clearTimeout(timeout);
   }
 }
@@ -564,6 +592,11 @@ export function SpriteGenerationModal({
 
   const fileInputRef = useRef<HTMLInputElement>(null);
   const promptReviewResolveRef = useRef<((overrides: ImagePromptOverride[] | null) => void) | null>(null);
+  const generationControllerRef = useRef<AbortController | null>(null);
+  const generationRunIdRef = useRef(0);
+  const framePreviewRequestRef = useRef(0);
+  const wasOpenRef = useRef(false);
+  const previousEntityIdRef = useRef(entityId);
   const reviewImagePromptsBeforeSend = useUIStore((s) => s.reviewImagePromptsBeforeSend);
 
   // Connections
@@ -669,8 +702,18 @@ export function SpriteGenerationModal({
     resolve?.(overrides);
   }, []);
 
+  const abortActiveGeneration = useCallback(() => {
+    generationRunIdRef.current += 1;
+    generationControllerRef.current?.abort();
+    generationControllerRef.current = null;
+    closePromptReview(null);
+  }, [closePromptReview]);
+
   useEffect(() => {
     return () => {
+      generationRunIdRef.current += 1;
+      generationControllerRef.current?.abort();
+      generationControllerRef.current = null;
       const resolve = promptReviewResolveRef.current;
       promptReviewResolveRef.current = null;
       resolve?.(null);
@@ -678,7 +721,34 @@ export function SpriteGenerationModal({
   }, []);
 
   useEffect(() => {
-    if (!open) return;
+    if (!open) {
+      if (wasOpenRef.current) {
+        abortActiveGeneration();
+        setStep(0);
+        setGeneratedSheet(null);
+        setGeneratedSheets([]);
+        setCells([]);
+        setFailedMatchedBatch(null);
+        setGenerationProgress(null);
+        setCleanupApplying(false);
+        setCleanupApplied(false);
+        setSliceAdjustments(DEFAULT_SLICE_ADJUSTMENTS);
+        setSliceApplying(false);
+        setActiveFrameIndex(null);
+        setFrameAdjustments(DEFAULT_SPRITE_FRAME_ADJUSTMENTS);
+        setFramePreviewUrl(null);
+        setFrameApplying(false);
+        setSaving(false);
+        setError(null);
+        setPromptReviewSubmitting(false);
+      }
+      wasOpenRef.current = false;
+      return;
+    }
+
+    if (wasOpenRef.current) return;
+    wasOpenRef.current = true;
+    previousEntityIdRef.current = entityId;
     setSpriteType(initialSpriteType);
     setPreset(DEFAULT_SPRITE_PRESET);
     setSelectedExpressions(
@@ -689,10 +759,32 @@ export function SpriteGenerationModal({
     setMatchExistingExpressions(false);
     setNativeTransparentPng(false);
     setNoBackground(false);
-  }, [open, initialSpriteType]);
+    setAppearance(defaultAppearance ?? "");
+    setReferenceImages([]);
+    setUseCurrentAvatarReference(!!defaultAvatarUrl);
+    setStep(0);
+    setGeneratedSheet(null);
+    setGeneratedSheets([]);
+    setCells([]);
+    setFailedMatchedBatch(null);
+    setGenerationProgress(null);
+    setCleanupApplying(false);
+    setCleanupApplied(false);
+    setSliceAdjustments(DEFAULT_SLICE_ADJUSTMENTS);
+    setSliceApplying(false);
+    setActiveFrameIndex(null);
+    setFrameAdjustments(DEFAULT_SPRITE_FRAME_ADJUSTMENTS);
+    setFramePreviewUrl(null);
+    setFrameApplying(false);
+    setSaving(false);
+    setError(null);
+  }, [abortActiveGeneration, defaultAppearance, defaultAvatarUrl, entityId, initialSpriteType, open]);
 
-  // Reset reference image & appearance when the target character changes
+  // Reset reference image & appearance only when the target character/persona changes.
   useEffect(() => {
+    if (previousEntityIdRef.current === entityId) return;
+    previousEntityIdRef.current = entityId;
+    abortActiveGeneration();
     setAppearance(defaultAppearance ?? "");
     setReferenceImages([]);
     setUseCurrentAvatarReference(!!defaultAvatarUrl);
@@ -710,7 +802,7 @@ export function SpriteGenerationModal({
     setNativeTransparentPng(false);
     setNoBackground(false);
     setError(null);
-  }, [entityId, defaultAvatarUrl, defaultAppearance]);
+  }, [abortActiveGeneration, defaultAppearance, defaultAvatarUrl, entityId]);
 
   useEffect(() => {
     if (activeFrameIndex !== null && activeFrameIndex >= cells.length) {
@@ -726,17 +818,26 @@ export function SpriteGenerationModal({
       return;
     }
 
+    const requestId = framePreviewRequestRef.current + 1;
+    framePreviewRequestRef.current = requestId;
     let cancelled = false;
-    cropSpriteDataUrl(activeFrameCell.dataUrl, frameAdjustments)
-      .then((preview) => {
-        if (!cancelled) setFramePreviewUrl(preview);
-      })
-      .catch(() => {
-        if (!cancelled) setFramePreviewUrl(activeFrameCell.dataUrl);
+    let rafId: number | null = null;
+    const timeoutId = window.setTimeout(() => {
+      rafId = window.requestAnimationFrame(() => {
+        cropSpriteDataUrl(activeFrameCell.dataUrl, frameAdjustments)
+          .then((preview) => {
+            if (!cancelled && framePreviewRequestRef.current === requestId) setFramePreviewUrl(preview);
+          })
+          .catch(() => {
+            if (!cancelled && framePreviewRequestRef.current === requestId) setFramePreviewUrl(activeFrameCell.dataUrl);
+          });
       });
+    }, 90);
 
     return () => {
       cancelled = true;
+      window.clearTimeout(timeoutId);
+      if (rafId !== null) window.cancelAnimationFrame(rafId);
     };
   }, [activeFrameCell, frameAdjustments]);
 
@@ -792,6 +893,8 @@ export function SpriteGenerationModal({
   const requestGeneratedSheet = useCallback(
     async (expressions: string[], grid: SpriteGrid, matchedFullBodyMode: boolean): Promise<GenerateSheetResult> => {
       if (!effectiveConnectionId) throw new Error("Image generation connection is required");
+      const signal = generationControllerRef.current?.signal;
+      if (signal?.aborted) throw new SpriteGenerationAbortedError();
 
       const payload = {
         connectionId: effectiveConnectionId,
@@ -808,23 +911,27 @@ export function SpriteGenerationModal({
       };
 
       if (reviewImagePromptsBeforeSend) {
-        const preview = await api.post<GenerateSheetPreviewResult>("/sprites/generate-sheet/preview", payload);
+        const preview = await api.post<GenerateSheetPreviewResult>("/sprites/generate-sheet/preview", payload, {
+          signal,
+        });
+        if (signal?.aborted) throw new SpriteGenerationAbortedError();
         if (preview.items.length > 0) {
           const overrides = await openPromptReview(preview.items);
           if (!overrides) throw new SpritePromptReviewCancelledError();
+          if (signal?.aborted) throw new SpriteGenerationAbortedError();
           setPromptReviewSubmitting(true);
           try {
             return await postSpriteGenerationRequest<GenerateSheetResult>({
               ...payload,
               promptOverrides: overrides,
-            });
+            }, signal);
           } finally {
             setPromptReviewSubmitting(false);
           }
         }
       }
 
-      return postSpriteGenerationRequest<GenerateSheetResult>(payload);
+      return postSpriteGenerationRequest<GenerateSheetResult>(payload, signal);
     },
     [
       appearance,
@@ -845,6 +952,7 @@ export function SpriteGenerationModal({
       let lastError = "Image generation failed";
 
       for (let attempt = 0; attempt < 2; attempt += 1) {
+        if (generationControllerRef.current?.signal.aborted) throw new SpriteGenerationAbortedError();
         setGenerationProgress(
           `Batch ${batchIndex + 1} of ${totalBatches}${attempt === 1 ? " (retrying once)" : ""}: ${batchExpressions
             .map((expr) => expr.replace(/_/g, " "))
@@ -861,6 +969,7 @@ export function SpriteGenerationModal({
           }
           return createGeneratedSpritesFromResult(result, grid, `Batch ${batchIndex + 1}`);
         } catch (err) {
+          if (isSpriteGenerationAborted(err)) throw err;
           lastError = getGenerationErrorMessage(err);
         }
       }
@@ -888,15 +997,25 @@ export function SpriteGenerationModal({
       setFailedMatchedBatch(null);
 
       for (let batchIndex = startIndex; batchIndex < batches.length; batchIndex += 1) {
+        if (generationControllerRef.current?.signal.aborted) {
+          setGenerationProgress(null);
+          setStep(0);
+          return;
+        }
         const batchExpressions = batches[batchIndex] ?? [];
         if (batchExpressions.length === 0) continue;
 
         try {
           const generated = await generateMatchedFullBodyBatch(batchExpressions, batchIndex, batches.length);
+          if (generationControllerRef.current?.signal.aborted) {
+            setGenerationProgress(null);
+            setStep(0);
+            return;
+          }
           nextCells = [...nextCells, ...generated.cells];
           if (generated.sheet) nextSheets = [...nextSheets, generated.sheet];
         } catch (err) {
-          if (isSpritePromptReviewCancelled(err)) {
+          if (isSpritePromptReviewCancelled(err) || isSpriteGenerationAborted(err)) {
             setStep(0);
             setError(null);
             setGenerationProgress(null);
@@ -936,6 +1055,12 @@ export function SpriteGenerationModal({
   const handleGenerate = useCallback(async () => {
     if (spriteGenerationUnavailable || !effectiveConnectionId || cappedSelectedExpressions.length === 0) return;
 
+    generationControllerRef.current?.abort();
+    const controller = new AbortController();
+    generationControllerRef.current = controller;
+    const runId = generationRunIdRef.current + 1;
+    generationRunIdRef.current = runId;
+
     setStep(1);
     setError(null);
     setGeneratedSheet(null);
@@ -949,18 +1074,19 @@ export function SpriteGenerationModal({
     setFramePreviewUrl(null);
     setSliceAdjustments(createDefaultSliceAdjustments(sliceAdjustmentGrid));
 
-    if (fullBodyExpressionMode) {
-      await runMatchedFullBodyBatches({
-        batches: matchedFullBodyBatches,
-        startIndex: 0,
-        initialCells: [],
-        initialSheets: [],
-      });
-      return;
-    }
-
     try {
+      if (fullBodyExpressionMode) {
+        await runMatchedFullBodyBatches({
+          batches: matchedFullBodyBatches,
+          startIndex: 0,
+          initialCells: [],
+          initialSheets: [],
+        });
+        return;
+      }
+
       const result = await requestGeneratedSheet(cappedSelectedExpressions, generationGrid, false);
+      if (controller.signal.aborted) throw new SpriteGenerationAbortedError();
       const generated = createGeneratedSpritesFromResult(result, generationGrid, "Generated sheet");
 
       setGeneratedSheet(generated.sheet?.dataUrl ?? null);
@@ -980,13 +1106,17 @@ export function SpriteGenerationModal({
       }
       setError(warnings.length > 0 ? warnings.join(" ") : null);
     } catch (err) {
-      if (isSpritePromptReviewCancelled(err)) {
+      if (isSpritePromptReviewCancelled(err) || isSpriteGenerationAborted(err)) {
         setError(null);
         setStep(0);
         return;
       }
       setError(getGenerationErrorMessage(err));
       setStep(0);
+    } finally {
+      if (generationRunIdRef.current === runId && generationControllerRef.current === controller) {
+        generationControllerRef.current = null;
+      }
     }
   }, [
     spriteGenerationUnavailable,
@@ -1005,6 +1135,12 @@ export function SpriteGenerationModal({
   const handleRetryFailedMatchedBatch = useCallback(async () => {
     if (!failedMatchedBatch || spriteGenerationUnavailable || !effectiveConnectionId) return;
 
+    generationControllerRef.current?.abort();
+    const controller = new AbortController();
+    generationControllerRef.current = controller;
+    const runId = generationRunIdRef.current + 1;
+    generationRunIdRef.current = runId;
+
     setStep(1);
     setError(null);
     setActiveFrameIndex(null);
@@ -1017,12 +1153,18 @@ export function SpriteGenerationModal({
       ...failedMatchedBatch.remainingBatches,
     ];
 
-    await runMatchedFullBodyBatches({
-      batches: retryBatches,
-      startIndex: failedMatchedBatch.batchIndex,
-      initialCells: cells,
-      initialSheets: generatedSheets,
-    });
+    try {
+      await runMatchedFullBodyBatches({
+        batches: retryBatches,
+        startIndex: failedMatchedBatch.batchIndex,
+        initialCells: cells,
+        initialSheets: generatedSheets,
+      });
+    } finally {
+      if (generationRunIdRef.current === runId && generationControllerRef.current === controller) {
+        generationControllerRef.current = null;
+      }
+    }
   }, [
     cells,
     effectiveConnectionId,
@@ -1032,6 +1174,14 @@ export function SpriteGenerationModal({
     runMatchedFullBodyBatches,
     spriteGenerationUnavailable,
   ]);
+
+  const handleCancelGeneration = useCallback(() => {
+    abortActiveGeneration();
+    setGenerationProgress(null);
+    setPromptReviewSubmitting(false);
+    setStep(0);
+    setError(null);
+  }, [abortActiveGeneration]);
 
   const handleApplyCleanup = useCallback(async () => {
     if (!noBackground || cells.length === 0) return;
@@ -1257,18 +1407,12 @@ export function SpriteGenerationModal({
   }, []);
 
   const handleCellRename = useCallback((idx: number, name: string) => {
+    setCells((prev) => prev.map((c, i) => (i === idx ? { ...c, expression: name } : c)));
+  }, []);
+
+  const handleCellRenameBlur = useCallback((idx: number) => {
     setCells((prev) =>
-      prev.map((c, i) =>
-        i === idx
-          ? {
-              ...c,
-              expression: name
-                .trim()
-                .toLowerCase()
-                .replace(/[^a-z0-9_-]/g, "_"),
-            }
-          : c,
-      ),
+      prev.map((c, i) => (i === idx ? { ...c, expression: normalizeSpriteLabel(c.expression) } : c)),
     );
   }, []);
 
@@ -1276,27 +1420,77 @@ export function SpriteGenerationModal({
     const toSave = cells.filter((c) => c.selected && c.expression);
     if (toSave.length === 0) return;
 
+    const saveTargets = toSave.map((cell) => {
+      const cleaned = normalizeSpriteLabel(cell.expression);
+      const expression =
+        spriteType === "full-body" ? (cleaned.startsWith("full_") ? cleaned : `full_${cleaned}`) : cleaned;
+      return { cell, expression };
+    });
+    if (saveTargets.some(({ expression }) => !expression || expression === "full_")) {
+      setError("Each selected sprite needs a valid expression label before saving.");
+      return;
+    }
+    const counts = new Map<string, number>();
+    for (const { expression } of saveTargets) {
+      counts.set(expression, (counts.get(expression) ?? 0) + 1);
+    }
+    const duplicateExpressions = [...counts.entries()]
+      .filter(([, count]) => count > 1)
+      .map(([expression]) => expression);
+    if (duplicateExpressions.length > 0) {
+      setError(
+        `Each selected sprite needs a unique expression label. Duplicate: ${duplicateExpressions
+          .map((expression) => expression.replace(/^full_/, "").replace(/_/g, " "))
+          .join(", ")}.`,
+      );
+      return;
+    }
+
     setSaving(true);
     setError(null);
 
     try {
-      for (const cell of toSave) {
-        const cleaned = cell.expression
-          .trim()
-          .toLowerCase()
-          .replace(/[^a-z0-9_-]/g, "_");
-        const expression =
-          spriteType === "full-body"
-            ? cleaned.startsWith("full_")
-              ? cleaned
-              : `full_${cleaned}`
-            : cleaned.replace(/^full_/, "");
-        await api.post(`/sprites/${entityId}`, {
-          expression,
-          image: cell.dataUrl,
+      const results = await Promise.allSettled(
+        saveTargets.map(({ cell, expression }) =>
+          api.post(`/sprites/${entityId}`, {
+            expression,
+            image: cell.dataUrl,
+          }),
+        ),
+      );
+      const failed = results
+        .map((result, index) => ({ result, target: saveTargets[index]! }))
+        .filter((entry): entry is { result: PromiseRejectedResult; target: (typeof saveTargets)[number] } => {
+          return entry.result.status === "rejected";
         });
+      const saved = saveTargets.filter((_, index) => results[index]?.status === "fulfilled");
+
+      if (saved.length > 0) {
+        onSpritesGenerated?.();
       }
-      onSpritesGenerated?.();
+
+      if (failed.length > 0) {
+        const savedExpressions = new Set(saved.map((target) => target.expression));
+        setCells((prev) =>
+          prev.map((cell) => {
+            const cleaned = normalizeSpriteLabel(cell.expression);
+            const expression =
+              spriteType === "full-body" ? (cleaned.startsWith("full_") ? cleaned : `full_${cleaned}`) : cleaned;
+            return savedExpressions.has(expression) ? { ...cell, selected: false } : cell;
+          }),
+        );
+        setError(
+          `Saved ${saved.length} sprite${saved.length === 1 ? "" : "s"}, failed ${failed.length}: ${failed
+            .slice(0, 3)
+            .map(({ target, result }) => {
+              const message = result.reason instanceof Error ? result.reason.message : "Save failed";
+              return `${target.expression.replace(/^full_/, "").replace(/_/g, " ")} (${message})`;
+            })
+            .join("; ")}${failed.length > 3 ? "; ..." : ""}`,
+        );
+        return;
+      }
+
       onClose();
       // Reset for next use
       setStep(0);
@@ -1328,13 +1522,21 @@ export function SpriteGenerationModal({
     setError(null);
   }, [handleCloseCellFrame]);
 
+  const handleClose = useCallback(() => {
+    abortActiveGeneration();
+    setSaving(false);
+    setPromptReviewSubmitting(false);
+    handleReset();
+    onClose();
+  }, [abortActiveGeneration, handleReset, onClose]);
+
   const selectedCount = cells.filter((c) => c.selected).length;
 
   // ── Render ──
 
   return (
     <>
-      <Modal open={open} onClose={onClose} title="Generate Sprites" width="max-w-2xl">
+      <Modal open={open} onClose={handleClose} title="Generate Sprites" width="max-w-2xl">
         <input ref={fileInputRef} type="file" accept="image/*" className="hidden" onChange={handleReferenceUpload} />
 
         {/* Step 0: Configuration */}
@@ -1686,7 +1888,7 @@ export function SpriteGenerationModal({
             {/* Generate Button */}
             <div className="flex items-center justify-between border-t border-[var(--border)]/30 pt-4">
               <button
-                onClick={onClose}
+                onClick={handleClose}
                 className="rounded-lg px-3 py-1.5 text-xs text-[var(--muted-foreground)] transition-colors hover:text-[var(--foreground)] hover:bg-[var(--secondary)]"
               >
                 Cancel
@@ -1744,6 +1946,13 @@ export function SpriteGenerationModal({
                     : "This may take 30–60 seconds depending on the provider."}
               </p>
             </div>
+            <button
+              type="button"
+              onClick={handleCancelGeneration}
+              className="rounded-lg px-3 py-1.5 text-xs text-[var(--muted-foreground)] ring-1 ring-[var(--border)] transition-colors hover:bg-[var(--secondary)] hover:text-[var(--foreground)]"
+            >
+              Cancel
+            </button>
           </div>
         )}
 
@@ -2114,6 +2323,7 @@ export function SpriteGenerationModal({
                         <input
                           value={cell.expression}
                           onChange={(e) => handleCellRename(i, e.target.value)}
+                          onBlur={() => handleCellRenameBlur(i)}
                           className="w-full rounded bg-[var(--secondary)]/70 px-2 py-1 text-center text-[0.625rem] text-[var(--muted-foreground)] outline-none focus:text-[var(--foreground)] focus:ring-1 focus:ring-[var(--primary)]/40"
                           aria-label={`Sprite filename for ${cell.expression}`}
                         />

--- a/packages/client/src/features/chat-settings/sections/AdvancedParametersSection.tsx
+++ b/packages/client/src/features/chat-settings/sections/AdvancedParametersSection.tsx
@@ -13,6 +13,21 @@ import { SettingsSwitch } from "../../../components/panels/settings/SettingContr
 import { useSaveConnectionDefaults } from "../../../hooks/use-connections";
 import { cn } from "../../../lib/utils";
 
+const EDITABLE_PARAMETER_KEYS: Array<keyof EditableGenerationParameters> = [
+  "temperature",
+  "maxTokens",
+  "topP",
+  "topK",
+  "frequencyPenalty",
+  "presencePenalty",
+  "reasoningEffort",
+  "verbosity",
+  "serviceTier",
+  "assistantPrefill",
+  "customThinkingTags",
+  "customParameters",
+];
+
 interface AdvancedParametersSectionProps {
   metadata: Record<string, unknown>;
   isConversation: boolean;
@@ -46,7 +61,17 @@ export function AdvancedParametersSection({
   const excludeReasoningEnabled = excludePastReasoning !== false;
 
   const setParameters = (next: EditableGenerationParameters) => {
-    onChatParametersChange({ ...params, ...next });
+    const editableKeys = new Set<string>(EDITABLE_PARAMETER_KEYS);
+    const sparse: Record<string, unknown> = {};
+    for (const [key, value] of Object.entries(params)) {
+      if (!editableKeys.has(key)) sparse[key] = value;
+    }
+    for (const key of EDITABLE_PARAMETER_KEYS) {
+      if (JSON.stringify(next[key]) !== JSON.stringify(defaults[key])) {
+        sparse[key] = next[key];
+      }
+    }
+    onChatParametersChange(sparse);
   };
   const toggleExpanded = () => setExpanded((open) => !open);
   const handleHeaderKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
@@ -147,7 +172,7 @@ export function AdvancedParametersSection({
             </button>
           )}
           <button
-            onClick={() => onChatParametersChange(defaults)}
+            onClick={() => onChatParametersChange({})}
             className="w-full rounded-lg bg-[var(--secondary)] px-3 py-1.5 text-[0.625rem] text-[var(--muted-foreground)] transition-colors hover:bg-[var(--accent)]"
           >
             Reset to Defaults

--- a/packages/client/src/hooks/use-agents.ts
+++ b/packages/client/src/hooks/use-agents.ts
@@ -41,6 +41,13 @@ export interface AgentRunRow {
   createdAt: string;
 }
 
+function upsertAgentConfig(rows: AgentConfigRow[] | undefined, agent: AgentConfigRow) {
+  if (!rows) return [agent];
+  const existingIndex = rows.findIndex((row) => row.id === agent.id);
+  if (existingIndex === -1) return [agent, ...rows];
+  return rows.map((row) => (row.id === agent.id ? agent : row));
+}
+
 export function useAgentConfigs(enabled = true) {
   return useQuery({
     queryKey: agentKeys.all,
@@ -104,8 +111,12 @@ export function useUpdateAgentByType() {
 export function useCreateAgent() {
   const qc = useQueryClient();
   return useMutation({
-    mutationFn: (data: Record<string, unknown>) => api.post("/agents", data),
-    onSuccess: () => {
+    mutationFn: (data: Record<string, unknown>) => api.post<AgentConfigRow>("/agents", data),
+    onSuccess: (agent) => {
+      if (agent?.id) {
+        qc.setQueryData(agentKeys.detail(agent.id), agent);
+        qc.setQueryData<AgentConfigRow[] | undefined>(agentKeys.all, (rows) => upsertAgentConfig(rows, agent));
+      }
       qc.invalidateQueries({ queryKey: agentKeys.all });
     },
   });

--- a/packages/client/src/hooks/use-background-autonomous.ts
+++ b/packages/client/src/hooks/use-background-autonomous.ts
@@ -164,17 +164,29 @@ export function useBackgroundAutonomousPolling() {
                   return;
                 }
 
+                const abortController = new AbortController();
+                useChatStore.getState().setAbortController(chat.id, abortController);
                 // Use streamEvents to drain the SSE — tokens aren't needed for background chats
-                for await (const _event of api.streamEvents("/generate", {
-                  chatId: chat.id,
-                  connectionId: null,
-                  forCharacterId: characterId,
-                  autonomous: true,
-                  autonomousIntentKey: result.autonomousIntentKey,
-                  skipPresenceDelay: true,
-                  streaming: useUIStore.getState().enableStreaming,
-                })) {
-                  if ((_event as { type: string }).type === "token") receivedTokens = true;
+                try {
+                  for await (const _event of api.streamEvents(
+                    "/generate",
+                    {
+                      chatId: chat.id,
+                      connectionId: null,
+                      forCharacterId: characterId,
+                      autonomous: true,
+                      autonomousIntentKey: result.autonomousIntentKey,
+                      skipPresenceDelay: true,
+                      streaming: useUIStore.getState().enableStreaming,
+                    },
+                    abortController.signal,
+                  )) {
+                    if ((_event as { type: string }).type === "token") receivedTokens = true;
+                  }
+                } finally {
+                  if (useChatStore.getState().abortControllers.get(chat.id) === abortController) {
+                    useChatStore.getState().setAbortController(chat.id, null);
+                  }
                 }
 
                 // Only notify if the generation actually produced a message

--- a/packages/client/src/hooks/use-chats.ts
+++ b/packages/client/src/hooks/use-chats.ts
@@ -503,14 +503,40 @@ export function useUpdateChatMetadata() {
   return useMutation({
     mutationFn: ({ id, ...metadata }: { id: string; [key: string]: unknown }) =>
       api.patch<Chat>(`/chats/${id}/metadata`, metadata),
+    onMutate: async ({ id, ...metadata }) => {
+      await qc.cancelQueries({ queryKey: chatKeys.detail(id) });
+      const previous = qc.getQueryData<Chat>(chatKeys.detail(id));
+      const updatedAt = new Date().toISOString();
+      qc.setQueryData<Chat>(chatKeys.detail(id), (existing) =>
+        existing
+          ? {
+              ...existing,
+              metadata: { ...existing.metadata, ...metadata },
+              updatedAt,
+            }
+          : existing,
+      );
+      return { previous };
+    },
+    onError: (_error, variables, context) => {
+      if (context?.previous) {
+        qc.setQueryData<Chat>(chatKeys.detail(variables.id), context.previous);
+      }
+    },
     onSuccess: (data, vars) => {
       // Metadata PATCH returns a full chat row, but concurrent updates to
       // non-metadata fields (for example promptPresetId) may still be in
-      // flight. Merge only the metadata fields so a stale full-row response
-      // cannot clobber fresher chat detail state.
+      // flight. Merge only metadata, and keep newer optimistic metadata on top
+      // so an older PATCH response cannot clobber a later in-flight edit.
       if (data) {
         qc.setQueryData<Chat>(chatKeys.detail(vars.id), (existing) =>
-          existing ? { ...existing, metadata: data.metadata, updatedAt: data.updatedAt } : data,
+          existing
+            ? {
+                ...existing,
+                metadata: { ...data.metadata, ...existing.metadata },
+                updatedAt: data.updatedAt,
+              }
+            : data,
         );
       } else {
         qc.invalidateQueries({ queryKey: chatKeys.detail(vars.id) });

--- a/packages/client/src/hooks/use-connections.ts
+++ b/packages/client/src/hooks/use-connections.ts
@@ -4,7 +4,9 @@
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { api } from "../lib/api-client";
 import { useUIStore } from "../stores/ui.store";
-import type { APIProvider, ConnectionTestResult } from "@marinara-engine/shared";
+import { useChatStore } from "../stores/chat.store";
+import { chatKeys } from "./use-chats";
+import type { APIProvider, Chat, ConnectionTestResult } from "@marinara-engine/shared";
 
 export const connectionKeys = {
   all: ["connections"] as const,
@@ -99,7 +101,20 @@ export function useDeleteConnection() {
   const qc = useQueryClient();
   return useMutation({
     mutationFn: (id: string) => api.delete(`/connections/${id}`),
-    onSuccess: () => qc.invalidateQueries({ queryKey: connectionKeys.list() }),
+    onSuccess: async (_data, id) => {
+      qc.invalidateQueries({ queryKey: connectionKeys.list() });
+      const activeChatId = useChatStore.getState().activeChatId;
+      if (!activeChatId) return;
+      const activeChat = qc.getQueryData<Chat>(chatKeys.detail(activeChatId));
+      if (activeChat?.connectionId !== id) return;
+      try {
+        const updated = await api.patch<Chat>(`/chats/${activeChatId}`, { connectionId: null });
+        qc.setQueryData<Chat>(chatKeys.detail(activeChatId), updated);
+        qc.invalidateQueries({ queryKey: chatKeys.list() });
+      } catch {
+        qc.invalidateQueries({ queryKey: chatKeys.detail(activeChatId) });
+      }
+    },
   });
 }
 

--- a/packages/client/src/hooks/use-generate.ts
+++ b/packages/client/src/hooks/use-generate.ts
@@ -929,10 +929,6 @@ export function useGenerate() {
       }
       activeGenerateLocks.add(params.chatId);
 
-      // Abort any in-progress generation for the SAME chat before starting a new one.
-      const prev = useChatStore.getState().abortControllers.get(params.chatId);
-      if (prev) prev.abort();
-
       // Create an AbortController so the stop button can cancel this generation.
       const abortController = new AbortController();
       try {
@@ -2108,7 +2104,13 @@ export function useGenerate() {
               if (spriteChangeReceived) {
                 qc.invalidateQueries({ queryKey: chatKeys.messages(params.chatId) });
               }
-              if (isActiveChat()) setProcessing(false);
+              if (isActiveChat()) {
+                if (useChatStore.getState().streamingChatId === params.chatId) {
+                  setStreaming(false);
+                  clearStreamBuffer(params.chatId);
+                }
+                setProcessing(false);
+              }
               clearMariPhaseForThisChat();
               break;
             }
@@ -2292,7 +2294,31 @@ export function useGenerate() {
         // + user send). The latest generation replaces the AbortController,
         // so the superseded one knows it no longer owns the state.
         const stillOwner = useChatStore.getState().abortControllers.get(params.chatId) === abortController;
-        const persistedForRefresh = [...persistedMessages.values()];
+        const partialContent = normalizeLineBreakSpacing(fullBuffer + pendingText).trim();
+        const unpersistedPartialMessage: Message | null =
+          receivedContent && persistedMessages.size === 0 && partialContent && !params.regenerateMessageId
+            ? {
+                id: `__partial_${params.chatId}_${Date.now()}`,
+                chatId: params.chatId,
+                role: params.impersonate ? "user" : "assistant",
+                characterId: params.impersonate
+                  ? null
+                  : (params.forCharacterId ?? useChatStore.getState().streamingCharacterId ?? null),
+                content: partialContent,
+                activeSwipeIndex: 0,
+                extra: {
+                  displayText: null,
+                  isGenerated: !params.impersonate,
+                  tokenCount: null,
+                  generationInfo: null,
+                },
+                createdAt: new Date().toISOString(),
+              }
+            : null;
+        const persistedForRefresh = [
+          ...persistedMessages.values(),
+          ...(unpersistedPartialMessage ? [unpersistedPartialMessage] : []),
+        ];
         const primeMessagesFromSaved = () => {
           if (persistedForRefresh.length > 0) {
             upsertPersistedMessages(qc, params.chatId, persistedForRefresh);
@@ -2442,6 +2468,11 @@ export function useGenerate() {
     async (chatId: string, agentTypes: string[], options?: RetryAgentsOptions): Promise<boolean> => {
       const isActiveChat = () => useChatStore.getState().activeChatId === chatId;
       const abortController = new AbortController();
+      if (useChatStore.getState().abortControllers.has(chatId)) {
+        console.warn("[RetryAgents] Skipped — generation already in progress for this chat");
+        return false;
+      }
+      useChatStore.getState().setAbortController(chatId, abortController);
       const isTrackerRetry = agentTypes.some(
         (agentType) => BUILT_IN_TRACKER_AGENT_TYPE_SET.has(agentType) || !BUILT_IN_AGENT_TYPE_SET.has(agentType),
       );
@@ -2733,6 +2764,9 @@ export function useGenerate() {
         showError(msg);
       } finally {
         setProcessing(false);
+        if (useChatStore.getState().abortControllers.get(chatId) === abortController) {
+          useChatStore.getState().setAbortController(chatId, null);
+        }
         if (isTrackerRetry) useGameStateStore.getState().clearRefreshingChat(chatId);
         if (hasError && isActiveChat()) {
           void refreshMessagesAuthoritatively(qc, chatId);

--- a/packages/client/src/hooks/use-presets.ts
+++ b/packages/client/src/hooks/use-presets.ts
@@ -2,6 +2,7 @@
 // React Query: Preset, Group, Section & Choice hooks
 // ──────────────────────────────────────────────
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { toast } from "sonner";
 import { api } from "../lib/api-client";
 import type {
   PromptPreset,
@@ -26,6 +27,10 @@ export const presetKeys = {
   preview: (presetId: string) => [...presetKeys.all, "preview", presetId] as const,
   default: () => [...presetKeys.all, "default"] as const,
 };
+
+function mutationErrorMessage(error: unknown, fallback: string): string {
+  return error instanceof Error ? error.message : fallback;
+}
 
 // ═══════════════════════════════════════════════
 //  Presets
@@ -92,6 +97,9 @@ export function useUpdatePreset() {
       qc.invalidateQueries({ queryKey: presetKeys.list() });
       qc.invalidateQueries({ queryKey: presetKeys.detail(variables.id) });
       qc.invalidateQueries({ queryKey: presetKeys.full(variables.id) });
+    },
+    onError: (error) => {
+      toast.error(mutationErrorMessage(error, "Failed to update preset."));
     },
   });
 }
@@ -283,6 +291,9 @@ export function useCreateVariable() {
       qc.invalidateQueries({ queryKey: presetKeys.choiceBlocks(variables.presetId) });
       qc.invalidateQueries({ queryKey: presetKeys.full(variables.presetId) });
     },
+    onError: (error) => {
+      toast.error(mutationErrorMessage(error, "Failed to create preset variable."));
+    },
   });
 }
 
@@ -298,6 +309,9 @@ export function useUpdateVariable() {
     onSuccess: (_data, variables) => {
       qc.invalidateQueries({ queryKey: presetKeys.choiceBlocks(variables.presetId) });
       qc.invalidateQueries({ queryKey: presetKeys.full(variables.presetId) });
+    },
+    onError: (error) => {
+      toast.error(mutationErrorMessage(error, "Failed to update preset variable."));
     },
   });
 }

--- a/packages/client/src/lib/api-client.ts
+++ b/packages/client/src/lib/api-client.ts
@@ -39,6 +39,49 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return !!value && typeof value === "object" && !Array.isArray(value);
 }
 
+function getSseDataPayload(line: string): string | null {
+  const normalized = line.endsWith("\r") ? line.slice(0, -1) : line;
+  if (!normalized.startsWith("data:")) return null;
+  const data = normalized.slice(5);
+  return (data.startsWith(" ") ? data.slice(1) : data).trimEnd();
+}
+
+function readSseDataPayloads(buffer: string, final = false): { payloads: string[]; rest: string } {
+  const lines = buffer.split(/\r?\n/);
+  const rest = final ? "" : (lines.pop() ?? "");
+  const payloads = lines.map(getSseDataPayload).filter((payload): payload is string => payload !== null);
+  return { payloads, rest };
+}
+
+function parseSseJsonPayload(data: string): Record<string, unknown> | null {
+  try {
+    const parsed = JSON.parse(data);
+    return isRecord(parsed) ? parsed : null;
+  } catch (error) {
+    console.warn("[api] Skipping malformed SSE frame", { error, data: data.slice(0, 200) });
+    return null;
+  }
+}
+
+async function releaseSseReader(reader: ReadableStreamDefaultReader<Uint8Array>, completed: boolean) {
+  if (!completed) {
+    try {
+      await reader.cancel();
+    } catch {
+      /* stream may already be closed or aborted */
+    }
+  }
+  try {
+    reader.releaseLock();
+  } catch {
+    /* lock may already be released */
+  }
+}
+
+function getSseErrorMessage(parsed: Record<string, unknown>): string {
+  return typeof parsed.data === "string" ? parsed.data : "Generation error";
+}
+
 export function getJsonRepairRequest(error: unknown): JsonRepairRequest | null {
   if (!(error instanceof ApiError) || !isRecord(error.payload)) return null;
   const repair = error.payload.jsonRepair;
@@ -189,12 +232,13 @@ export const api = {
   /**
    * Stream an SSE endpoint. Returns an async iterable of parsed events.
    */
-  stream: async function* (path: string, body?: unknown): AsyncGenerator<string> {
+  stream: async function* (path: string, body?: unknown, signal?: AbortSignal): AsyncGenerator<string> {
     const res = await fetch(`${BASE}${path}`, {
       method: "POST",
       headers: { ...getAdminSecretHeader(), [CSRF_HEADER]: CSRF_HEADER_VALUE, "Content-Type": "application/json" },
       body: body !== undefined ? JSON.stringify(body) : undefined,
       cache: "no-store",
+      signal,
     });
 
     if (!res.ok || !res.body) {
@@ -212,30 +256,41 @@ export const api = {
     const reader = res.body.getReader();
     const decoder = new TextDecoder();
     let buffer = "";
+    let completed = false;
 
-    while (true) {
-      const { done, value } = await reader.read();
-      if (done) break;
+    try {
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) {
+          completed = true;
+          buffer += decoder.decode();
+          break;
+        }
 
-      buffer += decoder.decode(value, { stream: true });
-      const lines = buffer.split("\n");
-      buffer = lines.pop() ?? "";
+        buffer += decoder.decode(value, { stream: true });
+        const parsedBuffer = readSseDataPayloads(buffer);
+        buffer = parsedBuffer.rest;
 
-      for (const line of lines) {
-        if (line.startsWith("data: ")) {
-          const data = line.slice(6);
+        for (const data of parsedBuffer.payloads) {
           if (data === "[DONE]") return;
-          try {
-            const parsed = JSON.parse(data);
-            if (parsed.type === "token" && parsed.data) yield parsed.data;
-            else if (parsed.type === "error") throw new ApiError(500, parsed.data ?? "Generation error", parsed);
-            else if (parsed.type === "done") return;
-          } catch (e) {
-            // If not JSON, yield as raw text
-            if (!(e instanceof ApiError)) yield data;
-          }
+          const parsed = parseSseJsonPayload(data);
+          if (!parsed) continue;
+          if (parsed.type === "token" && typeof parsed.data === "string") yield parsed.data;
+          else if (parsed.type === "error") throw new ApiError(500, getSseErrorMessage(parsed), parsed);
+          else if (parsed.type === "done") return;
         }
       }
+
+      for (const data of readSseDataPayloads(buffer, true).payloads) {
+        if (data === "[DONE]") return;
+        const parsed = parseSseJsonPayload(data);
+        if (!parsed) continue;
+        if (parsed.type === "token" && typeof parsed.data === "string") yield parsed.data;
+        else if (parsed.type === "error") throw new ApiError(500, getSseErrorMessage(parsed), parsed);
+        else if (parsed.type === "done") return;
+      }
+    } finally {
+      await releaseSseReader(reader, completed);
     }
   },
 
@@ -271,29 +326,39 @@ export const api = {
     const reader = res.body.getReader();
     const decoder = new TextDecoder();
     let buffer = "";
+    let completed = false;
 
-    while (true) {
-      const { done, value } = await reader.read();
-      if (done) break;
+    try {
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) {
+          completed = true;
+          buffer += decoder.decode();
+          break;
+        }
 
-      buffer += decoder.decode(value, { stream: true });
-      const lines = buffer.split("\n");
-      buffer = lines.pop() ?? "";
+        buffer += decoder.decode(value, { stream: true });
+        const parsedBuffer = readSseDataPayloads(buffer);
+        buffer = parsedBuffer.rest;
 
-      for (const line of lines) {
-        if (line.startsWith("data: ")) {
-          const data = line.slice(6);
+        for (const data of parsedBuffer.payloads) {
           if (data === "[DONE]") return;
-          try {
-            const parsed = JSON.parse(data);
-            yield parsed;
-            if (parsed.type === "error") return; // error is a terminal event — stop iteration
-          } catch {
-            // JSON parse failed — yield raw data as a token
-            yield { type: "token", data };
-          }
+          const parsed = parseSseJsonPayload(data);
+          if (!parsed || typeof parsed.type !== "string") continue;
+          yield { type: parsed.type, data: parsed.data };
+          if (parsed.type === "error") return;
         }
       }
+
+      for (const data of readSseDataPayloads(buffer, true).payloads) {
+        if (data === "[DONE]") return;
+        const parsed = parseSseJsonPayload(data);
+        if (!parsed || typeof parsed.type !== "string") continue;
+        yield { type: parsed.type, data: parsed.data };
+        if (parsed.type === "error") return;
+      }
+    } finally {
+      await releaseSseReader(reader, completed);
     }
   },
 

--- a/packages/client/src/lib/connection-transfer.ts
+++ b/packages/client/src/lib/connection-transfer.ts
@@ -64,6 +64,7 @@ export type ConnectionImportPayload = {
 
 export const CONNECTION_EXPORT_WARNING =
   "This will export your connection data, WITHOUT your provided API Key. Remember to never share those with others!";
+const MAX_PARALLEL_JOBS = 16;
 
 export function createConnectionExportEnvelope(connections: ConnectionTransferRow[]) {
   return {
@@ -103,22 +104,22 @@ export function normalizeImportedConnectionEntry(value: unknown): ConnectionImpo
       baseUrl: asString(value.baseUrl),
       model: asString(value.model),
       maxContext: asPositiveInteger(value.maxContext, 128000),
-      isDefault: asBoolean(value.isDefault),
-      useForRandom: asBoolean(value.useForRandom),
-      defaultForAgents: asBoolean(value.defaultForAgents),
+      isDefault: false,
+      useForRandom: false,
+      defaultForAgents: false,
       enableCaching: asBoolean(value.enableCaching),
       cachingAtDepth: asNonNegativeInteger(value.cachingAtDepth, 5),
       embeddingModel: asString(value.embeddingModel),
       embeddingBaseUrl: asString(value.embeddingBaseUrl),
-      embeddingConnectionId: asNullableString(value.embeddingConnectionId),
+      embeddingConnectionId: null,
       openrouterProvider: asNullableString(value.openrouterProvider),
       imageGenerationSource: asNullableString(value.imageGenerationSource),
       comfyuiWorkflow: asNullableString(value.comfyuiWorkflow),
       imageService,
       imageEndpointId: asNullableString(value.imageEndpointId),
-      promptPresetId: asNullableString(value.promptPresetId),
+      promptPresetId: null,
       maxTokensOverride: asNullablePositiveInteger(value.maxTokensOverride),
-      maxParallelJobs: asPositiveInteger(value.maxParallelJobs, 1),
+      maxParallelJobs: asBoundedPositiveInteger(value.maxParallelJobs, 1, MAX_PARALLEL_JOBS),
       treatAsLocalEndpoint: asBoolean(value.treatAsLocalEndpoint),
       claudeFastMode: asBoolean(value.claudeFastMode),
     },
@@ -168,18 +169,17 @@ function parseDefaultParameters(value: unknown): Record<string, unknown> | null 
     }
   }
 
-  const scrubbed = scrubSecrets(value);
+  const scrubbed = scrubTopLevelSecrets(value);
   return isRecord(scrubbed) ? scrubbed : null;
 }
 
-function scrubSecrets(value: unknown): unknown {
-  if (Array.isArray(value)) return value.map(scrubSecrets);
+function scrubTopLevelSecrets(value: unknown): unknown {
   if (!isRecord(value)) return value;
 
   const next: Record<string, unknown> = {};
   for (const [key, entry] of Object.entries(value)) {
     if (isSecretFieldName(key)) continue;
-    next[key] = scrubSecrets(entry);
+    next[key] = entry;
   }
   return next;
 }
@@ -227,6 +227,10 @@ function asPositiveInteger(value: unknown, fallback: number) {
   const numberValue = typeof value === "number" ? value : typeof value === "string" ? Number(value) : NaN;
   if (!Number.isFinite(numberValue)) return fallback;
   return Math.max(1, Math.round(numberValue));
+}
+
+function asBoundedPositiveInteger(value: unknown, fallback: number, max: number) {
+  return Math.min(max, asPositiveInteger(value, fallback));
 }
 
 function asNonNegativeInteger(value: unknown, fallback: number) {

--- a/packages/client/src/lib/game-asset-urls.ts
+++ b/packages/client/src/lib/game-asset-urls.ts
@@ -14,8 +14,13 @@ export function encodeGameAssetPath(path: string): string {
 }
 
 export function gameAssetFileUrl(path: string | null | undefined): string | null {
-  if (!path?.trim()) return null;
-  return `${GAME_ASSET_FILE_URL_PREFIX}${encodeGameAssetPath(path)}`;
+  const cleanPath = path?.trim();
+  if (!cleanPath) return null;
+  if (cleanPath.startsWith("__user_bg__/")) {
+    const filename = cleanPath.replace("__user_bg__/", "");
+    return filename ? `/api/backgrounds/file/${encodeURIComponent(filename)}` : null;
+  }
+  return `${GAME_ASSET_FILE_URL_PREFIX}${encodeGameAssetPath(cleanPath)}`;
 }
 
 export async function resolveGameAssetFileUrl(path: string | null | undefined): Promise<string | null> {

--- a/packages/client/src/lib/game-audio.ts
+++ b/packages/client/src/lib/game-audio.ts
@@ -82,7 +82,9 @@ function setAmbientAudioSession(): void {
 class GameAudioManager {
   private musicElement: LoopingAudioLayer | null = null;
   private nextMusicElement: LoopingAudioLayer | null = null;
+  private fadingMusicElement: LoopingAudioLayer | null = null;
   private ambientElement: LoopingAudioLayer | null = null;
+  private nextAmbientElement: LoopingAudioLayer | null = null;
   private sfxPool: HTMLAudioElement[] = [];
   private sfxIndex = 0;
   private sfxAudioContext: AudioContext | null = null;
@@ -277,7 +279,7 @@ class GameAudioManager {
     if (existing) return existing.gain;
 
     const ctx = this.getSfxAudioContext();
-    if (!ctx) return null;
+    if (!ctx || ctx.state !== "running") return null;
 
     try {
       const source = ctx.createMediaElementSource(audio);
@@ -646,8 +648,10 @@ class GameAudioManager {
 
   /** Play background music with crossfade. */
   playMusic(tag: string, manifest?: Record<string, { path: string }> | null): void {
-    if (tag === this.currentMusicTag) return;
-    const previousMusicTag = this.currentMusicTag;
+    if (tag === this.currentMusicTag) {
+      if (this.pendingMusic?.tag === tag) this.pendingMusic = null;
+      return;
+    }
     this.currentMusicTag = tag;
 
     // Defer playback if the user hasn't interacted yet (avoids autoplay warnings)
@@ -662,6 +666,10 @@ class GameAudioManager {
     if (this.fadeInterval) {
       clearInterval(this.fadeInterval);
       this.fadeInterval = null;
+    }
+    if (this.fadingMusicElement) {
+      this.fadingMusicElement.stop();
+      this.fadingMusicElement = null;
     }
 
     const oldAudio = this.musicElement;
@@ -729,7 +737,7 @@ class GameAudioManager {
 
         // Autoplay blocked — queue for retry on user gesture
         this.pendingMusic = { tag, manifest };
-        this.currentMusicTag = previousMusicTag;
+        this.currentMusicTag = tag;
         if (oldAudio) {
           oldAudio.setMuted(this.isMuted);
           oldAudio.setVolume(this.musicVolume);
@@ -739,7 +747,7 @@ class GameAudioManager {
   }
 
   /** Stop music with fade out. */
-  stopMusic(): void {
+  stopMusic(immediate = false): void {
     this.currentMusicTag = null;
     this.pendingMusic = null;
 
@@ -747,6 +755,10 @@ class GameAudioManager {
     if (this.fadeInterval) {
       clearInterval(this.fadeInterval);
       this.fadeInterval = null;
+    }
+    if (this.fadingMusicElement) {
+      this.fadingMusicElement.stop();
+      this.fadingMusicElement = null;
     }
     if (this.nextMusicElement) {
       this.nextMusicElement.stop();
@@ -757,18 +769,26 @@ class GameAudioManager {
 
     const audio = this.musicElement;
     this.musicElement = null;
+    if (immediate) {
+      audio.stop();
+      return;
+    }
     const steps = CROSSFADE_MS / 50;
     const fadeStep = audio.getVolume() / steps;
     let step = 0;
+    this.fadingMusicElement = audio;
 
     const interval = setInterval(() => {
       step++;
       audio.setVolume(Math.max(0, audio.getVolume() - fadeStep));
       if (step >= steps) {
         clearInterval(interval);
+        if (this.fadeInterval === interval) this.fadeInterval = null;
+        if (this.fadingMusicElement === audio) this.fadingMusicElement = null;
         audio.stop();
       }
     }, 50);
+    this.fadeInterval = interval;
   }
 
   /** Play a one-shot sound effect. */
@@ -796,6 +816,10 @@ class GameAudioManager {
     const previousAmbientTag = this.currentAmbientTag;
     const previousAmbient = this.ambientElement;
     this.currentAmbientTag = tag;
+    if (this.nextAmbientElement) {
+      this.nextAmbientElement.stop();
+      this.nextAmbientElement = null;
+    }
 
     // Defer playback if the user hasn't interacted yet (avoids autoplay warnings)
     if (!this.userHasInteracted) {
@@ -805,9 +829,10 @@ class GameAudioManager {
 
     const url = this.resolveAssetUrl(tag, manifest);
     const nextAmbient = this.createLoopingAudioLayer(url, this.ambientVolume, this.isMuted);
+    this.nextAmbientElement = nextAmbient;
     nextAmbient.ready
       .then(() => {
-        if (this.currentAmbientTag !== tag) {
+        if (this.currentAmbientTag !== tag || this.nextAmbientElement !== nextAmbient) {
           nextAmbient.stop();
           return;
         }
@@ -816,15 +841,17 @@ class GameAudioManager {
           previousAmbient.stop();
         }
         this.ambientElement = nextAmbient;
+        this.nextAmbientElement = null;
         this.pendingAmbient = null;
       })
       .catch((err) => {
         nextAmbient.stop();
-        if (this.currentAmbientTag !== tag) {
+        if (this.currentAmbientTag !== tag || this.nextAmbientElement !== nextAmbient) {
           return;
         }
 
         console.warn("[audio] Ambient playback failed:", tag, err);
+        this.nextAmbientElement = null;
         this.pendingAmbient = { tag, manifest };
         this.currentAmbientTag = previousAmbientTag;
         this.ambientElement = previousAmbient ?? null;
@@ -840,6 +867,10 @@ class GameAudioManager {
   stopAmbient(): void {
     this.currentAmbientTag = null;
     this.pendingAmbient = null;
+    if (this.nextAmbientElement) {
+      this.nextAmbientElement.stop();
+      this.nextAmbientElement = null;
+    }
     if (this.ambientElement) {
       this.ambientElement.stop();
       this.ambientElement = null;
@@ -858,6 +889,9 @@ class GameAudioManager {
     if (this.ambientElement) {
       this.ambientElement.setMuted(muted);
     }
+    if (this.nextAmbientElement) {
+      this.nextAmbientElement.setMuted(muted);
+    }
     // Mute any currently-playing SFX
     for (const el of this.sfxPool) {
       this.setElementLayerVolume(el, muted ? 0 : this.sfxVolume);
@@ -871,9 +905,12 @@ class GameAudioManager {
     this.sfxVolume = Math.max(0, Math.min(1, sfx));
     this.ambientVolume = Math.max(0, Math.min(1, ambient));
     if (!this.isMuted) {
-      this.musicElement?.setVolume(this.musicVolume);
-      this.nextMusicElement?.setVolume(this.musicVolume);
+      if (!this.fadeInterval || !this.nextMusicElement) {
+        this.musicElement?.setVolume(this.musicVolume);
+        this.nextMusicElement?.setVolume(this.musicVolume);
+      }
       this.ambientElement?.setVolume(this.ambientVolume);
+      this.nextAmbientElement?.setVolume(this.ambientVolume);
     }
     for (const el of this.sfxPool) {
       this.setElementLayerVolume(el, this.sfxVolume);
@@ -894,7 +931,7 @@ class GameAudioManager {
 
   /** Stop everything and clean up. */
   dispose(): void {
-    this.stopMusic();
+    this.stopMusic(true);
     this.stopAmbient();
     for (const el of this.sfxPool) {
       releaseAudio(el);

--- a/packages/client/src/lib/notification-sound.ts
+++ b/packages/client/src/lib/notification-sound.ts
@@ -4,10 +4,15 @@
 
 let audioCtx: AudioContext | null = null;
 
-function getAudioContext(): AudioContext {
+function getAudioContext(): AudioContext | null {
+  if (typeof window === "undefined") return null;
   if (!audioCtx) {
-    audioCtx = new AudioContext();
+    const AudioContextCtor =
+      window.AudioContext ?? (window as Window & { webkitAudioContext?: typeof AudioContext }).webkitAudioContext;
+    if (!AudioContextCtor) return null;
+    audioCtx = new AudioContextCtor();
   }
+  if (audioCtx.state === "suspended") void audioCtx.resume().catch(() => {});
   return audioCtx;
 }
 
@@ -19,6 +24,7 @@ function getAudioContext(): AudioContext {
 export function playNotificationPing(): void {
   try {
     const ctx = getAudioContext();
+    if (!ctx) return;
     const now = ctx.currentTime;
 
     // Main tone — a bright sine at ~880 Hz (A5)

--- a/packages/client/src/lib/tts-audio-cache.ts
+++ b/packages/client/src/lib/tts-audio-cache.ts
@@ -3,9 +3,13 @@
 // ──────────────────────────────────────────────
 
 const DB_NAME = "marinara-tts-audio-cache";
-const DB_VERSION = 1;
+const DB_VERSION = 2;
 const STORE_NAME = "voiceLines";
+const META_STORE_NAME = "voiceLineMeta";
 const MAX_MEMORY_ENTRIES = 150;
+const MAX_PERSISTENT_ENTRIES = 750;
+const MAX_PERSISTENT_BYTES = 100 * 1024 * 1024;
+const PERSISTENT_PRUNE_THROTTLE_MS = 30_000;
 
 type CachedVoiceLine = {
   key: string;
@@ -15,9 +19,12 @@ type CachedVoiceLine = {
   size: number;
 };
 
+type CachedVoiceLineMeta = Omit<CachedVoiceLine, "blob">;
+
 const memoryCache = new Map<string, Blob>();
 const inFlight = new Map<string, Promise<Blob>>();
 let dbPromise: Promise<IDBDatabase | null> | null = null;
+let lastPersistentPruneAt = 0;
 
 function rememberInMemory(key: string, blob: Blob) {
   memoryCache.delete(key);
@@ -60,14 +67,85 @@ function openDb(): Promise<IDBDatabase | null> {
       if (store && !store.indexNames.contains("lastUsedAt")) {
         store.createIndex("lastUsedAt", "lastUsedAt", { unique: false });
       }
+      const metaStore = db.objectStoreNames.contains(META_STORE_NAME)
+        ? request.transaction?.objectStore(META_STORE_NAME)
+        : db.createObjectStore(META_STORE_NAME, { keyPath: "key" });
+      if (metaStore && !metaStore.indexNames.contains("lastUsedAt")) {
+        metaStore.createIndex("lastUsedAt", "lastUsedAt", { unique: false });
+      }
     };
 
-    request.onsuccess = () => resolve(request.result);
-    request.onerror = () => resolve(null);
-    request.onblocked = () => resolve(null);
+    request.onsuccess = () => {
+      const db = request.result;
+      db.onversionchange = () => db.close();
+      resolve(db);
+    };
+    request.onerror = () => {
+      dbPromise = null;
+      resolve(null);
+    };
+    request.onblocked = () => {
+      dbPromise = null;
+      resolve(null);
+    };
   });
 
   return dbPromise;
+}
+
+function hasMetadataStore(db: IDBDatabase): boolean {
+  return db.objectStoreNames.contains(META_STORE_NAME);
+}
+
+async function touchPersistentBlobMeta(db: IDBDatabase, record: CachedVoiceLine): Promise<void> {
+  if (!hasMetadataStore(db)) return;
+
+  const now = Date.now();
+  const tx = db.transaction(META_STORE_NAME, "readwrite");
+  tx.objectStore(META_STORE_NAME).put({
+    key: record.key,
+    createdAt: record.createdAt || now,
+    lastUsedAt: now,
+    size: record.size || record.blob.size,
+  } satisfies CachedVoiceLineMeta);
+  await transactionDone(tx);
+}
+
+async function prunePersistentCache(db: IDBDatabase): Promise<void> {
+  if (!hasMetadataStore(db)) return;
+
+  const now = Date.now();
+  if (now - lastPersistentPruneAt < PERSISTENT_PRUNE_THROTTLE_MS) return;
+  lastPersistentPruneAt = now;
+
+  const readTx = db.transaction(META_STORE_NAME, "readonly");
+  const metas = await requestToPromise<CachedVoiceLineMeta[]>(readTx.objectStore(META_STORE_NAME).getAll());
+  await transactionDone(readTx);
+
+  const totalBytes = metas.reduce((sum, meta) => sum + Math.max(0, meta.size || 0), 0);
+  const excessEntries = Math.max(0, metas.length - MAX_PERSISTENT_ENTRIES);
+  const excessBytes = Math.max(0, totalBytes - MAX_PERSISTENT_BYTES);
+  if (excessEntries === 0 && excessBytes === 0) return;
+
+  const byOldest = [...metas].sort((a, b) => (a.lastUsedAt || a.createdAt) - (b.lastUsedAt || b.createdAt));
+  const keysToDelete = new Set<string>();
+  let bytesFreed = 0;
+  for (const meta of byOldest) {
+    if (keysToDelete.size >= excessEntries && bytesFreed >= excessBytes) break;
+    keysToDelete.add(meta.key);
+    bytesFreed += Math.max(0, meta.size || 0);
+  }
+  if (keysToDelete.size === 0) return;
+
+  const deleteTx = db.transaction([STORE_NAME, META_STORE_NAME], "readwrite");
+  const blobStore = deleteTx.objectStore(STORE_NAME);
+  const metaStore = deleteTx.objectStore(META_STORE_NAME);
+  for (const key of keysToDelete) {
+    blobStore.delete(key);
+    metaStore.delete(key);
+    memoryCache.delete(key);
+  }
+  await transactionDone(deleteTx);
 }
 
 async function getPersistentBlob(key: string): Promise<Blob | null> {
@@ -81,15 +159,7 @@ async function getPersistentBlob(key: string): Promise<Blob | null> {
     if (!record?.blob) return null;
 
     void transactionDone(tx).catch(() => {});
-    void (async () => {
-      try {
-        const writeTx = db.transaction(STORE_NAME, "readwrite");
-        writeTx.objectStore(STORE_NAME).put({ ...record, lastUsedAt: Date.now() });
-        await transactionDone(writeTx);
-      } catch {
-        // Best-effort recency update only.
-      }
-    })();
+    void touchPersistentBlobMeta(db, record).catch(() => {});
 
     return record.blob;
   } catch {
@@ -103,15 +173,25 @@ async function putPersistentBlob(key: string, blob: Blob): Promise<void> {
 
   try {
     const now = Date.now();
-    const tx = db.transaction(STORE_NAME, "readwrite");
-    tx.objectStore(STORE_NAME).put({
+    const record = {
       key,
       blob,
       createdAt: now,
       lastUsedAt: now,
       size: blob.size,
-    } satisfies CachedVoiceLine);
+    } satisfies CachedVoiceLine;
+    const tx = db.transaction(hasMetadataStore(db) ? [STORE_NAME, META_STORE_NAME] : STORE_NAME, "readwrite");
+    tx.objectStore(STORE_NAME).put(record);
+    if (hasMetadataStore(db)) {
+      tx.objectStore(META_STORE_NAME).put({
+        key,
+        createdAt: now,
+        lastUsedAt: now,
+        size: blob.size,
+      } satisfies CachedVoiceLineMeta);
+    }
     await transactionDone(tx);
+    void prunePersistentCache(db).catch(() => {});
   } catch {
     // Memory cache still protects this runtime even if IndexedDB is unavailable.
   }
@@ -141,7 +221,6 @@ export async function getOrCreateCachedTTSAudioBlob(
     if (cached) {
       if (cacheKey !== key) {
         rememberInMemory(key, cached);
-        await putPersistentBlob(key, cached);
       }
       return cached;
     }
@@ -152,7 +231,6 @@ export async function getOrCreateCachedTTSAudioBlob(
     if (pending) {
       const blob = await pending;
       rememberInMemory(key, blob);
-      await putPersistentBlob(key, blob);
       return blob;
     }
   }
@@ -163,7 +241,6 @@ export async function getOrCreateCachedTTSAudioBlob(
       if (secondLook) {
         if (cacheKey !== key) {
           rememberInMemory(key, secondLook);
-          await putPersistentBlob(key, secondLook);
         }
         return secondLook;
       }

--- a/packages/client/src/lib/tts-dialogue.ts
+++ b/packages/client/src/lib/tts-dialogue.ts
@@ -74,11 +74,16 @@ function stableTTSIndex(seed: string, length: number): number {
 }
 
 function hashTTSCacheKey(value: string): string {
-  let hash = 5381;
+  let h1 = 0xdeadbeef ^ value.length;
+  let h2 = 0x41c6ce57 ^ value.length;
   for (let index = 0; index < value.length; index += 1) {
-    hash = (hash * 33) ^ value.charCodeAt(index);
+    const ch = value.charCodeAt(index);
+    h1 = Math.imul(h1 ^ ch, 2654435761);
+    h2 = Math.imul(h2 ^ ch, 1597334677);
   }
-  return (hash >>> 0).toString(36);
+  h1 = Math.imul(h1 ^ (h1 >>> 16), 2246822507) ^ Math.imul(h2 ^ (h2 >>> 13), 3266489909);
+  h2 = Math.imul(h2 ^ (h2 >>> 16), 2246822507) ^ Math.imul(h1 ^ (h1 >>> 13), 3266489909);
+  return `${value.length.toString(36)}-${(h2 >>> 0).toString(36)}${(h1 >>> 0).toString(36)}`;
 }
 
 function buildTTSConfigCacheSignature(config: TTSConfig): string {
@@ -235,6 +240,20 @@ export function resolveTTSNarratorVoice(
 
 export function cleanTTSInputText(value: string): string {
   return value
+    .replace(/```[\s\S]*?```/g, " ")
+    .replace(/~~~[\s\S]*?~~~/g, " ")
+    .replace(/`[^`\n]*`/g, " ")
+    .replace(/!\[([^\]]*)\]\([^)]+\)/g, "$1")
+    .replace(/\[([^\]]+)\]\([^)]+\)/g, "$1")
+    .replace(/^\s{0,3}#{1,6}\s+/gm, "")
+    .replace(/^\s{0,3}>\s?/gm, "")
+    .replace(/^\s*(?:[-*+]\s+|\d+[.)]\s+)/gm, "")
+    .replace(/~~([\s\S]*?)~~/g, "$1")
+    .replace(/\*\*([\s\S]*?)\*\*/g, "$1")
+    .replace(/__([\s\S]*?)__/g, "$1")
+    .replace(/\*([^*\n]+)\*/g, "$1")
+    .replace(/_([^_\n]+)_/g, "$1")
+    .replace(/[*~`]/g, "")
     .replace(/\{(shake|shout|whisper|glow|pulse|wave|flicker|drip|bounce|tremble|glitch|expand):([^}]+)\}/gi, "$2")
     .replace(/\[[a-z_]+:[^\]]*\]/gi, "")
     .replace(/<[^>]+>/g, "")
@@ -365,6 +384,18 @@ export function buildTTSVoiceRequests(
   });
 }
 
+function isLikelyTTSVNSpeaker(value: string): boolean {
+  const speaker = value.trim();
+  if (!speaker || speaker.length > 48) return false;
+  if (/^(?:ooc|note|notes?|meta|system|debug|info|warning|warn|time|timestamp|link|url|image|img)$/i.test(speaker)) {
+    return false;
+  }
+  if (/^\d{1,2}:\d{2}(?::\d{2})?(?:\s*[ap]m)?$/i.test(speaker)) return false;
+  if (/^(?:https?:\/\/|www\.)/i.test(speaker)) return false;
+  if (/^\d+$/.test(speaker)) return false;
+  return /^[\p{L}\p{N}][\p{L}\p{N}' ._-]{0,47}$/u.test(speaker);
+}
+
 export function extractDialogueUtterances(
   text: string,
   config: Pick<TTSConfig, "dialogueScope" | "dialogueCharacterName">,
@@ -379,7 +410,9 @@ export function extractDialogueUtterances(
     const match = line.match(vnLineRe);
     if (!match) continue;
 
-    const speaker = match[1]?.trim() || fallbackSpeaker || undefined;
+    const rawSpeaker = match[1]?.trim() ?? "";
+    if (!isLikelyTTSVNSpeaker(rawSpeaker)) continue;
+    const speaker = rawSpeaker || fallbackSpeaker || undefined;
     const firstTag = match[2]?.trim();
     const secondTag = match[3]?.trim();
     const tone =
@@ -389,10 +422,6 @@ export function extractDialogueUtterances(
     if (spoken && ttsConfigMatchesSpeaker(config, speaker)) {
       utterances.push({ text: spoken, speaker, tone });
     }
-  }
-
-  if (utterances.length > 0) {
-    return dedupeUtterances(utterances);
   }
 
   const quoteRe = new RegExp(DIALOGUE_QUOTE_CAPTURE_GROUP_PATTERN_SOURCE, "g");

--- a/packages/client/src/lib/tts-service.ts
+++ b/packages/client/src/lib/tts-service.ts
@@ -26,6 +26,29 @@ export interface TTSSpeakRequest {
   cacheAliases?: string[];
 }
 
+function waitForBlobWithAbort(promise: Promise<Blob>, signal?: AbortSignal): Promise<Blob> {
+  if (!signal) return promise;
+  if (signal.aborted) return Promise.reject(new DOMException("TTS request aborted", "AbortError"));
+
+  return new Promise((resolve, reject) => {
+    const onAbort = () => {
+      signal.removeEventListener("abort", onAbort);
+      reject(new DOMException("TTS request aborted", "AbortError"));
+    };
+    signal.addEventListener("abort", onAbort, { once: true });
+    promise.then(
+      (blob) => {
+        signal.removeEventListener("abort", onAbort);
+        resolve(blob);
+      },
+      (error) => {
+        signal.removeEventListener("abort", onAbort);
+        reject(error);
+      },
+    );
+  });
+}
+
 class TTSService {
   private audio: HTMLAudioElement | null = null;
   private currentObjectUrl: string | null = null;
@@ -106,11 +129,12 @@ class TTSService {
 
   private async getAudioBlob(text: string, options: TTSSpeakOptions = {}): Promise<Blob> {
     if (!options.cacheKey) return this.generateAudio(text, options);
-    return getOrCreateCachedTTSAudioBlob(
+    const sharedPromise = getOrCreateCachedTTSAudioBlob(
       options.cacheKey,
-      () => this.generateAudio(text, options),
+      () => this.generateAudio(text, { ...options, signal: undefined }),
       options.cacheAliases,
     );
+    return waitForBlobWithAbort(sharedPromise, options.signal);
   }
 
   /** Speak the given text. `id` is an optional caller-supplied key (e.g. message id) so callers can track which item is active. */

--- a/packages/client/src/stores/chat.store.ts
+++ b/packages/client/src/stores/chat.store.ts
@@ -51,6 +51,15 @@ function saveDrafts(m: Map<string, string>) {
   }
 }
 
+function abortGenerationForChat(chatId: string, controller?: AbortController) {
+  controller?.abort();
+  fetch("/api/generate/abort", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ chatId }),
+  }).catch(() => {});
+}
+
 interface ChatState {
   activeChatId: string | null;
   activeChat: Chat | null;
@@ -137,7 +146,7 @@ interface ChatState {
   setStreamCommitted: (chatId: string, committed: boolean) => void;
   setMariPhase: (chatId: string, phase: "thinking" | "updating" | "idle") => void;
   setAbortController: (chatId: string, controller: AbortController | null) => void;
-  stopGeneration: () => void;
+  stopGeneration: (chatId?: string) => void;
   appendStreamBuffer: (text: string, chatId?: string) => void;
   setStreamBuffer: (text: string, chatId?: string) => void;
   clearStreamBuffer: (chatId?: string) => void;
@@ -343,18 +352,17 @@ export const useChatStore = create<ChatState>()(
         else m.delete(chatId);
         return { abortControllers: m };
       }),
-    stopGeneration: () => {
-      const { streamingChatId, abortControllers } = useChatStore.getState();
-      if (streamingChatId) {
-        const ctrl = abortControllers.get(streamingChatId);
-        if (ctrl) ctrl.abort();
-        // Explicitly tell the server to abort — the SSE close event may not
-        // fire reliably, so this ensures the backend (e.g. KoboldCPP) stops.
-        fetch("/api/generate/abort", {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ chatId: streamingChatId }),
-        }).catch(() => {});
+    stopGeneration: (chatId) => {
+      const { activeChatId, streamingChatId, abortControllers } = useChatStore.getState();
+      const targetIds = chatId
+        ? [chatId]
+        : activeChatId && abortControllers.has(activeChatId)
+          ? [activeChatId]
+          : streamingChatId
+            ? [streamingChatId]
+            : [...abortControllers.keys()];
+      for (const targetChatId of new Set(targetIds)) {
+        abortGenerationForChat(targetChatId, abortControllers.get(targetChatId));
       }
     },
     appendStreamBuffer: (text, chatId) =>
@@ -637,6 +645,10 @@ export const useChatStore = create<ChatState>()(
       }),
 
     reset: () => {
+      const { abortControllers } = useChatStore.getState();
+      for (const [chatId, controller] of abortControllers) {
+        abortGenerationForChat(chatId, controller);
+      }
       set({
         activeChatId: null,
         activeChat: null,

--- a/packages/client/src/stores/sidecar.store.ts
+++ b/packages/client/src/stores/sidecar.store.ts
@@ -168,67 +168,78 @@ async function consumeDownloadStream(
     const decoder = new TextDecoder();
     let buffer = "";
 
+    type DownloadSseData = Partial<SidecarDownloadProgress> & {
+      done?: boolean;
+      status?: string;
+      error?: string;
+    };
+    const readSseData = (line: string): string | null => {
+      const trimmed = line.trim();
+      if (!trimmed.startsWith("data:")) return null;
+      return trimmed.slice(5).trimStart();
+    };
+    const handleSseData = async (data: DownloadSseData): Promise<boolean> => {
+      if (data.done) {
+        set({ downloadProgress: null });
+        await get().fetchStatus();
+        return true;
+      }
+
+      if (data.status === "error") {
+        if (downloadCancelRequested || controller.signal.aborted) {
+          set({ downloadProgress: null });
+          await get().fetchStatus();
+          return true;
+        }
+        set({
+          downloadProgress: {
+            phase: (data.phase as SidecarDownloadProgress["phase"]) ?? "model",
+            status: "error",
+            downloaded: 0,
+            total: 0,
+            speed: 0,
+            error: data.error ?? "Download failed",
+            label: data.label,
+          },
+        });
+        await get().fetchStatus();
+        return true;
+      }
+
+      if (data.status === "downloading") {
+        set({
+          downloadProgress: {
+            phase: (data.phase as SidecarDownloadProgress["phase"]) ?? "model",
+            status: "downloading",
+            downloaded: Number(data.downloaded ?? 0),
+            total: Number(data.total ?? 0),
+            speed: Number(data.speed ?? 0),
+            label: data.label,
+          },
+          status: (data.phase === "runtime" ? "downloading_runtime" : "downloading_model") as SidecarStatus,
+        });
+      }
+
+      return false;
+    };
+
     while (true) {
       const { done, value } = await reader.read();
-      if (done) break;
 
-      buffer += decoder.decode(value, { stream: true });
-      const lines = buffer.split("\n");
-      buffer = lines.pop() ?? "";
+      buffer += done ? decoder.decode() : decoder.decode(value, { stream: true });
+      const lines = buffer.split(/\r?\n/);
+      buffer = done ? "" : (lines.pop() ?? "");
 
       for (const line of lines) {
-        if (!line.startsWith("data: ")) continue;
+        const payload = readSseData(line);
+        if (payload == null) continue;
         try {
-          const data = JSON.parse(line.slice(6)) as Partial<SidecarDownloadProgress> & {
-            done?: boolean;
-            status?: string;
-            error?: string;
-          };
-
-          if (data.done) {
-            set({ downloadProgress: null });
-            await get().fetchStatus();
-            return;
-          }
-
-          if (data.status === "error") {
-            if (downloadCancelRequested || controller.signal.aborted) {
-              set({ downloadProgress: null });
-              await get().fetchStatus();
-              return;
-            }
-            set({
-              downloadProgress: {
-                phase: (data.phase as SidecarDownloadProgress["phase"]) ?? "model",
-                status: "error",
-                downloaded: 0,
-                total: 0,
-                speed: 0,
-                error: data.error ?? "Download failed",
-                label: data.label,
-              },
-            });
-            await get().fetchStatus();
-            return;
-          }
-
-          if (data.status === "downloading") {
-            set({
-              downloadProgress: {
-                phase: (data.phase as SidecarDownloadProgress["phase"]) ?? "model",
-                status: "downloading",
-                downloaded: Number(data.downloaded ?? 0),
-                total: Number(data.total ?? 0),
-                speed: Number(data.speed ?? 0),
-                label: data.label,
-              },
-              status: (data.phase === "runtime" ? "downloading_runtime" : "downloading_model") as SidecarStatus,
-            });
-          }
+          if (await handleSseData(JSON.parse(payload) as DownloadSseData)) return;
         } catch {
           // Ignore malformed SSE chunks.
         }
       }
+      if (done) break;
     }
 
     set({ downloadProgress: null });

--- a/packages/server/src/routes/chats.routes.ts
+++ b/packages/server/src/routes/chats.routes.ts
@@ -440,26 +440,6 @@ export async function chatsRoutes(app: FastifyInstance) {
     );
     if (!chat) return chat;
 
-    // Pre-populate chat parameters from connection defaults if available
-    if (input.connectionId && input.connectionId !== "random") {
-      const connStorage = createConnectionsStorage(app.db);
-      const conn = await connStorage.getById(input.connectionId);
-      if (conn?.defaultParameters) {
-        let connDefaults: unknown = null;
-        try {
-          connDefaults =
-            typeof conn.defaultParameters === "string" ? JSON.parse(conn.defaultParameters) : conn.defaultParameters;
-        } catch {
-          /* malformed JSON — skip defaults */
-        }
-        if (connDefaults && typeof connDefaults === "object") {
-          const existingMeta = typeof chat.metadata === "string" ? JSON.parse(chat.metadata) : (chat.metadata ?? {});
-          await storage.updateMetadata(chat.id, { ...existingMeta, chatParameters: connDefaults });
-          return storage.getById(chat.id);
-        }
-      }
-    }
-
     return chat;
   });
 

--- a/packages/server/src/routes/chats.routes.ts
+++ b/packages/server/src/routes/chats.routes.ts
@@ -60,6 +60,7 @@ import {
   findTrackerContextInsertIndex,
   isManualTrackerCharacterId,
   parseExtra,
+  resolveRoleplayChatSummary,
   isMessageHiddenFromAI,
   resolveActiveCharacterIds,
   resolveVisibleGameStateAnchor,
@@ -1695,10 +1696,7 @@ export async function chatsRoutes(app: FastifyInstance) {
             ? (chatMeta.activeAgentIds as string[])
             : [];
           const activePromptAgentIds = filterGameInternalAgentIds(chatMode, promptActiveAgentIds);
-          const activeChatSummary =
-            chatMode === "roleplay" || chatMode === "visual_novel"
-              ? ((chatMeta.summary as string) ?? "").trim() || null
-              : null;
+          const activeChatSummary = resolveRoleplayChatSummary(chatMode, chatMeta);
 
           const assembled = await assemblePrompt({
             db: app.db,

--- a/packages/server/src/routes/connections.routes.ts
+++ b/packages/server/src/routes/connections.routes.ts
@@ -6,6 +6,7 @@ import { existsSync } from "fs";
 import { mkdir, readFile, writeFile } from "fs/promises";
 import { extname, join } from "path";
 import {
+  IMAGE_DEFAULTS_STORAGE_KEY,
   MODEL_LISTS,
   createConnectionSchema,
   generationParametersSchema,
@@ -302,7 +303,11 @@ export async function connectionsRoutes(app: FastifyInstance) {
           })),
         });
       }
-      params = parsed.data;
+      params = { ...parsed.data };
+      const rawRecord = raw as Record<string, unknown>;
+      if (Object.prototype.hasOwnProperty.call(rawRecord, IMAGE_DEFAULTS_STORAGE_KEY)) {
+        params[IMAGE_DEFAULTS_STORAGE_KEY] = rawRecord[IMAGE_DEFAULTS_STORAGE_KEY];
+      }
     }
     await storage.updateDefaultParameters(req.params.id, params);
     return { success: true };

--- a/packages/server/src/routes/game-assets.routes.ts
+++ b/packages/server/src/routes/game-assets.routes.ts
@@ -15,6 +15,8 @@ import {
   renameSync,
   copyFileSync,
   readFileSync,
+  rmSync,
+  unlinkSync,
 } from "fs";
 import { join, extname, basename, dirname } from "path";
 import { execFile } from "child_process";
@@ -49,7 +51,7 @@ function loadMeta(): Record<string, FolderMeta> {
  * @param meta - Map of folder paths to metadata
  */
 function saveMeta(meta: Record<string, FolderMeta>) {
-  writeFileSync(META_PATH, JSON.stringify(meta, null, 2), "utf-8");
+  atomicWriteText(META_PATH, JSON.stringify(meta, null, 2));
 }
 
 // sharp can fail to load on Android/Termux because it has no native Android
@@ -130,6 +132,33 @@ const MUSIC_INTENSITY_SET = new Set<string>(MUSIC_INTENSITIES);
  */
 function isSafePath(segment: string): boolean {
   return !segment.includes("..") && !segment.includes("\\") && !/^\//.test(segment);
+}
+
+function cleanupFile(filePath: string): void {
+  try {
+    if (existsSync(filePath)) unlinkSync(filePath);
+  } catch {
+    /* best-effort cleanup */
+  }
+}
+
+function tempWritePath(filePath: string): string {
+  return join(dirname(filePath), `.${basename(filePath)}.${process.pid}.${Date.now()}.${Math.random().toString(36).slice(2)}.tmp`);
+}
+
+function atomicWriteBuffer(filePath: string, buffer: Buffer): void {
+  const tmpPath = tempWritePath(filePath);
+  try {
+    writeFileSync(tmpPath, buffer);
+    renameSync(tmpPath, filePath);
+  } catch (err) {
+    cleanupFile(tmpPath);
+    throw err;
+  }
+}
+
+function atomicWriteText(filePath: string, value: string): void {
+  atomicWriteBuffer(filePath, Buffer.from(value, "utf-8"));
 }
 
 const uploadSchema = z.object({
@@ -290,7 +319,26 @@ async function normalizeGeneratedBackgroundBuffer(buffer: Buffer, ext: string) {
 async function normalizeGeneratedBackgroundFile(category: string, subcategory: string, filePath: string, ext: string) {
   if (!shouldNormalizeGeneratedBackground(category, subcategory, ext)) return;
   const normalized = await normalizeGeneratedBackgroundBuffer(readFileSync(filePath), ext);
-  writeFileSync(filePath, normalized);
+  atomicWriteBuffer(filePath, normalized);
+}
+
+function containsNativeMarker(dir: string): boolean {
+  if (existsSync(join(dir, ".native"))) return true;
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    if (!entry.isDirectory()) continue;
+    if (containsNativeMarker(join(dir, entry.name))) return true;
+  }
+  return false;
+}
+
+function isInsideNativeFolder(filePath: string): boolean {
+  let current = statSync(filePath).isDirectory() ? filePath : dirname(filePath);
+  while (current !== dirname(current)) {
+    if (existsSync(join(current, ".native"))) return true;
+    if (current === GAME_ASSETS_DIR) return false;
+    current = dirname(current);
+  }
+  return false;
 }
 
 // ════════════════════════════════════════════════
@@ -427,7 +475,7 @@ export async function gameAssetsRoutes(app: FastifyInstance) {
   app.post("/upload", async (req, reply) => {
     const contentType = req.headers["content-type"] ?? "";
     if (contentType.includes("multipart/form-data")) {
-      const file = await req.file();
+      const file = await req.file({ limits: { fileSize: MAX_UPLOAD_BYTES + 1 } });
       if (!file) {
         return reply.status(400).send({ error: "No file uploaded" });
       }
@@ -445,32 +493,52 @@ export async function gameAssetsRoutes(app: FastifyInstance) {
         return reply.status(400).send({ error: error instanceof Error ? error.message : "Invalid upload" });
       }
 
-      await pipeline(file.file, createWriteStream(target.targetPath));
+      const tempPath = tempWritePath(target.targetPath);
+      try {
+        await pipeline(file.file, createWriteStream(tempPath));
+      } catch (error) {
+        cleanupFile(tempPath);
+        const truncated = (file.file as typeof file.file & { truncated?: boolean }).truncated === true;
+        return reply.status(truncated ? 400 : 500).send({
+          error: truncated
+            ? `File too large: ${file.filename} exceeds the 50MB upload limit.`
+            : "Failed to upload file",
+          ...(truncated ? {} : { detail: String(error) }),
+        });
+      }
 
-      const writtenSize = statSync(target.targetPath).size;
+      const writtenSize = statSync(tempPath).size;
       const ext = extname(file.filename).toLowerCase();
       const isTextFile = TEXT_EXTS.has(ext);
       const maxBytes = isTextFile ? MAX_TEXT_BYTES : MAX_UPLOAD_BYTES;
       const maxLabel = isTextFile ? "10MB" : "50MB";
 
-      if (writtenSize > maxBytes) {
-        const { unlinkSync } = await import("fs");
-        unlinkSync(target.targetPath);
+      if (writtenSize > maxBytes || (file.file as typeof file.file & { truncated?: boolean }).truncated === true) {
+        cleanupFile(tempPath);
         return reply.status(400).send({
           error: `File too large: ${file.filename} is ${(writtenSize / 1024 / 1024).toFixed(1)} MB. Max size: ${maxLabel}.`,
         });
       }
 
-      await normalizeGeneratedBackgroundFile(category, subcategory, target.targetPath, extname(target.safeName).toLowerCase());
-      const processedSize = statSync(target.targetPath).size;
-      if (processedSize > maxBytes) {
-        const { unlinkSync } = await import("fs");
-        unlinkSync(target.targetPath);
-        return reply.status(400).send({
-          error: `File too large after processing: ${file.filename} is ${(processedSize / 1024 / 1024).toFixed(1)} MB. Max size: ${maxLabel}.`,
-        });
-      }
+      try {
+        await normalizeGeneratedBackgroundFile(category, subcategory, tempPath, extname(target.safeName).toLowerCase());
+        const processedSize = statSync(tempPath).size;
+        if (processedSize > maxBytes) {
+          cleanupFile(tempPath);
+          return reply.status(400).send({
+            error: `File too large after processing: ${file.filename} is ${(processedSize / 1024 / 1024).toFixed(1)} MB. Max size: ${maxLabel}.`,
+          });
+        }
 
+        if (existsSync(target.targetPath)) {
+          cleanupFile(tempPath);
+          return reply.status(409).send({ error: "A file with that name already exists" });
+        }
+        renameSync(tempPath, target.targetPath);
+      } catch (error) {
+        cleanupFile(tempPath);
+        return reply.status(500).send({ error: "Failed to process uploaded file", detail: String(error) });
+      }
       return finishAssetUpload(category, subcategory, target.safeName);
     }
 
@@ -512,7 +580,7 @@ export async function gameAssetsRoutes(app: FastifyInstance) {
       });
     }
 
-    writeFileSync(target.targetPath, buffer);
+    atomicWriteBuffer(target.targetPath, buffer);
 
     return finishAssetUpload(category, subcategory, target.safeName);
   });
@@ -529,7 +597,6 @@ export async function gameAssetsRoutes(app: FastifyInstance) {
       return reply.status(404).send({ error: "Asset not found" });
     }
 
-    const { unlinkSync } = await import("fs");
     unlinkSync(filePath);
 
     // Rebuild manifest after deletion
@@ -637,9 +704,6 @@ export async function gameAssetsRoutes(app: FastifyInstance) {
 
     const target = join(GAME_ASSETS_DIR, wildcard);
 
-    if (existsSync(join(target, ".native"))) {
-      return reply.status(403).send({ error: "Cannot delete native folders" });
-    }
     try {
       assertInsideDir(GAME_ASSETS_DIR, target);
     } catch {
@@ -655,6 +719,10 @@ export async function gameAssetsRoutes(app: FastifyInstance) {
       return reply.status(400).send({ error: "Not a directory" });
     }
 
+    if (containsNativeMarker(target)) {
+      return reply.status(403).send({ error: "Cannot delete folders containing native assets" });
+    }
+
     const entries = readdirSync(target);
     const visibleEntries = entries.filter((e) => !e.startsWith("."));
     const recursive = (req.query as { recursive?: string }).recursive === "true";
@@ -665,7 +733,6 @@ export async function gameAssetsRoutes(app: FastifyInstance) {
 
     try {
       if (recursive && visibleEntries.length > 0) {
-        const { rmSync } = await import("fs");
         rmSync(target, { recursive: true, force: true });
       } else {
         rmdirSync(target);
@@ -741,6 +808,14 @@ export async function gameAssetsRoutes(app: FastifyInstance) {
 
     if (!existsSync(oldFull)) {
       return reply.status(404).send({ error: "File not found" });
+    }
+
+    const oldStat = statSync(oldFull);
+    if (!oldStat.isFile()) {
+      return reply.status(400).send({ error: "Not a file" });
+    }
+    if (isInsideNativeFolder(oldFull)) {
+      return reply.status(403).send({ error: "Cannot move native assets" });
     }
 
     const destDir = join(GAME_ASSETS_DIR, targetFolder);
@@ -917,7 +992,6 @@ export async function gameAssetsRoutes(app: FastifyInstance) {
 
     const succeeded: string[] = [];
     const failed: { path: string; error: string }[] = [];
-    const { unlinkSync } = await import("fs");
 
     for (const filePath of paths) {
       if (!isSafePath(filePath)) {

--- a/packages/server/src/routes/game.routes.ts
+++ b/packages/server/src/routes/game.routes.ts
@@ -1718,6 +1718,7 @@ const CAMPAIGN_PROGRESSION_MIN_OUTPUT_TOKENS = SESSION_CONCLUSION_MIN_OUTPUT_TOK
 const GAME_GENERATION_TIMEOUT_MS = 4 * 60 * 1000;
 const GAME_ASSET_GENERATION_TIMEOUT_MS = 220 * 1000;
 const GAME_ASSET_PORTRAIT_CONCURRENCY = 2;
+const gameAssetGenerationLocks = new Map<string, Promise<void>>();
 
 class GameGenerationTimeoutError extends Error {
   constructor(label: string, timeoutMs: number) {
@@ -1827,6 +1828,57 @@ function createResponseAbortSignal(reply: FastifyReply, timeoutMs: number, label
   reply.raw.once("finish", onFinish);
   reply.raw.once("close", onClose);
   return controller.signal;
+}
+
+function abortReasonAsError(signal: AbortSignal, fallback: string): Error {
+  return signal.reason instanceof Error ? signal.reason : new Error(fallback);
+}
+
+function waitForPreviousGameAssetGeneration(chatId: string, previous: Promise<void>, signal: AbortSignal): Promise<void> {
+  if (signal.aborted) return Promise.reject(abortReasonAsError(signal, "Game asset generation cancelled"));
+
+  return new Promise((resolve, reject) => {
+    const cleanup = () => {
+      signal.removeEventListener("abort", onAbort);
+    };
+    const onAbort = () => {
+      cleanup();
+      reject(abortReasonAsError(signal, "Game asset generation cancelled"));
+    };
+
+    signal.addEventListener("abort", onAbort, { once: true });
+    previous
+      .catch(() => undefined)
+      .then(() => {
+        cleanup();
+        resolve();
+      });
+
+    logger.info("[game/generate-assets] waiting for in-flight asset generation for chat %s", chatId);
+  });
+}
+
+async function acquireGameAssetGenerationLock(chatId: string, signal: AbortSignal): Promise<() => void> {
+  const previous = gameAssetGenerationLocks.get(chatId);
+  if (previous) {
+    await waitForPreviousGameAssetGeneration(chatId, previous, signal);
+  }
+
+  let releasePromise: () => void = () => undefined;
+  const current = new Promise<void>((resolve) => {
+    releasePromise = resolve;
+  });
+  gameAssetGenerationLocks.set(chatId, current);
+
+  let released = false;
+  return () => {
+    if (released) return;
+    released = true;
+    releasePromise();
+    if (gameAssetGenerationLocks.get(chatId) === current) {
+      gameAssetGenerationLocks.delete(chatId);
+    }
+  };
 }
 const GAME_LOREBOOK_KEEPER_MIN_OUTPUT_TOKENS = 16_384;
 const GAME_LOREBOOK_KEEPER_MAX_ENTRIES = 32;
@@ -2426,6 +2478,7 @@ async function runGameLorebookKeeperAfterConclusion(args: {
   sessionSummary: SessionSummary;
   replaceExistingSessionEntries?: boolean;
   streaming?: boolean;
+  signal?: AbortSignal;
 }): Promise<GameLorebookKeeperRunResult> {
   const chats = createChatsStorage(args.app.db);
   const chat = await chats.getById(args.chatId);
@@ -2482,6 +2535,7 @@ async function runGameLorebookKeeperAfterConclusion(args: {
         maxTokens: Math.max(GAME_LOREBOOK_KEEPER_MIN_OUTPUT_TOKENS, generationParameters?.maxTokens ?? 0),
         temperature: 0.35,
         stream: streaming,
+        signal: args.signal,
         ...(streaming ? { onToken: () => {} } : {}),
       },
       generationParameters,
@@ -3860,11 +3914,13 @@ export async function gameRoutes(app: FastifyInstance) {
       maxTokens: Math.max(GAME_SETUP_MIN_OUTPUT_TOKENS, setupGenerationParameters?.maxTokens ?? 0),
       maxTokensOverride: conn.maxTokensOverride,
     });
+    const setupAbortSignal = createResponseAbortSignal(reply, GAME_GENERATION_TIMEOUT_MS, "Game setup");
     const setupOptions = gameGenOptions(
       conn.model,
       {
         maxTokens: setupMaxTokens,
         stream: false,
+        signal: setupAbortSignal,
       },
       setupGenerationParameters,
       conn.provider,
@@ -4124,7 +4180,7 @@ export async function gameRoutes(app: FastifyInstance) {
   };
 
   // ── POST /game/session/start ──
-  app.post("/session/start", async (req) => {
+  app.post("/session/start", async (req, reply) => {
     const { gameId, connectionId } = startSessionSchema.parse(req.body);
     const existingStart = pendingSessionStarts.get(gameId);
     if (existingStart) {
@@ -4300,6 +4356,7 @@ export async function gameRoutes(app: FastifyInstance) {
               conn.model,
               {
                 temperature: 0.7,
+                signal: createResponseAbortSignal(reply, GAME_GENERATION_TIMEOUT_MS, "Game session recap"),
               },
               null,
               conn.provider,
@@ -4470,12 +4527,14 @@ export async function gameRoutes(app: FastifyInstance) {
       conn.maxTokensOverride,
     );
 
+    const conclusionAbortSignal = createResponseAbortSignal(reply, GAME_GENERATION_TIMEOUT_MS, "Game session conclusion");
     const conclusionOptions = gameGenOptions(
       conn.model,
       {
         maxTokens: Math.max(SESSION_CONCLUSION_MIN_OUTPUT_TOKENS, conclusionGenerationParameters?.maxTokens ?? 0),
         temperature: 0.45,
         stream: streaming,
+        signal: conclusionAbortSignal,
         ...(streaming ? { onToken: () => {} } : {}),
       },
       conclusionGenerationParameters,
@@ -4853,6 +4912,7 @@ export async function gameRoutes(app: FastifyInstance) {
       sessionSummary: summary,
       replaceExistingSessionEntries: true,
       streaming,
+      signal: createResponseAbortSignal(reply, GAME_GENERATION_TIMEOUT_MS, "Game lorebook keeper regeneration"),
     });
 
     if (result.status === "failed") {
@@ -5008,12 +5068,18 @@ export async function gameRoutes(app: FastifyInstance) {
       conn.openrouterProvider,
       conn.maxTokensOverride,
     );
+    const conclusionAbortSignal = createResponseAbortSignal(
+      reply,
+      GAME_GENERATION_TIMEOUT_MS,
+      "Game session conclusion regeneration",
+    );
     const conclusionOptions = gameGenOptions(
       conn.model,
       {
         maxTokens: Math.max(SESSION_CONCLUSION_MIN_OUTPUT_TOKENS, conclusionGenerationParameters?.maxTokens ?? 0),
         temperature: 0.45,
         stream: streaming,
+        signal: conclusionAbortSignal,
         ...(streaming ? { onToken: () => {} } : {}),
       },
       conclusionGenerationParameters,
@@ -5260,12 +5326,18 @@ export async function gameRoutes(app: FastifyInstance) {
       conn.openrouterProvider,
       conn.maxTokensOverride,
     );
+    const progressionAbortSignal = createResponseAbortSignal(
+      reply,
+      GAME_GENERATION_TIMEOUT_MS,
+      "Game campaign progression update",
+    );
     const progressionOptions = gameGenOptions(
       conn.model,
       {
         maxTokens: Math.max(CAMPAIGN_PROGRESSION_MIN_OUTPUT_TOKENS, progressionGenerationParameters?.maxTokens ?? 0),
         temperature: 0.35,
         stream: streaming,
+        signal: progressionAbortSignal,
         ...(streaming ? { onToken: () => {} } : {}),
       },
       progressionGenerationParameters,
@@ -5473,7 +5545,7 @@ export async function gameRoutes(app: FastifyInstance) {
 
   // ── POST /game/party/recruit ──
   // Adds a library character or tracked NPC to the active game party.
-  app.post("/party/recruit", async (req) => {
+  app.post("/party/recruit", async (req, reply) => {
     const input = recruitPartyMemberSchema.parse(req.body);
     const chats = createChatsStorage(app.db);
     const chars = createCharactersStorage(app.db);
@@ -5636,13 +5708,19 @@ export async function gameRoutes(app: FastifyInstance) {
           language: setupConfig.language ?? null,
         });
 
+        const recruitAbortSignal = createResponseAbortSignal(reply, GAME_GENERATION_TIMEOUT_MS, "Game party recruit card");
         const result = await runGameChatComplete(
           provider,
           [
             { role: "system", content: prompt },
             { role: "user", content: `Create the recruited companion card for ${recruitName} now.` },
           ],
-          gameGenOptions(conn.model, { temperature: 0.6, maxTokens: 1200 }, generationParameters, conn.provider),
+          gameGenOptions(
+            conn.model,
+            { temperature: 0.6, maxTokens: 1200, signal: recruitAbortSignal },
+            generationParameters,
+            conn.provider,
+          ),
           "Game party recruit card",
         );
         const recruitExtraction = extractLeadingThinkingBlocks(
@@ -5975,7 +6053,7 @@ export async function gameRoutes(app: FastifyInstance) {
   });
 
   // ── POST /game/map/generate ──
-  app.post("/map/generate", async (req) => {
+  app.post("/map/generate", async (req, reply) => {
     const { chatId, locationType, context, connectionId } = mapGenerateSchema.parse(req.body);
     const chats = createChatsStorage(app.db);
     const connections = createConnectionsStorage(app.db);
@@ -5998,6 +6076,7 @@ export async function gameRoutes(app: FastifyInstance) {
       { role: "user", content: "Generate the map." },
     ];
 
+    const mapAbortSignal = createResponseAbortSignal(reply, GAME_GENERATION_TIMEOUT_MS, "Game map generation");
     const result = await runGameChatComplete(
       provider,
       messages,
@@ -6005,6 +6084,7 @@ export async function gameRoutes(app: FastifyInstance) {
         conn.model,
         {
           temperature: 0.6,
+          signal: mapAbortSignal,
         },
         null,
         conn.provider,
@@ -6574,7 +6654,7 @@ export async function gameRoutes(app: FastifyInstance) {
     debugMode: z.boolean().optional().default(false),
   });
 
-  app.post("/party-turn", async (req) => {
+  app.post("/party-turn", async (req, reply) => {
     const input = partyTurnSchema.parse(req.body);
     const chats = createChatsStorage(app.db);
     const connections = createConnectionsStorage(app.db);
@@ -6754,6 +6834,7 @@ export async function gameRoutes(app: FastifyInstance) {
       conn.openrouterProvider,
       conn.maxTokensOverride,
     );
+    const partyTurnAbortSignal = createResponseAbortSignal(reply, GAME_GENERATION_TIMEOUT_MS, "Game party turn");
     const result = await runGameChatComplete(
       provider,
       messages,
@@ -6761,6 +6842,7 @@ export async function gameRoutes(app: FastifyInstance) {
         conn.model ?? "",
         {
           maxTokens: 8192,
+          signal: partyTurnAbortSignal,
         },
         gameGenerationParameters,
         conn.provider,
@@ -6974,7 +7056,7 @@ export async function gameRoutes(app: FastifyInstance) {
     debugMode: z.boolean().optional().default(false),
   });
 
-  app.post("/scene-wrap", async (req) => {
+  app.post("/scene-wrap", async (req, reply) => {
     const input = sceneWrapSchema.parse(req.body);
     const requestDebug = input.debugMode === true;
     const debugOverrideEnabled = requestDebug || isDebugAgentsEnabled();
@@ -7073,11 +7155,13 @@ export async function gameRoutes(app: FastifyInstance) {
     // request should stay on the buffered completion path regardless of the
     // UI's live-streaming toggle. Some GPT-5.5/OpenAI-compatible stacks return
     // empty content when `chatComplete()` is asked to stream this JSON route.
+    const sceneWrapAbortSignal = createResponseAbortSignal(reply, GAME_GENERATION_TIMEOUT_MS, "Game scene wrap");
     const sceneWrapOptions = gameGenOptions(
       conn.model ?? "",
       {
         stream: false,
         responseFormat: { type: "json_object" },
+        signal: sceneWrapAbortSignal,
       },
       gameGenerationParameters,
       conn.provider,
@@ -7845,6 +7929,8 @@ export async function gameRoutes(app: FastifyInstance) {
       GAME_ASSET_GENERATION_TIMEOUT_MS,
       "Game asset generation",
     );
+    const releaseAssetGeneration = await acquireGameAssetGenerationLock(input.chatId, assetAbortSignal);
+    try {
     const requestDebug = input.debugMode === true;
     const debugOverrideEnabled = requestDebug || isDebugAgentsEnabled();
     const debugLogsEnabled = debugOverrideEnabled || logger.isLevelEnabled("debug");
@@ -8247,6 +8333,9 @@ export async function gameRoutes(app: FastifyInstance) {
     }
 
     return { generatedBackground, fallbackBackground, generatedIllustration, generatedNpcAvatars };
+    } finally {
+      releaseAssetGeneration();
+    }
   });
 
   // ── POST /game/checkpoint ──

--- a/packages/server/src/routes/game.routes.ts
+++ b/packages/server/src/routes/game.routes.ts
@@ -2634,6 +2634,28 @@ function buildJsonRepairPayload(args: {
   };
 }
 
+type JsonRepairRouteResult = {
+  type: "json_repair";
+  error: string;
+  repair: JsonRepairPayload;
+  validationError?: string;
+};
+
+function isJsonRepairRouteResult(value: unknown): value is JsonRepairRouteResult {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    (value as { type?: unknown }).type === "json_repair" &&
+    typeof (value as { error?: unknown }).error === "string" &&
+    typeof (value as { repair?: unknown }).repair === "object" &&
+    (value as { repair?: unknown }).repair !== null
+  );
+}
+
+function sendJsonRepairRouteResult(reply: FastifyReply, result: JsonRepairRouteResult): void {
+  sendJsonRepairError(reply, result.error, result.repair, result.validationError);
+}
+
 function validateGameSetupPayload(setupData: Record<string, unknown>): string | null {
   const missing: string[] = [];
   if (!setupData.storyArc) missing.push("storyArc");
@@ -3626,7 +3648,7 @@ export async function gameRoutes(app: FastifyInstance) {
   // ── POST /game/setup ──
   app.post("/setup", async (req, reply) => {
     logger.info("[game/setup] Received request");
-    const { chatId, connectionId, preferences, streaming, debugMode } = setupSchema.parse(req.body);
+    const { chatId, connectionId, preferences, debugMode } = setupSchema.parse(req.body);
     const requestDebug = debugMode === true;
     const debugLogsEnabled = requestDebug || logger.isLevelEnabled("debug");
     const debugLog = (message: string, ...args: any[]) => {
@@ -3842,20 +3864,7 @@ export async function gameRoutes(app: FastifyInstance) {
       conn.model,
       {
         maxTokens: setupMaxTokens,
-        stream: streaming,
-        ...(streaming
-          ? {
-              onToken: (() => {
-                const setupStartTime = Date.now();
-                let sawFirstToken = false;
-                return (chunk: string) => {
-                  if (!chunk || sawFirstToken) return;
-                  sawFirstToken = true;
-                  debugLog("[game/setup] First streamed token received after %d ms", Date.now() - setupStartTime);
-                };
-              })(),
-            }
-          : {}),
+        stream: false,
       },
       setupGenerationParameters,
       conn.provider,
@@ -4391,7 +4400,14 @@ export async function gameRoutes(app: FastifyInstance) {
   app.post("/session/conclude", async (req, reply) => {
     const { chatId, connectionId, streaming, nextSessionRequest } = concludeSessionSchema.parse(req.body);
     const existingConclusion = pendingSessionConclusions.get(chatId);
-    if (existingConclusion) return existingConclusion;
+    if (existingConclusion) {
+      const conclusionResult = await existingConclusion;
+      if (isJsonRepairRouteResult(conclusionResult)) {
+        sendJsonRepairRouteResult(reply, conclusionResult);
+        return;
+      }
+      return conclusionResult;
+    }
 
     const conclusionRequest = (async () => {
     const trimmedNextSessionRequest = nextSessionRequest.trim();
@@ -4526,18 +4542,17 @@ export async function gameRoutes(app: FastifyInstance) {
       }
     } catch (err) {
       logger.warn(err, "[session/conclude] Combined session conclusion parsing failed");
-      sendJsonRepairError(
-        reply,
-        "The generated session conclusion was not valid JSON.",
-        buildJsonRepairPayload({
+      return {
+        type: "json_repair",
+        error: "The generated session conclusion was not valid JSON.",
+        repair: buildJsonRepairPayload({
           kind: "session_conclusion",
           title: `Repair Session ${sessionNumber} Summary JSON`,
           rawJson: conclusionExtraction.content,
           applyEndpoint: "/game/session/conclude/apply-json",
           applyBody: { chatId, connectionId: conn.id, nextSessionRequest: trimmedNextSessionRequest },
         }),
-      );
-      return;
+      } satisfies JsonRepairRouteResult;
     }
 
     let conclusionWasStored = false;
@@ -4632,7 +4647,12 @@ export async function gameRoutes(app: FastifyInstance) {
 
     pendingSessionConclusions.set(chatId, conclusionRequest);
     try {
-      return await conclusionRequest;
+      const conclusionResult = await conclusionRequest;
+      if (isJsonRepairRouteResult(conclusionResult)) {
+        sendJsonRepairRouteResult(reply, conclusionResult);
+        return;
+      }
+      return conclusionResult;
     } finally {
       if (pendingSessionConclusions.get(chatId) === conclusionRequest) {
         pendingSessionConclusions.delete(chatId);
@@ -4644,7 +4664,14 @@ export async function gameRoutes(app: FastifyInstance) {
   app.post("/session/conclude/apply-json", async (req, reply) => {
     const { chatId, rawJson, connectionId, nextSessionRequest } = jsonRepairApplySchema.parse(req.body);
     const existingConclusion = pendingSessionConclusions.get(chatId);
-    if (existingConclusion) return existingConclusion;
+    if (existingConclusion) {
+      const conclusionResult = await existingConclusion;
+      if (isJsonRepairRouteResult(conclusionResult)) {
+        sendJsonRepairRouteResult(reply, conclusionResult);
+        return;
+      }
+      return conclusionResult;
+    }
 
     const conclusionRequest = (async () => {
     const trimmedNextSessionRequest = nextSessionRequest.trim();
@@ -4686,18 +4713,17 @@ export async function gameRoutes(app: FastifyInstance) {
       });
     } catch (err) {
       logger.warn(err, "[session/conclude/apply-json] Repaired session conclusion JSON still failed to parse");
-      sendJsonRepairError(
-        reply,
-        "The edited session conclusion JSON is still invalid.",
-        buildJsonRepairPayload({
+      return {
+        type: "json_repair",
+        error: "The edited session conclusion JSON is still invalid.",
+        repair: buildJsonRepairPayload({
           kind: "session_conclusion",
           title: `Repair Session ${sessionNumber} Summary JSON`,
           rawJson,
           applyEndpoint: "/game/session/conclude/apply-json",
           applyBody: { chatId, nextSessionRequest: trimmedNextSessionRequest },
         }),
-      );
-      return;
+      } satisfies JsonRepairRouteResult;
     }
 
     let conclusionWasStored = false;
@@ -4783,7 +4809,12 @@ export async function gameRoutes(app: FastifyInstance) {
 
     pendingSessionConclusions.set(chatId, conclusionRequest);
     try {
-      return await conclusionRequest;
+      const conclusionResult = await conclusionRequest;
+      if (isJsonRepairRouteResult(conclusionResult)) {
+        sendJsonRepairRouteResult(reply, conclusionResult);
+        return;
+      }
+      return conclusionResult;
     } finally {
       if (pendingSessionConclusions.get(chatId) === conclusionRequest) {
         pendingSessionConclusions.delete(chatId);

--- a/packages/server/src/routes/generate.routes.ts
+++ b/packages/server/src/routes/generate.routes.ts
@@ -246,7 +246,7 @@ import {
 import { registerDryRunRoute } from "./generate/dry-run-route.js";
 import { registerRetryAgentsRoute } from "./generate/retry-agents-route.js";
 import { fingerprintChatSummary } from "../services/prompt/chat-summary-fingerprint.js";
-import { sendSseEvent, startSseReply, trySendSseEvent } from "./generate/sse.js";
+import { sendSseEvent, startSseKeepalive, startSseReply, trySendSseEvent } from "./generate/sse.js";
 import { runTurnGameBotTurns } from "../services/turn-games/turn-game-bot-runner.service.js";
 import {
   getActiveTurnGame,
@@ -398,6 +398,10 @@ import {
 
 function findResultAgent(result: AgentResult, agents: ResolvedAgent[]): ResolvedAgent | null {
   return agents.find((agent) => agent.id === result.agentId || agent.type === result.agentType) ?? null;
+}
+
+function isAbortLikeError(error: unknown): boolean {
+  return error instanceof Error && error.name === "AbortError";
 }
 
 function customAgentCanApplyResult(
@@ -1335,6 +1339,7 @@ export async function generateRoutes(app: FastifyInstance) {
         return false;
       }
     }) as typeof reply.raw.write;
+    const stopSseKeepalive = startSseKeepalive(reply);
 
     const onClose = () => {
       if (generationComplete) return;
@@ -1345,7 +1350,6 @@ export async function generateRoutes(app: FastifyInstance) {
       }
       logger.info("[abort] Client disconnected — aborting generation");
       abortController.abort();
-      if (activeGenerations) activeGenerations.delete(input.chatId);
       if (baseUrl) {
         const backendRoot = baseUrl.replace(/\/v1\/?$/, "");
         fetch(backendRoot + "/api/extra/abort", {
@@ -1949,6 +1953,7 @@ export async function generateRoutes(app: FastifyInstance) {
             if (recentMsgs.trim()) {
               const embeddings = await embedMemoryRecallTexts([recentMsgs], {
                 embeddingSource: memoryRecallEmbeddingSource,
+                signal: abortController.signal,
               });
               chatContextEmbedding = embeddings[0] ?? null;
             }
@@ -3492,7 +3497,7 @@ export async function generateRoutes(app: FastifyInstance) {
         }
 
         const isLocalGemma = (conn.model ?? "").toLowerCase().includes("gemma");
-        applyParameterOverrides(connectionParams);
+        if (!presetId) applyParameterOverrides(connectionParams);
         applyParameterOverrides(chatParams);
 
         // Game mode: force optimal generation defaults after Advanced Parameters
@@ -4100,6 +4105,7 @@ export async function generateRoutes(app: FastifyInstance) {
             embeddingSource: memoryRecallEmbeddingSource,
             contextLimit: suppressModelParameters ? undefined : (effectiveMaxContext ?? connectionMaxContext),
             sendProgress,
+            signal: abortController.signal,
           });
         }
 
@@ -5955,21 +5961,6 @@ export async function generateRoutes(app: FastifyInstance) {
           let usage: LLMUsage | undefined;
           let finishReason: string | undefined;
 
-          // ── SSE keepalive: send periodic comments to prevent proxy timeouts ──
-          // Reasoning models (e.g. GPT-5.4 with xhigh effort) may spend a long time
-          // thinking before the first token arrives. Cloudflare and other reverse
-          // proxies often kill idle connections after ~100s. Sending SSE comments
-          // (`: keepalive`) keeps the connection alive without affecting the client.
-          const keepaliveTimer = setInterval(() => {
-            try {
-              if (!reply.raw.destroyed) {
-                reply.raw.write(": keepalive\n\n");
-              }
-            } catch {
-              // Connection already closed — ignore
-            }
-          }, 15_000);
-
           const logPromptSentToModel = (messages: ChatMessage[], label = "Prompt sent to model") => {
             if (isDebug || requestDebug) {
               const effModel = conn.model.toLowerCase();
@@ -6010,7 +6001,6 @@ export async function generateRoutes(app: FastifyInstance) {
             }
           };
 
-          try {
             if (enableChatTools && provider.chatComplete) {
               const maxToolRounds = getMaxToolRounds();
               let loopMessages: ChatMessage[] = initialProviderMessages;
@@ -6316,21 +6306,34 @@ export async function generateRoutes(app: FastifyInstance) {
                   : (items) => encryptedReasoningCache.set(input.chatId, items),
                 onChatCompletionsReasoning: rememberChatCompletionsReasoning,
               });
-              let result = await gen.next();
-              while (!result.done) {
-                fullResponse += result.value;
-                // Break large chunks (e.g. Gemini non-streaming) into small pieces
-                // so the client sees progressive streaming.
-                const val = result.value;
-                if (holdForProseGuardianRewrite) {
+              try {
+                let result = await gen.next();
+                while (!result.done) {
+                  if (abortController.signal.aborted) {
+                    return null;
+                  }
+                  fullResponse += result.value;
+                  // Break large chunks (e.g. Gemini non-streaming) into small pieces
+                  // so the client sees progressive streaming.
+                  const val = result.value;
+                  if (holdForProseGuardianRewrite) {
+                    result = await gen.next();
+                    continue;
+                  }
+                  await sendTokenTextChunked(val);
                   result = await gen.next();
-                  continue;
                 }
-                await sendTokenTextChunked(val);
-                result = await gen.next();
+                // Generator return value contains usage
+                if (result.value) usage = result.value;
+              } catch (err) {
+                if (abortController.signal.aborted || isAbortLikeError(err)) {
+                  return null;
+                }
+                throw err;
               }
-              // Generator return value contains usage
-              if (result.value) usage = result.value;
+              if (abortController.signal.aborted) {
+                return null;
+              }
             }
 
             const durationMs = Date.now() - genStartTime;
@@ -6846,9 +6849,6 @@ export async function generateRoutes(app: FastifyInstance) {
               oocMessages,
               characterId: targetCharId,
             };
-          } finally {
-            clearInterval(keepaliveTimer);
-          }
         };
 
         // ────────────────────────────────────────
@@ -10671,6 +10671,9 @@ export async function generateRoutes(app: FastifyInstance) {
         }
       }
     } catch (err) {
+      if (abortController.signal.aborted || isAbortLikeError(err)) {
+        return;
+      }
       if (!abortController.signal.aborted) {
         abortController.abort();
       }
@@ -10685,6 +10688,7 @@ export async function generateRoutes(app: FastifyInstance) {
       if (conversationGenerationStartedAt != null && !conversationAssistantSaved) {
         clearGenerationInProgress(input.chatId, conversationGenerationStartedAt);
       }
+      stopSseKeepalive();
       reply.raw.off("close", onClose);
       releaseActiveGeneration();
       if (!clientDisconnected && !reply.raw.destroyed) {
@@ -10727,7 +10731,9 @@ export async function generateRoutes(app: FastifyInstance) {
       }
     }
 
-    activeGenerations.delete(chatId);
+    // Keep the entry registered until the generation route reaches its
+    // identity-checked finally block. Deleting here opens a same-chat race where
+    // a replacement request can register before the aborted request has unwound.
     return reply.send({ aborted: true });
   });
 

--- a/packages/server/src/routes/generate.routes.ts
+++ b/packages/server/src/routes/generate.routes.ts
@@ -78,6 +78,7 @@ import { injectAtDepth } from "../services/lorebook/prompt-injector.js";
 import { createLLMProvider } from "../services/llm/provider-registry.js";
 import { resolveConnectionImageDefaults } from "../services/image/image-generation-defaults.js";
 import { loadImageGenerationUserSettings } from "../services/image/image-generation-settings.js";
+import { textRewriteDropsProtectedMarkup } from "../services/generation/text-rewrite-safety.js";
 import { compileImagePrompt } from "../services/image/image-prompt-compiler.js";
 import { extractLeadingThinkingBlocks } from "../services/llm/inline-thinking.js";
 import { resolveSpotifyCredentials, spotifyHasScope } from "../services/spotify/spotify.service.js";
@@ -203,6 +204,7 @@ import {
   parseStoredGenerationParameters,
   parseGameStateRow,
   parseSnapshotPlayerStats,
+  isRoleplaySummaryMode,
   preserveTrackerCharacterUiFields,
   prefixGroupIndividualHistorySpeakers,
   resolveActiveCharacterIds,
@@ -211,6 +213,7 @@ import {
   resolvePromptCharacterIdsForTarget,
   resolveRegenerationGameStateFallbackMessageIds,
   resolveRegenerationGameStateAnchor,
+  resolveRoleplayChatSummary,
   resolveUserRegenerationPersistentAttachments,
   resolveVisibleGameStateAnchor,
   resolveProviderTopK,
@@ -592,15 +595,6 @@ function clampRoleplaySummaryContextSize(value: unknown): number {
   const parsed = Number(value);
   if (!Number.isFinite(parsed) || parsed <= 0) return 50;
   return Math.max(MIN_SUMMARY_CONTEXT_SIZE, Math.min(MAX_SUMMARY_CONTEXT_SIZE, Math.trunc(parsed)));
-}
-
-function isRoleplaySummaryMode(chatMode: string): boolean {
-  return chatMode === "roleplay" || chatMode === "visual_novel";
-}
-
-function resolveRoleplayChatSummary(chatMode: string, chatMetadata: Record<string, unknown>): string | null {
-  if (!isRoleplaySummaryMode(chatMode)) return null;
-  return ((chatMetadata.summary as string) ?? "").trim() || null;
 }
 
 function isAutomaticRoleplaySummaryEnabled(chatMetadata: Record<string, unknown>): boolean {
@@ -8823,8 +8817,20 @@ export async function generateRoutes(app: FastifyInstance) {
                     editorResult.agentType === "prose-guardian" || editorResult.agentType === "continuity";
                   const rewriteAllowed =
                     editNeededValue === false ? false : strictEditNeeded ? editNeededValue === true : true;
+                  const droppedProtectedMarkup =
+                    strictEditNeeded && textRewriteDropsProtectedMarkup(currentResponseForRewrite, editedText);
+                  if (droppedProtectedMarkup) {
+                    logger.warn(
+                      "[text-rewrite] Skipping %s rewrite because it dropped protected markup from message %s",
+                      editorResult.agentType,
+                      messageId,
+                    );
+                  }
                   const changedMessage =
-                    rewriteAllowed && editedText.trim().length > 0 && editedText !== currentResponseForRewrite;
+                    rewriteAllowed &&
+                    !droppedProtectedMarkup &&
+                    editedText.trim().length > 0 &&
+                    editedText !== currentResponseForRewrite;
                   if (changedMessage) {
                     const originalText = strictEditNeeded ? originalResponseBeforeRewrite : null;
                     currentResponseForRewrite = editedText;

--- a/packages/server/src/routes/generate/dry-run-route.ts
+++ b/packages/server/src/routes/generate/dry-run-route.ts
@@ -1234,7 +1234,7 @@ export async function registerDryRunRoute(app: FastifyInstance) {
       );
     }
 
-    applyParameterOverrides(connectionParams);
+    if (!effectivePresetId) applyParameterOverrides(connectionParams);
     applyParameterOverrides(chatParams);
 
     if (!finalMessages.length) {

--- a/packages/server/src/routes/generate/dry-run-route.ts
+++ b/packages/server/src/routes/generate/dry-run-route.ts
@@ -58,6 +58,7 @@ import {
   resolveCharacterNameMap,
   resolveRegenerationGameStateAnchor,
   resolveProviderTopK,
+  resolveRoleplayChatSummary,
   normalizeServiceTier,
   resolveVisibleGameStateAnchor,
   resolveBaseUrl,
@@ -555,6 +556,7 @@ export async function registerDryRunRoute(app: FastifyInstance) {
     // Pull existing messages, apply the same conversation-start + context limit filtering
     const allChatMessages = await chats.listMessages(chatId);
     const chatMode = (chat.mode as string) ?? "roleplay";
+    const activeChatSummary = resolveRoleplayChatSummary(chatMode, chatMeta);
     const dryRunActiveAgentIds = Array.isArray(chatMeta.activeAgentIds) ? (chatMeta.activeAgentIds as string[]) : [];
     const dryRunChatEnableAgents = shouldEnableAgentsForGeneration({
       chatEnableAgents: chatMeta.enableAgents === true,
@@ -957,7 +959,7 @@ export async function registerDryRunRoute(app: FastifyInstance) {
 
       const chatSummaryBlock = (() => {
         if (!includeChatSummary) return "";
-        const summary = ((chatMeta.summary as string) ?? "").trim();
+        const summary = activeChatSummary ?? "";
         if (!summary) return "";
         return wrapFormat === "xml" ? `<chat_summary>\n${summary}\n</chat_summary>` : `Chat summary:\n${summary}`;
       })();
@@ -1174,7 +1176,7 @@ export async function registerDryRunRoute(app: FastifyInstance) {
           }
         })(),
         chatMessages: mappedMessages,
-        chatSummary: resolvedInjectChatSummary ? ((chatMeta.summary as string) ?? "").trim() || null : null,
+        chatSummary: resolvedInjectChatSummary ? activeChatSummary : null,
         enableAgents: false,
         activeAgentIds: [],
         activeLorebookIds: resolvedInjectLorebook
@@ -1258,7 +1260,7 @@ export async function registerDryRunRoute(app: FastifyInstance) {
 
     // Optional injection: chat summary (when not handled by preset assembler)
     if (!usePromptParts && !effectivePresetId && resolvedInjectChatSummary) {
-      const summary = ((chatMeta.summary as string) ?? "").trim();
+      const summary = activeChatSummary ?? "";
       if (summary) {
         const block =
           wrapFormat === "xml" ? `<chat_summary>\n${summary}\n</chat_summary>` : `Chat summary:\n${summary}`;

--- a/packages/server/src/routes/generate/generate-route-utils.ts
+++ b/packages/server/src/routes/generate/generate-route-utils.ts
@@ -200,7 +200,7 @@ export function resolveProviderTopK(provider: unknown, topK: number): number | u
   const normalized = Number.isFinite(topK) ? Math.max(0, Math.trunc(topK)) : 0;
   const providerId = typeof provider === "string" ? provider.toLowerCase() : "";
   if (providerId === "google" || providerId === "google_vertex") {
-    return normalized;
+    return normalized > 0 ? normalized : undefined;
   }
   return normalized > 0 ? normalized : undefined;
 }
@@ -213,9 +213,13 @@ export function mergeCustomParameters(
   base: Record<string, unknown> | null | undefined,
   next: Record<string, unknown> | null | undefined,
 ): Record<string, unknown> {
-  const merged: Record<string, unknown> = { ...(base ?? {}) };
+  const merged: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(base ?? {})) {
+    if (!isUnsafeCustomParameterKey(key)) merged[key] = value;
+  }
   if (!next) return merged;
   for (const [key, value] of Object.entries(next)) {
+    if (isUnsafeCustomParameterKey(key)) continue;
     if (value === undefined) continue;
     const current = merged[key];
     if (isPlainRecord(current) && isPlainRecord(value)) {
@@ -225,6 +229,10 @@ export function mergeCustomParameters(
     }
   }
   return merged;
+}
+
+function isUnsafeCustomParameterKey(key: string): boolean {
+  return key === "__proto__" || key === "constructor" || key === "prototype";
 }
 
 function normalizeStringArray(value: unknown): string[] {
@@ -972,7 +980,7 @@ export function parseStoredGenerationParameters(raw: unknown): StoredGenerationP
     out.customThinkingTags = normalizeThinkingTagPairs(source.customThinkingTags);
   }
   if (isPlainRecord(source.customParameters)) {
-    out.customParameters = source.customParameters;
+    out.customParameters = mergeCustomParameters({}, source.customParameters);
   }
   for (const key of [
     "squashSystemMessages",

--- a/packages/server/src/routes/generate/generate-route-utils.ts
+++ b/packages/server/src/routes/generate/generate-route-utils.ts
@@ -458,6 +458,15 @@ export function isMessageHiddenFromAI(message: { extra?: unknown }): boolean {
   return parseExtra(message.extra).hiddenFromAI === true;
 }
 
+export function isRoleplaySummaryMode(chatMode: string): boolean {
+  return chatMode === "roleplay" || chatMode === "visual_novel";
+}
+
+export function resolveRoleplayChatSummary(chatMode: string, chatMetadata: Record<string, unknown>): string | null {
+  if (!isRoleplaySummaryMode(chatMode)) return null;
+  return ((chatMetadata.summary as string) ?? "").trim() || null;
+}
+
 function escapeRegex(value: string): string {
   return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }

--- a/packages/server/src/routes/generate/illustrator-references.ts
+++ b/packages/server/src/routes/generate/illustrator-references.ts
@@ -14,6 +14,7 @@ type CharacterReferenceSource = {
   avatarPath: string | null;
   appearance: string | null;
   aliases: string[];
+  promptAliases: string[];
   sourceOrder: number;
 };
 
@@ -69,7 +70,7 @@ function normalizeReferenceName(value: string): string {
     .trim();
 }
 
-function buildNameAliases(name: string): string[] {
+function buildNameAliases(name: string, opts: { includeStandaloneTokens?: boolean } = {}): string[] {
   const normalized = normalizeReferenceName(name);
   if (!normalized) return [];
 
@@ -83,8 +84,10 @@ function buildNameAliases(name: string): string[] {
     if (withoutLeadingTitle) aliases.add(withoutLeadingTitle);
   }
 
-  for (const token of tokens) {
-    if (token.length >= 4 && !NAME_STOPWORDS.has(token)) aliases.add(token);
+  if (opts.includeStandaloneTokens !== false) {
+    for (const token of tokens) {
+      if (token.length >= 4 && !NAME_STOPWORDS.has(token)) aliases.add(token);
+    }
   }
 
   return [...aliases].sort((a, b) => b.length - a.length);
@@ -120,6 +123,7 @@ function characterRowToSource(row: CharacterRowLike, sourceOrder: number): Chara
     avatarPath: typeof row.avatarPath === "string" ? row.avatarPath : null,
     appearance: readAppearance(data),
     aliases: buildNameAliases(rawName),
+    promptAliases: buildNameAliases(rawName, { includeStandaloneTokens: false }),
     sourceOrder,
   };
 }
@@ -153,6 +157,7 @@ export async function resolveIllustratorCharacterReferences(args: {
       avatarPath: character.avatarPath ?? fromDb?.avatarPath ?? null,
       appearance: character.appearance ?? fromDb?.appearance ?? null,
       aliases: buildNameAliases(character.name),
+      promptAliases: buildNameAliases(character.name, { includeStandaloneTokens: false }),
       sourceOrder: index,
     });
   });
@@ -176,17 +181,20 @@ export async function resolveIllustratorCharacterReferences(args: {
 
   for (const source of sources) {
     if (selected.has(source.id)) continue;
-    if (source.aliases.some((alias) => textContainsAlias(normalizedPromptText, alias))) selected.set(source.id, source);
+    if (source.promptAliases.some((alias) => textContainsAlias(normalizedPromptText, alias))) {
+      selected.set(source.id, source);
+    }
   }
 
   const personaName = args.persona?.name?.trim() ?? "";
   const personaAliases = personaName ? buildNameAliases(personaName) : [];
+  const personaPromptAliases = personaName ? buildNameAliases(personaName, { includeStandaloneTokens: false }) : [];
   const personaRequested =
     personaAliases.length > 0 &&
     (requestedNames.some((requestedName) =>
       personaAliases.some((alias) => alias === requestedName || textContainsAlias(requestedName, alias)),
     ) ||
-      personaAliases.some((alias) => textContainsAlias(normalizedPromptText, alias)));
+      personaPromptAliases.some((alias) => textContainsAlias(normalizedPromptText, alias)));
 
   if (selected.size === 0 && args.fallbackToChatCharacters === true) {
     for (const character of args.chatCharacters) {

--- a/packages/server/src/routes/generate/retry-agents-route.ts
+++ b/packages/server/src/routes/generate/retry-agents-route.ts
@@ -84,7 +84,7 @@ import {
   isAgentWriteApprovalEnvelope,
 } from "./agent-write-approval.js";
 import { filterGameInternalAgentIds } from "../../services/lorebook/game-lorebook-scope.js";
-import { sendSseEvent, startSseReply } from "./sse.js";
+import { sendSseEvent, startSseKeepalive, startSseReply } from "./sse.js";
 import { buildGenerationPromptPresetCandidates } from "./prompt-preset-selection.js";
 import {
   buildAgentConnectionUnavailableWarning,
@@ -120,6 +120,26 @@ type PersonaContext = {
   personaStats: any;
   rpgStats: any;
 };
+
+function resolveIllustratorImageSize(
+  size: { width: number; height: number },
+  aspectRatio: unknown,
+): { width: number; height: number } {
+  const width = Math.max(1, Math.round(size.width));
+  const height = Math.max(1, Math.round(size.height));
+  const aspect = typeof aspectRatio === "string" ? aspectRatio.trim().toLowerCase() : "";
+  if (aspect === "portrait") {
+    return width <= height ? { width, height } : { width: height, height: width };
+  }
+  if (aspect === "landscape") {
+    return width >= height ? { width, height } : { width: height, height: width };
+  }
+  if (aspect === "square") {
+    const side = Math.min(width, height);
+    return { width: side, height: side };
+  }
+  return { width, height };
+}
 
 function cardPromptText(value: unknown): string {
   return typeof value === "string" ? stripMacroComments(value).trim() : "";
@@ -2623,8 +2643,9 @@ async function applyRetryResultEffects(args: {
               (typeof setupConfig.imageStyleProfileId === "string" ? setupConfig.imageStyleProfileId : "") ||
               (typeof chatMeta.imageStyleProfileId === "string" ? chatMeta.imageStyleProfileId : "") ||
               null;
-            const imgWidth = imageSettings.illustration.width;
-            const imgHeight = imageSettings.illustration.height;
+            const illustrationSize = resolveIllustratorImageSize(imageSettings.illustration, illData.aspectRatio);
+            const imgWidth = illustrationSize.width;
+            const imgHeight = illustrationSize.height;
 
             const gameArtStylePrompt =
               typeof agentContext.memory._gameImageStylePrompt === "string"
@@ -2892,7 +2913,7 @@ export async function registerRetryAgentsRoute(app: FastifyInstance) {
       return reply.status(400).send({ error: "chatId and agentTypes are required" });
     }
 
-    startSseReply(reply);
+    startSseReply(reply, { "X-Accel-Buffering": "no" });
 
     // Abort in-flight agent LLM calls when the client disconnects, and stop
     // writing to a closed socket. Mirrors the main /generate handler so a dropped
@@ -2908,6 +2929,7 @@ export async function registerRetryAgentsRoute(app: FastifyInstance) {
         return false;
       }
     }) as typeof reply.raw.write;
+    const stopSseKeepalive = startSseKeepalive(reply);
     const onClientClose = () => {
       clientDisconnected = true;
       abortController.abort();
@@ -3269,6 +3291,7 @@ export async function registerRetryAgentsRoute(app: FastifyInstance) {
           : "Agent retry failed";
       sendSseEvent(reply, { type: "error", data: message });
     } finally {
+      stopSseKeepalive();
       reply.raw.off("close", onClientClose);
       reply.raw.end();
     }

--- a/packages/server/src/routes/generate/retry-agents-route.ts
+++ b/packages/server/src/routes/generate/retry-agents-route.ts
@@ -48,6 +48,7 @@ import { createChatsStorage } from "../../services/storage/chats.storage.js";
 import { createConnectionsStorage } from "../../services/storage/connections.storage.js";
 import { createPromptsStorage } from "../../services/storage/prompts.storage.js";
 import { findLastUserMessageIdBefore } from "../../services/generation/message-history.js";
+import { textRewriteDropsProtectedMarkup } from "../../services/generation/text-rewrite-safety.js";
 import { resolveConnectionImageDefaults } from "../../services/image/image-generation-defaults.js";
 import { loadImageGenerationUserSettings } from "../../services/image/image-generation-settings.js";
 import { compileImagePrompt } from "../../services/image/image-prompt-compiler.js";
@@ -66,6 +67,7 @@ import {
   preserveTrackerCharacterUiFields,
   resolveActiveCharacterIds,
   resolveBaseUrl,
+  resolveRoleplayChatSummary,
   resolveVisibleGameStateAnchor,
 } from "./generate-route-utils.js";
 import {
@@ -590,9 +592,10 @@ async function buildRetryAgentContext(args: {
     return resolveHistoryMessageMacros([{ content: value, characterId: null }])[0]?.content ?? value;
   };
 
+  const chatMode = ((chat as { mode?: ChatMode }).mode ?? "conversation") as ChatMode;
   const agentContext: AgentContext = {
     chatId,
-    chatMode: (chat as any).mode ?? "conversation",
+    chatMode,
     wrapFormat,
     recentMessages: agentSlice.map((message: any, index: number) => {
       const resolved = resolvedAgentSlice[index];
@@ -639,7 +642,7 @@ async function buildRetryAgentContext(args: {
         : null,
     activatedLorebookEntries: null,
     writableLorebookIds: null,
-    chatSummary: ((chatMeta.summary as string) ?? "").trim() || null,
+    chatSummary: resolveRoleplayChatSummary(chatMode, chatMeta),
     streaming,
     memory: {},
   };
@@ -2188,8 +2191,20 @@ async function applyRetryResultEffects(args: {
         const editNeededValue = rewriteData.editNeeded;
         const strictEditNeeded = result.agentType === "prose-guardian" || result.agentType === "continuity";
         const rewriteAllowed = editNeededValue === false ? false : strictEditNeeded ? editNeededValue === true : true;
+        const droppedProtectedMarkup =
+          strictEditNeeded && textRewriteDropsProtectedMarkup(currentResponseForRewrite, editedText);
+        if (droppedProtectedMarkup) {
+          logger.warn(
+            "[retry-agents] Skipping %s rewrite because it dropped protected markup from message %s",
+            result.agentType,
+            retryMessageId,
+          );
+        }
         const changedMessage =
-          rewriteAllowed && editedText.trim().length > 0 && editedText !== currentResponseForRewrite;
+          rewriteAllowed &&
+          !droppedProtectedMarkup &&
+          editedText.trim().length > 0 &&
+          editedText !== currentResponseForRewrite;
         if (retryMessageId && changedMessage) {
           const currentMessage = await chats.getMessage(retryMessageId);
           if ((currentMessage?.content ?? "") !== expectedStoredMessageContent) {

--- a/packages/server/src/routes/generate/sse.ts
+++ b/packages/server/src/routes/generate/sse.ts
@@ -11,6 +11,20 @@ export function startSseReply(reply: FastifyReply, extraHeaders: Record<string, 
   });
 }
 
+export function startSseKeepalive(reply: FastifyReply, intervalMs = 15_000): () => void {
+  const timer = setInterval(() => {
+    try {
+      if (!reply.raw.destroyed && !reply.raw.writableEnded) {
+        reply.raw.write(": keepalive\n\n");
+      }
+    } catch {
+      // Ignore writes after the client disconnects.
+    }
+  }, intervalMs);
+  timer.unref?.();
+  return () => clearInterval(timer);
+}
+
 export function sendSseEvent(reply: FastifyReply, payload: SsePayload) {
   reply.raw.write(`data: ${JSON.stringify(payload)}\n\n`);
 }

--- a/packages/server/src/routes/professor-mari-workspace.routes.ts
+++ b/packages/server/src/routes/professor-mari-workspace.routes.ts
@@ -4,7 +4,7 @@
 import type { FastifyInstance, FastifyReply, FastifyRequest } from "fastify";
 import { z } from "zod";
 import { requirePrivilegedAccess } from "../middleware/privileged-gate.js";
-import { startSseReply, trySendSseEvent } from "./generate/sse.js";
+import { startSseKeepalive, startSseReply, trySendSseEvent } from "./generate/sse.js";
 import { getProfessorMariWorkspaceService } from "../services/professor-mari/workspace-agent.service.js";
 import { getProfessorMariWorkspaceSkillsService } from "../services/professor-mari/workspace-skills.service.js";
 import { getMariDbService } from "../services/mari-db/mari-db.service.js";
@@ -96,6 +96,7 @@ export async function professorMariWorkspaceRoutes(app: FastifyInstance) {
     const service = getProfessorMariWorkspaceService(app);
     startSseReply(reply, { "X-Accel-Buffering": "no" });
     reply.raw.flushHeaders?.();
+    const stopSseKeepalive = startSseKeepalive(reply);
 
     let complete = false;
     let clientDisconnected = false;
@@ -123,6 +124,7 @@ export async function professorMariWorkspaceRoutes(app: FastifyInstance) {
       send({ type: "error", data: err instanceof Error ? err.message : String(err) });
     } finally {
       complete = true;
+      stopSseKeepalive();
       reply.raw.off("close", onClose);
       if (!clientDisconnected && !reply.raw.destroyed && !reply.raw.writableEnded) reply.raw.end();
     }

--- a/packages/server/src/routes/sidecar.routes.ts
+++ b/packages/server/src/routes/sidecar.routes.ts
@@ -227,8 +227,12 @@ export const sidecarRoutes: FastifyPluginAsync = async (app) => {
     reply.raw.once("close", cancelActiveWork);
 
     const sendEvent = (data: unknown) => {
-      if (reply.raw.destroyed) return;
-      reply.raw.write(`data: ${JSON.stringify(data)}\n\n`);
+      if (reply.raw.destroyed || reply.raw.writableEnded) return;
+      try {
+        reply.raw.write(`data: ${JSON.stringify(data)}\n\n`);
+      } catch {
+        // Client disconnected between the guard and the write.
+      }
     };
 
     let lastProgressPhase: SidecarDownloadProgress["phase"] | undefined;
@@ -259,8 +263,12 @@ export const sidecarRoutes: FastifyPluginAsync = async (app) => {
     } finally {
       sidecarModelService.removeProgressListener(listener);
       completed = true;
-      if (!reply.raw.destroyed) {
-        reply.raw.end();
+      if (!reply.raw.destroyed && !reply.raw.writableEnded) {
+        try {
+          reply.raw.end();
+        } catch {
+          // Client disconnected between the guard and the end call.
+        }
       }
     }
   }

--- a/packages/server/src/routes/tts.routes.ts
+++ b/packages/server/src/routes/tts.routes.ts
@@ -226,6 +226,18 @@ function normalizeNanoGptTtsModelId(model: string) {
   return NANOGPT_TTS_MODEL_ALIASES[trimmed.toLowerCase()] ?? trimmed;
 }
 
+function clampElevenLabsSpeed(speed: number) {
+  return Math.min(1.2, Math.max(0.7, Number.isFinite(speed) ? speed : 1));
+}
+
+function elevenLabsModelSupportsSpeed(model: string) {
+  return model.trim().toLowerCase() !== "eleven_v3";
+}
+
+function isNanoGptElevenLabsModel(model: string) {
+  return /^elevenlabs[-_]/i.test(model.trim());
+}
+
 function readString(value: unknown) {
   return typeof value === "string" && value.trim().length > 0 ? value : undefined;
 }
@@ -596,14 +608,22 @@ export async function ttsRoutes(app: FastifyInstance) {
         ? normalizeElevenLabsTtsModelId(configuredModel)
         : configuredModel;
     const normalizedModel = model.toLowerCase();
-    if (cfg.source === "elevenlabs" && !useNanoGptSpeech && ELEVENLABS_NON_TTS_MODELS.has(normalizedModel)) {
+    if (cfg.source === "elevenlabs" && ELEVENLABS_NON_TTS_MODELS.has(normalizedModel)) {
       return reply.status(400).send({
         error: `ElevenLabs model "${model}" cannot generate text-to-speech`,
         detail: `That model is for Text to Voice / voice design. Use "eleven_v3" for Eleven v3 speech, or "eleven_multilingual_v2", "eleven_flash_v2_5", or "eleven_turbo_v2_5" for regular TTS.`,
       });
     }
 
-    const audioFormat = cfg.audioFormat ?? "mp3";
+    const audioFormat = cfg.source === "elevenlabs" ? "mp3" : (cfg.audioFormat ?? "mp3");
+    const nanoGptElevenLabsModel = useNanoGptSpeech && isNanoGptElevenLabsModel(model);
+    const includeSpeed =
+      useNanoGptSpeech
+        ? !nanoGptElevenLabsModel
+        : cfg.source === "elevenlabs"
+          ? elevenLabsModelSupportsSpeed(model)
+          : true;
+    const elevenLabsSpeed = clampElevenLabsSpeed(cfg.speed);
     const url = useNanoGptSpeech
       ? `${nanoGptV1BaseUrl(base)}/audio/speech`
       : usePocketTtsSpeech
@@ -615,8 +635,10 @@ export async function ttsRoutes(app: FastifyInstance) {
     const elevenLabsLanguageCode = cfg.elevenLabsLanguageCode?.trim();
     const includeSpeakerInstructions = cfg.source !== "elevenlabs";
     const speechInstructions = useNanoGptSpeech
-      ? buildSpeechInstructions({ speaker, tone, includeSpeaker: includeSpeakerInstructions })
-      : cfg.source === "openai" && openAiModelSupportsSpeechInstructions(cfg.model)
+      ? !nanoGptElevenLabsModel && openAiModelSupportsSpeechInstructions(model)
+        ? buildSpeechInstructions({ speaker, tone, includeSpeaker: includeSpeakerInstructions })
+        : undefined
+      : cfg.source === "openai" && openAiModelSupportsSpeechInstructions(model)
         ? buildSpeechInstructions({ speaker, tone })
         : undefined;
 
@@ -645,7 +667,7 @@ export async function ttsRoutes(app: FastifyInstance) {
                 model,
                 input: providerText,
                 voice: requestVoice || "alloy",
-                speed: cfg.speed,
+                ...(includeSpeed ? { speed: cfg.speed } : {}),
                 response_format: audioFormat,
                 ...(speechInstructions ? { instructions: speechInstructions } : {}),
               })
@@ -656,14 +678,14 @@ export async function ttsRoutes(app: FastifyInstance) {
                   ...(elevenLabsLanguageCode ? { language_code: elevenLabsLanguageCode } : {}),
                   voice_settings: {
                     stability: cfg.elevenLabsStability,
-                    speed: cfg.speed,
+                    ...(includeSpeed ? { speed: elevenLabsSpeed } : {}),
                   },
                 })
               : JSON.stringify({
                   model,
                   input: providerText,
                   voice: requestVoice,
-                  speed: cfg.speed,
+                  ...(includeSpeed ? { speed: cfg.speed } : {}),
                   response_format: audioFormat,
                   ...(speechInstructions ? { instructions: speechInstructions } : {}),
                 }),

--- a/packages/server/src/services/agents/agent-executor.ts
+++ b/packages/server/src/services/agents/agent-executor.ts
@@ -516,6 +516,7 @@ async function executeAgentWithTools(
   let totalTokens = 0;
   const debugAgentsEnabled = isDebugAgentsEnabled() && logger.isLevelEnabled("debug");
   const customParameters = agentCustomParameters(config);
+  const toolLoopSignal = agentCallSignal(context.signal);
 
   for (let round = 0; round < maxToolRounds; round++) {
     emitAgentDebug(context, {
@@ -533,7 +534,7 @@ async function executeAgentWithTools(
       customParameters,
       stream: streamResponses,
       tools: toolContext.tools,
-      signal: agentCallSignal(context.signal),
+      signal: toolLoopSignal,
     });
 
     totalTokens += result.usage?.totalTokens ?? 0;
@@ -613,7 +614,7 @@ async function executeAgentWithTools(
     maxTokens,
     customParameters,
     stream: streamResponses,
-    signal: agentCallSignal(context.signal),
+    signal: toolLoopSignal,
   });
   totalTokens += finalResult.usage?.totalTokens ?? 0;
   const responseText = finalResult.content?.trim() ?? "";
@@ -1215,8 +1216,10 @@ function buildStandardAgentMessages(config: AgentExecConfig, template: string, c
 
   // Build multi-turn message array for this agent (sliced to its own contextSize)
   const agentContextSize = normalizeAgentContextSize(config.settings.contextSize);
+  const resultType = resolveAgentResultType(config);
   return buildAgentMessages(systemParts.join("\n"), context, config.type, agentContextSize, [config.type], {
     includeMessageIds: normalizeCustomAgentCapabilities(config.settings).edit_messages === true,
+    preserveAssistantResponseMarkup: resultType === "text_rewrite",
   });
 }
 
@@ -1527,7 +1530,7 @@ function buildAgentMessages(
   agentType: string,
   contextSize = 5,
   contextAgentTypes: string[] = [agentType],
-  options: { includeMessageIds?: boolean } = {},
+  options: { includeMessageIds?: boolean; preserveAssistantResponseMarkup?: boolean } = {},
 ): ChatMessage[] {
   // ── 1. System message — already contains <role>, <lore>, <agents>, and extras ──
   const messages: ChatMessage[] = [{ role: "system", content: systemPrompt }];
@@ -1586,7 +1589,7 @@ function buildAgentMessages(
 
   if (context.mainResponse) {
     finalParts.push(`<assistant_response>`);
-    finalParts.push(stripHtmlTags(context.mainResponse));
+    finalParts.push(options.preserveAssistantResponseMarkup ? context.mainResponse : stripHtmlTags(context.mainResponse));
     finalParts.push(`</assistant_response>`);
   }
 

--- a/packages/server/src/services/conversation/server-autonomous-scheduler.service.ts
+++ b/packages/server/src/services/conversation/server-autonomous-scheduler.service.ts
@@ -18,6 +18,7 @@ const SERVER_AUTONOMOUS_INITIAL_DELAY_MS = 20_000;
 const SERVER_AUTONOMOUS_POLL_MS = 60_000;
 const RECENT_CLIENT_PRESENCE_MS = 75_000;
 const OFFLINE_MAX_FOLLOWUPS = 2;
+const MAX_SERVER_AUTONOMOUS_CONCURRENT_EVALUATIONS = 2;
 
 type RawChat = {
   id: string;
@@ -279,6 +280,7 @@ export function startServerAutonomousScheduler(app: FastifyInstance) {
       const allChats = (await chats.list()) as RawChat[];
       for (const chat of allChats) {
         if (stopped) return;
+        if (runningChats.size >= MAX_SERVER_AUTONOMOUS_CONCURRENT_EVALUATIONS) break;
         if (!shouldConsiderChat(chat)) continue;
         void evaluateChat(chat);
       }

--- a/packages/server/src/services/game/game-asset-generation.ts
+++ b/packages/server/src/services/game/game-asset-generation.ts
@@ -7,7 +7,7 @@
 // `enableSpriteGeneration` is active.
 // ──────────────────────────────────────────────
 
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from "fs";
+import { existsSync, mkdirSync, readFileSync, renameSync, statSync, unlinkSync, writeFileSync } from "fs";
 import { createHash } from "crypto";
 import { logger } from "../../lib/logger.js";
 import { basename, join } from "path";
@@ -27,6 +27,7 @@ export const DEFAULT_GAME_BACKGROUND_SIZE: ImageGenerationSize = { width: 1280, 
 export const DEFAULT_GAME_PORTRAIT_SIZE: ImageGenerationSize = { width: 1024, height: 1024 };
 export const GENERATED_GAME_BACKGROUND_EXTS = ["png", "jpg", "jpeg", "webp", "avif", "gif"] as const;
 const GAME_BACKGROUND_EXT_SET = new Set<string>(GENERATED_GAME_BACKGROUND_EXTS);
+const GENERATED_BACKGROUND_MAX_INPUT_PIXELS = 32_000_000;
 const GAME_PORTRAIT_NEGATIVE_PROMPT =
   "text, letters, captions, subtitles, UI, watermark, logo, signature, speech bubble, split screen, panel, collage, contact sheet, grid, four portraits, multiple portraits, duplicated face, extra head, extra person, bad anatomy, low quality";
 const GAME_BACKGROUND_NEGATIVE_PROMPT =
@@ -64,6 +65,25 @@ type GameBackgroundImage = {
 };
 
 type ChatBackgroundMeta = Record<string, { originalName?: string; tags: string[] }>;
+
+function atomicWriteBuffer(filePath: string, buffer: Buffer): void {
+  const tmpPath = `${filePath}.${process.pid}.${Date.now()}.${Math.random().toString(36).slice(2)}.tmp`;
+  try {
+    writeFileSync(tmpPath, buffer);
+    renameSync(tmpPath, filePath);
+  } catch (err) {
+    try {
+      if (existsSync(tmpPath)) unlinkSync(tmpPath);
+    } catch {
+      /* best-effort cleanup */
+    }
+    throw err;
+  }
+}
+
+function atomicWriteText(filePath: string, value: string): void {
+  atomicWriteBuffer(filePath, Buffer.from(value, "utf-8"));
+}
 
 /** Return the extension implied by known image file signatures. */
 function detectImageExt(buffer: Buffer): string | null {
@@ -111,7 +131,10 @@ async function gameBackgroundImage(result: ImageGenResult, size: ImageGeneration
   const sharp = await getSharp();
   if (!sharp) return { buffer: input, ext: normalizeGeneratedImageExt(result, input) };
   try {
-    const buffer = await sharp(input)
+    const buffer = await sharp(input, {
+      limitInputPixels: GENERATED_BACKGROUND_MAX_INPUT_PIXELS,
+      failOn: "warning",
+    })
       .resize(size.width, size.height, { fit: "cover", position: "centre" })
       .png()
       .toBuffer();
@@ -131,9 +154,28 @@ function generatedBackgroundPath(targetDir: string, slug: string, ext: string): 
 function existingGeneratedBackgroundPath(targetDir: string, slug: string): string | null {
   for (const ext of GENERATED_GAME_BACKGROUND_EXTS) {
     const candidate = generatedBackgroundPath(targetDir, slug, ext);
-    if (existsSync(candidate)) return candidate;
+    if (isUsableGeneratedImagePath(candidate)) return candidate;
   }
   return null;
+}
+
+function existingGeneratedPortraitPath(targetDir: string, slug: string): string | null {
+  for (const ext of GENERATED_GAME_BACKGROUND_EXTS) {
+    const candidate = join(targetDir, `${slug}.${ext}`);
+    if (isUsableGeneratedImagePath(candidate)) return candidate;
+  }
+  return null;
+}
+
+function isUsableGeneratedImagePath(filePath: string): boolean {
+  try {
+    if (!existsSync(filePath)) return false;
+    const stat = statSync(filePath);
+    if (!stat.isFile() || stat.size <= 0) return false;
+    return detectImageExt(readFileSync(filePath)) !== null;
+  } catch {
+    return false;
+  }
 }
 
 function readChatBackgroundMeta(): ChatBackgroundMeta {
@@ -148,7 +190,7 @@ function readChatBackgroundMeta(): ChatBackgroundMeta {
 
 function writeChatBackgroundMeta(meta: ChatBackgroundMeta): void {
   if (!existsSync(CHAT_BACKGROUND_DIR)) mkdirSync(CHAT_BACKGROUND_DIR, { recursive: true });
-  writeFileSync(CHAT_BACKGROUND_META_PATH, JSON.stringify(meta, null, 2), "utf-8");
+  atomicWriteText(CHAT_BACKGROUND_META_PATH, JSON.stringify(meta, null, 2));
 }
 
 function chatBackgroundTags(req: ChatBackgroundGenRequest, slug: string): string[] {
@@ -221,6 +263,17 @@ export function safeGeneratedAssetSlug(name: string, opts: { maxBytes?: number; 
   const prefixBudget = Math.max(1, maxBytes - Buffer.byteLength(tail, "utf8") - 1);
   const prefix = truncateSlugByBytes(slug, prefixBudget) || "asset";
   return `${prefix}-${tail}`;
+}
+
+function npcPortraitSlug(req: NpcPortraitRequest): string {
+  const identityHash = createHash("sha256")
+    .update([req.npcName, req.appearance, req.gender ?? "", req.pronouns ?? ""].join("\n"))
+    .digest("hex")
+    .slice(0, 8);
+  return safeGeneratedAssetSlug(req.npcName, {
+    maxBytes: 160,
+    suffix: identityHash,
+  });
 }
 
 function hasExplicitNonHumanCue(value: string): boolean {
@@ -443,15 +496,15 @@ function compileGameImagePrompt(
  * Returns the avatar URL path on success, or null on failure.
  */
 export async function generateNpcPortrait(req: NpcPortraitRequest): Promise<string | null> {
-  const slug = safeName(req.npcName);
+  const slug = npcPortraitSlug(req);
   if (!slug) return null;
 
   const avatarDir = join(NPC_AVATAR_DIR, req.chatId);
-  const avatarPath = join(avatarDir, `${slug}.png`);
 
   // Skip if already exists unless the caller explicitly asked for a fresh portrait.
-  if (!req.force && existsSync(avatarPath)) {
-    return `/api/avatars/npc/${req.chatId}/${slug}.png`;
+  const existingPortraitPath = !req.force ? existingGeneratedPortraitPath(avatarDir, slug) : null;
+  if (existingPortraitPath) {
+    return `/api/avatars/npc/${req.chatId}/${basename(existingPortraitPath)}`;
   }
 
   const compiled = await buildNpcPortraitProviderPrompt(req);
@@ -487,13 +540,16 @@ export async function generateNpcPortrait(req: NpcPortraitRequest): Promise<stri
     );
 
     if (!existsSync(avatarDir)) mkdirSync(avatarDir, { recursive: true });
-    writeFileSync(avatarPath, Buffer.from(result.base64, "base64"));
+    const avatarBuffer = Buffer.from(result.base64, "base64");
+    const ext = normalizeGeneratedImageExt(result, avatarBuffer);
+    const avatarPath = join(avatarDir, `${slug}.${ext}`);
+    atomicWriteBuffer(avatarPath, avatarBuffer);
 
-    const url = `/api/avatars/npc/${req.chatId}/${slug}.png`;
+    const url = `/api/avatars/npc/${req.chatId}/${slug}.${ext}`;
     req.debugLog?.(
       "[debug/game/image-generation] NPC portrait result name=%s bytes=%d url=%s",
       req.npcName,
-      Buffer.byteLength(result.base64, "base64"),
+      avatarBuffer.byteLength,
       url,
     );
     logger.info('[game-asset-gen] Generated NPC portrait for "%s" -> %s', req.npcName, url);
@@ -800,7 +856,7 @@ export async function generateBackground(req: BackgroundGenRequest): Promise<str
     if (!existsSync(targetDir)) mkdirSync(targetDir, { recursive: true });
     const image = await gameBackgroundImage(result, size);
     const targetPath = generatedBackgroundPath(targetDir, slug, image.ext);
-    writeFileSync(targetPath, image.buffer);
+    atomicWriteBuffer(targetPath, image.buffer);
 
     // Rebuild manifest so the new tag is available immediately
     buildAssetManifest();
@@ -868,7 +924,7 @@ export async function generateChatBackground(req: ChatBackgroundGenRequest): Pro
 
     const image = await gameBackgroundImage(result, size);
     const filename = `${slug}.${image.ext}`;
-    writeFileSync(join(CHAT_BACKGROUND_DIR, filename), image.buffer);
+    atomicWriteBuffer(join(CHAT_BACKGROUND_DIR, filename), image.buffer);
 
     const meta = readChatBackgroundMeta();
     meta[filename] = {
@@ -936,7 +992,7 @@ export async function generateSceneIllustration(req: SceneIllustrationGenRequest
     if (!existsSync(targetDir)) mkdirSync(targetDir, { recursive: true });
     const image = await gameBackgroundImage(result, size);
     const targetPath = generatedBackgroundPath(targetDir, slug, image.ext);
-    writeFileSync(targetPath, image.buffer);
+    atomicWriteBuffer(targetPath, image.buffer);
     buildAssetManifest();
 
     logger.info('[game-asset-gen] Generated scene illustration "%s" -> tag: %s', slug, tag);

--- a/packages/server/src/services/generation/memory-recall-context.ts
+++ b/packages/server/src/services/generation/memory-recall-context.ts
@@ -17,6 +17,7 @@ export async function injectMemoryRecallContext({
   embeddingSource,
   contextLimit,
   sendProgress,
+  signal,
 }: {
   db: DB;
   messages: PromptMessage[];
@@ -25,6 +26,7 @@ export async function injectMemoryRecallContext({
   embeddingSource: MemoryRecallEmbeddingSource | null;
   contextLimit: number | undefined;
   sendProgress(phase: string): void;
+  signal?: AbortSignal;
 }): Promise<void> {
   sendProgress("memory_recall");
   const startedAt = Date.now();
@@ -32,7 +34,7 @@ export async function injectMemoryRecallContext({
     const lastUserMsg = [...currentInputMessages].reverse().find((message) => message.role === "user");
     if (!lastUserMsg?.content?.trim()) return;
 
-    const recalled = await recallMemories(db, lastUserMsg.content, [chatId], { embeddingSource });
+    const recalled = await recallMemories(db, lastUserMsg.content, [chatId], { embeddingSource, signal });
     if (recalled.length === 0) return;
 
     const packedRecall = packRecalledMemories(recalled, contextLimit);

--- a/packages/server/src/services/generation/text-rewrite-safety.ts
+++ b/packages/server/src/services/generation/text-rewrite-safety.ts
@@ -1,0 +1,17 @@
+function hasHtmlOrXmlTag(text: string): boolean {
+  return /<\/?[a-zA-Z][^>]*>/.test(text);
+}
+
+function hasFencedBlock(text: string): boolean {
+  return /```/.test(text);
+}
+
+export function textRewriteDropsProtectedMarkup(original: string | null | undefined, edited: string): boolean {
+  if (!original) return false;
+
+  const originalHasTags = hasHtmlOrXmlTag(original);
+  const originalHasFences = hasFencedBlock(original);
+  if (!originalHasTags && !originalHasFences) return false;
+
+  return (originalHasTags && !hasHtmlOrXmlTag(edited)) || (originalHasFences && !hasFencedBlock(edited));
+}

--- a/packages/server/src/services/image/image-generation.ts
+++ b/packages/server/src/services/image/image-generation.ts
@@ -5,7 +5,7 @@
 // based on a user's configured image_generation connection.
 
 import { createHash } from "crypto";
-import { existsSync, mkdirSync, writeFileSync } from "fs";
+import { existsSync, mkdirSync, renameSync, unlinkSync, writeFileSync } from "fs";
 import { join } from "path";
 import { inflateRawSync } from "zlib";
 import { DATA_DIR } from "../../utils/data-dir.js";
@@ -25,7 +25,7 @@ import {
 import { isImageLocalUrlsEnabled } from "../../config/runtime-config.js";
 import { generateRunPodComfyUI } from "./runpod-comfyui.service.js";
 import { logger } from "../../lib/logger.js";
-import { normalizeLoopbackUrl, safeFetch, validateOutboundUrl } from "../../utils/security.js";
+import { assertInsideDir, normalizeLoopbackUrl, safeFetch, validateOutboundUrl } from "../../utils/security.js";
 
 // sharp is an optional native module (no prebuilds on some platforms like Termux).
 // Lazy-load so the server boots even when sharp is missing; the only callers that
@@ -156,57 +156,56 @@ export async function generateImage(
   serviceHint: string,
   request: ImageGenRequest,
 ): Promise<ImageGenResult> {
-  return withImageGenerationDeadline(
-    (async () => {
-      const resolvedSource = resolveImageBackend(source, baseUrl, serviceHint, request.model);
-      const normalizedBaseUrl = normalizeImageUrl(baseUrl);
-      const scopedRequest = {
-        ...request,
-        allowLocalUrls:
-          request.allowLocalUrls ?? (await shouldAllowLocalUrlsForImageConnection(normalizedBaseUrl, resolvedSource)),
-      };
+  return withImageGenerationDeadline(request, async (signal) => {
+    const resolvedSource = resolveImageBackend(source, baseUrl, serviceHint, request.model);
+    const normalizedBaseUrl = normalizeImageUrl(baseUrl);
+    const scopedRequest = {
+      ...request,
+      signal,
+      allowLocalUrls:
+        request.allowLocalUrls ?? (await shouldAllowLocalUrlsForImageConnection(normalizedBaseUrl, resolvedSource)),
+    };
 
-      switch (resolvedSource) {
-        case "openai":
-          return generateOpenAI(normalizedBaseUrl, apiKey, scopedRequest);
-        case "nanogpt":
-          return generateNanoGPT(normalizedBaseUrl, apiKey, scopedRequest);
-        case "openrouter":
-          return generateOpenRouter(normalizedBaseUrl, apiKey, scopedRequest);
-        case "pollinations":
-          return generatePollinations(scopedRequest);
-        case "stability":
-          return generateStability(normalizedBaseUrl, apiKey, scopedRequest);
-        case "togetherai":
-          return generateTogetherAI(normalizedBaseUrl, apiKey, scopedRequest);
-        case "novelai":
-          return generateNovelAI(normalizedBaseUrl, apiKey, scopedRequest);
-        case "horde":
-          return generateHorde(normalizedBaseUrl, apiKey, scopedRequest);
-        case "xai":
-          return generateXAI(normalizedBaseUrl, apiKey, scopedRequest);
-        case "comfyui":
-          return generateComfyUI(normalizedBaseUrl, scopedRequest);
-        case "runpod_comfyui": {
-          const endpointId = scopedRequest.imageEndpointId || "";
-          if (!endpointId) {
-            throw new Error(
-              "RunPod ComfyUI requires an endpoint ID. " +
-                "Enter your RunPod endpoint ID in the Endpoint ID field (e.g. 'abc123def456').",
-            );
-          }
-          return generateRunPodComfyUI(normalizedBaseUrl, endpointId, apiKey, scopedRequest);
+    switch (resolvedSource) {
+      case "openai":
+        return generateOpenAI(normalizedBaseUrl, apiKey, scopedRequest);
+      case "nanogpt":
+        return generateNanoGPT(normalizedBaseUrl, apiKey, scopedRequest);
+      case "openrouter":
+        return generateOpenRouter(normalizedBaseUrl, apiKey, scopedRequest);
+      case "pollinations":
+        return generatePollinations(scopedRequest);
+      case "stability":
+        return generateStability(normalizedBaseUrl, apiKey, scopedRequest);
+      case "togetherai":
+        return generateTogetherAI(normalizedBaseUrl, apiKey, scopedRequest);
+      case "novelai":
+        return generateNovelAI(normalizedBaseUrl, apiKey, scopedRequest);
+      case "horde":
+        return generateHorde(normalizedBaseUrl, apiKey, scopedRequest);
+      case "xai":
+        return generateXAI(normalizedBaseUrl, apiKey, scopedRequest);
+      case "comfyui":
+        return generateComfyUI(normalizedBaseUrl, scopedRequest);
+      case "runpod_comfyui": {
+        const endpointId = scopedRequest.imageEndpointId || "";
+        if (!endpointId) {
+          throw new Error(
+            "RunPod ComfyUI requires an endpoint ID. " +
+              "Enter your RunPod endpoint ID in the Endpoint ID field (e.g. 'abc123def456').",
+          );
         }
-        case "automatic1111":
-          return generateAutomatic1111(normalizedBaseUrl, scopedRequest, serviceHint);
-        case "gemini_image":
-          return generateViaChatCompletions(normalizedBaseUrl, apiKey, scopedRequest);
-        default:
-          // Fallback: try OpenAI-compatible endpoint
-          return generateOpenAI(normalizedBaseUrl, apiKey, scopedRequest);
+        return generateRunPodComfyUI(normalizedBaseUrl, endpointId, apiKey, scopedRequest);
       }
-    })(),
-  );
+      case "automatic1111":
+        return generateAutomatic1111(normalizedBaseUrl, scopedRequest, serviceHint);
+      case "gemini_image":
+        return generateViaChatCompletions(normalizedBaseUrl, apiKey, scopedRequest);
+      default:
+        // Fallback: try OpenAI-compatible endpoint
+        return generateOpenAI(normalizedBaseUrl, apiKey, scopedRequest);
+    }
+  });
 }
 
 /**
@@ -214,11 +213,22 @@ export async function generateImage(
  * Returns the relative file path (chatId/filename).
  */
 export function saveImageToDisk(chatId: string, base64: string, ext: string): string {
-  const dir = join(GALLERY_DIR, chatId);
+  const dir = assertInsideDir(GALLERY_DIR, join(GALLERY_DIR, chatId));
   if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
   const filename = `${newId()}.${ext}`;
-  const filePath = join(dir, filename);
-  writeFileSync(filePath, Buffer.from(base64, "base64"));
+  const filePath = assertInsideDir(GALLERY_DIR, join(dir, filename));
+  const tempPath = assertInsideDir(GALLERY_DIR, `${filePath}.${process.pid}.${Date.now()}.tmp`);
+  try {
+    writeFileSync(tempPath, Buffer.from(base64, "base64"));
+    renameSync(tempPath, filePath);
+  } catch (error) {
+    try {
+      if (existsSync(tempPath)) unlinkSync(tempPath);
+    } catch {
+      /* best-effort cleanup */
+    }
+    throw error;
+  }
   return `${chatId}/${filename}`;
 }
 
@@ -236,21 +246,70 @@ class ImageGenerationDeadlineError extends Error {
   }
 }
 
-function withImageGenerationDeadline<T>(promise: Promise<T>): Promise<T> {
+function withImageGenerationDeadline<T>(
+  request: Pick<ImageGenRequest, "signal">,
+  run: (signal: AbortSignal) => Promise<T>,
+): Promise<T> {
+  const controller = new AbortController();
+  const abortFromRequest = () => controller.abort(request.signal?.reason);
+  if (request.signal?.aborted) {
+    controller.abort(request.signal.reason);
+  } else {
+    request.signal?.addEventListener("abort", abortFromRequest, { once: true });
+  }
+
   let timeout: ReturnType<typeof setTimeout> | null = null;
   const deadline = new Promise<never>((_, reject) => {
-    timeout = setTimeout(() => reject(new ImageGenerationDeadlineError(IMAGE_GEN_TIMEOUT)), IMAGE_GEN_TIMEOUT);
+    timeout = setTimeout(() => {
+      const error = new ImageGenerationDeadlineError(IMAGE_GEN_TIMEOUT);
+      controller.abort(error);
+      reject(error);
+    }, IMAGE_GEN_TIMEOUT);
     timeout.unref?.();
   });
 
-  return Promise.race([promise, deadline]).finally(() => {
+  return Promise.race([run(controller.signal), deadline]).finally(() => {
+    request.signal?.removeEventListener("abort", abortFromRequest);
     if (timeout) clearTimeout(timeout);
   });
 }
 
 function imageRequestSignal(request: Pick<ImageGenRequest, "signal">): AbortSignal {
-  const timeoutSignal = AbortSignal.timeout(IMAGE_GEN_TIMEOUT);
-  return request.signal ? AbortSignal.any([request.signal, timeoutSignal]) : timeoutSignal;
+  return request.signal ?? AbortSignal.timeout(IMAGE_GEN_TIMEOUT);
+}
+
+function throwIfAborted(signal?: AbortSignal): void {
+  if (!signal?.aborted) return;
+  if (signal.reason instanceof Error) throw signal.reason;
+  throw new Error("Image generation aborted");
+}
+
+function sleepWithAbort(ms: number, signal?: AbortSignal): Promise<void> {
+  return new Promise((resolve, reject) => {
+    try {
+      throwIfAborted(signal);
+    } catch (err) {
+      reject(err);
+      return;
+    }
+
+    let timeout: ReturnType<typeof setTimeout> | null = null;
+    const onAbort = () => {
+      if (timeout) clearTimeout(timeout);
+      signal?.removeEventListener("abort", onAbort);
+      reject(signal?.reason instanceof Error ? signal.reason : new Error("Image generation aborted"));
+    };
+    const cleanup = () => {
+      if (timeout) clearTimeout(timeout);
+      signal?.removeEventListener("abort", onAbort);
+    };
+    timeout = setTimeout(() => {
+      cleanup();
+      resolve();
+    }, ms);
+    timeout.unref?.();
+    signal?.addEventListener("abort", onAbort, { once: true });
+  });
 }
 
 function normalizeImageUrl(url: string | URL): string {
@@ -386,10 +445,10 @@ function imageDataUrlFromReference(reference: string): string {
   const trimmed = reference.trim();
   if (trimmed.startsWith("data:")) return trimmed;
   const base64 = trimmed.replace(/\s+/g, "");
-  return `data:${detectImageMimeType(base64)};base64,${base64}`;
+  return `data:${detectImageMimeType(base64) ?? "image/png"};base64,${base64}`;
 }
 
-function detectImageMimeType(base64: string): string {
+function detectImageMimeType(base64: string): string | null {
   const bytes = Buffer.from(base64.slice(0, 64), "base64");
   if (bytes[0] === 0x89 && bytes[1] === 0x50 && bytes[2] === 0x4e && bytes[3] === 0x47) return "image/png";
   if (bytes[0] === 0xff && bytes[1] === 0xd8 && bytes[2] === 0xff) return "image/jpeg";
@@ -406,14 +465,28 @@ function detectImageMimeType(base64: string): string {
     return "image/webp";
   }
   if (bytes[0] === 0x47 && bytes[1] === 0x49 && bytes[2] === 0x46) return "image/gif";
-  return "image/png";
+  if (bytes[0] === 0x42 && bytes[1] === 0x4d) return "image/bmp";
+  if (bytes[4] === 0x66 && bytes[5] === 0x74 && bytes[6] === 0x79 && bytes[7] === 0x70) {
+    const brand = bytes.subarray(8, 12).toString("ascii").toLowerCase();
+    if (brand.startsWith("avif") || brand.startsWith("avis")) return "image/avif";
+  }
+  return null;
 }
 
 function imageExtensionFromMimeType(mimeType: string): string {
   if (mimeType.includes("jpeg") || mimeType.includes("jpg")) return "jpg";
   if (mimeType.includes("webp")) return "webp";
   if (mimeType.includes("gif")) return "gif";
+  if (mimeType.includes("avif")) return "avif";
+  if (mimeType.includes("bmp")) return "bmp";
   return "png";
+}
+
+function normalizeImageMimeType(mimeType: string | null | undefined): string | null {
+  const normalized = mimeType?.split(";")[0]?.trim().toLowerCase().replace("image/jpg", "image/jpeg") ?? "";
+  return /^(?:image\/png|image\/jpeg|image\/webp|image\/gif|image\/avif|image\/bmp)$/.test(normalized)
+    ? normalized
+    : null;
 }
 
 function imageResultMetadata(
@@ -437,13 +510,19 @@ function imageResultMetadata(
   if (normalizedContentType.includes("gif") || /\.gif(?:$|[?#])/i.test(normalizedFilename)) {
     return { mimeType: "image/gif", ext: "gif" };
   }
+  if (normalizedContentType.includes("avif") || /\.avif(?:$|[?#])/i.test(normalizedFilename)) {
+    return { mimeType: "image/avif", ext: "avif" };
+  }
+  if (normalizedContentType.includes("bmp") || /\.bmp(?:$|[?#])/i.test(normalizedFilename)) {
+    return { mimeType: "image/bmp", ext: "bmp" };
+  }
 
-  const detectedMimeType = detectImageMimeType(base64);
+  const detectedMimeType = detectImageMimeType(base64) ?? normalizeImageMimeType(contentType) ?? "image/png";
   return { mimeType: detectedMimeType, ext: imageExtensionFromMimeType(detectedMimeType) };
 }
 
 function decodeImageDataUrl(imageUrl: string): ImageGenResult {
-  const match = imageUrl.trim().match(/^data:(image\/(?:png|jpe?g|webp|gif));base64,([\s\S]+)$/i);
+  const match = imageUrl.trim().match(/^data:(image\/(?:png|jpe?g|webp|gif|avif|bmp));base64,([\s\S]+)$/i);
   if (!match) {
     throw new Error("Generated image data URL was not a supported image format");
   }
@@ -529,7 +608,7 @@ function openAIReferenceImages(request: ImageGenRequest): string[] {
 }
 
 function decodeReferenceImage(reference: string): { base64: string; mimeType: string; ext: string } {
-  const dataUrlMatch = reference.trim().match(/^data:(image\/(?:png|jpe?g|webp|gif));base64,([\s\S]+)$/i);
+  const dataUrlMatch = reference.trim().match(/^data:(image\/(?:png|jpe?g|webp|gif|avif|bmp));base64,([\s\S]+)$/i);
   if (dataUrlMatch) {
     const mimeType = dataUrlMatch[1]!.toLowerCase().replace("image/jpg", "image/jpeg");
     const base64 = dataUrlMatch[2]!.replace(/\s+/g, "");
@@ -537,7 +616,7 @@ function decodeReferenceImage(reference: string): { base64: string; mimeType: st
   }
 
   const base64 = reference.replace(/\s+/g, "");
-  const mimeType = detectImageMimeType(base64);
+  const mimeType = detectImageMimeType(base64) ?? "image/png";
   return { base64, mimeType, ext: imageExtensionFromMimeType(mimeType) };
 }
 
@@ -592,13 +671,17 @@ async function downloadImageUrl(
   const base64 = Buffer.from(arrayBuffer).toString("base64");
 
   const contentType = imgResp.headers.get("content-type") ?? "";
-  let mimeType = detectImageMimeType(base64);
+  let mimeType = detectImageMimeType(base64) ?? normalizeImageMimeType(contentType) ?? "image/png";
   if (contentType.includes("jpeg") || contentType.includes("jpg") || normalizedImageUrl.match(/\.jpe?g/i)) {
     mimeType = "image/jpeg";
   } else if (contentType.includes("webp") || normalizedImageUrl.match(/\.webp/i)) {
     mimeType = "image/webp";
   } else if (contentType.includes("gif") || normalizedImageUrl.match(/\.gif/i)) {
     mimeType = "image/gif";
+  } else if (contentType.includes("avif") || normalizedImageUrl.match(/\.avif/i)) {
+    mimeType = "image/avif";
+  } else if (contentType.includes("bmp") || normalizedImageUrl.match(/\.bmp/i)) {
+    mimeType = "image/bmp";
   }
 
   return { base64, mimeType, ext: imageExtensionFromMimeType(mimeType) };
@@ -944,7 +1027,7 @@ async function generateHorde(baseUrl: string, apiKey: string, request: ImageGenR
   if (image.startsWith("data:")) return decodeImageDataUrl(image);
   if (/^https?:\/\//i.test(image)) return downloadImageUrl(image, request.allowLocalUrls, request.signal);
 
-  const mimeType = detectImageMimeType(image);
+  const mimeType = detectImageMimeType(image) ?? "image/png";
   return { base64: image, mimeType, ext: imageExtensionFromMimeType(mimeType) };
 }
 
@@ -1037,8 +1120,9 @@ async function generateStability(baseUrl: string, apiKey: string, request: Image
   formData.append("prompt", request.prompt);
   if (request.negativePrompt) formData.append("negative_prompt", request.negativePrompt);
   if (endpoint.model) formData.append("model", endpoint.model);
+  const hasReference = Boolean(request.referenceImage || request.referenceImages?.length);
   const aspectRatio = stabilityAspectRatio(request.width, request.height);
-  if (aspectRatio) formData.append("aspect_ratio", aspectRatio);
+  if (aspectRatio && !hasReference) formData.append("aspect_ratio", aspectRatio);
   if (request.referenceImage) {
     formData.append(
       "image",
@@ -1576,17 +1660,26 @@ async function generateOpenRouter(baseUrl: string, apiKey: string, request: Imag
   const contentType = resp.headers.get("content-type") ?? "";
   const buffer = Buffer.from(await resp.arrayBuffer());
   const isImageContentType = contentType.startsWith("image/");
+  const isAvifLike =
+    buffer.length >= 12 &&
+    buffer[4] === 0x66 &&
+    buffer[5] === 0x74 &&
+    buffer[6] === 0x79 &&
+    buffer[7] === 0x70 &&
+    ["avif", "avis"].some((brand) => buffer.subarray(8, 12).toString("ascii").toLowerCase().startsWith(brand));
   const looksLikeImageBytes =
     buffer.length >= 4 &&
     ((buffer[0] === 0x89 && buffer[1] === 0x50 && buffer[2] === 0x4e && buffer[3] === 0x47) || // PNG
       (buffer[0] === 0xff && buffer[1] === 0xd8 && buffer[2] === 0xff) || // JPEG
       (buffer[0] === 0x47 && buffer[1] === 0x49 && buffer[2] === 0x46) || // GIF
+      (buffer[0] === 0x42 && buffer[1] === 0x4d) || // BMP
+      isAvifLike ||
       (buffer[0] === 0x52 && buffer[1] === 0x49 && buffer[2] === 0x46 && buffer[3] === 0x46)); // RIFF/WEBP
 
   if (isImageContentType || looksLikeImageBytes) {
     const base64 = buffer.toString("base64");
     let mimeType = detectImageMimeType(base64);
-    if (!mimeType && contentType.startsWith("image/")) mimeType = contentType.split(";")[0]!.trim();
+    if (!mimeType) mimeType = normalizeImageMimeType(contentType);
     if (!mimeType) mimeType = "image/png";
     return { base64, mimeType, ext: imageExtensionFromMimeType(mimeType) };
   }
@@ -1742,6 +1835,62 @@ interface ComfyUiOutputFile {
 interface ComfyUiNodeOutput {
   images?: ComfyUiOutputFile[];
   gifs?: ComfyUiOutputFile[];
+}
+
+interface ComfyUiHistoryEntry {
+  outputs?: Record<string, ComfyUiNodeOutput>;
+  status?: Record<string, unknown>;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === "object" && !Array.isArray(value);
+}
+
+function collectComfyUiErrorFragments(value: unknown, fragments: string[] = []): string[] {
+  if (typeof value === "string") {
+    const clean = value.trim();
+    if (clean) fragments.push(clean);
+    return fragments;
+  }
+  if (typeof value === "number" || typeof value === "boolean") {
+    fragments.push(String(value));
+    return fragments;
+  }
+  if (Array.isArray(value)) {
+    for (const entry of value) collectComfyUiErrorFragments(entry, fragments);
+    return fragments;
+  }
+  if (!isRecord(value)) return fragments;
+
+  for (const key of ["exception_message", "message", "error", "details", "traceback"]) {
+    collectComfyUiErrorFragments(value[key], fragments);
+  }
+  collectComfyUiErrorFragments(value.node_errors, fragments);
+  return fragments;
+}
+
+function formatComfyUiError(value: unknown): string {
+  const fragments = collectComfyUiErrorFragments(value);
+  if (fragments.length > 0) return sanitizeErrorText(fragments.join("; "));
+  try {
+    const json = JSON.stringify(value);
+    return typeof json === "string" ? sanitizeErrorText(json) : "";
+  } catch {
+    return "";
+  }
+}
+
+function getComfyUiStatusError(status: unknown): string | null {
+  if (!isRecord(status)) return null;
+  const statusStr = typeof status.status_str === "string" ? status.status_str.toLowerCase() : "";
+  if (statusStr !== "error") return null;
+  return formatComfyUiError(status.messages ?? status);
+}
+
+function isComfyUiStatusComplete(status: unknown): boolean {
+  if (!isRecord(status)) return false;
+  const statusStr = typeof status.status_str === "string" ? status.status_str.toLowerCase() : "";
+  return status.completed === true || statusStr === "success";
 }
 
 function randomSeed(): number {
@@ -1921,21 +2070,35 @@ async function generateComfyUI(baseUrl: string, request: ImageGenRequest): Promi
     throw new Error(`ComfyUI queue failed (${queueResp.status}): ${sanitizeErrorText(errText)}`);
   }
 
-  const { prompt_id } = (await queueResp.json()) as { prompt_id: string };
+  const queueJson = (await queueResp.json().catch(() => null)) as Record<string, unknown> | null;
+  const promptId = typeof queueJson?.prompt_id === "string" ? queueJson.prompt_id.trim() : "";
+  if (!promptId) {
+    const details = formatComfyUiError(queueJson);
+    throw new Error(`ComfyUI queue did not return a prompt_id${details ? `: ${details}` : ""}`);
+  }
 
   // Poll for completion. Default is 5 minutes to match shared image request timeout.
-  for (let i = 0; i < COMFYUI_GEN_TIMEOUT_SECONDS; i++) {
-    await new Promise((r) => setTimeout(r, 1000));
+  const pollTimeoutMs = Math.max(1000, Math.min(COMFYUI_GEN_TIMEOUT_SECONDS * 1000, IMAGE_GEN_TIMEOUT - 1000));
+  const pollStartedAt = Date.now();
+  while (Date.now() - pollStartedAt < pollTimeoutMs) {
+    await sleepWithAbort(1000, request.signal);
 
-    const historyResp = await localImageBackendFetch(`${base}/history/${prompt_id}`, {
+    const historyResp = await localImageBackendFetch(`${base}/history/${promptId}`, {
       signal: imageRequestSignal(request),
     });
     if (!historyResp.ok) continue;
 
-    const history = (await historyResp.json()) as Record<string, { outputs?: Record<string, ComfyUiNodeOutput> }>;
+    const history = (await historyResp.json()) as Record<string, ComfyUiHistoryEntry>;
 
-    const entry = history[prompt_id];
-    if (!entry?.outputs) continue;
+    const entry = history[promptId];
+    const statusError = getComfyUiStatusError(entry?.status);
+    if (statusError) throw new Error(`ComfyUI workflow failed: ${statusError}`);
+    if (!entry?.outputs) {
+      if (isComfyUiStatusComplete(entry?.status)) {
+        throw new Error("ComfyUI workflow completed without image outputs.");
+      }
+      continue;
+    }
 
     // Video Helper Suite's Video Combine reports animated WebP files as "gifs".
     for (const outputKey of COMFYUI_OUTPUT_FILE_KEYS) {
@@ -1963,9 +2126,13 @@ async function generateComfyUI(baseUrl: string, request: ImageGenRequest): Promi
         }
       }
     }
+
+    if (isComfyUiStatusComplete(entry.status)) {
+      throw new Error("ComfyUI workflow completed without image outputs.");
+    }
   }
 
-  throw new Error(`ComfyUI generation timed out after ${COMFYUI_GEN_TIMEOUT_SECONDS} seconds`);
+  throw new Error(`ComfyUI generation timed out after ${Math.round(pollTimeoutMs / 1000)} seconds`);
 }
 
 // ── AUTOMATIC1111 / SD Web UI / Forge ──

--- a/packages/server/src/services/llm/base-provider.ts
+++ b/packages/server/src/services/llm/base-provider.ts
@@ -7,15 +7,16 @@ import { requestHeadersWithIdentityEncoding, safeFetch, type SafeFetchOptions } 
 
 /**
  * Shared undici Agent with a 5-minute headers timeout (time to first byte)
- * and no body timeout — prevents indefinite hangs while still allowing
- * long-running streaming responses to complete.
+ * and a finite inter-chunk body timeout to prevent half-open streams from
+ * hanging indefinitely while still allowing long-running healthy streams.
  */
 const LLM_HEADERS_TIMEOUT = 5 * 60 * 1000; // 5 minutes
-const llmAgentOptions = { bodyTimeout: 0, headersTimeout: LLM_HEADERS_TIMEOUT };
+const LLM_BODY_TIMEOUT = 120 * 1000; // 2 minutes between body chunks
+const llmAgentOptions = { bodyTimeout: LLM_BODY_TIMEOUT, headersTimeout: LLM_HEADERS_TIMEOUT };
 
 /**
  * Drop-in replacement for `fetch()` that uses a custom undici dispatcher
- * with no body/headers timeout. Use this for all outgoing LLM requests.
+ * with provider-oriented timeout settings. Use this for all outgoing LLM requests.
  */
 export function llmFetch(
   url: string | URL,
@@ -150,6 +151,8 @@ export interface LLMUsage {
   acceptedPredictionTokens?: number;
   /** Predicted output tokens rejected by the model but still counted in output usage. */
   rejectedPredictionTokens?: number;
+  /** Provider-reported stream finish reason when usage is returned from a streaming generator. */
+  finishReason?: "stop" | "tool_calls" | "length" | string;
 }
 
 /** Result from a non-streaming chat call that may include tool calls */
@@ -614,16 +617,31 @@ export abstract class BaseLLMProvider {
     let content = "";
     const useStream = options.stream ?? !!options.onToken;
     const gen = this.chat(messages, { ...options, stream: useStream });
-    let result = await gen.next();
+    const returnPartialOnStreamFailure = (error: unknown): ChatCompletionResult => {
+      if (!content) throw error;
+      logger.warn(error, "LLM stream failed after partial content; returning partial completion");
+      return { content, toolCalls: [], finishReason: options.signal?.aborted ? "abort" : "error", usage: undefined };
+    };
+
+    let result: IteratorResult<string, LLMUsage | void>;
+    try {
+      result = await gen.next();
+    } catch (error) {
+      return returnPartialOnStreamFailure(error);
+    }
     while (!result.done) {
       content += result.value;
       if (options.onToken) {
         await options.onToken(result.value);
       }
-      result = await gen.next();
+      try {
+        result = await gen.next();
+      } catch (error) {
+        return returnPartialOnStreamFailure(error);
+      }
     }
     const usage = result.value || undefined;
-    return { content, toolCalls: [], finishReason: "stop", usage };
+    return { content, toolCalls: [], finishReason: usage?.finishReason ?? "stop", usage };
   }
 
   /**
@@ -631,8 +649,9 @@ export abstract class BaseLLMProvider {
    * Default implementation calls the OpenAI-compatible /embeddings endpoint.
    * Override in provider subclasses that use a different API shape.
    */
-  async embed(texts: string[], model: string): Promise<number[][]> {
+  async embed(texts: string[], model: string, signal?: AbortSignal): Promise<number[][]> {
     const timeoutMs = getEmbeddingRequestTimeoutMs();
+    const timeoutSignal = AbortSignal.timeout(timeoutMs);
     const headers: Record<string, string> = {
       "Content-Type": "application/json",
       Authorization: `Bearer ${this.apiKey}`,
@@ -645,8 +664,8 @@ export abstract class BaseLLMProvider {
       method: "POST",
       headers,
       body: JSON.stringify({ input: texts, model }),
-      signal: AbortSignal.timeout(timeoutMs),
-      agentOptions: { bodyTimeout: 0, headersTimeout: timeoutMs },
+      signal: signal ? AbortSignal.any([signal, timeoutSignal]) : timeoutSignal,
+      agentOptions: { bodyTimeout: timeoutMs, headersTimeout: timeoutMs },
       bufferResponse: true,
     });
     if (!res.ok) {
@@ -710,8 +729,13 @@ function isPlainRecord(value: unknown): value is Record<string, unknown> {
   return !!value && typeof value === "object" && !Array.isArray(value);
 }
 
+function isUnsafeRequestBodyKey(key: string): boolean {
+  return key === "__proto__" || key === "constructor" || key === "prototype";
+}
+
 function deepMergeRequestBody(target: Record<string, unknown>, source: Record<string, unknown>): void {
   for (const [key, value] of Object.entries(source)) {
+    if (isUnsafeRequestBodyKey(key)) continue;
     if (value === undefined) continue;
     const current = target[key];
     if (isPlainRecord(current) && isPlainRecord(value)) {

--- a/packages/server/src/services/llm/providers/anthropic.provider.ts
+++ b/packages/server/src/services/llm/providers/anthropic.provider.ts
@@ -88,6 +88,12 @@ interface AnthropicMessageResponse {
   usage?: { input_tokens?: number; output_tokens?: number };
 }
 
+function normalizeAnthropicFinishReason(reason: string | null | undefined): string {
+  if (reason === "max_tokens") return "length";
+  if (reason === "tool_use") return "tool_calls";
+  return reason ?? "stop";
+}
+
 function isRecord(value: unknown): value is Record<string, unknown> {
   return !!value && typeof value === "object" && !Array.isArray(value);
 }
@@ -354,7 +360,7 @@ export class AnthropicProvider extends BaseLLMProvider {
     return {
       content: text || null,
       toolCalls,
-      finishReason: toolCalls.length > 0 ? "tool_calls" : (json.stop_reason ?? "stop"),
+      finishReason: toolCalls.length > 0 ? "tool_calls" : normalizeAnthropicFinishReason(json.stop_reason),
       usage:
         typeof json.usage?.input_tokens === "number" && typeof json.usage.output_tokens === "number"
           ? {
@@ -505,11 +511,15 @@ export class AnthropicProvider extends BaseLLMProvider {
         usage?: { input_tokens: number; output_tokens: number };
       };
       // Extract thinking content if present
-      const thinkingBlock = json.content.find((c) => c.type === "thinking");
-      if (thinkingBlock?.thinking && options.onThinking) {
-        options.onThinking(thinkingBlock.thinking);
+      for (const block of json.content) {
+        if (block.type === "thinking" && block.thinking && options.onThinking) {
+          options.onThinking(block.thinking);
+        }
       }
-      yield json.content.find((c) => c.type === "text")?.text ?? "";
+      yield json.content
+        .filter((block) => block.type === "text" && typeof block.text === "string")
+        .map((block) => block.text)
+        .join("");
       if (json.usage) {
         return {
           promptTokens: json.usage.input_tokens,
@@ -538,27 +548,27 @@ export class AnthropicProvider extends BaseLLMProvider {
     let currentBlockType = "text"; // track whether we're in a thinking or text block
     let inputTokens = 0;
     let outputTokens = 0;
+    let finishReason = "stop";
+    let emittedText = false;
 
     try {
       while (true) {
         const { done, value } = await reader.read();
-        if (done) break;
-
-        buffer += decoder.decode(value, { stream: true });
-        const lines = buffer.split("\n");
-        buffer = lines.pop() ?? "";
+        buffer += done ? decoder.decode() : decoder.decode(value, { stream: true });
+        const lines = buffer.split(/\r?\n/);
+        buffer = done ? "" : (lines.pop() ?? "");
 
         for (const line of lines) {
           const trimmed = line.trim();
-          if (!trimmed.startsWith("data: ")) continue;
-          const data = trimmed.slice(6);
+          if (!trimmed.startsWith("data:")) continue;
+          const data = trimmed.slice(5).trimStart();
 
           let event: {
             type: string;
             error?: unknown;
             message?: { usage?: { input_tokens: number; output_tokens: number } };
             content_block?: { type: string };
-            delta?: { type: string; text?: string; thinking?: string };
+            delta?: { type: string; text?: string; thinking?: string; stop_reason?: string | null };
             usage?: { output_tokens: number };
           };
           try {
@@ -580,6 +590,9 @@ export class AnthropicProvider extends BaseLLMProvider {
           if (event.type === "message_delta" && event.usage) {
             outputTokens = event.usage.output_tokens;
           }
+          if (event.type === "message_delta" && typeof event.delta?.stop_reason === "string") {
+            finishReason = normalizeAnthropicFinishReason(event.delta.stop_reason);
+          }
           // Track block type (thinking vs text)
           if (event.type === "content_block_start" && event.content_block) {
             currentBlockType = event.content_block.type;
@@ -588,30 +601,44 @@ export class AnthropicProvider extends BaseLLMProvider {
             if (currentBlockType === "thinking" && event.delta?.thinking && options.onThinking) {
               options.onThinking(event.delta.thinking);
             } else if (event.delta?.text) {
+              emittedText = true;
               yield event.delta.text;
             }
           }
           if (event.type === "message_stop") {
+            if (!emittedText && !options.signal?.aborted) {
+              throw new Error(`Anthropic stream completed without text (finish reason: ${finishReason})`);
+            }
             if (inputTokens || outputTokens) {
               return {
                 promptTokens: inputTokens,
                 completionTokens: outputTokens,
                 totalTokens: inputTokens + outputTokens,
+                finishReason,
               };
             }
             return;
           }
         }
+        if (done) break;
       }
     } finally {
       if (options.signal) options.signal.removeEventListener("abort", onAbort);
     }
+    if (!emittedText && !options.signal?.aborted) {
+      throw new Error(`Anthropic stream completed without text (finish reason: ${finishReason})`);
+    }
     if (inputTokens || outputTokens) {
-      return { promptTokens: inputTokens, completionTokens: outputTokens, totalTokens: inputTokens + outputTokens };
+      return {
+        promptTokens: inputTokens,
+        completionTokens: outputTokens,
+        totalTokens: inputTokens + outputTokens,
+        finishReason,
+      };
     }
   }
 
-  override async embed(_texts: string[], _model: string): Promise<number[][]> {
+  override async embed(_texts: string[], _model: string, _signal?: AbortSignal): Promise<number[][]> {
     throw new Error(
       "Anthropic connections do not support embeddings through Marinara's OpenAI-compatible /embeddings path. Configure a dedicated OpenAI-compatible or local embedding connection.",
     );

--- a/packages/server/src/services/llm/providers/claude-subscription.provider.ts
+++ b/packages/server/src/services/llm/providers/claude-subscription.provider.ts
@@ -659,7 +659,7 @@ export class ClaudeSubscriptionProvider extends BaseLLMProvider {
    * Embeddings are not exposed by the Claude Agent SDK. Surface a clear error
    * so callers can route embedding work to a separate connection.
    */
-  override async embed(_texts: string[], _model: string): Promise<number[][]> {
+  override async embed(_texts: string[], _model: string, _signal?: AbortSignal): Promise<number[][]> {
     throw new Error(
       "The Claude (Subscription) provider does not support embeddings. Configure a separate embedding connection (OpenAI, Google, or local).",
     );

--- a/packages/server/src/services/llm/providers/google.provider.ts
+++ b/packages/server/src/services/llm/providers/google.provider.ts
@@ -389,6 +389,13 @@ function geminiUsage(usage?: GeminiUsageMetadata): LLMUsage | undefined {
   };
 }
 
+function normalizeGeminiFinishReason(reason: string | null | undefined): string {
+  const normalized = typeof reason === "string" ? reason.trim().toUpperCase() : "";
+  if (normalized === "MAX_TOKENS") return "length";
+  if (normalized === "STOP") return "stop";
+  return reason ?? "stop";
+}
+
 /**
  * Handles Google Gemini API (generateContent / streamGenerateContent).
  */
@@ -516,7 +523,7 @@ export class GoogleProvider extends BaseLLMProvider {
     return {
       content: content || null,
       toolCalls,
-      finishReason: toolCalls.length > 0 ? "tool_calls" : (candidate?.finishReason ?? "stop"),
+      finishReason: toolCalls.length > 0 ? "tool_calls" : normalizeGeminiFinishReason(candidate?.finishReason),
       usage: geminiUsage(json.usageMetadata),
     };
   }
@@ -715,19 +722,17 @@ export class GoogleProvider extends BaseLLMProvider {
     try {
       while (true) {
         const { done, value } = await reader.read();
-        if (done) break;
+        buffer += done ? decoder.decode() : decoder.decode(value, { stream: true });
 
-        buffer += decoder.decode(value, { stream: true });
-
-        const lines = buffer.split("\n");
-        buffer = lines.pop() ?? "";
+        const lines = buffer.split(/\r?\n/);
+        buffer = done ? "" : (lines.pop() ?? "");
 
         for (const line of lines) {
           const trimmed = line.trim();
           if (!trimmed) continue;
 
-          if (!trimmed.startsWith("data: ")) continue;
-          const data = trimmed.slice(6);
+          if (!trimmed.startsWith("data:")) continue;
+          const data = trimmed.slice(5).trimStart();
 
           let parsed: GeminiResponsePayload;
           try {
@@ -778,6 +783,7 @@ export class GoogleProvider extends BaseLLMProvider {
             }
           }
         }
+        if (done) break;
       }
     } finally {
       if (options.signal) options.signal.removeEventListener("abort", onAbort);
@@ -801,10 +807,10 @@ export class GoogleProvider extends BaseLLMProvider {
       options.onResponseParts(responseParts);
     }
 
-    if (streamUsage) return streamUsage;
+    if (streamUsage) return { ...streamUsage, finishReason: normalizeGeminiFinishReason(lastFinishReason) };
   }
 
-  override async embed(_texts: string[], _model: string): Promise<number[][]> {
+  override async embed(_texts: string[], _model: string, _signal?: AbortSignal): Promise<number[][]> {
     const label = this.providerKind === "google_vertex" ? "Vertex AI Gemini" : "Google Gemini";
     throw new Error(
       `${label} connections do not support embeddings through Marinara's OpenAI-compatible /embeddings path. Configure a dedicated OpenAI-compatible or local embedding connection.`,

--- a/packages/server/src/services/llm/providers/local-sidecar.provider.ts
+++ b/packages/server/src/services/llm/providers/local-sidecar.provider.ts
@@ -92,7 +92,7 @@ export class LocalSidecarProvider extends BaseLLMProvider {
     });
   }
 
-  async embed(texts: string[], _model: string): Promise<number[][]> {
+  async embed(texts: string[], _model: string, signal?: AbortSignal): Promise<number[][]> {
     if (sidecarModelService.getResolvedBackend() === "mlx") {
       throw new Error("Local sidecar embeddings are not supported on the MLX backend.");
     }
@@ -106,21 +106,27 @@ export class LocalSidecarProvider extends BaseLLMProvider {
     const requestModel = this.getRequestModel();
 
     try {
-      return await this.requestOpenAIEmbeddings(baseUrl, texts, requestModel);
+      return await this.requestOpenAIEmbeddings(baseUrl, texts, requestModel, signal);
     } catch (error) {
       if (!isNotFoundError(error)) throw error;
-      return this.requestLegacyEmbeddings(baseUrl, texts);
+      return this.requestLegacyEmbeddings(baseUrl, texts, signal);
     }
   }
 
-  private async requestOpenAIEmbeddings(baseUrl: string, texts: string[], model: string): Promise<number[][]> {
+  private async requestOpenAIEmbeddings(
+    baseUrl: string,
+    texts: string[],
+    model: string,
+    signal?: AbortSignal,
+  ): Promise<number[][]> {
     const timeoutMs = getEmbeddingRequestTimeoutMs();
+    const timeoutSignal = AbortSignal.timeout(timeoutMs);
     const response = await llmFetch(`${baseUrl}/v1/embeddings`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ input: texts, model }),
-      signal: AbortSignal.timeout(timeoutMs),
-      agentOptions: { bodyTimeout: 0, headersTimeout: timeoutMs },
+      signal: signal ? AbortSignal.any([signal, timeoutSignal]) : timeoutSignal,
+      agentOptions: { bodyTimeout: timeoutMs, headersTimeout: timeoutMs },
       bufferResponse: true,
     });
     if (!response.ok) {
@@ -130,16 +136,17 @@ export class LocalSidecarProvider extends BaseLLMProvider {
     return parseEmbeddingResponse(await response.json());
   }
 
-  private async requestLegacyEmbeddings(baseUrl: string, texts: string[]): Promise<number[][]> {
+  private async requestLegacyEmbeddings(baseUrl: string, texts: string[], signal?: AbortSignal): Promise<number[][]> {
     const timeoutMs = getEmbeddingRequestTimeoutMs();
     const embeddings: number[][] = [];
     for (const text of texts) {
+      const timeoutSignal = AbortSignal.timeout(timeoutMs);
       const response = await llmFetch(`${baseUrl}/embedding`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ content: text }),
-        signal: AbortSignal.timeout(timeoutMs),
-        agentOptions: { bodyTimeout: 0, headersTimeout: timeoutMs },
+        signal: signal ? AbortSignal.any([signal, timeoutSignal]) : timeoutSignal,
+        agentOptions: { bodyTimeout: timeoutMs, headersTimeout: timeoutMs },
         bufferResponse: true,
       });
       if (!response.ok) {

--- a/packages/server/src/services/llm/providers/openai.provider.ts
+++ b/packages/server/src/services/llm/providers/openai.provider.ts
@@ -997,11 +997,10 @@ export class OpenAIProvider extends BaseLLMProvider {
     try {
       while (true) {
         const { done, value } = await reader.read();
-        if (done) break;
 
-        buffer += decoder.decode(value, { stream: true });
-        const lines = buffer.split("\n");
-        buffer = lines.pop() ?? "";
+        buffer += done ? decoder.decode() : decoder.decode(value, { stream: true });
+        const lines = buffer.split(/\r?\n/);
+        buffer = done ? "" : (lines.pop() ?? "");
 
         for (const line of lines) {
           const trimmed = line.trim();
@@ -1052,6 +1051,7 @@ export class OpenAIProvider extends BaseLLMProvider {
             yield delta.refusal;
           }
         }
+        if (done) break;
       }
     } finally {
       if (options.signal) options.signal.removeEventListener("abort", onAbort);
@@ -1230,6 +1230,15 @@ export class OpenAIProvider extends BaseLLMProvider {
     const reader = response.body?.getReader();
     if (!reader) throw new Error("No response body");
 
+    const onAbort = () => reader.cancel().catch(() => {});
+    if (options.signal) {
+      if (options.signal.aborted) {
+        await reader.cancel().catch(() => {});
+        return { content: null, toolCalls: [], finishReason: "abort", usage: undefined };
+      }
+      options.signal.addEventListener("abort", onAbort, { once: true });
+    }
+
     const decoder = new TextDecoder();
     let buffer = "";
     let content = "";
@@ -1243,118 +1252,122 @@ export class OpenAIProvider extends BaseLLMProvider {
       { id: string; type: "function"; function: { name: string; arguments: string } }
     >();
 
-    while (true) {
-      const { done, value } = await reader.read();
-      if (done) break;
+    try {
+      while (true) {
+        const { done, value } = await reader.read();
 
-      buffer += decoder.decode(value, { stream: true });
-      const lines = buffer.split("\n");
-      buffer = lines.pop() ?? "";
+        buffer += done ? decoder.decode() : decoder.decode(value, { stream: true });
+        const lines = buffer.split(/\r?\n/);
+        buffer = done ? "" : (lines.pop() ?? "");
 
-      for (const line of lines) {
-        const trimmed = line.trim();
-        const data = OpenAIProvider.extractSseData(trimmed);
-        if (data == null) continue;
-        if (data === "[DONE]") break;
+        for (const line of lines) {
+          const trimmed = line.trim();
+          const data = OpenAIProvider.extractSseData(trimmed);
+          if (data == null) continue;
+          if (data === "[DONE]") break;
 
-        let parsed: Record<string, unknown>;
-        try {
-          parsed = JSON.parse(data) as Record<string, unknown>;
-        } catch {
-          // Skip malformed JSON lines
-          continue;
-        }
-
-        if (parsed.usage) {
-          streamUsage = OpenAIProvider.extractChatCompletionsUsage(parsed.usage as ChatCompletionsUsagePayload);
-        }
-
-        if (!Array.isArray(parsed.choices)) {
-          const providerMessage = OpenAIProvider.extractProviderErrorMessage(parsed);
-          if (providerMessage) {
-            throw new Error(
-              `OpenAI chatComplete() stream response missing choices: ${sanitizeApiError(providerMessage)}`,
-            );
+          let parsed: Record<string, unknown>;
+          try {
+            parsed = JSON.parse(data) as Record<string, unknown>;
+          } catch {
+            // Skip malformed JSON lines
+            continue;
           }
-          continue;
-        }
 
-        const choice = (
-          parsed.choices as Array<{
-            delta: Record<string, unknown> & {
-              content?: string | unknown[];
-              tool_calls?: unknown;
-            };
-            finish_reason?: string;
-          }>
-        )[0];
-        if (!choice) continue;
-
-        if (choice.finish_reason) {
-          finishReason = choice.finish_reason;
-        }
-
-        const delta = choice.delta;
-        OpenAIProvider.appendReasoningMetadata(reasoningMetadata, delta);
-
-        // Stream reasoning/thinking
-        const reasoning = OpenAIProvider.extractReasoning(delta);
-        if (reasoning && options.onThinking) {
-          options.onThinking(reasoning);
-        }
-
-        // Handle OpenRouter content block arrays (Anthropic-style)
-        const blocks = OpenAIProvider.extractContentBlocks(delta?.content);
-        if (blocks) {
-          if (!reasoning && blocks.thinking && options.onThinking) options.onThinking(blocks.thinking);
-          if (blocks.text) {
-            content += blocks.text;
-            await options.onToken?.(blocks.text);
+          if (parsed.usage) {
+            streamUsage = OpenAIProvider.extractChatCompletionsUsage(parsed.usage as ChatCompletionsUsagePayload);
           }
-        } else if (delta?.content) {
-          content += delta.content as string;
-          await options.onToken?.(delta.content as string);
-        } else if (typeof delta?.refusal === "string" && delta.refusal) {
-          content += delta.refusal;
-          await options.onToken?.(delta.refusal);
-        }
 
-        // Accumulate tool call deltas. Some OpenAI-compatible backends (including llama.cpp)
-        // may stream tool calls as { name, arguments } instead of { function: { ... } }.
-        if (Array.isArray(delta?.tool_calls)) {
-          for (const [fallbackIndex, rawToolCall] of delta.tool_calls.entries()) {
-            const tc = OpenAIProvider.asRecord(rawToolCall);
-            if (!tc) continue;
-            const fn = OpenAIProvider.asRecord(tc.function) ?? tc;
-            const index = typeof tc.index === "number" ? tc.index : fallbackIndex;
-            const nameDelta = typeof fn.name === "string" ? fn.name : typeof tc.name === "string" ? tc.name : "";
-            const argumentDelta =
-              typeof fn.arguments === "string"
-                ? fn.arguments
-                : typeof tc.arguments === "string"
-                  ? tc.arguments
-                  : fn.arguments !== undefined || tc.arguments !== undefined
-                    ? OpenAIProvider.stringifyToolArguments(fn.arguments ?? tc.arguments)
-                    : "";
-            const existing = toolCallsMap.get(index);
-            if (!existing) {
-              toolCallsMap.set(index, {
-                id: typeof tc.id === "string" ? tc.id : typeof tc.call_id === "string" ? tc.call_id : "",
-                type: "function",
-                function: {
-                  name: nameDelta,
-                  arguments: argumentDelta,
-                },
-              });
-            } else {
-              if (typeof tc.id === "string" && tc.id) existing.id = tc.id;
-              else if (typeof tc.call_id === "string" && tc.call_id) existing.id = tc.call_id;
-              if (nameDelta) existing.function.name += nameDelta;
-              if (argumentDelta) existing.function.arguments += argumentDelta;
+          if (!Array.isArray(parsed.choices)) {
+            const providerMessage = OpenAIProvider.extractProviderErrorMessage(parsed);
+            if (providerMessage) {
+              throw new Error(
+                `OpenAI chatComplete() stream response missing choices: ${sanitizeApiError(providerMessage)}`,
+              );
+            }
+            continue;
+          }
+
+          const choice = (
+            parsed.choices as Array<{
+              delta: Record<string, unknown> & {
+                content?: string | unknown[];
+                tool_calls?: unknown;
+              };
+              finish_reason?: string;
+            }>
+          )[0];
+          if (!choice) continue;
+
+          if (choice.finish_reason) {
+            finishReason = choice.finish_reason;
+          }
+
+          const delta = choice.delta;
+          OpenAIProvider.appendReasoningMetadata(reasoningMetadata, delta);
+
+          // Stream reasoning/thinking
+          const reasoning = OpenAIProvider.extractReasoning(delta);
+          if (reasoning && options.onThinking) {
+            options.onThinking(reasoning);
+          }
+
+          // Handle OpenRouter content block arrays (Anthropic-style)
+          const blocks = OpenAIProvider.extractContentBlocks(delta?.content);
+          if (blocks) {
+            if (!reasoning && blocks.thinking && options.onThinking) options.onThinking(blocks.thinking);
+            if (blocks.text) {
+              content += blocks.text;
+              await options.onToken?.(blocks.text);
+            }
+          } else if (delta?.content) {
+            content += delta.content as string;
+            await options.onToken?.(delta.content as string);
+          } else if (typeof delta?.refusal === "string" && delta.refusal) {
+            content += delta.refusal;
+            await options.onToken?.(delta.refusal);
+          }
+
+          // Accumulate tool call deltas. Some OpenAI-compatible backends (including llama.cpp)
+          // may stream tool calls as { name, arguments } instead of { function: { ... } }.
+          if (Array.isArray(delta?.tool_calls)) {
+            for (const [fallbackIndex, rawToolCall] of delta.tool_calls.entries()) {
+              const tc = OpenAIProvider.asRecord(rawToolCall);
+              if (!tc) continue;
+              const fn = OpenAIProvider.asRecord(tc.function) ?? tc;
+              const index = typeof tc.index === "number" ? tc.index : fallbackIndex;
+              const nameDelta = typeof fn.name === "string" ? fn.name : typeof tc.name === "string" ? tc.name : "";
+              const argumentDelta =
+                typeof fn.arguments === "string"
+                  ? fn.arguments
+                  : typeof tc.arguments === "string"
+                    ? tc.arguments
+                    : fn.arguments !== undefined || tc.arguments !== undefined
+                      ? OpenAIProvider.stringifyToolArguments(fn.arguments ?? tc.arguments)
+                      : "";
+              const existing = toolCallsMap.get(index);
+              if (!existing) {
+                toolCallsMap.set(index, {
+                  id: typeof tc.id === "string" ? tc.id : typeof tc.call_id === "string" ? tc.call_id : "",
+                  type: "function",
+                  function: {
+                    name: nameDelta,
+                    arguments: argumentDelta,
+                  },
+                });
+              } else {
+                if (typeof tc.id === "string" && tc.id) existing.id = tc.id;
+                else if (typeof tc.call_id === "string" && tc.call_id) existing.id = tc.call_id;
+                if (nameDelta) existing.function.name += nameDelta;
+                if (argumentDelta) existing.function.arguments += argumentDelta;
+              }
             }
           }
         }
+        if (done) break;
       }
+    } finally {
+      options.signal?.removeEventListener("abort", onAbort);
     }
 
     // Collect tool calls in order
@@ -1569,10 +1582,6 @@ export class OpenAIProvider extends BaseLLMProvider {
       if (options.temperature != null) body.temperature = options.temperature;
       const topP = OpenAIProvider.normalizeTopP(options.topP);
       if (topP != null) body.top_p = topP;
-      if (this.shouldSendPenaltyParams(options.model)) {
-        if (options.frequencyPenalty) body.frequency_penalty = options.frequencyPenalty;
-        if (options.presencePenalty) body.presence_penalty = options.presencePenalty;
-      }
     }
 
     if (!isOpenAIChatGPT && !suppressModelParameters) {
@@ -1708,38 +1717,52 @@ export class OpenAIProvider extends BaseLLMProvider {
     const reader = response.body?.getReader();
     if (!reader) throw new Error("No response body");
 
+    const onAbortResponses = () => reader.cancel().catch(() => {});
+    if (options.signal) {
+      if (options.signal.aborted) {
+        await reader.cancel().catch(() => {});
+        return;
+      }
+      options.signal.addEventListener("abort", onAbortResponses, { once: true });
+    }
+
     const decoder = new TextDecoder();
     let buffer = "";
     let streamUsage: LLMUsage | undefined;
     let yieldedAny = false;
+    let currentEvent = "";
 
-    while (true) {
-      const { done, value } = await reader.read();
-      if (done) break;
+    try {
+      while (true) {
+        const { done, value } = await reader.read();
 
-      buffer += decoder.decode(value, { stream: true });
-      const lines = buffer.split("\n");
-      buffer = lines.pop() ?? "";
+        buffer += done ? decoder.decode() : decoder.decode(value, { stream: true });
+        const lines = buffer.split(/\r?\n/);
+        buffer = done ? "" : (lines.pop() ?? "");
 
-      let currentEvent = "";
-      for (const line of lines) {
-        const trimmed = line.trim();
+        for (const line of lines) {
+          const trimmed = line.trim();
 
-        // SSE event type line
-        const eventName = OpenAIProvider.extractSseEvent(trimmed);
-        if (eventName != null) {
-          currentEvent = eventName;
-          continue;
-        }
+          // SSE event type line
+          const eventName = OpenAIProvider.extractSseEvent(trimmed);
+          if (eventName != null) {
+            currentEvent = eventName;
+            continue;
+          }
 
-        const data = OpenAIProvider.extractSseData(trimmed);
-        if (data == null) {
-          if (trimmed === "") currentEvent = ""; // reset on blank line
-          continue;
-        }
+          const data = OpenAIProvider.extractSseData(trimmed);
+          if (data == null) {
+            if (trimmed === "") currentEvent = ""; // reset on blank line
+            continue;
+          }
 
-        try {
-          const parsed = JSON.parse(data) as Record<string, unknown>;
+          let parsed: Record<string, unknown>;
+          try {
+            parsed = JSON.parse(data) as Record<string, unknown>;
+          } catch {
+            currentEvent = "";
+            continue;
+          }
           // Use SSE event: field if present, otherwise fall back to the JSON type field.
           // Some proxies strip SSE event names and only forward data lines.
           const eventType = currentEvent || (parsed.type as string) || "";
@@ -1791,7 +1814,7 @@ export class OpenAIProvider extends BaseLLMProvider {
               const error = resp?.error as Record<string, unknown> | undefined;
               const msg = (error?.message as string) ?? "unknown error";
               logger.error(new Error(msg), "[OpenAI Responses] Stream ended with response.failed");
-              break;
+              throw new Error(`OpenAI Responses stream failed: ${msg}`);
             }
             case "response.incomplete": {
               const resp = parsed.response as Record<string, unknown> | undefined;
@@ -1801,11 +1824,12 @@ export class OpenAIProvider extends BaseLLMProvider {
             }
             // Ignore other event types (response.created, response.in_progress, etc.)
           }
-        } catch {
-          // Skip malformed JSON
+          currentEvent = "";
         }
-        currentEvent = "";
+        if (done) break;
       }
+    } finally {
+      options.signal?.removeEventListener("abort", onAbortResponses);
     }
 
     if (streamUsage) return streamUsage;
@@ -1913,16 +1937,16 @@ export class OpenAIProvider extends BaseLLMProvider {
     const functionCalls: LLMToolCall[] = [];
     // Track in-progress function call argument deltas keyed by call_id
     const fnCallArgs = new Map<string, { id: string; name: string; arguments: string }>();
+    let currentEvent = "";
 
+    try {
     while (true) {
       const { done, value } = await reader.read();
-      if (done) break;
 
-      sseBuffer += decoder.decode(value, { stream: true });
-      const lines = sseBuffer.split("\n");
-      sseBuffer = lines.pop() ?? "";
+      sseBuffer += done ? decoder.decode() : decoder.decode(value, { stream: true });
+      const lines = sseBuffer.split(/\r?\n/);
+      sseBuffer = done ? "" : (lines.pop() ?? "");
 
-      let currentEvent = "";
       for (const line of lines) {
         const trimmed = line.trim();
 
@@ -1938,134 +1962,139 @@ export class OpenAIProvider extends BaseLLMProvider {
           continue;
         }
 
+        let parsed: Record<string, unknown>;
         try {
-          const parsed = JSON.parse(data) as Record<string, unknown>;
-          // Use SSE event: field if present, otherwise fall back to the JSON type field.
-          // Some proxies strip SSE event names and only forward data lines.
-          const eventType = currentEvent || (parsed.type as string) || "";
-
-          switch (eventType) {
-            case "response.text.delta":
-            case "response.output_text.delta": {
-              const delta = parsed.delta as string | undefined;
-              if (delta) {
-                content += delta;
-                await options.onToken?.(delta);
-              }
-              break;
-            }
-
-            case "response.refusal.delta": {
-              const delta = parsed.delta as string | undefined;
-              if (delta) {
-                content += delta;
-                await options.onToken?.(delta);
-              }
-              break;
-            }
-
-            case "response.reasoning_summary_text.delta": {
-              const delta = parsed.delta as string | undefined;
-              if (delta && options.onThinking) options.onThinking(delta);
-              break;
-            }
-
-            case "response.output_item.added": {
-              // A new output item appeared — could be a function_call
-              const item = parsed.item as Record<string, unknown> | undefined;
-              if (item?.type === "function_call") {
-                const callId = (item.call_id ?? item.id) as string;
-                fnCallArgs.set(callId, {
-                  id: callId,
-                  name: (item.name as string) ?? "",
-                  arguments: (item.arguments as string) ?? "",
-                });
-              }
-              break;
-            }
-
-            case "response.function_call_arguments.delta": {
-              const callId = parsed.call_id as string | undefined;
-              const delta = parsed.delta as string | undefined;
-              if (callId && delta) {
-                const entry = fnCallArgs.get(callId);
-                if (entry) entry.arguments += delta;
-              }
-              break;
-            }
-
-            case "response.function_call_arguments.done": {
-              const callId = parsed.call_id as string | undefined;
-              if (callId) {
-                const entry = fnCallArgs.get(callId);
-                if (entry) {
-                  // Overwrite with the final arguments if provided
-                  const args = parsed.arguments as string | undefined;
-                  if (args) entry.arguments = args;
-                }
-              }
-              break;
-            }
-
-            case "response.output_item.done": {
-              // Finalize function_call items
-              const item = parsed.item as Record<string, unknown> | undefined;
-              if (item?.type === "function_call") {
-                const callId = ((item.call_id ?? item.id) as string) ?? "";
-                const entry = fnCallArgs.get(callId);
-                functionCalls.push({
-                  id: callId,
-                  type: "function",
-                  function: {
-                    name: entry?.name ?? (item.name as string) ?? "",
-                    arguments: entry?.arguments ?? (item.arguments as string) ?? "",
-                  },
-                });
-              }
-              break;
-            }
-
-            case "response.completed": {
-              const resp = parsed.response as Record<string, unknown> | undefined;
-              if (resp) {
-                streamUsage = this.extractResponsesUsage(resp);
-                this.emitEncryptedReasoning(resp, options);
-                const status = resp.status as string | undefined;
-                if (status === "incomplete") finishReason = "length";
-                // Fallback: extract text/refusal from the completed response
-                // if nothing was streamed (e.g. model returned only in payload)
-                if (!content) {
-                  const fallback = this.extractResponsesText(resp);
-                  if (fallback) {
-                    content = fallback;
-                    await options.onToken?.(fallback);
-                  }
-                }
-              }
-              break;
-            }
-            case "response.failed": {
-              const resp = parsed.response as Record<string, unknown> | undefined;
-              const error = resp?.error as Record<string, unknown> | undefined;
-              const msg = (error?.message as string) ?? "unknown error";
-              logger.error(new Error(msg), "[OpenAI Responses] chatCompleteResponses stream failed");
-              break;
-            }
-            case "response.incomplete": {
-              const resp = parsed.response as Record<string, unknown> | undefined;
-              const reason = (resp?.incomplete_details as Record<string, unknown>)?.reason ?? "unknown";
-              logger.warn("[OpenAI Responses] chatCompleteResponses stream incomplete (reason=%s)", reason);
-              finishReason = "length";
-              break;
-            }
-          }
+          parsed = JSON.parse(data) as Record<string, unknown>;
         } catch {
-          // Skip malformed JSON
+          currentEvent = "";
+          continue;
+        }
+        // Use SSE event: field if present, otherwise fall back to the JSON type field.
+        // Some proxies strip SSE event names and only forward data lines.
+        const eventType = currentEvent || (parsed.type as string) || "";
+
+        switch (eventType) {
+          case "response.text.delta":
+          case "response.output_text.delta": {
+            const delta = parsed.delta as string | undefined;
+            if (delta) {
+              content += delta;
+              await options.onToken?.(delta);
+            }
+            break;
+          }
+
+          case "response.refusal.delta": {
+            const delta = parsed.delta as string | undefined;
+            if (delta) {
+              content += delta;
+              await options.onToken?.(delta);
+            }
+            break;
+          }
+
+          case "response.reasoning_summary_text.delta": {
+            const delta = parsed.delta as string | undefined;
+            if (delta && options.onThinking) options.onThinking(delta);
+            break;
+          }
+
+          case "response.output_item.added": {
+            // A new output item appeared — could be a function_call
+            const item = parsed.item as Record<string, unknown> | undefined;
+            if (item?.type === "function_call") {
+              const callId = (item.call_id ?? item.id) as string;
+              fnCallArgs.set(callId, {
+                id: callId,
+                name: (item.name as string) ?? "",
+                arguments: (item.arguments as string) ?? "",
+              });
+            }
+            break;
+          }
+
+          case "response.function_call_arguments.delta": {
+            const callId = parsed.call_id as string | undefined;
+            const delta = parsed.delta as string | undefined;
+            if (callId && delta) {
+              const entry = fnCallArgs.get(callId);
+              if (entry) entry.arguments += delta;
+            }
+            break;
+          }
+
+          case "response.function_call_arguments.done": {
+            const callId = parsed.call_id as string | undefined;
+            if (callId) {
+              const entry = fnCallArgs.get(callId);
+              if (entry) {
+                // Overwrite with the final arguments if provided
+                const args = parsed.arguments as string | undefined;
+                if (args) entry.arguments = args;
+              }
+            }
+            break;
+          }
+
+          case "response.output_item.done": {
+            // Finalize function_call items
+            const item = parsed.item as Record<string, unknown> | undefined;
+            if (item?.type === "function_call") {
+              const callId = ((item.call_id ?? item.id) as string) ?? "";
+              const entry = fnCallArgs.get(callId);
+              functionCalls.push({
+                id: callId,
+                type: "function",
+                function: {
+                  name: entry?.name ?? (item.name as string) ?? "",
+                  arguments: entry?.arguments ?? (item.arguments as string) ?? "",
+                },
+              });
+            }
+            break;
+          }
+
+          case "response.completed": {
+            const resp = parsed.response as Record<string, unknown> | undefined;
+            if (resp) {
+              streamUsage = this.extractResponsesUsage(resp);
+              this.emitEncryptedReasoning(resp, options);
+              const status = resp.status as string | undefined;
+              if (status === "incomplete") finishReason = "length";
+              // Fallback: extract text/refusal from the completed response
+              // if nothing was streamed (e.g. model returned only in payload)
+              if (!content) {
+                const fallback = this.extractResponsesText(resp);
+                if (fallback) {
+                  content = fallback;
+                  await options.onToken?.(fallback);
+                }
+              }
+            }
+            break;
+          }
+          case "response.failed": {
+            const resp = parsed.response as Record<string, unknown> | undefined;
+            const error = resp?.error as Record<string, unknown> | undefined;
+            const msg = (error?.message as string) ?? "unknown error";
+            logger.error(new Error(msg), "[OpenAI Responses] chatCompleteResponses stream failed");
+            throw new Error(`OpenAI Responses stream failed: ${msg}`);
+          }
+          case "response.incomplete": {
+            const resp = parsed.response as Record<string, unknown> | undefined;
+            const reason = (resp?.incomplete_details as Record<string, unknown>)?.reason ?? "unknown";
+            logger.warn("[OpenAI Responses] chatCompleteResponses stream incomplete (reason=%s)", reason);
+            finishReason = "length";
+            break;
+          }
         }
         currentEvent = "";
       }
+      if (done) break;
     }
-    if (options.signal) options.signal.removeEventListener("abort", onAbortCCR);
+    } finally {
+      options.signal?.removeEventListener("abort", onAbortCCR);
+    }
     // Check if we got tool calls
     if (functionCalls.length > 0) {
       finishReason = "tool_calls";

--- a/packages/server/src/services/lorebook/embeddings.ts
+++ b/packages/server/src/services/lorebook/embeddings.ts
@@ -82,6 +82,7 @@ async function embedLorebookTexts(texts: string[], options: LorebookEmbeddingOpt
   return embedMemoryRecallTexts(texts, {
     localEmbedder: options.localEmbedder ?? localEmbed,
     embeddingSource: options.embeddingSource,
+    signal: options.signal,
   });
 }
 

--- a/packages/server/src/services/lorebook/index.ts
+++ b/packages/server/src/services/lorebook/index.ts
@@ -702,6 +702,7 @@ export function resolveBudgetAndRecursivelyActivateLorebookEntriesWithDiagnostic
 ): { selected: ActivatedEntry[]; budgetSkippedEntries: LorebookBudgetSkippedEntry[] } {
   let state = createLorebookBudgetSelectionState();
   const processedIds = new Set<string>();
+  const selectedGroups = new Set<string>();
   const probabilityDecisions = options.probabilityDecisions ?? new Map<string, boolean>();
   const scanOptions = { ...options, probabilityDecisions };
   let frontier = scanForActivatedEntries(messages, entries, scanOptions);
@@ -709,7 +710,10 @@ export function resolveBudgetAndRecursivelyActivateLorebookEntriesWithDiagnostic
 
   for (let depth = 0; frontier.length > 0; depth++) {
     const candidates = frontier.filter(
-      (candidate) => !processedIds.has(candidate.entry.id) && !state.selectedIds.has(candidate.entry.id),
+      (candidate) =>
+        !processedIds.has(candidate.entry.id) &&
+        !state.selectedIds.has(candidate.entry.id) &&
+        !(candidate.entry.group && selectedGroups.has(candidate.entry.group)),
     );
     for (const candidate of candidates) {
       processedIds.add(candidate.entry.id);
@@ -725,6 +729,9 @@ export function resolveBudgetAndRecursivelyActivateLorebookEntriesWithDiagnostic
     );
     state = selectedBatch.state;
     budgetSkippedEntries.push(...selectedBatch.budgetSkippedEntries);
+    for (const selected of selectedBatch.selectedFromCandidates) {
+      if (selected.entry.group) selectedGroups.add(selected.entry.group);
+    }
 
     const recursiveContentParts = selectedBatch.selectedFromCandidates
       .filter((selected) => !selected.entry.preventRecursion)
@@ -737,7 +744,11 @@ export function resolveBudgetAndRecursivelyActivateLorebookEntriesWithDiagnostic
     if (!recursiveContent) break;
 
     const remaining = entries.filter(
-      (entry) => !processedIds.has(entry.id) && !state.selectedIds.has(entry.id) && !entry.excludeRecursion,
+      (entry) =>
+        !processedIds.has(entry.id) &&
+        !state.selectedIds.has(entry.id) &&
+        !entry.excludeRecursion &&
+        !(entry.group && selectedGroups.has(entry.group)),
     );
     if (remaining.length === 0) break;
 

--- a/packages/server/src/services/memory-recall-embedding.ts
+++ b/packages/server/src/services/memory-recall-embedding.ts
@@ -78,9 +78,9 @@ export async function resolveMemoryRecallEmbeddingSource(
     const label = "Local Model sidecar";
     return {
       label,
-      async embed(texts: string[]) {
+      async embed(texts: string[], signal?: AbortSignal) {
         try {
-          return await provider.embed(texts, LOCAL_SIDECAR_MODEL);
+          return await provider.embed(texts, LOCAL_SIDECAR_MODEL, signal);
         } catch (err) {
           logger.warn(err, "[memory-recall] Configured embedding source %s failed", label);
           return null;
@@ -122,9 +122,9 @@ export async function resolveMemoryRecallEmbeddingSource(
 
   return {
     label,
-    async embed(texts: string[]) {
+    async embed(texts: string[], signal?: AbortSignal) {
       try {
-        return await provider.embed(texts, embeddingModel);
+        return await provider.embed(texts, embeddingModel, signal);
       } catch (err) {
         logger.warn(err, "[memory-recall] Configured embedding source %s failed", label);
         return null;

--- a/packages/server/src/services/memory-recall.ts
+++ b/packages/server/src/services/memory-recall.ts
@@ -61,12 +61,13 @@ export interface RecalledMemory {
 
 export interface MemoryRecallEmbeddingSource {
   label: string;
-  embed(texts: string[]): Promise<number[][] | null>;
+  embed(texts: string[], signal?: AbortSignal): Promise<number[][] | null>;
 }
 
 export interface MemoryRecallEmbeddingOptions {
   embeddingSource?: MemoryRecallEmbeddingSource | null;
-  localEmbedder?: (texts: string[]) => Promise<number[][] | null>;
+  localEmbedder?: (texts: string[], signal?: AbortSignal) => Promise<number[][] | null>;
+  signal?: AbortSignal;
 }
 
 export async function embedMemoryRecallTexts(
@@ -74,7 +75,7 @@ export async function embedMemoryRecallTexts(
   options: MemoryRecallEmbeddingOptions = {},
 ): Promise<number[][]> {
   if (options.embeddingSource) {
-    const configuredEmbeddings = await options.embeddingSource.embed(texts);
+    const configuredEmbeddings = await options.embeddingSource.embed(texts, options.signal);
     if (configuredEmbeddings) {
       logger.debug("[memory-recall] Used configured embedding source %s", options.embeddingSource.label);
       return configuredEmbeddings;
@@ -83,7 +84,7 @@ export async function embedMemoryRecallTexts(
   }
 
   const localEmbedder = options.localEmbedder ?? localEmbed;
-  const localEmbeddings = await localEmbedder(texts);
+  const localEmbeddings = await localEmbedder(texts, options.signal);
   if (localEmbeddings) return localEmbeddings;
 
   logger.warn("[memory-recall] Local embeddings are unavailable and no embedding connection is configured");

--- a/packages/server/src/services/prompt/assembler.ts
+++ b/packages/server/src/services/prompt/assembler.ts
@@ -18,7 +18,7 @@ import type {
   MacroContext,
   ResolveMacroOptions,
 } from "@marinara-engine/shared";
-import { resolveMacros } from "@marinara-engine/shared";
+import { DEFAULT_GENERATION_PARAMS, resolveMacros } from "@marinara-engine/shared";
 import { wrapContent, wrapGroup } from "./format-engine.js";
 import { expandMarker, type MarkerContext } from "./marker-expander.js";
 import { mergeAdjacentMessages, squashLeadingSystemMessages } from "./merger.js";
@@ -204,13 +204,25 @@ export interface AssemblerOutput {
   runtimeAgentTypesUsed?: string[];
 }
 
+function parsePresetParameters(raw: string): GenerationParameters {
+  try {
+    const parsed = JSON.parse(raw) as unknown;
+    if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+      return { ...DEFAULT_GENERATION_PARAMS, ...(parsed as Partial<GenerationParameters>) };
+    }
+  } catch {
+    // Malformed legacy rows should not leave generation parameters undefined.
+  }
+  return { ...DEFAULT_GENERATION_PARAMS };
+}
+
 // ═══════════════════════════════════════════════
 //  Main Assembler
 // ═══════════════════════════════════════════════
 
 export async function assemblePrompt(input: AssemblerInput): Promise<AssemblerOutput> {
   const wrapFormat = (input.preset.wrapFormat || "xml") as WrapFormat;
-  const parameters = JSON.parse(input.preset.parameters) as GenerationParameters;
+  const parameters = parsePresetParameters(input.preset.parameters);
   const sectionOrder = JSON.parse(input.preset.sectionOrder) as string[];
   const groupOrder = JSON.parse(input.preset.groupOrder) as string[];
   const variableValues = JSON.parse(input.preset.variableValues) as Record<string, string>;

--- a/packages/server/src/services/prompt/assembler.ts
+++ b/packages/server/src/services/prompt/assembler.ts
@@ -353,7 +353,7 @@ export async function assemblePrompt(input: AssemblerInput): Promise<AssemblerOu
 
     if (!resolved) continue;
 
-    if (section.injectionPosition === "depth" && section.injectionDepth >= 0) {
+    if (!resolved.isChatHistory && section.injectionPosition === "depth" && section.injectionDepth >= 0) {
       depthSections.push(resolved);
     } else {
       orderedSections.push(resolved);

--- a/packages/server/src/services/sidecar/scene-analyzer.ts
+++ b/packages/server/src/services/sidecar/scene-analyzer.ts
@@ -176,6 +176,55 @@ function compactPromptLabel(value: string | null | undefined): string {
     .slice(0, 180);
 }
 
+function sceneAnalyzerSegmentBeats(narration: string): string[] {
+  const lines = narration.split(/\r?\n/);
+  const beats: string[] = [];
+  let fallbackLines: string[] = [];
+  const readablePlaceholderRe = /^\s*\[(?:Note|Book):/i;
+  const narrationRegex = /^\s*Narration\s*:\s*(.+)$/i;
+  const legacyDialogueRegex = /^\s*Dialogue\s*\[([^\]]+)\]\s*(?:\[([^\]]+)\])?\s*:\s*(.+)$/i;
+  const compactDialogueRegex = /^\s*\[([^\]]+)\]\s*(?:\[([^\]]+)\])?\s*:\s*(.+)$/;
+  const partyLineRegex =
+    /^\s*\[([^\]]+)\]\s*\[(main|side|extra|action|thought|whisper(?::([^\]]+))?)\]\s*(?:\[([^\]]+)\])?\s*:\s*(.+)$/i;
+
+  const flushFallback = () => {
+    const text = fallbackLines.join("\n").trim();
+    if (text) beats.push(text);
+    fallbackLines = [];
+  };
+
+  for (const rawLine of lines) {
+    const line = rawLine.trim();
+    if (!line) {
+      flushFallback();
+      continue;
+    }
+
+    const structuredMatch =
+      line.match(narrationRegex) ??
+      line.match(legacyDialogueRegex) ??
+      line.match(partyLineRegex) ??
+      line.match(compactDialogueRegex);
+    if (structuredMatch) {
+      flushFallback();
+      beats.push(line);
+      continue;
+    }
+
+    if (readablePlaceholderRe.test(line)) {
+      flushFallback();
+      beats.push(line);
+      continue;
+    }
+
+    fallbackLines.push(line);
+  }
+
+  flushFallback();
+  const fallback = narration.trim();
+  return beats.length > 0 ? beats : fallback ? [fallback] : [];
+}
+
 /** Build the user prompt with all choices inline in a JSON template. */
 export function buildSceneAnalyzerUserPrompt(
   narration: string,
@@ -201,10 +250,10 @@ export function buildSceneAnalyzerUserPrompt(
     parts.push(`<player_action>`, playerAction, `</player_action>`);
   }
 
-  const lines = narration.split(/\r?\n/).filter((l) => l.trim());
+  const beats = sceneAnalyzerSegmentBeats(narration);
   parts.push(`<narration>`);
-  for (let i = 0; i < lines.length; i++) {
-    parts.push(`[${i}] ${lines[i]}`);
+  for (let i = 0; i < beats.length; i++) {
+    parts.push(`[${i}] ${beats[i]}`);
   }
   parts.push(`</narration>`);
 
@@ -258,7 +307,7 @@ export function buildSceneAnalyzerUserPrompt(
           `2. AUDIO DIRECTION — Choose compact musicGenre/musicIntensity/locationKind hints. Do NOT choose music or ambient file tags; Marinara maps these hints to assets deterministically. Do NOT output spotifyTrack.`,
         ]),
     `3. REPUTATION — If an NPC relationship shifted, note it. Otherwise empty array.`,
-    `4. PER-BEAT EFFECTS — Scan each narration beat [0]-[${lines.length - 1}]. For each beat you can optionally add:`,
+    `4. PER-BEAT EFFECTS — Scan each narration beat [0]-[${Math.max(0, beats.length - 1)}]. For each beat you can optionally add:`,
     `   - "sfx": sound effects (door slam, explosion, footsteps, impact)`,
     `   - "directions": rare cinematic effects at the exact beat they should happen, usually paired with a meaningful sound or reveal`,
     `   - "background": a DIFFERENT background tag if the characters move to a new location at that beat. The background stays the same until the NEXT segment that changes it, so only set "background" on the beat where characters actually arrive at a new location. Do NOT repeat the current background.`,
@@ -344,7 +393,7 @@ export function buildSceneAnalyzerUserPrompt(
 
   // Build ONE segment example showing the range
   const segmentFields: string[] = [];
-  segmentFields.push(`      "segment": <0-${lines.length - 1}>`);
+  segmentFields.push(`      "segment": <0-${Math.max(0, beats.length - 1)}>`);
   if (sfxLine) segmentFields.push(sfxLine);
   segmentFields.push(
     `      "directions": [{"effect":"<flash|screen_shake|pulse|slow_zoom|impact_zoom|tilt|desaturate|chromatic_aberration|film_grain|rain_streaks|spotlight|focus|vignette|letterbox|color_grade>","duration":<0.4-3>,"intensity":<0-1>}]  // optional, rare`,
@@ -379,7 +428,7 @@ export function buildSceneAnalyzerUserPrompt(
       : []),
     ...(canGenerateIllustrations
       ? [
-          `,  "illustration": null OR {"segment":<0-${lines.length - 1}>,"title":"<short concrete visual title>","prompt":"<important CG image prompt from player POV>","characters":["<visible named character>"],"reason":"<why this is CG-worthy>","slug":"<short-safe-slug>"}`,
+          `,  "illustration": null OR {"segment":<0-${Math.max(0, beats.length - 1)}>,"title":"<short concrete visual title>","prompt":"<important CG image prompt from player POV>","characters":["<visible named character>"],"reason":"<why this is CG-worthy>","slug":"<short-safe-slug>"}`,
         ]
       : []),
     `}`,

--- a/packages/server/src/services/sidecar/sidecar-inference.service.ts
+++ b/packages/server/src/services/sidecar/sidecar-inference.service.ts
@@ -108,7 +108,37 @@ function formatStreamOutput(content: string, reasoning: string): string {
 
 function isContextOverflowError(error: unknown): boolean {
   const message = error instanceof Error ? error.message.toLowerCase() : String(error).toLowerCase();
-  return /context|ctx|prompt.*too|slot|exceed|overflow|too many tokens/.test(message);
+  return [
+    /context\s+(window|length|size|limit|overflow)/,
+    /ctx\s*(size|limit|overflow)/,
+    /prompt.*(too long|too large|exceed|overflow|context)/,
+    /(exceed|exceeds|exceeded|overflow).*(context|ctx|token|prompt)/,
+    /too many tokens/,
+    /maximum context/,
+    /n_ctx/,
+  ].some((pattern) => pattern.test(message));
+}
+
+function isAbortLikeError(error: unknown): boolean {
+  return error instanceof Error && /aborted|abort/i.test(`${error.name} ${error.message}`);
+}
+
+function isStreamStallError(error: unknown): boolean {
+  return error instanceof Error && /stalled waiting for tokens/i.test(error.message);
+}
+
+function isProviderStreamError(error: unknown): boolean {
+  return error instanceof Error && error.message.startsWith("llama-server stream error:");
+}
+
+function markStreamedBeforeError(error: unknown): void {
+  if (error && typeof error === "object") {
+    (error as { sidecarStreamedTokens?: boolean }).sidecarStreamedTokens = true;
+  }
+}
+
+function streamedBeforeError(error: unknown): boolean {
+  return !!(error && typeof error === "object" && (error as { sidecarStreamedTokens?: boolean }).sidecarStreamedTokens);
 }
 
 function getRequestModel(): string {
@@ -254,13 +284,17 @@ async function streamChatCompletion(options: {
     let buffer = "";
     let content = "";
     let reasoning = "";
+    let emittedText = false;
     const readChunk = async () => {
       let timeout: ReturnType<typeof setTimeout> | null = null;
       try {
         return await Promise.race([
           reader.read(),
           new Promise<never>((_, reject) => {
-            timeout = setTimeout(() => reject(new Error("llama-server stream stalled waiting for tokens")), STREAM_IDLE_TIMEOUT_MS);
+            timeout = setTimeout(
+              () => reject(new Error("llama-server stream stalled waiting for tokens")),
+              STREAM_IDLE_TIMEOUT_MS,
+            );
           }),
         ]);
       } finally {
@@ -268,12 +302,26 @@ async function streamChatCompletion(options: {
       }
     };
 
-    const appendText = (nextContent: string, nextReasoning: string) => {
+    const truncateAccumulatedText = (): string => {
+      const truncated = formatStreamOutput(content, reasoning).slice(0, MAX_ACCUMULATED_TEXT_CHARS);
+      content = truncated;
+      reasoning = "";
+      return truncated;
+    };
+
+    const appendText = (nextContent: string, nextReasoning: string): string | null => {
       content += nextContent;
       reasoning += nextReasoning;
+      if (nextContent || nextReasoning) emittedText = true;
       if (content.length + reasoning.length > MAX_ACCUMULATED_TEXT_CHARS) {
-        throw new Error("llama-server response exceeded local inference size limit");
+        return truncateAccumulatedText();
       }
+      return null;
+    };
+
+    const readSseData = (line: string): string | null => {
+      if (!line.startsWith("data:")) return null;
+      return line.slice(5).trimStart();
     };
 
     const handlePayload = (data: string): string | null => {
@@ -288,43 +336,44 @@ async function streamChatCompletion(options: {
       const choice = parsed.choices?.[0];
       if (!choice) return null;
       const extracted = extractChoiceContent(choice);
-      appendText(extracted.content, extracted.reasoning);
-      return null;
+      return appendText(extracted.content, extracted.reasoning);
     };
 
-    const flushTrailingPayload = () => {
-      if (!buffer.trim().startsWith("data: ")) return;
-      const trailing = buffer.trim().slice(6);
-      if (trailing === "[DONE]") return;
+    const flushTrailingPayload = (): string | null => {
+      const trailing = readSseData(buffer.trim());
+      if (trailing == null) return null;
+      if (trailing === "[DONE]") return null;
       try {
-        handlePayload(trailing);
-      } catch {
+        return handlePayload(trailing);
+      } catch (err) {
+        if (isProviderStreamError(err)) throw err;
         // Ignore malformed trailing chunk after the stream has ended.
+        return null;
       }
     };
 
     try {
       while (true) {
         const { done, value } = await readChunk();
-        if (done) break;
 
-        buffer += decoder.decode(value, { stream: true });
-        const lines = buffer.split("\n");
-        buffer = lines.pop() ?? "";
+        buffer += done ? decoder.decode() : decoder.decode(value, { stream: true });
+        const lines = buffer.split(/\r?\n/);
+        buffer = done ? "" : (lines.pop() ?? "");
 
         for (const line of lines) {
           const trimmed = line.trim();
-          if (!trimmed.startsWith("data: ")) continue;
-          const output = handlePayload(trimmed.slice(6));
+          const data = readSseData(trimmed);
+          if (data == null) continue;
+          const output = handlePayload(data);
           if (output !== null) return output;
         }
+        if (done) break;
       }
     } catch (err) {
+      if (emittedText) markStreamedBeforeError(err);
+      if (isProviderStreamError(err)) throw err;
       const partial = formatStreamOutput(content, reasoning);
-      const partialIsUsable =
-        partial &&
-        (options.signal?.aborted ||
-          (err instanceof Error && /aborted|abort|stalled waiting for tokens/i.test(`${err.name} ${err.message}`)));
+      const partialIsUsable = partial && !structuredOutput && (isAbortLikeError(err) || isStreamStallError(err));
       if (partialIsUsable) return partial;
       throw err;
     } finally {
@@ -335,14 +384,15 @@ async function streamChatCompletion(options: {
       }
     }
 
-    flushTrailingPayload();
+    const trailingOutput = flushTrailingPayload();
+    if (trailingOutput !== null) return trailingOutput;
     return formatStreamOutput(content, reasoning);
   };
 
   try {
     return await send(maxTokens);
   } catch (err) {
-    if (maxTokens > 512 && isContextOverflowError(err)) {
+    if (maxTokens > 512 && !streamedBeforeError(err) && isContextOverflowError(err)) {
       return await send(Math.max(512, Math.floor(maxTokens / 2)));
     }
     throw err;

--- a/packages/server/src/services/sidecar/sidecar-launch-plan.ts
+++ b/packages/server/src/services/sidecar/sidecar-launch-plan.ts
@@ -37,7 +37,7 @@ export function buildLlamaArgs(options: {
     args.push("--jinja");
   }
 
-  args.push("--embeddings", "--pooling", "mean");
+  args.push("--embeddings", "--pooling", "none");
 
   // Gemma 4 needs split mode disabled on CUDA multi-GPU launches,
   // but non-CUDA builds may reject the flag entirely.

--- a/packages/server/src/services/sidecar/sidecar-model.service.ts
+++ b/packages/server/src/services/sidecar/sidecar-model.service.ts
@@ -449,9 +449,17 @@ class SidecarModelService {
   }
 
   private emitProgress(progress: SidecarDownloadProgress, inline?: ProgressCallback): void {
-    inline?.(progress);
+    try {
+      inline?.(progress);
+    } catch (error) {
+      logger.warn(error, "[sidecar] Inline progress listener failed");
+    }
     for (const listener of this.progressListeners) {
-      listener(progress);
+      try {
+        listener(progress);
+      } catch (error) {
+        logger.warn(error, "[sidecar] Progress listener failed");
+      }
     }
   }
 

--- a/packages/server/src/services/sidecar/sidecar-process.service.ts
+++ b/packages/server/src/services/sidecar/sidecar-process.service.ts
@@ -434,8 +434,8 @@ class SidecarProcessService {
     return ["-m", "mlx_lm.server", "--model", modelRepo, "--host", "127.0.0.1", "--port", String(port)];
   }
 
-  private async waitForMlxCompletionProbe(baseUrl: string): Promise<void> {
-    const model = resolveSidecarRequestModel("mlx", sidecarModelService.getConfiguredModelRef());
+  private async waitForCompletionProbe(baseUrl: string, backend: SidecarBackend): Promise<void> {
+    const model = resolveSidecarRequestModel(backend, sidecarModelService.getConfiguredModelRef());
     const response = await fetch(`${baseUrl}/v1/chat/completions`, {
       method: "POST",
       headers: {
@@ -775,9 +775,7 @@ class SidecarProcessService {
           signal: AbortSignal.timeout(3_000),
         });
         if (response.ok) {
-          if (backend === "mlx") {
-            await this.waitForMlxCompletionProbe(baseUrl);
-          }
+          await this.waitForCompletionProbe(baseUrl, backend);
           return;
         }
         lastError = new Error(`HTTP ${response.status}`);

--- a/packages/server/src/services/storage/connections.storage.ts
+++ b/packages/server/src/services/storage/connections.storage.ts
@@ -219,7 +219,7 @@ export function createConnectionsStorage(db: DB) {
         imagePath: source.imagePath,
         maxContext: source.maxContext,
         isDefault: "false",
-        useForRandom: source.useForRandom,
+        useForRandom: "false",
         defaultForAgents: "false",
         enableCaching: source.enableCaching,
         cachingAtDepth: source.cachingAtDepth,

--- a/packages/server/src/services/storage/prompts.storage.ts
+++ b/packages/server/src/services/storage/prompts.storage.ts
@@ -27,6 +27,19 @@ function resolveTimestamps(overrides?: TimestampOverrides | null) {
   };
 }
 
+function parseGenerationParameters(raw: unknown): Record<string, unknown> {
+  if (!raw) return {};
+  if (typeof raw === "string") {
+    try {
+      const parsed = JSON.parse(raw) as unknown;
+      return parsed && typeof parsed === "object" && !Array.isArray(parsed) ? (parsed as Record<string, unknown>) : {};
+    } catch {
+      return {};
+    }
+  }
+  return typeof raw === "object" && !Array.isArray(raw) ? (raw as Record<string, unknown>) : {};
+}
+
 export function createPromptsStorage(db: DB) {
   return {
     // ═══════════════════════════════════════════
@@ -76,7 +89,19 @@ export function createPromptsStorage(db: DB) {
       if (data.groupOrder !== undefined) updateFields.groupOrder = JSON.stringify(data.groupOrder);
       if (data.variableGroups !== undefined) updateFields.variableGroups = JSON.stringify(data.variableGroups);
       if (data.variableValues !== undefined) updateFields.variableValues = JSON.stringify(data.variableValues);
-      if (data.parameters !== undefined) updateFields.parameters = JSON.stringify(data.parameters);
+      if (data.parameters !== undefined) {
+        const existingRows = await db
+          .select({ parameters: promptPresets.parameters })
+          .from(promptPresets)
+          .where(eq(promptPresets.id, id))
+          .limit(1);
+        const existingParameters = parseGenerationParameters(existingRows[0]?.parameters);
+        updateFields.parameters = JSON.stringify({
+          ...DEFAULT_GENERATION_PARAMS,
+          ...existingParameters,
+          ...data.parameters,
+        });
+      }
       if (data.wrapFormat !== undefined) updateFields.wrapFormat = data.wrapFormat;
       if (data.author !== undefined) updateFields.author = data.author;
       if ((data as any).defaultChoices !== undefined)

--- a/packages/server/src/utils/security.ts
+++ b/packages/server/src/utils/security.ts
@@ -433,22 +433,25 @@ function capStreamingResponse(response: Response, maxBytes: number, dispatcher?:
     return response;
   }
   let total = 0;
+  let innerReader: ReadableStreamDefaultReader<Uint8Array> | null = null;
+  const closeDispatcher = () => dispatcher?.close().catch(() => undefined);
   const stream = new ReadableStream<Uint8Array>({
     async start(controller) {
       const reader = response.body!.getReader();
+      innerReader = reader;
       try {
         while (true) {
           const { done, value } = await reader.read();
           if (done) {
             controller.close();
-            await dispatcher?.close().catch(() => undefined);
+            await closeDispatcher();
             return;
           }
 
           total += value.byteLength;
           if (total > maxBytes) {
             await reader.cancel().catch(() => undefined);
-            await dispatcher?.close().catch(() => undefined);
+            await closeDispatcher();
             controller.error(new Error(`Outbound response exceeded ${maxBytes} bytes`));
             return;
           }
@@ -456,9 +459,15 @@ function capStreamingResponse(response: Response, maxBytes: number, dispatcher?:
           controller.enqueue(value);
         }
       } catch (err) {
-        await dispatcher?.close().catch(() => undefined);
+        await closeDispatcher();
         controller.error(err);
+      } finally {
+        if (innerReader === reader) innerReader = null;
       }
+    },
+    async cancel(reason) {
+      await innerReader?.cancel(reason).catch(() => undefined);
+      await closeDispatcher();
     },
   });
   return new Response(stream, {
@@ -530,6 +539,26 @@ export function requestHeadersWithIdentityEncoding(headersInit: RequestInit["hea
   return headers;
 }
 
+const CROSS_ORIGIN_REDIRECT_STRIPPED_HEADERS = [
+  "authorization",
+  "proxy-authorization",
+  "cookie",
+  "xi-api-key",
+  "x-api-key",
+  "api-key",
+  "content-type",
+  "content-length",
+];
+
+function stripCrossOriginRedirectHeaders(headersInit: RequestInit["headers"] | undefined): Headers | undefined {
+  if (!headersInit) return undefined;
+  const headers = new Headers(headersInit);
+  for (const name of CROSS_ORIGIN_REDIRECT_STRIPPED_HEADERS) {
+    headers.delete(name);
+  }
+  return headers;
+}
+
 export async function safeFetch(url: string | URL, options: SafeFetchOptions = {}): Promise<Response> {
   const {
     policy,
@@ -548,12 +577,14 @@ export async function safeFetch(url: string | URL, options: SafeFetchOptions = {
 
   let current = await validateOutboundUrlForFetch(url, policy, dispatcher ? undefined : agentOptions);
   const redirects = policy?.maxRedirects ?? MAX_REDIRECTS;
+  let currentHeaders = headers;
+  let currentInit = { ...init };
 
   for (let i = 0; i <= redirects; i += 1) {
     const internalDispatcher = dispatcher ? undefined : current.dispatcher;
-    const requestHeaders = decodeCompressedResponse ? requestHeadersWithIdentityEncoding(headers) : headers;
+    const requestHeaders = decodeCompressedResponse ? requestHeadersWithIdentityEncoding(currentHeaders) : currentHeaders;
     const response = await fetch(current.url, {
-      ...init,
+      ...currentInit,
       ...(requestHeaders ? { headers: requestHeaders } : {}),
       redirect: "manual",
       dispatcher: dispatcher ?? internalDispatcher,
@@ -561,11 +592,14 @@ export async function safeFetch(url: string | URL, options: SafeFetchOptions = {
     if (response.status >= 300 && response.status < 400 && response.headers.has("location")) {
       if (i === redirects) throw new Error("Outbound request exceeded redirect limit");
       await internalDispatcher?.close().catch(() => undefined);
-      current = await validateOutboundUrlForFetch(
-        new URL(response.headers.get("location")!, current.url),
-        policy,
-        agentOptions,
-      );
+      const previousUrl = current.url;
+      const nextUrl = new URL(response.headers.get("location")!, previousUrl);
+      if (nextUrl.origin !== previousUrl.origin) {
+        currentHeaders = stripCrossOriginRedirectHeaders(currentHeaders);
+        currentInit = { ...currentInit };
+        delete (currentInit as { body?: unknown }).body;
+      }
+      current = await validateOutboundUrlForFetch(nextUrl, policy, agentOptions);
       continue;
     }
 

--- a/packages/shared/src/constants/image-style-profiles.ts
+++ b/packages/shared/src/constants/image-style-profiles.ts
@@ -65,7 +65,7 @@ export const DEFAULT_IMAGE_STYLE_PROFILES: ImageStyleProfile[] = [
     negativeTags:
       "worst quality, low quality, lowres, bad anatomy, bad hands, extra digits, fewer digits, text, watermark, logo, signature",
     subjectTags: {
-      portrait: "1girl, solo, portrait, upper body, looking at viewer",
+      portrait: "solo, portrait, upper body, looking at viewer",
       avatar: "solo, portrait, upper body, centered composition",
       selfie: "solo, selfie, close-up, looking at viewer",
       background: "scenery, environment, landscape, no humans",

--- a/packages/shared/src/types/chat-preset.ts
+++ b/packages/shared/src/types/chat-preset.ts
@@ -52,6 +52,7 @@ export const CHAT_PRESET_EXCLUDED_METADATA_KEYS: readonly string[] = [
   "tags",
   "appliedChatPresetId",
   "agentVariables",
+  "presetChoices",
   "spriteCharacterIds",
   "spritePlacements",
   "entryStateOverrides",

--- a/packages/shared/src/utils/image-prompt-compiler.ts
+++ b/packages/shared/src/utils/image-prompt-compiler.ts
@@ -39,12 +39,14 @@ export function compileImagePrompt(input: CompileImagePromptInput): CompiledImag
   const generatedStyle = input.generatedStyle?.trim() ?? "";
   const promptPrefix = imagePromptPrefixFromDefaults(input.imageDefaults);
   const negativePromptPrefix = imageNegativePromptPrefixFromDefaults(input.imageDefaults);
-  const profileSubjectTags = profile.subjectTags[input.kind] ?? "";
   const preserveScenePrompt = input.kind === "illustration" || input.kind === "background";
   const compactTags = !preserveScenePrompt && (promptMode === "tagged" || promptMode === "danbooru");
   const compactVisualPrompt =
     profile.baseStyle !== "z_image_turbo" && ["avatar", "portrait", "selfie", "sprite"].includes(input.kind);
   const compactPrompt = compactTags || compactVisualPrompt;
+  const sourceCueText = [input.prompt, input.userPositive].filter(Boolean).join("\n");
+  const sourceCues = compactPrompt ? deriveTaggedSourceCues(sourceCueText) : [];
+  const profileSubjectTags = reconcileProfileSubjectTags(profile.subjectTags[input.kind] ?? "", sourceCues);
   const fragmentMode = compactPrompt ? "tagged" : promptMode;
   const profileStyleText =
     compactPrompt || (profile.styleText && generatedStyle)
@@ -58,6 +60,7 @@ export function compileImagePrompt(input: CompileImagePromptInput): CompiledImag
   const positiveParts = compactPrompt
     ? [
         { value: promptPrefix, sourcePrompt: false, hardPrefix: true },
+        { value: sourceCues.join(", "), sourcePrompt: false },
         { value: generatedStyle, sourcePrompt: true },
         { value: input.prompt, sourcePrompt: true },
         { value: input.userPositive, sourcePrompt: true },
@@ -83,7 +86,7 @@ export function compileImagePrompt(input: CompileImagePromptInput): CompiledImag
     for (const fragment of splitPromptFragments(part.value, fragmentMode, shouldDistill)) {
       const negative = extractNegativeFragment(fragment);
       if (negative) {
-        negativeFragments.push(negative);
+        negativeFragments.push(...splitNegativePromptItems(negative));
         movedNegativeFragments.push(fragment);
       } else if (hasAvoidInstructionPrefix(fragment)) {
         movedNegativeFragments.push(fragment);
@@ -100,13 +103,15 @@ export function compileImagePrompt(input: CompileImagePromptInput): CompiledImag
 
   for (const part of negativeParts) {
     negativeFragments.push(
-      ...splitPromptFragments(part, promptMode).map((fragment) => cleanPromptFragment(fragment, promptMode)),
+      ...splitPromptFragments(part, promptMode)
+        .flatMap(splitNegativePromptItems)
+        .map((fragment) => cleanPromptFragment(fragment, promptMode)),
     );
   }
 
   const hardPrefix = dedupeFragments(hardPrefixFragments, profile.rules.dedupeStrength, positiveDiagnostics);
   let positive = compactPromptFragments(
-    [...hardPrefix, ...dedupeFragments(positiveFragments, profile.rules.dedupeStrength, positiveDiagnostics)],
+    dedupeFragments([...hardPrefix, ...positiveFragments], profile.rules.dedupeStrength, positiveDiagnostics),
     compactPrompt,
     hardPrefix.length,
   );
@@ -117,7 +122,7 @@ export function compileImagePrompt(input: CompileImagePromptInput): CompiledImag
 
   return {
     prompt: joinFragments(positive, compactPrompt ? "tagged" : promptMode),
-    negativePrompt: joinFragments(negative, promptMode),
+    negativePrompt: joinFragments(negative, "tagged"),
     profile,
     diagnostics: {
       removedPositiveDuplicates: positiveDiagnostics,
@@ -209,8 +214,15 @@ function splitPromptFragments(
     .filter(Boolean);
 }
 
+function splitNegativePromptItems(value: string): string[] {
+  return value
+    .split(/[,;]/g)
+    .map((part) => part.trim())
+    .filter(Boolean);
+}
+
 function distillTaggedPromptSource(value: string): string {
-  const fragments: string[] = deriveTaggedSourceCues(value);
+  const fragments: string[] = [];
   for (const raw of value.split(/\n+|(?<=[.!?])\s+/g)) {
     const sentence = raw.trim();
     if (!sentence) continue;
@@ -260,25 +272,90 @@ function distillTaggedPromptSource(value: string): string {
       }
     }
   }
+  if (fragments.length === 0) {
+    fragments.push(...fallbackTaggedSourceFragments(value));
+  }
   return fragments.join(", ");
 }
 
 function deriveTaggedSourceCues(value: string): string[] {
   const cues: string[] = [];
   const text = value.toLowerCase();
-  if (/\b(?:non[-\s]?binary|enby|androgynous|genderless|agender|they\/them)\b/.test(text)) {
-    cues.push("androgynous");
-  } else if (/\b(?:she|her|hers|woman|female|girl|lady)\b/.test(text)) {
-    cues.push("female");
-  } else if (/\b(?:he|him|his|man|male|boy|gentleman)\b/.test(text)) {
-    cues.push("male");
-  }
+  const genderCue = deriveGenderCue(text);
+  if (genderCue) cues.push(genderCue);
   if (/\bhuman(?:oid)?\s+person\b|\bhuman or humanoid\b/.test(text)) {
     cues.push("human");
   }
   const ageCue = deriveAgeCue(text);
   if (ageCue) cues.push(ageCue);
   return cues;
+}
+
+function reconcileProfileSubjectTags(tags: string, sourceCues: string[]): string {
+  const genderCue = sourceCues.find((cue) => /^(?:female|male|androgynous)$/.test(cue));
+  if (!tags.trim() || !genderCue) return tags;
+
+  return tags
+    .split(/[,;\n]+/g)
+    .map((tag) => tag.trim())
+    .filter(Boolean)
+    .flatMap((tag) => reconcileGenderedTag(tag, genderCue))
+    .join(", ");
+}
+
+function reconcileGenderedTag(tag: string, genderCue: string): string[] {
+  const clean = tag.trim();
+  const normalized = clean.toLowerCase().replace(/[_-]+/g, " ");
+  const isFemale = /^(?:1girl|female|woman|girl|lady)$/.test(normalized);
+  const isMale = /^(?:1boy|male|man|boy|gentleman)$/.test(normalized);
+  if (genderCue === "female") {
+    if (normalized === "1boy") return ["1girl"];
+    return isMale ? [] : [clean];
+  }
+  if (genderCue === "male") {
+    if (normalized === "1girl") return ["1boy"];
+    return isFemale ? [] : [clean];
+  }
+  if (isFemale || isMale) return [];
+  return [clean];
+}
+
+function deriveGenderCue(text: string): string | null {
+  if (/\b(?:non[-\s]?binary|enby|androgynous|genderless|agender|they\/them)\b/.test(text)) {
+    return "androgynous";
+  }
+
+  const subjectWindow = text.slice(0, 480);
+  const maleExplicit = countPattern(subjectWindow, /\b(?:man|male|boy|gentleman|bearded|father|king|prince)\b/g);
+  const femaleExplicit = countPattern(
+    subjectWindow,
+    /\b(?:woman|female|girl|lady|mother|queen|princess)\b/g,
+  );
+  if (maleExplicit > femaleExplicit) return "male";
+  if (femaleExplicit > maleExplicit) return "female";
+  if (maleExplicit > 0 || femaleExplicit > 0) return null;
+
+  const pronounText = subjectWindow.replace(/\bher\s+majesty\b/g, "").replace(/\bhis\s+majesty\b/g, "");
+  const malePronouns = countPattern(pronounText, /\b(?:he|him|his)\b/g);
+  const femalePronouns = countPattern(pronounText, /\b(?:she|her|hers)\b/g);
+  if (malePronouns >= 2 && malePronouns > femalePronouns) return "male";
+  if (femalePronouns >= 2 && femalePronouns > malePronouns) return "female";
+  return null;
+}
+
+function countPattern(value: string, pattern: RegExp): number {
+  return value.match(pattern)?.length ?? 0;
+}
+
+function fallbackTaggedSourceFragments(value: string): string[] {
+  return value
+    .split(/\n+|(?<=[.!?])\s+/g)
+    .map((fragment) => cleanPromptFragment(fragment, "tagged"))
+    .filter((fragment) => {
+      if (!fragment || looksLikeNameOnly(fragment)) return false;
+      if (extractNegativeFragment(fragment) || hasAvoidInstructionPrefix(fragment)) return false;
+      return shouldKeepTaggedSourceFragment(fragment);
+    });
 }
 
 function deriveAgeCue(text: string): string | null {
@@ -489,21 +566,21 @@ function extractNegativeFragment(fragment: string): string | null {
   const clean = fragment.trim();
   const match = clean.match(/^(?:avoid|no|without|exclude|do not include|don't include)\s+(.+)$/i);
   if (!match?.[1]) return null;
-  const negative = match[1].replace(/[.]+$/g, "").trim();
-  if (!negative || !looksLikeImageNegativeFragment(negative)) return null;
+  const negative = match[1]
+    .replace(/[.]+$/g, "")
+    .replace(/^(?:any|all)\s+/i, "")
+    .trim();
+  if (!negative || looksLikeNonImageNegativeFragment(negative)) return null;
   return negative;
 }
 
 function hasAvoidInstructionPrefix(fragment: string): boolean {
-  return /^(?:avoid|exclude|do not include|don't include)\b/i.test(fragment.trim());
+  return /^(?:avoid|no|without|exclude|do not include|don't include)\b/i.test(fragment.trim());
 }
 
-function looksLikeImageNegativeFragment(value: string): boolean {
+function looksLikeNonImageNegativeFragment(value: string): boolean {
   const clean = value.trim();
-  if (/^(?:matter|actual talents?|talents?|skills?|known spells?)\b/i.test(clean)) return false;
-  return /\b(?:anime|cartoons?|illustrations?|paintings?|plastic skin|uncanny|low quality|worst quality|bad quality|blurry|blur|out of focus|text|letters|captions?|subtitles?|ui|user interface|watermarks?|logos?|signatures?|bad anatomy|bad hands|extra fingers|fingers|digits|malformed|distorted|lowres|extra limbs?|missing limbs?)\b/i.test(
-    clean,
-  );
+  return /^(?:matter|actual talents?|talents?|skills?|known spells?)\b/i.test(clean);
 }
 
 function cleanPromptFragment(fragment: string, promptMode: ImageStyleProfile["promptMode"]): string {

--- a/packages/shared/src/utils/music-score.ts
+++ b/packages/shared/src/utils/music-score.ts
@@ -448,7 +448,6 @@ export function scoreAmbient(input: AmbientScoreInput): string | null {
   } else {
     keywords.push(...(STATE_AMBIENT[state] ?? []));
   }
-  keywords.push(...(STATE_AMBIENT[state] ?? []));
   if (weather) keywords.push(...(WEATHER_AMBIENT[weather.toLowerCase()] ?? []));
   if (timeOfDay) keywords.push(...(TIME_AMBIENT[timeOfDay.toLowerCase()] ?? []));
 

--- a/packages/shared/src/utils/tracker-field-locks.ts
+++ b/packages/shared/src/utils/tracker-field-locks.ts
@@ -527,36 +527,46 @@ function findCurrentCharacterMatch(
   next: Partial<PresentCharacter>,
   currentCharacters: PresentCharacter[],
   fallbackIndex: number,
+  usedCurrent: Set<number>,
 ) {
   const id = typeof next.characterId === "string" ? next.characterId.trim() : "";
   if (id) {
-    const byId = currentCharacters.findIndex((character) => character.characterId === id);
+    const byId = currentCharacters.findIndex((character, index) => !usedCurrent.has(index) && character.characterId === id);
     if (byId >= 0) return { index: byId, matchedByIdentity: true };
   }
   const name = normalizeComparableText(next.name);
   if (name) {
-    const byName = currentCharacters.findIndex((character) => normalizeComparableText(character.name) === name);
+    const byName = currentCharacters.findIndex((character, index) => {
+      return !usedCurrent.has(index) && normalizeComparableText(character.name) === name;
+    });
     if (byName >= 0) return { index: byName, matchedByIdentity: true };
   }
   return {
-    index: fallbackIndex < currentCharacters.length ? fallbackIndex : -1,
+    index: fallbackIndex < currentCharacters.length && !usedCurrent.has(fallbackIndex) ? fallbackIndex : -1,
     matchedByIdentity: false,
   };
 }
 
-function findCurrentQuestMatch(next: Partial<QuestProgress>, currentQuests: QuestProgress[], fallbackIndex: number) {
+function findCurrentQuestMatch(
+  next: Partial<QuestProgress>,
+  currentQuests: QuestProgress[],
+  fallbackIndex: number,
+  usedCurrent: Set<number>,
+) {
   const id = typeof next.questEntryId === "string" ? next.questEntryId.trim() : "";
   if (id) {
-    const byId = currentQuests.findIndex((quest) => quest.questEntryId === id);
+    const byId = currentQuests.findIndex((quest, index) => !usedCurrent.has(index) && quest.questEntryId === id);
     if (byId >= 0) return { index: byId, matchedByIdentity: true };
   }
   const name = normalizeComparableText(next.name);
   if (name) {
-    const byName = currentQuests.findIndex((quest) => normalizeComparableText(quest.name) === name);
+    const byName = currentQuests.findIndex((quest, index) => {
+      return !usedCurrent.has(index) && normalizeComparableText(quest.name) === name;
+    });
     if (byName >= 0) return { index: byName, matchedByIdentity: true };
   }
   return {
-    index: fallbackIndex < currentQuests.length ? fallbackIndex : -1,
+    index: fallbackIndex < currentQuests.length && !usedCurrent.has(fallbackIndex) ? fallbackIndex : -1,
     matchedByIdentity: false,
   };
 }
@@ -598,6 +608,7 @@ function mergeNamedRowsWithLocks<T extends { name?: string }>(
     const currentRow = currentIndex >= 0 ? current[currentIndex] : null;
     if (!currentRow) return row;
     if (!match.matchedByIdentity && hasLockWithPrefix(locks, prefixFor(currentRow, currentIndex))) {
+      usedCurrent.add(currentIndex);
       return row;
     }
     usedCurrent.add(currentIndex);
@@ -721,11 +732,12 @@ function mergeQuestsWithLocks(
   const current = currentQuests ?? [];
   const usedCurrent = new Set<number>();
   const merged = nextQuests.map((quest, index) => {
-    const match = findCurrentQuestMatch(quest, current, index);
+    const match = findCurrentQuestMatch(quest, current, index, usedCurrent);
     const currentIndex = match.index;
     const currentQuest = currentIndex >= 0 ? current[currentIndex] : null;
     if (!currentQuest) return quest;
     if (!match.matchedByIdentity && hasLockWithPrefix(locks, `${questTrackerLockPrefix(currentQuest, currentIndex)}.`)) {
+      usedCurrent.add(currentIndex);
       return quest;
     }
     usedCurrent.add(currentIndex);
@@ -787,7 +799,7 @@ function mergeCharactersWithLocks(
   const current = currentCharacters ?? [];
   const usedCurrent = new Set<number>();
   const merged = nextCharacters.map((character, index) => {
-    const match = findCurrentCharacterMatch(character, current, index);
+    const match = findCurrentCharacterMatch(character, current, index, usedCurrent);
     const currentIndex = match.index;
     const currentCharacter = currentIndex >= 0 ? current[currentIndex] : null;
     if (!currentCharacter) return character;
@@ -795,6 +807,7 @@ function mergeCharactersWithLocks(
       !match.matchedByIdentity &&
       hasLockWithPrefix(locks, `${characterTrackerLockPrefix(currentCharacter, currentIndex)}.`)
     ) {
+      usedCurrent.add(currentIndex);
       return character;
     }
     usedCurrent.add(currentIndex);


### PR DESCRIPTION
## Linked issue

Closes #2734
Closes #2735
Closes #2736
Closes #2737
Closes #2738

## Why this change

- Fixes five assigned release-blocking or low-severity regressions found after the recent staging work: broken llama.cpp sidecar chat, tracker lock duplication, prompt/generation robustness drift, text rewrite HTML loss, and Chat Summary marker UX confusion.

## What changed

- Restored llama.cpp sidecar chat readiness by avoiding embedding-only pooling and probing completion readiness for local sidecars.
- Prevented tracker field-lock merge duplication by tracking matched current rows across named character and quest merges.
- Hardened generation edge cases: shared agent tool-loop deadline, depth-0 chat history ordering, non-streaming game setup JSON, conclusion JSON repair dedupe, and recursive lorebook group caps.
- Preserved protected HTML/fenced markup for strict text rewrite agents and skipped destructive rewrites that drop protected markup.
- Clarified Chat Summary marker copy, added active-preset diagnostics in the Summary popover, and aligned roleplay summary reads across real generation, preview, retry, and chat prompt inspection.

## Validation

- [ ] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed `CONTRIBUTING.md`

### Manual verification notes

- `pnpm check` passed locally in `/tmp/marinara-issues-2734-2738`.
- The local shell is using Node 20.11.1, so the command emitted repo/Vite engine warnings before completing successfully. Repo currently wants Node >=24 <26.
- Manual browser verification remains for a human reviewer.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Version/release files updated (only if this PR includes a version bump)

## UI evidence (if applicable)

- Not captured. The UI change is a small Chat Summary diagnostic callout and marker description copy update.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Chat summary injection hints now available in roleplay mode
  * Enhanced voice selection UI with saved voice indicators

* **Bug Fixes**
  * Generation abort now properly targets specific chats
  * Fixed chat settings preset dropdown state handling
  * Fixed connection URL validation and normalization
  * Fixed sprite generation cancellation and save workflows
  * Improved streaming robustness and error handling

* **Performance**
  * Voice cache management improvements with bounds
  * Added generation concurrency limits

<!-- end of auto-generated comment: release notes by coderabbit.ai -->