### PR TITLE
feat: Reactions command toggle + fix group reaction attribution (#3219, #3220)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 
 - Conversation mode: emoji reactions can now target an individual character's part of a merged multi-character reply. Each speaker segment gets its own add-reaction button (next to the name) and its own reaction row; in the prompt, characters see reactions as a `[User reacted with 😹]` line directly under the exact part they were aimed at. Reactions without a segment target keep applying to the whole message, so existing chats and 1:1 conversations are unaffected (#3210).
 - Conversation mode: characters can now react to each other, not just to the user. A character writing `[react: emoji="🙄" to "Character Name"]` puts the reaction on that character's most recent part (same reply or recent history), rendered as a chip under it and shown to everyone in the prompt (e.g. `[User reacted with 😹, Aurey reacted with 🙄]`).
+- Conversation mode: character emoji reactions now have their own **Reactions** card in the per-command Commands grid (Chat Settings and the chat setup wizard), so they can be toggled independently like Selfies or Music (#3219).
 
 - Added the Agent Suite to the Chat Settings drawer's Agents section: a window listing the agents active in the current chat where you can view and edit everything they have stored — agent memory, tracker state, and custom-agent outputs — manually or with AI-assisted rewrites (select text, give an instruction, optionally attach grounding context such as character cards or active-lorebook entries, and pick a connection) (#3160).
 - Added first-class scene video generation for Game Mode, Roleplay, and Visual Novel galleries, including Video Generation connections for Gemini Omni and xAI Imagine, editable `game.video` prompts, manual Gallery video actions, per-image Animate buttons, Gallery video previews with prompt copy, live View Latest media, and draggable/resizable pinned video overlays.
@@ -16,6 +17,7 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 
 ### Fixed
 
+- Fixed group-chat character reactions always being credited to the first character in the chat: commands placed above the first `Name:` line of a merged reply now attribute to the speaker whose section they open, group chats now instruct models to write the `[react:]` tag inside the reacting character's own section, and a react aimed at the user's persona name (or "User") explicitly targets the user's latest message (#3220).
 - Renamed the editable scene-video prompt template from `game.omniVideo` to `game.video`, with legacy override fallback, and shortened scene-video prompts for smaller video providers by summarizing narration into a compact story beat, excerpting source illustration prompts, and loosening default motion guidance.
 - Removed the hard-coded three-sprite limit from Roleplay sprite selection, setup, and display paths so chats can enable all uploaded sprite owners they need (#3169).
 - Let Image Captioning use any non-image-generation connection instead of hiding local or custom multimodal models behind model-name heuristics (#3170).

--- a/packages/client/src/components/chat/ChatSettingsDrawer.tsx
+++ b/packages/client/src/components/chat/ChatSettingsDrawer.tsx
@@ -406,6 +406,11 @@ const CONVERSATION_COMMAND_TOGGLE_OPTIONS: Array<{
     description: "Let characters ring you for a Conversation call.",
   },
   {
+    id: "react",
+    label: "Reactions",
+    description: "Let characters react to messages with emoji badges.",
+  },
+  {
     id: "uno",
     label: "UNO",
     description: "Let characters start a game of UNO at the table when you agree to play.",

--- a/packages/client/src/components/chat/ChatSetupWizard.tsx
+++ b/packages/client/src/components/chat/ChatSetupWizard.tsx
@@ -164,6 +164,7 @@ const CONVERSATION_COMMAND_TOGGLE_OPTIONS: Array<{
   { id: "influence", label: "Influence", description: "Let characters influence a connected chat." },
   { id: "note", label: "Notes", description: "Let characters save durable notes for a connected chat." },
   { id: "call", label: "Calls", description: "Let characters ring you for a Conversation call." },
+  { id: "react", label: "Reactions", description: "Let characters react to messages with emoji badges." },
   { id: "uno", label: "UNO", description: "Let characters start a game of UNO at the table when you agree to play." },
   { id: "chess", label: "Chess", description: "Let characters accept a one-on-one chess challenge at the table." },
 ];

--- a/packages/client/src/components/chat/ConversationMessageGrouped.tsx
+++ b/packages/client/src/components/chat/ConversationMessageGrouped.tsx
@@ -196,6 +196,10 @@ export function ConversationMessageGrouped({
             ) : null;
 
           if (!grp.speaker) {
+            // Whitespace-only narration: render nothing — an empty
+            // [data-card-css] wrapper would paint a phantom themed box, the
+            // same invariant the speaker branches guard with segHasText.
+            if (!segHasText) return null;
             return (
               <div
                 key={i}

--- a/packages/client/src/components/chat/ReactionAddButton.tsx
+++ b/packages/client/src/components/chat/ReactionAddButton.tsx
@@ -4,7 +4,7 @@
 // user's reaction on the message. Standard emojis come from the picker; the global
 // custom emojis are shown in a pick-only "Custom" grid. Conversation mode only.
 // ──────────────────────────────────────────────
-import { useRef, useState } from "react";
+import { useRef, useState, type RefObject } from "react";
 import { SmilePlus } from "lucide-react";
 import { cn } from "../../lib/utils";
 import { EmojiPicker } from "../ui/EmojiPicker";
@@ -21,7 +21,6 @@ interface ReactionAddButtonProps {
 export function ReactionAddButton({ onPick, className, tabIndex }: ReactionAddButtonProps) {
   const [open, setOpen] = useState(false);
   const buttonRef = useRef<HTMLButtonElement>(null);
-  const { data: customEmojis } = useCustomEmojis();
 
   return (
     <>
@@ -42,42 +41,64 @@ export function ReactionAddButton({ onPick, className, tabIndex }: ReactionAddBu
       >
         <SmilePlus size="0.75rem" />
       </button>
-      <EmojiPicker
-        open={open}
-        onClose={() => setOpen(false)}
-        onSelect={(emoji) => {
-          setOpen(false);
-          onPick(emoji, null);
-        }}
-        anchorRef={buttonRef}
-        customTab={{
-          icon: "⭐",
-          label: "Custom emojis",
-          render: () => (
-            <div className="grid grid-cols-6 gap-1">
-              {(customEmojis ?? []).map((emoji) => (
-                <button
-                  key={emoji.id}
-                  type="button"
-                  onClick={() => {
-                    setOpen(false);
-                    onPick(`:${emoji.name}:`, emoji.url);
-                  }}
-                  title={`:${emoji.name}:`}
-                  className="flex aspect-square w-full items-center justify-center rounded-md p-1 transition-transform hover:scale-110 hover:bg-foreground/10 active:scale-100"
-                >
-                  <img src={emoji.url} alt={`:${emoji.name}:`} className="max-h-9 max-w-full object-contain" />
-                </button>
-              ))}
-              {(customEmojis ?? []).length === 0 && (
-                <p className="col-span-6 px-1 py-6 text-center text-[0.6875rem] text-foreground/45">
-                  No custom emojis to react with yet.
-                </p>
-              )}
-            </div>
-          ),
-        }}
-      />
+      {/* Mounted only while open: this button renders once per speaker segment
+          across the whole transcript, so a closed instance must cost nothing —
+          no picker subtree and no custom-emoji query subscription. */}
+      {open && (
+        <ReactionPickerPanel
+          anchorRef={buttonRef}
+          onClose={() => setOpen(false)}
+          onPick={(emoji, imageUrl) => {
+            setOpen(false);
+            onPick(emoji, imageUrl);
+          }}
+        />
+      )}
     </>
+  );
+}
+
+function ReactionPickerPanel({
+  anchorRef,
+  onClose,
+  onPick,
+}: {
+  anchorRef: RefObject<HTMLButtonElement | null>;
+  onClose: () => void;
+  onPick: (emoji: string, imageUrl: string | null) => void;
+}) {
+  const { data: customEmojis } = useCustomEmojis();
+
+  return (
+    <EmojiPicker
+      open
+      onClose={onClose}
+      onSelect={(emoji) => onPick(emoji, null)}
+      anchorRef={anchorRef}
+      customTab={{
+        icon: "⭐",
+        label: "Custom emojis",
+        render: () => (
+          <div className="grid grid-cols-6 gap-1">
+            {(customEmojis ?? []).map((emoji) => (
+              <button
+                key={emoji.id}
+                type="button"
+                onClick={() => onPick(`:${emoji.name}:`, emoji.url)}
+                title={`:${emoji.name}:`}
+                className="flex aspect-square w-full items-center justify-center rounded-md p-1 transition-transform hover:scale-110 hover:bg-foreground/10 active:scale-100"
+              >
+                <img src={emoji.url} alt={`:${emoji.name}:`} className="max-h-9 max-w-full object-contain" />
+              </button>
+            ))}
+            {(customEmojis ?? []).length === 0 && (
+              <p className="col-span-6 px-1 py-6 text-center text-[0.6875rem] text-foreground/45">
+                No custom emojis to react with yet.
+              </p>
+            )}
+          </div>
+        ),
+      }}
+    />
   );
 }

--- a/packages/server/src/routes/generate.routes.ts
+++ b/packages/server/src/routes/generate.routes.ts
@@ -3691,7 +3691,10 @@ export async function generateRoutes(app: FastifyInstance) {
           if (conversationCommandsEnabled && isConversationCommandEnabled(chatMeta, "react")) {
             conversationSystemPrompt +=
               '\n\nYou can react to the user\'s most recent message with a single emoji by writing [react: emoji="😂"] on its own line — any standard emoji, or a custom one you have access to as [react: emoji=":name:"]. It posts as a small badge on their message, the way you\'d react in a chat app. You can also react to another character instead by adding their name: [react: emoji="🙄" to "Character Name"] puts the badge on that character\'s most recent message. Only the [react: …] tag posts a badge — an emoji typed in your message body is just text. Use it only when it genuinely fits how your character feels in the moment; it is optional, may stand alone or sit alongside your reply, and choosing a flat reaction or none at all is itself a valid choice.';
-            if (characterIds.length > 1) {
+            // Merged group replies only: individual-order group chats forbid
+            // name-prefixed sections entirely (matching the other name-prefix
+            // instructions gated on earlyGroupMode !== "individual").
+            if (characterIds.length > 1 && earlyGroupMode !== "individual") {
               conversationSystemPrompt +=
                 " In this group chat, each character reacts for themselves: write the tag inside that character's own section of the reply, directly under their name line, so the reaction is credited to them — never above the first name line.";
             }
@@ -10536,14 +10539,7 @@ export async function generateRoutes(app: FastifyInstance) {
                       | string
                       | undefined;
                     let segmentTarget: { segment: number; speaker: string | null } | null = null;
-                    // Models name the human too ("to \"User\"" / the persona name) —
-                    // that IS the default target, so resolve it explicitly instead
-                    // of relying on the unknown-name fallback (#3220).
-                    const targetsPersona =
-                      !!reactCmd.targetCharacter &&
-                      (normalizeTextForMatch(reactCmd.targetCharacter) === normalizeTextForMatch(personaName) ||
-                        normalizeTextForMatch(reactCmd.targetCharacter) === "user");
-                    if (reactCmd.targetCharacter && !targetsPersona) {
+                    if (reactCmd.targetCharacter) {
                       // Resolve names against ALL chat members (disabled ones
                       // included) — the client renders and segments with the full
                       // member set, so a stored segment index derived from a
@@ -10566,10 +10562,18 @@ export async function generateRoutes(app: FastifyInstance) {
                       const wanted = normalizeTextForMatch(reactCmd.targetCharacter);
                       const targetChar = chatMembers.find((m) => normalizeTextForMatch(m.name) === wanted);
                       if (!targetChar) {
-                        logger.debug(
-                          '[react/conversation] Unknown react target "%s" — falling back to the user message',
-                          reactCmd.targetCharacter,
-                        );
+                        // Chat members take precedence; with none matching, a react
+                        // aimed at the human — the persona's name or "User" — IS the
+                        // default target, so keep it silently. Other unknown names
+                        // fall back the same way, with a log.
+                        const targetsPersona =
+                          wanted === normalizeTextForMatch(personaName) || wanted === "user";
+                        if (!targetsPersona) {
+                          logger.debug(
+                            '[react/conversation] Unknown react target "%s" — falling back to the user message',
+                            reactCmd.targetCharacter,
+                          );
+                        }
                       } else {
                         const baseNames = new Set(chatMembers.map((m) => normalizeTextForMatch(m.name)));
                         // A walked message's author may have been removed from the

--- a/packages/server/src/routes/generate.routes.ts
+++ b/packages/server/src/routes/generate.routes.ts
@@ -834,6 +834,8 @@ function getConversationCommandKey(command: CharacterCommand): ConversationComma
       return "influence";
     case "note":
       return "note";
+    case "react":
+      return "react";
     default:
       return null;
   }
@@ -3681,13 +3683,18 @@ export async function generateRoutes(app: FastifyInstance) {
           // conversation asset context below. Whether
           // to react — and how warmly or dryly — is emergent from personality, not
           // dictated here.
-          // Gated on `conversationCommandsEnabled`: the `[react: …]` tag is parsed,
-          // stripped, and applied inside the command pipeline, which only runs when
-          // Character Commands are enabled. Advertising the syntax while that pipeline
-          // is off leaves the raw tag in the visible message with no badge (#2877).
-          if (conversationCommandsEnabled) {
+          // Gated on `conversationCommandsEnabled` + the per-command "react"
+          // toggle (#3219): the `[react: …]` tag is parsed, stripped, and applied
+          // inside the command pipeline, which only runs when Character Commands
+          // are enabled. Advertising the syntax while that pipeline is off leaves
+          // the raw tag in the visible message with no badge (#2877).
+          if (conversationCommandsEnabled && isConversationCommandEnabled(chatMeta, "react")) {
             conversationSystemPrompt +=
               '\n\nYou can react to the user\'s most recent message with a single emoji by writing [react: emoji="😂"] on its own line — any standard emoji, or a custom one you have access to as [react: emoji=":name:"]. It posts as a small badge on their message, the way you\'d react in a chat app. You can also react to another character instead by adding their name: [react: emoji="🙄" to "Character Name"] puts the badge on that character\'s most recent message. Only the [react: …] tag posts a badge — an emoji typed in your message body is just text. Use it only when it genuinely fits how your character feels in the moment; it is optional, may stand alone or sit alongside your reply, and choosing a flat reaction or none at all is itself a valid choice.';
+            if (characterIds.length > 1) {
+              conversationSystemPrompt +=
+                " In this group chat, each character reacts for themselves: write the tag inside that character's own section of the reply, directly under their name line, so the reaction is credited to them — never above the first name line.";
+            }
           }
           // ── Home Professor Mari: inject assistant knowledge & commands ──
           if (isHomeProfessorMariAssistantChat) {
@@ -10529,7 +10536,14 @@ export async function generateRoutes(app: FastifyInstance) {
                       | string
                       | undefined;
                     let segmentTarget: { segment: number; speaker: string | null } | null = null;
-                    if (reactCmd.targetCharacter) {
+                    // Models name the human too ("to \"User\"" / the persona name) —
+                    // that IS the default target, so resolve it explicitly instead
+                    // of relying on the unknown-name fallback (#3220).
+                    const targetsPersona =
+                      !!reactCmd.targetCharacter &&
+                      (normalizeTextForMatch(reactCmd.targetCharacter) === normalizeTextForMatch(personaName) ||
+                        normalizeTextForMatch(reactCmd.targetCharacter) === "user");
+                    if (reactCmd.targetCharacter && !targetsPersona) {
                       // Resolve names against ALL chat members (disabled ones
                       // included) — the client renders and segments with the full
                       // member set, so a stored segment index derived from a

--- a/packages/server/src/routes/generate.routes.ts
+++ b/packages/server/src/routes/generate.routes.ts
@@ -3696,7 +3696,7 @@ export async function generateRoutes(app: FastifyInstance) {
             // instructions gated on earlyGroupMode !== "individual").
             if (characterIds.length > 1 && earlyGroupMode !== "individual") {
               conversationSystemPrompt +=
-                " In this group chat, each character reacts for themselves: write the tag inside that character's own section of the reply, directly under their name line, so the reaction is credited to them — never above the first name line.";
+                " In this group chat, each character reacts for themselves: write the tag inside that character's own section of the reply, directly under their name line, so the reaction is credited to them — never above the first name line. One reaction per reply is not a limit — every character who would plausibly react may include their own tag in their own section, the way several people tap a reaction on the same message in a real chat.";
             }
           }
           // ── Home Professor Mari: inject assistant knowledge & commands ──

--- a/packages/server/src/routes/generate.routes.ts
+++ b/packages/server/src/routes/generate.routes.ts
@@ -3134,11 +3134,16 @@ export async function generateRoutes(app: FastifyInstance) {
               // rather than mutating it: finalMessages shares objects with the
               // follow-up/agent message arrays, and a mutated object would get
               // annotated a second time on a follow-up generation pass.
+              const rawContentStr = typeof raw.content === "string" ? raw.content : String(raw.content ?? "");
               finalMessages[i] = {
                 ...finalMessages[i]!,
                 content: annotateContentWithReactions(
                   finalMessages[i]!.content,
-                  stripLeadingMessageTimestamps(typeof raw.content === "string" ? raw.content : String(raw.content ?? "")),
+                  // Oversized content skips segmentation inside annotate anyway —
+                  // don't pay the strip on it either.
+                  rawContentStr.length > REACTION_ANNOTATION_CONTENT_CAP
+                    ? rawContentStr
+                    : stripLeadingMessageTimestamps(rawContentStr),
                   parseExtra(raw.extra).reactions,
                   reactionSpeakersByNorm,
                   reactorDisplayName,
@@ -9903,6 +9908,28 @@ export async function generateRoutes(app: FastifyInstance) {
             type: "assistant_commands_start",
             data: { count: collectedCommands.length, professorMariCommandCount },
           });
+          // React target resolution needs the FULL chat-member list (disabled
+          // members included — the client segments with them). Built lazily once
+          // per request: each getById is a full-table scan in the file-native
+          // store, and a multi-react group reply runs several react commands.
+          let reactChatMembersCache: Array<{ id: string; name: string }> | null = null;
+          const getReactChatMembers = async (): Promise<Array<{ id: string; name: string }>> => {
+            if (reactChatMembersCache) return reactChatMembersCache;
+            const members: Array<{ id: string; name: string }> = charInfo.map((c) => ({ id: c.id, name: c.name }));
+            for (const cid of allCharacterIds) {
+              if (members.some((m) => m.id === cid)) continue;
+              const row = await chars.getById(cid);
+              if (!row) continue;
+              try {
+                const name = JSON.parse(row.data as string)?.name;
+                if (typeof name === "string" && name.trim()) members.push({ id: cid, name });
+              } catch {
+                // Malformed character data — not addressable as a react target.
+              }
+            }
+            reactChatMembersCache = members;
+            return members;
+          };
           try {
             for (const { command, characterId, messageId, swipeIndex } of collectedCommands) {
               try {
@@ -10539,26 +10566,12 @@ export async function generateRoutes(app: FastifyInstance) {
                       | string
                       | undefined;
                     let segmentTarget: { segment: number; speaker: string | null } | null = null;
+                    // The saved reply row, prefetched when the targeted-resolution
+                    // path already loaded it — the write below reuses it instead
+                    // of re-scanning the messages table.
+                    let prefetchedTargetMsg: Awaited<ReturnType<typeof chats.getMessage>> | null = null;
                     if (reactCmd.targetCharacter) {
-                      // Resolve names against ALL chat members (disabled ones
-                      // included) — the client renders and segments with the full
-                      // member set, so a stored segment index derived from a
-                      // narrower set would point at the wrong part.
-                      const chatMembers: Array<{ id: string; name: string }> = charInfo.map((c) => ({
-                        id: c.id,
-                        name: c.name,
-                      }));
-                      for (const cid of allCharacterIds) {
-                        if (chatMembers.some((m) => m.id === cid)) continue;
-                        const row = await chars.getById(cid);
-                        if (!row) continue;
-                        try {
-                          const name = JSON.parse(row.data as string)?.name;
-                          if (typeof name === "string" && name.trim()) chatMembers.push({ id: cid, name });
-                        } catch {
-                          // Malformed character data — not addressable as a react target.
-                        }
-                      }
+                      const chatMembers = await getReactChatMembers();
                       const wanted = normalizeTextForMatch(reactCmd.targetCharacter);
                       const targetChar = chatMembers.find((m) => normalizeTextForMatch(m.name) === wanted);
                       if (!targetChar) {
@@ -10610,10 +10623,12 @@ export async function generateRoutes(app: FastifyInstance) {
                           authorId: unknown,
                           beforePartByNorm?: string | null,
                         ): Promise<{ segment: number; speaker: string | null } | null> => {
-                          const text = stripLeadingMessageTimestamps(
-                            typeof content === "string" ? content : String(content ?? ""),
-                          );
-                          if (!text || text.length > REACTION_ANNOTATION_CONTENT_CAP) return null;
+                          const rawText = typeof content === "string" ? content : String(content ?? "");
+                          // Cap BEFORE the strip so pathological content skips all
+                          // regex work, not just the segmentation.
+                          if (!rawText.trim() || rawText.length > REACTION_ANNOTATION_CONTENT_CAP) return null;
+                          const text = stripLeadingMessageTimestamps(rawText);
+                          if (!text) return null;
                           const names = new Set(baseNames);
                           const author = await authorNameOf(authorId);
                           if (author) names.add(normalizeTextForMatch(author));
@@ -10655,7 +10670,10 @@ export async function generateRoutes(app: FastifyInstance) {
                               (ownMsg as { characterId?: unknown }).characterId,
                               reactorName ? normalizeTextForMatch(reactorName) : null,
                             );
-                            if (part) resolved = { id: messageId, target: part };
+                            if (part) {
+                              resolved = { id: messageId, target: part };
+                              prefetchedTargetMsg = ownMsg;
+                            }
                           }
                         }
                         if (!resolved) {
@@ -10704,7 +10722,10 @@ export async function generateRoutes(app: FastifyInstance) {
                     }
 
                     if (targetId) {
-                      const targetMsg = await chats.getMessage(targetId);
+                      const targetMsg =
+                        prefetchedTargetMsg && targetId === messageId
+                          ? prefetchedTargetMsg
+                          : await chats.getMessage(targetId);
                       if (targetMsg) {
                         const ex = parseExtra(targetMsg.extra);
                         const reactions = addMessageReactor(
@@ -10714,12 +10735,14 @@ export async function generateRoutes(app: FastifyInstance) {
                           imageUrl,
                           segmentTarget,
                         );
+                        // updateMessageExtra mirrors the ACTIVE swipe itself; the
+                        // loop below covers the remaining swipes so swiping the
+                        // target message doesn't drop the character's reaction
+                        // (same message-level semantics as the client PATCH route).
                         await chats.updateMessageExtra(targetId, { reactions });
-                        // Reactions are message-level: mirror them to every swipe row
-                        // (the client's PATCH route does the same) so swiping the
-                        // target message doesn't drop the character's reaction.
                         const targetSwipes = await chats.getSwipes(targetId);
                         for (const swipe of targetSwipes) {
+                          if (swipe.index === targetMsg.activeSwipeIndex) continue;
                           await chats.updateSwipeExtra(targetId, swipe.index, { reactions });
                         }
                         logger.info(

--- a/packages/server/src/services/conversation/character-commands.ts
+++ b/packages/server/src/services/conversation/character-commands.ts
@@ -1212,8 +1212,12 @@ export function parseCharacterCommands(content: string): {
  *
  * The authoritative command list and cleaned content come from a single whole-response
  * parse, so no command is dropped or reordered even if one spans a name boundary;
- * only the attribution is layered on. Commands with no matching segment (and text
- * before the first recognised name prefix) fall back to `fallbackCharacterId`.
+ * only the attribution is layered on. Commands with no matching segment fall back
+ * to `fallbackCharacterId`. Text ABOVE the first recognised name prefix is credited
+ * to the first named section's speaker (models park reply-opening commands like a
+ * `[react:]` header there, and crediting the generation-primary character instead
+ * deterministically mis-attributed every such command to the chat's first
+ * character — #3220); with no named sections at all it falls back as before.
  */
 export function parseCharacterCommandsBySpeaker(
   content: string,
@@ -1230,11 +1234,18 @@ export function parseCharacterCommandsBySpeaker(
 
   // Segment the response by leading "Name: " line prefixes, mirroring the client's
   // parseNamePrefixFormat so server-side attribution matches the rendered split.
-  const segments: Array<{ characterId: string | null; text: string }> = [];
+  const segments: Array<{ characterId: string | null; text: string; leading?: boolean }> = [];
   let currentId: string | null = fallbackCharacterId;
+  let inLeadingRegion = true;
   let currentLines: string[] = [];
   const flush = () => {
-    if (currentLines.length > 0) segments.push({ characterId: currentId, text: currentLines.join("\n") });
+    if (currentLines.length > 0) {
+      segments.push({
+        characterId: currentId,
+        text: currentLines.join("\n"),
+        ...(inLeadingRegion ? { leading: true } : {}),
+      });
+    }
     currentLines = [];
   };
   for (const line of content.split("\n")) {
@@ -1243,6 +1254,7 @@ export function parseCharacterCommandsBySpeaker(
       const mappedId = nameToId.get(normalizeTextForMatch(line.slice(0, colonIdx)));
       if (mappedId) {
         flush();
+        inLeadingRegion = false;
         currentId = mappedId;
         currentLines = [line.slice(colonIdx + 2)];
         continue;
@@ -1251,6 +1263,15 @@ export function parseCharacterCommandsBySpeaker(
     currentLines.push(line);
   }
   flush();
+
+  // Credit the leading region (above the first name prefix) to the speaker whose
+  // section it opens, not the generation-primary character.
+  const firstNamed = segments.find((segment) => !segment.leading);
+  if (firstNamed) {
+    for (const segment of segments) {
+      if (segment.leading) segment.characterId = firstNamed.characterId;
+    }
+  }
 
   // Build a per-command attribution queue keyed by command shape, consumed in
   // segment order so duplicate commands attribute left-to-right.

--- a/packages/server/src/services/conversation/character-commands.ts
+++ b/packages/server/src/services/conversation/character-commands.ts
@@ -35,7 +35,7 @@
 // - [navigate: panel="...", tab="..."]
 // - [fetch: type="character|persona|lorebook|chat|preset", name="..."]
 
-import { normalizeTextForMatch } from "@marinara-engine/shared";
+import { normalizeTextForMatch, stripLeadingMessageTimestamps } from "@marinara-engine/shared";
 
 import { stripConversationPromptTimestamps } from "./transcript-sanitize.js";
 
@@ -394,14 +394,20 @@ const REACT_RE = /\[react:([^\]\r\n]+)\]/gi;
 /** Split a `[react: ...]` body into its emoji token + optional `to "Name"` target. */
 function parseReactBody(body: string): { emoji: string; targetCharacter?: string } | null {
   const trimmed = body.trim();
+  // Tolerate spaces around '=' — a common model malformation of the advertised
+  // emoji="…" syntax.
+  const keyForm = trimmed.match(/^emoji\s*=\s*"/i);
   let emoji: string;
   let rest: string;
-  if (trimmed.toLowerCase().startsWith('emoji="')) {
-    const close = trimmed.indexOf('"', 7);
+  let quotedForm = false;
+  if (keyForm) {
+    quotedForm = true;
+    const close = trimmed.indexOf('"', keyForm[0].length);
     if (close === -1) return null;
-    emoji = trimmed.slice(7, close).trim();
+    emoji = trimmed.slice(keyForm[0].length, close).trim();
     rest = trimmed.slice(close + 1);
   } else if (trimmed.startsWith('"')) {
+    quotedForm = true;
     const close = trimmed.indexOf('"', 1);
     if (close === -1) return null;
     emoji = trimmed.slice(1, close).trim();
@@ -425,10 +431,13 @@ function parseReactBody(body: string): { emoji: string; targetCharacter?: string
       return target ? { emoji, targetCharacter: target } : { emoji };
     }
     // No recognizable target marker after a bare token — keep the old grammar's
-    // behavior where the whole body was the (possibly junk) emoji token.
-    if (!trimmed.startsWith('"') && !trimmed.toLowerCase().startsWith('emoji="')) return { emoji: trimmed };
+    // behavior where the whole body was the (possibly junk) emoji token. Bodies
+    // containing quotes were unreachable under the old grammar (prose asides
+    // like `[react: she said "hi"]`) — reject them rather than minting a junk
+    // text chip.
+    if (!quotedForm) return trimmed.includes('"') ? null : { emoji: trimmed };
   }
-  return { emoji };
+  return emoji.includes('"') ? null : { emoji };
 }
 const DIRECT_MESSAGE_RE = new RegExp(`\\[dm:\\s*(${QUOTED_PARAM_BLOCK})\\]`, "gi");
 const INFLUENCE_RE = /<influence>([\s\S]*?)<\/influence>/gi;
@@ -1176,7 +1185,10 @@ export function parseCharacterCommands(content: string): {
     .replace(HAPTIC_RE, "")
     .replace(SPOTIFY_RE, "")
     .replace(YOUTUBE_RE, "")
-    .replace(REACT_RE, "")
+    // Only strip react tags that actually parse into a command — bodies
+    // parseReactBody rejects (junk prose with quotes, unterminated quotes)
+    // stay visible, matching the old stricter grammar's behavior.
+    .replace(REACT_RE, (match, reactBody: string) => (parseReactBody(reactBody) ? "" : match))
     .replace(INFLUENCE_RE, "")
     .replace(NOTE_RE, "")
     .replace(INFLUENCE_BRACKET_RE, "")
@@ -1234,6 +1246,12 @@ export function parseCharacterCommandsBySpeaker(
 
   // Segment the response by leading "Name: " line prefixes, mirroring the client's
   // parseNamePrefixFormat so server-side attribution matches the rendered split.
+  // Segment the timestamp-stripped shape — the client strips leaked [HH:MM]
+  // tokens before rendering, so a line like "[12:01] Alice: hey" is Alice's
+  // section on screen and must be Alice's for attribution too. (Attribution
+  // only: commands and cleanContent still come from the raw whole-response
+  // parse above, and the strip never touches [command:] tokens.)
+  const attributionContent = stripLeadingMessageTimestamps(content);
   const segments: Array<{ characterId: string | null; text: string; leading?: boolean }> = [];
   let currentId: string | null = fallbackCharacterId;
   let inLeadingRegion = true;
@@ -1248,7 +1266,7 @@ export function parseCharacterCommandsBySpeaker(
     }
     currentLines = [];
   };
-  for (const line of content.split("\n")) {
+  for (const line of attributionContent.split("\n")) {
     const colonIdx = line.indexOf(": ");
     if (colonIdx > 0) {
       const mappedId = nameToId.get(normalizeTextForMatch(line.slice(0, colonIdx)));

--- a/packages/shared/src/types/chat.ts
+++ b/packages/shared/src/types/chat.ts
@@ -41,6 +41,7 @@ export const CONVERSATION_COMMAND_KEYS = [
   "haptic",
   "influence",
   "note",
+  "react",
 ] as const;
 
 export type ConversationCommandKey = (typeof CONVERSATION_COMMAND_KEYS)[number];

--- a/packages/shared/src/utils/speaker-segments.ts
+++ b/packages/shared/src/utils/speaker-segments.ts
@@ -17,9 +17,13 @@ import { normalizeTextForMatch } from "./text-matching.js";
  * empty `Name: ` part keeps parsing as a (filtered) speaker line on both sides.
  */
 export function stripLeadingMessageTimestamps(text: string): string {
+  // The leading whitespace class is deliberately same-line-only ([^\S\n], not
+  // \s): with \s* every line start inside a long blank run re-scanned the rest
+  // of the run before failing, going quadratic (~1s per call at 40KB of
+  // newlines). Same-line whitespace fails in O(1) at non-timestamp lines.
   return text
-    .replace(/^(\s*\[\d{1,2}[:.]\d{2}\]\s*)+/gm, "")
-    .replace(/^(\s*\[\d{1,2}\.\d{1,2}\.\d{4}\]\s*)+/gm, "")
+    .replace(/^([^\S\n]*\[\d{1,2}[:.]\d{2}\]\s*)+/gm, "")
+    .replace(/^([^\S\n]*\[\d{1,2}\.\d{1,2}\.\d{4}\]\s*)+/gm, "")
     .trim();
 }
 


### PR DESCRIPTION
Fixes #3219, fixes #3220

## Summary

Two follow-ups from maintainer playtesting of the reaction feature (#3211):

1. **Reactions toggle (#3219)**: character emoji reactions get their own card in the per-command Commands grid (Chat Settings and the chat setup wizard), wired like Selfies/Music/etc. — when off, the react instruction stays out of the prompt and `[react:]` tags are filtered by the command pipeline. Default on.
2. **Group attribution fix (#3220)**: character reactions in group chats were always credited to the first character in the chat. Real replies showed why: models emit the `[react:]` tag as the first line of the whole merged reply, above any character's `Name:` section, and that leading region fell back to the generation-primary (first) character.

## Why

While playtesting, reactions silently didn't work until the master Commands toggle was found (nothing indicates reactions depend on it), and once they worked, every chip's tooltip read "reacted by <first character>" regardless of who was reacting in the story. Inspecting `extra.conversationCommandContent` of the actual replies confirmed the tag-above-first-section placement in 3 out of 3 reacting replies.

## What changed

| Layer | Change |
|---|---|
| `packages/shared/src/types/chat.ts` | `"react"` added to `CONVERSATION_COMMAND_KEYS`. |
| `packages/server/src/routes/generate.routes.ts` | React instruction gated on the new per-command toggle; merged group chats (not individual-order mode, which forbids name prefixes) get added guidance instructing models to write the tag **inside the reacting character's own section** (never above the first name line) and stating explicitly that **multiple characters may each react in the same reply** (playtesting showed models emitting exactly one tag per merged reply, 5/5); a react targeting the persona name or "User" resolves to the user's latest message when no chat member shares the name (members take precedence); `getConversationCommandKey` maps `react` so the existing command filter enforces the toggle. |
| `packages/server/src/services/conversation/character-commands.ts` | `parseCharacterCommandsBySpeaker`: the leading region (text above the first recognized `Name:` prefix) now attributes to the speaker of the first named section — the turn the header visually opens — instead of the generation-primary character. No named sections → unchanged fallback. Affects all commands parked above the first section, not just reacts. |
| `packages/client/src/components/chat/ChatSettingsDrawer.tsx` + `ChatSetupWizard.tsx` | "Reactions" toggle card ("Let characters react to messages with emoji badges."), placed with the other command cards. |

Verified by executing the real parser: a header-placed tag now attributes to the first section's speaker, an in-section tag to that section's speaker, and a sectionless reply falls back exactly as before.

## Sweep hardening (adversarial regression/perf review of #3211 + this branch)

A multi-agent sweep (hunting the #3104/#3164 lag classes specifically) confirmed and fixed five more issues here:

- **Quadratic `stripLeadingMessageTimestamps`** on whitespace runs (measured 1.1s/call at 40KB of newlines, called per reacted history message per generation) — the leading whitespace class is now same-line-only: 100KB drops from ~6.9s to 0.68ms, output byte-identical on real timestamp shapes. Both new call sites also cap content size BEFORE stripping.
- **Redundant store scans per `[react:]` command** (each get/update is a full-table scan in the file-native store; 5 reacts on a 30k-message install measured ~2s of event-loop blocking): the chat-member build is now cached per request, the resolved target message is reused instead of re-fetched, and the swipe mirror skips the active swipe `updateMessageExtra` already writes.
- **Attribution vs leaked timestamps**: `parseCharacterCommandsBySpeaker` now segments the timestamp-stripped shape (matching the client display and the react resolver), so `[12:01] Alice: hey [react: …]` credits Alice, not the next character. Verified by execution.
- **Junk react tags**: quote-bearing bodies (`[react: she said "hi"]`) no longer mint literal-text chips — they're rejected and left visible like the old grammar; `emoji = "😂"` (spaces around `=`) now parses as intended.
- **Phantom themed box**: whitespace-only narration segments no longer render an empty `[data-card-css]` wrapper; and per-segment `ReactionAddButton`s now mount their picker + custom-emoji query subscription only while open (they render once per speaker segment across the transcript).

The sweep's remaining HIGH finding — the whole transcript re-rendering every streaming frame because `useConversationCustomEmojis/Stickers` return fresh Maps per render — **predates these PRs** (it's the #3164 disease on another prop) and is filed + fixed separately: #3223 / PR #3224.

## Known limitations

- A tag above the first section is inherently ambiguous — the model doesn't say who meant it. Attributing it to the section it opens is deterministic and positionally coherent, but the real cure is the new instruction pushing models to place tags inside their own sections; the fallback only covers non-compliant replies.
- The leading-region attribution change applies to every command type (e.g. a `[selfie]` above the first section), for consistency — flagging in case a different fallback is preferred there.

## Test plan (manual verification needed)

- [ ] Chat Settings → Commands: a "Reactions" card appears in the grid (and in the setup wizard's command step); light + dark mode, mobile width.
- [ ] With Reactions off: characters stop reacting, no raw `[react:]` text leaks into visible messages, and Peek Prompt no longer contains the react instruction.
- [x] With Reactions on in a group chat: when characters react, hover the chips — the "reacted by" tooltip credits different characters over time, not always the first one. *(Verified in live playtest against stored data — Floyd/Jade/Aurey all credited across one session; see verification report comment.)*
- [ ] Peek Prompt in a group chat shows the new placement sentence ("write the tag inside that character's own section..."); in a manual/individual-order group chat it does NOT appear.
- [x] Over a longer group session, replies sometimes carry reactions from more than one character (the multi-react guidance) — verified in raw output (`extra.conversationCommandContent`) or via chips from different reactors on the same turn. *(Verified: single replies carried 2–3 tags; chips from three characters on one message; see verification report comment.)*
- [x] Ask a character to react to your message: the chip lands on your latest message (models targeting `to "User"`/persona name now resolve explicitly). *(Verified in live playtest — models emit `to "User"` routinely and chips landed on the user's message; the collision-precedence edge is code-traced only.)*

## Docs touched

- `CHANGELOG.md` (Unreleased → Added + Fixed).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for character reactions in Conversation mode, including a new Reactions command toggle in settings and setup.

* **Bug Fixes**
  * Improved reaction targeting in group chats so reactions are attributed to the correct character.
  * Prevented empty message segments from rendering as visible placeholders.
  * Fixed reaction parsing to ignore malformed emoji inputs and leave invalid text unchanged.
  * Improved reaction performance and responsiveness by reducing unnecessary work during message processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->