### PR TITLE
fix: v2.0.5 chat/conversation/summary bug fixes (continue, swipe counter, author notes, drag handle, group selfie, react-gate, summary tail, streaming lag)

### DIFF
--- a/packages/client/src/components/chat/ChatInput.tsx
+++ b/packages/client/src/components/chat/ChatInput.tsx
@@ -557,6 +557,7 @@ export const ChatInput = memo(function ChatInput({
       characterNames: activeCharacterNames,
       characters: activeChatCharacters,
       latestAssistantMessageId: latestAssistantMessage?.id ?? null,
+      lastMessageRole,
       setSpriteExpression: onExpressionChange
         ? (characterId, expression) => onExpressionChange(characterId, expression, { immediate: true })
         : undefined,
@@ -569,6 +570,7 @@ export const ChatInput = memo(function ChatInput({
     activeCharacterNames,
     activeChatCharacters,
     latestAssistantMessage,
+    lastMessageRole,
     onExpressionChange,
     qc,
   ]);

--- a/packages/client/src/components/chat/ChatRoleplaySurface.tsx
+++ b/packages/client/src/components/chat/ChatRoleplaySurface.tsx
@@ -44,6 +44,7 @@ import { getTranscriptRenderWindow, TRANSCRIPT_RENDER_WINDOW_STEP } from "../../
 import { useUIStore } from "../../stores/ui.store";
 import { useChatStore } from "../../stores/chat.store";
 import { useGameStateStore } from "../../stores/game-state.store";
+import { useThrottledStreamBuffer } from "../../hooks/use-throttled-stream-buffer";
 import { useActiveLorebookEntries, useLorebooks } from "../../hooks/use-lorebooks";
 import { usePresetFull, usePresets } from "../../hooks/use-presets";
 import { ChatMessage } from "./ChatMessage";
@@ -312,7 +313,7 @@ function StreamingIndicator({
   groupChatMode?: string;
   expressionAvatarResolver?: ExpressionAvatarResolver;
 }) {
-  const streamBuffer = useChatStore((s) => s.streamBuffer);
+  const streamBuffer = useThrottledStreamBuffer();
   const thinkingBuffer = useChatStore((s) => s.thinkingBuffer);
   const streamingCharacterId = useChatStore((s) => s.streamingCharacterId);
 
@@ -353,7 +354,7 @@ function RegeneratingMessageContent({
 }: {
   msg: MessageWithSwipes;
 } & Omit<ComponentProps<typeof ChatMessage>, "message" | "isStreaming">) {
-  const streamBuffer = useChatStore((s) => s.streamBuffer);
+  const streamBuffer = useThrottledStreamBuffer();
   const thinkingBuffer = useChatStore((s) => s.thinkingBuffer);
   // Strip old-swipe attachments so a previous illustration doesn't linger
   // while the new swipe's text is streaming in.

--- a/packages/client/src/components/chat/ChatRoleplaySurface.tsx
+++ b/packages/client/src/components/chat/ChatRoleplaySurface.tsx
@@ -851,16 +851,20 @@ function AuthorNotesButton({
     const handle = (e: MouseEvent) => {
       const target = e.target as Node;
       if (ref.current?.contains(target) || panelRef.current?.contains(target)) return;
-      // Don't dismiss while a field inside the panel is focused. On mobile the
-      // virtual keyboard opening can synthesise a pointer/mouse event outside the
-      // panel that would otherwise close it mid-edit (see SummaryPopover).
-      const active = document.activeElement;
-      if (active instanceof Node && panelRef.current?.contains(active)) return;
+      // On mobile, the virtual keyboard opening can synthesise a pointer/mouse
+      // event outside the panel that would otherwise close it mid-edit; don't
+      // dismiss while a field inside the panel is focused. Mobile-only: on desktop
+      // a mousedown fires before focus moves, so guarding there would swallow the
+      // first outside click (see SummaryPopover, which only runs on touch).
+      if (useMobilePanel) {
+        const active = document.activeElement;
+        if (active instanceof Node && panelRef.current?.contains(active)) return;
+      }
       onOpenChange(false);
     };
     document.addEventListener("mousedown", handle);
     return () => document.removeEventListener("mousedown", handle);
-  }, [onOpenChange, open, renderPanel]);
+  }, [onOpenChange, open, renderPanel, useMobilePanel]);
 
   useLayoutEffect(() => {
     if (!open || !renderPanel || !useMobilePanel) {

--- a/packages/client/src/components/chat/ChatRoleplaySurface.tsx
+++ b/packages/client/src/components/chat/ChatRoleplaySurface.tsx
@@ -851,6 +851,11 @@ function AuthorNotesButton({
     const handle = (e: MouseEvent) => {
       const target = e.target as Node;
       if (ref.current?.contains(target) || panelRef.current?.contains(target)) return;
+      // Don't dismiss while a field inside the panel is focused. On mobile the
+      // virtual keyboard opening can synthesise a pointer/mouse event outside the
+      // panel that would otherwise close it mid-edit (see SummaryPopover).
+      const active = document.activeElement;
+      if (active instanceof Node && panelRef.current?.contains(active)) return;
       onOpenChange(false);
     };
     document.addEventListener("mousedown", handle);
@@ -862,7 +867,14 @@ function AuthorNotesButton({
       setMobileFrame(null);
       return;
     }
-    const update = () => setMobileFrame(getMobileFloatingPanelFrame(buttonRef.current, 288));
+    const update = () => {
+      const next = getMobileFloatingPanelFrame(buttonRef.current, 288);
+      // Keep the last good frame when the anchor button is transiently
+      // unmeasurable (e.g. the mobile keyboard opening collapses the toolbar /
+      // overflow menu so the button's rect is 0) — otherwise the portal panel
+      // unmounts the instant the keyboard appears and the user can't type.
+      if (next) setMobileFrame(next);
+    };
     update();
     window.addEventListener("resize", update);
     window.addEventListener("scroll", update, true);

--- a/packages/client/src/components/chat/ChatToolbarControls.tsx
+++ b/packages/client/src/components/chat/ChatToolbarControls.tsx
@@ -131,6 +131,7 @@ export function ChatToolbarMenu({
   const btnRef = useRef<HTMLDivElement>(null);
   const popRef = useRef<HTMLDivElement>(null);
   const neededDesktopWidthRef = useRef(0);
+  const lastViewportWidthRef = useRef(typeof window === "undefined" ? 0 : window.innerWidth);
   const [pos, setPos] = useState<{ top: number; right: number }>({ top: 0, right: 0 });
   const resolvedDesktopChildren = desktopChildren ?? children;
   const resolvedMobileChildren = mobileChildren ?? children;
@@ -141,9 +142,15 @@ export function ChatToolbarMenu({
 
     const mobileQuery = window.matchMedia("(max-width: 767px)");
     const measure = () => {
+      const widthChanged = window.innerWidth !== lastViewportWidthRef.current;
+      lastViewportWidthRef.current = window.innerWidth;
       if (mobileQuery.matches) {
         setOverflowCollapsed(false);
-        setOpen(false);
+        // Close the overflow menu only when the viewport WIDTH changes (orientation
+        // or window resize). The on-screen keyboard shrinks only the height and also
+        // fires resize; closing here would unmount an open child panel — the Author's
+        // Notes or Summary editor — mid-edit (#2868).
+        if (widthChanged) setOpen(false);
         return;
       }
 

--- a/packages/client/src/components/chat/ConversationInput.tsx
+++ b/packages/client/src/components/chat/ConversationInput.tsx
@@ -949,6 +949,7 @@ export function ConversationInput({
   }, [
     activeChatId,
     activeChatCharacters,
+    lastMessageRole,
     attachments,
     canRetry,
     isReadingAttachments,
@@ -1053,6 +1054,7 @@ export function ConversationInput({
       activeChatId,
       activeChatCharacters,
       activeCharacterNames,
+      lastMessageRole,
       clearInputDraft,
       completions,
       _mentionQuery,

--- a/packages/client/src/components/chat/ConversationInput.tsx
+++ b/packages/client/src/components/chat/ConversationInput.tsx
@@ -825,6 +825,7 @@ export function ConversationInput({
         characterNames: activeCharacterNames,
         characters: activeChatCharacters?.map((character) => ({ id: character.id, name: character.name })),
         latestAssistantMessageId: latestAssistantMessage?.id ?? null,
+        lastMessageRole,
       };
       const submittedDraft = textareaRef.current?.value ?? "";
       const submittedHeight = textareaRef.current?.style.height ?? "auto";
@@ -996,6 +997,7 @@ export function ConversationInput({
         characterNames: activeCharacterNames,
         characters: activeChatCharacters?.map((character) => ({ id: character.id, name: character.name })),
         latestAssistantMessageId: latestAssistantMessage?.id ?? null,
+        lastMessageRole,
       };
 
       const previousDraft = textareaRef.current?.value ?? "";

--- a/packages/client/src/components/chat/ConversationView.tsx
+++ b/packages/client/src/components/chat/ConversationView.tsx
@@ -31,6 +31,7 @@ import { useUIStore } from "../../stores/ui.store";
 import { playConfiguredNotificationPing } from "../../lib/notification-sound";
 import { messageHasPendingPostProcessing } from "../../lib/chat-message-extra";
 import { getTranscriptRenderWindow, TRANSCRIPT_RENDER_WINDOW_STEP } from "../../lib/transcript-render-window";
+import { useThrottledStreamBuffer } from "../../hooks/use-throttled-stream-buffer";
 import { useConversationCustomEmojis } from "../../hooks/use-conversation-custom-emojis";
 import { useConversationCustomStickers } from "../../hooks/use-conversation-custom-stickers";
 import type { CharacterMap, MessageSelectionToggle, PersonaInfo } from "./chat-area.types";
@@ -279,7 +280,7 @@ export function ConversationView({
   const closeUnoSetup = useUnoGameStore((s) => s.closeSetup);
   const isStreamCommitted = useChatStore((s) => s.committedStreamChatIds.has(chatId));
   const hasLiveStream = isStreaming && !isStreamCommitted;
-  const streamBuffer = useChatStore((s) => s.streamBuffer);
+  const streamBuffer = useThrottledStreamBuffer();
   const thinkingBuffer = useChatStore((s) => s.thinkingBuffer);
   const regenerateMessageId = useChatStore((s) => s.regenerateMessageId);
   const streamingCharacterId = useChatStore((s) => s.streamingCharacterId);

--- a/packages/client/src/components/chat/SwipeJumpControl.tsx
+++ b/packages/client/src/components/chat/SwipeJumpControl.tsx
@@ -31,7 +31,7 @@ export function SwipeJumpControl({
     setInputValue(String(activeSwipeIndex + 1));
   }, [activeSwipeIndex]);
 
-  if (swipeCount <= 1 && !onCreateNextSwipe) return null;
+  if (swipeCount <= 1) return null;
 
   const inputId = `swipe-jump-${messageId}`;
   const displaySwipeCount = Math.max(1, swipeCount);

--- a/packages/client/src/components/ui/TouchDragHandle.tsx
+++ b/packages/client/src/components/ui/TouchDragHandle.tsx
@@ -22,7 +22,11 @@ export function TouchDragHandle({
       tabIndex={-1}
       title={label}
       className={cn(
-        "mari-chrome-accent-text-muted mari-accent-animated flex h-8 w-6 shrink-0 cursor-grab touch-none items-center justify-center rounded-md opacity-100 transition-all hover:bg-[var(--marinara-chat-chrome-highlight-bg)] hover:text-[var(--marinara-chat-chrome-button-text-hover)] active:cursor-grabbing active:scale-95 md:hidden",
+        // Touch-only affordance: native HTML5 drag does not fire on touch, so this
+        // handle drives the custom touch-drag path. Gate on pointer type, not viewport
+        // width — a width gate (md:hidden) hid it on touch devices ≥768px (tablets),
+        // leaving them with no way to drag. Mouse/fine-pointer devices use native row drag.
+        "mari-chrome-accent-text-muted mari-accent-animated flex h-8 w-6 shrink-0 cursor-grab touch-none items-center justify-center rounded-md opacity-100 transition-all hover:bg-[var(--marinara-chat-chrome-highlight-bg)] hover:text-[var(--marinara-chat-chrome-button-text-hover)] active:cursor-grabbing active:scale-95 [@media(pointer:fine)]:hidden",
         className,
       )}
       onClick={(event) => event.stopPropagation()}

--- a/packages/client/src/hooks/use-throttled-stream-buffer.ts
+++ b/packages/client/src/hooks/use-throttled-stream-buffer.ts
@@ -22,11 +22,20 @@ import { rafThrottle } from "../lib/raf-throttle";
 // unaffected. The committed message is rendered from the React Query cache once
 // streaming ends, so a growth frame being up to ~16ms behind is never visible.
 
-// True when `next` is the previous buffer plus more tokens (ongoing growth) and
-// should be throttled; false for resets, the first token after a clear, and
-// shrinks, which are delivered immediately. Exported for unit testing.
+// True when `next` is the previous buffer plus more appended tokens (ongoing
+// growth) and should be throttled; false for resets, the first token after a
+// clear, shrinks, and any non-append change, which are delivered immediately.
+//
+// The `startsWith` prefix check is what makes a non-append swap a reset: a
+// per-token stream always appends (`next === lastSeen + token`), but switching
+// the active chat into a *different* chat that is also streaming replaces the
+// buffer with unrelated text. Without the prefix check, if that other chat's
+// buffer happened to be longer it would be misclassified as growth and held a
+// frame, briefly showing the previous chat's text in the new chat. Requiring
+// the prefix delivers cross-chat swaps synchronously instead. Exported for
+// unit testing.
 export function isOngoingStreamGrowth(lastSeen: string, next: string): boolean {
-  return lastSeen.length > 0 && next.length > lastSeen.length;
+  return lastSeen.length > 0 && next.length > lastSeen.length && next.startsWith(lastSeen);
 }
 
 export function useThrottledStreamBuffer(): string {

--- a/packages/client/src/hooks/use-throttled-stream-buffer.ts
+++ b/packages/client/src/hooks/use-throttled-stream-buffer.ts
@@ -3,26 +3,50 @@ import { useChatStore } from "../stores/chat.store";
 import { rafThrottle } from "../lib/raf-throttle";
 
 // Subscribe to the live stream buffer but re-render the caller at most once per
-// animation frame, even when tokens arrive faster than the display refreshes.
+// animation frame for the per-token *growth* that drives streaming lag, while
+// delivering resets immediately.
 //
-// The store's `streamBuffer` is still updated on every token (so token-exact
-// consumers such as ChatArea's auto-scroll subscriber are unaffected); only the
-// expensive markdown-rendering consumers throttle here. On a fast stream that
-// removes the per-token full re-parse of the growing message, which is the
-// concrete contributor to streaming GUI lag identified in #2878. The committed
-// message is rendered from the query cache once streaming ends, so a live frame
-// being up to ~16ms behind is never visible.
+// The cost #2878 is about is the per-token re-parse of the growing message, so
+// only monotonic growth (buffer getting longer, the same string plus the next
+// token) is throttled. Every other transition — the buffer clearing to "" at a
+// turn boundary, the first token after a clear, or any shrink/rewrite — is
+// delivered synchronously. This keeps the throttled buffer coherent with the
+// fields that are NOT throttled (notably `streamingCharacterId`): a group-turn
+// boundary does `setStreamBuffer("")` and then `setStreamingCharacterId(next)`
+// back to back, so delivering the clear in the same render as the id flip stops
+// the new speaker's row from briefly (or, in the bubble layout's monotonic
+// preview, persistently) showing the previous speaker's text.
+//
+// The store's `streamBuffer` itself is still written on every token, so
+// token-exact consumers such as ChatArea's auto-scroll subscriber are
+// unaffected. The committed message is rendered from the React Query cache once
+// streaming ends, so a growth frame being up to ~16ms behind is never visible.
+
+// True when `next` is the previous buffer plus more tokens (ongoing growth) and
+// should be throttled; false for resets, the first token after a clear, and
+// shrinks, which are delivered immediately. Exported for unit testing.
+export function isOngoingStreamGrowth(lastSeen: string, next: string): boolean {
+  return lastSeen.length > 0 && next.length > lastSeen.length;
+}
+
 export function useThrottledStreamBuffer(): string {
   const [value, setValue] = useState(() => useChatStore.getState().streamBuffer);
 
   useEffect(() => {
-    const throttle = rafThrottle<string>(setValue);
+    let lastSeen = useChatStore.getState().streamBuffer;
     // Catch up on any change between the initial render and this effect.
-    const current = useChatStore.getState().streamBuffer;
-    setValue(current);
+    setValue(lastSeen);
+    const throttle = rafThrottle<string>(setValue);
     const unsubscribe = useChatStore.subscribe(
       (state) => state.streamBuffer,
-      (next) => throttle.call(next),
+      (next) => {
+        const growth = isOngoingStreamGrowth(lastSeen, next);
+        lastSeen = next;
+        throttle.call(next);
+        // Reset / clear / first token / shrink: deliver now, dropping any
+        // pending growth frame so a stale value can't land after the reset.
+        if (!growth) throttle.flush();
+      },
     );
     return () => {
       throttle.cancel();

--- a/packages/client/src/hooks/use-throttled-stream-buffer.ts
+++ b/packages/client/src/hooks/use-throttled-stream-buffer.ts
@@ -1,0 +1,34 @@
+import { useEffect, useState } from "react";
+import { useChatStore } from "../stores/chat.store";
+import { rafThrottle } from "../lib/raf-throttle";
+
+// Subscribe to the live stream buffer but re-render the caller at most once per
+// animation frame, even when tokens arrive faster than the display refreshes.
+//
+// The store's `streamBuffer` is still updated on every token (so token-exact
+// consumers such as ChatArea's auto-scroll subscriber are unaffected); only the
+// expensive markdown-rendering consumers throttle here. On a fast stream that
+// removes the per-token full re-parse of the growing message, which is the
+// concrete contributor to streaming GUI lag identified in #2878. The committed
+// message is rendered from the query cache once streaming ends, so a live frame
+// being up to ~16ms behind is never visible.
+export function useThrottledStreamBuffer(): string {
+  const [value, setValue] = useState(() => useChatStore.getState().streamBuffer);
+
+  useEffect(() => {
+    const throttle = rafThrottle<string>(setValue);
+    // Catch up on any change between the initial render and this effect.
+    const current = useChatStore.getState().streamBuffer;
+    setValue(current);
+    const unsubscribe = useChatStore.subscribe(
+      (state) => state.streamBuffer,
+      (next) => throttle.call(next),
+    );
+    return () => {
+      throttle.cancel();
+      unsubscribe();
+    };
+  }, []);
+
+  return value;
+}

--- a/packages/client/src/lib/raf-throttle.ts
+++ b/packages/client/src/lib/raf-throttle.ts
@@ -1,0 +1,63 @@
+// ──────────────────────────────────────────────
+// requestAnimationFrame coalescer
+// ──────────────────────────────────────────────
+//
+// Coalesces rapid `call(value)` invocations so the wrapped `apply` runs at most
+// once per animation frame, always with the most recently supplied value. Used
+// to cap how often an expensive consumer reacts to a fast-changing source — e.g.
+// re-rendering (and re-parsing the markdown of) a streamed message on every token
+// floods the main thread, while the user only perceives ~60fps anyway (#2878).
+//
+// The scheduler is injectable so the coalescing logic can be unit-tested with a
+// manual clock instead of a real animation frame.
+
+export interface RafThrottle<T> {
+  /** Record the latest value and ensure a flush is scheduled for the next frame. */
+  call: (value: T) => void;
+  /** Apply the pending value immediately (if any) and clear the scheduled frame. */
+  flush: () => void;
+  /** Drop any pending value and cancel the scheduled frame without applying. */
+  cancel: () => void;
+}
+
+export function rafThrottle<T>(
+  apply: (value: T) => void,
+  schedule: (cb: () => void) => number = requestAnimationFrame,
+  cancelScheduled: (handle: number) => void = cancelAnimationFrame,
+): RafThrottle<T> {
+  let handle: number | null = null;
+  let pending = false;
+  let latest: T;
+
+  const run = () => {
+    handle = null;
+    if (!pending) return;
+    pending = false;
+    apply(latest);
+  };
+
+  return {
+    call(value: T) {
+      latest = value;
+      pending = true;
+      if (handle === null) handle = schedule(run);
+    },
+    flush() {
+      if (handle !== null) {
+        cancelScheduled(handle);
+        handle = null;
+      }
+      if (pending) {
+        pending = false;
+        apply(latest);
+      }
+    },
+    cancel() {
+      if (handle !== null) {
+        cancelScheduled(handle);
+        handle = null;
+      }
+      pending = false;
+    },
+  };
+}

--- a/packages/client/src/lib/slash-commands.ts
+++ b/packages/client/src/lib/slash-commands.ts
@@ -53,6 +53,9 @@ export interface SlashCommandContext {
   characters?: Array<{ id: string; name: string }>;
   /** Latest assistant message, used when /continue appends to an unfinished reply */
   latestAssistantMessageId?: string | null;
+  /** Role of the last message in the chat. /continue only appends to a trailing
+   *  assistant reply; otherwise it generates a fresh response. */
+  lastMessageRole?: string | null;
   /** Apply a manual sprite expression override */
   setSpriteExpression?: (characterId: string, expression: string) => void | Promise<void>;
 }
@@ -396,10 +399,19 @@ const COMMANDS: SlashCommand[] = [
     description: "Continue the AI response without sending a message",
     usage: "/continue",
     async execute(_args, ctx) {
-      if (!ctx.latestAssistantMessageId) {
+      // Only append to the latest assistant message when it is actually the last
+      // message in the chat. When the user has posted a newer message (e.g. via
+      // /impersonate), there is no trailing reply to continue, so generate a
+      // fresh response instead of appending to an earlier message such as the
+      // scenario / first message.
+      if (ctx.lastMessageRole === "assistant" && ctx.latestAssistantMessageId) {
+        await ctx.generate({ chatId: ctx.chatId, connectionId: null, continueMessageId: ctx.latestAssistantMessageId });
+        return { handled: true };
+      }
+      if (!ctx.lastMessageRole) {
         return { handled: true, feedback: "There is no assistant message to continue." };
       }
-      await ctx.generate({ chatId: ctx.chatId, connectionId: null, continueMessageId: ctx.latestAssistantMessageId });
+      await ctx.generate({ chatId: ctx.chatId, connectionId: null });
       return { handled: true };
     },
   },

--- a/packages/server/src/routes/chats.routes.ts
+++ b/packages/server/src/routes/chats.routes.ts
@@ -2823,7 +2823,11 @@ export async function chatsRoutes(app: FastifyInstance) {
           selectedRangeEndIndex = to + 1;
           return allMessages.slice(from, to + 1).filter((message) => !isMessageHiddenFromAI(message));
         })()
-      : selectRollingSummaryMessages({ messages: allMessages, contextSize });
+      : selectRollingSummaryMessages({
+          messages: allMessages,
+          contextSize,
+          summaryEntries: chatMeta.summaryEntries as ChatSummaryEntry[] | undefined,
+        });
     if (selectedMessages && "error" in selectedMessages) {
       return reply.status(400).send({ error: selectedMessages.error });
     }

--- a/packages/server/src/routes/chats.routes.ts
+++ b/packages/server/src/routes/chats.routes.ts
@@ -62,6 +62,7 @@ import { normalizeTimestampOverrides } from "../services/import/import-timestamp
 import {
   appendNonLeadingSystemMessagesToLastUser,
   computeSummaryHideIds,
+  selectRollingSummaryMessages,
   findTrackerContextInsertIndex,
   isManualTrackerCharacterId,
   parseExtra,
@@ -2822,7 +2823,7 @@ export async function chatsRoutes(app: FastifyInstance) {
           selectedRangeEndIndex = to + 1;
           return allMessages.slice(from, to + 1).filter((message) => !isMessageHiddenFromAI(message));
         })()
-      : allMessages.slice(-contextSize).filter((message) => !isMessageHiddenFromAI(message));
+      : selectRollingSummaryMessages({ messages: allMessages, contextSize });
     if (selectedMessages && "error" in selectedMessages) {
       return reply.status(400).send({ error: selectedMessages.error });
     }

--- a/packages/server/src/routes/generate.routes.ts
+++ b/packages/server/src/routes/generate.routes.ts
@@ -205,6 +205,7 @@ import {
   extractImageAttachmentDataUrls,
   appendNonLeadingSystemMessagesToLastUser,
   computeSummaryHideIds,
+  selectRollingSummaryMessages,
   injectIntoOutputFormatOrLastUser,
   isManualTrackerCharacterId,
   isMessageHiddenFromAI,
@@ -7426,9 +7427,7 @@ export async function generateRoutes(app: FastifyInstance) {
           if (messagesSinceLastSummary < interval) return;
 
           const contextSize = clampRoleplaySummaryContextSize(chatMeta.summaryContextSize);
-          const selectedMessages = freshMessages
-            .filter((message: any) => !isMessageHiddenFromAI(message))
-            .slice(-contextSize);
+          const selectedMessages = selectRollingSummaryMessages({ messages: freshMessages, contextSize });
           if (selectedMessages.length === 0) return;
 
           const resolvedSummaryConnection = await resolveChatSummaryConnection({

--- a/packages/server/src/routes/generate.routes.ts
+++ b/packages/server/src/routes/generate.routes.ts
@@ -7433,7 +7433,11 @@ export async function generateRoutes(app: FastifyInstance) {
           if (messagesSinceLastSummary < interval) return;
 
           const contextSize = clampRoleplaySummaryContextSize(chatMeta.summaryContextSize);
-          const selectedMessages = selectRollingSummaryMessages({ messages: freshMessages, contextSize });
+          const selectedMessages = selectRollingSummaryMessages({
+            messages: freshMessages,
+            contextSize,
+            summaryEntries: chatMeta.summaryEntries as ChatSummaryEntry[] | undefined,
+          });
           if (selectedMessages.length === 0) return;
 
           const resolvedSummaryConnection = await resolveChatSummaryConnection({

--- a/packages/server/src/routes/generate.routes.ts
+++ b/packages/server/src/routes/generate.routes.ts
@@ -3092,8 +3092,14 @@ export async function generateRoutes(app: FastifyInstance) {
           // conversation asset context below. Whether
           // to react — and how warmly or dryly — is emergent from personality, not
           // dictated here.
-          conversationSystemPrompt +=
-            '\n\nYou can react to the user\'s most recent message with a single emoji by writing [react: emoji="😂"] on its own line — any standard emoji, or a custom one you have access to as [react: emoji=":name:"]. It posts as a small badge on their message, the way you\'d react in a chat app. Use it only when it genuinely fits how your character feels in the moment; it is optional, may stand alone or sit alongside your reply, and choosing a flat reaction or none at all is itself a valid choice.';
+          // Gated on `conversationCommandsEnabled`: the `[react: …]` tag is parsed,
+          // stripped, and applied inside the command pipeline, which only runs when
+          // Character Commands are enabled. Advertising the syntax while that pipeline
+          // is off leaves the raw tag in the visible message with no badge (#2877).
+          if (conversationCommandsEnabled) {
+            conversationSystemPrompt +=
+              '\n\nYou can react to the user\'s most recent message with a single emoji by writing [react: emoji="😂"] on its own line — any standard emoji, or a custom one you have access to as [react: emoji=":name:"]. It posts as a small badge on their message, the way you\'d react in a chat app. Use it only when it genuinely fits how your character feels in the moment; it is optional, may stand alone or sit alongside your reply, and choosing a flat reaction or none at all is itself a valid choice.';
+          }
           // ── Home Professor Mari: inject assistant knowledge & commands ──
           if (isHomeProfessorMariAssistantChat) {
             conversationSystemPrompt += "\n\n" + MARI_ASSISTANT_PROMPT;

--- a/packages/server/src/routes/generate.routes.ts
+++ b/packages/server/src/routes/generate.routes.ts
@@ -6735,17 +6735,17 @@ export async function generateRoutes(app: FastifyInstance) {
             // renders the character that took it, not always the first one.
             const useSpeakerAttribution =
               isGroupChat && groupChatMode === "merged" && chatMode === "conversation";
-            const parsed = useSpeakerAttribution
+            const speakerParse = useSpeakerAttribution
               ? parseCharacterCommandsBySpeaker(fullResponse, charInfo, targetCharId)
-              : parseCharacterCommands(fullResponse);
-            const speakerIdByCommand =
-              "commandCharacterIds" in parsed
-                ? new Map(
-                    parsed.commands.map(
-                      (command, index) => [command, parsed.commandCharacterIds[index] ?? targetCharId] as const,
-                    ),
-                  )
-                : null;
+              : null;
+            const parsed = speakerParse ?? parseCharacterCommands(fullResponse);
+            const speakerIdByCommand = speakerParse
+              ? new Map(
+                  speakerParse.commands.map(
+                    (command, index) => [command, speakerParse.commandCharacterIds[index] ?? targetCharId] as const,
+                  ),
+                )
+              : null;
             if (parsed.commands.length > 0) {
               parsedCommands = filterEnabledConversationCommands(parsed.commands, chatMeta);
               if (parsedCommands.length > 0) {

--- a/packages/server/src/routes/generate.routes.ts
+++ b/packages/server/src/routes/generate.routes.ts
@@ -108,6 +108,7 @@ import { generateChatBackground } from "../services/game/game-asset-generation.j
 import { sanitizeGameNpcAvatarUrls } from "../services/game/npc-avatar-utils.js";
 import {
   parseCharacterCommands,
+  parseCharacterCommandsBySpeaker,
   parseDirectMessageCommands,
   parseDuration,
   type CharacterCommand,
@@ -6114,6 +6115,7 @@ export async function generateRoutes(app: FastifyInstance) {
           savedMsg: Awaited<ReturnType<typeof chats.createMessage>>;
           response: string;
           commands: CharacterCommand[];
+          commandCharacterIds: (string | null)[] | null;
           oocMessages: string[];
           characterId: string | null;
         } | null> => {
@@ -6684,6 +6686,9 @@ export async function generateRoutes(app: FastifyInstance) {
 
           // ── Parse and strip hidden character commands ──
           let parsedCommands: CharacterCommand[] = [];
+          // Parallel to parsedCommands: per-command character attribution for merged
+          // group conversations (null elsewhere — caller falls back to the message char).
+          let parsedCommandCharacterIds: (string | null)[] | null = null;
           let conversationCommandContent: string | null = null;
           let contentReplaced = false;
           if (tailMessages.assistantPrefillInjected && assistantPrefill && fullResponse.startsWith(assistantPrefill)) {
@@ -6725,11 +6730,31 @@ export async function generateRoutes(app: FastifyInstance) {
           }
           if (conversationCommandsEnabled && !input.impersonate) {
             const responseBeforeCommandParsing = fullResponse;
-            const parsed = parseCharacterCommands(fullResponse);
+            // Merged group conversations carry multiple characters' turns in one
+            // response; attribute each command to its speaker so e.g. a [selfie]
+            // renders the character that took it, not always the first one.
+            const useSpeakerAttribution =
+              isGroupChat && groupChatMode === "merged" && chatMode === "conversation";
+            const parsed = useSpeakerAttribution
+              ? parseCharacterCommandsBySpeaker(fullResponse, charInfo, targetCharId)
+              : parseCharacterCommands(fullResponse);
+            const speakerIdByCommand =
+              "commandCharacterIds" in parsed
+                ? new Map(
+                    parsed.commands.map(
+                      (command, index) => [command, parsed.commandCharacterIds[index] ?? targetCharId] as const,
+                    ),
+                  )
+                : null;
             if (parsed.commands.length > 0) {
               parsedCommands = filterEnabledConversationCommands(parsed.commands, chatMeta);
               if (parsedCommands.length > 0) {
                 conversationCommandContent = responseBeforeCommandParsing.trim();
+                if (speakerIdByCommand) {
+                  parsedCommandCharacterIds = parsedCommands.map(
+                    (command) => speakerIdByCommand.get(command) ?? targetCharId,
+                  );
+                }
               }
               fullResponse = parsed.cleanContent;
               contentReplaced = true;
@@ -6751,6 +6776,9 @@ export async function generateRoutes(app: FastifyInstance) {
             });
             if (recoveredSelfieCommand) {
               parsedCommands = [...parsedCommands, recoveredSelfieCommand];
+              // Recovered (implicit) selfies have no speaker prefix to attribute to;
+              // fall back to the generation's character.
+              if (parsedCommandCharacterIds) parsedCommandCharacterIds = [...parsedCommandCharacterIds, targetCharId];
               logger.info("[generate] Recovered implicit selfie command for chat %s", input.chatId);
             }
           }
@@ -6928,6 +6956,7 @@ export async function generateRoutes(app: FastifyInstance) {
                 savedMsg: anchoredMsg,
                 response: "",
                 commands: parsedCommands,
+                commandCharacterIds: parsedCommandCharacterIds,
                 oocMessages,
                 characterId: targetCharId,
               };
@@ -7139,6 +7168,7 @@ export async function generateRoutes(app: FastifyInstance) {
             savedMsg,
             response: fullResponse,
             commands: parsedCommands,
+            commandCharacterIds: parsedCommandCharacterIds,
             oocMessages,
             characterId: targetCharId,
           };
@@ -7299,10 +7329,12 @@ export async function generateRoutes(app: FastifyInstance) {
             firstSavedMsg ??= genResult.savedMsg;
             lastSavedMsg = genResult.savedMsg;
             recordExpressionTarget(genResult.savedMsg, genResult.characterId);
-            for (const cmd of genResult.commands) {
+            for (let cmdIndex = 0; cmdIndex < genResult.commands.length; cmdIndex++) {
               collectedCommands.push({
-                command: cmd,
-                characterId: genResult.characterId,
+                command: genResult.commands[cmdIndex]!,
+                // Merged group responses attribute each command to its speaker; fall
+                // back to the generation's character when no attribution is available.
+                characterId: genResult.commandCharacterIds?.[cmdIndex] ?? genResult.characterId,
                 messageId: genResult.savedMsg?.id ?? "",
                 swipeIndex: genResult.savedMsg?.activeSwipeIndex ?? 0,
               });

--- a/packages/server/src/routes/generate/generate-route-utils.ts
+++ b/packages/server/src/routes/generate/generate-route-utils.ts
@@ -516,17 +516,25 @@ export function computeSummaryHideIds(args: {
 /**
  * Select the messages a non-range rolling summary should cover. Normally the most
  * recent `contextSize` *visible* messages (the historical `visible.slice(-contextSize)`
- * behavior). When a previous summary has already hidden earlier messages, the window
- * is extended back to that summary's hidden boundary, so a protected tail that has
- * drifted beyond the last `contextSize` visible messages is re-summarized and hidden
- * on this run instead of staying visible forever and accumulating (#2879). Because the
- * hide window for each entry is `entryMessageIds` minus the tail, the LLM-facing batch
- * and the hide set share this selection; extending it is what lets a stranded tail be
- * reclaimed. Pure: `messages` must be chat-ordered (ascending).
+ * behavior). When a previous summary has already hidden earlier messages, the window is
+ * extended back to that summary's hidden boundary, so a protected tail that has drifted
+ * beyond the last `contextSize` visible messages is re-summarized and hidden on this run
+ * instead of staying visible forever and accumulating (#2879). Because each entry's hide
+ * window is `entryMessageIds` minus the tail, the LLM-facing batch and the hide set share
+ * this selection; extending it is what lets a stranded tail be reclaimed.
+ *
+ * The boundary is identified ONLY by ids recorded in a live summary entry's
+ * `hiddenMessageIds` — NOT by the bare `hiddenFromAI` flag. That flag is ambiguous: the
+ * user's manual "Hide from AI" toggle writes the same flag, so keying off it would let a
+ * stray manual hide on an early message be misread as a summary boundary and balloon the
+ * window to (nearly) the whole chat. With no summary-hidden message before the window
+ * (e.g. the first summary, or only manual hides), the plain last-`size` window is used.
+ * Pure: `messages` must be chat-ordered (ascending).
  */
 export function selectRollingSummaryMessages<T extends { id: string; extra?: unknown }>(args: {
   messages: T[];
   contextSize: number;
+  summaryEntries?: ReadonlyArray<{ enabled?: boolean; hiddenMessageIds?: string[] }>;
 }): T[] {
   const { messages, contextSize } = args;
   const size = Number.isFinite(contextSize) ? Math.max(0, Math.floor(contextSize)) : 0;
@@ -534,20 +542,30 @@ export function selectRollingSummaryMessages<T extends { id: string; extra?: unk
   const visible = messages.filter((message) => !isMessageHiddenFromAI(message));
   // Fewer visible messages than the window — nothing can have drifted out of it.
   if (visible.length <= size) return visible;
-  // The previous summary's boundary: the most recent already-hidden message.
-  let lastHiddenIndex = -1;
+  // Messages hidden by a live (enabled) summary entry — the only hides that mark a real
+  // summary boundary. A manual "Hide from AI" never appears here, so it can't expand the
+  // window.
+  const summaryHidden = new Set<string>();
+  for (const entry of Array.isArray(args.summaryEntries) ? args.summaryEntries : []) {
+    if (entry?.enabled !== false && Array.isArray(entry?.hiddenMessageIds)) {
+      for (const id of entry.hiddenMessageIds) summaryHidden.add(id);
+    }
+  }
+  if (summaryHidden.size === 0) return visible.slice(-size);
+  // The previous summary's boundary: the most recent summary-hidden message.
+  let lastBoundaryIndex = -1;
   for (let i = messages.length - 1; i >= 0; i--) {
-    if (isMessageHiddenFromAI(messages[i]!)) {
-      lastHiddenIndex = i;
+    if (summaryHidden.has(messages[i]!.id)) {
+      lastBoundaryIndex = i;
       break;
     }
   }
-  // No prior summary boundary (first summary) — the plain last-`size` window is correct.
-  if (lastHiddenIndex < 0) return visible.slice(-size);
+  // No summary-hidden message precedes the window — keep the plain last-`size` window.
+  if (lastBoundaryIndex < 0) return visible.slice(-size);
   // Visible messages accumulated since that boundary. Extend the window to cover all of
   // them when they exceed `size`, pulling a drifted protected tail back into the batch.
   const sinceBoundary = messages
-    .slice(lastHiddenIndex + 1)
+    .slice(lastBoundaryIndex + 1)
     .filter((message) => !isMessageHiddenFromAI(message)).length;
   return visible.slice(-Math.max(size, sinceBoundary));
 }

--- a/packages/server/src/routes/generate/generate-route-utils.ts
+++ b/packages/server/src/routes/generate/generate-route-utils.ts
@@ -523,18 +523,18 @@ export function computeSummaryHideIds(args: {
  * window is `entryMessageIds` minus the tail, the LLM-facing batch and the hide set share
  * this selection; extending it is what lets a stranded tail be reclaimed.
  *
- * The boundary is identified ONLY by ids recorded in a live summary entry's
- * `hiddenMessageIds` — NOT by the bare `hiddenFromAI` flag. That flag is ambiguous: the
- * user's manual "Hide from AI" toggle writes the same flag, so keying off it would let a
- * stray manual hide on an early message be misread as a summary boundary and balloon the
- * window to (nearly) the whole chat. With no summary-hidden message before the window
- * (e.g. the first summary, or only manual hides), the plain last-`size` window is used.
- * Pure: `messages` must be chat-ordered (ascending).
+ * The boundary is identified ONLY by messages a live summary entry actually summarized
+ * (its `messageIds` / `hiddenMessageIds`) — NOT by the bare `hiddenFromAI` flag. That
+ * flag is ambiguous: the user's manual "Hide from AI" toggle writes the same flag, so
+ * keying off it would let a stray manual hide on an early message be misread as a summary
+ * boundary and balloon the window to (nearly) the whole chat. With no summary-owned
+ * hidden message before the window (e.g. the first summary, or only manual hides), the
+ * plain last-`size` window is used. Pure: `messages` must be chat-ordered (ascending).
  */
 export function selectRollingSummaryMessages<T extends { id: string; extra?: unknown }>(args: {
   messages: T[];
   contextSize: number;
-  summaryEntries?: ReadonlyArray<{ enabled?: boolean; hiddenMessageIds?: string[] }>;
+  summaryEntries?: ReadonlyArray<{ enabled?: boolean; hiddenMessageIds?: string[]; messageIds?: string[] }>;
 }): T[] {
   const { messages, contextSize } = args;
   const size = Number.isFinite(contextSize) ? Math.max(0, Math.floor(contextSize)) : 0;
@@ -542,20 +542,22 @@ export function selectRollingSummaryMessages<T extends { id: string; extra?: unk
   const visible = messages.filter((message) => !isMessageHiddenFromAI(message));
   // Fewer visible messages than the window — nothing can have drifted out of it.
   if (visible.length <= size) return visible;
-  // Messages hidden by a live (enabled) summary entry — the only hides that mark a real
-  // summary boundary. A manual "Hide from AI" never appears here, so it can't expand the
-  // window.
-  const summaryHidden = new Set<string>();
+  // Ids owned by a live (enabled) summary entry — what it summarized. A manual "Hide from
+  // AI" never appears here, so it can't be mistaken for a boundary. We include both
+  // `hiddenMessageIds` and `messageIds` so entries created before `hiddenMessageIds`
+  // existed (see ChatSummaryEntry) still anchor a boundary; the hidden check in the scan
+  // keeps the protected tail (also in `messageIds`, but visible) from being chosen.
+  const summaryOwned = new Set<string>();
   for (const entry of Array.isArray(args.summaryEntries) ? args.summaryEntries : []) {
-    if (entry?.enabled !== false && Array.isArray(entry?.hiddenMessageIds)) {
-      for (const id of entry.hiddenMessageIds) summaryHidden.add(id);
-    }
+    if (entry?.enabled === false) continue;
+    for (const id of Array.isArray(entry?.hiddenMessageIds) ? entry.hiddenMessageIds : []) summaryOwned.add(id);
+    for (const id of Array.isArray(entry?.messageIds) ? entry.messageIds : []) summaryOwned.add(id);
   }
-  if (summaryHidden.size === 0) return visible.slice(-size);
-  // The previous summary's boundary: the most recent summary-hidden message.
+  if (summaryOwned.size === 0) return visible.slice(-size);
+  // The previous summary's boundary: the most recent hidden message owned by a summary.
   let lastBoundaryIndex = -1;
   for (let i = messages.length - 1; i >= 0; i--) {
-    if (summaryHidden.has(messages[i]!.id)) {
+    if (isMessageHiddenFromAI(messages[i]!) && summaryOwned.has(messages[i]!.id)) {
       lastBoundaryIndex = i;
       break;
     }

--- a/packages/server/src/routes/generate/generate-route-utils.ts
+++ b/packages/server/src/routes/generate/generate-route-utils.ts
@@ -513,6 +513,45 @@ export function computeSummaryHideIds(args: {
     .map((message) => message.id);
 }
 
+/**
+ * Select the messages a non-range rolling summary should cover. Normally the most
+ * recent `contextSize` *visible* messages (the historical `visible.slice(-contextSize)`
+ * behavior). When a previous summary has already hidden earlier messages, the window
+ * is extended back to that summary's hidden boundary, so a protected tail that has
+ * drifted beyond the last `contextSize` visible messages is re-summarized and hidden
+ * on this run instead of staying visible forever and accumulating (#2879). Because the
+ * hide window for each entry is `entryMessageIds` minus the tail, the LLM-facing batch
+ * and the hide set share this selection; extending it is what lets a stranded tail be
+ * reclaimed. Pure: `messages` must be chat-ordered (ascending).
+ */
+export function selectRollingSummaryMessages<T extends { id: string; extra?: unknown }>(args: {
+  messages: T[];
+  contextSize: number;
+}): T[] {
+  const { messages, contextSize } = args;
+  const size = Number.isFinite(contextSize) ? Math.max(0, Math.floor(contextSize)) : 0;
+  if (size <= 0) return [];
+  const visible = messages.filter((message) => !isMessageHiddenFromAI(message));
+  // Fewer visible messages than the window — nothing can have drifted out of it.
+  if (visible.length <= size) return visible;
+  // The previous summary's boundary: the most recent already-hidden message.
+  let lastHiddenIndex = -1;
+  for (let i = messages.length - 1; i >= 0; i--) {
+    if (isMessageHiddenFromAI(messages[i]!)) {
+      lastHiddenIndex = i;
+      break;
+    }
+  }
+  // No prior summary boundary (first summary) — the plain last-`size` window is correct.
+  if (lastHiddenIndex < 0) return visible.slice(-size);
+  // Visible messages accumulated since that boundary. Extend the window to cover all of
+  // them when they exceed `size`, pulling a drifted protected tail back into the batch.
+  const sinceBoundary = messages
+    .slice(lastHiddenIndex + 1)
+    .filter((message) => !isMessageHiddenFromAI(message)).length;
+  return visible.slice(-Math.max(size, sinceBoundary));
+}
+
 export function resolveRoleplayChatSummary(chatMode: string, chatMetadata: Record<string, unknown>): string | null {
   if (!isRoleplaySummaryMode(chatMode)) return null;
   return ((chatMetadata.summary as string) ?? "").trim() || null;

--- a/packages/server/src/services/conversation/character-commands.ts
+++ b/packages/server/src/services/conversation/character-commands.ts
@@ -32,6 +32,8 @@
 // - [navigate: panel="...", tab="..."]
 // - [fetch: type="character|persona|lorebook|chat|preset", name="..."]
 
+import { normalizeTextForMatch } from "@marinara-engine/shared";
+
 import { stripConversationPromptTimestamps } from "./transcript-sanitize.js";
 
 export interface ScheduleUpdateCommand {
@@ -1077,6 +1079,81 @@ export function parseCharacterCommands(content: string): {
     .trim();
 
   return { cleanContent, commands };
+}
+
+/**
+ * Parse character commands from a merged group response, attributing each command
+ * to the character whose `Name:` line-prefixed segment it appears in.
+ *
+ * Conversation-mode group chats use "merged" generation: a single response carries
+ * multiple characters' turns, each introduced by a `CharacterName: ` line prefix
+ * (the same format the client splits on for display — see parseNamePrefixFormat).
+ * The base parseCharacterCommands() attributes every command to one character, so a
+ * command emitted by, say, the third character (e.g. `[selfie]`) is wrongly executed
+ * for the first. This segments the response the same way and matches each parsed
+ * command back to its segment so it is attributed to its actual speaker.
+ *
+ * The authoritative command list and cleaned content come from a single whole-response
+ * parse, so no command is dropped or reordered even if one spans a name boundary;
+ * only the attribution is layered on. Commands with no matching segment (and text
+ * before the first recognised name prefix) fall back to `fallbackCharacterId`.
+ */
+export function parseCharacterCommandsBySpeaker(
+  content: string,
+  knownCharacters: ReadonlyArray<{ id: string; name: string }>,
+  fallbackCharacterId: string | null,
+): { commands: CharacterCommand[]; commandCharacterIds: (string | null)[]; cleanContent: string } {
+  const base = parseCharacterCommands(content);
+
+  const nameToId = new Map<string, string>();
+  for (const character of knownCharacters) {
+    const key = normalizeTextForMatch(character.name);
+    if (key && !nameToId.has(key)) nameToId.set(key, character.id);
+  }
+
+  // Segment the response by leading "Name: " line prefixes, mirroring the client's
+  // parseNamePrefixFormat so server-side attribution matches the rendered split.
+  const segments: Array<{ characterId: string | null; text: string }> = [];
+  let currentId: string | null = fallbackCharacterId;
+  let currentLines: string[] = [];
+  const flush = () => {
+    if (currentLines.length > 0) segments.push({ characterId: currentId, text: currentLines.join("\n") });
+    currentLines = [];
+  };
+  for (const line of content.split("\n")) {
+    const colonIdx = line.indexOf(": ");
+    if (colonIdx > 0) {
+      const mappedId = nameToId.get(normalizeTextForMatch(line.slice(0, colonIdx)));
+      if (mappedId) {
+        flush();
+        currentId = mappedId;
+        currentLines = [line.slice(colonIdx + 2)];
+        continue;
+      }
+    }
+    currentLines.push(line);
+  }
+  flush();
+
+  // Build a per-command attribution queue keyed by command shape, consumed in
+  // segment order so duplicate commands attribute left-to-right.
+  const attributionQueue = new Map<string, (string | null)[]>();
+  for (const segment of segments) {
+    for (const command of parseCharacterCommands(segment.text).commands) {
+      const key = JSON.stringify(command);
+      const queue = attributionQueue.get(key) ?? [];
+      queue.push(segment.characterId);
+      attributionQueue.set(key, queue);
+    }
+  }
+
+  const commandCharacterIds = base.commands.map((command) => {
+    const queue = attributionQueue.get(JSON.stringify(command));
+    const matched = queue?.shift();
+    return matched === undefined ? fallbackCharacterId : matched;
+  });
+
+  return { commands: base.commands, commandCharacterIds, cleanContent: base.cleanContent };
 }
 
 /** Parse Roleplay-only direct-message commands without enabling the wider Conversation command set. */


### PR DESCRIPTION
## Linked issue

Closes #2866
Closes #2867
Closes #2868
Closes #2869
Closes #2870
Closes #2877
Closes #2878
Closes #2879

## Why this change

A batch of v2.0.5 issues reported in the community Discord, grouped into one PR. Each is independent and small; the root cause for each is below.

- **#2866 — `/continue` appends to the wrong message.** In Roleplay mode, the `/continue` slash command always targeted the latest assistant message, even when the user had posted since. After `/impersonate` (user posts last), `/continue` appended onto the scenario/first message (index 0) instead of generating a new reply. The toolbar `/continue` button is gated on `lastMessageRole === "assistant"`; the slash command had no equivalent gate.
- **#2867 — Swipe counter always visible.** Since 2.0.5 the swipe counter + arrows showed on every message, including single-swipe ones. The visibility guard had been changed to `swipeCount <= 1 && !onCreateNextSwipe`, and the message layouts always pass `onCreateNextSwipe`, so the control never hid.
- **#2868 — Author's Notes / Summary editor closes when the mobile keyboard opens.** On a mobile viewport the Author's Notes and manual Summary editors are opened from the chat toolbar's "More options" overflow menu (`ChatToolbarMenu`), and their panels are portals rendered by buttons that live *inside* that menu. The menu recomputes its layout on every `window` resize and, on a mobile viewport, closes itself each time. The on-screen keyboard opening fires a resize, so opening the keyboard closed the overflow menu and unmounted the open editor panel before the user could type.
- **#2869 — No usable drag handle for character folders.** The touch drag handle was hidden with `md:hidden` (≥768px). It is a touch-only affordance (native HTML5 row-drag covers mouse), so touch devices at ≥768px width (tablets) had no working way to drag a character into a folder.
- **#2870 — Group-chat selfies always use the first character.** In Conversation-mode group chats, the default "merged" generation produces one response carrying every character's turn. All commands parsed from that response — including `[selfie]` — were attributed to the first character, so a selfie taken by another character rendered the first character's appearance and name.
- **#2877 — Conversation reacts leak as raw `[react: …]` text when Character Commands is off.** The react capability instruction is appended to the conversation system prompt unconditionally, but the `[react: emoji="…"]` tag is parsed, stripped, and applied inside the command pipeline that only runs when Character Commands are enabled (`metadata.characterCommands !== false`). With commands off, the model was still told it could react, so it emitted the tag and the server left it in the visible message as raw text with no reaction badge. Reported in Discord as group-chat-only; it is not group-specific — the trigger is the Character Commands toggle, not group vs. solo.
- **#2878 — Streaming responses cause GUI lag during generation.** While a response streams, the live message re-renders on every token, and the markdown renderer re-parses the *entire* accumulated buffer from scratch each time (multiple per-line regex passes plus recursive inline parsing). The per-token cost therefore grows with the length of the message already received — roughly O(n²) over the whole stream. On fast streams, especially a local model running on the same machine as the server (the reported worst case), that work saturates the main thread and the UI stutters (input lag, scroll jank), worse the longer the reply.
- **#2879 — Summarization doesn't hide previously-summarized tail messages on later runs.** The rolling summary picks its batch with `visible.slice(-contextSize)`, and that same set bounds each entry's frozen `hiddenMessageIds` (the batch minus the protected tail). Once a previous summary's protected tail drifts beyond the last `contextSize` visible messages, no later entry claims it, so it stays visible forever and accumulates as stale context.

## What changed

- **#2866:** Added `lastMessageRole` to `SlashCommandContext` and gated the `/continue` handler on it — it continues the latest assistant message only when that message is the last in the chat, otherwise it generates a fresh reply. Threaded `lastMessageRole` through the three context build sites (`ChatInput`, `ConversationInput` ×2).
- **#2867:** Restored the guard to `if (swipeCount <= 1) return null;` so the counter and arrows only appear when a message has multiple swipes (pre-2.0.5 behavior). New swipes are still generated via the regenerate path.
- **#2868:** `ChatToolbarMenu` now closes its overflow menu only when the viewport **width** changes (orientation / window resize) rather than on every resize — so the on-screen keyboard, which only shrinks the height, no longer dismisses the menu and unmounts the open Author's Notes or Summary panel. Hardening in the same area: `AuthorNotesButton`'s resize/scroll frame recompute keeps the last good frame instead of clearing it when the anchor is transiently unmeasurable, and its outside-pointer close handler no longer dismisses while a field inside the panel is focused (mobile-only, so desktop outside-clicks still close on the first click).
- **#2869:** Changed `TouchDragHandle` visibility from the width-based `md:hidden` to the pointer-based `[@media(pointer:fine)]:hidden`, so the handle shows on touch (coarse-pointer) devices at any width and stays hidden on mouse desktops. This is the shared handle used by the Characters, Presets, Connections, Lorebooks, and Personas panels.
- **#2870:** Added `parseCharacterCommandsBySpeaker`, which segments a merged group response by the same `Name:` prefixes the client uses for display (`parseNamePrefixFormat` + the shared `normalizeTextForMatch`) and attributes each command to its segment's character. The authoritative command list and cleaned content still come from a single whole-response parse, so no command is dropped or reordered — only the attribution is layered on, with a fallback to the generating character. Wired into generation **only** for merged Conversation-mode group chats; Roleplay mode, the per-character individual loop, and non-group chats are byte-identical to before.
- **#2877:** Gated the react capability instruction on `conversationCommandsEnabled`, the same condition that guards the parse/strip/apply path, so the `[react: …]` syntax is only advertised to the model when it will actually be handled. With Character Commands enabled, reactions still strip and post as badges exactly as before.
- **#2878:** Added a small `requestAnimationFrame` coalescer (`rafThrottle`, with an injectable scheduler) and a `useThrottledStreamBuffer` hook, and switched the conversation and roleplay live-stream renderers to read the streaming buffer through it. The live message now re-renders — and so re-parses its markdown — at most once per animation frame instead of once per token, which removes the per-token full re-parse that grows with message length. The store's `streamBuffer` is still written on every token, so token-exact consumers (ChatArea's auto-scroll subscriber) are unaffected; the committed message is rendered from the React Query cache once streaming ends, so a live frame being up to ~16ms behind is never visible. On slow streams (≤60 tok/s) tokens already arrive slower than the frame budget, so this is a no-op there; the win scales with token rate (≈4× fewer markdown parses at 240 tok/s, ≈8× at 480 tok/s in a local micro-benchmark of the renderer).
- **#2879:** Added `selectRollingSummaryMessages`, a pure helper that keeps the plain last-`contextSize` window for the first summary and whenever the visible set fits the window, but extends the window back to the previous summary's boundary when visible messages have piled up past it — pulling the drifted tail back into the batch so it is summarized and hidden on this run. The boundary is identified by ids a live summary entry actually summarized (its `messageIds` / `hiddenMessageIds`), **not** the bare `hiddenFromAI` flag — a user's manual "Hide from AI" toggle writes the same flag, and keying off it would let a stray manual hide be misread as a boundary and balloon the window to nearly the whole chat. Including `messageIds` (guarded by a hidden-check so the protected tail isn't chosen) also covers entries created before the `hiddenMessageIds` field existed. Wired into the automatic summary (`generate.routes.ts`) and the manual "summarize last N" path (`chats.routes.ts`); the explicit manual range path is unchanged.

## Validation

- [x] `pnpm check` passes locally
- [x] Container (Docker / Podman) built and ran without issue
- [x] Ran the app, clicked through the changes manually
- [x] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [x] Above manual verification completed (describe below)
- [x] Read and followed `CONTRIBUTING.md`

### Manual verification notes

Tested on a build deployed to my private staging instance.

- **#2866:** In a Roleplay chat with a first-message scenario, `/impersonate "Hi"` then `/continue` — confirm a new assistant reply is created rather than text being appended to the scenario message. Also confirm the normal case still continues: with the last message being an assistant reply, `/continue` extends it.
- **#2867:** A message with one swipe shows no counter; a message with multiple swipes shows the `n / m` counter and arrows.
- **#2868 (please confirm on a real mobile device):** On Android, open the "More options" toolbar menu, open Author's Notes, tap the textarea — the panel stays open with the keyboard up and is editable. Same for the manual Summary editor. Also verified here with a Pixel-7 Playwright device-emulation run (the on-screen keyboard simulated by shrinking the viewport height, which fires the same `resize` / `visualViewport resize`): before the fix the panel unmounted on the simulated keyboard; after the fix it stays open and preserves typed text.
- **#2869 (needs a touch device ≥768px):** On a tablet, the drag handle appears on character rows and a character can be dragged into a folder. On a mouse desktop the handle stays hidden and native row-drag still works.
- **#2870:** In a Conversation-mode group chat with two or three visually distinct characters, have different characters take a selfie — each selfie should match the character that took it, not the first character.
- **#2877:** Reproduced live with an A/B test in a group chat. With Character Commands **on**, each character's reaction rendered as a badge. With Character Commands **off**, the same prompt produced literal `[react: emoji="…"]` text in every reply with no badge. After the fix, with commands off the model is no longer told it can react, so the raw tag no longer appears; with commands on, reactions still post as badges.
- **#2878:** Enable streaming, then generate a long multi-paragraph reply in both Conversation and Roleplay modes and confirm the stream stays smooth (no input/scroll stutter that worsens as the message grows), the live text still updates continuously, and the finished message matches what streamed. The throttle is covered by a focused unit test for `rafThrottle` (a burst of calls in one frame collapses to a single apply with the latest value; per-frame ordering; flush/cancel; clearing to empty is delivered). The O(n²) per-token re-parse and the throttled-vs-current parse counts were measured against the real `renderMarkdownBlocks` (message length ×2 → streaming parse time ×~4; throttling cuts parse work ≈4× at 240 tok/s and ≈8× at 480 tok/s, and is a no-op at ≤60 tok/s).
- **#2879:** Covered by a focused regression test for `selectRollingSummaryMessages` + `computeSummaryHideIds`: the first summary still selects the plain last-`contextSize` window; a previously-protected tail that has drifted beyond the window is bridged back and hidden (`e…n`) instead of stranded; a manual "Hide from AI" is **not** treated as a boundary (no window ballooning); and pre-`hiddenMessageIds` entries still anchor a boundary. Also manually verify across two consecutive automatic summaries with a nonzero tail that no previously-summarized message remains visible, and that toggling "Hide from AI" on an early message before an automatic summary does not blow up the summarized range.

## Docs and release impact

- [x] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Version/release files updated (only if this PR includes a version bump)
