### PR TITLE
[codex] Fix folder rename taps and peek prompt history display

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,7 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 - Fixed conditional macros for persona cards by adding persona field operands/macros such as `personaDescription`, `personaPersonality`, and related fields to the shared macro engine (#2964).
 - Fixed Android Firefox mobile keyboard layout by sizing the mobile shell from the visual viewport and nudging chat input bars into view after keyboard focus (#2965).
 - Fixed swipe counter flashes after regenerate/switch by preserving cached swipe counts and moving optimistic swipe content/extra together with the active index (#2963).
+- Fixed Peek Prompt display so the Chat History section only shows user/assistant turns and no longer repeats system prompt/history wrapper content already shown in separate prompt sections.
 
 ### Platform Notes
 

--- a/packages/client/src/components/chat/PeekPromptModal.tsx
+++ b/packages/client/src/components/chat/PeekPromptModal.tsx
@@ -94,6 +94,10 @@ interface ChatHistoryBlock {
 
 type DisplaySection = SectionBlock | ChatHistoryBlock;
 
+function isDisplayedChatHistoryRole(role: string): boolean {
+  return role === "user" || role === "assistant";
+}
+
 // ═══════════════════════════════════════════════
 //  Parsing: works on the WHOLE messages array
 // ═══════════════════════════════════════════════
@@ -186,7 +190,10 @@ function buildDisplaySections(messages: Array<{ role: string; content: string }>
       const entries: ChatHistoryEntry[] = [];
       const rawParts: string[] = [];
       for (let j = chStartIdx; j <= chEndIdx; j++) {
-        let content = messages[j]!.content;
+        const entry = messages[j]!;
+        if (!isDisplayedChatHistoryRole(entry.role)) continue;
+
+        let content = entry.content;
         // Strip the wrapping tags from the content shown inside child blocks
         content = content
           .replace(/^<chat_history>\n?/i, "")
@@ -194,7 +201,7 @@ function buildDisplaySections(messages: Array<{ role: string; content: string }>
           .replace(/^## Chat History\n?/i, "");
         const trimmed = content.trim();
         if (trimmed) {
-          entries.push({ role: messages[j]!.role, content: trimmed });
+          entries.push({ role: entry.role, content: trimmed });
           rawParts.push(trimmed);
         }
       }

--- a/packages/client/src/components/layout/ChatSidebar.tsx
+++ b/packages/client/src/components/layout/ChatSidebar.tsx
@@ -1402,7 +1402,7 @@ export function ChatSidebar() {
           )}
 
           {modeFolders.length > 0 && activeModeHasChats && (
-            <p className="mari-folder-helper">Drag and drop chats to folders</p>
+            <p className="mari-folder-helper">Drag and drop chats to folders, double-click or double-tap to rename</p>
           )}
 
           {/* Folders (drag-to-reorder) */}
@@ -1603,8 +1603,8 @@ function FolderRow({
           role="button"
           tabIndex={0}
           aria-expanded={isExpanded}
-          aria-label={`${isExpanded ? "Collapse" : "Expand"} folder ${folder.name}. Press F2 to rename.`}
-          title="Double-click or press F2 to rename."
+          aria-label={`${isExpanded ? "Collapse" : "Expand"} folder ${folder.name}. Double-tap or press F2 to rename.`}
+          title="Double-click, double-tap, or press F2 to rename."
           onClick={(e) =>
             handleFolderRenameGesture(folder.id, e, {
               onSingleClick: () => {

--- a/packages/client/src/components/panels/AgentsPanel.tsx
+++ b/packages/client/src/components/panels/AgentsPanel.tsx
@@ -862,7 +862,7 @@ export function AgentsPanel() {
             New Folder
           </button>
         </div>
-        {agentFolders.length > 0 && <p className="mari-folder-helper">Drag and drop agents to folders</p>}
+        {agentFolders.length > 0 && <p className="mari-folder-helper">Drag and drop agents to folders, double-click or double-tap to rename</p>}
         {draggedAgentId && (
           <div
             data-agent-folder-root
@@ -915,8 +915,8 @@ export function AgentsPanel() {
                 role="button"
                 tabIndex={0}
                 aria-expanded={isExpanded}
-                aria-label={`${isExpanded ? "Collapse" : "Expand"} folder ${folder.name}. Press F2 to rename.`}
-                title="Double-click or press F2 to rename."
+                aria-label={`${isExpanded ? "Collapse" : "Expand"} folder ${folder.name}. Double-tap or press F2 to rename.`}
+                title="Double-click, double-tap, or press F2 to rename."
                 className="group relative flex cursor-pointer items-center gap-1.5 rounded-lg px-2 py-1.5 transition-all hover:bg-[var(--sidebar-accent)]/40"
                 onClick={(event) =>
                   handleFolderRenameGesture(folder.id, event, {

--- a/packages/client/src/components/panels/CharactersPanel.tsx
+++ b/packages/client/src/components/panels/CharactersPanel.tsx
@@ -755,7 +755,7 @@ export function CharactersPanel() {
             New Folder
           </button>
         </div>
-        {parsedGroups.length > 0 && <p className="mari-folder-helper">Drag and drop characters to folders</p>}
+        {parsedGroups.length > 0 && <p className="mari-folder-helper">Drag and drop characters to folders, double-click or double-tap to rename</p>}
       </div>
 
       {/* Filters */}
@@ -867,8 +867,8 @@ export function CharactersPanel() {
                 role="button"
                 tabIndex={0}
                 aria-expanded={isExpanded}
-                aria-label={`${isExpanded ? "Collapse" : "Expand"} folder ${group.name}. Press F2 to rename.`}
-                title="Double-click or press F2 to rename."
+                aria-label={`${isExpanded ? "Collapse" : "Expand"} folder ${group.name}. Double-tap or press F2 to rename.`}
+                title="Double-click, double-tap, or press F2 to rename."
                 className="group relative flex cursor-pointer items-center gap-1.5 rounded-lg px-2 py-1.5 transition-all hover:bg-[var(--sidebar-accent)]/40"
                 onClick={(event) =>
                   handleFolderRenameGesture(group.id, event, {

--- a/packages/client/src/components/panels/ConnectionsPanel.tsx
+++ b/packages/client/src/components/panels/ConnectionsPanel.tsx
@@ -805,8 +805,8 @@ function ConnectionFolderRow({
         role="button"
         tabIndex={0}
         aria-expanded={isExpanded}
-        aria-label={`${isExpanded ? "Collapse" : "Expand"} folder ${folder.name}. Press F2 to rename.`}
-        title="Double-click or press F2 to rename."
+        aria-label={`${isExpanded ? "Collapse" : "Expand"} folder ${folder.name}. Double-tap or press F2 to rename.`}
+        title="Double-click, double-tap, or press F2 to rename."
         onClick={(event) =>
           handleFolderRenameGesture(folder.id, event, {
             onSingleClick: () => onToggleCollapse(folder),
@@ -1305,7 +1305,7 @@ export function ConnectionsPanel() {
         </div>
 
         {sortedFolders.length > 0 && (
-          <p className="mari-folder-helper">Drag and drop connections to folders</p>
+          <p className="mari-folder-helper">Drag and drop connections to folders, double-click or double-tap to rename</p>
         )}
       </div>
 

--- a/packages/client/src/components/panels/GlobalGalleryPanel.tsx
+++ b/packages/client/src/components/panels/GlobalGalleryPanel.tsx
@@ -201,8 +201,8 @@ export function GlobalGalleryPanel() {
               })
           : undefined
       }
-      aria-label={renamable ? `${label}. Press F2 to rename.` : label}
-      title={renamable ? `${label}. Double-click or press F2 to rename.` : undefined}
+      aria-label={renamable ? `${label}. Double-tap or press F2 to rename.` : label}
+      title={renamable ? `${label}. Double-click, double-tap, or press F2 to rename.` : undefined}
       onDragOver={dropTarget ? (e) => e.preventDefault() : undefined}
       onDragEnter={dropTarget ? () => setDragOverFolder(key) : undefined}
       onDragLeave={dropTarget ? () => setDragOverFolder((cur) => (cur === key ? null : cur)) : undefined}

--- a/packages/client/src/components/panels/LorebooksPanel.tsx
+++ b/packages/client/src/components/panels/LorebooksPanel.tsx
@@ -804,7 +804,7 @@ export function LorebooksPanel() {
             New Folder
           </button>
         </div>
-        {lorebookFolders.length > 0 && <p className="mari-folder-helper">Drag and drop lorebooks to folders</p>}
+        {lorebookFolders.length > 0 && <p className="mari-folder-helper">Drag and drop lorebooks to folders, double-click or double-tap to rename</p>}
       </div>
 
       {/* Filters */}
@@ -968,8 +968,8 @@ export function LorebooksPanel() {
                 role="button"
                 tabIndex={0}
                 aria-expanded={isExpanded}
-                aria-label={`${isExpanded ? "Collapse" : "Expand"} folder ${folder.name}. Press F2 to rename.`}
-                title="Double-click or press F2 to rename."
+                aria-label={`${isExpanded ? "Collapse" : "Expand"} folder ${folder.name}. Double-tap or press F2 to rename.`}
+                title="Double-click, double-tap, or press F2 to rename."
                 className="group relative flex cursor-pointer items-center gap-1.5 rounded-lg px-2 py-1.5 transition-all hover:bg-[var(--sidebar-accent)]/40"
                 onClick={(event) =>
                   handleFolderRenameGesture(folder.id, event, {

--- a/packages/client/src/components/panels/PersonasPanel.tsx
+++ b/packages/client/src/components/panels/PersonasPanel.tsx
@@ -576,7 +576,7 @@ export function PersonasPanel() {
             New Folder
           </button>
         </div>
-        {parsedGroups.length > 0 && <p className="mari-folder-helper">Drag and drop personas to folders</p>}
+        {parsedGroups.length > 0 && <p className="mari-folder-helper">Drag and drop personas to folders, double-click or double-tap to rename</p>}
       </div>
 
       {/* Filters */}
@@ -687,8 +687,8 @@ export function PersonasPanel() {
                 role="button"
                 tabIndex={0}
                 aria-expanded={isExpanded}
-                aria-label={`${isExpanded ? "Collapse" : "Expand"} folder ${group.name}. Press F2 to rename.`}
-                title="Double-click or press F2 to rename."
+                aria-label={`${isExpanded ? "Collapse" : "Expand"} folder ${group.name}. Double-tap or press F2 to rename.`}
+                title="Double-click, double-tap, or press F2 to rename."
                 className="group relative flex cursor-pointer items-center gap-1.5 rounded-lg px-2 py-1.5 transition-all hover:bg-[var(--sidebar-accent)]/40"
                 onClick={(event) =>
                   handleFolderRenameGesture(group.id, event, {

--- a/packages/client/src/components/panels/PresetsPanel.tsx
+++ b/packages/client/src/components/panels/PresetsPanel.tsx
@@ -1012,7 +1012,7 @@ export function PresetsPanel() {
             New Folder
           </button>
         </div>
-        {presetFolders.length > 0 && <p className="mari-folder-helper">Drag and drop presets to folders</p>}
+        {presetFolders.length > 0 && <p className="mari-folder-helper">Drag and drop presets to folders, double-click or double-tap to rename</p>}
       </div>
 
       <PanelSection title="Presets" icon={<FileText size="0.8125rem" />}>
@@ -1049,8 +1049,8 @@ export function PresetsPanel() {
                   role="button"
                   tabIndex={0}
                   aria-expanded={isExpanded}
-                  aria-label={`${isExpanded ? "Collapse" : "Expand"} folder ${folder.name}. Press F2 to rename.`}
-                  title="Double-click or press F2 to rename."
+                  aria-label={`${isExpanded ? "Collapse" : "Expand"} folder ${folder.name}. Double-tap or press F2 to rename.`}
+                  title="Double-click, double-tap, or press F2 to rename."
                   className="group relative flex cursor-pointer items-center gap-1.5 rounded-lg px-2 py-1.5 transition-all hover:bg-[var(--sidebar-accent)]/40"
                   onClick={(event) =>
                     handleFolderRenameGesture(folder.id, event, {

--- a/packages/client/src/hooks/use-folder-rename-gesture.ts
+++ b/packages/client/src/hooks/use-folder-rename-gesture.ts
@@ -43,6 +43,23 @@ export function useFolderRenameGesture() {
       event.stopPropagation();
 
       if (prefersImmediateFolderTap()) {
+        const now = Date.now();
+        const pending = pendingGesturesRef.current.get(key);
+
+        if (pending) {
+          window.clearTimeout(pending.timeout);
+          pendingGesturesRef.current.delete(key);
+        }
+
+        if (pending && now - pending.lastClickAt < delayMs) {
+          onRename();
+          return;
+        }
+
+        const timeout = window.setTimeout(() => {
+          pendingGesturesRef.current.delete(key);
+        }, delayMs);
+        pendingGesturesRef.current.set(key, { lastClickAt: now, timeout });
         onSingleClick();
         return;
       }


### PR DESCRIPTION
## Linked issue

No linked issue; maintainer-requested follow-up fixes from chat.

## Why this change

- Mobile users could not double-tap folder names to rename folders because coarse-pointer folder taps immediately toggled the folder without preserving a second-tap rename gesture.
- Peek Prompt could display system-role chat-history wrapper content inside the Chat History section even though system prompt sections are already shown separately, making the preview look duplicated or alarming.

## What changed

- Updated the shared folder rename gesture so mobile/coarse-pointer users can tap once to open/collapse and double-tap within the rename window to rename.
- Updated folder helper, tooltip, and accessibility copy across chats, characters, lorebooks, presets, connections, personas, agents, and gallery folders to mention double-click/double-tap rename behavior.
- Filtered Peek Prompt's displayed Chat History section to only show `user` and `assistant` turns, leaving system prompt sections visible only in their separate prompt blocks.
- Added the Peek Prompt display fix to the v2.0.7 changelog.

## Validation

- [ ] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed `CONTRIBUTING.md`

### Manual verification notes

- Ran `pnpm --filter @marinara-engine/client lint`.
- Ran `pnpm --filter @marinara-engine/client build`.
- Browser/device manual verification not performed in this session.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Version/release files updated (only if this PR includes a version bump)

## UI evidence (if applicable)

- Not captured; behavior validated through targeted code inspection plus client lint/build.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Folder renaming now works with double-tap on touch devices, alongside double-click and F2.
  * Updated folder helper text across several panels to make rename actions clearer.

* **Bug Fixes**
  * Peek Prompt now shows only user and assistant turns in Chat History, avoiding repeated system and wrapper content.

* **Documentation**
  * Changelog updated to reflect the Peek Prompt display fix.

* **Accessibility**
  * Improved folder labels and tooltips to better describe rename interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->