### PR TITLE
Fix mobile editor navigation and lorebook controls

### DIFF
--- a/packages/client/src/components/layout/AppShell.tsx
+++ b/packages/client/src/components/layout/AppShell.tsx
@@ -978,7 +978,7 @@ export function AppShell() {
             data-component="MobileDetailSheet"
             aria-label="Detail editor"
             className={cn(
-              "mari-mobile-detail-sheet !fixed bottom-0 right-0 z-40 !w-full overflow-hidden bg-[var(--background)]/95 pb-[max(env(safe-area-inset-bottom),0.5rem)] shadow-2xl backdrop-blur-xl",
+              "mari-mobile-detail-sheet !fixed bottom-0 right-0 z-40 flex min-h-0 !w-full flex-col overflow-hidden bg-[var(--background)]/95 pb-[max(env(safe-area-inset-bottom),0.5rem)] shadow-2xl backdrop-blur-xl",
               MOBILE_SHELL_PANEL_TOP_CLASS,
             )}
           >

--- a/packages/client/src/components/layout/RightPanel.tsx
+++ b/packages/client/src/components/layout/RightPanel.tsx
@@ -78,7 +78,7 @@ export function RightPanel() {
     <section
       data-component="RightPanel"
       aria-label={config.title}
-      className="mari-right-panel-content mari-chrome-token-scope flex h-full flex-col"
+      className="mari-right-panel-content mari-chrome-token-scope flex h-full min-h-0 flex-col"
     >
       {/* Header - OS window style */}
       <div className="mari-right-panel-header relative flex h-12 flex-shrink-0 items-center justify-between bg-[var(--card)]/80 px-4 backdrop-blur-sm">
@@ -105,7 +105,7 @@ export function RightPanel() {
       </div>
 
       {/* Content — keep visited panels mounted but hidden to avoid re-animation */}
-      <div className="relative flex-1 overflow-hidden">
+      <div className="relative min-h-0 flex-1 overflow-hidden">
         {Object.entries(PANELS).map(([key, PanelComp]) => {
           if (!mountedPanels.has(key)) return null;
           const active = key === panel;

--- a/packages/client/src/components/layout/TopBar.tsx
+++ b/packages/client/src/components/layout/TopBar.tsx
@@ -67,6 +67,10 @@ const TOPBAR_FORCE_HOVER_CLASS = "bg-[var(--accent)]";
 const TOPBAR_ACCENT_ICON_CLASS = "mari-topbar-accent-icon mari-accent-animated";
 const CHAT_TOPBAR_GRADIENT_ID = "mari-topbar-chats-gradient";
 
+function isMobileTopbarNavigation() {
+  return typeof window !== "undefined" && window.matchMedia("(max-width: 767px)").matches;
+}
+
 export function TopBar() {
   const sidebarOpen = useUIStore((s) => s.sidebarOpen);
   const toggleSidebar = useUIStore((s) => s.toggleSidebar);
@@ -124,6 +128,23 @@ export function TopBar() {
     !characterLibraryOpen;
 
   const isTopbarHovered = (key: string) => hoveredTopbarKey === key;
+
+  const prepareMobileTopbarNavigation = useCallback(() => {
+    if (isMobileTopbarNavigation()) closeAllDetails();
+  }, [closeAllDetails]);
+
+  const handleSidebarClick = useCallback(() => {
+    prepareMobileTopbarNavigation();
+    toggleSidebar();
+  }, [prepareMobileTopbarNavigation, toggleSidebar]);
+
+  const handleRightPanelClick = useCallback(
+    (panel: Parameters<typeof toggleRightPanel>[0]) => {
+      prepareMobileTopbarNavigation();
+      toggleRightPanel(panel);
+    },
+    [prepareMobileTopbarNavigation, toggleRightPanel],
+  );
 
   const handleTopbarPointerOver = (event: ReactPointerEvent<HTMLElement>) => {
     if (event.pointerType !== "mouse") return;
@@ -213,7 +234,7 @@ export function TopBar() {
       <div className="mari-topbar-left flex min-w-0 flex-1 items-center gap-2">
         <div ref={leftControlsRef} className="mari-topbar-left-controls mari-rgb-icon-scope flex shrink-0 items-center gap-2">
           <button
-            onClick={toggleSidebar}
+            onClick={handleSidebarClick}
             data-tour="sidebar-toggle"
             data-topbar-hover-key="chats"
             className={cn(
@@ -286,7 +307,7 @@ export function TopBar() {
       >
         {/* Browser */}
         <button
-          onClick={() => toggleRightPanel("bot-browser")}
+          onClick={() => handleRightPanelClick("bot-browser")}
           data-tour="panel-bot-browser"
           data-topbar-hover-key="browser"
           className={cn(
@@ -307,7 +328,7 @@ export function TopBar() {
         </button>
 
         <button
-          onClick={() => toggleRightPanel("characters")}
+          onClick={() => handleRightPanelClick("characters")}
           data-tour="panel-characters"
           data-topbar-hover-key="characters"
           className={cn(
@@ -333,7 +354,7 @@ export function TopBar() {
           return (
             <button
               key={panel}
-              onClick={() => toggleRightPanel(panel)}
+              onClick={() => handleRightPanelClick(panel)}
               data-tour={`panel-${panel}`}
               data-topbar-hover-key={panel}
               className={cn(
@@ -363,7 +384,7 @@ export function TopBar() {
 
         {/* Settings */}
         <button
-          onClick={() => toggleRightPanel("settings")}
+          onClick={() => handleRightPanelClick("settings")}
           data-tour="panel-settings"
           data-topbar-hover-key="settings"
           className={cn(

--- a/packages/client/src/components/lorebooks/LorebookEditor.tsx
+++ b/packages/client/src/components/lorebooks/LorebookEditor.tsx
@@ -58,6 +58,7 @@ import {
   Globe,
   Users,
   UserRound,
+  Drama,
   X,
   ArrowUpDown,
   Hash,
@@ -300,7 +301,7 @@ type TabId = (typeof TABS)[number]["id"];
 const CATEGORY_OPTIONS: Array<{ value: LorebookCategory; label: string; icon: typeof Globe }> = [
   { value: "world", label: "World", icon: Globe },
   { value: "character", label: "Character", icon: Users },
-  { value: "npc", label: "NPC", icon: UserRound },
+  { value: "npc", label: "NPC", icon: Drama },
   { value: "spellbook", label: "Spellbook", icon: Wand2 },
   { value: "uncategorized", label: "Uncategorized", icon: BookOpen },
 ];
@@ -1744,8 +1745,31 @@ export function LorebookEditor() {
 
                 {/* Category */}
                 <div className="mari-editor-panel p-3">
-                  <label className="mb-1.5 block text-xs font-medium">Category</label>
-                  <div className="flex gap-2">
+                  <label htmlFor="lorebook-editor-category" className="mb-1.5 block text-xs font-medium">
+                    Category
+                  </label>
+                  <div className="relative md:hidden">
+                    <select
+                      id="lorebook-editor-category"
+                      value={formCategory}
+                      onChange={(event) => {
+                        setFormCategory(event.target.value as LorebookCategory);
+                        markLorebookDirty();
+                      }}
+                      className="mari-editor-field h-10 w-full min-w-0 appearance-none truncate px-3 py-0 pr-9 text-xs"
+                    >
+                      {CATEGORY_OPTIONS.map((opt) => (
+                        <option key={opt.value} value={opt.value}>
+                          {opt.label}
+                        </option>
+                      ))}
+                    </select>
+                    <ChevronDown
+                      size="0.75rem"
+                      className="pointer-events-none absolute right-3 top-1/2 -translate-y-1/2 text-[var(--marinara-editor-muted)]"
+                    />
+                  </div>
+                  <div className="hidden gap-2 md:flex">
                     {CATEGORY_OPTIONS.map((opt) => {
                       const Icon = opt.icon;
                       return (

--- a/packages/client/src/components/panels/LorebooksPanel.tsx
+++ b/packages/client/src/components/panels/LorebooksPanel.tsx
@@ -2,7 +2,16 @@
 // Panel: Lorebooks (overhauled)
 // Category tabs, search, click-to-edit, AI generate
 // ──────────────────────────────────────────────
-import { useState, useMemo, useCallback, useRef, type ChangeEvent, type DragEvent, type TouchEvent } from "react";
+import {
+  useState,
+  useMemo,
+  useCallback,
+  useEffect,
+  useRef,
+  type ChangeEvent,
+  type DragEvent,
+  type TouchEvent,
+} from "react";
 import { toast } from "sonner";
 import {
   Plus,
@@ -72,6 +81,23 @@ const CATEGORY_COLORS: Record<string, string> = {
   all: "from-amber-400 to-orange-500",
 };
 
+function usePanelMobileOverlay() {
+  const [isMobileOverlay, setIsMobileOverlay] = useState(() =>
+    typeof window !== "undefined" ? window.matchMedia("(max-width: 767px)").matches : false,
+  );
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    const query = window.matchMedia("(max-width: 767px)");
+    const update = () => setIsMobileOverlay(query.matches);
+    update();
+    query.addEventListener("change", update);
+    return () => query.removeEventListener("change", update);
+  }, []);
+
+  return isMobileOverlay;
+}
+
 function remapLorebookEntryRelationships(
   relationships: Record<string, string> | null | undefined,
   entryIdMap: Map<string, string>,
@@ -96,6 +122,7 @@ export function LorebooksPanel() {
   const [selectionMode, setSelectionMode] = useState(false);
   const [selectedLorebookIds, setSelectedLorebookIds] = useState<Set<string>>(new Set());
   const [exportingSelected, setExportingSelected] = useState(false);
+  const isMobileOverlay = usePanelMobileOverlay();
   const [expandedFolderId, setExpandedFolderId] = useState<string | null>(null);
   const [editingFolderId, setEditingFolderId] = useState<string | null>(null);
   const [editFolderName, setEditFolderName] = useState("");
@@ -649,9 +676,10 @@ export function LorebooksPanel() {
           selectionMode={selectionMode}
           isSelected={selectedLorebookIds.has(lb.id)}
           onToggleSelect={() => toggleSelection(lb.id)}
-          draggable
+          draggable={!isMobileOverlay}
           isDragging={draggedLorebookId === lb.id}
           onDragStart={(event) => {
+            if (isMobileOverlay) return;
             const ids = getDraggedLorebookIds(lb.id);
             setDraggedLorebookId(lb.id);
             event.dataTransfer.effectAllowed = "move";
@@ -676,6 +704,7 @@ export function LorebooksPanel() {
       getPersonaNames,
       handleDuplicateLorebook,
       handlePickLorebookImage,
+      isMobileOverlay,
       openLorebookDetail,
       selectedLorebookIds,
       selectionMode,
@@ -774,7 +803,44 @@ export function LorebooksPanel() {
       </div>
 
       {/* Filters */}
-      <div className="flex flex-wrap gap-1">
+      <div className="flex gap-1 md:hidden">
+        <label htmlFor="lorebook-category-filter" className="sr-only">
+          Lorebook category
+        </label>
+        <div className="relative min-w-0 flex-1">
+          <select
+            id="lorebook-category-filter"
+            value={activeCategory}
+            onChange={(event) => setActiveCategory(event.target.value as LorebookCategory | "all" | "active")}
+            className="mari-chrome-field h-10 w-full min-w-0 appearance-none truncate py-0 pl-3 pr-8 text-xs"
+            title="Lorebook category"
+          >
+            {CATEGORIES.map((cat) => (
+              <option key={cat.id} value={cat.id}>
+                {cat.label}
+              </option>
+            ))}
+          </select>
+          <ChevronDown
+            size="0.75rem"
+            className="mari-chrome-field-icon pointer-events-none absolute right-2.5 top-1/2 -translate-y-1/2"
+          />
+        </div>
+        <button
+          onClick={() => setTagsExpanded(!tagsExpanded)}
+          className={cn(
+            "mari-chrome-control mari-chrome-control--small shrink-0 whitespace-nowrap px-2 text-[0.6875rem]",
+            tagFilterActive && "mari-chrome-control--selected",
+          )}
+          title={tagsExpanded ? "Collapse tags" : "Expand tags"}
+        >
+          <Tag size="0.6875rem" />
+          Tags
+          {tagsExpanded ? <ChevronUp size="0.625rem" /> : <ChevronDown size="0.625rem" />}
+        </button>
+      </div>
+
+      <div className="hidden flex-wrap gap-1 md:flex">
         {PRIMARY_CATEGORIES.map((cat) => {
           const isActive = activeCategory === cat.id;
           return (
@@ -825,7 +891,7 @@ export function LorebooksPanel() {
                 type="button"
                 onClick={() => setActiveCategory(isActive ? "all" : cat.id)}
                 className={cn(
-                  "mari-chrome-control mari-chrome-control--compact cursor-pointer",
+                  "mari-chrome-control mari-chrome-control--compact hidden cursor-pointer md:inline-flex",
                   isActive && "mari-chrome-control--selected",
                 )}
               >

--- a/packages/client/src/styles/globals.css
+++ b/packages/client/src/styles/globals.css
@@ -1485,11 +1485,13 @@
 .mari-editor-body {
   display: flex;
   flex: 1 1 0%;
+  min-height: 0;
   overflow: hidden;
 }
 
 .mari-editor-content {
   flex: 1 1 0%;
+  min-height: 0;
   overflow-y: auto;
   padding: 1.5rem;
 }
@@ -1876,10 +1878,39 @@
 
   .mari-editor-body {
     flex-direction: column;
+    min-height: 0;
   }
 
   .mari-editor-content {
+    min-height: 0;
     padding: 1rem;
+    -webkit-overflow-scrolling: touch;
+    overscroll-behavior-y: contain;
+    touch-action: pan-y;
+  }
+
+  .mari-editor-tab-rail {
+    width: 100%;
+    max-width: 100%;
+    flex-direction: row;
+    overflow-x: auto;
+    overflow-y: hidden;
+    border-right: 0;
+    border-bottom: 1px solid var(--marinara-editor-divider);
+    padding: 0.375rem;
+    -webkit-overflow-scrolling: touch;
+    overscroll-behavior-x: contain;
+    touch-action: pan-x;
+  }
+
+  .mari-editor-tab {
+    flex: 0 0 auto;
+    white-space: nowrap;
+    padding: 0.375rem 0.625rem;
+  }
+
+  .mari-editor-tab-badge {
+    margin-left: 0.25rem;
   }
 }
 


### PR DESCRIPTION
## Linked issue

N/A

## Why this change

- Mobile editor overlays trapped users because topbar panel buttons opened panels behind the editor instead of leaving the editor first.
- Lorebook category controls overflowed on mobile because long button labels were forced into cramped rows.

## What changed

- Close active detail editors before mobile topbar panel navigation.
- Restore mobile editor section rails to horizontal scrolling with stable editor content scrolling.
- Convert Lorebook panel and Lorebook editor category controls to mobile dropdowns while preserving desktop buttons.
- Disable native draggable lorebook cards on mobile so normal list scrolling wins, with grip drag still available.

## Validation

- [ ] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed `CONTRIBUTING.md`

### Manual verification notes

- `pnpm --filter @marinara-engine/client lint`
- Confirmed the `Drama` icon is available from the client lucide-react package.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Version/release files updated (only if this PR includes a version bump)

## UI evidence (if applicable)

- Not captured locally; this is a mobile layout and navigation patch based on reported mobile regressions.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Mobile navigation now closes detail views when toggling sidebar or panels.
  * Added mobile-optimized filters and controls for lorebook management.
  * Horizontally scrollable tab navigation on mobile editor.

* **Bug Fixes**
  * Improved editor layout constraints to prevent flex overflow issues.
  * Enhanced touch and scroll behavior for better mobile editor responsiveness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->