### PR TITLE
[codex] Make game narration summarizer prompt editable

### DIFF
--- a/packages/client/src/components/panels/SettingsPanel.tsx
+++ b/packages/client/src/components/panels/SettingsPanel.tsx
@@ -419,7 +419,12 @@ const GAME_ASSET_CATEGORIES = [
   },
 ] as const;
 
-const GAME_IMAGE_PROMPT_TEMPLATE_KEYS = ["game.npcPortrait", "game.background", "game.sceneIllustration"] as const;
+const GAME_IMAGE_PROMPT_TEMPLATE_KEYS = [
+  "game.npcPortrait",
+  "game.background",
+  "game.sceneIllustration",
+  "game.narrationSummarizer",
+] as const;
 
 type GameAssetCategoryId = (typeof GAME_ASSET_CATEGORIES)[number]["id"];
 const GAME_ASSET_CATEGORY_BY_ID = new Map(GAME_ASSET_CATEGORIES.map((category) => [category.id, category]));
@@ -5881,8 +5886,8 @@ function AdvancedSettings() {
       <ImageGenerationSettings />
       <PromptOverridesEditor
         title="Image Prompt Templates"
-        description="Edit the reusable templates used for NPC portraits, scene backgrounds, and scene illustrations."
-        help="These templates render before recurring Game image requests and manual Gallery background generation. One-off prompt review edits still only affect the current request."
+        description="Edit the reusable templates used for NPC portraits, scene backgrounds, scene illustrations, and narration summarization."
+        help="These templates render before recurring Game image requests, narration-to-illustration summarization, and manual Gallery background generation. One-off prompt review edits still only affect the current request."
         keys={GAME_IMAGE_PROMPT_TEMPLATE_KEYS}
         preferredKey="game.npcPortrait"
       />

--- a/packages/server/src/routes/game.routes.ts
+++ b/packages/server/src/routes/game.routes.ts
@@ -145,7 +145,11 @@ import {
   loadImageGenerationUserSettings,
   type ImageGenerationSize,
 } from "../services/image/image-generation-settings.js";
-import { createPromptOverridesStorage } from "../services/storage/prompt-overrides.storage.js";
+import {
+  createPromptOverridesStorage,
+  type PromptOverridesStorage,
+} from "../services/storage/prompt-overrides.storage.js";
+import { GAME_NARRATION_SUMMARIZER, loadPrompt } from "../services/prompt-overrides/index.js";
 import { now } from "../utils/id-generator.js";
 import {
   buildGameSpotifySceneQuery,
@@ -561,7 +565,8 @@ function mergeSummarizedIllustration(
   };
 }
 
-function buildIllustrationNarrationSummaryMessages(args: {
+async function buildIllustrationNarrationSummaryMessages(args: {
+  promptOverridesStorage?: PromptOverridesStorage;
   illustration: SceneIllustrationRequest;
   narration: string;
   state?: string | null;
@@ -573,7 +578,7 @@ function buildIllustrationNarrationSummaryMessages(args: {
   worldOverview?: string | null;
   artStyle?: string | null;
   imagePromptInstructions?: string | null;
-}): ChatMessage[] {
+}): Promise<ChatMessage[]> {
   const contextLines = [
     args.state ? `Mode: ${compactIllustrationContext(args.state, 80)}` : "",
     args.location ? `Location: ${compactIllustrationContext(args.location)}` : "",
@@ -595,26 +600,29 @@ function buildIllustrationNarrationSummaryMessages(args: {
     reason: args.illustration.reason ?? null,
     slug: args.illustration.slug ?? null,
   };
+  const gameContextBlock = contextLines.length ? `<game_context>\n${contextLines.join("\n")}\n</game_context>` : "";
+  const currentIllustrationRequestJson = JSON.stringify(currentRequest, null, 2);
+  const completedTurnNarration = compactIllustrationNarration(args.narration);
+  const summarizerVars = {
+    gameContextBlock,
+    currentIllustrationRequestJson,
+    completedTurnNarration,
+  };
+  const summarizerPrompt = args.promptOverridesStorage
+    ? await loadPrompt(args.promptOverridesStorage, GAME_NARRATION_SUMMARIZER, summarizerVars)
+    : GAME_NARRATION_SUMMARIZER.defaultBuilder(summarizerVars);
 
   return [
     {
       role: "system",
-      content: [
-        "You are Marinara's Game Mode narration summarizer for the Illustrator.",
-        "Read the completed turn narration and dialogue, then convert it into one concise image-generation prompt.",
-        "Focus on the single strongest visible moment from the full turn: who is present, what they are doing, expressions, pose, composition, lighting, setting, mood, and player POV.",
-        "Do not quote dialogue in the image prompt; translate spoken lines into visible expression, action, and relationship tension.",
-        "Do not invent unseen characters, UI, text, captions, speech bubbles, watermarks, or logos.",
-        "The player protagonist should not be visible unless the narration explicitly requires hands, arms, or body.",
-        "Return strict JSON only with keys: title, prompt, characters, reason, slug.",
-      ].join("\n"),
+      content: summarizerPrompt,
     },
     {
       role: "user",
       content: [
-        contextLines.length ? `<game_context>\n${contextLines.join("\n")}\n</game_context>` : "",
-        `<current_illustration_request>\n${JSON.stringify(currentRequest, null, 2)}\n</current_illustration_request>`,
-        `<completed_turn_narration>\n${compactIllustrationNarration(args.narration)}\n</completed_turn_narration>`,
+        gameContextBlock,
+        `<current_illustration_request>\n${currentIllustrationRequestJson}\n</current_illustration_request>`,
+        `<completed_turn_narration>\n${completedTurnNarration}\n</completed_turn_narration>`,
         [
           "Create JSON now.",
           "prompt: detailed concrete visual description only; preserve every visually important named character, pose, expression, setting detail, and mood from the completed turn. Do not truncate mid-detail. Keep the prompt under 6500 characters.",
@@ -630,6 +638,7 @@ function buildIllustrationNarrationSummaryMessages(args: {
 
 async function summarizeIllustrationFromNarration(args: {
   connections: ReturnType<typeof createConnectionsStorage>;
+  promptOverridesStorage?: PromptOverridesStorage;
   chat: NonNullable<StoredChatRecord>;
   meta: Record<string, unknown>;
   setupConfig: Record<string, unknown> | null;
@@ -644,7 +653,9 @@ async function summarizeIllustrationFromNarration(args: {
 
   try {
     const sceneConnId =
-      (args.meta.gameSceneConnectionId as string | undefined) || (args.setupConfig?.sceneConnectionId as string) || null;
+      (args.meta.gameSceneConnectionId as string | undefined) ||
+      (args.setupConfig?.sceneConnectionId as string) ||
+      null;
     const { conn, baseUrl, defaultGenerationParameters } = await resolveConnection(
       args.connections,
       sceneConnId,
@@ -659,7 +670,8 @@ async function summarizeIllustrationFromNarration(args: {
       conn.openrouterProvider,
       conn.maxTokensOverride,
     );
-    const messages = buildIllustrationNarrationSummaryMessages({
+    const messages = await buildIllustrationNarrationSummaryMessages({
+      promptOverridesStorage: args.promptOverridesStorage,
       illustration: args.illustration,
       narration,
       state: typeof args.meta.gameActiveState === "string" ? args.meta.gameActiveState : null,
@@ -680,6 +692,7 @@ async function summarizeIllustrationFromNarration(args: {
       narration.length,
       args.illustration.prompt.length,
     );
+    args.debugLog?.("[debug/game/illustration-summarizer] prompt messages:\n%s", JSON.stringify(messages, null, 2));
 
     const result = await runGameChatComplete(
       provider,
@@ -8285,6 +8298,7 @@ export async function gameRoutes(app: FastifyInstance) {
         let illustration = originalIllustration;
         illustration = await summarizeIllustrationFromNarration({
           connections,
+          promptOverridesStorage,
           chat,
           meta,
           setupConfig: setupCfg,
@@ -8536,6 +8550,7 @@ export async function gameRoutes(app: FastifyInstance) {
       const backgroundSize: ImageGenerationSize = input.imageSizes?.background ?? imageSettings.background;
       const portraitSize: ImageGenerationSize = input.imageSizes?.portrait ?? imageSettings.portrait;
       const styleProfiles = imageSettings.styleProfiles;
+      const promptOverridesStorage = createPromptOverridesStorage(app.db);
       const promptOverrideById = new Map(
         (input.promptOverrides ?? []).map((item) => [
           item.id,
@@ -8577,7 +8592,7 @@ export async function gameRoutes(app: FastifyInstance) {
           styleProfiles,
           styleProfileId,
           debugLog: debugLogsEnabled ? debugLog : undefined,
-          promptOverridesStorage: createPromptOverridesStorage(app.db),
+          promptOverridesStorage,
           size: backgroundSize,
           promptOverride: promptOverride?.prompt,
           negativePromptOverride: promptOverride?.negativePrompt,
@@ -8641,6 +8656,7 @@ export async function gameRoutes(app: FastifyInstance) {
           let illustration = originalIllustration;
           illustration = await summarizeIllustrationFromNarration({
             connections,
+            promptOverridesStorage,
             chat,
             meta,
             setupConfig: setupCfg,
@@ -8687,7 +8703,7 @@ export async function gameRoutes(app: FastifyInstance) {
             styleProfiles,
             styleProfileId,
             debugLog: debugLogsEnabled ? debugLog : undefined,
-            promptOverridesStorage: createPromptOverridesStorage(app.db),
+            promptOverridesStorage,
             size: backgroundSize,
             promptOverride: promptOverride?.prompt,
             negativePromptOverride: promptOverride?.negativePrompt,
@@ -8805,7 +8821,7 @@ export async function gameRoutes(app: FastifyInstance) {
                 styleProfiles,
                 styleProfileId,
                 debugLog: debugLogsEnabled ? debugLog : undefined,
-                promptOverridesStorage: createPromptOverridesStorage(app.db),
+                promptOverridesStorage,
                 size: portraitSize,
                 promptOverride: promptOverrideById.get(gameImagePromptReviewId("portrait", npc.name))?.prompt,
                 negativePromptOverride: promptOverrideById.get(gameImagePromptReviewId("portrait", npc.name))

--- a/packages/server/src/services/prompt-overrides/index.ts
+++ b/packages/server/src/services/prompt-overrides/index.ts
@@ -13,6 +13,7 @@ export {
   GAME_NPC_PORTRAIT,
   GAME_BACKGROUND,
   GAME_SCENE_ILLUSTRATION,
+  GAME_NARRATION_SUMMARIZER,
   CONVERSATION_SELFIE,
   getPromptOverrideDef,
   listPromptOverrideKeys,
@@ -27,5 +28,6 @@ export type {
   GameNpcPortraitCtx,
   GameBackgroundCtx,
   GameSceneIllustrationCtx,
+  GameNarrationSummarizerCtx,
   ConversationSelfieCtx,
 } from "./registry.js";

--- a/packages/server/src/services/prompt-overrides/registry.ts
+++ b/packages/server/src/services/prompt-overrides/registry.ts
@@ -12,7 +12,12 @@ import {
   SPRITES_SINGLE_FULL_BODY,
   SPRITES_FULL_BODY_SHEET,
 } from "./registry/sprites.js";
-import { GAME_NPC_PORTRAIT, GAME_BACKGROUND, GAME_SCENE_ILLUSTRATION } from "./registry/game-assets.js";
+import {
+  GAME_NPC_PORTRAIT,
+  GAME_BACKGROUND,
+  GAME_SCENE_ILLUSTRATION,
+  GAME_NARRATION_SUMMARIZER,
+} from "./registry/game-assets.js";
 import { CONVERSATION_SELFIE } from "./registry/conversation.js";
 
 export const PROMPT_OVERRIDE_REGISTRY = [
@@ -23,6 +28,7 @@ export const PROMPT_OVERRIDE_REGISTRY = [
   GAME_NPC_PORTRAIT,
   GAME_BACKGROUND,
   GAME_SCENE_ILLUSTRATION,
+  GAME_NARRATION_SUMMARIZER,
   CONVERSATION_SELFIE,
 ] as const;
 
@@ -57,6 +63,7 @@ export {
   GAME_NPC_PORTRAIT,
   GAME_BACKGROUND,
   GAME_SCENE_ILLUSTRATION,
+  GAME_NARRATION_SUMMARIZER,
   CONVERSATION_SELFIE,
 };
 export type {
@@ -65,6 +72,11 @@ export type {
   SpritesSingleFullBodyCtx,
   SpritesFullBodySheetCtx,
 } from "./registry/sprites.js";
-export type { GameNpcPortraitCtx, GameBackgroundCtx, GameSceneIllustrationCtx } from "./registry/game-assets.js";
+export type {
+  GameNpcPortraitCtx,
+  GameBackgroundCtx,
+  GameSceneIllustrationCtx,
+  GameNarrationSummarizerCtx,
+} from "./registry/game-assets.js";
 export type { ConversationSelfieCtx } from "./registry/conversation.js";
 export type { PromptOverrideKeyDef, PromptVariable } from "./types.js";

--- a/packages/server/src/services/prompt-overrides/registry/game-assets.ts
+++ b/packages/server/src/services/prompt-overrides/registry/game-assets.ts
@@ -1,7 +1,8 @@
 // ──────────────────────────────────────────────
 // Registered prompt-override keys: game-mode
 // asset generation (NPC portraits, location
-// backgrounds, VN scene illustrations).
+// backgrounds, VN scene illustrations, and
+// narration summarization for illustrations).
 // ──────────────────────────────────────────────
 import type { PromptOverrideKeyDef } from "../types.js";
 
@@ -200,5 +201,59 @@ export const GAME_SCENE_ILLUSTRATION: PromptOverrideKeyDef<GameSceneIllustration
       "Art direction: Watercolor fantasy illustration, soft edges, warm palette, Ghibli-inspired, fantasy, medieval kingdom.",
     imagePromptInstructionsLine:
       "User image instructions: Dottore's mask fully covers his eyes; do not render visible eyes behind it.",
+  },
+};
+
+// ── Narration summarizer (completed turn -> illustration prompt) ──
+
+export interface GameNarrationSummarizerCtx extends Record<string, string | number | undefined> {
+  gameContextBlock: string;
+  currentIllustrationRequestJson: string;
+  completedTurnNarration: string;
+}
+
+export const GAME_NARRATION_SUMMARIZER: PromptOverrideKeyDef<GameNarrationSummarizerCtx> = {
+  key: "game.narrationSummarizer",
+  description:
+    "Game Mode narration summarizer instructions used before scene illustrations are turned into image prompts.",
+  variables: [
+    {
+      name: "gameContextBlock",
+      description:
+        "Pre-formatted <game_context> block with state, location, weather, world, style, and user image notes.",
+      example:
+        "<game_context>\nMode: exploration\nLocation: moonlit graveyard with crumbling tombstones\nWeather: cold rain\nArt style: Watercolor fantasy illustration\n</game_context>",
+    },
+    {
+      name: "currentIllustrationRequestJson",
+      description: "JSON for the scene-analyzer's current illustration request before narration summarization.",
+      example:
+        '{\n  "title": "Lyra watching Korr fall",\n  "prompt": "the moonlit duel finally ends",\n  "characters": ["Lyra", "Korr"],\n  "reason": "duel climax",\n  "slug": "moonlit-duel"\n}',
+    },
+    {
+      name: "completedTurnNarration",
+      description:
+        "The completed turn narration and dialogue after GM command tags are stripped and long turns are compacted.",
+      example:
+        "Korr drops to one knee in the rain, his sword biting into the mud. Lyra stands over him, shaking but unblinking, while shattered moonlight catches on the wet stones.",
+    },
+  ],
+  defaultBuilder: () =>
+    [
+      "You are Marinara's Game Mode narration summarizer for the Illustrator.",
+      "Read the completed turn narration and dialogue, then convert it into one concise image-generation prompt.",
+      "Focus on the single strongest visible moment from the full turn: who is present, what they are doing, expressions, pose, composition, lighting, setting, mood, and player POV.",
+      "Do not quote dialogue in the image prompt; translate spoken lines into visible expression, action, and relationship tension.",
+      "Do not invent unseen characters, UI, text, captions, speech bubbles, watermarks, or logos.",
+      "The player protagonist should not be visible unless the narration explicitly requires hands, arms, or body.",
+      "Return strict JSON only with keys: title, prompt, characters, reason, slug.",
+    ].join("\n"),
+  exampleContext: {
+    gameContextBlock:
+      "<game_context>\nMode: exploration\nLocation: moonlit graveyard with crumbling tombstones\nWeather: cold rain\nArt style: Watercolor fantasy illustration\n</game_context>",
+    currentIllustrationRequestJson:
+      '{\n  "title": "Lyra watching Korr fall",\n  "prompt": "the moonlit duel finally ends",\n  "characters": ["Lyra", "Korr"],\n  "reason": "duel climax",\n  "slug": "moonlit-duel"\n}',
+    completedTurnNarration:
+      "Korr drops to one knee in the rain, his sword biting into the mud. Lyra stands over him, shaking but unblinking, while shattered moonlight catches on the wet stones.",
   },
 };


### PR DESCRIPTION
## Linked issue

Closes #3183

## Why this change

Users can edit Game Mode image prompt templates for NPC portraits, backgrounds, and scene illustrations, but the narration summarizer that converts completed Game Mode narration into the final illustration prompt was still hardcoded. That meant prompt engineering could tune the final image template but not the upstream summarization step that selects the visible moment and details.

## What changed

- Registered `game.narrationSummarizer` as a prompt override with default behavior matching the previous hardcoded summarizer instructions.
- Routed Game Mode illustration narration summarization through `loadPrompt`, with fallback to the built-in default when no enabled override exists or rendering fails.
- Added the summarizer key to Settings -> Advanced -> Image Prompt Templates so it appears beside Game NPC portrait, Game background, and Game scene illustration prompts.
- Reused prompt override storage across preview and generation paths so prompt preview and actual generation resolve the same saved templates.

## Validation

- [x] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed `CONTRIBUTING.md`

### Manual verification notes

- Automated validation run: `pnpm.cmd check` passed locally.
- Focused follow-up validation run after final diff cleanup: `pnpm.cmd --filter @marinara-engine/server lint`, `pnpm.cmd --filter @marinara-engine/shared lint`, and `pnpm.cmd --filter @marinara-engine/client exec eslint src/components/panels/SettingsPanel.tsx` passed locally.
- Manual browser verification still needed: open Settings -> Advanced -> Image Prompt Templates and verify `Game Narration Summarizer` appears in the registered prompt dropdown.
- Manual generation verification still needed: save a temporary `game.narrationSummarizer` override, generate or preview a Game Mode scene illustration from narration, and confirm the summarizer prompt uses the override while disabled/reset templates fall back to default behavior.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Version/release files updated (only if this PR includes a version bump)

No install, update, release, or version-bearing behavior changed.

## UI evidence (if applicable)

Not captured. The PR changes an existing settings dropdown entry rather than adding a new screen; manual UI verification is listed above.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The Image Prompt Templates editor now includes narration summarization as an editable template target.
  * Game asset generation now supports prompt overrides for narration-based illustration summaries, giving more flexible prompt behavior.
* **Bug Fixes**
  * Improved prompt assembly for illustration generation so the generated output better reflects the current game context and completed narration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->