### PR TITLE
[codex] Refine accent and editor theming

### DIFF
--- a/packages/client/src/App.tsx
+++ b/packages/client/src/App.tsx
@@ -20,7 +20,12 @@ import {
 import { useSidecarStore } from "./stores/sidecar.store";
 import { api } from "./lib/api-client";
 import { forceRefreshSpa } from "./lib/browser-runtime";
-import { getCssColorFallback, getCssGradientColorStops, isCssGradient } from "./lib/css-colors";
+import {
+  getCssColorFallback,
+  getCssGradientColorStops,
+  isCssGradient,
+  RAINBOW_GRADIENT_PRESET,
+} from "./lib/css-colors";
 import { useLegacyThemeMigration } from "./hooks/use-themes";
 import { useLegacyExtensionMigration } from "./hooks/use-extensions";
 import { useSettingsSync } from "./hooks/use-settings-sync";
@@ -269,8 +274,13 @@ export function App() {
     const accentSource = accent || defaultAccent;
     const solidAccent = getCssColorFallback(accentSource, defaultAccent);
     const accentIsGradient = isCssGradient(accentSource);
-    const accentAnimationEnabled = (appAccentRgbMode && accentIsGradient) || (appAccentPulseMode && !accentIsGradient);
-    const gradientStops = accentIsGradient ? getCssGradientColorStops(accentSource, solidAccent) : [solidAccent];
+    const animatedAccentSource = appAccentRgbMode ? RAINBOW_GRADIENT_PRESET : accentSource;
+    const animatedSolidAccent = getCssColorFallback(animatedAccentSource, solidAccent);
+    const animatedAccentIsGradient = isCssGradient(animatedAccentSource);
+    const animatedGradientStops = animatedAccentIsGradient
+      ? getCssGradientColorStops(animatedAccentSource, animatedSolidAccent)
+      : [animatedSolidAccent];
+    const accentAnimationEnabled = appAccentRgbMode || appAccentPulseMode;
 
     let accentAnimationTimer: ReturnType<typeof window.setInterval> | null = null;
 
@@ -301,7 +311,9 @@ export function App() {
 
     const applyLiveAccent = () => {
       const liveAccent =
-        accentIsGradient && gradientStops.length > 1 ? getGradientRgbAccent(gradientStops) : getSolidRgbAccent(solidAccent);
+        animatedAccentIsGradient && animatedGradientStops.length > 1
+          ? getGradientRgbAccent(animatedGradientStops)
+          : getSolidRgbAccent(animatedSolidAccent);
 
       applyAppAccentVariables({
         root,
@@ -323,7 +335,8 @@ export function App() {
     };
 
     const startAccentAnimation = () => {
-      root.dataset.marinaraAccentAnimation = accentIsGradient && gradientStops.length > 1 ? "gradient" : "solid";
+      root.dataset.marinaraAccentAnimation =
+        animatedAccentIsGradient && animatedGradientStops.length > 1 ? "gradient" : "solid";
       applyLiveAccent();
       if (accentAnimationTimer === null) {
         accentAnimationTimer = window.setInterval(applyLiveAccent, ACCENT_RGB_TICK_MS);

--- a/packages/client/src/components/agents/SecretPlotPanel.tsx
+++ b/packages/client/src/components/agents/SecretPlotPanel.tsx
@@ -216,7 +216,7 @@ export function SecretPlotPanel({
 
       {open && (
         <div className="space-y-2 border-t border-[var(--border)] pt-2 text-[0.625rem]">
-          {isLoading && <p className="py-2 text-center text-[var(--muted-foreground)]">Loading secret plot...</p>}
+          {isLoading && <p className="mari-chrome-text-muted py-2 text-center">Loading secret plot...</p>}
           {isError && (
             <p className="rounded-md border border-[var(--destructive)]/25 bg-[var(--destructive)]/10 px-2 py-1.5 text-center text-[var(--destructive)]">
               Could not load Director memory.

--- a/packages/client/src/components/layout/AppShell.tsx
+++ b/packages/client/src/components/layout/AppShell.tsx
@@ -126,7 +126,7 @@ function getViewportWidth() {
 
 function MainPaneFallback() {
   return (
-    <div className="flex flex-1 items-center justify-center text-sm text-[var(--muted-foreground)]">Loading...</div>
+    <div className="mari-chrome-text-muted flex flex-1 items-center justify-center text-sm">Loading...</div>
   );
 }
 /** Mounts children once `open` becomes true, then keeps them mounted so state persists.
@@ -169,7 +169,7 @@ function MountOnceWhenOpened({
 
 function SidePanelFallback() {
   return (
-    <div className="flex h-full items-center justify-center text-sm text-[var(--muted-foreground)]">Loading...</div>
+    <div className="mari-chrome-text-muted flex h-full items-center justify-center text-sm">Loading...</div>
   );
 }
 

--- a/packages/client/src/components/layout/ChatSidebar.tsx
+++ b/packages/client/src/components/layout/ChatSidebar.tsx
@@ -1089,7 +1089,7 @@ export function ChatSidebar() {
           title={`New ${activeModeConfig.label}`}
           aria-label={`New ${activeModeConfig.label}`}
         >
-          <Plus size="0.8125rem" />
+          <Plus size="0.8125rem" className="mari-chrome-accent-icon mari-accent-animated" />
         </button>
         <button
           onClick={() => chatImportInputRef.current?.click()}
@@ -1295,7 +1295,8 @@ export function ChatSidebar() {
                 activeModeConfig.logoModeClass,
               )}
             >
-              + New {activeTab === "conversation" ? "Conversation" : activeTab === "game" ? "Game" : "Roleplay"}
+              <span className="mari-chrome-accent-icon mari-accent-animated">+</span>
+              New {activeTab === "conversation" ? "Conversation" : activeTab === "game" ? "Game" : "Roleplay"}
             </button>
           </div>
         )}

--- a/packages/client/src/components/layout/TopBar.tsx
+++ b/packages/client/src/components/layout/TopBar.tsx
@@ -62,6 +62,7 @@ const TOPBAR_BUTTON_CLASS = "relative rounded-lg p-2 transition-all hover:bg-[va
 const TOPBAR_PANEL_BUTTON_CLASS = "relative rounded-lg p-2 transition-all duration-200 max-sm:p-1.5";
 const TOPBAR_ACTIVE_BUTTON_CLASS = "bg-[var(--accent)] shadow-sm";
 const TOPBAR_FORCE_HOVER_CLASS = "bg-[var(--accent)]";
+const TOPBAR_ACCENT_ICON_CLASS = "mari-topbar-accent-icon mari-accent-animated";
 const CHAT_TOPBAR_GRADIENT_ID = "mari-topbar-chats-gradient";
 
 export function TopBar() {
@@ -224,7 +225,7 @@ export function TopBar() {
             )}
             title="Chats"
           >
-            <MessageSquareText size="0.9375rem">
+            <MessageSquareText size="0.9375rem" className={TOPBAR_ACCENT_ICON_CLASS}>
               <defs>
                 <linearGradient
                   id={CHAT_TOPBAR_GRADIENT_ID}
@@ -255,7 +256,7 @@ export function TopBar() {
             className={cn(
               TOPBAR_BUTTON_CLASS,
               isHomeActive
-                ? cn(TOPBAR_ACTIVE_BUTTON_CLASS, "mari-chrome-accent-icon mari-accent-animated")
+                ? TOPBAR_ACTIVE_BUTTON_CLASS
                 : cn(
                     "text-[var(--muted-foreground)] hover:text-[var(--marinara-chat-chrome-button-text-hover)]",
                     isTopbarHovered("home") &&
@@ -264,9 +265,9 @@ export function TopBar() {
             )}
             title="Home"
           >
-            <Home size="0.9375rem" />
+            <Home size="0.9375rem" className={TOPBAR_ACCENT_ICON_CLASS} />
             {isHomeActive && (
-              <span className="mari-topbar-active-underline mari-accent-animated absolute -bottom-0.5 left-1/2 h-0.5 w-3 -translate-x-1/2 rounded-full" />
+              <span className="mari-topbar-active-underline absolute -bottom-0.5 left-1/2 h-0.5 w-3 -translate-x-1/2 rounded-full" />
             )}
           </button>
         </div>
@@ -297,7 +298,7 @@ export function TopBar() {
           )}
           title="Browser"
         >
-          <Bot size="0.9375rem" />
+          <Bot size="0.9375rem" className={TOPBAR_ACCENT_ICON_CLASS} />
           {isBotBrowserActive && (
             <span className="absolute -bottom-0.5 left-1/2 h-0.5 w-3 -translate-x-1/2 rounded-full bg-gradient-to-r from-lime-400 via-green-500 to-cyan-500" />
           )}
@@ -318,7 +319,7 @@ export function TopBar() {
           )}
           title="Characters"
         >
-          <Users size="0.9375rem" />
+          <Users size="0.9375rem" className={TOPBAR_ACCENT_ICON_CLASS} />
           {isCharactersPanelActive && (
             <span className="absolute -bottom-0.5 left-1/2 h-0.5 w-3 -translate-x-1/2 rounded-full bg-gradient-to-r from-pink-400 to-rose-500" />
           )}
@@ -342,7 +343,7 @@ export function TopBar() {
               )}
               title={label}
             >
-              <Icon size="0.9375rem" />
+              <Icon size="0.9375rem" className={TOPBAR_ACCENT_ICON_CLASS} />
               {isActive && (
                 <span
                   className={cn(
@@ -374,7 +375,7 @@ export function TopBar() {
           )}
           title="Settings"
         >
-          <Settings size="0.9375rem" />
+          <Settings size="0.9375rem" className={TOPBAR_ACCENT_ICON_CLASS} />
           {rightPanelOpen && rightPanel === "settings" && (
             <span className="absolute -bottom-0.5 left-1/2 h-0.5 w-3 -translate-x-1/2 rounded-full bg-gradient-to-r from-gray-400 to-gray-500" />
           )}

--- a/packages/client/src/components/lorebooks/LorebookEditor.tsx
+++ b/packages/client/src/components/lorebooks/LorebookEditor.tsx
@@ -1564,7 +1564,7 @@ export function LorebookEditor() {
 
   // ── Main editor ──
   return (
-    <div className="mari-editor-shell flex flex-1 flex-col overflow-hidden">
+    <div className="mari-editor-shell mari-editor-legacy-bridge flex flex-1 flex-col overflow-hidden">
       <ExportFormatDialog
         open={exportDialogOpen}
         title="Export Lorebook"

--- a/packages/client/src/components/panels/AgentsPanel.tsx
+++ b/packages/client/src/components/panels/AgentsPanel.tsx
@@ -852,7 +852,7 @@ export function AgentsPanel() {
         />
       </div>
 
-      {isLoading && <div className="py-4 text-center text-xs text-[var(--muted-foreground)]">Loading...</div>}
+      {isLoading && <div className="mari-chrome-text-muted py-4 text-center text-xs">Loading...</div>}
 
       {!hasVisibleAgents && (
         <p className="px-1 py-2 text-[0.625rem] text-[var(--muted-foreground)]">No agents match your search.</p>

--- a/packages/client/src/components/panels/BotBrowserPanel.tsx
+++ b/packages/client/src/components/panels/BotBrowserPanel.tsx
@@ -121,7 +121,7 @@ export function BotBrowserPanel() {
 
       {/* Character list */}
       {isLoading ? (
-        <div className="py-4 text-center text-xs text-[var(--muted-foreground)]">Loading...</div>
+        <div className="mari-chrome-text-muted py-4 text-center text-xs">Loading...</div>
       ) : filtered.length === 0 ? (
         <div className="py-4 text-center text-xs text-[var(--muted-foreground)]">
           {search ? "No matches" : "No imported characters yet"}

--- a/packages/client/src/components/panels/SettingsPanel.tsx
+++ b/packages/client/src/components/panels/SettingsPanel.tsx
@@ -28,7 +28,6 @@ import { ADMIN_SECRET_STORAGE_KEY, ApiError, api, getAdminSecretHeader } from ".
 import { chatBackgroundUrlToMetadata } from "../../lib/backgrounds";
 import { normalizeThemeCss } from "../../lib/theme-css";
 import { forceRefreshSpa } from "@/lib/browser-runtime";
-import { isCssGradient, RAINBOW_GRADIENT_PRESET } from "../../lib/css-colors";
 import React, { useRef, useState, useCallback, useEffect, useMemo } from "react";
 import { toast } from "sonner";
 import {
@@ -1771,8 +1770,6 @@ function AppearanceSettings() {
   const setAppBackgroundColor = useUIStore((s) => s.setAppBackgroundColor);
   const appAccentColor = useUIStore((s) => s.appAccentColor);
   const setAppAccentColor = useUIStore((s) => s.setAppAccentColor);
-  const appAccentColorBeforeRgbMode = useUIStore((s) => s.appAccentColorBeforeRgbMode);
-  const setAppAccentColorBeforeRgbMode = useUIStore((s) => s.setAppAccentColorBeforeRgbMode);
   const appAccentPulseMode = useUIStore((s) => s.appAccentPulseMode);
   const setAppAccentPulseMode = useUIStore((s) => s.setAppAccentPulseMode);
   const appAccentRgbMode = useUIStore((s) => s.appAccentRgbMode);
@@ -1783,7 +1780,6 @@ function AppearanceSettings() {
   const defaultAppAccentColor = getDefaultAppAccentColor(theme);
   const displayedAppAccentColor =
     appAccentColor.trim().toLowerCase() === defaultAppAccentColor.toLowerCase() ? "" : appAccentColor;
-  const appAccentIsGradient = isCssGradient(displayedAppAccentColor || defaultAppAccentColor);
   const visualTheme = useUIStore((s) => s.visualTheme);
   const setVisualTheme = useUIStore((s) => s.setVisualTheme);
   const chatBackground = useUIStore((s) => s.chatBackground);
@@ -1807,49 +1803,28 @@ function AppearanceSettings() {
     (color: string) => {
       const normalized = color.trim();
       const normalizedAccent = normalized.toLowerCase() === defaultAppAccentColor.toLowerCase() ? "" : normalized;
-      const nextAccent = normalizedAccent || defaultAppAccentColor;
 
       setAppAccentColor(normalizedAccent);
-
-      if (isCssGradient(nextAccent)) {
-        setAppAccentPulseMode(false);
-      }
-
-      if (appAccentRgbMode && !isCssGradient(nextAccent)) {
-        setAppAccentRgbMode(false);
-        setAppAccentColorBeforeRgbMode(null);
-      }
     },
-    [
-      appAccentRgbMode,
-      defaultAppAccentColor,
-      setAppAccentColor,
-      setAppAccentColorBeforeRgbMode,
-      setAppAccentPulseMode,
-      setAppAccentRgbMode,
-    ],
+    [defaultAppAccentColor, setAppAccentColor],
   );
   const handleAppAccentRgbModeChange = useCallback(
     (enabled: boolean) => {
-      if (enabled) {
-        setAppAccentColorBeforeRgbMode(appAccentColor);
-        setAppAccentColor(RAINBOW_GRADIENT_PRESET);
-        setAppAccentRgbMode(true);
-        return;
+      if (enabled && appAccentPulseMode) {
+        setAppAccentPulseMode(false);
       }
-      setAppAccentRgbMode(false);
-      if (appAccentColorBeforeRgbMode !== null) {
-        setAppAccentColor(appAccentColorBeforeRgbMode);
-        setAppAccentColorBeforeRgbMode(null);
-      }
+      setAppAccentRgbMode(enabled);
     },
-    [
-      appAccentColor,
-      appAccentColorBeforeRgbMode,
-      setAppAccentColor,
-      setAppAccentColorBeforeRgbMode,
-      setAppAccentRgbMode,
-    ],
+    [appAccentPulseMode, setAppAccentPulseMode, setAppAccentRgbMode],
+  );
+  const handleAppAccentPulseModeChange = useCallback(
+    (enabled: boolean) => {
+      if (enabled && appAccentRgbMode) {
+        setAppAccentRgbMode(false);
+      }
+      setAppAccentPulseMode(enabled);
+    },
+    [appAccentRgbMode, setAppAccentPulseMode, setAppAccentRgbMode],
   );
   // Persist background changes to the active chat's metadata immediately so
   // a clear (or pick) survives chat switches and page reloads. The effect-based
@@ -2115,41 +2090,30 @@ function AppearanceSettings() {
             gradient
             compact
             label="Accent Color"
-            helpText={
-              appAccentRgbMode
-                ? "Turn off RGB Mode to edit the saved accent color. While RGB Mode is on, the app accent is controlled by the animated rainbow preset."
-                : "Colors the shared app accent layer: buttons, active icons, focus rings, highlights, panel outlines, and chat chrome."
-            }
+            helpText="Colors the shared app accent layer: buttons, active icons, focus rings, highlights, panel outlines, and chat chrome. Accent Pulse animates this selected color."
             emptyText={`Default ${defaultAppAccentColor}`}
             emptyPreviewValue={defaultAppAccentColor}
             clearLabel="Reset to default"
-            disabled={appAccentRgbMode}
+          />
+
+          <ToggleSetting
+            label="Accent Pulse"
+            checked={appAccentPulseMode}
+            onChange={handleAppAccentPulseModeChange}
+            help="Animates the selected Accent Color. Solid colors gently brighten and darken; gradients cycle through their selected colors. Reduced-motion preferences are respected."
           />
 
           <ToggleSetting
             label={
-              <span
-                className={cn(
-                  appAccentRgbMode && appAccentIsGradient && "mari-logo-gradient-text mari-logo-gradient-text--active",
-                )}
-              >
+              <span className={cn(appAccentRgbMode && "mari-logo-gradient-text mari-logo-gradient-text--active")}>
                 RGB Mode
               </span>
             }
             checked={appAccentRgbMode}
             onChange={handleAppAccentRgbModeChange}
-            switchClassName={appAccentRgbMode && appAccentIsGradient ? "mari-rgb-toggle-track" : undefined}
-            help="Switches the app accent to the rainbow gradient while enabled, then restores your previous accent when disabled. Reduced-motion preferences are respected."
+            switchClassName={appAccentRgbMode ? "mari-rgb-toggle-track" : undefined}
+            help="Cycles the app accent through Marinara's rainbow palette while enabled. Your saved Accent Color stays unchanged. Reduced-motion preferences are respected."
           />
-
-          {!appAccentIsGradient && (
-            <ToggleSetting
-              label="Accent Pulse"
-              checked={appAccentPulseMode}
-              onChange={setAppAccentPulseMode}
-              help="Gently brightens and darkens solid accent colors. Reduced-motion preferences are respected."
-            />
-          )}
 
           <label className="flex flex-col gap-1">
             <span className="text-xs font-medium inline-flex items-center gap-1">
@@ -3731,7 +3695,7 @@ function ThemesSettings() {
             ))}
 
             {isLoading && syncedThemes.length === 0 && (
-              <p className="py-2 text-center text-[0.625rem] text-[var(--muted-foreground)]">
+              <p className="mari-chrome-text-muted py-2 text-center text-[0.625rem]">
                 Loading synced themes...
               </p>
             )}

--- a/packages/client/src/components/panels/settings/TrackerCardColorSettings.tsx
+++ b/packages/client/src/components/panels/settings/TrackerCardColorSettings.tsx
@@ -551,7 +551,7 @@ export function TrackerCardColorSettings() {
           Select a chat to edit tracker card colors.
         </p>
       ) : isLoadingGameState && targets.length === 0 ? (
-        <p className="rounded-md bg-[var(--secondary)]/42 px-2 py-2 text-[0.625rem] leading-relaxed text-[var(--muted-foreground)]">
+        <p className="mari-chrome-text-muted rounded-md bg-[var(--secondary)]/42 px-2 py-2 text-[0.625rem] leading-relaxed">
           Loading current tracker cards...
         </p>
       ) : targets.length === 0 ? (

--- a/packages/client/src/components/presets/PresetEditor.tsx
+++ b/packages/client/src/components/presets/PresetEditor.tsx
@@ -420,7 +420,7 @@ export function PresetEditor() {
   }
 
   return (
-    <div className="mari-editor-shell flex flex-1 flex-col overflow-hidden">
+    <div className="mari-editor-shell mari-editor-legacy-bridge flex flex-1 flex-col overflow-hidden">
       {/* ── Header ── */}
       <div className="mari-editor-header">
         <button onClick={handleClose} className="mari-editor-action inline-flex">
@@ -2604,7 +2604,7 @@ function ExpandedEditorModal({
     <PresetModalPortal>
       <div className="fixed inset-0 z-50 flex items-center justify-center p-3 pb-[max(0.75rem,env(safe-area-inset-bottom))] pt-[max(0.75rem,env(safe-area-inset-top))] sm:p-6">
         <div className="absolute inset-0 bg-black/60 backdrop-blur-sm" onClick={handleClose} />
-        <div className="mari-editor-shell relative flex h-[80vh] max-h-[calc(100vh-1.5rem)] w-full max-w-3xl flex-col rounded-2xl border border-[var(--marinara-editor-border)] bg-[var(--marinara-editor-surface-bg)] shadow-2xl shadow-black/50 supports-[height:100dvh]:h-[80dvh] supports-[height:100dvh]:max-h-[calc(100dvh-1.5rem)]">
+        <div className="mari-editor-shell mari-editor-legacy-bridge relative flex h-[80vh] max-h-[calc(100vh-1.5rem)] w-full max-w-3xl flex-col rounded-2xl border border-[var(--marinara-editor-border)] bg-[var(--marinara-editor-surface-bg)] shadow-2xl shadow-black/50 supports-[height:100dvh]:h-[80dvh] supports-[height:100dvh]:max-h-[calc(100dvh-1.5rem)]">
           {/* Header */}
           <div className="flex items-center justify-between border-b border-[var(--border)] px-4 py-3">
             <h3 className="text-sm font-semibold">{title}</h3>

--- a/packages/client/src/stores/ui.store.ts
+++ b/packages/client/src/stores/ui.store.ts
@@ -10,7 +10,7 @@ import {
   type ImageStyleProfileSettings,
   type QuoteFormat,
 } from "@marinara-engine/shared";
-import { isCssGradient } from "../lib/css-colors";
+import { isCssGradient, RAINBOW_GRADIENT_PRESET } from "../lib/css-colors";
 
 type Panel =
   | "chat"
@@ -1772,7 +1772,7 @@ export const useUIStore = create<UIState>()(
     }),
     {
       name: "marinara-engine-ui",
-      version: 61,
+      version: 62,
       // Debounce localStorage writes to avoid sync I/O on every state change
       storage: createJSONStorage(() => {
         let timer: ReturnType<typeof setTimeout> | null = null;
@@ -2181,6 +2181,16 @@ export const useUIStore = create<UIState>()(
         }
         if (version <= 60 && persisted.appAccentPulseMode === undefined) {
           persisted.appAccentPulseMode = false;
+        }
+        if (
+          version <= 61 &&
+          persisted.appAccentRgbMode === true &&
+          persisted.appAccentColor === RAINBOW_GRADIENT_PRESET &&
+          persisted.appAccentColorBeforeRgbMode !== null &&
+          persisted.appAccentColorBeforeRgbMode !== undefined
+        ) {
+          persisted.appAccentColor = persisted.appAccentColorBeforeRgbMode;
+          persisted.appAccentColorBeforeRgbMode = null;
         }
         persisted.characterLibrarySort = normalizeCharacterLibrarySort(persisted.characterLibrarySort);
         persisted.characterPanelScrollTop = normalizeScrollTop(persisted.characterPanelScrollTop);

--- a/packages/client/src/styles/globals.css
+++ b/packages/client/src/styles/globals.css
@@ -888,6 +888,11 @@
   stroke: url(#mari-topbar-chats-gradient);
 }
 
+.mari-topbar .mari-topbar-accent-icon {
+  color: var(--marinara-chat-chrome-button-text-active);
+  stroke: currentColor;
+}
+
 .mari-topbar-chat-gradient-underline {
   background: linear-gradient(
     90deg,
@@ -1081,13 +1086,16 @@
   --sidebar-foreground: var(--marinara-chat-chrome-panel-text);
 }
 
-.mari-chrome-accent-text,
+.mari-chrome-accent-text {
+  color: var(--marinara-chat-chrome-panel-title);
+}
+
 .mari-chrome-accent-icon {
   color: var(--marinara-chat-chrome-button-text-active);
 }
 
 .mari-chrome-accent-text-muted {
-  color: var(--marinara-chat-chrome-button-text);
+  color: var(--marinara-chat-chrome-panel-muted);
 }
 
 .mari-chrome-accent-surface {
@@ -1171,18 +1179,20 @@
   background: var(--marinara-chat-chrome-accent);
 }
 
-[data-marinara-chat-chrome-accent-mode="gradient"] .mari-chrome-control:not(.mari-chrome-control--danger) {
+[data-marinara-chat-chrome-accent-mode="gradient"]
+  .mari-chrome-control:not(.mari-chrome-control--danger):not(.mari-chat-mode-action):not(.mari-panel-gradient-button) {
   border-color: var(--marinara-chat-chrome-button-border);
   background: var(--marinara-chat-chrome-button-bg);
 }
 
-[data-marinara-chat-chrome-accent-mode="gradient"] .mari-chrome-control:not(.mari-chrome-control--danger):hover {
+[data-marinara-chat-chrome-accent-mode="gradient"]
+  .mari-chrome-control:not(.mari-chrome-control--danger):not(.mari-chat-mode-action):not(.mari-panel-gradient-button):hover {
   border-color: var(--marinara-chat-chrome-button-border-hover);
   background: var(--marinara-chat-chrome-surface-bg-hover);
 }
 
-[data-marinara-chat-chrome-accent-mode="gradient"] .mari-chrome-control--selected,
-[data-marinara-chat-chrome-accent-mode="gradient"] .mari-chrome-control[aria-pressed="true"] {
+[data-marinara-chat-chrome-accent-mode="gradient"] .mari-chrome-control--selected:not(.mari-chat-mode-action),
+[data-marinara-chat-chrome-accent-mode="gradient"] .mari-chrome-control[aria-pressed="true"]:not(.mari-chat-mode-action) {
   border-color: var(--marinara-chat-chrome-button-border-active);
   background: var(--marinara-chat-chrome-surface-bg-active);
   color: var(--marinara-chat-chrome-button-text-active);
@@ -1200,7 +1210,7 @@
 }
 
 [data-marinara-accent-animation]
-  :where(.mari-chrome-token-scope, .mari-rgb-icon-scope, .mari-editor-shell, .mari-settings-panel-chrome)
+  :where(.mari-chrome-token-scope, .mari-rgb-icon-scope, .mari-settings-panel-chrome)
   svg:not(.mari-rgb-static-icon) {
   color: var(--marinara-chat-chrome-button-text-active);
   stroke: currentColor;
@@ -1210,8 +1220,11 @@
     filter 140ms linear;
 }
 
-.mari-accent-gradient-fill,
 .mari-topbar-active-underline {
+  background: var(--marinara-chat-chrome-button-text-hover);
+}
+
+.mari-accent-gradient-fill {
   background: var(--marinara-app-accent-gradient);
 }
 
@@ -1253,7 +1266,6 @@
   :where(
     .mari-accent-animated,
     .mari-accent-gradient-fill,
-    .mari-topbar-active-underline,
     .mari-chrome-accent-text,
     .mari-chrome-accent-icon,
     .mari-chrome-accent-surface,
@@ -1612,6 +1624,33 @@
   background: color-mix(in srgb, var(--marinara-editor-control-bg) 54%, transparent);
 }
 
+.mari-editor-shell [class~="text-[var(--foreground)]"],
+.mari-editor-shell [class~="text-[var(--primary)]"],
+.mari-editor-shell [class~="text-sky-400"],
+.mari-editor-shell [class~="text-sky-300"],
+.mari-editor-shell [class~="text-sky-400/80"],
+.mari-editor-shell .mari-chrome-accent-text {
+  color: var(--marinara-editor-text);
+}
+
+.mari-editor-shell [class~="text-[var(--muted-foreground)]"],
+.mari-editor-shell [class~="text-[var(--muted-foreground)]/40"],
+.mari-editor-shell [class~="text-[var(--muted-foreground)]/45"],
+.mari-editor-shell [class~="text-[var(--muted-foreground)]/50"],
+.mari-editor-shell [class~="text-[var(--muted-foreground)]/60"],
+.mari-editor-shell [class~="text-[var(--muted-foreground)]/70"],
+.mari-editor-shell .mari-chrome-accent-text-muted,
+.mari-editor-shell .mari-chrome-accent-icon {
+  color: var(--marinara-editor-muted);
+}
+
+.mari-editor-shell [class~="hover:text-[var(--foreground)]"]:hover,
+.mari-editor-shell [class~="hover:text-[var(--primary)]"]:hover,
+.mari-editor-shell [class~="hover:text-sky-300"]:hover,
+.mari-editor-shell [class~="hover:text-sky-400"]:hover {
+  color: var(--marinara-editor-text);
+}
+
 .mari-editor-legacy-bridge
   input:not([type="range"]):not([type="checkbox"]):not([type="radio"]):not(.mari-editor-title-input):not(
     .mari-editor-subtitle-input
@@ -1669,11 +1708,21 @@
   --tw-ring-color: var(--marinara-editor-border);
 }
 
+.mari-editor-legacy-bridge [class~="text-[var(--foreground)]"],
 .mari-editor-legacy-bridge [class~="text-[var(--primary)]"],
 .mari-editor-legacy-bridge [class~="text-sky-400"],
 .mari-editor-legacy-bridge [class~="text-sky-300"],
 .mari-editor-legacy-bridge [class~="text-sky-400/80"] {
-  color: var(--marinara-editor-accent);
+  color: var(--marinara-editor-text);
+}
+
+.mari-editor-legacy-bridge [class~="text-[var(--muted-foreground)]"],
+.mari-editor-legacy-bridge [class~="text-[var(--muted-foreground)]/40"],
+.mari-editor-legacy-bridge [class~="text-[var(--muted-foreground)]/45"],
+.mari-editor-legacy-bridge [class~="text-[var(--muted-foreground)]/50"],
+.mari-editor-legacy-bridge [class~="text-[var(--muted-foreground)]/60"],
+.mari-editor-legacy-bridge [class~="text-[var(--muted-foreground)]/70"] {
+  color: var(--marinara-editor-muted);
 }
 
 .mari-editor-legacy-bridge [class~="bg-[var(--primary)]/10"],
@@ -1730,7 +1779,7 @@
 .mari-editor-legacy-bridge [class~="hover:text-[var(--primary)]"]:hover,
 .mari-editor-legacy-bridge [class~="hover:text-sky-300"]:hover,
 .mari-editor-legacy-bridge [class~="hover:text-sky-400"]:hover {
-  color: var(--marinara-editor-accent);
+  color: var(--marinara-editor-text);
 }
 
 .mari-editor-legacy-bridge [class~="hover:bg-[var(--primary)]/25"]:hover,

--- a/packages/client/src/styles/globals.css
+++ b/packages/client/src/styles/globals.css
@@ -890,7 +890,7 @@
 
 .mari-topbar .mari-topbar-accent-icon {
   color: var(--marinara-chat-chrome-button-text-active);
-  stroke: currentColor;
+  stroke: currentcolor;
 }
 
 .mari-topbar-chat-gradient-underline {
@@ -1191,8 +1191,10 @@
   background: var(--marinara-chat-chrome-surface-bg-hover);
 }
 
-[data-marinara-chat-chrome-accent-mode="gradient"] .mari-chrome-control--selected:not(.mari-chat-mode-action),
-[data-marinara-chat-chrome-accent-mode="gradient"] .mari-chrome-control[aria-pressed="true"]:not(.mari-chat-mode-action) {
+[data-marinara-chat-chrome-accent-mode="gradient"]
+  .mari-chrome-control--selected:not(.mari-chrome-control--danger):not(.mari-chat-mode-action):not(.mari-panel-gradient-button),
+[data-marinara-chat-chrome-accent-mode="gradient"]
+  .mari-chrome-control[aria-pressed="true"]:not(.mari-chrome-control--danger):not(.mari-chat-mode-action):not(.mari-panel-gradient-button) {
   border-color: var(--marinara-chat-chrome-button-border-active);
   background: var(--marinara-chat-chrome-surface-bg-active);
   color: var(--marinara-chat-chrome-button-text-active);


### PR DESCRIPTION
## Why this change

Pre-release v2.0.0 polish found regressions in the appearance controls: Accent Pulse/RGB handling could overwrite selected gradients, built-in button gradients could be flattened by global accent styling, topbar icon accent behavior affected nearby hover/underline effects, and editor/loading text still leaked pink/accent colors instead of following Chat Chrome Text Color.

No linked issue; maintainer-requested release polish.

## What changed

- Kept RGB mode runtime-only so it no longer overwrites the saved Accent Color.
- Added Accent Pulse behavior for both solid accents and selected gradients.
- Preserved built-in mode/button gradients while allowing only intended glyphs/icons to use accent coloring.
- Scoped topbar accent coloring to icon SVGs only, leaving hover effects and underline bars on their existing section styling.
- Routed editor and loading copy through editor/chrome text tokens so hard-coded pink/accent text is reduced across character, persona, lorebook, preset, connection, agent, and tool surfaces.

## Validation

- Ran `git diff --check` successfully.
- Ran `pnpm check` successfully, including lint and production build.

## Manual verification needed

Review Appearance settings, topbar icon hover/active states, New Chat mode buttons, and editor loading/text states in the browser before merging for release.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced accent animation with RGB mode support for dynamic color effects

* **Improvements**
  * Refined loading state UI styling across panels and components
  * Improved accent color settings interface with better mode coordination
  * Enhanced visual consistency for accent-animated icons throughout the application
  * Updated editor shell styling for improved visual coherence

<!-- end of auto-generated comment: release notes by coderabbit.ai -->