### PR TITLE
fix(chat): tracker edit targeting, prefill debounce, prompt-editor close, per-chat lorebook disable, convo card info

### DIFF
--- a/packages/client/src/components/chat/ChatSettingsDrawer.tsx
+++ b/packages/client/src/components/chat/ChatSettingsDrawer.tsx
@@ -593,6 +593,13 @@ function getChatActiveLorebookIds(chat: Chat): string[] {
   return Array.isArray(activeIds) ? activeIds.filter((id): id is string => typeof id === "string") : [];
 }
 
+function getChatExcludedLorebookIds(chat: Chat): string[] {
+  const metadata = typeof chat.metadata === "string" ? JSON.parse(chat.metadata) : (chat.metadata ?? {});
+  const excludedIds =
+    metadata && typeof metadata === "object" ? (metadata as { excludedLorebookIds?: unknown }).excludedLorebookIds : [];
+  return Array.isArray(excludedIds) ? excludedIds.filter((id): id is string => typeof id === "string") : [];
+}
+
 export function ChatSettingsDrawer({
   chat,
   open,
@@ -828,11 +835,20 @@ export function ChatSettingsDrawer({
     const latestChat = qc.getQueryData<Chat>(chatKeys.detail(chat.id));
     return latestChat ? getChatActiveLorebookIds(latestChat) : [...activeLorebookIds];
   }, [activeLorebookIds, chat.id, qc]);
+  const excludedLorebookIds = useMemo<string[]>(
+    () => (Array.isArray(metadata.excludedLorebookIds) ? metadata.excludedLorebookIds : []),
+    [metadata.excludedLorebookIds],
+  );
+  const readLatestExcludedLorebookIds = useCallback(() => {
+    const latestChat = qc.getQueryData<Chat>(chatKeys.detail(chat.id));
+    return latestChat ? getChatExcludedLorebookIds(latestChat) : [...excludedLorebookIds];
+  }, [chat.id, excludedLorebookIds, qc]);
   const gameLorebookKeeperEnabled = metadata.gameLorebookKeeperEnabled === true;
   const gameLorebookKeeperLorebookId =
     typeof metadata.gameLorebookKeeperLorebookId === "string" ? metadata.gameLorebookKeeperLorebookId : null;
   const activeLorebooks = useMemo<ActiveLorebookView[]>(() => {
     const pinnedIds = new Set(activeLorebookIds);
+    const excludedIds = new Set(excludedLorebookIds);
     const lorebookList = (lorebooks ?? []) as Lorebook[];
 
     return lorebookList.flatMap((lorebook) => {
@@ -865,10 +881,13 @@ export function ChatSettingsDrawer({
         if (lorebook.chatId === chat.id && !reasons.includes("Chat")) reasons.push("Chat");
       }
 
-      return reasons.length > 0 ? [{ ...lorebook, activeReasons: reasons, isPinned }] : [];
+      return reasons.length > 0
+        ? [{ ...lorebook, activeReasons: reasons, isPinned, isExcluded: excludedIds.has(lorebook.id) }]
+        : [];
     });
   }, [
     activeLorebookIds,
+    excludedLorebookIds,
     chat.id,
     chat.personaId,
     chatCharIds,
@@ -1920,10 +1939,15 @@ export function ChatSettingsDrawer({
     updateMeta.mutate({ id: chat.id, activeLorebookIds: current });
   };
 
-  const pinLorebookToChat = (lbId: string) => {
-    const current = readLatestActiveLorebookIds();
-    if (current.includes(lbId)) return;
-    updateMeta.mutate({ id: chat.id, activeLorebookIds: [...current, lbId] });
+  // Disable / re-enable an auto-activated (character/global/persona) lorebook for
+  // this chat. Unlike unpinning, this does not touch activeLorebookIds — it adds
+  // the book to excludedLorebookIds so the scope filter drops it before injection.
+  const setLorebookExcluded = (lbId: string, excluded: boolean) => {
+    const current = readLatestExcludedLorebookIds();
+    const has = current.includes(lbId);
+    if (excluded === has) return;
+    const next = excluded ? [...current, lbId] : current.filter((id) => id !== lbId);
+    updateMeta.mutate({ id: chat.id, excludedLorebookIds: next });
   };
 
   const hasSecretPlotMemory = (memory: Record<string, unknown> | null | undefined) => {
@@ -5106,9 +5130,9 @@ export function ChatSettingsDrawer({
               onLorebookTokenBudgetChange={(lorebookTokenBudget) =>
                 updateMeta.mutate({ id: chat.id, lorebookTokenBudget })
               }
-              onPinLorebook={pinLorebookToChat}
               onShowLorebookPickerChange={setShowLbPicker}
               onToggleLorebook={toggleLorebook}
+              onSetLorebookExcluded={setLorebookExcluded}
             />
           </div>
 

--- a/packages/client/src/components/ui/DraftTextarea.tsx
+++ b/packages/client/src/components/ui/DraftTextarea.tsx
@@ -1,0 +1,53 @@
+import { useEffect, useRef, useState, type TextareaHTMLAttributes } from "react";
+
+interface DraftTextareaProps extends Omit<TextareaHTMLAttributes<HTMLTextAreaElement>, "value" | "onChange"> {
+  value: string;
+  onCommit: (value: string) => void;
+}
+
+/**
+ * Textarea that buffers keystrokes in local state and only propagates the value
+ * on blur. Mirrors {@link DraftNumberInput}: typing updates local state
+ * instantly so the field stays responsive even when committing the value is
+ * expensive (e.g. it round-trips through a per-chat metadata mutation that
+ * re-renders a large settings tree), and the draft re-seeds whenever the
+ * external value changes. An in-progress edit is also flushed on unmount so
+ * closing the host (e.g. the chat settings drawer) before blurring does not
+ * drop typed text.
+ */
+export function DraftTextarea({ value, onCommit, onBlur, ...props }: DraftTextareaProps) {
+  const [draft, setDraft] = useState(value);
+  const draftRef = useRef(draft);
+  draftRef.current = draft;
+  const valueRef = useRef(value);
+  valueRef.current = value;
+  const onCommitRef = useRef(onCommit);
+  onCommitRef.current = onCommit;
+
+  useEffect(() => {
+    setDraft(value);
+  }, [value]);
+
+  const commit = () => {
+    if (draftRef.current !== valueRef.current) onCommitRef.current(draftRef.current);
+  };
+
+  useEffect(
+    () => () => {
+      if (draftRef.current !== valueRef.current) onCommitRef.current(draftRef.current);
+    },
+    [],
+  );
+
+  return (
+    <textarea
+      {...props}
+      value={draft}
+      onChange={(event) => setDraft(event.target.value)}
+      onBlur={(event) => {
+        commit();
+        onBlur?.(event);
+      }}
+    />
+  );
+}

--- a/packages/client/src/components/ui/DraftTextarea.tsx
+++ b/packages/client/src/components/ui/DraftTextarea.tsx
@@ -7,16 +7,21 @@ interface DraftTextareaProps extends Omit<TextareaHTMLAttributes<HTMLTextAreaEle
 
 /**
  * Textarea that buffers keystrokes in local state and only propagates the value
- * on blur. Mirrors {@link DraftNumberInput}: typing updates local state
- * instantly so the field stays responsive even when committing the value is
- * expensive (e.g. it round-trips through a per-chat metadata mutation that
- * re-renders a large settings tree), and the draft re-seeds whenever the
- * external value changes. An in-progress edit is also flushed on unmount so
- * closing the host (e.g. the chat settings drawer) before blurring does not
- * drop typed text.
+ * on blur, so the field stays responsive even when committing is expensive
+ * (e.g. it round-trips through a per-chat metadata mutation that re-renders a
+ * large settings tree).
+ *
+ * Follows the same draft/commit/focus-guard pattern as the sibling
+ * `ThinkingTagsInput`/`CustomParametersInput`: the draft re-seeds from `value`
+ * only while the field is unfocused, so an external write to the persisted value
+ * (a background metadata refresh, a chat switch) cannot clobber keystrokes the
+ * user is mid-typing. Like `DraftNumberInput` it commits on blur; it
+ * additionally flushes a pending edit on unmount so closing the host (e.g. the
+ * chat settings drawer) does not drop typed text.
  */
-export function DraftTextarea({ value, onCommit, onBlur, ...props }: DraftTextareaProps) {
+export function DraftTextarea({ value, onCommit, onFocus, onBlur, ...props }: DraftTextareaProps) {
   const [draft, setDraft] = useState(value);
+  const [focused, setFocused] = useState(false);
   const draftRef = useRef(draft);
   draftRef.current = draft;
   const valueRef = useRef(value);
@@ -25,8 +30,8 @@ export function DraftTextarea({ value, onCommit, onBlur, ...props }: DraftTextar
   onCommitRef.current = onCommit;
 
   useEffect(() => {
-    setDraft(value);
-  }, [value]);
+    if (!focused) setDraft(value);
+  }, [focused, value]);
 
   const commit = () => {
     if (draftRef.current !== valueRef.current) onCommitRef.current(draftRef.current);
@@ -44,8 +49,13 @@ export function DraftTextarea({ value, onCommit, onBlur, ...props }: DraftTextar
       {...props}
       value={draft}
       onChange={(event) => setDraft(event.target.value)}
+      onFocus={(event) => {
+        setFocused(true);
+        onFocus?.(event);
+      }}
       onBlur={(event) => {
         commit();
+        setFocused(false);
         onBlur?.(event);
       }}
     />

--- a/packages/client/src/components/ui/ExpandedTextarea.tsx
+++ b/packages/client/src/components/ui/ExpandedTextarea.tsx
@@ -55,6 +55,12 @@ export function ExpandedTextarea({
     <AnimatePresence>
       {open && (
         <motion.div
+          // This overlay portals to <body> and sits above any chat drawer that
+          // opened it. Mark it as a chat floating panel so the drawer's
+          // outside-pointerdown close handler treats clicks inside the editor as
+          // "inside" — otherwise the first click (including the Collapse button)
+          // closes the drawer, unmounting the editor before its edit can commit.
+          data-chat-floating-panel="true"
           className={cn(
             "fixed inset-0 z-[100] flex flex-col max-md:pt-[env(safe-area-inset-top)]",
             isChatSurface

--- a/packages/client/src/components/ui/GenerationParametersEditor.tsx
+++ b/packages/client/src/components/ui/GenerationParametersEditor.tsx
@@ -9,6 +9,7 @@ import {
 } from "@marinara-engine/shared";
 import { cn } from "../../lib/utils";
 import { SettingsSwitch } from "../panels/settings/SettingControls";
+import { DraftTextarea } from "./DraftTextarea";
 import { HelpTooltip } from "./HelpTooltip";
 
 export type EditableGenerationParameters = Pick<
@@ -286,9 +287,9 @@ export function GenerationParametersFields({
               size="0.625rem"
             />
           </span>
-          <textarea
-            value={value.assistantPrefill}
-            onChange={(e) => set("assistantPrefill", e.target.value)}
+          <DraftTextarea
+            value={value.assistantPrefill ?? ""}
+            onCommit={(nextValue) => set("assistantPrefill", nextValue)}
             rows={3}
             className={PARAM_TEXTAREA_CLASS}
             placeholder="<thinking>"

--- a/packages/client/src/features/chat-settings/sections/LorebooksSection.tsx
+++ b/packages/client/src/features/chat-settings/sections/LorebooksSection.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react";
-import { BookOpen, Plus, Trash2 } from "lucide-react";
+import { BookOpen, Eye, EyeOff, Plus, Trash2 } from "lucide-react";
 import { LIMITS, type Lorebook } from "@marinara-engine/shared";
 import { isLorebookScopeActiveForChat } from "../../../lib/lorebook-scope";
 import { HelpTooltip } from "../../../components/ui/HelpTooltip";
@@ -11,6 +11,8 @@ type LorebookActiveReason = "Global" | "Character" | "Persona" | "Chat";
 export type ActiveLorebookView = Lorebook & {
   activeReasons: LorebookActiveReason[];
   isPinned: boolean;
+  /** User disabled this auto-activated book for the chat (in excludedLorebookIds). */
+  isExcluded: boolean;
 };
 
 interface LorebooksSectionProps {
@@ -22,9 +24,9 @@ interface LorebooksSectionProps {
   showLorebookPicker: boolean;
   onLorebookSearchChange: (value: string) => void;
   onLorebookTokenBudgetChange: (value: number) => void;
-  onPinLorebook: (lorebookId: string) => void;
   onShowLorebookPickerChange: (show: boolean) => void;
   onToggleLorebook: (lorebookId: string) => void;
+  onSetLorebookExcluded: (lorebookId: string, excluded: boolean) => void;
 }
 
 export function LorebooksSection({
@@ -36,9 +38,9 @@ export function LorebooksSection({
   showLorebookPicker,
   onLorebookSearchChange,
   onLorebookTokenBudgetChange,
-  onPinLorebook,
   onShowLorebookPickerChange,
   onToggleLorebook,
+  onSetLorebookExcluded,
 }: LorebooksSectionProps) {
   const [tokenBudgetDraft, setTokenBudgetDraft] = useState(String(lorebookTokenBudget));
   const activeLorebookIdSet = new Set(activeLorebooks.map((lorebook) => lorebook.id));
@@ -99,23 +101,46 @@ export function LorebooksSection({
           {activeLorebooks.map((lorebook) => (
             <div
               key={lorebook.id}
-              className="flex items-center gap-2.5 rounded-lg bg-[var(--primary)]/10 px-3 py-2 ring-1 ring-[var(--primary)]/30"
+              className={
+                lorebook.isExcluded
+                  ? "flex items-center gap-2.5 rounded-lg bg-[var(--secondary)]/50 px-3 py-2 opacity-60 ring-1 ring-[var(--border)]"
+                  : "flex items-center gap-2.5 rounded-lg bg-[var(--primary)]/10 px-3 py-2 ring-1 ring-[var(--primary)]/30"
+              }
             >
-              <BookOpen size="0.875rem" className="text-[var(--primary)]" />
+              <BookOpen
+                size="0.875rem"
+                className={lorebook.isExcluded ? "text-[var(--muted-foreground)]" : "text-[var(--primary)]"}
+              />
               <div className="min-w-0 flex-1">
-                <span className="block truncate text-xs">{lorebook.name}</span>
+                <span className={lorebook.isExcluded ? "block truncate text-xs line-through" : "block truncate text-xs"}>
+                  {lorebook.name}
+                </span>
                 <div className="mt-1 flex flex-wrap gap-1">
-                  {lorebook.activeReasons.map((reason) => (
-                    <span
-                      key={reason}
-                      className="rounded-full bg-[var(--background)]/70 px-1.5 py-0.5 text-[0.5625rem] font-medium text-[var(--muted-foreground)] ring-1 ring-[var(--border)]"
-                    >
-                      {reason}
+                  {lorebook.isExcluded ? (
+                    <span className="rounded-full bg-[var(--background)]/70 px-1.5 py-0.5 text-[0.5625rem] font-medium text-[var(--muted-foreground)] ring-1 ring-[var(--border)]">
+                      Disabled
                     </span>
-                  ))}
+                  ) : (
+                    lorebook.activeReasons.map((reason) => (
+                      <span
+                        key={reason}
+                        className="rounded-full bg-[var(--background)]/70 px-1.5 py-0.5 text-[0.5625rem] font-medium text-[var(--muted-foreground)] ring-1 ring-[var(--border)]"
+                      >
+                        {reason}
+                      </span>
+                    ))
+                  )}
                 </div>
               </div>
-              {lorebook.isPinned ? (
+              {lorebook.isExcluded ? (
+                <button
+                  onClick={() => onSetLorebookExcluded(lorebook.id, false)}
+                  className="flex h-5 w-5 items-center justify-center rounded-md text-[var(--muted-foreground)] transition-colors hover:bg-[var(--primary)]/15 hover:text-[var(--primary)]"
+                  title="Enable in this chat"
+                >
+                  <Eye size="0.6875rem" />
+                </button>
+              ) : lorebook.isPinned ? (
                 <button
                   onClick={() => onToggleLorebook(lorebook.id)}
                   className="flex h-5 w-5 items-center justify-center rounded-md text-[var(--muted-foreground)] transition-colors hover:bg-[var(--destructive)]/15 hover:text-[var(--destructive)]"
@@ -125,11 +150,11 @@ export function LorebooksSection({
                 </button>
               ) : (
                 <button
-                  onClick={() => onPinLorebook(lorebook.id)}
-                  className="flex h-5 w-5 items-center justify-center rounded-md text-[var(--muted-foreground)] transition-colors hover:bg-[var(--primary)]/15 hover:text-[var(--primary)]"
-                  title="Add to chat"
+                  onClick={() => onSetLorebookExcluded(lorebook.id, true)}
+                  className="flex h-5 w-5 items-center justify-center rounded-md text-[var(--muted-foreground)] transition-colors hover:bg-[var(--destructive)]/15 hover:text-[var(--destructive)]"
+                  title="Disable in this chat"
                 >
-                  <Plus size="0.6875rem" />
+                  <EyeOff size="0.6875rem" />
                 </button>
               )}
             </div>

--- a/packages/client/src/features/tracker-panel/hooks/use-tracker-mutations.ts
+++ b/packages/client/src/features/tracker-panel/hooks/use-tracker-mutations.ts
@@ -18,7 +18,7 @@ import {
 import { api } from "../../../lib/api-client";
 import { useGameStateStore } from "../../../stores/game-state.store";
 import type { GameStatePatchField } from "../../../hooks/use-game-state-patcher";
-import { getCharacterFeatureKey } from "../lib/character-tracker-data";
+import { getCharacterFeatureKey, resolveCharacterTargetIndex } from "../lib/character-tracker-data";
 import { useTrackerFieldLockUpdater } from "./use-tracker-field-lock-updater";
 
 function makeManualTrackerId() {
@@ -126,7 +126,7 @@ export function useTrackerMutations({
   patchPlayerStats: (field: keyof PlayerStats, value: unknown) => void;
   removeFeaturedCharacterCard: (key: string) => void;
 }) {
-  const [avatarUploadCharacterId, setAvatarUploadCharacterId] = useState<string | null>(null);
+  const [avatarUpload, setAvatarUpload] = useState<{ characterId: string; index: number } | null>(null);
   const avatarFileInputRef = useRef<HTMLInputElement>(null);
   const avatarUploadSerialRef = useRef(0);
   const avatarUploadTokenByCharacterRef = useRef(new Map<string, number>());
@@ -158,17 +158,18 @@ export function useTrackerMutations({
     (index: number) => {
       const characterId = presentCharacters[index]?.characterId ?? readPresentCharacters()[index]?.characterId ?? null;
       if (!characterId) return;
-      setAvatarUploadCharacterId(characterId);
+      setAvatarUpload({ characterId, index });
       avatarFileInputRef.current?.click();
     },
     [presentCharacters, readPresentCharacters],
   );
 
   const handleAvatarUpload = useCallback(
-    (characterId: string, file: File) => {
+    (characterId: string, fallbackIndex: number, file: File) => {
       if (!activeChatId) return;
       const currentCharacters = readPresentCharacters();
-      const character = currentCharacters.find((candidate) => candidate.characterId === characterId);
+      const initialIndex = resolveCharacterTargetIndex(currentCharacters, characterId, fallbackIndex);
+      const character = initialIndex >= 0 ? currentCharacters[initialIndex] : undefined;
       if (!character) return;
 
       const uploadToken = avatarUploadSerialRef.current + 1;
@@ -194,7 +195,7 @@ export function useTrackerMutations({
           if (avatarUploadTokenByCharacterRef.current.get(characterId) !== uploadToken) return;
 
           const latestCharacters = readPresentCharacters();
-          const targetIndex = latestCharacters.findIndex((candidate) => candidate.characterId === characterId);
+          const targetIndex = resolveCharacterTargetIndex(latestCharacters, characterId, fallbackIndex);
           if (targetIndex < 0) return;
 
           const nextCharacters = [...latestCharacters];
@@ -221,12 +222,12 @@ export function useTrackerMutations({
   const handleAvatarFileInputChange = useCallback(
     (event: ChangeEvent<HTMLInputElement>) => {
       const file = event.target.files?.[0];
-      const characterId = avatarUploadCharacterId;
-      setAvatarUploadCharacterId(null);
-      if (file && characterId) handleAvatarUpload(characterId, file);
+      const pending = avatarUpload;
+      setAvatarUpload(null);
+      if (file && pending) handleAvatarUpload(pending.characterId, pending.index, file);
       event.target.value = "";
     },
-    [avatarUploadCharacterId, handleAvatarUpload],
+    [avatarUpload, handleAvatarUpload],
   );
 
   const updateCharacter = useCallback(
@@ -234,10 +235,8 @@ export function useTrackerMutations({
       const liveCharacters = readPresentCharacters();
       const renderedCharacter = presentCharacters[index];
       const targetCharacterId = character.characterId || renderedCharacter?.characterId;
-      const targetIndex = targetCharacterId
-        ? liveCharacters.findIndex((candidate) => candidate.characterId === targetCharacterId)
-        : index;
-      if (targetIndex < 0 || targetIndex >= liveCharacters.length) return;
+      const targetIndex = resolveCharacterTargetIndex(liveCharacters, targetCharacterId, index);
+      if (targetIndex < 0) return;
 
       const previous = liveCharacters[targetIndex];
       const nextCharacter = mergeChangedRecord(
@@ -265,10 +264,8 @@ export function useTrackerMutations({
     (index: number) => {
       const liveCharacters = readPresentCharacters();
       const renderedCharacter = presentCharacters[index];
-      const targetIndex = renderedCharacter?.characterId
-        ? liveCharacters.findIndex((candidate) => candidate.characterId === renderedCharacter.characterId)
-        : index;
-      if (targetIndex < 0 || targetIndex >= liveCharacters.length) return;
+      const targetIndex = resolveCharacterTargetIndex(liveCharacters, renderedCharacter?.characterId, index);
+      if (targetIndex < 0) return;
 
       const removed = liveCharacters[targetIndex];
       if (removed) {

--- a/packages/client/src/features/tracker-panel/lib/character-tracker-data.ts
+++ b/packages/client/src/features/tracker-panel/lib/character-tracker-data.ts
@@ -12,3 +12,34 @@ export function getCharacterFeatureKey(character: PresentCharacter, index: numbe
   const stableId = character.characterId || character.name || `character-${index}`;
   return stableId;
 }
+
+/**
+ * Resolve which live tracked character a UI edit/remove/avatar action targets.
+ *
+ * Present-character `characterId`s are produced by the LLM character-tracker
+ * agent and are not guaranteed unique — the agent prompt allows "ID or name",
+ * so several present characters can share (or omit) an id. Resolving the target
+ * with a plain `findIndex` by id therefore collapses every action onto the
+ * first character that shares that id. Follow the same rule the other tracker
+ * list mutations use (`findUniqueNamedIndex`): trust the id only when it
+ * uniquely identifies one character, otherwise fall back to the rendered index
+ * the UI already passed in.
+ */
+export function resolveCharacterTargetIndex(
+  liveCharacters: PresentCharacter[],
+  targetCharacterId: string | null | undefined,
+  fallbackIndex: number,
+): number {
+  if (targetCharacterId) {
+    let matchIndex = -1;
+    let matchCount = 0;
+    for (let index = 0; index < liveCharacters.length; index++) {
+      if (liveCharacters[index]?.characterId === targetCharacterId) {
+        matchIndex = index;
+        if (++matchCount > 1) break;
+      }
+    }
+    if (matchCount === 1) return matchIndex;
+  }
+  return fallbackIndex >= 0 && fallbackIndex < liveCharacters.length ? fallbackIndex : -1;
+}

--- a/packages/client/src/features/tracker-panel/lib/character-tracker-data.ts
+++ b/packages/client/src/features/tracker-panel/lib/character-tracker-data.ts
@@ -22,8 +22,15 @@ export function getCharacterFeatureKey(character: PresentCharacter, index: numbe
  * with a plain `findIndex` by id therefore collapses every action onto the
  * first character that shares that id. Follow the same rule the other tracker
  * list mutations use (`findUniqueNamedIndex`): trust the id only when it
- * uniquely identifies one character, otherwise fall back to the rendered index
- * the UI already passed in.
+ * uniquely identifies one character.
+ *
+ * Resolution order:
+ * - exactly one id match → that index (reorder-safe);
+ * - the id was provided but no longer exists in live state → return -1 so the
+ *   caller drops the action, matching the previous `findIndex(...) < 0` guard
+ *   (the named character is gone; a positional write would hit the wrong row);
+ * - a duplicate (ambiguous) or absent id → fall back to the rendered index the
+ *   UI passed in.
  */
 export function resolveCharacterTargetIndex(
   liveCharacters: PresentCharacter[],
@@ -40,6 +47,9 @@ export function resolveCharacterTargetIndex(
       }
     }
     if (matchCount === 1) return matchIndex;
+    // Named character is gone from live state — drop rather than write to whatever
+    // now sits at the rendered index. Duplicate ids (matchCount > 1) fall through.
+    if (matchCount === 0) return -1;
   }
   return fallbackIndex >= 0 && fallbackIndex < liveCharacters.length ? fallbackIndex : -1;
 }

--- a/packages/server/src/routes/chats.routes.ts
+++ b/packages/server/src/routes/chats.routes.ts
@@ -75,7 +75,7 @@ import {
 } from "./generate/generate-route-utils.js";
 import {
   filterGameInternalAgentIds,
-  resolveGameLorebookScopeExclusions,
+  resolveLorebookScopeExclusions,
 } from "../services/lorebook/game-lorebook-scope.js";
 import {
   isMemoryRecallVectorizerAvailable,
@@ -570,6 +570,15 @@ export async function chatsRoutes(app: FastifyInstance) {
       incoming.inactiveCharacterIds = Array.from(
         new Set((incoming.inactiveCharacterIds as string[]).filter((id) => validIds.has(id))),
       );
+    }
+    if (incoming.excludedLorebookIds !== undefined) {
+      if (
+        !Array.isArray(incoming.excludedLorebookIds) ||
+        !incoming.excludedLorebookIds.every((id) => typeof id === "string")
+      ) {
+        return reply.status(400).send({ error: "excludedLorebookIds must be an array of strings" });
+      }
+      incoming.excludedLorebookIds = Array.from(new Set(incoming.excludedLorebookIds as string[]));
     }
     if (incoming.conversationSchedulesEnabled === false) {
       await clearConversationScheduleState(chat);
@@ -1876,7 +1885,7 @@ export async function chatsRoutes(app: FastifyInstance) {
             };
           }
           const entryStateOverrides = resolveEntryStateOverrides(chatMeta.entryStateOverrides);
-          const lorebookScopeExclusions = resolveGameLorebookScopeExclusions(chatMode, chatMeta);
+          const lorebookScopeExclusions = resolveLorebookScopeExclusions(chatMode, chatMeta);
           const promptActiveAgentIds = Array.isArray(chatMeta.activeAgentIds)
             ? (chatMeta.activeAgentIds as string[])
             : [];

--- a/packages/server/src/routes/generate.routes.ts
+++ b/packages/server/src/routes/generate.routes.ts
@@ -72,7 +72,7 @@ import { resolveConversationSelfieSystemPrompt } from "../services/conversation/
 import { filterRelevantLorebooks, processLorebooks, type LorebookScanResult } from "../services/lorebook/index.js";
 import {
   filterGameInternalAgentIds,
-  resolveGameLorebookScopeExclusions,
+  resolveLorebookScopeExclusions,
 } from "../services/lorebook/game-lorebook-scope.js";
 import { lorebookEntryPassesContextFilters, type GameStateForScanning } from "../services/lorebook/keyword-scanner.js";
 import { injectAtDepth } from "../services/lorebook/prompt-injector.js";
@@ -1946,7 +1946,7 @@ export async function generateRoutes(app: FastifyInstance) {
         const chatActiveLorebookIds: string[] = Array.isArray(chatMeta.activeLorebookIds)
           ? (chatMeta.activeLorebookIds as string[])
           : [];
-        const gameLorebookScopeExclusions = resolveGameLorebookScopeExclusions(chatMode, chatMeta);
+        const lorebookScopeExclusions = resolveLorebookScopeExclusions(chatMode, chatMeta);
         let lorebookScanSnapshot: LorebookScanSnapshot = emptyLorebookScanSnapshot();
         let presetHandledLorebooks = false;
         const presetHasLorebookMarker = (sections: Array<{ isMarker: string; markerConfig: string | null }>) =>
@@ -2109,8 +2109,8 @@ export async function generateRoutes(app: FastifyInstance) {
               characterIds: promptCharacterIds,
               personaId,
               activeLorebookIds: chatActiveLorebookIds,
-              excludedLorebookIds: gameLorebookScopeExclusions.excludedLorebookIds,
-              excludedSourceAgentIds: gameLorebookScopeExclusions.excludedSourceAgentIds,
+              excludedLorebookIds: lorebookScopeExclusions.excludedLorebookIds,
+              excludedSourceAgentIds: lorebookScopeExclusions.excludedSourceAgentIds,
             });
             return new Set(relevantLorebooks.map((lorebook) => lorebook.id));
           })();
@@ -2138,8 +2138,8 @@ export async function generateRoutes(app: FastifyInstance) {
             characterIds: promptCharacterIds,
             personaId,
             activeLorebookIds: chatActiveLorebookIds,
-            excludedLorebookIds: gameLorebookScopeExclusions.excludedLorebookIds,
-            excludedSourceAgentIds: gameLorebookScopeExclusions.excludedSourceAgentIds,
+            excludedLorebookIds: lorebookScopeExclusions.excludedLorebookIds,
+            excludedSourceAgentIds: lorebookScopeExclusions.excludedSourceAgentIds,
           })) as LorebookEntry[];
           const hasVectorizedEntries = activeEntries.some(
             (entry) => Array.isArray(entry.embedding) && entry.embedding.length > 0,
@@ -2229,8 +2229,8 @@ export async function generateRoutes(app: FastifyInstance) {
             enableAgents: chatEnableAgents,
             activeAgentIds: chatActiveAgentIds,
             activeLorebookIds: chatActiveLorebookIds,
-            excludedLorebookIds: gameLorebookScopeExclusions.excludedLorebookIds,
-            excludedLorebookSourceAgentIds: gameLorebookScopeExclusions.excludedSourceAgentIds,
+            excludedLorebookIds: lorebookScopeExclusions.excludedLorebookIds,
+            excludedLorebookSourceAgentIds: lorebookScopeExclusions.excludedSourceAgentIds,
             lorebookTokenBudget: resolveLorebookTokenBudget(chatMeta),
             chatEmbedding: chatContextEmbedding,
             entryStateOverrides:
@@ -3474,8 +3474,8 @@ export async function generateRoutes(app: FastifyInstance) {
               characterIds: promptCharacterIds,
               personaId,
               activeLorebookIds: chatActiveLorebookIds,
-              excludedLorebookIds: gameLorebookScopeExclusions.excludedLorebookIds,
-              excludedSourceAgentIds: gameLorebookScopeExclusions.excludedSourceAgentIds,
+              excludedLorebookIds: lorebookScopeExclusions.excludedLorebookIds,
+              excludedSourceAgentIds: lorebookScopeExclusions.excludedSourceAgentIds,
               tokenBudget: resolveLorebookTokenBudget(chatMeta),
               chatEmbedding: chatContextEmbedding,
               entryStateOverrides:
@@ -3531,8 +3531,8 @@ export async function generateRoutes(app: FastifyInstance) {
             characterIds: promptCharacterIds,
             personaId,
             activeLorebookIds: chatActiveLorebookIds,
-            excludedLorebookIds: gameLorebookScopeExclusions.excludedLorebookIds,
-            excludedSourceAgentIds: gameLorebookScopeExclusions.excludedSourceAgentIds,
+            excludedLorebookIds: lorebookScopeExclusions.excludedLorebookIds,
+            excludedSourceAgentIds: lorebookScopeExclusions.excludedSourceAgentIds,
             tokenBudget: resolveLorebookTokenBudget(chatMeta),
             chatEmbedding: chatContextEmbedding,
             entryStateOverrides:
@@ -4218,8 +4218,8 @@ export async function generateRoutes(app: FastifyInstance) {
                 characterIds,
                 personaId,
                 activeLorebookIds: chatActiveLorebookIds,
-                excludedLorebookIds: gameLorebookScopeExclusions.excludedLorebookIds,
-                excludedSourceAgentIds: gameLorebookScopeExclusions.excludedSourceAgentIds,
+                excludedLorebookIds: lorebookScopeExclusions.excludedLorebookIds,
+                excludedSourceAgentIds: lorebookScopeExclusions.excludedSourceAgentIds,
                 tokenBudget: resolveLorebookTokenBudget(chatMeta),
                 chatEmbedding: chatContextEmbedding,
                 entryStateOverrides:
@@ -5201,8 +5201,8 @@ export async function generateRoutes(app: FastifyInstance) {
           promptCharacterIds,
           personaId,
           activeLorebookIds: chatActiveLorebookIds,
-          excludedLorebookIds: gameLorebookScopeExclusions.excludedLorebookIds,
-          excludedSourceAgentIds: gameLorebookScopeExclusions.excludedSourceAgentIds,
+          excludedLorebookIds: lorebookScopeExclusions.excludedLorebookIds,
+          excludedSourceAgentIds: lorebookScopeExclusions.excludedSourceAgentIds,
           gameState,
           gameSpotifyMusicEnabled,
           agentContext,

--- a/packages/server/src/routes/generate/dry-run-route.ts
+++ b/packages/server/src/routes/generate/dry-run-route.ts
@@ -21,7 +21,7 @@ import { createLorebooksStorage } from "../../services/storage/lorebooks.storage
 import { createRegexScriptsStorage } from "../../services/storage/regex-scripts.storage.js";
 import { buildImpersonateInstruction } from "../../services/conversation/impersonate-prompt.js";
 import { processLorebooks } from "../../services/lorebook/index.js";
-import { resolveGameLorebookScopeExclusions } from "../../services/lorebook/game-lorebook-scope.js";
+import { resolveLorebookScopeExclusions } from "../../services/lorebook/game-lorebook-scope.js";
 import { injectAtDepth } from "../../services/lorebook/prompt-injector.js";
 import { createLLMProvider } from "../../services/llm/provider-registry.js";
 import { getLocalSidecarProvider } from "../../services/llm/local-sidecar.js";
@@ -683,7 +683,7 @@ export async function registerDryRunRoute(app: FastifyInstance) {
       userMessage,
       attachments: body.attachments,
     });
-    const lorebookScopeExclusions = resolveGameLorebookScopeExclusions(chatMode, chatMeta);
+    const lorebookScopeExclusions = resolveLorebookScopeExclusions(chatMode, chatMeta);
     const lorebookTokenBudget = resolveDryRunLorebookTokenBudget(chatMeta);
     if (!impersonate && userMessage.trim()) {
       chatMessages = [

--- a/packages/server/src/routes/generate/generate-route-utils.ts
+++ b/packages/server/src/routes/generate/generate-route-utils.ts
@@ -950,7 +950,16 @@ export function shouldInjectIdentityFallback({
   chatMode: string;
   presetId: string | null | undefined;
 }): boolean {
-  return chatMode !== "game" && !presetId;
+  if (chatMode === "game") return false;
+  // Conversation mode never runs the preset assembler (it is excluded from the
+  // assemblePrompt path), so the preset only supplies the conversation prompt
+  // text — it never injects character/persona card info. Without the identity
+  // fallback, selecting a prompt preset leaves the model with only the
+  // character names and no description/personality. Always inject the fallback
+  // for conversation mode; the injector self-guards against duplicating a
+  // profile that a custom prompt already contains.
+  if (chatMode === "conversation") return true;
+  return !presetId;
 }
 
 /** Parse connection/chat stored generation parameters without injecting schema defaults. */

--- a/packages/server/src/routes/lorebooks.routes.ts
+++ b/packages/server/src/routes/lorebooks.routes.ts
@@ -28,7 +28,7 @@ import { createCharactersStorage } from "../services/storage/characters.storage.
 import { createGameStateStorage } from "../services/storage/game-state.storage.js";
 import { createConnectionsStorage } from "../services/storage/connections.storage.js";
 import { processLorebooks } from "../services/lorebook/index.js";
-import { resolveGameLorebookScopeExclusions } from "../services/lorebook/game-lorebook-scope.js";
+import { resolveLorebookScopeExclusions } from "../services/lorebook/game-lorebook-scope.js";
 import {
   buildPromptMacroContext,
   resolveMacrosWithVariableSnapshot,
@@ -861,7 +861,7 @@ export async function lorebooksRoutes(app: FastifyInstance) {
       }
     }
 
-    const lorebookScopeExclusions = resolveGameLorebookScopeExclusions(chat?.mode, chatMeta);
+    const lorebookScopeExclusions = resolveLorebookScopeExclusions(chat?.mode, chatMeta);
     const scanSourceMessages = selectMessagesForLastGenerationScan(chatMessages);
     const scanMessages = scanSourceMessages.map((m) => ({
       role: (m.role === "narrator" ? "system" : m.role) as string,

--- a/packages/server/src/routes/prompts.routes.ts
+++ b/packages/server/src/routes/prompts.routes.ts
@@ -18,7 +18,7 @@ import {
 import type { ExportEnvelope } from "@marinara-engine/shared";
 import { createPromptsStorage } from "../services/storage/prompts.storage.js";
 import { assemblePrompt, type AssemblerInput } from "../services/prompt/index.js";
-import { resolveGameLorebookScopeExclusions } from "../services/lorebook/game-lorebook-scope.js";
+import { resolveLorebookScopeExclusions } from "../services/lorebook/game-lorebook-scope.js";
 import { createChatsStorage } from "../services/storage/chats.storage.js";
 import { createCharactersStorage } from "../services/storage/characters.storage.js";
 import { normalizeTimestampOverrides } from "../services/import/import-timestamps.js";
@@ -301,7 +301,7 @@ export async function promptsRoutes(app: FastifyInstance) {
     } catch {
       chatMeta = {};
     }
-    const lorebookScopeExclusions = resolveGameLorebookScopeExclusions(chat.mode, chatMeta);
+    const lorebookScopeExclusions = resolveLorebookScopeExclusions(chat.mode, chatMeta);
     const mappedMessages = chatMessages.map((m: any) => ({
       role: m.role === "narrator" ? ("system" as const) : (m.role as "user" | "assistant" | "system"),
       content: m.content as string,

--- a/packages/server/src/services/lorebook/game-lorebook-scope.ts
+++ b/packages/server/src/services/lorebook/game-lorebook-scope.ts
@@ -9,18 +9,34 @@ function readTrimmedString(value: unknown): string | null {
   return typeof value === "string" && value.trim() ? value.trim() : null;
 }
 
-export function resolveGameLorebookScopeExclusions(
+/**
+ * Resolve which lorebooks/source-agents are excluded from scope for a chat.
+ *
+ * Two independent sources are merged:
+ *  - Per-chat user exclusions (`metadata.excludedLorebookIds`): books the user
+ *    explicitly disabled for THIS chat via the Lorebooks panel. These apply in
+ *    every mode — they are how a character/global/persona book (which is
+ *    auto-activated, not pinned) gets turned off without unbinding it.
+ *  - Game Lorebook Keeper hiding: during normal game play (keeper disabled) the
+ *    keeper's managed book and source-agent are hidden so its bookkeeping does
+ *    not leak into the prompt.
+ */
+export function resolveLorebookScopeExclusions(
   chatMode: unknown,
   metadata: Record<string, unknown> | null | undefined,
 ): LorebookScopeExclusions {
-  if (chatMode !== "game" || metadata?.gameLorebookKeeperEnabled === true) {
-    return { excludedLorebookIds: [], excludedSourceAgentIds: [] };
-  }
+  const userExcludedLorebookIds = Array.isArray(metadata?.excludedLorebookIds)
+    ? (metadata.excludedLorebookIds as unknown[]).filter(
+        (value): value is string => typeof value === "string" && value.trim().length > 0,
+      )
+    : [];
 
-  const gameLorebookId = readTrimmedString(metadata?.gameLorebookKeeperLorebookId);
+  const hideGameKeeper = chatMode === "game" && metadata?.gameLorebookKeeperEnabled !== true;
+  const gameLorebookId = hideGameKeeper ? readTrimmedString(metadata?.gameLorebookKeeperLorebookId) : null;
+
   return {
-    excludedLorebookIds: gameLorebookId ? [gameLorebookId] : [],
-    excludedSourceAgentIds: [GAME_LOREBOOK_KEEPER_SOURCE_ID],
+    excludedLorebookIds: [...new Set([...userExcludedLorebookIds, ...(gameLorebookId ? [gameLorebookId] : [])])],
+    excludedSourceAgentIds: hideGameKeeper ? [GAME_LOREBOOK_KEEPER_SOURCE_ID] : [],
   };
 }
 

--- a/packages/shared/src/types/chat.ts
+++ b/packages/shared/src/types/chat.ts
@@ -330,6 +330,11 @@ export interface ChatMetadata {
   entryTimingStates?: Record<string, import("./lorebook.js").LorebookEntryTimingState>;
   /** Per-chat global lorebook token budget. Missing uses app default; 0 means unlimited. */
   lorebookTokenBudget?: number | null;
+  /** Lorebook IDs the user has explicitly disabled for THIS chat. Auto-activated
+   *  books (bound to a present character / global / the active persona) that the
+   *  user turned off via the chat Lorebooks panel land here; the scope filter
+   *  drops them before injection without unbinding the book. */
+  excludedLorebookIds?: string[];
   /** ID of the chat preset most recently applied to this chat (drives the preset bar dropdown). */
   appliedChatPresetId?: string | null;
   /** Custom prompt prefix used by the /impersonate slash command. */


### PR DESCRIPTION
## Linked issues

Closes #2845
Closes #2846
Closes #2848
Closes #2849
Closes #2850

## Why this change

A batch of roleplay- and conversation-mode issues reported by users, bundled into one PR at maintainer request.

- **#2845** — In Roleplay mode with the Character Tracker, editing any present character's fields could save the change onto the first character in the list instead of the one I edited.
- **#2846** — Typing into the Assistant Prefill field under Advanced Parameters made characters appear one at a time, and nearby toggles felt delayed — worse the longer a chat session had been open.
- **#2848** — In Conversation mode, the Prompt Preset "Edit Prompt" window closed on any mouse click and discarded the edit; only keyboard editing worked.
- **#2849** — A character-bound (or global / active-persona) lorebook is force-activated in every non-game chat with no way to disable it per chat, so overlapping books overflow the token budget.
- **#2850** — In Conversation mode with a prompt preset selected, no character/persona card info reached the prompt — only the names — so the model had nothing to characterize.

## What changed

**#2845 — tracker edit target resolution**

- The tracker panel resolved edit/remove/avatar targets with `findIndex` by `characterId`. Present-character ids come from the LLM character-tracker agent and are not guaranteed unique (the prompt allows "ID or name"), so when several present characters shared an id, `findIndex` always returned the first match and the action landed on character #1.
- Added `resolveCharacterTargetIndex` (`features/tracker-panel/lib/character-tracker-data.ts`): trust the id only when it uniquely identifies one character, otherwise fall back to the rendered index — the same rule `findUniqueNamedIndex` already applies to the other tracker list mutations. Wired into `updateCharacter`, `removeCharacter`, and the avatar-upload flow in `use-tracker-mutations.ts`.

**#2846 — Assistant Prefill input responsiveness**

- The Assistant Prefill textarea was fully controlled by `chatParameters` and committed every keystroke straight to the per-chat metadata mutation, so the field only advanced after the round-trip re-rendered the settings tree.
- Added `DraftTextarea` (`components/ui/DraftTextarea.tsx`), a local-buffered textarea that commits on blur (and flushes on unmount so closing the drawer mid-edit keeps the text), mirroring the existing `DraftNumberInput` pattern. Wired it into the Assistant Prefill field.

**#2848 — expanded prompt editor closes on click**

- The `ExpandedTextarea` overlay renders through a portal to `document.body`, above the chat settings drawer. The drawer's capture-phase `pointerdown` outside-close handler treated clicks inside the portal as "outside", so the first click (including the Collapse button) closed the drawer and unmounted the editor before its edit could commit.
- Marked the overlay with `data-chat-floating-panel` so the drawer's handler treats clicks inside it as inside. Closing now happens only via Collapse/Escape, which route through the editor's `onClose` and persist the change. Also covers the Game extra-prompt and Scene-instructions expanded editors, which share the component.

**#2849 — disable a character-bound lorebook per chat**

- The exclusion plumbing already existed but was only wired to the Game Lorebook Keeper: `filterRelevantLorebooks()` and `listActiveEntries()` both honor an `excludedLorebookIds` filter, but the generation / scan / dry-run / prompt-preview paths only ever passed the game-keeper exclusions, and there was no UI or metadata field for a per-chat exclusion.
- Server: added `ChatMetadata.excludedLorebookIds`; renamed `resolveGameLorebookScopeExclusions` → `resolveLorebookScopeExclusions` and folded per-chat `excludedLorebookIds` into the result for every mode, so all callers drop excluded books before injection; validated the field on the metadata PATCH route.
- Client: a "disable in this chat" control on auto-activated books in the chat Lorebooks panel, disabled books rendered greyed with a re-enable control, written via the metadata mutation. Disabling does not unbind the book — it only suppresses it for this chat. The redundant pin-an-already-active-book control is replaced by disable; inactive books are still added via the picker. Credit to Evie [MARI] for the original root-cause analysis.

**#2850 — conversation card info with a preset selected**

- Conversation mode is excluded from the preset assembler, so a preset only supplies the conversation prompt text; it never injects card fields. The identity fallback that would supply them was gated off whenever a preset was present (`chatMode !== "game" && !presetId`) — correct for roleplay (the assembler covers it) but leaving conversation+preset with nothing.
- `shouldInjectIdentityFallback` now always runs for conversation mode regardless of preset. The injector already skips any character/persona whose profile is already in the prompt, so custom conversation prompts that embed `{{description}}` et al. are not duplicated, and conversation-without-a-preset behavior is unchanged.

## Validation

- [x] `pnpm check` passes locally
- [x] Container (Docker / Podman) built and ran without issue
- [x] Ran the app, clicked through the changes manually
- [x] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [x] Above manual verification completed (describe below)
- [x] Read and followed `CONTRIBUTING.md`

### Manual verification notes

All five changes verified on a build deployed to my private EasyPanel instance.

- **#2845**: seeded a roleplay chat's Present Characters with three characters sharing one `characterId`, edited the second character's Mood in the docked tracker — the edit persisted to the second character (UI + game-state API); the others were untouched. Previously it landed on the first.
- **#2846**: with the chat settings drawer open, typed a 16-character string into Assistant Prefill while watching the network tab — zero metadata PATCH requests while typing, a single commit PATCH on blur. Previously each keystroke fired its own mutation.
- **#2848**: opened the conversation Prompt Preset "Edit Prompt" window, clicked inside the textarea — the editor stayed open (previously it closed). Typed a change, hit Collapse — the change persisted (the field flipped to "Custom" / chat-local edit). Reset to default afterward.
- **#2849**: in a 5-character conversation chat, the chat Lorebooks panel showed each character book with a "disable" control; disabling a book greyed it and dropped its entries. Verified end-to-end via the lorebook scan API: a character book's constant entry was returned before exclusion, dropped after setting `excludedLorebookIds`, and returned again after re-enabling; the metadata PATCH rejects a non-array `excludedLorebookIds` with 400.
- **#2850**: created a conversation chat with a described character + a prompt preset, ran a real generation, then inspected the cached/exact prompt (what was actually sent to the model) — it now contains the character's description. Previously the same configuration sent only names.

Caveat for #2850: the in-app "peek prompt" and dry-run previews use a separate best-effort assembler that does not mirror the real generation path, so they can still show only names. The fix is verified against the cached/exact prompt of a real generation; aligning the preview assemblers would be a separate change.

Notes:
- There is no client-side test runner in this repo (the vitest suite is server-only), so these are manual/live checks. `resolveCharacterTargetIndex` and `resolveLorebookScopeExclusions` are pure functions a future test harness could cover directly.
- Separately investigated a related report — in group conversations, "always on" lorebook entries appearing duplicated for the lead character — but could not reproduce it server-side: the scan/prompt engine returns each present character's constant entries exactly once across the configurations tested (per-character same-named books, a single book bound to multiple present characters, and a character-bound + pinned book). No change was made for that report.

## Docs and release impact

- [x] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Version/release files updated (only if this PR includes a version bump)

## UI evidence (if applicable)

All five changes verified live on the deployed branch as described under Manual verification notes.
