### PR TITLE
fix(conversation): sync chat-list + in-chat status dots with live presence

### DIFF
--- a/packages/client/src/components/chat/ChatArea.tsx
+++ b/packages/client/src/components/chat/ChatArea.tsx
@@ -51,9 +51,13 @@ import {
   APP_VERSION,
   BUILT_IN_AGENTS,
   buildGuidedGenerationInstructionMessage,
+  getActiveStatusOverride,
+  getEffectiveCurrentStatus,
   type AchievementEvent,
+  type ConversationStatusOverride,
   type SpritePlacement,
   type SpriteSide,
+  type WeekSchedule,
 } from "@marinara-engine/shared";
 import { useUIStore } from "../../stores/ui.store";
 import { useAgentStore } from "../../stores/agent.store";
@@ -636,16 +640,43 @@ export function ChatArea() {
       const char = query.data;
       if (char?.id) map.set(char.id, toCharacterMapValue(char));
     }
-    // Overlay per-chat presence status so status dots reflect this chat, not the last chat to generate.
-    const chatStatuses = parseChatMetadata(chat?.metadata).conversationCharacterStatuses as
+    // Overlay per-chat presence status so status dots reflect this chat, not the last chat to
+    // generate. Prefer the live override/schedule-derived status (matching the presence pill)
+    // over the generation-time snapshot, which only refreshes on the next generated message.
+    const convoMeta = parseChatMetadata(chat?.metadata);
+    const chatStatuses = convoMeta.conversationCharacterStatuses as
       | Record<string, { status?: string; activity?: string }>
       | undefined;
-    if (chatStatuses) {
-      for (const [id, info] of Object.entries(chatStatuses)) {
-        const existing = map.get(id);
-        if (existing && info.status) {
-          map.set(id, { ...existing, conversationStatus: info.status as any, conversationActivity: info.activity ?? existing.conversationActivity });
-        }
+    const statusOverrides = convoMeta.conversationStatusOverrides as
+      | Record<string, ConversationStatusOverride>
+      | undefined;
+    const characterSchedules =
+      convoMeta.conversationSchedulesEnabled === false
+        ? undefined
+        : (convoMeta.characterSchedules as Record<string, WeekSchedule> | undefined);
+    const statusNow = new Date();
+    const presenceIds = new Set<string>([
+      ...Object.keys(chatStatuses ?? {}),
+      ...Object.keys(statusOverrides ?? {}),
+      ...Object.keys(characterSchedules ?? {}),
+    ]);
+    for (const id of presenceIds) {
+      const existing = map.get(id);
+      if (!existing) continue;
+      const schedule = characterSchedules?.[id];
+      const override = statusOverrides?.[id];
+      if (getActiveStatusOverride(override, statusNow) || schedule) {
+        const eff = getEffectiveCurrentStatus(schedule, override, statusNow);
+        map.set(id, { ...existing, conversationStatus: eff.status, conversationActivity: eff.activity });
+        continue;
+      }
+      const info = chatStatuses?.[id];
+      if (info?.status) {
+        map.set(id, {
+          ...existing,
+          conversationStatus: info.status as any,
+          conversationActivity: info.activity ?? existing.conversationActivity,
+        });
       }
     }
     return map;

--- a/packages/client/src/components/chat/ChatArea.tsx
+++ b/packages/client/src/components/chat/ChatArea.tsx
@@ -52,14 +52,11 @@ import {
   APP_VERSION,
   BUILT_IN_AGENTS,
   buildGuidedGenerationInstructionMessage,
-  getActiveStatusOverride,
-  getEffectiveCurrentStatus,
   type AchievementEvent,
-  type ConversationStatusOverride,
   type SpritePlacement,
   type SpriteSide,
-  type WeekSchedule,
 } from "@marinara-engine/shared";
+import { resolveLiveConversationStatus } from "../../lib/conversation-presence-status";
 import { useUIStore } from "../../stores/ui.store";
 import { useAgentStore } from "../../stores/agent.store";
 import { cn, parseAvatarCropJson } from "../../lib/utils";
@@ -646,33 +643,23 @@ export function ChatArea() {
       if (char?.id) map.set(char.id, toCharacterMapValue(char));
     }
     // Overlay per-chat presence status so status dots reflect this chat, not the last chat to
-    // generate. Prefer the live override/schedule-derived status (matching the presence pill)
-    // over the generation-time snapshot, which only refreshes on the next generated message.
+    // generate. Prefer the live override/schedule-derived status (matching the presence pill, via
+    // the shared resolver) over the generation-time snapshot, which only refreshes on generation.
     const convoMeta = parseChatMetadata(chat?.metadata);
     const chatStatuses = convoMeta.conversationCharacterStatuses as
       | Record<string, { status?: string; activity?: string }>
       | undefined;
-    const statusOverrides = convoMeta.conversationStatusOverrides as
-      | Record<string, ConversationStatusOverride>
-      | undefined;
-    const characterSchedules =
-      convoMeta.conversationSchedulesEnabled === false
-        ? undefined
-        : (convoMeta.characterSchedules as Record<string, WeekSchedule> | undefined);
-    const statusNow = presenceNow;
     const presenceIds = new Set<string>([
       ...Object.keys(chatStatuses ?? {}),
-      ...Object.keys(statusOverrides ?? {}),
-      ...Object.keys(characterSchedules ?? {}),
+      ...Object.keys((convoMeta.conversationStatusOverrides as Record<string, unknown> | undefined) ?? {}),
+      ...Object.keys((convoMeta.characterSchedules as Record<string, unknown> | undefined) ?? {}),
     ]);
     for (const id of presenceIds) {
       const existing = map.get(id);
       if (!existing) continue;
-      const schedule = characterSchedules?.[id];
-      const override = statusOverrides?.[id];
-      if (getActiveStatusOverride(override, statusNow) || schedule) {
-        const eff = getEffectiveCurrentStatus(schedule, override, statusNow);
-        map.set(id, { ...existing, conversationStatus: eff.status, conversationActivity: eff.activity });
+      const live = resolveLiveConversationStatus(convoMeta, id, presenceNow);
+      if (live) {
+        map.set(id, { ...existing, conversationStatus: live.status, conversationActivity: live.activity });
         continue;
       }
       const info = chatStatuses?.[id];

--- a/packages/client/src/components/chat/ChatArea.tsx
+++ b/packages/client/src/components/chat/ChatArea.tsx
@@ -36,6 +36,7 @@ import { useChatStore } from "../../stores/chat.store";
 import { useGenerate } from "../../hooks/use-generate";
 import { characterKeys, spriteKeys, useCharacters, usePersonas, type SpriteInfo } from "../../hooks/use-characters";
 import { usePageActivity } from "../../hooks/use-page-activity";
+import { usePresenceClock } from "../../hooks/use-presence-clock";
 import { api, ApiError } from "../../lib/api-client";
 import { getChatDisplayName, getConnectedChatDisplayName, parseChatMetadata } from "../../lib/chat-display";
 import { getChatCharacterIds } from "../../lib/chat-macros";
@@ -631,6 +632,10 @@ export function ChatArea() {
     })),
   });
 
+  // A 60s-cadence clock so schedule/override-derived presence refreshes when time
+  // alone changes the effective status (mirrors the presence pill's refetch).
+  const presenceNow = usePresenceClock();
+
   // Build character lookup map. Cold launches can render chat detail before the
   // full library list has produced every active character, so merge exact
   // per-chat character fetches as a rescue path.
@@ -654,7 +659,7 @@ export function ChatArea() {
       convoMeta.conversationSchedulesEnabled === false
         ? undefined
         : (convoMeta.characterSchedules as Record<string, WeekSchedule> | undefined);
-    const statusNow = new Date();
+    const statusNow = presenceNow;
     const presenceIds = new Set<string>([
       ...Object.keys(chatStatuses ?? {}),
       ...Object.keys(statusOverrides ?? {}),
@@ -680,7 +685,7 @@ export function ChatArea() {
       }
     }
     return map;
-  }, [baseCharacterMap, missingCharacterQueries, chat?.metadata]);
+  }, [baseCharacterMap, missingCharacterQueries, chat?.metadata, presenceNow]);
 
   const characterNames = useMemo(
     () => chatCharIds.map((id) => characterMap.get(id)?.name).filter((n): n is string => !!n),

--- a/packages/client/src/components/layout/ChatSidebar.tsx
+++ b/packages/client/src/components/layout/ChatSidebar.tsx
@@ -47,11 +47,15 @@ import { cn, getAvatarCropStyle, type AvatarCropValue } from "../../lib/utils";
 import { useState, useCallback, useMemo, useRef, useEffect } from "react";
 import { toast } from "sonner";
 import {
+  getActiveStatusOverride,
+  getEffectiveCurrentStatus,
   includesTextForMatch,
   normalizeTextForMatch,
   type Chat,
   type ChatFolder,
   type ChatMode,
+  type ConversationStatusOverride,
+  type WeekSchedule,
 } from "@marinara-engine/shared";
 import { Modal } from "../ui/Modal";
 import { Reorder, useDragControls } from "framer-motion";
@@ -849,18 +853,35 @@ export function ChatSidebar() {
         <div className="relative flex-shrink-0">
           {(() => {
             const charIds = normalizeChatCharacterIds((chat as { characterIds?: unknown }).characterIds);
-            const chatCharStatuses =
-              chat.mode === "conversation"
-                ? (parseChatMetadata(chat.metadata).conversationCharacterStatuses as
-                    | Record<string, { status?: string }>
-                    | undefined)
-                : undefined;
+            const convoMeta = chat.mode === "conversation" ? parseChatMetadata(chat.metadata) : undefined;
+            const chatCharStatuses = convoMeta?.conversationCharacterStatuses as
+              | Record<string, { status?: string }>
+              | undefined;
+            const statusOverrides = convoMeta?.conversationStatusOverrides as
+              | Record<string, ConversationStatusOverride>
+              | undefined;
+            const characterSchedules =
+              convoMeta?.conversationSchedulesEnabled === false
+                ? undefined
+                : (convoMeta?.characterSchedules as Record<string, WeekSchedule> | undefined);
+            const statusNow = new Date();
+            // Prefer the live override/schedule-derived status (matching the presence pill)
+            // over the generation-time snapshot, which only refreshes on the next generated
+            // message. Fall back to the snapshot when there is no active override or schedule.
+            const resolveConvoStatus = (id: string): string | undefined => {
+              const schedule = characterSchedules?.[id];
+              const override = statusOverrides?.[id];
+              if (getActiveStatusOverride(override, statusNow) || schedule) {
+                return getEffectiveCurrentStatus(schedule, override, statusNow).status;
+              }
+              return chatCharStatuses?.[id]?.status;
+            };
             const avatars = charIds
               .slice(0, 3)
               .map((id) => {
                 const base = charLookup.get(id);
                 if (!base) return null;
-                const chatStatus = chatCharStatuses?.[id]?.status;
+                const chatStatus = resolveConvoStatus(id);
                 return chatStatus ? { ...base, conversationStatus: chatStatus } : base;
               })
               .filter(Boolean) as {

--- a/packages/client/src/components/layout/ChatSidebar.tsx
+++ b/packages/client/src/components/layout/ChatSidebar.tsx
@@ -45,6 +45,7 @@ import { confirmNonEmptyFolderDelete, showConfirmDialog } from "../../lib/app-di
 import { useUIStore, type UserStatus } from "../../stores/ui.store";
 import { cn, getAvatarCropStyle, type AvatarCropValue } from "../../lib/utils";
 import { useState, useCallback, useMemo, useRef, useEffect } from "react";
+import { usePresenceClock } from "../../hooks/use-presence-clock";
 import { toast } from "sonner";
 import {
   getActiveStatusOverride,
@@ -163,6 +164,9 @@ export function ChatSidebar() {
   const unreadCounts = useChatStore((s) => s.unreadCounts);
   const hydrateUnread = useChatStore((s) => s.hydrateUnread);
   const { data: allCharacters } = useCharacters({ includeBuiltIn: true });
+  // One interval for the whole list: a 60s-cadence clock so schedule/override-derived
+  // status dots refresh when time alone changes them, without per-row timers.
+  const presenceNow = usePresenceClock();
   const hasAnyDetailOpen = useUIStore((s) => s.hasAnyDetailOpen);
   const editorDirty = useUIStore((s) => s.editorDirty);
   const closeAllDetails = useUIStore((s) => s.closeAllDetails);
@@ -864,7 +868,7 @@ export function ChatSidebar() {
               convoMeta?.conversationSchedulesEnabled === false
                 ? undefined
                 : (convoMeta?.characterSchedules as Record<string, WeekSchedule> | undefined);
-            const statusNow = new Date();
+            const statusNow = presenceNow;
             // Prefer the live override/schedule-derived status (matching the presence pill)
             // over the generation-time snapshot, which only refreshes on the next generated
             // message. Fall back to the snapshot when there is no active override or schedule.

--- a/packages/client/src/components/layout/ChatSidebar.tsx
+++ b/packages/client/src/components/layout/ChatSidebar.tsx
@@ -48,16 +48,13 @@ import { useState, useCallback, useMemo, useRef, useEffect } from "react";
 import { usePresenceClock } from "../../hooks/use-presence-clock";
 import { toast } from "sonner";
 import {
-  getActiveStatusOverride,
-  getEffectiveCurrentStatus,
   includesTextForMatch,
   normalizeTextForMatch,
   type Chat,
   type ChatFolder,
   type ChatMode,
-  type ConversationStatusOverride,
-  type WeekSchedule,
 } from "@marinara-engine/shared";
+import { resolveLiveConversationStatus } from "../../lib/conversation-presence-status";
 import { Modal } from "../ui/Modal";
 import { Reorder, useDragControls } from "framer-motion";
 import { parseChatMetadata } from "../../lib/chat-display";
@@ -861,25 +858,10 @@ export function ChatSidebar() {
             const chatCharStatuses = convoMeta?.conversationCharacterStatuses as
               | Record<string, { status?: string }>
               | undefined;
-            const statusOverrides = convoMeta?.conversationStatusOverrides as
-              | Record<string, ConversationStatusOverride>
-              | undefined;
-            const characterSchedules =
-              convoMeta?.conversationSchedulesEnabled === false
-                ? undefined
-                : (convoMeta?.characterSchedules as Record<string, WeekSchedule> | undefined);
-            const statusNow = presenceNow;
-            // Prefer the live override/schedule-derived status (matching the presence pill)
-            // over the generation-time snapshot, which only refreshes on the next generated
-            // message. Fall back to the snapshot when there is no active override or schedule.
-            const resolveConvoStatus = (id: string): string | undefined => {
-              const schedule = characterSchedules?.[id];
-              const override = statusOverrides?.[id];
-              if (getActiveStatusOverride(override, statusNow) || schedule) {
-                return getEffectiveCurrentStatus(schedule, override, statusNow).status;
-              }
-              return chatCharStatuses?.[id]?.status;
-            };
+            // Prefer the live override/schedule-derived status (matching the presence pill) over the
+            // generation-time snapshot, which only refreshes on the next generated message.
+            const resolveConvoStatus = (id: string): string | undefined =>
+              resolveLiveConversationStatus(convoMeta, id, presenceNow)?.status ?? chatCharStatuses?.[id]?.status;
             const avatars = charIds
               .slice(0, 3)
               .map((id) => {

--- a/packages/client/src/hooks/use-presence-clock.ts
+++ b/packages/client/src/hooks/use-presence-clock.ts
@@ -1,0 +1,48 @@
+import { useEffect, useState } from "react";
+
+/**
+ * Returns a `Date` that refreshes on a fixed cadence so components which derive
+ * conversation presence from schedules or expiring overrides re-render when time
+ * alone changes the effective status — without needing navigation, a new message,
+ * or an unrelated render. Mirrors the presence pill's 60s server refetch.
+ *
+ * Pass the returned value straight into the presence computation (and any memo
+ * dependency array) — its identity changes each tick. One interval per consumer
+ * (place it at a list root, not per row). The timer is paused while the tab is
+ * hidden and refreshes immediately when the tab becomes visible again, matching
+ * the pill query's `document.hidden` gating.
+ */
+export function usePresenceClock(intervalMs = 60_000): Date {
+  const [now, setNow] = useState(() => new Date());
+
+  useEffect(() => {
+    let timer: ReturnType<typeof setInterval> | null = null;
+
+    const start = () => {
+      if (timer == null) timer = setInterval(() => setNow(new Date()), intervalMs);
+    };
+    const stop = () => {
+      if (timer != null) {
+        clearInterval(timer);
+        timer = null;
+      }
+    };
+    const handleVisibility = () => {
+      if (document.hidden) {
+        stop();
+      } else {
+        setNow(new Date()); // catch up immediately on re-show
+        start();
+      }
+    };
+
+    if (!document.hidden) start();
+    document.addEventListener("visibilitychange", handleVisibility);
+    return () => {
+      stop();
+      document.removeEventListener("visibilitychange", handleVisibility);
+    };
+  }, [intervalMs]);
+
+  return now;
+}

--- a/packages/client/src/hooks/use-presence-clock.ts
+++ b/packages/client/src/hooks/use-presence-clock.ts
@@ -16,6 +16,10 @@ export function usePresenceClock(intervalMs = 60_000): Date {
   const [now, setNow] = useState(() => new Date());
 
   useEffect(() => {
+    // Guard non-DOM environments (tests / any non-browser runtime); the client
+    // normally runs in a browser or Tauri webview where `document` exists.
+    if (typeof document === "undefined") return;
+
     let timer: ReturnType<typeof setInterval> | null = null;
 
     const start = () => {

--- a/packages/client/src/lib/conversation-presence-status.ts
+++ b/packages/client/src/lib/conversation-presence-status.ts
@@ -18,17 +18,19 @@ type ConversationPresenceMeta = {
  * block — so the chat-list sidebar and the in-chat overlay agree with the
  * presence pill instead of reading a generation-time snapshot.
  *
- * Returns `null` when there is no live signal (no active override and the chat
- * has not opted into schedules), in which case the caller keeps the stored
+ * Returns `null` when there is no live signal (no active override and no
+ * schedule in play), in which case the caller keeps the stored
  * `conversationCharacterStatuses` snapshot. This is the single gate both client
  * surfaces share, so they cannot drift on which metadata is allowed to drive
  * live status.
  *
- * Schedules require an explicit `conversationSchedulesEnabled === true` opt-in
- * (which the server sets whenever it generates schedules), so a stray or
- * imported schedule-shaped payload cannot outvote the snapshot. Overrides are
- * validated by `getActiveStatusOverride` (status enum + expiry), so a malformed
- * or expired override also falls through to the snapshot.
+ * The schedule gate deliberately mirrors the server's own contract — its status
+ * endpoint reads schedules via `inheritFreshConversationSchedules`, which uses
+ * them whenever `conversationSchedulesEnabled !== false`. Matching that exactly
+ * keeps these surfaces consistent with the presence pill (a stricter client-only
+ * rule would diverge from the pill for legacy/imported schedule-backed chats).
+ * Overrides are validated by `getActiveStatusOverride` (status enum + expiry),
+ * so a malformed or expired override falls through to the snapshot.
  */
 export function resolveLiveConversationStatus(
   meta: ConversationPresenceMeta | null | undefined,
@@ -40,7 +42,7 @@ export function resolveLiveConversationStatus(
     characterId
   ];
   const schedule =
-    meta.conversationSchedulesEnabled === true
+    meta.conversationSchedulesEnabled !== false
       ? (meta.characterSchedules as Record<string, WeekSchedule> | undefined)?.[characterId]
       : undefined;
   if (!getActiveStatusOverride(override, now) && !schedule) return null;

--- a/packages/client/src/lib/conversation-presence-status.ts
+++ b/packages/client/src/lib/conversation-presence-status.ts
@@ -1,0 +1,49 @@
+import {
+  getActiveStatusOverride,
+  getEffectiveCurrentStatus,
+  type ConversationPresenceStatus,
+  type ConversationStatusOverride,
+  type WeekSchedule,
+} from "@marinara-engine/shared";
+
+type ConversationPresenceMeta = {
+  conversationSchedulesEnabled?: unknown;
+  characterSchedules?: unknown;
+  conversationStatusOverrides?: unknown;
+};
+
+/**
+ * Resolve a character's live conversation presence the same way the server's
+ * status endpoint does — active manual override first, then the current schedule
+ * block — so the chat-list sidebar and the in-chat overlay agree with the
+ * presence pill instead of reading a generation-time snapshot.
+ *
+ * Returns `null` when there is no live signal (no active override and the chat
+ * has not opted into schedules), in which case the caller keeps the stored
+ * `conversationCharacterStatuses` snapshot. This is the single gate both client
+ * surfaces share, so they cannot drift on which metadata is allowed to drive
+ * live status.
+ *
+ * Schedules require an explicit `conversationSchedulesEnabled === true` opt-in
+ * (which the server sets whenever it generates schedules), so a stray or
+ * imported schedule-shaped payload cannot outvote the snapshot. Overrides are
+ * validated by `getActiveStatusOverride` (status enum + expiry), so a malformed
+ * or expired override also falls through to the snapshot.
+ */
+export function resolveLiveConversationStatus(
+  meta: ConversationPresenceMeta | null | undefined,
+  characterId: string,
+  now: Date,
+): { status: ConversationPresenceStatus; activity: string } | null {
+  if (!meta) return null;
+  const override = (meta.conversationStatusOverrides as Record<string, ConversationStatusOverride> | undefined)?.[
+    characterId
+  ];
+  const schedule =
+    meta.conversationSchedulesEnabled === true
+      ? (meta.characterSchedules as Record<string, WeekSchedule> | undefined)?.[characterId]
+      : undefined;
+  if (!getActiveStatusOverride(override, now) && !schedule) return null;
+  const { status, activity } = getEffectiveCurrentStatus(schedule, override, now);
+  return { status, activity };
+}

--- a/packages/server/src/services/conversation/schedule.service.ts
+++ b/packages/server/src/services/conversation/schedule.service.ts
@@ -6,53 +6,30 @@
 
 import { createLLMProvider } from "../llm/provider-registry.js";
 import type { BaseLLMProvider } from "../llm/base-provider.js";
-import type { ConversationPresenceStatus, ConversationStatusOverride } from "@marinara-engine/shared";
+import {
+  CONVERSATION_SCHEDULE_DAYS,
+  getActiveStatusOverride,
+  getCurrentStatus,
+  getEffectiveCurrentStatus,
+  type CharacterSchedules,
+  type ConversationPresenceStatus,
+  type ConversationStatusOverride,
+  type CurrentConversationStatus,
+  type DaySchedule,
+  type ScheduleBlock,
+  type WeekSchedule,
+} from "@marinara-engine/shared";
 
-// ── Types ──
-
-/** A single time block in a character's daily schedule */
-export interface ScheduleBlock {
-  /** Hour range, e.g. "06:00-08:00" */
-  time: string;
-  /** What the character is doing */
-  activity: string;
-  /** Derived status for this block */
-  status: ConversationPresenceStatus;
-}
-
-/** One day of a character's schedule */
-export type DaySchedule = ScheduleBlock[];
-
-/** Full weekly schedule for a character */
-export interface WeekSchedule {
-  /** ISO date string of the Monday this schedule starts */
-  weekStart: string;
-  /** Schedules keyed by day name */
-  days: Record<string, DaySchedule>;
-  /** How many minutes of user inactivity before this character messages unprompted (0 = never) */
-  inactivityThresholdMinutes: number;
-  /** Optional exact response delay in minutes while idle */
-  idleResponseDelayMinutes?: number;
-  /** Optional exact response delay in minutes while busy / DND */
-  dndResponseDelayMinutes?: number;
-  /** How chatty the character is — affects autonomous messaging frequency (0-100) */
-  talkativeness: number;
-}
-
-/** All character schedules stored in chat metadata */
-export interface CharacterSchedules {
-  [characterId: string]: WeekSchedule;
-}
-
-export interface CurrentConversationStatus {
-  status: ConversationPresenceStatus;
-  activity: string;
-  override?: ConversationStatusOverride;
-}
+// The schedule/override status-derivation helpers and their schedule types now
+// live in @marinara-engine/shared so the client presence dots derive status the
+// same way the server does. Re-export them here so existing server imports from
+// "./schedule.service.js" keep resolving unchanged.
+export { getActiveStatusOverride, getCurrentStatus, getEffectiveCurrentStatus };
+export type { CharacterSchedules, CurrentConversationStatus, DaySchedule, ScheduleBlock, WeekSchedule };
 
 // ── Constants ──
 
-const DAYS = ["Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday", "Sunday"];
+const DAYS = CONVERSATION_SCHEDULE_DAYS;
 
 const STATUS_KEYWORDS: Record<string, ConversationPresenceStatus> = {
   sleep: "offline",
@@ -275,72 +252,8 @@ function inferStatusFromActivity(activity: string): ConversationPresenceStatus {
 }
 
 // ── Status Derivation ──
-
-/**
- * Get the current status and activity for a character based on their schedule.
- */
-export function getCurrentStatus(
-  schedule: WeekSchedule,
-  now: Date = new Date(),
-): { status: ConversationPresenceStatus; activity: string } {
-  const dayName = DAYS[(now.getDay() + 6) % 7]!; // JS Sunday=0, we want Monday=0
-  const daySchedule = schedule.days[dayName];
-  if (!daySchedule || daySchedule.length === 0) {
-    return { status: "online", activity: "free time" };
-  }
-
-  const currentMinutes = now.getHours() * 60 + now.getMinutes();
-
-  for (const block of daySchedule) {
-    const [startStr, endStr] = block.time.split("-");
-    if (!startStr || !endStr) continue;
-
-    const [sh, sm] = startStr.split(":").map(Number);
-    const [eh, em] = endStr.split(":").map(Number);
-    const startMin = (sh ?? 0) * 60 + (sm ?? 0);
-    const endMin = (eh ?? 0) * 60 + (em ?? 0);
-
-    // Handle blocks that don't wrap around midnight
-    if (startMin <= currentMinutes && currentMinutes < endMin) {
-      return { status: block.status, activity: block.activity };
-    }
-    // Handle midnight-wrapping blocks (e.g., 23:00-07:00)
-    if (startMin > endMin && (currentMinutes >= startMin || currentMinutes < endMin)) {
-      return { status: block.status, activity: block.activity };
-    }
-  }
-
-  return { status: "online", activity: "free time" };
-}
-
-function isManualPresenceStatus(value: unknown): value is ConversationStatusOverride["status"] {
-  return value === "online" || value === "idle" || value === "dnd" || value === "offline";
-}
-
-export function getActiveStatusOverride(
-  override: ConversationStatusOverride | null | undefined,
-  now: Date = new Date(),
-): ConversationStatusOverride | null {
-  if (!override || !isManualPresenceStatus(override.status)) return null;
-  if (typeof override.expiresAt === "string") {
-    const expiresAt = new Date(override.expiresAt).getTime();
-    if (!override.expiresAt.trim() || !Number.isFinite(expiresAt) || expiresAt <= now.getTime()) return null;
-  }
-  return override;
-}
-
-export function getEffectiveCurrentStatus(
-  schedule: WeekSchedule | null | undefined,
-  override: ConversationStatusOverride | null | undefined,
-  now: Date = new Date(),
-  fallbackActivity = "free time",
-): CurrentConversationStatus {
-  const scheduled = schedule ? getCurrentStatus(schedule, now) : { status: "online" as const, activity: fallbackActivity };
-  const activeOverride = getActiveStatusOverride(override, now);
-  if (!activeOverride) return scheduled;
-  const activity = typeof activeOverride.activity === "string" ? activeOverride.activity.trim() : scheduled.activity;
-  return { status: activeOverride.status, activity, override: activeOverride };
-}
+// getCurrentStatus / getActiveStatusOverride / getEffectiveCurrentStatus moved to
+// @marinara-engine/shared (utils/conversation-presence) — imported + re-exported above.
 
 /**
  * Get a human-readable summary of today's schedule for a character.

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -95,3 +95,4 @@ export * from "./utils/thinking-tags.js";
 export * from "./utils/lorebook-folder-tree.js";
 export * from "./utils/text-matching.js";
 export * from "./utils/sprite-labels.js";
+export * from "./utils/conversation-presence.js";

--- a/packages/shared/src/utils/conversation-presence.ts
+++ b/packages/shared/src/utils/conversation-presence.ts
@@ -1,0 +1,132 @@
+// ──────────────────────────────────────────────
+// Conversation Presence — schedule/override status derivation
+// ──────────────────────────────────────────────
+// Pure helpers shared by the server (schedule service, generation, autonomous
+// scheduler, status route) and the client (chat list + in-chat presence dots)
+// so every surface derives a character's current conversation status the same
+// way: active manual override > current schedule block > "online" default.
+
+import type { ConversationPresenceStatus, ConversationStatusOverride } from "../types/chat.js";
+
+// ── Types ──
+
+/** A single time block in a character's daily schedule */
+export interface ScheduleBlock {
+  /** Hour range, e.g. "06:00-08:00" */
+  time: string;
+  /** What the character is doing */
+  activity: string;
+  /** Derived status for this block */
+  status: ConversationPresenceStatus;
+}
+
+/** One day of a character's schedule */
+export type DaySchedule = ScheduleBlock[];
+
+/** Full weekly schedule for a character */
+export interface WeekSchedule {
+  /** ISO date string of the Monday this schedule starts */
+  weekStart: string;
+  /** Schedules keyed by day name */
+  days: Record<string, DaySchedule>;
+  /** How many minutes of user inactivity before this character messages unprompted (0 = never) */
+  inactivityThresholdMinutes: number;
+  /** Optional exact response delay in minutes while idle */
+  idleResponseDelayMinutes?: number;
+  /** Optional exact response delay in minutes while busy / DND */
+  dndResponseDelayMinutes?: number;
+  /** How chatty the character is — affects autonomous messaging frequency (0-100) */
+  talkativeness: number;
+}
+
+/** All character schedules stored in chat metadata */
+export interface CharacterSchedules {
+  [characterId: string]: WeekSchedule;
+}
+
+export interface CurrentConversationStatus {
+  status: ConversationPresenceStatus;
+  activity: string;
+  override?: ConversationStatusOverride;
+}
+
+// ── Constants ──
+
+/** Schedule day order, Monday-first to match getDay() remapping below. */
+export const CONVERSATION_SCHEDULE_DAYS = [
+  "Monday",
+  "Tuesday",
+  "Wednesday",
+  "Thursday",
+  "Friday",
+  "Saturday",
+  "Sunday",
+];
+
+// ── Status Derivation ──
+
+/**
+ * Get the current status and activity for a character based on their schedule.
+ */
+export function getCurrentStatus(
+  schedule: WeekSchedule,
+  now: Date = new Date(),
+): { status: ConversationPresenceStatus; activity: string } {
+  const dayName = CONVERSATION_SCHEDULE_DAYS[(now.getDay() + 6) % 7]!; // JS Sunday=0, we want Monday=0
+  const daySchedule = schedule.days[dayName];
+  if (!daySchedule || daySchedule.length === 0) {
+    return { status: "online", activity: "free time" };
+  }
+
+  const currentMinutes = now.getHours() * 60 + now.getMinutes();
+
+  for (const block of daySchedule) {
+    const [startStr, endStr] = block.time.split("-");
+    if (!startStr || !endStr) continue;
+
+    const [sh, sm] = startStr.split(":").map(Number);
+    const [eh, em] = endStr.split(":").map(Number);
+    const startMin = (sh ?? 0) * 60 + (sm ?? 0);
+    const endMin = (eh ?? 0) * 60 + (em ?? 0);
+
+    // Handle blocks that don't wrap around midnight
+    if (startMin <= currentMinutes && currentMinutes < endMin) {
+      return { status: block.status, activity: block.activity };
+    }
+    // Handle midnight-wrapping blocks (e.g., 23:00-07:00)
+    if (startMin > endMin && (currentMinutes >= startMin || currentMinutes < endMin)) {
+      return { status: block.status, activity: block.activity };
+    }
+  }
+
+  return { status: "online", activity: "free time" };
+}
+
+function isManualPresenceStatus(value: unknown): value is ConversationStatusOverride["status"] {
+  return value === "online" || value === "idle" || value === "dnd" || value === "offline";
+}
+
+export function getActiveStatusOverride(
+  override: ConversationStatusOverride | null | undefined,
+  now: Date = new Date(),
+): ConversationStatusOverride | null {
+  if (!override || !isManualPresenceStatus(override.status)) return null;
+  if (typeof override.expiresAt === "string") {
+    const expiresAt = new Date(override.expiresAt).getTime();
+    if (!override.expiresAt.trim() || !Number.isFinite(expiresAt) || expiresAt <= now.getTime()) return null;
+  }
+  return override;
+}
+
+export function getEffectiveCurrentStatus(
+  schedule: WeekSchedule | null | undefined,
+  override: ConversationStatusOverride | null | undefined,
+  now: Date = new Date(),
+  fallbackActivity = "free time",
+): CurrentConversationStatus {
+  const scheduled = schedule ? getCurrentStatus(schedule, now) : { status: "online" as const, activity: fallbackActivity };
+  const activeOverride = getActiveStatusOverride(override, now);
+  if (!activeOverride) return scheduled;
+  const activity = typeof activeOverride.activity === "string" ? activeOverride.activity.trim() : scheduled.activity;
+  return { status: activeOverride.status, activity, override: activeOverride };
+}


### PR DESCRIPTION
## Linked issue

Closes #2826

## Why this change

In Conversation mode, a character's presence status dot in the chat-list sidebar (and the in-chat avatar overlay) did not match the status shown in the toolbar presence pill. After a status change — a manual override set in the pill, or a generated schedule crossing into a new time block — the pill updated immediately while the chat-list dot kept showing the old status until the next generated message.

Root cause: the sidebar and the in-chat overlay color the dot from the per-chat `conversationCharacterStatuses` snapshot, which is only rewritten by the generation pipeline (`generate.routes.ts`). The presence pill instead reads the live status from `GET /conversation/status/:chatId`, which derives it as `active override > current schedule block > default`. So between generations the two surfaces diverge.

## What changed

- Extracted the status-derivation helpers (`getCurrentStatus`, `getActiveStatusOverride`, `getEffectiveCurrentStatus`) and their schedule types (`ScheduleBlock`, `WeekSchedule`, `CharacterSchedules`, `CurrentConversationStatus`) from `packages/server/.../schedule.service.ts` into `@marinara-engine/shared` (`utils/conversation-presence.ts`) so the client can derive presence the same way the server does. This is the single source of truth for "what status is this character right now".
- `schedule.service.ts` now imports and **re-exports** those helpers/types, so every existing server call site (`conversation.routes.ts`, `generate.routes.ts`, the autonomous scheduler, etc.) is unchanged — this is a behavior-preserving move on the server side.
- `ChatSidebar.tsx` (chat-list dots) and `ChatArea.tsx` (in-chat avatar overlay) now prefer the live `override > schedule` status over the generation-time snapshot, falling back to the snapshot when there is no active override or schedule. Schedules are gated by `conversationSchedulesEnabled`, matching the server.
- No change to the server's status computation, the generation snapshot write, or the persisted metadata shape.

## Validation

- [x] `pnpm check` passes locally
- [x] Container (Docker / Podman) built and ran without issue
- [x] Ran the app, clicked through the changes manually
- [x] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [x] Above manual verification completed (describe below)
- [x] Read and followed `CONTRIBUTING.md`

### Manual verification notes

- `pnpm check` (clean + impeccable + lint + build) passes locally; the extracted helpers also have local unit coverage for the precedence (override beats schedule), override expiry, and midnight-wrapping schedule blocks.
- Reproduced and verified on a build deployed to my private EasyPanel instance, in Conversation mode:
  - With a generation-time snapshot of `online` and a manual `offline` + "sleeping" override active: **before** this change the presence pill showed gray/"sleeping" while the chat-list dot stayed green; **after**, the chat-list dot is gray, matching the pill.
  - Clearing the override reverts both the pill and the chat-list dot to the snapshot/default (green/Online) — confirming the active-override gate falls through correctly and does not strand a stale value.
- Still worth a maintainer double-check: a character with a **generated schedule** crossing a time block (covered by unit tests but I didn't drive a live schedule transition), and a **multi-character** conversation chat's combined dot.

## Docs and release impact

- [x] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Version/release files updated (only if this PR includes a version bump)

## UI evidence (if applicable)

Conversation-mode chat list, single character with an active `offline` + "sleeping" override (snapshot = `online`):

- Before: presence pill = gray dot + "sleeping"; chat-list sidebar dot = green (stale).
- After: presence pill = gray dot + "sleeping"; chat-list sidebar dot = gray (matches).

