### PR TITLE
Remove text attachment prompt truncation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 
 ### Fixed
 
+- Fixed readable text-file attachments being pre-truncated to 60,000 characters before prompt context fitting, so large uploaded text files can use the selected model's actual context window.
 - Fixed Termux dependency refreshes so Android installs that add the `wasm32` optional-dependency architecture run `pnpm install --force`, allowing `@img/sharp-wasm32` to be linked for sprite generation and other sharp-backed image processing (#3167).
 
 ## [2.1.0]

--- a/packages/server/src/routes/generate/generate-route-utils.ts
+++ b/packages/server/src/routes/generate/generate-route-utils.ts
@@ -149,7 +149,6 @@ function createEmptyPlayerStats(): PlayerStats {
   return { stats: [], attributes: null, skills: {}, inventory: [], activeQuests: [], status: "" };
 }
 
-const TEXT_ATTACHMENT_CHAR_LIMIT = 60_000;
 const IMAGE_ATTACHMENT_PROVIDER_BYTE_LIMIT = 6 * 1024 * 1024;
 const FILE_ATTACHMENT_PROVIDER_BYTE_LIMIT = 20 * 1024 * 1024;
 const TEXT_ATTACHMENT_EXTENSIONS = new Set([
@@ -1059,15 +1058,11 @@ export function buildReadableAttachmentBlocks(attachments: PromptAttachment[] | 
 
     const filename = getAttachmentFilename(attachment);
     const type = typeof attachment.type === "string" && attachment.type.trim() ? attachment.type.trim() : "text/plain";
-    const trimmed =
-      decoded.length > TEXT_ATTACHMENT_CHAR_LIMIT
-        ? `${decoded.slice(0, TEXT_ATTACHMENT_CHAR_LIMIT)}\n\n[Attachment truncated after ${TEXT_ATTACHMENT_CHAR_LIMIT} characters.]`
-        : decoded;
 
     return [
       [
         `<attached_file name="${escapeXmlAttribute(filename)}" type="${escapeXmlAttribute(type)}">`,
-        trimmed,
+        decoded,
         `</attached_file>`,
       ].join("\n"),
     ];

--- a/scripts/regressions/prompt.regression.ts
+++ b/scripts/regressions/prompt.regression.ts
@@ -35,6 +35,7 @@ import type { DB } from "../../packages/server/src/db/connection.js";
 import { escapeXmlText } from "../../packages/server/src/services/prompt/prompt-escaping.js";
 import {
   appendNonLeadingSystemMessagesToLastUser,
+  appendReadableAttachmentsToContent,
   buildGenerationGuideInstruction,
   appendSeparateAgentInjectionMessage,
   shouldEnableAgentsForGeneration,
@@ -79,6 +80,25 @@ const keywordOptions = {
 };
 
 const cases: RegressionCase[] = [
+  {
+    name: "readable text attachments are not pre-truncated before context fitting",
+    run() {
+      const repeated = "0123456789".repeat(7_000);
+      const encoded = Buffer.from(repeated, "utf8").toString("base64");
+      const content = appendReadableAttachmentsToContent("Please read this.", [
+        {
+          type: "text/plain",
+          data: `data:text/plain;base64,${encoded}`,
+          filename: "long.txt",
+        },
+      ]);
+
+      assert.match(content, /<attached_file name="long.txt" type="text\/plain">/);
+      assert.match(content, /Please read this\./);
+      assert.equal(content.includes("[Attachment truncated after"), false);
+      assert.ok(content.includes(repeated));
+    },
+  },
   {
     name: "post-history system messages are folded into user turns",
     run() {


### PR DESCRIPTION
## Summary
- Removes the 60,000-character pre-truncation for readable text attachments before prompt context fitting.
- Lets large uploaded text files use the selected model/connection context window instead of Marinara slicing them first.
- Adds a prompt regression and changelog note.

## Why
A user report described an apparent ~15k token cap for the last user message after uploading a text file. That maps closely to the old 60,000-character attachment cap. This was not a max-output setting issue, and it happened before provider/model context fitting had a chance to decide what actually fits.

Normal lorebook entry content does not appear to have a 50k content cap in the lorebook schema; lorebook budget and activation rules are separate, and provider/model context still remains the real upper bound.

## Validation
- pnpm check
- pnpm regression:prompt
- git diff --check

## Manual verification
- Upload a readable text file larger than 60,000 characters and inspect/debug the generated prompt to confirm the attachment is no longer pre-truncated before context fitting.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Large readable text-file attachments are no longer cut off before being included in prompts, so uploaded text can use the model’s full available context.
  * Prompt content now preserves the complete attachment text instead of showing a truncation notice for these files.

* **Tests**
  * Added regression coverage to ensure long text attachments remain intact when added to prompt content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->