### PR TITLE
fix: parse markdown headings in files with CRLF line endings

### DIFF
--- a/packages/client/src/lib/markdown.tsx
+++ b/packages/client/src/lib/markdown.tsx
@@ -375,7 +375,10 @@ export function renderMarkdownBlocks(
   renderInline: (text: string, keyPrefix: string) => ReactNode[] = applyInlineMarkdown,
   keyBase = "md",
 ): ReactNode {
-  const lines = normalizeCardAssetImageSyntax(text).split("\n");
+  // Split on CRLF or LF — CRLF input (e.g. .md files written on Windows) must
+  // not leave a trailing \r on lines, or line-anchored patterns like
+  // HEADING_RE fail to match.
+  const lines = normalizeCardAssetImageSyntax(text).split(/\r?\n/);
   const segments: ReactNode[] = [];
   let key = 0;
 


### PR DESCRIPTION
Fixes #3242

## Summary

`renderMarkdownBlocks` split content on `"\n"` only, so text with Windows CRLF line endings left a trailing `\r` on every line. The heading regex (`/^(#{1,6})\s+(.+)$/`) cannot match across a carriage return, so headings in CRLF files rendered as literal `# ...` plain text. Now the renderer splits on `/\r?\n/`, making CRLF and LF input parse identically.

## Why

The seeded `CREDITS.md` in Game Assets arrives with CRLF endings on Windows (git converts it at checkout, and the seeder copies it byte-for-byte), so every Windows install shows broken headings when previewing it — while tables in the same file render fine, because the table parser happens to `.trim()` each line. Any markdown file written by a Windows editor and imported into game assets hits the same problem. Fixing it at the line-split also protects the parser's other line-anchored patterns that don't trim, instead of patching regexes one by one.

## Known limitations

The separate `applyInlineMarkdownHTML` path (sanitized-HTML pipeline where newlines are already `<br>` tags) is untouched — whether `\r` can survive into that pipeline depends on the upstream sanitizer and there is no observed repro there.

Note: the full styled result in the file preview also needs #3241 (the preview's CSS scoping fix, separate PR). This fix is observable independently: with it, the `#` marks are consumed and real `<h1>`–`<h6>` elements are emitted.

## Test plan

- [x] Manually verify in browser (Windows install): Settings → Game Assets → Asset Browser → open the seeded `CREDITS.md` → Preview shows "Game Assets Credits", "Music", etc. as headings with no literal `#` marks
- [x] Manually verify no regression for LF content: create a new markdown file in-app with `# Heading`, a list, and a table — everything still renders as before
- [x] Manually verify a code fence in a CRLF file still renders as a code block
- [x] Capture before/after screenshots for this PR

`pnpm check` passes locally.

## UI Evidence

How `credits.md` appears now:
<img width="1021" height="806" alt="image" src="https://github.com/user-attachments/assets/25367de9-7ff4-4365-af7e-b151b64abc82" />

With both this and #3241 applied:
<img width="1024" height="811" alt="image" src="https://github.com/user-attachments/assets/ccc2a8a3-3a11-40f6-8587-7ffc6ebbd019" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved markdown rendering to handle both Windows and Unix line endings consistently.
  * Fixed an issue where some headings and other line-based markdown patterns could fail to render correctly when content included carriage returns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->