### PR TITLE
[codex] Document Conversation audio calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 ### Changed
 
 - Bumped release metadata to v2.1.0 across packages, the PWA manifest, README release pointer, Windows installer sources, Android APK metadata, and the home-page-visible app version.
+- Documented Conversation audio-call setup, Local Whisper download, audio input modes, character-initiated call behavior, and Professor Mari's built-in guidance for the feature.
 - Made Android/Termux update builds use low-memory build wrappers: server builds transpile runtime JS with esbuild, client builds skip memory-heavy typechecking/PWA generation on Android, and the updater builds shared, server, and client sequentially on Android devices (#3156).
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -173,6 +173,7 @@ Export individual chats or bulk transcript zips as JSONL or plain text. Fully lo
 | ---------------------------------------------------- | --------------------------------------------------------------- |
 | [docs/INSTALLATION.md](docs/INSTALLATION.md)         | Installation guide index (all platforms)                        |
 | [docs/CONFIGURATION.md](docs/CONFIGURATION.md)       | Environment variables and `.env` reference                      |
+| [docs/CONVERSATION_CALLS.md](docs/CONVERSATION_CALLS.md) | Conversation audio-call setup, Local Whisper, TTS, and troubleshooting |
 | [docs/IMAGE_GENERATION.md](docs/IMAGE_GENERATION.md) | Image provider setup, style profiles, and prompt cleanup        |
 | [docs/SCENE_VIDEO_GENERATION.md](docs/SCENE_VIDEO_GENERATION.md) | Scene-video setup, Game Mode storyboards, Gallery animation workflow, and prompt templates |
 | [docs/STORYBOARD_ENGINE_GUIDE.md](docs/STORYBOARD_ENGINE_GUIDE.md) | Step-by-step guide to manual and automatic Game Mode storyboards |

--- a/docs/CONVERSATION.md
+++ b/docs/CONVERSATION.md
@@ -2,7 +2,7 @@
 
 Conversation Mode is one of Marinara Engine's chat modes, alongside Roleplay, Visual Novel, and Game. Where Game Mode runs a structured RPG and Roleplay drops you into an immersive scene with sprites and backgrounds, **Conversation is Discord-style DMs** — one or more characters, an input bar, and a message history. No GM, no scene chrome, no required mechanics. It's the lightest-weight mode and the one most users will spend the most time in.
 
-This guide is a getting-started reference. It covers what Conversation Mode does, how to set up a chat, the difference between 1:1 and group chats, the Conversation-specific features (schedules, autonomous messages, character exchanges, selfies), how connected chats work, and what models and parameters tend to fit well.
+This guide is a getting-started reference. It covers what Conversation Mode does, how to set up a chat, the difference between 1:1 and group chats, the Conversation-specific features (schedules, autonomous messages, character exchanges, audio calls, selfies), how connected chats work, and what models and parameters tend to fit well.
 
 **What this guide does not cover:** deep agent customization, regex scripts, branching/swipe internals (those work the same across modes), and the lorebook authoring UI itself (covered in the lorebook editor's in-app help). Ask in the Marinara Discord (or open a GitHub issue) for help with those.
 
@@ -27,6 +27,7 @@ The quick setup has these controls:
 - **Persona** (optional) — the character _you_ play, if you want to be more than a generic user.
 - **Character(s)** — tap to add one or more characters from your library. One = 1:1 chat. More than one = group chat. The chat name auto-generates from the picked characters' names unless you've renamed it.
 - **Autonomous messages toggle** — defaults to ON. When enabled, characters can message you on their own when you're idle (see [Autonomous messages](#autonomous-messages) below).
+- **Audio/Video Calls toggle** — enables the phone button for this Conversation so you can start a call with the selected character(s).
 - **Generate schedules toggle** — defaults to OFF. When enabled and you click Start chatting, the engine runs the Schedule Planner agent to generate weekly availability grids for each character.
 - **Customize generation parameters toggle** — defaults to OFF. When enabled, you can override the connection's default temperature, max tokens, etc.
 
@@ -95,6 +96,24 @@ A toggle in the chat settings drawer (and in the quick-setup modal). When enable
 Schedules are optional. Without schedules, chatty characters can still reach out based on talkativeness and whether your status is active or idle. If your status is DND, Marinara suppresses autonomous messages.
 
 Autonomous messages **default to ON** when you complete the quick-setup modal. Turn them off in the chat settings drawer if you want messages only when you initiate.
+
+### Audio/video calls
+
+Conversation Mode supports audio-first calls with characters. Calls use a Discord-style call screen, a separate call-only chat, TTS playback for characters with voices, microphone transcription for your speech, incoming character-call accept/decline controls, and a post-call summary injected back into the normal conversation.
+
+To enable calls for a chat:
+
+1. Open **Chat Settings -> Commands**.
+2. Open **Conversation Calls**.
+3. Enable **Audio/Video Calls** to show the phone button for you.
+4. Enable **Call Audio Pipeline** if you want Marinara to listen while your mic is unmuted.
+5. Choose an **Audio input mode**.
+
+Use **Connections -> Text to Speech** to configure the voice provider and character voices. Use **Connections -> Local Model -> Local Speech Model -> Download Whisper** if you want local microphone transcription, especially on Firefox or other browsers where browser speech recognition is unavailable.
+
+The **Calls** command toggle is separate from the phone button. If the Calls command is enabled, characters may ring you and you can accept or decline. If it is disabled, you can still call them yourself when Audio/Video Calls are enabled.
+
+See [Conversation Audio Calls](CONVERSATION_CALLS.md) for the full setup guide, audio input modes, Local Whisper notes, and troubleshooting.
 
 ### Selfies and per-character image generation
 

--- a/docs/CONVERSATION_CALLS.md
+++ b/docs/CONVERSATION_CALLS.md
@@ -1,0 +1,146 @@
+# Conversation Audio Calls
+
+Conversation Calls let you talk to Conversation-mode characters through a Discord-style call surface. Calls are audio-first: characters can speak through Text to Speech, you can answer by microphone or by typing, and the call keeps its own temporary transcript before Marinara summarizes it back into the normal conversation.
+
+Calls only exist in **Conversation Mode**. Roleplay, Visual Novel, and Game chats do not use this call surface.
+
+## What Calls Do
+
+- Replace the normal Conversation transcript with a call screen while the call is active.
+- Show your persona and available characters as call participants.
+- Play voice lines for characters that have a resolvable TTS voice.
+- Keep characters without voices in the call chat as typed participants.
+- Let you mute, control character output volume, use camera/screen controls when supported, open a soundboard, and end the call.
+- Keep the call running if you navigate elsewhere in Marinara; use the minimized call popout to return or end it.
+- Add call cards to the normal conversation history when calls start, end, are missed, or are declined.
+- Generate a post-call summary and inject it into the originating Conversation chat after the call ends.
+
+Calls are not WebRTC peer-to-peer calls. Marinara captures local browser media, sends the appropriate text/audio/video inputs through your selected Conversation connection, uses your configured TTS provider for spoken character replies, and stores call transcript data locally.
+
+## Requirements
+
+Before starting a voice call, set up these pieces:
+
+1. **A Conversation chat** with at least one character.
+2. **A normal LLM connection** selected for that Conversation. This is still the model that writes character replies.
+3. **Text to Speech** in the Connections panel if you want characters to speak aloud.
+4. **Conversation Calls** enabled in that chat's Commands settings.
+5. **Call Audio Pipeline** enabled if you want Marinara to listen to your microphone.
+
+Characters can still join a call without TTS, but their replies appear as typed call-chat messages instead of voice.
+
+## Set Up Text To Speech
+
+Open **Connections -> Text to Speech**.
+
+1. Enable Text to Speech.
+2. Choose a TTS source: OpenAI-compatible, ElevenLabs, PocketTTS, or xAI.
+3. Add the provider key or local server URL required by that source.
+4. Pick a model and voice.
+5. Choose **One voice for all characters** or **Selected per character**.
+6. Save and use the preview button to confirm audio plays.
+
+For group calls, per-character voices make turn-taking much clearer. If a character has no assigned voice and the global voice cannot be resolved, Marinara treats that character as text-only for the call.
+
+## Download Local Whisper
+
+Local Whisper is the most reliable microphone path for browsers that do not support Web Speech recognition well, including Firefox. It runs on the Marinara host machine and does not send your microphone audio to an external speech-to-text service. The resulting text is still sent to the selected Conversation model as part of the call prompt.
+
+Open **Connections -> Local Model**, expand the Local Model card, then use **Local Speech Model**:
+
+1. Choose **Whisper Tiny (Multilingual)** for the smallest download and best mobile/older-device starting point.
+2. Choose **Whisper Base (Multilingual)** if you want better accuracy and can spare more RAM.
+3. Click **Download Whisper**.
+4. Wait until the Local Speech Model status says it is downloaded or ready.
+
+Approximate download/RAM sizes are shown in the UI before download. Whisper Tiny is the default first choice because it is small enough for weaker machines and phones to try first.
+
+## Enable Calls For A Chat
+
+You can enable calls when creating a new Conversation or later from Chat Settings.
+
+During new Conversation setup, open the Automation step and enable **Audio/Video Calls** if you want the phone button to appear for that chat.
+
+For an existing Conversation:
+
+1. Open the chat.
+2. Open **Chat Settings**.
+3. Go to **Commands**.
+4. Open **Conversation Calls**.
+5. Enable **Audio/Video Calls**.
+6. Enable **Call Audio Pipeline** if you want microphone input.
+7. Pick an **Audio input mode**.
+
+The **Calls** command toggle is separate. **Audio/Video Calls** lets you call the character. **Calls** lets characters ring you. If the Calls command is off, you can still start calls yourself, but characters should not initiate incoming calls.
+
+## Choose An Audio Input Mode
+
+Conversation Calls support several microphone/input paths:
+
+- **Mic recording + Local Whisper**: records speech while you are unmuted, ignores silence, transcribes locally with the downloaded Whisper model, and sends text to the Conversation model. Recommended for Firefox and for users who want hands-free voice input without relying on browser Web Speech support.
+- **Browser speech recognition**: uses the browser's Web Speech API where available. Browser support varies; if it is unavailable, Marinara falls back to Local Whisper when possible.
+- **Manual system dictation**: focuses the call input so your operating system's dictation can type into it. You still send the message as text. This does not let Marinara continuously capture mic audio by itself.
+- **Provider-native audio/video**: sends recorded media to the selected Conversation model when that provider/model route supports native audio or video input. If the model cannot accept media, use Local Whisper or browser speech recognition instead.
+
+Camera and screen controls appear in the call UI, but video/screen input only helps when the selected model can use those inputs.
+
+## Starting And Receiving Calls
+
+When calls are enabled for a Conversation, a phone button appears beside the conversation name/status. Click it to start a call.
+
+For incoming character calls:
+
+- If you are inside that Conversation, accept/decline controls appear above the input box.
+- If you are elsewhere in Marinara, an incoming-call popup appears like autonomous-message notifications.
+- Marinara does not auto-answer character calls.
+
+Only characters available for the chat should join. If schedules mark a character offline, they should not hop into the call just because they are in the group chat.
+
+## During A Call
+
+- The call screen shows participant tiles and highlights the current speaker.
+- The call chat below the stage is for typed messages and text-only character replies.
+- Speech transcripts and voiced character lines are used for generation/playback, but they are not duplicated into the visible call chat.
+- Soundboard sounds play in the call when the soundboard is enabled.
+- Hidden call commands can still run when enabled for the chat, including memories, music, haptics, notes, influences, selfies, soundboard actions, character leave, and call end.
+- Selfies created during the call appear in the call chat and are added to the originating Conversation gallery.
+
+If you leave the Conversation while the call is active, the call minimizes into a small popout so you can keep browsing other Marinara panels or chats.
+
+## Ending A Call
+
+You can end the call from the red hang-up button. Characters can also leave or end a call when the relevant call command is available.
+
+When the call ends, Marinara:
+
+1. Stops recording and media tracks.
+2. Finishes or cancels pending call audio safely.
+3. Adds a call-ended card to the normal Conversation history.
+4. Generates an audio-call summary if anything meaningful happened.
+5. Injects the summary into the originating Conversation as model-visible context.
+
+The detailed call transcript remains stored separately for call handling and debugging instead of being appended turn-by-turn to the normal chat.
+
+## Troubleshooting
+
+### I can hear characters, but they cannot hear me
+
+Check **Chat Settings -> Commands -> Conversation Calls** and make sure **Call Audio Pipeline** is enabled. Then confirm your browser has microphone permission for the Marinara page.
+
+If you are on Firefox or browser speech recognition is unavailable, download Local Whisper from **Connections -> Local Model -> Local Speech Model** and use **Mic recording + Local Whisper**.
+
+### Local Whisper says it is unavailable
+
+Local Whisper needs the native ONNX runtime for the Node architecture running Marinara. Restart Marinara with the same Node architecture you used to install dependencies. If it still fails, rerun the launcher or reinstall dependencies so the optional native package is repaired for your platform.
+
+### The browser speech option does nothing
+
+Browser speech recognition depends on browser support. Firefox does not expose the same Web Speech recognition API as Chromium/Safari environments. Use **Mic recording + Local Whisper** for hands-free microphone capture, or use **Manual system dictation** if you prefer the operating system's dictation UI.
+
+### A character only types instead of speaking
+
+Check the Text to Speech settings and voice assignments. The character needs either a global voice or a per-character voice that can be resolved by the selected TTS provider.
+
+### Calls work, but the model misunderstands speech
+
+Try Whisper Base instead of Whisper Tiny, reduce background noise/music, or switch to provider-native audio if your selected model supports native audio input.

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -102,6 +102,32 @@ See [Professor Mari](PROFESSOR_MARI.md) for the full capabilities and safety not
 ---
 
 <details>
+<summary><strong>How do I set up Conversation audio calls?</strong></summary>
+<br>
+
+Conversation audio calls are only available in Conversation Mode. They need three pieces: calls enabled for the chat, Text to Speech for character voices, and an audio input mode if you want to speak through your microphone.
+
+Quick setup:
+
+1. Open **Connections -> Text to Speech**, enable TTS, choose a source, save it, and confirm the preview plays.
+2. If you want local microphone transcription, open **Connections -> Local Model**, expand the card, find **Local Speech Model**, choose Whisper Tiny or Whisper Base, then click **Download Whisper**.
+3. Open the Conversation chat, go to **Chat Settings -> Commands -> Conversation Calls**, and enable **Audio/Video Calls**.
+4. Enable **Call Audio Pipeline** if you want mic input.
+5. Pick an **Audio input mode**:
+   - **Mic recording + Local Whisper** for local hands-free transcription. This is the best fallback for Firefox.
+   - **Browser speech recognition** where Web Speech is supported.
+   - **Manual system dictation** if you want your OS dictation to type into the call input.
+   - **Provider-native audio/video** only when the selected Conversation model supports native media input.
+
+The phone button lets you start a call. The separate **Calls** command toggle controls whether characters are allowed to ring you first. Turning off that command does not stop you from calling them.
+
+See [Conversation Audio Calls](CONVERSATION_CALLS.md) for the full guide.
+
+</details>
+
+---
+
+<details>
 <summary><strong>Which AI providers are supported?</strong></summary>
 <br>
 

--- a/docs/PROFESSOR_MARI.md
+++ b/docs/PROFESSOR_MARI.md
@@ -13,6 +13,7 @@ Think of Mari as an in-app guide who can also take a few safe content actions fo
 Use Mari when you want help with:
 
 - Setting up your first connection, character, persona, conversation, roleplay, or Game Mode session.
+- Setting up Conversation audio calls, including Text to Speech, Local Whisper, and per-chat call toggles.
 - Understanding the difference between Conversation, Roleplay, and Game Mode.
 - Creating a new character card or persona from a rough description.
 - Updating an existing character card or persona.
@@ -116,6 +117,7 @@ The most useful report includes:
 ## Related Docs
 
 - [Conversation Mode](CONVERSATION.md)
+- [Conversation Audio Calls](CONVERSATION_CALLS.md)
 - [Roleplay Mode](ROLEPLAY.md)
 - [Game Mode](GAME_MODE.md)
 - [FAQ](FAQ.md)

--- a/packages/client/src/components/chat/HomeFaq.tsx
+++ b/packages/client/src/components/chat/HomeFaq.tsx
@@ -464,6 +464,20 @@ const HOME_FAQ_ITEMS: HomeFaqItem[] = [
     ],
   },
   {
+    id: "conversation-audio-calls",
+    category: "Misc",
+    question: "How do I set up Conversation audio calls?",
+    answer:
+      "Enable TTS first, then turn on Conversation Calls for the chat and pick how your microphone should be transcribed.",
+    bullets: [
+      "Open Connections > Text to Speech, enable a TTS provider, save it, and confirm the preview plays.",
+      "For local mic transcription, open Connections > Local Model, expand the card, choose Whisper Tiny or Whisper Base under Local Speech Model, then click Download Whisper.",
+      "In the Conversation chat, open Chat Settings > Commands > Conversation Calls, enable Audio/Video Calls, then enable Call Audio Pipeline.",
+      "Use Mic recording + Local Whisper for Firefox or reliable local speech capture. Browser speech recognition depends on browser support.",
+      "The Calls command toggle only controls whether characters can ring you first; you can still call them when Audio/Video Calls is enabled.",
+    ],
+  },
+  {
     id: "translations",
     category: "Misc",
     question: "Can I chat in languages other than English? What about the UI?",

--- a/packages/server/src/db/seed-mari.ts
+++ b/packages/server/src/db/seed-mari.ts
@@ -94,7 +94,7 @@ Marinara Engine is a local-first AI conversation, roleplay, and game engine. It'
 - Offline characters won't respond; DND characters reply with longer delays; idle characters have slight delays
 - Characters can send up to 3 follow-up autonomous messages with exponential backoff between each
 - Supports group DMs with multiple characters
-- Characters can take selfies, create scenes, cross-post to other chats, and send memory commands to other characters
+- Characters can take selfies, create scenes, start/ring audio calls when enabled, cross-post to other chats, and send memory commands to other characters
 
 ### Roleplay Mode 🎭
 - Traditional creative writing / roleplay format with rich narration
@@ -162,6 +162,9 @@ Characters automatically know what's happening in their other chats. When the us
 
 ### Settings, Audio, and Notification Sounds
 - App-wide settings live in the Settings panel, opened from the right panel/top bar settings button.
+- Text to Speech lives in **Connections > Text to Speech**. Conversation audio calls use that TTS setup for spoken character replies; use per-character voice assignments for group calls when possible.
+- Conversation audio calls are configured per chat in **Chat Settings > Commands > Conversation Calls**. **Audio/Video Calls** shows the user's phone button. The separate **Calls** command toggle lets characters ring the user first.
+- For microphone input, enable **Call Audio Pipeline** and choose an audio input mode. **Mic recording + Local Whisper** records while unmuted and transcribes locally; tell users to download it from **Connections > Local Model > Local Speech Model > Download Whisper**. **Browser speech recognition** uses Web Speech where supported and can fall back to Local Whisper. **Manual system dictation** only focuses the call input for OS dictation. **Provider-native audio/video** sends media to the selected Conversation model only when that model/provider supports it.
 - Notification pings are NOT browser-only. Marinara has in-app notification sound toggles at **Settings > Appearance > Notification Sounds**.
 - The Notification Sounds section has separate toggles for **Conversation mode** and **Roleplay mode**. Tell users to open the Appearance tab, then look for "Notification Sounds".
 - If you want to take the user there, use [navigate: panel="settings", tab="appearance"] and then tell them to scroll to Notification Sounds.


### PR DESCRIPTION
## Summary

- Add a dedicated Conversation Audio Calls guide covering TTS setup, Local Whisper download, per-chat call toggles, audio input modes, incoming calls, call behavior, summaries, and troubleshooting.
- Link the guide from the Conversation docs, README documentation table, FAQ, and Professor Mari docs.
- Add the audio-call setup answer to the Home FAQ.
- Update Professor Mari built-in app knowledge so she can explain call setup, Whisper, and the character-call command toggle.
- Add a v2.1.0 changelog note for the new docs/knowledge update.

## Context

No linked GitHub issue. This is a maintainer-requested documentation and Professor Mari knowledge update for the Conversation audio calls feature.

## Validation

- `pnpm --filter @marinara-engine/server lint`
- `pnpm --filter @marinara-engine/client lint` (passes with existing `ConversationView.tsx` missing dependency warning)
- `pnpm check` (passes with the same existing warning and the usual Vite chunk-size warning)

## Manual Verification Needed

- Review `docs/CONVERSATION_CALLS.md` for setup accuracy against the current Conversation Calls UI.
- Search the Home FAQ for audio calls and confirm the answer is discoverable.
- Ask Professor Mari how to set up audio calls and confirm she mentions Text to Speech, Chat Settings > Commands > Conversation Calls, and downloading Whisper from Connections > Local Model.
