### PR TITLE
[codex] Fix v2.0.7 issue sweep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,10 +16,12 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 - Added persisted drag-and-drop ordering for custom Functions in the Presets panel, including desktop hover handles and mobile touch dragging.
 - Added a Game Illustrator Chat Settings toggle for automatic visual generation plus a Gallery Background action for Roleplay and Game scenes that creates a background-only image, applies it to the current scene, and saves it into the Appearance background library.
 - Added a Game mode decision-step branch button on the latest narration/dialogue beat so players can fork before choosing their next action.
+- Added customizable RPG stat pools for characters, personas, and Game character sheets so HP-like bars such as HP, MP, EP, or Sanity can be added, colored, tracked, and passed into Present Characters/agent context (#3077).
 - Added a per-chat Illustrator Prompt Model override in Chat Settings so selfie and illustration prompts can be written by a different text connection than the main chat model (#2969).
 - Added an Advanced > Message Tools toggle to include saved reasoning/thinking in chat exports; exports now omit reasoning by default unless the toggle is enabled.
 - Added a built-in `web_search` function-call tool under function selection so chats and agents can fetch compact current web results without custom webhook setup (#3074).
 - Added an Appearance > App Style toggle for Marinara's custom mouse pointer, made cursor rules theme-overridable, and recolored the custom pointer from the live Accent Color so RGB Mode and Accent Pulse animate it too. Cursor recoloring now pauses briefly during wheel scrolling so scroll repaints keep one stable custom cursor image instead of flickering, doubling, or jumping at scroll limits.
+- Added a startup migration that detects built-in agents still storing untouched pre-2.0.0 default prompt text and moves them back onto the live default prompt path so they receive current default prompt updates automatically.
 
 ### Fixed
 
@@ -80,6 +82,11 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 - Fixed image and asset safety edge cases so image-prompt negation only moves the directly negated clause, local music file serving uses the same privileged gate as the folder picker, bundled native game assets cannot be deleted or moved through bulk routes, sprite-sheet grid dimensions validate before provider calls, reference images keep their real MIME type on chat-completions image backends, RunPod ComfyUI observes abort signals and rejects corrupt fallback image data, and chat/global gallery uploads validate real image bytes without leaving partial files or phantom-chat orphans (#3054, #3055, #3056, #3057, #3058, #3059, #3060, #3061, #3062, #3063).
 - Fixed mobile UI edge cases so Roleplay exposes the emoji picker on phones, composer emoji/GIF/sticker popovers clamp to short viewports, resource-panel action pills no longer cover row text, Spotify/media floating widgets stay reachable and below open mobile panels, Game Assets toolbar menus stay onscreen, and Game narration/readable copy actions are available on mobile (#3065, #3066, #3067, #3068, #3069, #3070, #3071).
 - Fixed Game Lorebook Keeper books carried from previous Game sessions so explicitly linked keeper lorebooks remain eligible for constant/keyword triggering in later sessions instead of being blocked by the old session chat ID (#3073).
+- Fixed Peek Prompt display so prompt/system sections surrounding Chat History stay visible while the Chat History block itself still lists only user and assistant turns.
+- Fixed `/impersonate` persona-description insertion so macros inside the persona description resolve before the impersonation instruction is appended (#3081).
+- Fixed regex import safety checks so optional `?` quantifiers do not incorrectly increase star height and reject valid patterns such as `(a+)?` (#3080).
+- Fixed Author's Notes autosave on fast chat switches so an outgoing chat cannot save the incoming chat's note text under the wrong chat ID (#3079).
+- Fixed Game Widget setup fields so label/stat drafts can be cleared or contain trailing spaces while editing, with normalization deferred until save/import/export (#3078).
 
 ### Platform Notes
 

--- a/packages/client/src/components/agents/AgentEditor.tsx
+++ b/packages/client/src/components/agents/AgentEditor.tsx
@@ -2499,7 +2499,7 @@ export function AgentEditor() {
                 description={
                   localInjectAsSection
                     ? `"${localName}" appears as a section option in prompt presets`
-                    : "Agent output is not injected into prompts"
+                    : "Agent output won't be available as a marker in the preset editor."
                 }
                 labelClassName="text-sm"
               />

--- a/packages/client/src/components/characters/CharacterEditor.tsx
+++ b/packages/client/src/components/characters/CharacterEditor.tsx
@@ -90,9 +90,13 @@ import { EditorTabRail } from "../ui/EditorTabRail";
 import { EditorSectionAnchor, EditorSectionJumps } from "../ui/EditorSectionJumps";
 import { SettingsSwitch } from "../panels/settings/SettingControls";
 import {
+  createDefaultRpgStatPools,
   normalizeSpriteExpressionLabel,
+  normalizeRpgStatPools,
+  syncRpgHpFromPools,
   type CharacterCardVersion,
   type CharacterData,
+  type RPGStatPool,
   type RPGStatsConfig,
 } from "@marinara-engine/shared";
 import { parseTrackerCardColorConfig, serializeTrackerCardColorConfig } from "../../lib/tracker-card-colors";
@@ -2786,7 +2790,18 @@ const DEFAULT_RPG_STATS: RPGStatsConfig = {
     { name: "CHA", value: 10 },
   ],
   hp: { value: 100, max: 100 },
+  pools: createDefaultRpgStatPools(),
 };
+
+function createNewRpgPool(existing: readonly RPGStatPool[]): RPGStatPool {
+  const used = new Set(existing.map((pool) => pool.name.trim().toLowerCase()).filter(Boolean));
+  let index = existing.length + 1;
+  let name = `Pool ${index}`;
+  while (used.has(name.toLowerCase())) {
+    name = `Pool ${++index}`;
+  }
+  return { name, value: 100, max: 100, color: "#a78bfa" };
+}
 
 function StatsTab({
   formData,
@@ -2796,9 +2811,22 @@ function StatsTab({
   updateExtension: (key: string, value: unknown) => void;
 }) {
   const stats: RPGStatsConfig = (formData.extensions.rpgStats as RPGStatsConfig) ?? DEFAULT_RPG_STATS;
+  const pools = normalizeRpgStatPools(stats);
 
   const update = (patch: Partial<RPGStatsConfig>) => {
     updateExtension("rpgStats", { ...stats, ...patch });
+  };
+
+  const updatePools = (nextPools: RPGStatPool[]) => {
+    update({
+      pools: nextPools,
+      hp: syncRpgHpFromPools(nextPools, stats.hp),
+    });
+  };
+
+  const updatePool = (index: number, patch: Partial<RPGStatPool>) => {
+    const nextPools = pools.map((pool, poolIndex) => (poolIndex === index ? { ...pool, ...patch } : pool));
+    updatePools(nextPools);
   };
 
   const updateAttribute = (index: number, field: string, value: string | number) => {
@@ -2835,21 +2863,64 @@ function StatsTab({
 
       {stats.enabled && (
         <>
-          {/* HP */}
-          <div className="rounded-xl border border-[var(--border)] bg-[var(--card)] p-4 space-y-3">
-            <div className="flex items-center gap-2">
-              <div className="h-2 w-2 rounded-full bg-red-500" />
-              <span className="text-xs font-semibold">Hit Points (HP)</span>
+          {/* Pools */}
+          <div className="space-y-3">
+            <div className="flex items-center justify-between">
+              <h3 className="text-sm font-semibold">Pools</h3>
+              <button
+                type="button"
+                onClick={() => updatePools([...pools, createNewRpgPool(pools)])}
+                className="mari-chrome-accent-surface mari-accent-animated flex items-center gap-1 rounded-lg px-2.5 py-1 text-[0.6875rem] font-medium transition-colors"
+              >
+                <Plus size="0.75rem" />
+                Add
+              </button>
             </div>
-            <div className="flex items-center gap-2">
-              <span className="text-xs text-[var(--muted-foreground)]">Max:</span>
-              <input
-                type="number"
-                value={stats.hp.max}
-                onChange={(e) => update({ hp: { ...stats.hp, max: parseInt(e.target.value) || 1 } })}
-                className="w-20 rounded-lg border border-[var(--border)] bg-[var(--input)] px-2 py-1.5 text-center text-sm"
-                min={1}
-              />
+            <div className="space-y-2">
+              {pools.map((pool, i) => (
+                <div
+                  key={i}
+                  className="grid gap-2 rounded-xl border border-[var(--border)] bg-[var(--card)] px-3 py-2 sm:grid-cols-[2rem_minmax(0,1fr)_5rem_5rem_auto] sm:items-center"
+                >
+                  <input
+                    type="color"
+                    value={pool.color}
+                    onChange={(e) => updatePool(i, { color: e.target.value })}
+                    className="h-8 w-8 rounded border border-[var(--border)] bg-transparent p-0.5"
+                    aria-label={`${pool.name || "Pool"} color`}
+                  />
+                  <input
+                    value={pool.name}
+                    onChange={(e) => updatePool(i, { name: e.target.value })}
+                    className="min-w-0 rounded-lg border border-[var(--border)] bg-[var(--input)] px-2 py-1 text-xs font-medium"
+                    placeholder="Name"
+                  />
+                  <input
+                    type="number"
+                    value={pool.value}
+                    onChange={(e) => updatePool(i, { value: Math.max(0, parseInt(e.target.value) || 0) })}
+                    className="w-full rounded-lg border border-[var(--border)] bg-[var(--input)] px-2 py-1 text-center text-xs"
+                    min={0}
+                    aria-label={`${pool.name || "Pool"} value`}
+                  />
+                  <input
+                    type="number"
+                    value={pool.max}
+                    onChange={(e) => updatePool(i, { max: Math.max(1, parseInt(e.target.value) || 1) })}
+                    className="w-full rounded-lg border border-[var(--border)] bg-[var(--input)] px-2 py-1 text-center text-xs"
+                    min={1}
+                    aria-label={`${pool.name || "Pool"} max`}
+                  />
+                  <button
+                    type="button"
+                    onClick={() => updatePools(pools.filter((_, poolIndex) => poolIndex !== i))}
+                    className="rounded-lg p-1 text-[var(--muted-foreground)] transition-colors hover:bg-red-500/15 hover:text-red-400"
+                    aria-label={`Remove ${pool.name || "pool"}`}
+                  >
+                    <X size="0.75rem" />
+                  </button>
+                </div>
+              ))}
             </div>
           </div>
 

--- a/packages/client/src/components/chat/ChatRoleplayPanels.tsx
+++ b/packages/client/src/components/chat/ChatRoleplayPanels.tsx
@@ -280,22 +280,25 @@ export function AuthorNotesPanel({
   const [depthStr, setDepthStr] = useState(String((chatMeta.authorNotesDepth as number) ?? 4));
   const updateMeta = useUpdateChatMetadata();
 
-  const latestRef = useRef({ notes, depthStr });
-  latestRef.current = { notes, depthStr };
-  const baselineRef = useRef({
+  const initialBaseline = {
     notes: (chatMeta.authorNotes as string) ?? "",
     depth: (chatMeta.authorNotesDepth as number) ?? 4,
-  });
+  };
+  const latestByChatRef = useRef(new Map<string, { notes: string; depthStr: string }>([[chatId, { notes, depthStr }]]));
+  latestByChatRef.current.set(chatId, { notes, depthStr });
+  const baselineByChatRef = useRef(new Map<string, { notes: string; depth: number }>([[chatId, initialBaseline]]));
   const mutateRef = useRef(updateMeta.mutate);
   mutateRef.current = updateMeta.mutate;
 
   useEffect(() => {
-    setNotes((chatMeta.authorNotes as string) ?? "");
-    setDepthStr(String((chatMeta.authorNotesDepth as number) ?? 4));
-    baselineRef.current = {
+    const nextBaseline = {
       notes: (chatMeta.authorNotes as string) ?? "",
       depth: (chatMeta.authorNotesDepth as number) ?? 4,
     };
+    setNotes(nextBaseline.notes);
+    setDepthStr(String(nextBaseline.depth));
+    baselineByChatRef.current.set(chatId, nextBaseline);
+    latestByChatRef.current.set(chatId, { notes: nextBaseline.notes, depthStr: String(nextBaseline.depth) });
   }, [chatId, chatMeta.authorNotes, chatMeta.authorNotesDepth]);
 
   // Outside-click closes the popover via mousedown, which unmounts the
@@ -303,13 +306,19 @@ export function AuthorNotesPanel({
   // the pending edit from the unmount cleanup so typed content survives.
   useEffect(() => {
     const capturedChatId = chatId;
+    const latestByChat = latestByChatRef.current;
+    const baselineByChat = baselineByChatRef.current;
+    const snapshot = latestByChat.get(capturedChatId) ?? { notes: "", depthStr: "4" };
+    const baselineSnapshot = baselineByChat.get(capturedChatId) ?? { notes: "", depth: 4 };
     return () => {
-      const { notes: n, depthStr: d } = latestRef.current;
+      const { notes: n, depthStr: d } = latestByChat.get(capturedChatId) ?? snapshot;
       const nextDepth = Math.max(0, parseInt(d, 10) || 0);
-      const base = baselineRef.current;
+      const base = baselineByChat.get(capturedChatId) ?? baselineSnapshot;
       if (n !== base.notes || nextDepth !== base.depth) {
         mutateRef.current({ id: capturedChatId, authorNotes: n, authorNotesDepth: nextDepth });
       }
+      latestByChat.delete(capturedChatId);
+      baselineByChat.delete(capturedChatId);
     };
   }, [chatId]);
 

--- a/packages/client/src/components/chat/ChatSettingsDrawer.tsx
+++ b/packages/client/src/components/chat/ChatSettingsDrawer.tsx
@@ -6902,7 +6902,7 @@ export function ChatSettingsDrawer({
               <div className="space-y-3">
                 <GameWidgetSetupEditor
                   widgets={gameWidgetDrafts}
-                  onChange={(widgets) => setGameWidgetDrafts(normalizeGameHudWidgets(widgets))}
+                  onChange={(widgets) => setGameWidgetDrafts(normalizeGameHudWidgets(widgets, { mode: "draft" }))}
                   disabled={updateGameWidgets.isPending}
                 />
                 <div className="flex flex-wrap items-center justify-end gap-2">

--- a/packages/client/src/components/chat/HomeFaq.tsx
+++ b/packages/client/src/components/chat/HomeFaq.tsx
@@ -19,6 +19,18 @@ const QUICK_FIXES = [
 
 const HOME_FAQ_ITEMS: HomeFaqItem[] = [
   {
+    id: "connect-model",
+    category: "Top Issue",
+    question: "How do I connect Marinara to a model?",
+    answer: "Create a connection first, test it, then select it for the chat before you send a message.",
+    bullets: [
+      "Open Connections from the top bar, create a new connection, choose your provider, then fill in the API key, base URL if needed, and model name.",
+      "Use Test Connection before saving. If the test fails, check the key, provider route, base URL, and model spelling before changing chat settings.",
+      "After saving, pick that connection from the chains icon on the left side of the chat input, or set it in Chat Settings for that chat.",
+      "For local models, make sure the local server or Marinara Local Model sidecar is running first. The bundled Local Model is best for helpers and trackers, not main roleplay generation.",
+    ],
+  },
+  {
     id: "game-mode-model",
     category: "Top Issue",
     question: "What model should I use for Game Mode?",

--- a/packages/client/src/components/chat/HomeFaq.tsx
+++ b/packages/client/src/components/chat/HomeFaq.tsx
@@ -609,16 +609,16 @@ export function HomeFaq({
                         aria-expanded={isOpen}
                       >
                         <div className="min-w-0 flex-1">
-                          <div className="flex flex-wrap items-center gap-1.5">
+                          <div className="flex items-start gap-1.5">
                             <span
                               className={cn(
-                                "shrink-0 rounded-full border px-1.5 py-0.5 text-[0.5rem] font-medium uppercase tracking-[0.12em]",
+                                "mt-[0.0625rem] shrink-0 rounded-full border px-1.5 py-0.5 text-[0.5rem] font-medium uppercase tracking-[0.12em]",
                                 CATEGORY_STYLES[item.category] ?? CATEGORY_STYLES.Misc,
                               )}
                             >
                               {item.category}
                             </span>
-                            <span className="min-w-0 text-[0.6875rem] font-medium leading-snug text-[var(--foreground)]">
+                            <span className="min-w-0 flex-1 break-words text-[0.6875rem] font-medium leading-snug text-[var(--foreground)]">
                               {item.question}
                             </span>
                           </div>
@@ -785,16 +785,16 @@ export function HomeFaq({
                         aria-expanded={isOpen}
                       >
                         <div className="min-w-0 flex-1">
-                          <div className="flex flex-wrap items-center gap-2">
+                          <div className="flex items-start gap-2">
                             <span
                               className={cn(
-                                "shrink-0 rounded-full border px-2 py-0.5 text-[0.5625rem] font-medium uppercase tracking-[0.16em]",
+                                "mt-[0.0625rem] shrink-0 rounded-full border px-2 py-0.5 text-[0.5625rem] font-medium uppercase tracking-[0.16em]",
                                 CATEGORY_STYLES[item.category] ?? CATEGORY_STYLES.Misc,
                               )}
                             >
                               {item.category}
                             </span>
-                            <span className="min-w-0 text-[0.75rem] font-medium leading-relaxed text-[var(--foreground)]">
+                            <span className="min-w-0 flex-1 break-words text-[0.75rem] font-medium leading-relaxed text-[var(--foreground)]">
                               {item.question}
                             </span>
                           </div>

--- a/packages/client/src/components/chat/PeekPromptModal.tsx
+++ b/packages/client/src/components/chat/PeekPromptModal.tsx
@@ -94,6 +94,12 @@ interface ChatHistoryBlock {
 
 type DisplaySection = SectionBlock | ChatHistoryBlock;
 
+interface PromptSegment {
+  role: string;
+  content: string;
+  inChatHistory: boolean;
+}
+
 function isDisplayedChatHistoryRole(role: string): boolean {
   return role === "user" || role === "assistant";
 }
@@ -136,133 +142,131 @@ function parseXmlSections(content: string, fallbackLabel: string): SectionBlock[
   return blocks.length > 0 ? blocks : [{ kind: "section", label: fallbackLabel, role: fallbackLabel, content }];
 }
 
-/**
- * Build the display section list from the raw messages array.
- *
- * The key challenge: `<chat_history>` opens in one message and closes in another,
- * with bare user/assistant messages in between. We detect boundaries at the
- * array level first, then handle each region appropriately.
- */
+function splitPromptSegments(messages: Array<{ role: string; content: string }>): PromptSegment[] {
+  const segments: PromptSegment[] = [];
+  let inXmlChatHistory = false;
+  let inMarkdownChatHistory = false;
+
+  const pushSegment = (role: string, content: string, inChatHistory: boolean) => {
+    if (!content.trim()) return;
+    segments.push({ role, content: content.trim(), inChatHistory });
+  };
+
+  for (const message of messages) {
+    let remaining = message.content;
+
+    while (remaining.length > 0) {
+      if (inXmlChatHistory) {
+        const closeIdx = remaining.search(/\n?<\/chat_history>/i);
+        if (closeIdx >= 0) {
+          const closeMatch = remaining.slice(closeIdx).match(/^\n?<\/chat_history>/i);
+          pushSegment(message.role, remaining.slice(0, closeIdx), true);
+          remaining = remaining.slice(closeIdx + (closeMatch?.[0].length ?? 0));
+          inXmlChatHistory = false;
+          continue;
+        }
+        pushSegment(message.role, remaining, true);
+        break;
+      }
+
+      if (inMarkdownChatHistory) {
+        const lastMessageIdx = remaining.search(/^## Last Message\n?/im);
+        if (lastMessageIdx >= 0) {
+          pushSegment(message.role, remaining.slice(0, lastMessageIdx), true);
+          remaining = remaining.slice(lastMessageIdx);
+          inMarkdownChatHistory = false;
+          continue;
+        }
+        pushSegment(message.role, remaining, true);
+        break;
+      }
+
+      const xmlOpenIdx = remaining.search(/<chat_history>\n?/i);
+      const markdownOpenIdx = remaining.search(/^## Chat History\n?/im);
+      const hasXmlOpen = xmlOpenIdx >= 0;
+      const hasMarkdownOpen = markdownOpenIdx >= 0;
+      const useXmlOpen = hasXmlOpen && (!hasMarkdownOpen || xmlOpenIdx <= markdownOpenIdx);
+      const openIdx = useXmlOpen ? xmlOpenIdx : markdownOpenIdx;
+
+      if (openIdx >= 0) {
+        pushSegment(message.role, remaining.slice(0, openIdx), false);
+        const openMatch = remaining
+          .slice(openIdx)
+          .match(useXmlOpen ? /<chat_history>\n?/i : /^## Chat History\n?/i);
+        remaining = remaining.slice(openIdx + (openMatch?.[0].length ?? 0));
+        if (useXmlOpen) inXmlChatHistory = true;
+        else inMarkdownChatHistory = true;
+        continue;
+      }
+
+      pushSegment(message.role, remaining, false);
+      break;
+    }
+  }
+
+  return segments;
+}
+
+function appendPromptSection(result: DisplaySection[], segment: PromptSegment) {
+  const openIdx = segment.content.search(/<last_message>/i);
+  const closingIdx = segment.content.search(/<\/last_message>/i);
+  if (openIdx >= 0 && closingIdx >= 0) {
+    const beforeOpen = segment.content.slice(0, openIdx).trim();
+    const innerContent = segment.content.slice(segment.content.indexOf(">", openIdx) + 1, closingIdx).trim();
+    const afterClose = segment.content.slice(segment.content.indexOf(">", closingIdx) + 1).trim();
+
+    if (beforeOpen) {
+      const pre = parseXmlSections(beforeOpen, segment.role);
+      for (const block of pre) result.push(block);
+    }
+    if (innerContent) {
+      result.push({ kind: "section", label: "last_message", role: segment.role, content: innerContent });
+    }
+    if (afterClose) {
+      const post = parseXmlSections(afterClose, segment.role);
+      for (const block of post) result.push(block);
+    }
+    return;
+  }
+
+  if (/^## Last Message\n?/i.test(segment.content)) {
+    result.push({
+      kind: "section",
+      label: "last_message",
+      role: segment.role,
+      content: segment.content.replace(/^## Last Message\n?/i, "").trim(),
+    });
+    return;
+  }
+
+  const blocks = parseXmlSections(segment.content, segment.role);
+  for (const block of blocks) result.push(block);
+}
+
 function buildDisplaySections(messages: Array<{ role: string; content: string }>): DisplaySection[] {
-  // ── Pass 1: find chat history boundaries across the messages array ──
-  let chStartIdx = -1;
-  let chEndIdx = -1;
-  let lastMsgIdx = -1; // <last_message> or ## Last Message
-
-  for (let i = 0; i < messages.length; i++) {
-    const c = messages[i]!.content;
-    if (chStartIdx < 0 && (/<chat_history>/i.test(c) || /^## Chat History\n/i.test(c))) {
-      chStartIdx = i;
-    }
-    if (/<\/chat_history>/i.test(c)) {
-      chEndIdx = i;
-    }
-    if (/<last_message>/i.test(c) || /^## Last Message\n/i.test(c)) {
-      lastMsgIdx = i;
-    }
-  }
-
-  // If we found an opening tag but no explicit close, the history runs until
-  // the message before <last_message>, or to the end of user/assistant messages.
-  if (chStartIdx >= 0 && chEndIdx < 0) {
-    if (lastMsgIdx > chStartIdx) {
-      chEndIdx = lastMsgIdx - 1;
-    } else {
-      // Find the last consecutive user/assistant message after chStartIdx
-      chEndIdx = chStartIdx;
-      for (let i = chStartIdx + 1; i < messages.length; i++) {
-        const r = messages[i]!.role;
-        if (r === "user" || r === "assistant") chEndIdx = i;
-        else break;
-      }
-    }
-  }
-
-  // ── Pass 2: build output sections ──
   const result: DisplaySection[] = [];
+  const historyEntries: ChatHistoryEntry[] = [];
+  const historyRawParts: string[] = [];
 
-  for (let i = 0; i < messages.length; i++) {
-    const msg = messages[i]!;
+  const flushChatHistory = () => {
+    if (historyEntries.length === 0) return;
+    result.push({ kind: "chat-history", entries: [...historyEntries], rawContent: historyRawParts.join("\n\n") });
+    historyEntries.length = 0;
+    historyRawParts.length = 0;
+  };
 
-    // ── Chat history region ──
-    if (chStartIdx >= 0 && i >= chStartIdx && i <= chEndIdx) {
-      // Collect all chat history entries in one pass
-      const entries: ChatHistoryEntry[] = [];
-      const rawParts: string[] = [];
-      for (let j = chStartIdx; j <= chEndIdx; j++) {
-        const entry = messages[j]!;
-        if (!isDisplayedChatHistoryRole(entry.role)) continue;
-
-        let content = entry.content;
-        // Strip the wrapping tags from the content shown inside child blocks
-        content = content
-          .replace(/^<chat_history>\n?/i, "")
-          .replace(/\n?<\/chat_history>\s*$/i, "")
-          .replace(/^## Chat History\n?/i, "");
-        const trimmed = content.trim();
-        if (trimmed) {
-          entries.push({ role: entry.role, content: trimmed });
-          rawParts.push(trimmed);
-        }
-      }
-      if (entries.length > 0) {
-        result.push({ kind: "chat-history", entries, rawContent: rawParts.join("\n\n") });
-      }
-      i = chEndIdx; // skip past the whole range
+  for (const segment of splitPromptSegments(messages)) {
+    if (segment.inChatHistory && isDisplayedChatHistoryRole(segment.role)) {
+      historyEntries.push({ role: segment.role, content: segment.content });
+      historyRawParts.push(segment.content);
       continue;
     }
 
-    // ── Last message (separate from chat history) ──
-    if (i === lastMsgIdx) {
-      // The server may merge <last_message> with adjacent same-role sections
-      // (e.g. <output_format>) when strict role formatting is on.
-      // Split out the <last_message> portion and parse the rest normally.
-      const openIdx = msg.content.search(/<last_message>/i);
-      const closingIdx = msg.content.search(/<\/last_message>/i);
-      if (openIdx >= 0 && closingIdx >= 0) {
-        const beforeOpen = msg.content.slice(0, openIdx).trim();
-        const innerContent = msg.content.slice(msg.content.indexOf(">", openIdx) + 1, closingIdx).trim();
-        const afterClose = msg.content.slice(msg.content.indexOf(">", closingIdx) + 1).trim();
-
-        // Content before <last_message>
-        if (beforeOpen) {
-          const pre = parseXmlSections(beforeOpen, msg.role);
-          for (const b of pre) result.push(b);
-        }
-        // The last_message block itself
-        if (innerContent) {
-          result.push({
-            kind: "section",
-            label: "last_message",
-            role: msg.role,
-            content: innerContent,
-          });
-        }
-        // Content after </last_message> (e.g. <output_format>)
-        if (afterClose) {
-          const post = parseXmlSections(afterClose, msg.role);
-          for (const b of post) result.push(b);
-        }
-      } else {
-        // Markdown format or no tags — strip heading and show as-is
-        const content = msg.content.replace(/^## Last Message\n?/i, "");
-        result.push({
-          kind: "section",
-          label: "last_message",
-          role: msg.role,
-          content: content.trim(),
-        });
-      }
-      continue;
-    }
-
-    // ── System/other messages: parse XML sections within them ──
-    const blocks = parseXmlSections(msg.content, msg.role);
-    for (const b of blocks) {
-      result.push(b);
-    }
+    flushChatHistory();
+    appendPromptSection(result, segment);
   }
 
+  flushChatHistory();
   return result;
 }
 

--- a/packages/client/src/components/game/GameCharacterSheet.tsx
+++ b/packages/client/src/components/game/GameCharacterSheet.tsx
@@ -21,6 +21,12 @@ import {
 import { cn, getAvatarCropStyle, type AvatarCropValue } from "../../lib/utils";
 import { DraftNumberInput } from "../ui/DraftNumberInput";
 import { NEUTRAL_SURFACE_VARIABLES } from "../ui/neutral-surface-styles";
+import {
+  createDefaultRpgStatPools,
+  normalizeRpgStatPools,
+  syncRpgHpFromPools,
+  type RPGStatPool,
+} from "@marinara-engine/shared";
 
 export interface GameCharacterSheetGameCard {
   shortDescription: string;
@@ -32,6 +38,7 @@ export interface GameCharacterSheetGameCard {
   rpgStats?: {
     attributes: Array<{ name: string; value: number }>;
     hp: { value: number; max: number };
+    pools?: RPGStatPool[];
   };
 }
 
@@ -65,6 +72,7 @@ interface GameCardDraft {
   weaknesses: string[];
   extraEntries: Array<{ key: string; value: string }>;
   rpgStatsEnabled: boolean;
+  pools: RPGStatPool[];
   attributes: Array<{ name: string; value: number }>;
   hpValue: number;
   hpMax: number;
@@ -80,6 +88,16 @@ const DEFAULT_ATTRIBUTES = [
   { name: "WIS", value: 10 },
   { name: "CHA", value: 10 },
 ];
+
+function createNewRpgPool(existing: readonly RPGStatPool[]): RPGStatPool {
+  const used = new Set(existing.map((pool) => pool.name.trim().toLowerCase()).filter(Boolean));
+  let index = existing.length + 1;
+  let name = `Pool ${index}`;
+  while (used.has(name.toLowerCase())) {
+    name = `Pool ${++index}`;
+  }
+  return { name, value: 100, max: 100, color: "#a78bfa" };
+}
 
 // Mirrors server's attributeModifier in skill-check.service.ts: floor((score - 10) / 2).
 function formatAttributeModifier(score: number): string {
@@ -156,6 +174,13 @@ function createDraft(gameCard?: GameCharacterSheetGameCard): GameCardDraft {
     rawRpgStats?.hp && typeof rawRpgStats.hp === "object" && !Array.isArray(rawRpgStats.hp)
       ? (rawRpgStats.hp as Record<string, unknown>)
       : undefined;
+  const pools = rawRpgStats
+    ? normalizeRpgStatPools(rawRpgStats as unknown as GameCharacterSheetGameCard["rpgStats"])
+    : createDefaultRpgStatPools();
+  const hp = syncRpgHpFromPools(pools, {
+    value: normalizeNumberValue(rawHp?.value, 100),
+    max: Math.max(1, normalizeNumberValue(rawHp?.max, 100)),
+  });
 
   return {
     shortDescription: normalizeTextValue(rawGameCard?.shortDescription).trim(),
@@ -165,9 +190,10 @@ function createDraft(gameCard?: GameCharacterSheetGameCard): GameCardDraft {
     weaknesses: normalizeDraftListSource(rawGameCard?.weaknesses),
     extraEntries: normalizeDraftExtraEntries(rawGameCard?.extra),
     rpgStatsEnabled: !!rawRpgStats,
+    pools,
     attributes: normalizeDraftAttributes(rawRpgStats?.attributes),
-    hpValue: normalizeNumberValue(rawHp?.value, 100),
-    hpMax: Math.max(1, normalizeNumberValue(rawHp?.max, 100)),
+    hpValue: hp.value,
+    hpMax: hp.max,
   };
 }
 
@@ -201,13 +227,17 @@ function normalizeDraft(draft: GameCardDraft): GameCharacterSheetGameCard | unde
     .filter((attr) => attr.name);
 
   const rpgStats = draft.rpgStatsEnabled
-    ? {
-        attributes,
-        hp: {
-          value: Math.max(0, draft.hpValue),
-          max: Math.max(1, draft.hpMax),
-        },
-      }
+    ? (() => {
+        const pools = normalizeRpgStatPools({
+          hp: { value: Math.max(0, draft.hpValue), max: Math.max(1, draft.hpMax) },
+          pools: draft.pools,
+        });
+        return {
+          attributes,
+          hp: syncRpgHpFromPools(pools, { value: Math.max(0, draft.hpValue), max: Math.max(1, draft.hpMax) }),
+          pools,
+        };
+      })()
     : undefined;
 
   const hasContent =
@@ -280,11 +310,9 @@ export function GameCharacterSheet({
     previewGameCard?.rpgStats &&
     Array.isArray(previewGameCard.rpgStats.attributes) &&
     previewGameCard.rpgStats.attributes.length > 0;
-  const hasRpgHp =
-    previewGameCard?.rpgStats?.hp &&
-    (Number.isFinite(Number(previewGameCard.rpgStats.hp.value)) ||
-      Number.isFinite(Number(previewGameCard.rpgStats.hp.max)));
-  const hasRpgStats = Boolean(hasRpgAttributes || hasRpgHp);
+  const previewRpgPools = previewGameCard?.rpgStats ? normalizeRpgStatPools(previewGameCard.rpgStats) : [];
+  const hasRpgPools = previewRpgPools.length > 0;
+  const hasRpgStats = Boolean(hasRpgAttributes || hasRpgPools);
   const hasPersistentSheetData = hasGameData(previewGameCard) || hasRpgStats;
   const hasAnyData =
     hasPersistentSheetData ||
@@ -358,6 +386,27 @@ export function GameCharacterSheet({
     setDraft((prev) => {
       const next = prev.attributes.filter((_, attrIndex) => attrIndex !== index);
       return { ...prev, attributes: next.length > 0 ? next : DEFAULT_ATTRIBUTES.map((attr) => ({ ...attr })) };
+    });
+  };
+
+  const updatePool = (index: number, patch: Partial<RPGStatPool>) => {
+    setDraft((prev) => {
+      const pools = prev.pools.map((pool, poolIndex) => (poolIndex === index ? { ...pool, ...patch } : pool));
+      const hp = syncRpgHpFromPools(pools, { value: prev.hpValue, max: prev.hpMax });
+      return { ...prev, pools, hpValue: hp.value, hpMax: hp.max };
+    });
+  };
+
+  const addPool = () => {
+    setDraft((prev) => ({ ...prev, pools: [...prev.pools, createNewRpgPool(prev.pools)] }));
+  };
+
+  const removePool = (index: number) => {
+    setDraft((prev) => {
+      const pools = prev.pools.filter((_, poolIndex) => poolIndex !== index);
+      const nextPools = pools.length > 0 ? pools : createDefaultRpgStatPools();
+      const hp = syncRpgHpFromPools(nextPools, { value: prev.hpValue, max: prev.hpMax });
+      return { ...prev, pools: nextPools, hpValue: hp.value, hpMax: hp.max };
     });
   };
 
@@ -569,27 +618,61 @@ export function GameCharacterSheet({
                 </div>
                 {draft.rpgStatsEnabled ? (
                   <div className="space-y-3">
-                    <div className="grid grid-cols-2 gap-3">
-                      <label className="block space-y-1.5">
-                        <span className={FIELD_LABEL_CLASS}>Current HP</span>
-                        <DraftNumberInput
-                          value={draft.hpValue}
-                          onCommit={(value) => setDraft((prev) => ({ ...prev, hpValue: value }))}
-                          min={0}
-                          selectOnFocus
-                          className={NUMBER_INPUT_CLASS}
-                        />
-                      </label>
-                      <label className="block space-y-1.5">
-                        <span className={FIELD_LABEL_CLASS}>Max HP</span>
-                        <DraftNumberInput
-                          value={draft.hpMax}
-                          min={1}
-                          onCommit={(value) => setDraft((prev) => ({ ...prev, hpMax: Math.max(1, value) }))}
-                          selectOnFocus
-                          className={NUMBER_INPUT_CLASS}
-                        />
-                      </label>
+                    <div className="space-y-2">
+                      <div className="flex items-center justify-between gap-2">
+                        <span className={FIELD_LABEL_CLASS}>Pools</span>
+                        <button
+                          onClick={addPool}
+                          className="inline-flex items-center gap-1.5 rounded-lg border border-dashed border-[var(--marinara-chat-chrome-panel-border)] px-3 py-1.5 text-xs text-[var(--muted-foreground)] transition-colors hover:bg-[var(--marinara-chat-chrome-highlight-bg)] hover:text-[var(--foreground)]"
+                        >
+                          <Plus size={13} />
+                          Add Pool
+                        </button>
+                      </div>
+                      {draft.pools.map((pool, index) => (
+                        <div
+                          key={`${pool.name}-${index}`}
+                          className="grid grid-cols-[2rem_minmax(0,1fr)_5rem_5rem_auto] gap-2 max-sm:grid-cols-1"
+                        >
+                          <input
+                            type="color"
+                            value={pool.color}
+                            onChange={(e) => updatePool(index, { color: e.target.value })}
+                            className="h-9 w-8 rounded border border-[var(--marinara-chat-chrome-panel-border)] bg-transparent p-0.5 max-sm:w-full"
+                            aria-label={`${pool.name || "Pool"} color`}
+                          />
+                          <input
+                            type="text"
+                            value={pool.name}
+                            onChange={(e) => updatePool(index, { name: e.target.value })}
+                            placeholder="HP"
+                            className={TEXT_INPUT_CLASS}
+                          />
+                          <DraftNumberInput
+                            value={pool.value}
+                            onCommit={(value) => updatePool(index, { value: Math.max(0, value) })}
+                            min={0}
+                            selectOnFocus
+                            ariaLabel={`${pool.name || "Pool"} value`}
+                            className={NUMBER_INPUT_CLASS}
+                          />
+                          <DraftNumberInput
+                            value={pool.max}
+                            min={1}
+                            onCommit={(value) => updatePool(index, { max: Math.max(1, value) })}
+                            selectOnFocus
+                            ariaLabel={`${pool.name || "Pool"} max`}
+                            className={NUMBER_INPUT_CLASS}
+                          />
+                          <button
+                            onClick={() => removePool(index)}
+                            className="inline-flex items-center justify-center rounded-lg border border-[var(--marinara-chat-chrome-panel-border)] px-2 text-[var(--muted-foreground)] transition-colors hover:bg-[var(--marinara-chat-chrome-highlight-bg)] hover:text-red-400 max-sm:h-9"
+                            title="Remove pool"
+                          >
+                            <Trash2 size={13} />
+                          </button>
+                        </div>
+                      ))}
                     </div>
                     <div className="space-y-2">
                       {draft.attributes.map((attr, index) => (
@@ -823,30 +906,33 @@ export function GameCharacterSheet({
                   ))}
                 </div>
               )}
-              {hasRpgHp &&
-                (() => {
-                  const hpMax = Math.max(1, Number(previewGameCard.rpgStats.hp.max) || 1);
-                  const hpValue = Math.max(0, Math.min(hpMax, Number(previewGameCard.rpgStats.hp.value) || 0));
-                  return (
-                    <div>
-                      <div className="mb-0.5 flex items-center justify-between text-xs">
-                        <span className="font-medium text-[var(--foreground)]/80">HP</span>
-                        <span className="font-mono text-[var(--muted-foreground)]">
-                          {hpValue}/{hpMax}
-                        </span>
+              {hasRpgPools && (
+                <div className="space-y-2">
+                  {previewRpgPools.map((pool) => {
+                    const poolMax = Math.max(1, Number(pool.max) || 1);
+                    const poolValue = Math.max(0, Math.min(poolMax, Number(pool.value) || 0));
+                    return (
+                      <div key={pool.name}>
+                        <div className="mb-0.5 flex items-center justify-between text-xs">
+                          <span className="font-medium text-[var(--foreground)]/80">{pool.name}</span>
+                          <span className="font-mono text-[var(--muted-foreground)]">
+                            {poolValue}/{poolMax}
+                          </span>
+                        </div>
+                        <div className="h-2.5 overflow-hidden rounded-full bg-[var(--marinara-chat-chrome-highlight-bg)] ring-1 ring-[var(--marinara-chat-chrome-panel-border)]">
+                          <div
+                            className="h-full rounded-full transition-all"
+                            style={{
+                              width: `${(poolValue / poolMax) * 100}%`,
+                              background: pool.color,
+                            }}
+                          />
+                        </div>
                       </div>
-                      <div className="h-2.5 overflow-hidden rounded-full bg-[var(--marinara-chat-chrome-highlight-bg)] ring-1 ring-[var(--marinara-chat-chrome-panel-border)]">
-                        <div
-                          className="h-full rounded-full transition-all"
-                          style={{
-                            width: `${(hpValue / hpMax) * 100}%`,
-                            background: "#ef4444",
-                          }}
-                        />
-                      </div>
-                    </div>
-                  );
-                })()}
+                    );
+                  })}
+                </div>
+              )}
             </div>
           )}
 

--- a/packages/client/src/components/game/GameSurface.tsx
+++ b/packages/client/src/components/game/GameSurface.tsx
@@ -110,6 +110,7 @@ import type { SceneSegmentEffect } from "@marinara-engine/shared";
 import {
   PROFESSOR_MARI_ID,
   formatTextQuotes,
+  normalizeRpgStatPools,
   normalizeTextForMatch,
   scoreMusic,
   scoreAmbient,
@@ -7063,6 +7064,7 @@ function GameSurfaceComponent({
           rpgStats?: {
             attributes: Array<{ name: string; value: number }>;
             hp: { value: number; max: number };
+            pools?: import("@marinara-engine/shared").RPGStatPool[];
           };
         };
       }
@@ -7102,7 +7104,11 @@ function GameSurfaceComponent({
               weaknesses: (gc.weaknesses as string[]) || [],
               extra: (gc.extra as Record<string, string>) || {},
               rpgStats: gc.rpgStats as
-                | { attributes: Array<{ name: string; value: number }>; hp: { value: number; max: number } }
+                | {
+                    attributes: Array<{ name: string; value: number }>;
+                    hp: { value: number; max: number };
+                    pools?: import("@marinara-engine/shared").RPGStatPool[];
+                  }
                 | undefined,
             }
           : undefined,
@@ -7248,6 +7254,7 @@ function GameSurfaceComponent({
                       value: Math.max(0, Number(gameCard.rpgStats.hp.value) || 0),
                       max: Math.max(1, Number(gameCard.rpgStats.hp.max) || 1),
                     },
+                    pools: normalizeRpgStatPools(gameCard.rpgStats),
                   },
                 }
               : {}),

--- a/packages/client/src/components/game/GameWidgetSetupEditor.tsx
+++ b/packages/client/src/components/game/GameWidgetSetupEditor.tsx
@@ -53,6 +53,10 @@ const DEFAULT_ICONS: Record<HudWidgetType, string> = {
 const WIDGET_NUMBER_INPUT_CLASS =
   "w-full rounded-lg border border-transparent bg-[var(--secondary)] px-2.5 py-2 text-xs text-[var(--foreground)] outline-none transition-colors focus:border-[var(--primary)]/40";
 
+interface NormalizeGameHudWidgetsOptions {
+  mode?: "persisted" | "draft";
+}
+
 function isHudWidgetType(value: unknown): value is HudWidgetType {
   return (
     value === "progress_bar" ||
@@ -175,9 +179,14 @@ function defaultWidgetConfig(type: HudWidgetType): HudWidgetConfig {
   }
 }
 
-function normalizeConfig(type: HudWidgetType, config: unknown): HudWidgetConfig {
+function normalizeConfig(
+  type: HudWidgetType,
+  config: unknown,
+  options: NormalizeGameHudWidgetsOptions = {},
+): HudWidgetConfig {
   const source = config && typeof config === "object" && !Array.isArray(config) ? (config as HudWidgetConfig) : {};
   const fallback = defaultWidgetConfig(type);
+  const draftMode = options.mode === "draft";
 
   if (type === "progress_bar" || type === "gauge" || type === "relationship_meter") {
     const max = parseNumber(source.max, fallback.max ?? 100, 1);
@@ -200,11 +209,13 @@ function normalizeConfig(type: HudWidgetType, config: unknown): HudWidgetConfig 
           .map((stat) => {
             const rawValue = (stat as { value?: unknown }).value;
             return {
-              name: String((stat as { name?: unknown }).name ?? "").trim(),
+              name: draftMode
+                ? String((stat as { name?: unknown }).name ?? "")
+                : String((stat as { name?: unknown }).name ?? "").trim(),
               value: typeof rawValue === "number" || typeof rawValue === "string" ? rawValue : "",
             };
           })
-          .filter((stat) => stat.name)
+          .filter((stat) => draftMode || stat.name)
       : (fallback.stats ?? []);
     return { ...source, stats };
   }
@@ -248,16 +259,18 @@ export function createDefaultGameHudWidget(type: HudWidgetType, widgets: readonl
   };
 }
 
-export function normalizeGameHudWidgets(value: unknown): HudWidget[] {
+export function normalizeGameHudWidgets(value: unknown, options: NormalizeGameHudWidgetsOptions = {}): HudWidget[] {
   if (!Array.isArray(value)) return [];
   const normalized: HudWidget[] = [];
   const usedIds = new Set<string>();
+  const draftMode = options.mode === "draft";
 
   for (const entry of value) {
     if (!entry || typeof entry !== "object" || normalized.length >= MAX_GAME_SETUP_WIDGETS) continue;
     const raw = entry as Partial<HudWidget>;
     const type = isHudWidgetType(raw.type) ? raw.type : "progress_bar";
-    const label = typeof raw.label === "string" && raw.label.trim() ? raw.label.trim() : formatWidgetTypeLabel(type);
+    const rawLabel = typeof raw.label === "string" ? raw.label : "";
+    const label = draftMode ? rawLabel : rawLabel.trim() || formatWidgetTypeLabel(type);
     const preferredId = typeof raw.id === "string" && raw.id.trim() ? raw.id.trim() : nextWidgetId(label, normalized);
     const id = usedIds.has(preferredId) ? nextWidgetId(label, normalized) : preferredId;
     usedIds.add(id);
@@ -268,7 +281,7 @@ export function normalizeGameHudWidgets(value: unknown): HudWidget[] {
       icon: typeof raw.icon === "string" ? raw.icon.slice(0, 8) : DEFAULT_ICONS[type],
       position: raw.position === "hud_right" ? "hud_right" : "hud_left",
       accent: typeof raw.accent === "string" && raw.accent.trim() ? raw.accent.trim() : DEFAULT_ACCENTS[type],
-      config: normalizeConfig(type, raw.config),
+      config: normalizeConfig(type, raw.config, options),
     });
   }
 
@@ -347,7 +360,7 @@ export function GameWidgetFileControls({
   importSuccessMessage,
 }: GameWidgetFileControlsProps) {
   const inputRef = useRef<HTMLInputElement | null>(null);
-  const normalizedWidgets = useMemo(() => normalizeGameHudWidgets(widgets), [widgets]);
+  const normalizedWidgets = useMemo(() => normalizeGameHudWidgets(widgets, { mode: "draft" }), [widgets]);
   const canExport = normalizedWidgets.length > 0 && !disabled;
 
   const handleImport = async (file: File | undefined) => {
@@ -427,7 +440,7 @@ export function GameWidgetSetupEditor({ widgets, onChange, disabled, className }
     onChange(
       normalizedWidgets.map((widget) =>
         widget.id === widgetId
-          ? { ...widget, config: normalizeConfig(widget.type, { ...widget.config, ...patch }) }
+          ? { ...widget, config: normalizeConfig(widget.type, { ...widget.config, ...patch }, { mode: "draft" }) }
           : widget,
       ),
     );
@@ -517,7 +530,7 @@ export function GameWidgetSetupEditor({ widgets, onChange, disabled, className }
                   onClick={() => onChange(normalizedWidgets.filter((entry) => entry.id !== widget.id))}
                   disabled={disabled}
                   className="inline-flex h-9 items-center justify-center rounded-lg border border-[var(--destructive)]/25 px-3 text-[var(--destructive)] transition-colors hover:bg-[var(--destructive)]/10 disabled:opacity-50"
-                  aria-label={`Remove ${widget.label}`}
+                  aria-label={`Remove ${widget.label.trim() || formatWidgetTypeLabel(widget.type)}`}
                 >
                   <Trash2 size="0.875rem" />
                 </button>

--- a/packages/client/src/components/layout/TopBar.tsx
+++ b/packages/client/src/components/layout/TopBar.tsx
@@ -6,7 +6,6 @@ import type { LucideIcon } from "lucide-react";
 import { useCallback, useEffect, useRef, useState, type PointerEvent as ReactPointerEvent } from "react";
 import { useUIStore } from "../../stores/ui.store";
 import { useChatStore } from "../../stores/chat.store";
-import { useAgentStore } from "../../stores/agent.store";
 import { cn } from "../../lib/utils";
 import { SpotifyMiniPlayer } from "../spotify/SpotifyMiniPlayer";
 import { YouTubePlayer } from "../chat/YouTubePlayer";
@@ -92,7 +91,6 @@ export function TopBar() {
   const botBrowserOpen = useUIStore((s) => s.botBrowserOpen);
   const gameAssetsBrowserOpen = useUIStore((s) => s.gameAssetsBrowserOpen);
   const characterLibraryOpen = useUIStore((s) => s.characterLibraryOpen);
-  const failedAgentCount = useAgentStore((s) => s.failedAgentTypes.length);
   const headerRef = useRef<HTMLElement | null>(null);
   const leftControlsRef = useRef<HTMLDivElement | null>(null);
   const rightNavRef = useRef<HTMLElement | null>(null);
@@ -377,9 +375,6 @@ export function TopBar() {
                     underlineClass ?? cn("mari-panel-gradient-surface", gradientClass),
                   )}
                 />
-              )}
-              {panel === "agents" && failedAgentCount > 0 && (
-                <span className="absolute -right-0.5 -top-0.5 h-2 w-2 rounded-full bg-amber-500 ring-1 ring-[var(--card)]" />
               )}
             </button>
           );

--- a/packages/client/src/components/personas/PersonaEditor.tsx
+++ b/packages/client/src/components/personas/PersonaEditor.tsx
@@ -85,10 +85,14 @@ import { EditorTabRail } from "../ui/EditorTabRail";
 import { EditorSectionAnchor, EditorSectionJumps } from "../ui/EditorSectionJumps";
 import { SettingsSwitch } from "../panels/settings/SettingControls";
 import {
+  createDefaultRpgStatPools,
   normalizeSpriteExpressionLabel,
+  normalizeRpgStatPools,
+  syncRpgHpFromPools,
   type CharacterData,
   type PersonaCardSnapshot,
   type PersonaCardVersion,
+  type RPGStatPool,
   type RPGStatsConfig,
   type TrackerCardColorConfig,
 } from "@marinara-engine/shared";
@@ -1871,24 +1875,13 @@ interface PersonaStatBar {
   color: string;
 }
 
-interface PersonaRPGAttribute {
-  name: string;
-  value: number;
-}
-
-interface PersonaRPGStats {
-  enabled: boolean;
-  attributes: PersonaRPGAttribute[];
-  hp: { value: number; max: number };
-}
-
 interface PersonaStatsData {
   enabled: boolean;
   bars: PersonaStatBar[];
-  rpgStats?: PersonaRPGStats;
+  rpgStats?: RPGStatsConfig;
 }
 
-const DEFAULT_RPG_STATS: PersonaRPGStats = {
+const DEFAULT_RPG_STATS: RPGStatsConfig = {
   enabled: false,
   attributes: [
     { name: "STR", value: 10 },
@@ -1899,6 +1892,7 @@ const DEFAULT_RPG_STATS: PersonaRPGStats = {
     { name: "CHA", value: 10 },
   ],
   hp: { value: 100, max: 100 },
+  pools: createDefaultRpgStatPools(),
 };
 
 const DEFAULT_PERSONA_STATS: PersonaStatsData = {
@@ -1911,6 +1905,16 @@ const DEFAULT_PERSONA_STATS: PersonaStatsData = {
   ],
   rpgStats: DEFAULT_RPG_STATS,
 };
+
+function createNewRpgPool(existing: readonly RPGStatPool[]): RPGStatPool {
+  const used = new Set(existing.map((pool) => pool.name.trim().toLowerCase()).filter(Boolean));
+  let index = existing.length + 1;
+  let name = `Pool ${index}`;
+  while (used.has(name.toLowerCase())) {
+    name = `Pool ${++index}`;
+  }
+  return { name, value: 100, max: 100, color: "#a78bfa" };
+}
 
 function PersonaStatsTab({
   formData,
@@ -1951,10 +1955,22 @@ function PersonaStatsTab({
   };
 
   // RPG Attributes helpers
-  const rpgStats: PersonaRPGStats = parsed.rpgStats ?? DEFAULT_RPG_STATS;
+  const rpgStats: RPGStatsConfig = parsed.rpgStats ?? DEFAULT_RPG_STATS;
+  const rpgPools = normalizeRpgStatPools(rpgStats);
 
-  const updateRpg = (patch: Partial<PersonaRPGStats>) => {
+  const updateRpg = (patch: Partial<RPGStatsConfig>) => {
     save({ ...parsed, rpgStats: { ...rpgStats, ...patch } });
+  };
+
+  const updateRpgPools = (nextPools: RPGStatPool[]) => {
+    updateRpg({
+      pools: nextPools,
+      hp: syncRpgHpFromPools(nextPools, rpgStats.hp),
+    });
+  };
+
+  const updateRpgPool = (index: number, patch: Partial<RPGStatPool>) => {
+    updateRpgPools(rpgPools.map((pool, poolIndex) => (poolIndex === index ? { ...pool, ...patch } : pool)));
   };
 
   const updateRpgAttribute = (index: number, field: string, value: string | number) => {
@@ -2065,21 +2081,64 @@ function PersonaStatsTab({
 
         {rpgStats.enabled && (
           <>
-            {/* HP */}
-            <div className="mt-4 rounded-xl border border-[var(--border)] bg-[var(--card)] p-4 space-y-3">
-              <div className="flex items-center gap-2">
-                <div className="h-2 w-2 rounded-full bg-red-500" />
-                <span className="text-xs font-semibold">Hit Points (HP)</span>
+            {/* Pools */}
+            <div className="mt-4 space-y-3">
+              <div className="flex items-center justify-between">
+                <h3 className="text-sm font-semibold">Pools</h3>
+                <button
+                  type="button"
+                  onClick={() => updateRpgPools([...rpgPools, createNewRpgPool(rpgPools)])}
+                  className="mari-chrome-accent-surface mari-accent-animated flex items-center gap-1 rounded-lg px-2.5 py-1 text-[0.6875rem] font-medium transition-colors"
+                >
+                  <Plus size="0.75rem" />
+                  Add
+                </button>
               </div>
-              <div className="flex items-center gap-2">
-                <span className="text-xs text-[var(--muted-foreground)]">Max:</span>
-                <input
-                  type="number"
-                  value={rpgStats.hp.max}
-                  onChange={(e) => updateRpg({ hp: { ...rpgStats.hp, max: parseInt(e.target.value) || 1 } })}
-                  className="w-20 rounded-lg border border-[var(--border)] bg-[var(--input)] px-2 py-1.5 text-center text-sm"
-                  min={1}
-                />
+              <div className="space-y-2">
+                {rpgPools.map((pool, i) => (
+                  <div
+                    key={i}
+                    className="grid gap-2 rounded-xl border border-[var(--border)] bg-[var(--card)] px-3 py-2 sm:grid-cols-[2rem_minmax(0,1fr)_5rem_5rem_auto] sm:items-center"
+                  >
+                    <input
+                      type="color"
+                      value={pool.color}
+                      onChange={(e) => updateRpgPool(i, { color: e.target.value })}
+                      className="h-8 w-8 rounded border border-[var(--border)] bg-transparent p-0.5"
+                      aria-label={`${pool.name || "Pool"} color`}
+                    />
+                    <input
+                      value={pool.name}
+                      onChange={(e) => updateRpgPool(i, { name: e.target.value })}
+                      className="min-w-0 rounded-lg border border-[var(--border)] bg-[var(--input)] px-2 py-1 text-xs font-medium"
+                      placeholder="Name"
+                    />
+                    <input
+                      type="number"
+                      value={pool.value}
+                      onChange={(e) => updateRpgPool(i, { value: Math.max(0, parseInt(e.target.value) || 0) })}
+                      className="w-full rounded-lg border border-[var(--border)] bg-[var(--input)] px-2 py-1 text-center text-xs"
+                      min={0}
+                      aria-label={`${pool.name || "Pool"} value`}
+                    />
+                    <input
+                      type="number"
+                      value={pool.max}
+                      onChange={(e) => updateRpgPool(i, { max: Math.max(1, parseInt(e.target.value) || 1) })}
+                      className="w-full rounded-lg border border-[var(--border)] bg-[var(--input)] px-2 py-1 text-center text-xs"
+                      min={1}
+                      aria-label={`${pool.name || "Pool"} max`}
+                    />
+                    <button
+                      type="button"
+                      onClick={() => updateRpgPools(rpgPools.filter((_, poolIndex) => poolIndex !== i))}
+                      className="rounded-lg p-1 text-[var(--muted-foreground)] transition-colors hover:bg-red-500/15 hover:text-red-400"
+                      aria-label={`Remove ${pool.name || "pool"}`}
+                    >
+                      <X size="0.75rem" />
+                    </button>
+                  </div>
+                ))}
               </div>
             </div>
 

--- a/packages/server/src/app.ts
+++ b/packages/server/src/app.ts
@@ -23,6 +23,7 @@ import { seedDefaultRegexScripts } from "./db/seed-regex.js";
 import { buildAssetManifest, ensureAssetDirs } from "./services/game/asset-manifest.service.js";
 import { recoverGalleryImages } from "./services/storage/gallery-recovery.js";
 import { migrateCharacterExtendedDescriptionsToLorebooks } from "./services/lorebook/extended-descriptions-migration.js";
+import { migrateLegacyDefaultAgentPrompts } from "./services/agents/default-prompt-migration.js";
 import { APP_VERSION } from "@marinara-engine/shared";
 import { existsSync } from "fs";
 import { basename, join, resolve, dirname } from "path";
@@ -97,6 +98,7 @@ export async function buildApp(https?: { cert: Buffer; key: Buffer }) {
     await seedDefaultConnection(db);
   }
   await seedDefaultRegexScripts(db);
+  await migrateLegacyDefaultAgentPrompts(db);
   await migrateCharacterExtendedDescriptionsToLorebooks(db);
   await seedDefaultBackgrounds();
   await seedDefaultGameAssets();

--- a/packages/server/src/routes/chats.routes.ts
+++ b/packages/server/src/routes/chats.routes.ts
@@ -26,6 +26,7 @@ import {
   normalizeTrackerFieldLocks,
   parseTrackerFieldLocks,
   normalizeTextForMatch,
+  formatRpgStatsForPrompt,
 } from "@marinara-engine/shared";
 import type {
   CharacterData,
@@ -37,6 +38,7 @@ import type {
   ExportEnvelope,
   GameNpc,
   LorebookEntryTimingState,
+  RPGStatsConfig,
 } from "@marinara-engine/shared";
 import { createChatsStorage } from "../services/storage/chats.storage.js";
 import { createAgentsStorage } from "../services/storage/agents.storage.js";
@@ -2425,15 +2427,14 @@ export async function chatsRoutes(app: FastifyInstance) {
                 fieldParts.push(wrapContent(resolvePromptMacros(personaFields.scenario), "scenario", wrapFormat, 2));
               // Include enabled RPG attributes
               if (personaStats?.rpgStats?.enabled) {
-                const rpg = personaStats.rpgStats as {
-                  attributes: Array<{ name: string; value: number }>;
-                  hp: { value: number; max: number };
-                };
-                const rpgLines = [`Max HP: ${rpg.hp.max}`];
-                for (const attr of rpg.attributes) {
-                  rpgLines.push(`${attr.name}: ${attr.value}`);
-                }
-                fieldParts.push(wrapContent(rpgLines.join("\n"), "rpg_attributes", wrapFormat, 2));
+                fieldParts.push(
+                  wrapContent(
+                    formatRpgStatsForPrompt(personaStats.rpgStats as RPGStatsConfig),
+                    "rpg_attributes",
+                    wrapFormat,
+                    2,
+                  ),
+                );
               }
               if (fieldParts.length > 0) {
                 const block = wrapContent(fieldParts.join("\n"), personaName, wrapFormat, 1);

--- a/packages/server/src/routes/encounter.routes.ts
+++ b/packages/server/src/routes/encounter.routes.ts
@@ -11,7 +11,7 @@ import { mapSheetAttributesToRPG } from "../services/game/skill-check.service.js
 import { createLLMProvider } from "../services/llm/provider-registry.js";
 import type { ChatMessage } from "../services/llm/base-provider.js";
 import { logger, logDebugOverride } from "../lib/logger.js";
-import { stripMacroComments } from "@marinara-engine/shared";
+import { normalizeRpgStatPools, stripMacroComments } from "@marinara-engine/shared";
 import type {
   EncounterInitRequest,
   EncounterActionRequest,
@@ -22,6 +22,7 @@ import type {
   CombatPlayerActions,
   CombatActionResult,
   EncounterLogEntry,
+  RPGStatsConfig,
 } from "@marinara-engine/shared";
 
 // ──────────────────────────────────────────────
@@ -32,6 +33,15 @@ const COMBAT_BLUEPRINT_OUTPUT_TOKENS = 12000;
 
 function cardPromptText(value: unknown): string {
   return typeof value === "string" ? stripMacroComments(value).trim() : "";
+}
+
+function configuredHpMax(rpgStats: RPGStatsConfig | undefined): number | null {
+  if (!rpgStats?.enabled) return null;
+  const hpPool = normalizeRpgStatPools(rpgStats).find((pool) =>
+    /^(?:hp|health|health points?|hit points?)$/i.test(pool.name.trim()),
+  );
+  const max = Number(hpPool?.max ?? rpgStats.hp?.max);
+  return Number.isFinite(max) && max > 0 ? max : null;
 }
 
 /** Resolve a connection (handles "random" pool + baseUrl fallback). */
@@ -130,9 +140,9 @@ async function buildCharacterContext(chars: ReturnType<typeof createCharactersSt
     // instead of inventing one for allies. Only `max` is exposed because
     // combat should always start at full HP regardless of the card's stale
     // `value` field — narrative damage applies after combat begins.
-    const rpg = data.extensions?.rpgStats;
-    const allyMaxHp = Number(rpg?.hp?.max);
-    if (rpg?.enabled && Number.isFinite(allyMaxHp) && allyMaxHp > 0) {
+    const rpg = data.extensions?.rpgStats as RPGStatsConfig | undefined;
+    const allyMaxHp = configuredHpMax(rpg);
+    if (rpg?.enabled && allyMaxHp) {
       ctx += `Max HP: ${allyMaxHp}\n`;
       if (Array.isArray(rpg.attributes) && rpg.attributes.length > 0) {
         ctx += `Attributes: ${rpg.attributes.map((a: { name: string; value: number }) => `${a.name} ${a.value}`).join(", ")}\n`;
@@ -196,15 +206,9 @@ async function buildPersonaContext(chars: ReturnType<typeof createCharactersStor
       ctx += `Persona Stat Bars (configured max for each):\n${renderedBars.join("")}`;
     }
   }
-  const personaRpg = personaStats?.rpgStats as
-    | {
-        enabled?: boolean;
-        attributes?: Array<{ name: string; value: number }>;
-        hp?: { value: number; max: number };
-      }
-    | undefined;
-  const personaMaxHp = Number(personaRpg?.hp?.max);
-  if (personaRpg?.enabled && Number.isFinite(personaMaxHp) && personaMaxHp > 0) {
+  const personaRpg = personaStats?.rpgStats as RPGStatsConfig | undefined;
+  const personaMaxHp = configuredHpMax(personaRpg);
+  if (personaRpg?.enabled && personaMaxHp) {
     ctx += `Persona RPG Stats:\n`;
     ctx += `- Max HP: ${personaMaxHp}\n`;
     if (Array.isArray(personaRpg.attributes) && personaRpg.attributes.length > 0) {

--- a/packages/server/src/routes/game.routes.ts
+++ b/packages/server/src/routes/game.routes.ts
@@ -101,6 +101,8 @@ import {
   serializeResolvedSkillCheckTag,
   applyTrackerFieldLocksToGameStatePatch,
   parseTrackerFieldLocks,
+  normalizeRpgStatPools,
+  type RPGStatsConfig,
 } from "@marinara-engine/shared";
 import { mergeCustomParameters, parseGameStateRow } from "./generate/generate-route-utils.js";
 import {
@@ -1016,7 +1018,7 @@ function buildNpcRecruitCharacterSourceCard(npc: Pick<GameNpc, "name" | "descrip
 }
 
 function extractRecruitCharacterRpgStats(characterData: Record<string, any>) {
-  const rpgStats = characterData.extensions?.rpgStats;
+  const rpgStats = characterData.extensions?.rpgStats as RPGStatsConfig | undefined;
   if (!rpgStats?.enabled || !Array.isArray(rpgStats.attributes) || !rpgStats.hp) return undefined;
 
   return {
@@ -1030,6 +1032,7 @@ function extractRecruitCharacterRpgStats(characterData: Record<string, any>) {
       value: Math.max(0, Number(rpgStats.hp.max) || 0),
       max: Math.max(1, Number(rpgStats.hp.max) || 1),
     },
+    pools: normalizeRpgStatPools(rpgStats),
   };
 }
 
@@ -3337,15 +3340,8 @@ export async function gameRoutes(app: FastifyInstance) {
   };
 
   type SetupRpgContext = {
-    partyRpgStats: Record<
-      string,
-      { enabled: boolean; attributes: Array<{ name: string; value: number }>; hp: { value: number; max: number } }
-    >;
-    personaRpgStats: {
-      enabled: boolean;
-      attributes: Array<{ name: string; value: number }>;
-      hp: { value: number; max: number };
-    } | null;
+    partyRpgStats: Record<string, RPGStatsConfig>;
+    personaRpgStats: RPGStatsConfig | null;
     personaName: string | null;
   };
 
@@ -3546,6 +3542,7 @@ export async function gameRoutes(app: FastifyInstance) {
               ? {
                   attributes: rpg.attributes,
                   hp: { value: rpg.hp.max, max: rpg.hp.max },
+                  pools: normalizeRpgStatPools(rpg),
                 }
               : undefined,
           };
@@ -3929,10 +3926,7 @@ export async function gameRoutes(app: FastifyInstance) {
     // Load party character cards for context (full detail)
     const partyCards: string[] = [];
     const partyNames: string[] = [];
-    const partyRpgStats: Record<
-      string,
-      { enabled: boolean; attributes: Array<{ name: string; value: number }>; hp: { value: number; max: number } }
-    > = {};
+    const partyRpgStats: Record<string, RPGStatsConfig> = {};
     for (const pcId of setupConfig.partyCharacterIds) {
       const pc = await characters.getById(pcId);
       if (pc) {
@@ -3957,11 +3951,7 @@ export async function gameRoutes(app: FastifyInstance) {
     }
 
     // Also collect persona RPG stats
-    let personaRpgStats: {
-      enabled: boolean;
-      attributes: Array<{ name: string; value: number }>;
-      hp: { value: number; max: number };
-    } | null = null;
+    let personaRpgStats: RPGStatsConfig | null = null;
     const personaName: string | null = setupPersona?.name ?? null;
     if (setupPersona) {
       try {

--- a/packages/server/src/routes/generate.routes.ts
+++ b/packages/server/src/routes/generate.routes.ts
@@ -5813,7 +5813,7 @@ export async function generateRoutes(app: FastifyInstance) {
             customPrompt: input.impersonatePromptTemplate || chatMeta.impersonatePrompt,
             direction: input.userMessage,
             personaName,
-            personaDescription,
+            personaDescription: resolvePromptMacros(personaDescription),
           });
           finalMessages.push({ role: "user", content: impersonateInstruction });
         }

--- a/packages/server/src/services/agents/agent-executor.ts
+++ b/packages/server/src/services/agents/agent-executor.ts
@@ -19,6 +19,7 @@ import {
   MIN_AGENT_MAX_TOKENS,
   normalizeCustomAgentCapabilities,
   getDefaultAgentPrompt,
+  normalizeRpgStatPools,
   resolveMacros,
 } from "@marinara-engine/shared";
 import { getMaxToolRounds, isDebugAgentsEnabled } from "../../config/runtime-config.js";
@@ -1957,7 +1958,15 @@ function buildLoreBlock(context: AgentContext): string {
     if (context.persona.rpgStats?.enabled) {
       const rpg = context.persona.rpgStats;
       parts.push(`RPG Stats:`);
-      parts.push(`- Max HP: ${rpg.hp.max}`);
+      const pools = normalizeRpgStatPools(rpg);
+      if (pools.length > 0) {
+        parts.push(`Pools:`);
+        for (const pool of pools) {
+          parts.push(`- ${pool.name}: ${pool.value}/${pool.max}`);
+        }
+      } else {
+        parts.push(`- Max HP: ${rpg.hp.max}`);
+      }
       if (rpg.attributes.length > 0) {
         parts.push(`Attributes:`);
         for (const attr of rpg.attributes) {

--- a/packages/server/src/services/agents/default-prompt-migration.ts
+++ b/packages/server/src/services/agents/default-prompt-migration.ts
@@ -1,0 +1,105 @@
+import { createHash } from "node:crypto";
+import { eq } from "drizzle-orm";
+import {
+  DEFAULT_AGENT_PROMPTS,
+  getDefaultBuiltInAgentSettings,
+  normalizeAgentPromptTemplateOptions,
+  parseAgentSettingsRecord,
+} from "@marinara-engine/shared";
+import type { DB } from "../../db/connection.js";
+import { agentConfigs } from "../../db/schema/index.js";
+import { logger } from "../../lib/logger.js";
+
+const LEGACY_V1_DEFAULT_AGENT_PROMPT_HASHES: Record<string, readonly string[]> = {
+  background: ["9f4fd2708eb348513e6b2b95587489cd979a7dc4b75f123954ec8b099db8851e"],
+  "card-evolution-auditor": ["072541f4141f847d8cf2baa6f72453ce246bd5c740c79cb542608a919e67b47f"],
+  "character-tracker": ["218f705897344e1e80e1fe46ea7141e73d49a82a7c67d503dd2d52c5b7582fad"],
+  combat: ["f87d476689f057e3734122fc82b8d6b0242c3a2ce10c7ffb2a9433507483cfa8"],
+  continuity: ["dc641e82eeb0829f486e99251b238ec22abb909e96f76d6f85b89bf2693fc709"],
+  "custom-tracker": ["1aee6c869521f11de7ca095bf1b1eaf6292edce863e2e8400fe2f9091025df30"],
+  cyoa: ["bea961d2292f945599fd16ff3a5860c40f86bd2277e5c65787c13eda5b568b36"],
+  director: ["644db63004a6cf58e747b2ca762084100789e8d5c0b29a3f1bdb1fec40ca4419"],
+  "echo-chamber": ["ffaedffd762de790445333550a22319daee5be6176c03dfee772dda37636191e"],
+  expression: ["a0dae5ce04e79b55bcb95e375e65d1bbbbdcf36df4c2882635053a4a25e37d2e"],
+  haptic: ["b859e11b47cfaf71addf1098d89f220e463eae709e74c7a11351a4647034a26f"],
+  html: ["2a0e9739c529c39dd5b9e879b3eed9f05f8dec0f0f46319b6fd159515079dec0"],
+  illustrator: ["4ea814bcf6c4037faa2431e7163bb889f74736400e708bb817497899b3a8c117"],
+  "knowledge-retrieval": ["4fa6d82e162c5c6249e726d618b5a4dfb04f51166ee9a06a5a82c7b1e8fe6e16"],
+  "knowledge-router": ["c9c06d85a9966b8d4391542a5e41faee743e02723f0f239780a6c1c2ee2d29be"],
+  "lorebook-keeper": ["fcadcc038895e3afaf9fa421decdfbbd4cac883d2c1212b14e2ba1fa26adffed"],
+  "persona-stats": ["1231c0c952de1dbb031756f371c89467d3a2ef53f7aaa126247ec34b74b118e5"],
+  "prose-guardian": ["8cf9672b67ded7204efc3ffd4ab31ad3796896b0cadb2191fe6d0a728129956b"],
+  quest: ["74ed682013c1b99742e184fdb6df5f7d6ba8bfc9d6fb52f809d5e9b0ac86645b"],
+  spotify: ["228be333d2af8de652cf868cb033f9d2091bc991ec9f316f7e8115b438386581"],
+  "world-state": ["08e275fbcf15de0bc7962ff0f950f0635381af8dca5aeab83e1c928ce2010512"],
+};
+
+function normalizedPromptHash(value: string): string {
+  return createHash("sha256").update(value.trim().replace(/\r\n/g, "\n")).digest("hex");
+}
+
+function defaultPromptHashes(agentType: string, currentDefault?: string): Set<string> {
+  const hashes = new Set(LEGACY_V1_DEFAULT_AGENT_PROMPT_HASHES[agentType] ?? []);
+  const current = currentDefault ?? DEFAULT_AGENT_PROMPTS[agentType];
+  if (current?.trim()) hashes.add(normalizedPromptHash(current));
+  return hashes;
+}
+
+function isKnownDefaultPrompt(agentType: string, prompt: string, currentDefault?: string): boolean {
+  if (!prompt.trim()) return false;
+  return defaultPromptHashes(agentType, currentDefault).has(normalizedPromptHash(prompt));
+}
+
+function migratePromptTemplateOptions(agentType: string, settings: unknown) {
+  const parsed = parseAgentSettingsRecord(settings);
+  const savedOptions = normalizeAgentPromptTemplateOptions(parsed.promptTemplates);
+  if (savedOptions.length === 0) return { settings: parsed, changed: false };
+
+  const defaultSettings = getDefaultBuiltInAgentSettings(agentType);
+  const defaultOptions = new Map(
+    normalizeAgentPromptTemplateOptions(defaultSettings.promptTemplates).map((option) => [option.id, option]),
+  );
+  let changed = false;
+  const promptTemplates = savedOptions.map((option) => {
+    const defaultOption = defaultOptions.get(option.id);
+    if (!defaultOption) return option;
+    if (!isKnownDefaultPrompt(agentType, option.promptTemplate, defaultOption.promptTemplate)) return option;
+    changed = true;
+    return { ...option, promptTemplate: defaultOption.promptTemplate };
+  });
+
+  if (!changed) return { settings: parsed, changed: false };
+  return { settings: { ...parsed, promptTemplates }, changed: true };
+}
+
+export async function migrateLegacyDefaultAgentPrompts(db: DB) {
+  const rows = await db.select().from(agentConfigs);
+  let migratedPromptTemplates = 0;
+  let migratedPromptTemplateOptions = 0;
+
+  for (const row of rows) {
+    const update: Partial<typeof agentConfigs.$inferInsert> = {};
+    if (isKnownDefaultPrompt(row.type, row.promptTemplate)) {
+      update.promptTemplate = "";
+      migratedPromptTemplates += 1;
+    }
+
+    const settingsMigration = migratePromptTemplateOptions(row.type, row.settings);
+    if (settingsMigration.changed) {
+      update.settings = JSON.stringify(settingsMigration.settings);
+      migratedPromptTemplateOptions += 1;
+    }
+
+    if (Object.keys(update).length > 0) {
+      await db.update(agentConfigs).set(update).where(eq(agentConfigs.id, row.id));
+    }
+  }
+
+  if (migratedPromptTemplates > 0 || migratedPromptTemplateOptions > 0) {
+    logger.info(
+      "[migration] Agent default prompts migrated: %d prompt templates, %d named options",
+      migratedPromptTemplates,
+      migratedPromptTemplateOptions,
+    );
+  }
+}

--- a/packages/server/src/services/generation/character-prompt-context.ts
+++ b/packages/server/src/services/generation/character-prompt-context.ts
@@ -1,4 +1,11 @@
-import { nameToXmlTag, resolveMacros, type CharacterMacroProfile, type MacroContext } from "@marinara-engine/shared";
+import {
+  formatRpgStatsForPrompt,
+  nameToXmlTag,
+  resolveMacros,
+  type CharacterMacroProfile,
+  type MacroContext,
+  type RPGStatsConfig,
+} from "@marinara-engine/shared";
 import { wrapContent } from "../prompt/format-engine.js";
 import { sanitizePromptLeaf } from "../prompt/prompt-escaping.js";
 import { cardPromptText } from "./generation-text-utils.js";
@@ -194,16 +201,9 @@ export function injectIdentityFallbackMessages(args: {
   if (args.persona?.personaStats) {
     const pStats = parseRecord(args.persona.personaStats);
     if (pStats?.rpgStats?.enabled) {
-      const rpg = pStats.rpgStats as {
-        attributes: Array<{ name: string; value: number }>;
-        hp: { value: number; max: number };
-      };
-      const rpgLines = [`Max HP: ${rpg.hp.max}`];
-      for (const attr of rpg.attributes) {
-        rpgLines.push(`${attr.name}: ${attr.value}`);
-      }
+      const rpgText = formatRpgStatsForPrompt(pStats.rpgStats as RPGStatsConfig);
       fieldParts.push(
-        wrapContent(sanitizePromptLeaf(rpgLines.join("\n"), args.wrapFormat), "rpg_attributes", args.wrapFormat, 2),
+        wrapContent(sanitizePromptLeaf(rpgText, args.wrapFormat), "rpg_attributes", args.wrapFormat, 2),
       );
     }
   }

--- a/packages/server/src/services/prompt/marker-expander.ts
+++ b/packages/server/src/services/prompt/marker-expander.ts
@@ -4,7 +4,7 @@
 // ──────────────────────────────────────────────
 import type { DB } from "../../db/connection.js";
 import { logger } from "../../lib/logger.js";
-import { resolveMacros, stripMacroComments } from "@marinara-engine/shared";
+import { formatRpgStatsForPrompt, resolveMacros, stripMacroComments } from "@marinara-engine/shared";
 import type {
   CharacterMacroProfile,
   MarkerConfig,
@@ -169,7 +169,7 @@ async function expandCharacter(config: MarkerConfig, ctx: MarkerContext): Promis
 
     // Auto-include RPG attributes if enabled and not already in fields
     if (!fields.includes("stats") && !fields.includes("rpg_attributes")) {
-      const statsText = formatRPGStats(data.extensions?.rpgStats as RPGStatsConfig | undefined);
+      const statsText = formatRpgStatsForPrompt(data.extensions?.rpgStats as RPGStatsConfig | undefined);
       if (statsText) {
         charParts.push(
           wrapContent(resolveSanitizedPromptLeaf(statsText, ctx), "rpg_attributes", ctx.wrapFormat, 2),
@@ -252,21 +252,10 @@ function getCharacterField(data: CharacterData, field: string): string {
     case "appearance":
       return data.extensions?.appearance ?? "";
     case "stats":
-      return formatRPGStats(data.extensions?.rpgStats as RPGStatsConfig | undefined);
+      return formatRpgStatsForPrompt(data.extensions?.rpgStats as RPGStatsConfig | undefined);
     default:
       return "";
   }
-}
-
-/** Format RPG stats into a readable block for the prompt. */
-function formatRPGStats(rpgStats: RPGStatsConfig | undefined): string {
-  if (!rpgStats?.enabled) return "";
-  const lines: string[] = [];
-  lines.push(`Max HP: ${rpgStats.hp.max}`);
-  if (rpgStats.attributes.length > 0) {
-    lines.push(rpgStats.attributes.map((a) => `${a.name}: ${a.value}`).join(", "));
-  }
-  return lines.join("\n");
 }
 
 // ── Persona ────────────────────────────────────
@@ -304,7 +293,7 @@ async function expandPersona(_config: MarkerConfig, ctx: MarkerContext): Promise
   // Include RPG attributes if enabled
   if (ctx.personaStats?.rpgStats?.enabled) {
     const rpg = ctx.personaStats.rpgStats as RPGStatsConfig;
-    const statsText = formatRPGStats(rpg);
+    const statsText = formatRpgStatsForPrompt(rpg);
     if (statsText) {
       parts.push(wrapContent(resolveSanitizedPromptLeaf(statsText, ctx), "rpg_attributes", ctx.wrapFormat, 2));
     }

--- a/packages/shared/src/constants/agent-prompts.ts
+++ b/packages/shared/src/constants/agent-prompts.ts
@@ -274,7 +274,7 @@ Instructions:
 1. Characters persist until they clearly leave, are dismissed, or the scene moves away from them. Nearby or implied characters may be included.
 2. Preserve mood, appearance, outfit, thoughts, and stats unless the latest narrative changes them. Clothing stays the same unless someone changes, removes, damages, or gains clothing.
 3. Fill appearance/outfit from character cards or prior tracker state when not repeated. Do not set them null just because this message omitted them.
-4. Track HP and other card stats realistically; use card initial values as maximums.
+4. Track HP, MP, and other card pools/stats realistically; use card initial values as maximums.
 5. Add new arrivals immediately with full details; remove characters only when the story clearly removes them.`,
 
   /* ────────────────────────────────────────── */

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -92,6 +92,7 @@ export * from "./utils/quest-state.js";
 export * from "./utils/quote-format.js";
 export * from "./utils/image-prompt-compiler.js";
 export * from "./utils/thinking-tags.js";
+export * from "./utils/rpg-stats.js";
 export * from "./utils/lorebook-folder-tree.js";
 export * from "./utils/text-matching.js";
 export * from "./utils/sprite-labels.js";

--- a/packages/shared/src/types/agent.ts
+++ b/packages/shared/src/types/agent.ts
@@ -364,6 +364,7 @@ export interface AgentContext {
       enabled: boolean;
       attributes: Array<{ name: string; value: number }>;
       hp: { value: number; max: number };
+      pools?: import("./character.js").RPGStatPool[];
     };
   } | null;
   /** The agent's own persistent memory (key-value) */

--- a/packages/shared/src/types/character.ts
+++ b/packages/shared/src/types/character.ts
@@ -52,6 +52,13 @@ export interface CharacterExtensions {
 }
 
 /** RPG stats configuration attached to a character card. */
+export interface RPGStatPool {
+  name: string;
+  value: number;
+  max: number;
+  color: string;
+}
+
 export interface RPGStatsConfig {
   /** Whether RPG stats are enabled for this character */
   enabled: boolean;
@@ -59,6 +66,8 @@ export interface RPGStatsConfig {
   attributes: Array<{ name: string; value: number }>;
   /** Hit Points */
   hp: { value: number; max: number };
+  /** HP-like bars such as HP, MP, EP, Sanity, etc. */
+  pools?: RPGStatPool[];
 }
 
 /** Depth-injected prompt attached to a character. */

--- a/packages/shared/src/types/game.ts
+++ b/packages/shared/src/types/game.ts
@@ -99,6 +99,7 @@ export interface GameCharacterCard {
   rpgStats?: {
     attributes: Array<{ name: string; value: number }>;
     hp: { value: number; max: number };
+    pools?: import("./character.js").RPGStatPool[];
   };
 }
 

--- a/packages/shared/src/utils/regex-safety.ts
+++ b/packages/shared/src/utils/regex-safety.ts
@@ -27,6 +27,11 @@ const DEFAULTS: Required<PatternSafetyOptions> = {
 
 const INVALID_QUANTIFIER = Symbol("invalid-quantifier");
 
+interface ConsumedQuantifier {
+  end: number;
+  addsStarHeight: boolean;
+}
+
 /**
  * Decide whether a regex source string is safe to compile and run against
  * untrusted input. Returns false for patterns likely to cause catastrophic
@@ -42,11 +47,11 @@ export function isPatternSafe(source: string, options: PatternSafetyOptions = {}
   // Walk the source once, tracking:
   //   - whether we are inside a character class (where quantifier semantics differ)
   //   - whether the previous character is escaped
-  //   - the stack of group "has-quantifier-after-close" markers, to compute star height
+  //   - the stack of group "has-repetition-quantifier-after-close" markers, to compute star height
   //
   // Star height here is the maximum number of nested groups whose closing `)`
-  // is followed by a quantifier (`*`, `+`, `?`, `{n,m}`), counted along with
-  // immediate-quantifier atoms. A bare `a+` has star height 1; `(a+)+` has 2.
+  // is followed by a repeating quantifier (`*`, `+`, `{n,m}`), counted along with
+  // immediate repeating-quantifier atoms. A bare `a+` has star height 1; `(a+)+` has 2.
   //
   // The walker is deliberately conservative — it does not need to be a full
   // regex parser to catch the common ReDoS shapes.
@@ -75,8 +80,8 @@ export function isPatternSafe(source: string, options: PatternSafetyOptions = {}
       if (atomEnd === null) return false;
       const consumed = consumeQuantifier(source, atomEnd, maxRepetition);
       if (consumed === INVALID_QUANTIFIER) return false;
-      recordAtomHeight(consumed === null ? 0 : 1);
-      i = consumed ?? atomEnd;
+      recordAtomHeight(consumed?.addsStarHeight ? 1 : 0);
+      i = consumed?.end ?? atomEnd;
       continue;
     }
 
@@ -88,8 +93,8 @@ export function isPatternSafe(source: string, options: PatternSafetyOptions = {}
       const atomEnd = closeIdx + 1;
       const consumed = consumeQuantifier(source, atomEnd, maxRepetition);
       if (consumed === INVALID_QUANTIFIER) return false;
-      recordAtomHeight(consumed === null ? 0 : 1);
-      i = consumed ?? atomEnd;
+      recordAtomHeight(consumed?.addsStarHeight ? 1 : 0);
+      i = consumed?.end ?? atomEnd;
       continue;
     }
 
@@ -110,12 +115,12 @@ export function isPatternSafe(source: string, options: PatternSafetyOptions = {}
       groupDepth -= 1;
       const consumed = consumeQuantifier(source, i + 1, maxRepetition);
       if (consumed === INVALID_QUANTIFIER) return false;
-      const quantified = consumed !== null;
+      const quantified = consumed?.addsStarHeight === true;
       if (quantified && hasUnsafeQuantifiedAlternation(source.slice(bodyStart, i))) return false;
       const groupHeight = innerHeight + (quantified ? 1 : 0);
       if (groupHeight > maxStarHeight) return false;
       recordAtomHeight(groupHeight);
-      i = consumed ?? i + 1;
+      i = consumed?.end ?? i + 1;
       continue;
     }
 
@@ -123,8 +128,8 @@ export function isPatternSafe(source: string, options: PatternSafetyOptions = {}
     const atomEnd = i + 1;
     const consumed = consumeQuantifier(source, atomEnd, maxRepetition);
     if (consumed === INVALID_QUANTIFIER) return false;
-    recordAtomHeight(consumed === null ? 0 : 1);
-    i = consumed ?? atomEnd;
+    recordAtomHeight(consumed?.addsStarHeight ? 1 : 0);
+    i = consumed?.end ?? atomEnd;
   }
 
   if (groupDepth !== 0) return false; // Unbalanced
@@ -137,13 +142,16 @@ function consumeQuantifier(
   source: string,
   i: number,
   maxRepetition: number,
-): number | null | typeof INVALID_QUANTIFIER {
+): ConsumedQuantifier | null | typeof INVALID_QUANTIFIER {
   const c = source[i];
   if (c === "*" || c === "+" || c === "?") {
     // JS has lazy quantifiers, not possessive quantifiers.
     const next = source[i + 1];
     if (next === "+") return INVALID_QUANTIFIER;
-    return next === "?" ? i + 2 : i + 1;
+    return {
+      end: next === "?" ? i + 2 : i + 1,
+      addsStarHeight: c !== "?",
+    };
   }
   if (c === "{") {
     const close = source.indexOf("}", i + 1);
@@ -160,7 +168,7 @@ function consumeQuantifier(
     let next = close + 1;
     if (source[next] === "+") return INVALID_QUANTIFIER;
     if (source[next] === "?") next += 1;
-    return next;
+    return { end: next, addsStarHeight: true };
   }
   return null;
 }

--- a/packages/shared/src/utils/rpg-stats.ts
+++ b/packages/shared/src/utils/rpg-stats.ts
@@ -1,0 +1,68 @@
+import type { RPGStatPool, RPGStatsConfig } from "../types/character.js";
+
+export const DEFAULT_RPG_STAT_POOLS: readonly RPGStatPool[] = [
+  { name: "HP", value: 100, max: 100, color: "#ef4444" },
+  { name: "MP", value: 100, max: 100, color: "#3b82f6" },
+];
+
+const HP_NAME_RE = /^(?:hp|health|health points?|hit points?)$/i;
+
+function finiteNumber(value: unknown, fallback: number, min = 0): number {
+  const numeric =
+    typeof value === "number" ? value : typeof value === "string" && value.trim() ? Number(value) : Number.NaN;
+  return Number.isFinite(numeric) ? Math.max(min, numeric) : fallback;
+}
+
+function normalizePool(value: unknown, fallback: RPGStatPool): RPGStatPool | null {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return null;
+  const raw = value as Partial<RPGStatPool>;
+  const name = typeof raw.name === "string" && raw.name.trim() ? raw.name.trim() : fallback.name;
+  const max = finiteNumber(raw.max, fallback.max, 1);
+  const valueNumber = Math.min(max, finiteNumber(raw.value, fallback.value, 0));
+  const color = typeof raw.color === "string" && /^#[0-9a-f]{6}$/i.test(raw.color) ? raw.color : fallback.color;
+  return { name, value: valueNumber, max, color };
+}
+
+export function createDefaultRpgStatPools(): RPGStatPool[] {
+  return DEFAULT_RPG_STAT_POOLS.map((pool) => ({ ...pool }));
+}
+
+export function normalizeRpgStatPools(rpgStats: Pick<RPGStatsConfig, "hp" | "pools"> | null | undefined): RPGStatPool[] {
+  if (Array.isArray(rpgStats?.pools) && rpgStats.pools.length > 0) {
+    return rpgStats.pools
+      .map((pool, index) => normalizePool(pool, DEFAULT_RPG_STAT_POOLS[index] ?? DEFAULT_RPG_STAT_POOLS[0]!))
+      .filter((pool): pool is RPGStatPool => !!pool);
+  }
+
+  const hpMax = finiteNumber(rpgStats?.hp?.max, 100, 1);
+  const hpValue = Math.min(hpMax, finiteNumber(rpgStats?.hp?.value ?? rpgStats?.hp?.max, hpMax, 0));
+  return [{ name: "HP", value: hpValue, max: hpMax, color: "#ef4444" }];
+}
+
+export function syncRpgHpFromPools(
+  pools: readonly RPGStatPool[],
+  fallbackHp: RPGStatsConfig["hp"] = { value: 100, max: 100 },
+): RPGStatsConfig["hp"] {
+  const hpPool = pools.find((pool) => HP_NAME_RE.test(pool.name.trim())) ?? pools[0];
+  if (!hpPool) return fallbackHp;
+  return {
+    value: Math.max(0, Math.min(Math.max(1, Number(hpPool.max) || 1), Number(hpPool.value) || 0)),
+    max: Math.max(1, Number(hpPool.max) || 1),
+  };
+}
+
+export function formatRpgStatsForPrompt(rpgStats: RPGStatsConfig | undefined): string {
+  if (!rpgStats?.enabled) return "";
+  const lines: string[] = [];
+  const pools = normalizeRpgStatPools(rpgStats);
+  if (pools.length > 0) {
+    lines.push(...pools.map((pool) => `${pool.name}: ${pool.value}/${pool.max}`));
+  } else {
+    lines.push(`Max HP: ${rpgStats.hp.max}`);
+  }
+  const attributes = Array.isArray(rpgStats.attributes) ? rpgStats.attributes : [];
+  if (attributes.length > 0) {
+    lines.push(attributes.map((attribute) => `${attribute.name}: ${attribute.value}`).join(", "));
+  }
+  return lines.join("\n");
+}


### PR DESCRIPTION
## What Changed

- Added customizable RPG stat pools for character cards, persona RPG attributes, and Game character sheets, preserving legacy `hp` compatibility while passing pool bars into prompt and agent context.
- Fixed Game Widget setup editing so labels/stat names can be blank or include trailing spaces while the user is still typing, with normalization deferred to save/import/export.
- Fixed Author's Notes autosave on fast chat switches by storing latest drafts and baselines by chat ID.
- Fixed `/impersonate` so macros inside persona descriptions resolve before the persona description is inserted into the impersonation instruction.
- Fixed regex safety star-height handling so optional `?` quantifiers do not reject valid patterns like `(a+)?`.
- Included the prior local v2.0.7 fixes for agent failure chrome, default-agent prompt migration, and Peek Prompt system-section display.

## Why

This closes a batch of v2.0.7 GitHub issues around RPG stat flexibility, widget editing friction, chat-switch data safety, macro resolution, and regex imports. It also carries forward already-validated local fixes that were waiting in the tree.

Closes #3077
Closes #3078
Closes #3079
Closes #3080
Closes #3081

## Validation

- [ ] `pnpm --filter @marinara-engine/shared lint`
- [ ] `pnpm --filter @marinara-engine/server lint`
- [ ] `pnpm --filter @marinara-engine/client lint`
- [ ] `pnpm check`
- [ ] `pnpm regression:prompt`
- [ ] Manual browser check: edit character/persona RPG pools and Game character-sheet pools.
- [ ] Manual browser check: type, clear, and save Game Widget labels/stat names.
- [ ] Manual chat check: fast-switch Author's Notes between two chats.
- [ ] Manual generation check: `/impersonate` with `{{user}}` in persona description.
