### PR TITLE
fix: keep memory recall modal interactive

### DIFF
--- a/e2e/core-flows.e2e.ts
+++ b/e2e/core-flows.e2e.ts
@@ -80,6 +80,37 @@ test("chat mode tabs and new-chat actions stay reachable", async ({ page }) => {
   expect(errors).toEqual([]);
 });
 
+test("memory recall modal accepts clicks from chat settings", async ({ page }, testInfo) => {
+  test.skip(!testInfo.project.name.includes("desktop"), "Memory recall modal regression is covered on desktop.");
+
+  const response = await page.request.post("/api/chats", {
+    data: {
+      name: "Memory Recall Menu Smoke",
+      mode: "conversation",
+      characterIds: [],
+    },
+  });
+  expect(response.ok()).toBeTruthy();
+  const chat = (await response.json()) as { id: string };
+
+  await page.addInitScript((chatId) => {
+    localStorage.setItem("marinara-active-chat-id", chatId);
+  }, chat.id);
+  await page.goto("/");
+
+  await page.getByRole("button", { name: "Chat Settings" }).click();
+  const drawer = page.locator(".mari-chat-settings-drawer");
+  await expect(drawer.getByRole("heading", { name: "Chat Settings" })).toBeVisible();
+  await drawer.getByText("Memory Recall", { exact: true }).click();
+  await drawer.getByRole("button", { name: "Access memories for this chat" }).click();
+
+  const dialog = page.getByRole("dialog", { name: "Memories for This Chat" });
+  await expect(dialog).toBeVisible();
+  await dialog.getByText("0 memory chunks").click();
+  await expect(dialog).toBeVisible();
+  await expect(drawer.getByRole("heading", { name: "Chat Settings" })).toBeVisible();
+});
+
 test("mobile topbar remains reachable while sidebars switch", async ({ page }, testInfo) => {
   test.skip(!testInfo.project.name.includes("mobile"), "Mobile shell smoke only runs in the mobile project.");
 

--- a/packages/client/src/components/chat/ChatSettingsDrawer.tsx
+++ b/packages/client/src/components/chat/ChatSettingsDrawer.tsx
@@ -7037,6 +7037,7 @@ export function ChatSettingsDrawer({
         chatId={chat.id}
         open={showMemoriesModal}
         onClose={() => setShowMemoriesModal(false)}
+        chatFloatingPanel
       />
 
       <Modal
@@ -7384,7 +7385,17 @@ const MEMORY_CONTENT_CLASS =
 const MAX_MEMORY_RECALL_IMPORT_FILE_BYTES = 25 * 1024 * 1024;
 const MAX_MEMORY_RECALL_IMPORT_FILE_LABEL = "25 MB";
 
-function MemoryRecallMemoriesModal({ chatId, open, onClose }: { chatId: string; open: boolean; onClose: () => void }) {
+function MemoryRecallMemoriesModal({
+  chatId,
+  open,
+  onClose,
+  chatFloatingPanel = false,
+}: {
+  chatId: string;
+  open: boolean;
+  onClose: () => void;
+  chatFloatingPanel?: boolean;
+}) {
   const memoriesQuery = useChatMemories(chatId, open);
   const deleteMemory = useDeleteChatMemory(chatId);
   const clearMemories = useClearChatMemories(chatId);
@@ -7460,7 +7471,13 @@ function MemoryRecallMemoriesModal({ chatId, open, onClose }: { chatId: string; 
   };
 
   return (
-    <Modal open={open} onClose={onClose} title="Memories for This Chat" width="max-w-3xl">
+    <Modal
+      open={open}
+      onClose={onClose}
+      title="Memories for This Chat"
+      width="max-w-3xl"
+      chatFloatingPanel={chatFloatingPanel}
+    >
       <div className="space-y-3">
         <div className="flex flex-wrap items-center justify-between gap-2 rounded-xl bg-[var(--secondary)]/70 px-3 py-2 ring-1 ring-[var(--border)]">
           <div className="text-[0.6875rem] text-[var(--muted-foreground)]">


### PR DESCRIPTION
## What?
Fix the Memory Recall chat-settings modal so clicks inside it stay interactive.

## Why?
The memories modal was opened from the chat settings drawer, but clicking inside the modal could close the drawer and dismiss the modal before import, export, or delete actions could run.

## How?
- Mark the Memory Recall modal as a chat floating panel so the chat settings drawer does not treat portal clicks inside it as outside clicks.
- Thread the floating-panel marker through the Memory Recall modal wrapper to the shared modal shell.
- Add a focused UI regression check that opens the Memory Recall modal from chat settings, clicks inside it, and verifies the modal stays open.

## Testing?
- `pnpm check`
- `pnpm smoke:ui -- --project=desktop-chromium --grep "memory recall modal"` as a focused regression check. Playwright's built-in webserver wrapper timed out locally, so the same check was run against a manually started dev server on the configured Playwright ports.

## Screenshots (optional)
No screenshots. The focused Playwright regression covers the interaction path.

## Anything Else?
Closes #2861.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the “Memory Recall” experience in chat settings so the memories dialog now behaves correctly as a floating panel and accepts clicks as expected.
  * Added end-to-end coverage for opening the memories dialog from chat settings and interacting with the “Memories for This Chat” view.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->