### PR TITLE
fix(client): O(1) segment index lookup in game narration (#3104)

### DIFF
--- a/packages/client/src/components/game/GameNarration.tsx
+++ b/packages/client/src/components/game/GameNarration.tsx
@@ -1670,6 +1670,16 @@ export function GameNarration({
     sourceMessagesById,
   ]);
 
+  // Fast O(1) segment-id → index lookup, rebuilt only when `segments` changes.
+  // The per-segment log renderers below previously each called
+  // `segments.findIndex(...)`, making stacked-log rendering O(n²) in segment
+  // count — the root of the #3104 game-mode freeze on long chats.
+  const segmentIndexById = useMemo(() => {
+    const map = new Map<string, number>();
+    segments.forEach((segment, index) => map.set(segment.id, index));
+    return map;
+  }, [segments]);
+
   // Clamp activeIndex when segments shrink (e.g. new party chat clears old dialogue)
   useEffect(() => {
     if (segments.length > 0 && activeIndex >= segments.length) {
@@ -3705,7 +3715,7 @@ export function GameNarration({
     const sourceMessageRole = sourceMessageId ? (sourceMessagesById.get(sourceMessageId)?.role ?? null) : null;
     const sourceRole = seg.sourceRole ?? sourceMessageRole;
     const isUserAuthoredSource = sourceRole === "user" || sourceMessageRole === "user";
-    const liveSegmentIndex = segments.findIndex((candidate) => candidate.id === seg.id);
+    const liveSegmentIndex = segmentIndexById.get(seg.id) ?? -1;
     const canEditMessage = !!onEditMessage && !!sourceMessageId && isUserAuthoredSource;
     const canEditSegment =
       !!onEditSegment &&
@@ -4865,7 +4875,7 @@ export function GameNarration({
                       const sourceRole = seg.sourceRole ?? sourceMessageRole;
                       const isUserAuthoredSource = sourceRole === "user" || sourceMessageRole === "user";
                       const isActiveSeg = active?.id === seg.id;
-                      const liveSegmentIndex = segments.findIndex((s) => s.id === seg.id);
+                      const liveSegmentIndex = segmentIndexById.get(seg.id) ?? -1;
                       const canJumpToSeg =
                         !!latestAssistant &&
                         sourceMessageId === latestAssistant.id &&


### PR DESCRIPTION
## Linked issue

Partially addresses #3104 (the **game-mode** half). This does **not** close #3104 — the roleplay/conversation lag is a separate, still-open thread (different render path; this change does not touch it).

## Why this change

A contributor confirmed the lag does **not** exist in v2.0.6, so #3104 is a regression. Bisecting the render-path diff (v2.0.6 → staging) surfaced one change that fits the instrumented signature (8–22s `render+commit` scaling with chat length, game mode):

In `GameNarration.tsx`, the stacked-log narration renderer computes, at the **top of each per-segment render**:

```js
const liveSegmentIndex = segments.findIndex((candidate) => candidate.id === seg.id);
```

`segments` is the **entire chat's** flattened, uncapped segment array, and `renderStackedLogSegment` runs **once per visible segment**. So the cost is `rendered × total` = **O(n²) in segment count, per render**. On long agent-heavy chats (hundreds of messages → thousands of segments) that's thousands of full-array scans per render — matching the measured multi-second freeze, and scaling with chat length exactly as users report.

In v2.0.6 this renderer was display-only and had no `findIndex`. The eager lookup was added in **v2.0.7, commit `e1e378b7e`** ("Prepare v2.0.7 follow-up fixes"), when the segment renderer gained an inline action-button suite. `GameNarration` is rendered solely by `GameSurface`, so this is game-mode only.

## What changed

Build an `id → index` Map once per `segments` change (a `useMemo` keyed on `segments`) and look it up in O(1) at both call sites (the delete-navigation handler and the jump-to-segment row). This collapses the per-render cost from O(n²) to O(n) (one Map build) + O(1) lookups.

Behavior-identical: `findIndex` returned `-1` when absent; `Map.get(...) ?? -1` returns the same. No visual or behavioral change — purely the cost of the index lookup.

## Validation

- [ ] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed `CONTRIBUTING.md`

### Manual verification notes

Done by the agent (not a substitute for human verification):
- `pnpm check` → exit 0 (TypeScript + ESLint + client build all clean).

Still needs manual verification:
- **Recommended before merge:** a DevTools Performance profile on a long, agent-heavy **game-mode** chat, before vs. after, confirming `renderStackedLogSegment` / `findIndex` self-time drops out (per #3104's "confirm perf fixes with a profile, don't trust code-reading alone").
- Open the **Logs** panel on a long game chat and confirm: stacked-log entries still render correctly, the **delete** button still deletes the right message/segment, and the **jump-to-segment** (click a past log row) still jumps to the correct segment.
- Confirm short/empty game chats and non-game chats are unaffected.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Version/release files updated (only if this PR includes a version bump)

## UI evidence (if applicable)

No UI change — this only changes how the per-segment index is computed (eager O(n²) scan → O(1) Map lookup).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved game narration log rendering by using faster segment lookup, making log updates and navigation more responsive.
* **Bug Fixes**
  * Fixed segment selection behavior in stacked and modal log views so “jump back” actions reliably target the correct entry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->