### PR TITLE
feat: in-app documentation viewer + FAQ entry + homepage button (#3238)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 
 ### Added
 
+- Added an in-app documentation viewer: the guides shipped in the `docs` folder (installation, configuration, troubleshooting, macros, extensions, Game Mode, and more) can now be browsed and read inside Marinara via a **Documentation** button in the home page footer next to **Replay Tutorial**, and a new "Where can I find documentation?" FAQ entry that shows the on-disk docs path and opens the viewer (#3238).
 - Conversation mode: character emoji reactions now have their own **Reactions** card in the per-command Commands grid (Chat Settings and the chat setup wizard), so they can be toggled independently like Selfies or Music (#3219).
 
 ### Fixed

--- a/Dockerfile
+++ b/Dockerfile
@@ -78,6 +78,9 @@ COPY --from=builder /app/packages/client/dist packages/client/dist
 COPY scripts/docker-entrypoint.mjs /usr/local/bin/marinara-docker-entrypoint.mjs
 COPY scripts/install-backgroundremover.mjs scripts/install-backgroundremover.mjs
 
+# User guides served by the in-app documentation viewer (/api/docs)
+COPY docs/ docs/
+
 # Ensure /app/data exists for runtime use (file storage, uploads, generated assets)
 RUN mkdir -p /app/data && \
     chown node:node /app/data

--- a/Dockerfile.lite
+++ b/Dockerfile.lite
@@ -122,6 +122,9 @@ COPY --from=builder /app/packages/client/dist packages/client/dist
 COPY scripts/docker-entrypoint.mjs /usr/local/bin/marinara-docker-entrypoint.mjs
 COPY scripts/install-backgroundremover.mjs scripts/install-backgroundremover.mjs
 
+# User guides served by the in-app documentation viewer (/api/docs)
+COPY docs/ docs/
+
 # Ensure data directory exists
 RUN mkdir -p /app/data && \
     chown nonroot:nonroot /app/data

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -263,3 +263,20 @@ For story direction, choose the tool by how persistent you want the guidance to 
 **One important exception:** the `agent_data` marker section, and the `{{agent::TYPE}}` macro, are the _intended_ way to thread an agent's output into a specific spot in the preset. That's wiring, not overlap — several agents (World State, Quest Tracker, Character Tracker, and others) set this up for you by default. The pattern to avoid is hand-writing preset sections that duplicate an agent's _behavior_, not using the marker section that carries the agent's _output_.
 
 </details>
+
+---
+
+<a id="how-do-i-read-the-documentation-inside-the-app"></a>
+
+<details>
+<summary><strong>How do I read the documentation inside the app?</strong></summary>
+<br>
+
+Every Marinara install ships with the full set of guides you are reading right now — installation, configuration, troubleshooting, macros, extensions, Game Mode, and more. You can read them without leaving the app:
+
+- **From the home page footer:** click the **Documentation** button next to **Replay Tutorial**.
+- **From the FAQ:** open the "Where can I find documentation?" entry and click **Open Documentation**.
+
+The in-app viewer lists every guide and renders it directly in Marinara. The same guides also live on disk as regular markdown files in the `docs` folder inside your Marinara install folder, and both the FAQ entry and the viewer show the exact folder path for your install.
+
+</details>

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -272,7 +272,7 @@ For story direction, choose the tool by how persistent you want the guidance to 
 <summary><strong>How do I read the documentation inside the app?</strong></summary>
 <br>
 
-Every Marinara install ships with the full set of guides you are reading right now — installation, configuration, troubleshooting, macros, extensions, Game Mode, and more. You can read them without leaving the app:
+Every Marinara install ships with the full set of guides you are reading right now: installation, configuration, troubleshooting, macros, extensions, Game Mode, and more. You can read them without leaving the app:
 
 - **From the home page footer:** click the **Documentation** button next to **Replay Tutorial**.
 - **From the FAQ:** open the "Where can I find documentation?" entry and click **Open Documentation**.

--- a/packages/client/src/components/chat/ChatArea.tsx
+++ b/packages/client/src/components/chat/ChatArea.tsx
@@ -54,7 +54,7 @@ import { chatBackgroundMetadataToUrl, chatBackgroundUrlToMetadata } from "../../
 import { useGameStateStore } from "../../stores/game-state.store";
 import { useGalleryStore } from "../../stores/gallery.store";
 import { toast } from "sonner";
-import { Check, HelpCircle, List, X } from "lucide-react";
+import { BookOpen, Check, HelpCircle, List, X } from "lucide-react";
 import {
   APP_VERSION,
   BUILT_IN_AGENTS,
@@ -2537,15 +2537,27 @@ export function ChatArea() {
                     </button>
                   </div>
 
-                  {/* Restart tutorial */}
-                  <button
-                    onClick={() => useUIStore.getState().setHasCompletedOnboarding(false)}
-                    className="mari-chrome-control mari-chrome-control--small text-xs"
-                    title="Replay tutorial"
-                  >
-                    <HelpCircle size="0.875rem" />
-                    Replay Tutorial
-                  </button>
+                  <div className="flex flex-wrap justify-center gap-2">
+                    {/* In-app documentation */}
+                    <button
+                      onClick={() => useUIStore.getState().openModal("docs-viewer")}
+                      className="mari-chrome-control mari-chrome-control--small text-xs"
+                      title="Browse the documentation"
+                    >
+                      <BookOpen size="0.875rem" />
+                      Documentation
+                    </button>
+
+                    {/* Restart tutorial */}
+                    <button
+                      onClick={() => useUIStore.getState().setHasCompletedOnboarding(false)}
+                      className="mari-chrome-control mari-chrome-control--small text-xs"
+                      title="Replay tutorial"
+                    >
+                      <HelpCircle size="0.875rem" />
+                      Replay Tutorial
+                    </button>
+                  </div>
                 </div>
               </>
             )}

--- a/packages/client/src/components/chat/ChatArea.tsx
+++ b/packages/client/src/components/chat/ChatArea.tsx
@@ -2540,6 +2540,7 @@ export function ChatArea() {
                   <div className="flex flex-wrap justify-center gap-2">
                     {/* In-app documentation */}
                     <button
+                      type="button"
                       onClick={() => useUIStore.getState().openModal("docs-viewer")}
                       className="mari-chrome-control mari-chrome-control--small text-xs"
                       title="Browse the documentation"
@@ -2550,6 +2551,7 @@ export function ChatArea() {
 
                     {/* Restart tutorial */}
                     <button
+                      type="button"
                       onClick={() => useUIStore.getState().setHasCompletedOnboarding(false)}
                       className="mari-chrome-control mari-chrome-control--small text-xs"
                       title="Replay tutorial"

--- a/packages/client/src/components/chat/HomeFaq.tsx
+++ b/packages/client/src/components/chat/HomeFaq.tsx
@@ -1,6 +1,8 @@
 import { useMemo, useState } from "react";
-import { ChevronDown, ChevronRight, HelpCircle, Search, Sparkles, TriangleAlert, X } from "lucide-react";
+import { BookOpen, ChevronDown, ChevronRight, HelpCircle, Search, Sparkles, TriangleAlert, X } from "lucide-react";
 import { cn } from "../../lib/utils";
+import { useDocsIndex } from "../../hooks/use-docs";
+import { useUIStore } from "../../stores/ui.store";
 
 interface HomeFaqItem {
   id: string;
@@ -8,6 +10,8 @@ interface HomeFaqItem {
   question: string;
   answer: string;
   bullets?: string[];
+  /** Renders the on-disk docs path plus an "Open Documentation" button under the answer */
+  docsAccess?: boolean;
 }
 
 const QUICK_FIXES = [
@@ -65,6 +69,18 @@ const HOME_FAQ_ITEMS: HomeFaqItem[] = [
       "The sidecar is there for helpers and utility tasks, not to compete with your main model for VRAM.",
       "Treat it as a problem only if the sidecar never recovers or keeps crashing instead of settling on CPU fallback.",
     ],
+  },
+  {
+    id: "find-documentation",
+    category: "Setup",
+    question: "Where can I find documentation?",
+    answer:
+      "Marinara ships full guides with every install — installation, configuration, troubleshooting, macros, extensions, Game Mode, and more — and you can read them without leaving the app.",
+    bullets: [
+      "Use the Open Documentation button below, or the Documentation button at the bottom of the home page, to browse every guide in-app.",
+      "The same guides live on disk as regular markdown files, at the folder path shown below.",
+    ],
+    docsAccess: true,
   },
   {
     id: "antivirus-installer",
@@ -513,6 +529,38 @@ function getFaqSearchText(item: HomeFaqItem) {
   return [item.category, item.question, item.answer, ...(item.bullets ?? [])].join(" ").toLowerCase();
 }
 
+/** Only mounted while the docs FAQ entry is open, so the index fetch stays lazy. */
+function FaqDocsAccess({ compact }: { compact?: boolean }) {
+  const { data: index } = useDocsIndex();
+
+  return (
+    <div className="mt-2 space-y-2">
+      <div
+        className={cn(
+          "rounded-lg border border-[var(--border)]/55 bg-[var(--background)]/60 px-2.5 py-1.5",
+          compact ? "text-[0.625rem]" : "text-[0.65625rem]",
+        )}
+      >
+        <p className="text-[var(--muted-foreground)]/70">On disk at:</p>
+        <code className="block break-all text-[var(--foreground)]/85">
+          {index ? index.root : "the docs folder inside your Marinara install folder"}
+        </code>
+      </div>
+      <button
+        type="button"
+        onClick={() => useUIStore.getState().openModal("docs-viewer")}
+        className={cn(
+          "inline-flex items-center gap-1.5 rounded-lg border border-[var(--primary)]/30 bg-[var(--primary)]/10 font-medium text-[var(--primary)] transition-colors hover:bg-[var(--primary)]/20",
+          compact ? "px-2 py-1 text-[0.625rem]" : "px-2.5 py-1.5 text-[0.6875rem]",
+        )}
+      >
+        <BookOpen size={compact ? "0.6875rem" : "0.75rem"} />
+        Open Documentation
+      </button>
+    </div>
+  );
+}
+
 export function HomeFaq({
   defaultExpanded = false,
   className,
@@ -657,6 +705,7 @@ export function HomeFaq({
                               ))}
                             </ul>
                           ) : null}
+                          {item.docsAccess ? <FaqDocsAccess compact /> : null}
                         </div>
                       )}
                     </div>
@@ -833,6 +882,7 @@ export function HomeFaq({
                               ))}
                             </ul>
                           ) : null}
+                          {item.docsAccess ? <FaqDocsAccess /> : null}
                         </div>
                       )}
                     </div>

--- a/packages/client/src/components/chat/HomeFaq.tsx
+++ b/packages/client/src/components/chat/HomeFaq.tsx
@@ -75,7 +75,7 @@ const HOME_FAQ_ITEMS: HomeFaqItem[] = [
     category: "Setup",
     question: "Where can I find documentation?",
     answer:
-      "Marinara ships full guides with every install — installation, configuration, troubleshooting, macros, extensions, Game Mode, and more — and you can read them without leaving the app.",
+      "Marinara ships full guides with every install: installation, configuration, troubleshooting, macros, extensions, Game Mode, and more. You can read them without leaving the app.",
     bullets: [
       "Use the Open Documentation button below, or the Documentation button at the bottom of the home page, to browse every guide in-app.",
       "The same guides live on disk as regular markdown files, at the folder path shown below.",

--- a/packages/client/src/components/layout/ModalRenderer.tsx
+++ b/packages/client/src/components/layout/ModalRenderer.tsx
@@ -48,6 +48,9 @@ const CharacterCardUpdateModal = lazy(() =>
 const AgentWriteApprovalModal = lazy(() =>
   import("../modals/AgentWriteApprovalModal").then((module) => ({ default: module.AgentWriteApprovalModal })),
 );
+const DocsViewerModal = lazy(() =>
+  import("../modals/DocsViewerModal").then((module) => ({ default: module.DocsViewerModal })),
+);
 
 export function ModalRenderer() {
   const modal = useUIStore((s) => s.modal);
@@ -108,6 +111,11 @@ export function ModalRenderer() {
       break;
     case "agent-write-approval":
       content = <AgentWriteApprovalModal open onClose={closeModal} />;
+      break;
+    case "docs-viewer":
+      content = (
+        <DocsViewerModal open onClose={closeModal} initialDoc={(modal?.props?.initialDoc as string | null) ?? null} />
+      );
       break;
     default:
       content = null;

--- a/packages/client/src/components/modals/DocsViewerModal.tsx
+++ b/packages/client/src/components/modals/DocsViewerModal.tsx
@@ -125,7 +125,10 @@ export function DocsViewerModal({
   const [searchQuery, setSearchQuery] = useState("");
   const [debouncedQuery, setDebouncedQuery] = useState("");
   const [pendingScrollTerm, setPendingScrollTerm] = useState<string | null>(null);
-  const scrollRef = useRef<HTMLDivElement | null>(null);
+  // State (not a plain ref) so effects re-run when the reader actually mounts:
+  // the Modal shell renders null on its first frame while its enter animation
+  // arms, and a cached doc means no later dep change would re-fire them.
+  const [scrollEl, setScrollEl] = useState<HTMLDivElement | null>(null);
   const restoreScrollRef = useRef(initialDoc === null && savedPlaceRef.current.doc !== null);
 
   useEffect(() => {
@@ -165,25 +168,67 @@ export function DocsViewerModal({
   // Restore the saved reading position on reopen, or jump to the first
   // occurrence of the search term after opening a doc from search results.
   useEffect(() => {
-    const el = scrollRef.current;
-    if (!el || !rendered) return;
+    if (!scrollEl || !rendered) return;
     if (restoreScrollRef.current && selected === savedPlaceRef.current.doc) {
-      el.scrollTop = savedPlaceRef.current.scrollTop;
+      scrollEl.scrollTop = savedPlaceRef.current.scrollTop;
       restoreScrollRef.current = false;
       return;
     }
     if (!pendingScrollTerm) return;
     const term = pendingScrollTerm.toLowerCase();
-    const walker = document.createTreeWalker(el, NodeFilter.SHOW_TEXT);
+    const walker = document.createTreeWalker(scrollEl, NodeFilter.SHOW_TEXT);
     let node: Node | null;
     while ((node = walker.nextNode())) {
       if (node.textContent?.toLowerCase().includes(term)) {
-        (node.parentElement ?? el).scrollIntoView({ block: "center" });
+        (node.parentElement ?? scrollEl).scrollIntoView({ block: "center" });
         break;
       }
     }
     setPendingScrollTerm(null);
-  }, [rendered, selected, pendingScrollTerm]);
+  }, [scrollEl, rendered, selected, pendingScrollTerm]);
+
+  // Give every rendered code block a Copy button (docs-viewer only — the
+  // markdown renderer is shared with chat, so we augment the committed DOM
+  // here instead of changing it globally). The rendered tree is memoized and
+  // the container remounts per doc, so these nodes are stable until cleanup.
+  useEffect(() => {
+    if (!scrollEl || !rendered) return;
+    const cleanups: (() => void)[] = [];
+    scrollEl.querySelectorAll<HTMLPreElement>("pre.mari-md-codeblock").forEach((block) => {
+      if (block.querySelector(".docs-copy-button")) return;
+      const button = document.createElement("button");
+      button.type = "button";
+      button.textContent = "Copy";
+      button.className =
+        "docs-copy-button absolute right-1.5 top-1.5 rounded-md border border-[var(--border)] bg-[var(--card)]/90 px-1.5 py-0.5 font-sans text-[0.625rem] text-[var(--muted-foreground)] transition-colors hover:bg-[var(--accent)] hover:text-[var(--foreground)]";
+      let resetTimer: ReturnType<typeof setTimeout> | undefined;
+      const onClick = () => {
+        const code = block.querySelector("code")?.textContent ?? "";
+        navigator.clipboard
+          .writeText(code)
+          .then(() => {
+            button.textContent = "Copied!";
+          })
+          .catch(() => {
+            button.textContent = "Copy failed";
+          })
+          .finally(() => {
+            clearTimeout(resetTimer);
+            resetTimer = setTimeout(() => {
+              button.textContent = "Copy";
+            }, 1500);
+          });
+      };
+      button.addEventListener("click", onClick);
+      block.appendChild(button);
+      cleanups.push(() => {
+        clearTimeout(resetTimer);
+        button.removeEventListener("click", onClick);
+        button.remove();
+      });
+    });
+    return () => cleanups.forEach((cleanup) => cleanup());
+  }, [scrollEl, rendered]);
 
   /** Follow rewritten cross-doc links inside the modal instead of opening a new tab. */
   const handleContentClick = (event: React.MouseEvent<HTMLDivElement>) => {
@@ -205,7 +250,7 @@ export function DocsViewerModal({
   const searchResults = search?.results ?? [];
 
   return (
-    <Modal open={open} onClose={onClose} title="Documentation" width="max-w-4xl">
+    <Modal open={open} onClose={onClose} title="Documentation" width="max-w-6xl">
       <div className="flex h-[calc(100dvh-5.5rem-max(0.75rem,env(safe-area-inset-top))-max(0.75rem,env(safe-area-inset-bottom)))] min-h-0 gap-3 sm:h-[min(46rem,calc(90dvh-6.5rem))]">
         {/* Guide list / search */}
         <aside
@@ -359,7 +404,7 @@ export function DocsViewerModal({
               </div>
               <div
                 key={selected}
-                ref={scrollRef}
+                ref={setScrollEl}
                 onScroll={(event) => {
                   if (selected) writeSavedPlace({ doc: selected, scrollTop: event.currentTarget.scrollTop });
                 }}
@@ -371,7 +416,7 @@ export function DocsViewerModal({
                   <p className="py-2 text-xs text-[var(--muted-foreground)]">Could not load this guide.</p>
                 ) : (
                   <div
-                    className="mari-message-content whitespace-pre-wrap break-words text-sm text-[var(--foreground)]"
+                    className="mari-message-content whitespace-pre-wrap break-words text-sm text-[var(--foreground)] [&_.mari-md-codeblock-lang]:right-14"
                     onClick={handleContentClick}
                   >
                     {rendered}

--- a/packages/client/src/components/modals/DocsViewerModal.tsx
+++ b/packages/client/src/components/modals/DocsViewerModal.tsx
@@ -1,0 +1,143 @@
+// ──────────────────────────────────────────────
+// DocsViewerModal: Browse the guides shipped in docs/
+// ──────────────────────────────────────────────
+import { useState } from "react";
+import { ArrowLeft, BookOpen, FileText } from "lucide-react";
+import { Modal } from "../ui/Modal";
+import { cn } from "../../lib/utils";
+import { renderMarkdownBlocks, applyInlineMarkdown } from "../../lib/markdown";
+import { useDocContent, useDocsIndex, type DocSummary } from "../../hooks/use-docs";
+
+const DIR_LABELS: Record<string, string> = {
+  "": "Guides",
+  installation: "Installation",
+  integrations: "Integrations",
+};
+
+function dirLabel(dir: string) {
+  return DIR_LABELS[dir] ?? dir.charAt(0).toUpperCase() + dir.slice(1);
+}
+
+export function DocsViewerModal({
+  open,
+  onClose,
+  initialDoc = null,
+}: {
+  open: boolean;
+  onClose: () => void;
+  initialDoc?: string | null;
+}) {
+  const [selected, setSelected] = useState<string | null>(initialDoc);
+  const { data: index, isLoading: indexLoading, isError: indexError } = useDocsIndex(open);
+  const { data: doc, isLoading: docLoading, isError: docError } = useDocContent(selected);
+
+  const groups: { dir: string; docs: DocSummary[] }[] = [];
+  for (const entry of index?.docs ?? []) {
+    const group = groups.find((g) => g.dir === entry.dir);
+    if (group) group.docs.push(entry);
+    else groups.push({ dir: entry.dir, docs: [entry] });
+  }
+
+  return (
+    <Modal open={open} onClose={onClose} title="Documentation" width="max-w-4xl">
+      <div className="flex h-[min(65dvh,42rem)] min-h-0 gap-3">
+        {/* Guide list */}
+        <aside
+          className={cn(
+            "flex w-full min-w-0 flex-col sm:w-60 sm:shrink-0",
+            selected !== null && "hidden sm:flex",
+          )}
+        >
+          <div className="min-h-0 flex-1 space-y-3 overflow-y-auto pr-1">
+            {indexLoading ? (
+              <p className="px-1 py-2 text-xs text-[var(--muted-foreground)]">Loading guides…</p>
+            ) : indexError || !index ? (
+              <p className="px-1 py-2 text-xs text-[var(--muted-foreground)]">
+                Could not load the documentation list. The docs folder may be missing from this install.
+              </p>
+            ) : (
+              groups.map((group) => (
+                <div key={group.dir || "root"}>
+                  <p className="px-1 pb-1 text-[0.625rem] font-medium uppercase tracking-[0.16em] text-[var(--muted-foreground)]/70">
+                    {dirLabel(group.dir)}
+                  </p>
+                  <div className="space-y-1">
+                    {group.docs.map((entry) => (
+                      <button
+                        key={entry.path}
+                        type="button"
+                        onClick={() => setSelected(entry.path)}
+                        className={cn(
+                          "flex w-full items-start gap-2 rounded-lg border px-2.5 py-2 text-left transition-colors",
+                          selected === entry.path
+                            ? "border-[var(--primary)]/40 bg-[var(--accent)] text-[var(--foreground)]"
+                            : "border-transparent text-[var(--muted-foreground)] hover:border-[var(--border)] hover:bg-[var(--accent)]/60 hover:text-[var(--foreground)]",
+                        )}
+                      >
+                        <FileText size="0.875rem" className="mt-0.5 shrink-0" />
+                        <span className="min-w-0 flex-1">
+                          <span className="block break-words text-xs font-medium leading-snug">{entry.title}</span>
+                          <span className="block truncate text-[0.625rem] text-[var(--muted-foreground)]/70">
+                            {entry.path}
+                          </span>
+                        </span>
+                      </button>
+                    ))}
+                  </div>
+                </div>
+              ))
+            )}
+          </div>
+          {index ? (
+            <div className="mt-2 shrink-0 border-t border-[var(--border)]/60 pt-2">
+              <p className="text-[0.625rem] text-[var(--muted-foreground)]/70">Also on disk at:</p>
+              <code className="block break-all text-[0.625rem] text-[var(--muted-foreground)]" title={index.root}>
+                {index.root}
+              </code>
+            </div>
+          ) : null}
+        </aside>
+
+        {/* Reader */}
+        <div
+          className={cn(
+            "min-w-0 flex-1 flex-col sm:flex sm:border-l sm:border-[var(--border)]/60 sm:pl-3",
+            selected === null ? "hidden sm:flex" : "flex",
+          )}
+        >
+          {selected === null ? (
+            <div className="flex flex-1 flex-col items-center justify-center gap-2 text-[var(--muted-foreground)]">
+              <BookOpen size="1.5rem" className="opacity-60" />
+              <p className="text-xs">Pick a guide from the list to start reading.</p>
+            </div>
+          ) : (
+            <>
+              <div className="mb-2 flex shrink-0 items-center gap-2">
+                <button
+                  type="button"
+                  onClick={() => setSelected(null)}
+                  className="flex h-7 w-7 items-center justify-center rounded-lg text-[var(--muted-foreground)] transition-colors hover:bg-[var(--accent)] hover:text-[var(--foreground)] sm:hidden"
+                  aria-label="Back to guide list"
+                >
+                  <ArrowLeft size="0.875rem" />
+                </button>
+                <p className="min-w-0 truncate text-[0.625rem] text-[var(--muted-foreground)]/70">docs/{selected}</p>
+              </div>
+              <div className="min-h-0 flex-1 overflow-y-auto pr-1">
+                {docLoading ? (
+                  <p className="py-2 text-xs text-[var(--muted-foreground)]">Loading…</p>
+                ) : docError || !doc ? (
+                  <p className="py-2 text-xs text-[var(--muted-foreground)]">Could not load this guide.</p>
+                ) : (
+                  <div className="prose prose-sm max-w-none text-[var(--foreground)]">
+                    {renderMarkdownBlocks(doc.content, applyInlineMarkdown, "docs-viewer")}
+                  </div>
+                )}
+              </div>
+            </>
+          )}
+        </div>
+      </div>
+    </Modal>
+  );
+}

--- a/packages/client/src/components/modals/DocsViewerModal.tsx
+++ b/packages/client/src/components/modals/DocsViewerModal.tsx
@@ -153,10 +153,13 @@ export function DocsViewerModal({
   );
 
   const selectDoc = (path: string, scrollTerm: string | null = null) => {
-    writeSavedPlace({ doc: path, scrollTop: 0 });
+    // Re-selecting the open doc must not reset the saved reading place.
+    if (path !== selected) {
+      writeSavedPlace({ doc: path, scrollTop: 0 });
+      setSelectedState(path);
+    }
     restoreScrollRef.current = false;
     setPendingScrollTerm(scrollTerm);
-    setSelectedState(path);
   };
 
   // Restore the saved reading position on reopen, or jump to the first
@@ -203,7 +206,7 @@ export function DocsViewerModal({
 
   return (
     <Modal open={open} onClose={onClose} title="Documentation" width="max-w-4xl">
-      <div className="flex h-[calc(100dvh-7rem)] min-h-0 gap-3 sm:h-[min(46rem,calc(90dvh-6.5rem))]">
+      <div className="flex h-[calc(100dvh-5.5rem-max(0.75rem,env(safe-area-inset-top))-max(0.75rem,env(safe-area-inset-bottom)))] min-h-0 gap-3 sm:h-[min(46rem,calc(90dvh-6.5rem))]">
         {/* Guide list / search */}
         <aside
           className={cn("flex w-full min-w-0 flex-col sm:w-64 sm:shrink-0", selected !== null && "hidden sm:flex")}
@@ -216,7 +219,7 @@ export function DocsViewerModal({
               onChange={(event) => setSearchQuery(event.target.value)}
               placeholder="Search all guides"
               aria-label="Search documentation"
-              className="min-w-0 flex-1 bg-transparent text-xs text-[var(--foreground)] outline-none placeholder:text-[var(--muted-foreground)]/65"
+              className="min-w-0 flex-1 bg-transparent text-xs text-[var(--foreground)] outline-none placeholder:text-[var(--muted-foreground)]/65 [&::-webkit-search-cancel-button]:hidden [&::-webkit-search-cancel-button]:appearance-none"
             />
             {searchQuery ? (
               <button
@@ -243,7 +246,7 @@ export function DocsViewerModal({
                   {searchFetching ? "Searching…" : `No matches for "${trimmedQuery}".`}
                 </p>
               ) : (
-                <div className="space-y-1.5">
+                <div className={cn("space-y-1.5", searchFetching && "opacity-60")}>
                   {searchResults.map((result) => (
                     <button
                       key={result.path}
@@ -340,7 +343,10 @@ export function DocsViewerModal({
               <div className="mb-2 flex shrink-0 items-center gap-2">
                 <button
                   type="button"
-                  onClick={() => setSelectedState(null)}
+                  onClick={() => {
+                    writeSavedPlace({ doc: null, scrollTop: 0 });
+                    setSelectedState(null);
+                  }}
                   className="flex h-7 w-7 items-center justify-center rounded-lg text-[var(--muted-foreground)] transition-colors hover:bg-[var(--accent)] hover:text-[var(--foreground)] sm:hidden"
                   aria-label="Back to guide list"
                 >

--- a/packages/client/src/components/modals/DocsViewerModal.tsx
+++ b/packages/client/src/components/modals/DocsViewerModal.tsx
@@ -1,7 +1,7 @@
 // ──────────────────────────────────────────────
 // DocsViewerModal: Browse the guides shipped in docs/
 // ──────────────────────────────────────────────
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import { ArrowLeft, BookOpen, FileText } from "lucide-react";
 import { Modal } from "../ui/Modal";
 import { cn } from "../../lib/utils";
@@ -16,6 +16,60 @@ const DIR_LABELS: Record<string, string> = {
 
 function dirLabel(dir: string) {
   return DIR_LABELS[dir] ?? dir.charAt(0).toUpperCase() + dir.slice(1);
+}
+
+/** Resolve a link target relative to the doc it appears in (e.g. "../FAQ.md" from "installation/windows.md"). */
+function resolveDocPath(currentPath: string, target: string): string {
+  const clean = target.replace(/\\/g, "/").replace(/^\.\//, "");
+  const segments = currentPath.split("/").slice(0, -1);
+  for (const part of clean.split("/")) {
+    if (part === "" || part === ".") continue;
+    if (part === "..") {
+      segments.pop();
+      continue;
+    }
+    segments.push(part);
+  }
+  return segments.join("/");
+}
+
+/**
+ * The shipped docs use a little structural HTML (FAQ.md's <details> blocks,
+ * anchor targets) and relative cross-doc links, neither of which the chat
+ * markdown renderer understands. Rewrite both into forms it can render:
+ * summaries become headings, structural tags are dropped, and relative .md
+ * links point at the content endpoint so the click handler below can follow
+ * them inside the modal.
+ */
+function prepareDocMarkdown(raw: string, docPath: string): string {
+  const out: string[] = [];
+  for (const line of raw.replace(/\r\n/g, "\n").split("\n")) {
+    const trimmed = line.trim();
+    if (/^<\/?details>$/i.test(trimmed) || /^<br\s*\/?>$/i.test(trimmed) || /^<\/?p(\s[^>]*)?>$/i.test(trimmed)) {
+      continue;
+    }
+    if (/^(<a id="[^"]*"><\/a>\s*)+$/i.test(trimmed)) continue;
+    const summary = trimmed.match(/^<summary>(?:<strong>)?(.+?)(?:<\/strong>)?<\/summary>$/i);
+    if (summary) {
+      out.push(`## ${summary[1]}`);
+      continue;
+    }
+    const img = trimmed.match(/^<img\b[^>]*\bsrc="(https?:\/\/[^"]+)"[^>]*>$/i);
+    if (img) {
+      out.push(`![](${img[1]})`);
+      continue;
+    }
+    if (/^<img\b[^>]*>$/i.test(trimmed)) continue;
+    out.push(line);
+  }
+  return out
+    .join("\n")
+    .replace(/\[([^\]]+)\]\(#[^)]*\)/g, "$1")
+    .replace(
+      /\[([^\]]+)\]\((?!(?:https?|card):\/\/|\/api\/|#|mailto:)([^()\s#]+\.md)(?:#[^)]*)?\)/gi,
+      (_match, text: string, target: string) =>
+        `[${text}](/api/docs/content?path=${encodeURIComponent(resolveDocPath(docPath, target))})`,
+    );
 }
 
 export function DocsViewerModal({
@@ -38,6 +92,29 @@ export function DocsViewerModal({
     else groups.push({ dir: entry.dir, docs: [entry] });
   }
 
+  const rendered = useMemo(
+    () =>
+      doc ? renderMarkdownBlocks(prepareDocMarkdown(doc.content, doc.path), applyInlineMarkdown, "docs-viewer") : null,
+    [doc],
+  );
+
+  /** Follow rewritten cross-doc links inside the modal instead of opening a new tab. */
+  const handleContentClick = (event: React.MouseEvent<HTMLDivElement>) => {
+    const anchor = (event.target as HTMLElement).closest?.("a");
+    if (!anchor) return;
+    let url: URL;
+    try {
+      url = new URL(anchor.href, window.location.origin);
+    } catch {
+      return;
+    }
+    if (url.origin !== window.location.origin || !url.pathname.endsWith("/api/docs/content")) return;
+    const target = url.searchParams.get("path");
+    if (!target) return;
+    event.preventDefault();
+    setSelected(target);
+  };
+
   return (
     <Modal open={open} onClose={onClose} title="Documentation" width="max-w-4xl">
       <div className="flex h-[min(65dvh,42rem)] min-h-0 gap-3">
@@ -55,6 +132,8 @@ export function DocsViewerModal({
               <p className="px-1 py-2 text-xs text-[var(--muted-foreground)]">
                 Could not load the documentation list. The docs folder may be missing from this install.
               </p>
+            ) : groups.length === 0 ? (
+              <p className="px-1 py-2 text-xs text-[var(--muted-foreground)]">No guides found in the docs folder.</p>
             ) : (
               groups.map((group) => (
                 <div key={group.dir || "root"}>
@@ -123,14 +202,17 @@ export function DocsViewerModal({
                 </button>
                 <p className="min-w-0 truncate text-[0.625rem] text-[var(--muted-foreground)]/70">docs/{selected}</p>
               </div>
-              <div className="min-h-0 flex-1 overflow-y-auto pr-1">
+              <div key={selected} className="min-h-0 flex-1 overflow-y-auto pr-1">
                 {docLoading ? (
                   <p className="py-2 text-xs text-[var(--muted-foreground)]">Loading…</p>
                 ) : docError || !doc ? (
                   <p className="py-2 text-xs text-[var(--muted-foreground)]">Could not load this guide.</p>
                 ) : (
-                  <div className="prose prose-sm max-w-none text-[var(--foreground)]">
-                    {renderMarkdownBlocks(doc.content, applyInlineMarkdown, "docs-viewer")}
+                  <div
+                    className="mari-message-content whitespace-pre-wrap break-words text-sm text-[var(--foreground)]"
+                    onClick={handleContentClick}
+                  >
+                    {rendered}
                   </div>
                 )}
               </div>

--- a/packages/client/src/components/modals/DocsViewerModal.tsx
+++ b/packages/client/src/components/modals/DocsViewerModal.tsx
@@ -1,12 +1,12 @@
 // ──────────────────────────────────────────────
 // DocsViewerModal: Browse the guides shipped in docs/
 // ──────────────────────────────────────────────
-import { useMemo, useState } from "react";
-import { ArrowLeft, BookOpen, FileText } from "lucide-react";
+import { useEffect, useMemo, useRef, useState } from "react";
+import { ArrowLeft, BookOpen, FileText, Search, X } from "lucide-react";
 import { Modal } from "../ui/Modal";
 import { cn } from "../../lib/utils";
 import { renderMarkdownBlocks, applyInlineMarkdown } from "../../lib/markdown";
-import { useDocContent, useDocsIndex, type DocSummary } from "../../hooks/use-docs";
+import { useDocContent, useDocsIndex, useDocsSearch, type DocSummary } from "../../hooks/use-docs";
 
 const DIR_LABELS: Record<string, string> = {
   "": "Guides",
@@ -16,6 +16,12 @@ const DIR_LABELS: Record<string, string> = {
 
 function dirLabel(dir: string) {
   return DIR_LABELS[dir] ?? dir.charAt(0).toUpperCase() + dir.slice(1);
+}
+
+function formatUpdatedAt(iso: string): string {
+  const date = new Date(iso);
+  if (Number.isNaN(date.getTime())) return "";
+  return date.toLocaleDateString(undefined, { year: "numeric", month: "short", day: "numeric" });
 }
 
 /** Resolve a link target relative to the doc it appears in (e.g. "../FAQ.md" from "installation/windows.md"). */
@@ -72,6 +78,39 @@ function prepareDocMarkdown(raw: string, docPath: string): string {
     );
 }
 
+// Session memory so reopening the viewer resumes where the user left off
+// (people bounce in and out while referencing macros, CSS, etc.).
+const PLACE_KEY = "marinara-docs-viewer-place";
+
+interface SavedPlace {
+  doc: string | null;
+  scrollTop: number;
+}
+
+function readSavedPlace(): SavedPlace {
+  try {
+    const raw = sessionStorage.getItem(PLACE_KEY);
+    if (raw) {
+      const parsed = JSON.parse(raw) as Partial<SavedPlace>;
+      return {
+        doc: typeof parsed.doc === "string" ? parsed.doc : null,
+        scrollTop: typeof parsed.scrollTop === "number" ? parsed.scrollTop : 0,
+      };
+    }
+  } catch {
+    // Ignore unavailable/corrupt sessionStorage; start fresh.
+  }
+  return { doc: null, scrollTop: 0 };
+}
+
+function writeSavedPlace(place: SavedPlace) {
+  try {
+    sessionStorage.setItem(PLACE_KEY, JSON.stringify(place));
+  } catch {
+    // Ignore unavailable sessionStorage.
+  }
+}
+
 export function DocsViewerModal({
   open,
   onClose,
@@ -81,9 +120,24 @@ export function DocsViewerModal({
   onClose: () => void;
   initialDoc?: string | null;
 }) {
-  const [selected, setSelected] = useState<string | null>(initialDoc);
+  const savedPlaceRef = useRef(readSavedPlace());
+  const [selected, setSelectedState] = useState<string | null>(initialDoc ?? savedPlaceRef.current.doc);
+  const [searchQuery, setSearchQuery] = useState("");
+  const [debouncedQuery, setDebouncedQuery] = useState("");
+  const [pendingScrollTerm, setPendingScrollTerm] = useState<string | null>(null);
+  const scrollRef = useRef<HTMLDivElement | null>(null);
+  const restoreScrollRef = useRef(initialDoc === null && savedPlaceRef.current.doc !== null);
+
+  useEffect(() => {
+    const timer = setTimeout(() => setDebouncedQuery(searchQuery), 250);
+    return () => clearTimeout(timer);
+  }, [searchQuery]);
+
   const { data: index, isLoading: indexLoading, isError: indexError } = useDocsIndex(open);
   const { data: doc, isLoading: docLoading, isError: docError } = useDocContent(selected);
+  const trimmedQuery = debouncedQuery.trim();
+  const searching = trimmedQuery.length >= 2;
+  const { data: search, isFetching: searchFetching } = useDocsSearch(trimmedQuery);
 
   const groups: { dir: string; docs: DocSummary[] }[] = [];
   for (const entry of index?.docs ?? []) {
@@ -97,6 +151,36 @@ export function DocsViewerModal({
       doc ? renderMarkdownBlocks(prepareDocMarkdown(doc.content, doc.path), applyInlineMarkdown, "docs-viewer") : null,
     [doc],
   );
+
+  const selectDoc = (path: string, scrollTerm: string | null = null) => {
+    writeSavedPlace({ doc: path, scrollTop: 0 });
+    restoreScrollRef.current = false;
+    setPendingScrollTerm(scrollTerm);
+    setSelectedState(path);
+  };
+
+  // Restore the saved reading position on reopen, or jump to the first
+  // occurrence of the search term after opening a doc from search results.
+  useEffect(() => {
+    const el = scrollRef.current;
+    if (!el || !rendered) return;
+    if (restoreScrollRef.current && selected === savedPlaceRef.current.doc) {
+      el.scrollTop = savedPlaceRef.current.scrollTop;
+      restoreScrollRef.current = false;
+      return;
+    }
+    if (!pendingScrollTerm) return;
+    const term = pendingScrollTerm.toLowerCase();
+    const walker = document.createTreeWalker(el, NodeFilter.SHOW_TEXT);
+    let node: Node | null;
+    while ((node = walker.nextNode())) {
+      if (node.textContent?.toLowerCase().includes(term)) {
+        (node.parentElement ?? el).scrollIntoView({ block: "center" });
+        break;
+      }
+    }
+    setPendingScrollTerm(null);
+  }, [rendered, selected, pendingScrollTerm]);
 
   /** Follow rewritten cross-doc links inside the modal instead of opening a new tab. */
   const handleContentClick = (event: React.MouseEvent<HTMLDivElement>) => {
@@ -112,19 +196,40 @@ export function DocsViewerModal({
     const target = url.searchParams.get("path");
     if (!target) return;
     event.preventDefault();
-    setSelected(target);
+    selectDoc(target);
   };
+
+  const searchResults = search?.results ?? [];
 
   return (
     <Modal open={open} onClose={onClose} title="Documentation" width="max-w-4xl">
-      <div className="flex h-[min(65dvh,42rem)] min-h-0 gap-3">
-        {/* Guide list */}
+      <div className="flex h-[calc(100dvh-7rem)] min-h-0 gap-3 sm:h-[min(46rem,calc(90dvh-6.5rem))]">
+        {/* Guide list / search */}
         <aside
-          className={cn(
-            "flex w-full min-w-0 flex-col sm:w-60 sm:shrink-0",
-            selected !== null && "hidden sm:flex",
-          )}
+          className={cn("flex w-full min-w-0 flex-col sm:w-64 sm:shrink-0", selected !== null && "hidden sm:flex")}
         >
+          <div className="mb-2 flex shrink-0 items-center gap-2 rounded-xl border border-[var(--border)]/60 bg-[var(--background)]/70 px-3 py-2">
+            <Search size="0.875rem" className="shrink-0 text-[var(--muted-foreground)]" />
+            <input
+              type="search"
+              value={searchQuery}
+              onChange={(event) => setSearchQuery(event.target.value)}
+              placeholder="Search all guides"
+              aria-label="Search documentation"
+              className="min-w-0 flex-1 bg-transparent text-xs text-[var(--foreground)] outline-none placeholder:text-[var(--muted-foreground)]/65"
+            />
+            {searchQuery ? (
+              <button
+                type="button"
+                onClick={() => setSearchQuery("")}
+                className="flex h-5 w-5 items-center justify-center rounded-md text-[var(--muted-foreground)] transition-colors hover:bg-[var(--accent)] hover:text-[var(--foreground)]"
+                aria-label="Clear documentation search"
+              >
+                <X size="0.6875rem" />
+              </button>
+            ) : null}
+          </div>
+
           <div className="min-h-0 flex-1 space-y-3 overflow-y-auto pr-1">
             {indexLoading ? (
               <p className="px-1 py-2 text-xs text-[var(--muted-foreground)]">Loading guides…</p>
@@ -132,6 +237,46 @@ export function DocsViewerModal({
               <p className="px-1 py-2 text-xs text-[var(--muted-foreground)]">
                 Could not load the documentation list. The docs folder may be missing from this install.
               </p>
+            ) : searching ? (
+              searchResults.length === 0 ? (
+                <p className="px-1 py-2 text-xs text-[var(--muted-foreground)]">
+                  {searchFetching ? "Searching…" : `No matches for "${trimmedQuery}".`}
+                </p>
+              ) : (
+                <div className="space-y-1.5">
+                  {searchResults.map((result) => (
+                    <button
+                      key={result.path}
+                      type="button"
+                      onClick={() => selectDoc(result.path, trimmedQuery)}
+                      className={cn(
+                        "flex w-full flex-col gap-1 rounded-lg border px-2.5 py-2 text-left transition-colors",
+                        selected === result.path
+                          ? "border-[var(--primary)]/40 bg-[var(--accent)]"
+                          : "border-transparent hover:border-[var(--border)] hover:bg-[var(--accent)]/60",
+                      )}
+                    >
+                      <span className="flex items-center gap-2">
+                        <FileText size="0.875rem" className="shrink-0 text-[var(--muted-foreground)]" />
+                        <span className="min-w-0 flex-1 truncate text-xs font-medium text-[var(--foreground)]">
+                          {result.title}
+                        </span>
+                        <span className="shrink-0 rounded-full border border-[var(--border)]/60 bg-black/5 px-1.5 py-0.5 text-[0.5625rem] text-[var(--muted-foreground)]/80 dark:bg-white/6">
+                          {result.matches}
+                        </span>
+                      </span>
+                      {result.snippets.map((snippet) => (
+                        <span
+                          key={`${result.path}-${snippet.line}`}
+                          className="block truncate pl-6 text-[0.625rem] leading-snug text-[var(--muted-foreground)]/80"
+                        >
+                          {snippet.text}
+                        </span>
+                      ))}
+                    </button>
+                  ))}
+                </div>
+              )
             ) : groups.length === 0 ? (
               <p className="px-1 py-2 text-xs text-[var(--muted-foreground)]">No guides found in the docs folder.</p>
             ) : (
@@ -145,7 +290,8 @@ export function DocsViewerModal({
                       <button
                         key={entry.path}
                         type="button"
-                        onClick={() => setSelected(entry.path)}
+                        onClick={() => selectDoc(entry.path)}
+                        title={entry.updatedAt ? `Last updated ${formatUpdatedAt(entry.updatedAt)}` : undefined}
                         className={cn(
                           "flex w-full items-start gap-2 rounded-lg border px-2.5 py-2 text-left transition-colors",
                           selected === entry.path
@@ -194,15 +340,25 @@ export function DocsViewerModal({
               <div className="mb-2 flex shrink-0 items-center gap-2">
                 <button
                   type="button"
-                  onClick={() => setSelected(null)}
+                  onClick={() => setSelectedState(null)}
                   className="flex h-7 w-7 items-center justify-center rounded-lg text-[var(--muted-foreground)] transition-colors hover:bg-[var(--accent)] hover:text-[var(--foreground)] sm:hidden"
                   aria-label="Back to guide list"
                 >
                   <ArrowLeft size="0.875rem" />
                 </button>
-                <p className="min-w-0 truncate text-[0.625rem] text-[var(--muted-foreground)]/70">docs/{selected}</p>
+                <p className="min-w-0 truncate text-[0.625rem] text-[var(--muted-foreground)]/70">
+                  docs/{selected}
+                  {doc?.updatedAt ? ` · Last updated ${formatUpdatedAt(doc.updatedAt)}` : ""}
+                </p>
               </div>
-              <div key={selected} className="min-h-0 flex-1 overflow-y-auto pr-1">
+              <div
+                key={selected}
+                ref={scrollRef}
+                onScroll={(event) => {
+                  if (selected) writeSavedPlace({ doc: selected, scrollTop: event.currentTarget.scrollTop });
+                }}
+                className="min-h-0 flex-1 overflow-y-auto pr-1"
+              >
                 {docLoading ? (
                   <p className="py-2 text-xs text-[var(--muted-foreground)]">Loading…</p>
                 ) : docError || !doc ? (

--- a/packages/client/src/components/modals/DocsViewerModal.tsx
+++ b/packages/client/src/components/modals/DocsViewerModal.tsx
@@ -250,8 +250,8 @@ export function DocsViewerModal({
   const searchResults = search?.results ?? [];
 
   return (
-    <Modal open={open} onClose={onClose} title="Documentation" width="max-w-6xl">
-      <div className="flex h-[calc(100dvh-5.5rem-max(0.75rem,env(safe-area-inset-top))-max(0.75rem,env(safe-area-inset-bottom)))] min-h-0 gap-3 sm:h-[min(46rem,calc(90dvh-6.5rem))]">
+    <Modal open={open} onClose={onClose} title="Documentation" width="max-w-6xl" mobileFullscreen>
+      <div className="flex h-full min-h-0 gap-3 sm:h-[min(46rem,calc(90dvh-6.5rem))]">
         {/* Guide list / search */}
         <aside
           className={cn("flex w-full min-w-0 flex-col sm:w-64 sm:shrink-0", selected !== null && "hidden sm:flex")}

--- a/packages/client/src/components/modals/DocsViewerModal.tsx
+++ b/packages/client/src/components/modals/DocsViewerModal.tsx
@@ -200,7 +200,7 @@ export function DocsViewerModal({
       button.type = "button";
       button.textContent = "Copy";
       button.className =
-        "docs-copy-button absolute right-1.5 top-1.5 rounded-md border border-[var(--border)] bg-[var(--card)]/90 px-1.5 py-0.5 font-sans text-[0.625rem] text-[var(--muted-foreground)] transition-colors hover:bg-[var(--accent)] hover:text-[var(--foreground)]";
+        "docs-copy-button absolute bottom-1.5 right-1.5 rounded-md border border-[var(--border)] bg-[var(--card)]/90 px-1.5 py-0.5 font-sans text-[0.625rem] text-[var(--muted-foreground)] transition-colors hover:bg-[var(--accent)] hover:text-[var(--foreground)]";
       let resetTimer: ReturnType<typeof setTimeout> | undefined;
       const onClick = () => {
         const code = block.querySelector("code")?.textContent ?? "";
@@ -416,7 +416,7 @@ export function DocsViewerModal({
                   <p className="py-2 text-xs text-[var(--muted-foreground)]">Could not load this guide.</p>
                 ) : (
                   <div
-                    className="mari-message-content whitespace-pre-wrap break-words text-sm text-[var(--foreground)] [&_.mari-md-codeblock-lang]:right-14"
+                    className="mari-message-content whitespace-pre-wrap break-words text-sm text-[var(--foreground)]"
                     onClick={handleContentClick}
                   >
                     {rendered}

--- a/packages/client/src/components/modals/DocsViewerModal.tsx
+++ b/packages/client/src/components/modals/DocsViewerModal.tsx
@@ -416,7 +416,11 @@ export function DocsViewerModal({
                   <p className="py-2 text-xs text-[var(--muted-foreground)]">Could not load this guide.</p>
                 ) : (
                   <div
-                    className="mari-message-content whitespace-pre-wrap break-words text-sm text-[var(--foreground)]"
+                    // Code blocks wrap instead of scrolling horizontally: the shared
+                    // .mari-md-codeblock rule is unlayered CSS (beats the utilities
+                    // layer, hence the !), and the corner-anchored lang tag + Copy
+                    // button would float over the text of a scrolled block.
+                    className="mari-message-content whitespace-pre-wrap break-words text-sm text-[var(--foreground)] [&_.mari-md-codeblock]:whitespace-pre-wrap! [&_.mari-md-codeblock]:[overflow-wrap:anywhere]! [&_.mari-md-codeblock]:pb-9!"
                     onClick={handleContentClick}
                   >
                     {rendered}

--- a/packages/client/src/components/ui/Modal.tsx
+++ b/packages/client/src/components/ui/Modal.tsx
@@ -22,6 +22,8 @@ interface ModalProps {
   width?: string;
   contentRef?: Ref<HTMLDivElement>;
   chatFloatingPanel?: boolean;
+  /** Below the sm breakpoint, fill the viewport edge-to-edge like a window instead of floating as a padded bubble. */
+  mobileFullscreen?: boolean;
 }
 
 export function Modal({
@@ -32,6 +34,7 @@ export function Modal({
   width = "max-w-md",
   contentRef,
   chatFloatingPanel = false,
+  mobileFullscreen = false,
 }: ModalProps) {
   const overlayRef = useRef<HTMLDivElement>(null);
   // Track mounted state separately so we can play the exit animation
@@ -107,7 +110,11 @@ export function Modal({
       aria-label={title}
       data-chat-floating-panel={chatFloatingPanel ? "true" : undefined}
       data-component="Modal"
-      className="mari-modal fixed inset-0 z-[10000] flex items-center justify-center p-3 max-md:pt-[max(0.75rem,env(safe-area-inset-top))] max-md:pb-[max(0.75rem,env(safe-area-inset-bottom))] sm:p-4"
+      className={`mari-modal fixed inset-0 z-[10000] flex items-center justify-center ${
+        mobileFullscreen
+          ? "p-0 sm:p-4"
+          : "p-3 max-md:pt-[max(0.75rem,env(safe-area-inset-top))] max-md:pb-[max(0.75rem,env(safe-area-inset-bottom))] sm:p-4"
+      }`}
       style={{
         opacity: isEntering ? 1 : 0,
         transition: "opacity 150ms ease-out",
@@ -128,7 +135,11 @@ export function Modal({
 
       {/* Panel */}
       <div
-        className={`mari-modal-panel ${NEUTRAL_PANEL_SHELL} relative flex w-full flex-col ${width} max-h-[calc(100dvh-1.5rem)] sm:max-h-[min(90dvh,52rem)]`}
+        className={`mari-modal-panel ${NEUTRAL_PANEL_SHELL} relative flex w-full flex-col ${width} max-h-[calc(100dvh-1.5rem)] sm:max-h-[min(90dvh,52rem)]${
+          mobileFullscreen
+            ? " max-sm:h-full max-sm:max-h-none max-sm:max-w-none max-sm:rounded-none max-sm:border-0 max-sm:pt-[env(safe-area-inset-top)] max-sm:pb-[env(safe-area-inset-bottom)]"
+            : ""
+        }`}
         style={{
           opacity: isEntering ? 1 : 0,
           transform: isEntering ? "scale(1) translateY(0)" : "scale(0.97) translateY(6px)",

--- a/packages/client/src/hooks/use-docs.ts
+++ b/packages/client/src/hooks/use-docs.ts
@@ -1,0 +1,50 @@
+// ──────────────────────────────────────────────
+// React Query: In-app documentation (docs/*.md)
+// ──────────────────────────────────────────────
+import { useQuery } from "@tanstack/react-query";
+import { api } from "../lib/api-client";
+
+export interface DocSummary {
+  /** Path relative to the docs folder, forward slashes (e.g. "installation/windows.md") */
+  path: string;
+  title: string;
+  /** Subfolder relative to docs ("" for root-level guides) */
+  dir: string;
+}
+
+export interface DocsIndex {
+  /** Absolute on-disk path of the docs folder */
+  root: string;
+  docs: DocSummary[];
+}
+
+export interface DocContent {
+  path: string;
+  title: string;
+  content: string;
+}
+
+export const docsKeys = {
+  all: ["docs"] as const,
+  index: () => [...docsKeys.all, "index"] as const,
+  content: (path: string) => [...docsKeys.all, "content", path] as const,
+};
+
+/** The docs shipped with the app only change on update, so cache for the session. */
+export function useDocsIndex(enabled = true) {
+  return useQuery({
+    queryKey: docsKeys.index(),
+    queryFn: () => api.get<DocsIndex>("/docs"),
+    enabled,
+    staleTime: Infinity,
+  });
+}
+
+export function useDocContent(path: string | null) {
+  return useQuery({
+    queryKey: docsKeys.content(path ?? ""),
+    queryFn: () => api.get<DocContent>(`/docs/content?path=${encodeURIComponent(path ?? "")}`),
+    enabled: !!path,
+    staleTime: Infinity,
+  });
+}

--- a/packages/client/src/hooks/use-docs.ts
+++ b/packages/client/src/hooks/use-docs.ts
@@ -10,6 +10,8 @@ export interface DocSummary {
   title: string;
   /** Subfolder relative to docs ("" for root-level guides) */
   dir: string;
+  /** File modification time (ISO). Reflects install/update time on fresh clones. */
+  updatedAt: string;
 }
 
 export interface DocsIndex {
@@ -22,12 +24,29 @@ export interface DocContent {
   path: string;
   title: string;
   content: string;
+  updatedAt: string;
+}
+
+export interface DocSearchSnippet {
+  line: number;
+  text: string;
+}
+
+export interface DocSearchResult extends DocSummary {
+  matches: number;
+  snippets: DocSearchSnippet[];
+}
+
+export interface DocsSearchResponse {
+  query: string;
+  results: DocSearchResult[];
 }
 
 export const docsKeys = {
   all: ["docs"] as const,
   index: () => [...docsKeys.all, "index"] as const,
   content: (path: string) => [...docsKeys.all, "content", path] as const,
+  search: (query: string) => [...docsKeys.all, "search", query] as const,
 };
 
 /** The docs shipped with the app only change on update, so cache for the session. */
@@ -46,5 +65,17 @@ export function useDocContent(path: string | null) {
     queryFn: () => api.get<DocContent>(`/docs/content?path=${encodeURIComponent(path ?? "")}`),
     enabled: !!path,
     staleTime: Infinity,
+  });
+}
+
+/** Full-text search across the shipped docs. Pass a debounced query of 2+ characters. */
+export function useDocsSearch(query: string) {
+  const trimmed = query.trim();
+  return useQuery({
+    queryKey: docsKeys.search(trimmed),
+    queryFn: () => api.get<DocsSearchResponse>(`/docs/search?q=${encodeURIComponent(trimmed)}`),
+    enabled: trimmed.length >= 2,
+    staleTime: Infinity,
+    placeholderData: (previous) => previous,
   });
 }

--- a/packages/server/src/routes/docs.routes.ts
+++ b/packages/server/src/routes/docs.routes.ts
@@ -1,0 +1,141 @@
+// ──────────────────────────────────────────────
+// Routes: In-app documentation (serves docs/*.md)
+// ──────────────────────────────────────────────
+import type { FastifyInstance } from "fastify";
+import { logger } from "../lib/logger.js";
+import { existsSync } from "fs";
+import { readdir, readFile, stat } from "fs/promises";
+import { join, resolve } from "path";
+import { getMonorepoRoot } from "../config/runtime-config.js";
+import { assertInsideDir } from "../utils/security.js";
+
+const DOCS_DIR = resolve(getMonorepoRoot(), "docs");
+
+/** Internal artifact folders that are not user documentation */
+const EXCLUDED_DIRS = new Set(["evidence", "pr-evidence", "screenshots", "examples"]);
+
+/** Max markdown file size served: 5 MB (real docs are well under 100 KB) */
+const MAX_DOC_BYTES = 5 * 1024 * 1024;
+
+/** Root-level docs pinned to the top of the index, in this order */
+const PINNED_DOCS = ["FAQ.md", "INSTALLATION.md", "UPGRADING.md", "CONFIGURATION.md", "TROUBLESHOOTING.md"];
+
+interface DocSummary {
+  /** Path relative to the docs folder, forward slashes (e.g. "installation/windows.md") */
+  path: string;
+  /** First `# ` heading in the file, or the filename when no heading exists */
+  title: string;
+  /** Subfolder relative to docs ("" for root-level guides) */
+  dir: string;
+}
+
+function isSafeSegment(value: string): boolean {
+  return (
+    value.length > 0 &&
+    value !== "." &&
+    value !== ".." &&
+    !value.includes("/") &&
+    !value.includes("\\") &&
+    !value.includes("\0")
+  );
+}
+
+async function extractTitle(filePath: string, fallback: string): Promise<string> {
+  try {
+    const head = (await readFile(filePath, "utf8")).slice(0, 4096);
+    return head.match(/^#\s+(.+?)\s*$/m)?.[1] ?? fallback;
+  } catch {
+    return fallback;
+  }
+}
+
+async function collectDocs(dir: string, relativeDir: string): Promise<DocSummary[]> {
+  const docs: DocSummary[] = [];
+  const entries = await readdir(dir, { withFileTypes: true });
+
+  for (const entry of entries) {
+    if (entry.isDirectory()) {
+      if (relativeDir === "" && EXCLUDED_DIRS.has(entry.name)) continue;
+      const childRelative = relativeDir ? `${relativeDir}/${entry.name}` : entry.name;
+      docs.push(...(await collectDocs(join(dir, entry.name), childRelative)));
+      continue;
+    }
+    if (!entry.isFile() || !entry.name.toLowerCase().endsWith(".md")) continue;
+    const relativePath = relativeDir ? `${relativeDir}/${entry.name}` : entry.name;
+    docs.push({
+      path: relativePath,
+      title: await extractTitle(join(dir, entry.name), entry.name.replace(/\.md$/i, "")),
+      dir: relativeDir,
+    });
+  }
+
+  return docs;
+}
+
+function docSortKey(doc: DocSummary): [number, number, string] {
+  const pinned = doc.dir === "" ? PINNED_DOCS.indexOf(doc.path) : -1;
+  // Root-level guides first (pinned ones ahead of the rest), then subfolders alphabetically.
+  return [doc.dir === "" ? 0 : 1, pinned === -1 ? PINNED_DOCS.length : pinned, `${doc.dir}/${doc.path}`];
+}
+
+export async function docsRoutes(app: FastifyInstance) {
+  /** List available documentation files plus the on-disk docs folder path */
+  app.get("/", async (_req, reply) => {
+    if (!existsSync(DOCS_DIR)) {
+      return reply.status(404).send({ error: "Documentation folder not found" });
+    }
+    try {
+      const docs = await collectDocs(DOCS_DIR, "");
+      docs.sort((a, b) => {
+        const ka = docSortKey(a);
+        const kb = docSortKey(b);
+        return ka[0] - kb[0] || ka[1] - kb[1] || ka[2].localeCompare(kb[2]);
+      });
+      return { root: DOCS_DIR, docs };
+    } catch (err) {
+      logger.error(err, "Failed to list documentation files");
+      return reply.status(500).send({ error: "Failed to list documentation files" });
+    }
+  });
+
+  /** Serve a single markdown file from the docs folder */
+  app.get("/content", async (req, reply) => {
+    const { path: docPath } = req.query as { path?: string };
+    if (!docPath || typeof docPath !== "string") {
+      return reply.status(400).send({ error: "Missing path" });
+    }
+
+    const segments = docPath.split("/");
+    const filename = segments[segments.length - 1];
+    if (!segments.every(isSafeSegment) || !filename || !filename.toLowerCase().endsWith(".md")) {
+      return reply.status(400).send({ error: "Invalid path" });
+    }
+    if (segments[0] && EXCLUDED_DIRS.has(segments[0])) {
+      return reply.status(400).send({ error: "Invalid path" });
+    }
+
+    let filePath: string;
+    try {
+      filePath = assertInsideDir(DOCS_DIR, join(DOCS_DIR, ...segments));
+    } catch {
+      return reply.status(400).send({ error: "Invalid path" });
+    }
+
+    if (!existsSync(filePath)) {
+      return reply.status(404).send({ error: "Not found" });
+    }
+
+    try {
+      const info = await stat(filePath);
+      if (!info.isFile() || info.size > MAX_DOC_BYTES) {
+        return reply.status(400).send({ error: "Invalid path" });
+      }
+      const content = await readFile(filePath, "utf8");
+      const title = content.slice(0, 4096).match(/^#\s+(.+?)\s*$/m)?.[1] ?? filename;
+      return { path: docPath, title, content };
+    } catch (err) {
+      logger.error(err, "Failed to read documentation file");
+      return reply.status(500).send({ error: "Failed to read documentation file" });
+    }
+  });
+}

--- a/packages/server/src/routes/docs.routes.ts
+++ b/packages/server/src/routes/docs.routes.ts
@@ -44,13 +44,17 @@ interface DocSearchResult extends DocSummary {
 /** Max snippet lines returned per document */
 const MAX_SNIPPETS_PER_DOC = 3;
 
-/** Trim a matched line to a readable snippet centered on the first match */
+/**
+ * Trim a matched line to a readable snippet. The sidebar only shows the first
+ * ~40 characters, so window the slice to keep the matched term near the start.
+ */
 function toSnippet(line: string, matchIndex: number): string {
+  const leading = line.length - line.trimStart().length;
   const trimmed = line.trim();
-  if (trimmed.length <= 160) return trimmed;
-  const offset = Math.max(0, matchIndex - 60);
-  const slice = line.slice(offset, offset + 160).trim();
-  return `${offset > 0 ? "…" : ""}${slice}…`;
+  const index = Math.max(0, matchIndex - leading);
+  const start = index <= 30 ? 0 : index - 30;
+  const slice = trimmed.slice(start, start + 160);
+  return `${start > 0 ? "…" : ""}${slice}${start + 160 < trimmed.length ? "…" : ""}`;
 }
 
 function isSafeSegment(value: string): boolean {
@@ -87,12 +91,16 @@ async function collectDocs(dir: string, relativeDir: string): Promise<DocSummary
     if (!entry.isFile() || !entry.name.toLowerCase().endsWith(".md")) continue;
     const relativePath = relativeDir ? `${relativeDir}/${entry.name}` : entry.name;
     const filePath = join(dir, entry.name);
-    docs.push({
-      path: relativePath,
-      title: await extractTitle(filePath, entry.name.replace(/\.md$/i, "")),
-      dir: relativeDir,
-      updatedAt: (await stat(filePath)).mtime.toISOString(),
-    });
+    try {
+      docs.push({
+        path: relativePath,
+        title: await extractTitle(filePath, entry.name.replace(/\.md$/i, "")),
+        dir: relativeDir,
+        updatedAt: (await stat(filePath)).mtime.toISOString(),
+      });
+    } catch {
+      // File vanished between readdir and stat; skip it rather than failing the whole index.
+    }
   }
 
   return docs;
@@ -140,12 +148,16 @@ export async function docsRoutes(app: FastifyInstance) {
       const results: DocSearchResult[] = [];
 
       for (const doc of await collectDocs(DOCS_DIR, "")) {
-        const content = await readFile(join(DOCS_DIR, ...doc.path.split("/")), "utf8");
+        let content: string;
+        try {
+          const filePath = join(DOCS_DIR, ...doc.path.split("/"));
+          if ((await stat(filePath)).size > MAX_DOC_BYTES) continue;
+          content = await readFile(filePath, "utf8");
+        } catch {
+          continue;
+        }
         const snippets: DocSearchSnippet[] = [];
         let matches = 0;
-
-        const titleMatch = doc.title.toLowerCase().includes(needle);
-        if (titleMatch) matches++;
 
         content.split(/\r?\n/).forEach((line, index) => {
           const matchIndex = line.toLowerCase().indexOf(needle);
@@ -155,6 +167,10 @@ export async function docsRoutes(app: FastifyInstance) {
             snippets.push({ line: index + 1, text: toSnippet(line, matchIndex) });
           }
         });
+
+        // Count a title hit only when no content line matched (the H1 the title
+        // came from is already counted by the line scan).
+        if (matches === 0 && doc.title.toLowerCase().includes(needle)) matches = 1;
 
         if (matches > 0) results.push({ ...doc, matches, snippets });
       }

--- a/packages/server/src/routes/docs.routes.ts
+++ b/packages/server/src/routes/docs.routes.ts
@@ -27,6 +27,30 @@ interface DocSummary {
   title: string;
   /** Subfolder relative to docs ("" for root-level guides) */
   dir: string;
+  /** File modification time (ISO). Reflects install/update time on fresh clones. */
+  updatedAt: string;
+}
+
+interface DocSearchSnippet {
+  line: number;
+  text: string;
+}
+
+interface DocSearchResult extends DocSummary {
+  matches: number;
+  snippets: DocSearchSnippet[];
+}
+
+/** Max snippet lines returned per document */
+const MAX_SNIPPETS_PER_DOC = 3;
+
+/** Trim a matched line to a readable snippet centered on the first match */
+function toSnippet(line: string, matchIndex: number): string {
+  const trimmed = line.trim();
+  if (trimmed.length <= 160) return trimmed;
+  const offset = Math.max(0, matchIndex - 60);
+  const slice = line.slice(offset, offset + 160).trim();
+  return `${offset > 0 ? "…" : ""}${slice}…`;
 }
 
 function isSafeSegment(value: string): boolean {
@@ -62,10 +86,12 @@ async function collectDocs(dir: string, relativeDir: string): Promise<DocSummary
     }
     if (!entry.isFile() || !entry.name.toLowerCase().endsWith(".md")) continue;
     const relativePath = relativeDir ? `${relativeDir}/${entry.name}` : entry.name;
+    const filePath = join(dir, entry.name);
     docs.push({
       path: relativePath,
-      title: await extractTitle(join(dir, entry.name), entry.name.replace(/\.md$/i, "")),
+      title: await extractTitle(filePath, entry.name.replace(/\.md$/i, "")),
       dir: relativeDir,
+      updatedAt: (await stat(filePath)).mtime.toISOString(),
     });
   }
 
@@ -95,6 +121,49 @@ export async function docsRoutes(app: FastifyInstance) {
     } catch (err) {
       logger.error(err, "Failed to list documentation files");
       return reply.status(500).send({ error: "Failed to list documentation files" });
+    }
+  });
+
+  /** Full-text search across all documentation files (case-insensitive substring) */
+  app.get("/search", async (req, reply) => {
+    const { q } = req.query as { q?: string };
+    const query = typeof q === "string" ? q.trim().slice(0, 200) : "";
+    if (query.length < 2) {
+      return reply.status(400).send({ error: "Query must be at least 2 characters" });
+    }
+    if (!existsSync(DOCS_DIR)) {
+      return reply.status(404).send({ error: "Documentation folder not found" });
+    }
+
+    try {
+      const needle = query.toLowerCase();
+      const results: DocSearchResult[] = [];
+
+      for (const doc of await collectDocs(DOCS_DIR, "")) {
+        const content = await readFile(join(DOCS_DIR, ...doc.path.split("/")), "utf8");
+        const snippets: DocSearchSnippet[] = [];
+        let matches = 0;
+
+        const titleMatch = doc.title.toLowerCase().includes(needle);
+        if (titleMatch) matches++;
+
+        content.split(/\r?\n/).forEach((line, index) => {
+          const matchIndex = line.toLowerCase().indexOf(needle);
+          if (matchIndex === -1) return;
+          matches++;
+          if (snippets.length < MAX_SNIPPETS_PER_DOC) {
+            snippets.push({ line: index + 1, text: toSnippet(line, matchIndex) });
+          }
+        });
+
+        if (matches > 0) results.push({ ...doc, matches, snippets });
+      }
+
+      results.sort((a, b) => b.matches - a.matches || a.path.localeCompare(b.path));
+      return { query, results };
+    } catch (err) {
+      logger.error(err, "Failed to search documentation files");
+      return reply.status(500).send({ error: "Failed to search documentation files" });
     }
   });
 
@@ -133,7 +202,7 @@ export async function docsRoutes(app: FastifyInstance) {
       }
       const content = await readFile(filePath, "utf8");
       const title = content.slice(0, 4096).match(/^#\s+(.+?)\s*$/m)?.[1] ?? filename;
-      return { path: docPath, title, content };
+      return { path: docPath, title, content, updatedAt: info.mtime.toISOString() };
     } catch (err) {
       logger.error(err, "Failed to read documentation file");
       return reply.status(500).send({ error: "Failed to read documentation file" });

--- a/packages/server/src/routes/docs.routes.ts
+++ b/packages/server/src/routes/docs.routes.ts
@@ -110,7 +110,8 @@ export async function docsRoutes(app: FastifyInstance) {
     if (!segments.every(isSafeSegment) || !filename || !filename.toLowerCase().endsWith(".md")) {
       return reply.status(400).send({ error: "Invalid path" });
     }
-    if (segments[0] && EXCLUDED_DIRS.has(segments[0])) {
+    // Lowercase so the exclusion can't be bypassed on case-insensitive filesystems
+    if (segments[0] && EXCLUDED_DIRS.has(segments[0].toLowerCase())) {
       return reply.status(400).send({ error: "Invalid path" });
     }
 

--- a/packages/server/src/routes/docs.routes.ts
+++ b/packages/server/src/routes/docs.routes.ts
@@ -4,7 +4,7 @@
 import type { FastifyInstance } from "fastify";
 import { logger } from "../lib/logger.js";
 import { existsSync } from "fs";
-import { readdir, readFile, stat } from "fs/promises";
+import { readdir, readFile, realpath, stat } from "fs/promises";
 import { join, resolve } from "path";
 import { getMonorepoRoot } from "../config/runtime-config.js";
 import { assertInsideDir } from "../utils/security.js";
@@ -66,6 +66,11 @@ function isSafeSegment(value: string): boolean {
     !value.includes("\\") &&
     !value.includes("\0")
   );
+}
+
+async function assertRealDocsPath(candidatePath: string): Promise<string> {
+  const [root, candidate] = await Promise.all([realpath(DOCS_DIR), realpath(candidatePath)]);
+  return assertInsideDir(root, candidate);
 }
 
 async function extractTitle(filePath: string, fallback: string): Promise<string> {
@@ -202,13 +207,13 @@ export async function docsRoutes(app: FastifyInstance) {
 
     let filePath: string;
     try {
-      filePath = assertInsideDir(DOCS_DIR, join(DOCS_DIR, ...segments));
+      const candidatePath = assertInsideDir(DOCS_DIR, join(DOCS_DIR, ...segments));
+      if (!existsSync(candidatePath)) {
+        return reply.status(404).send({ error: "Not found" });
+      }
+      filePath = await assertRealDocsPath(candidatePath);
     } catch {
       return reply.status(400).send({ error: "Invalid path" });
-    }
-
-    if (!existsSync(filePath)) {
-      return reply.status(404).send({ error: "Not found" });
     }
 
     try {

--- a/packages/server/src/routes/index.ts
+++ b/packages/server/src/routes/index.ts
@@ -42,6 +42,7 @@ import { chatFoldersRoutes } from "./chat-folders.routes.js";
 import { connectionFoldersRoutes } from "./connection-folders.routes.js";
 import { chatPresetsRoutes } from "./chat-presets.routes.js";
 import { updatesRoutes } from "./updates.routes.js";
+import { docsRoutes } from "./docs.routes.js";
 import { themesRoutes } from "./themes.routes.js";
 import { extensionsRoutes } from "./extensions.routes.js";
 import { appSettingsRoutes } from "./app-settings.routes.js";
@@ -96,6 +97,7 @@ export async function registerRoutes(app: FastifyInstance) {
   await app.register(botBrowserWyvernRoutes, { prefix: "/api/bot-browser" });
   await app.register(botBrowserDatacatRoutes, { prefix: "/api/bot-browser" });
   await app.register(updatesRoutes, { prefix: "/api/updates" });
+  await app.register(docsRoutes, { prefix: "/api/docs" });
   await app.register(themesRoutes, { prefix: "/api/themes" });
   await app.register(extensionsRoutes, { prefix: "/api/extensions" });
   await app.register(appSettingsRoutes, { prefix: "/api/app-settings" });


### PR DESCRIPTION
Closes #3238

## Summary

Adds an in-app documentation viewer so the guides shipped in `docs/` can be read directly inside Marinara, discoverable from a new **Documentation** button in the home page footer (next to **Replay Tutorial**) and a new FAQ entry ("Where can I find documentation?") that shows the on-disk docs path and opens the viewer. The viewer supports full-text search across all guides, shows a per-guide "Last updated" date, has one-click Copy buttons on every code block, and remembers the reader's place (guide + scroll position) across close/reopen.

## Why

Marinara ships ~28 user guides (installation, configuration, troubleshooting, macros, extensions, Game Mode, and more), but the app never mentioned them — users had to already know the `docs` folder existed inside the install directory. Discussed and approved beforehand; see #3238. The search, last-updated dates, larger layout, place-memory, and code-block copy buttons were requested during testing: last-updated helps triage "is this documentation outdated?" reports, place-memory supports bouncing in and out of the viewer while referencing macros/CSS guides mid-chat, and copy buttons serve the CSS-theming guide's paste-a-snippet workflow.

## Architecture

| Layer | Change |
|---|---|
| Server | New `docs.routes.ts`: `GET /api/docs` (index with titles from each file's first `#` heading, file-mtime `updatedAt`, and the absolute on-disk docs path), `GET /api/docs/content?path=…` (one markdown file), and `GET /api/docs/search?q=…` (case-insensitive full-text search with per-doc match counts and match-windowed line snippets). Path safety: per-segment validation (no `..`/`\`/null bytes), `.md`-only, case-insensitive exclusion of internal artifact folders (`evidence/`, `pr-evidence/`, `screenshots/`, `examples/`), `assertInsideDir` containment, and the `MAX_DOC_BYTES` size guard applied on both content and search reads. |
| Client | New `DocsViewerModal` (`max-w-6xl`, fills the modal shell height on desktop; on mobile it opens as a full-screen window via a new opt-in `mobileFullscreen` prop on the shared `Modal` — edge-to-edge, square corners, safe-area padding inside the panel; registered as `docs-viewer` in `ModalRenderer`), `use-docs.ts` React Query hooks (`staleTime: Infinity`, debounced search), FAQ entry + `FaqDocsAccess` block in `HomeFaq`, footer button in `ChatArea`. Reading place persists via `sessionStorage`; the reader element is tracked with a state callback ref because the `Modal` shell renders `null` on its first frame (plain refs never see the portal DOM when the doc is already cached). |
| Rendering | Reuses the chat markdown renderer (`renderMarkdownBlocks`) inside the standard `mari-message-content` styling scope. A `prepareDocMarkdown` pass converts the structural HTML used by `docs/FAQ.md` (`<details>`/`<summary>` blocks, anchor tags) into headings and rewrites relative cross-doc links to the content endpoint; a click handler follows those inside the modal, so cross-doc navigation works. Opening a search result jumps to the first occurrence of the term in the rendered text. Code blocks get a Copy button via viewer-scoped DOM augmentation (the renderer is shared with chat, so it is not modified globally). |
| Packaging | `Dockerfile` and `Dockerfile.lite` production stages now `COPY docs/ docs/` — container images previously shipped no docs at all, which would have 404'd the viewer for every Docker/Podman/HF-Spaces user. (Windows installer and Termux installs are full clones and already include `docs/`.) |

## What was verified so far (automated)

- `pnpm check` green (lint + production build).
- API smoke-tested against the built server: index returns all 28 guides with correct titles + `updatedAt` (CRLF files included) and pinned ordering; nested paths work; search returns windowed snippets, correct counts (H1 not double-counted), 400 on sub-2-character queries, and empty results cleanly.
- Path-traversal probes all rejected (`../`, encoded/double-encoded, backslash, absolute path, null byte, excluded dirs in any letter case).
- The markdown preprocessing was run against the real `FAQ.md`, `INSTALLATION.md`, `installation/ios-pwa.md`, and `PROFESSOR_MARI.md`: zero leftover raw-HTML lines, zero unrewritten relative links, correct `../` resolution from nested docs.
- Two multi-agent adversarial review passes over the diff; all confirmed findings fixed (inert `prose` classes → `mari-message-content`, Docker docs packaging, FAQ.md HTML handling, cross-doc links, safe-area-aware mobile height, saved-place edge cases, search count/snippet windowing, duplicate native search-clear button, scroll-restore racing the modal mount animation).

## Manual verification

- [x] Home page footer shows the **Documentation** button next to **Replay Tutorial**; clicking opens the viewer.
- [x] FAQ entry "Where can I find documentation?" appears (first Setup entry), shows the real on-disk path, and its **Open Documentation** button opens the viewer — in both the full home FAQ and the compact Professor Mari FAQ.
- [x] Viewer size feels right on desktop (wide two-pane layout, fills the modal shell).
- [x] FAQ.md renders with proper headings (no visible `<details>`/`<summary>` tags); lists/tables/code blocks styled; paragraphs separated.
- [x] "Last updated" date shows in the reader header and as a tooltip on sidebar entries.
- [x] Search: type a term (e.g. "macro"), see ranked results with snippets, click one → doc opens scrolled to the first occurrence; clear search returns to the guide list.
- [x] Code blocks show a Copy button (top right, next to the language tag); clicking copies the snippet and flashes "Copied!".
- [x] Close the viewer mid-guide, reopen → same guide at the same scroll position.
- [x] Cross-doc links navigate inside the modal (e.g. INSTALLATION.md → Windows Installation Guide); external links still open in a new tab.
- [x] Light mode AND dark mode.
- [x] Mobile viewport (~400px): the viewer opens as a full-screen window (no floating bubble margins); list ↔ reader switching with the back arrow; nothing overflows.
- [x] Empty/error states: stop the server mid-open → list shows the error message.

## Known limitations

- In-page `#anchor` fragments in cross-doc links are dropped (navigates to the top of the target doc); same-page anchor links render as plain text.
- Relative image references inside docs (e.g. `screenshots/*.png`) are not served and render as text — no shipped top-level guide currently relies on them for comprehension.
- `updatedAt` is the file's on-disk modification time: on fresh installs it reflects install/update time rather than when the guide was authored. It still distinguishes "docs from three versions ago" from "docs updated with this release".
- Search-result jump targets the rendered text; a term that only appears inside a link URL or stripped HTML opens the doc at the top.

## Docs touched

- `docs/FAQ.md` — new entry: "How do I read the documentation inside the app?"
- `CHANGELOG.md` — Unreleased → Added entry.

## UI Evidence

<img width="1180" height="873" alt="image" src="https://github.com/user-attachments/assets/0468974a-f9a4-4d0f-b6ef-2b80eaac6dbc" />

<img width="1313" height="831" alt="image" src="https://github.com/user-attachments/assets/7b03b2d6-d3b0-49bc-90b8-3943bcc3e677" />

<img width="386" height="581" alt="image" src="https://github.com/user-attachments/assets/2b8e1bbc-54b6-4654-b352-0a5eea4f7c0e" />

<img width="1298" height="828" alt="image" src="https://github.com/user-attachments/assets/9e14b22f-2b48-4af6-9dcd-fc490f28d238" />