### PR TITLE
fix: use mari-message-content styles for File Browser markdown preview

### DIFF
--- a/packages/client/src/components/game-assets/FileEditorModal.tsx
+++ b/packages/client/src/components/game-assets/FileEditorModal.tsx
@@ -175,7 +175,7 @@ export function FileEditorModal({ node, onClose, initialMode = "edit" }: FileEdi
             </div>
           ) : mode === "preview" && isMd ? (
             <div className="h-full overflow-y-auto p-6">
-              <div className="prose prose-sm max-w-none text-[var(--foreground)]">
+              <div className="mari-message-content whitespace-pre-wrap break-words text-sm text-[var(--foreground)]">
                 {renderMarkdownBlocks(content, applyInlineMarkdown, "editor-preview")}
               </div>
             </div>


### PR DESCRIPTION
Fixes #3240

## Summary

One-line class swap in `FileEditorModal.tsx`: the markdown preview wrapper used Tailwind `prose prose-sm max-w-none` classes, but `@tailwindcss/typography` is not installed anywhere in the client, so those classes were inert and the preview rendered as unstyled plain text. The wrapper now uses `mari-message-content whitespace-pre-wrap break-words text-sm`, the same pattern every working markdown consumer uses (`ChatMessage`, `GameJournal`, `HomeProfessorMariChat`).

## Why

Users previewing `.md` files in the Game Assets file browser see headings, lists, and tables collapse into undifferentiated plain text, while the exact same markdown renders correctly in chat. All of the markdown renderer's output styles (`.mari-md-heading`, `.mari-md-ul`, `.mari-md-table`, …) are scoped under `.mari-message-content` in `globals.css`, so the wrapper must carry that class for any styling to apply. The renderer also joins paragraph runs with `\n`, which is why the wrapper additionally needs `whitespace-pre-wrap` — without it, paragraph spacing collapses.

## Test plan

- [x] Manually verify in browser: open a `.md` file in the Game Assets file browser, switch to Preview, and confirm headings, bullet lists, and tables are styled (matching how the same markdown looks in a chat message)
- [x] Manually verify paragraph spacing: a file with multiple paragraphs separated by blank lines shows visible spacing between them
- [x] Manually verify in both light and dark mode
- [x] Manually verify at a narrow/mobile viewport (~400px) that long lines wrap instead of overflowing the modal

`pnpm check` passes locally.

## UI Evidence

<img width="1027" height="820" alt="image" src="https://github.com/user-attachments/assets/989a27c9-b6d5-45e0-8b2c-50051f8c654a" />

<img width="389" height="587" alt="image" src="https://github.com/user-attachments/assets/3339b388-5f9f-493c-a9f5-faf4ae060ff2" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the Markdown preview appearance in the file editor to use consistent message content styling while preserving wrapping, text sizing, and color behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->