### PR TITLE
[codex] Fix Windows server builds from paths with spaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 
 ### Fixed
 
+- Fixed Windows server builds failing from install paths with spaces by launching the TypeScript compiler through Node directly instead of a shell-resolved shim.
 - Fixed Termux dependency refreshes so Android installs that add the `wasm32` optional-dependency architecture run `pnpm install --force`, allowing `@img/sharp-wasm32` to be linked for sprite generation and other sharp-backed image processing (#3167).
 
 ## [2.1.0]

--- a/packages/server/scripts/build.mjs
+++ b/packages/server/scripts/build.mjs
@@ -7,15 +7,14 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 const PACKAGE_ROOT = resolve(__dirname, "..");
 const SRC_DIR = resolve(PACKAGE_ROOT, "src");
 const DIST_DIR = resolve(PACKAGE_ROOT, "dist");
+const TSC_CLI = fileURLToPath(import.meta.resolve("typescript/bin/tsc"));
 const LOW_MEMORY_BUILD = process.platform === "android" || process.env.MARINARA_LOW_MEMORY_BUILD === "1";
 
 function run(command, args, options = {}) {
   const result = spawnSync(command, args, {
     cwd: PACKAGE_ROOT,
     env: { ...process.env, ...options.env },
-    // The shell is only needed to resolve .cmd shims (tsc) on Windows; it
-    // breaks unquoted paths with spaces, e.g. "C:\Program Files\nodejs\node.exe".
-    shell: options.shell ?? process.platform === "win32",
+    shell: options.shell ?? false,
     stdio: "inherit",
   });
   if (result.status !== 0) {
@@ -65,7 +64,7 @@ function copyRuntimeAssets() {
 if (LOW_MEMORY_BUILD) {
   await buildLowMemoryServer();
 } else {
-  run("tsc", []);
+  run(process.execPath, [TSC_CLI]);
 }
 
 run(process.execPath, [resolve(__dirname, "write-build-meta.mjs")], { shell: false });


### PR DESCRIPTION
## Summary
- Runs the server TypeScript build through `process.execPath` and the resolved `typescript/bin/tsc` CLI file.
- Removes the Windows shell fallback from the server build wrapper so install paths containing spaces are not split by `cmd`/shim resolution.
- Adds a changelog note for the staging update/build fix.

## Why
A Windows user updating to staging from `F:\A.I\Marinara Engine\...` hit `Cannot find module 'F:\A.I\Marinara'` during `@marinara-engine/server build`. The path was being split at the space in `Marinara Engine` while launching the compiler through shell/shim resolution.

## Validation
- pnpm --filter @marinara-engine/server build
- node ./scripts/build.mjs from `/tmp/Marinara Engine/packages/server` symlink path
- pnpm --filter @marinara-engine/server lint
- git diff --check
