### PR TITLE
[codex] Fix Game session start branch selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 - Fixed Smart group response order so hidden responder selection no longer overrides `/guided` or `/impersonate` directives in Roleplay group chats (#3212).
 - Fixed stopped partial replies being cache-only placeholders, so editing a kept unfinished reply persists it as a real message instead of deleting it on refresh (#3213).
 - Fixed Game Mode party recruitment for mid-session NPCs by creating a game-scoped tracked NPC/card fallback instead of throwing when the NPC was not generated at setup (#3216).
+- Fixed starting the next Game Mode session when backup branches exist by using the active concluded session as the source and preventing branch labels from carrying into newly created sessions (#3229).
 - Removed the hard-coded three-sprite limit from Roleplay sprite selection, setup, and display paths so chats can enable all uploaded sprite owners they need (#3169).
 - Let Image Captioning use any non-image-generation connection instead of hiding local or custom multimodal models behind model-name heuristics (#3170).
 - Stabilized emoji and sticker popover positioning above the mobile composer when Android browsers resize the visual viewport around the keyboard (#3171).

--- a/packages/client/src/components/game/GameSurface.tsx
+++ b/packages/client/src/components/game/GameSurface.tsx
@@ -8344,7 +8344,7 @@ function GameSurfaceComponent({
     startSessionGuardRef.current = true;
     setStartSessionRequested(true);
     startSession.mutate(
-      { gameId },
+      { gameId, sourceChatId: activeChatId },
       {
         onSettled: () => {
           startSessionGuardRef.current = false;
@@ -8352,7 +8352,7 @@ function GameSurfaceComponent({
         },
       },
     );
-  }, [gameId, startSession, startSessionLocked]);
+  }, [activeChatId, gameId, startSession, startSessionLocked]);
 
   const handleStartNewSession = useCallback(() => {
     if (!gameId || startSessionLocked || startSessionGuardRef.current) return;

--- a/packages/client/src/hooks/use-game.ts
+++ b/packages/client/src/hooks/use-game.ts
@@ -259,7 +259,7 @@ export function useStartSession() {
   const store = useGameModeStore;
 
   return useMutation({
-    mutationFn: (data: { gameId: string; connectionId?: string }) =>
+    mutationFn: (data: { gameId: string; sourceChatId?: string; connectionId?: string }) =>
       api.post<StartSessionResponse>("/game/session/start", data),
     onMutate: (variables) => {
       toast.loading("Starting the next session and generating recap...", {

--- a/packages/server/src/routes/game.routes.ts
+++ b/packages/server/src/routes/game.routes.ts
@@ -1103,6 +1103,7 @@ const gameStartSchema = z.object({
 
 const startSessionSchema = z.object({
   gameId: z.string().min(1),
+  sourceChatId: z.string().min(1).optional(),
   connectionId: z.string().optional(),
 });
 
@@ -5572,9 +5573,49 @@ export async function gameRoutes(app: FastifyInstance) {
     return findSessionSummaryForNumber(summaries, sessionNumber) ?? summaries.at(-1) ?? null;
   };
 
+  const isGameSessionBranch = (meta: Record<string, unknown>): boolean => readTrimmedString(meta.branchName) !== null;
+
+  const gameSessionNumberFromMeta = (meta: Record<string, unknown>): number =>
+    typeof meta.gameSessionNumber === "number" && Number.isFinite(meta.gameSessionNumber) ? meta.gameSessionNumber : 0;
+
+  const compareGameSessions = (a: NonNullable<StoredChatRecord>, b: NonNullable<StoredChatRecord>): number => {
+    const ma = parseMeta(a.metadata);
+    const mb = parseMeta(b.metadata);
+    const sessionDiff = gameSessionNumberFromMeta(ma) - gameSessionNumberFromMeta(mb);
+    if (sessionDiff !== 0) return sessionDiff;
+    const updatedA = Date.parse(String(a.updatedAt ?? "")) || 0;
+    const updatedB = Date.parse(String(b.updatedAt ?? "")) || 0;
+    return updatedA - updatedB;
+  };
+
+  const selectSessionForNextStart = (
+    sessions: NonNullable<StoredChatRecord>[],
+    sourceChatId?: string,
+  ): NonNullable<StoredChatRecord> | null => {
+    const gameSessions = sessions.filter((c) => (c.mode as string) === "game");
+    const sourceSession = sourceChatId ? gameSessions.find((session) => session.id === sourceChatId) : null;
+    if (sourceChatId && !sourceSession) {
+      throw new Error("Requested source session was not found in this game");
+    }
+
+    const canonicalSessions = gameSessions.filter((session) => !isGameSessionBranch(parseMeta(session.metadata)));
+    const orderedSessions = (canonicalSessions.length > 0 ? canonicalSessions : gameSessions).sort(compareGameSessions);
+    let selected = orderedSessions.at(-1) ?? sourceSession ?? null;
+
+    if (sourceSession) {
+      const sourceNumber = gameSessionNumberFromMeta(parseMeta(sourceSession.metadata));
+      const selectedNumber = selected ? gameSessionNumberFromMeta(parseMeta(selected.metadata)) : 0;
+      if (!selected || sourceNumber >= selectedNumber) {
+        selected = sourceSession;
+      }
+    }
+
+    return selected;
+  };
+
   // ── POST /game/session/start ──
   app.post("/session/start", async (req, reply) => {
-    const { gameId, connectionId } = startSessionSchema.parse(req.body);
+    const { gameId, sourceChatId, connectionId } = startSessionSchema.parse(req.body);
     const existingStart = pendingSessionStarts.get(gameId);
     if (existingStart) {
       return existingStart;
@@ -5585,15 +5626,7 @@ export async function gameRoutes(app: FastifyInstance) {
       const connections = createConnectionsStorage(app.db);
 
       const sessions = await chats.listByGroup(gameId);
-      const gameSessions = sessions
-        .filter((c) => (c.mode as string) === "game")
-        .sort((a, b) => {
-          const ma = parseMeta(a.metadata);
-          const mb = parseMeta(b.metadata);
-          return ((ma.gameSessionNumber as number) || 0) - ((mb.gameSessionNumber as number) || 0);
-        });
-
-      const latestSession = gameSessions[gameSessions.length - 1];
+      const latestSession = selectSessionForNextStart(sessions, sourceChatId);
       if (!latestSession) throw new Error("No previous session found for this game");
 
       const prevMeta = parseMeta(latestSession.metadata);
@@ -5689,6 +5722,7 @@ export async function gameRoutes(app: FastifyInstance) {
         gameLastIllustrationTurn: _previousIllustrationTurn,
         gameLastIllustrationSessionNumber: _previousIllustrationSessionNumber,
         gameLastIllustrationTag: _previousIllustrationTag,
+        branchName: _previousBranchName,
         gameSceneBackground: _previousSceneBackground,
         gameSceneMusic: _previousSceneMusic,
         gameSceneAmbient: _previousSceneAmbient,


### PR DESCRIPTION
## Summary

- Use the active Game session as the explicit source when starting the next session.
- Ignore backup/branch-labeled game chats when selecting the latest canonical session, with a fallback for older data.
- Prevent new Game sessions from inheriting `branchName` metadata from the source session.
- Update the v2.1.0 changelog entry for #3229.

Fixes #3229.

## Root Cause

`/game/session/start` selected the latest game chat by session number only. Backup branches copy `gameSessionNumber`, `gameSessionStatus`, and `branchName`, so a backup branch with the same session number could be treated as the latest active session and returned instead of creating the next session.

## Validation

- `pnpm --filter @marinara-engine/server lint`
- `pnpm --filter @marinara-engine/client lint` (passes with existing `ConversationView.tsx` missing dependency warning)
- `pnpm check` (passes with the same existing warning and Vite chunk-size warning)

## Manual Verification Needed

- Manually verify a Game chat with backup branches creates or switches to the actual next session after completing the canonical session.
- Manually verify starting from an already-created later session still returns that existing later session instead of duplicating it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Starting a new game session now correctly uses the intended previous session when backup/branch sessions exist.
  * Branch labels and related session state no longer carry over incorrectly into newly created sessions.

* **New Features**
  * Session creation now supports choosing a specific prior session as the starting point, improving continuity when resuming gameplay.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->