### PR TITLE
[codex] Fix issue sweep for connections, assets, and game backgrounds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,12 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 
 ### Fixed
 
+- Fixed root-level Connections panel dragging by adding a Custom sort order backed by saved `sortOrder`, so unfiled connections can be reordered or moved into folders the same way foldered connections can (#3295).
+- Fixed merged group Conversation autonomous-message accounting so the selected autonomous character receives the saved message attribution, follow-up count, and daily-budget count instead of every turn being charged to the first group member (#3299).
+- Fixed launcher startup messages on Windows, macOS/Linux, and Termux so they show the configured bind host instead of always claiming `127.0.0.1`, while still printing/opening a browser-friendly local URL when the bind host is `0.0.0.0` (#3300).
+- Fixed Game Assets create menus inside the in-game floating asset browser so portaled New menus and create modals no longer close the browser, empty names cannot be submitted, and failed create actions keep the modal open with the error visible (#3301).
+- Improved mobile browser compatibility by lowering the production client bundle target for Safari and replacing newer `Array.prototype.at` / `replaceAll` usage in shared/client code paths that older iOS Safari versions may not provide (#3302).
+- Fixed Game Mode background selection from Settings so a manually selected chat background overrides automatic GM scene background selection until the user removes it (#3304).
 - Fixed character library favorites and non-favorites filtering so server-side pagination searches the full library before returning each 100-item page, and kept the **Load more** control in a bottom footer instead of overlapping character cards in both the side panel and full library (#3286).
 - Fixed Roleplay `/as` so `/as Character "message"` posts the exact message as that character, while bare `/as Character` still asks the model to generate that character's next response.
 - Fixed Roleplay tracker locks so AI tracker updates cannot bypass a locked field by renaming or replacing the locked row at the same position.

--- a/packages/client/src/components/game-assets/GameAssetsBrowserView.tsx
+++ b/packages/client/src/components/game-assets/GameAssetsBrowserView.tsx
@@ -575,6 +575,7 @@ export function GameAssetsBrowserView({
       }
     } catch (err) {
       toast.error(`Action failed: ${err instanceof Error ? err.message : "Unknown error"}`);
+      return;
     }
     setModal(null);
     setModalValue("");
@@ -1018,6 +1019,7 @@ export function GameAssetsBrowserView({
       {/* Modals */}
       {modal && (
         <div
+          data-chat-floating-panel
           role="dialog"
           aria-modal="true"
           className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 backdrop-blur-sm"
@@ -1133,6 +1135,10 @@ export function GameAssetsBrowserView({
                     modal.node.type === "folder" &&
                     countItems(modal.node) > 0 &&
                     !deleteRecursive) ||
+                  ((modal.type === "create-folder" ||
+                    modal.type === "new-text-file" ||
+                    modal.type === "new-markdown-file") &&
+                    !modalValue.trim()) ||
                   ((modal.type === "move" || modal.type === "bulk-move" || modal.type === "bulk-copy") && !modalValue)
                 }
                 className={cn(

--- a/packages/client/src/components/game-assets/Toolbar.tsx
+++ b/packages/client/src/components/game-assets/Toolbar.tsx
@@ -154,6 +154,7 @@ export function Toolbar({
     open
       ? createPortal(
           <div
+            data-chat-floating-panel
             ref={ref}
             className="fixed z-[60] min-w-[10rem] rounded-lg border border-[var(--border)] bg-[var(--card)] py-1 shadow-xl"
             style={{ left: pos.x, top: pos.y }}

--- a/packages/client/src/components/game/GameCharacterSheet.tsx
+++ b/packages/client/src/components/game/GameCharacterSheet.tsx
@@ -1028,7 +1028,7 @@ export function GameCharacterSheet({
                 {Object.entries(previewGameCard.extra).map(([key, value]) => (
                   <div key={key} className="flex items-start justify-between gap-3">
                     <span className="shrink-0 capitalize text-[var(--muted-foreground)]">
-                      {key.replaceAll("_", " ")}
+                      {key.replace(/_/g, " ")}
                     </span>
                     <span className="text-right text-[var(--foreground)]/80">{value}</span>
                   </div>

--- a/packages/client/src/components/game/GameSurface.tsx
+++ b/packages/client/src/components/game/GameSurface.tsx
@@ -8981,8 +8981,12 @@ function GameSurfaceComponent({
 
   // Resolve background image URL — supports exact tag match, partial/fuzzy match, and "black" override
   const resolvedBackground = useMemo(() => {
+    if (chatBackground) {
+      return chatBackground;
+    }
+
     if (!sceneAnalysisEnabled) {
-      return chatBackground ?? undefined;
+      return undefined;
     }
 
     if (currentBackground && scopedAssetMap) {

--- a/packages/client/src/components/panels/ConnectionsPanel.tsx
+++ b/packages/client/src/components/panels/ConnectionsPanel.tsx
@@ -18,13 +18,13 @@ import {
   useUpdateConnectionFolder,
   useDeleteConnectionFolder,
   useReorderConnectionFolders,
-  useMoveConnection,
+  useReorderConnections,
 } from "../../hooks/use-connection-folders";
 import { handleFolderRenameKeyDown, useFolderRenameGesture } from "../../hooks/use-folder-rename-gesture";
 import { useTouchFolderDrag } from "../../hooks/use-touch-folder-drag";
 import { useAgentConfigs, useCreateAgent, useUpdateAgent } from "../../hooks/use-agents";
 import { useChatStore } from "../../stores/chat.store";
-import { useUIStore, type ResourcePanelSort } from "../../stores/ui.store";
+import { useUIStore, type ConnectionPanelSort } from "../../stores/ui.store";
 import { useSidecarStore } from "../../stores/sidecar.store";
 import {
   BUILT_IN_AGENTS,
@@ -572,6 +572,7 @@ type ConnectionRowData = {
   maxParallelJobs?: number;
   claudeFastMode?: boolean | string;
   folderId?: string | null;
+  sortOrder?: number;
   createdAt?: string;
   updatedAt?: string;
 };
@@ -594,6 +595,30 @@ function connectionMatchesSearch(conn: ConnectionRowData, query: string) {
     .join(" ")
     .toLowerCase();
   return haystack.includes(query);
+}
+
+function sortConnections(
+  connections: readonly ConnectionRowData[],
+  sort: ConnectionPanelSort,
+): ConnectionRowData[] {
+  if (sort === "custom") {
+    return [...connections].sort((a, b) => {
+      const aOrder =
+        typeof a.sortOrder === "number" && Number.isFinite(a.sortOrder) ? a.sortOrder : Number.MAX_SAFE_INTEGER;
+      const bOrder =
+        typeof b.sortOrder === "number" && Number.isFinite(b.sortOrder) ? b.sortOrder : Number.MAX_SAFE_INTEGER;
+      const orderDiff = aOrder - bOrder;
+      if (orderDiff !== 0) return orderDiff;
+      return (a.name ?? "").localeCompare(b.name ?? "");
+    });
+  }
+
+  return sortBasicPanelItems(
+    connections,
+    sort,
+    (connection) => connection.name,
+    (connection) => connection.createdAt || connection.updatedAt,
+  );
 }
 
 function formatDefaultConnectionOption(connection: ConnectionRowData, fallbackModelLabel: string): string {
@@ -823,6 +848,7 @@ function ConnectionRow({
   isDragging,
   onDragStart,
   onDragEnd,
+  onDropOnRow,
   onTouchStart,
   suppressClickRef,
   onImagePick,
@@ -835,6 +861,7 @@ function ConnectionRow({
   isDragging: boolean;
   onDragStart: (event: React.DragEvent<HTMLDivElement>) => void;
   onDragEnd: () => void;
+  onDropOnRow: (event: React.DragEvent<HTMLDivElement>) => void;
   onTouchStart?: (event: TouchEvent<HTMLButtonElement>) => void;
   suppressClickRef?: { current: boolean };
   onImagePick: () => void;
@@ -858,6 +885,7 @@ function ConnectionRow({
 
   return (
     <div
+      data-connection-id={conn.id}
       data-touch-drag-card="connection"
       onClick={() => {
         if (suppressClickRef?.current) return;
@@ -866,6 +894,11 @@ function ConnectionRow({
       draggable
       onDragStart={onDragStart}
       onDragEnd={onDragEnd}
+      onDragOver={(event) => {
+        event.preventDefault();
+        event.dataTransfer.dropEffect = "move";
+      }}
+      onDrop={onDropOnRow}
       className={cn(
         "group relative flex touch-pan-y cursor-pointer items-center gap-3 rounded-xl p-2.5 transition-all hover:bg-[var(--sidebar-accent)]",
         isSelected && `ring-1 ${colors.ring} bg-[var(--sidebar-accent)]/50`,
@@ -1163,7 +1196,7 @@ export function ConnectionsPanel() {
   const updateFolderMut = useUpdateConnectionFolder();
   const deleteFolderMut = useDeleteConnectionFolder();
   const reorderFoldersMut = useReorderConnectionFolders();
-  const moveConnectionMut = useMoveConnection();
+  const reorderConnectionsMut = useReorderConnections();
 
   const [draggedConnectionId, setDraggedConnectionId] = useState<string | null>(null);
   const [selectionMode, setSelectionMode] = useState(false);
@@ -1179,15 +1212,10 @@ export function ConnectionsPanel() {
     const query = search.trim().toLowerCase();
     return connectionsList.filter((connection) => connectionMatchesSearch(connection, query));
   }, [connectionsList, search]);
-  const sortedConnections = useMemo(
-    () =>
-      sortBasicPanelItems(
-        filteredConnections,
-        sort,
-        (connection) => connection.name,
-        (connection) => connection.createdAt || connection.updatedAt,
-      ),
-    [filteredConnections, sort],
+  const sortedConnections = useMemo(() => sortConnections(filteredConnections, sort), [filteredConnections, sort]);
+  const sortedConnectionsForReorder = useMemo(
+    () => sortConnections(connectionsList, sort),
+    [connectionsList, sort],
   );
   const searchActive = search.trim().length > 0;
 
@@ -1272,20 +1300,71 @@ export function ConnectionsPanel() {
     setSelectedConnectionIds(new Set());
   }, []);
 
-  const handleDropConnectionsToFolder = useCallback(
-    (connectionIds: string[], folderId: string | null) => {
-      const ids = Array.from(new Set(connectionIds.filter(Boolean)));
-      for (const connectionId of ids) {
-        moveConnectionMut.mutate({ connectionId, folderId });
-      }
+  const getConnectionsInFolder = useCallback(
+    (folderId: string | null) =>
+      sortedConnectionsForReorder.filter((connection) => {
+        if (folderId) return connection.folderId === folderId;
+        return !(connection.folderId && sortedFolders.some((folder) => folder.id === connection.folderId));
+      }),
+    [sortedConnectionsForReorder, sortedFolders],
+  );
+
+  const reorderConnectionsInFolder = useCallback(
+    (connectionIds: string[], folderId: string | null, targetConnectionId?: string) => {
+      const draggedIds = Array.from(new Set(connectionIds.filter(Boolean)));
+      if (draggedIds.length === 0) return;
+      if (targetConnectionId && draggedIds.includes(targetConnectionId)) return;
+
+      const bucketIds = getConnectionsInFolder(folderId).map((connection) => connection.id);
+      const withoutDragged = bucketIds.filter((id) => !draggedIds.includes(id));
+      const insertIndex = targetConnectionId ? withoutDragged.indexOf(targetConnectionId) : withoutDragged.length;
+      const safeInsertIndex = insertIndex >= 0 ? insertIndex : withoutDragged.length;
+      const orderedConnectionIds = [
+        ...withoutDragged.slice(0, safeInsertIndex),
+        ...draggedIds,
+        ...withoutDragged.slice(safeInsertIndex),
+      ];
+
+      if (orderedConnectionIds.length === 0) return;
+      if (sort !== "custom") setSort("custom");
+      reorderConnectionsMut.mutate({ orderedConnectionIds, folderId });
       setDraggedConnectionId(null);
     },
-    [moveConnectionMut],
+    [getConnectionsInFolder, reorderConnectionsMut, setSort, sort],
+  );
+
+  const handleDropConnectionsToFolder = useCallback(
+    (connectionIds: string[], folderId: string | null) => {
+      reorderConnectionsInFolder(connectionIds, folderId);
+    },
+    [reorderConnectionsInFolder],
+  );
+
+  const handleDropConnectionsOnRow = useCallback(
+    (connectionIds: string[], targetConnectionId: string) => {
+      const targetConnection = connectionsList.find((connection) => connection.id === targetConnectionId);
+      if (!targetConnection) return;
+      const folderId =
+        targetConnection.folderId && sortedFolders.some((folder) => folder.id === targetConnection.folderId)
+          ? targetConnection.folderId
+          : null;
+      reorderConnectionsInFolder(connectionIds, folderId, targetConnectionId);
+    },
+    [connectionsList, reorderConnectionsInFolder, sortedFolders],
   );
 
   const finishConnectionTouchDrag = useCallback(
     (connectionId: string, x: number, y: number) => {
       const target = document.elementFromPoint(x, y);
+      const connectionElement = target?.closest("[data-connection-id]") as HTMLElement | null;
+      const targetConnectionId = connectionElement?.dataset.connectionId ?? null;
+      if (targetConnectionId && targetConnectionId !== connectionId) {
+        handleDropConnectionsOnRow(getDraggedConnectionIds(connectionId), targetConnectionId);
+        window.setTimeout(() => {
+          suppressConnectionClickRef.current = false;
+        }, 0);
+        return;
+      }
       const folderElement = target?.closest("[data-connection-folder-id]") as HTMLElement | null;
       const rootElement = target?.closest("[data-connection-folder-root]") as HTMLElement | null;
       const folderId = folderElement?.dataset.connectionFolderId ?? null;
@@ -1298,7 +1377,7 @@ export function ConnectionsPanel() {
         suppressConnectionClickRef.current = false;
       }, 0);
     },
-    [getDraggedConnectionIds, handleDropConnectionsToFolder],
+    [getDraggedConnectionIds, handleDropConnectionsOnRow, handleDropConnectionsToFolder],
   );
 
   const cancelConnectionTouchDrag = useCallback((_connectionId: string, wasActive: boolean) => {
@@ -1457,6 +1536,19 @@ export function ConnectionsPanel() {
           event.dataTransfer.setData("text/plain", conn.id);
         }}
         onDragEnd={() => setDraggedConnectionId(null)}
+        onDropOnRow={(event) => {
+          event.preventDefault();
+          event.stopPropagation();
+          const payload = event.dataTransfer.getData("application/x-marinara-connection-ids");
+          const fallbackId =
+            event.dataTransfer.getData("application/x-marinara-connection-id") ||
+            event.dataTransfer.getData("text/plain") ||
+            draggedConnectionId;
+          handleDropConnectionsOnRow(
+            payload ? (JSON.parse(payload) as string[]) : fallbackId ? [fallbackId] : [],
+            conn.id,
+          );
+        }}
         onTouchStart={(event) => {
           startConnectionTouchDrag(event, conn.id, {
             allowInteractiveTarget: true,
@@ -1532,11 +1624,12 @@ export function ConnectionsPanel() {
         <div className="relative">
           <select
             value={sort}
-            onChange={(event) => setSort(event.target.value as ResourcePanelSort)}
+            onChange={(event) => setSort(event.target.value as ConnectionPanelSort)}
             className="mari-chrome-field mari-chrome-sort-field mari-accent-animated h-10 appearance-none py-0 pl-2.5 pr-7 text-[0.6875rem] md:h-9"
             title="Sort order"
             aria-label="Sort connections"
           >
+            <option value="custom">Custom</option>
             <option value="name-asc">A-Z</option>
             <option value="name-desc">Z-A</option>
             <option value="newest">Newest</option>

--- a/packages/client/src/hooks/use-connection-folders.ts
+++ b/packages/client/src/hooks/use-connection-folders.ts
@@ -71,3 +71,12 @@ export function useMoveConnection() {
     onSuccess: () => qc.invalidateQueries({ queryKey: connectionKeys.list() }),
   });
 }
+
+export function useReorderConnections() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (data: { orderedConnectionIds: string[]; folderId: string | null }) =>
+      api.post("/connection-folders/reorder-connections", data),
+    onSuccess: () => qc.invalidateQueries({ queryKey: connectionKeys.list() }),
+  });
+}

--- a/packages/client/src/stores/ui.store.ts
+++ b/packages/client/src/stores/ui.store.ts
@@ -44,6 +44,14 @@ export const LOREBOOK_PANEL_SORT_OPTIONS = ["name-asc", "name-desc", "newest", "
 export type LorebookPanelSort = (typeof LOREBOOK_PANEL_SORT_OPTIONS)[number];
 export const RESOURCE_PANEL_SORT_OPTIONS = BASIC_PANEL_SORT_OPTIONS;
 export type ResourcePanelSort = BasicPanelSort;
+export const CONNECTION_PANEL_SORT_OPTIONS = [...BASIC_PANEL_SORT_OPTIONS, "custom"] as const;
+export type ConnectionPanelSort = (typeof CONNECTION_PANEL_SORT_OPTIONS)[number];
+
+function normalizeConnectionPanelSort(value: unknown): ConnectionPanelSort {
+  return CONNECTION_PANEL_SORT_OPTIONS.includes(value as ConnectionPanelSort)
+    ? (value as ConnectionPanelSort)
+    : "name-asc";
+}
 type FontSize = 12 | 14 | 16 | 17 | 19 | 22;
 export type VisualTheme = "default" | "sillytavern";
 export type ConversationMessageStyle = "classic" | "bubble";
@@ -481,7 +489,7 @@ interface UIState {
   /** Sort order for the compact Presets panel */
   presetPanelSort: ResourcePanelSort;
   /** Sort order for the compact Connections panel */
-  connectionPanelSort: ResourcePanelSort;
+  connectionPanelSort: ConnectionPanelSort;
   /** Sort order for the compact Agents panel */
   agentPanelSort: ResourcePanelSort;
   /** True when any open detail editor has unsaved changes */
@@ -761,7 +769,7 @@ interface UIState {
   setLorebookPanelTagsExpanded: (expanded: boolean) => void;
   setBotBrowserPanelSort: (sort: ResourcePanelSort) => void;
   setPresetPanelSort: (sort: ResourcePanelSort) => void;
-  setConnectionPanelSort: (sort: ResourcePanelSort) => void;
+  setConnectionPanelSort: (sort: ConnectionPanelSort) => void;
   setAgentPanelSort: (sort: ResourcePanelSort) => void;
   openCharacterDetail: (id: string, options?: { preserveCharacterLibrary?: boolean }) => void;
   closeCharacterDetail: () => void;
@@ -1161,7 +1169,7 @@ export const useUIStore = create<UIState>()(
       lorebookPanelTagsExpanded: false,
       botBrowserPanelSort: "name-asc" as ResourcePanelSort,
       presetPanelSort: "name-asc" as ResourcePanelSort,
-      connectionPanelSort: "name-asc" as ResourcePanelSort,
+      connectionPanelSort: "name-asc" as ConnectionPanelSort,
       agentPanelSort: "name-asc" as ResourcePanelSort,
       editorDirty: false,
       detailReturnRightPanel: null,
@@ -1404,7 +1412,7 @@ export const useUIStore = create<UIState>()(
       setLorebookPanelTagsExpanded: (expanded) => set({ lorebookPanelTagsExpanded: expanded }),
       setBotBrowserPanelSort: (sort) => set({ botBrowserPanelSort: normalizeBasicPanelSort(sort) }),
       setPresetPanelSort: (sort) => set({ presetPanelSort: normalizeBasicPanelSort(sort) }),
-      setConnectionPanelSort: (sort) => set({ connectionPanelSort: normalizeBasicPanelSort(sort) }),
+      setConnectionPanelSort: (sort) => set({ connectionPanelSort: normalizeConnectionPanelSort(sort) }),
       setAgentPanelSort: (sort) => set({ agentPanelSort: normalizeBasicPanelSort(sort) }),
       openCharacterDetail: (id, options) =>
         set((s) => {
@@ -2433,7 +2441,7 @@ export const useUIStore = create<UIState>()(
         persisted.lorebookPanelTagsExpanded = persisted.lorebookPanelTagsExpanded === true;
         persisted.botBrowserPanelSort = normalizeBasicPanelSort(persisted.botBrowserPanelSort);
         persisted.presetPanelSort = normalizeBasicPanelSort(persisted.presetPanelSort);
-        persisted.connectionPanelSort = normalizeBasicPanelSort(persisted.connectionPanelSort);
+        persisted.connectionPanelSort = normalizeConnectionPanelSort(persisted.connectionPanelSort);
         persisted.agentPanelSort = normalizeBasicPanelSort(persisted.agentPanelSort);
         normalizePersistedMainSurface(persisted);
         if (Array.isArray(persisted.recentUserActivities)) {

--- a/packages/client/vite.config.ts
+++ b/packages/client/vite.config.ts
@@ -126,6 +126,8 @@ export default defineConfig({
   },
   build: {
     outDir: "dist",
+    target: "es2020",
+    cssTarget: "safari14",
     sourcemap: ENABLE_SOURCE_MAPS,
     rollupOptions: {
       output: {

--- a/packages/server/src/routes/generate.routes.ts
+++ b/packages/server/src/routes/generate.routes.ts
@@ -7934,7 +7934,10 @@ export async function generateRoutes(app: FastifyInstance) {
         } else {
           // Single/merged: one generation
           sendProgress("generating");
-          let targetCharId = characterIds[0] ?? null;
+          let targetCharId =
+            typeof input.forCharacterId === "string" && characterIds.includes(input.forCharacterId)
+              ? input.forCharacterId
+              : (characterIds[0] ?? null);
           const sentMessages = [...finalMessages];
 
           if (generationGuideInstruction) {

--- a/packages/shared/src/utils/macro-engine.ts
+++ b/packages/shared/src/utils/macro-engine.ts
@@ -566,7 +566,7 @@ function stripOuterQuotes(value: string): string | null {
   const trimmed = value.trim();
   if (trimmed.length < 2) return null;
   const openingKind = quoteKind(trimmed[0]);
-  if (!openingKind || quoteKind(trimmed.at(-1)) !== openingKind) return null;
+  if (!openingKind || quoteKind(trimmed[trimmed.length - 1]) !== openingKind) return null;
   return trimmed
     .slice(1, -1)
     .replace(/\\(["'\u2018\u2019\u201a\u201b\u201c\u201d\u201e\u201f\\])/g, "$1")
@@ -1023,7 +1023,7 @@ function pickWeightedRandomChoice(choices: string[], options: ResolveMacroOption
     if (roll < 0) return choice.text;
   }
 
-  return weightedChoices.at(-1)?.text ?? "";
+  return weightedChoices[weightedChoices.length - 1]?.text ?? "";
 }
 
 type MacroDateTimeParts = {

--- a/packages/shared/src/utils/regex-replacement.ts
+++ b/packages/shared/src/utils/regex-replacement.ts
@@ -239,10 +239,11 @@ export function applyRegexReplacement(
 ): string {
   const preparedReplacement = prepareLiteralMacroPlaceholders(replacement, resolveReplacement);
   return text.replace(regex, (...args: unknown[]) => {
-    const hasGroups = typeof args.at(-1) === "object" && args.at(-1) !== null;
-    const groups = hasGroups ? (args.at(-1) as Record<string, string>) : undefined;
-    const input = args.at(hasGroups ? -2 : -1) as string;
-    const offset = args.at(hasGroups ? -3 : -2) as number;
+    const lastArg = args[args.length - 1];
+    const hasGroups = typeof lastArg === "object" && lastArg !== null;
+    const groups = hasGroups ? (lastArg as Record<string, string>) : undefined;
+    const input = args[args.length - (hasGroups ? 2 : 1)] as string;
+    const offset = args[args.length - (hasGroups ? 3 : 2)] as number;
     const match = args[0] as string;
     const captures = args.slice(1, hasGroups ? -3 : -2).map((capture) => (capture == null ? "" : String(capture)));
     const expanded = expandRegexReplacement(preparedReplacement.template, {

--- a/start-termux.sh
+++ b/start-termux.sh
@@ -340,6 +340,11 @@ else
   PROTOCOL=http
 fi
 
+BROWSER_HOST="$HOST"
+case "$BROWSER_HOST" in
+  ""|"0.0.0.0"|"::") BROWSER_HOST="127.0.0.1" ;;
+esac
+
 AUTO_OPEN_BROWSER_VALUE="${AUTO_OPEN_BROWSER:-true}"
 case "${AUTO_OPEN_BROWSER_VALUE,,}" in
   0|false|no|off) AUTO_OPEN_BROWSER_ENABLED=0 ;;
@@ -355,7 +360,10 @@ fi
 # ── Start ──
 echo ""
 echo "  ══════════════════════════════════════════"
-echo "    Starting Marinara Engine on ${PROTOCOL}://127.0.0.1:${PORT}"
+echo "    Starting Marinara Engine on ${PROTOCOL}://${HOST}:${PORT}"
+if [ "$BROWSER_HOST" != "$HOST" ]; then
+echo "    Local browser URL: ${PROTOCOL}://${BROWSER_HOST}:${PORT}"
+fi
 if [ -n "$LOCAL_IP" ]; then
 echo "    LAN access: ${PROTOCOL}://${LOCAL_IP}:${PORT}"
 fi
@@ -367,7 +375,7 @@ echo ""
 
 # Open in Termux browser if available (no-op if not)
 if [ "$AUTO_OPEN_BROWSER_ENABLED" = "1" ] && command -v termux-open-url &> /dev/null; then
-    (sleep 3 && termux-open-url "${PROTOCOL}://127.0.0.1:${PORT}") &
+    (sleep 3 && termux-open-url "${PROTOCOL}://${BROWSER_HOST}:${PORT}") &
 elif [ "$AUTO_OPEN_BROWSER_ENABLED" != "1" ]; then
     echo "  [OK] Auto-open disabled (AUTO_OPEN_BROWSER=${AUTO_OPEN_BROWSER_VALUE})"
 fi

--- a/start.bat
+++ b/start.bat
@@ -293,6 +293,10 @@ if not defined SIDECAR_RUNTIME_INSTALL_ENABLED set SIDECAR_RUNTIME_INSTALL_ENABL
 
 set PROTOCOL=http
 if defined SSL_CERT if defined SSL_KEY set PROTOCOL=https
+set "BROWSER_HOST=%HOST%"
+if "%BROWSER_HOST%"=="" set "BROWSER_HOST=127.0.0.1"
+if "%BROWSER_HOST%"=="0.0.0.0" set "BROWSER_HOST=127.0.0.1"
+if "%BROWSER_HOST%"=="::" set "BROWSER_HOST=127.0.0.1"
 
 set "AUTO_OPEN_BROWSER_ENABLED=1"
 if defined AUTO_OPEN_BROWSER (
@@ -310,14 +314,15 @@ if errorlevel 1 (
 
 echo.
 echo  ==========================================
-echo    Starting Marinara Engine on %PROTOCOL%://127.0.0.1:%PORT%
+echo    Starting Marinara Engine on %PROTOCOL%://%HOST%:%PORT%
+if not "%BROWSER_HOST%"=="%HOST%" echo    Local browser URL: %PROTOCOL%://%BROWSER_HOST%:%PORT%
 echo    Press Ctrl+C to stop
 echo  ==========================================
 echo.
 
 :: Open browser after a short delay (use explorer.exe as fallback)
 if defined AUTO_OPEN_BROWSER_ENABLED (
-    start "" cmd /c "timeout /t 4 /nobreak >nul && start %PROTOCOL%://127.0.0.1:%PORT% || explorer %PROTOCOL%://127.0.0.1:%PORT%"
+    start "" cmd /c "timeout /t 4 /nobreak >nul && start %PROTOCOL%://%BROWSER_HOST%:%PORT% || explorer %PROTOCOL%://%BROWSER_HOST%:%PORT%"
 ) else (
     echo  [OK] Auto-open disabled ^(AUTO_OPEN_BROWSER=%AUTO_OPEN_BROWSER%^)
 )

--- a/start.sh
+++ b/start.sh
@@ -258,6 +258,11 @@ else
   PROTOCOL=http
 fi
 
+BROWSER_HOST="$HOST"
+case "$BROWSER_HOST" in
+  ""|"0.0.0.0"|"::") BROWSER_HOST="127.0.0.1" ;;
+esac
+
 AUTO_OPEN_BROWSER_VALUE="${AUTO_OPEN_BROWSER:-true}"
 AUTO_OPEN_BROWSER_NORMALIZED=$(printf '%s' "$AUTO_OPEN_BROWSER_VALUE" | tr '[:upper:]' '[:lower:]')
 case "$AUTO_OPEN_BROWSER_NORMALIZED" in
@@ -271,14 +276,17 @@ fi
 
 echo ""
 echo "  ══════════════════════════════════════════"
-echo "    Starting Marinara Engine on ${PROTOCOL}://127.0.0.1:$PORT"
+echo "    Starting Marinara Engine on ${PROTOCOL}://${HOST}:$PORT"
+if [ "$BROWSER_HOST" != "$HOST" ]; then
+echo "    Local browser URL: ${PROTOCOL}://${BROWSER_HOST}:$PORT"
+fi
 echo "    Press Ctrl+C to stop"
 echo "  ══════════════════════════════════════════"
 echo ""
 
 # Open browser after a short delay
 if [ "$AUTO_OPEN_BROWSER_ENABLED" = "1" ]; then
-  (sleep 3 && open "${PROTOCOL}://127.0.0.1:$PORT" 2>/dev/null || xdg-open "${PROTOCOL}://127.0.0.1:$PORT" 2>/dev/null) &
+  (sleep 3 && open "${PROTOCOL}://${BROWSER_HOST}:$PORT" 2>/dev/null || xdg-open "${PROTOCOL}://${BROWSER_HOST}:$PORT" 2>/dev/null) &
 else
   echo "  [OK] Auto-open disabled (AUTO_OPEN_BROWSER=${AUTO_OPEN_BROWSER_VALUE})"
 fi


### PR DESCRIPTION
## Summary
- Fix root-level Connections drag/reorder by adding a persistent Custom sort backed by connection `sortOrder`.
- Fix merged group Conversation autonomous message attribution so the requested character receives the saved message/count.
- Fix Game Mode background overrides, Game Assets create-modal behavior, launcher host messaging, and older mobile browser compatibility.
- Update the v2.1.0 changelog for the addressed issues.

Closes #3295
Closes #3299
Closes #3300
Closes #3301
Closes #3302
Closes #3304

## Validation
- `pnpm check`

## Manual Verification Needed
- [ ] Drag unfiled Connections around the root list and into folders on desktop/mobile.
- [ ] Confirm merged group autonomous messages count against the selected character.
- [ ] Verify Game Assets create-folder/file actions stay inside the floating browser and show errors without closing.
- [ ] Verify manual Game Mode background selection overrides automatic scene backgrounds.
- [ ] Smoke-test launcher host output with default host and `HOST=0.0.0.0`.
- [ ] Smoke-test the production build on an older mobile Safari target if available.