### PR TITLE
Update container release tag examples

### DIFF
--- a/docs/installation/containers.md
+++ b/docs/installation/containers.md
@@ -10,7 +10,7 @@ docker compose up -d
 
 Then open **<http://127.0.0.1:7860>**.
 
-The Compose file tracks `ghcr.io/pasta-devs/marinara-engine:latest`. Every tagged release also publishes immutable version tags, such as `ghcr.io/pasta-devs/marinara-engine:1.6.1`, plus the matching lite tag `ghcr.io/pasta-devs/marinara-engine:1.6.1-lite`.
+The Compose file tracks `ghcr.io/pasta-devs/marinara-engine:latest`. Every tagged release also publishes immutable version tags, such as `ghcr.io/pasta-devs/marinara-engine:2.0.0`, plus the matching lite tag `ghcr.io/pasta-devs/marinara-engine:2.0.0-lite`.
 
 Compose binds to `127.0.0.1` by default. To expose the container to your LAN, change the port mapping to `${PORT:-7860}:7860`, set `BASIC_AUTH_USER`, `BASIC_AUTH_PASS`, and `ADMIN_SECRET`, then restart. See [Access Control](../CONFIGURATION.md#access-control).
 
@@ -101,7 +101,7 @@ docker build -f Dockerfile.lite -t marinara-engine:lite .
 docker run -d -p 127.0.0.1:7860:7860 -v marinara-data:/app/data marinara-engine:lite
 ```
 
-> **Note:** The lite image is published alongside each versioned release (e.g. `ghcr.io/pasta-devs/marinara-engine:1.5.4-lite`). It is **not** published on every push to `main`.
+> **Note:** The lite image is published alongside each versioned release (e.g. `ghcr.io/pasta-devs/marinara-engine:2.0.0-lite`). It is **not** published on every push to `main`.
 
 ## Updating
 


### PR DESCRIPTION
## Why this change

The v2.0.0 release prep audit found stale container documentation examples that still referenced older release tags.

## What changed

- Updated container guide example image tags to use 2.0.0 and 2.0.0-lite.

## Validation

- pnpm version:check
- pnpm guard:installer-artifacts
- pnpm release:notes -- 2.0.0 --output /tmp/marinara-release-notes-2.0.0.md
- git diff --check
- pnpm check
- pnpm test
- makensis installer.nsi
- docker build --build-arg BUILD_COMMIT=$(git rev-parse --short=12 HEAD) -t marinara-engine:release-audit .
- docker run smoke test against /api/health on the local release-audit image

## Manual validation needed

- Confirm final GitHub Release assets after the v2.0.0 tag workflows finish.
- Confirm Android APK install/start flow on a physical Android device after the release APK is built.