### PR TITLE
[codex] Prepare v2.0.6 issue sweep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,32 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 
 ## [Unreleased]
 
+## [2.0.6]
+
+### Added
+
+- Added a per-chat AI translation prompt override in Chat Settings, with a restore-default action, so chats can customize the translation system prompt without losing the built-in default (#2883).
+- Added llama.cpp sidecar embedding endpoint controls for pooling type and physical batch size so Gemma and other embedding GGUF models can use OpenAI-compatible lorebook/memory embeddings when they require non-default pooling (#2863).
+
+### Changed
+
+- Chat Branches no longer shows a separate "Active" pill; the checkmark and active row highlight identify the selected branch, while rename/delete actions remain available for the active branch.
+- Memory recall chunking now behaves as read-behind storage when a chat message limit is set, keeping the active prompt tail out of durable memory chunks (#2862).
+
+### Fixed
+
+- Fixed Professor Mari workspace privileged-route access so trusted LAN/Tailscale clients can use the workspace when loopback-only mode is disabled, while database command execution remains loopback-only (#2884).
+- Fixed privileged-route parameter errors so missing or invalid admin access is not rewritten as a generation-parameter warning (#2884).
+- Fixed chat exports so saved thinking/reasoning content is included in text exports and mirrored in JSONL exports/imports (#2881).
+- Fixed sprite prompt compilation so concise user descriptions survive prompt review/compaction, and reviewed prompts no longer receive a second layout/negative suffix (#2871).
+- Fixed memory-recall branch contamination by pruning native chunks whose timestamp span no longer matches the current chat message log (#2862).
+- Fixed v2.0.6 release metadata across packages, the homepage-visible app version, Windows installer sources, PWA manifest, README release pointer, and Android APK metadata.
+
+### Platform Notes
+
+- Android `versionName` is `2.0.6` with `versionCode 25`.
+- Windows, macOS/Linux, Termux, Docker, APK, and PWA users can update through the usual v2 updater paths once release assets are published.
+
 ## [2.0.5]
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@
 
 ## Latest Release
 
-Current stable release: **[v2.0.5](https://github.com/Pasta-Devs/Marinara-Engine/releases/tag/v2.0.5)**.
+Current stable release: **[v2.0.6](https://github.com/Pasta-Devs/Marinara-Engine/releases/tag/v2.0.6)**.
 
 See [CHANGELOG.md](CHANGELOG.md) for detailed release notes. Tagged releases use the `vX.Y.Z` format and are published on the [Releases](https://github.com/Pasta-Devs/Marinara-Engine/releases) page. Android APKs are Termux bootstrap + WebView shells: they can download Termux from F-Droid, launch Android's installer, start the Termux setup flow after required permission prompts, then open the local Marinara server on the same device.
 

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -22,10 +22,10 @@ android {
         applicationId "com.marinara.engine"
         minSdk 24
         targetSdk 34
-        versionCode 24
-        versionName "2.0.5"
+        versionCode 25
+        versionName "2.0.6"
         buildConfigField "String", "MARINARA_SERVER_URL", "\"http://127.0.0.1:${marinaraPort}\""
-        buildConfigField "String", "MARINARA_RELEASE_TAG", "\"v2.0.5\""
+        buildConfigField "String", "MARINARA_RELEASE_TAG", "\"v2.0.6\""
     }
 
     signingConfigs {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "marinara-engine",
-  "version": "2.0.5",
+  "version": "2.0.6",
   "private": true,
   "description": "AI Chat & Roleplay Frontend — Conversation, Roleplay, Visual Novel",
   "author": "Marianna",

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@marinara-engine/client",
   "private": true,
-  "version": "2.0.5",
+  "version": "2.0.6",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/packages/client/public/manifest.json
+++ b/packages/client/public/manifest.json
@@ -2,7 +2,7 @@
   "name": "Marinara Engine",
   "short_name": "Marinara",
   "description": "AI Chat & Roleplay Frontend — Conversation, Roleplay, Visual Novel",
-  "version": "2.0.5",
+  "version": "2.0.6",
   "start_url": "/",
   "display": "standalone",
   "background_color": "#0a0a0f",

--- a/packages/client/src/components/chat/ChatArea.tsx
+++ b/packages/client/src/components/chat/ChatArea.tsx
@@ -888,6 +888,7 @@ export function ChatArea() {
       provider: chatMeta.translationProvider ?? "google",
       targetLanguage: chatMeta.translationTargetLang ?? "en",
       connectionId: chatMeta.translationConnectionId,
+      systemPrompt: typeof chatMeta.translationPrompt === "string" ? chatMeta.translationPrompt : undefined,
       deeplApiKey: chatMeta.translationDeeplApiKey,
       deeplxUrl: chatMeta.translationDeeplxUrl,
     });
@@ -896,6 +897,7 @@ export function ChatArea() {
     chatMeta.translationProvider,
     chatMeta.translationTargetLang,
     chatMeta.translationConnectionId,
+    chatMeta.translationPrompt,
     chatMeta.translationDeeplApiKey,
     chatMeta.translationDeeplxUrl,
   ]);

--- a/packages/client/src/components/chat/ChatBranchSelector.tsx
+++ b/packages/client/src/components/chat/ChatBranchSelector.tsx
@@ -163,11 +163,13 @@ export function ChatBranchSelector({
     ) {
       return;
     }
-    const nextActiveChatId =
-      branchId === activeChatId ? displayBranches.find((branch) => branch.id !== branchId)?.id : null;
+    const deletingActiveBranch = branchId === activeChatId;
+    const nextActiveChatId = deletingActiveBranch
+      ? (displayBranches.find((branch) => branch.id !== branchId)?.id ?? null)
+      : null;
     try {
       await deleteChat.mutateAsync({ id: branchId, groupId: groupId ?? null, force: true });
-      if (nextActiveChatId) setActiveChatId(nextActiveChatId);
+      if (deletingActiveBranch) setActiveChatId(nextActiveChatId);
     } catch (err) {
       toast.error(err instanceof Error ? `Delete failed: ${err.message}` : "Delete failed.");
     }
@@ -378,32 +380,27 @@ export function ChatBranchSelector({
                       </div>
                     </button>
 
-                    {isActive && (
-                      <span className="shrink-0 rounded-full bg-[var(--foreground)]/10 px-2 py-0.5 text-[0.625rem] font-medium text-[var(--foreground)]/75">
-                        Active
-                      </span>
-                    )}
-                    {!isActive && (
-                      <div className="flex shrink-0 items-center gap-1">
-                        <button
-                          type="button"
-                          onClick={() => void handleRenameBranch(branch)}
-                          className="rounded-lg p-1.5 text-[var(--muted-foreground)] transition-colors hover:bg-[var(--accent)] hover:text-[var(--foreground)]"
-                          title="Rename branch"
-                        >
-                          <Pencil size="0.75rem" />
-                        </button>
-                        <button
-                          type="button"
-                          onClick={() => void handleDeleteBranch(branch.id)}
-                          disabled={deleteChat.isPending}
-                          className="rounded-lg p-1.5 text-[var(--muted-foreground)] transition-colors hover:bg-[var(--accent)] hover:text-[var(--foreground)] disabled:opacity-50"
-                          title="Delete branch"
-                        >
-                          <Trash2 size="0.75rem" />
-                        </button>
-                      </div>
-                    )}
+                    <div className="flex shrink-0 items-center gap-1">
+                      <button
+                        type="button"
+                        onClick={() => void handleRenameBranch(branch)}
+                        className="rounded-lg p-1.5 text-[var(--muted-foreground)] transition-colors hover:bg-[var(--accent)] hover:text-[var(--foreground)]"
+                        title="Rename branch"
+                        aria-label={`Rename ${getChatDisplayName(branch)}`}
+                      >
+                        <Pencil size="0.75rem" />
+                      </button>
+                      <button
+                        type="button"
+                        onClick={() => void handleDeleteBranch(branch.id)}
+                        disabled={deleteChat.isPending}
+                        className="rounded-lg p-1.5 text-[var(--muted-foreground)] transition-colors hover:bg-[var(--accent)] hover:text-[var(--foreground)] disabled:opacity-50"
+                        title="Delete branch"
+                        aria-label={`Delete ${getChatDisplayName(branch)}`}
+                      >
+                        <Trash2 size="0.75rem" />
+                      </button>
+                    </div>
                   </div>
                 );
               })}

--- a/packages/client/src/components/modals/ModelDownloadModal.tsx
+++ b/packages/client/src/components/modals/ModelDownloadModal.tsx
@@ -22,7 +22,13 @@ import {
   X,
   Zap,
 } from "lucide-react";
-import type { SidecarBackend, SidecarQuantization, SidecarRuntimePreference } from "@marinara-engine/shared";
+import {
+  SIDECAR_EMBEDDING_POOLING_TYPES,
+  type SidecarBackend,
+  type SidecarEmbeddingPooling,
+  type SidecarQuantization,
+  type SidecarRuntimePreference,
+} from "@marinara-engine/shared";
 import { Modal } from "../ui/Modal.js";
 import { useSidecarStore } from "../../stores/sidecar.store.js";
 
@@ -79,6 +85,23 @@ function describeGpuLayers(gpuLayers: number): string {
   if (gpuLayers === -1) return "Auto offload";
   if (gpuLayers === 0) return "CPU only";
   return `${gpuLayers} GPU layers`;
+}
+
+function formatEmbeddingPoolingLabel(pooling: SidecarEmbeddingPooling): string {
+  switch (pooling) {
+    case "none":
+      return "None";
+    case "mean":
+      return "Mean";
+    case "cls":
+      return "CLS";
+    case "last":
+      return "Last token";
+    case "rank":
+      return "Rank";
+    default:
+      return pooling;
+  }
 }
 
 function formatCompactTokens(value: number): string {
@@ -180,6 +203,7 @@ export function ModelDownloadModal({ open, onClose }: Props) {
   const [temperatureInput, setTemperatureInput] = useState(String(config.temperature));
   const [topPInput, setTopPInput] = useState(String(config.topP));
   const [topKInput, setTopKInput] = useState(String(config.topK));
+  const [embeddingBatchSizeInput, setEmbeddingBatchSizeInput] = useState(String(config.embeddingBatchSize));
   const modalScrollRef = useRef<HTMLDivElement>(null);
   const previousScrollLayoutRef = useRef({ showSetupProgress: false, showRuntimeSettings: false });
 
@@ -209,6 +233,7 @@ export function ModelDownloadModal({ open, onClose }: Props) {
           formatRuntimePreferenceLabel(config.runtimePreference, platform),
           describeGpuLayers(config.gpuLayers),
           config.enableNativeToolCalls ? "native tools on" : "native tools off",
+          `${formatEmbeddingPoolingLabel(config.embeddingPooling)} pooling`,
           `${formatCompactTokens(config.contextSize)} ctx`,
           `${formatCompactTokens(config.maxTokens)} max`,
         ].join(" • ");
@@ -250,7 +275,15 @@ export function ModelDownloadModal({ open, onClose }: Props) {
     setTemperatureInput(String(config.temperature));
     setTopPInput(String(config.topP));
     setTopKInput(String(config.topK));
-  }, [config.contextSize, config.maxTokens, config.temperature, config.topP, config.topK]);
+    setEmbeddingBatchSizeInput(String(config.embeddingBatchSize));
+  }, [
+    config.contextSize,
+    config.maxTokens,
+    config.temperature,
+    config.topP,
+    config.topK,
+    config.embeddingBatchSize,
+  ]);
 
   useEffect(() => {
     if (status === "server_error" || testMessageResult) {
@@ -360,6 +393,18 @@ export function ModelDownloadModal({ open, onClose }: Props) {
     void updateConfig({ enableNativeToolCalls: !config.enableNativeToolCalls });
   };
 
+  const handleEmbeddingPoolingChange = (pooling: SidecarEmbeddingPooling) => {
+    void updateConfig({ embeddingPooling: pooling });
+  };
+
+  const handleApplyEmbeddingBatchSize = () => {
+    const parsed = Number.parseInt(embeddingBatchSizeInput, 10);
+    if (!Number.isFinite(parsed) || parsed < 128 || parsed > 32768) {
+      return;
+    }
+    void updateConfig({ embeddingBatchSize: parsed });
+  };
+
   const handleApplyCustomGpuLayers = () => {
     const parsed = Number.parseInt(gpuLayersInput, 10);
     if (!Number.isFinite(parsed) || parsed < 1 || parsed > 1024) {
@@ -408,6 +453,10 @@ export function ModelDownloadModal({ open, onClose }: Props) {
   const parsedTemperature = Number.parseFloat(temperatureInput);
   const parsedTopP = Number.parseFloat(topPInput);
   const parsedTopK = Number.parseInt(topKInput, 10);
+  const parsedEmbeddingBatchSize = Number.parseInt(embeddingBatchSizeInput, 10);
+  const embeddingBatchSizeValid =
+    Number.isFinite(parsedEmbeddingBatchSize) && parsedEmbeddingBatchSize >= 128 && parsedEmbeddingBatchSize <= 32768;
+  const embeddingBatchSizeDirty = embeddingBatchSizeInput !== String(config.embeddingBatchSize);
   const generationSettingsValid =
     Number.isFinite(parsedContextSize) &&
     parsedContextSize >= 512 &&
@@ -712,6 +761,71 @@ export function ModelDownloadModal({ open, onClose }: Props) {
                   </div>
                 )}
               </div>
+
+              {activeBackend !== "mlx" && (
+                <div className="rounded-xl border border-[var(--border)] bg-[var(--card)]/50 p-4">
+                  <div className="text-xs font-medium uppercase tracking-wider text-[var(--muted-foreground)]/60">
+                    Embedding Endpoint
+                  </div>
+                  <div className="mt-3 grid gap-3 md:grid-cols-2">
+                    <label className="flex flex-col gap-1.5">
+                      <span className="text-[0.6875rem] font-medium uppercase tracking-wider text-[var(--muted-foreground)]/60">
+                        Pooling Type
+                      </span>
+                      <div className="relative">
+                        <select
+                          value={config.embeddingPooling}
+                          onChange={(event) =>
+                            handleEmbeddingPoolingChange(event.target.value as SidecarEmbeddingPooling)
+                          }
+                          className="w-full appearance-none rounded-xl border border-[var(--border)] bg-[var(--card)]/80 px-3 py-2 pr-10 text-sm text-[var(--foreground)] outline-none transition-colors focus:border-[var(--marinara-chat-chrome-input-border-focus)] focus:ring-1 focus:ring-[var(--marinara-chat-chrome-focus-ring)]"
+                        >
+                          {SIDECAR_EMBEDDING_POOLING_TYPES.map((pooling) => (
+                            <option key={pooling} value={pooling}>
+                              {formatEmbeddingPoolingLabel(pooling)}
+                            </option>
+                          ))}
+                        </select>
+                        <ChevronDown
+                          size="0.95rem"
+                          className="pointer-events-none absolute right-3 top-1/2 -translate-y-1/2 text-[var(--muted-foreground)]/70"
+                        />
+                      </div>
+                    </label>
+
+                    <label className="flex flex-col gap-1.5">
+                      <span className="text-[0.6875rem] font-medium uppercase tracking-wider text-[var(--muted-foreground)]/60">
+                        Physical Batch Size
+                      </span>
+                      <div className="flex items-center gap-2">
+                        <input
+                          value={embeddingBatchSizeInput}
+                          onChange={(event) => setEmbeddingBatchSizeInput(event.target.value.replace(/[^\d]/g, ""))}
+                          onKeyDown={(event) => {
+                            if (event.key === "Enter") {
+                              handleApplyEmbeddingBatchSize();
+                            }
+                          }}
+                          inputMode="numeric"
+                          placeholder="512"
+                          className="min-w-0 flex-1 rounded-xl border border-[var(--border)] bg-[var(--card)]/80 px-3 py-2 text-sm text-[var(--foreground)] outline-none transition-colors focus:border-[var(--marinara-chat-chrome-input-border-focus)] focus:ring-1 focus:ring-[var(--marinara-chat-chrome-focus-ring)]"
+                        />
+                        <button
+                          onClick={handleApplyEmbeddingBatchSize}
+                          disabled={!embeddingBatchSizeValid || !embeddingBatchSizeDirty}
+                          className="flex shrink-0 items-center justify-center rounded-xl border border-[var(--border)] bg-[var(--card)]/70 px-4 py-2 text-sm text-[var(--foreground)] transition-colors hover:bg-[var(--card)] disabled:cursor-not-allowed disabled:opacity-50"
+                        >
+                          Apply
+                        </button>
+                      </div>
+                    </label>
+                  </div>
+                  <div className="mt-3 text-xs leading-relaxed text-[var(--muted-foreground)]/70">
+                    Use Mean pooling for OpenAI-compatible lorebook embeddings. Raise the physical batch size when long
+                    entries exceed llama-server's current batch limit; Gemma commonly works with 1024.
+                  </div>
+                </div>
+              )}
 
               <div className="rounded-xl border border-[var(--border)] bg-[var(--card)]/50 p-4">
                 <div className="text-xs font-medium uppercase tracking-wider text-[var(--muted-foreground)]/60">

--- a/packages/client/src/features/chat-settings/sections/TranslationSection.tsx
+++ b/packages/client/src/features/chat-settings/sections/TranslationSection.tsx
@@ -1,4 +1,5 @@
-import { Languages } from "lucide-react";
+import { Languages, RotateCcw } from "lucide-react";
+import { DEFAULT_TRANSLATION_SYSTEM_PROMPT } from "@marinara-engine/shared";
 import { HelpTooltip } from "../../../components/ui/HelpTooltip";
 import { SettingsSwitch } from "../../../components/panels/settings/SettingControls";
 import { ChatSettingsSection } from "../ChatSettingsSection";
@@ -12,6 +13,15 @@ interface TranslationSectionProps {
 
 export function TranslationSection({ metadata, textConnections, onMetadataChange }: TranslationSectionProps) {
   const provider = (metadata.translationProvider as string | undefined) ?? "google";
+  const storedPrompt = typeof metadata.translationPrompt === "string" ? metadata.translationPrompt : "";
+  const customPrompt = storedPrompt.trim().length > 0 ? storedPrompt : "";
+  const promptValue = customPrompt || DEFAULT_TRANSLATION_SYSTEM_PROMPT;
+  const hasCustomPrompt = customPrompt.length > 0;
+
+  const updatePrompt = (value: string) => {
+    const nextPrompt = !value.trim() || value.trim() === DEFAULT_TRANSLATION_SYSTEM_PROMPT.trim() ? null : value;
+    onMetadataChange({ translationPrompt: nextPrompt });
+  };
 
   return (
     <ChatSettingsSection
@@ -56,24 +66,55 @@ export function TranslationSection({ metadata, textConnections, onMetadataChange
         </div>
 
         {provider === "ai" && (
-          <div>
-            <label className="text-[0.6875rem] font-medium text-[var(--muted-foreground)]">
-              Connection
-              <HelpTooltip text="Which AI connection to use for translation" size="0.625rem" />
-            </label>
-            <select
-              value={(metadata.translationConnectionId as string | undefined) ?? ""}
-              onChange={(e) => onMetadataChange({ translationConnectionId: e.target.value })}
-              className="mt-0.5 w-full rounded-lg bg-[var(--secondary)] px-3 py-2 text-xs outline-none ring-1 ring-transparent transition-shadow focus:ring-[var(--primary)]/40"
-            >
-              <option value="">Select connection…</option>
-              {textConnections.map((connection) => (
-                <option key={connection.id} value={connection.id}>
-                  {connection.name}
-                </option>
-              ))}
-            </select>
-          </div>
+          <>
+            <div>
+              <label className="text-[0.6875rem] font-medium text-[var(--muted-foreground)]">
+                Connection
+                <HelpTooltip text="Which AI connection to use for translation" size="0.625rem" />
+              </label>
+              <select
+                value={(metadata.translationConnectionId as string | undefined) ?? ""}
+                onChange={(e) => onMetadataChange({ translationConnectionId: e.target.value })}
+                className="mt-0.5 w-full rounded-lg bg-[var(--secondary)] px-3 py-2 text-xs outline-none ring-1 ring-transparent transition-shadow focus:ring-[var(--primary)]/40"
+              >
+                <option value="">Select connection…</option>
+                {textConnections.map((connection) => (
+                  <option key={connection.id} value={connection.id}>
+                    {connection.name}
+                  </option>
+                ))}
+              </select>
+            </div>
+
+            <div className="space-y-1">
+              <div className="flex items-center justify-between gap-2">
+                <label className="text-[0.6875rem] font-medium text-[var(--muted-foreground)]">
+                  AI Prompt
+                  <HelpTooltip
+                    text="System prompt used by AI translation. Restoring uses Marinara's built-in default."
+                    size="0.625rem"
+                  />
+                </label>
+                {hasCustomPrompt && (
+                  <button
+                    type="button"
+                    onClick={() => onMetadataChange({ translationPrompt: null })}
+                    className="flex shrink-0 items-center gap-1 rounded-md bg-[var(--secondary)] px-2 py-0.5 text-[0.625rem] text-[var(--muted-foreground)] ring-1 ring-[var(--border)] transition-colors hover:bg-[var(--accent)] hover:text-[var(--foreground)]"
+                    title="Restore default prompt"
+                  >
+                    <RotateCcw size="0.625rem" />
+                    Restore
+                  </button>
+                )}
+              </div>
+              <textarea
+                value={promptValue}
+                onChange={(e) => updatePrompt(e.target.value)}
+                rows={5}
+                className="min-h-28 w-full resize-y rounded-lg bg-[var(--secondary)] px-3 py-2 font-mono text-xs leading-relaxed outline-none ring-1 ring-transparent transition-shadow focus:ring-[var(--primary)]/40"
+              />
+            </div>
+          </>
         )}
 
         {provider === "deepl" && (

--- a/packages/client/src/hooks/use-generate.ts
+++ b/packages/client/src/hooks/use-generate.ts
@@ -2416,14 +2416,13 @@ export function useGenerate() {
         if (receivedContent) {
           try {
             const chatData = qc.getQueryData<Chat>(chatKeys.detail(params.chatId));
-            const meta =
-              chatData?.metadata != null
-                ? typeof chatData.metadata === "string"
-                  ? JSON.parse(chatData.metadata)
-                  : chatData.metadata
-                : {};
+            const meta = parseChatMetadata(chatData?.metadata);
             if (meta.autoTranslate) {
               const store = useTranslationStore.getState();
+              const chatSystemPrompt =
+                typeof meta.translationPrompt === "string" && meta.translationPrompt.trim().length > 0
+                  ? meta.translationPrompt
+                  : store.config.systemPrompt;
               for (const [id, msg] of persistedMessages) {
                 const textToTranslate =
                   chatData?.mode === "game" ? stripGmTagsKeepReadables(msg.content ?? "").trim() : (msg.content ?? "");
@@ -2440,6 +2439,7 @@ export function useGenerate() {
                       provider: store.config.provider,
                       targetLanguage: store.config.targetLanguage,
                       connectionId: store.config.connectionId,
+                      systemPrompt: chatSystemPrompt,
                       deeplApiKey: store.config.deeplApiKey,
                       deeplxUrl: store.config.deeplxUrl,
                     })

--- a/packages/client/src/hooks/use-translate.ts
+++ b/packages/client/src/hooks/use-translate.ts
@@ -34,6 +34,7 @@ export function useTranslate() {
         provider: store.config.provider,
         targetLanguage: store.config.targetLanguage,
         connectionId: store.config.connectionId,
+        systemPrompt: store.config.systemPrompt,
         deeplApiKey: store.config.deeplApiKey,
         deeplxUrl: store.config.deeplxUrl,
       });

--- a/packages/client/src/lib/generation-parameter-errors.ts
+++ b/packages/client/src/lib/generation-parameter-errors.ts
@@ -40,7 +40,13 @@ function extractParameter(message: string, patterns: RegExp[]) {
   return null;
 }
 
+function isPrivilegedAccessError(message: string): boolean {
+  return /\b(?:ADMIN_SECRET|X-Admin-Secret|Basic Auth|privileged APIs?|privileged API|authenticated access)\b/i.test(message);
+}
+
 export function formatGenerationParameterError(message: string): string {
+  if (isPrivilegedAccessError(message)) return message;
+
   const unsupported = extractParameter(message, [
     /\bunsupported parameters?\b[:\s]+([A-Za-z0-9_.-]+)/i,
     /\bunknown parameters?\b[:\s]+([A-Za-z0-9_.-]+)/i,

--- a/packages/client/src/lib/translate-text.ts
+++ b/packages/client/src/lib/translate-text.ts
@@ -9,6 +9,7 @@ export async function translateText(text: string): Promise<string> {
     provider: store.config.provider,
     targetLanguage: store.config.targetLanguage,
     connectionId: store.config.connectionId,
+    systemPrompt: store.config.systemPrompt,
     deeplApiKey: store.config.deeplApiKey,
     deeplxUrl: store.config.deeplxUrl,
   });

--- a/packages/client/src/stores/sidecar.store.ts
+++ b/packages/client/src/stores/sidecar.store.ts
@@ -90,6 +90,8 @@ interface SidecarState {
         | "topK"
         | "gpuLayers"
         | "enableNativeToolCalls"
+        | "embeddingPooling"
+        | "embeddingBatchSize"
         | "runtimePreference"
       >
     >,

--- a/packages/client/src/stores/translation.store.ts
+++ b/packages/client/src/stores/translation.store.ts
@@ -5,6 +5,7 @@ export interface TranslationConfig {
   provider: "ai" | "deeplx" | "deepl" | "google";
   targetLanguage: string;
   connectionId?: string;
+  systemPrompt?: string;
   deeplApiKey?: string;
   deeplxUrl?: string;
 }

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@marinara-engine/server",
-  "version": "2.0.5",
+  "version": "2.0.6",
   "private": true,
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/server/src/middleware/privileged-gate.ts
+++ b/packages/server/src/middleware/privileged-gate.ts
@@ -1,7 +1,7 @@
 import type { FastifyReply, FastifyRequest } from "fastify";
 import { getAdminSecret, isAdminSecretRequiredOnLoopback } from "../config/runtime-config.js";
 import { isBasicAuthSatisfied } from "./basic-auth.js";
-import { isLoopbackIp } from "./ip-allowlist.js";
+import { isInIpAllowlist, isLoopbackIp, isTrustedInterfaceRequest } from "./ip-allowlist.js";
 import { safeCompareString } from "../utils/security.js";
 
 export function isAdminAuthorized(request: FastifyRequest): boolean {
@@ -15,7 +15,7 @@ export function isAdminAuthorized(request: FastifyRequest): boolean {
 export function requirePrivilegedAccess(
   request: FastifyRequest,
   reply: FastifyReply,
-  options: { loopbackOnly?: boolean; feature?: string } = {},
+  options: { loopbackOnly?: boolean; trustedNetwork?: boolean; feature?: string } = {},
 ): boolean {
   if (!isBasicAuthSatisfied(request)) {
     reply.status(403).send({
@@ -34,6 +34,10 @@ export function requirePrivilegedAccess(
   }
 
   if (isLoopbackIp(request.ip) && !isAdminSecretRequiredOnLoopback()) {
+    return true;
+  }
+
+  if (options.trustedNetwork && (isInIpAllowlist(request.ip) || isTrustedInterfaceRequest(request))) {
     return true;
   }
 

--- a/packages/server/src/routes/chats.routes.ts
+++ b/packages/server/src/routes/chats.routes.ts
@@ -1273,7 +1273,18 @@ export async function chatsRoutes(app: FastifyInstance) {
       chatMetadata: chat.metadata,
       connectionId: chat.connectionId,
     });
-    const rebuilt = await rebuildMemoryChunks(app.db, req.params.id, { userName, characterNames }, { embeddingSource });
+    const chatMeta = parseExtra(chat.metadata) as Record<string, unknown>;
+    const contextMessageLimit = chatMeta.contextMessageLimit;
+    const rebuilt = await rebuildMemoryChunks(
+      app.db,
+      req.params.id,
+      { userName, characterNames },
+      {
+        embeddingSource,
+        readBehindMessageCount:
+          typeof contextMessageLimit === "number" && contextMessageLimit > 0 ? contextMessageLimit : undefined,
+      },
+    );
     return { rebuilt };
   });
 
@@ -2335,6 +2346,11 @@ export async function chatsRoutes(app: FastifyInstance) {
     }
   };
 
+  const getExportThinking = (extra: Record<string, unknown>): string | null => {
+    const value = extra.thinking ?? extra.reasoning ?? extra.reasoning_content;
+    return typeof value === "string" && value.trim().length > 0 ? value : null;
+  };
+
   const safeExportNamePart = (value: unknown, fallback: string): string => {
     const source = typeof value === "string" && value.trim() ? value.trim() : fallback;
     return (
@@ -2382,7 +2398,10 @@ export async function chatsRoutes(app: FastifyInstance) {
         .map((msg) => {
           const name = getDisplayName(msg);
           const ts = msg.createdAt ? new Date(msg.createdAt).toLocaleString() : "";
-          return `[${name}]${ts ? ` (${ts})` : ""}\n${msg.content}`;
+          const thinking = getExportThinking(parseExportMetadata(msg.extra));
+          const parts = [`[${name}]${ts ? ` (${ts})` : ""}`, msg.content];
+          if (thinking) parts.push(`[Thinking]\n${thinking}`);
+          return parts.join("\n");
         })
         .join("\n\n");
 
@@ -2410,6 +2429,7 @@ export async function chatsRoutes(app: FastifyInstance) {
 
     for (const msg of msgs) {
       const messageExtra = parseExportMetadata(msg.extra);
+      const thinking = getExportThinking(messageExtra);
       const swipes = await storage.getSwipes(msg.id);
       const exportSwipes =
         swipes.length > 0
@@ -2435,6 +2455,13 @@ export async function chatsRoutes(app: FastifyInstance) {
           role: msg.role,
           character_id: msg.characterId,
           mes: msg.content,
+          ...(thinking
+            ? {
+                thinking,
+                reasoning: thinking,
+                reasoning_content: thinking,
+              }
+            : {}),
           swipes: exportSwipes.map((swipe) => swipe.content),
           swipe_id: msg.activeSwipeIndex,
           send_date: msg.createdAt,

--- a/packages/server/src/routes/generate.routes.ts
+++ b/packages/server/src/routes/generate.routes.ts
@@ -10976,7 +10976,11 @@ export async function generateRoutes(app: FastifyInstance) {
               app.db,
               input.chatId,
               { userName: personaName, characterNames: charNameMap },
-              { embeddingSource: memoryRecallEmbeddingSource },
+              {
+                embeddingSource: memoryRecallEmbeddingSource,
+                readBehindMessageCount:
+                  typeof contextMessageLimit === "number" && contextMessageLimit > 0 ? contextMessageLimit : undefined,
+              },
             ).catch((err) => logger.error(err, "[memory-recall] Background chunking failed"));
           }
         }

--- a/packages/server/src/routes/professor-mari-workspace.routes.ts
+++ b/packages/server/src/routes/professor-mari-workspace.routes.ts
@@ -44,6 +44,7 @@ const skillUpdateSchema = z.object({
 function privileged(request: FastifyRequest, reply: FastifyReply, loopbackOnly = false) {
   return requirePrivilegedAccess(request, reply, {
     loopbackOnly,
+    trustedNetwork: !loopbackOnly,
     feature: "Professor Mari workspace",
   });
 }

--- a/packages/server/src/routes/sidecar.routes.ts
+++ b/packages/server/src/routes/sidecar.routes.ts
@@ -26,6 +26,7 @@ import {
 } from "../services/sidecar/scene-analyzer.js";
 import { postProcessSceneResult, type PostProcessContext } from "../services/sidecar/scene-postprocess.js";
 import {
+  SIDECAR_EMBEDDING_POOLING_TYPES,
   SIDECAR_RUNTIME_PREFERENCES,
   scoreAmbient,
   scoreMusic,
@@ -91,6 +92,8 @@ export const sidecarRoutes: FastifyPluginAsync = async (app) => {
     topK: z.number().int().min(0).max(500).optional(),
     gpuLayers: z.number().int().min(-1).max(1024).optional(),
     enableNativeToolCalls: z.boolean().optional(),
+    embeddingPooling: z.enum(SIDECAR_EMBEDDING_POOLING_TYPES).optional(),
+    embeddingBatchSize: z.number().int().min(128).max(32768).optional(),
     runtimePreference: z.enum(SIDECAR_RUNTIME_PREFERENCES).optional(),
   });
 

--- a/packages/server/src/routes/sprites.routes.ts
+++ b/packages/server/src/routes/sprites.routes.ts
@@ -138,6 +138,7 @@ type SpritePromptPlan = {
   spriteType?: SpriteType;
   fullBodyExpressionMode: boolean;
   generateExpressionsIndividually: boolean;
+  appearance: string;
   prompt: string;
   sheetWidth: number;
   sheetHeight: number;
@@ -268,6 +269,7 @@ function compileSpritePrompt(
   prompt: string,
   options: {
     negativePrompt?: string;
+    appearance?: string;
     styleProfiles: ImageStyleProfileSettings;
     imageDefaults?: ImageGenerationDefaultsProfile | null;
   },
@@ -276,6 +278,7 @@ function compileSpritePrompt(
     kind: "sprite",
     prompt,
     negativePrompt: options.negativePrompt,
+    userPositive: options.appearance,
     styleProfiles: options.styleProfiles,
     imageDefaults: options.imageDefaults,
   });
@@ -285,12 +288,16 @@ function compileSpritePrompt(
   };
 }
 
-function finalSpritePromptOverride(override: SpriteCompiledPrompt | undefined, fallback: SpriteCompiledPrompt) {
-  return override ?? fallback;
+function resolveSpritePromptOverride(override: SpriteCompiledPrompt | undefined, fallback: SpriteCompiledPrompt) {
+  return { value: override ?? fallback, overridden: !!override };
 }
 
-function withSpriteSheetLayoutContract(prompt: SpriteCompiledPrompt, plan: SpritePromptPlan): SpriteCompiledPrompt {
-  if (plan.generateExpressionsIndividually) return prompt;
+function withSpriteSheetLayoutContract(
+  prompt: SpriteCompiledPrompt,
+  plan: SpritePromptPlan,
+  options: { reviewedOverride?: boolean } = {},
+): SpriteCompiledPrompt {
+  if (plan.generateExpressionsIndividually || options.reviewedOverride) return prompt;
 
   const totalCells = plan.cols * plan.rows;
   const expressionList = plan.expressions.map(formatSpriteLabelForPrompt).join(", ");
@@ -1159,6 +1166,7 @@ async function buildSpritePromptPlan(
     spriteType: body.spriteType,
     fullBodyExpressionMode,
     generateExpressionsIndividually,
+    appearance: trimmedAppearance,
     prompt,
     sheetWidth,
     sheetHeight,
@@ -1608,10 +1616,11 @@ export async function spritesRoutes(app: FastifyInstance) {
             expressionPrompt = applyNativeTransparentPngPrompt(expressionPrompt, cleanupFriendlyTransparentPrompt);
           }
           const compiledPrompt = compileSpritePrompt(expressionPrompt, {
+            appearance: plan.appearance,
             styleProfiles: imageSettings.styleProfiles,
             imageDefaults,
           });
-          const reviewedPrompt = finalSpritePromptOverride(
+          const reviewedPrompt = resolveSpritePromptOverride(
             plan.promptOverrides.get(spritePromptReviewId("expression", plan.spriteType, expression)),
             compiledPrompt,
           );
@@ -1619,8 +1628,8 @@ export async function spritesRoutes(app: FastifyInstance) {
             id: spritePromptReviewId("expression", plan.spriteType, expression),
             kind: "sprite",
             title: `Expression: ${expression.replace(/_/g, " ")}`,
-            prompt: reviewedPrompt.prompt,
-            negativePrompt: reviewedPrompt.negativePrompt,
+            prompt: reviewedPrompt.value.prompt,
+            negativePrompt: reviewedPrompt.value.negativePrompt,
             width: 1024,
             height: 1024,
           };
@@ -1630,6 +1639,7 @@ export async function spritesRoutes(app: FastifyInstance) {
     }
 
     const compiledPrompt = compileSpritePrompt(plan.prompt, {
+      appearance: plan.appearance,
       styleProfiles: imageSettings.styleProfiles,
       imageDefaults,
     });
@@ -1638,10 +1648,10 @@ export async function spritesRoutes(app: FastifyInstance) {
       plan.spriteType,
       `${plan.cols}x${plan.rows}-${plan.expressions.join(",")}`,
     );
-    const reviewedPrompt = withSpriteSheetLayoutContract(
-      finalSpritePromptOverride(plan.promptOverrides.get(sheetPromptId), compiledPrompt),
-      plan,
-    );
+    const reviewedPrompt = resolveSpritePromptOverride(plan.promptOverrides.get(sheetPromptId), compiledPrompt);
+    const finalPrompt = withSpriteSheetLayoutContract(reviewedPrompt.value, plan, {
+      reviewedOverride: reviewedPrompt.overridden,
+    });
     return {
       items: [
         {
@@ -1651,8 +1661,8 @@ export async function spritesRoutes(app: FastifyInstance) {
             plan.spriteType === "full-body"
               ? `Full-body sprites: ${plan.cols}x${plan.rows}`
               : `Expression sprites: ${plan.cols}x${plan.rows}`,
-          prompt: reviewedPrompt.prompt,
-          negativePrompt: reviewedPrompt.negativePrompt,
+          prompt: finalPrompt.prompt,
+          negativePrompt: finalPrompt.negativePrompt,
           width: plan.sheetWidth,
           height: plan.sheetHeight,
         },
@@ -1705,13 +1715,17 @@ export async function spritesRoutes(app: FastifyInstance) {
       `${plan.cols}x${plan.rows}-${plan.expressions.join(",")}`,
     );
     const compiledSheetPrompt = compileSpritePrompt(plan.prompt, {
+      appearance: plan.appearance,
       styleProfiles: imageSettings.styleProfiles,
       imageDefaults,
     });
-    const sheetPrompt = withSpriteSheetLayoutContract(
-      finalSpritePromptOverride(plan.promptOverrides.get(sheetPromptId), compiledSheetPrompt),
-      plan,
+    const reviewedSheetPrompt = resolveSpritePromptOverride(
+      plan.promptOverrides.get(sheetPromptId),
+      compiledSheetPrompt,
     );
+    const sheetPrompt = withSpriteSheetLayoutContract(reviewedSheetPrompt.value, plan, {
+      reviewedOverride: reviewedSheetPrompt.overridden,
+    });
 
     // Parse reference images to raw base64 (supports data URL, raw base64, or local avatar URL)
     const rawRefs = body.referenceImages?.length
@@ -1738,18 +1752,19 @@ export async function spritesRoutes(app: FastifyInstance) {
               expressionPrompt = applyNativeTransparentPngPrompt(expressionPrompt, cleanupFriendlyTransparentPrompt);
             }
             const compiledExpressionPrompt = compileSpritePrompt(expressionPrompt, {
+              appearance: plan.appearance,
               styleProfiles: imageSettings.styleProfiles,
               imageDefaults,
             });
-            const finalExpressionPrompt = finalSpritePromptOverride(
+            const finalExpressionPrompt = resolveSpritePromptOverride(
               plan.promptOverrides.get(spritePromptReviewId("expression", plan.spriteType, expression)),
               compiledExpressionPrompt,
             );
 
             const targetSize = 1024;
             const imageResult = await generateImage(imgModel, imgBaseUrl, imgApiKey, imgServiceHint, {
-              prompt: finalExpressionPrompt.prompt,
-              negativePrompt: finalExpressionPrompt.negativePrompt || undefined,
+              prompt: finalExpressionPrompt.value.prompt,
+              negativePrompt: finalExpressionPrompt.value.negativePrompt || undefined,
               model: imgModel,
               width: targetSize,
               height: targetSize,

--- a/packages/server/src/routes/translate.routes.ts
+++ b/packages/server/src/routes/translate.routes.ts
@@ -5,7 +5,7 @@ import type { FastifyInstance } from "fastify";
 import { z } from "zod";
 import { createConnectionsStorage } from "../services/storage/connections.storage.js";
 import { createLLMProvider } from "../services/llm/provider-registry.js";
-import { PROVIDERS } from "@marinara-engine/shared";
+import { DEFAULT_TRANSLATION_SYSTEM_PROMPT, PROVIDERS } from "@marinara-engine/shared";
 import { isDeeplxLocalUrlsEnabled } from "../config/runtime-config.js";
 import { safeFetch, validateOutboundUrl } from "../utils/security.js";
 
@@ -16,6 +16,7 @@ const translateSchema = z.object({
   provider: z.enum(["ai", "deeplx", "deepl", "google"]),
   targetLanguage: z.string().min(1),
   connectionId: z.string().optional(),
+  systemPrompt: z.string().max(5000).optional().nullable(),
   deeplApiKey: z.string().optional(),
   deeplxUrl: z
     .string()
@@ -85,12 +86,12 @@ async function translateWithAI(
     conn.openrouterProvider,
     conn.maxTokensOverride,
   );
+  const systemPrompt = input.systemPrompt?.trim() || DEFAULT_TRANSLATION_SYSTEM_PROMPT;
   const result = await provider.chatComplete(
     [
       {
         role: "system",
-        content:
-          "You are a translator. Translate the given text accurately, preserving formatting, markdown, and any special characters like *asterisks* for actions. Output ONLY the translated text, nothing else — no explanations, no extra commentary.",
+        content: systemPrompt,
       },
       {
         role: "user",

--- a/packages/server/src/services/import/st-chat.importer.ts
+++ b/packages/server/src/services/import/st-chat.importer.ts
@@ -33,6 +33,9 @@ interface STChatMessage {
   character_id?: unknown;
   send_date?: string;
   mes?: unknown;
+  thinking?: unknown;
+  reasoning?: unknown;
+  reasoning_content?: unknown;
   swipes?: unknown;
   swipe_id?: unknown;
   extra?: STChatMessageExtra;
@@ -158,6 +161,10 @@ function normalizeImportedExtra(raw: unknown): Record<string, unknown> {
   return extra;
 }
 
+function normalizeImportedThinking(raw: unknown): string | null {
+  return typeof raw === "string" && raw.trim().length > 0 ? raw : null;
+}
+
 function normalizeSwipeContents(raw: unknown, fallbackContent: string): string[] {
   if (!Array.isArray(raw)) return [fallbackContent];
 
@@ -260,6 +267,13 @@ export async function importSTChat(jsonlContent: string, db: DB, opts?: ImportST
         (stMsg.is_user ? "user" : stMsg.is_system ? "system" : "assistant");
       const rawContent = typeof stMsg.mes === "string" ? stMsg.mes : "";
       const messageExtra = normalizeImportedExtra(stMsg.extra);
+      const exportedThinking =
+        normalizeImportedThinking(stMsg.thinking) ??
+        normalizeImportedThinking(stMsg.reasoning) ??
+        normalizeImportedThinking(stMsg.reasoning_content);
+      if (exportedThinking && typeof messageExtra.thinking !== "string") {
+        messageExtra.thinking = exportedThinking;
+      }
       const storedMessageExtra = Object.keys(messageExtra).length > 0 ? messageExtra : undefined;
       const swipeContents = normalizeSwipeContents(stMsg.swipes, rawContent);
       const activeSwipeIndex = normalizeSwipeIndex(stMsg.swipe_id, swipeContents.length);

--- a/packages/server/src/services/memory-recall.ts
+++ b/packages/server/src/services/memory-recall.ts
@@ -71,6 +71,15 @@ export interface MemoryRecallEmbeddingOptions {
   signal?: AbortSignal;
 }
 
+export interface ChunkAndEmbedMessagesOptions extends MemoryRecallEmbeddingOptions {
+  /**
+   * Keep the most recent N messages out of durable memory chunks. This lets
+   * recall operate as read-behind storage for messages that have left the
+   * active prompt window.
+   */
+  readBehindMessageCount?: number | null;
+}
+
 export async function embedMemoryRecallTexts(
   texts: string[],
   options: MemoryRecallEmbeddingOptions = {},
@@ -95,6 +104,93 @@ export async function embedMemoryRecallTexts(
   return [];
 }
 
+function normalizeReadBehindMessageCount(value: number | null | undefined): number {
+  if (typeof value !== "number" || !Number.isFinite(value) || value <= 0) return 0;
+  return Math.floor(value);
+}
+
+async function pruneStaleNativeMemoryChunks(
+  db: DB,
+  chatId: string,
+  currentMessages: Array<{ createdAt: string }>,
+): Promise<void> {
+  const chunks = await db
+    .select({
+      id: memoryChunks.id,
+      messageCount: memoryChunks.messageCount,
+      firstMessageAt: memoryChunks.firstMessageAt,
+      lastMessageAt: memoryChunks.lastMessageAt,
+    })
+    .from(memoryChunks)
+    .where(and(eq(memoryChunks.chatId, chatId), isNull(memoryChunks.sourceChatId)))
+    .orderBy(memoryChunks.firstMessageAt);
+
+  if (chunks.length === 0) return;
+
+  const messageTimes = currentMessages.map((message) => message.createdAt);
+  const messageTimeSet = new Set(messageTimes);
+  let invalidateFrom: string | null = null;
+
+  for (const chunk of chunks) {
+    const hasAnchors = messageTimeSet.has(chunk.firstMessageAt) && messageTimeSet.has(chunk.lastMessageAt);
+    const spanMessageCount = hasAnchors
+      ? messageTimes.filter((createdAt) => createdAt >= chunk.firstMessageAt && createdAt <= chunk.lastMessageAt).length
+      : 0;
+
+    if (!hasAnchors || spanMessageCount !== chunk.messageCount) {
+      invalidateFrom = chunk.firstMessageAt;
+      break;
+    }
+  }
+
+  if (!invalidateFrom) return;
+
+  const staleIds = chunks.filter((chunk) => chunk.firstMessageAt >= invalidateFrom).map((chunk) => chunk.id);
+  for (let i = 0; i < staleIds.length; i += 500) {
+    await db
+      .delete(memoryChunks)
+      .where(
+        and(
+          eq(memoryChunks.chatId, chatId),
+          isNull(memoryChunks.sourceChatId),
+          inArray(memoryChunks.id, staleIds.slice(i, i + 500)),
+        ),
+      );
+  }
+
+  logger.debug(
+    "[memory-recall] Pruned %d stale native chunk(s) for chat %s from %s",
+    staleIds.length,
+    chatId,
+    invalidateFrom,
+  );
+}
+
+async function pruneNativeMemoryChunksAfter(
+  db: DB,
+  chatId: string,
+  lastEligibleMessageAt: string | null,
+): Promise<void> {
+  if (!lastEligibleMessageAt) {
+    await db.delete(memoryChunks).where(and(eq(memoryChunks.chatId, chatId), isNull(memoryChunks.sourceChatId)));
+    logger.debug(
+      "[memory-recall] Pruned native chunks for chat %s because all messages are still in active context",
+      chatId,
+    );
+    return;
+  }
+
+  await db
+    .delete(memoryChunks)
+    .where(
+      and(
+        eq(memoryChunks.chatId, chatId),
+        isNull(memoryChunks.sourceChatId),
+        gt(memoryChunks.lastMessageAt, lastEligibleMessageAt),
+      ),
+    );
+}
+
 /**
  * Chunk any un-chunked messages for a given chat and embed them.
  * Should be called after generation completes (fire-and-forget).
@@ -104,9 +200,33 @@ export async function chunkAndEmbedMessages(
   chatId: string,
   /** Map from role → display name. Used to format "Name: content" lines. */
   nameMap: { userName: string; characterNames: Record<string, string> },
-  options: MemoryRecallEmbeddingOptions = {},
+  options: ChunkAndEmbedMessagesOptions = {},
 ): Promise<void> {
   if (isLite) return;
+  const allMessages = await db
+    .select({
+      id: messages.id,
+      role: messages.role,
+      characterId: messages.characterId,
+      content: messages.content,
+      createdAt: messages.createdAt,
+    })
+    .from(messages)
+    .where(eq(messages.chatId, chatId))
+    .orderBy(messages.createdAt);
+
+  await pruneStaleNativeMemoryChunks(db, chatId, allMessages);
+
+  const readBehindMessageCount = normalizeReadBehindMessageCount(options.readBehindMessageCount);
+  const eligibleMessages =
+    readBehindMessageCount > 0
+      ? allMessages.slice(0, Math.max(0, allMessages.length - readBehindMessageCount))
+      : allMessages;
+
+  if (readBehindMessageCount > 0) {
+    await pruneNativeMemoryChunksAfter(db, chatId, eligibleMessages.at(-1)?.createdAt ?? null);
+  }
+
   // Find the last chunk for this chat to know where to start
   const lastChunk = await db
     .select({ lastMessageAt: memoryChunks.lastMessageAt })
@@ -117,22 +237,8 @@ export async function chunkAndEmbedMessages(
 
   const after = lastChunk[0]?.lastMessageAt ?? null;
 
-  // Get messages that haven't been chunked yet
-  const conditions = [eq(messages.chatId, chatId)];
-  if (after) {
-    conditions.push(gt(messages.createdAt, after));
-  }
-  const unchunked = await db
-    .select({
-      id: messages.id,
-      role: messages.role,
-      characterId: messages.characterId,
-      content: messages.content,
-      createdAt: messages.createdAt,
-    })
-    .from(messages)
-    .where(and(...conditions))
-    .orderBy(messages.createdAt);
+  // Get eligible messages that haven't been chunked yet.
+  const unchunked = after ? eligibleMessages.filter((message) => message.createdAt > after) : eligibleMessages;
 
   if (unchunked.length < CHUNK_SIZE) return; // not enough to form a chunk yet
 
@@ -227,7 +333,7 @@ export async function rebuildMemoryChunks(
   db: DB,
   chatId: string,
   nameMap: { userName: string; characterNames: Record<string, string> },
-  options: MemoryRecallEmbeddingOptions = {},
+  options: ChunkAndEmbedMessagesOptions = {},
 ): Promise<number> {
   if (isLite) return 0;
 

--- a/packages/server/src/services/sidecar/sidecar-launch-plan.ts
+++ b/packages/server/src/services/sidecar/sidecar-launch-plan.ts
@@ -16,6 +16,8 @@ export function buildLlamaArgs(options: {
   contextSize: number;
   runtimeVariant: string;
   enableNativeToolCalls: boolean;
+  embeddingPooling: string;
+  embeddingBatchSize: number;
 }): string[] {
   // llama-server divides --ctx-size across --parallel slots; Marinara's setting is the per-request budget.
   const totalContextSize = options.contextSize * LLAMA_SERVER_PARALLEL_SLOTS;
@@ -37,7 +39,7 @@ export function buildLlamaArgs(options: {
     args.push("--jinja");
   }
 
-  args.push("--embeddings", "--pooling", "none");
+  args.push("--embeddings", "--pooling", options.embeddingPooling, "--ubatch-size", String(options.embeddingBatchSize));
 
   // Gemma 4 needs split mode disabled on CUDA multi-GPU launches,
   // but non-CUDA builds may reject the flag entirely.

--- a/packages/server/src/services/sidecar/sidecar-model.service.ts
+++ b/packages/server/src/services/sidecar/sidecar-model.service.ts
@@ -11,6 +11,7 @@ import { basename, join, relative, resolve, sep } from "path";
 import { existsSync, mkdirSync, readFileSync, statSync, unlinkSync, writeFileSync } from "fs";
 import {
   SIDECAR_DEFAULT_CONFIG,
+  SIDECAR_EMBEDDING_POOLING_TYPES,
   SIDECAR_RUNTIME_PREFERENCES,
   SIDECAR_MLX_MODELS,
   SIDECAR_MODELS,
@@ -105,6 +106,10 @@ function isRuntimePreference(value: unknown): value is SidecarConfig["runtimePre
   return typeof value === "string" && (SIDECAR_RUNTIME_PREFERENCES as readonly string[]).includes(value);
 }
 
+function isEmbeddingPooling(value: unknown): value is SidecarConfig["embeddingPooling"] {
+  return typeof value === "string" && (SIDECAR_EMBEDDING_POOLING_TYPES as readonly string[]).includes(value);
+}
+
 function delay(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
@@ -173,6 +178,17 @@ class SidecarModelService {
           nextConfig.enableNativeToolCalls,
           SIDECAR_DEFAULT_CONFIG.enableNativeToolCalls,
         );
+        nextConfig.embeddingBatchSize = normalizeIntegerSetting(
+          nextConfig.embeddingBatchSize,
+          SIDECAR_DEFAULT_CONFIG.embeddingBatchSize,
+          128,
+          32768,
+        );
+
+        if (!isEmbeddingPooling(nextConfig.embeddingPooling)) {
+          nextConfig.embeddingPooling = SIDECAR_DEFAULT_CONFIG.embeddingPooling;
+          shouldRewrite = true;
+        }
 
         if (!isRuntimePreference(nextConfig.runtimePreference)) {
           nextConfig.runtimePreference = SIDECAR_DEFAULT_CONFIG.runtimePreference;
@@ -550,6 +566,8 @@ class SidecarModelService {
         | "topK"
         | "gpuLayers"
         | "enableNativeToolCalls"
+        | "embeddingPooling"
+        | "embeddingBatchSize"
         | "runtimePreference"
       >
     >,

--- a/packages/server/src/services/sidecar/sidecar-process.service.ts
+++ b/packages/server/src/services/sidecar/sidecar-process.service.ts
@@ -427,6 +427,8 @@ class SidecarProcessService {
       contextSize: config.contextSize,
       runtimeVariant: runtime.variant,
       enableNativeToolCalls: config.enableNativeToolCalls,
+      embeddingPooling: config.embeddingPooling,
+      embeddingBatchSize: config.embeddingBatchSize,
     });
   }
 
@@ -528,6 +530,8 @@ class SidecarProcessService {
           contextSize: config.contextSize,
           gpuLayers: config.gpuLayers,
           enableNativeToolCalls: config.enableNativeToolCalls,
+          embeddingPooling: config.embeddingPooling,
+          embeddingBatchSize: config.embeddingBatchSize,
         });
   }
 

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@marinara-engine/shared",
-  "version": "2.0.5",
+  "version": "2.0.6",
   "private": true,
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/shared/src/constants/defaults.ts
+++ b/packages/shared/src/constants/defaults.ts
@@ -4,7 +4,7 @@
 import type { GenerationParameters } from "../types/prompt.js";
 
 /** App version — single source of truth. */
-export const APP_VERSION = "2.0.5";
+export const APP_VERSION = "2.0.6";
 
 /** Stable synthetic connection id for the built-in local llama sidecar. */
 export const LOCAL_SIDECAR_CONNECTION_ID = "__local_sidecar__";
@@ -14,6 +14,10 @@ export const PROFESSOR_MARI_ID = "__professor_mari__";
 
 /** Stable ID for the default OpenRouter free‑tier connection. */
 export const DEFAULT_CONNECTION_ID = "__default_openrouter__";
+
+/** Default system prompt for AI-backed translation. */
+export const DEFAULT_TRANSLATION_SYSTEM_PROMPT =
+  "You are a translator. Translate the given text accurately, preserving formatting, markdown, and any special characters like *asterisks* for actions. Output ONLY the translated text, nothing else -- no explanations, no extra commentary.";
 
 /** Default generation parameters for new presets. */
 export const DEFAULT_GENERATION_PARAMS: GenerationParameters = {

--- a/packages/shared/src/types/chat.ts
+++ b/packages/shared/src/types/chat.ts
@@ -341,6 +341,8 @@ export interface ChatMetadata {
   impersonatePrompt?: string | null;
   /** Show a manual draft translation button beside the send control. */
   showInputTranslateButton?: boolean;
+  /** Optional per-chat AI translation system prompt override. Missing or blank uses the default prompt. */
+  translationPrompt?: string | null;
   /** Allow roleplay characters to create direct-message conversation chats with hidden [dm] commands. */
   roleplayDmCommandsEnabled?: boolean;
   /** Chat-scoped Intiface Central WebSocket URL for haptic manual and auto-connect. */

--- a/packages/shared/src/types/sidecar.ts
+++ b/packages/shared/src/types/sidecar.ts
@@ -15,6 +15,10 @@ export type SidecarQuantization = "q8_0" | "q4_k_m";
 /** Runtime backend used by the built-in local model. */
 export type SidecarBackend = "llama_cpp" | "mlx";
 
+/** llama.cpp embedding pooling modes accepted by llama-server. */
+export const SIDECAR_EMBEDDING_POOLING_TYPES = ["none", "mean", "cls", "last", "rank"] as const;
+export type SidecarEmbeddingPooling = (typeof SIDECAR_EMBEDDING_POOLING_TYPES)[number];
+
 /** Which runtime target Marinara should prepare for llama.cpp-based local inference. */
 export const SIDECAR_RUNTIME_PREFERENCES = ["auto", "nvidia", "amd", "intel", "vulkan", "cpu", "system"] as const;
 export type SidecarRuntimePreference = (typeof SIDECAR_RUNTIME_PREFERENCES)[number];
@@ -78,6 +82,10 @@ export interface SidecarConfig {
   gpuLayers: number;
   /** Start llama.cpp with Jinja chat templates so OpenAI-compatible native tool calls can work. */
   enableNativeToolCalls: boolean;
+  /** llama.cpp pooling mode for the OpenAI-compatible embeddings endpoint. */
+  embeddingPooling: SidecarEmbeddingPooling;
+  /** llama.cpp physical batch size for embeddings and prompt processing. */
+  embeddingBatchSize: number;
   /** Which runtime target to install for llama.cpp-based local inference. */
   runtimePreference: SidecarRuntimePreference;
 }
@@ -293,6 +301,8 @@ export const SIDECAR_DEFAULT_CONFIG: SidecarConfig = {
   topK: 64,
   gpuLayers: -1,
   enableNativeToolCalls: true,
+  embeddingPooling: "none",
+  embeddingBatchSize: 512,
   runtimePreference: "auto",
 };
 

--- a/win/installer/install.bat
+++ b/win/installer/install.bat
@@ -11,14 +11,14 @@ set "NODE_DOWNLOAD_URL=https://nodejs.org/dist/v24.15.0/node-v24.15.0-x64.msi"
 set "NODE_SHA256=feffb8e5cb5ac47f793666636d496ef3e975be82c84c4da5d20e6aa8fa4eb806"
 set "GIT_DOWNLOAD_URL=https://github.com/git-for-windows/git/releases/download/v2.54.0.windows.1/Git-2.54.0-64-bit.exe"
 set "GIT_SHA256=2b96e7854f0520f0f6b709c21041d9801b1be44d5e1a0d9fa621b2fbc40f1983"
-set "RELEASE_TAG=v2.0.5"
+set "RELEASE_TAG=v2.0.6"
 if not defined MARINARA_RELEASE_COMMIT set "MARINARA_RELEASE_COMMIT="
 set "RELEASE_COMMIT=%MARINARA_RELEASE_COMMIT%"
 
 echo.
 echo  +==========================================+
 echo  ^|   Marinara Engine - Windows Installer     ^|
-echo  ^|   v2.0.5                                  ^|
+echo  ^|   v2.0.6                                  ^|
 
 echo  +==========================================+
 echo.

--- a/win/installer/installer.nsi
+++ b/win/installer/installer.nsi
@@ -13,7 +13,7 @@
 
 ; ── App metadata ──
 !define APP_NAME "Marinara Engine"
-!define APP_VERSION "2.0.5"
+!define APP_VERSION "2.0.6"
 !define APP_PUBLISHER "Pasta-Devs"
 !define APP_URL "https://github.com/Pasta-Devs/Marinara-Engine"
 !define REPO_URL "https://github.com/Pasta-Devs/Marinara-Engine.git"
@@ -27,7 +27,7 @@
 !define NODE_DOWNLOAD_URL "https://nodejs.org/dist/v24.15.0/node-v24.15.0-x64.msi"
 !define GIT_SHA256 "2b96e7854f0520f0f6b709c21041d9801b1be44d5e1a0d9fa621b2fbc40f1983"
 !define NODE_SHA256 "feffb8e5cb5ac47f793666636d496ef3e975be82c84c4da5d20e6aa8fa4eb806"
-!define RELEASE_TAG "v2.0.5"
+!define RELEASE_TAG "v2.0.6"
 !ifndef RELEASE_COMMIT
 !define RELEASE_COMMIT ""
 !endif


### PR DESCRIPTION
## Linked issue

Closes #2884
Closes #2883
Closes #2881
Closes #2871
Closes #2863
Closes #2862

## Why this change

- Clears the remaining issue queue and packages the fixes as the v2.0.6 staging release candidate.
- Restores expected behavior around Professor Mari workspace access, translation prompt customization, thinking export, sprite prompt preservation, llama.cpp embedding startup options, memory recall read-behind behavior, branch memory cleanup, and Chat Branches active-row actions.

## What changed

- Added per-chat translation prompt override controls and sent the override through AI translation requests.
- Added llama.cpp embedding pooling and physical batch-size options to sidecar config, launch args, API validation, and the model download modal.
- Made Professor Mari workspace access respect trusted LAN and Tailscale clients when loopback-only mode is disabled while keeping database command execution loopback-only.
- Exported assistant thinking and reasoning content in text and JSONL chat exports, and imported JSONL thinking fields back into message extra metadata.
- Preserved concise sprite appearance text through prompt compilation and avoided double-appending layout and negative suffixes after prompt review.
- Made memory recall chunking operate as read-behind storage for chats with a message limit, and prune stale native chunks when branch/edit/delete history no longer matches current messages.
- Removed the Chat Branches Active pill and restored rename/delete controls for the active branch.
- Updated CHANGELOG and synchronized v2.0.6 release metadata across packages, homepage-visible APP_VERSION, README, PWA manifest, Windows installer files, and Android versionName/versionCode.

## Validation

- [ ] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed `CONTRIBUTING.md`

### Manual verification notes

- Command validation completed locally:
  - `pnpm version:check`
  - `git diff --check`
  - `pnpm check`
- GitHub issue list checked after closing the issue sweep: no open issues remained.
- Browser/manual click-through was not performed in this pass.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Version/release files updated (only if this PR includes a version bump)

## UI evidence (if applicable)

- Not attached; UI changes are limited to Chat Branches action visibility and Translation/Sidecar settings controls, validated by type/lint/build.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added per-chat AI translation prompt overrides, including an option to restore the default prompt.
  * Added “Embedding Endpoint” controls (pooling mode and physical batch size) for non-MLX backends.

* **Bug Fixes**
  * Improved chat branch deletion/active chat handling.
  * Included “thinking”/reasoning content in chat exports and imported it into chat metadata.
  * Refined memory recall chunking and cleanup, improving context handling.
  * Improved sprite prompt generation and override-aware sheet layout behavior.

* **Documentation**
  * Updated release notes and version references to **v2.0.6**.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->