### PR TITLE
feat: add backfill summary button to chat summary popover

### DIFF
--- a/packages/client/src/components/chat/SummaryPopover.tsx
+++ b/packages/client/src/components/chat/SummaryPopover.tsx
@@ -16,10 +16,12 @@ import { createPortal } from "react-dom";
 import {
   useDeleteSummaryEntry,
   useGenerateSummary,
+  useRollingSummaryBackfill,
   useToggleSummaryEntry,
   useUpdateChatMetadata,
   useUpdateSummaryEntry,
 } from "../../hooks/use-chats";
+import { useRollingBackfillStore } from "../../stores/backfill.store";
 import {
   Check,
   ChevronRight,
@@ -28,6 +30,7 @@ import {
   Loader2,
   PenLine,
   Plus,
+  RefreshCw,
   Save,
   ScrollText,
   Sparkles,
@@ -303,6 +306,9 @@ export function SummaryPopover({
   const toggleSummaryEntry = useToggleSummaryEntry();
   const entryTextareaRef = useRef<HTMLTextAreaElement>(null);
   const panelRef = useRef<HTMLDivElement>(null);
+
+  const { startBackfill, stopBackfill } = useRollingSummaryBackfill();
+  const backfillState = useRollingBackfillStore();
 
   // Per-chat preference, default off — no global fallback, so one chat never
   // inherits another's setting.
@@ -969,6 +975,62 @@ export function SummaryPopover({
                       <span>user messages</span>
                     </span>
                   </label>
+
+                  {backfillState.status === "running" && backfillState.chatId === chatId && (
+                    <div className="space-y-1.5">
+                      <div className="h-1.5 w-full overflow-hidden rounded-full bg-[var(--border)]">
+                        <div
+                          role="progressbar"
+                          aria-valuenow={backfillState.completedBatches}
+                          aria-valuemin={0}
+                          aria-valuemax={backfillState.totalBatches}
+                          aria-labelledby="backfill-progress-label"
+                          className="h-full rounded-full bg-[var(--primary)] transition-all duration-300"
+                          style={{
+                            width: `${backfillState.totalBatches > 0 ? (backfillState.completedBatches / backfillState.totalBatches) * 100 : 0}%`,
+                          }}
+                        />
+                      </div>
+                      <p id="backfill-progress-label" className="text-[0.625rem] leading-snug text-[var(--muted-foreground)]">
+                        {backfillState.currentRangeStart && backfillState.currentRangeEnd
+                          ? `Summarizing messages ${backfillState.currentRangeStart}-${backfillState.currentRangeEnd} (${backfillState.completedBatches}/${backfillState.totalBatches})`
+                          : `${backfillState.completedBatches}/${backfillState.totalBatches} batches`}
+                      </p>
+                    </div>
+                  )}
+
+                  <div className="flex items-center gap-1.5">
+                    {backfillState.status === "running" && backfillState.chatId === chatId ? (
+                      <button
+                        type="button"
+                        onClick={stopBackfill}
+                        className="flex items-center gap-1.5 rounded-md bg-[var(--destructive)]/10 px-2.5 py-1.5 text-[0.6875rem] font-medium text-[var(--destructive)] ring-1 ring-[var(--destructive)]/30 transition-colors hover:bg-[var(--destructive)]/20"
+                      >
+                        <Loader2 size="0.75rem" className="animate-spin" />
+                        Stop
+                      </button>
+                    ) : (
+                      <button
+                        type="button"
+                        onClick={() => {
+                          startBackfill({
+                            chatId,
+                            summaryEntries: displayEntries,
+                            batchSize: normalizedAutomaticSummaryInterval,
+                            maxMessagesPerBatch: persistedContextSize,
+                            promptTemplateId: activePromptTemplateId,
+                          });
+                        }}
+                        disabled={
+                          totalMessageCount === 0
+                        }
+                        className="flex items-center gap-1.5 rounded-md bg-[var(--secondary)] px-2.5 py-1.5 text-[0.6875rem] font-medium text-[var(--foreground)] ring-1 ring-[var(--border)] transition-colors hover:bg-[var(--accent)] disabled:cursor-not-allowed disabled:opacity-50"
+                      >
+                        <RefreshCw size="0.75rem" />
+                        Backfill Summary
+                      </button>
+                    )}
+                  </div>
                 </div>
               )}
 

--- a/packages/client/src/hooks/use-chats.ts
+++ b/packages/client/src/hooks/use-chats.ts
@@ -1,6 +1,7 @@
 // ──────────────────────────────────────────────
 // React Query: Chat hooks
 // ──────────────────────────────────────────────
+import { useCallback } from "react";
 import {
   useQuery,
   useInfiniteQuery,
@@ -33,6 +34,8 @@ import type {
   DaySummaryEntry,
   WeekSummaryEntry,
 } from "@marinara-engine/shared";
+
+import { useRollingBackfillStore } from "../stores/backfill.store";
 
 export const chatKeys = {
   all: ["chats"] as const,
@@ -788,6 +791,185 @@ export function useBackfillConversationSummaries() {
       qc.invalidateQueries({ queryKey: chatKeys.detail(vars.chatId) });
     },
   });
+}
+
+export interface RollingSummaryBackfillInput {
+  chatId: string;
+  summaryEntries: ChatSummaryEntry[];
+  batchSize: number;
+  maxMessagesPerBatch: number;
+  promptTemplateId?: string | null;
+}
+
+export function useRollingSummaryBackfill() {
+  const qc = useQueryClient();
+
+  const startBackfill = useCallback(async (input: RollingSummaryBackfillInput) => {
+    const { chatId, summaryEntries, batchSize, maxMessagesPerBatch, promptTemplateId } = input;
+
+    const store = useRollingBackfillStore.getState();
+    if (store.status === "running") return;
+    
+    // Flip to "running" synchronously before any await
+    store.startBackfill(chatId);
+
+    let allMessages: Array<{ id: string; role: string; extra?: unknown }>;
+    try {
+      allMessages = await api.get(`/chats/${chatId}/messages`);
+    } catch {
+      useRollingBackfillStore.getState().stopBackfill();
+      toast.error("Could not start backfill: failed to load messages.");
+      return;
+    }
+    if (!Array.isArray(allMessages) || allMessages.length === 0) {
+      useRollingBackfillStore.getState().stopBackfill();
+      return;
+    }
+
+    const messageIds = allMessages.map((m) => m.id);
+    const totalMessageCount = messageIds.length;
+
+    const summarizedIds = new Set<string>();
+    for (const entry of summaryEntries) {
+      if (Array.isArray(entry.messageIds)) {
+        for (const id of entry.messageIds) summarizedIds.add(id);
+      }
+    }
+
+    const isMessageHidden = (msg: { extra?: unknown }) => {
+      let extra = msg.extra;
+      if (typeof extra === "string") {
+        try {
+          extra = JSON.parse(extra);
+        } catch {
+          return false;
+        }
+      }
+      return !!extra && typeof extra === "object" && (extra as any).hiddenFromAI === true;
+    };
+
+    const safeBatchSize = Math.max(1, Math.min(totalMessageCount, batchSize));
+    const batches: Array<{ rangeStart: number; rangeEnd: number }> = [];
+    let cursor = 0;
+    while (cursor < totalMessageCount) {
+      while (cursor < totalMessageCount) {
+        const msg = allMessages[cursor]!;
+        if (summarizedIds.has(msg.id) || isMessageHidden(msg)) {
+          cursor++;
+        } else {
+          break;
+        }
+      }
+      if (cursor >= totalMessageCount) break;
+
+      let userCount = 0;
+      let msgCount = 0;
+      let endCursor = cursor;
+      while (endCursor < totalMessageCount && userCount < safeBatchSize && msgCount < maxMessagesPerBatch) {
+        const msg = allMessages[endCursor]!;
+        if (!isMessageHidden(msg)) {
+          if (msg.role === "user") {
+            userCount++;
+          }
+          msgCount++;
+        }
+        endCursor++;
+      }
+
+      batches.push({ rangeStart: cursor + 1, rangeEnd: endCursor });
+      cursor = endCursor;
+    }
+
+    if (batches.length === 0) {
+      useRollingBackfillStore.getState().stopBackfill();
+      toast.info("Everything is already summarized.");
+      return;
+    }
+
+    const abortController = new AbortController();
+    useRollingBackfillStore.setState({ abortController });
+
+    const currentStore = useRollingBackfillStore.getState();
+    currentStore.setTotalBatches(batches.length);
+
+    const debugMode = useUIStore.getState().debugMode;
+
+    console.warn(
+      `[Backfill] Starting — ${batches.length} batch(es) covering ${totalMessageCount} messages` +
+        (debugMode ? "" : " (enable Advanced > Debug Mode for per-batch logs)"),
+    );
+
+    let failedBatches = 0;
+
+    for (let i = 0; i < batches.length; i++) {
+      if (abortController.signal.aborted) break;
+
+      const batch = batches[i]!;
+      currentStore.updateProgress(i + 1, batch.rangeStart, batch.rangeEnd);
+
+      if (debugMode) {
+        console.warn(
+          `[Backfill] Batch ${i + 1}/${batches.length}: messages ${batch.rangeStart}-${batch.rangeEnd}`,
+        );
+      }
+
+      try {
+        const result = await api.post<{
+          summary: string | null;
+          entry: ChatSummaryEntry | null;
+          entries: ChatSummaryEntry[];
+          messageIds: string[];
+          hideMessageIds: string[];
+        }>(
+          `/chats/${chatId}/generate-summary`,
+          { rangeStartIndex: batch.rangeStart, rangeEndIndex: batch.rangeEnd, promptTemplateId },
+          { signal: abortController.signal },
+        );
+
+        const existing = qc.getQueryData<Chat>(chatKeys.detail(chatId));
+        if (existing) {
+          syncCachedChat(qc, {
+            ...existing,
+            metadata: {
+              ...(normalizeChatMetadataValue(existing.metadata) as Record<string, unknown>),
+              summary: result.summary,
+              summaryEntries: result.entries,
+            } as Chat["metadata"],
+          });
+        }
+        qc.invalidateQueries({ queryKey: chatKeys.detail(chatId) });
+
+        if (debugMode) {
+          console.warn(`[Backfill] Batch ${i + 1} complete`);
+        }
+      } catch (err) {
+        if (abortController.signal.aborted) break;
+        failedBatches++;
+        if (debugMode) {
+          console.warn(`[Backfill] Batch ${i + 1} failed:`, err);
+        }
+      }
+    }
+
+    if (abortController.signal.aborted) {
+      useRollingBackfillStore.setState({ status: "idle", abortController: null });
+      console.warn(`[Backfill] Stopped`);
+    } else {
+      currentStore.stopBackfill();
+      if (failedBatches > 0) {
+        console.warn(`[Backfill] Done — ${batches.length - failedBatches}/${batches.length} batch(es) succeeded, ${failedBatches} failed`);
+        toast.error(`Backfill finished with ${failedBatches} failed batch(es).`);
+      } else {
+        console.warn(`[Backfill] Done — ${batches.length} batch(es) completed`);
+      }
+    }
+  }, [qc]);
+
+  const stopBackfill = useCallback(() => {
+    useRollingBackfillStore.getState().stopBackfill();
+  }, []);
+
+  return { startBackfill, stopBackfill };
 }
 
 export function useCreateMessage(chatId: string | null) {

--- a/packages/client/src/stores/backfill.store.ts
+++ b/packages/client/src/stores/backfill.store.ts
@@ -1,0 +1,51 @@
+import { create } from "zustand";
+
+export interface RollingBackfillState {
+  chatId: string | null;
+  status: "idle" | "running";
+  totalBatches: number;
+  completedBatches: number;
+  currentRangeStart: number | null;
+  currentRangeEnd: number | null;
+  abortController: AbortController | null;
+  startBackfill: (chatId: string) => void;
+  updateProgress: (completed: number, rangeStart?: number, rangeEnd?: number) => void;
+  setTotalBatches: (total: number) => void;
+  stopBackfill: () => void;
+  resetBackfill: () => void;
+}
+
+export const useRollingBackfillStore = create<RollingBackfillState>((set, get) => ({
+  chatId: null,
+  status: "idle",
+  totalBatches: 0,
+  completedBatches: 0,
+  currentRangeStart: null,
+  currentRangeEnd: null,
+  abortController: null,
+  startBackfill: (chatId) => set({ chatId, status: "running", completedBatches: 0 }),
+  updateProgress: (completed, rangeStart, rangeEnd) =>
+    set({
+      completedBatches: completed,
+      currentRangeStart: rangeStart ?? null,
+      currentRangeEnd: rangeEnd ?? null,
+    }),
+  setTotalBatches: (total) => set({ totalBatches: total }),
+  stopBackfill: () => {
+    const { abortController } = get();
+    if (abortController) {
+      abortController.abort();
+    }
+    set({ chatId: null, status: "idle", abortController: null });
+  },
+  resetBackfill: () =>
+    set({
+      chatId: null,
+      status: "idle",
+      totalBatches: 0,
+      completedBatches: 0,
+      currentRangeStart: null,
+      currentRangeEnd: null,
+      abortController: null,
+    }),
+}));


### PR DESCRIPTION
<!-- Target branch: `staging`. The default base in this UI is `main` (release branch). -->
<!-- Change the base to `staging` before submitting unless this is a maintainer-approved mainline change. -->
<!-- See CONTRIBUTING.md § Branches. -->

## Linked issue

<!-- Every PR should reference a feature request or issue report. If there isn't one yet, open one first to gather opinions: -->
<!-- https://github.com/Pasta-Devs/Marinara-Engine/issues/new/choose -->

Closes #3195

## Why this change

The automatic message summaries work great if you turn them on and configure them at the very start of a session. However, when you are on message 200 and realize you haven't set it up, the process of making new summaries in the desired batch size is highly vexing.

-

## What changed

<!-- List the key changes in this PR -->
1. Adds the 'Backfill Summary' button as well as a stop button. 
2. Adds a progress bar to monitor the batch jobs. 
3. Adds a zustand store for the batch status so that it is not lost when closing and reopening the summary card. I noticed that batches continued even when this ui state was lost. 
4. The actual meat of the functionality just automates the from/to/generate tool that you see at the bottom of the interface. It is actually not a very exciting change overall. 


-

## Validation

<!-- Required: include commands run and/or manual checks performed -->

- [x] `pnpm check` passes locally
- [x] Container (Docker / Podman) built and ran without issue
- [x] Ran the app, clicked through the changes manually
- [x] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [x] Above manual verification completed (describe below)
- [x] Read and followed `CONTRIBUTING.md`

### Manual verification notes

1. compile the app into a podman container & copy it to my server. 
2. get it online. 
3. Copy in my personal data from MAIN so I have a big chatfile to work with. 
4. Delete all the existing summaries (opportunity for a bulk deleter here lol).
5. click button.
6. All functionality seems to work as described. 
7. Send a message to the chat, observe that the summaries work as they always did. 
8. Press F12 -- debug messages are in the console. 
9. Flipped through light/dark on my personal theme and the default theme to make sure everything is compliant. 

-

## Docs and release impact

- [x] No docs changes needed
- [ ] N/A | Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] N/A | Version/release files updated (only if this PR includes a version bump)

## UI evidence (if applicable)

<!-- Add before/after screenshots or recordings for UI changes -->

<img width="659" height="1054" alt="image" src="https://github.com/user-attachments/assets/8640b4a3-701e-43f5-99ff-dde4b5a9f262" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new “Backfill Summary” action in chat summaries to generate missing automatic summaries in batches.
  * Users can now see backfill progress, including a live progress bar and a Stop button while it runs.
* **Bug Fixes**
  * Improved handling of partially summarized chats by skipping entries that already have summaries and continuing from the remaining ones.
  * Added support for safely stopping an in-progress backfill without interrupting the app.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->