### PR TITLE
feat(turn-games): add chess as the second conversation-mode table game

### DIFF
--- a/packages/client/src/components/chat/ChatSettingsDrawer.tsx
+++ b/packages/client/src/components/chat/ChatSettingsDrawer.tsx
@@ -394,6 +394,11 @@ const CONVERSATION_COMMAND_TOGGLE_OPTIONS: Array<{
     label: "UNO",
     description: "Let characters start a game of UNO at the table when you agree to play.",
   },
+  {
+    id: "chess",
+    label: "Chess",
+    description: "Let characters accept a one-on-one chess challenge at the table.",
+  },
 ];
 
 function normalizeSpotifySourceType(value: unknown): SpotifySourceType {

--- a/packages/client/src/components/chat/ChatSetupWizard.tsx
+++ b/packages/client/src/components/chat/ChatSetupWizard.tsx
@@ -163,6 +163,7 @@ const CONVERSATION_COMMAND_TOGGLE_OPTIONS: Array<{
   { id: "influence", label: "Influence", description: "Let characters influence a connected chat." },
   { id: "note", label: "Notes", description: "Let characters save durable notes for a connected chat." },
   { id: "uno", label: "UNO", description: "Let characters start a game of UNO at the table when you agree to play." },
+  { id: "chess", label: "Chess", description: "Let characters accept a one-on-one chess challenge at the table." },
 ];
 
 // ─── Main component ───────────────────────────

--- a/packages/client/src/components/chat/ChessBoard.tsx
+++ b/packages/client/src/components/chat/ChessBoard.tsx
@@ -1,0 +1,424 @@
+// ──────────────────────────────────────────────
+// ChessBoard — live, interactive chess board (conversation mode)
+// ──────────────────────────────────────────────
+// A real React component driven by the chess-game store (fed by
+// turn_game_state_patch SSE + an initial fetch). Renders the 8×8 board with
+// hand-authored inline SVG pieces (no image assets), click-to-move with
+// legal-target highlighting from the server's publicView, a promotion picker,
+// and check / last-move highlights. The board flips when the human plays black.
+import { useEffect, useMemo, useState } from "react";
+import { X } from "lucide-react";
+import type { ChessBoardSquare, ChessColor, ChessPieceLetter, PromotionPiece } from "@marinara-engine/shared";
+import { useChatStore } from "../../stores/chat.store";
+import { useChessGameStore } from "../../stores/chess-game.store";
+import { useChessMove, useChessState, useResignChess } from "../../hooks/use-chess";
+
+interface Props {
+  chatId: string;
+}
+
+// Classic muted board tones — readable on light and dark app themes alike
+// (piece colors are hardcoded too, matching UnoBoard's fixed card palette).
+const LIGHT_SQUARE = "#ebecd0";
+const DARK_SQUARE = "#739552";
+
+const PIECE_NAMES: Record<ChessPieceLetter, string> = {
+  p: "pawn",
+  n: "knight",
+  b: "bishop",
+  r: "rook",
+  q: "queen",
+  k: "king",
+};
+
+const PIECE_VALUES: Record<string, number> = { p: 1, n: 3, b: 3, r: 5, q: 9 };
+
+// ── hand-authored piece silhouettes (viewBox 0 0 45 45) ─────────────────────
+
+function pieceShapes(kind: ChessPieceLetter): React.ReactNode {
+  switch (kind) {
+    case "p":
+      return (
+        <>
+          <circle cx="22.5" cy="13" r="5.5" />
+          <path d="M18.5 17.5 C16 23 15.5 27 16.5 32 L28.5 32 C29.5 27 29 23 26.5 17.5 Z" />
+          <path d="M12.5 36.5 C12.5 33.5 16 32 22.5 32 C29 32 32.5 33.5 32.5 36.5 L32.5 38.5 L12.5 38.5 Z" />
+        </>
+      );
+    case "r":
+      return (
+        <>
+          <path d="M13 10 L17 10 L17 13.5 L20.5 13.5 L20.5 10 L24.5 10 L24.5 13.5 L28 13.5 L28 10 L32 10 L32 17 L29.5 20 L29.5 30 L32 33 L13 33 L15.5 30 L15.5 20 L13 17 Z" />
+          <path d="M11.5 36.5 C11.5 34.5 15 33 22.5 33 C30 33 33.5 34.5 33.5 36.5 L33.5 38.5 L11.5 38.5 Z" />
+        </>
+      );
+    case "n":
+      return (
+        <>
+          <path d="M15.5 32 C15.5 24 17.5 19.5 21 16.5 L19.5 10.5 L24 13.5 C29.5 15 32.5 20.5 32.5 27 L32.5 32 Z" />
+          <path d="M21 16.5 C18 18 15 21.5 13.5 25 L16.5 26.5 C17.5 24 19 21.5 21.5 20 Z" />
+          <path d="M12 36.5 C12 34 15.5 32.5 22.5 32.5 C29.5 32.5 33 34 33 36.5 L33 38.5 L12 38.5 Z" />
+        </>
+      );
+    case "b":
+      return (
+        <>
+          <circle cx="22.5" cy="8.5" r="2.5" />
+          <path d="M22.5 11.5 C27.5 16 30 20 30 24.5 C30 29 26.5 31.5 22.5 31.5 C18.5 31.5 15 29 15 24.5 C15 20 17.5 16 22.5 11.5 Z" />
+          <path d="M12.5 36.5 C12.5 34 16 32.5 22.5 32.5 C29 32.5 32.5 34 32.5 36.5 L32.5 38.5 L12.5 38.5 Z" />
+        </>
+      );
+    case "q":
+      return (
+        <>
+          <circle cx="10" cy="14" r="2.4" />
+          <circle cx="22.5" cy="10.5" r="2.4" />
+          <circle cx="35" cy="14" r="2.4" />
+          <path d="M11 17 L15.5 32.5 L29.5 32.5 L34 17 L28.5 23 L22.5 13.5 L16.5 23 Z" />
+          <path d="M12.5 37 C12.5 34.5 16 33 22.5 33 C29 33 32.5 34.5 32.5 37 L32.5 38.5 L12.5 38.5 Z" />
+        </>
+      );
+    case "k":
+      return (
+        <>
+          <path d="M21 7 L24 7 L24 10 L27 10 L27 13 L24 13 L24 16 L21 16 L21 13 L18 13 L18 10 L21 10 Z" />
+          <path d="M22.5 16.5 C28.5 16.5 32 20.5 32 25 C32 29 29.5 32.5 26 32.5 L19 32.5 C15.5 32.5 13 29 13 25 C13 20.5 16.5 16.5 22.5 16.5 Z" />
+          <path d="M12.5 37 C12.5 34.5 16 33 22.5 33 C29 33 32.5 34.5 32.5 37 L32.5 38.5 L12.5 38.5 Z" />
+        </>
+      );
+  }
+}
+
+export function ChessPiece({
+  kind,
+  color,
+  className,
+}: {
+  kind: ChessPieceLetter;
+  color: "w" | "b";
+  className?: string;
+}) {
+  const fill = color === "w" ? "#f8f8f2" : "#3b3f45";
+  const stroke = color === "w" ? "#44444a" : "#111418";
+  return (
+    <svg
+      viewBox="0 0 45 45"
+      className={className ?? "h-full w-full"}
+      role="img"
+      aria-label={`${color === "w" ? "white" : "black"} ${PIECE_NAMES[kind]}`}
+      fill={fill}
+      stroke={stroke}
+      strokeWidth="1.6"
+      strokeLinejoin="round"
+    >
+      {pieceShapes(kind)}
+    </svg>
+  );
+}
+
+// ── helpers ──────────────────────────────────────────────────────────────────
+
+/** Algebraic square name for a chess.js board index (row 0 = rank 8, col 0 = file a). */
+function squareName(row: number, col: number): string {
+  return `${String.fromCharCode(97 + col)}${8 - row}`;
+}
+
+function materialEdge(capturedByYou: ChessPieceLetter[], capturedByThem: ChessPieceLetter[]): number {
+  const sum = (arr: ChessPieceLetter[]) => arr.reduce((acc, p) => acc + (PIECE_VALUES[p] ?? 0), 0);
+  return sum(capturedByYou) - sum(capturedByThem);
+}
+
+/** The last few plies with move numbers, e.g. "12. Nf3 Nc6 13. Bb5". */
+function sanStrip(sanHistory: string[], maxPlies: number): string {
+  const total = sanHistory.length;
+  if (total === 0) return "";
+  const start = Math.max(0, total - maxPlies);
+  const parts: string[] = [];
+  for (let i = start; i < total; i++) {
+    const san = sanHistory[i]!;
+    const moveNo = Math.floor(i / 2) + 1;
+    if (i % 2 === 0) parts.push(`${moveNo}. ${san}`);
+    else if (i === start) parts.push(`${moveNo}. … ${san}`);
+    else parts.push(san);
+  }
+  return parts.join(" ");
+}
+
+const DRAW_TEXT: Record<string, string> = {
+  stalemate: "stalemate",
+  insufficient_material: "insufficient material",
+  threefold_repetition: "threefold repetition",
+  fifty_move_rule: "the fifty-move rule",
+};
+
+const PROMOTION_CHOICES: PromotionPiece[] = ["q", "r", "b", "n"];
+
+// ── component ─────────────────────────────────────────────────────────────────
+
+export function ChessBoard({ chatId }: Props) {
+  const current = useChessGameStore((s) => s.current);
+  const streaming = useChatStore((s) => s.isStreaming);
+  const streamingChatId = useChatStore((s) => s.streamingChatId);
+  const isStreaming = streaming && streamingChatId === chatId;
+  const move = useChessMove(chatId);
+  const resign = useResignChess(chatId);
+
+  // Hydrate the board on mount / chat switch (no-op if no active game).
+  const active = !!current && current.chatId === chatId;
+  useChessState(active ? null : chatId);
+
+  const [selected, setSelected] = useState<string | null>(null);
+  const [pendingPromotion, setPendingPromotion] = useState<{ from: string; to: string } | null>(null);
+  useEffect(() => {
+    setSelected(null);
+    setPendingPromotion(null);
+  }, [chatId]);
+
+  const view = active ? current : null;
+  const disabled = isStreaming || move.isPending || resign.isPending;
+  const isMyTurn = !!view && view.status !== "finished" && view.currentSeatId === view.yourSeatId;
+
+  // Legal targets grouped by origin square — drives selection + target dots.
+  const targetsByFrom = useMemo(() => {
+    const map = new Map<string, Array<{ to: string; promotion?: PromotionPiece }>>();
+    for (const m of view?.legalMovesForYou ?? []) {
+      const list = map.get(m.from) ?? [];
+      list.push({ to: m.to, ...(m.promotion ? { promotion: m.promotion } : {}) });
+      map.set(m.from, list);
+    }
+    return map;
+  }, [view]);
+
+  const selectedTargets = useMemo(() => {
+    if (!selected) return new Set<string>();
+    return new Set((targetsByFrom.get(selected) ?? []).map((t) => t.to));
+  }, [selected, targetsByFrom]);
+
+  // The checked king's square (side to move), for the red check ring.
+  const checkSquare = useMemo(() => {
+    if (!view?.check || view.status === "finished") return null;
+    const toMoveColor = view.seats.find((s) => s.seatId === view.currentSeatId)?.color;
+    const letter = toMoveColor === "black" ? "b" : "w";
+    for (let r = 0; r < 8; r++) {
+      for (let c = 0; c < 8; c++) {
+        const sq = view.board[r]?.[c];
+        if (sq && sq.type === "k" && sq.color === letter) return squareName(r, c);
+      }
+    }
+    return null;
+  }, [view]);
+
+  if (!view) return null;
+
+  const flipped = view.yourColor === "black";
+  const yourLetter = view.yourColor === "black" ? "b" : "w";
+
+  const submitMove = (from: string, to: string, promotion?: PromotionPiece) => {
+    if (disabled) return;
+    setSelected(null);
+    setPendingPromotion(null);
+    move.mutate({ move: { type: "move", from, to, ...(promotion ? { promotion } : {}) } });
+  };
+
+  const onSquareClick = (square: string, piece: ChessBoardSquare | null) => {
+    if (!isMyTurn || disabled) return;
+    if (selected && selectedTargets.has(square)) {
+      // Promotion if any legal move on this (from, to) pair carries a promotion piece.
+      const needsPromotion = (targetsByFrom.get(selected) ?? []).some((t) => t.to === square && t.promotion);
+      if (needsPromotion) return setPendingPromotion({ from: selected, to: square });
+      return submitMove(selected, square);
+    }
+    if (piece && piece.color === yourLetter && targetsByFrom.has(square)) {
+      return setSelected(selected === square ? null : square);
+    }
+    setSelected(null);
+  };
+
+  const you = view.seats.find((s) => s.seatId === view.yourSeatId) ?? null;
+  const opponent = view.seats.find((s) => s.seatId !== view.yourSeatId) ?? null;
+  const currentSeat = view.seats.find((s) => s.seatId === view.currentSeatId) ?? null;
+  const winner = view.winnerSeatId ? view.seats.find((s) => s.seatId === view.winnerSeatId) : null;
+  const strip = sanStrip(view.sanHistory, 6);
+
+  const seatChip = (seat: typeof you, capturedRow: ChessPieceLetter[], edge: number) =>
+    seat && (
+      <div
+        className={`flex items-center gap-1.5 rounded-lg px-1.5 py-1 ${
+          seat.isCurrent ? "bg-[var(--primary)]/10 ring-1 ring-[var(--primary)]/40" : "ring-1 ring-[var(--border)]"
+        }`}
+      >
+        <span
+          className="inline-block h-3 w-3 rounded-full ring-1 ring-black/30"
+          style={{ background: seat.color === "white" ? "#f8f8f2" : "#3b3f45" }}
+          title={seat.color}
+        />
+        <div className="leading-tight">
+          <div className="flex items-center gap-1 text-xs font-medium text-[var(--foreground)]">
+            {seat.displayName}
+            {seat.seatId === view.yourSeatId && (
+              <span className="text-[0.6rem] font-semibold text-[var(--muted-foreground)]">(you)</span>
+            )}
+          </div>
+          <div className="flex h-4 items-center gap-0.5">
+            {capturedRow.map((p, i) => (
+              <span key={`${p}-${i}`} className="h-4 w-4 opacity-80">
+                <ChessPiece kind={p} color={seat.color === "white" ? "b" : "w"} />
+              </span>
+            ))}
+            {edge > 0 && <span className="text-[0.65rem] font-semibold text-[var(--muted-foreground)]">+{edge}</span>}
+          </div>
+        </div>
+      </div>
+    );
+
+  return (
+    <div className="mx-2 mb-1 rounded-xl border border-[var(--border)] bg-[var(--card)] p-2 shadow-sm">
+      {/* Header: seats + status + resign */}
+      <div className="mb-2 flex flex-wrap items-center gap-2 text-xs text-[var(--muted-foreground)]">
+        <span className="font-semibold text-[var(--foreground)]">Chess</span>
+        {seatChip(
+          opponent,
+          opponent?.color === "white" ? view.capturedByWhite : view.capturedByBlack,
+          opponent
+            ? materialEdge(
+                opponent.color === "white" ? view.capturedByWhite : view.capturedByBlack,
+                opponent.color === "white" ? view.capturedByBlack : view.capturedByWhite,
+              )
+            : 0,
+        )}
+        {seatChip(
+          you,
+          you?.color === "white" ? view.capturedByWhite : view.capturedByBlack,
+          you
+            ? materialEdge(
+                you.color === "white" ? view.capturedByWhite : view.capturedByBlack,
+                you.color === "white" ? view.capturedByBlack : view.capturedByWhite,
+              )
+            : 0,
+        )}
+        <div className="ml-auto flex items-center gap-2">
+          {view.status !== "finished" && (
+            <span className={isMyTurn ? "font-semibold text-[var(--primary)] animate-pulse" : ""}>
+              {isMyTurn ? (view.check ? "Your turn — check!" : "Your turn") : `${currentSeat?.displayName ?? "…"} is thinking…`}
+            </span>
+          )}
+          <button
+            type="button"
+            onClick={() => {
+              if (window.confirm("Resign and end this game?")) resign.mutate();
+            }}
+            className="rounded p-1 text-[var(--muted-foreground)] hover:bg-[var(--muted)] active:scale-90"
+            title="Resign"
+            aria-label="Resign and end game"
+          >
+            <X className="h-3.5 w-3.5" />
+          </button>
+        </div>
+      </div>
+
+      {/* Finished banner */}
+      {view.status === "finished" && (
+        <div className="mb-2 rounded-lg bg-[var(--primary)]/10 px-3 py-2 text-center text-sm font-semibold text-[var(--primary)]">
+          {winner
+            ? `${winner.displayName} wins by checkmate! 🏆`
+            : view.drawReason
+              ? `Draw — ${DRAW_TEXT[view.drawReason] ?? view.drawReason}`
+              : "Game over"}
+        </div>
+      )}
+
+      {/* Board */}
+      <div className="mx-auto grid w-full max-w-[22rem] grid-cols-8 overflow-hidden rounded-lg ring-1 ring-black/25">
+        {Array.from({ length: 64 }, (_, i) => {
+          const rIdx = Math.floor(i / 8);
+          const cIdx = i % 8;
+          const row = flipped ? 7 - rIdx : rIdx;
+          const col = flipped ? 7 - cIdx : cIdx;
+          const square = squareName(row, col);
+          const piece = view.board[row]?.[col] ?? null;
+          const isLight = (row + col) % 2 === 0;
+          const isSelected = selected === square;
+          const isTarget = selectedTargets.has(square);
+          const isLastMove = view.lastMove?.from === square || view.lastMove?.to === square;
+          const isCheck = checkSquare === square;
+          const clickable =
+            isMyTurn && !disabled && (isTarget || (piece?.color === yourLetter && targetsByFrom.has(square)));
+          return (
+            <button
+              key={square}
+              type="button"
+              onClick={() => onSquareClick(square, piece)}
+              className={`relative aspect-square w-full p-0 ${clickable ? "cursor-pointer" : "cursor-default"}`}
+              style={{ background: isLight ? LIGHT_SQUARE : DARK_SQUARE }}
+              aria-label={`${square}${piece ? `, ${piece.color === "w" ? "white" : "black"} ${PIECE_NAMES[piece.type]}` : ""}${isTarget ? ", legal move" : ""}`}
+            >
+              {isLastMove && <span className="absolute inset-0 bg-yellow-300/35" />}
+              {isSelected && <span className="absolute inset-0 ring-2 ring-inset ring-yellow-500" />}
+              {isCheck && <span className="absolute inset-0 ring-2 ring-inset ring-red-500" />}
+              {piece && (
+                <span className="absolute inset-0 p-[6%]">
+                  <ChessPiece kind={piece.type} color={piece.color} />
+                </span>
+              )}
+              {isTarget &&
+                (piece ? (
+                  <span className="absolute inset-0 ring-4 ring-inset ring-black/25" />
+                ) : (
+                  <span className="absolute left-1/2 top-1/2 h-[28%] w-[28%] -translate-x-1/2 -translate-y-1/2 rounded-full bg-black/25" />
+                ))}
+              {cIdx === 0 && (
+                <span className="absolute left-0.5 top-0 text-[0.55rem] font-semibold" style={{ color: isLight ? DARK_SQUARE : LIGHT_SQUARE }}>
+                  {8 - row}
+                </span>
+              )}
+              {rIdx === 7 && (
+                <span className="absolute bottom-0 right-0.5 text-[0.55rem] font-semibold" style={{ color: isLight ? DARK_SQUARE : LIGHT_SQUARE }}>
+                  {String.fromCharCode(97 + col)}
+                </span>
+              )}
+            </button>
+          );
+        })}
+      </div>
+
+      {/* Promotion picker */}
+      {pendingPromotion && (
+        <div className="mt-2 flex items-center gap-2 rounded-lg border border-[var(--border)] bg-[var(--muted)]/40 p-2">
+          <span className="text-xs text-[var(--muted-foreground)]">Promote to:</span>
+          {PROMOTION_CHOICES.map((p) => (
+            <button
+              key={p}
+              type="button"
+              onClick={() => submitMove(pendingPromotion.from, pendingPromotion.to, p)}
+              className="h-9 w-9 rounded-lg bg-[var(--background)] ring-1 ring-[var(--border)] transition-transform hover:scale-110"
+              aria-label={`Promote to ${PIECE_NAMES[p]}`}
+            >
+              <ChessPiece kind={p} color={yourLetter} />
+            </button>
+          ))}
+          <button
+            type="button"
+            onClick={() => setPendingPromotion(null)}
+            className="ml-auto text-[var(--muted-foreground)] hover:text-[var(--foreground)]"
+            aria-label="Cancel promotion"
+          >
+            <X className="h-3.5 w-3.5" />
+          </button>
+        </div>
+      )}
+
+      {/* Move ticker */}
+      {(view.lastAction || strip) && (
+        <div className="mt-1.5 flex items-baseline gap-2 text-[0.7rem] text-[var(--muted-foreground)]">
+          {view.lastAction && view.status !== "finished" && (
+            <span className="truncate">
+              {view.seats.find((s) => s.seatId === view.lastAction!.seatId)?.displayName ?? "—"}{" "}
+              {view.lastAction.summary}
+            </span>
+          )}
+          {strip && <span className="ml-auto truncate font-mono">{strip}</span>}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/packages/client/src/components/chat/ChessBoard.tsx
+++ b/packages/client/src/components/chat/ChessBoard.tsx
@@ -8,7 +8,7 @@
 // and check / last-move highlights. The board flips when the human plays black.
 import { useEffect, useMemo, useState } from "react";
 import { X } from "lucide-react";
-import type { ChessBoardSquare, ChessColor, ChessPieceLetter, PromotionPiece } from "@marinara-engine/shared";
+import type { ChessBoardSquare, ChessPieceLetter, PromotionPiece } from "@marinara-engine/shared";
 import { useChatStore } from "../../stores/chat.store";
 import { useChessGameStore } from "../../stores/chess-game.store";
 import { useChessMove, useChessState, useResignChess } from "../../hooks/use-chess";

--- a/packages/client/src/components/chat/ChessSetup.tsx
+++ b/packages/client/src/components/chat/ChessSetup.tsx
@@ -1,0 +1,138 @@
+// ──────────────────────────────────────────────
+// ChessSetup — game configuration modal (conversation mode)
+// ──────────────────────────────────────────────
+// Opened from the /chess command or the natural-language launcher. Chess is
+// strictly one-on-one: pick a single opponent character and your color.
+import { useMemo, useState } from "react";
+import { Crown } from "lucide-react";
+import type { ChessColor } from "@marinara-engine/shared";
+import { Modal } from "../ui/Modal";
+import { useCharacters } from "../../hooks/use-characters";
+import { useChats } from "../../hooks/use-chats";
+import { parseCharacterDisplayData } from "../../lib/character-display";
+import { getChatCharacterIds } from "../../lib/chat-macros";
+import { useStartChess } from "../../hooks/use-chess";
+
+interface Props {
+  chatId: string;
+  open: boolean;
+  onClose: () => void;
+}
+
+const COLOR_OPTIONS: Array<{ value: ChessColor | "random"; label: string }> = [
+  { value: "white", label: "White" },
+  { value: "random", label: "Random" },
+  { value: "black", label: "Black" },
+];
+
+export function ChessSetup({ chatId, open, onClose }: Props) {
+  const { data: chats } = useChats();
+  const { data: characters } = useCharacters(open);
+  const start = useStartChess(chatId);
+
+  const chat = useMemo(() => (chats ?? []).find((c) => c.id === chatId), [chats, chatId]);
+  const charIds = useMemo(() => getChatCharacterIds(chat), [chat]);
+
+  const nameById = useMemo(() => {
+    const map = new Map<string, string>();
+    for (const c of characters ?? []) {
+      const item = c as { id?: string; data?: unknown; comment?: string | null };
+      if (typeof item.id === "string")
+        map.set(item.id, parseCharacterDisplayData({ data: item.data, comment: item.comment }).name);
+    }
+    return map;
+  }, [characters]);
+
+  const [opponentId, setOpponentId] = useState<string | null>(null);
+  const [humanColor, setHumanColor] = useState<ChessColor | "random">("random");
+
+  // Default opponent = the chat's first character (until the user picks one).
+  const selectedOpponent = opponentId ?? charIds[0] ?? null;
+  const canStart = !!selectedOpponent && !start.isPending;
+
+  const startGame = () => {
+    if (!selectedOpponent || !canStart) return;
+    start.mutate(
+      {
+        gameType: "chess",
+        config: { humanColor },
+        botCharacterIds: [selectedOpponent],
+        humanFirst: true,
+      },
+      { onSuccess: () => onClose() },
+    );
+  };
+
+  return (
+    <Modal open={open} onClose={onClose} title="Start Chess" width="max-w-md">
+      <div className="space-y-4 p-1">
+        {/* Opponent */}
+        <section>
+          <h3 className="mb-2 text-sm font-semibold text-[var(--foreground)]">Opponent</h3>
+          {charIds.length === 0 ? (
+            <p className="text-sm text-[var(--muted-foreground)]">Add at least one character to this chat to play.</p>
+          ) : (
+            <div className="space-y-1">
+              {charIds.map((id) => (
+                <label
+                  key={id}
+                  className="flex cursor-pointer items-center gap-2 rounded-lg px-2 py-1.5 hover:bg-[var(--muted)]"
+                >
+                  <input
+                    type="radio"
+                    name="chess-opponent"
+                    checked={selectedOpponent === id}
+                    onChange={() => setOpponentId(id)}
+                    className="accent-[var(--primary)]"
+                  />
+                  <span className="text-sm text-[var(--foreground)]">{nameById.get(id) ?? id}</span>
+                </label>
+              ))}
+            </div>
+          )}
+        </section>
+
+        {/* Color */}
+        <section>
+          <h3 className="mb-2 text-sm font-semibold text-[var(--foreground)]">Your color</h3>
+          <div className="flex overflow-hidden rounded-lg border border-[var(--border)]">
+            {COLOR_OPTIONS.map((opt) => (
+              <button
+                key={opt.value}
+                type="button"
+                onClick={() => setHumanColor(opt.value)}
+                className={`flex-1 px-3 py-1.5 text-sm font-medium transition-colors ${
+                  humanColor === opt.value
+                    ? "bg-[var(--primary)] text-[var(--primary-foreground)]"
+                    : "bg-[var(--background)] text-[var(--foreground)] hover:bg-[var(--muted)]"
+                }`}
+              >
+                {opt.label}
+              </button>
+            ))}
+          </div>
+          <p className="mt-1 text-xs text-[var(--muted-foreground)]">White moves first.</p>
+        </section>
+
+        <div className="flex items-center justify-end gap-2 pt-1">
+          <button
+            type="button"
+            onClick={onClose}
+            className="rounded-lg px-3 py-1.5 text-sm text-[var(--muted-foreground)] hover:bg-[var(--muted)]"
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            disabled={!canStart}
+            onClick={startGame}
+            className="flex items-center gap-1.5 rounded-lg bg-[var(--primary)] px-4 py-1.5 text-sm font-semibold text-[var(--primary-foreground)] transition-transform active:scale-95 disabled:opacity-50"
+          >
+            <Crown className="h-4 w-4" />
+            {start.isPending ? "Setting up…" : "Start game"}
+          </button>
+        </div>
+      </div>
+    </Modal>
+  );
+}

--- a/packages/client/src/components/chat/ChessSetup.tsx
+++ b/packages/client/src/components/chat/ChessSetup.tsx
@@ -3,7 +3,7 @@
 // ──────────────────────────────────────────────
 // Opened from the /chess command or the natural-language launcher. Chess is
 // strictly one-on-one: pick a single opponent character and your color.
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { Crown } from "lucide-react";
 import type { ChessColor } from "@marinara-engine/shared";
 import { Modal } from "../ui/Modal";
@@ -12,6 +12,7 @@ import { useChats } from "../../hooks/use-chats";
 import { parseCharacterDisplayData } from "../../lib/character-display";
 import { getChatCharacterIds } from "../../lib/chat-macros";
 import { useStartChess } from "../../hooks/use-chess";
+import { useChessGameStore } from "../../stores/chess-game.store";
 
 interface Props {
   chatId: string;
@@ -29,6 +30,13 @@ export function ChessSetup({ chatId, open, onClose }: Props) {
   const { data: chats } = useChats();
   const { data: characters } = useCharacters(open);
   const start = useStartChess(chatId);
+
+  // A game can start underneath the open modal — e.g. the user's "let's play
+  // chess" message opens this setup AND a character accepts via [chess].
+  const activeGame = useChessGameStore((s) => s.current);
+  useEffect(() => {
+    if (open && activeGame?.chatId === chatId) onClose();
+  }, [open, activeGame, chatId, onClose]);
 
   const chat = useMemo(() => (chats ?? []).find((c) => c.id === chatId), [chats, chatId]);
   const charIds = useMemo(() => getChatCharacterIds(chat), [chat]);

--- a/packages/client/src/components/chat/ChessSetup.tsx
+++ b/packages/client/src/components/chat/ChessSetup.tsx
@@ -33,9 +33,11 @@ export function ChessSetup({ chatId, open, onClose }: Props) {
 
   // A game can start underneath the open modal — e.g. the user's "let's play
   // chess" message opens this setup AND a character accepts via [chess].
+  // Finished games linger in the store, so exclude them or a rematch's setup
+  // modal closes itself on the same frame it opens.
   const activeGame = useChessGameStore((s) => s.current);
   useEffect(() => {
-    if (open && activeGame?.chatId === chatId) onClose();
+    if (open && activeGame?.chatId === chatId && activeGame.status !== "finished") onClose();
   }, [open, activeGame, chatId, onClose]);
 
   const chat = useMemo(() => (chats ?? []).find((c) => c.id === chatId), [chats, chatId]);

--- a/packages/client/src/components/chat/ConversationInput.tsx
+++ b/packages/client/src/components/chat/ConversationInput.tsx
@@ -25,6 +25,7 @@ import { useQueryClient, type InfiniteData } from "@tanstack/react-query";
 import { useChatStore } from "../../stores/chat.store";
 import { useUIStore } from "../../stores/ui.store";
 import { useUnoGameStore } from "../../stores/uno-game.store";
+import { useChessGameStore } from "../../stores/chess-game.store";
 import { useGenerate } from "../../hooks/use-generate";
 import { useApplyRegex } from "../../hooks/use-apply-regex";
 import { useCreateMessage, useDeleteMessage, useUpdateMessageExtra, useChat, chatKeys } from "../../hooks/use-chats";
@@ -925,13 +926,18 @@ export function ConversationInput({
       return;
     }
 
-    // Natural-language launcher: "let's play uno" opens the game setup. The message
-    // still sends normally, so the characters can react to the suggestion too.
+    // Natural-language launchers: "let's play uno" / "let's play chess" open the game
+    // setup. The message still sends normally, so the characters can react too.
     {
       const activeUno = useUnoGameStore.getState().current;
       const unoActive = !!activeUno && activeUno.chatId === activeChatId && activeUno.status !== "finished";
       if (!unoActive && /\b(?:play|start)\b[^.!?\n]{0,16}\buno\b/i.test(raw)) {
         useUnoGameStore.getState().openSetup(activeChatId);
+      }
+      const activeChess = useChessGameStore.getState().current;
+      const chessActive = !!activeChess && activeChess.chatId === activeChatId && activeChess.status !== "finished";
+      if (!chessActive && /\b(?:play|start)\b[^.!?\n]{0,16}\bchess\b/i.test(raw)) {
+        useChessGameStore.getState().openSetup(activeChatId);
       }
     }
 

--- a/packages/client/src/components/chat/ConversationView.tsx
+++ b/packages/client/src/components/chat/ConversationView.tsx
@@ -1205,7 +1205,10 @@ export function ConversationView({
           Keyed by chatId so their internal selection state resets on a chat switch
           (matches ConversationInput below) — otherwise stale selected ids would
           inflate botCount and could deal an empty botCharacterIds list. */}
-      <UnoSetup key={chatId} chatId={chatId} open={unoSetupOpen} onClose={closeUnoSetup} />
+      {/* Keys must be unique across this whole children list — ConversationInput
+          below is also keyed by chatId, and duplicate sibling keys make React
+          duplicate/orphan the setup modals (stuck un-closable "Start UNO"). */}
+      <UnoSetup key={`uno-${chatId}`} chatId={chatId} open={unoSetupOpen} onClose={closeUnoSetup} />
       <ChessSetup key={`chess-${chatId}`} chatId={chatId} open={chessSetupOpen} onClose={closeChessSetup} />
 
       {/* ── Input area ── */}

--- a/packages/client/src/components/chat/ConversationView.tsx
+++ b/packages/client/src/components/chat/ConversationView.tsx
@@ -18,6 +18,8 @@ import { ConversationMessage } from "./ConversationMessage";
 import { ConversationInput } from "./ConversationInput";
 import { UnoBoard } from "./UnoBoard";
 import { UnoSetup } from "./UnoSetup";
+import { ChessBoard } from "./ChessBoard";
+import { ChessSetup } from "./ChessSetup";
 import { SceneBanner, EndSceneBar } from "./SceneBanner";
 import { ChatBranchSelector } from "./ChatBranchSelector";
 import { ActiveLorebookEntriesButton } from "./ActiveLorebookEntriesButton";
@@ -27,6 +29,7 @@ import { TranscriptWindowControls } from "./TranscriptWindowControls";
 import { PinnedImageOverlay } from "./PinnedImageOverlay";
 import { useChatStore } from "../../stores/chat.store";
 import { useUnoGameStore } from "../../stores/uno-game.store";
+import { useChessGameStore } from "../../stores/chess-game.store";
 import { useUIStore } from "../../stores/ui.store";
 import { playConfiguredNotificationPing } from "../../lib/notification-sound";
 import { messageHasPendingPostProcessing } from "../../lib/chat-message-extra";
@@ -278,6 +281,9 @@ export function ConversationView({
   const unoGameActive = useUnoGameStore((s) => s.current?.chatId === chatId && s.current?.status !== "finished");
   const unoSetupOpen = useUnoGameStore((s) => s.setupChatId === chatId);
   const closeUnoSetup = useUnoGameStore((s) => s.closeSetup);
+  const chessGameActive = useChessGameStore((s) => s.current?.chatId === chatId && s.current?.status !== "finished");
+  const chessSetupOpen = useChessGameStore((s) => s.setupChatId === chatId);
+  const closeChessSetup = useChessGameStore((s) => s.closeSetup);
   const isStreamCommitted = useChatStore((s) => s.committedStreamChatIds.has(chatId));
   const hasLiveStream = isStreaming && !isStreamCommitted;
   const streamBuffer = useThrottledStreamBuffer();
@@ -1161,7 +1167,7 @@ export function ConversationView({
         )}
 
         {/* Scene banner — inline at bottom of messages (origin variant only); hidden during a turn-game */}
-        {sceneInfo?.variant === "origin" && !unoGameActive && (
+        {sceneInfo?.variant === "origin" && !unoGameActive && !chessGameActive && (
           <SceneBanner variant="origin" sceneChatId={sceneInfo.sceneChatId} sceneChatName={sceneInfo.sceneChatName} />
         )}
 
@@ -1192,13 +1198,15 @@ export function ConversationView({
         />
       )}
 
-      {/* ── Turn-game board (UNO, etc.) — self-hides when no game is active ── */}
+      {/* ── Turn-game boards (UNO, chess) — each self-hides when no game is active ── */}
       <UnoBoard chatId={chatId} />
-      {/* Setup modal mounted once here (stable position) so it never double-renders.
-          Keyed by chatId so its internal selection/house-rule state resets on a
-          chat switch (matches ConversationInput below) — otherwise stale selected
-          ids would inflate botCount and could deal an empty botCharacterIds list. */}
+      <ChessBoard chatId={chatId} />
+      {/* Setup modals mounted once here (stable position) so they never double-render.
+          Keyed by chatId so their internal selection state resets on a chat switch
+          (matches ConversationInput below) — otherwise stale selected ids would
+          inflate botCount and could deal an empty botCharacterIds list. */}
       <UnoSetup key={chatId} chatId={chatId} open={unoSetupOpen} onClose={closeUnoSetup} />
+      <ChessSetup key={`chess-${chatId}`} chatId={chatId} open={chessSetupOpen} onClose={closeChessSetup} />
 
       {/* ── Input area ── */}
       <ConversationInput

--- a/packages/client/src/components/chat/UnoSetup.tsx
+++ b/packages/client/src/components/chat/UnoSetup.tsx
@@ -35,9 +35,11 @@ export function UnoSetup({ chatId, open, onClose }: Props) {
 
   // A game can start underneath the open modal — e.g. the user's "let's play
   // UNO" message opens this setup AND a character accepts via [uno].
+  // Finished games linger in the store, so exclude them or a rematch's setup
+  // modal closes itself on the same frame it opens.
   const activeGame = useUnoGameStore((s) => s.current);
   useEffect(() => {
-    if (open && activeGame?.chatId === chatId) onClose();
+    if (open && activeGame?.chatId === chatId && activeGame.status !== "finished") onClose();
   }, [open, activeGame, chatId, onClose]);
 
   const chat = useMemo(() => (chats ?? []).find((c) => c.id === chatId), [chats, chatId]);

--- a/packages/client/src/components/chat/UnoSetup.tsx
+++ b/packages/client/src/components/chat/UnoSetup.tsx
@@ -3,7 +3,7 @@
 // ──────────────────────────────────────────────
 // Opened from the "Play UNO" launcher. Lets the player pick which characters
 // play as bots, who goes first, and which house rules are on, then deals.
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { Gamepad2 } from "lucide-react";
 import { DEFAULT_UNO_CONFIG, type UnoConfig } from "@marinara-engine/shared";
 import { Modal } from "../ui/Modal";
@@ -12,6 +12,7 @@ import { useChats } from "../../hooks/use-chats";
 import { parseCharacterDisplayData } from "../../lib/character-display";
 import { getChatCharacterIds } from "../../lib/chat-macros";
 import { useStartUno } from "../../hooks/use-uno";
+import { useUnoGameStore } from "../../stores/uno-game.store";
 
 interface Props {
   chatId: string;
@@ -31,6 +32,13 @@ export function UnoSetup({ chatId, open, onClose }: Props) {
   const { data: chats } = useChats();
   const { data: characters } = useCharacters(open);
   const start = useStartUno(chatId);
+
+  // A game can start underneath the open modal — e.g. the user's "let's play
+  // UNO" message opens this setup AND a character accepts via [uno].
+  const activeGame = useUnoGameStore((s) => s.current);
+  useEffect(() => {
+    if (open && activeGame?.chatId === chatId) onClose();
+  }, [open, activeGame, chatId, onClose]);
 
   const chat = useMemo(() => (chats ?? []).find((c) => c.id === chatId), [chats, chatId]);
   const charIds = useMemo(() => getChatCharacterIds(chat), [chat]);

--- a/packages/client/src/components/ui/Modal.tsx
+++ b/packages/client/src/components/ui/Modal.tsx
@@ -82,6 +82,19 @@ export function Modal({
     }
   };
 
+  // Fallback: browsers skip CSS transitions in hidden tabs, so transitionend
+  // may never fire when a modal is closed programmatically while the tab is
+  // backgrounded (e.g. a game starting auto-closes its setup). Without this
+  // the overlay stays mounted forever and blocks clicks.
+  useEffect(() => {
+    if (animating !== "exit") return;
+    const timer = setTimeout(() => {
+      setMounted(false);
+      setAnimating(null);
+    }, 400);
+    return () => clearTimeout(timer);
+  }, [animating]);
+
   if (!mounted) return null;
 
   const isEntering = animating === "enter";

--- a/packages/client/src/hooks/turn-game-keys.ts
+++ b/packages/client/src/hooks/turn-game-keys.ts
@@ -1,0 +1,12 @@
+// ──────────────────────────────────────────────
+// Query Keys: Turn-Games (shared by UNO + Chess)
+// ──────────────────────────────────────────────
+// Lives in its own module so use-generate.ts can invalidate turn-game state
+// without importing use-uno.ts (which imports use-generate back — a cycle).
+// One chat has at most one active turn-game, so every board shares the same
+// /state resource and key root; per-game hooks append their own suffix.
+export const turnGameKeys = {
+  all: ["turn-games"] as const,
+  catalog: () => [...turnGameKeys.all, "catalog"] as const,
+  state: (chatId: string) => [...turnGameKeys.all, "state", chatId] as const,
+};

--- a/packages/client/src/hooks/use-chess.ts
+++ b/packages/client/src/hooks/use-chess.ts
@@ -77,6 +77,7 @@ export function useChessState(chatId: string | null) {
       try {
         const res = await api.get<StateResponse>(`/turn-games/${chatId}/state`);
         if (isChessView(res?.view)) useChessGameStore.getState().setChess(res.view, chatId);
+        else if (res?.view) useChessGameStore.getState().clearChess(chatId); // another game type is active
         return res;
       } catch (err) {
         if (err instanceof ApiError && err.status === 404) {

--- a/packages/client/src/hooks/use-chess.ts
+++ b/packages/client/src/hooks/use-chess.ts
@@ -1,0 +1,136 @@
+// ──────────────────────────────────────────────
+// Hook: Turn-Game (Chess) API
+// ──────────────────────────────────────────────
+// Mirrors use-uno.ts against the same game-agnostic /turn-games REST surface.
+// Reuses unoKeys' query-key root (one chat has at most one active turn-game,
+// so both boards share the /state resource and invalidation stays coherent).
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { toast } from "sonner";
+import { ApiError, api } from "../lib/api-client";
+import { chatKeys } from "./use-chats";
+import { useGenerate } from "./use-generate";
+import { useChessGameStore } from "../stores/chess-game.store";
+import { unoKeys } from "./use-uno";
+import type { ChessConfig, ChessMove, ChessPublicView } from "@marinara-engine/shared";
+
+interface StateResponse {
+  view: ChessPublicView | { gameType?: string };
+}
+
+interface OutcomeResponse {
+  ok: boolean;
+  view?: ChessPublicView;
+  error?: string;
+  finished?: boolean;
+  winnerSeatId?: string | null;
+  currentSeatId?: string | null;
+  legalMoves?: unknown[];
+}
+
+export interface StartChessBody {
+  gameType: "chess";
+  config?: Partial<ChessConfig>;
+  botCharacterIds: string[];
+  humanFirst?: boolean;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === "object" && !Array.isArray(value);
+}
+
+function isChessView(view: unknown): view is ChessPublicView {
+  return isRecord(view) && view.gameType === "chess";
+}
+
+/**
+ * Open a generate request to drive the bot seat, but only when the resulting
+ * turn belongs to the bot (not the human, and not a finished game). Fired both
+ * after a human move AND right after starting — with random colors the bot can
+ * draw white and must play the opening move.
+ */
+function maybeFireBotTurns(
+  qc: ReturnType<typeof useQueryClient>,
+  generate: ReturnType<typeof useGenerate>["generate"],
+  chatId: string,
+  res: OutcomeResponse | undefined,
+): void {
+  const view = res?.view;
+  if (!view || res?.finished || !res?.currentSeatId || res.currentSeatId === view.yourSeatId) return;
+  const chat =
+    qc.getQueryData<{ connectionId?: string | null }>(chatKeys.detail(chatId)) ??
+    (qc.getQueryData<Array<{ id: string; connectionId?: string | null }>>(chatKeys.list()) ?? []).find(
+      (c) => c.id === chatId,
+    );
+  generate({ chatId, connectionId: chat?.connectionId ?? null, turnGameBots: true });
+}
+
+/** Fetch the current board for a chat (404 = no active game). Feeds the chess store
+ * only when the active turn-game IS chess; other game types are left alone. */
+export function useChessState(chatId: string | null) {
+  return useQuery({
+    queryKey: chatId ? [...unoKeys.state(chatId), "chess"] : [...unoKeys.all, "state", "none", "chess"],
+    enabled: !!chatId,
+    staleTime: 30_000,
+    retry: false,
+    queryFn: async () => {
+      if (!chatId) return null;
+      try {
+        const res = await api.get<StateResponse>(`/turn-games/${chatId}/state`);
+        if (isChessView(res?.view)) useChessGameStore.getState().setChess(res.view, chatId);
+        return res;
+      } catch (err) {
+        if (err instanceof ApiError && err.status === 404) {
+          useChessGameStore.getState().clearChess(chatId);
+          return null;
+        }
+        throw err;
+      }
+    },
+  });
+}
+
+export function useStartChess(chatId: string) {
+  const qc = useQueryClient();
+  const { generate } = useGenerate();
+  return useMutation({
+    mutationFn: (body: StartChessBody) => api.post<OutcomeResponse>(`/turn-games/${chatId}/start`, body),
+    onSuccess: (res) => {
+      if (isChessView(res?.view)) useChessGameStore.getState().setChess(res.view, chatId);
+      qc.invalidateQueries({ queryKey: unoKeys.state(chatId) });
+      // If the color draw hands the first move to the bot, kick off the bot loop.
+      maybeFireBotTurns(qc, generate, chatId, res);
+    },
+    onError: (err: unknown) => toast.error(err instanceof Error ? err.message : "Failed to start the game"),
+  });
+}
+
+export function useChessMove(chatId: string) {
+  const qc = useQueryClient();
+  const { generate } = useGenerate();
+  return useMutation({
+    mutationFn: (vars: { move: ChessMove }) => api.post<OutcomeResponse>(`/turn-games/${chatId}/move`, vars),
+    onSuccess: (res) => {
+      if (isChessView(res?.view)) useChessGameStore.getState().setChess(res.view, chatId);
+      // Open a generate request so the server drives the bot seat over SSE.
+      maybeFireBotTurns(qc, generate, chatId, res);
+    },
+    onError: (err: unknown) => {
+      // The server returns 409 with { error, legalMoves, view } for an illegal move.
+      if (err instanceof ApiError && isRecord(err.payload) && isChessView(err.payload.view)) {
+        useChessGameStore.getState().setChess(err.payload.view, chatId);
+      }
+      toast.error(err instanceof Error ? err.message : "Illegal move");
+    },
+  });
+}
+
+export function useResignChess(chatId: string) {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: () => api.post(`/turn-games/${chatId}/resign`, {}),
+    onSuccess: () => {
+      useChessGameStore.getState().clearChess(chatId);
+      qc.invalidateQueries({ queryKey: unoKeys.state(chatId) });
+    },
+  });
+}

--- a/packages/client/src/hooks/use-generate.ts
+++ b/packages/client/src/hooks/use-generate.ts
@@ -12,6 +12,7 @@ import { formatGenerationParameterError } from "../lib/generation-parameter-erro
 import { requestChatScrollToBottom } from "../lib/chat-scroll-events";
 import { agentKeys } from "./use-agents";
 import { discardPendingGameStatePatch } from "./use-game-state-patcher";
+import { turnGameKeys } from "./turn-game-keys";
 import type { PendingAgentWriteApproval, PendingCardUpdate } from "../stores/agent.store";
 import type { DelayedCharacterInfo } from "../stores/chat.store";
 import {
@@ -1724,10 +1725,20 @@ export function useGenerate() {
             }
 
             case "turn_game_state_patch": {
-              if (!isActiveChat()) break;
               // The payload carries a gameType discriminator — route it to the matching
               // board store only; a view from one game rendered by another board crashes.
               const turnGameType = (event.data as { gameType?: string } | null)?.gameType;
+              if (!isActiveChat()) {
+                // A background chat's board can't be painted, but a silently
+                // dropped patch leaves a stale snapshot that blocks re-hydration
+                // on switch-back (the state query is disabled while a snapshot
+                // exists). Drop the snapshot and mark the query stale so
+                // returning to the chat refetches the board.
+                if (turnGameType === "chess") useChessGameStore.getState().clearChess(params.chatId);
+                else if (turnGameType === "uno") useUnoGameStore.getState().clearUno(params.chatId);
+                void qc.invalidateQueries({ queryKey: turnGameKeys.state(params.chatId) });
+                break;
+              }
               if (turnGameType === "chess") {
                 useChessGameStore.getState().setChess(event.data as never, params.chatId);
               } else if (turnGameType === "uno") {
@@ -2770,10 +2781,20 @@ export function useGenerate() {
               break;
             }
             case "turn_game_state_patch": {
-              if (!isActiveChat()) break;
               // The payload carries a gameType discriminator — route it to the matching
               // board store only; a view from one game rendered by another board crashes.
               const turnGameType = (event.data as { gameType?: string } | null)?.gameType;
+              if (!isActiveChat()) {
+                // A background chat's board can't be painted, but a silently
+                // dropped patch leaves a stale snapshot that blocks re-hydration
+                // on switch-back (the state query is disabled while a snapshot
+                // exists). Drop the snapshot and mark the query stale so
+                // returning to the chat refetches the board.
+                if (turnGameType === "chess") useChessGameStore.getState().clearChess(chatId);
+                else if (turnGameType === "uno") useUnoGameStore.getState().clearUno(chatId);
+                void qc.invalidateQueries({ queryKey: turnGameKeys.state(chatId) });
+                break;
+              }
               if (turnGameType === "chess") {
                 useChessGameStore.getState().setChess(event.data as never, chatId);
               } else if (turnGameType === "uno") {

--- a/packages/client/src/hooks/use-generate.ts
+++ b/packages/client/src/hooks/use-generate.ts
@@ -377,6 +377,7 @@ import { useAgentStore } from "../stores/agent.store";
 import { useGameModeStore } from "../stores/game-mode.store";
 import { useGameStateStore } from "../stores/game-state.store";
 import { useUnoGameStore } from "../stores/uno-game.store";
+import { useChessGameStore } from "../stores/chess-game.store";
 import { useTranslationStore } from "../stores/translation.store";
 import { useUIStore } from "../stores/ui.store";
 import {
@@ -1724,7 +1725,12 @@ export function useGenerate() {
 
             case "turn_game_state_patch": {
               if (!isActiveChat()) break;
-              useUnoGameStore.getState().setUno(event.data as never, params.chatId);
+              // The payload carries a gameType discriminator — route it to the right board store.
+              if ((event.data as { gameType?: string } | null)?.gameType === "chess") {
+                useChessGameStore.getState().setChess(event.data as never, params.chatId);
+              } else {
+                useUnoGameStore.getState().setUno(event.data as never, params.chatId);
+              }
               break;
             }
 
@@ -2763,7 +2769,12 @@ export function useGenerate() {
             }
             case "turn_game_state_patch": {
               if (!isActiveChat()) break;
-              useUnoGameStore.getState().setUno(event.data as never, chatId);
+              // The payload carries a gameType discriminator — route it to the right board store.
+              if ((event.data as { gameType?: string } | null)?.gameType === "chess") {
+                useChessGameStore.getState().setChess(event.data as never, chatId);
+              } else {
+                useUnoGameStore.getState().setUno(event.data as never, chatId);
+              }
               break;
             }
             case "game_map_update": {

--- a/packages/client/src/hooks/use-generate.ts
+++ b/packages/client/src/hooks/use-generate.ts
@@ -1725,10 +1725,12 @@ export function useGenerate() {
 
             case "turn_game_state_patch": {
               if (!isActiveChat()) break;
-              // The payload carries a gameType discriminator — route it to the right board store.
-              if ((event.data as { gameType?: string } | null)?.gameType === "chess") {
+              // The payload carries a gameType discriminator — route it to the matching
+              // board store only; a view from one game rendered by another board crashes.
+              const turnGameType = (event.data as { gameType?: string } | null)?.gameType;
+              if (turnGameType === "chess") {
                 useChessGameStore.getState().setChess(event.data as never, params.chatId);
-              } else {
+              } else if (turnGameType === "uno") {
                 useUnoGameStore.getState().setUno(event.data as never, params.chatId);
               }
               break;
@@ -2769,10 +2771,12 @@ export function useGenerate() {
             }
             case "turn_game_state_patch": {
               if (!isActiveChat()) break;
-              // The payload carries a gameType discriminator — route it to the right board store.
-              if ((event.data as { gameType?: string } | null)?.gameType === "chess") {
+              // The payload carries a gameType discriminator — route it to the matching
+              // board store only; a view from one game rendered by another board crashes.
+              const turnGameType = (event.data as { gameType?: string } | null)?.gameType;
+              if (turnGameType === "chess") {
                 useChessGameStore.getState().setChess(event.data as never, chatId);
-              } else {
+              } else if (turnGameType === "uno") {
                 useUnoGameStore.getState().setUno(event.data as never, chatId);
               }
               break;

--- a/packages/client/src/hooks/use-uno.ts
+++ b/packages/client/src/hooks/use-uno.ts
@@ -41,6 +41,12 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return !!value && typeof value === "object" && !Array.isArray(value);
 }
 
+// The /turn-games REST surface is shared by every game type; only UNO views may
+// reach the UNO store (a chess view rendered as UNO crashes the board).
+function isUnoView(view: unknown): view is UnoPublicView {
+  return isRecord(view) && view.gameType === "uno";
+}
+
 /**
  * Open a generate request to drive the bot seats, but only when the resulting
  * turn belongs to a bot (not the human, and not a finished game). This is the
@@ -75,7 +81,8 @@ export function useUnoState(chatId: string | null) {
       if (!chatId) return null;
       try {
         const res = await api.get<StateResponse>(`/turn-games/${chatId}/state`);
-        if (res?.view) useUnoGameStore.getState().setUno(res.view, chatId);
+        if (isUnoView(res?.view)) useUnoGameStore.getState().setUno(res.view, chatId);
+        else if (res?.view) useUnoGameStore.getState().clearUno(chatId); // another game type is active
         return res;
       } catch (err) {
         if (err instanceof ApiError && err.status === 404) {
@@ -94,7 +101,7 @@ export function useStartUno(chatId: string) {
   return useMutation({
     mutationFn: (body: StartUnoBody) => api.post<OutcomeResponse>(`/turn-games/${chatId}/start`, body),
     onSuccess: (res) => {
-      if (res?.view) useUnoGameStore.getState().setUno(res.view, chatId);
+      if (isUnoView(res?.view)) useUnoGameStore.getState().setUno(res.view, chatId);
       qc.invalidateQueries({ queryKey: unoKeys.state(chatId) });
       // If the opening card or seat order hands the first turn to a bot, kick off the bot loop.
       maybeFireBotTurns(qc, generate, chatId, res);
@@ -109,14 +116,14 @@ export function useUnoMove(chatId: string) {
   return useMutation({
     mutationFn: (vars: { move: unknown }) => api.post<OutcomeResponse>(`/turn-games/${chatId}/move`, vars),
     onSuccess: (res) => {
-      if (res?.view) useUnoGameStore.getState().setUno(res.view, chatId);
+      if (isUnoView(res?.view)) useUnoGameStore.getState().setUno(res.view, chatId);
       // Open a generate request so the server drives the bot seats over SSE.
       maybeFireBotTurns(qc, generate, chatId, res);
     },
     onError: (err: unknown) => {
       // The server returns 409 with { error, legalMoves, view } for an illegal move.
-      if (err instanceof ApiError && isRecord(err.payload) && isRecord(err.payload.view)) {
-        useUnoGameStore.getState().setUno(err.payload.view as unknown as UnoPublicView, chatId);
+      if (err instanceof ApiError && isRecord(err.payload) && isUnoView(err.payload.view)) {
+        useUnoGameStore.getState().setUno(err.payload.view, chatId);
       }
       toast.error(err instanceof Error ? err.message : "Illegal move");
     },

--- a/packages/client/src/hooks/use-uno.ts
+++ b/packages/client/src/hooks/use-uno.ts
@@ -6,14 +6,11 @@ import { toast } from "sonner";
 import { ApiError, api } from "../lib/api-client";
 import { chatKeys } from "./use-chats";
 import { useGenerate } from "./use-generate";
+import { turnGameKeys } from "./turn-game-keys";
 import { useUnoGameStore } from "../stores/uno-game.store";
 import type { UnoConfig, UnoPublicView } from "@marinara-engine/shared";
 
-export const unoKeys = {
-  all: ["turn-games"] as const,
-  catalog: () => [...unoKeys.all, "catalog"] as const,
-  state: (chatId: string) => [...unoKeys.all, "state", chatId] as const,
-};
+export const unoKeys = turnGameKeys;
 
 interface StateResponse {
   view: UnoPublicView;

--- a/packages/client/src/lib/slash-commands.ts
+++ b/packages/client/src/lib/slash-commands.ts
@@ -5,6 +5,7 @@ import { api } from "./api-client";
 import { useChatStore } from "../stores/chat.store";
 import { useUIStore } from "../stores/ui.store";
 import { useUnoGameStore } from "../stores/uno-game.store";
+import { useChessGameStore } from "../stores/chess-game.store";
 import { toast } from "sonner";
 import {
   SUPPORTED_MACROS,
@@ -362,6 +363,19 @@ const COMMANDS: SlashCommand[] = [
         return { handled: true, feedback: "UNO can only be played in conversation chats." };
       }
       useUnoGameStore.getState().openSetup(ctx.chatId);
+      return { handled: true };
+    },
+  },
+  {
+    name: "chess",
+    description: "Start a one-on-one chess game with a character in this chat",
+    usage: "/chess",
+    local: true,
+    async execute(_args, ctx) {
+      if (ctx.mode === "roleplay") {
+        return { handled: true, feedback: "Chess can only be played in conversation chats." };
+      }
+      useChessGameStore.getState().openSetup(ctx.chatId);
       return { handled: true };
     },
   },

--- a/packages/client/src/stores/chess-game.store.ts
+++ b/packages/client/src/stores/chess-game.store.ts
@@ -1,0 +1,36 @@
+// ──────────────────────────────────────────────
+// Zustand Store: Chess Board (turn-game #2)
+// ──────────────────────────────────────────────
+// Holds the live, per-viewer chess snapshot pushed by the server
+// (turn_game_state_patch SSE, dispatched by gameType) or fetched on mount.
+// chatId-guarded so a background chat's game can never paint over the visible
+// board. Synchronous only — all async lives in use-chess.ts.
+import { create } from "zustand";
+import type { ChessPublicView } from "@marinara-engine/shared";
+
+export type ChessBoardSnapshot = ChessPublicView & { chatId: string };
+
+interface ChessGameStore {
+  current: ChessBoardSnapshot | null;
+  /** Chat whose setup modal is open (null = closed). Driven by the /chess command. */
+  setupChatId: string | null;
+  /** Replace the board with a fresh server snapshot for a chat. */
+  setChess: (view: ChessPublicView, chatId: string) => void;
+  /** Clear the board (optionally only if it belongs to a given chat). */
+  clearChess: (chatId?: string) => void;
+  /** Open the game-setup modal for a chat. */
+  openSetup: (chatId: string) => void;
+  closeSetup: () => void;
+  reset: () => void;
+}
+
+export const useChessGameStore = create<ChessGameStore>((set) => ({
+  current: null,
+  setupChatId: null,
+  setChess: (view, chatId) => set({ current: { ...view, chatId } }),
+  clearChess: (chatId) =>
+    set((state) => (!chatId || state.current?.chatId === chatId ? { current: null } : {})),
+  openSetup: (chatId) => set({ setupChatId: chatId }),
+  closeSetup: () => set({ setupChatId: null }),
+  reset: () => set({ current: null, setupChatId: null }),
+}));

--- a/packages/server/src/routes/generate.routes.ts
+++ b/packages/server/src/routes/generate.routes.ts
@@ -891,6 +891,8 @@ function getConversationCommandKey(command: CharacterCommand): ConversationComma
       return "scene";
     case "uno":
       return "uno";
+    case "chess":
+      return "chess";
     case "spotify":
     case "youtube":
       return "music";
@@ -3056,22 +3058,35 @@ export async function generateRoutes(app: FastifyInstance) {
                 `   - You invite {{user}} somewhere and they accept → trigger a scene for that activity.`,
                 `   - A plan is made (date, trip, hangout, confrontation) and the moment arrives → trigger a scene.`,
                 `   Do NOT wait for {{user}} to explicitly ask for a scene. If the conversation implies you and {{user}} are about to DO something together, initiate the scene yourself.`,
-                `   EXCEPTION: Do NOT start a scene for playing UNO, cards, or other board/table games — those have their own [uno] command. Use [uno], not [scene], for a game of UNO.`,
+                `   EXCEPTION: Do NOT start a scene for playing UNO, chess, cards, or other board/table games — those have their own commands. Use [uno] for UNO and [chess] for chess, not [scene].`,
               );
             }
 
-            // UNO turn-game — conversation mode only, when no game is running yet
+            // Turn-games — conversation mode only, when no game is running yet
             // and at least one other character is present to play with.
-            if (
+            const unoAdvertisable =
               chatMode === "conversation" &&
               isConversationCommandEnabled(chatMeta, "uno") &&
-              characterIds.length >= 1 &&
-              !(await getActiveTurnGame(app.db, input.chatId))
-            ) {
+              characterIds.length >= 1;
+            const chessAdvertisable =
+              chatMode === "conversation" &&
+              isConversationCommandEnabled(chatMeta, "chess") &&
+              characterIds.length >= 1;
+            // One lookup shared by both game commands (only when a game could be offered).
+            const noActiveTurnGame =
+              (unoAdvertisable || chessAdvertisable) && !(await getActiveTurnGame(app.db, input.chatId));
+            if (unoAdvertisable && noActiveTurnGame) {
               addCommandLines(
                 `- [uno] - start a game of UNO at the table. Include this ONLY when ${personaName} proposes playing UNO (or cards) and you are willing to play right now. The system deals the cards and runs the game — you do NOT narrate dealing or describe the hands.`,
                 `   If you are busy, tired, or simply don't feel like it, just say so in character and do NOT include [uno]. Agreeing to play IS including [uno].`,
                 `   Example: ${personaName} says "anyone up for a round of uno?" and you're in → "Oh, you're SO on. [uno]"`,
+              );
+            }
+            if (chessAdvertisable && noActiveTurnGame) {
+              addCommandLines(
+                `- [chess] - start a one-on-one chess game against ${personaName}. Include this ONLY when ${personaName} proposes playing chess and YOU are willing to play right now. Chess seats exactly two players: ${personaName} and you — whichever character includes [chess] takes the opponent's seat. The system sets up the board and runs the game — you do NOT describe the board or narrate setup.`,
+                `   If you'd rather not play, say so in character and do NOT include [chess]. Agreeing to play IS including [chess].`,
+                `   Example: ${personaName} says "up for a game of chess?" and you're in → "Prepare to lose your queen. [chess]"`,
               );
             }
 
@@ -10262,6 +10277,46 @@ export async function generateRoutes(app: FastifyInstance) {
                     }
                   } catch (unoErr) {
                     logger.error(unoErr, "[commands] UNO start failed");
+                  }
+                }
+
+                if (command.type === "chess") {
+                  // ── Chess: a character accepted a one-on-one challenge — set up the board ──
+                  try {
+                    const existingGame = await getActiveTurnGame(app.db, input.chatId);
+                    if (existingGame) {
+                      logger.info("[commands] chess requested but a game is already active in chat %s", input.chatId);
+                    } else if (!characterId) {
+                      logger.warn("[commands] chess requested without an agreeing character in chat %s", input.chatId);
+                    } else {
+                      // Chess seats exactly two players: the human persona and the
+                      // character who agreed (no schedule sweep — nobody else plays).
+                      const outcome = await startTurnGame(app.db, input.chatId, {
+                        gameType: "chess",
+                        botCharacterIds: [characterId],
+                        humanFirst: true,
+                      });
+                      if (outcome.ok) {
+                        reply.raw.write(
+                          `data: ${JSON.stringify({ type: "turn_game_state_patch", data: outcome.view })}\n\n`,
+                        );
+                        logger.info("[commands] chess started in chat %s against %s", input.chatId, characterId);
+                        // The default config assigns colors randomly from the seed — when the
+                        // bot drew white, play its opening move now instead of stalling.
+                        await runTurnGameBotTurns({
+                          db: app.db,
+                          chatId: input.chatId,
+                          conn,
+                          baseUrl,
+                          reply,
+                          signal: abortController.signal,
+                        });
+                      } else {
+                        logger.warn("[commands] chess start failed in chat %s: %s", input.chatId, outcome.error ?? "");
+                      }
+                    }
+                  } catch (chessErr) {
+                    logger.error(chessErr, "[commands] chess start failed");
                   }
                 }
 

--- a/packages/server/src/services/conversation/character-commands.ts
+++ b/packages/server/src/services/conversation/character-commands.ts
@@ -12,6 +12,7 @@
 // - [memory: target="CharName", summary="description of the memory"]
 // - [scene: scenario="...", background="...", plan="..."] (initiate a mini-roleplay scene)
 // - [uno] (start a game of UNO at the table; Conversation mode)
+// - [chess] (start a one-on-one chess game against the user; Conversation mode)
 // - [spotify: title="Song title", artist="Artist"] (play a song on the user's active Spotify player)
 // - [youtube: query="Song title Artist"] (play a song on the user's active YouTube player)
 // - [react: emoji="😂"] or [react: emoji=":custom_name:"] (react to the user's latest message; Conversation mode)
@@ -76,6 +77,11 @@ export interface SceneCommand {
 export interface UnoCommand {
   /** Start a game of UNO at the table. Param-less; the system deals + runs the game. */
   type: "uno";
+}
+
+export interface ChessCommand {
+  /** Start a one-on-one chess game against the user. Param-less; the system sets up + runs the board. */
+  type: "chess";
 }
 
 export interface InfluenceCommand {
@@ -327,6 +333,7 @@ export type CharacterCommand =
   | MemoryCommand
   | SceneCommand
   | UnoCommand
+  | ChessCommand
   | InfluenceCommand
   | NoteCommand
   | DirectMessageCommand
@@ -352,6 +359,8 @@ const MEMORY_RE = /\[memory:\s*target="([^"]+)"\s*,\s*summary="([^"]+)"\]/gi;
 const SCENE_RE = new RegExp(`\\[scene:\\s*(${QUOTED_PARAM_BLOCK})\\]`, "gi");
 // Param-less UNO trigger. Tolerates a stray `[uno: ...]` so a chatty model can't dodge the match.
 const UNO_RE = /\[uno(?::[^\]\r\n]*)?\]/gi;
+// Param-less chess trigger. Same tolerant shape as UNO_RE.
+const CHESS_RE = /\[chess(?::[^\]\r\n]*)?\]/gi;
 const HAPTIC_RE = new RegExp(`\\[haptic:\\s*(${QUOTED_PARAM_BLOCK})\\]`, "gi");
 const SPOTIFY_RE = new RegExp(`\\[spotify:\\s*(${QUOTED_PARAM_BLOCK})\\]`, "gi");
 const YOUTUBE_RE = new RegExp(`\\[youtube:\\s*(${QUOTED_PARAM_BLOCK})\\]`, "gi");
@@ -869,6 +878,12 @@ export function parseCharacterCommands(content: string): {
     break;
   }
 
+  // Parse chess command — start a one-on-one chess game. Param-less; only one per message.
+  for (const _chessMatch of content.matchAll(CHESS_RE)) {
+    commands.push({ type: "chess" });
+    break;
+  }
+
   // Parse influence commands (<influence>text</influence>)
   for (const match of content.matchAll(INFLUENCE_RE)) {
     const text = stripConversationPromptTimestamps(match[1]!.trim());
@@ -1058,6 +1073,7 @@ export function parseCharacterCommands(content: string): {
     .replace(MEMORY_RE, "")
     .replace(SCENE_RE, "")
     .replace(UNO_RE, "")
+    .replace(CHESS_RE, "")
     .replace(HAPTIC_RE, "")
     .replace(SPOTIFY_RE, "")
     .replace(YOUTUBE_RE, "")

--- a/packages/server/src/services/turn-games/turn-game-bot-runner.service.ts
+++ b/packages/server/src/services/turn-games/turn-game-bot-runner.service.ts
@@ -48,11 +48,11 @@ function truncate(value: unknown, max: number): string {
 
 /** Map a model-supplied display name on a move onto the matching seatId. */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-function resolveSeatRefs(move: any, state: { seatOrder: string[]; seatNames: Record<string, string> }): any {
+function resolveSeatRefs(move: any, state: { seatOrder?: string[]; seatNames: Record<string, string> }): any {
   if (!move || typeof move !== "object") return move;
   const map = (ref: unknown): unknown => {
     if (typeof ref !== "string" || !ref) return ref;
-    if (state.seatOrder.includes(ref)) return ref;
+    if (state.seatOrder?.includes(ref)) return ref;
     const lower = ref.toLowerCase();
     for (const [seatId, name] of Object.entries(state.seatNames)) {
       if (String(name).toLowerCase() === lower) return seatId;

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -18,6 +18,7 @@
     "lint": "node scripts/generate-feature-registries.mjs && tsc --noEmit"
   },
   "dependencies": {
+    "chess.js": "^1.4.0",
     "zod": "^3.25.76"
   },
   "devDependencies": {

--- a/packages/shared/scripts/generate-feature-registries.mjs
+++ b/packages/shared/scripts/generate-feature-registries.mjs
@@ -115,7 +115,7 @@ async function writeRegistry({
   await writeFile(outputPath, `${lines.join("\n")}\n`, "utf8");
 }
 
-const TURN_GAME_ORDER = ["uno"];
+const TURN_GAME_ORDER = ["uno", "chess"];
 
 await writeRegistry({
   baseDir: join(srcDir, "features", "agents"),

--- a/packages/shared/src/features/turn-games/chess/engine.manifest.ts
+++ b/packages/shared/src/features/turn-games/chess/engine.manifest.ts
@@ -1,0 +1,5 @@
+// Registry entry for the chess engine. The codegen scans turn-games/<game>/engine.manifest.ts
+// and collects the single exported const into TURN_GAME_ENGINES.
+import { chessEngine } from "./engine.js";
+
+export const chessGameEngine = chessEngine;

--- a/packages/shared/src/features/turn-games/chess/engine.ts
+++ b/packages/shared/src/features/turn-games/chess/engine.ts
@@ -377,7 +377,6 @@ export const chessEngine: TurnGameEngine<ChessState, ChessMove, ChessConfig, Che
       lastMove: null,
       lastAction: null,
       log: [],
-      moveCount: 0,
     };
 
     record(state, {
@@ -426,7 +425,6 @@ export const chessEngine: TurnGameEngine<ChessState, ChessMove, ChessConfig, Che
     s.fen = c.fen();
     s.check = c.inCheck();
     s.lastMove = { from: made.from, to: made.to, san: made.san, seatId };
-    s.moveCount += 1;
     setLast(s, seatId, `plays ${made.san}`);
 
     events.push({

--- a/packages/shared/src/features/turn-games/chess/engine.ts
+++ b/packages/shared/src/features/turn-games/chess/engine.ts
@@ -1,0 +1,588 @@
+// ──────────────────────────────────────────────
+// Chess — deterministic engine (server-authoritative)
+// ──────────────────────────────────────────────
+// Pure functions over ChessState, with move legality delegated to chess.js.
+// The single source of truth for legality, turn order, and game end. The LLM
+// only proposes SAN moves (validated here) and narrates the engine-confirmed
+// result; it never adjudicates rules. Chess has no randomness beyond the
+// deterministic color assignment derived from the setup seed, and no hidden
+// information — both players (and spectators) see the full board.
+//
+// IMPORTANT: `state.sanHistory` is the source of truth and every board-
+// dependent method replays it from the start position. `state.fen` is a cache
+// for O(1) reads (currentSeat/isTerminal run on hot server paths). Never
+// rebuild a position from FEN alone — that silently breaks threefold-
+// repetition and fifty-move draw detection.
+
+import { Chess, type Move } from "chess.js";
+import type {
+  GameEvent,
+  ModelTurnView,
+  MoveResult,
+  Seat,
+  TerminalResult,
+  TurnGameEngine,
+} from "../engine.types.js";
+import { CHESS_TOOL_MANIFESTS } from "./tools.js";
+import {
+  CHESS_LOG_CAP,
+  CHESS_MAX_PLAYERS,
+  CHESS_MIN_PLAYERS,
+  DEFAULT_CHESS_CONFIG,
+  chessConfigSchema,
+  type ChessColor,
+  type ChessConfig,
+  type ChessDrawReason,
+  type ChessMove,
+  type ChessPieceLetter,
+  type ChessPublicSeat,
+  type ChessPublicView,
+  type ChessState,
+  type PromotionPiece,
+} from "./types.js";
+
+// ── small helpers ───────────────────────────────────────────────────────────
+
+function clone(state: ChessState): ChessState {
+  return JSON.parse(JSON.stringify(state)) as ChessState;
+}
+
+const PIECE_NAMES: Record<string, string> = {
+  p: "pawn",
+  n: "knight",
+  b: "bishop",
+  r: "rook",
+  q: "queen",
+  k: "king",
+};
+
+const PIECE_VALUES: Record<string, number> = { p: 1, n: 3, b: 3, r: 5, q: 9 };
+
+function pieceName(letter: string | undefined): string {
+  return (letter && PIECE_NAMES[letter]) || "piece";
+}
+
+function nameOf(state: ChessState, seatId: string): string {
+  return state.seatNames[seatId] ?? seatId;
+}
+
+/** Replay the full move history onto a fresh board. History is engine-authored,
+ * so failures are unreachable in practice; stop replaying defensively if one occurs. */
+function replay(state: ChessState): Chess {
+  const c = new Chess();
+  for (const san of state.sanHistory) {
+    try {
+      c.move(san);
+    } catch {
+      break;
+    }
+  }
+  return c;
+}
+
+/** Side to move, parsed from the cached FEN (O(1), no replay). */
+function sideToMove(state: ChessState): "w" | "b" {
+  return state.fen.split(" ")[1] === "b" ? "b" : "w";
+}
+
+function moveNumberFromFen(fen: string): number {
+  const n = Number.parseInt(fen.split(" ")[5] ?? "1", 10);
+  return Number.isFinite(n) && n > 0 ? n : 1;
+}
+
+function seatForColor(state: ChessState, color: "w" | "b"): string {
+  return color === "w" ? state.whiteSeatId : state.blackSeatId;
+}
+
+function colorOfSeat(state: ChessState, seatId: string): ChessColor | null {
+  if (seatId === state.whiteSeatId) return "white";
+  if (seatId === state.blackSeatId) return "black";
+  return null;
+}
+
+function record(state: ChessState, event: GameEvent): void {
+  state.log.push(event);
+  if (state.log.length > CHESS_LOG_CAP) state.log.splice(0, state.log.length - CHESS_LOG_CAP);
+}
+
+function setLast(state: ChessState, seatId: string, summary: string): void {
+  state.lastAction = { seatId, summary };
+}
+
+/** Normalize model-flavored SAN: strip move numbers and annotations, fix castling zeros. */
+function normalizeSan(raw: string): string {
+  let san = raw.trim();
+  san = san.replace(/^\d+\.+\s*/, "");
+  san = san.replace(/[!?]+$/, "");
+  if (/^[0o]-[0o]-[0o]/i.test(san)) san = `O-O-O${san.slice(5)}`;
+  else if (/^[0o]-[0o]/i.test(san)) san = `O-O${san.slice(3)}`;
+  return san.trim();
+}
+
+function toChessMove(m: Move): ChessMove {
+  return {
+    type: "move",
+    san: m.san,
+    from: m.from,
+    to: m.to,
+    ...(m.promotion ? { promotion: m.promotion as PromotionPiece } : {}),
+  };
+}
+
+/** Material point balance from the FEN placement field (positive = white ahead). */
+function materialBalance(fen: string): number {
+  const placement = fen.split(" ")[0] ?? "";
+  let balance = 0;
+  for (const ch of placement) {
+    const lower = ch.toLowerCase();
+    const value = PIECE_VALUES[lower];
+    if (!value) continue;
+    balance += ch === lower ? -value : value;
+  }
+  return balance;
+}
+
+function materialLine(state: ChessState): string {
+  const balance = materialBalance(state.fen);
+  if (balance === 0) return "Material is even.";
+  const ahead = balance > 0 ? nameOf(state, state.whiteSeatId) : nameOf(state, state.blackSeatId);
+  const points = Math.abs(balance);
+  return `${ahead} is up ${points} point${points === 1 ? "" : "s"} of material.`;
+}
+
+/** The last `maxPlies` moves formatted with move numbers, e.g. "12. Nf3 Nc6 13. Bb5". */
+function recentMovesLine(state: ChessState, maxPlies: number): string {
+  const total = state.sanHistory.length;
+  if (total === 0) return "";
+  const start = Math.max(0, total - maxPlies);
+  const parts: string[] = [];
+  for (let i = start; i < total; i++) {
+    const san = state.sanHistory[i]!;
+    const moveNo = Math.floor(i / 2) + 1;
+    if (i % 2 === 0) parts.push(`${moveNo}. ${san}`);
+    else if (i === start) parts.push(`${moveNo}. … ${san}`);
+    else parts.push(san);
+  }
+  return parts.join(" ");
+}
+
+/** The last `max` human-readable game events, oldest→newest. */
+function recentPlayLines(state: ChessState, max: number): string[] {
+  return state.log
+    .filter((e) => e.type !== "game_started" && typeof e.message === "string" && e.message.trim().length > 0)
+    .slice(-max)
+    .map((e) => `  • ${e.message}`);
+}
+
+function drawReasonText(reason: ChessDrawReason): string {
+  switch (reason) {
+    case "stalemate":
+      return "stalemate";
+    case "insufficient_material":
+      return "insufficient material";
+    case "threefold_repetition":
+      return "threefold repetition";
+    case "fifty_move_rule":
+      return "the fifty-move rule";
+  }
+}
+
+function enumerateLegalMoves(state: ChessState, seatId: string): ChessMove[] {
+  if (state.status === "finished") return [];
+  if (seatForColor(state, sideToMove(state)) !== seatId) return [];
+  return replay(state).moves({ verbose: true }).map(toChessMove);
+}
+
+// ── move resolution ─────────────────────────────────────────────────────────
+
+/** Try the proposed move on the board. Returns the applied verbose move or null.
+ * chess.js `.move()` THROWS on illegal input, so every call is wrapped. */
+function tryApply(c: Chess, move: ChessMove): Move | null {
+  if (typeof move.san === "string" && move.san.trim()) {
+    try {
+      return c.move(normalizeSan(move.san));
+    } catch {
+      /* fall through to from/to */
+    }
+  }
+  if (typeof move.from === "string" && move.from && typeof move.to === "string" && move.to) {
+    // Default promotions to queen so a board UI that skipped the picker still works;
+    // retry without the field in case the library rejects it as extraneous.
+    try {
+      return c.move({ from: move.from, to: move.to, promotion: move.promotion ?? "q" });
+    } catch {
+      try {
+        return c.move({ from: move.from, to: move.to });
+      } catch {
+        return null;
+      }
+    }
+  }
+  return null;
+}
+
+function describeAttempt(move: ChessMove): string {
+  if (move.san && move.san.trim()) return move.san.trim();
+  if (move.from && move.to) return `${move.from}-${move.to}${move.promotion ? `=${move.promotion.toUpperCase()}` : ""}`;
+  return "(no move given)";
+}
+
+function moveFlavor(state: ChessState, seatId: string, made: Move): string {
+  const name = nameOf(state, seatId);
+  if (made.flags.includes("k")) return `${name} castles kingside (O-O).`;
+  if (made.flags.includes("q")) return `${name} castles queenside (O-O-O).`;
+  let text = `${name} plays ${made.san}`;
+  if (made.captured) {
+    text += `, capturing a ${pieceName(made.captured)}`;
+    if (made.flags.includes("e")) text += " en passant";
+  }
+  if (made.promotion) text += `, promoting to a ${pieceName(made.promotion)}`;
+  return `${text}.`;
+}
+
+// ── prompt builders ─────────────────────────────────────────────────────────
+
+function buildBoardSummary(state: ChessState, seatId: string, c: Chess): string {
+  const yourColor = colorOfSeat(state, seatId) ?? "white";
+  const oppSeatId = seatId === state.whiteSeatId ? state.blackSeatId : state.whiteSeatId;
+  const oppColor = yourColor === "white" ? "black" : "white";
+  const lines: string[] = [];
+  lines.push(
+    `Chess — move ${moveNumberFromFen(state.fen)}. You are ${nameOf(state, seatId)}, playing ${yourColor}. ` +
+      `Your opponent is ${nameOf(state, oppSeatId)} (${oppColor}).`,
+  );
+  lines.push(`Position (FEN): ${state.fen}`);
+  lines.push(c.ascii());
+  lines.push(`Material: ${materialLine(state)}`);
+  const recent = recentMovesLine(state, 6);
+  if (recent) lines.push(`Recent moves: ${recent}`);
+  if (state.check) lines.push("You are IN CHECK — your move must get your king out of check.");
+  return lines.join("\n");
+}
+
+function buildInstructions(sanList: string[]): string {
+  return (
+    `Legal moves (SAN): ${sanList.join(", ")}\n` +
+    `Call chess_move with exactly ONE of these strings as "san" — copy it verbatim. ` +
+    `Any other move is illegal and a fallback move will be chosen for you.`
+  );
+}
+
+/** Hand-free board summary for injecting game awareness into other (free-chat) prompts. */
+function buildSpectatorSummary(state: ChessState): string {
+  const white = nameOf(state, state.whiteSeatId);
+  const black = nameOf(state, state.blackSeatId);
+  if (state.status === "finished") {
+    const lines: string[] = [];
+    if (state.winnerSeatId) {
+      const winner = nameOf(state, state.winnerSeatId);
+      const loser = state.winnerSeatId === state.whiteSeatId ? black : white;
+      lines.push(`The chess game just finished — ${winner} defeated ${loser} by checkmate.`);
+    } else if (state.drawReason) {
+      lines.push(
+        `The chess game between ${white} (white) and ${black} (black) just ended in a draw by ${drawReasonText(state.drawReason)}.`,
+      );
+    } else {
+      lines.push(`The chess game between ${white} and ${black} just ended.`);
+    }
+    const plays = recentPlayLines(state, 6);
+    if (plays.length) lines.push("How it ended:", ...plays);
+    return lines.join("\n");
+  }
+  const lines: string[] = [
+    `A game of chess is in progress at the table: ${white} (white) vs ${black} (black), move ${moveNumberFromFen(state.fen)}.`,
+    materialLine(state),
+  ];
+  if (state.lastMove) lines.push(`Last move: ${nameOf(state, state.lastMove.seatId)} played ${state.lastMove.san}.`);
+  const toMove = seatForColor(state, sideToMove(state));
+  lines.push(`${nameOf(state, toMove)} is thinking about their move${state.check ? " — and is in check" : ""}.`);
+  return lines.join("\n");
+}
+
+// ── deterministic fallback ──────────────────────────────────────────────────
+
+/** A deterministic, never-embarrassing legal move: mate-in-1 > best capture > check > first
+ * in SAN order. Pure in the state (probes run on the local replay instance). */
+function pickFallback(state: ChessState): ChessMove {
+  const c = replay(state);
+  const moves = [...c.moves({ verbose: true })].sort((a, b) => (a.san < b.san ? -1 : a.san > b.san ? 1 : 0));
+  if (moves.length === 0) {
+    // Unreachable while the game is active; a rejectable sentinel keeps the contract total.
+    return { type: "move", san: "" };
+  }
+  for (const m of moves) {
+    c.move(m.san);
+    const mate = c.isCheckmate();
+    c.undo();
+    if (mate) return toChessMove(m);
+  }
+  let bestCapture: Move | null = null;
+  for (const m of moves) {
+    if (!m.captured) continue;
+    if (!bestCapture || (PIECE_VALUES[m.captured] ?? 0) > (PIECE_VALUES[bestCapture.captured ?? ""] ?? 0)) {
+      bestCapture = m;
+    }
+  }
+  if (bestCapture) return toChessMove(bestCapture);
+  const check = moves.find((m) => m.san.includes("+"));
+  if (check) return toChessMove(check);
+  return toChessMove(moves[0]!);
+}
+
+// ── the engine object ───────────────────────────────────────────────────────
+
+export const chessEngine: TurnGameEngine<ChessState, ChessMove, ChessConfig, ChessPublicView> = {
+  gameType: "chess",
+  schemaVersion: 1,
+  label: "Chess",
+  minPlayers: CHESS_MIN_PLAYERS,
+  maxPlayers: CHESS_MAX_PLAYERS,
+
+  defaultConfig() {
+    return { ...DEFAULT_CHESS_CONFIG };
+  },
+
+  normalizeConfig(config) {
+    const direct = chessConfigSchema.safeParse(config);
+    if (direct.success) return direct.data;
+    const merged = { ...DEFAULT_CHESS_CONFIG, ...(config && typeof config === "object" ? (config as object) : {}) };
+    const reparsed = chessConfigSchema.safeParse(merged);
+    return reparsed.success ? reparsed.data : { ...DEFAULT_CHESS_CONFIG };
+  },
+
+  setup(config, seats: Seat[], seed) {
+    const humanSeat = seats.find((s) => s.kind === "human") ?? seats[0]!;
+    const otherSeat = seats.find((s) => s.seatId !== humanSeat.seatId) ?? seats[seats.length - 1]!;
+    const humanIsWhite =
+      config.humanColor === "white" ? true : config.humanColor === "black" ? false : Math.abs(seed) % 2 === 0;
+    const whiteSeat = humanIsWhite ? humanSeat : otherSeat;
+    const blackSeat = humanIsWhite ? otherSeat : humanSeat;
+
+    const seatNames: Record<string, string> = {};
+    for (const s of seats) seatNames[s.seatId] = s.displayName;
+
+    const state: ChessState = {
+      config,
+      sanHistory: [],
+      fen: new Chess().fen(),
+      whiteSeatId: whiteSeat.seatId,
+      blackSeatId: blackSeat.seatId,
+      seatNames,
+      seats: seats.map((s) => ({ seatId: s.seatId, displayName: s.displayName, kind: s.kind })),
+      status: "active",
+      winnerSeatId: null,
+      drawReason: null,
+      check: false,
+      seed,
+      lastMove: null,
+      lastAction: null,
+      log: [],
+      moveCount: 0,
+    };
+
+    record(state, {
+      type: "game_started",
+      message: `${whiteSeat.displayName} has the white pieces, ${blackSeat.displayName} has black. ${whiteSeat.displayName} moves first.`,
+    });
+    return state;
+  },
+
+  currentSeat(state) {
+    return state.status === "finished" ? null : seatForColor(state, sideToMove(state));
+  },
+
+  interruptibleSeats() {
+    return [];
+  },
+
+  legalMoves(state, seatId) {
+    return enumerateLegalMoves(state, seatId);
+  },
+
+  applyMove(state, seatId, move): MoveResult<ChessState, ChessMove> {
+    if (state.status === "finished") {
+      return { ok: false, error: "The game is already over.", legalMoves: [] };
+    }
+    if (seatForColor(state, sideToMove(state)) !== seatId) {
+      return { ok: false, error: "It's not your turn.", legalMoves: [] };
+    }
+    if (!move || move.type !== "move") {
+      return { ok: false, error: "Unknown move.", legalMoves: enumerateLegalMoves(state, seatId) };
+    }
+
+    const c = replay(state);
+    const made = tryApply(c, move);
+    if (!made) {
+      return {
+        ok: false,
+        error: `Illegal move "${describeAttempt(move)}". Choose one of the legal moves.`,
+        legalMoves: replay(state).moves({ verbose: true }).map(toChessMove),
+      };
+    }
+
+    const s = clone(state);
+    const events: GameEvent[] = [];
+    s.sanHistory.push(made.san);
+    s.fen = c.fen();
+    s.check = c.inCheck();
+    s.lastMove = { from: made.from, to: made.to, san: made.san, seatId };
+    s.moveCount += 1;
+    setLast(s, seatId, `plays ${made.san}`);
+
+    events.push({
+      type: "move_played",
+      seatId,
+      message: moveFlavor(s, seatId, made),
+      data: {
+        san: made.san,
+        from: made.from,
+        to: made.to,
+        ...(made.captured ? { captured: made.captured } : {}),
+        ...(made.promotion ? { promotion: made.promotion } : {}),
+      },
+    });
+
+    const opponentSeatId = seatId === s.whiteSeatId ? s.blackSeatId : s.whiteSeatId;
+    if (c.isCheckmate()) {
+      s.status = "finished";
+      s.winnerSeatId = seatId;
+      events.push({
+        type: "checkmate",
+        seatId,
+        message: `Checkmate! ${nameOf(s, seatId)} defeats ${nameOf(s, opponentSeatId)}.`,
+      });
+      events.push({ type: "game_over", seatId, message: `${nameOf(s, seatId)} wins the chess game.` });
+    } else if (c.isStalemate()) {
+      s.status = "finished";
+      s.drawReason = "stalemate";
+    } else if (c.isThreefoldRepetition()) {
+      s.status = "finished";
+      s.drawReason = "threefold_repetition";
+    } else if (c.isInsufficientMaterial()) {
+      s.status = "finished";
+      s.drawReason = "insufficient_material";
+    } else if (c.isDraw()) {
+      // Stalemate / repetition / material are handled above, so this is the fifty-move rule.
+      s.status = "finished";
+      s.drawReason = "fifty_move_rule";
+    } else if (s.check) {
+      events.push({ type: "check", seatId: opponentSeatId, message: `${nameOf(s, opponentSeatId)} is in check!` });
+    }
+
+    if (s.drawReason) {
+      events.push({ type: "draw", message: `The game is a draw by ${drawReasonText(s.drawReason)}.` });
+      events.push({ type: "game_over", message: "The chess game ends in a draw." });
+    }
+
+    for (const e of events) record(s, e);
+    return { ok: true, state: s, events };
+  },
+
+  isTerminal(state): TerminalResult {
+    return state.status === "finished"
+      ? { done: true, ...(state.winnerSeatId ? { winnerSeatId: state.winnerSeatId } : {}) }
+      : { done: false };
+  },
+
+  describeForModel(state, seatId): ModelTurnView<ChessMove> {
+    const c = replay(state);
+    const isYourTurn = state.status !== "finished" && seatForColor(state, sideToMove(state)) === seatId;
+    const legal = isYourTurn ? c.moves({ verbose: true }) : [];
+    return {
+      boardSummary: buildBoardSummary(state, seatId, c),
+      legalMoves: legal.map(toChessMove),
+      // The runner injects ONLY boardSummary + instructions into the move prompt,
+      // so the legal SAN list must ride here or the model plays blind.
+      instructions: buildInstructions(legal.map((m) => m.san)),
+    };
+  },
+
+  spectatorSummary(state): string {
+    return buildSpectatorSummary(state);
+  },
+
+  publicView(state, viewerSeatId): ChessPublicView {
+    const c = replay(state);
+    const currentSeatId = state.status === "finished" ? null : seatForColor(state, sideToMove(state));
+    const seats: ChessPublicSeat[] = state.seats.map((s) => ({
+      seatId: s.seatId,
+      displayName: s.displayName,
+      color: colorOfSeat(state, s.seatId) ?? "white",
+      kind: s.kind,
+      isCurrent: currentSeatId === s.seatId,
+    }));
+
+    const capturedByWhite: ChessPieceLetter[] = [];
+    const capturedByBlack: ChessPieceLetter[] = [];
+    for (const m of c.history({ verbose: true })) {
+      if (!m.captured) continue;
+      if (m.color === "w") capturedByWhite.push(m.captured as ChessPieceLetter);
+      else capturedByBlack.push(m.captured as ChessPieceLetter);
+    }
+
+    const legalMovesForYou =
+      viewerSeatId && viewerSeatId === currentSeatId
+        ? c.moves({ verbose: true }).map((m) => ({
+            from: m.from as string,
+            to: m.to as string,
+            san: m.san,
+            ...(m.promotion ? { promotion: m.promotion as PromotionPiece } : {}),
+          }))
+        : [];
+
+    return {
+      gameType: "chess",
+      status: state.status,
+      fen: state.fen,
+      board: c
+        .board()
+        .map((row) => row.map((sq) => (sq ? { type: sq.type as ChessPieceLetter, color: sq.color } : null))),
+      seats,
+      currentSeatId,
+      winnerSeatId: state.winnerSeatId,
+      drawReason: state.drawReason,
+      yourSeatId: viewerSeatId,
+      yourColor: viewerSeatId ? colorOfSeat(state, viewerSeatId) : null,
+      check: state.check,
+      lastMove: state.lastMove,
+      legalMovesForYou,
+      capturedByWhite,
+      capturedByBlack,
+      sanHistory: [...state.sanHistory],
+      moveNumber: moveNumberFromFen(state.fen),
+      lastAction: state.lastAction,
+      config: state.config,
+      recentLog: state.log.slice(-8),
+    };
+  },
+
+  pickFallbackMove(state) {
+    return pickFallback(state);
+  },
+
+  toolManifests() {
+    return [...CHESS_TOOL_MANIFESTS];
+  },
+
+  parseToolCall(name, args) {
+    if (name !== "chess_move") return null;
+    const str = (v: unknown): string | undefined => (typeof v === "string" && v.trim() ? v.trim() : undefined);
+    const san = str(args.san) ?? str(args.move) ?? str(args.notation);
+    const from = str(args.from);
+    const to = str(args.to);
+    const promotionRaw = str(args.promotion)?.toLowerCase();
+    const promotion =
+      promotionRaw && ["q", "r", "b", "n"].includes(promotionRaw.charAt(0))
+        ? (promotionRaw.charAt(0) as PromotionPiece)
+        : undefined;
+    // Best-effort: an empty/garbage call still returns a move that applyMove will
+    // reject, so the runner's deterministic fallback kicks in (per the contract).
+    return {
+      type: "move",
+      ...(san ? { san } : {}),
+      ...(from ? { from } : {}),
+      ...(to ? { to } : {}),
+      ...(promotion ? { promotion } : {}),
+    };
+  },
+};

--- a/packages/shared/src/features/turn-games/chess/tools.ts
+++ b/packages/shared/src/features/turn-games/chess/tools.ts
@@ -1,0 +1,30 @@
+// ──────────────────────────────────────────────
+// Chess — model-facing move tool
+// ──────────────────────────────────────────────
+// NOT registered in the global tool registry. The runner injects this only on
+// a bot seat's turn (scoped per active game). The human never uses it — the
+// board UI posts moves to the REST endpoint directly — so the schema is tuned
+// purely for the model: a single SAN string copied verbatim from the legal-move
+// list that `describeForModel` provides.
+
+import type { ToolDefinition } from "../../function-calls/tool-definitions.js";
+
+export const chessMoveToolManifest = {
+  name: "chess_move",
+  description:
+    "Make your chess move in Standard Algebraic Notation (SAN). Copy EXACTLY one move from the legal-move list " +
+    'you were given — e.g. "e4", "Nf3", "exd5", "O-O", "e8=Q", "Qxf7#". Never invent a move that is not on the list.',
+  parameters: {
+    type: "object",
+    properties: {
+      san: {
+        type: "string",
+        description: "Your move in SAN, copied verbatim from the legal-move list.",
+      },
+    },
+    required: ["san"],
+  },
+} satisfies ToolDefinition;
+
+/** All chess tools. */
+export const CHESS_TOOL_MANIFESTS: readonly ToolDefinition[] = [chessMoveToolManifest];

--- a/packages/shared/src/features/turn-games/chess/types.ts
+++ b/packages/shared/src/features/turn-games/chess/types.ts
@@ -1,0 +1,137 @@
+// ──────────────────────────────────────────────
+// Chess — State, Moves, Config
+// ──────────────────────────────────────────────
+
+import { z } from "zod";
+import type { GameEvent } from "../engine.types.js";
+
+export type ChessColor = "white" | "black";
+export type PromotionPiece = "q" | "r" | "b" | "n";
+export type ChessPieceLetter = "p" | "n" | "b" | "r" | "q" | "k";
+
+export interface ChessConfig {
+  /** Which color the human plays. "random" resolves deterministically from the setup seed. */
+  humanColor: ChessColor | "random";
+}
+
+export type ChessDrawReason =
+  | "stalemate"
+  | "insufficient_material"
+  | "threefold_repetition"
+  | "fifty_move_rule";
+
+/**
+ * The single move type. The model proposes SAN (e.g. "Nf3", "O-O", "e8=Q");
+ * the board UI submits `from`/`to` squares (+ `promotion` when promoting).
+ * The engine tries `san` first, then falls back to `from`/`to`.
+ */
+export interface ChessMove {
+  type: "move";
+  /** Standard Algebraic Notation, e.g. "e4", "Nxf7", "O-O-O", "e8=Q+". */
+  san?: string;
+  /** Origin square in algebraic coordinates, e.g. "e2". */
+  from?: string;
+  /** Destination square, e.g. "e4". */
+  to?: string;
+  /** Piece to promote to when a pawn reaches the last rank (defaults to queen). */
+  promotion?: PromotionPiece;
+}
+
+export type ChessStatus = "active" | "finished";
+
+export interface ChessState {
+  config: ChessConfig;
+  /**
+   * Source of truth for the position. Every board-dependent method replays this
+   * from the standard start; `fen` below is strictly a cache. Replaying the full
+   * history (never rebuilding from FEN) is what keeps threefold-repetition and
+   * fifty-move detection correct.
+   */
+  sanHistory: string[];
+  /** Cached FEN of the current position (refreshed by setup/applyMove). */
+  fen: string;
+  whiteSeatId: string;
+  blackSeatId: string;
+  seatNames: Record<string, string>;
+  seats: Array<{ seatId: string; displayName: string; kind: "human" | "bot" }>;
+  status: ChessStatus;
+  /** Set on checkmate (and never for draws). */
+  winnerSeatId: string | null;
+  drawReason: ChessDrawReason | null;
+  /** Cached: the side to move is in check (refreshed by applyMove). */
+  check: boolean;
+  /** The setup seed (resolves "random" color; kept for reproducibility). */
+  seed: number;
+  lastMove: { from: string; to: string; san: string; seatId: string } | null;
+  /** A short summary of the most recent resolved action (for the board). */
+  lastAction: { seatId: string; summary: string } | null;
+  /** Capped ring buffer of recent events (newest last) for the board log. */
+  log: GameEvent[];
+  /** Plies played. */
+  moveCount: number;
+}
+
+// ── Public (per-viewer) view rendered by the client board ───────────────────
+
+export interface ChessPublicSeat {
+  seatId: string;
+  displayName: string;
+  color: ChessColor;
+  kind: "human" | "bot";
+  isCurrent: boolean;
+}
+
+export interface ChessBoardSquare {
+  type: ChessPieceLetter;
+  color: "w" | "b";
+}
+
+export interface ChessPublicView {
+  gameType: "chess";
+  status: ChessStatus;
+  fen: string;
+  /** 8×8 in chess.js `.board()` order: row 0 = rank 8, column 0 = file a. */
+  board: Array<Array<ChessBoardSquare | null>>;
+  seats: ChessPublicSeat[];
+  currentSeatId: string | null;
+  winnerSeatId: string | null;
+  drawReason: ChessDrawReason | null;
+  yourSeatId: string | null;
+  yourColor: ChessColor | null;
+  /** The side to move is in check. */
+  check: boolean;
+  lastMove: { from: string; to: string; san: string; seatId: string } | null;
+  /** Populated only when the viewer IS the current seat — drives click-to-move. */
+  legalMovesForYou: Array<{ from: string; to: string; san: string; promotion?: PromotionPiece }>;
+  /** Piece letters captured BY each color, in capture order (e.g. ["p", "p", "n"]). */
+  capturedByWhite: ChessPieceLetter[];
+  capturedByBlack: ChessPieceLetter[];
+  sanHistory: string[];
+  /** Full-move number (from the FEN). */
+  moveNumber: number;
+  lastAction: { seatId: string; summary: string } | null;
+  config: ChessConfig;
+  recentLog: GameEvent[];
+}
+
+// ── Zod schemas (validate untrusted config + move payloads at the boundary) ──
+
+export const chessConfigSchema = z.object({
+  humanColor: z.enum(["white", "black", "random"]),
+});
+
+export const chessMoveSchema: z.ZodType<ChessMove> = z.object({
+  type: z.literal("move"),
+  san: z.string().optional(),
+  from: z.string().optional(),
+  to: z.string().optional(),
+  promotion: z.enum(["q", "r", "b", "n"]).optional(),
+});
+
+export const DEFAULT_CHESS_CONFIG: ChessConfig = {
+  humanColor: "random",
+};
+
+export const CHESS_MIN_PLAYERS = 2;
+export const CHESS_MAX_PLAYERS = 2;
+export const CHESS_LOG_CAP = 24;

--- a/packages/shared/src/features/turn-games/chess/types.ts
+++ b/packages/shared/src/features/turn-games/chess/types.ts
@@ -67,8 +67,6 @@ export interface ChessState {
   lastAction: { seatId: string; summary: string } | null;
   /** Capped ring buffer of recent events (newest last) for the board log. */
   log: GameEvent[];
-  /** Plies played. */
-  moveCount: number;
 }
 
 // ── Public (per-viewer) view rendered by the client board ───────────────────

--- a/packages/shared/src/features/turn-games/registry.generated.ts
+++ b/packages/shared/src/features/turn-games/registry.generated.ts
@@ -3,8 +3,10 @@
 import type { AnyTurnGameEngine } from "./engine.types.js";
 
 import { unoGameEngine } from "./uno/engine.manifest.js";
+import { chessGameEngine } from "./chess/engine.manifest.js";
 
 export const TURN_GAME_ENGINES: readonly AnyTurnGameEngine[] = [
   unoGameEngine,
+  chessGameEngine,
 ];
 

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -73,6 +73,9 @@ export * from "./features/turn-games/registry.js";
 export * from "./features/turn-games/uno/types.js";
 export * from "./features/turn-games/uno/tools.js";
 export { unoEngine, cardLabel } from "./features/turn-games/uno/engine.js";
+export * from "./features/turn-games/chess/types.js";
+export * from "./features/turn-games/chess/tools.js";
+export { chessEngine } from "./features/turn-games/chess/engine.js";
 
 // Utils
 export * from "./utils/macro-engine.js";

--- a/packages/shared/src/types/chat.ts
+++ b/packages/shared/src/types/chat.ts
@@ -35,6 +35,7 @@ export const CONVERSATION_COMMAND_KEYS = [
   "memory",
   "scene",
   "uno",
+  "chess",
   "music",
   "haptic",
   "influence",

--- a/packages/shared/tsconfig.json
+++ b/packages/shared/tsconfig.json
@@ -5,5 +5,6 @@
     "rootDir": "./src",
     "composite": true
   },
-  "include": ["src/**/*.ts"]
+  "include": ["src/**/*.ts"],
+  "exclude": ["src/**/*.test.ts"]
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -217,6 +217,9 @@ importers:
 
   packages/shared:
     dependencies:
+      chess.js:
+        specifier: ^1.4.0
+        version: 1.4.0
       zod:
         specifier: ^3.25.76
         version: 3.25.76
@@ -2281,6 +2284,9 @@ packages:
   chalk@5.6.2:
     resolution: {integrity: sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==}
     engines: {node: ^12.17.0 || ^14.13 || >=16.0.0}
+
+  chess.js@1.4.0:
+    resolution: {integrity: sha512-BBJgrrtKQOzFLonR0l+k64A98NLemPwNsCskwb+29bRwobUa4iTm51E1kwGPbWXAcfdDa18nad6vpPPKPWarqw==}
 
   class-variance-authority@0.7.1:
     resolution: {integrity: sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg==}
@@ -6584,6 +6590,8 @@ snapshots:
       supports-color: 7.2.0
 
   chalk@5.6.2: {}
+
+  chess.js@1.4.0: {}
 
   class-variance-authority@0.7.1:
     dependencies:


### PR DESCRIPTION
## Linked issue

<!-- No prior feature request covered this; opening one retroactively to gather opinions is still worthwhile, but the work and verification are complete. -->

Closes #

_No pre-existing tracking issue. Happy to open a feature request for the record if maintainers want one linked._

## Why this change

- The turn-game framework we shipped with UNO (#2721) made a promise: adding a new game should be one folder under `packages/shared/src/features/turn-games/<game>/` implementing `TurnGameEngine`, plus a per-game client surface, with the server runner, REST routes, SSE, and persistence all staying game-agnostic. Chess is the first game built against that contract, so it doubles as a real test of whether the abstraction holds.
- It held: the server needed **zero** framework changes to run chess. The only server edits are the `[chess]` conversation command wiring, which mirrors `[uno]` exactly.
- For players, this adds a second table game to conversation mode: a one-on-one chess match against a character, who talks at the table while the system runs the board.

## What changed

- **Shared chess engine** (`packages/shared/src/features/turn-games/chess/`) implementing `TurnGameEngine`. Moves are SAN, validated by `chess.js`; the LLM proposes a move via a single `chess_move` tool and the engine falls back to a deterministic legal move if the model stalls or proposes something illegal, so a game can never wedge. `applyMove` never throws. Auto-draws (stalemate, insufficient material, threefold repetition, fifty-move) are detected from move history; there is no draw-offer handshake in this version (noted under scope below).
- **`chess.js` dependency** added to `packages/shared` only. Server and client resolve it transitively through shared and never import it directly.
- **`[chess]` conversation command**, mirroring `[uno]`: server dispatch, a natural-language launcher, a `/chess` slash command, and a settings toggle. A character that includes `[chess]` takes the opposing seat; the system runs the board.
- **Client board surface**: `ChessBoard` (hand-authored inline SVG pieces, click-to-move, promotion picker, board flip when the human plays black, check / last-move highlights, captured-piece rows), a `ChessSetup` modal (pick one opponent, choose colour), a dedicated store, and a `use-chess` hook over the existing game-agnostic `/turn-games` REST surface.
- **Turn-game framework robustness fixes** found while reviewing this work, several of which also affect UNO and are fixed for both games: guard the board stores by `gameType` so one game's view can never paint another's board; fix setup-modal lifecycle so a modal auto-closes when a game starts underneath it but can still be reopened for a rematch after a finished game; and recover a board when a state patch arrives while the chat is backgrounded (previously the board could get stuck on switch-back until resign or reload).

## Validation

- [x] `pnpm check` passes locally
- [x] Container (Docker / Podman) built and ran without issue
- [x] Ran the app, clicked through the changes manually
- [x] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [x] Above manual verification completed (describe below)
- [x] Read and followed `CONTRIBUTING.md`

### Manual verification notes

- `pnpm check` passes (TypeScript + ESLint across all three packages). Local engine + runner tests pass: engine conformance is fuzzed against a fresh `chess.js` oracle, and the bot-runner path is pinned to confirm the legal-move list is injected into the model prompt. (Those tests are local-only and not part of this diff, matching how the UNO suite is kept.)
- The production container builds and boots healthy; the built bundle serves the chess client surface.
- In-browser pass against a live model:
  - `/chess` setup modal, board render, click-to-move with legal-target dots.
  - A real game against a character: legal SAN moves land with in-character narration, castling resolves, and moves persist across a reload.
  - Board flips correctly when the human plays black, and the bot plays the opening move when it draws white.
  - Promotion picker, resign (X clears the board and ends the game), and the `[chess]` acceptance gate (only the agreeing character is seated).
  - Free-chat spectator awareness: a non-seated character can talk about the live game.
  - UNO regression: started a game after chess and played several turns — the shared SSE dispatch and the store/modal fixes behave correctly for both games. Scene banner is suppressed during an active game.

## Docs and release impact

- [x] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Version/release files updated (only if this PR includes a version bump)

<!-- No version-bearing files are touched in this PR. -->

## Scope / follow-ups

- v1 supports auto-draws only; a draw offer/accept handshake is a natural follow-up.
- A pre-existing framework race (a mount-time hydration fetch can briefly lose to an in-flight SSE patch on the singleton board stores) is noted for a separate change; it predates this branch and is not a chess regression.
