### PR TITLE
[codex] Fix lorebook title collapse and NanoGPT reference cap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 
 ### Fixed
 
+- Fixed lorebook entry rows collapsing when editing the entry title by making row-header inline controls opt out of the expand/collapse click handler (#3244).
+- Capped NanoGPT image-generation reference payloads at three images so Qwen Image/edit-capable NanoGPT models only receive the number of references those services accept.
 - Fixed group-chat character reactions always being credited to the first character in the chat: commands placed above the first `Name:` line of a merged reply now attribute to the speaker whose section they open (leaked `[HH:MM]` timestamps no longer skew this), merged group chats now instruct models to write the `[react:]` tag inside the reacting character's own section — and that several characters may react in the same reply — and a react aimed at the user's persona name (or "User") explicitly targets the user's latest message (#3220).
 - Hardened Conversation reaction processing against stalls and junk: the shared timestamp strip is no longer quadratic on pathological whitespace runs (~7s → <1ms at 100KB), each `[react:]` command persists with far fewer storage scans so multi-react group replies no longer block generations for seconds on large installs, malformed quote-bearing react tags stay visible instead of becoming junk text chips, and per-segment add-reaction buttons mount their emoji picker only while open.
 

--- a/packages/client/src/components/lorebooks/LorebookEntryRow.tsx
+++ b/packages/client/src/components/lorebooks/LorebookEntryRow.tsx
@@ -125,6 +125,15 @@ const STATUS_DOT_COLOR: Record<EntryStatus, string> = {
   normal: "bg-emerald-400",
 };
 
+function isHeaderInlineControlTarget(target: EventTarget | null) {
+  if (!(target instanceof Element)) return false;
+  return Boolean(
+    target.closest(
+      'button, input, select, textarea, a, [role="button"], [role="menuitem"], [role="menuitemradio"]',
+    ),
+  );
+}
+
 const SELECTIVE_LOGIC_OPTIONS: Array<{ value: SelectiveLogic; label: string }> = [
   { value: "and", label: "AND Any" },
   { value: "and_all", label: "AND All" },
@@ -366,6 +375,18 @@ export function LorebookEntryRow({
     [localUseRegex, patch],
   );
 
+  const handleHeaderClick = useCallback(
+    (e: ReactMouseEvent<HTMLDivElement>) => {
+      if (isHeaderInlineControlTarget(e.target)) return;
+      if (selectionMode) {
+        onToggleSelected?.();
+        return;
+      }
+      onToggleExpand();
+    },
+    [onToggleExpand, onToggleSelected, selectionMode],
+  );
+
   const handleNameCommit = useCallback(() => {
     if (localName.trim() && localName !== entry.name) {
       const previous = entry.name;
@@ -478,7 +499,7 @@ export function LorebookEntryRow({
       {/* ── Compact row ── */}
       <div
         className="group flex min-w-0 cursor-pointer items-center gap-0.5 px-1.5 py-1.5 sm:gap-2 sm:px-2"
-        onClick={selectionMode ? onToggleSelected : onToggleExpand}
+        onClick={handleHeaderClick}
       >
         {/* Drag handle */}
         <button

--- a/packages/server/src/services/image/image-generation.ts
+++ b/packages/server/src/services/image/image-generation.ts
@@ -245,6 +245,7 @@ export function saveImageToDisk(chatId: string, base64: string, ext: string): st
 
 const MAX_IMAGE_RESPONSE_BYTES = 30 * 1024 * 1024;
 const LOCAL_IMAGE_BACKENDS = new Set(["comfyui", "automatic1111"]);
+const NANOGPT_REFERENCE_IMAGE_LIMIT = 3;
 
 class ImageGenerationDeadlineError extends Error {
   constructor(timeoutMs: number) {
@@ -801,6 +802,10 @@ function xAIReferenceImages(request: ImageGenRequest): string[] {
   return openAIReferenceImages(request).slice(0, 3);
 }
 
+function nanoGPTReferenceImages(request: ImageGenRequest): string[] {
+  return openAIReferenceImages(request).slice(0, NANOGPT_REFERENCE_IMAGE_LIMIT);
+}
+
 function xAIImageInput(reference: string): { type: "image_url"; url: string } {
   const decoded = decodeReferenceImage(reference);
   return {
@@ -868,11 +873,7 @@ async function generateNanoGPT(baseUrl: string, apiKey: string, request: ImageGe
   if (request.model) body.model = request.model;
   if (request.negativePrompt) body.negative_prompt = request.negativePrompt;
 
-  const references = request.referenceImages?.length
-    ? request.referenceImages
-    : request.referenceImage
-      ? [request.referenceImage]
-      : [];
+  const references = nanoGPTReferenceImages(request);
   if (request.model?.toLowerCase().includes("flux-kontext")) {
     body.kontext_max_mode = true;
   }


### PR DESCRIPTION
## Summary
- Fixes lorebook entry rows collapsing when users click or edit the inline title field by ignoring header expand/collapse clicks that originate from row controls.
- Caps NanoGPT image-generation reference payloads to three images, covering Qwen Image/edit-capable NanoGPT models that reject larger reference sets.
- Updates the Unreleased changelog.

Fixes #3244

## Validation
- [ ] Manually verify an expanded lorebook entry stays expanded while clicking, typing, and blurring the title field on Windows/browser.
- [ ] Manually verify a NanoGPT/Qwen Image request with more than three references succeeds or shows only three references in provider logs.
- [ ] `git diff --check`
- [ ] `pnpm check`

## Notes
Local validation was run before opening this draft PR: `git diff --check` and `pnpm check` both passed. The manual rows above are left unchecked for reviewer verification.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Lorebook entry rows no longer collapse when editing the title or using controls in the row header.
  * NanoGPT image generation now limits reference images to three, matching service support.
  * Changelog updated to note the two fixes above.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->