### PR TITLE
Fix game setup cancel delete guard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed a Game Setup Wizard cancel path that could silently hard-delete an existing campaign when stale metadata or a setup status made the wizard appear for a real game.
+
 ## [2.0.1]
 
 ### Fixed

--- a/packages/client/src/components/chat/ChatBranchSelector.tsx
+++ b/packages/client/src/components/chat/ChatBranchSelector.tsx
@@ -386,7 +386,7 @@ export function ChatBranchSelector({
                     ) {
                       return;
                     }
-                    deleteChatGroup.mutate(groupId);
+                    deleteChatGroup.mutate({ groupId, force: true });
                     setActiveChatId(null);
                     setOpen(false);
                   }}

--- a/packages/client/src/components/chat/ChatBranchSelector.tsx
+++ b/packages/client/src/components/chat/ChatBranchSelector.tsx
@@ -156,7 +156,7 @@ export function ChatBranchSelector({
     const nextActiveChatId =
       branchId === activeChatId ? displayBranches.find((branch) => branch.id !== branchId)?.id : null;
     try {
-      await deleteChat.mutateAsync({ id: branchId, groupId: groupId ?? null });
+      await deleteChat.mutateAsync({ id: branchId, groupId: groupId ?? null, force: true });
       if (nextActiveChatId) setActiveChatId(nextActiveChatId);
     } catch (err) {
       toast.error(err instanceof Error ? `Delete failed: ${err.message}` : "Delete failed.");

--- a/packages/client/src/components/chat/ChatFilesDrawer.tsx
+++ b/packages/client/src/components/chat/ChatFilesDrawer.tsx
@@ -346,7 +346,7 @@ export function ChatFilesDrawer({ chat, open, onClose }: ChatFilesDrawerProps) {
               ) {
                 return;
               }
-              deleteChatGroup.mutate(groupId);
+              deleteChatGroup.mutate({ groupId, force: true });
               setActiveChatId(null);
               onClose();
             }}

--- a/packages/client/src/components/chat/ChatFilesDrawer.tsx
+++ b/packages/client/src/components/chat/ChatFilesDrawer.tsx
@@ -115,7 +115,7 @@ export function ChatFilesDrawer({ chat, open, onClose }: ChatFilesDrawerProps) {
     }
     const nextActiveChatId = chatId === activeChatId ? chatFiles.find((c) => c.id !== chatId)?.id : null;
     try {
-      await deleteChat.mutateAsync({ id: chatId, groupId });
+      await deleteChat.mutateAsync({ id: chatId, groupId, force: true });
       if (nextActiveChatId) setActiveChatId(nextActiveChatId);
     } catch (err) {
       toast.error(err instanceof Error ? `Delete failed: ${err.message}` : "Delete failed.");

--- a/packages/client/src/components/game/GameSurface.tsx
+++ b/packages/client/src/components/game/GameSurface.tsx
@@ -2184,6 +2184,7 @@ export function GameSurface({
   const [viewedMapId, setViewedMapId] = useState<string | null>(null);
   const [startGameRequested, setStartGameRequested] = useState(false);
   const [startSessionRequested, setStartSessionRequested] = useState(false);
+  const [dismissedSetupWizardChatId, setDismissedSetupWizardChatId] = useState<string | null>(null);
   const [activeReadable, setActiveReadable] = useState<JournalReadable | null>(null);
   const readableQueueRef = useRef<JournalReadable[]>([]);
   const recentMusicHistoryRef = useRef<string[]>(normalizeRecentMusicHistory(chatMeta.gameRecentMusic));
@@ -2227,6 +2228,7 @@ export function GameSurface({
     setPendingAssetGeneration(null);
     setAssetGenerationBlocksScene(false);
     setAssetGenerationFailed(false);
+    setDismissedSetupWizardChatId(null);
     {
       const resolve = imagePromptReviewResolveRef.current;
       imagePromptReviewResolveRef.current = null;
@@ -8047,6 +8049,10 @@ export function GameSurface({
 
   // Does this chat need initial game creation?
   const needsCreation = !chatMeta.gameId;
+  const setupWizardDismissed = dismissedSetupWizardChatId === activeChatId;
+  const canAutoDeleteEmptySetupChat = needsCreation && !isMessagesLoading && messages.length === 0;
+  const shouldShowSetupWizard =
+    isSetupActive || (!setupWizardDismissed && (needsCreation || sessionStatus === "setup"));
 
   // While messages are still loading for an existing active game, show a loading
   // indicator instead of flashing the setup/start screens.
@@ -8062,7 +8068,7 @@ export function GameSurface({
   }
 
   // Setup wizard — show when explicitly active, when game needs creation, or when status is still "setup" (e.g. previous setup failed)
-  if (isSetupActive || needsCreation || sessionStatus === "setup") {
+  if (shouldShowSetupWizard) {
     return (
       <>
         <GameSetupWizard
@@ -8104,12 +8110,17 @@ export function GameSurface({
             }
           }}
           onCancel={() => {
-            if (needsCreation || sessionStatus === "setup") {
-              // Delete the broken/empty game chat
-              useChatStore.getState().setActiveChatId(null);
-              deleteChat.mutate(activeChatId);
-            }
             useGameModeStore.getState().setSetupActive(false);
+            if (canAutoDeleteEmptySetupChat) {
+              deleteChat.mutate(activeChatId, {
+                onSuccess: () => useChatStore.getState().setActiveChatId(null),
+              });
+              return;
+            }
+            setDismissedSetupWizardChatId(activeChatId);
+            if (needsCreation || sessionStatus === "setup") {
+              toast.info("Game setup dismissed. The campaign was kept.");
+            }
           }}
           isLoading={createGame.isPending || gameSetup.isPending}
           characters={characters}

--- a/packages/client/src/components/layout/ChatSidebar.tsx
+++ b/packages/client/src/components/layout/ChatSidebar.tsx
@@ -1424,7 +1424,7 @@ export function ChatSidebar() {
               <button
                 onClick={() => {
                   if (deleteTarget.groupId) {
-                    deleteChatGroup.mutate(deleteTarget.groupId);
+                    deleteChatGroup.mutate({ groupId: deleteTarget.groupId, force: true });
                     if (activeGroupId === deleteTarget.groupId) setActiveChatId(null);
                   }
                   setDeleteTarget(null);

--- a/packages/client/src/components/layout/ChatSidebar.tsx
+++ b/packages/client/src/components/layout/ChatSidebar.tsx
@@ -731,7 +731,7 @@ export function ChatSidebar() {
       return;
     }
     for (const id of selectedChatIds) {
-      deleteChat.mutate(id);
+      deleteChat.mutate({ id, force: true });
     }
     if (activeChatId && selectedChatIds.has(activeChatId)) setActiveChatId(null);
     exitMultiSelect();
@@ -1020,7 +1020,7 @@ export function ChatSidebar() {
                     tone: "destructive",
                   })
                 ) {
-                  deleteChat.mutate(chat.id);
+                  deleteChat.mutate({ id: chat.id, force: true });
                   if (activeChatId === chat.id) setActiveChatId(null);
                 }
               }
@@ -1412,7 +1412,7 @@ export function ChatSidebar() {
             <div className="flex flex-col gap-2">
               <button
                 onClick={() => {
-                  deleteChat.mutate(deleteTarget.chatId);
+                  deleteChat.mutate({ id: deleteTarget.chatId, force: true });
                   if (activeChatId === deleteTarget.chatId) setActiveChatId(null);
                   setDeleteTarget(null);
                 }}

--- a/packages/client/src/hooks/use-chats.ts
+++ b/packages/client/src/hooks/use-chats.ts
@@ -519,8 +519,13 @@ export function useDeleteChat() {
 export function useDeleteChatGroup() {
   const qc = useQueryClient();
   return useMutation({
-    mutationFn: (groupId: string) => api.delete(`/chats/group/${groupId}`),
-    onMutate: async (groupId) => {
+    mutationFn: (input: string | { groupId: string; force?: boolean }) => {
+      const groupId = typeof input === "string" ? input : input.groupId;
+      const force = typeof input === "string" ? "" : input.force === true ? "?force=true" : "";
+      return api.delete(`/chats/group/${groupId}${force}`);
+    },
+    onMutate: async (input) => {
+      const groupId = typeof input === "string" ? input : input.groupId;
       await qc.cancelQueries({ queryKey: chatKeys.list() });
       const previous = qc.getQueryData<Chat[]>(chatKeys.list());
 
@@ -529,13 +534,13 @@ export function useDeleteChatGroup() {
 
       return { previous, groupId };
     },
-    onError: (_err, _groupId, context) => {
+    onError: (_err, _input, context) => {
       if (context?.previous) qc.setQueryData(chatKeys.list(), context.previous);
       if (context?.groupId) {
         qc.invalidateQueries({ queryKey: chatKeys.group(context.groupId) });
       }
     },
-    onSettled: (_data, _err, _groupId, context) => {
+    onSettled: (_data, _err, _input, context) => {
       qc.invalidateQueries({ queryKey: chatKeys.list() });
       if (context?.groupId) {
         qc.invalidateQueries({ queryKey: chatKeys.group(context.groupId) });

--- a/packages/client/src/hooks/use-chats.ts
+++ b/packages/client/src/hooks/use-chats.ts
@@ -329,7 +329,7 @@ export function useChatGroup(groupId: string | null) {
   });
 }
 
-type DeleteChatInput = string | { id: string; groupId?: string | null };
+type DeleteChatInput = string | { id: string; groupId?: string | null; force?: boolean };
 
 function getDeleteChatId(input: DeleteChatInput) {
   return typeof input === "string" ? input : input.id;
@@ -337,6 +337,10 @@ function getDeleteChatId(input: DeleteChatInput) {
 
 function getDeleteChatGroupId(input: DeleteChatInput) {
   return typeof input === "string" ? null : (input.groupId ?? null);
+}
+
+function getDeleteChatForce(input: DeleteChatInput) {
+  return typeof input === "string" ? false : input.force === true;
 }
 
 function chatMutationErrorMessage(error: unknown, fallback: string) {
@@ -463,7 +467,10 @@ export function useCreateChat() {
 export function useDeleteChat() {
   const qc = useQueryClient();
   return useMutation({
-    mutationFn: (input: DeleteChatInput) => api.delete(`/chats/${getDeleteChatId(input)}`),
+    mutationFn: (input: DeleteChatInput) => {
+      const force = getDeleteChatForce(input) ? "?force=true" : "";
+      return api.delete(`/chats/${getDeleteChatId(input)}${force}`);
+    },
     onMutate: async (input) => {
       const id = getDeleteChatId(input);
       const providedGroupId = getDeleteChatGroupId(input);

--- a/packages/server/src/routes/chats.routes.ts
+++ b/packages/server/src/routes/chats.routes.ts
@@ -947,7 +947,20 @@ export async function chatsRoutes(app: FastifyInstance) {
   });
 
   // Delete all chats in a group (all branches)
-  app.delete<{ Params: { groupId: string } }>("/group/:groupId", async (req, reply) => {
+  app.delete<{ Params: { groupId: string }; Querystring: { force?: string } }>("/group/:groupId", async (req, reply) => {
+    const force = req.query.force === "true" || req.query.force === "1";
+    if (!force) {
+      const groupChats = await storage.listByGroup(req.params.groupId);
+      for (const chat of groupChats) {
+        const meta = parseExtra(chat.metadata) as Record<string, unknown>;
+        const hasGameId = typeof meta.gameId === "string" && meta.gameId.trim().length > 0;
+        if (chat.mode === "game" && (hasGameId || (await storage.hasGameDeletePayload(chat.id)))) {
+          return reply.status(409).send({
+            error: "Refusing to hard-delete a game campaign group without explicit confirmation.",
+          });
+        }
+      }
+    }
     await storage.removeGroup(req.params.groupId);
     return reply.status(204).send();
   });

--- a/packages/server/src/routes/chats.routes.ts
+++ b/packages/server/src/routes/chats.routes.ts
@@ -953,11 +953,18 @@ export async function chatsRoutes(app: FastifyInstance) {
   });
 
   // Delete chat
-  app.delete<{ Params: { id: string } }>("/:id", async (req, reply) => {
+  app.delete<{ Params: { id: string }; Querystring: { force?: string } }>("/:id", async (req, reply) => {
+    const force = req.query.force === "true" || req.query.force === "1";
     // If this is a scene chat, clean up the origin chat's scene pointer
     const chat = await storage.getById(req.params.id);
     if (chat) {
       const meta = parseExtra(chat.metadata) as Record<string, unknown>;
+      const hasGameId = typeof meta.gameId === "string" && meta.gameId.trim().length > 0;
+      if (chat.mode === "game" && !force && (hasGameId || (await storage.hasGameDeletePayload(req.params.id)))) {
+        return reply.status(409).send({
+          error: "Refusing to hard-delete a game campaign without explicit confirmation.",
+        });
+      }
       const originId = meta.sceneOriginChatId;
       if (typeof originId === "string" && originId) {
         const origin = await storage.getById(originId);

--- a/packages/server/src/services/storage/chats.storage.ts
+++ b/packages/server/src/services/storage/chats.storage.ts
@@ -568,6 +568,33 @@ export function createChatsStorage(db: DB) {
       return rows.length;
     },
 
+    async hasGameDeletePayload(chatId: string): Promise<boolean> {
+      const existingMessage = await db
+        .select({ id: messages.id })
+        .from(messages)
+        .where(eq(messages.chatId, chatId))
+        .limit(1);
+      if (existingMessage.length > 0) return true;
+      const existingSnapshot = await db
+        .select({ id: gameStateSnapshots.id })
+        .from(gameStateSnapshots)
+        .where(eq(gameStateSnapshots.chatId, chatId))
+        .limit(1);
+      if (existingSnapshot.length > 0) return true;
+      const existingCheckpoint = await db
+        .select({ id: gameCheckpoints.id })
+        .from(gameCheckpoints)
+        .where(eq(gameCheckpoints.chatId, chatId))
+        .limit(1);
+      if (existingCheckpoint.length > 0) return true;
+      const existingImage = await db
+        .select({ id: chatImages.id })
+        .from(chatImages)
+        .where(eq(chatImages.chatId, chatId))
+        .limit(1);
+      return existingImage.length > 0;
+    },
+
     async listMessages(chatId: string) {
       const rows = await db
         .select()


### PR DESCRIPTION
## Why this change

Fixes #2804.

Canceling the Game Setup Wizard could hard-delete an existing game campaign when stale metadata or `setup` session status made the wizard appear for a real game. That is a data-loss path, so the cancel behavior needs a stronger distinction between a newborn empty setup chat and an existing campaign.

## What changed

- Only auto-delete from the setup wizard when the game chat is still uncreated and has no loaded messages.
- Dismiss the setup wizard for existing or setup-status games instead of deleting the chat.
- Add a server guard that refuses unforced hard-deletes of game chats with a game id or saved game payload.
- Mark confirmed chat delete actions as explicit forced deletes so normal user-confirmed deletion still works.
- Added the fix to `CHANGELOG.md` under Unreleased.

## Validation

- [ ] `pnpm check` (completed locally; passed on this branch)
- [ ] Manually verify canceling Game Setup Wizard on an existing campaign keeps the chat.
- [ ] Manually verify canceling a freshly created empty game setup chat still cleans up the empty chat.
- [ ] Manually verify confirmed chat/branch deletes still work from the UI.
