### PR TITLE
[codex] Fix Professor Mari floating dismiss lifecycle

### DIFF
--- a/packages/client/src/components/chat/ChatArea.tsx
+++ b/packages/client/src/components/chat/ChatArea.tsx
@@ -547,7 +547,9 @@ export function ChatArea() {
   }, []);
 
   useEffect(() => {
-    if (activeChatId) setHomeProfessorChatOpen(false);
+    if (!activeChatId) return;
+    setHomeProfessorChatOpen(false);
+    setHomeProfessorChatActive(false);
   }, [activeChatId]);
   const closeFloatingChatDrawers = useCallback(() => {
     setSettingsOpen(false);

--- a/packages/client/src/components/chat/ProfessorMariFloatingAssistantHost.tsx
+++ b/packages/client/src/components/chat/ProfessorMariFloatingAssistantHost.tsx
@@ -4,6 +4,7 @@ import {
   PROFESSOR_MARI_FLOATING_SHOW_EVENT,
   rememberProfessorMariFloatingEnabled,
 } from "./professor-mari-floating-events";
+import { useChatStore } from "../../stores/chat.store";
 
 const ProfessorMariFloatingAssistant = lazy(() =>
   import("./HomeProfessorMariChat").then((module) => ({ default: module.ProfessorMariFloatingAssistant })),
@@ -15,6 +16,8 @@ interface ProfessorMariFloatingAssistantHostProps {
 
 export function ProfessorMariFloatingAssistantHost({ active }: ProfessorMariFloatingAssistantHostProps) {
   const [visible, setVisible] = useState(false);
+  const [mounted, setMounted] = useState(active);
+  const hasActiveGeneration = useChatStore((state) => state.abortControllers.size > 0);
 
   const dismissFloating = useCallback(() => {
     rememberProfessorMariFloatingEnabled(false);
@@ -22,12 +25,18 @@ export function ProfessorMariFloatingAssistantHost({ active }: ProfessorMariFloa
   }, []);
 
   useEffect(() => {
-    setVisible(active);
+    if (active) {
+      setMounted(true);
+      setVisible(true);
+    } else {
+      setVisible(false);
+    }
   }, [active]);
 
   useEffect(() => {
     const showFloating = () => {
       rememberProfessorMariFloatingEnabled(true);
+      setMounted(true);
       setVisible(true);
     };
     const hideFloating = () => {
@@ -42,11 +51,23 @@ export function ProfessorMariFloatingAssistantHost({ active }: ProfessorMariFloa
     };
   }, []);
 
-  if (!visible) return null;
+  useEffect(() => {
+    if (visible) {
+      setMounted(true);
+      return;
+    }
+    if (!mounted || hasActiveGeneration) return;
+    const timeout = window.setTimeout(() => setMounted(false), 300);
+    return () => window.clearTimeout(timeout);
+  }, [hasActiveGeneration, mounted, visible]);
+
+  if (!mounted) return null;
 
   return (
-    <Suspense fallback={null}>
-      <ProfessorMariFloatingAssistant onDismiss={dismissFloating} />
-    </Suspense>
+    <div className={visible ? undefined : "hidden"} aria-hidden={!visible}>
+      <Suspense fallback={null}>
+        <ProfessorMariFloatingAssistant onDismiss={dismissFloating} />
+      </Suspense>
+    </div>
   );
 }

--- a/packages/server/src/services/professor-mari/workspace-agent.service.ts
+++ b/packages/server/src/services/professor-mari/workspace-agent.service.ts
@@ -1323,8 +1323,40 @@ export class ProfessorMariWorkspaceService {
 
     const workspaceTrace: MariWorkspaceTraceItem[] = [];
     let assistantText = "";
+    let streamedVisibleText = "";
     let thinkingText = "";
     let totalUsage = { promptTokens: 0, completionTokens: 0, totalTokens: 0 };
+    const commandResultsForContinuity: WorkspaceCommandResult[] = [];
+    let assistantMessagePersisted = false;
+
+    const persistAssistantMessage = async () => {
+      const persistedText = assistantText.trim();
+      if (!persistedText || assistantMessagePersisted) return null;
+
+      const message = await chatStorage.createMessage({
+        chatId: args.chatId,
+        role: "assistant",
+        characterId: PROFESSOR_MARI_ID,
+        content: persistedText,
+      });
+      if (!message) return null;
+      assistantMessagePersisted = true;
+
+      const extraUpdate: Record<string, unknown> = {};
+      const storedTrace = sanitizeTraceForStorage(workspaceTrace);
+      if (thinkingText.trim()) extraUpdate.thinking = thinkingText;
+      if (storedTrace.length > 0) extraUpdate.mariWorkspaceTimeline = storedTrace;
+      const continuity = buildWorkspaceContinuitySnapshot({
+        userText: args.text,
+        assistantText: persistedText,
+        commandResults: commandResultsForContinuity,
+      });
+      if (continuity) extraUpdate.mariWorkspaceContinuity = continuity;
+      extraUpdate.generationInfo = { provider: connection.provider, model: connection.model, usage: totalUsage };
+      await chatStorage.updateMessageExtra(message.id, extraUpdate);
+      await chatStorage.updateSwipeExtra(message.id, 0, extraUpdate);
+      return message;
+    };
 
     try {
       await this.ensureMariCliShim();
@@ -1335,14 +1367,17 @@ export class ProfessorMariWorkspaceService {
         appendTraceThinking(workspaceTrace, delta);
         args.onEvent({ type: "thinking", data: delta });
       });
-      const commandResultsForContinuity: WorkspaceCommandResult[] = [];
       const repeatedFailureCounts = new Map<string, number>();
       let protocolRepairRounds = 0;
 
       for (let round = 0; round < MAX_COMMAND_ROUNDS; round += 1) {
         if (controller.signal.aborted) throw new Error("aborted");
-        const onToken = (chunk: string) => args.onEvent({ type: "token", data: chunk });
-      const result = await this.chatCompleteWorkspace(provider, messages, baseOptions, onToken);
+        streamedVisibleText = "";
+        const onToken = (chunk: string) => {
+          streamedVisibleText += chunk;
+          args.onEvent({ type: "token", data: chunk });
+        };
+        const result = await this.chatCompleteWorkspace(provider, messages, baseOptions, onToken);
         const usage = mapUsage(result.usage);
         totalUsage = {
           promptTokens: totalUsage.promptTokens + usage.promptTokens,
@@ -1406,6 +1441,7 @@ export class ProfessorMariWorkspaceService {
           assistantText = appendVisibleText(assistantText, action.visibleText);
           appendTraceText(workspaceTrace, `${action.visibleText}\n`);
         }
+        streamedVisibleText = "";
 
         messages.push({ role: "assistant", content: action.assistantHistoryContent });
 
@@ -1474,6 +1510,7 @@ export class ProfessorMariWorkspaceService {
             args.onEvent({ type: "status", data: { content, kind: "info", level: "warning" } });
             for (const chunk of chunkText(content)) args.onEvent({ type: "token", data: chunk });
           }
+          streamedVisibleText = "";
         }
       }
 
@@ -1489,36 +1526,32 @@ export class ProfessorMariWorkspaceService {
         for (const chunk of chunkText(content)) args.onEvent({ type: "token", data: chunk });
       }
 
-      const persistedText = assistantText.trim();
-      if (persistedText) {
-        const message = await chatStorage.createMessage({
-          chatId: args.chatId,
-          role: "assistant",
-          characterId: PROFESSOR_MARI_ID,
-          content: persistedText,
-        });
-        if (message) {
-          const extraUpdate: Record<string, unknown> = {};
-          const storedTrace = sanitizeTraceForStorage(workspaceTrace);
-          if (thinkingText.trim()) extraUpdate.thinking = thinkingText;
-          if (storedTrace.length > 0) extraUpdate.mariWorkspaceTimeline = storedTrace;
-          const continuity = buildWorkspaceContinuitySnapshot({
-            userText: args.text,
-            assistantText: persistedText,
-            commandResults: commandResultsForContinuity,
-          });
-          if (continuity) extraUpdate.mariWorkspaceContinuity = continuity;
-          extraUpdate.generationInfo = { provider: connection.provider, model: connection.model, usage: totalUsage };
-          await chatStorage.updateMessageExtra(message.id, extraUpdate);
-          await chatStorage.updateSwipeExtra(message.id, 0, extraUpdate);
-        }
-      }
+      await persistAssistantMessage();
       args.onEvent({ type: "metadata", data: { connection: connectionSummary(connection) ?? undefined } });
     } catch (err) {
       if (controller.signal.aborted) {
-        const content = "Professor Mari workspace run was cancelled.";
+        if (streamedVisibleText.trim()) {
+          assistantText = appendVisibleText(assistantText, streamedVisibleText);
+          streamedVisibleText = "";
+        }
+        const hadPartialWorkspaceState =
+          assistantText.trim().length > 0 || thinkingText.trim().length > 0 || workspaceTrace.length > 0;
+        const content = assistantText.trim()
+          ? "Professor Mari workspace run was cancelled after saving the partial response."
+          : "Professor Mari workspace run was cancelled.";
         appendTraceStatus(workspaceTrace, content);
         args.onEvent({ type: "status", data: { content, kind: "info", level: "warning" } });
+        if (!assistantText.trim() && hadPartialWorkspaceState) {
+          assistantText = appendVisibleText(assistantText, content);
+        }
+        try {
+          await persistAssistantMessage();
+        } catch (saveErr) {
+          logger.error(
+            saveErr instanceof Error ? saveErr : new Error(String(saveErr)),
+            "[Professor Mari] Failed to persist aborted workspace response",
+          );
+        }
       } else {
         this.lastError = err instanceof Error ? err.message : String(err);
         throw err;


### PR DESCRIPTION
## Linked issue

Closes #3159

## Why this change

- Dismissing the floating Professor Mari window could leave the Home surface in a stale active-chat layout state, hiding the normal Home content after navigation.
- The floating assistant could also unmount while a workspace response was still streaming, risking a dropped SSE consumer and missing assistant history.
- The workspace service only persisted assistant messages on the full success path, so aborted or disconnected runs could lose partial visible text and trace state.

## What changed

- Clear `homeProfessorChatActive` whenever a real chat becomes active, so returning Home cannot render a blank Professor Mari layout shell.
- Keep the floating Professor Mari assistant mounted but hidden while any generation controller is active, then allow it to unmount once idle.
- Reuse the Professor Mari workspace assistant-message persistence path on abort, including streamed `say` text, thinking text, workspace timeline, continuity, and usage metadata when available.

## Validation

- [ ] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed `CONTRIBUTING.md`

### Manual verification notes

Automated validation performed by Codex:

- `pnpm --filter @marinara-engine/client lint`
- `pnpm --filter @marinara-engine/server lint`
- `pnpm --filter @marinara-engine/client build`
- `pnpm --filter @marinara-engine/server build`
- `pnpm check`
- `git diff --check`

Manual browser reproduction of the floating-window dismiss flow was not performed in this environment.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Version/release files updated (only if this PR includes a version bump)

No docs or release metadata changes are expected for this bug fix.

## UI evidence (if applicable)

No screenshots attached; this is a lifecycle/persistence fix without visual redesign.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved chat state handling so opening a different chat now reliably clears previous Professor Mari chat activity.
  * Made the floating assistant smoother to dismiss and reopen, with less abrupt disappearing during transitions.
  * Improved assistant response saving so partial or canceled replies are more consistently preserved and shown to users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->