### PR TITLE
fix: stop conversation emoji/sticker maps re-rendering the whole transcript every streaming frame (#3223)

### DIFF
--- a/packages/client/src/hooks/use-conversation-custom-emojis.ts
+++ b/packages/client/src/hooks/use-conversation-custom-emojis.ts
@@ -5,6 +5,7 @@
 // emojis override a global of the same name (owner-wins). Used by the message
 // renderer, the composer autocomplete, and the picker's Custom tab.
 // ──────────────────────────────────────────────
+import { useRef } from "react";
 import { useQueries } from "@tanstack/react-query";
 import { api } from "../lib/api-client";
 import { useChatStore } from "../stores/chat.store";
@@ -36,6 +37,7 @@ function displayName(row: { data?: unknown; name?: unknown } | undefined, fallba
 }
 
 export function useConversationCustomEmojis(): { list: ConversationCustomEmoji[]; map: Map<string, string> } {
+  const stableResultRef = useRef<{ list: ConversationCustomEmoji[]; map: Map<string, string> } | null>(null);
   const activeChatId = useChatStore((s) => s.activeChatId);
   const { data: activeChat } = useChat(activeChatId);
   const personaId = (activeChat as { personaId?: string | null } | undefined)?.personaId ?? null;
@@ -90,7 +92,31 @@ export function useConversationCustomEmojis(): { list: ConversationCustomEmoji[]
     }
   });
 
-  const list = [...byName.values()];
-  const map = new Map(list.map((emoji) => [emoji.name, emoji.url] as const));
-  return { list, map };
+  // [#3223] The derivation above rebuilds fresh objects every render (the
+  // useQueries result arrays churn identity per render), but the resolved set
+  // rarely changes. Reuse the previous { list, map } when it is element-wise
+  // identical — every mounted ConversationMessage receives `map` as a prop, so
+  // a fresh Map per render broke React.memo for the whole transcript on every
+  // streaming frame (the #3164 disease; same ref-reuse pattern as ChatArea's
+  // chatCharacterRows).
+  const next = [...byName.values()];
+  const previous = stableResultRef.current;
+  if (
+    previous &&
+    previous.list.length === next.length &&
+    next.every((emoji, index) => {
+      const before = previous.list[index]!;
+      return (
+        before.name === emoji.name &&
+        before.url === emoji.url &&
+        before.source === emoji.source &&
+        before.editable === emoji.editable
+      );
+    })
+  ) {
+    return previous;
+  }
+  const result = { list: next, map: new Map(next.map((emoji) => [emoji.name, emoji.url] as const)) };
+  stableResultRef.current = result;
+  return result;
 }

--- a/packages/client/src/hooks/use-conversation-custom-stickers.ts
+++ b/packages/client/src/hooks/use-conversation-custom-stickers.ts
@@ -5,6 +5,7 @@
 // stickers override a global of the same name (owner-wins). Used by the message
 // renderer and the sticker selector.
 // ──────────────────────────────────────────────
+import { useRef } from "react";
 import { useQueries } from "@tanstack/react-query";
 import { api } from "../lib/api-client";
 import { useChatStore } from "../stores/chat.store";
@@ -36,6 +37,7 @@ function displayName(row: { data?: unknown; name?: unknown } | undefined, fallba
 }
 
 export function useConversationCustomStickers(): { list: ConversationCustomSticker[]; map: Map<string, string> } {
+  const stableResultRef = useRef<{ list: ConversationCustomSticker[]; map: Map<string, string> } | null>(null);
   const activeChatId = useChatStore((s) => s.activeChatId);
   const { data: activeChat } = useChat(activeChatId);
   const personaId = (activeChat as { personaId?: string | null } | undefined)?.personaId ?? null;
@@ -90,7 +92,31 @@ export function useConversationCustomStickers(): { list: ConversationCustomStick
     }
   });
 
-  const list = [...byName.values()];
-  const map = new Map(list.map((sticker) => [sticker.name, sticker.url] as const));
-  return { list, map };
+  // [#3223] The derivation above rebuilds fresh objects every render (the
+  // useQueries result arrays churn identity per render), but the resolved set
+  // rarely changes. Reuse the previous { list, map } when it is element-wise
+  // identical — every mounted ConversationMessage receives `map` as a prop, so
+  // a fresh Map per render broke React.memo for the whole transcript on every
+  // streaming frame (the #3164 disease; same ref-reuse pattern as ChatArea's
+  // chatCharacterRows).
+  const next = [...byName.values()];
+  const previous = stableResultRef.current;
+  if (
+    previous &&
+    previous.list.length === next.length &&
+    next.every((sticker, index) => {
+      const before = previous.list[index]!;
+      return (
+        before.name === sticker.name &&
+        before.url === sticker.url &&
+        before.source === sticker.source &&
+        before.editable === sticker.editable
+      );
+    })
+  ) {
+    return previous;
+  }
+  const result = { list: next, map: new Map(next.map((sticker) => [sticker.name, sticker.url] as const)) };
+  stableResultRef.current = result;
+  return result;
 }


### PR DESCRIPTION
Fixes #3223

## Summary

`useConversationCustomEmojis()` and `useConversationCustomStickers()` returned a fresh `list` array and a fresh `Map` on every render. `ConversationView` passes those Maps as `emojiMap`/`stickerMap` props to every `memo(ConversationMessage)`, so the memo's shallow compare failed for **every mounted message on every ConversationView render** — and ConversationView renders once per animation frame during any token stream. Net effect: the whole transcript re-rendered per streaming frame (~15–35 ms/frame measured on a 100-message group chat), the same disease class as #3104/#3164.

The fix applies the ref-backed reuse pattern ChatArea already uses for `chatCharacterRows` (the #3164 fix): build the resolved list as before, compare it element-wise against the previous one (all fields are primitives), and return the cached `{ list, map }` object when unchanged. Both hooks fixed identically.

## Why

Found by a regression/performance sweep of the reaction PRs (#3211/#3221). The bug predates them — but per-segment reactions added more per-message subtrees under the broken memo boundary, so fixing the boundary is what makes the transcript cheap again during streaming.

## Known limitations

- The element-wise compare is O(emoji+sticker count) per render — trivial, and the price of the `useQueries` inputs having no stable identity to memo against (a plain `useMemo` cannot work here, which is why the ref pattern exists).

## Test plan (manual verification needed)

- [ ] React DevTools → "Highlight updates when components render": in a long conversation chat, stream a reply — only the streaming message (and composer chrome) should flash per frame, not the whole transcript. Before this fix, every mounted message flashed.
- [ ] Custom emojis/stickers still render in messages, the composer autocomplete, the picker's Custom tab, and the sticker selector; adding/renaming/deleting a custom emoji updates them (the cache must invalidate on real changes).
- [ ] Long group chat scroll + streaming feels smoother on a loaded machine (subjective, but the measurable proxy is the DevTools flashing).

## Docs touched

- None (internal perf fix; no user-facing behavior change).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved consistency when rendering conversations by keeping custom emoji and sticker results stable across re-renders.
  * Reduced unnecessary updates by reusing previously computed emoji and sticker collections when the content hasn’t changed.
  * Helped preserve UI memoization, which can prevent flicker or extra rendering work in transcript views.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->