### PR TITLE
[codex] Reduce pending generation animation load

### DIFF
--- a/packages/client/src/components/chat/ChatArea.tsx
+++ b/packages/client/src/components/chat/ChatArea.tsx
@@ -105,6 +105,7 @@ import { HomeProfessorMariChat } from "./HomeProfessorMariChat";
 import { HomeAchievements } from "./HomeAchievements";
 import { NewChatConnectionGate } from "./NewChatConnectionGate";
 import { ChatCommonOverlays, preloadChatSettingsDrawer, type ChatSettingsInitialSection } from "./ChatCommonOverlays";
+import { PendingTypingDots } from "./PendingTypingDots";
 import { CreatorNotesCssInjector, type CardCssMode } from "./CreatorNotesCssInjector";
 import type { ChatModeFilter } from "../../lib/card-css";
 import { ImagePromptReviewModal, type ImagePromptOverride, type ImagePromptReviewItem } from "../ui/ImagePromptReviewModal";
@@ -2877,9 +2878,7 @@ function TypingIndicator() {
   return (
     <div className="flex items-center gap-1 px-4 py-3">
       <div className="flex items-center gap-1 rounded-xl bg-[var(--secondary)] px-4 py-2.5">
-        <span className="h-2 w-2 animate-bounce rounded-full bg-[var(--muted-foreground)]/60 [animation-delay:0ms]" />
-        <span className="h-2 w-2 animate-bounce rounded-full bg-[var(--muted-foreground)]/60 [animation-delay:150ms]" />
-        <span className="h-2 w-2 animate-bounce rounded-full bg-[var(--muted-foreground)]/60 [animation-delay:300ms]" />
+        <PendingTypingDots dotClassName="bg-[var(--muted-foreground)]/60" />
       </div>
     </div>
   );

--- a/packages/client/src/components/chat/ChatMessage.tsx
+++ b/packages/client/src/components/chat/ChatMessage.tsx
@@ -11,6 +11,7 @@ import {
 } from "../../lib/utils";
 import { applyInlineMarkdown, renderMarkdownBlocks, applyInlineMarkdownHTML } from "../../lib/markdown";
 import { normalizeCardAssetImageSyntax, resolveCardAssetUrl } from "../../lib/card-asset-links";
+import { PendingTypingDots } from "./PendingTypingDots";
 import {
   User,
   Bot,
@@ -1757,11 +1758,7 @@ export const ChatMessage = memo(function ChatMessage({
         style={messageTextStyle}
       >
         {isStreaming && !message.content ? (
-          <div className="mari-message-typing flex items-center gap-1 py-0.5">
-            <span className="h-2 w-2 animate-bounce rounded-full bg-blue-400/60 [animation-delay:0ms]" />
-            <span className="h-2 w-2 animate-bounce rounded-full bg-blue-400/60 [animation-delay:150ms]" />
-            <span className="h-2 w-2 animate-bounce rounded-full bg-blue-400/60 [animation-delay:300ms]" />
-          </div>
+          <PendingTypingDots className="mari-message-typing py-0.5" dotClassName="bg-blue-400/60" />
         ) : (
           <>
             {renderedContent}
@@ -2602,11 +2599,10 @@ export const ChatMessage = memo(function ChatMessage({
                   style={messageTextStyle}
                 >
                   {isStreaming && !message.content ? (
-                    <div className="mari-message-typing flex items-center gap-1 py-0.5">
-                      <span className="h-2 w-2 animate-bounce rounded-full bg-[var(--muted-foreground)]/60 [animation-delay:0ms]" />
-                      <span className="h-2 w-2 animate-bounce rounded-full bg-[var(--muted-foreground)]/60 [animation-delay:150ms]" />
-                      <span className="h-2 w-2 animate-bounce rounded-full bg-[var(--muted-foreground)]/60 [animation-delay:300ms]" />
-                    </div>
+                    <PendingTypingDots
+                      className="mari-message-typing py-0.5"
+                      dotClassName="bg-[var(--muted-foreground)]/60"
+                    />
                   ) : (
                     <>
                       {renderedContent}

--- a/packages/client/src/components/chat/ConversationMessageBubble.tsx
+++ b/packages/client/src/components/chat/ConversationMessageBubble.tsx
@@ -4,6 +4,7 @@
 import { User } from "lucide-react";
 import { normalizeTextForMatch } from "@marinara-engine/shared";
 import { cn } from "../../lib/utils";
+import { PendingTypingDots } from "./PendingTypingDots";
 import {
   HiddenFromAIConversationSummary,
   MessageContent,
@@ -199,11 +200,7 @@ export function ConversationMessageBubble({ ctx }: { ctx: MessageRenderContext }
                       onImageOpen={(url) => onImageOpen(url)}
                     />
                   )}
-                  <div className="flex items-center gap-1" aria-label="Still typing">
-                    <span className="h-2 w-2 animate-bounce rounded-full bg-[var(--muted-foreground)]/60 [animation-delay:0ms]" />
-                    <span className="h-2 w-2 animate-bounce rounded-full bg-[var(--muted-foreground)]/60 [animation-delay:150ms]" />
-                    <span className="h-2 w-2 animate-bounce rounded-full bg-[var(--muted-foreground)]/60 [animation-delay:300ms]" />
-                  </div>
+                  <PendingTypingDots label="Still typing" dotClassName="bg-[var(--muted-foreground)]/60" />
                 </div>
               ) : groupedSegments && !isUser ? (
                 /* Multi-speaker content inside a bubble */

--- a/packages/client/src/components/chat/ConversationMessageLine.tsx
+++ b/packages/client/src/components/chat/ConversationMessageLine.tsx
@@ -3,6 +3,7 @@
 // ──────────────────────────────────────────────
 import { User } from "lucide-react";
 import { cn } from "../../lib/utils";
+import { PendingTypingDots } from "./PendingTypingDots";
 import {
   HiddenFromAIConversationSummary,
   MessageContent,
@@ -147,11 +148,7 @@ export function ConversationMessageLine({ ctx }: { ctx: MessageRenderContext }) 
             style={messageTextStyle}
           >
             {isStreaming && !renderedContent ? (
-              <div className="flex items-center gap-1">
-                <span className="h-2 w-2 animate-bounce rounded-full bg-[var(--muted-foreground)]/60 [animation-delay:0ms]" />
-                <span className="h-2 w-2 animate-bounce rounded-full bg-[var(--muted-foreground)]/60 [animation-delay:150ms]" />
-                <span className="h-2 w-2 animate-bounce rounded-full bg-[var(--muted-foreground)]/60 [animation-delay:300ms]" />
-              </div>
+              <PendingTypingDots dotClassName="bg-[var(--muted-foreground)]/60" />
             ) : (
               <>
                 {renderedContentParts ? (

--- a/packages/client/src/components/chat/ConversationView.tsx
+++ b/packages/client/src/components/chat/ConversationView.tsx
@@ -26,6 +26,7 @@ import { ActiveLorebookEntriesButton } from "./ActiveLorebookEntriesButton";
 import { ChatToolbarButton, ChatToolbarMenu } from "./ChatToolbarControls";
 import { groupConsecutiveSegments, parseNamePrefixFormat, parseSpeakerTags } from "./ConversationMessageShared";
 import { ConversationPresenceCard } from "./ConversationPresenceCard";
+import { PendingTypingDots } from "./PendingTypingDots";
 import { TranscriptWindowControls } from "./TranscriptWindowControls";
 import { PinnedImageOverlay } from "./PinnedImageOverlay";
 import { useChatStore } from "../../stores/chat.store";
@@ -1255,20 +1256,12 @@ export function ConversationView({
             data-typing-name={liveTypingName}
             data-card-css={typingCardCssId}
           >
-            <span className="mari-typing-dots flex gap-0.5">
-              <span
-                className="inline-block h-1.5 w-1.5 animate-bounce rounded-full bg-[var(--text-secondary)]"
-                style={{ animationDelay: "0ms" }}
-              />
-              <span
-                className="inline-block h-1.5 w-1.5 animate-bounce rounded-full bg-[var(--text-secondary)]"
-                style={{ animationDelay: "150ms" }}
-              />
-              <span
-                className="inline-block h-1.5 w-1.5 animate-bounce rounded-full bg-[var(--text-secondary)]"
-                style={{ animationDelay: "300ms" }}
-              />
-            </span>
+            <PendingTypingDots
+              className="mari-typing-dots gap-0.5"
+              dotClassName="bg-[var(--text-secondary)]"
+              label={`${liveTypingName} ${liveTypingVerb} typing`}
+              small
+            />
             <span className="mari-typing-text italic">
               {liveTypingName} {liveTypingVerb} typing...
             </span>

--- a/packages/client/src/components/chat/PendingTypingDots.tsx
+++ b/packages/client/src/components/chat/PendingTypingDots.tsx
@@ -1,0 +1,25 @@
+import { cn } from "../../lib/utils";
+
+type PendingTypingDotsProps = {
+  className?: string;
+  dotClassName?: string;
+  label?: string;
+  small?: boolean;
+};
+
+export function PendingTypingDots({
+  className,
+  dotClassName,
+  label = "Waiting for reply",
+  small = false,
+}: PendingTypingDotsProps) {
+  const sizeClass = small ? "h-1.5 w-1.5" : "h-2 w-2";
+
+  return (
+    <div className={cn("mari-pending-typing-dots flex items-center gap-1", className)} role="status" aria-label={label}>
+      <span className={cn(sizeClass, "rounded-full opacity-45", dotClassName)} />
+      <span className={cn(sizeClass, "rounded-full opacity-65", dotClassName)} />
+      <span className={cn(sizeClass, "rounded-full opacity-85", dotClassName)} />
+    </div>
+  );
+}


### PR DESCRIPTION
## Why

Chromium-based browsers can lag or freeze during the silent pending-generation window before any assistant text arrives. Issue #3187 points at the animated waiting indicator as the active UI during that period, with no repeated render warnings.

Closes #3187

## What Changed

- Added a shared static `PendingTypingDots` indicator for no-content pending replies.
- Replaced the continuously bouncing pending dots in Roleplay and Conversation message renderers.
- Replaced the classic Conversation typing indicator dots and the unused fallback typing indicator so future reuse stays low-motion.
- Kept the animated streaming cursor after text exists, so active typewriter feedback remains intact.

## Validation

- [ ] Manually verify a slow remote provider in Brave/Edge no longer makes video/audio playback or other tabs lag during the pre-token waiting period.
- [ ] Manually verify pending replies still show a visible waiting indicator in Roleplay mode.
- [ ] Manually verify pending replies still show a visible waiting indicator in Conversation bubble and classic layouts.
- [ ] Manually verify text streaming still shows the live cursor once assistant content begins.

Local proof run: `pnpm check` passed on July 4, 2026.

## Notes

This targets the cheapest likely client-side cause from #3187: continuous pending-state animation before content arrives. It does not claim to prove every Chromium compositor or GPU-driver-specific freeze is eliminated without manual browser reproduction.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a shared typing indicator with consistent three-dot animation across chat and conversation screens.
  * Improved support for different display sizes and styling so pending messages match each chat view more closely.
* **Bug Fixes**
  * Replaced multiple inconsistent inline typing indicators with a single reusable version for a more uniform experience.
  * Kept the “still typing” status clear and accessible while messages are loading.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->