### PR TITLE
[codex] Fix lorebook revectorization and scene streaming polish

### DIFF
--- a/packages/client/src/components/chat/ChatRoleplaySurface.tsx
+++ b/packages/client/src/components/chat/ChatRoleplaySurface.tsx
@@ -1333,7 +1333,7 @@ export function ChatRoleplaySurface({
     previousEndIndex: number;
   } | null>(null);
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     setTranscriptWindowStart(null);
     pendingLoadMoreRevealRef.current = null;
   }, [activeChatId]);

--- a/packages/client/src/components/chat/ConversationView.tsx
+++ b/packages/client/src/components/chat/ConversationView.tsx
@@ -420,7 +420,28 @@ export function ConversationView({
   const lastScrollTopRef = useRef(0);
   const composerScrollTopRef = useRef(0);
   const userScrolledAtRef = useRef(0);
+  const openedAtBottomChatIdRef = useRef<string | null>(null);
   const shouldKeepMobileComposerOpen = hasLiveStream || hasDraftInput || isFetchingNextPage;
+
+  const scrollToMessagesBottom = useCallback((behavior: ScrollBehavior = "smooth") => {
+    const el = scrollRef.current;
+    if (el) {
+      el.scrollTo({ top: el.scrollHeight, behavior });
+      return;
+    }
+    messagesEndRef.current?.scrollIntoView({ behavior });
+  }, []);
+
+  const scheduleScrollToMessagesBottom = useCallback(
+    (behavior: ScrollBehavior = "smooth") => {
+      scrollToMessagesBottom(behavior);
+      requestAnimationFrame(() => {
+        scrollToMessagesBottom(behavior);
+        requestAnimationFrame(() => scrollToMessagesBottom(behavior));
+      });
+    },
+    [scrollToMessagesBottom],
+  );
 
   useEffect(() => {
     if (shouldKeepMobileComposerOpen) setMobileHistoryComposerCollapsed(false);
@@ -484,7 +505,7 @@ export function ConversationView({
     if (isLoadingMoreRef.current) return;
     // Always scroll when the user just sent a message (optimistic msg)
     if (isOptimistic || (isNearBottomRef.current && !userScrolledAwayRef.current)) {
-      messagesEndRef.current?.scrollIntoView({ behavior: "smooth" });
+      scrollToMessagesBottom("smooth");
     }
   }, [
     newestMsgId,
@@ -494,6 +515,7 @@ export function ConversationView({
     delayedCharacterInfo,
     typingCharacterName,
     isOptimistic,
+    scrollToMessagesBottom,
   ]);
 
   // Preserve scroll on load-more
@@ -514,7 +536,7 @@ export function ConversationView({
 
   const [transcriptWindowStart, setTranscriptWindowStart] = useState<number | null>(null);
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     setTranscriptWindowStart(null);
   }, [chatId]);
 
@@ -540,6 +562,25 @@ export function ConversationView({
   const jumpToLatestTranscriptMessages = useCallback(() => {
     setTranscriptWindowStart(null);
   }, []);
+
+  useLayoutEffect(() => {
+    if (!chatId || isFetchingNextPage || isLoadingMoreRef.current) return;
+    if (openedAtBottomChatIdRef.current === chatId) return;
+    if (isLoading && (messages?.length ?? 0) === 0) return;
+    if (transcriptWindow.hiddenAfterCount > 0) return;
+
+    openedAtBottomChatIdRef.current = chatId;
+    userScrolledAwayRef.current = false;
+    isNearBottomRef.current = true;
+    scheduleScrollToMessagesBottom("auto");
+  }, [
+    chatId,
+    isFetchingNextPage,
+    isLoading,
+    messages?.length,
+    scheduleScrollToMessagesBottom,
+    transcriptWindow.hiddenAfterCount,
+  ]);
 
   // ── Build message list with day separators ──
   // Assistant multi-line reveal is presentation-only: a real message can carry
@@ -970,9 +1011,9 @@ export function ConversationView({
   // Auto-scroll when staggered parts are revealed
   useEffect(() => {
     if (!isLoadingMoreRef.current && isNearBottomRef.current && !userScrolledAwayRef.current) {
-      messagesEndRef.current?.scrollIntoView({ behavior: "smooth" });
+      scrollToMessagesBottom("smooth");
     }
-  }, [visiblePartCounts, visibleSegmentCounts]);
+  }, [scrollToMessagesBottom, visiblePartCounts, visibleSegmentCounts]);
 
   return (
     <div

--- a/packages/client/src/components/chat/LocalMusicPlayer.tsx
+++ b/packages/client/src/components/chat/LocalMusicPlayer.tsx
@@ -23,17 +23,19 @@ import { cn } from "../../lib/utils";
 import { useAgentStore } from "../../stores/agent.store";
 import { useUIStore } from "../../stores/ui.store";
 
-const MUSIC_NEUTRAL_SHELL_BORDER_CLASS = "border-[#f7f3ef]/15";
-const MUSIC_NEUTRAL_SHELL_BG_CLASS = "bg-[#0f0f0f]/95";
-const MUSIC_NEUTRAL_BUTTON_BG_CLASS = "bg-[#f7f3ef]/5";
-const MUSIC_NEUTRAL_TILE_BG_CLASS = "bg-[#f7f3ef]/5";
-const MUSIC_NEUTRAL_TEXT_CLASS = "text-[#f7f3ef]";
-const MUSIC_NEUTRAL_MUTED_CLASS = "text-[#aaa]";
-const MUSIC_NEUTRAL_ICON_CLASS = "text-[#aaa]";
-const MUSIC_NEUTRAL_ICON_HOVER_CLASS = "hover:bg-[#f7f3ef]/10 hover:text-[#f7f3ef]";
-const MUSIC_NEUTRAL_ACTION_BG_CLASS = "bg-[var(--primary)]";
-const MUSIC_NEUTRAL_ACTION_TEXT_CLASS = "text-[var(--primary-foreground)]";
-const MUSIC_NEUTRAL_PROGRESS_BG_CLASS = "bg-[#f7f3ef]/15";
+const MUSIC_NEUTRAL_SHELL_BORDER_CLASS = "border-[var(--marinara-music-player-shell-border)]";
+const MUSIC_NEUTRAL_SHELL_BG_CLASS = "bg-[var(--marinara-music-player-shell-bg)]";
+const MUSIC_NEUTRAL_BUTTON_BG_CLASS = "bg-[var(--marinara-music-player-button-bg)]";
+const MUSIC_NEUTRAL_TILE_BG_CLASS = "bg-[var(--marinara-music-player-tile-bg)]";
+const MUSIC_NEUTRAL_TILE_RING_CLASS = "ring-[var(--marinara-music-player-tile-ring)]";
+const MUSIC_NEUTRAL_TEXT_CLASS = "text-[var(--marinara-music-player-text)]";
+const MUSIC_NEUTRAL_MUTED_CLASS = "text-[var(--marinara-music-player-muted)]";
+const MUSIC_NEUTRAL_ICON_CLASS = "text-[var(--marinara-music-player-icon)]";
+const MUSIC_NEUTRAL_ICON_HOVER_CLASS =
+  "hover:bg-[var(--marinara-music-player-button-bg-hover)] hover:text-[var(--marinara-music-player-icon-hover)]";
+const MUSIC_NEUTRAL_ACTION_BG_CLASS = "bg-[var(--marinara-music-player-action-bg)]";
+const MUSIC_NEUTRAL_ACTION_TEXT_CLASS = "text-[var(--marinara-music-player-action-text)]";
+const MUSIC_NEUTRAL_PROGRESS_BG_CLASS = "bg-[var(--marinara-music-player-progress-bg)]";
 const MOBILE_WIDGET_COLLAPSED_SIZE = 48;
 const MOBILE_WIDGET_EXPANDED_MAX_WIDTH = 320;
 const MOBILE_WIDGET_EXPANDED_HORIZONTAL_GUTTER = 24;
@@ -322,8 +324,9 @@ export function LocalMusicPlayer({ mobile = false }: { mobile?: boolean } = {}) 
         <MusicSourceButton source="custom" className={MUSIC_NEUTRAL_BUTTON_BG_CLASS} />
         <div
           className={cn(
-            "flex h-7 w-10 shrink-0 items-center justify-center overflow-hidden rounded-[0.375rem] ring-1 ring-[#f7f3ef]/10",
+            "flex h-7 w-10 shrink-0 items-center justify-center overflow-hidden rounded-[0.375rem] ring-1",
             MUSIC_NEUTRAL_TILE_BG_CLASS,
+            MUSIC_NEUTRAL_TILE_RING_CLASS,
           )}
         >
           <LocalPlayerIcon icon={Music2} />

--- a/packages/client/src/components/chat/YouTubePlayer.tsx
+++ b/packages/client/src/components/chat/YouTubePlayer.tsx
@@ -34,19 +34,21 @@ interface SearchResult {
 
 let ytApiPromise: Promise<void> | null = null;
 
-const MUSIC_NEUTRAL_BORDER_CLASS = "border-[#f7f3ef]/15";
-const MUSIC_NEUTRAL_SHELL_BORDER_CLASS = "border-[#f7f3ef]/15";
-const MUSIC_NEUTRAL_SHELL_BG_CLASS = "bg-[#0f0f0f]/95";
-const MUSIC_NEUTRAL_BUTTON_BG_CLASS = "bg-[#f7f3ef]/5";
-const MUSIC_NEUTRAL_TILE_BG_CLASS = "bg-[#f7f3ef]/5";
-const MUSIC_NEUTRAL_TEXT_CLASS = "text-[#f7f3ef]";
-const MUSIC_NEUTRAL_MUTED_CLASS = "text-[#aaa]";
-const MUSIC_NEUTRAL_ICON_CLASS = "text-[#aaa]";
-const MUSIC_NEUTRAL_ICON_HOVER_CLASS = "hover:bg-[#f7f3ef]/10 hover:text-[#f7f3ef]";
-const MUSIC_NEUTRAL_PROGRESS_BG_CLASS = "bg-[#f7f3ef]/15";
+const MUSIC_NEUTRAL_BORDER_CLASS = "border-[var(--marinara-music-player-button-border)]";
+const MUSIC_NEUTRAL_SHELL_BORDER_CLASS = "border-[var(--marinara-music-player-shell-border)]";
+const MUSIC_NEUTRAL_SHELL_BG_CLASS = "bg-[var(--marinara-music-player-shell-bg)]";
+const MUSIC_NEUTRAL_BUTTON_BG_CLASS = "bg-[var(--marinara-music-player-button-bg)]";
+const MUSIC_NEUTRAL_TILE_BG_CLASS = "bg-[var(--marinara-music-player-tile-bg)]";
+const MUSIC_NEUTRAL_TILE_RING_CLASS = "ring-[var(--marinara-music-player-tile-ring)]";
+const MUSIC_NEUTRAL_TEXT_CLASS = "text-[var(--marinara-music-player-text)]";
+const MUSIC_NEUTRAL_MUTED_CLASS = "text-[var(--marinara-music-player-muted)]";
+const MUSIC_NEUTRAL_ICON_CLASS = "text-[var(--marinara-music-player-icon)]";
+const MUSIC_NEUTRAL_ICON_HOVER_CLASS =
+  "hover:bg-[var(--marinara-music-player-button-bg-hover)] hover:text-[var(--marinara-music-player-icon-hover)]";
+const MUSIC_NEUTRAL_PROGRESS_BG_CLASS = "bg-[var(--marinara-music-player-progress-bg)]";
 const MUSIC_NEUTRAL_PROGRESS_FILL_CLASS = "bg-[#FF0000]";
-const MUSIC_NEUTRAL_ACTION_BG_CLASS = "bg-[#f7f3ef]";
-const MUSIC_NEUTRAL_ACTION_TEXT_CLASS = "text-[#0f0f0f]";
+const MUSIC_NEUTRAL_ACTION_BG_CLASS = "bg-[var(--marinara-music-player-action-bg)]";
+const MUSIC_NEUTRAL_ACTION_TEXT_CLASS = "text-[var(--marinara-music-player-action-text)]";
 const YOUTUBE_LOGO_CLASS = "text-[#FF0000]";
 const MOBILE_WIDGET_COLLAPSED_SIZE = 48;
 const MOBILE_WIDGET_EXPANDED_MAX_WIDTH = 320;
@@ -427,6 +429,7 @@ export function YouTubePlayer({ mobile = false }: { mobile?: boolean } = {}) {
         className="mari-youtube-volume-slider w-full"
         title="Volume"
         aria-label="YouTube volume"
+        style={{ "--range-progress": `${playerVolume}%` } as CSSProperties}
       />
     </div>
   );
@@ -439,7 +442,7 @@ export function YouTubePlayer({ mobile = false }: { mobile?: boolean } = {}) {
           className={cn(
             "flex h-7 w-10 shrink-0 items-center justify-center overflow-hidden rounded-[0.375rem] ring-1",
             MUSIC_NEUTRAL_TILE_BG_CLASS,
-            "ring-[#f7f3ef]/10",
+            MUSIC_NEUTRAL_TILE_RING_CLASS,
           )}
         >
           {loading ? (

--- a/packages/client/src/components/lorebooks/LorebookEditor.tsx
+++ b/packages/client/src/components/lorebooks/LorebookEditor.tsx
@@ -72,6 +72,7 @@ import {
   Wand2,
   FlaskConical,
   FolderPlus,
+  RefreshCw,
 } from "lucide-react";
 import { cn } from "../../lib/utils";
 import { HelpTooltip } from "../ui/HelpTooltip";
@@ -2592,7 +2593,7 @@ function VectorizeSection({
     [connections, sidecarEmbeddingConnections],
   );
   const [selectedConnectionId, setSelectedConnectionId] = useState<string>("");
-  const [vectorizing, setVectorizing] = useState(false);
+  const [vectorizingMode, setVectorizingMode] = useState<"missing" | "all" | null>(null);
   const [clearingVectors, setClearingVectors] = useState(false);
   const [result, setResult] = useState<{ success: boolean; message: string } | null>(null);
   const excludedCount = excludeFromVectorization
@@ -2610,6 +2611,9 @@ function VectorizeSection({
   ).length;
   const missingCount = Math.max(0, vectorizableEntryCount - vectorizedCount);
   const allVectorized = vectorizableEntryCount > 0 && missingCount === 0;
+  const vectorizing = vectorizingMode !== null;
+  const primaryVectorizeMode: "missing" | "all" = missingCount > 0 ? "missing" : "all";
+  const showRevectorizeAllAction = missingCount > 0 && storedVectorCount > 0;
 
   useEffect(() => {
     if (import.meta.env.VITE_MARINARA_LITE !== "true") {
@@ -2651,29 +2655,43 @@ function VectorizeSection({
     }
   };
 
-  const handleVectorize = async () => {
+  const handleVectorize = async (mode: "missing" | "all") => {
     if (!selectedConnectionId) return;
-    setVectorizing(true);
+    if (mode === "missing" && missingCount === 0) return;
+    const conn = embeddingConnections.find((c) => c.id === selectedConnectionId);
+    if (mode === "all" && storedVectorCount > 0) {
+      const confirmed = await showConfirmDialog({
+        title: "Re-vectorize All Entries",
+        message: `Re-vectorize all ${vectorizableEntryCount} vectorizable entr${
+          vectorizableEntryCount === 1 ? "y" : "ies"
+        } with ${conn?.name ?? "the selected connection"}? Existing stored vectors will be overwritten.`,
+        confirmLabel: "Re-vectorize all",
+        cancelLabel: "Cancel",
+        tone: "default",
+      });
+      if (!confirmed) return;
+    }
+
+    setVectorizingMode(mode);
     setResult(null);
     try {
-      const conn = embeddingConnections.find((c) => c.id === selectedConnectionId);
       const res = await api.post(`/lorebooks/${lorebookId}/vectorize`, {
         connectionId: selectedConnectionId,
         model: conn?.embeddingModel ?? "",
-        onlyMissing: !allVectorized,
+        onlyMissing: mode === "missing",
       });
       const data = res as { vectorized: number; total?: number; skipped?: number };
       await queryClient.invalidateQueries({ queryKey: lorebookKeys.entries(lorebookId) });
       setResult({
         success: true,
-        message: allVectorized
+        message: mode === "all"
           ? `Re-vectorized ${data.vectorized} entries`
           : `Vectorized ${data.vectorized} missing entries`,
       });
     } catch (err) {
       setResult({ success: false, message: err instanceof Error ? err.message : "Vectorization failed" });
     } finally {
-      setVectorizing(false);
+      setVectorizingMode(null);
     }
   };
 
@@ -2798,11 +2816,11 @@ function VectorizeSection({
         </p>
       ) : (
         <>
-          <div className="flex items-center gap-2">
+          <div className="flex flex-wrap items-center gap-2">
             <select
               value={selectedConnectionId}
               onChange={(e) => handleConnectionChange(e.target.value)}
-              className="mari-editor-field flex-1 px-2.5 py-1.5 text-xs"
+              className="mari-editor-field min-w-44 flex-1 px-2.5 py-1.5 text-xs"
             >
               <option value="">No semantic search</option>
               {embeddingConnections.map((c) => (
@@ -2812,19 +2830,47 @@ function VectorizeSection({
               ))}
             </select>
             <button
-              onClick={handleVectorize}
-              disabled={vectorizing || vectorizableEntryCount === 0 || !selectedConnectionId}
+              onClick={() => handleVectorize(primaryVectorizeMode)}
+              disabled={
+                vectorizing ||
+                vectorizableEntryCount === 0 ||
+                !selectedConnectionId ||
+                (primaryVectorizeMode === "missing" && missingCount === 0)
+              }
               className="mari-chrome-accent-surface mari-accent-animated flex items-center gap-1.5 rounded-xl px-3 py-1.5 text-xs font-medium transition-all active:scale-[0.98] disabled:opacity-50"
             >
-              {vectorizing ? <Loader2 size="0.75rem" className="animate-spin" /> : <Sparkles size="0.75rem" />}
-              {vectorizing
-                ? "Vectorizing..."
+              {vectorizingMode === primaryVectorizeMode ? (
+                <Loader2 size="0.75rem" className="animate-spin" />
+              ) : primaryVectorizeMode === "all" ? (
+                <RefreshCw size="0.75rem" />
+              ) : (
+                <Sparkles size="0.75rem" />
+              )}
+              {vectorizingMode === primaryVectorizeMode
+                ? primaryVectorizeMode === "all"
+                  ? "Re-vectorizing..."
+                  : "Vectorizing..."
                 : !selectedConnectionId
                   ? "Select connection"
-                  : allVectorized
+                  : primaryVectorizeMode === "all"
                     ? `Re-vectorize ${vectorizableEntryCount} entries`
                     : `Vectorize ${missingCount} missing`}
             </button>
+            {showRevectorizeAllAction && (
+              <button
+                onClick={() => handleVectorize("all")}
+                disabled={vectorizing || vectorizableEntryCount === 0 || !selectedConnectionId}
+                className="flex items-center gap-1.5 rounded-xl bg-[var(--secondary)]/70 px-3 py-1.5 text-xs font-medium text-[var(--foreground)] ring-1 ring-[var(--border)] transition-all hover:bg-[var(--secondary)] active:scale-[0.98] disabled:opacity-50"
+                title="Overwrite every stored vector in this lorebook with the selected embedding model"
+              >
+                {vectorizingMode === "all" ? (
+                  <Loader2 size="0.75rem" className="animate-spin" />
+                ) : (
+                  <RefreshCw size="0.75rem" />
+                )}
+                {vectorizingMode === "all" ? "Re-vectorizing..." : "Re-vectorize all"}
+              </button>
+            )}
             <button
               onClick={handleClearVectors}
               disabled={clearingVectors || vectorizing || storedVectorCount === 0}

--- a/packages/client/src/components/lorebooks/LorebookEditor.tsx
+++ b/packages/client/src/components/lorebooks/LorebookEditor.tsx
@@ -2831,12 +2831,7 @@ function VectorizeSection({
             </select>
             <button
               onClick={() => handleVectorize(primaryVectorizeMode)}
-              disabled={
-                vectorizing ||
-                vectorizableEntryCount === 0 ||
-                !selectedConnectionId ||
-                (primaryVectorizeMode === "missing" && missingCount === 0)
-              }
+              disabled={vectorizing || vectorizableEntryCount === 0 || !selectedConnectionId}
               className="mari-chrome-accent-surface mari-accent-animated flex items-center gap-1.5 rounded-xl px-3 py-1.5 text-xs font-medium transition-all active:scale-[0.98] disabled:opacity-50"
             >
               {vectorizingMode === primaryVectorizeMode ? (

--- a/packages/client/src/components/music/MusicSourceButton.tsx
+++ b/packages/client/src/components/music/MusicSourceButton.tsx
@@ -46,7 +46,7 @@ export function MusicSourceButton({ source, className }: { source: MusicPlayerSo
     custom: "Custom",
   };
   const sourceClasses = cn(
-    "border-[#f7f3ef]/15 bg-[#f7f3ef]/5 hover:border-[#f7f3ef]/30 hover:bg-[#f7f3ef]/10",
+    "border-[var(--marinara-music-player-button-border)] bg-[var(--marinara-music-player-button-bg)] hover:border-[var(--marinara-music-player-button-border-hover)] hover:bg-[var(--marinara-music-player-button-bg-hover)]",
     source === "spotify" && "text-[#1DB954]",
     source === "youtube" && "text-[#FF0000]",
     source === "custom" && "text-[var(--primary)]",

--- a/packages/client/src/components/spotify/SpotifyMiniPlayer.tsx
+++ b/packages/client/src/components/spotify/SpotifyMiniPlayer.tsx
@@ -150,17 +150,18 @@ const SPOTIFY_GREEN_CLASS = "text-[#1DB954]";
 const SPOTIFY_GREEN_BG_CLASS = "bg-[#1DB954]";
 const MUSIC_PLAYER_SHELL_BORDER_CLASS = "border-[var(--marinara-music-player-shell-border)]";
 const MUSIC_PLAYER_SHELL_BG_CLASS = "bg-[var(--marinara-music-player-shell-bg)]";
-const MUSIC_PLAYER_BORDER_CLASS = "border-[#f7f3ef]/15";
-const MUSIC_PLAYER_BUTTON_BG_CLASS = "bg-[#f7f3ef]/5";
-const MUSIC_PLAYER_TILE_BG_CLASS = "bg-[#f7f3ef]/5";
-const MUSIC_PLAYER_TILE_RING_CLASS = "ring-[#f7f3ef]/10";
-const MUSIC_PLAYER_TEXT_CLASS = "text-[#f7f3ef]";
-const MUSIC_PLAYER_MUTED_CLASS = "text-[#b3b3b3]";
-const MUSIC_PLAYER_ICON_CLASS = "text-[#b3b3b3]";
-const MUSIC_PLAYER_ICON_HOVER_CLASS = "hover:bg-[#f7f3ef]/10 hover:text-[#f7f3ef]";
-const MUSIC_PLAYER_ACTION_BG_CLASS = "bg-[#f7f3ef]";
-const MUSIC_PLAYER_ACTION_TEXT_CLASS = "text-[#191414]";
-const MUSIC_PLAYER_PROGRESS_BG_CLASS = "bg-[#f7f3ef]/15";
+const MUSIC_PLAYER_BORDER_CLASS = "border-[var(--marinara-music-player-button-border)]";
+const MUSIC_PLAYER_BUTTON_BG_CLASS = "bg-[var(--marinara-music-player-button-bg)]";
+const MUSIC_PLAYER_TILE_BG_CLASS = "bg-[var(--marinara-music-player-tile-bg)]";
+const MUSIC_PLAYER_TILE_RING_CLASS = "ring-[var(--marinara-music-player-tile-ring)]";
+const MUSIC_PLAYER_TEXT_CLASS = "text-[var(--marinara-music-player-text)]";
+const MUSIC_PLAYER_MUTED_CLASS = "text-[var(--marinara-music-player-muted)]";
+const MUSIC_PLAYER_ICON_CLASS = "text-[var(--marinara-music-player-icon)]";
+const MUSIC_PLAYER_ICON_HOVER_CLASS =
+  "hover:bg-[var(--marinara-music-player-button-bg-hover)] hover:text-[var(--marinara-music-player-icon-hover)]";
+const MUSIC_PLAYER_ACTION_BG_CLASS = "bg-[var(--marinara-music-player-action-bg)]";
+const MUSIC_PLAYER_ACTION_TEXT_CLASS = "text-[var(--marinara-music-player-action-text)]";
+const MUSIC_PLAYER_PROGRESS_BG_CLASS = "bg-[var(--marinara-music-player-progress-bg)]";
 const REPEAT_TRACK_END_GRACE_MS = 15_000;
 const REPEAT_TRACK_REPLAY_COOLDOWN_MS = 8_000;
 const MANUAL_CONTROL_REPEAT_SUPPRESS_MS = 15_000;
@@ -873,7 +874,7 @@ export function SpotifyMiniPlayer({
       "--range-thumb-color": "#1DB954",
       "--range-thumb-size": "0.6875rem",
       "--range-track-height": "0.25rem",
-      "--range-thumb-shadow": "0 0 0 0.125rem #191414",
+      "--range-thumb-shadow": "0 0 0 0.125rem var(--marinara-music-player-shell-bg)",
     }),
     [volumeDraft],
   );
@@ -895,7 +896,7 @@ export function SpotifyMiniPlayer({
         <button
           type="button"
           className={cn(
-            "flex w-full shrink-0 items-center gap-1 rounded-md px-1 py-0.5 text-left transition-colors hover:bg-[#f7f3ef]/10",
+            "flex w-full shrink-0 items-center gap-1 rounded-md px-1 py-0.5 text-left transition-colors",
             MUSIC_PLAYER_ICON_CLASS,
             MUSIC_PLAYER_ICON_HOVER_CLASS,
           )}

--- a/packages/client/src/hooks/use-generate.ts
+++ b/packages/client/src/hooks/use-generate.ts
@@ -1135,6 +1135,10 @@ export function useGenerate() {
         const normalized = Math.max(0, Math.min(1, (speed - 1) / 98));
         return 12 + Math.pow(normalized, 1.65) * 248;
       };
+      const getMaxCharsPerTypewriterFrame = (charsPerSecond: number) => {
+        if (charsPerSecond === Infinity) return Infinity;
+        return Math.max(1, Math.ceil(charsPerSecond / 60));
+      };
 
       const TYPEWRITER_MAX_FRAME_MS = 120;
       let lastTypewriterPaintAt = 0;
@@ -1148,6 +1152,7 @@ export function useGenerate() {
         pendingText = "";
         typingActive = false;
         typewriterRemainder = 0;
+        lastTypewriterPaintAt = 0;
         if (streamingEnabled && shouldDisplayRawStream && fullBuffer) setStreamBuffer(fullBuffer, params.chatId);
         if (typewriterDone) {
           const done = typewriterDone;
@@ -1161,6 +1166,7 @@ export function useGenerate() {
         cancelAnimationFrame(rafId);
         typingActive = false;
         typewriterRemainder = 0;
+        lastTypewriterPaintAt = 0;
 
         if (!streamingEnabled || !shouldDisplayRawStream) {
           fullBuffer = nextContent;
@@ -1207,6 +1213,7 @@ export function useGenerate() {
           }
           if (pendingText.length === 0) {
             typingActive = false;
+            lastTypewriterPaintAt = 0;
             if (typewriterDone) {
               typewriterDone();
               typewriterDone = null;
@@ -1227,7 +1234,8 @@ export function useGenerate() {
           }
 
           typewriterRemainder += (charsPerSecond * elapsedMs) / 1000;
-          const n = Math.min(Math.floor(typewriterRemainder), pendingText.length);
+          const maxCharsThisFrame = getMaxCharsPerTypewriterFrame(charsPerSecond);
+          const n = Math.min(Math.floor(typewriterRemainder), maxCharsThisFrame, pendingText.length);
           if (n < 1) {
             rafId = requestAnimationFrame(tick);
             return;

--- a/packages/client/src/hooks/use-generate.ts
+++ b/packages/client/src/hooks/use-generate.ts
@@ -2329,7 +2329,7 @@ export function useGenerate() {
         if (isAbortError(error)) return receivedContent;
         if (isPassiveStreamDisconnect(error, pageWasHiddenDuringStream, abortController.signal)) {
           passiveStreamRecovered = true;
-          useChatStore.getState().setGenerationPhase("Finishing in background...");
+          if (isActiveChat()) useChatStore.getState().setGenerationPhase("Finishing in background...");
           const settled = await waitForServerGenerationToSettle(params.chatId, abortController.signal);
           if (!abortController.signal.aborted) {
             await refreshMessagesAuthoritatively(qc, params.chatId, persistedMessages.values());

--- a/packages/client/src/hooks/use-generate.ts
+++ b/packages/client/src/hooks/use-generate.ts
@@ -5,7 +5,7 @@ import { useCallback, useRef } from "react";
 import type { AvatarCropValue } from "../lib/utils";
 import { useQueryClient, type InfiniteData, type QueryClient } from "@tanstack/react-query";
 import { toast, type ExternalToast } from "sonner";
-import { api } from "../lib/api-client";
+import { api, ApiError } from "../lib/api-client";
 import { formatAgentFailuresToast, toAgentFailure, type AgentFailure } from "../lib/agent-failures";
 import { chatBackgroundMetadataToUrl } from "../lib/backgrounds";
 import { formatGenerationParameterError } from "../lib/generation-parameter-errors";
@@ -757,6 +757,47 @@ function shouldRefreshGameStateAfterGeneration(qc: QueryClient, chatId: string) 
 
 const pendingVisibleGameStateRefreshes = new Map<string, Promise<void>>();
 const activeGenerateLocks = new Set<string>();
+const PASSIVE_STREAM_SETTLE_POLL_MS = 1_500;
+const PASSIVE_STREAM_SETTLE_MAX_WAIT_MS = 30 * 60_000;
+
+function wait(ms: number, signal?: AbortSignal) {
+  if (!signal) return new Promise<void>((resolve) => setTimeout(resolve, ms));
+  if (signal.aborted) return Promise.resolve();
+  return new Promise<void>((resolve) => {
+    const timeout = window.setTimeout(resolve, ms);
+    signal.addEventListener(
+      "abort",
+      () => {
+        window.clearTimeout(timeout);
+        resolve();
+      },
+      { once: true },
+    );
+  });
+}
+
+async function waitForServerGenerationToSettle(chatId: string, signal: AbortSignal) {
+  const startedAt = Date.now();
+  while (!signal.aborted && Date.now() - startedAt < PASSIVE_STREAM_SETTLE_MAX_WAIT_MS) {
+    try {
+      const status = await api.get<{ active: boolean }>(`/generate/status/${encodeURIComponent(chatId)}`);
+      if (!status.active) return true;
+    } catch {
+      // The resumed browser may still be restoring network access; keep polling.
+    }
+    await wait(PASSIVE_STREAM_SETTLE_POLL_MS, signal);
+  }
+  return false;
+}
+
+function isAbortError(error: unknown) {
+  return error instanceof DOMException && error.name === "AbortError";
+}
+
+function isPassiveStreamDisconnect(error: unknown, pageWasHiddenDuringStream: boolean, signal: AbortSignal) {
+  if (!pageWasHiddenDuringStream || signal.aborted || isAbortError(error) || error instanceof ApiError) return false;
+  return error instanceof Error;
+}
 
 async function refreshVisibleGameStateAfterGeneration(chatId: string) {
   const existing = pendingVisibleGameStateRefreshes.get(chatId);
@@ -1080,6 +1121,7 @@ export function useGenerate() {
       let receivedThinking = false; // Whether provider-native thinking chunks were received
       let gameTurnLoadedSoundPlayed = false;
       let sawDoneEvent = false;
+      let passiveStreamRecovered = false;
       let typingActive = false;
       let typewriterDone: (() => void) | null = null;
       let rafId = 0;
@@ -1144,6 +1186,7 @@ export function useGenerate() {
       let lastTypewriterPaintAt = 0;
       let typewriterRemainder = 0;
       const canInspectPageFocus = typeof document !== "undefined";
+      let pageWasHiddenDuringStream = canInspectPageFocus && document.visibilityState !== "visible";
       const shouldFlushTypewriterForBackground = () => canInspectPageFocus && document.visibilityState !== "visible";
 
       const flushTypewriterBuffer = () => {
@@ -1249,13 +1292,18 @@ export function useGenerate() {
         };
         rafId = requestAnimationFrame(tick);
       };
-      const flushBackgroundedTypewriter = () => {
-        if (shouldFlushTypewriterForBackground() && (pendingText.length > 0 || typingActive)) {
+      const markPageHiddenAndFlushTypewriter = () => {
+        pageWasHiddenDuringStream = true;
+        if (pendingText.length > 0 || typingActive) {
           flushTypewriterBuffer();
         }
       };
+      const flushBackgroundedTypewriter = () => {
+        if (shouldFlushTypewriterForBackground()) markPageHiddenAndFlushTypewriter();
+      };
       if (canInspectPageFocus) {
         document.addEventListener("visibilitychange", flushBackgroundedTypewriter);
+        window.addEventListener("pagehide", markPageHiddenAndFlushTypewriter);
       }
 
       const waitForTypewriterDrain = async () => {
@@ -2278,7 +2326,19 @@ export function useGenerate() {
         flushLeadingSpeakerPrefix();
         flushTypewriterBuffer();
         // Abort is intentional — don't log or toast
-        if (error instanceof DOMException && error.name === "AbortError") return receivedContent;
+        if (isAbortError(error)) return receivedContent;
+        if (isPassiveStreamDisconnect(error, pageWasHiddenDuringStream, abortController.signal)) {
+          passiveStreamRecovered = true;
+          useChatStore.getState().setGenerationPhase("Finishing in background...");
+          const settled = await waitForServerGenerationToSettle(params.chatId, abortController.signal);
+          if (!abortController.signal.aborted) {
+            await refreshMessagesAuthoritatively(qc, params.chatId, persistedMessages.values());
+            if (!settled) {
+              toast.info("Generation is still finishing in the background. Refresh the chat in a moment if it has not appeared.");
+            }
+          }
+          return abortController.signal.aborted ? receivedContent : true;
+        }
         const msg = error instanceof Error ? error.message : "Generation failed";
         showError(msg);
         window.dispatchEvent(new CustomEvent("marinara:generation-error", { detail: { chatId: params.chatId } }));
@@ -2290,6 +2350,7 @@ export function useGenerate() {
         cancelAnimationFrame(rafId);
         if (canInspectPageFocus) {
           document.removeEventListener("visibilitychange", flushBackgroundedTypewriter);
+          window.removeEventListener("pagehide", markPageHiddenAndFlushTypewriter);
         }
         const stillOwnerAtCleanupStart =
           useChatStore.getState().abortControllers.get(params.chatId) === abortController;
@@ -2500,7 +2561,7 @@ export function useGenerate() {
           }
         }
       }
-      return receivedContent;
+      return receivedContent || passiveStreamRecovered;
     },
     [
       qc,

--- a/packages/client/src/styles/globals.css
+++ b/packages/client/src/styles/globals.css
@@ -211,6 +211,19 @@
   --marinara-shell-edge-border: color-mix(in srgb, var(--foreground) 14%, var(--background) 86%);
   --marinara-music-player-shell-bg: var(--marinara-topbar-surface);
   --marinara-music-player-shell-border: var(--marinara-topbar-border);
+  --marinara-music-player-text: #f7f3ef;
+  --marinara-music-player-muted: #b3b3b3;
+  --marinara-music-player-icon: #b3b3b3;
+  --marinara-music-player-icon-hover: #f7f3ef;
+  --marinara-music-player-button-bg: color-mix(in srgb, #f7f3ef 5%, transparent);
+  --marinara-music-player-button-bg-hover: color-mix(in srgb, #f7f3ef 10%, transparent);
+  --marinara-music-player-button-border: color-mix(in srgb, #f7f3ef 15%, transparent);
+  --marinara-music-player-button-border-hover: color-mix(in srgb, #f7f3ef 30%, transparent);
+  --marinara-music-player-tile-bg: color-mix(in srgb, #f7f3ef 5%, transparent);
+  --marinara-music-player-tile-ring: color-mix(in srgb, #f7f3ef 10%, transparent);
+  --marinara-music-player-action-bg: #f7f3ef;
+  --marinara-music-player-action-text: #191414;
+  --marinara-music-player-progress-bg: color-mix(in srgb, #f7f3ef 15%, transparent);
   --mari-logo-cyan: #4de5dd;
   --mari-logo-cyan-deep: #3ab8b1;
   --mari-logo-orange: #eb8951;
@@ -449,6 +462,21 @@
   --sidebar-accent-foreground: #d4acfb;
   --glow-primary: color-mix(in srgb, var(--primary) 12%, transparent);
   --glow-accent: rgba(212, 173, 252, 0.08);
+  --marinara-music-player-shell-bg: color-mix(in srgb, var(--card) 94%, var(--secondary) 6%);
+  --marinara-music-player-shell-border: color-mix(in srgb, var(--foreground) 14%, transparent);
+  --marinara-music-player-text: color-mix(in srgb, var(--foreground) 96%, var(--primary) 4%);
+  --marinara-music-player-muted: color-mix(in srgb, var(--foreground) 62%, transparent);
+  --marinara-music-player-icon: color-mix(in srgb, var(--foreground) 70%, transparent);
+  --marinara-music-player-icon-hover: var(--foreground);
+  --marinara-music-player-button-bg: color-mix(in srgb, var(--secondary) 82%, var(--card) 18%);
+  --marinara-music-player-button-bg-hover: color-mix(in srgb, var(--primary) 14%, var(--secondary) 86%);
+  --marinara-music-player-button-border: color-mix(in srgb, var(--foreground) 16%, transparent);
+  --marinara-music-player-button-border-hover: color-mix(in srgb, var(--foreground) 28%, transparent);
+  --marinara-music-player-tile-bg: color-mix(in srgb, var(--secondary) 78%, var(--card) 22%);
+  --marinara-music-player-tile-ring: color-mix(in srgb, var(--foreground) 14%, transparent);
+  --marinara-music-player-action-bg: color-mix(in srgb, var(--foreground) 88%, var(--primary) 12%);
+  --marinara-music-player-action-text: var(--background);
+  --marinara-music-player-progress-bg: color-mix(in srgb, var(--foreground) 16%, transparent);
   --tracker-card-neutral-surface-top: color-mix(in srgb, var(--card) 84%, var(--accent) 16%);
   --tracker-card-neutral-surface-bottom: color-mix(in srgb, var(--secondary) 86%, var(--primary) 14%);
   --tracker-card-neutral-material: color-mix(in srgb, var(--secondary) 88%, var(--primary) 12%);
@@ -2051,7 +2079,7 @@ input[type="range"].mari-spotify-volume-slider {
   --range-thumb-color: #1db954;
   --range-thumb-size: 0.6875rem;
   --range-track-height: 0.25rem;
-  --range-thumb-shadow: 0 0 0 0.125rem #191414;
+  --range-thumb-shadow: 0 0 0 0.125rem var(--marinara-music-player-shell-bg);
 
   accent-color: #1db954;
 }
@@ -2088,7 +2116,7 @@ input[type="range"].mari-youtube-volume-slider {
   --range-thumb-color: #ff0000;
   --range-thumb-size: 0.6875rem;
   --range-track-height: 0.25rem;
-  --range-thumb-shadow: 0 0 0 0.125rem #0f0f0f;
+  --range-thumb-shadow: 0 0 0 0.125rem var(--marinara-music-player-shell-bg);
 
   accent-color: #ff0000;
 }
@@ -2125,7 +2153,7 @@ input[type="range"].mari-local-music-volume-slider {
   --range-thumb-color: var(--primary);
   --range-thumb-size: 0.6875rem;
   --range-track-height: 0.25rem;
-  --range-thumb-shadow: 0 0 0 0.125rem #0f0f0f;
+  --range-thumb-shadow: 0 0 0 0.125rem var(--marinara-music-player-shell-bg);
 
   accent-color: var(--primary);
 }

--- a/packages/server/src/routes/generate.routes.ts
+++ b/packages/server/src/routes/generate.routes.ts
@@ -1746,7 +1746,7 @@ export async function generateRoutes(app: FastifyInstance) {
     const onClose = () => {
       clientDisconnected = true;
       if (generationComplete) return;
-      if (!shouldAbortOnPassiveGenerationDisconnect({ chatMode: requestChatMode, impersonate: input.impersonate })) {
+      if (!shouldAbortOnPassiveGenerationDisconnect({ impersonate: input.impersonate })) {
         logger.info(
           "[generate] Client disconnected; generation will continue for %s chat: %s",
           requestChatMode,

--- a/packages/server/src/routes/generate.routes.ts
+++ b/packages/server/src/routes/generate.routes.ts
@@ -1747,7 +1747,11 @@ export async function generateRoutes(app: FastifyInstance) {
       clientDisconnected = true;
       if (generationComplete) return;
       if (!shouldAbortOnPassiveGenerationDisconnect({ chatMode: requestChatMode, impersonate: input.impersonate })) {
-        logger.info("[generate] Conversation client disconnected; generation will continue for chat: %s", input.chatId);
+        logger.info(
+          "[generate] Client disconnected; generation will continue for %s chat: %s",
+          requestChatMode,
+          input.chatId,
+        );
         return;
       }
       logger.info("[abort] Client disconnected — aborting generation");
@@ -11452,6 +11456,15 @@ export async function generateRoutes(app: FastifyInstance) {
 
   // Expose the map so the route handler can register/unregister generations
   app.decorate("activeGenerations", activeGenerations);
+
+  /**
+   * GET /api/generate/status/:chatId
+   * Lets clients recover from passive mobile/browser stream disconnects by
+   * waiting until the server-side generation has finished saving.
+   */
+  app.get<{ Params: { chatId: string } }>("/status/:chatId", async (req) => ({
+    active: activeGenerations.has(req.params.chatId),
+  }));
 
   /**
    * POST /api/generate/abort

--- a/packages/server/src/routes/generate/generate-route-utils.ts
+++ b/packages/server/src/routes/generate/generate-route-utils.ts
@@ -301,7 +301,7 @@ export function parseSnapshotPlayerStats(snapshot: { playerStats?: unknown } | n
 }
 
 export function shouldAbortOnPassiveGenerationDisconnect(args: { chatMode: string; impersonate?: boolean }): boolean {
-  return args.chatMode !== "conversation" || args.impersonate === true;
+  return args.impersonate === true;
 }
 
 export function resolveProviderTopK(provider: unknown, topK: number): number | undefined {

--- a/packages/server/src/routes/generate/generate-route-utils.ts
+++ b/packages/server/src/routes/generate/generate-route-utils.ts
@@ -300,7 +300,7 @@ export function parseSnapshotPlayerStats(snapshot: { playerStats?: unknown } | n
   }
 }
 
-export function shouldAbortOnPassiveGenerationDisconnect(args: { chatMode: string; impersonate?: boolean }): boolean {
+export function shouldAbortOnPassiveGenerationDisconnect(args: { impersonate?: boolean }): boolean {
   return args.impersonate === true;
 }
 

--- a/packages/server/src/routes/lorebooks.routes.ts
+++ b/packages/server/src/routes/lorebooks.routes.ts
@@ -1197,7 +1197,7 @@ export async function lorebooksRoutes(app: FastifyInstance) {
       ) {
         return reply.status(409).send({
           error:
-            "Embedding dimensions changed. Re-vectorize all entries instead of only missing entries before switching embedding models.",
+            "Embedding dimensions changed. Use Re-vectorize all entries instead of only missing entries before switching embedding models.",
         });
       }
       for (let j = 0; j < batchEntries.length; j++) {

--- a/packages/server/src/routes/scene.routes.ts
+++ b/packages/server/src/routes/scene.routes.ts
@@ -250,7 +250,9 @@ export async function sceneRoutes(app: FastifyInstance) {
       characterIds: finalParticipantIds,
       groupId: originChat.groupId,
       personaId: originChat.personaId,
-      promptPresetId: originChat.promptPresetId,
+      // Scene chats use the generated sceneSystemPrompt as their prompt source.
+      // Copying the origin conversation preset can make those instructions clash.
+      promptPresetId: null,
       connectionId: connectionId ?? originChat.connectionId,
     });
 


### PR DESCRIPTION
## Why

Closes #3182.
Closes #3185.

Changing embedding models can leave existing lorebook vectors with dimensions that do not match newly generated vectors. The server already rejects missing-only vectorization in that state, but the editor did not expose a direct way to re-vectorize every entry.

Mobile browsers can also suspend or cut the generation stream when the user switches apps. In Roleplay mode that passive disconnect aborted the server-side generation and surfaced a network error when the user returned.

Restored chats should reopen at the latest visible message instead of landing at the top of the loaded history window.

## What Changed

- Added an explicit `Re-vectorize all` action when a lorebook has both stored vectors and entries missing vectors.
- Kept missing-only vectorization available for the normal “new entries added” case, with separate loading states for each vectorization mode.
- Updated the server dimension-mismatch error to point users at the new re-vectorize-all action.
- Smoothed Roleplay typewriter streaming by capping per-frame reveals and resetting stale paint timing between bursts.
- Made conversation-created scene chats start with `None` for prompt preset so generated scene instructions do not clash with inherited presets.
- Themed Spotify, YouTube, and Custom Music players through shared light/dark music-player tokens.
- Improved light-mode visibility for mini-player buttons, icon controls, tiles, progress tracks, and volume thumb outlines.
- Let normal chat generations continue server-side after passive client disconnects, while explicit impersonation disconnects still abort.
- Added `/api/generate/status/:chatId` so the client can recover from mobile background stream drops by waiting for the server generation to finish, then refreshing messages without showing a false network error.
- Restored conversation and roleplay chats to the latest rendered message on initial open while preserving load-older scroll behavior.

## Validation

- `git diff --check`
- `pnpm --filter @marinara-engine/server lint`
- `pnpm --filter @marinara-engine/client lint`
- `pnpm --filter @marinara-engine/client build`
- `pnpm check`
- After rebasing on the updated PR branch: `pnpm --filter @marinara-engine/server lint`
- After rebasing on the updated PR branch: `pnpm --filter @marinara-engine/client lint`

## Manual Verification Needed

- Manually verify changing an embedding model on a partially vectorized lorebook offers and completes `Re-vectorize all`.
- Manually verify Roleplay streaming still feels smooth with streaming speed set around 30.
- Manually verify chats created from a conversation scene show prompt preset `None`.
- Manually verify Spotify, YouTube, and Custom Music mini players in both light and dark mode.
- Manually verify on mobile: send a Roleplay message, switch apps while it generates, return, and confirm the reply appears without a network-error toast.
- Manually verify reopening ME on a previously active conversation or roleplay chat starts at the latest message, and that loading older history still preserves position.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a clearer vectorization flow for lorebooks, including separate actions for missing entries and re-vectorizing all entries.
  * Improved generation recovery in background tabs so chats can finish reliably even after a disconnect.

* **Bug Fixes**
  * Music players now use refreshed theme styling for more consistent light/dark appearance.
  * Volume sliders and mini-player tiles now render more consistent progress and ring styles.
  * Scene creation now starts without inheriting the origin chat’s preset, avoiding instruction conflicts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
