### PR TITLE
Publish staging container tag

### DIFF
--- a/.github/workflows/build-container-lite.yml
+++ b/.github/workflows/build-container-lite.yml
@@ -2,7 +2,7 @@
 # Build & push lite container image to GHCR
 # ──────────────────────────────────────────────
 # Triggers:
-#   • Tag v*  → ghcr.io/pasta-devs/marinara-engine:1.5.4-lite + :lite
+#   • Tag v*  → ghcr.io/pasta-devs/marinara-engine:2.0.0-lite + :lite
 #   • Manual workflow_dispatch
 # NOT triggered on push to main — lite images are only published
 # alongside versioned releases.
@@ -149,10 +149,20 @@ jobs:
         id: manifest
         working-directory: /tmp/digests
         run: |
-          tags=$(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON")
           image="${{ env.REGISTRY }}/${{ steps.lower.outputs.image }}"
-          digests=$(printf "${image}@sha256:%s " *)
-          docker buildx imagetools create $tags $digests
+          tag_args=()
+          while IFS= read -r tag; do
+            tag_args+=("-t" "$tag")
+          done < <(jq -r '.tags[]' <<< "$DOCKER_METADATA_OUTPUT_JSON")
+          digest_args=()
+          for digest_file in *; do
+            digest_args+=("${image}@sha256:${digest_file}")
+          done
+          if [ "${#digest_args[@]}" -eq 0 ]; then
+            echo "No digest files found" >&2
+            exit 1
+          fi
+          docker buildx imagetools create "${tag_args[@]}" "${digest_args[@]}"
           digest=$(docker buildx imagetools inspect "$image:${{ steps.meta.outputs.version }}" --raw | sha256sum | cut -d' ' -f1 | sed 's/^/sha256:/')
           echo "digest=$digest" >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/build-container.yml
+++ b/.github/workflows/build-container.yml
@@ -2,15 +2,16 @@
 # Build & push Container image to GitHub Container Registry (ghcr.io)
 # ──────────────────────────────────────────────
 # Triggers:
+#   • Push to staging         → ghcr.io/pasta-devs/marinara-engine:staging
 #   • Push to main            → ghcr.io/pasta-devs/marinara-engine:sha-abc1234
-#   • Tag v*                  → ghcr.io/pasta-devs/marinara-engine:1.4.0 + :latest
-#   • Manual workflow_dispatch → same as push-to-main
+#   • Tag v*                  → ghcr.io/pasta-devs/marinara-engine:2.0.0 + :latest
+#   • Manual workflow_dispatch → same tags as the selected branch or tag
 # ──────────────────────────────────────────────
 name: Build & Push Container Image
 
 on:
   push:
-    branches: [main]
+    branches: [main, staging]
     tags: ["v*"]
     paths-ignore:
       # Documentation & metadata
@@ -87,6 +88,8 @@ jobs:
         with:
           images: ${{ env.REGISTRY }}/${{ steps.lower.outputs.image }}
           tags: |
+            # On push to staging → :staging
+            type=raw,value=staging,enable=${{ github.ref == 'refs/heads/staging' }}
             # On push to main → :sha-<short> :main
             type=sha,prefix=sha-,enable={{is_default_branch}}
             type=raw,value=main,enable={{is_default_branch}}
@@ -168,6 +171,8 @@ jobs:
         with:
           images: ${{ env.REGISTRY }}/${{ steps.lower.outputs.image }}
           tags: |
+            # On push to staging → :staging
+            type=raw,value=staging,enable=${{ github.ref == 'refs/heads/staging' }}
             # On push to main → :sha-<short> :main
             type=sha,prefix=sha-,enable={{is_default_branch}}
             type=raw,value=main,enable={{is_default_branch}}
@@ -181,10 +186,20 @@ jobs:
         id: manifest
         working-directory: /tmp/digests
         run: |
-          tags=$(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON")
           image="${{ env.REGISTRY }}/${{ steps.lower.outputs.image }}"
-          digests=$(printf "${image}@sha256:%s " *)
-          docker buildx imagetools create $tags $digests
+          tag_args=()
+          while IFS= read -r tag; do
+            tag_args+=("-t" "$tag")
+          done < <(jq -r '.tags[]' <<< "$DOCKER_METADATA_OUTPUT_JSON")
+          digest_args=()
+          for digest_file in *; do
+            digest_args+=("${image}@sha256:${digest_file}")
+          done
+          if [ "${#digest_args[@]}" -eq 0 ]; then
+            echo "No digest files found" >&2
+            exit 1
+          fi
+          docker buildx imagetools create "${tag_args[@]}" "${digest_args[@]}"
           # Get the digest of the pushed manifest list using raw format
           digest=$(docker buildx imagetools inspect "$image:${{ steps.meta.outputs.version }}" --raw | sha256sum | cut -d' ' -f1 | sed 's/^/sha256:/')
           echo "digest=$digest" >> "$GITHUB_OUTPUT"

--- a/docs/installation/containers.md
+++ b/docs/installation/containers.md
@@ -28,6 +28,33 @@ To pull the latest image and restart:
 docker compose down && docker compose pull && docker compose up -d
 ```
 
+### Staging Image
+
+An unstable `ghcr.io/pasta-devs/marinara-engine:staging` image is published from the latest `staging` branch build. Use it only for testing unreleased changes.
+
+Use a separate data volume for staging so unstable builds cannot mutate your stable release data:
+
+```bash
+docker run -d \
+  --name marinara-staging \
+  -p 127.0.0.1:7860:7860 \
+  -v marinara-staging-data:/app/data \
+  ghcr.io/pasta-devs/marinara-engine:staging
+```
+
+To update that staging container:
+
+```bash
+docker pull ghcr.io/pasta-devs/marinara-engine:staging
+docker rm -f marinara-staging 2>/dev/null || true
+docker run -d --name marinara-staging \
+  -p 127.0.0.1:7860:7860 \
+  -v marinara-staging-data:/app/data \
+  ghcr.io/pasta-devs/marinara-engine:staging
+```
+
+> **Warning:** The staging image may be broken, may change behavior without release notes, and may not support downgrading data back to stable builds. `:latest` remains the recommended stable release image.
+
 ### Build from Source
 
 If you prefer to build the image yourself:


### PR DESCRIPTION
## Why this change

Users asked for an unstable Docker image tag that follows the latest staging branch without moving the stable :latest release tag.

## What changed

- Build the full container image on pushes to staging.
- Publish the staging branch image as ghcr.io/pasta-devs/marinara-engine:staging.
- Document the staging image with a separate-volume warning.
- Clean up shell-safe manifest argument handling in container workflows.

## Validation

- docker run --rm -v "$PWD":/repo -w /repo rhysd/actionlint:latest -color=false .github/workflows/build-container.yml .github/workflows/build-container-lite.yml
- git diff --check
- pnpm version:check
- pnpm guard:installer-artifacts

## Manual validation needed

- Confirm the Build & Push Container Image workflow publishes :staging after this PR lands in staging.
- Confirm GHCR shows ghcr.io/pasta-devs/marinara-engine:staging after the workflow completes.