### PR TITLE
[codex] Prepare v2.1.0 release metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,25 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 
 ## [Unreleased]
 
+## [2.1.0]
+
+### Changed
+
+- Bumped release metadata to v2.1.0 across packages, the PWA manifest, README release pointer, Windows installer sources, Android APK metadata, and the home-page-visible app version.
+- Made Android/Termux update builds use low-memory build wrappers: server builds transpile runtime JS with esbuild, client builds skip memory-heavy typechecking/PWA generation on Android, and the updater builds shared, server, and client sequentially on Android devices (#3156).
+
+### Fixed
+
+- Fixed Android/Termux git updates aborting during release rebuilds with exit status 134 by making the default package build scripts Android-aware and documenting the low-memory update path (#3156).
+- Fixed `pnpm install --frozen-lockfile` failures with `ERR_PNPM_TRUST_DOWNGRADE` for older locked dependencies such as `pino` and `semver` by disabling trust-downgrade enforcement for released Marinara installs.
+- Fixed partial installs after aborted pnpm runs so launchers detect missing workspace dependencies such as `chess.js` and repair `node_modules` before shared builds run.
+- Fixed non-interactive launcher, installer, and in-app updater installs so pnpm can purge and recreate stale dependency folders without stopping for a TTY confirmation prompt.
+
+### Platform Notes
+
+- Android `versionName` is `2.1.0` with `versionCode 29`.
+- Windows, macOS/Linux, Termux, Docker, APK, and PWA users can update through the usual v2 updater paths once release assets are published.
+
 ## [2.0.9]
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@
 
 ## Latest Release
 
-Current stable release: **[v2.0.9](https://github.com/Pasta-Devs/Marinara-Engine/releases/tag/v2.0.9)**.
+Current stable release: **[v2.1.0](https://github.com/Pasta-Devs/Marinara-Engine/releases/tag/v2.1.0)**.
 
 See [CHANGELOG.md](CHANGELOG.md) for detailed release notes. Tagged releases use the `vX.Y.Z` format and are published on the [Releases](https://github.com/Pasta-Devs/Marinara-Engine/releases) page. Android APKs are Termux bootstrap + WebView shells: they can download Termux from F-Droid, launch Android's installer, start the Termux setup flow after required permission prompts, then open the local Marinara server on the same device.
 

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -22,10 +22,10 @@ android {
         applicationId "com.marinara.engine"
         minSdk 24
         targetSdk 34
-        versionCode 28
-        versionName "2.0.9"
+        versionCode 29
+        versionName "2.1.0"
         buildConfigField "String", "MARINARA_SERVER_URL", "\"http://127.0.0.1:${marinaraPort}\""
-        buildConfigField "String", "MARINARA_RELEASE_TAG", "\"v2.0.9\""
+        buildConfigField "String", "MARINARA_RELEASE_TAG", "\"v2.1.0\""
     }
 
     signingConfigs {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "marinara-engine",
-  "version": "2.0.9",
+  "version": "2.1.0",
   "private": true,
   "description": "AI Chat & Roleplay Frontend — Conversation, Roleplay, Visual Novel",
   "author": "Marianna",

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@marinara-engine/client",
   "private": true,
-  "version": "2.0.9",
+  "version": "2.1.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/packages/client/public/manifest.json
+++ b/packages/client/public/manifest.json
@@ -2,7 +2,7 @@
   "name": "Marinara Engine",
   "short_name": "Marinara",
   "description": "AI Chat & Roleplay Frontend — Conversation, Roleplay, Visual Novel",
-  "version": "2.0.9",
+  "version": "2.1.0",
   "start_url": "/",
   "display": "standalone",
   "background_color": "#0a0a0f",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@marinara-engine/server",
-  "version": "2.0.9",
+  "version": "2.1.0",
   "private": true,
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@marinara-engine/shared",
-  "version": "2.0.9",
+  "version": "2.1.0",
   "private": true,
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/shared/src/constants/defaults.ts
+++ b/packages/shared/src/constants/defaults.ts
@@ -4,7 +4,7 @@
 import type { GenerationParameters } from "../types/prompt.js";
 
 /** App version — single source of truth. */
-export const APP_VERSION = "2.0.9";
+export const APP_VERSION = "2.1.0";
 
 /** Stable synthetic connection id for the built-in local llama sidecar. */
 export const LOCAL_SIDECAR_CONNECTION_ID = "__local_sidecar__";

--- a/win/installer/install.bat
+++ b/win/installer/install.bat
@@ -11,14 +11,14 @@ set "NODE_DOWNLOAD_URL=https://nodejs.org/dist/v24.15.0/node-v24.15.0-x64.msi"
 set "NODE_SHA256=feffb8e5cb5ac47f793666636d496ef3e975be82c84c4da5d20e6aa8fa4eb806"
 set "GIT_DOWNLOAD_URL=https://github.com/git-for-windows/git/releases/download/v2.54.0.windows.1/Git-2.54.0-64-bit.exe"
 set "GIT_SHA256=2b96e7854f0520f0f6b709c21041d9801b1be44d5e1a0d9fa621b2fbc40f1983"
-set "RELEASE_TAG=v2.0.9"
+set "RELEASE_TAG=v2.1.0"
 if not defined MARINARA_RELEASE_COMMIT set "MARINARA_RELEASE_COMMIT="
 set "RELEASE_COMMIT=%MARINARA_RELEASE_COMMIT%"
 
 echo.
 echo  +==========================================+
 echo  ^|   Marinara Engine - Windows Installer     ^|
-echo  ^|   v2.0.9                                  ^|
+echo  ^|   v2.1.0                                  ^|
 
 echo  +==========================================+
 echo.

--- a/win/installer/installer.nsi
+++ b/win/installer/installer.nsi
@@ -13,7 +13,7 @@
 
 ; ── App metadata ──
 !define APP_NAME "Marinara Engine"
-!define APP_VERSION "2.0.9"
+!define APP_VERSION "2.1.0"
 !define APP_PUBLISHER "Pasta-Devs"
 !define APP_URL "https://github.com/Pasta-Devs/Marinara-Engine"
 !define REPO_URL "https://github.com/Pasta-Devs/Marinara-Engine.git"
@@ -27,7 +27,7 @@
 !define NODE_DOWNLOAD_URL "https://nodejs.org/dist/v24.15.0/node-v24.15.0-x64.msi"
 !define GIT_SHA256 "2b96e7854f0520f0f6b709c21041d9801b1be44d5e1a0d9fa621b2fbc40f1983"
 !define NODE_SHA256 "feffb8e5cb5ac47f793666636d496ef3e975be82c84c4da5d20e6aa8fa4eb806"
-!define RELEASE_TAG "v2.0.9"
+!define RELEASE_TAG "v2.1.0"
 !ifndef RELEASE_COMMIT
 !define RELEASE_COMMIT ""
 !endif


### PR DESCRIPTION
## Linked issue

- No linked issue; maintainer-requested release prep.

## Why this change

- v2.0.9 needs to move forward to v2.1.0 after the update/install recovery fixes landed on staging.
- Release-facing version metadata should stay synchronized across packages, installers, Android, README, PWA manifest, shared `APP_VERSION`, and the home-page-visible version label.
- The changelog needs the new v2.1.0 entries before release assets are prepared.

## What changed

- Bumped the canonical package version from `2.0.9` to `2.1.0` and synced derived version files.
- Incremented Android `versionCode` from `28` to `29`, with `versionName` and release tag set to `2.1.0` / `v2.1.0`.
- Updated the README latest-release pointer and PWA manifest version.
- Added `CHANGELOG.md` notes for v2.1.0 covering Termux low-memory update builds, pnpm trust downgrade install recovery, partial install repair, and platform notes.

## Validation

- [ ] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed `CONTRIBUTING.md`

### Manual verification notes

- `pnpm version:sync -- --android-version-code 29`
- `pnpm version:check`
- `rg -n "2\.0\.9|v2\.0\.9" package.json packages/client/package.json packages/server/package.json packages/shared/package.json packages/client/public/manifest.json packages/shared/src/constants/defaults.ts win/installer/installer.nsi win/installer/install.bat android/app/build.gradle README.md`
- `rg -n "2\.1\.0|v2\.1\.0|versionCode 29|APP_VERSION" package.json packages/client/package.json packages/server/package.json packages/shared/package.json packages/client/public/manifest.json packages/shared/src/constants/defaults.ts win/installer/installer.nsi win/installer/install.bat android/app/build.gradle README.md CHANGELOG.md packages/client/src/components/chat/ChatArea.tsx`
- `pnpm check`
- `git diff --check`

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Version/release files updated (only if this PR includes a version bump)

## UI evidence (if applicable)

- Not applicable; the home screen reads `v{APP_VERSION}` from `packages/shared/src/constants/defaults.ts`, which is included in the version sync.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changed**
  * Updated app and package versions to **2.1.0** across desktop, mobile, server, and shared components.
  * Refreshed release labels in the app, README, and installers to match the new version.
  * Android build metadata now reflects the new release number and version code.

* **Fixed**
  * Improved update and install reliability in edge cases, including interrupted rebuilds, partial installs, and non-interactive environments.
  * Android/Termux update behavior has been adjusted for lower-memory devices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->