### PR TITLE
[codex] Fix color picker drag lag and panel text clipping

### DIFF
--- a/packages/client/src/components/panels/ConnectionsPanel.tsx
+++ b/packages/client/src/components/panels/ConnectionsPanel.tsx
@@ -661,11 +661,11 @@ function ConnectionRow({
           </div>
         )}
       </button>
-      <div className="min-w-0 flex-1 pr-24">
-        <div className="truncate text-sm font-medium" title={conn.name}>
+      <div className="min-w-0 flex-1 pr-0 transition-[padding] max-md:pr-24 [@media(pointer:coarse)]:pr-24 [@media(pointer:fine)]:group-hover:pr-24">
+        <div className="truncate text-sm font-medium leading-5" title={conn.name}>
           {conn.name}
         </div>
-        <div className="truncate text-[0.6875rem] text-[var(--muted-foreground)]">
+        <div className="truncate text-[0.6875rem] leading-4 text-[var(--muted-foreground)]">
           {conn.provider} • {conn.model || "No model set"}
         </div>
       </div>

--- a/packages/client/src/components/panels/PresetsPanel.tsx
+++ b/packages/client/src/components/panels/PresetsPanel.tsx
@@ -818,20 +818,32 @@ export function PresetsPanel() {
                 </div>
               )}
             </div>
-            <div className={cn("min-w-0 flex-1", !selectionMode && "pr-32")}>
-              <div className="flex items-center gap-1.5">
-                <span className="truncate text-sm font-medium">{preset.name}</span>
+            <div
+              className={cn(
+                "min-w-0 flex-1",
+                !selectionMode &&
+                  "pr-0 transition-[padding] max-md:pr-32 [@media(pointer:coarse)]:pr-32 [@media(pointer:fine)]:group-hover:pr-32",
+              )}
+            >
+              <div className="flex min-w-0 items-center gap-1.5">
+                <span className="min-w-0 flex-1 truncate text-sm font-medium leading-5" title={preset.name}>
+                  {preset.name}
+                </span>
                 {isDefault && (
                   <span className="mari-chrome-muted-badge shrink-0 rounded px-1 py-0.5 text-[0.5625rem]">DEFAULT</span>
                 )}
               </div>
-              <div className="flex items-center gap-2 text-[0.6875rem] text-[var(--muted-foreground)]">
-                <span className="flex items-center gap-0.5">
+              <div className="flex min-w-0 items-center gap-2 text-[0.6875rem] leading-4 text-[var(--muted-foreground)]">
+                <span className="flex shrink-0 items-center gap-0.5">
                   {wrapFormat === "xml" ? <Code2 size="0.5625rem" /> : <Hash size="0.5625rem" />}
                   {wrapFormat.toUpperCase()}
                 </span>
-                <span>{sectionCount} sections</span>
-                {preset.author && <span className="truncate">by {preset.author}</span>}
+                <span className="shrink-0">{sectionCount} sections</span>
+                {preset.author && (
+                  <span className="min-w-0 truncate" title={`by ${preset.author}`}>
+                    by {preset.author}
+                  </span>
+                )}
               </div>
             </div>
           </div>

--- a/packages/client/src/components/panels/SettingsPanel.tsx
+++ b/packages/client/src/components/panels/SettingsPanel.tsx
@@ -1904,6 +1904,69 @@ function AppearanceSettings() {
   const currentGradient = convoGradient[activeGradientScheme];
   const [draftFrom, setDraftFrom] = useState(currentGradient.from);
   const [draftTo, setDraftTo] = useState(currentGradient.to);
+  const pendingGradientChangeRef = useRef<{
+    scheme: "dark" | "light";
+    field: "from" | "to";
+    value: string;
+  } | null>(null);
+  const pendingGradientFrameRef = useRef<number | null>(null);
+
+  const flushPendingGradientChange = useCallback(() => {
+    if (pendingGradientFrameRef.current !== null) {
+      window.cancelAnimationFrame(pendingGradientFrameRef.current);
+      pendingGradientFrameRef.current = null;
+    }
+
+    const pending = pendingGradientChangeRef.current;
+    pendingGradientChangeRef.current = null;
+    if (pending) {
+      setConvoGradientField(pending.scheme, pending.field, pending.value);
+    }
+  }, [setConvoGradientField]);
+
+  const cancelPendingGradientChange = useCallback(() => {
+    if (pendingGradientFrameRef.current !== null) {
+      window.cancelAnimationFrame(pendingGradientFrameRef.current);
+      pendingGradientFrameRef.current = null;
+    }
+    pendingGradientChangeRef.current = null;
+  }, []);
+
+  useEffect(
+    () => () => {
+      flushPendingGradientChange();
+    },
+    [flushPendingGradientChange],
+  );
+
+  const commitConvoGradientField = useCallback(
+    (scheme: "dark" | "light", field: "from" | "to", value: string, defer = false) => {
+      if (!defer) {
+        cancelPendingGradientChange();
+        setConvoGradientField(scheme, field, value);
+        return;
+      }
+
+      pendingGradientChangeRef.current = { scheme, field, value };
+      if (pendingGradientFrameRef.current !== null) return;
+      pendingGradientFrameRef.current = window.requestAnimationFrame(() => {
+        pendingGradientFrameRef.current = null;
+        const pending = pendingGradientChangeRef.current;
+        pendingGradientChangeRef.current = null;
+        if (pending) {
+          setConvoGradientField(pending.scheme, pending.field, pending.value);
+        }
+      });
+    },
+    [cancelPendingGradientChange, setConvoGradientField],
+  );
+
+  const handleGradientColorInput = useCallback(
+    (field: "from" | "to", value: string) => {
+      commitConvoGradientField(activeGradientScheme, field, value, true);
+    },
+    [activeGradientScheme, commitConvoGradientField],
+  );
 
   // Sync draft inputs when switching between scheme tabs so the text fields
   // always reflect the stored value for the active scheme.
@@ -2815,10 +2878,11 @@ function AppearanceSettings() {
                   <input
                     type="color"
                     value={currentGradient.from}
-                    onChange={(e) => {
-                      setConvoGradientField(activeGradientScheme, "from", e.target.value);
-                      setDraftFrom(e.target.value);
-                    }}
+                    onInput={(e) => handleGradientColorInput("from", e.currentTarget.value)}
+                    onChange={(e) => handleGradientColorInput("from", e.currentTarget.value)}
+                    onBlur={flushPendingGradientChange}
+                    onPointerUp={flushPendingGradientChange}
+                    onKeyUp={flushPendingGradientChange}
                     className="h-8 w-8 flex-shrink-0 cursor-pointer rounded-md border border-[var(--border)] bg-transparent p-0.5"
                   />
                   <input
@@ -2827,7 +2891,7 @@ function AppearanceSettings() {
                     onChange={(e) => {
                       setDraftFrom(e.target.value);
                       if (/^#[0-9a-fA-F]{6}$/.test(e.target.value))
-                        setConvoGradientField(activeGradientScheme, "from", e.target.value);
+                        commitConvoGradientField(activeGradientScheme, "from", e.target.value);
                     }}
                     onBlur={() => setDraftFrom(currentGradient.from)}
                     className="w-full rounded-md bg-[var(--secondary)] px-2 py-1.5 text-xs outline-none ring-1 ring-transparent transition-shadow focus:ring-[var(--primary)]/40"
@@ -2839,10 +2903,11 @@ function AppearanceSettings() {
                   <input
                     type="color"
                     value={currentGradient.to}
-                    onChange={(e) => {
-                      setConvoGradientField(activeGradientScheme, "to", e.target.value);
-                      setDraftTo(e.target.value);
-                    }}
+                    onInput={(e) => handleGradientColorInput("to", e.currentTarget.value)}
+                    onChange={(e) => handleGradientColorInput("to", e.currentTarget.value)}
+                    onBlur={flushPendingGradientChange}
+                    onPointerUp={flushPendingGradientChange}
+                    onKeyUp={flushPendingGradientChange}
                     className="h-8 w-8 flex-shrink-0 cursor-pointer rounded-md border border-[var(--border)] bg-transparent p-0.5"
                   />
                   <input
@@ -2851,7 +2916,7 @@ function AppearanceSettings() {
                     onChange={(e) => {
                       setDraftTo(e.target.value);
                       if (/^#[0-9a-fA-F]{6}$/.test(e.target.value))
-                        setConvoGradientField(activeGradientScheme, "to", e.target.value);
+                        commitConvoGradientField(activeGradientScheme, "to", e.target.value);
                     }}
                     onBlur={() => setDraftTo(currentGradient.to)}
                     className="w-full rounded-md bg-[var(--secondary)] px-2 py-1.5 text-xs outline-none ring-1 ring-transparent transition-shadow focus:ring-[var(--primary)]/40"
@@ -2866,8 +2931,8 @@ function AppearanceSettings() {
                   activeGradientScheme === "dark"
                     ? { from: "#0a0a0e", to: "#1c2133" }
                     : { from: "#f2eff7", to: "#eae6f0" };
-                setConvoGradientField(activeGradientScheme, "from", defaults.from);
-                setConvoGradientField(activeGradientScheme, "to", defaults.to);
+                commitConvoGradientField(activeGradientScheme, "from", defaults.from);
+                commitConvoGradientField(activeGradientScheme, "to", defaults.to);
                 setDraftFrom(defaults.from);
                 setDraftTo(defaults.to);
               }}

--- a/packages/client/src/components/ui/ColorPicker.tsx
+++ b/packages/client/src/components/ui/ColorPicker.tsx
@@ -110,6 +110,9 @@ export function ColorPicker({
   const [expanded, setExpanded] = useState(false);
   const nativeRef = useRef<HTMLInputElement>(null);
   const activeStopRef = useRef<number>(0);
+  const onChangeRef = useRef(onChange);
+  const pendingChangeRef = useRef<string | null>(null);
+  const pendingFrameRef = useRef<number | null>(null);
 
   // Sync value → local state when value changes externally
   useEffect(() => {
@@ -129,57 +132,100 @@ export function ColorPicker({
     }
   }, [disabled]);
 
-  const handleSolidChange = useCallback(
-    (color: string) => {
-      onChange(color);
+  useEffect(() => {
+    onChangeRef.current = onChange;
+  }, [onChange]);
+
+  const flushPendingChange = useCallback(() => {
+    if (pendingFrameRef.current !== null) {
+      window.cancelAnimationFrame(pendingFrameRef.current);
+      pendingFrameRef.current = null;
+    }
+    const pending = pendingChangeRef.current;
+    pendingChangeRef.current = null;
+    if (pending !== null) {
+      onChangeRef.current(pending);
+    }
+  }, []);
+
+  const cancelPendingChange = useCallback(() => {
+    if (pendingFrameRef.current !== null) {
+      window.cancelAnimationFrame(pendingFrameRef.current);
+      pendingFrameRef.current = null;
+    }
+    pendingChangeRef.current = null;
+  }, []);
+
+  useEffect(
+    () => () => {
+      flushPendingChange();
     },
-    [onChange],
+    [flushPendingChange],
+  );
+
+  const commitChange = useCallback((nextValue: string, defer = false) => {
+    if (!defer) {
+      cancelPendingChange();
+      onChangeRef.current(nextValue);
+      return;
+    }
+
+    pendingChangeRef.current = nextValue;
+    if (pendingFrameRef.current !== null) return;
+    pendingFrameRef.current = window.requestAnimationFrame(() => {
+      pendingFrameRef.current = null;
+      const pending = pendingChangeRef.current;
+      pendingChangeRef.current = null;
+      if (pending !== null) {
+        onChangeRef.current(pending);
+      }
+    });
+  }, [cancelPendingChange]);
+
+  const handleSolidChange = useCallback(
+    (color: string, defer = false) => {
+      commitChange(color, defer);
+    },
+    [commitChange],
   );
 
   const handleGradientStopChange = useCallback(
-    (index: number, color: string) => {
-      setGradientStops((prev) => {
-        const updated = [...prev];
-        updated[index] = color;
-        onChange(buildGradient(gradientAngle, updated));
-        return updated;
-      });
+    (index: number, color: string, defer = false) => {
+      const updated = gradientStops.map((stop, i) => (i === index ? color : stop));
+      setGradientStops(updated);
+      commitChange(buildGradient(gradientAngle, updated), defer);
     },
-    [onChange, gradientAngle],
+    [commitChange, gradientAngle, gradientStops],
   );
 
   const addStop = useCallback(() => {
-    setGradientStops((prev) => {
-      const updated = [...prev, "#ffffff"];
-      onChange(buildGradient(gradientAngle, updated));
-      return updated;
-    });
-  }, [onChange, gradientAngle]);
+    const updated = [...gradientStops, "#ffffff"];
+    setGradientStops(updated);
+    commitChange(buildGradient(gradientAngle, updated));
+  }, [commitChange, gradientAngle, gradientStops]);
 
   const removeStop = useCallback(
     (index: number) => {
       if (gradientStops.length <= 2) return;
-      setGradientStops((prev) => {
-        const updated = prev.filter((_, i) => i !== index);
-        onChange(buildGradient(gradientAngle, updated));
-        return updated;
-      });
+      const updated = gradientStops.filter((_, i) => i !== index);
+      setGradientStops(updated);
+      commitChange(buildGradient(gradientAngle, updated));
     },
-    [onChange, gradientAngle, gradientStops.length],
+    [commitChange, gradientAngle, gradientStops],
   );
 
   const handleAngleChange = useCallback(
-    (angle: number) => {
+    (angle: number, defer = false) => {
       setGradientAngle(angle);
-      onChange(buildGradient(angle, gradientStops));
+      commitChange(buildGradient(angle, gradientStops), defer);
     },
-    [onChange, gradientStops],
+    [commitChange, gradientStops],
   );
 
   const clearColor = useCallback(() => {
-    onChange(clearValue);
+    commitChange(clearValue);
     setExpanded(false);
-  }, [clearValue, onChange]);
+  }, [clearValue, commitChange]);
 
   const previewValue = value || emptyPreviewValue;
   const showClear = clearValue ? value !== clearValue : !!value;
@@ -306,7 +352,9 @@ export function ColorPicker({
                     type="color"
                     aria-label={`Pick ${label} color`}
                     value={!isCssGradient(previewValue) ? getNativeColorValue(previewValue) : "#6c5ce7"}
-                    onChange={(e) => handleSolidChange(e.target.value)}
+                    onInput={(e) => handleSolidChange(e.currentTarget.value, true)}
+                    onChange={(e) => handleSolidChange(e.currentTarget.value, true)}
+                    onBlur={flushPendingChange}
                     className="absolute inset-0 h-full w-full cursor-pointer opacity-0"
                   />
                 </label>
@@ -371,10 +419,15 @@ export function ColorPicker({
                     <input
                       type="color"
                       value={stop}
+                      onInput={(e) => {
+                        activeStopRef.current = i;
+                        handleGradientStopChange(i, e.currentTarget.value, true);
+                      }}
                       onChange={(e) => {
                         activeStopRef.current = i;
-                        handleGradientStopChange(i, e.target.value);
+                        handleGradientStopChange(i, e.currentTarget.value, true);
                       }}
+                      onBlur={flushPendingChange}
                       className="h-7 w-7 cursor-pointer rounded-md border-0 bg-transparent p-0"
                     />
                     <input
@@ -409,7 +462,10 @@ export function ColorPicker({
                   min={0}
                   max={360}
                   value={gradientAngle}
-                  onChange={(e) => handleAngleChange(parseInt(e.target.value))}
+                  onChange={(e) => handleAngleChange(parseInt(e.target.value), true)}
+                  onPointerUp={flushPendingChange}
+                  onKeyUp={flushPendingChange}
+                  onBlur={flushPendingChange}
                   className="h-1.5 w-full cursor-pointer accent-[var(--primary)]"
                 />
               </div>


### PR DESCRIPTION
## Summary

- Coalesce high-frequency native color picker, gradient-stop, and angle-slider updates through `requestAnimationFrame` so drag operations do not flood React/global settings updates.
- Apply the same frame-coalesced path to the Appearance conversation-gradient swatches, while keeping typed hex values and reset actions immediate.
- Let Presets and Connections rows reserve action-button space only on touch or hover, and add explicit line-height/truncation so text ellipsizes instead of being visually clipped.

## Root Cause

Color picker drag events could fire many updates in a tight burst, including global UI store writes for Appearance gradients and parent callbacks from reusable color pickers. Presets and Connections also permanently reserved action-button padding on narrow rows, leaving too little room for text and making existing truncation look like clipping.

Fixes #3147
Fixes #3148

## Validation

- `pnpm --filter @marinara-engine/client lint`
- `pnpm check`
- Headless browser stress test: dispatched 180 rapid Appearance swatch updates; final color persisted, app stayed mounted, no page or console errors.
- Headless browser mobile layout pass: Presets and Connections visible rows reported 0 vertical clipping and 0 unexpected horizontal overflow.

## Manual Verification Needed

- [ ] Manually drag Appearance conversation-gradient color pickers in Chrome/Opera on Windows and confirm there is no severe lag or React crash.
- [ ] Manually verify Presets text on the reporter's Windows/browser layout.
- [ ] Manually verify Connections text on the reporter's Windows/browser layout.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved the appearance editor so color and gradient changes feel smoother while adjusting values.
  * Updated list rows for connections and presets with better responsive spacing and clearer truncated text.

* **Bug Fixes**
  * Reduced visual jank when editing theme colors and gradients by applying changes more consistently during interaction.
  * Improved labels and tooltips so long names and authors remain readable without breaking layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->