### PR TITLE
feat: add re-run button to Echo Chamber panel

### DIFF
--- a/packages/client/src/components/chat/EchoChamberPanel.tsx
+++ b/packages/client/src/components/chat/EchoChamberPanel.tsx
@@ -5,13 +5,14 @@
 // HUD widget position (top/left/right), and the top bar.
 // ──────────────────────────────────────────────
 import { useRef, useEffect, useMemo, useState, type CSSProperties } from "react";
-import { X, Trash2 } from "lucide-react";
+import { X, Trash2, RefreshCw } from "lucide-react";
 import { useAgentStore } from "../../stores/agent.store";
 import { useUIStore } from "../../stores/ui.store";
 import type { EchoChamberSide } from "../../stores/ui.store";
 import { useAgentConfigs } from "../../hooks/use-agents";
 import { useChatStore } from "../../stores/chat.store";
 import { useChat } from "../../hooks/use-chats";
+import { useGenerate } from "../../hooks/use-generate";
 import { api } from "../../lib/api-client";
 import { cn } from "../../lib/utils";
 import { ROLEPLAY_POPOVER_SHELL } from "./roleplay-popover-styles";
@@ -146,11 +147,16 @@ export function EchoChamberPanel({ hiddenOnMobile = false }: EchoChamberPanelPro
   const toggleEchoChamber = useUIStore((s) => s.toggleEchoChamber);
   const setEchoChamberSide = useUIStore((s) => s.setEchoChamberSide);
   const echoMessages = useAgentStore((s) => s.echoMessages);
+  const isAgentProcessing = useAgentStore((s) => s.isProcessing);
   const scrollRef = useRef<HTMLDivElement>(null);
 
   const activeChatId = useChatStore((s) => s.activeChatId);
+  const isStreaming = useChatStore((s) => s.isStreaming);
+  const streamingChatId = useChatStore((s) => s.streamingChatId);
   const { data: chat } = useChat(activeChatId);
   const { data: agentConfigs } = useAgentConfigs();
+  const { retryAgents } = useGenerate();
+  const echoRetryBusy = isAgentProcessing || (isStreaming && streamingChatId === activeChatId);
 
   // Mirror the enabledAgentTypes logic from ChatArea so per-chat overrides are respected
   const echoEnabled = useMemo(() => {
@@ -386,6 +392,17 @@ export function EchoChamberPanel({ hiddenOnMobile = false }: EchoChamberPanelPro
           )}
         </span>
         <div className="flex items-center gap-1.5">
+          <button
+            onClick={() => {
+              if (!activeChatId || echoRetryBusy) return;
+              void retryAgents(activeChatId, ["echo-chamber"]);
+            }}
+            disabled={echoRetryBusy}
+            title={echoRetryBusy ? "A reply or agent is already running" : "Re-run Echo Chamber"}
+            className="rounded p-0.5 text-[var(--marinara-chat-chrome-button-text)] transition-colors hover:bg-[var(--marinara-chat-chrome-highlight-bg-hover)] hover:text-[var(--marinara-chat-chrome-button-text-hover)] disabled:opacity-30 disabled:cursor-not-allowed"
+          >
+            <RefreshCw size="0.5625rem" className={echoRetryBusy ? "animate-spin" : ""} />
+          </button>
           {visibleMessages.length > 0 && (
             <button
               onClick={async () => {


### PR DESCRIPTION
## Linked issue

Closes #2822

## Why this change

The Echo Chamber agent has no manual re-run path. It only fires during normal generation — there's no way to refresh its reactions without generating a new reply. The existing tracker refresh button retries agents via `retryAgents()`, but it's scoped to `category: "tracker"` agents only. Echo Chamber is `category: "misc"`, so it's excluded by design.

## What changed

- Added a `RefreshCw` button to the Echo Chamber panel header (left of the clear-messages button)
- Button calls `retryAgents(chatId, ["echo-chamber"])` — reuses the existing retry infrastructure, scoped to just echo chamber
- Button is disabled while a reply or agent is already processing (`isAgentProcessing || (isStreaming && streamingChatId === activeChatId)`)
- Animated spin icon when busy
- Styled with the same CSS variables as other header buttons

Only `EchoChamberPanel.tsx` is modified (18 lines added).

## Validation

- [x] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [x] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [x] Read and followed `CONTRIBUTING.md`

### Manual verification notes

- Built the app and loaded it locally
- Opened a roleplay chat with Echo Chamber enabled
- Confirmed the refresh button appears in the panel header
- Clicked the button and observed echo chamber agent re-running and new messages appearing
- Confirmed button disables + spins while a reply is streaming
- Confirmed button disables while agents are processing

## Docs and release impact

- [x] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Version/release files updated (only if this PR includes a version bump)

## UI evidence (if applicable)

<img width="540" height="72" alt="image" src="https://github.com/user-attachments/assets/47a6be33-8c16-49a6-8ff4-61f103c859aa" />
