### PR TITLE
Preserve caret while formatting editor quotes

### DIFF
--- a/packages/client/src/hooks/use-quote-formatter.ts
+++ b/packages/client/src/hooks/use-quote-formatter.ts
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useRef } from "react";
 import { formatTextQuotes } from "@marinara-engine/shared";
 import { useUIStore } from "../stores/ui.store";
+import { captureTextSelection, restoreTextSelectionAfterRender, type TextSelectionSnapshot } from "../lib/text-selection";
 
 type TextInputElement = HTMLInputElement | HTMLTextAreaElement;
 
@@ -14,53 +15,28 @@ function getActiveTextInput(value: string): TextInputElement | null {
 
 export function useQuoteFormatter() {
   const quoteFormat = useUIStore((s) => s.quoteFormat);
-  const restoreFrameRef = useRef<number | null>(null);
+  const cancelSelectionRestoreRef = useRef<(() => void) | null>(null);
 
   useEffect(() => {
     return () => {
-      if (restoreFrameRef.current !== null && typeof window !== "undefined") {
-        window.cancelAnimationFrame(restoreFrameRef.current);
-      }
+      cancelSelectionRestoreRef.current?.();
     };
   }, []);
 
   return useCallback(
     (value: string) => {
       const activeInput = getActiveTextInput(value);
-      const selection =
-        activeInput && activeInput.selectionStart !== null
-          ? {
-              element: activeInput,
-              start: activeInput.selectionStart,
-              end: activeInput.selectionEnd ?? activeInput.selectionStart,
-              direction: activeInput.selectionDirection ?? "none",
-            }
-          : null;
+      const selection: TextSelectionSnapshot | null = activeInput ? captureTextSelection(activeInput) : null;
 
       const formatted = formatTextQuotes(value, quoteFormat);
 
       if (selection && activeInput && activeInput.value !== formatted) {
         activeInput.value = formatted;
-        const max = formatted.length;
-        activeInput.setSelectionRange(
-          Math.min(selection.start, max),
-          Math.min(selection.end, max),
-          selection.direction,
-        );
       }
 
-      if (selection && typeof window !== "undefined") {
-        if (restoreFrameRef.current !== null) window.cancelAnimationFrame(restoreFrameRef.current);
-        restoreFrameRef.current = window.requestAnimationFrame(() => {
-          restoreFrameRef.current = null;
-          if (document.activeElement !== selection.element) return;
-          const max = selection.element.value.length;
-          selection.element.setSelectionRange(
-            Math.min(selection.start, max),
-            Math.min(selection.end, max),
-            selection.direction,
-          );
-        });
+      if (selection) {
+        cancelSelectionRestoreRef.current?.();
+        cancelSelectionRestoreRef.current = restoreTextSelectionAfterRender(selection);
       }
 
       return formatted;

--- a/packages/client/src/lib/text-selection.ts
+++ b/packages/client/src/lib/text-selection.ts
@@ -1,0 +1,56 @@
+type EditableTextInput = HTMLInputElement | HTMLTextAreaElement;
+type TextSelectionDirection = "forward" | "backward" | "none";
+
+export interface TextSelectionSnapshot {
+  element: EditableTextInput;
+  start: number;
+  end: number;
+  direction: TextSelectionDirection;
+}
+
+export function captureTextSelection(element: EditableTextInput): TextSelectionSnapshot | null {
+  if (typeof element.selectionStart !== "number") return null;
+  return {
+    element,
+    start: element.selectionStart,
+    end: element.selectionEnd ?? element.selectionStart,
+    direction: element.selectionDirection ?? "none",
+  };
+}
+
+function applyTextSelection(snapshot: TextSelectionSnapshot) {
+  if (typeof document !== "undefined" && document.activeElement !== snapshot.element) return;
+  const max = snapshot.element.value.length;
+  snapshot.element.setSelectionRange(Math.min(snapshot.start, max), Math.min(snapshot.end, max), snapshot.direction);
+}
+
+export function restoreTextSelectionAfterRender(snapshot: TextSelectionSnapshot): () => void {
+  let canceled = false;
+  const frameIds: number[] = [];
+
+  const restore = () => {
+    if (!canceled) applyTextSelection(snapshot);
+  };
+
+  restore();
+
+  if (typeof queueMicrotask === "function") {
+    queueMicrotask(restore);
+  }
+
+  if (typeof window !== "undefined") {
+    frameIds.push(
+      window.requestAnimationFrame(() => {
+        restore();
+        frameIds.push(window.requestAnimationFrame(restore));
+      }),
+    );
+  }
+
+  return () => {
+    canceled = true;
+    if (typeof window !== "undefined") {
+      frameIds.forEach((id) => window.cancelAnimationFrame(id));
+    }
+  };
+}

--- a/packages/client/src/lib/textarea-quotes.ts
+++ b/packages/client/src/lib/textarea-quotes.ts
@@ -1,13 +1,13 @@
 import { formatTextQuotes, type QuoteFormat } from "@marinara-engine/shared";
+import { captureTextSelection, restoreTextSelectionAfterRender } from "./text-selection";
 
 export function applyTextareaQuoteFormat(textarea: HTMLTextAreaElement, quoteFormat: QuoteFormat): string {
   const raw = textarea.value;
   const formatted = formatTextQuotes(raw, quoteFormat);
   if (raw === formatted) return formatted;
 
-  const selectionStart = textarea.selectionStart;
-  const selectionEnd = textarea.selectionEnd;
+  const selection = captureTextSelection(textarea);
   textarea.value = formatted;
-  textarea.setSelectionRange(selectionStart, selectionEnd);
+  if (selection) restoreTextSelectionAfterRender(selection);
   return formatted;
 }


### PR DESCRIPTION
## Linked issue

No linked issue; maintainer-requested bug fix from direct editor report.

## Why this change

- Typing straight or typographic quote characters inside card and preset editor fields could push the caret to the end of the field after quote formatting.

## What changed

- Added a shared text-selection helper that captures and restores input/textarea selections across React controlled-value renders.
- Updated textarea quote formatting to restore the caret after the DOM value and React state settle.
- Reused the same post-render selection restoration in the quote formatter hook used by character and persona editors.

## Validation

- [ ] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed `CONTRIBUTING.md`

### Manual verification notes

- `pnpm --filter @marinara-engine/client lint`
- `pnpm --filter @marinara-engine/client exec tsc -b --pretty false`
- Browser manual verification not run in this pass.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Version/release files updated (only if this PR includes a version bump)

## UI evidence (if applicable)

N/A - behavioral caret fix only.
