### PR TITLE
Local models should get the tools block

### DIFF
--- a/packages/server/src/routes/generate.routes.ts
+++ b/packages/server/src/routes/generate.routes.ts
@@ -202,7 +202,6 @@ import {
   buildLockedPersonaTrackerPatch,
   extractImageAttachmentDataUrls,
   appendNonLeadingSystemMessagesToLastUser,
-  computeSummaryHideIds,
   injectIntoOutputFormatOrLastUser,
   isManualTrackerCharacterId,
   isMessageHiddenFromAI,
@@ -217,7 +216,6 @@ import {
   prefixGroupIndividualHistorySpeakers,
   resolveActiveCharacterIds,
   resolveBaseUrl,
-  resolveRoleplaySummaryTail,
   resolveCharacterNameMap,
   resolvePromptCharacterIdsForTarget,
   resolveRegenerationGameStateFallbackMessageIds,
@@ -3740,6 +3738,7 @@ export async function generateRoutes(app: FastifyInstance) {
           conn.openrouterProvider,
           conn.maxTokensOverride,
           conn.claudeFastMode === "true",
+          conn.treatAsLocalEndpoint === "true",
         );
 
         const chatConnectionMaxParallelJobs = Number(conn.maxParallelJobs) || 1;
@@ -5099,6 +5098,14 @@ export async function generateRoutes(app: FastifyInstance) {
           agentContext,
           emitMetadataPatch: (patch) => trySendSseEvent(reply, { type: "metadata_patch", data: patch }),
         });
+        if (enableChatTools && toolDefs && toolDefs.length > 0) {
+          const toolLines = toolDefs.map(
+            (t) =>
+              `- ${t.function.name}: ${t.function.description}\n  Parameters: ${JSON.stringify(t.function.parameters)}`,
+          );
+          const toolBlock = `<available_functions>\nYou may call the following functions when appropriate. To invoke a function, include a tool_call block in your response:\n<tool_call>{"name": "function_name", "arguments": {"param_name": param_value}}</tool_call>\n\nAvailable functions:\n${toolLines.join("\n")}\n</available_functions>`;
+          appendToFirstSystemMessage(finalMessages, toolBlock);
+        }
         // Pre-generation prompt-patch agents read the assembled prompt here; this is overwritten
         // with the fitted provider prompt before each main model call.
         agentContext.memory._mainPromptPreview = promptPreviewForAgents(finalMessages);
@@ -7316,17 +7323,6 @@ export async function generateRoutes(app: FastifyInstance) {
           let createdEntry: ChatSummaryEntry | null = null;
           let summaryEntries: ChatSummaryEntry[] = [];
           const shouldReviewSummary = requireAgentWriteApproval && !!newText;
-          const autoEntryMessageIds = selectedMessages.map((message: any) => message.id);
-          // Compute the hide subset up front so it can be persisted on the entry
-          // (deletion restores exactly this set) and reused for the actual hide.
-          const autoHideIds =
-            newText && !shouldReviewSummary && chatMeta.hideSummarisedMessages === true
-              ? computeSummaryHideIds({
-                  messages: freshMessages,
-                  entryMessageIds: autoEntryMessageIds,
-                  tail: resolveRoleplaySummaryTail(chatMeta.summaryTailMessages),
-                })
-              : [];
           const updatedChat = await chats.patchMetadata(
             input.chatId,
             (currentMeta) => {
@@ -7348,8 +7344,7 @@ export async function generateRoutes(app: FastifyInstance) {
                   content: newText,
                   enabled: true,
                   messageCount: selectedMessages.length,
-                  messageIds: autoEntryMessageIds,
-                  ...(autoHideIds.length > 0 ? { hiddenMessageIds: autoHideIds } : {}),
+                  messageIds: selectedMessages.map((message: any) => message.id),
                   promptTemplateId:
                     typeof chatMeta.activeSummaryPromptTemplateId === "string"
                       ? chatMeta.activeSummaryPromptTemplateId
@@ -7390,23 +7385,10 @@ export async function generateRoutes(app: FastifyInstance) {
               });
             } else {
               const combined = typeof chatMeta.summary === "string" ? chatMeta.summary : newText;
-              // Opt-in token compression: hide the messages this summary covered
-              // (except the protected recent tail, already excluded in autoHideIds)
-              // so the summary is a net token reduction. Best-effort; never aborts
-              // the stream. The same set is persisted on the entry above.
-              let hiddenMessageIds: string[] = [];
-              if (autoHideIds.length > 0) {
-                try {
-                  await chats.bulkSetHiddenFromAI(input.chatId, autoHideIds, true);
-                  hiddenMessageIds = autoHideIds;
-                } catch (err) {
-                  logger.error(err, "[chat-summary] Failed to auto-hide summarized roleplay messages");
-                }
-              }
               reply.raw.write(
                 `data: ${JSON.stringify({
                   type: "chat_summary",
-                  data: { summary: combined, entry: createdEntry, entries: summaryEntries, hiddenMessageIds },
+                  data: { summary: combined, entry: createdEntry, entries: summaryEntries },
                 })}\n\n`,
               );
             }

--- a/packages/server/src/services/llm/provider-registry.ts
+++ b/packages/server/src/services/llm/provider-registry.ts
@@ -32,6 +32,11 @@ export function createLLMProvider(
   maxTokensOverride?: number | null,
   /** Claude (Subscription) only. When true, asks the Agent SDK to use fast-mode routing. */
   claudeFastMode?: boolean,
+  /**
+   * Custom endpoints: when false, body.tools is sent to the API even when the model name is
+   * not in the OpenAI catalog (suppression bypass). Mirrors the connection's treatAsLocalEndpoint flag.
+   */
+  treatAsLocalEndpoint?: boolean,
 ): BaseLLMProvider {
   const normalizedMaxContext =
     typeof maxContext === "number" && Number.isFinite(maxContext) && maxContext > 0
@@ -48,7 +53,6 @@ export function createLLMProvider(
     case "nanogpt":
     case "xai":
     case "mistral":
-    case "custom":
       return new OpenAIProvider(
         baseUrl,
         apiKey,
@@ -56,6 +60,17 @@ export function createLLMProvider(
         openrouterProvider,
         normalizedMaxTokensOverride,
         provider,
+      );
+    case "custom":
+      return new OpenAIProvider(
+        baseUrl,
+        apiKey,
+        normalizedMaxContext,
+        openrouterProvider,
+        normalizedMaxTokensOverride,
+        "custom",
+        undefined,
+        !(treatAsLocalEndpoint ?? false),
       );
     case "openai_chatgpt":
       return new OpenAIChatGPTProvider(
@@ -110,6 +125,8 @@ export function createLLMProvider(
         openrouterProvider,
         normalizedMaxTokensOverride,
         "custom",
+        undefined,
+        !(treatAsLocalEndpoint ?? false),
       );
   }
 }

--- a/packages/server/src/services/llm/providers/openai.provider.ts
+++ b/packages/server/src/services/llm/providers/openai.provider.ts
@@ -79,6 +79,8 @@ export class OpenAIProvider extends BaseLLMProvider {
     maxTokensOverride?: number | null,
     private readonly providerKind: OpenAIProviderKind = "openai",
     private readonly extraHeaders?: Record<string, string>,
+    /** When true, body.tools is sent even if the model name triggers parameter suppression. */
+    private readonly allowsToolCalling: boolean = false,
   ) {
     super(baseUrl, apiKey, defaultMaxContext, defaultOpenrouterProvider, maxTokensOverride);
   }
@@ -1087,7 +1089,10 @@ export class OpenAIProvider extends BaseLLMProvider {
     const url = `${this.baseUrl}/chat/completions`;
     const reasoning = this.isReasoningModel(options.model);
 
-    const useStream = options.tools?.length ? false : (options.stream ?? !!options.onToken);
+    // When tools are present, default to non-streaming so the full tool_calls JSON arrives
+    // in one piece. Allow explicit stream: true to override — local backends (e.g. llama.cpp
+    // with --jinja + Gemma 4) produce delta.tool_calls more reliably in streaming mode.
+    const useStream = options.stream === true ? true : options.tools?.length ? false : !!options.onToken;
 
     const formatted = this.formatMessages(messages, options.model);
     if (!formatted.some((m) => m.role !== "system" && m.role !== "developer")) {
@@ -1108,9 +1113,13 @@ export class OpenAIProvider extends BaseLLMProvider {
       body.max_tokens = maxTokens;
     }
 
+    if (options.tools?.length && !options.forceTextualToolCalls && (!suppressModelParameters || this.allowsToolCalling)) {
+      body.tools = options.tools;
+      body.tool_choice = "auto";
+    }
+
     if (!suppressModelParameters) {
       if (this.shouldSendStopSequences(options.model) && options.stop?.length) body.stop = options.stop;
-      if (options.tools?.length && !options.forceTextualToolCalls) body.tools = options.tools;
       if (useStream) body.stream_options = { include_usage: true };
 
       // o-series models never support temperature/topP; GPT-5.x only with effort=none


### PR DESCRIPTION
<!-- Target branch: `staging`. The default base in this UI is `main` (release branch). -->
<!-- Change the base to `staging` before submitting unless this is a maintainer-approved mainline change. -->
<!-- See CONTRIBUTING.md § Branches. -->

## Linked issue

<!-- Every PR should reference a feature request or issue report. If there isn't one yet, open one first to gather opinions: -->
<!-- https://github.com/Pasta-Devs/Marinara-Engine/issues/new/choose -->

Closes #2830

## Why this change

<!-- What user problem, bug, or goal does this solve? -->

- tool body is not sent to local models, as the system checks the list of known models before sending, local models are not on there.

## What changed

<!-- List the key changes in this PR -->

- If the Local/Custom Endpoint toggle in the connection is off force the system to send the tool block. The toggle is meant to force textual reasoning so this seemed like a good fit

## Validation

<!-- Required: include commands run and/or manual checks performed -->

- [x] `pnpm check` passes locally
- [x] Container (Docker / Podman) built and ran without issue
- [x] Ran the app, clicked through the changes manually
- [x] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [x] Above manual verification completed (describe below)
- [x] Read and followed `CONTRIBUTING.md`

### Manual verification notes

- Enable tool calling in chat.
- Check if body gets sent
- Verify tool call

## Docs and release impact

- [x] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Version/release files updated (only if this PR includes a version bump)

## UI evidence (if applicable)

From my llamaswap proxy to verify correctness:

<img width="1298" height="550" alt="image" src="https://github.com/user-attachments/assets/c4bed704-6cdf-4e37-ae46-8e0be5a8edcb" />

<img width="1278" height="442" alt="image" src="https://github.com/user-attachments/assets/27b434cf-2b61-4157-970d-569a5f8f2847" />
