### PR TITLE
[codex] Fix issue queue regressions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 
 ## [Unreleased]
 
+### Added
+
+- Added native Gemini API embedding support for Google and Vertex Gemini connections so lorebook vectorization and memory recall can use Gemini embedding models (#2889).
+
+### Fixed
+
+- Fixed impersonation generations so preset-driven prompts skip regular preset instructions while preserving marker-provided context, preventing conflicting "respond as the assistant" system text from contaminating `/impersonate` prompts (#2886).
+- Fixed Professor Mari home-chat restart so chat messages are deleted only after the workspace reset succeeds, preventing failed restarts from causing delayed chat history loss (#2887).
+
 ## [2.0.6]
 
 ### Added

--- a/packages/client/src/components/chat/HomeProfessorMariChat.tsx
+++ b/packages/client/src/components/chat/HomeProfessorMariChat.tsx
@@ -1843,12 +1843,12 @@ export function HomeProfessorMariChat({
   const handleRestart = useCallback(async () => {
     const chat = await ensureProfessorMariChat(effectiveConnectionId);
     const currentMessages = await api.get<Message[]>(`/chats/${chat.id}/messages`);
+    await api.post("/professor-mari/workspace/reset", { clearHistory: true });
     if (currentMessages.length > 0) {
       await api.post(`/chats/${chat.id}/messages/bulk-delete`, {
         messageIds: currentMessages.map((message) => message.id),
       });
     }
-    await api.post("/professor-mari/workspace/reset", { clearHistory: true });
     setMessages([]);
     setDraft("");
     setWorkspaceActive(false);

--- a/packages/server/src/routes/generate.routes.ts
+++ b/packages/server/src/routes/generate.routes.ts
@@ -2250,6 +2250,7 @@ export async function generateRoutes(app: FastifyInstance) {
             lastGenerationType: promptLastGenerationType,
             idleDuration: promptIdleDuration,
             timeZone: promptTimeZone,
+            impersonate: input.impersonate === true,
             deferCharacterMacros,
           };
 

--- a/packages/server/src/routes/generate/dry-run-route.ts
+++ b/packages/server/src/routes/generate/dry-run-route.ts
@@ -1307,6 +1307,7 @@ export async function registerDryRunRoute(app: FastifyInstance) {
             : null,
         lastGenerationType: promptLastGenerationType,
         idleDuration: promptIdleDuration,
+        impersonate,
       };
 
       const assembled = await assemblePrompt(assemblerInput);

--- a/packages/server/src/services/llm/providers/google.provider.ts
+++ b/packages/server/src/services/llm/providers/google.provider.ts
@@ -14,6 +14,7 @@ import {
   type LLMUsage,
 } from "../base-provider.js";
 import { shouldSuppressUnknownModelParameters } from "@marinara-engine/shared";
+import { getEmbeddingRequestTimeoutMs } from "../../../config/runtime-config.js";
 import { decodePossiblyCompressedBody } from "../../../utils/security.js";
 
 /** A single Gemini response part (text, thought summary, or signature-only). */
@@ -59,6 +60,12 @@ interface GeminiResponsePayload {
   promptFeedback?: GeminiPromptFeedback;
   error?: GeminiApiError;
   usageMetadata?: GeminiUsageMetadata;
+}
+
+interface GeminiEmbeddingPayload {
+  embedding?: { values?: unknown };
+  embeddings?: Array<{ values?: unknown }>;
+  error?: GeminiApiError;
 }
 
 type GoogleProviderKind = "google" | "google_vertex";
@@ -174,11 +181,14 @@ export async function googleAuthHeadersForVertex(apiKey: string): Promise<Record
 export function buildGoogleVertexModelUrl(
   baseUrl: string,
   model: string,
-  endpoint: "generateContent" | "streamGenerateContent" | "models",
+  endpoint: "generateContent" | "streamGenerateContent" | "embedContent" | "models",
 ): string {
   const base = baseUrl
     .replace(/\/+$/, "")
-    .replace(/\/publishers\/google\/models(?:\/[^/:]+(?::(?:generateContent|streamGenerateContent))?)?$/i, "");
+    .replace(
+      /\/publishers\/google\/models(?:\/[^/:]+(?::(?:generateContent|streamGenerateContent|embedContent))?)?$/i,
+      "",
+    );
   if (endpoint === "models") {
     return `${base}/publishers/google/models`;
   }
@@ -206,6 +216,26 @@ function formatGeminiApiError(error: GeminiApiError | undefined): string | null 
   if (status) return status;
   if (code !== null) return `code ${code}`;
   return "unknown Gemini API error";
+}
+
+function parseGeminiEmbeddingResponse(payload: GeminiEmbeddingPayload): number[] {
+  const apiError = formatGeminiApiError(payload.error);
+  if (apiError) throw new Error(`Gemini embedding API error: ${apiError}`);
+
+  const values = payload.embedding?.values ?? payload.embeddings?.[0]?.values;
+  if (!Array.isArray(values)) {
+    throw new Error("Gemini embedding response did not include an embedding vector.");
+  }
+  const embedding = values.map((value) => {
+    if (typeof value !== "number" || !Number.isFinite(value)) {
+      throw new Error("Gemini embedding response contained a non-numeric vector value.");
+    }
+    return value;
+  });
+  if (embedding.length === 0) {
+    throw new Error("Gemini embedding response contained an empty vector.");
+  }
+  return embedding;
 }
 
 function formatGeminiPromptBlock(feedback: GeminiPromptFeedback | undefined): string | null {
@@ -822,10 +852,45 @@ export class GoogleProvider extends BaseLLMProvider {
     if (streamUsage) return { ...streamUsage, finishReason: normalizeGeminiFinishReason(lastFinishReason) };
   }
 
-  override async embed(_texts: string[], _model: string, _signal?: AbortSignal): Promise<number[][]> {
-    const label = this.providerKind === "google_vertex" ? "Vertex AI Gemini" : "Google Gemini";
-    throw new Error(
-      `${label} connections do not support embeddings through Marinara's OpenAI-compatible /embeddings path. Configure a dedicated OpenAI-compatible or local embedding connection.`,
-    );
+  override async embed(texts: string[], model: string, signal?: AbortSignal): Promise<number[][]> {
+    if (texts.length === 0) return [];
+
+    const label = this.providerKind === "google_vertex" ? "Vertex AI Gemini" : "Gemini API";
+    const requestModel = model.replace(/^models\//, "") || "gemini-embedding-001";
+    const timeoutMs = getEmbeddingRequestTimeoutMs();
+    let base = normalizeGoogleBaseUrl(this.baseUrl);
+    if (this.providerKind === "google" && !/\/v\d/.test(base)) base += "/v1beta";
+    const url =
+      this.providerKind === "google_vertex"
+        ? buildGoogleVertexModelUrl(base, requestModel, "embedContent")
+        : `${base}/models/${requestModel}:embedContent`;
+    const authHeaders =
+      this.providerKind === "google_vertex"
+        ? await googleAuthHeadersForVertex(this.apiKey)
+        : this.apiKey.trim()
+          ? { "x-goog-api-key": this.apiKey.trim() }
+          : {};
+
+    const embeddings: number[][] = [];
+    for (const text of texts) {
+      const timeoutSignal = AbortSignal.timeout(timeoutMs);
+      const response = await llmFetch(url, {
+        method: "POST",
+        headers: { "Content-Type": "application/json", ...authHeaders },
+        body: JSON.stringify({
+          content: { parts: [{ text: text.trim() ? text : " " }] },
+        }),
+        signal: signal ? AbortSignal.any([signal, timeoutSignal]) : timeoutSignal,
+        agentOptions: { bodyTimeout: timeoutMs, headersTimeout: timeoutMs },
+        bufferResponse: true,
+      });
+
+      if (!response.ok) {
+        const body = await response.text().catch(() => "");
+        throw new Error(`${label} embedding request failed (${response.status}): ${sanitizeApiError(body)}`);
+      }
+      embeddings.push(parseGeminiEmbeddingResponse((await response.json()) as GeminiEmbeddingPayload));
+    }
+    return embeddings;
   }
 }

--- a/packages/server/src/services/llm/providers/google.provider.ts
+++ b/packages/server/src/services/llm/providers/google.provider.ts
@@ -218,11 +218,11 @@ function formatGeminiApiError(error: GeminiApiError | undefined): string | null 
   return "unknown Gemini API error";
 }
 
-function parseGeminiEmbeddingResponse(payload: GeminiEmbeddingPayload): number[] {
-  const apiError = formatGeminiApiError(payload.error);
-  if (apiError) throw new Error(`Gemini embedding API error: ${apiError}`);
+function geminiEmbeddingContent(text: string): { parts: Array<{ text: string }> } {
+  return { parts: [{ text: text.trim() ? text : " " }] };
+}
 
-  const values = payload.embedding?.values ?? payload.embeddings?.[0]?.values;
+function parseGeminiEmbeddingValues(values: unknown): number[] {
   if (!Array.isArray(values)) {
     throw new Error("Gemini embedding response did not include an embedding vector.");
   }
@@ -236,6 +236,29 @@ function parseGeminiEmbeddingResponse(payload: GeminiEmbeddingPayload): number[]
     throw new Error("Gemini embedding response contained an empty vector.");
   }
   return embedding;
+}
+
+function parseGeminiEmbeddingResponse(payload: GeminiEmbeddingPayload): number[] {
+  const apiError = formatGeminiApiError(payload.error);
+  if (apiError) throw new Error(`Gemini embedding API error: ${apiError}`);
+
+  const values = payload.embedding?.values ?? payload.embeddings?.[0]?.values;
+  return parseGeminiEmbeddingValues(values);
+}
+
+function parseGeminiBatchEmbeddingResponse(payload: GeminiEmbeddingPayload, expectedCount: number): number[][] {
+  const apiError = formatGeminiApiError(payload.error);
+  if (apiError) throw new Error(`Gemini embedding API error: ${apiError}`);
+
+  if (!Array.isArray(payload.embeddings)) {
+    throw new Error("Gemini batch embedding response did not include embedding vectors.");
+  }
+  if (payload.embeddings.length !== expectedCount) {
+    throw new Error(
+      `Gemini batch embedding response returned ${payload.embeddings.length} vectors for ${expectedCount} inputs.`,
+    );
+  }
+  return payload.embeddings.map((embedding) => parseGeminiEmbeddingValues(embedding.values));
 }
 
 function formatGeminiPromptBlock(feedback: GeminiPromptFeedback | undefined): string | null {
@@ -871,6 +894,29 @@ export class GoogleProvider extends BaseLLMProvider {
           ? { "x-goog-api-key": this.apiKey.trim() }
           : {};
 
+    if (this.providerKind === "google" && texts.length > 1) {
+      const timeoutSignal = AbortSignal.timeout(timeoutMs);
+      const response = await llmFetch(`${base}/models/${requestModel}:batchEmbedContents`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json", ...authHeaders },
+        body: JSON.stringify({
+          requests: texts.map((text) => ({
+            model: `models/${requestModel}`,
+            content: geminiEmbeddingContent(text),
+          })),
+        }),
+        signal: signal ? AbortSignal.any([signal, timeoutSignal]) : timeoutSignal,
+        agentOptions: { bodyTimeout: timeoutMs, headersTimeout: timeoutMs },
+        bufferResponse: true,
+      });
+
+      if (!response.ok) {
+        const body = await response.text().catch(() => "");
+        throw new Error(`${label} batch embedding request failed (${response.status}): ${sanitizeApiError(body)}`);
+      }
+      return parseGeminiBatchEmbeddingResponse((await response.json()) as GeminiEmbeddingPayload, texts.length);
+    }
+
     const embeddings: number[][] = [];
     for (const text of texts) {
       const timeoutSignal = AbortSignal.timeout(timeoutMs);
@@ -878,7 +924,7 @@ export class GoogleProvider extends BaseLLMProvider {
         method: "POST",
         headers: { "Content-Type": "application/json", ...authHeaders },
         body: JSON.stringify({
-          content: { parts: [{ text: text.trim() ? text : " " }] },
+          content: geminiEmbeddingContent(text),
         }),
         signal: signal ? AbortSignal.any([signal, timeoutSignal]) : timeoutSignal,
         agentOptions: { bodyTimeout: timeoutMs, headersTimeout: timeoutMs },

--- a/packages/server/src/services/prompt/assembler.ts
+++ b/packages/server/src/services/prompt/assembler.ts
@@ -186,6 +186,8 @@ export interface AssemblerInput {
   idleDuration?: string;
   /** IANA timezone used by date/time macros. */
   timeZone?: string;
+  /** Skip regular preset instructions that would conflict with user impersonation. */
+  impersonate?: boolean;
   /** Preserve character-scoped macros for a later known-speaker finalization pass. */
   deferCharacterMacros?: boolean;
 }
@@ -340,6 +342,7 @@ export async function assemblePrompt(input: AssemblerInput): Promise<AssemblerOu
     const section = sectionMap.get(sectionId);
     if (!section) continue;
     if (section.enabled !== "true") continue;
+    if (input.impersonate === true && section.isMarker !== "true") continue;
 
     // Check if group is enabled
     if (section.groupId) {

--- a/scripts/regressions/prompt.regression.ts
+++ b/scripts/regressions/prompt.regression.ts
@@ -5,7 +5,9 @@ import {
   resolveMacros,
   testPrimaryKeys,
   testSecondaryKeys,
+  type ChatMLMessage,
 } from "../../packages/shared/src/index.js";
+import type { DB } from "../../packages/server/src/db/connection.js";
 import {
   appendNonLeadingSystemMessagesToLastUser,
   appendSeparateAgentInjectionMessage,
@@ -14,10 +16,11 @@ import {
   type SimpleMessage,
 } from "../../packages/server/src/routes/generate/generate-route-utils.js";
 import { fitMessagesForModelAccess } from "../../packages/server/src/services/generation/model-access-policy.js";
+import { assemblePrompt, type AssemblerInput } from "../../packages/server/src/services/prompt/index.js";
 
 type RegressionCase = {
   name: string;
-  run: () => void;
+  run: () => void | Promise<void>;
 };
 
 const keywordOptions = {
@@ -154,6 +157,83 @@ const cases: RegressionCase[] = [
     },
   },
   {
+    name: "impersonate assembly skips regular preset instructions but keeps markers",
+    async run() {
+      const chatMessages: ChatMLMessage[] = [
+        { role: "user", content: "Can you answer as me?" },
+        { role: "assistant", content: "I can help." },
+      ];
+      const baseInput: AssemblerInput = {
+        db: undefined as unknown as DB,
+        preset: {
+          id: "preset-impersonate",
+          name: "Impersonate Fixture",
+          sectionOrder: JSON.stringify(["main", "history"]),
+          groupOrder: JSON.stringify([]),
+          wrapFormat: "xml",
+          parameters: JSON.stringify({}),
+          variableGroups: JSON.stringify([]),
+          variableValues: JSON.stringify({}),
+        },
+        sections: [
+          {
+            id: "main",
+            presetId: "preset-impersonate",
+            identifier: "main",
+            name: "Main Prompt",
+            content: "You are {{char}}. Never answer as {{user}}.",
+            role: "system",
+            enabled: "true",
+            isMarker: "false",
+            groupId: null,
+            markerConfig: null,
+            injectionPosition: "ordered",
+            injectionDepth: 0,
+            injectionOrder: 0,
+            forbidOverrides: "false",
+          },
+          {
+            id: "history",
+            presetId: "preset-impersonate",
+            identifier: "chatHistory",
+            name: "Chat History",
+            content: "",
+            role: "system",
+            enabled: "true",
+            isMarker: "true",
+            groupId: null,
+            markerConfig: JSON.stringify({
+              type: "chat_history",
+              chatHistoryOptions: { includeSystemMessages: false },
+            }),
+            injectionPosition: "ordered",
+            injectionDepth: 0,
+            injectionOrder: 1,
+            forbidOverrides: "false",
+          },
+        ],
+        groups: [],
+        choiceBlocks: [],
+        chatChoices: {},
+        chatId: "chat-impersonate",
+        characterIds: [],
+        personaName: "Mari",
+        personaDescription: "The current user.",
+        chatMessages,
+      };
+
+      const normal = await assemblePrompt(baseInput);
+      const impersonate = await assemblePrompt({ ...baseInput, impersonate: true });
+      const normalText = normal.messages.map((message) => message.content).join("\n");
+      const impersonateText = impersonate.messages.map((message) => message.content).join("\n");
+
+      assert.match(normalText, /Never answer as Mari/);
+      assert.equal(impersonateText.includes("Never answer as Mari"), false);
+      assert.match(impersonateText, /Can you answer as me\?/);
+      assert.match(impersonateText, /I can help\./);
+    },
+  },
+  {
     name: "separate agent injections survive long-history context fitting",
     run() {
       const messages: SimpleMessage[] = [{ role: "system", content: "Stable system prompt." }];
@@ -217,7 +297,7 @@ let failed = 0;
 
 for (const regression of cases) {
   try {
-    regression.run();
+    await regression.run();
     console.log(`ok - ${regression.name}`);
   } catch (error) {
     failed += 1;


### PR DESCRIPTION
## Summary
- Add native Gemini/Vertex embedding support through Gemini embedContent for lorebook vectorization and memory recall.
- Make Professor Mari restart delete home-chat messages only after workspace reset succeeds.
- Keep preset marker context for impersonation while skipping regular preset instructions that can conflict with /impersonate.
- Update CHANGELOG with the fixed issue notes.

## Why
These fixes clear the reported GitHub issue queue for #2889, #2887, and #2886. The root causes were a Google provider embedding stub, destructive restart ordering in the home Professor Mari chat, and preset assembly reusing assistant-oriented regular prompt sections during user impersonation.

## Validation
- pnpm --filter @marinara-engine/server lint
- pnpm --filter @marinara-engine/client lint
- pnpm regression:prompt
- pnpm check

## Manual verification
- [ ] Manually verify Gemini embedding models can be selected and used for memory/lorebook embeddings.
- [ ] Manually verify Professor Mari /restart and Restart button still clear the home chat after a successful workspace reset.
- [ ] Manually verify /impersonate in a preset-driven roleplay chat does not include regular assistant-role preset instructions.

Addresses #2889, #2887, #2886.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added native Gemini embedding support for Google/Vertex connections.

* **Bug Fixes**
  * Fixed impersonation/preset prompt contamination by ensuring impersonation-aware assembly only includes marker preset sections.
  * Prevented chat history loss by deleting chat messages only after workspace reset succeeds.
  * Improved restart sequencing to reduce message loss during reset.

* **Tests**
  * Added regression coverage verifying impersonation skips regular preset instructions while keeping marker-based content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->