### PR TITLE
Fix Mari command gaps and generation retry issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 
 - Fixed continue generation with rewrite agents so continued assistant messages are rewritten from the full merged message instead of being overwritten by only the new continuation text.
 - Added backoff for failed conversation summaries and server-side autonomous generations so permanent 4xx/model errors no longer retry every poll forever.
+- Fixed staging updates so Settings can target the current checkout branch, staging applies create/update a real local `staging` branch, and Windows/macOS/Linux/Termux launchers no longer drag staging installs back to stable `main`.
 - Expanded Professor Mari data commands with paginated chat message offsets, lorebook entry lookup by entry id, entry descriptions in lorebook entry lists, and entry tag support for add/update flows.
 - Polished mobile input controls by using a paperclip attachment icon in Conversation mode, placing Game mode attachments before the address selector, hiding Roleplay's mobile emoji button, and tightening Game/Roleplay composer spacing.
 - Fixed migrated default agent prompts causing roleplay lag by keeping compatible agents batched with a raw JSON result map instead of wrapping JSON-only prompts in `<result>` tags, and made the default-prompt migration stop rewriting already-current named prompt options on every startup.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,9 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 ### Fixed
 
 - Fixed continue generation with rewrite agents so continued assistant messages are rewritten from the full merged message instead of being overwritten by only the new continuation text.
-- Added backoff for failed conversation summaries and server-side autonomous generations so permanent 4xx/model errors no longer retry every poll forever.
+- Added backoff for failed conversation summaries and server-side autonomous generations so permanent 4xx/model errors no longer retry every poll forever, while keeping stored failure metadata sanitized and bounded.
 - Fixed staging updates so Settings can target the current checkout branch, staging applies create/update a real local `staging` branch, and Windows/macOS/Linux/Termux launchers no longer drag staging installs back to stable `main`.
-- Expanded Professor Mari data commands with paginated chat message offsets, lorebook entry lookup by entry id, entry descriptions in lorebook entry lists, and entry tag support for add/update flows.
+- Expanded Professor Mari data commands with paginated chat message offsets, full lorebook entry lookup by entry id, entry descriptions in lorebook entry lists, and entry tag support for add/update flows.
 - Polished mobile input controls by using a paperclip attachment icon in Conversation mode, placing Game mode attachments before the address selector, hiding Roleplay's mobile emoji button, and tightening Game/Roleplay composer spacing.
 - Fixed migrated default agent prompts causing roleplay lag by keeping compatible agents batched with a raw JSON result map instead of wrapping JSON-only prompts in `<result>` tags, and made the default-prompt migration stop rewriting already-current named prompt options on every startup.
 - Fixed agent UI flicker by scoping agent processing and failure badges to the chat that owns the run, and stopped ChatArea from repeatedly auto-switching Game chats to the newest session during chat-list refreshes.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 
 ### Fixed
 
+- Fixed continue generation with rewrite agents so continued assistant messages are rewritten from the full merged message instead of being overwritten by only the new continuation text.
+- Added backoff for failed conversation summaries and server-side autonomous generations so permanent 4xx/model errors no longer retry every poll forever.
+- Expanded Professor Mari data commands with paginated chat message offsets, lorebook entry lookup by entry id, entry descriptions in lorebook entry lists, and entry tag support for add/update flows.
+- Polished mobile input controls by using a paperclip attachment icon in Conversation mode, placing Game mode attachments before the address selector, hiding Roleplay's mobile emoji button, and tightening Game/Roleplay composer spacing.
 - Fixed migrated default agent prompts causing roleplay lag by keeping compatible agents batched with a raw JSON result map instead of wrapping JSON-only prompts in `<result>` tags, and made the default-prompt migration stop rewriting already-current named prompt options on every startup.
 - Fixed agent UI flicker by scoping agent processing and failure badges to the chat that owns the run, and stopped ChatArea from repeatedly auto-switching Game chats to the newest session during chat-list refreshes.
 - Reduced background request churn by stopping synced themes/extensions from polling every 15 seconds and slowing Professor Mari workspace status refreshes outside explicit workspace actions.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 - Hardened prompt regex scripts against polynomial ReDoS by rejecting chained broad unbounded patterns and guarding long server-side replacement runs with a VM timeout.
 - Improved profile/backup ZIP import diagnostics when the selected archive does not contain `marinara-profile.json`.
 - Tightened Android Firefox chat input sizing so the mobile composer grows less rigidly and leaves more room for typed text.
+- Shortened mobile Roleplay and Conversation composer placeholders so command hints do not wrap and pull the input caret upward.
 
 ### Platform Notes
 

--- a/docs/UPGRADING.md
+++ b/docs/UPGRADING.md
@@ -20,7 +20,7 @@ Close Marinara Engine and run:
 ./start.sh
 ```
 
-The launcher fetches `origin/main`, fast-forwards normal clones or moves detached release checkouts to the released code, reinstalls dependencies when needed, rebuilds, and starts v2.0.0.
+The launcher fetches the current update branch, fast-forwards normal clones or moves detached release checkouts to the released code, reinstalls dependencies when needed, rebuilds, and starts v2.0.0. Local `staging` branches follow `origin/staging`; all other launcher checkouts follow stable `origin/main`.
 
 If it says Node.js is too old, install Node.js 24 LTS or newer, then run `./start.sh` again.
 

--- a/docs/installation/android-termux.md
+++ b/docs/installation/android-termux.md
@@ -73,7 +73,7 @@ The Termux launcher binds to `0.0.0.0` by default, so the app is already reachab
 
 The `start-termux.sh` launcher automatically updates Marinara Engine on each run:
 
-1. Fetches the latest code from GitHub into `origin/main`, then fast-forwards normal clones or moves detached release checkouts to that commit
+1. Fetches the latest code for the current update branch, then fast-forwards normal clones or moves detached release checkouts to that commit. Local `staging` branches follow `origin/staging`; all other launcher checkouts follow stable `origin/main`.
 2. Detects whether the checkout changed
 3. Temporarily stashes tracked local changes if needed, then reapplies them
 4. Reinstalls dependencies and rebuilds when needed

--- a/docs/installation/macos-linux.md
+++ b/docs/installation/macos-linux.md
@@ -101,7 +101,7 @@ Want to use Marinara Engine from your phone, tablet, or another computer? See th
 
 When you launch Marinara Engine via `./start.sh` from a git checkout, the launcher automatically:
 
-1. Fetches the latest code from GitHub into `origin/main`, then fast-forwards normal clones or moves detached release checkouts to that commit
+1. Fetches the latest code for the current update branch, then fast-forwards normal clones or moves detached release checkouts to that commit. Local `staging` branches follow `origin/staging`; all other launcher checkouts follow stable `origin/main`.
 2. Detects whether the checkout changed
 3. Temporarily stashes tracked local changes if needed, then reapplies them
 4. Reinstalls dependencies and rebuilds when needed
@@ -120,6 +120,15 @@ If you use a git checkout without the launcher or the in-app updater:
 ```bash
 git fetch origin +refs/heads/main:refs/remotes/origin/main
 git merge --ff-only origin/main || git checkout --detach origin/main
+pnpm install
+pnpm build
+```
+
+For tester builds, use the staging target instead:
+
+```bash
+git fetch origin +refs/heads/staging:refs/remotes/origin/staging
+git checkout -B staging origin/staging
 pnpm install
 pnpm build
 ```

--- a/docs/installation/windows.md
+++ b/docs/installation/windows.md
@@ -81,7 +81,7 @@ Want to use Marinara Engine from your phone, tablet, or another computer? See th
 
 When you launch Marinara Engine via the Start Menu shortcut or `start.bat` from a git checkout, the launcher automatically:
 
-1. Fetches the latest code from GitHub into `origin/main`, then fast-forwards normal clones or moves installer-created release checkouts to that commit
+1. Fetches the latest code for the current update branch, then fast-forwards normal clones or moves installer-created release checkouts to that commit. Local `staging` branches follow `origin/staging`; all other launcher checkouts follow stable `origin/main`.
 2. Detects whether the checkout changed
 3. Temporarily stashes tracked local changes if needed, then reapplies them
 4. Reinstalls dependencies and rebuilds when needed
@@ -102,6 +102,15 @@ If you use a git checkout without the launcher or the in-app updater:
 ```bat
 git fetch origin +refs/heads/main:refs/remotes/origin/main
 git merge --ff-only origin/main || git checkout --detach origin/main
+pnpm install
+pnpm build
+```
+
+For tester builds, use the staging target instead:
+
+```bat
+git fetch origin +refs/heads/staging:refs/remotes/origin/staging
+git checkout -B staging origin/staging
 pnpm install
 pnpm build
 ```

--- a/packages/client/src/components/chat/ChatInput.tsx
+++ b/packages/client/src/components/chat/ChatInput.tsx
@@ -1508,7 +1508,7 @@ export const ChatInput = memo(function ChatInput({
           onClick={() => fileInputRef.current?.click()}
           disabled={!activeChatId}
           className={cn(
-            "flex h-11 w-11 items-center justify-center rounded-xl transition-all active:scale-90 disabled:cursor-not-allowed disabled:text-foreground/25 disabled:opacity-50 sm:h-8 sm:w-8",
+            "flex h-9 w-9 items-center justify-center rounded-xl transition-all active:scale-90 disabled:cursor-not-allowed disabled:text-foreground/25 disabled:opacity-50 sm:h-8 sm:w-8",
             attachments.length
               ? "bg-foreground/10 text-foreground/75 ring-1 ring-foreground/20"
               : "text-foreground/40 hover:bg-foreground/10 hover:text-foreground/70",
@@ -1551,12 +1551,12 @@ export const ChatInput = memo(function ChatInput({
         />
 
         {/* Emoji picker */}
-        <div className="relative shrink-0">
+        <div className="relative hidden shrink-0 sm:block">
           <button
             ref={emojiButtonRef}
             onClick={() => setEmojiOpen((v) => !v)}
             className={cn(
-              "flex h-11 w-11 items-center justify-center rounded-xl transition-colors active:scale-90 sm:h-8 sm:w-8 sm:rounded-full",
+              "flex h-8 w-8 items-center justify-center rounded-full transition-colors active:scale-90",
               emojiOpen
                 ? "bg-foreground/10 text-foreground/75 ring-1 ring-foreground/20"
                 : "text-foreground/40 hover:bg-foreground/10 hover:text-foreground/70",
@@ -1637,7 +1637,7 @@ export const ChatInput = memo(function ChatInput({
             !activeChatId
           }
           className={cn(
-            "mari-chat-send-btn flex h-11 w-11 shrink-0 items-center justify-center rounded-xl transition-all duration-200 sm:h-8 sm:w-8",
+            "mari-chat-send-btn flex h-9 w-9 shrink-0 items-center justify-center rounded-xl transition-all duration-200 sm:h-8 sm:w-8",
             isStreaming
               ? "text-foreground/75 hover:bg-foreground/10 hover:text-foreground/90"
               : (hasInput || attachments.length || canRetry || canContinue) && activeChatId && !isReadingAttachments

--- a/packages/client/src/components/chat/ChatInput.tsx
+++ b/packages/client/src/components/chat/ChatInput.tsx
@@ -125,12 +125,12 @@ function resizeChatInputTextarea(el: HTMLTextAreaElement) {
 
 function useIsMobileComposerViewport() {
   const [isMobileViewport, setIsMobileViewport] = useState(() =>
-    typeof window === "undefined" ? false : window.matchMedia("(max-width: 767px)").matches,
+    typeof window === "undefined" ? false : window.matchMedia("(max-width: 639px)").matches,
   );
 
   useEffect(() => {
     if (typeof window === "undefined") return;
-    const media = window.matchMedia("(max-width: 767px)");
+    const media = window.matchMedia("(max-width: 639px)");
     const update = () => setIsMobileViewport(media.matches);
     update();
     media.addEventListener("change", update);

--- a/packages/client/src/components/chat/ChatInput.tsx
+++ b/packages/client/src/components/chat/ChatInput.tsx
@@ -123,6 +123,23 @@ function resizeChatInputTextarea(el: HTMLTextAreaElement) {
   el.style.height = `${Math.min(el.scrollHeight, getChatInputTextareaMaxHeightPx())}px`;
 }
 
+function useIsMobileComposerViewport() {
+  const [isMobileViewport, setIsMobileViewport] = useState(() =>
+    typeof window === "undefined" ? false : window.matchMedia("(max-width: 767px)").matches,
+  );
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    const media = window.matchMedia("(max-width: 767px)");
+    const update = () => setIsMobileViewport(media.matches);
+    update();
+    media.addEventListener("change", update);
+    return () => media.removeEventListener("change", update);
+  }, []);
+
+  return isMobileViewport;
+}
+
 function readFileAsDataUrl(file: Blob): Promise<string> {
   return new Promise((resolve, reject) => {
     const reader = new FileReader();
@@ -170,6 +187,7 @@ export const ChatInput = memo(function ChatInput({
   const [pendingAttachmentReadsByChat, setPendingAttachmentReadsByChat] = useState<Record<string, number>>({});
   const [isTranslatingDraft, setIsTranslatingDraft] = useState(false);
   const [emojiOpen, setEmojiOpen] = useState(false);
+  const isMobileComposerViewport = useIsMobileComposerViewport();
   const [pushStoryArmed, setPushStoryArmed] = useState(false);
   const [isDragging, setIsDragging] = useState(false);
   const [charPickerOpen, setCharPickerOpen] = useState(false);
@@ -212,6 +230,14 @@ export const ChatInput = memo(function ChatInput({
     () => (activeChatCharacters ? activeChatCharacters.map((character) => character.name) : characterNames),
     [activeChatCharacters, characterNames],
   );
+  const inputPlaceholder = useMemo(() => {
+    if (!activeChatId) return "Select a chat first";
+    if (isMobileComposerViewport) return mode === "roleplay" ? "Write… /cmds" : "Message… /cmds";
+    if (mode === "roleplay") return "Write your response, / for commands";
+    if (activeCharacterNames.length > 1) return `Message @${activeCharacterNames.join(", @")}, / for commands`;
+    if (activeCharacterNames.length === 1) return `Message @${activeCharacterNames[0]}, / for commands`;
+    return "Type here, / for commands.";
+  }, [activeCharacterNames, activeChatId, isMobileComposerViewport, mode]);
   const queuedResponseOrder = useMemo(
     () => new Map(responseQueue.map((characterId, index) => [characterId, index + 1])),
     [responseQueue],
@@ -1532,17 +1558,7 @@ export const ChatInput = memo(function ChatInput({
           onKeyDown={handleKeyDown}
           onPaste={handlePaste}
           onFocus={ensureInputVisible}
-          placeholder={
-            activeChatId
-              ? mode === "roleplay"
-                ? "Write your response, / for commands"
-                : activeCharacterNames.length > 0
-                  ? activeCharacterNames.length > 1
-                    ? `Message @${activeCharacterNames.join(", @")}, / for commands`
-                    : `Message @${activeCharacterNames[0]}, / for commands`
-                  : "Type here, / for commands."
-              : "Select a chat first"
-          }
+          placeholder={inputPlaceholder}
           disabled={!activeChatId}
           rows={1}
           spellCheck

--- a/packages/client/src/components/chat/ConversationInput.tsx
+++ b/packages/client/src/components/chat/ConversationInput.tsx
@@ -264,6 +264,23 @@ function readFileAsDataUrl(file: Blob): Promise<string> {
   });
 }
 
+function useIsMobileComposerViewport() {
+  const [isMobileViewport, setIsMobileViewport] = useState(() =>
+    typeof window === "undefined" ? false : window.matchMedia("(max-width: 767px)").matches,
+  );
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    const media = window.matchMedia("(max-width: 767px)");
+    const update = () => setIsMobileViewport(media.matches);
+    update();
+    media.addEventListener("change", update);
+    return () => media.removeEventListener("change", update);
+  }, []);
+
+  return isMobileViewport;
+}
+
 interface ConversationInputProps {
   characterNames?: string[];
   groupResponseOrder?: string;
@@ -296,6 +313,7 @@ export function ConversationInput({
   const [stickerOpen, setStickerOpen] = useState(false);
   const [mobilePickerOpen, setMobilePickerOpen] = useState(false);
   const [mobilePickerTab, setMobilePickerTab] = useState<"emoji" | "gifs" | "stickers">("emoji");
+  const isMobileComposerViewport = useIsMobileComposerViewport();
   const [isDragging, setIsDragging] = useState(false);
   // @mention autocomplete
   const [_mentionQuery, setMentionQuery] = useState<string | null>(null);
@@ -370,6 +388,17 @@ export function ConversationInput({
     [activeChatCharacters, characterNames],
   );
   const requiresManualGuideTarget = groupResponseOrder === "manual" && activeCharacterNames.length > 1;
+  const inputPlaceholder = useMemo(() => {
+    if (isMobileComposerViewport) return "Message… /cmds";
+    if (groupResponseOrder === "manual") {
+      return activeCharacterNames.length > 0
+        ? `Message freely; @${activeCharacterNames[0]} to get a reply`
+        : "Message freely...";
+    }
+    if (activeCharacterNames.length > 1 && chatName) return `Message ${chatName}, / for commands`;
+    if (activeCharacterNames.length > 0) return `Message @${activeCharacterNames[0]}, / for commands`;
+    return "Message...";
+  }, [activeCharacterNames, chatName, groupResponseOrder, isMobileComposerViewport]);
 
   // Read from the existing infinite-message cache so an empty Send can retry
   // after a failed generation without adding a second user message.
@@ -1930,17 +1959,7 @@ export function ConversationInput({
 
         <textarea
           ref={textareaRef}
-          placeholder={
-            groupResponseOrder === "manual"
-              ? activeCharacterNames.length > 0
-                ? `Message freely; @${activeCharacterNames[0]} to get a reply`
-                : "Message freely..."
-              : activeCharacterNames.length > 1 && chatName
-                ? `Message ${chatName}, / for commands`
-                : activeCharacterNames.length > 0
-                  ? `Message @${activeCharacterNames[0]}, / for commands`
-                  : "Message..."
-          }
+          placeholder={inputPlaceholder}
           rows={1}
           onInput={handleInput}
           onKeyDown={handleKeyDown}

--- a/packages/client/src/components/chat/ConversationInput.tsx
+++ b/packages/client/src/components/chat/ConversationInput.tsx
@@ -266,12 +266,12 @@ function readFileAsDataUrl(file: Blob): Promise<string> {
 
 function useIsMobileComposerViewport() {
   const [isMobileViewport, setIsMobileViewport] = useState(() =>
-    typeof window === "undefined" ? false : window.matchMedia("(max-width: 767px)").matches,
+    typeof window === "undefined" ? false : window.matchMedia("(max-width: 639px)").matches,
   );
 
   useEffect(() => {
     if (typeof window === "undefined") return;
-    const media = window.matchMedia("(max-width: 767px)");
+    const media = window.matchMedia("(max-width: 639px)");
     const update = () => setIsMobileViewport(media.matches);
     update();
     media.addEventListener("change", update);
@@ -389,12 +389,15 @@ export function ConversationInput({
   );
   const requiresManualGuideTarget = groupResponseOrder === "manual" && activeCharacterNames.length > 1;
   const inputPlaceholder = useMemo(() => {
-    if (isMobileComposerViewport) return "Message… /cmds";
     if (groupResponseOrder === "manual") {
+      if (isMobileComposerViewport) {
+        return activeCharacterNames.length > 0 ? `Message… @${activeCharacterNames[0]}` : "Message freely…";
+      }
       return activeCharacterNames.length > 0
         ? `Message freely; @${activeCharacterNames[0]} to get a reply`
         : "Message freely...";
     }
+    if (isMobileComposerViewport) return "Message… /cmds";
     if (activeCharacterNames.length > 1 && chatName) return `Message ${chatName}, / for commands`;
     if (activeCharacterNames.length > 0) return `Message @${activeCharacterNames[0]}, / for commands`;
     return "Message...";

--- a/packages/client/src/components/chat/ConversationInput.tsx
+++ b/packages/client/src/components/chat/ConversationInput.tsx
@@ -8,7 +8,7 @@ import {
   Sticker,
   StopCircle,
   X,
-  Plus,
+  Paperclip,
   ImagePlay,
   Keyboard,
   AtSign,
@@ -1914,7 +1914,7 @@ export function ConversationInput({
           )}
           title="Attach file"
         >
-          <Plus size="1rem" />
+          <Paperclip size="1rem" />
         </button>
 
         {/* Quick Switchers — desktop: inline, mobile: chevron */}

--- a/packages/client/src/components/chat/chat-input-styles.ts
+++ b/packages/client/src/components/chat/chat-input-styles.ts
@@ -12,7 +12,7 @@ interface ChatInputShellClassOptions {
 
 const CHAT_INPUT_LAYOUT_CLASSES: Record<ChatInputLayout, string> = {
   conversation: "items-center gap-0.5 px-2 py-1.5 sm:gap-2 sm:px-4 sm:py-2.5",
-  game: "items-center gap-1.5 px-2 py-2 sm:px-4 sm:py-3",
+  game: "items-center gap-1 px-2 py-1.5 sm:gap-1.5 sm:px-4 sm:py-3",
   roleplay: "items-center gap-1 px-2 py-1.5 sm:gap-2 sm:px-4 sm:py-2.5",
 };
 

--- a/packages/client/src/components/game/GameInput.tsx
+++ b/packages/client/src/components/game/GameInput.tsx
@@ -462,6 +462,7 @@ export function GameInput({
         />
         <button
           onClick={() => fileInputRef.current?.click()}
+          aria-label="Attach files"
           className={cn(
             "shrink-0 rounded-lg p-1 transition-all active:scale-90 sm:p-1.5",
             attachments.length

--- a/packages/client/src/components/game/GameInput.tsx
+++ b/packages/client/src/components/game/GameInput.tsx
@@ -451,7 +451,28 @@ export function GameInput({
         })}
         style={forceInterruptStyle}
       >
-        {/* Left: Address selector + Attach files */}
+        {/* Left: Attach files + address selector */}
+        <input
+          ref={fileInputRef}
+          type="file"
+          accept="image/*,video/*,audio/*,.pdf,.txt,.md,.json,.csv"
+          multiple
+          className="hidden"
+          onChange={handleFileUpload}
+        />
+        <button
+          onClick={() => fileInputRef.current?.click()}
+          className={cn(
+            "shrink-0 rounded-lg p-1 transition-all active:scale-90 sm:p-1.5",
+            attachments.length
+              ? "bg-foreground/10 text-foreground/75 ring-1 ring-foreground/20 hover:bg-foreground/15"
+              : "text-foreground/40 hover:bg-foreground/10 hover:text-foreground/70",
+          )}
+          title="Attach files"
+        >
+          <Paperclip size={18} />
+        </button>
+
         <div className="relative shrink-0">
           {addressMenuOpen && (
             <div
@@ -492,7 +513,7 @@ export function GameInput({
             ref={addressButtonRef}
             onClick={() => setAddressMenuOpen((open) => !open)}
             className={cn(
-              "shrink-0 rounded-lg p-1.5 transition-all active:scale-90",
+              "shrink-0 rounded-lg p-1 transition-all active:scale-90 sm:p-1.5",
               addressMode === "party"
                 ? "bg-foreground/10 text-foreground/75 ring-1 ring-foreground/20 hover:bg-foreground/15"
                 : addressMode === "gm"
@@ -512,27 +533,6 @@ export function GameInput({
             <MessageSquare size={18} />
           </button>
         </div>
-
-        <input
-          ref={fileInputRef}
-          type="file"
-          accept="image/*,video/*,audio/*,.pdf,.txt,.md,.json,.csv"
-          multiple
-          className="hidden"
-          onChange={handleFileUpload}
-        />
-        <button
-          onClick={() => fileInputRef.current?.click()}
-          className={cn(
-            "shrink-0 rounded-lg p-1.5 transition-all active:scale-90",
-            attachments.length
-              ? "bg-foreground/10 text-foreground/75 ring-1 ring-foreground/20 hover:bg-foreground/15"
-              : "text-foreground/40 hover:bg-foreground/10 hover:text-foreground/70",
-          )}
-          title="Attach files"
-        >
-          <Paperclip size={18} />
-        </button>
 
         <textarea
           ref={inputRef}
@@ -598,7 +598,7 @@ export function GameInput({
           type="button"
           onClick={() => setShowDice(!showDice)}
           className={cn(
-            "shrink-0 rounded-lg p-1.5 transition-all active:scale-90",
+            "shrink-0 rounded-lg p-1 transition-all active:scale-90 sm:p-1.5",
             showDice
               ? "bg-foreground/10 text-foreground/75 ring-1 ring-foreground/20 hover:bg-foreground/15"
               : "text-foreground/40 hover:bg-foreground/10 hover:text-foreground/70",

--- a/packages/client/src/components/panels/SettingsPanel.tsx
+++ b/packages/client/src/components/panels/SettingsPanel.tsx
@@ -5305,13 +5305,14 @@ function AdvancedSettings() {
   }, [adminSecret]);
 
   type UpdateChannelId = "stable" | "staging";
-  const [updateChannel, setUpdateChannel] = useState<UpdateChannelId>("stable");
+  const [updateChannel, setUpdateChannel] = useState<UpdateChannelId | null>(null);
   const updateCheck = useQuery<{
     currentVersion: string;
     currentCommit: string | null;
     currentBuild: string;
     channel: UpdateChannelId;
     channelLabel: string;
+    currentBranch?: string | null;
     channels: Array<{
       id: UpdateChannelId;
       label: string;
@@ -5341,17 +5342,20 @@ function AdvancedSettings() {
     manualUpdateCommand?: string | null;
     manualUpdateHint?: string | null;
   }>({
-    queryKey: ["update-check", updateChannel],
-    queryFn: () => api.get(`/updates/check?channel=${encodeURIComponent(updateChannel)}`),
+    queryKey: ["update-check", updateChannel ?? "current"],
+    queryFn: () =>
+      api.get(updateChannel ? `/updates/check?channel=${encodeURIComponent(updateChannel)}` : "/updates/check"),
     enabled: false,
     retry: false,
   });
+
+  const selectedUpdateChannelId = updateChannel ?? updateCheck.data?.channel ?? "stable";
 
   const applyUpdate = useMutation({
     mutationFn: () =>
       api.post<{ status: string; message: string }>("/updates/apply", {
         confirm: true,
-        channel: updateChannel,
+        channel: selectedUpdateChannelId,
         currentVersion: updateCheck.data?.currentVersion ?? health.data?.version ?? APP_VERSION,
         currentCommit: updateCheck.data?.currentCommit ?? health.data?.commit ?? null,
         currentBuild: updateCheck.data?.currentBuild ?? health.data?.build ?? null,
@@ -5390,7 +5394,7 @@ function AdvancedSettings() {
       warning: "Staging builds are pre-release tester builds. Back up your app data before applying them.",
     },
   ];
-  const selectedUpdateChannel = updateChannelOptions.find((channel) => channel.id === updateChannel);
+  const selectedUpdateChannel = updateChannelOptions.find((channel) => channel.id === selectedUpdateChannelId);
   const currentReleaseLabel = `v${health.data?.version ?? updateCheck.data?.currentVersion ?? APP_VERSION}`;
   const currentCommit = health.data?.commit ?? updateCheck.data?.currentCommit ?? null;
   const currentBuildLabel = currentCommit ? `Build: ${currentCommit.slice(0, 7)}` : "Build: unavailable";
@@ -5484,7 +5488,7 @@ function AdvancedSettings() {
             <label className="flex min-w-0 flex-col gap-1 text-[0.625rem] font-semibold uppercase tracking-wide text-[var(--muted-foreground)]">
               Release Channel
               <select
-                value={updateChannel}
+                value={selectedUpdateChannelId}
                 onChange={(event) => setUpdateChannel(event.target.value as UpdateChannelId)}
                 className="w-full rounded-lg bg-[var(--background)] px-3 py-2 text-xs font-medium normal-case tracking-normal text-[var(--foreground)] outline-none ring-1 ring-[var(--border)] focus:ring-[var(--primary)]"
               >
@@ -5515,6 +5519,7 @@ function AdvancedSettings() {
             <div className="flex flex-col px-1 text-[0.6875rem] text-[var(--muted-foreground)]">
               <span>Release: {currentReleaseLabel}</span>
               <span>{currentBuildLabel}</span>
+              {updateCheck.data?.currentBranch && <span>Branch: {updateCheck.data.currentBranch}</span>}
             </div>
           </div>
 

--- a/packages/server/src/routes/generate.routes.ts
+++ b/packages/server/src/routes/generate.routes.ts
@@ -2709,7 +2709,7 @@ export async function generateRoutes(app: FastifyInstance) {
           const hasNewSummaries =
             Object.keys(summaryRun.newlyGeneratedDays).length > 0 ||
             Object.keys(summaryRun.newlyConsolidatedWeeks).length > 0;
-          if (hasNewSummaries) {
+          if (hasNewSummaries || summaryRun.summaryFailureMetadataChanged) {
             await chats.patchMetadata(input.chatId, (freshMeta) => {
               const existingDaySummaries = (freshMeta.daySummaries as Record<string, unknown> | undefined) ?? {};
               const existingWeekSummaries = (freshMeta.weekSummaries as Record<string, unknown> | undefined) ?? {};
@@ -2717,6 +2717,7 @@ export async function generateRoutes(app: FastifyInstance) {
                 ...freshMeta,
                 daySummaries: { ...existingDaySummaries, ...summaryRun.newlyGeneratedDays },
                 weekSummaries: { ...existingWeekSummaries, ...summaryRun.newlyConsolidatedWeeks },
+                conversationSummaryFailures: summaryRun.summaryFailures,
               };
             });
             chatMeta.daySummaries = {
@@ -2727,6 +2728,7 @@ export async function generateRoutes(app: FastifyInstance) {
               ...((chatMeta.weekSummaries as Record<string, unknown> | undefined) ?? {}),
               ...summaryRun.newlyConsolidatedWeeks,
             };
+            chatMeta.conversationSummaryFailures = summaryRun.summaryFailures;
           }
 
           const daySummaries = summaryRun.daySummaries;
@@ -5839,6 +5841,7 @@ export async function generateRoutes(app: FastifyInstance) {
         let fullThinking = "";
         let providerThinking = "";
         let allResponses: string[] = [];
+        let continuedMessageRewriteSource: string | null = null;
         const generatedExpressionTargetIds = new Set<string>();
         const recordExpressionTarget = (savedMsg: any, fallbackCharacterId: string | null) => {
           const savedRole =
@@ -7026,10 +7029,8 @@ export async function generateRoutes(app: FastifyInstance) {
             savedMsg = await chats.getMessage(input.regenerateMessageId);
           } else if (input.continueMessageId) {
             const targetMessage = (await chats.getMessage(input.continueMessageId)) ?? continueTargetMessage;
-            savedMsg = await chats.updateMessageContent(
-              input.continueMessageId,
-              appendContinuationMessageContent(targetMessage?.content, fullResponse),
-            );
+            continuedMessageRewriteSource = appendContinuationMessageContent(targetMessage?.content, fullResponse);
+            savedMsg = await chats.updateMessageContent(input.continueMessageId, continuedMessageRewriteSource);
             savedSwipeIndex =
               typeof savedMsg?.activeSwipeIndex === "number" && Number.isInteger(savedMsg.activeSwipeIndex)
                 ? savedMsg.activeSwipeIndex
@@ -9205,8 +9206,8 @@ export async function generateRoutes(app: FastifyInstance) {
 
           // ── Text rewrite/editing agents: run after ALL other agents ──
           if (textRewriteRunAgents.length > 0 && messageId && !abortController.signal.aborted) {
-            let currentResponseForRewrite = combinedResponse;
-            const originalResponseBeforeRewrite = combinedResponse;
+            let currentResponseForRewrite = continuedMessageRewriteSource ?? combinedResponse;
+            const originalResponseBeforeRewrite = currentResponseForRewrite;
             let textRewriteApplied = false;
 
             for (const textRewriteAgent of textRewriteRunAgents) {

--- a/packages/server/src/routes/updates.routes.ts
+++ b/packages/server/src/routes/updates.routes.ts
@@ -128,10 +128,14 @@ function getGitLauncherCommand(platform: ServerPlatform) {
   }
 }
 
+function getUpdateChannelForBranch(branch: string | null | undefined) {
+  return branch === UPDATE_CHANNELS.staging.branch ? UPDATE_CHANNELS.staging : UPDATE_CHANNELS.stable;
+}
+
 function getManualGitApplyCommand(channel = UPDATE_CHANNELS.stable) {
   const checkoutCommand =
     channel.id === "staging"
-      ? `git checkout --detach ${channel.targetRef}`
+      ? `git checkout -B ${channel.branch} ${channel.targetRef}`
       : `(git merge --ff-only ${channel.targetRef} || git checkout --detach ${channel.targetRef})`;
   return `git fetch ${UPDATE_REMOTE} ${channel.fetchRef} && ${checkoutCommand} && pnpm install --frozen-lockfile && pnpm --filter @marinara-engine/shared build && pnpm --filter @marinara-engine/server --filter @marinara-engine/client --parallel run build`;
 }
@@ -154,7 +158,7 @@ function getManualUpdateHint(installType: InstallType, platform: ServerPlatform,
   }
   if (installType === "git") {
     const launcher = getGitLauncherCommand(platform);
-    return `Relaunch Marinara with ${launcher} to let the platform launcher fetch origin/main, install dependencies, rebuild, and start the new version.`;
+    return `Relaunch Marinara with ${launcher} to let the platform launcher fetch the current checkout's update branch, install dependencies, rebuild, and start the new version.`;
   }
   return "Download the release asset or update the host install manually, then restart Marinara.";
 }
@@ -425,8 +429,10 @@ type ApplyUpdateBody = {
   targetCommit?: string;
 };
 
-function readUpdateChannel(value: unknown): UpdateChannelInfo {
-  return value === "staging" ? UPDATE_CHANNELS.staging : UPDATE_CHANNELS.stable;
+function readUpdateChannel(value: unknown, currentBranch?: string | null): UpdateChannelInfo {
+  if (value === "staging") return UPDATE_CHANNELS.staging;
+  if (value === "stable") return UPDATE_CHANNELS.stable;
+  return getUpdateChannelForBranch(currentBranch);
 }
 
 function serializeUpdateChannels() {
@@ -495,7 +501,6 @@ export async function updatesRoutes(app: FastifyInstance) {
   // with matching release metadata when that release exists.
   // For git installs, also checks if the local commit is behind the selected update channel.
   app.get("/check", async (req, reply) => {
-    const channel = readUpdateChannel((req.query as { channel?: unknown } | undefined)?.channel);
     const now = Date.now();
     const currentCommit = getBuildCommit();
     const currentBuild = getBuildLabel();
@@ -503,6 +508,9 @@ export async function updatesRoutes(app: FastifyInstance) {
     const installType = getInstallType(gitInstall);
     const serverPlatform = getServerPlatform();
     const clientPlatform = getClientPlatform(req.headers["user-agent"]);
+    const root = getMonorepoRoot();
+    const currentBranch = gitInstall ? await getCurrentBranch(root) : null;
+    const channel = readUpdateChannel((req.query as { channel?: unknown } | undefined)?.channel, currentBranch);
     const applyAvailability = getApplyAvailability(installType, serverPlatform, channel);
 
     // Check commits behind for git installs
@@ -526,6 +534,7 @@ export async function updatesRoutes(app: FastifyInstance) {
         currentBuild,
         channel: channel.id,
         channelLabel: channel.label,
+        currentBranch,
         channels: serializeUpdateChannels(),
         ...buildReleasePayload(cachedRelease),
         updateAvailable: (channel.id === "stable" && versionUpdate) || (commitsBehind != null && commitsBehind > 0),
@@ -536,7 +545,7 @@ export async function updatesRoutes(app: FastifyInstance) {
         clientPlatform,
         ...applyAvailability,
         targetRef: channel.targetRef,
-        targetCommit: gitInstall ? await resolveGitRef(getMonorepoRoot(), channel.targetRef) : null,
+        targetCommit: gitInstall ? await resolveGitRef(root, channel.targetRef) : null,
       };
     }
 
@@ -557,6 +566,7 @@ export async function updatesRoutes(app: FastifyInstance) {
         currentBuild,
         channel: channel.id,
         channelLabel: channel.label,
+        currentBranch,
         channels: serializeUpdateChannels(),
         ...buildReleasePayload(cachedRelease),
         updateAvailable: (channel.id === "stable" && versionUpdate) || (commitsBehind != null && commitsBehind > 0),
@@ -567,7 +577,7 @@ export async function updatesRoutes(app: FastifyInstance) {
         clientPlatform,
         ...applyAvailability,
         targetRef: channel.targetRef,
-        targetCommit: gitInstall ? await resolveGitRef(getMonorepoRoot(), channel.targetRef) : null,
+        targetCommit: gitInstall ? await resolveGitRef(root, channel.targetRef) : null,
       };
     } catch (err: unknown) {
       const message = err instanceof Error ? err.message : String(err);
@@ -578,6 +588,7 @@ export async function updatesRoutes(app: FastifyInstance) {
         currentBuild,
         channel: channel.id,
         channelLabel: channel.label,
+        currentBranch,
         channels: serializeUpdateChannels(),
         updateAvailable: commitsBehind != null && commitsBehind > 0,
         commitsBehind: commitsBehind ?? 0,
@@ -593,10 +604,12 @@ export async function updatesRoutes(app: FastifyInstance) {
   // POST /api/updates/apply
   // Fast-forwards to the selected update channel, installs, rebuilds, then signals the process to restart.
   app.post<{ Body: ApplyUpdateBody }>("/apply", async (req, reply) => {
-    const channel = readUpdateChannel(req.body?.channel);
     const gitInstall = isGitInstall();
     const installType = getInstallType(gitInstall);
     const serverPlatform = getServerPlatform();
+    const root = getMonorepoRoot();
+    const currentBranch = gitInstall ? await getCurrentBranch(root) : null;
+    const channel = readUpdateChannel(req.body?.channel, currentBranch);
 
     if (!gitInstall) {
       const manualUpdateCommand = getManualUpdateCommand(installType, serverPlatform, channel);
@@ -635,8 +648,6 @@ export async function updatesRoutes(app: FastifyInstance) {
       return;
     }
 
-    const root = getMonorepoRoot();
-
     try {
       const body = req.body ?? {};
       if (body.confirm !== true) {
@@ -653,7 +664,6 @@ export async function updatesRoutes(app: FastifyInstance) {
         return reply.status(400).send({ error: `Update target ref must be ${channel.targetRef}` });
       }
 
-      const currentBranch = await getCurrentBranch(root);
       const oldHead = await resolveGitRef(root, "HEAD");
       if (!oldHead) {
         throw new Error("Could not read the current git commit.");
@@ -693,6 +703,11 @@ export async function updatesRoutes(app: FastifyInstance) {
         try {
           if (currentBranch === channel.branch) {
             await execFileAsync("git", ["merge", "--ff-only", channel.targetRef], {
+              cwd: root,
+              timeout: 60_000,
+            });
+          } else if (channel.id === "staging") {
+            await execFileAsync("git", ["checkout", "-B", channel.branch, channel.targetRef], {
               cwd: root,
               timeout: 60_000,
             });

--- a/packages/server/src/routes/updates.routes.ts
+++ b/packages/server/src/routes/updates.routes.ts
@@ -128,14 +128,42 @@ function getGitLauncherCommand(platform: ServerPlatform) {
   }
 }
 
-function getUpdateChannelForBranch(branch: string | null | undefined) {
-  return branch === UPDATE_CHANNELS.staging.branch ? UPDATE_CHANNELS.staging : UPDATE_CHANNELS.stable;
+async function gitCommandSucceeds(root: string, args: string[]): Promise<boolean> {
+  try {
+    await execFileAsync("git", args, { cwd: root, timeout: 5_000 });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function isDetachedStagingCheckout(root: string): Promise<boolean> {
+  const isOnStagingHistory = await gitCommandSucceeds(root, [
+    "merge-base",
+    "--is-ancestor",
+    "HEAD",
+    UPDATE_CHANNELS.staging.targetRef,
+  ]);
+  if (!isOnStagingHistory) return false;
+  const isOnStableHistory = await gitCommandSucceeds(root, [
+    "merge-base",
+    "--is-ancestor",
+    "HEAD",
+    UPDATE_CHANNELS.stable.targetRef,
+  ]);
+  return !isOnStableHistory;
+}
+
+async function getUpdateChannelForCheckout(root: string, branch: string | null | undefined) {
+  if (branch === UPDATE_CHANNELS.staging.branch) return UPDATE_CHANNELS.staging;
+  if (!branch && (await isDetachedStagingCheckout(root))) return UPDATE_CHANNELS.staging;
+  return UPDATE_CHANNELS.stable;
 }
 
 function getManualGitApplyCommand(channel = UPDATE_CHANNELS.stable) {
   const checkoutCommand =
     channel.id === "staging"
-      ? `git checkout -B ${channel.branch} ${channel.targetRef}`
+      ? `git show-ref --verify --quiet refs/heads/${channel.branch} && (git checkout ${channel.branch} && git merge --ff-only ${channel.targetRef}) || git checkout -b ${channel.branch} ${channel.targetRef}`
       : `(git merge --ff-only ${channel.targetRef} || git checkout --detach ${channel.targetRef})`;
   return `git fetch ${UPDATE_REMOTE} ${channel.fetchRef} && ${checkoutCommand} && pnpm install --frozen-lockfile && pnpm --filter @marinara-engine/shared build && pnpm --filter @marinara-engine/server --filter @marinara-engine/client --parallel run build`;
 }
@@ -198,6 +226,26 @@ async function getCurrentBranch(root: string): Promise<string | null> {
   } catch {
     return null;
   }
+}
+
+async function checkoutOrCreateUpdateBranch(root: string, channel: UpdateChannelInfo): Promise<void> {
+  const branchRef = `refs/heads/${channel.branch}`;
+  const branchExists = await gitCommandSucceeds(root, ["show-ref", "--verify", "--quiet", branchRef]);
+  if (branchExists) {
+    await execFileAsync("git", ["checkout", channel.branch], {
+      cwd: root,
+      timeout: 60_000,
+    });
+    await execFileAsync("git", ["merge", "--ff-only", channel.targetRef], {
+      cwd: root,
+      timeout: 60_000,
+    });
+    return;
+  }
+  await execFileAsync("git", ["checkout", "-b", channel.branch, channel.targetRef], {
+    cwd: root,
+    timeout: 60_000,
+  });
 }
 
 async function hasTrackedChanges(root: string): Promise<boolean> {
@@ -429,10 +477,14 @@ type ApplyUpdateBody = {
   targetCommit?: string;
 };
 
-function readUpdateChannel(value: unknown, currentBranch?: string | null): UpdateChannelInfo {
+async function resolveUpdateChannel(
+  root: string,
+  value: unknown,
+  currentBranch?: string | null,
+): Promise<UpdateChannelInfo> {
   if (value === "staging") return UPDATE_CHANNELS.staging;
   if (value === "stable") return UPDATE_CHANNELS.stable;
-  return getUpdateChannelForBranch(currentBranch);
+  return getUpdateChannelForCheckout(root, currentBranch);
 }
 
 function serializeUpdateChannels() {
@@ -510,7 +562,11 @@ export async function updatesRoutes(app: FastifyInstance) {
     const clientPlatform = getClientPlatform(req.headers["user-agent"]);
     const root = getMonorepoRoot();
     const currentBranch = gitInstall ? await getCurrentBranch(root) : null;
-    const channel = readUpdateChannel((req.query as { channel?: unknown } | undefined)?.channel, currentBranch);
+    const channel = await resolveUpdateChannel(
+      root,
+      (req.query as { channel?: unknown } | undefined)?.channel,
+      currentBranch,
+    );
     const applyAvailability = getApplyAvailability(installType, serverPlatform, channel);
 
     // Check commits behind for git installs
@@ -609,7 +665,7 @@ export async function updatesRoutes(app: FastifyInstance) {
     const serverPlatform = getServerPlatform();
     const root = getMonorepoRoot();
     const currentBranch = gitInstall ? await getCurrentBranch(root) : null;
-    const channel = readUpdateChannel(req.body?.channel, currentBranch);
+    const channel = await resolveUpdateChannel(root, req.body?.channel, currentBranch);
 
     if (!gitInstall) {
       const manualUpdateCommand = getManualUpdateCommand(installType, serverPlatform, channel);
@@ -699,15 +755,20 @@ export async function updatesRoutes(app: FastifyInstance) {
       // Installer-created release checkouts are shallow detached HEADs, so
       // they cannot reliably merge a remote-tracking branch. A detached
       // checkout is expected there; normal main-branch clones still fast-forward.
-      if (oldHead !== targetHead) {
+      const shouldAttachStagingBranch = channel.id === "staging" && currentBranch !== channel.branch;
+      if (oldHead !== targetHead || shouldAttachStagingBranch) {
         try {
-          if (currentBranch === channel.branch) {
+          if (channel.id === "staging") {
+            if (currentBranch === channel.branch) {
+              await execFileAsync("git", ["merge", "--ff-only", channel.targetRef], {
+                cwd: root,
+                timeout: 60_000,
+              });
+            } else {
+              await checkoutOrCreateUpdateBranch(root, channel);
+            }
+          } else if (currentBranch === channel.branch) {
             await execFileAsync("git", ["merge", "--ff-only", channel.targetRef], {
-              cwd: root,
-              timeout: 60_000,
-            });
-          } else if (channel.id === "staging") {
-            await execFileAsync("git", ["checkout", "-B", channel.branch, channel.targetRef], {
               cwd: root,
               timeout: 60_000,
             });

--- a/packages/server/src/services/conversation/auto-summary.service.ts
+++ b/packages/server/src/services/conversation/auto-summary.service.ts
@@ -21,6 +21,8 @@ export interface ConversationSummaryRunResult {
   weekSummaries: Record<string, WeekSummaryEntry>;
   newlyGeneratedDays: Record<string, DaySummaryEntry>;
   newlyConsolidatedWeeks: Record<string, WeekSummaryEntry>;
+  summaryFailures: ConversationSummaryFailures;
+  summaryFailureMetadataChanged: boolean;
   failedDays: Array<{ date: string; error: string }>;
   failedWeeks: Array<{ weekKey: string; error: string }>;
   missingDayCount: number;
@@ -31,6 +33,19 @@ export interface ConversationSummaryRunResult {
 interface ConversationSummaryDayBucket {
   date: string;
   msgs: Array<{ role: string; content: string; author: string; ts: Date }>;
+}
+
+export interface ConversationSummaryFailureRecord {
+  attempts: number;
+  lastAttemptAt: string;
+  lastError: string;
+  model: string;
+  permanent: boolean;
+}
+
+export interface ConversationSummaryFailures {
+  days: Record<string, ConversationSummaryFailureRecord>;
+  weeks: Record<string, ConversationSummaryFailureRecord>;
 }
 
 interface GenerateMissingConversationSummariesOptions {
@@ -50,6 +65,44 @@ interface GenerateMissingConversationSummariesOptions {
 const DEFAULT_SUMMARY_TIMEOUT_MS = 300_000;
 const DAILY_TRANSCRIPT_CHUNK_CHARS = 32_000;
 const MAX_SUMMARY_CHUNKS_PER_DAY = 12;
+const SUMMARY_TRANSIENT_RETRY_BASE_MS = 5 * 60_000;
+const SUMMARY_TRANSIENT_RETRY_MAX_MS = 60 * 60_000;
+const SUMMARY_PERMANENT_RETRY_MS = 24 * 60 * 60_000;
+
+function coerceFailureRecord(value: unknown): ConversationSummaryFailureRecord | null {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return null;
+  const record = value as Record<string, unknown>;
+  const attempts = Number(record.attempts);
+  const lastAttemptAt = typeof record.lastAttemptAt === "string" ? record.lastAttemptAt : "";
+  const lastError = typeof record.lastError === "string" ? record.lastError : "";
+  const model = typeof record.model === "string" ? record.model : "";
+  if (!Number.isFinite(attempts) || attempts <= 0 || !lastAttemptAt || !lastError || !model) return null;
+  return {
+    attempts: Math.floor(attempts),
+    lastAttemptAt,
+    lastError,
+    model,
+    permanent: record.permanent === true,
+  };
+}
+
+export function normalizeConversationSummaryFailures(raw: unknown): ConversationSummaryFailures {
+  const empty: ConversationSummaryFailures = { days: {}, weeks: {} };
+  if (!raw || typeof raw !== "object" || Array.isArray(raw)) return empty;
+  const record = raw as Record<string, unknown>;
+  for (const [bucketName, target] of [
+    ["days", empty.days],
+    ["weeks", empty.weeks],
+  ] as const) {
+    const bucket = record[bucketName];
+    if (!bucket || typeof bucket !== "object" || Array.isArray(bucket)) continue;
+    for (const [key, value] of Object.entries(bucket as Record<string, unknown>)) {
+      const failure = coerceFailureRecord(value);
+      if (failure) target[key] = failure;
+    }
+  }
+  return empty;
+}
 
 function coerceSummaryEntry(value: unknown): DaySummaryEntry | null {
   if (typeof value === "string") {
@@ -331,6 +384,41 @@ function errorMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
 }
 
+function isPermanentSummaryFailure(error: string): boolean {
+  return /\b(?:400|401|403|404|405|410|422)\b/u.test(error);
+}
+
+function transientSummaryRetryDelayMs(attempts: number): number {
+  return Math.min(SUMMARY_TRANSIENT_RETRY_MAX_MS, SUMMARY_TRANSIENT_RETRY_BASE_MS * 2 ** Math.max(0, attempts - 1));
+}
+
+function shouldSkipFailedSummary(
+  record: ConversationSummaryFailureRecord | undefined,
+  model: string,
+  now: Date,
+): boolean {
+  if (!record || record.model !== model) return false;
+  const lastAttemptTime = new Date(record.lastAttemptAt).getTime();
+  if (!Number.isFinite(lastAttemptTime)) return false;
+  if (record.permanent) return now.getTime() - lastAttemptTime < SUMMARY_PERMANENT_RETRY_MS;
+  return now.getTime() - lastAttemptTime < transientSummaryRetryDelayMs(record.attempts);
+}
+
+function recordSummaryFailure(
+  previous: ConversationSummaryFailureRecord | undefined,
+  error: string,
+  model: string,
+  now: Date,
+): ConversationSummaryFailureRecord {
+  return {
+    attempts: previous && previous.model === model ? previous.attempts + 1 : 1,
+    lastAttemptAt: now.toISOString(),
+    lastError: error,
+    model,
+    permanent: isPermanentSummaryFailure(error),
+  };
+}
+
 export async function generateMissingConversationSummaries(
   options: GenerateMissingConversationSummariesOptions,
 ): Promise<ConversationSummaryRunResult> {
@@ -340,6 +428,8 @@ export async function generateMissingConversationSummaries(
   const todayDateKey = logicalDateKey(now, rolloverHour, options.timeZone);
   const daySummaries = normalizeDaySummaries(options.metadata.daySummaries);
   const weekSummaries = normalizeWeekSummaries(options.metadata.weekSummaries);
+  const summaryFailures = normalizeConversationSummaryFailures(options.metadata.conversationSummaryFailures);
+  let summaryFailureMetadataChanged = false;
 
   const buckets = buildDayBuckets(
     options.messages,
@@ -349,7 +439,11 @@ export async function generateMissingConversationSummaries(
     options.timeZone,
   );
   const pastBuckets = buckets.filter((bucket) => bucket.date !== todayDateKey);
-  const missingBuckets = pastBuckets.filter((bucket) => !daySummaries[bucket.date]);
+  const missingBuckets = pastBuckets.filter(
+    (bucket) =>
+      !daySummaries[bucket.date] &&
+      !shouldSkipFailedSummary(summaryFailures.days[bucket.date], options.model, now),
+  );
   const maxMissingDays =
     typeof options.maxMissingDays === "number" && Number.isFinite(options.maxMissingDays)
       ? Math.max(0, Math.floor(options.maxMissingDays))
@@ -367,9 +461,21 @@ export async function generateMissingConversationSummaries(
       if (entry.summary || entry.keyDetails.length > 0) {
         daySummaries[bucket.date] = entry;
         newlyGeneratedDays[bucket.date] = entry;
+        if (summaryFailures.days[bucket.date]) {
+          delete summaryFailures.days[bucket.date];
+          summaryFailureMetadataChanged = true;
+        }
       }
     } catch (error) {
-      failedDays.push({ date: bucket.date, error: errorMessage(error) });
+      const message = errorMessage(error);
+      failedDays.push({ date: bucket.date, error: message });
+      summaryFailures.days[bucket.date] = recordSummaryFailure(
+        summaryFailures.days[bucket.date],
+        message,
+        options.model,
+        now,
+      );
+      summaryFailureMetadataChanged = true;
     }
   }
 
@@ -391,6 +497,7 @@ export async function generateMissingConversationSummaries(
 
   for (const [weekKey, days] of daysByWeek) {
     if (weekSummaries[weekKey]) continue;
+    if (shouldSkipFailedSummary(summaryFailures.weeks[weekKey], options.model, now)) continue;
     const monday = parseConversationDateKey(weekKey);
     const nextMonday = new Date(monday.getFullYear(), monday.getMonth(), monday.getDate() + 7);
     if (logicalDate(now, rolloverHour, options.timeZone).getTime() < nextMonday.getTime()) continue;
@@ -418,9 +525,21 @@ export async function generateMissingConversationSummaries(
       if (entry.summary || entry.keyDetails.length > 0) {
         weekSummaries[weekKey] = entry;
         newlyConsolidatedWeeks[weekKey] = entry;
+        if (summaryFailures.weeks[weekKey]) {
+          delete summaryFailures.weeks[weekKey];
+          summaryFailureMetadataChanged = true;
+        }
       }
     } catch (error) {
-      failedWeeks.push({ weekKey, error: errorMessage(error) });
+      const message = errorMessage(error);
+      failedWeeks.push({ weekKey, error: message });
+      summaryFailures.weeks[weekKey] = recordSummaryFailure(
+        summaryFailures.weeks[weekKey],
+        message,
+        options.model,
+        now,
+      );
+      summaryFailureMetadataChanged = true;
     }
   }
 
@@ -429,6 +548,8 @@ export async function generateMissingConversationSummaries(
     weekSummaries,
     newlyGeneratedDays,
     newlyConsolidatedWeeks,
+    summaryFailures,
+    summaryFailureMetadataChanged,
     failedDays,
     failedWeeks,
     missingDayCount: missingBuckets.length,

--- a/packages/server/src/services/conversation/auto-summary.service.ts
+++ b/packages/server/src/services/conversation/auto-summary.service.ts
@@ -68,6 +68,11 @@ const MAX_SUMMARY_CHUNKS_PER_DAY = 12;
 const SUMMARY_TRANSIENT_RETRY_BASE_MS = 5 * 60_000;
 const SUMMARY_TRANSIENT_RETRY_MAX_MS = 60 * 60_000;
 const SUMMARY_PERMANENT_RETRY_MS = 24 * 60 * 60_000;
+const MAX_STORED_SUMMARY_FAILURE_ERROR_CHARS = 240;
+
+function createSummaryFailureMap(): Record<string, ConversationSummaryFailureRecord> {
+  return Object.create(null) as Record<string, ConversationSummaryFailureRecord>;
+}
 
 function coerceFailureRecord(value: unknown): ConversationSummaryFailureRecord | null {
   if (!value || typeof value !== "object" || Array.isArray(value)) return null;
@@ -87,7 +92,7 @@ function coerceFailureRecord(value: unknown): ConversationSummaryFailureRecord |
 }
 
 export function normalizeConversationSummaryFailures(raw: unknown): ConversationSummaryFailures {
-  const empty: ConversationSummaryFailures = { days: {}, weeks: {} };
+  const empty: ConversationSummaryFailures = { days: createSummaryFailureMap(), weeks: createSummaryFailureMap() };
   if (!raw || typeof raw !== "object" || Array.isArray(raw)) return empty;
   const record = raw as Record<string, unknown>;
   for (const [bucketName, target] of [
@@ -384,6 +389,14 @@ function errorMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
 }
 
+function storedSummaryFailureError(error: string): string {
+  const sanitized = error.replace(/[\u0000-\u001f\u007f]+/gu, " ").replace(/\s+/gu, " ").trim();
+  if (!sanitized) return "Summary generation failed";
+  return sanitized.length > MAX_STORED_SUMMARY_FAILURE_ERROR_CHARS
+    ? `${sanitized.slice(0, MAX_STORED_SUMMARY_FAILURE_ERROR_CHARS - 1)}…`
+    : sanitized;
+}
+
 function isPermanentSummaryFailure(error: string): boolean {
   return /\b(?:400|401|403|404|405|410|422)\b/u.test(error);
 }
@@ -413,7 +426,7 @@ function recordSummaryFailure(
   return {
     attempts: previous && previous.model === model ? previous.attempts + 1 : 1,
     lastAttemptAt: now.toISOString(),
-    lastError: error,
+    lastError: storedSummaryFailureError(error),
     model,
     permanent: isPermanentSummaryFailure(error),
   };

--- a/packages/server/src/services/conversation/server-autonomous-scheduler.service.ts
+++ b/packages/server/src/services/conversation/server-autonomous-scheduler.service.ts
@@ -19,6 +19,16 @@ const SERVER_AUTONOMOUS_POLL_MS = 60_000;
 const RECENT_CLIENT_PRESENCE_MS = 75_000;
 const OFFLINE_MAX_FOLLOWUPS = 2;
 const MAX_SERVER_AUTONOMOUS_CONCURRENT_EVALUATIONS = 2;
+const AUTONOMOUS_FAILURE_BASE_BACKOFF_MS = 5 * 60_000;
+const AUTONOMOUS_FAILURE_MAX_BACKOFF_MS = 60 * 60_000;
+const AUTONOMOUS_HARD_FAILURE_BACKOFF_MS = 30 * 60_000;
+
+type AutonomousFailureBackoff = {
+  attempts: number;
+  nextAllowedAt: number;
+  lastError: string;
+  hardFailure: boolean;
+};
 
 type RawChat = {
   id: string;
@@ -94,9 +104,17 @@ function parseSsePayload(payload: string): { done: boolean; error: string | null
   return { done, error };
 }
 
+function isHardGenerationFailure(error: string, statusCode?: number): boolean {
+  if (statusCode !== undefined && statusCode >= 400 && statusCode < 500 && statusCode !== 408 && statusCode !== 409 && statusCode !== 429) {
+    return true;
+  }
+  return /\b(?:400|401|403|404|405|410|422)\b/u.test(error);
+}
+
 export function startServerAutonomousScheduler(app: FastifyInstance) {
   const chats = createChatsStorage(app.db);
   const runningChats = new Set<string>();
+  const failureBackoffByChat = new Map<string, AutonomousFailureBackoff>();
   let stopped = false;
   let polling = false;
   let pollTimer: ReturnType<typeof setTimeout> | null = null;
@@ -108,6 +126,39 @@ export function startServerAutonomousScheduler(app: FastifyInstance) {
       void poll();
     }, delayMs);
     pollTimer.unref?.();
+  };
+
+  const isChatOnFailureBackoff = (chatId: string) => {
+    const backoff = failureBackoffByChat.get(chatId);
+    if (!backoff) return false;
+    if (Date.now() < backoff.nextAllowedAt) return true;
+    return false;
+  };
+
+  const clearFailureBackoff = (chatId: string) => {
+    failureBackoffByChat.delete(chatId);
+  };
+
+  const recordFailureBackoff = (chatId: string, error: string, statusCode?: number) => {
+    const previous = failureBackoffByChat.get(chatId);
+    const attempts = (previous?.attempts ?? 0) + 1;
+    const hardFailure = isHardGenerationFailure(error, statusCode);
+    const delayMs = hardFailure
+      ? Math.min(AUTONOMOUS_FAILURE_MAX_BACKOFF_MS, AUTONOMOUS_HARD_FAILURE_BACKOFF_MS * attempts)
+      : Math.min(AUTONOMOUS_FAILURE_MAX_BACKOFF_MS, AUTONOMOUS_FAILURE_BASE_BACKOFF_MS * 2 ** Math.max(0, attempts - 1));
+    failureBackoffByChat.set(chatId, {
+      attempts,
+      nextAllowedAt: Date.now() + delayMs,
+      lastError: error,
+      hardFailure,
+    });
+    logger.warn(
+      "[autonomous-scheduler] Pausing retries for chat %s for %d seconds after %s failure: %s",
+      chatId,
+      Math.ceil(delayMs / 1000),
+      hardFailure ? "hard" : "transient",
+      error,
+    );
   };
 
   const generateAutonomousMessage = async (
@@ -145,6 +196,7 @@ export function startServerAutonomousScheduler(app: FastifyInstance) {
 
     if (response.statusCode !== 200) {
       clearGenerationInProgress(chatId, claimedAt);
+      recordFailureBackoff(chatId, response.payload.slice(0, 300), response.statusCode);
       logger.warn(
         "[autonomous-scheduler] Generate failed for chat %s with status %d: %s",
         chatId,
@@ -157,6 +209,7 @@ export function startServerAutonomousScheduler(app: FastifyInstance) {
     const result = parseSsePayload(response.payload);
     if (result.error) {
       clearGenerationInProgress(chatId, claimedAt);
+      recordFailureBackoff(chatId, result.error);
       logger.warn("[autonomous-scheduler] Generate failed for chat %s: %s", chatId, result.error);
       return false;
     }
@@ -166,6 +219,7 @@ export function startServerAutonomousScheduler(app: FastifyInstance) {
       return false;
     }
 
+    clearFailureBackoff(chatId);
     await chats.markAutonomousUnread(chatId, { characterId });
     return true;
   };
@@ -188,6 +242,10 @@ export function startServerAutonomousScheduler(app: FastifyInstance) {
             clearGenerationInProgress(chatId, claimedAt);
             return;
           }
+          if (isChatOnFailureBackoff(chatId)) {
+            clearGenerationInProgress(chatId, claimedAt);
+            return;
+          }
           const generated = await generateAutonomousMessage(chatId, characterId, schedule, chatMeta, claimedAt);
           if (generated) {
             logger.info("[autonomous-scheduler] Generated autonomous message for chat %s (after delay)", chatId);
@@ -205,6 +263,7 @@ export function startServerAutonomousScheduler(app: FastifyInstance) {
 
   const evaluateChat = async (chat: RawChat) => {
     if (runningChats.has(chat.id)) return;
+    if (isChatOnFailureBackoff(chat.id)) return;
     const activeGenerations = (app as unknown as { activeGenerations?: Map<string, unknown> }).activeGenerations;
     if (activeGenerations?.has(chat.id)) return;
 
@@ -268,6 +327,7 @@ export function startServerAutonomousScheduler(app: FastifyInstance) {
       }
     } catch (err) {
       clearGenerationInProgress(chat.id, generationStartedAt);
+      recordFailureBackoff(chat.id, err instanceof Error ? err.message : String(err));
       logger.warn(err, "[autonomous-scheduler] Failed while evaluating chat %s", chat.id);
     } finally {
       if (!handedOffToTimer) runningChats.delete(chat.id);

--- a/packages/server/src/services/conversation/server-autonomous-scheduler.service.ts
+++ b/packages/server/src/services/conversation/server-autonomous-scheduler.service.ts
@@ -105,8 +105,8 @@ function parseSsePayload(payload: string): { done: boolean; error: string | null
 }
 
 function isHardGenerationFailure(error: string, statusCode?: number): boolean {
-  if (statusCode !== undefined && statusCode >= 400 && statusCode < 500 && statusCode !== 408 && statusCode !== 409 && statusCode !== 429) {
-    return true;
+  if (statusCode !== undefined) {
+    return statusCode >= 400 && statusCode < 500 && statusCode !== 408 && statusCode !== 409 && statusCode !== 429;
   }
   return /\b(?:400|401|403|404|405|410|422)\b/u.test(error);
 }

--- a/packages/server/src/services/mari-db/mari-db.service.ts
+++ b/packages/server/src/services/mari-db/mari-db.service.ts
@@ -561,6 +561,12 @@ function normalizeLimit(value: unknown, fallback: number, max: number) {
   return Math.min(max, Math.floor(parsed));
 }
 
+function normalizeOffset(value: unknown) {
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed) || parsed <= 0) return 0;
+  return Math.floor(parsed);
+}
+
 function makeEmptyValidation(): MariDbValidationResult {
   return { status: "passed", errors: [], notices: [], infos: [] };
 }
@@ -650,6 +656,8 @@ function normalizeAppDataActionName(action: string): string {
     "lorebook.entry.create": "lorebook.addentry",
     "lorebook.entries.add": "lorebook.addentry",
     "lorebook.entries.create": "lorebook.addentry",
+    "lorebook.entry.get": "lorebook.getentry",
+    "lorebook.entries.get": "lorebook.getentry",
     "lorebook.entry.update": "lorebook.updateentry",
     "lorebook.entries.update": "lorebook.updateentry",
     "theme.set": "theme.setactive",
@@ -884,6 +892,24 @@ function summarizeLorebookRow(row: Row): Row {
     vectorMaxResults: row.vectorMaxResults,
     createdAt: row.createdAt,
     updatedAt: row.updatedAt,
+  };
+}
+
+function summarizeLorebookEntryRow(row: Row): Row {
+  const parsed = parseRow("lorebook_entries", row);
+  return {
+    id: parsed.id,
+    lorebookId: parsed.lorebookId,
+    name: parsed.name,
+    description: typeof parsed.description === "string" ? parsed.description : "",
+    tag: typeof parsed.tag === "string" ? parsed.tag : "",
+    enabled: parsed.enabled,
+    constant: parsed.constant,
+    keys: parsed.keys,
+    content: typeof parsed.content === "string" ? truncateStr(parsed.content, 200) : "",
+    order: parsed.order,
+    createdAt: parsed.createdAt,
+    updatedAt: parsed.updatedAt,
   };
 }
 
@@ -1480,6 +1506,7 @@ export class MariDbService {
     changed = assignStringField(target, source, ["name"], "name") || changed;
     changed = assignStringField(target, source, ["content"], "content") || changed;
     changed = assignStringField(target, source, ["description"], "description") || changed;
+    changed = assignStringField(target, source, ["tag"], "tag") || changed;
     changed = assignListField(target, source, ["keys"], "keys") || changed;
     changed = assignListField(target, source, ["secondaryKeys", "secondary_keys"], "secondaryKeys") || changed;
     changed = assignBooleanTextField(target, source, ["enabled"], "enabled") || changed;
@@ -1523,27 +1550,25 @@ export class MariDbService {
       }
       case "entries": {
         const lorebookId = requiredString(args, ["lorebookId", "id"], "lorebook id");
+        const entryId = firstString(args, ["entryId"]);
         const limit = normalizeLimit(firstNumber(args, ["limit"]), 100, 2000);
         const entries = (await this.rawRows("lorebook_entries"))
           .filter((entry) => entry.lorebookId === lorebookId)
+          .filter((entry) => !entryId || entry.id === entryId)
           .sort((a, b) => Number(a.order ?? 100) - Number(b.order ?? 100))
           .slice(0, limit)
-          .map((row) => {
-            const parsed = parseRow("lorebook_entries", row);
-            return {
-              id: parsed.id,
-              lorebookId: parsed.lorebookId,
-              name: parsed.name,
-              enabled: parsed.enabled,
-              constant: parsed.constant,
-              keys: parsed.keys,
-              content: typeof parsed.content === "string" ? truncateStr(parsed.content, 200) : "",
-              order: parsed.order,
-              createdAt: parsed.createdAt,
-              updatedAt: parsed.updatedAt,
-            };
-          });
+          .map(summarizeLorebookEntryRow);
         return { ok: true, mode: "read", command: context.command, output: entries };
+      }
+      case "getentry": {
+        const entryId = requiredString(args, ["entryId", "id"], "lorebook entry id");
+        const row = await this.getRawById(getMeta("lorebook_entries"), entryId);
+        return {
+          ok: !!row,
+          mode: "read",
+          command: context.command,
+          output: row ? summarizeLorebookEntryRow(row) : null,
+        };
       }
       case "search": {
         const query = requiredString(args, ["query", "search"], "lorebook search query").toLowerCase();
@@ -1669,6 +1694,7 @@ export class MariDbService {
           "name",
           "content",
           "description",
+          "tag",
           "keys",
           "secondaryKeys",
           "enabled",
@@ -1688,6 +1714,7 @@ export class MariDbService {
           name: entryName,
           content: "",
           description: "",
+          tag: "",
           keys: [],
           secondaryKeys: [],
           enabled: "true",
@@ -1717,7 +1744,6 @@ export class MariDbService {
           delayUntilRecursion: "false",
           excludeFromVectorization: "false",
           locked: "false",
-          tag: "",
           createdAt: timestamp,
           updatedAt: timestamp,
         };
@@ -1746,6 +1772,7 @@ export class MariDbService {
           "name",
           "content",
           "description",
+          "tag",
           "keys",
           "secondaryKeys",
           "enabled",
@@ -2620,26 +2647,27 @@ export class MariDbService {
       }
       case "entries": {
         const lorebookId = parsed.positionals[0];
-        if (!lorebookId) throw new Error("Usage: mari lorebooks entries <lorebook-id> [--limit <n>]");
+        if (!lorebookId) throw new Error("Usage: mari lorebooks entries <lorebook-id> [--limit <n>] [--entry-id <entry-id>]");
         const limit = normalizeLimit(flagString(flags, "limit"), 100, 2000);
+        const entryId = flagString(flags, "entry-id") ?? flagString(flags, "entryId");
         const entries = (await this.rawRows("lorebook_entries"))
           .filter((e) => e.lorebookId === lorebookId)
+          .filter((e) => !entryId || e.id === entryId)
           .sort((a, b) => Number(a.order ?? 100) - Number(b.order ?? 100))
           .slice(0, limit)
-          .map((row) => {
-            const p = parseRow("lorebook_entries", row);
-            return {
-              id: p.id,
-              name: p.name,
-              enabled: p.enabled,
-              constant: p.constant,
-              keys: p.keys,
-              content: typeof p.content === "string" ? truncateStr(p.content, 200) : "",
-              order: p.order,
-              createdAt: p.createdAt,
-            };
-          });
+          .map(summarizeLorebookEntryRow);
         return { ok: true, mode: "read", command: context.command, output: entries };
+      }
+      case "get-entry": {
+        const entryId = parsed.positionals[0] ?? flagString(flags, "entry-id") ?? flagString(flags, "entryId");
+        if (!entryId) throw new Error("Usage: mari lorebooks get-entry <entry-id>");
+        const row = await this.getRawById(getMeta("lorebook_entries"), entryId);
+        return {
+          ok: !!row,
+          mode: "read",
+          command: context.command,
+          output: row ? summarizeLorebookEntryRow(row) : null,
+        };
       }
       case "search": {
         const query = parsed.positionals[0];
@@ -2733,7 +2761,7 @@ export class MariDbService {
         const lorebookId = parsed.positionals[0];
         if (!lorebookId) {
           throw new Error(
-            "Usage: mari lorebooks add-entry <lorebook-id> --name <name> [--content <text>] [--keys <k1,k2,...>] [--description <text>] [--apply] [--reason <text>]",
+            "Usage: mari lorebooks add-entry <lorebook-id> --name <name> [--content <text>] [--keys <k1,k2,...>] [--description <text>] [--tag <tag>] [--apply] [--reason <text>]",
           );
         }
         const entryName = flagString(flags, "name")?.trim();
@@ -2754,6 +2782,7 @@ export class MariDbService {
           name: entryName,
           content: flagString(flags, "content") ?? "",
           description: flagString(flags, "description") ?? "",
+          tag: flagString(flags, "tag") ?? "",
           keys,
           secondaryKeys: [],
           enabled: "true",
@@ -2783,7 +2812,6 @@ export class MariDbService {
           delayUntilRecursion: "false",
           excludeFromVectorization: "false",
           locked: "false",
-          tag: "",
           createdAt: timestamp,
           updatedAt: timestamp,
         };
@@ -2803,7 +2831,7 @@ export class MariDbService {
         const entryId = parsed.positionals[0];
         if (!entryId) {
           throw new Error(
-            "Usage: mari lorebooks update-entry <entry-id> [--name <name>] [--content <text>] [--keys <k1,k2,...>] [--description <text>] [--enable] [--disable] [--constant] [--no-constant] [--order <n>] [--apply] [--reason <text>]",
+            "Usage: mari lorebooks update-entry <entry-id> [--name <name>] [--content <text>] [--keys <k1,k2,...>] [--description <text>] [--tag <tag>] [--enable] [--disable] [--constant] [--no-constant] [--order <n>] [--apply] [--reason <text>]",
           );
         }
         const entryExists = await this.getRawById(getMeta("lorebook_entries"), entryId);
@@ -2813,6 +2841,7 @@ export class MariDbService {
           ["name", "name"],
           ["content", "content"],
           ["description", "description"],
+          ["tag", "tag"],
         ];
         for (const [flagName, fieldName] of entryFieldMap) {
           const val = flagString(flags, flagName);
@@ -2836,7 +2865,7 @@ export class MariDbService {
         if (hasFlag(flags, "no-constant")) entryPatch.constant = "false";
         if (Object.keys(entryPatch).length <= 1) {
           throw new Error(
-            "Provide at least one field to update (--name, --content, --keys, --description, --enable, --disable, --constant, --no-constant, --order)",
+            "Provide at least one field to update (--name, --content, --keys, --description, --tag, --enable, --disable, --constant, --no-constant, --order)",
           );
         }
         const updateEntryRequest: ParsedMutationRequest = {
@@ -2963,14 +2992,18 @@ export class MariDbService {
       }
       case "messages": {
         const chatId = parsed.positionals[0];
-        if (!chatId) throw new Error("Usage: mari chats messages <chat-id> [--limit <n>] [--tail]");
+        if (!chatId) throw new Error("Usage: mari chats messages <chat-id> [--limit <n>] [--offset <n>] [--tail]");
         const limitFlag = flagString(flags, "limit");
         const limit = limitFlag !== undefined ? normalizeLimit(limitFlag, 20, 200) : null;
+        const offset = normalizeOffset(flagString(flags, "offset"));
         const tail = hasFlag(flags, "tail");
         let messages = (await this.rawRows("messages")).filter((m) => m.chatId === chatId);
         messages.sort((a, b) => String(a.createdAt ?? "").localeCompare(String(b.createdAt ?? "")));
-        if (limit !== null) {
-          messages = tail ? messages.slice(-limit) : messages.slice(0, limit);
+        if (tail) {
+          const offsetMessages = offset > 0 ? messages.slice(0, Math.max(0, messages.length - offset)) : messages;
+          messages = limit !== null ? offsetMessages.slice(-limit) : offsetMessages;
+        } else {
+          messages = messages.slice(offset, limit !== null ? offset + limit : undefined);
         }
         const result = messages.map((row) => ({
           id: row.id,
@@ -3879,7 +3912,7 @@ export class MariDbService {
       "Images/media:        mari images connections|preview|generate|edit|assign|delete|list",
       "Creative data:       mari characters list|get|search|create|update|delete",
       "Creative data:       mari personas list|active|get|search|create|update|delete",
-      "Creative data:       mari lorebooks list|get|entries <lorebook-id>|search|create|update <lorebook-id>|add-entry <lorebook-id>|update-entry <entry-id>|delete-entry <entry-id>|link-character|unlink-character|delete",
+      "Creative data:       mari lorebooks list|get|get-entry <entry-id>|entries <lorebook-id>|search|create|update <lorebook-id>|add-entry <lorebook-id>|update-entry <entry-id>|delete-entry <entry-id>|link-character|unlink-character|delete",
       "Chats (read-only):   mari chats list|get|messages|search",
       "Fandom/wiki reads:   mari wiki find-wikis|search-all|search|get-page|sections|category|site-info",
       "Discovery:           mari <group> --help or mari <group> <command> --help",
@@ -3920,12 +3953,13 @@ export class MariDbService {
       "Usage: mari lorebooks <command>",
       "Read:  list [--limit <n>] [--global] [--character <id>]",
       "Read:  get <id>",
-      "Read:  entries <lorebook-id> [--limit <n>]",
+      "Read:  entries <lorebook-id> [--limit <n>] [--entry-id <entry-id>]",
+      "Read:  get-entry <entry-id>",
       "Read:  search <query> [--limit <n>]",
       "Write: create --name <name> [--description <text>] [--category <text>] [--global] [--apply] [--reason <text>]",
       "Write: update <id> [--name <name>] [--description <text>] [--category <text>] [--tags <t1,t2,...>] [--global] [--enable] [--disable] [--apply] [--reason <text>]",
-      "Write: add-entry <lorebook-id> --name <name> [--content <text>] [--keys <k1,k2,...>] [--description <text>] [--apply] [--reason <text>]",
-      "Write: update-entry <entry-id> [--name <name>] [--content <text>] [--keys <k1,k2,...>] [--description <text>] [--enable] [--disable] [--constant] [--no-constant] [--order <n>] [--apply] [--reason <text>]",
+      "Write: add-entry <lorebook-id> --name <name> [--content <text>] [--keys <k1,k2,...>] [--description <text>] [--tag <tag>] [--apply] [--reason <text>]",
+      "Write: update-entry <entry-id> [--name <name>] [--content <text>] [--keys <k1,k2,...>] [--description <text>] [--tag <tag>] [--enable] [--disable] [--constant] [--no-constant] [--order <n>] [--apply] [--reason <text>]",
       "Write: delete-entry <entry-id> [--apply] [--reason <text>]",
       "Write: link-character <lorebook-id> --character <character-id> [--apply] [--reason <text>]",
       "Write: unlink-character <lorebook-id> --character <character-id> [--apply] [--reason <text>]",
@@ -3939,7 +3973,7 @@ export class MariDbService {
       "Usage: mari chats <command>",
       "Read:  list [--limit <n>] [--character <id>]",
       "Read:  get <id>",
-      "Read:  messages <chat-id> [--limit <n>] [--tail]",
+      "Read:  messages <chat-id> [--limit <n>] [--offset <n>] [--tail]",
       "Read:  search <query> [--limit <n>]",
       "All chat commands are read-only.",
     ].join("\n");

--- a/packages/server/src/services/mari-db/mari-db.service.ts
+++ b/packages/server/src/services/mari-db/mari-db.service.ts
@@ -1567,7 +1567,7 @@ export class MariDbService {
           ok: !!row,
           mode: "read",
           command: context.command,
-          output: row ? summarizeLorebookEntryRow(row) : null,
+          output: row ? parseRow("lorebook_entries", row) : null,
         };
       }
       case "search": {
@@ -2666,7 +2666,7 @@ export class MariDbService {
           ok: !!row,
           mode: "read",
           command: context.command,
-          output: row ? summarizeLorebookEntryRow(row) : null,
+          output: row ? parseRow("lorebook_entries", row) : null,
         };
       }
       case "search": {

--- a/start-termux.sh
+++ b/start-termux.sh
@@ -184,6 +184,15 @@ elif [ -d ".git" ]; then
     TARGET_BRANCH="main"
     if [ "$CURRENT_BRANCH" = "staging" ]; then
         TARGET_BRANCH="staging"
+    elif [ -z "$CURRENT_BRANCH" ]; then
+        git fetch origin \
+            "+refs/heads/main:refs/remotes/origin/main" \
+            "+refs/heads/staging:refs/remotes/origin/staging" \
+            --quiet 2>/dev/null || true
+        if git merge-base --is-ancestor HEAD origin/staging 2>/dev/null \
+            && ! git merge-base --is-ancestor HEAD origin/main 2>/dev/null; then
+            TARGET_BRANCH="staging"
+        fi
     fi
     TARGET_REF="origin/${TARGET_BRANCH}"
     if ! git fetch origin "+refs/heads/${TARGET_BRANCH}:refs/remotes/origin/${TARGET_BRANCH}" --quiet 2>/dev/null; then

--- a/start-termux.sh
+++ b/start-termux.sh
@@ -180,13 +180,18 @@ if [ "$SKIP_UPDATE" = "1" ]; then
 elif [ -d ".git" ]; then
     echo "  [..] Checking for updates..."
     OLD_HEAD=$(git rev-parse HEAD 2>/dev/null)
-    if ! git fetch origin +refs/heads/main:refs/remotes/origin/main --quiet 2>/dev/null; then
+    CURRENT_BRANCH=$(git branch --show-current 2>/dev/null || true)
+    TARGET_BRANCH="main"
+    if [ "$CURRENT_BRANCH" = "staging" ]; then
+        TARGET_BRANCH="staging"
+    fi
+    TARGET_REF="origin/${TARGET_BRANCH}"
+    if ! git fetch origin "+refs/heads/${TARGET_BRANCH}:refs/remotes/origin/${TARGET_BRANCH}" --quiet 2>/dev/null; then
         echo "  [WARN] Could not check for updates (no internet?). Continuing with current version."
-    elif [ "$OLD_HEAD" = "$(git rev-parse origin/main 2>/dev/null || true)" ]; then
+    elif [ "$OLD_HEAD" = "$(git rev-parse "$TARGET_REF" 2>/dev/null || true)" ]; then
         echo "  [OK] Already up to date"
     else
-        TARGET_HEAD=$(git rev-parse origin/main 2>/dev/null || true)
-        CURRENT_BRANCH=$(git branch --show-current 2>/dev/null || true)
+        TARGET_HEAD=$(git rev-parse "$TARGET_REF" 2>/dev/null || true)
         # Stash local changes, including untracked non-ignored files, so the update doesn't fail
         STASHED=0
         STASH_REF=""
@@ -210,10 +215,10 @@ elif [ -d ".git" ]; then
             elif git reset --hard "$TARGET_HEAD" >"$UPDATE_LOG" 2>&1; then
                 UPDATED_TO_TARGET=1
             fi
-        elif git merge --ff-only origin/main >"$UPDATE_LOG" 2>&1; then
+        elif git merge --ff-only "$TARGET_REF" >"$UPDATE_LOG" 2>&1; then
             UPDATED_TO_TARGET=1
-        elif [ "$CURRENT_BRANCH" = "main" ] || [ "$CURRENT_BRANCH" = "master" ]; then
-            echo "  [..] Fast-forward failed; resetting the installed checkout to the released main commit..."
+        elif [ "$CURRENT_BRANCH" = "main" ] || [ "$CURRENT_BRANCH" = "master" ] || [ "$CURRENT_BRANCH" = "staging" ]; then
+            echo "  [..] Fast-forward failed; resetting the installed checkout to the latest ${TARGET_BRANCH} commit..."
             if git reset --hard "$TARGET_HEAD" >"$UPDATE_LOG" 2>&1; then
                 UPDATED_TO_TARGET=1
             fi
@@ -224,7 +229,7 @@ elif [ -d ".git" ]; then
                 restore_stashed_changes || true
             fi
             if [ "$NEW_HEAD" != "$TARGET_HEAD" ]; then
-                echo "  [WARN] Update did not land on origin/main. Continuing with current version."
+                echo "  [WARN] Update did not land on ${TARGET_REF}. Continuing with current version."
             else
                 echo "  [OK] Updated to $(git log -1 --format='%h %s' 2>/dev/null)"
                 echo "  [..] Reinstalling dependencies..."
@@ -233,7 +238,7 @@ elif [ -d ".git" ]; then
                 rm -f packages/shared/tsconfig.tsbuildinfo packages/server/tsconfig.tsbuildinfo packages/client/tsconfig.tsbuildinfo
             fi
         elif [ "$SKIP_UPDATE_FOR_LOCAL_CHANGES" != "1" ]; then
-            echo "  [WARN] Could not update to origin/main. Continuing with current version."
+            echo "  [WARN] Could not update to ${TARGET_REF}. Continuing with current version."
             if [ -s "$UPDATE_LOG" ]; then
                 echo "         Git reported:"
                 sed 's/^/         /' "$UPDATE_LOG"

--- a/start.bat
+++ b/start.bat
@@ -105,6 +105,14 @@ set "CURRENT_BRANCH="
 for /f "tokens=*" %%i in ('git branch --show-current 2^>nul') do set "CURRENT_BRANCH=%%i"
 set "TARGET_BRANCH=main"
 if /I "!CURRENT_BRANCH!"=="staging" set "TARGET_BRANCH=staging"
+if "!CURRENT_BRANCH!"=="" (
+    git fetch origin "+refs/heads/main:refs/remotes/origin/main" "+refs/heads/staging:refs/remotes/origin/staging" --quiet >nul 2>&1
+    git merge-base --is-ancestor HEAD origin/staging >nul 2>&1
+    if not errorlevel 1 (
+        git merge-base --is-ancestor HEAD origin/main >nul 2>&1
+        if errorlevel 1 set "TARGET_BRANCH=staging"
+    )
+)
 set "TARGET_REF=origin/!TARGET_BRANCH!"
 git fetch origin "+refs/heads/!TARGET_BRANCH!:refs/remotes/origin/!TARGET_BRANCH!" --quiet >nul 2>&1
 if errorlevel 1 (

--- a/start.bat
+++ b/start.bat
@@ -101,12 +101,17 @@ goto :eof
 if not exist ".git" goto :skip_update
 echo  [..] Checking for updates...
 for /f "tokens=*" %%i in ('git rev-parse HEAD 2^>nul') do set "OLD_HEAD=%%i"
-git fetch origin "+refs/heads/main:refs/remotes/origin/main" --quiet >nul 2>&1
+set "CURRENT_BRANCH="
+for /f "tokens=*" %%i in ('git branch --show-current 2^>nul') do set "CURRENT_BRANCH=%%i"
+set "TARGET_BRANCH=main"
+if /I "!CURRENT_BRANCH!"=="staging" set "TARGET_BRANCH=staging"
+set "TARGET_REF=origin/!TARGET_BRANCH!"
+git fetch origin "+refs/heads/!TARGET_BRANCH!:refs/remotes/origin/!TARGET_BRANCH!" --quiet >nul 2>&1
 if errorlevel 1 (
     echo  [WARN] Could not check for updates. Continuing with current version.
     goto :skip_update
 )
-for /f "tokens=*" %%i in ('git rev-parse origin/main 2^>nul') do set "TARGET_HEAD=%%i"
+for /f "tokens=*" %%i in ('git rev-parse !TARGET_REF! 2^>nul') do set "TARGET_HEAD=%%i"
 if /I "!OLD_HEAD!"=="!TARGET_HEAD!" (
     echo  [OK] Already up to date
     goto :skip_update
@@ -138,12 +143,11 @@ if "!DIRTY!"=="1" (
     if not "!STASHED!"=="1" set "STASH_FAILED=1"
     if "!STASHED!"=="1" for /f "tokens=*" %%i in ('git stash list -1 --format^=%%gd 2^>nul') do set "STASH_REF=%%i"
 )
-set "CURRENT_BRANCH="
-for /f "tokens=*" %%i in ('git branch --show-current 2^>nul') do set "CURRENT_BRANCH=%%i"
 set "UPDATED_TO_TARGET=0"
 set "ALLOW_DETACHED_FALLBACK=0"
 if /I "!CURRENT_BRANCH!"=="main" set "ALLOW_DETACHED_FALLBACK=1"
 if /I "!CURRENT_BRANCH!"=="master" set "ALLOW_DETACHED_FALLBACK=1"
+if /I "!CURRENT_BRANCH!"=="staging" set "ALLOW_DETACHED_FALLBACK=1"
 set "UPDATE_LOG=%TEMP%\marinara-update-!RANDOM!-!RANDOM!.log"
 if exist "!UPDATE_LOG!" del /q "!UPDATE_LOG!" >nul 2>&1
 if "!STASH_FAILED!"=="1" (
@@ -153,9 +157,9 @@ if "!STASH_FAILED!"=="1" (
         git checkout --detach "!TARGET_HEAD!" >"!UPDATE_LOG!" 2>&1 && set "UPDATED_TO_TARGET=1"
         if not "!UPDATED_TO_TARGET!"=="1" git reset --hard "!TARGET_HEAD!" >"!UPDATE_LOG!" 2>&1 && set "UPDATED_TO_TARGET=1"
     ) else (
-        git merge --ff-only origin/main >"!UPDATE_LOG!" 2>&1 && set "UPDATED_TO_TARGET=1"
+        git merge --ff-only "!TARGET_REF!" >"!UPDATE_LOG!" 2>&1 && set "UPDATED_TO_TARGET=1"
         if not "!UPDATED_TO_TARGET!"=="1" if "!ALLOW_DETACHED_FALLBACK!"=="1" (
-            echo  [..] Fast-forward failed; resetting the installed checkout to the released main commit...
+            echo  [..] Fast-forward failed; resetting the installed checkout to the latest !TARGET_BRANCH! commit...
             git reset --hard "!TARGET_HEAD!" >"!UPDATE_LOG!" 2>&1 && set "UPDATED_TO_TARGET=1"
         )
     )
@@ -166,7 +170,7 @@ if not "!UPDATED_TO_TARGET!"=="1" (
         goto :skip_update
     )
     if "!STASHED!"=="1" call :restore_stashed_changes
-    echo  [WARN] Could not update to origin/main. Continuing with current version.
+    echo  [WARN] Could not update to !TARGET_REF!. Continuing with current version.
     if exist "!UPDATE_LOG!" (
         for %%A in ("!UPDATE_LOG!") do if %%~zA GTR 0 (
             echo         Git reported:
@@ -179,7 +183,7 @@ if not "!UPDATED_TO_TARGET!"=="1" (
 for /f "tokens=*" %%i in ('git rev-parse HEAD 2^>nul') do set "NEW_HEAD=%%i"
 if /I not "!NEW_HEAD!"=="!TARGET_HEAD!" (
     if "!STASHED!"=="1" call :restore_stashed_changes
-    echo  [WARN] Update did not land on origin/main. Continuing with current version.
+    echo  [WARN] Update did not land on !TARGET_REF!. Continuing with current version.
     if exist "!UPDATE_LOG!" del /q "!UPDATE_LOG!" >nul 2>&1
     goto :skip_update
 )

--- a/start.sh
+++ b/start.sh
@@ -105,6 +105,15 @@ if [ -d ".git" ]; then
     TARGET_BRANCH="main"
     if [ "$CURRENT_BRANCH" = "staging" ]; then
         TARGET_BRANCH="staging"
+    elif [ -z "$CURRENT_BRANCH" ]; then
+        git fetch origin \
+            "+refs/heads/main:refs/remotes/origin/main" \
+            "+refs/heads/staging:refs/remotes/origin/staging" \
+            --quiet 2>/dev/null || true
+        if git merge-base --is-ancestor HEAD origin/staging 2>/dev/null \
+            && ! git merge-base --is-ancestor HEAD origin/main 2>/dev/null; then
+            TARGET_BRANCH="staging"
+        fi
     fi
     TARGET_REF="origin/${TARGET_BRANCH}"
     if ! git fetch origin "+refs/heads/${TARGET_BRANCH}:refs/remotes/origin/${TARGET_BRANCH}" --quiet 2>/dev/null; then

--- a/start.sh
+++ b/start.sh
@@ -101,13 +101,18 @@ has_git_worktree_changes() {
 if [ -d ".git" ]; then
     echo "  [..] Checking for updates..."
     OLD_HEAD=$(git rev-parse HEAD 2>/dev/null)
-    if ! git fetch origin +refs/heads/main:refs/remotes/origin/main --quiet 2>/dev/null; then
+    CURRENT_BRANCH=$(git branch --show-current 2>/dev/null || true)
+    TARGET_BRANCH="main"
+    if [ "$CURRENT_BRANCH" = "staging" ]; then
+        TARGET_BRANCH="staging"
+    fi
+    TARGET_REF="origin/${TARGET_BRANCH}"
+    if ! git fetch origin "+refs/heads/${TARGET_BRANCH}:refs/remotes/origin/${TARGET_BRANCH}" --quiet 2>/dev/null; then
         echo "  [WARN] Could not check for updates (no internet?). Continuing with current version."
-    elif [ "$OLD_HEAD" = "$(git rev-parse origin/main 2>/dev/null || true)" ]; then
+    elif [ "$OLD_HEAD" = "$(git rev-parse "$TARGET_REF" 2>/dev/null || true)" ]; then
         echo "  [OK] Already up to date"
     else
-        TARGET_HEAD=$(git rev-parse origin/main 2>/dev/null || true)
-        CURRENT_BRANCH=$(git branch --show-current 2>/dev/null || true)
+        TARGET_HEAD=$(git rev-parse "$TARGET_REF" 2>/dev/null || true)
         # Stash local changes, including untracked non-ignored files, so the update doesn't fail
         STASHED=0
         STASH_REF=""
@@ -131,10 +136,10 @@ if [ -d ".git" ]; then
             elif git reset --hard "$TARGET_HEAD" >"$UPDATE_LOG" 2>&1; then
                 UPDATED_TO_TARGET=1
             fi
-        elif git merge --ff-only origin/main >"$UPDATE_LOG" 2>&1; then
+        elif git merge --ff-only "$TARGET_REF" >"$UPDATE_LOG" 2>&1; then
             UPDATED_TO_TARGET=1
-        elif [ "$CURRENT_BRANCH" = "main" ] || [ "$CURRENT_BRANCH" = "master" ]; then
-            echo "  [..] Fast-forward failed; resetting the installed checkout to the released main commit..."
+        elif [ "$CURRENT_BRANCH" = "main" ] || [ "$CURRENT_BRANCH" = "master" ] || [ "$CURRENT_BRANCH" = "staging" ]; then
+            echo "  [..] Fast-forward failed; resetting the installed checkout to the latest ${TARGET_BRANCH} commit..."
             if git reset --hard "$TARGET_HEAD" >"$UPDATE_LOG" 2>&1; then
                 UPDATED_TO_TARGET=1
             fi
@@ -145,7 +150,7 @@ if [ -d ".git" ]; then
                 restore_stashed_changes || true
             fi
             if [ "$NEW_HEAD" != "$TARGET_HEAD" ]; then
-                echo "  [WARN] Update did not land on origin/main. Continuing with current version."
+                echo "  [WARN] Update did not land on ${TARGET_REF}. Continuing with current version."
             else
                 echo "  [OK] Updated to $(git log -1 --format='%h %s' 2>/dev/null)"
                 echo "  [..] Reinstalling dependencies..."
@@ -155,7 +160,7 @@ if [ -d ".git" ]; then
                 rm -f packages/shared/tsconfig.tsbuildinfo packages/server/tsconfig.tsbuildinfo packages/client/tsconfig.tsbuildinfo
             fi
         elif [ "$SKIP_UPDATE_FOR_LOCAL_CHANGES" != "1" ]; then
-            echo "  [WARN] Could not update to origin/main. Continuing with current version."
+            echo "  [WARN] Could not update to ${TARGET_REF}. Continuing with current version."
             if [ -s "$UPDATE_LOG" ]; then
                 echo "         Git reported:"
                 sed 's/^/         /' "$UPDATE_LOG"


### PR DESCRIPTION
## Why

This issue sweep fixes several concrete regressions reported against v2.0.9: continue generation could lose prior text when rewrite agents ran, Professor Mari was missing small but important data-command affordances, mobile composers had inconsistent controls, and failed conversation-summary/autonomous generation retries could hammer dead model endpoints forever.

Closes #3105
Closes #3103
Closes #3102
Closes #3101
Closes #3100
Closes #3098
Closes #3106

## What changed

- Rewrite agents now edit the full merged message when `/continue` appends to an existing assistant message.
- `mari lorebooks` can fetch entries by entry id, include entry descriptions/tags in summaries, and set entry tags in add/update flows.
- `mari chats messages` supports `--offset` with existing `--limit`/`--tail` behavior.
- Conversation/Game/Roleplay input controls were aligned with requested icon, ordering, and mobile compactness changes.
- Conversation summary failures are recorded with cooldowns so bad 4xx/model errors do not retry every tick; server-side autonomous generation also backs off after repeated failures.
- v2.0.9 changelog updated.

## Validation

- [ ] Run `pnpm regression:prompt`
- [ ] Run `pnpm check`
- [ ] Manually verify `/continue` with text rewrite agents preserves the original assistant message plus continuation.
- [ ] Manually verify Professor Mari lorebook entry commands in a local app session.
- [ ] Manually verify Conversation, Roleplay mobile, and Game input composer layouts.
- [ ] Manually verify summary/autonomous backoff behavior with a deliberately invalid model connection.

## Notes

Automated validation was run locally before opening this draft PR; boxes are left unchecked for human review per repo instructions.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Update tools now better recognize and follow the current branch, including staging builds, for smoother installs and upgrades.
  * Chat and conversation inputs now adapt their placeholders and controls for mobile, improving usability on smaller screens.
  * Added more command-line options for viewing chat messages and lorebook entries, including pagination and entry-specific lookup.

* **Bug Fixes**
  * Fixed update behavior so staging installs no longer drift back to the wrong branch.
  * Improved handling of failed summaries and generation retries to avoid endless retry loops.

* **Documentation**
  * Updated installation and upgrade guides to match the new update flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->