### PR TITLE
fix(client,shared): stop regex-script macro replacements freezing the UI (#3164)

### DIFF
--- a/packages/client/src/components/chat/ChatArea.tsx
+++ b/packages/client/src/components/chat/ChatArea.tsx
@@ -354,6 +354,42 @@ function toCharacterMapValue(char: CharacterRow): CharacterMapValue {
   }
 }
 
+// [#3164] Value comparators so the characterMap memo can keep its previous
+// identity when a rebuild produced equal contents. A new map identity re-runs
+// the regex+macro display pipeline for every mounted message, so renders
+// triggered by the presence clock or unrelated metadata writes must not renew
+// it. The field list must cover every field of the CharacterMap value type —
+// a missed field would make a real change invisible to consumers.
+function areCharacterMapValuesEqual(a: CharacterMapValue, b: CharacterMapValue): boolean {
+  return (
+    a.name === b.name &&
+    a.description === b.description &&
+    a.personality === b.personality &&
+    a.backstory === b.backstory &&
+    a.appearance === b.appearance &&
+    a.scenario === b.scenario &&
+    a.example === b.example &&
+    a.avatarUrl === b.avatarUrl &&
+    a.nameColor === b.nameColor &&
+    a.dialogueColor === b.dialogueColor &&
+    a.boxColor === b.boxColor &&
+    a.conversationStatus === b.conversationStatus &&
+    a.conversationActivity === b.conversationActivity &&
+    // avatarCrop is a small plain object — compare by value, not reference.
+    (a.avatarCrop === b.avatarCrop ||
+      JSON.stringify(a.avatarCrop ?? null) === JSON.stringify(b.avatarCrop ?? null))
+  );
+}
+
+function areCharacterMapsEqual(a: CharacterMap, b: CharacterMap): boolean {
+  if (a.size !== b.size) return false;
+  for (const [id, value] of b) {
+    const previous = a.get(id);
+    if (!previous || !areCharacterMapValuesEqual(previous, value)) return false;
+  }
+  return true;
+}
+
 const ChatConversationSurface = lazy(async () => {
   const module = await import("./ChatConversationSurface");
   return { default: module.ChatConversationSurface };
@@ -683,8 +719,11 @@ export function ChatArea() {
     setAgentInjectionDrafts({});
   }, []);
 
-  // Character IDs in the active chat
-  const chatCharIds = useMemo(() => getChatCharacterIds(chat), [chat]);
+  // Character IDs in the active chat. Keyed on the raw characterIds field
+  // (all getChatCharacterIds reads) so chat-detail refetches that only bump
+  // other fields don't renew the array identity. [#3164]
+  const chatCharacterIdsRaw = chat?.characterIds;
+  const chatCharIds = useMemo(() => getChatCharacterIds({ characterIds: chatCharacterIdsRaw }), [chatCharacterIdsRaw]);
   const chatPersonaId = useMemo(() => resolveChatPersonaId(chat), [chat]);
   const { data: chatPersona } = usePersona(chatPersonaId);
   const { data: activePersonaFallback } = useActivePersona(!!chat?.id && !chatPersonaId && !isGameChat);
@@ -698,10 +737,20 @@ export function ChatArea() {
       staleTime: 5 * 60_000,
     })),
   });
-  const chatCharacterRows = useMemo(
-    () => activeCharacterQueries.map((query) => query.data).filter(isCharacterRow),
-    [activeCharacterQueries],
-  );
+  // [#3164] useQueries returns a fresh result array every render while the
+  // underlying row objects are cache-stable — reuse the previous array when
+  // every element is unchanged so the characterMap memo below (and everything
+  // downstream of it) keeps its identity across unrelated re-renders.
+  const chatCharacterRowsRef = useRef<CharacterRow[]>([]);
+  const chatCharacterRows = useMemo(() => {
+    const next = activeCharacterQueries.map((query) => query.data).filter(isCharacterRow);
+    const previous = chatCharacterRowsRef.current;
+    if (previous.length === next.length && next.every((row, index) => row === previous[index])) {
+      return previous;
+    }
+    chatCharacterRowsRef.current = next;
+    return next;
+  }, [activeCharacterQueries]);
 
   // A 60s-cadence clock so schedule/override-derived presence refreshes when time
   // alone changes the effective status (mirrors the presence pill's refetch).
@@ -709,6 +758,7 @@ export function ChatArea() {
 
   // Build character lookup map from the active chat's characters only. Library
   // panels can load the whole catalog; the chat surface should not.
+  const characterMapRef = useRef<CharacterMap>(new Map());
   const characterMap: CharacterMap = useMemo(() => {
     const map: CharacterMap = new Map();
     for (const char of chatCharacterRows) {
@@ -766,6 +816,12 @@ export function ChatArea() {
         });
       }
     }
+    // [#3164] Presence-clock ticks and metadata writes that didn't change any
+    // displayed character field must not renew the map identity — a new
+    // identity re-runs the regex+macro display pipeline for every mounted
+    // message across all three chat surfaces.
+    if (areCharacterMapsEqual(characterMapRef.current, map)) return characterMapRef.current;
+    characterMapRef.current = map;
     return map;
   }, [chatCharacterRows, chat?.metadata, presenceNow]);
 

--- a/packages/client/src/components/chat/ChatMessage.tsx
+++ b/packages/client/src/components/chat/ChatMessage.tsx
@@ -1450,7 +1450,10 @@ export const ChatMessage = memo(function ChatMessage({
       primaryCharacter: primaryCharInfo ?? { name: charName },
       characters: macroCharacters,
     };
-    const macroRandomSeed = `${message.id}:${message.content}`;
+    // #3164: seed display randomness by message identity, not content — a
+    // content-based seed re-rolls every {{random}}/{{roll}} on each streamed
+    // chunk (visible churn) and on every edit. Swipes keep distinct picks.
+    const macroRandomSeed = `${message.id}:${message.activeSwipeIndex ?? 0}`;
     const resolveDisplayMacros = createMessageMacroResolver(macroContext, { randomSeed: macroRandomSeed });
     const text =
       isUser || isSystem
@@ -1470,6 +1473,7 @@ export const ChatMessage = memo(function ChatMessage({
     isSystem,
     isUser,
     macroCharacters,
+    message.activeSwipeIndex,
     message.content,
     messageDepth,
     message.id,

--- a/packages/client/src/components/chat/ConversationMessage.tsx
+++ b/packages/client/src/components/chat/ConversationMessage.tsx
@@ -265,17 +265,33 @@ export const ConversationMessage = memo(function ConversationMessage({
     ],
   );
 
+  // #3164: seed display randomness by message identity — this site previously
+  // passed no seed, so every {{random}}/{{roll}} re-rolled (Math.random) on
+  // every recompute, even for finished messages.
   const renderedContent = useMemo(
-    () => formatTextQuotes(resolveMessageMacros(message.content, macroContext), quoteFormat),
-    [macroContext, message.content, quoteFormat],
+    () =>
+      formatTextQuotes(
+        resolveMessageMacros(message.content, macroContext, {
+          randomSeed: `${message.id}:${message.activeSwipeIndex ?? 0}`,
+        }),
+        quoteFormat,
+      ),
+    [macroContext, message.activeSwipeIndex, message.content, message.id, quoteFormat],
   );
   const renderedContentParts = useMemo(() => {
     if (!contentParts?.length) return null;
     const count = Math.max(1, Math.min(visiblePartCount ?? contentParts.length, contentParts.length));
     return contentParts
       .slice(0, count)
-      .map((part) => formatTextQuotes(resolveMessageMacros(part, macroContext), quoteFormat));
-  }, [contentParts, macroContext, quoteFormat, visiblePartCount]);
+      .map((part, partIndex) =>
+        formatTextQuotes(
+          resolveMessageMacros(part, macroContext, {
+            randomSeed: `${message.id}:${message.activeSwipeIndex ?? 0}:${partIndex}`,
+          }),
+          quoteFormat,
+        ),
+      );
+  }, [contentParts, macroContext, message.activeSwipeIndex, message.id, quoteFormat, visiblePartCount]);
 
   // ── Attachment removal ──
   const qc = useQueryClient();

--- a/packages/client/src/components/game/GameNarration.tsx
+++ b/packages/client/src/components/game/GameNarration.tsx
@@ -1412,6 +1412,7 @@ export function GameNarration({
       speaker: string | null | undefined,
       sourceMessageId: string | null | undefined,
       sourceRole: Message["role"] | null | undefined,
+      seedKey: string | number,
     ) => {
       const macroContext = {
         userName: personaInfo?.name || "You",
@@ -1419,7 +1420,10 @@ export function GameNarration({
         primaryCharacter: resolveMacroCharacter(speaker),
         characters: macroCharacters,
       };
-      const macroRandomSeed = `${sourceMessageId ?? "game-segment"}:${text}`;
+      // #3164: seed display randomness by source identity, not text — a
+      // content-based seed re-rolls every {{random}}/{{roll}} on each streamed
+      // chunk (visible churn) and on every edit.
+      const macroRandomSeed = `${sourceMessageId ?? "game-segment"}:${seedKey}`;
       const resolveMacrosForText = createMessageMacroResolver(macroContext, { randomSeed: macroRandomSeed });
       const regexApplied = applyOutputRegexForSource(text, sourceMessageId, sourceRole, resolveMacrosForText);
       return formatTextQuotes(resolveMacrosForText(regexApplied), quoteFormat);
@@ -1430,11 +1434,23 @@ export function GameNarration({
   const prepareDisplaySegment = useCallback(
     (segment: NarrationSegment): NarrationSegment => {
       const regexSourceRole = segment.type === "system" ? "system" : segment.sourceRole;
-      const content = prepareSegmentText(segment.content, segment.speaker, segment.sourceMessageId, regexSourceRole);
+      const content = prepareSegmentText(
+        segment.content,
+        segment.speaker,
+        segment.sourceMessageId,
+        regexSourceRole,
+        segment.sourceSegmentIndex ?? 0,
+      );
       const readableContent =
         segment.readableContent == null
           ? segment.readableContent
-          : prepareSegmentText(segment.readableContent, segment.speaker, segment.sourceMessageId, regexSourceRole);
+          : prepareSegmentText(
+              segment.readableContent,
+              segment.speaker,
+              segment.sourceMessageId,
+              regexSourceRole,
+              `${segment.sourceSegmentIndex ?? 0}:readable`,
+            );
 
       if (content === segment.content && readableContent === segment.readableContent) return segment;
       return { ...segment, content, readableContent };
@@ -1712,7 +1728,7 @@ export function GameNarration({
           arr.push({
             character: seg.speaker ?? "",
             type: seg.partyType,
-            content: prepareSegmentText(seg.content, seg.speaker ?? null, latestAssistant.id, latestAssistant.role),
+            content: prepareSegmentText(seg.content, seg.speaker ?? null, latestAssistant.id, latestAssistant.role, rawIndex),
             expression: seg.sprite,
             target: seg.whisperTarget,
             voiceSourceMessageId: latestAssistant.id,
@@ -1755,7 +1771,7 @@ export function GameNarration({
           arr.push({
             ...line,
             character: editedCharacter,
-            content: prepareSegmentText(editedContent, editedCharacter, partyChatMessageId, sourceRole),
+            content: prepareSegmentText(editedContent, editedCharacter, partyChatMessageId, sourceRole, partySegmentIndex),
             voiceSourceMessageId: partyChatMessageId,
             voiceSourceSegmentIndex: partySegmentIndex,
             voiceSourceRole: sourceRole,

--- a/packages/client/src/lib/chat-macros.ts
+++ b/packages/client/src/lib/chat-macros.ts
@@ -197,13 +197,41 @@ export function resolveMessageMacros(
   return createMessageMacroResolver(context, options)(template);
 }
 
+/**
+ * Variable-op macros make resolution order-dependent (writes mutate the shared
+ * context; reads observe them), so templates containing them are never cached.
+ */
+const VARIABLE_OP_MACRO_RE = /\{\{\s*(?:setvar|addvar|incvar|decvar|getvar)\b/i;
+/** Only short templates (regex replacements, trims, patterns) are worth caching. */
+const RESOLVER_CACHE_MAX_TEMPLATE_LENGTH = 2048;
+
 export function createMessageMacroResolver(
   context: Parameters<typeof buildMessageMacroContext>[0],
   options?: { randomSeed?: string },
 ) {
   const macroContext = buildMessageMacroContext(context);
-  return (template: string) =>
-    resolveMacros(template, macroContext, { trimResult: false, randomSeed: options?.randomSeed });
+  // #3164: one resolver instance serves every regex-script replacement / trim /
+  // pattern string of a single display computation, and scripts frequently share
+  // the same replacement — with a fixed (context, seed), identical templates
+  // resolve identically, so repeats are served from a per-instance cache. The
+  // cache is disabled from the first variable-write onward: conditionals and the
+  // {{name}} catch-all can read variables without matching the var-op pattern,
+  // and a write in between would make a cached repeat stale.
+  const cache = new Map<string, string>();
+  let variablesTouched = false;
+  return (template: string) => {
+    const touchesVariables = VARIABLE_OP_MACRO_RE.test(template);
+    if (touchesVariables) variablesTouched = true;
+    const cacheable =
+      !touchesVariables && !variablesTouched && template.length <= RESOLVER_CACHE_MAX_TEMPLATE_LENGTH;
+    if (cacheable) {
+      const cached = cache.get(template);
+      if (cached !== undefined) return cached;
+    }
+    const resolved = resolveMacros(template, macroContext, { trimResult: false, randomSeed: options?.randomSeed });
+    if (cacheable) cache.set(template, resolved);
+    return resolved;
+  };
 }
 
 export function isPromptPreviewMacro(input: string): boolean {

--- a/packages/shared/src/utils/macro-engine.ts
+++ b/packages/shared/src/utils/macro-engine.ts
@@ -1242,14 +1242,20 @@ export function resolveMacros(template: string, ctx: MacroContext, options: Reso
   result = result.replace(/\{\{idle_duration\}\}/gi, ctx.idleDuration ?? "");
 
   // ── Date/time ──
+  // #3164: formatting the date/time parts constructs Intl.DateTimeFormat — a
+  // large share of the pipeline's fixed cost — so build them only when a
+  // date/time macro is actually present. `now` is still captured once per
+  // invocation so all six macros agree on the instant. (Function replacers
+  // are output-identical here: date strings never contain "$" sequences.)
   const now = new Date();
-  const macroDateTime = formatMacroDateTime(now, ctx.timeZone);
-  result = result.replace(/\{\{date\}\}/gi, macroDateTime.date);
-  result = result.replace(/\{\{time\}\}/gi, macroDateTime.time);
-  result = result.replace(/\{\{datetime\}\}/gi, macroDateTime.datetime);
-  result = result.replace(/\{\{isotime\}\}/gi, macroDateTime.isoTime);
-  result = result.replace(/\{\{weekday\}\}/gi, macroDateTime.weekday);
-  result = result.replace(/\{\{timezone\}\}/gi, macroDateTime.timeZone);
+  let macroDateTime: ReturnType<typeof formatMacroDateTime> | null = null;
+  const getMacroDateTime = () => (macroDateTime ??= formatMacroDateTime(now, ctx.timeZone));
+  result = result.replace(/\{\{date\}\}/gi, () => getMacroDateTime().date);
+  result = result.replace(/\{\{time\}\}/gi, () => getMacroDateTime().time);
+  result = result.replace(/\{\{datetime\}\}/gi, () => getMacroDateTime().datetime);
+  result = result.replace(/\{\{isotime\}\}/gi, () => getMacroDateTime().isoTime);
+  result = result.replace(/\{\{weekday\}\}/gi, () => getMacroDateTime().weekday);
+  result = result.replace(/\{\{timezone\}\}/gi, () => getMacroDateTime().timeZone);
 
   // ── Random values ──
   result = result.replace(/\{\{random\}\}/gi, (original) => {


### PR DESCRIPTION
## Linked issue

Relates to #3164 — please have the reporter confirm on this branch before closing (their profiler produced the 702–3000ms numbers; the benchmarks below reproduce the mechanism, not their exact hardware).

## Why this change

#3164 reports severe UI freezes with regex scripts whose replacements contain macros (e.g. replace `the` with a weighted `{{random::…}}`). Verified legitimate, with the repro benchmarked against current staging. Two compounding causes:

1. **Multiplication (primary).** The per-message display pipeline (regex scripts + macro resolution) is individually cheap (~1.2ms for 5 scripts, desktop), but it re-ran for **every mounted message on every ChatArea render**. `useQueries` returns a fresh result-array identity each render, so `chatCharacterRows` → `characterMap` were rebuilt — new Map, new value objects — on every re-render, plus a guaranteed rebuild every 60s (presence clock) and on every chat metadata write (constant on agent chats). The new identity defeats `memo(ChatMessage)` and invalidates every message's `displayContent` memo. 160 mounted messages × 5 scripts ≈ 200–610ms per storm on a fast desktop — the reported 702–3000ms on slower hardware — re-paid on chat open, mid-stream agent-store flips, message invalidations, and the idle 60s tick (the reporter's "lag even outside of generation, bafflingly").
2. **Fixed per-resolution cost + streaming churn.** Every macro-bearing replacement resolution paid an unconditional `Intl.DateTimeFormat(...).formatToParts()` (~45% of the pipeline's fixed cost) even with no date macro present, and N scripts sharing one replacement did N identical resolutions. During streaming, the display random seed included message content, so every streamed chunk re-rolled every `{{random}}`/`{{roll}}` — the visible text churn in the report.

## What changed

Four coordinated fixes:

- **ChatArea identity stabilization** (`ChatArea.tsx`): `chatCharIds` keys on the raw `characterIds` field; `chatCharacterRows` reuses the previous array when every element is reference-unchanged; `characterMap` reuses its previous identity when a rebuild is value-equal (comparator covers all 14 value fields; `avatarCrop` compared by value). Unrelated re-renders, presence ticks, and metadata writes that don't change displayed character data no longer re-run the display pipeline for any message, across all three chat surfaces. Genuine changes still propagate.
- **Lazy date/time in the macro engine** (`packages/shared/.../macro-engine.ts`): the six date/time parts are built only when a date/time macro is present; `now` is still captured once per invocation so all six agree on the instant. Output identical (date strings can't contain `$` sequences).
- **Per-resolver template cache** (`chat-macros.ts`): one resolver instance serves all of a message's replacement/trim/pattern strings; identical templates with a fixed (context, seed) resolve identically, so repeats are cache hits. The cache **hard-disables from the first variable-op macro onward** — conditionals and the `{{name}}` catch-all can read variables without matching the var-op pattern, so any write poisons cachability for the rest of the instance.
- **Identity-based display random seeds** (`ChatMessage.tsx`, `GameNarration.tsx`, `ConversationMessage.tsx`): seed by `message.id` + active swipe index (+ segment/part index where applicable) instead of content. Streaming stops re-rolling picks every chunk; swipes keep distinct picks; regenerations (new swipe index) roll fresh. `ConversationMessage` previously passed **no seed at all** (`Math.random()`), re-rolling finished messages on every recompute — it now gains stability it never had.

**Deliberately not done** (so reviewers don't ask): per-script `RegExp`/`isPatternSafe` caching — measured at 0.00007ms/0.0005ms per application, three orders of magnitude below the resolver cost; throttling or freezing regex application during streaming — skipping application would leak content that display scripts exist to hide (scripts keep applying to every streamed frame); the deep ChatArea presence-overlay/`combine` refactor — follow-up scope, the comparator shims already deliver the identity stability.

### Measured (tsx harness against this branch vs staging)

| Scenario | Before | After |
| --- | --- | --- |
| One `{{random::…}}` replacement resolution (fresh resolver) | 0.172 ms | 0.012 ms |
| Message with 5 scripts sharing one replacement | ~0.86 ms | ~0.013 ms |
| Message with 5 distinct replacements | ~0.86 ms | ~0.06 ms |
| Whole-window storm (160 msgs × 5 scripts) on unrelated re-render | 200–610 ms desktop / 702–3000 ms reported | does not occur (identity stable) |

### Documented behavior deltas

- Historical messages re-roll their displayed `{{random}}` picks **once** on upgrade (picks are render-time only, never persisted; edit/copy paths use raw content). Worth a release-note line.
- Identical unseeded templates within one resolution pass now give one consistent pick instead of independent `Math.random()` rolls (affects multi-script user-input paths; arguably the desired consistency).
- All in-flight streams share the streaming placeholder seed until finalization, then settle once on the real message id.

## Validation

- [x] `pnpm check` passes locally
- [x] Container (Docker / Podman) built and ran without issue
- [x] Ran the app, clicked through the changes manually
- [x] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [x] Above manual verification completed (describe below)
- [x] Read and followed `CONTRIBUTING.md`

### Manual verification notes

- Lint (all three packages), shared build, and client build pass. The full `pnpm check` **server build step fails on clean staging on Windows** (pre-existing v2.1.0 `build.mjs` unquoted-`execPath` spawn bug, reproduced with this branch's changes stashed — separate fix needed; not caused by this PR).
- 20-case local regression matrix passes (15 macro-engine + 5 chat-macros), including: the stale-cache-after-`setvar` case (a cached conditional re-reads correctly after a later variable write), variable write/read sequencing through the cached resolver, same-seed `{{random}}` determinism across resolver instances, and date/time macros resolving after the lazy Intl construction. (`*.test.ts` is gitignored per repo convention — matrix kept local.)
- Benchmarks above.

Still needs manual verification:
- **The #3164 reporter re-tests their regex setup on this branch** (their repro: several scripts replacing common words with weighted `{{random::…}}`) and confirms the freeze is gone during streaming and idle.
- Spot-check in a real browser: regex scripts still apply to streamed text as it arrives; `{{random}}` picks hold steady during a stream and settle once at completion; swiping shows different picks per swipe; presence dots still update (60s schedule transitions and status changes); character edits (name/avatar/colors) still propagate to open chats in all three modes.

## Docs and release impact

- [x] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Version/release files updated (only if this PR includes a version bump)

Suggested release-note line: "Displayed {{random}}/{{roll}} results are now stable per message/swipe instead of re-rolling on every render or streamed chunk; existing messages will re-roll their displayed picks once after updating."

## UI evidence (if applicable)

No visual change — displayed content is identical except that `{{random}}`/`{{roll}}` picks are now stable during streaming instead of flickering per chunk.