### PR TITLE
Fix agent retry issue sweep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,7 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 - Fixed Android Firefox mobile keyboard layout by sizing the mobile shell from the visual viewport and nudging chat input bars into view after keyboard focus (#2965).
 - Fixed swipe counter flashes after regenerate/switch by preserving cached swipe counts and moving optimistic swipe content/extra together with the active index (#2963).
 - Fixed Peek Prompt display so the Chat History section only shows user/assistant turns and no longer repeats system prompt/history wrapper content already shown in separate prompt sections.
+- Fixed agent retry and generation edge cases around Local Model sidecar fallback, built-in default tools, runtime phase normalization, retry persona/wrap-format parity, noncritical pre-generation failures, Spotify retry fallback, edit-message retry tools, lorebook-update permissions and scoping, Lorebook Keeper error isolation, message-scoped tracker effects, atomic Illustrator attachment appends, batch result parsing, text-rewrite markup preservation, JSON repair, custom-agent run listing/limits, sprite expression variants, and Custom Music DJ reset state (#2983, #2984, #2985, #2986, #2987, #2988, #2989, #2990, #2991, #2992, #2993, #2994, #2995, #2996, #2997, #2998, #2999, #3000, #3001, #3002).
 
 ### Platform Notes
 

--- a/packages/client/src/stores/agent.store.ts
+++ b/packages/client/src/stores/agent.store.ts
@@ -165,26 +165,55 @@ interface AgentState {
   reset: () => void;
 }
 
+type AgentDataState = Pick<
+  AgentState,
+  | "activeAgents"
+  | "lastResults"
+  | "debugLog"
+  | "isProcessing"
+  | "failedAgentTypes"
+  | "failedAgentFailures"
+  | "thoughtBubbles"
+  | "echoMessages"
+  | "echoVisibleCount"
+  | "echoBaseline"
+  | "echoLoadedChatId"
+  | "cyoaChoices"
+  | "cyoaChoicesChatId"
+  | "youtubePlay"
+  | "youtubeVolume"
+  | "localMusicPlay"
+  | "localMusicVolume"
+  | "pendingCardUpdates"
+  | "pendingAgentWriteApprovals"
+>;
+
+function createInitialAgentDataState(): AgentDataState {
+  return {
+    activeAgents: [],
+    lastResults: new Map(),
+    debugLog: [],
+    isProcessing: false,
+    failedAgentTypes: [],
+    failedAgentFailures: [],
+    thoughtBubbles: [],
+    echoMessages: [],
+    echoVisibleCount: 0,
+    echoBaseline: 0,
+    echoLoadedChatId: null,
+    cyoaChoices: [],
+    cyoaChoicesChatId: null,
+    youtubePlay: null,
+    youtubeVolume: null,
+    localMusicPlay: null,
+    localMusicVolume: null,
+    pendingCardUpdates: [],
+    pendingAgentWriteApprovals: [],
+  };
+}
+
 export const useAgentStore = create<AgentState>((set) => ({
-  activeAgents: [],
-  lastResults: new Map(),
-  debugLog: [],
-  isProcessing: false,
-  failedAgentTypes: [],
-  failedAgentFailures: [],
-  thoughtBubbles: [],
-  echoMessages: [],
-  echoVisibleCount: 0,
-  echoBaseline: 0,
-  echoLoadedChatId: null,
-  cyoaChoices: [],
-  cyoaChoicesChatId: null,
-  youtubePlay: null,
-  youtubeVolume: null,
-  localMusicPlay: null,
-  localMusicVolume: null,
-  pendingCardUpdates: [],
-  pendingAgentWriteApprovals: [],
+  ...createInitialAgentDataState(),
 
   setActiveAgents: (agents) => set({ activeAgents: agents }),
   setProcessing: (processing) => set({ isProcessing: processing }),
@@ -278,26 +307,5 @@ export const useAgentStore = create<AgentState>((set) => ({
     })),
   clearPendingAgentWriteApprovals: () => set({ pendingAgentWriteApprovals: [] }),
 
-  reset: () =>
-    set({
-      activeAgents: [],
-      lastResults: new Map(),
-      debugLog: [],
-      isProcessing: false,
-      failedAgentTypes: [],
-      failedAgentFailures: [],
-      thoughtBubbles: [],
-      echoMessages: [],
-      echoVisibleCount: 0,
-      echoBaseline: 0,
-      echoLoadedChatId: null,
-      cyoaChoices: [],
-      cyoaChoicesChatId: null,
-      youtubePlay: null,
-      youtubeVolume: null,
-      localMusicPlay: null,
-      localMusicVolume: null,
-      pendingCardUpdates: [],
-      pendingAgentWriteApprovals: [],
-    }),
+  reset: () => set(createInitialAgentDataState()),
 }));

--- a/packages/client/src/stores/agent.store.ts
+++ b/packages/client/src/stores/agent.store.ts
@@ -295,6 +295,8 @@ export const useAgentStore = create<AgentState>((set) => ({
       cyoaChoicesChatId: null,
       youtubePlay: null,
       youtubeVolume: null,
+      localMusicPlay: null,
+      localMusicVolume: null,
       pendingCardUpdates: [],
       pendingAgentWriteApprovals: [],
     }),

--- a/packages/server/src/routes/agents.routes.ts
+++ b/packages/server/src/routes/agents.routes.ts
@@ -152,7 +152,8 @@ export async function agentsRoutes(app: FastifyInstance) {
 
   /** Get editable custom-agent outputs for a roleplay chat. */
   app.get<{ Params: { chatId: string }; Querystring: { limit?: string } }>("/runs/:chatId/custom", async (req) => {
-    const parsedLimit = req.query.limit ? Number.parseInt(req.query.limit, 10) : undefined;
+    const parsed = req.query.limit ? Number.parseInt(req.query.limit, 10) : undefined;
+    const parsedLimit = Number.isFinite(parsed) ? parsed : undefined;
     return storage.listCustomRunsForChat(req.params.chatId, parsedLimit);
   });
 

--- a/packages/server/src/routes/generate.routes.ts
+++ b/packages/server/src/routes/generate.routes.ts
@@ -5776,18 +5776,21 @@ export async function generateRoutes(app: FastifyInstance) {
                   r.agentType !== "knowledge-router" &&
                   r.agentType !== "secret-plot-driver",
               );
-              const failedRegen = regenPreGenResults.filter((r) => !r.success);
-              if (failedRegen.length > 0) {
-                const failedNames = failedRegen.map((r) => r.agentType).join(", ");
-                const firstError = failedRegen[0]!.error ?? "unknown error";
-                logger.error(
-                  `[pre-gen] FATAL: ${failedRegen.length} agent(s) failed on regen (${failedNames}) — aborting generation`,
-                );
+              const criticalFailedRegen = regenPreGenResults.filter((r) => !r.success && r.type === "secret_plot");
+              const nonCriticalFailedRegen = regenPreGenResults.filter((r) => !r.success && r.type !== "secret_plot");
+              if (criticalFailedRegen.length > 0) {
+                const failedNames = criticalFailedRegen.map((r) => r.agentType).join(", ");
+                const firstError = criticalFailedRegen[0]!.error ?? "unknown error";
+                logger.error(`[pre-gen] FATAL: critical agent(s) failed on regen (${failedNames}) — aborting generation`);
                 sendSseEvent(reply, {
                   type: "error",
-                  data: `Pre-generation agent${failedRegen.length > 1 ? "s" : ""} failed (${failedNames}): ${firstError}. Please try again.`,
+                  data: `Critical pre-generation agent failed (${failedNames}): ${firstError}. Please try again.`,
                 });
                 return;
+              }
+              if (nonCriticalFailedRegen.length > 0) {
+                const failedNames = nonCriticalFailedRegen.map((r) => r.agentType).join(", ");
+                logger.warn(`[pre-gen] Non-critical agent(s) failed on regen (${failedNames}) — continuing generation`);
               }
             }
           }

--- a/packages/server/src/routes/generate/agent-connection-guards.ts
+++ b/packages/server/src/routes/generate/agent-connection-guards.ts
@@ -20,7 +20,7 @@ export function resolveAgentConnectionId(args: {
   localSidecarAvailable: boolean;
 }): string | null | "skip-local-sidecar" {
   if (isLocalSidecarConnectionId(args.requestedConnectionId) && !args.localSidecarAvailable) {
-    return args.defaultAgentConnectionId ?? "skip-local-sidecar";
+    return "skip-local-sidecar";
   }
 
   return args.requestedConnectionId ?? args.defaultAgentConnectionId ?? null;

--- a/packages/server/src/routes/generate/expression-agent-utils.ts
+++ b/packages/server/src/routes/generate/expression-agent-utils.ts
@@ -200,10 +200,13 @@ function resolveExpression(expression: string, availableExpressions: string[]): 
   const lower = trimmed.toLowerCase();
 
   const prefixMatches = availableExpressions.filter((entry) => getExpressionPrefixVariant(entry, trimmed));
-  const randomPrefixMatch = prefixMatches.length > 1 ? pickRandomExpression(prefixMatches) : null;
-  if (randomPrefixMatch) return randomPrefixMatch;
-
   const exact = availableExpressions.find((entry) => entry.toLowerCase() === lower);
+  if (prefixMatches.length > 1) {
+    const groupPool = exact ? [exact, ...prefixMatches] : prefixMatches;
+    const randomGroupMatch = pickRandomExpression(groupPool);
+    if (randomGroupMatch) return randomGroupMatch;
+  }
+
   if (exact) return exact;
 
   const normalized = normalizeExpressionToken(trimmed);

--- a/packages/server/src/routes/generate/retry-agents-route.ts
+++ b/packages/server/src/routes/generate/retry-agents-route.ts
@@ -1001,7 +1001,11 @@ async function resolveRetryAgents(args: {
   );
   const resolvedTypeSet = new Set(enabledConfigs.map((config: any) => config.type));
   const builtInFallbackConfigs = BUILT_IN_AGENTS.filter(
-    (agent) => agentTypeSet.has(agent.id) && !resolvedTypeSet.has(agent.id) && !isBuiltInAgentRuntimeDisabled(agent.id),
+    (agent) =>
+      agentTypeSet.has(agent.id) &&
+      !resolvedTypeSet.has(agent.id) &&
+      !isBuiltInAgentRuntimeDisabled(agent.id) &&
+      !isRetiredBuiltInAgentId(agent.id),
   );
 
   const setupConfig = parseSettingsRecord(chatMeta.gameSetupConfig);
@@ -1581,15 +1585,22 @@ async function attachRetryEditChatMessageToolContexts(args: {
   if (!tool) return;
 
   const replaceChatMessageContent = async (input: { messageId: string; content: string; reason?: string }) => {
-    const message = await chats.getMessage(input.messageId);
+    if (!input || typeof input.messageId !== "string" || !input.messageId.trim()) {
+      return { error: "messageId is required and must be a string." };
+    }
+    if (typeof input.content !== "string") {
+      return { error: "content is required and must be a string.", messageId: input.messageId };
+    }
+    const messageId = input.messageId.trim();
+    const message = await chats.getMessage(messageId);
     if (!message || message.chatId !== chatId) {
-      return { error: "Message not found in this chat.", messageId: input.messageId };
+      return { error: "Message not found in this chat.", messageId };
     }
     if (message.role !== "user" && message.role !== "assistant") {
-      return { error: "Only user or assistant messages can be edited.", messageId: input.messageId };
+      return { error: "Only user or assistant messages can be edited.", messageId };
     }
-    await chats.updateMessageContent(input.messageId, input.content);
-    return { applied: true, messageId: input.messageId, role: message.role, reason: input.reason ?? null };
+    await chats.updateMessageContent(messageId, input.content);
+    return { applied: true, messageId, role: message.role, reason: input.reason ?? null };
   };
 
   for (const entry of resolvedAgents) {
@@ -2268,52 +2279,71 @@ async function executeLorebookKeeperRetries(args: {
 
   const results: Array<{ messageId: string; result: AgentResult }> = [];
   for (const target of targets) {
-    const retryContext = buildHistoricalLorebookKeeperContext(baseContext, messages, target.id);
-    if (!retryContext) continue;
+    const startedAt = Date.now();
+    try {
+      const retryContext = buildHistoricalLorebookKeeperContext(baseContext, messages, target.id);
+      if (!retryContext) continue;
 
-    if (preferredTargetLorebookId) {
-      retryContext.memory._lorebookKeeperTargetLorebookId = preferredTargetLorebookId;
-    }
-    const existingEntries = await loadLorebookKeeperExistingEntries(lorebooksStore, preferredTargetLorebookId);
-    if (existingEntries.length > 0) {
-      retryContext.memory._existingLorebookEntries = existingEntries;
-    }
-
-    const rawResult = await executeAgent(
-      lorebookKeeperAgent.resolved,
-      retryContext,
-      lorebookKeeperAgent.agentProvider,
-      lorebookKeeperAgent.agentModel,
-    );
-    const result = requireApproval
-      ? markRetryLorebookResultForApproval({
-          result: rawResult,
-          chatId,
-          agentContext: retryContext,
-          resolvedAgents: [lorebookKeeperAgent],
-        })
-      : rawResult;
-    results.push({ messageId: target.id, result });
-
-    if (
-      result.success &&
-      result.type === "lorebook_update" &&
-      result.data &&
-      typeof result.data === "object" &&
-      !isAgentWriteApprovalEnvelope(result.data)
-    ) {
-      const lkData = result.data as Record<string, unknown>;
-      const updates = (lkData.updates as Array<Record<string, unknown>>) ?? [];
-      if (updates.length > 0) {
-        preferredTargetLorebookId = await persistLorebookKeeperUpdates({
-          lorebooksStore,
-          chatId,
-          chatName,
-          preferredTargetLorebookId,
-          writableLorebookIds: retryContext.writableLorebookIds,
-          updates,
-        });
+      if (preferredTargetLorebookId) {
+        retryContext.memory._lorebookKeeperTargetLorebookId = preferredTargetLorebookId;
       }
+      const existingEntries = await loadLorebookKeeperExistingEntries(lorebooksStore, preferredTargetLorebookId);
+      if (existingEntries.length > 0) {
+        retryContext.memory._existingLorebookEntries = existingEntries;
+      }
+
+      const rawResult = await executeAgent(
+        lorebookKeeperAgent.resolved,
+        retryContext,
+        lorebookKeeperAgent.agentProvider,
+        lorebookKeeperAgent.agentModel,
+      );
+      const result = requireApproval
+        ? markRetryLorebookResultForApproval({
+            result: rawResult,
+            chatId,
+            agentContext: retryContext,
+            resolvedAgents: [lorebookKeeperAgent],
+          })
+        : rawResult;
+
+      if (
+        result.success &&
+        result.type === "lorebook_update" &&
+        result.data &&
+        typeof result.data === "object" &&
+        !isAgentWriteApprovalEnvelope(result.data)
+      ) {
+        const lkData = result.data as Record<string, unknown>;
+        const updates = (lkData.updates as Array<Record<string, unknown>>) ?? [];
+        if (updates.length > 0) {
+          preferredTargetLorebookId = await persistLorebookKeeperUpdates({
+            lorebooksStore,
+            chatId,
+            chatName,
+            preferredTargetLorebookId,
+            writableLorebookIds: retryContext.writableLorebookIds,
+            updates,
+          });
+        }
+      }
+
+      results.push({ messageId: target.id, result });
+    } catch (err) {
+      logger.error(err, "[retry-agents] Lorebook Keeper retry failed for target message %s", target.id);
+      results.push({
+        messageId: target.id,
+        result: {
+          agentId: lorebookKeeperAgent.resolved.id,
+          agentType: lorebookKeeperAgent.resolved.type,
+          type: "lorebook_update",
+          data: null,
+          tokensUsed: 0,
+          durationMs: Date.now() - startedAt,
+          success: false,
+          error: err instanceof Error ? err.message : "Lorebook Keeper failed",
+        },
+      });
     }
   }
 
@@ -2975,10 +3005,7 @@ async function applyRetryResultEffects(args: {
                 galleryId: (galleryEntry as any)?.id,
               };
               await chatsDb.appendSwipeAttachment(retryMessageId, retrySwipeIndex, attachment);
-              const msgRow = await chatsDb.getMessage(retryMessageId);
-              if (msgRow && (msgRow.activeSwipeIndex ?? 0) === retrySwipeIndex) {
-                await chatsDb.appendMessageAttachment(retryMessageId, attachment);
-              }
+              await chatsDb.appendMessageAttachmentForActiveSwipe(retryMessageId, retrySwipeIndex, attachment);
             }
 
             sendSseEvent(reply, {

--- a/packages/server/src/routes/generate/retry-agents-route.ts
+++ b/packages/server/src/routes/generate/retry-agents-route.ts
@@ -12,6 +12,8 @@ import {
   customAgentHasCapability,
   isAgentAvailableInChatMode,
   isAgentConfigDeleted,
+  isBuiltInAgentRuntimeDisabled,
+  isRetiredBuiltInAgentId,
   normalizeAgentPromptTemplateSelectionMap,
   resolveAgentPromptTemplate,
   stripMacroComments,
@@ -353,6 +355,10 @@ async function resolveRetryAgentWrapFormat(args: {
   conn: any | null;
   presets: ReturnType<typeof createPromptsStorage>;
 }): Promise<WrapFormat> {
+  if (args.chatMode === "conversation" || args.chatMode === "game") {
+    return "xml";
+  }
+
   const candidates = buildGenerationPromptPresetCandidates({
     chatMode: args.chatMode,
     chatPromptPresetId: args.chat.promptPresetId,
@@ -387,7 +393,14 @@ function applyRetryMusicPlayerSource(
 }
 
 function resolveRetryAgentRuntimePhase(agentType: string, configuredPhase: string): string {
-  if (agentType === "prose-guardian" || agentType === "continuity") return "post_processing";
+  if (
+    agentType === "prose-guardian" ||
+    agentType === "continuity" ||
+    agentType === "expression" ||
+    agentType === "spotify"
+  ) {
+    return "post_processing";
+  }
   return configuredPhase;
 }
 
@@ -442,9 +455,10 @@ async function resolvePersonaContext(
   let rpgStats: any = null;
 
   const allPersonas = await chars.listPersonas();
+  const chatMode = ((chat as { mode?: ChatMode }).mode ?? "conversation") as ChatMode;
   const persona =
     (chat.personaId ? allPersonas.find((p: any) => p.id === chat.personaId) : null) ??
-    allPersonas.find((p: any) => p.isActive === "true");
+    (chatMode !== "game" ? allPersonas.find((p: any) => p.isActive === "true") : null);
 
   if (!persona) {
     return { personaId, personaName, personaDescription, personaFields, personaStats, rpgStats };
@@ -979,11 +993,15 @@ async function resolveRetryAgents(args: {
     agentTypeSet.delete(agentType);
   }
   const enabledConfigs = configs.filter(
-    (config: any) => !isAgentConfigDeleted(config.settings) && agentTypeSet.has(config.type),
+    (config: any) =>
+      !isAgentConfigDeleted(config.settings) &&
+      !isBuiltInAgentRuntimeDisabled(config.type) &&
+      !isRetiredBuiltInAgentId(config.type) &&
+      agentTypeSet.has(config.type),
   );
   const resolvedTypeSet = new Set(enabledConfigs.map((config: any) => config.type));
   const builtInFallbackConfigs = BUILT_IN_AGENTS.filter(
-    (agent) => agentTypeSet.has(agent.id) && !resolvedTypeSet.has(agent.id),
+    (agent) => agentTypeSet.has(agent.id) && !resolvedTypeSet.has(agent.id) && !isBuiltInAgentRuntimeDisabled(agent.id),
   );
 
   const setupConfig = parseSettingsRecord(chatMeta.gameSetupConfig);
@@ -1325,6 +1343,7 @@ const CHAT_METADATA_TOOL_NAMES = new Set([
   "write_chat_variable",
 ]);
 const LOREBOOK_WRITE_TOOL_NAME = "save_lorebook_entry";
+const EDIT_CHAT_MESSAGE_TOOL_NAME = "edit_chat_message";
 
 function resolveRetryAgentWritableLorebookId(settings: Record<string, unknown>): string | null {
   const enabledTools = Array.isArray(settings.enabledTools) ? settings.enabledTools : [];
@@ -1341,6 +1360,21 @@ function resolveRetryAgentWritableLorebookId(settings: Record<string, unknown>):
     if (first) return first.trim();
   }
   return null;
+}
+
+function resolveRetryCustomWritableLorebookIds(settings: Record<string, unknown>): string[] | null {
+  const ids: string[] = [];
+  for (const key of ["writableLorebookId", "targetLorebookId"]) {
+    const value = settings[key];
+    if (typeof value === "string" && value.trim()) ids.push(value.trim());
+  }
+  const writableIds = settings.writableLorebookIds;
+  if (Array.isArray(writableIds)) {
+    for (const value of writableIds) {
+      if (typeof value === "string" && value.trim()) ids.push(value.trim());
+    }
+  }
+  return ids.length > 0 ? Array.from(new Set(ids)) : null;
 }
 
 async function attachRetryLorebookWriterToolContexts(args: {
@@ -1531,6 +1565,55 @@ async function attachRetryChatMetadataToolContexts(args: {
           chatMeta,
           onUpdateMetadata: updateChatMetadataForTools,
         });
+        return results[0]?.result ?? "Tool execution failed";
+      },
+    };
+  }
+}
+
+async function attachRetryEditChatMessageToolContexts(args: {
+  chats: ReturnType<typeof createChatsStorage>;
+  chatId: string;
+  resolvedAgents: ResolvedRetryAgent[];
+}) {
+  const { chats, chatId, resolvedAgents } = args;
+  const tool = toLLMToolDefinition(EDIT_CHAT_MESSAGE_TOOL_NAME);
+  if (!tool) return;
+
+  const replaceChatMessageContent = async (input: { messageId: string; content: string; reason?: string }) => {
+    const message = await chats.getMessage(input.messageId);
+    if (!message || message.chatId !== chatId) {
+      return { error: "Message not found in this chat.", messageId: input.messageId };
+    }
+    if (message.role !== "user" && message.role !== "assistant") {
+      return { error: "Only user or assistant messages can be edited.", messageId: input.messageId };
+    }
+    await chats.updateMessageContent(input.messageId, input.content);
+    return { applied: true, messageId: input.messageId, role: message.role, reason: input.reason ?? null };
+  };
+
+  for (const entry of resolvedAgents) {
+    const settings = parseSettingsRecord(entry.resolved.settings);
+    const enabledNames = Array.isArray(settings.enabledTools) ? (settings.enabledTools as string[]) : [];
+    if (!enabledNames.includes(EDIT_CHAT_MESSAGE_TOOL_NAME)) continue;
+    if (!customAgentHasCapability(settings, "edit_messages")) continue;
+
+    const existingContext = entry.resolved.toolContext;
+    const tools = existingContext?.tools.some((item) => item.function.name === EDIT_CHAT_MESSAGE_TOOL_NAME)
+      ? [...existingContext.tools]
+      : [...(existingContext?.tools ?? []), tool];
+
+    entry.resolved.toolContext = {
+      tools,
+      executeToolCall: async (call) => {
+        if (call.function.name !== EDIT_CHAT_MESSAGE_TOOL_NAME) {
+          if (existingContext) return existingContext.executeToolCall(call);
+          return JSON.stringify({
+            error: `Tool not allowed for agent ${entry.resolved.type}: ${call.function.name}`,
+            allowed: [EDIT_CHAT_MESSAGE_TOOL_NAME],
+          });
+        }
+        const results = await executeToolCalls([call], { replaceChatMessageContent });
         return results[0]?.result ?? "Tool execution failed";
       },
     };
@@ -1877,7 +1960,7 @@ async function validateSpotifyRetryPlayback(
       ? (context.memory._spotifyDjConstraints as Record<string, unknown>)
       : {};
   const forceFreshPick = constraints.manualRetry === true || constraints.forceFreshPick === true;
-  if (!forceFreshPick || constraints.mode !== "game") return result;
+  if (!forceFreshPick) return result;
 
   const toolCalls = (entry.resolved as any).__spotifyToolCalls;
   const spotifyPlayCalled = toolCalls instanceof Set && toolCalls.has("spotify_play");
@@ -1892,6 +1975,10 @@ async function validateSpotifyRetryPlayback(
   const currentAfterPlay = (entry.resolved as any).__spotifyCurrentAfterPlayUri;
   const repeatAfterPlay = (entry.resolved as any).__spotifyRepeatAfterPlayState;
   const playbackPending = (entry.resolved as any).__spotifyPlaybackPending === true;
+  if (constraints.mode !== "game" && spotifyPlayCalled && spotifyPlayApplied) {
+    return result;
+  }
+
   if (
     spotifyPlayCalled &&
     spotifyPlayApplied &&
@@ -2292,7 +2379,7 @@ async function applyRetryResultEffects(args: {
     return retryBaseGameStateSnapshotPromise;
   };
   const loadRetryTargetGameStateSnapshot = async () => {
-    if (!retryMessageId) return loadRetryBaseGameStateSnapshot();
+    if (!retryMessageId) return null;
     const existing = await gameStateStore.getByMessage(retryMessageId, retrySwipeIndex);
     if (existing) return existing;
     return gameStateStore.updateByMessage(retryMessageId, retrySwipeIndex, chatId, {}, undefined, {
@@ -2363,6 +2450,7 @@ async function applyRetryResultEffects(args: {
     }
 
     if (
+      retryMessageId &&
       result.success &&
       result.type === "game_state_update" &&
       result.agentType !== "combat" &&
@@ -2448,6 +2536,7 @@ async function applyRetryResultEffects(args: {
     }
 
     if (
+      retryMessageId &&
       result.success &&
       result.type === "character_tracker_update" &&
       result.data &&
@@ -2499,6 +2588,7 @@ async function applyRetryResultEffects(args: {
     }
 
     if (
+      retryMessageId &&
       result.success &&
       result.type === "persona_stats_update" &&
       result.data &&
@@ -2557,18 +2647,39 @@ async function applyRetryResultEffects(args: {
     if (result.success && result.type === "lorebook_update" && result.data && typeof result.data === "object") {
       try {
         if (isAgentWriteApprovalEnvelope(result.data)) continue;
+        const resultAgent = findRetryResultAgent(result, resolvedAgents);
+        const isBuiltInLorebookAgent = BUILT_IN_AGENT_TYPE_SET.has(result.agentType);
+        const customCanEditLorebooks =
+          isBuiltInLorebookAgent ||
+          (resultAgent ? customAgentHasCapability(resultAgent.settings, "edit_lorebooks") : false);
+        const customCanCreateLorebooks =
+          isBuiltInLorebookAgent ||
+          (resultAgent ? customAgentHasCapability(resultAgent.settings, "create_lorebooks") : false);
+        if (!customCanEditLorebooks && !customCanCreateLorebooks) continue;
+
         const lkData = result.data as Record<string, unknown>;
         const retryUpdates = (lkData.updates as any[]) ?? [];
         if (retryUpdates.length > 0) {
+          const customWritableLorebookIds =
+            !isBuiltInLorebookAgent && resultAgent
+              ? resolveRetryCustomWritableLorebookIds(resultAgent.settings)
+              : agentContext.writableLorebookIds;
+          const writableLorebookIds = customCanEditLorebooks ? customWritableLorebookIds : null;
+          const preferredTargetLorebookId =
+            !isBuiltInLorebookAgent && resultAgent
+              ? (writableLorebookIds?.[0] ?? null)
+              : typeof agentContext.memory._lorebookKeeperTargetLorebookId === "string"
+                ? (agentContext.memory._lorebookKeeperTargetLorebookId as string)
+                : null;
+          if (!customCanCreateLorebooks && !preferredTargetLorebookId && !writableLorebookIds?.length) {
+            continue;
+          }
           await persistLorebookKeeperUpdates({
             lorebooksStore,
             chatId,
             chatName: (chat as any).name,
-            preferredTargetLorebookId:
-              typeof agentContext.memory._lorebookKeeperTargetLorebookId === "string"
-                ? (agentContext.memory._lorebookKeeperTargetLorebookId as string)
-                : null,
-            writableLorebookIds: agentContext.writableLorebookIds,
+            preferredTargetLorebookId,
+            writableLorebookIds,
             updates: retryUpdates,
           });
         }
@@ -2578,6 +2689,7 @@ async function applyRetryResultEffects(args: {
     }
 
     if (
+      retryMessageId &&
       result.success &&
       result.type === "quest_update" &&
       result.data &&
@@ -2647,6 +2759,7 @@ async function applyRetryResultEffects(args: {
     }
 
     if (
+      retryMessageId &&
       result.success &&
       result.type === "custom_tracker_update" &&
       result.data &&
@@ -2861,13 +2974,10 @@ async function applyRetryResultEffects(args: {
                 prompt: compiledPrompt.prompt,
                 galleryId: (galleryEntry as any)?.id,
               };
-              const swipeRow = (await chatsDb.getSwipes(retryMessageId)).find((s: any) => s.index === retrySwipeIndex);
-              if (swipeRow) {
-                const swipeExtra =
-                  typeof swipeRow.extra === "string" ? JSON.parse(swipeRow.extra) : (swipeRow.extra ?? {});
-                const swipeAtts = (swipeExtra.attachments as any[]) ?? [];
-                swipeAtts.push(attachment);
-                await chatsDb.updateMessageExtraForSwipe(retryMessageId, retrySwipeIndex, { attachments: swipeAtts });
+              await chatsDb.appendSwipeAttachment(retryMessageId, retrySwipeIndex, attachment);
+              const msgRow = await chatsDb.getMessage(retryMessageId);
+              if (msgRow && (msgRow.activeSwipeIndex ?? 0) === retrySwipeIndex) {
+                await chatsDb.appendMessageAttachment(retryMessageId, attachment);
               }
             }
 
@@ -2927,7 +3037,7 @@ async function applyRetryResultEffects(args: {
 
     // ── EXPRESSION ENGINE: persist validated sprite expressions ──
     // Validation already happened before SSE send; here we just persist to DB.
-    if (result.success && result.type === "sprite_change" && result.data && typeof result.data === "object") {
+    if (retryMessageId && result.success && result.type === "sprite_change" && result.data && typeof result.data === "object") {
       const spriteData = result.data as { expressions?: Array<{ characterId: string; expression: string }> };
       const exprMap: Record<string, string> = {};
       const personaExprMap: Record<string, string> = {};
@@ -3124,6 +3234,7 @@ export async function registerRetryAgentsRoute(app: FastifyInstance) {
         requireApproval: requireAgentWriteApproval,
         chatId,
       });
+      await attachRetryEditChatMessageToolContexts({ chats, chatId, resolvedAgents });
       const cyoaAgentWillRun = resolvedAgents.some((e) => e.resolved.type === "cyoa");
       const agentContext = await buildRetryAgentContext({
         cyoaAgentWillRun,
@@ -3212,8 +3323,10 @@ export async function registerRetryAgentsRoute(app: FastifyInstance) {
             ? markRetryLorebookResultForApproval({ result, chatId, agentContext, resolvedAgents: nonLorebookAgents })
             : result,
         );
-      const rawLorebookKeeperRunEntries = lorebookKeeperAgent
-        ? await executeLorebookKeeperRetries({
+      let rawLorebookKeeperRunEntries: Array<{ messageId: string; result: AgentResult }> = [];
+      if (lorebookKeeperAgent) {
+        try {
+          rawLorebookKeeperRunEntries = await executeLorebookKeeperRetries({
             lorebookKeeperAgent,
             baseContext: agentContext,
             messages: recentMessages,
@@ -3225,8 +3338,19 @@ export async function registerRetryAgentsRoute(app: FastifyInstance) {
             chatId,
             chatName: (chat as any).name,
             requireApproval: requireAgentWriteApproval,
-          })
-        : [];
+          });
+        } catch (err) {
+          logger.error(err, "[retry-agents] Lorebook Keeper retry failed; applying other agent results");
+          sendSseEvent(reply, {
+            type: "agent_error",
+            data: {
+              agentType: "lorebook-keeper",
+              agentName: lorebookKeeperAgent.cfg?.name ?? "Lorebook Keeper",
+              error: err instanceof Error ? err.message : "Lorebook Keeper failed",
+            },
+          });
+        }
+      }
       const lorebookKeeperRunEntries = rawLorebookKeeperRunEntries.map((entry) => ({
         ...entry,
         result: markInvalidJsonAgentResult(entry.result),

--- a/packages/server/src/services/agents/agent-executor.ts
+++ b/packages/server/src/services/agents/agent-executor.ts
@@ -1161,9 +1161,7 @@ function extractResultBlocks(responseText: string): ExtractedResultBlock[] {
         depth--;
         if (depth <= 0) {
           selectedCloseIdx = j;
-          depth = 0;
-          const next = tokens[j + 1];
-          if (!next || !next.isClose) break;
+          break;
         }
       } else {
         depth++;

--- a/packages/server/src/services/agents/agent-executor.ts
+++ b/packages/server/src/services/agents/agent-executor.ts
@@ -1122,34 +1122,67 @@ type ExtractedResultBlock = {
 };
 
 function extractResultBlocks(responseText: string): ExtractedResultBlock[] {
-  const openRegex = /<result\b([^>]*)>/gi;
-  const opens = Array.from(responseText.matchAll(openRegex));
+  const tokenRegex = /<result\b([^>]*)>|<\/result\s*>/gi;
+  type Token = { index: number; length: number; isClose: boolean; attributes: string };
+  const tokens: Token[] = [];
+  let match: RegExpExecArray | null;
+  while ((match = tokenRegex.exec(responseText))) {
+    const isClose = match[0][1] === "/";
+    tokens.push({
+      index: match.index,
+      length: match[0].length,
+      isClose,
+      attributes: isClose ? "" : (match[1] ?? ""),
+    });
+  }
+
   const blocks: ExtractedResultBlock[] = [];
 
-  for (let i = 0; i < opens.length; i++) {
-    const open = opens[i]!;
-    const agent = readResultAgentAttribute(open[1] ?? "");
-    if (!agent) continue;
-
-    const contentStart = open.index + open[0].length;
-    const nextStart = opens[i + 1]?.index ?? responseText.length;
-    const closeRegex = /<\/result\s*>/gi;
-    closeRegex.lastIndex = contentStart;
-
-    let selectedClose: RegExpExecArray | null = null;
-    let closeMatch: RegExpExecArray | null;
-    while ((closeMatch = closeRegex.exec(responseText))) {
-      if (closeMatch.index >= nextStart) break;
-      selectedClose = closeMatch;
+  let i = 0;
+  while (i < tokens.length) {
+    const open = tokens[i]!;
+    if (open.isClose) {
+      i++;
+      continue;
     }
-    if (!selectedClose) continue;
+    const agent = readResultAgentAttribute(open.attributes);
+    if (!agent) {
+      i++;
+      continue;
+    }
 
+    const contentStart = open.index + open.length;
+    let depth = 1;
+    let selectedCloseIdx = -1;
+    let j = i + 1;
+    while (j < tokens.length) {
+      const token = tokens[j]!;
+      if (token.isClose) {
+        depth--;
+        if (depth <= 0) {
+          selectedCloseIdx = j;
+          depth = 0;
+          const next = tokens[j + 1];
+          if (!next || !next.isClose) break;
+        }
+      } else {
+        depth++;
+      }
+      j++;
+    }
+    if (selectedCloseIdx === -1) {
+      i++;
+      continue;
+    }
+
+    const close = tokens[selectedCloseIdx]!;
     blocks.push({
       agent,
-      content: responseText.slice(contentStart, selectedClose.index),
+      content: responseText.slice(contentStart, close.index),
       start: open.index,
-      end: selectedClose.index + selectedClose[0].length,
+      end: close.index + close.length,
     });
+    i = selectedCloseIdx + 1;
   }
 
   return blocks;
@@ -1253,6 +1286,7 @@ function shouldRunAgentIndividually(config: Pick<AgentExecConfig, "type" | "sett
     config.type === "expression" ||
     config.type === "illustrator" ||
     config.type === "lorebook-keeper" ||
+    resolveAgentResultType(config) === "text_rewrite" ||
     musicDjUsesJsonOnlyProvider(config)
   );
 }
@@ -2368,8 +2402,44 @@ function repairJson(str: string): string {
     JSON.parse(str);
     return str;
   } catch {
-    return stripJsonRepairTokens(str).replace(/,\s*([\]\}])/g, "$1");
+    return stripTrailingCommas(stripJsonRepairTokens(str));
   }
+}
+
+function stripTrailingCommas(str: string): string {
+  let repaired = "";
+  let inString = false;
+  let escaped = false;
+  for (let index = 0; index < str.length; index++) {
+    const char = str[index] ?? "";
+    if (inString) {
+      repaired += char;
+      if (escaped) {
+        escaped = false;
+      } else if (char === "\\") {
+        escaped = true;
+      } else if (char === '"') {
+        inString = false;
+      }
+      continue;
+    }
+
+    if (char === '"') {
+      inString = true;
+      repaired += char;
+      continue;
+    }
+
+    if (char === ",") {
+      let lookahead = index + 1;
+      while (lookahead < str.length && /\s/.test(str[lookahead] ?? "")) lookahead++;
+      const nextSignificant = str[lookahead];
+      if (nextSignificant === "}" || nextSignificant === "]") continue;
+    }
+
+    repaired += char;
+  }
+  return repaired;
 }
 
 function stripJsonRepairTokens(str: string): string {

--- a/packages/server/src/services/generation/agent-resolution.ts
+++ b/packages/server/src/services/generation/agent-resolution.ts
@@ -318,6 +318,14 @@ export async function resolveAgentPipelineAgents({
     ) {
       settings.enabledTools = DEFAULT_AGENT_TOOLS.spotify ?? [];
     }
+    if (
+      cfg.type !== "spotify" &&
+      BUILT_IN_AGENTS.some((agent) => agent.id === cfg.type) &&
+      !Array.isArray(settings.enabledTools) &&
+      (DEFAULT_AGENT_TOOLS[cfg.type as string]?.length ?? 0) > 0
+    ) {
+      settings.enabledTools = [...DEFAULT_AGENT_TOOLS[cfg.type as string]!];
+    }
     let selectedPromptTemplate = resolveAgentPromptTemplate({
       agentType: cfg.type as string,
       promptTemplate: normalizeProseGuardianPromptTemplate(cfg.type as string, cfg.promptTemplate),
@@ -452,6 +460,13 @@ export async function resolveAgentPipelineAgents({
       (!Array.isArray(builtInSettings.enabledTools) || builtInSettings.enabledTools.length === 0)
     ) {
       builtInSettings.enabledTools = DEFAULT_AGENT_TOOLS.spotify ?? [];
+    }
+    if (
+      builtIn.id !== "spotify" &&
+      !Array.isArray(builtInSettings.enabledTools) &&
+      (DEFAULT_AGENT_TOOLS[builtIn.id]?.length ?? 0) > 0
+    ) {
+      builtInSettings.enabledTools = [...DEFAULT_AGENT_TOOLS[builtIn.id]!];
     }
     let selectedPromptTemplate = resolveAgentPromptTemplate({
       agentType: builtIn.id,

--- a/packages/server/src/services/storage/agents.storage.ts
+++ b/packages/server/src/services/storage/agents.storage.ts
@@ -1,7 +1,7 @@
 // ──────────────────────────────────────────────
 // Storage: Agent Configs, Runs & Memory
 // ──────────────────────────────────────────────
-import { eq, and, desc } from "drizzle-orm";
+import { eq, and, desc, notInArray } from "drizzle-orm";
 import type { DB } from "../../db/connection.js";
 import { agentConfigs, agentRuns, agentMemory } from "../../db/schema/index.js";
 import { newId, now } from "../../utils/id-generator.js";
@@ -372,17 +372,17 @@ export function createAgentsStorage(db: DB) {
         .select()
         .from(agentRuns)
         .innerJoin(agentConfigs, eq(agentRuns.agentConfigId, agentConfigs.id))
-        .where(and(eq(agentRuns.chatId, chatId), eq(agentRuns.success, "true")))
-        .orderBy(desc(agentRuns.createdAt));
+        .where(
+          and(
+            eq(agentRuns.chatId, chatId),
+            eq(agentRuns.success, "true"),
+            notInArray(agentConfigs.type, Array.from(BUILT_IN_AGENT_TYPES)),
+          ),
+        )
+        .orderBy(desc(agentRuns.createdAt))
+        .limit(normalizedLimit);
 
-      const customRows: typeof rows = [];
-      for (const row of rows) {
-        if (isBuiltInAgentType(row.agent_configs.type)) continue;
-        customRows.push(row);
-        if (customRows.length >= normalizedLimit) break;
-      }
-
-      return customRows.map((row) => serializeRunWithConfig(row));
+      return rows.map((row) => serializeRunWithConfig(row));
     },
 
     async getRunWithConfig(id: string) {

--- a/packages/server/src/services/storage/agents.storage.ts
+++ b/packages/server/src/services/storage/agents.storage.ts
@@ -366,19 +366,23 @@ export function createAgentsStorage(db: DB) {
 
     /** Get recent custom-agent runs for a chat, newest first. */
     async listCustomRunsForChat(chatId: string, limit = 50) {
-      const normalizedLimit = Math.max(1, Math.min(limit, 200));
+      const finiteLimit = Number.isFinite(limit) ? limit : 50;
+      const normalizedLimit = Math.max(1, Math.min(finiteLimit, 200));
       const rows = await db
         .select()
         .from(agentRuns)
         .innerJoin(agentConfigs, eq(agentRuns.agentConfigId, agentConfigs.id))
         .where(and(eq(agentRuns.chatId, chatId), eq(agentRuns.success, "true")))
-        .orderBy(desc(agentRuns.createdAt))
-        .limit(200);
+        .orderBy(desc(agentRuns.createdAt));
 
-      return rows
-        .filter((row) => !isBuiltInAgentType(row.agent_configs.type))
-        .slice(0, normalizedLimit)
-        .map((row) => serializeRunWithConfig(row));
+      const customRows: typeof rows = [];
+      for (const row of rows) {
+        if (isBuiltInAgentType(row.agent_configs.type)) continue;
+        customRows.push(row);
+        if (customRows.length >= normalizedLimit) break;
+      }
+
+      return customRows.map((row) => serializeRunWithConfig(row));
     },
 
     async getRunWithConfig(id: string) {

--- a/packages/server/src/services/storage/chats.storage.ts
+++ b/packages/server/src/services/storage/chats.storage.ts
@@ -1121,6 +1121,23 @@ export function createChatsStorage(db: DB) {
       });
     },
 
+    /** Append an attachment to the message mirror only when the expected swipe is still active. */
+    async appendMessageAttachmentForActiveSwipe(id: string, swipeIndex: number, attachment: Record<string, unknown>) {
+      return withPatchQueue(messageExtraPatchQueues, id, async () => {
+        const msg = await this.getMessage(id);
+        if (!msg || (msg.activeSwipeIndex ?? 0) !== swipeIndex) return null;
+        const existing = parseExtraRecord(msg.extra);
+        const attachments = Array.isArray(existing.attachments) ? existing.attachments : [];
+        const merged = { ...existing, attachments: [...attachments, attachment] };
+        await db
+          .update(messages)
+          .set({ extra: JSON.stringify(merged) })
+          .where(and(eq(messages.id, id), eq(messages.activeSwipeIndex, swipeIndex)));
+        const next = await this.getMessage(id);
+        return next && (next.activeSwipeIndex ?? 0) === swipeIndex ? next : null;
+      });
+    },
+
     async removeMessage(id: string) {
       const existing = await this.getMessage(id);
       if (existing) await deleteGameStateForMessages([id]);

--- a/packages/shared/src/types/agent.ts
+++ b/packages/shared/src/types/agent.ts
@@ -27,7 +27,14 @@ export function normalizeAgentPhaseForType(
   configuredPhase: unknown,
   fallback: AgentPhase = "post_processing",
 ): AgentPhase {
-  if (agentType === "prose-guardian" || agentType === "continuity") return "post_processing";
+  if (
+    agentType === "prose-guardian" ||
+    agentType === "continuity" ||
+    agentType === "expression" ||
+    agentType === "spotify"
+  ) {
+    return "post_processing";
+  }
   return normalizeAgentPhaseValue(configuredPhase, fallback);
 }
 


### PR DESCRIPTION
## Summary

Fixes the open agent retry/generation issue sweep reported in #2983 through #3002.

## What Changed

- Hardened agent connection selection, runtime phase normalization, retry wrap format, persona fallback, disabled/retired built-in filtering, built-in default tool resolution, and noncritical pre-generation failure handling.
- Fixed retry side effects for edit-message tools, lorebook-update permissions/scoping, Lorebook Keeper failure isolation, message-scoped tracker effects, Spotify retry fallback, and atomic Illustrator attachment writes.
- Fixed agent executor/result edge cases for nested `<result>` parsing, text-rewrite retry markup preservation, JSON trailing-comma repair, custom run listing/limits, sprite expression selection, and Custom Music DJ reset state.
- Updated the v2.0.7 changelog.

## Validation

- `pnpm --filter @marinara-engine/server lint`
- `pnpm --filter @marinara-engine/client lint`
- `pnpm check`
- `pnpm regression:prompt`

## Manual Verification Needed

- Manually verify representative retry flows in Conversation, Roleplay, and Game modes.
- Manually verify custom agent retry tools for lorebook edits and message edits.
- Manually verify Spotify DJ retry behavior with a fresh track request.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved retry and regeneration behavior so non-critical failures no longer stop a run, while key failures still surface clearly.
  * Fixed local music state resetting correctly when starting over.
  * Improved handling of custom-agent run history, including safer limits and more reliable loading.
  * Made message edits, attachment updates, lorebook changes, and tracker updates behave more consistently during retries.
  * Hardened result parsing and JSON repair to better handle complex or malformed content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->