### PR TITLE
Promote Docker Compose docs fix

### DIFF
--- a/docs/installation/containers.md
+++ b/docs/installation/containers.md
@@ -4,13 +4,15 @@
 
 ### Pre-built Image
 
+The repo includes a ready-to-use [`docker-compose.yml`](../../docker-compose.yml) in the project root. From a Marinara Engine checkout, run:
+
 ```bash
 docker compose up -d
 ```
 
 Then open **<http://127.0.0.1:7860>**.
 
-The Compose file tracks `ghcr.io/pasta-devs/marinara-engine:latest`. Every tagged release also publishes immutable version tags, such as `ghcr.io/pasta-devs/marinara-engine:2.0.0`, plus the matching lite tag `ghcr.io/pasta-devs/marinara-engine:2.0.0-lite`.
+That Compose file tracks `ghcr.io/pasta-devs/marinara-engine:latest`. Every tagged release also publishes immutable version tags, such as `ghcr.io/pasta-devs/marinara-engine:2.0.0`, plus the matching lite tag `ghcr.io/pasta-devs/marinara-engine:2.0.0-lite`.
 
 Compose binds to `127.0.0.1` by default. To expose the container to your LAN, change the port mapping to `${PORT:-7860}:7860`, set `BASIC_AUTH_USER`, `BASIC_AUTH_PASS`, and `ADMIN_SECRET`, then restart. See [Access Control](../CONFIGURATION.md#access-control).
 


### PR DESCRIPTION
## Why this change

Promote the Docker Compose documentation fix from `staging` to `main` so users reading the released container guide can find the root `docker-compose.yml` without confusion.

## What changed

- Links `docker-compose.yml` from `docs/installation/containers.md`.
- Clarifies that `docker compose up -d` should be run from a Marinara Engine checkout.

## Validation

- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved Docker container setup instructions with clearer guidance on using the provided configuration file and expanded details about available image tag options for releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->