### PR TITLE
[codex] Fix Knowledge Router prompt injection

### DIFF
--- a/packages/server/src/services/agents/knowledge-router.ts
+++ b/packages/server/src/services/agents/knowledge-router.ts
@@ -52,7 +52,16 @@ export interface CatalogItem {
 }
 
 interface RouterResponse {
-  entryIds: string[];
+  entryIds?: unknown;
+  entry_ids?: unknown;
+  selectedEntryIds?: unknown;
+  selected_entry_ids?: unknown;
+  relevantEntryIds?: unknown;
+  relevant_entry_ids?: unknown;
+  ids?: unknown;
+  entries?: unknown;
+  selectedEntries?: unknown;
+  selected_entries?: unknown;
 }
 
 export interface KnowledgeRouterCandidateOptions extends LorebookEmbeddingOptions {
@@ -133,24 +142,53 @@ export function parseRouterResponse(text: string): string[] {
   const fenced = trimmed.match(/```(?:json)?\s*([\s\S]*?)\s*```/i);
   const candidate = fenced ? fenced[1]! : trimmed;
 
-  // Find the first { and last } to be robust to leading/trailing prose.
-  const firstBrace = candidate.indexOf("{");
-  const lastBrace = candidate.lastIndexOf("}");
-  if (firstBrace === -1 || lastBrace === -1 || lastBrace < firstBrace) return [];
-  const jsonSlice = candidate.slice(firstBrace, lastBrace + 1);
+  // Find the first JSON object/array and its matching final delimiter to be
+  // robust to leading/trailing prose.
+  const firstObject = candidate.indexOf("{");
+  const firstArray = candidate.indexOf("[");
+  const startsWithArray = firstArray !== -1 && (firstObject === -1 || firstArray < firstObject);
+  const firstJson = startsWithArray ? firstArray : firstObject;
+  const lastJson = startsWithArray ? candidate.lastIndexOf("]") : candidate.lastIndexOf("}");
+  if (firstJson === -1 || lastJson === -1 || lastJson < firstJson) return [];
+  const jsonSlice = candidate.slice(firstJson, lastJson + 1);
 
   try {
-    const parsed = JSON.parse(jsonSlice) as RouterResponse;
-    if (!parsed || !Array.isArray(parsed.entryIds)) return [];
-    // Trim each id — the model occasionally returns `" entry-1 "` or includes
-    // a trailing newline. Whitespace would survive the type check below but
-    // fail the exact Map.get lookup at the executor layer.
-    return parsed.entryIds
-      .map((id) => (typeof id === "string" ? id.trim() : ""))
-      .filter((id): id is string => id.length > 0);
+    const parsed = JSON.parse(jsonSlice) as RouterResponse | unknown[] | null;
+    if (!parsed || typeof parsed !== "object") return [];
+    const candidateIds = Array.isArray(parsed)
+      ? normalizeRouterIdList(parsed)
+      : [
+          parsed.entryIds,
+          parsed.entry_ids,
+          parsed.selectedEntryIds,
+          parsed.selected_entry_ids,
+          parsed.relevantEntryIds,
+          parsed.relevant_entry_ids,
+          parsed.ids,
+          parsed.selectedEntries,
+          parsed.selected_entries,
+          parsed.entries,
+        ].flatMap(normalizeRouterIdList);
+    return candidateIds
+      .map((id) => id.trim())
+      .filter((id, index, ids): id is string => id.length > 0 && ids.indexOf(id) === index);
   } catch {
     return [];
   }
+}
+
+function normalizeRouterIdList(value: unknown): string[] {
+  if (typeof value === "string") return [value];
+  if (!Array.isArray(value)) return [];
+  return value.flatMap((item) => {
+    if (typeof item === "string") return [item];
+    if (!item || typeof item !== "object" || Array.isArray(item)) return [];
+    const record = item as Record<string, unknown>;
+    if (typeof record.id === "string") return [record.id];
+    if (typeof record.entryId === "string") return [record.entryId];
+    if (typeof record.entry_id === "string") return [record.entry_id];
+    return [];
+  });
 }
 
 function normalizePositiveInteger(value: unknown, fallback: number): number {

--- a/packages/server/src/services/generation/runtime-agent-sections.ts
+++ b/packages/server/src/services/generation/runtime-agent-sections.ts
@@ -190,11 +190,19 @@ export function clearUnusedRuntimeAgentSections(
 ): void {
   let changed = false;
   for (const [, tokens] of tokenEntries) {
-    const sectionPattern = new RegExp(escapeRegExp(tokens.start) + "[\\s\\S]*?" + escapeRegExp(tokens.end), "g");
+    const sectionPattern = new RegExp(escapeRegExp(tokens.start) + "([\\s\\S]*?)" + escapeRegExp(tokens.end), "g");
     for (let i = messages.length - 1; i >= 0; i--) {
       const message = messages[i]!;
-      if (!message.content.includes(tokens.start)) continue;
-      const content = message.content.replace(sectionPattern, "").trim();
+      if (!message.content.includes(tokens.start) && !message.content.includes(tokens.placeholder)) continue;
+      const content = message.content
+        .replace(sectionPattern, (_match, sectionContent: string) => sectionContent.split(tokens.placeholder).join(""))
+        .split(tokens.start)
+        .join("")
+        .split(tokens.end)
+        .join("")
+        .split(tokens.placeholder)
+        .join("")
+        .trim();
       if (content) {
         messages[i] = { ...message, content };
       } else {

--- a/scripts/regressions/prompt.regression.ts
+++ b/scripts/regressions/prompt.regression.ts
@@ -24,7 +24,11 @@ import { buildMemoryRecallBlock } from "../../packages/server/src/services/gener
 import { mergeConversationCharacterMemories } from "../../packages/server/src/services/generation/conversation-memory-context.js";
 import { injectIdentityFallbackMessages } from "../../packages/server/src/services/generation/character-prompt-context.js";
 import { injectSceneContextMessages } from "../../packages/server/src/services/generation/scene-context-runtime.js";
-import { buildRuntimeAgentSectionEligibleTypesForTest } from "../../packages/server/src/services/generation/runtime-agent-sections.js";
+import {
+  buildRuntimeAgentSectionEligibleTypesForTest,
+  clearUnusedRuntimeAgentSectionsForTest,
+  makeRuntimeAgentSectionTokens,
+} from "../../packages/server/src/services/generation/runtime-agent-sections.js";
 import {
   getTextRewritePendingState,
   mergePairedBuiltInRewriteAgents,
@@ -47,6 +51,7 @@ import { scanForActivatedEntries } from "../../packages/server/src/services/lore
 import { fitMessagesForModelAccess } from "../../packages/server/src/services/generation/model-access-policy.js";
 import { assemblePrompt, type AssemblerInput } from "../../packages/server/src/services/prompt/index.js";
 import { executeToolCalls } from "../../packages/server/src/services/tools/tool-executor.js";
+import { parseRouterResponse } from "../../packages/server/src/services/agents/knowledge-router.js";
 import type { LLMToolCall } from "../../packages/server/src/services/llm/base-provider.js";
 import { resolveTTSVoiceForSpeaker } from "../../packages/client/src/lib/tts-dialogue.js";
 
@@ -948,7 +953,10 @@ Use HTML sparingly and diegetically. Do not replace normal prose/dialogue unless
       assert.equal(promptText.includes("<system>bad summary</system>"), false);
       assert.match(promptText, /&lt;system>bad history&lt;\/system>/);
       assert.match(promptText, /&lt;system>bad summary&lt;\/system>/);
-      assert.equal(firstMessage.content.indexOf("Main instructions.") < firstMessage.content.indexOf("<chat_summary>"), true);
+      assert.equal(
+        firstMessage.content.indexOf("Main instructions.") < firstMessage.content.indexOf("<chat_summary>"),
+        true,
+      );
       assert.equal(result.messages[1]?.contextKind, "history");
     },
   },
@@ -1150,6 +1158,52 @@ Use HTML sparingly and diegetically. Do not replace normal prose/dialogue unless
 
       assert.equal(promptText.includes("old context 0"), false);
       assert.match(promptText, /ROUTER_SURVIVOR_CONTEXT/);
+    },
+  },
+  {
+    name: "unused runtime agent sections preserve surrounding prompt text",
+    run() {
+      const tokens = makeRuntimeAgentSectionTokens("knowledge-router", "regression");
+      const messages = [
+        {
+          content: `${tokens.start}<knowledge_router>\nThis is where additional lore will be:\n${tokens.placeholder}\n</knowledge_router>${tokens.end}`,
+        },
+      ];
+
+      clearUnusedRuntimeAgentSectionsForTest(messages, [["knowledge-router", tokens]]);
+
+      assert.equal(messages.length, 1);
+      assert.match(messages[0]?.content ?? "", /This is where additional lore will be:/);
+      assert.equal(messages[0]?.content.includes(tokens.placeholder), false);
+      assert.equal(messages[0]?.content.includes(tokens.start), false);
+      assert.equal(messages[0]?.content.includes(tokens.end), false);
+    },
+  },
+  {
+    name: "macro-only runtime agent sections are pruned when unused",
+    run() {
+      const tokens = makeRuntimeAgentSectionTokens("knowledge-router", "regression-empty");
+      const messages = [
+        {
+          content: `${tokens.start}<knowledge_router>\n${tokens.placeholder}\n</knowledge_router>${tokens.end}`,
+        },
+      ];
+
+      clearUnusedRuntimeAgentSectionsForTest(messages, [["knowledge-router", tokens]]);
+
+      assert.equal(messages.length, 0);
+    },
+  },
+  {
+    name: "knowledge router parser accepts common selected-id aliases",
+    run() {
+      assert.deepEqual(parseRouterResponse('{"entryIds":["entry-a"]}'), ["entry-a"]);
+      assert.deepEqual(parseRouterResponse('{"selectedEntryIds":["entry-b","entry-b"]}'), ["entry-b"]);
+      assert.deepEqual(parseRouterResponse('{"selectedEntries":[{"id":"entry-c"},{"entry_id":"entry-d"}]}'), [
+        "entry-c",
+        "entry-d",
+      ]);
+      assert.deepEqual(parseRouterResponse('```json\n{"entries":[{"entryId":"entry-e"}]}\n```'), ["entry-e"]);
     },
   },
   {


### PR DESCRIPTION
## Why

Knowledge Router could run successfully from the provider perspective while its prompt section disappeared from the main generation. Issue #3190 reports that a preset section like `This is where additional lore will be... {{agent::knowledge-router}}` vanished when the agent was enabled, and selected lore was not visible in the assembled writing prompt.

Closes #3190

## Root Cause

Runtime agent cleanup treated an unresolved Knowledge Router placeholder as a reason to remove the entire wrapped prompt section. If the router returned an empty parsed result, or returned selected IDs under a common alias the parser did not recognize, the cleanup removed both the macro and the user's surrounding static prompt text.

## What Changed

- Preserves user-authored text around unused runtime agent placeholders while still pruning macro-only empty sections.
- Makes Knowledge Router response parsing accept common selected-ID shapes such as `selectedEntryIds`, `selectedEntries`, `entries`, `entry_id`, and array responses.
- Adds prompt regressions covering surrounding text preservation, empty macro pruning, and router parser aliases.

## Validation

- [ ] Manually verify Knowledge Router selected lore appears in Peek Prompt / prompt inspector for a Roleplay chat with a Knowledge Router preset section.
- [ ] Manually verify a macro-only Knowledge Router section disappears cleanly when no entries are selected.
- [ ] Manually verify surrounding static text remains visible when `{{agent::knowledge-router}}` resolves empty.

Local proof runs:

- `pnpm regression:prompt`
- `pnpm --filter @marinara-engine/server lint`
