### PR TITLE
[codex] Fix issue sweep 3169-3173

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 
 ### Fixed
 
+- Removed the hard-coded three-sprite limit from Roleplay sprite selection, setup, and display paths so chats can enable all uploaded sprite owners they need (#3169).
+- Let Image Captioning use any non-image-generation connection instead of hiding local or custom multimodal models behind model-name heuristics (#3170).
+- Stabilized emoji and sticker popover positioning above the mobile composer when Android browsers resize the visual viewport around the keyboard (#3171).
+- Switched Persona editor textarea counters from raw character counts to the same approximate token counts used elsewhere in the UI (#3172).
+- Fixed Illustrator prompt tag cleanup so grouped weighted tags such as `(shaved head, bald:1.2)` stay intact during deduplication and negative-prompt extraction (#3173).
 - Fixed Termux dependency refreshes so Android installs that add the `wasm32` optional-dependency architecture run `pnpm install --force`, allowing `@img/sharp-wasm32` to be linked for sprite generation and other sharp-backed image processing (#3167).
 
 ## [2.1.0]

--- a/packages/client/src/components/chat/AgentAddSetupFields.tsx
+++ b/packages/client/src/components/chat/AgentAddSetupFields.tsx
@@ -281,7 +281,7 @@ export function buildInitialAgentAddSetupState({
       typeof metadata.illustratorUseAvatarReferences === "boolean"
         ? metadata.illustratorUseAvatarReferences
         : settings.useAvatarReferences === true,
-    spriteCharacterIds: normalizeStringArray(metadata.spriteCharacterIds).slice(0, 3),
+    spriteCharacterIds: normalizeStringArray(metadata.spriteCharacterIds),
     spriteDisplayModes: normalizeSpriteDisplayModes(metadata.spriteDisplayModes),
     expressionAvatarsEnabled: metadata.expressionAvatarsEnabled === true,
     spritePosition: metadata.spritePosition === "right" ? "right" : "left",
@@ -916,7 +916,6 @@ function ExpressionSetupFields({
       onChange({ spriteCharacterIds: selectedSpriteIds.filter((current) => current !== id) });
       return;
     }
-    if (selectedSpriteIds.length >= 3) return;
     onChange({ spriteCharacterIds: [...selectedSpriteIds, id] });
   };
 
@@ -943,12 +942,11 @@ function ExpressionSetupFields({
           <div className="max-h-40 space-y-1 overflow-y-auto rounded-lg border border-[var(--border)] bg-[var(--background)]/75 p-2">
             {subjectsWithSprites.map((subject) => {
               const active = selectedSpriteIds.includes(subject.id);
-              const maxed = !active && selectedSpriteIds.length >= 3;
               return (
                 <button
                   key={subject.id}
                   type="button"
-                  disabled={disabled || maxed}
+                  disabled={disabled}
                   onClick={() => toggleSprite(subject.id)}
                   className={cn(
                     "flex w-full items-center gap-2.5 rounded-lg px-3 py-2 text-left text-xs transition-all disabled:cursor-not-allowed disabled:opacity-50",

--- a/packages/client/src/components/chat/ChatSettingsDrawer.tsx
+++ b/packages/client/src/components/chat/ChatSettingsDrawer.tsx
@@ -7127,7 +7127,7 @@ export function ChatSettingsDrawer({
               metadata={metadata}
               isConversation={isConversation}
               connectionId={chat.connectionId ?? null}
-              connections={chatGenerationConnectionsList as Record<string, unknown>[]}
+              connections={chatGenerationConnectionsList}
               contextMessageLimit={metadata.contextMessageLimit as number | null | undefined}
               excludePastReasoning={metadata.excludePastReasoning as boolean | undefined}
               imageCaptioningEnabled={metadata.imageCaptioningEnabled as boolean | undefined}

--- a/packages/client/src/components/chat/ChatSettingsDrawer.tsx
+++ b/packages/client/src/components/chat/ChatSettingsDrawer.tsx
@@ -1798,7 +1798,6 @@ export function ChatSettingsDrawer({
     if (idx >= 0) {
       current.splice(idx, 1);
     } else {
-      if (current.length >= 3) return; // max 3
       current.push(charId);
     }
     updateMeta.mutate({ id: chat.id, spriteCharacterIds: current });
@@ -5939,7 +5938,7 @@ export function ChatSettingsDrawer({
                         badge={
                           spriteCharacterIds.length > 0 ? (
                             <span className="shrink-0 rounded-full bg-[var(--primary)]/10 px-1.5 py-0.5 text-[0.5625rem] font-medium text-[var(--primary)]">
-                              {spriteCharacterIds.length}/3 enabled
+                              {spriteCharacterIds.length} enabled
                             </span>
                           ) : null
                         }
@@ -6056,7 +6055,6 @@ export function ChatSettingsDrawer({
 
                                   <SpriteToggleButton
                                     active={spriteActive}
-                                    disabled={!spriteActive && spriteCharacterIds.length >= 3}
                                     onToggle={() => toggleSprite(subject.id)}
                                   />
                                 </div>
@@ -6075,8 +6073,7 @@ export function ChatSettingsDrawer({
                         )}
 
                         <p className="text-[0.625rem] text-[var(--muted-foreground)]">
-                          Only added characters and the active persona with uploaded sprites appear here. You can enable
-                          up to 3 at a time.
+                          Only added characters and the active persona with uploaded sprites appear here.
                         </p>
 
                         {spriteCharacterIds.length > 0 && (
@@ -8316,25 +8313,21 @@ function SpriteDisplayModeToggle({
 // ── Sprite toggle button (per character) ──
 function SpriteToggleButton({
   active,
-  disabled,
   onToggle,
 }: {
   active: boolean;
-  disabled: boolean;
   onToggle: () => void;
 }) {
   return (
     <button
       onClick={onToggle}
-      disabled={disabled}
       className={cn(
         "inline-flex items-center gap-1.5 rounded-md px-2.5 py-1.5 text-[0.625rem] font-medium transition-colors ring-1",
         active
           ? "bg-[var(--primary)]/10 text-[var(--primary)] ring-[var(--primary)]/30 hover:bg-[var(--primary)]/15"
           : "text-[var(--muted-foreground)] ring-[var(--border)] hover:bg-[var(--accent)]",
-        disabled && "opacity-30 cursor-not-allowed",
       )}
-      title={active ? "Disable sprite" : disabled ? "Max 3 sprites" : "Enable sprite"}
+      title={active ? "Disable sprite" : "Enable sprite"}
     >
       <Image size="0.6875rem" />
       <span>{active ? "Enabled" : "Enable"}</span>

--- a/packages/client/src/components/chat/SpriteOverlay.tsx
+++ b/packages/client/src/components/chat/SpriteOverlay.tsx
@@ -250,7 +250,6 @@ export function SpriteOverlay({
     setStates(newStates);
   }, [messages, characterIds, expressionResult, spriteExpressions, fullBodyOnly]);
 
-  const visibleChars = useMemo(() => characterIds, [characterIds]);
   const renderModes = useMemo<SpriteRenderMode[]>(() => {
     if (fullBodyOnly) return ["full-body"];
     const modes: SpriteRenderMode[] = [];
@@ -262,9 +261,9 @@ export function SpriteOverlay({
     const entries: VisibleSpriteEntry[] = [];
     const hasPairedSprites = renderModes.length > 1;
 
-    for (const [index, charId] of visibleChars.entries()) {
+    for (const [index, charId] of characterIds.entries()) {
       const basePlacement = clampSpritePlacement(
-        spritePlacements?.[charId] ?? getDefaultSpritePlacement(index, visibleChars.length, side),
+        spritePlacements?.[charId] ?? getDefaultSpritePlacement(index, characterIds.length, side),
       );
 
       for (const [modeIndex, renderMode] of renderModes.entries()) {
@@ -283,7 +282,7 @@ export function SpriteOverlay({
     }
 
     return entries;
-  }, [renderModes, side, spritePlacements, visibleChars]);
+  }, [characterIds, renderModes, side, spritePlacements]);
 
   if (visibleSpriteEntries.length === 0) return null;
 
@@ -304,7 +303,7 @@ export function SpriteOverlay({
           expression={states[entry.characterId]?.expression ?? "neutral"}
           transition={states[entry.characterId]?.transition ?? "crossfade"}
           placement={entry.placement}
-          spriteCount={visibleChars.length}
+          spriteCount={characterIds.length}
           editing={editing}
           zIndex={entry.zIndex}
           stageRef={stageRef}

--- a/packages/client/src/components/chat/SpriteOverlay.tsx
+++ b/packages/client/src/components/chat/SpriteOverlay.tsx
@@ -250,7 +250,7 @@ export function SpriteOverlay({
     setStates(newStates);
   }, [messages, characterIds, expressionResult, spriteExpressions, fullBodyOnly]);
 
-  const visibleChars = useMemo(() => characterIds.slice(0, 3), [characterIds]);
+  const visibleChars = useMemo(() => characterIds, [characterIds]);
   const renderModes = useMemo<SpriteRenderMode[]>(() => {
     if (fullBodyOnly) return ["full-body"];
     const modes: SpriteRenderMode[] = [];

--- a/packages/client/src/components/chat/SpriteSidebar.tsx
+++ b/packages/client/src/components/chat/SpriteSidebar.tsx
@@ -42,11 +42,11 @@ export const SpriteSidebar = memo(function SpriteSidebar({
   return (
     <div
       className={cn(
-        "hidden sm:flex w-48 flex-col items-center justify-end gap-2 overflow-hidden py-2",
+        "hidden sm:flex w-48 flex-col items-center justify-end gap-2 overflow-x-hidden overflow-y-auto py-2",
         isRoleplay ? "bg-black/40 border-white/5" : "bg-[var(--secondary)]/50 border-[var(--border)]",
       )}
     >
-      {characterIds.slice(0, 3).map((charId) => (
+      {characterIds.map((charId) => (
         <SidebarSprite
           key={charId}
           characterId={charId}

--- a/packages/client/src/components/chat/StickerPicker.tsx
+++ b/packages/client/src/components/chat/StickerPicker.tsx
@@ -55,7 +55,7 @@ export function StickerPicker({ open, onClose, onSelect, anchorRef, containerRef
   const [query, setQuery] = useState("");
   const [error, setError] = useState<string | null>(null);
   const [showSettings, setShowSettings] = useState(false);
-  const [pos, setPos] = useState<{ bottom: number; right?: number; left?: number; maxHeight?: number }>({ bottom: 0 });
+  const [pos, setPos] = useState<{ top: number; left?: number; maxHeight?: number }>({ top: 0 });
 
   const updatePosition = useCallback(() => {
     if (!anchorRef?.current) return;
@@ -65,17 +65,24 @@ export function StickerPicker({ open, onClose, onSelect, anchorRef, containerRef
     const pickerWidth = 336;
     const pickerHeight = 352;
     const viewport = window.visualViewport;
+    const viewportLeft = viewport?.offsetLeft ?? 0;
+    const viewportTop = viewport?.offsetTop ?? 0;
     const vw = viewport?.width ?? window.innerWidth;
-    const vh = viewport?.height ?? window.innerHeight;
+    const visibleLeft = viewportLeft;
+    const visibleTop = viewportTop;
+    const visibleRight = viewportLeft + vw;
+    const panelWidth = Math.min(pickerWidth, Math.max(0, vw - 2 * pad));
     const refTop = barRect ? barRect.top : btnRect.top;
-    const bottom = vh - refTop + pad;
-    const maxHeight = Math.min(pickerHeight, Math.max(0, refTop - 2 * pad));
+    const anchorTop = refTop + viewportTop;
+    const maxHeight = Math.min(pickerHeight, Math.max(0, anchorTop - visibleTop - 2 * pad));
+    const top = Math.max(visibleTop + pad, anchorTop - maxHeight - pad);
     if (vw < 480) {
-      const left = Math.max(8, (vw - Math.min(pickerWidth, vw - 16)) / 2);
-      setPos({ bottom, left, maxHeight });
+      const left = visibleLeft + Math.max(pad, (vw - panelWidth) / 2);
+      setPos({ top, left, maxHeight });
     } else {
-      const right = Math.max(8, vw - btnRect.right);
-      setPos({ bottom, right, maxHeight });
+      const btnRight = btnRect.right + viewportLeft;
+      const left = Math.max(visibleLeft + pad, Math.min(btnRight - panelWidth, visibleRight - panelWidth - pad));
+      setPos({ top, left, maxHeight });
     }
   }, [anchorRef, containerRef]);
 
@@ -427,8 +434,7 @@ export function StickerPicker({ open, onClose, onSelect, anchorRef, containerRef
       ref={panelRef}
       className="fixed z-[9999] flex h-[22rem] w-[21rem] max-w-[calc(100vw-1rem)] flex-col overflow-hidden rounded-xl border border-foreground/10 bg-[var(--card)] shadow-xl"
       style={{
-        bottom: pos.bottom,
-        ...(pos.right != null ? { right: pos.right } : {}),
+        top: pos.top,
         ...(pos.left != null ? { left: pos.left } : {}),
         ...(pos.maxHeight != null ? { maxHeight: pos.maxHeight } : {}),
       }}

--- a/packages/client/src/components/chat/sprite-placement.ts
+++ b/packages/client/src/components/chat/sprite-placement.ts
@@ -49,7 +49,7 @@ export function getDefaultSpritePlacement(index: number, total: number, side: Sp
   if (total > 3) {
     const start = side === "right" ? 86 : 14;
     const end = side === "right" ? 14 : 86;
-    const x = total <= 1 ? 50 : start + ((end - start) * index) / (total - 1);
+    const x = start + ((end - start) * index) / (total - 1);
     const y = 98 - (index % 4) * 1.5;
     return clampSpritePlacement({ x, y });
   }

--- a/packages/client/src/components/chat/sprite-placement.ts
+++ b/packages/client/src/components/chat/sprite-placement.ts
@@ -46,7 +46,15 @@ export function getDefaultSpritePlacement(index: number, total: number, side: Sp
     center: [[50], [35, 65], [25, 50, 75]],
   };
 
-  const byCount = layouts[side][Math.max(0, Math.min(total, 3) - 1)] ?? layouts[side][0];
+  if (total > 3) {
+    const start = side === "right" ? 86 : 14;
+    const end = side === "right" ? 14 : 86;
+    const x = total <= 1 ? 50 : start + ((end - start) * index) / (total - 1);
+    const y = 98 - (index % 4) * 1.5;
+    return clampSpritePlacement({ x, y });
+  }
+
+  const byCount = layouts[side][Math.max(0, total - 1)] ?? layouts[side][0];
   const x = byCount[index] ?? (side === "left" ? 26 + index * 16 : 74 - index * 16);
   const yOffsets = total >= 3 ? [98, 96, 94] : total === 2 ? [98, 96] : [98];
   const y = yOffsets[index] ?? 98;

--- a/packages/client/src/components/personas/PersonaEditor.tsx
+++ b/packages/client/src/components/personas/PersonaEditor.tsx
@@ -62,6 +62,7 @@ import { ImageUploadDropzone } from "../ui/ImageUploadDropzone";
 import { CustomEmojiTagButton } from "../ui/CustomEmojiTagButton";
 import { api } from "../../lib/api-client";
 import { parseTrackerCardColorConfig, serializeTrackerCardColorConfig } from "../../lib/tracker-card-colors";
+import { estimateTextTokens, formatEstimatedTokens } from "../../lib/character-token-count";
 import {
   useCharacterSprites,
   useUploadSprite,
@@ -119,6 +120,10 @@ const PERSONA_CARD_SECTIONS = [
   { id: "persona-card-appearance", label: "Appearance" },
   { id: "persona-card-scenario", label: "Scenario" },
 ] as const;
+
+function formatPersonaTextTokens(value: string): string {
+  return formatEstimatedTokens(estimateTextTokens(value));
+}
 
 const PERSONA_METADATA_HELP =
   "Use metadata for identity, sharing, and library organization. Name is injected as your persona name, creator/version help track authorship and revisions, tags make the persona searchable, and creator notes stay private.";
@@ -2781,7 +2786,7 @@ function DescriptionTab({
         className="w-full resize-y rounded-xl border border-[var(--border)] bg-[var(--secondary)] p-4 text-sm leading-relaxed outline-none transition-colors placeholder:text-[var(--muted-foreground)]/40 focus:border-emerald-400/40 focus:ring-1 focus:ring-emerald-400/20"
       />
       <p className="mt-1.5 text-right text-[0.625rem] text-[var(--muted-foreground)]">
-        {formData.description.length} characters
+        {formatPersonaTextTokens(formData.description)}
       </p>
     </div>
   );
@@ -2837,7 +2842,9 @@ function TextareaTab({
         title={title}
         className="w-full resize-y rounded-xl border border-[var(--border)] bg-[var(--secondary)] p-4 text-sm leading-relaxed outline-none transition-colors placeholder:text-[var(--muted-foreground)]/40 focus:border-emerald-400/40 focus:ring-1 focus:ring-emerald-400/20"
       />
-      <p className="mt-1.5 text-right text-[0.625rem] text-[var(--muted-foreground)]">{value.length} characters</p>
+      <p className="mt-1.5 text-right text-[0.625rem] text-[var(--muted-foreground)]">
+        {formatPersonaTextTokens(value)}
+      </p>
     </div>
   );
 }

--- a/packages/client/src/components/ui/EmojiPicker.tsx
+++ b/packages/client/src/components/ui/EmojiPicker.tsx
@@ -1167,8 +1167,6 @@ export function EmojiPicker({ open, onClose, onSelect, anchorRef, containerRef, 
   // Position state for portal
   const [pos, setPos] = useState<{
     top?: number;
-    bottom?: number;
-    right?: number;
     left?: number;
     maxHeight?: number;
   }>({});
@@ -1180,22 +1178,33 @@ export function EmojiPicker({ open, onClose, onSelect, anchorRef, containerRef, 
     const pickerWidth = 336; // 21rem
     const pickerHeight = 352; // 22rem
     const viewport = window.visualViewport;
+    const viewportLeft = viewport?.offsetLeft ?? 0;
+    const viewportTop = viewport?.offsetTop ?? 0;
     const vw = viewport?.width ?? window.innerWidth;
     const vh = viewport?.height ?? window.innerHeight;
+    const visibleLeft = viewportLeft;
+    const visibleTop = viewportTop;
+    const visibleRight = viewportLeft + vw;
+    const visibleBottom = viewportTop + vh;
+    const panelWidth = Math.min(pickerWidth, Math.max(0, vw - 2 * pad));
+    const btnRight = btnRect.right + viewportLeft;
+    const btnBottom = btnRect.bottom + viewportTop;
+    const btnTop = btnRect.top + viewportTop;
 
     // Composer mode (anchored to an input bar): pin the bottom edge above the bar's
     // top and grow upward. The bar sits at the bottom of the screen, so this fits.
     if (containerRef?.current) {
       const barRect = containerRef.current.getBoundingClientRect();
-      const bottom = vh - barRect.top + pad;
-      const maxHeight = Math.min(pickerHeight, Math.max(0, barRect.top - 2 * pad));
+      const barTop = barRect.top + viewportTop;
+      const maxHeight = Math.min(pickerHeight, Math.max(0, barTop - visibleTop - 2 * pad));
+      const top = Math.max(visibleTop + pad, barTop - maxHeight - pad);
       if (vw < 480) {
         // Center horizontally on mobile
-        const left = Math.max(pad, (vw - Math.min(pickerWidth, vw - 2 * pad)) / 2);
-        setPos({ bottom, left, maxHeight });
+        const left = visibleLeft + Math.max(pad, (vw - panelWidth) / 2);
+        setPos({ top, left, maxHeight });
       } else {
-        const right = Math.max(pad, vw - btnRect.right);
-        setPos({ bottom, right, maxHeight });
+        const left = Math.max(visibleLeft + pad, Math.min(btnRight - panelWidth, visibleRight - panelWidth - pad));
+        setPos({ top, left, maxHeight });
       }
       return;
     }
@@ -1203,14 +1212,14 @@ export function EmojiPicker({ open, onClose, onSelect, anchorRef, containerRef, 
     // Anchored mode (e.g. a message's reaction button, which can sit anywhere on
     // screen): open BELOW the anchor; flip above only when there isn't room below;
     // and clamp to the viewport so the panel never crosses an edge.
-    const maxHeight = Math.min(pickerHeight, vh - 2 * pad);
-    const spaceBelow = vh - btnRect.bottom;
-    const openBelow = spaceBelow >= maxHeight + pad || spaceBelow >= btnRect.top;
-    let top = openBelow ? btnRect.bottom + pad : btnRect.top - pad - maxHeight;
-    top = Math.max(pad, Math.min(top, vh - maxHeight - pad));
+    const maxHeight = Math.min(pickerHeight, Math.max(0, vh - 2 * pad));
+    const spaceBelow = visibleBottom - btnBottom;
+    const openBelow = spaceBelow >= maxHeight + pad || spaceBelow >= btnTop - visibleTop;
+    let top = openBelow ? btnBottom + pad : btnTop - pad - maxHeight;
+    top = Math.max(visibleTop + pad, Math.min(top, visibleBottom - maxHeight - pad));
     // Align the panel's right edge to the button, then clamp into view.
-    let left = btnRect.right - pickerWidth;
-    left = Math.max(pad, Math.min(left, vw - pickerWidth - pad));
+    let left = btnRight - panelWidth;
+    left = Math.max(visibleLeft + pad, Math.min(left, visibleRight - panelWidth - pad));
     setPos({ top, left, maxHeight });
   }, [anchorRef, containerRef]);
 
@@ -1348,8 +1357,6 @@ export function EmojiPicker({ open, onClose, onSelect, anchorRef, containerRef, 
       className="fixed z-[9999] flex h-[22rem] w-[21rem] max-w-[calc(100vw-1rem)] flex-col overflow-hidden rounded-xl border border-foreground/10 bg-[var(--card)] shadow-xl"
       style={{
         ...(pos.top != null ? { top: pos.top } : {}),
-        ...(pos.bottom != null ? { bottom: pos.bottom } : {}),
-        ...(pos.right != null ? { right: pos.right } : {}),
         ...(pos.left != null ? { left: pos.left } : {}),
         ...(pos.maxHeight != null ? { maxHeight: pos.maxHeight } : {}),
       }}

--- a/packages/client/src/features/chat-settings/sections/AdvancedParametersSection.tsx
+++ b/packages/client/src/features/chat-settings/sections/AdvancedParametersSection.tsx
@@ -12,6 +12,7 @@ import {
 import { DraftNumberInput } from "../../../components/ui/DraftNumberInput";
 import { SettingsSwitch } from "../../../components/panels/settings/SettingControls";
 import { useSaveConnectionDefaults } from "../../../hooks/use-connections";
+import { isLanguageGenerationConnection, type ConnectionProviderLike } from "../../../lib/connection-filters";
 import { cn } from "../../../lib/utils";
 
 const EDITABLE_PARAMETER_KEYS: Array<keyof EditableGenerationParameters> = [
@@ -30,16 +31,13 @@ const EDITABLE_PARAMETER_KEYS: Array<keyof EditableGenerationParameters> = [
   "enabledParameters",
 ];
 
-function isCaptioningSelectableConnection(connection: Record<string, unknown>): boolean {
-  const provider = typeof connection.provider === "string" ? connection.provider : "";
-  return provider !== "image_generation";
-}
+type AdvancedConnection = ConnectionProviderLike & Record<string, unknown>;
 
 interface AdvancedParametersSectionProps {
   metadata: Record<string, unknown>;
   isConversation: boolean;
   connectionId: string | null;
-  connections: Record<string, unknown>[];
+  connections: AdvancedConnection[];
   contextMessageLimit: number | null | undefined;
   excludePastReasoning: boolean | undefined;
   imageCaptioningEnabled: boolean | undefined;
@@ -81,11 +79,11 @@ export function AdvancedParametersSection({
   const effectiveParams = getEditableGenerationParameters(defaults, params);
   const excludeReasoningEnabled = excludePastReasoning !== false;
   const captioningEnabled = imageCaptioningEnabled === true;
-  const chatConnectionCanCaption = !!conn && isCaptioningSelectableConnection(conn);
+  const chatConnectionCanCaption = !!conn && isLanguageGenerationConnection(conn);
   const connectionOptions = useMemo(
     () =>
       connections.flatMap((connection) => {
-        if (!isCaptioningSelectableConnection(connection)) return [];
+        if (!isLanguageGenerationConnection(connection)) return [];
         const id = typeof connection.id === "string" ? connection.id : "";
         if (!id) return [];
         const name = typeof connection.name === "string" && connection.name.trim() ? connection.name.trim() : id;

--- a/packages/client/src/features/chat-settings/sections/AdvancedParametersSection.tsx
+++ b/packages/client/src/features/chat-settings/sections/AdvancedParametersSection.tsx
@@ -30,28 +30,9 @@ const EDITABLE_PARAMETER_KEYS: Array<keyof EditableGenerationParameters> = [
   "enabledParameters",
 ];
 
-const GENERIC_VISION_MODEL_RE =
-  /\b(?:vision|visual|multimodal|omni|vl|llava|pixtral|internvl|molmo|mllama|idefics)\b|qwen[\w.-]*vl/i;
-
-function isLikelyVisionConnection(connection: Record<string, unknown>): boolean {
+function isCaptioningSelectableConnection(connection: Record<string, unknown>): boolean {
   const provider = typeof connection.provider === "string" ? connection.provider : "";
-  const model = typeof connection.model === "string" ? connection.model.toLowerCase() : "";
-  if (!model || provider === "image_generation") return false;
-  if (GENERIC_VISION_MODEL_RE.test(model)) return true;
-  if (provider === "google" || provider === "google_vertex") return model.includes("gemini");
-  if (provider === "anthropic" || provider === "claude_subscription") {
-    return /\bclaude-(?:3|4|fable|mythos|opus|sonnet|haiku)/i.test(model);
-  }
-  if (provider === "openai" || provider === "openai_chatgpt") {
-    return /\b(?:gpt-4o|gpt-4\.1|gpt-5|chatgpt|chat-latest|o3|o4)\b/i.test(model);
-  }
-  if (provider === "cohere") return /(?:aya-vision|command-a-vision)/i.test(model);
-  if (provider === "mistral") return /(?:pixtral|mistral-(?:small|medium|large)-3)/i.test(model);
-  if (provider === "xai") return /(?:grok.*vision|grok-[34])/i.test(model);
-  if (provider === "openrouter" || provider === "nanogpt" || provider === "custom") {
-    return /(?:gpt-4o|gpt-4\.1|gpt-5|gemini|claude-(?:3|4)|pixtral|aya-vision|command-a-vision)/i.test(model);
-  }
-  return false;
+  return provider !== "image_generation";
 }
 
 interface AdvancedParametersSectionProps {
@@ -100,11 +81,11 @@ export function AdvancedParametersSection({
   const effectiveParams = getEditableGenerationParameters(defaults, params);
   const excludeReasoningEnabled = excludePastReasoning !== false;
   const captioningEnabled = imageCaptioningEnabled === true;
-  const chatConnectionCanCaption = !!conn && isLikelyVisionConnection(conn);
+  const chatConnectionCanCaption = !!conn && isCaptioningSelectableConnection(conn);
   const connectionOptions = useMemo(
     () =>
       connections.flatMap((connection) => {
-        if (!isLikelyVisionConnection(connection)) return [];
+        if (!isCaptioningSelectableConnection(connection)) return [];
         const id = typeof connection.id === "string" ? connection.id : "";
         if (!id) return [];
         const name = typeof connection.name === "string" && connection.name.trim() ? connection.name.trim() : id;
@@ -238,8 +219,8 @@ export function AdvancedParametersSection({
               label="Image Captioning"
               description={
                 hasCaptioningConnection
-                  ? "Describe image attachments with a selected vision-capable connection instead of sending native images."
-                  : "Add a vision-capable connection before enabling image captioning."
+                  ? "Describe image attachments with a selected connection instead of sending native images. Text-only endpoints may fail."
+                  : "Add a connection before enabling image captioning."
               }
               checked={captioningEnabled}
               onChange={(checked) =>
@@ -278,7 +259,7 @@ export function AdvancedParametersSection({
                     <option value="">Use chat connection</option>
                   ) : (
                     <option value="" disabled>
-                      Select a vision connection
+                      Select a captioning connection
                     </option>
                   )}
                   {connectionOptions.map((connection) => (

--- a/packages/client/src/lib/character-token-count.ts
+++ b/packages/client/src/lib/character-token-count.ts
@@ -20,7 +20,7 @@ const CARD_TEXT_FIELDS: Array<keyof CharacterData> = [
   "post_history_instructions",
 ];
 
-function estimateTokens(text: string): number {
+export function estimateTextTokens(text: string): number {
   return Math.ceil(text.length / CHARS_PER_TOKEN);
 }
 
@@ -83,7 +83,7 @@ export function estimateCharacterCardTokens(data: CharacterTokenData): number {
 
   collectCharacterBook(data.character_book, textParts);
 
-  return estimateTokens(textParts.join("\n"));
+  return estimateTextTokens(textParts.join("\n"));
 }
 
 export function formatEstimatedTokens(tokens: number): string {

--- a/packages/shared/src/utils/image-prompt-compiler.ts
+++ b/packages/shared/src/utils/image-prompt-compiler.ts
@@ -229,6 +229,69 @@ function splitPromptListItems(value: string): string[] {
   return parts;
 }
 
+function splitNaturalPromptClauses(value: string): string[] {
+  const parts: string[] = [];
+  let current = "";
+  let parenDepth = 0;
+  let bracketDepth = 0;
+  let braceDepth = 0;
+  let quote: '"' | null = null;
+  let escaped = false;
+
+  const pushCurrent = () => {
+    const clean = current.trim();
+    if (clean) parts.push(clean);
+    current = "";
+  };
+
+  for (let index = 0; index < value.length; index += 1) {
+    const char = value[index]!;
+
+    if (escaped) {
+      current += char;
+      escaped = false;
+      continue;
+    }
+
+    if (char === "\\") {
+      current += char;
+      escaped = true;
+      continue;
+    }
+
+    if (quote) {
+      current += char;
+      if (char === quote) quote = null;
+      continue;
+    }
+
+    if (char === '"') {
+      current += char;
+      quote = char;
+      continue;
+    }
+
+    if (char === "(") parenDepth += 1;
+    else if (char === ")" && parenDepth > 0) parenDepth -= 1;
+    else if (char === "[") bracketDepth += 1;
+    else if (char === "]" && bracketDepth > 0) bracketDepth -= 1;
+    else if (char === "{") braceDepth += 1;
+    else if (char === "}" && braceDepth > 0) braceDepth -= 1;
+
+    const insideGroup = parenDepth > 0 || bracketDepth > 0 || braceDepth > 0;
+    const startsNegativeClause = /^\s*(?:avoid|no|without)\b/i.test(value.slice(index + 1));
+    if (!insideGroup && (char === "\n" || (char === "," && startsNegativeClause))) {
+      pushCurrent();
+      continue;
+    }
+
+    current += char;
+  }
+
+  pushCurrent();
+  return parts;
+}
+
 export function mergeCompiledPromptMeta(
   meta: Record<string, unknown> | undefined,
   compiled: Pick<CompiledImagePrompt, "profile" | "diagnostics">,
@@ -269,7 +332,7 @@ function splitPromptFragments(
 
   if (promptMode === "natural") {
     const fragments: string[] = [];
-    for (const part of normalized.split(/\n+|,(?=\s*(?:avoid|no|without)\b)/i)) {
+    for (const part of splitNaturalPromptClauses(normalized)) {
       const clean = part.trim();
       if (!clean) continue;
       if (hasAvoidInstructionPrefix(clean)) {
@@ -453,9 +516,7 @@ function distillLabeledPromptValue(label: string, value: string): string[] {
   }
 
   if (/^(?:appearance|canonical appearance|species|equipment|composition)$/i.test(normalizedLabel)) {
-    return cleanValue
-      .split(/\s+\band\b\s+/gi)
-      .flatMap(splitPromptListItems)
+    return splitPromptListItems(cleanValue)
       .map((part) => part.trim())
       .filter((part) => shouldKeepTaggedSourceFragment(part));
   }

--- a/packages/shared/src/utils/image-prompt-compiler.ts
+++ b/packages/shared/src/utils/image-prompt-compiler.ts
@@ -169,6 +169,66 @@ function imageNegativePromptPrefixFromDefaults(defaults: ImageGenerationDefaults
   return "";
 }
 
+function splitPromptListItems(value: string): string[] {
+  const parts: string[] = [];
+  let current = "";
+  let parenDepth = 0;
+  let bracketDepth = 0;
+  let braceDepth = 0;
+  let quote: '"' | null = null;
+  let escaped = false;
+
+  const pushCurrent = () => {
+    const clean = current.trim();
+    if (clean) parts.push(clean);
+    current = "";
+  };
+
+  for (const char of value) {
+    if (escaped) {
+      current += char;
+      escaped = false;
+      continue;
+    }
+
+    if (char === "\\") {
+      current += char;
+      escaped = true;
+      continue;
+    }
+
+    if (quote) {
+      current += char;
+      if (char === quote) quote = null;
+      continue;
+    }
+
+    if (char === '"') {
+      current += char;
+      quote = char;
+      continue;
+    }
+
+    if (char === "(") parenDepth += 1;
+    else if (char === ")" && parenDepth > 0) parenDepth -= 1;
+    else if (char === "[") bracketDepth += 1;
+    else if (char === "]" && bracketDepth > 0) bracketDepth -= 1;
+    else if (char === "{") braceDepth += 1;
+    else if (char === "}" && braceDepth > 0) braceDepth -= 1;
+
+    const insideGroup = parenDepth > 0 || bracketDepth > 0 || braceDepth > 0;
+    if (!insideGroup && (char === "," || char === ";" || char === "\n")) {
+      pushCurrent();
+      continue;
+    }
+
+    current += char;
+  }
+
+  pushCurrent();
+  return parts;
+}
+
 export function mergeCompiledPromptMeta(
   meta: Record<string, unknown> | undefined,
   compiled: Pick<CompiledImagePrompt, "profile" | "diagnostics">,
@@ -203,35 +263,31 @@ function splitPromptFragments(
 
   const normalized = text
     .replace(/\r\n?/g, "\n")
-    .replace(
-      /((?:^|[\n,])\s*(?:avoid|no|without|exclude|do not include|don't include)\s+[^,;\n]+),/gi,
-      "$1\n",
-    )
     .replace(/[.!?]\s+(?=(?:avoid|no|without|exclude|do not include|don't include)\b)/gi, "\n")
     .replace(/\b(?:avoid|negative prompt|undesired content)\s*:/gi, "\navoid ")
-    .replace(/\b(?:positive prompt|tags?)\s*:/gi, "\n")
-    .replace(/((?:^|[\n,])\s*(?:avoid|no|without|exclude|do not include|don't include)\s+[^,;\n]+),/gi, "$1\n");
+    .replace(/\b(?:positive prompt|tags?)\s*:/gi, "\n");
 
   if (promptMode === "natural") {
-    return normalized
-      .split(/\n+|,(?=\s*(?:avoid|no|without)\b)/i)
-      .map((part) => part.trim())
-      .filter(Boolean);
+    const fragments: string[] = [];
+    for (const part of normalized.split(/\n+|,(?=\s*(?:avoid|no|without)\b)/i)) {
+      const clean = part.trim();
+      if (!clean) continue;
+      if (hasAvoidInstructionPrefix(clean)) {
+        fragments.push(...splitPromptListItems(clean));
+      } else {
+        fragments.push(clean);
+      }
+    }
+    return fragments;
   }
 
   const prepared = sourcePrompt ? distillTaggedPromptSource(normalized) : normalized;
 
-  return prepared
-    .split(/[,;\n]+/g)
-    .map((part) => part.trim())
-    .filter(Boolean);
+  return splitPromptListItems(prepared);
 }
 
 function splitNegativePromptItems(value: string): string[] {
-  return value
-    .split(/[,;]/g)
-    .map((part) => part.trim())
-    .filter(Boolean);
+  return splitPromptListItems(value);
 }
 
 function distillTaggedPromptSource(value: string): string {
@@ -241,7 +297,7 @@ function distillTaggedPromptSource(value: string): string {
     if (!sentence) continue;
     const negative = extractNegativeFragment(sentence);
     if (negative) {
-      for (const item of negative.split(/[,;]/g)) {
+      for (const item of splitNegativePromptItems(negative)) {
         const cleanNegative = item.trim();
         if (cleanNegative) fragments.push(`avoid ${cleanNegative}`);
       }
@@ -271,7 +327,7 @@ function distillTaggedPromptSource(value: string): string {
     if (distilled.length > 0) {
       fragments.push(...distilled);
     }
-    for (const item of clean.split(/[,;]/g)) {
+    for (const item of splitPromptListItems(clean)) {
       const cleanItem = item.trim();
       if (hasAvoidInstructionPrefix(cleanItem)) {
         fragments.push(cleanItem);
@@ -309,8 +365,7 @@ function reconcileProfileSubjectTags(tags: string, sourceCues: string[]): string
   const genderCue = sourceCues.find((cue) => /^(?:female|male|androgynous)$/.test(cue));
   if (!tags.trim() || !genderCue) return tags;
 
-  return tags
-    .split(/[,;\n]+/g)
+  return splitPromptListItems(tags)
     .map((tag) => tag.trim())
     .filter(Boolean)
     .flatMap((tag) => reconcileGenderedTag(tag, genderCue))
@@ -399,7 +454,8 @@ function distillLabeledPromptValue(label: string, value: string): string[] {
 
   if (/^(?:appearance|canonical appearance|species|equipment|composition)$/i.test(normalizedLabel)) {
     return cleanValue
-      .split(/[,;]|\s+\band\b\s+/gi)
+      .split(/\s+\band\b\s+/gi)
+      .flatMap(splitPromptListItems)
       .map((part) => part.trim())
       .filter((part) => shouldKeepTaggedSourceFragment(part));
   }
@@ -594,9 +650,9 @@ function isLowPriorityCompactTag(value: string): boolean {
 
 function extractNegativeFragment(fragment: string): string | null {
   const clean = fragment.trim();
-  const match = clean.match(/^(?:avoid|no|without|exclude|do not include|don't include)\s+([^,;]+)/i);
+  const match = clean.match(/^(?:avoid|no|without|exclude|do not include|don't include)\s+(.+)/i);
   if (!match?.[1]) return null;
-  const negative = match[1]
+  const negative = (splitPromptListItems(match[1])[0] ?? "")
     .replace(/[.]+$/g, "")
     .replace(/^(?:any|all)\s+/i, "")
     .trim();
@@ -605,10 +661,10 @@ function extractNegativeFragment(fragment: string): string | null {
 }
 
 function stripLeadingNegativeClause(fragment: string): string {
-  return fragment
-    .trim()
-    .replace(/^(?:avoid|no|without|exclude|do not include|don't include)\s+[^,;]+[,;]?\s*/i, "")
-    .trim();
+  const clean = fragment.trim();
+  const match = clean.match(/^(?:avoid|no|without|exclude|do not include|don't include)\s+(.+)/i);
+  if (!match?.[1]) return clean;
+  return splitPromptListItems(match[1]).slice(1).join(", ").trim();
 }
 
 function hasAvoidInstructionPrefix(fragment: string): boolean {

--- a/scripts/regressions/prompt.regression.ts
+++ b/scripts/regressions/prompt.regression.ts
@@ -593,6 +593,16 @@ Use HTML sparingly and diegetically. Do not replace normal prose/dialogue unless
       assert.match(compiled.prompt, /\bstanding\b/);
       assert.match(compiled.negativePrompt, /\(bad hands, extra fingers:1\.2\)/);
       assert.doesNotMatch(compiled.prompt, /\(bad hands, extra fingers:1\.2\)/);
+
+      const taggedAppearance = compileImagePrompt({
+        kind: "portrait",
+        prompt: "Equipment: (sword and shield), cloak",
+        styleProfiles,
+        styleProfileId: "danbooru",
+      });
+
+      assert.match(taggedAppearance.prompt, /\(sword and shield\)/);
+      assert.match(taggedAppearance.prompt, /\bcloak\b/);
     },
   },
   {
@@ -610,6 +620,18 @@ Use HTML sparingly and diegetically. Do not replace normal prose/dialogue unless
       assert.doesNotMatch(natural.negativePrompt, /holding flowers|smiling/);
       assert.match(natural.prompt, /holding flowers/);
       assert.match(natural.prompt, /smiling/);
+
+      const groupedNatural = compileImagePrompt({
+        kind: "selfie",
+        prompt: 'A cafe sign says "no shoes, no service", no (bad hands, extra fingers:1.2), holding flowers',
+        styleProfiles,
+        styleProfileId: "realistic",
+      });
+
+      assert.match(groupedNatural.prompt, /no shoes, no service/);
+      assert.match(groupedNatural.prompt, /holding flowers/);
+      assert.match(groupedNatural.negativePrompt, /\(bad hands, extra fingers:1\.2\)/);
+      assert.doesNotMatch(groupedNatural.negativePrompt, /no shoes|no service|holding flowers/);
 
       const tagged = compileImagePrompt({
         kind: "portrait",

--- a/scripts/regressions/prompt.regression.ts
+++ b/scripts/regressions/prompt.regression.ts
@@ -569,6 +569,33 @@ Use HTML sparingly and diegetically. Do not replace normal prose/dialogue unless
     },
   },
   {
+    name: "danbooru illustration prompts keep grouped weighted tags intact",
+    run() {
+      const styleProfiles = createDefaultImageStyleProfileSettings();
+      const compiled = compileImagePrompt({
+        kind: "illustration",
+        prompt: [
+          "masterpiece",
+          "1boy",
+          "solo",
+          "(shaved head, bald:1.2)",
+          "(grey beard, short beard, stubble:1.3)",
+          "blue eyes",
+          "no (bad hands, extra fingers:1.2)",
+          "standing",
+        ].join(", "),
+        styleProfiles,
+        styleProfileId: "danbooru",
+      });
+
+      assert.match(compiled.prompt, /\(shaved head, bald:1\.2\)/);
+      assert.match(compiled.prompt, /\(grey beard, short beard, stubble:1\.3\)/);
+      assert.match(compiled.prompt, /\bstanding\b/);
+      assert.match(compiled.negativePrompt, /\(bad hands, extra fingers:1\.2\)/);
+      assert.doesNotMatch(compiled.prompt, /\(bad hands, extra fingers:1\.2\)/);
+    },
+  },
+  {
     name: "image prompt negation only moves the directly negated comma clause",
     run() {
       const styleProfiles = createDefaultImageStyleProfileSettings();


### PR DESCRIPTION
## Summary
- Removes the Roleplay sprite owner limit from settings, agent setup, overlay rendering, sidebar rendering, and default placement fallback.
- Lets Image Captioning select any non-image-generation connection, with warning copy for text-only endpoints.
- Anchors emoji and sticker popovers above the mobile composer using visual-viewport-aware top placement.
- Shows Persona editor textarea counters as approximate tokens instead of characters.
- Preserves grouped and weighted Illustrator tags during prompt splitting, dedupe, and negative extraction.

## Issues
Addresses #3169, #3170, #3171, #3172, and #3173.

## Validation
- pnpm regression:prompt
- pnpm --filter @marinara-engine/shared build
- pnpm check

## Manual verification needed
- Verify Roleplay sprite toggles allow more than three sprite owners and the overlay can arrange them.
- Verify Image Captioning exposes the intended local/custom connection in the dropdown.
- Verify mobile emoji/sticker popovers stay anchored above the composer while focusing the input on Android Firefox or a comparable mobile browser.
- Verify Persona textarea counters show approximate token counts.
- Verify Illustrator prompts preserve grouped weighted tags such as `(shaved head, bald:1.2)`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added token-based counters in persona editing for a more accurate text estimate.
  * Expanded captioning connection choices to include more eligible connections.

* **Bug Fixes**
  * Removed the three-sprite limit across chat sprite selection and display.
  * Improved emoji and sticker picker positioning on mobile and small viewports.
  * Fixed prompt cleanup so grouped weighted tags and negative clauses are preserved correctly.

* **Tests**
  * Added regression coverage for illustration prompt compilation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->