### PR TITLE
Add xAI image reference support

### DIFF
--- a/packages/server/src/services/image/image-generation.ts
+++ b/packages/server/src/services/image/image-generation.ts
@@ -785,25 +785,41 @@ async function generateOpenAI(baseUrl: string, apiKey: string, request: ImageGen
   return readOpenAIImageResult(resp, request, "generation");
 }
 
-function xAIImagesUrl(baseUrl: string): string {
-  return openAIImagesUrl(baseUrl, "generations");
+function xAIImagesUrl(baseUrl: string, endpoint: "generations" | "edits"): string {
+  return openAIImagesUrl(baseUrl, endpoint);
+}
+
+function xAIReferenceImages(request: ImageGenRequest): string[] {
+  return openAIReferenceImages(request).slice(0, 3);
+}
+
+function xAIImageInput(reference: string): { type: "image_url"; url: string } {
+  const decoded = decodeReferenceImage(reference);
+  return {
+    type: "image_url",
+    url: `data:${decoded.mimeType};base64,${decoded.base64}`,
+  };
 }
 
 async function generateXAI(baseUrl: string, apiKey: string, request: ImageGenRequest): Promise<ImageGenResult> {
-  if (request.referenceImage || request.referenceImages?.length) {
-    throw new Error("xAI image generation does not support reference images in Marinara yet.");
-  }
-
+  const references = xAIReferenceImages(request);
+  const endpoint = references.length > 0 ? "edits" : "generations";
   const body: Record<string, unknown> = {
     prompt: request.prompt,
     n: 1,
     aspect_ratio: xAIImageAspectRatio(request.width, request.height),
-    response_format: "b64_json",
   };
   if (request.model) body.model = request.model;
+  if (references.length === 0) {
+    body.response_format = "b64_json";
+  } else if (references.length === 1) {
+    body.image = xAIImageInput(references[0]!);
+  } else {
+    body.images = references.map(xAIImageInput);
+  }
 
   const resp = await imageFetch(
-    xAIImagesUrl(baseUrl),
+    xAIImagesUrl(baseUrl, endpoint),
     {
       method: "POST",
       headers: {
@@ -818,7 +834,8 @@ async function generateXAI(baseUrl: string, apiKey: string, request: ImageGenReq
 
   if (!resp.ok) {
     const errText = await resp.text().catch(() => "Unknown error");
-    throw new Error(`xAI image generation failed (${resp.status}): ${sanitizeErrorText(errText)}`);
+    const operation = endpoint === "edits" ? "edit" : "generation";
+    throw new Error(`xAI image ${operation} failed (${resp.status}): ${sanitizeErrorText(errText)}`);
   }
 
   const data = (await resp.json()) as { data?: Array<{ b64_json?: string; url?: string }> };


### PR DESCRIPTION
## Linked issue

Closes #3130

## Why this change

- xAI image generation currently does not accept reference images through Marinara's image provider path, so features that pass character or scene references cannot use xAI for reference-guided generation.

## What changed

- Reuses Marinara's existing reference-image normalization path for xAI image requests.
- Uses the xAI image edit endpoint when reference images are present.
- Keeps text-only xAI generation on the existing generation endpoint.
- Caps xAI reference inputs to three images.
- Improves error wording so xAI edit failures are distinguished from generation failures.

## Validation

- [ ] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed `CONTRIBUTING.md`

### Manual verification notes

- Ran `pnpm.cmd --filter @marinara-engine/server lint`.
- Ran `pnpm.cmd --filter @marinara-engine/shared build`.
- Ran `pnpm.cmd --filter @marinara-engine/server build`.
- `pnpm check`, container build, and live xAI reference-image generation were not run in this environment.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Version/release files updated (only if this PR includes a version bump)

No version-bearing files are touched.

## UI evidence (if applicable)

Not applicable; this is a server/provider request-shaping change.