### PR TITLE
Fix/bot browser avatar images

### DIFF
--- a/packages/server/src/routes/bot-browser-chartavern.routes.ts
+++ b/packages/server/src/routes/bot-browser-chartavern.routes.ts
@@ -3,7 +3,7 @@
 // ──────────────────────────────────────────────
 import type { FastifyInstance } from "fastify";
 import { logger } from "../lib/logger.js";
-import { isAllowedImageBuffer, safeFetch } from "../utils/security.js";
+import { resolveValidatedImage, safeFetch } from "../utils/security.js";
 
 const CT_API_BASE = "https://character-tavern.com/api";
 const CT_CARDS_CDN = "https://ct-cards.storage.character-tavern.com";
@@ -41,12 +41,9 @@ async function fetchAvatarImage(url: string, signal: AbortSignal) {
   });
   if (!res.ok) return null;
   const buf = Buffer.from(await res.arrayBuffer());
-  const contentType = res.headers.get("content-type")?.toLowerCase() ?? "";
-  const imageInfo = isAllowedImageBuffer(buf);
-  if (!contentType.startsWith("image/") && !imageInfo) {
-    throw new Error("Unsupported avatar image content");
-  }
-  return { buf, mimeType: imageInfo?.mimeType ?? contentType };
+  const image = resolveValidatedImage(buf, res.headers.get("content-type") ?? "");
+  if (!image) throw new Error("Unsupported avatar image content");
+  return { buf, mimeType: image.mimeType };
 }
 
 /** Build headers for CT API — includes session cookie if stored */

--- a/packages/server/src/routes/bot-browser-chartavern.routes.ts
+++ b/packages/server/src/routes/bot-browser-chartavern.routes.ts
@@ -6,7 +6,7 @@ import { logger } from "../lib/logger.js";
 import { isAllowedImageBuffer, safeFetch } from "../utils/security.js";
 
 const CT_API_BASE = "https://character-tavern.com/api";
-const CT_CARDS_CDN = "https://cards.character-tavern.com";
+const CT_CARDS_CDN = "https://ct-cards.storage.character-tavern.com";
 const AVATAR_PROXY_MAX_BYTES = 10 * 1024 * 1024;
 
 // In-memory session cookie store (persists until server restart)
@@ -27,20 +27,26 @@ async function proxyFetch(url: string, init?: RequestInit): Promise<unknown> {
   }
 }
 
+const CT_UA = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36";
+
 async function fetchAvatarImage(url: string, signal: AbortSignal) {
   const res = await safeFetch(url, {
     signal,
     policy: { allowedProtocols: ["https:"] },
     maxResponseBytes: AVATAR_PROXY_MAX_BYTES,
+    headers: {
+      "User-Agent": CT_UA,
+      Referer: "https://character-tavern.com/",
+    },
   });
   if (!res.ok) return null;
   const buf = Buffer.from(await res.arrayBuffer());
   const contentType = res.headers.get("content-type")?.toLowerCase() ?? "";
   const imageInfo = isAllowedImageBuffer(buf);
-  if (!contentType.startsWith("image/") || !imageInfo) {
+  if (!contentType.startsWith("image/") && !imageInfo) {
     throw new Error("Unsupported avatar image content");
   }
-  return { buf, mimeType: imageInfo.mimeType };
+  return { buf, mimeType: imageInfo?.mimeType ?? contentType };
 }
 
 /** Build headers for CT API — includes session cookie if stored */
@@ -280,7 +286,7 @@ export async function botBrowserChartavernRoutes(app: FastifyInstance) {
     const timeout = setTimeout(() => controller.abort(), 15_000);
     try {
       const primary = await fetchAvatarImage(
-        `${CT_CARDS_CDN}/cdn-cgi/image/format=auto,width=320,quality=85/${encodeURI(path)}.png`,
+        `${CT_CARDS_CDN}/${encodeURI(path)}.png?width=320&quality=85&format=auto`,
         controller.signal,
       );
       const image = primary ?? (await fetchAvatarImage(`${CT_CARDS_CDN}/${encodeURI(path)}.png`, controller.signal));

--- a/packages/server/src/routes/bot-browser-datacat.routes.ts
+++ b/packages/server/src/routes/bot-browser-datacat.routes.ts
@@ -6,7 +6,7 @@
 import { randomUUID } from "node:crypto";
 import type { FastifyInstance } from "fastify";
 import { logger } from "../lib/logger.js";
-import { isAllowedImageBuffer, safeFetch } from "../utils/security.js";
+import { resolveValidatedImage, safeFetch } from "../utils/security.js";
 
 const DATACAT_API_BASE = "https://datacat.run";
 const DATACAT_IMAGE_BASE = "https://ella.janitorai.com/bot-avatars/";
@@ -87,12 +87,9 @@ async function fetchAvatarImage(url: string, signal: AbortSignal) {
   });
   if (!res.ok) return null;
   const buf = Buffer.from(await res.arrayBuffer());
-  const contentType = res.headers.get("content-type")?.toLowerCase() ?? "";
-  const imageInfo = isAllowedImageBuffer(buf);
-  if (!contentType.startsWith("image/") && !imageInfo) {
-    throw new Error("Unsupported avatar image content");
-  }
-  return { buf, mimeType: imageInfo?.mimeType ?? contentType };
+  const image = resolveValidatedImage(buf, res.headers.get("content-type") ?? "");
+  if (!image) throw new Error("Unsupported avatar image content");
+  return { buf, mimeType: image.mimeType };
 }
 
 async function dcFetch(path: string): Promise<unknown> {

--- a/packages/server/src/routes/bot-browser-datacat.routes.ts
+++ b/packages/server/src/routes/bot-browser-datacat.routes.ts
@@ -80,15 +80,19 @@ async function fetchAvatarImage(url: string, signal: AbortSignal) {
     signal,
     policy: { allowedProtocols: ["https:"] },
     maxResponseBytes: AVATAR_PROXY_MAX_BYTES,
+    headers: {
+      "User-Agent": DC_USER_AGENT,
+      Referer: `${DATACAT_API_BASE}/`,
+    },
   });
   if (!res.ok) return null;
   const buf = Buffer.from(await res.arrayBuffer());
   const contentType = res.headers.get("content-type")?.toLowerCase() ?? "";
   const imageInfo = isAllowedImageBuffer(buf);
-  if (!contentType.startsWith("image/") || !imageInfo) {
+  if (!contentType.startsWith("image/") && !imageInfo) {
     throw new Error("Unsupported avatar image content");
   }
-  return { buf, mimeType: imageInfo.mimeType };
+  return { buf, mimeType: imageInfo?.mimeType ?? contentType };
 }
 
 async function dcFetch(path: string): Promise<unknown> {
@@ -234,7 +238,8 @@ export async function botBrowserDatacatRoutes(app: FastifyInstance) {
       } catch {
         return reply.status(400).send({ error: "Invalid avatar URL" });
       }
-      if (parsed.protocol !== "https:" || parsed.hostname !== "ella.janitorai.com") {
+      const ALLOWED_DC_HOSTS = ["ella.janitorai.com", "media.datacat.run"];
+      if (parsed.protocol !== "https:" || !ALLOWED_DC_HOSTS.includes(parsed.hostname)) {
         return reply.status(400).send({ error: "Unsupported avatar host" });
       }
       url = parsed.toString();

--- a/packages/server/src/routes/bot-browser-janny.routes.ts
+++ b/packages/server/src/routes/bot-browser-janny.routes.ts
@@ -24,10 +24,10 @@ async function fetchAvatarImage(url: string, signal: AbortSignal) {
   const buf = Buffer.from(await res.arrayBuffer());
   const contentType = res.headers.get("content-type")?.toLowerCase() ?? "";
   const imageInfo = isAllowedImageBuffer(buf);
-  if (!contentType.startsWith("image/") || !imageInfo) {
+  if (!contentType.startsWith("image/") && !imageInfo) {
     throw new Error("Unsupported avatar image content");
   }
-  return { buf, mimeType: imageInfo.mimeType };
+  return { buf, mimeType: imageInfo?.mimeType ?? contentType };
 }
 
 function jannySearchHeaders(token: string): Record<string, string> {

--- a/packages/server/src/routes/bot-browser-janny.routes.ts
+++ b/packages/server/src/routes/bot-browser-janny.routes.ts
@@ -2,7 +2,7 @@
 // Routes: Browser — JannyAI provider
 // ──────────────────────────────────────────────
 import type { FastifyInstance } from "fastify";
-import { isAllowedImageBuffer, safeFetch } from "../utils/security.js";
+import { resolveValidatedImage, safeFetch } from "../utils/security.js";
 
 const JANNY_SEARCH_URL = "https://search.jannyai.com/multi-search";
 const JANNY_IMAGE_BASE = "https://image.jannyai.com/bot-avatars/";
@@ -22,12 +22,9 @@ async function fetchAvatarImage(url: string, signal: AbortSignal) {
   });
   if (!res.ok) return null;
   const buf = Buffer.from(await res.arrayBuffer());
-  const contentType = res.headers.get("content-type")?.toLowerCase() ?? "";
-  const imageInfo = isAllowedImageBuffer(buf);
-  if (!contentType.startsWith("image/") && !imageInfo) {
-    throw new Error("Unsupported avatar image content");
-  }
-  return { buf, mimeType: imageInfo?.mimeType ?? contentType };
+  const image = resolveValidatedImage(buf, res.headers.get("content-type") ?? "");
+  if (!image) throw new Error("Unsupported avatar image content");
+  return { buf, mimeType: image.mimeType };
 }
 
 function jannySearchHeaders(token: string): Record<string, string> {

--- a/packages/server/src/routes/bot-browser-pygmalion.routes.ts
+++ b/packages/server/src/routes/bot-browser-pygmalion.routes.ts
@@ -3,7 +3,7 @@
 // ──────────────────────────────────────────────
 import type { FastifyInstance } from "fastify";
 import { logger } from "../lib/logger.js";
-import { isAllowedImageBuffer, safeFetch } from "../utils/security.js";
+import { resolveValidatedImage, safeFetch } from "../utils/security.js";
 
 const PYGMALION_API_BASE = "https://server.pygmalion.chat/galatea.v1.PublicCharacterService";
 const PYGMALION_ORIGIN = "https://pygmalion.chat";
@@ -258,18 +258,12 @@ export async function botBrowserPygmalionRoutes(app: FastifyInstance) {
       });
       if (!res.ok) return reply.status(404).send({ error: "Avatar not found" });
       const buf = Buffer.from(await res.arrayBuffer());
-      const contentType = res.headers.get("content-type")?.toLowerCase() ?? "";
-      const imageInfo = isAllowedImageBuffer(buf);
-      if (contentType && !contentType.startsWith("image/") && !imageInfo) {
-        logger.warn("[bot-browser] Pygmalion avatar returned unsupported content type: %s", contentType);
+      const image = resolveValidatedImage(buf, res.headers.get("content-type") ?? "");
+      if (!image) {
+        logger.warn("[bot-browser] Pygmalion avatar returned unsupported content type: %s", res.headers.get("content-type") || "(missing)");
         return reply.status(415).send({ error: "Unsupported avatar content type" });
       }
-      if (!contentType && !imageInfo) {
-        logger.warn("[bot-browser] Pygmalion avatar response was missing a usable image content type");
-        return reply.status(415).send({ error: "Unsupported avatar content type" });
-      }
-      const ct = contentType || imageInfo?.mimeType || "image/webp";
-      return reply.header("Content-Type", ct).header("Cache-Control", "public, max-age=86400").send(buf);
+      return reply.header("Content-Type", image.mimeType).header("Cache-Control", "public, max-age=86400").send(buf);
     } finally {
       clearTimeout(timeout);
     }

--- a/packages/server/src/routes/bot-browser-pygmalion.routes.ts
+++ b/packages/server/src/routes/bot-browser-pygmalion.routes.ts
@@ -249,12 +249,12 @@ export async function botBrowserPygmalionRoutes(app: FastifyInstance) {
     const url = assetPath.startsWith("http") ? assetPath : `${PYGMALION_ASSETS_BASE}/${assetPath}`;
 
     const controller = new AbortController();
-    const timeout = setTimeout(() => controller.abort(), 15_000);
+    const timeout = setTimeout(() => controller.abort(), 30_000);
     try {
       const res = await safeFetch(url, {
         signal: controller.signal,
         policy: { allowedProtocols: ["https:"] },
-        maxResponseBytes: 10 * 1024 * 1024,
+        maxResponseBytes: 25 * 1024 * 1024,
       });
       if (!res.ok) return reply.status(404).send({ error: "Avatar not found" });
       const buf = Buffer.from(await res.arrayBuffer());

--- a/packages/server/src/routes/bot-browser-wyvern.routes.ts
+++ b/packages/server/src/routes/bot-browser-wyvern.routes.ts
@@ -2,7 +2,7 @@
 // Routes: Browser — Wyvern provider
 // ──────────────────────────────────────────────
 import type { FastifyInstance } from "fastify";
-import { isAllowedImageBuffer, safeFetch } from "../utils/security.js";
+import { resolveValidatedImage, safeFetch } from "../utils/security.js";
 import { logger } from "../lib/logger.js";
 
 const WYVERN_API_BASE = "https://api.wyvern.chat";
@@ -126,18 +126,12 @@ export async function botBrowserWyvernRoutes(app: FastifyInstance) {
       });
       if (!res.ok) return reply.status(404).send({ error: "Avatar not found" });
       const buf = Buffer.from(await res.arrayBuffer());
-      const contentType = res.headers.get("content-type")?.toLowerCase() ?? "";
-      const imageInfo = isAllowedImageBuffer(buf);
-      if (contentType && !contentType.startsWith("image/") && !imageInfo) {
-        logger.warn("[bot-browser] Wyvern avatar returned unsupported content type: %s", contentType);
+      const image = resolveValidatedImage(buf, res.headers.get("content-type") ?? "");
+      if (!image) {
+        logger.warn("[bot-browser] Wyvern avatar returned unsupported content type: %s", res.headers.get("content-type") || "(missing)");
         return reply.status(415).send({ error: "Unsupported avatar content type" });
       }
-      if (!contentType && !imageInfo) {
-        logger.warn("[bot-browser] Wyvern avatar response was missing a usable image content type");
-        return reply.status(415).send({ error: "Unsupported avatar content type" });
-      }
-      const ct = contentType || imageInfo?.mimeType || "image/webp";
-      return reply.header("Content-Type", ct).header("Cache-Control", "public, max-age=86400").send(buf);
+      return reply.header("Content-Type", image.mimeType).header("Cache-Control", "public, max-age=86400").send(buf);
     } finally {
       clearTimeout(timeout);
     }

--- a/packages/server/src/routes/bot-browser-wyvern.routes.ts
+++ b/packages/server/src/routes/bot-browser-wyvern.routes.ts
@@ -2,7 +2,8 @@
 // Routes: Browser — Wyvern provider
 // ──────────────────────────────────────────────
 import type { FastifyInstance } from "fastify";
-import { safeFetch } from "../utils/security.js";
+import { isAllowedImageBuffer, safeFetch } from "../utils/security.js";
+import { logger } from "../lib/logger.js";
 
 const WYVERN_API_BASE = "https://api.wyvern.chat";
 const WYVERN_IMAGE_BASE = "https://imagedelivery.net";
@@ -121,12 +122,21 @@ export async function botBrowserWyvernRoutes(app: FastifyInstance) {
       const res = await safeFetch(parsedUrl, {
         signal: controller.signal,
         policy: { allowedProtocols: ["https:"] },
-        allowedContentTypes: ["image/"],
         maxResponseBytes: 10 * 1024 * 1024,
       });
       if (!res.ok) return reply.status(404).send({ error: "Avatar not found" });
       const buf = Buffer.from(await res.arrayBuffer());
-      const ct = res.headers.get("content-type") || "image/webp";
+      const contentType = res.headers.get("content-type")?.toLowerCase() ?? "";
+      const imageInfo = isAllowedImageBuffer(buf);
+      if (contentType && !contentType.startsWith("image/") && !imageInfo) {
+        logger.warn("[bot-browser] Wyvern avatar returned unsupported content type: %s", contentType);
+        return reply.status(415).send({ error: "Unsupported avatar content type" });
+      }
+      if (!contentType && !imageInfo) {
+        logger.warn("[bot-browser] Wyvern avatar response was missing a usable image content type");
+        return reply.status(415).send({ error: "Unsupported avatar content type" });
+      }
+      const ct = contentType || imageInfo?.mimeType || "image/webp";
       return reply.header("Content-Type", ct).header("Cache-Control", "public, max-age=86400").send(buf);
     } finally {
       clearTimeout(timeout);

--- a/packages/server/src/routes/bot-browser.routes.ts
+++ b/packages/server/src/routes/bot-browser.routes.ts
@@ -2,7 +2,7 @@
 // Routes: Browser (proxy to character sources)
 // ──────────────────────────────────────────────
 import type { FastifyInstance } from "fastify";
-import { isAllowedImageBuffer, safeFetch } from "../utils/security.js";
+import { resolveValidatedImage, safeFetch } from "../utils/security.js";
 
 const CHUB_API_BASE = "https://api.chub.ai";
 const CHUB_AVATARS = "https://avatars.charhub.io";
@@ -16,12 +16,9 @@ async function fetchAvatarImage(url: string, signal: AbortSignal) {
   });
   if (!res.ok) return null;
   const buf = Buffer.from(await res.arrayBuffer());
-  const contentType = res.headers.get("content-type")?.toLowerCase() ?? "";
-  const imageInfo = isAllowedImageBuffer(buf);
-  if (!contentType.startsWith("image/") && !imageInfo) {
-    throw new Error("Unsupported avatar image content");
-  }
-  return { buf, mimeType: imageInfo?.mimeType ?? contentType };
+  const image = resolveValidatedImage(buf, res.headers.get("content-type") ?? "");
+  if (!image) throw new Error("Unsupported avatar image content");
+  return { buf, mimeType: image.mimeType };
 }
 
 /** Safely proxy-fetch an external URL, returning sanitised JSON. */

--- a/packages/server/src/routes/bot-browser.routes.ts
+++ b/packages/server/src/routes/bot-browser.routes.ts
@@ -18,10 +18,10 @@ async function fetchAvatarImage(url: string, signal: AbortSignal) {
   const buf = Buffer.from(await res.arrayBuffer());
   const contentType = res.headers.get("content-type")?.toLowerCase() ?? "";
   const imageInfo = isAllowedImageBuffer(buf);
-  if (!contentType.startsWith("image/") || !imageInfo) {
+  if (!contentType.startsWith("image/") && !imageInfo) {
     throw new Error("Unsupported avatar image content");
   }
-  return { buf, mimeType: imageInfo.mimeType };
+  return { buf, mimeType: imageInfo?.mimeType ?? contentType };
 }
 
 /** Safely proxy-fetch an external URL, returning sanitised JSON. */

--- a/packages/server/src/utils/security.ts
+++ b/packages/server/src/utils/security.ts
@@ -620,6 +620,13 @@ export async function safeFetch(url: string | URL, options: SafeFetchOptions = {
   throw new Error("Outbound request exceeded redirect limit");
 }
 
+export function resolveValidatedImage(buf: Buffer, contentTypeHeader: string): { mimeType: string } | null {
+  const contentType = contentTypeHeader.toLowerCase();
+  const imageInfo = isAllowedImageBuffer(buf);
+  if (!contentType.startsWith("image/") && !imageInfo) return null;
+  return { mimeType: imageInfo?.mimeType ?? contentType };
+}
+
 export function sanitizePathFilename(filename: string, allowedExts?: Set<string>): string {
   const safe = safeBasename(filename);
   const ext = extname(safe).toLowerCase();

--- a/packages/server/src/utils/security.ts
+++ b/packages/server/src/utils/security.ts
@@ -620,11 +620,14 @@ export async function safeFetch(url: string | URL, options: SafeFetchOptions = {
   throw new Error("Outbound request exceeded redirect limit");
 }
 
+const SAFE_HEADER_ONLY_IMAGE_TYPES = new Set(["image/png", "image/jpeg", "image/webp", "image/gif"]);
+
 export function resolveValidatedImage(buf: Buffer, contentTypeHeader: string): { mimeType: string } | null {
-  const contentType = contentTypeHeader.toLowerCase();
+  const contentType = contentTypeHeader.toLowerCase().split(";")[0]?.trim() ?? "";
   const imageInfo = isAllowedImageBuffer(buf);
-  if (!contentType.startsWith("image/") && !imageInfo) return null;
-  return { mimeType: imageInfo?.mimeType ?? contentType };
+  if (imageInfo) return { mimeType: imageInfo.mimeType };
+  if (SAFE_HEADER_ONLY_IMAGE_TYPES.has(contentType)) return { mimeType: contentType };
+  return null;
 }
 
 export function sanitizePathFilename(filename: string, allowedExts?: Set<string>): string {


### PR DESCRIPTION
**Closes #3319**

## Why this change

- Avatar thumbnails fail to load in the bot browser across JannyAI, DataCat, ChubAI, CharacterTavern, Wyvern, and Pygmalion due to several independent bugs in the server-side avatar proxy routes.

## What changed

- All providers — fetchAvatarImage guard changed from || to &&; images were being rejected whenever a CDN response omitted a Content-Type header even if the buffer was a valid image
- Wyvern — removed allowedContentTypes from safeFetch and replaced with post-download isAllowedImageBuffer check; imagedelivery.net omits Content-Type on image responses
- Pygmalion — raised avatar proxy cap 10MB→25MB and timeout 15s→30s for large card PNGs with embedded lore 
- DataCat — added media.datacat.run to host allowlist (CDN migrated from ella.janitorai.com); added Referer and User-Agent headers to pass hotlink checks
- CharacterTavern — fixed wrong CDN host from cards.character-tavern.com (Cloudflare-protected, blocks server-side requests) to ct-cards.storage.character-tavern.com (BunnyCDN, open); added thumbnail query params

## Validation

- [x] pnpm check passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [x] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [x] Above manual verification completed (describe below)
- [x] Read and followed CONTRIBUTING.md

### Manual verification notes

- Opened the bot browser on Zen, as well as Safari. All thumbnails now load for every card. All providers work correctly.

## Docs and release impact

- [x] No docs changes needed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved avatar loading reliability across browser-based character pages, including updated Character Tavern card/CDN URLs.
  * Enhanced avatar proxy behavior to better handle inconsistent headers vs. image contents and correctly derive the returned image type.
  * Reduced avatar failures for slower/larger images by increasing proxy timeouts and maximum download size.
  * Added/strengthened image validation for proxied avatars, returning clearer “unsupported” responses and setting appropriate response headers (including caching where applicable).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->