### PR TITLE
[codex] Reduce chat area render scope

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,8 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 - Fixed branch switching so a valid selected branch is not cleared just because the flat chat list briefly does not include it while detail/group caches are resolving (#3087).
 - Fixed provider requests so blank custom `model` parameters cannot erase the configured model, and corrected missing-model error guidance for MiMo/OpenAI-compatible endpoints (#3110).
 - Reduced tracker-panel freezes on chats with world-state/character-tracker agents by scoping tracker character/persona lookups to the active chat and containing off-screen tracker card rendering (#3104).
+- Reduced ChatArea render stalls by scoping chat character/persona, creator-notes CSS, and Conversation emoji/sticker lookups to the active chat instead of full libraries.
+- Lowered the mounted transcript render window in Conversation and Roleplay modes so long loaded chats keep fewer message components mounted at once.
 
 ### Platform Notes
 

--- a/packages/client/src/components/chat/ChatArea.tsx
+++ b/packages/client/src/components/chat/ChatArea.tsx
@@ -33,7 +33,14 @@ import {
 
 import { useChatStore } from "../../stores/chat.store";
 import { useGenerate } from "../../hooks/use-generate";
-import { characterKeys, spriteKeys, useCharacters, usePersonas, type SpriteInfo } from "../../hooks/use-characters";
+import {
+  characterKeys,
+  spriteKeys,
+  useActivePersona,
+  useCharacters,
+  usePersona,
+  type SpriteInfo,
+} from "../../hooks/use-characters";
 import { usePageActivity } from "../../hooks/use-page-activity";
 import { useRenderTimer } from "../../lib/perf-diagnostics";
 import { usePresenceClock } from "../../hooks/use-presence-clock";
@@ -284,8 +291,31 @@ type AgentInjectionReviewRequest = {
   injections: AgentInjectionReviewItem[];
 };
 
-type CharacterRow = { id: string; data: unknown; avatarPath: string | null };
+type CharacterRow = { id: string; data: unknown; avatarPath: string | null; comment?: string | null };
 type CharacterMapValue = NonNullable<ReturnType<CharacterMap["get"]>>;
+
+function isCharacterRow(value: unknown): value is CharacterRow {
+  return (
+    !!value &&
+    typeof value === "object" &&
+    !Array.isArray(value) &&
+    typeof (value as { id?: unknown }).id === "string" &&
+    typeof (value as { data?: unknown }).data !== "undefined"
+  );
+}
+
+function resolveChatPersonaId(chat: unknown): string | null {
+  const rawPersonaId = (chat as { personaId?: unknown } | null | undefined)?.personaId;
+  if (typeof rawPersonaId === "string" && rawPersonaId.trim()) return rawPersonaId.trim();
+
+  const metadata = parseChatMetadata((chat as { metadata?: unknown } | null | undefined)?.metadata);
+  const setupConfig = metadata.gameSetupConfig;
+  const rawSetupPersonaId =
+    setupConfig && typeof setupConfig === "object" && !Array.isArray(setupConfig)
+      ? (setupConfig as { personaId?: unknown }).personaId
+      : null;
+  return typeof rawSetupPersonaId === "string" && rawSetupPersonaId.trim() ? rawSetupPersonaId.trim() : null;
+}
 
 function toCharacterMapValue(char: CharacterRow): CharacterMapValue {
   try {
@@ -577,8 +607,10 @@ export function ChatArea() {
     });
     return map;
   }, [messageOffset, messages]);
-  const { data: allCharacters } = useCharacters({ includeBuiltIn: true });
-  const { data: allPersonas } = usePersonas();
+  const { data: gameLibraryCharacters } = useCharacters({
+    enabled: !!chat?.id && chat.id === activeChatId && isGameChat,
+    includeBuiltIn: true,
+  });
   const deleteMessage = useDeleteMessage(activeChatId);
   const deleteMessages = useDeleteMessages(activeChatId);
   const deleteSwipe = useDeleteSwipe(activeChatId);
@@ -644,41 +676,34 @@ export function ChatArea() {
 
   // Character IDs in the active chat
   const chatCharIds = useMemo(() => getChatCharacterIds(chat), [chat]);
+  const chatPersonaId = useMemo(() => resolveChatPersonaId(chat), [chat]);
+  const { data: chatPersona } = usePersona(chatPersonaId);
+  const { data: activePersonaFallback } = useActivePersona(!!chat?.id && !chatPersonaId && !isGameChat);
 
-  const baseCharacterMap: CharacterMap = useMemo(() => {
-    const map: CharacterMap = new Map();
-    if (!allCharacters) return map;
-    for (const char of allCharacters as CharacterRow[]) {
-      map.set(char.id, toCharacterMapValue(char));
-    }
-    return map;
-  }, [allCharacters]);
-
-  const missingChatCharacterIds = useMemo(
-    () => chatCharIds.filter((id) => !baseCharacterMap.has(id)),
-    [baseCharacterMap, chatCharIds],
-  );
-  const missingCharacterQueries = useQueries({
-    queries: missingChatCharacterIds.map((id) => ({
+  const activeCharacterQueries = useQueries({
+    queries: chatCharIds.map((id) => ({
       queryKey: characterKeys.detail(id),
       queryFn: () => api.get<CharacterRow>(`/characters/${id}`),
       enabled: !!chat?.id,
+      retry: false,
       staleTime: 5 * 60_000,
     })),
   });
+  const chatCharacterRows = useMemo(
+    () => activeCharacterQueries.map((query) => query.data).filter(isCharacterRow),
+    [activeCharacterQueries],
+  );
 
   // A 60s-cadence clock so schedule/override-derived presence refreshes when time
   // alone changes the effective status (mirrors the presence pill's refetch).
   const presenceNow = usePresenceClock();
 
-  // Build character lookup map. Cold launches can render chat detail before the
-  // full library list has produced every active character, so merge exact
-  // per-chat character fetches as a rescue path.
+  // Build character lookup map from the active chat's characters only. Library
+  // panels can load the whole catalog; the chat surface should not.
   const characterMap: CharacterMap = useMemo(() => {
-    const map: CharacterMap = new Map(baseCharacterMap);
-    for (const query of missingCharacterQueries) {
-      const char = query.data;
-      if (char?.id) map.set(char.id, toCharacterMapValue(char));
+    const map: CharacterMap = new Map();
+    for (const char of chatCharacterRows) {
+      map.set(char.id, toCharacterMapValue(char));
     }
     const convoMeta = parseChatMetadata(chat?.metadata);
     const archivedSnapshots = convoMeta.archivedCharacterSnapshots as Record<string, unknown> | undefined;
@@ -733,7 +758,7 @@ export function ChatArea() {
       }
     }
     return map;
-  }, [baseCharacterMap, missingCharacterQueries, chat?.metadata, presenceNow]);
+  }, [chatCharacterRows, chat?.metadata, presenceNow]);
 
   const characterNames = useMemo(
     () => chatCharIds.map((id) => characterMap.get(id)?.name).filter((n): n is string => !!n),
@@ -741,9 +766,9 @@ export function ChatArea() {
   );
 
   const gameCharacters = useMemo(() => {
-    if (!allCharacters) return [];
+    if (!isGameChat || !gameLibraryCharacters) return [];
     return (
-      allCharacters as Array<{ id: string; data: string; comment?: string | null; avatarPath: string | null }>
+      gameLibraryCharacters as Array<{ id: string; data: string; comment?: string | null; avatarPath: string | null }>
     ).flatMap((c) => {
       if (c.id === PROFESSOR_MARI_ID) return [];
       try {
@@ -769,34 +794,14 @@ export function ChatArea() {
         return [{ id: c.id, name: "Unknown" }];
       }
     });
-  }, [allCharacters]);
+  }, [gameLibraryCharacters, isGameChat]);
 
   // Active persona info (for user message styling: name, avatar, colors)
   const personaInfo = useMemo(() => {
-    if (!allPersonas) return undefined;
-    const personas = allPersonas as Array<{
-      id: string;
-      isActive: string | boolean;
-      name: string;
-      description?: string;
-      personality?: string;
-      scenario?: string;
-      backstory?: string;
-      appearance?: string;
-      avatarPath?: string | null;
-      avatarCrop?: string;
-      nameColor?: string;
-      dialogueColor?: string;
-      boxColor?: string;
-    }>;
-    // Prefer per-chat personaId, fall back to globally active persona
-    // (Game mode skips the fallback — persona must be explicitly selected)
-    const chatPersonaId = (chat as unknown as { personaId?: string | null })?.personaId;
-    const isGame = (chat as unknown as { mode?: string })?.mode === "game";
-    const persona =
-      (chatPersonaId ? personas.find((p) => p.id === chatPersonaId) : null) ??
-      (!isGame ? personas.find((p) => p.isActive === "true" || p.isActive === true) : null);
+    // Prefer per-chat personaId, fall back to the globally active persona outside Game mode.
+    const persona = chatPersona ?? (!isGameChat ? activePersonaFallback : null);
     if (!persona) return undefined;
+    const avatarCrop = typeof persona.avatarCrop === "string" ? parseAvatarCropJson(persona.avatarCrop) : (persona.avatarCrop ?? null);
     return {
       id: persona.id,
       name: persona.name,
@@ -806,12 +811,12 @@ export function ChatArea() {
       backstory: persona.backstory || undefined,
       appearance: persona.appearance || undefined,
       avatarUrl: persona.avatarPath || undefined,
-      avatarCrop: parseAvatarCropJson(persona.avatarCrop),
+      avatarCrop,
       nameColor: persona.nameColor || undefined,
       dialogueColor: persona.dialogueColor || undefined,
       boxColor: persona.boxColor || undefined,
     };
-  }, [allPersonas, chat]);
+  }, [activePersonaFallback, chatPersona, isGameChat]);
 
   const { startEncounter } = useEncounter();
   const { concludeScene, abandonScene, forkScene, isForking } = useScene();
@@ -950,7 +955,7 @@ export function ChatArea() {
   const cardCssInjector = (
     <CreatorNotesCssInjector
       characterIds={chatCharIds}
-      allCharacters={allCharacters as CharacterRow[] | undefined}
+      allCharacters={chatCharacterRows}
       mode={cardCssMode}
       chatMode={cardCssChatMode}
     />

--- a/packages/client/src/hooks/use-characters.ts
+++ b/packages/client/src/hooks/use-characters.ts
@@ -42,6 +42,7 @@ export const characterKeys = {
   gallery: (id: string) => [...characterKeys.all, "gallery", id] as const,
   personaGallery: (id: string) => ["persona-gallery", id] as const,
   personas: ["personas"] as const,
+  personaActive: () => [...characterKeys.personas, "active"] as const,
   personaDetail: (id: string) => [...characterKeys.personas, "detail", id] as const,
   personaVersions: (id: string) => [...characterKeys.personaDetail(id), "versions"] as const,
   groups: ["character-groups"] as const,
@@ -520,6 +521,16 @@ export function usePersona(id: string | null) {
   });
 }
 
+export function useActivePersona(enabled = true) {
+  return useQuery({
+    queryKey: characterKeys.personaActive(),
+    queryFn: () => api.get<Persona | null>("/characters/personas/active"),
+    enabled,
+    retry: false,
+    staleTime: 5 * 60_000,
+  });
+}
+
 export function useCreatePersona() {
   const qc = useQueryClient();
   return useMutation({
@@ -607,6 +618,7 @@ export function useUpdatePersona() {
       });
 
       qc.invalidateQueries({ queryKey: characterKeys.personas });
+      qc.invalidateQueries({ queryKey: characterKeys.personaActive() });
       if (updatedId) {
         qc.invalidateQueries({ queryKey: characterKeys.personaDetail(updatedId) });
         qc.invalidateQueries({ queryKey: characterKeys.personaVersions(updatedId) });
@@ -631,6 +643,7 @@ export function useRestorePersonaVersion() {
       api.post(`/characters/personas/${id}/versions/${versionId}/restore`, {}),
     onSuccess: (_data, variables) => {
       qc.invalidateQueries({ queryKey: characterKeys.personas });
+      qc.invalidateQueries({ queryKey: characterKeys.personaActive() });
       qc.invalidateQueries({ queryKey: characterKeys.personaDetail(variables.id) });
       qc.invalidateQueries({ queryKey: characterKeys.personaVersions(variables.id) });
     },
@@ -654,6 +667,7 @@ export function useDeletePersona() {
     mutationFn: (id: string) => api.delete(`/characters/personas/${id}`),
     onSuccess: (_data, id) => {
       qc.invalidateQueries({ queryKey: characterKeys.personas });
+      qc.invalidateQueries({ queryKey: characterKeys.personaActive() });
       qc.removeQueries({ queryKey: characterKeys.personaDetail(id) });
     },
   });
@@ -673,6 +687,7 @@ export function useActivatePersona() {
     mutationFn: (id: string) => api.put(`/characters/personas/${id}/activate`, {}),
     onSuccess: (_data, id) => {
       qc.invalidateQueries({ queryKey: characterKeys.personas });
+      qc.invalidateQueries({ queryKey: characterKeys.personaActive() });
       qc.invalidateQueries({ queryKey: characterKeys.personaDetail(id) });
     },
   });
@@ -685,6 +700,7 @@ export function useUploadPersonaAvatar() {
       api.post(`/characters/personas/${id}/avatar`, { avatar, filename }),
     onSuccess: (_data, variables) => {
       qc.invalidateQueries({ queryKey: characterKeys.personas });
+      qc.invalidateQueries({ queryKey: characterKeys.personaActive() });
       qc.invalidateQueries({ queryKey: characterKeys.personaDetail(variables.id) });
       qc.invalidateQueries({ queryKey: characterKeys.personaVersions(variables.id) });
     },

--- a/packages/client/src/hooks/use-conversation-custom-emojis.ts
+++ b/packages/client/src/hooks/use-conversation-custom-emojis.ts
@@ -13,8 +13,7 @@ import { getChatCharacterIds } from "../lib/chat-macros";
 import { parseCharacterDisplayData } from "../lib/character-display";
 import { useCustomEmojis } from "./use-custom-emojis";
 import {
-  useCharacters,
-  usePersonas,
+  usePersona,
   usePersonaGalleryImages,
   characterKeys,
   type CharacterGalleryImage,
@@ -44,8 +43,16 @@ export function useConversationCustomEmojis(): { list: ConversationCustomEmoji[]
 
   const { data: globalEmojis } = useCustomEmojis();
   const { data: personaImages } = usePersonaGalleryImages(personaId);
-  const { data: characters } = useCharacters();
-  const { data: personas } = usePersonas();
+  const { data: persona } = usePersona(personaId);
+  const characterQueries = useQueries({
+    queries: characterIds.map((id) => ({
+      queryKey: characterKeys.detail(id),
+      queryFn: () => api.get<{ id: string; data?: unknown; name?: unknown }>(`/characters/${id}`),
+      enabled: !!id,
+      retry: false,
+      staleTime: 5 * 60_000,
+    })),
+  });
 
   const charGalleries = useQueries({
     queries: characterIds.map((id) => ({
@@ -56,9 +63,10 @@ export function useConversationCustomEmojis(): { list: ConversationCustomEmoji[]
     })),
   });
 
-  const personaRows = (personas as Array<{ id: string; data?: unknown; name?: unknown }>) ?? [];
-  const characterRows = (characters as Array<{ id: string; data?: unknown; name?: unknown }>) ?? [];
-  const personaName = personaId ? displayName(personaRows.find((p) => p.id === personaId), "Persona") : "Persona";
+  const characterRows = characterQueries
+    .map((query) => query.data)
+    .filter((row): row is { id: string; data?: unknown; name?: unknown } => typeof row?.id === "string");
+  const personaName = personaId ? displayName(persona, "Persona") : "Persona";
   const charNameById = new Map<string, string>();
   for (const row of characterRows) charNameById.set(row.id, displayName(row, "Character"));
 

--- a/packages/client/src/hooks/use-conversation-custom-stickers.ts
+++ b/packages/client/src/hooks/use-conversation-custom-stickers.ts
@@ -13,8 +13,7 @@ import { getChatCharacterIds } from "../lib/chat-macros";
 import { parseCharacterDisplayData } from "../lib/character-display";
 import { useCustomStickers } from "./use-custom-stickers";
 import {
-  useCharacters,
-  usePersonas,
+  usePersona,
   usePersonaGalleryImages,
   characterKeys,
   type CharacterGalleryImage,
@@ -44,8 +43,16 @@ export function useConversationCustomStickers(): { list: ConversationCustomStick
 
   const { data: globalStickers } = useCustomStickers();
   const { data: personaImages } = usePersonaGalleryImages(personaId);
-  const { data: characters } = useCharacters();
-  const { data: personas } = usePersonas();
+  const { data: persona } = usePersona(personaId);
+  const characterQueries = useQueries({
+    queries: characterIds.map((id) => ({
+      queryKey: characterKeys.detail(id),
+      queryFn: () => api.get<{ id: string; data?: unknown; name?: unknown }>(`/characters/${id}`),
+      enabled: !!id,
+      retry: false,
+      staleTime: 5 * 60_000,
+    })),
+  });
 
   const charGalleries = useQueries({
     queries: characterIds.map((id) => ({
@@ -56,9 +63,10 @@ export function useConversationCustomStickers(): { list: ConversationCustomStick
     })),
   });
 
-  const personaRows = (personas as Array<{ id: string; data?: unknown; name?: unknown }>) ?? [];
-  const characterRows = (characters as Array<{ id: string; data?: unknown; name?: unknown }>) ?? [];
-  const personaName = personaId ? displayName(personaRows.find((p) => p.id === personaId), "Persona") : "Persona";
+  const characterRows = characterQueries
+    .map((query) => query.data)
+    .filter((row): row is { id: string; data?: unknown; name?: unknown } => typeof row?.id === "string");
+  const personaName = personaId ? displayName(persona, "Persona") : "Persona";
   const charNameById = new Map<string, string>();
   for (const row of characterRows) charNameById.set(row.id, displayName(row, "Character"));
 

--- a/packages/client/src/lib/transcript-render-window.ts
+++ b/packages/client/src/lib/transcript-render-window.ts
@@ -1,5 +1,5 @@
-const MAX_MOUNTED_TRANSCRIPT_MESSAGES = 160;
-export const TRANSCRIPT_RENDER_WINDOW_STEP = 80;
+const MAX_MOUNTED_TRANSCRIPT_MESSAGES = 80;
+export const TRANSCRIPT_RENDER_WINDOW_STEP = 40;
 
 export type TranscriptRenderWindow<T> = {
   messages: T[] | undefined;

--- a/packages/server/src/routes/characters.routes.ts
+++ b/packages/server/src/routes/characters.routes.ts
@@ -830,6 +830,11 @@ export async function charactersRoutes(app: FastifyInstance) {
     return storage.listPersonas();
   });
 
+  app.get("/personas/active", async () => {
+    const personas = await storage.listPersonas();
+    return personas.find((persona) => String(persona.isActive) === "true") ?? null;
+  });
+
   app.get<{ Params: { id: string } }>("/personas/:id", async (req, reply) => {
     const persona = await storage.getPersona(req.params.id);
     if (!persona) return reply.status(404).send({ error: "Persona not found" });


### PR DESCRIPTION
## Summary

- Scope ChatArea character and persona data to the active chat instead of loading full libraries on the hot render path.
- Add an active-persona endpoint/query for the non-game fallback persona case.
- Scope Conversation emoji/sticker display-name lookups to active participants.
- Lower the mounted transcript render window for long Conversation and Roleplay chats.
- Update the v2.0.9 changelog.

## Why

User performance traces showed `chat-area render+commit` taking 6-24 seconds while tracker-panel commits stayed near 0-8ms. The chat surface was paying library-wide lookup costs during active chat renders.

## Validation

- pnpm check

## Manual Verification

- [ ] Manually verify a long Conversation chat opens and scrolls without multi-second chat-area commits.
- [ ] Manually verify Roleplay message rendering still shows character/persona styling, creator notes CSS, emojis, and stickers.
- [ ] Manually verify Game mode still has access to the broader character library where required.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The app now consistently uses the currently active persona in chat-related views and emoji/sticker display.
  * Long conversations should load more smoothly, with fewer messages kept mounted at once.

* **Bug Fixes**
  * Reduced render stalls in chats by narrowing lookups and rendering work to the active conversation.
  * Improved character and persona display accuracy in game and roleplay chats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->