### PR TITLE
[codex] v2.1.1 issue sweep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,19 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 
 - Fixed Marinara profile/full backup exports so generated scene-video MP4s and reusable Conversation Call character video clips are included with their storage metadata and accepted on profile ZIP import (#3315).
 - Fixed Card Evolution Auditor review proposals being falsely marked stale from cached character data by refreshing the character card before validation, and added an explicit stale override path that appends edited replacement text after confirmation instead of blocking the proposal outright (#3314).
+- Fixed Memory Recall embedding creation for very large memories by chunking oversized recall text before sending it to embedding providers, preventing single giant entries from exceeding provider limits (#3317).
+- Fixed Windows/git updater and launcher flows so they use the pinned pnpm version, avoid stale aggregate clean/build commands, and rebuild shared/server/client in update-safe package steps (#3318, #3323, #3324).
+- Fixed Bot Browser avatar importing for sources that return generic or missing image content types, including Datacat, Character Tavern, Janitor/Janny, Pygmalion, and Wyvern avatar CDNs (#3319).
+- Fixed Game Mode NPC portrait generation so GM-generated NPC descriptions are distilled into canonical portrait guidance for the initial and later NPC asset prompts (#3321).
+- Fixed the Roleplay setup wizard's **Use Settings Presets** shortcut so it still seeds the selected character's first message when creating an empty chat (#3322).
+- Added phonetic name fields to Character and Persona metadata, resolves phonetic-name macros, and uses those values when sending Conversation Call voice lines to TTS so names can be pronounced correctly (#3325).
+- Fixed Conversation Call prompt macro resolution so live audio prompts, persona/character context, lorebook entries, daily history, and call transcript content resolve macros such as `{{user}}` before provider dispatch (#3326).
+- Fixed custom preset choice confirmation so edited multi-select preset variables can intentionally be saved empty instead of disabling **Confirm Choices** (#3327).
+- Fixed Conversation message avatars that were cropped in editors but appeared oversized in DMs/groups by restoring the relative avatar crop container (#3328).
+- Restored the Echo Chamber chat as a collapsible panel instead of making close/collapse hide the chamber permanently for the chat (#3329).
+- Fixed manual group Conversation character triggers so the prompted character receives recent visible group transcript context and does not answer from profile/lorebook content alone (#3330).
+- Fixed Text to Speech character voice assignment so users can add character voices using provider default voices, including ElevenLabs defaults, even before custom/account voices are loaded.
+- Added a per-chat Conversation Calls setting to disable generated bracketed voice cues for TTS providers that do not accept `[whispering]`, `[laughing]`, `[sighs]`, and similar tags.
 
 ## [2.1.0]
 

--- a/packages/client/src/components/characters/CharacterEditor.tsx
+++ b/packages/client/src/components/characters/CharacterEditor.tsx
@@ -1250,6 +1250,18 @@ function MetadataTab({
         </label>
         <label className="space-y-1.5">
           <span className="inline-flex items-center gap-1 text-xs font-medium text-[var(--muted-foreground)]">
+            Phonetic name{" "}
+            <HelpTooltip text="Optional pronunciation override used only when this character's name is sent to text-to-speech." />
+          </span>
+          <input
+            value={typeof formData.extensions?.phoneticName === "string" ? formData.extensions.phoneticName : ""}
+            onChange={(e) => updateExtension("phoneticName", e.target.value)}
+            className="w-full rounded-xl border border-[var(--border)] bg-[var(--secondary)] px-3 py-2 text-sm outline-none focus:border-[var(--primary)]/40 focus:ring-1 focus:ring-[var(--primary)]/20"
+            placeholder={formData.name}
+          />
+        </label>
+        <label className="space-y-1.5">
+          <span className="inline-flex items-center gap-1 text-xs font-medium text-[var(--muted-foreground)]">
             Creator{" "}
             <HelpTooltip text="The person who made this character. Useful for giving credit when sharing characters." />
           </span>

--- a/packages/client/src/components/chat/ChatArea.tsx
+++ b/packages/client/src/components/chat/ChatArea.tsx
@@ -345,6 +345,7 @@ function toCharacterMapValue(char: CharacterRow): CharacterMapValue {
     const extensions = data.extensions && typeof data.extensions === "object" ? data.extensions : {};
     return {
       name: data.name ?? "Unknown",
+      phoneticName: extensions.phoneticName || undefined,
       description: data.description ?? "",
       personality: data.personality ?? "",
       backstory: extensions.backstory ?? "",
@@ -373,6 +374,7 @@ function toCharacterMapValue(char: CharacterRow): CharacterMapValue {
 function areCharacterMapValuesEqual(a: CharacterMapValue, b: CharacterMapValue): boolean {
   return (
     a.name === b.name &&
+    a.phoneticName === b.phoneticName &&
     a.description === b.description &&
     a.personality === b.personality &&
     a.backstory === b.backstory &&
@@ -923,6 +925,7 @@ export function ChatArea() {
     return {
       id: persona.id,
       name: persona.name,
+      phoneticName: persona.phoneticName || undefined,
       description: persona.description ?? "",
       personality: persona.personality || undefined,
       scenario: persona.scenario || undefined,

--- a/packages/client/src/components/chat/ChatSettingsDrawer.tsx
+++ b/packages/client/src/components/chat/ChatSettingsDrawer.tsx
@@ -5168,6 +5168,39 @@ export function ChatSettingsDrawer({
 
                     <button
                       type="button"
+                      onClick={() => {
+                        updateMeta.mutate({
+                          id: chat.id,
+                          conversationCallVoiceCues: metadata.conversationCallVoiceCues === false ? true : false,
+                        });
+                      }}
+                      className="flex w-full items-center justify-between gap-3 rounded-lg bg-[var(--background)]/35 px-2.5 py-2 text-left transition-colors hover:bg-[var(--secondary)]/50"
+                    >
+                      <div className="min-w-0 flex-1">
+                        <span className="block text-[0.6875rem] font-medium text-[var(--foreground)]">
+                          Generate voice cues in [tags]
+                        </span>
+                        <p className="mt-0.5 text-[0.59375rem] leading-snug text-[var(--muted-foreground)]">
+                          Ask call models for cues like [whispering], [laughing], and [sighs] for TTS/video timing.
+                        </p>
+                      </div>
+                      <div
+                        className={cn(
+                          "mari-chat-option-switch h-5 w-9 shrink-0 rounded-full p-0.5 transition-colors",
+                          metadata.conversationCallVoiceCues !== false && "mari-chat-option-switch--active",
+                        )}
+                      >
+                        <div
+                          className={cn(
+                            "h-4 w-4 rounded-full bg-white shadow-sm transition-transform",
+                            metadata.conversationCallVoiceCues !== false && "translate-x-3.5",
+                          )}
+                        />
+                      </div>
+                    </button>
+
+                    <button
+                      type="button"
                       disabled={callSettingsDisabled}
                       onClick={() => {
                         patchConversationCallTtsConfig({

--- a/packages/client/src/components/chat/ChatSetupWizard.tsx
+++ b/packages/client/src/components/chat/ChatSetupWizard.tsx
@@ -1995,8 +1995,22 @@ function RoleplaySetupWizard({ chat, onFinish }: ChatSetupWizardProps) {
     onFinish();
   }, [chat.id, chatCharIds, createInitialGreetingForCharacter, customizeParameters, generationParameters, onFinish, updateMeta]);
 
+  const seedInitialGreetingsIfEmpty = useCallback(async () => {
+    if (chatCharIds.length === 0) return;
+    try {
+      const { count } = await api.get<{ count: number }>(`/chats/${chat.id}/message-count`);
+      if (count > 0) return;
+    } catch {
+      return;
+    }
+    for (const charId of chatCharIds) {
+      await createInitialGreetingForCharacter(charId);
+    }
+  }, [chat.id, chatCharIds, createInitialGreetingForCharacter]);
+
   const handleShortcutApply = useCallback(async () => {
     if (!shortcutPresetId) {
+      await seedInitialGreetingsIfEmpty();
       onFinish();
       return;
     }
@@ -2006,10 +2020,11 @@ function RoleplaySetupWizard({ chat, onFinish }: ChatSetupWizardProps) {
     } catch {
       /* fall through — still close the wizard */
     } finally {
+      await seedInitialGreetingsIfEmpty();
       setShortcutApplying(false);
       onFinish();
     }
-  }, [shortcutPresetId, chat.id, applyChatPreset, onFinish]);
+  }, [shortcutPresetId, chat.id, applyChatPreset, onFinish, seedInitialGreetingsIfEmpty]);
 
   // Search state for character & lorebook pickers
   const [charSearch, setCharSearch] = useState("");

--- a/packages/client/src/components/chat/ConversationCallSurface.tsx
+++ b/packages/client/src/components/chat/ConversationCallSurface.tsx
@@ -326,9 +326,12 @@ function pushCallTtsVideoChunk(
   text: string,
   videoKind: ConversationCallCharacterVideoClipKind,
   followKind?: "talking",
+  participants?: Participant[],
 ) {
   const trimmed = text.trim();
-  const audioText = stripCallTtsCueText(trimmed);
+  const audioText = participants
+    ? applyCallTtsPhoneticNames(stripCallTtsCueText(trimmed), participants)
+    : stripCallTtsCueText(trimmed);
   if (!trimmed || !audioText) return;
   const chunk = { text: trimmed, audioText, videoKind, followKind };
   chunks.push(...splitCallTtsVideoChunkByLimit(chunk));
@@ -338,7 +341,7 @@ function hasNonCueSpeech(text: string) {
   return text.replace(/\[[^\]\r\n]+\]/g, "").trim().length > 0;
 }
 
-function buildCallTtsVideoChunks(lines: string[], tone: string): CallTtsVideoChunk[] {
+function buildCallTtsVideoChunks(lines: string[], tone: string, participants?: Participant[]): CallTtsVideoChunk[] {
   const chunks: CallTtsVideoChunk[] = [];
   const cuePattern = /\[[^\]\r\n]+\]/g;
   let recognizedCueCount = 0;
@@ -356,18 +359,36 @@ function buildCallTtsVideoChunks(lines: string[], tone: string): CallTtsVideoChu
 
       const beforeCue = line.slice(cursor, cueStart);
       if (hasNonCueSpeech(beforeCue)) {
-        pushCallTtsVideoChunk(chunks, beforeCue, pendingCueKind ?? "talking", pendingCueKind ? "talking" : undefined);
+        pushCallTtsVideoChunk(
+          chunks,
+          beforeCue,
+          pendingCueKind ?? "talking",
+          pendingCueKind ? "talking" : undefined,
+          participants,
+        );
       } else {
         const beforeCueAudio = stripCallTtsCueText(beforeCue);
         if (beforeCueAudio) {
-          pushCallTtsVideoChunk(chunks, beforeCue, pendingCueKind ?? "talking", pendingCueKind ? "talking" : undefined);
+          pushCallTtsVideoChunk(
+            chunks,
+            beforeCue,
+            pendingCueKind ?? "talking",
+            pendingCueKind ? "talking" : undefined,
+            participants,
+          );
         }
       }
       pendingCueKind = reactionKind;
       recognizedCueCount += 1;
       cursor = cueStart + cue.length;
     }
-    pushCallTtsVideoChunk(chunks, line.slice(cursor), pendingCueKind ?? "talking", pendingCueKind ? "talking" : undefined);
+    pushCallTtsVideoChunk(
+      chunks,
+      line.slice(cursor),
+      pendingCueKind ?? "talking",
+      pendingCueKind ? "talking" : undefined,
+      participants,
+    );
   }
 
   if (chunks.length === 0) return [];
@@ -1897,7 +1918,7 @@ export function ConversationCallSurface({
 
               const sequenceItems = voiceBatch.flatMap((item) => {
                 const tone = item.turn.tone?.trim() ?? "";
-                const chunks = buildCallTtsVideoChunks([item.turn.content], tone);
+                const chunks = buildCallTtsVideoChunks([item.turn.content], tone, participants);
                 const participantId = item.participant?.id ?? null;
                 const voiceKey = [
                   session.id,
@@ -1908,7 +1929,7 @@ export function ConversationCallSurface({
                   .map((chunk) => ({
                     item,
                     chunk,
-                    text: applyCallTtsPhoneticNames(chunk.audioText.trim(), participants),
+                    text: chunk.audioText.trim(),
                     participantId,
                     voiceKey,
                     tone,

--- a/packages/client/src/components/chat/ConversationCallSurface.tsx
+++ b/packages/client/src/components/chat/ConversationCallSurface.tsx
@@ -102,6 +102,7 @@ interface ConversationCallSurfaceProps {
 type Participant = {
   id: string;
   name: string;
+  phoneticName?: string;
   avatarUrl: string | null;
   avatarCrop?: AvatarCropValue | null;
   kind: "user" | "character";
@@ -136,6 +137,7 @@ type CharacterVideoPlaybackState = {
 type CallVideoReactionKind = Exclude<ConversationCallCharacterVideoClipKind, "idle" | "talking">;
 type CallTtsVideoChunk = {
   text: string;
+  audioText: string;
   videoKind: ConversationCallCharacterVideoClipKind;
   followKind?: "talking";
 };
@@ -282,16 +284,41 @@ function detectCallVideoCueKind(value: string | null | undefined): CallVideoReac
 }
 
 function splitCallTtsVideoChunkByLimit(chunk: CallTtsVideoChunk): CallTtsVideoChunk[] {
-  if (chunk.text.length <= CALL_TTS_MAX_REQUEST_CHARS) return [chunk];
+  if (chunk.audioText.length <= CALL_TTS_MAX_REQUEST_CHARS) return [chunk];
   const pieces: CallTtsVideoChunk[] = [];
-  for (let start = 0; start < chunk.text.length; start += CALL_TTS_MAX_REQUEST_CHARS) {
+  for (let start = 0; start < chunk.audioText.length; start += CALL_TTS_MAX_REQUEST_CHARS) {
+    const audioText = chunk.audioText.slice(start, start + CALL_TTS_MAX_REQUEST_CHARS);
     pieces.push({
       ...chunk,
-      text: chunk.text.slice(start, start + CALL_TTS_MAX_REQUEST_CHARS),
+      text: audioText,
+      audioText,
       followKind: undefined,
     });
   }
   return pieces;
+}
+
+function stripCallTtsCueText(text: string) {
+  return text
+    .replace(/\[[^\]\r\n]+\]/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+function escapeRegExp(value: string) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function applyCallTtsPhoneticNames(text: string, participants: Participant[]) {
+  let next = text;
+  for (const participant of participants) {
+    const name = participant.name.trim();
+    const phoneticName = participant.phoneticName?.trim();
+    if (!name || !phoneticName || name === phoneticName) continue;
+    const pattern = new RegExp(`(^|[^\\p{L}\\p{N}_])(${escapeRegExp(name)})(?=$|[^\\p{L}\\p{N}_])`, "giu");
+    next = next.replace(pattern, (_match, prefix: string) => `${prefix}${phoneticName}`);
+  }
+  return next;
 }
 
 function pushCallTtsVideoChunk(
@@ -301,8 +328,9 @@ function pushCallTtsVideoChunk(
   followKind?: "talking",
 ) {
   const trimmed = text.trim();
-  if (!trimmed) return;
-  const chunk = { text: trimmed, videoKind, followKind };
+  const audioText = stripCallTtsCueText(trimmed);
+  if (!trimmed || !audioText) return;
+  const chunk = { text: trimmed, audioText, videoKind, followKind };
   chunks.push(...splitCallTtsVideoChunkByLimit(chunk));
 }
 
@@ -319,6 +347,7 @@ function buildCallTtsVideoChunks(lines: string[], tone: string): CallTtsVideoChu
     const line = rawLine.trim();
     if (!line) continue;
     let cursor = 0;
+    let pendingCueKind: CallVideoReactionKind | null = null;
     for (const match of line.matchAll(cuePattern)) {
       const cue = match[0] ?? "";
       const cueStart = match.index ?? 0;
@@ -327,15 +356,18 @@ function buildCallTtsVideoChunks(lines: string[], tone: string): CallTtsVideoChu
 
       const beforeCue = line.slice(cursor, cueStart);
       if (hasNonCueSpeech(beforeCue)) {
-        pushCallTtsVideoChunk(chunks, beforeCue, "talking");
-        pushCallTtsVideoChunk(chunks, cue, reactionKind, "talking");
+        pushCallTtsVideoChunk(chunks, beforeCue, pendingCueKind ?? "talking", pendingCueKind ? "talking" : undefined);
       } else {
-        pushCallTtsVideoChunk(chunks, `${beforeCue.trim()} ${cue}`.trim(), reactionKind, "talking");
+        const beforeCueAudio = stripCallTtsCueText(beforeCue);
+        if (beforeCueAudio) {
+          pushCallTtsVideoChunk(chunks, beforeCue, pendingCueKind ?? "talking", pendingCueKind ? "talking" : undefined);
+        }
       }
+      pendingCueKind = reactionKind;
       recognizedCueCount += 1;
       cursor = cueStart + cue.length;
     }
-    pushCallTtsVideoChunk(chunks, line.slice(cursor), "talking");
+    pushCallTtsVideoChunk(chunks, line.slice(cursor), pendingCueKind ?? "talking", pendingCueKind ? "talking" : undefined);
   }
 
   if (chunks.length === 0) return [];
@@ -1214,6 +1246,7 @@ export function ConversationCallSurface({
     const user: Participant = {
       id: "user",
       name: personaInfo?.name || "You",
+      phoneticName: personaInfo?.phoneticName,
       avatarUrl: personaInfo?.avatarUrl ?? null,
       avatarCrop: personaInfo?.avatarCrop,
       kind: "user",
@@ -1228,6 +1261,7 @@ export function ConversationCallSurface({
         {
           id: `character:${id}`,
           name: character?.name ?? "Character",
+          phoneticName: character?.phoneticName,
           avatarUrl: character?.avatarUrl ?? null,
           avatarCrop: character?.avatarCrop,
           kind: "character" as const,
@@ -1874,7 +1908,7 @@ export function ConversationCallSurface({
                   .map((chunk) => ({
                     item,
                     chunk,
-                    text: chunk.text.trim(),
+                    text: applyCallTtsPhoneticNames(chunk.audioText.trim(), participants),
                     participantId,
                     voiceKey,
                     tone,

--- a/packages/client/src/components/chat/ConversationMessageGrouped.tsx
+++ b/packages/client/src/components/chat/ConversationMessageGrouped.tsx
@@ -227,7 +227,7 @@ export function ConversationMessageGrouped({
                   className={["animate-[fadeSlideIn_0.4s_ease-out]", i > 0 && "mt-2"].filter(Boolean).join(" ")}
                 >
                 <div className="flex items-end gap-2">
-                  <div className="h-8 w-8 shrink-0 overflow-hidden rounded-full bg-[var(--accent)]">
+                  <div className="relative h-8 w-8 shrink-0 overflow-hidden rounded-full bg-[var(--accent)]">
                     {segAvatar ? (
                       <img
                         src={segAvatar}

--- a/packages/client/src/components/chat/EchoChamberPanel.tsx
+++ b/packages/client/src/components/chat/EchoChamberPanel.tsx
@@ -5,7 +5,7 @@
 // HUD widget position (top/left/right), and the top bar.
 // ──────────────────────────────────────────────
 import { useRef, useEffect, useMemo, useState, type CSSProperties } from "react";
-import { Trash2, RefreshCw } from "lucide-react";
+import { ChevronDown, MessageCircle, Trash2, RefreshCw } from "lucide-react";
 import { useAgentStore } from "../../stores/agent.store";
 import { useUIStore } from "../../stores/ui.store";
 import type { EchoChamberSide } from "../../stores/ui.store";
@@ -143,6 +143,8 @@ function CornerPicker({ current, onChange }: { current: EchoChamberSide; onChang
 export function EchoChamberPanel({ hiddenOnMobile = false }: EchoChamberPanelProps) {
   const echoChamberSide = useUIStore((s) => s.echoChamberSide);
   const setEchoChamberSide = useUIStore((s) => s.setEchoChamberSide);
+  const echoChamberOpen = useUIStore((s) => s.echoChamberOpen);
+  const toggleEchoChamber = useUIStore((s) => s.toggleEchoChamber);
   const echoMessages = useAgentStore((s) => s.echoMessages);
   const scrollRef = useRef<HTMLDivElement>(null);
 
@@ -364,6 +366,35 @@ export function EchoChamberPanel({ hiddenOnMobile = false }: EchoChamberPanelPro
 
   if (!echoEnabled || (isMobile && hiddenOnMobile)) return null;
   const visibleMessages = echoMessages.slice(0, visibleCount);
+  if (!echoChamberOpen) {
+    const collapsedStyle = { ...posStyle };
+    delete collapsedStyle.width;
+    return (
+      <button
+        type="button"
+        onClick={toggleEchoChamber}
+        className={cn(
+          ROLEPLAY_POPOVER_SHELL,
+          "absolute z-[60] pointer-events-auto inline-flex items-center gap-2 px-2.5 py-1.5 text-[0.6875rem] font-semibold uppercase tracking-wider",
+          "text-[var(--marinara-chat-chrome-button-text)] transition-colors hover:text-[var(--marinara-chat-chrome-button-text-hover)]",
+        )}
+        style={collapsedStyle}
+        title="Open Echo Chamber"
+      >
+        <span className="relative flex h-1.5 w-1.5 shrink-0">
+          <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-red-400 opacity-60" />
+          <span className="relative inline-flex h-1.5 w-1.5 rounded-full bg-red-500" />
+        </span>
+        <MessageCircle size="0.75rem" />
+        Echo
+        {visibleMessages.length > 0 && (
+          <span className="rounded-full bg-[var(--marinara-chat-chrome-highlight-bg)] px-1.5 py-0.5 text-[0.5625rem] font-normal text-[var(--marinara-chat-chrome-panel-muted)]">
+            {visibleMessages.length}
+          </span>
+        )}
+      </button>
+    );
+  }
 
   return (
     <div
@@ -389,6 +420,13 @@ export function EchoChamberPanel({ hiddenOnMobile = false }: EchoChamberPanelPro
           )}
         </span>
         <div className="flex items-center gap-1.5">
+          <button
+            onClick={toggleEchoChamber}
+            className="rounded p-0.5 text-[var(--marinara-chat-chrome-button-text)] transition-colors hover:bg-[var(--marinara-chat-chrome-highlight-bg-hover)] hover:text-[var(--marinara-chat-chrome-button-text-hover)]"
+            title="Collapse Echo Chamber"
+          >
+            <ChevronDown size="0.5625rem" />
+          </button>
           <button
             onClick={() => {
               if (!activeChatId || echoRetryBusy) return;

--- a/packages/client/src/components/chat/SummaryPopover.tsx
+++ b/packages/client/src/components/chat/SummaryPopover.tsx
@@ -1287,13 +1287,14 @@ export function SummaryPopover({
                     onCancelEdit={handleCancelEditEntry}
                     onSaveEdit={handleSaveEntry}
                     onDelete={() => void handleDeleteEntry(entry)}
+                    dockedToFooter={entry.id === visibleEntries[visibleEntries.length - 1]?.id}
                   />
                 ))
               ) : allVisibleEntriesHidden ? (
                 <button
                   type="button"
                   onClick={() => setShowInactiveSummaries(true)}
-                  className="w-full rounded-lg border border-dashed border-[var(--border)] bg-[var(--secondary)]/20 p-5 text-center text-xs italic text-[var(--muted-foreground)] transition-colors hover:bg-[var(--accent)]/35"
+                  className="w-full rounded-t-lg rounded-b-none border border-b-0 border-dashed border-[var(--border)] bg-[var(--secondary)]/20 p-5 text-center text-xs italic text-[var(--muted-foreground)] transition-colors hover:bg-[var(--accent)]/35"
                 >
                   Inactive summaries are hidden. Show inactive summaries to view them.
                 </button>
@@ -1301,7 +1302,7 @@ export function SummaryPopover({
                 <button
                   type="button"
                   onClick={handleCreateManualEntry}
-                  className="w-full rounded-lg border border-dashed border-[var(--border)] bg-[var(--secondary)]/20 p-5 text-center text-xs italic text-[var(--muted-foreground)] transition-colors hover:bg-[var(--accent)]/35"
+                  className="w-full rounded-t-lg rounded-b-none border border-b-0 border-dashed border-[var(--border)] bg-[var(--secondary)]/20 p-5 text-center text-xs italic text-[var(--muted-foreground)] transition-colors hover:bg-[var(--accent)]/35"
                 >
                   No summaries yet. Generate one or write your own.
                 </button>
@@ -1484,6 +1485,7 @@ interface SummaryEntryRowProps {
   onCancelEdit: () => void;
   onSaveEdit: () => void;
   onDelete: () => void;
+  dockedToFooter?: boolean;
 }
 
 function SummaryEntryRow({
@@ -1500,12 +1502,14 @@ function SummaryEntryRow({
   onCancelEdit,
   onSaveEdit,
   onDelete,
+  dockedToFooter = false,
 }: SummaryEntryRowProps) {
   const metaLine = getSummaryEntryMetaLine(entry);
   return (
     <div
       className={cn(
         "group overflow-hidden rounded-lg border shadow-sm shadow-black/10 ring-1 ring-[var(--border)]/25 transition-colors",
+        dockedToFooter && "rounded-b-none border-b-0",
         expanded
           ? "border-[var(--primary)]/45 bg-[var(--accent)]/22 ring-[var(--primary)]/20"
           : "border-[var(--border)]/80 bg-[var(--secondary)]/28 hover:border-[var(--primary)]/30 hover:bg-[var(--accent)]/30",

--- a/packages/client/src/components/chat/chat-area.types.ts
+++ b/packages/client/src/components/chat/chat-area.types.ts
@@ -5,6 +5,7 @@ export type CharacterMap = Map<
   string,
   {
     name: string;
+    phoneticName?: string;
     description?: string;
     personality?: string;
     backstory?: string;
@@ -24,6 +25,7 @@ export type CharacterMap = Map<
 export type PersonaInfo = {
   id?: string;
   name: string;
+  phoneticName?: string;
   description?: string;
   personality?: string;
   backstory?: string;

--- a/packages/client/src/components/panels/settings/TTSConfigCard.tsx
+++ b/packages/client/src/components/panels/settings/TTSConfigCard.tsx
@@ -100,6 +100,18 @@ const ELEVENLABS_TTS_MODELS = [
   "eleven_flash_v2",
 ];
 
+const ELEVENLABS_DEFAULT_VOICE_OPTIONS: VoiceOption[] = [
+  { id: "21m00Tcm4TlvDq8ikWAM", name: "Rachel", category: "ElevenLabs default" },
+  { id: "AZnzlk1XvdvUeBnXmlld", name: "Domi", category: "ElevenLabs default" },
+  { id: "EXAVITQu4vr4xnSDxMaL", name: "Bella", category: "ElevenLabs default" },
+  { id: "ErXwobaYiN019PkySvjV", name: "Antoni", category: "ElevenLabs default" },
+  { id: "MF3mGyEYCl7XYWbV9V6O", name: "Elli", category: "ElevenLabs default" },
+  { id: "TxGEqnHWrfWFTfGW9XjX", name: "Josh", category: "ElevenLabs default" },
+  { id: "VR6AewLTigWG4xSOukaG", name: "Arnold", category: "ElevenLabs default" },
+  { id: "pNInz6obpgDQGcFmaJgB", name: "Adam", category: "ElevenLabs default" },
+  { id: "yoZ06aMxZJJ28mfd3POQ", name: "Sam", category: "ElevenLabs default" },
+];
+
 type CharacterOption = {
   id: string;
   name: string;
@@ -562,7 +574,10 @@ export function TTSConfigCard() {
   const voices = voicesData?.voices ?? [];
   const fetchedVoiceOptions = voicesData?.voiceOptions ?? voices.map((v) => ({ id: v, name: v }));
   const voiceOptions = useMemo(() => {
-    let nextOptions = fetchedVoiceOptions;
+    let nextOptions = fetchedVoiceOptions.length > 0 ? fetchedVoiceOptions : [];
+    if (source === "elevenlabs" && nextOptions.length === 0) {
+      nextOptions = ELEVENLABS_DEFAULT_VOICE_OPTIONS;
+    }
     for (const savedVoice of [
       voice,
       narratorVoice,
@@ -573,7 +588,7 @@ export function TTSConfigCard() {
       nextOptions = addSavedVoiceOption(nextOptions, savedVoice);
     }
     return nextOptions;
-  }, [fetchedVoiceOptions, narratorVoice, npcDefaultFemaleVoices, npcDefaultMaleVoices, voice, voiceAssignments]);
+  }, [fetchedVoiceOptions, narratorVoice, npcDefaultFemaleVoices, npcDefaultMaleVoices, source, voice, voiceAssignments]);
   const voicesFromProvider = voicesData?.fromProvider ?? false;
   const elevenLabsMatchedMaleVoiceOptions = useMemo(
     () =>
@@ -1094,7 +1109,7 @@ export function TTSConfigCard() {
                 <button
                   type="button"
                   onClick={handleAddVoiceAssignment}
-                  disabled={voiceOptions.length === 0 || characterOptions.length === 0 || allCharactersAssigned}
+                  disabled={characterOptions.length === 0 || allCharactersAssigned}
                   className="mari-chrome-control w-full text-xs"
                 >
                   <Plus size="0.75rem" />

--- a/packages/client/src/components/personas/PersonaEditor.tsx
+++ b/packages/client/src/components/personas/PersonaEditor.tsx
@@ -173,6 +173,7 @@ const PERSONA_RPG_ATTRIBUTES_HELP =
 interface PersonaFormData {
   name: string;
   comment: string;
+  phoneticName: string;
   creator: string;
   personaVersion: string;
   creatorNotes: string;
@@ -198,6 +199,7 @@ interface PersonaRow {
   id: string;
   name: string;
   comment?: string;
+  phoneticName?: string;
   creator?: string;
   personaVersion?: string;
   creatorNotes?: string;
@@ -880,6 +882,7 @@ function createCharacterDataFromPersona(formData: PersonaFormData): CharacterDat
       depth_prompt: { prompt: "", depth: 4, role: "system" },
       backstory: formData.backstory ?? "",
       appearance: formData.appearance ?? "",
+      phoneticName: formData.phoneticName.trim() || undefined,
       nameColor: formData.nameColor || undefined,
       dialogueColor: formData.dialogueColor || undefined,
       boxColor: formData.boxColor || undefined,
@@ -986,6 +989,7 @@ export function PersonaEditor() {
     setFormData({
       name: rawPersona.name,
       comment: rawPersona.comment ?? "",
+      phoneticName: rawPersona.phoneticName ?? "",
       creator: rawPersona.creator ?? "",
       personaVersion: rawPersona.personaVersion ?? "1.0",
       creatorNotes: rawPersona.creatorNotes ?? "",
@@ -2752,6 +2756,18 @@ function PersonaMetadataTab({
             onChange={(e) => updateField("creator", e.target.value)}
             className="w-full rounded-xl border border-[var(--border)] bg-[var(--secondary)] px-3 py-2 text-sm outline-none focus:border-[var(--primary)]/40 focus:ring-1 focus:ring-[var(--primary)]/20"
             placeholder="Your name"
+          />
+        </label>
+        <label className="space-y-1.5">
+          <span className="inline-flex items-center gap-1 text-xs font-medium text-[var(--muted-foreground)]">
+            Phonetic name{" "}
+            <HelpTooltip text="Optional pronunciation override used only when your persona name is sent to text-to-speech." />
+          </span>
+          <input
+            value={formData.phoneticName}
+            onChange={(e) => updateField("phoneticName", e.target.value)}
+            className="w-full rounded-xl border border-[var(--border)] bg-[var(--secondary)] px-3 py-2 text-sm outline-none focus:border-[var(--primary)]/40 focus:ring-1 focus:ring-[var(--primary)]/20"
+            placeholder={formData.name}
           />
         </label>
         <label className="space-y-1.5">

--- a/packages/client/src/components/presets/ChoiceSelectionModal.tsx
+++ b/packages/client/src/components/presets/ChoiceSelectionModal.tsx
@@ -176,7 +176,7 @@ export function ChoiceSelectionModal({
 
   const allSelected = variables.every((v) => {
     const sel = selections[v.variableName];
-    if (v.multiSelect) return Array.isArray(sel) && sel.length > 0;
+    if (v.multiSelect) return Array.isArray(sel);
     // Single-option variables are boolean toggles — both ON and OFF are valid
     if (v.options.length === 1) return sel !== undefined;
     return sel !== undefined && sel !== "";

--- a/packages/client/src/hooks/use-characters.ts
+++ b/packages/client/src/hooks/use-characters.ts
@@ -972,6 +972,7 @@ export function useCreatePersona() {
       creator?: string;
       personaVersion?: string;
       creatorNotes?: string;
+      phoneticName?: string;
       personality?: string;
       scenario?: string;
       backstory?: string;
@@ -1007,6 +1008,7 @@ export function useUpdatePersona() {
       creator?: string;
       personaVersion?: string;
       creatorNotes?: string;
+      phoneticName?: string;
       description?: string;
       personality?: string;
       scenario?: string;

--- a/packages/client/src/stores/ui.store.ts
+++ b/packages/client/src/stores/ui.store.ts
@@ -1275,7 +1275,7 @@ export const useUIStore = create<UIState>()(
       hasCompletedOnboarding: false,
       gameTutorialDisabled: false,
       linkApiBannerDismissed: false,
-      echoChamberOpen: false,
+      echoChamberOpen: true,
       echoChamberSide: "bottom-right" as EchoChamberSide,
       userStatusManual: "active" as const,
       userStatus: "active" as UserStatus,

--- a/packages/server/src/db/migrate.ts
+++ b/packages/server/src/db/migrate.ts
@@ -103,6 +103,7 @@ const CREATE_TABLES: string[] = [
     creator TEXT NOT NULL DEFAULT '',
     persona_version TEXT NOT NULL DEFAULT '1.0',
     creator_notes TEXT NOT NULL DEFAULT '',
+    phonetic_name TEXT NOT NULL DEFAULT '',
     description TEXT NOT NULL DEFAULT '',
     personality TEXT NOT NULL DEFAULT '',
     scenario TEXT NOT NULL DEFAULT '',
@@ -814,6 +815,11 @@ const COLUMN_MIGRATIONS: ColumnMigration[] = [
   {
     table: "personas",
     column: "creator_notes",
+    definition: "TEXT NOT NULL DEFAULT ''",
+  },
+  {
+    table: "personas",
+    column: "phonetic_name",
     definition: "TEXT NOT NULL DEFAULT ''",
   },
   {

--- a/packages/server/src/db/schema/characters.ts
+++ b/packages/server/src/db/schema/characters.ts
@@ -44,6 +44,8 @@ export const personas = sqliteTable("personas", {
   personaVersion: text("persona_version").notNull().default("1.0"),
   /** Private notes about intended use, quirks, or recommended settings */
   creatorNotes: text("creator_notes").notNull().default(""),
+  /** Pronunciation override used when sending this persona name to TTS */
+  phoneticName: text("phonetic_name").notNull().default(""),
   description: text("description").notNull().default(""),
   personality: text("personality").notNull().default(""),
   scenario: text("scenario").notNull().default(""),

--- a/packages/server/src/routes/bot-browser-chartavern.routes.ts
+++ b/packages/server/src/routes/bot-browser-chartavern.routes.ts
@@ -3,11 +3,13 @@
 // ──────────────────────────────────────────────
 import type { FastifyInstance } from "fastify";
 import { logger } from "../lib/logger.js";
-import { isAllowedImageBuffer, safeFetch } from "../utils/security.js";
+import { resolveValidatedImage, safeFetch } from "../utils/security.js";
 
 const CT_API_BASE = "https://character-tavern.com/api";
-const CT_CARDS_CDN = "https://cards.character-tavern.com";
+const CT_CARDS_CDN = "https://ct-cards.storage.character-tavern.com";
 const AVATAR_PROXY_MAX_BYTES = 10 * 1024 * 1024;
+const CT_UA =
+  "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36";
 
 // In-memory session cookie store (persists until server restart)
 let ctSessionCookie: string = "";
@@ -32,15 +34,16 @@ async function fetchAvatarImage(url: string, signal: AbortSignal) {
     signal,
     policy: { allowedProtocols: ["https:"] },
     maxResponseBytes: AVATAR_PROXY_MAX_BYTES,
+    headers: {
+      "User-Agent": CT_UA,
+      Referer: "https://character-tavern.com/",
+    },
   });
   if (!res.ok) return null;
   const buf = Buffer.from(await res.arrayBuffer());
-  const contentType = res.headers.get("content-type")?.toLowerCase() ?? "";
-  const imageInfo = isAllowedImageBuffer(buf);
-  if (!contentType.startsWith("image/") || !imageInfo) {
-    throw new Error("Unsupported avatar image content");
-  }
-  return { buf, mimeType: imageInfo.mimeType };
+  const image = resolveValidatedImage(buf, res.headers.get("content-type") ?? "");
+  if (!image) throw new Error("Unsupported avatar image content");
+  return { buf, mimeType: image.mimeType };
 }
 
 /** Build headers for CT API — includes session cookie if stored */
@@ -280,7 +283,7 @@ export async function botBrowserChartavernRoutes(app: FastifyInstance) {
     const timeout = setTimeout(() => controller.abort(), 15_000);
     try {
       const primary = await fetchAvatarImage(
-        `${CT_CARDS_CDN}/cdn-cgi/image/format=auto,width=320,quality=85/${encodeURI(path)}.png`,
+        `${CT_CARDS_CDN}/${encodeURI(path)}.png?width=320&quality=85&format=auto`,
         controller.signal,
       );
       const image = primary ?? (await fetchAvatarImage(`${CT_CARDS_CDN}/${encodeURI(path)}.png`, controller.signal));

--- a/packages/server/src/routes/bot-browser-chartavern.routes.ts
+++ b/packages/server/src/routes/bot-browser-chartavern.routes.ts
@@ -29,7 +29,14 @@ async function proxyFetch(url: string, init?: RequestInit): Promise<unknown> {
   }
 }
 
-async function fetchAvatarImage(url: string, signal: AbortSignal) {
+async function fetchAvatarImage(url: string, signal: AbortSignal): Promise<
+  | {
+      status: "ok";
+      buf: Buffer;
+      mimeType: string;
+    }
+  | { status: "not_found" | "unsupported" }
+> {
   const res = await safeFetch(url, {
     signal,
     policy: { allowedProtocols: ["https:"] },
@@ -39,11 +46,11 @@ async function fetchAvatarImage(url: string, signal: AbortSignal) {
       Referer: "https://character-tavern.com/",
     },
   });
-  if (!res.ok) return null;
+  if (!res.ok) return { status: "not_found" };
   const buf = Buffer.from(await res.arrayBuffer());
   const image = resolveValidatedImage(buf, res.headers.get("content-type") ?? "");
-  if (!image) throw new Error("Unsupported avatar image content");
-  return { buf, mimeType: image.mimeType };
+  if (!image) return { status: "unsupported" };
+  return { status: "ok", buf, mimeType: image.mimeType };
 }
 
 /** Build headers for CT API — includes session cookie if stored */
@@ -286,14 +293,17 @@ export async function botBrowserChartavernRoutes(app: FastifyInstance) {
         `${CT_CARDS_CDN}/${encodeURI(path)}.png?width=320&quality=85&format=auto`,
         controller.signal,
       );
-      const image = primary ?? (await fetchAvatarImage(`${CT_CARDS_CDN}/${encodeURI(path)}.png`, controller.signal));
-      if (!image) return reply.status(404).send({ error: "Avatar not found" });
-      return reply.header("Content-Type", image.mimeType).header("Cache-Control", "public, max-age=86400").send(image.buf);
-    } catch (err) {
-      if ((err as Error).message.includes("Unsupported avatar image content")) {
-        return reply.status(415).send({ error: "Unsupported avatar content type" });
+      const fallback =
+        primary.status === "ok"
+          ? primary
+          : await fetchAvatarImage(`${CT_CARDS_CDN}/${encodeURI(path)}.png`, controller.signal);
+      if (fallback.status !== "ok") {
+        return fallback.status === "not_found"
+          ? reply.status(404).send({ error: "Avatar not found" })
+          : reply.status(415).send({ error: "Unsupported avatar content type" });
       }
-      throw err;
+      const image = fallback;
+      return reply.header("Content-Type", image.mimeType).header("Cache-Control", "public, max-age=86400").send(image.buf);
     } finally {
       clearTimeout(timeout);
     }

--- a/packages/server/src/routes/bot-browser-datacat.routes.ts
+++ b/packages/server/src/routes/bot-browser-datacat.routes.ts
@@ -6,7 +6,7 @@
 import { randomUUID } from "node:crypto";
 import type { FastifyInstance } from "fastify";
 import { logger } from "../lib/logger.js";
-import { isAllowedImageBuffer, safeFetch } from "../utils/security.js";
+import { resolveValidatedImage, safeFetch } from "../utils/security.js";
 
 const DATACAT_API_BASE = "https://datacat.run";
 const DATACAT_IMAGE_BASE = "https://ella.janitorai.com/bot-avatars/";
@@ -80,15 +80,16 @@ async function fetchAvatarImage(url: string, signal: AbortSignal) {
     signal,
     policy: { allowedProtocols: ["https:"] },
     maxResponseBytes: AVATAR_PROXY_MAX_BYTES,
+    headers: {
+      "User-Agent": DC_USER_AGENT,
+      Referer: `${DATACAT_API_BASE}/`,
+    },
   });
   if (!res.ok) return null;
   const buf = Buffer.from(await res.arrayBuffer());
-  const contentType = res.headers.get("content-type")?.toLowerCase() ?? "";
-  const imageInfo = isAllowedImageBuffer(buf);
-  if (!contentType.startsWith("image/") || !imageInfo) {
-    throw new Error("Unsupported avatar image content");
-  }
-  return { buf, mimeType: imageInfo.mimeType };
+  const image = resolveValidatedImage(buf, res.headers.get("content-type") ?? "");
+  if (!image) throw new Error("Unsupported avatar image content");
+  return { buf, mimeType: image.mimeType };
 }
 
 async function dcFetch(path: string): Promise<unknown> {
@@ -234,7 +235,8 @@ export async function botBrowserDatacatRoutes(app: FastifyInstance) {
       } catch {
         return reply.status(400).send({ error: "Invalid avatar URL" });
       }
-      if (parsed.protocol !== "https:" || parsed.hostname !== "ella.janitorai.com") {
+      const allowedDataCatHosts = new Set(["ella.janitorai.com", "media.datacat.run"]);
+      if (parsed.protocol !== "https:" || !allowedDataCatHosts.has(parsed.hostname)) {
         return reply.status(400).send({ error: "Unsupported avatar host" });
       }
       url = parsed.toString();

--- a/packages/server/src/routes/bot-browser-janny.routes.ts
+++ b/packages/server/src/routes/bot-browser-janny.routes.ts
@@ -2,7 +2,7 @@
 // Routes: Browser — JannyAI provider
 // ──────────────────────────────────────────────
 import type { FastifyInstance } from "fastify";
-import { isAllowedImageBuffer, safeFetch } from "../utils/security.js";
+import { resolveValidatedImage, safeFetch } from "../utils/security.js";
 
 const JANNY_SEARCH_URL = "https://search.jannyai.com/multi-search";
 const JANNY_IMAGE_BASE = "https://image.jannyai.com/bot-avatars/";
@@ -22,12 +22,9 @@ async function fetchAvatarImage(url: string, signal: AbortSignal) {
   });
   if (!res.ok) return null;
   const buf = Buffer.from(await res.arrayBuffer());
-  const contentType = res.headers.get("content-type")?.toLowerCase() ?? "";
-  const imageInfo = isAllowedImageBuffer(buf);
-  if (!contentType.startsWith("image/") || !imageInfo) {
-    throw new Error("Unsupported avatar image content");
-  }
-  return { buf, mimeType: imageInfo.mimeType };
+  const image = resolveValidatedImage(buf, res.headers.get("content-type") ?? "");
+  if (!image) throw new Error("Unsupported avatar image content");
+  return { buf, mimeType: image.mimeType };
 }
 
 function jannySearchHeaders(token: string): Record<string, string> {

--- a/packages/server/src/routes/bot-browser-pygmalion.routes.ts
+++ b/packages/server/src/routes/bot-browser-pygmalion.routes.ts
@@ -3,7 +3,7 @@
 // ──────────────────────────────────────────────
 import type { FastifyInstance } from "fastify";
 import { logger } from "../lib/logger.js";
-import { isAllowedImageBuffer, safeFetch } from "../utils/security.js";
+import { resolveValidatedImage, safeFetch } from "../utils/security.js";
 
 const PYGMALION_API_BASE = "https://server.pygmalion.chat/galatea.v1.PublicCharacterService";
 const PYGMALION_ORIGIN = "https://pygmalion.chat";
@@ -249,27 +249,24 @@ export async function botBrowserPygmalionRoutes(app: FastifyInstance) {
     const url = assetPath.startsWith("http") ? assetPath : `${PYGMALION_ASSETS_BASE}/${assetPath}`;
 
     const controller = new AbortController();
-    const timeout = setTimeout(() => controller.abort(), 15_000);
+    const timeout = setTimeout(() => controller.abort(), 30_000);
     try {
       const res = await safeFetch(url, {
         signal: controller.signal,
         policy: { allowedProtocols: ["https:"] },
-        maxResponseBytes: 10 * 1024 * 1024,
+        maxResponseBytes: 25 * 1024 * 1024,
       });
       if (!res.ok) return reply.status(404).send({ error: "Avatar not found" });
       const buf = Buffer.from(await res.arrayBuffer());
-      const contentType = res.headers.get("content-type")?.toLowerCase() ?? "";
-      const imageInfo = isAllowedImageBuffer(buf);
-      if (contentType && !contentType.startsWith("image/") && !imageInfo) {
-        logger.warn("[bot-browser] Pygmalion avatar returned unsupported content type: %s", contentType);
+      const image = resolveValidatedImage(buf, res.headers.get("content-type") ?? "");
+      if (!image) {
+        logger.warn(
+          "[bot-browser] Pygmalion avatar returned unsupported content type: %s",
+          res.headers.get("content-type") || "(missing)",
+        );
         return reply.status(415).send({ error: "Unsupported avatar content type" });
       }
-      if (!contentType && !imageInfo) {
-        logger.warn("[bot-browser] Pygmalion avatar response was missing a usable image content type");
-        return reply.status(415).send({ error: "Unsupported avatar content type" });
-      }
-      const ct = contentType || imageInfo?.mimeType || "image/webp";
-      return reply.header("Content-Type", ct).header("Cache-Control", "public, max-age=86400").send(buf);
+      return reply.header("Content-Type", image.mimeType).header("Cache-Control", "public, max-age=86400").send(buf);
     } finally {
       clearTimeout(timeout);
     }

--- a/packages/server/src/routes/bot-browser-wyvern.routes.ts
+++ b/packages/server/src/routes/bot-browser-wyvern.routes.ts
@@ -2,7 +2,8 @@
 // Routes: Browser — Wyvern provider
 // ──────────────────────────────────────────────
 import type { FastifyInstance } from "fastify";
-import { safeFetch } from "../utils/security.js";
+import { logger } from "../lib/logger.js";
+import { resolveValidatedImage, safeFetch } from "../utils/security.js";
 
 const WYVERN_API_BASE = "https://api.wyvern.chat";
 const WYVERN_IMAGE_BASE = "https://imagedelivery.net";
@@ -121,13 +122,19 @@ export async function botBrowserWyvernRoutes(app: FastifyInstance) {
       const res = await safeFetch(parsedUrl, {
         signal: controller.signal,
         policy: { allowedProtocols: ["https:"] },
-        allowedContentTypes: ["image/"],
         maxResponseBytes: 10 * 1024 * 1024,
       });
       if (!res.ok) return reply.status(404).send({ error: "Avatar not found" });
       const buf = Buffer.from(await res.arrayBuffer());
-      const ct = res.headers.get("content-type") || "image/webp";
-      return reply.header("Content-Type", ct).header("Cache-Control", "public, max-age=86400").send(buf);
+      const image = resolveValidatedImage(buf, res.headers.get("content-type") ?? "");
+      if (!image) {
+        logger.warn(
+          "[bot-browser] Wyvern avatar returned unsupported content type: %s",
+          res.headers.get("content-type") || "(missing)",
+        );
+        return reply.status(415).send({ error: "Unsupported avatar content type" });
+      }
+      return reply.header("Content-Type", image.mimeType).header("Cache-Control", "public, max-age=86400").send(buf);
     } finally {
       clearTimeout(timeout);
     }

--- a/packages/server/src/routes/bot-browser.routes.ts
+++ b/packages/server/src/routes/bot-browser.routes.ts
@@ -2,7 +2,7 @@
 // Routes: Browser (proxy to character sources)
 // ──────────────────────────────────────────────
 import type { FastifyInstance } from "fastify";
-import { isAllowedImageBuffer, safeFetch } from "../utils/security.js";
+import { resolveValidatedImage, safeFetch } from "../utils/security.js";
 
 const CHUB_API_BASE = "https://api.chub.ai";
 const CHUB_AVATARS = "https://avatars.charhub.io";
@@ -16,12 +16,9 @@ async function fetchAvatarImage(url: string, signal: AbortSignal) {
   });
   if (!res.ok) return null;
   const buf = Buffer.from(await res.arrayBuffer());
-  const contentType = res.headers.get("content-type")?.toLowerCase() ?? "";
-  const imageInfo = isAllowedImageBuffer(buf);
-  if (!contentType.startsWith("image/") || !imageInfo) {
-    throw new Error("Unsupported avatar image content");
-  }
-  return { buf, mimeType: imageInfo.mimeType };
+  const image = resolveValidatedImage(buf, res.headers.get("content-type") ?? "");
+  if (!image) throw new Error("Unsupported avatar image content");
+  return { buf, mimeType: image.mimeType };
 }
 
 /** Safely proxy-fetch an external URL, returning sanitised JSON. */

--- a/packages/server/src/routes/characters.routes.ts
+++ b/packages/server/src/routes/characters.routes.ts
@@ -1496,6 +1496,7 @@ export async function charactersRoutes(app: FastifyInstance) {
       creator?: string;
       personaVersion?: string;
       creatorNotes?: string;
+      phoneticName?: string;
       personality?: string;
       scenario?: string;
       backstory?: string;

--- a/packages/server/src/routes/conversation-calls.routes.ts
+++ b/packages/server/src/routes/conversation-calls.routes.ts
@@ -74,6 +74,8 @@ import {
   isSilentConversationSpotifyCommandError,
   playConversationSpotifyCommand,
 } from "../services/spotify/conversation-spotify-command.service.js";
+import { buildPromptMacroContext, resolveCharacterMacroData, resolvePromptMessageMacros } from "../services/prompt/index.js";
+import { cardPromptText } from "../services/generation/generation-text-utils.js";
 import {
   getConversationCallCharacterVideoFile,
   getConversationCallCustomVideoClipFile,
@@ -934,16 +936,52 @@ async function buildCallPrompt(input: {
   const characterIds = getAvailableCallCharacterIds(metadata, allCharacterIds, promptNow);
   const characters = await resolveCallCharacters(chars, characterIds, { metadata, now: promptNow });
   const persona = input.chat.personaId ? await chars.getPersona(input.chat.personaId) : null;
+  const personaPhoneticName = typeof persona?.phoneticName === "string" ? persona.phoneticName : "";
+  const personaDescription = cardPromptText(persona?.description);
+  const personaFields = {
+    phoneticName: personaPhoneticName,
+    personality: cardPromptText(persona?.personality),
+    scenario: cardPromptText(persona?.scenario),
+    backstory: cardPromptText(persona?.backstory),
+    appearance: cardPromptText(persona?.appearance),
+  };
+  const promptMacroContext = await buildPromptMacroContext({
+    db: input.app.db,
+    characterIds,
+    personaName: persona?.name || "User",
+    personaPhoneticName,
+    personaDescription,
+    personaFields,
+    variables: {},
+    groupScenarioOverrideText:
+      typeof metadata.groupScenarioText === "string" && metadata.groupScenarioText.trim()
+        ? metadata.groupScenarioText.trim()
+        : null,
+    lastInput: input.userText,
+    chatId: input.chat.id,
+    lastGenerationType: "conversation_call",
+  });
+  const callMacroProfilesById = (await resolveCharacterMacroData(input.app.db, characterIds)).profilesById;
+  const resolveCallMacros = (value: string, characterId?: string | null) =>
+    resolvePromptMessageMacros([{ content: value, characterId }], promptMacroContext, callMacroProfilesById)[0]?.content ??
+    value;
   const personaParts = persona
     ? [
         `Name: ${persona.name}`,
-        persona.description ? `Description: ${persona.description}` : "",
-        persona.personality ? `Personality: ${persona.personality}` : "",
-        persona.appearance ? `Appearance: ${persona.appearance}` : "",
+        personaDescription ? `Description: ${resolveCallMacros(personaDescription)}` : "",
+        personaFields.personality ? `Personality: ${resolveCallMacros(personaFields.personality)}` : "",
+        personaFields.scenario ? `Scenario: ${resolveCallMacros(personaFields.scenario)}` : "",
+        personaFields.backstory ? `Backstory: ${resolveCallMacros(personaFields.backstory)}` : "",
+        personaFields.appearance ? `Appearance: ${resolveCallMacros(personaFields.appearance)}` : "",
       ]
         .filter(Boolean)
         .join("\n")
     : "";
+  const promptCharacters = characters.map((character) => ({
+    ...character,
+    context: resolveCallMacros(character.context, character.id),
+    appearance: character.appearance ? resolveCallMacros(character.appearance, character.id) : null,
+  }));
   const callMessages = await createConversationCallsStorage(input.app.db).listMessages(input.session.id);
   const allChatMessages = await chats.listMessages(input.chat.id);
   const todayKey = promptNow.toISOString().slice(0, 10);
@@ -1085,16 +1123,16 @@ async function buildCallPrompt(input: {
   const lorebookText = activeEntries
     .filter((entry: any) => entry.enabled !== false)
     .slice(0, 30)
-    .map((entry: any) => `- ${entry.name ?? "Entry"}: ${entry.content ?? ""}`)
+    .map((entry: any) => `- ${entry.name ?? "Entry"}: ${resolveCallMacros(String(entry.content ?? ""))}`)
     .join("\n");
-  const characterText = characters.map((character) => `<character>\n${character.context}\n</character>`).join("\n\n");
+  const characterText = promptCharacters.map((character) => `<character>\n${character.context}\n</character>`).join("\n\n");
   const mainHistoryText = todaysMessages
     .map((message) => {
       const label =
         message.role === "user"
           ? persona?.name || "User"
           : characters.find((character) => character.id === message.characterId)?.name || message.role;
-      return `${label}: ${message.content}`;
+      return `${label}: ${resolveCallMacros(message.content, message.characterId)}`;
     })
     .join("\n");
   const characterNames = characters.map((character) => character.name).join(", ") || "the character";
@@ -1115,15 +1153,20 @@ async function buildCallPrompt(input: {
           "</commands>",
         ].join("\n")
       : "";
+  const voiceCuesEnabled = metadata.conversationCallVoiceCues !== false;
   const outputFormat = [
     "<output_format>",
-    'Return ONLY valid JSON with this shape: {"turns":[{"speakerName":"Exact character name","mode":"voice|text|command","content":"message text, voice text with TTS [cues], or command text","tone":"voice-only tone tags"}]}',
+    voiceCuesEnabled
+      ? 'Return ONLY valid JSON with this shape: {"turns":[{"speakerName":"Exact character name","mode":"voice|text|command","content":"message text, voice text with TTS [cues], or command text","tone":"voice-only tone tags"}]}'
+      : 'Return ONLY valid JSON with this shape: {"turns":[{"speakerName":"Exact character name","mode":"voice|text|command","content":"message text, plain voice text without bracketed cues, or command text","tone":"voice-only tone description"}]}',
     'Use mode "voice" for characters who can speak, "text" when a character should type, and "command" for hidden actions.',
     "One response may include several ordered turns from multiple characters. Use that when a natural live-call exchange should happen before the user speaks again.",
     "If multiple characters respond, order the turns exactly as they should be heard or displayed.",
     "In group calls, every speaking character must get their own turn so their assigned voice and video clips play on the correct participant.",
     'Do not put speaker prefixes like "Dottore (speech):" inside content. Put the speaker in speakerName and only the spoken/typed/command text in content.',
-    "For voice turns, include natural TTS cues inside content or tone when useful, such as [soft], [sighs], [brief pause], or [laughing quietly], etc.",
+    voiceCuesEnabled
+      ? "For voice turns, include natural TTS cues inside content or tone when useful, such as [soft], [sighs], [brief pause], or [laughing quietly], etc."
+      : "For voice turns, do not include bracketed voice cues such as [soft], [sighs], [brief pause], or [laughing quietly]. Keep voice content plain.",
     "</output_format>",
   ].join("\n");
 
@@ -1134,7 +1177,9 @@ async function buildCallPrompt(input: {
     "<instructions>",
     "The user's spoken audio may have been transcribed imperfectly. Deduce the likely intended meaning if a phrase looks slightly wrong.",
     characterVideoPresenceEnabled
-      ? "Character video presence is enabled. Voice turns will be spoken aloud and paired with character video-call clips, so use natural voice cues and visual-call awareness when appropriate."
+      ? voiceCuesEnabled
+        ? "Character video presence is enabled. Voice turns will be spoken aloud and paired with character video-call clips, so use natural voice cues and visual-call awareness when appropriate."
+        : "Character video presence is enabled. Voice turns will be spoken aloud and paired with character video-call clips, but bracketed voice cues are disabled for this chat; keep spoken content plain and natural."
       : "",
     nativeMedia.length > 0
       ? "The latest user input includes provider-native audio and/or video attachments. Use those attachments as the primary evidence for what the user said or showed; the written marker is only a label."
@@ -1185,8 +1230,8 @@ async function buildCallPrompt(input: {
         (message.kind === "speech" || message.kind === "text");
       const messageContent =
         isAssistantSpeechOrText && message.id !== lastAssistantHistoryMessageId
-          ? stripCallTtsCuesFromHistory(message.content)
-          : message.content;
+          ? stripCallTtsCuesFromHistory(resolveCallMacros(message.content, message.characterId))
+          : resolveCallMacros(message.content, message.characterId);
       const content =
         message.kind === "system" || message.role === "system"
           ? `Call note: ${messageContent}`

--- a/packages/server/src/routes/generate.routes.ts
+++ b/packages/server/src/routes/generate.routes.ts
@@ -2274,8 +2274,15 @@ export async function generateRoutes(app: FastifyInstance) {
       // (Game mode skips the fallback — persona must be explicitly selected in the setup wizard)
       let personaId: string | null = null;
       let personaName = "User";
+      let personaPhoneticName = "";
       let personaDescription = "";
-      let personaFields: { personality?: string; scenario?: string; backstory?: string; appearance?: string } = {};
+      let personaFields: {
+        phoneticName?: string;
+        personality?: string;
+        scenario?: string;
+        backstory?: string;
+        appearance?: string;
+      } = {};
       const allPersonas = await chars.listPersonas();
       // ── Game mode: apply segment edit overlays to message content ──
       // Users can edit individual narration/dialogue segments in the VN UI.
@@ -2300,9 +2307,11 @@ export async function generateRoutes(app: FastifyInstance) {
       if (persona) {
         personaId = persona.id as string;
         personaName = persona.name;
+        personaPhoneticName = typeof persona.phoneticName === "string" ? persona.phoneticName : "";
         personaDescription = cardPromptText(persona.description);
 
         personaFields = {
+          phoneticName: personaPhoneticName,
           personality: cardPromptText(persona.personality),
           scenario: cardPromptText(persona.scenario),
           backstory: cardPromptText(persona.backstory),
@@ -2524,6 +2533,7 @@ export async function generateRoutes(app: FastifyInstance) {
           db: app.db,
           characterIds: promptCharacterIds,
           personaName,
+          personaPhoneticName,
           personaDescription,
           personaFields,
           variables: {},
@@ -2746,6 +2756,7 @@ export async function generateRoutes(app: FastifyInstance) {
             characterIds: promptCharacterIds,
             personaId,
             personaName,
+            personaPhoneticName,
             personaDescription,
             personaFields,
             personaStats: (() => {
@@ -7885,6 +7896,29 @@ export async function generateRoutes(app: FastifyInstance) {
             `You may address ${personaName} or another character if that is what the context calls for, but do not speak or act for them.`,
           ].join("\n");
         };
+        const buildManualGroupRecentTranscript = (targetCharId: string) => {
+          if (!isGroupChat || groupResponseOrder !== "manual" || !targetCharId) return null;
+          const recentLines = chatMessages
+            .filter((message: any) => message.role === "user" || message.role === "assistant")
+            .slice(-12)
+            .map((message: any) => {
+              const speaker = resolveMessageSpeakerName(message);
+              const text = stripConversationPromptTimestamps(conversationPromptHistoryContent(message, chatMode))
+                .replace(/\s+/g, " ")
+                .trim()
+                .slice(0, 1200);
+              return text ? `${speaker}: ${text}` : "";
+            })
+            .filter(Boolean);
+          if (recentLines.length === 0) return null;
+          return [
+            `Recent visible group transcript for this manual character trigger:`,
+            `<recent_group_transcript>`,
+            recentLines.join("\n"),
+            `</recent_group_transcript>`,
+            `Use this transcript as the current scene context. Do not restart the chat, ignore the user's latest visible reply, or answer from lorebook/profile content alone.`,
+          ].join("\n");
+        };
 
         if (useIndividualLoop) {
           // Individual group mode: generate one response per character
@@ -7908,6 +7942,10 @@ export async function generateRoutes(app: FastifyInstance) {
             // Append "Respond ONLY as [name]" instruction
             const charInstruction = buildCharacterInstruction(charId, charName);
             const messagesWithInstruction = [...filterManualTargetProfileBlocks(runningMessages, charId)];
+            const manualTranscript = buildManualGroupRecentTranscript(charId);
+            if (manualTranscript) {
+              messagesWithInstruction.push({ role: "system", content: manualTranscript });
+            }
             // Add as a system message at the end (just before any trailing user message)
             if (charInstruction) {
               messagesWithInstruction.push({ role: "system", content: charInstruction });
@@ -7962,6 +8000,12 @@ export async function generateRoutes(app: FastifyInstance) {
 
           if (generationGuideInstruction) {
             sentMessages.push({ role: "system", content: generationGuideInstruction });
+          }
+          if (targetCharId) {
+            const manualTranscript = buildManualGroupRecentTranscript(targetCharId);
+            if (manualTranscript) {
+              sentMessages.push({ role: "system", content: manualTranscript });
+            }
           }
 
           if (mentionedConversationCharacters.length > 0 && !regenGroupChatIndividual) {

--- a/packages/server/src/routes/tts.routes.ts
+++ b/packages/server/src/routes/tts.routes.ts
@@ -19,6 +19,17 @@ import { safeFetch } from "../utils/security.js";
 // OpenAI built-in voices used as fallback when the provider has no /audio/voices endpoint
 const OPENAI_FALLBACK_VOICES = ["alloy", "ash", "coral", "echo", "fable", "nova", "onyx", "sage", "shimmer"];
 const XAI_FALLBACK_VOICES = ["eve", "ara", "rex", "sal", "leo"];
+const ELEVENLABS_DEFAULT_VOICES: VoiceOption[] = [
+  { id: "21m00Tcm4TlvDq8ikWAM", name: "Rachel", category: "ElevenLabs default" },
+  { id: "AZnzlk1XvdvUeBnXmlld", name: "Domi", category: "ElevenLabs default" },
+  { id: "EXAVITQu4vr4xnSDxMaL", name: "Bella", category: "ElevenLabs default" },
+  { id: "ErXwobaYiN019PkySvjV", name: "Antoni", category: "ElevenLabs default" },
+  { id: "MF3mGyEYCl7XYWbV9V6O", name: "Elli", category: "ElevenLabs default" },
+  { id: "TxGEqnHWrfWFTfGW9XjX", name: "Josh", category: "ElevenLabs default" },
+  { id: "VR6AewLTigWG4xSOukaG", name: "Arnold", category: "ElevenLabs default" },
+  { id: "pNInz6obpgDQGcFmaJgB", name: "Adam", category: "ElevenLabs default" },
+  { id: "yoZ06aMxZJJ28mfd3POQ", name: "Sam", category: "ElevenLabs default" },
+];
 
 const TTS_SOURCE_DEFAULTS: Record<TTSSource, { baseUrl: string; model: string }> = {
   openai: {
@@ -149,7 +160,7 @@ function responseFromVoiceOptions(
 
 function fallbackVoices(source: TTSSource): TTSVoicesResponse {
   if (source === "elevenlabs") {
-    return responseFromVoiceOptions(source, [], false);
+    return responseFromVoiceOptions(source, ELEVENLABS_DEFAULT_VOICES, false);
   }
 
   if (source === "pockettts") {

--- a/packages/server/src/routes/updates.routes.ts
+++ b/packages/server/src/routes/updates.routes.ts
@@ -54,9 +54,10 @@ const UPDATE_CHANNELS: Record<UpdateChannel, UpdateChannelInfo> = {
 const DEFAULT_PNPM_VERSION = "10.33.2";
 const PNPM_NONINTERACTIVE_ARGS = ["--config.trustPolicy=off", "--config.confirmModulesPurge=false"];
 const PNPM_UPDATE_INSTALL_ARGS = ["install", "--force", "--frozen-lockfile"];
+const MANUAL_PNPM_COMMAND = `corepack pnpm@${DEFAULT_PNPM_VERSION}`;
 const DOCKER_IMAGE = "ghcr.io/pasta-devs/marinara-engine";
 const MANUAL_GIT_UPDATE_COMMAND =
-  "git fetch origin +refs/heads/main:refs/remotes/origin/main && (git merge --ff-only origin/main || git checkout --detach origin/main) && pnpm --config.trustPolicy=off --config.confirmModulesPurge=false install --force --frozen-lockfile && pnpm build && pnpm start";
+  `git fetch origin +refs/heads/main:refs/remotes/origin/main && (git merge --ff-only origin/main || git checkout --detach origin/main) && ${MANUAL_PNPM_COMMAND} --config.trustPolicy=off --config.confirmModulesPurge=false install --force --frozen-lockfile && ${MANUAL_PNPM_COMMAND} --filter @marinara-engine/shared build && ${MANUAL_PNPM_COMMAND} --filter @marinara-engine/server --filter @marinara-engine/client --parallel run build && ${MANUAL_PNPM_COMMAND} start`;
 const DOCKER_UPDATE_COMMAND = "docker compose pull && docker compose up -d";
 const ANDROID_APK_NOTICE =
   "> [!IMPORTANT]\n" +
@@ -169,9 +170,9 @@ function getManualGitApplyCommand(channel = UPDATE_CHANNELS.stable, platform: Se
       : `(git merge --ff-only ${channel.targetRef} || git checkout --detach ${channel.targetRef})`;
   const buildCommand =
     platform === "android-termux"
-      ? "pnpm --filter @marinara-engine/shared build && pnpm --filter @marinara-engine/server build && pnpm --filter @marinara-engine/client build"
-      : "pnpm --filter @marinara-engine/shared build && pnpm --filter @marinara-engine/server --filter @marinara-engine/client --parallel run build";
-  return `git fetch ${UPDATE_REMOTE} ${channel.fetchRef} && ${checkoutCommand} && pnpm --config.trustPolicy=off --config.confirmModulesPurge=false ${PNPM_UPDATE_INSTALL_ARGS.join(" ")} && ${buildCommand}`;
+      ? `${MANUAL_PNPM_COMMAND} --filter @marinara-engine/shared build && ${MANUAL_PNPM_COMMAND} --filter @marinara-engine/server build && ${MANUAL_PNPM_COMMAND} --filter @marinara-engine/client build`
+      : `${MANUAL_PNPM_COMMAND} --filter @marinara-engine/shared build && ${MANUAL_PNPM_COMMAND} --filter @marinara-engine/server --filter @marinara-engine/client --parallel run build`;
+  return `git fetch ${UPDATE_REMOTE} ${channel.fetchRef} && ${checkoutCommand} && ${MANUAL_PNPM_COMMAND} --config.trustPolicy=off --config.confirmModulesPurge=false ${PNPM_UPDATE_INSTALL_ARGS.join(" ")} && ${buildCommand}`;
 }
 
 function getManualUpdateCommand(installType: InstallType, platform: ServerPlatform, channel = UPDATE_CHANNELS.stable) {
@@ -385,7 +386,7 @@ async function resolvePinnedPnpmRunner(root: string): Promise<PnpmRunner> {
       timeout: 10_000,
       shell,
     });
-    if (stdout.trim()) {
+    if (stdout.trim() === pnpmVersion) {
       return { command: "pnpm", prefixArgs: [] };
     }
   } catch {
@@ -876,7 +877,7 @@ export async function updatesRoutes(app: FastifyInstance) {
       const pnpmVersion = getPinnedPnpmVersion(root);
       return reply.status(500).send({
         error: `Update failed: ${message}`,
-        hint: `You can try running the update manually: ${getManualGitApplyCommand(channel)}. If pnpm is unavailable, run npm install -g pnpm@${pnpmVersion} first.`,
+        hint: `You can try running the update manually: ${getManualGitApplyCommand(channel)}. If Corepack cannot launch pnpm ${pnpmVersion}, install the pinned version with npm install -g pnpm@${pnpmVersion} and rerun the command.`,
       });
     }
   });

--- a/packages/server/src/routes/updates.routes.ts
+++ b/packages/server/src/routes/updates.routes.ts
@@ -163,16 +163,20 @@ async function getUpdateChannelForCheckout(root: string, branch: string | null |
   return UPDATE_CHANNELS.stable;
 }
 
-function getManualGitApplyCommand(channel = UPDATE_CHANNELS.stable, platform: ServerPlatform = "unknown") {
+function getManualGitApplyCommand(
+  channel = UPDATE_CHANNELS.stable,
+  platform: ServerPlatform = "unknown",
+  pnpmCommand = MANUAL_PNPM_COMMAND,
+) {
   const checkoutCommand =
     channel.id === "staging"
       ? `git show-ref --verify --quiet refs/heads/${channel.branch} && (git checkout ${channel.branch} && git merge --ff-only ${channel.targetRef}) || git checkout -b ${channel.branch} ${channel.targetRef}`
       : `(git merge --ff-only ${channel.targetRef} || git checkout --detach ${channel.targetRef})`;
   const buildCommand =
     platform === "android-termux"
-      ? `${MANUAL_PNPM_COMMAND} --filter @marinara-engine/shared build && ${MANUAL_PNPM_COMMAND} --filter @marinara-engine/server build && ${MANUAL_PNPM_COMMAND} --filter @marinara-engine/client build`
-      : `${MANUAL_PNPM_COMMAND} --filter @marinara-engine/shared build && ${MANUAL_PNPM_COMMAND} --filter @marinara-engine/server --filter @marinara-engine/client --parallel run build`;
-  return `git fetch ${UPDATE_REMOTE} ${channel.fetchRef} && ${checkoutCommand} && ${MANUAL_PNPM_COMMAND} --config.trustPolicy=off --config.confirmModulesPurge=false ${PNPM_UPDATE_INSTALL_ARGS.join(" ")} && ${buildCommand}`;
+      ? `${pnpmCommand} --filter @marinara-engine/shared build && ${pnpmCommand} --filter @marinara-engine/server build && ${pnpmCommand} --filter @marinara-engine/client build`
+      : `${pnpmCommand} --filter @marinara-engine/shared build && ${pnpmCommand} --filter @marinara-engine/server --filter @marinara-engine/client --parallel run build`;
+  return `git fetch ${UPDATE_REMOTE} ${channel.fetchRef} && ${checkoutCommand} && ${pnpmCommand} --config.trustPolicy=off --config.confirmModulesPurge=false ${PNPM_UPDATE_INSTALL_ARGS.join(" ")} && ${buildCommand}`;
 }
 
 function getManualUpdateCommand(installType: InstallType, platform: ServerPlatform, channel = UPDATE_CHANNELS.stable) {
@@ -875,9 +879,10 @@ export async function updatesRoutes(app: FastifyInstance) {
     } catch (err: unknown) {
       const message = err instanceof Error ? err.message : String(err);
       const pnpmVersion = getPinnedPnpmVersion(root);
+      const manualPnpmCommand = `corepack pnpm@${pnpmVersion}`;
       return reply.status(500).send({
         error: `Update failed: ${message}`,
-        hint: `You can try running the update manually: ${getManualGitApplyCommand(channel)}. If Corepack cannot launch pnpm ${pnpmVersion}, install the pinned version with npm install -g pnpm@${pnpmVersion} and rerun the command.`,
+        hint: `You can try running the update manually: ${getManualGitApplyCommand(channel, serverPlatform, manualPnpmCommand)}. If Corepack cannot launch pnpm ${pnpmVersion}, install the pinned version with npm install -g pnpm@${pnpmVersion} and rerun the command.`,
       });
     }
   });

--- a/packages/server/src/services/game/game-asset-generation.ts
+++ b/packages/server/src/services/game/game-asset-generation.ts
@@ -489,16 +489,20 @@ function compileGameImagePrompt(
   req: Pick<
     NpcPortraitRequest | BackgroundGenRequest | SceneIllustrationGenRequest,
     "styleProfiles" | "styleProfileId" | "imgDefaults" | "artStyle"
-  >,
+  > & { appearance?: string | null },
   kind: "portrait" | "background" | "illustration",
   prompt: string,
   maxLength: number,
   hardNegative?: string,
   negativePrompt?: string | null,
 ) {
+  const canonicalAppearance = kind === "portrait" && typeof req.appearance === "string" ? req.appearance.trim() : "";
+  const canonicalPrefix = canonicalAppearance
+    ? `Required canonical NPC visual profile: ${canonicalAppearance.slice(0, 700)}`
+    : "";
   if (!req.styleProfiles) {
     return {
-      prompt: prompt.slice(0, maxLength),
+      prompt: [canonicalPrefix, prompt].filter(Boolean).join(". ").slice(0, maxLength),
       negativePrompt: [negativePrompt, hardNegative].filter(Boolean).join(", "),
     };
   }
@@ -512,8 +516,9 @@ function compileGameImagePrompt(
     imageDefaults: req.imgDefaults,
     generatedStyle: req.artStyle,
   });
+  const protectedPrompt = [canonicalPrefix, compiled.prompt].filter(Boolean).join(", ");
   return {
-    prompt: compiled.prompt.slice(0, maxLength),
+    prompt: protectedPrompt.slice(0, maxLength),
     negativePrompt: compiled.negativePrompt,
   };
 }

--- a/packages/server/src/services/memory-recall.ts
+++ b/packages/server/src/services/memory-recall.ts
@@ -134,7 +134,7 @@ function splitLongMemoryText(text: string, maxChars = MAX_EMBEDDING_CHUNK_CHARS)
   return parts;
 }
 
-function splitMemoryChunksForEmbedding<T extends { content: string }>(chunks: T[]): T[] {
+function splitMemoryChunksForEmbedding<T extends { content: string; messageCount: number }>(chunks: T[]): T[] {
   const expanded: T[] = [];
   let splitCount = 0;
   for (const chunk of chunks) {
@@ -147,6 +147,7 @@ function splitMemoryChunksForEmbedding<T extends { content: string }>(chunks: T[
     for (let index = 0; index < parts.length; index += 1) {
       expanded.push({
         ...chunk,
+        messageCount: index === 0 ? chunk.messageCount : 0,
         content: `[Memory chunk part ${index + 1}/${parts.length}]\n${parts[index]}`,
       });
     }
@@ -185,7 +186,7 @@ async function pruneStaleNativeMemoryChunks(
       ? messageTimes.filter((createdAt) => createdAt >= chunk.firstMessageAt && createdAt <= chunk.lastMessageAt).length
       : 0;
 
-    if (!hasAnchors || spanMessageCount !== chunk.messageCount) {
+    if (!hasAnchors || (chunk.messageCount > 0 && spanMessageCount !== chunk.messageCount)) {
       invalidateFrom = chunk.firstMessageAt;
       break;
     }

--- a/packages/server/src/services/memory-recall.ts
+++ b/packages/server/src/services/memory-recall.ts
@@ -16,6 +16,9 @@ let warnedUnavailableEmbeddingSource = false;
 /** How many messages per chunk. */
 const CHUNK_SIZE = 5;
 
+/** Keep embedding requests comfortably below common 8k-token embedding ceilings. */
+const MAX_EMBEDDING_CHUNK_CHARS = 18_000;
+
 /** Minimum similarity score to include a memory in results. */
 const SIMILARITY_THRESHOLD = 0.25;
 
@@ -107,6 +110,51 @@ export async function embedMemoryRecallTexts(
 function normalizeReadBehindMessageCount(value: number | null | undefined): number {
   if (typeof value !== "number" || !Number.isFinite(value) || value <= 0) return 0;
   return Math.floor(value);
+}
+
+function splitLongMemoryText(text: string, maxChars = MAX_EMBEDDING_CHUNK_CHARS): string[] {
+  const normalized = text.trim();
+  if (!normalized) return [];
+  if (normalized.length <= maxChars) return [normalized];
+
+  const parts: string[] = [];
+  let remaining = normalized;
+
+  while (remaining.length > maxChars) {
+    const windowText = remaining.slice(0, maxChars);
+    const breakAt =
+      Math.max(windowText.lastIndexOf("\n\n"), windowText.lastIndexOf("\n"), windowText.lastIndexOf(". ")) || maxChars;
+    const sliceAt = breakAt < maxChars * 0.5 ? maxChars : breakAt;
+    const part = remaining.slice(0, sliceAt).trim();
+    if (part) parts.push(part);
+    remaining = remaining.slice(sliceAt).trim();
+  }
+
+  if (remaining) parts.push(remaining);
+  return parts;
+}
+
+function splitMemoryChunksForEmbedding<T extends { content: string }>(chunks: T[]): T[] {
+  const expanded: T[] = [];
+  let splitCount = 0;
+  for (const chunk of chunks) {
+    const parts = splitLongMemoryText(chunk.content);
+    if (parts.length <= 1) {
+      expanded.push({ ...chunk, content: parts[0] ?? chunk.content });
+      continue;
+    }
+    splitCount += parts.length - 1;
+    for (let index = 0; index < parts.length; index += 1) {
+      expanded.push({
+        ...chunk,
+        content: `[Memory chunk part ${index + 1}/${parts.length}]\n${parts[index]}`,
+      });
+    }
+  }
+  if (splitCount > 0) {
+    logger.debug("[memory-recall] Split oversized memory input into %d additional embedding chunk(s)", splitCount);
+  }
+  return expanded;
 }
 
 async function pruneStaleNativeMemoryChunks(
@@ -272,20 +320,22 @@ export async function chunkAndEmbedMessages(
   }
 
   if (chunksToCreate.length === 0) return;
+  const embeddableChunks = splitMemoryChunksForEmbedding(chunksToCreate);
+  if (embeddableChunks.length === 0) return;
 
   // Embed all chunks using local model
-  const texts = chunksToCreate.map((c) => c.content);
+  const texts = embeddableChunks.map((c) => c.content);
   const embeddings = await embedMemoryRecallTexts(texts, options);
   if (
-    embeddings.length !== chunksToCreate.length ||
+    embeddings.length !== embeddableChunks.length ||
     embeddings.some((embedding) => !Array.isArray(embedding) || embedding.length === 0)
   ) {
     logger.debug(
       "[memory-recall] Skipping %d memory chunk(s) for chat %s because embedding generation returned %d/%d usable vectors",
-      chunksToCreate.length,
+      embeddableChunks.length,
       chatId,
       embeddings.filter((embedding) => Array.isArray(embedding) && embedding.length > 0).length,
-      chunksToCreate.length,
+      embeddableChunks.length,
     );
     return;
   }
@@ -309,8 +359,8 @@ export async function chunkAndEmbedMessages(
 
   // Store chunks
   const timestamp = now();
-  for (let i = 0; i < chunksToCreate.length; i++) {
-    const chunk = chunksToCreate[i]!;
+  for (let i = 0; i < embeddableChunks.length; i++) {
+    const chunk = embeddableChunks[i]!;
     await db.insert(memoryChunks).values({
       id: newId(),
       chatId,
@@ -323,7 +373,7 @@ export async function chunkAndEmbedMessages(
     });
   }
 
-  logger.debug("[memory-recall] Created %d chunk(s) for chat %s", chunksToCreate.length, chatId);
+  logger.debug("[memory-recall] Created %d chunk(s) for chat %s", embeddableChunks.length, chatId);
 }
 
 /**

--- a/packages/server/src/services/prompt/assembler.ts
+++ b/packages/server/src/services/prompt/assembler.ts
@@ -136,8 +136,10 @@ export interface AssemblerInput {
   characterIds: string[];
   personaId?: string | null;
   personaName: string;
+  personaPhoneticName?: string;
   personaDescription: string;
   personaFields?: {
+    phoneticName?: string;
     personality?: string;
     scenario?: string;
     backstory?: string;
@@ -302,6 +304,7 @@ export async function assemblePrompt(input: AssemblerInput): Promise<AssemblerOu
     db: input.db,
     characterIds: input.characterIds,
     personaName: input.personaName,
+    personaPhoneticName: input.personaPhoneticName,
     personaDescription: input.personaDescription,
     personaFields: input.personaFields,
     variables: variableValues,

--- a/packages/server/src/services/prompt/macro-context.ts
+++ b/packages/server/src/services/prompt/macro-context.ts
@@ -25,6 +25,7 @@ export interface BuildPromptMacroContextInput {
   db: DB;
   characterIds: string[];
   personaName: string;
+  personaPhoneticName?: string;
   personaDescription?: string;
   personaFields?: PersonaFields;
   variables?: Record<string, string>;
@@ -39,6 +40,7 @@ export interface BuildPromptMacroContextInput {
 
 export interface CharacterMacroData {
   names: string[];
+  phoneticNames: string[];
   profiles: NonNullable<MacroContext["characterProfiles"]>;
   profilesById: Map<string, CharacterMacroProfile>;
   primaryFields?: NonNullable<MacroContext["characterFields"]>;
@@ -189,10 +191,11 @@ function parseCharacterData(raw: unknown): CharacterData | null {
 }
 
 export async function resolveCharacterMacroData(db: DB, characterIds: string[]): Promise<CharacterMacroData> {
-  if (characterIds.length === 0) return { names: [], profiles: [], profilesById: new Map() };
+  if (characterIds.length === 0) return { names: [], phoneticNames: [], profiles: [], profilesById: new Map() };
 
   const chars = createCharactersStorage(db);
   const names: string[] = [];
+  const phoneticNames: string[] = [];
   const profiles: CharacterMacroData["profiles"] = [];
   const profilesById = new Map<string, CharacterMacroProfile>();
   let primaryFields: CharacterMacroData["primaryFields"] | undefined;
@@ -203,10 +206,16 @@ export async function resolveCharacterMacroData(db: DB, characterIds: string[]):
     if (!data) continue;
 
     if (data.name) names.push(data.name);
+    const phoneticName =
+      typeof data.extensions?.phoneticName === "string" && data.extensions.phoneticName.trim()
+        ? data.extensions.phoneticName.trim()
+        : "";
+    phoneticNames.push(phoneticName || data.name || "Character");
 
     const description = data.description ?? "";
     const profile = {
       name: data.name ?? "Character",
+      phoneticName,
       description,
       personality: data.personality ?? "",
       backstory: data.extensions?.backstory ?? "",
@@ -222,6 +231,7 @@ export async function resolveCharacterMacroData(db: DB, characterIds: string[]):
 
     if (!primaryFields) {
       primaryFields = {
+        phoneticName: profile.phoneticName,
         description: profile.description,
         personality: profile.personality,
         backstory: profile.backstory,
@@ -234,7 +244,7 @@ export async function resolveCharacterMacroData(db: DB, characterIds: string[]):
     }
   }
 
-  return { names, profiles, profilesById, primaryFields };
+  return { names, phoneticNames, profiles, profilesById, primaryFields };
 }
 
 export async function buildPromptMacroContext(input: BuildPromptMacroContextInput): Promise<MacroContext> {
@@ -243,7 +253,9 @@ export async function buildPromptMacroContext(input: BuildPromptMacroContextInpu
 
   return {
     user: input.personaName || "User",
+    userPhonetic: input.personaPhoneticName || input.personaFields?.phoneticName || input.personaName || "User",
     char: characterMacroData.names[0] || "Character",
+    charPhonetic: characterMacroData.phoneticNames[0] || characterMacroData.names[0] || "Character",
     characters: characterMacroData.names,
     characterProfiles: characterMacroData.profiles,
     variables,
@@ -266,6 +278,7 @@ export async function buildPromptMacroContext(input: BuildPromptMacroContextInpu
 
 function characterFieldsFromProfile(profile: CharacterMacroProfile): NonNullable<MacroContext["characterFields"]> {
   return {
+    phoneticName: profile.phoneticName ?? "",
     description: profile.description ?? "",
     personality: profile.personality ?? "",
     backstory: profile.backstory ?? "",
@@ -288,6 +301,7 @@ function macroContextForMessage(
   return {
     ...macroCtx,
     char: profile.name,
+    charPhonetic: profile.phoneticName || profile.name,
     characterFields: characterFieldsFromProfile(profile),
   };
 }
@@ -352,7 +366,9 @@ export async function collectCharacterDepthPromptEntries(
     const content = resolveMacros(depthPrompt.prompt, {
       ...macroCtx,
       char: data?.name ?? macroCtx.char,
+      charPhonetic: data?.extensions?.phoneticName ?? macroCtx.charPhonetic,
       characterFields: {
+        phoneticName: data?.extensions?.phoneticName ?? "",
         description: data?.description ?? "",
         personality: data?.personality ?? "",
         backstory: data?.extensions?.backstory ?? "",
@@ -393,7 +409,9 @@ export async function collectCharacterPostHistoryEntries(
     const content = resolveMacros(raw, {
       ...macroCtx,
       char: data.name ?? macroCtx.char,
+      charPhonetic: data.extensions?.phoneticName ?? macroCtx.charPhonetic,
       characterFields: {
+        phoneticName: data.extensions?.phoneticName ?? "",
         description: data.description ?? "",
         personality: data.personality ?? "",
         backstory: data.extensions?.backstory ?? "",

--- a/packages/server/src/services/storage/characters.storage.ts
+++ b/packages/server/src/services/storage/characters.storage.ts
@@ -181,6 +181,7 @@ function buildPersonaSnapshot(persona: PersonaRow): PersonaCardSnapshot {
     creator: persona.creator ?? "",
     personaVersion: persona.personaVersion?.trim() ? persona.personaVersion : "1.0",
     creatorNotes: persona.creatorNotes ?? "",
+    phoneticName: persona.phoneticName ?? "",
     description: persona.description ?? "",
     personality: persona.personality ?? "",
     scenario: persona.scenario ?? "",
@@ -214,6 +215,7 @@ function normalizePersonaSnapshot(data: PersonaCardSnapshot): PersonaCardSnapsho
     creator: data.creator ?? "",
     personaVersion: data.personaVersion?.trim() ? data.personaVersion : "1.0",
     creatorNotes: data.creatorNotes ?? "",
+    phoneticName: data.phoneticName ?? "",
     description: data.description ?? "",
     personality: data.personality ?? "",
     scenario: data.scenario ?? "",
@@ -599,6 +601,7 @@ export function createCharactersStorage(db: DB) {
         creator?: string;
         personaVersion?: string;
         creatorNotes?: string;
+        phoneticName?: string;
         personality?: string;
         scenario?: string;
         backstory?: string;
@@ -623,6 +626,7 @@ export function createCharactersStorage(db: DB) {
         creator: extra?.creator ?? "",
         personaVersion: extra?.personaVersion?.trim() ? extra.personaVersion : "1.0",
         creatorNotes: extra?.creatorNotes ?? "",
+        phoneticName: extra?.phoneticName ?? "",
         description,
         personality: extra?.personality ?? "",
         scenario: extra?.scenario ?? "",
@@ -686,6 +690,7 @@ export function createCharactersStorage(db: DB) {
         creator: source.creator ?? "",
         personaVersion: source.personaVersion?.trim() ? source.personaVersion : "1.0",
         creatorNotes: source.creatorNotes ?? "",
+        phoneticName: source.phoneticName ?? "",
         description: source.description ?? "",
         personality: source.personality ?? "",
         scenario: source.scenario ?? "",
@@ -715,6 +720,7 @@ export function createCharactersStorage(db: DB) {
         creator?: string;
         personaVersion?: string;
         creatorNotes?: string;
+        phoneticName?: string;
         description?: string;
         personality?: string;
         scenario?: string;
@@ -744,6 +750,7 @@ export function createCharactersStorage(db: DB) {
         ...(updates.creator !== undefined && { creator: updates.creator }),
         ...(updates.personaVersion !== undefined && { personaVersion: updates.personaVersion }),
         ...(updates.creatorNotes !== undefined && { creatorNotes: updates.creatorNotes }),
+        ...(updates.phoneticName !== undefined && { phoneticName: updates.phoneticName }),
         ...(updates.description !== undefined && { description: updates.description }),
         ...(updates.personality !== undefined && { personality: updates.personality }),
         ...(updates.scenario !== undefined && { scenario: updates.scenario }),
@@ -777,6 +784,7 @@ export function createCharactersStorage(db: DB) {
       if (updates.creator !== undefined) sets.creator = updates.creator;
       if (updates.personaVersion !== undefined) sets.personaVersion = updates.personaVersion;
       if (updates.creatorNotes !== undefined) sets.creatorNotes = updates.creatorNotes;
+      if (updates.phoneticName !== undefined) sets.phoneticName = updates.phoneticName;
       if (updates.description !== undefined) sets.description = updates.description;
       if (updates.personality !== undefined) sets.personality = updates.personality;
       if (updates.scenario !== undefined) sets.scenario = updates.scenario;
@@ -809,6 +817,7 @@ export function createCharactersStorage(db: DB) {
           creator: data.creator,
           personaVersion: data.personaVersion,
           creatorNotes: data.creatorNotes,
+          phoneticName: data.phoneticName ?? "",
           description: data.description,
           personality: data.personality,
           scenario: data.scenario,

--- a/packages/server/src/utils/security.ts
+++ b/packages/server/src/utils/security.ts
@@ -620,6 +620,13 @@ export async function safeFetch(url: string | URL, options: SafeFetchOptions = {
   throw new Error("Outbound request exceeded redirect limit");
 }
 
+export function resolveValidatedImage(buf: Buffer, contentTypeHeader: string): { mimeType: string } | null {
+  const contentType = contentTypeHeader.toLowerCase();
+  const imageInfo = isAllowedImageBuffer(buf);
+  if (!contentType.startsWith("image/") && !imageInfo) return null;
+  return { mimeType: imageInfo?.mimeType ?? contentType };
+}
+
 export function sanitizePathFilename(filename: string, allowedExts?: Set<string>): string {
   const safe = safeBasename(filename);
   const ext = extname(safe).toLowerCase();

--- a/packages/server/src/utils/security.ts
+++ b/packages/server/src/utils/security.ts
@@ -621,10 +621,9 @@ export async function safeFetch(url: string | URL, options: SafeFetchOptions = {
 }
 
 export function resolveValidatedImage(buf: Buffer, contentTypeHeader: string): { mimeType: string } | null {
-  const contentType = contentTypeHeader.toLowerCase();
   const imageInfo = isAllowedImageBuffer(buf);
-  if (!contentType.startsWith("image/") && !imageInfo) return null;
-  return { mimeType: imageInfo?.mimeType ?? contentType };
+  if (!imageInfo) return null;
+  return { mimeType: imageInfo.mimeType };
 }
 
 export function sanitizePathFilename(filename: string, allowedExts?: Set<string>): string {

--- a/packages/shared/src/types/character.ts
+++ b/packages/shared/src/types/character.ts
@@ -48,6 +48,8 @@ export interface CharacterExtensions {
   rpgStats?: RPGStatsConfig;
   /** Marinara Engine: Conversation-mode availability status */
   conversationStatus?: import("./chat.js").ConversationPresenceStatus;
+  /** Marinara Engine: pronunciation override used when sending this character's name to TTS. */
+  phoneticName?: string;
   [key: string]: unknown;
 }
 
@@ -157,6 +159,7 @@ export interface PersonaCardSnapshot {
   creator: string;
   personaVersion: string;
   creatorNotes: string;
+  phoneticName?: string;
   description: string;
   personality: string;
   scenario: string;

--- a/packages/shared/src/types/chat.ts
+++ b/packages/shared/src/types/chat.ts
@@ -398,6 +398,8 @@ export interface ChatMetadata {
   conversationCallsEnabled?: boolean;
   /** Allow characters to ring the user through the call command. Default: true when calls are enabled. */
   conversationCharactersCanCall?: boolean;
+  /** Ask call models to include TTS/video voice cues in bracket tags. Default: true. */
+  conversationCallVoiceCues?: boolean;
   /** Chat-scoped generated schedules for conversation characters. */
   characterSchedules?: Record<string, unknown>;
   /** Chat-scoped manual status overrides for conversation characters. */

--- a/packages/shared/src/types/persona.ts
+++ b/packages/shared/src/types/persona.ts
@@ -8,6 +8,8 @@ export interface Persona {
   name: string;
   /** Short comment shown under the name (for disambiguation) */
   comment: string;
+  /** Optional pronunciation override used when this persona name is sent to TTS. */
+  phoneticName?: string;
   description: string;
   personality: string;
   scenario: string;

--- a/packages/shared/src/utils/image-prompt-compiler.ts
+++ b/packages/shared/src/utils/image-prompt-compiler.ts
@@ -565,13 +565,22 @@ function distillVisualPhrases(value: string): string[] {
   addIfPresent(fragments, text, /\breading glasses\b/i, "reading glasses");
   addIfPresent(fragments, text, /\bstatement ring\b/i, "statement ring");
   addIfPresent(fragments, text, /\bdark red nails\b/i, "dark red nails");
+  addIfPresent(fragments, text, /\b(?:fox|kitsune|wolf|cat|rabbit|deer|lizard|dragon|bird|serpent)[-\s](?:woman|man|girl|boy|person|humanoid|creature)\b/i);
+  addIfPresent(fragments, text, /\b(?:silver|white|black|brown|red|golden|blue|grey|gray|orange)[-\s]furred\b/i);
+  addIfPresent(fragments, text, /\b(?:silver|white|black|brown|red|golden|blue|grey|gray|orange)\s+fur\b/i);
+  addIfPresent(fragments, text, /\b(?:fox|wolf|cat|rabbit|deer|lizard|dragon|bird|serpent)\s+(?:ears?|tail|tails?|horns?|wings?)\b/i);
+  addIfPresent(fragments, text, /\b(?:persimmon|red|blue|black|white|gold|golden|green|purple|pink|silver|grey|gray|brown)\s+kimono\b/i);
+  addIfPresent(fragments, text, /\b(?:kimono|sari|hanfu|cheongsam|qipao|cloak|cape|mantle|hood|veil|mask|visor|goggles)\b/i);
+  addIfPresent(fragments, text, /\b(?:scroll|debt[-\s]scroll|book|tome|lantern|fan|parasol|satchel|pouch)\b/i);
+  addIfPresent(fragments, text, /\btucked in (?:her|his|their|a|the)?\s*sleeve\b/i);
 
   if (fragments.length > 0) return fragments.filter((fragment) => shouldKeepTaggedSourceFragment(fragment));
   return [];
 }
 
-function addIfPresent(fragments: string[], text: string, pattern: RegExp, fragment: string): void {
-  if (pattern.test(text)) fragments.push(fragment);
+function addIfPresent(fragments: string[], text: string, pattern: RegExp, fragment?: string): void {
+  const match = text.match(pattern);
+  if (match?.[0]) fragments.push(fragment ?? cleanVisualPhrase(match[0]));
 }
 
 function cleanVisualPhrase(value: string): string {
@@ -593,7 +602,7 @@ function shouldKeepTaggedSourceFragment(value: string, requireVisualCue = false)
   if (!clean) return false;
   if (clean.length > 120) return false;
   if (
-    /\b(?:debt|childhood|academy|army|airship|country|refugee|business|district|background|universe|agency|determined|goal|dream|survived|moved|born|build|hoped|hope|better|spells?|uncertain|terms?|eventually|struggles?|managed|opened|enrolled|expelled|tracked)\b/i.test(
+    /\b(?:childhood|academy|army|airship|country|refugee|business|district|background|universe|agency|determined|goal|dream|survived|moved|born|build|hoped|hope|better|spells?|uncertain|terms?|eventually|struggles?|managed|opened|enrolled|expelled|tracked)\b/i.test(
       clean,
     )
   ) {
@@ -606,7 +615,7 @@ function shouldKeepTaggedSourceFragment(value: string, requireVisualCue = false)
 }
 
 function hasVisualCue(value: string): boolean {
-  return /\b(?:female|male|woman|man|girl|boy|non[-\s]?binary|androgynous|genderless|adult|young adult|middle-aged|middle aged|elderly|senior|human|elf|dwarf|orc|android|robot|twenties|thirties|forties|fifties|sixties|statuesque|hair|eyes?|skin|face|body|petite|tall|short|slim|muscular|scar|freckles|beard|makeup|cheekbones|nails|smil(?:e|ing)|flowers?|ring|armor|armour|dress|shirt|blouse|trousers|coat|jacket|blazer|robe|uniform|sword|staff|hat|glasses|boots|portrait|close-up|upper body|face-and-shoulders|full body|centered|looking at viewer|expression|silhouette|fantasy|medieval|kingdom|castle|village|tavern|dungeon|forest|field|farm|road|market|city|urban|street|alley|temple|church|ruins?|graveyard|cave|mountain|river|lake|desert|snow|rain|storm|fog|night|dawn|morning|noon|afternoon|evening|sci-fi|scifi|cyberpunk|space|futuristic|modern|contemporary|western|victorian|steampunk|environment|landscape|scenery|location|interior|exterior)\b/i.test(
+  return /\b(?:female|male|woman|man|girl|boy|non[-\s]?binary|androgynous|genderless|adult|young adult|middle-aged|middle aged|elderly|senior|human|humanoid|elf|dwarf|orc|fae|fairy|demon|angel|vampire|mermaid|harpy|centaur|kobold|kitsune|fox|wolf|cat|rabbit|deer|lizard|dragon|serpent|fur|furred|tail|tails?|ears?|horns?|wings?|android|robot|twenties|thirties|forties|fifties|sixties|statuesque|hair|eyes?|skin|face|body|petite|tall|short|slim|muscular|scar|freckles|beard|makeup|cheekbones|nails|smil(?:e|ing)|flowers?|ring|armor|armour|dress|shirt|blouse|trousers|coat|jacket|blazer|robe|uniform|kimono|sari|hanfu|cheongsam|qipao|cloak|cape|mantle|hood|veil|mask|visor|goggles|sword|staff|scroll|book|tome|lantern|fan|parasol|satchel|pouch|hat|glasses|boots|sleeve|portrait|close-up|upper body|face-and-shoulders|full body|centered|looking at viewer|expression|silhouette|fantasy|medieval|kingdom|castle|village|tavern|dungeon|forest|field|farm|road|market|city|urban|street|alley|temple|church|ruins?|graveyard|cave|mountain|river|lake|desert|snow|rain|storm|fog|night|dawn|morning|noon|afternoon|evening|sci-fi|scifi|cyberpunk|space|futuristic|modern|contemporary|western|victorian|steampunk|environment|landscape|scenery|location|interior|exterior)\b/i.test(
     value,
   );
 }

--- a/packages/shared/src/utils/macro-engine.ts
+++ b/packages/shared/src/utils/macro-engine.ts
@@ -4,12 +4,15 @@
 
 export interface MacroContext {
   user: string;
+  userPhonetic?: string;
   char: string;
+  charPhonetic?: string;
   /** All characters in the chat */
   characters: string[];
   /** Full per-character card fields for grouped macro expansion */
   characterProfiles?: Array<{
     name: string;
+    phoneticName?: string;
     description?: string;
     personality?: string;
     backstory?: string;
@@ -37,6 +40,7 @@ export interface MacroContext {
   agentData?: Record<string, string>;
   /** Current character card fields used by macros like {{description}} */
   characterFields?: {
+    phoneticName?: string;
     description?: string;
     personality?: string;
     backstory?: string;
@@ -48,6 +52,7 @@ export interface MacroContext {
   };
   /** Active persona card fields used by {{persona}} */
   personaFields?: {
+    phoneticName?: string;
     description?: string;
     personality?: string;
     backstory?: string;
@@ -86,7 +91,7 @@ export interface SupportedMacroDefinition {
 }
 
 const CHARACTER_MACRO_PATTERN =
-  /\{\{(?:char|charName|description|personality|backstory|appearance|scenario|example|charSysInfo|charPostHistory)\}\}|\{\{\s*#if\s+[^}]*\b(?:char|charName|character|speaker|description|personality|backstory|appearance|scenario|example|charSysInfo|charPostHistory)\b/i;
+  /\{\{(?:char|charName|charNamePhonetic|charPhonetic|description|personality|backstory|appearance|scenario|example|charSysInfo|charPostHistory)\}\}|\{\{\s*#if\s+[^}]*\b(?:char|charName|charNamePhonetic|charPhonetic|character|speaker|description|personality|backstory|appearance|scenario|example|charSysInfo|charPostHistory)\b/i;
 const MAX_CHARACTER_FIELD_RESOLUTION_DEPTH = 4;
 const MAX_DICE_COUNT = 1000;
 const MAX_DICE_SIDES = 1_000_000;
@@ -104,6 +109,7 @@ const DEFERRED_CHARACTER_CONDITIONAL_TOKEN_RE = new RegExp(
 const MACRO_COMMENT_PATTERN = /\{\{\/\/[^}]*\}\}/g;
 const DEFERRED_CHARACTER_MACRO_TOKENS = {
   char: `${DEFERRED_CHARACTER_MACRO_TOKEN_PREFIX}CHAR\x1f`,
+  charPhonetic: `${DEFERRED_CHARACTER_MACRO_TOKEN_PREFIX}CHAR_PHONETIC\x1f`,
   description: `${DEFERRED_CHARACTER_MACRO_TOKEN_PREFIX}DESCRIPTION\x1f`,
   personality: `${DEFERRED_CHARACTER_MACRO_TOKEN_PREFIX}PERSONALITY\x1f`,
   backstory: `${DEFERRED_CHARACTER_MACRO_TOKEN_PREFIX}BACKSTORY\x1f`,
@@ -115,7 +121,7 @@ const DEFERRED_CHARACTER_MACRO_TOKENS = {
 } as const;
 
 export type CharacterMacroProfile = NonNullable<MacroContext["characterProfiles"]>[number];
-type CharacterFieldMacroName = Exclude<keyof typeof DEFERRED_CHARACTER_MACRO_TOKENS, "char">;
+type CharacterFieldMacroName = Exclude<keyof typeof DEFERRED_CHARACTER_MACRO_TOKENS, "char" | "charPhonetic">;
 type ConditionalBlockPayload = {
   condition: string;
   truthy: string;
@@ -221,6 +227,11 @@ export const SUPPORTED_MACROS: readonly SupportedMacroDefinition[] = [
   { category: "Identity", syntax: "{{userName}}", description: "Alias for {{user}}" },
   {
     category: "Identity",
+    syntax: "{{userNamePhonetic}}",
+    description: "Active persona phonetic name, or {{user}} when none is configured",
+  },
+  {
+    category: "Identity",
     syntax: "{{persona}}",
     description: "Active persona description, personality, backstory, appearance, and scenario joined by new lines",
   },
@@ -231,6 +242,11 @@ export const SUPPORTED_MACROS: readonly SupportedMacroDefinition[] = [
   { category: "Identity", syntax: "{{personaScenario}}", description: "Active persona scenario" },
   { category: "Identity", syntax: "{{char}}", description: "Current character name" },
   { category: "Identity", syntax: "{{charName}}", description: "Alias for {{char}}" },
+  {
+    category: "Identity",
+    syntax: "{{charNamePhonetic}}",
+    description: "Current character phonetic name, or {{char}} when none is configured",
+  },
   { category: "Identity", syntax: "{{characters}}", description: "All character names, comma-separated" },
   { category: "Character", syntax: "{{description}}", description: "Current character description" },
   { category: "Character", syntax: "{{personality}}", description: "Current character personality" },
@@ -323,7 +339,9 @@ function resolveCharacterFieldValue(
 function macroContextForCharacterProfile(profile: CharacterMacroProfile, base?: MacroContext): MacroContext {
   return {
     user: base?.user ?? "User",
+    userPhonetic: base?.userPhonetic,
     char: profile.name,
+    charPhonetic: profile.phoneticName ?? profile.name,
     characters: base?.characters ?? [profile.name],
     characterProfiles: base?.characterProfiles ?? [profile],
     variables: base?.variables ?? {},
@@ -336,6 +354,7 @@ function macroContextForCharacterProfile(profile: CharacterMacroProfile, base?: 
     agentData: base?.agentData,
     personaFields: base?.personaFields,
     characterFields: {
+      phoneticName: profile.phoneticName ?? "",
       description: profile.description ?? "",
       personality: profile.personality ?? "",
       backstory: profile.backstory ?? "",
@@ -361,6 +380,7 @@ export function resolveCharacterScopedMacros(
   );
   return scoped
     .replace(/\{\{char(?:Name)?\}\}/gi, profile.name)
+    .replace(/\{\{char(?:Name)?Phonetic\}\}/gi, profile.phoneticName ?? profile.name)
     .replace(/\{\{description\}\}/gi, () => resolveCharacterFieldValue(profile, "description", depth, baseContext))
     .replace(/\{\{personality\}\}/gi, () => resolveCharacterFieldValue(profile, "personality", depth, baseContext))
     .replace(/\{\{backstory\}\}/gi, () => resolveCharacterFieldValue(profile, "backstory", depth, baseContext))
@@ -382,6 +402,7 @@ export function resolveDeferredCharacterMacros(
   const scopedContext = macroContextForCharacterProfile(profile, baseContext);
   let result = resolveDeferredCharacterConditionals(template, scopedContext);
   result = result.split(DEFERRED_CHARACTER_MACRO_TOKENS.char).join(profile.name);
+  result = result.split(DEFERRED_CHARACTER_MACRO_TOKENS.charPhonetic).join(profile.phoneticName ?? profile.name);
   result = result
     .split(DEFERRED_CHARACTER_MACRO_TOKENS.description)
     .join(resolveCharacterFieldValue(profile, "description", 0, baseContext));
@@ -601,9 +622,17 @@ function resolveConditionalOperand(raw: string, ctx: MacroContext): string {
     case "character":
     case "speaker":
       return ctx.char;
+    case "charphonetic":
+    case "charnamephonetic":
+    case "characterphonetic":
+    case "speakerphonetic":
+      return ctx.charPhonetic || ctx.characterFields?.phoneticName || ctx.char;
     case "user":
     case "username":
       return ctx.user;
+    case "userphonetic":
+    case "usernamephonetic":
+      return ctx.userPhonetic || ctx.personaFields?.phoneticName || ctx.user;
     case "persona":
       return resolvePersonaText(ctx);
     case "personadescription":
@@ -651,7 +680,7 @@ function resolveConditionalOperand(raw: string, ctx: MacroContext): string {
 
 function isCharacterConditionalOperand(raw: string): boolean {
   const normalized = normalizeConditionKey(raw);
-  return /^(char|charname|character|speaker|description|personality|backstory|appearance|scenario|example|charsysinfo|charposthistory)$/.test(
+  return /^(char|charname|charphonetic|charnamephonetic|character|characterphonetic|speaker|speakerphonetic|description|personality|backstory|appearance|scenario|example|charsysinfo|charposthistory)$/.test(
     normalized,
   );
 }
@@ -1162,10 +1191,12 @@ export function resolveMacros(template: string, ctx: MacroContext, options: Reso
   };
   const deferCharacterMacros = options.deferCharacterMacros;
   const characterReplacement = (field: keyof typeof DEFERRED_CHARACTER_MACRO_TOKENS): string => {
-    if (deferCharacterMacros === "all" || (deferCharacterMacros === "names" && field === "char")) {
+    const isNameField = field === "char" || field === "charPhonetic";
+    if (deferCharacterMacros === "all" || (deferCharacterMacros === "names" && isNameField)) {
       return DEFERRED_CHARACTER_MACRO_TOKENS[field];
     }
     if (field === "char") return ctx.char;
+    if (field === "charPhonetic") return ctx.charPhonetic || ctx.characterFields?.phoneticName || ctx.char;
     return resolveNestedFieldMacros(ctx.characterFields?.[field] ?? "");
   };
 
@@ -1203,6 +1234,10 @@ export function resolveMacros(template: string, ctx: MacroContext, options: Reso
 
   // ── Static substitutions ──
   result = result.replace(/\{\{user(?:Name)?\}\}/gi, ctx.user);
+  result = result.replace(
+    /\{\{user(?:Name)?Phonetic\}\}/gi,
+    ctx.userPhonetic || ctx.personaFields?.phoneticName || ctx.user,
+  );
   // The gated build above can be skipped when {{persona}} only materializes
   // mid-pipeline (e.g. substituted in by an earlier pass), so fall back to
   // building here. String form is kept so $-sequences in persona text
@@ -1226,6 +1261,7 @@ export function resolveMacros(template: string, ctx: MacroContext, options: Reso
     resolveNestedFieldMacros(ctx.personaFields?.scenario ?? ""),
   );
   result = result.replace(/\{\{char(?:Name)?\}\}/gi, characterReplacement("char"));
+  result = result.replace(/\{\{char(?:Name)?Phonetic\}\}/gi, characterReplacement("charPhonetic"));
   result = result.replace(/\{\{characters\}\}/gi, ctx.characters.join(", "));
   result = result.replace(/\{\{description\}\}/gi, characterReplacement("description"));
   result = result.replace(/\{\{personality\}\}/gi, characterReplacement("personality"));

--- a/scripts/regressions/prompt.regression.ts
+++ b/scripts/regressions/prompt.regression.ts
@@ -337,6 +337,32 @@ const cases: RegressionCase[] = [
     },
   },
   {
+    name: "phonetic name macros fall back to visible names",
+    run() {
+      assert.equal(
+        resolveMacros("{{userNamePhonetic}} calls {{charNamePhonetic}}.", {
+          user: "Mari",
+          userPhonetic: "Mah-ree",
+          char: "Dottore",
+          charPhonetic: "Doctor-ray",
+          characters: ["Dottore"],
+          variables: {},
+        }),
+        "Mah-ree calls Doctor-ray.",
+      );
+
+      assert.equal(
+        resolveMacros("{{userNamePhonetic}} calls {{charNamePhonetic}}.", {
+          user: "Mari",
+          char: "Dottore",
+          characters: ["Dottore"],
+          variables: {},
+        }),
+        "Mari calls Dottore.",
+      );
+    },
+  },
+  {
     name: "macro passthrough preserves plain text and deferred sentinels",
     run() {
       const context = {

--- a/start.bat
+++ b/start.bat
@@ -56,8 +56,11 @@ if not defined CURRENT_PNPM_VERSION (
     where pnpm >nul 2>&1
     if not errorlevel 1 (
         for /f "usebackq delims=" %%i in (`pnpm --version 2^>nul`) do set "CURRENT_PNPM_VERSION=%%i"
-        if defined CURRENT_PNPM_VERSION (
+        if /I "!CURRENT_PNPM_VERSION!"=="%PNPM_VERSION%" (
             echo  [..] Using installed pnpm !CURRENT_PNPM_VERSION!
+        ) else (
+            if defined CURRENT_PNPM_VERSION echo  [..] Installed pnpm !CURRENT_PNPM_VERSION! does not match required %PNPM_VERSION%; trying a pinned temporary runner...
+            set "CURRENT_PNPM_VERSION="
         )
     )
 )
@@ -272,6 +275,8 @@ if not exist "packages\server\dist\index.js" set "BUILD_REQUIRED=1"
 if not exist "packages\client\dist\index.html" set "BUILD_REQUIRED=1"
 if "!BUILD_REQUIRED!"=="1" (
     echo  [..] Cleaning stale build artifacts...
+    call :run_pnpm clean:stale-client
+    if errorlevel 1 echo  [ERROR] Failed to clean stale client artifacts. & pause & exit /b 1
     call :run_pnpm --filter @marinara-engine/shared clean
     if errorlevel 1 echo  [ERROR] Failed to clean shared build artifacts. & pause & exit /b 1
     call :run_pnpm --filter @marinara-engine/server clean
@@ -279,8 +284,10 @@ if "!BUILD_REQUIRED!"=="1" (
     call :run_pnpm --filter @marinara-engine/client clean
     if errorlevel 1 echo  [ERROR] Failed to clean client build artifacts. & pause & exit /b 1
     echo  [..] Building Marinara Engine...
-    call :run_pnpm build
-    if errorlevel 1 echo  [ERROR] Failed to build Marinara Engine. & pause & exit /b 1
+    call :run_pnpm --filter @marinara-engine/shared build
+    if errorlevel 1 echo  [ERROR] Failed to build shared package. & pause & exit /b 1
+    call :run_pnpm --filter @marinara-engine/server --filter @marinara-engine/client --parallel run build
+    if errorlevel 1 echo  [ERROR] Failed to build server or client package. & pause & exit /b 1
 )
 
 :: Database migrations are handled automatically at server startup by runMigrations()

--- a/win/installer/install.bat
+++ b/win/installer/install.bat
@@ -189,8 +189,11 @@ if not defined CURRENT_PNPM_VERSION (
     where pnpm >nul 2>&1
     if not errorlevel 1 (
         for /f "usebackq delims=" %%i in (`pnpm --version 2^>nul`) do set "CURRENT_PNPM_VERSION=%%i"
-        if defined CURRENT_PNPM_VERSION (
+        if /I "!CURRENT_PNPM_VERSION!"=="%PNPM_VERSION%" (
             set "PNPM_RUNNER=pnpm"
+        ) else (
+            if defined CURRENT_PNPM_VERSION echo  [..] Installed pnpm !CURRENT_PNPM_VERSION! does not match required %PNPM_VERSION%; trying a pinned temporary runner...
+            set "CURRENT_PNPM_VERSION="
         )
     )
 )


### PR DESCRIPTION
## Why

Sweeps the next v2.1.1 issue batch after the initial post-release fixes and includes the Roleplay Chat Summary footer docking polish. The fixes target update reliability, prompt/call regressions, bot-browser avatar imports, Game Mode NPC portraits, Conversation UI regressions, and TTS/call configuration sharp edges reported by users.

## What

- Keeps the Roleplay Chat Summary empty/generated summary surface visually docked into the footer controls.
- Fixes oversized Conversation cropped avatars, Echo Chamber collapse behavior, Roleplay preset-shortcut first-message seeding, preset choice confirmation, manual group Conversation trigger context, and initial Game Mode NPC portrait prompts.
- Adds Character/Persona phonetic-name metadata, phonetic-name macros, and Conversation Call TTS pronunciation replacement.
- Resolves macros in Conversation Call prompt inputs, daily history, lorebooks, persona/character blocks, and call transcript content.
- Adds a per-chat Conversation Calls toggle for generated bracketed voice cues so chats can disable `[whispering]`, `[laughing]`, `[sighs]`, and similar tags for TTS providers that do not accept them.
- Lets Text to Speech character voice assignment use provider default voices, including ElevenLabs defaults, before custom/account voices are loaded.
- Hardens Windows/git update flows around pinned pnpm, safe per-package builds, and clearer manual update hints.
- Splits oversized memory recall embedding payloads before embedding.
- Accepts bot-browser avatar images from providers/CDNs that omit or generalize image content types.
- Updates the v2.1.1 changelog entries for the sweep.

## Issues

Addresses #3317, #3318, #3319, #3321, #3322, #3323, #3324, #3325, #3326, #3327, #3328, #3329, and #3330.

## Local validation run

- `pnpm check`
- `pnpm regression:prompt`
- Earlier focused builds during the sweep: `pnpm --filter @marinara-engine/shared build`, `pnpm --filter @marinara-engine/server build`, `pnpm --filter @marinara-engine/client build`

## Manual verification checklist

- [ ] Manually verify Chat Settings > Commands > Conversation Calls shows and persists **Generate voice cues in [tags]**, and disabled calls omit cue requests from the next call prompt.
- [ ] Manually verify Text to Speech > Character Voices can add a character voice with default provider voices before custom/account voices load.
- [ ] Manually verify a Roleplay setup shortcut still seeds the selected character first message in a new empty chat.
- [ ] Manually verify Echo Chamber can collapse and reopen without permanently disappearing from the chat.
- [ ] Manually verify a Conversation DM/group with cropped avatars renders circular avatars correctly.
- [ ] Manually verify a Game Mode setup with GM-generated NPC descriptions uses those descriptions for initial NPC portrait generation.
- [ ] Manually verify Windows/git updater flows on a Windows checkout with no global pnpm and with a mismatched global pnpm.
