### PR TITLE
Fix tracker panel freeze on agent-heavy chats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 - Added mobile chat composer minimization while scrolling through older messages, with automatic restore near the bottom, on downward scroll, or when the minimized input is tapped (#3091).
 - Fixed branch switching so a valid selected branch is not cleared just because the flat chat list briefly does not include it while detail/group caches are resolving (#3087).
 - Fixed provider requests so blank custom `model` parameters cannot erase the configured model, and corrected missing-model error guidance for MiMo/OpenAI-compatible endpoints (#3110).
+- Reduced tracker-panel freezes on chats with world-state/character-tracker agents by scoping tracker character/persona lookups to the active chat and containing off-screen tracker card rendering (#3104).
 
 ### Platform Notes
 

--- a/packages/client/src/features/tracker-panel/components/sections/CharacterTrackerPanel.tsx
+++ b/packages/client/src/features/tracker-panel/components/sections/CharacterTrackerPanel.tsx
@@ -16,6 +16,7 @@ import { CharacterTrackerCard } from "../character-card/CharacterTrackerCard";
 const COMPACT_CHARACTER_GHOST_SLOT_CLASS =
   "pointer-events-none relative hidden min-h-0 self-stretch overflow-hidden rounded-md border border-[color-mix(in_srgb,var(--border)_28%,transparent)] bg-[var(--tracker-panel-card-background,linear-gradient(135deg,color-mix(in_srgb,var(--card)_18%,transparent),color-mix(in_srgb,var(--background)_12%,transparent)_48%,transparent))] opacity-55 shadow-[inset_0_1px_0_color-mix(in_srgb,var(--foreground)_3%,transparent),inset_0_-1px_0_color-mix(in_srgb,var(--background)_18%,transparent)] @min-[260px]:block before:pointer-events-none before:absolute before:left-0 before:right-2 before:top-0.5 before:h-5 before:rounded-l-[4px] before:rounded-r-[2px] before:bg-[linear-gradient(180deg,color-mix(in_srgb,var(--background)_78%,var(--card)_22%),color-mix(in_srgb,var(--card)_42%,transparent))] before:opacity-65 after:pointer-events-none after:absolute after:inset-1 after:rounded-[4px] after:bg-[repeating-linear-gradient(135deg,color-mix(in_srgb,var(--border)_12%,transparent)_0_1px,transparent_1px_7px)] after:opacity-35";
 const COMPACT_CHARACTER_CARD_SLOT_CLASS = "min-h-0 h-full";
+const CHARACTER_CARD_RENDER_CONTAINMENT_CLASS = "[content-visibility:auto] [contain-intrinsic-size:10rem]";
 
 export function CharacterTrackerPanel({
   activeChatId,
@@ -91,6 +92,8 @@ export function CharacterTrackerPanel({
     });
     const featuredEntries = characterEntries.filter((entry) => entry.featured);
     const compactEntries = characterEntries.filter((entry) => !entry.featured);
+    const getCharacterEntryKey = (entry: (typeof characterEntries)[number]) =>
+      `${activeChatId ?? "chat"}-${entry.character.characterId}-${entry.index}`;
     const renderCharacterCard = ({
       character,
       cardKey,
@@ -102,7 +105,6 @@ export function CharacterTrackerPanel({
       index,
     }: (typeof characterEntries)[number]) => (
       <CharacterTrackerCard
-        key={`${activeChatId ?? "chat"}-${character.characterId}-${index}`}
         character={character}
         spriteCharacterId={spriteCharacterId}
         spriteExpression={spriteExpression}
@@ -127,16 +129,21 @@ export function CharacterTrackerPanel({
     const shouldRenderCompactGhostSlot = useCompactCardColumns && compactEntries.length % 2 === 1;
     const renderCompactCharacterCard = (entry: (typeof characterEntries)[number]) => (
       <div
-        key={`${activeChatId ?? "chat"}-${entry.character.characterId}-${entry.index}`}
-        className={COMPACT_CHARACTER_CARD_SLOT_CLASS}
+        key={getCharacterEntryKey(entry)}
+        className={cn(COMPACT_CHARACTER_CARD_SLOT_CLASS, CHARACTER_CARD_RENDER_CONTAINMENT_CLASS)}
       >
+        {renderCharacterCard(entry)}
+      </div>
+    );
+    const renderFeaturedCharacterCard = (entry: (typeof characterEntries)[number]) => (
+      <div key={getCharacterEntryKey(entry)} className={CHARACTER_CARD_RENDER_CONTAINMENT_CLASS}>
         {renderCharacterCard(entry)}
       </div>
     );
 
     return (
       <div className="space-y-1">
-        {featuredEntries.map(renderCharacterCard)}
+        {featuredEntries.map(renderFeaturedCharacterCard)}
         {compactEntries.length > 0 && (
           <div
             className={cn(

--- a/packages/client/src/features/tracker-panel/hooks/use-tracker-panel-model.ts
+++ b/packages/client/src/features/tracker-panel/hooks/use-tracker-panel-model.ts
@@ -1,7 +1,6 @@
 import { useCallback, useMemo } from "react";
-import type { Persona } from "@marinara-engine/shared";
 import { useAgentConfigs, type AgentConfigRow } from "../../../hooks/use-agents";
-import { usePersonas } from "../../../hooks/use-characters";
+import { usePersona } from "../../../hooks/use-characters";
 import { useChat, useChatMessages } from "../../../hooks/use-chats";
 import type { TrackerDataPanelSection } from "../../../stores/ui.store";
 import { TRACKER_FEATURED_CHARACTER_META_KEY, TRACKER_SECTION_AGENT_TYPES } from "../lib/tracker-panel.constants";
@@ -34,6 +33,10 @@ export function useTrackerPanelModel({
     () => normalizeMaybeJsonStringArray((chat as unknown as { characterIds?: unknown } | undefined)?.characterIds),
     [chat],
   );
+  const chatPersonaId = useMemo(() => {
+    const rawPersonaId = (chat as unknown as { personaId?: unknown } | undefined)?.personaId;
+    return typeof rawPersonaId === "string" && rawPersonaId.trim() ? rawPersonaId.trim() : null;
+  }, [chat]);
   const enabledAgentTypes = useMemo(() => {
     const set = new Set<string>();
     if (!chatMeta.enableAgents) return set;
@@ -67,7 +70,7 @@ export function useTrackerPanelModel({
   const agentConfigLookupEnabled = !!activeChatId && characterTrackerEnabled;
   const { data: messageData } = useChatMessages(activeChatId, 20, spriteExpressionLookupEnabled);
   const { data: agentConfigs } = useAgentConfigs(agentConfigLookupEnabled);
-  const { data: personasData } = usePersonas(personaDataLookupEnabled);
+  const { data: activePersonaData } = usePersona(personaDataLookupEnabled ? chatPersonaId : null);
   const { characterSpriteLookup, resolveSpriteCharacterId } = useTrackerSpriteLookup({
     enabled: characterDataLookupEnabled,
     chatCharacterIds,
@@ -92,16 +95,7 @@ export function useTrackerPanelModel({
     () => new Set(normalizeStringArray(chatMeta[TRACKER_FEATURED_CHARACTER_META_KEY])),
     [chatMeta],
   );
-  const personas = useMemo(() => (Array.isArray(personasData) ? (personasData as Persona[]) : []), [personasData]);
-  const activePersona = useMemo(() => {
-    const chatPersonaId = (chat as unknown as { personaId?: unknown } | undefined)?.personaId;
-    const selectedPersonaId = typeof chatPersonaId === "string" ? chatPersonaId : null;
-    return (
-      (selectedPersonaId ? personas.find((persona) => persona.id === selectedPersonaId) : null) ??
-      personas.find((persona) => persona.isActive) ??
-      null
-    );
-  }, [chat, personas]);
+  const activePersona = activePersonaData ?? null;
   const expressionSpritesEnabled = trackerPanelUseExpressionSprites && expressionAgentEnabled;
 
   return {

--- a/packages/client/src/features/tracker-panel/hooks/use-tracker-sprite-lookup.ts
+++ b/packages/client/src/features/tracker-panel/hooks/use-tracker-sprite-lookup.ts
@@ -1,6 +1,8 @@
 import { useCallback, useMemo } from "react";
+import { useQueries } from "@tanstack/react-query";
 import type { PresentCharacter } from "@marinara-engine/shared";
-import { useCharacters } from "../../../hooks/use-characters";
+import { characterKeys } from "../../../hooks/use-characters";
+import { api } from "../../../lib/api-client";
 import { parseCharacterDisplayData } from "../../../lib/character-display";
 import type { TrackerSpriteLookup } from "../tracker-panel.types";
 import { isSpriteLookupCharacterId } from "../lib/sprite-expressions";
@@ -12,40 +14,72 @@ interface UseTrackerSpriteLookupOptions {
   chatCharacterIds: string[];
 }
 
+interface TrackerLookupCharacterRow {
+  id: string;
+  data: unknown;
+  comment?: string | null;
+  avatarPath?: string | null;
+}
+
+function normalizeLookupCharacterIds(characterIds: string[]) {
+  const seen = new Set<string>();
+  const normalized: string[] = [];
+
+  for (const id of characterIds) {
+    const trimmed = id.trim();
+    if (!trimmed || seen.has(trimmed)) continue;
+    seen.add(trimmed);
+    normalized.push(trimmed);
+  }
+
+  return normalized;
+}
+
+function isTrackerLookupCharacterRow(value: unknown): value is TrackerLookupCharacterRow {
+  return (
+    !!value &&
+    typeof value === "object" &&
+    !Array.isArray(value) &&
+    typeof (value as { id?: unknown }).id === "string" &&
+    (value as { id: string }).id.length > 0
+  );
+}
+
 export function useTrackerSpriteLookup({ enabled, chatCharacterIds }: UseTrackerSpriteLookupOptions) {
-  const { data: charactersData } = useCharacters(enabled);
+  const lookupCharacterIds = useMemo(() => normalizeLookupCharacterIds(chatCharacterIds), [chatCharacterIds]);
+  const characterQueries = useQueries({
+    queries: lookupCharacterIds.map((id) => ({
+      queryKey: characterKeys.detail(id),
+      queryFn: () => api.get<TrackerLookupCharacterRow>(`/characters/${id}`),
+      enabled,
+      retry: false,
+      staleTime: 5 * 60_000,
+    })),
+  });
   const characterSpriteLookup = useMemo<TrackerSpriteLookup>(() => {
-    const rows = (
-      Array.isArray(charactersData)
-        ? (charactersData as Array<{ id: string; data: unknown; comment?: string | null; avatarPath?: string | null }>)
-        : []
-    ).filter((character) => typeof character.id === "string" && character.id.length > 0);
-    const chatIdSet = new Set(chatCharacterIds);
-    const orderedRows = [
-      ...rows.filter((character) => chatIdSet.has(character.id)),
-      ...rows.filter((character) => !chatIdSet.has(character.id)),
-    ];
+    const rows = characterQueries
+      .map((query) => query.data)
+      .filter(isTrackerLookupCharacterRow);
     const knownIds = new Set(rows.map((character) => character.id));
     const idByName = new Map<string, string>();
     const pictureById: Record<string, string> = {};
     const profileColorsById: TrackerSpriteLookup["profileColorsById"] = {};
-    const displayRows = orderedRows.map((character) => ({
+    const displayRows = rows.map((character) => ({
       character,
       display: parseCharacterDisplayData(character),
     }));
-    const chatDisplayRows = displayRows.filter(({ character }) => chatIdSet.has(character.id));
-    const fallbackDisplayRows = displayRows.filter(({ character }) => !chatIdSet.has(character.id));
-    for (const character of orderedRows) {
+
+    for (const character of rows) {
       if (character.avatarPath) pictureById[character.id] = character.avatarPath;
       const profileColors = getCharacterProfileColors(character.data);
       if (profileColors) profileColorsById[character.id] = profileColors;
     }
-    addExactNameLookups(chatDisplayRows, idByName);
-    addAliasLookups(chatDisplayRows, idByName);
-    addExactNameLookups(fallbackDisplayRows, idByName);
-    addAliasLookups(fallbackDisplayRows, idByName);
+
+    addExactNameLookups(displayRows, idByName);
+    addAliasLookups(displayRows, idByName);
+
     return { knownIds, idByName, pictureById, profileColorsById };
-  }, [charactersData, chatCharacterIds]);
+  }, [characterQueries]);
 
   const resolveSpriteCharacterId = useCallback(
     (character: PresentCharacter) => {

--- a/packages/client/src/hooks/use-characters.ts
+++ b/packages/client/src/hooks/use-characters.ts
@@ -9,7 +9,12 @@ import {
   serializeTrackerCardColorConfig,
   TRACKER_CARD_COLOR_PREVIEW_BASE_FIELD,
 } from "../lib/tracker-card-colors";
-import { PROFESSOR_MARI_ID, type CharacterCardVersion, type PersonaCardVersion } from "@marinara-engine/shared";
+import {
+  PROFESSOR_MARI_ID,
+  type CharacterCardVersion,
+  type Persona,
+  type PersonaCardVersion,
+} from "@marinara-engine/shared";
 import type { CustomKind, CustomTagPatch } from "../lib/custom-emoji";
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -37,7 +42,8 @@ export const characterKeys = {
   gallery: (id: string) => [...characterKeys.all, "gallery", id] as const,
   personaGallery: (id: string) => ["persona-gallery", id] as const,
   personas: ["personas"] as const,
-  personaVersions: (id: string) => [...characterKeys.personas, "detail", id, "versions"] as const,
+  personaDetail: (id: string) => [...characterKeys.personas, "detail", id] as const,
+  personaVersions: (id: string) => [...characterKeys.personaDetail(id), "versions"] as const,
   groups: ["character-groups"] as const,
   groupDetail: (id: string) => ["character-groups", "detail", id] as const,
   personaGroups: ["persona-groups"] as const,
@@ -504,6 +510,16 @@ export function usePersonas(enabled = true) {
   });
 }
 
+export function usePersona(id: string | null) {
+  return useQuery({
+    queryKey: characterKeys.personaDetail(id ?? ""),
+    queryFn: () => api.get<Persona>(`/characters/personas/${id}`),
+    enabled: !!id,
+    retry: false,
+    staleTime: 5 * 60_000,
+  });
+}
+
 export function useCreatePersona() {
   const qc = useQueryClient();
   return useMutation({
@@ -592,6 +608,7 @@ export function useUpdatePersona() {
 
       qc.invalidateQueries({ queryKey: characterKeys.personas });
       if (updatedId) {
+        qc.invalidateQueries({ queryKey: characterKeys.personaDetail(updatedId) });
         qc.invalidateQueries({ queryKey: characterKeys.personaVersions(updatedId) });
       }
     },
@@ -614,6 +631,7 @@ export function useRestorePersonaVersion() {
       api.post(`/characters/personas/${id}/versions/${versionId}/restore`, {}),
     onSuccess: (_data, variables) => {
       qc.invalidateQueries({ queryKey: characterKeys.personas });
+      qc.invalidateQueries({ queryKey: characterKeys.personaDetail(variables.id) });
       qc.invalidateQueries({ queryKey: characterKeys.personaVersions(variables.id) });
     },
   });
@@ -634,7 +652,10 @@ export function useDeletePersona() {
   const qc = useQueryClient();
   return useMutation({
     mutationFn: (id: string) => api.delete(`/characters/personas/${id}`),
-    onSuccess: () => qc.invalidateQueries({ queryKey: characterKeys.personas }),
+    onSuccess: (_data, id) => {
+      qc.invalidateQueries({ queryKey: characterKeys.personas });
+      qc.removeQueries({ queryKey: characterKeys.personaDetail(id) });
+    },
   });
 }
 
@@ -650,7 +671,10 @@ export function useActivatePersona() {
   const qc = useQueryClient();
   return useMutation({
     mutationFn: (id: string) => api.put(`/characters/personas/${id}/activate`, {}),
-    onSuccess: () => qc.invalidateQueries({ queryKey: characterKeys.personas }),
+    onSuccess: (_data, id) => {
+      qc.invalidateQueries({ queryKey: characterKeys.personas });
+      qc.invalidateQueries({ queryKey: characterKeys.personaDetail(id) });
+    },
   });
 }
 
@@ -661,6 +685,7 @@ export function useUploadPersonaAvatar() {
       api.post(`/characters/personas/${id}/avatar`, { avatar, filename }),
     onSuccess: (_data, variables) => {
       qc.invalidateQueries({ queryKey: characterKeys.personas });
+      qc.invalidateQueries({ queryKey: characterKeys.personaDetail(variables.id) });
       qc.invalidateQueries({ queryKey: characterKeys.personaVersions(variables.id) });
     },
   });


### PR DESCRIPTION
Fixes #3104.

## Why

Chats with world-state or character-tracker agents were mounting the tracker panel and doing work that scaled with the user's full character/persona libraries. On large installs and older tracker-heavy chats, that made the browser main thread freeze even when the chat was just sitting open.

## What changed

- Scoped tracker sprite/profile lookups to the active chat's character IDs instead of fetching and parsing the full character library.
- Added a persona detail query and switched the tracker persona panel to the active chat persona instead of loading every persona.
- Kept persona detail cache invalidation aligned with persona update/restore/delete/avatar changes.
- Added browser render containment around tracker character cards so off-screen accumulated cards cost less layout/paint work.
- Added the v2.0.9 changelog entry.

## Validation

- `pnpm check` passed.

## Manual verification still needed

- [ ] Open a large tracker-heavy chat on staging and confirm `[mari-perf] tracker-panel` no longer reports huge render/commit blocks.
- [ ] Confirm chat-linked character sprites/profile colors still resolve in the tracker panel.
- [ ] Confirm the Persona tracker panel still displays for chats with a selected persona.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed tracker panel freezes in chats that use world-state or character-tracker agents.
  * Improved tracker card rendering so off-screen cards are limited, reducing slowdowns.
  * Persona and character lookups are now more reliable, helping tracker data and sprites appear correctly in active chats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->