### PR TITLE
feat: Agent Suite — view and edit stored agent data (manual + AI-assisted)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 
 ### Added
 
-- Added the Agent Suite to the Chat Settings drawer's Agents section: a window listing the agents active in the current chat where you can view and edit everything they have stored — agent memory, tracker state, and custom-agent outputs — manually or with AI-assisted rewrites (select text, give an instruction, pick a connection) (#3160).
+- Added the Agent Suite to the Chat Settings drawer's Agents section: a window listing the agents active in the current chat where you can view and edit everything they have stored — agent memory, tracker state, and custom-agent outputs — manually or with AI-assisted rewrites (select text, give an instruction, optionally attach grounding context such as character cards or active-lorebook entries, and pick a connection) (#3160).
 
 ## [2.1.0]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 
 ## [Unreleased]
 
+### Added
+
+- Added the Agent Suite to the Chat Settings drawer's Agents section: a window listing the agents active in the current chat where you can view and edit everything they have stored — agent memory, tracker state, and custom-agent outputs — manually or with AI-assisted rewrites (select text, give an instruction, pick a connection) (#3160).
+
 ## [2.1.0]
 
 ### Changed

--- a/packages/client/src/App.tsx
+++ b/packages/client/src/App.tsx
@@ -903,6 +903,10 @@ export function App() {
       <AppDialogRenderer />
       <CsrfOriginWarningBanner />
       <div
+        // Interacting with a toast (including its close button) must not count
+        // as an outside click for chat floating panels — otherwise dismissing
+        // a toast closes the settings/gallery drawer (and any modal inside it).
+        data-chat-floating-panel
         onClickCapture={(event) => {
           if (!(event.target instanceof Element)) return;
           if (event.target.closest("[data-close-button],button[aria-label^='Close'],button[aria-label^='Dismiss']")) {

--- a/packages/client/src/components/agents/SecretPlotPanel.tsx
+++ b/packages/client/src/components/agents/SecretPlotPanel.tsx
@@ -1,8 +1,9 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Check, ChevronDown, Eye, EyeOff, RefreshCw, Save } from "lucide-react";
-import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
 import type { Message } from "@marinara-engine/shared";
+import { agentKeys, useAgentMemory } from "../../hooks/use-agents";
 import { useGenerate } from "../../hooks/use-generate";
 import { api } from "../../lib/api-client";
 import { showConfirmDialog } from "../../lib/app-dialogs";
@@ -75,13 +76,10 @@ export function SecretPlotPanel({
   const draftRef = useRef<SecretPlotDraft | null>(null);
   const savedFingerprintRef = useRef<string | null>(null);
 
-  const queryKey = useMemo(() => ["agent-memory", AGENT_TYPE, chatId ?? ""] as const, [chatId]);
-  const { data, isLoading, isError, refetch } = useQuery({
-    queryKey,
-    enabled: !!chatId,
-    queryFn: async () =>
-      api.get<{ agentConfigId: string; memory: Record<string, unknown> }>(`/agents/memory/${AGENT_TYPE}/${chatId}`),
-  });
+  // Shared hook so this key has exactly one queryFn cache-wide (the Agent
+  // Suite modal reads the same key; two different queryFns would race).
+  const queryKey = useMemo(() => agentKeys.memory(AGENT_TYPE, chatId ?? ""), [chatId]);
+  const { data, isLoading, isError, refetch } = useAgentMemory(AGENT_TYPE, chatId);
 
   const target = useMemo(() => findLastAssistant(messages), [messages]);
   const draftSignature = useMemo(() => (draft ? draftFingerprint(draft) : null), [draft]);

--- a/packages/client/src/components/agents/SecretPlotPanel.tsx
+++ b/packages/client/src/components/agents/SecretPlotPanel.tsx
@@ -3,9 +3,8 @@ import { Check, ChevronDown, Eye, EyeOff, RefreshCw, Save } from "lucide-react";
 import { useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
 import type { Message } from "@marinara-engine/shared";
-import { agentKeys, useAgentMemory } from "../../hooks/use-agents";
+import { agentKeys, useAgentMemory, useUpdateAgentMemory } from "../../hooks/use-agents";
 import { useGenerate } from "../../hooks/use-generate";
-import { api } from "../../lib/api-client";
 import { showConfirmDialog } from "../../lib/app-dialogs";
 import { cn } from "../../lib/utils";
 import { HelpTooltip } from "../ui/HelpTooltip";
@@ -80,6 +79,7 @@ export function SecretPlotPanel({
   // Suite modal reads the same key; two different queryFns would race).
   const queryKey = useMemo(() => agentKeys.memory(AGENT_TYPE, chatId ?? ""), [chatId]);
   const { data, isLoading, isError, refetch } = useAgentMemory(AGENT_TYPE, chatId);
+  const updateMemory = useUpdateAgentMemory();
 
   const target = useMemo(() => findLastAssistant(messages), [messages]);
   const draftSignature = useMemo(() => (draft ? draftFingerprint(draft) : null), [draft]);
@@ -133,10 +133,9 @@ export function SecretPlotPanel({
   const patchMemory = useCallback(
     async (patch: Record<string, unknown>) => {
       if (!chatId) return;
-      await api.patch<{ memory: Record<string, unknown> }>(`/agents/memory/${AGENT_TYPE}/${chatId}`, { patch });
-      await qc.invalidateQueries({ queryKey });
+      await updateMemory.mutateAsync({ agentType: AGENT_TYPE, chatId, patch });
     },
-    [chatId, qc, queryKey],
+    [chatId, updateMemory],
   );
 
   const handleSave = useCallback(async () => {

--- a/packages/client/src/components/chat/AgentSuiteModal.tsx
+++ b/packages/client/src/components/chat/AgentSuiteModal.tsx
@@ -1,0 +1,722 @@
+// ──────────────────────────────────────────────
+// Agent Suite — view and edit everything the agents in the
+// active chat have stored (memory, tracker state, custom
+// outputs), manually or via AI-assisted selection rewrites.
+// ──────────────────────────────────────────────
+import { useCallback, useMemo, useRef, useState } from "react";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { AlertTriangle, Bot, Eye, EyeOff, Loader2, RotateCcw, Save, Trash2, Wand2 } from "lucide-react";
+import { toast } from "sonner";
+import type { Chat, GameState, PlayerStats } from "@marinara-engine/shared";
+import {
+  useAgentMemory,
+  useAgentSuiteRewrite,
+  useCustomAgentRuns,
+  useUpdateAgentMemory,
+  useUpdateAgentRunData,
+  agentKeys,
+  type AgentRunRow,
+} from "../../hooks/use-agents";
+import { useConnections } from "../../hooks/use-connections";
+import { api } from "../../lib/api-client";
+import { showConfirmDialog } from "../../lib/app-dialogs";
+import { filterLanguageGenerationConnections } from "../../lib/connection-filters";
+import { cn } from "../../lib/utils";
+import { useAgentStore } from "../../stores/agent.store";
+import { useChatStore } from "../../stores/chat.store";
+import { useGameStateStore } from "../../stores/game-state.store";
+import { Modal } from "../ui/Modal";
+
+export interface AgentSuiteAgent {
+  id: string;
+  name: string;
+  description: string;
+  category: string;
+  builtIn: boolean;
+}
+
+interface AgentSuiteModalProps {
+  chat: Chat;
+  open: boolean;
+  onClose: () => void;
+  agents: AgentSuiteAgent[];
+}
+
+type ConnectionOption = {
+  id: string;
+  name: string;
+  model?: string | null;
+  provider?: string | null;
+  defaultForAgents?: boolean | string | null;
+};
+
+const MAX_REWRITE_SELECTION_CHARS = 50000;
+const MAX_REWRITE_DOCUMENT_CHARS = 100000;
+
+const CATEGORY_LABELS: Record<string, string> = {
+  writer: "Writer",
+  tracker: "Tracker",
+  misc: "Misc",
+  custom: "Custom",
+};
+
+function createEmptyPlayerStats(): PlayerStats {
+  return {
+    stats: [],
+    attributes: null,
+    skills: {},
+    inventory: [],
+    activeQuests: [],
+    status: "",
+  };
+}
+
+/** Per-tracker-agent slice of the latest game-state snapshot. */
+const TRACKER_SLICES: Record<
+  string,
+  {
+    label: string;
+    description: string;
+    getValue: (gs: GameState) => unknown;
+    buildPatch: (gs: GameState, parsed: unknown) => Record<string, unknown> | { error: string };
+  }
+> = {
+  "world-state": {
+    label: "Scene",
+    description: "Date, time, location, weather, and temperature of the current scene.",
+    getValue: (gs) => ({
+      date: gs.date,
+      time: gs.time,
+      location: gs.location,
+      weather: gs.weather,
+      temperature: gs.temperature,
+    }),
+    buildPatch: (_gs, parsed) => {
+      if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+        return { error: "Scene data must be a JSON object" };
+      }
+      const record = parsed as Record<string, unknown>;
+      return {
+        date: record.date ?? null,
+        time: record.time ?? null,
+        location: record.location ?? null,
+        weather: record.weather ?? null,
+        temperature: record.temperature ?? null,
+      };
+    },
+  },
+  "character-tracker": {
+    label: "Present Characters",
+    description: "Characters in the current scene with mood, appearance, outfit, and thoughts.",
+    getValue: (gs) => gs.presentCharacters ?? [],
+    buildPatch: (_gs, parsed) =>
+      Array.isArray(parsed) ? { presentCharacters: parsed } : { error: "Present characters must be a JSON array" },
+  },
+  "persona-stats": {
+    label: "Persona Stats",
+    description: "Your persona's status bars (satiety, energy, etc.).",
+    getValue: (gs) => gs.personaStats ?? [],
+    buildPatch: (_gs, parsed) =>
+      Array.isArray(parsed) ? { personaStats: parsed } : { error: "Persona stats must be a JSON array" },
+  },
+  "custom-tracker": {
+    label: "Custom Tracker Fields",
+    description: "User-defined tracker fields maintained by the Custom Tracker agent.",
+    getValue: (gs) => gs.playerStats?.customTrackerFields ?? [],
+    buildPatch: (gs, parsed) =>
+      Array.isArray(parsed)
+        ? { playerStats: { ...(gs.playerStats ?? createEmptyPlayerStats()), customTrackerFields: parsed } }
+        : { error: "Custom tracker fields must be a JSON array" },
+  },
+  quest: {
+    label: "Active Quests",
+    description: "Quest progress tracked for this chat.",
+    getValue: (gs) => gs.playerStats?.activeQuests ?? [],
+    buildPatch: (gs, parsed) =>
+      Array.isArray(parsed)
+        ? { playerStats: { ...(gs.playerStats ?? createEmptyPlayerStats()), activeQuests: parsed } }
+        : { error: "Active quests must be a JSON array" },
+  },
+};
+
+function serializeValue(value: unknown, mode: "text" | "json"): string {
+  if (mode === "text") return typeof value === "string" ? value : String(value ?? "");
+  return JSON.stringify(value ?? null, null, 2);
+}
+
+function formatRunTimestamp(value: string): string {
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return "";
+  return date.toLocaleString([], { month: "short", day: "numeric", hour: "2-digit", minute: "2-digit" });
+}
+
+// ── Editable data block with AI-assisted selection rewrite ──
+
+interface DataBlockProps {
+  label: string;
+  description?: string;
+  mode: "text" | "json";
+  value: string;
+  onSave: (draft: string) => Promise<void>;
+  disabled: boolean;
+  agentName: string;
+  connectionOptions: ConnectionOption[];
+  rewriteConnectionId: string;
+  onRewriteConnectionChange: (id: string) => void;
+}
+
+function DataBlock({
+  label,
+  description,
+  mode,
+  value,
+  onSave,
+  disabled,
+  agentName,
+  connectionOptions,
+  rewriteConnectionId,
+  onRewriteConnectionChange,
+}: DataBlockProps) {
+  const rewrite = useAgentSuiteRewrite();
+
+  // draft === null means pristine: the textarea mirrors the server value and
+  // silently follows refetches. Any edit detaches it until Save or Reset.
+  const [draft, setDraft] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [saving, setSaving] = useState(false);
+  const [aiOpen, setAiOpen] = useState(false);
+  const [instruction, setInstruction] = useState("");
+  const [selection, setSelection] = useState<{ start: number; end: number } | null>(null);
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+
+  const currentText = draft ?? value;
+  const isDirty = draft !== null && draft !== value;
+
+  const captureSelection = useCallback(() => {
+    const el = textareaRef.current;
+    if (!el) return;
+    setSelection(el.selectionStart !== el.selectionEnd ? { start: el.selectionStart, end: el.selectionEnd } : null);
+  }, []);
+
+  const handleSave = useCallback(async () => {
+    if (!isDirty || saving) return;
+    if (mode === "json") {
+      try {
+        JSON.parse(currentText);
+      } catch (err) {
+        setError(err instanceof Error ? `Invalid JSON: ${err.message}` : "Invalid JSON");
+        return;
+      }
+    }
+    setError(null);
+    setSaving(true);
+    try {
+      await onSave(currentText);
+      setDraft(null);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to save");
+    } finally {
+      setSaving(false);
+    }
+  }, [currentText, isDirty, mode, onSave, saving]);
+
+  const handleRewrite = useCallback(async () => {
+    if (rewrite.isPending || !instruction.trim() || !rewriteConnectionId) return;
+    const text = currentText;
+    const clamped =
+      selection && selection.start < selection.end && selection.end <= text.length
+        ? { start: selection.start, end: selection.end }
+        : null;
+    const selectedText = clamped ? text.slice(clamped.start, clamped.end) : text;
+    if (!selectedText.trim()) {
+      setError("There is no text to rewrite");
+      return;
+    }
+    if (selectedText.length > MAX_REWRITE_SELECTION_CHARS) {
+      setError(`Selection too large for AI rewrite (max ${MAX_REWRITE_SELECTION_CHARS.toLocaleString()} characters)`);
+      return;
+    }
+    setError(null);
+    try {
+      const result = await rewrite.mutateAsync({
+        connectionId: rewriteConnectionId,
+        instruction: instruction.trim(),
+        selectedText,
+        documentText: clamped && text.length <= MAX_REWRITE_DOCUMENT_CHARS ? text : undefined,
+        agentName,
+        dataLabel: label,
+      });
+      const next = clamped
+        ? text.slice(0, clamped.start) + result.rewrittenText + text.slice(clamped.end)
+        : result.rewrittenText;
+      setDraft(next);
+      setSelection(null);
+      toast.success("AI rewrite applied to the draft — review and save");
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "AI rewrite failed");
+    }
+  }, [agentName, currentText, instruction, label, rewrite, rewriteConnectionId, selection]);
+
+  return (
+    <div className="rounded-lg border border-[var(--border)] bg-[var(--secondary)]/35 p-2.5">
+      <div className="flex items-start justify-between gap-2">
+        <div className="min-w-0 flex-1">
+          <div className="flex flex-wrap items-center gap-x-1.5 gap-y-0.5">
+            <span className="text-[0.6875rem] font-semibold">{label}</span>
+            <span className="rounded bg-[var(--secondary)]/55 px-1 py-0.5 text-[0.5rem] uppercase tracking-wide text-[var(--muted-foreground)]">
+              {mode === "json" ? "JSON" : "Text"}
+            </span>
+            {isDirty && <span className="h-1.5 w-1.5 shrink-0 rounded-full bg-[var(--primary)]" title="Unsaved changes" />}
+          </div>
+          {description && <p className="text-[0.625rem] text-[var(--muted-foreground)]">{description}</p>}
+        </div>
+        <button
+          type="button"
+          onClick={() => {
+            setAiOpen((open) => !open);
+            setError(null);
+          }}
+          disabled={disabled}
+          className={cn(
+            "inline-flex min-h-7 shrink-0 items-center gap-1 rounded-md px-2 py-1 text-[0.625rem] font-medium ring-1 transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-[var(--ring)] disabled:cursor-not-allowed disabled:opacity-50",
+            aiOpen
+              ? "bg-[var(--primary)]/10 text-[var(--primary)] ring-[var(--primary)]/30"
+              : "bg-[var(--secondary)] text-[var(--foreground)] ring-[var(--border)] hover:bg-[var(--accent)]",
+          )}
+          title="Rewrite a selection (or all of this text) with AI"
+        >
+          <Wand2 size="0.6875rem" />
+          AI Edit
+        </button>
+      </div>
+
+      <textarea
+        ref={textareaRef}
+        value={currentText}
+        onChange={(event) => {
+          setDraft(event.target.value);
+          setError(null);
+        }}
+        onSelect={captureSelection}
+        disabled={disabled}
+        rows={Math.min(14, Math.max(3, currentText.split("\n").length))}
+        spellCheck={false}
+        className="mt-2 w-full resize-y rounded-md border border-[var(--input)] bg-[var(--secondary)]/45 px-2 py-1.5 font-mono text-[0.625rem] leading-relaxed text-[var(--foreground)] outline-none transition-colors focus:border-[var(--ring)] focus:ring-1 focus:ring-[var(--ring)] disabled:opacity-60"
+      />
+
+      {aiOpen && (
+        <div className="mt-2 space-y-2 rounded-md border border-[var(--primary)]/25 bg-[var(--primary)]/5 p-2">
+          <p className="text-[0.625rem] text-[var(--muted-foreground)]">
+            {selection && selection.start < selection.end
+              ? `Rewriting the selected ${selection.end - selection.start} characters.`
+              : "No text selected — the whole block will be rewritten. Select a chunk in the editor to target it."}
+          </p>
+          <textarea
+            value={instruction}
+            onChange={(event) => setInstruction(event.target.value)}
+            rows={2}
+            maxLength={4000}
+            placeholder="How should this text change? e.g. Fix the garbled character names — she is called Mira."
+            spellCheck={false}
+            className="w-full resize-y rounded-md border border-[var(--input)] bg-[var(--background)]/60 px-2 py-1.5 text-[0.625rem] leading-relaxed text-[var(--foreground)] outline-none transition-colors placeholder:text-[var(--muted-foreground)] focus:border-[var(--ring)] focus:ring-1 focus:ring-[var(--ring)]"
+          />
+          <div className="flex flex-wrap items-center gap-1.5">
+            <select
+              value={rewriteConnectionId}
+              onChange={(event) => onRewriteConnectionChange(event.target.value)}
+              className="min-w-0 flex-1 rounded-md bg-[var(--secondary)] px-2 py-1.5 text-[0.625rem] outline-none ring-1 ring-[var(--border)] transition-shadow focus:ring-[var(--primary)]/40"
+            >
+              {connectionOptions.length === 0 && <option value="">No connections available</option>}
+              {connectionOptions.map((conn) => (
+                <option key={conn.id} value={conn.id}>
+                  {conn.name}
+                  {conn.model ? ` — ${conn.model}` : ""}
+                </option>
+              ))}
+            </select>
+            <button
+              type="button"
+              onClick={handleRewrite}
+              disabled={disabled || rewrite.isPending || !instruction.trim() || !rewriteConnectionId}
+              className="inline-flex min-h-7 items-center gap-1 rounded-md bg-[var(--primary)] px-2.5 py-1 text-[0.625rem] font-medium text-[var(--primary-foreground)] transition-opacity hover:opacity-90 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-[var(--ring)] disabled:cursor-not-allowed disabled:opacity-50"
+            >
+              {rewrite.isPending ? <Loader2 size="0.6875rem" className="animate-spin" /> : <Wand2 size="0.6875rem" />}
+              {rewrite.isPending ? "Rewriting..." : "Rewrite"}
+            </button>
+          </div>
+        </div>
+      )}
+
+      {error && <div className="mt-1.5 text-[0.5625rem] text-[var(--destructive)]">{error}</div>}
+
+      <div className="mt-2 flex items-center justify-end gap-1.5">
+        <button
+          type="button"
+          onClick={() => {
+            setDraft(null);
+            setError(null);
+          }}
+          disabled={!isDirty || saving}
+          className="inline-flex min-h-7 items-center gap-1 rounded-md border border-[var(--border)] px-2 py-1 text-[0.625rem] text-[var(--muted-foreground)] transition-colors hover:bg-[var(--accent)] focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-[var(--ring)] disabled:cursor-not-allowed disabled:opacity-40"
+        >
+          <RotateCcw size="0.625rem" />
+          Reset
+        </button>
+        <button
+          type="button"
+          onClick={handleSave}
+          disabled={disabled || !isDirty || saving}
+          className="inline-flex min-h-7 items-center gap-1 rounded-md bg-[var(--primary)] px-2.5 py-1 text-[0.625rem] font-medium text-[var(--primary-foreground)] transition-opacity hover:opacity-90 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-[var(--ring)] disabled:cursor-not-allowed disabled:opacity-50"
+        >
+          {saving ? <Loader2 size="0.625rem" className="animate-spin" /> : <Save size="0.625rem" />}
+          {saving ? "Saving..." : "Save"}
+        </button>
+      </div>
+    </div>
+  );
+}
+
+// ── Modal ──
+
+export function AgentSuiteModal({ chat, open, onClose, agents }: AgentSuiteModalProps) {
+  const qc = useQueryClient();
+
+  // 1. Zustand selectors
+  const isAgentProcessing = useAgentStore((s) => s.processingChatIds.includes(chat.id));
+
+  // 2. React Query hooks
+  const { data: connections } = useConnections();
+  const [selectedAgentId, setSelectedAgentId] = useState<string | null>(null);
+  const effectiveAgentId = selectedAgentId && agents.some((a) => a.id === selectedAgentId) ? selectedAgentId : (agents[0]?.id ?? null);
+  const selectedAgent = agents.find((a) => a.id === effectiveAgentId) ?? null;
+  const isTrackerAgent = !!selectedAgent && !!TRACKER_SLICES[selectedAgent.id];
+
+  const memoryQuery = useAgentMemory(effectiveAgentId, chat.id, open);
+  const updateMemory = useUpdateAgentMemory();
+  const gameStateKey = useMemo(() => ["agent-suite", "game-state", chat.id] as const, [chat.id]);
+  const gameStateQuery = useQuery({
+    queryKey: gameStateKey,
+    queryFn: () => api.get<GameState | null>(`/chats/${chat.id}/game-state`),
+    enabled: open && isTrackerAgent,
+    staleTime: 15_000,
+  });
+  const customRunsQuery = useCustomAgentRuns(chat.id, open && selectedAgent?.category === "custom");
+  const updateRunData = useUpdateAgentRunData();
+
+  // 3. Local state
+  const [rewriteConnectionId, setRewriteConnectionId] = useState("");
+  const [spoilersRevealed, setSpoilersRevealed] = useState(false);
+
+  // 4. Memos and callbacks
+  const connectionOptions = useMemo(() => {
+    return filterLanguageGenerationConnections((connections ?? []) as ConnectionOption[]);
+  }, [connections]);
+
+  const effectiveRewriteConnectionId = useMemo(() => {
+    if (rewriteConnectionId && connectionOptions.some((c) => c.id === rewriteConnectionId)) {
+      return rewriteConnectionId;
+    }
+    const agentDefault = connectionOptions.find(
+      (c) => c.defaultForAgents === true || c.defaultForAgents === "true",
+    );
+    const chatConnection = connectionOptions.find((c) => c.id === chat.connectionId);
+    return (agentDefault ?? chatConnection ?? connectionOptions[0])?.id ?? "";
+  }, [chat.connectionId, connectionOptions, rewriteConnectionId]);
+
+  const refreshGameState = useCallback(async () => {
+    const fresh = await api.get<GameState | null>(`/chats/${chat.id}/game-state`);
+    qc.setQueryData(gameStateKey, fresh);
+    // Keep the live tracker HUD in sync when this chat is on screen.
+    if (useChatStore.getState().activeChatId === chat.id) {
+      useGameStateStore.getState().setGameState(fresh ?? null);
+    }
+  }, [chat.id, gameStateKey, qc]);
+
+  const saveMemoryKey = useCallback(
+    async (agentType: string, key: string, mode: "text" | "json", draftText: string) => {
+      const parsed: unknown = mode === "json" ? JSON.parse(draftText) : draftText;
+      await updateMemory.mutateAsync({ agentType, chatId: chat.id, patch: { [key]: parsed } });
+    },
+    [chat.id, updateMemory],
+  );
+
+  const saveTrackerSlice = useCallback(
+    async (agentId: string, draftText: string) => {
+      const slice = TRACKER_SLICES[agentId];
+      const snapshot = gameStateQuery.data;
+      if (!slice || !snapshot) throw new Error("No tracker snapshot to update");
+      const patch = slice.buildPatch(snapshot, JSON.parse(draftText));
+      if ("error" in patch && typeof patch.error === "string") throw new Error(patch.error);
+      await api.patch(`/chats/${chat.id}/game-state`, { ...patch, manual: true });
+      await refreshGameState();
+    },
+    [chat.id, gameStateQuery.data, refreshGameState],
+  );
+
+  const clearAgentMemory = useCallback(async () => {
+    if (!selectedAgent) return;
+    const confirmed = await showConfirmDialog({
+      title: "Clear Agent Memory",
+      message: `Delete everything ${selectedAgent.name} remembers about this chat? This cannot be undone.`,
+      confirmLabel: "Clear Memory",
+      cancelLabel: "Cancel",
+      tone: "destructive",
+    });
+    if (!confirmed) return;
+    try {
+      await api.delete(`/agents/memory/${selectedAgent.id}/${chat.id}`);
+      qc.invalidateQueries({ queryKey: agentKeys.memory(selectedAgent.id, chat.id) });
+      toast.success(`${selectedAgent.name} memory cleared`);
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : "Failed to clear memory");
+    }
+  }, [chat.id, qc, selectedAgent]);
+
+  const memoryEntries = useMemo(() => {
+    const memory = memoryQuery.data?.memory ?? {};
+    return Object.entries(memory).map(([key, value]) => ({
+      key,
+      mode: (typeof value === "string" ? "text" : "json") as "text" | "json",
+      serialized: serializeValue(value, typeof value === "string" ? "text" : "json"),
+    }));
+  }, [memoryQuery.data?.memory]);
+
+  const customRuns = useMemo(() => {
+    if (!selectedAgent || selectedAgent.category !== "custom") return [];
+    return ((customRunsQuery.data ?? []) as AgentRunRow[]).filter((run) => run.agentType === selectedAgent.id).slice(0, 5);
+  }, [customRunsQuery.data, selectedAgent]);
+
+  const hideSpoilers = selectedAgent?.id === "director" && !spoilersRevealed && memoryEntries.length > 0;
+  const trackerSlice = selectedAgent ? TRACKER_SLICES[selectedAgent.id] : undefined;
+
+  // 5. Render
+  return (
+    <Modal open={open} onClose={onClose} title="Agent Suite" width="max-w-3xl" chatFloatingPanel>
+      {agents.length === 0 ? (
+        <div className="rounded-lg border border-dashed border-[var(--border)] px-3 py-6 text-center text-[0.6875rem] text-[var(--muted-foreground)]">
+          No agents are active in this chat. Add agents in the Agents section first.
+        </div>
+      ) : (
+        <div className="flex flex-col gap-3 sm:flex-row">
+          {/* Agent picker — dropdown on mobile, rail on desktop */}
+          <div className="shrink-0 sm:w-44">
+            <select
+              value={effectiveAgentId ?? ""}
+              onChange={(event) => {
+                setSelectedAgentId(event.target.value);
+                setSpoilersRevealed(false);
+              }}
+              className="w-full rounded-lg bg-[var(--secondary)] px-3 py-2 text-xs outline-none ring-1 ring-[var(--border)] transition-shadow focus:ring-[var(--primary)]/40 sm:hidden"
+            >
+              {agents.map((agent) => (
+                <option key={agent.id} value={agent.id}>
+                  {agent.name}
+                </option>
+              ))}
+            </select>
+            <div className="hidden flex-col gap-1 sm:flex">
+              {agents.map((agent) => (
+                <button
+                  key={agent.id}
+                  type="button"
+                  onClick={() => {
+                    setSelectedAgentId(agent.id);
+                    setSpoilersRevealed(false);
+                  }}
+                  className={cn(
+                    "flex w-full flex-col rounded-lg px-2.5 py-2 text-left transition-all",
+                    agent.id === effectiveAgentId
+                      ? "bg-[var(--primary)]/10 ring-1 ring-[var(--primary)]/30"
+                      : "bg-[var(--secondary)] hover:bg-[var(--accent)]",
+                  )}
+                >
+                  <span className="truncate text-[0.6875rem] font-medium">{agent.name}</span>
+                  <span className="text-[0.5625rem] uppercase tracking-wide text-[var(--muted-foreground)]">
+                    {CATEGORY_LABELS[agent.category] ?? agent.category}
+                  </span>
+                </button>
+              ))}
+            </div>
+          </div>
+
+          {/* Selected agent detail */}
+          <div className="min-w-0 flex-1 space-y-3">
+            {selectedAgent && (
+              <>
+                <div className="flex items-start gap-2">
+                  <Bot size="0.875rem" className="mt-0.5 shrink-0 text-[var(--primary)]" />
+                  <div className="min-w-0 flex-1">
+                    <h3 className="text-xs font-semibold">{selectedAgent.name}</h3>
+                    <p className="text-[0.625rem] text-[var(--muted-foreground)]">{selectedAgent.description}</p>
+                  </div>
+                </div>
+
+                {isAgentProcessing && (
+                  <div className="flex items-center gap-1.5 rounded-lg bg-amber-400/10 px-2.5 py-2 text-[0.625rem] text-amber-400/90 ring-1 ring-amber-400/30">
+                    <AlertTriangle size="0.75rem" className="shrink-0" />
+                    Agents are currently running for this chat — saving is disabled until they finish.
+                  </div>
+                )}
+
+                {/* Stored memory */}
+                <section className="space-y-2">
+                  <div className="flex items-center justify-between gap-2">
+                    <h4 className="text-[0.6875rem] font-semibold text-[var(--muted-foreground)]">Stored Memory</h4>
+                    <div className="flex items-center gap-1.5">
+                      {selectedAgent.id === "director" && memoryEntries.length > 0 && (
+                        <button
+                          type="button"
+                          onClick={() => setSpoilersRevealed((v) => !v)}
+                          className="inline-flex min-h-7 items-center gap-1 rounded-md border border-[var(--border)] px-2 py-1 text-[0.625rem] text-[var(--muted-foreground)] transition-colors hover:bg-[var(--accent)] focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-[var(--ring)]"
+                        >
+                          {spoilersRevealed ? <EyeOff size="0.625rem" /> : <Eye size="0.625rem" />}
+                          {spoilersRevealed ? "Hide spoilers" : "Reveal spoilers"}
+                        </button>
+                      )}
+                      {memoryEntries.length > 0 && (
+                        <button
+                          type="button"
+                          onClick={clearAgentMemory}
+                          disabled={isAgentProcessing}
+                          className="inline-flex min-h-7 items-center gap-1 rounded-md border border-[var(--border)] px-2 py-1 text-[0.625rem] text-[var(--destructive)] transition-colors hover:bg-[var(--destructive)]/15 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-[var(--ring)] disabled:cursor-not-allowed disabled:opacity-40"
+                        >
+                          <Trash2 size="0.625rem" />
+                          Clear memory
+                        </button>
+                      )}
+                    </div>
+                  </div>
+                  {memoryQuery.isLoading && (
+                    <p className="py-2 text-center text-[0.625rem] text-[var(--muted-foreground)]">
+                      Loading stored memory...
+                    </p>
+                  )}
+                  {memoryQuery.isError && (
+                    <p className="rounded-md border border-[var(--destructive)]/25 bg-[var(--destructive)]/10 px-2 py-1.5 text-center text-[0.625rem] text-[var(--destructive)]">
+                      Could not load this agent's memory.
+                    </p>
+                  )}
+                  {!memoryQuery.isLoading && !memoryQuery.isError && memoryEntries.length === 0 && (
+                    <p className="rounded-md border border-dashed border-[var(--border)] px-2 py-2 text-center text-[0.625rem] text-[var(--muted-foreground)]">
+                      No stored memory for this agent in this chat.
+                    </p>
+                  )}
+                  {hideSpoilers ? (
+                    <p className="rounded-md border border-dashed border-[var(--border)] px-2 py-2 text-center text-[0.625rem] text-[var(--muted-foreground)]">
+                      Contains hidden narrative spoilers. Use "Reveal spoilers" to view and edit.
+                    </p>
+                  ) : (
+                    memoryEntries.map((entry) => (
+                      <DataBlock
+                        key={`${selectedAgent.id}:memory:${entry.key}`}
+                        label={entry.key}
+                        mode={entry.mode}
+                        value={entry.serialized}
+                        onSave={(draftText) => saveMemoryKey(selectedAgent.id, entry.key, entry.mode, draftText)}
+                        disabled={isAgentProcessing}
+                        agentName={selectedAgent.name}
+                        connectionOptions={connectionOptions}
+                        rewriteConnectionId={effectiveRewriteConnectionId}
+                        onRewriteConnectionChange={setRewriteConnectionId}
+                      />
+                    ))
+                  )}
+                </section>
+
+                {/* Tracker slice */}
+                {trackerSlice && (
+                  <section className="space-y-2">
+                    <h4 className="text-[0.6875rem] font-semibold text-[var(--muted-foreground)]">Tracker Data</h4>
+                    {gameStateQuery.isLoading && (
+                      <p className="py-2 text-center text-[0.625rem] text-[var(--muted-foreground)]">
+                        Loading tracker data...
+                      </p>
+                    )}
+                    {gameStateQuery.isError && (
+                      <p className="rounded-md border border-[var(--destructive)]/25 bg-[var(--destructive)]/10 px-2 py-1.5 text-center text-[0.625rem] text-[var(--destructive)]">
+                        Could not load tracker data.
+                      </p>
+                    )}
+                    {!gameStateQuery.isLoading && !gameStateQuery.isError && !gameStateQuery.data && (
+                      <p className="rounded-md border border-dashed border-[var(--border)] px-2 py-2 text-center text-[0.625rem] text-[var(--muted-foreground)]">
+                        No tracker data recorded for this chat yet.
+                      </p>
+                    )}
+                    {gameStateQuery.data && (
+                      <>
+                        <DataBlock
+                          key={`${selectedAgent.id}:tracker`}
+                          label={trackerSlice.label}
+                          description={trackerSlice.description}
+                          mode="json"
+                          value={serializeValue(trackerSlice.getValue(gameStateQuery.data), "json")}
+                          onSave={(draftText) => saveTrackerSlice(selectedAgent.id, draftText)}
+                          disabled={isAgentProcessing}
+                          agentName={selectedAgent.name}
+                          connectionOptions={connectionOptions}
+                          rewriteConnectionId={effectiveRewriteConnectionId}
+                          onRewriteConnectionChange={setRewriteConnectionId}
+                        />
+                        {selectedAgent.id === "world-state" && (gameStateQuery.data.recentEvents?.length ?? 0) > 0 && (
+                          <div className="rounded-lg border border-[var(--border)] bg-[var(--secondary)]/35 p-2.5">
+                            <span className="text-[0.6875rem] font-semibold">Recent Events</span>
+                            <p className="text-[0.625rem] text-[var(--muted-foreground)]">
+                              Maintained by the agent and rewritten on each run — view only.
+                            </p>
+                            <ul className="mt-1.5 list-disc space-y-0.5 pl-4 text-[0.625rem] text-[var(--muted-foreground)]">
+                              {gameStateQuery.data.recentEvents.map((event, index) => (
+                                <li key={index}>{event}</li>
+                              ))}
+                            </ul>
+                          </div>
+                        )}
+                      </>
+                    )}
+                  </section>
+                )}
+
+                {/* Custom agent outputs */}
+                {selectedAgent.category === "custom" && (
+                  <section className="space-y-2">
+                    <h4 className="text-[0.6875rem] font-semibold text-[var(--muted-foreground)]">Recent Outputs</h4>
+                    {customRunsQuery.isLoading && (
+                      <p className="py-2 text-center text-[0.625rem] text-[var(--muted-foreground)]">
+                        Loading outputs...
+                      </p>
+                    )}
+                    {!customRunsQuery.isLoading && customRuns.length === 0 && (
+                      <p className="rounded-md border border-dashed border-[var(--border)] px-2 py-2 text-center text-[0.625rem] text-[var(--muted-foreground)]">
+                        No stored outputs from this agent in this chat.
+                      </p>
+                    )}
+                    {customRuns.map((run) => {
+                      const mode: "text" | "json" = typeof run.resultData === "string" ? "text" : "json";
+                      return (
+                        <DataBlock
+                          key={run.id}
+                          label={run.resultType.replace(/_/g, " ")}
+                          description={formatRunTimestamp(run.createdAt)}
+                          mode={mode}
+                          value={serializeValue(run.resultData, mode)}
+                          onSave={async (draftText) => {
+                            const parsed: unknown = mode === "json" ? JSON.parse(draftText) : draftText;
+                            await updateRunData.mutateAsync({ id: run.id, chatId: chat.id, resultData: parsed });
+                          }}
+                          disabled={isAgentProcessing}
+                          agentName={selectedAgent.name}
+                          connectionOptions={connectionOptions}
+                          rewriteConnectionId={effectiveRewriteConnectionId}
+                          onRewriteConnectionChange={setRewriteConnectionId}
+                        />
+                      );
+                    })}
+                  </section>
+                )}
+              </>
+            )}
+          </div>
+        </div>
+      )}
+    </Modal>
+  );
+}

--- a/packages/client/src/components/chat/AgentSuiteModal.tsx
+++ b/packages/client/src/components/chat/AgentSuiteModal.tsx
@@ -3,11 +3,23 @@
 // active chat have stored (memory, tracker state, custom
 // outputs), manually or via AI-assisted selection rewrites.
 // ──────────────────────────────────────────────
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from "react";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
-import { AlertTriangle, Bot, Eye, EyeOff, Loader2, RotateCcw, Save, Trash2, Wand2 } from "lucide-react";
+import {
+  AlertTriangle,
+  Bot,
+  ChevronDown,
+  Eye,
+  EyeOff,
+  Loader2,
+  Paperclip,
+  RotateCcw,
+  Save,
+  Trash2,
+  Wand2,
+} from "lucide-react";
 import { toast } from "sonner";
-import type { Chat, GameState, PlayerStats } from "@marinara-engine/shared";
+import type { Chat, GameState, Lorebook, PlayerStats } from "@marinara-engine/shared";
 import {
   useAgentMemory,
   useAgentSuiteRewrite,
@@ -17,10 +29,14 @@ import {
   agentKeys,
   type AgentRunRow,
 } from "../../hooks/use-agents";
+import { useCharacters } from "../../hooks/use-characters";
 import { useConnections } from "../../hooks/use-connections";
+import { useEntriesAcrossLorebooks, useLorebooks } from "../../hooks/use-lorebooks";
 import { api } from "../../lib/api-client";
 import { showConfirmDialog } from "../../lib/app-dialogs";
+import { getChatCharacterIds } from "../../lib/chat-macros";
 import { filterLanguageGenerationConnections } from "../../lib/connection-filters";
+import { isLorebookScopeActiveForChat } from "../../lib/lorebook-scope";
 import { cn } from "../../lib/utils";
 import { useAgentStore } from "../../stores/agent.store";
 import { useChatStore } from "../../stores/chat.store";
@@ -52,6 +68,38 @@ type ConnectionOption = {
 
 const MAX_REWRITE_SELECTION_CHARS = 50000;
 const MAX_REWRITE_DOCUMENT_CHARS = 100000;
+const MAX_CONTEXT_SECTION_CHARS = 20000;
+const MAX_CONTEXT_TOTAL_CHARS = 100000;
+const MAX_CONTEXT_SECTIONS = 20;
+const CONTEXT_TRUNCATION_MARKER = "\n…[truncated for length]";
+
+/** A selectable grounding source for AI rewrites (character card, lorebook entry). */
+type ContextSource = {
+  key: string;
+  group: string;
+  /** Short name shown in the picker (the group header carries the rest). */
+  display: string;
+  /** Full label sent to the model. */
+  label: string;
+  content: string;
+};
+
+function clampContextContent(content: string): string {
+  if (content.length <= MAX_CONTEXT_SECTION_CHARS) return content;
+  // Strip a lone trailing high surrogate so the cut never splits an emoji
+  // (same guard as tool-executor.ts / chat-summary-entries.ts truncation).
+  const head = content
+    .slice(0, MAX_CONTEXT_SECTION_CHARS - CONTEXT_TRUNCATION_MARKER.length)
+    .replace(/[\uD800-\uDBFF]$/, "");
+  return head + CONTEXT_TRUNCATION_MARKER;
+}
+
+const MAX_CONTEXT_LABEL_CHARS = 200;
+
+function clampContextLabel(label: string): string {
+  if (label.length <= MAX_CONTEXT_LABEL_CHARS) return label;
+  return `${label.slice(0, MAX_CONTEXT_LABEL_CHARS - 1).replace(/[\uD800-\uDBFF]$/, "")}…`;
+}
 
 const CATEGORY_LABELS: Record<string, string> = {
   writer: "Writer",
@@ -165,6 +213,10 @@ interface DataBlockProps {
   connectionOptions: ConnectionOption[];
   rewriteConnectionId: string;
   onRewriteConnectionChange: (id: string) => void;
+  contextPicker: ReactNode;
+  contextCount: number;
+  contextOverLimit: boolean;
+  buildContextSections: () => Array<{ label: string; content: string }>;
 }
 
 function DataBlock({
@@ -180,6 +232,10 @@ function DataBlock({
   connectionOptions,
   rewriteConnectionId,
   onRewriteConnectionChange,
+  contextPicker,
+  contextCount,
+  contextOverLimit,
+  buildContextSections,
 }: DataBlockProps) {
   const rewrite = useAgentSuiteRewrite();
 
@@ -189,6 +245,7 @@ function DataBlock({
   const [error, setError] = useState<string | null>(null);
   const [saving, setSaving] = useState(false);
   const [aiOpen, setAiOpen] = useState(false);
+  const [contextOpen, setContextOpen] = useState(false);
   const [instruction, setInstruction] = useState("");
   const [selection, setSelection] = useState<{ start: number; end: number } | null>(null);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
@@ -247,8 +304,15 @@ function DataBlock({
       setError(`Selection too large for AI rewrite (max ${MAX_REWRITE_SELECTION_CHARS.toLocaleString()} characters)`);
       return;
     }
+    if (contextOverLimit) {
+      setError(
+        `Attached context is too large (max ${MAX_CONTEXT_SECTIONS} sources / ${MAX_CONTEXT_TOTAL_CHARS.toLocaleString()} characters) — deselect some sources`,
+      );
+      return;
+    }
     setError(null);
     try {
+      const contextSections = buildContextSections();
       const result = await rewrite.mutateAsync({
         connectionId: rewriteConnectionId,
         instruction: instruction.trim(),
@@ -256,6 +320,7 @@ function DataBlock({
         documentText: clamped && text.length <= MAX_REWRITE_DOCUMENT_CHARS ? text : undefined,
         agentName,
         dataLabel: label,
+        contextSections: contextSections.length > 0 ? contextSections : undefined,
       });
       const next = clamped
         ? text.slice(0, clamped.start) + result.rewrittenText + text.slice(clamped.end)
@@ -266,7 +331,18 @@ function DataBlock({
     } catch (err) {
       setError(err instanceof Error ? err.message : "AI rewrite failed");
     }
-  }, [agentName, busy, currentText, instruction, label, rewrite, rewriteConnectionId, selection]);
+  }, [
+    agentName,
+    buildContextSections,
+    busy,
+    contextOverLimit,
+    currentText,
+    instruction,
+    label,
+    rewrite,
+    rewriteConnectionId,
+    selection,
+  ]);
 
   return (
     <div className="rounded-lg border border-[var(--border)] bg-[var(--secondary)]/35 p-2.5">
@@ -340,6 +416,22 @@ function DataBlock({
             spellCheck={false}
             className="w-full resize-y rounded-md border border-[var(--input)] bg-[var(--background)]/60 px-2 py-1.5 text-[0.625rem] leading-relaxed text-[var(--foreground)] outline-none transition-colors placeholder:text-[var(--muted-foreground)] focus:border-[var(--ring)] focus:ring-1 focus:ring-[var(--ring)]"
           />
+          <button
+            type="button"
+            onClick={() => setContextOpen((open) => !open)}
+            className="inline-flex min-h-7 items-center gap-1 rounded-md border border-[var(--border)]/70 bg-[var(--secondary)]/45 px-2 py-1 text-[0.625rem] font-medium text-[var(--foreground)] transition-colors hover:bg-[var(--accent)] focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-[var(--ring)]"
+            title="Attach character cards or lorebook entries so the model knows what the data refers to"
+          >
+            <Paperclip size="0.6875rem" />
+            Add Context
+            {contextCount > 0 && (
+              <span className="rounded-full bg-[var(--primary)]/15 px-1.5 py-0.5 text-[0.5625rem] font-medium text-[var(--primary)]">
+                {contextCount}
+              </span>
+            )}
+            <ChevronDown size="0.625rem" className={cn("transition-transform", contextOpen && "rotate-180")} />
+          </button>
+          {contextOpen && contextPicker}
           <div className="flex flex-wrap items-center gap-1.5">
             <select
               value={rewriteConnectionId}
@@ -425,9 +517,73 @@ export function AgentSuiteModal({ chat, open, onClose, agents }: AgentSuiteModal
   const customRunsQuery = useCustomAgentRuns(chat.id, open && selectedAgent?.category === "custom");
   const updateRunData = useUpdateAgentRunData();
 
+  // Context sources for AI rewrites: the chat's character cards + entries of
+  // its pinned lorebooks. Queries are gated on the modal being open.
+  const metadata = useMemo<Record<string, unknown>>(() => {
+    const raw = chat.metadata as unknown;
+    if (typeof raw === "string") {
+      try {
+        const parsed = JSON.parse(raw);
+        return parsed && typeof parsed === "object" ? (parsed as Record<string, unknown>) : {};
+      } catch {
+        return {};
+      }
+    }
+    return raw && typeof raw === "object" ? (raw as Record<string, unknown>) : {};
+  }, [chat.metadata]);
+  const activeLorebookIds = useMemo<string[]>(
+    () =>
+      Array.isArray(metadata.activeLorebookIds)
+        ? metadata.activeLorebookIds.filter((id): id is string => typeof id === "string")
+        : [],
+    [metadata.activeLorebookIds],
+  );
+  const excludedLorebookIds = useMemo<string[]>(
+    () =>
+      Array.isArray(metadata.excludedLorebookIds)
+        ? metadata.excludedLorebookIds.filter((id): id is string => typeof id === "string")
+        : [],
+    [metadata.excludedLorebookIds],
+  );
+  // chat.characterIds arrives as a JSON string from the API despite the shared type.
+  const chatCharacterIds = useMemo(() => getChatCharacterIds({ characterIds: chat.characterIds }), [chat.characterIds]);
+  // includeBuiltIn matches the drawer's query so built-ins (Professor Mari)
+  // resolve and the already-cached list is reused instead of refetched.
+  const { data: allCharacters, isLoading: charactersLoading } = useCharacters({ enabled: open, includeBuiltIn: true });
+  const { data: allLorebooks } = useLorebooks();
+  // Mirror the drawer's active-lorebook derivation: pinned + global + chat-scoped
+  // + character-linked + persona-linked, minus explicit exclusions.
+  const contextLorebooks = useMemo<Array<{ id: string; name: string }>>(() => {
+    const pinnedIds = new Set(activeLorebookIds);
+    const excludedIds = new Set(excludedLorebookIds);
+    return ((allLorebooks ?? []) as Lorebook[])
+      .filter((lorebook) => {
+        if (excludedIds.has(lorebook.id)) return false;
+        if (lorebook.enabled === false || !isLorebookScopeActiveForChat(lorebook.scope, chat.id)) return false;
+        return (
+          pinnedIds.has(lorebook.id) ||
+          lorebook.isGlobal ||
+          lorebook.chatId === chat.id ||
+          (lorebook.characterIds ?? []).some((id) => chatCharacterIds.includes(id)) ||
+          (!!lorebook.characterId && chatCharacterIds.includes(lorebook.characterId)) ||
+          (!!chat.personaId &&
+            ((lorebook.personaIds ?? []).includes(chat.personaId) || lorebook.personaId === chat.personaId))
+        );
+      })
+      .map((lorebook) => ({ id: lorebook.id, name: lorebook.name }));
+  }, [activeLorebookIds, allLorebooks, chat.id, chat.personaId, chatCharacterIds, excludedLorebookIds]);
+  const contextLorebookIds = useMemo(() => contextLorebooks.map((lorebook) => lorebook.id), [contextLorebooks]);
+  const {
+    entries: lorebookEntries,
+    isLoading: entriesLoading,
+    isError: entriesError,
+  } = useEntriesAcrossLorebooks(open ? contextLorebookIds : []);
+  const contextSourcesLoading = charactersLoading || entriesLoading;
+
   // 3. Local state
   const [rewriteConnectionId, setRewriteConnectionId] = useState("");
   const [spoilersRevealed, setSpoilersRevealed] = useState(false);
+  const [contextSelection, setContextSelection] = useState<Set<string>>(() => new Set());
   const dirtyBlocksRef = useRef<Set<string>>(new Set());
   const closingRef = useRef(false);
   const wasProcessingRef = useRef(isAgentProcessing);
@@ -499,6 +655,91 @@ export function AgentSuiteModal({ chat, open, onClose, agents }: AgentSuiteModal
       })();
     },
     [confirmDiscardDrafts, effectiveAgentId],
+  );
+
+  const contextSources = useMemo<ContextSource[]>(() => {
+    const sources: ContextSource[] = [];
+    const charactersById = new Map(
+      ((allCharacters ?? []) as Array<{ id: string; data: unknown }>).map((row) => [row.id, row]),
+    );
+    for (const characterId of chatCharacterIds) {
+      const row = charactersById.get(characterId);
+      if (!row) continue;
+      let data: Record<string, unknown>;
+      try {
+        data = (typeof row.data === "string" ? JSON.parse(row.data) : row.data) as Record<string, unknown>;
+      } catch {
+        continue;
+      }
+      if (!data || typeof data !== "object") continue;
+      const name = typeof data.name === "string" && data.name.trim() ? data.name.trim() : "Unnamed character";
+      const parts: string[] = [];
+      for (const [field, fieldLabel] of [
+        ["description", "Description"],
+        ["personality", "Personality"],
+        ["scenario", "Scenario"],
+      ] as const) {
+        const value = data[field];
+        if (typeof value === "string" && value.trim()) parts.push(`${fieldLabel}:\n${value.trim()}`);
+      }
+      if (parts.length === 0) continue;
+      sources.push({
+        key: `char:${characterId}`,
+        group: "Characters",
+        display: name,
+        label: clampContextLabel(`Character card — ${name}`),
+        content: clampContextContent(`Name: ${name}\n\n${parts.join("\n\n")}`),
+      });
+    }
+    const lorebookNames = new Map(contextLorebooks.map((lorebook) => [lorebook.id, lorebook.name]));
+    for (const entry of lorebookEntries ?? []) {
+      if (!entry.content?.trim()) continue;
+      const lorebookName = lorebookNames.get(entry.lorebookId) ?? "Lorebook";
+      const entryName = entry.name?.trim() || "Untitled entry";
+      sources.push({
+        key: `lore:${entry.id}`,
+        group: `Lorebook — ${lorebookName}`,
+        display: entryName,
+        label: clampContextLabel(`Lorebook "${lorebookName}" — ${entryName}`),
+        content: clampContextContent(entry.content.trim()),
+      });
+    }
+    return sources;
+  }, [allCharacters, chatCharacterIds, contextLorebooks, lorebookEntries]);
+
+  const groupedContextSources = useMemo(() => {
+    const groups = new Map<string, ContextSource[]>();
+    for (const source of contextSources) {
+      const list = groups.get(source.group);
+      if (list) list.push(source);
+      else groups.set(source.group, [source]);
+    }
+    return Array.from(groups.entries());
+  }, [contextSources]);
+
+  const selectedContextSources = useMemo(
+    () => contextSources.filter((source) => contextSelection.has(source.key)),
+    [contextSelection, contextSources],
+  );
+  const contextTotalChars = useMemo(
+    () => selectedContextSources.reduce((total, source) => total + source.content.length, 0),
+    [selectedContextSources],
+  );
+  const contextOverLimit =
+    selectedContextSources.length > MAX_CONTEXT_SECTIONS || contextTotalChars > MAX_CONTEXT_TOTAL_CHARS;
+
+  const toggleContextSource = useCallback((key: string) => {
+    setContextSelection((current) => {
+      const next = new Set(current);
+      if (next.has(key)) next.delete(key);
+      else next.add(key);
+      return next;
+    });
+  }, []);
+
+  const buildContextSections = useCallback(
+    () => selectedContextSources.map(({ label, content }) => ({ label, content })),
+    [selectedContextSources],
   );
 
   const refreshGameState = useCallback(async () => {
@@ -605,6 +846,75 @@ export function AgentSuiteModal({ chat, open, onClose, agents }: AgentSuiteModal
 
   const hideSpoilers = selectedAgent?.id === "director" && !spoilersRevealed && memoryEntries.length > 0;
   const trackerSlice = selectedAgent ? TRACKER_SLICES[selectedAgent.id] : undefined;
+
+  const contextPicker: ReactNode = (
+    <div className="space-y-1.5 rounded-md border border-[var(--border)] bg-[var(--background)]/40 p-2">
+      <p className="text-[0.5625rem] text-[var(--muted-foreground)]">
+        Attached sources ground the rewrite. The selection applies to every AI Edit in this window.
+      </p>
+      {contextSourcesLoading ? (
+        <p className="py-1 text-center text-[0.625rem] text-[var(--muted-foreground)]">Loading context sources...</p>
+      ) : contextSources.length === 0 ? (
+        <p
+          className={cn(
+            "py-1 text-center text-[0.625rem]",
+            entriesError ? "text-[var(--destructive)]" : "text-[var(--muted-foreground)]",
+          )}
+        >
+          {entriesError
+            ? "Couldn't load lorebook entries — close and reopen the Agent Suite to retry."
+            : "No context sources available — this chat has no character cards or active lorebooks."}
+        </p>
+      ) : (
+        <>
+          {entriesError && (
+            <p className="text-[0.5625rem] text-[var(--destructive)]">
+              Couldn't load lorebook entries — showing character cards only.
+            </p>
+          )}
+          {groupedContextSources.map(([group, sources]) => (
+          <div key={group}>
+            <p className="mb-0.5 text-[0.5625rem] font-semibold uppercase tracking-wide text-[var(--muted-foreground)]">
+              {group}
+            </p>
+            <div className="max-h-32 space-y-0.5 overflow-y-auto">
+              {sources.map((source) => (
+                <label
+                  key={source.key}
+                  className="flex cursor-pointer items-center gap-1.5 rounded px-1 py-0.5 text-[0.625rem] transition-colors hover:bg-[var(--accent)]/40"
+                >
+                  <input
+                    type="checkbox"
+                    checked={contextSelection.has(source.key)}
+                    onChange={() => toggleContextSource(source.key)}
+                    className="h-3 w-3 shrink-0 accent-[var(--primary)]"
+                  />
+                  <span className="min-w-0 flex-1 truncate">{source.display}</span>
+                  <span className="shrink-0 text-[0.5rem] text-[var(--muted-foreground)]">
+                    ~{Math.ceil(source.content.length / 4).toLocaleString()} tokens
+                  </span>
+                </label>
+              ))}
+            </div>
+          </div>
+          ))}
+        </>
+      )}
+      {selectedContextSources.length > 0 && (
+        <p
+          className={cn(
+            "text-[0.5625rem]",
+            contextOverLimit ? "text-[var(--destructive)]" : "text-[var(--muted-foreground)]",
+          )}
+        >
+          {selectedContextSources.length} source{selectedContextSources.length === 1 ? "" : "s"} attached · ~
+          {Math.ceil(contextTotalChars / 4).toLocaleString()} tokens
+          {contextOverLimit &&
+            ` — too large (max ${MAX_CONTEXT_SECTIONS} sources / ${MAX_CONTEXT_TOTAL_CHARS.toLocaleString()} characters), deselect some sources`}
+        </p>
+      )}
+    </div>
+  );
 
   // 5. Render
   return (
@@ -731,6 +1041,10 @@ export function AgentSuiteModal({ chat, open, onClose, agents }: AgentSuiteModal
                         connectionOptions={connectionOptions}
                         rewriteConnectionId={effectiveRewriteConnectionId}
                         onRewriteConnectionChange={setRewriteConnectionId}
+                        contextPicker={contextPicker}
+                        contextCount={selectedContextSources.length}
+                        contextOverLimit={contextOverLimit}
+                        buildContextSections={buildContextSections}
                       />
                     ))
                   )}
@@ -771,6 +1085,10 @@ export function AgentSuiteModal({ chat, open, onClose, agents }: AgentSuiteModal
                           connectionOptions={connectionOptions}
                           rewriteConnectionId={effectiveRewriteConnectionId}
                           onRewriteConnectionChange={setRewriteConnectionId}
+                          contextPicker={contextPicker}
+                          contextCount={selectedContextSources.length}
+                          contextOverLimit={contextOverLimit}
+                          buildContextSections={buildContextSections}
                         />
                         {selectedAgent.id === "world-state" && (gameStateQuery.data.recentEvents?.length ?? 0) > 0 && (
                           <div className="rounded-lg border border-[var(--border)] bg-[var(--secondary)]/35 p-2.5">
@@ -824,6 +1142,10 @@ export function AgentSuiteModal({ chat, open, onClose, agents }: AgentSuiteModal
                           connectionOptions={connectionOptions}
                           rewriteConnectionId={effectiveRewriteConnectionId}
                           onRewriteConnectionChange={setRewriteConnectionId}
+                          contextPicker={contextPicker}
+                          contextCount={selectedContextSources.length}
+                          contextOverLimit={contextOverLimit}
+                          buildContextSections={buildContextSections}
                         />
                       );
                     })}

--- a/packages/client/src/components/chat/AgentSuiteModal.tsx
+++ b/packages/client/src/components/chat/AgentSuiteModal.tsx
@@ -19,7 +19,7 @@ import {
   Wand2,
 } from "lucide-react";
 import { toast } from "sonner";
-import type { Chat, GameState, Lorebook, PlayerStats } from "@marinara-engine/shared";
+import type { Chat, GameState, PlayerStats } from "@marinara-engine/shared";
 import {
   useAgentMemory,
   useAgentSuiteRewrite,
@@ -34,9 +34,9 @@ import { useConnections } from "../../hooks/use-connections";
 import { useEntriesAcrossLorebooks, useLorebooks } from "../../hooks/use-lorebooks";
 import { api } from "../../lib/api-client";
 import { showConfirmDialog } from "../../lib/app-dialogs";
+import { deriveActiveLorebookViews, getChatActiveLorebookIds, getChatExcludedLorebookIds } from "../../lib/chat-lorebooks";
 import { getChatCharacterIds } from "../../lib/chat-macros";
 import { filterLanguageGenerationConnections } from "../../lib/connection-filters";
-import { isLorebookScopeActiveForChat } from "../../lib/lorebook-scope";
 import { cn } from "../../lib/utils";
 import { useAgentStore } from "../../stores/agent.store";
 import { useChatStore } from "../../stores/chat.store";
@@ -55,6 +55,7 @@ interface AgentSuiteModalProps {
   chat: Chat;
   open: boolean;
   onClose: () => void;
+  onCloseGuardChange?: (guard: (() => Promise<boolean>) | null) => void;
   agents: AgentSuiteAgent[];
 }
 
@@ -247,7 +248,7 @@ function DataBlock({
   const [aiOpen, setAiOpen] = useState(false);
   const [contextOpen, setContextOpen] = useState(false);
   const [instruction, setInstruction] = useState("");
-  const [selection, setSelection] = useState<{ start: number; end: number } | null>(null);
+  const [selection, setSelection] = useState<{ start: number; end: number; sourceText: string } | null>(null);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
 
   const currentText = draft ?? value;
@@ -263,8 +264,12 @@ function DataBlock({
   const captureSelection = useCallback(() => {
     const el = textareaRef.current;
     if (!el) return;
-    setSelection(el.selectionStart !== el.selectionEnd ? { start: el.selectionStart, end: el.selectionEnd } : null);
-  }, []);
+    setSelection(
+      el.selectionStart !== el.selectionEnd
+        ? { start: el.selectionStart, end: el.selectionEnd, sourceText: currentText }
+        : null,
+    );
+  }, [currentText]);
 
   const handleSave = useCallback(async () => {
     if (!isDirty || busy) return;
@@ -281,6 +286,7 @@ function DataBlock({
     try {
       await onSave(currentText);
       setDraft(null);
+      setSelection(null);
     } catch (err) {
       setError(err instanceof Error ? err.message : "Failed to save");
     } finally {
@@ -292,7 +298,7 @@ function DataBlock({
     if (busy || !instruction.trim() || !rewriteConnectionId) return;
     const text = currentText;
     const clamped =
-      selection && selection.start < selection.end && selection.end <= text.length
+      selection && selection.sourceText === text && selection.start < selection.end && selection.end <= text.length
         ? { start: selection.start, end: selection.end }
         : null;
     const selectedText = clamped ? text.slice(clamped.start, clamped.end) : text;
@@ -383,6 +389,7 @@ function DataBlock({
         onChange={(event) => {
           setDraft(event.target.value);
           setError(null);
+          setSelection(null);
         }}
         onSelect={captureSelection}
         disabled={disabled || busy}
@@ -467,6 +474,7 @@ function DataBlock({
           onClick={() => {
             setDraft(null);
             setError(null);
+            setSelection(null);
           }}
           disabled={!isDirty || busy}
           className="inline-flex min-h-7 items-center gap-1 rounded-md border border-[var(--border)] px-2 py-1 text-[0.625rem] text-[var(--muted-foreground)] transition-colors hover:bg-[var(--accent)] focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-[var(--ring)] disabled:cursor-not-allowed disabled:opacity-40"
@@ -490,7 +498,7 @@ function DataBlock({
 
 // ── Modal ──
 
-export function AgentSuiteModal({ chat, open, onClose, agents }: AgentSuiteModalProps) {
+export function AgentSuiteModal({ chat, open, onClose, onCloseGuardChange, agents }: AgentSuiteModalProps) {
   const qc = useQueryClient();
 
   // 1. Zustand selectors
@@ -519,32 +527,8 @@ export function AgentSuiteModal({ chat, open, onClose, agents }: AgentSuiteModal
 
   // Context sources for AI rewrites: the chat's character cards + entries of
   // its pinned lorebooks. Queries are gated on the modal being open.
-  const metadata = useMemo<Record<string, unknown>>(() => {
-    const raw = chat.metadata as unknown;
-    if (typeof raw === "string") {
-      try {
-        const parsed = JSON.parse(raw);
-        return parsed && typeof parsed === "object" ? (parsed as Record<string, unknown>) : {};
-      } catch {
-        return {};
-      }
-    }
-    return raw && typeof raw === "object" ? (raw as Record<string, unknown>) : {};
-  }, [chat.metadata]);
-  const activeLorebookIds = useMemo<string[]>(
-    () =>
-      Array.isArray(metadata.activeLorebookIds)
-        ? metadata.activeLorebookIds.filter((id): id is string => typeof id === "string")
-        : [],
-    [metadata.activeLorebookIds],
-  );
-  const excludedLorebookIds = useMemo<string[]>(
-    () =>
-      Array.isArray(metadata.excludedLorebookIds)
-        ? metadata.excludedLorebookIds.filter((id): id is string => typeof id === "string")
-        : [],
-    [metadata.excludedLorebookIds],
-  );
+  const activeLorebookIds = useMemo(() => getChatActiveLorebookIds({ metadata: chat.metadata }), [chat.metadata]);
+  const excludedLorebookIds = useMemo(() => getChatExcludedLorebookIds({ metadata: chat.metadata }), [chat.metadata]);
   // chat.characterIds arrives as a JSON string from the API despite the shared type.
   const chatCharacterIds = useMemo(() => getChatCharacterIds({ characterIds: chat.characterIds }), [chat.characterIds]);
   // includeBuiltIn matches the drawer's query so built-ins (Professor Mari)
@@ -554,24 +538,14 @@ export function AgentSuiteModal({ chat, open, onClose, agents }: AgentSuiteModal
   // Mirror the drawer's active-lorebook derivation: pinned + global + chat-scoped
   // + character-linked + persona-linked, minus explicit exclusions.
   const contextLorebooks = useMemo<Array<{ id: string; name: string }>>(() => {
-    const pinnedIds = new Set(activeLorebookIds);
-    const excludedIds = new Set(excludedLorebookIds);
-    return ((allLorebooks ?? []) as Lorebook[])
-      .filter((lorebook) => {
-        if (excludedIds.has(lorebook.id)) return false;
-        if (lorebook.enabled === false || !isLorebookScopeActiveForChat(lorebook.scope, chat.id)) return false;
-        return (
-          pinnedIds.has(lorebook.id) ||
-          lorebook.isGlobal ||
-          lorebook.chatId === chat.id ||
-          (lorebook.characterIds ?? []).some((id) => chatCharacterIds.includes(id)) ||
-          (!!lorebook.characterId && chatCharacterIds.includes(lorebook.characterId)) ||
-          (!!chat.personaId &&
-            ((lorebook.personaIds ?? []).includes(chat.personaId) || lorebook.personaId === chat.personaId))
-        );
-      })
-      .map((lorebook) => ({ id: lorebook.id, name: lorebook.name }));
-  }, [activeLorebookIds, allLorebooks, chat.id, chat.personaId, chatCharacterIds, excludedLorebookIds]);
+    return deriveActiveLorebookViews({
+      activeLorebookIds,
+      chat,
+      dropExcluded: true,
+      excludedLorebookIds,
+      lorebooks: allLorebooks ?? [],
+    }).map((lorebook) => ({ id: lorebook.id, name: lorebook.name }));
+  }, [activeLorebookIds, allLorebooks, chat, excludedLorebookIds]);
   const contextLorebookIds = useMemo(() => contextLorebooks.map((lorebook) => lorebook.id), [contextLorebooks]);
   const {
     entries: lorebookEntries,
@@ -632,6 +606,12 @@ export function AgentSuiteModal({ chat, open, onClose, agents }: AgentSuiteModal
     if (ok) dirtyBlocksRef.current.clear();
     return ok;
   }, []);
+
+  useEffect(() => {
+    if (!onCloseGuardChange) return;
+    onCloseGuardChange(open ? confirmDiscardDrafts : null);
+    return () => onCloseGuardChange(null);
+  }, [confirmDiscardDrafts, onCloseGuardChange, open]);
 
   const guardedClose = useCallback(() => {
     if (closingRef.current) return;

--- a/packages/client/src/components/chat/AgentSuiteModal.tsx
+++ b/packages/client/src/components/chat/AgentSuiteModal.tsx
@@ -3,7 +3,7 @@
 // active chat have stored (memory, tracker state, custom
 // outputs), manually or via AI-assisted selection rewrites.
 // ──────────────────────────────────────────────
-import { useCallback, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { AlertTriangle, Bot, Eye, EyeOff, Loader2, RotateCcw, Save, Trash2, Wand2 } from "lucide-react";
 import { toast } from "sonner";
@@ -96,13 +96,13 @@ const TRACKER_SLICES: Record<
         return { error: "Scene data must be a JSON object" };
       }
       const record = parsed as Record<string, unknown>;
-      return {
-        date: record.date ?? null,
-        time: record.time ?? null,
-        location: record.location ?? null,
-        weather: record.weather ?? null,
-        temperature: record.temperature ?? null,
-      };
+      // Only send keys present in the edited JSON: a dropped key (e.g. from an
+      // AI rewrite) means "leave unchanged" — an explicit null still clears.
+      const patch: Record<string, unknown> = {};
+      for (const key of ["date", "time", "location", "weather", "temperature"] as const) {
+        if (key in record) patch[key] = record[key] ?? null;
+      }
+      return patch;
     },
   },
   "character-tracker": {
@@ -153,11 +153,13 @@ function formatRunTimestamp(value: string): string {
 // ── Editable data block with AI-assisted selection rewrite ──
 
 interface DataBlockProps {
+  blockId: string;
   label: string;
   description?: string;
   mode: "text" | "json";
   value: string;
   onSave: (draft: string) => Promise<void>;
+  onDirtyChange: (blockId: string, dirty: boolean) => void;
   disabled: boolean;
   agentName: string;
   connectionOptions: ConnectionOption[];
@@ -166,11 +168,13 @@ interface DataBlockProps {
 }
 
 function DataBlock({
+  blockId,
   label,
   description,
   mode,
   value,
   onSave,
+  onDirtyChange,
   disabled,
   agentName,
   connectionOptions,
@@ -191,6 +195,13 @@ function DataBlock({
 
   const currentText = draft ?? value;
   const isDirty = draft !== null && draft !== value;
+  const busy = saving || rewrite.isPending;
+
+  // Report dirty state so the modal can guard close/agent-switch transitions.
+  useEffect(() => {
+    onDirtyChange(blockId, isDirty);
+    return () => onDirtyChange(blockId, false);
+  }, [blockId, isDirty, onDirtyChange]);
 
   const captureSelection = useCallback(() => {
     const el = textareaRef.current;
@@ -199,7 +210,7 @@ function DataBlock({
   }, []);
 
   const handleSave = useCallback(async () => {
-    if (!isDirty || saving) return;
+    if (!isDirty || busy) return;
     if (mode === "json") {
       try {
         JSON.parse(currentText);
@@ -218,10 +229,10 @@ function DataBlock({
     } finally {
       setSaving(false);
     }
-  }, [currentText, isDirty, mode, onSave, saving]);
+  }, [busy, currentText, isDirty, mode, onSave]);
 
   const handleRewrite = useCallback(async () => {
-    if (rewrite.isPending || !instruction.trim() || !rewriteConnectionId) return;
+    if (busy || !instruction.trim() || !rewriteConnectionId) return;
     const text = currentText;
     const clamped =
       selection && selection.start < selection.end && selection.end <= text.length
@@ -255,7 +266,7 @@ function DataBlock({
     } catch (err) {
       setError(err instanceof Error ? err.message : "AI rewrite failed");
     }
-  }, [agentName, currentText, instruction, label, rewrite, rewriteConnectionId, selection]);
+  }, [agentName, busy, currentText, instruction, label, rewrite, rewriteConnectionId, selection]);
 
   return (
     <div className="rounded-lg border border-[var(--border)] bg-[var(--secondary)]/35 p-2.5">
@@ -298,14 +309,23 @@ function DataBlock({
           setError(null);
         }}
         onSelect={captureSelection}
-        disabled={disabled}
+        disabled={disabled || busy}
         rows={Math.min(14, Math.max(3, currentText.split("\n").length))}
         spellCheck={false}
         className="mt-2 w-full resize-y rounded-md border border-[var(--input)] bg-[var(--secondary)]/45 px-2 py-1.5 font-mono text-[0.625rem] leading-relaxed text-[var(--foreground)] outline-none transition-colors focus:border-[var(--ring)] focus:ring-1 focus:ring-[var(--ring)] disabled:opacity-60"
       />
 
       {aiOpen && (
-        <div className="mt-2 space-y-2 rounded-md border border-[var(--primary)]/25 bg-[var(--primary)]/5 p-2">
+        <div
+          className="mt-2 space-y-2 rounded-md border border-[var(--primary)]/25 bg-[var(--primary)]/5 p-2"
+          onKeyDown={(event) => {
+            // Habitual Escape should close the AI panel, not the whole modal.
+            if (event.key === "Escape") {
+              event.stopPropagation();
+              setAiOpen(false);
+            }
+          }}
+        >
           <p className="text-[0.625rem] text-[var(--muted-foreground)]">
             {selection && selection.start < selection.end
               ? `Rewriting the selected ${selection.end - selection.start} characters.`
@@ -356,7 +376,7 @@ function DataBlock({
             setDraft(null);
             setError(null);
           }}
-          disabled={!isDirty || saving}
+          disabled={!isDirty || busy}
           className="inline-flex min-h-7 items-center gap-1 rounded-md border border-[var(--border)] px-2 py-1 text-[0.625rem] text-[var(--muted-foreground)] transition-colors hover:bg-[var(--accent)] focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-[var(--ring)] disabled:cursor-not-allowed disabled:opacity-40"
         >
           <RotateCcw size="0.625rem" />
@@ -365,7 +385,7 @@ function DataBlock({
         <button
           type="button"
           onClick={handleSave}
-          disabled={disabled || !isDirty || saving}
+          disabled={disabled || !isDirty || busy}
           className="inline-flex min-h-7 items-center gap-1 rounded-md bg-[var(--primary)] px-2.5 py-1 text-[0.625rem] font-medium text-[var(--primary-foreground)] transition-opacity hover:opacity-90 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-[var(--ring)] disabled:cursor-not-allowed disabled:opacity-50"
         >
           {saving ? <Loader2 size="0.625rem" className="animate-spin" /> : <Save size="0.625rem" />}
@@ -384,13 +404,15 @@ export function AgentSuiteModal({ chat, open, onClose, agents }: AgentSuiteModal
   // 1. Zustand selectors
   const isAgentProcessing = useAgentStore((s) => s.processingChatIds.includes(chat.id));
 
-  // 2. React Query hooks
-  const { data: connections } = useConnections();
+  // Agent selection — local state the queries below take as input.
   const [selectedAgentId, setSelectedAgentId] = useState<string | null>(null);
-  const effectiveAgentId = selectedAgentId && agents.some((a) => a.id === selectedAgentId) ? selectedAgentId : (agents[0]?.id ?? null);
+  const effectiveAgentId =
+    selectedAgentId && agents.some((a) => a.id === selectedAgentId) ? selectedAgentId : (agents[0]?.id ?? null);
   const selectedAgent = agents.find((a) => a.id === effectiveAgentId) ?? null;
   const isTrackerAgent = !!selectedAgent && !!TRACKER_SLICES[selectedAgent.id];
 
+  // 2. React Query hooks
+  const { data: connections } = useConnections();
   const memoryQuery = useAgentMemory(effectiveAgentId, chat.id, open);
   const updateMemory = useUpdateAgentMemory();
   const gameStateKey = useMemo(() => ["agent-suite", "game-state", chat.id] as const, [chat.id]);
@@ -406,6 +428,20 @@ export function AgentSuiteModal({ chat, open, onClose, agents }: AgentSuiteModal
   // 3. Local state
   const [rewriteConnectionId, setRewriteConnectionId] = useState("");
   const [spoilersRevealed, setSpoilersRevealed] = useState(false);
+  const dirtyBlocksRef = useRef<Set<string>>(new Set());
+  const closingRef = useRef(false);
+  const wasProcessingRef = useRef(isAgentProcessing);
+
+  // Agents finishing a run may have rewritten memory and tracker state on the
+  // server; refetch so pristine blocks show the fresh values instead of
+  // letting a later save silently clobber agent-written data.
+  useEffect(() => {
+    if (wasProcessingRef.current && !isAgentProcessing && open) {
+      void qc.invalidateQueries({ queryKey: ["agent-memory"] });
+      void qc.invalidateQueries({ queryKey: gameStateKey });
+    }
+    wasProcessingRef.current = isAgentProcessing;
+  }, [gameStateKey, isAgentProcessing, open, qc]);
 
   // 4. Memos and callbacks
   const connectionOptions = useMemo(() => {
@@ -423,18 +459,85 @@ export function AgentSuiteModal({ chat, open, onClose, agents }: AgentSuiteModal
     return (agentDefault ?? chatConnection ?? connectionOptions[0])?.id ?? "";
   }, [chat.connectionId, connectionOptions, rewriteConnectionId]);
 
+  const handleBlockDirtyChange = useCallback((blockId: string, dirty: boolean) => {
+    if (dirty) dirtyBlocksRef.current.add(blockId);
+    else dirtyBlocksRef.current.delete(blockId);
+  }, []);
+
+  const confirmDiscardDrafts = useCallback(async () => {
+    if (dirtyBlocksRef.current.size === 0) return true;
+    const ok = await showConfirmDialog({
+      title: "Discard Unsaved Changes",
+      message: "You have unsaved edits in the Agent Suite. Discard them?",
+      confirmLabel: "Discard",
+      cancelLabel: "Keep Editing",
+      tone: "destructive",
+    });
+    if (ok) dirtyBlocksRef.current.clear();
+    return ok;
+  }, []);
+
+  const guardedClose = useCallback(() => {
+    if (closingRef.current) return;
+    closingRef.current = true;
+    void (async () => {
+      try {
+        if (await confirmDiscardDrafts()) onClose();
+      } finally {
+        closingRef.current = false;
+      }
+    })();
+  }, [confirmDiscardDrafts, onClose]);
+
+  const selectAgent = useCallback(
+    (agentId: string) => {
+      if (agentId === effectiveAgentId) return;
+      void (async () => {
+        if (!(await confirmDiscardDrafts())) return;
+        setSelectedAgentId(agentId);
+        setSpoilersRevealed(false);
+      })();
+    },
+    [confirmDiscardDrafts, effectiveAgentId],
+  );
+
   const refreshGameState = useCallback(async () => {
+    // Land any queued HUD tracker edits first so the snapshot includes them.
+    let hudInSync = true;
+    const flushPatch = useGameStateStore.getState().flushPatch;
+    if (flushPatch) {
+      try {
+        await flushPatch();
+      } catch {
+        hudInSync = false; // edits were requeued — don't clobber optimistic HUD state
+      }
+    }
     const fresh = await api.get<GameState | null>(`/chats/${chat.id}/game-state`);
     qc.setQueryData(gameStateKey, fresh);
     // Keep the live tracker HUD in sync when this chat is on screen.
-    if (useChatStore.getState().activeChatId === chat.id) {
+    if (hudInSync && useChatStore.getState().activeChatId === chat.id) {
       useGameStateStore.getState().setGameState(fresh ?? null);
     }
   }, [chat.id, gameStateKey, qc]);
 
   const saveMemoryKey = useCallback(
     async (agentType: string, key: string, mode: "text" | "json", draftText: string) => {
-      const parsed: unknown = mode === "json" ? JSON.parse(draftText) : draftText;
+      let parsed: unknown;
+      if (mode === "json") {
+        parsed = JSON.parse(draftText);
+      } else {
+        // The server stores strings raw and JSON.parses on read, so a text
+        // draft that happens to decode as JSON ("123", "true", '{"a":1}')
+        // would change type on the next read. Pre-encode exactly those drafts
+        // as JSON string literals to keep them strings round-trip.
+        parsed = draftText;
+        try {
+          JSON.parse(draftText);
+          parsed = JSON.stringify(draftText);
+        } catch {
+          /* not JSON-parsable — stored raw and read back verbatim */
+        }
+      }
       await updateMemory.mutateAsync({ agentType, chatId: chat.id, patch: { [key]: parsed } });
     },
     [chat.id, updateMemory],
@@ -443,14 +546,28 @@ export function AgentSuiteModal({ chat, open, onClose, agents }: AgentSuiteModal
   const saveTrackerSlice = useCallback(
     async (agentId: string, draftText: string) => {
       const slice = TRACKER_SLICES[agentId];
-      const snapshot = gameStateQuery.data;
-      if (!slice || !snapshot) throw new Error("No tracker snapshot to update");
+      if (!slice) throw new Error("No tracker snapshot to update");
+      // Flush queued HUD edits, then build the patch from a fresh snapshot so
+      // the whole-playerStats write can't revert concurrent agent or HUD
+      // updates made after the modal fetched its display copy.
+      await useGameStateStore.getState().flushPatch?.();
+      const snapshot = await api.get<GameState | null>(`/chats/${chat.id}/game-state`);
+      if (!snapshot) throw new Error("No tracker snapshot to update");
+      qc.setQueryData(gameStateKey, snapshot);
       const patch = slice.buildPatch(snapshot, JSON.parse(draftText));
       if ("error" in patch && typeof patch.error === "string") throw new Error(patch.error);
-      await api.patch(`/chats/${chat.id}/game-state`, { ...patch, manual: true });
+      // Target the exact row the snapshot came from, like use-game-state-patcher.
+      await api.patch(`/chats/${chat.id}/game-state`, {
+        ...patch,
+        manual: true,
+        ...(snapshot.messageId ? { messageId: snapshot.messageId } : {}),
+        ...(snapshot.messageId && Number.isInteger(snapshot.swipeIndex) && snapshot.swipeIndex >= 0
+          ? { swipeIndex: snapshot.swipeIndex }
+          : {}),
+      });
       await refreshGameState();
     },
-    [chat.id, gameStateQuery.data, refreshGameState],
+    [chat.id, gameStateKey, qc, refreshGameState],
   );
 
   const clearAgentMemory = useCallback(async () => {
@@ -491,7 +608,7 @@ export function AgentSuiteModal({ chat, open, onClose, agents }: AgentSuiteModal
 
   // 5. Render
   return (
-    <Modal open={open} onClose={onClose} title="Agent Suite" width="max-w-3xl" chatFloatingPanel>
+    <Modal open={open} onClose={guardedClose} title="Agent Suite" width="max-w-3xl" chatFloatingPanel>
       {agents.length === 0 ? (
         <div className="rounded-lg border border-dashed border-[var(--border)] px-3 py-6 text-center text-[0.6875rem] text-[var(--muted-foreground)]">
           No agents are active in this chat. Add agents in the Agents section first.
@@ -502,10 +619,7 @@ export function AgentSuiteModal({ chat, open, onClose, agents }: AgentSuiteModal
           <div className="shrink-0 sm:w-44">
             <select
               value={effectiveAgentId ?? ""}
-              onChange={(event) => {
-                setSelectedAgentId(event.target.value);
-                setSpoilersRevealed(false);
-              }}
+              onChange={(event) => selectAgent(event.target.value)}
               className="w-full rounded-lg bg-[var(--secondary)] px-3 py-2 text-xs outline-none ring-1 ring-[var(--border)] transition-shadow focus:ring-[var(--primary)]/40 sm:hidden"
             >
               {agents.map((agent) => (
@@ -519,10 +633,7 @@ export function AgentSuiteModal({ chat, open, onClose, agents }: AgentSuiteModal
                 <button
                   key={agent.id}
                   type="button"
-                  onClick={() => {
-                    setSelectedAgentId(agent.id);
-                    setSpoilersRevealed(false);
-                  }}
+                  onClick={() => selectAgent(agent.id)}
                   className={cn(
                     "flex w-full flex-col rounded-lg px-2.5 py-2 text-left transition-all",
                     agent.id === effectiveAgentId
@@ -609,10 +720,12 @@ export function AgentSuiteModal({ chat, open, onClose, agents }: AgentSuiteModal
                     memoryEntries.map((entry) => (
                       <DataBlock
                         key={`${selectedAgent.id}:memory:${entry.key}`}
+                        blockId={`${selectedAgent.id}:memory:${entry.key}`}
                         label={entry.key}
                         mode={entry.mode}
                         value={entry.serialized}
                         onSave={(draftText) => saveMemoryKey(selectedAgent.id, entry.key, entry.mode, draftText)}
+                        onDirtyChange={handleBlockDirtyChange}
                         disabled={isAgentProcessing}
                         agentName={selectedAgent.name}
                         connectionOptions={connectionOptions}
@@ -646,11 +759,13 @@ export function AgentSuiteModal({ chat, open, onClose, agents }: AgentSuiteModal
                       <>
                         <DataBlock
                           key={`${selectedAgent.id}:tracker`}
+                          blockId={`${selectedAgent.id}:tracker`}
                           label={trackerSlice.label}
                           description={trackerSlice.description}
                           mode="json"
                           value={serializeValue(trackerSlice.getValue(gameStateQuery.data), "json")}
                           onSave={(draftText) => saveTrackerSlice(selectedAgent.id, draftText)}
+                          onDirtyChange={handleBlockDirtyChange}
                           disabled={isAgentProcessing}
                           agentName={selectedAgent.name}
                           connectionOptions={connectionOptions}
@@ -694,6 +809,7 @@ export function AgentSuiteModal({ chat, open, onClose, agents }: AgentSuiteModal
                       return (
                         <DataBlock
                           key={run.id}
+                          blockId={run.id}
                           label={run.resultType.replace(/_/g, " ")}
                           description={formatRunTimestamp(run.createdAt)}
                           mode={mode}
@@ -702,6 +818,7 @@ export function AgentSuiteModal({ chat, open, onClose, agents }: AgentSuiteModal
                             const parsed: unknown = mode === "json" ? JSON.parse(draftText) : draftText;
                             await updateRunData.mutateAsync({ id: run.id, chatId: chat.id, resultData: parsed });
                           }}
+                          onDirtyChange={handleBlockDirtyChange}
                           disabled={isAgentProcessing}
                           agentName={selectedAgent.name}
                           connectionOptions={connectionOptions}

--- a/packages/client/src/components/chat/ChatSettingsDrawer.tsx
+++ b/packages/client/src/components/chat/ChatSettingsDrawer.tsx
@@ -49,6 +49,7 @@ import {
   Music2,
   ShieldCheck,
   Loader2,
+  Wrench,
 } from "lucide-react";
 import {
   ROLEPLAY_POPOVER_CLOSE_BUTTON,
@@ -80,6 +81,7 @@ import { Modal } from "../ui/Modal";
 import { ChoiceSelectionModal } from "../presets/ChoiceSelectionModal";
 import { SecretPlotPanel } from "../agents/SecretPlotPanel";
 import { SummariesEditorModal } from "./SummariesEditorModal";
+import { AgentSuiteModal } from "./AgentSuiteModal";
 import { useCharacters, usePersonas, useCharacterGroups, type SpriteInfo } from "../../hooks/use-characters";
 import { useLorebooks, useEntriesAcrossLorebooks } from "../../hooks/use-lorebooks";
 import { useDefaultPreset, usePresetFull, usePresets } from "../../hooks/use-presets";
@@ -1162,6 +1164,13 @@ export function ChatSettingsDrawer({
   const visibleActiveAgentIds = useMemo(
     () => activeAgentIds.filter((agentId) => availableAgents.some((agent) => agent.id === agentId)),
     [activeAgentIds, availableAgents],
+  );
+  const agentSuiteAgents = useMemo(
+    () =>
+      visibleActiveAgentIds
+        .map((agentId) => availableAgents.find((agent) => agent.id === agentId))
+        .filter((agent): agent is AvailableAgent => !!agent),
+    [availableAgents, visibleActiveAgentIds],
   );
   const getAgentDisplayMeta = useCallback(
     (agentId: string, fallback: { name: string; description: string }) => {
@@ -2278,6 +2287,7 @@ export function ChatSettingsDrawer({
   const [showPersonaPicker, setShowPersonaPicker] = useState(false);
   const [showConnectionPicker, setShowConnectionPicker] = useState(false);
   const [showSummariesModal, setShowSummariesModal] = useState(false);
+  const [showAgentSuiteModal, setShowAgentSuiteModal] = useState(false);
   const [showMemoriesModal, setShowMemoriesModal] = useState(false);
   // Session-ephemeral: did the user change Day Rollover Hour in this drawer mount?
   // Used to gate the "transitional duplication" warning so it only appears
@@ -5345,6 +5355,18 @@ export function ChatSettingsDrawer({
                     </div>
                   </button>
                 )}
+                <button
+                  onClick={() => setShowAgentSuiteModal(true)}
+                  className="flex w-full items-center justify-between rounded-lg bg-[var(--secondary)] px-3 py-2.5 text-left transition-all hover:bg-[var(--accent)]"
+                >
+                  <div className="flex-1 min-w-0">
+                    <span className="text-[0.6875rem] font-medium">Agent Suite</span>
+                    <p className="text-[0.625rem] text-[var(--muted-foreground)]">
+                      View and edit everything agents have stored in this chat — manually or with AI.
+                    </p>
+                  </div>
+                  <Wrench size="0.875rem" className="shrink-0 text-[var(--muted-foreground)]" />
+                </button>
                 {roleplayAgentMenuLinks.length > 0 && (
                   <div className="rounded-lg bg-[var(--background)]/45 px-2.5 py-2 ring-1 ring-[var(--border)]">
                     <div className="mb-1.5 flex items-center gap-1.5 text-[0.625rem] font-medium text-[var(--muted-foreground)]">
@@ -7177,6 +7199,14 @@ export function ChatSettingsDrawer({
 
       {/* Automatic summarization editor */}
       <SummariesEditorModal chat={chat} open={showSummariesModal} onClose={() => setShowSummariesModal(false)} />
+
+      {/* Agent Suite — stored agent data viewer/editor */}
+      <AgentSuiteModal
+        chat={chat}
+        open={showAgentSuiteModal}
+        onClose={() => setShowAgentSuiteModal(false)}
+        agents={agentSuiteAgents}
+      />
 
       {/* Memory recall chunk viewer */}
       <MemoryRecallMemoriesModal

--- a/packages/client/src/components/chat/ChatSettingsDrawer.tsx
+++ b/packages/client/src/components/chat/ChatSettingsDrawer.tsx
@@ -69,7 +69,7 @@ import { DiscordMirrorControls } from "../../features/chat-settings/sections/Dis
 import { FunctionCallingSection } from "../../features/chat-settings/sections/FunctionCallingSection";
 import { GameExtraPromptSection } from "../../features/chat-settings/sections/GameExtraPromptSection";
 import { ImpersonateSection } from "../../features/chat-settings/sections/ImpersonateSection";
-import { LorebooksSection, type ActiveLorebookView } from "../../features/chat-settings/sections/LorebooksSection";
+import { LorebooksSection } from "../../features/chat-settings/sections/LorebooksSection";
 import { PromptPresetSection } from "../../features/chat-settings/sections/PromptPresetSection";
 import { SceneInstructionsSection } from "../../features/chat-settings/sections/SceneInstructionsSection";
 import { TranslationSection } from "../../features/chat-settings/sections/TranslationSection";
@@ -114,6 +114,12 @@ import {
   appendLocalSidecarConnectionOption,
   filterLanguageGenerationConnections,
 } from "../../lib/connection-filters";
+import {
+  deriveActiveLorebookViews,
+  getChatActiveLorebookIds,
+  getChatExcludedLorebookIds,
+  type ActiveLorebookView,
+} from "../../lib/chat-lorebooks";
 import { getConnectedChatDisplayName } from "../../lib/chat-display";
 import { getTouchReorderDropIndex } from "../../lib/touch-reorder";
 import {
@@ -601,20 +607,6 @@ function getChatActiveAgentIds(chat: Chat): string[] {
   return Array.isArray(activeIds) ? activeIds.filter((id): id is string => typeof id === "string") : [];
 }
 
-function getChatActiveLorebookIds(chat: Chat): string[] {
-  const metadata = typeof chat.metadata === "string" ? JSON.parse(chat.metadata) : (chat.metadata ?? {});
-  const activeIds =
-    metadata && typeof metadata === "object" ? (metadata as { activeLorebookIds?: unknown }).activeLorebookIds : [];
-  return Array.isArray(activeIds) ? activeIds.filter((id): id is string => typeof id === "string") : [];
-}
-
-function getChatExcludedLorebookIds(chat: Chat): string[] {
-  const metadata = typeof chat.metadata === "string" ? JSON.parse(chat.metadata) : (chat.metadata ?? {});
-  const excludedIds =
-    metadata && typeof metadata === "object" ? (metadata as { excludedLorebookIds?: unknown }).excludedLorebookIds : [];
-  return Array.isArray(excludedIds) ? excludedIds.filter((id): id is string => typeof id === "string") : [];
-}
-
 export function ChatSettingsDrawer({
   chat,
   open,
@@ -632,6 +624,8 @@ export function ChatSettingsDrawer({
   const panelRef = useRef<HTMLDivElement | null>(null);
   const scheduleControlsRef = useRef<HTMLDivElement | null>(null);
   const modePromptDefaultAppliedRef = useRef<string | null>(null);
+  const agentSuiteCloseGuardRef = useRef<(() => Promise<boolean>) | null>(null);
+  const drawerClosingRef = useRef(false);
   const updateChat = useUpdateChat();
   const updateMeta = useUpdateChatMetadata();
   const updateGameWidgets = useUpdateGameWidgets();
@@ -869,18 +863,12 @@ export function ChatSettingsDrawer({
     typeof metadata.autonomousDailyCapOverride === "number" && Number.isFinite(metadata.autonomousDailyCapOverride)
       ? Math.max(1, Math.floor(metadata.autonomousDailyCapOverride))
       : null;
-  const activeLorebookIds = useMemo<string[]>(
-    () => (Array.isArray(metadata.activeLorebookIds) ? metadata.activeLorebookIds : []),
-    [metadata.activeLorebookIds],
-  );
+  const activeLorebookIds = useMemo(() => getChatActiveLorebookIds({ metadata: chat.metadata }), [chat.metadata]);
   const readLatestActiveLorebookIds = useCallback(() => {
     const latestChat = qc.getQueryData<Chat>(chatKeys.detail(chat.id));
     return latestChat ? getChatActiveLorebookIds(latestChat) : [...activeLorebookIds];
   }, [activeLorebookIds, chat.id, qc]);
-  const excludedLorebookIds = useMemo<string[]>(
-    () => (Array.isArray(metadata.excludedLorebookIds) ? metadata.excludedLorebookIds : []),
-    [metadata.excludedLorebookIds],
-  );
+  const excludedLorebookIds = useMemo(() => getChatExcludedLorebookIds({ metadata: chat.metadata }), [chat.metadata]);
   const readLatestExcludedLorebookIds = useCallback(() => {
     const latestChat = qc.getQueryData<Chat>(chatKeys.detail(chat.id));
     return latestChat ? getChatExcludedLorebookIds(latestChat) : [...excludedLorebookIds];
@@ -889,50 +877,18 @@ export function ChatSettingsDrawer({
   const gameLorebookKeeperLorebookId =
     typeof metadata.gameLorebookKeeperLorebookId === "string" ? metadata.gameLorebookKeeperLorebookId : null;
   const activeLorebooks = useMemo<ActiveLorebookView[]>(() => {
-    const pinnedIds = new Set(activeLorebookIds);
-    const excludedIds = new Set(excludedLorebookIds);
-    const lorebookList = (lorebooks ?? []) as Lorebook[];
-
-    return lorebookList.flatMap((lorebook) => {
-      if (
-        isGame &&
-        !gameLorebookKeeperEnabled &&
-        (lorebook.id === gameLorebookKeeperLorebookId || lorebook.sourceAgentId === "game-lorebook-keeper")
-      ) {
-        return [];
-      }
-
-      const reasons: ActiveLorebookView["activeReasons"] = [];
-      const isPinned = pinnedIds.has(lorebook.id);
-
-      if (lorebook.enabled !== false && isLorebookScopeActiveForChat(lorebook.scope, chat.id)) {
-        if (isPinned) reasons.push("Chat");
-        if (lorebook.isGlobal) reasons.push("Global");
-        if (
-          lorebook.characterIds?.some((id) => chatCharIds.includes(id)) ||
-          (lorebook.characterId && chatCharIds.includes(lorebook.characterId))
-        ) {
-          reasons.push("Character");
-        }
-        if (
-          chat.personaId &&
-          (lorebook.personaIds?.includes(chat.personaId) || lorebook.personaId === chat.personaId)
-        ) {
-          reasons.push("Persona");
-        }
-        if (lorebook.chatId === chat.id && !reasons.includes("Chat")) reasons.push("Chat");
-      }
-
-      return reasons.length > 0
-        ? [{ ...lorebook, activeReasons: reasons, isPinned, isExcluded: excludedIds.has(lorebook.id) }]
-        : [];
+    return deriveActiveLorebookViews({
+      activeLorebookIds,
+      chat,
+      excludedLorebookIds,
+      excludeGameLorebookKeeper: isGame && !gameLorebookKeeperEnabled,
+      gameLorebookKeeperLorebookId,
+      lorebooks: (lorebooks ?? []) as Lorebook[],
     });
   }, [
     activeLorebookIds,
     excludedLorebookIds,
-    chat.id,
-    chat.personaId,
-    chatCharIds,
+    chat,
     gameLorebookKeeperEnabled,
     gameLorebookKeeperLorebookId,
     isGame,
@@ -2289,6 +2245,24 @@ export function ChatSettingsDrawer({
   const [showSummariesModal, setShowSummariesModal] = useState(false);
   const [showAgentSuiteModal, setShowAgentSuiteModal] = useState(false);
   const [showMemoriesModal, setShowMemoriesModal] = useState(false);
+  const handleAgentSuiteCloseGuardChange = useCallback((guard: (() => Promise<boolean>) | null) => {
+    agentSuiteCloseGuardRef.current = guard;
+  }, []);
+  const requestClose = useCallback(() => {
+    if (drawerClosingRef.current) return;
+    drawerClosingRef.current = true;
+    void (async () => {
+      try {
+        const canCloseAgentSuite =
+          !showAgentSuiteModal || (await (agentSuiteCloseGuardRef.current?.() ?? Promise.resolve(true)));
+        if (!canCloseAgentSuite) return;
+        setShowAgentSuiteModal(false);
+        onClose();
+      } finally {
+        drawerClosingRef.current = false;
+      }
+    })();
+  }, [onClose, showAgentSuiteModal]);
   // Session-ephemeral: did the user change Day Rollover Hour in this drawer mount?
   // Used to gate the "transitional duplication" warning so it only appears
   // immediately after a change (when the warning is operationally useful) and
@@ -3044,12 +3018,12 @@ export function ChatSettingsDrawer({
       if (!(target instanceof Node)) return;
       if (panelRef.current?.contains(target)) return;
       if (target instanceof Element && target.closest("[data-chat-floating-panel]")) return;
-      onClose();
+      requestClose();
     };
 
     document.addEventListener("pointerdown", handlePointerDown, true);
     return () => document.removeEventListener("pointerdown", handlePointerDown, true);
-  }, [onClose, open]);
+  }, [open, requestClose]);
 
   if (!open) return null;
   const anchoredOnMobile = !!anchor && typeof window !== "undefined" && window.innerWidth < 768;
@@ -3089,7 +3063,7 @@ export function ChatSettingsDrawer({
           </h3>
           <button
             type="button"
-            onClick={onClose}
+            onClick={requestClose}
             aria-label="Close chat settings"
             className={ROLEPLAY_POPOVER_CLOSE_BUTTON}
           >
@@ -7205,6 +7179,7 @@ export function ChatSettingsDrawer({
         chat={chat}
         open={showAgentSuiteModal}
         onClose={() => setShowAgentSuiteModal(false)}
+        onCloseGuardChange={handleAgentSuiteCloseGuardChange}
         agents={agentSuiteAgents}
       />
 

--- a/packages/client/src/components/ui/AppDialogRenderer.tsx
+++ b/packages/client/src/components/ui/AppDialogRenderer.tsx
@@ -45,7 +45,16 @@ export function AppDialogRenderer() {
       : "bg-[var(--primary)] text-white hover:bg-[var(--primary)]/85";
 
   return (
-    <Modal open onClose={dismissActiveDialog} title={getDialogTitle(dialog.kind, dialog.title)} width="max-w-sm">
+    // chatFloatingPanel: app dialogs are topmost confirmations — clicking them
+    // must never register as an outside click that closes a chat drawer (and
+    // unmounts the very modal whose dirty-draft guard opened the dialog).
+    <Modal
+      open
+      onClose={dismissActiveDialog}
+      title={getDialogTitle(dialog.kind, dialog.title)}
+      width="max-w-sm"
+      chatFloatingPanel
+    >
       <div className="space-y-4">
         <p className="whitespace-pre-wrap text-sm leading-relaxed text-[var(--foreground)]">{dialog.message}</p>
 

--- a/packages/client/src/features/chat-settings/sections/LorebooksSection.tsx
+++ b/packages/client/src/features/chat-settings/sections/LorebooksSection.tsx
@@ -2,18 +2,10 @@ import { useEffect, useState } from "react";
 import { BookOpen, Eye, EyeOff, Plus, Trash2 } from "lucide-react";
 import { LIMITS, type Lorebook } from "@marinara-engine/shared";
 import { isLorebookScopeActiveForChat } from "../../../lib/lorebook-scope";
+import type { ActiveLorebookView } from "../../../lib/chat-lorebooks";
 import { HelpTooltip } from "../../../components/ui/HelpTooltip";
 import { ChatSettingsSection } from "../ChatSettingsSection";
 import { PickerDropdown } from "../PickerDropdown";
-
-type LorebookActiveReason = "Global" | "Character" | "Persona" | "Chat";
-
-export type ActiveLorebookView = Lorebook & {
-  activeReasons: LorebookActiveReason[];
-  isPinned: boolean;
-  /** User disabled this auto-activated book for the chat (in excludedLorebookIds). */
-  isExcluded: boolean;
-};
 
 interface LorebooksSectionProps {
   chatId: string;

--- a/packages/client/src/hooks/use-agents.ts
+++ b/packages/client/src/hooks/use-agents.ts
@@ -2,12 +2,15 @@
 // Hooks: Agent Configs (React Query)
 // ──────────────────────────────────────────────
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
-import { api } from "../lib/api-client";
+import type { AgentSuiteRewriteInput } from "@marinara-engine/shared";
+import { ApiError, api } from "../lib/api-client";
 
 export const agentKeys = {
   all: ["agents"] as const,
   detail: (id: string) => ["agents", id] as const,
   customRuns: (chatId: string) => ["agents", "runs", "custom", chatId] as const,
+  // Same key shape SecretPlotPanel uses inline, so invalidations stay coherent.
+  memory: (agentType: string, chatId: string) => ["agent-memory", agentType, chatId] as const,
 };
 
 export interface AgentConfigRow {
@@ -119,6 +122,54 @@ export function useCreateAgent() {
       }
       qc.invalidateQueries({ queryKey: agentKeys.all });
     },
+  });
+}
+
+export interface AgentMemoryResponse {
+  agentConfigId: string;
+  memory: Record<string, unknown>;
+}
+
+export function useAgentMemory(agentType: string | null, chatId: string | null, enabled = true) {
+  return useQuery({
+    queryKey: agentKeys.memory(agentType ?? "", chatId ?? ""),
+    queryFn: async (): Promise<AgentMemoryResponse> => {
+      try {
+        return await api.get<AgentMemoryResponse>(`/agents/memory/${agentType}/${chatId}`);
+      } catch (err) {
+        // Agents without a saved config 404 here — that just means no stored memory.
+        if (err instanceof ApiError && err.status === 404) {
+          return { agentConfigId: "", memory: {} };
+        }
+        throw err;
+      }
+    },
+    enabled: !!agentType && !!chatId && enabled,
+    staleTime: 15_000,
+  });
+}
+
+export function useUpdateAgentMemory() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: ({
+      agentType,
+      chatId,
+      patch,
+    }: {
+      agentType: string;
+      chatId: string;
+      patch: Record<string, unknown>;
+    }) => api.patch<AgentMemoryResponse>(`/agents/memory/${agentType}/${chatId}`, { patch }),
+    onSuccess: (_data, variables) => {
+      qc.invalidateQueries({ queryKey: agentKeys.memory(variables.agentType, variables.chatId) });
+    },
+  });
+}
+
+export function useAgentSuiteRewrite() {
+  return useMutation({
+    mutationFn: (body: AgentSuiteRewriteInput) => api.post<{ rewrittenText: string }>("/agents/suite/rewrite", body),
   });
 }
 

--- a/packages/client/src/hooks/use-agents.ts
+++ b/packages/client/src/hooks/use-agents.ts
@@ -135,7 +135,9 @@ export function useAgentMemory(agentType: string | null, chatId: string | null, 
     queryKey: agentKeys.memory(agentType ?? "", chatId ?? ""),
     queryFn: async (): Promise<AgentMemoryResponse> => {
       try {
-        return await api.get<AgentMemoryResponse>(`/agents/memory/${agentType}/${chatId}`);
+        return await api.get<AgentMemoryResponse>(
+          `/agents/memory/${encodeURIComponent(agentType ?? "")}/${encodeURIComponent(chatId ?? "")}`,
+        );
       } catch (err) {
         // Agents without a saved config 404 here — that just means no stored memory.
         if (err instanceof ApiError && err.status === 404) {
@@ -160,7 +162,11 @@ export function useUpdateAgentMemory() {
       agentType: string;
       chatId: string;
       patch: Record<string, unknown>;
-    }) => api.patch<AgentMemoryResponse>(`/agents/memory/${agentType}/${chatId}`, { patch }),
+    }) =>
+      api.patch<AgentMemoryResponse>(
+        `/agents/memory/${encodeURIComponent(agentType)}/${encodeURIComponent(chatId)}`,
+        { patch },
+      ),
     onSuccess: (_data, variables) => {
       qc.invalidateQueries({ queryKey: agentKeys.memory(variables.agentType, variables.chatId) });
     },

--- a/packages/client/src/lib/chat-lorebooks.ts
+++ b/packages/client/src/lib/chat-lorebooks.ts
@@ -1,0 +1,93 @@
+import type { Chat, Lorebook } from "@marinara-engine/shared";
+import { getChatCharacterIds } from "./chat-macros";
+import { isLorebookScopeActiveForChat } from "./lorebook-scope";
+
+export type LorebookActiveReason = "Global" | "Character" | "Persona" | "Chat";
+
+export type ActiveLorebookView = Lorebook & {
+  activeReasons: LorebookActiveReason[];
+  isPinned: boolean;
+  /** User disabled this auto-activated book for the chat (in excludedLorebookIds). */
+  isExcluded: boolean;
+};
+
+function parseChatMetadata(value: unknown): Record<string, unknown> {
+  if (typeof value === "string") {
+    try {
+      const parsed = JSON.parse(value);
+      return parsed && typeof parsed === "object" ? (parsed as Record<string, unknown>) : {};
+    } catch {
+      return {};
+    }
+  }
+  return value && typeof value === "object" ? (value as Record<string, unknown>) : {};
+}
+
+function readStringArray(value: unknown): string[] {
+  return Array.isArray(value) ? value.filter((id): id is string => typeof id === "string") : [];
+}
+
+export function getChatActiveLorebookIds(chat: Pick<Chat, "metadata">): string[] {
+  return readStringArray(parseChatMetadata(chat.metadata).activeLorebookIds);
+}
+
+export function getChatExcludedLorebookIds(chat: Pick<Chat, "metadata">): string[] {
+  return readStringArray(parseChatMetadata(chat.metadata).excludedLorebookIds);
+}
+
+export function deriveActiveLorebookViews({
+  activeLorebookIds,
+  chat,
+  dropExcluded = false,
+  excludedLorebookIds,
+  excludeGameLorebookKeeper = false,
+  gameLorebookKeeperLorebookId = null,
+  lorebooks,
+}: {
+  activeLorebookIds: string[];
+  chat: Pick<Chat, "characterIds" | "id" | "personaId">;
+  dropExcluded?: boolean;
+  excludedLorebookIds: string[];
+  excludeGameLorebookKeeper?: boolean;
+  gameLorebookKeeperLorebookId?: string | null;
+  lorebooks: Lorebook[];
+}): ActiveLorebookView[] {
+  const chatCharacterIds = getChatCharacterIds({ characterIds: chat.characterIds });
+  const pinnedIds = new Set(activeLorebookIds);
+  const excludedIds = new Set(excludedLorebookIds);
+
+  return lorebooks.flatMap((lorebook) => {
+    if (dropExcluded && excludedIds.has(lorebook.id)) return [];
+    if (
+      excludeGameLorebookKeeper &&
+      (lorebook.id === gameLorebookKeeperLorebookId || lorebook.sourceAgentId === "game-lorebook-keeper")
+    ) {
+      return [];
+    }
+
+    const reasons: LorebookActiveReason[] = [];
+    const isPinned = pinnedIds.has(lorebook.id);
+
+    if (lorebook.enabled !== false && isLorebookScopeActiveForChat(lorebook.scope, chat.id)) {
+      if (isPinned) reasons.push("Chat");
+      if (lorebook.isGlobal) reasons.push("Global");
+      if (
+        (lorebook.characterIds ?? []).some((id) => chatCharacterIds.includes(id)) ||
+        (!!lorebook.characterId && chatCharacterIds.includes(lorebook.characterId))
+      ) {
+        reasons.push("Character");
+      }
+      if (
+        !!chat.personaId &&
+        ((lorebook.personaIds ?? []).includes(chat.personaId) || lorebook.personaId === chat.personaId)
+      ) {
+        reasons.push("Persona");
+      }
+      if (lorebook.chatId === chat.id && !reasons.includes("Chat")) reasons.push("Chat");
+    }
+
+    return reasons.length > 0
+      ? [{ ...lorebook, activeReasons: reasons, isPinned, isExcluded: excludedIds.has(lorebook.id) }]
+      : [];
+  });
+}

--- a/packages/server/src/middleware/rate-limit.ts
+++ b/packages/server/src/middleware/rate-limit.ts
@@ -28,6 +28,9 @@ const ROUTE_RULES: Array<{ pattern: RegExp; rule: RateLimitRule }> = [
     rule: { key: "sidecar-privileged", limit: 20, windowMs: 60_000 },
   },
   { pattern: /^\/api\/haptic\/command(?:\?|$)/, rule: { key: "haptic-command", limit: 30, windowMs: 60_000 } },
+  // One-shot LLM call per user click; keep it out of the 600/min default
+  // class so a runaway loop can't burn API credits.
+  { pattern: /^\/api\/agents\/suite\/rewrite(?:\?|$)/, rule: { key: "agent-suite-rewrite", limit: 20, windowMs: 60_000 } },
   // Cap on extension routes so an XSS-driven mass install / spam can't
   // exploit the persistent storage path. 60/min covers React Query
   // refetches + legacy migrations of small extension lists comfortably.

--- a/packages/server/src/routes/agents.routes.ts
+++ b/packages/server/src/routes/agents.routes.ts
@@ -34,8 +34,9 @@ const AGENT_SUITE_REWRITE_SYSTEM_PROMPT = [
   "Rules:",
   "- Return ONLY the rewritten excerpt. No explanations, no preamble, no code fences.",
   "- The excerpt may be a fragment of a larger document; the surrounding document is provided for context but must NOT be included in your output.",
+  "- Reference context blocks (character cards, lorebook entries) may be provided. Use them to ground names, facts, and details, but never copy them into the output beyond what the instruction requires.",
   "- If the excerpt is JSON or a fragment of JSON, keep the same structural shape so the result can be spliced back without breaking the document.",
-  "- Preserve everything the instruction does not ask to change. Do not invent new facts beyond what the instruction requires.",
+  "- Preserve everything the instruction does not ask to change. Do not invent new facts beyond what the instruction and provided context support.",
 ].join("\n");
 
 /** Strip a single markdown code fence when it wraps the entire response. */
@@ -467,12 +468,26 @@ export async function agentsRoutes(app: FastifyInstance) {
     const contextLines: string[] = [];
     if (input.agentName) contextLines.push(`Agent: ${input.agentName}`);
     if (input.dataLabel) contextLines.push(`Data: ${input.dataLabel}`);
+    // Keep the frame intact: labels stay single-line and content can't
+    // close the delimiter early (names/entries are user- or import-authored).
+    const referenceBlock = input.contextSections?.length
+      ? `Reference context selected by the user (grounding only — do not output):\n${input.contextSections
+          .map(
+            (section) =>
+              `<<<CONTEXT: ${section.label.replace(/[\r\n]+/g, " ")}\n${section.content.replace(
+                /^CONTEXT>>>/gm,
+                "CONTEXT >>>",
+              )}\nCONTEXT>>>`,
+          )
+          .join("\n")}\n\n`
+      : "";
     const documentBlock =
       input.documentText && input.documentText !== input.selectedText
         ? `Full document (context only — do not output):\n<<<DOCUMENT\n${input.documentText}\nDOCUMENT>>>\n\n`
         : "";
     const userContent =
       `${contextLines.length ? `${contextLines.join("\n")}\n\n` : ""}` +
+      `${referenceBlock}` +
       `${documentBlock}` +
       `Excerpt to rewrite:\n<<<EXCERPT\n${input.selectedText}\nEXCERPT>>>\n\n` +
       `Instruction: ${input.instruction}`;

--- a/packages/server/src/routes/agents.routes.ts
+++ b/packages/server/src/routes/agents.routes.ts
@@ -45,6 +45,11 @@ function stripWrappingCodeFence(text: string): string {
   return match ? match[1]! : text;
 }
 
+function escapePromptFrameDelimiter(text: string, marker: string): string {
+  const pattern = new RegExp(`^${marker}`, "gm");
+  return text.replace(pattern, `${marker.slice(0, -1)} ${marker.slice(-1)}`);
+}
+
 const secretPlotArcSchema = z
   .object({
     description: z.string().optional(),
@@ -483,13 +488,16 @@ export async function agentsRoutes(app: FastifyInstance) {
       : "";
     const documentBlock =
       input.documentText && input.documentText !== input.selectedText
-        ? `Full document (context only — do not output):\n<<<DOCUMENT\n${input.documentText}\nDOCUMENT>>>\n\n`
+        ? `Full document (context only — do not output):\n<<<DOCUMENT\n${escapePromptFrameDelimiter(
+            input.documentText,
+            "DOCUMENT>>>",
+          )}\nDOCUMENT>>>\n\n`
         : "";
     const userContent =
       `${contextLines.length ? `${contextLines.join("\n")}\n\n` : ""}` +
       `${referenceBlock}` +
       `${documentBlock}` +
-      `Excerpt to rewrite:\n<<<EXCERPT\n${input.selectedText}\nEXCERPT>>>\n\n` +
+      `Excerpt to rewrite:\n<<<EXCERPT\n${escapePromptFrameDelimiter(input.selectedText, "EXCERPT>>>")}\nEXCERPT>>>\n\n` +
       `Instruction: ${input.instruction}`;
 
     const result = await provider.chatComplete(

--- a/packages/server/src/routes/agents.routes.ts
+++ b/packages/server/src/routes/agents.routes.ts
@@ -6,15 +6,19 @@ import { existsSync } from "fs";
 import { mkdir, readFile, writeFile } from "fs/promises";
 import { extname, join } from "path";
 import {
+  agentSuiteRewriteSchema,
   createAgentConfigSchema,
   updateAgentConfigSchema,
   BUILT_IN_AGENTS,
   DEFAULT_AGENT_TOOLS,
+  PROVIDERS,
   getDefaultBuiltInAgentSettings,
   normalizeAgentPhaseForType,
 } from "@marinara-engine/shared";
 import { createAgentsStorage } from "../services/storage/agents.storage.js";
 import { createChatsStorage } from "../services/storage/chats.storage.js";
+import { createConnectionsStorage } from "../services/storage/connections.storage.js";
+import { createLLMProvider } from "../services/llm/provider-registry.js";
 import { DATA_DIR } from "../utils/data-dir.js";
 import { assertInsideDir, extensionFromImageMime, isAllowedImageBuffer } from "../utils/security.js";
 import { z } from "zod";
@@ -24,6 +28,21 @@ const AGENT_IMAGES_DIR = join(DATA_DIR, "agents", "images");
 const updateAgentRunSchema = z.object({
   resultData: z.unknown(),
 });
+
+const AGENT_SUITE_REWRITE_SYSTEM_PROMPT = [
+  "You are a precise text editor embedded in a roleplay application. You edit fragments of stored AI-agent data (memory, tracker state, generated notes). Rewrite ONLY the provided excerpt according to the user's instruction.",
+  "Rules:",
+  "- Return ONLY the rewritten excerpt. No explanations, no preamble, no code fences.",
+  "- The excerpt may be a fragment of a larger document; the surrounding document is provided for context but must NOT be included in your output.",
+  "- If the excerpt is JSON or a fragment of JSON, keep the same structural shape so the result can be spliced back without breaking the document.",
+  "- Preserve everything the instruction does not ask to change. Do not invent new facts beyond what the instruction requires.",
+].join("\n");
+
+/** Strip a single markdown code fence when it wraps the entire response. */
+function stripWrappingCodeFence(text: string): string {
+  const match = text.match(/^```[a-zA-Z0-9_-]*\r?\n([\s\S]*?)\r?\n?```$/);
+  return match ? match[1]! : text;
+}
 
 const secretPlotArcSchema = z
   .object({
@@ -112,6 +131,7 @@ function getSafeAgentImagePath(filename: string): string | null {
 export async function agentsRoutes(app: FastifyInstance) {
   const storage = createAgentsStorage(app.db);
   const chats = createChatsStorage(app.db);
+  const connections = createConnectionsStorage(app.db);
   const getOrCreateConfigByType = async (agentType: string) => {
     const existing = await storage.getByType(agentType);
     if (existing) return existing;
@@ -408,5 +428,67 @@ export async function agentsRoutes(app: FastifyInstance) {
       await storage.clearMemoryForAgentInChat(config.id, req.params.chatId);
     }
     return reply.status(204).send();
+  });
+
+  /**
+   * POST /api/agents/suite/rewrite
+   * Agent Suite AI-assisted edit: rewrite a fragment of stored agent data
+   * with the user's instruction via a chosen connection. One-shot, non-streaming.
+   */
+  app.post("/suite/rewrite", async (req) => {
+    const input = agentSuiteRewriteSchema.parse(req.body);
+
+    const conn = await connections.getWithKey(input.connectionId);
+    if (!conn) {
+      throw Object.assign(new Error("API connection not found"), { statusCode: 400 });
+    }
+
+    let baseUrl = conn.baseUrl;
+    if (!baseUrl) {
+      const providerDef = PROVIDERS[conn.provider as keyof typeof PROVIDERS];
+      baseUrl = providerDef?.defaultBaseUrl ?? "";
+    }
+    // Claude (Subscription) uses the local Claude Agent SDK; no HTTP endpoint.
+    if (!baseUrl && conn.provider === "claude_subscription") baseUrl = "claude-agent-sdk://local";
+    if (!baseUrl && conn.provider === "openai_chatgpt") baseUrl = "openai-chatgpt://codex-auth";
+    if (!baseUrl) {
+      throw Object.assign(new Error("No base URL configured for this connection"), { statusCode: 400 });
+    }
+
+    const provider = createLLMProvider(
+      conn.provider,
+      baseUrl,
+      conn.apiKey,
+      conn.maxContext,
+      conn.openrouterProvider,
+      conn.maxTokensOverride,
+    );
+
+    const contextLines: string[] = [];
+    if (input.agentName) contextLines.push(`Agent: ${input.agentName}`);
+    if (input.dataLabel) contextLines.push(`Data: ${input.dataLabel}`);
+    const documentBlock =
+      input.documentText && input.documentText !== input.selectedText
+        ? `Full document (context only — do not output):\n<<<DOCUMENT\n${input.documentText}\nDOCUMENT>>>\n\n`
+        : "";
+    const userContent =
+      `${contextLines.length ? `${contextLines.join("\n")}\n\n` : ""}` +
+      `${documentBlock}` +
+      `Excerpt to rewrite:\n<<<EXCERPT\n${input.selectedText}\nEXCERPT>>>\n\n` +
+      `Instruction: ${input.instruction}`;
+
+    const result = await provider.chatComplete(
+      [
+        { role: "system", content: AGENT_SUITE_REWRITE_SYSTEM_PROMPT },
+        { role: "user", content: userContent },
+      ],
+      { model: conn.model, temperature: 0.3 },
+    );
+
+    const rewrittenText = stripWrappingCodeFence((result.content ?? "").trim());
+    if (!rewrittenText) {
+      throw Object.assign(new Error("The model returned an empty response"), { statusCode: 502 });
+    }
+    return { rewrittenText };
   });
 }

--- a/packages/shared/src/schemas/agent.schema.ts
+++ b/packages/shared/src/schemas/agent.schema.ts
@@ -66,6 +66,19 @@ export const agentSuiteRewriteSchema = z.object({
   documentText: z.string().max(100000).optional(),
   agentName: z.string().max(200).optional(),
   dataLabel: z.string().max(200).optional(),
+  /** User-selected grounding context (character cards, lorebook entries) — never rewritten. */
+  contextSections: z
+    .array(
+      z.object({
+        label: z.string().min(1).max(200),
+        content: z.string().min(1).max(20000),
+      }),
+    )
+    .max(20)
+    .refine((sections) => sections.reduce((total, section) => total + section.content.length, 0) <= 100000, {
+      message: "Combined context is too large (max 100,000 characters)",
+    })
+    .optional(),
 });
 
 export type CreateAgentConfigInput = z.infer<typeof createAgentConfigSchema>;

--- a/packages/shared/src/schemas/agent.schema.ts
+++ b/packages/shared/src/schemas/agent.schema.ts
@@ -57,5 +57,17 @@ export const createAgentConfigSchema = z.object({
 
 export const updateAgentConfigSchema = createAgentConfigSchema.partial();
 
+/** AI-assisted rewrite of a fragment of stored agent data (Agent Suite). */
+export const agentSuiteRewriteSchema = z.object({
+  connectionId: z.string().min(1),
+  instruction: z.string().min(1).max(4000),
+  selectedText: z.string().min(1).max(50000),
+  /** Full document the excerpt was selected from — context only, never rewritten. */
+  documentText: z.string().max(100000).optional(),
+  agentName: z.string().max(200).optional(),
+  dataLabel: z.string().max(200).optional(),
+});
+
 export type CreateAgentConfigInput = z.infer<typeof createAgentConfigSchema>;
 export type UpdateAgentConfigInput = z.infer<typeof updateAgentConfigSchema>;
+export type AgentSuiteRewriteInput = z.infer<typeof agentSuiteRewriteSchema>;


### PR DESCRIPTION
## Linked issue

Closes #3165

## Why this change

- In earlier Marinara versions, agents and their prompts had fewer guards and were buggier. Legacy chats can carry agents with garbled stored data (memory, tracker state, outputs) that silently pollutes every prompt and degrades the experience.
- Today that data is only editable in scattered places (Secret Plot panel, tracker HUD, Roleplay HUD popover) — and generic agent memory isn't editable anywhere.
- The Agent Suite gives users one window to inspect and repair everything the agents in the active chat have stored — manually, or with a targeted AI rewrite (select text → give an instruction → pick a connection).

## What changed

**Shared** (`packages/shared`)
- New `agentSuiteRewriteSchema` + `AgentSuiteRewriteInput` in `agent.schema.ts` (connectionId, instruction, selected excerpt, optional document context, optional `contextSections` grounding blocks, size caps end-to-end).

**Server** (`packages/server`)
- New `POST /api/agents/suite/rewrite` in `agents.routes.ts`: one-shot, non-streaming AI rewrite of a stored-data excerpt. Follows the `POST /api/translate` AI pattern exactly (`getWithKey` → baseUrl fallback → `createLLMProvider` → `chatComplete`, temperature 0.3, wrapping-code-fence strip, 400/502 error convention). System prompt instructs the model to return only the rewritten excerpt and to preserve JSON structure.
- New rate-limit class for the endpoint (20/min) in `middleware/rate-limit.ts` so it doesn't sit in the 600/min default class.

**Client** (`packages/client`)
- New `AgentSuiteModal.tsx` (`ui/Modal`, `max-w-3xl`, `chatFloatingPanel`): agent rail (dropdown on mobile) → per-agent editable data blocks:
  - **Stored Memory** (all agents) via existing `GET/PATCH /agents/memory/:type/:chatId`; director memory sits behind a spoiler gate like the Secret Plot panel; per-agent destructive "Clear memory" with confirm.
  - **Tracker Data** (world-state / character-tracker / persona-stats / custom-tracker / quest) via existing `GET/PATCH /chats/:id/game-state` — saves flush queued HUD patches, rebuild from a fresh snapshot, target the exact (messageId, swipeIndex), and re-sync the live HUD store.
  - **Recent Outputs** (custom agents) via existing run endpoints.
  - Every block: draft editing with explicit Save/Reset, dirty tracking, JSON validation, and **AI Edit** — select text in the editor (or none for the whole block), type an instruction, pick a connection (`filterLanguageGenerationConnections`), and the rewrite lands in the draft for review. Nothing is persisted without an explicit Save.
  - **Add Context** in the AI Edit panel: attach grounding sources — the chat's character cards (description/personality/scenario) and entries from its active lorebooks (pinned + global + chat-scoped + character/persona-linked, minus exclusions — mirroring the drawer's activation logic). Sources are wrapped server-side in delimited reference blocks the system prompt treats as grounding-only. Per-section 20k chars (visible truncation marker), 20 sources / 100k chars total, validated on both ends; the selection is shared across all AI edits in the window.
  - Dirty drafts guard close/Escape/agent-switch with a confirm dialog; blocks lock while a save or rewrite is in flight.
- New hooks in `use-agents.ts`: `useAgentMemory` (404 → empty memory), `useUpdateAgentMemory`, `useAgentSuiteRewrite`; `agentKeys.memory` reuses the Secret Plot panel's key shape, and `SecretPlotPanel` now consumes the shared hook so the key has one queryFn.
- Launcher row-button in the Agents section of `ChatSettingsDrawer.tsx`, styled like the existing "Edit Summaries" button.
- Drawer outside-click fix: the sonner toaster wrapper (`App.tsx`) and the app-dialog `Modal` (`AppDialogRenderer.tsx`) are now tagged `data-chat-floating-panel`. Previously, dismissing a toast or clicking any confirm-dialog button counted as an outside click, closed the settings/gallery drawer, and unmounted the chat-local modal inside it (destroying unsaved drafts). Found while manually testing the Agent Suite; also fixes the same pre-existing interaction for the Secret Plot regenerate and Memory Recall delete-all confirms.

**Docs**
- `CHANGELOG.md`: feature entry under `[Unreleased]`.

The branch went through two multi-agent adversarial reviews (per-finding verification); 14 + 8 confirmed findings were fixed in follow-up commits (stale-snapshot clobber protection, in-flight edit locking, draft-loss guards, URL encoding, rate limiting, query-key coherence, `chat.characterIds` string-at-runtime parse, label caps, picker loading/error states, delimiter-safe prompt framing).

## Validation

- [x] `pnpm check` passes locally
- [x] Container (Docker / Podman) built and ran without issue
- [x] Ran the app, clicked through the changes manually
- [x] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [x] Above manual verification completed (describe below)
- [x] Read and followed `CONTRIBUTING.md`

### Manual verification notes

Checklist for manual verification in a real browser (boxes above reflect the human contributor's own run-through; container run still pending):

- Open Chat Settings → Agents → **Agent Suite** in a chat with active agents; confirm the drawer stays open while clicking inside the modal.
- Select each agent category: a tracker agent (edit + save its slice, confirm the tracker HUD updates), the Narrative Director (spoiler gate, memory edit round-trip), a custom agent (edit a recent output).
- Run an **AI Edit**: select a chunk of text, give an instruction, pick a real connection, confirm the rewrite replaces only the selection in the draft and nothing persists until Save.
- Use **Add Context**: confirm the picker lists the chat's character cards and active-lorebook entries (including character-linked/embedded lorebooks, not just pinned ones); attach a card + an entry, run a rewrite like "fill in these values" on the World State tracker, and confirm the output reflects the attached card and setting. Also check the loading state and the over-limit message with many large sources attached.
- Try the guards: Escape with unsaved edits (confirm dialog), switching agents with unsaved edits, saving while agents are running (blocked with banner), Clear memory (confirm dialog). In the discard-confirm dialog, click "Keep Editing" and confirm the drawer + modal + drafts all survive.
- Trigger a toast (e.g. run an AI rewrite) and dismiss it via its X: the Agent Suite and the drawer must stay open with drafts intact.
- Empty states: chat with no active agents; agent with no stored memory; no tracker snapshot yet.
- Light + dark mode, and mobile viewport (~400 px; agent rail becomes a dropdown).

Automated checks already run: `pnpm lint` (tsc strict + ESLint, all packages) passes; client production build passes (modal adds ~18 kB to the lazy drawer chunk only; main entry byte-identical). `pnpm check`'s final build step fails on this dev machine due to a pre-existing Windows-only build-script bug (unquoted `process.execPath`, reproducible without this branch) — the server `tsc` step it wraps passes.

## Docs and release impact

- [x] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Version/release files updated (only if this PR includes a version bump)

## UI evidence (if applicable)

<img width="427" height="315" alt="{366646D2-AFCE-4F75-9DB2-9B46020EB42B}" src="https://github.com/user-attachments/assets/b091b125-1b45-4425-9414-e079ee9864fe" />

<img width="1280" height="595" alt="{E4B18B78-508A-4488-A4DB-5737DD41EF26}" src="https://github.com/user-attachments/assets/5c7e72db-81ae-46af-99f4-585f50734976" />

<img width="618" height="544" alt="{2330495F-55ED-4E3A-8369-C7C72C17A0FC}" src="https://github.com/user-attachments/assets/9652f20e-f3a2-4d0b-947a-a12f4308d21d" />

<img width="617" height="543" alt="{9CB76B48-9860-498B-BAF5-529D803D6C40}" src="https://github.com/user-attachments/assets/793a1d7d-a371-4dad-b1bb-2445061ea548" />

<img width="616" height="542" alt="{090EA49A-6A7A-4B42-8504-BA6A647FEB8A}" src="https://github.com/user-attachments/assets/39878284-2b57-4093-a2dd-e1c2a9bd07c4" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an **Agent Suite** option in Chat Settings to view and edit stored agent data.
  * Support now includes editing agent memory, tracker state, and recent custom-agent output.
  * Added optional AI-assisted rewrite for selected text with supporting context from related chat data.

* **Bug Fixes**
  * Improved dialog and toast interactions so closing toasts won’t accidentally dismiss chat drawers or modals.

* **Chores**
  * Updated the changelog with the new Agent Suite feature.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->