### PR TITLE
fix(agents): reflect YouTube provider in Music DJ editor prompt + tools

### DIFF
--- a/packages/client/src/components/agents/AgentEditor.tsx
+++ b/packages/client/src/components/agents/AgentEditor.tsx
@@ -466,9 +466,6 @@ export function AgentEditor() {
       ? getAgentRunIntervalMeta(isNewCustomAgent ? "__new__" : (dbConfig?.type ?? agentDetailId ?? ""), false)
       : null;
 
-  // Default prompt for this agent type
-  const defaultPrompt = useMemo(() => (agentDetailId ? getDefaultAgentPrompt(agentDetailId) : ""), [agentDetailId]);
-
   // ── Local editable state ──
   const [localName, setLocalName] = useState("");
   const [localDescription, setLocalDescription] = useState("");
@@ -749,6 +746,18 @@ export function AgentEditor() {
   const isMusicAgent = isSpotifyAgent;
 
   const showsYoutubeSettings = isMusicAgent;
+
+  // In YouTube mode Music DJ runs tool-free and returns its pick as a search-query
+  // JSON, so the editor reflects the YouTube-specific built-in prompt and skips the
+  // (Spotify-only) tool toggles.
+  const musicDjYoutubeMode = isMusicAgent && localMusicProvider === "youtube";
+
+  // Default prompt for this agent type. Music DJ has a separate built-in prompt per
+  // provider, so show the YouTube prompt when the YouTube provider is selected.
+  const defaultPrompt = useMemo(
+    () => (agentDetailId ? getDefaultAgentPrompt(musicDjYoutubeMode ? "youtube" : agentDetailId) : ""),
+    [agentDetailId, musicDjYoutubeMode],
+  );
 
   // Lorebook Keeper agent — run interval setting
   const isLorebookKeeperAgent = agentDetailId === "lorebook-keeper" || dbConfig?.type === "lorebook-keeper";
@@ -3229,48 +3238,61 @@ export function AgentEditor() {
             collapsible
             expanded={toolsSectionOpen}
             onExpandedChange={setToolsSectionOpen}
-            summary={`${selectedVisibleToolCount}/${availableVisibleToolCount} enabled`}
+            summary={
+              musicDjYoutubeMode
+                ? "Not used in YouTube mode"
+                : `${selectedVisibleToolCount}/${availableVisibleToolCount} enabled`
+            }
           >
-            <p className="text-[0.625rem] text-[var(--muted-foreground)] mb-3">
-              Toggle tools on or off for this agent. When enabled for a chat, only selected tools will be available
-              during generation.
-            </p>
-            <div className="space-y-2">
-              {visibleBuiltInTools.map((tool: ToolDefinition) => (
-                <ToolCard
-                  key={tool.name}
-                  tool={tool}
-                  enabled={localEnabledTools.includes(tool.name)}
-                  onToggle={(name) => {
-                    setLocalEnabledTools((prev) =>
-                      prev.includes(name) ? prev.filter((n) => n !== name) : [...prev, name],
-                    );
-                    markDirty();
-                  }}
-                />
-              ))}
-              {selectableCustomTools.map((tool) => (
-                <ToolCard
-                  key={tool.name}
-                  tool={{
-                    name: tool.name,
-                    description: tool.description,
-                    parameters: JSON.parse(tool.parametersSchema || "{}"),
-                  }}
-                  enabled={localEnabledTools.includes(tool.name)}
-                  onToggle={(name) => {
-                    setLocalEnabledTools((prev) =>
-                      prev.includes(name) ? prev.filter((n) => n !== name) : [...prev, name],
-                    );
-                    markDirty();
-                  }}
-                  isCustom
-                />
-              ))}
-            </div>
-            <p className="mt-2 text-[0.625rem] text-[var(--muted-foreground)]">
-              Tool-use must also be enabled per chat via Chat Settings → "Enable Function Calling".
-            </p>
+            {musicDjYoutubeMode ? (
+              <p className="rounded-xl bg-[var(--secondary)]/60 px-3 py-2 text-[0.6875rem] text-[var(--muted-foreground)] ring-1 ring-[var(--border)]">
+                In YouTube mode, Music DJ doesn't use function tools. It returns its pick as JSON and the app plays the
+                top YouTube search result directly. Switch the Music Player to Spotify to enable playback tools.
+              </p>
+            ) : (
+              <>
+                <p className="text-[0.625rem] text-[var(--muted-foreground)] mb-3">
+                  Toggle tools on or off for this agent. When enabled for a chat, only selected tools will be available
+                  during generation.
+                </p>
+                <div className="space-y-2">
+                  {visibleBuiltInTools.map((tool: ToolDefinition) => (
+                    <ToolCard
+                      key={tool.name}
+                      tool={tool}
+                      enabled={localEnabledTools.includes(tool.name)}
+                      onToggle={(name) => {
+                        setLocalEnabledTools((prev) =>
+                          prev.includes(name) ? prev.filter((n) => n !== name) : [...prev, name],
+                        );
+                        markDirty();
+                      }}
+                    />
+                  ))}
+                  {selectableCustomTools.map((tool) => (
+                    <ToolCard
+                      key={tool.name}
+                      tool={{
+                        name: tool.name,
+                        description: tool.description,
+                        parameters: JSON.parse(tool.parametersSchema || "{}"),
+                      }}
+                      enabled={localEnabledTools.includes(tool.name)}
+                      onToggle={(name) => {
+                        setLocalEnabledTools((prev) =>
+                          prev.includes(name) ? prev.filter((n) => n !== name) : [...prev, name],
+                        );
+                        markDirty();
+                      }}
+                      isCustom
+                    />
+                  ))}
+                </div>
+                <p className="mt-2 text-[0.625rem] text-[var(--muted-foreground)]">
+                  Tool-use must also be enabled per chat via Chat Settings → "Enable Function Calling".
+                </p>
+              </>
+            )}
           </FieldGroup>
         </div>
       </div>


### PR DESCRIPTION
## Linked issue

Closes #2811

## Why this change

- After the Spotify/YouTube merge, switching the Music DJ "Music Player" provider to YouTube left the agent editor looking like YouTube mode was half-implemented: the Prompt Template preview still showed the Spotify built-in prompt, and the Tools / Function Calling section showed a bare "0/15 enabled" with the (now inert) Spotify tool toggles still listed.
- This is purely an editor-display gap. At generation time the backend already does the right thing for YouTube — it swaps to the YouTube built-in prompt (`getAgentFallbackPrompt` / `getDefaultPromptForAgent`) and forces `enabledTools: []` via `applyMusicPlayerSourceToMusicDjSettings`. The editor just wasn't reflecting the selected provider in those two sections, which led to a user reporting the YouTube prompt and tools as "missing."

## What changed

- `packages/client/src/components/agents/AgentEditor.tsx`:
  - Added a `musicDjYoutubeMode` flag (`isMusicAgent && localMusicProvider === "youtube"`) and made the built-in `defaultPrompt` memo provider-aware, so the preview resolves `getDefaultAgentPrompt("youtube")` when the YouTube provider is selected — matching what the backend injects at runtime. (The memo moved a few lines down so it can read `localMusicProvider`/`isMusicAgent`.)
  - Made the Tools / Function Calling section provider-aware: in YouTube mode its summary now reads "Not used in YouTube mode" and the body shows a short explanatory note ("Music DJ returns its pick as JSON and the app plays the top YouTube search result") instead of the Spotify tool toggles, which are discarded on save anyway.
- No backend, shared-package, or behavior changes — prompt selection and tool gating at generation time are untouched.

## Validation

- [x] `pnpm check` passes locally
- [x] Container (Docker / Podman) built and ran without issue
- [x] Ran the app, clicked through the changes manually
- [x] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [x] Above manual verification completed (describe below)
- [x] Read and followed `CONTRIBUTING.md`

### Manual verification notes

- Manually verify in a browser: open the Music DJ agent editor, switch the Music Player provider to YouTube, and confirm the Prompt Template preview switches to the YouTube built-in prompt (short, `searchQuery`-based, no Spotify tool names).
- Manually verify the Tools / Function Calling section in YouTube mode shows the "Not used in YouTube mode" summary and the explanatory note rather than the Spotify tool toggles.
- Manually verify switching back to Spotify restores the Spotify prompt preview and the normal tool list / count.
- Manually verify a Music DJ agent with a hand-edited custom prompt still shows that custom text (provider swap applies to the built-in default only).

## Docs and release impact

- [x] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Version/release files updated (only if this PR includes a version bump)

## UI evidence (if applicable)

<img width="1568" height="773" alt="image" src="https://github.com/user-attachments/assets/bcfbba3f-a213-480d-9366-4a74d880c335" />
