### PR TITLE
[codex] Restore chat UI fixes and remove lorebook entry write cap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 
 ### Fixed
 
+- Restored chat input and generation cleanup behavior so post-generation agents such as Illustrator keep the UI busy state without leaving a duplicate live-stream message visible, and preserved textarea caret position while quote formatting runs on apostrophes.
+- Removed the agent/tool write-path size cap on lorebook entry content so large entries are no longer truncated before storage.
 - Fixed Termux dependency refreshes so Android installs that add the `wasm32` optional-dependency architecture run `pnpm install --force`, allowing `@img/sharp-wasm32` to be linked for sprite generation and other sharp-backed image processing (#3167).
 
 ## [2.1.0]

--- a/packages/client/src/components/chat/ChatInput.tsx
+++ b/packages/client/src/components/chat/ChatInput.tsx
@@ -1727,8 +1727,10 @@ export const ChatInput = memo(function ChatInput({
                 : "text-foreground/20",
           )}
         >
-          {isInputBusy ? (
+          {isStreaming ? (
             <StopCircle size="1rem" />
+          ) : isInputBusy ? (
+            <Loader2 size="1rem" className="animate-spin" />
           ) : (
             <Send size="0.9375rem" className={cn(hasInput && "translate-x-[1px]")} />
           )}

--- a/packages/client/src/hooks/use-generate.ts
+++ b/packages/client/src/hooks/use-generate.ts
@@ -2154,7 +2154,6 @@ export function useGenerate() {
               if (spriteChangeReceived) {
                 qc.invalidateQueries({ queryKey: chatKeys.messages(params.chatId) });
               }
-              setProcessing(false, params.chatId);
               if (isActiveChat()) {
                 if (useChatStore.getState().streamingChatId === params.chatId) {
                   setStreaming(false);
@@ -2415,8 +2414,8 @@ export function useGenerate() {
             }
             clearStreamBuffer(params.chatId);
           }
+          setProcessing(false, params.chatId);
           if (isActiveChat()) {
-            setProcessing(false, params.chatId);
             setRegenerateMessageId(null);
             setStreamingCharacterId(null);
             setTypingCharacterName(null);

--- a/packages/client/src/lib/textarea-quotes.ts
+++ b/packages/client/src/lib/textarea-quotes.ts
@@ -1,13 +1,20 @@
 import { formatTextQuotes, type QuoteFormat } from "@marinara-engine/shared";
 import { captureTextSelection, restoreTextSelectionAfterRender } from "./text-selection";
 
+const pendingSelectionRestores = new WeakMap<HTMLTextAreaElement, () => void>();
+
 export function applyTextareaQuoteFormat(textarea: HTMLTextAreaElement, quoteFormat: QuoteFormat): string {
+  pendingSelectionRestores.get(textarea)?.();
+  pendingSelectionRestores.delete(textarea);
+
   const raw = textarea.value;
   const formatted = formatTextQuotes(raw, quoteFormat);
   if (raw === formatted) return formatted;
 
   const selection = captureTextSelection(textarea);
   textarea.value = formatted;
-  if (selection) restoreTextSelectionAfterRender(selection);
+  if (selection) {
+    pendingSelectionRestores.set(textarea, restoreTextSelectionAfterRender(selection));
+  }
   return formatted;
 }

--- a/packages/server/src/services/tools/tool-executor.ts
+++ b/packages/server/src/services/tools/tool-executor.ts
@@ -66,7 +66,6 @@ export type MetadataUpdater = (current: MetadataPatch) => MetadataPatch | Promis
 export type MetadataPatchInput = MetadataPatch | MetadataUpdater;
 
 const MAX_APPEND_BYTES = 16 * 1024;
-const MAX_LOREBOOK_ENTRY_CONTENT_BYTES = 64 * 1024;
 const MAX_LOREBOOK_ENTRY_DESCRIPTION_BYTES = 4 * 1024;
 const MAX_LOREBOOK_ENTRY_NAME_LENGTH = 160;
 const MAX_LOREBOOK_ENTRY_KEYS = 24;
@@ -774,7 +773,7 @@ async function saveLorebookEntry(
   }
 
   const name = args.name.trim().slice(0, MAX_LOREBOOK_ENTRY_NAME_LENGTH);
-  const content = trimToUtf8Bytes(args.content.trim(), MAX_LOREBOOK_ENTRY_CONTENT_BYTES);
+  const content = args.content.trim();
   const description =
     typeof args.description === "string" && args.description.trim()
       ? trimToUtf8Bytes(args.description.trim(), MAX_LOREBOOK_ENTRY_DESCRIPTION_BYTES)

--- a/packages/shared/src/features/function-calls/tools/save-lorebook-entry/manifest.ts
+++ b/packages/shared/src/features/function-calls/tools/save-lorebook-entry/manifest.ts
@@ -8,7 +8,7 @@ export const saveLorebookEntryToolManifest = {
     type: "object",
     properties: {
       name: { type: "string", description: "Short entry title, such as a character, location, object, or event name" },
-      content: { type: "string", description: "Concise lorebook entry content to store" },
+      content: { type: "string", description: "Lorebook entry content to store" },
       description: { type: "string", description: "Optional one-line description for routing and editor context" },
       keys: {
         type: "array",

--- a/scripts/regressions/prompt.regression.ts
+++ b/scripts/regressions/prompt.regression.ts
@@ -45,6 +45,8 @@ import { resolveGenerationPromptPresetChoices } from "../../packages/server/src/
 import { scanForActivatedEntries } from "../../packages/server/src/services/lorebook/keyword-scanner.js";
 import { fitMessagesForModelAccess } from "../../packages/server/src/services/generation/model-access-policy.js";
 import { assemblePrompt, type AssemblerInput } from "../../packages/server/src/services/prompt/index.js";
+import { executeToolCalls } from "../../packages/server/src/services/tools/tool-executor.js";
+import type { LLMToolCall } from "../../packages/server/src/services/llm/base-provider.js";
 
 type RegressionCase = {
   name: string;
@@ -154,6 +156,38 @@ const cases: RegressionCase[] = [
       });
       assert.equal(testSecondaryKeys(["forbidden"], "This has the forbidden key.", "not", keywordOptions), false);
       assert.equal(testSecondaryKeys(["forbidden"], "This is safe.", "not", keywordOptions), true);
+    },
+  },
+  {
+    name: "save_lorebook_entry tool preserves large entry content",
+    async run() {
+      const longContent = `entry-start\n${"0123456789".repeat(8_000)}\nentry-end`;
+      let savedContent = "";
+      const calls: LLMToolCall[] = [
+        {
+          id: "call_save_lore",
+          type: "function",
+          function: {
+            name: "save_lorebook_entry",
+            arguments: JSON.stringify({
+              name: "Large entry",
+              content: longContent,
+              keys: ["Large entry"],
+              mode: "replace",
+            }),
+          },
+        },
+      ];
+
+      const results = await executeToolCalls(calls, {
+        saveLorebookEntry: async (entry) => {
+          savedContent = entry.content;
+          return { ok: true };
+        },
+      });
+
+      assert.equal(results[0]?.success, true);
+      assert.equal(savedContent, longContent);
     },
   },
   {


### PR DESCRIPTION
## Summary
- Recovers the quote-format caret preservation fix so typing apostrophes does not jump the cursor.
- Restores the Roleplay send-button/agent cleanup behavior so post-generation agents such as Illustrator keep the busy spinner without keeping the live stream bubble alive as a duplicate message.
- Removes the agent/tool write-path content cap for `save_lorebook_entry` and updates its tool description so large lorebook entries are preserved.
- Adds a prompt regression covering large `save_lorebook_entry` content.

## Why
The quote/caret and Illustrator cleanup fixes were local but not yet in `staging`. Users could still see the apostrophe caret jump, and Roleplay agent work could leave confusing UI state while Illustrator finished image generation.

The reported lorebook per-entry limit comes from the agent/tool write path trimming `save_lorebook_entry` content to 64 KiB before storage. The main lorebook editor schema and SQLite storage already allow larger content, so this removes the hidden agent-side truncation.

## Validation
- pnpm regression:prompt
- pnpm check
- git diff --check

## Manual verification needed
- In Roleplay mode with streaming enabled, trigger Illustrator and confirm the last text message does not appear as a duplicate while the image is generating.
- Type apostrophes in the chat input with quote formatting enabled and confirm the caret stays in place.
- Use an agent/tool write to save a lorebook entry larger than 64 KiB and confirm the stored entry is not truncated.
