### PR TITLE
fix(ha): default integration port to 7860 to match server

### DIFF
--- a/custom_components/marinara_engine/const.py
+++ b/custom_components/marinara_engine/const.py
@@ -3,7 +3,7 @@
 DOMAIN = "marinara_engine"
 
 DEFAULT_HOST = "localhost"
-DEFAULT_PORT = 3000
+DEFAULT_PORT = 7860
 SCAN_INTERVAL = 30  # seconds
 
 CONF_HOST = "host"

--- a/custom_components/marinara_engine/strings.json
+++ b/custom_components/marinara_engine/strings.json
@@ -3,7 +3,7 @@
     "step": {
       "user": {
         "title": "Connect to Marinara Engine",
-        "description": "Enter the host and port where Marinara Engine is running.",
+        "description": "Enter the host and port where Marinara Engine is running (default: localhost:7860).",
         "data": {
           "host": "Host",
           "port": "Port"

--- a/custom_components/marinara_engine/translations/en.json
+++ b/custom_components/marinara_engine/translations/en.json
@@ -3,7 +3,7 @@
     "step": {
       "user": {
         "title": "Connect to Marinara Engine",
-        "description": "Enter the host and port where Marinara Engine is running (default: localhost:3000).",
+        "description": "Enter the host and port where Marinara Engine is running (default: localhost:7860).",
         "data": {
           "host": "Host",
           "port": "Port"

--- a/docs/integrations/home-assistant.md
+++ b/docs/integrations/home-assistant.md
@@ -23,7 +23,7 @@ Everything happens on first startup. You never copy URLs or configure tools manu
 
 - Home Assistant 2024.1 or newer
 - [HACS](https://hacs.xyz) installed
-- [Marinara Engine](https://github.com/Pasta-Devs/Marinara-Engine) running locally (default: `localhost:3000`)
+- [Marinara Engine](https://github.com/Pasta-Devs/Marinara-Engine) running locally (default: `localhost:7860`)
 
 ## Installation
 
@@ -39,7 +39,7 @@ Everything happens on first startup. You never copy URLs or configure tools manu
 
 1. Go to **Settings → Devices & Services → Add Integration**
 2. Search for **Marinara Engine**
-3. Enter the host and port where Marinara Engine is running (default: `localhost` / `3000`)
+3. Enter the host and port where Marinara Engine is running (default: `localhost` / `7860`)
 4. Click **Submit**
 
 On startup, the integration automatically:
@@ -155,7 +155,7 @@ The **Home Assistant** custom agent must be synced in Marinara and added to the 
 Check that Home Assistant is reachable from the machine running Marinara Engine. If they run on the same machine, the internal URL (`http://localhost:8123`) is used automatically. If Marinara runs on a different device, make sure HA's local network URL is accessible from that device.
 
 **Cannot connect on setup**
-Make sure Marinara Engine is running (`pnpm dev` or the packaged app) and the host/port you entered match where it's actually listening (default: `localhost:3000`).
+Make sure Marinara Engine is running (`pnpm dev` or the packaged app) and the host/port you entered match where it's actually listening (default: `localhost:7860`).
 
 **Finding the webhook URL manually**
 Go to **Settings → Devices & Services → Marinara Engine** in HA. The webhook ID is stored in the config entry. The full URL follows the pattern:


### PR DESCRIPTION
Resolves #3291

## Why

Marinara Engine's server listens on **7860** everywhere — `packages/server/src/config/runtime-config.ts` (`DEFAULT_PORT = 7860`), `.env.example` (`PORT=7860`), `start.bat` / `start.sh` / `start-termux.sh` (`export PORT=7860`), and `scripts/dev.mjs`.

But the Home Assistant integration's config flow pre-filled port **3000**. A user adding the integration against a stock Marinara install submits the form as-is and immediately hits **`cannot_connect`**, because the default never points at a real listener. The fix aligns the integration default with the server's actual port.

## What changed

- **`custom_components/marinara_engine/const.py`** — `DEFAULT_PORT = 3000` → `7860`. This is the value the config-flow form uses as the port pre-fill (`config_flow.py` `_STEP_USER_SCHEMA`), so it's the actual behavior fix.
- **`custom_components/marinara_engine/strings.json`** and **`translations/en.json`** — both now state `(default: localhost:7860)`. Note: `en.json` carried a stale `localhost:3000` string while `strings.json` had *no* default text at all, so these two files were already out of sync — this also brings them back into agreement (HA expects `translations/en.json` to mirror `strings.json`).
- **`docs/integrations/home-assistant.md`** — updated the three `localhost:3000` references (lines 26, 42, 158) to `7860`.

## Coordination

- The three doc-line edits overlap with a **separate docs audit** that is already reporting the `localhost:3000` doc references. They're included here because they're part of the same one-line-of-truth fix, but if the audit's doc change lands first, expect a trivial conflict on those three lines only. The `const.py` change is the unique, primary deliverable and won't collide.
- **No linked issue** currently exists for this fix. Per `CONTRIBUTING.md § Before You Open a Pull Request`, an issue/feature request should be opened to track it before this PR is merged.

## Validation

- `pnpm check` passes (typecheck + lint + build, exit 0). *(Note: the changed files are Python / JSON / Markdown and are outside `pnpm check`'s TypeScript+ESLint scope, so it confirms the baseline is green rather than exercising this change directly.)*
- Both JSON files re-parse successfully after the edit.
- No `3000` references remain under `custom_components/` or in the HA doc.

## Manual verification (not yet done)

- [ ] In a Home Assistant instance, add the Marinara Engine integration against a stock local install and confirm the port field pre-fills **7860** and the flow connects without `cannot_connect`.
- [ ] Confirm the config-flow form description renders `(default: localhost:7860)` in the HA UI.
- [ ] Confirm the rendered `docs/integrations/home-assistant.md` reads correctly at the three updated spots.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated setup and troubleshooting guidance to reflect the current default connection address: `localhost:7860`.
  * Revised the integration’s user-facing configuration text to match the new default host and port.
* **Bug Fixes**
  * Aligned the default connection port with the value expected by the integration, improving out-of-box setup consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->