### PR TITLE
fix: preserve knowledge router prompt injections

### DIFF
--- a/packages/server/src/routes/generate.routes.ts
+++ b/packages/server/src/routes/generate.routes.ts
@@ -203,6 +203,7 @@ import {
   buildLockedPersonaTrackerPatch,
   extractImageAttachmentDataUrls,
   appendNonLeadingSystemMessagesToLastUser,
+  appendSeparateAgentInjectionMessage,
   computeSummaryHideIds,
   injectIntoOutputFormatOrLastUser,
   isManualTrackerCharacterId,
@@ -5310,36 +5311,11 @@ export async function generateRoutes(app: FastifyInstance) {
           return results;
         };
 
-        // Helper: wrap a separate-injection agent's text and append it to the last
-        // user message. Used by both knowledge-retrieval and knowledge-router on
-        // both fresh generations AND regen-cache replays — keeping the wrap+append
-        // in one place prevents the two paths from drifting again (PR #228 had to
-        // fix exactly that drift once already).
+        // Helper: wrap a separate-injection agent's text as protected prompt
+        // context. Used by both knowledge-retrieval and knowledge-router on both
+        // fresh generations AND regen-cache replays so the two paths stay aligned.
         const appendSeparateAgentInjection = (agentType: string, text: string): void => {
-          const meta =
-            agentType === "knowledge-router"
-              ? { heading: "Knowledge Router", tag: "knowledge_router" }
-              : agentType === "knowledge-retrieval"
-                ? { heading: "Knowledge Retrieval", tag: "knowledge_retrieval" }
-                : agentType === "director"
-                  ? { heading: "Narrative Director", tag: "narrative_director" }
-                  : { heading: agentType, tag: agentType.replace(/[^a-z0-9_-]/gi, "_") };
-          // Honor all three wrapFormat values (the previous KR-only injection had
-          // a markdown-or-xml-fallback bug that "none" silently fell into).
-          const wrapped =
-            wrapFormat === "none"
-              ? `\n\n${meta.heading}:\n${text}`
-              : wrapFormat === "markdown"
-                ? `\n\n## ${meta.heading}\n${text}`
-                : `\n\n<${meta.tag}>\n${text}\n</${meta.tag}>`;
-          const lastUserIdx = findLastIndex(finalMessages, "user");
-          if (lastUserIdx >= 0) {
-            const target = finalMessages[lastUserIdx]!;
-            finalMessages[lastUserIdx] = { ...target, content: target.content + wrapped };
-          } else {
-            const last = finalMessages[finalMessages.length - 1]!;
-            finalMessages[finalMessages.length - 1] = { ...last, content: last.content + wrapped };
-          }
+          appendSeparateAgentInjectionMessage(finalMessages, agentType, text, wrapFormat);
         };
 
         if (shouldRunDirectorSecretPlot || shouldRunPreGen || shouldRunKR || shouldRunRouter) {

--- a/packages/server/src/routes/generate/generate-route-utils.ts
+++ b/packages/server/src/routes/generate/generate-route-utils.ts
@@ -917,6 +917,34 @@ export function appendReadableAttachmentsToContent(
   return `${content}${content.trim() ? "\n\n" : ""}${blocks.join("\n\n")}`;
 }
 
+export function formatSeparateAgentInjection(agentType: string, text: string, wrapFormat: string): string {
+  const meta =
+    agentType === "knowledge-router"
+      ? { heading: "Knowledge Router", tag: "knowledge_router" }
+      : agentType === "knowledge-retrieval"
+        ? { heading: "Knowledge Retrieval", tag: "knowledge_retrieval" }
+        : agentType === "director"
+          ? { heading: "Narrative Director", tag: "narrative_director" }
+          : { heading: agentType, tag: agentType.replace(/[^a-z0-9_-]/gi, "_") };
+
+  if (wrapFormat === "none") return `${meta.heading}:\n${text}`;
+  if (wrapFormat === "markdown") return `## ${meta.heading}\n${text}`;
+  return `<${meta.tag}>\n${text}\n</${meta.tag}>`;
+}
+
+export function appendSeparateAgentInjectionMessage(
+  messages: SimpleMessage[],
+  agentType: string,
+  text: string,
+  wrapFormat: string,
+): void {
+  messages.push({
+    role: "system",
+    content: formatSeparateAgentInjection(agentType, text, wrapFormat),
+    contextKind: "injection",
+  });
+}
+
 /** Resolve the base URL for a connection, falling back to the provider default. */
 export function resolveBaseUrl(connection: { baseUrl: string | null; provider: string }): string {
   if (connection.baseUrl) return connection.baseUrl.replace(/\/+$/, "");

--- a/scripts/regressions/prompt.regression.ts
+++ b/scripts/regressions/prompt.regression.ts
@@ -180,6 +180,37 @@ const cases: RegressionCase[] = [
       assert.match(promptText, /ROUTER_SURVIVOR_CONTEXT/);
     },
   },
+  {
+    name: "separate agent injections do not depend on a user-adjacent tail",
+    run() {
+      const messages: SimpleMessage[] = [{ role: "system", content: "Stable system prompt." }];
+      messages.push({
+        role: "user",
+        content: `old user anchor ${"x ".repeat(450)}`,
+        contextKind: "history",
+      });
+      for (let index = 0; index < 6; index += 1) {
+        messages.push({
+          role: "assistant",
+          content: `assistant history tail ${index} ${"x ".repeat(450)}`,
+          contextKind: "history",
+        });
+      }
+
+      appendSeparateAgentInjectionMessage(messages, "knowledge-router", "ROUTER_SURVIVOR_CONTEXT", "xml");
+      messages.push({ role: "assistant", content: "assistant prefill tail" });
+
+      const fitted = fitMessagesForModelAccess({
+        messages,
+        policy: { suppressModelParameters: false, effectiveMaxContext: 900 },
+        maxTokens: 128,
+      }).messages;
+      const promptText = fitted.map((message) => message.content).join("\n");
+
+      assert.equal(promptText.includes("old user anchor"), false);
+      assert.match(promptText, /ROUTER_SURVIVOR_CONTEXT/);
+    },
+  },
 ];
 
 let failed = 0;

--- a/scripts/regressions/prompt.regression.ts
+++ b/scripts/regressions/prompt.regression.ts
@@ -8,10 +8,12 @@ import {
 } from "../../packages/shared/src/index.js";
 import {
   appendNonLeadingSystemMessagesToLastUser,
+  appendSeparateAgentInjectionMessage,
   shouldEnableAgentsForGeneration,
   shouldInjectIdentityFallback,
   type SimpleMessage,
 } from "../../packages/server/src/routes/generate/generate-route-utils.js";
+import { fitMessagesForModelAccess } from "../../packages/server/src/services/generation/model-access-policy.js";
 
 type RegressionCase = {
   name: string;
@@ -149,6 +151,33 @@ const cases: RegressionCase[] = [
         }),
         false,
       );
+    },
+  },
+  {
+    name: "separate agent injections survive long-history context fitting",
+    run() {
+      const messages: SimpleMessage[] = [{ role: "system", content: "Stable system prompt." }];
+      for (let index = 0; index < 8; index += 1) {
+        messages.push({
+          role: index % 2 === 0 ? "user" : "assistant",
+          content: `old context ${index} ${"x ".repeat(450)}`,
+          contextKind: "history",
+        });
+      }
+      messages.push({ role: "user", content: "latest visible user turn", contextKind: "history" });
+
+      appendSeparateAgentInjectionMessage(messages, "knowledge-router", "ROUTER_SURVIVOR_CONTEXT", "xml");
+      messages.push({ role: "assistant", content: "assistant prefill tail" });
+
+      const fitted = fitMessagesForModelAccess({
+        messages,
+        policy: { suppressModelParameters: false, effectiveMaxContext: 900 },
+        maxTokens: 128,
+      }).messages;
+      const promptText = fitted.map((message) => message.content).join("\n");
+
+      assert.equal(promptText.includes("old context 0"), false);
+      assert.match(promptText, /ROUTER_SURVIVOR_CONTEXT/);
     },
   },
 ];


### PR DESCRIPTION
## What?
Fix Knowledge Router output being omitted from assembled prompts in established chats.

## Why?
Router requests can complete and return lorebook selections, but established chats can lose that output before final prompt assembly, so the main model cannot use it.

## How?
- Store separate Knowledge Router and Knowledge Retrieval prompt injections as protected prompt injection messages instead of appending them to chat history.
- Keep the runtime-section replacement path intact when a preset section handles the agent output.
- Add a prompt regression that forces long-history context fitting and verifies the router injection survives while old history is trimmed.

## Testing?
- pnpm regression:prompt
- pnpm check

## Anything Else?
Closes #2874.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved how injected agent instructions are added to prompts, with cleaner formatting for different agent types and wrapping styles.
* **Bug Fixes**
  * Prompts now preserve injected instructions more reliably when long conversation history is trimmed for model limits.
* **Tests**
  * Added regression coverage for prompt fitting to ensure older context is removed while injected routing instructions remain included.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->