### PR TITLE
[codex] fix /as posting and NPC portrait prompts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 
 - Fixed character library favorites and non-favorites filtering so server-side pagination searches the full library before returning each 100-item page, and separated the **Load more** control from character cards for large libraries (#3286).
 - Fixed Roleplay `/as` so `/as Character "message"` posts the exact message as that character, while bare `/as Character` still asks the model to generate that character's next response.
+- Fixed Roleplay tracker locks so AI tracker updates cannot bypass a locked field by renaming or replacing the locked row at the same position.
 - Fixed Game Mode NPC portrait generation so GM-created NPC profile descriptions from initial world setup take priority over weaker tracker/narration snippets and are sent as canonical visual guidance for portrait prompts.
 - Fixed launcher startup ordering so `.env` values such as `BACKGROUNDREMOVER_AUTO_INSTALL=true` are loaded before optional background-remover setup begins (#3269).
 - Fixed Home Assistant documentation and defaults to point at Marinara's current port, note `WEBHOOK_LOCAL_URLS_ENABLED=true` for local webhooks, and explain that re-syncing updates existing generated tools.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,8 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 ### Fixed
 
 - Fixed character library favorites and non-favorites filtering so server-side pagination searches the full library before returning each 100-item page, and separated the **Load more** control from character cards for large libraries (#3286).
+- Fixed Roleplay `/as` so `/as Character "message"` posts the exact message as that character, while bare `/as Character` still asks the model to generate that character's next response.
+- Fixed Game Mode NPC portrait generation so GM-created NPC profile descriptions from initial world setup take priority over weaker tracker/narration snippets and are sent as canonical visual guidance for portrait prompts.
 - Fixed launcher startup ordering so `.env` values such as `BACKGROUNDREMOVER_AUTO_INSTALL=true` are loaded before optional background-remover setup begins (#3269).
 - Fixed Home Assistant documentation and defaults to point at Marinara's current port, note `WEBHOOK_LOCAL_URLS_ENABLED=true` for local webhooks, and explain that re-syncing updates existing generated tools.
 - Added delete controls to Character and Persona Gallery Clips, including call-video resets plus custom call clip and scene/game clip cleanup from the originating stored media.

--- a/packages/client/src/components/chat/ChatInput.tsx
+++ b/packages/client/src/components/chat/ChatInput.tsx
@@ -616,7 +616,10 @@ export const ChatInput = memo(function ChatInput({
       chatId: activeChatId,
       mode,
       generate: generateWithNarrativeDirector,
-      createMessage: (data) => createMessage.mutate(data),
+      createMessage: async (data) => {
+        await createMessage.mutateAsync(data);
+        requestChatScrollToBottom({ chatId: activeChatId, behavior: "auto" });
+      },
       invalidate: () => qc.invalidateQueries({ queryKey: chatKeys.all }),
       characterNames: activeCharacterNames,
       characters: activeChatCharacters,

--- a/packages/client/src/components/chat/ConversationInput.tsx
+++ b/packages/client/src/components/chat/ConversationInput.tsx
@@ -41,6 +41,7 @@ import { applyTextareaQuoteFormat } from "../../lib/textarea-quotes";
 import { translateDraftText } from "../../lib/draft-translation";
 import { prepareImageAttachment } from "../../lib/chat-attachment-images";
 import { CARD_ASSET_INSERT_EVENT, type CardAssetInsertDetail } from "../../lib/card-asset-links";
+import { requestChatScrollToBottom } from "../../lib/chat-scroll-events";
 import { QuickConnectionSwitcher } from "./QuickConnectionSwitcher";
 import { QuickPersonaSwitcher } from "./QuickPersonaSwitcher";
 import { QuickSwitcherMobile } from "./QuickSwitcherMobile";
@@ -864,7 +865,10 @@ export function ConversationInput({
         chatId: activeChatId,
         mode: "conversation",
         generate,
-        createMessage: (data) => createMessage.mutate(data),
+        createMessage: async (data) => {
+          await createMessage.mutateAsync(data);
+          requestChatScrollToBottom({ chatId: activeChatId, behavior: "auto" });
+        },
         invalidate: () => qc.invalidateQueries({ queryKey: chatKeys.all }),
         characterNames: activeCharacterNames,
         characters: activeChatCharacters?.map((character) => ({ id: character.id, name: character.name })),
@@ -1044,7 +1048,10 @@ export function ConversationInput({
           if (succeeded !== undefined) generationStatus.succeeded = succeeded;
           return succeeded;
         },
-        createMessage: (data) => createMessage.mutate(data),
+        createMessage: async (data) => {
+          await createMessage.mutateAsync(data);
+          requestChatScrollToBottom({ chatId: submittingChatId, behavior: "auto" });
+        },
         invalidate: () => qc.invalidateQueries({ queryKey: chatKeys.all }),
         characterNames: activeCharacterNames,
         characters: activeChatCharacters?.map((character) => ({ id: character.id, name: character.name })),

--- a/packages/client/src/components/game/GameSurface.tsx
+++ b/packages/client/src/components/game/GameSurface.tsx
@@ -1110,6 +1110,50 @@ function mergeSceneAssetNpcCandidates(
 ): GameNpc[] {
   const excluded = new Set(excludedNames.map(normalizeSceneAssetName));
   const candidates = new Map<string, GameNpc>();
+  const descriptionPriority = (source: GameNpc["descriptionSource"] | undefined) => {
+    switch (source) {
+      case "user":
+        return 4;
+      case "model":
+        return 3;
+      case "library":
+        return 2;
+      case "narration":
+        return 1;
+      default:
+        return 0;
+    }
+  };
+  const chooseDescription = (existing: GameNpc, incoming: GameNpc) => {
+    const existingDescription = typeof existing.description === "string" ? existing.description.trim() : "";
+    const incomingDescription = typeof incoming.description === "string" ? incoming.description.trim() : "";
+    if (!incomingDescription) {
+      return {
+        description: existingDescription,
+        descriptionSource: existing.descriptionSource || incoming.descriptionSource,
+      };
+    }
+    if (!existingDescription) {
+      return {
+        description: incomingDescription,
+        descriptionSource: incoming.descriptionSource || existing.descriptionSource,
+      };
+    }
+
+    const existingPriority = descriptionPriority(existing.descriptionSource);
+    const incomingPriority = descriptionPriority(incoming.descriptionSource);
+    if (incomingPriority > existingPriority) {
+      return {
+        description: incomingDescription,
+        descriptionSource: incoming.descriptionSource || existing.descriptionSource,
+      };
+    }
+
+    return {
+      description: existingDescription,
+      descriptionSource: existing.descriptionSource || incoming.descriptionSource,
+    };
+  };
 
   const addNpcCandidate = (npc: GameNpc) => {
     const name = typeof npc.name === "string" ? npc.name.trim() : "";
@@ -1120,10 +1164,11 @@ function mergeSceneAssetNpcCandidates(
       candidates.set(normalizedName, { ...npc, name });
       return;
     }
+    const chosenDescription = chooseDescription(existing, npc);
     candidates.set(normalizedName, {
       ...existing,
-      description: existing.description || npc.description,
-      descriptionSource: existing.descriptionSource || npc.descriptionSource,
+      description: chosenDescription.description,
+      descriptionSource: chosenDescription.descriptionSource,
       gender: existing.gender ?? npc.gender ?? null,
       pronouns: existing.pronouns ?? npc.pronouns ?? null,
       location: existing.location || npc.location,

--- a/packages/client/src/components/game/GameSurface.tsx
+++ b/packages/client/src/components/game/GameSurface.tsx
@@ -1206,6 +1206,11 @@ function mergeSceneAssetNpcCandidates(
     candidates.set(normalizedName, {
       ...existing,
       description: existing.description || description,
+      descriptionSource: existing.description
+        ? existing.descriptionSource
+        : description
+          ? (existing.descriptionSource ?? "narration")
+          : existing.descriptionSource,
       location: existing.location || currentLocation || "",
       avatarUrl: existing.avatarUrl || avatarUrl,
     });
@@ -1221,6 +1226,11 @@ function mergeSceneAssetNpcCandidates(
     candidates.set(normalizedName, {
       ...existing,
       description: existing.description || candidate.description,
+      descriptionSource: existing.description
+        ? existing.descriptionSource
+        : candidate.description
+          ? (existing.descriptionSource ?? "narration")
+          : existing.descriptionSource,
     });
   }
 

--- a/packages/client/src/lib/slash-commands.ts
+++ b/packages/client/src/lib/slash-commands.ts
@@ -46,7 +46,7 @@ export interface SlashCommandContext {
     impersonatePromptTemplate?: string;
   }) => Promise<boolean | void>;
   /** Insert a message directly into the chat (no LLM) */
-  createMessage: (data: { role: string; content: string; characterId?: string | null }) => void;
+  createMessage: (data: { role: string; content: string; characterId?: string | null }) => void | Promise<void>;
   /** Invalidate chat queries to refresh the UI */
   invalidate: () => void;
   /** Character names in the current chat */
@@ -71,7 +71,7 @@ function quoteCommandArgument(value: string): string {
   return `"${trimmed.replace(/["\\]/g, "\\$&")}"`;
 }
 
-function formatAvailableCharacterList(characters: Array<{ id: string; name: string }>): string {
+function formatAvailableCharacterList(characters: Array<{ name: string }>): string {
   return characters.map((character) => character.name).join(", ");
 }
 
@@ -236,10 +236,7 @@ function isAllEmoteTarget(value: string): boolean {
   return normalized === "all" || normalized === "*";
 }
 
-function findSceneCharacter(
-  characters: Array<{ id: string; name: string }>,
-  name: string,
-): { id: string; name: string } | null {
+function findSceneCharacter<T extends { name: string }>(characters: T[], name: string): T | null {
   const normalized = normalizeLookup(name);
   if (!normalized) return null;
   return (
@@ -247,6 +244,120 @@ function findSceneCharacter(
     characters.find((character) => normalizeLookup(character.name).includes(normalized)) ??
     null
   );
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function unescapeCommandQuotedText(value: string): string {
+  return value.replace(/\\(["'\u201c\u201d\u2018\u2019\\])/g, "$1");
+}
+
+function parseLeadingQuotedSegment(input: string): { value: string; rest: string } | null {
+  const trimmed = input.trimStart();
+  const quotePairs: Record<string, string> = {
+    '"': '"',
+    "'": "'",
+    "\u201c": "\u201d",
+    "\u2018": "\u2019",
+  };
+  const quote = trimmed[0];
+  const closingQuote = quote ? quotePairs[quote] : undefined;
+  if (!quote || !closingQuote) return null;
+
+  let escaped = false;
+  for (let i = 1; i < trimmed.length; i += 1) {
+    const char = trimmed[i];
+    if (escaped) {
+      escaped = false;
+      continue;
+    }
+    if (char === "\\") {
+      escaped = true;
+      continue;
+    }
+    if (char === closingQuote) {
+      return {
+        value: unescapeCommandQuotedText(trimmed.slice(1, i)),
+        rest: trimmed.slice(i + 1).trim(),
+      };
+    }
+  }
+
+  return null;
+}
+
+function stripSingleWrappingQuotePair(input: string): string {
+  const trimmed = input.trim();
+  const quotePairs: Record<string, string> = {
+    '"': '"',
+    "'": "'",
+    "\u201c": "\u201d",
+    "\u2018": "\u2019",
+  };
+  const opening = trimmed[0];
+  const closing = opening ? quotePairs[opening] : undefined;
+  if (opening && closing && trimmed.endsWith(closing) && trimmed.length >= 2) {
+    return unescapeCommandQuotedText(trimmed.slice(1, -1)).trim();
+  }
+  return trimmed;
+}
+
+function resolveAsCommandTarget(
+  args: string,
+  characters: Array<{ id: string | null; name: string }>,
+): { target: { id: string | null; name: string } | null; requestedName: string; message: string } {
+  const trimmed = args.trim();
+  if (!trimmed) return { target: null, requestedName: "", message: "" };
+
+  const quotedTarget = parseLeadingQuotedSegment(trimmed);
+  if (quotedTarget) {
+    const target = findSceneCharacter(characters, quotedTarget.value);
+    return {
+      target,
+      requestedName: quotedTarget.value,
+      message: stripSingleWrappingQuotePair(quotedTarget.rest),
+    };
+  }
+
+  const sortedCharacters = [...characters].sort((a, b) => b.name.length - a.name.length);
+  for (const character of sortedCharacters) {
+    const pattern = new RegExp(`^${escapeRegExp(character.name)}(?:\\s+|$)`, "iu");
+    const match = trimmed.match(pattern);
+    if (match) {
+      return {
+        target: character,
+        requestedName: character.name,
+        message: stripSingleWrappingQuotePair(trimmed.slice(match[0].length).trim()),
+      };
+    }
+  }
+
+  const tokens = parseCommandTokens(trimmed);
+  for (let length = tokens.length; length >= 1; length -= 1) {
+    const requestedName = tokens
+      .slice(0, length)
+      .map((token) => token.value)
+      .join(" ")
+      .trim();
+    const target = findSceneCharacter(characters, requestedName);
+    if (target) {
+      return {
+        target,
+        requestedName,
+        message: stripSingleWrappingQuotePair(
+          tokens
+            .slice(length)
+            .map((token) => token.value)
+            .join(" "),
+        ),
+      };
+    }
+  }
+
+  const fallbackName = tokens[0]?.value ?? trimmed;
+  return { target: null, requestedName: fallbackName, message: "" };
 }
 
 async function listSpriteExpressions(characterId: string): Promise<string[]> {
@@ -363,7 +474,7 @@ const COMMANDS: SlashCommand[] = [
       const modStr = parsed.modifier > 0 ? `+${parsed.modifier}` : parsed.modifier < 0 ? `${parsed.modifier}` : "";
       const detail = parsed.count > 1 ? ` [${rolls.join(", ")}]${modStr}` : modStr ? ` (${rolls[0]}${modStr})` : "";
       const text = `🎲 **${notation}** → **${sum}**${detail}`;
-      ctx.createMessage({ role: "narrator", content: text });
+      await ctx.createMessage({ role: "narrator", content: text });
       return { handled: true };
     },
   },
@@ -401,7 +512,7 @@ const COMMANDS: SlashCommand[] = [
     local: true,
     async execute(args, ctx) {
       if (!args.trim()) return { handled: true, feedback: "Usage: /sys <message text>" };
-      ctx.createMessage({ role: "system", content: args.trim() });
+      await ctx.createMessage({ role: "system", content: args.trim() });
       return { handled: true };
     },
   },
@@ -446,23 +557,43 @@ const COMMANDS: SlashCommand[] = [
   {
     name: "as",
     aliases: ["respond"],
-    description: "Generate a response as a specific character",
-    usage: "/as <character name>",
+    description: "Post a message as a character, or generate that character's next response",
+    usage: '/as <character name> "message" | /as <character name>',
     async execute(args, ctx) {
-      const name = args.trim();
-      if (!name) return { handled: true, feedback: "Usage: /as <character name>" };
-      const match = ctx.characterNames.find((n) => normalizeLookup(n) === normalizeLookup(name));
-      if (!match) {
+      const characters: Array<{ id: string | null; name: string }> = [...(ctx.characters ?? [])];
+      for (const name of ctx.characterNames) {
+        if (!characters.some((character) => normalizeLookup(character.name) === normalizeLookup(name))) {
+          characters.push({ id: null, name });
+        }
+      }
+      const { target, requestedName, message } = resolveAsCommandTarget(args, characters);
+      if (!args.trim()) return { handled: true, feedback: 'Usage: /as <character name> "message"' };
+      if (!target) {
         return {
           handled: true,
-          feedback: `Character "${name}" not found. Available: ${ctx.characterNames.join(", ")}`,
+          feedback: `Character "${requestedName || args.trim()}" not found. Available: ${
+            characters.length > 0 ? formatAvailableCharacterList(characters) : ctx.characterNames.join(", ")
+          }`,
         };
       }
-      // Inject instruction to respond as the specific character
+
+      if (message) {
+        if (!target.id) {
+          return {
+            handled: true,
+            feedback: `Character metadata for "${target.name}" is still loading. Try again in a moment.`,
+          };
+        }
+        await ctx.createMessage({ role: "assistant", characterId: target.id, content: message });
+        return { handled: true };
+      }
+
+      // No explicit text: preserve the existing shortcut that asks the model to
+      // continue as the named character.
       await ctx.generate({
         chatId: ctx.chatId,
         connectionId: null,
-        userMessage: `[Respond as ${match}]`,
+        userMessage: `[Respond as ${target.name}]`,
       });
       return { handled: true };
     },

--- a/packages/server/src/routes/game.routes.ts
+++ b/packages/server/src/routes/game.routes.ts
@@ -3823,10 +3823,12 @@ function resolveNpcPortraitAppearance(
 ): string {
   const parts: string[] = [];
   const metadataDescriptionIsCanonical =
-    metadataNpc?.descriptionSource === "model" || metadataNpc?.descriptionSource === "library";
+    metadataNpc?.descriptionSource === "model" ||
+    metadataNpc?.descriptionSource === "library" ||
+    metadataNpc?.descriptionSource === "user";
 
   if (metadataDescriptionIsCanonical) {
-    addPortraitAppearancePart(parts, metadataNpc?.description);
+    addPortraitAppearancePart(parts, metadataNpc?.description, "Canonical NPC profile");
   }
 
   addPortraitAppearancePart(parts, npc.description);

--- a/packages/shared/src/types/game.ts
+++ b/packages/shared/src/types/game.ts
@@ -111,7 +111,7 @@ export interface GameNpc {
   name: string;
   emoji: string;
   description: string;
-  /** Origin of the description. Only "model" descriptions should be treated as canonical profile text. */
+  /** Origin of the description. "model", "library", and "user" descriptions are canonical profile text. */
   descriptionSource?: "model" | "library" | "narration" | "user";
   /** Optional presentation hint used for systems like NPC voice matching. */
   gender?: string | null;

--- a/packages/shared/src/utils/tracker-field-locks.ts
+++ b/packages/shared/src/utils/tracker-field-locks.ts
@@ -615,7 +615,7 @@ function mergeNamedRowsWithLocks<T extends { name?: string }>(
     if (!currentRow) return row;
     if (!match.matchedByIdentity && hasLockWithPrefix(locks, prefixFor(currentRow, currentIndex))) {
       usedCurrent.add(currentIndex);
-      return row;
+      return currentRow;
     }
     usedCurrent.add(currentIndex);
     return mergeRow(row, currentRow, currentIndex);
@@ -706,7 +706,8 @@ function mergeQuestObjectivesWithLocks(
     if (!currentObjective) return objective;
     const currentPrefix = questObjectiveTrackerLockPrefix(quest, questIndex, currentObjective, currentIndex);
     if (byText < 0 && hasLockWithPrefix(locks, `${currentPrefix}.`)) {
-      return objective;
+      usedCurrent.add(currentIndex);
+      return currentObjective;
     }
     usedCurrent.add(currentIndex);
     const next = { ...objective };
@@ -753,7 +754,7 @@ function mergeQuestsWithLocks(
       hasLockWithPrefix(locks, `${questTrackerLockPrefix(currentQuest, currentIndex)}.`)
     ) {
       usedCurrent.add(currentIndex);
-      return quest;
+      return currentQuest;
     }
     usedCurrent.add(currentIndex);
     const next = { ...quest };
@@ -829,7 +830,7 @@ function mergeCharactersWithLocks(
       hasLockWithPrefix(locks, `${characterTrackerLockPrefix(currentCharacter, currentIndex)}.`)
     ) {
       usedCurrent.add(currentIndex);
-      return character;
+      return currentCharacter;
     }
     usedCurrent.add(currentIndex);
     const next = { ...character };


### PR DESCRIPTION
## Summary

Fixes two maintainer-reported behaviors:

- Roleplay `/as Character "message"` now posts the exact message as that character, while bare `/as Character` keeps the existing generated-response shortcut.
- Game Mode NPC portrait generation now preserves GM-created initial-world NPC profile descriptions as canonical portrait guidance instead of letting weaker tracker or narration snippets override them.

## Why

`/as` was only routing through a model-generation instruction (`[Respond as Character]`), so it could not post an exact authored line as a character. Game Mode portrait candidates also merged NPC descriptions with a first-non-empty rule, which meant setup-generated model descriptions could be shadowed before portrait prompts were built.

## Validation

- `pnpm check`

## Manual Verification Needed

- Manually verify `/as Dottore "Hey there"` in Roleplay posts one assistant message attributed to Dottore.
- Manually verify bare `/as Dottore` still triggers generated response behavior.
- Manually verify Game Mode NPC portrait prompt review/generation includes the GM-created initial-world NPC description for NPCs that have one.

No linked issue; maintainer-requested follow-up from chat.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Slash commands can now post an explicit quoted message for a character, and chat auto-scrolls after command-generated messages.

* **Bug Fixes**
  * `/as` now sends the exact message provided when used with quoted text.
  * Locked fields in trackers, quests, inventory, and character merges can no longer be bypassed by renaming or replacing rows.
  * NPC portrait guidance now prioritizes the most reliable profile description and labels canonical profile text more clearly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->