### PR TITLE
[codex] Fix lite Docker runtime dependencies

### DIFF
--- a/Dockerfile.lite
+++ b/Dockerfile.lite
@@ -77,7 +77,9 @@ COPY packages/client/package.json packages/client/
 RUN --mount=type=cache,target=/app/.pnpm-store \
     pnpm install --frozen-lockfile --prod --ignore-scripts && \
     pnpm rebuild sharp && \
-    rm -rf node_modules/.pnpm/onnxruntime-node@* \
+    rm -rf .pnpm/onnxruntime-node@* \
+           .pnpm/onnxruntime-web@* \
+           node_modules/.pnpm/onnxruntime-node@* \
            node_modules/.pnpm/onnxruntime-web@* \
            packages/server/node_modules/onnxruntime-node \
            packages/server/node_modules/onnxruntime-web
@@ -85,6 +87,7 @@ RUN --mount=type=cache,target=/app/.pnpm-store \
 # Archive node_modules preserving pnpm symlinks — Docker COPY
 # dereferences them which would break module resolution.
 RUN tar cf /tmp/node_modules.tar \
+    .pnpm \
     node_modules \
     packages/shared/node_modules \
     packages/server/node_modules 2>/dev/null; true
@@ -108,6 +111,9 @@ COPY package.json pnpm-workspace.yaml ./
 COPY packages/shared/package.json packages/shared/
 COPY packages/server/package.json packages/server/
 COPY packages/client/package.json packages/client/
+
+# Fail the image build if pnpm's symlinked virtual store is incomplete.
+RUN node -e "for (const dep of ['fastify', '@fastify/cors', 'sharp']) require.resolve(dep, { paths: ['/app/packages/server'] })"
 
 # Copy built artifacts from builder
 COPY --from=builder /app/packages/shared/dist packages/shared/dist


### PR DESCRIPTION
## Linked issue

Closes #3201

## Why this change

The lite Docker image installed production dependencies with pnpm's repo-local virtual store (`virtual-store-dir=.pnpm`), but the runtime dependency archive only copied `node_modules` and package-level `node_modules` folders. Server package symlinks such as `packages/server/node_modules/fastify -> ../../../.pnpm/...` became dangling links in the final image, so the container crashed at startup with `ERR_MODULE_NOT_FOUND` for `fastify`.

## What changed

- Include the root `.pnpm` virtual store in the lite runtime dependency archive so pnpm symlinks resolve inside the final image.
- Prune onnxruntime packages from the actual `.pnpm` virtual store as well as the legacy `node_modules/.pnpm` path.
- Add a Dockerfile build-time module-resolution smoke check for lite runtime dependencies (`fastify`, `@fastify/cors`, `sharp`) so broken symlink archives fail during image build instead of after release.

## Validation

- [ ] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed `CONTRIBUTING.md`

### Manual verification notes

- Reproduced the failure on current `staging` with `docker build -f Dockerfile.lite -t marinara-lite-3201 .` followed by `docker run`; startup exited with `ERR_MODULE_NOT_FOUND: Cannot find package 'fastify' imported from /app/packages/server/dist/app.js`.
- Inspected the broken image and confirmed `packages/server/node_modules/fastify` pointed at `../../../.pnpm/...` while `/app/.pnpm` was missing from the runtime image.
- Built the fixed lite image with `docker build -f Dockerfile.lite -t marinara-lite-3201-fixed --progress=plain .`; the new dependency smoke check passed.
- Started the fixed image with `docker run -d -p 127.0.0.1::7860 -e AUTO_CREATE_DEFAULT_CONNECTION=false -e ALLOW_UNAUTHENTICATED_PRIVATE_NETWORK=true marinara-lite-3201-fixed` and confirmed `/` served the app over HTTP.
- Ran `pnpm check` locally.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Version/release files updated (only if this PR includes a version bump)

## UI evidence (if applicable)

Not applicable; Docker runtime fix only.
