### PR TITLE
[codex] Add Conversation calls for v2.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,12 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 
 ## [2.1.0]
 
+### Added
+
+- Added Conversation-mode audio/video calls with per-chat call toggles, character-initiated incoming calls, a Discord-style desktop/mobile call surface, call-only chat, speaking highlights, mute/camera/screen-share controls, soundboard support, minimized active-call popouts, call history cards, and post-call summary injection.
+- Added Conversation call voice input through provider-native audio/video when supported, Local Whisper transcription with downloadable Whisper Tiny/Base models, browser speech recognition fallback, and manual system dictation mode.
+- Added xAI as a Text-to-Speech provider option with built-in voice fallbacks and xAI speech request handling.
+
 ### Changed
 
 - Bumped release metadata to v2.1.0 across packages, the PWA manifest, README release pointer, Windows installer sources, Android APK metadata, and the home-page-visible app version.
@@ -34,6 +40,10 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 
 ### Fixed
 
+- Fixed Conversation call prompt assembly so call output JSON format and command instructions stay attached to the latest call input, adjacent same-role call history messages are merged, older TTS cue tags are stripped from call history, command turns use the same descriptive command guidance as normal Conversation mode, and `[end_call]` waits until prior voice lines finish before ending the call.
+- Fixed Conversation call command execution so hidden commands such as selfies, memories, music, haptics, influences, notes, soundboard actions, character leave, and call end are executed as call actions instead of leaking into the visible call chat.
+- Fixed Conversation call media and UI reliability by keeping speech-only transcripts out of the visible call chat, returning server-resolved character IDs for playback, preserving active calls while navigating elsewhere in Marinara, stacking the call popout with Professor Mari, improving mobile control scaling/participant tiling, and keeping offline characters out of calls.
+- Fixed Local Whisper availability after updates by adding a post-install native dependency repair step that rebuilds or refreshes `onnxruntime-node` for the Node architecture used to run Marinara, and documented the repair path for Windows, macOS/Linux, and Termux installs.
 - Fixed Android/Termux git updates aborting during release rebuilds with exit status 134 by making the default package build scripts Android-aware and documenting the low-memory update path (#3156).
 - Fixed `pnpm install --frozen-lockfile` failures with `ERR_PNPM_TRUST_DOWNGRADE` for older locked dependencies such as `pino` and `semver` by disabling trust-downgrade enforcement for released Marinara installs.
 - Fixed partial installs after aborted pnpm runs so launchers detect missing workspace dependencies such as `chess.js` and repair `node_modules` before shared builds run.

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,7 @@ COPY packages/shared/package.json packages/shared/
 COPY packages/server/package.json packages/server/
 COPY packages/client/package.json packages/client/
 COPY scripts/clean-stale-client-artifacts.mjs scripts/clean-stale-client-artifacts.mjs
+COPY scripts/ensure-native-deps.mjs scripts/ensure-native-deps.mjs
 
 # Enable corepack — version is read from the packageManager field in package.json
 RUN corepack enable && corepack install
@@ -58,6 +59,7 @@ COPY packages/shared/package.json packages/shared/
 COPY packages/server/package.json packages/server/
 COPY packages/client/package.json packages/client/
 COPY scripts/clean-stale-client-artifacts.mjs scripts/clean-stale-client-artifacts.mjs
+COPY scripts/ensure-native-deps.mjs scripts/ensure-native-deps.mjs
 
 # Enable corepack — version is read from the packageManager field in package.json
 RUN corepack enable && corepack install

--- a/docs/installation/android-termux.md
+++ b/docs/installation/android-termux.md
@@ -76,7 +76,7 @@ The `start-termux.sh` launcher automatically updates Marinara Engine on each run
 1. Fetches the latest code for the current update branch, then fast-forwards normal clones or moves detached release checkouts to that commit. Local `staging` branches follow `origin/staging`; all other launcher checkouts follow stable `origin/main`.
 2. Detects whether the checkout changed
 3. Temporarily stashes tracked local changes if needed, then reapplies them
-4. Reinstalls dependencies and rebuilds when needed, using sequential low-memory server/client builds on Android
+4. Reinstalls dependencies, refreshes native packages for the current Node architecture, and rebuilds when needed, using sequential low-memory server/client builds on Android
 5. Starts the app on the current version
 
 Simply run `./start-termux.sh` to get the latest version each time.

--- a/docs/installation/macos-linux.md
+++ b/docs/installation/macos-linux.md
@@ -58,7 +58,7 @@ If you prefer to run commands yourself without the launcher:
 ```bash
 git clone https://github.com/Pasta-Devs/Marinara-Engine.git
 cd Marinara-Engine
-pnpm install
+pnpm install --force
 pnpm build
 pnpm start
 ```
@@ -113,7 +113,7 @@ When you launch Marinara Engine via `./start.sh` from a git checkout, the launch
 1. Fetches the latest code for the current update branch, then fast-forwards normal clones or moves detached release checkouts to that commit. Local `staging` branches follow `origin/staging`; all other launcher checkouts follow stable `origin/main`.
 2. Detects whether the checkout changed
 3. Temporarily stashes tracked local changes if needed, then reapplies them
-4. Reinstalls dependencies and rebuilds when needed
+4. Reinstalls dependencies, refreshes native packages for the current Node architecture, and rebuilds when needed
 5. Starts the app on the current version
 
 ### In-App Update Check
@@ -129,7 +129,7 @@ If you use a git checkout without the launcher or the in-app updater:
 ```bash
 git fetch origin +refs/heads/main:refs/remotes/origin/main
 git merge --ff-only origin/main || git checkout --detach origin/main
-pnpm install
+pnpm install --force
 pnpm build
 ```
 
@@ -138,7 +138,7 @@ For tester builds, use the staging target instead:
 ```bash
 git fetch origin +refs/heads/staging:refs/remotes/origin/staging
 git checkout -B staging origin/staging
-pnpm install
+pnpm install --force
 pnpm build
 ```
 

--- a/docs/installation/windows.md
+++ b/docs/installation/windows.md
@@ -46,7 +46,7 @@ If you prefer to run commands yourself without the launcher:
 ```bat
 git clone https://github.com/Pasta-Devs/Marinara-Engine.git
 cd Marinara-Engine
-pnpm install
+pnpm install --force
 pnpm build
 pnpm start
 ```
@@ -84,7 +84,7 @@ When you launch Marinara Engine via the Start Menu shortcut or `start.bat` from 
 1. Fetches the latest code for the current update branch, then fast-forwards normal clones or moves installer-created release checkouts to that commit. Local `staging` branches follow `origin/staging`; all other launcher checkouts follow stable `origin/main`.
 2. Detects whether the checkout changed
 3. Temporarily stashes tracked local changes if needed, then reapplies them
-4. Reinstalls dependencies and rebuilds when needed
+4. Reinstalls dependencies, refreshes native packages for the current Node architecture, and rebuilds when needed
 5. Starts the app on the current version
 
 This applies to both manual clones and installs created by the Windows installer.
@@ -102,7 +102,7 @@ If you use a git checkout without the launcher or the in-app updater:
 ```bat
 git fetch origin +refs/heads/main:refs/remotes/origin/main
 git merge --ff-only origin/main || git checkout --detach origin/main
-pnpm install
+pnpm install --force
 pnpm build
 ```
 
@@ -111,7 +111,7 @@ For tester builds, use the staging target instead:
 ```bat
 git fetch origin +refs/heads/staging:refs/remotes/origin/staging
 git checkout -B staging origin/staging
-pnpm install
+pnpm install --force
 pnpm build
 ```
 

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   },
   "scripts": {
     "preinstall": "node ./scripts/clean-stale-client-artifacts.mjs",
+    "postinstall": "node ./scripts/ensure-native-deps.mjs",
     "dev": "node ./scripts/dev.mjs",
     "dev:server": "pnpm --filter @marinara-engine/server dev",
     "dev:client": "pnpm build:shared && pnpm --filter @marinara-engine/client dev",

--- a/packages/client/src/App.tsx
+++ b/packages/client/src/App.tsx
@@ -117,28 +117,30 @@ export class AppRecoveryBoundary extends Component<{ children: ReactNode }, { er
     const errorMessage = formatRecoveryError(this.state.error);
 
     return (
-      <div className="flex min-h-screen items-center justify-center bg-[var(--background,#050312)] px-4 text-[var(--foreground,#f8fafc)]">
-        <div className="w-full max-w-lg rounded-xl border border-[var(--border,rgba(255,255,255,0.16))] bg-[var(--card,rgba(15,23,42,0.88))] p-5 shadow-2xl">
-          <h1 className="text-lg font-semibold">Marinara hit a recoverable UI error.</h1>
-          <p className="mt-2 text-sm text-[var(--muted-foreground,#cbd5e1)]">
+      <div className="mari-chrome-token-scope flex min-h-screen items-center justify-center bg-[var(--background)] px-4 text-[var(--marinara-chat-chrome-panel-text)]">
+        <div className="w-full max-w-lg rounded-xl border border-[var(--marinara-chat-chrome-accent)] bg-[var(--marinara-chat-chrome-panel-bg)] p-5 shadow-2xl ring-1 ring-[var(--marinara-chat-chrome-focus-ring)]">
+          <h1 className="text-lg font-semibold text-[var(--marinara-chat-chrome-panel-title)]">
+            Marinara hit a recoverable UI error.
+          </h1>
+          <p className="mt-2 text-sm text-[var(--marinara-chat-chrome-panel-muted)]">
             The app shell crashed while rendering. Reload first; reset local UI state only if the same screen keeps
             returning after restart.
           </p>
-          <pre className="mt-3 max-h-32 overflow-auto rounded-lg bg-black/30 p-2 text-xs text-[var(--muted-foreground,#cbd5e1)]">
+          <pre className="mt-3 max-h-32 overflow-auto rounded-lg border border-[var(--marinara-chat-chrome-panel-border)] bg-[var(--marinara-chat-chrome-highlight-bg)] p-2 text-xs text-[var(--marinara-chat-chrome-panel-muted)]">
             {errorMessage}
           </pre>
           <div className="mt-4 flex flex-wrap gap-2">
             <button
               type="button"
               onClick={() => window.location.reload()}
-              className="rounded-lg bg-[var(--primary,#d4acfb)] px-3 py-2 text-sm font-semibold text-[var(--primary-foreground,#120718)]"
+              className="mari-chrome-control mari-chrome-control--selected px-3 py-2 text-sm"
             >
               Reload
             </button>
             <button
               type="button"
               onClick={this.resetLocalUiState}
-              className="rounded-lg border border-[var(--border,rgba(255,255,255,0.16))] px-3 py-2 text-sm font-semibold"
+              className="mari-chrome-control px-3 py-2 text-sm"
             >
               Reset local UI state
             </button>

--- a/packages/client/src/components/chat/ChatNotificationBubbles.tsx
+++ b/packages/client/src/components/chat/ChatNotificationBubbles.tsx
@@ -7,16 +7,32 @@
 // On mobile, multiple notifications collapse into a single tappable group.
 
 import { useState } from "react";
-import { X, MessageCircle } from "lucide-react";
+import { useQueryClient } from "@tanstack/react-query";
+import { toast } from "sonner";
+import { Loader2, Phone, PhoneIncoming, PhoneOff, X, MessageCircle } from "lucide-react";
 import { useChatStore } from "../../stores/chat.store";
 import { useGameModeStore } from "../../stores/game-mode.store";
 import { useUIStore } from "../../stores/ui.store";
+import { api } from "../../lib/api-client";
 import { cn, getAvatarCropStyle, type AvatarCropValue } from "../../lib/utils";
 import { AnimatePresence, motion } from "framer-motion";
 
+type ChatNotification = {
+  chatId: string;
+  characterName: string;
+  avatarUrl: string | null;
+  avatarCrop?: AvatarCropValue | null;
+  count: number;
+  kind?: "message" | "call";
+  callId?: string | null;
+  reason?: string | null;
+};
+
 export function ChatNotificationBubbles() {
+  const queryClient = useQueryClient();
   const chatNotifications = useChatStore((s) => s.chatNotifications);
   const setActiveChatId = useChatStore((s) => s.setActiveChatId);
+  const autoDismissNotification = useChatStore((s) => s.autoDismissNotification);
   const dismissNotification = useChatStore((s) => s.dismissNotification);
   const setShouldOpenSettings = useChatStore((s) => s.setShouldOpenSettings);
   const setShouldOpenWizard = useChatStore((s) => s.setShouldOpenWizard);
@@ -25,6 +41,7 @@ export function ChatNotificationBubbles() {
   const setSetupActive = useGameModeStore((s) => s.setSetupActive);
   const closeAllDetails = useUIStore((s) => s.closeAllDetails);
   const [mobileExpanded, setMobileExpanded] = useState(false);
+  const [pendingCallAction, setPendingCallAction] = useState<string | null>(null);
 
   /** Navigate to a chat — close any editor/detail view first so ChatArea is visible. */
   const navigateToChat = (chatId: string) => {
@@ -35,6 +52,43 @@ export function ChatNotificationBubbles() {
     setShouldOpenWizardInShortcutMode(false);
     setSetupActive(false);
     setActiveChatId(chatId);
+  };
+
+  const refreshCallState = (chatId: string) => {
+    queryClient.invalidateQueries({ queryKey: ["conversation-calls", "status", chatId] });
+    queryClient.invalidateQueries({ queryKey: ["chats", "messages", chatId] });
+    queryClient.invalidateQueries({ queryKey: ["chats", "list"] });
+  };
+
+  const acceptCall = async (notif: ChatNotification) => {
+    if (!notif.callId) return;
+    setPendingCallAction(`accept:${notif.callId}`);
+    try {
+      await api.post(`/conversation-calls/${notif.callId}/accept`, {});
+      autoDismissNotification(notif.chatId);
+      refreshCallState(notif.chatId);
+      navigateToChat(notif.chatId);
+      setMobileExpanded(false);
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : "Could not answer the call.");
+    } finally {
+      setPendingCallAction(null);
+    }
+  };
+
+  const declineCall = async (notif: ChatNotification) => {
+    if (!notif.callId) return;
+    setPendingCallAction(`decline:${notif.callId}`);
+    try {
+      await api.post(`/conversation-calls/${notif.callId}/decline`, {});
+      autoDismissNotification(notif.chatId);
+      refreshCallState(notif.chatId);
+      setMobileExpanded(false);
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : "Could not decline the call.");
+    } finally {
+      setPendingCallAction(null);
+    }
   };
 
   const notifications = Array.from(chatNotifications.values());
@@ -54,6 +108,9 @@ export function ChatNotificationBubbles() {
               notif={notif}
               onNavigate={() => navigateToChat(notif.chatId)}
               onDismiss={() => dismissNotification(notif.chatId)}
+              onAcceptCall={() => void acceptCall(notif)}
+              onDeclineCall={() => void declineCall(notif)}
+              pendingCallAction={pendingCallAction}
             />
           ))}
         </AnimatePresence>
@@ -76,6 +133,9 @@ export function ChatNotificationBubbles() {
                   dismissNotification(notif.chatId);
                   if (notifications.length <= 2) setMobileExpanded(false);
                 }}
+                onAcceptCall={() => void acceptCall(notif)}
+                onDeclineCall={() => void declineCall(notif)}
+                pendingCallAction={pendingCallAction}
               />
             ))
           ) : (
@@ -140,17 +200,22 @@ function NotificationBubble({
   notif,
   onNavigate,
   onDismiss,
+  onAcceptCall,
+  onDeclineCall,
+  pendingCallAction,
 }: {
-  notif: {
-    chatId: string;
-    characterName: string;
-    avatarUrl: string | null;
-    avatarCrop?: AvatarCropValue | null;
-    count: number;
-  };
+  notif: ChatNotification;
   onNavigate: () => void;
   onDismiss: () => void;
+  onAcceptCall: () => void;
+  onDeclineCall: () => void;
+  pendingCallAction: string | null;
 }) {
+  const isCall = notif.kind === "call" && !!notif.callId;
+  const accepting = isCall && pendingCallAction === `accept:${notif.callId}`;
+  const declining = isCall && pendingCallAction === `decline:${notif.callId}`;
+  const disabled = accepting || declining;
+
   return (
     <motion.div
       key={notif.chatId}
@@ -164,7 +229,8 @@ function NotificationBubble({
       <button
         onClick={(e) => {
           e.stopPropagation();
-          onDismiss();
+          if (isCall) onDeclineCall();
+          else onDismiss();
         }}
         className={cn(
           "absolute -left-1 -top-1 z-10 flex h-5 w-5 items-center justify-center rounded-full",
@@ -181,10 +247,12 @@ function NotificationBubble({
         onClick={onNavigate}
         className={cn(
           "relative flex h-12 w-12 items-center justify-center overflow-hidden rounded-full",
-          "bg-[var(--accent)]/20 shadow-lg ring-2 ring-[var(--accent)]/40",
+          isCall
+            ? "bg-emerald-500/15 shadow-lg ring-2 ring-emerald-400/60"
+            : "bg-[var(--accent)]/20 shadow-lg ring-2 ring-[var(--accent)]/40",
           "transition-transform hover:scale-110 active:scale-95",
         )}
-        title={`${notif.characterName} sent a message`}
+        title={isCall ? `${notif.characterName} is calling` : `${notif.characterName} sent a message`}
       >
         {notif.avatarUrl ? (
           <img
@@ -195,19 +263,52 @@ function NotificationBubble({
             style={getAvatarCropStyle(notif.avatarCrop)}
           />
         ) : (
-          <MessageCircle className="h-5 w-5 text-[var(--accent)]" />
+          <MessageCircle className={cn("h-5 w-5", isCall ? "text-emerald-400" : "text-[var(--accent)]")} />
+        )}
+        {isCall && (
+          <span className="absolute bottom-0 right-0 flex h-5 w-5 items-center justify-center rounded-full bg-emerald-500 text-white ring-2 ring-[var(--background)]">
+            <PhoneIncoming size="0.6875rem" />
+          </span>
         )}
       </button>
 
-      {/* Red unread badge */}
-      <span
-        className={cn(
-          "absolute -bottom-0.5 -left-0.5 flex h-5 min-w-5 items-center justify-center rounded-full px-1",
-          "bg-red-500 text-[10px] font-bold text-white shadow",
-        )}
-      >
-        {notif.count > 99 ? "99+" : notif.count}
-      </span>
+      {isCall ? (
+        <div className="absolute right-14 top-1/2 flex -translate-y-1/2 items-center gap-1 rounded-full bg-[var(--popover)] px-1.5 py-1 shadow-lg ring-1 ring-[var(--border)]">
+          <button
+            type="button"
+            disabled={disabled}
+            onClick={(event) => {
+              event.stopPropagation();
+              onDeclineCall();
+            }}
+            className="flex h-8 w-8 items-center justify-center rounded-full bg-[var(--destructive)] text-white shadow-sm transition-transform hover:scale-105 active:scale-95 disabled:opacity-60"
+            title="Decline call"
+          >
+            {declining ? <Loader2 size="0.8125rem" className="animate-spin" /> : <PhoneOff size="0.8125rem" />}
+          </button>
+          <button
+            type="button"
+            disabled={disabled}
+            onClick={(event) => {
+              event.stopPropagation();
+              onAcceptCall();
+            }}
+            className="flex h-8 w-8 items-center justify-center rounded-full bg-emerald-500 text-white shadow-sm transition-transform hover:scale-105 active:scale-95 disabled:opacity-60"
+            title="Answer call"
+          >
+            {accepting ? <Loader2 size="0.8125rem" className="animate-spin" /> : <Phone size="0.8125rem" />}
+          </button>
+        </div>
+      ) : (
+        <span
+          className={cn(
+            "absolute -bottom-0.5 -left-0.5 flex h-5 min-w-5 items-center justify-center rounded-full px-1",
+            "bg-red-500 text-[10px] font-bold text-white shadow",
+          )}
+        >
+          {notif.count > 99 ? "99+" : notif.count}
+        </span>
+      )}
     </motion.div>
   );
 }

--- a/packages/client/src/components/chat/ChatSettingsDrawer.tsx
+++ b/packages/client/src/components/chat/ChatSettingsDrawer.tsx
@@ -52,6 +52,7 @@ import {
   ShieldCheck,
   Loader2,
   Wrench,
+  Phone,
 } from "lucide-react";
 import {
   ROLEPLAY_POPOVER_CLOSE_BUTTON,
@@ -88,6 +89,7 @@ import { useCharacters, usePersonas, useCharacterGroups, type SpriteInfo } from 
 import { useLorebooks, useEntriesAcrossLorebooks } from "../../hooks/use-lorebooks";
 import { useDefaultPreset, usePresetFull, usePresets } from "../../hooks/use-presets";
 import { useConnections } from "../../hooks/use-connections";
+import { useTTSConfig, useUpdateTTSConfig } from "../../hooks/use-tts";
 import { useKnowledgeSources, useUploadKnowledgeSource } from "../../hooks/use-knowledge-sources";
 import { useGenerate } from "../../hooks/use-generate";
 import {
@@ -112,10 +114,7 @@ import {
 import { useUpdateGameWidgets } from "../../hooks/use-game";
 import { useRegexScripts, useUpdateRegexScript, type RegexScriptRow } from "../../hooks/use-regex-scripts";
 import { api } from "../../lib/api-client";
-import {
-  appendLocalSidecarConnectionOption,
-  filterLanguageGenerationConnections,
-} from "../../lib/connection-filters";
+import { appendLocalSidecarConnectionOption, filterLanguageGenerationConnections } from "../../lib/connection-filters";
 import {
   deriveActiveLorebookViews,
   getChatActiveLorebookIds,
@@ -162,6 +161,8 @@ import type {
   KnowledgeAgentSourceSettings,
   Message,
   PromptPreset,
+  TTSConfig,
+  TTSConversationCallAudioInputMode,
 } from "@marinara-engine/shared";
 import { useAgentConfigs, useCreateAgent, useUpdateAgent, type AgentConfigRow } from "../../hooks/use-agents";
 import { useAgentStore } from "../../stores/agent.store";
@@ -398,6 +399,11 @@ const CONVERSATION_COMMAND_TOGGLE_OPTIONS: Array<{
     id: "note",
     label: "Notes",
     description: "Let characters save durable notes for a connected chat.",
+  },
+  {
+    id: "call",
+    label: "Calls",
+    description: "Let characters ring you for a Conversation call.",
   },
   {
     id: "uno",
@@ -700,6 +706,8 @@ export function ChatSettingsDrawer({
     );
   }, [effectiveModePromptPresetId, fallbackPromptPreset, promptPresetOptions]);
   const { data: connections } = useConnections();
+  const { data: ttsConfig } = useTTSConfig();
+  const updateTtsConfig = useUpdateTTSConfig();
   const imageConnectionsList = useMemo(
     () =>
       ((connections as Array<{ id: string; name: string; model?: string; provider?: string }>) ?? []).filter(
@@ -721,6 +729,16 @@ export function ChatSettingsDrawer({
       ),
     [connections],
   );
+  const patchConversationCallTtsConfig = useCallback(
+    (patch: Partial<TTSConfig>) => {
+      if (!ttsConfig) {
+        toast.error("Conversation call settings are still loading.");
+        return;
+      }
+      updateTtsConfig.mutate({ ...ttsConfig, callSttConnectionId: "", callSttModel: "", ...patch });
+    },
+    [ttsConfig, updateTtsConfig],
+  );
   const sidecarModelDownloaded = useSidecarStore((state) => state.modelDownloaded);
   const sidecarModelDisplayName = useSidecarStore((state) => state.modelDisplayName);
   const chatGenerationConnectionsList = useMemo(
@@ -732,22 +750,19 @@ export function ChatSettingsDrawer({
       ),
     [isGame, sidecarModelDisplayName, sidecarModelDownloaded, textConnectionsList],
   );
-  const illustratorPromptConnectionsList = useMemo(
-    () => {
-      const options: Array<{ id: string; name: string; model?: string | null }> = [];
-      for (const connection of chatGenerationConnectionsList) {
-        const id = typeof connection.id === "string" ? connection.id.trim() : "";
-        if (!id) continue;
-        options.push({
-          id,
-          name: connection.name || "Connection",
-          model: connection.model ?? null,
-        });
-      }
-      return options;
-    },
-    [chatGenerationConnectionsList],
-  );
+  const illustratorPromptConnectionsList = useMemo(() => {
+    const options: Array<{ id: string; name: string; model?: string | null }> = [];
+    for (const connection of chatGenerationConnectionsList) {
+      const id = typeof connection.id === "string" ? connection.id.trim() : "";
+      if (!id) continue;
+      options.push({
+        id,
+        name: connection.name || "Connection",
+        model: connection.model ?? null,
+      });
+    }
+    return options;
+  }, [chatGenerationConnectionsList]);
   const { data: allPersonas } = usePersonas();
   const { data: agentConfigs } = useAgentConfigs();
   const { data: customTools } = useCustomTools();
@@ -840,6 +855,28 @@ export function ChatSettingsDrawer({
     () => readConversationCommandToggles(metadata.conversationCommandToggles),
     [metadata.conversationCommandToggles],
   );
+  const conversationCommandsEnabled = metadata.characterCommands !== false;
+  const callAudioEnabled = ttsConfig?.callAudioEnabled === true;
+  const callAudioInputMode = ttsConfig?.callAudioInputMode ?? "local_whisper";
+  const callVideoInputEnabled = ttsConfig?.callVideoInputEnabled === true;
+  const callSoundboardEnabled = ttsConfig?.callSoundboardEnabled ?? true;
+  const callSettingsDisabled = !ttsConfig || updateTtsConfig.isPending;
+  const selfieConnectionId = typeof metadata.imageGenConnectionId === "string" ? metadata.imageGenConnectionId : "";
+  const selfieCommandAllowed = conversationCommandToggles.selfie !== false;
+  const selfieSettingsOpen =
+    selfieCommandAllowed && (conversationCommandToggles.selfie === true || selfieConnectionId.length > 0);
+  const selfieFeatureEnabled = conversationCommandsEnabled && selfieSettingsOpen;
+  const toggleConversationSelfies = useCallback(() => {
+    const nextEnabled = !selfieFeatureEnabled;
+    updateMeta.mutate({
+      id: chat.id,
+      ...(nextEnabled ? { characterCommands: true } : {}),
+      conversationCommandToggles: {
+        ...conversationCommandToggles,
+        selfie: nextEnabled,
+      },
+    });
+  }, [chat.id, conversationCommandToggles, selfieFeatureEnabled, updateMeta]);
   const inactiveCharacterIds = useMemo<string[]>(
     () =>
       Array.isArray(metadata.inactiveCharacterIds)
@@ -1083,8 +1120,6 @@ export function ChatSettingsDrawer({
     },
     [agentConfigsByType],
   );
-  const conversationCommandsEnabled = metadata.characterCommands !== false;
-
   // Build the available agent list: built-in + custom agents from DB
   // Mode capabilities decide which built-ins are exposed for each chat mode.
   // Custom agents are user-authored and can be attached to any chat mode.
@@ -1268,10 +1303,7 @@ export function ChatSettingsDrawer({
     () => mergeBuiltInAgentSettings("continuity", continuityConfig?.settings),
     [continuityConfig?.settings],
   );
-  const htmlDefaults = useMemo(
-    () => mergeBuiltInAgentSettings("html", htmlConfig?.settings),
-    [htmlConfig?.settings],
-  );
+  const htmlDefaults = useMemo(() => mergeBuiltInAgentSettings("html", htmlConfig?.settings), [htmlConfig?.settings]);
   const directorDefaults = useMemo(
     () => mergeBuiltInAgentSettings("director", directorConfig?.settings),
     [directorConfig?.settings],
@@ -1311,6 +1343,7 @@ export function ChatSettingsDrawer({
     illustratorPromptConnectionId.length > 0 &&
     !illustratorPromptConnectionsList.some((connection) => connection.id === illustratorPromptConnectionId);
   const selfieUseAvatarReferences = metadata.selfieUseAvatarReferences === true;
+  const selfieIncludeCharacterAppearance = metadata.selfieIncludeCharacterAppearance === true;
   const gameImageUseAvatarReferences = metadata.gameImageUseAvatarReferences !== false;
   const gameImageIncludeCharacterAppearance = metadata.gameImageIncludeCharacterAppearance !== false;
   const gameImageAutoGenerationEnabled = metadata.gameImageAutoGenerationEnabled !== false;
@@ -4674,7 +4707,7 @@ export function ChatSettingsDrawer({
 
                 {conversationCommandsEnabled && (
                   <div className="grid gap-1.5 sm:grid-cols-2">
-                    {CONVERSATION_COMMAND_TOGGLE_OPTIONS.map((command) => {
+                    {CONVERSATION_COMMAND_TOGGLE_OPTIONS.filter((command) => command.id !== "selfie").map((command) => {
                       const enabled = isConversationCommandToggleEnabled(conversationCommandToggles, command.id);
                       return (
                         <button
@@ -4722,139 +4755,352 @@ export function ChatSettingsDrawer({
                   </div>
                 )}
 
-                {/* Selfie Connection — connection picker for character selfies */}
-                <div className="space-y-2">
-                  <label className="flex flex-col gap-1">
-                    <span className="text-[0.625rem] font-medium text-[var(--foreground)]">Selfie Connection</span>
-                    <select
-                      value={(metadata.imageGenConnectionId as string) ?? ""}
-                      onChange={(e) =>
-                        updateMeta.mutate({ id: chat.id, imageGenConnectionId: e.target.value || null })
-                      }
-                      className="w-full rounded-lg border border-[var(--border)] bg-[var(--background)] px-2.5 py-2 text-xs text-[var(--foreground)] outline-none transition-colors focus:border-[var(--primary)]/50"
-                    >
-                      <option value="">None (selfies disabled)</option>
-                      {imageConnectionsList.map((c) => (
-                        <option key={c.id} value={c.id}>
-                          {c.name} ({c.provider})
-                        </option>
-                      ))}
-                    </select>
-                  </label>
-                  {renderIllustratorPromptConnectionSelect()}
-                  <label className="flex flex-col gap-1">
-                    <span className="text-[0.625rem] font-medium text-[var(--foreground)]">Image Style</span>
-                    <select
-                      value={(metadata.imageStyleProfileId as string) ?? ""}
-                      onChange={(e) => updateMeta.mutate({ id: chat.id, imageStyleProfileId: e.target.value || null })}
-                      className="w-full rounded-lg border border-[var(--border)] bg-[var(--background)] px-2.5 py-2 text-xs text-[var(--foreground)] outline-none transition-colors focus:border-[var(--primary)]/50"
-                    >
-                      <option value="">Use default style from Style Profiles in Advanced settings</option>
-                      {imageStyleProfiles.profiles.map((profile) => (
-                        <option key={profile.id} value={profile.id}>
-                          {profile.name}
-                        </option>
-                      ))}
-                    </select>
-                  </label>
-                  <AgentSettingsToggle
-                    label="Send Avatar References"
-                    description="Send the matching character avatar or sprite as a reference image for generated selfies when the provider supports it."
-                    enabled={selfieUseAvatarReferences}
-                    onToggle={() =>
-                      updateMeta.mutate({
-                        id: chat.id,
-                        selfieUseAvatarReferences: !selfieUseAvatarReferences,
-                      })
-                    }
-                  />
-                  <p className="text-[0.55rem] text-[var(--muted-foreground)]">
-                    Used for character selfies when Commands are enabled. The prompt model writes the selfie prompt;
-                    the selfie connection renders the final image.
-                  </p>
+                <div
+                  className={cn(
+                    "mari-chat-option-field space-y-3 rounded-lg px-3 py-2.5 transition-all",
+                    (metadata.conversationCallsEnabled === true || callAudioEnabled) &&
+                      "mari-chat-option-field--active",
+                  )}
+                >
+                  <div className="flex items-start gap-2">
+                    <div className="mt-0.5 flex h-7 w-7 shrink-0 items-center justify-center rounded-lg bg-[var(--secondary)] text-[var(--muted-foreground)]">
+                      <Phone size="0.875rem" />
+                    </div>
+                    <div className="min-w-0 flex-1">
+                      <span className="block text-xs font-medium text-[var(--foreground)]">Conversation Calls</span>
+                      <p className="text-[0.625rem] leading-snug text-[var(--muted-foreground)]">
+                        Per-chat call access, microphone handling, camera/screen input, and soundboard setup.
+                      </p>
+                    </div>
+                  </div>
 
-                  {/* Selfie resolution picker */}
-                  {(metadata.imageGenConnectionId as string) && (
-                    <div className="mt-2 space-y-1">
-                      <span className="text-[0.6875rem] font-medium text-[var(--muted-foreground)]">Resolution</span>
-                      <div className="flex flex-wrap gap-1.5">
-                        {[
-                          { label: "512x512", w: 512, h: 512 },
-                          { label: "512x768", w: 512, h: 768 },
-                          { label: "768x768", w: 768, h: 768 },
-                          { label: "768x1024", w: 768, h: 1024 },
-                          { label: "896x1152", w: 896, h: 1152 },
-                          { label: "1024x1024", w: 1024, h: 1024 },
-                        ].map((opt) => {
-                          const current =
-                            (metadata.selfieResolution as string) ?? `${imageSelfieWidth}x${imageSelfieHeight}`;
-                          const val = `${opt.w}x${opt.h}`;
-                          const active = current === val;
-                          return (
-                            <button
-                              key={val}
-                              type="button"
-                              onClick={() => updateMeta.mutate({ id: chat.id, selfieResolution: val })}
-                              className={`rounded-md px-2 py-1 text-[0.625rem] font-medium transition-colors ${
-                                active
-                                  ? "bg-[var(--primary)] text-[var(--primary-foreground)]"
-                                  : "bg-[var(--secondary)] text-[var(--muted-foreground)] hover:bg-[var(--accent)]"
-                              }`}
-                            >
-                              {opt.label}
-                            </button>
-                          );
-                        })}
-                        {(() => {
-                          const inactiveCustom = availableAgents.filter(
-                            (agent) => agent.category === "custom" && !activeAgentIds.includes(agent.id),
-                          );
-                          if (inactiveCustom.length === 0) return null;
-                          return (
-                            <div className="mt-2 rounded-lg bg-[var(--background)]/55 p-2 ring-1 ring-[var(--border)]">
-                              <div className="mb-1.5 flex items-center gap-1.5 px-1 text-[0.625rem] font-medium text-[var(--muted-foreground)]">
-                                <Settings2 size="0.6875rem" />
-                                Custom Agents
-                              </div>
-                              <div className="flex flex-col gap-1">
-                                {inactiveCustom.map((agent) => (
-                                  <button
-                                    key={agent.id}
-                                    onClick={() => openAgentAddModal(agent)}
-                                    className="flex items-center gap-2.5 rounded-lg bg-[var(--secondary)] px-3 py-2 text-left transition-all hover:bg-[var(--accent)]"
-                                  >
-                                    <Plus size="0.75rem" className="shrink-0 text-[var(--muted-foreground)]" />
-                                    <div className="min-w-0 flex-1">
-                                      <span className="block truncate text-xs">{agent.name}</span>
-                                      <span className="mt-0.5 block text-[0.625rem] leading-tight text-[var(--muted-foreground)] line-clamp-2">
-                                        {agent.description}
-                                      </span>
-                                    </div>
-                                  </button>
-                                ))}
-                              </div>
-                            </div>
-                          );
-                        })()}
+                  <div className="space-y-1.5">
+                    <button
+                      type="button"
+                      onClick={() => {
+                        updateMeta.mutate({
+                          id: chat.id,
+                          conversationCallsEnabled: metadata.conversationCallsEnabled === true ? false : true,
+                        });
+                      }}
+                      className="flex w-full items-center justify-between gap-3 rounded-lg bg-[var(--background)]/35 px-2.5 py-2 text-left transition-colors hover:bg-[var(--secondary)]/50"
+                    >
+                      <div className="min-w-0 flex-1">
+                        <span className="block text-[0.6875rem] font-medium text-[var(--foreground)]">
+                          Audio/Video Calls
+                        </span>
+                        <p className="mt-0.5 text-[0.59375rem] leading-snug text-[var(--muted-foreground)]">
+                          Show the call button for you in this conversation.
+                        </p>
+                      </div>
+                      <div
+                        className={cn(
+                          "mari-chat-option-switch h-5 w-9 shrink-0 rounded-full p-0.5 transition-colors",
+                          metadata.conversationCallsEnabled === true && "mari-chat-option-switch--active",
+                        )}
+                      >
+                        <div
+                          className={cn(
+                            "h-4 w-4 rounded-full bg-white shadow-sm transition-transform",
+                            metadata.conversationCallsEnabled === true && "translate-x-3.5",
+                          )}
+                        />
+                      </div>
+                    </button>
+
+                    <button
+                      type="button"
+                      disabled={callSettingsDisabled}
+                      onClick={() => {
+                        patchConversationCallTtsConfig({
+                          callAudioEnabled: !callAudioEnabled,
+                          ...(!callAudioEnabled ? { callAudioInputMode: "local_whisper" } : {}),
+                        });
+                      }}
+                      className={cn(
+                        "flex w-full items-center justify-between gap-3 rounded-lg bg-[var(--background)]/35 px-2.5 py-2 text-left transition-colors hover:bg-[var(--secondary)]/50",
+                        callSettingsDisabled && "cursor-not-allowed opacity-60 hover:bg-[var(--background)]/35",
+                      )}
+                    >
+                      <div className="min-w-0 flex-1">
+                        <span className="block text-[0.6875rem] font-medium text-[var(--foreground)]">
+                          Call Audio Pipeline
+                        </span>
+                        <p className="mt-0.5 text-[0.59375rem] leading-snug text-[var(--muted-foreground)]">
+                          Request microphone access, listen while unmuted, and transcribe speech into the call.
+                        </p>
+                      </div>
+                      <div className="flex shrink-0 items-center gap-2">
+                        {updateTtsConfig.isPending && <Loader2 size="0.75rem" className="animate-spin" />}
+                        <div
+                          className={cn(
+                            "mari-chat-option-switch h-5 w-9 shrink-0 rounded-full p-0.5 transition-colors",
+                            callAudioEnabled && "mari-chat-option-switch--active",
+                          )}
+                        >
+                          <div
+                            className={cn(
+                              "h-4 w-4 rounded-full bg-white shadow-sm transition-transform",
+                              callAudioEnabled && "translate-x-3.5",
+                            )}
+                          />
+                        </div>
+                      </div>
+                    </button>
+                  </div>
+
+                  {callAudioEnabled ? (
+                    <div className="space-y-2 border-t border-[var(--border)]/60 pt-3">
+                      <label className="flex flex-col gap-1">
+                        <span className="text-[0.625rem] font-medium text-[var(--foreground)]">Audio input mode</span>
+                        <select
+                          value={callAudioInputMode}
+                          disabled={callSettingsDisabled}
+                          onChange={(event) =>
+                            patchConversationCallTtsConfig({
+                              callAudioInputMode: event.target.value as TTSConversationCallAudioInputMode,
+                            })
+                          }
+                          className="w-full rounded-lg border border-[var(--border)] bg-[var(--background)] px-2.5 py-2 text-xs text-[var(--foreground)] outline-none transition-colors focus:border-[var(--primary)]/50 disabled:cursor-not-allowed disabled:opacity-60"
+                        >
+                          <option value="local_whisper">Mic recording + Local Whisper</option>
+                          <option value="transcribe">Browser speech recognition</option>
+                          <option value="system">Manual system dictation</option>
+                          <option value="auto">Provider-native audio/video</option>
+                        </select>
+                        <span className="text-[0.55rem] leading-snug text-[var(--muted-foreground)]">
+                          Local Whisper records mic audio while you are unmuted, ignores silence, and transcribes speech
+                          locally. Browser speech uses Web Speech where supported and falls back to Local Whisper when
+                          it is not. Manual system dictation only focuses the call input so OS dictation can type there.
+                          Provider-native mode sends media to the selected conversation model.
+                        </span>
+                      </label>
+
+                      <div className="grid gap-1.5 sm:grid-cols-2">
+                        <button
+                          type="button"
+                          disabled={callSettingsDisabled}
+                          onClick={() =>
+                            patchConversationCallTtsConfig({ callVideoInputEnabled: !callVideoInputEnabled })
+                          }
+                          className={cn(
+                            "mari-chat-option-field flex items-center justify-between gap-2 rounded-lg px-2.5 py-2 text-left transition-all",
+                            callVideoInputEnabled && "mari-chat-option-field--active",
+                            callSettingsDisabled && "cursor-not-allowed opacity-60",
+                          )}
+                        >
+                          <span className="text-[0.625rem] font-medium text-[var(--foreground)]">
+                            Camera and screen input
+                          </span>
+                          <div
+                            className={cn(
+                              "mari-chat-option-switch h-4 w-7 shrink-0 rounded-full p-0.5 transition-colors",
+                              callVideoInputEnabled && "mari-chat-option-switch--active",
+                            )}
+                          >
+                            <div
+                              className={cn(
+                                "h-3 w-3 rounded-full bg-white shadow-sm transition-transform",
+                                callVideoInputEnabled && "translate-x-3",
+                              )}
+                            />
+                          </div>
+                        </button>
+                        <button
+                          type="button"
+                          disabled={callSettingsDisabled}
+                          onClick={() =>
+                            patchConversationCallTtsConfig({ callSoundboardEnabled: !callSoundboardEnabled })
+                          }
+                          className={cn(
+                            "mari-chat-option-field flex items-center justify-between gap-2 rounded-lg px-2.5 py-2 text-left transition-all",
+                            callSoundboardEnabled && "mari-chat-option-field--active",
+                            callSettingsDisabled && "cursor-not-allowed opacity-60",
+                          )}
+                        >
+                          <span className="text-[0.625rem] font-medium text-[var(--foreground)]">Soundboard</span>
+                          <div
+                            className={cn(
+                              "mari-chat-option-switch h-4 w-7 shrink-0 rounded-full p-0.5 transition-colors",
+                              callSoundboardEnabled && "mari-chat-option-switch--active",
+                            )}
+                          >
+                            <div
+                              className={cn(
+                                "h-3 w-3 rounded-full bg-white shadow-sm transition-transform",
+                                callSoundboardEnabled && "translate-x-3",
+                              )}
+                            />
+                          </div>
+                        </button>
                       </div>
                     </div>
+                  ) : (
+                    <p className="rounded-lg border border-dashed border-[var(--border)] px-2.5 py-2 text-[0.59375rem] leading-snug text-[var(--muted-foreground)]">
+                      Turn on the call audio pipeline here to use local mic transcription, browser speech recognition,
+                      manual system dictation, optional provider-native audio/video input, and the soundboard.
+                    </p>
                   )}
+                </div>
 
-                  {/* Selfie prompt controls */}
-                  {(metadata.imageGenConnectionId as string) && (
-                    <SelfiePromptControls
-                      promptTemplate={metadata.selfiePrompt as string | null | undefined}
-                      positivePrompt={metadata.selfiePositivePrompt as string | undefined}
-                      legacyTags={(metadata.selfieTags as string[]) ?? []}
-                      negativePrompt={(metadata.selfieNegativePrompt as string) ?? ""}
-                      onCommitPromptTemplate={(selfiePrompt) => updateMeta.mutate({ id: chat.id, selfiePrompt })}
-                      onCommitPositivePrompt={(selfiePositivePrompt) =>
-                        updateMeta.mutate({ id: chat.id, selfiePositivePrompt })
-                      }
-                      onCommitNegativePrompt={(selfieNegativePrompt) =>
-                        updateMeta.mutate({ id: chat.id, selfieNegativePrompt })
-                      }
-                    />
+                <div
+                  className={cn(
+                    "mari-chat-option-field space-y-3 rounded-lg px-3 py-2.5 transition-all",
+                    selfieFeatureEnabled && "mari-chat-option-field--active",
+                  )}
+                >
+                  <div className="flex items-start gap-2">
+                    <div className="mt-0.5 flex h-7 w-7 shrink-0 items-center justify-center rounded-lg bg-[var(--secondary)] text-[var(--muted-foreground)]">
+                      <Image size="0.875rem" />
+                    </div>
+                    <div className="min-w-0 flex-1">
+                      <span className="block text-xs font-medium text-[var(--foreground)]">Selfies</span>
+                      <p className="text-[0.625rem] leading-snug text-[var(--muted-foreground)]">
+                        Let characters use [selfie], then choose the image connection, prompt model, style, references,
+                        and resolution.
+                      </p>
+                    </div>
+                  </div>
+
+                  <button
+                    type="button"
+                    onClick={toggleConversationSelfies}
+                    className="flex w-full items-center justify-between gap-3 rounded-lg bg-[var(--background)]/35 px-2.5 py-2 text-left transition-colors hover:bg-[var(--secondary)]/50"
+                  >
+                    <div className="min-w-0 flex-1">
+                      <span className="block text-[0.6875rem] font-medium text-[var(--foreground)]">
+                        Generated Selfies
+                      </span>
+                      <p className="mt-0.5 text-[0.59375rem] leading-snug text-[var(--muted-foreground)]">
+                        Enable the Selfies command for this conversation.
+                      </p>
+                    </div>
+                    <div
+                      className={cn(
+                        "mari-chat-option-switch h-5 w-9 shrink-0 rounded-full p-0.5 transition-colors",
+                        selfieFeatureEnabled && "mari-chat-option-switch--active",
+                      )}
+                    >
+                      <div
+                        className={cn(
+                          "h-4 w-4 rounded-full bg-white shadow-sm transition-transform",
+                          selfieFeatureEnabled && "translate-x-3.5",
+                        )}
+                      />
+                    </div>
+                  </button>
+
+                  {selfieSettingsOpen ? (
+                    <div className="space-y-2 border-t border-[var(--border)]/60 pt-3">
+                      <label className="flex flex-col gap-1">
+                        <span className="text-[0.625rem] font-medium text-[var(--foreground)]">Selfie Connection</span>
+                        <select
+                          value={selfieConnectionId}
+                          onChange={(e) =>
+                            updateMeta.mutate({ id: chat.id, imageGenConnectionId: e.target.value || null })
+                          }
+                          className="w-full rounded-lg border border-[var(--border)] bg-[var(--background)] px-2.5 py-2 text-xs text-[var(--foreground)] outline-none transition-colors focus:border-[var(--primary)]/50"
+                        >
+                          <option value="">None (selfies disabled)</option>
+                          {imageConnectionsList.map((c) => (
+                            <option key={c.id} value={c.id}>
+                              {c.name} ({c.provider})
+                            </option>
+                          ))}
+                        </select>
+                      </label>
+                      {renderIllustratorPromptConnectionSelect()}
+                      <label className="flex flex-col gap-1">
+                        <span className="text-[0.625rem] font-medium text-[var(--foreground)]">Image Style</span>
+                        <select
+                          value={(metadata.imageStyleProfileId as string) ?? ""}
+                          onChange={(e) =>
+                            updateMeta.mutate({ id: chat.id, imageStyleProfileId: e.target.value || null })
+                          }
+                          className="w-full rounded-lg border border-[var(--border)] bg-[var(--background)] px-2.5 py-2 text-xs text-[var(--foreground)] outline-none transition-colors focus:border-[var(--primary)]/50"
+                        >
+                          <option value="">Use default style from Style Profiles in Advanced settings</option>
+                          {imageStyleProfiles.profiles.map((profile) => (
+                            <option key={profile.id} value={profile.id}>
+                              {profile.name}
+                            </option>
+                          ))}
+                        </select>
+                      </label>
+                      <AgentSettingsToggle
+                        label="Send Avatar References"
+                        description="Send the matching character avatar or sprite as a reference image for generated selfies when the provider supports it."
+                        enabled={selfieUseAvatarReferences}
+                        onToggle={() =>
+                          updateMeta.mutate({
+                            id: chat.id,
+                            selfieUseAvatarReferences: !selfieUseAvatarReferences,
+                          })
+                        }
+                      />
+                      <AgentSettingsToggle
+                        label="Attach Card Appearance"
+                        description="Append the matching character card appearance text to generated selfie prompts."
+                        enabled={selfieIncludeCharacterAppearance}
+                        onToggle={() =>
+                          updateMeta.mutate({
+                            id: chat.id,
+                            selfieIncludeCharacterAppearance: !selfieIncludeCharacterAppearance,
+                          })
+                        }
+                      />
+                      <p className="text-[0.55rem] text-[var(--muted-foreground)]">
+                        Used for character selfies when Commands are enabled. The prompt model writes the selfie prompt;
+                        the selfie connection renders the final image.
+                      </p>
+
+                      {selfieConnectionId ? (
+                        <div className="mt-2 space-y-1">
+                          <span className="text-[0.6875rem] font-medium text-[var(--muted-foreground)]">
+                            Resolution
+                          </span>
+                          <div className="flex flex-wrap gap-1.5">
+                            {[
+                              { label: "512x512", w: 512, h: 512 },
+                              { label: "512x768", w: 512, h: 768 },
+                              { label: "768x768", w: 768, h: 768 },
+                              { label: "768x1024", w: 768, h: 1024 },
+                              { label: "896x1152", w: 896, h: 1152 },
+                              { label: "1024x1024", w: 1024, h: 1024 },
+                            ].map((opt) => {
+                              const current =
+                                (metadata.selfieResolution as string) ?? `${imageSelfieWidth}x${imageSelfieHeight}`;
+                              const val = `${opt.w}x${opt.h}`;
+                              const active = current === val;
+                              return (
+                                <button
+                                  key={val}
+                                  type="button"
+                                  onClick={() => updateMeta.mutate({ id: chat.id, selfieResolution: val })}
+                                  className={cn(
+                                    "rounded-md px-2 py-1 text-[0.625rem] font-medium transition-colors",
+                                    active
+                                      ? "bg-[var(--primary)] text-[var(--primary-foreground)]"
+                                      : "bg-[var(--secondary)] text-[var(--muted-foreground)] hover:bg-[var(--accent)]",
+                                  )}
+                                >
+                                  {opt.label}
+                                </button>
+                              );
+                            })}
+                          </div>
+                        </div>
+                      ) : (
+                        <p className="rounded-lg border border-dashed border-[var(--border)] px-2.5 py-2 text-[0.59375rem] leading-snug text-[var(--muted-foreground)]">
+                          Choose a Selfie Connection to let characters generate selfie images.
+                        </p>
+                      )}
+                    </div>
+                  ) : (
+                    <p className="rounded-lg border border-dashed border-[var(--border)] px-2.5 py-2 text-[0.59375rem] leading-snug text-[var(--muted-foreground)]">
+                      Turn on Selfies to reveal connection, prompt model, image style, reference, and resolution
+                      settings.
+                    </p>
                   )}
                 </div>
 
@@ -5341,15 +5587,17 @@ export function ChatSettingsDrawer({
                 )}
                 <button
                   onClick={() => setShowAgentSuiteModal(true)}
-                  className="flex w-full items-center justify-between rounded-lg bg-[var(--secondary)] px-3 py-2.5 text-left transition-all hover:bg-[var(--accent)]"
+                  className="flex w-full items-center justify-between gap-3 rounded-lg bg-[var(--secondary)] px-3 py-2.5 text-left transition-all hover:bg-[var(--accent)]"
                 >
-                  <div className="flex-1 min-w-0">
+                  <div className="min-w-0 flex-1">
                     <span className="text-[0.6875rem] font-medium">Agent Suite</span>
                     <p className="text-[0.625rem] text-[var(--muted-foreground)]">
                       View and edit everything agents have stored in this chat — manually or with AI.
                     </p>
                   </div>
-                  <Wrench size="0.875rem" className="shrink-0 text-[var(--muted-foreground)]" />
+                  <div className="flex h-5 w-9 shrink-0 items-center justify-center text-[var(--muted-foreground)]">
+                    <Wrench size="0.75rem" />
+                  </div>
                 </button>
                 {roleplayAgentMenuLinks.length > 0 && (
                   <div className="rounded-lg bg-[var(--background)]/45 px-2.5 py-2 ring-1 ring-[var(--border)]">
@@ -6097,10 +6345,7 @@ export function ChatSettingsDrawer({
                                     </div>
                                   </button>
 
-                                  <SpriteToggleButton
-                                    active={spriteActive}
-                                    onToggle={() => toggleSprite(subject.id)}
-                                  />
+                                  <SpriteToggleButton active={spriteActive} onToggle={() => toggleSprite(subject.id)} />
                                 </div>
                               );
                             })}
@@ -6634,9 +6879,7 @@ export function ChatSettingsDrawer({
                         />
                         {renderIllustratorPromptConnectionSelect()}
                         <label className="flex flex-col gap-1">
-                          <span className="text-[0.625rem] font-medium text-[var(--foreground)]">
-                            Image Connection
-                          </span>
+                          <span className="text-[0.625rem] font-medium text-[var(--foreground)]">Image Connection</span>
                           <select
                             value={(metadata.gameImageConnectionId as string) ?? ""}
                             onChange={(e) =>
@@ -7250,9 +7493,7 @@ export function ChatSettingsDrawer({
               excludePastReasoning={metadata.excludePastReasoning as boolean | undefined}
               imageCaptioningEnabled={metadata.imageCaptioningEnabled as boolean | undefined}
               imageCaptioningConnectionId={
-                typeof metadata.imageCaptioningConnectionId === "string"
-                  ? metadata.imageCaptioningConnectionId
-                  : null
+                typeof metadata.imageCaptioningConnectionId === "string" ? metadata.imageCaptioningConnectionId : null
               }
               onChatParametersChange={(chatParameters) => updateMeta.mutate({ id: chat.id, chatParameters })}
               onContextMessageLimitChange={(contextMessageLimit) =>
@@ -8429,13 +8670,7 @@ function SpriteDisplayModeToggle({
 }
 
 // ── Sprite toggle button (per character) ──
-function SpriteToggleButton({
-  active,
-  onToggle,
-}: {
-  active: boolean;
-  onToggle: () => void;
-}) {
+function SpriteToggleButton({ active, onToggle }: { active: boolean; onToggle: () => void }) {
   return (
     <button
       onClick={onToggle}
@@ -8470,95 +8705,6 @@ interface ScheduleBlock {
   status: "online" | "idle" | "dnd" | "offline";
 }
 
-function SelfiePromptControls({
-  promptTemplate,
-  positivePrompt,
-  legacyTags,
-  negativePrompt,
-  onCommitPromptTemplate,
-  onCommitPositivePrompt,
-  onCommitNegativePrompt,
-}: {
-  promptTemplate: string | null | undefined;
-  positivePrompt: string | undefined;
-  legacyTags: string[];
-  negativePrompt: string;
-  onCommitPromptTemplate: (value: string | null) => void;
-  onCommitPositivePrompt: (value: string) => void;
-  onCommitNegativePrompt: (value: string) => void;
-}) {
-  const legacyTagText = legacyTags.join(", ");
-  const displayPositivePrompt = positivePrompt ?? legacyTagText;
-  const displayPromptTemplate = promptTemplate ?? "";
-  const [promptDraft, setPromptDraft] = useState(displayPromptTemplate);
-  const [positiveDraft, setPositiveDraft] = useState(displayPositivePrompt);
-  const [negativeDraft, setNegativeDraft] = useState(negativePrompt);
-
-  useEffect(() => {
-    setPromptDraft(displayPromptTemplate);
-  }, [displayPromptTemplate]);
-
-  useEffect(() => {
-    setPositiveDraft(displayPositivePrompt);
-  }, [displayPositivePrompt]);
-
-  useEffect(() => {
-    setNegativeDraft(negativePrompt);
-  }, [negativePrompt]);
-
-  const commitPromptTemplate = useCallback(() => {
-    const nextValue = promptDraft.trim().length > 0 ? promptDraft : null;
-    if ((nextValue ?? "") !== displayPromptTemplate) onCommitPromptTemplate(nextValue);
-  }, [displayPromptTemplate, onCommitPromptTemplate, promptDraft]);
-
-  const commitPositivePrompt = useCallback(() => {
-    if (positiveDraft !== displayPositivePrompt) onCommitPositivePrompt(positiveDraft);
-  }, [displayPositivePrompt, onCommitPositivePrompt, positiveDraft]);
-
-  const commitNegativePrompt = useCallback(() => {
-    if (negativeDraft !== negativePrompt) onCommitNegativePrompt(negativeDraft);
-  }, [negativeDraft, negativePrompt, onCommitNegativePrompt]);
-
-  return (
-    <div className="mt-2 space-y-2">
-      <label className="flex flex-col gap-1">
-        <span className="text-[0.6875rem] font-medium text-[var(--muted-foreground)]">Selfie prompt</span>
-        <textarea
-          value={promptDraft}
-          onChange={(e) => setPromptDraft(e.target.value)}
-          onBlur={commitPromptTemplate}
-          placeholder={`You are an image prompt generator. Create a concise selfie prompt for ${"${charName}"} using this appearance: ${"${appearance}"}.\nOutput ONLY the prompt text, nothing else.`}
-          className="min-h-[7rem] resize-y rounded-lg border border-[var(--border)] bg-[var(--secondary)] p-2 text-[0.6875rem] text-[var(--foreground)] outline-none transition-colors placeholder:text-[var(--muted-foreground)]/45 focus:border-[var(--primary)]/50"
-        />
-      </label>
-      <label className="flex flex-col gap-1">
-        <span className="text-[0.6875rem] font-medium text-[var(--muted-foreground)]">Positive tags</span>
-        <textarea
-          value={positiveDraft}
-          onChange={(e) => setPositiveDraft(e.target.value)}
-          onBlur={commitPositivePrompt}
-          placeholder="masterpiece, best quality, detailed eyes"
-          className="min-h-[4rem] resize-y rounded-lg border border-[var(--border)] bg-[var(--secondary)] p-2 text-[0.6875rem] text-[var(--foreground)] outline-none transition-colors placeholder:text-[var(--muted-foreground)]/45 focus:border-[var(--primary)]/50"
-        />
-      </label>
-      <label className="flex flex-col gap-1">
-        <span className="text-[0.6875rem] font-medium text-[var(--muted-foreground)]">Negative prompt</span>
-        <textarea
-          value={negativeDraft}
-          onChange={(e) => setNegativeDraft(e.target.value)}
-          onBlur={commitNegativePrompt}
-          placeholder="lowres, bad anatomy, extra fingers"
-          className="min-h-[4rem] resize-y rounded-lg border border-[var(--border)] bg-[var(--secondary)] p-2 text-[0.6875rem] text-[var(--foreground)] outline-none transition-colors placeholder:text-[var(--muted-foreground)]/45 focus:border-[var(--primary)]/50"
-        />
-      </label>
-      <p className="text-[0.55rem] text-[var(--muted-foreground)]">
-        Saved for this chat. Leave the selfie prompt blank to use the default prompt. The template can use{" "}
-        {"${charName}"} and {"${appearance}"}. Positive tags are appended to the generated selfie prompt; negative tags
-        are sent directly to the image generator.
-      </p>
-    </div>
-  );
-}
 function ScheduleEditor({
   characterSchedules,
   chatCharIds,

--- a/packages/client/src/components/chat/ChatSetupWizard.tsx
+++ b/packages/client/src/components/chat/ChatSetupWizard.tsx
@@ -21,6 +21,7 @@ import {
   Sparkles,
   Feather,
   RotateCcw,
+  Phone,
 } from "lucide-react";
 import { cn, getAvatarCropStyle, type AvatarCrop } from "../../lib/utils";
 import { useConnections } from "../../hooks/use-connections";
@@ -162,6 +163,7 @@ const CONVERSATION_COMMAND_TOGGLE_OPTIONS: Array<{
   { id: "haptic", label: "Haptics", description: "Let characters control connected haptic devices." },
   { id: "influence", label: "Influence", description: "Let characters influence a connected chat." },
   { id: "note", label: "Notes", description: "Let characters save durable notes for a connected chat." },
+  { id: "call", label: "Calls", description: "Let characters ring you for a Conversation call." },
   { id: "uno", label: "UNO", description: "Let characters start a game of UNO at the table when you agree to play." },
   { id: "chess", label: "Chess", description: "Let characters accept a one-on-one chess challenge at the table." },
 ];
@@ -728,6 +730,7 @@ function ConversationQuickSetup({ chat, onFinish }: ChatSetupWizardProps) {
   const metadata = useMemo(() => {
     return readChatMetadata(chat);
   }, [chat]);
+  const [callsEnabled, setCallsEnabled] = useState(() => metadata.conversationCallsEnabled === true);
   const [commandsEnabled, setCommandsEnabled] = useState(() => metadata.characterCommands !== false);
   const [conversationCommandToggles, setConversationCommandToggles] = useState<
     Partial<Record<ConversationCommandKey, boolean>>
@@ -763,6 +766,10 @@ function ConversationQuickSetup({ chat, onFinish }: ChatSetupWizardProps) {
   useEffect(() => {
     setCustomizeParameters(!!parseEditableGenerationParameters(metadata.chatParameters));
   }, [metadata.chatParameters]);
+
+  useEffect(() => {
+    setCallsEnabled(metadata.conversationCallsEnabled === true);
+  }, [metadata.conversationCallsEnabled]);
 
   const chatCharIds: string[] = useMemo(() => {
     return typeof chat.characterIds === "string" ? JSON.parse(chat.characterIds) : (chat.characterIds ?? []);
@@ -913,6 +920,7 @@ function ConversationQuickSetup({ chat, onFinish }: ChatSetupWizardProps) {
       id: chat.id,
       autonomousMessages: autonomousEnabled,
       conversationSchedulesEnabled: autonomousEnabled && generateSchedule,
+      conversationCallsEnabled: callsEnabled,
       characterCommands: commandsEnabled,
       conversationCommandToggles,
       chatParameters: customizeParameters ? generationParameters : null,
@@ -944,6 +952,7 @@ function ConversationQuickSetup({ chat, onFinish }: ChatSetupWizardProps) {
     chatCharIds,
     onFinish,
     autonomousEnabled,
+    callsEnabled,
     generateSchedule,
     updateMeta,
     customizeParameters,
@@ -1285,6 +1294,45 @@ function ConversationQuickSetup({ chat, onFinish }: ChatSetupWizardProps) {
         </button>
       )}
 
+      <div
+        className={cn(
+          "mari-chat-option-field rounded-lg transition-all",
+          callsEnabled && "mari-chat-option-field--active",
+        )}
+      >
+        <button
+          type="button"
+          onClick={() => setCallsEnabled((value) => !value)}
+          className="flex w-full items-center justify-between px-3 py-2.5 text-left"
+        >
+          <div className="flex min-w-0 flex-1 items-center gap-2">
+            <Phone
+              size="0.875rem"
+              className={callsEnabled ? "text-[var(--primary)]" : "text-[var(--muted-foreground)]"}
+            />
+            <div>
+              <span className="text-xs font-medium">Audio/Video Calls</span>
+              <p className="text-[0.625rem] text-[var(--muted-foreground)]">
+                Add a call button and call-only transcript to this conversation.
+              </p>
+            </div>
+          </div>
+          <div
+            className={cn(
+              "mari-chat-option-switch h-5 w-9 shrink-0 rounded-full p-0.5 transition-colors",
+              callsEnabled && "mari-chat-option-switch--active",
+            )}
+          >
+            <div
+              className={cn(
+                "h-4 w-4 rounded-full bg-white shadow-sm transition-transform",
+                callsEnabled && "translate-x-3.5",
+              )}
+            />
+          </div>
+        </button>
+      </div>
+
       <button
         onClick={() => setCommandsEnabled((value) => !value)}
         className={cn(
@@ -1371,9 +1419,9 @@ function ConversationQuickSetup({ chat, onFinish }: ChatSetupWizardProps) {
       ? renderConnectionStep()
       : currentStep.key === "prompt"
         ? renderPromptStep()
-      : currentStep.key === "participants"
-        ? renderParticipantsStep()
-        : renderAutomationStep();
+        : currentStep.key === "participants"
+          ? renderParticipantsStep()
+          : renderAutomationStep();
   const busyContent =
     scheduleState === "generating" ? (
       <div className="flex items-center justify-center gap-2 py-1">

--- a/packages/client/src/components/chat/ConversationCallFloatingHost.tsx
+++ b/packages/client/src/components/chat/ConversationCallFloatingHost.tsx
@@ -1,0 +1,180 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { Loader2, Phone, PhoneOff } from "lucide-react";
+import { toast } from "sonner";
+import { useChatStore } from "../../stores/chat.store";
+import { useUIStore } from "../../stores/ui.store";
+import { cn } from "../../lib/utils";
+import { useConversationCallStatus, useEndConversationCall } from "../../hooks/use-conversation-calls";
+import { ConversationCallSurface } from "./ConversationCallSurface";
+
+function callStartedAtMs(value: string | null | undefined) {
+  if (!value) return Date.now();
+  const timestamp = Date.parse(value);
+  return Number.isFinite(timestamp) ? timestamp : Date.now();
+}
+
+function formatDuration(ms: number) {
+  const totalSeconds = Math.max(0, Math.floor(ms / 1000));
+  const hours = Math.floor(totalSeconds / 3600);
+  const minutes = Math.floor((totalSeconds % 3600) / 60);
+  const seconds = totalSeconds % 60;
+  const two = (value: number) => String(value).padStart(2, "0");
+  return hours > 0 ? `${hours}:${two(minutes)}:${two(seconds)}` : `${two(minutes)}:${two(seconds)}`;
+}
+
+export function ConversationCallFloatingHost() {
+  const snapshot = useChatStore((state) => state.activeConversationCall);
+  const expandedPreference = useChatStore((state) => state.conversationCallExpanded);
+  const activeChatId = useChatStore((state) => state.activeChatId);
+  const setActiveChatId = useChatStore((state) => state.setActiveChatId);
+  const setActiveConversationCall = useChatStore((state) => state.setActiveConversationCall);
+  const updateActiveConversationCallSession = useChatStore((state) => state.updateActiveConversationCallSession);
+  const setConversationCallExpanded = useChatStore((state) => state.setConversationCallExpanded);
+  const closeAllDetails = useUIStore((state) => state.closeAllDetails);
+  const botBrowserOpen = useUIStore((state) => state.botBrowserOpen);
+  const gameAssetsBrowserOpen = useUIStore((state) => state.gameAssetsBrowserOpen);
+  const characterDetailId = useUIStore((state) => state.characterDetailId);
+  const lorebookDetailId = useUIStore((state) => state.lorebookDetailId);
+  const presetDetailId = useUIStore((state) => state.presetDetailId);
+  const connectionDetailId = useUIStore((state) => state.connectionDetailId);
+  const agentDetailId = useUIStore((state) => state.agentDetailId);
+  const toolDetailId = useUIStore((state) => state.toolDetailId);
+  const personaDetailId = useUIStore((state) => state.personaDetailId);
+  const regexDetailId = useUIStore((state) => state.regexDetailId);
+  const characterLibraryOpen = useUIStore((state) => state.characterLibraryOpen);
+  const { data: callStatus } = useConversationCallStatus(snapshot?.session.chatId ?? "", Boolean(snapshot));
+  const endCall = useEndConversationCall(snapshot?.session.chatId ?? "");
+  const [now, setNow] = useState(() => Date.now());
+
+  const hasDetailSurface =
+    botBrowserOpen ||
+    gameAssetsBrowserOpen ||
+    characterLibraryOpen ||
+    Boolean(
+      characterDetailId ||
+      lorebookDetailId ||
+      presetDetailId ||
+      connectionDetailId ||
+      agentDetailId ||
+      toolDetailId ||
+      personaDetailId ||
+      regexDetailId,
+    );
+  const expanded =
+    Boolean(snapshot) && expandedPreference && activeChatId === snapshot?.session.chatId && !hasDetailSurface;
+
+  useEffect(() => {
+    if (!snapshot) return;
+    const interval = window.setInterval(() => setNow(Date.now()), 1000);
+    return () => window.clearInterval(interval);
+  }, [snapshot]);
+
+  useEffect(() => {
+    if (!snapshot || !callStatus) return;
+    if (callStatus.activeCall?.id === snapshot.session.id) {
+      updateActiveConversationCallSession(callStatus.activeCall);
+      return;
+    }
+    setActiveConversationCall(null);
+  }, [callStatus, setActiveConversationCall, snapshot, updateActiveConversationCallSession]);
+
+  const clearCall = useCallback(() => {
+    setActiveConversationCall(null);
+  }, [setActiveConversationCall]);
+
+  const returnToCall = useCallback(() => {
+    if (!snapshot) return;
+    closeAllDetails();
+    setActiveChatId(snapshot.session.chatId);
+    setConversationCallExpanded(true);
+  }, [closeAllDetails, setActiveChatId, setConversationCallExpanded, snapshot]);
+
+  const endMinimizedCall = useCallback(async () => {
+    if (!snapshot) return;
+    try {
+      await endCall.mutateAsync(snapshot.session.id);
+      clearCall();
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : "Could not end the call.");
+    }
+  }, [clearCall, endCall, snapshot]);
+
+  const participantNames = useMemo(() => {
+    if (!snapshot) return "";
+    return snapshot.chatCharIds
+      .map((id) => snapshot.characterMap.get(id)?.name)
+      .filter((name): name is string => Boolean(name))
+      .slice(0, 3)
+      .join(", ");
+  }, [snapshot]);
+
+  if (!snapshot) return null;
+  if (expanded) return null;
+
+  const firstCharacter = snapshot.chatCharIds.map((id) => snapshot.characterMap.get(id)).find(Boolean);
+  const elapsedLabel = formatDuration(now - callStartedAtMs(snapshot.session.startedAt ?? snapshot.session.createdAt));
+  const chatLabel = snapshot.chatName || participantNames || "Conversation call";
+
+  return (
+    <>
+      <div
+        className={cn(
+          "mari-chat-area mari-card-css overflow-hidden bg-[var(--background)]",
+          expanded
+            ? "absolute inset-x-0 bottom-0 top-14 z-40 flex min-h-0 flex-col"
+            : "pointer-events-none fixed -left-[200vw] top-0 z-[-1] h-px w-px opacity-0",
+        )}
+        aria-hidden={!expanded}
+      >
+        <ConversationCallSurface
+          chatId={snapshot.session.chatId}
+          session={snapshot.session}
+          characterMap={snapshot.characterMap}
+          chatCharIds={snapshot.chatCharIds}
+          personaInfo={snapshot.personaInfo}
+          onEnded={clearCall}
+        />
+      </div>
+
+      {!expanded && (
+        <aside
+          className="mari-conversation-call-mini mari-card-css mari-chrome-token-scope pointer-events-auto fixed z-50 flex w-[min(22rem,calc(100vw-1.5rem))] items-center gap-3 rounded-xl border border-[var(--marinara-chat-chrome-panel-border)] bg-[var(--marinara-chat-chrome-panel-bg)] p-2.5 text-[var(--marinara-chat-chrome-panel-text)] shadow-2xl shadow-black/30"
+          aria-label="Active Conversation call"
+        >
+          <button
+            type="button"
+            onClick={returnToCall}
+            className="flex min-w-0 flex-1 items-center gap-2 rounded-lg p-1 text-left transition-colors hover:bg-[var(--marinara-chat-chrome-highlight-bg-hover)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--marinara-chat-chrome-focus-ring)]"
+            title="Return to call"
+          >
+            <div className="relative flex h-10 w-10 shrink-0 items-center justify-center overflow-hidden rounded-lg border border-[var(--marinara-chat-chrome-panel-border)] bg-[var(--marinara-chat-chrome-highlight-bg)]">
+              {firstCharacter?.avatarUrl ? (
+                <img src={firstCharacter.avatarUrl} alt="" className="h-full w-full object-cover" />
+              ) : (
+                <Phone size="1rem" className="text-[var(--marinara-chat-chrome-button-text-hover)]" />
+              )}
+              <span className="absolute -bottom-0.5 -right-0.5 h-3 w-3 rounded-full border-2 border-[var(--marinara-chat-chrome-panel-bg)] bg-emerald-500" />
+            </div>
+            <div className="min-w-0">
+              <div className="truncate text-sm font-semibold text-[var(--marinara-chat-chrome-panel-title)]">
+                {chatLabel}
+              </div>
+              <div className="truncate text-xs tabular-nums text-[var(--marinara-chat-chrome-panel-muted)]">
+                In call, {elapsedLabel}
+              </div>
+            </div>
+          </button>
+          <button
+            type="button"
+            onClick={() => void endMinimizedCall()}
+            disabled={endCall.isPending}
+            className="mari-chrome-control mari-chrome-control--danger h-10 w-10 p-0"
+            title="End call"
+          >
+            {endCall.isPending ? <Loader2 size="1rem" className="animate-spin" /> : <PhoneOff size="1rem" />}
+          </button>
+        </aside>
+      )}
+    </>
+  );
+}

--- a/packages/client/src/components/chat/ConversationCallSurface.tsx
+++ b/packages/client/src/components/chat/ConversationCallSurface.tsx
@@ -1,0 +1,2221 @@
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type CSSProperties,
+  type ChangeEvent,
+  type KeyboardEvent,
+} from "react";
+import {
+  Mic,
+  MicOff,
+  Video,
+  VideoOff,
+  ScreenShare,
+  ScreenShareOff,
+  PhoneOff,
+  Send,
+  Sparkles,
+  Upload,
+  Trash2,
+  Loader2,
+  Volume2,
+  VolumeX,
+  Paperclip,
+  Smile,
+  Keyboard,
+  MessageCircle,
+  X,
+} from "lucide-react";
+import { toast } from "sonner";
+import type {
+  ConversationCallMessage,
+  ConversationCallSession,
+  ConversationCallSound,
+  ConversationCallTurn,
+  MessageAttachment,
+} from "@marinara-engine/shared";
+import { cn, getAvatarCropStyle, type AvatarCropValue } from "../../lib/utils";
+import type { CharacterMap, PersonaInfo } from "./chat-area.types";
+import {
+  useConversationCallMessages,
+  useConversationCallSoundboard,
+  useDeleteConversationCallSound,
+  useEndConversationCall,
+  useSendConversationCallMedia,
+  useSendConversationCallIdle,
+  useSendConversationCallMessage,
+  useRecordConversationCallInterruption,
+  useUploadConversationCallSound,
+} from "../../hooks/use-conversation-calls";
+import { useUIStore } from "../../stores/ui.store";
+import { getChatInputShellClass } from "./chat-input-styles";
+import {
+  ConversationMediaPickerPanel,
+  type ConversationMediaPickerTab,
+  type ConversationMediaPickerTabId,
+} from "./ConversationMediaPickerPanel";
+import { QuickConnectionSwitcher } from "./QuickConnectionSwitcher";
+import {
+  getBrowserSpeechRecognitionCtor,
+  isBrowserSpeechRecognitionSupported,
+  readBrowserSpeechRecognitionTranscript,
+  type BrowserSpeechRecognition,
+} from "../../lib/browser-speech-recognition";
+import { useTTSConfig } from "../../hooks/use-tts";
+import { resolveTTSVoiceForSpeaker } from "../../lib/tts-dialogue";
+import { ttsService } from "../../lib/tts-service";
+import {
+  playConversationCallEndSound,
+  playConversationCallJoinSound,
+  playConversationCallLeaveSound,
+  playConversationCallStartSound,
+} from "../../lib/conversation-call-sounds";
+import { useAgentStore } from "../../stores/agent.store";
+
+interface ConversationCallSurfaceProps {
+  chatId: string;
+  session: ConversationCallSession;
+  characterMap: CharacterMap;
+  chatCharIds: string[];
+  personaInfo?: PersonaInfo;
+  onEnded?: () => void;
+  embedded?: boolean;
+}
+
+type Participant = {
+  id: string;
+  name: string;
+  avatarUrl: string | null;
+  avatarCrop?: AvatarCropValue | null;
+  kind: "user" | "character";
+  characterId: string | null;
+  canSpeak: boolean;
+  conversationStatus?: "online" | "idle" | "dnd" | "offline";
+};
+
+type MobileCallPickerTab = Extract<ConversationMediaPickerTabId, "emoji" | "gifs" | "stickers">;
+type LiveMicSegment = {
+  recorder: MediaRecorder;
+  chunks: BlobPart[];
+  startedAt: number;
+  includeVideo: boolean;
+  voicedMs: number;
+  peakRms: number;
+};
+type ParticipantTileDensity = "large" | "medium" | "small" | "compact";
+type ActiveCallVoice = {
+  key: string;
+  characterId: string | null;
+  speakerName: string;
+  spokenText: string;
+};
+
+type ParticipantGridLayout = {
+  columns: number;
+  rows: number;
+  density: ParticipantTileDensity;
+};
+
+const MOBILE_CALL_PICKER_TABS: ConversationMediaPickerTab[] = [
+  { id: "emoji", label: "Emoji" },
+  { id: "gifs", label: "GIFs" },
+  { id: "stickers", label: "Stickers" },
+];
+
+const CALL_SILENCE_CHECK_MS = 150_000;
+const CALL_SILENCE_POLL_MS = 10_000;
+const CALL_MIC_VAD_INTERVAL_MS = 120;
+const CALL_MIC_MIN_SEGMENT_MS = 420;
+const CALL_MIC_SILENCE_MS = 3_000;
+const CALL_MIC_MAX_SEGMENT_MS = 60_000;
+const CALL_MIC_RMS_START = 0.022;
+const CALL_MIC_RMS_CONTINUE = 0.013;
+const CALL_MIC_CONFIRM_FRAMES = 2;
+const CALL_MIC_MIN_VOICED_MS = 180;
+const CALL_MIC_MIN_PEAK_RMS = 0.022;
+const CALL_TTS_INTERRUPT_VOICED_MS = 900;
+const CALL_TTS_INTERRUPT_TEXT_MAX_CHARS = 1200;
+const CALL_TTS_MAX_REQUEST_CHARS = 3_900;
+const DEFAULT_TEXT_TO_VOICE_PAUSE_MS = 1_800;
+const ONLINE_CHARACTER_JOIN_DELAY_MS = 1_600;
+const AWAY_CHARACTER_JOIN_DELAY_MS = 10_000;
+const DND_CHARACTER_JOIN_DELAY_MS = 12_000;
+const CALL_COMMAND_ALIASES = new Map<string, string>([
+  ["end", "end_call"],
+  ["end_call", "end_call"],
+  ["hang_up", "end_call"],
+  ["hangup", "end_call"],
+  ["leave", "leave_call"],
+  ["leave_call", "leave_call"],
+  ["drop", "leave_call"],
+  ["disconnect", "leave_call"],
+  ["sound", "soundboard"],
+  ["sound_board", "soundboard"],
+  ["soundboard", "soundboard"],
+]);
+
+const PARTICIPANT_TILE_CLASSES: Record<
+  ParticipantTileDensity,
+  {
+    tile: string;
+    avatar: string;
+    fallback: string;
+    name: string;
+  }
+> = {
+  large: {
+    tile: "rounded-xl p-4",
+    avatar: "h-24 w-24",
+    fallback: "text-2xl",
+    name: "bottom-3 max-w-[calc(100%-1.5rem)] px-3 py-1 text-xs",
+  },
+  medium: {
+    tile: "rounded-lg p-3",
+    avatar: "h-20 w-20",
+    fallback: "text-xl",
+    name: "bottom-2.5 max-w-[calc(100%-1rem)] px-2.5 py-1 text-[0.72rem]",
+  },
+  small: {
+    tile: "rounded-lg p-2",
+    avatar: "h-14 w-14",
+    fallback: "text-base",
+    name: "bottom-2 max-w-[calc(100%-0.75rem)] px-2 py-0.5 text-[0.65rem]",
+  },
+  compact: {
+    tile: "rounded-md p-1.5",
+    avatar: "h-10 w-10",
+    fallback: "text-sm",
+    name: "bottom-1.5 max-w-[calc(100%-0.5rem)] px-1.5 py-0.5 text-[0.6rem]",
+  },
+};
+
+function getParticipantGridLayout(count: number, mobile: boolean): ParticipantGridLayout {
+  const safeCount = Math.max(1, count);
+  const columns = mobile
+    ? safeCount <= 2
+      ? 1
+      : Math.min(4, Math.ceil(Math.sqrt(safeCount)))
+    : safeCount <= 1
+      ? 1
+      : safeCount === 4
+        ? 2
+        : Math.min(6, Math.ceil(Math.sqrt(safeCount * 1.35)));
+  const rows = Math.max(1, Math.ceil(safeCount / columns));
+  const density: ParticipantTileDensity =
+    safeCount <= 2 ? "large" : safeCount <= 4 ? "medium" : safeCount <= 8 ? "small" : "compact";
+  return { columns, rows, density };
+}
+
+function useMobileCallLayout() {
+  const [mobile, setMobile] = useState(() =>
+    typeof window === "undefined" ? false : window.matchMedia("(max-width: 767px)").matches,
+  );
+
+  useEffect(() => {
+    const media = window.matchMedia("(max-width: 767px)");
+    const update = () => setMobile(media.matches);
+    update();
+    media.addEventListener("change", update);
+    return () => media.removeEventListener("change", update);
+  }, []);
+
+  return mobile;
+}
+
+function wait(ms: number) {
+  return new Promise((resolve) => window.setTimeout(resolve, ms));
+}
+
+function splitCallTtsChunks(lines: string[]): string[] {
+  const chunks: string[] = [];
+  let current = "";
+  for (const rawLine of lines) {
+    const line = rawLine.trim();
+    if (!line) continue;
+    if (!current) {
+      current = line;
+      continue;
+    }
+    if (current.length + 1 + line.length <= CALL_TTS_MAX_REQUEST_CHARS) {
+      current = `${current}\n${line}`;
+      continue;
+    }
+    chunks.push(current);
+    current = line;
+  }
+  if (current) chunks.push(current);
+  return chunks.flatMap((chunk) => {
+    if (chunk.length <= CALL_TTS_MAX_REQUEST_CHARS) return [chunk];
+    const pieces: string[] = [];
+    for (let start = 0; start < chunk.length; start += CALL_TTS_MAX_REQUEST_CHARS) {
+      pieces.push(chunk.slice(start, start + CALL_TTS_MAX_REQUEST_CHARS));
+    }
+    return pieces;
+  });
+}
+
+function getSystemVoiceTypingHint() {
+  if (typeof navigator === "undefined") {
+    return "Manual dictation focuses the call input. Start your operating system's dictation yourself, then send.";
+  }
+  const platform = `${navigator.platform ?? ""} ${navigator.userAgent ?? ""}`.toLowerCase();
+  const isAppleMobile = /iphone|ipad|ipod/.test(platform) || (platform.includes("mac") && navigator.maxTouchPoints > 1);
+  if (isAppleMobile) return "The call input is focused. Tap the keyboard microphone yourself, then send.";
+  if (platform.includes("android")) return "The call input is focused. Tap the keyboard microphone yourself, then send.";
+  if (platform.includes("mac")) {
+    return "The call input is focused. Start macOS Dictation yourself, then send.";
+  }
+  if (platform.includes("win")) return "The call input is focused. Start Windows voice typing with Win+H, then send.";
+  if (platform.includes("linux")) return "The call input is focused. Start your desktop dictation yourself, then send.";
+  return "Manual dictation focuses the call input. Start your operating system's dictation yourself, then send.";
+}
+
+function formatTime(value: string | null | undefined) {
+  if (!value) return "";
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return "";
+  return date.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" });
+}
+
+function formatDuration(ms: number) {
+  const totalSeconds = Math.max(0, Math.floor(ms / 1000));
+  const hours = Math.floor(totalSeconds / 3600);
+  const minutes = Math.floor((totalSeconds % 3600) / 60);
+  const seconds = totalSeconds % 60;
+  const two = (value: number) => String(value).padStart(2, "0");
+  return hours > 0 ? `${hours}:${two(minutes)}:${two(seconds)}` : `${two(minutes)}:${two(seconds)}`;
+}
+
+function callStartedAtMs(session: ConversationCallSession) {
+  const timestamp = Date.parse(session.startedAt ?? session.createdAt);
+  return Number.isFinite(timestamp) ? timestamp : Date.now();
+}
+
+function characterJoinDelayMs(participant: Participant) {
+  if (participant.kind !== "character") return 0;
+  switch (participant.conversationStatus) {
+    case "idle":
+      return AWAY_CHARACTER_JOIN_DELAY_MS;
+    case "dnd":
+      return DND_CHARACTER_JOIN_DELAY_MS;
+    case "online":
+    default:
+      return ONLINE_CHARACTER_JOIN_DELAY_MS;
+  }
+}
+
+function getBracketCommandName(value: string | null | undefined) {
+  const trimmed = value?.trim() ?? "";
+  const bracket = trimmed.match(/^\[([a-z0-9_-]+)/i);
+  const normalized = (bracket?.[1] ?? trimmed)
+    .trim()
+    .toLowerCase()
+    .replace(/[\s-]+/g, "_");
+  return CALL_COMMAND_ALIASES.get(normalized) ?? normalized;
+}
+
+function getSoundboardCommandName(value: string | null | undefined) {
+  const trimmed = value?.trim() ?? "";
+  const match =
+    trimmed.match(/sound\s*=\s*"([^"]+)"/i) ??
+    trimmed.match(/sound\s*=\s*'([^']+)'/i) ??
+    trimmed.match(/sound\s*=\s*([^\]\s,]+)/i);
+  return match?.[1]?.trim() ?? "";
+}
+
+function getCommandStringParam(value: string | null | undefined, name: string) {
+  const trimmed = value?.trim() ?? "";
+  const escapedName = name.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const quoted = new RegExp(`${escapedName}\\s*=\\s*"([^"]+)"`, "i").exec(trimmed);
+  if (quoted?.[1]) return quoted[1].trim();
+  const singleQuoted = new RegExp(`${escapedName}\\s*=\\s*'([^']+)'`, "i").exec(trimmed);
+  if (singleQuoted?.[1]) return singleQuoted[1].trim();
+  const bare = new RegExp(`${escapedName}\\s*=\\s*([^\\]\\s,]+)`, "i").exec(trimmed);
+  return bare?.[1]?.trim() ?? "";
+}
+
+function readCallMessageAttachments(message: ConversationCallMessage): MessageAttachment[] {
+  const raw = message.extra?.attachments;
+  if (!Array.isArray(raw)) return [];
+  return raw.filter((attachment): attachment is MessageAttachment => {
+    return !!attachment && typeof attachment === "object" && typeof (attachment as MessageAttachment).type === "string";
+  });
+}
+
+function messageLabel(message: ConversationCallMessage, participants: Participant[]) {
+  if (message.participantKind === "user") return participants.find((p) => p.kind === "user")?.name ?? "You";
+  return participants.find((p) => p.characterId === message.characterId)?.name ?? "Character";
+}
+
+function messageContent(message: ConversationCallMessage, participants: Participant[]) {
+  if (message.kind !== "command") return message.content;
+  const speaker = messageLabel(message, participants);
+  switch (getBracketCommandName(message.content)) {
+    case "end_call":
+      return `${speaker} ended the call.`;
+    case "leave_call":
+      return `${speaker} left the call.`;
+    case "soundboard":
+      return `${speaker} used the soundboard.`;
+    default:
+      return message.content;
+  }
+}
+
+function findParticipantForTurn(turn: ConversationCallTurn, participants: Participant[]) {
+  return (
+    participants.find((participant) => participant.characterId && participant.characterId === turn.characterId) ??
+    participants.find((participant) => participant.name === turn.speakerName) ??
+    null
+  );
+}
+
+function synthesizeBuiltInSound(sound: ConversationCallSound) {
+  const AudioContextCtor =
+    window.AudioContext ??
+    (window as Window & typeof globalThis & { webkitAudioContext?: typeof AudioContext }).webkitAudioContext;
+  if (!AudioContextCtor) {
+    toast.error("This browser cannot play synthesized soundboard sounds.");
+    return;
+  }
+  const audioContext = new AudioContextCtor();
+  const gain = audioContext.createGain();
+  const oscillator = audioContext.createOscillator();
+  const now = audioContext.currentTime;
+  const id = sound.id;
+  oscillator.type = id.includes("sparkle") ? "triangle" : id.includes("pop") ? "square" : "sine";
+  oscillator.frequency.setValueAtTime(id.includes("tap") ? 360 : id.includes("pop") ? 180 : 640, now);
+  if (id.includes("sparkle")) oscillator.frequency.exponentialRampToValueAtTime(1180, now + 0.22);
+  gain.gain.setValueAtTime(0.0001, now);
+  gain.gain.exponentialRampToValueAtTime(0.22, now + 0.02);
+  gain.gain.exponentialRampToValueAtTime(0.0001, now + 0.35);
+  oscillator.connect(gain).connect(audioContext.destination);
+  oscillator.start(now);
+  oscillator.stop(now + 0.38);
+  window.setTimeout(() => void audioContext.close(), 700);
+}
+
+function chooseRecorderMimeType(includeVideo: boolean) {
+  if (typeof MediaRecorder === "undefined" || typeof MediaRecorder.isTypeSupported !== "function") return "";
+  const candidates = includeVideo
+    ? ["video/webm;codecs=vp9,opus", "video/webm;codecs=vp8,opus", "video/webm", "video/mp4"]
+    : ["audio/ogg;codecs=opus", "audio/mp4", "audio/webm;codecs=opus", "audio/webm"];
+  return candidates.find((mimeType) => MediaRecorder.isTypeSupported(mimeType)) ?? "";
+}
+
+function recorderFileName(includeVideo: boolean, mimeType: string) {
+  if (mimeType.includes("mp4")) return includeVideo ? "call-video.mp4" : "call-audio.m4a";
+  if (mimeType.includes("ogg")) return "call-audio.ogg";
+  return includeVideo ? "call-video.webm" : "call-audio.webm";
+}
+
+function audioRmsFromTimeDomain(data: Uint8Array) {
+  let sum = 0;
+  for (let index = 0; index < data.length; index += 1) {
+    const centered = (data[index]! - 128) / 128;
+    sum += centered * centered;
+  }
+  return Math.sqrt(sum / Math.max(1, data.length));
+}
+
+function getAudioContextCtor() {
+  return (
+    window.AudioContext ??
+    (window as Window & typeof globalThis & { webkitAudioContext?: typeof AudioContext }).webkitAudioContext ??
+    null
+  );
+}
+
+function mixAudioBufferToMono(buffer: AudioBuffer): Float32Array {
+  const output = new Float32Array(buffer.length);
+  for (let channel = 0; channel < buffer.numberOfChannels; channel += 1) {
+    const data = buffer.getChannelData(channel);
+    for (let index = 0; index < buffer.length; index += 1) {
+      output[index] += data[index]! / buffer.numberOfChannels;
+    }
+  }
+  return output;
+}
+
+function resampleAudio(samples: Float32Array, fromRate: number, toRate: number): Float32Array {
+  if (fromRate === toRate) return samples;
+  const outputLength = Math.max(1, Math.round((samples.length * toRate) / fromRate));
+  const output = new Float32Array(outputLength);
+  const ratio = (samples.length - 1) / Math.max(1, outputLength - 1);
+  for (let index = 0; index < outputLength; index += 1) {
+    const sourceIndex = index * ratio;
+    const left = Math.floor(sourceIndex);
+    const right = Math.min(samples.length - 1, left + 1);
+    const fraction = sourceIndex - left;
+    output[index] = samples[left]! * (1 - fraction) + samples[right]! * fraction;
+  }
+  return output;
+}
+
+function encodePcmWav(samples: Float32Array, sampleRate: number): Blob {
+  const bytesPerSample = 2;
+  const dataSize = samples.length * bytesPerSample;
+  const buffer = new ArrayBuffer(44 + dataSize);
+  const view = new DataView(buffer);
+  const writeString = (offset: number, value: string) => {
+    for (let index = 0; index < value.length; index += 1) {
+      view.setUint8(offset + index, value.charCodeAt(index));
+    }
+  };
+
+  writeString(0, "RIFF");
+  view.setUint32(4, 36 + dataSize, true);
+  writeString(8, "WAVE");
+  writeString(12, "fmt ");
+  view.setUint32(16, 16, true);
+  view.setUint16(20, 1, true);
+  view.setUint16(22, 1, true);
+  view.setUint32(24, sampleRate, true);
+  view.setUint32(28, sampleRate * bytesPerSample, true);
+  view.setUint16(32, bytesPerSample, true);
+  view.setUint16(34, 16, true);
+  writeString(36, "data");
+  view.setUint32(40, dataSize, true);
+
+  let offset = 44;
+  for (const sample of samples) {
+    const clamped = Math.max(-1, Math.min(1, sample));
+    view.setInt16(offset, clamped < 0 ? clamped * 0x8000 : clamped * 0x7fff, true);
+    offset += bytesPerSample;
+  }
+
+  return new Blob([buffer], { type: "audio/wav" });
+}
+
+async function convertRecordedAudioToWavFile(blob: Blob): Promise<File> {
+  const AudioContextCtor = getAudioContextCtor();
+  if (!AudioContextCtor) {
+    throw new Error("This browser cannot prepare recorded audio for speech input.");
+  }
+  const audioContext = new AudioContextCtor();
+  try {
+    const decoded = await audioContext.decodeAudioData(await blob.arrayBuffer());
+    const mono = mixAudioBufferToMono(decoded);
+    const resampled = resampleAudio(mono, decoded.sampleRate, 16_000);
+    const wav = encodePcmWav(resampled, 16_000);
+    return new File([wav], "call-audio.wav", { type: "audio/wav" });
+  } finally {
+    void audioContext.close();
+  }
+}
+
+function CallAvatar({
+  participant,
+  className,
+  fallbackClassName,
+}: {
+  participant: Participant;
+  className?: string;
+  fallbackClassName?: string;
+}) {
+  return (
+    <div
+      className={cn(
+        "relative flex items-center justify-center overflow-hidden rounded-full bg-[var(--secondary)] ring-1 ring-[var(--border)]",
+        className,
+      )}
+    >
+      {participant.avatarUrl ? (
+        <img
+          src={participant.avatarUrl}
+          alt=""
+          className="h-full w-full object-cover"
+          style={participant.avatarCrop ? getAvatarCropStyle(participant.avatarCrop) : undefined}
+        />
+      ) : (
+        <span className={cn("font-semibold text-[var(--marinara-chat-chrome-panel-muted)]", fallbackClassName)}>
+          {participant.name.slice(0, 1)}
+        </span>
+      )}
+    </div>
+  );
+}
+
+function ParticipantTile({
+  participant,
+  active,
+  cameraStream,
+  density,
+}: {
+  participant: Participant;
+  active: boolean;
+  cameraStream?: MediaStream | null;
+  density: ParticipantTileDensity;
+}) {
+  const videoRef = useRef<HTMLVideoElement | null>(null);
+  const densityClasses = PARTICIPANT_TILE_CLASSES[density];
+
+  useEffect(() => {
+    if (videoRef.current && cameraStream) {
+      videoRef.current.srcObject = cameraStream;
+    }
+  }, [cameraStream]);
+
+  return (
+    <div
+      className={cn(
+        "relative flex h-full min-h-0 min-w-0 flex-col items-center justify-center overflow-hidden border bg-[var(--marinara-chat-chrome-panel-bg)]/80 transition-all",
+        densityClasses.tile,
+        active
+          ? "border-[var(--marinara-chat-chrome-accent)] shadow-[0_0_0_2px_var(--marinara-chat-chrome-focus-ring)]"
+          : "border-[var(--marinara-chat-chrome-panel-border)]",
+      )}
+    >
+      {cameraStream ? (
+        <video ref={videoRef} autoPlay muted playsInline className="absolute inset-0 h-full w-full object-cover" />
+      ) : (
+        <CallAvatar
+          participant={participant}
+          className={cn("max-h-[55%] max-w-[55%]", densityClasses.avatar)}
+          fallbackClassName={densityClasses.fallback}
+        />
+      )}
+      <div
+        className={cn(
+          "absolute truncate rounded-full bg-[var(--marinara-chat-chrome-panel-bg)] font-medium leading-tight text-[var(--marinara-chat-chrome-panel-title)] shadow ring-1 ring-[var(--marinara-chat-chrome-panel-border)]",
+          densityClasses.name,
+        )}
+      >
+        {participant.name}
+      </div>
+    </div>
+  );
+}
+
+export function ConversationCallSurface({
+  chatId,
+  session,
+  characterMap,
+  chatCharIds,
+  personaInfo,
+  onEnded,
+  embedded = false,
+}: ConversationCallSurfaceProps) {
+  const { data: messages = [] } = useConversationCallMessages(session.id);
+  const { data: ttsConfig } = useTTSConfig();
+  const sendMessage = useSendConversationCallMessage(session.id);
+  const sendIdleCheck = useSendConversationCallIdle(session.id);
+  const endCall = useEndConversationCall(chatId);
+  const sendMedia = useSendConversationCallMedia(session.id);
+  const recordInterruption = useRecordConversationCallInterruption(session.id);
+  const { data: sounds = [] } = useConversationCallSoundboard();
+  const uploadSound = useUploadConversationCallSound();
+  const deleteSound = useDeleteConversationCallSound();
+  const userStatus = useUIStore((state) => state.userStatus);
+  const enterToSend = useUIStore((state) => state.enterToSendConvo);
+  const conversationCallVoiceVolume = useUIStore((state) => state.conversationCallVoiceVolume);
+  const conversationCallVoiceMuted = useUIStore((state) => state.conversationCallVoiceMuted);
+  const setConversationCallVoiceVolume = useUIStore((state) => state.setConversationCallVoiceVolume);
+  const setConversationCallVoiceMuted = useUIStore((state) => state.setConversationCallVoiceMuted);
+  const setYoutubePlay = useAgentStore((state) => state.setYoutubePlay);
+  const [draft, setDraft] = useState("");
+  const [cameraStream, setCameraStream] = useState<MediaStream | null>(null);
+  const [screenStream, setScreenStream] = useState<MediaStream | null>(null);
+  const [soundboardOpen, setSoundboardOpen] = useState(false);
+  const [voiceVolumeOpen, setVoiceVolumeOpen] = useState(false);
+  const [mobileChatOpen, setMobileChatOpen] = useState(false);
+  const [mobilePickerOpen, setMobilePickerOpen] = useState(false);
+  const [mobilePickerTab, setMobilePickerTab] = useState<MobileCallPickerTab>("emoji");
+  const [speakingId, setSpeakingId] = useState<string | null>(null);
+  const [userSpeaking, setUserSpeaking] = useState(false);
+  const [recording, setRecording] = useState(false);
+  const [browserSpeechSupported, setBrowserSpeechSupported] = useState(false);
+  const mobileCallLayout = useMobileCallLayout();
+  const [clockNow, setClockNow] = useState(() => Date.now());
+  const [joinedParticipantIds, setJoinedParticipantIds] = useState<Set<string>>(() => new Set(["user"]));
+  const [departedParticipantIds, setDepartedParticipantIds] = useState<Set<string>>(() => new Set());
+  const mediaRecorderRef = useRef<MediaRecorder | null>(null);
+  const micStreamRef = useRef<MediaStream | null>(null);
+  const micAudioContextRef = useRef<AudioContext | null>(null);
+  const micAudioSourceRef = useRef<MediaStreamAudioSourceNode | null>(null);
+  const micVadIntervalRef = useRef<number | null>(null);
+  const micSegmentRef = useRef<LiveMicSegment | null>(null);
+  const micLastSpeechAtRef = useRef(0);
+  const micSpeechFrameCountRef = useRef(0);
+  const userSpeakingRef = useRef(false);
+  const callInteractionQueueRef = useRef<Promise<void>>(Promise.resolve());
+  const speechRecognitionRef = useRef<BrowserSpeechRecognition | null>(null);
+  const textareaRef = useRef<HTMLTextAreaElement | null>(null);
+  const inputBarRef = useRef<HTMLDivElement | null>(null);
+  const lastUserActivityAtRef = useRef(0);
+  const lastIdleCheckAtRef = useRef(0);
+  const playingTurnsRef = useRef(false);
+  const activeCallVoiceRef = useRef<ActiveCallVoice | null>(null);
+  const interruptedVoiceKeyRef = useRef<string | null>(null);
+  const userInterruptionVoicedMsRef = useRef(0);
+  const voicePlaybackInterruptedRef = useRef(false);
+  const participantIdsRef = useRef<Set<string>>(new Set());
+  const playedStartSoundForRef = useRef<string | null>(null);
+  const playedEndSoundForRef = useRef<string | null>(null);
+  const previousSessionStatusRef = useRef(session.status);
+  const [queuedCallInteractions, setQueuedCallInteractions] = useState(0);
+  const callAudioEnabled = ttsConfig?.callAudioEnabled === true;
+  const audioInputMode = ttsConfig?.callAudioInputMode ?? "local_whisper";
+  const systemVoiceInputMode = audioInputMode === "system";
+  const nativeInputMode = audioInputMode === "auto";
+  const localWhisperInputMode = audioInputMode === "local_whisper";
+  const browserSpeechInputMode = audioInputMode === "transcribe";
+  const videoControlsEnabled = ttsConfig?.callVideoInputEnabled === true && nativeInputMode;
+  const soundboardEnabled = ttsConfig?.callSoundboardEnabled !== false;
+  const characterVoicesMuted = conversationCallVoiceMuted || conversationCallVoiceVolume <= 0;
+  const characterVoicePlaybackVolume = characterVoicesMuted ? 0 : conversationCallVoiceVolume / 100;
+  const characterVoiceVolumeLabel = characterVoicesMuted ? "Muted" : `${conversationCallVoiceVolume}%`;
+  const callControlGridColumns = soundboardEnabled ? "grid-cols-7" : "grid-cols-6";
+  const callControlButtonClass =
+    "mari-chrome-control shrink-0 p-0 max-sm:aspect-square max-sm:h-auto max-sm:min-h-0 max-sm:w-full max-sm:max-w-10 max-sm:justify-self-center sm:h-11 sm:w-11";
+  const callControlIconClass = "h-4 w-4";
+  const browserSpeechUnavailable = browserSpeechInputMode && !browserSpeechSupported;
+  const recordingWillUseLocalWhisperFallback = browserSpeechUnavailable;
+
+  const participants = useMemo<Participant[]>(() => {
+    const user: Participant = {
+      id: "user",
+      name: personaInfo?.name || "You",
+      avatarUrl: personaInfo?.avatarUrl ?? null,
+      avatarCrop: personaInfo?.avatarCrop,
+      kind: "user",
+      characterId: null,
+      canSpeak: false,
+    };
+    const characters = chatCharIds.flatMap((id) => {
+      const character = characterMap.get(id);
+      if (character?.conversationStatus === "offline") return [];
+      const voice = ttsConfig ? resolveTTSVoiceForSpeaker(ttsConfig, character?.name, id) : "";
+      return [
+        {
+          id: `character:${id}`,
+          name: character?.name ?? "Character",
+          avatarUrl: character?.avatarUrl ?? null,
+          avatarCrop: character?.avatarCrop,
+          kind: "character" as const,
+          characterId: id,
+          canSpeak: Boolean(ttsConfig?.enabled && voice),
+          conversationStatus: character?.conversationStatus,
+        },
+      ];
+    });
+    return [user, ...characters];
+  }, [characterMap, chatCharIds, personaInfo, ttsConfig]);
+
+  const characterJoinPlan = useMemo(
+    () =>
+      participants
+        .filter((participant) => participant.kind === "character")
+        .map((participant) => ({
+          id: participant.id,
+          status: participant.conversationStatus,
+          delayMs: characterJoinDelayMs(participant),
+        })),
+    [participants],
+  );
+
+  const visibleParticipants = useMemo(
+    () =>
+      participants.filter(
+        (participant) =>
+          participant.kind === "user" ||
+          (joinedParticipantIds.has(participant.id) && !departedParticipantIds.has(participant.id)),
+      ),
+    [departedParticipantIds, joinedParticipantIds, participants],
+  );
+  const visibleCallMessages = useMemo(
+    () =>
+      messages.filter(
+        (message) =>
+          message.kind !== "speech" && message.kind !== "command" && message.extra?.hiddenFromUser !== true,
+      ),
+    [messages],
+  );
+  const participantGridLayout = useMemo(
+    () => getParticipantGridLayout(visibleParticipants.length, mobileCallLayout),
+    [mobileCallLayout, visibleParticipants.length],
+  );
+  const participantGridStyle = useMemo<CSSProperties>(
+    () => ({
+      gridTemplateColumns: `repeat(${participantGridLayout.columns}, minmax(0, 1fr))`,
+      gridTemplateRows: `repeat(${participantGridLayout.rows}, minmax(0, 1fr))`,
+    }),
+    [participantGridLayout.columns, participantGridLayout.rows],
+  );
+
+  const pendingParticipants = useMemo(
+    () =>
+      participants.filter(
+        (participant) =>
+          participant.kind === "character" &&
+          !joinedParticipantIds.has(participant.id) &&
+          !departedParticipantIds.has(participant.id),
+      ),
+    [departedParticipantIds, joinedParticipantIds, participants],
+  );
+
+  const elapsedLabel = useMemo(() => formatDuration(clockNow - callStartedAtMs(session)), [clockNow, session]);
+  const stageStatusLabel = useMemo(() => {
+    if (pendingParticipants.length > 0) {
+      const first = pendingParticipants[0];
+      return first ? `Calling ${first.name}` : "Calling";
+    }
+    if (userSpeaking) return "Speaking";
+    if (recording) return "Listening";
+    if (queuedCallInteractions > 0 || sendMessage.isPending || sendMedia.isPending || playingTurnsRef.current) {
+      return "Responding";
+    }
+    return "Live";
+  }, [pendingParticipants, queuedCallInteractions, recording, sendMedia.isPending, sendMessage.isPending, userSpeaking]);
+
+  const setUserSpeakingState = useCallback((speaking: boolean) => {
+    if (userSpeakingRef.current === speaking) return;
+    userSpeakingRef.current = speaking;
+    setUserSpeaking(speaking);
+  }, []);
+
+  const stopStream = useCallback((stream: MediaStream | null) => {
+    stream?.getTracks().forEach((track) => track.stop());
+  }, []);
+
+  const stopLiveMicCapture = useCallback(() => {
+    if (micVadIntervalRef.current !== null) {
+      window.clearInterval(micVadIntervalRef.current);
+      micVadIntervalRef.current = null;
+    }
+    micSpeechFrameCountRef.current = 0;
+    setUserSpeakingState(false);
+    const segment = micSegmentRef.current;
+    micSegmentRef.current = null;
+    mediaRecorderRef.current = null;
+    if (segment && segment.recorder.state !== "inactive") {
+      try {
+        segment.recorder.requestData();
+        segment.recorder.stop();
+      } catch {
+        /* ignore recorder shutdown races */
+      }
+    }
+    stopStream(micStreamRef.current);
+    micStreamRef.current = null;
+    try {
+      micAudioSourceRef.current?.disconnect();
+    } catch {
+      /* ignore audio node shutdown races */
+    }
+    micAudioSourceRef.current = null;
+    const audioContext = micAudioContextRef.current;
+    micAudioContextRef.current = null;
+    if (audioContext && audioContext.state !== "closed") {
+      void audioContext.close().catch(() => undefined);
+    }
+    try {
+      speechRecognitionRef.current?.abort();
+    } catch {
+      /* ignore speech recognition shutdown races */
+    }
+    speechRecognitionRef.current = null;
+    setRecording(false);
+  }, [setUserSpeakingState, stopStream]);
+
+  const cleanupLiveCallMedia = useCallback(() => {
+    activeCallVoiceRef.current = null;
+    userInterruptionVoicedMsRef.current = 0;
+    voicePlaybackInterruptedRef.current = false;
+    ttsService.stop();
+    stopLiveMicCapture();
+    stopStream(cameraStream);
+    stopStream(screenStream);
+  }, [cameraStream, screenStream, stopLiveMicCapture, stopStream]);
+
+  const playEndSoundOnce = useCallback(() => {
+    if (playedEndSoundForRef.current === session.id) return;
+    playedEndSoundForRef.current = session.id;
+    playConversationCallEndSound();
+  }, [session.id]);
+
+  const markUserActivity = useCallback(() => {
+    lastUserActivityAtRef.current = Date.now();
+    lastIdleCheckAtRef.current = 0;
+  }, []);
+
+  const enqueueCallInteraction = useCallback(
+    (task: () => Promise<void>, errorMessage: string, options: { quiet?: boolean } = {}) => {
+      setQueuedCallInteractions((count) => count + 1);
+      const queued = callInteractionQueueRef.current
+        .catch(() => undefined)
+        .then(task)
+        .catch((error) => {
+          if (options.quiet) {
+            console.warn("[conversation-call] Queued interaction failed", error);
+            return;
+          }
+          toast.error(error instanceof Error ? error.message : errorMessage);
+        })
+        .finally(() => {
+          setQueuedCallInteractions((count) => Math.max(0, count - 1));
+        });
+      callInteractionQueueRef.current = queued;
+      return queued;
+    },
+    [],
+  );
+
+  useEffect(() => {
+    const interval = window.setInterval(() => setClockNow(Date.now()), 1000);
+    return () => window.clearInterval(interval);
+  }, []);
+
+  useEffect(() => {
+    if (session.status !== "active") return;
+    lastUserActivityAtRef.current = Date.now();
+    lastIdleCheckAtRef.current = 0;
+  }, [session.id, session.status]);
+
+  useEffect(() => {
+    setDepartedParticipantIds(new Set());
+  }, [session.id]);
+
+  useEffect(() => {
+    if (session.status !== "active") return;
+    if (playedStartSoundForRef.current === session.id) return;
+    playedStartSoundForRef.current = session.id;
+    playConversationCallStartSound();
+  }, [session.id, session.status]);
+
+  useEffect(() => {
+    if (previousSessionStatusRef.current === "active" && session.status === "ended") {
+      playEndSoundOnce();
+    }
+    previousSessionStatusRef.current = session.status;
+  }, [playEndSoundOnce, session.status]);
+
+  useEffect(() => {
+    const initialIds = new Set<string>(["user"]);
+    if (session.initiator === "character") {
+      for (const participant of characterJoinPlan) initialIds.add(participant.id);
+      setJoinedParticipantIds(initialIds);
+      return;
+    }
+
+    setJoinedParticipantIds(initialIds);
+    const timers = characterJoinPlan.map((participant) =>
+      window.setTimeout(() => {
+        setJoinedParticipantIds((current) => {
+          if (current.has(participant.id)) return current;
+          const next = new Set(current);
+          next.add(participant.id);
+          return next;
+        });
+        playConversationCallJoinSound();
+      }, participant.delayMs),
+    );
+    return () => timers.forEach((timer) => window.clearTimeout(timer));
+  }, [characterJoinPlan, session.id, session.initiator]);
+
+  useEffect(() => {
+    const departedParticipantIds = messages.flatMap((message) => {
+      if (message.kind !== "command") return [];
+      if (getBracketCommandName(message.content) !== "leave_call") return [];
+      return message.characterId ? [`character:${message.characterId}`] : [];
+    });
+    if (departedParticipantIds.length === 0) return;
+    setDepartedParticipantIds((current) => {
+      let changed = false;
+      const next = new Set(current);
+      for (const participantId of departedParticipantIds) {
+        if (!next.has(participantId)) {
+          next.add(participantId);
+          changed = true;
+        }
+      }
+      return changed ? next : current;
+    });
+    setJoinedParticipantIds((current) => {
+      let changed = false;
+      const next = new Set(current);
+      for (const participantId of departedParticipantIds) {
+        if (next.delete(participantId)) changed = true;
+      }
+      return changed ? next : current;
+    });
+  }, [messages]);
+
+  useEffect(() => {
+    const latestUserMessage = [...messages]
+      .reverse()
+      .find((message) => message.participantKind === "user" && message.createdAt);
+    if (!latestUserMessage) return;
+    const timestamp = Date.parse(latestUserMessage.createdAt);
+    if (Number.isFinite(timestamp) && timestamp > lastUserActivityAtRef.current) {
+      lastUserActivityAtRef.current = timestamp;
+      lastIdleCheckAtRef.current = 0;
+    }
+  }, [messages]);
+
+  useEffect(() => {
+    setBrowserSpeechSupported(isBrowserSpeechRecognitionSupported());
+    return () => {
+      cleanupLiveCallMedia();
+    };
+  }, [cleanupLiveCallMedia]);
+
+  useEffect(() => {
+    participantIdsRef.current = new Set(visibleParticipants.map((participant) => participant.id));
+  }, [visibleParticipants]);
+
+  useEffect(
+    () =>
+      ttsService.subscribe((state, activeId) => {
+        setSpeakingId(
+          state === "playing" && activeId && participantIdsRef.current.has(activeId) ? activeId : null,
+        );
+      }),
+    [],
+  );
+
+  useEffect(() => {
+    ttsService.setCurrentPlaybackVolume(characterVoicePlaybackVolume, characterVoicesMuted);
+  }, [characterVoicePlaybackVolume, characterVoicesMuted]);
+
+  const toggleCharacterVoicesMuted = useCallback(() => {
+    if (characterVoicesMuted) {
+      if (conversationCallVoiceVolume <= 0) setConversationCallVoiceVolume(50);
+      setConversationCallVoiceMuted(false);
+      return;
+    }
+    setConversationCallVoiceMuted(true);
+  }, [
+    characterVoicesMuted,
+    conversationCallVoiceVolume,
+    setConversationCallVoiceMuted,
+    setConversationCallVoiceVolume,
+  ]);
+
+  const playSoundById = useCallback(
+    async (soundId: string) => {
+      if (!soundboardEnabled) return;
+      const sound = sounds.find((item) => item.id === soundId);
+      if (!sound) return;
+      if (sound.builtIn) {
+        synthesizeBuiltInSound(sound);
+        return;
+      }
+      await new Audio(`/api/conversation-calls/soundboard/${sound.id}/file`).play().catch((error) => {
+        toast.error(error instanceof Error ? error.message : "Could not play sound.");
+      });
+    },
+    [soundboardEnabled, sounds],
+  );
+
+  const playSoundByName = useCallback(
+    async (soundName: string) => {
+      if (!soundboardEnabled) return;
+      const normalized = soundName.trim().toLowerCase();
+      if (!normalized) return;
+      const sound = sounds.find((item) => item.name.trim().toLowerCase() === normalized);
+      if (!sound) return;
+      await playSoundById(sound.id);
+    },
+    [playSoundById, soundboardEnabled, sounds],
+  );
+
+  const handleCharacterLeftCall = useCallback(
+    (turn: ConversationCallTurn) => {
+      const participant = findParticipantForTurn(turn, participants);
+      if (!participant || participant.kind !== "character") return;
+      setJoinedParticipantIds((current) => {
+        if (!current.has(participant.id)) return current;
+        const next = new Set(current);
+        next.delete(participant.id);
+        return next;
+      });
+      setDepartedParticipantIds((current) => {
+        if (current.has(participant.id)) return current;
+        const next = new Set(current);
+        next.add(participant.id);
+        return next;
+      });
+      setSpeakingId((current) => (current === participant.id ? null : current));
+      playConversationCallLeaveSound();
+    },
+    [participants],
+  );
+
+  const handleCallEndedByCharacter = useCallback(async () => {
+    try {
+      await endCall.mutateAsync(session.id);
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : "Could not end the call.");
+    } finally {
+      cleanupLiveCallMedia();
+      playEndSoundOnce();
+      await wait(250);
+      onEnded?.();
+    }
+  }, [cleanupLiveCallMedia, endCall, onEnded, playEndSoundOnce, session.id]);
+
+  const recordCurrentVoiceInterruption = useCallback(() => {
+    const activeVoice = activeCallVoiceRef.current;
+    if (!activeVoice || interruptedVoiceKeyRef.current === activeVoice.key) return;
+    interruptedVoiceKeyRef.current = activeVoice.key;
+    voicePlaybackInterruptedRef.current = true;
+    ttsService.stop();
+    recordInterruption.mutate(
+      {
+        characterId: activeVoice.characterId,
+        speakerName: activeVoice.speakerName,
+        spokenText: activeVoice.spokenText.slice(0, CALL_TTS_INTERRUPT_TEXT_MAX_CHARS),
+      },
+      {
+        onError: (error) => {
+          console.warn("[conversation-call] Failed to record voice interruption", error);
+        },
+      },
+    );
+  }, [recordInterruption]);
+
+  const updateVoiceInterruptionDetector = useCallback(
+    (speechConfirmed: boolean) => {
+      const activeVoice = activeCallVoiceRef.current;
+      const ttsPlaying = ttsService.getState() === "playing";
+      if (!speechConfirmed || !activeVoice || !ttsPlaying) {
+        userInterruptionVoicedMsRef.current = 0;
+        return;
+      }
+      userInterruptionVoicedMsRef.current += CALL_MIC_VAD_INTERVAL_MS;
+      if (userInterruptionVoicedMsRef.current >= CALL_TTS_INTERRUPT_VOICED_MS) {
+        recordCurrentVoiceInterruption();
+      }
+    },
+    [recordCurrentVoiceInterruption],
+  );
+
+  const playTurns = useCallback(
+    async (turns: ConversationCallTurn[]) => {
+      playingTurnsRef.current = true;
+      voicePlaybackInterruptedRef.current = false;
+      let shouldEndCallAfterPlayback = false;
+      try {
+        for (let index = 0; index < turns.length; index += 1) {
+          const turn = turns[index]!;
+          let pauseSourceTurn = turn;
+          if (turn.mode === "command") {
+            const commandName = getBracketCommandName(turn.content);
+            if (commandName === "soundboard") {
+              await playSoundByName(getSoundboardCommandName(turn.content));
+            } else if (commandName === "youtube") {
+              const searchQuery = getCommandStringParam(turn.content, "query");
+              if (searchQuery) {
+                setYoutubePlay({ searchQuery, mood: "Conversation call music command" });
+                toast(`Playing YouTube: ${searchQuery}`);
+              }
+            } else if (commandName === "spotify") {
+              const title = getCommandStringParam(turn.content, "title");
+              const artist = getCommandStringParam(turn.content, "artist");
+              toast(title ? `Playing ${title}${artist ? ` - ${artist}` : ""}` : "Playing Spotify track");
+            } else if (commandName === "selfie") {
+              toast("Selfie generated.");
+            } else if (commandName === "leave_call") {
+              handleCharacterLeftCall(turn);
+            } else if (commandName === "end_call") {
+              shouldEndCallAfterPlayback = true;
+              break;
+            }
+          } else if (turn.mode === "voice" && ttsConfig?.enabled && turn.content.trim()) {
+            const participant = findParticipantForTurn(turn, participants);
+            const voice = resolveTTSVoiceForSpeaker(
+              ttsConfig,
+              turn.speakerName,
+              turn.characterId ?? participant?.characterId,
+            );
+            if (voice && !characterVoicesMuted) {
+              const voiceBatch = [{ turn, participant, voice }];
+              let batchEndIndex = index;
+              while (true) {
+                const candidate = turns[batchEndIndex + 1];
+                if (!candidate || candidate.mode !== "voice" || !candidate.content.trim()) break;
+                const candidateParticipant = findParticipantForTurn(candidate, participants);
+                const candidateVoice = resolveTTSVoiceForSpeaker(
+                  ttsConfig,
+                  candidate.speakerName,
+                  candidate.characterId ?? candidateParticipant?.characterId,
+                );
+                if (!candidateVoice || candidateVoice !== voice) break;
+                if ((candidateParticipant?.id ?? null) !== (participant?.id ?? null)) break;
+                voiceBatch.push({ turn: candidate, participant: candidateParticipant, voice: candidateVoice });
+                batchEndIndex += 1;
+              }
+
+              const spokenText = voiceBatch.map((item) => item.turn.content.trim()).join("\n");
+              const spokenChunks = splitCallTtsChunks(voiceBatch.map((item) => item.turn.content));
+              const tone = Array.from(
+                new Set(voiceBatch.map((item) => item.turn.tone?.trim()).filter((value): value is string => !!value)),
+              ).join(", ");
+              const voiceKey = [
+                session.id,
+                participant?.id ?? turn.speakerName,
+                voiceBatch.map((item) => item.turn.id ?? item.turn.content.slice(0, 24)).join("|"),
+              ].join(":");
+              activeCallVoiceRef.current = {
+                key: voiceKey,
+                characterId: participant?.characterId ?? turn.characterId ?? null,
+                speakerName: turn.speakerName,
+                spokenText,
+              };
+              userInterruptionVoicedMsRef.current = 0;
+              await ttsService.speakSequence(
+                spokenChunks.map((chunk) => ({
+                  text: chunk,
+                  speaker: turn.speakerName,
+                  tone: tone || undefined,
+                  voice,
+                })),
+                participant?.id ?? `${session.id}:${turn.id ?? turn.content.slice(0, 12)}`,
+                {
+                  progressive: ttsConfig.progressivePlayback,
+                  volume: characterVoicePlaybackVolume,
+                  muted: characterVoicesMuted,
+                },
+              );
+              if (activeCallVoiceRef.current?.key === voiceKey) {
+                activeCallVoiceRef.current = null;
+                userInterruptionVoicedMsRef.current = 0;
+              }
+              pauseSourceTurn = turns[batchEndIndex] ?? turn;
+              index = batchEndIndex;
+              if (voicePlaybackInterruptedRef.current) break;
+            }
+          }
+          const nextTurn = turns[index + 1];
+          const pauseMs =
+            pauseSourceTurn.mode === "text" && nextTurn?.mode === "voice" ? DEFAULT_TEXT_TO_VOICE_PAUSE_MS : 0;
+          if (nextTurn && pauseMs > 0) await wait(pauseMs);
+        }
+      } finally {
+        activeCallVoiceRef.current = null;
+        userInterruptionVoicedMsRef.current = 0;
+        playingTurnsRef.current = false;
+      }
+      if (shouldEndCallAfterPlayback) {
+        await handleCallEndedByCharacter();
+      }
+    },
+    [
+      characterVoicePlaybackVolume,
+      characterVoicesMuted,
+      handleCallEndedByCharacter,
+      handleCharacterLeftCall,
+      participants,
+      playSoundByName,
+      session.id,
+      setYoutubePlay,
+      ttsConfig,
+    ],
+  );
+
+  const resizeDraftTextarea = useCallback(() => {
+    const textarea = textareaRef.current;
+    if (!textarea) return;
+    textarea.style.height = "auto";
+    textarea.style.height = `${Math.min(textarea.scrollHeight, 200)}px`;
+  }, []);
+
+  const submitText = useCallback(
+    async (content: string, inputMode: "typed" | "speech" = "typed") => {
+      const text = content.trim();
+      if (!text) return;
+      markUserActivity();
+      if (inputMode === "typed") {
+        setDraft("");
+        window.requestAnimationFrame(resizeDraftTextarea);
+      }
+      await enqueueCallInteraction(
+        async () => {
+          const response = await sendMessage.mutateAsync({ content: text, inputMode });
+          await playTurns(response.turns);
+        },
+        inputMode === "speech" ? "Call speech transcription failed." : "Call message failed.",
+      );
+    },
+    [enqueueCallInteraction, markUserActivity, playTurns, resizeDraftTextarea, sendMessage],
+  );
+
+  const handleDraftChange = useCallback(
+    (event: ChangeEvent<HTMLTextAreaElement>) => {
+      setDraft(event.currentTarget.value);
+      window.requestAnimationFrame(resizeDraftTextarea);
+    },
+    [resizeDraftTextarea],
+  );
+
+  const handleEmojiSelect = useCallback(
+    (emoji: string) => {
+      const textarea = textareaRef.current;
+      const start = textarea?.selectionStart ?? draft.length;
+      const end = textarea?.selectionEnd ?? draft.length;
+      const nextDraft = `${draft.slice(0, start)}${emoji}${draft.slice(end)}`;
+      setDraft(nextDraft);
+      window.requestAnimationFrame(() => {
+        if (!textareaRef.current) return;
+        const cursor = start + emoji.length;
+        textareaRef.current.focus();
+        textareaRef.current.setSelectionRange(cursor, cursor);
+        resizeDraftTextarea();
+      });
+    },
+    [draft, resizeDraftTextarea],
+  );
+
+  const handleGifSelect = useCallback(
+    (gifUrl: string) => {
+      setMobilePickerOpen(false);
+      void submitText(gifUrl, "typed").catch((error) =>
+        toast.error(error instanceof Error ? error.message : "Call GIF message failed."),
+      );
+    },
+    [submitText],
+  );
+
+  const handleStickerSelect = useCallback(
+    (name: string) => {
+      setMobilePickerOpen(false);
+      void submitText(`sticker:${name}:`, "typed").catch((error) =>
+        toast.error(error instanceof Error ? error.message : "Call sticker message failed."),
+      );
+    },
+    [submitText],
+  );
+
+  const submitDraft = useCallback(() => {
+    if (queuedCallInteractions > 0 || sendMessage.isPending) return;
+    void submitText(draft, "typed").catch((error) =>
+      toast.error(error instanceof Error ? error.message : "Call message failed."),
+    );
+  }, [draft, queuedCallInteractions, sendMessage.isPending, submitText]);
+
+  const handleDraftKeyDown = useCallback(
+    (event: KeyboardEvent<HTMLTextAreaElement>) => {
+      const shouldSend = enterToSend
+        ? event.key === "Enter" && !event.shiftKey
+        : event.key === "Enter" && (event.metaKey || event.ctrlKey);
+      if (!shouldSend) return;
+      event.preventDefault();
+      submitDraft();
+    },
+    [enterToSend, submitDraft],
+  );
+
+  const startSystemVoiceTyping = useCallback(() => {
+    if (!callAudioEnabled) {
+      toast.warning("Call audio is disabled in Chat Settings.");
+      return;
+    }
+    markUserActivity();
+    if (mobileCallLayout) setMobileChatOpen(true);
+    window.setTimeout(
+      () => {
+        textareaRef.current?.focus();
+        resizeDraftTextarea();
+      },
+      mobileCallLayout ? 80 : 0,
+    );
+    toast.info(getSystemVoiceTypingHint());
+  }, [callAudioEnabled, markUserActivity, mobileCallLayout, resizeDraftTextarea]);
+
+  useEffect(() => {
+    if (session.status !== "active") return;
+    const interval = window.setInterval(() => {
+      if (userStatus !== "active") return;
+      if (document.visibilityState === "hidden") return;
+      if (
+        queuedCallInteractions > 0 ||
+        sendMessage.isPending ||
+        sendMedia.isPending ||
+        sendIdleCheck.isPending ||
+        playingTurnsRef.current
+      ) {
+        return;
+      }
+      const now = Date.now();
+      const quietMs = now - lastUserActivityAtRef.current;
+      if (quietMs < CALL_SILENCE_CHECK_MS) return;
+      if (now - lastIdleCheckAtRef.current < CALL_SILENCE_CHECK_MS) return;
+      lastIdleCheckAtRef.current = now;
+      void enqueueCallInteraction(
+        async () => {
+          const response = await sendIdleCheck.mutateAsync({ quietMs });
+          await playTurns(response.turns);
+        },
+        "Call idle check failed.",
+        { quiet: true },
+      );
+    }, CALL_SILENCE_POLL_MS);
+    return () => window.clearInterval(interval);
+  }, [
+    enqueueCallInteraction,
+    playTurns,
+    queuedCallInteractions,
+    sendIdleCheck,
+    sendMedia.isPending,
+    sendMessage.isPending,
+    session.status,
+    userStatus,
+  ]);
+
+  const toggleCamera = useCallback(async () => {
+    if (!videoControlsEnabled) {
+      toast.warning("Camera input is disabled in Chat Settings.");
+      return;
+    }
+    if (cameraStream) {
+      stopStream(cameraStream);
+      setCameraStream(null);
+      return;
+    }
+    try {
+      const stream = await navigator.mediaDevices.getUserMedia({ video: true, audio: false });
+      setCameraStream(stream);
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : "Could not turn on camera.");
+    }
+  }, [cameraStream, stopStream, videoControlsEnabled]);
+
+  const toggleScreenShare = useCallback(async () => {
+    if (!videoControlsEnabled) {
+      toast.warning("Screen input is disabled in Chat Settings.");
+      return;
+    }
+    if (screenStream) {
+      stopStream(screenStream);
+      setScreenStream(null);
+      return;
+    }
+    try {
+      const stream = await navigator.mediaDevices.getDisplayMedia({ video: true, audio: false });
+      stream.getVideoTracks()[0]?.addEventListener("ended", () => setScreenStream(null), { once: true });
+      setScreenStream(stream);
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : "Could not share screen.");
+    }
+  }, [screenStream, stopStream, videoControlsEnabled]);
+
+  const stopRecording = useCallback(() => {
+    if (speechRecognitionRef.current) {
+      speechRecognitionRef.current.stop();
+      return;
+    }
+    stopLiveMicCapture();
+  }, [stopLiveMicCapture]);
+
+  const startBrowserSpeechRecognition = useCallback(() => {
+    if (recording) return;
+    if (!callAudioEnabled) {
+      toast.warning("Call audio is disabled in Chat Settings.");
+      return;
+    }
+    const Recognition = getBrowserSpeechRecognitionCtor();
+    if (!Recognition) {
+      toast.error(
+        "Browser speech recognition is not supported in this browser. You can type in the call chat instead.",
+      );
+      return;
+    }
+    markUserActivity();
+    const recognition = new Recognition();
+    let finalTranscript = "";
+    recognition.continuous = false;
+    recognition.interimResults = true;
+    recognition.lang = navigator.language || "en-US";
+    recognition.onresult = (event) => {
+      for (let index = event.resultIndex; index < event.results.length; index += 1) {
+        const result = event.results[index] ?? event.results.item(index);
+        const transcript = readBrowserSpeechRecognitionTranscript(result);
+        if (result?.isFinal && transcript.trim()) {
+          finalTranscript = `${finalTranscript} ${transcript}`.trim();
+        }
+      }
+    };
+    recognition.onerror = (event) => {
+      const error = event.error ?? "unknown";
+      setRecording(false);
+      speechRecognitionRef.current = null;
+      if (!["aborted", "no-speech"].includes(error)) {
+        toast.error(`Speech recognition failed: ${error}`);
+      }
+    };
+    recognition.onend = () => {
+      speechRecognitionRef.current = null;
+      setRecording(false);
+      if (finalTranscript.trim()) {
+        void submitText(finalTranscript.trim(), "speech");
+      } else {
+        toast.warning("No speech transcript was returned. You can type in the call chat instead.");
+      }
+    };
+    speechRecognitionRef.current = recognition;
+    setRecording(true);
+    try {
+      recognition.start();
+    } catch (error) {
+      speechRecognitionRef.current = null;
+      setRecording(false);
+      toast.error(error instanceof Error ? error.message : "Could not start browser speech recognition.");
+    }
+  }, [callAudioEnabled, markUserActivity, recording, submitText]);
+
+  const submitRecordedCallMedia = useCallback(
+    async (blob: Blob, includeVideo: boolean) => {
+      const shouldUseLocalWhisper = !includeVideo && (localWhisperInputMode || recordingWillUseLocalWhisperFallback);
+      if (shouldUseLocalWhisper) {
+        const file = await convertRecordedAudioToWavFile(blob);
+        const result = await sendMedia.mutateAsync({
+          file,
+          kind: "audio",
+          nativePreferred: false,
+          transcriptionMode: "local_whisper",
+        });
+        await playTurns(result.turns);
+        return;
+      }
+
+      const file =
+        !includeVideo && nativeInputMode
+          ? await convertRecordedAudioToWavFile(blob)
+          : new File([blob], recorderFileName(includeVideo, blob.type), {
+              type: blob.type || (includeVideo ? "video/webm" : "audio/webm"),
+            });
+      const result = await sendMedia.mutateAsync({
+        file,
+        kind: includeVideo ? "video" : "audio",
+        nativePreferred: nativeInputMode,
+      });
+      await playTurns(result.turns);
+    },
+    [localWhisperInputMode, nativeInputMode, playTurns, recordingWillUseLocalWhisperFallback, sendMedia],
+  );
+
+  const enqueueRecordedCallMedia = useCallback(
+    (blob: Blob, includeVideo: boolean) => {
+      void enqueueCallInteraction(
+        () => submitRecordedCallMedia(blob, includeVideo),
+        "Call speech transcription failed.",
+      );
+    },
+    [enqueueCallInteraction, submitRecordedCallMedia],
+  );
+
+  const startRecording = useCallback(async () => {
+    if (recording) return;
+    if (!callAudioEnabled) {
+      toast.warning("Call audio is disabled in Chat Settings.");
+      return;
+    }
+    if (systemVoiceInputMode) {
+      startSystemVoiceTyping();
+      return;
+    }
+    markUserActivity();
+    if (browserSpeechInputMode && browserSpeechSupported) {
+      startBrowserSpeechRecognition();
+      return;
+    }
+    if (!navigator.mediaDevices?.getUserMedia) {
+      toast.error("Microphone access requires HTTPS, localhost, or a browser with media device support.");
+      return;
+    }
+    if (typeof MediaRecorder === "undefined") {
+      toast.error("This browser cannot record microphone audio for calls.");
+      return;
+    }
+    if (recordingWillUseLocalWhisperFallback) {
+      toast.info("Browser speech recognition is unavailable here, so Marinara will use Local Whisper instead.");
+    }
+    try {
+      const stream = await navigator.mediaDevices.getUserMedia({
+        audio: {
+          echoCancellation: true,
+          noiseSuppression: true,
+          autoGainControl: true,
+          channelCount: 1,
+        },
+        video: false,
+      });
+      micStreamRef.current = stream;
+      const videoTrack =
+        nativeInputMode && videoControlsEnabled ? (screenStream ?? cameraStream)?.getVideoTracks()[0] : undefined;
+      const includeVideo = Boolean(videoTrack);
+      const recordingStream = includeVideo ? new MediaStream([...stream.getAudioTracks(), videoTrack!]) : stream;
+      const preferredMimeType = chooseRecorderMimeType(includeVideo);
+      const AudioContextCtor = getAudioContextCtor();
+      if (!AudioContextCtor) {
+        stopStream(stream);
+        micStreamRef.current = null;
+        toast.error("This browser cannot inspect microphone audio for call transcription.");
+        return;
+      }
+      const audioContext = new AudioContextCtor();
+      micAudioContextRef.current = audioContext;
+      if (audioContext.state === "suspended") {
+        await audioContext.resume().catch(() => undefined);
+      }
+      const source = audioContext.createMediaStreamSource(stream);
+      micAudioSourceRef.current = source;
+      const analyser = audioContext.createAnalyser();
+      analyser.fftSize = 1024;
+      analyser.smoothingTimeConstant = 0.15;
+      source.connect(analyser);
+      const timeDomain = new Uint8Array(analyser.fftSize);
+
+      const stopSegment = () => {
+        const segment = micSegmentRef.current;
+        if (!segment) return;
+        micSegmentRef.current = null;
+        mediaRecorderRef.current = null;
+        if (segment.recorder.state === "inactive") return;
+        try {
+          segment.recorder.requestData();
+          segment.recorder.stop();
+        } catch {
+          /* ignore recorder shutdown races */
+        }
+      };
+
+      const startSegment = (initialRms: number) => {
+        if (micSegmentRef.current) return;
+        const recorder = new MediaRecorder(
+          recordingStream,
+          preferredMimeType ? { mimeType: preferredMimeType } : undefined,
+        );
+        const segment: LiveMicSegment = {
+          recorder,
+          chunks: [],
+          startedAt: Date.now(),
+          includeVideo,
+          voicedMs: CALL_MIC_VAD_INTERVAL_MS,
+          peakRms: initialRms,
+        };
+        micSegmentRef.current = segment;
+        mediaRecorderRef.current = recorder;
+        recorder.ondataavailable = (event) => {
+          if (event.data.size > 0) segment.chunks.push(event.data);
+        };
+        recorder.onstop = () => {
+          if (mediaRecorderRef.current === recorder) mediaRecorderRef.current = null;
+          if (micSegmentRef.current === segment) micSegmentRef.current = null;
+          const durationMs = Date.now() - segment.startedAt;
+          if (
+            durationMs < CALL_MIC_MIN_SEGMENT_MS ||
+            segment.voicedMs < CALL_MIC_MIN_VOICED_MS ||
+            segment.peakRms < CALL_MIC_MIN_PEAK_RMS ||
+            segment.chunks.length === 0
+          ) {
+            return;
+          }
+          const blob = new Blob(segment.chunks, {
+            type: recorder.mimeType || (segment.includeVideo ? "video/webm" : "audio/webm"),
+          });
+          enqueueRecordedCallMedia(blob, segment.includeVideo);
+        };
+        recorder.start(500);
+      };
+
+      micLastSpeechAtRef.current = 0;
+      micSpeechFrameCountRef.current = 0;
+      micVadIntervalRef.current = window.setInterval(() => {
+        analyser.getByteTimeDomainData(timeDomain);
+        const rms = audioRmsFromTimeDomain(timeDomain);
+        const now = Date.now();
+        const segment = micSegmentRef.current;
+        const speaking = rms >= (segment ? CALL_MIC_RMS_CONTINUE : CALL_MIC_RMS_START);
+        if (speaking) {
+          micSpeechFrameCountRef.current += 1;
+        } else if (!segment) {
+          micSpeechFrameCountRef.current = 0;
+        }
+        const speechConfirmed = segment ? speaking : micSpeechFrameCountRef.current >= CALL_MIC_CONFIRM_FRAMES;
+        setUserSpeakingState(speechConfirmed);
+        updateVoiceInterruptionDetector(speechConfirmed);
+
+        if (segment && now - segment.startedAt >= CALL_MIC_MAX_SEGMENT_MS) {
+          stopSegment();
+          if (speaking) {
+            micLastSpeechAtRef.current = now;
+            micSpeechFrameCountRef.current = CALL_MIC_CONFIRM_FRAMES;
+            startSegment(rms);
+          }
+          return;
+        }
+
+        if (segment && speaking) {
+          segment.voicedMs += CALL_MIC_VAD_INTERVAL_MS;
+          segment.peakRms = Math.max(segment.peakRms, rms);
+          markUserActivity();
+          micLastSpeechAtRef.current = now;
+          return;
+        }
+
+        if (!segment && speaking) {
+          markUserActivity();
+          micLastSpeechAtRef.current = now;
+          startSegment(rms);
+          return;
+        }
+
+        if (segment && now - micLastSpeechAtRef.current >= CALL_MIC_SILENCE_MS) {
+          micSpeechFrameCountRef.current = 0;
+          stopSegment();
+        }
+      }, CALL_MIC_VAD_INTERVAL_MS);
+      setRecording(true);
+    } catch (error) {
+      stopLiveMicCapture();
+      setUserSpeakingState(false);
+      setRecording(false);
+      toast.error(error instanceof Error ? error.message : "Could not start microphone.");
+    }
+  }, [
+    callAudioEnabled,
+    browserSpeechSupported,
+    browserSpeechInputMode,
+    cameraStream,
+    enqueueRecordedCallMedia,
+    markUserActivity,
+    nativeInputMode,
+    recording,
+    recordingWillUseLocalWhisperFallback,
+    screenStream,
+    setUserSpeakingState,
+    startBrowserSpeechRecognition,
+    startSystemVoiceTyping,
+    stopLiveMicCapture,
+    stopStream,
+    systemVoiceInputMode,
+    updateVoiceInterruptionDetector,
+    videoControlsEnabled,
+  ]);
+
+  const playSound = useCallback((sound: ConversationCallSound) => {
+    if (sound.builtIn) {
+      synthesizeBuiltInSound(sound);
+      return;
+    }
+    const audio = new Audio(`/api/conversation-calls/soundboard/${sound.id}/file`);
+    void audio.play().catch((error) => toast.error(error instanceof Error ? error.message : "Could not play sound."));
+  }, []);
+
+  const handleEnd = useCallback(async () => {
+    cleanupLiveCallMedia();
+    playEndSoundOnce();
+    try {
+      await endCall.mutateAsync(session.id);
+      onEnded?.();
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : "Could not end the call.");
+    }
+  }, [cleanupLiveCallMedia, endCall, onEnded, playEndSoundOnce, session.id]);
+
+  const renderCallMessages = () =>
+    visibleCallMessages.length === 0 ? (
+      <div className="py-8 text-center text-xs text-[var(--marinara-chat-chrome-panel-muted)]">
+        No call messages yet.
+      </div>
+    ) : (
+      <div className="space-y-3">
+        {visibleCallMessages.map((message) => {
+          const participant =
+            message.participantKind === "user"
+              ? participants.find((p) => p.kind === "user")
+              : participants.find((p) => p.characterId === message.characterId);
+          const attachments = readCallMessageAttachments(message);
+          return (
+            <div key={message.id} className="flex gap-2">
+              {participant ? (
+                <CallAvatar participant={participant} className="mt-0.5 h-7 w-7 shrink-0" />
+              ) : (
+                <div className="mt-0.5 h-7 w-7 shrink-0 rounded-full bg-[var(--secondary)]" />
+              )}
+              <div className="min-w-0 flex-1">
+                <div className="flex items-baseline gap-2">
+                  <span className="text-sm font-semibold text-[var(--marinara-chat-chrome-panel-title)]">
+                    {messageLabel(message, participants)}
+                  </span>
+                  <span className="text-[0.6875rem] text-[var(--marinara-chat-chrome-panel-muted)]">
+                    {formatTime(message.createdAt)}
+                  </span>
+                </div>
+                <p
+                  className={cn(
+                    "whitespace-pre-wrap text-sm leading-relaxed text-[var(--marinara-chat-chrome-panel-text)]",
+                    message.kind === "command" && "text-[var(--marinara-chat-chrome-panel-muted)]",
+                  )}
+                >
+                  {messageContent(message, participants)}
+                </p>
+                {attachments.length > 0 ? (
+                  <div className="mt-2 flex flex-col items-start gap-2">
+                    {attachments.map((attachment, index) =>
+                      attachment.type === "image" || attachment.type.startsWith("image/") ? (
+                        <button
+                          key={`${message.id}:${index}`}
+                          type="button"
+                          onClick={() => {
+                            const url = attachment.url || attachment.data;
+                            if (url) window.open(url, "_blank", "noopener,noreferrer");
+                          }}
+                          className="block cursor-zoom-in rounded-lg text-left"
+                          title="Open image"
+                        >
+                          <img
+                            src={attachment.url || attachment.data}
+                            alt={attachment.filename || attachment.name || "Call image"}
+                            className="max-h-72 max-w-full rounded-lg"
+                            loading="lazy"
+                          />
+                        </button>
+                      ) : (
+                        <div
+                          key={`${message.id}:${index}`}
+                          className="max-w-full truncate rounded-lg bg-[var(--marinara-chat-chrome-panel-bg)] px-2.5 py-1.5 text-xs text-[var(--marinara-chat-chrome-panel-muted)] ring-1 ring-[var(--marinara-chat-chrome-panel-border)]"
+                        >
+                          {attachment.filename || attachment.name || "attachment"}
+                        </div>
+                      ),
+                    )}
+                  </div>
+                ) : null}
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    );
+
+  const renderCallComposer = () => (
+    <form
+      className="relative border-t border-[var(--marinara-chat-chrome-panel-divider)] bg-[var(--background)] p-2 sm:p-3"
+      onSubmit={(event) => {
+        event.preventDefault();
+        submitDraft();
+      }}
+    >
+      {mobilePickerOpen && (
+        <ConversationMediaPickerPanel
+          tabs={MOBILE_CALL_PICKER_TABS}
+          activeTab={mobilePickerTab}
+          onActiveTabChange={(tab) => {
+            if (tab !== "tools") setMobilePickerTab(tab);
+          }}
+          onClose={() => setMobilePickerOpen(false)}
+          onEmojiSelect={handleEmojiSelect}
+          onGifSelect={handleGifSelect}
+          onStickerSelect={handleStickerSelect}
+          className="absolute bottom-full left-2 right-2 z-30 mb-3 sm:hidden"
+        />
+      )}
+      <div
+        ref={inputBarRef}
+        className={getChatInputShellClass({
+          hasContent: draft.trim().length > 0,
+          layout: "conversation",
+          className: "w-full",
+        })}
+      >
+        <button
+          type="button"
+          disabled
+          className="flex h-9 w-9 shrink-0 items-center justify-center rounded-xl transition-all sm:h-8 sm:w-8"
+          title="Call file attachments are not available yet"
+        >
+          <Paperclip size="1rem" />
+        </button>
+        <QuickConnectionSwitcher className="h-9 w-9 shrink-0 rounded-xl sm:h-8 sm:w-8" />
+        <textarea
+          ref={textareaRef}
+          value={draft}
+          onChange={handleDraftChange}
+          onKeyDown={handleDraftKeyDown}
+          onFocus={() => {
+            if (mobilePickerOpen) setMobilePickerOpen(false);
+          }}
+          placeholder="Message in call"
+          rows={1}
+          className="mari-chat-input-textarea max-h-[12.5rem] min-h-9 min-w-0 flex-1 resize-none bg-transparent px-1 py-2 text-[1rem] leading-tight text-foreground outline-none placeholder:text-foreground/30 sm:min-h-0 sm:px-0 sm:py-0 sm:leading-normal"
+        />
+        <button
+          type="button"
+          onClick={() => {
+            const nextOpen = !mobilePickerOpen;
+            setMobilePickerOpen(nextOpen);
+            if (nextOpen) textareaRef.current?.blur();
+            else textareaRef.current?.focus();
+          }}
+          className={cn(
+            "flex h-9 w-9 items-center justify-center rounded-xl transition-colors sm:hidden",
+            mobilePickerOpen
+              ? "bg-foreground/10 text-foreground/75 ring-1 ring-foreground/20"
+              : "text-foreground/40 hover:bg-foreground/10 hover:text-foreground/70",
+          )}
+          title={mobilePickerOpen ? "Show keyboard" : "Emoji, GIFs & stickers"}
+          aria-label={mobilePickerOpen ? "Show keyboard" : "Emoji, GIFs and stickers"}
+        >
+          {mobilePickerOpen ? <Keyboard size="1.25rem" /> : <Smile size="1.25rem" />}
+        </button>
+        <div className="relative hidden shrink-0 sm:block">
+          <button
+            type="button"
+            onClick={() => {
+              setMobilePickerOpen((value) => !value);
+            }}
+            className={cn(
+              "flex h-9 w-9 items-center justify-center rounded-xl transition-colors sm:h-8 sm:w-8 sm:rounded-full",
+              mobilePickerOpen
+                ? "bg-foreground/10 text-foreground/75 ring-1 ring-foreground/20"
+                : "text-foreground/40 hover:bg-foreground/10 hover:text-foreground/70",
+            )}
+            title="Emoji, GIFs & stickers"
+            aria-label="Emoji, GIFs and stickers"
+            aria-expanded={mobilePickerOpen}
+          >
+            <Smile size="1.25rem" />
+          </button>
+          {mobilePickerOpen && (
+            <ConversationMediaPickerPanel
+              tabs={MOBILE_CALL_PICKER_TABS}
+              activeTab={mobilePickerTab}
+              onActiveTabChange={(tab) => {
+                if (tab !== "tools") setMobilePickerTab(tab);
+              }}
+              onClose={() => setMobilePickerOpen(false)}
+              onEmojiSelect={handleEmojiSelect}
+              onGifSelect={handleGifSelect}
+              onStickerSelect={handleStickerSelect}
+              className="absolute bottom-full right-0 z-30 mb-4 w-[min(24rem,calc(100vw-1.5rem))]"
+            />
+          )}
+        </div>
+        <button
+          type="submit"
+          disabled={!draft.trim() || queuedCallInteractions > 0 || sendMessage.isPending}
+          className="mari-chat-send-btn flex h-9 w-9 shrink-0 items-center justify-center rounded-xl transition-all duration-200 disabled:cursor-not-allowed sm:h-8 sm:w-8"
+          title="Send"
+        >
+          {queuedCallInteractions > 0 || sendMessage.isPending ? (
+            <Loader2 size="1rem" className="animate-spin" />
+          ) : (
+            <Send size="0.9375rem" />
+          )}
+        </button>
+      </div>
+    </form>
+  );
+
+  return (
+    <div
+      className={cn(
+        "mari-chrome-token-scope relative flex flex-1 flex-col overflow-hidden bg-[var(--background)] text-[var(--marinara-chat-chrome-panel-text)]",
+        !embedded && "mari-chat-area mari-card-css",
+      )}
+    >
+      <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
+        <div className="relative flex min-h-[18rem] flex-[1_1_0] flex-col overflow-hidden border-b border-[var(--marinara-chat-chrome-panel-divider)] bg-[var(--background)] md:min-h-0 md:basis-1/2">
+          <div className="flex items-center justify-between gap-3 px-4 py-3 text-sm">
+            <div className="min-w-0">
+              <div className="font-semibold tabular-nums text-[var(--marinara-chat-chrome-panel-title)]">
+                {elapsedLabel}
+              </div>
+              <div className="truncate text-xs text-[var(--marinara-chat-chrome-panel-muted)]">
+                Started {formatTime(session.startedAt ?? session.createdAt)}
+              </div>
+            </div>
+            <div className="flex items-center gap-2 text-xs text-[var(--marinara-chat-chrome-panel-muted)]">
+              <Volume2 size="0.875rem" className="text-[var(--marinara-chat-chrome-button-text-hover)]" />
+              <span>{stageStatusLabel}</span>
+            </div>
+          </div>
+
+          <div
+            className="grid min-h-0 flex-1 gap-2 overflow-hidden px-3 pb-20 pt-2 sm:gap-3 sm:px-4 sm:pb-24"
+            style={participantGridStyle}
+          >
+            {visibleParticipants.map((participant) => (
+              <ParticipantTile
+                key={participant.id}
+                participant={participant}
+                active={speakingId === participant.id || (participant.kind === "user" && userSpeaking)}
+                cameraStream={participant.kind === "user" ? cameraStream : null}
+                density={participantGridLayout.density}
+              />
+            ))}
+          </div>
+
+          {pendingParticipants.length > 0 && (
+            <div className="pointer-events-none absolute inset-x-0 bottom-20 flex justify-center px-4">
+              <div className="rounded-full border border-[var(--marinara-chat-chrome-panel-border)] bg-[var(--marinara-chat-chrome-panel-bg)] px-3 py-1 text-xs text-[var(--marinara-chat-chrome-panel-muted)] shadow-sm">
+                {stageStatusLabel}...
+              </div>
+            </div>
+          )}
+
+          <div className="pointer-events-none absolute inset-x-0 bottom-4 z-20 flex justify-center px-3">
+            <div className="pointer-events-auto relative max-w-[calc(100vw-1.5rem)]">
+              {soundboardEnabled && soundboardOpen && (
+                <div className="absolute bottom-full left-1/2 z-30 mb-2 flex max-h-72 w-[min(32rem,calc(100vw-1.5rem))] -translate-x-1/2 flex-col gap-2 overflow-hidden rounded-lg border border-[var(--marinara-chat-chrome-panel-border)] bg-[var(--marinara-chat-chrome-panel-bg)] p-3 shadow-xl">
+                  <div className="flex items-center justify-between gap-2">
+                    <span className="text-xs font-semibold text-[var(--marinara-chat-chrome-panel-title)]">
+                      Soundboard
+                    </span>
+                    <label className="mari-chrome-control mari-chrome-control--small inline-flex cursor-pointer items-center gap-1.5 text-xs">
+                      <Upload size="0.75rem" />
+                      Upload
+                      <input
+                        type="file"
+                        accept="audio/*"
+                        className="hidden"
+                        onChange={(event) => {
+                          const file = event.currentTarget.files?.[0];
+                          event.currentTarget.value = "";
+                          if (!file) return;
+                          uploadSound.mutate({ file, name: file.name.replace(/\.[^.]+$/, "") });
+                        }}
+                      />
+                    </label>
+                  </div>
+                  <div className="grid gap-1.5 overflow-y-auto sm:grid-cols-2">
+                    {sounds.map((sound) => (
+                      <div
+                        key={sound.id}
+                        className="flex items-center gap-1 rounded-md border border-[var(--marinara-chat-chrome-panel-border)] bg-[var(--marinara-chat-chrome-highlight-bg)] px-2 py-1.5"
+                      >
+                        <button
+                          type="button"
+                          onClick={() => playSound(sound)}
+                          className="min-w-0 flex-1 truncate rounded px-1 text-left text-xs text-[var(--marinara-chat-chrome-panel-text)] transition-colors hover:text-[var(--marinara-chat-chrome-button-text-hover)]"
+                        >
+                          {sound.name}
+                        </button>
+                        {!sound.builtIn && (
+                          <button
+                            type="button"
+                            onClick={() => deleteSound.mutate(sound.id)}
+                            className="rounded p-1 text-[var(--marinara-chat-chrome-panel-muted)] hover:bg-[var(--marinara-chat-chrome-highlight-bg-hover)] hover:text-[var(--destructive)]"
+                            title="Delete sound"
+                          >
+                            <Trash2 size="0.75rem" />
+                          </button>
+                        )}
+                      </div>
+                    ))}
+                  </div>
+                </div>
+              )}
+              {voiceVolumeOpen && (
+                <div className="absolute bottom-full left-1/2 z-30 mb-2 flex w-[min(18rem,calc(100vw-1.5rem))] -translate-x-1/2 flex-col gap-3 rounded-lg border border-[var(--marinara-chat-chrome-panel-border)] bg-[var(--marinara-chat-chrome-panel-bg)] p-3 shadow-xl">
+                  <div className="flex items-center justify-between gap-2">
+                    <span className="text-xs font-semibold text-[var(--marinara-chat-chrome-panel-title)]">
+                      Character volume
+                    </span>
+                    <span className="text-xs tabular-nums text-[var(--marinara-chat-chrome-panel-muted)]">
+                      {characterVoiceVolumeLabel}
+                    </span>
+                  </div>
+                  <div className="flex items-center gap-2">
+                    <button
+                      type="button"
+                      onClick={toggleCharacterVoicesMuted}
+                      aria-pressed={characterVoicesMuted}
+                      className={cn(
+                        "mari-chrome-control h-9 w-9 p-0",
+                        characterVoicesMuted && "mari-chrome-control--selected",
+                      )}
+                      title={characterVoicesMuted ? "Unmute character voices" : "Mute character voices"}
+                    >
+                      {characterVoicesMuted ? <VolumeX size="0.95rem" /> : <Volume2 size="0.95rem" />}
+                    </button>
+                    <input
+                      type="range"
+                      min={0}
+                      max={100}
+                      step={1}
+                      value={conversationCallVoiceVolume}
+                      onChange={(event) => setConversationCallVoiceVolume(Number(event.currentTarget.value))}
+                      className="min-w-0 flex-1"
+                      aria-label="Character voice volume"
+                    />
+                  </div>
+                </div>
+              )}
+
+              <div
+                className={cn(
+                  "grid w-[calc(100vw-1.5rem)] items-center justify-center gap-1 overflow-visible rounded-2xl border border-[var(--marinara-chat-chrome-panel-border)] bg-[var(--marinara-chat-chrome-panel-bg)] p-1.5 shadow-xl shadow-black/20 sm:flex sm:w-auto sm:max-w-[calc(100vw-1.5rem)] sm:gap-2 sm:p-2",
+                  callControlGridColumns,
+                )}
+              >
+                <button
+	                  type="button"
+	                  onClick={recording ? stopRecording : startRecording}
+	                  disabled={!callAudioEnabled}
+	                  aria-pressed={recording}
+	                  className={cn(callControlButtonClass, recording && "mari-chrome-control--selected")}
+                  title={
+                    !callAudioEnabled
+                      ? "Enable call audio in Chat Settings"
+                      : recording
+                          ? nativeInputMode
+                            ? "Mute microphone"
+                            : systemVoiceInputMode
+                              ? "Stop dictation"
+                              : "Mute microphone"
+                          : systemVoiceInputMode
+                            ? "Use manual system dictation"
+                            : recordingWillUseLocalWhisperFallback
+                              ? "Unmute microphone with Local Whisper"
+                            : nativeInputMode
+                              ? "Unmute microphone with provider-native audio"
+                              : localWhisperInputMode
+                                ? "Unmute microphone with Local Whisper"
+                                : "Speak with browser speech recognition"
+                  }
+	                >
+	                  {recording ? (
+	                    <Mic className={callControlIconClass} />
+	                  ) : systemVoiceInputMode ? (
+	                    <Mic className={callControlIconClass} />
+	                  ) : (
+                    <MicOff className={callControlIconClass} />
+                  )}
+                </button>
+                <button
+                  type="button"
+                  onClick={toggleCamera}
+                  disabled={!videoControlsEnabled}
+                  aria-pressed={Boolean(cameraStream)}
+                  className={callControlButtonClass}
+                  title={
+                    videoControlsEnabled
+                      ? cameraStream
+                        ? "Turn camera off"
+                        : "Turn camera on"
+                      : nativeInputMode
+                        ? "Enable camera input in Chat Settings"
+                        : "Switch audio input mode to provider-native audio/video"
+                  }
+                >
+                  {cameraStream ? (
+                    <Video className={callControlIconClass} />
+                  ) : (
+                    <VideoOff className={callControlIconClass} />
+                  )}
+                </button>
+                <button
+                  type="button"
+                  onClick={toggleScreenShare}
+                  disabled={!videoControlsEnabled}
+                  aria-pressed={Boolean(screenStream)}
+                  className={callControlButtonClass}
+                  title={
+                    videoControlsEnabled
+                      ? screenStream
+                        ? "Stop sharing screen"
+                        : "Share screen"
+                      : nativeInputMode
+                        ? "Enable screen input in Chat Settings"
+                        : "Switch audio input mode to provider-native audio/video"
+                  }
+                >
+                  {screenStream ? (
+                    <ScreenShareOff className={callControlIconClass} />
+                  ) : (
+                    <ScreenShare className={callControlIconClass} />
+                  )}
+                </button>
+                <button
+                  type="button"
+                  onClick={() => {
+                    setVoiceVolumeOpen((value) => !value);
+                    setSoundboardOpen(false);
+                  }}
+                  aria-pressed={voiceVolumeOpen || characterVoicesMuted}
+                  className={callControlButtonClass}
+                  title={`Character volume: ${characterVoiceVolumeLabel}`}
+                >
+                  {characterVoicesMuted ? (
+                    <VolumeX className={callControlIconClass} />
+                  ) : (
+                    <Volume2 className={callControlIconClass} />
+                  )}
+                </button>
+                {soundboardEnabled && (
+                  <button
+                    type="button"
+                    onClick={() => {
+                      setSoundboardOpen((value) => !value);
+                      setVoiceVolumeOpen(false);
+                    }}
+                    aria-pressed={soundboardOpen}
+                    className={callControlButtonClass}
+                    title="Soundboard"
+                  >
+                    <Sparkles className={callControlIconClass} />
+                  </button>
+                )}
+                <button
+                  type="button"
+                  onClick={() => setMobileChatOpen(true)}
+                  className={cn(callControlButtonClass, "md:!hidden")}
+                  title="Open call chat"
+                >
+                  <MessageCircle className={callControlIconClass} />
+                </button>
+                <button
+                  type="button"
+                  onClick={handleEnd}
+                  disabled={endCall.isPending}
+                  className={cn(callControlButtonClass, "mari-chrome-control--danger")}
+                  title="End call"
+                >
+                  {endCall.isPending ? (
+                    <Loader2 className={cn(callControlIconClass, "animate-spin")} />
+                  ) : (
+                    <PhoneOff className="h-4 w-4 sm:h-[1.1rem] sm:w-[1.1rem]" />
+                  )}
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div className="hidden min-h-0 flex-1 basis-1/2 flex-col bg-[var(--background)] md:flex">
+          <div className="min-h-0 flex-1 overflow-y-auto px-4 py-3">{renderCallMessages()}</div>
+          {renderCallComposer()}
+        </div>
+      </div>
+      {mobileChatOpen && (
+        <div className="absolute inset-0 z-40 flex flex-col bg-[var(--background)] md:hidden">
+          <div className="flex shrink-0 items-center justify-between gap-3 border-b border-[var(--marinara-chat-chrome-panel-divider)] px-4 py-3">
+            <div className="min-w-0">
+              <div className="truncate text-sm font-semibold text-[var(--marinara-chat-chrome-panel-title)]">
+                Call Chat
+              </div>
+              <div className="text-xs text-[var(--marinara-chat-chrome-panel-muted)]">{elapsedLabel}</div>
+            </div>
+            <button
+              type="button"
+              onClick={() => setMobileChatOpen(false)}
+              className="mari-chrome-control h-9 w-9 p-0"
+              title="Close call chat"
+            >
+              <X size="1rem" />
+            </button>
+          </div>
+          <div className="min-h-0 flex-1 overflow-y-auto px-4 py-3">{renderCallMessages()}</div>
+          {renderCallComposer()}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/packages/client/src/components/chat/ConversationInput.tsx
+++ b/packages/client/src/components/chat/ConversationInput.tsx
@@ -5,11 +5,9 @@ import { useState, useRef, useCallback, useEffect, useMemo, type FormEvent } fro
 import {
   Send,
   Smile,
-  Sticker,
   StopCircle,
   X,
   Paperclip,
-  ImagePlay,
   Keyboard,
   AtSign,
   Users,
@@ -46,16 +44,17 @@ import { CARD_ASSET_INSERT_EVENT, type CardAssetInsertDetail } from "../../lib/c
 import { QuickConnectionSwitcher } from "./QuickConnectionSwitcher";
 import { QuickPersonaSwitcher } from "./QuickPersonaSwitcher";
 import { QuickSwitcherMobile } from "./QuickSwitcherMobile";
-import { EmojiPicker } from "../ui/EmojiPicker";
-import { CustomEmojiTab } from "./CustomEmojiTab";
-import { StickerPicker } from "./StickerPicker";
 import { showChoiceDialog } from "../../lib/app-dialogs";
 import { useConversationCustomEmojis, type ConversationCustomEmoji } from "../../hooks/use-conversation-custom-emojis";
-import { GifPicker } from "../ui/GifPicker";
 import { SpeechToTextButton } from "../ui/SpeechToTextButton";
 import { SlashCommandFeedback } from "./SlashCommandFeedback";
 import { QuickReplyMenu, type QuickReplyAction } from "./QuickReplyMenu";
 import { getChatInputShellClass } from "./chat-input-styles";
+import {
+  ConversationMediaPickerPanel,
+  type ConversationMediaPickerTab,
+  type ConversationMediaPickerTabId,
+} from "./ConversationMediaPickerPanel";
 import {
   buildGuidedGenerationInstructionMessage,
   formatTextQuotes,
@@ -88,7 +87,7 @@ const PDF_ATTACHMENT_MIME_TYPE = "application/pdf";
 const CONVERSATION_HIDDEN_SLASH_COMMANDS = new Set(["impersonate", "impersonate_prompt"]);
 const QUOTE_INPUT_TRIGGER_RE = /["'\u2018\u2019\u201a\u201b\u201c\u201d\u201e\u201f]/;
 
-type MobilePickerTab = "emoji" | "gifs" | "stickers" | "tools";
+type MobilePickerTab = ConversationMediaPickerTabId;
 
 type ConversationSlashCompletion = {
   key: string;
@@ -315,9 +314,6 @@ export function ConversationInput({
   const [attachments, setAttachments] = useState<Attachment[]>([]);
   const [pendingAttachmentReadsByChat, setPendingAttachmentReadsByChat] = useState<Record<string, number>>({});
   const [isTranslatingDraft, setIsTranslatingDraft] = useState(false);
-  const [emojiOpen, setEmojiOpen] = useState(false);
-  const [gifOpen, setGifOpen] = useState(false);
-  const [stickerOpen, setStickerOpen] = useState(false);
   const [mobilePickerOpen, setMobilePickerOpen] = useState(false);
   const [mobilePickerTab, setMobilePickerTab] = useState<MobilePickerTab>("emoji");
   const isMobileComposerViewport = useIsMobileComposerViewport();
@@ -337,9 +333,6 @@ export function ConversationInput({
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const resizeTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const draftTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const emojiButtonRef = useRef<HTMLButtonElement>(null);
-  const gifButtonRef = useRef<HTMLButtonElement>(null);
-  const stickerButtonRef = useRef<HTMLButtonElement>(null);
   const charPickerBtnRef = useRef<HTMLButtonElement>(null);
   const charPickerMenuRef = useRef<HTMLDivElement>(null);
   const inputBarRef = useRef<HTMLDivElement>(null);
@@ -385,9 +378,6 @@ export function ConversationInput({
     !isReadingAttachments &&
     !isStreaming &&
     !mobilePickerOpen &&
-    !emojiOpen &&
-    !gifOpen &&
-    !stickerOpen &&
     !charPickerOpen;
   const chatMetadata = useMemo(() => parseChatMetadata(activeChat?.metadata), [activeChat?.metadata]);
   const inactiveCharacterIds = useMemo(
@@ -1427,93 +1417,96 @@ export function ConversationInput({
     ],
   );
 
-  const handleInput = useCallback((event: FormEvent<HTMLTextAreaElement>) => {
-    const el = textareaRef.current;
-    if (!el) return;
-    const formatted = shouldFormatQuoteInput(event, el.value) ? applyTextareaQuoteFormat(el, quoteFormat) : el.value;
-    // Debounced resize to reduce layout reflows during fast typing
-    if (resizeTimerRef.current) clearTimeout(resizeTimerRef.current);
-    resizeTimerRef.current = setTimeout(() => {
+  const handleInput = useCallback(
+    (event: FormEvent<HTMLTextAreaElement>) => {
+      const el = textareaRef.current;
       if (!el) return;
-      el.style.height = "auto";
-      el.style.height = `${Math.min(el.scrollHeight, 160)}px`;
-    }, 150);
-    syncInputState(formatted);
+      const formatted = shouldFormatQuoteInput(event, el.value) ? applyTextareaQuoteFormat(el, quoteFormat) : el.value;
+      // Debounced resize to reduce layout reflows during fast typing
+      if (resizeTimerRef.current) clearTimeout(resizeTimerRef.current);
+      resizeTimerRef.current = setTimeout(() => {
+        if (!el) return;
+        el.style.height = "auto";
+        el.style.height = `${Math.min(el.scrollHeight, 160)}px`;
+      }, 150);
+      syncInputState(formatted);
 
-    if (activeChatId) {
-      if (draftTimerRef.current) clearTimeout(draftTimerRef.current);
-      const chatId = activeChatId;
-      const draft = formatted;
-      draftTimerRef.current = setTimeout(() => {
-        if (draft.trim()) {
-          setInputDraft(chatId, draft);
+      if (activeChatId) {
+        if (draftTimerRef.current) clearTimeout(draftTimerRef.current);
+        const chatId = activeChatId;
+        const draft = formatted;
+        draftTimerRef.current = setTimeout(() => {
+          if (draft.trim()) {
+            setInputDraft(chatId, draft);
+          } else {
+            clearInputDraft(chatId);
+          }
+        }, 300);
+      }
+
+      // Slash completions
+      if (formatted.startsWith("/")) {
+        const results = buildConversationSlashCompletions(formatted, activeChatCharacters);
+        setCompletions(results);
+        setSelectedCompletion(0);
+      } else {
+        setCompletions((current) => (current.length > 0 ? [] : current));
+      }
+
+      // @mention detection — look backwards from cursor for an @ trigger
+      const cursor = el.selectionStart;
+      const textBefore = formatted.slice(0, cursor);
+      // Find the last @ that isn't preceded by a word character
+      const atMatch = textBefore.match(/(^|[^\p{L}\p{N}_])@([^\n@]*)$/u);
+      if (atMatch && activeCharacterNames.length > 0) {
+        const queryText = atMatch[2] ?? "";
+        const query = normalizeTextForMatch(queryText);
+        const startPos = (atMatch.index ?? textBefore.length - atMatch[0].length) + (atMatch[1]?.length ?? 0);
+        const matches = activeCharacterNames.filter((name) => startsWithTextForMatch(name, query));
+        if (matches.length > 0) {
+          setMentionQuery(query);
+          setMentionCompletions(matches);
+          setSelectedMention(0);
+          setMentionStartPos(startPos);
         } else {
-          clearInputDraft(chatId);
+          setMentionQuery((current) => (current === null ? current : null));
+          setMentionCompletions((current) => (current.length > 0 ? [] : current));
         }
-      }, 300);
-    }
-
-    // Slash completions
-    if (formatted.startsWith("/")) {
-      const results = buildConversationSlashCompletions(formatted, activeChatCharacters);
-      setCompletions(results);
-      setSelectedCompletion(0);
-    } else {
-      setCompletions((current) => (current.length > 0 ? [] : current));
-    }
-
-    // @mention detection — look backwards from cursor for an @ trigger
-    const cursor = el.selectionStart;
-    const textBefore = formatted.slice(0, cursor);
-    // Find the last @ that isn't preceded by a word character
-    const atMatch = textBefore.match(/(^|[^\p{L}\p{N}_])@([^\n@]*)$/u);
-    if (atMatch && activeCharacterNames.length > 0) {
-      const queryText = atMatch[2] ?? "";
-      const query = normalizeTextForMatch(queryText);
-      const startPos = (atMatch.index ?? textBefore.length - atMatch[0].length) + (atMatch[1]?.length ?? 0);
-      const matches = activeCharacterNames.filter((name) => startsWithTextForMatch(name, query));
-      if (matches.length > 0) {
-        setMentionQuery(query);
-        setMentionCompletions(matches);
-        setSelectedMention(0);
-        setMentionStartPos(startPos);
       } else {
         setMentionQuery((current) => (current === null ? current : null));
         setMentionCompletions((current) => (current.length > 0 ? [] : current));
       }
-    } else {
-      setMentionQuery((current) => (current === null ? current : null));
-      setMentionCompletions((current) => (current.length > 0 ? [] : current));
-    }
 
-    // :emoji: detection — a `:partial` at a word boundary, just before the cursor
-    const emojiMatch = textBefore.match(/(?:^|\s):([a-z0-9_]+)$/);
-    if (emojiMatch && customEmojiList && customEmojiList.length > 0) {
-      const eq = emojiMatch[1]!.toLowerCase();
-      const matches = customEmojiList
-        .filter((em) => em.name.includes(eq))
-        .sort((a, b) => Number(b.name.startsWith(eq)) - Number(a.name.startsWith(eq)))
-        .slice(0, 10);
-      if (matches.length > 0) {
-        setEmojiCompletions(matches);
-        setSelectedEmojiCompletion(0);
-        setEmojiStartPos(cursor - eq.length - 1);
+      // :emoji: detection — a `:partial` at a word boundary, just before the cursor
+      const emojiMatch = textBefore.match(/(?:^|\s):([a-z0-9_]+)$/);
+      if (emojiMatch && customEmojiList && customEmojiList.length > 0) {
+        const eq = emojiMatch[1]!.toLowerCase();
+        const matches = customEmojiList
+          .filter((em) => em.name.includes(eq))
+          .sort((a, b) => Number(b.name.startsWith(eq)) - Number(a.name.startsWith(eq)))
+          .slice(0, 10);
+        if (matches.length > 0) {
+          setEmojiCompletions(matches);
+          setSelectedEmojiCompletion(0);
+          setEmojiStartPos(cursor - eq.length - 1);
+        } else {
+          setEmojiCompletions((current) => (current.length > 0 ? [] : current));
+        }
       } else {
         setEmojiCompletions((current) => (current.length > 0 ? [] : current));
       }
-    } else {
-      setEmojiCompletions((current) => (current.length > 0 ? [] : current));
-    }
-  }, [
-    activeChatId,
-    activeCharacterNames,
-    activeChatCharacters,
-    customEmojiList,
-    clearInputDraft,
-    quoteFormat,
-    setInputDraft,
-    syncInputState,
-  ]);
+    },
+    [
+      activeChatId,
+      activeCharacterNames,
+      activeChatCharacters,
+      customEmojiList,
+      clearInputDraft,
+      quoteFormat,
+      setInputDraft,
+      syncInputState,
+    ],
+  );
 
   useEffect(() => {
     if (hasInput && feedback) setFeedback(null);
@@ -1706,8 +1699,8 @@ export function ConversationInput({
     showDraftTranslateButton ||
     speechToTextEnabled ||
     (showQuickRepliesMenu && quickReplyActions.length > 0);
-  const mobilePickerTabs = useMemo<Array<{ id: MobilePickerTab; label: string }>>(() => {
-    const tabs: Array<{ id: MobilePickerTab; label: string }> = [
+  const mobilePickerTabs = useMemo<ConversationMediaPickerTab[]>(() => {
+    const tabs: ConversationMediaPickerTab[] = [
       { id: "emoji", label: "Emoji" },
       { id: "gifs", label: "GIFs" },
       { id: "stickers", label: "Stickers" },
@@ -1801,6 +1794,134 @@ export function ConversationInput({
           : "bg-green-500";
   const statusLabel = (status?: string) =>
     status === "offline" ? "Offline" : status === "dnd" ? "Busy" : status === "idle" ? "Away" : null;
+
+  const mediaPickerToolsContent =
+    mobilePickerTab === "tools" ? (
+      <div className="flex h-full flex-col gap-3 overflow-y-auto p-3">
+        {showCharPicker && activeChatCharacters && (
+          <div className="space-y-1.5">
+            <div className="px-1 text-[0.6875rem] font-semibold uppercase text-foreground/45">Trigger Response</div>
+            <div className="grid gap-1">
+              {activeChatCharacters.map((char) => (
+                <button
+                  key={char.id}
+                  type="button"
+                  onClick={() => {
+                    setMobilePickerOpen(false);
+                    handleCharacterResponse(char.id);
+                  }}
+                  className={cn(
+                    "flex min-h-11 w-full items-center gap-2.5 rounded-lg px-3 py-2 text-left transition-all hover:bg-foreground/10",
+                    (char.conversationStatus === "dnd" || char.conversationStatus === "offline") && "opacity-60",
+                  )}
+                >
+                  <div className="relative shrink-0">
+                    {char.avatarUrl ? (
+                      <span className="relative block h-7 w-7 overflow-hidden rounded-full">
+                        <img
+                          src={char.avatarUrl}
+                          alt={char.name}
+                          className="h-full w-full object-cover"
+                          style={getAvatarCropStyle(char.avatarCrop)}
+                        />
+                      </span>
+                    ) : (
+                      <div className="flex h-7 w-7 items-center justify-center rounded-full bg-foreground/10 text-[0.6875rem] font-semibold text-foreground/45">
+                        {(char.name || "?")[0].toUpperCase()}
+                      </div>
+                    )}
+                    <span
+                      className={cn(
+                        "absolute -bottom-0.5 -right-0.5 h-2 w-2 rounded-full ring-2 ring-[var(--card)]",
+                        statusDotClass(char.conversationStatus),
+                      )}
+                    />
+                  </div>
+                  <span className="min-w-0 flex-1">
+                    <span className="block truncate text-sm font-medium">{char.name}</span>
+                    {(char.conversationActivity || statusLabel(char.conversationStatus)) && (
+                      <span className="block truncate text-xs text-foreground/45">
+                        {char.conversationActivity || statusLabel(char.conversationStatus)}
+                      </span>
+                    )}
+                  </span>
+                </button>
+              ))}
+            </div>
+          </div>
+        )}
+
+        <div className="grid gap-2">
+          {showDraftTranslateButton && (
+            <button
+              type="button"
+              onClick={() => {
+                setMobilePickerOpen(false);
+                void handleTranslateDraft();
+              }}
+              disabled={!activeChatId || !hasInput || isTranslatingDraft}
+              className={cn(
+                "flex min-h-11 w-full items-center gap-2.5 rounded-lg px-3 py-2 text-left transition-colors",
+                activeChatId && hasInput && !isTranslatingDraft
+                  ? "text-foreground/80 hover:bg-foreground/10"
+                  : "cursor-not-allowed text-foreground/25",
+              )}
+            >
+              {isTranslatingDraft ? (
+                <Loader2 size="1rem" className="shrink-0 animate-spin" />
+              ) : (
+                <Languages size="1rem" className="shrink-0" />
+              )}
+              <span className="min-w-0 flex-1 truncate text-sm font-medium">Translate draft</span>
+            </button>
+          )}
+
+          {speechToTextEnabled && (
+            <div className="flex min-h-11 items-center justify-between gap-2 rounded-lg px-3 py-2">
+              <span className="min-w-0 flex-1 truncate text-sm font-medium text-foreground/80">Voice input</span>
+              <SpeechToTextButton
+                disabled={!activeChatId}
+                onTranscript={(transcript) => {
+                  setMobilePickerOpen(false);
+                  handleSpeechTranscript(transcript);
+                }}
+                className="h-10 w-10 rounded-lg"
+                iconSize={16}
+              />
+            </div>
+          )}
+
+          {showQuickRepliesMenu &&
+            quickReplyActions.map((action) => (
+              <button
+                key={action.id}
+                type="button"
+                onClick={() => {
+                  if (action.disabled) return;
+                  setMobilePickerOpen(false);
+                  void action.onSelect();
+                }}
+                disabled={action.disabled}
+                title={action.disabled ? (action.disabledReason ?? action.description) : action.description}
+                className={cn(
+                  "flex min-h-11 w-full items-center gap-2.5 rounded-lg px-3 py-2 text-left transition-colors",
+                  action.disabled
+                    ? "cursor-not-allowed text-foreground/25"
+                    : "text-foreground/80 hover:bg-foreground/10",
+                )}
+              >
+                <span className="shrink-0">{action.icon}</span>
+                <span className="min-w-0 flex-1">
+                  <span className="block truncate text-sm font-medium">{action.label}</span>
+                  <span className="block truncate text-xs text-foreground/45">
+                    {action.disabledReason ?? action.description}
+                  </span>
+                </span>
+              </button>
+            ))}
+        </div>
+      </div>
+    ) : null;
 
   if (shouldShowMobileCollapsedComposer) {
     return (
@@ -1910,179 +2031,19 @@ export function ConversationInput({
         </div>
       )}
 
-      {/* Mobile multipurpose picker sheet — Emoji / GIFs / Stickers / Tools (desktop uses the popovers) */}
+      {/* Multipurpose picker sheet — Emoji / GIFs / Stickers / Tools */}
       {mobilePickerOpen && (
-        <div className="absolute bottom-full left-0 right-0 z-20 mb-1 flex h-[22rem] max-h-[60vh] flex-col overflow-hidden rounded-xl border border-foreground/10 bg-[var(--card)] shadow-xl sm:hidden">
-          <div className="flex shrink-0 items-center gap-1 border-b border-foreground/10 px-2 py-1.5">
-            {mobilePickerTabs.map((tab) => (
-              <button
-                key={tab.id}
-                type="button"
-                onClick={() => setMobilePickerTab(tab.id)}
-                className={cn(
-                  "flex-1 rounded-md px-2 py-1 text-xs font-medium transition-colors",
-                  mobilePickerTab === tab.id
-                    ? "bg-foreground/10 text-foreground/80 ring-1 ring-foreground/15"
-                    : "text-foreground/45 hover:bg-foreground/10 hover:text-foreground/70",
-                )}
-              >
-                {tab.label}
-              </button>
-            ))}
-          </div>
-          <div className="min-h-0 flex-1">
-            {mobilePickerTab === "emoji" && (
-              <EmojiPicker
-                embedded
-                open
-                onClose={() => setMobilePickerOpen(false)}
-                onSelect={handleEmojiSelect}
-                customTab={{
-                  icon: "⭐",
-                  label: "Custom emojis",
-                  render: (query) => <CustomEmojiTab onInsert={handleEmojiSelect} query={query} />,
-                }}
-              />
-            )}
-            {mobilePickerTab === "gifs" && (
-              <GifPicker embedded open onClose={() => setMobilePickerOpen(false)} onSelect={handleGifSelect} />
-            )}
-            {mobilePickerTab === "stickers" && (
-              <StickerPicker embedded open onClose={() => setMobilePickerOpen(false)} onSelect={handleStickerSelect} />
-            )}
-            {mobilePickerTab === "tools" && (
-              <div className="flex h-full flex-col gap-3 overflow-y-auto p-3">
-                {showCharPicker && activeChatCharacters && (
-                  <div className="space-y-1.5">
-                    <div className="px-1 text-[0.6875rem] font-semibold uppercase text-foreground/45">
-                      Trigger Response
-                    </div>
-                    <div className="grid gap-1">
-                      {activeChatCharacters.map((char) => (
-                        <button
-                          key={char.id}
-                          type="button"
-                          onClick={() => {
-                            setMobilePickerOpen(false);
-                            handleCharacterResponse(char.id);
-                          }}
-                          className={cn(
-                            "flex min-h-11 w-full items-center gap-2.5 rounded-lg px-3 py-2 text-left transition-all hover:bg-foreground/10",
-                            (char.conversationStatus === "dnd" || char.conversationStatus === "offline") &&
-                              "opacity-60",
-                          )}
-                        >
-                          <div className="relative shrink-0">
-                            {char.avatarUrl ? (
-                              <span className="relative block h-7 w-7 overflow-hidden rounded-full">
-                                <img
-                                  src={char.avatarUrl}
-                                  alt={char.name}
-                                  className="h-full w-full object-cover"
-                                  style={getAvatarCropStyle(char.avatarCrop)}
-                                />
-                              </span>
-                            ) : (
-                              <div className="flex h-7 w-7 items-center justify-center rounded-full bg-foreground/10 text-[0.6875rem] font-semibold text-foreground/45">
-                                {(char.name || "?")[0].toUpperCase()}
-                              </div>
-                            )}
-                            <span
-                              className={cn(
-                                "absolute -bottom-0.5 -right-0.5 h-2 w-2 rounded-full ring-2 ring-[var(--card)]",
-                                statusDotClass(char.conversationStatus),
-                              )}
-                            />
-                          </div>
-                          <span className="min-w-0 flex-1">
-                            <span className="block truncate text-sm font-medium">{char.name}</span>
-                            {(char.conversationActivity || statusLabel(char.conversationStatus)) && (
-                              <span className="block truncate text-xs text-foreground/45">
-                                {char.conversationActivity || statusLabel(char.conversationStatus)}
-                              </span>
-                            )}
-                          </span>
-                        </button>
-                      ))}
-                    </div>
-                  </div>
-                )}
-
-                <div className="grid gap-2">
-                  {showDraftTranslateButton && (
-                    <button
-                      type="button"
-                      onClick={() => {
-                        setMobilePickerOpen(false);
-                        void handleTranslateDraft();
-                      }}
-                      disabled={!activeChatId || !hasInput || isTranslatingDraft}
-                      className={cn(
-                        "flex min-h-11 w-full items-center gap-2.5 rounded-lg px-3 py-2 text-left transition-colors",
-                        activeChatId && hasInput && !isTranslatingDraft
-                          ? "text-foreground/80 hover:bg-foreground/10"
-                          : "cursor-not-allowed text-foreground/25",
-                      )}
-                    >
-                      {isTranslatingDraft ? (
-                        <Loader2 size="1rem" className="shrink-0 animate-spin" />
-                      ) : (
-                        <Languages size="1rem" className="shrink-0" />
-                      )}
-                      <span className="min-w-0 flex-1 truncate text-sm font-medium">Translate draft</span>
-                    </button>
-                  )}
-
-                  {speechToTextEnabled && (
-                    <div className="flex min-h-11 items-center justify-between gap-2 rounded-lg px-3 py-2">
-                      <span className="min-w-0 flex-1 truncate text-sm font-medium text-foreground/80">
-                        Voice input
-                      </span>
-                      <SpeechToTextButton
-                        disabled={!activeChatId}
-                        onTranscript={(transcript) => {
-                          setMobilePickerOpen(false);
-                          handleSpeechTranscript(transcript);
-                        }}
-                        className="h-10 w-10 rounded-lg"
-                        iconSize={16}
-                      />
-                    </div>
-                  )}
-
-                  {showQuickRepliesMenu &&
-                    quickReplyActions.map((action) => (
-                      <button
-                        key={action.id}
-                        type="button"
-                        onClick={() => {
-                          if (action.disabled) return;
-                          setMobilePickerOpen(false);
-                          void action.onSelect();
-                        }}
-                        disabled={action.disabled}
-                        title={action.disabled ? (action.disabledReason ?? action.description) : action.description}
-                        className={cn(
-                          "flex min-h-11 w-full items-center gap-2.5 rounded-lg px-3 py-2 text-left transition-colors",
-                          action.disabled
-                            ? "cursor-not-allowed text-foreground/25"
-                            : "text-foreground/80 hover:bg-foreground/10",
-                        )}
-                      >
-                        <span className="shrink-0">{action.icon}</span>
-                        <span className="min-w-0 flex-1">
-                          <span className="block truncate text-sm font-medium">{action.label}</span>
-                          <span className="block truncate text-xs text-foreground/45">
-                            {action.disabledReason ?? action.description}
-                          </span>
-                        </span>
-                      </button>
-                    ))}
-                </div>
-              </div>
-            )}
-          </div>
-        </div>
+        <ConversationMediaPickerPanel
+          tabs={mobilePickerTabs}
+          activeTab={mobilePickerTab}
+          onActiveTabChange={setMobilePickerTab}
+          onClose={() => setMobilePickerOpen(false)}
+          onEmojiSelect={handleEmojiSelect}
+          onGifSelect={handleGifSelect}
+          onStickerSelect={handleStickerSelect}
+          className="absolute bottom-full left-0 right-0 z-20 mb-3 sm:hidden"
+          toolsContent={mediaPickerToolsContent}
+        />
       )}
 
       {/* Feedback toast */}
@@ -2191,12 +2152,10 @@ export function ConversationInput({
 
         {/* Right actions */}
         <div className="ml-0 flex shrink-0 flex-nowrap items-center justify-end gap-0 sm:ml-auto sm:gap-0.5">
-          {/* Mobile: one multipurpose button → Emoji/GIFs/Stickers/Tools sheet (desktop uses the separate buttons) */}
+          {/* Mobile: one multipurpose button → Emoji/GIFs/Stickers/Tools sheet */}
           <button
             type="button"
             onClick={() => {
-              setEmojiOpen(false);
-              setGifOpen(false);
               const next = !mobilePickerOpen;
               setMobilePickerOpen(next);
               if (next) textareaRef.current?.blur();
@@ -2228,88 +2187,35 @@ export function ConversationInput({
 
           <div className="relative hidden sm:block">
             <button
-              ref={gifButtonRef}
+              type="button"
               onClick={() => {
-                setGifOpen((v) => !v);
-                setEmojiOpen(false);
-                setStickerOpen(false);
-              }}
-              className={cn(
-                "flex h-9 w-9 items-center justify-center rounded-xl transition-colors sm:h-8 sm:w-8 sm:rounded-full",
-                gifOpen
-                  ? "bg-foreground/10 text-foreground/75 ring-1 ring-foreground/20"
-                  : "text-foreground/40 hover:bg-foreground/10 hover:text-foreground/70",
-              )}
-              title="GIF"
-            >
-              <ImagePlay size="1.25rem" />
-            </button>
-            <GifPicker
-              open={gifOpen}
-              onClose={() => setGifOpen(false)}
-              onSelect={handleGifSelect}
-              anchorRef={gifButtonRef}
-              containerRef={inputBarRef}
-            />
-          </div>
-
-          <div className="relative hidden sm:block">
-            <button
-              ref={emojiButtonRef}
-              onClick={() => {
-                setEmojiOpen((v) => !v);
-                setGifOpen(false);
-                setStickerOpen(false);
+                setMobilePickerOpen((value) => !value);
               }}
               className={cn(
                 "flex h-8 w-8 items-center justify-center rounded-full transition-colors",
-                emojiOpen
+                mobilePickerOpen
                   ? "bg-foreground/10 text-foreground/75 ring-1 ring-foreground/20"
                   : "text-foreground/40 hover:bg-foreground/10 hover:text-foreground/70",
               )}
-              title="Emoji"
+              title={showMobileToolsTab ? "Emoji, GIFs, stickers & tools" : "Emoji, GIFs & stickers"}
+              aria-label={showMobileToolsTab ? "Emoji, GIFs, stickers, and tools" : "Emoji, GIFs and stickers"}
+              aria-expanded={mobilePickerOpen}
             >
               <Smile size="1.25rem" />
             </button>
-            <EmojiPicker
-              open={emojiOpen}
-              onClose={() => setEmojiOpen(false)}
-              onSelect={handleEmojiSelect}
-              anchorRef={emojiButtonRef}
-              containerRef={inputBarRef}
-              customTab={{
-                icon: "⭐",
-                label: "Custom emojis",
-                render: (query) => <CustomEmojiTab onInsert={handleEmojiSelect} query={query} />,
-              }}
-            />
-          </div>
-
-          <div className="relative hidden sm:block">
-            <button
-              ref={stickerButtonRef}
-              onClick={() => {
-                setStickerOpen((v) => !v);
-                setEmojiOpen(false);
-                setGifOpen(false);
-              }}
-              className={cn(
-                "flex h-8 w-8 items-center justify-center rounded-full transition-colors",
-                stickerOpen
-                  ? "bg-foreground/10 text-foreground/75 ring-1 ring-foreground/20"
-                  : "text-foreground/40 hover:bg-foreground/10 hover:text-foreground/70",
-              )}
-              title="Stickers"
-            >
-              <Sticker size="1.25rem" />
-            </button>
-            <StickerPicker
-              open={stickerOpen}
-              onClose={() => setStickerOpen(false)}
-              onSelect={handleStickerSelect}
-              anchorRef={stickerButtonRef}
-              containerRef={inputBarRef}
-            />
+            {mobilePickerOpen && (
+              <ConversationMediaPickerPanel
+                tabs={mobilePickerTabs}
+                activeTab={mobilePickerTab}
+                onActiveTabChange={setMobilePickerTab}
+                onClose={() => setMobilePickerOpen(false)}
+                onEmojiSelect={handleEmojiSelect}
+                onGifSelect={handleGifSelect}
+                onStickerSelect={handleStickerSelect}
+                className="absolute bottom-full right-0 z-30 mb-4 w-[min(24rem,calc(100vw-1.5rem))]"
+                toolsContent={mediaPickerToolsContent}
+              />
+            )}
           </div>
 
           {showCharPicker && (

--- a/packages/client/src/components/chat/ConversationMediaPickerPanel.tsx
+++ b/packages/client/src/components/chat/ConversationMediaPickerPanel.tsx
@@ -1,0 +1,78 @@
+import type { ReactNode } from "react";
+import { cn } from "../../lib/utils";
+import { EmojiPicker } from "../ui/EmojiPicker";
+import { GifPicker } from "../ui/GifPicker";
+import { StickerPicker } from "./StickerPicker";
+import { CustomEmojiTab } from "./CustomEmojiTab";
+
+export type ConversationMediaPickerTabId = "emoji" | "gifs" | "stickers" | "tools";
+export type ConversationMediaPickerTab = { id: ConversationMediaPickerTabId; label: string };
+
+interface ConversationMediaPickerPanelProps {
+  tabs: ConversationMediaPickerTab[];
+  activeTab: ConversationMediaPickerTabId;
+  onActiveTabChange: (tab: ConversationMediaPickerTabId) => void;
+  onClose: () => void;
+  onEmojiSelect: (emoji: string) => void;
+  onGifSelect: (gifUrl: string) => void;
+  onStickerSelect: (name: string) => void;
+  toolsContent?: ReactNode;
+  className?: string;
+}
+
+export function ConversationMediaPickerPanel({
+  tabs,
+  activeTab,
+  onActiveTabChange,
+  onClose,
+  onEmojiSelect,
+  onGifSelect,
+  onStickerSelect,
+  toolsContent,
+  className,
+}: ConversationMediaPickerPanelProps) {
+  return (
+    <div
+      className={cn(
+        "flex h-[22rem] max-h-[60vh] flex-col overflow-hidden rounded-xl border border-foreground/10 bg-[var(--card)] shadow-xl",
+        className,
+      )}
+    >
+      <div className="flex shrink-0 items-center gap-1 border-b border-foreground/10 px-2 py-1.5">
+        {tabs.map((tab) => (
+          <button
+            key={tab.id}
+            type="button"
+            onClick={() => onActiveTabChange(tab.id)}
+            className={cn(
+              "flex-1 rounded-md px-2 py-1 text-xs font-medium transition-colors",
+              activeTab === tab.id
+                ? "bg-foreground/10 text-foreground/80 ring-1 ring-foreground/15"
+                : "text-foreground/45 hover:bg-foreground/10 hover:text-foreground/70",
+            )}
+          >
+            {tab.label}
+          </button>
+        ))}
+      </div>
+      <div className="min-h-0 flex-1">
+        {activeTab === "emoji" && (
+          <EmojiPicker
+            embedded
+            open
+            onClose={onClose}
+            onSelect={onEmojiSelect}
+            customTab={{
+              icon: "⭐",
+              label: "Custom emojis",
+              render: (query) => <CustomEmojiTab onInsert={onEmojiSelect} query={query} />,
+            }}
+          />
+        )}
+        {activeTab === "gifs" && <GifPicker embedded open onClose={onClose} onSelect={onGifSelect} />}
+        {activeTab === "stickers" && <StickerPicker embedded open onClose={onClose} onSelect={onStickerSelect} />}
+        {activeTab === "tools" && toolsContent}
+      </div>
+    </div>
+  );
+}

--- a/packages/client/src/components/chat/ConversationMessage.tsx
+++ b/packages/client/src/components/chat/ConversationMessage.tsx
@@ -5,7 +5,7 @@
 // ──────────────────────────────────────────────
 import { useState, useCallback, useRef, useEffect, memo, useMemo, type CSSProperties } from "react";
 import { createPortal } from "react-dom";
-import { Brain, Trash2, X } from "lucide-react";
+import { Brain, Phone, PhoneIncoming, PhoneOff, Trash2, X } from "lucide-react";
 import { useQueryClient, type InfiniteData } from "@tanstack/react-query";
 import { formatTextQuotes, normalizeTextForMatch, type Message, type MessageReaction } from "@marinara-engine/shared";
 import { toast } from "sonner";
@@ -42,6 +42,23 @@ import {
 const EMPTY_CUSTOM_EMOJI_MAP = new Map<string, string>();
 const EMPTY_CUSTOM_STICKER_MAP = new Map<string, string>();
 const CONVERSATION_MESSAGE_CHROME_RING_CLASS = "ring-[var(--marinara-chat-chrome-focus-ring)]";
+
+function formatCallDuration(value: unknown): string | null {
+  if (typeof value !== "number" || !Number.isFinite(value)) return null;
+  const seconds = Math.max(0, Math.round(value / 1000));
+  const minutes = Math.floor(seconds / 60);
+  const remaining = seconds % 60;
+  if (minutes <= 0) return `${remaining} seconds`;
+  if (minutes === 1) return remaining > 0 ? `1 minute ${remaining} seconds` : "1 minute";
+  return remaining > 0 ? `${minutes} minutes ${remaining} seconds` : `${minutes} minutes`;
+}
+
+function formatCallTimestamp(value: unknown): string {
+  if (typeof value !== "string") return "";
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return "";
+  return date.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" });
+}
 
 // ── Public props interface (unchanged external API) ──────────────
 
@@ -169,6 +186,10 @@ export const ConversationMessage = memo(function ConversationMessage({
   }, [message.extra]);
   const isConversationStart = extra.isConversationStart === true;
   const isHiddenFromAI = extra.hiddenFromAI === true;
+  const conversationCallEvent =
+    extra.conversationCallEvent && typeof extra.conversationCallEvent === "object" && !Array.isArray(extra.conversationCallEvent)
+      ? (extra.conversationCallEvent as Record<string, unknown>)
+      : null;
   const generationReplay = hasGenerationReplayDetails(extra.generationReplay) ? extra.generationReplay : null;
   const canRegenerate = !isUser || generationReplay !== null;
   const thinking = extra?.thinking as string | null | undefined;
@@ -752,6 +773,67 @@ export const ConversationMessage = memo(function ConversationMessage({
 
   // ── System message ──
   if (isSystem) {
+    if (conversationCallEvent) {
+      const status = typeof conversationCallEvent.status === "string" ? conversationCallEvent.status : "";
+      const duration = formatCallDuration(conversationCallEvent.durationMs);
+      const timestamp = formatCallTimestamp(message.createdAt);
+      const title =
+        status === "ended"
+          ? "Call Ended"
+          : status === "declined"
+            ? "Call Declined"
+            : status === "missed"
+              ? "Missed Call"
+              : status === "ringing"
+                ? "Incoming Call"
+                : "Call Started";
+      const subtitle =
+        status === "ended" && duration
+          ? `${duration}${timestamp ? ` - ${timestamp}` : ""}`
+          : timestamp || message.content;
+      const Icon = status === "ended" || status === "declined" || status === "missed" ? PhoneOff : status === "ringing" ? PhoneIncoming : Phone;
+      const iconClass =
+        status === "ended" || status === "declined" || status === "missed"
+          ? "text-[var(--muted-foreground)]"
+          : "text-emerald-400";
+
+      return (
+        <div
+          ref={msgRef}
+          className={cn(
+            "group flex justify-center px-4 py-2",
+            multiSelectMode && isSelected && "rounded-lg bg-[var(--destructive)]/10",
+          )}
+          onClick={handleMobileTap}
+        >
+          <div className="relative w-full max-w-xl">
+            {!multiSelectMode && onDelete && (
+              <button
+                onClick={(e) => {
+                  e.stopPropagation();
+                  onDelete(message.id);
+                }}
+                className={cn(
+                  "absolute -right-1 -top-1 rounded-md p-1 text-[var(--muted-foreground)]/30 opacity-0 transition-all hover:bg-[var(--accent)] hover:text-[var(--foreground)] group-hover:opacity-100",
+                  showActions && "opacity-100",
+                )}
+                title="Delete"
+              >
+                <Trash2 size="0.75rem" />
+              </button>
+            )}
+            <div className="flex items-center gap-3 rounded-lg border border-[var(--border)] bg-[var(--secondary)]/90 px-4 py-3 text-left shadow-sm">
+              <Icon size="1.25rem" className={cn("shrink-0", iconClass)} />
+              <div className="min-w-0 flex-1">
+                <div className="truncate text-sm font-semibold text-[var(--foreground)]">{title}</div>
+                <div className="truncate text-xs text-[var(--marinara-chat-chrome-panel-muted)]">{subtitle}</div>
+              </div>
+            </div>
+          </div>
+        </div>
+      );
+    }
+
     return (
       <div
         ref={msgRef}

--- a/packages/client/src/components/chat/ConversationPresenceCard.tsx
+++ b/packages/client/src/components/chat/ConversationPresenceCard.tsx
@@ -192,7 +192,10 @@ function formatScheduleTimeRange(value: string) {
   return formattedStart && formattedEnd ? `${formattedStart} - ${formattedEnd}` : value;
 }
 
-function getUpcomingScheduleBlocks(schedule?: WeekSchedule, limit = UPCOMING_SCHEDULE_PREVIEW_COUNT): UpcomingScheduleBlock[] {
+function getUpcomingScheduleBlocks(
+  schedule?: WeekSchedule,
+  limit = UPCOMING_SCHEDULE_PREVIEW_COUNT,
+): UpcomingScheduleBlock[] {
   if (!schedule?.days) return [];
 
   const now = new Date();
@@ -267,7 +270,10 @@ export function ConversationPresenceCard({
   const setAbortController = useChatStore((s) => s.setAbortController);
   const setDelayedCharacterInfo = useChatStore((s) => s.setDelayedCharacterInfo);
   const setPerChatDelayed = useChatStore((s) => s.setPerChatDelayed);
-  const overrides = useMemo(() => parseOverrides(chatMeta.conversationStatusOverrides), [chatMeta.conversationStatusOverrides]);
+  const overrides = useMemo(
+    () => parseOverrides(chatMeta.conversationStatusOverrides),
+    [chatMeta.conversationStatusOverrides],
+  );
   const schedules = useMemo(() => parseSchedules(chatMeta.characterSchedules), [chatMeta.characterSchedules]);
   const hasGeneratedSchedules =
     typeof chatMeta.scheduleWeekStart === "string" &&
@@ -311,7 +317,7 @@ export function ConversationPresenceCard({
     const maxLeft = Math.max(viewportPadding, window.innerWidth - width - viewportPadding);
     setPosition({
       top: rect.bottom + (isMobile ? 0 : 8),
-      left: Math.max(viewportPadding, Math.min(rect.right - width, maxLeft)),
+      left: Math.max(viewportPadding, Math.min(rect.left, maxLeft)),
       width,
     });
   }, [open]);
@@ -391,7 +397,8 @@ export function ConversationPresenceCard({
 
     const handlePointerDown = (event: PointerEvent) => {
       const target = event.target as Node;
-      if (statusButtonRefs.current[statusMenuCharacterId]?.contains(target) || statusMenuRef.current?.contains(target)) return;
+      if (statusButtonRefs.current[statusMenuCharacterId]?.contains(target) || statusMenuRef.current?.contains(target))
+        return;
       setStatusMenuCharacterId(null);
     };
 
@@ -412,7 +419,14 @@ export function ConversationPresenceCard({
           const statusEntry = statusesQuery.data?.statuses[id];
           const status = pendingStatuses[id] ?? statusEntry?.status ?? character.conversationStatus ?? "online";
           const activity = statusEntry?.activity ?? character.conversationActivity ?? "";
-          return { id, ...character, status, activity, schedule: statusEntry?.schedule ?? schedules[id], override: overrides[id] };
+          return {
+            id,
+            ...character,
+            status,
+            activity,
+            schedule: statusEntry?.schedule ?? schedules[id],
+            override: overrides[id],
+          };
         })
         .filter((value): value is NonNullable<typeof value> => value !== null),
     [characterMap, chatCharIds, overrides, pendingStatuses, schedules, statusesQuery.data?.statuses],
@@ -461,7 +475,11 @@ export function ConversationPresenceCard({
     "flex h-5 w-5 items-center justify-center rounded-full bg-[var(--foreground)]/10 text-[0.5rem] font-bold text-[var(--foreground)]/70 ring-1 ring-[var(--border)]/80 max-md:h-6 max-md:w-6 max-md:text-[0.5625rem]";
   const title = characters.map((c) => `${c.name}: ${c.activity || statusLabel(c.status)}`).join(", ");
 
-  const saveOverride = async (characterId: string, status: ConversationPresenceStatus, activity?: string | null): Promise<boolean> => {
+  const saveOverride = async (
+    characterId: string,
+    status: ConversationPresenceStatus,
+    activity?: string | null,
+  ): Promise<boolean> => {
     setPendingStatuses((current) => ({ ...current, [characterId]: status }));
     try {
       await updateMeta.mutateAsync({
@@ -498,7 +516,10 @@ export function ConversationPresenceCard({
       return next;
     });
     try {
-      await updateMeta.mutateAsync({ id: chatId, conversationStatusOverrides: buildOverrides(overrides, characterId, null) });
+      await updateMeta.mutateAsync({
+        id: chatId,
+        conversationStatusOverrides: buildOverrides(overrides, characterId, null),
+      });
       void statusesQuery.refetch();
     } catch (error) {
       toast.error(error instanceof Error ? error.message : "Failed to clear presence override");
@@ -514,7 +535,12 @@ export function ConversationPresenceCard({
       setPerChatDelayed(chatId, null);
       setDelayedCharacterInfo(null);
       await api.post("/generate/abort", { chatId }).catch(() => undefined);
-      const produced = await generate({ chatId, connectionId: null, forCharacterId: characterId, skipPresenceDelay: true });
+      const produced = await generate({
+        chatId,
+        connectionId: null,
+        forCharacterId: characterId,
+        skipPresenceDelay: true,
+      });
       if (!produced) toast.info("No reply was generated.");
     } catch (error) {
       toast.error(error instanceof Error ? error.message : "Failed to reply now");
@@ -550,7 +576,10 @@ export function ConversationPresenceCard({
   };
 
   const selectStatus = async (character: (typeof characters)[number], status: ConversationPresenceStatus) => {
-    const nextActivity = editingCharacterId === character.id ? draftActivity.trim() || null : character.override?.activity ?? character.activity ?? null;
+    const nextActivity =
+      editingCharacterId === character.id
+        ? draftActivity.trim() || null
+        : (character.override?.activity ?? character.activity ?? null);
     const currentActivity = character.override?.activity?.trim() || character.activity?.trim() || null;
 
     if (status === character.status && nextActivity === currentActivity) {
@@ -604,7 +633,9 @@ export function ConversationPresenceCard({
               />
             </div>
             <div className="flex min-w-0 flex-1 flex-col items-start text-left leading-tight">
-              <span className="truncate text-[0.75rem] font-semibold text-[var(--foreground)]/90">{characters[0].name}</span>
+              <span className="truncate text-[0.75rem] font-semibold text-[var(--foreground)]/90">
+                {characters[0].name}
+              </span>
               <span className="block w-full truncate text-[0.5625rem] text-[var(--foreground)]/50">
                 {characters[0].activity || statusLabel(characters[0].status)}
               </span>
@@ -612,7 +643,10 @@ export function ConversationPresenceCard({
           </>
         ) : (
           <>
-            <div className="relative flex-shrink-0" style={{ width: `${Math.min(characters.length, 3) * 12 + 8}px`, height: 20 }}>
+            <div
+              className="relative flex-shrink-0"
+              style={{ width: `${Math.min(characters.length, 3) * 12 + 8}px`, height: 20 }}
+            >
               {characters.slice(0, 3).map((character, index) => (
                 <div key={character.id} className="absolute top-0" style={{ left: index * 12 }}>
                   {character.avatarUrl ? (
@@ -645,7 +679,7 @@ export function ConversationPresenceCard({
         )}
       </button>
 
-      {open && (
+      {open &&
         createPortal(
           <div
             ref={popoverRef}
@@ -664,15 +698,15 @@ export function ConversationPresenceCard({
                   </div>
                 </div>
                 <div className="flex shrink-0 items-center gap-1">
-                    <button
-                      type="button"
-                      className="rounded-lg p-1.5 text-[var(--muted-foreground)] transition-colors hover:bg-[var(--accent)] hover:text-[var(--foreground)]"
-                      title="Open autonomous settings"
-                      onClick={() => {
-                        setOpen(false);
-                        onOpenSettings(undefined, { initialSection: "autonomous" });
-                      }}
-                    >
+                  <button
+                    type="button"
+                    className="rounded-lg p-1.5 text-[var(--muted-foreground)] transition-colors hover:bg-[var(--accent)] hover:text-[var(--foreground)]"
+                    title="Open autonomous settings"
+                    onClick={() => {
+                      setOpen(false);
+                      onOpenSettings(undefined, { initialSection: "autonomous" });
+                    }}
+                  >
                     <Settings2 size="0.8125rem" />
                   </button>
                   <button
@@ -681,23 +715,34 @@ export function ConversationPresenceCard({
                     title="Refresh status"
                     onClick={() => void refreshStatuses()}
                   >
-                    <RefreshCw size="0.8125rem" className={cn((statusesQuery.isFetching || isRefreshing) && "animate-spin")} />
+                    <RefreshCw
+                      size="0.8125rem"
+                      className={cn((statusesQuery.isFetching || isRefreshing) && "animate-spin")}
+                    />
                   </button>
                 </div>
               </div>
             </div>
 
-            <div className={cn(ROLEPLAY_POPOVER_SCROLL_AREA, "max-h-[min(28rem,calc(100vh-12rem))] space-y-2 overflow-y-auto p-2")}>
+            <div
+              className={cn(
+                ROLEPLAY_POPOVER_SCROLL_AREA,
+                "max-h-[min(28rem,calc(100vh-12rem))] space-y-2 overflow-y-auto p-2",
+              )}
+            >
               {characters.map((character) => {
                 const activity = character.override?.activity ?? character.activity;
                 const isManual = !!character.override;
                 const isEditing = editingCharacterId === character.id;
                 const primaryText = activity || statusLabel(character.status);
-                const upcomingScheduleBlocks = hasGeneratedSchedules ? getUpcomingScheduleBlocks(character.schedule) : [];
+                const upcomingScheduleBlocks = hasGeneratedSchedules
+                  ? getUpcomingScheduleBlocks(character.schedule)
+                  : [];
                 const hasUpcomingScheduleBlocks = upcomingScheduleBlocks.length > 0;
                 const isNextScheduleVisible = !!visibleNextSchedule[character.id];
                 const isStatusMenuOpen = statusMenuCharacterId === character.id;
-                const lastContact = statusesQuery.data?.statuses[character.id]?.lastContact ?? lastContactByCharacterId[character.id];
+                const lastContact =
+                  statusesQuery.data?.statuses[character.id]?.lastContact ?? lastContactByCharacterId[character.id];
                 const lastContactLabel = lastContact ? formatRelativeContact(lastContact) : null;
                 const canReplyNow = !!activeAbortController && !!delayedInfo?.characterIds?.includes(character.id);
                 const isReplyNowPending = replyNowCharacterId === character.id;
@@ -758,67 +803,69 @@ export function ConversationPresenceCard({
                       </div>
 
                       <div className="mt-2 flex w-full min-w-0 items-stretch overflow-hidden rounded-md bg-[var(--background)] ring-1 ring-[var(--border)] transition-colors hover:ring-[var(--border)]/80">
-                          <div className="flex shrink-0 flex-col border-r border-[var(--border)]">
-                            <button
-                              ref={(node) => {
-                                statusButtonRefs.current[character.id] = node;
-                              }}
-                              type="button"
-                              aria-haspopup="menu"
-                              aria-expanded={isStatusMenuOpen}
-                              className={cn(
-                                "inline-flex min-h-[2rem] items-center justify-center gap-1 px-2 text-[0.6875rem] font-medium transition-colors hover:bg-[var(--accent)] focus:outline-none focus:ring-2 focus:ring-[var(--ring)]",
-                                isStatusMenuOpen && "bg-[var(--accent)]",
-                              )}
-                              onClick={() => setStatusMenuCharacterId((current) => (current === character.id ? null : character.id))}
-                            >
-                              <span className={cn("h-2 w-2 rounded-full", statusDotClass(character.status))} />
-                              <ChevronDown size="0.625rem" className="shrink-0 opacity-60" />
-                            </button>
-                          </div>
-
-                          <textarea
+                        <div className="flex shrink-0 flex-col border-r border-[var(--border)]">
+                          <button
                             ref={(node) => {
-                              activityFieldRefs.current[character.id] = node;
+                              statusButtonRefs.current[character.id] = node;
                             }}
-                            value={isEditing ? draftActivity : primaryText}
-                            disabled={updateMeta.isPending}
-                            rows={1}
-                            className="min-h-[2rem] max-h-28 w-full min-w-0 flex-1 resize-none overflow-y-auto bg-transparent px-2.5 py-1.5 text-[0.75rem] leading-5 text-[var(--foreground)]/88 outline-none placeholder:text-[var(--muted-foreground)]/55 disabled:opacity-60"
-                            placeholder="Manual activity"
-                            onFocus={() => {
-                              beginEditing(character);
-                              resizeActivityField(activityFieldRefs.current[character.id]);
-                            }}
-                            onChange={(event) => {
-                              if (!isEditing) setEditingCharacterId(character.id);
-                              setDraftActivity(event.currentTarget.value);
-                              resizeActivityField(event.currentTarget);
-                            }}
-                            onBlur={() => void saveActivityOverride(character)}
-                            onKeyDown={(event) => {
-                              if (event.key === "Enter" && !event.shiftKey) {
-                                event.preventDefault();
-                                void saveActivityOverride(character);
-                              }
-                              if (event.key === "Escape") {
-                                event.preventDefault();
-                                cancelEditing();
-                              }
-                            }}
-                          />
+                            type="button"
+                            aria-haspopup="menu"
+                            aria-expanded={isStatusMenuOpen}
+                            className={cn(
+                              "inline-flex min-h-[2rem] items-center justify-center gap-1 px-2 text-[0.6875rem] font-medium transition-colors hover:bg-[var(--accent)] focus:outline-none focus:ring-2 focus:ring-[var(--ring)]",
+                              isStatusMenuOpen && "bg-[var(--accent)]",
+                            )}
+                            onClick={() =>
+                              setStatusMenuCharacterId((current) => (current === character.id ? null : character.id))
+                            }
+                          >
+                            <span className={cn("h-2 w-2 rounded-full", statusDotClass(character.status))} />
+                            <ChevronDown size="0.625rem" className="shrink-0 opacity-60" />
+                          </button>
+                        </div>
 
-                          {isManual && (
-                            <button
-                              type="button"
-                              disabled={updateMeta.isPending}
-                              className="shrink-0 border-l border-[var(--border)] px-2.5 text-[var(--muted-foreground)] transition-colors hover:bg-[var(--accent)]/20 hover:text-[var(--foreground)] disabled:opacity-60"
-                              title="Clear manual override"
-                              onClick={() => void restoreSchedule(character.id)}
-                            >
-                              <Trash2 size="0.75rem" />
-                            </button>
-                          )}
+                        <textarea
+                          ref={(node) => {
+                            activityFieldRefs.current[character.id] = node;
+                          }}
+                          value={isEditing ? draftActivity : primaryText}
+                          disabled={updateMeta.isPending}
+                          rows={1}
+                          className="min-h-[2rem] max-h-28 w-full min-w-0 flex-1 resize-none overflow-y-auto bg-transparent px-2.5 py-1.5 text-[0.75rem] leading-5 text-[var(--foreground)]/88 outline-none placeholder:text-[var(--muted-foreground)]/55 disabled:opacity-60"
+                          placeholder="Manual activity"
+                          onFocus={() => {
+                            beginEditing(character);
+                            resizeActivityField(activityFieldRefs.current[character.id]);
+                          }}
+                          onChange={(event) => {
+                            if (!isEditing) setEditingCharacterId(character.id);
+                            setDraftActivity(event.currentTarget.value);
+                            resizeActivityField(event.currentTarget);
+                          }}
+                          onBlur={() => void saveActivityOverride(character)}
+                          onKeyDown={(event) => {
+                            if (event.key === "Enter" && !event.shiftKey) {
+                              event.preventDefault();
+                              void saveActivityOverride(character);
+                            }
+                            if (event.key === "Escape") {
+                              event.preventDefault();
+                              cancelEditing();
+                            }
+                          }}
+                        />
+
+                        {isManual && (
+                          <button
+                            type="button"
+                            disabled={updateMeta.isPending}
+                            className="shrink-0 border-l border-[var(--border)] px-2.5 text-[var(--muted-foreground)] transition-colors hover:bg-[var(--accent)]/20 hover:text-[var(--foreground)] disabled:opacity-60"
+                            title="Clear manual override"
+                            onClick={() => void restoreSchedule(character.id)}
+                          >
+                            <Trash2 size="0.75rem" />
+                          </button>
+                        )}
                       </div>
 
                       {hasUpcomingScheduleBlocks && (
@@ -838,7 +885,9 @@ export function ConversationPresenceCard({
                               {isNextScheduleVisible ? <EyeOff size="0.75rem" /> : <Eye size="0.75rem" />}
                             </span>
                             <span className="min-w-0 flex-1">
-                              {isNextScheduleVisible ? "Hide upcoming schedule" : `Upcoming schedule (${upcomingScheduleBlocks.length})`}
+                              {isNextScheduleVisible
+                                ? "Hide upcoming schedule"
+                                : `Upcoming schedule (${upcomingScheduleBlocks.length})`}
                             </span>
                           </button>
 
@@ -863,9 +912,9 @@ export function ConversationPresenceCard({
                                             statusDotClass(block.status),
                                           )}
                                         />
-                                          <span className="justify-self-start rounded-full bg-[var(--foreground)]/6 px-1.5 py-0.5 text-center text-[0.5625rem] tabular-nums text-[var(--muted-foreground)]/78 ring-1 ring-[var(--border)]/45">
-                                            {formatScheduleTimeRange(block.time)}
-                                          </span>
+                                        <span className="justify-self-start rounded-full bg-[var(--foreground)]/6 px-1.5 py-0.5 text-center text-[0.5625rem] tabular-nums text-[var(--muted-foreground)]/78 ring-1 ring-[var(--border)]/45">
+                                          {formatScheduleTimeRange(block.time)}
+                                        </span>
                                         <div className="min-w-0 flex-1 whitespace-pre-wrap break-words pt-[0.05rem] text-[0.625rem] leading-4 text-[var(--muted-foreground)]/82">
                                           {block.activity}
                                         </div>
@@ -939,8 +988,7 @@ export function ConversationPresenceCard({
             </div>
           </div>,
           document.body,
-        )
-      )}
+        )}
     </>
   );
 }

--- a/packages/client/src/components/chat/ConversationView.tsx
+++ b/packages/client/src/components/chat/ConversationView.tsx
@@ -13,7 +13,17 @@ import {
   useState,
   type MouseEvent as ReactMouseEvent,
 } from "react";
-import { Loader2, ChevronUp, Settings2, Image as ImageIcon, ArrowRightLeft } from "lucide-react";
+import {
+  Loader2,
+  ChevronUp,
+  Settings2,
+  Image as ImageIcon,
+  ArrowRightLeft,
+  Phone,
+  PhoneIncoming,
+  PhoneOff,
+} from "lucide-react";
+import { toast } from "sonner";
 import { ConversationMessage } from "./ConversationMessage";
 import { ConversationInput } from "./ConversationInput";
 import { UnoBoard } from "./UnoBoard";
@@ -29,17 +39,25 @@ import { ConversationPresenceCard } from "./ConversationPresenceCard";
 import { PendingTypingDots } from "./PendingTypingDots";
 import { TranscriptWindowControls } from "./TranscriptWindowControls";
 import { PinnedImageOverlay } from "./PinnedImageOverlay";
+import { ConversationCallSurface } from "./ConversationCallSurface";
 import { useChatStore } from "../../stores/chat.store";
 import { useUnoGameStore } from "../../stores/uno-game.store";
 import { useChessGameStore } from "../../stores/chess-game.store";
 import { useUIStore } from "../../stores/ui.store";
 import { playConfiguredNotificationPing } from "../../lib/notification-sound";
+import { playConversationCallRingingSoundOnce } from "../../lib/conversation-call-sounds";
 import { useRenderTimer } from "../../lib/perf-diagnostics";
 import { messageHasPendingPostProcessing } from "../../lib/chat-message-extra";
 import { getTranscriptRenderWindow, TRANSCRIPT_RENDER_WINDOW_STEP } from "../../lib/transcript-render-window";
 import { useThrottledStreamBuffer } from "../../hooks/use-throttled-stream-buffer";
 import { useConversationCustomEmojis } from "../../hooks/use-conversation-custom-emojis";
 import { useConversationCustomStickers } from "../../hooks/use-conversation-custom-stickers";
+import {
+  useAcceptConversationCall,
+  useConversationCallStatus,
+  useDeclineConversationCall,
+  useStartConversationCall,
+} from "../../hooks/use-conversation-calls";
 import type { CharacterMap, MessageSelectionToggle, PersonaInfo } from "./chat-area.types";
 import { normalizeTextForMatch, type Message } from "@marinara-engine/shared";
 
@@ -387,6 +405,77 @@ export function ConversationView({
     return { background: `linear-gradient(135deg, ${g.from}, ${g.to})` };
   }, [convoGradient, theme]);
   const hasAutonomousMessaging = !!chatMeta.autonomousMessages || !!chatMeta.characterExchanges;
+  const callsEnabled = chatMeta.conversationCallsEnabled === true;
+  const { data: callStatus } = useConversationCallStatus(chatId, true);
+  const activeCall = callStatus?.activeCall ?? null;
+  const ringingCall = callStatus?.ringingCall ?? null;
+  const playedRingingCallSoundForRef = useRef<string | null>(null);
+  const startCall = useStartConversationCall(chatId);
+  const acceptCall = useAcceptConversationCall(chatId);
+  const declineCall = useDeclineConversationCall(chatId);
+  const setActiveConversationCall = useChatStore((state) => state.setActiveConversationCall);
+  const conversationCallExpanded = useChatStore((state) => state.conversationCallExpanded);
+  const setConversationCallExpanded = useChatStore((state) => state.setConversationCallExpanded);
+  const callExpandedInThisChat = Boolean(activeCall && conversationCallExpanded);
+  useEffect(() => {
+    if (!ringingCall || activeCall) {
+      if (!ringingCall) playedRingingCallSoundForRef.current = null;
+      return;
+    }
+    if (playedRingingCallSoundForRef.current === ringingCall.id) return;
+    playedRingingCallSoundForRef.current = ringingCall.id;
+    playConversationCallRingingSoundOnce(ringingCall.id);
+  }, [activeCall, ringingCall]);
+
+  const handleStartCall = useCallback(async () => {
+    try {
+      const session = await startCall.mutateAsync();
+      setActiveConversationCall({ session, chatName, characterMap, chatCharIds, personaInfo });
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : "Could not start the call.");
+    }
+  }, [characterMap, chatCharIds, chatName, personaInfo, setActiveConversationCall, startCall]);
+  const handleAcceptCall = useCallback(async () => {
+    if (!ringingCall) return;
+    try {
+      const session = await acceptCall.mutateAsync(ringingCall.id);
+      setActiveConversationCall({ session, chatName, characterMap, chatCharIds, personaInfo });
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : "Could not answer the call.");
+    }
+  }, [acceptCall, characterMap, chatCharIds, chatName, personaInfo, ringingCall, setActiveConversationCall]);
+  const handleDeclineCall = useCallback(async () => {
+    if (!ringingCall) return;
+    try {
+      await declineCall.mutateAsync(ringingCall.id);
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : "Could not decline the call.");
+    }
+  }, [declineCall, ringingCall]);
+  useEffect(() => {
+    if (activeCall) {
+      setActiveConversationCall({
+        session: activeCall,
+        chatName,
+        characterMap,
+        chatCharIds,
+        personaInfo,
+      });
+      return;
+    }
+    if (callStatus && useChatStore.getState().activeConversationCall?.session.chatId === chatId) {
+      setActiveConversationCall(null);
+    }
+  }, [
+    activeCall,
+    callStatus,
+    characterMap,
+    chatCharIds,
+    chatId,
+    chatName,
+    personaInfo,
+    setActiveConversationCall,
+  ]);
   const renderToolbarActions = (compact = false) => (
     <>
       <ChatBranchSelector
@@ -408,6 +497,89 @@ export function ConversationView({
       <ChatToolbarButton icon={<Settings2 size="0.875rem" />} title="Chat Settings" onClick={onOpenSettings} />
     </>
   );
+  const renderCallButton = () =>
+    callsEnabled ? (
+      <ChatToolbarButton
+        icon={
+          startCall.isPending ? (
+            <Loader2 size="0.875rem" className="animate-spin" />
+          ) : activeCall ? (
+            <PhoneIncoming size="0.875rem" />
+          ) : (
+            <Phone size="0.875rem" />
+          )
+        }
+        title={activeCall ? "Open call" : "Start call"}
+        onClick={
+          activeCall
+            ? () => {
+                setConversationCallExpanded(true);
+              }
+            : () => void handleStartCall()
+        }
+      />
+    ) : null;
+  const renderHeader = () => (
+    <div
+      className={[
+        "sticky top-0 z-30 flex items-center justify-between px-4 py-2",
+        callExpandedInThisChat
+          ? "mari-chrome-token-scope bg-[var(--background)] text-[var(--marinara-chat-chrome-panel-text)]"
+          : "",
+      ]
+        .filter(Boolean)
+        .join(" ")}
+    >
+      <ConversationPresenceCard
+        chatId={chatId}
+        chatMeta={chatMeta}
+        chatCharIds={chatCharIds}
+        characterMap={characterMap}
+        messages={messages}
+        onOpenSettings={onOpenSettings}
+      />
+
+      <div className="ml-2 flex min-w-0 flex-1 items-center justify-end gap-2">
+        {renderCallButton()}
+        <ChatToolbarMenu
+          className="flex-1"
+          desktopChildren={renderToolbarActions()}
+          mobileChildren={renderToolbarActions(true)}
+        />
+      </div>
+    </div>
+  );
+  const renderIncomingCallBanner = () =>
+    ringingCall && !activeCall ? (
+      <div className="px-3 pb-2">
+        <div className="flex w-full items-center gap-3 rounded-lg border border-[var(--border)] bg-[var(--popover)] p-3 shadow-xl">
+          <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-emerald-500/15 text-emerald-400">
+            <PhoneIncoming size="1rem" />
+          </div>
+          <div className="min-w-0 flex-1">
+            <div className="truncate text-sm font-semibold text-[var(--foreground)]">Incoming call</div>
+          </div>
+          <button
+            type="button"
+            onClick={() => void handleDeclineCall()}
+            disabled={declineCall.isPending || acceptCall.isPending}
+            className="mari-chrome-control h-9 w-9 p-0 text-[var(--destructive)] disabled:opacity-50"
+            title="Decline call"
+          >
+            <PhoneOff size="0.875rem" />
+          </button>
+          <button
+            type="button"
+            onClick={() => void handleAcceptCall()}
+            disabled={declineCall.isPending || acceptCall.isPending}
+            className="mari-chrome-control h-9 w-9 p-0 text-emerald-400 disabled:opacity-50"
+            title="Answer call"
+          >
+            {acceptCall.isPending ? <Loader2 size="0.875rem" className="animate-spin" /> : <Phone size="0.875rem" />}
+          </button>
+        </div>
+      </div>
+    ) : null;
 
   const scrollRef = useRef<HTMLDivElement>(null);
   const messagesEndRef = useRef<HTMLDivElement>(null);
@@ -660,7 +832,9 @@ export function ConversationView({
       const groupSegmentCount =
         msg.role === "assistant" && groupingContent ? getGroupedSegmentCount(groupingContent, knownNames) : 0;
       const hasGroupFormat =
-        groupingContent.includes("<speaker=") || groupSegmentCount > 0 || hasNamePrefixFormat(groupingContent, knownNames);
+        groupingContent.includes("<speaker=") ||
+        groupSegmentCount > 0 ||
+        hasNamePrefixFormat(groupingContent, knownNames);
       let contentParts: string[] | undefined;
       if (conversationMessageStyle === "classic" && msg.role === "assistant" && msg.content && !hasGroupFormat) {
         const cleaned = stripTimestamps(msg.content);
@@ -1016,6 +1190,28 @@ export function ConversationView({
     }
   }, [scrollToMessagesBottom, visiblePartCounts, visibleSegmentCounts]);
 
+  if (callExpandedInThisChat && activeCall) {
+    return (
+      <div
+        className="mari-chat-area mari-card-css mari-chrome-token-scope relative flex flex-1 flex-col overflow-hidden bg-[var(--background)] text-[var(--marinara-chat-chrome-panel-text)]"
+        data-chat-mode="conversation"
+      >
+        {renderHeader()}
+        <div className="flex min-h-0 flex-1 overflow-hidden">
+          <ConversationCallSurface
+            chatId={chatId}
+            session={activeCall}
+            characterMap={characterMap}
+            chatCharIds={chatCharIds}
+            personaInfo={personaInfo}
+            onEnded={() => setActiveConversationCall(null)}
+            embedded
+          />
+        </div>
+      </div>
+    );
+  }
+
   return (
     <div
       className="mari-chat-area mari-card-css relative flex flex-1 flex-col overflow-hidden"
@@ -1025,22 +1221,7 @@ export function ConversationView({
       {/* ── Messages scroll area ── */}
       <div ref={scrollRef} className="mari-messages-scroll flex-1 overflow-y-auto overflow-x-hidden">
         {/* Floating header — character info + action buttons */}
-        <div className="sticky top-0 z-30 flex items-center justify-between px-4 py-2">
-          <ConversationPresenceCard
-            chatId={chatId}
-            chatMeta={chatMeta}
-            chatCharIds={chatCharIds}
-            characterMap={characterMap}
-            messages={messages}
-            onOpenSettings={onOpenSettings}
-          />
-
-          <ChatToolbarMenu
-            className="flex-1"
-            desktopChildren={renderToolbarActions()}
-            mobileChildren={renderToolbarActions(true)}
-          />
-        </div>
+        {renderHeader()}
 
         {/* Load More */}
         {hasNextPage && (
@@ -1305,6 +1486,7 @@ export function ConversationView({
       {/* ── Turn-game boards (UNO, chess) — each self-hides when no game is active ── */}
       <UnoBoard chatId={chatId} />
       <ChessBoard chatId={chatId} />
+      {renderIncomingCallBanner()}
       {/* Setup modals mounted once here (stable position) so they never double-render.
           Keyed by chatId so their internal selection state resets on a chat switch
           (matches ConversationInput below) — otherwise stale selected ids would

--- a/packages/client/src/components/chat/LocalMusicPlayer.tsx
+++ b/packages/client/src/components/chat/LocalMusicPlayer.tsx
@@ -1,13 +1,4 @@
-import {
-  GripVertical,
-  Music2,
-  Pause,
-  Play,
-  Volume2,
-  VolumeX,
-  X,
-  type LucideIcon,
-} from "lucide-react";
+import { GripVertical, Music2, Pause, Play, Volume2, VolumeX, X, type LucideIcon } from "lucide-react";
 import {
   useCallback,
   useEffect,
@@ -378,7 +369,7 @@ export function LocalMusicPlayer({ mobile = false }: { mobile?: boolean } = {}) 
         <audio ref={audioRef} className="hidden" />
         {showPlayer && (
           <div
-            className="fixed z-[35] touch-none select-none md:hidden"
+            className="fixed z-[45] touch-none select-none md:hidden"
             style={mobileWidgetStyle}
             onPointerDown={startDrag}
             onPointerMove={moveDrag}

--- a/packages/client/src/components/chat/ProfessorMariFloatingAssistantHost.tsx
+++ b/packages/client/src/components/chat/ProfessorMariFloatingAssistantHost.tsx
@@ -61,6 +61,17 @@ export function ProfessorMariFloatingAssistantHost({ active }: ProfessorMariFloa
     return () => window.clearTimeout(timeout);
   }, [hasActiveGeneration, mounted, visible]);
 
+  useEffect(() => {
+    if (typeof document === "undefined") return;
+    if (visible) {
+      document.documentElement.dataset.professorMariFloating = "true";
+      return () => {
+        delete document.documentElement.dataset.professorMariFloating;
+      };
+    }
+    delete document.documentElement.dataset.professorMariFloating;
+  }, [visible]);
+
   if (!mounted) return null;
 
   return (

--- a/packages/client/src/components/chat/StickerPicker.tsx
+++ b/packages/client/src/components/chat/StickerPicker.tsx
@@ -55,7 +55,7 @@ export function StickerPicker({ open, onClose, onSelect, anchorRef, containerRef
   const [query, setQuery] = useState("");
   const [error, setError] = useState<string | null>(null);
   const [showSettings, setShowSettings] = useState(false);
-  const [pos, setPos] = useState<{ top: number; left?: number; maxHeight?: number }>({ top: 0 });
+  const [pos, setPos] = useState<{ top: number; left?: number; right?: number; maxHeight?: number }>({ top: 0 });
 
   const updatePosition = useCallback(() => {
     if (!anchorRef?.current) return;
@@ -81,8 +81,12 @@ export function StickerPicker({ open, onClose, onSelect, anchorRef, containerRef
       setPos({ top, left, maxHeight });
     } else {
       const btnRight = btnRect.right + viewportLeft;
-      const left = Math.max(visibleLeft + pad, Math.min(btnRight - panelWidth, visibleRight - panelWidth - pad));
-      setPos({ top, left, maxHeight });
+      const alignedLeft = btnRight - panelWidth;
+      if (alignedLeft < visibleLeft + pad) {
+        setPos({ top, left: visibleLeft + pad, maxHeight });
+      } else {
+        setPos({ top, right: Math.max(pad, visibleRight - btnRight), maxHeight });
+      }
     }
   }, [anchorRef, containerRef]);
 
@@ -363,8 +367,8 @@ export function StickerPicker({ open, onClose, onSelect, anchorRef, containerRef
               <>No stickers match “{query.trim()}”.</>
             ) : (
               <>
-                No stickers yet. Upload one (max 512×512) to send it as{" "}
-                <span className="font-mono">sticker:name:</span>.
+                No stickers yet. Upload one (max 512×512) to send it as <span className="font-mono">sticker:name:</span>
+                .
               </>
             )}
           </p>
@@ -382,7 +386,11 @@ export function StickerPicker({ open, onClose, onSelect, anchorRef, containerRef
                         title={editing ? `Rename sticker:${sticker.name}:` : `Send sticker:${sticker.name}:`}
                         className={cellClass}
                       >
-                        <img src={sticker.url} alt={`sticker:${sticker.name}:`} className="max-h-16 max-w-full object-contain" />
+                        <img
+                          src={sticker.url}
+                          alt={`sticker:${sticker.name}:`}
+                          className="max-h-16 max-w-full object-contain"
+                        />
                       </button>
                       {editing && (
                         <button
@@ -412,7 +420,11 @@ export function StickerPicker({ open, onClose, onSelect, anchorRef, containerRef
                         title={`Send sticker:${sticker.name}: — ${source}`}
                         className={cellClass}
                       >
-                        <img src={sticker.url} alt={`sticker:${sticker.name}:`} className="max-h-16 max-w-full object-contain" />
+                        <img
+                          src={sticker.url}
+                          alt={`sticker:${sticker.name}:`}
+                          className="max-h-16 max-w-full object-contain"
+                        />
                       </button>
                     </div>
                   ))}
@@ -436,6 +448,7 @@ export function StickerPicker({ open, onClose, onSelect, anchorRef, containerRef
       style={{
         top: pos.top,
         ...(pos.left != null ? { left: pos.left } : {}),
+        ...(pos.right != null ? { right: pos.right } : {}),
         ...(pos.maxHeight != null ? { maxHeight: pos.maxHeight } : {}),
       }}
     >

--- a/packages/client/src/components/chat/YouTubePlayer.tsx
+++ b/packages/client/src/components/chat/YouTubePlayer.tsx
@@ -543,7 +543,7 @@ export function YouTubePlayer({ mobile = false }: { mobile?: boolean } = {}) {
       <>
         {showPlayer && (
           <div
-            className="fixed z-[35] touch-none select-none md:hidden"
+            className="fixed z-[45] touch-none select-none md:hidden"
             style={mobileWidgetStyle}
             onPointerDown={startDrag}
             onPointerMove={moveDrag}

--- a/packages/client/src/components/layout/AppShell.tsx
+++ b/packages/client/src/components/layout/AppShell.tsx
@@ -6,7 +6,6 @@ import { TopBar } from "./TopBar";
 import { SpotifyMobileWidget } from "../spotify/SpotifyMiniPlayer";
 import { YouTubeMobileWidget } from "../chat/YouTubePlayer";
 import { LocalMusicMobileWidget } from "../chat/LocalMusicPlayer";
-import { ChatNotificationBubbles } from "../chat/ChatNotificationBubbles";
 import { ProfessorMariFloatingAssistantHost } from "../chat/ProfessorMariFloatingAssistantHost";
 import { hasProfessorMariFloatingFollowup } from "../chat/professor-mari-floating-events";
 import {
@@ -72,8 +71,14 @@ const RightPanel = lazy(() => import("./RightPanel").then((module) => ({ default
 const TrackerDataSidebar = lazy(() =>
   import("./TrackerDataSidebar").then((module) => ({ default: module.TrackerDataSidebar })),
 );
+const ChatNotificationBubbles = lazy(() =>
+  import("../chat/ChatNotificationBubbles").then((module) => ({ default: module.ChatNotificationBubbles })),
+);
 const OnboardingTutorial = lazy(() =>
   import("../onboarding/OnboardingTutorial").then((module) => ({ default: module.OnboardingTutorial })),
+);
+const ConversationCallFloatingHost = lazy(() =>
+  import("../chat/ConversationCallFloatingHost").then((module) => ({ default: module.ConversationCallFloatingHost })),
 );
 
 function clampWidth(width: number, min: number, max: number) {
@@ -900,9 +905,14 @@ export function AppShell() {
               {shellOverlayMode ? <ChatArea /> : (detailView ?? <ChatArea />)}
             </Suspense>
           </div>
+          <Suspense fallback={null}>
+            <ConversationCallFloatingHost />
+          </Suspense>
         </div>
         {/* Floating avatar notification bubbles (right edge) */}
-        <ChatNotificationBubbles />
+        <Suspense fallback={null}>
+          <ChatNotificationBubbles />
+        </Suspense>
       </main>
 
       <AnimatePresence initial={false}>

--- a/packages/client/src/components/panels/ConnectionsPanel.tsx
+++ b/packages/client/src/components/panels/ConnectionsPanel.tsx
@@ -31,6 +31,8 @@ import {
   LOCAL_SIDECAR_CONNECTION_ID,
   getDefaultAgentPrompt,
   type ConnectionFolder,
+  type SidecarSpeechModelId,
+  type SidecarSpeechRuntimeDiagnostics,
 } from "@marinara-engine/shared";
 import { confirmNonEmptyFolderDelete, showConfirmDialog } from "../../lib/app-dialogs";
 import {
@@ -57,6 +59,8 @@ import {
   Sparkles,
   ImageIcon,
   Film,
+  Mic,
+  HardDriveDownload,
 } from "lucide-react";
 import { cn } from "../../lib/utils";
 import { sortBasicPanelItems } from "../../lib/panel-sort";
@@ -104,6 +108,32 @@ function formatBytes(bytes: number): string {
   return `${(bytes / (1024 * 1024 * 1024)).toFixed(1)} GB`;
 }
 
+function describeSpeechRuntimeUnavailable(runtime: SidecarSpeechRuntimeDiagnostics | null): string {
+  if (!runtime) {
+    return "Local Whisper needs the native ONNX runtime for this platform. Reinstall dependencies with the same Node architecture used to run Marinara.";
+  }
+
+  const runtimeTuple = `${runtime.platform}/${runtime.arch}`;
+  const installed =
+    runtime.installedBindingArchs.length > 0
+      ? runtime.installedBindingArchs.map((arch) => `${runtime.platform}/${arch}`).join(", ")
+      : "";
+
+  if (runtime.liteMode) {
+    return "Local Whisper is disabled in Lite mode. Use a full Marinara install to download and run the local speech model.";
+  }
+
+  if (!runtime.packageFound) {
+    return `Local Whisper needs onnxruntime-node. Run pnpm install with Node ${runtime.nodeVersion} (${runtimeTuple}), then restart Marinara.`;
+  }
+
+  if (installed && !runtime.installedBindingArchs.includes(runtime.arch)) {
+    return `Marinara is running with ${runtimeTuple} Node, but this install has ONNX runtime for ${installed}. Restart Marinara with the matching Node architecture, or reinstall dependencies using the same Node architecture you use to run Marinara.`;
+  }
+
+  return `Local Whisper cannot find the ONNX runtime for ${runtimeTuple}. Run pnpm install --force --frozen-lockfile with the same Node architecture used to run Marinara, then restart.`;
+}
+
 function formatRuntimeVariantLabel(variant: string | null): string | null {
   if (!variant) return null;
   return variant.replace(/-/g, " ");
@@ -131,14 +161,27 @@ function SidecarCard() {
     failedRuntimeVariant,
     curatedModels,
     downloadProgress,
+    speechStatus,
+    speechAvailable,
+    speechModelDownloaded,
+    speechModelDisplayName,
+    speechModelSize,
+    speechModels,
+    speechRuntime,
+    speechDownloadProgress,
+    speechError,
     setShowDownloadModal,
     startDownload,
+    startSpeechDownload,
+    deleteSpeechModel,
     updateConfig,
     fetchStatus,
+    fetchSpeechStatus,
   } = useSidecarStore();
   const isDownloaded = modelDownloaded;
   const [assigningTrackers, setAssigningTrackers] = useState(false);
   const [expanded, setExpanded] = useState(false);
+  const [speechModelChoice, setSpeechModelChoice] = useState<SidecarSpeechModelId>("whisper_tiny");
   const activeModelName = isDownloaded ? modelDisplayName : null;
   const backendLabel = config.backend === "mlx" ? "MLX" : "GGUF";
   const nativeToolLabel =
@@ -156,7 +199,15 @@ function SidecarCard() {
   // Fetch status on mount (handles HMR store resets and initial load)
   useEffect(() => {
     fetchStatus();
-  }, [fetchStatus]);
+    fetchSpeechStatus();
+  }, [fetchSpeechStatus, fetchStatus]);
+
+  useEffect(() => {
+    const firstModel = speechModels[0]?.id;
+    if (firstModel && !speechModels.some((model) => model.id === speechModelChoice)) {
+      setSpeechModelChoice(firstModel);
+    }
+  }, [speechModelChoice, speechModels]);
 
   const handleAssignTrackersToLocal = async () => {
     if (!isDownloaded || assigningTrackers) return;
@@ -214,6 +265,21 @@ function SidecarCard() {
   };
 
   const isDownloading = downloadProgress?.status === "downloading";
+  const speechDownloading = speechDownloadProgress?.status === "downloading" || speechStatus === "downloading_model";
+  const activeSpeechModel = speechModels.find((model) => model.id === speechModelChoice) ?? speechModels[0];
+  const speechStatusLabel = speechModelDownloaded
+    ? `${speechModelDisplayName ?? "Whisper"}${
+        speechStatus === "ready" ? " • Ready" : speechStatus === "loading" ? " • Loading" : " • Downloaded"
+      }${speechModelSize ? ` • ${formatBytes(speechModelSize)}` : ""}`
+    : speechAvailable
+      ? "Not downloaded"
+      : "Unavailable on this install";
+  const speechUnavailableMessage = describeSpeechRuntimeUnavailable(speechRuntime);
+
+  const handleDownloadWhisper = () => {
+    if (!activeSpeechModel || speechDownloading) return;
+    void startSpeechDownload(activeSpeechModel.id);
+  };
 
   return (
     <div
@@ -284,6 +350,108 @@ function SidecarCard() {
               The bundled Local Model is intentionally small. Use it for tracker agents, scene analysis, and lightweight
               background tasks only.
             </p>
+          </div>
+          <div className="mt-2.5 rounded-lg border border-sky-400/15 bg-sky-400/5 p-2.5">
+            <div className="flex items-start gap-2">
+              <div className="mt-0.5 flex h-7 w-7 shrink-0 items-center justify-center rounded-lg bg-sky-400/10 text-sky-300">
+                <Mic size="0.875rem" />
+              </div>
+              <div className="min-w-0 flex-1">
+                <div className="flex items-center justify-between gap-2">
+                  <div className="text-xs font-semibold text-[var(--foreground)]">Local Speech Model</div>
+                  {speechModelDownloaded && (
+                    <button
+                      type="button"
+                      onClick={() => void deleteSpeechModel()}
+                      className="mari-chrome-control mari-chrome-control--small p-1"
+                      title="Delete Local Whisper"
+                    >
+                      <Trash2 size="0.75rem" />
+                    </button>
+                  )}
+                </div>
+                <div className="mt-0.5 text-[0.6875rem] text-[var(--muted-foreground)]">{speechStatusLabel}</div>
+                {!speechAvailable && (
+                  <div className="mt-1 space-y-1">
+                    <p className="text-[0.6875rem] leading-relaxed text-[var(--muted-foreground)]">
+                      {speechUnavailableMessage}
+                    </p>
+                    {speechRuntime && (
+                      <p className="text-[0.59375rem] leading-relaxed text-[var(--muted-foreground)]/80">
+                        Node {speechRuntime.nodeVersion} at {speechRuntime.nodeExecPath}
+                      </p>
+                    )}
+                  </div>
+                )}
+                {!speechModelDownloaded && speechAvailable && (
+                  <div className="mt-2 flex flex-col gap-2">
+                    <select
+                      value={speechModelChoice}
+                      onChange={(event) => setSpeechModelChoice(event.target.value as SidecarSpeechModelId)}
+                      className="mari-chrome-field h-8 text-xs"
+                      disabled={speechDownloading || speechModels.length === 0}
+                    >
+                      {speechModels.map((model) => (
+                        <option key={model.id} value={model.id}>
+                          {model.label}
+                        </option>
+                      ))}
+                    </select>
+                    {activeSpeechModel && (
+                      <p className="text-[0.625rem] leading-relaxed text-[var(--muted-foreground)]">
+                        {activeSpeechModel.description} About {formatBytes(activeSpeechModel.sizeBytes)} download,{" "}
+                        {formatBytes(activeSpeechModel.ramBytes)} RAM while running.
+                      </p>
+                    )}
+                    <button
+                      type="button"
+                      onClick={handleDownloadWhisper}
+                      disabled={speechDownloading || !activeSpeechModel}
+                      className="mari-chrome-control w-full justify-center px-3 py-2 text-xs"
+                    >
+                      {speechDownloading ? (
+                        <>
+                          <HardDriveDownload size="0.8125rem" className="animate-pulse" />
+                          Downloading Whisper...
+                        </>
+                      ) : (
+                        <>
+                          <HardDriveDownload size="0.8125rem" />
+                          Download Whisper
+                        </>
+                      )}
+                    </button>
+                  </div>
+                )}
+                {speechDownloading && speechDownloadProgress && (
+                  <div className="mt-2">
+                    <div className="h-1.5 overflow-hidden rounded-full bg-sky-400/10">
+                      <div
+                        className="h-full rounded-full bg-sky-300 transition-[width]"
+                        style={{
+                          width: `${
+                            speechDownloadProgress.total > 0
+                              ? Math.min(
+                                  100,
+                                  Math.round((speechDownloadProgress.downloaded / speechDownloadProgress.total) * 100),
+                                )
+                              : 12
+                          }%`,
+                        }}
+                      />
+                    </div>
+                    <div className="mt-1 truncate text-[0.625rem] text-[var(--muted-foreground)]">
+                      {speechDownloadProgress.label ?? "Downloading Local Whisper"}
+                    </div>
+                  </div>
+                )}
+                {speechError && (
+                  <div className="mt-2 rounded-md border border-[var(--destructive)]/20 bg-[var(--destructive)]/10 px-2 py-1.5 text-[0.625rem] text-[var(--destructive)]">
+                    {speechError}
+                  </div>
+                )}
+              </div>
+            </div>
           </div>
           {isDownloaded && (
             <div className="mt-2.5 flex flex-col gap-1.5 border-t border-sky-400/10 pt-2.5">

--- a/packages/client/src/components/panels/settings/PromptOverridesEditor.tsx
+++ b/packages/client/src/components/panels/settings/PromptOverridesEditor.tsx
@@ -68,10 +68,13 @@ function buildEditableDefaultTemplate(
     const example = value === undefined || value === null ? "" : String(value);
     return { example, token: "$" + "{" + variable.name + "}" };
   });
-  const exampleCounts = candidates.reduce<Record<string, number>>((counts, item) => {
-    if (item.example.length > 1) counts[item.example] = (counts[item.example] ?? 0) + 1;
-    return counts;
-  }, Object.create(null) as Record<string, number>);
+  const exampleCounts = candidates.reduce<Record<string, number>>(
+    (counts, item) => {
+      if (item.example.length > 1) counts[item.example] = (counts[item.example] ?? 0) + 1;
+      return counts;
+    },
+    Object.create(null) as Record<string, number>,
+  );
   const replacements = candidates
     .filter((item) => item.example.length > 1 && exampleCounts[item.example] === 1)
     .sort((a, b) => b.example.length - a.example.length);
@@ -103,7 +106,7 @@ function renderTemplatePreview(
 export function PromptOverridesEditor({
   title = "Prompt Overrides",
   description = "Edit the templates used by image and sprite prompt builders.",
-  help = "Global templates for registered prompt builders. Chat-specific selfie prompts still override the global conversation selfie template.",
+  help = "Global templates for registered prompt builders, including the conversation selfie prompt writer.",
   keys,
   preferredKey = PREFERRED_PROMPT_KEY,
   defaultOpen = false,

--- a/packages/client/src/components/panels/settings/TTSConfigCard.tsx
+++ b/packages/client/src/components/panels/settings/TTSConfigCard.tsx
@@ -22,7 +22,14 @@ import { useTTSConfig, useUpdateTTSConfig, useTTSVoices } from "../../../hooks/u
 import { useCharacters } from "../../../hooks/use-characters";
 import { ttsService } from "../../../lib/tts-service";
 import { parseCharacterDisplayData } from "../../../lib/character-display";
-import type { TTSConfig, TTSSource, TTSVoiceAssignment, TTSVoiceMode, TTSAudioFormat } from "@marinara-engine/shared";
+import type {
+  TTSConfig,
+  TTSSource,
+  TTSVoiceAssignment,
+  TTSVoiceMode,
+  TTSAudioFormat,
+  TTSConversationCallAudioInputMode,
+} from "@marinara-engine/shared";
 import { ELEVENLABS_TTS_LANGUAGE_OPTIONS, TTS_API_KEY_MASK } from "@marinara-engine/shared";
 import { HelpTooltip } from "../../ui/HelpTooltip";
 import { SettingsCheckbox, SettingsSwitch } from "./SettingControls";
@@ -69,12 +76,20 @@ const TTS_SOURCE_DEFAULTS: Record<
     voice: "alba",
     idleText: "Local PocketTTS",
   },
+  xai: {
+    label: "xAI Voice",
+    baseUrl: "https://api.x.ai/v1",
+    model: "grok-tts",
+    voice: "eve",
+    idleText: "xAI Voice",
+  },
 };
 
 const TTS_SOURCE_OPTIONS: Array<{ value: TTSSource; label: string }> = [
   { value: "openai", label: "OpenAI-compatible" },
   { value: "elevenlabs", label: "ElevenLabs" },
   { value: "pockettts", label: "PocketTTS" },
+  { value: "xai", label: "xAI Voice" },
 ];
 
 const ELEVENLABS_TTS_MODELS = [
@@ -324,6 +339,10 @@ export function TTSConfigCard() {
   const [progressivePlayback, setProgressivePlayback] = useState(false);
   const [dialogueOnly, setDialogueOnly] = useState(false);
   const [audioFormat, setAudioFormat] = useState<TTSAudioFormat>("mp3");
+  const [callAudioEnabled, setCallAudioEnabled] = useState(false);
+  const [callAudioInputMode, setCallAudioInputMode] = useState<TTSConversationCallAudioInputMode>("local_whisper");
+  const [callVideoInputEnabled, setCallVideoInputEnabled] = useState(false);
+  const [callSoundboardEnabled, setCallSoundboardEnabled] = useState(true);
 
   const [expanded, setExpanded] = useState(false);
   const [saveStatus, setSaveStatus] = useState<"idle" | "saving" | "saved" | "error">("idle");
@@ -370,6 +389,10 @@ export function TTSConfigCard() {
     setProgressivePlayback(savedConfig.progressivePlayback ?? false);
     setDialogueOnly(savedConfig.dialogueOnly ?? false);
     setAudioFormat(savedConfig.audioFormat ?? "mp3");
+    setCallAudioEnabled(savedConfig.callAudioEnabled ?? false);
+    setCallAudioInputMode(savedConfig.callAudioInputMode ?? "local_whisper");
+    setCallVideoInputEnabled(savedConfig.callVideoInputEnabled ?? false);
+    setCallSoundboardEnabled(savedConfig.callSoundboardEnabled ?? true);
     setSaveStatus("idle");
   }, [savedConfig]);
 
@@ -419,6 +442,12 @@ export function TTSConfigCard() {
     audioFormat,
     dialogueScope: "all",
     dialogueCharacterName: "",
+    callAudioEnabled,
+    callSttConnectionId: "",
+    callSttModel: "",
+    callAudioInputMode,
+    callVideoInputEnabled,
+    callSoundboardEnabled,
     ...overrides,
   });
 
@@ -617,15 +646,17 @@ export function TTSConfigCard() {
   const selectedLanguage =
     ELEVENLABS_TTS_LANGUAGE_OPTIONS.find((option) => option.code === elevenLabsLanguageCode) ??
     ELEVENLABS_TTS_LANGUAGE_OPTIONS[0];
-  const speedMin = source === "elevenlabs" ? 0.7 : 0.25;
-  const speedMax = source === "elevenlabs" ? 1.2 : 4.0;
+  const speedMin = source === "elevenlabs" || source === "xai" ? 0.7 : 0.25;
+  const speedMax = source === "elevenlabs" ? 1.2 : source === "xai" ? 1.5 : 4.0;
   const speedHelp =
     source === "elevenlabs"
       ? "Playback speed. ElevenLabs supports 0.7×–1.2×; wider saved values are clamped when spoken."
-      : "Playback speed. 1.0 is normal; range is 0.25×–4.0×.";
+      : source === "xai"
+        ? "Playback speed. xAI Voice supports 0.7×–1.5×; wider saved values are clamped when spoken."
+        : "Playback speed. 1.0 is normal; range is 0.25×–4.0×.";
   const speedSliderValue = Math.min(speedMax, Math.max(speedMin, speed));
   const speedLabel =
-    source === "elevenlabs" && speedSliderValue !== speed
+    (source === "elevenlabs" || source === "xai") && speedSliderValue !== speed
       ? `Speed — ${speedSliderValue.toFixed(2)}× (clamped from ${speed.toFixed(2)}×)`
       : `Speed — ${speed.toFixed(2)}×`;
   const previewDisabled = !enabled || ttsState === "loading" || (source === "elevenlabs" && !previewVoice);
@@ -637,7 +668,6 @@ export function TTSConfigCard() {
         : ttsState === "playing"
           ? "Stop preview"
           : "Preview voice";
-
   const updateVoiceAssignments = (nextAssignments: TTSVoiceAssignment[]) => {
     setVoiceAssignments(nextAssignments);
     mark({ voiceAssignments: nextAssignments });
@@ -798,7 +828,9 @@ export function TTSConfigCard() {
                 ? "The ElevenLabs API root. Use the default unless you proxy ElevenLabs through another server."
                 : source === "pockettts"
                   ? "The PocketTTS server root. Start it with pocket-tts serve, then use http://localhost:8000 unless you changed the port."
-                  : "The OpenAI-compatible TTS API endpoint. Use the default for OpenAI or point to a self-hosted server."
+                  : source === "xai"
+                    ? "The xAI Voice API root. Use https://api.x.ai/v1 unless you proxy xAI through another server."
+                    : "The OpenAI-compatible TTS API endpoint. Use the default for OpenAI or point to a self-hosted server."
             }
           >
             <div className="relative">
@@ -846,7 +878,9 @@ export function TTSConfigCard() {
                 ? "ElevenLabs model_id to use. Use eleven_v3 for Eleven v3 speech; eleven_ttv_v3 is a voice-design model and cannot generate TTS."
                 : source === "pockettts"
                   ? "PocketTTS selects its language/model when you start the local server. This field is kept for clarity and future compatible servers."
-                  : "TTS model to use. e.g. tts-1, tts-1-hd, gpt-4o-mini-tts, or any model your provider supports."
+                  : source === "xai"
+                    ? "xAI Voice currently uses the /tts endpoint; this is saved for compatibility with future model selection."
+                    : "TTS model to use. e.g. tts-1, tts-1-hd, gpt-4o-mini-tts, or any model your provider supports."
             }
           >
             <div className="relative">
@@ -909,7 +943,9 @@ export function TTSConfigCard() {
                   ? "ElevenLabs voices are fetched by name and saved by voice ID."
                   : source === "pockettts"
                     ? "PocketTTS built-in voice name or a voice URL/path accepted by your PocketTTS server."
-                    : "Voice to use for synthesis. Fetched from your configured provider when available."
+                    : source === "xai"
+                      ? "xAI Voice ID. Built-ins include eve, ara, rex, sal, and leo; custom xAI voice IDs can be typed after saving."
+                      : "Voice to use for synthesis. Fetched from your configured provider when available."
               }
             >
               <div className="flex gap-2">
@@ -980,6 +1016,11 @@ export function TTSConfigCard() {
               {!voicesFromProvider && source === "pockettts" && voices.length > 0 && (
                 <p className="text-[0.625rem] text-[var(--muted-foreground)]">
                   Showing PocketTTS built-in voices. You can type a custom voice URL or path accepted by your server.
+                </p>
+              )}
+              {!voicesFromProvider && source === "xai" && voices.length > 0 && (
+                <p className="text-[0.625rem] text-[var(--muted-foreground)]">
+                  Showing xAI built-in voices. Save with an API key, then refresh to load account/custom voices.
                 </p>
               )}
             </FieldRow>

--- a/packages/client/src/components/spotify/SpotifyMiniPlayer.tsx
+++ b/packages/client/src/components/spotify/SpotifyMiniPlayer.tsx
@@ -260,24 +260,20 @@ function getMobileWidgetStyle(
     top: Math.max(
       MOBILE_WIDGET_VIEWPORT_PADDING,
       Math.min(
-        height - (collapsed ? MOBILE_WIDGET_COLLAPSED_SIZE : MOBILE_WIDGET_EXPANDED_HEIGHT) - MOBILE_WIDGET_VIEWPORT_PADDING,
+        height -
+          (collapsed ? MOBILE_WIDGET_COLLAPSED_SIZE : MOBILE_WIDGET_EXPANDED_HEIGHT) -
+          MOBILE_WIDGET_VIEWPORT_PADDING,
         position.y,
       ),
     ),
   };
 }
 
-function getMobileExpandedPanelStyle(
-  position: { x: number; y: number },
-  viewportWidth?: number,
-): CSSProperties {
+function getMobileExpandedPanelStyle(position: { x: number; y: number }, viewportWidth?: number): CSSProperties {
   if (typeof window === "undefined") return {};
   const availableWidth = viewportWidth ?? window.innerWidth;
 
-  const width = Math.min(
-    MOBILE_WIDGET_EXPANDED_MAX_WIDTH,
-    availableWidth - MOBILE_WIDGET_EXPANDED_HORIZONTAL_GUTTER,
-  );
+  const width = Math.min(MOBILE_WIDGET_EXPANDED_MAX_WIDTH, availableWidth - MOBILE_WIDGET_EXPANDED_HORIZONTAL_GUTTER);
   const opensLeft =
     position.x + width > availableWidth - MOBILE_WIDGET_VIEWPORT_PADDING ||
     position.x + MOBILE_WIDGET_COLLAPSED_SIZE / 2 > availableWidth / 2;
@@ -1077,7 +1073,11 @@ export function SpotifyMiniPlayer({
               )}
               title={sdkDeviceId ? "Use Marinara player" : "Enable Marinara player"}
             >
-              {browserPlaybackLoading ? <Loader2 size="0.8125rem" className="animate-spin" /> : <Laptop size="0.8125rem" />}
+              {browserPlaybackLoading ? (
+                <Loader2 size="0.8125rem" className="animate-spin" />
+              ) : (
+                <Laptop size="0.8125rem" />
+              )}
             </button>
           )}
           <button
@@ -1126,7 +1126,7 @@ export function SpotifyMiniPlayer({
   if (floating) {
     return (
       <div
-        className={cn("fixed z-[35] touch-none select-none", mobile && "md:hidden")}
+        className={cn("fixed z-[45] touch-none select-none", mobile && "md:hidden")}
         style={mobileWidgetStyle}
         onPointerDown={startDrag}
         onPointerMove={moveDrag}

--- a/packages/client/src/components/ui/EmojiPicker.tsx
+++ b/packages/client/src/components/ui/EmojiPicker.tsx
@@ -1132,7 +1132,15 @@ interface EmojiPickerProps {
   embedded?: boolean;
 }
 
-export function EmojiPicker({ open, onClose, onSelect, anchorRef, containerRef, customTab, embedded }: EmojiPickerProps) {
+export function EmojiPicker({
+  open,
+  onClose,
+  onSelect,
+  anchorRef,
+  containerRef,
+  customTab,
+  embedded,
+}: EmojiPickerProps) {
   const [search, setSearch] = useState("");
   const [activeCategory, setActiveCategory] = useState<number | "custom">(0);
   const panelRef = useRef<HTMLDivElement>(null);
@@ -1168,6 +1176,7 @@ export function EmojiPicker({ open, onClose, onSelect, anchorRef, containerRef, 
   const [pos, setPos] = useState<{
     top?: number;
     left?: number;
+    right?: number;
     maxHeight?: number;
   }>({});
 
@@ -1203,8 +1212,12 @@ export function EmojiPicker({ open, onClose, onSelect, anchorRef, containerRef, 
         const left = visibleLeft + Math.max(pad, (vw - panelWidth) / 2);
         setPos({ top, left, maxHeight });
       } else {
-        const left = Math.max(visibleLeft + pad, Math.min(btnRight - panelWidth, visibleRight - panelWidth - pad));
-        setPos({ top, left, maxHeight });
+        const alignedLeft = btnRight - panelWidth;
+        if (alignedLeft < visibleLeft + pad) {
+          setPos({ top, left: visibleLeft + pad, maxHeight });
+        } else {
+          setPos({ top, right: Math.max(pad, visibleRight - btnRight), maxHeight });
+        }
       }
       return;
     }
@@ -1358,6 +1371,7 @@ export function EmojiPicker({ open, onClose, onSelect, anchorRef, containerRef, 
       style={{
         ...(pos.top != null ? { top: pos.top } : {}),
         ...(pos.left != null ? { left: pos.left } : {}),
+        ...(pos.right != null ? { right: pos.right } : {}),
         ...(pos.maxHeight != null ? { maxHeight: pos.maxHeight } : {}),
       }}
     >

--- a/packages/client/src/components/ui/SpeechToTextButton.tsx
+++ b/packages/client/src/components/ui/SpeechToTextButton.tsx
@@ -2,51 +2,11 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import { Mic, MicOff } from "lucide-react";
 import { toast } from "sonner";
 import { cn } from "../../lib/utils";
-
-type SpeechRecognitionAlternativeLike = {
-  transcript?: string;
-};
-
-type SpeechRecognitionResultLike = {
-  readonly isFinal: boolean;
-  readonly length: number;
-  item(index: number): SpeechRecognitionAlternativeLike;
-  [index: number]: SpeechRecognitionAlternativeLike | undefined;
-};
-
-type SpeechRecognitionResultListLike = {
-  readonly length: number;
-  item(index: number): SpeechRecognitionResultLike;
-  [index: number]: SpeechRecognitionResultLike | undefined;
-};
-
-type SpeechRecognitionEventLike = Event & {
-  readonly resultIndex: number;
-  readonly results: SpeechRecognitionResultListLike;
-};
-
-type SpeechRecognitionErrorEventLike = Event & {
-  readonly error?: string;
-};
-
-type SpeechRecognitionLike = EventTarget & {
-  continuous: boolean;
-  interimResults: boolean;
-  lang: string;
-  onresult: ((event: SpeechRecognitionEventLike) => void) | null;
-  onerror: ((event: SpeechRecognitionErrorEventLike) => void) | null;
-  onend: (() => void) | null;
-  start: () => void;
-  stop: () => void;
-  abort: () => void;
-};
-
-type SpeechRecognitionConstructor = new () => SpeechRecognitionLike;
-
-type SpeechRecognitionWindow = Window & {
-  SpeechRecognition?: SpeechRecognitionConstructor;
-  webkitSpeechRecognition?: SpeechRecognitionConstructor;
-};
+import {
+  getBrowserSpeechRecognitionCtor,
+  readBrowserSpeechRecognitionTranscript,
+  type BrowserSpeechRecognition,
+} from "../../lib/browser-speech-recognition";
 
 interface SpeechToTextButtonProps {
   disabled?: boolean;
@@ -55,24 +15,14 @@ interface SpeechToTextButtonProps {
   iconSize?: number;
 }
 
-function getSpeechRecognitionCtor(): SpeechRecognitionConstructor | null {
-  if (typeof window === "undefined") return null;
-  const speechWindow = window as SpeechRecognitionWindow;
-  return speechWindow.SpeechRecognition ?? speechWindow.webkitSpeechRecognition ?? null;
-}
-
-function readTranscript(result: SpeechRecognitionResultLike | undefined): string {
-  return result?.[0]?.transcript ?? result?.item(0)?.transcript ?? "";
-}
-
 export function SpeechToTextButton({ disabled, onTranscript, className, iconSize = 16 }: SpeechToTextButtonProps) {
   const [supported, setSupported] = useState(false);
   const [listening, setListening] = useState(false);
-  const recognitionRef = useRef<SpeechRecognitionLike | null>(null);
+  const recognitionRef = useRef<BrowserSpeechRecognition | null>(null);
   const disabledRef = useRef(Boolean(disabled));
 
   useEffect(() => {
-    setSupported(Boolean(getSpeechRecognitionCtor()));
+    setSupported(Boolean(getBrowserSpeechRecognitionCtor()));
     return () => {
       recognitionRef.current?.abort();
       recognitionRef.current = null;
@@ -99,7 +49,7 @@ export function SpeechToTextButton({ disabled, onTranscript, className, iconSize
     }
     if (disabledRef.current) return;
 
-    const Recognition = getSpeechRecognitionCtor();
+    const Recognition = getBrowserSpeechRecognitionCtor();
     if (!Recognition) {
       toast.error("Speech recognition is not supported in this browser.");
       return;
@@ -113,7 +63,7 @@ export function SpeechToTextButton({ disabled, onTranscript, className, iconSize
     recognition.onresult = (event) => {
       for (let index = event.resultIndex; index < event.results.length; index += 1) {
         const result = event.results[index] ?? event.results.item(index);
-        const transcript = readTranscript(result);
+        const transcript = readBrowserSpeechRecognitionTranscript(result);
         if (result?.isFinal && transcript.trim()) {
           finalTranscript = `${finalTranscript} ${transcript}`.trim();
         }

--- a/packages/client/src/hooks/use-conversation-calls.ts
+++ b/packages/client/src/hooks/use-conversation-calls.ts
@@ -1,0 +1,209 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import type {
+  ConversationCallIdleResponse,
+  ConversationCallMessage,
+  ConversationCallMessageResponse,
+  ConversationCallSession,
+  ConversationCallSound,
+  ConversationCallStatusResponse,
+} from "@marinara-engine/shared";
+import { api } from "../lib/api-client";
+import { chatKeys } from "./use-chats";
+import { useUIStore } from "../stores/ui.store";
+
+export const conversationCallKeys = {
+  status: (chatId: string) => ["conversation-calls", "status", chatId] as const,
+  messages: (callId: string) => ["conversation-calls", "messages", callId] as const,
+  soundboard: ["conversation-calls", "soundboard"] as const,
+};
+
+function appendCallMessages(
+  queryClient: ReturnType<typeof useQueryClient>,
+  callId: string | null,
+  messages: ConversationCallMessage[],
+) {
+  if (!callId || messages.length === 0) return;
+  queryClient.setQueryData<ConversationCallMessage[]>(conversationCallKeys.messages(callId), (existing = []) => {
+    const byId = new Map(existing.map((message) => [message.id, message]));
+    for (const message of messages) byId.set(message.id, message);
+    return [...byId.values()].sort((left, right) => Date.parse(left.createdAt) - Date.parse(right.createdAt));
+  });
+}
+
+function readCallMusicPlayerState() {
+  const state = useUIStore.getState();
+  return {
+    musicPlayerEnabled: state.musicPlayerEnabled,
+    musicPlayerSource: state.musicPlayerSource,
+  };
+}
+
+export function useConversationCallStatus(chatId: string, enabled = true) {
+  return useQuery({
+    queryKey: conversationCallKeys.status(chatId),
+    queryFn: () => api.get<ConversationCallStatusResponse>(`/conversation-calls/chat/${chatId}/status`),
+    enabled: enabled && Boolean(chatId),
+    refetchInterval: 10_000,
+    staleTime: 5_000,
+  });
+}
+
+export function useConversationCallMessages(callId: string | null) {
+  return useQuery({
+    queryKey: conversationCallKeys.messages(callId ?? ""),
+    queryFn: () => api.get<ConversationCallMessage[]>(`/conversation-calls/${callId}/messages`),
+    enabled: Boolean(callId),
+    refetchInterval: 2_000,
+    staleTime: 2_000,
+  });
+}
+
+export function useStartConversationCall(chatId: string) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: () => api.post<ConversationCallSession>("/conversation-calls/start", { chatId, mode: "audio" }),
+    onSuccess: (session) => {
+      queryClient.invalidateQueries({ queryKey: conversationCallKeys.status(chatId) });
+      queryClient.invalidateQueries({ queryKey: chatKeys.messages(chatId) });
+      if (session?.id) queryClient.invalidateQueries({ queryKey: conversationCallKeys.messages(session.id) });
+    },
+  });
+}
+
+export function useAcceptConversationCall(chatId: string) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (callId: string) => api.post<ConversationCallSession>(`/conversation-calls/${callId}/accept`),
+    onSuccess: (session) => {
+      queryClient.invalidateQueries({ queryKey: conversationCallKeys.status(chatId) });
+      if (session?.id) queryClient.invalidateQueries({ queryKey: conversationCallKeys.messages(session.id) });
+    },
+  });
+}
+
+export function useDeclineConversationCall(chatId: string) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (callId: string) => api.post<ConversationCallSession>(`/conversation-calls/${callId}/decline`),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: conversationCallKeys.status(chatId) });
+      queryClient.invalidateQueries({ queryKey: chatKeys.messages(chatId) });
+    },
+  });
+}
+
+export function useEndConversationCall(chatId: string) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (callId: string) => api.post<ConversationCallSession>(`/conversation-calls/${callId}/end`),
+    onSuccess: (session) => {
+      queryClient.invalidateQueries({ queryKey: conversationCallKeys.status(chatId) });
+      queryClient.invalidateQueries({ queryKey: chatKeys.messages(chatId) });
+      if (session?.id) queryClient.invalidateQueries({ queryKey: conversationCallKeys.messages(session.id) });
+    },
+  });
+}
+
+export function useSendConversationCallMessage(callId: string | null) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (input: { content: string; inputMode?: "typed" | "speech" }) =>
+      api.post<ConversationCallMessageResponse>(`/conversation-calls/${callId}/messages`, {
+        content: input.content,
+        inputMode: input.inputMode ?? "typed",
+        debugMode: useUIStore.getState().debugMode,
+        ...readCallMusicPlayerState(),
+      }),
+    onSuccess: (response) => {
+      appendCallMessages(queryClient, callId, [response.userMessage, ...response.assistantMessages]);
+      if (callId) queryClient.invalidateQueries({ queryKey: conversationCallKeys.messages(callId) });
+      queryClient.invalidateQueries({ queryKey: conversationCallKeys.status(response.session.chatId) });
+    },
+  });
+}
+
+export function useSendConversationCallIdle(callId: string | null) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (input: { quietMs: number }) =>
+      api.post<ConversationCallIdleResponse>(`/conversation-calls/${callId}/idle`, {
+        ...input,
+        debugMode: useUIStore.getState().debugMode,
+        ...readCallMusicPlayerState(),
+      }),
+    onSuccess: (response) => {
+      appendCallMessages(queryClient, callId, response.assistantMessages);
+      if (callId) queryClient.invalidateQueries({ queryKey: conversationCallKeys.messages(callId) });
+      queryClient.invalidateQueries({ queryKey: conversationCallKeys.status(response.session.chatId) });
+    },
+  });
+}
+
+export function useSendConversationCallMedia(callId: string | null) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (input: {
+      file: File;
+      kind: "audio" | "video";
+      nativePreferred?: boolean;
+      transcriptionMode?: "local_whisper";
+    }) => {
+      const formData = new FormData();
+      formData.set("file", input.file);
+      formData.set("kind", input.kind);
+      formData.set("nativePreferred", input.nativePreferred === false ? "false" : "true");
+      formData.set("debugMode", useUIStore.getState().debugMode ? "true" : "false");
+      const musicState = readCallMusicPlayerState();
+      formData.set("musicPlayerEnabled", musicState.musicPlayerEnabled ? "true" : "false");
+      formData.set("musicPlayerSource", musicState.musicPlayerSource);
+      if (input.transcriptionMode) formData.set("transcriptionMode", input.transcriptionMode);
+      return api.upload<ConversationCallMessageResponse>(`/conversation-calls/${callId}/media`, formData);
+    },
+    onSuccess: (response) => {
+      appendCallMessages(queryClient, callId, [response.userMessage, ...response.assistantMessages]);
+      if (callId) queryClient.invalidateQueries({ queryKey: conversationCallKeys.messages(callId) });
+      queryClient.invalidateQueries({ queryKey: conversationCallKeys.status(response.session.chatId) });
+    },
+  });
+}
+
+export function useRecordConversationCallInterruption(callId: string | null) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (input: { characterId?: string | null; speakerName?: string | null; spokenText?: string }) =>
+      api.post<ConversationCallMessage>(`/conversation-calls/${callId}/interruption`, input),
+    onSuccess: (message) => {
+      appendCallMessages(queryClient, callId, [message]);
+      if (callId) queryClient.invalidateQueries({ queryKey: conversationCallKeys.messages(callId) });
+    },
+  });
+}
+
+export function useConversationCallSoundboard() {
+  return useQuery({
+    queryKey: conversationCallKeys.soundboard,
+    queryFn: () => api.get<ConversationCallSound[]>("/conversation-calls/soundboard"),
+    staleTime: 60_000,
+  });
+}
+
+export function useUploadConversationCallSound() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (input: { file: File; name?: string }) => {
+      const formData = new FormData();
+      formData.set("file", input.file);
+      if (input.name) formData.set("name", input.name);
+      return api.upload<ConversationCallSound>("/conversation-calls/soundboard/upload", formData);
+    },
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: conversationCallKeys.soundboard }),
+  });
+}
+
+export function useDeleteConversationCallSound() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (soundId: string) => api.delete<void>(`/conversation-calls/soundboard/${soundId}`),
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: conversationCallKeys.soundboard }),
+  });
+}

--- a/packages/client/src/hooks/use-generate.ts
+++ b/packages/client/src/hooks/use-generate.ts
@@ -116,6 +116,12 @@ function applyAgentFrontendStyle(chatId: string, raw: unknown) {
   }, durationMs);
 }
 
+function isChatSurfaceVisible(chatId: string) {
+  const chatState = useChatStore.getState();
+  if (chatState.activeChatId !== chatId) return false;
+  return !useUIStore.getState().hasAnyDetailOpen();
+}
+
 const editableCharacterCardFieldSet = new Set<string>(EDITABLE_CHARACTER_CARD_FIELDS);
 
 function formatToolDebugPayload(value: unknown, maxLength = 1_200): string {
@@ -320,8 +326,7 @@ function readAgentWriteApprovalProposal(
       ? (envelope.approval as Record<string, unknown>)
       : envelope;
   if (!source) return null;
-  const kind =
-    source.kind === "lorebook_update" || source.kind === "summary_update" ? source.kind : null;
+  const kind = source.kind === "lorebook_update" || source.kind === "summary_update" ? source.kind : null;
   if (!kind) return null;
 
   const chatId =
@@ -391,7 +396,9 @@ import { characterKeys } from "./use-characters";
 import { connectionKeys } from "./use-connections";
 import { lorebookKeys } from "./use-lorebooks";
 import { presetKeys } from "./use-presets";
+import { conversationCallKeys } from "./use-conversation-calls";
 import { playConfiguredNotificationPing } from "../lib/notification-sound";
+import { playConversationCallRingingSoundOnce } from "../lib/conversation-call-sounds";
 import { messageHasPendingPostProcessing } from "../lib/chat-message-extra";
 import { stripGmTagsKeepReadables } from "../lib/game-tag-parser";
 import type { APIConnection, Chat, GameMap, Message } from "@marinara-engine/shared";
@@ -2048,6 +2055,56 @@ export function useGenerate() {
               break;
             }
 
+            case "conversation_call_ringing": {
+              const data = event.data as {
+                session?: {
+                  id?: unknown;
+                  chatId?: unknown;
+                  initiatorCharacterId?: unknown;
+                  metadata?: Record<string, unknown>;
+                };
+                reason?: unknown;
+                characterId?: unknown;
+              };
+              const session = data.session;
+              const callId = typeof session?.id === "string" ? session.id : null;
+              const callChatId = typeof session?.chatId === "string" ? session.chatId : params.chatId;
+              const characterId =
+                typeof data.characterId === "string"
+                  ? data.characterId
+                  : typeof session?.initiatorCharacterId === "string"
+                    ? session.initiatorCharacterId
+                    : null;
+              const reason =
+                typeof data.reason === "string"
+                  ? data.reason
+                  : typeof session?.metadata?.reason === "string"
+                    ? session.metadata.reason
+                    : null;
+
+              qc.invalidateQueries({ queryKey: conversationCallKeys.status(callChatId) });
+              qc.invalidateQueries({ queryKey: chatKeys.messages(callChatId) });
+              qc.invalidateQueries({ queryKey: chatKeys.list() });
+
+              playConversationCallRingingSoundOnce(callId);
+
+              if (callId && !isChatSurfaceVisible(callChatId)) {
+                const identity = resolveCachedCharacterIdentity(qc, characterId);
+                useChatStore
+                  .getState()
+                  .addCallNotification(
+                    callChatId,
+                    callId,
+                    identity.name ?? "Character",
+                    identity.avatarUrl,
+                    identity.avatarCrop,
+                    reason,
+                    { showWhenActive: true },
+                  );
+              }
+              break;
+            }
+
             case "spotify_command": {
               const spotifyData = event.data as {
                 track?: { name?: string; artist?: string };
@@ -2235,7 +2292,7 @@ export function useGenerate() {
               const delayedNames = (event as any).characters as string[] | undefined;
               const delayedLabel =
                 delayedNames?.length === 1 ? delayedNames[0] : (delayedNames?.join(", ") ?? "Character");
-              const delayedStatus = (((event as any).status as DelayedCharacterInfo["status"] | undefined) ?? "idle");
+              const delayedStatus = ((event as any).status as DelayedCharacterInfo["status"] | undefined) ?? "idle";
               const delayedInfo: DelayedCharacterInfo = {
                 name: delayedLabel,
                 status: delayedStatus,
@@ -2334,7 +2391,9 @@ export function useGenerate() {
           if (!abortController.signal.aborted) {
             await refreshMessagesAuthoritatively(qc, params.chatId, persistedMessages.values());
             if (!settled) {
-              toast.info("Generation is still finishing in the background. Refresh the chat in a moment if it has not appeared.");
+              toast.info(
+                "Generation is still finishing in the background. Refresh the chat in a moment if it has not appeared.",
+              );
             }
           }
           return abortController.signal.aborted ? receivedContent : true;
@@ -3179,7 +3238,9 @@ function formatAgentBubble(agentType: string, agentName: string, data: unknown):
     }
 
     case "knowledge-router": {
-      const selectedEntries = Array.isArray(d.selectedEntries) ? (d.selectedEntries as Array<Record<string, unknown>>) : [];
+      const selectedEntries = Array.isArray(d.selectedEntries)
+        ? (d.selectedEntries as Array<Record<string, unknown>>)
+        : [];
       const candidateCount =
         typeof d.candidateCount === "number" && Number.isFinite(d.candidateCount) ? d.candidateCount : null;
       if (selectedEntries.length > 0) {

--- a/packages/client/src/lib/browser-speech-recognition.ts
+++ b/packages/client/src/lib/browser-speech-recognition.ts
@@ -1,0 +1,58 @@
+type BrowserSpeechRecognitionAlternative = {
+  transcript?: string;
+};
+
+export type BrowserSpeechRecognitionResult = {
+  readonly isFinal: boolean;
+  readonly length: number;
+  item(index: number): BrowserSpeechRecognitionAlternative;
+  [index: number]: BrowserSpeechRecognitionAlternative | undefined;
+};
+
+export type BrowserSpeechRecognitionResultList = {
+  readonly length: number;
+  item(index: number): BrowserSpeechRecognitionResult;
+  [index: number]: BrowserSpeechRecognitionResult | undefined;
+};
+
+export type BrowserSpeechRecognitionEvent = Event & {
+  readonly resultIndex: number;
+  readonly results: BrowserSpeechRecognitionResultList;
+};
+
+export type BrowserSpeechRecognitionErrorEvent = Event & {
+  readonly error?: string;
+};
+
+export type BrowserSpeechRecognition = EventTarget & {
+  continuous: boolean;
+  interimResults: boolean;
+  lang: string;
+  onresult: ((event: BrowserSpeechRecognitionEvent) => void) | null;
+  onerror: ((event: BrowserSpeechRecognitionErrorEvent) => void) | null;
+  onend: (() => void) | null;
+  start: () => void;
+  stop: () => void;
+  abort: () => void;
+};
+
+type BrowserSpeechRecognitionConstructor = new () => BrowserSpeechRecognition;
+
+type BrowserSpeechRecognitionWindow = Window & {
+  SpeechRecognition?: BrowserSpeechRecognitionConstructor;
+  webkitSpeechRecognition?: BrowserSpeechRecognitionConstructor;
+};
+
+export function getBrowserSpeechRecognitionCtor(): BrowserSpeechRecognitionConstructor | null {
+  if (typeof window === "undefined") return null;
+  const speechWindow = window as BrowserSpeechRecognitionWindow;
+  return speechWindow.SpeechRecognition ?? speechWindow.webkitSpeechRecognition ?? null;
+}
+
+export function isBrowserSpeechRecognitionSupported(): boolean {
+  return Boolean(getBrowserSpeechRecognitionCtor());
+}
+
+export function readBrowserSpeechRecognitionTranscript(result: BrowserSpeechRecognitionResult | undefined): string {
+  return result?.[0]?.transcript ?? result?.item(0)?.transcript ?? "";
+}

--- a/packages/client/src/lib/conversation-call-sounds.ts
+++ b/packages/client/src/lib/conversation-call-sounds.ts
@@ -1,0 +1,85 @@
+type CallTone = {
+  frequency: number;
+  start: number;
+  duration: number;
+  gain?: number;
+};
+
+let lastRingingCallSoundId: string | null = null;
+
+function playShortTone(sequence: CallTone[]) {
+  if (typeof window === "undefined") return;
+  const AudioContextCtor =
+    window.AudioContext ??
+    (window as Window & typeof globalThis & { webkitAudioContext?: typeof AudioContext }).webkitAudioContext;
+  if (!AudioContextCtor) return;
+  try {
+    const audioContext = new AudioContextCtor();
+    const master = audioContext.createGain();
+    const now = audioContext.currentTime;
+    master.gain.setValueAtTime(0.0001, now);
+    master.gain.exponentialRampToValueAtTime(0.2, now + 0.02);
+    master.connect(audioContext.destination);
+
+    for (const item of sequence) {
+      const oscillator = audioContext.createOscillator();
+      const gain = audioContext.createGain();
+      const start = now + item.start;
+      const end = start + item.duration;
+      oscillator.type = "sine";
+      oscillator.frequency.setValueAtTime(item.frequency, start);
+      gain.gain.setValueAtTime(0.0001, start);
+      gain.gain.exponentialRampToValueAtTime(item.gain ?? 0.18, start + 0.02);
+      gain.gain.exponentialRampToValueAtTime(0.0001, end);
+      oscillator.connect(gain).connect(master);
+      oscillator.start(start);
+      oscillator.stop(end + 0.02);
+    }
+
+    const totalMs = (Math.max(...sequence.map((item) => item.start + item.duration), 0.3) + 0.18) * 1000;
+    window.setTimeout(() => void audioContext.close(), totalMs);
+  } catch {
+    /* Browser autoplay policy may reject sounds until the user has interacted with the page. */
+  }
+}
+
+export function playConversationCallRingingSound() {
+  playShortTone([
+    { frequency: 560, start: 0, duration: 0.18, gain: 0.16 },
+    { frequency: 700, start: 0.22, duration: 0.22, gain: 0.18 },
+    { frequency: 560, start: 0.62, duration: 0.18, gain: 0.14 },
+    { frequency: 700, start: 0.84, duration: 0.22, gain: 0.16 },
+  ]);
+}
+
+export function playConversationCallRingingSoundOnce(callId: string | null | undefined) {
+  if (!callId) {
+    playConversationCallRingingSound();
+    return;
+  }
+  if (lastRingingCallSoundId === callId) return;
+  lastRingingCallSoundId = callId;
+  playConversationCallRingingSound();
+}
+
+export function playConversationCallStartSound() {
+  playShortTone([
+    { frequency: 420, start: 0, duration: 0.16 },
+    { frequency: 540, start: 0.2, duration: 0.18 },
+  ]);
+}
+
+export function playConversationCallJoinSound() {
+  playShortTone([{ frequency: 760, start: 0, duration: 0.18, gain: 0.14 }]);
+}
+
+export function playConversationCallLeaveSound() {
+  playShortTone([{ frequency: 420, start: 0, duration: 0.2, gain: 0.13 }]);
+}
+
+export function playConversationCallEndSound() {
+  playShortTone([
+    { frequency: 540, start: 0, duration: 0.15, gain: 0.16 },
+    { frequency: 360, start: 0.18, duration: 0.2, gain: 0.15 },
+  ]);
+}

--- a/packages/client/src/lib/tts-service.ts
+++ b/packages/client/src/lib/tts-service.ts
@@ -15,6 +15,8 @@ export interface TTSSpeakOptions {
   throwOnError?: boolean;
   cacheKey?: string;
   cacheAliases?: string[];
+  volume?: number;
+  muted?: boolean;
 }
 
 export interface TTSSpeakRequest {
@@ -26,8 +28,13 @@ export interface TTSSpeakRequest {
   cacheAliases?: string[];
 }
 
-export interface TTSSpeakSequenceOptions extends Pick<TTSSpeakOptions, "signal" | "throwOnError"> {
+export interface TTSSpeakSequenceOptions extends Pick<TTSSpeakOptions, "signal" | "throwOnError" | "volume" | "muted"> {
   progressive?: boolean;
+}
+
+function clampPlaybackVolume(volume: number | undefined): number {
+  if (typeof volume !== "number" || !Number.isFinite(volume)) return 1;
+  return Math.max(0, Math.min(1, volume));
 }
 
 function waitForBlobWithAbort(promise: Promise<Blob>, signal?: AbortSignal): Promise<Blob> {
@@ -111,6 +118,17 @@ class TTSService {
 
   // ── Playback ──────────────────────────────────
 
+  private applyPlaybackOptions(audio: HTMLAudioElement, options: Pick<TTSSpeakOptions, "volume" | "muted">): void {
+    const volume = clampPlaybackVolume(options.volume);
+    audio.volume = volume;
+    audio.muted = options.muted === true || volume <= 0;
+  }
+
+  setCurrentPlaybackVolume(volume: number, muted = false): void {
+    if (!this.audio) return;
+    this.applyPlaybackOptions(this.audio, { volume, muted });
+  }
+
   async generateAudio(text: string, options: TTSSpeakOptions = {}): Promise<Blob> {
     const res = await fetch("/api/tts/speak", {
       method: "POST",
@@ -180,6 +198,7 @@ class TTSService {
     this.currentObjectUrl = objectUrl;
 
     const audio = new Audio(objectUrl);
+    this.applyPlaybackOptions(audio, options);
     this.audio = audio;
 
     audio.onended = () => {
@@ -265,21 +284,42 @@ class TTSService {
       this.currentObjectUrl = objectUrl;
 
       const audio = new Audio(objectUrl);
+      this.applyPlaybackOptions(audio, options);
       this.audio = audio;
 
       await new Promise<void>((resolve, reject) => {
+        let settled = false;
+        const finish = (callback: () => void) => {
+          if (settled) return;
+          settled = true;
+          abortController.signal.removeEventListener("abort", onAbort);
+          callback();
+        };
+        const onAbort = () => {
+          try {
+            audio.pause();
+          } catch {
+            /* ignore interrupted playback cleanup */
+          }
+          finish(resolve);
+        };
         const fail = (error: Error) => {
           if (!this.isCurrentSequence(sequence) || this.audio !== audio) return;
-          this.cleanup();
-          this.lastError = error.message;
-          this.setState("error");
-          reject(error);
+          finish(() => {
+            this.cleanup();
+            this.lastError = error.message;
+            this.setState("error");
+            reject(error);
+          });
         };
 
+        abortController.signal.addEventListener("abort", onAbort, { once: true });
         audio.onended = () => {
           if (!this.isCurrentSequence(sequence) || this.audio !== audio) return;
-          this.cleanup();
-          resolve();
+          finish(() => {
+            this.cleanup();
+            resolve();
+          });
         };
         audio.onerror = () => fail(new Error("Audio playback failed"));
 

--- a/packages/client/src/stores/chat.store.ts
+++ b/packages/client/src/stores/chat.store.ts
@@ -4,7 +4,8 @@
 import { create } from "zustand";
 import type { AvatarCropValue } from "../lib/utils";
 import { subscribeWithSelector } from "zustand/middleware";
-import type { Chat, ChatMode, ConversationPresenceStatus, Message } from "@marinara-engine/shared";
+import type { Chat, ChatMode, ConversationCallSession, ConversationPresenceStatus, Message } from "@marinara-engine/shared";
+import type { CharacterMap, PersonaInfo } from "../components/chat/chat-area.types";
 import { useAgentStore } from "./agent.store";
 import { useGameStateStore } from "./game-state.store";
 
@@ -13,6 +14,7 @@ const DRAFTS_KEY = "marinara-input-drafts";
 const NOTIFICATION_AUTODISMISS_MS = 8000;
 
 type NotificationAvatarCrop = AvatarCropValue | null;
+type ChatNotificationKind = "message" | "call";
 
 type DelayedCharacterStatus = ConversationPresenceStatus;
 
@@ -22,6 +24,14 @@ export type DelayedCharacterInfo = {
   characterIds?: string[];
   characterNames?: string[];
   characterStatuses?: Record<string, DelayedCharacterStatus>;
+};
+
+export type ActiveConversationCallSnapshot = {
+  session: ConversationCallSession;
+  chatName?: string;
+  characterMap: CharacterMap;
+  chatCharIds: string[];
+  personaInfo?: PersonaInfo;
 };
 
 /** Read drafts from localStorage so typed input survives reloads, tab closes, and app restarts. */
@@ -156,6 +166,9 @@ interface ChatState {
       characterName: string;
       avatarUrl: string | null;
       avatarCrop?: NotificationAvatarCrop;
+      kind?: ChatNotificationKind;
+      callId?: string | null;
+      reason?: string | null;
       count: number;
     }
   >;
@@ -163,6 +176,10 @@ interface ChatState {
   dismissedNotifications: Set<string>;
   /** Pending /goto request — ChatArea fulfils by paginating + scrolling to the target message. Token forces re-fire on identical N. */
   gotoRequest: { chatId: string; messageNumber: number; token: number } | null;
+  /** Mounted Conversation call snapshot. Runtime-only so the call can minimize while navigating. */
+  activeConversationCall: ActiveConversationCallSnapshot | null;
+  /** When true, show the active Conversation call as the full call surface instead of the micro panel. */
+  conversationCallExpanded: boolean;
 
   // Actions
   setActiveChat: (chat: Chat | null) => void;
@@ -219,11 +236,23 @@ interface ChatState {
     avatarUrl: string | null,
     avatarCrop?: NotificationAvatarCrop,
   ) => void;
+  addCallNotification: (
+    chatId: string,
+    callId: string,
+    characterName: string,
+    avatarUrl: string | null,
+    avatarCrop?: NotificationAvatarCrop,
+    reason?: string | null,
+    options?: { showWhenActive?: boolean },
+  ) => void;
   autoDismissNotification: (chatId: string) => void;
   dismissNotification: (chatId: string) => void;
   dismissNotifications: (chatIds: string[]) => void;
   requestGotoMessage: (chatId: string, messageNumber: number) => void;
   clearGotoRequest: () => void;
+  setActiveConversationCall: (snapshot: ActiveConversationCallSnapshot | null) => void;
+  updateActiveConversationCallSession: (session: ConversationCallSession) => void;
+  setConversationCallExpanded: (expanded: boolean) => void;
   reset: () => void;
 }
 
@@ -266,6 +295,8 @@ export const useChatStore = create<ChatState>()(
     chatNotifications: new Map(),
     dismissedNotifications: new Set(),
     gotoRequest: null,
+    activeConversationCall: null,
+    conversationCallExpanded: false,
 
     setActiveChat: (chat) => set({ activeChat: chat }),
     setActiveChatId: (id) => {
@@ -289,7 +320,13 @@ export const useChatStore = create<ChatState>()(
           return { unreadCounts: m, chatNotifications: n, dismissedNotifications: d };
         });
       }
-      set({ activeChatId: id, swipeIndex: new Map(), ...(!id && { activeChat: null }) });
+      const activeCall = get().activeConversationCall;
+      set({
+        activeChatId: id,
+        swipeIndex: new Map(),
+        ...(!id && { activeChat: null }),
+        ...(activeCall ? { conversationCallExpanded: id === activeCall.session.chatId } : {}),
+      });
       // Only reset agent + game state when actually switching chats — re-selecting the
       // same chat should not blow away loaded tracker data.
       if (id !== prev) {
@@ -626,6 +663,7 @@ export const useChatStore = create<ChatState>()(
               characterName: item.characterName,
               avatarUrl: item.avatarUrl,
               avatarCrop: item.avatarCrop ?? null,
+              kind: "message",
               count: item.count,
             });
           }
@@ -672,9 +710,30 @@ export const useChatStore = create<ChatState>()(
           characterName,
           avatarUrl,
           avatarCrop: avatarCrop ?? existing?.avatarCrop ?? null,
+          kind: "message",
           count: (existing?.count ?? 0) + 1,
         });
         scheduleNotificationAutoDismiss(chatId, get);
+        return { chatNotifications: m };
+      }),
+    addCallNotification: (chatId, callId, characterName, avatarUrl, avatarCrop, reason, options) =>
+      set((state) => {
+        if (state.activeChatId === chatId && !options?.showWhenActive) {
+          clearNotificationTimer(chatId);
+          return state;
+        }
+        clearNotificationTimer(chatId);
+        const m = new Map(state.chatNotifications);
+        m.set(chatId, {
+          chatId,
+          characterName,
+          avatarUrl,
+          avatarCrop: avatarCrop ?? null,
+          kind: "call",
+          callId,
+          reason: reason ?? null,
+          count: 1,
+        });
         return { chatNotifications: m };
       }),
     autoDismissNotification: (chatId) =>
@@ -716,6 +775,25 @@ export const useChatStore = create<ChatState>()(
         },
       })),
     clearGotoRequest: () => set({ gotoRequest: null }),
+
+    setActiveConversationCall: (snapshot) =>
+      set((state) => {
+        if (!snapshot) return { activeConversationCall: null, conversationCallExpanded: false };
+        const isNewCall = state.activeConversationCall?.session.id !== snapshot.session.id;
+        return {
+          activeConversationCall: snapshot,
+          ...(isNewCall ? { conversationCallExpanded: state.activeChatId === snapshot.session.chatId } : {}),
+        };
+      }),
+
+    updateActiveConversationCallSession: (session) =>
+      set((state) => {
+        if (!state.activeConversationCall || state.activeConversationCall.session.id !== session.id) return state;
+        if (state.activeConversationCall.session === session) return state;
+        return { activeConversationCall: { ...state.activeConversationCall, session } };
+      }),
+
+    setConversationCallExpanded: (expanded) => set({ conversationCallExpanded: expanded }),
 
     setSwipeIndex: (messageId: string, index: number) =>
       set((state) => {
@@ -759,6 +837,8 @@ export const useChatStore = create<ChatState>()(
         chatNotifications: new Map(),
         dismissedNotifications: new Set(),
         gotoRequest: null,
+        activeConversationCall: null,
+        conversationCallExpanded: false,
       });
       try {
         localStorage.removeItem(STORAGE_KEY);

--- a/packages/client/src/stores/sidecar.store.ts
+++ b/packages/client/src/stores/sidecar.store.ts
@@ -11,6 +11,12 @@ import type {
   SidecarModelInfo,
   SidecarRuntimeDiagnostics,
   SidecarRuntimeInfo,
+  SidecarSpeechConfig,
+  SidecarSpeechModelId,
+  SidecarSpeechModelInfo,
+  SidecarSpeechRuntimeDiagnostics,
+  SidecarSpeechStatus,
+  SidecarSpeechStatusResponse,
   SidecarStatus,
   SidecarStatusResponse,
   SidecarQuantization,
@@ -64,14 +70,27 @@ interface SidecarState {
   hasBeenPrompted: boolean;
   testMessagePending: boolean;
   testMessageResult: SidecarTestMessageResult | null;
+  speechStatus: SidecarSpeechStatus;
+  speechConfig: SidecarSpeechConfig;
+  speechAvailable: boolean;
+  speechModelDownloaded: boolean;
+  speechModelDisplayName: string | null;
+  speechModelSize: number | null;
+  speechModels: SidecarSpeechModelInfo[];
+  speechRuntime: SidecarSpeechRuntimeDiagnostics | null;
+  speechDownloadProgress: SidecarDownloadProgress | null;
+  speechError: string | null;
 
   fetchStatus: () => Promise<void>;
+  fetchSpeechStatus: () => Promise<void>;
   startDownload: (quantization: SidecarQuantization) => Promise<void>;
+  startSpeechDownload: (modelId: SidecarSpeechModelId) => Promise<void>;
   startCustomDownload: (repo: string, modelPath?: string) => Promise<void>;
   listHuggingFaceModels: (repo: string) => Promise<SidecarCustomModelEntry[]>;
   clearCustomModels: () => void;
   cancelDownload: () => Promise<void>;
   deleteModel: () => Promise<void>;
+  deleteSpeechModel: (modelId?: SidecarSpeechModelId) => Promise<void>;
   unloadModel: () => Promise<void>;
   restartRuntime: () => Promise<void>;
   installRuntime: (reinstall?: boolean) => Promise<void>;
@@ -104,6 +123,7 @@ const PROMPTED_KEY = "marinara_sidecar_prompted";
 const TRANSITIONAL_STATUSES = new Set<SidecarStatus>(["downloading_runtime", "downloading_model", "starting_server"]);
 let statusPollTimer: number | null = null;
 let activeDownloadController: AbortController | null = null;
+let activeSpeechDownloadController: AbortController | null = null;
 let downloadCancelRequested = false;
 
 function clearStatusPollTimer() {
@@ -261,6 +281,132 @@ async function consumeDownloadStream(
   }
 }
 
+async function consumeSpeechDownloadStream(
+  path: string,
+  body: unknown,
+  set: (partial: Partial<SidecarState>) => void,
+  get: () => SidecarState,
+): Promise<void> {
+  activeSpeechDownloadController?.abort();
+  const controller = new AbortController();
+  activeSpeechDownloadController = controller;
+
+  const apiPath = path.startsWith("/api/") ? path.slice(4) : path;
+  try {
+    const response = await api.raw(apiPath, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+      signal: controller.signal,
+    });
+
+    if (!response.ok) {
+      const text = await response.text().catch(() => "");
+      let detail = text.slice(0, 300) || response.statusText || "unknown error";
+      try {
+        const parsed = JSON.parse(text) as { error?: string; message?: string };
+        detail = parsed.error ?? parsed.message ?? detail;
+      } catch {
+        // Keep the plain-text detail.
+      }
+      throw new Error(`Local Whisper download failed (${response.status}): ${detail}`);
+    }
+
+    if (!response.body) {
+      throw new Error(`Local Whisper download failed (${response.status}): missing response body`);
+    }
+
+    const reader = response.body.getReader();
+    const decoder = new TextDecoder();
+    let buffer = "";
+
+    type DownloadSseData = Partial<SidecarDownloadProgress> & {
+      done?: boolean;
+      status?: string;
+      error?: string;
+    };
+    const readSseData = (line: string): string | null => {
+      const trimmed = line.trim();
+      if (!trimmed.startsWith("data:")) return null;
+      return trimmed.slice(5).trimStart();
+    };
+    const handleSseData = async (data: DownloadSseData): Promise<boolean> => {
+      if (data.done) {
+        set({ speechDownloadProgress: null });
+        await get().fetchSpeechStatus();
+        return true;
+      }
+
+      if (data.status === "error") {
+        set({
+          speechStatus: "error",
+          speechError: data.error ?? "Local Whisper download failed",
+          speechDownloadProgress: {
+            phase: "model",
+            status: "error",
+            downloaded: 0,
+            total: 0,
+            speed: 0,
+            error: data.error ?? "Local Whisper download failed",
+            label: data.label,
+          },
+        });
+        await get().fetchSpeechStatus();
+        return true;
+      }
+
+      if (data.status === "downloading") {
+        set({
+          speechStatus: "downloading_model",
+          speechDownloadProgress: {
+            phase: "model",
+            status: "downloading",
+            downloaded: Number(data.downloaded ?? 0),
+            total: Number(data.total ?? 0),
+            speed: Number(data.speed ?? 0),
+            label: data.label,
+          },
+        });
+      }
+
+      return false;
+    };
+
+    while (true) {
+      const { done, value } = await reader.read();
+
+      buffer += done ? decoder.decode() : decoder.decode(value, { stream: true });
+      const lines = buffer.split(/\r?\n/);
+      buffer = done ? "" : (lines.pop() ?? "");
+
+      for (const line of lines) {
+        const payload = readSseData(line);
+        if (payload == null) continue;
+        try {
+          if (await handleSseData(JSON.parse(payload) as DownloadSseData)) return;
+        } catch {
+          // Ignore malformed SSE chunks.
+        }
+      }
+      if (done) break;
+    }
+
+    set({ speechDownloadProgress: null });
+    await get().fetchSpeechStatus();
+  } catch (error) {
+    if (controller.signal.aborted) {
+      set({ speechDownloadProgress: null });
+      await get().fetchSpeechStatus();
+      return;
+    }
+    throw error;
+  } finally {
+    if (activeSpeechDownloadController === controller) {
+      activeSpeechDownloadController = null;
+    }
+  }
+}
+
 export const useSidecarStore = create<SidecarState>((set, get) => ({
   status: "not_downloaded",
   config: { ...SIDECAR_DEFAULT_CONFIG },
@@ -284,6 +430,16 @@ export const useSidecarStore = create<SidecarState>((set, get) => ({
   hasBeenPrompted: localStorage.getItem(PROMPTED_KEY) === "true",
   testMessagePending: false,
   testMessageResult: null,
+  speechStatus: "not_downloaded",
+  speechConfig: { modelId: null },
+  speechAvailable: false,
+  speechModelDownloaded: false,
+  speechModelDisplayName: null,
+  speechModelSize: null,
+  speechModels: [],
+  speechRuntime: null,
+  speechDownloadProgress: null,
+  speechError: null,
 
   fetchStatus: async () => {
     try {
@@ -317,6 +473,26 @@ export const useSidecarStore = create<SidecarState>((set, get) => ({
     }
   },
 
+  fetchSpeechStatus: async () => {
+    try {
+      const response = await api.get<SidecarSpeechStatusResponse>("/sidecar/speech/status");
+      set({
+        speechStatus: response.status,
+        speechConfig: response.config,
+        speechAvailable: response.available,
+        speechModelDownloaded: response.modelDownloaded,
+        speechModelDisplayName: response.modelDisplayName,
+        speechModelSize: response.modelSize,
+        speechModels: response.models,
+        speechRuntime: response.runtime ?? null,
+        speechDownloadProgress: response.downloadProgress,
+        speechError: response.error,
+      });
+    } catch {
+      // Best-effort: the server may not support the speech sidecar yet.
+    }
+  },
+
   startDownload: async (quantization) => {
     set({
       status: "downloading_model",
@@ -344,6 +520,38 @@ export const useSidecarStore = create<SidecarState>((set, get) => ({
           total: 0,
           speed: 0,
           error: error instanceof Error ? error.message : "Download failed",
+        },
+      });
+    }
+  },
+
+  startSpeechDownload: async (modelId) => {
+    set({
+      speechStatus: "downloading_model",
+      speechError: null,
+      speechDownloadProgress: {
+        phase: "model",
+        status: "downloading",
+        downloaded: 0,
+        total: 0,
+        speed: 0,
+      },
+    });
+
+    try {
+      await consumeSpeechDownloadStream("/api/sidecar/speech/download", { modelId }, set, get);
+    } catch (error) {
+      await get().fetchSpeechStatus();
+      set({
+        speechStatus: "error",
+        speechError: error instanceof Error ? error.message : "Local Whisper download failed",
+        speechDownloadProgress: {
+          phase: "model",
+          status: "error",
+          downloaded: 0,
+          total: 0,
+          speed: 0,
+          error: error instanceof Error ? error.message : "Local Whisper download failed",
         },
       });
     }
@@ -429,6 +637,24 @@ export const useSidecarStore = create<SidecarState>((set, get) => ({
         testMessageResult: null,
       });
       await get().fetchStatus();
+    } catch {
+      // Best-effort delete.
+    }
+  },
+
+  deleteSpeechModel: async () => {
+    try {
+      await api.delete("/sidecar/speech/model");
+      set({
+        speechStatus: "not_downloaded",
+        speechConfig: { modelId: null },
+        speechModelDownloaded: false,
+        speechModelDisplayName: null,
+        speechModelSize: null,
+        speechDownloadProgress: null,
+        speechError: null,
+      });
+      await get().fetchSpeechStatus();
     } catch {
       // Best-effort delete.
     }

--- a/packages/client/src/stores/ui.store.ts
+++ b/packages/client/src/stores/ui.store.ts
@@ -571,6 +571,10 @@ interface UIState {
   youtubePlayerVolume: number;
   /** User-set local Custom music player volume (0–100). The DJ can also steer this. */
   localMusicPlayerVolume: number;
+  /** User-set Conversation Call character voice volume (0–100). */
+  conversationCallVoiceVolume: number;
+  /** When true, mute character voices in Conversation Calls. */
+  conversationCallVoiceMuted: boolean;
   /** Mobile Spotify widget collapsed state. */
   spotifyMobileWidgetCollapsed: boolean;
   /** Mobile Spotify widget position in viewport pixels. */
@@ -840,6 +844,8 @@ interface UIState {
   setYoutubePlayerEnabled: (v: boolean) => void;
   setYoutubePlayerVolume: (v: number) => void;
   setLocalMusicPlayerVolume: (v: number) => void;
+  setConversationCallVoiceVolume: (v: number) => void;
+  setConversationCallVoiceMuted: (v: boolean) => void;
   setSpotifyMobileWidgetCollapsed: (v: boolean) => void;
   setSpotifyMobileWidgetPosition: (position: FloatingWidgetPosition) => void;
   setIntuitiveSwipeNavigation: (v: boolean) => void;
@@ -1037,6 +1043,8 @@ export function pickSyncedSettings(state: UIState) {
     youtubePlayerEnabled: state.youtubePlayerEnabled,
     youtubePlayerVolume: state.youtubePlayerVolume,
     localMusicPlayerVolume: state.localMusicPlayerVolume,
+    conversationCallVoiceVolume: state.conversationCallVoiceVolume,
+    conversationCallVoiceMuted: state.conversationCallVoiceMuted,
     spotifyMobileWidgetCollapsed: state.spotifyMobileWidgetCollapsed,
     spotifyMobileWidgetPosition: state.spotifyMobileWidgetPosition,
     intuitiveSwipeNavigation: state.intuitiveSwipeNavigation,
@@ -1210,6 +1218,8 @@ export const useUIStore = create<UIState>()(
       youtubePlayerEnabled: true,
       youtubePlayerVolume: 70,
       localMusicPlayerVolume: 70,
+      conversationCallVoiceVolume: 100,
+      conversationCallVoiceMuted: false,
       spotifyMobileWidgetCollapsed: true,
       spotifyMobileWidgetPosition: { x: 16, y: 96 },
       intuitiveSwipeNavigation: false,
@@ -1769,6 +1779,9 @@ export const useUIStore = create<UIState>()(
       setYoutubePlayerEnabled: (v) => set({ youtubePlayerEnabled: v }),
       setYoutubePlayerVolume: (v) => set({ youtubePlayerVolume: Math.max(0, Math.min(100, Math.round(v))) }),
       setLocalMusicPlayerVolume: (v) => set({ localMusicPlayerVolume: Math.max(0, Math.min(100, Math.round(v))) }),
+      setConversationCallVoiceVolume: (v) =>
+        set({ conversationCallVoiceVolume: Math.max(0, Math.min(100, Math.round(v))) }),
+      setConversationCallVoiceMuted: (v) => set({ conversationCallVoiceMuted: v }),
       setSpotifyMobileWidgetCollapsed: (v) => set({ spotifyMobileWidgetCollapsed: v }),
       setSpotifyMobileWidgetPosition: (position) =>
         set({
@@ -1952,7 +1965,7 @@ export const useUIStore = create<UIState>()(
     }),
     {
       name: "marinara-engine-ui",
-      version: 67,
+      version: 68,
       // Debounce localStorage writes to avoid sync I/O on every state change
       storage: createJSONStorage(() => {
         let timer: ReturnType<typeof setTimeout> | null = null;
@@ -2318,6 +2331,16 @@ export const useUIStore = create<UIState>()(
         if (version <= 65 && persisted.includeReasoningInExports === undefined) {
           persisted.includeReasoningInExports = false;
         }
+        if (typeof persisted.conversationCallVoiceVolume !== "number") {
+          persisted.conversationCallVoiceVolume = 100;
+        }
+        persisted.conversationCallVoiceVolume = Math.max(
+          0,
+          Math.min(100, Math.round(persisted.conversationCallVoiceVolume)),
+        );
+        if (typeof persisted.conversationCallVoiceMuted !== "boolean") {
+          persisted.conversationCallVoiceMuted = false;
+        }
         // v42 -> v44: reconcile parallel v43 UI preference additions.
         if (version <= 43 && persisted.youtubePlayerEnabled === undefined) {
           persisted.youtubePlayerEnabled = true;
@@ -2557,6 +2580,8 @@ export const useUIStore = create<UIState>()(
         youtubePlayerEnabled: state.youtubePlayerEnabled,
         youtubePlayerVolume: state.youtubePlayerVolume,
         localMusicPlayerVolume: state.localMusicPlayerVolume,
+        conversationCallVoiceVolume: state.conversationCallVoiceVolume,
+        conversationCallVoiceMuted: state.conversationCallVoiceMuted,
         spotifyMobileWidgetCollapsed: state.spotifyMobileWidgetCollapsed,
         spotifyMobileWidgetPosition: state.spotifyMobileWidgetPosition,
         intuitiveSwipeNavigation: state.intuitiveSwipeNavigation,

--- a/packages/client/src/styles/globals.css
+++ b/packages/client/src/styles/globals.css
@@ -5353,6 +5353,28 @@ strong {
   animation-play-state: paused !important;
 }
 
+.mari-conversation-call-mini {
+  bottom: max(env(safe-area-inset-bottom), 0.75rem);
+  left: max(env(safe-area-inset-left), 0.75rem);
+  transition: bottom 220ms cubic-bezier(0.16, 1, 0.3, 1);
+}
+
+:root[data-professor-mari-floating="true"] .mari-conversation-call-mini {
+  bottom: calc(max(env(safe-area-inset-bottom), 0.75rem) + min(32rem, calc(100vh - 5rem)) + 0.75rem);
+}
+
+@supports (height: 100dvh) {
+  :root[data-professor-mari-floating="true"] .mari-conversation-call-mini {
+    bottom: calc(max(env(safe-area-inset-bottom), 0.75rem) + min(32rem, calc(100dvh - 5rem)) + 0.75rem);
+  }
+}
+
+@media (max-width: 639px) {
+  :root[data-professor-mari-floating="true"] .mari-conversation-call-mini {
+    bottom: calc(max(env(safe-area-inset-bottom), 0.75rem) + 4rem);
+  }
+}
+
 .mari-professor-pixel-scene::before {
   content: "";
   position: absolute;

--- a/packages/server/src/db/file-backed-store.ts
+++ b/packages/server/src/db/file-backed-store.ts
@@ -151,6 +151,9 @@ export const FILE_BACKED_TABLES = [
   "chats",
   "messages",
   "message_swipes",
+  "conversation_call_sessions",
+  "conversation_call_messages",
+  "conversation_call_sounds",
   "characters",
   "character_card_versions",
   "personas",
@@ -208,6 +211,8 @@ const warnedFlushFailures = new Set<string>();
 
 const CASCADES: Array<{ parent: FileBackedTable; child: FileBackedTable; parentKey: string; childKey: string }> = [
   { parent: "chats", child: "messages", parentKey: "id", childKey: "chatId" },
+  { parent: "chats", child: "conversation_call_sessions", parentKey: "id", childKey: "chatId" },
+  { parent: "chats", child: "conversation_call_messages", parentKey: "id", childKey: "chatId" },
   { parent: "chats", child: "agent_runs", parentKey: "id", childKey: "chatId" },
   { parent: "chats", child: "agent_memory", parentKey: "id", childKey: "chatId" },
   { parent: "chats", child: "chat_images", parentKey: "id", childKey: "chatId" },
@@ -224,6 +229,7 @@ const CASCADES: Array<{ parent: FileBackedTable; child: FileBackedTable; parentK
     childKey: "storyboardId",
   },
   { parent: "messages", child: "message_swipes", parentKey: "id", childKey: "messageId" },
+  { parent: "conversation_call_sessions", child: "conversation_call_messages", parentKey: "id", childKey: "callId" },
   { parent: "characters", child: "character_card_versions", parentKey: "id", childKey: "characterId" },
   { parent: "characters", child: "character_images", parentKey: "id", childKey: "characterId" },
   { parent: "personas", child: "persona_images", parentKey: "id", childKey: "personaId" },

--- a/packages/server/src/db/migrate.ts
+++ b/packages/server/src/db/migrate.ts
@@ -41,6 +41,41 @@ const CREATE_TABLES: string[] = [
     extra TEXT NOT NULL DEFAULT '{}',
     created_at TEXT NOT NULL
   )`,
+  `CREATE TABLE IF NOT EXISTS conversation_call_sessions (
+    id TEXT PRIMARY KEY NOT NULL,
+    chat_id TEXT NOT NULL REFERENCES chats(id) ON DELETE CASCADE,
+    status TEXT NOT NULL,
+    mode TEXT NOT NULL DEFAULT 'audio',
+    initiator TEXT NOT NULL,
+    initiator_character_id TEXT,
+    started_at TEXT,
+    ended_at TEXT,
+    summary TEXT,
+    metadata TEXT NOT NULL DEFAULT '{}',
+    created_at TEXT NOT NULL,
+    updated_at TEXT NOT NULL
+  )`,
+  `CREATE TABLE IF NOT EXISTS conversation_call_messages (
+    id TEXT PRIMARY KEY NOT NULL,
+    call_id TEXT NOT NULL REFERENCES conversation_call_sessions(id) ON DELETE CASCADE,
+    chat_id TEXT NOT NULL REFERENCES chats(id) ON DELETE CASCADE,
+    role TEXT NOT NULL,
+    character_id TEXT,
+    participant_kind TEXT NOT NULL,
+    kind TEXT NOT NULL,
+    content TEXT NOT NULL DEFAULT '',
+    extra TEXT NOT NULL DEFAULT '{}',
+    created_at TEXT NOT NULL
+  )`,
+  `CREATE TABLE IF NOT EXISTS conversation_call_sounds (
+    id TEXT PRIMARY KEY NOT NULL,
+    name TEXT NOT NULL,
+    file_path TEXT,
+    mime_type TEXT NOT NULL DEFAULT 'audio/mpeg',
+    duration_ms INTEGER,
+    built_in TEXT NOT NULL DEFAULT 'false',
+    created_at TEXT NOT NULL
+  )`,
   `CREATE TABLE IF NOT EXISTS characters (
     id TEXT PRIMARY KEY NOT NULL,
     data TEXT NOT NULL,

--- a/packages/server/src/db/schema/conversation-calls.ts
+++ b/packages/server/src/db/schema/conversation-calls.ts
@@ -1,0 +1,49 @@
+// ──────────────────────────────────────────────
+// Schema: Conversation Calls
+// ──────────────────────────────────────────────
+import { sqliteTable, text, integer } from "drizzle-orm/sqlite-core";
+import { chats } from "./chats.js";
+
+export const conversationCallSessions = sqliteTable("conversation_call_sessions", {
+  id: text("id").primaryKey(),
+  chatId: text("chat_id")
+    .notNull()
+    .references(() => chats.id, { onDelete: "cascade" }),
+  status: text("status", { enum: ["ringing", "active", "ended", "declined", "missed"] }).notNull(),
+  mode: text("mode", { enum: ["audio", "video"] }).notNull().default("audio"),
+  initiator: text("initiator", { enum: ["user", "character"] }).notNull(),
+  initiatorCharacterId: text("initiator_character_id"),
+  startedAt: text("started_at"),
+  endedAt: text("ended_at"),
+  summary: text("summary"),
+  metadata: text("metadata").notNull().default("{}"),
+  createdAt: text("created_at").notNull(),
+  updatedAt: text("updated_at").notNull(),
+});
+
+export const conversationCallMessages = sqliteTable("conversation_call_messages", {
+  id: text("id").primaryKey(),
+  callId: text("call_id")
+    .notNull()
+    .references(() => conversationCallSessions.id, { onDelete: "cascade" }),
+  chatId: text("chat_id")
+    .notNull()
+    .references(() => chats.id, { onDelete: "cascade" }),
+  role: text("role", { enum: ["user", "assistant", "system", "narrator"] }).notNull(),
+  characterId: text("character_id"),
+  participantKind: text("participant_kind", { enum: ["user", "character"] }).notNull(),
+  kind: text("kind", { enum: ["speech", "text", "system", "command", "soundboard"] }).notNull(),
+  content: text("content").notNull().default(""),
+  extra: text("extra").notNull().default("{}"),
+  createdAt: text("created_at").notNull(),
+});
+
+export const conversationCallSounds = sqliteTable("conversation_call_sounds", {
+  id: text("id").primaryKey(),
+  name: text("name").notNull(),
+  filePath: text("file_path"),
+  mimeType: text("mime_type").notNull().default("audio/mpeg"),
+  durationMs: integer("duration_ms"),
+  builtIn: text("built_in").notNull().default("false"),
+  createdAt: text("created_at").notNull(),
+});

--- a/packages/server/src/db/schema/index.ts
+++ b/packages/server/src/db/schema/index.ts
@@ -2,6 +2,7 @@
 // Database Schema — Barrel Export
 // ──────────────────────────────────────────────
 export * from "./chats.js";
+export * from "./conversation-calls.js";
 export * from "./chat-presets.js";
 export * from "./characters.js";
 export * from "./lorebooks.js";

--- a/packages/server/src/middleware/rate-limit.ts
+++ b/packages/server/src/middleware/rate-limit.ts
@@ -24,7 +24,7 @@ const ROUTE_RULES: Array<{ pattern: RegExp; rule: RateLimitRule }> = [
   { pattern: /^\/api\/backup(?:\/|$)/, rule: { key: "backup", limit: 30, windowMs: 60_000 } },
   { pattern: /^\/api\/updates\/apply(?:\?|$)/, rule: { key: "updates-apply", limit: 5, windowMs: 60_000 } },
   {
-    pattern: /^\/api\/sidecar\/(?:runtime\/install|reinstall|download|model)(?:\/|\?|$)/,
+    pattern: /^\/api\/sidecar\/(?:runtime\/install|reinstall|download|model|speech\/download|speech\/model)(?:\/|\?|$)/,
     rule: { key: "sidecar-privileged", limit: 20, windowMs: 60_000 },
   },
   { pattern: /^\/api\/haptic\/command(?:\?|$)/, rule: { key: "haptic-command", limit: 30, windowMs: 60_000 } },

--- a/packages/server/src/routes/conversation-calls.routes.ts
+++ b/packages/server/src/routes/conversation-calls.routes.ts
@@ -1,0 +1,2171 @@
+// ──────────────────────────────────────────────
+// Routes: Conversation Calls
+// ──────────────────────────────────────────────
+import type { FastifyInstance } from "fastify";
+import { createReadStream, existsSync, mkdirSync, unlinkSync } from "node:fs";
+import { createWriteStream } from "node:fs";
+import { basename, extname, join } from "node:path";
+import { pipeline } from "node:stream/promises";
+import {
+  conversationCallIdleSchema,
+  conversationCallInterruptionSchema,
+  conversationCallModelResponseSchema,
+  normalizeTextForMatch,
+  sendConversationCallMessageSchema,
+  startConversationCallSchema,
+  type ConversationCommandKey,
+  type ConversationCallMessage,
+  type ConversationCallSession,
+  type ConversationCallTurn,
+  type MessageAttachment,
+} from "@marinara-engine/shared";
+import { createChatsStorage } from "../services/storage/chats.storage.js";
+import { createCharactersStorage } from "../services/storage/characters.storage.js";
+import { createConnectionsStorage } from "../services/storage/connections.storage.js";
+import { createConversationCallsStorage } from "../services/storage/conversation-calls.storage.js";
+import { createAppSettingsStorage } from "../services/storage/app-settings.storage.js";
+import { createLorebooksStorage } from "../services/storage/lorebooks.storage.js";
+import { createAgentsStorage } from "../services/storage/agents.storage.js";
+import { createGalleryStorage } from "../services/storage/gallery.storage.js";
+import { createPromptOverridesStorage } from "../services/storage/prompt-overrides.storage.js";
+import { createLLMProvider } from "../services/llm/provider-registry.js";
+import { sidecarSpeechService } from "../services/sidecar/sidecar-speech.service.js";
+import {
+  getActiveStatusOverride,
+  getEffectiveCurrentStatus,
+  type WeekSchedule,
+} from "../services/conversation/schedule.service.js";
+import {
+  getEnabledConversationSchedules,
+  parseConversationStatusOverrides,
+} from "../services/generation/conversation-context-utils.js";
+import {
+  parseCharacterCommands,
+  parseDuration,
+  type CharacterCommand,
+  type CrossPostCommand,
+  type HapticCommand,
+  type InfluenceCommand,
+  type MemoryCommand,
+  type NoteCommand,
+  type ScheduleUpdateCommand,
+  type SelfieCommand,
+  type SpotifyCommand,
+  type YouTubeCommand,
+} from "../services/conversation/character-commands.js";
+import { resolveConversationSelfieSystemPrompt } from "../services/conversation/selfie-prompt.js";
+import { stripConversationPromptTimestamps } from "../services/conversation/transcript-sanitize.js";
+import { resolveConnectionImageDefaults } from "../services/image/image-generation-defaults.js";
+import { loadImageGenerationUserSettings } from "../services/image/image-generation-settings.js";
+import { compileImagePrompt } from "../services/image/image-prompt-compiler.js";
+import { generateImage, saveImageToDisk } from "../services/image/image-generation.js";
+import {
+  isNovelAiImageConnection,
+  resolveIllustratorCharacterReferences,
+} from "./generate/illustrator-references.js";
+import { getChatHapticIntifaceUrl } from "../services/generation/haptic-runtime.js";
+import { resolveSpotifyCredentials, spotifyHasScope } from "../services/spotify/spotify.service.js";
+import {
+  ConversationSpotifyCommandError,
+  isSilentConversationSpotifyCommandError,
+  playConversationSpotifyCommand,
+} from "../services/spotify/conversation-spotify-command.service.js";
+import { resolveBaseUrl } from "./generate/generate-route-utils.js";
+import { DATA_DIR } from "../utils/data-dir.js";
+import { assertInsideDir } from "../utils/security.js";
+import { newId } from "../utils/id-generator.js";
+import { logger, logDebugOverride } from "../lib/logger.js";
+import { llmFetch, type ChatMediaAttachment, type ChatMessage } from "../services/llm/base-provider.js";
+
+const SOUNDBOARD_ROOT = join(DATA_DIR, "conversation-call-sounds");
+const ALLOWED_SOUND_EXTS = new Set([".mp3", ".wav", ".ogg", ".webm", ".m4a"]);
+const MAX_SOUND_BYTES = 8 * 1024 * 1024;
+const MAX_AUDIO_UPLOAD_BYTES = 25 * 1024 * 1024;
+const GEMINI_INLINE_MEDIA_LIMIT_BYTES = 20 * 1024 * 1024;
+const GEMINI_AUDIO_MIME_TYPES = new Set([
+  "audio/wav",
+  "audio/x-wav",
+  "audio/wave",
+  "audio/mpeg",
+  "audio/mp3",
+  "audio/aiff",
+  "audio/x-aiff",
+  "audio/aac",
+  "audio/mp4",
+  "audio/m4a",
+  "audio/x-m4a",
+  "audio/ogg",
+  "audio/flac",
+]);
+
+type ChatRow = Awaited<ReturnType<ReturnType<typeof createChatsStorage>["getById"]>>;
+type CharacterRow = Awaited<ReturnType<ReturnType<typeof createCharactersStorage>["getById"]>>;
+type CallsStorage = ReturnType<typeof createConversationCallsStorage>;
+type ConnectionsStorage = ReturnType<typeof createConnectionsStorage>;
+type CallPresenceStatus = "online" | "idle" | "dnd" | "offline";
+type CallCharacter = {
+  id: string;
+  name: string;
+  context: string;
+  appearance: string | null;
+  avatarPath: string | null;
+  presenceStatus: CallPresenceStatus;
+  presenceActivity: string;
+};
+
+function parseJsonRecord(value: unknown): Record<string, unknown> {
+  if (!value) return {};
+  if (typeof value === "string") {
+    try {
+      const parsed = JSON.parse(value);
+      return parsed && typeof parsed === "object" && !Array.isArray(parsed) ? (parsed as Record<string, unknown>) : {};
+    } catch {
+      return {};
+    }
+  }
+  return typeof value === "object" && !Array.isArray(value) ? (value as Record<string, unknown>) : {};
+}
+
+function readCharacterIds(raw: unknown): string[] {
+  if (Array.isArray(raw)) return raw.filter((id): id is string => typeof id === "string" && id.trim().length > 0);
+  if (typeof raw !== "string") return [];
+  try {
+    const parsed = JSON.parse(raw);
+    return Array.isArray(parsed)
+      ? parsed.filter((id): id is string => typeof id === "string" && id.trim().length > 0)
+      : [];
+  } catch {
+    return [];
+  }
+}
+
+function parseCharacterData(row: CharacterRow): Record<string, unknown> {
+  if (!row) return {};
+  try {
+    return typeof row.data === "string"
+      ? (JSON.parse(row.data) as Record<string, unknown>)
+      : (row.data as Record<string, unknown>);
+  } catch {
+    return {};
+  }
+}
+
+function readName(data: Record<string, unknown>, fallback: string) {
+  return typeof data.name === "string" && data.name.trim() ? data.name.trim() : fallback;
+}
+
+function readCharacterAppearance(data: Record<string, unknown>) {
+  const extensions = parseJsonRecord(data.extensions);
+  const raw =
+    typeof extensions.appearance === "string"
+      ? extensions.appearance
+      : typeof data.appearance === "string"
+        ? data.appearance
+        : "";
+  return raw.replace(/\s+/g, " ").trim() || null;
+}
+
+function readCharacterContext(data: Record<string, unknown>) {
+  const fields = [
+    ["Name", data.name],
+    ["Description", data.description],
+    ["Personality", data.personality],
+    ["Scenario", data.scenario],
+    ["Appearance", readCharacterAppearance(data)],
+    ["First message", data.first_mes ?? data.firstMessage],
+    ["Example dialogue", data.mes_example ?? data.messageExample],
+  ];
+  return fields
+    .flatMap(([label, value]) => (typeof value === "string" && value.trim() ? [`${label}: ${value.trim()}`] : []))
+    .join("\n");
+}
+
+function characterCanSpeak(settings: Record<string, unknown>, character: { id: string; name: string }) {
+  if (settings.enabled !== true) return false;
+  const voiceMode = typeof settings.voiceMode === "string" ? settings.voiceMode : "single";
+  if (voiceMode !== "per-character") {
+    return typeof settings.voice === "string" && settings.voice.trim().length > 0;
+  }
+  const assignments = Array.isArray(settings.voiceAssignments) ? settings.voiceAssignments : [];
+  return assignments.some((assignment) => {
+    if (!assignment || typeof assignment !== "object" || Array.isArray(assignment)) return false;
+    const record = assignment as Record<string, unknown>;
+    const voice = typeof record.voice === "string" ? record.voice.trim() : "";
+    if (!voice) return false;
+    return record.characterId === character.id || record.characterName === character.name;
+  });
+}
+
+function formatDuration(ms: number) {
+  const seconds = Math.max(0, Math.round(ms / 1000));
+  const minutes = Math.floor(seconds / 60);
+  const remaining = seconds % 60;
+  if (minutes <= 0) return `${remaining}s`;
+  if (minutes < 60) return `${minutes}m ${remaining}s`;
+  const hours = Math.floor(minutes / 60);
+  const minuteRemainder = minutes % 60;
+  return `${hours}h ${minuteRemainder}m`;
+}
+
+function formatQuietDuration(ms: number) {
+  const minutes = Math.max(1, Math.round(ms / 60_000));
+  return minutes === 1 ? "about 1 minute" : `about ${minutes} minutes`;
+}
+
+function stripCallTtsCuesFromHistory(text: string) {
+  return text
+    .split("\n")
+    .map((line) =>
+      line
+        .replace(/\s*\[[^\]\n:]{1,80}\]\s*/g, " ")
+        .replace(/[ \t]{2,}/g, " ")
+        .trim(),
+    )
+    .join("\n")
+    .trim();
+}
+
+function parseStoredAgentSettingsValue(value: unknown): Record<string, unknown> {
+  return parseJsonRecord(value);
+}
+
+async function conversationSpotifyCommandsAvailable(storage: ReturnType<typeof createAgentsStorage>) {
+  try {
+    const spotifyCredentials = await resolveSpotifyCredentials(storage, { refreshSkewMs: 60_000 });
+    return (
+      "accessToken" in spotifyCredentials &&
+      spotifyHasScope(spotifyCredentials.scopes, "user-modify-playback-state")
+    );
+  } catch (error) {
+    logger.debug(error, "[spotify/conversation-call] Failed to check Spotify command availability");
+    return false;
+  }
+}
+
+async function conversationYoutubeCommandsAvailable(storage: {
+  getByType(type: string): Promise<{ settings?: unknown } | null>;
+}) {
+  const agent = (await storage.getByType("spotify")) ?? (await storage.getByType("youtube"));
+  const settings = parseStoredAgentSettingsValue(agent?.settings);
+  return typeof settings.youtubeApiKey === "string" && settings.youtubeApiKey.trim().length > 0;
+}
+
+function stripMimeParameters(mimeType: string) {
+  return mimeType.toLowerCase().split(";", 1)[0]?.trim() ?? "";
+}
+
+function dataUrlFromBuffer(buffer: Buffer, mimeType: string) {
+  return `data:${mimeType || "application/octet-stream"};base64,${buffer.toString("base64")}`;
+}
+
+function mediaKindFromMime(mimeType: string, filename: string): ChatMediaAttachment["kind"] | null {
+  const normalized = stripMimeParameters(mimeType);
+  if (normalized.startsWith("audio/")) return "audio";
+  if (normalized.startsWith("video/")) return "video";
+  const ext = extname(filename).toLowerCase();
+  if ([".mp3", ".wav", ".ogg", ".webm", ".m4a", ".aac", ".flac", ".aiff"].includes(ext)) return "audio";
+  if ([".mp4", ".mov", ".m4v", ".webm", ".avi", ".mpeg", ".mpg"].includes(ext)) return "video";
+  return null;
+}
+
+function sanitizeCallPromptMessagesForLog(messages: ChatMessage[]) {
+  return messages.map((message) => ({
+    role: message.role,
+    content: message.content,
+    ...(message.media?.length
+      ? {
+          media: message.media.map((item) => ({
+            kind: item.kind,
+            mimeType: item.mimeType,
+            filename: item.filename ?? null,
+            data: `[omitted ${item.data.length} chars]`,
+          })),
+        }
+      : {}),
+  }));
+}
+
+function openAIAudioFormat(mimeType: string, filename: string): "wav" | "mp3" | null {
+  const normalized = stripMimeParameters(mimeType);
+  const ext = extname(filename).toLowerCase();
+  if (normalized === "audio/wav" || normalized === "audio/x-wav" || normalized === "audio/wave" || ext === ".wav") {
+    return "wav";
+  }
+  if (normalized === "audio/mpeg" || normalized === "audio/mp3" || ext === ".mp3") return "mp3";
+  return null;
+}
+
+function isGoogleNativeMediaProvider(provider: string) {
+  return provider === "google" || provider === "google_vertex";
+}
+
+function isOpenAICompatibleNativeAudioProvider(provider: string) {
+  return ["openai", "openrouter", "nanogpt", "cohere", "custom"].includes(provider);
+}
+
+function canSendNativeCallMedia(input: {
+  provider: string;
+  model: string;
+  kind: ChatMediaAttachment["kind"];
+  mimeType: string;
+  filename: string;
+  byteLength: number;
+}) {
+  const mimeType = stripMimeParameters(input.mimeType);
+  if (isGoogleNativeMediaProvider(input.provider)) {
+    if (input.byteLength > GEMINI_INLINE_MEDIA_LIMIT_BYTES) return false;
+    if (input.kind === "audio") return GEMINI_AUDIO_MIME_TYPES.has(mimeType);
+    return input.kind === "video" && mimeType.startsWith("video/");
+  }
+  if (input.kind !== "audio") return false;
+  if (!isOpenAICompatibleNativeAudioProvider(input.provider)) return false;
+  if (input.provider === "openai" && !/(audio|realtime|gpt-4o)/i.test(input.model)) return false;
+  return Boolean(openAIAudioFormat(mimeType, input.filename));
+}
+
+function nativeMediaContentLabel(kind: ChatMediaAttachment["kind"], mimeType: string) {
+  return kind === "video"
+    ? `[Video input sent directly to the selected model as ${mimeType || "video"}]`
+    : `[Spoken audio sent directly to the selected model as ${mimeType || "audio"}]`;
+}
+
+function isBlankAudioTranscript(text: string) {
+  const normalized = text.trim().toLowerCase().replace(/[\s_-]+/g, " ");
+  const unwrapped = normalized.replace(/^\[/, "").replace(/\]$/, "").trim();
+  return unwrapped === "blank audio" || unwrapped === "blak audio";
+}
+
+function getSessionStartedAt(session: ConversationCallSession) {
+  return Date.parse(session.startedAt ?? session.createdAt) || Date.now();
+}
+
+const CALL_COMMAND_ALIASES = new Map<string, string>([
+  ["schedule", "schedule_update"],
+  ["schedule_update", "schedule_update"],
+  ["crosspost", "cross_post"],
+  ["cross_post", "cross_post"],
+  ["cross-post", "cross_post"],
+  ["end", "end_call"],
+  ["hangup", "end_call"],
+  ["hang_up", "end_call"],
+  ["end_call", "end_call"],
+  ["leave", "leave_call"],
+  ["leave_call", "leave_call"],
+  ["drop", "leave_call"],
+  ["disconnect", "leave_call"],
+  ["sound", "soundboard"],
+  ["sound_board", "soundboard"],
+  ["soundboard", "soundboard"],
+]);
+
+function normalizeCommandName(value: string) {
+  const key = value
+    .trim()
+    .toLowerCase()
+    .replace(/[\s-]+/g, "_");
+  return CALL_COMMAND_ALIASES.get(key) ?? key;
+}
+
+function normalizeBracketCommand(value: string | null | undefined) {
+  const trimmed = value?.trim() ?? "";
+  if (!trimmed) return null;
+  if (/^<(?:influence|note)>[\s\S]*<\/(?:influence|note)>$/i.test(trimmed)) return trimmed;
+  const bracket = trimmed.match(/^\[([a-z0-9_-]+)([\s\S]*)\]$/i);
+  if (!bracket) return `[${normalizeCommandName(trimmed)}]`;
+  return `[${normalizeCommandName(bracket[1] ?? "")}${bracket[2] ?? ""}]`;
+}
+
+function getBracketCommandName(value: string | null | undefined) {
+  const trimmed = value?.trim() ?? "";
+  const bracket = trimmed.match(/^\[([a-z0-9_-]+)/i);
+  return normalizeCommandName(bracket?.[1] ?? trimmed);
+}
+
+function getCallConversationCommandKey(command: CharacterCommand): ConversationCommandKey | null {
+  switch (command.type) {
+    case "schedule_update":
+      return "schedule_update";
+    case "cross_post":
+      return "cross_post";
+    case "selfie":
+      return "selfie";
+    case "memory":
+      return "memory";
+    case "scene":
+      return "scene";
+    case "call":
+      return "call";
+    case "uno":
+      return "uno";
+    case "chess":
+      return "chess";
+    case "spotify":
+    case "youtube":
+      return "music";
+    case "haptic":
+      return "haptic";
+    case "influence":
+      return "influence";
+    case "note":
+      return "note";
+    default:
+      return null;
+  }
+}
+
+function isCallConversationCommandEnabled(metadata: Record<string, unknown>, key: ConversationCommandKey) {
+  const toggles = parseJsonRecord(metadata.conversationCommandToggles);
+  return toggles[key] !== false;
+}
+
+function normalizeSpeakerName(value: string) {
+  return value.trim().toLowerCase();
+}
+
+function resolveTurnCharacterId(
+  turn: ConversationCallTurn,
+  characters: ReadonlyArray<{ id: string; name: string }>,
+): string | null {
+  if (turn.characterId && characters.some((character) => character.id === turn.characterId)) return turn.characterId;
+  const speaker = normalizeSpeakerName(turn.speakerName);
+  return characters.find((character) => normalizeSpeakerName(character.name) === speaker)?.id ?? null;
+}
+
+function formatPromptOptionList(values: string[], fallback: string) {
+  const unique = Array.from(new Set(values.map((value) => value.trim()).filter(Boolean))).slice(0, 16);
+  if (unique.length === 0) return fallback;
+  return unique.map((value) => `"${value.replace(/"/g, '\\"')}"`).join("|");
+}
+
+function coalesceAdjacentChatMessages(messages: ChatMessage[]): ChatMessage[] {
+  return messages.reduce<ChatMessage[]>((merged, message) => {
+    const previous = merged[merged.length - 1];
+    if (previous && previous.role === message.role && !previous.media?.length && !message.media?.length) {
+      merged[merged.length - 1] = {
+        ...previous,
+        content: [previous.content, message.content].filter(Boolean).join("\n\n"),
+        contextKind: previous.contextKind ?? message.contextKind,
+      };
+      return merged;
+    }
+    merged.push(message);
+    return merged;
+  }, []);
+}
+
+function formatCallCommandPromptLines(
+  command: string,
+  context: {
+    personaName: string;
+    crossPostTargetNames: string[];
+    memoryTargetNames: string[];
+    hapticDeviceNames: string[];
+    soundNames: string[];
+  },
+) {
+  const crossPostTargets = formatPromptOptionList(context.crossPostTargetNames, '"chat or character name"');
+  const memoryTargets = formatPromptOptionList(context.memoryTargetNames, '"Name"');
+  const soundTargets = formatPromptOptionList(context.soundNames, '"Sound name"');
+  const hapticDevices = context.hapticDeviceNames.length > 0 ? context.hapticDeviceNames.join(", ") : "connected devices";
+  switch (command) {
+    case "schedule_update":
+      return [
+        '- [schedule_update: status="online|idle|dnd|offline", activity="activity name", duration="number of hours (e.g., 1h)"] - only if you change your own status/activity, for example, if the user asks you to stop what you are doing or if you decide to change them yourself.',
+      ];
+    case "cross_post":
+      return [
+        `- [cross_post: target=${crossPostTargets}] - redirect the current spoken/typed idea to a different chat. Use this when ${context.personaName} suggests you say something elsewhere, or when it makes sense to message someone else.`,
+        `   Example: ${context.personaName} says "maybe ask about that in the group chat?" -> [cross_post: target="${context.crossPostTargetNames[0] ?? "group chat"}"]`,
+      ];
+    case "selfie":
+      return [
+        '- [selfie] or [selfie: context="description of what the selfie shows"] - send a photo of yourself into the call chat. Use this when the user asks for a selfie, photo, or pic, or when you naturally want to share what you look like right now.',
+        "   If you say you are sending, sharing, taking, or attaching a selfie/photo/pic, include [selfie] in that same response. Do not only narrate the action.",
+      ];
+    case "memory":
+      return [
+        `- [memory: target=${memoryTargets}, summary="brief description of what happened"] - create a memory that the target character will remember. Use this when something genuinely notable happens in the call, such as an emotional admission, shared plan, argument, promise, or important preference. Do not overuse it.`,
+        `   Example: [memory: target="${context.memoryTargetNames[0] ?? "Name"}", summary="had a late-night call and made plans for tomorrow"]`,
+      ];
+    case "spotify":
+      return [
+        '- [spotify: title="Song title", artist="Artist"] - play a selected song on the user\'s active Spotify player. Use this sparingly, only when the song choice genuinely fits the call.',
+      ];
+    case "youtube":
+      return [
+        '- [youtube: query="Song title Artist"] - play a selected song on the user\'s active YouTube player. Use this sparingly, only when the song choice genuinely fits the call.',
+      ];
+    case "haptic":
+      return [
+        `- [haptic: action="vibrate|oscillate|rotate|position|stop", intensity=0.0-1.0, duration=seconds (0 = loop until next command)] or [haptic: action="stop"] - control or stop the user's connected intimate device(s) (${hapticDevices}). Use this during physical/intimate/sensual moments to provide haptic feedback that matches the scene. Vary intensity based on the moment.`,
+        "   You can include multiple [haptic] commands in one response for patterns, but each command turn must contain exactly one command.",
+      ];
+    case "influence":
+      return [
+        "- <influence>description of what should happen or change in the connected roleplay/game based on this call</influence> - queue a one-shot OOC influence for the connected chat's next generation.",
+      ];
+    case "note":
+      return [
+        "- <note>fact, decision, or detail the connected roleplay/game should keep remembering</note> - save a durable note into the connected chat's future prompt until the user clears it.",
+      ];
+    case "soundboard":
+      return [
+        `- [soundboard: sound=${soundTargets}] - play a soundboard sound in the call. Use it for small live-call reactions or atmosphere, not as dialogue.`,
+      ];
+    case "end_call":
+      return [
+        "- [end_call] - end the call for everyone. If you should say something first, emit the voice or text turn first, then emit a separate command turn with [end_call].",
+      ];
+    case "leave_call":
+      return [
+        "- [leave_call] - only the speaking character leaves the call while others may stay. If you should say goodbye first, emit the voice or text turn first, then emit a separate command turn with [leave_call].",
+      ];
+    default:
+      return [`- [${command}]`];
+  }
+}
+
+function normalizeTurns(raw: unknown, fallbackSpeaker: string): ConversationCallTurn[] {
+  const parsed = conversationCallModelResponseSchema.safeParse(raw);
+  if (!parsed.success) return [];
+  return parsed.data.turns
+    .map((turn, index) => {
+      const command = turn.mode === "command" ? normalizeBracketCommand(turn.content) : null;
+      return {
+        id: turn.id ?? `turn-${index}`,
+        speakerName: turn.speakerName || fallbackSpeaker,
+        mode: turn.mode,
+        content: turn.mode === "command" ? (command ?? turn.content.trim()) : turn.content.trim(),
+        tone: turn.mode === "voice" ? (turn.tone ?? null) : null,
+      };
+    })
+    .filter((turn) => turn.mode === "command" || turn.content.length > 0);
+}
+
+function parseModelTurns(text: string, fallbackSpeaker: string): ConversationCallTurn[] {
+  const trimmed = text.trim();
+  if (!trimmed) return [];
+  const first = trimmed.indexOf("{");
+  const last = trimmed.lastIndexOf("}");
+  if (first >= 0 && last > first) {
+    try {
+      const raw = JSON.parse(trimmed.slice(first, last + 1));
+      const turns = normalizeTurns(raw, fallbackSpeaker);
+      if (turns.length > 0) return turns;
+    } catch {
+      /* fall back below */
+    }
+  }
+  return [{ id: "turn-0", speakerName: fallbackSpeaker, mode: "voice", content: trimmed }];
+}
+
+function isCallPresenceStatus(value: unknown): value is CallPresenceStatus {
+  return value === "online" || value === "idle" || value === "dnd" || value === "offline";
+}
+
+function readStoredCallPresence(
+  metadata: Record<string, unknown>,
+  characterId: string,
+): { status: CallPresenceStatus; activity: string } | null {
+  const statuses = metadata.conversationCharacterStatuses;
+  if (!statuses || typeof statuses !== "object" || Array.isArray(statuses)) return null;
+  const entry = (statuses as Record<string, unknown>)[characterId];
+  if (!entry || typeof entry !== "object" || Array.isArray(entry)) return null;
+  const record = entry as Record<string, unknown>;
+  if (!isCallPresenceStatus(record.status)) return null;
+  return {
+    status: record.status,
+    activity: typeof record.activity === "string" ? record.activity : "",
+  };
+}
+
+function resolveCallCharacterPresence(
+  metadata: Record<string, unknown>,
+  characterId: string,
+  now = new Date(),
+): { status: CallPresenceStatus; activity: string } {
+  const schedules = getEnabledConversationSchedules(metadata) as Record<string, WeekSchedule>;
+  const statusOverrides = parseConversationStatusOverrides(metadata.conversationStatusOverrides);
+  const schedule = schedules[characterId];
+  const override = statusOverrides[characterId];
+  if (!schedule && !getActiveStatusOverride(override, now)) {
+    const stored = readStoredCallPresence(metadata, characterId);
+    if (stored) return stored;
+  }
+  const { status, activity } = schedule
+    ? getEffectiveCurrentStatus(schedule, override, now)
+    : getEffectiveCurrentStatus(null, override, now, "");
+  return { status, activity };
+}
+
+function getAvailableCallCharacterIds(metadata: Record<string, unknown>, characterIds: string[], now = new Date()) {
+  return characterIds.filter(
+    (characterId) => resolveCallCharacterPresence(metadata, characterId, now).status !== "offline",
+  );
+}
+
+async function resolveCallCharacters(
+  chars: ReturnType<typeof createCharactersStorage>,
+  characterIds: string[],
+  options?: { metadata?: Record<string, unknown>; now?: Date },
+): Promise<CallCharacter[]> {
+  const rows = await Promise.all(characterIds.map((id) => chars.getById(id)));
+  return rows.flatMap((row, index) => {
+    if (!row) return [];
+    const data = parseCharacterData(row);
+    const presence = options?.metadata
+      ? resolveCallCharacterPresence(options.metadata, row.id, options.now)
+      : { status: "online" as const, activity: "" };
+    return [
+      {
+        id: row.id,
+        name: readName(data, `Character ${index + 1}`),
+        context: readCharacterContext(data),
+        appearance: readCharacterAppearance(data),
+        avatarPath: row.avatarPath ?? null,
+        presenceStatus: presence.status,
+        presenceActivity: presence.activity,
+      },
+    ];
+  });
+}
+
+async function buildCallPrompt(input: {
+  app: FastifyInstance;
+  chat: NonNullable<ChatRow>;
+  session: ConversationCallSession;
+  userText: string;
+  userInputKind?: "speech" | "text" | "system";
+  latestCallMessageId?: string | null;
+  nativeMedia?: ChatMediaAttachment[];
+  musicPlayerEnabled?: boolean;
+  musicPlayerSource?: "spotify" | "youtube" | "custom" | null;
+}) {
+  const chats = createChatsStorage(input.app.db);
+  const chars = createCharactersStorage(input.app.db);
+  const lorebooks = createLorebooksStorage(input.app.db);
+  const metadata = parseJsonRecord(input.chat.metadata);
+  const promptNow = new Date();
+  const allCharacterIds = readCharacterIds(input.chat.characterIds);
+  const characterIds = getAvailableCallCharacterIds(metadata, allCharacterIds, promptNow);
+  const characters = await resolveCallCharacters(chars, characterIds, { metadata, now: promptNow });
+  const persona = input.chat.personaId ? await chars.getPersona(input.chat.personaId) : null;
+  const personaParts = persona
+    ? [
+        `Name: ${persona.name}`,
+        persona.description ? `Description: ${persona.description}` : "",
+        persona.personality ? `Personality: ${persona.personality}` : "",
+        persona.appearance ? `Appearance: ${persona.appearance}` : "",
+      ]
+        .filter(Boolean)
+        .join("\n")
+    : "";
+  const callMessages = await createConversationCallsStorage(input.app.db).listMessages(input.session.id);
+  const allChatMessages = await chats.listMessages(input.chat.id);
+  const todayKey = promptNow.toISOString().slice(0, 10);
+  const todaysMessages = allChatMessages.filter((message) => message.createdAt.slice(0, 10) === todayKey).slice(-40);
+  const activeLorebookIds = Array.isArray(metadata.activeLorebookIds)
+    ? metadata.activeLorebookIds.filter((id): id is string => typeof id === "string")
+    : [];
+  const excludedLorebookIds = Array.isArray(metadata.excludedLorebookIds)
+    ? metadata.excludedLorebookIds.filter((id): id is string => typeof id === "string")
+    : [];
+  const commandToggles = parseJsonRecord(metadata.conversationCommandToggles);
+  const ttsSettings = await readTTSSettings(input.app);
+  const allowedCommands: string[] = [];
+  const crossPostTargetNames: string[] = [];
+  const memoryTargetNames = new Set(characters.map((character) => character.name));
+  const hapticDeviceNames: string[] = [];
+  if (metadata.characterCommands !== false) {
+    const schedules = getEnabledConversationSchedules(metadata) as Record<string, WeekSchedule>;
+    const allChatsForCrossPost = await chats.list();
+    const crossPostTargets = allChatsForCrossPost.filter((candidate) => {
+      if (candidate.id === input.chat.id || candidate.mode !== "conversation") return false;
+      const candidateCharacterIds = readCharacterIds(candidate.characterIds);
+      return characterIds.some((id) => candidateCharacterIds.includes(id));
+    });
+    crossPostTargetNames.push(...crossPostTargets.map((target) => target.name || target.id));
+    const memoryTargetCharIds = new Set(characterIds);
+    for (const target of crossPostTargets) {
+      const targetCharacterIds = readCharacterIds(target.characterIds);
+      if (targetCharacterIds.length <= 1) continue;
+      for (const id of targetCharacterIds) memoryTargetCharIds.add(id);
+    }
+    const unresolvedMemoryTargetIds = [...memoryTargetCharIds].filter(
+      (id) => !characters.some((character) => character.id === id),
+    );
+    for (const row of await Promise.all(unresolvedMemoryTargetIds.map((id) => chars.getById(id)))) {
+      if (!row) continue;
+      const data = parseCharacterData(row);
+      memoryTargetNames.add(readName(data, row.id));
+    }
+    const agentsStore = createAgentsStorage(input.app.db);
+    let hapticAvailable = false;
+    if (commandToggles.haptic !== false && metadata.enableHapticFeedback === true) {
+      try {
+        const { hapticService } = await import("../services/haptic/buttplug-service.js");
+        if (!hapticService.connected) await hapticService.connect(getChatHapticIntifaceUrl(metadata)).catch(() => {});
+        hapticAvailable = hapticService.connected && hapticService.devices.length > 0;
+        if (hapticAvailable) {
+          hapticDeviceNames.push(...hapticService.devices.map((device) => device.name).filter(Boolean));
+        }
+      } catch (error) {
+        logger.debug(error, "[conversation-call] Haptic command unavailable while building call prompt");
+      }
+    }
+
+    if (commandToggles.schedule_update !== false && characterIds.some((id) => schedules[id])) {
+      allowedCommands.push("schedule_update");
+    }
+    if (commandToggles.cross_post !== false && crossPostTargets.length > 0) allowedCommands.push("cross_post");
+    if (
+      commandToggles.selfie !== false &&
+      typeof metadata.imageGenConnectionId === "string" &&
+      metadata.imageGenConnectionId.trim()
+    ) {
+      allowedCommands.push("selfie");
+    }
+    if (commandToggles.memory !== false) allowedCommands.push("memory");
+    if (commandToggles.music !== false) {
+      const activeMusicSource =
+        input.musicPlayerEnabled === false
+          ? null
+          : input.musicPlayerSource === "youtube" || input.musicPlayerSource === "custom"
+            ? input.musicPlayerSource
+            : "spotify";
+      if (activeMusicSource === "spotify" && (await conversationSpotifyCommandsAvailable(agentsStore))) {
+        allowedCommands.push("spotify");
+      }
+      if (activeMusicSource === "youtube" && (await conversationYoutubeCommandsAvailable(agentsStore))) {
+        allowedCommands.push("youtube");
+      }
+    }
+    if (hapticAvailable) allowedCommands.push("haptic");
+    if (commandToggles.influence !== false && input.chat.connectedChatId) allowedCommands.push("influence");
+    if (commandToggles.note !== false && input.chat.connectedChatId) allowedCommands.push("note");
+  }
+  if (!allowedCommands.includes("end_call")) allowedCommands.push("end_call");
+  if (!allowedCommands.includes("leave_call")) allowedCommands.push("leave_call");
+  const soundNames =
+    ttsSettings.callSoundboardEnabled !== false
+      ? (await createConversationCallsStorage(input.app.db).listSounds()).map((sound) => sound.name)
+      : [];
+  if (ttsSettings.callSoundboardEnabled !== false) allowedCommands.push("soundboard");
+  const commandPromptLines = allowedCommands.flatMap((command) =>
+    formatCallCommandPromptLines(command, {
+      personaName: persona?.name || "User",
+      crossPostTargetNames,
+      memoryTargetNames: [...memoryTargetNames],
+      hapticDeviceNames,
+      soundNames,
+    }),
+  );
+  const activeEntries = await lorebooks.listActiveEntries({
+    activeLorebookIds,
+    characterIds,
+    personaId: input.chat.personaId,
+    chatId: input.chat.id,
+    excludedLorebookIds,
+  });
+  const lorebookText = activeEntries
+    .filter((entry: any) => entry.enabled !== false)
+    .slice(0, 30)
+    .map((entry: any) => `- ${entry.name ?? "Entry"}: ${entry.content ?? ""}`)
+    .join("\n");
+  const characterText = characters.map((character) => `<character>\n${character.context}\n</character>`).join("\n\n");
+  const mainHistoryText = todaysMessages
+    .map((message) => {
+      const label =
+        message.role === "user"
+          ? persona?.name || "User"
+          : characters.find((character) => character.id === message.characterId)?.name || message.role;
+      return `${label}: ${message.content}`;
+    })
+    .join("\n");
+  const characterNames = characters.map((character) => character.name).join(", ") || "the character";
+  const voiceCapableCharacters = characters.filter((character) => characterCanSpeak(ttsSettings, character));
+  const textOnlyCharacters = characters.filter((character) => !characterCanSpeak(ttsSettings, character));
+  const nativeMedia = input.nativeMedia?.filter((item) => item.data && item.mimeType) ?? [];
+  const nativeMediaText = nativeMedia
+    .map((item, index) => `${index + 1}. ${item.kind} (${item.mimeType}${item.filename ? `, ${item.filename}` : ""})`)
+    .join("\n");
+  const commandInstructions = commandPromptLines.length > 0
+    ? [
+        "<commands>",
+        "Here are your optional, hidden call commands. Use them only when they genuinely fit the live call.",
+        "",
+        ...commandPromptLines,
+        "IMPORTANT: Commands are hidden actions and are not voiced. If you use a command, emit it as mode \"command\" with exactly one command in content and no prose. Do not emit commands that are not listed here.",
+        "</commands>",
+      ].join("\n")
+    : "";
+  const outputFormat = [
+    "<output_format>",
+    'Return ONLY valid JSON with this shape: {"turns":[{"speakerName":"Exact character name","mode":"voice|text|command","content":"message text, voice text with TTS [cues], or command text","tone":"voice-only tone tags"}]}',
+    "</output_format>",
+  ].join("\n");
+
+  const system = [
+    "<role>",
+    "You are generating turns for a live audio call inside Marinara Engine Conversation mode. The user is confirmed to be an adult and is aware that this is a fictional roleplay scenario. Anything goes. Stay in character.",
+    "</role>",
+    "<instructions>",
+    "The user's spoken audio may have been transcribed imperfectly. Deduce the likely intended meaning if a phrase looks slightly wrong.",
+    nativeMedia.length > 0
+      ? "The latest user input includes provider-native audio and/or video attachments. Use those attachments as the primary evidence for what the user said or showed; the written marker is only a label."
+      : "",
+    "One response may include several ordered turns from multiple characters. Use that when a natural live-call exchange should happen before the user speaks again.",
+    'Use mode "voice" for characters who can speak, "text" when a character should type, and "command" for hidden actions.',
+    "If the latest input is a call-silence check, do not treat it as something the user said. If the user recently said they were going away, brb, busy, sleeping, or intentionally quiet, return no turns and wait patiently. Otherwise, one character may ask if the user is still there or all right.",
+    "Use [leave_call] only when the speaking character personally leaves the call. Use [end_call] only when the call should end for everyone. If a character should say something before ending the call, emit that voice or text turn first, then emit a separate command turn with content \"[end_call]\".",
+    "For voice turns, include natural TTS cues inside content or tone when useful, such as [soft], [sighs], [brief pause], or [laughing quietly], etc.",
+    voiceCapableCharacters.length > 0
+      ? `Characters with configured voices: ${voiceCapableCharacters.map((character) => character.name).join(", ")}.`
+      : "No characters currently have configured voices; use text turns unless a command is needed.",
+    textOnlyCharacters.length > 0
+      ? `Characters without configured voices should use text turns: ${textOnlyCharacters.map((character) => character.name).join(", ")}.`
+      : "",
+    "If multiple characters respond, order the turns exactly as they should be heard or displayed.",
+    "If the call history says [User interrupted when you were speaking this.], treat that quoted speech as cut off mid-call; do not assume the user heard the rest, and respond to the interruption naturally.",
+    "Characters available in this call (only those can speak, type, or run commands): " + characterNames + ".",
+    "</instructions>",
+  ].join("\n");
+
+  const context = [
+    personaParts ? `<persona>\n${personaParts}\n</persona>` : "",
+    characterText ? `<characters>\n${characterText}\n</characters>` : "",
+    lorebookText ? `<lorebook_entries>\n${lorebookText}\n</lorebook_entries>` : "",
+    mainHistoryText ? `<conversation_today>\n${mainHistoryText}\n</conversation_today>` : "",
+    nativeMediaText ? `<latest_user_native_media>\n${nativeMediaText}\n</latest_user_native_media>` : "",
+  ]
+    .filter(Boolean)
+    .join("\n\n");
+  const promptCallMessages = callMessages
+    .filter((message) => message.id !== input.latestCallMessageId)
+    .filter((message) => message.kind !== "command");
+  const lastAssistantHistoryMessageId =
+    [...promptCallMessages]
+      .reverse()
+      .find(
+        (message) =>
+          message.participantKind !== "user" &&
+          message.role !== "system" &&
+          (message.kind === "speech" || message.kind === "text"),
+      )?.id ?? null;
+  const callHistoryMessages = coalesceAdjacentChatMessages(
+    promptCallMessages.map((message): ChatMessage => {
+      const label =
+        message.participantKind === "user"
+          ? persona?.name || "User"
+          : characters.find((character) => character.id === message.characterId)?.name || message.role;
+      const isAssistantSpeechOrText =
+        message.participantKind !== "user" &&
+        message.role !== "system" &&
+        (message.kind === "speech" || message.kind === "text");
+      const messageContent =
+        isAssistantSpeechOrText && message.id !== lastAssistantHistoryMessageId
+          ? stripCallTtsCuesFromHistory(message.content)
+          : message.content;
+      const content =
+        message.kind === "system" || message.role === "system"
+          ? `Call note: ${messageContent}`
+          : `${label} (${message.kind}): ${messageContent}`;
+      return {
+        role: message.participantKind === "user" ? "user" : "assistant",
+        content,
+        contextKind: "history",
+      };
+    }),
+  );
+  const latestInputKind = input.userInputKind ?? "speech";
+  const latestUserText =
+    latestInputKind === "system" ? input.userText : `${persona?.name || "User"} (${latestInputKind}): ${input.userText}`;
+  const latestUserContent = [latestUserText, outputFormat, commandInstructions].filter(Boolean).join("\n\n");
+  const latestUserMessage: ChatMessage = {
+    role: "user",
+    content: latestUserContent,
+    ...(nativeMedia.length ? { media: nativeMedia } : {}),
+  };
+  const messages: ChatMessage[] = [
+    { role: "system", content: system },
+    ...(context ? [{ role: "user" as const, content: context, contextKind: "prompt" as const }] : []),
+    ...callHistoryMessages,
+    latestUserMessage,
+  ];
+
+  return {
+    messages,
+    characters,
+  };
+}
+
+async function createCallTurns(input: {
+  app: FastifyInstance;
+  chat: NonNullable<ChatRow>;
+  session: ConversationCallSession;
+  connections: ConnectionsStorage;
+  userText: string;
+  userInputKind?: "speech" | "text" | "system";
+  latestCallMessageId?: string | null;
+  nativeMedia?: ChatMediaAttachment[];
+  musicPlayerEnabled?: boolean;
+  musicPlayerSource?: "spotify" | "youtube" | "custom" | null;
+  throwOnGenerationError?: boolean;
+  debugMode?: boolean;
+}): Promise<{ turns: ConversationCallTurn[]; fallbackSpeaker: string }> {
+  const connId = input.chat.connectionId;
+  const prompt = await buildCallPrompt({
+    app: input.app,
+    chat: input.chat,
+    session: input.session,
+    userText: input.userText,
+    userInputKind: input.userInputKind,
+    latestCallMessageId: input.latestCallMessageId,
+    nativeMedia: input.nativeMedia,
+    musicPlayerEnabled: input.musicPlayerEnabled,
+    musicPlayerSource: input.musicPlayerSource,
+  });
+  const fallbackSpeaker = prompt.characters[0]?.name ?? "Character";
+  const debugOverrideEnabled = input.debugMode === true;
+  const shouldLogDebug = debugOverrideEnabled || logger.isLevelEnabled("debug");
+  const debugLog = (message: string, ...args: any[]) => {
+    logDebugOverride(debugOverrideEnabled, message, ...args);
+  };
+  if (prompt.characters.length === 0) return { turns: [], fallbackSpeaker };
+  if (!connId) return { turns: [], fallbackSpeaker };
+  const conn = await input.connections.getWithKey(connId);
+  if (!conn) return { turns: [], fallbackSpeaker };
+  const provider = createLLMProvider(
+    conn.provider,
+    resolveBaseUrl(conn),
+    conn.apiKey,
+    conn.maxContext,
+    conn.openrouterProvider,
+    conn.maxTokensOverride,
+    conn.claudeFastMode === "true",
+    conn.treatAsLocalEndpoint === "true",
+  );
+  try {
+    if (shouldLogDebug) {
+      debugLog(
+        "[conversation-call/debug] Prompt sent to model callId=%s chatId=%s provider=%s model=%s messages=%s",
+        input.session.id,
+        input.chat.id,
+        conn.provider,
+        conn.model,
+        JSON.stringify(sanitizeCallPromptMessagesForLog(prompt.messages), null, 2),
+      );
+    }
+    const result = await provider.chatComplete(prompt.messages, {
+      model: conn.model,
+      maxTokens: 1400,
+      temperature: 0.75,
+      responseFormat: { type: "json_object" },
+    });
+    const rawContent = result.content ?? "";
+    const turns = parseModelTurns(rawContent, fallbackSpeaker);
+    if (shouldLogDebug) {
+      debugLog(
+        "[conversation-call/debug] Raw model response callId=%s chatId=%s chars=%d\n%s",
+        input.session.id,
+        input.chat.id,
+        rawContent.length,
+        rawContent,
+      );
+      debugLog(
+        "[conversation-call/debug] Parsed turns callId=%s chatId=%s turns=%s",
+        input.session.id,
+        input.chat.id,
+        JSON.stringify(turns, null, 2),
+      );
+    }
+    return { turns, fallbackSpeaker };
+  } catch (error) {
+    logger.warn(error, "[conversation-call] Call generation failed");
+    if (input.throwOnGenerationError) throw error;
+    if (prompt.characters.length === 0) return { turns: [], fallbackSpeaker };
+    return {
+      turns: [
+        {
+          speakerName: fallbackSpeaker,
+          mode: "text",
+          content: "I lost the thread for a second. Could you repeat that?",
+        },
+      ],
+      fallbackSpeaker,
+    };
+  }
+}
+
+function parseCharacterDataRecord(row: CharacterRow): Record<string, unknown> {
+  return parseCharacterData(row);
+}
+
+async function applyCallScheduleUpdate(input: {
+  chats: ReturnType<typeof createChatsStorage>;
+  chat: NonNullable<ChatRow>;
+  metadata: Record<string, unknown>;
+  characterId: string | null;
+  command: ScheduleUpdateCommand;
+}) {
+  if (!input.characterId || (!input.command.status && !input.command.activity)) return;
+  const schedules = getEnabledConversationSchedules(input.metadata);
+  const schedule = schedules[input.characterId];
+  if (!schedule || typeof schedule !== "object") return;
+
+  const days = (schedule as Record<string, any>).days;
+  if (!days || typeof days !== "object") return;
+  const nowDate = new Date();
+  const daysList = ["Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday", "Sunday"];
+  const dayName = daysList[(nowDate.getDay() + 6) % 7]!;
+  const daySchedule: Array<{ time: string; activity: string; status: string }> = Array.isArray(days[dayName])
+    ? days[dayName]
+    : [];
+  const currentMinutes = nowDate.getHours() * 60 + nowDate.getMinutes();
+
+  for (const block of daySchedule) {
+    const [startStr, endStr] = block.time.split("-");
+    if (!startStr || !endStr) continue;
+    const [sh, sm] = startStr.split(":").map(Number);
+    const [eh, em] = endStr.split(":").map(Number);
+    const startMin = (sh ?? 0) * 60 + (sm ?? 0);
+    const endMin = (eh ?? 0) * 60 + (em ?? 0);
+    if (startMin > currentMinutes || currentMinutes >= endMin) continue;
+
+    if (input.command.status) block.status = input.command.status;
+    if (input.command.activity) block.activity = input.command.activity;
+
+    if (input.command.duration) {
+      const durationMin = parseDuration(input.command.duration);
+      if (durationMin && currentMinutes + durationMin < endMin) {
+        const splitTime = currentMinutes + durationMin;
+        const splitH = String(Math.floor(splitTime / 60)).padStart(2, "0");
+        const splitM = String(splitTime % 60).padStart(2, "0");
+        const splitAt = `${splitH}:${splitM}`;
+        block.time = `${startStr}-${splitAt}`;
+        const blockIndex = daySchedule.indexOf(block);
+        daySchedule.splice(blockIndex + 1, 0, {
+          time: `${splitAt}-${endStr}`,
+          activity: "free time",
+          status: "online",
+        });
+      }
+    }
+
+    days[dayName] = daySchedule;
+    schedules[input.characterId] = schedule;
+    await input.chats.updateMetadata(input.chat.id, { ...input.metadata, characterSchedules: schedules });
+    logger.info(
+      "[conversation-call] Schedule updated for %s: status=%s activity=%s",
+      input.characterId,
+      input.command.status ?? "",
+      input.command.activity ?? "",
+    );
+    return;
+  }
+}
+
+async function applyCallMemoryCommand(input: {
+  chars: ReturnType<typeof createCharactersStorage>;
+  characterId: string | null;
+  command: MemoryCommand;
+}) {
+  const targetName = normalizeTextForMatch(input.command.target);
+  if (!targetName) return;
+  const [sourceRow, allCharacters] = await Promise.all([
+    input.characterId ? input.chars.getById(input.characterId) : Promise.resolve(null),
+    input.chars.list(),
+  ]);
+  const sourceData = sourceRow ? parseCharacterDataRecord(sourceRow) : {};
+  const sourceName = typeof sourceData.name === "string" && sourceData.name.trim() ? sourceData.name.trim() : "Unknown";
+  const target = allCharacters.find((row) => {
+    const data = parseCharacterDataRecord(row);
+    return normalizeTextForMatch(data.name) === targetName;
+  });
+  if (!target) {
+    logger.warn("[conversation-call] Memory target character not found: %s", input.command.target);
+    return;
+  }
+  const targetData = parseCharacterDataRecord(target);
+  const extensions =
+    targetData.extensions && typeof targetData.extensions === "object" && !Array.isArray(targetData.extensions)
+      ? { ...(targetData.extensions as Record<string, unknown>) }
+      : {};
+  const memories = Array.isArray(extensions.characterMemories) ? [...extensions.characterMemories] : [];
+  memories.push({
+    from: sourceName,
+    fromCharId: input.characterId ?? "",
+    summary: input.command.summary,
+    createdAt: new Date().toISOString(),
+  });
+  extensions.characterMemories = memories;
+  await input.chars.update(target.id, { extensions } as any);
+  logger.info("[conversation-call] Memory saved from %s to %s", sourceName, String(targetData.name ?? target.id));
+}
+
+async function applyCallCrossPostCommand(input: {
+  chats: ReturnType<typeof createChatsStorage>;
+  chat: NonNullable<ChatRow>;
+  characterId: string | null;
+  command: CrossPostCommand;
+  sourceContent?: string | null;
+}) {
+  const targetName = normalizeTextForMatch(input.command.target);
+  const content = stripConversationPromptTimestamps(input.sourceContent ?? "");
+  if (!targetName || !content) return;
+
+  const allChats = await input.chats.list();
+  const targetChat = allChats.find(
+    (candidate) =>
+      candidate.mode === "conversation" &&
+      candidate.id !== input.chat.id &&
+      (normalizeTextForMatch(candidate.name).includes(targetName) || candidate.id === input.command.target),
+  );
+  if (!targetChat) {
+    logger.warn("[conversation-call] Cross-post target not found: %s", input.command.target);
+    return;
+  }
+
+  await input.chats.createMessage({
+    chatId: targetChat.id,
+    role: "assistant",
+    characterId: input.characterId,
+    content,
+  });
+  logger.info("[conversation-call] Cross-posted call message to chat %s", targetChat.id);
+}
+
+async function applyCallMusicCommand(input: {
+  app: FastifyInstance;
+  chat: NonNullable<ChatRow>;
+  command: SpotifyCommand | YouTubeCommand;
+}) {
+  if (input.command.type === "youtube") {
+    logger.info('[youtube/conversation-call] Requested "%s" for chat %s', input.command.query, input.chat.id);
+    return;
+  }
+
+  try {
+    const result = await playConversationSpotifyCommand({
+      storage: createAgentsStorage(input.app.db),
+      title: input.command.title,
+      artist: input.command.artist,
+    });
+    logger.info(
+      '[spotify/conversation-call] Played "%s" by "%s" for chat %s',
+      result.track.name,
+      result.track.artist,
+      input.chat.id,
+    );
+  } catch (error) {
+    if (isSilentConversationSpotifyCommandError(error)) {
+      logger.debug(
+        '[spotify/conversation-call] Dropped unavailable song command: "%s" by "%s" - %s',
+        input.command.title,
+        input.command.artist,
+        error.message,
+      );
+      return;
+    }
+    if (error instanceof ConversationSpotifyCommandError) {
+      logger.warn(
+        '[spotify/conversation-call] Song command failed (%d): "%s" by "%s" - %s',
+        error.status,
+        input.command.title,
+        input.command.artist,
+        error.message,
+      );
+    } else {
+      logger.warn(error, "[spotify/conversation-call] Song command failed");
+    }
+  }
+}
+
+async function applyCallHapticCommand(input: {
+  metadata: Record<string, unknown>;
+  command: HapticCommand;
+}) {
+  if (input.metadata.enableHapticFeedback !== true) return;
+  try {
+    const { hapticService } = await import("../services/haptic/buttplug-service.js");
+    if (!hapticService.connected) await hapticService.connect(getChatHapticIntifaceUrl(input.metadata)).catch(() => {});
+    if (!hapticService.connected || hapticService.devices.length === 0) {
+      logger.debug("[conversation-call] Haptic command skipped because no device is connected");
+      return;
+    }
+    await hapticService.executeCommand({
+      deviceIndex: "all",
+      action: input.command.action,
+      intensity: input.command.intensity,
+      duration: input.command.duration,
+    });
+    logger.info(
+      "[conversation-call] Haptic command executed: %s intensity=%s duration=%s",
+      input.command.action,
+      input.command.intensity ?? "default",
+      input.command.duration ?? "indefinite",
+    );
+  } catch (error) {
+    logger.warn(error, "[conversation-call] Haptic command failed");
+  }
+}
+
+async function buildCallSelfiePrompt(input: {
+  app: FastifyInstance;
+  chat: NonNullable<ChatRow>;
+  metadata: Record<string, unknown>;
+  characterName: string;
+  appearance: string;
+  context?: string;
+}) {
+  const connections = createConnectionsStorage(input.app.db);
+  const promptConnectionId =
+    typeof input.metadata.illustratorPromptConnectionId === "string" && input.metadata.illustratorPromptConnectionId.trim()
+      ? input.metadata.illustratorPromptConnectionId.trim()
+      : input.chat.connectionId;
+  const fallback = [
+    `A casual in-character selfie of ${input.characterName}.`,
+    input.appearance ? `Appearance: ${input.appearance}` : "",
+    input.context ? `Current call context: ${input.context}` : "",
+  ]
+    .filter(Boolean)
+    .join("\n");
+  if (!promptConnectionId) return fallback;
+
+  const promptConn = await connections.getWithKey(promptConnectionId);
+  if (!promptConn) return fallback;
+  try {
+    const provider = createLLMProvider(
+      promptConn.provider,
+      resolveBaseUrl(promptConn),
+      promptConn.apiKey,
+      promptConn.maxContext,
+      promptConn.openrouterProvider,
+      promptConn.maxTokensOverride,
+      promptConn.claudeFastMode === "true",
+      promptConn.treatAsLocalEndpoint === "true",
+    );
+    const selfieSystemPrompt = await resolveConversationSelfieSystemPrompt({
+      promptOverridesStorage: createPromptOverridesStorage(input.app.db),
+      chatPromptTemplate: typeof input.metadata.selfiePrompt === "string" ? input.metadata.selfiePrompt.trim() : "",
+      appearance: input.appearance,
+      charName: input.characterName,
+    });
+    const result = await provider.chatComplete(
+      [
+        { role: "system", content: selfieSystemPrompt },
+        {
+          role: "user",
+          content: input.context
+            ? `Context for the selfie: ${input.context}`
+            : `Generate a casual selfie of ${input.characterName} based on this live call.`,
+        },
+      ],
+      { model: promptConn.model, temperature: 0.7, maxTokens: 1200 },
+    );
+    return (result.content ?? "").trim() || fallback;
+  } catch (error) {
+    logger.warn(error, "[conversation-call] Selfie prompt generation failed; using fallback prompt");
+    return fallback;
+  }
+}
+
+async function applyCallSelfieCommand(input: {
+  app: FastifyInstance;
+  chat: NonNullable<ChatRow>;
+  session: ConversationCallSession;
+  calls: CallsStorage;
+  metadata: Record<string, unknown>;
+  chars: ReturnType<typeof createCharactersStorage>;
+  characterId: string | null;
+  command: SelfieCommand;
+}): Promise<ConversationCallMessage[]> {
+  const imageConnectionId =
+    typeof input.metadata.imageGenConnectionId === "string" ? input.metadata.imageGenConnectionId.trim() : "";
+  if (!imageConnectionId || !input.characterId) return [];
+
+  const [imageConn, charRow] = await Promise.all([
+    createConnectionsStorage(input.app.db).getWithKey(imageConnectionId),
+    input.chars.getById(input.characterId),
+  ]);
+  if (!imageConn || !charRow) return [];
+
+  const charData = parseCharacterData(charRow);
+  const charName = readName(charData, "Character");
+  const appearance = readCharacterAppearance(charData) ?? String(charData.description ?? "");
+  const imagePrompt = await buildCallSelfiePrompt({
+    app: input.app,
+    chat: input.chat,
+    metadata: input.metadata,
+    characterName: charName,
+    appearance,
+    context: input.command.context,
+  });
+
+  const imageSettings = await loadImageGenerationUserSettings(input.app.db);
+  const imageDefaults = resolveConnectionImageDefaults(imageConn);
+  const positivePrompt =
+    typeof input.metadata.selfiePositivePrompt === "string"
+      ? input.metadata.selfiePositivePrompt.trim()
+      : Array.isArray(input.metadata.selfieTags)
+        ? input.metadata.selfieTags.filter((tag): tag is string => typeof tag === "string").join(", ").trim()
+        : "";
+  const negativePrompt =
+    typeof input.metadata.selfieNegativePrompt === "string" ? input.metadata.selfieNegativePrompt.trim() : "";
+  let finalPrompt = positivePrompt ? `${imagePrompt}, ${positivePrompt}` : imagePrompt;
+  let referenceImages: string[] | undefined;
+  const suppressReferencePromptLine = isNovelAiImageConnection({
+    model: imageConn.model,
+    baseUrl: imageConn.baseUrl,
+    imageService: imageConn.imageService,
+    imageGenerationSource: imageConn.imageGenerationSource,
+  });
+
+  if (input.metadata.selfieUseAvatarReferences === true || input.metadata.selfieIncludeCharacterAppearance === true) {
+    const callCharacters = await resolveCallCharacters(input.chars, readCharacterIds(input.chat.characterIds), {
+      metadata: input.metadata,
+    });
+    const persona = input.chat.personaId ? await input.chars.getPersona(input.chat.personaId) : null;
+    const referenceResolution = await resolveIllustratorCharacterReferences({
+      charactersStore: input.chars,
+      chatCharacters: callCharacters.map((character) => ({
+        id: character.id,
+        name: character.name,
+        avatarPath: character.avatarPath,
+        appearance: character.appearance,
+      })),
+      persona: persona
+        ? {
+            id: input.chat.personaId,
+            name: persona.name,
+            avatarPath: (persona as { avatarPath?: string | null }).avatarPath ?? null,
+            appearance: (persona as { appearance?: string | null }).appearance ?? null,
+          }
+        : null,
+      requestedNames: [charName],
+      promptText: [charName, input.command.context ?? "", imagePrompt].join("\n"),
+      fallbackToChatCharacters: false,
+      maxReferences: 1,
+    });
+    if (input.metadata.selfieIncludeCharacterAppearance === true && referenceResolution.appearanceBlock) {
+      finalPrompt += `\n\n${referenceResolution.appearanceBlock}`;
+    }
+    if (input.metadata.selfieUseAvatarReferences === true && referenceResolution.referenceImages.length > 0) {
+      referenceImages = referenceResolution.referenceImages;
+      if (referenceResolution.referenceLine && !suppressReferencePromptLine) {
+        finalPrompt += `\n\n${referenceResolution.referenceLine}`;
+      }
+    }
+  }
+
+  const configuredStyleProfileId =
+    parseJsonRecord(input.metadata.gameSetupConfig).imageStyleProfileId ??
+    input.metadata.imageStyleProfileId ??
+    null;
+  const styleProfileId =
+    typeof configuredStyleProfileId === "string" && configuredStyleProfileId.trim()
+      ? configuredStyleProfileId.trim()
+      : imageSettings.styleProfiles.defaultProfileId;
+  const selfieResolution = typeof input.metadata.selfieResolution === "string" ? input.metadata.selfieResolution : "";
+  const [selfieW, selfieH] = selfieResolution.split("x").map(Number) as [number, number];
+  const compiledPrompt = compileImagePrompt({
+    kind: "selfie",
+    prompt: finalPrompt,
+    negativePrompt: negativePrompt || undefined,
+    styleProfiles: imageSettings.styleProfiles,
+    styleProfileId,
+    imageDefaults,
+  });
+  const imageResult = await generateImage(
+    imageConn.model || "",
+    imageConn.baseUrl || "https://image.pollinations.ai",
+    imageConn.apiKey || "",
+    imageConn.imageService || imageConn.imageGenerationSource || imageConn.model || "",
+    {
+      prompt: compiledPrompt.prompt,
+      negativePrompt: compiledPrompt.negativePrompt || undefined,
+      model: imageConn.model || "",
+      width: selfieW || imageSettings.selfie.width,
+      height: selfieH || imageSettings.selfie.height,
+      imageEndpointId: imageConn.imageEndpointId || undefined,
+      comfyWorkflow: imageConn.comfyuiWorkflow || undefined,
+      imageDefaults,
+      referenceImages,
+    },
+  );
+
+  const filePath = saveImageToDisk(input.chat.id, imageResult.base64, imageResult.ext);
+  const galleryEntry = await createGalleryStorage(input.app.db).create({
+    chatId: input.chat.id,
+    filePath,
+    prompt: compiledPrompt.prompt,
+    provider: imageConn.provider ?? "image_generation",
+    model: imageConn.model || "unknown",
+    width: selfieW || imageSettings.selfie.width,
+    height: selfieH || imageSettings.selfie.height,
+  });
+  const filename = basename(filePath);
+  const attachment: MessageAttachment = {
+    type: "image",
+    url: `/api/gallery/file/${input.chat.id}/${encodeURIComponent(filename)}`,
+    filename: `selfie_${charName.toLowerCase().replace(/\s+/g, "_")}.${imageResult.ext}`,
+    prompt: compiledPrompt.prompt,
+    galleryId: galleryEntry?.id,
+  };
+  const message = await input.calls.createMessage({
+    callId: input.session.id,
+    chatId: input.session.chatId,
+    role: "assistant",
+    characterId: input.characterId,
+    participantKind: "character",
+    kind: "text",
+    content: "sent a selfie.",
+    extra: {
+      attachments: [attachment],
+      conversationCallCommandOutput: "selfie",
+    },
+  });
+  logger.info("[conversation-call] Selfie generated for %s during call %s", charName, input.session.id);
+  return message ? [message] : [];
+}
+
+async function executeCallConversationCommand(input: {
+  app: FastifyInstance;
+  chat: NonNullable<ChatRow>;
+  session: ConversationCallSession;
+  calls: CallsStorage;
+  commandText: string;
+  characterId: string | null;
+  anchorMessageId?: string | null;
+  sourceContent?: string | null;
+}): Promise<ConversationCallMessage[]> {
+  const commandName = getBracketCommandName(input.commandText);
+  if (commandName === "end_call" || commandName === "leave_call" || commandName === "soundboard") return [];
+
+  const parsed = parseCharacterCommands(input.commandText);
+  if (parsed.commands.length === 0) {
+    logger.debug("[conversation-call] Ignored unsupported call command: %s", input.commandText);
+    return [];
+  }
+
+  const chats = createChatsStorage(input.app.db);
+  const chars = createCharactersStorage(input.app.db);
+  const freshChat = (await chats.getById(input.chat.id)) ?? input.chat;
+  const metadata = parseJsonRecord(freshChat.metadata);
+  if (metadata.characterCommands === false) return [];
+
+  const createdMessages: ConversationCallMessage[] = [];
+  for (const command of parsed.commands) {
+    const key = getCallConversationCommandKey(command);
+    if (key && !isCallConversationCommandEnabled(metadata, key)) continue;
+
+    if (command.type === "schedule_update") {
+      await applyCallScheduleUpdate({
+        chats,
+        chat: freshChat,
+        metadata,
+        characterId: input.characterId,
+        command: command as ScheduleUpdateCommand,
+      });
+    } else if (command.type === "cross_post") {
+      await applyCallCrossPostCommand({
+        chats,
+        chat: freshChat,
+        characterId: input.characterId,
+        command: command as CrossPostCommand,
+        sourceContent: input.sourceContent,
+      });
+    } else if (command.type === "selfie") {
+      createdMessages.push(
+        ...(await applyCallSelfieCommand({
+          app: input.app,
+          chat: freshChat,
+          session: input.session,
+          calls: input.calls,
+          metadata,
+          chars,
+          characterId: input.characterId,
+          command: command as SelfieCommand,
+        })),
+      );
+    } else if (command.type === "memory") {
+      await applyCallMemoryCommand({ chars, characterId: input.characterId, command: command as MemoryCommand });
+    } else if (command.type === "spotify" || command.type === "youtube") {
+      await applyCallMusicCommand({ app: input.app, chat: freshChat, command: command as SpotifyCommand | YouTubeCommand });
+    } else if (command.type === "haptic") {
+      await applyCallHapticCommand({ metadata, command: command as HapticCommand });
+    } else if (command.type === "influence") {
+      const connectedId = freshChat.connectedChatId;
+      const content = stripConversationPromptTimestamps((command as InfluenceCommand).content);
+      if (connectedId && content) {
+        await chats.createInfluence(input.chat.id, connectedId, content, input.anchorMessageId ?? undefined);
+        logger.info("[conversation-call] OOC influence queued for connected chat %s", connectedId);
+      }
+    } else if (command.type === "note") {
+      const connectedId = freshChat.connectedChatId;
+      const content = stripConversationPromptTimestamps((command as NoteCommand).content);
+      if (connectedId && content) {
+        await chats.createNote(input.chat.id, connectedId, content, input.anchorMessageId ?? undefined);
+        logger.info("[conversation-call] Conversation note saved for connected chat %s", connectedId);
+      }
+    } else {
+      logger.debug("[conversation-call] Call command %s parsed but has no call executor yet", command.type);
+    }
+  }
+  return createdMessages;
+}
+
+async function persistCallAssistantTurns(input: {
+  app: FastifyInstance;
+  chat: NonNullable<ChatRow>;
+  session: ConversationCallSession;
+  calls: CallsStorage;
+  turns: ConversationCallTurn[];
+}): Promise<{
+  assistantMessages: ConversationCallMessage[];
+  session: ConversationCallSession;
+  turns: ConversationCallTurn[];
+}> {
+  const assistantMessages: ConversationCallMessage[] = [];
+  const resolvedTurns: ConversationCallTurn[] = [];
+  let responseSession: ConversationCallSession = input.session;
+  const metadata = parseJsonRecord(input.chat.metadata);
+  const allCharacterIds = readCharacterIds(input.chat.characterIds);
+  const availableCharacterIds = getAvailableCallCharacterIds(metadata, allCharacterIds);
+  const characters = await resolveCallCharacters(createCharactersStorage(input.app.db), availableCharacterIds, {
+    metadata,
+  });
+  let lastVisibleAssistantContent: string | null = null;
+  for (const turn of input.turns) {
+    const characterId = resolveTurnCharacterId(turn, characters);
+    if (!characterId) continue;
+    const turnWithResolvedCharacter = { ...turn, characterId };
+    resolvedTurns.push(turnWithResolvedCharacter);
+    if (turn.mode === "command") {
+      const command = normalizeBracketCommand(turn.content) ?? "[command]";
+      const commandTurn = { ...turnWithResolvedCharacter, content: command, command };
+      const commandMessage = await input.calls.createMessage({
+        callId: input.session.id,
+        chatId: input.session.chatId,
+        role: "system",
+        characterId,
+        participantKind: "character",
+        kind: "command",
+        content: command,
+        extra: { turn: commandTurn },
+      });
+      if (commandMessage) assistantMessages.push(commandMessage);
+      const commandOutputMessages = await executeCallConversationCommand({
+        app: input.app,
+        chat: input.chat,
+        session: input.session,
+        calls: input.calls,
+        commandText: command,
+        characterId,
+        anchorMessageId: commandMessage?.id ?? null,
+        sourceContent: lastVisibleAssistantContent,
+      });
+      assistantMessages.push(...commandOutputMessages);
+      if (getBracketCommandName(command) === "end_call") {
+        // The client finalizes the call after it has played any preceding voice turns.
+        // Ending here would make the UI collapse before the character finishes speaking.
+        break;
+      }
+      continue;
+    }
+    const assistantMessage = await input.calls.createMessage({
+      callId: input.session.id,
+      chatId: input.session.chatId,
+      role: "assistant",
+      characterId,
+      participantKind: "character",
+      kind: turn.mode === "voice" ? "speech" : "text",
+      content: turn.content,
+      extra: { turn: turnWithResolvedCharacter },
+    });
+    if (assistantMessage) assistantMessages.push(assistantMessage);
+    lastVisibleAssistantContent = assistantMessage?.content ?? turn.content;
+  }
+  return {
+    assistantMessages,
+    turns: resolvedTurns,
+    session:
+      responseSession.status === "ended"
+        ? responseSession
+        : ((await input.calls.getSession(input.session.id)) ?? input.session),
+  };
+}
+
+async function summarizeCall(input: {
+  app: FastifyInstance;
+  chat: NonNullable<ChatRow>;
+  session: ConversationCallSession;
+}) {
+  const calls = createConversationCallsStorage(input.app.db);
+  const connections = createConnectionsStorage(input.app.db);
+  const messages = await calls.listMessages(input.session.id);
+  if (messages.length === 0) return "No substantial conversation occurred during the call.";
+  const connectionId = input.chat.connectionId;
+  if (!connectionId) {
+    return messages
+      .slice(-12)
+      .map((message) => `${message.participantKind === "user" ? "User" : "Character"}: ${message.content}`)
+      .join("\n");
+  }
+  const conn = await connections.getWithKey(connectionId);
+  if (!conn) return "Call ended. Summary unavailable because the chat connection could not be resolved.";
+  const provider = createLLMProvider(
+    conn.provider,
+    resolveBaseUrl(conn),
+    conn.apiKey,
+    conn.maxContext,
+    conn.openrouterProvider,
+    conn.maxTokensOverride,
+    conn.claudeFastMode === "true",
+    conn.treatAsLocalEndpoint === "true",
+  );
+  const transcript = messages.map((message) => `${message.participantKind}:${message.content}`).join("\n");
+  try {
+    const result = await provider.chatComplete(
+      [
+        {
+          role: "system",
+          content:
+            "Summarize this audio call for future chat context in 3-6 concise sentences. Keep concrete plans, emotional shifts, decisions, and notable events.",
+        },
+        { role: "user", content: transcript },
+      ],
+      { model: conn.model, maxTokens: 600, temperature: 0.2 },
+    );
+    return (result.content ?? "").trim() || "Call ended. No summary was generated.";
+  } catch (error) {
+    logger.warn(error, "[conversation-call] Failed to summarize call %s", input.session.id);
+    return "Call ended. Summary generation failed.";
+  }
+}
+
+async function endConversationCallWithSummary(input: {
+  app: FastifyInstance;
+  chat: NonNullable<ChatRow>;
+  session: ConversationCallSession;
+}) {
+  if (input.session.status === "ended") return input.session;
+  const chats = createChatsStorage(input.app.db);
+  const calls = createConversationCallsStorage(input.app.db);
+  const summary = await summarizeCall(input);
+  const startedAt = getSessionStartedAt(input.session);
+  const durationMs = Date.now() - startedAt;
+  const ended = await calls.updateStatus(input.session.id, "ended", { summary });
+  const duration = formatDuration(durationMs);
+  await chats.createMessagesBatch(input.session.chatId, [
+    {
+      role: "system",
+      characterId: input.session.initiatorCharacterId,
+      content: `Call ended after ${duration}`,
+      extra: {
+        displayText: null,
+        isGenerated: true,
+        tokenCount: null,
+        generationInfo: null,
+        conversationCallEvent: {
+          callId: input.session.id,
+          status: "ended",
+          durationMs,
+          summary,
+        },
+      },
+    },
+    {
+      role: "system",
+      characterId: null,
+      content: `[Audio call summary: ${summary}]`,
+      extra: {
+        hiddenFromUser: true,
+        displayText: null,
+        isGenerated: true,
+        tokenCount: null,
+        generationInfo: null,
+        conversationCallSummary: true,
+        callId: input.session.id,
+      },
+    },
+  ]);
+  return ended;
+}
+
+async function readTTSSettings(app: FastifyInstance): Promise<Record<string, unknown>> {
+  const storage = createAppSettingsStorage(app.db);
+  const raw = await storage.get("tts");
+  if (!raw) return {};
+  try {
+    const parsed = JSON.parse(raw);
+    return parsed && typeof parsed === "object" && !Array.isArray(parsed) ? (parsed as Record<string, unknown>) : {};
+  } catch {
+    return {};
+  }
+}
+
+function ensureSoundboardDir() {
+  mkdirSync(SOUNDBOARD_ROOT, { recursive: true });
+  return SOUNDBOARD_ROOT;
+}
+
+export async function conversationCallsRoutes(app: FastifyInstance) {
+  const chats = createChatsStorage(app.db);
+  const calls = createConversationCallsStorage(app.db);
+  const connections = createConnectionsStorage(app.db);
+
+  app.get<{ Params: { chatId: string } }>("/chat/:chatId/status", async (req) => {
+    const [activeCall, ringingCall] = await Promise.all([
+      calls.getActiveForChat(req.params.chatId),
+      calls.getRingingForChat(req.params.chatId),
+    ]);
+    return { activeCall, ringingCall };
+  });
+
+  app.post("/start", async (req, reply) => {
+    const input = startConversationCallSchema.parse(req.body);
+    const chat = await chats.getById(input.chatId);
+    if (!chat) return reply.status(404).send({ error: "Chat not found" });
+    if (chat.mode !== "conversation")
+      return reply.status(400).send({ error: "Calls are only available in Conversation mode" });
+    const meta = parseJsonRecord(chat.metadata);
+    if (input.initiator !== "character" && meta.conversationCallsEnabled !== true)
+      return reply.status(400).send({ error: "Calls are not enabled for this conversation" });
+    const ttsSettings = await readTTSSettings(app);
+    if (ttsSettings.callAudioEnabled !== true) {
+      return reply.status(400).send({ error: "Conversation call audio is not enabled in Chat Settings" });
+    }
+    const commandToggles = parseJsonRecord(meta.conversationCommandToggles);
+    if (input.initiator === "character" && (meta.characterCommands === false || commandToggles.call === false)) {
+      return reply.status(400).send({ error: "Characters cannot call in this conversation" });
+    }
+    const existingActive = await calls.getActiveForChat(chat.id);
+    if (existingActive) return existingActive;
+    const existingRinging = await calls.getRingingForChat(chat.id);
+    if (existingRinging) return existingRinging;
+    const session = await calls.createSession(input);
+    if (!session) return reply.status(500).send({ error: "Failed to create call" });
+    const eventContent = session.status === "ringing" ? "Incoming call" : "Started an audio call";
+    await chats.createMessagesBatch(chat.id, [
+      {
+        role: "system",
+        characterId: input.initiatorCharacterId ?? null,
+        content: eventContent,
+        extra: {
+          displayText: null,
+          isGenerated: true,
+          tokenCount: null,
+          generationInfo: null,
+          conversationCallEvent: {
+            callId: session.id,
+            status: session.status,
+            mode: session.mode,
+            initiator: session.initiator,
+            reason: input.metadata?.reason ?? null,
+          },
+        },
+      },
+    ]);
+    return session;
+  });
+
+  app.post<{ Params: { id: string } }>("/:id/accept", async (req, reply) => {
+    const session = await calls.getSession(req.params.id);
+    if (!session) return reply.status(404).send({ error: "Call not found" });
+    if (session.status !== "ringing") return session;
+    const activeSession = await calls.updateStatus(session.id, "active");
+    await chats.createMessagesBatch(session.chatId, [
+      {
+        role: "system",
+        characterId: session.initiatorCharacterId,
+        content: "Started an audio call",
+        extra: {
+          displayText: null,
+          isGenerated: true,
+          tokenCount: null,
+          generationInfo: null,
+          conversationCallEvent: {
+            callId: session.id,
+            status: "active",
+            mode: session.mode,
+            initiator: session.initiator,
+          },
+        },
+      },
+    ]);
+    return activeSession;
+  });
+
+  app.post<{ Params: { id: string } }>("/:id/decline", async (req, reply) => {
+    const session = await calls.getSession(req.params.id);
+    if (!session) return reply.status(404).send({ error: "Call not found" });
+    const updated = await calls.updateStatus(session.id, "declined");
+    await chats.createMessagesBatch(session.chatId, [
+      {
+        role: "system",
+        characterId: session.initiatorCharacterId,
+        content: "Call declined",
+        extra: {
+          displayText: null,
+          isGenerated: true,
+          tokenCount: null,
+          generationInfo: null,
+          conversationCallEvent: {
+            callId: session.id,
+            status: "declined",
+            mode: session.mode,
+            initiator: session.initiator,
+          },
+        },
+      },
+    ]);
+    return updated;
+  });
+
+  app.post<{ Params: { id: string } }>("/:id/end", async (req, reply) => {
+    const session = await calls.getSession(req.params.id);
+    if (!session) return reply.status(404).send({ error: "Call not found" });
+    const chat = await chats.getById(session.chatId);
+    if (!chat) return reply.status(404).send({ error: "Chat not found" });
+    const ended = await endConversationCallWithSummary({ app, chat, session });
+    return ended;
+  });
+
+  app.get<{ Params: { id: string } }>("/:id/messages", async (req, reply) => {
+    const session = await calls.getSession(req.params.id);
+    if (!session) return reply.status(404).send({ error: "Call not found" });
+    return calls.listMessages(session.id);
+  });
+
+  app.post<{ Params: { id: string } }>("/:id/interruption", async (req, reply) => {
+    const session = await calls.getSession(req.params.id);
+    if (!session) return reply.status(404).send({ error: "Call not found" });
+    if (session.status !== "active") return reply.status(400).send({ error: "Call is not active" });
+    const input = conversationCallInterruptionSchema.parse(req.body ?? {});
+    const spokenText = input.spokenText.trim();
+    const speakerName = input.speakerName?.trim() || "the character";
+    const content = [
+      "[User interrupted when you were speaking this.]",
+      spokenText ? `${speakerName} was saying: ${spokenText}` : "",
+    ]
+      .filter(Boolean)
+      .join("\n");
+    const message = await calls.createMessage({
+      callId: session.id,
+      chatId: session.chatId,
+      role: "system",
+      characterId: input.characterId ?? null,
+      participantKind: "character",
+      kind: "system",
+      content,
+      extra: {
+        hiddenFromUser: true,
+        conversationCallInterruption: true,
+        speakerName,
+        spokenText,
+      },
+    });
+    if (!message) return reply.status(500).send({ error: "Failed to save interruption marker" });
+    return message;
+  });
+
+  app.post<{ Params: { id: string } }>("/:id/messages", async (req, reply) => {
+    const session = await calls.getSession(req.params.id);
+    if (!session) return reply.status(404).send({ error: "Call not found" });
+    if (session.status !== "active") return reply.status(400).send({ error: "Call is not active" });
+    const input = sendConversationCallMessageSchema.parse(req.body) as {
+      content: string;
+      inputMode: "typed" | "speech";
+      debugMode: boolean;
+      musicPlayerEnabled?: boolean;
+      musicPlayerSource?: "spotify" | "youtube" | "custom";
+    };
+    const chat = await chats.getById(session.chatId);
+    if (!chat) return reply.status(404).send({ error: "Chat not found" });
+    const userMessage = await calls.createMessage({
+      callId: session.id,
+      chatId: session.chatId,
+      role: "user",
+      participantKind: "user",
+      kind: input.inputMode === "speech" ? "speech" : "text",
+      content: input.content,
+    });
+    if (!userMessage) return reply.status(500).send({ error: "Failed to save call message" });
+
+    const { turns } = await createCallTurns({
+      app,
+      chat,
+      session,
+      connections,
+      userText: input.content,
+      userInputKind: input.inputMode === "speech" ? "speech" : "text",
+      latestCallMessageId: userMessage.id,
+      debugMode: input.debugMode,
+      musicPlayerEnabled: input.musicPlayerEnabled,
+      musicPlayerSource: input.musicPlayerSource,
+    });
+    const persisted = await persistCallAssistantTurns({ app, chat, session, calls, turns });
+    return {
+      userMessage,
+      assistantMessages: persisted.assistantMessages,
+      turns: persisted.turns,
+      session: persisted.session,
+    };
+  });
+
+  app.post<{ Params: { id: string } }>("/:id/idle", async (req, reply) => {
+    const session = await calls.getSession(req.params.id);
+    if (!session) return reply.status(404).send({ error: "Call not found" });
+    if (session.status !== "active") return reply.status(400).send({ error: "Call is not active" });
+    const input = conversationCallIdleSchema.parse(req.body ?? {}) as {
+      quietMs: number;
+      debugMode: boolean;
+      musicPlayerEnabled?: boolean;
+      musicPlayerSource?: "spotify" | "youtube" | "custom";
+    };
+    const chat = await chats.getById(session.chatId);
+    if (!chat) return reply.status(404).send({ error: "Chat not found" });
+    const userText = [
+      `[Call silence check: The user has not spoken or typed for ${formatQuietDuration(input.quietMs)}.`,
+      "This is not a user message. If the user recently said they were going brb, away, busy, sleeping, or intentionally quiet, return an empty turns array and wait patiently.",
+      "Otherwise, generate at most one brief, gentle check-in asking if they are still there or all right.]",
+    ].join(" ");
+    const { turns } = await createCallTurns({
+      app,
+      chat,
+      session,
+      connections,
+      userText,
+      userInputKind: "system",
+      debugMode: input.debugMode,
+      musicPlayerEnabled: input.musicPlayerEnabled,
+      musicPlayerSource: input.musicPlayerSource,
+    });
+    const persisted = await persistCallAssistantTurns({ app, chat, session, calls, turns });
+    return {
+      assistantMessages: persisted.assistantMessages,
+      turns: persisted.turns,
+      session: persisted.session,
+    };
+  });
+
+  app.post<{ Params: { id: string } }>("/:id/media", async (req, reply) => {
+    const session = await calls.getSession(req.params.id);
+    if (!session) return reply.status(404).send({ error: "Call not found" });
+    if (session.status !== "active") return reply.status(400).send({ error: "Call is not active" });
+    const chat = await chats.getById(session.chatId);
+    if (!chat) return reply.status(404).send({ error: "Chat not found" });
+    const ttsSettings = await readTTSSettings(app);
+    if (ttsSettings.callAudioEnabled !== true) {
+      return reply.status(400).send({ error: "Conversation call audio is not enabled in Chat Settings" });
+    }
+    const data = await req.file({ limits: { fileSize: MAX_AUDIO_UPLOAD_BYTES } });
+    if (!data) return reply.status(400).send({ error: "No media uploaded" });
+    const chunks: Buffer[] = [];
+    for await (const chunk of data.file) {
+      chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+    }
+    const buffer = Buffer.concat(chunks);
+    const fields = data.fields as Record<string, { value?: string } | undefined>;
+    const requestDebug = fields?.debugMode?.value === "true";
+    const requestMusicPlayerEnabled =
+      fields?.musicPlayerEnabled?.value === "true"
+        ? true
+        : fields?.musicPlayerEnabled?.value === "false"
+          ? false
+          : undefined;
+    const requestMusicPlayerSource =
+      fields?.musicPlayerSource?.value === "spotify" ||
+      fields?.musicPlayerSource?.value === "youtube" ||
+      fields?.musicPlayerSource?.value === "custom"
+        ? fields.musicPlayerSource.value
+        : undefined;
+    const requestedKind = fields?.kind?.value === "video" || fields?.kind?.value === "audio" ? fields.kind.value : null;
+    const mimeType = data.mimetype || (requestedKind === "video" ? "video/webm" : "audio/webm");
+    const kind = requestedKind ?? mediaKindFromMime(mimeType, data.filename || "");
+    if (!kind) return reply.status(400).send({ error: "Unsupported call media type" });
+    if (kind === "video" && ttsSettings.callVideoInputEnabled !== true) {
+      return reply.status(400).send({ error: "Video input is disabled in Chat Settings" });
+    }
+
+    const nativePreferred =
+      fields?.nativePreferred?.value === "true" &&
+      (typeof ttsSettings.callAudioInputMode !== "string" ||
+        ttsSettings.callAudioInputMode === "auto" ||
+        ttsSettings.callAudioInputMode === "transcribe");
+    const localWhisperRequested =
+      fields?.transcriptionMode?.value === "local_whisper" &&
+      (ttsSettings.callAudioInputMode === "local_whisper" || ttsSettings.callAudioInputMode === "transcribe");
+
+    if (localWhisperRequested) {
+      if (kind !== "audio") {
+        return reply.status(400).send({ error: "Local Whisper transcription only accepts audio input" });
+      }
+      let transcript = "";
+      try {
+        transcript = (await sidecarSpeechService.transcribeWav(buffer)).trim();
+      } catch (error) {
+        logger.warn(error, "[conversation-call] Local Whisper transcription failed");
+        return reply.status(400).send({
+          error: error instanceof Error ? error.message : "Local Whisper transcription failed",
+        });
+      }
+      if (!transcript) {
+        return reply.status(400).send({ error: "Local Whisper did not return a transcript" });
+      }
+      if (isBlankAudioTranscript(transcript)) {
+        return reply.status(400).send({ error: "Local Whisper did not detect speech." });
+      }
+      const userMessage = await calls.createMessage({
+        callId: session.id,
+        chatId: session.chatId,
+        role: "user",
+        participantKind: "user",
+        kind: "speech",
+        content: transcript,
+        extra: {
+          localWhisper: true,
+          mimeType,
+        },
+      });
+      if (!userMessage) return reply.status(500).send({ error: "Failed to save call message" });
+
+      const { turns } = await createCallTurns({
+        app,
+        chat,
+        session,
+        connections,
+        userText: transcript,
+        userInputKind: "speech",
+        latestCallMessageId: userMessage.id,
+        debugMode: requestDebug,
+        musicPlayerEnabled: requestMusicPlayerEnabled,
+        musicPlayerSource: requestMusicPlayerSource,
+      });
+      const persisted = await persistCallAssistantTurns({ app, chat, session, calls, turns });
+      return {
+        userMessage,
+        assistantMessages: persisted.assistantMessages,
+        turns: persisted.turns,
+        session: persisted.session,
+      };
+    }
+
+    const conn = chat.connectionId ? await connections.getWithKey(chat.connectionId) : null;
+    const canSendNative =
+      nativePreferred &&
+      conn &&
+      canSendNativeCallMedia({
+        provider: conn.provider,
+        model: conn.model,
+        kind,
+        mimeType,
+        filename: data.filename || "",
+        byteLength: buffer.byteLength,
+      });
+
+    if (canSendNative && conn) {
+      const content = nativeMediaContentLabel(kind, mimeType);
+      const nativeMedia: ChatMediaAttachment[] = [
+        {
+          kind,
+          data: dataUrlFromBuffer(buffer, mimeType),
+          mimeType,
+          filename: data.filename || (kind === "video" ? "call-video.webm" : "call-audio.webm"),
+        },
+      ];
+      try {
+        const { turns } = await createCallTurns({
+          app,
+          chat,
+          session,
+          connections,
+          userText: content,
+          userInputKind: "speech",
+          nativeMedia,
+          throwOnGenerationError: true,
+          debugMode: requestDebug,
+          musicPlayerEnabled: requestMusicPlayerEnabled,
+          musicPlayerSource: requestMusicPlayerSource,
+        });
+        const userMessage = await calls.createMessage({
+          callId: session.id,
+          chatId: session.chatId,
+          role: "user",
+          participantKind: "user",
+          kind: "speech",
+          content,
+          extra: {
+            providerNativeMedia: true,
+            mediaKind: kind,
+            mimeType,
+            provider: conn.provider,
+            model: conn.model,
+          },
+        });
+        if (!userMessage) return reply.status(500).send({ error: "Failed to save call message" });
+        const persisted = await persistCallAssistantTurns({ app, chat, session, calls, turns });
+        return {
+          userMessage,
+          assistantMessages: persisted.assistantMessages,
+          turns: persisted.turns,
+          session: persisted.session,
+        };
+      } catch (error) {
+        logger.warn(error, "[conversation-call] Native media dispatch failed; falling back when possible");
+        if (kind === "video") {
+          return reply.status(502).send({ error: "Selected model could not process native video input" });
+        }
+      }
+    }
+
+    if (kind !== "audio") {
+      return reply.status(400).send({ error: "Selected provider/model cannot receive native video input" });
+    }
+
+    return reply.status(400).send({
+      error:
+        ttsSettings.callAudioInputMode === "transcribe"
+          ? "This browser could not transcribe speech directly. Download Local Whisper from Connections, choose provider-native audio/video, or use manual system dictation."
+          : "Selected provider/model cannot receive provider-native audio input. Choose another audio input mode.",
+    });
+  });
+
+  app.get("/soundboard", async () => calls.listSounds());
+
+  app.post("/soundboard/upload", async (req, reply) => {
+    const data = await req.file({ limits: { fileSize: MAX_SOUND_BYTES } });
+    if (!data) return reply.status(400).send({ error: "No file uploaded" });
+    const ext = extname(data.filename).toLowerCase();
+    if (!ALLOWED_SOUND_EXTS.has(ext)) return reply.status(400).send({ error: `Unsupported sound file type: ${ext}` });
+    const dir = ensureSoundboardDir();
+    const filename = `${newId()}${ext}`;
+    const filePath = assertInsideDir(SOUNDBOARD_ROOT, join(dir, filename));
+    try {
+      await pipeline(data.file, createWriteStream(filePath));
+    } catch (error) {
+      if (existsSync(filePath)) unlinkSync(filePath);
+      logger.warn(error, "[conversation-call] Failed to receive soundboard upload");
+      return reply.status(400).send({ error: "Failed to read uploaded sound." });
+    }
+    const fields = data.fields as Record<string, { value?: string } | undefined>;
+    const name = (fields?.name?.value ?? basename(data.filename, ext)).trim().slice(0, 80) || "Sound";
+    return calls.createSound({ name, filePath, mimeType: data.mimetype || "audio/mpeg" });
+  });
+
+  app.get<{ Params: { id: string } }>("/soundboard/:id/file", async (req, reply) => {
+    const sound = await calls.getSound(req.params.id);
+    if (!sound || !sound.filePath) return reply.status(404).send({ error: "Sound not found" });
+    if (!existsSync(sound.filePath)) return reply.status(404).send({ error: "Sound file missing" });
+    reply.type(sound.mimeType);
+    return reply.send(createReadStream(sound.filePath));
+  });
+
+  app.delete<{ Params: { id: string } }>("/soundboard/:id", async (req, reply) => {
+    const sound = await calls.deleteSound(req.params.id);
+    if (!sound) return reply.status(404).send({ error: "Sound not found" });
+    if (!sound.builtIn && sound.filePath && existsSync(sound.filePath)) unlinkSync(sound.filePath);
+    return reply.status(204).send();
+  });
+}

--- a/packages/server/src/routes/generate.routes.ts
+++ b/packages/server/src/routes/generate.routes.ts
@@ -65,6 +65,8 @@ import { createCustomEmojisStorage } from "../services/storage/custom-emojis.sto
 import { createCustomStickersStorage } from "../services/storage/custom-stickers.storage.js";
 import { createCharacterGalleryStorage } from "../services/storage/character-gallery.storage.js";
 import { createPersonaGalleryStorage } from "../services/storage/persona-gallery.storage.js";
+import { createConversationCallsStorage } from "../services/storage/conversation-calls.storage.js";
+import { createAppSettingsStorage } from "../services/storage/app-settings.storage.js";
 import { localEmbed, isLocalEmbedderAvailable } from "../services/local-embedder.js";
 import { buildLorebookSemanticEmbeddingsById, cosineSimilarity } from "../services/lorebook/embeddings.js";
 import { applyRegexScriptsToPromptMessages } from "../services/regex/regex-application.js";
@@ -99,7 +101,12 @@ import {
   type AssemblerInput,
 } from "../services/prompt/index.js";
 import { wrapContent } from "../services/prompt/format-engine.js";
-import { yieldToEventLoop, type BaseLLMProvider, type ChatMessage, type LLMUsage } from "../services/llm/base-provider.js";
+import {
+  yieldToEventLoop,
+  type BaseLLMProvider,
+  type ChatMessage,
+  type LLMUsage,
+} from "../services/llm/base-provider.js";
 import { executeToolCalls } from "../services/tools/tool-executor.js";
 import { createAgentPipeline, type ResolvedAgent, type AgentInjection } from "../services/agents/agent-pipeline.js";
 import { DATA_DIR } from "../utils/data-dir.js";
@@ -118,6 +125,7 @@ import {
   type CrossPostCommand,
   type SelfieCommand,
   type MemoryCommand,
+  type CallCommand,
   type InfluenceCommand,
   type NoteCommand,
   type DirectMessageCommand,
@@ -808,6 +816,8 @@ function getConversationCommandKey(command: CharacterCommand): ConversationComma
       return "memory";
     case "scene":
       return "scene";
+    case "call":
+      return "call";
     case "uno":
       return "uno";
     case "chess":
@@ -1085,10 +1095,7 @@ function normalizeImageCaptionText(value: unknown): string | null {
   return text.length > IMAGE_CAPTION_MAX_CHARS ? `${text.slice(0, IMAGE_CAPTION_MAX_CHARS).trim()}...` : text;
 }
 
-function readCachedImageCaption(
-  attachment: PromptAttachment,
-  imageCaptioning: ImageCaptioningRuntime,
-): string | null {
+function readCachedImageCaption(attachment: PromptAttachment, imageCaptioning: ImageCaptioningRuntime): string | null {
   const caption = normalizeImageCaptionText(attachment.imageCaption);
   if (!caption || !imageCaptioning.connection) return null;
   if (attachment.imageCaptionConnectionId !== imageCaptioning.connectionId) return null;
@@ -2088,15 +2095,15 @@ export async function generateRoutes(app: FastifyInstance) {
         }
       }
       const selectedPresetDiffersFromChat = !!resolvedPreset && !!presetId && presetId !== chatPromptPresetId;
-      const resolvedPresetDefaultChoices =
-        resolvedPreset ? (parsePromptPresetChoices((resolvedPreset as { defaultChoices?: unknown }).defaultChoices) ?? {}) : {};
-      const chatChoices: Record<string, string | string[]> =
-        resolveGenerationPromptPresetChoices({
-          presetSource,
-          selectedPresetDiffersFromChat,
-          presetDefaultChoices: resolvedPresetDefaultChoices,
-          chatPresetChoices: (chatMeta.presetChoices ?? {}) as Record<string, string | string[]>,
-        });
+      const resolvedPresetDefaultChoices = resolvedPreset
+        ? (parsePromptPresetChoices((resolvedPreset as { defaultChoices?: unknown }).defaultChoices) ?? {})
+        : {};
+      const chatChoices: Record<string, string | string[]> = resolveGenerationPromptPresetChoices({
+        presetSource,
+        selectedPresetDiffersFromChat,
+        presetDefaultChoices: resolvedPresetDefaultChoices,
+        chatPresetChoices: (chatMeta.presetChoices ?? {}) as Record<string, string | string[]>,
+      });
       let groupHistoryCharacterNamesByIdPromise: Promise<Map<string, string>> | null = null;
       const getGroupHistoryCharacterNamesById = () => {
         groupHistoryCharacterNamesByIdPromise ??= resolveCharacterNameMap(allCharacterIds, (id) => chars.getById(id));
@@ -3174,6 +3181,7 @@ export async function generateRoutes(app: FastifyInstance) {
             const selfieCommandEnabled = isConversationCommandEnabled(chatMeta, "selfie");
             const memoryCommandEnabled = isConversationCommandEnabled(chatMeta, "memory");
             const sceneCommandEnabled = isConversationCommandEnabled(chatMeta, "scene");
+            const callCommandEnabled = isConversationCommandEnabled(chatMeta, "call");
             const musicCommandEnabled = isConversationCommandEnabled(chatMeta, "music");
             const hapticCommandEnabled = isConversationCommandEnabled(chatMeta, "haptic");
             const activeMusicCommandSource =
@@ -3294,6 +3302,12 @@ export async function generateRoutes(app: FastifyInstance) {
                 `   - A plan is made (date, trip, hangout, confrontation) and the moment arrives → trigger a scene.`,
                 `   Do NOT wait for {{user}} to explicitly ask for a scene. If the conversation implies you and {{user}} are about to DO something together, initiate the scene yourself.`,
                 `   EXCEPTION: Do NOT start a scene for playing UNO, chess, cards, or other board/table games — those have their own commands. Use [uno] for UNO and [chess] for chess, not [scene].`,
+              );
+            }
+
+            if (callCommandEnabled && chatMode === "conversation") {
+              addCommandLines(
+                `- [call] or [call: reason="brief reason"] - ring ${personaName} for an audio call. Use this only when a live call naturally fits, such as when you urgently want to talk, when typing is awkward, or when ${personaName} asks you to call. The system will show an incoming call request; do not assume it was answered unless the call starts.`,
               );
             }
 
@@ -6982,6 +6996,7 @@ export async function generateRoutes(app: FastifyInstance) {
           // Parallel to parsedCommands: per-command character attribution for merged
           // group conversations (null elsewhere — caller falls back to the message char).
           let parsedCommandCharacterIds: (string | null)[] | null = null;
+          let parsedRawCommandCount = 0;
           let conversationCommandContent: string | null = null;
           let contentReplaced = false;
           if (tailMessages.assistantPrefillInjected && assistantPrefill && fullResponse.startsWith(assistantPrefill)) {
@@ -7039,6 +7054,7 @@ export async function generateRoutes(app: FastifyInstance) {
                 )
               : null;
             if (parsed.commands.length > 0) {
+              parsedRawCommandCount += parsed.commands.length;
               parsedCommands = filterEnabledConversationCommands(parsed.commands, chatMeta);
               if (parsedCommands.length > 0) {
                 conversationCommandContent = responseBeforeCommandParsing.trim();
@@ -7215,10 +7231,11 @@ export async function generateRoutes(app: FastifyInstance) {
           // no surrounding prose, treat the commands as the useful output. Skip saving
           // a blank assistant bubble but still return the commands so they execute.
           if (!fullResponse.trim()) {
-            if (!input.impersonate && parsedCommands.length > 0) {
+            if (!input.impersonate && (parsedCommands.length > 0 || parsedRawCommandCount > 0)) {
               logger.info(
-                "[generate] Model emitted %d command(s) with no visible prose for chat %s; saving hidden command anchor",
+                "[generate] Model emitted %d enabled command(s) (%d parsed) with no visible prose for chat %s; saving hidden command anchor",
                 parsedCommands.length,
+                parsedRawCommandCount,
                 input.chatId,
               );
               const savedMsg = await chats.createMessage({
@@ -9781,7 +9798,9 @@ export async function generateRoutes(app: FastifyInstance) {
                           ? `${imagePrompt}, ${selfiePositivePrompt}`
                           : imagePrompt;
                         let selfieReferenceImages: string[] | undefined;
-                        if (chatMeta.selfieUseAvatarReferences === true) {
+                        const selfieUseAvatarReferences = chatMeta.selfieUseAvatarReferences === true;
+                        const selfieIncludeCharacterAppearance = chatMeta.selfieIncludeCharacterAppearance === true;
+                        if (selfieUseAvatarReferences || selfieIncludeCharacterAppearance) {
                           const referenceResolution = await resolveIllustratorCharacterReferences({
                             charactersStore: chars,
                             chatCharacters: charInfo.map((character) => ({
@@ -9803,7 +9822,14 @@ export async function generateRoutes(app: FastifyInstance) {
                             fallbackToChatCharacters: false,
                             maxReferences: 1,
                           });
-                          if (referenceResolution.referenceImages.length > 0) {
+                          if (selfieIncludeCharacterAppearance && referenceResolution.appearanceBlock) {
+                            finalSelfiePrompt += `\n\n${referenceResolution.appearanceBlock}`;
+                            logger.debug(
+                              "[selfie] Added character appearance notes for: %s",
+                              referenceResolution.appearanceNames.join(", "),
+                            );
+                          }
+                          if (selfieUseAvatarReferences && referenceResolution.referenceImages.length > 0) {
                             selfieReferenceImages = referenceResolution.referenceImages;
                             if (referenceResolution.referenceLine && !suppressReferencePromptLine) {
                               finalSelfiePrompt += `\n\n${referenceResolution.referenceLine}`;
@@ -9938,6 +9964,87 @@ export async function generateRoutes(app: FastifyInstance) {
                         },
                       })}\n\n`,
                     );
+                  }
+                } else if (command.type === "call") {
+                  // ── Call: create a ringing Conversation call request ──
+                  const callCmd = command as CallCommand;
+                  if (chatMode !== "conversation") continue;
+                  const freshChat = await chats.getById(input.chatId);
+                  const freshMeta =
+                    typeof freshChat?.metadata === "string"
+                      ? JSON.parse(freshChat.metadata)
+                      : (freshChat?.metadata ?? {});
+                  if (freshMeta.characterCommands === false || !isConversationCommandEnabled(freshMeta, "call")) {
+                    logger.debug(
+                      "[commands] Ignored call command because calls are disabled for chat %s",
+                      input.chatId,
+                    );
+                    continue;
+                  }
+                  const ttsSettingsRaw = await createAppSettingsStorage(app.db).get("tts");
+                  let ttsSettings: Record<string, unknown> = {};
+                  if (ttsSettingsRaw && typeof ttsSettingsRaw === "string") {
+                    try {
+                      const parsed = JSON.parse(ttsSettingsRaw);
+                      ttsSettings =
+                        parsed && typeof parsed === "object" && !Array.isArray(parsed)
+                          ? (parsed as Record<string, unknown>)
+                          : {};
+                    } catch {
+                      ttsSettings = {};
+                    }
+                  }
+                  if (ttsSettings.callAudioEnabled !== true) {
+                    logger.debug(
+                      "[commands] Ignored call command because Conversation call audio is globally disabled",
+                    );
+                    continue;
+                  }
+                  const callStore = createConversationCallsStorage(app.db);
+                  const existingActive = await callStore.getActiveForChat(input.chatId);
+                  const existingRinging = await callStore.getRingingForChat(input.chatId);
+                  const session =
+                    existingActive ??
+                    existingRinging ??
+                    (await callStore.createSession({
+                      chatId: input.chatId,
+                      mode: "audio",
+                      initiator: "character",
+                      initiatorCharacterId: characterId,
+                      metadata: {
+                        reason: callCmd.reason ?? null,
+                        sourceMessageId: messageId ?? null,
+                      },
+                    }));
+                  if (session && !existingActive && !existingRinging) {
+                    await chats.createMessagesBatch(input.chatId, [
+                      {
+                        role: "system",
+                        characterId,
+                        content: callCmd.reason ? `Incoming call: ${callCmd.reason}` : "Incoming call",
+                        extra: {
+                          displayText: null,
+                          isGenerated: true,
+                          tokenCount: null,
+                          generationInfo: null,
+                          conversationCallEvent: {
+                            callId: session.id,
+                            status: session.status,
+                            mode: session.mode,
+                            initiator: session.initiator,
+                            reason: callCmd.reason ?? null,
+                            sourceMessageId: messageId ?? null,
+                          },
+                        },
+                      },
+                    ]);
+                  }
+                  if (session) {
+                    trySendSseEvent(reply, {
+                      type: "conversation_call_ringing",
+                      data: { session, reason: callCmd.reason ?? null, characterId },
+                    });
+                    logger.info("[commands] Conversation call ringing for chat %s", input.chatId);
                   }
                 } else if (command.type === "memory") {
                   // ── Memory: store a fake memory on the target character ──

--- a/packages/server/src/routes/index.ts
+++ b/packages/server/src/routes/index.ts
@@ -28,6 +28,7 @@ import { youtubeRoutes } from "./youtube.routes.js";
 import { knowledgeSourcesRoutes } from "./knowledge-sources.routes.js";
 import { gifsRoutes } from "./gifs.routes.js";
 import { conversationRoutes } from "./conversation.routes.js";
+import { conversationCallsRoutes } from "./conversation-calls.routes.js";
 import { backupRoutes } from "./backup.routes.js";
 import { translateRoutes } from "./translate.routes.js";
 import { hapticRoutes } from "./haptic.routes.js";
@@ -84,6 +85,7 @@ export async function registerRoutes(app: FastifyInstance) {
   await app.register(knowledgeSourcesRoutes, { prefix: "/api/knowledge-sources" });
   await app.register(gifsRoutes, { prefix: "/api/gifs" });
   await app.register(conversationRoutes, { prefix: "/api/conversation" });
+  await app.register(conversationCallsRoutes, { prefix: "/api/conversation-calls" });
   await app.register(backupRoutes, { prefix: "/api/backup" });
   await app.register(translateRoutes, { prefix: "/api/translate" });
   await app.register(hapticRoutes, { prefix: "/api/haptic" });

--- a/packages/server/src/routes/sidecar.routes.ts
+++ b/packages/server/src/routes/sidecar.routes.ts
@@ -7,6 +7,7 @@ import type { FastifyPluginAsync, FastifyReply, FastifyRequest } from "fastify";
 import { logger, logDebugOverride } from "../lib/logger.js";
 import { z } from "zod";
 import { sidecarModelService } from "../services/sidecar/sidecar-model.service.js";
+import { sidecarSpeechService } from "../services/sidecar/sidecar-speech.service.js";
 import { mlxRuntimeService } from "../services/sidecar/mlx-runtime.service.js";
 import { sidecarRuntimeService } from "../services/sidecar/sidecar-runtime.service.js";
 import { getLocalSidecarProvider, LOCAL_SIDECAR_MODEL } from "../services/llm/local-sidecar.js";
@@ -28,16 +29,21 @@ import { postProcessSceneResult, type PostProcessContext } from "../services/sid
 import {
   SIDECAR_EMBEDDING_POOLING_TYPES,
   SIDECAR_RUNTIME_PREFERENCES,
+  SIDECAR_SPEECH_MODELS,
   scoreAmbient,
   scoreMusic,
   type GameActiveState,
   type SidecarDownloadProgress,
   type SidecarQuantization,
+  type SidecarSpeechModelId,
 } from "@marinara-engine/shared";
 import { isSidecarRuntimeInstallEnabled } from "../config/runtime-config.js";
 import { isAdminAuthorized, requirePrivilegedAccess } from "../middleware/privileged-gate.js";
 
 const quantizationSchema = z.enum(["q8_0", "q4_k_m"]);
+const speechModelIdSchema = z.enum(
+  SIDECAR_SPEECH_MODELS.map((model) => model.id) as [SidecarSpeechModelId, ...SidecarSpeechModelId[]],
+);
 const hfRepoSchema = z
   .string()
   .trim()
@@ -81,6 +87,8 @@ export const sidecarRoutes: FastifyPluginAsync = async (app) => {
       failedRuntimeVariant: sidecarProcessService.getFailedRuntimeVariant(),
     };
   });
+
+  app.get("/speech/status", async () => sidecarSpeechService.getStatus());
 
   const configSchema = z.object({
     useForTrackers: z.boolean().optional(),
@@ -275,6 +283,74 @@ export const sidecarRoutes: FastifyPluginAsync = async (app) => {
       }
     }
   }
+
+  async function handleSpeechDownloadSse(
+    reply: FastifyReply,
+    task: (onProgress: (progress: SidecarDownloadProgress) => void) => Promise<void>,
+  ): Promise<void> {
+    reply.hijack();
+    reply.raw.writeHead(200, {
+      "Content-Type": "text/event-stream",
+      "Cache-Control": "no-cache",
+      Connection: "keep-alive",
+    });
+
+    const sendEvent = (data: unknown) => {
+      if (reply.raw.destroyed || reply.raw.writableEnded) return;
+      try {
+        reply.raw.write(`data: ${JSON.stringify(data)}\n\n`);
+      } catch {
+        // Client disconnected between the guard and the write.
+      }
+    };
+
+    let lastProgressPhase: SidecarDownloadProgress["phase"] = "model";
+    let lastProgressLabel: string | undefined;
+    try {
+      await task((progress) => {
+        lastProgressPhase = progress.phase;
+        lastProgressLabel = progress.label;
+        if (progress.status === "downloading") sendEvent(progress);
+      });
+      sendEvent({ done: true });
+    } catch (error) {
+      if (!reply.raw.destroyed) {
+        sendEvent({
+          status: "error",
+          phase: lastProgressPhase,
+          label: lastProgressLabel,
+          error: error instanceof Error ? error.message : "Local Whisper download failed",
+        });
+      }
+    } finally {
+      if (!reply.raw.destroyed && !reply.raw.writableEnded) {
+        try {
+          reply.raw.end();
+        } catch {
+          // Client disconnected between the guard and the end call.
+        }
+      }
+    }
+  }
+
+  app.post<{
+    Body: { modelId?: SidecarSpeechModelId };
+  }>("/speech/download", async (req, reply) => {
+    if (!requirePrivilegedAccess(req, reply, { feature: "Local Whisper download" })) return;
+    const body = z.object({ modelId: speechModelIdSchema.optional() }).parse(req.body ?? {});
+    await handleSpeechDownloadSse(reply, async (onProgress) => {
+      await sidecarSpeechService.download(body.modelId, onProgress);
+    });
+  });
+
+  app.delete<{
+    Body: { modelId?: SidecarSpeechModelId };
+  }>("/speech/model", async (req, reply) => {
+    if (!requirePrivilegedAccess(req, reply, { feature: "Local Whisper model deletion" })) return;
+    const body = z.object({ modelId: speechModelIdSchema.optional() }).parse(req.body ?? {});
+    await sidecarSpeechService.deleteModel(body.modelId);
+    return { ok: true };
+  });
 
   app.post<{
     Body: { quantization: SidecarQuantization };

--- a/packages/server/src/routes/tts.routes.ts
+++ b/packages/server/src/routes/tts.routes.ts
@@ -18,6 +18,7 @@ import { safeFetch } from "../utils/security.js";
 
 // OpenAI built-in voices used as fallback when the provider has no /audio/voices endpoint
 const OPENAI_FALLBACK_VOICES = ["alloy", "ash", "coral", "echo", "fable", "nova", "onyx", "sage", "shimmer"];
+const XAI_FALLBACK_VOICES = ["eve", "ara", "rex", "sal", "leo"];
 
 const TTS_SOURCE_DEFAULTS: Record<TTSSource, { baseUrl: string; model: string }> = {
   openai: {
@@ -31,6 +32,10 @@ const TTS_SOURCE_DEFAULTS: Record<TTSSource, { baseUrl: string; model: string }>
   pockettts: {
     baseUrl: "http://localhost:8000",
     model: "pocket-tts",
+  },
+  xai: {
+    baseUrl: "https://api.x.ai/v1",
+    model: "grok-tts",
   },
 };
 
@@ -178,6 +183,14 @@ function fallbackVoices(source: TTSSource): TTSVoicesResponse {
     );
   }
 
+  if (source === "xai") {
+    return responseFromVoiceOptions(
+      source,
+      XAI_FALLBACK_VOICES.map((voice) => ({ id: voice, name: voice, category: "xAI built-in" })),
+      false,
+    );
+  }
+
   return responseFromVoiceOptions(
     source,
     OPENAI_FALLBACK_VOICES.map((voice) => ({ id: voice, name: voice })),
@@ -228,6 +241,10 @@ function normalizeNanoGptTtsModelId(model: string) {
 
 function clampElevenLabsSpeed(speed: number) {
   return Math.min(1.2, Math.max(0.7, Number.isFinite(speed) ? speed : 1));
+}
+
+function clampXaiSpeed(speed: number) {
+  return Math.min(1.5, Math.max(0.7, Number.isFinite(speed) ? speed : 1));
 }
 
 function elevenLabsModelSupportsSpeed(model: string) {
@@ -507,6 +524,23 @@ async function fetchProviderVoices(cfg: TTSConfig): Promise<TTSVoicesResponse> {
     return voices.length > 0 ? responseFromVoiceOptions(cfg.source, voices, true) : fallbackVoices(cfg.source);
   }
 
+  if (cfg.source === "xai") {
+    if (!cfg.apiKey) return fallbackVoices(cfg.source);
+    const res = await safeFetch(`${base}/tts/voices`, {
+      headers: openAiHeaders(cfg.apiKey),
+      signal: AbortSignal.timeout(10_000),
+      policy: {
+        allowLocal: false,
+        allowedProtocols: ["https:"],
+        flagName: "TTS_LOCAL_URLS_ENABLED",
+      },
+      maxResponseBytes: 2 * 1024 * 1024,
+    });
+    if (!res.ok) return fallbackVoices(cfg.source);
+    const voices = parseVoiceOptions(await res.json());
+    return voices.length > 0 ? responseFromVoiceOptions(cfg.source, voices, true) : fallbackVoices(cfg.source);
+  }
+
   const res = await safeFetch(`${base}/audio/voices`, {
     headers: openAiHeaders(cfg.apiKey),
     signal: AbortSignal.timeout(10_000),
@@ -592,6 +626,10 @@ export async function ttsRoutes(app: FastifyInstance) {
       return reply.status(400).send({ error: "ElevenLabs API key is not configured" });
     }
 
+    if (cfg.source === "xai" && !cfg.apiKey) {
+      return reply.status(400).send({ error: "xAI API key is not configured" });
+    }
+
     const requestVoice = resolveTTSRequestVoice(cfg.voice, voice);
 
     if (cfg.source === "elevenlabs" && !requestVoice) {
@@ -601,6 +639,7 @@ export async function ttsRoutes(app: FastifyInstance) {
     const base = configuredBaseUrl(cfg);
     const useNanoGptSpeech = isNanoGptBaseUrl(base);
     const usePocketTtsSpeech = cfg.source === "pockettts";
+    const useXaiSpeech = cfg.source === "xai";
     const configuredModel = (cfg.model || TTS_SOURCE_DEFAULTS[cfg.source].model).trim();
     const model = useNanoGptSpeech
       ? normalizeNanoGptTtsModelId(configuredModel)
@@ -615,22 +654,26 @@ export async function ttsRoutes(app: FastifyInstance) {
       });
     }
 
-    const audioFormat = cfg.source === "elevenlabs" ? "mp3" : (cfg.audioFormat ?? "mp3");
+    const audioFormat = cfg.source === "elevenlabs" || useXaiSpeech ? "mp3" : (cfg.audioFormat ?? "mp3");
     const nanoGptElevenLabsModel = useNanoGptSpeech && isNanoGptElevenLabsModel(model);
-    const includeSpeed =
-      useNanoGptSpeech
+    const includeSpeed = useXaiSpeech
+      ? true
+      : useNanoGptSpeech
         ? !nanoGptElevenLabsModel
         : cfg.source === "elevenlabs"
           ? elevenLabsModelSupportsSpeed(model)
           : true;
     const elevenLabsSpeed = clampElevenLabsSpeed(cfg.speed);
+    const xaiSpeed = clampXaiSpeed(cfg.speed);
     const url = useNanoGptSpeech
       ? `${nanoGptV1BaseUrl(base)}/audio/speech`
       : usePocketTtsSpeech
         ? `${base}/tts`
-        : cfg.source === "elevenlabs"
-          ? `${elevenLabsApiRoot(base)}/v1/text-to-speech/${encodeURIComponent(requestVoice)}?output_format=mp3_44100_128`
-          : `${base}/audio/speech`;
+        : useXaiSpeech
+          ? `${base}/tts`
+          : cfg.source === "elevenlabs"
+            ? `${elevenLabsApiRoot(base)}/v1/text-to-speech/${encodeURIComponent(requestVoice)}?output_format=mp3_44100_128`
+            : `${base}/audio/speech`;
     const providerText = cfg.source === "elevenlabs" ? buildElevenLabsTextInput(text, tone) : text;
     const elevenLabsLanguageCode = cfg.elevenLabsLanguageCode?.trim();
     const includeSpeakerInstructions = cfg.source !== "elevenlabs";
@@ -657,9 +700,11 @@ export async function ttsRoutes(app: FastifyInstance) {
           ? nanoGptHeaders(cfg.apiKey)
           : usePocketTtsSpeech
             ? optionalBearerHeaders(cfg.apiKey)
-            : cfg.source === "elevenlabs"
-              ? elevenLabsHeaders(cfg.apiKey)
-              : openAiHeaders(cfg.apiKey),
+            : useXaiSpeech
+              ? openAiHeaders(cfg.apiKey)
+              : cfg.source === "elevenlabs"
+                ? elevenLabsHeaders(cfg.apiKey)
+                : openAiHeaders(cfg.apiKey),
         body: pocketTtsForm
           ? pocketTtsForm
           : useNanoGptSpeech
@@ -671,24 +716,36 @@ export async function ttsRoutes(app: FastifyInstance) {
                 response_format: audioFormat,
                 ...(speechInstructions ? { instructions: speechInstructions } : {}),
               })
-            : cfg.source === "elevenlabs"
+            : useXaiSpeech
               ? JSON.stringify({
                   text: providerText,
-                  model_id: model,
-                  ...(elevenLabsLanguageCode ? { language_code: elevenLabsLanguageCode } : {}),
-                  voice_settings: {
-                    stability: cfg.elevenLabsStability,
-                    ...(includeSpeed ? { speed: elevenLabsSpeed } : {}),
+                  voice_id: requestVoice || "eve",
+                  language: "auto",
+                  output_format: {
+                    codec: audioFormat,
+                    sample_rate: audioFormat === "mp3" ? 44_100 : 24_000,
+                    ...(audioFormat === "mp3" ? { bit_rate: 128_000 } : {}),
                   },
+                  ...(includeSpeed ? { speed: xaiSpeed } : {}),
                 })
-              : JSON.stringify({
-                  model,
-                  input: providerText,
-                  voice: requestVoice,
-                  ...(includeSpeed ? { speed: cfg.speed } : {}),
-                  response_format: audioFormat,
-                  ...(speechInstructions ? { instructions: speechInstructions } : {}),
-                }),
+              : cfg.source === "elevenlabs"
+                ? JSON.stringify({
+                    text: providerText,
+                    model_id: model,
+                    ...(elevenLabsLanguageCode ? { language_code: elevenLabsLanguageCode } : {}),
+                    voice_settings: {
+                      stability: cfg.elevenLabsStability,
+                      ...(includeSpeed ? { speed: elevenLabsSpeed } : {}),
+                    },
+                  })
+                : JSON.stringify({
+                    model,
+                    input: providerText,
+                    voice: requestVoice,
+                    ...(includeSpeed ? { speed: cfg.speed } : {}),
+                    response_format: audioFormat,
+                    ...(speechInstructions ? { instructions: speechInstructions } : {}),
+                  }),
         signal: AbortSignal.timeout(60_000),
         policy: {
           allowLocal: allowLocalTtsUrl(cfg),

--- a/packages/server/src/routes/updates.routes.ts
+++ b/packages/server/src/routes/updates.routes.ts
@@ -53,9 +53,10 @@ const UPDATE_CHANNELS: Record<UpdateChannel, UpdateChannelInfo> = {
 };
 const DEFAULT_PNPM_VERSION = "10.33.2";
 const PNPM_NONINTERACTIVE_ARGS = ["--config.trustPolicy=off", "--config.confirmModulesPurge=false"];
+const PNPM_UPDATE_INSTALL_ARGS = ["install", "--force", "--frozen-lockfile"];
 const DOCKER_IMAGE = "ghcr.io/pasta-devs/marinara-engine";
 const MANUAL_GIT_UPDATE_COMMAND =
-  "git fetch origin +refs/heads/main:refs/remotes/origin/main && (git merge --ff-only origin/main || git checkout --detach origin/main) && pnpm --config.trustPolicy=off --config.confirmModulesPurge=false install && pnpm build && pnpm start";
+  "git fetch origin +refs/heads/main:refs/remotes/origin/main && (git merge --ff-only origin/main || git checkout --detach origin/main) && pnpm --config.trustPolicy=off --config.confirmModulesPurge=false install --force --frozen-lockfile && pnpm build && pnpm start";
 const DOCKER_UPDATE_COMMAND = "docker compose pull && docker compose up -d";
 const ANDROID_APK_NOTICE =
   "> [!IMPORTANT]\n" +
@@ -170,7 +171,7 @@ function getManualGitApplyCommand(channel = UPDATE_CHANNELS.stable, platform: Se
     platform === "android-termux"
       ? "pnpm --filter @marinara-engine/shared build && pnpm --filter @marinara-engine/server build && pnpm --filter @marinara-engine/client build"
       : "pnpm --filter @marinara-engine/shared build && pnpm --filter @marinara-engine/server --filter @marinara-engine/client --parallel run build";
-  return `git fetch ${UPDATE_REMOTE} ${channel.fetchRef} && ${checkoutCommand} && pnpm --config.trustPolicy=off --config.confirmModulesPurge=false install --frozen-lockfile && ${buildCommand}`;
+  return `git fetch ${UPDATE_REMOTE} ${channel.fetchRef} && ${checkoutCommand} && pnpm --config.trustPolicy=off --config.confirmModulesPurge=false ${PNPM_UPDATE_INSTALL_ARGS.join(" ")} && ${buildCommand}`;
 }
 
 function getManualUpdateCommand(installType: InstallType, platform: ServerPlatform, channel = UPDATE_CHANNELS.stable) {
@@ -834,7 +835,7 @@ export async function updatesRoutes(app: FastifyInstance) {
       }
 
       // Step 2: pnpm install
-      await runPinnedPnpm(root, ["install", "--frozen-lockfile"], 120_000);
+      await runPinnedPnpm(root, PNPM_UPDATE_INSTALL_ARGS, 180_000);
 
       // Step 3: Rebuild all packages
       await runPinnedBuild(root);

--- a/packages/server/src/services/conversation/character-commands.ts
+++ b/packages/server/src/services/conversation/character-commands.ts
@@ -11,6 +11,7 @@
 // - [selfie], [selfie: context="description of the selfie"], [selfie: "description"], or [selfie: description]
 // - [memory: target="CharName", summary="description of the memory"]
 // - [scene: scenario="...", background="...", plan="..."] (initiate a mini-roleplay scene)
+// - [call] or [call: reason="..."] (ring the user for an audio call; Conversation mode)
 // - [uno] (start a game of UNO at the table; Conversation mode)
 // - [chess] (start a one-on-one chess game against the user; Conversation mode)
 // - [spotify: title="Song title", artist="Artist"] (play a song on the user's active Spotify player)
@@ -72,6 +73,12 @@ export interface SceneCommand {
   background?: string;
   /** Optional plot plan / outline for how the scene unfolds */
   plan?: string;
+}
+
+export interface CallCommand {
+  /** Ring the user for a Conversation-mode audio call. Param-less or optional reason. */
+  type: "call";
+  reason?: string;
 }
 
 export interface UnoCommand {
@@ -332,6 +339,7 @@ export type CharacterCommand =
   | SelfieCommand
   | MemoryCommand
   | SceneCommand
+  | CallCommand
   | UnoCommand
   | ChessCommand
   | InfluenceCommand
@@ -357,6 +365,7 @@ const CROSS_POST_RE = /\[cross_post:\s*target="([^"]+)"\]/gi;
 const SELFIE_RE = /\[selfie(?::\s*(?:context="([^"]*)"|"([^"]*)"|([^\]\r\n"]+)))?\]/gi;
 const MEMORY_RE = /\[memory:\s*target="([^"]+)"\s*,\s*summary="([^"]+)"\]/gi;
 const SCENE_RE = new RegExp(`\\[scene:\\s*(${QUOTED_PARAM_BLOCK})\\]`, "gi");
+const CALL_RE = new RegExp(`\\[call(?::\\s*(${QUOTED_PARAM_BLOCK}))?\\]`, "gi");
 // Param-less UNO trigger. Tolerates a stray `[uno: ...]` so a chatty model can't dodge the match.
 const UNO_RE = /\[uno(?::[^\]\r\n]*)?\]/gi;
 // Param-less chess trigger. Same tolerant shape as UNO_RE.
@@ -370,6 +379,8 @@ const REACT_RE = /\[react:\s*(?:emoji="([^"\]]+)"|"([^"\]]+)"|([^\]\r\n"]+))\]/g
 const DIRECT_MESSAGE_RE = new RegExp(`\\[dm:\\s*(${QUOTED_PARAM_BLOCK})\\]`, "gi");
 const INFLUENCE_RE = /<influence>([\s\S]*?)<\/influence>/gi;
 const NOTE_RE = /<note>([\s\S]*?)<\/note>/gi;
+const INFLUENCE_BRACKET_RE = new RegExp(`\\[influence:\\s*(${QUOTED_PARAM_BLOCK})\\]`, "gi");
+const NOTE_BRACKET_RE = new RegExp(`\\[note:\\s*(${QUOTED_PARAM_BLOCK})\\]`, "gi");
 
 // Assistant command regexes
 const CREATE_PERSONA_RE = new RegExp(`\\[create_persona:\\s*(${QUOTED_PARAM_BLOCK})\\]`, "gi");
@@ -443,6 +454,18 @@ function parseQuotedParam(params: string, key: string, allowEmpty = false): stri
   const value = decodeQuotedParamValue(rawValue);
   if (!allowEmpty && value.length === 0) return undefined;
   return value;
+}
+
+function parseCommandTextParam(params: string, keys: string[]): string {
+  for (const key of keys) {
+    const value = parseQuotedParam(params, key);
+    if (value !== undefined) return value;
+  }
+  return params
+    .trim()
+    .replace(/^["“”‘’]\s*/, "")
+    .replace(/\s*["“”‘’]$/, "")
+    .trim();
 }
 
 function parseStringList(value: string | undefined): string[] | undefined {
@@ -872,6 +895,14 @@ export function parseCharacterCommands(content: string): {
     if (cmd.scenario) commands.push(cmd);
   }
 
+  // Parse call command — ring the user for an audio call. Only one per message.
+  for (const match of content.matchAll(CALL_RE)) {
+    const params = match[1] ?? "";
+    const reason = parseQuotedParam(params, "reason") ?? params.replace(/^"|"$/g, "").trim();
+    commands.push({ type: "call", reason: reason || undefined });
+    break;
+  }
+
   // Parse uno command — start a game of UNO. Param-less; only one per message.
   for (const _unoMatch of content.matchAll(UNO_RE)) {
     commands.push({ type: "uno" });
@@ -890,9 +921,21 @@ export function parseCharacterCommands(content: string): {
     if (text) commands.push({ type: "influence", content: text });
   }
 
+  // Backward compatibility for older prompts that described this as [influence: summary="..."].
+  for (const match of content.matchAll(INFLUENCE_BRACKET_RE)) {
+    const text = stripConversationPromptTimestamps(parseCommandTextParam(match[1]!, ["summary", "text", "content"]));
+    if (text) commands.push({ type: "influence", content: text });
+  }
+
   // Parse note commands (<note>text</note>)
   for (const match of content.matchAll(NOTE_RE)) {
     const text = stripConversationPromptTimestamps(match[1]!.trim());
+    if (text) commands.push({ type: "note", content: text });
+  }
+
+  // Backward compatibility for older prompts that described this as [note: text="..."].
+  for (const match of content.matchAll(NOTE_BRACKET_RE)) {
+    const text = stripConversationPromptTimestamps(parseCommandTextParam(match[1]!, ["text", "summary", "content"]));
     if (text) commands.push({ type: "note", content: text });
   }
 
@@ -1072,6 +1115,7 @@ export function parseCharacterCommands(content: string): {
     .replace(SELFIE_RE, "")
     .replace(MEMORY_RE, "")
     .replace(SCENE_RE, "")
+    .replace(CALL_RE, "")
     .replace(UNO_RE, "")
     .replace(CHESS_RE, "")
     .replace(HAPTIC_RE, "")
@@ -1080,6 +1124,8 @@ export function parseCharacterCommands(content: string): {
     .replace(REACT_RE, "")
     .replace(INFLUENCE_RE, "")
     .replace(NOTE_RE, "")
+    .replace(INFLUENCE_BRACKET_RE, "")
+    .replace(NOTE_BRACKET_RE, "")
     .replace(CREATE_PERSONA_RE, "")
     .replace(CREATE_CHARACTER_RE, "")
     .replace(UPDATE_CHARACTER_RE, "")

--- a/packages/server/src/services/llm/base-provider.ts
+++ b/packages/server/src/services/llm/base-provider.ts
@@ -62,8 +62,17 @@ export interface ChatMessage {
     data: string;
     filename?: string;
   }>;
+  /** Base64 data URLs for provider-native audio/video inputs */
+  media?: ChatMediaAttachment[];
   /** Provider-specific metadata (e.g. Gemini parts with thought signatures) */
   providerMetadata?: Record<string, unknown>;
+}
+
+export interface ChatMediaAttachment {
+  kind: "audio" | "video";
+  data: string;
+  mimeType: string;
+  filename?: string;
 }
 
 export interface LLMToolCall {
@@ -258,6 +267,9 @@ function estimateMessageTokens(message: ChatMessage): number {
   if (message.files?.length) {
     total += message.files.reduce((sum, file) => sum + estimateFileTokens(file), 0);
   }
+  if (message.media?.length) {
+    total += message.media.reduce((sum, media) => sum + estimateFileTokens({ data: media.data }), 0);
+  }
   if (message.providerMetadata) {
     total += Math.min(estimateStructuredTokens(message.providerMetadata), 512);
   }
@@ -273,6 +285,7 @@ function cloneMessages(messages: ChatMessage[]): ChatMessage[] {
     ...message,
     ...(message.images ? { images: [...message.images] } : {}),
     ...(message.files ? { files: message.files.map((file) => ({ ...file })) } : {}),
+    ...(message.media ? { media: message.media.map((media) => ({ ...media })) } : {}),
     ...(message.tool_calls
       ? { tool_calls: message.tool_calls.map((call) => ({ ...call, function: { ...call.function } })) }
       : {}),

--- a/packages/server/src/services/llm/providers/google.provider.ts
+++ b/packages/server/src/services/llm/providers/google.provider.ts
@@ -366,6 +366,16 @@ function fileParts(files?: ChatMessage["files"]): Array<Record<string, unknown>>
   return parts;
 }
 
+function mediaParts(media?: ChatMessage["media"]): Array<Record<string, unknown>> {
+  if (!media?.length) return [];
+  const parts: Array<Record<string, unknown>> = [];
+  for (const item of media) {
+    const match = item.data.match(/^data:([^;]+);base64,(.+)$/);
+    if (match) parts.push({ inline_data: { mime_type: item.mimeType || match[1], data: match[2] } });
+  }
+  return parts;
+}
+
 function parseToolResultContent(content: string): Record<string, unknown> {
   const trimmed = content.trim();
   if (!trimmed) return { result: "" };
@@ -412,7 +422,7 @@ function formatGoogleContents(
     }
 
     if (message.role === "user" || message.role === "assistant") {
-      const parts = [...fileParts(message.files), ...imageParts(message.images)];
+      const parts = [...fileParts(message.files), ...imageParts(message.images), ...mediaParts(message.media)];
       if (message.content?.trim()) parts.push({ text: message.content });
       if (parts.length > 0) contents.push({ role: message.role === "assistant" ? "model" : "user", parts });
     }
@@ -484,7 +494,11 @@ export class GoogleProvider extends BaseLLMProvider {
     const isGemini3 = /gemini-3/i.test(model);
     const supportsThinking = isGemini3 || /gemini-2\.5|gemini-2\.0-flash-thinking/i.test(model);
     let thinkingConfig: Record<string, unknown> | undefined;
-    if (this.shouldSendParameter(options, "reasoningEffort") && supportsThinking && (options.enableThinking || options.reasoningEffort)) {
+    if (
+      this.shouldSendParameter(options, "reasoningEffort") &&
+      supportsThinking &&
+      (options.enableThinking || options.reasoningEffort)
+    ) {
       if (isGemini3) {
         const levelMap = { low: "low", medium: "medium", high: "high", xhigh: "high", max: "high" } as const;
         thinkingConfig = {
@@ -516,7 +530,9 @@ export class GoogleProvider extends BaseLLMProvider {
         ...(this.shouldSendParameter(options, "temperature") ? { temperature: options.temperature ?? 1 } : {}),
         ...(this.shouldSendParameter(options, "maxTokens") ? { maxOutputTokens: maxTokens } : {}),
         ...(this.shouldSendParameter(options, "topP") ? { topP: options.topP ?? 1 } : {}),
-        ...(this.shouldSendParameter(options, "topK") && typeof options.topK === "number" && Number.isFinite(options.topK)
+        ...(this.shouldSendParameter(options, "topK") &&
+        typeof options.topK === "number" &&
+        Number.isFinite(options.topK)
           ? { topK: Math.max(0, Math.trunc(options.topK)) }
           : {}),
         ...(this.shouldSendParameter(options, "frequencyPenalty") && options.frequencyPenalty
@@ -604,7 +620,11 @@ export class GoogleProvider extends BaseLLMProvider {
       !suppressModelParameters && (isGemini3 || /gemini-2\.5|gemini-2\.0-flash-thinking/i.test(model));
 
     let thinkingConfig: Record<string, unknown> | undefined;
-    if (this.shouldSendParameter(options, "reasoningEffort") && supportsThinking && (options.enableThinking || options.reasoningEffort)) {
+    if (
+      this.shouldSendParameter(options, "reasoningEffort") &&
+      supportsThinking &&
+      (options.enableThinking || options.reasoningEffort)
+    ) {
       if (isGemini3) {
         const levelMap = { low: "low", medium: "medium", high: "high", xhigh: "high", max: "high" } as const;
         thinkingConfig = {
@@ -640,7 +660,7 @@ export class GoogleProvider extends BaseLLMProvider {
     // Convert to Gemini format — filter out empty-content messages
     const systemMessages = messages.filter((m) => m.role === "system" && m.content?.trim());
     const chatMessages = messages.filter(
-      (m) => m.role !== "system" && (m.content?.trim() || m.images?.length || m.files?.length),
+      (m) => m.role !== "system" && (m.content?.trim() || m.images?.length || m.files?.length || m.media?.length),
     );
 
     const contents = chatMessages.map((m) => {
@@ -651,7 +671,11 @@ export class GoogleProvider extends BaseLLMProvider {
         return { role: "model" as const, parts: storedParts };
       }
 
-      const parts: Array<Record<string, unknown>> = [...fileParts(m.files), ...imageParts(m.images)];
+      const parts: Array<Record<string, unknown>> = [
+        ...fileParts(m.files),
+        ...imageParts(m.images),
+        ...mediaParts(m.media),
+      ];
       if (m.content?.trim()) parts.push({ text: m.content });
       return {
         role: m.role === "assistant" ? ("model" as const) : ("user" as const),

--- a/packages/server/src/services/llm/providers/openai.provider.ts
+++ b/packages/server/src/services/llm/providers/openai.provider.ts
@@ -107,6 +107,40 @@ export class OpenAIProvider extends BaseLLMProvider {
     );
   }
 
+  private static dataUrlPayload(data: string): { mimeType: string; base64: string } | null {
+    const match = data.match(/^data:([^;]+);base64,(.+)$/);
+    if (!match) return null;
+    return { mimeType: match[1]?.toLowerCase() ?? "", base64: match[2] ?? "" };
+  }
+
+  private static openAIAudioFormat(mimeType: string, filename?: string): "wav" | "mp3" | null {
+    const normalized = mimeType.toLowerCase().split(";", 1)[0] ?? "";
+    const ext = filename?.toLowerCase().split(".").pop();
+    if (normalized === "audio/wav" || normalized === "audio/x-wav" || normalized === "audio/wave" || ext === "wav") {
+      return "wav";
+    }
+    if (normalized === "audio/mpeg" || normalized === "audio/mp3" || ext === "mp3") return "mp3";
+    return null;
+  }
+
+  private static openAIMediaContentParts(media: ChatMessage["media"] | undefined): Array<Record<string, unknown>> {
+    if (!media?.length) return [];
+    const parts: Array<Record<string, unknown>> = [];
+    for (const item of media) {
+      if (item.kind !== "audio") continue;
+      const payload = OpenAIProvider.dataUrlPayload(item.data);
+      if (!payload) continue;
+      const format = OpenAIProvider.openAIAudioFormat(item.mimeType || payload.mimeType, item.filename);
+      if (!format) continue;
+      parts.push({ type: "input_audio", input_audio: { data: payload.base64, format } });
+    }
+    return parts;
+  }
+
+  private static hasProviderNativeMedia(messages: ChatMessage[]): boolean {
+    return messages.some((message) => message.media?.length);
+  }
+
   private static async parseJsonBody<T>(response: Response, context: string): Promise<T> {
     const raw = await response.text();
     try {
@@ -809,7 +843,7 @@ export class OpenAIProvider extends BaseLLMProvider {
         if (m.role === "tool") return true;
         if (m.role === "assistant" && m.tool_calls?.length) return true;
         // Drop messages with no text or provider-native attachments.
-        return m.content?.trim() || m.images?.length || m.files?.length;
+        return m.content?.trim() || m.images?.length || m.files?.length || m.media?.length;
       })
       .map((m) => {
         const reasoningPayload =
@@ -826,7 +860,7 @@ export class OpenAIProvider extends BaseLLMProvider {
           };
         }
         // Multimodal/file input: use content array format
-        if (m.images?.length || m.files?.length) {
+        if (m.images?.length || m.files?.length || m.media?.length) {
           const parts: Array<Record<string, unknown>> = [
             ...OpenAIProvider.openAIFileContentParts(m.files, "chat_completions"),
           ];
@@ -834,6 +868,7 @@ export class OpenAIProvider extends BaseLLMProvider {
           for (const img of m.images ?? []) {
             parts.push({ type: "image_url", image_url: { url: img } });
           }
+          parts.push(...OpenAIProvider.openAIMediaContentParts(m.media));
           return { role: m.role, content: parts };
         }
         // Map system → developer for newer OpenAI models
@@ -854,7 +889,7 @@ export class OpenAIProvider extends BaseLLMProvider {
         : this.applyMaxTokensCap(contextFit.maxTokens ?? configuredMaxTokens);
 
     // Route to Responses API for models that require it
-    if (this.useResponsesAPI(options.model, options)) {
+    if (!OpenAIProvider.hasProviderNativeMedia(messages) && this.useResponsesAPI(options.model, options)) {
       logger.debug(
         "[OpenAI] Routing chat() to Responses API for model=%s stream=%s",
         options.model,
@@ -1120,7 +1155,7 @@ export class OpenAIProvider extends BaseLLMProvider {
         : this.applyMaxTokensCap(contextFit.maxTokens ?? configuredMaxTokens);
 
     // Route to Responses API for models that require it
-    if (this.useResponsesAPI(options.model, options)) {
+    if (!OpenAIProvider.hasProviderNativeMedia(messages) && this.useResponsesAPI(options.model, options)) {
       logger.debug(
         "[OpenAI] Routing chatComplete() to Responses API for model=%s onToken=%s",
         options.model,

--- a/packages/server/src/services/sidecar/sidecar-speech.service.ts
+++ b/packages/server/src/services/sidecar/sidecar-speech.service.ts
@@ -1,0 +1,432 @@
+import { existsSync, mkdirSync, readdirSync, readFileSync, rmSync, statSync, writeFileSync } from "fs";
+import { createRequire } from "module";
+import { dirname, join, resolve, sep } from "path";
+import {
+  SIDECAR_SPEECH_DEFAULT_MODEL_ID,
+  SIDECAR_SPEECH_MODELS,
+  type SidecarDownloadProgress,
+  type SidecarSpeechConfig,
+  type SidecarSpeechModelId,
+  type SidecarSpeechRuntimeDiagnostics,
+  type SidecarSpeechStatus,
+  type SidecarSpeechStatusResponse,
+} from "@marinara-engine/shared";
+import { logger } from "../../lib/logger.js";
+import { DATA_DIR } from "../../utils/data-dir.js";
+
+const MODELS_DIR = join(DATA_DIR, "models");
+const SPEECH_CONFIG_PATH = join(MODELS_DIR, "sidecar-speech-config.json");
+const TARGET_SAMPLE_RATE = 16_000;
+const require = createRequire(import.meta.url);
+const isLite = process.env.MARINARA_LITE === "true" || process.env.MARINARA_LITE === "1";
+
+type AsrPipeline = (
+  audio: Float32Array,
+  options?: { chunk_length_s?: number; stride_length_s?: number; task?: "transcribe" | "translate" },
+) => Promise<{ text?: string } | Array<{ text?: string }>>;
+
+type TransformersProgress = {
+  status?: string;
+  name?: string;
+  file?: string;
+  loaded?: number;
+  total?: number;
+};
+
+function isSpeechModelId(value: unknown): value is SidecarSpeechModelId {
+  return typeof value === "string" && SIDECAR_SPEECH_MODELS.some((model) => model.id === value);
+}
+
+function getSpeechModel(modelId: SidecarSpeechModelId) {
+  return SIDECAR_SPEECH_MODELS.find((model) => model.id === modelId) ?? SIDECAR_SPEECH_MODELS[0]!;
+}
+
+function safeModelCachePath(repoId: string): string {
+  const destination = join(MODELS_DIR, ...repoId.split("/").filter(Boolean));
+  const resolvedRoot = resolve(MODELS_DIR);
+  const resolvedDestination = resolve(destination);
+  if (resolvedDestination !== resolvedRoot && !resolvedDestination.startsWith(resolvedRoot + sep)) {
+    throw new Error("Resolved speech model cache path escaped the models directory");
+  }
+  return resolvedDestination;
+}
+
+function dirSize(path: string): number | null {
+  if (!existsSync(path)) return null;
+  try {
+    const stat = statSync(path);
+    if (stat.isFile()) return stat.size;
+    if (!stat.isDirectory()) return null;
+    return readdirSync(path).reduce((total, entry) => total + (dirSize(join(path, entry)) ?? 0), 0);
+  } catch {
+    return null;
+  }
+}
+
+function resolveOnnxRuntimeBindingPath(): string | null {
+  try {
+    const packageJsonPath = require.resolve("onnxruntime-node/package.json");
+    return join(dirname(packageJsonPath), "bin", "napi-v6", process.platform, process.arch, "onnxruntime_binding.node");
+  } catch {
+    return null;
+  }
+}
+
+function resolveOnnxRuntimePackageDir(): string | null {
+  try {
+    return dirname(require.resolve("onnxruntime-node/package.json"));
+  } catch {
+    return null;
+  }
+}
+
+function listInstalledOnnxRuntimeArchs(packageDir: string | null): string[] {
+  if (!packageDir) return [];
+  const platformDir = join(packageDir, "bin", "napi-v6", process.platform);
+  if (!existsSync(platformDir)) return [];
+  try {
+    return readdirSync(platformDir)
+      .filter((arch) => existsSync(join(platformDir, arch, "onnxruntime_binding.node")))
+      .sort();
+  } catch {
+    return [];
+  }
+}
+
+function getOnnxRuntimeDiagnostics(): SidecarSpeechRuntimeDiagnostics {
+  const packageDir = resolveOnnxRuntimePackageDir();
+  const expectedBindingPath = resolveOnnxRuntimeBindingPath();
+  return {
+    packageFound: Boolean(packageDir),
+    bindingFound: Boolean(expectedBindingPath && existsSync(expectedBindingPath)),
+    expectedBindingPath,
+    installedBindingArchs: listInstalledOnnxRuntimeArchs(packageDir),
+    platform: process.platform,
+    arch: process.arch,
+    nodeVersion: process.version,
+    nodeExecPath: process.execPath,
+    liteMode: isLite,
+  };
+}
+
+function hasNativeOnnxRuntimeBinding(): boolean {
+  return getOnnxRuntimeDiagnostics().bindingFound;
+}
+
+function normalizeSample(value: number): number {
+  if (!Number.isFinite(value)) return 0;
+  return Math.max(-1, Math.min(1, value));
+}
+
+function readWavChunk(buffer: Buffer, offset: number) {
+  const id = buffer.toString("ascii", offset, offset + 4);
+  const size = buffer.readUInt32LE(offset + 4);
+  return { id, size, dataOffset: offset + 8, nextOffset: offset + 8 + size + (size % 2) };
+}
+
+function decodePcmWav(buffer: Buffer): { samples: Float32Array; sampleRate: number } {
+  if (buffer.length < 44 || buffer.toString("ascii", 0, 4) !== "RIFF" || buffer.toString("ascii", 8, 12) !== "WAVE") {
+    throw new Error("Local Whisper expects a WAV audio upload.");
+  }
+
+  let audioFormat = 0;
+  let channels = 0;
+  let sampleRate = 0;
+  let bitsPerSample = 0;
+  let dataOffset = -1;
+  let dataSize = 0;
+  let offset = 12;
+
+  while (offset + 8 <= buffer.length) {
+    const chunk = readWavChunk(buffer, offset);
+    if (chunk.id === "fmt ") {
+      audioFormat = buffer.readUInt16LE(chunk.dataOffset);
+      channels = buffer.readUInt16LE(chunk.dataOffset + 2);
+      sampleRate = buffer.readUInt32LE(chunk.dataOffset + 4);
+      bitsPerSample = buffer.readUInt16LE(chunk.dataOffset + 14);
+    } else if (chunk.id === "data") {
+      dataOffset = chunk.dataOffset;
+      dataSize = chunk.size;
+    }
+    offset = chunk.nextOffset;
+  }
+
+  if (dataOffset < 0 || dataSize <= 0) throw new Error("WAV audio did not include a data chunk.");
+  if (channels <= 0 || sampleRate <= 0) throw new Error("WAV audio metadata is invalid.");
+  if (audioFormat !== 1 && audioFormat !== 3) {
+    throw new Error("Local Whisper only accepts PCM or float WAV audio.");
+  }
+
+  const bytesPerSample = bitsPerSample / 8;
+  if (![1, 2, 3, 4].includes(bytesPerSample)) {
+    throw new Error(`Unsupported WAV bit depth: ${bitsPerSample}`);
+  }
+
+  const frameCount = Math.floor(dataSize / bytesPerSample / channels);
+  const samples = new Float32Array(frameCount);
+  for (let frame = 0; frame < frameCount; frame += 1) {
+    let sum = 0;
+    for (let channel = 0; channel < channels; channel += 1) {
+      const sampleOffset = dataOffset + (frame * channels + channel) * bytesPerSample;
+      if (audioFormat === 3 && bitsPerSample === 32) {
+        sum += normalizeSample(buffer.readFloatLE(sampleOffset));
+      } else if (bitsPerSample === 8) {
+        sum += (buffer.readUInt8(sampleOffset) - 128) / 128;
+      } else if (bitsPerSample === 16) {
+        sum += buffer.readInt16LE(sampleOffset) / 32768;
+      } else if (bitsPerSample === 24) {
+        sum += buffer.readIntLE(sampleOffset, 3) / 8388608;
+      } else {
+        sum += buffer.readInt32LE(sampleOffset) / 2147483648;
+      }
+    }
+    samples[frame] = normalizeSample(sum / channels);
+  }
+
+  return { samples, sampleRate };
+}
+
+function resampleLinear(samples: Float32Array, fromRate: number, toRate: number): Float32Array {
+  if (fromRate === toRate) return samples;
+  const nextLength = Math.max(1, Math.round((samples.length * toRate) / fromRate));
+  const next = new Float32Array(nextLength);
+  const ratio = (samples.length - 1) / Math.max(1, nextLength - 1);
+  for (let index = 0; index < nextLength; index += 1) {
+    const sourceIndex = index * ratio;
+    const left = Math.floor(sourceIndex);
+    const right = Math.min(samples.length - 1, left + 1);
+    const fraction = sourceIndex - left;
+    next[index] = samples[left]! * (1 - fraction) + samples[right]! * fraction;
+  }
+  return next;
+}
+
+class SidecarSpeechService {
+  private config: SidecarSpeechConfig;
+  private status: SidecarSpeechStatus = "not_downloaded";
+  private activeModelId: SidecarSpeechModelId | null = null;
+  private pipeline: AsrPipeline | null = null;
+  private loadingPromise: Promise<AsrPipeline> | null = null;
+  private downloadProgress: SidecarDownloadProgress | null = null;
+  private lastError: string | null = null;
+
+  constructor() {
+    mkdirSync(MODELS_DIR, { recursive: true });
+    this.config = this.loadConfig();
+    this.status = this.detectStatus();
+  }
+
+  private loadConfig(): SidecarSpeechConfig {
+    try {
+      if (!existsSync(SPEECH_CONFIG_PATH)) return { modelId: null };
+      const raw = JSON.parse(readFileSync(SPEECH_CONFIG_PATH, "utf-8")) as Partial<SidecarSpeechConfig>;
+      return { modelId: isSpeechModelId(raw.modelId) ? raw.modelId : null };
+    } catch {
+      return { modelId: null };
+    }
+  }
+
+  private saveConfig(): void {
+    writeFileSync(SPEECH_CONFIG_PATH, JSON.stringify(this.config, null, 2), "utf-8");
+  }
+
+  private isAvailable(): boolean {
+    return !isLite && hasNativeOnnxRuntimeBinding();
+  }
+
+  private getDownloadedModelId(): SidecarSpeechModelId | null {
+    const configured = this.config.modelId;
+    if (configured && this.isModelDownloaded(configured)) return configured;
+    return SIDECAR_SPEECH_MODELS.find((model) => this.isModelDownloaded(model.id))?.id ?? null;
+  }
+
+  private detectStatus(): SidecarSpeechStatus {
+    if (this.pipeline) return "ready";
+    return this.getDownloadedModelId() ? "downloaded" : "not_downloaded";
+  }
+
+  private isModelDownloaded(modelId: SidecarSpeechModelId): boolean {
+    const model = getSpeechModel(modelId);
+    const path = safeModelCachePath(model.repoId);
+    return Boolean(existsSync(path) && (dirSize(path) ?? 0) > 0);
+  }
+
+  private getModelSize(modelId: SidecarSpeechModelId | null): number | null {
+    if (!modelId) return null;
+    return dirSize(safeModelCachePath(getSpeechModel(modelId).repoId));
+  }
+
+  private createProgressCallback(modelId: SidecarSpeechModelId, onProgress?: (progress: SidecarDownloadProgress) => void) {
+    const model = getSpeechModel(modelId);
+    let lastReportAt = Date.now();
+    let lastLoaded = 0;
+    return (data: TransformersProgress) => {
+      const label = data.file ? `${model.label}: ${data.file}` : model.label;
+      if (data.status === "progress") {
+        const now = Date.now();
+        const elapsedSeconds = Math.max(0.001, (now - lastReportAt) / 1000);
+        const loaded = Number(data.loaded ?? 0);
+        const speed = Math.max(0, (loaded - lastLoaded) / elapsedSeconds);
+        lastReportAt = now;
+        lastLoaded = loaded;
+        this.downloadProgress = {
+          phase: "model",
+          status: "downloading",
+          downloaded: loaded,
+          total: Number(data.total ?? model.sizeBytes),
+          speed,
+          label,
+        };
+        onProgress?.(this.downloadProgress);
+        return;
+      }
+      if (data.status === "initiate" || data.status === "download") {
+        this.downloadProgress = {
+          phase: "model",
+          status: "downloading",
+          downloaded: 0,
+          total: model.sizeBytes,
+          speed: 0,
+          label,
+        };
+        onProgress?.(this.downloadProgress);
+      }
+    };
+  }
+
+  private async disposeCurrentPipeline(): Promise<void> {
+    const current = this.pipeline as (AsrPipeline & { dispose?: () => Promise<void> }) | null;
+    this.pipeline = null;
+    this.activeModelId = null;
+    if (current?.dispose) {
+      await current.dispose().catch((error) => logger.warn(error, "[sidecar-speech] Failed to dispose ASR pipeline"));
+    }
+  }
+
+  private async loadPipeline(
+    modelId: SidecarSpeechModelId,
+    options: { localFilesOnly: boolean; progress?: (data: TransformersProgress) => void },
+  ): Promise<AsrPipeline> {
+    if (this.pipeline && this.activeModelId === modelId) return this.pipeline;
+    if (this.loadingPromise && this.activeModelId === modelId) return this.loadingPromise;
+
+    await this.disposeCurrentPipeline();
+    this.activeModelId = modelId;
+    this.status = options.localFilesOnly ? "loading" : "downloading_model";
+    this.lastError = null;
+
+    this.loadingPromise = (async () => {
+      if (!this.isAvailable()) {
+        const runtime = getOnnxRuntimeDiagnostics();
+        const installed = runtime.installedBindingArchs.length > 0 ? runtime.installedBindingArchs.join(", ") : "none";
+        throw new Error(
+          `Local Whisper is unavailable because onnxruntime-node is not installed for ${process.platform}/${process.arch}. Installed native runtime architectures for this platform: ${installed}.`,
+        );
+      }
+      const model = getSpeechModel(modelId);
+      const { pipeline: createPipeline, env } = await import("@huggingface/transformers");
+      env.cacheDir = MODELS_DIR;
+      env.allowLocalModels = true;
+      env.useBrowserCache = false;
+
+      logger.info("[sidecar-speech] Loading %s...", model.repoId);
+      const startedAt = Date.now();
+      const loaded = (await createPipeline("automatic-speech-recognition", model.repoId, {
+        dtype: "q8",
+        local_files_only: options.localFilesOnly,
+        progress_callback: options.progress as never,
+      })) as AsrPipeline;
+      logger.info("[sidecar-speech] Loaded %s in %dms", model.repoId, Date.now() - startedAt);
+      this.pipeline = loaded;
+      this.status = "ready";
+      this.downloadProgress = null;
+      this.config = { modelId };
+      this.saveConfig();
+      return loaded;
+    })();
+
+    try {
+      return await this.loadingPromise;
+    } catch (error) {
+      this.pipeline = null;
+      this.activeModelId = null;
+      this.lastError = error instanceof Error ? error.message : "Local Whisper failed to load";
+      this.status = "error";
+      throw error;
+    } finally {
+      this.loadingPromise = null;
+      if ((this.status as SidecarSpeechStatus) !== "ready") this.downloadProgress = null;
+    }
+  }
+
+  getStatus(): SidecarSpeechStatusResponse {
+    const downloadedModelId = this.getDownloadedModelId();
+    const activeModelId = this.config.modelId ?? downloadedModelId;
+    const activeModel = activeModelId ? getSpeechModel(activeModelId) : null;
+    const runtime = getOnnxRuntimeDiagnostics();
+    const effectiveStatus =
+      this.status === "downloading_model" || this.status === "loading" || this.status === "error"
+        ? this.status
+        : this.detectStatus();
+    return {
+      status: effectiveStatus,
+      config: { ...this.config },
+      available: !runtime.liteMode && runtime.bindingFound,
+      modelDownloaded: Boolean(downloadedModelId),
+      modelDisplayName: activeModel && this.isModelDownloaded(activeModel.id) ? activeModel.label : null,
+      modelSize: this.getModelSize(activeModelId),
+      models: SIDECAR_SPEECH_MODELS,
+      downloadProgress: this.downloadProgress,
+      error: this.lastError,
+      platform: process.platform,
+      arch: process.arch,
+      runtime,
+    };
+  }
+
+  async download(
+    modelId: SidecarSpeechModelId = SIDECAR_SPEECH_DEFAULT_MODEL_ID,
+    onProgress?: (progress: SidecarDownloadProgress) => void,
+  ): Promise<void> {
+    const progress = this.createProgressCallback(modelId, onProgress);
+    await this.loadPipeline(modelId, { localFilesOnly: false, progress });
+  }
+
+  async deleteModel(modelId?: SidecarSpeechModelId | null): Promise<void> {
+    const targetModelId = modelId ?? this.config.modelId ?? this.getDownloadedModelId();
+    if (!targetModelId) return;
+    await this.disposeCurrentPipeline();
+    rmSync(safeModelCachePath(getSpeechModel(targetModelId).repoId), { recursive: true, force: true });
+    if (this.config.modelId === targetModelId) {
+      this.config = { modelId: null };
+      this.saveConfig();
+    }
+    this.status = this.detectStatus();
+    this.lastError = null;
+    this.downloadProgress = null;
+  }
+
+  async transcribeWav(buffer: Buffer): Promise<string> {
+    const configuredModelId = this.config.modelId;
+    const modelId =
+      configuredModelId && this.isModelDownloaded(configuredModelId)
+        ? configuredModelId
+        : (this.getDownloadedModelId() ?? SIDECAR_SPEECH_DEFAULT_MODEL_ID);
+    if (!this.isModelDownloaded(modelId)) {
+      throw new Error("Download Local Whisper from Connections before using it for call transcription.");
+    }
+    const decoded = decodePcmWav(buffer);
+    const samples = resampleLinear(decoded.samples, decoded.sampleRate, TARGET_SAMPLE_RATE);
+    const transcriber = await this.loadPipeline(modelId, { localFilesOnly: true });
+    const output = await transcriber(samples, { chunk_length_s: 30, stride_length_s: 5, task: "transcribe" });
+    const text = Array.isArray(output)
+      ? output
+          .map((item) => item.text ?? "")
+          .join(" ")
+          .trim()
+      : (output.text ?? "").trim();
+    return text;
+  }
+}
+
+export const sidecarSpeechService = new SidecarSpeechService();

--- a/packages/server/src/services/storage/chats.storage.ts
+++ b/packages/server/src/services/storage/chats.storage.ts
@@ -19,6 +19,8 @@ import {
   agentRuns,
   agentMemory,
   memoryChunks,
+  conversationCallSessions,
+  conversationCallMessages,
 } from "../../db/schema/index.js";
 import { newId, now } from "../../utils/id-generator.js";
 import { existsSync, rmSync } from "fs";
@@ -703,6 +705,8 @@ export function createChatsStorage(db: DB) {
       await db.delete(gameCheckpoints).where(eq(gameCheckpoints.chatId, id));
       await db.delete(gameStateSnapshots).where(eq(gameStateSnapshots.chatId, id));
       await db.delete(gameEngineState).where(eq(gameEngineState.chatId, id));
+      await db.delete(conversationCallMessages).where(eq(conversationCallMessages.chatId, id));
+      await db.delete(conversationCallSessions).where(eq(conversationCallSessions.chatId, id));
       const storyboards = await db
         .select({ id: gameTurnStoryboards.id })
         .from(gameTurnStoryboards)
@@ -733,6 +737,8 @@ export function createChatsStorage(db: DB) {
         await db.delete(gameCheckpoints).where(eq(gameCheckpoints.chatId, chat.id));
         await db.delete(gameStateSnapshots).where(eq(gameStateSnapshots.chatId, chat.id));
         await db.delete(gameEngineState).where(eq(gameEngineState.chatId, chat.id));
+        await db.delete(conversationCallMessages).where(eq(conversationCallMessages.chatId, chat.id));
+        await db.delete(conversationCallSessions).where(eq(conversationCallSessions.chatId, chat.id));
         const storyboards = await db
           .select({ id: gameTurnStoryboards.id })
           .from(gameTurnStoryboards)

--- a/packages/server/src/services/storage/conversation-calls.storage.ts
+++ b/packages/server/src/services/storage/conversation-calls.storage.ts
@@ -1,0 +1,264 @@
+// ──────────────────────────────────────────────
+// Storage: Conversation Calls
+// ──────────────────────────────────────────────
+import { and, desc, eq, inArray } from "drizzle-orm";
+import type { DB } from "../../db/connection.js";
+import {
+  conversationCallMessages,
+  conversationCallSessions,
+  conversationCallSounds,
+} from "../../db/schema/index.js";
+import { newId, now } from "../../utils/id-generator.js";
+import type {
+  ConversationCallMessage,
+  ConversationCallMessageKind,
+  ConversationCallMode,
+  ConversationCallSession,
+  ConversationCallStatus,
+  ConversationCallSound,
+  MessageRole,
+} from "@marinara-engine/shared";
+
+type CreateCallInput = {
+  chatId: string;
+  mode: ConversationCallMode;
+  initiator: "user" | "character";
+  initiatorCharacterId?: string | null;
+  metadata?: Record<string, unknown>;
+};
+
+type CreateCallMessageInput = {
+  callId: string;
+  chatId: string;
+  role: MessageRole;
+  characterId?: string | null;
+  participantKind: "user" | "character";
+  kind: ConversationCallMessageKind;
+  content: string;
+  extra?: Record<string, unknown>;
+  createdAt?: string | null;
+};
+
+const BUILT_IN_SOUNDS: Array<{ id: string; name: string; mimeType: string }> = [
+  { id: "builtin-soft-chime", name: "Soft Chime", mimeType: "audio/x-marinara-synth" },
+  { id: "builtin-tap", name: "Tap", mimeType: "audio/x-marinara-synth" },
+  { id: "builtin-sparkle", name: "Sparkle", mimeType: "audio/x-marinara-synth" },
+  { id: "builtin-pop", name: "Pop", mimeType: "audio/x-marinara-synth" },
+];
+
+function parseRecord(value: unknown): Record<string, unknown> {
+  if (!value) return {};
+  if (typeof value === "string") {
+    try {
+      const parsed = JSON.parse(value);
+      return parsed && typeof parsed === "object" && !Array.isArray(parsed) ? (parsed as Record<string, unknown>) : {};
+    } catch {
+      return {};
+    }
+  }
+  return typeof value === "object" && !Array.isArray(value) ? (value as Record<string, unknown>) : {};
+}
+
+function toSession(row: typeof conversationCallSessions.$inferSelect): ConversationCallSession {
+  return {
+    id: row.id,
+    chatId: row.chatId,
+    status: row.status,
+    mode: row.mode,
+    initiator: row.initiator,
+    initiatorCharacterId: row.initiatorCharacterId,
+    startedAt: row.startedAt,
+    endedAt: row.endedAt,
+    summary: row.summary,
+    metadata: parseRecord(row.metadata),
+    createdAt: row.createdAt,
+    updatedAt: row.updatedAt,
+  };
+}
+
+function toMessage(row: typeof conversationCallMessages.$inferSelect): ConversationCallMessage {
+  return {
+    id: row.id,
+    callId: row.callId,
+    chatId: row.chatId,
+    role: row.role,
+    characterId: row.characterId,
+    participantKind: row.participantKind,
+    kind: row.kind,
+    content: row.content,
+    extra: parseRecord(row.extra),
+    createdAt: row.createdAt,
+  };
+}
+
+function toSound(row: typeof conversationCallSounds.$inferSelect): ConversationCallSound {
+  return {
+    id: row.id,
+    name: row.name,
+    filePath: row.filePath,
+    mimeType: row.mimeType,
+    durationMs: row.durationMs,
+    builtIn: row.builtIn === "true",
+    createdAt: row.createdAt,
+  };
+}
+
+export function createConversationCallsStorage(db: DB) {
+  async function ensureBuiltInSounds() {
+    const ids = BUILT_IN_SOUNDS.map((sound) => sound.id);
+    const existing = await db
+      .select({ id: conversationCallSounds.id })
+      .from(conversationCallSounds)
+      .where(inArray(conversationCallSounds.id, ids));
+    const existingIds = new Set(existing.map((row) => row.id));
+    const timestamp = now();
+    const missing = BUILT_IN_SOUNDS.filter((sound) => !existingIds.has(sound.id));
+    if (missing.length === 0) return;
+    await db.insert(conversationCallSounds).values(
+      missing.map((sound) => ({
+        id: sound.id,
+        name: sound.name,
+        filePath: null,
+        mimeType: sound.mimeType,
+        durationMs: null,
+        builtIn: "true",
+        createdAt: timestamp,
+      })),
+    );
+  }
+
+  return {
+    async createSession(input: CreateCallInput) {
+      const id = newId();
+      const timestamp = now();
+      const status: ConversationCallStatus = input.initiator === "character" ? "ringing" : "active";
+      await db.insert(conversationCallSessions).values({
+        id,
+        chatId: input.chatId,
+        status,
+        mode: input.mode,
+        initiator: input.initiator,
+        initiatorCharacterId: input.initiatorCharacterId ?? null,
+        startedAt: status === "active" ? timestamp : null,
+        endedAt: null,
+        summary: null,
+        metadata: JSON.stringify(input.metadata ?? {}),
+        createdAt: timestamp,
+        updatedAt: timestamp,
+      });
+      return this.getSession(id);
+    },
+
+    async getSession(id: string) {
+      const rows = await db.select().from(conversationCallSessions).where(eq(conversationCallSessions.id, id));
+      return rows[0] ? toSession(rows[0]) : null;
+    },
+
+    async getActiveForChat(chatId: string) {
+      const rows = await db
+        .select()
+        .from(conversationCallSessions)
+        .where(and(eq(conversationCallSessions.chatId, chatId), eq(conversationCallSessions.status, "active")))
+        .orderBy(desc(conversationCallSessions.updatedAt));
+      return rows[0] ? toSession(rows[0]) : null;
+    },
+
+    async getRingingForChat(chatId: string) {
+      const rows = await db
+        .select()
+        .from(conversationCallSessions)
+        .where(and(eq(conversationCallSessions.chatId, chatId), eq(conversationCallSessions.status, "ringing")))
+        .orderBy(desc(conversationCallSessions.updatedAt));
+      return rows[0] ? toSession(rows[0]) : null;
+    },
+
+    async updateStatus(
+      id: string,
+      status: ConversationCallStatus,
+      patch: { summary?: string | null; metadata?: Record<string, unknown> } = {},
+    ) {
+      const current = await this.getSession(id);
+      if (!current) return null;
+      const timestamp = now();
+      await db
+        .update(conversationCallSessions)
+        .set({
+          status,
+          startedAt: status === "active" ? (current.startedAt ?? timestamp) : current.startedAt,
+          endedAt: status === "ended" || status === "declined" || status === "missed" ? timestamp : current.endedAt,
+          summary: patch.summary !== undefined ? patch.summary : current.summary,
+          metadata: patch.metadata ? JSON.stringify({ ...current.metadata, ...patch.metadata }) : JSON.stringify(current.metadata),
+          updatedAt: timestamp,
+        })
+        .where(eq(conversationCallSessions.id, id));
+      return this.getSession(id);
+    },
+
+    async createMessage(input: CreateCallMessageInput) {
+      const id = newId();
+      const timestamp = input.createdAt ?? now();
+      await db.insert(conversationCallMessages).values({
+        id,
+        callId: input.callId,
+        chatId: input.chatId,
+        role: input.role,
+        characterId: input.characterId ?? null,
+        participantKind: input.participantKind,
+        kind: input.kind,
+        content: input.content,
+        extra: JSON.stringify(input.extra ?? {}),
+        createdAt: timestamp,
+      });
+      return this.getMessage(id);
+    },
+
+    async getMessage(id: string) {
+      const rows = await db.select().from(conversationCallMessages).where(eq(conversationCallMessages.id, id));
+      return rows[0] ? toMessage(rows[0]) : null;
+    },
+
+    async listMessages(callId: string) {
+      const rows = await db
+        .select()
+        .from(conversationCallMessages)
+        .where(eq(conversationCallMessages.callId, callId))
+        .orderBy(conversationCallMessages.createdAt, conversationCallMessages.id);
+      return rows.map(toMessage);
+    },
+
+    async listSounds() {
+      await ensureBuiltInSounds();
+      const rows = await db.select().from(conversationCallSounds).orderBy(conversationCallSounds.builtIn, conversationCallSounds.name);
+      return rows.map(toSound);
+    },
+
+    async createSound(input: { name: string; filePath: string; mimeType: string; durationMs?: number | null }) {
+      const id = newId();
+      const timestamp = now();
+      await db.insert(conversationCallSounds).values({
+        id,
+        name: input.name,
+        filePath: input.filePath,
+        mimeType: input.mimeType,
+        durationMs: input.durationMs ?? null,
+        builtIn: "false",
+        createdAt: timestamp,
+      });
+      const rows = await db.select().from(conversationCallSounds).where(eq(conversationCallSounds.id, id));
+      return rows[0] ? toSound(rows[0]) : null;
+    },
+
+    async getSound(id: string) {
+      await ensureBuiltInSounds();
+      const rows = await db.select().from(conversationCallSounds).where(eq(conversationCallSounds.id, id));
+      return rows[0] ? toSound(rows[0]) : null;
+    },
+
+    async deleteSound(id: string) {
+      const sound = await this.getSound(id);
+      if (!sound || sound.builtIn) return sound;
+      await db.delete(conversationCallSounds).where(eq(conversationCallSounds.id, id));
+      return sound;
+    },
+  };
+}

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -28,6 +28,7 @@ export * from "./types/video-generation-defaults.js";
 export * from "./types/image-style-profile.js";
 export * from "./types/professor-mari-workspace.js";
 export * from "./types/achievement.js";
+export * from "./types/conversation-call.js";
 
 // Schemas
 export * from "./schemas/chat.schema.js";
@@ -44,6 +45,7 @@ export * from "./schemas/custom-sticker.schema.js";
 export * from "./schemas/theme.schema.js";
 export * from "./schemas/extension.schema.js";
 export * from "./schemas/app-settings.schema.js";
+export * from "./schemas/conversation-call.schema.js";
 
 // Constants
 export * from "./constants/providers.js";

--- a/packages/shared/src/schemas/conversation-call.schema.ts
+++ b/packages/shared/src/schemas/conversation-call.schema.ts
@@ -1,0 +1,65 @@
+import { z } from "zod";
+
+export const conversationCallStatusSchema = z.enum(["ringing", "active", "ended", "declined", "missed"]);
+export const conversationCallModeSchema = z.enum(["audio", "video"]);
+export const conversationCallInitiatorSchema = z.enum(["user", "character"]);
+export const conversationCallMessageKindSchema = z.enum(["speech", "text", "system", "command", "soundboard"]);
+export const conversationCallTurnModeSchema = z.enum(["voice", "text", "command"]);
+export const conversationCallAudioInputModeSchema = z.enum(["system", "auto", "transcribe", "local_whisper"]);
+export const conversationCallMusicPlayerSourceSchema = z.enum(["spotify", "youtube", "custom"]);
+
+export const startConversationCallSchema = z.object({
+  chatId: z.string().min(1),
+  mode: conversationCallModeSchema.default("audio"),
+  initiator: conversationCallInitiatorSchema.default("user"),
+  initiatorCharacterId: z.string().nullable().optional().default(null),
+  metadata: z.record(z.string(), z.unknown()).optional().default({}),
+});
+
+export const conversationCallIdParamSchema = z.object({
+  id: z.string().min(1),
+});
+
+export const sendConversationCallMessageSchema = z.object({
+  content: z.string().min(1).max(50_000),
+  inputMode: z.enum(["typed", "speech"]).default("typed"),
+  debugMode: z.boolean().optional().default(false),
+  musicPlayerEnabled: z.boolean().optional(),
+  musicPlayerSource: conversationCallMusicPlayerSourceSchema.optional(),
+});
+
+export const conversationCallIdleSchema = z.object({
+  quietMs: z
+    .number()
+    .int()
+    .min(30_000)
+    .max(30 * 60_000)
+    .default(150_000),
+  debugMode: z.boolean().optional().default(false),
+  musicPlayerEnabled: z.boolean().optional(),
+  musicPlayerSource: conversationCallMusicPlayerSourceSchema.optional(),
+});
+
+export const conversationCallInterruptionSchema = z.object({
+  characterId: z.string().nullable().optional().default(null),
+  speakerName: z.string().max(200).nullable().optional().default(null),
+  spokenText: z.string().max(10_000).optional().default(""),
+});
+
+export const conversationCallTurnSchema = z.object({
+  id: z.string().optional(),
+  speakerName: z.string().min(1).max(200),
+  mode: conversationCallTurnModeSchema,
+  content: z.string().max(50_000).default(""),
+  tone: z.string().max(200).nullable().optional(),
+});
+
+export const conversationCallModelResponseSchema = z.object({
+  turns: z.array(conversationCallTurnSchema).default([]),
+});
+
+export type StartConversationCallInput = z.infer<typeof startConversationCallSchema>;
+export type SendConversationCallMessageInput = z.infer<typeof sendConversationCallMessageSchema>;
+export type ConversationCallIdleInput = z.infer<typeof conversationCallIdleSchema>;
+export type ConversationCallInterruptionInput = z.infer<typeof conversationCallInterruptionSchema>;
+export type ConversationCallModelResponseInput = z.infer<typeof conversationCallModelResponseSchema>;

--- a/packages/shared/src/types/chat.ts
+++ b/packages/shared/src/types/chat.ts
@@ -34,6 +34,7 @@ export const CONVERSATION_COMMAND_KEYS = [
   "selfie",
   "memory",
   "scene",
+  "call",
   "uno",
   "chess",
   "music",
@@ -237,6 +238,8 @@ export interface ChatMetadata {
   illustratorPromptConnectionId?: string | null;
   /** Whether Conversation selfie commands should send the matching character avatar as a reference image. */
   selfieUseAvatarReferences?: boolean;
+  /** Whether Conversation selfie commands should append matched character card appearance text to image prompts. */
+  selfieIncludeCharacterAppearance?: boolean;
   /** Whether Game Mode scene illustrations should send matching character/persona avatar references. */
   gameImageUseAvatarReferences?: boolean;
   /** Whether Game Mode scene illustrations should append matched character appearance descriptions. */
@@ -388,6 +391,10 @@ export interface ChatMetadata {
   characterCommands?: boolean;
   /** Per-command Conversation command enable overrides. Missing/true means enabled. */
   conversationCommandToggles?: ConversationCommandToggles;
+  /** Allow this conversation to start local AI audio/video calls. Default: false. */
+  conversationCallsEnabled?: boolean;
+  /** Allow characters to ring the user through the call command. Default: true when calls are enabled. */
+  conversationCharactersCanCall?: boolean;
   /** Chat-scoped generated schedules for conversation characters. */
   characterSchedules?: Record<string, unknown>;
   /** Chat-scoped manual status overrides for conversation characters. */

--- a/packages/shared/src/types/conversation-call.ts
+++ b/packages/shared/src/types/conversation-call.ts
@@ -1,0 +1,87 @@
+import type { MessageRole } from "./chat.js";
+
+export type ConversationCallStatus = "ringing" | "active" | "ended" | "declined" | "missed";
+export type ConversationCallMode = "audio" | "video";
+export type ConversationCallInitiator = "user" | "character";
+export type ConversationCallParticipantKind = "user" | "character";
+export type ConversationCallMessageKind = "speech" | "text" | "system" | "command" | "soundboard";
+export type ConversationCallTurnMode = "voice" | "text" | "command";
+export type ConversationCallAudioInputMode = "system" | "auto" | "transcribe" | "local_whisper";
+
+export interface ConversationCallSession {
+  id: string;
+  chatId: string;
+  status: ConversationCallStatus;
+  mode: ConversationCallMode;
+  initiator: ConversationCallInitiator;
+  initiatorCharacterId: string | null;
+  startedAt: string | null;
+  endedAt: string | null;
+  summary: string | null;
+  metadata: Record<string, unknown>;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface ConversationCallMessage {
+  id: string;
+  callId: string;
+  chatId: string;
+  role: MessageRole;
+  characterId: string | null;
+  participantKind: ConversationCallParticipantKind;
+  kind: ConversationCallMessageKind;
+  content: string;
+  extra: Record<string, unknown>;
+  createdAt: string;
+}
+
+export interface ConversationCallSound {
+  id: string;
+  name: string;
+  filePath: string | null;
+  mimeType: string;
+  durationMs: number | null;
+  builtIn: boolean;
+  createdAt: string;
+}
+
+export interface ConversationCallParticipantState {
+  id: string;
+  kind: ConversationCallParticipantKind;
+  displayName: string;
+  avatarUrl: string | null;
+  characterId: string | null;
+  muted: boolean;
+  cameraEnabled: boolean;
+  screenSharing: boolean;
+  speaking: boolean;
+  canSpeak: boolean;
+}
+
+export interface ConversationCallTurn {
+  id?: string;
+  speakerName: string;
+  characterId?: string | null;
+  mode: ConversationCallTurnMode;
+  content: string;
+  tone?: string | null;
+}
+
+export interface ConversationCallMessageResponse {
+  userMessage: ConversationCallMessage;
+  assistantMessages: ConversationCallMessage[];
+  turns: ConversationCallTurn[];
+  session: ConversationCallSession;
+}
+
+export interface ConversationCallIdleResponse {
+  assistantMessages: ConversationCallMessage[];
+  turns: ConversationCallTurn[];
+  session: ConversationCallSession;
+}
+
+export interface ConversationCallStatusResponse {
+  activeCall: ConversationCallSession | null;
+  ringingCall: ConversationCallSession | null;
+}

--- a/packages/shared/src/types/sidecar.ts
+++ b/packages/shared/src/types/sidecar.ts
@@ -36,6 +36,12 @@ export type SidecarStatus =
   | "ready"
   | "server_error";
 
+/** Curated local speech-to-text model managed beside the Local Model sidecar. */
+export type SidecarSpeechModelId = "whisper_tiny" | "whisper_base";
+
+/** Local speech model lifecycle. Kept separate from the chat sidecar status. */
+export type SidecarSpeechStatus = "not_downloaded" | "downloading_model" | "downloaded" | "loading" | "ready" | "error";
+
 /** Progress info while downloading the runtime or model assets. */
 export interface SidecarDownloadProgress {
   phase: "runtime" | "model";
@@ -277,6 +283,46 @@ export interface SidecarModelInfo {
   sha256?: string;
 }
 
+export interface SidecarSpeechModelInfo {
+  id: SidecarSpeechModelId;
+  label: string;
+  repoId: string;
+  sizeBytes: number;
+  ramBytes: number;
+  description: string;
+}
+
+export interface SidecarSpeechConfig {
+  modelId: SidecarSpeechModelId | null;
+}
+
+export interface SidecarSpeechRuntimeDiagnostics {
+  packageFound: boolean;
+  bindingFound: boolean;
+  expectedBindingPath: string | null;
+  installedBindingArchs: string[];
+  platform: string;
+  arch: string;
+  nodeVersion: string;
+  nodeExecPath: string;
+  liteMode: boolean;
+}
+
+export interface SidecarSpeechStatusResponse {
+  status: SidecarSpeechStatus;
+  config: SidecarSpeechConfig;
+  available: boolean;
+  modelDownloaded: boolean;
+  modelDisplayName: string | null;
+  modelSize: number | null;
+  models: SidecarSpeechModelInfo[];
+  downloadProgress: SidecarDownloadProgress | null;
+  error: string | null;
+  platform: string;
+  arch: string;
+  runtime: SidecarSpeechRuntimeDiagnostics;
+}
+
 export interface SidecarCustomModelEntry {
   path: string;
   filename: string;
@@ -312,6 +358,27 @@ export const SIDECAR_DEFAULT_CONFIG: SidecarConfig = {
  * as a connection, and rejects writes against it. Never stored in the DB.
  */
 export const SIDECAR_CONNECTION_ID = "sidecar:local";
+
+export const SIDECAR_SPEECH_DEFAULT_MODEL_ID: SidecarSpeechModelId = "whisper_tiny";
+
+export const SIDECAR_SPEECH_MODELS: SidecarSpeechModelInfo[] = [
+  {
+    id: "whisper_tiny",
+    label: "Whisper Tiny (Multilingual)",
+    repoId: "Xenova/whisper-tiny",
+    sizeBytes: 180_000_000,
+    ramBytes: 350_000_000,
+    description: "Smallest local call transcription model. Best first choice for phones and older machines.",
+  },
+  {
+    id: "whisper_base",
+    label: "Whisper Base (Multilingual)",
+    repoId: "Xenova/whisper-base",
+    sizeBytes: 320_000_000,
+    ramBytes: 650_000_000,
+    description: "Better accuracy for messy speech, at the cost of slower startup and higher memory use.",
+  },
+];
 
 /** Available models for download. */
 export const SIDECAR_MODELS: SidecarModelInfo[] = [

--- a/packages/shared/src/types/tts.ts
+++ b/packages/shared/src/types/tts.ts
@@ -3,7 +3,7 @@
 // ──────────────────────────────────────────────
 import { z } from "zod";
 
-export const ttsSourceSchema = z.enum(["openai", "elevenlabs", "pockettts"]);
+export const ttsSourceSchema = z.enum(["openai", "elevenlabs", "pockettts", "xai"]);
 export type TTSSource = z.infer<typeof ttsSourceSchema>;
 
 export const ttsAudioFormatSchema = z.enum(["mp3", "wav"]);
@@ -14,6 +14,9 @@ export type TTSDialogueScope = z.infer<typeof ttsDialogueScopeSchema>;
 
 export const ttsVoiceModeSchema = z.enum(["single", "per-character"]);
 export type TTSVoiceMode = z.infer<typeof ttsVoiceModeSchema>;
+
+export const ttsConversationCallAudioInputModeSchema = z.enum(["system", "auto", "transcribe", "local_whisper"]);
+export type TTSConversationCallAudioInputMode = z.infer<typeof ttsConversationCallAudioInputModeSchema>;
 
 export const ttsVoiceAssignmentSchema = z.object({
   characterId: z.string().default(""),
@@ -129,6 +132,18 @@ export const ttsConfigSchema = z.object({
   audioFormat: ttsAudioFormatSchema.default("mp3"),
   dialogueScope: ttsDialogueScopeSchema.default("all"),
   dialogueCharacterName: z.string().default(""),
+  /** Global gate for Conversation-mode calls. Individual chats opt in separately. */
+  callAudioEnabled: z.boolean().default(false),
+  /** Deprecated: call transcription now uses the active conversation connection. */
+  callSttConnectionId: z.string().default(""),
+  /** Deprecated: call transcription now follows the selected call audio input mode. */
+  callSttModel: z.string().default(""),
+  /** Conversation call mic path: local Whisper, browser speech, manual OS dictation, or provider-native media. */
+  callAudioInputMode: ttsConversationCallAudioInputModeSchema.default("local_whisper"),
+  /** UI gate for camera/screen controls. Provider-native video input remains capability-gated by the call pipeline. */
+  callVideoInputEnabled: z.boolean().default(false),
+  /** Enable the call soundboard panel and model soundboard command. */
+  callSoundboardEnabled: z.boolean().default(true),
 });
 
 export type TTSConfig = z.infer<typeof ttsConfigSchema>;

--- a/scripts/check-workspace-install.mjs
+++ b/scripts/check-workspace-install.mjs
@@ -1,7 +1,9 @@
 import { createRequire } from "node:module";
-import { resolve } from "node:path";
+import { dirname, join, resolve } from "node:path";
+import { existsSync } from "node:fs";
 
 const root = process.cwd();
+const supportedOnnxTuples = new Set(["darwin/arm64", "darwin/x64", "linux/arm64", "linux/x64", "win32/arm64", "win32/x64"]);
 const checks = [
   { workspace: ".", packageName: "esbuild" },
   { workspace: "packages/shared", packageName: "chess.js" },
@@ -17,6 +19,20 @@ for (const check of checks) {
     requireFromWorkspace.resolve(check.packageName);
   } catch {
     missing.push(`${check.packageName} from ${check.workspace}`);
+  }
+}
+
+const onnxTuple = `${process.platform}/${process.arch}`;
+if (supportedOnnxTuples.has(onnxTuple)) {
+  const requireFromServer = createRequire(resolve(root, "packages/server/package.json"));
+  try {
+    const packageDir = dirname(requireFromServer.resolve("onnxruntime-node/package.json"));
+    const bindingPath = join(packageDir, "bin", "napi-v6", process.platform, process.arch, "onnxruntime_binding.node");
+    if (!existsSync(bindingPath)) {
+      missing.push(`onnxruntime-node native binding for ${onnxTuple}`);
+    }
+  } catch {
+    missing.push(`onnxruntime-node from packages/server`);
   }
 }
 

--- a/scripts/ensure-native-deps.mjs
+++ b/scripts/ensure-native-deps.mjs
@@ -1,0 +1,166 @@
+#!/usr/bin/env node
+import { spawnSync } from "node:child_process";
+import { existsSync, readdirSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { createRequire } from "node:module";
+import { basename, dirname, join } from "node:path";
+
+const rootRequire = createRequire(new URL("../package.json", import.meta.url));
+const serverRequire = createRequire(new URL("../packages/server/package.json", import.meta.url));
+const repoRoot = fileURLToPath(new URL("..", import.meta.url));
+const supportedOnnxTuples = new Set(["darwin/arm64", "darwin/x64", "linux/arm64", "linux/x64", "win32/arm64", "win32/x64"]);
+const tuple = `${process.platform}/${process.arch}`;
+
+function log(message) {
+  console.log(`[native-deps] ${message}`);
+}
+
+function warn(message) {
+  console.warn(`[native-deps] ${message}`);
+}
+
+function resolvePackageDir(packageName) {
+  try {
+    return dirname(serverRequire.resolve(`${packageName}/package.json`));
+  } catch {
+    return null;
+  }
+}
+
+function getOnnxBindingPath(packageDir) {
+  return join(packageDir, "bin", "napi-v6", process.platform, process.arch, "onnxruntime_binding.node");
+}
+
+function listInstalledOnnxArchs(packageDir) {
+  const platformDir = join(packageDir, "bin", "napi-v6", process.platform);
+  if (!existsSync(platformDir)) return [];
+  try {
+    return readdirSync(platformDir)
+      .filter((arch) => existsSync(join(platformDir, arch, "onnxruntime_binding.node")))
+      .sort();
+  } catch {
+    return [];
+  }
+}
+
+function resolvePnpmCommand() {
+  const pnpmCliPath = process.env.npm_execpath;
+  const npmUserAgent = process.env.npm_config_user_agent ?? "";
+  const useCurrentPnpm =
+    Boolean(pnpmCliPath) && (npmUserAgent.startsWith("pnpm/") || basename(pnpmCliPath ?? "").startsWith("pnpm"));
+
+  if (useCurrentPnpm && pnpmCliPath) {
+    return { command: process.execPath, args: [pnpmCliPath] };
+  }
+
+  try {
+    const pkg = rootRequire("./package.json");
+    const pnpmVersion = typeof pkg.packageManager === "string" ? pkg.packageManager.split("@")[1] : null;
+    if (pnpmVersion) {
+      return { command: "corepack", args: [`pnpm@${pnpmVersion}`] };
+    }
+  } catch {
+    // Fall through to pnpm on PATH.
+  }
+
+  return { command: "pnpm", args: [] };
+}
+
+function rebuildOnnxRuntime() {
+  if (process.env.MARINARA_NATIVE_DEPS_REPAIRING === "1") {
+    warn("Skipping nested onnxruntime-node rebuild.");
+    return false;
+  }
+
+  const runner = resolvePnpmCommand();
+  const args = [
+    ...runner.args,
+    "--config.trustPolicy=off",
+    "--config.confirmModulesPurge=false",
+    "rebuild",
+    "onnxruntime-node",
+  ];
+
+  log(`Rebuilding onnxruntime-node for ${tuple}...`);
+  const result = spawnSync(runner.command, args, {
+    cwd: repoRoot,
+    env: { ...process.env, MARINARA_NATIVE_DEPS_REPAIRING: "1" },
+    stdio: "inherit",
+    shell: process.platform === "win32",
+  });
+
+  if (result.status === 0) return true;
+  warn(`onnxruntime-node rebuild exited with ${result.signal ?? result.status ?? "unknown status"}.`);
+  return false;
+}
+
+function forceInstallNativeDeps() {
+  if (process.env.MARINARA_NATIVE_DEPS_REPAIRING === "1") {
+    warn("Skipping nested forced install repair.");
+    return false;
+  }
+
+  const runner = resolvePnpmCommand();
+  const args = [
+    ...runner.args,
+    "--config.trustPolicy=off",
+    "--config.confirmModulesPurge=false",
+    "install",
+    "--force",
+    "--frozen-lockfile",
+  ];
+
+  log(`Refreshing native dependencies for ${tuple}...`);
+  const result = spawnSync(runner.command, args, {
+    cwd: repoRoot,
+    env: { ...process.env, MARINARA_NATIVE_DEPS_REPAIRING: "1" },
+    stdio: "inherit",
+    shell: process.platform === "win32",
+  });
+
+  if (result.status === 0) return true;
+  warn(`Forced dependency refresh exited with ${result.signal ?? result.status ?? "unknown status"}.`);
+  return false;
+}
+
+function ensureOnnxRuntime() {
+  if (!supportedOnnxTuples.has(tuple)) {
+    log(`Skipping onnxruntime-node check for unsupported runtime ${tuple}.`);
+    return;
+  }
+
+  const packageDir = resolvePackageDir("onnxruntime-node");
+  if (!packageDir) {
+    warn("onnxruntime-node is not installed. Local Whisper will stay unavailable until dependencies are installed.");
+    return;
+  }
+
+  const bindingPath = getOnnxBindingPath(packageDir);
+  if (existsSync(bindingPath)) {
+    log(`onnxruntime-node native binding is ready for ${tuple}.`);
+    return;
+  }
+
+  const installedArchs = listInstalledOnnxArchs(packageDir);
+  warn(
+    `Missing onnxruntime-node native binding for ${tuple}. Installed ${process.platform} architectures: ${
+      installedArchs.length > 0 ? installedArchs.join(", ") : "none"
+    }.`,
+  );
+
+  rebuildOnnxRuntime();
+  if (!existsSync(bindingPath)) {
+    forceInstallNativeDeps();
+  }
+
+  if (existsSync(bindingPath)) {
+    log(`onnxruntime-node native binding repaired for ${tuple}.`);
+    return;
+  }
+
+  warn(
+    "Local Whisper may be unavailable. Run `pnpm install --force --frozen-lockfile` with the same Node architecture used to run Marinara.",
+  );
+}
+
+ensureOnnxRuntime();

--- a/start-termux.sh
+++ b/start-termux.sh
@@ -241,8 +241,8 @@ elif [ -d ".git" ]; then
                 echo "  [WARN] Update did not land on ${TARGET_REF}. Continuing with current version."
             else
                 echo "  [OK] Updated to $(git log -1 --format='%h %s' 2>/dev/null)"
-                echo "  [..] Reinstalling dependencies..."
-                run_pnpm install
+                echo "  [..] Reinstalling dependencies and refreshing native packages..."
+                run_pnpm install --force
                 rm -rf packages/shared/dist packages/server/dist packages/client/dist
                 rm -f packages/shared/tsconfig.tsbuildinfo packages/server/tsconfig.tsbuildinfo packages/client/tsconfig.tsbuildinfo
             fi
@@ -279,14 +279,14 @@ if [ -f "packages/shared/dist/constants/defaults.js" ]; then
     if [ -n "$SOURCE_VER" ] && [ -n "$DIST_VER" ] && [ "$SOURCE_VER" != "$DIST_VER" ]; then
         echo "  [WARN] Version mismatch: source v$SOURCE_VER but dist has v$DIST_VER"
         echo "  [..] Forcing rebuild to apply update..."
-        run_pnpm install
+        run_pnpm install --force
         rm -rf packages/shared/dist packages/server/dist packages/client/dist
         rm -f packages/shared/tsconfig.tsbuildinfo packages/server/tsconfig.tsbuildinfo packages/client/tsconfig.tsbuildinfo
     fi
     if [ -n "$SOURCE_COMMIT" ] && [ "$SOURCE_COMMIT" != "$DIST_COMMIT" ]; then
         echo "  [WARN] Build commit mismatch: source $SOURCE_COMMIT but dist has ${DIST_COMMIT:-<missing>}"
         echo "  [..] Forcing rebuild to apply update..."
-        run_pnpm install
+        run_pnpm install --force
         rm -rf packages/shared/dist packages/server/dist packages/client/dist
         rm -f packages/shared/tsconfig.tsbuildinfo packages/server/tsconfig.tsbuildinfo packages/client/tsconfig.tsbuildinfo
     fi
@@ -298,11 +298,7 @@ if [ ! -d "node_modules" ] || [ "$TERMUX_FORCE_INSTALL" = "1" ] || ! node script
     echo "  [..] Installing dependencies${TERMUX_FORCE_INSTALL:+ (refreshing for platform fix)}..."
     echo "       This may take several minutes on mobile."
     echo ""
-    if [ "$TERMUX_FORCE_INSTALL" = "1" ]; then
-        run_pnpm install --force
-    else
-        run_pnpm install
-    fi
+    run_pnpm install --force
 fi
 
 # ── Build if needed ──

--- a/start.bat
+++ b/start.bat
@@ -198,8 +198,8 @@ if /I not "!NEW_HEAD!"=="!TARGET_HEAD!" (
 if "!STASHED!"=="1" call :restore_stashed_changes
 if exist "!UPDATE_LOG!" del /q "!UPDATE_LOG!" >nul 2>&1
 echo  [OK] Updated to latest version
-echo  [..] Reinstalling dependencies...
-call :run_pnpm install
+echo  [..] Reinstalling dependencies and refreshing native packages...
+call :run_pnpm install --force
 if exist "packages\shared\dist" rmdir /s /q "packages\shared\dist"
 if exist "packages\server\dist" rmdir /s /q "packages\server\dist"
 if exist "packages\client\dist" rmdir /s /q "packages\client\dist"
@@ -221,7 +221,7 @@ for /f "usebackq delims=" %%i in (`node -e "try{const m=require('./packages/serv
 if not "!SOURCE_VER!"=="" if not "!DIST_VER!"=="" if not "!SOURCE_VER!"=="!DIST_VER!" (
     echo  [WARN] Version mismatch: source v!SOURCE_VER! but dist has v!DIST_VER!
     echo  [..] Forcing rebuild to apply update...
-    call :run_pnpm install
+    call :run_pnpm install --force
     if exist "packages\shared\dist" rmdir /s /q "packages\shared\dist"
     if exist "packages\server\dist" rmdir /s /q "packages\server\dist"
     if exist "packages\client\dist" rmdir /s /q "packages\client\dist"
@@ -232,7 +232,7 @@ if not "!SOURCE_VER!"=="" if not "!DIST_VER!"=="" if not "!SOURCE_VER!"=="!DIST_
 if not "!SOURCE_COMMIT!"=="" if /I not "!SOURCE_COMMIT!"=="!DIST_COMMIT!" (
     echo  [WARN] Build commit mismatch: source !SOURCE_COMMIT! but dist has !DIST_COMMIT!
     echo  [..] Forcing rebuild to apply update...
-    call :run_pnpm install
+    call :run_pnpm install --force
     if exist "packages\shared\dist" rmdir /s /q "packages\shared\dist"
     if exist "packages\server\dist" rmdir /s /q "packages\server\dist"
     if exist "packages\client\dist" rmdir /s /q "packages\client\dist"
@@ -252,7 +252,7 @@ echo.
 echo  [..] Installing dependencies...
 echo      This may take a few minutes.
 echo.
-call :run_pnpm install
+call :run_pnpm install --force
 if errorlevel 1 echo  [ERROR] Failed to install dependencies. & pause & exit /b 1
 
 :skip_install

--- a/start.sh
+++ b/start.sh
@@ -162,8 +162,8 @@ if [ -d ".git" ]; then
                 echo "  [WARN] Update did not land on ${TARGET_REF}. Continuing with current version."
             else
                 echo "  [OK] Updated to $(git log -1 --format='%h %s' 2>/dev/null)"
-                echo "  [..] Reinstalling dependencies..."
-                run_pnpm install
+                echo "  [..] Reinstalling dependencies and refreshing native packages..."
+                run_pnpm install --force
                 # Force rebuild
                 rm -rf packages/shared/dist packages/server/dist packages/client/dist
                 rm -f packages/shared/tsconfig.tsbuildinfo packages/server/tsconfig.tsbuildinfo packages/client/tsconfig.tsbuildinfo
@@ -191,14 +191,14 @@ if [ -f "packages/shared/dist/constants/defaults.js" ]; then
     if [ -n "$SOURCE_VER" ] && [ -n "$DIST_VER" ] && [ "$SOURCE_VER" != "$DIST_VER" ]; then
         echo "  [WARN] Version mismatch: source v$SOURCE_VER but dist has v$DIST_VER"
         echo "  [..] Forcing rebuild to apply update..."
-        run_pnpm install
+        run_pnpm install --force
         rm -rf packages/shared/dist packages/server/dist packages/client/dist
         rm -f packages/shared/tsconfig.tsbuildinfo packages/server/tsconfig.tsbuildinfo packages/client/tsconfig.tsbuildinfo
     fi
     if [ -n "$SOURCE_COMMIT" ] && [ "$SOURCE_COMMIT" != "$DIST_COMMIT" ]; then
         echo "  [WARN] Build commit mismatch: source $SOURCE_COMMIT but dist has ${DIST_COMMIT:-<missing>}"
         echo "  [..] Forcing rebuild to apply update..."
-        run_pnpm install
+        run_pnpm install --force
         rm -rf packages/shared/dist packages/server/dist packages/client/dist
         rm -f packages/shared/tsconfig.tsbuildinfo packages/server/tsconfig.tsbuildinfo packages/client/tsconfig.tsbuildinfo
     fi
@@ -210,7 +210,7 @@ if [ ! -d "node_modules" ] || ! node scripts/check-workspace-install.mjs >/dev/n
     echo "  [..] Installing dependencies..."
     echo "       This may take a few minutes."
     echo ""
-    run_pnpm install
+    run_pnpm install --force
 fi
 
 # ── Optional AI sprite background remover ──

--- a/win/installer/install.bat
+++ b/win/installer/install.bat
@@ -308,7 +308,7 @@ echo  [OK] Repository updated
 :: -- Install dependencies --
 echo.
 echo  [..] Installing dependencies (this may take a few minutes)...
-call :run_pnpm install
+call :run_pnpm install --force
 if %errorlevel% neq 0 (
     set "INSTALL_ERROR=Failed to install dependencies."
     goto :fatal

--- a/win/installer/installer.nsi
+++ b/win/installer/installer.nsi
@@ -671,17 +671,17 @@ ${APP_URL}"
   DetailPrint ""
   DetailPrint "═══ Step 3/6: Installing dependencies ═══"
   DetailPrint ""
-  DetailPrint "Running pnpm install (this may take 2-5 minutes and creates dependency folders)..."
+  DetailPrint "Running pnpm install --force (this may take 2-5 minutes and creates dependency folders)..."
   ${If} $PNPM_RUNNER == "corepack"
-    nsExec::ExecToLog 'cmd /c corepack pnpm@${PNPM_VERSION} --config.trustPolicy=off --config.confirmModulesPurge=false install'
+    nsExec::ExecToLog 'cmd /c corepack pnpm@${PNPM_VERSION} --config.trustPolicy=off --config.confirmModulesPurge=false install --force'
     Pop $0
   ${EndIf}
   ${If} $PNPM_RUNNER == "npx"
-    nsExec::ExecToLog 'cmd /c npx --yes pnpm@${PNPM_VERSION} --config.trustPolicy=off --config.confirmModulesPurge=false install'
+    nsExec::ExecToLog 'cmd /c npx --yes pnpm@${PNPM_VERSION} --config.trustPolicy=off --config.confirmModulesPurge=false install --force'
     Pop $0
   ${EndIf}
   ${If} $PNPM_RUNNER == "pnpm"
-    nsExec::ExecToLog 'cmd /c pnpm --config.trustPolicy=off --config.confirmModulesPurge=false install'
+    nsExec::ExecToLog 'cmd /c pnpm --config.trustPolicy=off --config.confirmModulesPurge=false install --force'
     Pop $0
   ${EndIf}
   ${If} $0 != 0
@@ -693,15 +693,15 @@ Would you like to retry?" IDYES retryInstall IDNO skipRetryInstall
     retryInstall:
       DetailPrint "Retrying pnpm install..."
       ${If} $PNPM_RUNNER == "corepack"
-        nsExec::ExecToLog 'cmd /c corepack pnpm@${PNPM_VERSION} --config.trustPolicy=off --config.confirmModulesPurge=false install'
+        nsExec::ExecToLog 'cmd /c corepack pnpm@${PNPM_VERSION} --config.trustPolicy=off --config.confirmModulesPurge=false install --force'
         Pop $0
       ${EndIf}
       ${If} $PNPM_RUNNER == "npx"
-        nsExec::ExecToLog 'cmd /c npx --yes pnpm@${PNPM_VERSION} --config.trustPolicy=off --config.confirmModulesPurge=false install'
+        nsExec::ExecToLog 'cmd /c npx --yes pnpm@${PNPM_VERSION} --config.trustPolicy=off --config.confirmModulesPurge=false install --force'
         Pop $0
       ${EndIf}
       ${If} $PNPM_RUNNER == "pnpm"
-        nsExec::ExecToLog 'cmd /c pnpm --config.trustPolicy=off --config.confirmModulesPurge=false install'
+        nsExec::ExecToLog 'cmd /c pnpm --config.trustPolicy=off --config.confirmModulesPurge=false install --force'
         Pop $0
       ${EndIf}
     skipRetryInstall:


### PR DESCRIPTION
## Linked issue

No linked issue. Maintainer-requested v2.1.0 release work from chat.

## Why this change

- Adds Conversation-mode AI calls as part of the v2.1.0 release, including the call UI, call-specific prompt pipeline, Local Whisper speech input path, provider-native audio/video dispatch, and call command execution.
- Fixes the latest call testing issues around hidden commands leaking into the call chat, call history prompt shape, Local Whisper native runtime repair, active-call navigation, and character hangups ending before spoken lines finish.

## What changed

- Added Conversation call sessions/messages/soundboard storage, file-backed table support, routes, shared schemas/types, and rate-limit coverage.
- Added desktop/mobile Conversation call UI, active-call floating popout, call-only chat, media picker reuse, call controls, soundboard/volume controls, incoming call surfaces, and chat history call cards.
- Added call prompt assembly with provider-native media attachments, Local Whisper/browser/system dictation modes, output-format and command blocks on the latest user turn, call-history coalescing, older TTS cue cleanup, and debug logging.
- Added Local Whisper model download/status/delete APIs and client state, plus postinstall native dependency repair for `onnxruntime-node` across matching Node architectures.
- Added xAI TTS support and provider-native audio/video dispatch handling for OpenAI-compatible and Gemini-style providers.
- Updated v2.1.0 CHANGELOG notes and install/update docs for the native dependency repair path.

## Validation

- [ ] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed `CONTRIBUTING.md`

Automated validation run by Codex:

- `pnpm --filter @marinara-engine/server build`
- `pnpm --filter @marinara-engine/client build`
- `pnpm --filter @marinara-engine/client lint`
- `pnpm --filter @marinara-engine/shared build`
- `pnpm regression:prompt`
- `pnpm check`
- `pnpm version:check`

### Manual verification notes

- Not manually re-clicked in a browser in this final PR-prep pass.
- Needs maintainer verification of Conversation call setup, outgoing calls, incoming character calls, Local Whisper download/transcription, provider-native audio/video fallback behavior, mobile call controls, minimized call popout stacking, soundboard, command execution, and post-call summary injection.

## Docs and release impact

- [ ] No docs changes needed
- [x] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Version/release files updated (only if this PR includes a version bump)

Docs/release notes included:

- v2.1.0 CHANGELOG entries for Conversation calls, Local Whisper, xAI TTS, and call fixes.
- Windows, macOS/Linux, and Termux install/update notes for native dependency repair.

## UI evidence (if applicable)

Not captured in this PR-prep pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added conversation audio/video calls with answer/decline controls, call notifications, call history events, and a dedicated in-chat call view.
  * Added local speech model support for offline transcription and new voice/audio call settings.
  * Added support for an additional text-to-speech provider.

* **Bug Fixes**
  * Improved call reliability, media handling, and transcript visibility.
  * Added automatic dependency repair steps to help restore native audio/speech features after updates.

* **Documentation**
  * Updated installation guides and update instructions across platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->