### PR TITLE
[codex] Fix game NPC portraits, TTS NPC voices, and Termux update

### DIFF
--- a/packages/client/src/components/panels/settings/TTSConfigCard.tsx
+++ b/packages/client/src/components/panels/settings/TTSConfigCard.tsx
@@ -286,7 +286,7 @@ function NpcDefaultVoicePool({
         </div>
       ) : (
         <p className="rounded-lg border border-dashed border-[var(--border)] px-2.5 py-2 text-[0.625rem] leading-relaxed text-[var(--muted-foreground)]">
-          No ElevenLabs voices loaded yet.
+          No provider voices loaded yet.
         </p>
       )}
       {note && <p className="text-[0.625rem] leading-relaxed text-[var(--muted-foreground)]">{note}</p>}
@@ -566,19 +566,25 @@ export function TTSConfigCard() {
   }, [elevenLabsMatchedFemaleVoiceOptions, npcDefaultFemaleVoices, voiceOptions]);
   const maleNpcVoiceFallbackNote =
     voiceOptions.length > 0 && elevenLabsMatchedMaleVoiceOptions.length === 0
-      ? "No male-labeled defaults were detected, so choose male voices manually here."
+      ? "No male-labeled defaults were detected, so this pool uses the provider voice list."
       : undefined;
   const femaleNpcVoiceFallbackNote =
     voiceOptions.length > 0 && elevenLabsMatchedFemaleVoiceOptions.length === 0
-      ? "No female-labeled defaults were detected, so choose female voices manually here."
+      ? "No female-labeled defaults were detected, so this pool uses the provider voice list."
       : undefined;
   const defaultMaleVoiceIds = useMemo(
-    () => elevenLabsMatchedMaleVoiceOptions.map((option) => option.id),
-    [elevenLabsMatchedMaleVoiceOptions],
+    () =>
+      (elevenLabsMatchedMaleVoiceOptions.length > 0 ? elevenLabsMatchedMaleVoiceOptions : voiceOptions).map(
+        (option) => option.id,
+      ),
+    [elevenLabsMatchedMaleVoiceOptions, voiceOptions],
   );
   const defaultFemaleVoiceIds = useMemo(
-    () => elevenLabsMatchedFemaleVoiceOptions.map((option) => option.id),
-    [elevenLabsMatchedFemaleVoiceOptions],
+    () =>
+      (elevenLabsMatchedFemaleVoiceOptions.length > 0 ? elevenLabsMatchedFemaleVoiceOptions : voiceOptions).map(
+        (option) => option.id,
+      ),
+    [elevenLabsMatchedFemaleVoiceOptions, voiceOptions],
   );
   const characterOptions = useMemo<CharacterOption[]>(() => {
     return ((characters ?? []) as Array<{ id?: string; data?: unknown; comment?: string | null }>)
@@ -1144,46 +1150,44 @@ export function TTSConfigCard() {
             </FieldRow>
           )}
 
-          {source === "elevenlabs" && (
-            <FieldRow
-              label="Random NPC Voices"
-              help="When enabled, tracked game NPCs without a character-specific voice use a stable random ElevenLabs default voice matched to inferred male/female presentation."
-            >
-              <div className="space-y-2 rounded-lg border border-[var(--border)] bg-[var(--secondary)]/40 p-2">
-                <ToggleRow
-                  label="Use default voices for random NPCs"
-                  checked={npcDefaultVoicesEnabled}
-                  onChange={toggleNpcDefaultVoices}
-                />
-                {npcDefaultVoicesEnabled && (
-                  <div className="space-y-3 pt-1">
-                    <NpcDefaultVoicePool
-                      label="Male NPC defaults"
-                      options={elevenLabsNpcMaleVoiceOptions}
-                      selected={npcDefaultMaleVoices}
-                      onToggle={(voiceId, checked) => toggleNpcDefaultVoice("male", voiceId, checked)}
-                      note={maleNpcVoiceFallbackNote}
-                    />
-                    <NpcDefaultVoicePool
-                      label="Female NPC defaults"
-                      options={elevenLabsNpcFemaleVoiceOptions}
-                      selected={npcDefaultFemaleVoices}
-                      onToggle={(voiceId, checked) => toggleNpcDefaultVoice("female", voiceId, checked)}
-                      note={femaleNpcVoiceFallbackNote}
-                    />
-                    <p className="text-[0.625rem] leading-relaxed text-[var(--muted-foreground)]">
-                      NPCs with unclear gender use a stable pick from both pools. Assigned character voices still win.
+          <FieldRow
+            label="Random NPC Voices"
+            help="When enabled, tracked game NPCs without a character-specific voice use a stable random provider voice. If voice metadata is available, Marinara prefers matching male/female pools."
+          >
+            <div className="space-y-2 rounded-lg border border-[var(--border)] bg-[var(--secondary)]/40 p-2">
+              <ToggleRow
+                label="Use default voices for random NPCs"
+                checked={npcDefaultVoicesEnabled}
+                onChange={toggleNpcDefaultVoices}
+              />
+              {npcDefaultVoicesEnabled && (
+                <div className="space-y-3 pt-1">
+                  <NpcDefaultVoicePool
+                    label="Male NPC defaults"
+                    options={elevenLabsNpcMaleVoiceOptions}
+                    selected={npcDefaultMaleVoices}
+                    onToggle={(voiceId, checked) => toggleNpcDefaultVoice("male", voiceId, checked)}
+                    note={maleNpcVoiceFallbackNote}
+                  />
+                  <NpcDefaultVoicePool
+                    label="Female NPC defaults"
+                    options={elevenLabsNpcFemaleVoiceOptions}
+                    selected={npcDefaultFemaleVoices}
+                    onToggle={(voiceId, checked) => toggleNpcDefaultVoice("female", voiceId, checked)}
+                    note={femaleNpcVoiceFallbackNote}
+                  />
+                  <p className="text-[0.625rem] leading-relaxed text-[var(--muted-foreground)]">
+                    NPCs with unclear gender use a stable pick from both pools. Assigned character voices still win.
+                  </p>
+                  {!voicesFromProvider && (
+                    <p className="text-[0.625rem] leading-relaxed text-amber-300/80">
+                      Save and enable this TTS provider, then refresh voices to load provider voice options.
                     </p>
-                    {!voicesFromProvider && (
-                      <p className="text-[0.625rem] leading-relaxed text-amber-300/80">
-                        Save the ElevenLabs connection and refresh voices to load the provider's default voice list.
-                      </p>
-                    )}
-                  </div>
-                )}
-              </div>
-            </FieldRow>
-          )}
+                  )}
+                </div>
+              )}
+            </div>
+          </FieldRow>
 
           {/* Speed */}
           <FieldRow label={speedLabel} help={speedHelp}>

--- a/packages/client/src/lib/tts-dialogue.ts
+++ b/packages/client/src/lib/tts-dialogue.ts
@@ -158,22 +158,23 @@ function resolveNpcDefaultVoice(
   >,
   npcHint?: TTSNpcVoiceHint | null,
 ): string {
-  if (config.source !== "elevenlabs" || !config.npcDefaultVoicesEnabled || !npcHint) return "";
+  if (!config.npcDefaultVoicesEnabled || !npcHint) return "";
 
   const maleVoices = (config.npcDefaultMaleVoices ?? []).filter(Boolean);
   const femaleVoices = (config.npcDefaultFemaleVoices ?? []).filter(Boolean);
+  const combinedVoices = [...new Set([...femaleVoices, ...maleVoices])];
   const gender = inferTTSNpcVoiceGender(npcHint);
   const poolsAreUnpartitioned = sameVoicePool(maleVoices, femaleVoices);
   const pool =
     gender === "female"
       ? !poolsAreUnpartitioned && femaleVoices.length > 0
         ? femaleVoices
-        : []
+        : combinedVoices
       : gender === "male"
         ? !poolsAreUnpartitioned && maleVoices.length > 0
           ? maleVoices
-          : []
-        : [...new Set([...femaleVoices, ...maleVoices])];
+          : combinedVoices
+        : combinedVoices;
 
   if (pool.length === 0) return "";
   const seed = normalizeTTSCharacterName(npcHint.name) || npcHint.name;

--- a/packages/server/src/db/schema/gallery.ts
+++ b/packages/server/src/db/schema/gallery.ts
@@ -2,8 +2,8 @@
 // Schema: Chat Gallery Images
 // ──────────────────────────────────────────────
 import { sqliteTable, text, integer } from "drizzle-orm/sqlite-core";
-import { chats } from "./chats.ts";
-import { characters, personas } from "./characters.ts";
+import { chats } from "./chats.js";
+import { characters, personas } from "./characters.js";
 
 export const chatImages = sqliteTable("chat_images", {
   id: text("id").primaryKey(),

--- a/packages/server/src/routes/game.routes.ts
+++ b/packages/server/src/routes/game.routes.ts
@@ -3201,6 +3201,41 @@ function optionalTrimmedString(value: unknown): string | null {
   return typeof value === "string" && value.trim() ? value.trim() : null;
 }
 
+function normalizePortraitAppearancePart(value: string): string {
+  return value.toLowerCase().replace(/\s+/g, " ").trim();
+}
+
+function addPortraitAppearancePart(parts: string[], value: unknown, label?: string): void {
+  const trimmed = optionalTrimmedString(value);
+  if (!trimmed) return;
+
+  const part = label ? `${label}: ${trimmed}` : trimmed;
+  const normalized = normalizePortraitAppearancePart(part);
+  if (!normalized || parts.some((existing) => normalizePortraitAppearancePart(existing) === normalized)) return;
+  parts.push(part);
+}
+
+function addPortraitAppearanceNotes(parts: string[], notes: unknown): void {
+  if (!Array.isArray(notes)) return;
+
+  const noteText = notes
+    .map((note) => optionalTrimmedString(note))
+    .filter((note): note is string => Boolean(note))
+    .join("; ");
+  addPortraitAppearancePart(parts, noteText, "Notable details");
+}
+
+function addPresentCharacterPortraitAppearance(
+  parts: string[],
+  presentCharacter: Record<string, unknown> | null,
+): void {
+  if (!presentCharacter) return;
+
+  addPortraitAppearancePart(parts, presentCharacter.appearance);
+  addPortraitAppearancePart(parts, presentCharacter.outfit, "Current outfit");
+  addPortraitAppearancePart(parts, presentCharacter.mood, "Current expression or mood");
+}
+
 function findNpcRecordByName(npcs: GameNpc[], name: string): GameNpc | null {
   const normalizedName = normalizeJournalMatch(name);
   if (!normalizedName) return null;
@@ -3222,12 +3257,24 @@ function resolveNpcPortraitAppearance(
   metadataNpc: GameNpc | null,
   presentCharacter: Record<string, unknown> | null,
 ): string {
-  return (
-    optionalTrimmedString(npc.description) ??
-    optionalTrimmedString(metadataNpc?.description) ??
-    optionalTrimmedString(presentCharacter?.appearance) ??
-    ""
-  );
+  const parts: string[] = [];
+  const metadataDescriptionIsCanonical =
+    metadataNpc?.descriptionSource === "model" || metadataNpc?.descriptionSource === "library";
+
+  if (metadataDescriptionIsCanonical) {
+    addPortraitAppearancePart(parts, metadataNpc?.description);
+  }
+
+  addPortraitAppearancePart(parts, npc.description);
+
+  if (!metadataDescriptionIsCanonical) {
+    addPortraitAppearancePart(parts, metadataNpc?.description);
+  }
+
+  addPresentCharacterPortraitAppearance(parts, presentCharacter);
+  addPortraitAppearanceNotes(parts, metadataNpc?.notes);
+
+  return parts.join(" ");
 }
 
 function hasReadableAvatar(avatarUrl: string | null | undefined): avatarUrl is string {

--- a/scripts/regressions/prompt.regression.ts
+++ b/scripts/regressions/prompt.regression.ts
@@ -48,6 +48,7 @@ import { fitMessagesForModelAccess } from "../../packages/server/src/services/ge
 import { assemblePrompt, type AssemblerInput } from "../../packages/server/src/services/prompt/index.js";
 import { executeToolCalls } from "../../packages/server/src/services/tools/tool-executor.js";
 import type { LLMToolCall } from "../../packages/server/src/services/llm/base-provider.js";
+import { resolveTTSVoiceForSpeaker } from "../../packages/client/src/lib/tts-dialogue.js";
 
 type RegressionCase = {
   name: string;
@@ -208,6 +209,73 @@ const cases: RegressionCase[] = [
 
       assert.equal(results[0]?.success, true);
       assert.equal(savedContent, longContent);
+    },
+  },
+  {
+    name: "npc default TTS voice pools work for non-ElevenLabs providers",
+    run() {
+      const baseConfig: Parameters<typeof resolveTTSVoiceForSpeaker>[0] = {
+        source: "openai",
+        voice: "alloy",
+        voiceMode: "per-character",
+        voiceAssignments: [],
+        npcDefaultVoicesEnabled: true,
+        npcDefaultMaleVoices: ["ash", "verse"],
+        npcDefaultFemaleVoices: ["nova", "shimmer"],
+      };
+
+      const maleVoice = resolveTTSVoiceForSpeaker(baseConfig, "Captain Mora", undefined, {
+        name: "Captain Mora",
+        gender: "male",
+      });
+      assert.ok(["ash", "verse"].includes(maleVoice));
+
+      const sharedPoolVoice = resolveTTSVoiceForSpeaker(
+        {
+          ...baseConfig,
+          npcDefaultMaleVoices: ["ash", "nova"],
+          npcDefaultFemaleVoices: ["ash", "nova"],
+        },
+        "Captain Mora",
+        undefined,
+        {
+          name: "Captain Mora",
+          gender: "male",
+        },
+      );
+      assert.ok(["ash", "nova"].includes(sharedPoolVoice));
+
+      const fallbackVoice = resolveTTSVoiceForSpeaker(
+        {
+          ...baseConfig,
+          npcDefaultMaleVoices: [],
+          npcDefaultFemaleVoices: [],
+        },
+        "Captain Mora",
+        undefined,
+        {
+          name: "Captain Mora",
+          gender: "male",
+        },
+      );
+      assert.equal(fallbackVoice, "alloy");
+
+      const emptyElevenLabsVoice = resolveTTSVoiceForSpeaker(
+        {
+          ...baseConfig,
+          source: "elevenlabs",
+          voice: "",
+          npcDefaultMaleVoices: [],
+          npcDefaultFemaleVoices: [],
+        },
+        "Captain Mora",
+        undefined,
+        {
+          name: "Captain Mora",
+          gender: "male",
+        },
+      );
+      assert.equal(emptyElevenLabsVoice, "");
     },
   },
   {


### PR DESCRIPTION
## Why

Fixes #3178.
Fixes #3179.
Fixes #3180.

This PR handles the current issue sweep for Game Mode NPC portrait prompts, Termux staging startup, and NPC TTS fallback/random voice behavior.

## What Changed

- Includes canonical Game Mode NPC descriptions, current tracker appearance, outfit, mood, and notes when composing NPC portrait image prompts, instead of stopping at the first non-empty description.
- Fixes the server schema import extension in `gallery.ts` so the Android/low-memory esbuild output imports emitted `.js` modules instead of missing source `.ts` modules.
- Exposes Random NPC Voices for all TTS providers, not only ElevenLabs.
- Allows non-ElevenLabs TTS providers to use stable random NPC voice pools, including shared/unpartitioned pools for local providers.
- Adds a prompt regression covering non-ElevenLabs NPC default voice resolution.

## Validation

Ran locally:

- `pnpm regression:prompt`
- `MARINARA_LOW_MEMORY_BUILD=1 pnpm --filter @marinara-engine/server build`
- `pnpm --filter @marinara-engine/server lint`
- `pnpm --filter @marinara-engine/client lint`
- `pnpm check`

Confirmed emitted low-memory server output has `packages/server/dist/db/schema/gallery.js` importing `./chats.js` and `./characters.js`.

## Manual Verification Needed

- [ ] In Game Mode, generate/regenerate an NPC portrait for an NPC with a stored generated description and confirm the prompt includes that description.
- [ ] On Termux/Android, update to this staging build and confirm the server starts without the missing `chats.ts` import error.
- [ ] With an OpenAI-compatible/Chatterbox TTS server, enable per-character voices and Random NPC Voices, then confirm unprofiled Game Mode NPC dialogue is voiced.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded random NPC voice options to work with all TTS providers, with clearer guidance when voices haven’t loaded yet.
  * Improved NPC portrait appearance details by combining appearance, outfit, expression, and notable notes into a richer description.

* **Bug Fixes**
  * Fixed voice selection so NPCs can still get a default voice when gender-specific pools are empty.
  * Updated fallback messaging for empty voice lists to be more generic.

* **Tests**
  * Added regression coverage for NPC voice selection across multiple provider pool scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->