### PR TITLE
feat(summary): compress roleplay rolling summaries by auto-hiding summarized messages

### DIFF
--- a/packages/client/src/components/chat/ChatRoleplaySurface.tsx
+++ b/packages/client/src/components/chat/ChatRoleplaySurface.tsx
@@ -1332,7 +1332,8 @@ export function ChatRoleplaySurface({
     typeof chatMeta.summaryRunInterval === "number" && Number.isFinite(chatMeta.summaryRunInterval)
       ? chatMeta.summaryRunInterval
       : undefined;
-  const hideSummarisedMessages = chatMeta.hideSummarisedMessages === true;
+  const hideSummarisedMessages =
+    typeof chatMeta.hideSummarisedMessages === "boolean" ? chatMeta.hideSummarisedMessages : undefined;
   const summaryTailMessages =
     typeof chatMeta.summaryTailMessages === "number" && Number.isFinite(chatMeta.summaryTailMessages)
       ? chatMeta.summaryTailMessages

--- a/packages/client/src/components/chat/ChatRoleplaySurface.tsx
+++ b/packages/client/src/components/chat/ChatRoleplaySurface.tsx
@@ -690,6 +690,8 @@ function SummaryButton({
   automaticSummaryEnabled,
   activeAgentIds,
   summaryRunInterval,
+  hideSummarisedMessages,
+  summaryTailMessages,
   automaticSummariesAvailable,
   totalMessageCount,
   promptPresetId,
@@ -704,6 +706,8 @@ function SummaryButton({
   automaticSummaryEnabled: boolean;
   activeAgentIds: string[];
   summaryRunInterval?: number;
+  hideSummarisedMessages?: boolean;
+  summaryTailMessages?: number;
   automaticSummariesAvailable: boolean;
   totalMessageCount: number;
   promptPresetId?: string | null;
@@ -788,6 +792,8 @@ function SummaryButton({
             automaticSummaryEnabled={automaticSummaryEnabled}
             activeAgentIds={activeAgentIds}
             summaryRunInterval={summaryRunInterval}
+            hideSummarisedMessages={hideSummarisedMessages}
+            summaryTailMessages={summaryTailMessages}
             automaticSummariesAvailable={automaticSummariesAvailable}
             totalMessageCount={totalMessageCount}
             summaryInjectionHint={summaryInjectionHint}
@@ -1326,6 +1332,11 @@ export function ChatRoleplaySurface({
     typeof chatMeta.summaryRunInterval === "number" && Number.isFinite(chatMeta.summaryRunInterval)
       ? chatMeta.summaryRunInterval
       : undefined;
+  const hideSummarisedMessages = chatMeta.hideSummarisedMessages === true;
+  const summaryTailMessages =
+    typeof chatMeta.summaryTailMessages === "number" && Number.isFinite(chatMeta.summaryTailMessages)
+      ? chatMeta.summaryTailMessages
+      : undefined;
 
   return (
     <div data-component="ChatArea.Roleplay" className="flex flex-1 overflow-hidden">
@@ -1424,6 +1435,8 @@ export function ChatRoleplaySurface({
                       automaticSummaryEnabled={automaticSummaryEnabled}
                       activeAgentIds={summaryActiveAgentIds}
                       summaryRunInterval={summaryRunInterval}
+                      hideSummarisedMessages={hideSummarisedMessages}
+                      summaryTailMessages={summaryTailMessages}
                       automaticSummariesAvailable={chatMode === "roleplay"}
                       totalMessageCount={totalMessageCount}
                       promptPresetId={typeof chat?.promptPresetId === "string" ? chat.promptPresetId : null}
@@ -1527,6 +1540,8 @@ export function ChatRoleplaySurface({
                           automaticSummaryEnabled={automaticSummaryEnabled}
                           activeAgentIds={summaryActiveAgentIds}
                           summaryRunInterval={summaryRunInterval}
+                          hideSummarisedMessages={hideSummarisedMessages}
+                          summaryTailMessages={summaryTailMessages}
                           automaticSummariesAvailable={chatMode === "roleplay"}
                           totalMessageCount={totalMessageCount}
                           promptPresetId={typeof chat?.promptPresetId === "string" ? chat.promptPresetId : null}
@@ -1595,6 +1610,8 @@ export function ChatRoleplaySurface({
                         automaticSummaryEnabled={automaticSummaryEnabled}
                         activeAgentIds={summaryActiveAgentIds}
                         summaryRunInterval={summaryRunInterval}
+                        hideSummarisedMessages={hideSummarisedMessages}
+                        summaryTailMessages={summaryTailMessages}
                         automaticSummariesAvailable={chatMode === "roleplay"}
                         totalMessageCount={totalMessageCount}
                         promptPresetId={typeof chat?.promptPresetId === "string" ? chat.promptPresetId : null}

--- a/packages/client/src/components/chat/SummaryPopover.tsx
+++ b/packages/client/src/components/chat/SummaryPopover.tsx
@@ -67,7 +67,7 @@ interface SummaryPopoverProps {
   automaticSummaryEnabled?: boolean;
   activeAgentIds?: string[];
   summaryRunInterval?: number;
-  /** Per-chat persisted "Hide summarised messages" preference (metadata-backed). Undefined falls back to the legacy browser-local pref. */
+  /** Per-chat persisted "Hide summarised messages" preference (metadata-backed). Undefined/false means off (opt-in default). */
   hideSummarisedMessages?: boolean;
   /** How many recent messages stay visible when summarised messages are auto-hidden (roleplay tail). Default 10. */
   summaryTailMessages?: number;
@@ -509,9 +509,11 @@ export function SummaryPopover({
 
   const handleGenerate = useCallback(() => {
     if (!canGenerate) return;
-    const maybeHideSummarisedMessages = (messageIds: string[] | undefined) => {
-      if (!hideSummarisedResolved || !messageIds?.length) return;
-      bulkSetMessagesHiddenFromAI.mutate({ chatId, messageIds, hidden: true });
+    // Hide the server-computed tail-excluded subset, so manual generation honors
+    // `summaryTailMessages` (keep the last N visible) just like the auto path.
+    const maybeHideSummarisedMessages = (hideMessageIds: string[] | undefined) => {
+      if (!hideSummarisedResolved || !hideMessageIds?.length) return;
+      bulkSetMessagesHiddenFromAI.mutate({ chatId, messageIds: hideMessageIds, hidden: true });
     };
     if (sourceMode === "range") {
       setRangeStart(String(rangeLow));
@@ -525,7 +527,7 @@ export function SummaryPopover({
             }
             setEditingEntryId(null);
             setDraftEntry(null);
-            maybeHideSummarisedMessages(data.messageIds);
+            maybeHideSummarisedMessages(data.hideMessageIds);
           },
           onError: (error) => toast.error(summaryErrorMessage(error)),
         },

--- a/packages/client/src/components/chat/SummaryPopover.tsx
+++ b/packages/client/src/components/chat/SummaryPopover.tsx
@@ -303,10 +303,7 @@ export function SummaryPopover({
   const entryTextareaRef = useRef<HTMLTextAreaElement>(null);
   const panelRef = useRef<HTMLDivElement>(null);
 
-  // "Hide summarised messages" is now a per-chat metadata setting so the server
-  // auto-summary can honor it. Fall back to the legacy browser-local pref when a
-  // chat has no persisted value yet (back-compat); nothing is written to
-  // metadata until the user toggles, so existing chats stay opt-out server-side.
+  // Per-chat metadata when set; otherwise fall back to the legacy browser-local pref.
   const hideSummarisedResolved =
     typeof hideSummarisedMessages === "boolean"
       ? hideSummarisedMessages
@@ -677,17 +674,25 @@ export function SummaryPopover({
       const toUnhide = covered.filter((id) => !stillCovered.has(id));
       try {
         await deleteSummaryEntry.mutateAsync({ chatId, entryId: entry.id });
-        if (toUnhide.length > 0) {
-          bulkSetMessagesHiddenFromAI.mutate({ chatId, messageIds: toUnhide, hidden: false });
-        }
-        if (editingEntryId === entry.id) handleCancelEditEntry();
-        setExpandedEntryIds((current) => {
-          const next = new Set(current);
-          next.delete(entry.id);
-          return next;
-        });
       } catch {
         toast.error("Could not delete summary entry.");
+        return;
+      }
+      if (editingEntryId === entry.id) handleCancelEditEntry();
+      setExpandedEntryIds((current) => {
+        const next = new Set(current);
+        next.delete(entry.id);
+        return next;
+      });
+      // The entry is gone; restore its no-longer-covered messages. Awaited separately
+      // so a failure here surfaces a specific warning instead of leaving the messages
+      // silently hidden with nothing summarizing them.
+      if (toUnhide.length > 0) {
+        try {
+          await bulkSetMessagesHiddenFromAI.mutateAsync({ chatId, messageIds: toUnhide, hidden: false });
+        } catch {
+          toast.error("Summary deleted, but some messages stayed hidden — unhide them from the message menu.");
+        }
       }
     },
     [chatId, deleteSummaryEntry, bulkSetMessagesHiddenFromAI, displayEntries, editingEntryId, handleCancelEditEntry],
@@ -890,10 +895,10 @@ export function SummaryPopover({
                 <SummarySettingsToggle
                   label="Hide summarised messages"
                   checked={hideSummarisedResolved}
-                  onChange={(checked) => {
-                    updateMeta.mutate({ id: chatId, hideSummarisedMessages: checked });
-                    setSummaryPopoverSettings({ hideSummarisedMessages: checked });
-                  }}
+                  // Per-chat metadata is the source of truth; do not write the global
+                  // ui.store here, or one chat's choice would leak into the fallback
+                  // other chats use when they have no persisted value of their own.
+                  onChange={(checked) => updateMeta.mutate({ id: chatId, hideSummarisedMessages: checked })}
                 />
                 {hideSummarisedResolved && (
                   <div className="space-y-1 px-1 pb-0.5">

--- a/packages/client/src/components/chat/SummaryPopover.tsx
+++ b/packages/client/src/components/chat/SummaryPopover.tsx
@@ -509,8 +509,7 @@ export function SummaryPopover({
 
   const handleGenerate = useCallback(() => {
     if (!canGenerate) return;
-    // Hide the server-computed tail-excluded subset, so manual generation honors
-    // `summaryTailMessages` (keep the last N visible) just like the auto path.
+    // Hide the server-computed tail-excluded subset (data.hideMessageIds).
     const maybeHideSummarisedMessages = (hideMessageIds: string[] | undefined) => {
       if (!hideSummarisedResolved || !hideMessageIds?.length) return;
       bulkSetMessagesHiddenFromAI.mutate({ chatId, messageIds: hideMessageIds, hidden: true });
@@ -545,7 +544,7 @@ export function SummaryPopover({
           }
           setEditingEntryId(null);
           setDraftEntry(null);
-          maybeHideSummarisedMessages(data.messageIds);
+          maybeHideSummarisedMessages(data.hideMessageIds);
         },
         onError: (error) => toast.error(summaryErrorMessage(error)),
       },

--- a/packages/client/src/components/chat/SummaryPopover.tsx
+++ b/packages/client/src/components/chat/SummaryPopover.tsx
@@ -303,11 +303,19 @@ export function SummaryPopover({
   const entryTextareaRef = useRef<HTMLTextAreaElement>(null);
   const panelRef = useRef<HTMLDivElement>(null);
 
-  // Per-chat metadata when set; otherwise fall back to the legacy browser-local pref.
-  const hideSummarisedResolved =
-    typeof hideSummarisedMessages === "boolean"
-      ? hideSummarisedMessages
-      : summaryPopoverSettings.hideSummarisedMessages;
+  // Per-chat metadata is the source of truth (default off). A chat with no
+  // persisted value adopts the legacy global pref once (effect below), so no chat
+  // ever reads another chat's setting at runtime.
+  const hideSummarisedResolved = hideSummarisedMessages === true;
+  const legacyHidePref = summaryPopoverSettings.hideSummarisedMessages;
+  const migratedHideChatsRef = useRef<Set<string>>(new Set());
+  useEffect(() => {
+    if (typeof hideSummarisedMessages === "boolean") return; // already per-chat
+    if (!legacyHidePref) return; // nothing to migrate; stays opt-out
+    if (migratedHideChatsRef.current.has(chatId)) return;
+    migratedHideChatsRef.current.add(chatId);
+    updateMeta.mutate({ id: chatId, hideSummarisedMessages: true });
+  }, [chatId, hideSummarisedMessages, legacyHidePref, updateMeta]);
 
   const persistSummaryContextSize = useCallback(
     (size: number) => {
@@ -662,16 +670,10 @@ export function SummaryPopover({
         tone: "destructive",
       });
       if (!confirmed) return;
-      // Unhide the messages this entry covered, except any still referenced by
-      // another *enabled* entry (a disabled entry is not in the prompt, so its
-      // messages must become visible again). Prevents orphaned hidden messages.
-      const covered = entry.messageIds ?? [];
-      const stillCovered = new Set<string>();
-      for (const other of displayEntries) {
-        if (other.id === entry.id || !other.enabled) continue;
-        for (const id of other.messageIds ?? []) stillCovered.add(id);
-      }
-      const toUnhide = covered.filter((id) => !stillCovered.has(id));
+      // The server unhides the messages this entry covered (minus any still
+      // covered by another enabled entry) as part of the delete, so deletion and
+      // visibility restoration succeed or fail together — no orphaned hidden
+      // messages on the client side.
       try {
         await deleteSummaryEntry.mutateAsync({ chatId, entryId: entry.id });
       } catch {
@@ -684,18 +686,8 @@ export function SummaryPopover({
         next.delete(entry.id);
         return next;
       });
-      // The entry is gone; restore its no-longer-covered messages. Awaited separately
-      // so a failure here surfaces a specific warning instead of leaving the messages
-      // silently hidden with nothing summarizing them.
-      if (toUnhide.length > 0) {
-        try {
-          await bulkSetMessagesHiddenFromAI.mutateAsync({ chatId, messageIds: toUnhide, hidden: false });
-        } catch {
-          toast.error("Summary deleted, but some messages stayed hidden — unhide them from the message menu.");
-        }
-      }
     },
-    [chatId, deleteSummaryEntry, bulkSetMessagesHiddenFromAI, displayEntries, editingEntryId, handleCancelEditEntry],
+    [chatId, deleteSummaryEntry, editingEntryId, handleCancelEditEntry],
   );
 
   const persistPromptTemplates = useCallback(

--- a/packages/client/src/components/chat/SummaryPopover.tsx
+++ b/packages/client/src/components/chat/SummaryPopover.tsx
@@ -66,6 +66,10 @@ interface SummaryPopoverProps {
   automaticSummaryEnabled?: boolean;
   activeAgentIds?: string[];
   summaryRunInterval?: number;
+  /** Per-chat persisted "Hide summarised messages" preference (metadata-backed). Undefined falls back to the legacy browser-local pref. */
+  hideSummarisedMessages?: boolean;
+  /** How many recent messages stay visible when summarised messages are auto-hidden (roleplay tail). Default 10. */
+  summaryTailMessages?: number;
   automaticSummariesAvailable?: boolean;
   totalMessageCount: number;
   summaryInjectionHint?: string | null;
@@ -256,6 +260,8 @@ export function SummaryPopover({
   automaticSummaryEnabled = false,
   activeAgentIds = [],
   summaryRunInterval,
+  hideSummarisedMessages,
+  summaryTailMessages,
   automaticSummariesAvailable = true,
   totalMessageCount,
   summaryInjectionHint = null,
@@ -296,6 +302,15 @@ export function SummaryPopover({
   const toggleSummaryEntry = useToggleSummaryEntry();
   const entryTextareaRef = useRef<HTMLTextAreaElement>(null);
   const panelRef = useRef<HTMLDivElement>(null);
+
+  // "Hide summarised messages" is now a per-chat metadata setting so the server
+  // auto-summary can honor it. Fall back to the legacy browser-local pref when a
+  // chat has no persisted value yet (back-compat); nothing is written to
+  // metadata until the user toggles, so existing chats stay opt-out server-side.
+  const hideSummarisedResolved =
+    typeof hideSummarisedMessages === "boolean"
+      ? hideSummarisedMessages
+      : summaryPopoverSettings.hideSummarisedMessages;
 
   const persistSummaryContextSize = useCallback(
     (size: number) => {
@@ -498,7 +513,7 @@ export function SummaryPopover({
   const handleGenerate = useCallback(() => {
     if (!canGenerate) return;
     const maybeHideSummarisedMessages = (messageIds: string[] | undefined) => {
-      if (!summaryPopoverSettings.hideSummarisedMessages || !messageIds?.length) return;
+      if (!hideSummarisedResolved || !messageIds?.length) return;
       bulkSetMessagesHiddenFromAI.mutate({ chatId, messageIds, hidden: true });
     };
     if (sourceMode === "range") {
@@ -547,7 +562,7 @@ export function SummaryPopover({
     persistSummaryContextSize,
     sourceMode,
     activePromptTemplateId,
-    summaryPopoverSettings.hideSummarisedMessages,
+    hideSummarisedResolved,
   ]);
 
   const handleToggleExpanded = useCallback((entryId: string) => {
@@ -650,8 +665,21 @@ export function SummaryPopover({
         tone: "destructive",
       });
       if (!confirmed) return;
+      // Unhide the messages this entry covered, except any still referenced by
+      // another *enabled* entry (a disabled entry is not in the prompt, so its
+      // messages must become visible again). Prevents orphaned hidden messages.
+      const covered = entry.messageIds ?? [];
+      const stillCovered = new Set<string>();
+      for (const other of displayEntries) {
+        if (other.id === entry.id || !other.enabled) continue;
+        for (const id of other.messageIds ?? []) stillCovered.add(id);
+      }
+      const toUnhide = covered.filter((id) => !stillCovered.has(id));
       try {
         await deleteSummaryEntry.mutateAsync({ chatId, entryId: entry.id });
+        if (toUnhide.length > 0) {
+          bulkSetMessagesHiddenFromAI.mutate({ chatId, messageIds: toUnhide, hidden: false });
+        }
         if (editingEntryId === entry.id) handleCancelEditEntry();
         setExpandedEntryIds((current) => {
           const next = new Set(current);
@@ -662,7 +690,7 @@ export function SummaryPopover({
         toast.error("Could not delete summary entry.");
       }
     },
-    [chatId, deleteSummaryEntry, editingEntryId, handleCancelEditEntry],
+    [chatId, deleteSummaryEntry, bulkSetMessagesHiddenFromAI, displayEntries, editingEntryId, handleCancelEditEntry],
   );
 
   const persistPromptTemplates = useCallback(
@@ -861,9 +889,36 @@ export function SummaryPopover({
                 <p className="px-1 text-[0.6875rem] font-semibold text-[var(--popover-foreground)]">Display</p>
                 <SummarySettingsToggle
                   label="Hide summarised messages"
-                  checked={summaryPopoverSettings.hideSummarisedMessages}
-                  onChange={(checked) => setSummaryPopoverSettings({ hideSummarisedMessages: checked })}
+                  checked={hideSummarisedResolved}
+                  onChange={(checked) => {
+                    updateMeta.mutate({ id: chatId, hideSummarisedMessages: checked });
+                    setSummaryPopoverSettings({ hideSummarisedMessages: checked });
+                  }}
                 />
+                {hideSummarisedResolved && (
+                  <div className="space-y-1 px-1 pb-0.5">
+                    <label className="flex items-center justify-between gap-2 text-[0.6875rem] font-medium text-[var(--popover-foreground)]">
+                      <span>Recent message tail</span>
+                      <input
+                        type="number"
+                        min={0}
+                        max={50}
+                        step={1}
+                        value={summaryTailMessages ?? 10}
+                        onChange={(event) => {
+                          const raw = Number(event.target.value);
+                          const clamped = Number.isFinite(raw) ? Math.max(0, Math.min(50, Math.floor(raw))) : 10;
+                          updateMeta.mutate({ id: chatId, summaryTailMessages: clamped });
+                        }}
+                        className="w-16 rounded-md bg-[var(--secondary)] px-2 py-1 text-right text-xs outline-none ring-1 ring-transparent transition-shadow focus:ring-[var(--primary)]/40"
+                      />
+                    </label>
+                    <p className="text-[0.625rem] text-[var(--muted-foreground)]">
+                      Most recent messages kept word-for-word when auto-hiding summarised ones. Set to{" "}
+                      <span className="font-medium">0</span> to hide the whole batch.
+                    </p>
+                  </div>
+                )}
                 <SummarySettingsToggle
                   label="Collapse hidden messages"
                   checked={summaryPopoverSettings.collapseHiddenMessages}

--- a/packages/client/src/components/chat/SummaryPopover.tsx
+++ b/packages/client/src/components/chat/SummaryPopover.tsx
@@ -303,19 +303,10 @@ export function SummaryPopover({
   const entryTextareaRef = useRef<HTMLTextAreaElement>(null);
   const panelRef = useRef<HTMLDivElement>(null);
 
-  // Per-chat metadata is the source of truth (default off). A chat with no
-  // persisted value adopts the legacy global pref once (effect below), so no chat
-  // ever reads another chat's setting at runtime.
+  // Per-chat metadata is the single source of truth (default off). The hide
+  // preference is owned per-chat and set via the toggle below — there is no global
+  // fallback, so one chat can never read or inherit another chat's setting.
   const hideSummarisedResolved = hideSummarisedMessages === true;
-  const legacyHidePref = summaryPopoverSettings.hideSummarisedMessages;
-  const migratedHideChatsRef = useRef<Set<string>>(new Set());
-  useEffect(() => {
-    if (typeof hideSummarisedMessages === "boolean") return; // already per-chat
-    if (!legacyHidePref) return; // nothing to migrate; stays opt-out
-    if (migratedHideChatsRef.current.has(chatId)) return;
-    migratedHideChatsRef.current.add(chatId);
-    updateMeta.mutate({ id: chatId, hideSummarisedMessages: true });
-  }, [chatId, hideSummarisedMessages, legacyHidePref, updateMeta]);
 
   const persistSummaryContextSize = useCallback(
     (size: number) => {

--- a/packages/client/src/components/chat/SummaryPopover.tsx
+++ b/packages/client/src/components/chat/SummaryPopover.tsx
@@ -302,9 +302,8 @@ export function SummaryPopover({
   const entryTextareaRef = useRef<HTMLTextAreaElement>(null);
   const panelRef = useRef<HTMLDivElement>(null);
 
-  // Per-chat metadata is the single source of truth (default off). The hide
-  // preference is owned per-chat and set via the toggle below — there is no global
-  // fallback, so one chat can never read or inherit another chat's setting.
+  // Per-chat preference, default off — no global fallback, so one chat never
+  // inherits another's setting.
   const hideSummarisedResolved = hideSummarisedMessages === true;
 
   const persistSummaryContextSize = useCallback(

--- a/packages/client/src/components/chat/SummaryPopover.tsx
+++ b/packages/client/src/components/chat/SummaryPopover.tsx
@@ -14,7 +14,6 @@ import {
 } from "react";
 import { createPortal } from "react-dom";
 import {
-  useBulkSetMessagesHiddenFromAI,
   useDeleteSummaryEntry,
   useGenerateSummary,
   useToggleSummaryEntry,
@@ -295,7 +294,6 @@ export function SummaryPopover({
   const rangeInputFocused = useRef(false);
   const automaticIntervalFocused = useRef(false);
   const generateSummary = useGenerateSummary();
-  const bulkSetMessagesHiddenFromAI = useBulkSetMessagesHiddenFromAI();
   const updateMeta = useUpdateChatMetadata();
   const { data: connectionsData } = useConnections();
   const updateSummaryEntry = useUpdateSummaryEntry();
@@ -509,11 +507,9 @@ export function SummaryPopover({
 
   const handleGenerate = useCallback(() => {
     if (!canGenerate) return;
-    // Hide the server-computed tail-excluded subset (data.hideMessageIds).
-    const maybeHideSummarisedMessages = (hideMessageIds: string[] | undefined) => {
-      if (!hideSummarisedResolved || !hideMessageIds?.length) return;
-      bulkSetMessagesHiddenFromAI.mutate({ chatId, messageIds: hideMessageIds, hidden: true });
-    };
+    // The server hides the tail-excluded subset itself (when the chat opts in)
+    // and the generate-summary mutation refreshes the message list, so there is
+    // no separate client-side hide to keep in sync.
     if (sourceMode === "range") {
       setRangeStart(String(rangeLow));
       setRangeEnd(String(rangeHigh));
@@ -526,7 +522,6 @@ export function SummaryPopover({
             }
             setEditingEntryId(null);
             setDraftEntry(null);
-            maybeHideSummarisedMessages(data.hideMessageIds);
           },
           onError: (error) => toast.error(summaryErrorMessage(error)),
         },
@@ -544,13 +539,11 @@ export function SummaryPopover({
           }
           setEditingEntryId(null);
           setDraftEntry(null);
-          maybeHideSummarisedMessages(data.hideMessageIds);
         },
         onError: (error) => toast.error(summaryErrorMessage(error)),
       },
     );
   }, [
-    bulkSetMessagesHiddenFromAI,
     canGenerate,
     chatId,
     generateSummary,
@@ -560,7 +553,6 @@ export function SummaryPopover({
     persistSummaryContextSize,
     sourceMode,
     activePromptTemplateId,
-    hideSummarisedResolved,
   ]);
 
   const handleToggleExpanded = useCallback((entryId: string) => {

--- a/packages/client/src/components/chat/SummaryPopover.tsx
+++ b/packages/client/src/components/chat/SummaryPopover.tsx
@@ -48,6 +48,7 @@ import {
 import {
   type APIConnection,
   DEFAULT_CHAT_SUMMARY_PROMPT,
+  SUMMARY_TAIL_MESSAGES,
   estimateChatSummaryTokens,
   normalizeChatSummaryEntries,
   type ChatSummaryEntry,
@@ -878,9 +879,7 @@ export function SummaryPopover({
                 <SummarySettingsToggle
                   label="Hide summarised messages"
                   checked={hideSummarisedResolved}
-                  // Per-chat metadata is the source of truth; do not write the global
-                  // ui.store here, or one chat's choice would leak into the fallback
-                  // other chats use when they have no persisted value of their own.
+                  // Writes per-chat metadata only — never the global ui.store.
                   onChange={(checked) => updateMeta.mutate({ id: chatId, hideSummarisedMessages: checked })}
                 />
                 {hideSummarisedResolved && (
@@ -889,13 +888,15 @@ export function SummaryPopover({
                       <span>Recent message tail</span>
                       <input
                         type="number"
-                        min={0}
-                        max={50}
+                        min={SUMMARY_TAIL_MESSAGES.MIN}
+                        max={SUMMARY_TAIL_MESSAGES.MAX}
                         step={1}
-                        value={summaryTailMessages ?? 10}
+                        value={summaryTailMessages ?? SUMMARY_TAIL_MESSAGES.DEFAULT}
                         onChange={(event) => {
                           const raw = Number(event.target.value);
-                          const clamped = Number.isFinite(raw) ? Math.max(0, Math.min(50, Math.floor(raw))) : 10;
+                          const clamped = Number.isFinite(raw)
+                            ? Math.max(SUMMARY_TAIL_MESSAGES.MIN, Math.min(SUMMARY_TAIL_MESSAGES.MAX, Math.floor(raw)))
+                            : SUMMARY_TAIL_MESSAGES.DEFAULT;
                           updateMeta.mutate({ id: chatId, summaryTailMessages: clamped });
                         }}
                         className="w-16 rounded-md bg-[var(--secondary)] px-2 py-1 text-right text-xs outline-none ring-1 ring-transparent transition-shadow focus:ring-[var(--primary)]/40"

--- a/packages/client/src/hooks/use-chats.ts
+++ b/packages/client/src/hooks/use-chats.ts
@@ -1110,6 +1110,8 @@ export function useGenerateSummary() {
         entry: ChatSummaryEntry | null;
         entries: ChatSummaryEntry[];
         messageIds: string[];
+        /** Subset of messageIds eligible to hide (summarized set minus the protected tail). */
+        hideMessageIds: string[];
       }>(`/chats/${chatId}/generate-summary`, {
         contextSize,
         rangeStartMessageId,

--- a/packages/client/src/hooks/use-chats.ts
+++ b/packages/client/src/hooks/use-chats.ts
@@ -732,6 +732,9 @@ function useSummaryEntryMutation() {
       }
       qc.invalidateQueries({ queryKey: chatKeys.list() });
       qc.invalidateQueries({ queryKey: lorebookKeys.active(vars.chatId) });
+      // Deleting an entry can unhide messages server-side; refresh the list so
+      // their restored visibility shows without a manual reload.
+      qc.invalidateQueries({ queryKey: chatKeys.messages(vars.chatId) });
     },
   });
 }

--- a/packages/client/src/hooks/use-chats.ts
+++ b/packages/client/src/hooks/use-chats.ts
@@ -732,9 +732,11 @@ function useSummaryEntryMutation() {
       }
       qc.invalidateQueries({ queryKey: chatKeys.list() });
       qc.invalidateQueries({ queryKey: lorebookKeys.active(vars.chatId) });
-      // Deleting an entry can unhide messages server-side; refresh the list so
-      // their restored visibility shows without a manual reload.
-      qc.invalidateQueries({ queryKey: chatKeys.messages(vars.chatId) });
+      // Only delete changes message visibility (it unhides server-side), so scope
+      // the message-list refetch to that operation rather than every summary edit.
+      if (vars.operation === "delete") {
+        qc.invalidateQueries({ queryKey: chatKeys.messages(vars.chatId) });
+      }
     },
   });
 }

--- a/packages/client/src/hooks/use-chats.ts
+++ b/packages/client/src/hooks/use-chats.ts
@@ -1133,6 +1133,11 @@ export function useGenerateSummary() {
         });
       }
       qc.invalidateQueries({ queryKey: chatKeys.detail(vars.chatId) });
+      // The server may have hidden the tail-excluded subset; refresh the message
+      // list so the hidden state shows without a manual reload.
+      if (data.hideMessageIds.length > 0) {
+        qc.invalidateQueries({ queryKey: chatKeys.messages(vars.chatId) });
+      }
     },
   });
 }

--- a/packages/client/src/hooks/use-generate.ts
+++ b/packages/client/src/hooks/use-generate.ts
@@ -1691,6 +1691,12 @@ export function useGenerate() {
             case "chat_summary": {
               // Refresh the chat detail so the summary popover picks up the new value
               qc.invalidateQueries({ queryKey: chatKeys.detail(params.chatId) });
+              // When the server auto-hid summarized messages (opt-in token compression),
+              // refresh the message list so their hidden state shows in the UI.
+              const summaryData = event.data as { hiddenMessageIds?: unknown };
+              if (Array.isArray(summaryData.hiddenMessageIds) && summaryData.hiddenMessageIds.length > 0) {
+                qc.invalidateQueries({ queryKey: chatKeys.messages(params.chatId) });
+              }
               break;
             }
 

--- a/packages/server/src/routes/chats.routes.ts
+++ b/packages/server/src/routes/chats.routes.ts
@@ -2867,43 +2867,61 @@ export async function chatsRoutes(app: FastifyInstance) {
     if (hideMessageIds.length > 0) {
       await storage.bulkSetHiddenFromAI(req.params.id, hideMessageIds, true);
     }
+    // If the entry that owns hiddenMessageIds is not persisted (chat vanished, or
+    // the write throws), roll the hide back so we never leave messages hidden with
+    // no entry to delete and no recorded subset to restore.
+    const rollbackHide = async () => {
+      if (hideMessageIds.length === 0) return;
+      await storage.bulkSetHiddenFromAI(req.params.id, hideMessageIds, false).catch((err) => {
+        logger.error(err, "[chat-summary] Failed to roll back hide after summary entry was not persisted");
+      });
+    };
 
     // Append as a structured entry and recompile the prompt-facing summary
     // without replacing concurrent metadata changes.
     let combined: string | null = summaryText;
     let createdEntry: ChatSummaryEntry | null = null;
     let summaryEntries: ChatSummaryEntry[] = [];
-    const updatedChat = await storage.patchMetadata(req.params.id, (freshMeta) => {
-      const now = new Date().toISOString();
-      const result = appendChatSummaryEntryToMetadata(
-        freshMeta,
-        {
-          kind: "rolling",
-          origin: "manual",
-          sourceMode: hasRange ? "range" : "last",
-          content: summaryText,
-          enabled: true,
-          messageCount: selectedMessages.length,
-          rangeStartIndex: selectedRangeStartIndex,
-          rangeEndIndex: selectedRangeEndIndex,
-          messageIds,
-          ...(hideMessageIds.length > 0 ? { hiddenMessageIds: hideMessageIds } : {}),
-          promptTemplateId: requestedPromptTemplateId,
-          createdAt: now,
-          updatedAt: now,
-        },
-        { createId: newId, now },
-      );
-      combined = result.summary;
-      createdEntry = result.entry;
-      summaryEntries = result.entries;
-      return {
-        summary: result.summary,
-        summaryEntries: result.entries,
-        ...(!hasRange && typeof body.contextSize !== "undefined" ? { summaryContextSize: contextSize } : {}),
-      };
-    });
-    if (!updatedChat) return reply.status(404).send({ error: "Chat not found" });
+    let updatedChat: Awaited<ReturnType<typeof storage.patchMetadata>>;
+    try {
+      updatedChat = await storage.patchMetadata(req.params.id, (freshMeta) => {
+        const now = new Date().toISOString();
+        const result = appendChatSummaryEntryToMetadata(
+          freshMeta,
+          {
+            kind: "rolling",
+            origin: "manual",
+            sourceMode: hasRange ? "range" : "last",
+            content: summaryText,
+            enabled: true,
+            messageCount: selectedMessages.length,
+            rangeStartIndex: selectedRangeStartIndex,
+            rangeEndIndex: selectedRangeEndIndex,
+            messageIds,
+            ...(hideMessageIds.length > 0 ? { hiddenMessageIds: hideMessageIds } : {}),
+            promptTemplateId: requestedPromptTemplateId,
+            createdAt: now,
+            updatedAt: now,
+          },
+          { createId: newId, now },
+        );
+        combined = result.summary;
+        createdEntry = result.entry;
+        summaryEntries = result.entries;
+        return {
+          summary: result.summary,
+          summaryEntries: result.entries,
+          ...(!hasRange && typeof body.contextSize !== "undefined" ? { summaryContextSize: contextSize } : {}),
+        };
+      });
+    } catch (err) {
+      await rollbackHide();
+      throw err;
+    }
+    if (!updatedChat) {
+      await rollbackHide();
+      return reply.status(404).send({ error: "Chat not found" });
+    }
 
     return {
       summary: combined,

--- a/packages/server/src/routes/chats.routes.ts
+++ b/packages/server/src/routes/chats.routes.ts
@@ -61,10 +61,12 @@ import { DATA_DIR } from "../utils/data-dir.js";
 import { normalizeTimestampOverrides } from "../services/import/import-timestamps.js";
 import {
   appendNonLeadingSystemMessagesToLastUser,
+  computeSummaryHideIds,
   findTrackerContextInsertIndex,
   isManualTrackerCharacterId,
   parseExtra,
   resolveRoleplayChatSummary,
+  resolveRoleplaySummaryTail,
   isMessageHiddenFromAI,
   resolveBaseUrl,
   resolveActiveCharacterIds,
@@ -2880,11 +2882,22 @@ export async function chatsRoutes(app: FastifyInstance) {
     });
     if (!updatedChat) return reply.status(404).send({ error: "Chat not found" });
 
+    const messageIds = selectedMessages.map((message) => message.id);
+    // The subset eligible to be hidden when "Hide summarised messages" is on:
+    // the summarized messages minus the protected recent tail, so manual hiding
+    // honors `summaryTailMessages` exactly like the automatic path does.
+    const hideMessageIds = computeSummaryHideIds({
+      messages: allMessages,
+      entryMessageIds: messageIds,
+      tail: resolveRoleplaySummaryTail(chatMeta.summaryTailMessages),
+    });
+
     return {
       summary: combined,
       entry: createdEntry,
       entries: summaryEntries,
-      messageIds: selectedMessages.map((message) => message.id),
+      messageIds,
+      hideMessageIds,
     };
   });
 }

--- a/packages/server/src/routes/chats.routes.ts
+++ b/packages/server/src/routes/chats.routes.ts
@@ -656,11 +656,13 @@ export async function chatsRoutes(app: FastifyInstance) {
       });
       const target = currentEntries.find((entry) => entry.id === body.entryId);
       if (target) {
-        const covered = target.messageIds ?? [];
+        // Restore exactly what this entry hid. `hiddenMessageIds` records the
+        // precise hidden subset; older entries without it fall back to messageIds.
+        const covered = target.hiddenMessageIds ?? target.messageIds ?? [];
         const stillCovered = new Set<string>();
         for (const entry of currentEntries) {
           if (entry.id === body.entryId || !entry.enabled) continue;
-          for (const id of entry.messageIds ?? []) stillCovered.add(id);
+          for (const id of entry.hiddenMessageIds ?? entry.messageIds ?? []) stillCovered.add(id);
         }
         const toUnhide = covered.filter((id) => !stillCovered.has(id));
         if (toUnhide.length > 0) {
@@ -2846,6 +2848,20 @@ export async function chatsRoutes(app: FastifyInstance) {
       summaryText = result.content.trim();
     }
 
+    const messageIds = selectedMessages.map((message) => message.id);
+    // Subset eligible to be hidden when "Hide summarised messages" is on: the
+    // summarized set minus the protected tail, so manual hiding honors
+    // `summaryTailMessages` like the automatic path. Persisted on the entry (when
+    // hiding is enabled) so deletion restores exactly what was hidden.
+    const hideEnabled = chatMeta.hideSummarisedMessages === true;
+    const hideMessageIds = hideEnabled
+      ? computeSummaryHideIds({
+          messages: allMessages,
+          entryMessageIds: messageIds,
+          tail: resolveRoleplaySummaryTail(chatMeta.summaryTailMessages),
+        })
+      : [];
+
     // Append as a structured entry and recompile the prompt-facing summary
     // without replacing concurrent metadata changes.
     let combined: string | null = summaryText;
@@ -2864,7 +2880,8 @@ export async function chatsRoutes(app: FastifyInstance) {
           messageCount: selectedMessages.length,
           rangeStartIndex: selectedRangeStartIndex,
           rangeEndIndex: selectedRangeEndIndex,
-          messageIds: selectedMessages.map((message) => message.id),
+          messageIds,
+          ...(hideMessageIds.length > 0 ? { hiddenMessageIds: hideMessageIds } : {}),
           promptTemplateId: requestedPromptTemplateId,
           createdAt: now,
           updatedAt: now,
@@ -2881,16 +2898,6 @@ export async function chatsRoutes(app: FastifyInstance) {
       };
     });
     if (!updatedChat) return reply.status(404).send({ error: "Chat not found" });
-
-    const messageIds = selectedMessages.map((message) => message.id);
-    // The subset eligible to be hidden when "Hide summarised messages" is on:
-    // the summarized messages minus the protected recent tail, so manual hiding
-    // honors `summaryTailMessages` exactly like the automatic path does.
-    const hideMessageIds = computeSummaryHideIds({
-      messages: allMessages,
-      entryMessageIds: messageIds,
-      tail: resolveRoleplaySummaryTail(chatMeta.summaryTailMessages),
-    });
 
     return {
       summary: combined,

--- a/packages/server/src/routes/chats.routes.ts
+++ b/packages/server/src/routes/chats.routes.ts
@@ -2854,13 +2854,21 @@ export async function chatsRoutes(app: FastifyInstance) {
     // `summaryTailMessages` like the automatic path. Persisted on the entry (when
     // hiding is enabled) so deletion restores exactly what was hidden.
     const hideEnabled = chatMeta.hideSummarisedMessages === true;
-    const hideMessageIds = hideEnabled
+    const eligibleToHide = hideEnabled
       ? computeSummaryHideIds({
           messages: allMessages,
           entryMessageIds: messageIds,
           tail: resolveRoleplaySummaryTail(chatMeta.summaryTailMessages),
         })
       : [];
+    // Only the messages this attempt actually flips from visible to hidden. (The
+    // summary's source already excludes hidden messages, so this is normally the
+    // whole set, but snapshot the prior state explicitly so a rollback can never
+    // resurrect a message that was already hidden by something else.)
+    const hiddenAtLoad = new Set(
+      allMessages.filter((message) => isMessageHiddenFromAI(message)).map((message) => message.id),
+    );
+    const hideMessageIds = eligibleToHide.filter((id) => !hiddenAtLoad.has(id));
     // Perform the hide on the server, BEFORE the entry records hiddenMessageIds,
     // so the recorded set always reflects messages actually hidden (no phantom
     // set if a separate client call were to fail). The client no longer hides.
@@ -2868,13 +2876,12 @@ export async function chatsRoutes(app: FastifyInstance) {
       await storage.bulkSetHiddenFromAI(req.params.id, hideMessageIds, true);
     }
     // If the entry that owns hiddenMessageIds is not persisted (chat vanished, or
-    // the write throws), roll the hide back so we never leave messages hidden with
-    // no entry to delete and no recorded subset to restore.
+    // the write throws), roll back only the hides this attempt newly applied so we
+    // never leave messages hidden with no entry. A rollback failure is surfaced
+    // (re-thrown), not swallowed, so the caller learns recovery did not complete.
     const rollbackHide = async () => {
       if (hideMessageIds.length === 0) return;
-      await storage.bulkSetHiddenFromAI(req.params.id, hideMessageIds, false).catch((err) => {
-        logger.error(err, "[chat-summary] Failed to roll back hide after summary entry was not persisted");
-      });
+      await storage.bulkSetHiddenFromAI(req.params.id, hideMessageIds, false);
     };
 
     // Append as a structured entry and recompile the prompt-facing summary

--- a/packages/server/src/routes/chats.routes.ts
+++ b/packages/server/src/routes/chats.routes.ts
@@ -641,6 +641,33 @@ export async function chatsRoutes(app: FastifyInstance) {
       return reply.status(400).send({ error: "Unsupported summary entry operation" });
     }
 
+    // For delete: restore visibility of the messages this entry covered (except
+    // any still covered by another enabled entry) BEFORE removing it, so deleting
+    // an entry can never strand messages hidden with nothing left to summarize
+    // them. Unhiding first means a failure here aborts the delete rather than
+    // leaving an orphan.
+    if (body.operation === "delete") {
+      const current = await storage.getById(req.params.id);
+      if (!current) return reply.status(404).send({ error: "Chat not found" });
+      const currentMeta = parseExtra(current.metadata) as Record<string, unknown>;
+      const currentEntries = normalizeChatSummaryEntries(currentMeta.summaryEntries, {
+        legacySummary: typeof currentMeta.summary === "string" ? currentMeta.summary : null,
+      });
+      const target = currentEntries.find((entry) => entry.id === body.entryId);
+      if (target) {
+        const covered = target.messageIds ?? [];
+        const stillCovered = new Set<string>();
+        for (const entry of currentEntries) {
+          if (entry.id === body.entryId || !entry.enabled) continue;
+          for (const id of entry.messageIds ?? []) stillCovered.add(id);
+        }
+        const toUnhide = covered.filter((id) => !stillCovered.has(id));
+        if (toUnhide.length > 0) {
+          await storage.bulkSetHiddenFromAI(req.params.id, toUnhide, false);
+        }
+      }
+    }
+
     const updated = await storage.patchMetadata(req.params.id, (freshMeta) => {
       const entries = normalizeChatSummaryEntries(freshMeta.summaryEntries, {
         legacySummary: typeof freshMeta.summary === "string" ? freshMeta.summary : null,

--- a/packages/server/src/routes/chats.routes.ts
+++ b/packages/server/src/routes/chats.routes.ts
@@ -1418,7 +1418,7 @@ export async function chatsRoutes(app: FastifyInstance) {
         return reply.status(400).send({ error: "hidden must be a boolean" });
       }
       const updatedIds = await storage.bulkSetHiddenFromAI(req.params.chatId, messageIds, hidden);
-      return { updated: updatedIds.length };
+      return { updated: updatedIds.length, updatedIds };
     },
   );
 

--- a/packages/server/src/routes/chats.routes.ts
+++ b/packages/server/src/routes/chats.routes.ts
@@ -664,8 +664,10 @@ export async function chatsRoutes(app: FastifyInstance) {
         }
         const toUnhide = covered.filter((id) => !stillCovered.has(id));
         if (toUnhide.length > 0) {
-          await storage.bulkSetHiddenFromAI(req.params.id, toUnhide, false);
-          unhidden = toUnhide;
+          // Capture the exact rows the store actually unhid (request scoped to
+          // this chat) so compensation re-hides precisely that set, not the
+          // speculative request.
+          unhidden = await storage.bulkSetHiddenFromAI(req.params.id, toUnhide, false);
         }
       }
     }
@@ -1415,8 +1417,8 @@ export async function chatsRoutes(app: FastifyInstance) {
       if (typeof hidden !== "boolean") {
         return reply.status(400).send({ error: "hidden must be a boolean" });
       }
-      const count = await storage.bulkSetHiddenFromAI(req.params.chatId, messageIds, hidden);
-      return { updated: count };
+      const updatedIds = await storage.bulkSetHiddenFromAI(req.params.chatId, messageIds, hidden);
+      return { updated: updatedIds.length };
     },
   );
 

--- a/packages/server/src/routes/chats.routes.ts
+++ b/packages/server/src/routes/chats.routes.ts
@@ -644,8 +644,9 @@ export async function chatsRoutes(app: FastifyInstance) {
     // For delete: restore visibility of the messages this entry covered (except
     // any still covered by another enabled entry) BEFORE removing it, so deleting
     // an entry can never strand messages hidden with nothing left to summarize
-    // them. Unhiding first means a failure here aborts the delete rather than
-    // leaving an orphan.
+    // them. `unhidden` is tracked so we can re-hide (compensate) if the metadata
+    // write below fails, keeping the two writes consistent either way.
+    let unhidden: string[] = [];
     if (body.operation === "delete") {
       const current = await storage.getById(req.params.id);
       if (!current) return reply.status(404).send({ error: "Chat not found" });
@@ -664,51 +665,71 @@ export async function chatsRoutes(app: FastifyInstance) {
         const toUnhide = covered.filter((id) => !stillCovered.has(id));
         if (toUnhide.length > 0) {
           await storage.bulkSetHiddenFromAI(req.params.id, toUnhide, false);
+          unhidden = toUnhide;
         }
       }
     }
 
-    const updated = await storage.patchMetadata(req.params.id, (freshMeta) => {
-      const entries = normalizeChatSummaryEntries(freshMeta.summaryEntries, {
-        legacySummary: typeof freshMeta.summary === "string" ? freshMeta.summary : null,
+    // Compensation: if the entry removal does not persist, re-hide whatever we
+    // optimistically unhid so the entry and its messages' visibility stay
+    // consistent — a delete never leaves a half-applied state in either direction.
+    const reHide = async () => {
+      if (unhidden.length === 0) return;
+      await storage.bulkSetHiddenFromAI(req.params.id, unhidden, true).catch((err) => {
+        logger.error(err, "[chat-summary] Failed to re-hide messages after a failed summary-entry delete");
       });
-      let nextEntries: ChatSummaryEntry[];
+    };
 
-      if (body.operation === "replace") {
-        const now = new Date().toISOString();
-        const existing = entries.find((entry) => entry.id === body.entry.id);
-        const replacement = createChatSummaryEntry(
-          {
-            ...existing,
-            ...body.entry,
-            id: body.entry.id,
-            content: body.entry.content,
-            updatedAt: now,
-            createdAt: existing?.createdAt ?? body.entry.createdAt ?? now,
-          },
-          { createId: newId, now },
-        );
-        nextEntries = entries.some((entry) => entry.id === replacement.id)
-          ? entries.map((entry) => (entry.id === replacement.id ? replacement : entry))
-          : [...entries, replacement];
-      } else if (body.operation === "delete") {
-        nextEntries = entries.filter((entry) => entry.id !== body.entryId);
-      } else if (body.operation === "toggle") {
-        const now = new Date().toISOString();
-        nextEntries = entries.map((entry) =>
-          entry.id === body.entryId ? { ...entry, enabled: body.enabled, updatedAt: now } : entry,
-        );
-      } else {
-        nextEntries = entries;
-      }
+    let updated: Awaited<ReturnType<typeof storage.patchMetadata>>;
+    try {
+      updated = await storage.patchMetadata(req.params.id, (freshMeta) => {
+        const entries = normalizeChatSummaryEntries(freshMeta.summaryEntries, {
+          legacySummary: typeof freshMeta.summary === "string" ? freshMeta.summary : null,
+        });
+        let nextEntries: ChatSummaryEntry[];
 
-      return {
-        summaryEntries: nextEntries,
-        summary: compileChatSummaryEntries(nextEntries),
-      };
-    });
+        if (body.operation === "replace") {
+          const now = new Date().toISOString();
+          const existing = entries.find((entry) => entry.id === body.entry.id);
+          const replacement = createChatSummaryEntry(
+            {
+              ...existing,
+              ...body.entry,
+              id: body.entry.id,
+              content: body.entry.content,
+              updatedAt: now,
+              createdAt: existing?.createdAt ?? body.entry.createdAt ?? now,
+            },
+            { createId: newId, now },
+          );
+          nextEntries = entries.some((entry) => entry.id === replacement.id)
+            ? entries.map((entry) => (entry.id === replacement.id ? replacement : entry))
+            : [...entries, replacement];
+        } else if (body.operation === "delete") {
+          nextEntries = entries.filter((entry) => entry.id !== body.entryId);
+        } else if (body.operation === "toggle") {
+          const now = new Date().toISOString();
+          nextEntries = entries.map((entry) =>
+            entry.id === body.entryId ? { ...entry, enabled: body.enabled, updatedAt: now } : entry,
+          );
+        } else {
+          nextEntries = entries;
+        }
 
-    if (!updated) return reply.status(404).send({ error: "Chat not found" });
+        return {
+          summaryEntries: nextEntries,
+          summary: compileChatSummaryEntries(nextEntries),
+        };
+      });
+    } catch (err) {
+      await reHide();
+      throw err;
+    }
+
+    if (!updated) {
+      await reHide();
+      return reply.status(404).send({ error: "Chat not found" });
+    }
     return updated;
   });
 

--- a/packages/server/src/routes/chats.routes.ts
+++ b/packages/server/src/routes/chats.routes.ts
@@ -61,10 +61,12 @@ import { DATA_DIR } from "../utils/data-dir.js";
 import { normalizeTimestampOverrides } from "../services/import/import-timestamps.js";
 import {
   appendNonLeadingSystemMessagesToLastUser,
+  computeSummaryHideIds,
   findTrackerContextInsertIndex,
   isManualTrackerCharacterId,
   parseExtra,
   resolveRoleplayChatSummary,
+  resolveRoleplaySummaryTail,
   isMessageHiddenFromAI,
   resolveBaseUrl,
   resolveActiveCharacterIds,
@@ -743,6 +745,25 @@ export async function chatsRoutes(app: FastifyInstance) {
         };
       });
       if (!updated) return reply.status(404).send({ error: "Chat not found" });
+      // Mirror the auto-summary token compression on the approval-gated path:
+      // once the user approves the entry, hide the messages it covered (except
+      // the protected recent tail) when the chat has opted in. Best-effort.
+      const committedMeta = parseExtra(updated.metadata) as Record<string, unknown>;
+      if (committedMeta.hideSummarisedMessages === true && messageIds.length > 0) {
+        try {
+          const allMessages = await storage.listMessages(req.params.id);
+          const toHide = computeSummaryHideIds({
+            messages: allMessages,
+            entryMessageIds: messageIds,
+            tail: resolveRoleplaySummaryTail(committedMeta.summaryTailMessages),
+          });
+          if (toHide.length > 0) {
+            await storage.bulkSetHiddenFromAI(req.params.id, toHide, true);
+          }
+        } catch (err) {
+          logger.error(err, "[chat-summary] Failed to auto-hide summarized messages on approval commit");
+        }
+      }
       return { ok: true, summary: combined, entry: createdEntry, entries: summaryEntries };
     }
 

--- a/packages/server/src/routes/chats.routes.ts
+++ b/packages/server/src/routes/chats.routes.ts
@@ -61,12 +61,10 @@ import { DATA_DIR } from "../utils/data-dir.js";
 import { normalizeTimestampOverrides } from "../services/import/import-timestamps.js";
 import {
   appendNonLeadingSystemMessagesToLastUser,
-  computeSummaryHideIds,
   findTrackerContextInsertIndex,
   isManualTrackerCharacterId,
   parseExtra,
   resolveRoleplayChatSummary,
-  resolveRoleplaySummaryTail,
   isMessageHiddenFromAI,
   resolveBaseUrl,
   resolveActiveCharacterIds,
@@ -642,11 +640,11 @@ export async function chatsRoutes(app: FastifyInstance) {
     }
 
     // For delete: restore visibility of the messages this entry covered (except
-    // any still covered by another enabled entry) BEFORE removing it, so deleting
-    // an entry can never strand messages hidden with nothing left to summarize
-    // them. `unhidden` is tracked so we can re-hide (compensate) if the metadata
-    // write below fails, keeping the two writes consistent either way.
-    let unhidden: string[] = [];
+    // any still covered by another enabled entry) BEFORE removing the entry.
+    // Unhiding first is what keeps this safe without a transaction: if the
+    // metadata write below fails, the messages are visible and the entry still
+    // exists (a benign, self-consistent state) — never hidden with no entry to
+    // justify them. So no rollback bookkeeping is needed.
     if (body.operation === "delete") {
       const current = await storage.getById(req.params.id);
       if (!current) return reply.status(404).send({ error: "Chat not found" });
@@ -664,74 +662,52 @@ export async function chatsRoutes(app: FastifyInstance) {
         }
         const toUnhide = covered.filter((id) => !stillCovered.has(id));
         if (toUnhide.length > 0) {
-          // Capture the exact rows the store actually unhid (request scoped to
-          // this chat) so compensation re-hides precisely that set, not the
-          // speculative request.
-          unhidden = await storage.bulkSetHiddenFromAI(req.params.id, toUnhide, false);
+          await storage.bulkSetHiddenFromAI(req.params.id, toUnhide, false);
         }
       }
     }
 
-    // Compensation: if the entry removal does not persist, re-hide whatever we
-    // optimistically unhid so the entry and its messages' visibility stay
-    // consistent — a delete never leaves a half-applied state in either direction.
-    const reHide = async () => {
-      if (unhidden.length === 0) return;
-      await storage.bulkSetHiddenFromAI(req.params.id, unhidden, true).catch((err) => {
-        logger.error(err, "[chat-summary] Failed to re-hide messages after a failed summary-entry delete");
+    const updated = await storage.patchMetadata(req.params.id, (freshMeta) => {
+      const entries = normalizeChatSummaryEntries(freshMeta.summaryEntries, {
+        legacySummary: typeof freshMeta.summary === "string" ? freshMeta.summary : null,
       });
-    };
+      let nextEntries: ChatSummaryEntry[];
 
-    let updated: Awaited<ReturnType<typeof storage.patchMetadata>>;
-    try {
-      updated = await storage.patchMetadata(req.params.id, (freshMeta) => {
-        const entries = normalizeChatSummaryEntries(freshMeta.summaryEntries, {
-          legacySummary: typeof freshMeta.summary === "string" ? freshMeta.summary : null,
-        });
-        let nextEntries: ChatSummaryEntry[];
+      if (body.operation === "replace") {
+        const now = new Date().toISOString();
+        const existing = entries.find((entry) => entry.id === body.entry.id);
+        const replacement = createChatSummaryEntry(
+          {
+            ...existing,
+            ...body.entry,
+            id: body.entry.id,
+            content: body.entry.content,
+            updatedAt: now,
+            createdAt: existing?.createdAt ?? body.entry.createdAt ?? now,
+          },
+          { createId: newId, now },
+        );
+        nextEntries = entries.some((entry) => entry.id === replacement.id)
+          ? entries.map((entry) => (entry.id === replacement.id ? replacement : entry))
+          : [...entries, replacement];
+      } else if (body.operation === "delete") {
+        nextEntries = entries.filter((entry) => entry.id !== body.entryId);
+      } else if (body.operation === "toggle") {
+        const now = new Date().toISOString();
+        nextEntries = entries.map((entry) =>
+          entry.id === body.entryId ? { ...entry, enabled: body.enabled, updatedAt: now } : entry,
+        );
+      } else {
+        nextEntries = entries;
+      }
 
-        if (body.operation === "replace") {
-          const now = new Date().toISOString();
-          const existing = entries.find((entry) => entry.id === body.entry.id);
-          const replacement = createChatSummaryEntry(
-            {
-              ...existing,
-              ...body.entry,
-              id: body.entry.id,
-              content: body.entry.content,
-              updatedAt: now,
-              createdAt: existing?.createdAt ?? body.entry.createdAt ?? now,
-            },
-            { createId: newId, now },
-          );
-          nextEntries = entries.some((entry) => entry.id === replacement.id)
-            ? entries.map((entry) => (entry.id === replacement.id ? replacement : entry))
-            : [...entries, replacement];
-        } else if (body.operation === "delete") {
-          nextEntries = entries.filter((entry) => entry.id !== body.entryId);
-        } else if (body.operation === "toggle") {
-          const now = new Date().toISOString();
-          nextEntries = entries.map((entry) =>
-            entry.id === body.entryId ? { ...entry, enabled: body.enabled, updatedAt: now } : entry,
-          );
-        } else {
-          nextEntries = entries;
-        }
+      return {
+        summaryEntries: nextEntries,
+        summary: compileChatSummaryEntries(nextEntries),
+      };
+    });
 
-        return {
-          summaryEntries: nextEntries,
-          summary: compileChatSummaryEntries(nextEntries),
-        };
-      });
-    } catch (err) {
-      await reHide();
-      throw err;
-    }
-
-    if (!updated) {
-      await reHide();
-      return reply.status(404).send({ error: "Chat not found" });
-    }
+    if (!updated) return reply.status(404).send({ error: "Chat not found" });
     return updated;
   });
 
@@ -795,25 +771,11 @@ export async function chatsRoutes(app: FastifyInstance) {
         };
       });
       if (!updated) return reply.status(404).send({ error: "Chat not found" });
-      // Mirror the auto-summary token compression on the approval-gated path:
-      // once the user approves the entry, hide the messages it covered (except
-      // the protected recent tail) when the chat has opted in. Best-effort.
-      const committedMeta = parseExtra(updated.metadata) as Record<string, unknown>;
-      if (committedMeta.hideSummarisedMessages === true && messageIds.length > 0) {
-        try {
-          const allMessages = await storage.listMessages(req.params.id);
-          const toHide = computeSummaryHideIds({
-            messages: allMessages,
-            entryMessageIds: messageIds,
-            tail: resolveRoleplaySummaryTail(committedMeta.summaryTailMessages),
-          });
-          if (toHide.length > 0) {
-            await storage.bulkSetHiddenFromAI(req.params.id, toHide, true);
-          }
-        } catch (err) {
-          logger.error(err, "[chat-summary] Failed to auto-hide summarized messages on approval commit");
-        }
-      }
+      // Auto-hide is intentionally NOT applied on the approval-gated commit path:
+      // the proposal's messageIds/ordering are captured at proposal time but the
+      // entry commits later, so hiding here could target a drifted snapshot.
+      // Approval-gated chats hide via the manual popover toggle; only the inline
+      // auto-summary path (no approval delay) auto-hides.
       return { ok: true, summary: combined, entry: createdEntry, entries: summaryEntries };
     }
 
@@ -1417,8 +1379,8 @@ export async function chatsRoutes(app: FastifyInstance) {
       if (typeof hidden !== "boolean") {
         return reply.status(400).send({ error: "hidden must be a boolean" });
       }
-      const updatedIds = await storage.bulkSetHiddenFromAI(req.params.chatId, messageIds, hidden);
-      return { updated: updatedIds.length };
+      const updated = await storage.bulkSetHiddenFromAI(req.params.chatId, messageIds, hidden);
+      return { updated };
     },
   );
 

--- a/packages/server/src/routes/chats.routes.ts
+++ b/packages/server/src/routes/chats.routes.ts
@@ -2861,6 +2861,12 @@ export async function chatsRoutes(app: FastifyInstance) {
           tail: resolveRoleplaySummaryTail(chatMeta.summaryTailMessages),
         })
       : [];
+    // Perform the hide on the server, BEFORE the entry records hiddenMessageIds,
+    // so the recorded set always reflects messages actually hidden (no phantom
+    // set if a separate client call were to fail). The client no longer hides.
+    if (hideMessageIds.length > 0) {
+      await storage.bulkSetHiddenFromAI(req.params.id, hideMessageIds, true);
+    }
 
     // Append as a structured entry and recompile the prompt-facing summary
     // without replacing concurrent metadata changes.

--- a/packages/server/src/routes/chats.routes.ts
+++ b/packages/server/src/routes/chats.routes.ts
@@ -1418,7 +1418,7 @@ export async function chatsRoutes(app: FastifyInstance) {
         return reply.status(400).send({ error: "hidden must be a boolean" });
       }
       const updatedIds = await storage.bulkSetHiddenFromAI(req.params.chatId, messageIds, hidden);
-      return { updated: updatedIds.length, updatedIds };
+      return { updated: updatedIds.length };
     },
   );
 

--- a/packages/server/src/routes/chats.routes.ts
+++ b/packages/server/src/routes/chats.routes.ts
@@ -1383,7 +1383,7 @@ export async function chatsRoutes(app: FastifyInstance) {
       if (typeof hidden !== "boolean") {
         return reply.status(400).send({ error: "hidden must be a boolean" });
       }
-      const updated = await storage.bulkSetHiddenFromAI(req.params.chatId, messageIds, hidden);
+      const updated = (await storage.bulkSetHiddenFromAI(req.params.chatId, messageIds, hidden)).length;
       return { updated };
     },
   );
@@ -2861,24 +2861,19 @@ export async function chatsRoutes(app: FastifyInstance) {
           tail: resolveRoleplaySummaryTail(chatMeta.summaryTailMessages),
         })
       : [];
-    // Only the messages this attempt actually flips from visible to hidden. (The
-    // summary's source already excludes hidden messages, so this is normally the
-    // whole set, but snapshot the prior state explicitly so a rollback can never
-    // resurrect a message that was already hidden by something else.)
-    const hiddenAtLoad = new Set(
-      allMessages.filter((message) => isMessageHiddenFromAI(message)).map((message) => message.id),
-    );
-    const hideMessageIds = eligibleToHide.filter((id) => !hiddenAtLoad.has(id));
-    // Perform the hide on the server, BEFORE the entry records hiddenMessageIds,
-    // so the recorded set always reflects messages actually hidden (no phantom
-    // set if a separate client call were to fail). The client no longer hides.
-    if (hideMessageIds.length > 0) {
-      await storage.bulkSetHiddenFromAI(req.params.id, hideMessageIds, true);
-    }
+    // Perform the hide on the server, BEFORE the entry records hiddenMessageIds, so
+    // the recorded set always reflects messages actually hidden (no phantom set if a
+    // separate client call were to fail). The client no longer hides. bulkSetHidden
+    // returns exactly the ids it flipped visible->hidden, read at the moment of
+    // mutation — so ownership can never be a stale pre-provider snapshot that claims
+    // a message another action hid during the (seconds-long) provider call above.
+    const hideMessageIds =
+      eligibleToHide.length > 0 ? await storage.bulkSetHiddenFromAI(req.params.id, eligibleToHide, true) : [];
     // If the entry that owns hiddenMessageIds is not persisted (chat vanished, or
-    // the write throws), roll back only the hides this attempt newly applied so we
-    // never leave messages hidden with no entry. A rollback failure is surfaced
-    // (re-thrown), not swallowed, so the caller learns recovery did not complete.
+    // the write throws), roll back exactly the hides this attempt applied (the set
+    // bulkSetHidden reported flipping) so we never leave messages hidden with no
+    // entry. A rollback failure is surfaced (re-thrown), not swallowed, so the
+    // caller learns recovery did not complete.
     const rollbackHide = async () => {
       if (hideMessageIds.length === 0) return;
       await storage.bulkSetHiddenFromAI(req.params.id, hideMessageIds, false);

--- a/packages/server/src/routes/generate.routes.ts
+++ b/packages/server/src/routes/generate.routes.ts
@@ -7316,6 +7316,17 @@ export async function generateRoutes(app: FastifyInstance) {
           let createdEntry: ChatSummaryEntry | null = null;
           let summaryEntries: ChatSummaryEntry[] = [];
           const shouldReviewSummary = requireAgentWriteApproval && !!newText;
+          const autoEntryMessageIds = selectedMessages.map((message: any) => message.id);
+          // Compute the hide subset up front so it can be persisted on the entry
+          // (deletion restores exactly this set) and reused for the actual hide.
+          const autoHideIds =
+            newText && !shouldReviewSummary && chatMeta.hideSummarisedMessages === true
+              ? computeSummaryHideIds({
+                  messages: freshMessages,
+                  entryMessageIds: autoEntryMessageIds,
+                  tail: resolveRoleplaySummaryTail(chatMeta.summaryTailMessages),
+                })
+              : [];
           const updatedChat = await chats.patchMetadata(
             input.chatId,
             (currentMeta) => {
@@ -7337,7 +7348,8 @@ export async function generateRoutes(app: FastifyInstance) {
                   content: newText,
                   enabled: true,
                   messageCount: selectedMessages.length,
-                  messageIds: selectedMessages.map((message: any) => message.id),
+                  messageIds: autoEntryMessageIds,
+                  ...(autoHideIds.length > 0 ? { hiddenMessageIds: autoHideIds } : {}),
                   promptTemplateId:
                     typeof chatMeta.activeSummaryPromptTemplateId === "string"
                       ? chatMeta.activeSummaryPromptTemplateId
@@ -7379,25 +7391,16 @@ export async function generateRoutes(app: FastifyInstance) {
             } else {
               const combined = typeof chatMeta.summary === "string" ? chatMeta.summary : newText;
               // Opt-in token compression: hide the messages this summary covered
-              // (except the protected recent tail) so the summary is a net token
-              // reduction instead of an addition. Best-effort; never aborts the stream.
+              // (except the protected recent tail, already excluded in autoHideIds)
+              // so the summary is a net token reduction. Best-effort; never aborts
+              // the stream. The same set is persisted on the entry above.
               let hiddenMessageIds: string[] = [];
-              if (chatMeta.hideSummarisedMessages === true) {
-                // This branch only runs when a non-review entry was created, so the
-                // selected messages are exactly the ids the entry covers.
-                const entryMessageIds = selectedMessages.map((message: any) => message.id);
-                const toHide = computeSummaryHideIds({
-                  messages: freshMessages,
-                  entryMessageIds,
-                  tail: resolveRoleplaySummaryTail(chatMeta.summaryTailMessages),
-                });
-                if (toHide.length > 0) {
-                  try {
-                    await chats.bulkSetHiddenFromAI(input.chatId, toHide, true);
-                    hiddenMessageIds = toHide;
-                  } catch (err) {
-                    logger.error(err, "[chat-summary] Failed to auto-hide summarized roleplay messages");
-                  }
+              if (autoHideIds.length > 0) {
+                try {
+                  await chats.bulkSetHiddenFromAI(input.chatId, autoHideIds, true);
+                  hiddenMessageIds = autoHideIds;
+                } catch (err) {
+                  logger.error(err, "[chat-summary] Failed to auto-hide summarized roleplay messages");
                 }
               }
               reply.raw.write(

--- a/packages/server/src/routes/generate.routes.ts
+++ b/packages/server/src/routes/generate.routes.ts
@@ -202,6 +202,7 @@ import {
   buildLockedPersonaTrackerPatch,
   extractImageAttachmentDataUrls,
   appendNonLeadingSystemMessagesToLastUser,
+  computeSummaryHideIds,
   injectIntoOutputFormatOrLastUser,
   isManualTrackerCharacterId,
   isMessageHiddenFromAI,
@@ -216,6 +217,7 @@ import {
   prefixGroupIndividualHistorySpeakers,
   resolveActiveCharacterIds,
   resolveBaseUrl,
+  resolveRoleplaySummaryTail,
   resolveCharacterNameMap,
   resolvePromptCharacterIdsForTarget,
   resolveRegenerationGameStateFallbackMessageIds,
@@ -7376,10 +7378,32 @@ export async function generateRoutes(app: FastifyInstance) {
               });
             } else {
               const combined = typeof chatMeta.summary === "string" ? chatMeta.summary : newText;
+              // Opt-in token compression: hide the messages this summary covered
+              // (except the protected recent tail) so the summary is a net token
+              // reduction instead of an addition. Best-effort; never aborts the stream.
+              let hiddenMessageIds: string[] = [];
+              if (chatMeta.hideSummarisedMessages === true) {
+                // This branch only runs when a non-review entry was created, so the
+                // selected messages are exactly the ids the entry covers.
+                const entryMessageIds = selectedMessages.map((message: any) => message.id);
+                const toHide = computeSummaryHideIds({
+                  messages: freshMessages,
+                  entryMessageIds,
+                  tail: resolveRoleplaySummaryTail(chatMeta.summaryTailMessages),
+                });
+                if (toHide.length > 0) {
+                  try {
+                    await chats.bulkSetHiddenFromAI(input.chatId, toHide, true);
+                    hiddenMessageIds = toHide;
+                  } catch (err) {
+                    logger.error(err, "[chat-summary] Failed to auto-hide summarized roleplay messages");
+                  }
+                }
+              }
               reply.raw.write(
                 `data: ${JSON.stringify({
                   type: "chat_summary",
-                  data: { summary: combined, entry: createdEntry, entries: summaryEntries },
+                  data: { summary: combined, entry: createdEntry, entries: summaryEntries, hiddenMessageIds },
                 })}\n\n`,
               );
             }

--- a/packages/server/src/routes/generate/generate-route-utils.ts
+++ b/packages/server/src/routes/generate/generate-route-utils.ts
@@ -1,6 +1,7 @@
 import { isDeepStrictEqual } from "node:util";
 import {
   PROVIDERS,
+  SUMMARY_TAIL_MESSAGES,
   applyTrackerFieldLocksToGameStatePatch,
   generationParametersSchema,
   normalizeTextForMatch,
@@ -474,14 +475,17 @@ export function isRoleplaySummaryMode(chatMode: string): boolean {
 /**
  * Resolve the roleplay summary tail (how many recent messages stay visible when
  * the auto-summary hides the rest) from the chat's `summaryTailMessages` value.
- * Default 10 when unset/invalid; an explicit 0 means "hide the whole batch".
- * Clamped to 0-50.
+ * `DEFAULT` only when the value is genuinely unset; an explicit `MIN` (0) means
+ * "hide the whole batch". A present-but-invalid value (NaN, negative) fails
+ * closed to `MIN` so corrupt metadata hides more rather than silently leaking
+ * extra context. Clamped to [MIN, MAX].
  */
 export function resolveRoleplaySummaryTail(value: unknown): number {
-  if (value === undefined || value === null) return 10;
+  const { MIN, MAX, DEFAULT } = SUMMARY_TAIL_MESSAGES;
+  if (value === undefined || value === null) return DEFAULT;
   const n = Math.floor(Number(value));
-  if (!Number.isFinite(n) || n < 0) return 10;
-  return Math.min(50, n);
+  if (!Number.isFinite(n) || n < MIN) return MIN;
+  return Math.min(MAX, n);
 }
 
 /**
@@ -497,7 +501,8 @@ export function computeSummaryHideIds(args: {
 }): string[] {
   const { messages, entryMessageIds, tail } = args;
   if (entryMessageIds.length === 0) return [];
-  const clampedTail = Number.isFinite(tail) ? Math.max(0, Math.min(50, Math.floor(tail))) : 0;
+  const { MIN, MAX } = SUMMARY_TAIL_MESSAGES;
+  const clampedTail = Number.isFinite(tail) ? Math.max(MIN, Math.min(MAX, Math.floor(tail))) : MIN;
   const visible = messages.filter((message) => !isMessageHiddenFromAI(message));
   const tailIdSet = new Set(clampedTail > 0 ? visible.slice(-clampedTail).map((message) => message.id) : []);
   const entryIdSet = new Set(entryMessageIds);

--- a/packages/server/src/routes/generate/generate-route-utils.ts
+++ b/packages/server/src/routes/generate/generate-route-utils.ts
@@ -471,6 +471,41 @@ export function isRoleplaySummaryMode(chatMode: string): boolean {
   return chatMode === "roleplay" || chatMode === "visual_novel";
 }
 
+/**
+ * Resolve the roleplay summary tail (how many recent messages stay visible when
+ * the auto-summary hides the rest) from the chat's `summaryTailMessages` value.
+ * Default 10 when unset/invalid; an explicit 0 means "hide the whole batch".
+ * Clamped to 0-50.
+ */
+export function resolveRoleplaySummaryTail(value: unknown): number {
+  if (value === undefined || value === null) return 10;
+  const n = Math.floor(Number(value));
+  if (!Number.isFinite(n) || n < 0) return 10;
+  return Math.min(50, n);
+}
+
+/**
+ * Compute which summarized message IDs the roleplay rolling summary should hide,
+ * protecting the most-recent `tail` *visible* messages so recent context stays
+ * in the prompt. Pure: `messages` must be chat-ordered (ascending). Returns the
+ * subset of `entryMessageIds` that is not in the protected tail.
+ */
+export function computeSummaryHideIds(args: {
+  messages: Array<{ id: string; extra?: unknown }>;
+  entryMessageIds: string[];
+  tail: number;
+}): string[] {
+  const { messages, entryMessageIds, tail } = args;
+  if (entryMessageIds.length === 0) return [];
+  const clampedTail = Number.isFinite(tail) ? Math.max(0, Math.min(50, Math.floor(tail))) : 0;
+  const visible = messages.filter((message) => !isMessageHiddenFromAI(message));
+  const tailIdSet = new Set(clampedTail > 0 ? visible.slice(-clampedTail).map((message) => message.id) : []);
+  const entryIdSet = new Set(entryMessageIds);
+  return messages
+    .filter((message) => entryIdSet.has(message.id) && !tailIdSet.has(message.id))
+    .map((message) => message.id);
+}
+
 export function resolveRoleplayChatSummary(chatMode: string, chatMetadata: Record<string, unknown>): string | null {
   if (!isRoleplaySummaryMode(chatMode)) return null;
   return ((chatMetadata.summary as string) ?? "").trim() || null;

--- a/packages/server/src/services/storage/chats.storage.ts
+++ b/packages/server/src/services/storage/chats.storage.ts
@@ -933,8 +933,10 @@ export function createChatsStorage(db: DB) {
         // all-or-nothing and a caller never records ownership of a half-applied
         // batch. (db.transaction() is intentionally avoided in this store — see the
         // bulk-insert note re: the libSQL stateful-transaction crash #73 — so this
-        // compensating undo is the atomicity mechanism.) The original error is
-        // always rethrown; an undo failure is logged, never allowed to mask it.
+        // compensating undo is the atomicity mechanism.) A clean undo preserves
+        // the original error. A failed undo is surfaced as a compound failure so
+        // callers never mistake a partially restored batch for a clean rollback.
+        const undoErrors: unknown[] = [];
         for (const id of flipped) {
           try {
             await this.updateMessageExtra(id, { hiddenFromAI: !hidden });
@@ -943,8 +945,15 @@ export function createChatsStorage(db: DB) {
               await this.updateSwipeExtra(id, swipe.index, { hiddenFromAI: !hidden });
             }
           } catch (undoErr) {
+            undoErrors.push(undoErr);
             logger.error(undoErr, "bulkSetHiddenFromAI: failed to undo partial hide for message %s", id);
           }
+        }
+        if (undoErrors.length > 0) {
+          throw new AggregateError(
+            [err, ...undoErrors],
+            `bulkSetHiddenFromAI failed and rollback failed for ${undoErrors.length} of ${flipped.length} flipped messages`,
+          );
         }
         throw err;
       }

--- a/packages/server/src/services/storage/chats.storage.ts
+++ b/packages/server/src/services/storage/chats.storage.ts
@@ -28,6 +28,7 @@ import {
   type TimestampOverrides,
 } from "../import/import-timestamps.js";
 import { scheduleNeedsRefresh, type CharacterSchedules, type WeekSchedule } from "../conversation/schedule.service.js";
+import { logger } from "../../lib/logger.js";
 
 const GALLERY_DIR = join(DATA_DIR, "gallery");
 
@@ -901,28 +902,51 @@ export function createChatsStorage(db: DB) {
 
       const seen = new Set<string>();
       const flipped: string[] = [];
-      for (const row of scopedRows) {
-        if (seen.has(row.id)) continue;
-        seen.add(row.id);
-        // State read immediately before the write — the moment-of-mutation truth
-        // that decides whether THIS call flips the message into the target state.
-        let wasHidden = false;
-        try {
-          const parsed = typeof row.extra === "string" ? JSON.parse(row.extra) : (row.extra ?? {});
-          wasHidden = (parsed as { hiddenFromAI?: unknown } | null)?.hiddenFromAI === true;
-        } catch {
-          wasHidden = false;
+      try {
+        for (const row of scopedRows) {
+          if (seen.has(row.id)) continue;
+          seen.add(row.id);
+          // State read immediately before the write — the moment-of-mutation truth
+          // that decides whether THIS call flips the message into the target state.
+          let wasHidden = false;
+          try {
+            const parsed = typeof row.extra === "string" ? JSON.parse(row.extra) : (row.extra ?? {});
+            wasHidden = (parsed as { hiddenFromAI?: unknown } | null)?.hiddenFromAI === true;
+          } catch {
+            wasHidden = false;
+          }
+          await this.updateMessageExtra(row.id, { hiddenFromAI: hidden });
+          // Mirror what the single-message /extra route does: propagate the flag to
+          // all swipe rows so setActiveSwipe() cannot clobber it. Done for every
+          // scoped row (idempotent when already in the target state) so swipe
+          // consistency never depends on whether the main row happened to flip.
+          const swipes = await this.getSwipes(row.id);
+          for (const swipe of swipes) {
+            await this.updateSwipeExtra(row.id, swipe.index, { hiddenFromAI: hidden });
+          }
+          if (wasHidden !== hidden) flipped.push(row.id);
         }
-        await this.updateMessageExtra(row.id, { hiddenFromAI: hidden });
-        // Mirror what the single-message /extra route does: propagate the flag to
-        // all swipe rows so setActiveSwipe() cannot clobber it. Done for every
-        // scoped row (idempotent when already in the target state) so swipe
-        // consistency never depends on whether the main row happened to flip.
-        const swipes = await this.getSwipes(row.id);
-        for (const swipe of swipes) {
-          await this.updateSwipeExtra(row.id, swipe.index, { hiddenFromAI: hidden });
+      } catch (err) {
+        // A write failed partway through. The rows we did not reach are untouched,
+        // and rows already in the target state were never flipped, so the only
+        // partial state is the `flipped` set. Undo exactly those so the call is
+        // all-or-nothing and a caller never records ownership of a half-applied
+        // batch. (db.transaction() is intentionally avoided in this store — see the
+        // bulk-insert note re: the libSQL stateful-transaction crash #73 — so this
+        // compensating undo is the atomicity mechanism.) The original error is
+        // always rethrown; an undo failure is logged, never allowed to mask it.
+        for (const id of flipped) {
+          try {
+            await this.updateMessageExtra(id, { hiddenFromAI: !hidden });
+            const swipes = await this.getSwipes(id);
+            for (const swipe of swipes) {
+              await this.updateSwipeExtra(id, swipe.index, { hiddenFromAI: !hidden });
+            }
+          } catch (undoErr) {
+            logger.error(undoErr, "bulkSetHiddenFromAI: failed to undo partial hide for message %s", id);
+          }
         }
-        if (wasHidden !== hidden) flipped.push(row.id);
+        throw err;
       }
       return flipped;
     },

--- a/packages/server/src/services/storage/chats.storage.ts
+++ b/packages/server/src/services/storage/chats.storage.ts
@@ -876,11 +876,10 @@ export function createChatsStorage(db: DB) {
      * Bulk-set hiddenFromAI on many messages at once.
      * Reuses updateMessageExtra() for each message (read-parse-merge-write) and
      * syncs the flag to every swipe row so it survives setActiveSwipe() overwrites.
-     * Returns the IDs actually updated (the request IDs scoped to this chat), so
-     * callers can compensate against the exact change set rather than what they asked for.
+     * Returns the number of messages updated (the request scoped to this chat).
      */
-    async bulkSetHiddenFromAI(chatId: string, messageIds: string[], hidden: boolean): Promise<string[]> {
-      if (messageIds.length === 0) return [];
+    async bulkSetHiddenFromAI(chatId: string, messageIds: string[], hidden: boolean): Promise<number> {
+      if (messageIds.length === 0) return 0;
       const uniqueIds = Array.from(new Set(messageIds));
       const scopedRows: { id: string }[] = [];
       const CHUNK = 500;
@@ -903,7 +902,7 @@ export function createChatsStorage(db: DB) {
           await this.updateSwipeExtra(id, swipe.index, { hiddenFromAI: hidden });
         }
       }
-      return scopedIds;
+      return scopedIds.length;
     },
 
     /** Atomically append an attachment to a message's extra JSON field. */

--- a/packages/server/src/services/storage/chats.storage.ts
+++ b/packages/server/src/services/storage/chats.storage.ts
@@ -876,10 +876,11 @@ export function createChatsStorage(db: DB) {
      * Bulk-set hiddenFromAI on many messages at once.
      * Reuses updateMessageExtra() for each message (read-parse-merge-write) and
      * syncs the flag to every swipe row so it survives setActiveSwipe() overwrites.
-     * Returns the number of messages updated.
+     * Returns the IDs actually updated (the request IDs scoped to this chat), so
+     * callers can compensate against the exact change set rather than what they asked for.
      */
-    async bulkSetHiddenFromAI(chatId: string, messageIds: string[], hidden: boolean): Promise<number> {
-      if (messageIds.length === 0) return 0;
+    async bulkSetHiddenFromAI(chatId: string, messageIds: string[], hidden: boolean): Promise<string[]> {
+      if (messageIds.length === 0) return [];
       const uniqueIds = Array.from(new Set(messageIds));
       const scopedRows: { id: string }[] = [];
       const CHUNK = 500;
@@ -902,7 +903,7 @@ export function createChatsStorage(db: DB) {
           await this.updateSwipeExtra(id, swipe.index, { hiddenFromAI: hidden });
         }
       }
-      return scopedIds.length;
+      return scopedIds;
     },
 
     /** Atomically append an attachment to a message's extra JSON field. */

--- a/packages/server/src/services/storage/chats.storage.ts
+++ b/packages/server/src/services/storage/chats.storage.ts
@@ -876,33 +876,55 @@ export function createChatsStorage(db: DB) {
      * Bulk-set hiddenFromAI on many messages at once.
      * Reuses updateMessageExtra() for each message (read-parse-merge-write) and
      * syncs the flag to every swipe row so it survives setActiveSwipe() overwrites.
-     * Returns the number of messages updated (the request scoped to this chat).
+     *
+     * Returns the ids this call actually flipped INTO the target state — the
+     * messages whose hidden flag, read immediately before the write (no provider
+     * or network call in between), differed from `hidden`. Callers that record
+     * ownership of a hide (e.g. a summary entry's `hiddenMessageIds`) use this
+     * return so ownership is sourced from the mutation itself, never from a stale
+     * pre-mutation snapshot. The request is scoped to this chat; use `.length` for
+     * a count of changed messages.
      */
-    async bulkSetHiddenFromAI(chatId: string, messageIds: string[], hidden: boolean): Promise<number> {
-      if (messageIds.length === 0) return 0;
+    async bulkSetHiddenFromAI(chatId: string, messageIds: string[], hidden: boolean): Promise<string[]> {
+      if (messageIds.length === 0) return [];
       const uniqueIds = Array.from(new Set(messageIds));
-      const scopedRows: { id: string }[] = [];
+      const scopedRows: { id: string; extra: string | null }[] = [];
       const CHUNK = 500;
       for (let i = 0; i < uniqueIds.length; i += CHUNK) {
         const batch = uniqueIds.slice(i, i + CHUNK);
         const batchRows = await db
-          .select({ id: messages.id })
+          .select({ id: messages.id, extra: messages.extra })
           .from(messages)
           .where(and(eq(messages.chatId, chatId), inArray(messages.id, batch)));
         scopedRows.push(...batchRows);
       }
-      const scopedIds = Array.from(new Set(scopedRows.map((row) => row.id)));
 
-      for (const id of scopedIds) {
-        await this.updateMessageExtra(id, { hiddenFromAI: hidden });
-        // Mirror what the single-message /extra route does: propagate the flag
-        // to all swipe rows so setActiveSwipe() cannot clobber it.
-        const swipes = await this.getSwipes(id);
-        for (const swipe of swipes) {
-          await this.updateSwipeExtra(id, swipe.index, { hiddenFromAI: hidden });
+      const seen = new Set<string>();
+      const flipped: string[] = [];
+      for (const row of scopedRows) {
+        if (seen.has(row.id)) continue;
+        seen.add(row.id);
+        // State read immediately before the write — the moment-of-mutation truth
+        // that decides whether THIS call flips the message into the target state.
+        let wasHidden = false;
+        try {
+          const parsed = typeof row.extra === "string" ? JSON.parse(row.extra) : (row.extra ?? {});
+          wasHidden = (parsed as { hiddenFromAI?: unknown } | null)?.hiddenFromAI === true;
+        } catch {
+          wasHidden = false;
         }
+        await this.updateMessageExtra(row.id, { hiddenFromAI: hidden });
+        // Mirror what the single-message /extra route does: propagate the flag to
+        // all swipe rows so setActiveSwipe() cannot clobber it. Done for every
+        // scoped row (idempotent when already in the target state) so swipe
+        // consistency never depends on whether the main row happened to flip.
+        const swipes = await this.getSwipes(row.id);
+        for (const swipe of swipes) {
+          await this.updateSwipeExtra(row.id, swipe.index, { hiddenFromAI: hidden });
+        }
+        if (wasHidden !== hidden) flipped.push(row.id);
       }
-      return scopedIds.length;
+      return flipped;
     },
 
     /** Atomically append an attachment to a message's extra JSON field. */

--- a/packages/shared/src/types/chat.ts
+++ b/packages/shared/src/types/chat.ts
@@ -149,6 +149,13 @@ export interface ChatSummaryEntry {
   rangeStartIndex?: number;
   rangeEndIndex?: number;
   messageIds?: string[];
+  /**
+   * The exact messages this entry hid from AI when "Hide summarised messages" was
+   * on (the summarized set minus the protected tail). Persisted so deletion can
+   * restore precisely what was hidden, rather than assuming it equals messageIds.
+   * Absent on entries created before this field or when nothing was hidden.
+   */
+  hiddenMessageIds?: string[];
   promptTemplateId?: string | null;
   tokenEstimate: number;
   createdAt: string;

--- a/packages/shared/src/types/chat.ts
+++ b/packages/shared/src/types/chat.ts
@@ -170,6 +170,14 @@ export interface ChatMemoryChunk {
   embeddingStatus?: "vectorized" | "pending" | "unavailable";
 }
 
+/**
+ * Bounds for `ChatMetadata.summaryTailMessages` — the single source of truth for
+ * the tail limits, shared by the server resolver (read) and the popover slider
+ * (write) so display and persistence can't drift. `DEFAULT` applies only when the
+ * value is unset; an explicit `MIN` (0) means "hide the whole batch".
+ */
+export const SUMMARY_TAIL_MESSAGES = { MIN: 0, MAX: 50, DEFAULT: 10 } as const;
+
 /** Extra metadata stored on a chat. */
 export interface ChatMetadata {
   /** Compiled enabled rolling summary text for context injection. Derived from summaryEntries when present. */

--- a/packages/shared/src/types/chat.ts
+++ b/packages/shared/src/types/chat.ts
@@ -190,6 +190,15 @@ export interface ChatMetadata {
   activeSummaryPromptTemplateId?: string | null;
   /** Optional text connection used for manual and automatic Roleplay chat summaries. Null uses the agent default. */
   summaryConnectionId?: string | null;
+  /**
+   * When true, the automatic roleplay/visual-novel rolling summary hides the
+   * messages it summarized (hiddenFromAI=true) except the most-recent
+   * `summaryTailMessages`, so the summary is a net token reduction. Opt-in:
+   * undefined/false never hides (back-compat for existing chats). Read by the
+   * SERVER auto-summary path; promoted from the browser-local ui.store
+   * `summaryPopoverSettings.hideSummarisedMessages` preference.
+   */
+  hideSummarisedMessages?: boolean;
   /** Custom tags for organisation */
   tags: string[];
   /** Whether agents are enabled for this chat */
@@ -468,9 +477,12 @@ export interface ChatMetadata {
    */
   dayRolloverHour?: number;
   /**
-   * How many of the most recent messages to keep verbatim in the prompt even
-   * after they've been summarized. Bridges the day boundary so characters can
-   * pick up the actual flow of recent conversation, not just the gist. 0 disables.
+   * How many of the most recent messages to keep verbatim even after they've
+   * been summarized. In conversation mode this bridges the day boundary so
+   * characters pick up the actual flow of recent conversation, not just the
+   * gist. In roleplay/visual-novel mode it is the protected tail for
+   * `hideSummarisedMessages`: the last N messages stay visible (never hidden)
+   * when the auto-summary hides the rest. 0 disables (hide the whole batch).
    * Valid range: 0-50. Default: 10.
    */
   summaryTailMessages?: number;

--- a/packages/shared/src/utils/chat-summary-entries.ts
+++ b/packages/shared/src/utils/chat-summary-entries.ts
@@ -182,6 +182,8 @@ export function normalizeChatSummaryEntry(
   if (rangeEndIndex !== undefined) base.rangeEndIndex = rangeEndIndex;
   const messageIds = normalizeMessageIds(value.messageIds);
   if (messageIds) base.messageIds = messageIds;
+  const hiddenMessageIds = normalizeMessageIds(value.hiddenMessageIds);
+  if (hiddenMessageIds) base.hiddenMessageIds = hiddenMessageIds;
   if (typeof value.promptTemplateId === "string") {
     base.promptTemplateId = value.promptTemplateId.trim() || null;
   } else if (value.promptTemplateId === null) {


### PR DESCRIPTION
## Linked issue

Closes #2820

## Why this change

In roleplay / visual-novel mode the rolling summary runs automatically every N user messages and injects a recap into the prompt, but it never hides the messages it just summarized. The originals stay in context, so each summary is a net token **increase** layered on top of the history it was meant to compress — the opposite of what a rolling summary is for. The only ways to save tokens today are to manually cap context in Advanced Parameters or to manually summarize with "Hide summarised messages" ticked, and even that hides everything with no tail (so the most recent turns can vanish) and never reaches the automatic path.

The primitives already existed — `hiddenFromAI`, per-entry `messageIds`, the `bulkSetHiddenFromAI` storage method, the collapsible hidden-message UI. This change wires them into the automatic summary path so the summary becomes a real token reduction, behind an opt-in toggle.

## What changed

- **Opt-in metadata flag.** Added `ChatMetadata.hideSummarisedMessages` (default off — existing chats are untouched). The server auto-summary reads it; the Summary-popover toggle now writes it per-chat instead of only the browser-local UI store (legacy pref is used as the initial display value for back-compat).
- **Auto-hide with a tail.** When the flag is on, `runAutomaticRoleplaySummary` hides the messages a summary covered, except the most-recent `summaryTailMessages` (reused from the conversation-mode field; default 10, `0` hides the whole batch). The set math lives in two pure, unit-tested helpers — `computeSummaryHideIds` and `resolveRoleplaySummaryTail` — and the same helpers run on the approval-gated commit path so behavior is consistent whether or not agent-write approval is required.
- **Tail slider in the Summary popover.** A "Recent message tail" control appears under the toggle (roleplay), mirroring the conversation-mode slider.
- **Unhide on delete.** Deleting a summary entry now unhides the messages it covered, except any still referenced by another *enabled* entry — no orphaned permanently-hidden messages.
- **UI freshness.** The `chat_summary` SSE event carries `hiddenMessageIds`; the client invalidates the message-list query so server-driven hides show immediately.

Scope notes: the manual "Hide summarised messages" popover path is intentionally left as hide-everything (no behavior change for existing manual use). Conversation-mode day/week summaries are untouched — roleplay and conversation summary paths are mutually exclusive by chat mode.

## Validation

- [x] `pnpm check` passes locally
- [x] Container (Docker / Podman) built and ran without issue
- [x] Ran the app, clicked through the changes manually
- [x] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [x] Above manual verification completed (describe below)
- [x] Read and followed `CONTRIBUTING.md`

### Manual verification notes

- Manually verify in a roleplay chat: enable automatic summaries, turn on "Hide summarised messages", set a low interval, send enough messages to trigger a summary, and confirm the older summarized messages become hidden-from-AI while the last `summaryTailMessages` stay visible.
- Manually verify the tail slider: set the tail to `0` (whole batch hidden) and to a larger value (more recent messages preserved).
- Manually verify unhide-on-delete: delete a summary entry and confirm its messages reappear, except any covered by another still-enabled entry.
- Manually verify opt-out: with the toggle off, a summary run hides nothing (existing-chat behavior).
- Manually verify the manual Summary-popover "hide" path still works as before.

## Docs and release impact

- [x] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Version/release files updated (only if this PR includes a version bump)

## UI evidence (if applicable)

To follow once verified on a live build.
