### PR TITLE
[codex] Use chat chrome color for conversation system text

### DIFF
--- a/packages/client/src/components/chat/ConversationMessage.tsx
+++ b/packages/client/src/components/chat/ConversationMessage.tsx
@@ -777,7 +777,7 @@ export const ConversationMessage = memo(function ConversationMessage({
               <Trash2 size="0.75rem" />
             </button>
           )}
-          <span className="rounded-full bg-[var(--secondary)] px-3 py-1 text-[0.6875rem] text-[var(--muted-foreground)]">
+          <span className="rounded-full bg-[var(--secondary)] px-3 py-1 text-[0.6875rem] text-[var(--marinara-chat-chrome-panel-muted)]">
             {message.content}
           </span>
         </div>

--- a/packages/client/src/components/chat/ConversationView.tsx
+++ b/packages/client/src/components/chat/ConversationView.tsx
@@ -1092,7 +1092,9 @@ export function ConversationView({
             return (
               <div key={item.key} className="relative my-4 flex items-center px-4">
                 <div className="flex-1 border-t border-[var(--border)]/40" />
-                <span className="mx-4 text-[0.6875rem] font-semibold text-[var(--muted-foreground)]">{item.label}</span>
+                <span className="mx-4 text-[0.6875rem] font-semibold text-[var(--marinara-chat-chrome-panel-muted)]">
+                  {item.label}
+                </span>
                 <div className="flex-1 border-t border-[var(--border)]/40" />
               </div>
             );


### PR DESCRIPTION
## What changed

Conversation-mode system message chips and day/date separators now use `--marinara-chat-chrome-panel-muted`, which follows the user-selected chat chrome text color.

## Why

These small meta rows still used the generic muted foreground token, so they could stay visually tied to the old pink/default theme instead of respecting the configured chat chrome text color.

## Validation

- `git diff --check`
- `pnpm --filter @marinara-engine/client lint`

## Manual verification

- Verify Conversation mode date separators follow the selected chat chrome text color.
- Verify system messages such as join/leave notices follow the selected chat chrome text color.
