### PR TITLE
[codex] Support Professor Mari file attachments

### DIFF
--- a/packages/client/src/components/chat/HomeProfessorMariChat.tsx
+++ b/packages/client/src/components/chat/HomeProfessorMariChat.tsx
@@ -28,6 +28,7 @@ import {
   Loader2,
   MessageCircle,
   Palette,
+  Paperclip,
   Plus,
   RefreshCw,
   Save,
@@ -81,9 +82,9 @@ const MARI_CHIBI_URL = "/sprites/mari/chibi-professor-mari.png";
 const MARI_CONNECTION_STORAGE_KEY = "marinara:home-professor-mari-connection-id";
 const PROFESSOR_MARI_ERROR_TOAST_DURATION_MS = 120_000;
 const PROFESSOR_MARI_NO_CONNECTION_TOAST =
-  "You haven't set up a connection yet! Click the chains icon on the left side of the input box to select one.";
+  "You haven't set up a connection yet! Click the link icon beside the paperclip to select one.";
 const MARI_WELCOME =
-  "Howdy, welcome to Marinara Engine!\n\nFeeling a little lost? It is not a skill issue yet, I am here to help! Ask me about the app, your setup, or what to do next.\n\nNeed something made or changed? I can create character cards, personas, lorebooks, chats, and presets, and I can make reversible local workspace changes with a Keep/Restore review. Select a connection via the chains icon on the left side of the input box first and then ask away!";
+  "Howdy, welcome to Marinara Engine!\n\nFeeling a little lost? It is not a skill issue yet, I am here to help! Ask me about the app, your setup, or what to do next.\n\nNeed something made or changed? I can create character cards, personas, lorebooks, chats, and presets, and I can make reversible local workspace changes with a Keep/Restore review. Select a connection via the link icon beside the paperclip first and then ask away!";
 const NEW_SKILL_CONTENT = `# Custom Professor Mari Skill
 
 Use this skill when the request matches a workflow you want Professor Mari to follow.
@@ -95,12 +96,29 @@ Use this skill when the request matches a workflow you want Professor Mari to fo
 - Add any checks or evidence she should collect before saying the work is done.
 `;
 
-type ProfessorMariImageAttachment = {
+type ProfessorMariAttachment = {
   type: string;
   data: string;
   name: string;
+  filename?: string;
   resized?: boolean;
 };
+const PROFESSOR_MARI_ATTACHMENT_ACCEPT =
+  "image/*,application/pdf,.pdf,.txt,.md,.markdown,.json,.jsonl,.csv,.log,.xml,.yaml,.yml";
+const PROFESSOR_MARI_ATTACHMENT_MAX_BYTES = 20 * 1024 * 1024;
+const PROFESSOR_MARI_TEXT_ATTACHMENT_EXTENSIONS = new Set([
+  "csv",
+  "json",
+  "jsonl",
+  "log",
+  "markdown",
+  "md",
+  "txt",
+  "xml",
+  "yaml",
+  "yml",
+]);
+const PROFESSOR_MARI_PDF_ATTACHMENT_MIME_TYPE = "application/pdf";
 const PROFESSOR_MARI_PANE_TRANSITION = { duration: 0.24, ease: [0.16, 1, 0.3, 1] } as const;
 const PROFESSOR_MARI_FLOATING_EDGE_GAP = 12;
 const PROFESSOR_MARI_FLOATING_MOBILE_TOP_GAP = 64;
@@ -169,6 +187,53 @@ function shouldExpandHomeFaqByDefault() {
   return isProfessorMariDesktopViewport();
 }
 
+function getProfessorMariFileExtension(fileName: string): string {
+  const match = fileName.toLowerCase().match(/\.([a-z0-9]+)$/);
+  return match?.[1] ?? "";
+}
+
+function inferProfessorMariAttachmentType(file: File): string {
+  const extension = getProfessorMariFileExtension(file.name);
+  if (extension === "pdf") return PROFESSOR_MARI_PDF_ATTACHMENT_MIME_TYPE;
+  if (file.type) return file.type;
+  if (extension === "json" || extension === "jsonl") return "application/json";
+  if (extension === "csv") return "text/csv";
+  if (extension === "md" || extension === "markdown") return "text/markdown";
+  if (extension === "xml") return "application/xml";
+  if (extension === "yaml" || extension === "yml") return "application/yaml";
+  if (extension === "txt" || extension === "log") return "text/plain";
+  return "application/octet-stream";
+}
+
+function isSupportedProfessorMariAttachment(file: File): boolean {
+  if (file.type.startsWith("image/")) return true;
+  if (file.type.startsWith("text/")) return true;
+  const type = inferProfessorMariAttachmentType(file);
+  if (type === PROFESSOR_MARI_PDF_ATTACHMENT_MIME_TYPE) return true;
+  if (
+    type === "application/json" ||
+    type === "application/xml" ||
+    type === "application/yaml" ||
+    type === "application/x-yaml"
+  ) {
+    return true;
+  }
+  return PROFESSOR_MARI_TEXT_ATTACHMENT_EXTENSIONS.has(getProfessorMariFileExtension(file.name));
+}
+
+function readProfessorMariFileAsDataUrl(file: Blob): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => resolve(reader.result as string);
+    reader.onerror = () => reject(reader.error ?? new Error("Failed to read file"));
+    reader.readAsDataURL(file);
+  });
+}
+
+function isProfessorMariImageAttachment(attachment: ProfessorMariAttachment): boolean {
+  return attachment.type.startsWith("image/") && attachment.data.startsWith("data:image/");
+}
+
 function describeProfessorMariError(error: unknown) {
   const message = getPrivilegedActionErrorMessage(error, "").trim();
   if (message) {
@@ -193,23 +258,28 @@ function toMessageExtra(message: Message): Message["extra"] {
   return message.extra;
 }
 
-function getProfessorMariImageAttachments(message: Message): ProfessorMariImageAttachment[] {
+function getProfessorMariAttachments(message: Message): ProfessorMariAttachment[] {
   const extra = toMessageExtra(message);
   const rawAttachments =
     extra && typeof extra === "object" && "attachments" in extra
       ? (extra as { attachments?: unknown }).attachments
       : undefined;
   if (!Array.isArray(rawAttachments)) return [];
-  return rawAttachments.filter((attachment): attachment is ProfessorMariImageAttachment => {
-    if (!attachment || typeof attachment !== "object") return false;
-    const candidate = attachment as Partial<ProfessorMariImageAttachment>;
-    return (
-      typeof candidate.type === "string" &&
-      candidate.type.startsWith("image/") &&
-      typeof candidate.data === "string" &&
-      candidate.data.startsWith("data:image/") &&
-      typeof candidate.name === "string"
-    );
+  return rawAttachments.flatMap((attachment): ProfessorMariAttachment[] => {
+    if (!attachment || typeof attachment !== "object") return [];
+    const candidate = attachment as Partial<ProfessorMariAttachment>;
+    if (typeof candidate.type !== "string" || typeof candidate.data !== "string") return [];
+    if (!candidate.data.startsWith("data:")) return [];
+    const filename =
+      typeof candidate.filename === "string" && candidate.filename.trim() ? candidate.filename.trim() : undefined;
+    const name =
+      typeof candidate.name === "string" && candidate.name.trim()
+        ? candidate.name.trim()
+        : (filename ?? "attachment");
+    const normalized: ProfessorMariAttachment = { type: candidate.type, data: candidate.data, name };
+    if (filename) normalized.filename = filename;
+    if (typeof candidate.resized === "boolean") normalized.resized = candidate.resized;
+    return [normalized];
   });
 }
 
@@ -246,7 +316,7 @@ function createWelcomeMessage(chatId: string | null): Message {
 function createLocalUserMessage(
   chatId: string,
   content: string,
-  attachments: ProfessorMariImageAttachment[] = [],
+  attachments: ProfessorMariAttachment[] = [],
 ): Message {
   return {
     id: `__professor_mari_local_${Date.now()}`,
@@ -1030,27 +1100,95 @@ function CompactMarkdown({ content, streaming }: { content: string; streaming?: 
   );
 }
 
-function ProfessorMariAttachedImages({ attachments }: { attachments: ProfessorMariImageAttachment[] }) {
+function ProfessorMariAttachedFiles({ attachments }: { attachments: ProfessorMariAttachment[] }) {
   if (attachments.length === 0) return null;
   return (
     <div className="mt-2 flex flex-wrap gap-2">
+      {attachments.map((attachment, index) =>
+        isProfessorMariImageAttachment(attachment) ? (
+          <a
+            key={`${attachment.name}-${index}`}
+            href={attachment.data}
+            target="_blank"
+            rel="noreferrer"
+            className="block overflow-hidden rounded-lg border border-[var(--border)] bg-[var(--background)]/70"
+            title={attachment.name}
+          >
+            <img
+              src={attachment.data}
+              alt={attachment.name || "Attached image"}
+              className="h-24 w-24 object-cover sm:h-28 sm:w-28"
+              draggable={false}
+            />
+          </a>
+        ) : (
+          <a
+            key={`${attachment.name}-${index}`}
+            href={attachment.data}
+            target="_blank"
+            rel="noreferrer"
+            download={attachment.name}
+            className="flex max-w-[14rem] items-center gap-2 rounded-lg border border-[var(--border)] bg-[var(--background)]/70 px-2.5 py-2 text-xs text-[var(--muted-foreground)] transition-colors hover:bg-[var(--accent)] hover:text-[var(--foreground)]"
+            title={attachment.name}
+          >
+            <FileText size="0.875rem" className="shrink-0 text-[var(--primary)]" />
+            <span className="min-w-0 truncate">{attachment.name}</span>
+          </a>
+        ),
+      )}
+    </div>
+  );
+}
+
+function ProfessorMariAttachmentPreviews({
+  attachments,
+  isReading,
+  onRemove,
+}: {
+  attachments: ProfessorMariAttachment[];
+  isReading: boolean;
+  onRemove: (index: number) => void;
+}) {
+  if (attachments.length === 0 && !isReading) return null;
+  return (
+    <div className="mb-2 flex flex-wrap gap-2">
       {attachments.map((attachment, index) => (
-        <a
+        <div
           key={`${attachment.name}-${index}`}
-          href={attachment.data}
-          target="_blank"
-          rel="noreferrer"
-          className="block overflow-hidden rounded-lg border border-[var(--border)] bg-[var(--background)]/70"
-          title={attachment.name}
+          className="group relative flex max-w-[9rem] items-center gap-2 rounded-lg border border-[var(--border)] bg-[var(--background)]/70 p-1.5 pr-7"
         >
-          <img
-            src={attachment.data}
-            alt={attachment.name || "Attached image"}
-            className="h-24 w-24 object-cover sm:h-28 sm:w-28"
-            draggable={false}
-          />
-        </a>
+          {isProfessorMariImageAttachment(attachment) ? (
+            <img
+              src={attachment.data}
+              alt={attachment.name}
+              className="h-9 w-9 shrink-0 rounded-md object-cover"
+              draggable={false}
+            />
+          ) : (
+            <span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-md bg-foreground/10 text-[var(--primary)]">
+              <FileText size="1rem" />
+            </span>
+          )}
+          <span className="min-w-0 flex-1 truncate text-[0.6875rem] text-[var(--muted-foreground)]">
+            {attachment.name}
+          </span>
+          <button
+            type="button"
+            onClick={() => onRemove(index)}
+            className="absolute right-1.5 top-1.5 rounded-md p-0.5 text-[var(--muted-foreground)] transition-colors hover:bg-[var(--accent)] hover:text-[var(--foreground)]"
+            aria-label={`Remove ${attachment.name}`}
+            title="Remove file"
+          >
+            <X size="0.7rem" />
+          </button>
+        </div>
       ))}
+      {isReading && (
+        <div className="flex min-h-12 items-center gap-2 rounded-lg border border-[var(--border)] bg-[var(--background)]/70 px-2 text-[0.6875rem] text-[var(--muted-foreground)]">
+          <Loader2 size="0.8rem" className="animate-spin" />
+          Reading file...
+        </div>
+      )}
     </div>
   );
 }
@@ -1256,7 +1394,7 @@ function WorkspaceTimelineList({
 
 function CompactMariMessage({ message, thinking }: { message: Message; thinking?: string | null }) {
   const content = message.content ?? "";
-  const imageAttachments = getProfessorMariImageAttachments(message);
+  const attachments = getProfessorMariAttachments(message);
 
   if (message.role === "user") {
     return (
@@ -1264,7 +1402,7 @@ function CompactMariMessage({ message, thinking }: { message: Message; thinking?
         marker={<span className="pt-0.5 text-[0.6875rem] font-semibold text-[var(--muted-foreground)]">You</span>}
       >
         <CompactMarkdown content={content} />
-        <ProfessorMariAttachedImages attachments={imageAttachments} />
+        <ProfessorMariAttachedFiles attachments={attachments} />
       </TranscriptRow>
     );
   }
@@ -1711,8 +1849,8 @@ export function HomeProfessorMariChat({
   const [chatId, setChatId] = useState<string | null>(null);
   const [messages, setMessages] = useState<Message[]>([]);
   const [draft, setDraft] = useState("");
-  const [imageAttachments, setImageAttachments] = useState<ProfessorMariImageAttachment[]>([]);
-  const [isReadingImages, setIsReadingImages] = useState(false);
+  const [attachments, setAttachments] = useState<ProfessorMariAttachment[]>([]);
+  const [isReadingAttachments, setIsReadingAttachments] = useState(false);
   const [selectedConnectionId, setSelectedConnectionId] = useState<string | null>(() => readStoredConnectionId());
   const [workspaceStatus, setWorkspaceStatus] = useState<MariWorkspaceStatus | null>(null);
   const [workspaceActive, setWorkspaceActive] = useState(false);
@@ -1751,7 +1889,7 @@ export function HomeProfessorMariChat({
   const connectionButtonRef = useRef<HTMLButtonElement>(null);
   const connectionMenuRef = useRef<HTMLDivElement>(null);
   const skillFileInputRef = useRef<HTMLInputElement>(null);
-  const imageInputRef = useRef<HTMLInputElement>(null);
+  const attachmentInputRef = useRef<HTMLInputElement>(null);
   const workspaceAbortRef = useRef<AbortController | null>(null);
   const handledWorkspaceRefreshIdsRef = useRef<Set<string>>(new Set());
   const workspaceStatusErrorToastShownRef = useRef(false);
@@ -1787,7 +1925,7 @@ export function HomeProfessorMariChat({
     selectedConnection ?? connectionOptions.find((connection) => connection.isDefault) ?? connectionOptions[0] ?? null;
   const effectiveConnectionId = effectiveConnection?.id ?? null;
   const isBusy = sending || hasActiveGeneration || workspaceActive;
-  const canSubmitMessage = (draft.trim().length > 0 || imageAttachments.length > 0) && !isReadingImages;
+  const canSubmitMessage = (draft.trim().length > 0 || attachments.length > 0) && !isReadingAttachments;
   const selectedSkill = useMemo(
     () => skills.find((skill) => skill.id === selectedSkillId) ?? null,
     [selectedSkillId, skills],
@@ -2492,17 +2630,41 @@ export function HomeProfessorMariChat({
     [chatHistory, chatId, effectiveConnectionId, ensureProfessorMariChat, loadChatHistory, loadMessages],
   );
 
-  const handleImageUpload = useCallback(async (files: FileList | null) => {
-    const imageFiles = Array.from(files ?? []).filter((file) => file.type.startsWith("image/"));
-    if (imageFiles.length === 0) {
-      if (files && files.length > 0) toast.error("Professor Mari only accepts image attachments here.");
-      return;
-    }
+  const handleAttachmentUpload = useCallback(async (files: FileList | null) => {
+    const acceptedFiles = Array.from(files ?? []).filter((file) => {
+      if (file.size > PROFESSOR_MARI_ATTACHMENT_MAX_BYTES) {
+        toast.error(`${file.name} is too large (max 20 MB).`);
+        return false;
+      }
+      if (!isSupportedProfessorMariAttachment(file)) {
+        toast.error(
+          `${file.name || "That file"} is not supported here. Attach images, PDFs, or text files like JSON, TXT, Markdown, or CSV.`,
+        );
+        return false;
+      }
+      return true;
+    });
+    if (acceptedFiles.length === 0) return;
 
-    setIsReadingImages(true);
+    setIsReadingAttachments(true);
+    const prepared: ProfessorMariAttachment[] = [];
     try {
-      const prepared = await Promise.all(imageFiles.map((file) => prepareImageAttachment(file, file.name)));
-      setImageAttachments((current) => [...current, ...prepared]);
+      for (const file of acceptedFiles) {
+        const displayName = file.name || "attached-file";
+        if (file.type.startsWith("image/")) {
+          prepared.push(await prepareImageAttachment(file, displayName));
+          continue;
+        }
+        prepared.push({
+          type: inferProfessorMariAttachmentType(file),
+          data: await readProfessorMariFileAsDataUrl(file),
+          name: displayName,
+        });
+      }
+
+      if (prepared.length > 0) {
+        setAttachments((current) => [...current, ...prepared]);
+      }
       const resizedCount = prepared.filter((attachment) => attachment.resized).length;
       if (resizedCount > 0) {
         toast.info(
@@ -2510,18 +2672,18 @@ export function HomeProfessorMariChat({
         );
       }
     } catch (error) {
-      console.error("[Professor Mari] Failed to prepare image attachment", error);
-      toast.error("Professor Mari could not attach that image.", {
-        description: error instanceof Error ? error.message : "The image could not be read.",
+      console.error("[Professor Mari] Failed to prepare attachment", error);
+      toast.error("Professor Mari could not attach that file.", {
+        description: error instanceof Error ? error.message : "The file could not be read.",
         duration: PROFESSOR_MARI_ERROR_TOAST_DURATION_MS,
       });
     } finally {
-      setIsReadingImages(false);
+      setIsReadingAttachments(false);
     }
   }, []);
 
   const sendWorkspaceMessage = useCallback(
-    async (chat: Chat, text: string, attachments: ProfessorMariImageAttachment[] = []) => {
+    async (chat: Chat, text: string, attachments: ProfessorMariAttachment[] = []) => {
       const controller = new AbortController();
       workspaceAbortRef.current = controller;
       setWorkspaceActive(true);
@@ -2617,9 +2779,9 @@ export function HomeProfessorMariChat({
 
   const handleSubmit = async () => {
     const text = draft.trim();
-    const submittedAttachments = imageAttachments;
-    const messageText = text || (submittedAttachments.length > 0 ? "Please inspect the attached image." : "");
-    if (!messageText || isBusy || isReadingImages) return;
+    const submittedAttachments = attachments;
+    const messageText = text || (submittedAttachments.length > 0 ? "Please inspect the attached file." : "");
+    if (!messageText || isBusy || isReadingAttachments) return;
 
     if (messageText === "/restart") {
       await runRestart();
@@ -2637,7 +2799,7 @@ export function HomeProfessorMariChat({
     try {
       const chat = await ensureProfessorMariChat(effectiveConnectionId);
       setDraft("");
-      setImageAttachments([]);
+      setAttachments([]);
       setMessages((current) => [...current, createLocalUserMessage(chat.id, messageText, submittedAttachments)]);
       trackAchievement.mutate("prof_mari_message_sent");
       const received = await sendWorkspaceMessage(chat, messageText, submittedAttachments);
@@ -2655,7 +2817,7 @@ export function HomeProfessorMariChat({
       }
     } catch (error) {
       setDraft(text);
-      setImageAttachments(submittedAttachments);
+      setAttachments(submittedAttachments);
       console.error("[Professor Mari] Failed to send", error);
       toast.error("Professor Mari could not answer right now.", {
         description: describeProfessorMariError(error),
@@ -2710,54 +2872,39 @@ export function HomeProfessorMariChat({
         }}
       >
         <input
-          ref={imageInputRef}
+          ref={attachmentInputRef}
           type="file"
-          accept="image/*"
+          accept={PROFESSOR_MARI_ATTACHMENT_ACCEPT}
           multiple
           className="hidden"
           onChange={(event: ChangeEvent<HTMLInputElement>) => {
-            void handleImageUpload(event.target.files);
+            void handleAttachmentUpload(event.target.files);
             event.target.value = "";
           }}
         />
-        {(imageAttachments.length > 0 || isReadingImages) && (
-          <div className="mb-2 flex flex-wrap gap-2">
-            {imageAttachments.map((attachment, index) => (
-              <div
-                key={`${attachment.name}-${index}`}
-                className="group relative flex max-w-[9rem] items-center gap-2 rounded-lg border border-[var(--border)] bg-[var(--background)]/70 p-1.5 pr-7"
-              >
-                <img
-                  src={attachment.data}
-                  alt={attachment.name}
-                  className="h-9 w-9 shrink-0 rounded-md object-cover"
-                  draggable={false}
-                />
-                <span className="min-w-0 flex-1 truncate text-[0.6875rem] text-[var(--muted-foreground)]">
-                  {attachment.name}
-                </span>
-                <button
-                  type="button"
-                  onClick={() =>
-                    setImageAttachments((current) => current.filter((_, itemIndex) => itemIndex !== index))
-                  }
-                  className="absolute right-1.5 top-1.5 rounded-md p-0.5 text-[var(--muted-foreground)] transition-colors hover:bg-[var(--accent)] hover:text-[var(--foreground)]"
-                  aria-label={`Remove ${attachment.name}`}
-                  title="Remove image"
-                >
-                  <X size="0.7rem" />
-                </button>
-              </div>
-            ))}
-            {isReadingImages && (
-              <div className="flex min-h-12 items-center gap-2 rounded-lg border border-[var(--border)] bg-[var(--background)]/70 px-2 text-[0.6875rem] text-[var(--muted-foreground)]">
-                <Loader2 size="0.8rem" className="animate-spin" />
-                Reading image...
-              </div>
-            )}
-          </div>
-        )}
+        <ProfessorMariAttachmentPreviews
+          attachments={attachments}
+          isReading={isReadingAttachments}
+          onRemove={(index) => setAttachments((current) => current.filter((_, itemIndex) => itemIndex !== index))}
+        />
         <div className="relative flex items-center gap-2 rounded-xl border border-[var(--border)] bg-[var(--card)] px-2 py-1.5 shadow-inner shadow-black/10 focus-within:border-[var(--primary)]/50">
+          <button
+            type="button"
+            onClick={() => attachmentInputRef.current?.click()}
+            disabled={isBusy || isReadingAttachments}
+            className={cn(
+              "flex h-8 w-8 shrink-0 items-center justify-center rounded-xl transition-all",
+              attachments.length > 0
+                ? "bg-foreground/10 text-foreground/75"
+                : "text-foreground/40 hover:bg-foreground/10 hover:text-foreground/70",
+              (isBusy || isReadingAttachments) && "cursor-not-allowed opacity-40",
+            )}
+            title="Attach files"
+            aria-label="Attach files"
+          >
+            {isReadingAttachments ? <Loader2 size="1rem" className="animate-spin" /> : <Paperclip size="1rem" />}
+          </button>
+
           <button
             ref={connectionButtonRef}
             type="button"
@@ -2776,7 +2923,7 @@ export function HomeProfessorMariChat({
           {connectionMenuOpen && (
             <div
               ref={connectionMenuRef}
-              className="absolute bottom-full left-2 z-20 mb-2 flex max-h-72 min-w-[15rem] max-w-[20rem] flex-col overflow-hidden rounded-xl border border-[var(--border)] bg-[var(--card)] text-left shadow-2xl"
+              className="absolute bottom-full left-12 z-20 mb-2 flex max-h-72 min-w-[15rem] max-w-[20rem] flex-col overflow-hidden rounded-xl border border-[var(--border)] bg-[var(--card)] text-left shadow-2xl"
             >
               <div className="border-b border-[var(--border)] px-3 py-2 text-[0.6875rem] font-semibold text-[var(--foreground)]">
                 Connections
@@ -2823,23 +2970,6 @@ export function HomeProfessorMariChat({
               </div>
             </div>
           )}
-
-          <button
-            type="button"
-            onClick={() => imageInputRef.current?.click()}
-            disabled={isBusy || isReadingImages}
-            className={cn(
-              "flex h-8 w-8 shrink-0 items-center justify-center rounded-xl transition-all",
-              imageAttachments.length > 0
-                ? "bg-foreground/10 text-foreground/75"
-                : "text-foreground/40 hover:bg-foreground/10 hover:text-foreground/70",
-              (isBusy || isReadingImages) && "cursor-not-allowed opacity-40",
-            )}
-            title="Attach images"
-            aria-label="Attach images"
-          >
-            {isReadingImages ? <Loader2 size="1rem" className="animate-spin" /> : <ImageIcon size="1rem" />}
-          </button>
 
           <textarea
             value={draft}
@@ -3323,56 +3453,45 @@ export function HomeProfessorMariChat({
                         }}
                       >
                         <input
-                          ref={imageInputRef}
+                          ref={attachmentInputRef}
                           type="file"
-                          accept="image/*"
+                          accept={PROFESSOR_MARI_ATTACHMENT_ACCEPT}
                           multiple
                           className="hidden"
                           onChange={(event: ChangeEvent<HTMLInputElement>) => {
-                            void handleImageUpload(event.target.files);
+                            void handleAttachmentUpload(event.target.files);
                             event.target.value = "";
                           }}
                         />
-                        {(imageAttachments.length > 0 || isReadingImages) && (
-                          <div className="mb-2 flex flex-wrap gap-2">
-                            {imageAttachments.map((attachment, index) => (
-                              <div
-                                key={`${attachment.name}-${index}`}
-                                className="group relative flex max-w-[9rem] items-center gap-2 rounded-lg border border-[var(--border)] bg-[var(--background)]/70 p-1.5 pr-7"
-                              >
-                                <img
-                                  src={attachment.data}
-                                  alt={attachment.name}
-                                  className="h-9 w-9 shrink-0 rounded-md object-cover"
-                                  draggable={false}
-                                />
-                                <span className="min-w-0 flex-1 truncate text-[0.6875rem] text-[var(--muted-foreground)]">
-                                  {attachment.name}
-                                </span>
-                                <button
-                                  type="button"
-                                  onClick={() =>
-                                    setImageAttachments((current) =>
-                                      current.filter((_, itemIndex) => itemIndex !== index),
-                                    )
-                                  }
-                                  className="absolute right-1.5 top-1.5 rounded-md p-0.5 text-[var(--muted-foreground)] transition-colors hover:bg-[var(--accent)] hover:text-[var(--foreground)]"
-                                  aria-label={`Remove ${attachment.name}`}
-                                  title="Remove image"
-                                >
-                                  <X size="0.7rem" />
-                                </button>
-                              </div>
-                            ))}
-                            {isReadingImages && (
-                              <div className="flex min-h-12 items-center gap-2 rounded-lg border border-[var(--border)] bg-[var(--background)]/70 px-2 text-[0.6875rem] text-[var(--muted-foreground)]">
-                                <Loader2 size="0.8rem" className="animate-spin" />
-                                Reading image...
-                              </div>
-                            )}
-                          </div>
-                        )}
+                        <ProfessorMariAttachmentPreviews
+                          attachments={attachments}
+                          isReading={isReadingAttachments}
+                          onRemove={(index) =>
+                            setAttachments((current) => current.filter((_, itemIndex) => itemIndex !== index))
+                          }
+                        />
                         <div className="relative flex items-center gap-2 rounded-xl border border-[var(--border)] bg-[var(--card)] px-2 py-1.5 shadow-inner shadow-black/10 focus-within:border-[var(--primary)]/50">
+                          <button
+                            type="button"
+                            onClick={() => attachmentInputRef.current?.click()}
+                            disabled={isBusy || isReadingAttachments}
+                            className={cn(
+                              "flex h-8 w-8 shrink-0 items-center justify-center rounded-xl transition-all",
+                              attachments.length > 0
+                                ? "bg-foreground/10 text-foreground/75"
+                                : "text-foreground/40 hover:bg-foreground/10 hover:text-foreground/70",
+                              (isBusy || isReadingAttachments) && "cursor-not-allowed opacity-40",
+                            )}
+                            title="Attach files"
+                            aria-label="Attach files"
+                          >
+                            {isReadingAttachments ? (
+                              <Loader2 size="1rem" className="animate-spin" />
+                            ) : (
+                              <Paperclip size="1rem" />
+                            )}
+                          </button>
+
                           <button
                             ref={connectionButtonRef}
                             type="button"
@@ -3395,7 +3514,7 @@ export function HomeProfessorMariChat({
                           {connectionMenuOpen && (
                             <div
                               ref={connectionMenuRef}
-                              className="absolute bottom-full left-2 z-20 mb-2 flex max-h-72 min-w-[15rem] max-w-[20rem] flex-col overflow-hidden rounded-xl border border-[var(--border)] bg-[var(--card)] text-left shadow-2xl"
+                              className="absolute bottom-full left-12 z-20 mb-2 flex max-h-72 min-w-[15rem] max-w-[20rem] flex-col overflow-hidden rounded-xl border border-[var(--border)] bg-[var(--card)] text-left shadow-2xl"
                             >
                               <div className="border-b border-[var(--border)] px-3 py-2 text-[0.6875rem] font-semibold text-[var(--foreground)]">
                                 Connections
@@ -3444,23 +3563,6 @@ export function HomeProfessorMariChat({
                               </div>
                             </div>
                           )}
-
-                          <button
-                            type="button"
-                            onClick={() => imageInputRef.current?.click()}
-                            disabled={isBusy || isReadingImages}
-                            className={cn(
-                              "flex h-8 w-8 shrink-0 items-center justify-center rounded-xl transition-all",
-                              imageAttachments.length > 0
-                                ? "bg-foreground/10 text-foreground/75"
-                                : "text-foreground/40 hover:bg-foreground/10 hover:text-foreground/70",
-                              (isBusy || isReadingImages) && "cursor-not-allowed opacity-40",
-                            )}
-                            title="Attach images"
-                            aria-label="Attach images"
-                          >
-                            {isReadingImages ? <Loader2 size="1rem" className="animate-spin" /> : <ImageIcon size="1rem" />}
-                          </button>
 
                           <textarea
                             value={draft}

--- a/packages/server/src/services/professor-mari/workspace-agent.service.ts
+++ b/packages/server/src/services/professor-mari/workspace-agent.service.ts
@@ -18,9 +18,14 @@ import { createLLMProvider } from "../llm/provider-registry.js";
 import { getLocalSidecarProvider, LOCAL_SIDECAR_MODEL } from "../llm/local-sidecar.js";
 import { createChatsStorage } from "../storage/chats.storage.js";
 import {
+  appendReadableAttachmentsToContent,
+  extractFileAttachmentInputs,
+  extractImageAttachmentDataUrls,
+  getAttachmentFilename,
   resolveBaseUrl,
   mergeCustomParameters,
   normalizeServiceTier,
+  type PromptAttachment,
 } from "../../routes/generate/generate-route-utils.js";
 import { getFileStorageDir, getMonorepoRoot, getPort, getServerProtocol } from "../../config/runtime-config.js";
 import { apiConnections } from "../../db/schema/index.js";
@@ -67,12 +72,7 @@ type WorkspaceConnection = Pick<
   | "cachingAtDepth"
 > & { provider: string; isLocalSidecar?: boolean };
 type PromptEventSink = (event: MariWorkspacePromptEvent) => void;
-type ProfessorMariPromptAttachment = {
-  type: string;
-  data: string;
-  name?: string;
-  filename?: string;
-};
+type ProfessorMariPromptAttachment = PromptAttachment;
 type WorkspaceCommandCall = {
   id: string;
   name: MariWorkspaceToolName;
@@ -490,7 +490,7 @@ function parseExtra(value: unknown): Record<string, unknown> {
   return parseJsonObject(value) ?? {};
 }
 
-function normalizeProfessorMariImageAttachments(value: unknown): ProfessorMariPromptAttachment[] {
+function normalizeProfessorMariAttachments(value: unknown): ProfessorMariPromptAttachment[] {
   if (!Array.isArray(value)) return [];
   return value
     .map((attachment): ProfessorMariPromptAttachment | null => {
@@ -498,26 +498,28 @@ function normalizeProfessorMariImageAttachments(value: unknown): ProfessorMariPr
       const record = attachment as Record<string, unknown>;
       const type = typeof record.type === "string" ? record.type.trim() : "";
       const data = typeof record.data === "string" ? record.data.trim() : "";
-      if (!type.startsWith("image/") || !data.startsWith("data:image/")) return null;
+      if (!type || !data.startsWith("data:")) return null;
       const name =
         typeof record.name === "string" && record.name.trim()
           ? record.name.trim()
           : typeof record.filename === "string" && record.filename.trim()
             ? record.filename.trim()
-            : "image";
+            : "attachment";
       return { type, data, name, filename: name };
     })
     .filter((attachment): attachment is ProfessorMariPromptAttachment => attachment !== null);
 }
 
-function professorMariPromptImages(extra: Record<string, unknown>): string[] {
-  return normalizeProfessorMariImageAttachments(extra.attachments).map((attachment) => attachment.data);
-}
-
 function appendProfessorMariAttachmentNames(content: string, attachments: ProfessorMariPromptAttachment[]): string {
-  if (attachments.length === 0) return content;
-  const names = attachments.map((attachment) => `[Attached image: ${attachment.name ?? "image"}]`).join("\n");
-  return `${content.trim() || "Please inspect the attached image."}\n\n${names}`;
+  const withReadableFiles = appendReadableAttachmentsToContent(content, attachments);
+  if (attachments.length === 0) return withReadableFiles;
+  const names = attachments
+    .map((attachment) => {
+      const label = typeof attachment.type === "string" && attachment.type.startsWith("image/") ? "image" : "file";
+      return `[Attached ${label}: ${getAttachmentFilename(attachment)}]`;
+    })
+    .join("\n");
+  return `${withReadableFiles.trim() || "Please inspect the attached file."}\n\n${names}`;
 }
 
 type MariWorkspaceTraceTool = Extract<MariWorkspaceTraceItem, { type: "tool" }>["tool"];
@@ -1353,15 +1355,15 @@ export class ProfessorMariWorkspaceService {
   }) {
     if (!this.enabled) throw new Error("Professor Mari workspace mode is disabled.");
     const chatStorage = createChatsStorage(this.app.db);
-    const imageAttachments = normalizeProfessorMariImageAttachments(args.attachments);
+    const attachments = normalizeProfessorMariAttachments(args.attachments);
     const userMessage = await chatStorage.createMessage({
       chatId: args.chatId,
       role: "user",
       characterId: null,
       content: args.text,
     });
-    if (imageAttachments.length > 0 && userMessage) {
-      const extra = { attachments: imageAttachments };
+    if (attachments.length > 0 && userMessage) {
+      const extra = { attachments };
       await chatStorage.updateMessageExtra(userMessage.id, extra);
       await chatStorage.updateSwipeExtra(userMessage.id, 0, extra);
     }
@@ -1642,16 +1644,18 @@ export class ProfessorMariWorkspaceService {
       const content = typeof row.content === "string" ? row.content : String(row.content ?? "");
       if (!content.trim()) continue;
       const role = roleForMessage(row);
-      const imageAttachments = role === "user" ? normalizeProfessorMariImageAttachments(extra.attachments) : [];
-      const images = professorMariPromptImages(extra);
+      const attachments = role === "user" ? normalizeProfessorMariAttachments(extra.attachments) : [];
+      const images = extractImageAttachmentDataUrls(attachments);
+      const files = extractFileAttachmentInputs(attachments);
       messages.push({
         role,
         content:
           role === "assistant"
             ? assistantHistoryContentFromVisibleText(content)
-            : appendProfessorMariAttachmentNames(content, imageAttachments),
+            : appendProfessorMariAttachmentNames(content, attachments),
         contextKind: "history",
         ...(role === "user" && images.length > 0 ? { images } : {}),
+        ...(role === "user" && files.length > 0 ? { files } : {}),
       });
     }
     if (continuityPrompt) messages.push({ role: "system", content: continuityPrompt, contextKind: "injection" });


### PR DESCRIPTION
## What changed

Professor Mari's chat composer now uses a paperclip as the first left-side control and accepts images, PDFs, and common readable text/data files instead of images only.

The workspace prompt path now preserves those attachments for Professor Mari: images continue through vision inputs, PDFs are passed as provider-native file inputs where supported, and readable text/data files are appended into the prompt as attached file blocks.

## Why

Professor Mari previously exposed an image-only attachment flow. That made the UI too narrow for workspace help where PDFs, JSON, Markdown, logs, and similar files are natural inputs.

## Notes

No linked issue was provided for this small maintainer-requested change. One should be opened before final submission if the project board needs issue tracking for it.

## Validation

- `git diff --check`
- `pnpm --filter @marinara-engine/server lint`
- `pnpm --filter @marinara-engine/client lint`
- `pnpm build:client`

## Manual verification

- Verify Professor Mari's paperclip appears as the first composer icon in both floating and embedded chat.
- Verify attaching an image, PDF, and text file shows the expected previews and sends successfully.
- Verify the connection menu still opens from the link icon beside the paperclip.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Chat attachments now support general files, including images, PDFs, and text-like documents.
  * Updated attachment previews and message rendering to show images as thumbnails and files as downloadable items.

* **Bug Fixes**
  * Improved attachment handling when sending and restoring chat messages so multiple file types work consistently.
  * Adjusted the chat controls and attachment picker to support the new multi-file flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->