### PR TITLE
Prepare v2.0.4 stabilization polish

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,12 +6,23 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 
 ## [2.0.4]
 
+### Added
+
+- Added Game mode HUD widget import/export controls in Chat Settings and the Game Setup Wizard so widget layouts can be reused between games.
+
 ### Fixed
 
 - Fixed Roleplay streaming so failed post-processing/rewrite agent calls no longer drop the Typewriter effect from the final generated message.
 - Fixed Roleplay Chat Settings preset-variable configuration so clicking inside the "Configure Preset Variables" modal no longer closes Chat Settings before users can edit choices.
 - Fixed `/continue` so it can find the latest assistant message even when the transcript tail is not an assistant turn, injects a continuation cue into the prompt, and appends the model output to the continued assistant message.
 - Fixed Professor Mari's home-page chat connection so the selected connection is remembered across Marinara restarts instead of resetting to the first/default connection.
+- Fixed legacy group chats with the old Professor Mari character so those chats can still resolve her restored card while keeping the home-page assistant avatar out of Roleplay/Game expression matching.
+- Fixed agent activation regressions after removing the old global enabled state so adding agents to chats no longer depends on a legacy per-agent flag.
+- Fixed pinned Gallery images so pinned chat images persist across refresh/restart/chat switches and pinning from the full image view actually pins instead of only closing the lightbox.
+- Fixed Active Context lorebook reporting so Conversation, Roleplay, and Game modes show the cached lorebook scan from the last generation instead of a best-effort rescan that could disagree with the prompt.
+- Fixed Lorebook recursion defaults by making recursion opt-in with a "Recursion" toggle that is off by default for new/imported entries, and fixed keyword entry so pending keys are added when the user clicks away.
+- Fixed Game mode generated NPC portrait prompts so NPC descriptions created during world setup are available to portrait generation even when the NPC is not in the character library.
+- Fixed Characters and Lorebooks panel filters so search, sort, tag, category, and favorite filters persist while opening and returning from editors.
 - Fixed v2.0.4 release metadata across packages, the homepage-visible app version, Windows installer sources, PWA manifest, README release pointer, and Android APK metadata.
 
 ### Platform Notes

--- a/packages/client/src/components/bot-browser/BotBrowserView.tsx
+++ b/packages/client/src/components/bot-browser/BotBrowserView.tsx
@@ -53,6 +53,13 @@ const TAG_IMPORT_OPTIONS: Array<{ value: TagImportMode; label: string; descripti
 const SOURCE_MENU_MIN_WIDTH = 180;
 const SOURCE_MENU_MARGIN = 8;
 
+function encodeProxyPath(path: unknown): string {
+  return String(path ?? "")
+    .split("/")
+    .map((segment) => encodeURIComponent(segment))
+    .join("/");
+}
+
 interface BrowseCard {
   id: string;
   name: string;
@@ -378,7 +385,7 @@ const chubProvider: ProviderConfig = {
   extraToggles: [],
   nsfwAvailable: true,
   nsfwMode: "free",
-  getAvatarUrl: (card) => `/api/bot-browser/chub/avatar/${card.id}`,
+  getAvatarUrl: (card) => `/api/bot-browser/chub/avatar/${encodeProxyPath(card.id)}`,
   getExternalUrl: (card) => `https://chub.ai/characters/${card.id}`,
   search: async (p) => {
     const preset = CHUB_SORT_PRESETS.find((pr) => pr.value === p.sort) ?? CHUB_SORT_PRESETS[0];
@@ -416,7 +423,7 @@ const chubProvider: ProviderConfig = {
         creator: (n.fullPath || "").split("/")[0] || "",
         tagline: n.tagline || "",
         tags: n.topics || [],
-        avatarUrl: `/api/bot-browser/chub/avatar/${n.fullPath}`,
+        avatarUrl: `/api/bot-browser/chub/avatar/${encodeProxyPath(n.fullPath)}`,
         stat1: n.starCount || 0,
         stat1Label: "Downloads",
         stat1Icon: "download" as const,
@@ -483,7 +490,7 @@ const jannyProvider: ProviderConfig = {
   extraToggles: [{ key: "showLowQuality", label: "Show Low Quality", icon: "🚫" }],
   nsfwAvailable: true,
   nsfwMode: "free",
-  getAvatarUrl: (card) => `/api/bot-browser/janny/avatar/${(card._raw as any)?.avatar || ""}`,
+  getAvatarUrl: (card) => `/api/bot-browser/janny/avatar/${encodeProxyPath((card._raw as any)?.avatar || "")}`,
   getExternalUrl: (card) => {
     const raw = card._raw as any;
     const slug = card.name
@@ -624,7 +631,7 @@ const jannyProvider: ProviderConfig = {
         creator: h.creatorUsername || "",
         tagline: (h.description || "").replace(/<[^>]*>/g, "").slice(0, 200),
         tags: jannyTagNames(h.tagIds),
-        avatarUrl: h.avatar ? `/api/bot-browser/janny/avatar/${h.avatar}` : "",
+        avatarUrl: h.avatar ? `/api/bot-browser/janny/avatar/${encodeProxyPath(h.avatar)}` : "",
         stat1: h.totalToken || 0,
         stat1Label: "Tokens",
         stat1Icon: "hash" as const,
@@ -786,7 +793,7 @@ const chartavernProvider: ProviderConfig = {
   extraToggles: [{ key: "isOC", label: "Original Character", icon: "⭐" }],
   nsfwAvailable: false,
   nsfwMode: "login",
-  getAvatarUrl: (card) => `/api/bot-browser/chartavern/avatar/${card.id}`,
+  getAvatarUrl: (card) => `/api/bot-browser/chartavern/avatar/${encodeProxyPath(card.id)}`,
   getExternalUrl: (card) => `https://character-tavern.com/character/${card.id}`,
   search: async (p) => {
     const params = new URLSearchParams({
@@ -813,7 +820,7 @@ const chartavernProvider: ProviderConfig = {
         creator: h.author || (h.path || "").split("/")[0] || "",
         tagline: h.tagline || "",
         tags: Array.isArray(h.tags) ? h.tags : [],
-        avatarUrl: h.path ? `/api/bot-browser/chartavern/avatar/${h.path}` : "",
+        avatarUrl: h.path ? `/api/bot-browser/chartavern/avatar/${encodeProxyPath(h.path)}` : "",
         stat1: h.downloads || 0,
         stat1Label: "Downloads",
         stat1Icon: "download" as const,
@@ -881,7 +888,7 @@ const pygmalionProvider: ProviderConfig = {
     const av = raw?.avatarUrl;
     if (!av) return "";
     if (av.startsWith("http")) return `/api/bot-browser/pygmalion/avatar/${encodeURIComponent(av)}`;
-    return `/api/bot-browser/pygmalion/avatar/${av}`;
+    return `/api/bot-browser/pygmalion/avatar/${encodeProxyPath(av)}`;
   },
   getExternalUrl: (card) => `https://pygmalion.chat/character/${card.id}`,
   search: async (p) => {
@@ -908,7 +915,7 @@ const pygmalionProvider: ProviderConfig = {
         if (av) {
           avatarProxyUrl = av.startsWith("http")
             ? `/api/bot-browser/pygmalion/avatar/${encodeURIComponent(av)}`
-            : `/api/bot-browser/pygmalion/avatar/${av}`;
+            : `/api/bot-browser/pygmalion/avatar/${encodeProxyPath(av)}`;
         }
         return {
           id: c.id || "",
@@ -995,7 +1002,7 @@ const wyvernProvider: ProviderConfig = {
     const src = raw?.avatar_url || raw?.avatar;
     if (!src) return "";
     if (src.startsWith("http")) return `/api/bot-browser/wyvern/avatar/${encodeURIComponent(src)}`;
-    return `/api/bot-browser/wyvern/avatar/${src}/public`;
+    return `/api/bot-browser/wyvern/avatar/${encodeProxyPath(src)}/public`;
   },
   getExternalUrl: (card) => `https://app.wyvern.chat/characters/${card.id}`,
   search: async (p) => {
@@ -1024,7 +1031,7 @@ const wyvernProvider: ProviderConfig = {
         if (src) {
           avatarProxyUrl = src.startsWith("http")
             ? `/api/bot-browser/wyvern/avatar/${encodeURIComponent(src)}`
-            : `/api/bot-browser/wyvern/avatar/${src}/public`;
+            : `/api/bot-browser/wyvern/avatar/${encodeProxyPath(src)}/public`;
         }
         return {
           id: c.id || "",
@@ -1149,7 +1156,7 @@ const datacatProvider: ProviderConfig = {
     const av = raw?.avatar || "";
     if (!av) return "";
     if (av.startsWith("http")) return `/api/bot-browser/datacat/avatar/${encodeURIComponent(av)}`;
-    return `/api/bot-browser/datacat/avatar/${av}`;
+    return `/api/bot-browser/datacat/avatar/${encodeProxyPath(av)}`;
   },
   getExternalUrl: (card) => {
     const raw = card._raw as any;
@@ -1229,7 +1236,7 @@ const datacatProvider: ProviderConfig = {
         const avatarProxyUrl = av
           ? av.startsWith("http")
             ? `/api/bot-browser/datacat/avatar/${encodeURIComponent(av)}`
-            : `/api/bot-browser/datacat/avatar/${av}`
+            : `/api/bot-browser/datacat/avatar/${encodeProxyPath(av)}`
           : "";
         const charId = c.characterId || c.character_id || c.id || "";
         return {

--- a/packages/client/src/components/chat/ChatArea.tsx
+++ b/packages/client/src/components/chat/ChatArea.tsx
@@ -618,19 +618,14 @@ export function ChatArea() {
     const map: CharacterMap = new Map();
     if (!allCharacters) return map;
     for (const char of allCharacters as CharacterRow[]) {
-      if (suppressBuiltInProfessorMari && char.id === PROFESSOR_MARI_ID) continue;
       map.set(char.id, toCharacterMapValue(char));
     }
     return map;
-  }, [allCharacters, suppressBuiltInProfessorMari]);
+  }, [allCharacters]);
 
   const missingChatCharacterIds = useMemo(
-    () =>
-      chatCharIds.filter((id) => {
-        if (suppressBuiltInProfessorMari && id === PROFESSOR_MARI_ID) return false;
-        return !baseCharacterMap.has(id);
-      }),
-    [baseCharacterMap, chatCharIds, suppressBuiltInProfessorMari],
+    () => chatCharIds.filter((id) => !baseCharacterMap.has(id)),
+    [baseCharacterMap, chatCharIds],
   );
   const missingCharacterQueries = useQueries({
     queries: missingChatCharacterIds.map((id) => ({
@@ -1087,7 +1082,7 @@ export function ChatArea() {
     [chat?.id, hasCustomSpritePlacements, patchLocalSpriteVisualSettings, spritePlacements, spritePosition],
   );
 
-  // Set of enabled agent type IDs (respects both global enableAgents toggle and per-chat agent list)
+  // Set of active agent type IDs for this chat.
   const enabledAgentTypes = useMemo(() => {
     const set = new Set<string>();
     if (!chatMeta.enableAgents) return set;

--- a/packages/client/src/components/chat/ChatGallery.tsx
+++ b/packages/client/src/components/chat/ChatGallery.tsx
@@ -90,6 +90,13 @@ export function ChatGallery({ chatId, mode, onIllustrate }: ChatGalleryProps) {
     }
   };
 
+  const handlePinImage = useCallback(
+    (image: ChatImage) => {
+      pinImage({ ...image, chatId });
+    },
+    [chatId, pinImage],
+  );
+
   const handleInsertAsset = useCallback(
     (asset: ChatAssetBrowserItem) => {
       const label = asset.prompt.trim() || asset.name;
@@ -187,7 +194,7 @@ export function ChatGallery({ chatId, mode, onIllustrate }: ChatGalleryProps) {
                     <div className="flex gap-1">
                       <button
                         type="button"
-                        onClick={() => pinImage(img)}
+                        onClick={() => handlePinImage(img)}
                         aria-label="Pin image to chat"
                         className="pointer-events-auto rounded-md bg-white/20 p-1.5 text-white transition-colors hover:bg-white/30"
                         title="Pin to chat"
@@ -334,7 +341,9 @@ export function ChatGallery({ chatId, mode, onIllustrate }: ChatGalleryProps) {
         )}
 
       {/* Lightbox */}
-      {lightbox && <ChatImageLightbox image={lightbox} onClose={() => setLightbox(null)} />}
+      {lightbox && (
+        <ChatImageLightbox image={lightbox} onPin={handlePinImage} onClose={() => setLightbox(null)} />
+      )}
     </>
   );
 }

--- a/packages/client/src/components/chat/ChatImageLightbox.tsx
+++ b/packages/client/src/components/chat/ChatImageLightbox.tsx
@@ -25,6 +25,7 @@ interface ChatImageLightboxProps {
   alt?: string;
   pinEnabled?: boolean;
   downloadEnabled?: boolean;
+  onPin?: (image: ChatImage) => void;
   onClose: () => void;
 }
 
@@ -33,6 +34,7 @@ export function ChatImageLightbox({
   alt,
   pinEnabled = true,
   downloadEnabled = true,
+  onPin,
   onClose,
 }: ChatImageLightboxProps) {
   const pinImage = useGalleryStore((s) => s.pinImage);
@@ -81,8 +83,12 @@ export function ChatImageLightbox({
             {pinEnabled && (
               <button
                 type="button"
-                onClick={() => {
-                  pinImage(image);
+                onPointerDown={(event) => event.stopPropagation()}
+                onClick={(event) => {
+                  event.preventDefault();
+                  event.stopPropagation();
+                  if (onPin) onPin(image);
+                  else pinImage(image);
                   onClose();
                 }}
                 aria-label="Pin image to chat"

--- a/packages/client/src/components/chat/ChatRoleplayPanels.tsx
+++ b/packages/client/src/components/chat/ChatRoleplayPanels.tsx
@@ -45,11 +45,20 @@ function getLorebookEntryStatus(entry: { constant?: boolean; selective?: boolean
 function ActiveLorebookEntryRow({
   entry,
 }: {
-  entry: { name: string; keys: string[]; content: string; constant: boolean; selective: boolean; order: number };
+  entry: {
+    name: string;
+    keys: string[];
+    content: string;
+    constant: boolean;
+    selective: boolean;
+    order: number;
+    matchedKeys?: string[];
+  };
 }) {
   const [expanded, setExpanded] = useState(false);
   const status = getLorebookEntryStatus(entry);
   const statusStyle = LOREBOOK_ENTRY_STATUS_STYLE[status];
+  const matchedKeys = entry.matchedKeys ?? [];
 
   return (
     <div
@@ -68,6 +77,12 @@ function ActiveLorebookEntryRow({
         <p className="mt-0.5 truncate text-[0.625rem] text-[var(--muted-foreground)]">
           Keys: {entry.keys.slice(0, 5).join(", ")}
           {entry.keys.length > 5 && ` +${entry.keys.length - 5}`}
+        </p>
+      )}
+      {matchedKeys.length > 0 && (
+        <p className="mt-0.5 truncate text-[0.625rem] text-[var(--muted-foreground)]">
+          Matched: {matchedKeys.slice(0, 5).join(", ")}
+          {matchedKeys.length > 5 && ` +${matchedKeys.length - 5}`}
         </p>
       )}
       {expanded && (

--- a/packages/client/src/components/chat/ChatSettingsDrawer.tsx
+++ b/packages/client/src/components/chat/ChatSettingsDrawer.tsx
@@ -218,7 +218,7 @@ import {
   type AgentAddSpriteSubject,
   type MusicProvider,
 } from "./AgentAddSetupFields";
-import { GameWidgetSetupEditor, normalizeGameHudWidgets } from "../game/GameWidgetSetupEditor";
+import { GameWidgetFileControls, GameWidgetSetupEditor, normalizeGameHudWidgets } from "../game/GameWidgetSetupEditor";
 
 interface ChatSettingsDrawerProps {
   chat: Chat;
@@ -2429,14 +2429,13 @@ export function ChatSettingsDrawer({
     setAddingAgentToChat(true);
     try {
       if (config) {
-        await updateAgentConfig.mutateAsync({ id: config.id, enabled: true, settings: nextSettings });
+        await updateAgentConfig.mutateAsync({ id: config.id, settings: nextSettings });
       } else if (builtInMeta) {
         await createAgent.mutateAsync({
           type: builtInMeta.id,
           name: agent.name,
           description: agent.description,
           phase: normalizeAgentPhaseForType(agent.id, agent.phase),
-          enabled: true,
           connectionId: null,
           promptTemplate: "",
           settings: nextSettings,
@@ -2451,6 +2450,7 @@ export function ChatSettingsDrawer({
           allowSecretPlot: supportsNarrativeDirectorSecretPlot,
         }),
       });
+      toast.success(`Added ${agent.name}! You can access its settings in Agents section in Chat Settings!`);
       setAgentAddPreview(null);
     } catch (error) {
       await showAlertDialog({
@@ -2476,7 +2476,7 @@ export function ChatSettingsDrawer({
       };
 
       if (config) {
-        await updateAgentConfig.mutateAsync({ id: config.id, enabled: true, settings: nextSettings });
+        await updateAgentConfig.mutateAsync({ id: config.id, settings: nextSettings });
         return;
       }
 
@@ -2485,7 +2485,6 @@ export function ChatSettingsDrawer({
         name: builtInMeta.name,
         description: builtInMeta.description,
         phase: normalizeAgentPhaseForType(builtInMeta.id, builtInMeta.phase),
-        enabled: true,
         connectionId: null,
         promptTemplate: "",
         settings: nextSettings,
@@ -2533,12 +2532,13 @@ export function ChatSettingsDrawer({
   );
 
   const toggleGameMusicDj = useCallback(async () => {
+    const latestActiveAgentIds = readLatestActiveAgentIds();
     if (gameMusicDjEnabled) {
       await updateMeta.mutateAsync({
         id: chat.id,
         gameUseMusicDj: false,
         gameUseSpotifyMusic: false,
-        activeAgentIds: activeAgentIds.filter((id) => id !== "spotify" && id !== "youtube"),
+        activeAgentIds: latestActiveAgentIds.filter((id) => id !== "spotify" && id !== "youtube"),
       });
       return;
     }
@@ -2551,7 +2551,7 @@ export function ChatSettingsDrawer({
         gameUseMusicDj: true,
         gameUseSpotifyMusic: musicPlayerSource === "spotify",
         gameSpotifySourceType,
-        activeAgentIds: Array.from(new Set([...activeAgentIds.filter((id) => id !== "youtube"), "spotify"])),
+        activeAgentIds: Array.from(new Set([...latestActiveAgentIds.filter((id) => id !== "youtube"), "spotify"])),
       });
     } catch (error) {
       await showAlertDialog({
@@ -2563,12 +2563,12 @@ export function ChatSettingsDrawer({
       });
     }
   }, [
-    activeAgentIds,
     chat.id,
     ensureMusicDjAgent,
     gameMusicDjEnabled,
     gameSpotifySourceType,
     musicPlayerSource,
+    readLatestActiveAgentIds,
     updateMeta,
   ]);
 
@@ -2583,7 +2583,8 @@ export function ChatSettingsDrawer({
   }, [chat.id, gameWidgetDrafts, updateGameWidgets]);
 
   const toggleGameLorebookKeeper = useCallback(() => {
-    const nextActiveAgentIds = activeAgentIds.filter((id) => id !== "lorebook-keeper");
+    const latestActiveAgentIds = readLatestActiveAgentIds();
+    const nextActiveAgentIds = latestActiveAgentIds.filter((id) => id !== "lorebook-keeper");
     if (gameLorebookKeeperEnabled) {
       const keeperLorebookIds = new Set(
         ((lorebooks ?? []) as Lorebook[])
@@ -2606,12 +2607,12 @@ export function ChatSettingsDrawer({
       activeAgentIds: nextActiveAgentIds,
     });
   }, [
-    activeAgentIds,
     activeLorebookIds,
     chat.id,
     gameLorebookKeeperEnabled,
     gameLorebookKeeperLorebookId,
     lorebooks,
+    readLatestActiveAgentIds,
     updateMeta,
   ]);
 
@@ -6536,15 +6537,17 @@ export function ChatSettingsDrawer({
                                 <div key={agent.id} className="space-y-1.5">
                                   <button
                                     onClick={() => {
+                                      const latestActiveAgentIds = readLatestActiveAgentIds();
                                       if (active) {
                                         updateMeta.mutate({
                                           id: chat.id,
-                                          activeAgentIds: activeAgentIds.filter((id) => id !== agent.id),
+                                          activeAgentIds: latestActiveAgentIds.filter((id) => id !== agent.id),
                                         });
                                       } else {
                                         updateMeta.mutate({
                                           id: chat.id,
-                                          activeAgentIds: [...activeAgentIds, agent.id],
+                                          enableAgents: true,
+                                          activeAgentIds: Array.from(new Set([...latestActiveAgentIds, agent.id])),
                                         });
                                       }
                                     }}
@@ -6652,7 +6655,7 @@ export function ChatSettingsDrawer({
 
                         {visibleActiveAgentIds.length === 0 && (
                           <p className="text-[0.6875rem] text-[var(--muted-foreground)] px-1">
-                            No per-chat agent overrides. Workspace default agents will be used for this chat.
+                            No agents are active for this chat yet. Add one below to let it run here.
                           </p>
                         )}
 
@@ -6809,6 +6812,15 @@ export function ChatSettingsDrawer({
                     <span>{updateGameWidgets.isPending ? "Saving..." : "Save Widgets"}</span>
                   </button>
                 </div>
+                <GameWidgetFileControls
+                  widgets={gameWidgetDrafts}
+                  onImport={(widgets) => setGameWidgetDrafts(normalizeGameHudWidgets(widgets))}
+                  disabled={updateGameWidgets.isPending}
+                  exportFilename={`${chat.name || "game"}-widgets`}
+                  importSuccessMessage={(count) =>
+                    `Imported ${count === 1 ? "1 widget" : `${count} widgets`}. Save Widgets to apply them.`
+                  }
+                />
               </div>
             </Section>
           )}
@@ -7013,6 +7025,7 @@ export function ChatSettingsDrawer({
         }}
         title={agentAddPreview ? `Add ${agentAddPreview.agent.name}` : "Add Agent"}
         width="max-w-lg"
+        chatFloatingPanel
       >
         {agentAddPreview && (
           <div className="space-y-4">

--- a/packages/client/src/components/chat/ChatSetupWizard.tsx
+++ b/packages/client/src/components/chat/ChatSetupWizard.tsx
@@ -234,6 +234,12 @@ function readChatMetadata(chat: Chat): Record<string, unknown> {
   return raw ?? {};
 }
 
+function readChatActiveAgentIds(chat: Chat): string[] {
+  const metadata = readChatMetadata(chat);
+  const activeIds = metadata.activeAgentIds;
+  return Array.isArray(activeIds) ? activeIds.filter((id): id is string => typeof id === "string") : [];
+}
+
 function readConversationCommandToggles(value: unknown): Partial<Record<ConversationCommandKey, boolean>> {
   if (!value || typeof value !== "object" || Array.isArray(value)) return {};
   const source = value as Record<string, unknown>;
@@ -1385,6 +1391,10 @@ function RoleplaySetupWizard({ chat, onFinish }: ChatSetupWizardProps) {
       ),
     [metadata.activeAgentIds],
   );
+  const readLatestActiveAgentIds = useCallback(() => {
+    const latestChat = queryClient.getQueryData<Chat>(chatKeys.detail(chat.id));
+    return latestChat ? readChatActiveAgentIds(latestChat) : [...activeAgentIds];
+  }, [activeAgentIds, chat.id, queryClient]);
   const agentsEnabled = metadata.enableAgents === true;
   const agentConfigsByType = useMemo(() => {
     const map = new Map<string, AgentConfigRow>();
@@ -1710,13 +1720,14 @@ function RoleplaySetupWizard({ chat, onFinish }: ChatSetupWizardProps) {
 
   const removeAgentFromChat = useCallback(
     (agentId: string) => {
+      const latestActiveAgentIds = readLatestActiveAgentIds();
       updateMeta.mutate({
         id: chat.id,
-        activeAgentIds: activeAgentIds.filter((id) => id !== agentId),
+        activeAgentIds: latestActiveAgentIds.filter((id) => id !== agentId),
       });
       if (agentAddPreview?.agent.id === agentId) setAgentAddPreview(null);
     },
-    [activeAgentIds, agentAddPreview?.agent.id, chat.id, updateMeta],
+    [agentAddPreview?.agent.id, chat.id, readLatestActiveAgentIds, updateMeta],
   );
 
   const confirmAddAgent = useCallback(async () => {
@@ -1745,14 +1756,13 @@ function RoleplaySetupWizard({ chat, onFinish }: ChatSetupWizardProps) {
     setAddingAgentToChat(true);
     try {
       if (config) {
-        await updateAgentConfig.mutateAsync({ id: config.id, enabled: true, settings: nextSettings });
+        await updateAgentConfig.mutateAsync({ id: config.id, settings: nextSettings });
       } else if (builtInMeta) {
         await createAgent.mutateAsync({
           type: builtInMeta.id,
           name: agent.name,
           description: agent.description,
           phase: normalizeAgentPhaseForType(agent.id, agent.phase),
-          enabled: true,
           connectionId: null,
           promptTemplate: "",
           settings: nextSettings,
@@ -1762,11 +1772,12 @@ function RoleplaySetupWizard({ chat, onFinish }: ChatSetupWizardProps) {
       await updateMeta.mutateAsync({
         id: chat.id,
         enableAgents: true,
-        activeAgentIds: Array.from(new Set([...activeAgentIds, agent.id])),
+        activeAgentIds: Array.from(new Set([...readLatestActiveAgentIds(), agent.id])),
         ...buildAgentAddMetadataPatch(agent.id, setup, metadata, {
           allowSecretPlot: supportsNarrativeDirectorSecretPlot,
         }),
       });
+      toast.success(`Added ${agent.name}! You can access its settings in Agents section in Chat Settings!`);
       setAgentAddPreview(null);
     } catch (error) {
       toast.error(error instanceof Error ? error.message : "Could not add this agent to the chat.");
@@ -1774,11 +1785,11 @@ function RoleplaySetupWizard({ chat, onFinish }: ChatSetupWizardProps) {
       setAddingAgentToChat(false);
     }
   }, [
-    activeAgentIds,
     agentAddPreview,
     chat.id,
     createAgent,
     metadata,
+    readLatestActiveAgentIds,
     supportsNarrativeDirectorSecretPlot,
     updateAgentConfig,
     updateMeta,
@@ -2114,7 +2125,7 @@ function RoleplaySetupWizard({ chat, onFinish }: ChatSetupWizardProps) {
             updateMeta.mutate({
               id: chat.id,
               enableAgents: !agentsEnabled,
-              activeAgentIds: !agentsEnabled ? activeAgentIds : [],
+              activeAgentIds: !agentsEnabled ? readLatestActiveAgentIds() : [],
             })
           }
           className={cn(

--- a/packages/client/src/components/chat/EchoChamberPanel.tsx
+++ b/packages/client/src/components/chat/EchoChamberPanel.tsx
@@ -9,7 +9,6 @@ import { X, Trash2, RefreshCw } from "lucide-react";
 import { useAgentStore } from "../../stores/agent.store";
 import { useUIStore } from "../../stores/ui.store";
 import type { EchoChamberSide } from "../../stores/ui.store";
-import { useAgentConfigs } from "../../hooks/use-agents";
 import { useChatStore } from "../../stores/chat.store";
 import { useChat } from "../../hooks/use-chats";
 import { useGenerate } from "../../hooks/use-generate";
@@ -154,7 +153,6 @@ export function EchoChamberPanel({ hiddenOnMobile = false }: EchoChamberPanelPro
   const isStreaming = useChatStore((s) => s.isStreaming);
   const streamingChatId = useChatStore((s) => s.streamingChatId);
   const { data: chat } = useChat(activeChatId);
-  const { data: agentConfigs } = useAgentConfigs();
   const { retryAgents } = useGenerate();
   const echoRetryBusy = isAgentProcessing || (isStreaming && streamingChatId === activeChatId);
 
@@ -165,14 +163,8 @@ export function EchoChamberPanel({ hiddenOnMobile = false }: EchoChamberPanelPro
     const meta = typeof raw === "string" ? JSON.parse(raw) : ((raw ?? {}) as Record<string, unknown>);
     if (!meta.enableAgents) return false;
     const activeAgentIds: string[] = Array.isArray(meta.activeAgentIds) ? meta.activeAgentIds : [];
-    if (activeAgentIds.length > 0) {
-      return activeAgentIds.includes("echo-chamber");
-    }
-    // Fallback: check global agent config
-    if (!agentConfigs) return false;
-    const cfg = (agentConfigs as Array<{ type: string; enabled: string }>).find((a) => a.type === "echo-chamber");
-    return cfg?.enabled === "true";
-  }, [chat, agentConfigs]);
+    return activeAgentIds.includes("echo-chamber");
+  }, [chat]);
 
   // ── Timed reveal: show one more message every 30 s ──
   // visibleCount and baseline live in the Zustand store so they survive

--- a/packages/client/src/components/chat/RoleplayHUD.tsx
+++ b/packages/client/src/components/chat/RoleplayHUD.tsx
@@ -4,7 +4,7 @@
 // a compact preview and expandable editable popover.
 // Supports top (horizontal) and left/right (vertical) layout.
 // ──────────────────────────────────────────────
-import { Suspense, lazy, useState, useEffect, useRef, useCallback, useMemo, useLayoutEffect } from "react";
+import { Suspense, lazy, useState, useEffect, useRef, useCallback, useLayoutEffect } from "react";
 import { createPortal } from "react-dom";
 import {
   MapPin,
@@ -64,6 +64,7 @@ import type { HudPosition, TrackerTemperatureUnit } from "../../stores/ui.store"
 
 const ACTIONS_DROPDOWN_WIDTH_PX = 288;
 const EMPTY_INVENTORY: InventoryItem[] = [];
+const EMPTY_AGENT_TYPE_SET = new Set<string>();
 
 interface RoleplayHUDProps {
   chatId: string;
@@ -126,16 +127,7 @@ export function RoleplayHUD({
   const { patchField, patchPlayerStats } = useGameStatePatcher(chatId, "roleplay-hud");
 
   const { data: agentConfigs } = useAgentConfigs();
-  const globalEnabledAgentTypes = useMemo(() => {
-    const set = new Set<string>();
-    if (agentConfigs) {
-      for (const a of agentConfigs as Array<{ type: string; enabled: string }>) {
-        if (a.enabled === "true") set.add(a.type);
-      }
-    }
-    return set;
-  }, [agentConfigs]);
-  const enabledAgentTypes = enabledAgentTypesProp ?? globalEnabledAgentTypes;
+  const enabledAgentTypes = enabledAgentTypesProp ?? EMPTY_AGENT_TYPE_SET;
 
   const thoughtBubbles = useAgentStore((s) => s.thoughtBubbles);
   const isAgentProcessing = useAgentStore((s) => s.isProcessing);

--- a/packages/client/src/components/chat/RoleplayHUDActionsMenu.tsx
+++ b/packages/client/src/components/chat/RoleplayHUDActionsMenu.tsx
@@ -397,20 +397,22 @@ function CustomAgentRunsSection({
 }
 
 function hasActiveInjectableCustomAgent(configs: AgentConfigRow[], enabledAgentTypes?: Set<string>): boolean {
+  if (!enabledAgentTypes) return false;
   const builtInTypes = new Set(BUILT_IN_AGENTS.map((agent) => agent.id));
   return configs.some((config) => {
     if (builtInTypes.has(config.type)) return false;
-    if (enabledAgentTypes ? !enabledAgentTypes.has(config.type) : config.enabled !== "true") return false;
+    if (!enabledAgentTypes.has(config.type)) return false;
     const settings = parseAgentSettings(config.settings);
     return settings.injectAsSection === true;
   });
 }
 
 function hasActiveCustomAgentType(configs: AgentConfigRow[], enabledAgentTypes?: Set<string>): boolean {
+  if (!enabledAgentTypes) return false;
   const builtInTypes = new Set(BUILT_IN_AGENTS.map((agent) => agent.id));
   return configs.some((config) => {
     if (builtInTypes.has(config.type)) return false;
-    return enabledAgentTypes ? enabledAgentTypes.has(config.type) : config.enabled === "true";
+    return enabledAgentTypes.has(config.type);
   });
 }
 
@@ -419,12 +421,13 @@ function getLatestInjectableCustomRuns(
   configs: AgentConfigRow[],
   enabledAgentTypes?: Set<string>,
 ): AgentRunRow[] {
+  if (!enabledAgentTypes) return [];
   const builtInTypes = new Set(BUILT_IN_AGENTS.map((agent) => agent.id));
   const injectableTypes = new Set(
     configs
       .filter((config) => {
         if (builtInTypes.has(config.type)) return false;
-        if (enabledAgentTypes ? !enabledAgentTypes.has(config.type) : config.enabled !== "true") return false;
+        if (!enabledAgentTypes.has(config.type)) return false;
         const settings = parseAgentSettings(config.settings);
         return settings.injectAsSection === true;
       })

--- a/packages/client/src/components/game/GameSetupWizard.tsx
+++ b/packages/client/src/components/game/GameSetupWizard.tsx
@@ -42,6 +42,7 @@ import {
 } from "../ui/neutral-surface-styles";
 import {
   createDefaultGameHudWidget,
+  GameWidgetFileControls,
   GameWidgetSetupEditor,
   normalizeGameHudWidgets,
 } from "./GameWidgetSetupEditor";
@@ -1626,6 +1627,17 @@ export function GameSetupWizard({ onComplete, onCancel, isLoading, characters }:
               </button>
               {enableCustomWidgets && (
                 <div className="mt-3 space-y-3 border-t border-[var(--border)] pt-3">
+                  <GameWidgetFileControls
+                    widgets={customHudWidgets}
+                    onImport={(widgets) => {
+                      setCustomHudWidgets(normalizeGameHudWidgets(widgets));
+                      setManualWidgetSetupEnabled(true);
+                    }}
+                    exportFilename="game-setup-widgets"
+                    importSuccessMessage={(count) =>
+                      `Imported ${count === 1 ? "1 widget" : `${count} widgets`} for this game setup.`
+                    }
+                  />
                   <button
                     type="button"
                     onClick={() => setManualWidgetSetupEnabled((enabled) => !enabled)}

--- a/packages/client/src/components/game/GameSurface.tsx
+++ b/packages/client/src/components/game/GameSurface.tsx
@@ -8,6 +8,7 @@ import {
   useRef,
   useState,
   lazy,
+  memo,
   Suspense,
   type CSSProperties,
   type MouseEvent as ReactMouseEvent,
@@ -959,6 +960,7 @@ function extractNarrationNpcCandidates(
 
 function mergeSceneAssetNpcCandidates(
   trackedNpcs: GameNpc[],
+  metadataNpcs: unknown,
   presentCharacters: SceneAssetPresentCharacter[],
   excludedNames: string[],
   currentLocation: string | null | undefined,
@@ -967,10 +969,35 @@ function mergeSceneAssetNpcCandidates(
   const excluded = new Set(excludedNames.map(normalizeSceneAssetName));
   const candidates = new Map<string, GameNpc>();
 
+  const addNpcCandidate = (npc: GameNpc) => {
+    const name = typeof npc.name === "string" ? npc.name.trim() : "";
+    const normalizedName = normalizeSceneAssetName(name);
+    if (!normalizedName) return;
+    const existing = candidates.get(normalizedName);
+    if (!existing) {
+      candidates.set(normalizedName, { ...npc, name });
+      return;
+    }
+    candidates.set(normalizedName, {
+      ...existing,
+      description: existing.description || npc.description,
+      descriptionSource: existing.descriptionSource || npc.descriptionSource,
+      gender: existing.gender ?? npc.gender ?? null,
+      pronouns: existing.pronouns ?? npc.pronouns ?? null,
+      location: existing.location || npc.location,
+      avatarUrl: existing.avatarUrl || npc.avatarUrl,
+    });
+  };
+
   for (const npc of trackedNpcs) {
-    const normalizedName = normalizeSceneAssetName(npc.name);
-    if (!normalizedName) continue;
-    candidates.set(normalizedName, npc);
+    addNpcCandidate(npc);
+  }
+
+  if (Array.isArray(metadataNpcs)) {
+    for (const rawNpc of metadataNpcs) {
+      if (!rawNpc || typeof rawNpc !== "object") continue;
+      addNpcCandidate(rawNpc as GameNpc);
+    }
   }
 
   for (const presentCharacter of presentCharacters) {
@@ -1886,7 +1913,7 @@ interface GameSurfaceProps {
   selectedMessageIds?: Set<string>;
 }
 
-export function GameSurface({
+function GameSurfaceComponent({
   activeChatId,
   chat,
   chatMeta,
@@ -3148,12 +3175,20 @@ export function GameSurface({
     () =>
       mergeSceneAssetNpcCandidates(
         npcs,
+        chatMeta.gameNpcs,
         (gameSnapshot?.presentCharacters as SceneAssetPresentCharacter[] | undefined) ?? [],
         sceneWrapCharacterNames,
         gameSnapshot?.location ?? null,
         latestNarrationText,
       ),
-    [gameSnapshot?.location, gameSnapshot?.presentCharacters, latestNarrationText, npcs, sceneWrapCharacterNames],
+    [
+      chatMeta.gameNpcs,
+      gameSnapshot?.location,
+      gameSnapshot?.presentCharacters,
+      latestNarrationText,
+      npcs,
+      sceneWrapCharacterNames,
+    ],
   );
 
   const npcAvatarLookup = useMemo(
@@ -9897,3 +9932,5 @@ export function GameSurface({
     </div>
   );
 }
+
+export const GameSurface = memo(GameSurfaceComponent);

--- a/packages/client/src/components/game/GameWidgetSetupEditor.tsx
+++ b/packages/client/src/components/game/GameWidgetSetupEditor.tsx
@@ -1,8 +1,9 @@
 // ──────────────────────────────────────────────
 // Game: HUD Widget Setup Editor
 // ──────────────────────────────────────────────
-import { useMemo, useState } from "react";
-import { Plus, Trash2 } from "lucide-react";
+import { useMemo, useRef, useState } from "react";
+import { Download, Plus, Trash2, Upload } from "lucide-react";
+import { toast } from "sonner";
 import {
   normalizeTextForMatch,
   type HudWidget,
@@ -13,6 +14,8 @@ import { cn } from "../../lib/utils";
 import { DraftNumberInput } from "../ui/DraftNumberInput";
 
 export const MAX_GAME_SETUP_WIDGETS = 4;
+const GAME_WIDGET_EXPORT_KIND = "marinara-game-hud-widgets";
+const GAME_WIDGET_EXPORT_VERSION = 1;
 
 const WIDGET_TYPES: readonly HudWidgetType[] = [
   "progress_bar",
@@ -262,6 +265,125 @@ export function normalizeGameHudWidgets(value: unknown): HudWidget[] {
   }
 
   return normalized;
+}
+
+function getImportedWidgetSource(value: unknown): unknown {
+  if (Array.isArray(value)) return value;
+  if (!value || typeof value !== "object") return [];
+  const record = value as { widgets?: unknown; hudWidgets?: unknown; gameWidgetState?: unknown };
+  if (Array.isArray(record.widgets)) return record.widgets;
+  if (Array.isArray(record.hudWidgets)) return record.hudWidgets;
+  if (Array.isArray(record.gameWidgetState)) return record.gameWidgetState;
+  return [];
+}
+
+function formatWidgetCount(count: number) {
+  return count === 1 ? "1 widget" : `${count} widgets`;
+}
+
+function buildWidgetExportFilename(filename?: string) {
+  const stem =
+    filename
+      ?.replace(/\.json$/i, "")
+      .trim()
+      .replace(/[^\p{L}\p{N}._-]+/gu, "-")
+      .replace(/^-+|-+$/g, "") || "marinara-game-widgets";
+  return `${stem}.json`;
+}
+
+function exportGameHudWidgets(widgets: readonly HudWidget[], filename?: string) {
+  const normalizedWidgets = normalizeGameHudWidgets(widgets);
+  const payload = {
+    kind: GAME_WIDGET_EXPORT_KIND,
+    version: GAME_WIDGET_EXPORT_VERSION,
+    exportedAt: new Date().toISOString(),
+    widgets: normalizedWidgets,
+  };
+  const blob = new Blob([JSON.stringify(payload, null, 2)], { type: "application/json" });
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement("a");
+  link.href = url;
+  link.download = buildWidgetExportFilename(filename);
+  document.body.appendChild(link);
+  link.click();
+  link.remove();
+  URL.revokeObjectURL(url);
+  toast.success(`Exported ${formatWidgetCount(normalizedWidgets.length)}.`);
+}
+
+async function importGameHudWidgetsFromFile(file: File) {
+  const text = await file.text();
+  const parsed = JSON.parse(text) as unknown;
+  const widgets = normalizeGameHudWidgets(getImportedWidgetSource(parsed));
+  if (widgets.length === 0) {
+    throw new Error("No valid game widgets were found in that file.");
+  }
+  return widgets;
+}
+
+interface GameWidgetFileControlsProps {
+  widgets: HudWidget[];
+  onImport: (widgets: HudWidget[]) => void;
+  disabled?: boolean;
+  className?: string;
+  exportFilename?: string;
+  importSuccessMessage?: (count: number) => string;
+}
+
+export function GameWidgetFileControls({
+  widgets,
+  onImport,
+  disabled,
+  className,
+  exportFilename,
+  importSuccessMessage,
+}: GameWidgetFileControlsProps) {
+  const inputRef = useRef<HTMLInputElement | null>(null);
+  const normalizedWidgets = useMemo(() => normalizeGameHudWidgets(widgets), [widgets]);
+  const canExport = normalizedWidgets.length > 0 && !disabled;
+
+  const handleImport = async (file: File | undefined) => {
+    if (!file || disabled) return;
+    try {
+      const importedWidgets = await importGameHudWidgetsFromFile(file);
+      onImport(importedWidgets);
+      toast.success(importSuccessMessage?.(importedWidgets.length) ?? `Imported ${formatWidgetCount(importedWidgets.length)}.`);
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : "Failed to import game widgets.");
+    } finally {
+      if (inputRef.current) inputRef.current.value = "";
+    }
+  };
+
+  return (
+    <div className={cn("flex flex-wrap items-center justify-end gap-2", className)}>
+      <input
+        ref={inputRef}
+        type="file"
+        accept="application/json,.json"
+        className="hidden"
+        onChange={(event) => void handleImport(event.target.files?.[0])}
+      />
+      <button
+        type="button"
+        onClick={() => inputRef.current?.click()}
+        disabled={disabled}
+        className="inline-flex items-center gap-1.5 rounded-lg border border-[var(--border)] px-3 py-1.5 text-xs font-medium text-[var(--muted-foreground)] transition-colors hover:bg-[var(--accent)] hover:text-[var(--foreground)] disabled:cursor-not-allowed disabled:opacity-50"
+      >
+        <Download size="0.75rem" />
+        <span>Import Widgets</span>
+      </button>
+      <button
+        type="button"
+        onClick={() => exportGameHudWidgets(normalizedWidgets, exportFilename)}
+        disabled={!canExport}
+        className="inline-flex items-center gap-1.5 rounded-lg border border-[var(--border)] px-3 py-1.5 text-xs font-medium text-[var(--muted-foreground)] transition-colors hover:bg-[var(--accent)] hover:text-[var(--foreground)] disabled:cursor-not-allowed disabled:opacity-50"
+      >
+        <Upload size="0.75rem" />
+        <span>Export Widgets</span>
+      </button>
+    </div>
+  );
 }
 
 interface GameWidgetSetupEditorProps {

--- a/packages/client/src/components/lorebooks/LorebookEditor.tsx
+++ b/packages/client/src/components/lorebooks/LorebookEditor.tsx
@@ -1344,6 +1344,7 @@ export function LorebookEditor() {
       name: "New Entry",
       content: "",
       keys: [],
+      preventRecursion: true,
     });
     if (result && typeof result === "object" && "id" in result) {
       // Auto-expand the new entry's drawer so the user can fill it in.

--- a/packages/client/src/components/lorebooks/LorebookEntryRow.tsx
+++ b/packages/client/src/components/lorebooks/LorebookEntryRow.tsx
@@ -1521,10 +1521,10 @@ function ExpandedDrawer({
           tooltip="Prevents the Lorebook Keeper agent from modifying this entry."
         />
         <ToggleButton
-          label="No Recursion"
-          value={form.preventRecursion ?? false}
-          onChange={(v) => update({ preventRecursion: v })}
-          tooltip="When enabled, this entry's content won't trigger additional entries during recursive scanning."
+          label="Recursion"
+          value={!(form.preventRecursion ?? true)}
+          onChange={(v) => update({ preventRecursion: !v })}
+          tooltip="When enabled, this entry's content can trigger additional entries during recursive scanning. Keep this off unless this entry should chain lore."
         />
         <ToggleButton
           label="No Vector"

--- a/packages/client/src/components/lorebooks/LorebookFormFields.tsx
+++ b/packages/client/src/components/lorebooks/LorebookFormFields.tsx
@@ -68,11 +68,13 @@ export function KeysEditor({ keys, onChange }: { keys: string[]; onChange: (keys
         <input
           value={input}
           onChange={(e) => setInput(e.target.value)}
+          onBlur={addKey}
           onKeyDown={(e) => e.key === "Enter" && (e.preventDefault(), addKey())}
           className="mari-editor-field flex-1 px-2 py-1.5 text-xs"
-          placeholder="Type a keyword and press Enter…"
+          placeholder="Type a keyword, press Enter, or click away…"
         />
         <button
+          type="button"
           onClick={addKey}
           className="mari-editor-action mari-editor-action--compact px-2 py-1.5 text-[0.6875rem]"
         >

--- a/packages/client/src/components/panels/CharactersPanel.tsx
+++ b/packages/client/src/components/panels/CharactersPanel.tsx
@@ -150,9 +150,18 @@ export function CharactersPanel() {
   const openCharacterLibrary = useUIStore((s) => s.openCharacterLibrary);
   const sort = useUIStore((s) => s.characterLibrarySort);
   const setCharacterLibrarySort = useUIStore((s) => s.setCharacterLibrarySort);
+  const search = useUIStore((s) => s.characterPanelSearch);
+  const setSearch = useUIStore((s) => s.setCharacterPanelSearch);
+  const includedTagValues = useUIStore((s) => s.characterPanelIncludedTags);
+  const setCharacterPanelIncludedTags = useUIStore((s) => s.setCharacterPanelIncludedTags);
+  const excludedTagValues = useUIStore((s) => s.characterPanelExcludedTags);
+  const setCharacterPanelExcludedTags = useUIStore((s) => s.setCharacterPanelExcludedTags);
+  const tagsExpanded = useUIStore((s) => s.characterPanelTagsExpanded);
+  const setTagsExpanded = useUIStore((s) => s.setCharacterPanelTagsExpanded);
+  const favFilter = useUIStore((s) => s.characterPanelFavoriteFilter);
+  const setFavFilter = useUIStore((s) => s.setCharacterPanelFavoriteFilter);
   const setCharacterPanelScrollTop = useUIStore((s) => s.setCharacterPanelScrollTop);
 
-  const [search, setSearch] = useState("");
   const [expandedGroupId, setExpandedGroupId] = useState<string | null>(null);
   const [editingGroupId, setEditingGroupId] = useState<string | null>(null);
   const [editGroupName, setEditGroupName] = useState("");
@@ -163,10 +172,8 @@ export function CharactersPanel() {
   const suppressCharacterClickRef = useRef(false);
   const isMobileOverlay = usePanelMobileOverlay();
   const handleFolderRenameGesture = useFolderRenameGesture();
-  const [includedTags, setIncludedTags] = useState<Set<string>>(new Set());
-  const [excludedTags, setExcludedTags] = useState<Set<string>>(new Set());
-  const [tagsExpanded, setTagsExpanded] = useState(false);
-  const [favFilter, setFavFilter] = useState<"all" | "favorites" | "non-favorites">("all");
+  const includedTags = useMemo(() => new Set(includedTagValues), [includedTagValues]);
+  const excludedTags = useMemo(() => new Set(excludedTagValues), [excludedTagValues]);
   const [selectionMode, setSelectionMode] = useState(false);
   const [selectedCharacterIds, setSelectedCharacterIds] = useState<Set<string>>(new Set());
   const [exportingSelected, setExportingSelected] = useState(false);
@@ -278,47 +285,52 @@ export function CharactersPanel() {
           await updateCharacter.mutateAsync({ id: c.id, data: { tags: newTags } });
         }
         if (includedTags.has(tag)) {
-          setIncludedTags((prev) => {
-            const next = new Set(prev);
-            next.delete(tag);
-            return next;
-          });
-        }
-        setExcludedTags((prev) => {
-          if (!prev.has(tag)) return prev;
-          const next = new Set(prev);
+          const next = new Set(includedTags);
           next.delete(tag);
-          return next;
-        });
+          setCharacterPanelIncludedTags([...next]);
+        }
+        if (excludedTags.has(tag)) {
+          const next = new Set(excludedTags);
+          next.delete(tag);
+          setCharacterPanelExcludedTags([...next]);
+        }
       } catch {
         toast.error("Failed to remove tag from some characters");
       }
     },
-    [parsedCharacters, updateCharacter, includedTags],
+    [
+      parsedCharacters,
+      updateCharacter,
+      includedTags,
+      excludedTags,
+      setCharacterPanelIncludedTags,
+      setCharacterPanelExcludedTags,
+    ],
   );
 
-  const toggleIncludedTag = useCallback((tag: string) => {
-    setIncludedTags((prev) => {
-      const next = new Set(prev);
-      if (next.has(tag)) {
-        next.delete(tag);
+  const toggleIncludedTag = useCallback(
+    (tag: string) => {
+      const nextIncluded = new Set(includedTags);
+      if (nextIncluded.has(tag)) {
+        nextIncluded.delete(tag);
       } else {
-        next.add(tag);
+        nextIncluded.add(tag);
       }
-      return next;
-    });
-    setExcludedTags((prev) => {
-      if (!prev.has(tag)) return prev;
-      const next = new Set(prev);
-      next.delete(tag);
-      return next;
-    });
-  }, []);
+      setCharacterPanelIncludedTags([...nextIncluded]);
+
+      if (excludedTags.has(tag)) {
+        const nextExcluded = new Set(excludedTags);
+        nextExcluded.delete(tag);
+        setCharacterPanelExcludedTags([...nextExcluded]);
+      }
+    },
+    [excludedTags, includedTags, setCharacterPanelExcludedTags, setCharacterPanelIncludedTags],
+  );
 
   const clearTagFilters = useCallback(() => {
-    setIncludedTags(new Set());
-    setExcludedTags(new Set());
-  }, []);
+    setCharacterPanelIncludedTags([]);
+    setCharacterPanelExcludedTags([]);
+  }, [setCharacterPanelExcludedTags, setCharacterPanelIncludedTags]);
 
   const sortedCharacters = useMemo(() => {
     const list = [...filteredCharacters];

--- a/packages/client/src/components/panels/LorebooksPanel.tsx
+++ b/packages/client/src/components/panels/LorebooksPanel.tsx
@@ -31,7 +31,7 @@ import {
   Trash2,
   Camera,
 } from "lucide-react";
-import { useUIStore } from "../../stores/ui.store";
+import { useUIStore, type LorebookPanelCategory, type LorebookPanelSort } from "../../stores/ui.store";
 import { useChatStore } from "../../stores/chat.store";
 import {
   useLorebooks,
@@ -114,11 +114,16 @@ function remapLorebookEntryRelationships(
 }
 
 export function LorebooksPanel() {
-  const [activeCategory, setActiveCategory] = useState<LorebookCategory | "all" | "active">("all");
-  const [searchQuery, setSearchQuery] = useState("");
-  const [sort, setSort] = useState<"name-asc" | "name-desc" | "newest" | "oldest" | "tokens">("name-asc");
-  const [activeTag, setActiveTag] = useState<string | null>(null);
-  const [tagsExpanded, setTagsExpanded] = useState(false);
+  const activeCategory = useUIStore((s) => s.lorebookPanelCategory);
+  const setActiveCategory = useUIStore((s) => s.setLorebookPanelCategory);
+  const searchQuery = useUIStore((s) => s.lorebookPanelSearch);
+  const setSearchQuery = useUIStore((s) => s.setLorebookPanelSearch);
+  const sort = useUIStore((s) => s.lorebookPanelSort);
+  const setSort = useUIStore((s) => s.setLorebookPanelSort);
+  const activeTag = useUIStore((s) => s.lorebookPanelActiveTag);
+  const setActiveTag = useUIStore((s) => s.setLorebookPanelActiveTag);
+  const tagsExpanded = useUIStore((s) => s.lorebookPanelTagsExpanded);
+  const setTagsExpanded = useUIStore((s) => s.setLorebookPanelTagsExpanded);
   const [selectionMode, setSelectionMode] = useState(false);
   const [selectedLorebookIds, setSelectedLorebookIds] = useState<Set<string>>(new Set());
   const [exportingSelected, setExportingSelected] = useState(false);
@@ -255,7 +260,7 @@ export function LorebooksPanel() {
         toast.error("Failed to remove tag from some lorebooks");
       }
     },
-    [lorebooks, updateLorebook, activeTag],
+    [lorebooks, updateLorebook, activeTag, setActiveTag],
   );
 
   // Filter by search
@@ -772,7 +777,7 @@ export function LorebooksPanel() {
         <div className="relative">
           <select
             value={sort}
-            onChange={(e) => setSort(e.target.value as typeof sort)}
+            onChange={(e) => setSort(e.target.value as LorebookPanelSort)}
             className="mari-chrome-field mari-chrome-sort-field mari-accent-animated h-10 appearance-none py-0 pl-2.5 pr-7 text-[0.6875rem] md:h-9"
             title="Sort order"
           >
@@ -811,7 +816,7 @@ export function LorebooksPanel() {
           <select
             id="lorebook-category-filter"
             value={activeCategory}
-            onChange={(event) => setActiveCategory(event.target.value as LorebookCategory | "all" | "active")}
+            onChange={(event) => setActiveCategory(event.target.value as LorebookPanelCategory)}
             className="mari-chrome-field h-10 w-full min-w-0 appearance-none truncate py-0 pl-3 pr-8 text-xs"
             title="Lorebook category"
           >

--- a/packages/client/src/hooks/use-game.ts
+++ b/packages/client/src/hooks/use-game.ts
@@ -22,6 +22,7 @@ import type {
   GameActiveState,
   GameMap,
   GameSetupConfig,
+  GameNpc,
   DiceRollResult,
   SessionSummary,
   Combatant,
@@ -49,6 +50,7 @@ interface CreateGameResponse {
 interface SetupResponse {
   setup: Record<string, unknown>;
   worldOverview: string | null;
+  gameNpcs?: GameNpc[];
 }
 
 interface StartGameResponse {
@@ -204,8 +206,11 @@ export function useGameSetup() {
         streaming: useUIStore.getState().enableStreaming,
         debugMode: useUIStore.getState().debugMode,
       }),
-    onSuccess: () => {
+    onSuccess: (res) => {
       store.getState().setSetupActive(false);
+      if (Array.isArray(res.gameNpcs)) {
+        store.getState().setNpcs(res.gameNpcs);
+      }
       const sessionChatId = store.getState().activeSessionChatId;
       if (sessionChatId) {
         qc.invalidateQueries({ queryKey: chatKeys.detail(sessionChatId) });

--- a/packages/client/src/hooks/use-lorebooks.ts
+++ b/packages/client/src/hooks/use-lorebooks.ts
@@ -393,6 +393,7 @@ export interface ActiveLorebookEntry {
   order: number;
   constant: boolean;
   selective: boolean;
+  matchedKeys?: string[];
 }
 
 export interface BudgetSkippedLorebookEntry {

--- a/packages/client/src/stores/gallery.store.ts
+++ b/packages/client/src/stores/gallery.store.ts
@@ -4,6 +4,46 @@
 import { create } from "zustand";
 import type { ChatImage } from "../hooks/use-gallery";
 
+const PINNED_GALLERY_IMAGES_STORAGE_KEY = "marinara-pinned-gallery-images";
+
+function isStoredChatImage(value: unknown): value is ChatImage {
+  if (!value || typeof value !== "object") return false;
+  const image = value as Partial<ChatImage>;
+  return (
+    typeof image.id === "string" &&
+    typeof image.chatId === "string" &&
+    typeof image.filePath === "string" &&
+    typeof image.prompt === "string" &&
+    typeof image.provider === "string" &&
+    typeof image.model === "string" &&
+    typeof image.createdAt === "string" &&
+    typeof image.url === "string" &&
+    (typeof image.width === "number" || image.width === null) &&
+    (typeof image.height === "number" || image.height === null)
+  );
+}
+
+function loadPinnedImages(): ChatImage[] {
+  if (typeof window === "undefined") return [];
+  try {
+    const raw = window.localStorage.getItem(PINNED_GALLERY_IMAGES_STORAGE_KEY);
+    if (!raw) return [];
+    const parsed = JSON.parse(raw);
+    return Array.isArray(parsed) ? parsed.filter(isStoredChatImage) : [];
+  } catch {
+    return [];
+  }
+}
+
+function savePinnedImages(images: ChatImage[]) {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.setItem(PINNED_GALLERY_IMAGES_STORAGE_KEY, JSON.stringify(images));
+  } catch {
+    // Pinned images are a convenience overlay; storage failures should not break chat rendering.
+  }
+}
+
 interface GalleryState {
   /** Images pinned to the chat area as floating overlays */
   pinnedImages: ChatImage[];
@@ -16,15 +56,28 @@ interface GalleryState {
 }
 
 export const useGalleryStore = create<GalleryState>((set) => ({
-  pinnedImages: [],
+  pinnedImages: loadPinnedImages(),
   illustratingChatIds: new Set(),
 
   pinImage: (image) =>
-    set((s) => (s.pinnedImages.some((p) => p.id === image.id) ? s : { pinnedImages: [...s.pinnedImages, image] })),
+    set((s) => {
+      if (s.pinnedImages.some((p) => p.id === image.id)) return s;
+      const pinnedImages = [...s.pinnedImages, image];
+      savePinnedImages(pinnedImages);
+      return { pinnedImages };
+    }),
 
-  unpinImage: (imageId) => set((s) => ({ pinnedImages: s.pinnedImages.filter((p) => p.id !== imageId) })),
+  unpinImage: (imageId) =>
+    set((s) => {
+      const pinnedImages = s.pinnedImages.filter((p) => p.id !== imageId);
+      savePinnedImages(pinnedImages);
+      return { pinnedImages };
+    }),
 
-  clearPinned: () => set({ pinnedImages: [] }),
+  clearPinned: () => {
+    savePinnedImages([]);
+    set({ pinnedImages: [] });
+  },
 
   setChatIllustrating: (chatId, illustrating) =>
     set((s) => {

--- a/packages/client/src/stores/ui.store.ts
+++ b/packages/client/src/stores/ui.store.ts
@@ -8,6 +8,7 @@ import {
   normalizeImageStyleProfileSettings,
   normalizeQuoteFormat,
   type ImageStyleProfileSettings,
+  type LorebookCategory,
   type QuoteFormat,
 } from "@marinara-engine/shared";
 import { isCssGradient, RAINBOW_GRADIENT_PRESET } from "../lib/css-colors";
@@ -26,6 +27,20 @@ type Panel =
 export type ChatModeShortcut = "conversation" | "roleplay" | "game";
 export const CHARACTER_LIBRARY_SORT_OPTIONS = ["name-asc", "name-desc", "newest", "oldest", "favorites"] as const;
 export type CharacterLibrarySort = (typeof CHARACTER_LIBRARY_SORT_OPTIONS)[number];
+export const CHARACTER_PANEL_FAVORITE_FILTER_OPTIONS = ["all", "favorites", "non-favorites"] as const;
+export type CharacterPanelFavoriteFilter = (typeof CHARACTER_PANEL_FAVORITE_FILTER_OPTIONS)[number];
+export const LOREBOOK_PANEL_CATEGORY_OPTIONS = [
+  "all",
+  "active",
+  "world",
+  "character",
+  "npc",
+  "spellbook",
+  "uncategorized",
+] as const satisfies readonly (LorebookCategory | "all" | "active")[];
+export type LorebookPanelCategory = (typeof LOREBOOK_PANEL_CATEGORY_OPTIONS)[number];
+export const LOREBOOK_PANEL_SORT_OPTIONS = ["name-asc", "name-desc", "newest", "oldest", "tokens"] as const;
+export type LorebookPanelSort = (typeof LOREBOOK_PANEL_SORT_OPTIONS)[number];
 type FontSize = 12 | 14 | 16 | 17 | 19 | 22;
 export type VisualTheme = "default" | "sillytavern";
 export type ConversationMessageStyle = "classic" | "bubble";
@@ -159,6 +174,33 @@ export function normalizeCharacterLibrarySort(value: unknown): CharacterLibraryS
   return CHARACTER_LIBRARY_SORT_OPTIONS.includes(value as CharacterLibrarySort)
     ? (value as CharacterLibrarySort)
     : "name-asc";
+}
+
+function normalizeCharacterPanelFavoriteFilter(value: unknown): CharacterPanelFavoriteFilter {
+  return CHARACTER_PANEL_FAVORITE_FILTER_OPTIONS.includes(value as CharacterPanelFavoriteFilter)
+    ? (value as CharacterPanelFavoriteFilter)
+    : "all";
+}
+
+function normalizeLorebookPanelCategory(value: unknown): LorebookPanelCategory {
+  return LOREBOOK_PANEL_CATEGORY_OPTIONS.includes(value as LorebookPanelCategory)
+    ? (value as LorebookPanelCategory)
+    : "all";
+}
+
+function normalizeLorebookPanelSort(value: unknown): LorebookPanelSort {
+  return LOREBOOK_PANEL_SORT_OPTIONS.includes(value as LorebookPanelSort) ? (value as LorebookPanelSort) : "name-asc";
+}
+
+function normalizePanelText(value: unknown) {
+  return typeof value === "string" ? value : "";
+}
+
+function normalizePanelStringArray(value: unknown) {
+  if (!Array.isArray(value)) return [];
+  return Array.from(
+    new Set(value.filter((item): item is string => typeof item === "string").map((item) => item.trim()).filter(Boolean)),
+  );
 }
 
 function normalizeScrollTop(value: unknown) {
@@ -406,10 +448,30 @@ interface UIState {
   characterLibrarySelectedId: string | null;
   /** Last selected sort order for character lists and the full-page character library */
   characterLibrarySort: CharacterLibrarySort;
+  /** Search text for the compact Characters panel */
+  characterPanelSearch: string;
+  /** Included tag filters for the compact Characters panel */
+  characterPanelIncludedTags: string[];
+  /** Excluded tag filters for the compact Characters panel */
+  characterPanelExcludedTags: string[];
+  /** Whether the compact Characters panel tag filter shelf is expanded */
+  characterPanelTagsExpanded: boolean;
+  /** Favorite filter for the compact Characters panel */
+  characterPanelFavoriteFilter: CharacterPanelFavoriteFilter;
   /** Last scroll offset for the compact Characters panel */
   characterPanelScrollTop: number;
   /** Last scroll offset for the full-page Character Library list */
   characterLibraryScrollTop: number;
+  /** Selected category for the compact Lorebooks panel */
+  lorebookPanelCategory: LorebookPanelCategory;
+  /** Search text for the compact Lorebooks panel */
+  lorebookPanelSearch: string;
+  /** Sort order for the compact Lorebooks panel */
+  lorebookPanelSort: LorebookPanelSort;
+  /** Selected tag filter for the compact Lorebooks panel */
+  lorebookPanelActiveTag: string | null;
+  /** Whether the compact Lorebooks panel tag/category shelf is expanded */
+  lorebookPanelTagsExpanded: boolean;
   /** True when any open detail editor has unsaved changes */
   editorDirty: boolean;
   /** Mobile-only return target for detail editors opened from a right panel */
@@ -666,8 +728,18 @@ interface UIState {
   setChatBackgroundBlur: (v: number) => void;
   setCharacterLibrarySelectedId: (id: string | null) => void;
   setCharacterLibrarySort: (sort: CharacterLibrarySort) => void;
+  setCharacterPanelSearch: (search: string) => void;
+  setCharacterPanelIncludedTags: (tags: string[]) => void;
+  setCharacterPanelExcludedTags: (tags: string[]) => void;
+  setCharacterPanelTagsExpanded: (expanded: boolean) => void;
+  setCharacterPanelFavoriteFilter: (filter: CharacterPanelFavoriteFilter) => void;
   setCharacterPanelScrollTop: (scrollTop: number) => void;
   setCharacterLibraryScrollTop: (scrollTop: number) => void;
+  setLorebookPanelCategory: (category: LorebookPanelCategory) => void;
+  setLorebookPanelSearch: (search: string) => void;
+  setLorebookPanelSort: (sort: LorebookPanelSort) => void;
+  setLorebookPanelActiveTag: (tag: string | null) => void;
+  setLorebookPanelTagsExpanded: (expanded: boolean) => void;
   openCharacterDetail: (id: string, options?: { preserveCharacterLibrary?: boolean }) => void;
   closeCharacterDetail: () => void;
   openLorebookDetail: (id: string) => void;
@@ -1045,8 +1117,18 @@ export const useUIStore = create<UIState>()(
       characterLibraryOpen: false,
       characterLibrarySelectedId: null,
       characterLibrarySort: "name-asc" as CharacterLibrarySort,
+      characterPanelSearch: "",
+      characterPanelIncludedTags: [],
+      characterPanelExcludedTags: [],
+      characterPanelTagsExpanded: false,
+      characterPanelFavoriteFilter: "all" as CharacterPanelFavoriteFilter,
       characterPanelScrollTop: 0,
       characterLibraryScrollTop: 0,
+      lorebookPanelCategory: "all" as LorebookPanelCategory,
+      lorebookPanelSearch: "",
+      lorebookPanelSort: "name-asc" as LorebookPanelSort,
+      lorebookPanelActiveTag: null,
+      lorebookPanelTagsExpanded: false,
       editorDirty: false,
       detailReturnRightPanel: null,
 
@@ -1269,8 +1351,19 @@ export const useUIStore = create<UIState>()(
       setChatBackgroundBlur: (v) => set({ chatBackgroundBlur: Math.max(0, Math.min(24, Math.round(v))) }),
       setCharacterLibrarySelectedId: (id) => set({ characterLibrarySelectedId: id }),
       setCharacterLibrarySort: (sort) => set({ characterLibrarySort: normalizeCharacterLibrarySort(sort) }),
+      setCharacterPanelSearch: (search) => set({ characterPanelSearch: normalizePanelText(search) }),
+      setCharacterPanelIncludedTags: (tags) => set({ characterPanelIncludedTags: normalizePanelStringArray(tags) }),
+      setCharacterPanelExcludedTags: (tags) => set({ characterPanelExcludedTags: normalizePanelStringArray(tags) }),
+      setCharacterPanelTagsExpanded: (expanded) => set({ characterPanelTagsExpanded: expanded }),
+      setCharacterPanelFavoriteFilter: (filter) =>
+        set({ characterPanelFavoriteFilter: normalizeCharacterPanelFavoriteFilter(filter) }),
       setCharacterPanelScrollTop: (scrollTop) => set({ characterPanelScrollTop: normalizeScrollTop(scrollTop) }),
       setCharacterLibraryScrollTop: (scrollTop) => set({ characterLibraryScrollTop: normalizeScrollTop(scrollTop) }),
+      setLorebookPanelCategory: (category) => set({ lorebookPanelCategory: normalizeLorebookPanelCategory(category) }),
+      setLorebookPanelSearch: (search) => set({ lorebookPanelSearch: normalizePanelText(search) }),
+      setLorebookPanelSort: (sort) => set({ lorebookPanelSort: normalizeLorebookPanelSort(sort) }),
+      setLorebookPanelActiveTag: (tag) => set({ lorebookPanelActiveTag: tag ? tag.trim() || null : null }),
+      setLorebookPanelTagsExpanded: (expanded) => set({ lorebookPanelTagsExpanded: expanded }),
       openCharacterDetail: (id, options) =>
         set((s) => {
           const preserveCharacterLibrary = options?.preserveCharacterLibrary ?? s.characterLibraryOpen;
@@ -2262,8 +2355,21 @@ export const useUIStore = create<UIState>()(
           persisted.appAccentColorBeforeRgbMode = null;
         }
         persisted.characterLibrarySort = normalizeCharacterLibrarySort(persisted.characterLibrarySort);
+        persisted.characterPanelSearch = normalizePanelText(persisted.characterPanelSearch);
+        persisted.characterPanelIncludedTags = normalizePanelStringArray(persisted.characterPanelIncludedTags);
+        persisted.characterPanelExcludedTags = normalizePanelStringArray(persisted.characterPanelExcludedTags);
+        persisted.characterPanelTagsExpanded = persisted.characterPanelTagsExpanded === true;
+        persisted.characterPanelFavoriteFilter = normalizeCharacterPanelFavoriteFilter(persisted.characterPanelFavoriteFilter);
         persisted.characterPanelScrollTop = normalizeScrollTop(persisted.characterPanelScrollTop);
         persisted.characterLibraryScrollTop = normalizeScrollTop(persisted.characterLibraryScrollTop);
+        persisted.lorebookPanelCategory = normalizeLorebookPanelCategory(persisted.lorebookPanelCategory);
+        persisted.lorebookPanelSearch = normalizePanelText(persisted.lorebookPanelSearch);
+        persisted.lorebookPanelSort = normalizeLorebookPanelSort(persisted.lorebookPanelSort);
+        persisted.lorebookPanelActiveTag =
+          typeof persisted.lorebookPanelActiveTag === "string" && persisted.lorebookPanelActiveTag.trim()
+            ? persisted.lorebookPanelActiveTag.trim()
+            : null;
+        persisted.lorebookPanelTagsExpanded = persisted.lorebookPanelTagsExpanded === true;
         normalizePersistedMainSurface(persisted);
         if (Array.isArray(persisted.recentUserActivities)) {
           persisted.recentUserActivities = persisted.recentUserActivities
@@ -2315,8 +2421,18 @@ export const useUIStore = create<UIState>()(
         characterLibraryOpen: state.characterLibraryOpen,
         characterLibrarySelectedId: state.characterLibrarySelectedId,
         characterLibrarySort: state.characterLibrarySort,
+        characterPanelSearch: state.characterPanelSearch,
+        characterPanelIncludedTags: state.characterPanelIncludedTags,
+        characterPanelExcludedTags: state.characterPanelExcludedTags,
+        characterPanelTagsExpanded: state.characterPanelTagsExpanded,
+        characterPanelFavoriteFilter: state.characterPanelFavoriteFilter,
         characterPanelScrollTop: state.characterPanelScrollTop,
         characterLibraryScrollTop: state.characterLibraryScrollTop,
+        lorebookPanelCategory: state.lorebookPanelCategory,
+        lorebookPanelSearch: state.lorebookPanelSearch,
+        lorebookPanelSort: state.lorebookPanelSort,
+        lorebookPanelActiveTag: state.lorebookPanelActiveTag,
+        lorebookPanelTagsExpanded: state.lorebookPanelTagsExpanded,
         trackerPanelEnabled: state.trackerPanelEnabled,
         trackerPanelOpen: state.trackerPanelOpen,
         trackerPanelSide: state.trackerPanelSide,

--- a/packages/server/src/db/migrate.ts
+++ b/packages/server/src/db/migrate.ts
@@ -202,7 +202,7 @@ const CREATE_TABLES: string[] = [
     dynamic_state TEXT NOT NULL DEFAULT '{}',
     activation_conditions TEXT NOT NULL DEFAULT '[]',
     schedule TEXT,
-    prevent_recursion TEXT NOT NULL DEFAULT 'false',
+    prevent_recursion TEXT NOT NULL DEFAULT 'true',
     exclude_recursion TEXT NOT NULL DEFAULT 'false',
     delay_until_recursion TEXT NOT NULL DEFAULT 'false',
     exclude_from_vectorization TEXT NOT NULL DEFAULT 'false',
@@ -642,7 +642,7 @@ const COLUMN_MIGRATIONS: ColumnMigration[] = [
   {
     table: "lorebook_entries",
     column: "prevent_recursion",
-    definition: "TEXT NOT NULL DEFAULT 'false'",
+    definition: "TEXT NOT NULL DEFAULT 'true'",
   },
   {
     table: "lorebook_entries",

--- a/packages/server/src/db/schema/lorebooks.ts
+++ b/packages/server/src/db/schema/lorebooks.ts
@@ -162,7 +162,7 @@ export const lorebookEntries = sqliteTable("lorebook_entries", {
   schedule: text("schedule"),
 
   /** When true, this entry's content won't trigger further entries during recursive scanning */
-  preventRecursion: text("prevent_recursion").notNull().default("false"),
+  preventRecursion: text("prevent_recursion").notNull().default("true"),
 
   /** When true, recursive scanning cannot activate this entry */
   excludeRecursion: text("exclude_recursion").notNull().default("false"),

--- a/packages/server/src/routes/agents.routes.ts
+++ b/packages/server/src/routes/agents.routes.ts
@@ -122,7 +122,6 @@ export async function agentsRoutes(app: FastifyInstance) {
       name: builtIn.name,
       description: builtIn.description,
       phase: normalizeAgentPhaseForType(builtIn.id, builtIn.phase),
-      enabled: true,
       connectionId: null,
       imagePath: null,
       promptTemplate: "",
@@ -289,7 +288,7 @@ export async function agentsRoutes(app: FastifyInstance) {
 
     const existing = await storage.getByType(agentType);
     if (existing) {
-      return storage.update(existing.id, { enabled: true });
+      return existing;
     }
 
     // First toggle — create a normal config; chats decide whether it runs.
@@ -298,7 +297,6 @@ export async function agentsRoutes(app: FastifyInstance) {
       name: builtIn.name,
       description: builtIn.description,
       phase: normalizeAgentPhaseForType(builtIn.id, builtIn.phase),
-      enabled: true,
       connectionId: null,
       imagePath: null,
       promptTemplate: "",

--- a/packages/server/src/routes/game.routes.ts
+++ b/packages/server/src/routes/game.routes.ts
@@ -2931,6 +2931,19 @@ function findRecordByName(records: Array<Record<string, unknown>>, name: string)
   );
 }
 
+function resolveNpcPortraitAppearance(
+  npc: { description?: string | null },
+  metadataNpc: GameNpc | null,
+  presentCharacter: Record<string, unknown> | null,
+): string {
+  return (
+    optionalTrimmedString(npc.description) ??
+    optionalTrimmedString(metadataNpc?.description) ??
+    optionalTrimmedString(presentCharacter?.appearance) ??
+    ""
+  );
+}
+
 function hasReadableAvatar(avatarUrl: string | null | undefined): avatarUrl is string {
   return !!avatarUrl && !!readAvatarBase64(avatarUrl);
 }
@@ -3666,6 +3679,7 @@ export async function gameRoutes(app: FastifyInstance) {
     return {
       setup: setupData,
       worldOverview: (setupData.worldOverview as string) || null,
+      gameNpcs: (hydratedUpdates.gameNpcs as GameNpc[] | undefined) ?? [],
     };
   };
 
@@ -8017,12 +8031,13 @@ export async function gameRoutes(app: FastifyInstance) {
         if (!forceNpcAvatar && findCharAvatarFuzzy(npc.name, charAvatarByName)) continue;
         const metadataNpc = findNpcRecordByName(currentNpcs, npc.name);
         const presentCharacter = findRecordByName(presentCharacters, npc.name);
+        const appearance = resolveNpcPortraitAppearance(npc, metadataNpc, presentCharacter);
         const promptOverride = promptOverrideById.get(gameImagePromptReviewId("portrait", npc.name));
 
         const compiledReviewPrompt = await buildNpcPortraitProviderPrompt({
           chatId: input.chatId,
           npcName: npc.name,
-          appearance: npc.description,
+          appearance,
           gender: npc.gender ?? metadataNpc?.gender ?? optionalTrimmedString(presentCharacter?.gender),
           pronouns: npc.pronouns ?? metadataNpc?.pronouns ?? optionalTrimmedString(presentCharacter?.pronouns),
           artStyle,
@@ -8392,10 +8407,11 @@ export async function gameRoutes(app: FastifyInstance) {
               }
               const metadataNpc = findNpcRecordByName(currentNpcs, npc.name);
               const presentCharacter = findRecordByName(presentCharacters, npc.name);
+              const appearance = resolveNpcPortraitAppearance(npc, metadataNpc, presentCharacter);
               const avatarUrl = await generateNpcPortrait({
                 chatId: input.chatId,
                 npcName: npc.name,
-                appearance: npc.description,
+                appearance,
                 gender: npc.gender ?? metadataNpc?.gender ?? optionalTrimmedString(presentCharacter?.gender),
                 pronouns: npc.pronouns ?? metadataNpc?.pronouns ?? optionalTrimmedString(presentCharacter?.pronouns),
                 artStyle,

--- a/packages/server/src/routes/generate.routes.ts
+++ b/packages/server/src/routes/generate.routes.ts
@@ -69,7 +69,7 @@ import { cosineSimilarity } from "../services/lorebook/embeddings.js";
 import { applyRegexScriptsToPromptMessages } from "../services/regex/regex-application.js";
 import { createPromptOverridesStorage } from "../services/storage/prompt-overrides.storage.js";
 import { resolveConversationSelfieSystemPrompt } from "../services/conversation/selfie-prompt.js";
-import { filterRelevantLorebooks, processLorebooks } from "../services/lorebook/index.js";
+import { filterRelevantLorebooks, processLorebooks, type LorebookScanResult } from "../services/lorebook/index.js";
 import {
   filterGameInternalAgentIds,
   resolveGameLorebookScopeExclusions,
@@ -407,6 +407,32 @@ import {
 } from "./generate/agent-write-approval.js";
 
 const PROFESSOR_MARI_INTERNAL_CHAT_MARKER = "professor-mari";
+
+type LorebookScanSnapshot = {
+  activatedEntries: LorebookScanResult["activatedEntries"];
+  budgetSkippedEntries: LorebookScanResult["budgetSkippedEntries"];
+  totalTokensEstimate: number;
+  totalEntries: number;
+};
+
+function emptyLorebookScanSnapshot(): LorebookScanSnapshot {
+  return {
+    activatedEntries: [],
+    budgetSkippedEntries: [],
+    totalTokensEstimate: 0,
+    totalEntries: 0,
+  };
+}
+
+function toLorebookScanSnapshot(result: LorebookScanResult | null | undefined): LorebookScanSnapshot {
+  if (!result) return emptyLorebookScanSnapshot();
+  return {
+    activatedEntries: result.activatedEntries,
+    budgetSkippedEntries: result.budgetSkippedEntries,
+    totalTokensEstimate: result.totalTokensEstimate,
+    totalEntries: result.totalEntries,
+  };
+}
 
 function findResultAgent(result: AgentResult, agents: ResolvedAgent[]): ResolvedAgent | null {
   return agents.find((agent) => agent.id === result.agentId || agent.type === result.agentType) ?? null;
@@ -1921,6 +1947,7 @@ export async function generateRoutes(app: FastifyInstance) {
           ? (chatMeta.activeLorebookIds as string[])
           : [];
         const gameLorebookScopeExclusions = resolveGameLorebookScopeExclusions(chatMode, chatMeta);
+        let lorebookScanSnapshot: LorebookScanSnapshot = emptyLorebookScanSnapshot();
         let presetHandledLorebooks = false;
         const presetHasLorebookMarker = (sections: Array<{ isMarker: string; markerConfig: string | null }>) =>
           sections.some((section) => {
@@ -2224,6 +2251,17 @@ export async function generateRoutes(app: FastifyInstance) {
           };
 
           const assembled = await assemblePrompt(assemblerInput);
+          if (assembled.lorebookActivatedEntries || assembled.lorebookBudgetSkippedEntries) {
+            lorebookScanSnapshot = {
+              activatedEntries: assembled.lorebookActivatedEntries ?? [],
+              budgetSkippedEntries: assembled.lorebookBudgetSkippedEntries ?? [],
+              totalTokensEstimate: Math.ceil(
+                (assembled.lorebookActivatedEntries ?? []).reduce((total, entry) => total + entry.content.length, 0) /
+                  4,
+              ),
+              totalEntries: (assembled.lorebookActivatedEntries ?? []).length,
+            };
+          }
           presetHandledLorebooks =
             presetHasLorebookMarker(sections) ||
             assembled.lorebookDepthEntriesCount > 0 ||
@@ -3447,6 +3485,7 @@ export async function generateRoutes(app: FastifyInstance) {
               generationTriggers: lorebookGenerationTriggers,
               resolveContent: resolvePromptMacrosForLorebook,
             });
+            lorebookScanSnapshot = toLorebookScanSnapshot(lorebookResult);
             rememberKnowledgeRouterActivatedLorebookIds(
               knowledgeRouterActivatedLorebookEntryIds,
               knowledgeRouterExcludedLorebookEntryIds,
@@ -3503,6 +3542,7 @@ export async function generateRoutes(app: FastifyInstance) {
             generationTriggers: lorebookGenerationTriggers,
             resolveContent: resolvePromptMacrosForLorebook,
           });
+          lorebookScanSnapshot = toLorebookScanSnapshot(lorebookResult);
           rememberKnowledgeRouterActivatedLorebookIds(
             knowledgeRouterActivatedLorebookEntryIds,
             knowledgeRouterExcludedLorebookEntryIds,
@@ -4191,6 +4231,7 @@ export async function generateRoutes(app: FastifyInstance) {
                 resolveContent: resolvePromptMacrosForLorebook,
               },
             );
+            lorebookScanSnapshot = toLorebookScanSnapshot(lorebookResult);
             rememberKnowledgeRouterActivatedLorebookIds(
               knowledgeRouterActivatedLorebookEntryIds,
               knowledgeRouterExcludedLorebookEntryIds,
@@ -6972,6 +7013,9 @@ export async function generateRoutes(app: FastifyInstance) {
             extraUpdate.generationReplay = buildGenerationReplay(input);
             // Cache the final prompt (what was actually sent to the model) for Peek Prompt
             extraUpdate.cachedPrompt = finalPromptSent.map((m) => ({ role: m.role, content: m.content }));
+            // Cache the lorebook scan that produced the prompt so Active Context
+            // reflects the last generation instead of a best-effort rescan.
+            extraUpdate.lorebookScan = lorebookScanSnapshot;
             extraUpdate.chatSummaryFingerprint = fingerprintChatSummary(chatMeta.summary);
             const persistentAttachments = resolveUserRegenerationPersistentAttachments(regenMsg ?? {});
             if (persistentAttachments) extraUpdate.attachments = persistentAttachments;

--- a/packages/server/src/routes/lorebooks.routes.ts
+++ b/packages/server/src/routes/lorebooks.routes.ts
@@ -130,6 +130,81 @@ function resolveScanGenerationTriggers(mode: unknown): string[] {
   return Array.from(new Set(["test_scan", modeTrigger, "chat"]));
 }
 
+type CachedLorebookScanEntry = {
+  id: string;
+  content: string;
+  matchedKeys: string[];
+};
+
+type CachedLorebookScan = {
+  activatedEntries: CachedLorebookScanEntry[];
+  budgetSkippedEntries: Array<Record<string, unknown>>;
+  totalTokensEstimate: number;
+  totalEntries: number;
+};
+
+function parseRecord(raw: unknown): Record<string, unknown> {
+  if (!raw) return {};
+  if (typeof raw === "string") {
+    try {
+      const parsed = JSON.parse(raw);
+      return parsed && typeof parsed === "object" && !Array.isArray(parsed) ? (parsed as Record<string, unknown>) : {};
+    } catch {
+      return {};
+    }
+  }
+  return raw && typeof raw === "object" && !Array.isArray(raw) ? (raw as Record<string, unknown>) : {};
+}
+
+function normalizeCachedLorebookScan(raw: unknown): CachedLorebookScan | null {
+  const value = parseRecord(raw);
+  if (
+    !Object.prototype.hasOwnProperty.call(value, "activatedEntries") &&
+    !Object.prototype.hasOwnProperty.call(value, "budgetSkippedEntries")
+  ) {
+    return null;
+  }
+
+  const activatedEntries = Array.isArray(value.activatedEntries)
+    ? value.activatedEntries.flatMap((entry): CachedLorebookScanEntry[] => {
+        const candidate = parseRecord(entry);
+        if (typeof candidate.id !== "string") return [];
+        return [
+          {
+            id: candidate.id,
+            content: typeof candidate.content === "string" ? candidate.content : "",
+            matchedKeys: Array.isArray(candidate.matchedKeys)
+              ? candidate.matchedKeys.filter((key): key is string => typeof key === "string")
+              : [],
+          },
+        ];
+      })
+    : [];
+
+  const budgetSkippedEntries = Array.isArray(value.budgetSkippedEntries)
+    ? value.budgetSkippedEntries.flatMap((entry): Array<Record<string, unknown>> => {
+        const candidate = parseRecord(entry);
+        return typeof candidate.id === "string" ? [candidate] : [];
+      })
+    : [];
+
+  const totalTokensEstimate =
+    typeof value.totalTokensEstimate === "number" && Number.isFinite(value.totalTokensEstimate)
+      ? value.totalTokensEstimate
+      : Math.ceil(activatedEntries.reduce((total, entry) => total + entry.content.length, 0) / 4);
+  const totalEntries =
+    typeof value.totalEntries === "number" && Number.isFinite(value.totalEntries)
+      ? value.totalEntries
+      : activatedEntries.length;
+
+  return {
+    activatedEntries,
+    budgetSkippedEntries,
+    totalTokensEstimate,
+    totalEntries,
+  };
+}
+
 function selectMessagesForLastGenerationScan<T extends { role: string }>(messages: T[]): T[] {
   let lastGeneratedIndex = -1;
   for (let index = messages.length - 1; index >= 0; index--) {
@@ -737,6 +812,55 @@ export async function lorebooksRoutes(app: FastifyInstance) {
       }
     }
 
+    const latestGeneratedMessage = (() => {
+      for (let index = chatMessages.length - 1; index >= 0; index--) {
+        const message = chatMessages[index]!;
+        if (message.role === "assistant" || message.role === "narrator") return message;
+      }
+      return null;
+    })();
+    if (latestGeneratedMessage) {
+      let cachedScan: CachedLorebookScan | null = null;
+      try {
+        const swipes = await chatsStorage.getSwipes(latestGeneratedMessage.id);
+        const activeSwipe = swipes.find((swipe: any) => swipe.index === latestGeneratedMessage.activeSwipeIndex);
+        cachedScan = normalizeCachedLorebookScan(parseRecord(activeSwipe?.extra).lorebookScan);
+      } catch {
+        cachedScan = null;
+      }
+      cachedScan ??= normalizeCachedLorebookScan(parseRecord(latestGeneratedMessage.extra).lorebookScan);
+
+      if (cachedScan) {
+        const resolvedContentById = new Map(cachedScan.activatedEntries.map((entry) => [entry.id, entry.content]));
+        const matchedKeysById = new Map(cachedScan.activatedEntries.map((entry) => [entry.id, entry.matchedKeys]));
+        const activeEntries =
+          cachedScan.activatedEntries.length > 0
+            ? await Promise.all(cachedScan.activatedEntries.map((entry) => storage.getEntry(entry.id))).then((entries) =>
+                entries.filter(Boolean),
+              )
+            : [];
+
+        return {
+          entries: activeEntries.map((e) => ({
+            id: (e as Record<string, unknown>).id,
+            name: (e as Record<string, unknown>).name,
+            content:
+              resolvedContentById.get(String((e as Record<string, unknown>).id)) ??
+              (e as Record<string, unknown>).content,
+            keys: (e as Record<string, unknown>).keys,
+            lorebookId: (e as Record<string, unknown>).lorebookId,
+            order: (e as Record<string, unknown>).order,
+            constant: (e as Record<string, unknown>).constant,
+            selective: (e as Record<string, unknown>).selective === true,
+            matchedKeys: matchedKeysById.get(String((e as Record<string, unknown>).id)) ?? [],
+          })),
+          totalTokens: cachedScan.totalTokensEstimate,
+          totalEntries: cachedScan.totalEntries,
+          budgetSkippedEntries: cachedScan.budgetSkippedEntries,
+        };
+      }
+    }
+
     const lorebookScopeExclusions = resolveGameLorebookScopeExclusions(chat?.mode, chatMeta);
     const scanSourceMessages = selectMessagesForLastGenerationScan(chatMessages);
     const scanMessages = scanSourceMessages.map((m) => ({
@@ -848,6 +972,7 @@ export async function lorebooksRoutes(app: FastifyInstance) {
     });
 
     const resolvedContentById = new Map(result.activatedEntries.map((entry) => [entry.id, entry.content]));
+    const matchedKeysById = new Map(result.activatedEntries.map((entry) => [entry.id, entry.matchedKeys]));
 
     // Fetch full entry data for the activated IDs
     const activeEntries =
@@ -868,6 +993,7 @@ export async function lorebooksRoutes(app: FastifyInstance) {
         order: (e as Record<string, unknown>).order,
         constant: (e as Record<string, unknown>).constant,
         selective: (e as Record<string, unknown>).selective === true,
+        matchedKeys: matchedKeysById.get(String((e as Record<string, unknown>).id)) ?? [],
       })),
       totalTokens: result.totalTokensEstimate,
       totalEntries: result.totalEntries,

--- a/packages/server/src/services/import/marinara.importer.ts
+++ b/packages/server/src/services/import/marinara.importer.ts
@@ -516,7 +516,7 @@ async function importLorebook(data: unknown, db: DB) {
         groupWeight: e.groupWeight != null ? Number(e.groupWeight) : null,
         folderId: newFolderId,
         locked: Boolean(e.locked),
-        preventRecursion: Boolean(e.preventRecursion),
+        preventRecursion: e.preventRecursion == null ? true : Boolean(e.preventRecursion),
         excludeRecursion: Boolean(e.excludeRecursion),
         delayUntilRecursion: Boolean(e.delayUntilRecursion),
         excludeFromVectorization: Boolean(e.excludeFromVectorization),

--- a/packages/server/src/services/import/st-lorebook.importer.ts
+++ b/packages/server/src/services/import/st-lorebook.importer.ts
@@ -475,7 +475,7 @@ export async function importSTLorebook(
       dynamicState: {},
       activationConditions: [],
       schedule: null,
-      preventRecursion: Boolean(entry.preventRecursion ?? false),
+      preventRecursion: entry.preventRecursion == null ? true : Boolean(entry.preventRecursion),
       excludeRecursion: Boolean(entry.excludeRecursion ?? false),
       delayUntilRecursion: Boolean(entry.delayUntilRecursion ?? false),
       excludeFromVectorization: entry.vectorized === false ? true : entry.excludeFromVectorization === true,

--- a/packages/server/src/services/lorebook/index.ts
+++ b/packages/server/src/services/lorebook/index.ts
@@ -699,12 +699,14 @@ export function resolveBudgetAndRecursivelyActivateLorebookEntriesWithDiagnostic
   tokenBudget: number,
   maxEntries: number,
   resolveContent?: LorebookFinalContentResolver,
+  recursiveLorebookIds?: ReadonlySet<string>,
 ): { selected: ActivatedEntry[]; budgetSkippedEntries: LorebookBudgetSkippedEntry[] } {
   let state = createLorebookBudgetSelectionState();
   const processedIds = new Set<string>();
   const selectedGroups = new Set<string>();
   const probabilityDecisions = options.probabilityDecisions ?? new Map<string, boolean>();
   const scanOptions = { ...options, probabilityDecisions };
+  const canRecurseEntry = (entry: LorebookEntry) => !recursiveLorebookIds || recursiveLorebookIds.has(entry.lorebookId);
   let frontier = scanForActivatedEntries(messages, entries, scanOptions);
   const budgetSkippedEntries: LorebookBudgetSkippedEntry[] = [];
 
@@ -734,7 +736,7 @@ export function resolveBudgetAndRecursivelyActivateLorebookEntriesWithDiagnostic
     }
 
     const recursiveContentParts = selectedBatch.selectedFromCandidates
-      .filter((selected) => !selected.entry.preventRecursion)
+      .filter((selected) => canRecurseEntry(selected.entry) && !selected.entry.preventRecursion)
       .map((selected) => selected.entry.content);
 
     if (depth >= maxDepth) break;
@@ -747,6 +749,7 @@ export function resolveBudgetAndRecursivelyActivateLorebookEntriesWithDiagnostic
       (entry) =>
         !processedIds.has(entry.id) &&
         !state.selectedIds.has(entry.id) &&
+        canRecurseEntry(entry) &&
         !entry.excludeRecursion &&
         !(entry.group && selectedGroups.has(entry.group)),
     );
@@ -773,6 +776,7 @@ export function resolveBudgetAndRecursivelyActivateLorebookEntries(
   tokenBudget: number,
   maxEntries: number,
   resolveContent?: LorebookFinalContentResolver,
+  recursiveLorebookIds?: ReadonlySet<string>,
 ): ActivatedEntry[] {
   return resolveBudgetAndRecursivelyActivateLorebookEntriesWithDiagnostics(
     messages,
@@ -783,6 +787,7 @@ export function resolveBudgetAndRecursivelyActivateLorebookEntries(
     tokenBudget,
     maxEntries,
     resolveContent,
+    recursiveLorebookIds,
   ).selected;
 }
 
@@ -921,8 +926,11 @@ export async function processLorebooks(
   };
 
   // Determine recursion settings from relevant enabled lorebooks only.
+  const recursiveLorebookIds = new Set(
+    relevantLorebooks.filter((b: { recursiveScanning: boolean }) => b.recursiveScanning).map((b) => b.id),
+  );
   const anyRecursive =
-    options?.enableRecursive || relevantLorebooks.some((b: { recursiveScanning: boolean }) => b.recursiveScanning);
+    options?.enableRecursive || recursiveLorebookIds.size > 0;
   const maxRecursionDepth = relevantLorebooks.reduce(
     (max: number, b: { recursiveScanning: boolean; maxRecursionDepth?: number }) => {
       if (!b.recursiveScanning) return max;
@@ -941,6 +949,7 @@ export async function processLorebooks(
         tokenBudget,
         0,
         options?.resolveContent,
+        options?.enableRecursive ? undefined : recursiveLorebookIds,
       )
     : resolveAndBudgetActivatedLorebookEntriesWithDiagnostics(
         scanForActivatedEntries(messages, allEntries, scanOpts),

--- a/packages/server/src/services/lorebook/keyword-scanner.ts
+++ b/packages/server/src/services/lorebook/keyword-scanner.ts
@@ -535,6 +535,9 @@ export function scanForActivatedEntries(
   if (chatEmbedding && chatEmbedding.length > 0) {
     for (const entry of entries) {
       if (!entry.enabled || entry.constant || activatedIds.has(entry.id)) continue;
+      // Explicit primary keys mean the entry is keyword-gated. Vectorization is
+      // still useful for router/search flows, but it must not bypass those keys.
+      if (entry.keys.some((key) => key.trim().length > 0)) continue;
       if (entry.delayUntilRecursion && !recursionPass) continue;
       if (entry.excludeRecursion && recursionPass) continue;
       if (entry.excludeFromVectorization) continue;

--- a/packages/server/src/services/mari-db/mari-db.service.ts
+++ b/packages/server/src/services/mari-db/mari-db.service.ts
@@ -1888,7 +1888,7 @@ export class MariDbService {
           relationships: {},
           dynamicState: {},
           activationConditions: [],
-          preventRecursion: "false",
+          preventRecursion: "true",
           excludeRecursion: "false",
           delayUntilRecursion: "false",
           excludeFromVectorization: "false",

--- a/packages/server/src/services/storage/agents.storage.ts
+++ b/packages/server/src/services/storage/agents.storage.ts
@@ -49,8 +49,8 @@ function keepLatestConfigPerType<T extends { type: string }>(rows: T[]): T[] {
 function normalizeAgentConfigRow<T extends AgentConfigRow | null>(row: T): T {
   if (!row) return row;
   const phase = normalizeAgentPhaseForType(row.type, row.phase);
-  if (phase === row.phase && row.enabled === "true") return row;
-  return { ...row, phase, enabled: "true" } as T;
+  if (phase === row.phase) return row;
+  return { ...row, phase } as T;
 }
 
 function isRemovedBuiltInAgentType(type: string): boolean {
@@ -77,7 +77,6 @@ function mergeBuiltInCreateUpdate(
     name: input.name,
     description: input.description,
     phase: input.phase,
-    enabled: true,
     settings: nextSettings,
   };
 
@@ -245,7 +244,6 @@ export function createAgentsStorage(db: DB) {
         const current = await getById(id);
         updateFields.phase = normalizeAgentPhaseForType(current?.type ?? "", data.phase);
       }
-      if (data.enabled !== undefined) updateFields.enabled = "true";
       if (data.connectionId !== undefined) updateFields.connectionId = data.connectionId;
       if (data.imagePath !== undefined) updateFields.imagePath = data.imagePath;
       if (data.promptTemplate !== undefined) updateFields.promptTemplate = data.promptTemplate;
@@ -277,7 +275,6 @@ export function createAgentsStorage(db: DB) {
       if (existing) {
         await removeRuntimeData(existing.id);
         return this.update(existing.id, {
-          enabled: true,
           settings: markAgentConfigDeletedSettings(existing.settings),
         });
       }
@@ -287,7 +284,6 @@ export function createAgentsStorage(db: DB) {
         name: builtIn.name,
         description: builtIn.description,
         phase: normalizeAgentPhaseForType(builtIn.id, builtIn.phase),
-        enabled: true,
         connectionId: null,
         imagePath: null,
         promptTemplate: "",

--- a/packages/server/src/services/storage/chat-presets.storage.ts
+++ b/packages/server/src/services/storage/chat-presets.storage.ts
@@ -275,22 +275,29 @@ export function createChatPresetsStorage(db: DB) {
           }
         })();
 
+        const presetMetadata = (preset.settings.metadata ?? {}) as Record<string, unknown>;
+
         // Preserve only chat-specific (non-preset) metadata keys.
         const preserved: Record<string, unknown> = {};
         for (const [key, value] of Object.entries(currentMetadata)) {
           if (isPresetExcludedMetadataKey(key)) preserved[key] = value;
+        }
+        if (!Object.prototype.hasOwnProperty.call(presetMetadata, "activeAgentIds")) {
+          preserved.activeAgentIds = sanitizePresetAgentIds(currentMetadata.activeAgentIds);
+        }
+        if (!Object.prototype.hasOwnProperty.call(presetMetadata, "agentOverrides")) {
+          preserved.agentOverrides = sanitizePresetAgentMap(currentMetadata.agentOverrides);
+        }
+        if (!Object.prototype.hasOwnProperty.call(presetMetadata, "agentPromptTemplateIds")) {
+          preserved.agentPromptTemplateIds = sanitizePresetAgentMap(currentMetadata.agentPromptTemplateIds);
         }
 
         const baseDefaults: Record<string, unknown> = {
           summary: null,
           tags: [],
           enableAgents: true,
-          agentOverrides: {},
-          activeAgentIds: [],
           activeToolIds: [],
         };
-
-        const presetMetadata = (preset.settings.metadata ?? {}) as Record<string, unknown>;
 
         const newMetadata: Record<string, unknown> = {
           ...baseDefaults,

--- a/packages/server/src/services/storage/lorebooks.storage.ts
+++ b/packages/server/src/services/storage/lorebooks.storage.ts
@@ -566,7 +566,7 @@ export function createLorebooksStorage(db: DB) {
         activationConditions: JSON.stringify(input.activationConditions ?? []),
         schedule: input.schedule ? JSON.stringify(input.schedule) : null,
         locked: String(input.locked ?? false),
-        preventRecursion: String(input.preventRecursion ?? false),
+        preventRecursion: String(input.preventRecursion ?? true),
         excludeRecursion: String(input.excludeRecursion ?? false),
         delayUntilRecursion: String(input.delayUntilRecursion ?? false),
         excludeFromVectorization: String(input.excludeFromVectorization ?? false),

--- a/packages/shared/src/schemas/agent.schema.ts
+++ b/packages/shared/src/schemas/agent.schema.ts
@@ -46,7 +46,8 @@ export const createAgentConfigSchema = z.object({
   name: z.string().min(1).max(200),
   description: z.string().default(""),
   phase: agentPhaseSchema,
-  enabled: z.boolean().default(true),
+  /** Legacy compatibility only. Agent activation is chat-scoped via chat metadata. */
+  enabled: z.boolean().optional(),
   connectionId: z.string().nullable().default(null),
   imagePath: z.string().nullable().default(null),
   resultType: agentResultTypeSchema.optional(),

--- a/packages/shared/src/schemas/lorebook.schema.ts
+++ b/packages/shared/src/schemas/lorebook.schema.ts
@@ -188,7 +188,7 @@ export const createLorebookEntrySchema = z.object({
   groupWeight: z.number().nullable().default(null),
   /** Optional folder this entry belongs to. Null/omitted = root level. */
   folderId: z.string().nullable().default(null),
-  preventRecursion: z.boolean().default(false),
+  preventRecursion: z.boolean().default(true),
   excludeRecursion: z.boolean().default(false),
   delayUntilRecursion: z.boolean().default(false),
   locked: z.boolean().default(false),


### PR DESCRIPTION
## Linked issue

No single linked issue; this is the v2.0.4 stabilization/release polish batch requested by the maintainer.

## Why this change

- v2.0.4 needs the remaining stabilization fixes gathered into staging before release preparation.
- Several fixes protect user data and restore expected behavior across chat agents, lorebooks, pinned gallery images, game NPC portraits, and library filters.

## What changed

- Added Game HUD widget import/export controls in Chat Settings and the Game Setup Wizard.
- Persisted pinned chat gallery images and fixed pinning from the full image lightbox.
- Restored legacy group-chat lookup for the old Professor Mari card while keeping the home-page assistant out of expression/game avatar matching.
- Removed remaining reliance on the old global agent enabled flag so chat-scoped agent activation works normally.
- Made lorebook recursion opt-in by default, added click-away keyword commits, and cached the actual lorebook scan used by the last generation for Active Context.
- Persisted Characters and Lorebooks panel search/filter/sort state while moving into and out of editors.
- Passed Game mode generated NPC descriptions into portrait prompt generation.
- Updated CHANGELOG.md for the v2.0.4 release batch.

## Validation

- [ ] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed `CONTRIBUTING.md`

### Manual verification notes

- Automated/local validation run by Codex: `git diff --check`, conflict-marker scan with `rg`, `pnpm version:check`, and `pnpm check`.
- Browser/manual verification still needs maintainer pass before release tagging.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Version/release files updated (only if this PR includes a version bump)

## UI evidence (if applicable)

- Not captured in this pass; maintainer browser verification recommended for the UI paths.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added widget import/export controls for reusing Game Mode HUD layouts between games in Chat Settings and Game Setup Wizard.
  * Image pinning now persists across sessions.

* **Bug Fixes**
  * Fixed character card resolution with avatar matching in legacy group chats.
  * Fixed agent activation regressions and Active Context lorebook caching.
  * Fixed lorebook recursion defaults and keyword-based entry filtering.
  * Fixed NPC portrait availability and persistence in Game Mode.
  * Fixed Chat Settings persistence for widgets, image pins, and panel filters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->