### PR TITLE
[codex] Polish conversation calls and media clips

### DIFF
--- a/packages/client/src/App.tsx
+++ b/packages/client/src/App.tsx
@@ -4,7 +4,6 @@
 import { Component, lazy, Suspense, useEffect, useMemo, type ErrorInfo, type ReactNode } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { APP_VERSION } from "@marinara-engine/shared";
-import { AppShell } from "./components/layout/AppShell";
 import { CustomThemeInjector } from "./components/layout/CustomThemeInjector";
 import { ModelDownloadModal } from "./components/modals/ModelDownloadModal";
 import { AppDialogRenderer } from "./components/ui/AppDialogRenderer";
@@ -36,6 +35,9 @@ const VERSION_RECOVERY_KEY = "marinara:pwa-version-recovery";
 const VERSION_CHECK_INTERVAL_MS = 5 * 60_000;
 const LazyModalRenderer = lazy(() =>
   import("./components/layout/ModalRenderer").then((module) => ({ default: module.ModalRenderer })),
+);
+const LazyAppShell = lazy(() =>
+  import("./components/layout/AppShell").then((module) => ({ default: module.AppShell })),
 );
 
 type HealthResponse = {
@@ -137,11 +139,7 @@ export class AppRecoveryBoundary extends Component<{ children: ReactNode }, { er
             >
               Reload
             </button>
-            <button
-              type="button"
-              onClick={this.resetLocalUiState}
-              className="mari-chrome-control px-3 py-2 text-sm"
-            >
+            <button type="button" onClick={this.resetLocalUiState} className="mari-chrome-control px-3 py-2 text-sm">
               Reset local UI state
             </button>
           </div>
@@ -612,10 +610,7 @@ export function App() {
       if (cursorRecolorFreezeTimer !== null) {
         window.clearTimeout(cursorRecolorFreezeTimer);
       }
-      cursorRecolorFreezeTimer = window.setTimeout(
-        unfreezeCursorRecolor,
-        CUSTOM_CURSOR_RECOLOR_SCROLL_FREEZE_MS,
-      );
+      cursorRecolorFreezeTimer = window.setTimeout(unfreezeCursorRecolor, CUSTOM_CURSOR_RECOLOR_SCROLL_FREEZE_MS);
     };
 
     const setAccentModeDataset = () => {
@@ -895,7 +890,9 @@ export function App() {
     <>
       <CustomThemeInjector />
       <ChibiProfessorMariEasterEgg />
-      <AppShell />
+      <Suspense fallback={null}>
+        <LazyAppShell />
+      </Suspense>
       {!isLite && <ModelDownloadModal open={showDownloadModal} onClose={() => setShowDownloadModal(false)} />}
       {hasModalOpen && (
         <Suspense fallback={null}>

--- a/packages/client/src/components/characters/CharacterEditor.tsx
+++ b/packages/client/src/components/characters/CharacterEditor.tsx
@@ -3,15 +3,7 @@
 // Replaces the chat area when editing a character.
 // Sections: Metadata, Card, Lorebook, Advanced
 // ──────────────────────────────────────────────
-import {
-  useState,
-  useEffect,
-  useRef,
-  useCallback,
-  type ChangeEvent,
-  type ReactNode,
-  type SyntheticEvent,
-} from "react";
+import { useState, useEffect, useRef, useCallback, type ChangeEvent, type ReactNode, type SyntheticEvent } from "react";
 import { toast } from "sonner";
 import { useQueryClient } from "@tanstack/react-query";
 import {
@@ -31,6 +23,7 @@ import {
   useDeleteCharacterGalleryClip,
   useUpdateCharacterGalleryClipTrim,
   useUploadCharacterGalleryClip,
+  useUploadCharacterGalleryVideo,
   useTagCharacterGalleryImage,
   useGenerateCharacterCallVideoClips,
   useUploadSprite,
@@ -43,6 +36,7 @@ import {
   useRestoreCharacterVersion,
   useDeleteCharacterVersion,
   spriteKeys,
+  type CharacterCallVideoGenerationInput,
   type CharacterGalleryClip,
   type CharacterGalleryImage,
   type SpriteInfo,
@@ -54,6 +48,7 @@ import { showConfirmDialog } from "../../lib/app-dialogs";
 import { SpriteGenerationModal } from "../ui/SpriteGenerationModal";
 import { AvatarGenerationModal } from "../ui/AvatarGenerationModal";
 import { AvatarCropWidget } from "../ui/AvatarCropWidget";
+import { CallClipGenerationModal } from "../ui/CallClipGenerationModal";
 import { ImageUploadDropzone } from "../ui/ImageUploadDropzone";
 import { CustomEmojiTagButton } from "../ui/CustomEmojiTagButton";
 import { CharacterRegexSection } from "./CharacterRegexSection";
@@ -112,6 +107,7 @@ import {
   syncRpgHpFromPools,
   type CharacterCardVersion,
   type CharacterData,
+  type ConversationCallCharacterVideoClipKind,
   type RPGStatPool,
   type RPGStatsConfig,
 } from "@marinara-engine/shared";
@@ -1895,8 +1891,10 @@ function characterGalleryClipSourceLabel(source: CharacterGalleryClip["source"])
       return "Game scene";
     case "scene-video":
       return "Scene video";
+    case "uploaded-video":
+      return "Uploaded video";
     default:
-      return "Clip";
+      return "Video";
   }
 }
 
@@ -1920,6 +1918,10 @@ function characterGalleryClipDeleteMessage(clip: CharacterGalleryClip) {
 
 function isCharacterCallVideoClip(clip: CharacterGalleryClip) {
   return clip.source === "conversation-call" || clip.source === "conversation-call-custom";
+}
+
+function isCharacterGalleryVideoClip(clip: CharacterGalleryClip) {
+  return !isCharacterCallVideoClip(clip);
 }
 
 function forceSilentCharacterCallClipVideo(video: HTMLVideoElement | null) {
@@ -2022,14 +2024,14 @@ function CharacterGalleryTab({ characterId, characterName }: { characterId: stri
     <div className="space-y-6">
       <SectionHeader
         title="Character Gallery"
-        subtitle="Keep character images and generated clips attached to this character even if chats get deleted."
+        subtitle="Keep character images and generated videos attached to this character even if chats get deleted."
         helpText={CHARACTER_GALLERY_HELP}
       />
 
       <div className="inline-flex rounded-xl border border-[var(--border)] bg-[var(--secondary)] p-1">
         {[
           { id: "images" as const, label: "Images", icon: Camera, count: images?.length ?? 0 },
-          { id: "clips" as const, label: "Clips", icon: Film, count: null },
+          { id: "clips" as const, label: "Videos", icon: Film, count: null },
         ].map((tab) => {
           const Icon = tab.icon;
           const active = mediaTab === tab.id;
@@ -2131,7 +2133,7 @@ function CharacterGalleryTab({ characterId, characterName }: { characterId: stri
           )}
         </>
       ) : (
-        <CharacterClipsGallery characterId={characterId} characterName={characterName} />
+        <CharacterVideosGallery characterId={characterId} characterName={characterName} />
       )}
 
       {lightbox && (
@@ -2168,7 +2170,129 @@ function CharacterGalleryTab({ characterId, characterName }: { characterId: stri
   );
 }
 
-function CharacterClipsGallery({ characterId, characterName }: { characterId: string; characterName?: string }) {
+function CharacterVideosGallery({ characterId, characterName }: { characterId: string; characterName?: string }) {
+  const { data, isLoading } = useCharacterGalleryClips(characterId);
+  const deleteClip = useDeleteCharacterGalleryClip(characterId);
+  const uploadVideo = useUploadCharacterGalleryVideo(characterId);
+  const [deletingClipId, setDeletingClipId] = useState<string | null>(null);
+  const videoUploadInputRef = useRef<HTMLInputElement | null>(null);
+  const clips = (data?.clips ?? []).filter(isCharacterGalleryVideoClip);
+
+  const handleUploadClipFile = useCallback(
+    async (event: ChangeEvent<HTMLInputElement>) => {
+      const file = event.target.files?.[0];
+      event.target.value = "";
+      if (!file) return;
+
+      try {
+        await uploadVideo.mutateAsync({ file });
+        toast.success("Video uploaded.");
+      } catch (error) {
+        toast.error(error instanceof Error ? error.message : "Could not upload video.");
+      }
+    },
+    [uploadVideo],
+  );
+
+  const handleDeleteClip = useCallback(
+    async (clip: CharacterGalleryClip) => {
+      if (!canDeleteCharacterGalleryClip(clip)) return;
+      if (
+        !(await showConfirmDialog({
+          title: "Delete Clip",
+          message: characterGalleryClipDeleteMessage(clip),
+          confirmLabel: "Delete",
+          tone: "destructive",
+        }))
+      ) {
+        return;
+      }
+
+      setDeletingClipId(clip.id);
+      try {
+        await deleteClip.mutateAsync(clip.id);
+        toast.success("Video deleted.");
+      } catch (error) {
+        toast.error(error instanceof Error ? error.message : "Could not delete video.");
+      } finally {
+        setDeletingClipId(null);
+      }
+    },
+    [deleteClip],
+  );
+
+  if (isLoading) {
+    return (
+      <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-3">
+        {Array.from({ length: 4 }).map((_, index) => (
+          <div key={index} className="shimmer aspect-video rounded-xl" />
+        ))}
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      <input
+        ref={videoUploadInputRef}
+        type="file"
+        accept="video/mp4,video/webm,video/quicktime,.mp4,.webm,.mov"
+        className="hidden"
+        onChange={handleUploadClipFile}
+      />
+      <div className="flex flex-wrap items-center justify-between gap-3 rounded-xl border border-[var(--border)] bg-[var(--card)] p-3">
+        <div className="min-w-0">
+          <p className="text-sm font-semibold text-[var(--foreground)]">Character videos</p>
+          <p className="mt-0.5 text-xs text-[var(--muted-foreground)]">
+            Generated scene videos and your own uploads attached to {characterName || "this character"}.
+          </p>
+        </div>
+        <button
+          type="button"
+          onClick={() => videoUploadInputRef.current?.click()}
+          disabled={uploadVideo.isPending}
+          className="inline-flex items-center gap-2 rounded-lg border border-[var(--border)] bg-[var(--secondary)] px-3 py-2 text-xs font-semibold text-[var(--foreground)] transition-colors hover:border-[var(--primary)]/50 disabled:cursor-not-allowed disabled:opacity-60"
+        >
+          {uploadVideo.isPending ? <Loader2 size="0.85rem" className="animate-spin" /> : <Upload size="0.85rem" />}
+          Upload video
+        </button>
+      </div>
+
+      {clips.length > 0 ? (
+        <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-3">
+          {clips.map((clip) => (
+            <CharacterClipCard
+              key={clip.id}
+              clip={clip}
+              characterName={characterName}
+              deleting={deletingClipId === clip.id}
+              generating={false}
+              uploading={false}
+              uploadDisabled
+              generationDisabled
+              onGenerate={() => undefined}
+              onUpload={() => undefined}
+              onDelete={handleDeleteClip}
+              onEditTrim={() => undefined}
+            />
+          ))}
+        </div>
+      ) : (
+        <div className="flex flex-col items-center gap-3 rounded-xl border-2 border-dashed border-[var(--border)] py-12 text-center">
+          <Film size="1.75rem" className="text-[var(--muted-foreground)]/40" />
+          <div>
+            <p className="text-sm font-medium text-[var(--muted-foreground)]">No character videos yet</p>
+            <p className="mt-0.5 text-xs text-[var(--muted-foreground)]/60">
+              Upload videos or generate scene videos with {characterName || "this character"}.
+            </p>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function CharacterCallClipsGallery({ characterId, characterName }: { characterId: string; characterName?: string }) {
   const { data, isLoading } = useCharacterGalleryClips(characterId);
   const generateCallClips = useGenerateCharacterCallVideoClips(characterId);
   const deleteClip = useDeleteCharacterGalleryClip(characterId);
@@ -2178,9 +2302,13 @@ function CharacterClipsGallery({ characterId, characterName }: { characterId: st
   const [generatingClipId, setGeneratingClipId] = useState<string | null>(null);
   const [uploadingClipId, setUploadingClipId] = useState<string | null>(null);
   const [trimClip, setTrimClip] = useState<CharacterGalleryClip | null>(null);
+  const [generationDialogOpen, setGenerationDialogOpen] = useState(false);
+  const [generationInitialKind, setGenerationInitialKind] = useState<ConversationCallCharacterVideoClipKind | null>(
+    null,
+  );
   const clipUploadInputRef = useRef<HTMLInputElement | null>(null);
   const pendingClipUploadRef = useRef<{ kind: string | null; label: string | null; clipId: string } | null>(null);
-  const clips = data?.clips ?? [];
+  const clips = (data?.clips ?? []).filter(isCharacterCallVideoClip);
   const standardCallClips = clips.filter((clip) => clip.source === "conversation-call");
   const customCallClipCount = clips.filter((clip) => clip.source === "conversation-call-custom").length;
   const readyCallClipCount = standardCallClips.filter((clip) => clip.status === "ready").length;
@@ -2190,19 +2318,30 @@ function CharacterClipsGallery({ characterId, characterName }: { characterId: st
     generateCallClips.isPending;
   const batchGenerationPending = generateCallClips.isPending && generatingClipId === null;
 
-  const handleGenerateCallClips = useCallback(async (clip?: CharacterGalleryClip) => {
-    const clipKind = clip?.source === "conversation-call" ? clip.clipKind : null;
-    if (clip && !clipKind) return;
-    setGeneratingClipId(clip?.id ?? null);
-    try {
-      await generateCallClips.mutateAsync(clipKind ? { clipKind } : undefined);
-      toast.success(clipKind ? `${clip?.label || "Call clip"} generation started.` : "Call clip generation started.");
-    } catch (error) {
-      toast.error(error instanceof Error ? error.message : "Could not start call clip generation.");
-    } finally {
-      setGeneratingClipId(null);
-    }
-  }, [generateCallClips]);
+  const openGenerationDialog = useCallback((clip?: CharacterGalleryClip) => {
+    const kind =
+      clip?.source === "conversation-call" ? (clip.clipKind as ConversationCallCharacterVideoClipKind | null) : null;
+    if (clip && !kind) return;
+    setGenerationInitialKind(kind ?? null);
+    setGenerationDialogOpen(true);
+  }, []);
+
+  const handleGenerateCallClips = useCallback(
+    async (input: CharacterCallVideoGenerationInput) => {
+      const singleKind = input.clipKinds?.length === 1 ? input.clipKinds[0] : input.clipKind;
+      setGeneratingClipId(singleKind ? `call:${singleKind}` : null);
+      try {
+        await generateCallClips.mutateAsync(input);
+        toast.success(singleKind ? "Call clip generation started." : "Call clip generation batch started.");
+        setGenerationDialogOpen(false);
+      } catch (error) {
+        toast.error(error instanceof Error ? error.message : "Could not start call clip generation.");
+      } finally {
+        setGeneratingClipId(null);
+      }
+    },
+    [generateCallClips],
+  );
 
   const handleUploadClipFile = useCallback(
     async (event: ChangeEvent<HTMLInputElement>) => {
@@ -2236,7 +2375,7 @@ function CharacterClipsGallery({ characterId, characterName }: { characterId: st
       if (clip && !kind) return;
       pendingClipUploadRef.current = {
         kind,
-        label: kind ? clip?.label ?? null : null,
+        label: kind ? (clip?.label ?? null) : null,
         clipId: clip?.id ?? "custom-call:upload",
       };
       clipUploadInputRef.current?.click();
@@ -2329,14 +2468,12 @@ function CharacterClipsGallery({ characterId, characterName }: { characterId: st
           </button>
           <button
             type="button"
-            onClick={() => void handleGenerateCallClips()}
+            onClick={() => openGenerationDialog()}
             disabled={generationLockActive}
-            className={cn(
-              "inline-flex items-center gap-2 rounded-lg bg-[var(--primary)] px-3 py-2 text-xs font-semibold text-[var(--primary-foreground)] transition-all hover:shadow-md disabled:cursor-not-allowed disabled:opacity-60",
-            )}
+            className="inline-flex items-center gap-2 rounded-lg bg-[var(--primary)] px-3 py-2 text-xs font-semibold text-[var(--primary-foreground)] transition-all hover:shadow-md disabled:cursor-not-allowed disabled:opacity-60"
           >
             {batchGenerationPending ? <Loader2 size="0.85rem" className="animate-spin" /> : <Wand2 size="0.85rem" />}
-            {batchGenerationPending ? "Generating" : "Pre-generate"}
+            {batchGenerationPending ? "Generating" : "Generate Clips"}
           </button>
         </div>
       </div>
@@ -2353,7 +2490,7 @@ function CharacterClipsGallery({ characterId, characterName }: { characterId: st
               uploading={uploadingClipId === clip.id}
               uploadDisabled={uploadClip.isPending}
               generationDisabled={generationLockActive}
-              onGenerate={handleGenerateCallClips}
+              onGenerate={openGenerationDialog}
               onUpload={handleUploadCallClip}
               onDelete={handleDeleteClip}
               onEditTrim={setTrimClip}
@@ -2364,9 +2501,9 @@ function CharacterClipsGallery({ characterId, characterName }: { characterId: st
         <div className="flex flex-col items-center gap-3 rounded-xl border-2 border-dashed border-[var(--border)] py-12 text-center">
           <Film size="1.75rem" className="text-[var(--muted-foreground)]/40" />
           <div>
-            <p className="text-sm font-medium text-[var(--muted-foreground)]">No character clips yet</p>
+            <p className="text-sm font-medium text-[var(--muted-foreground)]">No call clips yet</p>
             <p className="mt-0.5 text-xs text-[var(--muted-foreground)]/60">
-              Pre-generate call clips or generate scene videos with {characterName || "this character"}.
+              Generate or upload video-call loops for {characterName || "this character"}.
             </p>
           </div>
         </div>
@@ -2376,6 +2513,14 @@ function CharacterClipsGallery({ characterId, characterName }: { characterId: st
         saving={updateClipTrim.isPending}
         onClose={() => setTrimClip(null)}
         onSave={handleSaveTrim}
+      />
+      <CallClipGenerationModal
+        open={generationDialogOpen}
+        entityName={characterName || "this character"}
+        initialKind={generationInitialKind}
+        generating={generateCallClips.isPending}
+        onClose={() => setGenerationDialogOpen(false)}
+        onGenerate={handleGenerateCallClips}
       />
     </div>
   );
@@ -2506,7 +2651,9 @@ function CharacterClipTrimModal({
               keepCharacterCallClipVideoSilent(event);
               seekCharacterCallClipToTrimStart(event.currentTarget, previewClip);
             }}
-            onTimeUpdate={(event) => handleCharacterCallClipTimeUpdate(event.currentTarget, previewClip, { loop: true })}
+            onTimeUpdate={(event) =>
+              handleCharacterCallClipTimeUpdate(event.currentTarget, previewClip, { loop: true })
+            }
             onVolumeChange={keepCharacterCallClipVideoSilent}
           />
         </div>
@@ -2671,7 +2818,9 @@ function CharacterClipCard({
       <div className="space-y-2 p-3">
         <div className="flex items-start justify-between gap-2">
           <div className="min-w-0">
-            <p className="truncate text-sm font-semibold text-[var(--foreground)]">{clip.label || characterName || "Clip"}</p>
+            <p className="truncate text-sm font-semibold text-[var(--foreground)]">
+              {clip.label || characterName || "Clip"}
+            </p>
             <p className="mt-0.5 truncate text-[0.6875rem] text-[var(--muted-foreground)]">
               {clip.chatName ? `${clip.chatName} · ${dateLabel}` : dateLabel}
             </p>
@@ -2727,9 +2876,7 @@ function CharacterClipCard({
         {clip.prompt ? (
           <p className="line-clamp-2 text-xs leading-relaxed text-[var(--muted-foreground)]">{clip.prompt}</p>
         ) : null}
-        {clipDetails ? (
-          <p className="text-[0.65rem] text-[var(--muted-foreground)]/70">{clipDetails}</p>
-        ) : null}
+        {clipDetails ? <p className="text-[0.65rem] text-[var(--muted-foreground)]/70">{clipDetails}</p> : null}
       </div>
     </div>
   );
@@ -2777,7 +2924,7 @@ function SpritesTab({
   defaultAppearance?: string;
   defaultAvatarUrl?: string | null;
 }) {
-  type SpriteCategory = "expressions" | "full-body";
+  type SpriteCategory = "expressions" | "full-body" | "clips";
 
   const { data: sprites, isLoading } = useCharacterSprites(characterId);
   const { data: spriteCapabilities } = useSpriteCapabilities();
@@ -2813,7 +2960,11 @@ function SpritesTab({
     .filter((s) => !s.expression.toLowerCase().startsWith("full_"))
     .map((s) => s.expression);
   const visibleSprites = allSprites.filter((s) =>
-    category === "full-body" ? s.expression.startsWith("full_") : !s.expression.startsWith("full_"),
+    category === "clips"
+      ? false
+      : category === "full-body"
+        ? s.expression.startsWith("full_")
+        : !s.expression.startsWith("full_"),
   );
   const existingExpressions = new Set(
     visibleSprites.map((s) => (category === "full-body" ? s.expression.replace(/^full_/, "") : s.expression)),
@@ -2826,6 +2977,30 @@ function SpritesTab({
   const backgroundRemoverUnavailable = spriteCapabilities?.backgroundRemover?.installed === false;
   const backgroundRemoverReason =
     spriteCapabilities?.backgroundRemover?.reason ?? "Local backgroundremover is not installed.";
+
+  const categoryTabs = (
+    <div className="inline-flex rounded-xl bg-[var(--secondary)] p-1 ring-1 ring-[var(--border)]">
+      {[
+        { id: "expressions" as const, label: "Facial Expressions" },
+        { id: "full-body" as const, label: "Full-body" },
+        { id: "clips" as const, label: "Clips" },
+      ].map((tab) => (
+        <button
+          key={tab.id}
+          type="button"
+          onClick={() => setCategory(tab.id)}
+          className={cn(
+            "rounded-lg px-3 py-1.5 text-xs font-medium transition-colors",
+            category === tab.id
+              ? "bg-[var(--primary)]/15 text-[var(--primary)]"
+              : "text-[var(--muted-foreground)] hover:text-[var(--foreground)]",
+          )}
+        >
+          {tab.label}
+        </button>
+      ))}
+    </div>
+  );
 
   const normalizeExpressionForCategory = (raw: string) => {
     return normalizeSpriteExpressionLabel(raw, { fullBody: category === "full-body" });
@@ -3080,6 +3255,22 @@ function SpritesTab({
     [characterId, displayExpression, uploadSprite, wandCleanupSprite],
   );
 
+  if (category === "clips") {
+    return (
+      <div className="space-y-6">
+        <SectionHeader
+          title="Character Sprites"
+          subtitle="Upload VN-style sprites and video-call clips for this character."
+          helpText={CHARACTER_SPRITES_HELP}
+        />
+
+        {categoryTabs}
+
+        <CharacterCallClipsGallery characterId={characterId} characterName={characterName} />
+      </div>
+    );
+  }
+
   return (
     <div className="space-y-6">
       <SectionHeader
@@ -3088,32 +3279,7 @@ function SpritesTab({
         helpText={CHARACTER_SPRITES_HELP}
       />
 
-      <div className="inline-flex rounded-xl bg-[var(--secondary)] p-1 ring-1 ring-[var(--border)]">
-        <button
-          type="button"
-          onClick={() => setCategory("expressions")}
-          className={cn(
-            "rounded-lg px-3 py-1.5 text-xs font-medium transition-colors",
-            category === "expressions"
-              ? "bg-[var(--primary)]/15 text-[var(--primary)]"
-              : "text-[var(--muted-foreground)] hover:text-[var(--foreground)]",
-          )}
-        >
-          Facial Expressions
-        </button>
-        <button
-          type="button"
-          onClick={() => setCategory("full-body")}
-          className={cn(
-            "rounded-lg px-3 py-1.5 text-xs font-medium transition-colors",
-            category === "full-body"
-              ? "bg-[var(--primary)]/15 text-[var(--primary)]"
-              : "text-[var(--muted-foreground)] hover:text-[var(--foreground)]",
-          )}
-        >
-          Full-body
-        </button>
-      </div>
+      {categoryTabs}
 
       <input ref={fileInputRef} type="file" accept="image/*" className="hidden" onChange={handleUpload} />
       <input

--- a/packages/client/src/components/characters/CharacterEditor.tsx
+++ b/packages/client/src/components/characters/CharacterEditor.tsx
@@ -26,6 +26,7 @@ import {
   useUploadCharacterGalleryVideo,
   useTagCharacterGalleryImage,
   useGenerateCharacterCallVideoClips,
+  useGenerateCharacterCustomCallVideoClip,
   useUploadSprite,
   useDeleteSprite,
   useExportSprites,
@@ -2280,6 +2281,7 @@ function CharacterVideosGallery({ characterId, characterName }: { characterId: s
 function CharacterCallClipsGallery({ characterId, characterName }: { characterId: string; characterName?: string }) {
   const { data, isLoading } = useCharacterGalleryClips(characterId);
   const generateCallClips = useGenerateCharacterCallVideoClips(characterId);
+  const generateCustomCallClip = useGenerateCharacterCustomCallVideoClip(characterId);
   const deleteClip = useDeleteCharacterGalleryClip(characterId);
   const updateClipTrim = useUpdateCharacterGalleryClipTrim(characterId);
   const uploadClip = useUploadCharacterGalleryClip(characterId);
@@ -2300,8 +2302,10 @@ function CharacterCallClipsGallery({ characterId, characterName }: { characterId
   const generationLockActive =
     data?.callVideoGenerating === true ||
     clips.some((clip) => isCharacterCallVideoClip(clip) && clip.status === "generating") ||
-    generateCallClips.isPending;
-  const batchGenerationPending = generateCallClips.isPending && generatingClipId === null;
+    generateCallClips.isPending ||
+    generateCustomCallClip.isPending;
+  const batchGenerationPending =
+    (generateCallClips.isPending || generateCustomCallClip.isPending) && generatingClipId === null;
 
   const openGenerationDialog = useCallback((clip?: CharacterGalleryClip) => {
     const kind =
@@ -2313,11 +2317,36 @@ function CharacterCallClipsGallery({ characterId, characterName }: { characterId
 
   const handleGenerateCallClips = useCallback(
     async (input: CharacterCallVideoGenerationInput) => {
-      const singleKind = input.clipKinds?.length === 1 ? input.clipKinds[0] : input.clipKind;
-      setGeneratingClipId(singleKind ? `call:${singleKind}` : null);
+      const standardKinds = input.clipKinds?.length ? input.clipKinds : input.clipKind ? [input.clipKind] : [];
+      const customClip = input.customClip?.label.trim() && input.customClip.prompt.trim() ? input.customClip : null;
+      const singleKind = standardKinds.length === 1 && !customClip ? standardKinds[0] : null;
+      setGeneratingClipId(
+        singleKind ? `call:${singleKind}` : customClip && standardKinds.length === 0 ? "custom-call:pending" : null,
+      );
       try {
-        await generateCallClips.mutateAsync(input);
-        toast.success(singleKind ? "Call clip generation started." : "Call clip generation batch started.");
+        if (standardKinds.length > 0) {
+          await generateCallClips.mutateAsync({
+            ...input,
+            clipKinds: standardKinds,
+            clipCount: standardKinds.length,
+            customClip: null,
+          });
+        }
+        if (customClip) {
+          await generateCustomCallClip.mutateAsync({
+            ...input,
+            customClip,
+          });
+        }
+        toast.success(
+          customClip && standardKinds.length === 0
+            ? "Custom call clip generation started."
+            : singleKind
+              ? "Call clip generation started."
+              : customClip
+                ? "Call clip and custom clip generation started."
+                : "Call clip generation batch started.",
+        );
         setGenerationDialogOpen(false);
       } catch (error) {
         toast.error(error instanceof Error ? error.message : "Could not start call clip generation.");
@@ -2325,7 +2354,7 @@ function CharacterCallClipsGallery({ characterId, characterName }: { characterId
         setGeneratingClipId(null);
       }
     },
-    [generateCallClips],
+    [generateCallClips, generateCustomCallClip],
   );
 
   const handleUploadClipFile = useCallback(
@@ -2503,7 +2532,7 @@ function CharacterCallClipsGallery({ characterId, characterName }: { characterId
         open={generationDialogOpen}
         entityName={characterName || "this character"}
         initialKind={generationInitialKind}
-        generating={generateCallClips.isPending}
+        generating={generateCallClips.isPending || generateCustomCallClip.isPending}
         onClose={() => setGenerationDialogOpen(false)}
         onGenerate={handleGenerateCallClips}
       />

--- a/packages/client/src/components/characters/CharacterEditor.tsx
+++ b/packages/client/src/components/characters/CharacterEditor.tsx
@@ -2771,38 +2771,44 @@ function CharacterClipCard({
         {isReady && clip.url ? (
           <CharacterClipPreviewVideo clip={clip} />
         ) : (
-          <div className="flex h-full flex-col items-center justify-center gap-2 text-center text-xs text-[var(--muted-foreground)]">
-            {clip.status === "generating" ? (
-              <Loader2 size="1.25rem" className="animate-spin text-[var(--primary)]" />
-            ) : clip.status === "error" ? (
-              <AlertTriangle size="1.25rem" className="text-[var(--destructive)]" />
-            ) : (
-              <Film size="1.25rem" className="opacity-50" />
-            )}
-            <span>{clip.status === "missing" ? "Not generated" : clip.status}</span>
-            {canGenerate ? (
-              <button
-                type="button"
-                onClick={() => void onGenerate(clip)}
-                disabled={generationDisabled || generating}
-                className="mt-1 inline-flex min-h-8 items-center gap-1.5 rounded-lg border border-[var(--border)] bg-[var(--card)] px-2.5 py-1 text-[0.7rem] font-semibold text-[var(--foreground)] opacity-0 shadow-sm transition-all hover:border-[var(--primary)]/50 hover:text-[var(--primary)] focus-visible:opacity-100 disabled:cursor-not-allowed disabled:text-[var(--muted-foreground)] group-hover:opacity-100 max-md:opacity-100"
-                title={`Generate ${clip.label || "call clip"}`}
-              >
-                {generating ? <Loader2 size="0.75rem" className="animate-spin" /> : <Wand2 size="0.75rem" />}
-                <span>Generate</span>
-              </button>
-            ) : null}
-            {canUploadSlot ? (
-              <button
-                type="button"
-                onClick={() => onUpload(clip)}
-                disabled={uploading || uploadDisabled || generationDisabled}
-                className="inline-flex min-h-8 items-center gap-1.5 rounded-lg border border-[var(--border)] bg-[var(--card)] px-2.5 py-1 text-[0.7rem] font-semibold text-[var(--foreground)] opacity-0 shadow-sm transition-all hover:border-[var(--primary)]/50 hover:text-[var(--primary)] focus-visible:opacity-100 disabled:cursor-not-allowed disabled:text-[var(--muted-foreground)] group-hover:opacity-100 max-md:opacity-100"
-                title={`Upload ${clip.label || "call clip"}`}
-              >
-                {uploading ? <Loader2 size="0.75rem" className="animate-spin" /> : <Upload size="0.75rem" />}
-                <span>Upload</span>
-              </button>
+          <div className="absolute inset-0">
+            <div className="flex h-full flex-col items-center justify-center gap-2 text-center text-xs text-[var(--muted-foreground)]">
+              {clip.status === "generating" ? (
+                <Loader2 size="1.25rem" className="animate-spin text-[var(--primary)]" />
+              ) : clip.status === "error" ? (
+                <AlertTriangle size="1.25rem" className="text-[var(--destructive)]" />
+              ) : (
+                <Film size="1.25rem" className="opacity-50" />
+              )}
+              <span>{clip.status === "missing" ? "Not generated" : clip.status}</span>
+            </div>
+            {canGenerate || canUploadSlot ? (
+              <div className="absolute inset-x-2 bottom-2 flex flex-wrap items-center justify-center gap-1.5">
+                {canGenerate ? (
+                  <button
+                    type="button"
+                    onClick={() => void onGenerate(clip)}
+                    disabled={generationDisabled || generating}
+                    className="inline-flex min-h-8 items-center gap-1.5 rounded-lg border border-[var(--border)] bg-[var(--card)] px-2.5 py-1 text-[0.7rem] font-semibold text-[var(--foreground)] opacity-0 shadow-sm transition-all hover:border-[var(--primary)]/50 hover:text-[var(--primary)] focus-visible:opacity-100 disabled:cursor-not-allowed disabled:text-[var(--muted-foreground)] group-hover:opacity-100 max-md:opacity-100"
+                    title={`Generate ${clip.label || "call clip"}`}
+                  >
+                    {generating ? <Loader2 size="0.75rem" className="animate-spin" /> : <Wand2 size="0.75rem" />}
+                    <span>Generate</span>
+                  </button>
+                ) : null}
+                {canUploadSlot ? (
+                  <button
+                    type="button"
+                    onClick={() => onUpload(clip)}
+                    disabled={uploading || uploadDisabled || generationDisabled}
+                    className="inline-flex min-h-8 items-center gap-1.5 rounded-lg border border-[var(--border)] bg-[var(--card)] px-2.5 py-1 text-[0.7rem] font-semibold text-[var(--foreground)] opacity-0 shadow-sm transition-all hover:border-[var(--primary)]/50 hover:text-[var(--primary)] focus-visible:opacity-100 disabled:cursor-not-allowed disabled:text-[var(--muted-foreground)] group-hover:opacity-100 max-md:opacity-100"
+                    title={`Upload ${clip.label || "call clip"}`}
+                  >
+                    {uploading ? <Loader2 size="0.75rem" className="animate-spin" /> : <Upload size="0.75rem" />}
+                    <span>Upload</span>
+                  </button>
+                ) : null}
+              </div>
             ) : null}
           </div>
         )}

--- a/packages/client/src/components/characters/CharacterEditor.tsx
+++ b/packages/client/src/components/characters/CharacterEditor.tsx
@@ -2175,18 +2175,16 @@ function CharacterVideosGallery({ characterId, characterName }: { characterId: s
   const deleteClip = useDeleteCharacterGalleryClip(characterId);
   const uploadVideo = useUploadCharacterGalleryVideo(characterId);
   const [deletingClipId, setDeletingClipId] = useState<string | null>(null);
-  const videoUploadInputRef = useRef<HTMLInputElement | null>(null);
   const clips = (data?.clips ?? []).filter(isCharacterGalleryVideoClip);
 
-  const handleUploadClipFile = useCallback(
-    async (event: ChangeEvent<HTMLInputElement>) => {
-      const file = event.target.files?.[0];
-      event.target.value = "";
-      if (!file) return;
-
+  const handleUploadVideos = useCallback(
+    async (files: File[]) => {
+      if (files.length === 0) return;
       try {
-        await uploadVideo.mutateAsync({ file });
-        toast.success("Video uploaded.");
+        for (const file of files) {
+          await uploadVideo.mutateAsync({ file });
+        }
+        toast.success(files.length === 1 ? "Video uploaded." : "Videos uploaded.");
       } catch (error) {
         toast.error(error instanceof Error ? error.message : "Could not upload video.");
       }
@@ -2232,31 +2230,18 @@ function CharacterVideosGallery({ characterId, characterName }: { characterId: s
   }
 
   return (
-    <div className="space-y-4">
-      <input
-        ref={videoUploadInputRef}
-        type="file"
+    <div className="space-y-6">
+      <ImageUploadDropzone
+        label="Upload Character Videos"
+        pending={uploadVideo.isPending}
+        pendingLabel="Uploading…"
+        dragLabel="Drop character videos to upload"
+        onFilesSelected={handleUploadVideos}
+        icon={<Upload size="1rem" />}
         accept="video/mp4,video/webm,video/quicktime,.mp4,.webm,.mov"
-        className="hidden"
-        onChange={handleUploadClipFile}
+        fileKind="video"
+        className="w-full"
       />
-      <div className="flex flex-wrap items-center justify-between gap-3 rounded-xl border border-[var(--border)] bg-[var(--card)] p-3">
-        <div className="min-w-0">
-          <p className="text-sm font-semibold text-[var(--foreground)]">Character videos</p>
-          <p className="mt-0.5 text-xs text-[var(--muted-foreground)]">
-            Generated scene videos and your own uploads attached to {characterName || "this character"}.
-          </p>
-        </div>
-        <button
-          type="button"
-          onClick={() => videoUploadInputRef.current?.click()}
-          disabled={uploadVideo.isPending}
-          className="inline-flex items-center gap-2 rounded-lg border border-[var(--border)] bg-[var(--secondary)] px-3 py-2 text-xs font-semibold text-[var(--foreground)] transition-colors hover:border-[var(--primary)]/50 disabled:cursor-not-allowed disabled:opacity-60"
-        >
-          {uploadVideo.isPending ? <Loader2 size="0.85rem" className="animate-spin" /> : <Upload size="0.85rem" />}
-          Upload video
-        </button>
-      </div>
 
       {clips.length > 0 ? (
         <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-3">

--- a/packages/client/src/components/chat/ChatGallery.tsx
+++ b/packages/client/src/components/chat/ChatGallery.tsx
@@ -107,6 +107,7 @@ export function ChatGallery({
   const [selectedSelfieCharacterId, setSelectedSelfieCharacterId] = useState("");
   const copyResetTimerRef = useRef<number | null>(null);
   const isIllustrating = useGalleryStore((s) => s.illustratingChatIds.has(chatId));
+  const isGeneratingSelfie = useGalleryStore((s) => s.selfieGeneratingChatIds.has(chatId));
   const isGeneratingVideo = useGalleryStore((s) => s.videoGeneratingChatIds.has(chatId));
   const isGeneratingBackground = useGalleryStore((s) => s.backgroundGeneratingChatIds.has(chatId));
   const isGeneratingStoryboard = useGalleryStore((s) => s.storyboardGeneratingChatIds.has(chatId));
@@ -114,6 +115,7 @@ export function ChatGallery({
   const pinVideo = useGalleryStore((s) => s.pinVideo);
   const unpinImage = useGalleryStore((s) => s.unpinImage);
   const setChatIllustrating = useGalleryStore((s) => s.setChatIllustrating);
+  const setChatGeneratingSelfie = useGalleryStore((s) => s.setChatGeneratingSelfie);
   const setChatGeneratingVideo = useGalleryStore((s) => s.setChatGeneratingVideo);
   const setChatGeneratingBackground = useGalleryStore((s) => s.setChatGeneratingBackground);
   const setChatGeneratingStoryboard = useGalleryStore((s) => s.setChatGeneratingStoryboard);
@@ -146,7 +148,10 @@ export function ChatGallery({
       if (selectedSelfieCharacterId) setSelectedSelfieCharacterId("");
       return;
     }
-    if (!selectedSelfieCharacterId || !selfieCharacters.some((character) => character.id === selectedSelfieCharacterId)) {
+    if (
+      !selectedSelfieCharacterId ||
+      !selfieCharacters.some((character) => character.id === selectedSelfieCharacterId)
+    ) {
       setSelectedSelfieCharacterId(selfieCharacters[0]!.id);
     }
   }, [selectedSelfieCharacterId, selfieCharacters]);
@@ -190,17 +195,17 @@ export function ChatGallery({
   };
 
   const handleGenerateSelfie = async () => {
-    if (!onGenerateSelfie || useGalleryStore.getState().illustratingChatIds.has(chatId)) return;
+    if (!onGenerateSelfie || useGalleryStore.getState().selfieGeneratingChatIds.has(chatId)) return;
 
     const characterId = selfieCharacters.length > 1 ? selectedSelfieCharacterId : selfieCharacters[0]?.id;
-    setChatIllustrating(chatId, true);
+    setChatGeneratingSelfie(chatId, true);
     try {
       await onGenerateSelfie(characterId);
       toast.success("Selfie generated.");
     } catch (error) {
       toast.error(error instanceof Error ? error.message : "Selfie generation failed.");
     } finally {
-      setChatIllustrating(chatId, false);
+      setChatGeneratingSelfie(chatId, false);
     }
   };
 
@@ -353,22 +358,22 @@ export function ChatGallery({
                 <button
                   type="button"
                   onClick={() => void handleGenerateSelfie()}
-                  disabled={isIllustrating}
-                  aria-busy={isIllustrating}
+                  disabled={isGeneratingSelfie}
+                  aria-busy={isGeneratingSelfie}
                   className="flex min-w-0 items-center justify-center gap-2 rounded-xl bg-[var(--primary)]/15 px-3 py-3 text-xs font-medium text-[var(--primary)] transition-all hover:bg-[var(--primary)]/25 disabled:cursor-wait disabled:opacity-75"
                 >
-                  {isIllustrating ? (
+                  {isGeneratingSelfie ? (
                     <Loader2 size="1rem" className="shrink-0 animate-spin" />
                   ) : (
                     <Camera size="1rem" className="shrink-0" />
                   )}
-                  <span className="min-w-0 truncate">{isIllustrating ? "Generating..." : "Selfie"}</span>
+                  <span className="min-w-0 truncate">{isGeneratingSelfie ? "Generating..." : "Selfie"}</span>
                 </button>
                 {selfieCharacters.length > 1 && (
                   <select
                     value={selectedSelfieCharacterId}
                     onChange={(event) => setSelectedSelfieCharacterId(event.target.value)}
-                    disabled={isIllustrating}
+                    disabled={isGeneratingSelfie}
                     className="min-w-0 rounded-lg bg-[var(--secondary)] px-2 py-1.5 text-[0.6875rem] text-[var(--foreground)] outline-none ring-1 ring-[var(--border)] disabled:cursor-wait disabled:opacity-70"
                     aria-label="Selfie character"
                   >
@@ -394,9 +399,7 @@ export function ChatGallery({
                 ) : (
                   <PanelsTopLeft size="1rem" className="shrink-0" />
                 )}
-                <span className="min-w-0 truncate">
-                  {isGeneratingStoryboard ? "Creating..." : "Create storyboard"}
-                </span>
+                <span className="min-w-0 truncate">{isGeneratingStoryboard ? "Creating..." : "Create storyboard"}</span>
               </button>
             )}
             {onGenerateVideo && (
@@ -520,191 +523,196 @@ export function ChatGallery({
 
         {activeTab === "images" && (
           <>
-        <ImageUploadDropzone
-          label="Upload Images"
-          pending={upload.isPending}
-          pendingLabel="Uploading…"
-          dragLabel="Drop images to upload"
-          onFilesSelected={handleUpload}
-          icon={<ImagePlus size="1rem" />}
-        />
+            <ImageUploadDropzone
+              label="Upload Images"
+              pending={upload.isPending}
+              pendingLabel="Uploading…"
+              dragLabel="Drop images to upload"
+              onFilesSelected={handleUpload}
+              icon={<ImagePlus size="1rem" />}
+            />
 
-        {/* Loading state */}
-        {isLoading && <p className="text-center text-xs text-[var(--muted-foreground)]">Loading gallery…</p>}
+            {/* Loading state */}
+            {isLoading && <p className="text-center text-xs text-[var(--muted-foreground)]">Loading gallery…</p>}
 
-        {/* Empty state */}
-        {!isLoading && !hasImages && (
-          <div className="flex flex-col items-center gap-2 py-8 text-[var(--muted-foreground)]">
-            <Sparkles size="1.5rem" className="opacity-40" />
-            <p className="text-xs">No images yet</p>
-            <p className="text-[0.625rem] opacity-60">Upload images or generate illustrations to build your gallery</p>
-          </div>
-        )}
+            {/* Empty state */}
+            {!isLoading && !hasImages && (
+              <div className="flex flex-col items-center gap-2 py-8 text-[var(--muted-foreground)]">
+                <Sparkles size="1.5rem" className="opacity-40" />
+                <p className="text-xs">No images yet</p>
+                <p className="text-[0.625rem] opacity-60">
+                  Upload images or generate illustrations to build your gallery
+                </p>
+              </div>
+            )}
 
-        {/* Image grid */}
-        {hasImages && (
-          <div className="grid grid-cols-2 gap-2 sm:grid-cols-2">
-            {images!.map((img) => (
-              <div
-                key={img.id}
-                className="group relative overflow-hidden rounded-lg bg-[var(--secondary)] ring-1 ring-transparent transition-all hover:ring-[var(--primary)]/40 hover:shadow-lg focus-within:ring-2 focus-within:ring-[var(--primary)]"
-              >
-                <button
-                  type="button"
-                  onClick={() => setLightbox(img)}
-                  className="block w-full"
-                  aria-label="Open gallery image"
-                >
-                  <img
-                    src={img.url}
-                    alt={img.prompt || "Gallery image"}
-                    loading="lazy"
-                    decoding="async"
-                    className="aspect-square w-full object-cover transition-transform group-hover:scale-105"
-                  />
-                </button>
-                {/* Overlay */}
-                <div className="pointer-events-none absolute inset-0 flex items-end bg-gradient-to-t from-black/60 via-transparent to-transparent opacity-0 transition-opacity group-hover:opacity-100 group-focus-within:opacity-100 max-md:opacity-100">
-                  <div className="flex w-full items-center justify-between p-2">
-                    <div className="flex gap-1">
-                      <button
-                        type="button"
-                        onClick={() => handlePinImage(img)}
-                        aria-label="Pin image to chat"
-                        className="pointer-events-auto rounded-md bg-white/20 p-1.5 text-white transition-colors hover:bg-white/30"
-                        title="Pin to chat"
-                      >
-                        <Pin size="0.75rem" />
-                      </button>
-                      <a
-                        href={img.url}
-                        download={getChatImageDownloadName(img)}
-                        aria-label="Download gallery image"
-                        className="pointer-events-auto rounded-md bg-white/20 p-1.5 text-white transition-colors hover:bg-white/30"
-                        title="Download image"
-                      >
-                        <Download size="0.75rem" />
-                      </a>
-                      {onAnimateImage && (
-                        <button
-                          type="button"
-                          onClick={() => void handleAnimateImage(img)}
-                          disabled={isGeneratingVideo}
-                          aria-label="Animate gallery illustration"
-                          className="pointer-events-auto rounded-md bg-white/20 p-1.5 text-white transition-colors hover:bg-white/30 disabled:cursor-wait disabled:opacity-60"
-                          title="Animate illustration"
-                        >
-                          {isGeneratingVideo ? <Loader2 size="0.75rem" className="animate-spin" /> : <Film size="0.75rem" />}
-                        </button>
-                      )}
-                      <button
-                        type="button"
-                        onClick={(event) => {
-                          event.preventDefault();
-                          event.stopPropagation();
-                          void handleCopyPrompt(img);
-                        }}
-                        disabled={!img.prompt.trim()}
-                        aria-label="Copy image prompt"
-                        className="pointer-events-auto rounded-md bg-white/20 p-1.5 text-white transition-colors hover:bg-white/30 disabled:cursor-not-allowed disabled:opacity-45"
-                        title={img.prompt.trim() ? "Copy prompt" : "No prompt saved"}
-                      >
-                        {copiedPromptImageId === img.id ? <Check size="0.75rem" /> : <Copy size="0.75rem" />}
-                      </button>
-                    </div>
+            {/* Image grid */}
+            {hasImages && (
+              <div className="grid grid-cols-2 gap-2 sm:grid-cols-2">
+                {images!.map((img) => (
+                  <div
+                    key={img.id}
+                    className="group relative overflow-hidden rounded-lg bg-[var(--secondary)] ring-1 ring-transparent transition-all hover:ring-[var(--primary)]/40 hover:shadow-lg focus-within:ring-2 focus-within:ring-[var(--primary)]"
+                  >
                     <button
                       type="button"
-                      onClick={() => setConfirmDeleteId(img.id)}
-                      aria-label="Delete gallery image"
-                      className="pointer-events-auto rounded-md bg-red-500/40 p-1.5 text-white transition-colors hover:bg-red-500/60"
+                      onClick={() => setLightbox(img)}
+                      className="block w-full"
+                      aria-label="Open gallery image"
                     >
-                      <Trash2 size="0.75rem" />
+                      <img
+                        src={img.url}
+                        alt={img.prompt || "Gallery image"}
+                        loading="lazy"
+                        decoding="async"
+                        className="aspect-square w-full object-cover transition-transform group-hover:scale-105"
+                      />
                     </button>
+                    {/* Overlay */}
+                    <div className="pointer-events-none absolute inset-0 flex items-end bg-gradient-to-t from-black/60 via-transparent to-transparent opacity-0 transition-opacity group-hover:opacity-100 group-focus-within:opacity-100 max-md:opacity-100">
+                      <div className="flex w-full items-center justify-between p-2">
+                        <div className="flex gap-1">
+                          <button
+                            type="button"
+                            onClick={() => handlePinImage(img)}
+                            aria-label="Pin image to chat"
+                            className="pointer-events-auto rounded-md bg-white/20 p-1.5 text-white transition-colors hover:bg-white/30"
+                            title="Pin to chat"
+                          >
+                            <Pin size="0.75rem" />
+                          </button>
+                          <a
+                            href={img.url}
+                            download={getChatImageDownloadName(img)}
+                            aria-label="Download gallery image"
+                            className="pointer-events-auto rounded-md bg-white/20 p-1.5 text-white transition-colors hover:bg-white/30"
+                            title="Download image"
+                          >
+                            <Download size="0.75rem" />
+                          </a>
+                          {onAnimateImage && (
+                            <button
+                              type="button"
+                              onClick={() => void handleAnimateImage(img)}
+                              disabled={isGeneratingVideo}
+                              aria-label="Animate gallery illustration"
+                              className="pointer-events-auto rounded-md bg-white/20 p-1.5 text-white transition-colors hover:bg-white/30 disabled:cursor-wait disabled:opacity-60"
+                              title="Animate illustration"
+                            >
+                              {isGeneratingVideo ? (
+                                <Loader2 size="0.75rem" className="animate-spin" />
+                              ) : (
+                                <Film size="0.75rem" />
+                              )}
+                            </button>
+                          )}
+                          <button
+                            type="button"
+                            onClick={(event) => {
+                              event.preventDefault();
+                              event.stopPropagation();
+                              void handleCopyPrompt(img);
+                            }}
+                            disabled={!img.prompt.trim()}
+                            aria-label="Copy image prompt"
+                            className="pointer-events-auto rounded-md bg-white/20 p-1.5 text-white transition-colors hover:bg-white/30 disabled:cursor-not-allowed disabled:opacity-45"
+                            title={img.prompt.trim() ? "Copy prompt" : "No prompt saved"}
+                          >
+                            {copiedPromptImageId === img.id ? <Check size="0.75rem" /> : <Copy size="0.75rem" />}
+                          </button>
+                        </div>
+                        <button
+                          type="button"
+                          onClick={() => setConfirmDeleteId(img.id)}
+                          aria-label="Delete gallery image"
+                          className="pointer-events-auto rounded-md bg-red-500/40 p-1.5 text-white transition-colors hover:bg-red-500/60"
+                        >
+                          <Trash2 size="0.75rem" />
+                        </button>
+                      </div>
+                    </div>
                   </div>
-                </div>
+                ))}
               </div>
-            ))}
-          </div>
-        )}
-
+            )}
           </>
         )}
 
         {activeTab === "videos" && (
           <>
-        {sceneVideosQuery.isLoading && sceneVideosEnabled && (
-          <p className="text-center text-xs text-[var(--muted-foreground)]">Loading scene videos...</p>
-        )}
+            {sceneVideosQuery.isLoading && sceneVideosEnabled && (
+              <p className="text-center text-xs text-[var(--muted-foreground)]">Loading scene videos...</p>
+            )}
 
-        {!sceneVideosQuery.isLoading && !hasVideos && (
-          <div className="flex flex-col items-center gap-2 py-8 text-[var(--muted-foreground)]">
-            <Film size="1.5rem" className="opacity-40" />
-            <p className="text-xs">No videos yet</p>
-            <p className="text-[0.625rem] opacity-60">Generate or animate scene videos to fill this tab</p>
-          </div>
-        )}
+            {!sceneVideosQuery.isLoading && !hasVideos && (
+              <div className="flex flex-col items-center gap-2 py-8 text-[var(--muted-foreground)]">
+                <Film size="1.5rem" className="opacity-40" />
+                <p className="text-xs">No videos yet</p>
+                <p className="text-[0.625rem] opacity-60">Generate or animate scene videos to fill this tab</p>
+              </div>
+            )}
 
-        {hasVideos && (
-          <section className="space-y-2">
-            <div className="flex items-center gap-2 text-[0.6875rem] font-medium uppercase text-[var(--muted-foreground)]">
-              <Film size="0.75rem" />
-              Scene videos
-            </div>
-            <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
-              {sceneVideos.map((video) => (
-                <div
-                  key={video.id}
-                  className="group relative overflow-hidden rounded-lg bg-[var(--secondary)] ring-1 ring-transparent transition-all hover:ring-[var(--primary)]/40 hover:shadow-lg focus-within:ring-2 focus-within:ring-[var(--primary)]"
-                >
-                  <button
-                    type="button"
-                    onClick={() => setVideoLightbox(video)}
-                    className="block w-full"
-                    aria-label="Open scene video"
-                  >
-                    <video
-                      src={video.url}
-                      muted
-                      playsInline
-                      preload="metadata"
-                      className="aspect-video w-full bg-black object-contain"
-                    />
-                  </button>
-                  <div className="pointer-events-none absolute inset-x-0 bottom-0 flex items-end bg-gradient-to-t from-black/70 via-black/20 to-transparent opacity-0 transition-opacity group-hover:opacity-100 group-focus-within:opacity-100 max-md:opacity-100">
-                    <div className="flex w-full items-center justify-between gap-2 p-2">
-                      <div className="min-w-0 text-white">
-                        <div className="truncate text-[0.6875rem] font-medium">
-                          {video.durationSeconds}s scene video
+            {hasVideos && (
+              <section className="space-y-2">
+                <div className="flex items-center gap-2 text-[0.6875rem] font-medium uppercase text-[var(--muted-foreground)]">
+                  <Film size="0.75rem" />
+                  Scene videos
+                </div>
+                <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
+                  {sceneVideos.map((video) => (
+                    <div
+                      key={video.id}
+                      className="group relative overflow-hidden rounded-lg bg-[var(--secondary)] ring-1 ring-transparent transition-all hover:ring-[var(--primary)]/40 hover:shadow-lg focus-within:ring-2 focus-within:ring-[var(--primary)]"
+                    >
+                      <button
+                        type="button"
+                        onClick={() => setVideoLightbox(video)}
+                        className="block w-full"
+                        aria-label="Open scene video"
+                      >
+                        <video
+                          src={video.url}
+                          muted
+                          playsInline
+                          preload="metadata"
+                          className="aspect-video w-full bg-black object-contain"
+                        />
+                      </button>
+                      <div className="pointer-events-none absolute inset-x-0 bottom-0 flex items-end bg-gradient-to-t from-black/70 via-black/20 to-transparent opacity-0 transition-opacity group-hover:opacity-100 group-focus-within:opacity-100 max-md:opacity-100">
+                        <div className="flex w-full items-center justify-between gap-2 p-2">
+                          <div className="min-w-0 text-white">
+                            <div className="truncate text-[0.6875rem] font-medium">
+                              {video.durationSeconds}s scene video
+                            </div>
+                            <div className="truncate text-[0.625rem] text-white/70">{video.model}</div>
+                          </div>
+                          <div className="flex shrink-0 gap-1">
+                            <button
+                              type="button"
+                              onClick={() => handlePinVideo(video)}
+                              aria-label="Pin video to chat"
+                              className="pointer-events-auto rounded-md bg-white/20 p-1.5 text-white transition-colors hover:bg-white/30"
+                              title="Pin to chat"
+                            >
+                              <Pin size="0.75rem" />
+                            </button>
+                            <a
+                              href={video.url}
+                              download={getSceneVideoDownloadName(video)}
+                              aria-label="Download scene video"
+                              className="pointer-events-auto rounded-md bg-white/20 p-1.5 text-white transition-colors hover:bg-white/30"
+                              title="Download video"
+                            >
+                              <Download size="0.75rem" />
+                            </a>
+                          </div>
                         </div>
-                        <div className="truncate text-[0.625rem] text-white/70">{video.model}</div>
-                      </div>
-                      <div className="flex shrink-0 gap-1">
-                        <button
-                          type="button"
-                          onClick={() => handlePinVideo(video)}
-                          aria-label="Pin video to chat"
-                          className="pointer-events-auto rounded-md bg-white/20 p-1.5 text-white transition-colors hover:bg-white/30"
-                          title="Pin to chat"
-                        >
-                          <Pin size="0.75rem" />
-                        </button>
-                        <a
-                          href={video.url}
-                          download={getSceneVideoDownloadName(video)}
-                          aria-label="Download scene video"
-                          className="pointer-events-auto rounded-md bg-white/20 p-1.5 text-white transition-colors hover:bg-white/30"
-                          title="Download video"
-                        >
-                          <Download size="0.75rem" />
-                        </a>
                       </div>
                     </div>
-                  </div>
+                  ))}
                 </div>
-              ))}
-            </div>
-          </section>
-        )}
+              </section>
+            )}
           </>
         )}
       </div>

--- a/packages/client/src/components/chat/ChatSettingsDrawer.tsx
+++ b/packages/client/src/components/chat/ChatSettingsDrawer.tsx
@@ -1026,9 +1026,9 @@ export function ChatSettingsDrawer({
   const callAudioInputMode = ttsConfig?.callAudioInputMode ?? "local_whisper";
   const callVideoInputEnabled = ttsConfig?.callVideoInputEnabled === true;
   const callCharacterVideoEnabled = ttsConfig?.callCharacterVideoEnabled === true;
-  const callCustomVideoClipsEnabled =
-    callCharacterVideoEnabled && ttsConfig?.callCustomVideoClipsEnabled === true;
-  const callSoundboardEnabled = ttsConfig?.callSoundboardEnabled ?? true;
+  const callAutomaticVideoClipsEnabled =
+    callCharacterVideoEnabled && ttsConfig?.callAutomaticVideoClipsEnabled === true;
+  const callCustomVideoClipsEnabled = callCharacterVideoEnabled && ttsConfig?.callCustomVideoClipsEnabled === true;
   const callSettingsDisabled = !ttsConfig || updateTtsConfig.isPending;
   const selfieConnectionId = typeof metadata.imageGenConnectionId === "string" ? metadata.imageGenConnectionId : "";
   const selfieCommandAllowed = conversationCommandToggles.selfie !== false;
@@ -5127,7 +5127,7 @@ export function ChatSettingsDrawer({
                     <div className="min-w-0 flex-1">
                       <span className="block text-xs font-medium text-[var(--foreground)]">Conversation Calls</span>
                       <p className="text-[0.625rem] leading-snug text-[var(--muted-foreground)]">
-                        Per-chat call access, microphone handling, camera/screen input, and soundboard setup.
+                        Per-chat call access, microphone handling, camera/screen input, and character video setup.
                       </p>
                     </div>
                   </div>
@@ -5270,7 +5270,12 @@ export function ChatSettingsDrawer({
                           onClick={() =>
                             patchConversationCallTtsConfig({
                               callCharacterVideoEnabled: !callCharacterVideoEnabled,
-                              ...(!callCharacterVideoEnabled ? {} : { callCustomVideoClipsEnabled: false }),
+                              ...(!callCharacterVideoEnabled
+                                ? {}
+                                : {
+                                    callAutomaticVideoClipsEnabled: false,
+                                    callCustomVideoClipsEnabled: false,
+                                  }),
                             })
                           }
                           className={cn(
@@ -5302,6 +5307,39 @@ export function ChatSettingsDrawer({
                             disabled={callSettingsDisabled}
                             onClick={() =>
                               patchConversationCallTtsConfig({
+                                callAutomaticVideoClipsEnabled: !callAutomaticVideoClipsEnabled,
+                              })
+                            }
+                            className={cn(
+                              "mari-chat-option-field flex items-center justify-between gap-2 rounded-lg px-2.5 py-2 text-left transition-all",
+                              callAutomaticVideoClipsEnabled && "mari-chat-option-field--active",
+                              callSettingsDisabled && "cursor-not-allowed opacity-60",
+                            )}
+                          >
+                            <span className="text-[0.625rem] font-medium text-[var(--foreground)]">
+                              Automatic video clips generation
+                            </span>
+                            <div
+                              className={cn(
+                                "mari-chat-option-switch h-4 w-7 shrink-0 rounded-full p-0.5 transition-colors",
+                                callAutomaticVideoClipsEnabled && "mari-chat-option-switch--active",
+                              )}
+                            >
+                              <div
+                                className={cn(
+                                  "h-3 w-3 rounded-full bg-white shadow-sm transition-transform",
+                                  callAutomaticVideoClipsEnabled && "translate-x-3",
+                                )}
+                              />
+                            </div>
+                          </button>
+                        ) : null}
+                        {callCharacterVideoEnabled ? (
+                          <button
+                            type="button"
+                            disabled={callSettingsDisabled}
+                            onClick={() =>
+                              patchConversationCallTtsConfig({
                                 callCustomVideoClipsEnabled: !callCustomVideoClipsEnabled,
                               })
                             }
@@ -5327,48 +5365,19 @@ export function ChatSettingsDrawer({
                             </div>
                           </button>
                         ) : null}
-                        <button
-                          type="button"
-                          disabled={callSettingsDisabled}
-                          onClick={() =>
-                            patchConversationCallTtsConfig({ callSoundboardEnabled: !callSoundboardEnabled })
-                          }
-                          className={cn(
-                            "mari-chat-option-field flex items-center justify-between gap-2 rounded-lg px-2.5 py-2 text-left transition-all",
-                            callSoundboardEnabled && "mari-chat-option-field--active",
-                            callSettingsDisabled && "cursor-not-allowed opacity-60",
-                          )}
-                        >
-                          <span className="text-[0.625rem] font-medium text-[var(--foreground)]">Soundboard</span>
-                          <div
-                            className={cn(
-                              "mari-chat-option-switch h-4 w-7 shrink-0 rounded-full p-0.5 transition-colors",
-                              callSoundboardEnabled && "mari-chat-option-switch--active",
-                            )}
-                          >
-                            <div
-                              className={cn(
-                                "h-3 w-3 rounded-full bg-white shadow-sm transition-transform",
-                                callSoundboardEnabled && "translate-x-3",
-                              )}
-                            />
-                          </div>
-                        </button>
                       </div>
                       {callCharacterVideoEnabled && (
                         <p className="text-[0.55rem] leading-snug text-[var(--muted-foreground)]">
-                          Character video presence uses the Default for Videos connection to generate cached idle,
-                          talking, laughing, angry, crying, and sighing clips from character avatars.
-                          {callCustomVideoClipsEnabled
-                            ? " Custom clips let characters sparsely create one-off requested clips, saved to their call-video gallery."
-                            : " Custom clips stay off unless you explicitly allow one-off requested clips."}
+                          Character video presence uses Clips from Characters Sprites. The Automatic video clips
+                          generation generates cached idle and talking clips from character avatars. Custom clips let
+                          characters sparsely create one-off requested clips.
                         </p>
                       )}
                     </div>
                   ) : (
                     <p className="rounded-lg border border-dashed border-[var(--border)] px-2.5 py-2 text-[0.59375rem] leading-snug text-[var(--muted-foreground)]">
                       Turn on the call audio pipeline here to use local mic transcription, browser speech recognition,
-                      manual system dictation, optional provider-native audio/video input, and the soundboard.
+                      manual system dictation, optional provider-native audio/video input, and call controls.
                     </p>
                   )}
                 </div>

--- a/packages/client/src/components/chat/ConversationCallSurface.tsx
+++ b/packages/client/src/components/chat/ConversationCallSurface.tsx
@@ -33,6 +33,7 @@ import {
 import { toast } from "sonner";
 import { useQueryClient } from "@tanstack/react-query";
 import type {
+  ConversationCallCharacterVideoCustomClip,
   ConversationCallCharacterVideoClipKind,
   ConversationCallCharacterVideoManifest,
   ConversationCallMessage,
@@ -86,6 +87,7 @@ import { useAgentStore } from "../../stores/agent.store";
 import { ReactionAddButton } from "./ReactionAddButton";
 import { MessageReactions } from "./MessageReactions";
 import { toggleReaction, USER_REACTOR } from "../../lib/reactions";
+import { api } from "../../lib/api-client";
 
 interface ConversationCallSurfaceProps {
   chatId: string;
@@ -129,6 +131,7 @@ type CharacterVideoPlaybackState = {
   followKind?: ConversationCallCharacterVideoClipKind;
   voiceKey: string;
   nonce: number;
+  customClip?: ConversationCallCharacterVideoCustomClip | null;
 };
 type CallVideoReactionKind = Exclude<ConversationCallCharacterVideoClipKind, "idle" | "talking">;
 type CallTtsVideoChunk = {
@@ -182,6 +185,8 @@ const CALL_COMMAND_ALIASES = new Map<string, string>([
   ["sound", "soundboard"],
   ["sound_board", "soundboard"],
   ["soundboard", "soundboard"],
+  ["play_clip", "play_clip"],
+  ["clip", "play_clip"],
 ]);
 
 const PARTICIPANT_TILE_CLASSES: Record<
@@ -426,6 +431,29 @@ function getCommandStringParam(value: string | null | undefined, name: string) {
   if (singleQuoted?.[1]) return singleQuoted[1].trim();
   const bare = new RegExp(`${escapedName}\\s*=\\s*([^\\]\\s,]+)`, "i").exec(trimmed);
   return bare?.[1]?.trim() ?? "";
+}
+
+function getCommandRootStringValue(value: string | null | undefined) {
+  const trimmed = value?.trim() ?? "";
+  const quoted = /^\[[a-z0-9_-]+\s*=\s*"([^"]+)"/i.exec(trimmed);
+  if (quoted?.[1]) return quoted[1].trim();
+  const singleQuoted = /^\[[a-z0-9_-]+\s*=\s*'([^']+)'/i.exec(trimmed);
+  if (singleQuoted?.[1]) return singleQuoted[1].trim();
+  const bare = /^\[[a-z0-9_-]+\s*=\s*([^\]\s,]+)/i.exec(trimmed);
+  return bare?.[1]?.trim() ?? "";
+}
+
+function readPlayClipCommandName(value: string | null | undefined) {
+  return (
+    getCommandStringParam(value, "name") ||
+    getCommandStringParam(value, "clip") ||
+    getCommandStringParam(value, "label") ||
+    getCommandRootStringValue(value)
+  ).trim();
+}
+
+function normalizeClipLookupName(value: string) {
+  return value.trim().toLowerCase().replace(/\s+/g, " ");
 }
 
 function getReadyCallVideoClip(
@@ -827,16 +855,20 @@ function ParticipantTile({
   cameraStream,
   density,
   characterVideoEnabled,
+  automaticVideoClipGenerationEnabled,
   videoPlayback,
   onVideoEmotionEnded,
+  onVideoClipReadiness,
 }: {
   participant: Participant;
   active: boolean;
   cameraStream?: MediaStream | null;
   density: ParticipantTileDensity;
   characterVideoEnabled: boolean;
+  automaticVideoClipGenerationEnabled: boolean;
   videoPlayback?: CharacterVideoPlaybackState;
   onVideoEmotionEnded: (participantId: string, voiceKey: string) => void;
+  onVideoClipReadiness: (characterId: string, hasReadyBasicClip: boolean) => void;
 }) {
   const videoRef = useRef<HTMLVideoElement | null>(null);
   const requestedGenerationRef = useRef(false);
@@ -857,11 +889,22 @@ function ParticipantTile({
   useEffect(() => {
     if (!characterVideoEnabled || !characterId || !characterVideoManifest || requestedGenerationRef.current) return;
     if (characterVideoManifest.generating) return;
-    const hasMissingClips = characterVideoManifest.clips.some((clip) => clip.status === "missing");
-    if (!hasMissingClips) return;
+    const basicClipKinds: ConversationCallCharacterVideoClipKind[] = ["idle", "talking"];
+    const hasReadyBasicClip = characterVideoManifest.clips.some(
+      (clip) => basicClipKinds.includes(clip.kind) && clip.status === "ready" && clip.url,
+    );
+    onVideoClipReadiness(characterId, hasReadyBasicClip);
+    if (!automaticVideoClipGenerationEnabled) {
+      return;
+    }
+    const missingBasicClipKinds = basicClipKinds.filter((kind) => {
+      const clip = characterVideoManifest.clips.find((item) => item.kind === kind);
+      return !clip || (clip.status !== "ready" && clip.status !== "generating");
+    });
+    if (missingBasicClipKinds.length === 0) return;
     requestedGenerationRef.current = true;
     generateCharacterVideos.mutate(
-      { characterId },
+      { characterId, clipKinds: missingBasicClipKinds, clipCount: missingBasicClipKinds.length },
       {
         onError: (error) => {
           console.warn("[conversation-call] Failed to start character video generation", error);
@@ -869,29 +912,43 @@ function ParticipantTile({
         },
       },
     );
-  }, [characterId, characterVideoEnabled, characterVideoManifest, generateCharacterVideos]);
+  }, [
+    automaticVideoClipGenerationEnabled,
+    characterId,
+    characterVideoEnabled,
+    characterVideoManifest,
+    generateCharacterVideos,
+    onVideoClipReadiness,
+  ]);
 
-  const requestedVideoKind = videoPlayback?.kind ?? "idle";
+  const customVideoClip =
+    videoPlayback?.customClip?.status === "ready" && videoPlayback.customClip.url ? videoPlayback.customClip : null;
+  const requestedVideoKind = customVideoClip ? "idle" : (videoPlayback?.kind ?? "idle");
   const preferredVideoClip = getReadyCallVideoClip(characterVideoManifest, requestedVideoKind);
   const fallbackVideoClip =
     requestedVideoKind !== "talking" ? getReadyCallVideoClip(characterVideoManifest, "talking") : null;
   const idleVideoClip = requestedVideoKind !== "idle" ? getReadyCallVideoClip(characterVideoManifest, "idle") : null;
-  const characterVideoClip = characterVideoEnabled ? (preferredVideoClip ?? fallbackVideoClip ?? idleVideoClip) : null;
+  const characterVideoClip = characterVideoEnabled
+    ? (customVideoClip ?? preferredVideoClip ?? fallbackVideoClip ?? idleVideoClip)
+    : null;
   const characterVideoUrl = characterVideoClip?.url ?? null;
   const activeVideoKind =
-    characterVideoClip === preferredVideoClip
-      ? requestedVideoKind
-      : characterVideoClip === fallbackVideoClip
-        ? "talking"
-        : characterVideoClip
-          ? "idle"
-          : null;
-  const videoLoops = activeVideoKind === "idle" || activeVideoKind === "talking";
+    characterVideoClip === customVideoClip
+      ? "custom"
+      : characterVideoClip === preferredVideoClip
+        ? requestedVideoKind
+        : characterVideoClip === fallbackVideoClip
+          ? "talking"
+          : characterVideoClip
+            ? "idle"
+            : null;
+  const videoLoops = !customVideoClip && (activeVideoKind === "idle" || activeVideoKind === "talking");
   const videoResetKey = videoLoops ? "loop" : `${videoPlayback?.voiceKey ?? "one-shot"}:${videoPlayback?.nonce ?? 0}`;
   const videoKey = [
     participant.id,
     activeVideoKind ?? "avatar",
     videoResetKey,
+    customVideoClip?.id ?? "",
     characterVideoUrl ?? "",
     characterVideoClip?.trimStartSeconds ?? 0,
     characterVideoClip?.trimEndSeconds ?? "end",
@@ -1063,6 +1120,7 @@ export function ConversationCallSurface({
   const [browserSpeechSupported, setBrowserSpeechSupported] = useState(false);
   const [optimisticCallMessages, setOptimisticCallMessages] = useState<ConversationCallMessage[]>([]);
   const [characterVideoPlayback, setCharacterVideoPlayback] = useState<Record<string, CharacterVideoPlaybackState>>({});
+  const [characterVideoReadyById, setCharacterVideoReadyById] = useState<Record<string, boolean>>({});
   const mobileCallLayout = useMobileCallLayout();
   const [clockNow, setClockNow] = useState(() => Date.now());
   const [joinedParticipantIds, setJoinedParticipantIds] = useState<Set<string>>(() => new Set(["user"]));
@@ -1093,6 +1151,7 @@ export function ConversationCallSurface({
   const playedStartSoundForRef = useRef<string | null>(null);
   const playedEndSoundForRef = useRef<string | null>(null);
   const playedInitialGreetingIdsRef = useRef<Set<string>>(new Set());
+  const missingVideoClipsToastShownRef = useRef(false);
   const previousSessionStatusRef = useRef(session.status);
   const [queuedCallInteractions, setQueuedCallInteractions] = useState(0);
   const messages = useMemo(() => {
@@ -1114,6 +1173,10 @@ export function ConversationCallSurface({
       ),
     );
   }, [optimisticCallMessages.length, persistedMessages]);
+  useEffect(() => {
+    setCharacterVideoReadyById({});
+    missingVideoClipsToastShownRef.current = false;
+  }, [session.id]);
   const callAudioEnabled = ttsConfig?.callAudioEnabled === true;
   const audioInputMode = ttsConfig?.callAudioInputMode ?? "local_whisper";
   const systemVoiceInputMode = audioInputMode === "system";
@@ -1122,16 +1185,30 @@ export function ConversationCallSurface({
   const browserSpeechInputMode = audioInputMode === "transcribe";
   const videoControlsEnabled = ttsConfig?.callVideoInputEnabled === true && nativeInputMode;
   const characterVideoEnabled = ttsConfig?.callCharacterVideoEnabled === true;
-  const soundboardEnabled = ttsConfig?.callSoundboardEnabled !== false;
+  const automaticVideoClipGenerationEnabled = ttsConfig?.callAutomaticVideoClipsEnabled === true;
+  const soundboardEnabled = true;
   const characterVoicesMuted = conversationCallVoiceMuted || conversationCallVoiceVolume <= 0;
   const characterVoicePlaybackVolume = characterVoicesMuted ? 0 : conversationCallVoiceVolume / 100;
   const characterVoiceVolumeLabel = characterVoicesMuted ? "Muted" : `${conversationCallVoiceVolume}%`;
-  const callControlGridColumns = soundboardEnabled ? "grid-cols-7" : "grid-cols-6";
+  const callControlGridColumns = "grid-cols-7";
   const callControlButtonClass =
     "mari-chrome-control shrink-0 p-0 max-sm:aspect-square max-sm:h-auto max-sm:min-h-0 max-sm:w-full max-sm:max-w-10 max-sm:justify-self-center sm:h-11 sm:w-11";
   const callControlIconClass = "h-4 w-4";
   const browserSpeechUnavailable = browserSpeechInputMode && !browserSpeechSupported;
   const recordingWillUseLocalWhisperFallback = browserSpeechUnavailable;
+  const showMissingVideoClipsToast = useCallback(() => {
+    if (missingVideoClipsToastShownRef.current) return;
+    missingVideoClipsToastShownRef.current = true;
+    toast("No video-call clips are ready yet.", {
+      description: "Open the character editor, then Sprites > Clips, to generate idle and talking clips first.",
+      duration: 10_000,
+    });
+  }, []);
+  const updateVideoClipReadiness = useCallback((characterId: string, hasReadyBasicClip: boolean) => {
+    setCharacterVideoReadyById((current) =>
+      current[characterId] === hasReadyBasicClip ? current : { ...current, [characterId]: hasReadyBasicClip },
+    );
+  }, []);
 
   const participants = useMemo<Participant[]>(() => {
     const user: Participant = {
@@ -1184,6 +1261,28 @@ export function ConversationCallSurface({
       ),
     [departedParticipantIds, joinedParticipantIds, participants],
   );
+  const visibleCharacterIds = useMemo(
+    () =>
+      visibleParticipants
+        .filter((participant) => participant.kind === "character" && participant.characterId)
+        .map((participant) => participant.characterId!),
+    [visibleParticipants],
+  );
+  useEffect(() => {
+    if (!characterVideoEnabled || automaticVideoClipGenerationEnabled || visibleCharacterIds.length === 0) return;
+    const allReadinessKnown = visibleCharacterIds.every((characterId) =>
+      Object.prototype.hasOwnProperty.call(characterVideoReadyById, characterId),
+    );
+    if (!allReadinessKnown) return;
+    if (visibleCharacterIds.some((characterId) => characterVideoReadyById[characterId])) return;
+    showMissingVideoClipsToast();
+  }, [
+    automaticVideoClipGenerationEnabled,
+    characterVideoEnabled,
+    characterVideoReadyById,
+    showMissingVideoClipsToast,
+    visibleCharacterIds,
+  ]);
   const visibleCallMessages = useMemo(
     () =>
       messages.filter(
@@ -1506,6 +1605,22 @@ export function ConversationCallSurface({
     [],
   );
 
+  const setParticipantCustomVideoClip = useCallback(
+    (participantId: string, voiceKey: string, clip: ConversationCallCharacterVideoCustomClip) => {
+      setCharacterVideoPlayback((current) => ({
+        ...current,
+        [participantId]: {
+          kind: "idle",
+          followKind: "idle",
+          voiceKey,
+          nonce: Date.now(),
+          customClip: clip,
+        },
+      }));
+    },
+    [],
+  );
+
   const clearParticipantVideoTalking = useCallback((participantId: string | null | undefined, voiceKey: string) => {
     if (!participantId) return;
     setCharacterVideoPlayback((current) => {
@@ -1529,6 +1644,7 @@ export function ConversationCallSurface({
           ...existing,
           kind: existing.followKind,
           followKind: undefined,
+          customClip: null,
           nonce: Date.now(),
         },
       };
@@ -1561,6 +1677,43 @@ export function ConversationCallSurface({
       await playSoundById(sound.id);
     },
     [playSoundById, soundboardEnabled, sounds],
+  );
+
+  const playCustomClipByName = useCallback(
+    async (turn: ConversationCallTurn) => {
+      if (!characterVideoEnabled) return;
+      const requestedName = readPlayClipCommandName(turn.content);
+      if (!requestedName) return;
+      const participant = findParticipantForTurn(turn, participants);
+      const characterId = turn.characterId ?? participant?.characterId ?? null;
+      if (!participant || participant.kind !== "character" || !characterId) return;
+      const manifest = await queryClient.fetchQuery({
+        queryKey: conversationCallKeys.characterVideos(characterId),
+        queryFn: () =>
+          api.get<ConversationCallCharacterVideoManifest>(`/conversation-calls/character-videos/${characterId}`),
+        staleTime: 15_000,
+      });
+      const normalizedRequestedName = normalizeClipLookupName(requestedName);
+      const customClip =
+        manifest.customClips.find(
+          (clip) =>
+            clip.status === "ready" && clip.url && normalizeClipLookupName(clip.label) === normalizedRequestedName,
+        ) ?? null;
+      if (!customClip) {
+        toast(`No ready custom clip named ${requestedName} for ${participant.name}.`);
+        return;
+      }
+      setParticipantCustomVideoClip(
+        participant.id,
+        `${session.id}:${participant.id}:custom:${customClip.id}:${Date.now()}`,
+        customClip,
+      );
+      const trimStart = customClip.trimStartSeconds ?? 0;
+      const trimEnd = customClip.trimEndSeconds ?? 0;
+      const fallbackDurationMs = Math.max(1_500, Math.min(8_000, ((trimEnd || 5) - trimStart) * 1000 || 5_000));
+      await wait(fallbackDurationMs);
+    },
+    [characterVideoEnabled, participants, queryClient, session.id, setParticipantCustomVideoClip],
   );
 
   const handleCharacterLeftCall = useCallback(
@@ -1658,6 +1811,8 @@ export function ConversationCallSurface({
             const commandName = getBracketCommandName(turn.content);
             if (commandName === "soundboard") {
               await playSoundByName(getSoundboardCommandName(turn.content));
+            } else if (commandName === "play_clip") {
+              await playCustomClipByName(turn);
             } else if (commandName === "youtube") {
               const searchQuery = getCommandStringParam(turn.content, "query");
               if (searchQuery) {
@@ -1829,6 +1984,7 @@ export function ConversationCallSurface({
       handleCallEndedByCharacter,
       handleCharacterLeftCall,
       participants,
+      playCustomClipByName,
       playSoundByName,
       queryClient,
       session.id,
@@ -2715,8 +2871,10 @@ export function ConversationCallSurface({
                 cameraStream={participant.kind === "user" ? cameraStream : null}
                 density={participantGridLayout.density}
                 characterVideoEnabled={characterVideoEnabled}
+                automaticVideoClipGenerationEnabled={automaticVideoClipGenerationEnabled}
                 videoPlayback={characterVideoPlayback[participant.id]}
                 onVideoEmotionEnded={handleVideoEmotionEnded}
+                onVideoClipReadiness={updateVideoClipReadiness}
               />
             ))}
           </div>

--- a/packages/client/src/components/chat/ConversationCallSurface.tsx
+++ b/packages/client/src/components/chat/ConversationCallSurface.tsx
@@ -160,9 +160,11 @@ const CALL_MIC_RMS_CONTINUE = 0.013;
 const CALL_MIC_CONFIRM_FRAMES = 2;
 const CALL_MIC_MIN_VOICED_MS = 180;
 const CALL_MIC_MIN_PEAK_RMS = 0.022;
-const CALL_TTS_INTERRUPT_VOICED_MS = 900;
+const CALL_TTS_INTERRUPT_VOICED_MS = 600;
 const CALL_TTS_INTERRUPT_TEXT_MAX_CHARS = 1200;
 const CALL_TTS_MAX_REQUEST_CHARS = 3_900;
+const CALL_VIDEO_LOOP_GUARD_SECONDS = 0.12;
+const CALL_OPTIMISTIC_MESSAGE_RECONCILE_MS = 5 * 60 * 1000;
 const CALL_MUTED_REMINDER_TIMEOUT_MS = 10_000;
 const DEFAULT_TEXT_TO_VOICE_PAUSE_MS = 1_800;
 const ONLINE_CHARACTER_JOIN_DELAY_MS = 1_600;
@@ -478,6 +480,20 @@ function handleCallVideoTrimTimeUpdate(
   }
 }
 
+function handleCallVideoLoopFrame(video: HTMLVideoElement, clip: TrimmedCallVideoClip | null | undefined) {
+  const start = readCallVideoTrimStart(clip);
+  const trimEnd = readCallVideoTrimEnd(clip);
+  const naturalEnd = Number.isFinite(video.duration) && video.duration > 0 ? video.duration : null;
+  const end = trimEnd ?? naturalEnd;
+  if (end === null || start >= end) return;
+  const duration = end - start;
+  const guard = Math.min(CALL_VIDEO_LOOP_GUARD_SECONDS, Math.max(0.025, duration * 0.08));
+  if (video.currentTime >= end - guard && video.currentTime > start + guard) {
+    video.currentTime = start;
+    if (!video.paused) void video.play().catch(() => undefined);
+  }
+}
+
 function readCallMessageAttachments(message: ConversationCallMessage): MessageAttachment[] {
   const raw = message.extra?.attachments;
   if (!Array.isArray(raw)) return [];
@@ -544,6 +560,30 @@ function messageContent(message: ConversationCallMessage, participants: Particip
     default:
       return message.content;
   }
+}
+
+function callMessageTimestampMs(message: ConversationCallMessage) {
+  const timestamp = Date.parse(message.createdAt);
+  return Number.isFinite(timestamp) ? timestamp : 0;
+}
+
+function isSamePersistedCallMessage(
+  optimisticMessage: ConversationCallMessage,
+  persistedMessage: ConversationCallMessage,
+) {
+  if (optimisticMessage.extra?.optimistic !== true) return false;
+  if (persistedMessage.extra?.optimistic === true) return false;
+  if (optimisticMessage.callId !== persistedMessage.callId) return false;
+  if (optimisticMessage.chatId !== persistedMessage.chatId) return false;
+  if (optimisticMessage.role !== persistedMessage.role) return false;
+  if (optimisticMessage.participantKind !== persistedMessage.participantKind) return false;
+  if ((optimisticMessage.characterId ?? null) !== (persistedMessage.characterId ?? null)) return false;
+  if (optimisticMessage.kind !== persistedMessage.kind) return false;
+  if (optimisticMessage.content.trim() !== persistedMessage.content.trim()) return false;
+  const optimisticAt = callMessageTimestampMs(optimisticMessage);
+  const persistedAt = callMessageTimestampMs(persistedMessage);
+  if (!optimisticAt || !persistedAt) return true;
+  return Math.abs(persistedAt - optimisticAt) <= CALL_OPTIMISTIC_MESSAGE_RECONCILE_MS;
 }
 
 function findParticipantForTurn(turn: ConversationCallTurn, participants: Participant[]) {
@@ -845,19 +885,38 @@ function ParticipantTile({
           ? "idle"
           : null;
   const videoLoops = activeVideoKind === "idle" || activeVideoKind === "talking";
+  const videoResetKey = videoLoops
+    ? "loop"
+    : `${videoPlayback?.voiceKey ?? "one-shot"}:${videoPlayback?.nonce ?? 0}`;
   const videoKey = [
     participant.id,
     activeVideoKind ?? "avatar",
-    videoPlayback?.voiceKey ?? "idle",
-    videoPlayback?.nonce ?? 0,
+    videoResetKey,
+    characterVideoUrl ?? "",
     characterVideoClip?.trimStartSeconds ?? 0,
     characterVideoClip?.trimEndSeconds ?? "end",
   ].join(":");
   const trimEndedRef = useRef(false);
+  const [readyVideoKey, setReadyVideoKey] = useState<string | null>(null);
+  const videoReady = readyVideoKey === videoKey;
 
   useEffect(() => {
     trimEndedRef.current = false;
+    setReadyVideoKey(null);
   }, [videoKey]);
+
+  useEffect(() => {
+    if (!characterVideoUrl || !videoLoops) return;
+    const video = videoRef.current;
+    if (!video) return;
+    let animationFrame = 0;
+    const tick = () => {
+      handleCallVideoLoopFrame(video, characterVideoClip);
+      animationFrame = window.requestAnimationFrame(tick);
+    };
+    animationFrame = window.requestAnimationFrame(tick);
+    return () => window.cancelAnimationFrame(animationFrame);
+  }, [characterVideoClip, characterVideoUrl, videoKey, videoLoops]);
 
   return (
     <div
@@ -872,43 +931,70 @@ function ParticipantTile({
       {cameraStream ? (
         <video ref={videoRef} autoPlay muted playsInline className="absolute inset-0 h-full w-full object-cover" />
       ) : characterVideoUrl ? (
-        <video
-          key={videoKey}
-          src={characterVideoUrl}
-          autoPlay
-          muted
-          playsInline
-          loop={videoLoops}
-          className="absolute inset-0 h-full w-full object-cover"
-          onLoadedMetadata={(event) => {
-            keepCallVideoSilent(event);
-            seekCallVideoToTrimStart(event.currentTarget, characterVideoClip);
-          }}
-          onPlay={(event) => {
-            keepCallVideoSilent(event);
-            seekCallVideoToTrimStart(event.currentTarget, characterVideoClip);
-          }}
-          onTimeUpdate={(event) => {
-            handleCallVideoTrimTimeUpdate(event.currentTarget, characterVideoClip, {
-              loop: videoLoops,
-              onEnded: () => {
-                if (trimEndedRef.current) return;
-                trimEndedRef.current = true;
-                if (videoPlayback?.followKind && videoPlayback.voiceKey) {
-                  onVideoEmotionEnded(participant.id, videoPlayback.voiceKey);
-                }
-              },
-            });
-          }}
-          onVolumeChange={keepCallVideoSilent}
-          onEnded={() => {
-            if (trimEndedRef.current) return;
-            trimEndedRef.current = true;
-            if (videoPlayback?.followKind && videoPlayback.voiceKey) {
-              onVideoEmotionEnded(participant.id, videoPlayback.voiceKey);
-            }
-          }}
-        />
+        <>
+          <CallAvatar
+            participant={participant}
+            className={cn("max-h-[55%] max-w-[55%]", densityClasses.avatar)}
+            fallbackClassName={densityClasses.fallback}
+          />
+          <video
+            key={videoKey}
+            src={characterVideoUrl}
+            autoPlay
+            muted
+            playsInline
+            loop={false}
+            preload="auto"
+            poster={participant.avatarUrl ?? undefined}
+            className={cn(
+              "absolute inset-0 h-full w-full object-cover transition-opacity duration-75",
+              videoReady ? "opacity-100" : "opacity-0",
+            )}
+            onLoadedMetadata={(event) => {
+              keepCallVideoSilent(event);
+              seekCallVideoToTrimStart(event.currentTarget, characterVideoClip);
+            }}
+            onLoadedData={(event) => {
+              keepCallVideoSilent(event);
+              seekCallVideoToTrimStart(event.currentTarget, characterVideoClip);
+              setReadyVideoKey(videoKey);
+            }}
+            onCanPlay={(event) => {
+              keepCallVideoSilent(event);
+              seekCallVideoToTrimStart(event.currentTarget, characterVideoClip);
+              setReadyVideoKey(videoKey);
+            }}
+            onPlay={(event) => {
+              keepCallVideoSilent(event);
+              seekCallVideoToTrimStart(event.currentTarget, characterVideoClip);
+            }}
+            onTimeUpdate={(event) => {
+              handleCallVideoTrimTimeUpdate(event.currentTarget, characterVideoClip, {
+                loop: false,
+                onEnded: () => {
+                  if (trimEndedRef.current) return;
+                  trimEndedRef.current = true;
+                  if (videoPlayback?.followKind && videoPlayback.voiceKey) {
+                    onVideoEmotionEnded(participant.id, videoPlayback.voiceKey);
+                  }
+                },
+              });
+            }}
+            onVolumeChange={keepCallVideoSilent}
+            onEnded={(event) => {
+              if (videoLoops) {
+                seekCallVideoToTrimStart(event.currentTarget, characterVideoClip);
+                void event.currentTarget.play().catch(() => undefined);
+                return;
+              }
+              if (trimEndedRef.current) return;
+              trimEndedRef.current = true;
+              if (videoPlayback?.followKind && videoPlayback.voiceKey) {
+                onVideoEmotionEnded(participant.id, videoPlayback.voiceKey);
+              }
+            }}
+          />
+        </>
       ) : (
         <CallAvatar
           participant={participant}
@@ -1003,6 +1089,8 @@ export function ConversationCallSurface({
   const interruptedVoiceKeyRef = useRef<string | null>(null);
   const userInterruptionVoicedMsRef = useRef(0);
   const voicePlaybackInterruptedRef = useRef(false);
+  const callCancelledRef = useRef(session.status !== "active");
+  const callPlaybackAbortRef = useRef<AbortController | null>(null);
   const participantIdsRef = useRef<Set<string>>(new Set());
   const playedStartSoundForRef = useRef<string | null>(null);
   const playedEndSoundForRef = useRef<string | null>(null);
@@ -1013,9 +1101,22 @@ export function ConversationCallSurface({
     if (optimisticCallMessages.length === 0) return persistedMessages;
     const byId = new Map<string, ConversationCallMessage>();
     for (const message of persistedMessages) byId.set(message.id, message);
-    for (const message of optimisticCallMessages) byId.set(message.id, message);
+    for (const message of optimisticCallMessages) {
+      if (persistedMessages.some((persisted) => isSamePersistedCallMessage(message, persisted))) continue;
+      byId.set(message.id, message);
+    }
     return [...byId.values()].sort((left, right) => Date.parse(left.createdAt) - Date.parse(right.createdAt));
   }, [optimisticCallMessages, persistedMessages]);
+
+  useEffect(() => {
+    if (optimisticCallMessages.length === 0 || persistedMessages.length === 0) return;
+    setOptimisticCallMessages((current) =>
+      current.filter(
+        (optimistic) =>
+          !persistedMessages.some((persisted) => isSamePersistedCallMessage(optimistic, persisted)),
+      ),
+    );
+  }, [optimisticCallMessages.length, persistedMessages]);
   const callAudioEnabled = ttsConfig?.callAudioEnabled === true;
   const audioInputMode = ttsConfig?.callAudioInputMode ?? "local_whisper";
   const systemVoiceInputMode = audioInputMode === "system";
@@ -1191,6 +1292,21 @@ export function ConversationCallSurface({
     stopStream(screenStream);
   }, [cameraStream, screenStream, stopLiveMicCapture, stopStream]);
 
+  useEffect(() => {
+    callCancelledRef.current = session.status !== "active";
+    callPlaybackAbortRef.current?.abort();
+    callPlaybackAbortRef.current = session.status === "active" ? new AbortController() : null;
+    if (session.status !== "active") {
+      ttsService.stop();
+    }
+    return () => {
+      callCancelledRef.current = true;
+      callPlaybackAbortRef.current?.abort();
+      ttsService.stop();
+      callPlaybackAbortRef.current = null;
+    };
+  }, [session.id, session.status]);
+
   const playEndSoundOnce = useCallback(() => {
     if (playedEndSoundForRef.current === session.id) return;
     playedEndSoundForRef.current = session.id;
@@ -1207,7 +1323,10 @@ export function ConversationCallSurface({
       setQueuedCallInteractions((count) => count + 1);
       const queued = callInteractionQueueRef.current
         .catch(() => undefined)
-        .then(task)
+        .then(async () => {
+          if (callCancelledRef.current) return;
+          await task();
+        })
         .catch((error) => {
           if (options.quiet) {
             console.warn("[conversation-call] Queued interaction failed", error);
@@ -1501,9 +1620,17 @@ export function ConversationCallSurface({
   const updateVoiceInterruptionDetector = useCallback(
     (speechConfirmed: boolean) => {
       const activeVoice = activeCallVoiceRef.current;
-      const ttsPlaying = ttsService.getState() === "playing";
-      if (!speechConfirmed || !activeVoice || !ttsPlaying) {
+      const ttsState = ttsService.getState();
+      const ttsInterruptible = ttsState === "playing" || ttsState === "loading";
+      if (!activeVoice || !ttsInterruptible) {
         userInterruptionVoicedMsRef.current = 0;
+        return;
+      }
+      if (!speechConfirmed) {
+        userInterruptionVoicedMsRef.current = Math.max(
+          0,
+          userInterruptionVoicedMsRef.current - CALL_MIC_VAD_INTERVAL_MS,
+        );
         return;
       }
       userInterruptionVoicedMsRef.current += CALL_MIC_VAD_INTERVAL_MS;
@@ -1516,11 +1643,14 @@ export function ConversationCallSurface({
 
   const playTurns = useCallback(
     async (turns: ConversationCallTurn[]) => {
+      if (callCancelledRef.current) return;
+      const playbackSignal = callPlaybackAbortRef.current?.signal;
       playingTurnsRef.current = true;
       voicePlaybackInterruptedRef.current = false;
       let shouldEndCallAfterPlayback = false;
       try {
         for (let index = 0; index < turns.length; index += 1) {
+          if (callCancelledRef.current || playbackSignal?.aborted) break;
           const turn = turns[index]!;
           let pauseSourceTurn = turn;
           if (turn.mode === "command") {
@@ -1570,82 +1700,115 @@ export function ConversationCallSurface({
                   candidate.speakerName,
                   candidate.characterId ?? candidateParticipant?.characterId,
                 );
-                if (!candidateVoice || candidateVoice !== voice) break;
-                if ((candidateParticipant?.id ?? null) !== (participant?.id ?? null)) break;
+                if (!candidateVoice) break;
                 voiceBatch.push({ turn: candidate, participant: candidateParticipant, voice: candidateVoice });
                 batchEndIndex += 1;
               }
 
-              const tone = Array.from(
-                new Set(voiceBatch.map((item) => item.turn.tone?.trim()).filter((value): value is string => !!value)),
-              ).join(", ");
-              const spokenText = voiceBatch.map((item) => item.turn.content.trim()).join("\n");
-              const spokenChunks = buildCallTtsVideoChunks(
-                voiceBatch.map((item) => item.turn.content),
-                tone,
+              const sequenceItems = voiceBatch.flatMap((item) => {
+                const tone = item.turn.tone?.trim() ?? "";
+                const chunks = buildCallTtsVideoChunks([item.turn.content], tone);
+                const participantId = item.participant?.id ?? null;
+                const voiceKey = [
+                  session.id,
+                  participantId ?? item.turn.speakerName,
+                  item.turn.id ?? item.turn.content.slice(0, 24),
+                ].join(":");
+                return chunks.map((chunk) => ({
+                  item,
+                  chunk,
+                  participantId,
+                  voiceKey,
+                  tone,
+                  spokenText: item.turn.content.trim(),
+                }));
+              });
+              const speakerKeys = new Set(
+                sequenceItems.map((item) => item.participantId ?? item.item.turn.speakerName),
               );
-              const voiceKey = [
-                session.id,
-                participant?.id ?? turn.speakerName,
-                voiceBatch.map((item) => item.turn.id ?? item.turn.content.slice(0, 24)).join("|"),
-              ].join(":");
-              activeCallVoiceRef.current = {
-                key: voiceKey,
-                characterId: participant?.characterId ?? turn.characterId ?? null,
-                speakerName: turn.speakerName,
-                spokenText,
-              };
-              userInterruptionVoicedMsRef.current = 0;
-              const participantId = participant?.id ?? null;
+              let activeVideoParticipantId: string | null = null;
+              let activeVideoVoiceKey: string | null = null;
               try {
                 await ttsService.speakSequence(
-                  spokenChunks.map((chunk) => ({
+                  sequenceItems.map(({ item, chunk, tone, participantId }) => ({
                     text: chunk.text,
-                    speaker: turn.speakerName,
+                    speaker: item.turn.speakerName,
                     tone: tone || undefined,
-                    voice,
+                    voice: item.voice,
+                    activeId: participantId,
                   })),
                   participant?.id ?? `${session.id}:${turn.id ?? turn.content.slice(0, 12)}`,
                   {
-                    progressive: ttsConfig.progressivePlayback,
+                    signal: playbackSignal,
+                    progressive: speakerKeys.size > 1 ? false : ttsConfig.progressivePlayback,
                     volume: characterVoicePlaybackVolume,
                     muted: characterVoicesMuted,
                     onChunkStart: (_request, chunkIndex) => {
-                      if (!characterVideoEnabled || !participantId) return;
-                      const chunk = spokenChunks[chunkIndex];
-                      if (!chunk) return;
+                      const meta = sequenceItems[chunkIndex];
+                      if (!meta) return;
+                      activeCallVoiceRef.current = {
+                        key: meta.voiceKey,
+                        characterId: meta.item.participant?.characterId ?? meta.item.turn.characterId ?? null,
+                        speakerName: meta.item.turn.speakerName,
+                        spokenText: meta.spokenText,
+                      };
+                      userInterruptionVoicedMsRef.current = 0;
+                      if (!characterVideoEnabled || !meta.participantId) return;
+                      if (
+                        activeVideoParticipantId &&
+                        activeVideoVoiceKey &&
+                        (activeVideoParticipantId !== meta.participantId || activeVideoVoiceKey !== meta.voiceKey)
+                      ) {
+                        clearParticipantVideoTalking(activeVideoParticipantId, activeVideoVoiceKey);
+                      }
+                      activeVideoParticipantId = meta.participantId;
+                      activeVideoVoiceKey = meta.voiceKey;
                       setParticipantVideoTalking(
-                        participantId,
-                        makeCallVideoCueKey(voiceKey, chunkIndex),
-                        chunk.videoKind,
-                        chunk.followKind,
+                        meta.participantId,
+                        makeCallVideoCueKey(meta.voiceKey, chunkIndex),
+                        meta.chunk.videoKind,
+                        meta.chunk.followKind,
                       );
+                    },
+                    onChunkEnd: (_request, chunkIndex) => {
+                      const meta = sequenceItems[chunkIndex];
+                      if (!meta) return;
+                      if (activeCallVoiceRef.current?.key === meta.voiceKey) {
+                        activeCallVoiceRef.current = null;
+                        userInterruptionVoicedMsRef.current = 0;
+                      }
                     },
                   },
                 );
               } finally {
-                clearParticipantVideoTalking(participantId, voiceKey);
-              }
-              if (activeCallVoiceRef.current?.key === voiceKey) {
                 activeCallVoiceRef.current = null;
                 userInterruptionVoicedMsRef.current = 0;
+                const clearedVideoKeys = new Set<string>();
+                for (const meta of sequenceItems) {
+                  if (!meta.participantId) continue;
+                  const key = `${meta.participantId}:${meta.voiceKey}`;
+                  if (clearedVideoKeys.has(key)) continue;
+                  clearedVideoKeys.add(key);
+                  clearParticipantVideoTalking(meta.participantId, meta.voiceKey);
+                }
               }
               pauseSourceTurn = turns[batchEndIndex] ?? turn;
               index = batchEndIndex;
               if (voicePlaybackInterruptedRef.current) break;
             }
           }
+          if (callCancelledRef.current || playbackSignal?.aborted) break;
           const nextTurn = turns[index + 1];
           const pauseMs =
             pauseSourceTurn.mode === "text" && nextTurn?.mode === "voice" ? DEFAULT_TEXT_TO_VOICE_PAUSE_MS : 0;
-          if (nextTurn && pauseMs > 0) await wait(pauseMs);
+          if (nextTurn && pauseMs > 0 && !callCancelledRef.current && !playbackSignal?.aborted) await wait(pauseMs);
         }
       } finally {
         activeCallVoiceRef.current = null;
         userInterruptionVoicedMsRef.current = 0;
         playingTurnsRef.current = false;
       }
-      if (shouldEndCallAfterPlayback) {
+      if (shouldEndCallAfterPlayback && !callCancelledRef.current && !playbackSignal?.aborted) {
         await handleCallEndedByCharacter();
       }
     },
@@ -2232,6 +2395,8 @@ export function ConversationCallSurface({
   }, []);
 
   const handleEnd = useCallback(async () => {
+    callCancelledRef.current = true;
+    callPlaybackAbortRef.current?.abort();
     cleanupLiveCallMedia();
     playEndSoundOnce();
     try {
@@ -2558,6 +2723,23 @@ export function ConversationCallSurface({
             </div>
           )}
 
+          {mutedReminderVisible && !recording ? (
+            <div
+              className="absolute inset-x-3 bottom-24 z-30 mx-auto rounded-xl border border-[var(--marinara-chat-chrome-panel-border)] bg-[var(--marinara-chat-chrome-panel-bg)] px-3 py-2.5 pr-8 text-left text-xs leading-relaxed text-[var(--marinara-chat-chrome-panel-title)] shadow-xl shadow-black/25 sm:hidden"
+              role="status"
+            >
+              <button
+                type="button"
+                onClick={() => setMutedReminderVisible(false)}
+                className="absolute right-1.5 top-1.5 rounded-md p-1 text-[var(--marinara-chat-chrome-panel-muted)] transition-colors hover:bg-[var(--marinara-chat-chrome-highlight-bg-hover)] hover:text-[var(--marinara-chat-chrome-button-text-hover)]"
+                aria-label="Dismiss muted reminder"
+              >
+                <X size="0.75rem" />
+              </button>
+              You are muted! Remember to unmute yourself first if you want to talk.
+            </div>
+          ) : null}
+
           <div className="pointer-events-none absolute inset-x-0 bottom-4 z-20 flex justify-center px-3">
             <div className="pointer-events-auto relative max-w-[calc(100vw-1.5rem)]">
               {soundboardEnabled && soundboardOpen && (
@@ -2656,7 +2838,7 @@ export function ConversationCallSurface({
                 <div className="relative flex min-w-0 justify-center max-sm:w-full">
                   {mutedReminderVisible && !recording ? (
                     <div
-                      className="absolute bottom-full left-1/2 z-30 mb-3 w-64 max-w-[calc(100vw-2rem)] -translate-x-1/2 rounded-xl border border-[var(--marinara-chat-chrome-panel-border)] bg-[var(--marinara-chat-chrome-panel-bg)] px-3 py-2.5 pr-8 text-left text-xs leading-relaxed text-[var(--marinara-chat-chrome-panel-title)] shadow-xl shadow-black/25"
+                      className="absolute bottom-full left-1/2 z-30 mb-3 hidden w-64 max-w-[calc(100vw-2rem)] -translate-x-1/2 rounded-xl border border-[var(--marinara-chat-chrome-panel-border)] bg-[var(--marinara-chat-chrome-panel-bg)] px-3 py-2.5 pr-8 text-left text-xs leading-relaxed text-[var(--marinara-chat-chrome-panel-title)] shadow-xl shadow-black/25 sm:block"
                       role="status"
                     >
                       <button

--- a/packages/client/src/components/chat/ConversationCallSurface.tsx
+++ b/packages/client/src/components/chat/ConversationCallSurface.tsx
@@ -354,7 +354,8 @@ function getSystemVoiceTypingHint() {
   const platform = `${navigator.platform ?? ""} ${navigator.userAgent ?? ""}`.toLowerCase();
   const isAppleMobile = /iphone|ipad|ipod/.test(platform) || (platform.includes("mac") && navigator.maxTouchPoints > 1);
   if (isAppleMobile) return "The call input is focused. Tap the keyboard microphone yourself, then send.";
-  if (platform.includes("android")) return "The call input is focused. Tap the keyboard microphone yourself, then send.";
+  if (platform.includes("android"))
+    return "The call input is focused. Tap the keyboard microphone yourself, then send.";
   if (platform.includes("mac")) {
     return "The call input is focused. Start macOS Dictation yourself, then send.";
   }
@@ -729,7 +730,10 @@ async function convertRecordedAudioToWavFile(blob: Blob): Promise<File> {
 }
 
 function CallCustomClipPreview({ clip }: { clip: ConversationCallCustomClipExtra }) {
-  const { data: manifest } = useConversationCallCharacterVideos(clip.characterId, Boolean(clip.characterId && clip.clipId));
+  const { data: manifest } = useConversationCallCharacterVideos(
+    clip.characterId,
+    Boolean(clip.characterId && clip.clipId),
+  );
   const customClip = clip.clipId ? manifest?.customClips.find((item) => item.id === clip.clipId) : null;
   const status = customClip?.status ?? "generating";
   const title = customClip?.label ?? clip.label;
@@ -872,9 +876,7 @@ function ParticipantTile({
   const fallbackVideoClip =
     requestedVideoKind !== "talking" ? getReadyCallVideoClip(characterVideoManifest, "talking") : null;
   const idleVideoClip = requestedVideoKind !== "idle" ? getReadyCallVideoClip(characterVideoManifest, "idle") : null;
-  const characterVideoClip = characterVideoEnabled
-    ? (preferredVideoClip ?? fallbackVideoClip ?? idleVideoClip)
-    : null;
+  const characterVideoClip = characterVideoEnabled ? (preferredVideoClip ?? fallbackVideoClip ?? idleVideoClip) : null;
   const characterVideoUrl = characterVideoClip?.url ?? null;
   const activeVideoKind =
     characterVideoClip === preferredVideoClip
@@ -885,9 +887,7 @@ function ParticipantTile({
           ? "idle"
           : null;
   const videoLoops = activeVideoKind === "idle" || activeVideoKind === "talking";
-  const videoResetKey = videoLoops
-    ? "loop"
-    : `${videoPlayback?.voiceKey ?? "one-shot"}:${videoPlayback?.nonce ?? 0}`;
+  const videoResetKey = videoLoops ? "loop" : `${videoPlayback?.voiceKey ?? "one-shot"}:${videoPlayback?.nonce ?? 0}`;
   const videoKey = [
     participant.id,
     activeVideoKind ?? "avatar",
@@ -1062,9 +1062,7 @@ export function ConversationCallSurface({
   const [recording, setRecording] = useState(false);
   const [browserSpeechSupported, setBrowserSpeechSupported] = useState(false);
   const [optimisticCallMessages, setOptimisticCallMessages] = useState<ConversationCallMessage[]>([]);
-  const [characterVideoPlayback, setCharacterVideoPlayback] = useState<Record<string, CharacterVideoPlaybackState>>(
-    {},
-  );
+  const [characterVideoPlayback, setCharacterVideoPlayback] = useState<Record<string, CharacterVideoPlaybackState>>({});
   const mobileCallLayout = useMobileCallLayout();
   const [clockNow, setClockNow] = useState(() => Date.now());
   const [joinedParticipantIds, setJoinedParticipantIds] = useState<Set<string>>(() => new Set(["user"]));
@@ -1112,8 +1110,7 @@ export function ConversationCallSurface({
     if (optimisticCallMessages.length === 0 || persistedMessages.length === 0) return;
     setOptimisticCallMessages((current) =>
       current.filter(
-        (optimistic) =>
-          !persistedMessages.some((persisted) => isSamePersistedCallMessage(optimistic, persisted)),
+        (optimistic) => !persistedMessages.some((persisted) => isSamePersistedCallMessage(optimistic, persisted)),
       ),
     );
   }, [optimisticCallMessages.length, persistedMessages]);
@@ -1190,8 +1187,7 @@ export function ConversationCallSurface({
   const visibleCallMessages = useMemo(
     () =>
       messages.filter(
-        (message) =>
-          message.kind !== "speech" && message.kind !== "command" && message.extra?.hiddenFromUser !== true,
+        (message) => message.kind !== "speech" && message.kind !== "command" && message.extra?.hiddenFromUser !== true,
       ),
     [messages],
   );
@@ -1230,7 +1226,14 @@ export function ConversationCallSurface({
       return "Responding";
     }
     return "Live";
-  }, [pendingParticipants, queuedCallInteractions, recording, sendMedia.isPending, sendMessage.isPending, userSpeaking]);
+  }, [
+    pendingParticipants,
+    queuedCallInteractions,
+    recording,
+    sendMedia.isPending,
+    sendMessage.isPending,
+    userSpeaking,
+  ]);
 
   const setUserSpeakingState = useCallback((speaking: boolean) => {
     if (userSpeakingRef.current === speaking) return;
@@ -1465,9 +1468,7 @@ export function ConversationCallSurface({
   useEffect(
     () =>
       ttsService.subscribe((state, activeId) => {
-        setSpeakingId(
-          state === "playing" && activeId && participantIdsRef.current.has(activeId) ? activeId : null,
-        );
+        setSpeakingId(state === "playing" && activeId && participantIdsRef.current.has(activeId) ? activeId : null);
       }),
     [],
   );
@@ -1714,15 +1715,23 @@ export function ConversationCallSurface({
                   participantId ?? item.turn.speakerName,
                   item.turn.id ?? item.turn.content.slice(0, 24),
                 ].join(":");
-                return chunks.map((chunk) => ({
-                  item,
-                  chunk,
-                  participantId,
-                  voiceKey,
-                  tone,
-                  spokenText: item.turn.content.trim(),
-                }));
+                return chunks
+                  .map((chunk) => ({
+                    item,
+                    chunk,
+                    text: chunk.text.trim(),
+                    participantId,
+                    voiceKey,
+                    tone,
+                    spokenText: item.turn.content.trim(),
+                  }))
+                  .filter((chunk) => chunk.text.length > 0);
               });
+              if (sequenceItems.length === 0) {
+                pauseSourceTurn = turns[batchEndIndex] ?? turn;
+                index = batchEndIndex;
+                continue;
+              }
               const speakerKeys = new Set(
                 sequenceItems.map((item) => item.participantId ?? item.item.turn.speakerName),
               );
@@ -1730,8 +1739,8 @@ export function ConversationCallSurface({
               let activeVideoVoiceKey: string | null = null;
               try {
                 await ttsService.speakSequence(
-                  sequenceItems.map(({ item, chunk, tone, participantId }) => ({
-                    text: chunk.text,
+                  sequenceItems.map(({ item, text, tone, participantId }) => ({
+                    text,
                     speaker: item.turn.speakerName,
                     tone: tone || undefined,
                     voice: item.voice,
@@ -2420,10 +2429,7 @@ export function ConversationCallSurface({
   );
 
   const applyCallMessageReactions = useCallback(
-    async (
-      message: ConversationCallMessage,
-      buildNext: (current: MessageReaction[]) => MessageReaction[],
-    ) => {
+    async (message: ConversationCallMessage, buildNext: (current: MessageReaction[]) => MessageReaction[]) => {
       const key = conversationCallKeys.messages(session.id);
       const previous = queryClient.getQueryData<ConversationCallMessage[]>(key);
       const cachedMessage = previous?.find((item) => item.id === message.id) ?? message;

--- a/packages/client/src/components/connections/ConnectionEditor.tsx
+++ b/packages/client/src/components/connections/ConnectionEditor.tsx
@@ -164,7 +164,11 @@ function videoSourceToProviderOption(value: string | null | undefined): string {
   return service === "gemini_omni" || service === "google_veo" ? "google_ai_studio" : service;
 }
 
-function videoProviderServiceForModel(provider: string | null | undefined, model = "", baseUrl = ""): VideoDefaultsService {
+function videoProviderServiceForModel(
+  provider: string | null | undefined,
+  model = "",
+  baseUrl = "",
+): VideoDefaultsService {
   const normalized = provider?.trim();
   if (normalized === "google_ai_studio") {
     return videoSourceToDefaultsService(inferVideoSource(model, baseUrl));
@@ -321,10 +325,7 @@ export function ConnectionEditor() {
   // Remote models fetched from provider API
   const [remoteModels, setRemoteModels] = useState<RemoteConnectionModel[]>([]);
   const [fetchError, setFetchError] = useState<string | null>(null);
-  const baseUrlValidation = useMemo(
-    () => normalizeEndpointUrlInput(localBaseUrl, "Base URL"),
-    [localBaseUrl],
-  );
+  const baseUrlValidation = useMemo(() => normalizeEndpointUrlInput(localBaseUrl, "Base URL"), [localBaseUrl]);
   const embeddingBaseUrlValidation = useMemo(
     () => normalizeEndpointUrlInput(localEmbeddingBaseUrl, "Embedding endpoint URL"),
     [localEmbeddingBaseUrl],
@@ -343,9 +344,7 @@ export function ConnectionEditor() {
     setLocalMaxContext(Number(c.maxContext) || 128000);
     setLocalMaxParallelJobs(normalizeMaxParallelJobs(c.maxParallelJobs));
     setLocalEnableCaching(c.enableCaching === "true" || c.enableCaching === true);
-    setLocalAnthropicExtendedCacheTtl(
-      c.anthropicExtendedCacheTtl === "true" || c.anthropicExtendedCacheTtl === true,
-    );
+    setLocalAnthropicExtendedCacheTtl(c.anthropicExtendedCacheTtl === "true" || c.anthropicExtendedCacheTtl === true);
     setLocalCachingAtDepth(normalizeCachingAtDepth(c.cachingAtDepth));
     setLocalDefaultForAgents(c.defaultForAgents === "true" || c.defaultForAgents === true);
     setLocalEmbeddingModel((c.embeddingModel as string) ?? "");
@@ -378,7 +377,9 @@ export function ConnectionEditor() {
       (c.model as string) ?? "",
       (c.baseUrl as string) ?? "",
     );
-    const videoProviderSource = videoSourceToProviderOption(videoGenerationSource || explicitVideoService || videoDefaultsService);
+    const videoProviderSource = videoSourceToProviderOption(
+      videoGenerationSource || explicitVideoService || videoDefaultsService,
+    );
     setLocalImageGenerationSource(imageGenerationSource);
     setLocalComfyuiWorkflow((c.comfyuiWorkflow as string) ?? "");
     setLocalImageService(imageService);
@@ -395,9 +396,9 @@ export function ConnectionEditor() {
     );
     setLocalVideoDefaults(
       (c.provider as APIProvider) === "video_generation"
-        ? (storedVideoDefaults
-            ? sanitizeVideoGenerationProfile({ ...storedVideoDefaults, service: videoDefaultsService })
-            : createDefaultVideoGenerationProfile(videoDefaultsService))
+        ? storedVideoDefaults
+          ? sanitizeVideoGenerationProfile({ ...storedVideoDefaults, service: videoDefaultsService })
+          : createDefaultVideoGenerationProfile(videoDefaultsService)
         : null,
     );
     setImageDefaultsExpanded(!!storedImageDefaults);
@@ -487,9 +488,9 @@ export function ConnectionEditor() {
       ? API_KEY_LINKS.xai
       : localProvider === "video_generation" && selectedVideoDefaultsService === "openrouter"
         ? API_KEY_LINKS.openrouter
-      : localProvider === "video_generation" && selectedVideoDefaultsService === "seedance"
-        ? { label: "Open Seedance API docs", url: "https://seedance2.ai/pl/api-docs" }
-      : API_KEY_LINKS[localProvider];
+        : localProvider === "video_generation" && selectedVideoDefaultsService === "seedance"
+          ? { label: "Open Seedance API docs", url: "https://seedance2.ai/api-docs" }
+          : API_KEY_LINKS[localProvider];
 
   useEffect(() => {
     if (localProvider !== "image_generation" || !selectedImageDefaultsService) {
@@ -618,14 +619,11 @@ export function ConnectionEditor() {
       embeddingConnectionId: localEmbeddingConnectionId || null,
       promptPresetId: !isMediaProvider ? localPromptPresetId || null : null,
       openrouterProvider: localOpenrouterProvider || null,
-      imageGenerationSource:
-        isImageProvider ? localImageGenerationSource || localImageService || null : null,
+      imageGenerationSource: isImageProvider ? localImageGenerationSource || localImageService || null : null,
       comfyuiWorkflow: isImageProvider ? localComfyuiWorkflow || null : null,
       imageService: isImageProvider ? localImageGenerationSource || localImageService || null : null,
       imageEndpointId:
-        isImageProvider && selectedImageService === "runpod_comfyui"
-          ? localImageEndpointId || null
-          : null,
+        isImageProvider && selectedImageService === "runpod_comfyui" ? localImageEndpointId || null : null,
       videoGenerationSource: isVideoProvider ? selectedVideoProvider || null : null,
       videoService: isVideoProvider ? selectedVideoDefaultsService : null,
       maxTokensOverride: localMaxTokensOverride ?? null,
@@ -754,21 +752,20 @@ export function ConnectionEditor() {
     const isImageProvider = localProvider === "image_generation";
     const isVideoProvider = localProvider === "video_generation";
     const isMediaProvider = isImageProvider || isVideoProvider;
-    const defaultParameters =
-      isImageProvider
-        ? buildImageDefaultParameters(
+    const defaultParameters = isImageProvider
+      ? buildImageDefaultParameters(
+          currentConnection.defaultParameters,
+          selectedImageDefaultsService && localImageDefaults
+            ? sanitizeImageGenerationProfile(localImageDefaults, selectedImageDefaultsService)
+            : null,
+        )
+      : isVideoProvider
+        ? buildVideoDefaultParameters(
             currentConnection.defaultParameters,
-            selectedImageDefaultsService && localImageDefaults
-              ? sanitizeImageGenerationProfile(localImageDefaults, selectedImageDefaultsService)
+            localVideoDefaults
+              ? sanitizeVideoGenerationProfile({ ...localVideoDefaults, service: selectedVideoDefaultsService })
               : null,
           )
-        : isVideoProvider
-          ? buildVideoDefaultParameters(
-              currentConnection.defaultParameters,
-              localVideoDefaults
-                ? sanitizeVideoGenerationProfile({ ...localVideoDefaults, service: selectedVideoDefaultsService })
-                : null,
-            )
         : localDefaultParametersEnabled
           ? (localDefaultParameters as unknown as Record<string, unknown>)
           : null;
@@ -803,9 +800,7 @@ export function ConnectionEditor() {
       videoGenerationSource: videoProvider,
       videoService,
       imageEndpointId:
-        isImageProvider && selectedImageService === "runpod_comfyui"
-          ? localImageEndpointId || null
-          : null,
+        isImageProvider && selectedImageService === "runpod_comfyui" ? localImageEndpointId || null : null,
       comfyuiWorkflow: isImageProvider ? localComfyuiWorkflow || null : null,
       claudeFastMode: localClaudeFastMode,
     };
@@ -1567,7 +1562,11 @@ export function ConnectionEditor() {
                         const previousDefaultModel = defaultVideoModelForService(selectedVideoDefaultsService);
                         const nextDefaultModel = defaultVideoModelForService(src.id);
                         const shouldSeedModel = !localModel || localModel === previousDefaultModel;
-                        const nextDefaultsService = videoProviderServiceForModel(src.id, nextDefaultModel, src.defaultBaseUrl);
+                        const nextDefaultsService = videoProviderServiceForModel(
+                          src.id,
+                          nextDefaultModel,
+                          src.defaultBaseUrl,
+                        );
                         setLocalVideoGenerationSource(src.id);
                         setLocalVideoService(nextDefaultsService);
                         setLocalVideoDefaults(createDefaultVideoGenerationProfile(nextDefaultsService));
@@ -2211,66 +2210,64 @@ export function ConnectionEditor() {
                 Only one video generation connection should be marked as the default video connection.
               </p>
             )}
-            {isVideoGenerationProvider &&
-              selectedVideoDefaultsService === "seedance" &&
-              localVideoDefaults && (
-                <div className="mx-2 mt-2 space-y-2 rounded-lg bg-[var(--secondary)]/35 p-2 ring-1 ring-[var(--border)]">
-                  <SettingsSwitch
-                    label="Upload Seedance reference frames temporarily"
-                    checked={localVideoDefaults.seedance.temporaryPublicReferenceUploadEnabled}
-                    onChange={(checked) => {
-                      setLocalVideoDefaults(
-                        sanitizeVideoGenerationProfile({
-                          ...localVideoDefaults,
-                          service: "seedance",
-                          seedance: {
-                            ...localVideoDefaults.seedance,
-                            temporaryPublicReferenceUploadEnabled: checked,
-                          },
-                        }),
-                      );
-                      markDirty();
-                    }}
-                    description="Uses temporary public links when Seedance needs first/last-frame references and cannot fetch local Marinara URLs."
-                    className="p-1"
-                  />
-                  {localVideoDefaults.seedance.temporaryPublicReferenceUploadEnabled && (
-                    <label className="flex flex-wrap items-center justify-between gap-2 rounded-md bg-[var(--card)]/70 px-2 py-1.5 ring-1 ring-[var(--border)]">
-                      <span className="text-[0.625rem] font-medium text-[var(--muted-foreground)]">
-                        Temporary link lifetime
-                      </span>
-                      <select
-                        value={localVideoDefaults.seedance.temporaryPublicReferenceUploadExpiry}
-                        onChange={(event) => {
-                          const expiry = event.target.value as VideoReferenceUploadExpiry;
-                          setLocalVideoDefaults(
-                            sanitizeVideoGenerationProfile({
-                              ...localVideoDefaults,
-                              service: "seedance",
-                              seedance: {
-                                ...localVideoDefaults.seedance,
-                                temporaryPublicReferenceUploadExpiry: expiry,
-                              },
-                            }),
-                          );
-                          markDirty();
-                        }}
-                        className="h-8 rounded-md bg-[var(--background)] px-2 text-xs ring-1 ring-[var(--border)] focus:outline-none focus:ring-sky-400/50"
-                      >
-                        {VIDEO_REFERENCE_UPLOAD_EXPIRY_OPTIONS.map((option) => (
-                          <option key={option.value} value={option.value}>
-                            {option.label}
-                          </option>
-                        ))}
-                      </select>
-                    </label>
-                  )}
-                  <p className="px-1 text-[0.55rem] leading-relaxed text-[var(--muted-foreground)]">
-                    Keep this off if you do not want local avatar or gallery reference frames uploaded outside this
-                    Marinara install.
-                  </p>
-                </div>
-              )}
+            {isVideoGenerationProvider && selectedVideoDefaultsService === "seedance" && localVideoDefaults && (
+              <div className="mx-2 mt-2 space-y-2 rounded-lg bg-[var(--secondary)]/35 p-2 ring-1 ring-[var(--border)]">
+                <SettingsSwitch
+                  label="Upload Seedance reference frames temporarily"
+                  checked={localVideoDefaults.seedance.temporaryPublicReferenceUploadEnabled}
+                  onChange={(checked) => {
+                    setLocalVideoDefaults(
+                      sanitizeVideoGenerationProfile({
+                        ...localVideoDefaults,
+                        service: "seedance",
+                        seedance: {
+                          ...localVideoDefaults.seedance,
+                          temporaryPublicReferenceUploadEnabled: checked,
+                        },
+                      }),
+                    );
+                    markDirty();
+                  }}
+                  description="Uses temporary public links when Seedance needs first/last-frame references and cannot fetch local Marinara URLs."
+                  className="p-1"
+                />
+                {localVideoDefaults.seedance.temporaryPublicReferenceUploadEnabled && (
+                  <label className="flex flex-wrap items-center justify-between gap-2 rounded-md bg-[var(--card)]/70 px-2 py-1.5 ring-1 ring-[var(--border)]">
+                    <span className="text-[0.625rem] font-medium text-[var(--muted-foreground)]">
+                      Temporary link lifetime
+                    </span>
+                    <select
+                      value={localVideoDefaults.seedance.temporaryPublicReferenceUploadExpiry}
+                      onChange={(event) => {
+                        const expiry = event.target.value as VideoReferenceUploadExpiry;
+                        setLocalVideoDefaults(
+                          sanitizeVideoGenerationProfile({
+                            ...localVideoDefaults,
+                            service: "seedance",
+                            seedance: {
+                              ...localVideoDefaults.seedance,
+                              temporaryPublicReferenceUploadExpiry: expiry,
+                            },
+                          }),
+                        );
+                        markDirty();
+                      }}
+                      className="h-8 rounded-md bg-[var(--background)] px-2 text-xs ring-1 ring-[var(--border)] focus:outline-none focus:ring-sky-400/50"
+                    >
+                      {VIDEO_REFERENCE_UPLOAD_EXPIRY_OPTIONS.map((option) => (
+                        <option key={option.value} value={option.value}>
+                          {option.label}
+                        </option>
+                      ))}
+                    </select>
+                  </label>
+                )}
+                <p className="px-1 text-[0.55rem] leading-relaxed text-[var(--muted-foreground)]">
+                  Keep this off if you do not want local avatar or gallery reference frames uploaded outside this
+                  Marinara install.
+                </p>
+              </div>
+            )}
           </FieldGroup>
 
           {/* ── Claude (Subscription) — Fast Mode toggle ── */}
@@ -2286,36 +2283,36 @@ export function ConnectionEditor() {
                   <>
                     <span className="mt-0.5 block text-[var(--muted-foreground)]">
                       <strong className="text-amber-400">99% of users should leave this off.</strong> Fast mode is
-                      effectively a dead feature today — Claude/Anthropic removed support for downgrading current models,
-                      and Opus 4.7 has no faster variant to route to. Turning it on does nothing useful for roleplay
-                      quality and may add overhead. The toggle exists only so we don&apos;t have to ship a new release if
-                      Anthropic re-enables it. Leave off until that happens.
+                      effectively a dead feature today — Claude/Anthropic removed support for downgrading current
+                      models, and Opus 4.7 has no faster variant to route to. Turning it on does nothing useful for
+                      roleplay quality and may add overhead. The toggle exists only so we don&apos;t have to ship a new
+                      release if Anthropic re-enables it. Leave off until that happens.
                     </span>
                     <span className="mt-1.5 flex items-start gap-1 text-[var(--muted-foreground)]">
                       <AlertCircle size="0.625rem" className="mt-px shrink-0 text-amber-400" />
                       <span>
-                        <strong className="text-amber-400">Doesn&apos;t work on Claude Opus 4.7 yet.</strong> There is no
-                        faster Opus 4.7 variant for the SDK to route to, so this toggle is a no-op when Opus 4.7 is the
-                        selected model.
+                        <strong className="text-amber-400">Doesn&apos;t work on Claude Opus 4.7 yet.</strong> There is
+                        no faster Opus 4.7 variant for the SDK to route to, so this toggle is a no-op when Opus 4.7 is
+                        the selected model.
                       </span>
                     </span>
                   </>
                 }
                 checked={localClaudeFastMode}
                 onChange={async (next) => {
-                    if (next) {
-                      const confirmed = await showConfirmDialog({
-                        title: "YOU DON'T WANT THIS SETTING ON!",
-                        message:
-                          "Fast mode is effectively a dead feature today — Claude/Anthropic removed support for downgrading current models, and Opus 4.7 has no faster variant for the SDK to route to. Turning this on does nothing useful for roleplay quality and may add overhead. The toggle exists only so we don't have to ship a new release if Anthropic re-enables it.\n\nAre you absolutely sure you want to enable it?",
-                        confirmLabel: "Enable anyway",
-                        cancelLabel: "Keep it off",
-                        tone: "destructive",
-                      });
-                      if (!confirmed) return;
-                    }
-                    setLocalClaudeFastMode(next);
-                    markDirty();
+                  if (next) {
+                    const confirmed = await showConfirmDialog({
+                      title: "YOU DON'T WANT THIS SETTING ON!",
+                      message:
+                        "Fast mode is effectively a dead feature today — Claude/Anthropic removed support for downgrading current models, and Opus 4.7 has no faster variant for the SDK to route to. Turning this on does nothing useful for roleplay quality and may add overhead. The toggle exists only so we don't have to ship a new release if Anthropic re-enables it.\n\nAre you absolutely sure you want to enable it?",
+                      confirmLabel: "Enable anyway",
+                      cancelLabel: "Keep it off",
+                      tone: "destructive",
+                    });
+                    if (!confirmed) return;
+                  }
+                  setLocalClaudeFastMode(next);
+                  markDirty();
                 }}
                 labelPosition="start"
                 className="items-start justify-between rounded-xl bg-[var(--secondary)] px-3 py-2.5 ring-1 ring-[var(--border)]"
@@ -3178,11 +3175,11 @@ function VideoGenerationDefaultsPanel({
       ? `${value.xai.durationSeconds}s, ${value.xai.aspectRatio}, ${value.xai.resolution}`
       : service === "google_veo"
         ? `${value.googleVeo.durationSeconds}s, ${value.googleVeo.aspectRatio}, ${value.googleVeo.resolution}`
-      : service === "openrouter"
-        ? `${value.openrouter.durationSeconds}s, ${value.openrouter.aspectRatio}, ${value.openrouter.resolution}`
-      : service === "seedance"
-        ? `${value.seedance.durationSeconds}s, ${value.seedance.aspectRatio}, ${value.seedance.resolution}`
-      : `${value.geminiOmni.durationSeconds}s, ${value.geminiOmni.aspectRatio}`;
+        : service === "openrouter"
+          ? `${value.openrouter.durationSeconds}s, ${value.openrouter.aspectRatio}, ${value.openrouter.resolution}`
+          : service === "seedance"
+            ? `${value.seedance.durationSeconds}s, ${value.seedance.aspectRatio}, ${value.seedance.resolution}`
+            : `${value.geminiOmni.durationSeconds}s, ${value.geminiOmni.aspectRatio}`;
   const serviceLabel =
     service === "xai"
       ? "xAI Imagine"
@@ -3190,9 +3187,9 @@ function VideoGenerationDefaultsPanel({
         ? "Google AI Studio Veo"
         : service === "openrouter"
           ? "OpenRouter Video"
-        : service === "seedance"
-          ? "Seedance 2.0"
-          : "Google AI Studio Gemini Omni";
+          : service === "seedance"
+            ? "Seedance 2.0"
+            : "Google AI Studio Gemini Omni";
 
   const updateGeminiOmni = (patch: Partial<VideoGenerationDefaultsProfile["geminiOmni"]>) => {
     onChange({
@@ -3239,11 +3236,11 @@ function VideoGenerationDefaultsPanel({
           ? "Connection-scoped defaults for xAI scene video generation."
           : service === "google_veo"
             ? "Connection-scoped defaults for Google AI Studio Veo video generation."
-          : service === "openrouter"
-            ? "Connection-scoped defaults for OpenRouter asynchronous video generation."
-          : service === "seedance"
-            ? "Connection-scoped defaults for Seedance 2.0 asynchronous video generation."
-          : "Connection-scoped defaults for scene video generation. Duration is rendered into the Omni prompt."
+            : service === "openrouter"
+              ? "Connection-scoped defaults for OpenRouter asynchronous video generation."
+              : service === "seedance"
+                ? "Connection-scoped defaults for Seedance 2.0 asynchronous video generation."
+                : "Connection-scoped defaults for scene video generation. Duration is rendered into the Omni prompt."
       }
     >
       <div className="rounded-xl bg-[var(--secondary)]/40 ring-1 ring-[var(--border)]">
@@ -3253,9 +3250,7 @@ function VideoGenerationDefaultsPanel({
           className="flex w-full items-center justify-between gap-3 px-3 py-2.5 text-left transition-colors hover:bg-[var(--accent)]"
         >
           <div className="min-w-0">
-            <div className="text-xs font-medium text-[var(--foreground)]">
-              {serviceLabel} setup
-            </div>
+            <div className="text-xs font-medium text-[var(--foreground)]">{serviceLabel} setup</div>
             <div className="text-[0.625rem] text-[var(--muted-foreground)]">{summary}</div>
           </div>
           <ChevronDown
@@ -3287,9 +3282,9 @@ function VideoGenerationDefaultsPanel({
                         ? value.xai.durationSeconds
                         : service === "google_veo"
                           ? value.googleVeo.durationSeconds
-                        : service === "seedance"
-                          ? value.seedance.durationSeconds
-                          : value.openrouter.durationSeconds
+                          : service === "seedance"
+                            ? value.seedance.durationSeconds
+                            : value.openrouter.durationSeconds
                     }
                     min={service === "google_veo" || service === "seedance" ? 4 : 1}
                     max={service === "xai" || service === "seedance" ? 15 : service === "google_veo" ? 8 : 60}
@@ -3310,9 +3305,9 @@ function VideoGenerationDefaultsPanel({
                           ? value.xai.aspectRatio
                           : service === "google_veo"
                             ? value.googleVeo.aspectRatio
-                          : service === "seedance"
-                            ? value.seedance.aspectRatio
-                            : value.openrouter.aspectRatio
+                            : service === "seedance"
+                              ? value.seedance.aspectRatio
+                              : value.openrouter.aspectRatio
                       }
                       onChange={(event) => {
                         const aspectRatio = event.target.value === "9:16" ? "9:16" : "16:9";
@@ -3335,9 +3330,9 @@ function VideoGenerationDefaultsPanel({
                           ? value.xai.resolution
                           : service === "google_veo"
                             ? value.googleVeo.resolution
-                          : service === "seedance"
-                            ? value.seedance.resolution
-                            : value.openrouter.resolution
+                            : service === "seedance"
+                              ? value.seedance.resolution
+                              : value.openrouter.resolution
                       }
                       onChange={(event) => {
                         const resolution = event.target.value as VideoResolution;
@@ -3348,7 +3343,9 @@ function VideoGenerationDefaultsPanel({
                       }}
                       className="mt-1 w-full rounded-lg bg-[var(--card)] px-3 py-2 text-xs ring-1 ring-[var(--border)] focus:outline-none focus:ring-sky-400/50"
                     >
-                      {VIDEO_RESOLUTION_OPTIONS.filter((option) => service !== "google_veo" || option.value !== "480p").map((option) => (
+                      {VIDEO_RESOLUTION_OPTIONS.filter(
+                        (option) => service !== "google_veo" || option.value !== "480p",
+                      ).map((option) => (
                         <option key={option.value} value={option.value}>
                           {option.label}
                         </option>
@@ -3361,9 +3358,9 @@ function VideoGenerationDefaultsPanel({
                     ? "These values are sent to the xAI Videos API. xAI accepts 1-15 seconds for generated videos."
                     : service === "google_veo"
                       ? "Veo accepts 4, 6, or 8 seconds. Character loop references use the avatar as the first and last frame and run at 8 seconds."
-                    : service === "seedance"
-                      ? "Seedance accepts 4-15 seconds. Reference-image jobs send matching first and last frames when the provider can fetch the reference URL."
-                      : "These values are sent to OpenRouter's asynchronous Videos API. OpenRouter model support varies, so keep the model's own limits in mind."}
+                      : service === "seedance"
+                        ? "Seedance accepts 4-15 seconds. Reference-image jobs send matching first and last frames when the provider can fetch the reference URL."
+                        : "These values are sent to OpenRouter's asynchronous Videos API. OpenRouter model support varies, so keep the model's own limits in mind."}
                 </p>
               </>
             ) : (

--- a/packages/client/src/components/panels/settings/TTSConfigCard.tsx
+++ b/packages/client/src/components/panels/settings/TTSConfigCard.tsx
@@ -454,6 +454,7 @@ export function TTSConfigCard() {
     callCharacterVideoEnabled,
     callAutomaticVideoClipsEnabled,
     callCustomVideoClipsEnabled,
+    // Soundboard is intentionally always-on for Conversation Calls. Saving this card also migrates old false values.
     callSoundboardEnabled: true,
     ...overrides,
   });

--- a/packages/client/src/components/panels/settings/TTSConfigCard.tsx
+++ b/packages/client/src/components/panels/settings/TTSConfigCard.tsx
@@ -343,8 +343,8 @@ export function TTSConfigCard() {
   const [callAudioInputMode, setCallAudioInputMode] = useState<TTSConversationCallAudioInputMode>("local_whisper");
   const [callVideoInputEnabled, setCallVideoInputEnabled] = useState(false);
   const [callCharacterVideoEnabled, setCallCharacterVideoEnabled] = useState(false);
+  const [callAutomaticVideoClipsEnabled, setCallAutomaticVideoClipsEnabled] = useState(false);
   const [callCustomVideoClipsEnabled, setCallCustomVideoClipsEnabled] = useState(false);
-  const [callSoundboardEnabled, setCallSoundboardEnabled] = useState(true);
 
   const [expanded, setExpanded] = useState(false);
   const [saveStatus, setSaveStatus] = useState<"idle" | "saving" | "saved" | "error">("idle");
@@ -395,8 +395,8 @@ export function TTSConfigCard() {
     setCallAudioInputMode(savedConfig.callAudioInputMode ?? "local_whisper");
     setCallVideoInputEnabled(savedConfig.callVideoInputEnabled ?? false);
     setCallCharacterVideoEnabled(savedConfig.callCharacterVideoEnabled ?? false);
+    setCallAutomaticVideoClipsEnabled(savedConfig.callAutomaticVideoClipsEnabled ?? false);
     setCallCustomVideoClipsEnabled(savedConfig.callCustomVideoClipsEnabled ?? false);
-    setCallSoundboardEnabled(savedConfig.callSoundboardEnabled ?? true);
     setSaveStatus("idle");
   }, [savedConfig]);
 
@@ -452,8 +452,9 @@ export function TTSConfigCard() {
     callAudioInputMode,
     callVideoInputEnabled,
     callCharacterVideoEnabled,
+    callAutomaticVideoClipsEnabled,
     callCustomVideoClipsEnabled,
-    callSoundboardEnabled,
+    callSoundboardEnabled: true,
     ...overrides,
   });
 

--- a/packages/client/src/components/personas/PersonaEditor.tsx
+++ b/packages/client/src/components/personas/PersonaEditor.tsx
@@ -20,9 +20,12 @@ import {
   usePersonaGalleryClips,
   useUploadPersonaGalleryImage,
   useUploadPersonaGalleryClip,
+  useUploadPersonaGalleryVideo,
   useDeletePersonaGalleryImage,
   useDeletePersonaGalleryClip,
+  useGeneratePersonaCallVideoClips,
   useTagPersonaGalleryImage,
+  type CharacterCallVideoGenerationInput,
   type CharacterGalleryClip,
   type PersonaGalleryImage,
 } from "../../hooks/use-characters";
@@ -65,6 +68,7 @@ import { ColorPicker } from "../ui/ColorPicker";
 import { MacroTextarea } from "../ui/MacroTextarea";
 import { ImageUploadDropzone } from "../ui/ImageUploadDropzone";
 import { CustomEmojiTagButton } from "../ui/CustomEmojiTagButton";
+import { CallClipGenerationModal } from "../ui/CallClipGenerationModal";
 import { api } from "../../lib/api-client";
 import { parseTrackerCardColorConfig, serializeTrackerCardColorConfig } from "../../lib/tracker-card-colors";
 import { estimateTextTokens, formatEstimatedTokens } from "../../lib/character-token-count";
@@ -139,8 +143,7 @@ const PERSONA_CARD_HELP =
 const PERSONA_DESCRIPTION_HELP =
   "Your persona's general identity and role. This is sent in prompts so the AI knows who you are in the scene.";
 
-const PERSONA_PERSONALITY_HELP =
-  "Your temperament, behavior, speech habits, preferences, and emotional patterns.";
+const PERSONA_PERSONALITY_HELP = "Your temperament, behavior, speech habits, preferences, and emotional patterns.";
 
 const PERSONA_BACKSTORY_HELP =
   "History, origin, important relationships, and formative events that explain your persona.";
@@ -255,8 +258,10 @@ function personaGalleryClipSourceLabel(source: CharacterGalleryClip["source"]) {
       return "Call presence";
     case "conversation-call-custom":
       return "Custom call clip";
+    case "uploaded-video":
+      return "Uploaded video";
     default:
-      return "Clip";
+      return "Video";
   }
 }
 
@@ -267,6 +272,10 @@ function formatPersonaClipDate(value: string | null) {
 
 function canDeletePersonaGalleryClip(clip: CharacterGalleryClip) {
   return clip.status !== "generating";
+}
+
+function isPersonaCallVideoClip(clip: CharacterGalleryClip) {
+  return clip.source === "conversation-call" || clip.source === "conversation-call-custom";
 }
 
 function PersonaGalleryTab({ personaId, personaName }: { personaId: string; personaName?: string }) {
@@ -312,14 +321,14 @@ function PersonaGalleryTab({ personaId, personaName }: { personaId: string; pers
       <div className="mb-4">
         <h2 className="text-lg font-bold">Persona Gallery</h2>
         <p className="mt-0.5 text-xs text-[var(--muted-foreground)]">
-          Keep reference art, alternate looks, and generated clips attached to this persona.
+          Keep reference art, alternate looks, and generated videos attached to this persona.
         </p>
       </div>
 
       <div className="inline-flex rounded-xl border border-[var(--border)] bg-[var(--secondary)] p-1">
         {[
           { id: "images" as const, label: "Images", icon: Camera, count: images?.length ?? 0 },
-          { id: "clips" as const, label: "Clips", icon: Film, count: null },
+          { id: "clips" as const, label: "Videos", icon: Film, count: null },
         ].map((tab) => {
           const Icon = tab.icon;
           const active = mediaTab === tab.id;
@@ -420,7 +429,7 @@ function PersonaGalleryTab({ personaId, personaName }: { personaId: string; pers
           )}
         </>
       ) : (
-        <PersonaClipsGallery personaId={personaId} personaName={personaName} />
+        <PersonaVideosGallery personaId={personaId} personaName={personaName} />
       )}
 
       {lightbox && (
@@ -457,14 +466,13 @@ function PersonaGalleryTab({ personaId, personaName }: { personaId: string; pers
   );
 }
 
-function PersonaClipsGallery({ personaId, personaName }: { personaId: string; personaName?: string }) {
+function PersonaVideosGallery({ personaId, personaName }: { personaId: string; personaName?: string }) {
   const { data, isLoading } = usePersonaGalleryClips(personaId);
-  const uploadClip = useUploadPersonaGalleryClip(personaId);
+  const uploadVideo = useUploadPersonaGalleryVideo(personaId);
   const deleteClip = useDeletePersonaGalleryClip(personaId);
   const [deletingClipId, setDeletingClipId] = useState<string | null>(null);
   const clipUploadInputRef = useRef<HTMLInputElement | null>(null);
-  const clips = data?.clips ?? [];
-  const customCallClipCount = clips.filter((clip) => clip.source === "conversation-call-custom").length;
+  const clips = (data?.clips ?? []).filter((clip) => !isPersonaCallVideoClip(clip));
 
   const handleUploadClipFile = useCallback(
     async (event: ChangeEvent<HTMLInputElement>) => {
@@ -473,13 +481,13 @@ function PersonaClipsGallery({ personaId, personaName }: { personaId: string; pe
       if (!file) return;
 
       try {
-        await uploadClip.mutateAsync({ file });
-        toast.success("Clip uploaded.");
+        await uploadVideo.mutateAsync({ file });
+        toast.success("Video uploaded.");
       } catch (error) {
-        toast.error(error instanceof Error ? error.message : "Could not upload clip.");
+        toast.error(error instanceof Error ? error.message : "Could not upload video.");
       }
     },
-    [uploadClip],
+    [uploadVideo],
   );
 
   const handleDeleteClip = useCallback(
@@ -499,7 +507,144 @@ function PersonaClipsGallery({ personaId, personaName }: { personaId: string; pe
       setDeletingClipId(clip.id);
       try {
         await deleteClip.mutateAsync(clip.id);
-        toast.success("Clip deleted.");
+        toast.success("Video deleted.");
+      } catch (error) {
+        toast.error(error instanceof Error ? error.message : "Could not delete video.");
+      } finally {
+        setDeletingClipId(null);
+      }
+    },
+    [deleteClip],
+  );
+
+  if (isLoading) {
+    return (
+      <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-3">
+        {Array.from({ length: 4 }).map((_, index) => (
+          <div key={index} className="shimmer aspect-video rounded-xl" />
+        ))}
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      <input
+        ref={clipUploadInputRef}
+        type="file"
+        accept="video/mp4,video/webm,video/quicktime,.mp4,.webm,.mov"
+        className="hidden"
+        onChange={handleUploadClipFile}
+      />
+      <div className="flex flex-wrap items-center justify-between gap-3 rounded-xl border border-[var(--border)] bg-[var(--card)] p-3">
+        <div className="min-w-0">
+          <p className="text-sm font-semibold text-[var(--foreground)]">Persona videos</p>
+          <p className="mt-0.5 text-xs text-[var(--muted-foreground)]">
+            Generated scene videos and your own uploads attached to {personaName || "this persona"}.
+          </p>
+        </div>
+        <button
+          type="button"
+          onClick={() => clipUploadInputRef.current?.click()}
+          disabled={uploadVideo.isPending}
+          className="inline-flex items-center gap-2 rounded-lg border border-[var(--border)] bg-[var(--secondary)] px-3 py-2 text-xs font-semibold text-[var(--foreground)] transition-colors hover:border-[var(--primary)]/50 disabled:cursor-not-allowed disabled:opacity-60"
+        >
+          {uploadVideo.isPending ? <Loader2 size="0.85rem" className="animate-spin" /> : <Upload size="0.85rem" />}
+          Upload video
+        </button>
+      </div>
+
+      {clips.length > 0 ? (
+        <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-3">
+          {clips.map((clip) => (
+            <PersonaClipCard
+              key={clip.id}
+              clip={clip}
+              personaName={personaName}
+              deleting={deletingClipId === clip.id}
+              onDelete={handleDeleteClip}
+            />
+          ))}
+        </div>
+      ) : (
+        <div className="flex flex-col items-center gap-3 rounded-xl border-2 border-dashed border-[var(--border)] py-12 text-center">
+          <Film size="1.75rem" className="text-[var(--muted-foreground)]/40" />
+          <div>
+            <p className="text-sm font-medium text-[var(--muted-foreground)]">No persona videos yet</p>
+            <p className="mt-0.5 text-xs text-[var(--muted-foreground)]/60">
+              Upload videos or generate game and scene videos from chats using {personaName || "this persona"}.
+            </p>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function PersonaCallClipsGallery({ personaId, personaName }: { personaId: string; personaName?: string }) {
+  const { data, isLoading } = usePersonaGalleryClips(personaId);
+  const uploadClip = useUploadPersonaGalleryClip(personaId);
+  const deleteClip = useDeletePersonaGalleryClip(personaId);
+  const generateCallClips = useGeneratePersonaCallVideoClips(personaId);
+  const [deletingClipId, setDeletingClipId] = useState<string | null>(null);
+  const [generationDialogOpen, setGenerationDialogOpen] = useState(false);
+  const clipUploadInputRef = useRef<HTMLInputElement | null>(null);
+  const clips = (data?.clips ?? []).filter(isPersonaCallVideoClip);
+  const standardCallClips = clips.filter((clip) => clip.source === "conversation-call");
+  const customCallClipCount = clips.filter((clip) => clip.source === "conversation-call-custom").length;
+  const readyCallClipCount = standardCallClips.filter((clip) => clip.status === "ready").length;
+  const generationLockActive =
+    data?.callVideoGenerating === true ||
+    clips.some((clip) => clip.status === "generating") ||
+    generateCallClips.isPending;
+
+  const handleUploadClipFile = useCallback(
+    async (event: ChangeEvent<HTMLInputElement>) => {
+      const file = event.target.files?.[0];
+      event.target.value = "";
+      if (!file) return;
+
+      try {
+        await uploadClip.mutateAsync({ file });
+        toast.success("Call clip uploaded.");
+      } catch (error) {
+        toast.error(error instanceof Error ? error.message : "Could not upload clip.");
+      }
+    },
+    [uploadClip],
+  );
+
+  const handleGenerateCallClips = useCallback(
+    async (input: CharacterCallVideoGenerationInput) => {
+      try {
+        await generateCallClips.mutateAsync(input);
+        toast.success("Call clip generation started.");
+        setGenerationDialogOpen(false);
+      } catch (error) {
+        toast.error(error instanceof Error ? error.message : "Could not start call clip generation.");
+      }
+    },
+    [generateCallClips],
+  );
+
+  const handleDeleteClip = useCallback(
+    async (clip: CharacterGalleryClip) => {
+      if (!canDeletePersonaGalleryClip(clip)) return;
+      if (
+        !(await showConfirmDialog({
+          title: "Delete Clip",
+          message: "Delete this call clip? This cannot be undone.",
+          confirmLabel: "Delete",
+          tone: "destructive",
+        }))
+      ) {
+        return;
+      }
+
+      setDeletingClipId(clip.id);
+      try {
+        await deleteClip.mutateAsync(clip.id);
+        toast.success(clip.source === "conversation-call" ? "Call clip reset." : "Clip deleted.");
       } catch (error) {
         toast.error(error instanceof Error ? error.message : "Could not delete clip.");
       } finally {
@@ -530,18 +675,35 @@ function PersonaClipsGallery({ personaId, personaName }: { personaId: string; pe
       />
       <div className="flex flex-wrap items-center justify-between gap-3 rounded-xl border border-[var(--border)] bg-[var(--card)] p-3">
         <div className="min-w-0">
-          <p className="text-sm font-semibold text-[var(--foreground)]">Persona clips</p>
-          <p className="mt-0.5 text-xs text-[var(--muted-foreground)]">{customCallClipCount} uploaded call clips</p>
+          <p className="text-sm font-semibold text-[var(--foreground)]">Video call clips</p>
+          <p className="mt-0.5 text-xs text-[var(--muted-foreground)]">
+            {readyCallClipCount}/{standardCallClips.length || 6} standard ready · {customCallClipCount} custom
+          </p>
         </div>
-        <button
-          type="button"
-          onClick={() => clipUploadInputRef.current?.click()}
-          disabled={uploadClip.isPending}
-          className="inline-flex items-center gap-2 rounded-lg border border-[var(--border)] bg-[var(--secondary)] px-3 py-2 text-xs font-semibold text-[var(--foreground)] transition-colors hover:border-[var(--primary)]/50 disabled:cursor-not-allowed disabled:opacity-60"
-        >
-          {uploadClip.isPending ? <Loader2 size="0.85rem" className="animate-spin" /> : <Upload size="0.85rem" />}
-          Upload clip
-        </button>
+        <div className="flex flex-wrap items-center gap-2">
+          <button
+            type="button"
+            onClick={() => clipUploadInputRef.current?.click()}
+            disabled={uploadClip.isPending}
+            className="inline-flex items-center gap-2 rounded-lg border border-[var(--border)] bg-[var(--secondary)] px-3 py-2 text-xs font-semibold text-[var(--foreground)] transition-colors hover:border-[var(--primary)]/50 disabled:cursor-not-allowed disabled:opacity-60"
+          >
+            {uploadClip.isPending ? <Loader2 size="0.85rem" className="animate-spin" /> : <Upload size="0.85rem" />}
+            Upload extra
+          </button>
+          <button
+            type="button"
+            onClick={() => setGenerationDialogOpen(true)}
+            disabled={generationLockActive}
+            className="inline-flex items-center gap-2 rounded-lg bg-[var(--primary)] px-3 py-2 text-xs font-semibold text-[var(--primary-foreground)] transition-all hover:shadow-md disabled:cursor-not-allowed disabled:opacity-60"
+          >
+            {generateCallClips.isPending ? (
+              <Loader2 size="0.85rem" className="animate-spin" />
+            ) : (
+              <Wand2 size="0.85rem" />
+            )}
+            {generateCallClips.isPending ? "Generating" : "Generate Clips"}
+          </button>
+        </div>
       </div>
 
       {clips.length > 0 ? (
@@ -560,13 +722,20 @@ function PersonaClipsGallery({ personaId, personaName }: { personaId: string; pe
         <div className="flex flex-col items-center gap-3 rounded-xl border-2 border-dashed border-[var(--border)] py-12 text-center">
           <Film size="1.75rem" className="text-[var(--muted-foreground)]/40" />
           <div>
-            <p className="text-sm font-medium text-[var(--muted-foreground)]">No persona clips yet</p>
+            <p className="text-sm font-medium text-[var(--muted-foreground)]">No call clips yet</p>
             <p className="mt-0.5 text-xs text-[var(--muted-foreground)]/60">
-              Upload clips or generate game and scene videos from chats using {personaName || "this persona"}.
+              Generate or upload video-call loops for {personaName || "this persona"}.
             </p>
           </div>
         </div>
       )}
+      <CallClipGenerationModal
+        open={generationDialogOpen}
+        entityName={personaName || "this persona"}
+        generating={generateCallClips.isPending}
+        onClose={() => setGenerationDialogOpen(false)}
+        onGenerate={handleGenerateCallClips}
+      />
     </div>
   );
 }
@@ -656,9 +825,7 @@ function PersonaClipCard({
         {clip.prompt ? (
           <p className="line-clamp-2 text-xs leading-relaxed text-[var(--muted-foreground)]">{clip.prompt}</p>
         ) : null}
-        {clipDetails ? (
-          <p className="text-[0.65rem] text-[var(--muted-foreground)]/70">{clipDetails}</p>
-        ) : null}
+        {clipDetails ? <p className="text-[0.65rem] text-[var(--muted-foreground)]/70">{clipDetails}</p> : null}
       </div>
     </div>
   );
@@ -1119,12 +1286,7 @@ export function PersonaEditor() {
       {/* ── Header ── */}
       <div className="mari-editor-header items-start">
         <div className="mari-editor-header-main max-md:min-w-full">
-          <button
-            type="button"
-            onClick={handleClose}
-            className="mari-editor-action inline-flex"
-            title="Back"
-          >
+          <button type="button" onClick={handleClose} className="mari-editor-action inline-flex" title="Back">
             <ArrowLeft size="1.125rem" />
           </button>
 
@@ -1241,11 +1403,7 @@ export function PersonaEditor() {
               />
             )}
             {activeTab === "card" && (
-              <PersonaCardTab
-                formData={formData}
-                updateField={updateField}
-                setDirty={setDirty}
-              />
+              <PersonaCardTab formData={formData} updateField={updateField} setDirty={setDirty} />
             )}
             {activeTab === "lorebook" && personaId && (
               <PersonaLorebookTab personaId={personaId} personaName={formData.name} />
@@ -1310,7 +1468,7 @@ function PersonaSpritesTab({
   defaultAppearance?: string;
   defaultAvatarUrl?: string | null;
 }) {
-  type SpriteCategory = "expressions" | "full-body";
+  type SpriteCategory = "expressions" | "full-body" | "clips";
 
   const { data: sprites, isLoading } = useCharacterSprites(personaId);
   const { data: spriteCapabilities } = useSpriteCapabilities();
@@ -1346,7 +1504,11 @@ function PersonaSpritesTab({
     .filter((s) => !s.expression.toLowerCase().startsWith("full_"))
     .map((s) => s.expression);
   const visibleSprites = allSprites.filter((s) =>
-    category === "full-body" ? s.expression.startsWith("full_") : !s.expression.startsWith("full_"),
+    category === "clips"
+      ? false
+      : category === "full-body"
+        ? s.expression.startsWith("full_")
+        : !s.expression.startsWith("full_"),
   );
   const existingExpressions = new Set(
     visibleSprites.map((s) => (category === "full-body" ? s.expression.replace(/^full_/, "") : s.expression)),
@@ -1359,6 +1521,30 @@ function PersonaSpritesTab({
   const backgroundRemoverUnavailable = spriteCapabilities?.backgroundRemover?.installed === false;
   const backgroundRemoverReason =
     spriteCapabilities?.backgroundRemover?.reason ?? "Local backgroundremover is not installed.";
+
+  const categoryTabs = (
+    <div className="inline-flex rounded-xl bg-[var(--secondary)] p-1 ring-1 ring-[var(--border)]">
+      {[
+        { id: "expressions" as const, label: "Facial Expressions" },
+        { id: "full-body" as const, label: "Full-body" },
+        { id: "clips" as const, label: "Clips" },
+      ].map((tab) => (
+        <button
+          key={tab.id}
+          type="button"
+          onClick={() => setCategory(tab.id)}
+          className={cn(
+            "rounded-lg px-3 py-1.5 text-xs font-medium transition-colors",
+            category === tab.id
+              ? "bg-[var(--primary)]/15 text-[var(--primary)]"
+              : "text-[var(--muted-foreground)] hover:text-[var(--foreground)]",
+          )}
+        >
+          {tab.label}
+        </button>
+      ))}
+    </div>
+  );
 
   const normalizeExpressionForCategory = (raw: string) => {
     return normalizeSpriteExpressionLabel(raw, { fullBody: category === "full-body" });
@@ -1600,6 +1786,22 @@ function PersonaSpritesTab({
     [displayExpression, personaId, uploadSprite, wandCleanupSprite],
   );
 
+  if (category === "clips") {
+    return (
+      <div className="space-y-6">
+        <SectionHeader
+          title="Persona Sprites"
+          subtitle="Upload VN-style sprites and video-call clips for your persona."
+          helpText={PERSONA_SPRITES_HELP}
+        />
+
+        {categoryTabs}
+
+        <PersonaCallClipsGallery personaId={personaId} personaName={personaName} />
+      </div>
+    );
+  }
+
   return (
     <div className="space-y-6">
       <SectionHeader
@@ -1608,32 +1810,7 @@ function PersonaSpritesTab({
         helpText={PERSONA_SPRITES_HELP}
       />
 
-      <div className="inline-flex rounded-xl bg-[var(--secondary)] p-1 ring-1 ring-[var(--border)]">
-        <button
-          type="button"
-          onClick={() => setCategory("expressions")}
-          className={cn(
-            "rounded-lg px-3 py-1.5 text-xs font-medium transition-colors",
-            category === "expressions"
-              ? "bg-[var(--primary)]/15 text-[var(--primary)]"
-              : "text-[var(--muted-foreground)] hover:text-[var(--foreground)]",
-          )}
-        >
-          Facial Expressions
-        </button>
-        <button
-          type="button"
-          onClick={() => setCategory("full-body")}
-          className={cn(
-            "rounded-lg px-3 py-1.5 text-xs font-medium transition-colors",
-            category === "full-body"
-              ? "bg-[var(--primary)]/15 text-[var(--primary)]"
-              : "text-[var(--muted-foreground)] hover:text-[var(--foreground)]",
-          )}
-        >
-          Full-body
-        </button>
-      </div>
+      {categoryTabs}
 
       <input ref={fileInputRef} type="file" accept="image/*" className="hidden" onChange={handleUpload} />
       <input
@@ -2138,7 +2315,6 @@ function PersonaColorsTab({
         label="Message Box Color"
         helpText="Background color for your persona's chat message bubbles. Use a semi-transparent color for best results (e.g. rgba)."
       />
-
     </div>
   );
 }
@@ -2334,7 +2510,6 @@ function PersonaStatsTab({
               ))}
             </div>
           </div>
-
         </>
       )}
 
@@ -2462,7 +2637,6 @@ function PersonaStatsTab({
                 ))}
               </div>
             </div>
-
           </>
         )}
       </div>
@@ -2592,11 +2766,7 @@ function PersonaMetadataTab({
             className="w-full rounded-xl border border-[var(--border)] bg-[var(--secondary)] px-3 py-2 text-sm outline-none focus:border-[var(--primary)]/40 focus:ring-1 focus:ring-[var(--primary)]/20"
             placeholder="1.0"
           />
-          <PersonaVersionHistoryPanel
-            personaId={personaId}
-            currentData={formData}
-            currentAvatarPath={avatarPreview}
-          />
+          <PersonaVersionHistoryPanel personaId={personaId} currentData={formData} currentAvatarPath={avatarPreview} />
         </label>
       </div>
 
@@ -2618,10 +2788,7 @@ function PersonaMetadataTab({
         </div>
         <div className="flex flex-wrap gap-1.5">
           {formData.tags.map((tag) => (
-            <span
-              key={tag}
-              className="mari-chrome-control mari-chrome-control--compact group/tag"
-            >
+            <span key={tag} className="mari-chrome-control mari-chrome-control--compact group/tag">
               <Tag size="0.625rem" />
               {tag}
               <button
@@ -2736,12 +2903,7 @@ function formatPersonaVersionValue(data: PersonaCardSnapshot, key: keyof Persona
   const value = data[key];
   if (typeof value !== "string") return "";
   if (!value.trim()) return "";
-  if (
-    key === "avatarCrop" ||
-    key === "trackerCardColors" ||
-    key === "personaStats" ||
-    key === "tags"
-  ) {
+  if (key === "avatarCrop" || key === "trackerCardColors" || key === "personaStats" || key === "tags") {
     try {
       return JSON.stringify(JSON.parse(value), null, 2);
     } catch {

--- a/packages/client/src/components/personas/PersonaEditor.tsx
+++ b/packages/client/src/components/personas/PersonaEditor.tsx
@@ -271,6 +271,7 @@ function formatPersonaClipDate(value: string | null) {
 }
 
 function canDeletePersonaGalleryClip(clip: CharacterGalleryClip) {
+  if (clip.source === "conversation-call" && clip.status === "missing") return false;
   return clip.status !== "generating";
 }
 

--- a/packages/client/src/components/personas/PersonaEditor.tsx
+++ b/packages/client/src/components/personas/PersonaEditor.tsx
@@ -472,18 +472,16 @@ function PersonaVideosGallery({ personaId, personaName }: { personaId: string; p
   const uploadVideo = useUploadPersonaGalleryVideo(personaId);
   const deleteClip = useDeletePersonaGalleryClip(personaId);
   const [deletingClipId, setDeletingClipId] = useState<string | null>(null);
-  const clipUploadInputRef = useRef<HTMLInputElement | null>(null);
   const clips = (data?.clips ?? []).filter((clip) => !isPersonaCallVideoClip(clip));
 
-  const handleUploadClipFile = useCallback(
-    async (event: ChangeEvent<HTMLInputElement>) => {
-      const file = event.target.files?.[0];
-      event.target.value = "";
-      if (!file) return;
-
+  const handleUploadVideos = useCallback(
+    async (files: File[]) => {
+      if (files.length === 0) return;
       try {
-        await uploadVideo.mutateAsync({ file });
-        toast.success("Video uploaded.");
+        for (const file of files) {
+          await uploadVideo.mutateAsync({ file });
+        }
+        toast.success(files.length === 1 ? "Video uploaded." : "Videos uploaded.");
       } catch (error) {
         toast.error(error instanceof Error ? error.message : "Could not upload video.");
       }
@@ -529,31 +527,18 @@ function PersonaVideosGallery({ personaId, personaName }: { personaId: string; p
   }
 
   return (
-    <div className="space-y-4">
-      <input
-        ref={clipUploadInputRef}
-        type="file"
+    <div className="space-y-6">
+      <ImageUploadDropzone
+        label="Upload Persona Videos"
+        pending={uploadVideo.isPending}
+        pendingLabel="Uploading…"
+        dragLabel="Drop persona videos to upload"
+        onFilesSelected={handleUploadVideos}
+        icon={<Upload size="1rem" />}
         accept="video/mp4,video/webm,video/quicktime,.mp4,.webm,.mov"
-        className="hidden"
-        onChange={handleUploadClipFile}
+        fileKind="video"
+        className="w-full"
       />
-      <div className="flex flex-wrap items-center justify-between gap-3 rounded-xl border border-[var(--border)] bg-[var(--card)] p-3">
-        <div className="min-w-0">
-          <p className="text-sm font-semibold text-[var(--foreground)]">Persona videos</p>
-          <p className="mt-0.5 text-xs text-[var(--muted-foreground)]">
-            Generated scene videos and your own uploads attached to {personaName || "this persona"}.
-          </p>
-        </div>
-        <button
-          type="button"
-          onClick={() => clipUploadInputRef.current?.click()}
-          disabled={uploadVideo.isPending}
-          className="inline-flex items-center gap-2 rounded-lg border border-[var(--border)] bg-[var(--secondary)] px-3 py-2 text-xs font-semibold text-[var(--foreground)] transition-colors hover:border-[var(--primary)]/50 disabled:cursor-not-allowed disabled:opacity-60"
-        >
-          {uploadVideo.isPending ? <Loader2 size="0.85rem" className="animate-spin" /> : <Upload size="0.85rem" />}
-          Upload video
-        </button>
-      </div>
 
       {clips.length > 0 ? (
         <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-3">

--- a/packages/client/src/components/personas/PersonaEditor.tsx
+++ b/packages/client/src/components/personas/PersonaEditor.tsx
@@ -24,6 +24,7 @@ import {
   useDeletePersonaGalleryImage,
   useDeletePersonaGalleryClip,
   useGeneratePersonaCallVideoClips,
+  useGeneratePersonaCustomCallVideoClip,
   useTagPersonaGalleryImage,
   type CharacterCallVideoGenerationInput,
   type CharacterGalleryClip,
@@ -572,6 +573,7 @@ function PersonaCallClipsGallery({ personaId, personaName }: { personaId: string
   const uploadClip = useUploadPersonaGalleryClip(personaId);
   const deleteClip = useDeletePersonaGalleryClip(personaId);
   const generateCallClips = useGeneratePersonaCallVideoClips(personaId);
+  const generateCustomCallClip = useGeneratePersonaCustomCallVideoClip(personaId);
   const [deletingClipId, setDeletingClipId] = useState<string | null>(null);
   const [generationDialogOpen, setGenerationDialogOpen] = useState(false);
   const clipUploadInputRef = useRef<HTMLInputElement | null>(null);
@@ -582,7 +584,8 @@ function PersonaCallClipsGallery({ personaId, personaName }: { personaId: string
   const generationLockActive =
     data?.callVideoGenerating === true ||
     clips.some((clip) => clip.status === "generating") ||
-    generateCallClips.isPending;
+    generateCallClips.isPending ||
+    generateCustomCallClip.isPending;
 
   const handleUploadClipFile = useCallback(
     async (event: ChangeEvent<HTMLInputElement>) => {
@@ -602,15 +605,36 @@ function PersonaCallClipsGallery({ personaId, personaName }: { personaId: string
 
   const handleGenerateCallClips = useCallback(
     async (input: CharacterCallVideoGenerationInput) => {
+      const standardKinds = input.clipKinds?.length ? input.clipKinds : input.clipKind ? [input.clipKind] : [];
+      const customClip = input.customClip?.label.trim() && input.customClip.prompt.trim() ? input.customClip : null;
       try {
-        await generateCallClips.mutateAsync(input);
-        toast.success("Call clip generation started.");
+        if (standardKinds.length > 0) {
+          await generateCallClips.mutateAsync({
+            ...input,
+            clipKinds: standardKinds,
+            clipCount: standardKinds.length,
+            customClip: null,
+          });
+        }
+        if (customClip) {
+          await generateCustomCallClip.mutateAsync({
+            ...input,
+            customClip,
+          });
+        }
+        toast.success(
+          customClip && standardKinds.length === 0
+            ? "Custom call clip generation started."
+            : customClip
+              ? "Call clip and custom clip generation started."
+              : "Call clip generation started.",
+        );
         setGenerationDialogOpen(false);
       } catch (error) {
         toast.error(error instanceof Error ? error.message : "Could not start call clip generation.");
       }
     },
-    [generateCallClips],
+    [generateCallClips, generateCustomCallClip],
   );
 
   const handleDeleteClip = useCallback(
@@ -682,12 +706,12 @@ function PersonaCallClipsGallery({ personaId, personaName }: { personaId: string
             disabled={generationLockActive}
             className="inline-flex items-center gap-2 rounded-lg bg-[var(--primary)] px-3 py-2 text-xs font-semibold text-[var(--primary-foreground)] transition-all hover:shadow-md disabled:cursor-not-allowed disabled:opacity-60"
           >
-            {generateCallClips.isPending ? (
+            {generateCallClips.isPending || generateCustomCallClip.isPending ? (
               <Loader2 size="0.85rem" className="animate-spin" />
             ) : (
               <Wand2 size="0.85rem" />
             )}
-            {generateCallClips.isPending ? "Generating" : "Generate Clips"}
+            {generateCallClips.isPending || generateCustomCallClip.isPending ? "Generating" : "Generate Clips"}
           </button>
         </div>
       </div>
@@ -718,7 +742,7 @@ function PersonaCallClipsGallery({ personaId, personaName }: { personaId: string
       <CallClipGenerationModal
         open={generationDialogOpen}
         entityName={personaName || "this persona"}
-        generating={generateCallClips.isPending}
+        generating={generateCallClips.isPending || generateCustomCallClip.isPending}
         onClose={() => setGenerationDialogOpen(false)}
         onGenerate={handleGenerateCallClips}
       />

--- a/packages/client/src/components/personas/PersonaEditor.tsx
+++ b/packages/client/src/components/personas/PersonaEditor.tsx
@@ -772,7 +772,7 @@ function PersonaClipCard({
             className="h-full w-full bg-black object-contain"
           />
         ) : (
-          <div className="flex h-full flex-col items-center justify-center gap-2 text-center text-xs text-[var(--muted-foreground)]">
+          <div className="absolute inset-0 flex flex-col items-center justify-center gap-2 text-center text-xs text-[var(--muted-foreground)]">
             {clip.status === "generating" ? (
               <Loader2 size="1.25rem" className="animate-spin text-[var(--primary)]" />
             ) : clip.status === "error" ? (

--- a/packages/client/src/components/ui/CallClipGenerationModal.tsx
+++ b/packages/client/src/components/ui/CallClipGenerationModal.tsx
@@ -134,25 +134,31 @@ export function CallClipGenerationModal({
             </span>
           </div>
           <div className="grid grid-cols-2 gap-2 sm:grid-cols-3">
-            {CONVERSATION_CALL_CHARACTER_VIDEO_CLIP_KINDS.map((kind) => (
-              <label
-                key={kind}
-                className={cn(
-                  "flex cursor-pointer items-center gap-2 rounded-lg border px-3 py-2 text-xs font-medium transition-colors",
-                  selectedKinds.includes(kind)
-                    ? "border-[var(--primary)]/45 bg-[var(--primary)]/10 text-[var(--foreground)]"
-                    : "border-[var(--border)] bg-[var(--secondary)] text-[var(--muted-foreground)] hover:text-[var(--foreground)]",
-                )}
-              >
-                <input
-                  type="checkbox"
-                  checked={selectedKinds.includes(kind)}
-                  onChange={() => toggleKind(kind)}
-                  className="h-3.5 w-3.5 accent-[var(--primary)]"
-                />
-                {CALL_VIDEO_CLIP_LABEL_BY_KIND[kind]}
-              </label>
-            ))}
+            {CONVERSATION_CALL_CHARACTER_VIDEO_CLIP_KINDS.map((kind) => {
+              const selected = selectedKinds.includes(kind);
+              const disableClearingLastKind = selected && selectedKinds.length === 1 && !customClipEnabled;
+              return (
+                <label
+                  key={kind}
+                  className={cn(
+                    "flex cursor-pointer items-center gap-2 rounded-lg border px-3 py-2 text-xs font-medium transition-colors",
+                    selected
+                      ? "border-[var(--primary)]/45 bg-[var(--primary)]/10 text-[var(--foreground)]"
+                      : "border-[var(--border)] bg-[var(--secondary)] text-[var(--muted-foreground)] hover:text-[var(--foreground)]",
+                    disableClearingLastKind && "cursor-not-allowed opacity-70",
+                  )}
+                >
+                  <input
+                    type="checkbox"
+                    checked={selected}
+                    disabled={disableClearingLastKind}
+                    onChange={() => toggleKind(kind)}
+                    className="h-3.5 w-3.5 accent-[var(--primary)] disabled:cursor-not-allowed"
+                  />
+                  {CALL_VIDEO_CLIP_LABEL_BY_KIND[kind]}
+                </label>
+              );
+            })}
           </div>
         </div>
 

--- a/packages/client/src/components/ui/CallClipGenerationModal.tsx
+++ b/packages/client/src/components/ui/CallClipGenerationModal.tsx
@@ -1,0 +1,195 @@
+import { useEffect, useMemo, useState } from "react";
+import { Loader2, Wand2 } from "lucide-react";
+import {
+  CONVERSATION_CALL_CHARACTER_VIDEO_CLIP_KINDS,
+  type ConversationCallCharacterVideoClipKind,
+} from "@marinara-engine/shared";
+import { useConnections } from "../../hooks/use-connections";
+import { type CharacterCallVideoGenerationInput } from "../../hooks/use-characters";
+import { cn } from "../../lib/utils";
+import { Modal } from "./Modal";
+
+type VideoGenerationConnectionOption = {
+  id: string;
+  name?: string;
+  model?: string | null;
+  provider?: string | null;
+  defaultForAgents?: boolean | string | null;
+};
+
+const CALL_VIDEO_CLIP_LABEL_BY_KIND: Record<ConversationCallCharacterVideoClipKind, string> = {
+  idle: "Idle",
+  talking: "Talking",
+  laughing: "Laughing",
+  angry: "Angry",
+  crying: "Crying",
+  sighing: "Sighing",
+};
+
+function isDefaultVideoGenerationConnection(connection: VideoGenerationConnectionOption) {
+  return connection.defaultForAgents === true || connection.defaultForAgents === "true";
+}
+
+export function CallClipGenerationModal({
+  open,
+  entityName,
+  initialKind = null,
+  generating,
+  onClose,
+  onGenerate,
+}: {
+  open: boolean;
+  entityName: string;
+  initialKind?: ConversationCallCharacterVideoClipKind | null;
+  generating: boolean;
+  onClose: () => void;
+  onGenerate: (input: CharacterCallVideoGenerationInput) => void | Promise<void>;
+}) {
+  const { data: connectionsList } = useConnections();
+  const videoConnections = useMemo(() => {
+    if (!connectionsList) return [];
+    return (connectionsList as VideoGenerationConnectionOption[])
+      .filter((connection) => connection.provider === "video_generation")
+      .sort((a, b) => Number(isDefaultVideoGenerationConnection(b)) - Number(isDefaultVideoGenerationConnection(a)));
+  }, [connectionsList]);
+  const defaultConnectionId =
+    videoConnections.find(isDefaultVideoGenerationConnection)?.id ?? videoConnections[0]?.id ?? null;
+  const [connectionId, setConnectionId] = useState<string | null>(null);
+  const [includeAvatarReference, setIncludeAvatarReference] = useState(true);
+  const [selectedKinds, setSelectedKinds] = useState<ConversationCallCharacterVideoClipKind[]>(
+    initialKind ? [initialKind] : CONVERSATION_CALL_CHARACTER_VIDEO_CLIP_KINDS,
+  );
+  const [clipCount, setClipCount] = useState(initialKind ? 1 : CONVERSATION_CALL_CHARACTER_VIDEO_CLIP_KINDS.length);
+
+  useEffect(() => {
+    if (!open) return;
+    const nextKinds = initialKind ? [initialKind] : CONVERSATION_CALL_CHARACTER_VIDEO_CLIP_KINDS;
+    setSelectedKinds(nextKinds);
+    setClipCount(nextKinds.length);
+    setConnectionId(null);
+    setIncludeAvatarReference(true);
+  }, [initialKind, open]);
+
+  const effectiveConnectionId = connectionId ?? defaultConnectionId;
+  const maxClipCount = Math.max(1, selectedKinds.length);
+  const safeClipCount = Math.min(Math.max(1, clipCount), maxClipCount);
+  const requestedClipKinds = selectedKinds.slice(0, safeClipCount);
+  const canGenerate = requestedClipKinds.length > 0 && Boolean(effectiveConnectionId) && !generating;
+
+  const toggleKind = (kind: ConversationCallCharacterVideoClipKind) => {
+    setSelectedKinds((current) => {
+      const exists = current.includes(kind);
+      const next = exists ? current.filter((item) => item !== kind) : [...current, kind];
+      if (next.length === 0) return current;
+      setClipCount((count) => Math.min(Math.max(1, count), next.length));
+      return next;
+    });
+  };
+
+  return (
+    <Modal open={open} onClose={onClose} title="Generate Call Clips" width="max-w-lg">
+      <div className="space-y-4">
+        <p className="text-sm leading-relaxed text-[var(--muted-foreground)]">
+          Generate video-call loop clips for {entityName}. Marinara will use the selected video generation connection.
+        </p>
+
+        <label className="grid gap-1.5 text-xs font-semibold text-[var(--foreground)]">
+          Video Generation Connection
+          <select
+            value={effectiveConnectionId ?? ""}
+            onChange={(event) => setConnectionId(event.target.value || null)}
+            className="rounded-lg border border-[var(--border)] bg-[var(--secondary)] px-3 py-2 text-sm font-medium text-[var(--foreground)] outline-none focus:border-[var(--primary)]/40 focus:ring-1 focus:ring-[var(--primary)]/20"
+          >
+            {videoConnections.length === 0 ? <option value="">No video generation connections</option> : null}
+            {videoConnections.map((connection) => (
+              <option key={connection.id} value={connection.id}>
+                {connection.name || connection.model || "Video connection"}
+                {isDefaultVideoGenerationConnection(connection) ? " (Default)" : ""}
+              </option>
+            ))}
+          </select>
+        </label>
+
+        <label className="flex items-center justify-between gap-3 rounded-lg border border-[var(--border)] bg-[var(--secondary)]/60 px-3 py-2">
+          <span className="min-w-0">
+            <span className="block text-xs font-semibold text-[var(--foreground)]">Use avatar as reference</span>
+            <span className="block text-[0.6875rem] text-[var(--muted-foreground)]">
+              Recommended for first and final frame matching.
+            </span>
+          </span>
+          <input
+            type="checkbox"
+            checked={includeAvatarReference}
+            onChange={(event) => setIncludeAvatarReference(event.target.checked)}
+            className="h-4 w-4 accent-[var(--primary)]"
+          />
+        </label>
+
+        <div className="grid gap-2">
+          <div className="flex items-center justify-between gap-3">
+            <span className="text-xs font-semibold text-[var(--foreground)]">Clips to generate</span>
+            <label className="flex items-center gap-2 text-[0.6875rem] text-[var(--muted-foreground)]">
+              Count
+              <input
+                type="number"
+                min={1}
+                max={maxClipCount}
+                value={safeClipCount}
+                onChange={(event) => setClipCount(Number(event.target.value) || 1)}
+                className="w-16 rounded-md border border-[var(--border)] bg-[var(--secondary)] px-2 py-1 text-xs text-[var(--foreground)] outline-none focus:border-[var(--primary)]/40"
+              />
+            </label>
+          </div>
+          <div className="grid grid-cols-2 gap-2 sm:grid-cols-3">
+            {CONVERSATION_CALL_CHARACTER_VIDEO_CLIP_KINDS.map((kind) => (
+              <label
+                key={kind}
+                className={cn(
+                  "flex cursor-pointer items-center gap-2 rounded-lg border px-3 py-2 text-xs font-medium transition-colors",
+                  selectedKinds.includes(kind)
+                    ? "border-[var(--primary)]/45 bg-[var(--primary)]/10 text-[var(--foreground)]"
+                    : "border-[var(--border)] bg-[var(--secondary)] text-[var(--muted-foreground)] hover:text-[var(--foreground)]",
+                )}
+              >
+                <input
+                  type="checkbox"
+                  checked={selectedKinds.includes(kind)}
+                  onChange={() => toggleKind(kind)}
+                  className="h-3.5 w-3.5 accent-[var(--primary)]"
+                />
+                {CALL_VIDEO_CLIP_LABEL_BY_KIND[kind]}
+              </label>
+            ))}
+          </div>
+        </div>
+
+        <div className="flex items-center justify-end gap-2">
+          <button
+            type="button"
+            onClick={onClose}
+            disabled={generating}
+            className="rounded-lg px-3 py-2 text-sm font-medium text-[var(--muted-foreground)] transition-colors hover:bg-[var(--accent)] hover:text-[var(--foreground)] disabled:opacity-50"
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            onClick={() =>
+              void onGenerate({
+                clipKinds: requestedClipKinds,
+                clipCount: requestedClipKinds.length,
+                connectionId: effectiveConnectionId,
+                includeAvatarReference,
+              })
+            }
+            disabled={!canGenerate}
+            className="inline-flex items-center gap-2 rounded-lg bg-[var(--primary)] px-3 py-2 text-sm font-semibold text-[var(--primary-foreground)] transition-all hover:shadow-md disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            {generating ? <Loader2 size="0.875rem" className="animate-spin" /> : <Wand2 size="0.875rem" />}
+            Generate
+          </button>
+        </div>
+      </div>
+    </Modal>
+  );
+}

--- a/packages/client/src/components/ui/CallClipGenerationModal.tsx
+++ b/packages/client/src/components/ui/CallClipGenerationModal.tsx
@@ -59,29 +59,23 @@ export function CallClipGenerationModal({
   const [selectedKinds, setSelectedKinds] = useState<ConversationCallCharacterVideoClipKind[]>(
     initialKind ? [initialKind] : CONVERSATION_CALL_CHARACTER_VIDEO_CLIP_KINDS,
   );
-  const [clipCount, setClipCount] = useState(initialKind ? 1 : CONVERSATION_CALL_CHARACTER_VIDEO_CLIP_KINDS.length);
 
   useEffect(() => {
     if (!open) return;
     const nextKinds = initialKind ? [initialKind] : CONVERSATION_CALL_CHARACTER_VIDEO_CLIP_KINDS;
     setSelectedKinds(nextKinds);
-    setClipCount(nextKinds.length);
     setConnectionId(null);
     setIncludeAvatarReference(true);
   }, [initialKind, open]);
 
   const effectiveConnectionId = connectionId ?? defaultConnectionId;
-  const maxClipCount = Math.max(1, selectedKinds.length);
-  const safeClipCount = Math.min(Math.max(1, clipCount), maxClipCount);
-  const requestedClipKinds = selectedKinds.slice(0, safeClipCount);
-  const canGenerate = requestedClipKinds.length > 0 && Boolean(effectiveConnectionId) && !generating;
+  const canGenerate = selectedKinds.length > 0 && Boolean(effectiveConnectionId) && !generating;
 
   const toggleKind = (kind: ConversationCallCharacterVideoClipKind) => {
     setSelectedKinds((current) => {
       const exists = current.includes(kind);
       const next = exists ? current.filter((item) => item !== kind) : [...current, kind];
       if (next.length === 0) return current;
-      setClipCount((count) => Math.min(Math.max(1, count), next.length));
       return next;
     });
   };
@@ -128,17 +122,9 @@ export function CallClipGenerationModal({
         <div className="grid gap-2">
           <div className="flex items-center justify-between gap-3">
             <span className="text-xs font-semibold text-[var(--foreground)]">Clips to generate</span>
-            <label className="flex items-center gap-2 text-[0.6875rem] text-[var(--muted-foreground)]">
-              Count
-              <input
-                type="number"
-                min={1}
-                max={maxClipCount}
-                value={safeClipCount}
-                onChange={(event) => setClipCount(Number(event.target.value) || 1)}
-                className="w-16 rounded-md border border-[var(--border)] bg-[var(--secondary)] px-2 py-1 text-xs text-[var(--foreground)] outline-none focus:border-[var(--primary)]/40"
-              />
-            </label>
+            <span className="rounded-md border border-[var(--border)] bg-[var(--secondary)] px-2 py-1 text-[0.6875rem] font-medium text-[var(--muted-foreground)]">
+              {selectedKinds.length} selected
+            </span>
           </div>
           <div className="grid grid-cols-2 gap-2 sm:grid-cols-3">
             {CONVERSATION_CALL_CHARACTER_VIDEO_CLIP_KINDS.map((kind) => (
@@ -176,8 +162,8 @@ export function CallClipGenerationModal({
             type="button"
             onClick={() =>
               void onGenerate({
-                clipKinds: requestedClipKinds,
-                clipCount: requestedClipKinds.length,
+                clipKinds: selectedKinds,
+                clipCount: selectedKinds.length,
                 connectionId: effectiveConnectionId,
                 includeAvatarReference,
               })

--- a/packages/client/src/components/ui/CallClipGenerationModal.tsx
+++ b/packages/client/src/components/ui/CallClipGenerationModal.tsx
@@ -59,6 +59,9 @@ export function CallClipGenerationModal({
   const [selectedKinds, setSelectedKinds] = useState<ConversationCallCharacterVideoClipKind[]>(
     initialKind ? [initialKind] : CONVERSATION_CALL_CHARACTER_VIDEO_CLIP_KINDS,
   );
+  const [customClipEnabled, setCustomClipEnabled] = useState(false);
+  const [customClipLabel, setCustomClipLabel] = useState("");
+  const [customClipPrompt, setCustomClipPrompt] = useState("");
 
   useEffect(() => {
     if (!open) return;
@@ -66,16 +69,20 @@ export function CallClipGenerationModal({
     setSelectedKinds(nextKinds);
     setConnectionId(null);
     setIncludeAvatarReference(true);
+    setCustomClipEnabled(false);
+    setCustomClipLabel("");
+    setCustomClipPrompt("");
   }, [initialKind, open]);
 
   const effectiveConnectionId = connectionId ?? defaultConnectionId;
-  const canGenerate = selectedKinds.length > 0 && Boolean(effectiveConnectionId) && !generating;
+  const customClipReady = customClipEnabled && customClipLabel.trim().length > 0 && customClipPrompt.trim().length > 0;
+  const canGenerate = (selectedKinds.length > 0 || customClipReady) && Boolean(effectiveConnectionId) && !generating;
 
   const toggleKind = (kind: ConversationCallCharacterVideoClipKind) => {
     setSelectedKinds((current) => {
       const exists = current.includes(kind);
       const next = exists ? current.filter((item) => item !== kind) : [...current, kind];
-      if (next.length === 0) return current;
+      if (next.length === 0 && !customClipEnabled) return current;
       return next;
     });
   };
@@ -149,6 +156,55 @@ export function CallClipGenerationModal({
           </div>
         </div>
 
+        <div className="grid gap-3 rounded-lg border border-[var(--border)] bg-[var(--secondary)]/45 p-3">
+          <label className="flex items-start justify-between gap-3">
+            <span className="min-w-0">
+              <span className="block text-xs font-semibold text-[var(--foreground)]">Custom clip</span>
+              <span className="block text-[0.6875rem] leading-snug text-[var(--muted-foreground)]">
+                Add a named action clip the character can later play with [play_clip="name"].
+              </span>
+            </span>
+            <input
+              type="checkbox"
+              checked={customClipEnabled}
+              onChange={(event) => setCustomClipEnabled(event.target.checked)}
+              className="mt-0.5 h-4 w-4 accent-[var(--primary)]"
+            />
+          </label>
+
+          {customClipEnabled ? (
+            <div className="grid gap-2">
+              <label className="grid gap-1 text-xs font-semibold text-[var(--foreground)]">
+                Clip name
+                <input
+                  type="text"
+                  value={customClipLabel}
+                  onChange={(event) => setCustomClipLabel(event.target.value)}
+                  placeholder="Kissing"
+                  maxLength={80}
+                  className="rounded-lg border border-[var(--border)] bg-[var(--background)] px-3 py-2 text-sm font-medium text-[var(--foreground)] outline-none focus:border-[var(--primary)]/40 focus:ring-1 focus:ring-[var(--primary)]/20"
+                />
+              </label>
+              <label className="grid gap-1 text-xs font-semibold text-[var(--foreground)]">
+                Action
+                <textarea
+                  value={customClipPrompt}
+                  onChange={(event) => setCustomClipPrompt(event.target.value)}
+                  placeholder="Blow a kiss toward the screen, then return to the starting pose."
+                  rows={3}
+                  maxLength={800}
+                  className="resize-none rounded-lg border border-[var(--border)] bg-[var(--background)] px-3 py-2 text-sm font-medium text-[var(--foreground)] outline-none focus:border-[var(--primary)]/40 focus:ring-1 focus:ring-[var(--primary)]/20"
+                />
+              </label>
+              {selectedKinds.length === 0 ? (
+                <p className="text-[0.6875rem] leading-snug text-[var(--muted-foreground)]">
+                  Only the custom clip will be generated.
+                </p>
+              ) : null}
+            </div>
+          ) : null}
+        </div>
+
         <div className="flex items-center justify-end gap-2">
           <button
             type="button"
@@ -166,6 +222,12 @@ export function CallClipGenerationModal({
                 clipCount: selectedKinds.length,
                 connectionId: effectiveConnectionId,
                 includeAvatarReference,
+                customClip: customClipReady
+                  ? {
+                      label: customClipLabel.trim(),
+                      prompt: customClipPrompt.trim(),
+                    }
+                  : null,
               })
             }
             disabled={!canGenerate}

--- a/packages/client/src/components/ui/ImageUploadDropzone.tsx
+++ b/packages/client/src/components/ui/ImageUploadDropzone.tsx
@@ -14,17 +14,21 @@ interface ImageUploadDropzoneProps {
   multiple?: boolean;
   disabled?: boolean;
   ariaLabel?: string;
+  fileKind?: "image" | "video";
 }
 
 const IMAGE_EXTENSION_PATTERN = /\.(avif|gif|jpe?g|png|webp)$/i;
+const VIDEO_EXTENSION_PATTERN = /\.(mov|mp4|webm)$/i;
 
 function isFileDrag(event: DragEvent<HTMLElement>) {
   return Array.from(event.dataTransfer.types).includes("Files");
 }
 
-function getSupportedImageFiles(files: FileList | null) {
+function getSupportedFiles(files: FileList | null, fileKind: "image" | "video") {
   return Array.from(files ?? []).filter(
-    (file) => file.type.startsWith("image/") || IMAGE_EXTENSION_PATTERN.test(file.name),
+    (file) =>
+      file.type.startsWith(`${fileKind}/`) ||
+      (fileKind === "image" ? IMAGE_EXTENSION_PATTERN : VIDEO_EXTENSION_PATTERN).test(file.name),
   );
 }
 
@@ -40,6 +44,7 @@ export function ImageUploadDropzone({
   multiple = true,
   disabled = false,
   ariaLabel,
+  fileKind = "image",
 }: ImageUploadDropzoneProps) {
   const inputRef = useRef<HTMLInputElement>(null);
   const dragDepthRef = useRef(0);
@@ -47,17 +52,19 @@ export function ImageUploadDropzone({
   const isDisabled = disabled || pending;
 
   const submitFiles = (files: FileList | null) => {
-    const imageFiles = getSupportedImageFiles(files);
-    if (imageFiles.length === 0) {
+    const supportedFiles = getSupportedFiles(files, fileKind);
+    if (supportedFiles.length === 0) {
       if (files && files.length > 0) {
-        toast.error("Drop image files to upload.");
+        toast.error(fileKind === "image" ? "Drop image files to upload." : "Drop video files to upload.");
       }
       return;
     }
-    if (files && imageFiles.length < files.length) {
-      toast.warning("Only image files can be uploaded here.");
+    if (files && supportedFiles.length < files.length) {
+      toast.warning(
+        fileKind === "image" ? "Only image files can be uploaded here." : "Only video files can be uploaded here.",
+      );
     }
-    onFilesSelected(imageFiles);
+    onFilesSelected(supportedFiles);
   };
 
   const resetDragState = () => {

--- a/packages/client/src/hooks/use-characters.ts
+++ b/packages/client/src/hooks/use-characters.ts
@@ -137,11 +137,13 @@ export function flattenCharacterPages(data: { pages?: Array<PaginatedList<Record
   return flattenPaginatedItems(data?.pages);
 }
 
-export function fetchAllCharacterPages(options: {
-  includeBuiltIn?: boolean;
-  search?: string;
-  sort?: string;
-} = {}) {
+export function fetchAllCharacterPages(
+  options: {
+    includeBuiltIn?: boolean;
+    search?: string;
+    sort?: string;
+  } = {},
+) {
   const includeBuiltIn = options.includeBuiltIn === true;
   const search = (options.search ?? "").trim();
   const sort = options.sort ?? "";
@@ -373,7 +375,7 @@ export interface CharacterGalleryImage {
 
 export interface CharacterGalleryClip {
   id: string;
-  source: "conversation-call" | "conversation-call-custom" | "game-scene" | "scene-video";
+  source: "conversation-call" | "conversation-call-custom" | "game-scene" | "scene-video" | "uploaded-video";
   label: string;
   prompt: string;
   status: "ready" | "generating" | "error" | "missing";
@@ -401,6 +403,14 @@ export type CharacterGalleryClipUploadInput = {
   file: File;
   label?: string | null;
   kind?: string | null;
+};
+
+export type CharacterCallVideoGenerationInput = {
+  clipKind?: string | null;
+  clipKinds?: string[] | null;
+  clipCount?: number | null;
+  connectionId?: string | null;
+  includeAvatarReference?: boolean;
 };
 
 export const spriteKeys = {
@@ -517,10 +527,14 @@ export function useCharacterGalleryClips(characterId: string | null) {
 export function useGenerateCharacterCallVideoClips(characterId: string) {
   const qc = useQueryClient();
   return useMutation({
-    mutationFn: (input?: { clipKind?: string | null }) =>
+    mutationFn: (input?: CharacterCallVideoGenerationInput) =>
       api.post(`/conversation-calls/character-videos/${characterId}/generate`, {
         debugMode: useUIStore.getState().debugMode,
         ...(input?.clipKind ? { clipKind: input.clipKind } : {}),
+        ...(input?.clipKinds?.length ? { clipKinds: input.clipKinds } : {}),
+        ...(input?.clipCount ? { clipCount: input.clipCount } : {}),
+        ...(input?.connectionId ? { connectionId: input.connectionId } : {}),
+        ...(input?.includeAvatarReference === false ? { includeAvatarReference: false } : {}),
       }),
     onSuccess: () => {
       qc.invalidateQueries({ queryKey: characterKeys.galleryClips(characterId) });
@@ -529,10 +543,30 @@ export function useGenerateCharacterCallVideoClips(characterId: string) {
   });
 }
 
+export function useGeneratePersonaCallVideoClips(personaId: string) {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (input?: CharacterCallVideoGenerationInput) =>
+      api.post(`/conversation-calls/persona-videos/${personaId}/generate`, {
+        debugMode: useUIStore.getState().debugMode,
+        ...(input?.clipKind ? { clipKind: input.clipKind } : {}),
+        ...(input?.clipKinds?.length ? { clipKinds: input.clipKinds } : {}),
+        ...(input?.clipCount ? { clipCount: input.clipCount } : {}),
+        ...(input?.connectionId ? { connectionId: input.connectionId } : {}),
+        ...(input?.includeAvatarReference === false ? { includeAvatarReference: false } : {}),
+      }),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: characterKeys.personaGalleryClips(personaId) });
+      qc.invalidateQueries({ queryKey: ["conversation-calls", "character-videos", personaId] });
+    },
+  });
+}
+
 export function useDeleteCharacterGalleryClip(characterId: string) {
   const qc = useQueryClient();
   return useMutation({
-    mutationFn: (clipId: string) => api.delete(`/characters/${characterId}/gallery/clips/${encodeURIComponent(clipId)}`),
+    mutationFn: (clipId: string) =>
+      api.delete(`/characters/${characterId}/gallery/clips/${encodeURIComponent(clipId)}`),
     onSuccess: () => {
       qc.invalidateQueries({ queryKey: characterKeys.galleryClips(characterId) });
       qc.invalidateQueries({ queryKey: ["conversation-calls", "character-videos", characterId] });
@@ -576,6 +610,21 @@ export function useUploadCharacterGalleryClip(characterId: string) {
     onSuccess: () => {
       qc.invalidateQueries({ queryKey: characterKeys.galleryClips(characterId) });
       qc.invalidateQueries({ queryKey: ["conversation-calls", "character-videos", characterId] });
+    },
+  });
+}
+
+export function useUploadCharacterGalleryVideo(characterId: string) {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: ({ file, label }: CharacterGalleryClipUploadInput) => {
+      const formData = new FormData();
+      formData.append("file", file);
+      if (label?.trim()) formData.append("label", label.trim());
+      return api.upload<CharacterGalleryClip>(`/characters/${characterId}/gallery/videos/upload`, formData);
+    },
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: characterKeys.galleryClips(characterId) });
     },
   });
 }
@@ -705,11 +754,31 @@ export function useUpdatePersonaGalleryClipTrim(personaId: string) {
 export function useUploadPersonaGalleryClip(personaId: string) {
   const qc = useQueryClient();
   return useMutation({
+    mutationFn: ({ file, label, kind }: CharacterGalleryClipUploadInput) => {
+      const formData = new FormData();
+      formData.append("file", file);
+      if (label?.trim()) formData.append("label", label.trim());
+      if (kind?.trim()) formData.append("kind", kind.trim());
+      return api.upload<CharacterGalleryClipsResponse>(
+        `/characters/personas/${personaId}/gallery/clips/upload`,
+        formData,
+      );
+    },
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: characterKeys.personaGalleryClips(personaId) });
+      qc.invalidateQueries({ queryKey: ["conversation-calls", "character-videos", personaId] });
+    },
+  });
+}
+
+export function useUploadPersonaGalleryVideo(personaId: string) {
+  const qc = useQueryClient();
+  return useMutation({
     mutationFn: ({ file, label }: CharacterGalleryClipUploadInput) => {
       const formData = new FormData();
       formData.append("file", file);
       if (label?.trim()) formData.append("label", label.trim());
-      return api.upload<CharacterGalleryClipsResponse>(`/characters/personas/${personaId}/gallery/clips/upload`, formData);
+      return api.upload<CharacterGalleryClip>(`/characters/personas/${personaId}/gallery/videos/upload`, formData);
     },
     onSuccess: () => {
       qc.invalidateQueries({ queryKey: characterKeys.personaGalleryClips(personaId) });

--- a/packages/client/src/hooks/use-characters.ts
+++ b/packages/client/src/hooks/use-characters.ts
@@ -411,6 +411,10 @@ export type CharacterCallVideoGenerationInput = {
   clipCount?: number | null;
   connectionId?: string | null;
   includeAvatarReference?: boolean;
+  customClip?: {
+    label: string;
+    prompt: string;
+  } | null;
 };
 
 export const spriteKeys = {
@@ -543,6 +547,28 @@ export function useGenerateCharacterCallVideoClips(characterId: string) {
   });
 }
 
+export function useGenerateCharacterCustomCallVideoClip(characterId: string) {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (input: CharacterCallVideoGenerationInput) => {
+      if (!input.customClip?.label.trim() || !input.customClip.prompt.trim()) {
+        throw new Error("Custom clips need a name and action.");
+      }
+      return api.post(`/conversation-calls/character-videos/${characterId}/custom/generate`, {
+        debugMode: useUIStore.getState().debugMode,
+        label: input.customClip.label.trim(),
+        prompt: input.customClip.prompt.trim(),
+        ...(input.connectionId ? { connectionId: input.connectionId } : {}),
+        ...(input.includeAvatarReference === false ? { includeAvatarReference: false } : {}),
+      });
+    },
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: characterKeys.galleryClips(characterId) });
+      qc.invalidateQueries({ queryKey: ["conversation-calls", "character-videos", characterId] });
+    },
+  });
+}
+
 export function useGeneratePersonaCallVideoClips(personaId: string) {
   const qc = useQueryClient();
   return useMutation({
@@ -555,6 +581,28 @@ export function useGeneratePersonaCallVideoClips(personaId: string) {
         ...(input?.connectionId ? { connectionId: input.connectionId } : {}),
         ...(input?.includeAvatarReference === false ? { includeAvatarReference: false } : {}),
       }),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: characterKeys.personaGalleryClips(personaId) });
+      qc.invalidateQueries({ queryKey: ["conversation-calls", "character-videos", personaId] });
+    },
+  });
+}
+
+export function useGeneratePersonaCustomCallVideoClip(personaId: string) {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (input: CharacterCallVideoGenerationInput) => {
+      if (!input.customClip?.label.trim() || !input.customClip.prompt.trim()) {
+        throw new Error("Custom clips need a name and action.");
+      }
+      return api.post(`/conversation-calls/persona-videos/${personaId}/custom/generate`, {
+        debugMode: useUIStore.getState().debugMode,
+        label: input.customClip.label.trim(),
+        prompt: input.customClip.prompt.trim(),
+        ...(input.connectionId ? { connectionId: input.connectionId } : {}),
+        ...(input.includeAvatarReference === false ? { includeAvatarReference: false } : {}),
+      });
+    },
     onSuccess: () => {
       qc.invalidateQueries({ queryKey: characterKeys.personaGalleryClips(personaId) });
       qc.invalidateQueries({ queryKey: ["conversation-calls", "character-videos", personaId] });

--- a/packages/client/src/hooks/use-characters.ts
+++ b/packages/client/src/hooks/use-characters.ts
@@ -55,6 +55,7 @@ export const characterKeys = {
   galleryClips: (id: string) => [...characterKeys.all, "gallery", id, "clips"] as const,
   personaGallery: (id: string) => ["persona-gallery", id] as const,
   personaGalleryClips: (id: string) => ["persona-gallery", id, "clips"] as const,
+  personaCallVideos: (id: string) => ["conversation-calls", "persona-videos", id] as const,
   personas: ["personas"] as const,
   personaActive: () => [...characterKeys.personas, "active"] as const,
   personaDetail: (id: string) => [...characterKeys.personas, "detail", id] as const,
@@ -583,7 +584,7 @@ export function useGeneratePersonaCallVideoClips(personaId: string) {
       }),
     onSuccess: () => {
       qc.invalidateQueries({ queryKey: characterKeys.personaGalleryClips(personaId) });
-      qc.invalidateQueries({ queryKey: ["conversation-calls", "character-videos", personaId] });
+      qc.invalidateQueries({ queryKey: characterKeys.personaCallVideos(personaId) });
     },
   });
 }
@@ -605,7 +606,7 @@ export function useGeneratePersonaCustomCallVideoClip(personaId: string) {
     },
     onSuccess: () => {
       qc.invalidateQueries({ queryKey: characterKeys.personaGalleryClips(personaId) });
-      qc.invalidateQueries({ queryKey: ["conversation-calls", "character-videos", personaId] });
+      qc.invalidateQueries({ queryKey: characterKeys.personaCallVideos(personaId) });
     },
   });
 }
@@ -814,7 +815,7 @@ export function useUploadPersonaGalleryClip(personaId: string) {
     },
     onSuccess: () => {
       qc.invalidateQueries({ queryKey: characterKeys.personaGalleryClips(personaId) });
-      qc.invalidateQueries({ queryKey: ["conversation-calls", "character-videos", personaId] });
+      qc.invalidateQueries({ queryKey: characterKeys.personaCallVideos(personaId) });
     },
   });
 }

--- a/packages/client/src/hooks/use-conversation-calls.ts
+++ b/packages/client/src/hooks/use-conversation-calls.ts
@@ -209,7 +209,8 @@ export function useConversationCallSoundboard() {
 export function useConversationCallCharacterVideos(characterId: string | null, enabled = true) {
   return useQuery({
     queryKey: conversationCallKeys.characterVideos(characterId ?? ""),
-    queryFn: () => api.get<ConversationCallCharacterVideoManifest>(`/conversation-calls/character-videos/${characterId}`),
+    queryFn: () =>
+      api.get<ConversationCallCharacterVideoManifest>(`/conversation-calls/character-videos/${characterId}`),
     enabled: enabled && Boolean(characterId),
     refetchInterval: (query) => (query.state.data?.generating ? 15_000 : false),
     staleTime: 15_000,
@@ -219,10 +220,22 @@ export function useConversationCallCharacterVideos(characterId: string | null, e
 export function useGenerateConversationCallCharacterVideos() {
   const queryClient = useQueryClient();
   return useMutation({
-    mutationFn: (input: { characterId: string }) =>
+    mutationFn: (input: {
+      characterId: string;
+      clipKinds?: string[] | null;
+      clipCount?: number | null;
+      connectionId?: string | null;
+      includeAvatarReference?: boolean;
+    }) =>
       api.post<ConversationCallCharacterVideoManifest>(
         `/conversation-calls/character-videos/${input.characterId}/generate`,
-        { debugMode: useUIStore.getState().debugMode },
+        {
+          debugMode: useUIStore.getState().debugMode,
+          ...(input.clipKinds?.length ? { clipKinds: input.clipKinds } : {}),
+          ...(input.clipCount ? { clipCount: input.clipCount } : {}),
+          ...(input.connectionId ? { connectionId: input.connectionId } : {}),
+          ...(input.includeAvatarReference === false ? { includeAvatarReference: false } : {}),
+        },
       ),
     onSuccess: (manifest) => {
       queryClient.setQueryData(conversationCallKeys.characterVideos(manifest.characterId), manifest);

--- a/packages/client/src/lib/markdown.tsx
+++ b/packages/client/src/lib/markdown.tsx
@@ -33,13 +33,41 @@ const INLINE_MD_RE = new RegExp(
 
 /** Maximum recursion depth for nested inline markdown. */
 const MAX_INLINE_DEPTH = 6;
+const CHAT_TEXT_HTML_ENTITY_RE = /&(amp|lt|gt|quot|apos|#\d{1,7}|#x[0-9a-f]{1,6});/gi;
 
 function shouldConvertLatexSymbols(): boolean {
   return useUIStore.getState().convertLatexSymbols !== false;
 }
 
+function decodeChatTextHtmlEntities(text: string): string {
+  return text.replace(CHAT_TEXT_HTML_ENTITY_RE, (match, entity: string) => {
+    const normalized = entity.toLowerCase();
+    switch (normalized) {
+      case "amp":
+        return "&";
+      case "lt":
+        return "<";
+      case "gt":
+        return ">";
+      case "quot":
+        return '"';
+      case "apos":
+        return "'";
+      default: {
+        const isHex = normalized.startsWith("#x");
+        const rawCodePoint = isHex ? normalized.slice(2) : normalized.slice(1);
+        const codePoint = Number.parseInt(rawCodePoint, isHex ? 16 : 10);
+        return Number.isFinite(codePoint) && codePoint > 0 && codePoint <= 0x10ffff
+          ? String.fromCodePoint(codePoint)
+          : match;
+      }
+    }
+  });
+}
+
 function maybeConvertLatexSymbols(text: string, enabled = shouldConvertLatexSymbols()): string {
-  return enabled ? convertBasicLatexSymbols(text) : text;
+  const decoded = decodeChatTextHtmlEntities(text);
+  return enabled ? convertBasicLatexSymbols(decoded) : decoded;
 }
 
 /**
@@ -53,7 +81,7 @@ function maybeConvertLatexSymbols(text: string, enabled = shouldConvertLatexSymb
  */
 export function applyInlineMarkdown(text: string, keyPrefix: string, _depth = 0): ReactNode[] {
   // Safety: prevent runaway recursion
-  if (_depth > MAX_INLINE_DEPTH) return [text];
+  if (_depth > MAX_INLINE_DEPTH) return [maybeConvertLatexSymbols(text)];
 
   const markdownText = normalizeCardAssetImageSyntax(text);
   const convertLatex = shouldConvertLatexSymbols();
@@ -84,7 +112,7 @@ export function applyInlineMarkdown(text: string, keyPrefix: string, _depth = 0)
           <img
             key={`${keyPrefix}img${key++}`}
             src={resolvedUrl}
-            alt={match[3] || ""}
+            alt={decodeChatTextHtmlEntities(match[3] || "")}
             className="my-1 inline-block max-w-full rounded-lg align-bottom sm:max-w-md"
             loading="lazy"
             decoding="async"
@@ -100,7 +128,7 @@ export function applyInlineMarkdown(text: string, keyPrefix: string, _depth = 0)
             rel="noopener noreferrer"
             className="text-blue-400 underline hover:text-blue-300"
           >
-            {match[3]}
+            {decodeChatTextHtmlEntities(match[3])}
           </a>,
         );
       }
@@ -108,7 +136,7 @@ export function applyInlineMarkdown(text: string, keyPrefix: string, _depth = 0)
       // ── Inline code: `code` (no recursion — content is literal) ──
       nodes.push(
         <code key={`${keyPrefix}c${key++}`} className="mari-md-inline-code">
-          {match[5]}
+          {decodeChatTextHtmlEntities(match[5])}
         </code>,
       );
     } else if (match[6] != null) {

--- a/packages/client/src/lib/tts-service.ts
+++ b/packages/client/src/lib/tts-service.ts
@@ -26,6 +26,7 @@ export interface TTSSpeakRequest {
   voice?: string;
   cacheKey?: string;
   cacheAliases?: string[];
+  activeId?: string | null;
 }
 
 export interface TTSSpeakSequenceOptions extends Pick<TTSSpeakOptions, "signal" | "throwOnError" | "volume" | "muted"> {
@@ -352,7 +353,7 @@ class TTSService {
         };
 
         runChunkStart();
-        this.setState("playing", id ?? null);
+        this.setState("playing", request.activeId ?? id ?? null);
         void audio.play().catch((err) => fail(toError(err, "Browser blocked audio playback")));
       });
     };

--- a/packages/client/src/stores/gallery.store.ts
+++ b/packages/client/src/stores/gallery.store.ts
@@ -61,7 +61,9 @@ function loadPinnedImages(): PinnedGalleryMedia[] {
     const raw = window.localStorage.getItem(PINNED_GALLERY_IMAGES_STORAGE_KEY);
     if (!raw) return [];
     const parsed = JSON.parse(raw);
-    return Array.isArray(parsed) ? parsed.map(normalizeStoredMedia).filter((item): item is PinnedGalleryMedia => !!item) : [];
+    return Array.isArray(parsed)
+      ? parsed.map(normalizeStoredMedia).filter((item): item is PinnedGalleryMedia => !!item)
+      : [];
   } catch {
     return [];
   }
@@ -85,6 +87,8 @@ interface GalleryState {
   latestViewerChatId: string | null;
   /** Chat IDs with an in-flight manual gallery illustration request. */
   illustratingChatIds: Set<string>;
+  /** Chat IDs with an in-flight manual selfie generation request. */
+  selfieGeneratingChatIds: Set<string>;
   /** Chat IDs with an in-flight manual scene video request. */
   videoGeneratingChatIds: Set<string>;
   /** Chat IDs with an in-flight manual scene background request. */
@@ -101,6 +105,7 @@ interface GalleryState {
   unpinImage: (mediaId: string) => void;
   clearPinned: () => void;
   setChatIllustrating: (chatId: string, illustrating: boolean) => void;
+  setChatGeneratingSelfie: (chatId: string, generating: boolean) => void;
   setChatGeneratingVideo: (chatId: string, generating: boolean) => void;
   setChatGeneratingBackground: (chatId: string, generating: boolean) => void;
   setChatGeneratingStoryboard: (chatId: string, generating: boolean) => void;
@@ -111,6 +116,7 @@ export const useGalleryStore = create<GalleryState>((set) => ({
   viewerMedia: null,
   latestViewerChatId: null,
   illustratingChatIds: new Set(),
+  selfieGeneratingChatIds: new Set(),
   videoGeneratingChatIds: new Set(),
   backgroundGeneratingChatIds: new Set(),
   storyboardGeneratingChatIds: new Set(),
@@ -163,6 +169,14 @@ export const useGalleryStore = create<GalleryState>((set) => ({
       if (illustrating) next.add(chatId);
       else next.delete(chatId);
       return { illustratingChatIds: next };
+    }),
+
+  setChatGeneratingSelfie: (chatId, generating) =>
+    set((s) => {
+      const next = new Set(s.selfieGeneratingChatIds);
+      if (generating) next.add(chatId);
+      else next.delete(chatId);
+      return { selfieGeneratingChatIds: next };
     }),
 
   setChatGeneratingVideo: (chatId, generating) =>

--- a/packages/server/src/routes/characters.routes.ts
+++ b/packages/server/src/routes/characters.routes.ts
@@ -37,7 +37,7 @@ import {
   uploadConversationCallCharacterVideoClip,
 } from "../services/conversation/call-character-videos.service.js";
 import { removeSavedVideoFromDisk } from "../services/video/video-generation.js";
-import { writeFile, mkdir, readFile, readdir } from "fs/promises";
+import { writeFile, mkdir, readFile, readdir, unlink } from "fs/promises";
 import { join } from "path";
 import { DATA_DIR } from "../utils/data-dir.js";
 import { createWriteStream, existsSync, rmSync, unlinkSync } from "fs";
@@ -53,7 +53,10 @@ import { newId } from "../utils/id-generator.js";
 
 const CHARACTER_GALLERY_ROOT = join(DATA_DIR, "gallery", "characters");
 const PERSONA_GALLERY_ROOT = join(DATA_DIR, "gallery", "personas");
+const CHARACTER_GALLERY_VIDEO_ROOT = join(DATA_DIR, "gallery", "character-videos");
+const PERSONA_GALLERY_VIDEO_ROOT = join(DATA_DIR, "gallery", "persona-videos");
 const ALLOWED_GALLERY_EXTS = new Set([".jpg", ".jpeg", ".png", ".gif", ".webp", ".avif"]);
+const ALLOWED_GALLERY_VIDEO_EXTS = new Set([".mp4", ".webm", ".mov"]);
 const CHARACTER_CARD_PNG_KEYWORDS = new Set(["chara", "ccv3"]);
 const CUSTOM_NAME_RE = /^[a-z0-9_]{1,32}$/;
 const CUSTOM_KIND_MAX_DIMENSION = {
@@ -71,6 +74,24 @@ const CALL_VIDEO_CLIP_LABELS = {
 const CALL_VIDEO_CLIP_UPLOAD_MAX_BYTES = 250 * 1024 * 1024;
 const ALLOWED_CALL_VIDEO_CLIP_UPLOAD_EXTS = new Set([".mp4"]);
 type UploadedMultipartFile = NonNullable<Awaited<ReturnType<FastifyRequest["file"]>>>;
+
+type GalleryVideoEntry = {
+  id: string;
+  filename: string;
+  label: string;
+  prompt: string;
+  provider: string;
+  model: string;
+  aspectRatio: string;
+  durationSeconds: number | null;
+  createdAt: string;
+  updatedAt: string;
+};
+
+type GalleryVideoManifest = {
+  version: 1;
+  videos: GalleryVideoEntry[];
+};
 
 class CallVideoClipUploadTooLargeError extends Error {
   constructor() {
@@ -111,6 +132,101 @@ async function ensurePersonaGalleryDir(personaId: string) {
   const dir = assertInsideDir(PERSONA_GALLERY_ROOT, join(PERSONA_GALLERY_ROOT, personaId));
   await mkdir(dir, { recursive: true });
   return dir;
+}
+
+function ensureGalleryVideoDir(root: string, entityId: string) {
+  if (isUnsafePathSegment(entityId)) {
+    throw new Error("Invalid gallery video id");
+  }
+  return assertInsideDir(root, join(root, entityId));
+}
+
+function galleryVideoManifestPath(root: string, entityId: string) {
+  return assertInsideDir(root, join(ensureGalleryVideoDir(root, entityId), "manifest.json"));
+}
+
+async function readGalleryVideoManifest(root: string, entityId: string): Promise<GalleryVideoManifest> {
+  try {
+    const raw = await readFile(galleryVideoManifestPath(root, entityId), "utf8");
+    const parsed = JSON.parse(raw) as Partial<GalleryVideoManifest>;
+    return {
+      version: 1,
+      videos: Array.isArray(parsed.videos)
+        ? parsed.videos.filter((entry): entry is GalleryVideoEntry => {
+            return (
+              !!entry &&
+              typeof entry === "object" &&
+              typeof entry.id === "string" &&
+              typeof entry.filename === "string" &&
+              !isUnsafePathSegment(entry.id) &&
+              !isUnsafePathSegment(entry.filename)
+            );
+          })
+        : [],
+    };
+  } catch {
+    return { version: 1, videos: [] };
+  }
+}
+
+async function writeGalleryVideoManifest(root: string, entityId: string, manifest: GalleryVideoManifest) {
+  const dir = ensureGalleryVideoDir(root, entityId);
+  await mkdir(dir, { recursive: true });
+  await writeFile(galleryVideoManifestPath(root, entityId), JSON.stringify(manifest, null, 2));
+}
+
+function toGalleryVideoClip(input: {
+  entry: GalleryVideoEntry;
+  entityId: string;
+  entityKind: "character" | "persona";
+}) {
+  const routeBase =
+    input.entityKind === "character"
+      ? `/api/characters/${input.entityId}/gallery/videos/file`
+      : `/api/characters/personas/${input.entityId}/gallery/videos/file`;
+  return {
+    id: `uploaded:${input.entry.id}`,
+    source: "uploaded-video" as const,
+    label: input.entry.label || "Uploaded video",
+    prompt: input.entry.prompt,
+    status: "ready" as const,
+    url: `${routeBase}/${encodeURIComponent(input.entry.filename)}`,
+    createdAt: input.entry.createdAt,
+    updatedAt: input.entry.updatedAt,
+    origin: "uploaded" as const,
+    durationSeconds: input.entry.durationSeconds,
+    trimStartSeconds: null,
+    trimEndSeconds: null,
+    aspectRatio: input.entry.aspectRatio,
+    provider: input.entry.provider,
+    model: input.entry.model,
+    chatId: null,
+    chatName: null,
+    clipKind: null,
+  };
+}
+
+async function listGalleryVideoClips(root: string, entityId: string, entityKind: "character" | "persona") {
+  const manifest = await readGalleryVideoManifest(root, entityId);
+  return manifest.videos.map((entry) => toGalleryVideoClip({ entry, entityId, entityKind }));
+}
+
+async function removeGalleryVideoClip(root: string, entityId: string, clipId: string) {
+  const videoId = clipId.slice("uploaded:".length);
+  if (!videoId || isUnsafePathSegment(videoId)) return false;
+  const manifest = await readGalleryVideoManifest(root, entityId);
+  const entry = manifest.videos.find((video) => video.id === videoId);
+  if (!entry) return false;
+  const dir = ensureGalleryVideoDir(root, entityId);
+  const filePath = assertInsideDir(dir, join(dir, entry.filename));
+  await unlink(filePath).catch((error: NodeJS.ErrnoException) => {
+    if (error.code !== "ENOENT") throw error;
+  });
+  await writeGalleryVideoManifest(root, entityId, {
+    version: 1,
+    videos: manifest.videos.filter((video) => video.id !== videoId),
+  });
+  return true;
 }
 
 function isUnsafePathSegment(value: string) {
@@ -186,7 +302,11 @@ function readMultipartStringField(fields: unknown, key: string): string {
 
 function labelFromUploadedClipFilename(filename: string): string {
   const base = filename.split(/[\\/]/).pop() ?? "";
-  return base.replace(/\.[^.]+$/, "").replace(/[-_]+/g, " ").replace(/\s+/g, " ").trim();
+  return base
+    .replace(/\.[^.]+$/, "")
+    .replace(/[-_]+/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
 }
 
 function toSafeExportName(name: string, fallback: string) {
@@ -433,26 +553,23 @@ export async function charactersRoutes(app: FastifyInstance) {
       sort?: string;
       favoriteFilter?: string;
     };
-  }>(
-    "/",
-    async (req) => {
-      const includeBuiltIn = req.query.includeBuiltIn === "true";
-      const page = parseLibraryPageQuery(req.query);
-      if (page.hasPaging) {
-        return storage.listPage({
-          includeBuiltIn,
-          limit: page.limit,
-          offset: page.offset,
-          search: page.search,
-          sort: page.sort,
-          favoriteFilter: page.favoriteFilter,
-        });
-      }
-      const characters = await storage.list();
-      if (includeBuiltIn) return characters;
-      return characters.filter((character) => character.id !== PROFESSOR_MARI_ID);
-    },
-  );
+  }>("/", async (req) => {
+    const includeBuiltIn = req.query.includeBuiltIn === "true";
+    const page = parseLibraryPageQuery(req.query);
+    if (page.hasPaging) {
+      return storage.listPage({
+        includeBuiltIn,
+        limit: page.limit,
+        offset: page.offset,
+        search: page.search,
+        sort: page.sort,
+        favoriteFilter: page.favoriteFilter,
+      });
+    }
+    const characters = await storage.list();
+    if (includeBuiltIn) return characters;
+    return characters.filter((character) => character.id !== PROFESSOR_MARI_ID);
+  });
 
   app.post<{ Body: { ids?: unknown } }>("/summaries", async (req) => {
     const ids = Array.isArray(req.body?.ids) ? req.body.ids.filter((id): id is string => typeof id === "string") : [];
@@ -734,8 +851,9 @@ export async function charactersRoutes(app: FastifyInstance) {
         };
       }),
     );
+    const uploadedVideoClips = await listGalleryVideoClips(CHARACTER_GALLERY_VIDEO_ROOT, req.params.id, "character");
 
-    const clips = [...customCallClips, ...callClips, ...sceneClips].sort((left, right) => {
+    const clips = [...customCallClips, ...callClips, ...uploadedVideoClips, ...sceneClips].sort((left, right) => {
       const leftTime = Date.parse(left.updatedAt ?? left.createdAt ?? "") || 0;
       const rightTime = Date.parse(right.updatedAt ?? right.createdAt ?? "") || 0;
       return rightTime - leftTime;
@@ -929,7 +1047,76 @@ export async function charactersRoutes(app: FastifyInstance) {
       return { success: true };
     }
 
+    if (clipId.startsWith("uploaded:")) {
+      const deleted = await removeGalleryVideoClip(CHARACTER_GALLERY_VIDEO_ROOT, id, clipId);
+      if (!deleted) return reply.status(404).send({ error: "Clip not found" });
+      return { success: true };
+    }
+
     return reply.status(400).send({ error: "Unsupported clip type" });
+  });
+
+  app.post<{ Params: { id: string } }>("/:id/gallery/videos/upload", async (req, reply) => {
+    const { id } = req.params;
+    const char = await storage.getById(id);
+    if (!char) return reply.status(404).send({ error: "Character not found" });
+
+    const data = await req.file({ limits: { fileSize: CALL_VIDEO_CLIP_UPLOAD_MAX_BYTES } });
+    if (!data) {
+      return reply.status(400).send({ error: "No file uploaded" });
+    }
+
+    const ext = extname(data.filename).toLowerCase();
+    if (!ALLOWED_GALLERY_VIDEO_EXTS.has(ext)) {
+      return reply.status(400).send({ error: `Unsupported video type: ${ext}` });
+    }
+
+    const dir = ensureGalleryVideoDir(CHARACTER_GALLERY_VIDEO_ROOT, id);
+    await mkdir(dir, { recursive: true });
+    const videoId = newId();
+    const filename = `${videoId}${ext}`;
+    const filePath = assertInsideDir(dir, join(dir, filename));
+    await pipeline(data.file, createWriteStream(filePath));
+    if (isMultipartFileTruncated(data)) {
+      await unlink(filePath).catch(() => undefined);
+      return reply.status(413).send({ error: "Gallery video uploads must be 250 MB or smaller." });
+    }
+
+    const fields = data.fields as Record<string, unknown>;
+    const timestamp = new Date().toISOString();
+    const manifest = await readGalleryVideoManifest(CHARACTER_GALLERY_VIDEO_ROOT, id);
+    const entry: GalleryVideoEntry = {
+      id: videoId,
+      filename,
+      label: readMultipartStringField(fields, "label") || labelFromUploadedClipFilename(data.filename),
+      prompt: readMultipartStringField(fields, "prompt") || "",
+      provider: readMultipartStringField(fields, "provider") || "upload",
+      model: readMultipartStringField(fields, "model") || "",
+      aspectRatio: readMultipartStringField(fields, "aspectRatio") || "video",
+      durationSeconds: null,
+      createdAt: timestamp,
+      updatedAt: timestamp,
+    };
+    await writeGalleryVideoManifest(CHARACTER_GALLERY_VIDEO_ROOT, id, {
+      version: 1,
+      videos: [entry, ...manifest.videos],
+    });
+    return toGalleryVideoClip({ entry, entityId: id, entityKind: "character" });
+  });
+
+  app.get<{ Params: { id: string; filename: string } }>("/:id/gallery/videos/file/:filename", async (req, reply) => {
+    const { id, filename } = req.params;
+    if (isUnsafePathSegment(id) || isUnsafePathSegment(filename)) {
+      return reply.status(400).send({ error: "Invalid path" });
+    }
+
+    const dir = ensureGalleryVideoDir(CHARACTER_GALLERY_VIDEO_ROOT, id);
+    const filePath = assertInsideDir(dir, join(dir, filename));
+    if (!existsSync(filePath)) {
+      return reply.status(404).send({ error: "Not found" });
+    }
+
+    return reply.sendFile(filename, dir);
   });
 
   app.post<{ Params: { id: string } }>("/:id/gallery/upload", async (req, reply) => {
@@ -1407,6 +1594,26 @@ export async function charactersRoutes(app: FastifyInstance) {
       characterName: personaName,
       avatarPath: persona.avatarPath ?? null,
     });
+    const callClips = callManifest.clips.map((clip) => ({
+      id: `call:${clip.kind}`,
+      source: "conversation-call" as const,
+      label: CALL_VIDEO_CLIP_LABELS[clip.kind] ?? clip.kind,
+      prompt: "",
+      status: clip.status,
+      url: clip.url,
+      createdAt: clip.updatedAt ?? null,
+      updatedAt: clip.updatedAt,
+      origin: clip.origin ?? null,
+      durationSeconds: null,
+      trimStartSeconds: clip.trimStartSeconds ?? null,
+      trimEndSeconds: clip.trimEndSeconds ?? null,
+      aspectRatio: "16:9",
+      provider: "",
+      model: "",
+      chatId: null,
+      chatName: null,
+      clipKind: clip.kind,
+    }));
     const customCallClips = callManifest.customClips.map((clip) => ({
       id: `custom-call:${clip.id}`,
       source: "conversation-call-custom" as const,
@@ -1464,8 +1671,9 @@ export async function charactersRoutes(app: FastifyInstance) {
         };
       }),
     );
+    const uploadedVideoClips = await listGalleryVideoClips(PERSONA_GALLERY_VIDEO_ROOT, req.params.id, "persona");
 
-    const clips = [...customCallClips, ...sceneClips].sort((left, right) => {
+    const clips = [...customCallClips, ...callClips, ...uploadedVideoClips, ...sceneClips].sort((left, right) => {
       const leftTime = Date.parse(left.updatedAt ?? left.createdAt ?? "") || 0;
       const rightTime = Date.parse(right.updatedAt ?? right.createdAt ?? "") || 0;
       return rightTime - leftTime;
@@ -1487,25 +1695,35 @@ export async function charactersRoutes(app: FastifyInstance) {
         return reply.status(400).send({ error: "Clip trim values must be numbers, null, or omitted" });
       }
 
-      if (!clipId.startsWith("custom-call:")) {
-        return reply.status(400).send({ error: "Unsupported clip type" });
-      }
-
       const customClipId = clipId.slice("custom-call:".length);
-      if (!/^[A-Za-z0-9_-]{6,80}$/.test(customClipId)) {
-        return reply.status(400).send({ error: "Invalid custom clip id" });
-      }
-
       const personaName = typeof persona.name === "string" && persona.name.trim() ? persona.name.trim() : "Persona";
       try {
-        return await updateConversationCallCustomVideoClipTrim({
-          characterId: id,
-          characterName: personaName,
-          avatarPath: persona.avatarPath ?? null,
-          clipId: customClipId,
-          trimStartSeconds,
-          trimEndSeconds,
-        });
+        if (clipId.startsWith("call:")) {
+          const kind = parseConversationCallClipKind(clipId.slice("call:".length));
+          if (!kind) return reply.status(400).send({ error: "Invalid call clip kind" });
+          return await updateConversationCallCharacterVideoClipTrim({
+            characterId: id,
+            characterName: personaName,
+            avatarPath: persona.avatarPath ?? null,
+            kind,
+            trimStartSeconds,
+            trimEndSeconds,
+          });
+        }
+
+        if (clipId.startsWith("custom-call:")) {
+          if (!/^[A-Za-z0-9_-]{6,80}$/.test(customClipId)) {
+            return reply.status(400).send({ error: "Invalid custom clip id" });
+          }
+          return await updateConversationCallCustomVideoClipTrim({
+            characterId: id,
+            characterName: personaName,
+            avatarPath: persona.avatarPath ?? null,
+            clipId: customClipId,
+            trimStartSeconds,
+            trimEndSeconds,
+          });
+        }
       } catch (error) {
         if (error instanceof ConversationCallVideoClipNotFoundError) {
           return reply.status(404).send({ error: error.message });
@@ -1521,6 +1739,8 @@ export async function charactersRoutes(app: FastifyInstance) {
         }
         throw error;
       }
+
+      return reply.status(400).send({ error: "Unsupported clip type" });
     },
   );
 
@@ -1528,6 +1748,26 @@ export async function charactersRoutes(app: FastifyInstance) {
     const { id, clipId } = req.params;
     const persona = await storage.getPersona(id);
     if (!persona) return reply.status(404).send({ error: "Persona not found" });
+
+    if (clipId.startsWith("call:")) {
+      const kind = parseConversationCallClipKind(clipId.slice("call:".length));
+      if (!kind) return reply.status(400).send({ error: "Invalid call clip kind" });
+      const personaName = typeof persona.name === "string" && persona.name.trim() ? persona.name.trim() : "Persona";
+      try {
+        await deleteConversationCallCharacterVideoClip({
+          characterId: id,
+          characterName: personaName,
+          avatarPath: persona.avatarPath ?? null,
+          kind,
+        });
+      } catch (error) {
+        if (error instanceof ConversationCallVideoGenerationInProgressError) {
+          return reply.status(409).send({ error: error.message });
+        }
+        throw error;
+      }
+      return { success: true };
+    }
 
     if (clipId.startsWith("custom-call:")) {
       const customClipId = clipId.slice("custom-call:".length);
@@ -1554,6 +1794,11 @@ export async function charactersRoutes(app: FastifyInstance) {
     }
 
     if (!clipId.startsWith("scene:")) {
+      if (clipId.startsWith("uploaded:")) {
+        const deleted = await removeGalleryVideoClip(PERSONA_GALLERY_VIDEO_ROOT, id, clipId);
+        if (!deleted) return reply.status(404).send({ error: "Clip not found" });
+        return { success: true };
+      }
       return reply.status(400).send({ error: "Unsupported clip type" });
     }
 
@@ -1574,6 +1819,72 @@ export async function charactersRoutes(app: FastifyInstance) {
     await sceneVideos.remove(video.id);
     return { success: true };
   });
+
+  app.post<{ Params: { id: string } }>("/personas/:id/gallery/videos/upload", async (req, reply) => {
+    const { id } = req.params;
+    const persona = await storage.getPersona(id);
+    if (!persona) return reply.status(404).send({ error: "Persona not found" });
+
+    const data = await req.file({ limits: { fileSize: CALL_VIDEO_CLIP_UPLOAD_MAX_BYTES } });
+    if (!data) {
+      return reply.status(400).send({ error: "No file uploaded" });
+    }
+
+    const ext = extname(data.filename).toLowerCase();
+    if (!ALLOWED_GALLERY_VIDEO_EXTS.has(ext)) {
+      return reply.status(400).send({ error: `Unsupported video type: ${ext}` });
+    }
+
+    const dir = ensureGalleryVideoDir(PERSONA_GALLERY_VIDEO_ROOT, id);
+    await mkdir(dir, { recursive: true });
+    const videoId = newId();
+    const filename = `${videoId}${ext}`;
+    const filePath = assertInsideDir(dir, join(dir, filename));
+    await pipeline(data.file, createWriteStream(filePath));
+    if (isMultipartFileTruncated(data)) {
+      await unlink(filePath).catch(() => undefined);
+      return reply.status(413).send({ error: "Gallery video uploads must be 250 MB or smaller." });
+    }
+
+    const fields = data.fields as Record<string, unknown>;
+    const timestamp = new Date().toISOString();
+    const manifest = await readGalleryVideoManifest(PERSONA_GALLERY_VIDEO_ROOT, id);
+    const entry: GalleryVideoEntry = {
+      id: videoId,
+      filename,
+      label: readMultipartStringField(fields, "label") || labelFromUploadedClipFilename(data.filename),
+      prompt: readMultipartStringField(fields, "prompt") || "",
+      provider: readMultipartStringField(fields, "provider") || "upload",
+      model: readMultipartStringField(fields, "model") || "",
+      aspectRatio: readMultipartStringField(fields, "aspectRatio") || "video",
+      durationSeconds: null,
+      createdAt: timestamp,
+      updatedAt: timestamp,
+    };
+    await writeGalleryVideoManifest(PERSONA_GALLERY_VIDEO_ROOT, id, {
+      version: 1,
+      videos: [entry, ...manifest.videos],
+    });
+    return toGalleryVideoClip({ entry, entityId: id, entityKind: "persona" });
+  });
+
+  app.get<{ Params: { id: string; filename: string } }>(
+    "/personas/:id/gallery/videos/file/:filename",
+    async (req, reply) => {
+      const { id, filename } = req.params;
+      if (isUnsafePathSegment(id) || isUnsafePathSegment(filename)) {
+        return reply.status(400).send({ error: "Invalid path" });
+      }
+
+      const dir = ensureGalleryVideoDir(PERSONA_GALLERY_VIDEO_ROOT, id);
+      const filePath = assertInsideDir(dir, join(dir, filename));
+      if (!existsSync(filePath)) {
+        return reply.status(404).send({ error: "Not found" });
+      }
+
+      return reply.sendFile(filename, dir);
+    },
+  );
 
   app.post<{ Params: { id: string } }>("/personas/:id/gallery/clips/upload", async (req, reply) => {
     const { id } = req.params;
@@ -1604,6 +1915,11 @@ export async function charactersRoutes(app: FastifyInstance) {
     }
 
     const fields = data.fields as Record<string, unknown>;
+    const requestedKind = readMultipartStringField(fields, "kind");
+    const kind = requestedKind ? parseConversationCallClipKind(requestedKind) : null;
+    if (requestedKind && !kind) {
+      return reply.status(400).send({ error: "Invalid call clip kind" });
+    }
     const personaName = typeof persona.name === "string" && persona.name.trim() ? persona.name.trim() : "Persona";
     const label = readMultipartStringField(fields, "label") || labelFromUploadedClipFilename(data.filename);
     try {
@@ -1613,6 +1929,7 @@ export async function charactersRoutes(app: FastifyInstance) {
         avatarPath: persona.avatarPath ?? null,
         buffer,
         label,
+        kind,
       });
     } catch (error) {
       if (error instanceof ConversationCallVideoClipUploadError) {

--- a/packages/server/src/routes/characters.routes.ts
+++ b/packages/server/src/routes/characters.routes.ts
@@ -1891,7 +1891,7 @@ export async function charactersRoutes(app: FastifyInstance) {
     const persona = await storage.getPersona(id);
     if (!persona) return reply.status(404).send({ error: "Persona not found" });
 
-    const data = await req.file();
+    const data = await req.file({ limits: { fileSize: CALL_VIDEO_CLIP_UPLOAD_MAX_BYTES } });
     if (!data) {
       return reply.status(400).send({ error: "No file uploaded" });
     }

--- a/packages/server/src/routes/conversation-calls.routes.ts
+++ b/packages/server/src/routes/conversation-calls.routes.ts
@@ -968,6 +968,7 @@ async function buildCallPrompt(input: {
           .getDefaultForVideoGeneration()
           .catch(() => null)
       : null;
+  const soundNames = (await createConversationCallsStorage(input.app.db).listSounds()).map((sound) => sound.name);
   if (characterVideoPresenceEnabled) {
     const manifests = await Promise.all(
       characters.map((character) =>
@@ -1058,13 +1059,12 @@ async function buildCallPrompt(input: {
     if (hapticAvailable) allowedCommands.push("haptic");
     if (customVideoClipConnection) allowedCommands.push("custom_clip");
     if (playableCustomClipTargets.length > 0) allowedCommands.push("play_clip");
+    if (soundNames.length > 0) allowedCommands.push("soundboard");
     if (commandToggles.influence !== false && input.chat.connectedChatId) allowedCommands.push("influence");
     if (commandToggles.note !== false && input.chat.connectedChatId) allowedCommands.push("note");
   }
   if (!allowedCommands.includes("end_call")) allowedCommands.push("end_call");
   if (!allowedCommands.includes("leave_call")) allowedCommands.push("leave_call");
-  const soundNames = (await createConversationCallsStorage(input.app.db).listSounds()).map((sound) => sound.name);
-  allowedCommands.push("soundboard");
   const commandPromptLines = allowedCommands.flatMap((command) =>
     formatCallCommandPromptLines(command, {
       personaName: persona?.name || "User",

--- a/packages/server/src/routes/conversation-calls.routes.ts
+++ b/packages/server/src/routes/conversation-calls.routes.ts
@@ -66,10 +66,7 @@ import { resolveConnectionImageDefaults } from "../services/image/image-generati
 import { loadImageGenerationUserSettings } from "../services/image/image-generation-settings.js";
 import { compileImagePrompt } from "../services/image/image-prompt-compiler.js";
 import { generateImage, saveImageToDisk } from "../services/image/image-generation.js";
-import {
-  isNovelAiImageConnection,
-  resolveIllustratorCharacterReferences,
-} from "./generate/illustrator-references.js";
+import { isNovelAiImageConnection, resolveIllustratorCharacterReferences } from "./generate/illustrator-references.js";
 import { getChatHapticIntifaceUrl } from "../services/generation/haptic-runtime.js";
 import { resolveSpotifyCredentials, spotifyHasScope } from "../services/spotify/spotify.service.js";
 import {
@@ -138,6 +135,54 @@ function parseJsonRecord(value: unknown): Record<string, unknown> {
     }
   }
   return typeof value === "object" && !Array.isArray(value) ? (value as Record<string, unknown>) : {};
+}
+
+function parseCallVideoClipKinds(body: Record<string, unknown>): ConversationCallCharacterVideoClipKind[] | null {
+  const requestedKinds = Array.isArray(body.clipKinds)
+    ? body.clipKinds
+    : typeof body.clipKind === "string"
+      ? [body.clipKind]
+      : typeof body.kind === "string"
+        ? [body.kind]
+        : [];
+  const clipKinds: ConversationCallCharacterVideoClipKind[] = [];
+  for (const rawKind of requestedKinds) {
+    if (typeof rawKind !== "string") continue;
+    if (!CONVERSATION_CALL_CHARACTER_VIDEO_CLIP_KINDS.includes(rawKind as ConversationCallCharacterVideoClipKind)) {
+      throw new Error("Invalid call video clip kind");
+    }
+    const kind = rawKind as ConversationCallCharacterVideoClipKind;
+    if (!clipKinds.includes(kind)) clipKinds.push(kind);
+  }
+  const requestedCount = Number(body.clipCount);
+  const clipCount =
+    Number.isFinite(requestedCount) && requestedCount > 0
+      ? Math.min(CONVERSATION_CALL_CHARACTER_VIDEO_CLIP_KINDS.length, Math.floor(requestedCount))
+      : null;
+  if (clipKinds.length > 0) return clipCount ? clipKinds.slice(0, clipCount) : clipKinds;
+  if (clipCount) return CONVERSATION_CALL_CHARACTER_VIDEO_CLIP_KINDS.slice(0, clipCount);
+  return null;
+}
+
+async function resolveRequestedVideoGenerationConnection(
+  connections: ReturnType<typeof createConnectionsStorage>,
+  body: Record<string, unknown>,
+) {
+  const requestedConnectionId = typeof body.connectionId === "string" ? body.connectionId.trim() : "";
+  const videoConnection = requestedConnectionId
+    ? await connections.getWithKey(requestedConnectionId)
+    : await connections.getDefaultForVideoGeneration();
+  if (!videoConnection) {
+    throw new Error(
+      requestedConnectionId
+        ? "Selected video generation connection was not found."
+        : "No Default for Videos connection is configured.",
+    );
+  }
+  if (videoConnection.provider !== "video_generation") {
+    throw new Error("Selected connection is not a Video Generation connection.");
+  }
+  return videoConnection;
 }
 
 function readCharacterIds(raw: unknown): string[] {
@@ -235,8 +280,7 @@ async function conversationSpotifyCommandsAvailable(storage: ReturnType<typeof c
   try {
     const spotifyCredentials = await resolveSpotifyCredentials(storage, { refreshSkewMs: 60_000 });
     return (
-      "accessToken" in spotifyCredentials &&
-      spotifyHasScope(spotifyCredentials.scopes, "user-modify-playback-state")
+      "accessToken" in spotifyCredentials && spotifyHasScope(spotifyCredentials.scopes, "user-modify-playback-state")
     );
   } catch (error) {
     logger.debug(error, "[spotify/conversation-call] Failed to check Spotify command availability");
@@ -332,7 +376,10 @@ function nativeMediaContentLabel(kind: ChatMediaAttachment["kind"], mimeType: st
 }
 
 function isBlankAudioTranscript(text: string) {
-  const normalized = text.trim().toLowerCase().replace(/[\s_-]+/g, " ");
+  const normalized = text
+    .trim()
+    .toLowerCase()
+    .replace(/[\s_-]+/g, " ");
   const unwrapped = normalized.replace(/^\[/, "").replace(/\]$/, "").trim();
   return unwrapped === "blank audio" || unwrapped === "blak audio";
 }
@@ -621,7 +668,8 @@ function formatCallCommandPromptLines(
   const crossPostTargets = formatPromptOptionList(context.crossPostTargetNames, '"chat or character name"');
   const memoryTargets = formatPromptOptionList(context.memoryTargetNames, '"Name"');
   const soundTargets = formatPromptOptionList(context.soundNames, '"Sound name"');
-  const hapticDevices = context.hapticDeviceNames.length > 0 ? context.hapticDeviceNames.join(", ") : "connected devices";
+  const hapticDevices =
+    context.hapticDeviceNames.length > 0 ? context.hapticDeviceNames.join(", ") : "connected devices";
   switch (command) {
     case "schedule_update":
       return [
@@ -1016,16 +1064,17 @@ async function buildCallPrompt(input: {
   const nativeMediaText = nativeMedia
     .map((item, index) => `${index + 1}. ${item.kind} (${item.mimeType}${item.filename ? `, ${item.filename}` : ""})`)
     .join("\n");
-  const commandInstructions = commandPromptLines.length > 0
-    ? [
-        "<commands>",
-        "Here are your optional, hidden call commands. Use them only when they genuinely fit the live call.",
-        "",
-        ...commandPromptLines,
-        "IMPORTANT: Commands are hidden actions and are not voiced. If you use a command, emit it as mode \"command\" with exactly one command in content and no prose. Do not emit commands that are not listed here.",
-        "</commands>",
-      ].join("\n")
-    : "";
+  const commandInstructions =
+    commandPromptLines.length > 0
+      ? [
+          "<commands>",
+          "Here are your optional, hidden call commands. Use them only when they genuinely fit the live call.",
+          "",
+          ...commandPromptLines,
+          'IMPORTANT: Commands are hidden actions and are not voiced. If you use a command, emit it as mode "command" with exactly one command in content and no prose. Do not emit commands that are not listed here.',
+          "</commands>",
+        ].join("\n")
+      : "";
   const outputFormat = [
     "<output_format>",
     'Return ONLY valid JSON with this shape: {"turns":[{"speakerName":"Exact character name","mode":"voice|text|command","content":"message text, voice text with TTS [cues], or command text","tone":"voice-only tone tags"}]}',
@@ -1033,7 +1082,7 @@ async function buildCallPrompt(input: {
     "One response may include several ordered turns from multiple characters. Use that when a natural live-call exchange should happen before the user speaks again.",
     "If multiple characters respond, order the turns exactly as they should be heard or displayed.",
     "In group calls, every speaking character must get their own turn so their assigned voice and video clips play on the correct participant.",
-    "Do not put speaker prefixes like \"Dottore (speech):\" inside content. Put the speaker in speakerName and only the spoken/typed/command text in content.",
+    'Do not put speaker prefixes like "Dottore (speech):" inside content. Put the speaker in speakerName and only the spoken/typed/command text in content.',
     "For voice turns, include natural TTS cues inside content or tone when useful, such as [soft], [sighs], [brief pause], or [laughing quietly], etc.",
     "</output_format>",
   ].join("\n");
@@ -1051,7 +1100,7 @@ async function buildCallPrompt(input: {
       ? "The latest user input includes provider-native audio and/or video attachments. Use those attachments as the primary evidence for what the user said or showed; the written marker is only a label."
       : "",
     "If the latest input is a call-silence check, do not treat it as something the user said. If the user recently said they were going away, brb, busy, sleeping, or intentionally quiet, return no turns and wait patiently. Otherwise, one character may ask if the user is still there or all right.",
-    "Use [leave_call] only when the speaking character personally leaves the call. Use [end_call] only when the call should end for everyone. If a character should say something before ending the call, emit that voice or text turn first, then emit a separate command turn with content \"[end_call]\".",
+    'Use [leave_call] only when the speaking character personally leaves the call. Use [end_call] only when the call should end for everyone. If a character should say something before ending the call, emit that voice or text turn first, then emit a separate command turn with content "[end_call]".',
     voiceCapableCharacters.length > 0
       ? `Characters with configured voices: ${voiceCapableCharacters.map((character) => character.name).join(", ")}.`
       : "No characters currently have configured voices; use text turns unless a command is needed.",
@@ -1111,7 +1160,9 @@ async function buildCallPrompt(input: {
   );
   const latestInputKind = input.userInputKind ?? "speech";
   const latestUserText =
-    latestInputKind === "system" ? input.userText : `${persona?.name || "User"} (${latestInputKind}): ${input.userText}`;
+    latestInputKind === "system"
+      ? input.userText
+      : `${persona?.name || "User"} (${latestInputKind}): ${input.userText}`;
   const latestUserContent = [latestUserText, outputFormat, commandInstructions].filter(Boolean).join("\n\n");
   const latestUserMessage: ChatMessage = {
     role: "user",
@@ -1437,10 +1488,7 @@ async function applyCallMusicCommand(input: {
   }
 }
 
-async function applyCallHapticCommand(input: {
-  metadata: Record<string, unknown>;
-  command: HapticCommand;
-}) {
+async function applyCallHapticCommand(input: { metadata: Record<string, unknown>; command: HapticCommand }) {
   if (input.metadata.enableHapticFeedback !== true) return;
   try {
     const { hapticService } = await import("../services/haptic/buttplug-service.js");
@@ -1476,7 +1524,8 @@ async function buildCallSelfiePrompt(input: {
 }) {
   const connections = createConnectionsStorage(input.app.db);
   const promptConnectionId =
-    typeof input.metadata.illustratorPromptConnectionId === "string" && input.metadata.illustratorPromptConnectionId.trim()
+    typeof input.metadata.illustratorPromptConnectionId === "string" &&
+    input.metadata.illustratorPromptConnectionId.trim()
       ? input.metadata.illustratorPromptConnectionId.trim()
       : input.chat.connectionId;
   const fallback = [
@@ -1564,7 +1613,10 @@ async function applyCallSelfieCommand(input: {
     typeof input.metadata.selfiePositivePrompt === "string"
       ? input.metadata.selfiePositivePrompt.trim()
       : Array.isArray(input.metadata.selfieTags)
-        ? input.metadata.selfieTags.filter((tag): tag is string => typeof tag === "string").join(", ").trim()
+        ? input.metadata.selfieTags
+            .filter((tag): tag is string => typeof tag === "string")
+            .join(", ")
+            .trim()
         : "";
   const negativePrompt =
     typeof input.metadata.selfieNegativePrompt === "string" ? input.metadata.selfieNegativePrompt.trim() : "";
@@ -1615,9 +1667,7 @@ async function applyCallSelfieCommand(input: {
   }
 
   const configuredStyleProfileId =
-    parseJsonRecord(input.metadata.gameSetupConfig).imageStyleProfileId ??
-    input.metadata.imageStyleProfileId ??
-    null;
+    parseJsonRecord(input.metadata.gameSetupConfig).imageStyleProfileId ?? input.metadata.imageStyleProfileId ?? null;
   const styleProfileId =
     typeof configuredStyleProfileId === "string" && configuredStyleProfileId.trim()
       ? configuredStyleProfileId.trim()
@@ -1843,7 +1893,11 @@ async function executeCallConversationCommand(input: {
         command: command as ReactCommand,
       });
     } else if (command.type === "spotify" || command.type === "youtube") {
-      await applyCallMusicCommand({ app: input.app, chat: freshChat, command: command as SpotifyCommand | YouTubeCommand });
+      await applyCallMusicCommand({
+        app: input.app,
+        chat: freshChat,
+        command: command as SpotifyCommand | YouTubeCommand,
+      });
     } else if (command.type === "haptic") {
       await applyCallHapticCommand({ metadata, command: command as HapticCommand });
     } else if (command.type === "influence") {
@@ -2008,10 +2062,9 @@ async function endConversationCallWithSummary(input: {
   if (input.session.status === "ended") return input.session;
   const chats = createChatsStorage(input.app.db);
   const calls = createConversationCallsStorage(input.app.db);
-  const summary = await summarizeCall(input);
   const startedAt = getSessionStartedAt(input.session);
   const durationMs = Date.now() - startedAt;
-  const ended = await calls.updateStatus(input.session.id, "ended", { summary });
+  const ended = await calls.updateStatus(input.session.id, "ended");
   const duration = formatDuration(durationMs);
   await chats.createMessagesBatch(input.session.chatId, [
     {
@@ -2027,10 +2080,31 @@ async function endConversationCallWithSummary(input: {
           callId: input.session.id,
           status: "ended",
           durationMs,
-          summary,
+          summary: null,
         },
       },
     },
+  ]);
+  if (ended) {
+    void finalizeConversationCallSummary({ app: input.app, chat: input.chat, session: ended }).catch((error) => {
+      logger.warn(error, "[conversation-call] Background summary finalization failed for call %s", input.session.id);
+    });
+  }
+  return ended;
+}
+
+async function finalizeConversationCallSummary(input: {
+  app: FastifyInstance;
+  chat: NonNullable<ChatRow>;
+  session: ConversationCallSession;
+}) {
+  const calls = createConversationCallsStorage(input.app.db);
+  const existing = await calls.getSession(input.session.id);
+  if (!existing || existing.summary) return existing;
+  const chats = createChatsStorage(input.app.db);
+  const summary = await summarizeCall(input);
+  await calls.updateSummary(input.session.id, summary);
+  await chats.createMessagesBatch(input.session.chatId, [
     {
       role: "system",
       characterId: null,
@@ -2046,7 +2120,7 @@ async function endConversationCallWithSummary(input: {
       },
     },
   ]);
-  return ended;
+  return calls.getSession(input.session.id);
 }
 
 async function readTTSSettings(app: FastifyInstance): Promise<Record<string, unknown>> {
@@ -2147,19 +2221,14 @@ export async function conversationCallsRoutes(app: FastifyInstance) {
       return reply.status(403).send({ error: "Character video presence is not enabled for Conversation Calls." });
     }
     const data = parseCharacterData(character);
-    const videoConnection = await connections.getDefaultForVideoGeneration();
-    if (!videoConnection) {
-      return reply.status(400).send({ error: "No Default for Videos connection is configured." });
-    }
     const body = parseJsonRecord(req.body);
-    const requestedKind =
-      typeof body.clipKind === "string" ? body.clipKind : typeof body.kind === "string" ? body.kind : "";
+    let videoConnection: Awaited<ReturnType<typeof resolveRequestedVideoGenerationConnection>>;
     let clipKinds: ConversationCallCharacterVideoClipKind[] | null = null;
-    if (requestedKind) {
-      if (!CONVERSATION_CALL_CHARACTER_VIDEO_CLIP_KINDS.includes(requestedKind as ConversationCallCharacterVideoClipKind)) {
-        return reply.status(400).send({ error: "Invalid call video clip kind" });
-      }
-      clipKinds = [requestedKind as ConversationCallCharacterVideoClipKind];
+    try {
+      videoConnection = await resolveRequestedVideoGenerationConnection(connections, body);
+      clipKinds = parseCallVideoClipKinds(body);
+    } catch (error) {
+      return reply.status(400).send({ error: error instanceof Error ? error.message : "Invalid call clip request." });
     }
     const videoSettings = normalizeVideoGenerationUserSettings(
       await createAppSettingsStorage(app.db).get(VIDEO_GENERATION_SETTINGS_KEY),
@@ -2173,6 +2242,51 @@ export async function conversationCallsRoutes(app: FastifyInstance) {
       promptOverridesStorage: createPromptOverridesStorage(app.db),
       videoSettings,
       debugMode: body.debugMode === true,
+      includeAvatarReference: body.includeAvatarReference !== false,
+    });
+  });
+
+  app.get<{ Params: { personaId: string } }>("/persona-videos/:personaId", async (req, reply) => {
+    const persona = await characters.getPersona(req.params.personaId);
+    if (!persona) return reply.status(404).send({ error: "Persona not found" });
+    const personaName = typeof persona.name === "string" && persona.name.trim() ? persona.name.trim() : "Persona";
+    return getConversationCallCharacterVideoManifest({
+      characterId: req.params.personaId,
+      characterName: personaName,
+      avatarPath: persona.avatarPath ?? null,
+    });
+  });
+
+  app.post<{ Params: { personaId: string } }>("/persona-videos/:personaId/generate", async (req, reply) => {
+    const persona = await characters.getPersona(req.params.personaId);
+    if (!persona) return reply.status(404).send({ error: "Persona not found" });
+    const ttsSettings = await readTTSSettings(app);
+    if (ttsSettings.callCharacterVideoEnabled !== true) {
+      return reply.status(403).send({ error: "Character video presence is not enabled for Conversation Calls." });
+    }
+    const body = parseJsonRecord(req.body);
+    let videoConnection: Awaited<ReturnType<typeof resolveRequestedVideoGenerationConnection>>;
+    let clipKinds: ConversationCallCharacterVideoClipKind[] | null = null;
+    try {
+      videoConnection = await resolveRequestedVideoGenerationConnection(connections, body);
+      clipKinds = parseCallVideoClipKinds(body);
+    } catch (error) {
+      return reply.status(400).send({ error: error instanceof Error ? error.message : "Invalid call clip request." });
+    }
+    const videoSettings = normalizeVideoGenerationUserSettings(
+      await createAppSettingsStorage(app.db).get(VIDEO_GENERATION_SETTINGS_KEY),
+    );
+    const personaName = typeof persona.name === "string" && persona.name.trim() ? persona.name.trim() : "Persona";
+    return startConversationCallCharacterVideoGeneration({
+      characterId: req.params.personaId,
+      characterName: personaName,
+      avatarPath: persona.avatarPath ?? null,
+      clipKinds,
+      connection: videoConnection,
+      promptOverridesStorage: createPromptOverridesStorage(app.db),
+      videoSettings,
+      debugMode: body.debugMode === true,
+      includeAvatarReference: body.includeAvatarReference !== false,
     });
   });
 

--- a/packages/server/src/routes/conversation-calls.routes.ts
+++ b/packages/server/src/routes/conversation-calls.routes.ts
@@ -410,6 +410,8 @@ const CALL_COMMAND_ALIASES = new Map<string, string>([
   ["video_clip", "custom_clip"],
   ["generate", "custom_clip"],
   ["generate_clip", "custom_clip"],
+  ["play_clip", "play_clip"],
+  ["clip", "play_clip"],
   ["react", "react"],
   ["reaction", "react"],
 ]);
@@ -445,6 +447,16 @@ function getCommandStringParam(value: string | null | undefined, name: string) {
   const singleQuoted = new RegExp(`${escapedName}\\s*=\\s*'([^']+)'`, "i").exec(trimmed);
   if (singleQuoted?.[1]) return singleQuoted[1].trim();
   const bare = new RegExp(`${escapedName}\\s*=\\s*([^\\]\\s,]+)`, "i").exec(trimmed);
+  return bare?.[1]?.trim() ?? "";
+}
+
+function getCommandRootStringValue(value: string | null | undefined) {
+  const trimmed = value?.trim() ?? "";
+  const quoted = /^\[[a-z0-9_-]+\s*=\s*"([^"]+)"/i.exec(trimmed);
+  if (quoted?.[1]) return quoted[1].trim();
+  const singleQuoted = /^\[[a-z0-9_-]+\s*=\s*'([^']+)'/i.exec(trimmed);
+  if (singleQuoted?.[1]) return singleQuoted[1].trim();
+  const bare = /^\[[a-z0-9_-]+\s*=\s*([^\]\s,]+)/i.exec(trimmed);
   return bare?.[1]?.trim() ?? "";
 }
 
@@ -663,11 +675,13 @@ function formatCallCommandPromptLines(
     memoryTargetNames: string[];
     hapticDeviceNames: string[];
     soundNames: string[];
+    customClipTargets: string[];
   },
 ) {
   const crossPostTargets = formatPromptOptionList(context.crossPostTargetNames, '"chat or character name"');
   const memoryTargets = formatPromptOptionList(context.memoryTargetNames, '"Name"');
   const soundTargets = formatPromptOptionList(context.soundNames, '"Sound name"');
+  const customClipTargets = context.customClipTargets.length > 0 ? context.customClipTargets.join("; ") : "none";
   const hapticDevices =
     context.hapticDeviceNames.length > 0 ? context.hapticDeviceNames.join(", ") : "connected devices";
   switch (command) {
@@ -724,6 +738,10 @@ function formatCallCommandPromptLines(
         '- [custom_clip: label="short title", prompt="visual action or look"] - generate one custom video-call clip for the speaking character and save it to their call-video clip gallery. Use only when the user explicitly asks to see a special visual action, outfit, reveal, or look that standard idle/talking/laughing/angry/crying/sighing clips cannot show.',
         "   The prompt value is the exact visual action for the video prompt; keep it short, concrete, and focused on what the character does before returning to their starting pose.",
         "   Use this sparsely: do not create custom clips for ordinary moods, normal dialogue, or every response. Emit at most one [custom_clip] for a direct user request, and do not repeat it unless the user asks for another distinct clip.",
+      ];
+    case "play_clip":
+      return [
+        `- [play_clip="Clip name"] - play one existing custom video-call clip for the speaking character after their normal voice/text response. Available clips by character: ${customClipTargets}. Use only the clip name for your own character, for example [play_clip="Kissing"].`,
       ];
     case "end_call":
       return [
@@ -943,12 +961,35 @@ async function buildCallPrompt(input: {
   const crossPostTargetNames: string[] = [];
   const memoryTargetNames = new Set(characters.map((character) => character.name));
   const hapticDeviceNames: string[] = [];
+  const playableCustomClipTargets: string[] = [];
   const customVideoClipConnection =
     characterVideoPresenceEnabled && ttsSettings.callCustomVideoClipsEnabled === true
       ? await createConnectionsStorage(input.app.db)
           .getDefaultForVideoGeneration()
           .catch(() => null)
       : null;
+  if (characterVideoPresenceEnabled) {
+    const manifests = await Promise.all(
+      characters.map((character) =>
+        getConversationCallCharacterVideoManifest({
+          characterId: character.id,
+          characterName: character.name,
+          avatarPath: character.avatarPath ?? null,
+        }).catch((error) => {
+          logger.debug(error, "[conversation-call] Could not read call video clips for %s", character.id);
+          return null;
+        }),
+      ),
+    );
+    manifests.forEach((manifest, index) => {
+      if (!manifest) return;
+      const characterName = characters[index]?.name ?? manifest.characterName;
+      const readyClips = manifest.customClips
+        .filter((clip) => clip.status === "ready" && clip.url && clip.label.trim())
+        .map((clip) => clip.label.trim());
+      if (readyClips.length > 0) playableCustomClipTargets.push(`${characterName}: ${readyClips.join(", ")}`);
+    });
+  }
   if (metadata.characterCommands !== false) {
     const schedules = getEnabledConversationSchedules(metadata) as Record<string, WeekSchedule>;
     const allChatsForCrossPost = await chats.list();
@@ -1016,16 +1057,14 @@ async function buildCallPrompt(input: {
     }
     if (hapticAvailable) allowedCommands.push("haptic");
     if (customVideoClipConnection) allowedCommands.push("custom_clip");
+    if (playableCustomClipTargets.length > 0) allowedCommands.push("play_clip");
     if (commandToggles.influence !== false && input.chat.connectedChatId) allowedCommands.push("influence");
     if (commandToggles.note !== false && input.chat.connectedChatId) allowedCommands.push("note");
   }
   if (!allowedCommands.includes("end_call")) allowedCommands.push("end_call");
   if (!allowedCommands.includes("leave_call")) allowedCommands.push("leave_call");
-  const soundNames =
-    ttsSettings.callSoundboardEnabled !== false
-      ? (await createConversationCallsStorage(input.app.db).listSounds()).map((sound) => sound.name)
-      : [];
-  if (ttsSettings.callSoundboardEnabled !== false) allowedCommands.push("soundboard");
+  const soundNames = (await createConversationCallsStorage(input.app.db).listSounds()).map((sound) => sound.name);
+  allowedCommands.push("soundboard");
   const commandPromptLines = allowedCommands.flatMap((command) =>
     formatCallCommandPromptLines(command, {
       personaName: persona?.name || "User",
@@ -1033,6 +1072,7 @@ async function buildCallPrompt(input: {
       memoryTargetNames: [...memoryTargetNames],
       hapticDeviceNames,
       soundNames,
+      customClipTargets: playableCustomClipTargets,
     }),
   );
   const activeEntries = await lorebooks.listActiveEntries({
@@ -1741,7 +1781,8 @@ function readCustomClipPrompt(commandText: string) {
     getCommandStringParam(commandText, "clip") ||
     getCommandStringParam(commandText, "action") ||
     getCommandStringParam(commandText, "description") ||
-    getCommandStringParam(commandText, "context")
+    getCommandStringParam(commandText, "context") ||
+    getCommandRootStringValue(commandText)
   )
     .replace(/\s+/g, " ")
     .trim();
@@ -1819,7 +1860,14 @@ async function executeCallConversationCommand(input: {
   sourceContent?: string | null;
 }): Promise<ConversationCallMessage[]> {
   const commandName = getBracketCommandName(input.commandText);
-  if (commandName === "end_call" || commandName === "leave_call" || commandName === "soundboard") return [];
+  if (
+    commandName === "end_call" ||
+    commandName === "leave_call" ||
+    commandName === "soundboard" ||
+    commandName === "play_clip"
+  ) {
+    return [];
+  }
   if (commandName === "custom_clip") {
     const chats = createChatsStorage(input.app.db);
     const chars = createCharactersStorage(input.app.db);
@@ -2246,6 +2294,46 @@ export async function conversationCallsRoutes(app: FastifyInstance) {
     });
   });
 
+  app.post<{ Params: { characterId: string } }>(
+    "/character-videos/:characterId/custom/generate",
+    async (req, reply) => {
+      const character = await characters.getById(req.params.characterId);
+      if (!character) return reply.status(404).send({ error: "Character not found" });
+      const ttsSettings = await readTTSSettings(app);
+      if (ttsSettings.callCharacterVideoEnabled !== true) {
+        return reply.status(403).send({ error: "Character video presence is not enabled for Conversation Calls." });
+      }
+      const data = parseCharacterData(character);
+      const body = parseJsonRecord(req.body);
+      const label = typeof body.label === "string" ? body.label.trim() : "";
+      const prompt = typeof body.prompt === "string" ? body.prompt.trim() : "";
+      if (!label || !prompt) {
+        return reply.status(400).send({ error: "Custom clips need a name and action." });
+      }
+      let videoConnection: Awaited<ReturnType<typeof resolveRequestedVideoGenerationConnection>>;
+      try {
+        videoConnection = await resolveRequestedVideoGenerationConnection(connections, body);
+      } catch (error) {
+        return reply.status(400).send({ error: error instanceof Error ? error.message : "Invalid call clip request." });
+      }
+      const videoSettings = normalizeVideoGenerationUserSettings(
+        await createAppSettingsStorage(app.db).get(VIDEO_GENERATION_SETTINGS_KEY),
+      );
+      return startConversationCallCustomVideoClipGeneration({
+        characterId: character.id,
+        characterName: readName(data, "Character"),
+        avatarPath: character.avatarPath ?? null,
+        connection: videoConnection,
+        promptOverridesStorage: createPromptOverridesStorage(app.db),
+        videoSettings,
+        label,
+        prompt,
+        debugMode: body.debugMode === true,
+        includeAvatarReference: body.includeAvatarReference !== false,
+      });
+    },
+  );
+
   app.get<{ Params: { personaId: string } }>("/persona-videos/:personaId", async (req, reply) => {
     const persona = await characters.getPersona(req.params.personaId);
     if (!persona) return reply.status(404).send({ error: "Persona not found" });
@@ -2285,6 +2373,43 @@ export async function conversationCallsRoutes(app: FastifyInstance) {
       connection: videoConnection,
       promptOverridesStorage: createPromptOverridesStorage(app.db),
       videoSettings,
+      debugMode: body.debugMode === true,
+      includeAvatarReference: body.includeAvatarReference !== false,
+    });
+  });
+
+  app.post<{ Params: { personaId: string } }>("/persona-videos/:personaId/custom/generate", async (req, reply) => {
+    const persona = await characters.getPersona(req.params.personaId);
+    if (!persona) return reply.status(404).send({ error: "Persona not found" });
+    const ttsSettings = await readTTSSettings(app);
+    if (ttsSettings.callCharacterVideoEnabled !== true) {
+      return reply.status(403).send({ error: "Character video presence is not enabled for Conversation Calls." });
+    }
+    const body = parseJsonRecord(req.body);
+    const label = typeof body.label === "string" ? body.label.trim() : "";
+    const prompt = typeof body.prompt === "string" ? body.prompt.trim() : "";
+    if (!label || !prompt) {
+      return reply.status(400).send({ error: "Custom clips need a name and action." });
+    }
+    let videoConnection: Awaited<ReturnType<typeof resolveRequestedVideoGenerationConnection>>;
+    try {
+      videoConnection = await resolveRequestedVideoGenerationConnection(connections, body);
+    } catch (error) {
+      return reply.status(400).send({ error: error instanceof Error ? error.message : "Invalid call clip request." });
+    }
+    const videoSettings = normalizeVideoGenerationUserSettings(
+      await createAppSettingsStorage(app.db).get(VIDEO_GENERATION_SETTINGS_KEY),
+    );
+    const personaName = typeof persona.name === "string" && persona.name.trim() ? persona.name.trim() : "Persona";
+    return startConversationCallCustomVideoClipGeneration({
+      characterId: req.params.personaId,
+      characterName: personaName,
+      avatarPath: persona.avatarPath ?? null,
+      connection: videoConnection,
+      promptOverridesStorage: createPromptOverridesStorage(app.db),
+      videoSettings,
+      label,
+      prompt,
       debugMode: body.debugMode === true,
       includeAvatarReference: body.includeAvatarReference !== false,
     });

--- a/packages/server/src/routes/gallery.routes.ts
+++ b/packages/server/src/routes/gallery.routes.ts
@@ -817,6 +817,7 @@ export async function galleryRoutes(app: FastifyInstance) {
     const promptDraft = await loadGameVideoPrompt({
       promptOverridesStorage,
       meta,
+      debugMode: requestDebug,
       ctx: {
         sceneTitle: compactVideoPromptText(sceneTitleFromGalleryImage(galleryImage), promptLimits.title),
         narrationSummary: latestNarrationSummary(messages, promptLimits.narrationSummary),

--- a/packages/server/src/routes/game.routes.ts
+++ b/packages/server/src/routes/game.routes.ts
@@ -1246,6 +1246,7 @@ async function buildStoryboardGalleryAnimatePrompt(args: {
   meta: Record<string, unknown>;
   artStyle: string;
   promptLimits: SceneVideoPromptLimits;
+  debugMode?: boolean;
 }): Promise<string> {
   const sourceDescription = `storyboard keyframe ${args.frameIndex + 1} (${args.galleryImage.id})`;
   const narrationSummary =
@@ -1259,6 +1260,7 @@ async function buildStoryboardGalleryAnimatePrompt(args: {
   const promptDraft = await loadGameVideoPrompt({
     promptOverridesStorage: args.promptOverridesStorage,
     meta: args.meta,
+    debugMode: args.debugMode,
     ctx: {
       sceneTitle: compactVideoPromptText(
         args.plannedFrame.title || sceneTitleFromGalleryImage(args.galleryImage),
@@ -9964,6 +9966,7 @@ export async function gameRoutes(app: FastifyInstance) {
                 meta,
                 artStyle,
                 promptLimits: videoRuntime.promptLimits,
+                debugMode: requestDebug,
               });
               await storyboards.updateKeyframe(frame.id, { videoPrompt: prompt });
               if (debugLogsEnabled) {
@@ -10317,6 +10320,7 @@ export async function gameRoutes(app: FastifyInstance) {
     const promptDraft = await loadGameVideoPrompt({
       promptOverridesStorage,
       meta,
+      debugMode: requestDebug,
       ctx: {
         sceneTitle: compactVideoPromptText(sourceTitle, promptLimits.title),
         narrationSummary: latestNarrationSummary(messages, promptLimits.narrationSummary),

--- a/packages/server/src/routes/game.routes.ts
+++ b/packages/server/src/routes/game.routes.ts
@@ -9594,7 +9594,7 @@ export async function gameRoutes(app: FastifyInstance) {
       const sourceSections = normalizeStoryboardSections(input.sections, sourceNarration);
 
       const meta = parseMeta(chat.metadata);
-      const generateStoryboardVideos = input.generateVideos ?? (meta.gameStoryboardAutoGenerationEnabled === true);
+      const generateStoryboardVideos = input.generateVideos ?? meta.gameStoryboardAutoGenerationEnabled === true;
       const enableGen = !!meta.enableSpriteGeneration;
       const imgConnId = await resolveGameImageConnectionId(meta, agents);
       if (!enableGen || !imgConnId) {
@@ -9804,9 +9804,11 @@ export async function gameRoutes(app: FastifyInstance) {
             (videoDefaults.service !== "gemini_omni"
               ? videoDefaults.service
               : inferVideoSource(videoConn.model || "", videoConn.baseUrl || ""));
+          const rawServiceHint = videoConn.videoService || source;
           const serviceHint =
-            videoConn.videoService ||
-            (source === "google_ai_studio" ? inferVideoSource(videoConn.model || "", videoConn.baseUrl || "") : source);
+            rawServiceHint === "google_ai_studio"
+              ? inferVideoSource(videoConn.model || "", videoConn.baseUrl || "")
+              : rawServiceHint;
           const isXaiVideo = source === "xai" || serviceHint === "xai";
           const isGoogleVeoVideo = source === "google_veo" || serviceHint === "google_veo";
           const isOpenRouterVideo = source === "openrouter" || serviceHint === "openrouter";
@@ -9823,9 +9825,9 @@ export async function gameRoutes(app: FastifyInstance) {
                   ? DEFAULT_GOOGLE_VEO_BASE_URL
                   : isOpenRouterVideo
                     ? DEFAULT_OPENROUTER_VIDEO_BASE_URL
-                  : isSeedanceVideo
-                    ? DEFAULT_SEEDANCE_VIDEO_BASE_URL
-                    : DEFAULT_GEMINI_OMNI_BASE_URL),
+                    : isSeedanceVideo
+                      ? DEFAULT_SEEDANCE_VIDEO_BASE_URL
+                      : DEFAULT_GEMINI_OMNI_BASE_URL),
             apiKey: videoConn.apiKey || "",
             model:
               videoConn.model ||
@@ -9835,18 +9837,18 @@ export async function gameRoutes(app: FastifyInstance) {
                   ? DEFAULT_GOOGLE_VEO_MODEL
                   : isOpenRouterVideo
                     ? DEFAULT_OPENROUTER_VIDEO_MODEL
-                  : isSeedanceVideo
-                    ? DEFAULT_SEEDANCE_VIDEO_MODEL
-                    : DEFAULT_GEMINI_OMNI_MODEL),
+                    : isSeedanceVideo
+                      ? DEFAULT_SEEDANCE_VIDEO_MODEL
+                      : DEFAULT_GEMINI_OMNI_MODEL),
             resolution: isXaiVideo
               ? videoDefaults.xai.resolution
               : isGoogleVeoVideo
                 ? videoDefaults.googleVeo.resolution
                 : isOpenRouterVideo
-                ? videoDefaults.openrouter.resolution
-                : isSeedanceVideo
-                ? videoDefaults.seedance.resolution
-                : undefined,
+                  ? videoDefaults.openrouter.resolution
+                  : isSeedanceVideo
+                    ? videoDefaults.seedance.resolution
+                    : undefined,
             maxDurationSeconds: isXaiVideo || isSeedanceVideo ? 15 : isGoogleVeoVideo ? 8 : 60,
             promptLimits,
             publicReferenceUpload: resolveVideoReferencePublicUploadOptions(isSeedanceVideo, videoDefaults.seedance),
@@ -10235,9 +10237,11 @@ export async function gameRoutes(app: FastifyInstance) {
       (videoDefaults.service !== "gemini_omni"
         ? videoDefaults.service
         : inferVideoSource(videoConn.model || "", videoConn.baseUrl || ""));
+    const rawServiceHint = videoConn.videoService || source;
     const serviceHint =
-      videoConn.videoService ||
-      (source === "google_ai_studio" ? inferVideoSource(videoConn.model || "", videoConn.baseUrl || "") : source);
+      rawServiceHint === "google_ai_studio"
+        ? inferVideoSource(videoConn.model || "", videoConn.baseUrl || "")
+        : rawServiceHint;
     const isXaiVideo = source === "xai" || serviceHint === "xai";
     const isGoogleVeoVideo = source === "google_veo" || serviceHint === "google_veo";
     const isOpenRouterVideo = source === "openrouter" || serviceHint === "openrouter";
@@ -10248,9 +10252,9 @@ export async function gameRoutes(app: FastifyInstance) {
         ? videoDefaults.googleVeo
         : isOpenRouterVideo
           ? videoDefaults.openrouter
-        : isSeedanceVideo
-          ? videoDefaults.seedance
-          : videoDefaults.geminiOmni;
+          : isSeedanceVideo
+            ? videoDefaults.seedance
+            : videoDefaults.geminiOmni;
     const videoSettings = normalizeVideoGenerationUserSettings(
       await createAppSettingsStorage(app.db).get(VIDEO_GENERATION_SETTINGS_KEY),
     );
@@ -10272,9 +10276,9 @@ export async function gameRoutes(app: FastifyInstance) {
           ? DEFAULT_GOOGLE_VEO_BASE_URL
           : isOpenRouterVideo
             ? DEFAULT_OPENROUTER_VIDEO_BASE_URL
-          : isSeedanceVideo
-            ? DEFAULT_SEEDANCE_VIDEO_BASE_URL
-            : DEFAULT_GEMINI_OMNI_BASE_URL);
+            : isSeedanceVideo
+              ? DEFAULT_SEEDANCE_VIDEO_BASE_URL
+              : DEFAULT_GEMINI_OMNI_BASE_URL);
     const model =
       videoConn.model ||
       (isXaiVideo
@@ -10283,18 +10287,18 @@ export async function gameRoutes(app: FastifyInstance) {
           ? DEFAULT_GOOGLE_VEO_MODEL
           : isOpenRouterVideo
             ? DEFAULT_OPENROUTER_VIDEO_MODEL
-          : isSeedanceVideo
-            ? DEFAULT_SEEDANCE_VIDEO_MODEL
-            : DEFAULT_GEMINI_OMNI_MODEL);
+            : isSeedanceVideo
+              ? DEFAULT_SEEDANCE_VIDEO_MODEL
+              : DEFAULT_GEMINI_OMNI_MODEL);
     const resolution = isXaiVideo
       ? videoDefaults.xai.resolution
       : isGoogleVeoVideo
         ? videoDefaults.googleVeo.resolution
         : isOpenRouterVideo
           ? videoDefaults.openrouter.resolution
-        : isSeedanceVideo
-          ? videoDefaults.seedance.resolution
-          : undefined;
+          : isSeedanceVideo
+            ? videoDefaults.seedance.resolution
+            : undefined;
     const promptLimits = getSceneVideoPromptLimits(isXaiVideo);
 
     const latestState = await createGameStateStorage(app.db)

--- a/packages/server/src/services/agents/default-prompt-migration.ts
+++ b/packages/server/src/services/agents/default-prompt-migration.ts
@@ -103,7 +103,8 @@ function migratePromptTemplateOptions(agentType: string, settings: unknown) {
 
 export function buildLegacyDefaultAgentConfigUpdate(row: typeof agentConfigs.$inferSelect) {
   const update: Partial<typeof agentConfigs.$inferInsert> = {};
-  if (isKnownDefaultPrompt(row.type, row.promptTemplate)) {
+  const hasKnownDefaultPrompt = isKnownDefaultPrompt(row.type, row.promptTemplate);
+  if (hasKnownDefaultPrompt) {
     update.promptTemplate = "";
   }
 
@@ -112,12 +113,16 @@ export function buildLegacyDefaultAgentConfigUpdate(row: typeof agentConfigs.$in
 
   const builtIn = BUILT_IN_AGENTS.find((agent) => agent.id === row.type);
   if (builtIn) {
-    if (isKnownDefaultDescription(row.type, row.description, builtIn.description)) {
+    const hasKnownDefaultDescription = isKnownDefaultDescription(row.type, row.description, builtIn.description);
+    if (hasKnownDefaultDescription) {
       update.description = builtIn.description;
     }
 
     const normalizedStoredPhase = normalizeAgentPhaseForType(row.type, row.phase);
     if (row.phase !== normalizedStoredPhase) update.phase = normalizedStoredPhase;
+    if (row.type === "html" && hasKnownDefaultPrompt && hasKnownDefaultDescription && row.phase !== builtIn.phase) {
+      update.phase = builtIn.phase;
+    }
 
     const defaults = getDefaultBuiltInAgentSettings(builtIn.id);
     let settingsChanged = settingsMigration.changed;

--- a/packages/server/src/services/conversation/call-character-videos.service.ts
+++ b/packages/server/src/services/conversation/call-character-videos.service.ts
@@ -633,6 +633,7 @@ async function buildCustomClipPrompt(input: {
   label: string;
   prompt: string;
   durationSeconds: number;
+  usesAvatarReference: boolean;
 }) {
   return loadPrompt(input.promptOverridesStorage, CONVERSATION_CALL_CUSTOM_VIDEO_PROMPT, {
     characterName: input.characterName,
@@ -640,6 +641,9 @@ async function buildCustomClipPrompt(input: {
     customPrompt: input.prompt,
     durationSeconds: input.durationSeconds,
     aspectRatio: "16:9",
+    referenceInstruction: input.usesAvatarReference
+      ? "Reference: use the attached 16:9 image as the character identity, crop, and first/final frame target."
+      : "No reference image is attached. Generate from the custom action and keep identity, framing, and styling consistent.",
   });
 }
 
@@ -893,16 +897,19 @@ async function runCustomClipGenerationJob(input: {
   label: string;
   prompt: string;
   debugMode?: boolean;
+  includeAvatarReference?: boolean;
 }) {
   const startedAt = nowIso();
   try {
-    const reference = await readAvatarReferenceImage(input.avatarPath);
+    const avatar = await readAvatarIdentity(input.avatarPath);
+    const reference = input.includeAvatarReference === false ? null : await readAvatarReferenceImage(input.avatarPath);
+    const clipAvatar = reference?.identity ?? avatar;
     const resolved = resolveVideoConnection(input.connection);
     const requestedDurationSeconds = input.videoSettings.callCustomClipDurationSeconds;
     const durationSeconds = resolveVideoRequestDuration(resolved.source, resolved.serviceHint, {
       durationSeconds: requestedDurationSeconds,
       resolution: resolved.resolution,
-      referenceImage: reference.image,
+      referenceImage: reference?.image,
     });
     const prompt = await buildCustomClipPrompt({
       promptOverridesStorage: input.promptOverridesStorage,
@@ -910,6 +917,7 @@ async function runCustomClipGenerationJob(input: {
       label: input.label,
       prompt: input.prompt,
       durationSeconds,
+      usesAvatarReference: reference !== null,
     });
     if (input.debugMode) {
       logDebugOverride(
@@ -931,8 +939,7 @@ async function runCustomClipGenerationJob(input: {
         durationSeconds,
         aspectRatio: "16:9",
         resolution: resolved.resolution,
-        referenceImage: reference.image,
-        lastFrameImage: reference.image,
+        ...(reference ? { referenceImage: reference.image, lastFrameImage: reference.image } : {}),
         publicReferenceUpload: resolved.publicReferenceUpload,
       },
     );
@@ -950,7 +957,7 @@ async function runCustomClipGenerationJob(input: {
           ...latest,
           characterName: input.characterName,
           sourceAvatarPath: input.avatarPath,
-          sourceAvatarDigest: reference.identity.digest,
+          sourceAvatarDigest: clipAvatar.digest,
           updatedAt,
           customClips: {
             ...latest.customClips,
@@ -966,7 +973,7 @@ async function runCustomClipGenerationJob(input: {
               updatedAt,
               origin: "generated",
               sourceAvatarPath: input.avatarPath,
-              sourceAvatarDigest: reference.identity.digest,
+              sourceAvatarDigest: clipAvatar.digest,
               trimStartSeconds: null,
               trimEndSeconds: null,
             },
@@ -1093,6 +1100,7 @@ export async function startConversationCallCustomVideoClipGeneration(input: {
   label?: string | null;
   prompt: string;
   debugMode?: boolean;
+  includeAvatarReference?: boolean;
 }): Promise<ConversationCallCharacterVideoManifest> {
   assertSafeCharacterId(input.characterId);
   const videoSettings = normalizeVideoGenerationUserSettings(input.videoSettings);

--- a/packages/server/src/services/conversation/call-character-videos.service.ts
+++ b/packages/server/src/services/conversation/call-character-videos.service.ts
@@ -173,7 +173,13 @@ function nowIso() {
 }
 
 function assertSafeCharacterId(characterId: string) {
-  if (!characterId || characterId.includes("..") || characterId.includes("/") || characterId.includes("\\") || characterId.includes("\0")) {
+  if (
+    !characterId ||
+    characterId.includes("..") ||
+    characterId.includes("/") ||
+    characterId.includes("\\") ||
+    characterId.includes("\0")
+  ) {
     throw new Error("Invalid character id");
   }
   return characterId;
@@ -185,7 +191,10 @@ function assertSafeCustomClipId(clipId: string) {
 }
 
 function characterDir(characterId: string) {
-  return assertInsideDir(CALL_CHARACTER_VIDEO_ROOT, join(CALL_CHARACTER_VIDEO_ROOT, assertSafeCharacterId(characterId)));
+  return assertInsideDir(
+    CALL_CHARACTER_VIDEO_ROOT,
+    join(CALL_CHARACTER_VIDEO_ROOT, assertSafeCharacterId(characterId)),
+  );
 }
 
 function manifestPath(characterId: string) {
@@ -202,7 +211,10 @@ function clipUrl(characterId: string, kind: ConversationCallCharacterVideoClipKi
 }
 
 function customClipPath(characterId: string, clipId: string) {
-  return assertInsideDir(CALL_CHARACTER_VIDEO_ROOT, join(characterDir(characterId), `${assertSafeCustomClipId(clipId)}.mp4`));
+  return assertInsideDir(
+    CALL_CHARACTER_VIDEO_ROOT,
+    join(characterDir(characterId), `${assertSafeCustomClipId(clipId)}.mp4`),
+  );
 }
 
 function customClipUrl(characterId: string, clipId: string) {
@@ -345,10 +357,7 @@ function isMp4Buffer(buffer: Buffer): boolean {
   return buffer.length >= 12 && buffer.subarray(4, 8).toString("ascii") === "ftyp";
 }
 
-function normalizeClipTrim(input: {
-  trimStartSeconds?: unknown;
-  trimEndSeconds?: unknown;
-}): {
+function normalizeClipTrim(input: { trimStartSeconds?: unknown; trimEndSeconds?: unknown }): {
   trimStartSeconds: number | null;
   trimEndSeconds: number | null;
 } {
@@ -400,20 +409,28 @@ function toPublicManifest(
     const activeClipGenerating = activeGeneration?.clipKinds.has(kind) === true;
     const fileExists = existsSync(clipPath(manifest.characterId, kind));
     const diskReady = disk.status === "ready" || !disk.status;
-    const status = fileExists && avatarMatches && diskReady
-      ? "ready"
-      : avatarMatches && disk.status === "generating" && activeClipGenerating
-        ? "generating"
-        : avatarMatches && disk.status === "error"
-          ? "error"
-          : "missing";
+    const status =
+      fileExists && avatarMatches && diskReady
+        ? "ready"
+        : avatarMatches && disk.status === "generating" && activeClipGenerating
+          ? "generating"
+          : avatarMatches && disk.status === "error"
+            ? "error"
+            : "missing";
     return {
       kind,
       status,
       url: status === "ready" ? clipUrl(manifest.characterId, kind, clipUrlVersion(disk, clipAvatar)) : null,
       error: status === "error" ? (disk.error ?? "Video generation failed") : null,
       updatedAt: disk.updatedAt ?? null,
-      origin: status === "missing" ? undefined : disk.origin === "uploaded" ? "uploaded" : disk.updatedAt ? "generated" : undefined,
+      origin:
+        status === "missing"
+          ? undefined
+          : disk.origin === "uploaded"
+            ? "uploaded"
+            : disk.updatedAt
+              ? "generated"
+              : undefined,
       trimStartSeconds: readTrimSecond(disk.trimStartSeconds),
       trimEndSeconds: readTrimSecond(disk.trimEndSeconds),
     };
@@ -559,17 +576,28 @@ async function buildClipPrompt(input: {
   characterName: string;
   kind: ConversationCallCharacterVideoClipKind;
   durationSeconds: number;
+  usesAvatarReference: boolean;
 }) {
   const def = CONVERSATION_CALL_VIDEO_PROMPT_BY_KIND.get(input.kind);
   if (!def) {
+    const referenceLines = input.usesAvatarReference
+      ? [
+          "Reference: use the attached 16:9 image as the character identity, crop, and first/final frame target.",
+          "Preserve the reference image's crop, especially the top/head framing. If any framing must be lost, crop lower body or lower clothing instead of hair, head, mask, or face.",
+          "Preserve the reference image's background, lighting, colors, face shape, hair, clothing, mask or eyewear, accessories, and art style.",
+        ]
+      : [
+          "No reference image is attached. Generate a clean 16:9 animated portrait loop from the prompt alone.",
+          "Keep the character design consistent for the whole clip, with no outfit, accessory, face, hair, or background changes.",
+        ];
     return [
       `Create a ${input.durationSeconds}-second 16:9 animated portrait loop for an AI video call.`,
-      "Reference: use the attached 16:9 image as the character identity, crop, and first/final frame target.",
-      "Preserve the reference image's crop, especially the top/head framing. If any framing must be lost, crop lower body or lower clothing instead of hair, head, mask, or face.",
-      "Preserve the reference image's background, lighting, colors, face shape, hair, clothing, mask or eyewear, accessories, and art style.",
+      ...referenceLines,
       `Action: ${getClipInstruction(input.kind)}`,
       "Motion quality: one smooth, restrained, video-call-like motion throughout the clip.",
-      "Lighting and background: keep them from the reference image; do not invent a new ambience or setting.",
+      input.usesAvatarReference
+        ? "Lighting and background: keep them from the reference image; do not invent a new ambience or setting."
+        : "Lighting and background: keep them stable and simple; do not change the setting mid-clip.",
       "Camera: locked-off still camera, no zoom, pan, tilt, dolly, crop change, reframing, handheld shake, or scene cut.",
       "Looping: return to the first-frame pose by the final frame for a seamless loop.",
       "Focus: single character only, no captions, subtitles, UI, logos, extra people, new clothing, or new facial features.",
@@ -583,6 +611,9 @@ async function buildClipPrompt(input: {
     clipInstruction: getClipInstruction(input.kind),
     durationSeconds: input.durationSeconds,
     aspectRatio: "16:9",
+    referenceInstruction: input.usesAvatarReference
+      ? "Use the attached image as the character identity, crop, and first/final frame target."
+      : "No reference image is attached. Generate from the prompt alone and keep identity, framing, and styling consistent.",
   });
 }
 
@@ -633,31 +664,31 @@ function resolveVideoConnection(connection: VideoGenerationConnection) {
         ? DEFAULT_XAI_VIDEO_BASE_URL
         : isGoogleVeoVideo
           ? DEFAULT_GOOGLE_VEO_BASE_URL
-        : isOpenRouterVideo
-          ? DEFAULT_OPENROUTER_VIDEO_BASE_URL
-        : isSeedanceVideo
-          ? DEFAULT_SEEDANCE_VIDEO_BASE_URL
-          : DEFAULT_GEMINI_OMNI_BASE_URL),
+          : isOpenRouterVideo
+            ? DEFAULT_OPENROUTER_VIDEO_BASE_URL
+            : isSeedanceVideo
+              ? DEFAULT_SEEDANCE_VIDEO_BASE_URL
+              : DEFAULT_GEMINI_OMNI_BASE_URL),
     model:
       connection.model ||
       (isXaiVideo
         ? DEFAULT_XAI_VIDEO_MODEL
         : isGoogleVeoVideo
           ? DEFAULT_GOOGLE_VEO_MODEL
-        : isOpenRouterVideo
-          ? DEFAULT_OPENROUTER_VIDEO_MODEL
-        : isSeedanceVideo
-          ? DEFAULT_SEEDANCE_VIDEO_MODEL
-          : DEFAULT_GEMINI_OMNI_MODEL),
+          : isOpenRouterVideo
+            ? DEFAULT_OPENROUTER_VIDEO_MODEL
+            : isSeedanceVideo
+              ? DEFAULT_SEEDANCE_VIDEO_MODEL
+              : DEFAULT_GEMINI_OMNI_MODEL),
     resolution: isXaiVideo
       ? videoDefaults.xai.resolution
       : isGoogleVeoVideo
         ? videoDefaults.googleVeo.resolution
-      : isOpenRouterVideo
-        ? videoDefaults.openrouter.resolution
-      : isSeedanceVideo
-        ? videoDefaults.seedance.resolution
-        : undefined,
+        : isOpenRouterVideo
+          ? videoDefaults.openrouter.resolution
+          : isSeedanceVideo
+            ? videoDefaults.seedance.resolution
+            : undefined,
     publicReferenceUpload: resolveVideoReferencePublicUploadOptions(isSeedanceVideo, videoDefaults.seedance),
   };
 }
@@ -689,9 +720,12 @@ async function runGenerationJob(input: {
   promptOverridesStorage: PromptOverridesStorage;
   videoSettings: VideoGenerationUserSettings;
   debugMode?: boolean;
+  includeAvatarReference?: boolean;
 }) {
   const startedAt = nowIso();
-  const reference = await readAvatarReferenceImage(input.avatarPath);
+  const avatar = await readAvatarIdentity(input.avatarPath);
+  const reference = input.includeAvatarReference === false ? null : await readAvatarReferenceImage(input.avatarPath);
+  const clipAvatar = reference?.identity ?? avatar;
   const resolved = resolveVideoConnection(input.connection);
   logger.info(
     "[conversation-call/videos] Generating call videos for %s via connection=%s source=%s model=%s",
@@ -706,7 +740,7 @@ async function runGenerationJob(input: {
     const manifest = stampClipSourceAvatarPaths(
       await readDiskManifest(input.characterId, input.characterName, input.avatarPath),
     );
-    if (isClipReadyForAvatar(manifest, kind, reference.identity)) {
+    if (isClipReadyForAvatar(manifest, kind, clipAvatar)) {
       continue;
     }
     const queuedAt = nowIso();
@@ -718,7 +752,7 @@ async function runGenerationJob(input: {
         ...latest,
         characterName: input.characterName,
         sourceAvatarPath: input.avatarPath,
-        sourceAvatarDigest: reference.identity.digest,
+        sourceAvatarDigest: clipAvatar.digest,
         updatedAt: queuedAt,
         clips: {
           ...latest.clips,
@@ -728,7 +762,7 @@ async function runGenerationJob(input: {
             updatedAt: queuedAt,
             origin: "generated",
             sourceAvatarPath: input.avatarPath,
-            sourceAvatarDigest: reference.identity.digest,
+            sourceAvatarDigest: clipAvatar.digest,
             trimStartSeconds: null,
             trimEndSeconds: null,
           },
@@ -739,17 +773,24 @@ async function runGenerationJob(input: {
     const durationSeconds = resolveVideoRequestDuration(resolved.source, resolved.serviceHint, {
       durationSeconds: requestedDurationSeconds,
       resolution: resolved.resolution,
-      referenceImage: reference.image,
+      referenceImage: reference?.image,
     });
     const prompt = await buildClipPrompt({
       promptOverridesStorage: input.promptOverridesStorage,
       characterName: input.characterName,
       kind,
       durationSeconds,
+      usesAvatarReference: reference !== null,
     });
     try {
       if (input.debugMode) {
-        logDebugOverride(true, "[debug/conversation-call/videos] %s prompt for %s:\n%s", kind, input.characterId, prompt);
+        logDebugOverride(
+          true,
+          "[debug/conversation-call/videos] %s prompt for %s:\n%s",
+          kind,
+          input.characterId,
+          prompt,
+        );
       }
       const generated = await generateVideo(
         resolved.source,
@@ -762,8 +803,7 @@ async function runGenerationJob(input: {
           durationSeconds,
           aspectRatio: "16:9",
           resolution: resolved.resolution,
-          referenceImage: reference.image,
-          lastFrameImage: reference.image,
+          ...(reference ? { referenceImage: reference.image, lastFrameImage: reference.image } : {}),
           publicReferenceUpload: resolved.publicReferenceUpload,
         },
       );
@@ -780,7 +820,7 @@ async function runGenerationJob(input: {
           ...latest,
           characterName: input.characterName,
           sourceAvatarPath: input.avatarPath,
-          sourceAvatarDigest: reference.identity.digest,
+          sourceAvatarDigest: clipAvatar.digest,
           updatedAt,
           clips: {
             ...latest.clips,
@@ -790,7 +830,7 @@ async function runGenerationJob(input: {
               updatedAt,
               origin: "generated",
               sourceAvatarPath: input.avatarPath,
-              sourceAvatarDigest: reference.identity.digest,
+              sourceAvatarDigest: clipAvatar.digest,
               trimStartSeconds: null,
               trimEndSeconds: null,
             },
@@ -809,7 +849,7 @@ async function runGenerationJob(input: {
           ...latest,
           characterName: input.characterName,
           sourceAvatarPath: input.avatarPath,
-          sourceAvatarDigest: reference.identity.digest,
+          sourceAvatarDigest: clipAvatar.digest,
           updatedAt,
           clips: {
             ...latest.clips,
@@ -819,7 +859,7 @@ async function runGenerationJob(input: {
               updatedAt,
               origin: "generated",
               sourceAvatarPath: input.avatarPath,
-              sourceAvatarDigest: reference.identity.digest,
+              sourceAvatarDigest: clipAvatar.digest,
               trimStartSeconds: null,
               trimEndSeconds: null,
             },
@@ -962,7 +1002,12 @@ async function runCustomClipGenerationJob(input: {
         },
       }),
     });
-    logger.warn(error, "[conversation-call/videos] Failed to generate custom clip %s for %s", input.clipId, input.characterId);
+    logger.warn(
+      error,
+      "[conversation-call/videos] Failed to generate custom clip %s for %s",
+      input.clipId,
+      input.characterId,
+    );
   }
 }
 
@@ -986,6 +1031,7 @@ export async function startConversationCallCharacterVideoGeneration(input: {
   promptOverridesStorage: PromptOverridesStorage;
   videoSettings?: VideoGenerationUserSettings | null;
   debugMode?: boolean;
+  includeAvatarReference?: boolean;
 }): Promise<ConversationCallCharacterVideoManifest> {
   assertSafeCharacterId(input.characterId);
   const videoSettings = normalizeVideoGenerationUserSettings(input.videoSettings);
@@ -1113,7 +1159,9 @@ export async function uploadConversationCallCharacterVideoClip(input: {
       throw new ConversationCallVideoClipUploadError("Invalid call video clip kind.");
     }
     if (GENERATION_LOCKS.has(input.characterId)) {
-      throw new ConversationCallVideoGenerationInProgressError("Call video clips are still generating for this character");
+      throw new ConversationCallVideoGenerationInProgressError(
+        "Call video clips are still generating for this character",
+      );
     }
 
     const file = clipPath(input.characterId, input.kind);
@@ -1321,7 +1369,9 @@ export async function deleteConversationCallCharacterVideoClip(input: {
     throw new Error("Invalid call video clip kind");
   }
   if (GENERATION_LOCKS.has(input.characterId)) {
-    throw new ConversationCallVideoGenerationInProgressError("Call video clips are still generating for this character");
+    throw new ConversationCallVideoGenerationInProgressError(
+      "Call video clips are still generating for this character",
+    );
   }
 
   const file = clipPath(input.characterId, input.kind);
@@ -1418,7 +1468,10 @@ export async function deleteConversationCallCustomVideoClip(input: {
   return deleted;
 }
 
-export function getConversationCallCharacterVideoFile(characterId: string, kind: ConversationCallCharacterVideoClipKind) {
+export function getConversationCallCharacterVideoFile(
+  characterId: string,
+  kind: ConversationCallCharacterVideoClipKind,
+) {
   assertSafeCharacterId(characterId);
   if (!CONVERSATION_CALL_CHARACTER_VIDEO_CLIP_KINDS.includes(kind)) return null;
   const file = clipPath(characterId, kind);

--- a/packages/server/src/services/conversation/call-character-videos.service.ts
+++ b/packages/server/src/services/conversation/call-character-videos.service.ts
@@ -390,7 +390,11 @@ function isClipReadyForAvatar(
   const disk = manifest.clips[kind] ?? {};
   const clipAvatar = getClipAvatarIdentity(manifest, disk);
   const diskReady = disk.status === "ready" || !disk.status;
-  return diskReady && avatarIdentityMatches(clipAvatar, avatar) && existsSync(clipPath(manifest.characterId, kind));
+  return (
+    diskReady &&
+    (disk.origin === "uploaded" || avatarIdentityMatches(clipAvatar, avatar)) &&
+    existsSync(clipPath(manifest.characterId, kind))
+  );
 }
 
 function toPublicManifest(
@@ -409,8 +413,9 @@ function toPublicManifest(
     const activeClipGenerating = activeGeneration?.clipKinds.has(kind) === true;
     const fileExists = existsSync(clipPath(manifest.characterId, kind));
     const diskReady = disk.status === "ready" || !disk.status;
+    const uploadedStandardClip = disk.origin === "uploaded";
     const status =
-      fileExists && avatarMatches && diskReady
+      fileExists && diskReady && (avatarMatches || uploadedStandardClip)
         ? "ready"
         : avatarMatches && disk.status === "generating" && activeClipGenerating
           ? "generating"

--- a/packages/server/src/services/prompt-overrides/registry/conversation-call-videos.ts
+++ b/packages/server/src/services/prompt-overrides/registry/conversation-call-videos.ts
@@ -84,7 +84,7 @@ function buildDefaultCustomClipPrompt(ctx: ConversationCallCustomVideoClipCtx) {
   const hasReference = ctx.referenceInstruction.startsWith("Reference:");
   const startingPose = hasReference ? "the reference pose" : "a stable neutral video-call pose";
   return [
-    `Create a ${ctx.durationSeconds}-second ${ctx.aspectRatio} custom animated portrait loop for an AI video call.`,
+    `Create a ${ctx.durationSeconds}-second ${ctx.aspectRatio} animated portrait loop for an AI video call.`,
     ctx.referenceInstruction,
     hasReference
       ? "Preserve the reference image's crop, especially the top/head framing. If any framing must be lost, crop lower body or lower clothing instead of hair, head, mask, or face."
@@ -92,8 +92,8 @@ function buildDefaultCustomClipPrompt(ctx: ConversationCallCustomVideoClipCtx) {
     hasReference
       ? "Preserve the reference image's base background, lighting, colors, face shape, hair, clothing, mask or eyewear, accessories, and art style unless the custom request explicitly changes one visual detail."
       : "",
-    `Action from command: ${ctx.customPrompt}. Start from ${startingPose}, perform only this custom action, then return to that same pose by the final frame.`,
-    "Motion quality: one smooth, restrained, video-call-like motion throughout the clip, with natural breathing, small head or shoulder movement, and slight hair or clothing motion if present.",
+    `Action: Start from ${startingPose}, ${ctx.customPrompt}, then return to that same pose by the final frame.`,
+    "Motion quality: one smooth, natural, video-call-like motion throughout the clip, with subtle breathing, small head or shoulder movement, and slight hair or clothing motion if present.",
     hasReference
       ? "Lighting and background: keep them from the reference image unless the custom request explicitly changes them."
       : "Lighting and background: keep them stable unless the custom request explicitly changes them.",

--- a/packages/server/src/services/prompt-overrides/registry/conversation-call-videos.ts
+++ b/packages/server/src/services/prompt-overrides/registry/conversation-call-videos.ts
@@ -15,6 +15,7 @@ export interface ConversationCallCustomVideoClipCtx extends Record<string, strin
   customPrompt: string;
   durationSeconds: number;
   aspectRatio: string;
+  referenceInstruction: string;
 }
 
 type ClipPromptSeed = {
@@ -80,14 +81,22 @@ function buildDefaultPrompt(ctx: ConversationCallVideoClipCtx) {
 }
 
 function buildDefaultCustomClipPrompt(ctx: ConversationCallCustomVideoClipCtx) {
+  const hasReference = ctx.referenceInstruction.startsWith("Reference:");
+  const startingPose = hasReference ? "the reference pose" : "a stable neutral video-call pose";
   return [
     `Create a ${ctx.durationSeconds}-second ${ctx.aspectRatio} custom animated portrait loop for an AI video call.`,
-    "Reference: use the attached 16:9 image as the character identity, crop, and first/final frame target.",
-    "Preserve the reference image's crop, especially the top/head framing. If any framing must be lost, crop lower body or lower clothing instead of hair, head, mask, or face.",
-    "Preserve the reference image's base background, lighting, colors, face shape, hair, clothing, mask or eyewear, accessories, and art style unless the custom request explicitly changes one visual detail.",
-    `Action from command: ${ctx.customPrompt}. Start from the reference pose, perform only this custom action, then return to that same pose by the final frame.`,
-    "Motion quality: one smooth, restrained, video-call-like motion throughout the clip.",
-    "Lighting and background: keep them from the reference image unless the custom request explicitly changes them.",
+    ctx.referenceInstruction,
+    hasReference
+      ? "Preserve the reference image's crop, especially the top/head framing. If any framing must be lost, crop lower body or lower clothing instead of hair, head, mask, or face."
+      : "Keep the character design, crop, lighting, background, clothing, accessories, and art style consistent throughout the clip.",
+    hasReference
+      ? "Preserve the reference image's base background, lighting, colors, face shape, hair, clothing, mask or eyewear, accessories, and art style unless the custom request explicitly changes one visual detail."
+      : "",
+    `Action from command: ${ctx.customPrompt}. Start from ${startingPose}, perform only this custom action, then return to that same pose by the final frame.`,
+    "Motion quality: one smooth, restrained, video-call-like motion throughout the clip, with natural breathing, small head or shoulder movement, and slight hair or clothing motion if present.",
+    hasReference
+      ? "Lighting and background: keep them from the reference image unless the custom request explicitly changes them."
+      : "Lighting and background: keep them stable unless the custom request explicitly changes them.",
     "Camera: locked-off still camera, no zoom, pan, tilt, dolly, crop change, reframing, handheld shake, or scene cut.",
     "Looping: return to the first-frame pose by the final frame for a seamless loop.",
     "Focus: single character only, no captions, subtitles, UI, logos, extra people, or unrelated costume/accessory changes.",
@@ -137,6 +146,11 @@ export const CONVERSATION_CALL_CUSTOM_VIDEO_PROMPT: PromptOverrideKeyDef<Convers
     },
     { name: "durationSeconds", description: "Requested clip duration in seconds.", example: "5" },
     { name: "aspectRatio", description: "Requested video aspect ratio.", example: "16:9" },
+    {
+      name: "referenceInstruction",
+      description: "Whether a reference image is attached and how it should be used.",
+      example: "Reference: use the attached 16:9 image as the character identity, crop, and first/final frame target.",
+    },
   ],
   defaultBuilder: buildDefaultCustomClipPrompt,
   exampleContext: {
@@ -145,6 +159,8 @@ export const CONVERSATION_CALL_CUSTOM_VIDEO_PROMPT: PromptOverrideKeyDef<Convers
     customPrompt: "blow a kiss",
     durationSeconds: 5,
     aspectRatio: "16:9",
+    referenceInstruction:
+      "Reference: use the attached 16:9 image as the character identity, crop, and first/final frame target.",
   },
 };
 

--- a/packages/server/src/services/storage/conversation-calls.storage.ts
+++ b/packages/server/src/services/storage/conversation-calls.storage.ts
@@ -3,11 +3,7 @@
 // ──────────────────────────────────────────────
 import { and, desc, eq, inArray } from "drizzle-orm";
 import type { DB } from "../../db/connection.js";
-import {
-  conversationCallMessages,
-  conversationCallSessions,
-  conversationCallSounds,
-} from "../../db/schema/index.js";
+import { conversationCallMessages, conversationCallSessions, conversationCallSounds } from "../../db/schema/index.js";
 import { newId, now } from "../../utils/id-generator.js";
 import type {
   ConversationCallMessage,
@@ -187,8 +183,23 @@ export function createConversationCallsStorage(db: DB) {
           startedAt: status === "active" ? (current.startedAt ?? timestamp) : current.startedAt,
           endedAt: status === "ended" || status === "declined" || status === "missed" ? timestamp : current.endedAt,
           summary: patch.summary !== undefined ? patch.summary : current.summary,
-          metadata: patch.metadata ? JSON.stringify({ ...current.metadata, ...patch.metadata }) : JSON.stringify(current.metadata),
+          metadata: patch.metadata
+            ? JSON.stringify({ ...current.metadata, ...patch.metadata })
+            : JSON.stringify(current.metadata),
           updatedAt: timestamp,
+        })
+        .where(eq(conversationCallSessions.id, id));
+      return this.getSession(id);
+    },
+
+    async updateSummary(id: string, summary: string | null) {
+      const current = await this.getSession(id);
+      if (!current) return null;
+      await db
+        .update(conversationCallSessions)
+        .set({
+          summary,
+          updatedAt: now(),
         })
         .where(eq(conversationCallSessions.id, id));
       return this.getSession(id);
@@ -238,7 +249,10 @@ export function createConversationCallsStorage(db: DB) {
 
     async listSounds() {
       await ensureBuiltInSounds();
-      const rows = await db.select().from(conversationCallSounds).orderBy(conversationCallSounds.builtIn, conversationCallSounds.name);
+      const rows = await db
+        .select()
+        .from(conversationCallSounds)
+        .orderBy(conversationCallSounds.builtIn, conversationCallSounds.name);
       return rows.map(toSound);
     },
 

--- a/packages/server/src/services/video/game-video-prompt.ts
+++ b/packages/server/src/services/video/game-video-prompt.ts
@@ -4,13 +4,9 @@ import {
   normalizeAgentPromptTemplateOptions,
   type AgentPromptTemplateOption,
 } from "@marinara-engine/shared";
-import {
-  GAME_VIDEO,
-  loadPrompt,
-  renderTemplate,
-  type GameVideoCtx,
-} from "../prompt-overrides/index.js";
+import { GAME_VIDEO, renderTemplate, type GameVideoCtx } from "../prompt-overrides/index.js";
 import type { PromptOverridesStorage } from "../storage/prompt-overrides.storage.js";
+import { logger } from "../../lib/logger.js";
 
 const GAME_VIDEO_BUILT_IN_PROMPT_TEMPLATE_IDS = new Set(
   GAME_VIDEO_BUILT_IN_PROMPT_TEMPLATES.map((template) => template.id),
@@ -57,11 +53,34 @@ function resolveGameVideoPromptTemplateId(args: {
   return GAME_VIDEO_PROMPT_TEMPLATE_ID;
 }
 
+async function loadStoredGameVideoPromptOverride(args: {
+  promptOverridesStorage: PromptOverridesStorage;
+  ctx: GameVideoCtx;
+}): Promise<string | null> {
+  const declared = GAME_VIDEO.variables.map((variable) => variable.name);
+  try {
+    for (const key of [GAME_VIDEO.key, ...(GAME_VIDEO.legacyKeys ?? [])]) {
+      const row = await args.promptOverridesStorage.get(key);
+      if (!row) continue;
+      return row.enabled ? renderTemplate(row.template, args.ctx, declared) : null;
+    }
+  } catch (error) {
+    logger.warn(error, "[game-video] Failed to load stored prompt override");
+  }
+  return null;
+}
+
 export async function loadGameVideoPrompt(args: {
   promptOverridesStorage: PromptOverridesStorage;
   meta: Record<string, unknown>;
   ctx: GameVideoCtx;
 }): Promise<string> {
+  const storedOverride = await loadStoredGameVideoPromptOverride({
+    promptOverridesStorage: args.promptOverridesStorage,
+    ctx: args.ctx,
+  });
+  if (storedOverride) return storedOverride;
+
   const options = [
     ...GAME_VIDEO_BUILT_IN_PROMPT_TEMPLATES,
     ...normalizeGameVideoPromptTemplates(args.meta.gameVideoPromptTemplates),
@@ -74,7 +93,7 @@ export async function loadGameVideoPrompt(args: {
     options.find((template) => template.id === templateId) ??
     GAME_VIDEO_BUILT_IN_PROMPT_TEMPLATES.find((template) => template.id === GAME_VIDEO_PROMPT_TEMPLATE_ID);
   if (!selectedTemplate?.promptTemplate.trim()) {
-    return loadPrompt(args.promptOverridesStorage, GAME_VIDEO, args.ctx);
+    return GAME_VIDEO.defaultBuilder(args.ctx);
   }
   const declared = GAME_VIDEO.variables.map((variable) => variable.name);
   return renderTemplate(selectedTemplate.promptTemplate, args.ctx, declared);

--- a/packages/server/src/services/video/game-video-prompt.ts
+++ b/packages/server/src/services/video/game-video-prompt.ts
@@ -6,7 +6,8 @@ import {
 } from "@marinara-engine/shared";
 import { GAME_VIDEO, renderTemplate, type GameVideoCtx } from "../prompt-overrides/index.js";
 import type { PromptOverridesStorage } from "../storage/prompt-overrides.storage.js";
-import { logger } from "../../lib/logger.js";
+import { isDebugAgentsEnabled } from "../../config/runtime-config.js";
+import { logger, logDebugOverride } from "../../lib/logger.js";
 
 const GAME_VIDEO_BUILT_IN_PROMPT_TEMPLATE_IDS = new Set(
   GAME_VIDEO_BUILT_IN_PROMPT_TEMPLATES.map((template) => template.id),
@@ -53,6 +54,21 @@ function resolveGameVideoPromptTemplateId(args: {
   return GAME_VIDEO_PROMPT_TEMPLATE_ID;
 }
 
+function renderSelectedGameVideoPromptTemplate(args: {
+  template: AgentPromptTemplateOption | undefined;
+  ctx: GameVideoCtx;
+}) {
+  if (!args.template?.promptTemplate.trim()) return GAME_VIDEO.defaultBuilder(args.ctx);
+  const declared = GAME_VIDEO.variables.map((variable) => variable.name);
+  return renderTemplate(args.template.promptTemplate, args.ctx, declared);
+}
+
+function finalizeGameVideoPrompt(args: { prompt: string; source: string; debugMode?: boolean }) {
+  const debugOverrideEnabled = args.debugMode === true || isDebugAgentsEnabled();
+  logDebugOverride(debugOverrideEnabled, "[debug/game-video] %s prompt:\n%s", args.source, args.prompt);
+  return args.prompt;
+}
+
 async function loadStoredGameVideoPromptOverride(args: {
   promptOverridesStorage: PromptOverridesStorage;
   ctx: GameVideoCtx;
@@ -74,17 +90,15 @@ export async function loadGameVideoPrompt(args: {
   promptOverridesStorage: PromptOverridesStorage;
   meta: Record<string, unknown>;
   ctx: GameVideoCtx;
+  debugMode?: boolean;
 }): Promise<string> {
-  const storedOverride = await loadStoredGameVideoPromptOverride({
-    promptOverridesStorage: args.promptOverridesStorage,
-    ctx: args.ctx,
-  });
-  if (storedOverride) return storedOverride;
-
   const options = [
     ...GAME_VIDEO_BUILT_IN_PROMPT_TEMPLATES,
     ...normalizeGameVideoPromptTemplates(args.meta.gameVideoPromptTemplates),
   ];
+  const explicitTemplateId = readTrimmedString(args.meta.gameVideoPromptTemplateId);
+  const hasExplicitTemplateSelection =
+    explicitTemplateId !== null && options.some((option) => option.id === explicitTemplateId);
   const templateId = resolveGameVideoPromptTemplateId({
     meta: args.meta,
     options,
@@ -92,9 +106,30 @@ export async function loadGameVideoPrompt(args: {
   const selectedTemplate =
     options.find((template) => template.id === templateId) ??
     GAME_VIDEO_BUILT_IN_PROMPT_TEMPLATES.find((template) => template.id === GAME_VIDEO_PROMPT_TEMPLATE_ID);
-  if (!selectedTemplate?.promptTemplate.trim()) {
-    return GAME_VIDEO.defaultBuilder(args.ctx);
+
+  if (hasExplicitTemplateSelection) {
+    return finalizeGameVideoPrompt({
+      prompt: renderSelectedGameVideoPromptTemplate({ template: selectedTemplate, ctx: args.ctx }),
+      source: `selected template ${templateId}`,
+      debugMode: args.debugMode,
+    });
   }
-  const declared = GAME_VIDEO.variables.map((variable) => variable.name);
-  return renderTemplate(selectedTemplate.promptTemplate, args.ctx, declared);
+
+  const storedOverride = await loadStoredGameVideoPromptOverride({
+    promptOverridesStorage: args.promptOverridesStorage,
+    ctx: args.ctx,
+  });
+  if (storedOverride) {
+    return finalizeGameVideoPrompt({
+      prompt: storedOverride,
+      source: "stored override",
+      debugMode: args.debugMode,
+    });
+  }
+
+  return finalizeGameVideoPrompt({
+    prompt: renderSelectedGameVideoPromptTemplate({ template: selectedTemplate, ctx: args.ctx }),
+    source: `template ${templateId}`,
+    debugMode: args.debugMode,
+  });
 }

--- a/packages/server/src/services/video/video-generation.ts
+++ b/packages/server/src/services/video/video-generation.ts
@@ -294,11 +294,7 @@ async function generateGoogleVeoVideo(
     request.signal,
   );
 
-  if (
-    !start.ok &&
-    request.referenceImage &&
-    shouldRetryGoogleVeoBytesPayload(start.status, start.text)
-  ) {
+  if (!start.ok && request.referenceImage && shouldRetryGoogleVeoBytesPayload(start.status, start.text)) {
     logger.info(
       "[video-gen/google-veo] Retrying model %s with bytesBase64Encoded image payload after inlineData was rejected",
       model,
@@ -538,7 +534,8 @@ async function generateOpenRouterVideo(
   }
   const startRecord = asRecord(startJson);
   const jobId = readString(startRecord.id);
-  const pollingUrl = readString(startRecord.polling_url) ?? (jobId ? buildOpenRouterVideosUrl(baseUrl, `videos/${jobId}`) : null);
+  const pollingUrl =
+    readString(startRecord.polling_url) ?? (jobId ? buildOpenRouterVideosUrl(baseUrl, `videos/${jobId}`) : null);
   if (!jobId || !pollingUrl) {
     throw new Error("OpenRouter video generation response did not include a job id");
   }
@@ -679,7 +676,7 @@ async function generateSeedanceVideo(
           logger.warn("[video-gen/seedance] completed response without video URL: %s", pollText.slice(0, 2000));
           throw new Error("Seedance response did not include a downloadable video");
         }
-        return downloadSeedanceVideo(url, apiKey, request.signal);
+        return downloadSeedanceVideo(url, baseUrl, apiKey, request.signal);
       }
       if (status && ["failed", "error", "cancelled", "canceled", "expired"].includes(status)) {
         const errorMessage = formatSeedanceOperationError(pollJson);
@@ -820,10 +817,11 @@ function buildSeedanceUrl(baseUrl: string, path: string): string {
   }
 }
 
-function isTrustedSeedanceDownloadOrigin(url: string): boolean {
+function isTrustedSeedanceDownloadOrigin(url: string, baseUrl: string): boolean {
   try {
     const parsed = new URL(url);
-    return parsed.origin === "https://api.seedance2.ai";
+    const configured = new URL(buildSeedanceUrl(baseUrl, "v1/tasks/origin-check"));
+    return parsed.origin === configured.origin;
   } catch {
     return false;
   }
@@ -914,11 +912,12 @@ async function downloadOpenRouterVideo(
 
 async function downloadSeedanceVideo(
   url: string,
+  baseUrl: string,
   apiKey: string,
   signal: AbortSignal | undefined,
 ): Promise<VideoGenerationResult> {
   const headers: Record<string, string> = { Accept: "video/mp4,video/*;q=0.9,*/*;q=0.1" };
-  if (isTrustedSeedanceDownloadOrigin(url)) {
+  if (isTrustedSeedanceDownloadOrigin(url, baseUrl)) {
     headers.Authorization = `Bearer ${apiKey}`;
   }
   const res = await safeFetch(url, {
@@ -1063,11 +1062,7 @@ async function maybeUploadSeedanceReferenceImage(
     },
   });
 
-  logger.warn(
-    "[video-gen/seedance] Uploading %s reference image to a temporary public URL for %s",
-    label,
-    expiry,
-  );
+  logger.warn("[video-gen/seedance] Uploading %s reference image to a temporary public URL for %s", label, expiry);
   const res = await safeFetch(LITTERBOX_UPLOAD_URL, {
     method: "POST",
     headers: upload.headers,
@@ -1133,7 +1128,9 @@ function escapeMultipartToken(value: string): string {
   return value.replace(/[\r\n"]/g, "_");
 }
 
-function normalizeReferenceUploadExpiry(value: VideoReferencePublicUploadOptions["expiry"]): VideoReferencePublicUploadExpiry {
+function normalizeReferenceUploadExpiry(
+  value: VideoReferencePublicUploadOptions["expiry"],
+): VideoReferencePublicUploadExpiry {
   return LITTERBOX_EXPIRY_VALUES.has(value as VideoReferencePublicUploadExpiry)
     ? (value as VideoReferencePublicUploadExpiry)
     : "12h";
@@ -1214,9 +1211,7 @@ function shouldRetryGoogleVeoBytesPayload(status: number, text: string): boolean
 function googleVeoImage(
   image: VideoReferenceImage,
   encoding: GoogleVeoImageEncoding,
-):
-  | { inlineData: { mimeType: string; data: string } }
-  | { bytesBase64Encoded: string; mimeType: string } {
+): { inlineData: { mimeType: string; data: string } } | { bytesBase64Encoded: string; mimeType: string } {
   if (encoding === "bytesBase64Encoded") {
     return {
       bytesBase64Encoded: stripDataUrl(image.base64),
@@ -1457,12 +1452,14 @@ function readSeedanceStatus(value: unknown): string | null {
   const root = asRecord(value);
   const data = asRecord(root.data);
   return (
-    readString(root.status) ??
-    readString(root.state) ??
-    readString(data.status) ??
-    readString(data.state) ??
-    readString(data.task_status)
-  )?.toLowerCase() ?? null;
+    (
+      readString(root.status) ??
+      readString(root.state) ??
+      readString(data.status) ??
+      readString(data.state) ??
+      readString(data.task_status)
+    )?.toLowerCase() ?? null
+  );
 }
 
 function formatProviderError(text: string): string {
@@ -1477,7 +1474,10 @@ function formatProviderError(text: string): string {
   } catch {
     /* use raw text */
   }
-  return trimmed.replace(/<[^>]+>/g, " ").replace(/\s+/g, " ").slice(0, 500);
+  return trimmed
+    .replace(/<[^>]+>/g, " ")
+    .replace(/\s+/g, " ")
+    .slice(0, 500);
 }
 
 function formatOperationError(value: unknown): string {

--- a/packages/shared/src/constants/model-lists.ts
+++ b/packages/shared/src/constants/model-lists.ts
@@ -711,14 +711,6 @@ export function inferVideoSource(model: string, baseUrl: string): string {
   if (m === "google_veo" || m === "veo" || /^veo-[\d.]+/.test(m)) return "google_veo";
   if (m === "xai" || u.includes("api.x.ai") || u.includes("x.ai")) return "xai";
   if (m.includes("grok") && m.includes("imagine") && m.includes("video")) return "xai";
-  if (
-    m === "google_ai_studio" ||
-    m === "gemini_omni" ||
-    m.includes("omni") ||
-    u.includes("generativelanguage.googleapis.com")
-  ) {
-    return "gemini_omni";
-  }
   return "gemini_omni";
 }
 

--- a/packages/shared/src/types/tts.ts
+++ b/packages/shared/src/types/tts.ts
@@ -144,9 +144,11 @@ export const ttsConfigSchema = z.object({
   callVideoInputEnabled: z.boolean().default(false),
   /** Generate and play cached character presence videos during Conversation Calls. */
   callCharacterVideoEnabled: z.boolean().default(false),
+  /** Automatically generate the minimum idle/talking call-presence clips for call participants. */
+  callAutomaticVideoClipsEnabled: z.boolean().default(false),
   /** Let characters sparsely generate custom call-presence clips on explicit user request. */
   callCustomVideoClipsEnabled: z.boolean().default(false),
-  /** Enable the call soundboard panel and model soundboard command. */
+  /** Deprecated: soundboard is always available during calls. */
   callSoundboardEnabled: z.boolean().default(true),
 });
 


### PR DESCRIPTION
## Summary

Fixes several follow-up issues from Conversation Call testing, normal chat rendering, and editor media organization:

- Decodes standard HTML entities in safe React-rendered chat text so `<` no longer appears as `&lt;` in messages.
- Smooths video-call character clips by guarding loop boundaries and hiding newly switched clips until the first frame is decoded.
- Stops call voice playback and queued response playback immediately when the user ends a call.
- Ends calls server-side immediately and finalizes the audio-call summary in the background.
- Makes voice interruption detection more responsive while characters are speaking or TTS is loading.
- Batches adjacent multi-character voice turns into a single prepared TTS sequence so group-call speakers hand off with less silence.
- Reconciles optimistic call-chat messages with persisted server messages to avoid temporary duplicated typed messages.
- Centers the mobile muted-microphone reminder above the call controls so it is not clipped by the viewport edge.
- Renames Gallery clips to Videos for broader roleplay/game/chat video assets, with upload support for user videos.
- Moves Video Call Clips into the Sprites tab for characters and personas as a third category.
- Adds a call-clip generation dialog with video connection selection, avatar-reference toggle, specific clip-kind selection, and named custom clip generation.
- Uses the same loop/camera/motion scaffold for custom call clips, with only the user-entered action swapped into the prompt.
- Allows mixed video-call participants where only some characters have video clips, while others stay avatar-only.
- Replaces the per-chat Soundboard toggle with Automatic video clips generation, defaulting off and generating only cached idle/talking clips when enabled.
- Keeps the call soundboard always available in the call UI.
- Adds playable custom call clips through `[play_clip="name"]`, listing ready per-character clips in the call prompt.
- Centers missing call-clip placeholders in the preview tile and keeps persona empty slots from showing delete actions.
- Matches Character/Persona Gallery Videos upload controls to the Images tab dropzone styling and spacing.
- Applies CodeRabbit follow-ups for Seedance source/download handling, persona clip cache invalidation, uploaded call-clip avatar persistence, game-video prompt override precedence/debug logging, selfie busy state, call TTS metadata alignment, soundboard command gating, and legacy Immersive HTML migration.

## Why

Conversation Calls were close, but testing still exposed immersion-breaking edges: escaped symbols in chat text, black-frame flashes when videos switched, voices continuing after hang-up, unreliable interruption, long speaker handoff gaps, doubled typed call messages, and call summaries blocking user hang-up. The editor media model also needed clearer separation between general generated/uploaded videos and reusable video-call loop clips. This update also avoids forcing every call participant into generated video presence: characters without clips can remain avatar-only, while users can opt into basic idle/talking auto-generation or create named gesture clips manually.

## Validation

- `pnpm --filter @marinara-engine/client lint`
- `pnpm --filter @marinara-engine/server lint`
- `pnpm --filter @marinara-engine/shared lint`
- `pnpm --filter @marinara-engine/client build`
- `pnpm exec prettier --check packages/client/src/components/personas/PersonaEditor.tsx`
- `git diff --check`
- `pnpm regression:prompt`
- `pnpm check`
- `coderabbit review --agent --base staging -c AGENTS.md`

## Manual Verification Needed

- Manually verify a mobile call starts muted and shows the reminder centered above the bottom controls.
- Manually verify ending a call cuts off any remaining character voice lines immediately.
- Manually verify ending a call returns control immediately while the call summary appears later in the conversation context.
- Manually verify talking over a character interrupts current playback.
- Manually verify group-call character voice turns hand off smoothly.
- Manually verify character video clips do not flash black when switching idle/talking/expression clips.
- Manually verify typed call-chat messages do not briefly duplicate.
- Manually verify Character and Persona Gallery tabs show Images/Videos, and uploaded videos can be added/deleted.
- Manually verify Character and Persona Sprites tabs show Expressions/Full Body/Clips, and call clips can be generated with selected settings.
- Manually verify Automatic video clips generation is off by default and only generates idle/talking clips when enabled.
- Manually verify a group call can include one character with ready clips and other characters without clips, without forcing generation or showing a reminder.
- Manually verify enabling character video presence with no ready idle/talking clips shows the dismissible Sprites > Clips reminder.
- Manually verify a named custom clip can be generated from Sprites > Clips and played during a call via `[play_clip="name"]`.
- Manually verify missing call-clip placeholders are centered and persona missing slots do not show trash actions.
- Manually verify Gallery Videos upload dropzones match the Images tab spacing and style.

## Notes

Maintainer-requested follow-up from Conversation Call and editor media testing; no linked issue was provided for this PR.
