### PR TITLE
Fix tool calling with local providers

### DIFF
--- a/packages/server/src/services/llm/base-provider.ts
+++ b/packages/server/src/services/llm/base-provider.ts
@@ -134,6 +134,13 @@ export interface ChatOptions {
   customParameters?: Record<string, unknown>;
   /** Do not add inferred sampler/model parameters; max output tokens and customParameters still apply. */
   suppressModelParameters?: boolean;
+  /**
+   * Skip sending tools to the provider API and rely entirely on textual tool-call parsing.
+   * Set by the local-sidecar provider when native tool calls are disabled (no --jinja),
+   * because sending a tools array to a server started without Jinja templates produces
+   * garbled or ignored output. The tools array is still used for parsing the response.
+   */
+  forceTextualToolCalls?: boolean;
 }
 
 /** Token usage statistics returned by the model */

--- a/packages/server/src/services/llm/providers/local-sidecar.provider.ts
+++ b/packages/server/src/services/llm/providers/local-sidecar.provider.ts
@@ -42,9 +42,17 @@ export class LocalSidecarProvider extends BaseLLMProvider {
     if (sidecarModelService.getResolvedBackend() === "llama_cpp" && !config.enableNativeToolCalls) {
       if (!warnedNativeToolCallsDisabled) {
         warnedNativeToolCallsDisabled = true;
-        logger.warn("[local-sidecar] Native tool calls are disabled; attempting textual tool-call fallback");
+        logger.warn(
+          "[local-sidecar] Native tool calls are disabled (no --jinja); tool definitions will not be sent to the API. " +
+            "Tool calls in the model response will be extracted via textual parsing only.",
+        );
       }
     }
+  }
+
+  private isTextualToolCallFallback(): boolean {
+    const config = sidecarModelService.getConfig();
+    return sidecarModelService.getResolvedBackend() === "llama_cpp" && !config.enableNativeToolCalls;
   }
 
   private applyRuntimeSettings(options: ChatOptions): ChatOptions {
@@ -81,9 +89,11 @@ export class LocalSidecarProvider extends BaseLLMProvider {
     this.assertToolCallsAvailable(options);
     const delegate = await this.createDelegate();
     const runtimeOptions = this.applyBackendRequestConstraints(this.applyRuntimeSettings(options));
+    const forceTextual = this.isTextualToolCallFallback() && !!runtimeOptions.tools?.length;
     return yield* delegate.chat(messages, {
       ...runtimeOptions,
       model: this.getRequestModel(),
+      ...(forceTextual ? { forceTextualToolCalls: true } : {}),
     });
   }
 
@@ -91,9 +101,11 @@ export class LocalSidecarProvider extends BaseLLMProvider {
     this.assertToolCallsAvailable(options);
     const delegate = await this.createDelegate();
     const runtimeOptions = this.applyBackendRequestConstraints(this.applyRuntimeSettings(options));
+    const forceTextual = this.isTextualToolCallFallback() && !!runtimeOptions.tools?.length;
     return delegate.chatComplete(messages, {
       ...runtimeOptions,
       model: this.getRequestModel(),
+      ...(forceTextual ? { forceTextualToolCalls: true } : {}),
     });
   }
 

--- a/packages/server/src/services/llm/providers/openai.provider.ts
+++ b/packages/server/src/services/llm/providers/openai.provider.ts
@@ -289,7 +289,8 @@ export class OpenAIProvider extends BaseLLMProvider {
       type: "function",
       function: {
         name,
-        arguments: OpenAIProvider.stringifyToolArguments(fn.arguments ?? raw.arguments ?? raw.args),
+        // "parameters" is used by some models instead of the OpenAI-standard "arguments"
+      arguments: OpenAIProvider.stringifyToolArguments(fn.arguments ?? fn.parameters ?? raw.arguments ?? raw.args ?? raw.parameters),
       },
     };
   }
@@ -864,7 +865,7 @@ export class OpenAIProvider extends BaseLLMProvider {
 
     if (!suppressModelParameters) {
       if (this.shouldSendStopSequences(options.model) && options.stop?.length) body.stop = options.stop;
-      if (options.tools?.length) body.tools = options.tools;
+      if (options.tools?.length && !options.forceTextualToolCalls) body.tools = options.tools;
       if (effectiveStream) body.stream_options = { include_usage: true };
 
       // o-series models never support temperature/topP; GPT-5.x only with effort=none
@@ -1109,7 +1110,7 @@ export class OpenAIProvider extends BaseLLMProvider {
 
     if (!suppressModelParameters) {
       if (this.shouldSendStopSequences(options.model) && options.stop?.length) body.stop = options.stop;
-      if (options.tools?.length) body.tools = options.tools;
+      if (options.tools?.length && !options.forceTextualToolCalls) body.tools = options.tools;
       if (useStream) body.stream_options = { include_usage: true };
 
       // o-series models never support temperature/topP; GPT-5.x only with effort=none
@@ -1347,9 +1348,13 @@ export class OpenAIProvider extends BaseLLMProvider {
                   ? fn.arguments
                   : typeof tc.arguments === "string"
                     ? tc.arguments
-                    : fn.arguments !== undefined || tc.arguments !== undefined
-                      ? OpenAIProvider.stringifyToolArguments(fn.arguments ?? tc.arguments)
-                      : "";
+                    : typeof fn.parameters === "string"
+                      ? fn.parameters
+                      : typeof tc.parameters === "string"
+                        ? tc.parameters
+                        : fn.arguments !== undefined || tc.arguments !== undefined || fn.parameters !== undefined || tc.parameters !== undefined
+                          ? OpenAIProvider.stringifyToolArguments(fn.arguments ?? tc.arguments ?? fn.parameters ?? tc.parameters)
+                          : "";
               const existing = toolCallsMap.get(index);
               if (!existing) {
                 toolCallsMap.set(index, {

--- a/packages/server/src/services/llm/textual-tool-call-parser.ts
+++ b/packages/server/src/services/llm/textual-tool-call-parser.ts
@@ -34,12 +34,24 @@ function parseJsonishObject(value: string): Record<string, unknown> | null {
   return null;
 }
 
+/**
+ * Gemma 4 uses <|"|>string value<|"|> as a string delimiter instead of "string value".
+ * Normalize these to standard double-quoted strings so JSON parsing can succeed.
+ */
+function normalizeGemma4Delimiters(content: string): string {
+  return content.replace(/<\|"\|>(.*?)<\|"\|>/gs, (_, inner: string) => JSON.stringify(inner));
+}
+
 function rawToolCalls(payload: Record<string, unknown>): unknown[] {
   const plural = payload.tool_calls ?? payload.toolCalls ?? payload.calls;
   if (Array.isArray(plural)) return plural;
   const single = payload.tool_call ?? payload.toolCall;
   if (single) return [single];
   if (typeof payload.name === "string" || typeof payload.tool === "string" || typeof payload.command === "string") {
+    return [payload];
+  }
+  // Handle {"type": "function", "function": {"name": "...", ...}} OpenAI-style wrapper
+  if (isRecord(payload.function) && typeof (payload.function as Record<string, unknown>).name === "string") {
     return [payload];
   }
   return [];
@@ -66,6 +78,12 @@ function parseTaggedSnippets(content: string): ParsedTaggedSnippet[] {
     },
     { re: /<tool_code>([\s\S]*?)<\/tool_code>/gi, allowCommandFallback: true, allowAnonymousJsonPayload: true },
     { re: /```(?:json)?\s*([\s\S]*?)\s*```/gi, allowCommandFallback: false, allowAnonymousJsonPayload: false },
+    // Meta Llama 3.1+ uses <|python_tag|> to delimit tool calls in content
+    {
+      re: /<\|python_tag\|>([\s\S]*?)(?:<\|eom_id\|>|<\|eot_id\|>|<\|end_header_id\|>|$)/gi,
+      allowCommandFallback: false,
+      allowAnonymousJsonPayload: false,
+    },
   ];
   for (const pattern of patterns) {
     for (const match of content.matchAll(pattern.re)) {
@@ -90,6 +108,10 @@ function snippetToPayload(snippet: string, options: Omit<ParsedTaggedSnippet, "t
   const jsonPayload = parseJsonishObject(snippet);
   if (jsonPayload) {
     if (typeof jsonPayload.name === "string" || typeof jsonPayload.tool === "string") return jsonPayload;
+    // Pass through {"type":"function","function":{...}} wrappers to toolCallFromRaw
+    if (isRecord(jsonPayload.function) && typeof (jsonPayload.function as Record<string, unknown>).name === "string") {
+      return jsonPayload;
+    }
     return options.allowAnonymousJsonPayload ? { name: "mari_db", arguments: jsonPayload } : null;
   }
   const callMatch = snippet.trim().match(/^(?:call\s*:\s*)?([A-Za-z_][\w.-]*)\s*(\{[\s\S]*\})\s*$/);
@@ -124,10 +146,16 @@ function toolCallFromRaw(
   hasBashTool: boolean,
 ): LLMToolCall | null {
   if (!isRecord(raw)) return null;
-  const nameValue = raw.name ?? raw.tool;
+  // Handle {"type":"function","function":{"name":"...","arguments":"..."}} OpenAI-style wrapper
+  const fnWrap = isRecord(raw.function) ? (raw.function as Record<string, unknown>) : null;
+  const nameValue = raw.name ?? raw.tool ?? fnWrap?.name;
   if (typeof nameValue !== "string") return null;
   const name = nameValue.trim();
-  const args = normalizeArguments(raw.arguments ?? raw.args ?? raw.input ?? {});
+  // "parameters" is used by many models (e.g. Llama 3.1, Gemma) instead of "arguments"
+  const args = normalizeArguments(
+    raw.arguments ?? raw.args ?? raw.input ?? raw.parameters ??
+    fnWrap?.arguments ?? fnWrap?.args ?? fnWrap?.parameters ?? {},
+  );
   if (knownTools.has(name)) {
     return {
       id: typeof raw.id === "string" && raw.id.trim() ? raw.id.trim() : toolCallId(index),
@@ -150,11 +178,17 @@ function toolCallFromRaw(
 
 export function parseTextualToolCalls(content: string | null | undefined, tools: LLMToolDefinition[] = []): LLMToolCall[] {
   if (!content || tools.length === 0) return [];
+
+  // Gemma 4 uses <|"|>string<|"|> instead of "string" in tool call arguments.
+  // Normalize these to standard JSON strings before any parsing attempt.
+  const normalized = content.includes('<|"|>') ? normalizeGemma4Delimiters(content) : content;
+
   const knownTools = new Set(tools.map((tool) => tool.function.name));
   const hasBashTool = knownTools.has("bash");
   const calls: LLMToolCall[] = [];
 
-  const wholePayload = parseJsonishObject(content);
+  // Try the whole content as a single JSON object
+  const wholePayload = parseJsonishObject(normalized);
   if (wholePayload) {
     rawToolCalls(wholePayload).forEach((raw, index) => {
       const call = toolCallFromRaw(raw, index, knownTools, hasBashTool);
@@ -163,7 +197,24 @@ export function parseTextualToolCalls(content: string | null | undefined, tools:
   }
   if (calls.length > 0) return calls;
 
-  parseTaggedSnippets(content).forEach((snippet, index) => {
+  // Try the whole content as a top-level JSON array of tool calls
+  const trimmed = normalized.trim();
+  if (trimmed.startsWith("[")) {
+    try {
+      const arr = JSON.parse(trimmed);
+      if (Array.isArray(arr)) {
+        arr.forEach((raw, index) => {
+          const call = toolCallFromRaw(raw, index, knownTools, hasBashTool);
+          if (call) calls.push(call);
+        });
+      }
+    } catch {
+      /* not a valid JSON array */
+    }
+    if (calls.length > 0) return calls;
+  }
+
+  parseTaggedSnippets(normalized).forEach((snippet, index) => {
     const payload = snippetToPayload(snippet.text, {
       allowCommandFallback: snippet.allowCommandFallback,
       allowAnonymousJsonPayload: snippet.allowAnonymousJsonPayload,

--- a/packages/server/src/services/llm/textual-tool-call-parser.ts
+++ b/packages/server/src/services/llm/textual-tool-call-parser.ts
@@ -42,6 +42,10 @@ function normalizeGemma4Delimiters(content: string): string {
   return content.replace(/<\|"\|>(.*?)<\|"\|>/gs, (_, inner: string) => JSON.stringify(inner));
 }
 
+function parseJsonishObjectWithGemmaDelimiters(value: string): Record<string, unknown> | null {
+  return parseJsonishObject(value) ?? (value.includes('<|"|>') ? parseJsonishObject(normalizeGemma4Delimiters(value)) : null);
+}
+
 function rawToolCalls(payload: Record<string, unknown>): unknown[] {
   const plural = payload.tool_calls ?? payload.toolCalls ?? payload.calls;
   if (Array.isArray(plural)) return plural;
@@ -179,16 +183,12 @@ function toolCallFromRaw(
 export function parseTextualToolCalls(content: string | null | undefined, tools: LLMToolDefinition[] = []): LLMToolCall[] {
   if (!content || tools.length === 0) return [];
 
-  // Gemma 4 uses <|"|>string<|"|> instead of "string" in tool call arguments.
-  // Normalize these to standard JSON strings before any parsing attempt.
-  const normalized = content.includes('<|"|>') ? normalizeGemma4Delimiters(content) : content;
-
   const knownTools = new Set(tools.map((tool) => tool.function.name));
   const hasBashTool = knownTools.has("bash");
   const calls: LLMToolCall[] = [];
 
   // Try the whole content as a single JSON object
-  const wholePayload = parseJsonishObject(normalized);
+  const wholePayload = parseJsonishObjectWithGemmaDelimiters(content);
   if (wholePayload) {
     rawToolCalls(wholePayload).forEach((raw, index) => {
       const call = toolCallFromRaw(raw, index, knownTools, hasBashTool);
@@ -198,10 +198,10 @@ export function parseTextualToolCalls(content: string | null | undefined, tools:
   if (calls.length > 0) return calls;
 
   // Try the whole content as a top-level JSON array of tool calls
-  const trimmed = normalized.trim();
+  const trimmed = content.trim();
   if (trimmed.startsWith("[")) {
     try {
-      const arr = JSON.parse(trimmed);
+      const arr = JSON.parse(trimmed.includes('<|"|>') ? normalizeGemma4Delimiters(trimmed) : trimmed);
       if (Array.isArray(arr)) {
         arr.forEach((raw, index) => {
           const call = toolCallFromRaw(raw, index, knownTools, hasBashTool);
@@ -214,8 +214,9 @@ export function parseTextualToolCalls(content: string | null | undefined, tools:
     if (calls.length > 0) return calls;
   }
 
-  parseTaggedSnippets(normalized).forEach((snippet, index) => {
-    const payload = snippetToPayload(snippet.text, {
+  parseTaggedSnippets(content).forEach((snippet, index) => {
+    const snippetText = snippet.text.includes('<|"|>') ? normalizeGemma4Delimiters(snippet.text) : snippet.text;
+    const payload = snippetToPayload(snippetText, {
       allowCommandFallback: snippet.allowCommandFallback,
       allowAnonymousJsonPayload: snippet.allowAnonymousJsonPayload,
     });


### PR DESCRIPTION
CONVERTING TO DRAFT - Tool calling for everything but professor Mari seems to not know what to call yet, working on a fix hopefully

## Linked issue

<!-- Every PR should reference a feature request or issue report. If there isn't one yet, open one first to gather opinions: -->
<!-- https://github.com/Pasta-Devs/Marinara-Engine/issues/new/choose -->

Closes #2824

## Why this change

Fix tool calling behaviour for local providers

## What changed

Add some parsing for different tool call syntax, as well as fix a bug with detecting the end of a tool call block


## Validation

<!-- Required: include commands run and/or manual checks performed -->

- [x] `pnpm check` passes locally
- [x] Container (Docker / Podman) built and ran without issue
- [x] Ran the app, clicked through the changes manually
- [x] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [x] Above manual verification completed (describe below)
- [x] Read and followed `CONTRIBUTING.md`

### Manual verification notes

- Ran sidecar and called a tool
- Ran local model with llama.cpp and called a tool (Gemma and Qwen just in case)


## Docs and release impact

- [x] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Version/release files updated (only if this PR includes a version bump)

## UI evidence (if applicable)

sidecar gemma:
<img width="510" height="401" alt="image" src="https://github.com/user-attachments/assets/14d46edb-6290-48a5-a22b-19573b9670d7" />

local qwen:
<img width="517" height="421" alt="image" src="https://github.com/user-attachments/assets/db6f5eb8-a7ff-48eb-b673-e7dc4b6f3012" />

local gemma26ba4b, tried something with multiple calls required:
<img width="772" height="605" alt="image" src="https://github.com/user-attachments/assets/7970e43f-48e5-4b14-a534-557a870c4e16" />

Ah, and just in case with GLM 5 on nanogpt to make sure there are no regressions elsewhere:
<img width="779" height="627" alt="image" src="https://github.com/user-attachments/assets/713eb48c-51f0-4e0c-914b-3d418e7e52bb" />


