### PR TITLE
fix(summary): restore auto-hide for roleplay rolling summaries

### DIFF
--- a/packages/server/src/routes/generate.routes.ts
+++ b/packages/server/src/routes/generate.routes.ts
@@ -203,6 +203,7 @@ import {
   buildLockedPersonaTrackerPatch,
   extractImageAttachmentDataUrls,
   appendNonLeadingSystemMessagesToLastUser,
+  computeSummaryHideIds,
   injectIntoOutputFormatOrLastUser,
   isManualTrackerCharacterId,
   isMessageHiddenFromAI,
@@ -217,6 +218,7 @@ import {
   prefixGroupIndividualHistorySpeakers,
   resolveActiveCharacterIds,
   resolveBaseUrl,
+  resolveRoleplaySummaryTail,
   resolveCharacterNameMap,
   resolvePromptCharacterIdsForTarget,
   resolveRegenerationGameStateFallbackMessageIds,
@@ -7407,6 +7409,17 @@ export async function generateRoutes(app: FastifyInstance) {
           let createdEntry: ChatSummaryEntry | null = null;
           let summaryEntries: ChatSummaryEntry[] = [];
           const shouldReviewSummary = requireAgentWriteApproval && !!newText;
+          const autoEntryMessageIds = selectedMessages.map((message: any) => message.id);
+          // Compute the hide subset up front so it can be persisted on the entry
+          // (deletion restores exactly this set) and reused for the actual hide.
+          const autoHideIds =
+            newText && !shouldReviewSummary && chatMeta.hideSummarisedMessages === true
+              ? computeSummaryHideIds({
+                  messages: freshMessages,
+                  entryMessageIds: autoEntryMessageIds,
+                  tail: resolveRoleplaySummaryTail(chatMeta.summaryTailMessages),
+                })
+              : [];
           const updatedChat = await chats.patchMetadata(
             input.chatId,
             (currentMeta) => {
@@ -7428,7 +7441,8 @@ export async function generateRoutes(app: FastifyInstance) {
                   content: newText,
                   enabled: true,
                   messageCount: selectedMessages.length,
-                  messageIds: selectedMessages.map((message: any) => message.id),
+                  messageIds: autoEntryMessageIds,
+                  ...(autoHideIds.length > 0 ? { hiddenMessageIds: autoHideIds } : {}),
                   promptTemplateId:
                     typeof chatMeta.activeSummaryPromptTemplateId === "string"
                       ? chatMeta.activeSummaryPromptTemplateId
@@ -7469,10 +7483,23 @@ export async function generateRoutes(app: FastifyInstance) {
               });
             } else {
               const combined = typeof chatMeta.summary === "string" ? chatMeta.summary : newText;
+              // Opt-in token compression: hide the messages this summary covered
+              // (except the protected recent tail, already excluded in autoHideIds)
+              // so the summary is a net token reduction. Best-effort; never aborts
+              // the stream. The same set is persisted on the entry above.
+              let hiddenMessageIds: string[] = [];
+              if (autoHideIds.length > 0) {
+                try {
+                  await chats.bulkSetHiddenFromAI(input.chatId, autoHideIds, true);
+                  hiddenMessageIds = autoHideIds;
+                } catch (err) {
+                  logger.error(err, "[chat-summary] Failed to auto-hide summarized roleplay messages");
+                }
+              }
               reply.raw.write(
                 `data: ${JSON.stringify({
                   type: "chat_summary",
-                  data: { summary: combined, entry: createdEntry, entries: summaryEntries },
+                  data: { summary: combined, entry: createdEntry, entries: summaryEntries, hiddenMessageIds },
                 })}\n\n`,
               );
             }


### PR DESCRIPTION
## Linked issue

Re-applies the auto-hide behavior from #2820 / #2821, which regressed on `staging` after merge. No separate regression issue was opened — this PR documents the regression below.

## Why this change

The roleplay rolling-summary auto-hide shipped in #2821, but commit `f955a646` ("Local models should get the tools block") inadvertently reverted it. That commit's branch was based on an older `staging` (before #2821 merged); when it landed, its copy of `generate.routes.ts` overwrote the auto-hide orchestration while correctly adding the tools block. As a result, **automatic** rolling summaries stopped hiding the messages they covered, so the summary no longer reduces prompt tokens.

Manual summaries and unhide-on-delete were not touched by the conflict and still work — only the automatic path regressed. The supporting helpers (`computeSummaryHideIds`, `resolveRoleplaySummaryTail`), the storage method (`bulkSetHiddenFromAI`), and the manual-hide route all survived, so this is a faithful re-application with no new logic.

## What changed

`packages/server/src/routes/generate.routes.ts` (automatic-summary path only):

- Re-add the `computeSummaryHideIds` / `resolveRoleplaySummaryTail` imports.
- Recompute `autoHideIds` up front, gated on the per-chat `hideSummarisedMessages` setting and excluding the protected recent tail (`summaryTailMessages`).
- Persist `hiddenMessageIds` on the summary entry so deleting the entry restores exactly the set it hid.
- Call `bulkSetHiddenFromAI` and echo `hiddenMessageIds` back in the `chat_summary` SSE payload.

The tools-block change from `f955a646` is left intact (verified present after this patch).

## Validation

- [ ] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed `CONTRIBUTING.md`

### Manual verification notes

- `pnpm check` run locally → exit 0 (TypeScript + ESLint + client build all clean).
- The two restored blocks were diffed byte-for-byte against their #2821 originals — identical.
- To verify in a running app: in roleplay mode, enable **Hide summarised messages**, trigger an automatic rolling summary, and confirm the covered messages (minus the recent tail) become hidden from the AI; then delete the summary entry and confirm exactly those messages unhide.

## Docs and release impact

- [x] No docs changes needed

## UI evidence (if applicable)

Server-only change; no UI surface added. Behavior is observable via the message hidden-from-AI state after an automatic summary.
