### PR TITLE
Prepare v2.0.8 release fixes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,9 @@
 # Auto detect text files and perform LF normalization
 * text=auto
 
+# Generated TypeScript registries are written with LF by the codegen script.
+# Keep Windows checkouts aligned so every launcher build does not dirty them.
+packages/shared/src/features/**/*.generated.ts text eol=lf
+
 # Windows batch files must keep CRLF line endings
 *.bat text eol=crlf

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 
 ## [Unreleased]
 
+## [2.0.8]
+
+### Fixed
+
+- Slowed custom cursor recoloring during Accent Pulse/RGB Mode and kept the previous custom cursor as a fallback so color changes do not flash the native cursor.
+- Hardened Windows, macOS/Linux, and Termux launcher updates so generated feature registries keep LF line endings on Windows, launchers stash untracked local files, main/detached installs reset to the exact fetched `origin/main` commit when a normal fast-forward refuses, and Git's real error prints if updating is still blocked.
+- Fixed the Android APK blocked-Termux fallback so it copies a full Marinara setup command instead of telling fresh Termux users to run a missing `./start-termux.sh`, and made the copied `allow-external-apps` command tolerate Termux builds without `termux-reload-settings`.
+
+### Platform Notes
+
+- Android `versionName` is `2.0.8` with `versionCode 27`.
+- Windows, macOS/Linux, Termux, Docker, APK, and PWA users can update through the usual v2 updater paths once release assets are published.
+
 ## [2.0.7]
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 
 ### Fixed
 
-- Slowed custom cursor recoloring during Accent Pulse/RGB Mode and kept the previous custom cursor as a fallback so color changes do not flash the native cursor.
+- Slowed custom cursor recoloring during Accent Pulse/RGB Mode and skipped cursor recolor work entirely when Marinara's custom pointer is disabled.
 - Hardened Windows, macOS/Linux, and Termux launcher updates so generated feature registries keep LF line endings on Windows, launchers stash untracked local files, main/detached installs reset to the exact fetched `origin/main` commit when a normal fast-forward refuses, and Git's real error prints if updating is still blocked.
 - Fixed the Android APK blocked-Termux fallback so it copies a full Marinara setup command instead of telling fresh Termux users to run a missing `./start-termux.sh`, and made the copied `allow-external-apps` command tolerate Termux builds without `termux-reload-settings`.
 

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@
 
 ## Latest Release
 
-Current stable release: **[v2.0.7](https://github.com/Pasta-Devs/Marinara-Engine/releases/tag/v2.0.7)**.
+Current stable release: **[v2.0.8](https://github.com/Pasta-Devs/Marinara-Engine/releases/tag/v2.0.8)**.
 
 See [CHANGELOG.md](CHANGELOG.md) for detailed release notes. Tagged releases use the `vX.Y.Z` format and are published on the [Releases](https://github.com/Pasta-Devs/Marinara-Engine/releases) page. Android APKs are Termux bootstrap + WebView shells: they can download Termux from F-Droid, launch Android's installer, start the Termux setup flow after required permission prompts, then open the local Marinara server on the same device.
 
@@ -129,7 +129,7 @@ More detailed public [roadmap](https://github.com/orgs/Pasta-Devs/projects/1).
 | 🤖 Android Manual Termux     | [Android (Termux) Installation Guide](docs/installation/android-termux.md) — manual fallback    |
 | 📱 iOS / iPadOS              | [iOS / iPadOS PWA Guide](docs/installation/ios-pwa.md)                                          |
 
-> **Recommended Android path:** download the Android APK from the latest GitHub Release, open it, then tap **Install / Start Marinara**. The APK can download Termux from F-Droid, hand it to Android's installer, request Termux command permission, start the setup command, and open the local Marinara server when it is ready. Android still shows its required install/permission prompts.
+> **Recommended Android path:** download the Android APK from the latest GitHub Release, open it, then tap **Install / Start Marinara**. The APK can download Termux from F-Droid, hand it to Android's installer, request Termux command permission, start the setup command, and open the local Marinara server when it is ready. If Android blocks that handoff, the APK copies a fresh-Termux setup command that can be pasted into Termux manually. Android still shows its required install/permission prompts.
 
 Each guide covers installation, updating, and LAN access for that platform. See [Configuration Reference](docs/CONFIGURATION.md) for environment variables setup. Having trouble? See [FAQ](docs/FAQ.md) and [Troubleshooting](docs/TROUBLESHOOTING.md).
 

--- a/android/README.md
+++ b/android/README.md
@@ -17,7 +17,7 @@ The Android app is a Termux bootstrap + WebView shell for Marinara Engine. It is
 
 **Fast path:** install the APK, open it, tap **Install / Start Marinara**, approve Android/Termux prompts, wait for the Termux launcher to finish, then return to the Marinara Engine app.
 
-**Manual fallback:** install Termux from F-Droid, run `./start-termux.sh`, then open the Marinara Engine Android app.
+**Manual fallback:** install Termux from F-Droid, paste the fresh-Termux command below so it creates/updates the Marinara folder, then open the Marinara Engine Android app.
 
 ## Features
 
@@ -98,9 +98,16 @@ cd android
 
 ### Manual Path
 
-Start Marinara Engine in Termux:
+On a fresh Termux install, paste this command first:
 
 ```bash
+pkg update -y && pkg install -y git nodejs-lts && ([ -d "$HOME/Marinara-Engine/.git" ] || git clone https://github.com/Pasta-Devs/Marinara-Engine.git "$HOME/Marinara-Engine") && cd "$HOME/Marinara-Engine" && chmod +x start-termux.sh && ./start-termux.sh
+```
+
+After Marinara has been installed once, start it again in Termux:
+
+```bash
+cd "$HOME/Marinara-Engine"
 ./start-termux.sh
 ```
 

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -22,10 +22,10 @@ android {
         applicationId "com.marinara.engine"
         minSdk 24
         targetSdk 34
-        versionCode 26
-        versionName "2.0.7"
+        versionCode 27
+        versionName "2.0.8"
         buildConfigField "String", "MARINARA_SERVER_URL", "\"http://127.0.0.1:${marinaraPort}\""
-        buildConfigField "String", "MARINARA_RELEASE_TAG", "\"v2.0.7\""
+        buildConfigField "String", "MARINARA_RELEASE_TAG", "\"v2.0.8\""
     }
 
     signingConfigs {

--- a/android/app/src/main/java/com/marinara/engine/MainActivity.java
+++ b/android/app/src/main/java/com/marinara/engine/MainActivity.java
@@ -59,7 +59,9 @@ public class MainActivity extends Activity {
     private static final String TERMUX_HOME = "/data/data/com.termux/files/home";
     private static final String TERMUX_BASH = "/data/data/com.termux/files/usr/bin/bash";
     private static final String TERMUX_EXTERNAL_APPS_COMMAND =
-            "mkdir -p ~/.termux && grep -qxF 'allow-external-apps=true' ~/.termux/termux.properties 2>/dev/null || echo 'allow-external-apps=true' >> ~/.termux/termux.properties; termux-reload-settings";
+            "mkdir -p ~/.termux; "
+                    + "grep -qxF 'allow-external-apps=true' ~/.termux/termux.properties 2>/dev/null || echo 'allow-external-apps=true' >> ~/.termux/termux.properties; "
+                    + "if command -v termux-reload-settings >/dev/null 2>&1; then termux-reload-settings; else echo 'allow-external-apps=true saved. Fully close and reopen Termux if Marinara still cannot start it.'; fi";
 
     private WebView webView;
     private View splashView;
@@ -594,8 +596,7 @@ public class MainActivity extends Activity {
         } catch (SecurityException e) {
             showTermuxExternalAppsInstructions();
         } catch (IllegalStateException | ActivityNotFoundException e) {
-            showBootstrap("Android blocked the Termux setup launch.\nOpen Termux, run ./start-termux.sh, then return here.", false);
-            openTermux();
+            showManualTermuxSetupInstructions("Android blocked the Termux setup launch.");
         }
     }
 
@@ -626,6 +627,17 @@ public class MainActivity extends Activity {
         }
         pauseConnectionRetryLoop();
         showBootstrap("Termux blocked external setup.\nPaste the copied allow-external-apps command once, then return and tap Install / Start Marinara.", false);
+        openTermux();
+    }
+
+    private void showManualTermuxSetupInstructions(String reason) {
+        ClipboardManager clipboard = (ClipboardManager) getSystemService(Context.CLIPBOARD_SERVICE);
+        if (clipboard != null) {
+            clipboard.setPrimaryClip(ClipData.newPlainText("Marinara Termux setup", buildTermuxSetupCommand()));
+            Toast.makeText(this, "Copied Marinara setup command", Toast.LENGTH_LONG).show();
+        }
+        pauseConnectionRetryLoop();
+        showBootstrap(reason + "\nOpen Termux, paste the copied setup command, then return here.", false);
         openTermux();
     }
 

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -79,7 +79,7 @@ Fast path:
 5. If Termux blocks external commands, paste the copied `allow-external-apps` command into Termux once.
 6. Wait for Termux to install/build/start Marinara Engine, then return to the APK.
 
-Manual fallback: follow the [Android (Termux) Installation Guide](installation/android-termux.md), run `./start-termux.sh`, then open the APK as a dedicated home-screen shell.
+Manual fallback: follow the [Android (Termux) Installation Guide](installation/android-termux.md) so Termux creates or enters the `Marinara-Engine` folder first, then run `./start-termux.sh` from inside that folder and open the APK as a dedicated home-screen shell.
 
 </details>
 

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -62,8 +62,15 @@ If the APK stays on the connection screen:
 Manual fallback:
 
 1. Open Termux.
-2. Go to the Marinara Engine folder.
-3. Run `./start-termux.sh`.
+2. If Marinara is not installed yet, paste:
+   ```bash
+   pkg update -y && pkg install -y git nodejs-lts && ([ -d "$HOME/Marinara-Engine/.git" ] || git clone https://github.com/Pasta-Devs/Marinara-Engine.git "$HOME/Marinara-Engine") && cd "$HOME/Marinara-Engine" && chmod +x start-termux.sh && ./start-termux.sh
+   ```
+3. If Marinara is already installed, run:
+   ```bash
+   cd "$HOME/Marinara-Engine"
+   ./start-termux.sh
+   ```
 4. Wait for the launcher to finish and start the server.
 5. Open the APK again.
 

--- a/docs/UPGRADING.md
+++ b/docs/UPGRADING.md
@@ -57,6 +57,8 @@ The Termux launcher updates the repo, upgrades Node.js through `nodejs-lts` when
 6. If Termux blocks external commands, paste the copied `allow-external-apps` command into Termux once, then tap **Install / Start Marinara** again.
 7. Wait for Termux to finish installing/building, then return to Marinara Engine. The APK keeps retrying until the local server is ready.
 
+If Android blocks the Termux setup launch completely, the APK copies a full Marinara setup command. Open Termux, paste that copied command, wait for it to start the server, then return to the APK.
+
 Android does not allow an ordinary APK to silently install Termux or run Termux commands without user confirmation. The v2.0.0 APK reduces the setup to taps and Android permission prompts, but those prompts cannot be removed.
 
 ## iPhone and iPad

--- a/docs/installation/android-termux.md
+++ b/docs/installation/android-termux.md
@@ -26,14 +26,14 @@ Install **Termux** from [F-Droid](https://f-droid.org/en/packages/com.termux/). 
 Open Termux and run:
 
 ```bash
-pkg update && pkg install -y git nodejs-lts && git clone https://github.com/Pasta-Devs/Marinara-Engine.git && cd Marinara-Engine && chmod +x start-termux.sh && ./start-termux.sh
+pkg update -y && pkg install -y git nodejs-lts && ([ -d "$HOME/Marinara-Engine/.git" ] || git clone https://github.com/Pasta-Devs/Marinara-Engine.git "$HOME/Marinara-Engine") && cd "$HOME/Marinara-Engine" && chmod +x start-termux.sh && ./start-termux.sh
 ```
 
 This one-liner:
 
 1. Updates Termux packages
 2. Installs Git and Node.js. Marinara requires Node.js 24 LTS or newer; after installation, run `node -v` to confirm Termux installed `v24` or newer.
-3. Clones the Marinara Engine repo
+3. Clones the Marinara Engine repo if it is not already installed
 4. Makes the launcher executable
 5. Runs the Termux launcher for the first time
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "marinara-engine",
-  "version": "2.0.7",
+  "version": "2.0.8",
   "private": true,
   "description": "AI Chat & Roleplay Frontend — Conversation, Roleplay, Visual Novel",
   "author": "Marianna",

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@marinara-engine/client",
   "private": true,
-  "version": "2.0.7",
+  "version": "2.0.8",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/packages/client/public/manifest.json
+++ b/packages/client/public/manifest.json
@@ -2,7 +2,7 @@
   "name": "Marinara Engine",
   "short_name": "Marinara",
   "description": "AI Chat & Roleplay Frontend — Conversation, Roleplay, Visual Novel",
-  "version": "2.0.7",
+  "version": "2.0.8",
   "start_url": "/",
   "display": "standalone",
   "background_color": "#0a0a0f",

--- a/packages/client/src/App.tsx
+++ b/packages/client/src/App.tsx
@@ -279,14 +279,6 @@ function getAccentCursorValue(fill: string, stroke: string) {
 function setAccentCursorVariable(root: HTMLElement, accent: string, theme: "dark" | "light") {
   const { fill, stroke } = getAccentCursorColors(accent, theme);
   const nextCursor = getAccentCursorValue(fill, stroke);
-  const currentCursor =
-    root.style.getPropertyValue("--cursor-pink").trim() ||
-    getComputedStyle(root).getPropertyValue("--cursor-pink").trim();
-  if (currentCursor && currentCursor !== nextCursor) {
-    root.style.setProperty("--cursor-pink-previous", currentCursor);
-  } else if (!root.style.getPropertyValue("--cursor-pink-previous").trim()) {
-    root.style.setProperty("--cursor-pink-previous", nextCursor);
-  }
 
   root.style.setProperty("--marinara-custom-cursor-fill", fill);
   root.style.setProperty("--marinara-custom-cursor-stroke", stroke);

--- a/packages/client/src/App.tsx
+++ b/packages/client/src/App.tsx
@@ -68,6 +68,7 @@ const APP_ACCENT_CUSTOM_VARIABLES = [
 const ACCENT_RGB_TICK_MS = 500;
 const ACCENT_RGB_SOLID_CYCLE_MS = 7_200;
 const ACCENT_RGB_GRADIENT_STOP_MS = 6_000;
+const CUSTOM_CURSOR_ANIMATED_RECOLOR_MS = 6_000;
 const CUSTOM_CURSOR_RECOLOR_SCROLL_FREEZE_MS = 360;
 const TOAST_DURATION_MS = 6_000;
 const TOAST_VISIBLE_LIMIT = 3;
@@ -277,9 +278,19 @@ function getAccentCursorValue(fill: string, stroke: string) {
 
 function setAccentCursorVariable(root: HTMLElement, accent: string, theme: "dark" | "light") {
   const { fill, stroke } = getAccentCursorColors(accent, theme);
+  const nextCursor = getAccentCursorValue(fill, stroke);
+  const currentCursor =
+    root.style.getPropertyValue("--cursor-pink").trim() ||
+    getComputedStyle(root).getPropertyValue("--cursor-pink").trim();
+  if (currentCursor && currentCursor !== nextCursor) {
+    root.style.setProperty("--cursor-pink-previous", currentCursor);
+  } else if (!root.style.getPropertyValue("--cursor-pink-previous").trim()) {
+    root.style.setProperty("--cursor-pink-previous", nextCursor);
+  }
+
   root.style.setProperty("--marinara-custom-cursor-fill", fill);
   root.style.setProperty("--marinara-custom-cursor-stroke", stroke);
-  root.style.setProperty("--cursor-pink", getAccentCursorValue(fill, stroke));
+  root.style.setProperty("--cursor-pink", nextCursor);
 }
 
 function getSolidAccentGradient(accent: string) {
@@ -557,13 +568,26 @@ export function App() {
     let cursorRecolorFreezeTimer: ReturnType<typeof window.setTimeout> | null = null;
     let cursorRecolorFrozen = false;
     let pendingCursorAccent: string | null = null;
+    let lastCursorRecolorAt = 0;
 
-    const applyCursorAccent = (cursorAccent: string) => {
+    const applyCursorAccent = (cursorAccent: string, options: { slow?: boolean } = {}) => {
+      if (!customCursorEnabled) {
+        pendingCursorAccent = null;
+        return;
+      }
       if (customCursorEnabled && cursorRecolorFrozen) {
         pendingCursorAccent = cursorAccent;
         return;
       }
+      if (customCursorEnabled && options.slow && lastCursorRecolorAt > 0) {
+        const now = performance.now();
+        if (now - lastCursorRecolorAt < CUSTOM_CURSOR_ANIMATED_RECOLOR_MS) {
+          pendingCursorAccent = cursorAccent;
+          return;
+        }
+      }
       pendingCursorAccent = null;
+      lastCursorRecolorAt = performance.now();
       setAccentCursorVariable(root, cursorAccent, theme);
     };
 
@@ -577,7 +601,7 @@ export function App() {
       if (pendingCursorAccent !== null) {
         const nextCursorAccent = pendingCursorAccent;
         pendingCursorAccent = null;
-        setAccentCursorVariable(root, nextCursorAccent, theme);
+        applyCursorAccent(nextCursorAccent, { slow: accentAnimationEnabled });
       }
     };
 
@@ -636,7 +660,7 @@ export function App() {
         theme,
         updateCursor: false,
       });
-      applyCursorAccent(liveAccent);
+      applyCursorAccent(liveAccent, { slow: true });
       setAccentModeDataset();
     };
 
@@ -692,7 +716,9 @@ export function App() {
     window.addEventListener("blur", syncAccentAnimationState);
     window.addEventListener("pageshow", syncAccentAnimationState);
     window.addEventListener("pagehide", syncAccentAnimationState);
-    window.addEventListener("wheel", freezeCursorRecolorDuringScroll, { capture: true, passive: true });
+    if (customCursorEnabled) {
+      window.addEventListener("wheel", freezeCursorRecolorDuringScroll, { capture: true, passive: true });
+    }
     reducedMotionQuery.addEventListener("change", syncAccentAnimationState);
 
     return () => {
@@ -701,7 +727,9 @@ export function App() {
       window.removeEventListener("blur", syncAccentAnimationState);
       window.removeEventListener("pageshow", syncAccentAnimationState);
       window.removeEventListener("pagehide", syncAccentAnimationState);
-      window.removeEventListener("wheel", freezeCursorRecolorDuringScroll, true);
+      if (customCursorEnabled) {
+        window.removeEventListener("wheel", freezeCursorRecolorDuringScroll, true);
+      }
       reducedMotionQuery.removeEventListener("change", syncAccentAnimationState);
       if (accentAnimationTimer !== null) {
         window.clearTimeout(accentAnimationTimer);

--- a/packages/client/src/components/chat/HomeFaq.tsx
+++ b/packages/client/src/components/chat/HomeFaq.tsx
@@ -107,7 +107,7 @@ const HOME_FAQ_ITEMS: HomeFaqItem[] = [
     question: "Is the Android APK standalone?",
     answer: "No. The APK is only a WebView shell for Marinara Engine running locally in Termux.",
     bullets: [
-      "Install Termux from F-Droid and run Marinara with ./start-termux.sh first.",
+      "Use Install / Start Marinara in the APK, or follow the Android Termux guide so Termux creates the Marinara-Engine folder before running ./start-termux.sh.",
       "The APK opens the same-device local server at 127.0.0.1, so it cannot work if Termux is closed.",
       "If it stays on the connection screen, go back to Termux and start the server.",
     ],

--- a/packages/client/src/styles/globals.css
+++ b/packages/client/src/styles/globals.css
@@ -382,7 +382,9 @@
 
   --marinara-custom-cursor-fill: #d4acfb;
   --marinara-custom-cursor-stroke: #050312;
-  --cursor-pink: url("data:image/svg+xml,%3Csvg width='24' height='24' viewBox='0 0 24 24' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M3 3L10 20L12 12L20 10L3 3Z' fill='%23D4ACFB' stroke='%23050312' stroke-width='1'/%3E%3C/svg%3E");
+  --cursor-pink: url("data:image/svg+xml,%3Csvg width='24' height='24' viewBox='0 0 24 24' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M3 3L10 20L12 12L20 10L3 3Z' fill='%23D4ACFB' stroke='%23050312' stroke-width='1'/%3E%3C/svg%3E") 3 3;
+  --cursor-pink-previous: url("data:image/svg+xml,%3Csvg width='24' height='24' viewBox='0 0 24 24' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M3 3L10 20L12 12L20 10L3 3Z' fill='%23D4ACFB' stroke='%23050312' stroke-width='1'/%3E%3C/svg%3E") 3 3;
+  --marinara-custom-cursor: var(--cursor-pink), var(--cursor-pink-previous), auto;
 
   --y2k-pink: var(--primary);
   --y2k-purple: #d4adfc;
@@ -1388,7 +1390,7 @@
 }
 
 :where(:root[data-marinara-custom-cursor="enabled"] .mari-editor-avatar-tile) {
-  cursor: var(--cursor-pink), auto !important;
+  cursor: var(--marinara-custom-cursor) !important;
 }
 
 .mari-editor-avatar-tile.mari-avatar-placeholder {
@@ -1929,11 +1931,11 @@
    5. BASE RESET & BODY
    ───────────────────────────────────────────── */
 :where(:root[data-marinara-custom-cursor="enabled"], :root[data-marinara-custom-cursor="enabled"] body) {
-  cursor: var(--cursor-pink), auto !important;
+  cursor: var(--marinara-custom-cursor) !important;
 }
 
 :where(:root[data-marinara-custom-cursor="enabled"] *) {
-  cursor: var(--cursor-pink), auto !important;
+  cursor: var(--marinara-custom-cursor) !important;
 }
 
 @layer base {
@@ -1951,7 +1953,7 @@ textarea {
 }
 
 :where(:root[data-marinara-custom-cursor="enabled"] input, :root[data-marinara-custom-cursor="enabled"] select, :root[data-marinara-custom-cursor="enabled"] textarea) {
-  cursor: var(--cursor-pink), auto !important;
+  cursor: var(--marinara-custom-cursor) !important;
 }
 
 input[type="range"] {
@@ -1970,7 +1972,7 @@ input[type="range"] {
 }
 
 :where(:root[data-marinara-custom-cursor="enabled"] input[type="range"]) {
-  cursor: var(--cursor-pink), auto !important;
+  cursor: var(--marinara-custom-cursor) !important;
 }
 
 input[type="range"]::-webkit-slider-runnable-track {
@@ -2521,7 +2523,7 @@ strong {
   :root[data-marinara-custom-cursor="enabled"] .mari-resize-x,
   :root[data-marinara-custom-cursor="enabled"] .mari-resize-y
 ) {
-  cursor: var(--cursor-pink), auto !important;
+  cursor: var(--marinara-custom-cursor) !important;
 }
 :where(.cursor-not-allowed, .disabled\:cursor-not-allowed:disabled) {
   cursor: not-allowed !important;
@@ -2530,10 +2532,10 @@ strong {
   :root[data-marinara-custom-cursor="enabled"] .cursor-not-allowed,
   :root[data-marinara-custom-cursor="enabled"] .disabled\:cursor-not-allowed:disabled
 ) {
-  cursor: var(--cursor-pink), auto !important;
+  cursor: var(--marinara-custom-cursor) !important;
 }
 :where(:root[data-marinara-custom-cursor="enabled"] .active\:cursor-grabbing:active) {
-  cursor: var(--cursor-pink), auto !important;
+  cursor: var(--marinara-custom-cursor) !important;
 }
 :where(.mari-resize-x) {
   cursor: ew-resize !important;
@@ -2548,7 +2550,7 @@ strong {
   :root[data-marinara-custom-cursor="enabled"] .cursor-w-resize,
   :root[data-marinara-custom-cursor="enabled"] .mari-resize-x
 ) {
-  cursor: var(--cursor-pink), auto !important;
+  cursor: var(--marinara-custom-cursor) !important;
 }
 :where(
   :root[data-marinara-custom-cursor="enabled"] .cursor-row-resize,
@@ -2557,21 +2559,21 @@ strong {
   :root[data-marinara-custom-cursor="enabled"] .cursor-s-resize,
   :root[data-marinara-custom-cursor="enabled"] .mari-resize-y
 ) {
-  cursor: var(--cursor-pink), auto !important;
+  cursor: var(--marinara-custom-cursor) !important;
 }
 :where(
   :root[data-marinara-custom-cursor="enabled"] .cursor-nwse-resize,
   :root[data-marinara-custom-cursor="enabled"] .cursor-nw-resize,
   :root[data-marinara-custom-cursor="enabled"] .cursor-se-resize
 ) {
-  cursor: var(--cursor-pink), auto !important;
+  cursor: var(--marinara-custom-cursor) !important;
 }
 :where(
   :root[data-marinara-custom-cursor="enabled"] .cursor-nesw-resize,
   :root[data-marinara-custom-cursor="enabled"] .cursor-ne-resize,
   :root[data-marinara-custom-cursor="enabled"] .cursor-sw-resize
 ) {
-  cursor: var(--cursor-pink), auto !important;
+  cursor: var(--marinara-custom-cursor) !important;
 }
 
 /* ─────────────────────────────────────────────
@@ -2590,7 +2592,7 @@ strong {
 :root[data-marinara-custom-cursor="enabled"] ::-webkit-scrollbar-track,
 :root[data-marinara-custom-cursor="enabled"] ::-webkit-scrollbar-thumb,
 :root[data-marinara-custom-cursor="enabled"] ::-webkit-scrollbar-corner {
-  cursor: var(--cursor-pink), auto !important;
+  cursor: var(--marinara-custom-cursor) !important;
 }
 
 ::-webkit-scrollbar-track {

--- a/packages/client/src/styles/globals.css
+++ b/packages/client/src/styles/globals.css
@@ -383,8 +383,7 @@
   --marinara-custom-cursor-fill: #d4acfb;
   --marinara-custom-cursor-stroke: #050312;
   --cursor-pink: url("data:image/svg+xml,%3Csvg width='24' height='24' viewBox='0 0 24 24' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M3 3L10 20L12 12L20 10L3 3Z' fill='%23D4ACFB' stroke='%23050312' stroke-width='1'/%3E%3C/svg%3E") 3 3;
-  --cursor-pink-previous: url("data:image/svg+xml,%3Csvg width='24' height='24' viewBox='0 0 24 24' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M3 3L10 20L12 12L20 10L3 3Z' fill='%23D4ACFB' stroke='%23050312' stroke-width='1'/%3E%3C/svg%3E") 3 3;
-  --marinara-custom-cursor: var(--cursor-pink), var(--cursor-pink-previous), auto;
+  --marinara-custom-cursor: var(--cursor-pink), auto;
 
   --y2k-pink: var(--primary);
   --y2k-purple: #d4adfc;

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@marinara-engine/server",
-  "version": "2.0.7",
+  "version": "2.0.8",
   "private": true,
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@marinara-engine/shared",
-  "version": "2.0.7",
+  "version": "2.0.8",
   "private": true,
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/shared/src/constants/defaults.ts
+++ b/packages/shared/src/constants/defaults.ts
@@ -4,7 +4,7 @@
 import type { GenerationParameters } from "../types/prompt.js";
 
 /** App version — single source of truth. */
-export const APP_VERSION = "2.0.7";
+export const APP_VERSION = "2.0.8";
 
 /** Stable synthetic connection id for the built-in local llama sidecar. */
 export const LOCAL_SIDECAR_CONNECTION_ID = "__local_sidecar__";

--- a/start-termux.sh
+++ b/start-termux.sh
@@ -168,6 +168,12 @@ restore_stashed_changes() {
     return 1
 }
 
+has_git_worktree_changes() {
+    ! git diff --quiet 2>/dev/null \
+        || ! git diff --cached --quiet 2>/dev/null \
+        || [ -n "$(git ls-files --others --exclude-standard 2>/dev/null)" ]
+}
+
 # ── Auto-update from Git ──
 if [ "$SKIP_UPDATE" = "1" ]; then
     echo "  [OK] Skipping update check; starting the current local install."
@@ -181,21 +187,32 @@ elif [ -d ".git" ]; then
     else
         TARGET_HEAD=$(git rev-parse origin/main 2>/dev/null || true)
         CURRENT_BRANCH=$(git branch --show-current 2>/dev/null || true)
-        # Stash any tracked local changes (e.g. pnpm install modifying package.json) so the update doesn't fail
+        # Stash local changes, including untracked non-ignored files, so the update doesn't fail
         STASHED=0
         STASH_REF=""
-        if ! git diff --quiet 2>/dev/null || ! git diff --cached --quiet 2>/dev/null; then
-            if git stash push -q -m "auto-stash before update" 2>/dev/null; then
+        if has_git_worktree_changes; then
+            if git stash push -u -q -m "auto-stash before update" 2>/dev/null; then
                 STASHED=1
                 STASH_REF=$(git stash list -1 --format=%gd 2>/dev/null || true)
             fi
         fi
+        UPDATE_LOG=$(mktemp "${TMPDIR:-/tmp}/marinara-update.XXXXXX")
+        UPDATED_TO_TARGET=0
         if [ -z "$CURRENT_BRANCH" ]; then
-            UPDATE_COMMAND=(git checkout --detach "$TARGET_HEAD")
-        else
-            UPDATE_COMMAND=(git merge --ff-only origin/main)
+            if git checkout --detach "$TARGET_HEAD" >"$UPDATE_LOG" 2>&1; then
+                UPDATED_TO_TARGET=1
+            elif git reset --hard "$TARGET_HEAD" >"$UPDATE_LOG" 2>&1; then
+                UPDATED_TO_TARGET=1
+            fi
+        elif git merge --ff-only origin/main >"$UPDATE_LOG" 2>&1; then
+            UPDATED_TO_TARGET=1
+        elif [ "$CURRENT_BRANCH" = "main" ] || [ "$CURRENT_BRANCH" = "master" ]; then
+            echo "  [..] Fast-forward failed; resetting the installed checkout to the released main commit..."
+            if git reset --hard "$TARGET_HEAD" >"$UPDATE_LOG" 2>&1; then
+                UPDATED_TO_TARGET=1
+            fi
         fi
-        if "${UPDATE_COMMAND[@]}" 2>/dev/null; then
+        if [ "$UPDATED_TO_TARGET" = "1" ]; then
             NEW_HEAD=$(git rev-parse HEAD 2>/dev/null)
             if [ "$STASHED" = "1" ]; then
                 restore_stashed_changes || true
@@ -211,10 +228,15 @@ elif [ -d ".git" ]; then
             fi
         else
             echo "  [WARN] Could not update to origin/main. Continuing with current version."
+            if [ -s "$UPDATE_LOG" ]; then
+                echo "         Git reported:"
+                sed 's/^/         /' "$UPDATE_LOG"
+            fi
             if [ "$STASHED" = "1" ]; then
                 restore_stashed_changes || true
             fi
         fi
+        rm -f "$UPDATE_LOG"
     fi
 fi
 

--- a/start-termux.sh
+++ b/start-termux.sh
@@ -190,15 +190,21 @@ elif [ -d ".git" ]; then
         # Stash local changes, including untracked non-ignored files, so the update doesn't fail
         STASHED=0
         STASH_REF=""
+        SKIP_UPDATE_FOR_LOCAL_CHANGES=0
         if has_git_worktree_changes; then
             if git stash push -u -q -m "auto-stash before update" 2>/dev/null; then
                 STASHED=1
                 STASH_REF=$(git stash list -1 --format=%gd 2>/dev/null || true)
+            else
+                SKIP_UPDATE_FOR_LOCAL_CHANGES=1
+                echo "  [WARN] Could not stash local changes. Skipping auto-update to avoid overwriting them."
             fi
         fi
         UPDATE_LOG=$(mktemp "${TMPDIR:-/tmp}/marinara-update.XXXXXX")
         UPDATED_TO_TARGET=0
-        if [ -z "$CURRENT_BRANCH" ]; then
+        if [ "$SKIP_UPDATE_FOR_LOCAL_CHANGES" = "1" ]; then
+            UPDATED_TO_TARGET=0
+        elif [ -z "$CURRENT_BRANCH" ]; then
             if git checkout --detach "$TARGET_HEAD" >"$UPDATE_LOG" 2>&1; then
                 UPDATED_TO_TARGET=1
             elif git reset --hard "$TARGET_HEAD" >"$UPDATE_LOG" 2>&1; then
@@ -226,7 +232,7 @@ elif [ -d ".git" ]; then
                 rm -rf packages/shared/dist packages/server/dist packages/client/dist
                 rm -f packages/shared/tsconfig.tsbuildinfo packages/server/tsconfig.tsbuildinfo packages/client/tsconfig.tsbuildinfo
             fi
-        else
+        elif [ "$SKIP_UPDATE_FOR_LOCAL_CHANGES" != "1" ]; then
             echo "  [WARN] Could not update to origin/main. Continuing with current version."
             if [ -s "$UPDATE_LOG" ]; then
                 echo "         Git reported:"

--- a/start.bat
+++ b/start.bat
@@ -125,6 +125,7 @@ if exist "app-icon.ico" (
 set "STASHED=0"
 set "STASH_REF="
 set "DIRTY=0"
+set "STASH_FAILED=0"
 git diff --quiet >nul 2>&1
 if errorlevel 1 set "DIRTY=1"
 git diff --cached --quiet >nul 2>&1
@@ -134,6 +135,7 @@ for /f "tokens=*" %%i in ('git ls-files --others --exclude-standard 2^>nul') do 
 if defined UNTRACKED set "DIRTY=1"
 if "!DIRTY!"=="1" (
     git stash push -u -q -m "auto-stash before update" >nul 2>&1 && set "STASHED=1"
+    if not "!STASHED!"=="1" set "STASH_FAILED=1"
     if "!STASHED!"=="1" for /f "tokens=*" %%i in ('git stash list -1 --format^=%%gd 2^>nul') do set "STASH_REF=%%i"
 )
 set "CURRENT_BRANCH="
@@ -144,17 +146,25 @@ if /I "!CURRENT_BRANCH!"=="main" set "ALLOW_DETACHED_FALLBACK=1"
 if /I "!CURRENT_BRANCH!"=="master" set "ALLOW_DETACHED_FALLBACK=1"
 set "UPDATE_LOG=%TEMP%\marinara-update-!RANDOM!-!RANDOM!.log"
 if exist "!UPDATE_LOG!" del /q "!UPDATE_LOG!" >nul 2>&1
-if "!CURRENT_BRANCH!"=="" (
-    git checkout --detach "!TARGET_HEAD!" >"!UPDATE_LOG!" 2>&1 && set "UPDATED_TO_TARGET=1"
-    if not "!UPDATED_TO_TARGET!"=="1" git reset --hard "!TARGET_HEAD!" >"!UPDATE_LOG!" 2>&1 && set "UPDATED_TO_TARGET=1"
+if "!STASH_FAILED!"=="1" (
+    echo  [WARN] Could not stash local changes. Skipping auto-update to avoid overwriting them.
 ) else (
-    git merge --ff-only origin/main >"!UPDATE_LOG!" 2>&1 && set "UPDATED_TO_TARGET=1"
-    if not "!UPDATED_TO_TARGET!"=="1" if "!ALLOW_DETACHED_FALLBACK!"=="1" (
-        echo  [..] Fast-forward failed; resetting the installed checkout to the released main commit...
-        git reset --hard "!TARGET_HEAD!" >"!UPDATE_LOG!" 2>&1 && set "UPDATED_TO_TARGET=1"
+    if "!CURRENT_BRANCH!"=="" (
+        git checkout --detach "!TARGET_HEAD!" >"!UPDATE_LOG!" 2>&1 && set "UPDATED_TO_TARGET=1"
+        if not "!UPDATED_TO_TARGET!"=="1" git reset --hard "!TARGET_HEAD!" >"!UPDATE_LOG!" 2>&1 && set "UPDATED_TO_TARGET=1"
+    ) else (
+        git merge --ff-only origin/main >"!UPDATE_LOG!" 2>&1 && set "UPDATED_TO_TARGET=1"
+        if not "!UPDATED_TO_TARGET!"=="1" if "!ALLOW_DETACHED_FALLBACK!"=="1" (
+            echo  [..] Fast-forward failed; resetting the installed checkout to the released main commit...
+            git reset --hard "!TARGET_HEAD!" >"!UPDATE_LOG!" 2>&1 && set "UPDATED_TO_TARGET=1"
+        )
     )
 )
 if not "!UPDATED_TO_TARGET!"=="1" (
+    if "!STASH_FAILED!"=="1" (
+        if exist "!UPDATE_LOG!" del /q "!UPDATE_LOG!" >nul 2>&1
+        goto :skip_update
+    )
     if "!STASHED!"=="1" call :restore_stashed_changes
     echo  [WARN] Could not update to origin/main. Continuing with current version.
     if exist "!UPDATE_LOG!" (

--- a/start.bat
+++ b/start.bat
@@ -121,7 +121,7 @@ if exist "app-icon.ico" (
     if errorlevel 1 del /q "app-icon.ico" >nul 2>&1
 )
 
-:: Stash any tracked local changes so the update doesn't fail
+:: Stash local changes, including untracked non-ignored files, so the update doesn't fail
 set "STASHED=0"
 set "STASH_REF="
 set "DIRTY=0"
@@ -129,30 +129,52 @@ git diff --quiet >nul 2>&1
 if errorlevel 1 set "DIRTY=1"
 git diff --cached --quiet >nul 2>&1
 if errorlevel 1 set "DIRTY=1"
+set "UNTRACKED="
+for /f "tokens=*" %%i in ('git ls-files --others --exclude-standard 2^>nul') do if not defined UNTRACKED set "UNTRACKED=1"
+if defined UNTRACKED set "DIRTY=1"
 if "!DIRTY!"=="1" (
-    git stash push -q -m "auto-stash before update" >nul 2>&1 && set "STASHED=1"
+    git stash push -u -q -m "auto-stash before update" >nul 2>&1 && set "STASHED=1"
     if "!STASHED!"=="1" for /f "tokens=*" %%i in ('git stash list -1 --format^=%%gd 2^>nul') do set "STASH_REF=%%i"
 )
 set "CURRENT_BRANCH="
 for /f "tokens=*" %%i in ('git branch --show-current 2^>nul') do set "CURRENT_BRANCH=%%i"
 set "UPDATED_TO_TARGET=0"
+set "ALLOW_DETACHED_FALLBACK=0"
+if /I "!CURRENT_BRANCH!"=="main" set "ALLOW_DETACHED_FALLBACK=1"
+if /I "!CURRENT_BRANCH!"=="master" set "ALLOW_DETACHED_FALLBACK=1"
+set "UPDATE_LOG=%TEMP%\marinara-update-!RANDOM!-!RANDOM!.log"
+if exist "!UPDATE_LOG!" del /q "!UPDATE_LOG!" >nul 2>&1
 if "!CURRENT_BRANCH!"=="" (
-    git checkout --detach "!TARGET_HEAD!" >nul 2>&1 && set "UPDATED_TO_TARGET=1"
+    git checkout --detach "!TARGET_HEAD!" >"!UPDATE_LOG!" 2>&1 && set "UPDATED_TO_TARGET=1"
+    if not "!UPDATED_TO_TARGET!"=="1" git reset --hard "!TARGET_HEAD!" >"!UPDATE_LOG!" 2>&1 && set "UPDATED_TO_TARGET=1"
 ) else (
-    git merge --ff-only origin/main >nul 2>&1 && set "UPDATED_TO_TARGET=1"
+    git merge --ff-only origin/main >"!UPDATE_LOG!" 2>&1 && set "UPDATED_TO_TARGET=1"
+    if not "!UPDATED_TO_TARGET!"=="1" if "!ALLOW_DETACHED_FALLBACK!"=="1" (
+        echo  [..] Fast-forward failed; resetting the installed checkout to the released main commit...
+        git reset --hard "!TARGET_HEAD!" >"!UPDATE_LOG!" 2>&1 && set "UPDATED_TO_TARGET=1"
+    )
 )
 if not "!UPDATED_TO_TARGET!"=="1" (
     if "!STASHED!"=="1" call :restore_stashed_changes
     echo  [WARN] Could not update to origin/main. Continuing with current version.
+    if exist "!UPDATE_LOG!" (
+        for %%A in ("!UPDATE_LOG!") do if %%~zA GTR 0 (
+            echo         Git reported:
+            for /f "usebackq delims=" %%i in ("!UPDATE_LOG!") do echo         %%i
+        )
+        del /q "!UPDATE_LOG!" >nul 2>&1
+    )
     goto :skip_update
 )
 for /f "tokens=*" %%i in ('git rev-parse HEAD 2^>nul') do set "NEW_HEAD=%%i"
 if /I not "!NEW_HEAD!"=="!TARGET_HEAD!" (
     if "!STASHED!"=="1" call :restore_stashed_changes
     echo  [WARN] Update did not land on origin/main. Continuing with current version.
+    if exist "!UPDATE_LOG!" del /q "!UPDATE_LOG!" >nul 2>&1
     goto :skip_update
 )
 if "!STASHED!"=="1" call :restore_stashed_changes
+if exist "!UPDATE_LOG!" del /q "!UPDATE_LOG!" >nul 2>&1
 echo  [OK] Updated to latest version
 echo  [..] Reinstalling dependencies...
 call :run_pnpm install

--- a/start.sh
+++ b/start.sh
@@ -91,6 +91,12 @@ restore_stashed_changes() {
     return 1
 }
 
+has_git_worktree_changes() {
+    ! git diff --quiet 2>/dev/null \
+        || ! git diff --cached --quiet 2>/dev/null \
+        || [ -n "$(git ls-files --others --exclude-standard 2>/dev/null)" ]
+}
+
 # ── Auto-update from Git ──
 if [ -d ".git" ]; then
     echo "  [..] Checking for updates..."
@@ -102,21 +108,32 @@ if [ -d ".git" ]; then
     else
         TARGET_HEAD=$(git rev-parse origin/main 2>/dev/null || true)
         CURRENT_BRANCH=$(git branch --show-current 2>/dev/null || true)
-        # Stash any tracked local changes (e.g. pnpm install modifying package.json) so the update doesn't fail
+        # Stash local changes, including untracked non-ignored files, so the update doesn't fail
         STASHED=0
         STASH_REF=""
-        if ! git diff --quiet 2>/dev/null || ! git diff --cached --quiet 2>/dev/null; then
-            if git stash push -q -m "auto-stash before update" 2>/dev/null; then
+        if has_git_worktree_changes; then
+            if git stash push -u -q -m "auto-stash before update" 2>/dev/null; then
                 STASHED=1
                 STASH_REF=$(git stash list -1 --format=%gd 2>/dev/null || true)
             fi
         fi
+        UPDATE_LOG=$(mktemp "${TMPDIR:-/tmp}/marinara-update.XXXXXX")
+        UPDATED_TO_TARGET=0
         if [ -z "$CURRENT_BRANCH" ]; then
-            UPDATE_COMMAND=(git checkout --detach "$TARGET_HEAD")
-        else
-            UPDATE_COMMAND=(git merge --ff-only origin/main)
+            if git checkout --detach "$TARGET_HEAD" >"$UPDATE_LOG" 2>&1; then
+                UPDATED_TO_TARGET=1
+            elif git reset --hard "$TARGET_HEAD" >"$UPDATE_LOG" 2>&1; then
+                UPDATED_TO_TARGET=1
+            fi
+        elif git merge --ff-only origin/main >"$UPDATE_LOG" 2>&1; then
+            UPDATED_TO_TARGET=1
+        elif [ "$CURRENT_BRANCH" = "main" ] || [ "$CURRENT_BRANCH" = "master" ]; then
+            echo "  [..] Fast-forward failed; resetting the installed checkout to the released main commit..."
+            if git reset --hard "$TARGET_HEAD" >"$UPDATE_LOG" 2>&1; then
+                UPDATED_TO_TARGET=1
+            fi
         fi
-        if "${UPDATE_COMMAND[@]}" 2>/dev/null; then
+        if [ "$UPDATED_TO_TARGET" = "1" ]; then
             NEW_HEAD=$(git rev-parse HEAD 2>/dev/null)
             if [ "$STASHED" = "1" ]; then
                 restore_stashed_changes || true
@@ -133,10 +150,15 @@ if [ -d ".git" ]; then
             fi
         else
             echo "  [WARN] Could not update to origin/main. Continuing with current version."
+            if [ -s "$UPDATE_LOG" ]; then
+                echo "         Git reported:"
+                sed 's/^/         /' "$UPDATE_LOG"
+            fi
             if [ "$STASHED" = "1" ]; then
                 restore_stashed_changes || true
             fi
         fi
+        rm -f "$UPDATE_LOG"
     fi
 fi
 

--- a/start.sh
+++ b/start.sh
@@ -111,15 +111,21 @@ if [ -d ".git" ]; then
         # Stash local changes, including untracked non-ignored files, so the update doesn't fail
         STASHED=0
         STASH_REF=""
+        SKIP_UPDATE_FOR_LOCAL_CHANGES=0
         if has_git_worktree_changes; then
             if git stash push -u -q -m "auto-stash before update" 2>/dev/null; then
                 STASHED=1
                 STASH_REF=$(git stash list -1 --format=%gd 2>/dev/null || true)
+            else
+                SKIP_UPDATE_FOR_LOCAL_CHANGES=1
+                echo "  [WARN] Could not stash local changes. Skipping auto-update to avoid overwriting them."
             fi
         fi
         UPDATE_LOG=$(mktemp "${TMPDIR:-/tmp}/marinara-update.XXXXXX")
         UPDATED_TO_TARGET=0
-        if [ -z "$CURRENT_BRANCH" ]; then
+        if [ "$SKIP_UPDATE_FOR_LOCAL_CHANGES" = "1" ]; then
+            UPDATED_TO_TARGET=0
+        elif [ -z "$CURRENT_BRANCH" ]; then
             if git checkout --detach "$TARGET_HEAD" >"$UPDATE_LOG" 2>&1; then
                 UPDATED_TO_TARGET=1
             elif git reset --hard "$TARGET_HEAD" >"$UPDATE_LOG" 2>&1; then
@@ -148,7 +154,7 @@ if [ -d ".git" ]; then
                 rm -rf packages/shared/dist packages/server/dist packages/client/dist
                 rm -f packages/shared/tsconfig.tsbuildinfo packages/server/tsconfig.tsbuildinfo packages/client/tsconfig.tsbuildinfo
             fi
-        else
+        elif [ "$SKIP_UPDATE_FOR_LOCAL_CHANGES" != "1" ]; then
             echo "  [WARN] Could not update to origin/main. Continuing with current version."
             if [ -s "$UPDATE_LOG" ]; then
                 echo "         Git reported:"

--- a/win/installer/install.bat
+++ b/win/installer/install.bat
@@ -11,14 +11,14 @@ set "NODE_DOWNLOAD_URL=https://nodejs.org/dist/v24.15.0/node-v24.15.0-x64.msi"
 set "NODE_SHA256=feffb8e5cb5ac47f793666636d496ef3e975be82c84c4da5d20e6aa8fa4eb806"
 set "GIT_DOWNLOAD_URL=https://github.com/git-for-windows/git/releases/download/v2.54.0.windows.1/Git-2.54.0-64-bit.exe"
 set "GIT_SHA256=2b96e7854f0520f0f6b709c21041d9801b1be44d5e1a0d9fa621b2fbc40f1983"
-set "RELEASE_TAG=v2.0.7"
+set "RELEASE_TAG=v2.0.8"
 if not defined MARINARA_RELEASE_COMMIT set "MARINARA_RELEASE_COMMIT="
 set "RELEASE_COMMIT=%MARINARA_RELEASE_COMMIT%"
 
 echo.
 echo  +==========================================+
 echo  ^|   Marinara Engine - Windows Installer     ^|
-echo  ^|   v2.0.7                                  ^|
+echo  ^|   v2.0.8                                  ^|
 
 echo  +==========================================+
 echo.

--- a/win/installer/installer.nsi
+++ b/win/installer/installer.nsi
@@ -13,7 +13,7 @@
 
 ; ── App metadata ──
 !define APP_NAME "Marinara Engine"
-!define APP_VERSION "2.0.7"
+!define APP_VERSION "2.0.8"
 !define APP_PUBLISHER "Pasta-Devs"
 !define APP_URL "https://github.com/Pasta-Devs/Marinara-Engine"
 !define REPO_URL "https://github.com/Pasta-Devs/Marinara-Engine.git"
@@ -27,7 +27,7 @@
 !define NODE_DOWNLOAD_URL "https://nodejs.org/dist/v24.15.0/node-v24.15.0-x64.msi"
 !define GIT_SHA256 "2b96e7854f0520f0f6b709c21041d9801b1be44d5e1a0d9fa621b2fbc40f1983"
 !define NODE_SHA256 "feffb8e5cb5ac47f793666636d496ef3e975be82c84c4da5d20e6aa8fa4eb806"
-!define RELEASE_TAG "v2.0.7"
+!define RELEASE_TAG "v2.0.8"
 !ifndef RELEASE_COMMIT
 !define RELEASE_COMMIT ""
 !endif


### PR DESCRIPTION
## Summary

Prepares v2.0.8 release metadata and fixes the update/install edges found after v2.0.7:

- Bumps Marinara Engine version metadata to v2.0.8 across package, shared app version, PWA manifest, Windows installer sources, README, and Android APK metadata.
- Hardens Windows, macOS/Linux, and Termux launcher updates by preserving untracked local files, keeping generated registries LF on Windows, printing Git errors, and resetting installer-style main/detached checkouts to the fetched main commit when fast-forward update fails.
- Fixes Android APK fallback copy so a blocked Termux setup launch copies a full Marinara setup command instead of instructing fresh Termux users to run a missing script.
- Keeps custom cursor recoloring from doing unnecessary work when the custom pointer is disabled, and preserves the previous cursor image during slow recolors.

## Validation

Ran locally:

- pnpm version:check
- pnpm check
- pnpm --filter @marinara-engine/client lint
- pnpm --filter @marinara-engine/client build
- pnpm guard:installer-artifacts
- bash -n start.sh && bash -n start-termux.sh
- git diff --check

Manual verification still recommended before release:

- Verify Windows installer/start.bat update from a shallow tag install.
- Verify Android APK Termux handoff and blocked-handoff manual command on device.
- Verify homepage/version display reads v2.0.8 after build.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved Android Termux “manual fallback” by providing a single paste-and-run setup command and clearer restart guidance when launches are blocked.
* **Bug Fixes**
  * Enhanced auto-updater resilience across platforms by detecting more “dirty” working trees (including untracked files) and improving update/rollback behavior.
  * Smoothed custom cursor recoloring to reduce rapid flicker and support slower animated updates.
* **Documentation**
  * Updated changelog, installation, FAQ, troubleshooting, and upgrading guides to reflect the 2.0.8 Termux and updater behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->