### PR TITLE
[codex] Start v2.1.1 and fix first post-release issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 
 ## [Unreleased]
 
+## [2.1.1]
+
+### Changed
+
+- Bumped release metadata to v2.1.1 across packages, the PWA manifest, README release pointer, Windows installer sources, Android APK metadata, and the home-page-visible app version.
+
+### Fixed
+
 ## [2.1.0]
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 
 ### Fixed
 
+- Fixed Marinara profile/full backup exports so generated scene-video MP4s and reusable Conversation Call character video clips are included with their storage metadata and accepted on profile ZIP import (#3315).
+- Fixed Card Evolution Auditor review proposals being falsely marked stale from cached character data by refreshing the character card before validation, and added an explicit stale override path that appends edited replacement text after confirmation instead of blocking the proposal outright (#3314).
+
 ## [2.1.0]
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@
 
 ## Latest Release
 
-Current stable release: **[v2.1.0](https://github.com/Pasta-Devs/Marinara-Engine/releases/tag/v2.1.0)**.
+Current stable release: **[v2.1.1](https://github.com/Pasta-Devs/Marinara-Engine/releases/tag/v2.1.1)**.
 
 See [CHANGELOG.md](CHANGELOG.md) for detailed release notes. Tagged releases use the `vX.Y.Z` format and are published on the [Releases](https://github.com/Pasta-Devs/Marinara-Engine/releases) page. Android APKs are Termux bootstrap + WebView shells: they can download Termux from F-Droid, launch Android's installer, start the Termux setup flow after required permission prompts, then open the local Marinara server on the same device.
 

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -22,10 +22,10 @@ android {
         applicationId "com.marinara.engine"
         minSdk 24
         targetSdk 34
-        versionCode 29
-        versionName "2.1.0"
+        versionCode 30
+        versionName "2.1.1"
         buildConfigField "String", "MARINARA_SERVER_URL", "\"http://127.0.0.1:${marinaraPort}\""
-        buildConfigField "String", "MARINARA_RELEASE_TAG", "\"v2.1.0\""
+        buildConfigField "String", "MARINARA_RELEASE_TAG", "\"v2.1.1\""
     }
 
     signingConfigs {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "marinara-engine",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "private": true,
   "description": "AI Chat & Roleplay Frontend — Conversation, Roleplay, Visual Novel",
   "author": "Marianna",

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@marinara-engine/client",
   "private": true,
-  "version": "2.1.0",
+  "version": "2.1.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/packages/client/public/manifest.json
+++ b/packages/client/public/manifest.json
@@ -2,7 +2,7 @@
   "name": "Marinara Engine",
   "short_name": "Marinara",
   "description": "AI Chat & Roleplay Frontend — Conversation, Roleplay, Visual Novel",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "start_url": "/",
   "display": "standalone",
   "background_color": "#0a0a0f",

--- a/packages/client/src/components/modals/CharacterCardUpdateModal.tsx
+++ b/packages/client/src/components/modals/CharacterCardUpdateModal.tsx
@@ -51,6 +51,14 @@ function setCharacterCardFieldValue(
   };
 }
 
+function appendStaleCardReplacement(base: string, replacement: string): string {
+  const trimmedReplacement = replacement.trim();
+  if (!trimmedReplacement) return base;
+  if (base.includes(trimmedReplacement)) return base;
+  const separator = base.trim().length > 0 ? "\n\n" : "";
+  return `${base.trimEnd()}${separator}${trimmedReplacement}`;
+}
+
 function bumpCharacterVersion(value: unknown): string {
   const raw = typeof value === "string" ? value.trim() : "";
   if (!raw) return "1.1";
@@ -69,6 +77,10 @@ interface Props {
 }
 
 type BusyAction = "approve" | "regenerate" | null;
+type CardUpdateState = {
+  update: CharacterCardFieldUpdate;
+  stale: boolean;
+};
 
 export function CharacterCardUpdateModal({ open, onClose }: Props) {
   const pending = useAgentStore((s) => s.pendingCardUpdates);
@@ -76,7 +88,9 @@ export function CharacterCardUpdateModal({ open, onClose }: Props) {
 
   const entry = pending[0] ?? null;
   const { retryAgents } = useGenerate();
-  const { data: character } = useCharacter(entry?.characterId ?? null);
+  const { data: character, isFetching: isFetchingCharacter, refetch: refetchCharacter } = useCharacter(
+    entry?.characterId ?? null,
+  );
   const updateCharacter = useUpdateCharacter();
   const [error, setError] = useState<string | null>(null);
   const [busyAction, setBusyAction] = useState<BusyAction>(null);
@@ -87,6 +101,11 @@ export function CharacterCardUpdateModal({ open, onClose }: Props) {
     setError(null);
     setBusyAction(null);
   }, [entry?.id, entry?.updates]);
+
+  useEffect(() => {
+    if (!entry?.characterId) return;
+    void refetchCharacter();
+  }, [entry?.characterId, entry?.id, refetchCharacter]);
 
   // Character rows come back from /characters with `data` serialized as a JSON
   // string, so parse it once here and reuse below.
@@ -102,17 +121,30 @@ export function CharacterCardUpdateModal({ open, onClose }: Props) {
     return (raw as Record<string, unknown>) ?? {};
   }, [character]);
 
-  // Only show updates whose oldText is still present in the current field —
-  // stale suggestions (field already changed since the agent ran) are dropped.
+  // Only apply exact replacements whose oldText is still present in the current
+  // field. We force-refetch the character above before letting the user approve,
+  // because a 5-minute React Query cache can otherwise make fresh server-side
+  // auditor proposals look stale in this modal.
   // We use substring match, not equality, because oldText is a sentence-level
   // slice of a field that often contains multiple paragraphs.
-  const applicableUpdates = useMemo(() => {
+  const updateStates = useMemo<CardUpdateState[]>(() => {
     if (!entry || !character) return [];
-    return draftUpdates.filter((u) => {
+    return draftUpdates.map((u) => {
       const current = getCharacterCardFieldValue(parsedData, u.field);
-      return typeof current === "string" && u.oldText.length > 0 && current.includes(u.oldText);
+      return {
+        update: u,
+        stale: !(typeof current === "string" && u.oldText.length > 0 && current.includes(u.oldText)),
+      };
     });
   }, [entry, character, draftUpdates, parsedData]);
+  const applicableUpdates = useMemo(
+    () => updateStates.filter((state) => !state.stale).map((state) => state.update),
+    [updateStates],
+  );
+  const staleUpdates = useMemo(
+    () => updateStates.filter((state) => state.stale).map((state) => state.update),
+    [updateStates],
+  );
 
   if (!entry) return null;
 
@@ -127,21 +159,34 @@ export function CharacterCardUpdateModal({ open, onClose }: Props) {
     }
   };
 
-  const handleApprove = async () => {
-    if (!character || applicableUpdates.length === 0) {
+  const handleApprove = async (overrideStale = false) => {
+    if (!character || (applicableUpdates.length === 0 && (!overrideStale || staleUpdates.length === 0))) {
       closeAndAdvance();
       return;
     }
+    if (overrideStale && staleUpdates.length > 0) {
+      const ok = window.confirm(
+        "Some proposed card edits no longer match the current card text exactly. Override anyway? Stale replacements will be appended to their fields instead of replacing unknown text.",
+      );
+      if (!ok) return;
+    }
     // Apply each edit as a targeted substring replace inside the field's current
     // value, NOT by overwriting the field with newText (which would erase
-    // everything around the edited sentence).
+    // everything around the edited sentence). If the user explicitly overrides
+    // a stale proposal, append the edited replacement text to the current field
+    // so stale oldText cannot delete unrelated card content.
     setBusyAction("approve");
     setError(null);
     let nextData: Record<string, unknown> = { ...parsedData };
-    for (const u of applicableUpdates) {
+    for (const u of overrideStale ? [...applicableUpdates, ...staleUpdates] : applicableUpdates) {
       const base = getCharacterCardFieldValue(nextData, u.field);
       if (typeof base !== "string") continue;
-      nextData = setCharacterCardFieldValue(nextData, u.field, base.replace(u.oldText, u.newText));
+      const nextValue = base.includes(u.oldText)
+        ? base.replace(u.oldText, u.newText)
+        : overrideStale
+          ? appendStaleCardReplacement(base, u.newText)
+          : base;
+      nextData = setCharacterCardFieldValue(nextData, u.field, nextValue);
     }
     nextData.character_version = bumpCharacterVersion(nextData.character_version);
     try {
@@ -208,17 +253,24 @@ export function CharacterCardUpdateModal({ open, onClose }: Props) {
           </div>
         </div>
 
-        {applicableUpdates.length === 0 && (
+        {isFetchingCharacter && (
+          <div className="flex items-center gap-2 rounded-lg bg-[var(--secondary)] p-2.5 text-xs text-[var(--muted-foreground)]">
+            <Loader2 size="0.75rem" className="shrink-0 animate-spin" />
+            Refreshing the current character card before checking stale proposals...
+          </div>
+        )}
+
+        {applicableUpdates.length === 0 && !isFetchingCharacter && (
           <div className="flex items-center gap-2 rounded-lg bg-[var(--secondary)] p-2.5 text-xs text-[var(--muted-foreground)]">
             <AlertCircle size="0.75rem" className="shrink-0" />
-            None of these proposals still match the current card — the field was probably already edited. Reject to
-            dismiss.
+            None of these proposals still match the freshly loaded card. Regenerate, reject, or override if you still
+            want to keep the edited text.
           </div>
         )}
 
         <div className="flex max-h-[60vh] flex-col gap-3 overflow-y-auto">
           {draftUpdates.map((u, idx) => {
-            const stale = !applicableUpdates.includes(u);
+            const stale = updateStates[idx]?.stale ?? true;
             return (
               <div
                 key={idx}
@@ -295,8 +347,10 @@ export function CharacterCardUpdateModal({ open, onClose }: Props) {
           </button>
           <button
             type="button"
-            onClick={handleApprove}
-            disabled={busyAction !== null || updateCharacter.isPending || applicableUpdates.length === 0}
+            onClick={() => void handleApprove(false)}
+            disabled={
+              busyAction !== null || updateCharacter.isPending || isFetchingCharacter || applicableUpdates.length === 0
+            }
             className="flex items-center gap-1.5 rounded-lg bg-[var(--primary)] px-4 py-2 text-xs font-medium text-[var(--primary-foreground)] transition-all hover:opacity-90 disabled:opacity-50"
           >
             {busyAction === "approve" || updateCharacter.isPending ? (
@@ -306,6 +360,21 @@ export function CharacterCardUpdateModal({ open, onClose }: Props) {
             )}
             Approve {applicableUpdates.length > 0 ? `(${applicableUpdates.length})` : ""}
           </button>
+          {staleUpdates.length > 0 && (
+            <button
+              type="button"
+              onClick={() => void handleApprove(true)}
+              disabled={busyAction !== null || updateCharacter.isPending || isFetchingCharacter}
+              className="flex items-center gap-1.5 rounded-lg border border-[var(--border)] px-4 py-2 text-xs font-medium text-[var(--foreground)] transition-colors hover:bg-[var(--accent)] disabled:opacity-50"
+            >
+              {busyAction === "approve" || updateCharacter.isPending ? (
+                <Loader2 size="0.75rem" className="animate-spin" />
+              ) : (
+                <AlertCircle size="0.75rem" />
+              )}
+              Override stale ({staleUpdates.length})
+            </button>
+          )}
         </div>
       </div>
     </Modal>

--- a/packages/client/src/components/modals/CharacterCardUpdateModal.tsx
+++ b/packages/client/src/components/modals/CharacterCardUpdateModal.tsx
@@ -182,7 +182,7 @@ export function CharacterCardUpdateModal({ open, onClose }: Props) {
       const base = getCharacterCardFieldValue(nextData, u.field);
       if (typeof base !== "string") continue;
       const nextValue = base.includes(u.oldText)
-        ? base.replace(u.oldText, u.newText)
+        ? base.replace(u.oldText, () => u.newText)
         : overrideStale
           ? appendStaleCardReplacement(base, u.newText)
           : base;

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@marinara-engine/server",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "private": true,
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/server/src/routes/backup.routes.ts
+++ b/packages/server/src/routes/backup.routes.ts
@@ -37,6 +37,8 @@ const BACKUP_DIRS = [
   "sprites",
   "backgrounds",
   "gallery",
+  "game-scene-videos",
+  "conversation-call-character-videos",
   "fonts",
   "knowledge-sources",
   "game-assets",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@marinara-engine/shared",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "private": true,
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/shared/src/constants/defaults.ts
+++ b/packages/shared/src/constants/defaults.ts
@@ -4,7 +4,7 @@
 import type { GenerationParameters } from "../types/prompt.js";
 
 /** App version — single source of truth. */
-export const APP_VERSION = "2.1.0";
+export const APP_VERSION = "2.1.1";
 
 /** Stable synthetic connection id for the built-in local llama sidecar. */
 export const LOCAL_SIDECAR_CONNECTION_ID = "__local_sidecar__";

--- a/win/installer/install.bat
+++ b/win/installer/install.bat
@@ -11,14 +11,14 @@ set "NODE_DOWNLOAD_URL=https://nodejs.org/dist/v24.15.0/node-v24.15.0-x64.msi"
 set "NODE_SHA256=feffb8e5cb5ac47f793666636d496ef3e975be82c84c4da5d20e6aa8fa4eb806"
 set "GIT_DOWNLOAD_URL=https://github.com/git-for-windows/git/releases/download/v2.54.0.windows.1/Git-2.54.0-64-bit.exe"
 set "GIT_SHA256=2b96e7854f0520f0f6b709c21041d9801b1be44d5e1a0d9fa621b2fbc40f1983"
-set "RELEASE_TAG=v2.1.0"
+set "RELEASE_TAG=v2.1.1"
 if not defined MARINARA_RELEASE_COMMIT set "MARINARA_RELEASE_COMMIT="
 set "RELEASE_COMMIT=%MARINARA_RELEASE_COMMIT%"
 
 echo.
 echo  +==========================================+
 echo  ^|   Marinara Engine - Windows Installer     ^|
-echo  ^|   v2.1.0                                  ^|
+echo  ^|   v2.1.1                                  ^|
 
 echo  +==========================================+
 echo.

--- a/win/installer/installer.nsi
+++ b/win/installer/installer.nsi
@@ -13,7 +13,7 @@
 
 ; ── App metadata ──
 !define APP_NAME "Marinara Engine"
-!define APP_VERSION "2.1.0"
+!define APP_VERSION "2.1.1"
 !define APP_PUBLISHER "Pasta-Devs"
 !define APP_URL "https://github.com/Pasta-Devs/Marinara-Engine"
 !define REPO_URL "https://github.com/Pasta-Devs/Marinara-Engine.git"
@@ -27,7 +27,7 @@
 !define NODE_DOWNLOAD_URL "https://nodejs.org/dist/v24.15.0/node-v24.15.0-x64.msi"
 !define GIT_SHA256 "2b96e7854f0520f0f6b709c21041d9801b1be44d5e1a0d9fa621b2fbc40f1983"
 !define NODE_SHA256 "feffb8e5cb5ac47f793666636d496ef3e975be82c84c4da5d20e6aa8fa4eb806"
-!define RELEASE_TAG "v2.1.0"
+!define RELEASE_TAG "v2.1.1"
 !ifndef RELEASE_COMMIT
 !define RELEASE_COMMIT ""
 !endif


### PR DESCRIPTION
## Summary
- Start the v2.1.1 release train.
- Fix #3315: include stored video assets in Marinara backup exports/restores.
- Fix #3314: make Card Evolution Auditor stale-card blocking recoverable for valid updates.

## Why
The first two open bugs after v2.1.0 affect backup completeness for generated videos and long-running roleplay usability when Card Evolution Auditor rejects valid character-card updates as stale.

## Validation
- [ ] `pnpm version:check`
- [ ] `pnpm check`
- [ ] Targeted backup/export or storage regression proof
- [ ] Targeted Card Evolution Auditor stale-update proof

Closes #3315.
Closes #3314.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Backup downloads now include additional media folders, improving completeness of full backups.

* **Bug Fixes**
  * Fixed backup exports so generated video files and conversation clips import correctly.
  * Improved proposal review so outdated suggestions are detected more reliably, with a clear override option when needed.

* **Chores**
  * Updated app, installer, and release versioning to **2.1.1** across platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->