### PR TITLE
[codex] Smooth typewriter and address chat issue sweep

### DIFF
--- a/packages/client/src/components/chat/ChatInput.tsx
+++ b/packages/client/src/components/chat/ChatInput.tsx
@@ -203,6 +203,9 @@ export const ChatInput = memo(function ChatInput({
   const emojiButtonRef = useRef<HTMLButtonElement>(null);
   const inputBarRef = useRef<HTMLDivElement>(null);
   const focusAfterMobileRestoreRef = useRef(false);
+  const textareaFocusedRef = useRef(false);
+  const restoreFocusAfterBusyRef = useRef(false);
+  const wasInputBusyRef = useRef(false);
   const draftTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const attachmentsRef = useRef<Attachment[]>([]);
   const pendingAttachmentDraftsRef = useRef<Map<string, Attachment[]>>(new Map());
@@ -1426,6 +1429,32 @@ export const ChatInput = memo(function ChatInput({
   }, []);
 
   useEffect(() => {
+    const wasInputBusy = wasInputBusyRef.current;
+    wasInputBusyRef.current = isInputBusy;
+
+    if (isInputBusy) {
+      if (textareaFocusedRef.current) restoreFocusAfterBusyRef.current = true;
+      return;
+    }
+
+    if (!wasInputBusy || !restoreFocusAfterBusyRef.current) return;
+    restoreFocusAfterBusyRef.current = false;
+    if (!activeChatId || shouldShowMobileCollapsedComposer) return;
+
+    const focus = () => {
+      const textarea = textareaRef.current;
+      if (!textarea || textarea.disabled) return;
+      const activeElement = document.activeElement;
+      if (activeElement && activeElement !== document.body && activeElement !== textarea) return;
+      textarea.focus({ preventScroll: true });
+      textareaFocusedRef.current = true;
+      ensureInputVisible();
+    };
+
+    requestAnimationFrame(focus);
+  }, [activeChatId, ensureInputVisible, isInputBusy, shouldShowMobileCollapsedComposer]);
+
+  useEffect(() => {
     if (mobileHistoryCollapsed || !focusAfterMobileRestoreRef.current) return;
     focusAfterMobileRestoreRef.current = false;
     const focus = () => {
@@ -1620,7 +1649,13 @@ export const ChatInput = memo(function ChatInput({
           onChange={handleInput}
           onKeyDown={handleKeyDown}
           onPaste={handlePaste}
-          onFocus={ensureInputVisible}
+          onFocus={() => {
+            textareaFocusedRef.current = true;
+            ensureInputVisible();
+          }}
+          onBlur={() => {
+            if (!isInputBusy) textareaFocusedRef.current = false;
+          }}
           placeholder={inputPlaceholder}
           disabled={!activeChatId || isInputBusy}
           rows={1}

--- a/packages/client/src/components/chat/ConversationInput.tsx
+++ b/packages/client/src/components/chat/ConversationInput.tsx
@@ -88,6 +88,8 @@ const PDF_ATTACHMENT_MIME_TYPE = "application/pdf";
 const CONVERSATION_HIDDEN_SLASH_COMMANDS = new Set(["impersonate", "impersonate_prompt"]);
 const QUOTE_INPUT_TRIGGER_RE = /["'\u2018\u2019\u201a\u201b\u201c\u201d\u201e\u201f]/;
 
+type MobilePickerTab = "emoji" | "gifs" | "stickers" | "tools";
+
 type ConversationSlashCompletion = {
   key: string;
   label: string;
@@ -317,7 +319,7 @@ export function ConversationInput({
   const [gifOpen, setGifOpen] = useState(false);
   const [stickerOpen, setStickerOpen] = useState(false);
   const [mobilePickerOpen, setMobilePickerOpen] = useState(false);
-  const [mobilePickerTab, setMobilePickerTab] = useState<"emoji" | "gifs" | "stickers">("emoji");
+  const [mobilePickerTab, setMobilePickerTab] = useState<MobilePickerTab>("emoji");
   const isMobileComposerViewport = useIsMobileComposerViewport();
   const [isDragging, setIsDragging] = useState(false);
   // @mention autocomplete
@@ -1699,6 +1701,24 @@ export function ConversationInput({
 
   const showCharPicker = groupResponseOrder === "manual" && !!activeChatCharacters && activeChatCharacters.length > 1;
   const showDraftTranslateButton = chatMetadata.showInputTranslateButton === true;
+  const showMobileToolsTab =
+    showCharPicker ||
+    showDraftTranslateButton ||
+    speechToTextEnabled ||
+    (showQuickRepliesMenu && quickReplyActions.length > 0);
+  const mobilePickerTabs = useMemo<Array<{ id: MobilePickerTab; label: string }>>(() => {
+    const tabs: Array<{ id: MobilePickerTab; label: string }> = [
+      { id: "emoji", label: "Emoji" },
+      { id: "gifs", label: "GIFs" },
+      { id: "stickers", label: "Stickers" },
+    ];
+    if (showMobileToolsTab) tabs.push({ id: "tools", label: "Tools" });
+    return tabs;
+  }, [showMobileToolsTab]);
+
+  useEffect(() => {
+    if (!showMobileToolsTab && mobilePickerTab === "tools") setMobilePickerTab("emoji");
+  }, [mobilePickerTab, showMobileToolsTab]);
 
   const handleTranslateDraft = useCallback(async () => {
     if (!activeChatId || isTranslatingDraft) return;
@@ -1890,23 +1910,23 @@ export function ConversationInput({
         </div>
       )}
 
-      {/* Mobile multipurpose picker sheet — Emoji / GIFs / Stickers (desktop uses the popovers) */}
+      {/* Mobile multipurpose picker sheet — Emoji / GIFs / Stickers / Tools (desktop uses the popovers) */}
       {mobilePickerOpen && (
         <div className="absolute bottom-full left-0 right-0 z-20 mb-1 flex h-[22rem] max-h-[60vh] flex-col overflow-hidden rounded-xl border border-foreground/10 bg-[var(--card)] shadow-xl sm:hidden">
           <div className="flex shrink-0 items-center gap-1 border-b border-foreground/10 px-2 py-1.5">
-            {(["emoji", "gifs", "stickers"] as const).map((tab) => (
+            {mobilePickerTabs.map((tab) => (
               <button
-                key={tab}
+                key={tab.id}
                 type="button"
-                onClick={() => setMobilePickerTab(tab)}
+                onClick={() => setMobilePickerTab(tab.id)}
                 className={cn(
                   "flex-1 rounded-md px-2 py-1 text-xs font-medium transition-colors",
-                  mobilePickerTab === tab
+                  mobilePickerTab === tab.id
                     ? "bg-foreground/10 text-foreground/80 ring-1 ring-foreground/15"
                     : "text-foreground/45 hover:bg-foreground/10 hover:text-foreground/70",
                 )}
               >
-                {tab === "gifs" ? "GIFs" : tab === "stickers" ? "Stickers" : "Emoji"}
+                {tab.label}
               </button>
             ))}
           </div>
@@ -1929,6 +1949,137 @@ export function ConversationInput({
             )}
             {mobilePickerTab === "stickers" && (
               <StickerPicker embedded open onClose={() => setMobilePickerOpen(false)} onSelect={handleStickerSelect} />
+            )}
+            {mobilePickerTab === "tools" && (
+              <div className="flex h-full flex-col gap-3 overflow-y-auto p-3">
+                {showCharPicker && activeChatCharacters && (
+                  <div className="space-y-1.5">
+                    <div className="px-1 text-[0.6875rem] font-semibold uppercase text-foreground/45">
+                      Trigger Response
+                    </div>
+                    <div className="grid gap-1">
+                      {activeChatCharacters.map((char) => (
+                        <button
+                          key={char.id}
+                          type="button"
+                          onClick={() => {
+                            setMobilePickerOpen(false);
+                            handleCharacterResponse(char.id);
+                          }}
+                          className={cn(
+                            "flex min-h-11 w-full items-center gap-2.5 rounded-lg px-3 py-2 text-left transition-all hover:bg-foreground/10",
+                            (char.conversationStatus === "dnd" || char.conversationStatus === "offline") &&
+                              "opacity-60",
+                          )}
+                        >
+                          <div className="relative shrink-0">
+                            {char.avatarUrl ? (
+                              <span className="relative block h-7 w-7 overflow-hidden rounded-full">
+                                <img
+                                  src={char.avatarUrl}
+                                  alt={char.name}
+                                  className="h-full w-full object-cover"
+                                  style={getAvatarCropStyle(char.avatarCrop)}
+                                />
+                              </span>
+                            ) : (
+                              <div className="flex h-7 w-7 items-center justify-center rounded-full bg-foreground/10 text-[0.6875rem] font-semibold text-foreground/45">
+                                {(char.name || "?")[0].toUpperCase()}
+                              </div>
+                            )}
+                            <span
+                              className={cn(
+                                "absolute -bottom-0.5 -right-0.5 h-2 w-2 rounded-full ring-2 ring-[var(--card)]",
+                                statusDotClass(char.conversationStatus),
+                              )}
+                            />
+                          </div>
+                          <span className="min-w-0 flex-1">
+                            <span className="block truncate text-sm font-medium">{char.name}</span>
+                            {(char.conversationActivity || statusLabel(char.conversationStatus)) && (
+                              <span className="block truncate text-xs text-foreground/45">
+                                {char.conversationActivity || statusLabel(char.conversationStatus)}
+                              </span>
+                            )}
+                          </span>
+                        </button>
+                      ))}
+                    </div>
+                  </div>
+                )}
+
+                <div className="grid gap-2">
+                  {showDraftTranslateButton && (
+                    <button
+                      type="button"
+                      onClick={() => {
+                        setMobilePickerOpen(false);
+                        void handleTranslateDraft();
+                      }}
+                      disabled={!activeChatId || !hasInput || isTranslatingDraft}
+                      className={cn(
+                        "flex min-h-11 w-full items-center gap-2.5 rounded-lg px-3 py-2 text-left transition-colors",
+                        activeChatId && hasInput && !isTranslatingDraft
+                          ? "text-foreground/80 hover:bg-foreground/10"
+                          : "cursor-not-allowed text-foreground/25",
+                      )}
+                    >
+                      {isTranslatingDraft ? (
+                        <Loader2 size="1rem" className="shrink-0 animate-spin" />
+                      ) : (
+                        <Languages size="1rem" className="shrink-0" />
+                      )}
+                      <span className="min-w-0 flex-1 truncate text-sm font-medium">Translate draft</span>
+                    </button>
+                  )}
+
+                  {speechToTextEnabled && (
+                    <div className="flex min-h-11 items-center justify-between gap-2 rounded-lg px-3 py-2">
+                      <span className="min-w-0 flex-1 truncate text-sm font-medium text-foreground/80">
+                        Voice input
+                      </span>
+                      <SpeechToTextButton
+                        disabled={!activeChatId}
+                        onTranscript={(transcript) => {
+                          setMobilePickerOpen(false);
+                          handleSpeechTranscript(transcript);
+                        }}
+                        className="h-10 w-10 rounded-lg"
+                        iconSize={16}
+                      />
+                    </div>
+                  )}
+
+                  {showQuickRepliesMenu &&
+                    quickReplyActions.map((action) => (
+                      <button
+                        key={action.id}
+                        type="button"
+                        onClick={() => {
+                          if (action.disabled) return;
+                          setMobilePickerOpen(false);
+                          void action.onSelect();
+                        }}
+                        disabled={action.disabled}
+                        title={action.disabled ? (action.disabledReason ?? action.description) : action.description}
+                        className={cn(
+                          "flex min-h-11 w-full items-center gap-2.5 rounded-lg px-3 py-2 text-left transition-colors",
+                          action.disabled
+                            ? "cursor-not-allowed text-foreground/25"
+                            : "text-foreground/80 hover:bg-foreground/10",
+                        )}
+                      >
+                        <span className="shrink-0">{action.icon}</span>
+                        <span className="min-w-0 flex-1">
+                          <span className="block truncate text-sm font-medium">{action.label}</span>
+                          <span className="block truncate text-xs text-foreground/45">
+                            {action.disabledReason ?? action.description}
+                          </span>
+                        </span>
+                      </button>
+                    ))}
+                </div>
+              </div>
             )}
           </div>
         </div>
@@ -2040,7 +2191,7 @@ export function ConversationInput({
 
         {/* Right actions */}
         <div className="ml-0 flex shrink-0 flex-nowrap items-center justify-end gap-0 sm:ml-auto sm:gap-0.5">
-          {/* Mobile: one multipurpose button → Emoji/GIFs/Stickers sheet (desktop uses the separate buttons) */}
+          {/* Mobile: one multipurpose button → Emoji/GIFs/Stickers/Tools sheet (desktop uses the separate buttons) */}
           <button
             type="button"
             onClick={() => {
@@ -2057,8 +2208,20 @@ export function ConversationInput({
                 ? "bg-foreground/10 text-foreground/75 ring-1 ring-foreground/20"
                 : "text-foreground/40 hover:bg-foreground/10 hover:text-foreground/70",
             )}
-            title={mobilePickerOpen ? "Show keyboard" : "Emoji, GIFs & stickers"}
-            aria-label={mobilePickerOpen ? "Show keyboard" : "Emoji, GIFs and stickers"}
+            title={
+              mobilePickerOpen
+                ? "Show keyboard"
+                : showMobileToolsTab
+                  ? "Emoji, GIFs, stickers & tools"
+                  : "Emoji, GIFs & stickers"
+            }
+            aria-label={
+              mobilePickerOpen
+                ? "Show keyboard"
+                : showMobileToolsTab
+                  ? "Emoji, GIFs, stickers, and tools"
+                  : "Emoji, GIFs and stickers"
+            }
           >
             {mobilePickerOpen ? <Keyboard size="1.25rem" /> : <Smile size="1.25rem" />}
           </button>

--- a/packages/client/src/components/chat/HomeProfessorMariChat.tsx
+++ b/packages/client/src/components/chat/HomeProfessorMariChat.tsx
@@ -64,6 +64,7 @@ import { useChatStore } from "../../stores/chat.store";
 import { useSidecarStore } from "../../stores/sidecar.store";
 import { useUIStore } from "../../stores/ui.store";
 import { applyInlineMarkdown, renderMarkdownBlocks } from "../../lib/markdown";
+import { prepareImageAttachment } from "../../lib/chat-attachment-images";
 import { cn } from "../../lib/utils";
 import { ProfessorMariWorkingWindow } from "../ui/ProfessorMariWorkingWindow";
 import { SettingsSwitch } from "../panels/settings/SettingControls";
@@ -93,6 +94,13 @@ Use this skill when the request matches a workflow you want Professor Mari to fo
 - Add the steps Professor Mari should follow.
 - Add any checks or evidence she should collect before saying the work is done.
 `;
+
+type ProfessorMariImageAttachment = {
+  type: string;
+  data: string;
+  name: string;
+  resized?: boolean;
+};
 const PROFESSOR_MARI_PANE_TRANSITION = { duration: 0.24, ease: [0.16, 1, 0.3, 1] } as const;
 const PROFESSOR_MARI_FLOATING_EDGE_GAP = 12;
 const PROFESSOR_MARI_FLOATING_MOBILE_TOP_GAP = 64;
@@ -185,6 +193,26 @@ function toMessageExtra(message: Message): Message["extra"] {
   return message.extra;
 }
 
+function getProfessorMariImageAttachments(message: Message): ProfessorMariImageAttachment[] {
+  const extra = toMessageExtra(message);
+  const rawAttachments =
+    extra && typeof extra === "object" && "attachments" in extra
+      ? (extra as { attachments?: unknown }).attachments
+      : undefined;
+  if (!Array.isArray(rawAttachments)) return [];
+  return rawAttachments.filter((attachment): attachment is ProfessorMariImageAttachment => {
+    if (!attachment || typeof attachment !== "object") return false;
+    const candidate = attachment as Partial<ProfessorMariImageAttachment>;
+    return (
+      typeof candidate.type === "string" &&
+      candidate.type.startsWith("image/") &&
+      typeof candidate.data === "string" &&
+      candidate.data.startsWith("data:image/") &&
+      typeof candidate.name === "string"
+    );
+  });
+}
+
 function isProfessorMariChatActive(chat: ProfessorMariChatSummary) {
   const raw = chat.metadata;
   try {
@@ -215,7 +243,11 @@ function createWelcomeMessage(chatId: string | null): Message {
   };
 }
 
-function createLocalUserMessage(chatId: string, content: string): Message {
+function createLocalUserMessage(
+  chatId: string,
+  content: string,
+  attachments: ProfessorMariImageAttachment[] = [],
+): Message {
   return {
     id: `__professor_mari_local_${Date.now()}`,
     chatId,
@@ -229,6 +261,7 @@ function createLocalUserMessage(chatId: string, content: string): Message {
       isGenerated: false,
       tokenCount: null,
       generationInfo: null,
+      ...(attachments.length > 0 ? { attachments } : {}),
     },
   };
 }
@@ -997,6 +1030,31 @@ function CompactMarkdown({ content, streaming }: { content: string; streaming?: 
   );
 }
 
+function ProfessorMariAttachedImages({ attachments }: { attachments: ProfessorMariImageAttachment[] }) {
+  if (attachments.length === 0) return null;
+  return (
+    <div className="mt-2 flex flex-wrap gap-2">
+      {attachments.map((attachment, index) => (
+        <a
+          key={`${attachment.name}-${index}`}
+          href={attachment.data}
+          target="_blank"
+          rel="noreferrer"
+          className="block overflow-hidden rounded-lg border border-[var(--border)] bg-[var(--background)]/70"
+          title={attachment.name}
+        >
+          <img
+            src={attachment.data}
+            alt={attachment.name || "Attached image"}
+            className="h-24 w-24 object-cover sm:h-28 sm:w-28"
+            draggable={false}
+          />
+        </a>
+      ))}
+    </div>
+  );
+}
+
 function MariAvatar({ active }: { active?: boolean }) {
   return (
     <span
@@ -1198,6 +1256,7 @@ function WorkspaceTimelineList({
 
 function CompactMariMessage({ message, thinking }: { message: Message; thinking?: string | null }) {
   const content = message.content ?? "";
+  const imageAttachments = getProfessorMariImageAttachments(message);
 
   if (message.role === "user") {
     return (
@@ -1205,6 +1264,7 @@ function CompactMariMessage({ message, thinking }: { message: Message; thinking?
         marker={<span className="pt-0.5 text-[0.6875rem] font-semibold text-[var(--muted-foreground)]">You</span>}
       >
         <CompactMarkdown content={content} />
+        <ProfessorMariAttachedImages attachments={imageAttachments} />
       </TranscriptRow>
     );
   }
@@ -1651,6 +1711,8 @@ export function HomeProfessorMariChat({
   const [chatId, setChatId] = useState<string | null>(null);
   const [messages, setMessages] = useState<Message[]>([]);
   const [draft, setDraft] = useState("");
+  const [imageAttachments, setImageAttachments] = useState<ProfessorMariImageAttachment[]>([]);
+  const [isReadingImages, setIsReadingImages] = useState(false);
   const [selectedConnectionId, setSelectedConnectionId] = useState<string | null>(() => readStoredConnectionId());
   const [workspaceStatus, setWorkspaceStatus] = useState<MariWorkspaceStatus | null>(null);
   const [workspaceActive, setWorkspaceActive] = useState(false);
@@ -1689,6 +1751,7 @@ export function HomeProfessorMariChat({
   const connectionButtonRef = useRef<HTMLButtonElement>(null);
   const connectionMenuRef = useRef<HTMLDivElement>(null);
   const skillFileInputRef = useRef<HTMLInputElement>(null);
+  const imageInputRef = useRef<HTMLInputElement>(null);
   const workspaceAbortRef = useRef<AbortController | null>(null);
   const handledWorkspaceRefreshIdsRef = useRef<Set<string>>(new Set());
   const workspaceStatusErrorToastShownRef = useRef(false);
@@ -1724,6 +1787,7 @@ export function HomeProfessorMariChat({
     selectedConnection ?? connectionOptions.find((connection) => connection.isDefault) ?? connectionOptions[0] ?? null;
   const effectiveConnectionId = effectiveConnection?.id ?? null;
   const isBusy = sending || hasActiveGeneration || workspaceActive;
+  const canSubmitMessage = (draft.trim().length > 0 || imageAttachments.length > 0) && !isReadingImages;
   const selectedSkill = useMemo(
     () => skills.find((skill) => skill.id === selectedSkillId) ?? null,
     [selectedSkillId, skills],
@@ -2428,8 +2492,36 @@ export function HomeProfessorMariChat({
     [chatHistory, chatId, effectiveConnectionId, ensureProfessorMariChat, loadChatHistory, loadMessages],
   );
 
+  const handleImageUpload = useCallback(async (files: FileList | null) => {
+    const imageFiles = Array.from(files ?? []).filter((file) => file.type.startsWith("image/"));
+    if (imageFiles.length === 0) {
+      if (files && files.length > 0) toast.error("Professor Mari only accepts image attachments here.");
+      return;
+    }
+
+    setIsReadingImages(true);
+    try {
+      const prepared = await Promise.all(imageFiles.map((file) => prepareImageAttachment(file, file.name)));
+      setImageAttachments((current) => [...current, ...prepared]);
+      const resizedCount = prepared.filter((attachment) => attachment.resized).length;
+      if (resizedCount > 0) {
+        toast.info(
+          `${resizedCount} image${resizedCount === 1 ? "" : "s"} resized for Professor Mari's vision prompt.`,
+        );
+      }
+    } catch (error) {
+      console.error("[Professor Mari] Failed to prepare image attachment", error);
+      toast.error("Professor Mari could not attach that image.", {
+        description: error instanceof Error ? error.message : "The image could not be read.",
+        duration: PROFESSOR_MARI_ERROR_TOAST_DURATION_MS,
+      });
+    } finally {
+      setIsReadingImages(false);
+    }
+  }, []);
+
   const sendWorkspaceMessage = useCallback(
-    async (chat: Chat, text: string) => {
+    async (chat: Chat, text: string, attachments: ProfessorMariImageAttachment[] = []) => {
       const controller = new AbortController();
       workspaceAbortRef.current = controller;
       setWorkspaceActive(true);
@@ -2443,7 +2535,7 @@ export function HomeProfessorMariChat({
       try {
         for await (const event of api.streamEvents(
           "/professor-mari/workspace/prompt",
-          { chatId: chat.id, message: text, connectionId: effectiveConnectionId },
+          { chatId: chat.id, message: text, connectionId: effectiveConnectionId, attachments },
           controller.signal,
         )) {
           if (event.type === "token" && typeof event.data === "string") {
@@ -2525,9 +2617,11 @@ export function HomeProfessorMariChat({
 
   const handleSubmit = async () => {
     const text = draft.trim();
-    if (!text || isBusy) return;
+    const submittedAttachments = imageAttachments;
+    const messageText = text || (submittedAttachments.length > 0 ? "Please inspect the attached image." : "");
+    if (!messageText || isBusy || isReadingImages) return;
 
-    if (text === "/restart") {
+    if (messageText === "/restart") {
       await runRestart();
       return;
     }
@@ -2543,9 +2637,10 @@ export function HomeProfessorMariChat({
     try {
       const chat = await ensureProfessorMariChat(effectiveConnectionId);
       setDraft("");
-      setMessages((current) => [...current, createLocalUserMessage(chat.id, text)]);
+      setImageAttachments([]);
+      setMessages((current) => [...current, createLocalUserMessage(chat.id, messageText, submittedAttachments)]);
       trackAchievement.mutate("prof_mari_message_sent");
-      const received = await sendWorkspaceMessage(chat, text);
+      const received = await sendWorkspaceMessage(chat, messageText, submittedAttachments);
       await loadMessages(chat.id);
       useChatStore.getState().clearStreamBuffer(chat.id);
       useChatStore.getState().clearThinkingBuffer(chat.id);
@@ -2559,6 +2654,8 @@ export function HomeProfessorMariChat({
         });
       }
     } catch (error) {
+      setDraft(text);
+      setImageAttachments(submittedAttachments);
       console.error("[Professor Mari] Failed to send", error);
       toast.error("Professor Mari could not answer right now.", {
         description: describeProfessorMariError(error),
@@ -3160,6 +3257,56 @@ export function HomeProfessorMariChat({
                           void handleSubmit();
                         }}
                       >
+                        <input
+                          ref={imageInputRef}
+                          type="file"
+                          accept="image/*"
+                          multiple
+                          className="hidden"
+                          onChange={(event: ChangeEvent<HTMLInputElement>) => {
+                            void handleImageUpload(event.target.files);
+                            event.target.value = "";
+                          }}
+                        />
+                        {(imageAttachments.length > 0 || isReadingImages) && (
+                          <div className="mb-2 flex flex-wrap gap-2">
+                            {imageAttachments.map((attachment, index) => (
+                              <div
+                                key={`${attachment.name}-${index}`}
+                                className="group relative flex max-w-[9rem] items-center gap-2 rounded-lg border border-[var(--border)] bg-[var(--background)]/70 p-1.5 pr-7"
+                              >
+                                <img
+                                  src={attachment.data}
+                                  alt={attachment.name}
+                                  className="h-9 w-9 shrink-0 rounded-md object-cover"
+                                  draggable={false}
+                                />
+                                <span className="min-w-0 flex-1 truncate text-[0.6875rem] text-[var(--muted-foreground)]">
+                                  {attachment.name}
+                                </span>
+                                <button
+                                  type="button"
+                                  onClick={() =>
+                                    setImageAttachments((current) =>
+                                      current.filter((_, itemIndex) => itemIndex !== index),
+                                    )
+                                  }
+                                  className="absolute right-1.5 top-1.5 rounded-md p-0.5 text-[var(--muted-foreground)] transition-colors hover:bg-[var(--accent)] hover:text-[var(--foreground)]"
+                                  aria-label={`Remove ${attachment.name}`}
+                                  title="Remove image"
+                                >
+                                  <X size="0.7rem" />
+                                </button>
+                              </div>
+                            ))}
+                            {isReadingImages && (
+                              <div className="flex min-h-12 items-center gap-2 rounded-lg border border-[var(--border)] bg-[var(--background)]/70 px-2 text-[0.6875rem] text-[var(--muted-foreground)]">
+                                <Loader2 size="0.8rem" className="animate-spin" />
+                                Reading image...
+                              </div>
+                            )}
+                          </div>
+                        )}
                         <div className="relative flex items-center gap-2 rounded-xl border border-[var(--border)] bg-[var(--card)] px-2 py-1.5 shadow-inner shadow-black/10 focus-within:border-[var(--primary)]/50">
                           <button
                             ref={connectionButtonRef}
@@ -3233,6 +3380,23 @@ export function HomeProfessorMariChat({
                             </div>
                           )}
 
+                          <button
+                            type="button"
+                            onClick={() => imageInputRef.current?.click()}
+                            disabled={isBusy || isReadingImages}
+                            className={cn(
+                              "flex h-8 w-8 shrink-0 items-center justify-center rounded-xl transition-all",
+                              imageAttachments.length > 0
+                                ? "bg-foreground/10 text-foreground/75"
+                                : "text-foreground/40 hover:bg-foreground/10 hover:text-foreground/70",
+                              (isBusy || isReadingImages) && "cursor-not-allowed opacity-40",
+                            )}
+                            title="Attach images"
+                            aria-label="Attach images"
+                          >
+                            {isReadingImages ? <Loader2 size="1rem" className="animate-spin" /> : <ImageIcon size="1rem" />}
+                          </button>
+
                           <textarea
                             value={draft}
                             onChange={(event) => {
@@ -3252,17 +3416,17 @@ export function HomeProfessorMariChat({
                           />
                           <button
                             type="submit"
-                            disabled={!draft.trim() || isBusy}
+                            disabled={!canSubmitMessage || isBusy}
                             className={cn(
                               "mari-chat-send-btn inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-xl text-white transition-all duration-200",
-                              draft.trim() && !isBusy
+                              canSubmitMessage && !isBusy
                                 ? "hover:text-white active:scale-90"
                                 : "cursor-not-allowed opacity-40",
                             )}
                             aria-label="Send to Professor Mari"
                             title="Send"
                           >
-                            <Send size="0.9375rem" className={cn(draft.trim() && "translate-x-[1px]")} />
+                            <Send size="0.9375rem" className={cn(canSubmitMessage && "translate-x-[1px]")} />
                           </button>
                         </div>
                       </form>

--- a/packages/client/src/components/chat/HomeProfessorMariChat.tsx
+++ b/packages/client/src/components/chat/HomeProfessorMariChat.tsx
@@ -2709,6 +2709,54 @@ export function HomeProfessorMariChat({
           void handleSubmit();
         }}
       >
+        <input
+          ref={imageInputRef}
+          type="file"
+          accept="image/*"
+          multiple
+          className="hidden"
+          onChange={(event: ChangeEvent<HTMLInputElement>) => {
+            void handleImageUpload(event.target.files);
+            event.target.value = "";
+          }}
+        />
+        {(imageAttachments.length > 0 || isReadingImages) && (
+          <div className="mb-2 flex flex-wrap gap-2">
+            {imageAttachments.map((attachment, index) => (
+              <div
+                key={`${attachment.name}-${index}`}
+                className="group relative flex max-w-[9rem] items-center gap-2 rounded-lg border border-[var(--border)] bg-[var(--background)]/70 p-1.5 pr-7"
+              >
+                <img
+                  src={attachment.data}
+                  alt={attachment.name}
+                  className="h-9 w-9 shrink-0 rounded-md object-cover"
+                  draggable={false}
+                />
+                <span className="min-w-0 flex-1 truncate text-[0.6875rem] text-[var(--muted-foreground)]">
+                  {attachment.name}
+                </span>
+                <button
+                  type="button"
+                  onClick={() =>
+                    setImageAttachments((current) => current.filter((_, itemIndex) => itemIndex !== index))
+                  }
+                  className="absolute right-1.5 top-1.5 rounded-md p-0.5 text-[var(--muted-foreground)] transition-colors hover:bg-[var(--accent)] hover:text-[var(--foreground)]"
+                  aria-label={`Remove ${attachment.name}`}
+                  title="Remove image"
+                >
+                  <X size="0.7rem" />
+                </button>
+              </div>
+            ))}
+            {isReadingImages && (
+              <div className="flex min-h-12 items-center gap-2 rounded-lg border border-[var(--border)] bg-[var(--background)]/70 px-2 text-[0.6875rem] text-[var(--muted-foreground)]">
+                <Loader2 size="0.8rem" className="animate-spin" />
+                Reading image...
+              </div>
+            )}
+          </div>
+        )}
         <div className="relative flex items-center gap-2 rounded-xl border border-[var(--border)] bg-[var(--card)] px-2 py-1.5 shadow-inner shadow-black/10 focus-within:border-[var(--primary)]/50">
           <button
             ref={connectionButtonRef}
@@ -2776,6 +2824,23 @@ export function HomeProfessorMariChat({
             </div>
           )}
 
+          <button
+            type="button"
+            onClick={() => imageInputRef.current?.click()}
+            disabled={isBusy || isReadingImages}
+            className={cn(
+              "flex h-8 w-8 shrink-0 items-center justify-center rounded-xl transition-all",
+              imageAttachments.length > 0
+                ? "bg-foreground/10 text-foreground/75"
+                : "text-foreground/40 hover:bg-foreground/10 hover:text-foreground/70",
+              (isBusy || isReadingImages) && "cursor-not-allowed opacity-40",
+            )}
+            title="Attach images"
+            aria-label="Attach images"
+          >
+            {isReadingImages ? <Loader2 size="1rem" className="animate-spin" /> : <ImageIcon size="1rem" />}
+          </button>
+
           <textarea
             value={draft}
             onChange={(event) => {
@@ -2795,15 +2860,15 @@ export function HomeProfessorMariChat({
           />
           <button
             type="submit"
-            disabled={!draft.trim() || isBusy}
+            disabled={!canSubmitMessage || isBusy}
             className={cn(
               "mari-chat-send-btn inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-xl text-white transition-all duration-200",
-              draft.trim() && !isBusy ? "hover:text-white active:scale-90" : "cursor-not-allowed opacity-40",
+              canSubmitMessage && !isBusy ? "hover:text-white active:scale-90" : "cursor-not-allowed opacity-40",
             )}
             aria-label="Send to Professor Mari"
             title="Send"
           >
-            <Send size="0.9375rem" className={cn(draft.trim() && "translate-x-[1px]")} />
+            <Send size="0.9375rem" className={cn(canSubmitMessage && "translate-x-[1px]")} />
           </button>
         </div>
       </form>

--- a/packages/client/src/hooks/use-generate.ts
+++ b/packages/client/src/hooks/use-generate.ts
@@ -3178,6 +3178,22 @@ function formatAgentBubble(agentType: string, agentName: string, data: unknown):
       return updates.map((u: any) => `📖 ${u.action === "create" ? "New" : "Updated"}: ${u.entryName}`).join("\n");
     }
 
+    case "knowledge-router": {
+      const selectedEntries = Array.isArray(d.selectedEntries) ? (d.selectedEntries as Array<Record<string, unknown>>) : [];
+      const candidateCount =
+        typeof d.candidateCount === "number" && Number.isFinite(d.candidateCount) ? d.candidateCount : null;
+      if (selectedEntries.length > 0) {
+        const names = selectedEntries
+          .map((entry) => (typeof entry.name === "string" ? entry.name.trim() : ""))
+          .filter(Boolean);
+        const list = names.slice(0, 5).join(", ");
+        const suffix = names.length > 5 ? ` +${names.length - 5} more` : "";
+        return `Selected ${selectedEntries.length}${candidateCount != null ? `/${candidateCount}` : ""} lorebook entries${list ? `: ${list}${suffix}` : ""}`;
+      }
+      if (candidateCount != null) return `Selected 0/${candidateCount} lorebook entries`;
+      return "Selected 0 lorebook entries";
+    }
+
     case "html": {
       const text = d.text as string;
       return `🎨 ${text || "HTML formatting active"}`;

--- a/packages/client/src/hooks/use-throttled-stream-buffer.ts
+++ b/packages/client/src/hooks/use-throttled-stream-buffer.ts
@@ -3,8 +3,8 @@ import { useChatStore } from "../stores/chat.store";
 import { rafThrottle } from "../lib/raf-throttle";
 
 // Subscribe to the live stream buffer but re-render the caller at most once per
-// animation frame for the per-token *growth* that drives streaming lag, while
-// delivering resets immediately.
+// animation frame for bursty *growth* that drives streaming lag, while
+// delivering resets and typewriter-sized advances immediately.
 //
 // The cost #2878 is about is the per-token re-parse of the growing message, so
 // only monotonic growth (buffer getting longer, the same string plus the next
@@ -20,7 +20,10 @@ import { rafThrottle } from "../lib/raf-throttle";
 // The store's `streamBuffer` itself is still written on every token, so
 // token-exact consumers such as ChatArea's auto-scroll subscriber are
 // unaffected. The committed message is rendered from the React Query cache once
-// streaming ends, so a growth frame being up to ~16ms behind is never visible.
+// streaming ends, so burst growth being up to ~16ms behind is never visible.
+// The main typewriter path already rate-limits text before writing it here, so
+// one-character growth should not be coalesced again or letters visually land in
+// chunks.
 
 // True when `next` is the previous buffer plus more appended tokens (ongoing
 // growth) and should be throttled; false for resets, the first token after a
@@ -38,6 +41,10 @@ export function isOngoingStreamGrowth(lastSeen: string, next: string): boolean {
   return lastSeen.length > 0 && next.length > lastSeen.length && next.startsWith(lastSeen);
 }
 
+export function isTypewriterSizedStreamGrowth(lastSeen: string, next: string): boolean {
+  return isOngoingStreamGrowth(lastSeen, next) && next.length - lastSeen.length === 1;
+}
+
 export function useThrottledStreamBuffer(): string {
   const [value, setValue] = useState(() => useChatStore.getState().streamBuffer);
 
@@ -50,11 +57,14 @@ export function useThrottledStreamBuffer(): string {
       (state) => state.streamBuffer,
       (next) => {
         const growth = isOngoingStreamGrowth(lastSeen, next);
+        const typewriterSizedGrowth = isTypewriterSizedStreamGrowth(lastSeen, next);
         lastSeen = next;
         throttle.call(next);
         // Reset / clear / first token / shrink: deliver now, dropping any
         // pending growth frame so a stale value can't land after the reset.
-        if (!growth) throttle.flush();
+        // One-character typewriter ticks are already paced upstream, so deliver
+        // them immediately instead of coalescing multiple letters into a chunk.
+        if (!growth || typewriterSizedGrowth) throttle.flush();
       },
     );
     return () => {

--- a/packages/server/src/routes/professor-mari-workspace.routes.ts
+++ b/packages/server/src/routes/professor-mari-workspace.routes.ts
@@ -13,6 +13,17 @@ const promptSchema = z.object({
   chatId: z.string().min(1),
   message: z.string().min(1),
   connectionId: z.string().optional().nullable(),
+  attachments: z
+    .array(
+      z.object({
+        type: z.string().min(1),
+        data: z.string().min(1),
+        name: z.string().optional(),
+        filename: z.string().optional(),
+      }),
+    )
+    .optional()
+    .default([]),
 });
 
 const resetSchema = z.object({
@@ -123,6 +134,7 @@ export async function professorMariWorkspaceRoutes(app: FastifyInstance) {
         chatId: body.chatId,
         text: body.message,
         connectionId: body.connectionId ?? null,
+        attachments: body.attachments,
         onEvent: send,
       });
       send({ type: "done", data: { ok: true } });

--- a/packages/server/src/services/agents/knowledge-router.ts
+++ b/packages/server/src/services/agents/knowledge-router.ts
@@ -274,7 +274,16 @@ export async function executeKnowledgeRouter(
       agentId: config.id,
       agentType: config.type,
       type: "context_injection",
-      data: { text: "" },
+      data: {
+        text: "",
+        candidateCount: 0,
+        totalEntryCount: 0,
+        selectedEntryIds: [],
+        selectedEntries: [],
+        returnedEntryIds: [],
+        unknownEntryIds: [],
+        catalogTruncated: false,
+      },
       tokensUsed: 0,
       durationMs: Date.now() - startTime,
       success: true,
@@ -293,7 +302,8 @@ export async function executeKnowledgeRouter(
   // truncation is order-preserving (matches `listEntriesByLorebooks` order).
   const candidates =
     routerEntries.length > MAX_ROUTER_CANDIDATES ? routerEntries.slice(0, MAX_ROUTER_CANDIDATES) : routerEntries;
-  if (routerEntries.length > MAX_ROUTER_CANDIDATES) {
+  const catalogTruncated = routerEntries.length > MAX_ROUTER_CANDIDATES;
+  if (catalogTruncated) {
     logger.warn(
       "[knowledge-router] catalog truncated to %d/%d entries (MAX_ROUTER_CANDIDATES)",
       candidates.length,
@@ -337,13 +347,24 @@ export async function executeKnowledgeRouter(
   const selectedEntries = dedupedIds
     .map((id) => entriesById.get(id))
     .filter((entry): entry is LorebookEntry => entry !== undefined);
+  const unknownEntryIds = dedupedIds.filter((id) => !entriesById.has(id));
+  const routerData = {
+    candidateCount: candidates.length,
+    totalEntryCount: entries.length,
+    routedEntryCount: routerEntries.length,
+    selectedEntryIds: selectedEntries.map((entry) => entry.id),
+    selectedEntries: selectedEntries.map((entry) => ({ id: entry.id, name: entry.name })),
+    returnedEntryIds: selectedIds,
+    unknownEntryIds,
+    catalogTruncated,
+  };
 
   if (selectedEntries.length === 0) {
     logger.debug("[knowledge-router] no entries selected from %d candidates", candidates.length);
     return {
       ...result,
       type: "context_injection",
-      data: { text: "" },
+      data: { text: "", ...routerData },
     };
   }
 
@@ -361,6 +382,6 @@ export async function executeKnowledgeRouter(
   return {
     ...result,
     type: "context_injection",
-    data: { text: injectionText },
+    data: { text: injectionText, ...routerData },
   };
 }

--- a/packages/server/src/services/conversation/awareness.service.ts
+++ b/packages/server/src/services/conversation/awareness.service.ts
@@ -110,6 +110,24 @@ interface MessageRow {
   characterId: string | null;
   content: string;
   createdAt: string;
+  extra?: unknown;
+}
+
+function parseMessageExtra(extra: unknown): Record<string, unknown> {
+  if (!extra) return {};
+  if (typeof extra === "string") {
+    try {
+      const parsed = JSON.parse(extra) as unknown;
+      return parsed && typeof parsed === "object" && !Array.isArray(parsed) ? (parsed as Record<string, unknown>) : {};
+    } catch {
+      return {};
+    }
+  }
+  return typeof extra === "object" && !Array.isArray(extra) ? (extra as Record<string, unknown>) : {};
+}
+
+function isMessageHiddenFromAI(message: { extra?: unknown }): boolean {
+  return parseMessageExtra(message.extra).hiddenFromAI === true;
 }
 
 /**
@@ -236,11 +254,12 @@ export async function buildAwarenessBlock(
         characterId: messages.characterId,
         content: messages.content,
         createdAt: messages.createdAt,
+        extra: messages.extra,
       })
       .from(messages)
       .where(eq(messages.chatId, chat.id))
       .orderBy(messages.createdAt)) as MessageRow[];
-    const filteredRows = rows.filter((row) => isWithinRequestedWindow(row.createdAt));
+    const filteredRows = rows.filter((row) => !isMessageHiddenFromAI(row) && isWithinRequestedWindow(row.createdAt));
 
     if (filteredRows.length > 0) {
       chatMessages.set(chat.id, {

--- a/packages/server/src/services/professor-mari/workspace-agent.service.ts
+++ b/packages/server/src/services/professor-mari/workspace-agent.service.ts
@@ -67,6 +67,12 @@ type WorkspaceConnection = Pick<
   | "cachingAtDepth"
 > & { provider: string; isLocalSidecar?: boolean };
 type PromptEventSink = (event: MariWorkspacePromptEvent) => void;
+type ProfessorMariPromptAttachment = {
+  type: string;
+  data: string;
+  name?: string;
+  filename?: string;
+};
 type WorkspaceCommandCall = {
   id: string;
   name: MariWorkspaceToolName;
@@ -482,6 +488,36 @@ function normalizeMariMaxTokens(value: unknown): number | undefined {
 
 function parseExtra(value: unknown): Record<string, unknown> {
   return parseJsonObject(value) ?? {};
+}
+
+function normalizeProfessorMariImageAttachments(value: unknown): ProfessorMariPromptAttachment[] {
+  if (!Array.isArray(value)) return [];
+  return value
+    .map((attachment): ProfessorMariPromptAttachment | null => {
+      if (!attachment || typeof attachment !== "object") return null;
+      const record = attachment as Record<string, unknown>;
+      const type = typeof record.type === "string" ? record.type.trim() : "";
+      const data = typeof record.data === "string" ? record.data.trim() : "";
+      if (!type.startsWith("image/") || !data.startsWith("data:image/")) return null;
+      const name =
+        typeof record.name === "string" && record.name.trim()
+          ? record.name.trim()
+          : typeof record.filename === "string" && record.filename.trim()
+            ? record.filename.trim()
+            : "image";
+      return { type, data, name, filename: name };
+    })
+    .filter((attachment): attachment is ProfessorMariPromptAttachment => attachment !== null);
+}
+
+function professorMariPromptImages(extra: Record<string, unknown>): string[] {
+  return normalizeProfessorMariImageAttachments(extra.attachments).map((attachment) => attachment.data);
+}
+
+function appendProfessorMariAttachmentNames(content: string, attachments: ProfessorMariPromptAttachment[]): string {
+  if (attachments.length === 0) return content;
+  const names = attachments.map((attachment) => `[Attached image: ${attachment.name ?? "image"}]`).join("\n");
+  return `${content.trim() || "Please inspect the attached image."}\n\n${names}`;
 }
 
 type MariWorkspaceTraceTool = Extract<MariWorkspaceTraceItem, { type: "tool" }>["tool"];
@@ -1308,10 +1344,27 @@ export class ProfessorMariWorkspaceService {
     if (options?.clearHistory === true) await getMariDbService(this.app.db).clearHistory();
   }
 
-  async prompt(args: { chatId: string; text: string; connectionId?: string | null; onEvent: PromptEventSink }) {
+  async prompt(args: {
+    chatId: string;
+    text: string;
+    connectionId?: string | null;
+    attachments?: ProfessorMariPromptAttachment[];
+    onEvent: PromptEventSink;
+  }) {
     if (!this.enabled) throw new Error("Professor Mari workspace mode is disabled.");
     const chatStorage = createChatsStorage(this.app.db);
-    await chatStorage.createMessage({ chatId: args.chatId, role: "user", characterId: null, content: args.text });
+    const imageAttachments = normalizeProfessorMariImageAttachments(args.attachments);
+    const userMessage = await chatStorage.createMessage({
+      chatId: args.chatId,
+      role: "user",
+      characterId: null,
+      content: args.text,
+    });
+    if (imageAttachments.length > 0 && userMessage) {
+      const extra = { attachments: imageAttachments };
+      await chatStorage.updateMessageExtra(userMessage.id, extra);
+      await chatStorage.updateSwipeExtra(userMessage.id, 0, extra);
+    }
 
     const connection = await this.resolveConnection(args.connectionId);
     if (!connection) throw new Error("Set up a language connection before using Professor Mari workspace mode.");
@@ -1589,10 +1642,16 @@ export class ProfessorMariWorkspaceService {
       const content = typeof row.content === "string" ? row.content : String(row.content ?? "");
       if (!content.trim()) continue;
       const role = roleForMessage(row);
+      const imageAttachments = role === "user" ? normalizeProfessorMariImageAttachments(extra.attachments) : [];
+      const images = professorMariPromptImages(extra);
       messages.push({
         role,
-        content: role === "assistant" ? assistantHistoryContentFromVisibleText(content) : content,
+        content:
+          role === "assistant"
+            ? assistantHistoryContentFromVisibleText(content)
+            : appendProfessorMariAttachmentNames(content, imageAttachments),
         contextKind: "history",
+        ...(role === "user" && images.length > 0 ? { images } : {}),
       });
     }
     if (continuityPrompt) messages.push({ role: "system", content: continuityPrompt, contextKind: "injection" });


### PR DESCRIPTION
## Why

Smooth streaming in Roleplay regressed into chunked updates, and the current unclaimed issue sweep had several chat-facing bugs that were safe to address together before the next staging pull.

Closes #3198
Closes #3197
Closes #3194
Closes #3193
Closes #3190

## What Changed

- Restores immediate one-character stream buffer flushes so the Roleplay typewriter cadence stays smooth while still throttling bursty updates.
- Restores Roleplay composer focus after generation/agent work when the user had been typing there.
- Filters `hiddenFromAI` messages out of cross-chat awareness blocks.
- Adds a mobile `Tools` tab to Conversation composer media sheet for trigger response, translate draft, voice input, and quick replies below 640px.
- Adds image attachments to Professor Mari chat, including compressed upload prep, previews, persistence, and multimodal prompt injection.
- Surfaces Knowledge Router diagnostics in agent activity so zero-selection runs are visible instead of looking absent.

## Validation

- [ ] Manually verify Roleplay streaming appears letter-smooth with streaming speed set low.
- [ ] Manually verify Roleplay composer focus returns after generation starts/finishes when the textarea was focused.
- [ ] Manually verify hidden-from-AI messages do not appear in cross-chat awareness prompt context.
- [ ] Manually verify Conversation mobile composer below 640px exposes Tools actions.
- [ ] Manually verify Professor Mari can attach an image and a vision-capable model receives it.
- [ ] Manually verify Knowledge Router activity shows selected entry counts, including zero-selection runs.

Local proof run: `pnpm check` passed on July 4, 2026.

## Notes

#3187 is intentionally not included here. It is a Chromium-specific freeze/lag report and needs browser perf reproduction before a responsible fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added image attachments for Professor Mari chats, including upload, preview, removal, and sending with messages.
  * Added a mobile **Tools** tab with quick access to trigger responses, translation, voice input, and quick replies when available.
  * Improved visibility of knowledge-router activity with clearer selection details.

* **Bug Fixes**
  * Restores chat input focus after streaming or other busy states, reducing interrupted typing.
  * Hidden messages are now excluded from AI awareness when marked accordingly.
  * One-character stream updates now appear immediately for smoother live text rendering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->