### PR TITLE
Fix iOS PWA chin strip on Face ID iPhones

### DIFF
--- a/docs/IOS_PWA_BOTTOM_SAFE_AREA.md
+++ b/docs/IOS_PWA_BOTTOM_SAFE_AREA.md
@@ -1,0 +1,80 @@
+# iOS PWA Bottom Safe Area — How It Works and How to Fix It
+
+## The Problem
+
+On iPhones with a home indicator (Face ID models), the bottom ~34px of the screen is a "safe area" zone for the home gesture. In a PWA with `apple-mobile-web-app-status-bar-style: black-translucent`, iOS prevents `position: fixed` elements from painting into this zone entirely. Every CSS trick fails — negative bottom offsets, `calc(100dvh + env(safe-area-inset-bottom))`, negative AppShell height overrides — all get silently clamped by WebKit.
+
+The result is a visible "chin" strip below the chat input box that shows a different color from the rest of the UI.
+
+## The Fix (What We Ship)
+
+**`packages/client/index.html`** uses `content="black"` instead of `content="black-translucent"`:
+
+```html
+<meta name="apple-mobile-web-app-status-bar-style" content="black" />
+```
+
+In `black` mode, iOS does not apply the bottom restriction. `position: fixed; inset: 0` on AppShell reaches the physical screen bottom, covering the chin zone with the app background.
+
+**Trade-off:** The status bar is a solid dark bar instead of a transparent glass overlay. `black-translucent` gives a prettier top (glass effect under the status bar) but makes the bottom chin unfixable. This is a hard iOS limitation — you cannot have both.
+
+## How It Was Diagnosed
+
+1. Set `html, body { background-color: #ff0000 }` in the inline `<style>` block of `dist/index.html` (not SW-cached, takes effect on next reopen with no cache clear).
+2. Set `.mari-chat-input-box { background-color: #00ff00 }` to see the input bar.
+3. **Chin red = html canvas** — no CSS div can paint there in `black-translucent` mode.
+4. **Chin dark = AppShell background** — AppShell's box covers that zone.
+5. **Chin green = already fixed.**
+
+Switching to `black` mode turned the chin dark (AppShell covers it). That's the working state.
+
+## If an Update Breaks It
+
+### Symptom: chin strip reappears below the input box
+
+**Check 1:** Has `apple-mobile-web-app-status-bar-style` been changed back to `black-translucent` in `packages/client/index.html`? Change it back to `black`.
+
+**Check 2:** Is the AppShell `className` still `"mari-app mari-app-background-paint fixed inset-0 flex overflow-hidden"` in `packages/client/src/components/layout/AppShell.tsx`? No extra `bottom-*` or `h-*` overrides should be on it for mobile — `inset-0` is sufficient in `black` mode.
+
+**Check 3:** Run the red/green diagnostic to confirm which layer is painting the chin:
+
+```html
+<!-- Add temporarily to packages/client/dist/index.html <style> block -->
+html, body { background-color: #ff0000 !important; }
+.mari-chat-input-box { background-color: #00ff00 !important; }
+.mari-app { background: #0000ff !important; }
+```
+
+Force-kill and reopen (no cache clear needed, `dist/index.html` is not SW-cached):
+
+- **Chin red, AppShell blue elsewhere** → AppShell box doesn't reach bottom → check status bar style is `black`, not `black-translucent`
+- **Chin still red with blue AppShell** → AppShell somehow not covering → check AppShell's `fixed inset-0` is intact
+- **Chin blue** → AppShell covers it but input box doesn't fill down to it → check outer wrapper padding (see below)
+
+### Symptom: input box is flush to the screen edge with no breathing room
+
+The outer wrapper divs in the three input components should have `pb-3` (not `pb-0`) for natural float spacing:
+
+- `packages/client/src/components/chat/ChatInput.tsx` — look for `mari-chat-input chat-input-container`, ensure `pb-3` not `pb-0`
+- `packages/client/src/components/chat/ConversationInput.tsx` — look for `relative px-2 sm:px-3 pb-3`
+- `packages/client/src/components/game/GameInput.tsx` — look for `px-3 pt-2 pb-3`
+
+### Rebuilding
+
+After any source change, the server serves from `packages/client/dist/` which requires a build:
+
+```bash
+pnpm --filter client build
+```
+
+Then clear site data on the device (Settings → Safari → Advanced → Website Data, or via DevTools) and reopen the PWA. The service worker caches JS/CSS by hash — if asset hashes changed, clearing site data is necessary to pick up new chunks.
+
+`dist/index.html` is **not** cached by the service worker and always served fresh. Use it for quick diagnostic style injections without rebuilding.
+
+## Key Facts
+
+- `black-translucent` → transparent status bar, chin zone locked (WebKit restriction), no CSS workaround exists
+- `black` or `default` → solid status bar, chin zone reachable by fixed elements
+- `env(safe-area-inset-bottom)` = ~34px on Face ID iPhones; use it for padding interactive content above the home indicator if needed
+- `dvh`/`lvh` viewport units in `black-translucent` mode equal the safe-content-area height (not physical screen height) — do not attempt to use these to extend AppShell past the safe-content boundary in that mode
+- SillyTavern avoids this entirely by not using `black-translucent`

--- a/docs/IOS_PWA_BOTTOM_SAFE_AREA.md
+++ b/docs/IOS_PWA_BOTTOM_SAFE_AREA.md
@@ -8,13 +8,14 @@ The result is a visible "chin" strip below the chat input box that shows a diffe
 
 ## The Fix (What We Ship)
 
-**`packages/client/index.html`** uses `content="black"` instead of `content="black-translucent"`:
+**`packages/client/index.html`** uses `content="black"` instead of `content="black-translucent"`, and adds `interactive-widget=resizes-content` to the viewport meta:
 
 ```html
 <meta name="apple-mobile-web-app-status-bar-style" content="black" />
+<meta name="viewport" content="..., viewport-fit=cover, interactive-widget=resizes-content" />
 ```
 
-In `black` mode, iOS does not apply the bottom restriction. `position: fixed; inset: 0` on AppShell reaches the physical screen bottom, covering the chin zone with the app background.
+In `black` mode, iOS does not apply the bottom restriction. AppShell uses `fixed top-0 left-0 right-0 h-dvh` — no explicit `bottom: 0`, height controlled by the `dvh` unit. With `interactive-widget=resizes-content`, `dvh` shrinks when the keyboard opens (iOS resizes the viewport instead of scrolling it), so the layout compresses cleanly above the keyboard without the UI shooting upward.
 
 **Trade-off:** The status bar is a solid dark bar instead of a transparent glass overlay. `black-translucent` gives a prettier top (glass effect under the status bar) but makes the bottom chin unfixable. This is a hard iOS limitation — you cannot have both.
 
@@ -34,7 +35,7 @@ Switching to `black` mode turned the chin dark (AppShell covers it). That's the 
 
 **Check 1:** Has `apple-mobile-web-app-status-bar-style` been changed back to `black-translucent` in `packages/client/index.html`? Change it back to `black`.
 
-**Check 2:** Is the AppShell `className` still `"mari-app mari-app-background-paint fixed inset-0 flex overflow-hidden"` in `packages/client/src/components/layout/AppShell.tsx`? No extra `bottom-*` or `h-*` overrides should be on it for mobile — `inset-0` is sufficient in `black` mode.
+**Check 2:** Is the AppShell `className` still `"mari-app mari-app-background-paint fixed top-0 left-0 right-0 h-dvh flex overflow-hidden"` in `packages/client/src/components/layout/AppShell.tsx`? Do not add `bottom-0` or `inset-0` — that creates an over-constrained layout that makes the UI shoot up when the keyboard opens.
 
 **Check 3:** Run the red/green diagnostic to confirm which layer is painting the chin:
 

--- a/packages/client/index.html
+++ b/packages/client/index.html
@@ -4,15 +4,21 @@
     <meta charset="UTF-8" />
     <meta
       name="viewport"
-      content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no, viewport-fit=cover"
+      content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no, viewport-fit=cover, interactive-widget=resizes-content"
     />
     <meta name="description" content="Marinara Engine — RPG chat and roleplay engine" />
     <meta name="theme-color" content="#0a0a0f" />
     <meta name="color-scheme" content="dark light" />
     <meta name="apple-mobile-web-app-capable" content="yes" />
-    <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
+    <meta name="apple-mobile-web-app-status-bar-style" content="black" />
     <meta name="mobile-web-app-capable" content="yes" />
     <title>Marinara Engine</title>
+    <style>
+      /* Sets WKWebView native backing color for iOS safe-area zones.
+         Literal opaque value required — CSS vars not resolved for backing.
+         !important guards against any external stylesheet override winning cascade. */
+      html, body { background-color: #050312 !important; }
+    </style>
     <link rel="icon" type="image/png" href="/favicon.png" />
     <link rel="manifest" href="/manifest.json" />
     <link rel="apple-touch-icon" href="/icon-192.png" />

--- a/packages/client/src/components/chat/ConversationInput.tsx
+++ b/packages/client/src/components/chat/ConversationInput.tsx
@@ -1789,7 +1789,7 @@ export function ConversationInput({
   }
 
   return (
-    <div className="mari-chat-input chat-input-container relative px-2 pb-3 sm:px-3">
+    <div className="mari-chat-input chat-input-container relative px-2 sm:px-3 pb-3">
       {/* Slash command autocomplete */}
       {completions.length > 0 && (
         <div className="absolute bottom-full left-3 right-3 z-40 mb-1 max-h-[min(18rem,45dvh)] overflow-y-auto rounded-lg border border-foreground/10 bg-[var(--card)] shadow-lg [-webkit-overflow-scrolling:touch]">

--- a/packages/client/src/components/game/GameInput.tsx
+++ b/packages/client/src/components/game/GameInput.tsx
@@ -344,7 +344,7 @@ export function GameInput({
 
   return (
     <div
-      className={cn(inline ? "" : "px-3 pb-3 pt-2")}
+      className={cn(inline ? "" : "px-3 pt-2 pb-3")}
       style={inline ? undefined : { minHeight: 61 }}
     >
       {/* Dice picker */}

--- a/packages/client/src/components/layout/AppShell.tsx
+++ b/packages/client/src/components/layout/AppShell.tsx
@@ -795,7 +795,7 @@ export function AppShell() {
     <div
       data-component="AppShell"
       className={cn(
-        "mari-app mari-app-background-paint fixed inset-0 flex overflow-hidden max-md:h-screen max-md:max-h-screen max-md:pb-[env(safe-area-inset-bottom)] max-md:pt-[env(safe-area-inset-top)] supports-[height:100dvh]:max-md:h-[100dvh] supports-[height:100dvh]:max-md:max-h-[100dvh]",
+        "mari-app mari-app-background-paint fixed inset-0 flex overflow-hidden",
         showAmbientDecor && "retro-scanlines noise-bg geometric-grid",
       )}
     >
@@ -870,6 +870,8 @@ export function AppShell() {
         aria-label="Main content"
         className="@container mari-main mari-app-background-paint relative flex min-w-0 flex-1 flex-col overflow-hidden"
       >
+        {/* iOS safe area spacer — pushes TopBar below status bar and fills that gap with topbar bg */}
+        <div className="flex-shrink-0 md:hidden h-[env(safe-area-inset-top)] bg-[var(--marinara-topbar-surface)] backdrop-blur-sm" />
         <TopBar />
         <div className="mari-app-background-paint relative flex flex-1 flex-col overflow-hidden">
           {/* Bot Browser — kept mounted once opened so state persists across close/reopen */}

--- a/packages/client/src/components/layout/AppShell.tsx
+++ b/packages/client/src/components/layout/AppShell.tsx
@@ -795,7 +795,7 @@ export function AppShell() {
     <div
       data-component="AppShell"
       className={cn(
-        "mari-app mari-app-background-paint fixed inset-0 flex overflow-hidden",
+        "mari-app mari-app-background-paint fixed top-0 left-0 right-0 h-dvh flex overflow-hidden",
         showAmbientDecor && "retro-scanlines noise-bg geometric-grid",
       )}
     >

--- a/packages/client/src/styles/globals.css
+++ b/packages/client/src/styles/globals.css
@@ -4165,9 +4165,19 @@ strong {
     max-height: var(--mari-visual-viewport-height, 100dvh) !important;
   }
 
+  /*
+   * WKWebView native backing color is set by the literal background-color in
+   * index.html <style> (inline critical CSS — not cached by SW, always fresh).
+   * Do NOT set html { background-color } here; a CSS variable would override
+   * the literal and WKWebView cannot resolve variables → shows black instead.
+   */
+  html {
+    min-height: 100dvh;
+    overflow: hidden;
+  }
+
   body {
-    /* Safe-area insets handled by AppShell — only apply sides + bottom here */
-    padding-bottom: env(safe-area-inset-bottom);
+    /* Safe-area insets handled by AppShell — only apply sides here */
     padding-left: env(safe-area-inset-left);
     padding-right: env(safe-area-inset-right);
   }

--- a/packages/client/src/styles/globals.css
+++ b/packages/client/src/styles/globals.css
@@ -4160,11 +4160,6 @@ strong {
 }
 
 @media (max-width: 767px) {
-  .mari-app {
-    height: var(--mari-visual-viewport-height, 100dvh) !important;
-    max-height: var(--mari-visual-viewport-height, 100dvh) !important;
-  }
-
   /*
    * WKWebView native backing color is set by the literal background-color in
    * index.html <style> (inline critical CSS — not cached by SW, always fresh).


### PR DESCRIPTION
## Linked issue

Closes #3117

## Why this change

- On Face ID iPhones in PWA standalone mode, `black-translucent` status bar style triggers a WebKit restriction that prevents `position: fixed` elements from painting the home-indicator zone (~34px). No CSS workaround exists — offsets, `calc(100dvh + env(safe-area-inset-bottom))`, and height overrides are all silently clamped. Result: visible chin strip below the chat input.

## What changed

- `packages/client/index.html` — status bar style `black`, inline background-color for WKWebView native backing colour, `interactive-widget=resizes-content` viewport flag
- `packages/client/src/components/layout/AppShell.tsx` — root div changed to `fixed top-0 left-0 right-0 h-dvh` (no explicit bottom to avoid over-constrained layout when keyboard opens); top safe-area spacer added
- `packages/client/src/styles/globals.css` — mobile html/body rules simplified; upstream `.mari-app { height: var(--mari-visual-viewport-height) }` override removed (conflicted with interactive-widget resize)
- `docs/IOS_PWA_BOTTOM_SAFE_AREA.md` — root-cause explanation, diagnostic technique, regression checklist

## Validation

- [x] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [x] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed `CONTRIBUTING.md`

### Manual verification notes

- Manually verify on Face ID iPhone PWA: no chin strip below chat input
- Manually verify status bar zone is filled (no gap at top)
- Manually verify chat input has natural padding (not flush to screen edge)
- Manually verify keyboard opens without UI jumping or purple background showing

## Docs and release impact

- [x] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Version/release files updated (only if this PR includes a version bump)

## Before and after

<img width="563" height="1218" alt="Before" src="https://github.com/user-attachments/assets/4c732ded-67a7-44da-a572-ba87a8119735" />

<img width="563" height="1218" alt="After" src="https://github.com/user-attachments/assets/df2ff601-e04e-413a-84ab-de5ec38e0425" />

