### PR TITLE
[codex] Polish settings and conversation prompt wrapping

### DIFF
--- a/.github/agents/chai-workflow.md
+++ b/.github/agents/chai-workflow.md
@@ -88,6 +88,7 @@ Use this for code reviews, PR preparation, PR iteration, and ready-for-review ga
 
 - For reviews, lead with findings ordered by severity. If no issues are found, say so.
 - Before pushing or opening a PR, check the dirty tree, remotes, branch, intended files, and target branch.
+- When the PR bumps or prepares a release version, run `pnpm credits:check`; if stale, run `pnpm credits:sync` and include the Credits modal update in the same release PR.
 - New PRs should target `staging` and be draft by default unless the maintainer says otherwise.
 - Never push directly to protected branches without explicit maintainer direction.
 - Do not auto-check PR validation boxes. Treat them as human verification tasks.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,6 +56,7 @@ Android-specific rule:
 ## Safe Multi-File Updates
 
 - When changing version numbers, bump root `package.json` first, then run `pnpm version:sync -- --android-version-code <next-code>`.
+- When changing version numbers or preparing a release, run `pnpm credits:check`; if it fails, run `pnpm credits:sync` and include the Credits modal update.
 - Run `pnpm version:check` before tagging or publishing.
 - Keep `CONTRIBUTING.md` authoritative. Add Codex-specific notes here only when they are operationally useful and not already covered there.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 ### Changed
 
 - Bumped release metadata to v2.1.1 across packages, the PWA manifest, README release pointer, Windows installer sources, Android APK metadata, and the home-page-visible app version.
+- Reorganized Settings so Addons combines Themes and Extensions, Generations houses image/video generation and prompt overrides, Imports uses the plural label, generation prompt editors start collapsed, and Danger Zone uses accent-color selections with no default checked categories.
+- Refreshed the in-app Credits modal from the GitHub contributors list and added credits sync/check helpers to the release workflow.
 
 ### Fixed
 
@@ -23,6 +25,7 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 - Fixed Conversation Call prompt macro resolution so live audio prompts, persona/character context, lorebook entries, daily history, and call transcript content resolve macros such as `{{user}}` before provider dispatch (#3326).
 - Fixed custom preset choice confirmation so edited multi-select preset variables can intentionally be saved empty instead of disabling **Confirm Choices** (#3327).
 - Fixed Conversation message avatars that were cropped in editors but appeared oversized in DMs/groups by restoring the relative avatar crop container (#3328).
+- Fixed Conversation mode prompt assembly so selected preset wrap formats (XML, Markdown, or None) are respected for instructions, daily summary/date blocks, current context, memories, and lorebook injections instead of always wrapping supplemental sections in XML.
 - Restored the Echo Chamber chat as a collapsible panel instead of making close/collapse hide the chamber permanently for the chat (#3329).
 - Fixed manual group Conversation character triggers so the prompted character receives recent visible group transcript context and does not answer from profile/lorebook content alone (#3330).
 - Fixed Text to Speech character voice assignment so users can add character voices using provider default voices, including ElevenLabs defaults, even before custom/account voices are loaded.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -222,15 +222,17 @@ Standard release flow:
 
 1. Bump the canonical version in root `package.json`.
 2. Run `pnpm version:sync -- --android-version-code <next-code>` to sync all derived version fields.
-3. Update `CHANGELOG.md`.
-4. Merge the release-ready `staging` change to `main`.
-5. Create and push the tag `vX.Y.Z` from the `main` commit that contains that exact version bump.
-6. Let the release workflows publish or update the GitHub Release, Windows installer, Android WebView shell APK, and GHCR container images (`X.Y.Z`, `X.Y`, `X`, `latest`, plus `X.Y.Z-lite` / `lite`) from the matching changelog entry.
+3. Run `pnpm credits:check`; if it reports stale contributor credits, run `pnpm credits:sync` and include the Credits modal update in the release PR.
+4. Update `CHANGELOG.md`.
+5. Merge the release-ready `staging` change to `main`.
+6. Create and push the tag `vX.Y.Z` from the `main` commit that contains that exact version bump.
+7. Let the release workflows publish or update the GitHub Release, Windows installer, Android WebView shell APK, and GHCR container images (`X.Y.Z`, `X.Y`, `X`, `latest`, plus `X.Y.Z-lite` / `lite`) from the matching changelog entry.
 
 Release helpers now in the repo:
 
 - `pnpm version:sync -- --android-version-code <next-code>` updates the derived version files and README release references from the root `package.json` version.
 - `pnpm version:check` fails when those derived files drift out of sync.
+- `pnpm credits:check` compares the in-app Credits modal with the GitHub contributors list, and `pnpm credits:sync` refreshes it.
 - `pnpm guard:installer-artifacts` fails when tracked installer binaries appear under `win/installer/*.exe`.
 - `pnpm release:notes -- <version>` renders the matching `CHANGELOG.md` entry for release publication and prepends the temporary Android APK / Termux notice.
 

--- a/docs/EXTENSIONS.md
+++ b/docs/EXTENSIONS.md
@@ -2,7 +2,7 @@
 
 Marinara Engine extensions are add-ons for changing how the app looks and behaves. Browser extensions can include CSS or JavaScript that runs in the Marinara page, observes or edits the DOM, adds controls, registers hotkeys, calls allowed Marinara API routes, and cleans itself up when disabled. Trusted server extensions can include JavaScript that runs in the Marinara Node.js server process.
 
-Extensions are imported from **Settings -> Extensions** as a `.json`, `.css`, `.js`, `.server.js`, `.zip`, or a folder. Only install extensions from people you trust. Browser extension JavaScript runs with the same browser privileges as the app UI. Server extension JavaScript runs on the host server and can affect that server until disabled. Neither runtime directly patches Marinara's source code on disk.
+Extensions are imported from **Settings -> Addons -> Extension Library** as a `.json`, `.css`, `.js`, `.server.js`, `.zip`, or a folder. Only install extensions from people you trust. Browser extension JavaScript runs with the same browser privileges as the app UI. Server extension JavaScript runs on the host server and can affect that server until disabled. Neither runtime directly patches Marinara's source code on disk.
 
 Installing, updating, toggling, or removing extensions is a privileged action. It works from loopback/local access, or from remote browsers when `ADMIN_SECRET` is set on the server and saved in **Settings -> Advanced -> Admin Access**. Without that, the server returns 403. See [Configuration -> Privileged APIs](CONFIGURATION.md#privileged-apis).
 
@@ -258,5 +258,5 @@ If there is no root package file, folder import scans for every `manifest.json` 
 - A loose folder with `.server.js`, `.server.mjs`, or `.server.cjs` files and no manifest imports as one disabled server extension.
 - CSS is sanitized before injection. External `url()`, `@import`, `@namespace`, remote or `local()` web fonts, `expression()`, `javascript:`, `vbscript:`, `behavior`, and `-moz-binding` are stripped or rewritten; external URLs become `url(about:invalid)`, and `:visited` selectors are rewritten to `:link`. Embed images and fonts as safe `data:` URIs when needed.
 - Browser JavaScript is loaded by the browser client when the extension is enabled. It can change client behavior at runtime, but it is not run by the server.
-- Server JavaScript is loaded by the Marinara server when the extension is enabled. Startup status appears in Settings -> Extensions.
+- Server JavaScript is loaded by the Marinara server when the extension is enabled. Startup status appears in Settings -> Addons -> Extension Library.
 - TypeScript files can be included in imported folders as package text, but Marinara does not compile TypeScript for extension execution. Point `jsPath` at JavaScript that the browser can run.

--- a/docs/FRONTEND.md
+++ b/docs/FRONTEND.md
@@ -414,7 +414,7 @@ The project uses Tailwind CSS v4 with the `@tailwindcss/vite` plugin (no PostCSS
 
 ### Custom Themes
 
-Users can create custom themes via the Settings > Themes panel. Theme definitions are stored on the Marinara server and sync across connected devices; the active custom theme is also shared. The CSS is injected as a `<style>` tag by `CustomThemeInjector.tsx`.
+Users can create custom themes via Settings > Addons > Theme Library. Theme definitions are stored on the Marinara server and sync across connected devices; the active custom theme is also shared. The CSS is injected as a `<style>` tag by `CustomThemeInjector.tsx`.
 
 Synced theme CSS can request the built-in Accent Pulse engine with `--marinara-theme-accent-pulse: enabled`. Add `--marinara-theme-accent-pulse-source: #a78bfa` or a gradient when the pulse should use a specific theme accent instead of the current Appearance accent/default.
 

--- a/docs/IMAGE_GENERATION.md
+++ b/docs/IMAGE_GENERATION.md
@@ -1,6 +1,6 @@
 # Image Generation
 
-Marinara Engine centralizes image prompt style through **Settings -> Image Generation -> Style Profiles**. A style profile controls how roleplay selfies, avatars, sprites, Game Mode backgrounds, NPC portraits, and scene illustrations are shaped before they are sent to the selected image provider.
+Marinara Engine centralizes image prompt style through **Settings -> Generations -> Image Generation -> Style Profiles**. A style profile controls how roleplay selfies, avatars, sprites, Game Mode backgrounds, NPC portraits, and scene illustrations are shaped before they are sent to the selected image provider.
 
 ## Style profiles
 
@@ -41,7 +41,7 @@ The backend-specific controls for AUTOMATIC1111/Forge, ComfyUI, NovelAI, and oth
 
 ## Prompt review
 
-When **Expose image prompts before sending** is enabled in **Settings -> Image Generation**, Marinara shows the final compiled positive prompt and, when available, the final compiled negative prompt before generation. Editing either field changes exactly what is sent for that request; reviewed prompts are not compiled a second time after confirmation.
+When **Expose image prompts before sending** is enabled in **Settings -> Generations -> Image Generation**, Marinara shows the final compiled positive prompt and, when available, the final compiled negative prompt before generation. Editing either field changes exactly what is sent for that request; reviewed prompts are not compiled a second time after confirmation.
 
 ## Scene videos
 

--- a/docs/SCENE_VIDEO_GENERATION.md
+++ b/docs/SCENE_VIDEO_GENERATION.md
@@ -98,7 +98,7 @@ Storyboard and video prompt style are selected per chat:
 - **Chat Settings -> Agents -> Scene Videos -> Game Video Prompt** is used for Game scene videos and storyboard clips. The default **Cinematic Scene Video** preset turns the saved first-frame image into motion.
 - **Chat Settings -> Agents -> Scene Videos -> Edit Video Presets** copies the built-in video prompt into chat-local editable templates.
 
-Open **Settings -> Advanced -> Game Prompt Templates and Prompt Overrides** to edit the reusable global templates used by scene media.
+Open **Settings -> Generations -> Video Generation Prompt Templates** and **Prompt Overrides** to edit the reusable global templates used by scene media.
 
 The relevant keys are:
 

--- a/docs/STORYBOARD_ENGINE_GUIDE.md
+++ b/docs/STORYBOARD_ENGINE_GUIDE.md
@@ -55,7 +55,7 @@ Find these switches in either place:
 
 Use automatic illustrations when you want every turn to get a visual panel sequence. Add automatic animations only when you are comfortable with multiple video-generation calls per completed GM turn (currently this is expensive).
 
-Built-in storyboard prompt presets are **Still Keyframes**, **Comic Page**, **Colored Manga**, and **B&W Manga**. They are separate from Roleplay Illustrator prompt presets and from the global Game Prompt Templates screen.
+Built-in storyboard prompt presets are **Still Keyframes**, **Comic Page**, **Colored Manga**, and **B&W Manga**. They are separate from Roleplay Illustrator prompt presets and from the global game prompt entries in Settings -> Generations -> Prompt Overrides.
 
 Storyboard animations combine two prompt layers. The Storyboards card chooses how Marinara plans and renders the keyframe image. The Scene Videos card's **Game Video Prompt** chooses how Marinara animates that saved image into motion.
 
@@ -107,7 +107,7 @@ For common tuning, use **Chat Settings -> Agents -> Storyboards** first:
 | **Edit Storyboard Presets** | Chat-local custom copies of built-in storyboard presets. |
 | **Scene Videos -> Game Video Prompt** | The video-template layer used to animate generated scene illustrations and storyboard keyframes. |
 
-For global media-template tuning, open **Settings -> Advanced -> Game Prompt Templates and Prompt Overrides**. The most relevant keys are:
+For global media-template tuning, open **Settings -> Generations -> Prompt Overrides**. The most relevant keys are:
 
 | Key | What it changes |
 | --- | --- |

--- a/package.json
+++ b/package.json
@@ -34,6 +34,8 @@
     "test": "node ./scripts/check-windows-installer-layout.mjs && pnpm -r run test",
     "version:sync": "node ./scripts/sync-version.mjs",
     "version:check": "node ./scripts/check-version-drift.mjs",
+    "credits:sync": "node ./scripts/sync-credits.mjs",
+    "credits:check": "node ./scripts/sync-credits.mjs --check",
     "backgroundremover:install": "node ./scripts/install-backgroundremover.mjs",
     "backgroundremover:reinstall": "node ./scripts/install-backgroundremover.mjs --reinstall",
     "guard:installer-artifacts": "node ./scripts/check-tracked-installers.mjs",

--- a/packages/client/src/components/chat/HomeCreditsModal.tsx
+++ b/packages/client/src/components/chat/HomeCreditsModal.tsx
@@ -2,27 +2,30 @@ import { ExternalLink } from "lucide-react";
 import { Modal } from "../ui/Modal";
 
 const CONTRIBUTORS = [
-  { login: "SpicyMarinara", url: "https://github.com/SpicyMarinara", contributions: 497 },
+  { login: "SpicyMarinara", url: "https://github.com/SpicyMarinara", contributions: 1079 },
   { login: "cha1latte", url: "https://github.com/cha1latte", contributions: 319 },
+  { login: "Romuromylus", url: "https://github.com/Romuromylus", contributions: 175 },
+  { login: "kolacheee", url: "https://github.com/kolacheee", contributions: 143 },
   { login: "LukaTheHero", url: "https://github.com/LukaTheHero", contributions: 86 },
-  { login: "Romuromylus", url: "https://github.com/Romuromylus", contributions: 77 },
-  { login: "TheLonelyDevil9", url: "https://github.com/TheLonelyDevil9", contributions: 66 },
-  { login: "Xelvanis", url: "https://github.com/Xelvanis", contributions: 66 },
+  { login: "Xelvanis", url: "https://github.com/Xelvanis", contributions: 70 },
+  { login: "TheLonelyDevil9", url: "https://github.com/TheLonelyDevil9", contributions: 69 },
   { login: "Promansis", url: "https://github.com/Promansis", contributions: 64 },
   { login: "coxde", url: "https://github.com/coxde", contributions: 60 },
-  { login: "kolacheee", url: "https://github.com/kolacheee", contributions: 15 },
-  { login: "aeriondyseti", url: "https://github.com/aeriondyseti", contributions: 14 },
-  { login: "Copilot", url: "https://github.com/apps/copilot-swe-agent", contributions: 13 },
-  { login: "Minsklatte", url: "https://github.com/Minsklatte", contributions: 12 },
+  { login: "thetopham", url: "https://github.com/thetopham", contributions: 49 },
+  { login: "Gunterlie", url: "https://github.com/Gunterlie", contributions: 48 },
+  { login: "munimunigamer", url: "https://github.com/munimunigamer", contributions: 30 },
+  { login: "Minsklatte", url: "https://github.com/Minsklatte", contributions: 16 },
+  { login: "aeriondyseti", url: "https://github.com/aeriondyseti", contributions: 15 },
   { login: "JorgeLTE", url: "https://github.com/JorgeLTE", contributions: 11 },
-  { login: "munimunigamer", url: "https://github.com/munimunigamer", contributions: 11 },
+  { login: "Sulphuratum", url: "https://github.com/Sulphuratum", contributions: 10 },
   { login: "loungemeister", url: "https://github.com/loungemeister", contributions: 9 },
   { login: "NeoKazuya", url: "https://github.com/NeoKazuya", contributions: 7 },
   { login: "felorhik", url: "https://github.com/felorhik", contributions: 6 },
-  { login: "amauragis", url: "https://github.com/amauragis", contributions: 5 },
+  { login: "bignast", url: "https://github.com/bignast", contributions: 6 },
+  { login: "jake9000", url: "https://github.com/jake9000", contributions: 5 },
   { login: "mm14141", url: "https://github.com/mm14141", contributions: 5 },
+  { login: "amauragis", url: "https://github.com/amauragis", contributions: 5 },
   { login: "marysia", url: "https://github.com/marysia", contributions: 4 },
-  { login: "jake9000", url: "https://github.com/jake9000", contributions: 4 },
   { login: "LightD31", url: "https://github.com/LightD31", contributions: 3 },
   { login: "Lochalan", url: "https://github.com/Lochalan", contributions: 2 },
   { login: "ailthrim", url: "https://github.com/ailthrim", contributions: 2 },
@@ -34,17 +37,18 @@ const CONTRIBUTORS = [
   { login: "Javedz678", url: "https://github.com/Javedz678", contributions: 2 },
   { login: "Morgul", url: "https://github.com/Morgul", contributions: 2 },
   { login: "BahamutRU", url: "https://github.com/BahamutRU", contributions: 2 },
-  { login: "Anarchistcowboy", url: "https://github.com/Anarchistcowboy", contributions: 1 },
-  { login: "DarthTheMonster", url: "https://github.com/DarthTheMonster", contributions: 1 },
-  { login: "Dinokin", url: "https://github.com/Dinokin", contributions: 1 },
-  { login: "Gunterlie", url: "https://github.com/Gunterlie", contributions: 1 },
-  { login: "Rafa-Ross", url: "https://github.com/Rafa-Ross", contributions: 1 },
-  { login: "kevin-ho", url: "https://github.com/kevin-ho", contributions: 1 },
-  { login: "pwildani", url: "https://github.com/pwildani", contributions: 1 },
-  { login: "vanta-jack", url: "https://github.com/vanta-jack", contributions: 1 },
-  { login: "Yasyasyasvil", url: "https://github.com/Yasyasyasvil", contributions: 1 },
-  { login: "taiman724", url: "https://github.com/taiman724", contributions: 1 },
   { login: "smurfboyyessir", url: "https://github.com/smurfboyyessir", contributions: 1 },
+  { login: "taiman724", url: "https://github.com/taiman724", contributions: 1 },
+  { login: "Yasyasyasvil", url: "https://github.com/Yasyasyasvil", contributions: 1 },
+  { login: "vanta-jack", url: "https://github.com/vanta-jack", contributions: 1 },
+  { login: "pwildani", url: "https://github.com/pwildani", contributions: 1 },
+  { login: "Lemon-will", url: "https://github.com/Lemon-will", contributions: 1 },
+  { login: "Lamboozled", url: "https://github.com/Lamboozled", contributions: 1 },
+  { login: "kevin-ho", url: "https://github.com/kevin-ho", contributions: 1 },
+  { login: "Rafa-Ross", url: "https://github.com/Rafa-Ross", contributions: 1 },
+  { login: "Dinokin", url: "https://github.com/Dinokin", contributions: 1 },
+  { login: "DarthTheMonster", url: "https://github.com/DarthTheMonster", contributions: 1 },
+  { login: "Anarchistcowboy", url: "https://github.com/Anarchistcowboy", contributions: 1 },
 ];
 
 const SPECIAL_THANKS = [
@@ -100,7 +104,7 @@ export function HomeCreditsModal({ open, onClose }: { open: boolean; onClose: ()
               GitHub Contributors
             </h3>
             <p className="mt-1 text-xs text-[var(--muted-foreground)]">
-              Current contributors from the Marinara Engine GitHub repository.
+              Synced from the Marinara Engine GitHub contributors list.
             </p>
           </div>
           <div className="grid max-h-[18rem] grid-cols-1 gap-2 overflow-y-auto pr-1 sm:grid-cols-2">

--- a/packages/client/src/components/panels/SettingsPanel.tsx
+++ b/packages/client/src/components/panels/SettingsPanel.tsx
@@ -165,9 +165,9 @@ type CustomFontFace = {
 const TABS = [
   { id: "general", label: "General" },
   { id: "appearance", label: "Appearance" },
-  { id: "themes", label: "Themes" },
-  { id: "extensions", label: "Extensions" },
-  { id: "import", label: "Import" },
+  { id: "generations", label: "Generations" },
+  { id: "addons", label: "Addons" },
+  { id: "import", label: "Imports" },
   { id: "advanced", label: "Advanced" },
 ] as const;
 
@@ -217,11 +217,17 @@ function getNativeConsoleShortcutHelp(): string {
 const SETTINGS_COMPONENTS: Record<(typeof TABS)[number]["id"], React.FC> = {
   general: React.memo(GeneralSettings),
   appearance: React.memo(AppearanceSettings),
-  themes: React.memo(ThemesSettings),
-  extensions: React.memo(ExtensionsSettings),
+  generations: React.memo(GenerationsSettings),
+  addons: React.memo(AddonsSettings),
   import: React.memo(ImportSettings),
   advanced: React.memo(AdvancedSettings),
 };
+
+function normalizeSettingsTab(tab: string): (typeof TABS)[number]["id"] {
+  if (tab === "themes") return "addons";
+  if (tab === "extensions") return "addons";
+  return TABS.some((entry) => entry.id === tab) ? (tab as (typeof TABS)[number]["id"]) : "general";
+}
 
 type SettingsArtPreviewSize = { width: number; height: number };
 
@@ -268,7 +274,7 @@ const EXPUNGE_SCOPE_OPTIONS: Array<{ id: ExpungeScope; label: string; descriptio
   { id: "connections", label: "Connections", description: "API connections and model endpoints." },
   {
     id: "automation",
-    label: "Automation & Themes",
+    label: "Automation & Addons",
     description: "Agents, tools, regex scripts, synced themes, and automation state.",
   },
   {
@@ -429,14 +435,6 @@ const GAME_ASSET_CATEGORIES = [
     defaultFolder: "custom",
     accept: "image/*",
   },
-] as const;
-
-const GAME_IMAGE_PROMPT_TEMPLATE_KEYS = [
-  "game.npcPortrait",
-  "game.background",
-  "game.sceneIllustration",
-  "game.narrationSummarizer",
-  "game.storyboardIllustrationDirector",
 ] as const;
 
 const VIDEO_PROMPT_TEMPLATE_KEYS = [
@@ -681,7 +679,7 @@ function ImageStyleProfilesEditor({
             type="button"
             onClick={deleteSelected}
             disabled={selected.builtIn || settings.profiles.length <= 1}
-            className="inline-flex h-8 items-center gap-1 rounded-md bg-[var(--secondary)] px-2.5 text-xs text-[var(--destructive)] ring-1 ring-[var(--border)] transition-colors hover:bg-[var(--accent)] disabled:cursor-not-allowed disabled:opacity-45"
+            className="inline-flex h-8 items-center gap-1 rounded-md bg-[var(--secondary)] px-2.5 text-xs text-[var(--muted-foreground)] ring-1 ring-[var(--border)] transition-colors hover:bg-[var(--accent)] hover:text-[var(--foreground)] disabled:cursor-not-allowed disabled:opacity-45"
           >
             <Trash2 size="0.75rem" />
             Delete
@@ -760,7 +758,7 @@ function ImageStyleProfilesEditor({
         </div>
       </details>
 
-      <details className="mt-2 rounded-md bg-[var(--secondary)]/55 p-2 ring-1 ring-[var(--border)]" open>
+      <details className="mt-2 rounded-md bg-[var(--secondary)]/55 p-2 ring-1 ring-[var(--border)]">
         <summary className="cursor-pointer text-xs font-medium text-[var(--foreground)]">Test bench</summary>
         <div className="mt-2 grid gap-2 lg:grid-cols-[minmax(0,0.9fr)_minmax(0,1.1fr)]">
           <div className="space-y-2">
@@ -1161,8 +1159,16 @@ function TrackerPanelAppearanceDrawer({
 }
 
 export function SettingsPanel() {
-  const settingsTab = useUIStore((s) => s.settingsTab);
+  const rawSettingsTab = useUIStore((s) => s.settingsTab);
   const setSettingsTab = useUIStore((s) => s.setSettingsTab);
+  const settingsTab = normalizeSettingsTab(rawSettingsTab);
+
+  useEffect(() => {
+    if (rawSettingsTab !== settingsTab) {
+      setSettingsTab(settingsTab);
+    }
+  }, [rawSettingsTab, setSettingsTab, settingsTab]);
+
   mountedSettingsTabs.add(settingsTab);
 
   return (
@@ -3673,7 +3679,45 @@ function BackgroundPicker({
   );
 }
 
-function ThemesSettings() {
+function GenerationsSettings() {
+  return (
+    <div className="flex flex-col gap-3">
+      <SettingsIntro>
+        Global defaults for generated images, generated videos, and reusable prompt templates.
+      </SettingsIntro>
+
+      <ImageGenerationSettings />
+      <VideoGenerationSettings />
+      <PromptOverridesEditor
+        title="Video Generation Prompt Overrides"
+        description="Edit reusable templates for Game/Gallery scene videos, Conversation Call character clips, and animated Expression portraits."
+        help="Game scene videos use this before sending a reference-image video request. Conversation Call clips use the selected character avatar as the identity reference and return to idle at the end of each clip. Animated Expression portraits become looping GIF sprites."
+        keys={VIDEO_PROMPT_TEMPLATE_KEYS}
+        preferredKey="game.video"
+      />
+      <PromptOverridesEditor
+        title="Image Generation Prompt Overrides"
+        description="Edit the templates used by image, sprite, Game, and prompt-builder systems."
+        help="Global templates for registered prompt builders, including Conversation selfies, Game NPC portraits, scene media, storyboard prompts, and other registered builders."
+        preferredKey="game.npcPortrait"
+      />
+    </div>
+  );
+}
+
+function AddonsSettings() {
+  return (
+    <div className="flex flex-col gap-3">
+      <SettingsIntro>
+        Custom themes change Marinara's look; extensions add trusted browser or server behavior.
+      </SettingsIntro>
+      <ThemesSettings showIntro={false} />
+      <ExtensionsSettings showIntro={false} />
+    </div>
+  );
+}
+
+function ThemesSettings({ showIntro = true }: { showIntro?: boolean } = {}) {
   const { data: syncedThemes = [], isLoading } = useThemes();
   const createTheme = useCreateTheme();
   const updateTheme = useUpdateTheme();
@@ -3950,9 +3994,11 @@ function ThemesSettings() {
   // ── Theme List View ──
   return (
     <div className="flex flex-col gap-3">
-      <SettingsIntro>
-        Create or import custom CSS themes. Themes sync across devices connected to this Marinara server.
-      </SettingsIntro>
+      {showIntro && (
+        <SettingsIntro>
+          Create or import custom CSS themes. Themes sync across devices connected to this Marinara server.
+        </SettingsIntro>
+      )}
 
       <SettingsSection
         title="Theme Library"
@@ -4386,7 +4432,7 @@ function triggerFilePicker(options: {
   el.click();
 }
 
-function ExtensionsSettings() {
+function ExtensionsSettings({ showIntro = true }: { showIntro?: boolean } = {}) {
   const { data: extensions, isLoading } = useExtensions();
   const extensionList = extensions ?? [];
   const createExtension = useCreateExtension();
@@ -4595,7 +4641,9 @@ function ExtensionsSettings() {
 
   return (
     <div className="flex flex-col gap-3">
-      <SettingsIntro>Install browser or trusted server extensions to add custom behavior or styling.</SettingsIntro>
+      {showIntro && (
+        <SettingsIntro>Install browser or trusted server extensions to add custom behavior or styling.</SettingsIntro>
+      )}
 
       <SettingsSection
         title="Extension Library"
@@ -4741,11 +4789,11 @@ function ExtensionsSettings() {
             <code className="rounded bg-[var(--secondary)] px-1">Extensions/My Extension/manifest.json</code>
             . Browser extensions can include CSS and/or JavaScript files to modify the UI.
           </div>
-          <div className="rounded-lg bg-amber-500/10 p-2.5 text-[0.625rem] leading-relaxed text-amber-200 ring-1 ring-amber-500/20">
+          <div className="rounded-lg bg-[var(--secondary)]/50 p-2.5 text-[0.625rem] leading-relaxed text-[var(--muted-foreground)] ring-1 ring-[var(--border)]">
             <strong>Server extensions:</strong> use{" "}
-            <code className="rounded bg-amber-500/10 px-1">runtime: "server"</code> with{" "}
-            <code className="rounded bg-amber-500/10 px-1">serverJsPath</code>, or import a{" "}
-            <code className="rounded bg-amber-500/10 px-1">.server.js</code> file. They run in the Node.js server
+            <code className="rounded bg-[var(--secondary)] px-1">runtime: "server"</code> with{" "}
+            <code className="rounded bg-[var(--secondary)] px-1">serverJsPath</code>, or import a{" "}
+            <code className="rounded bg-[var(--secondary)] px-1">.server.js</code> file. They run in the Node.js server
             process and should only come from trusted sources.
           </div>
           <div className="rounded-lg bg-[var(--secondary)]/35 p-2.5 text-[0.625rem] leading-relaxed text-[var(--muted-foreground)] ring-1 ring-[var(--border)]">
@@ -5514,7 +5562,7 @@ function AdvancedSettings() {
   const setDebugMode = useUIStore((s) => s.setDebugMode);
   const clearAllData = useClearAllData();
   const expungeData = useExpungeData();
-  const [selectedScopes, setSelectedScopes] = useState<ExpungeScope[]>(["chats"]);
+  const [selectedScopes, setSelectedScopes] = useState<ExpungeScope[]>([]);
   const [confirmAction, setConfirmAction] = useState<"selected" | "all" | null>(null);
   const [exportingProfile, setExportingProfile] = useState(false);
   const [exportProfileDialogOpen, setExportProfileDialogOpen] = useState(false);
@@ -5875,7 +5923,7 @@ function AdvancedSettings() {
       />
 
       <SettingsIntro>
-        Server maintenance, generation tooling, message utilities, backups, and data removal.
+        Server maintenance, message utilities, backups, and data removal.
       </SettingsIntro>
 
       <SettingsSection
@@ -6109,24 +6157,6 @@ function AdvancedSettings() {
           </div>
         </div>
       </SettingsSection>
-
-      <ImageGenerationSettings />
-      <VideoGenerationSettings />
-      <PromptOverridesEditor
-        title="Video Generation Prompt Templates"
-        description="Edit reusable templates for Game/Gallery scene videos, Conversation Call character clips, and animated Expression portraits."
-        help="Game scene videos use this before sending a reference-image video request. Conversation Call clips use the selected character avatar as the identity reference and return to idle at the end of each clip. Animated Expression portraits become looping GIF sprites."
-        keys={VIDEO_PROMPT_TEMPLATE_KEYS}
-        preferredKey="game.video"
-      />
-      <PromptOverridesEditor
-        title="Game Prompt Templates"
-        description="Edit the reusable templates used for NPC portraits, scene backgrounds, scene illustrations, storyboard keyframes, and narration summarization."
-        help="These templates render before recurring Game image requests, storyboard keyframe planning, and narration-to-illustration summarization. One-off prompt review edits still only affect the current request."
-        keys={GAME_IMAGE_PROMPT_TEMPLATE_KEYS}
-        preferredKey="game.npcPortrait"
-      />
-      <PromptOverridesEditor />
 
       <SettingsSection
         title="Message Tools"
@@ -6411,7 +6441,6 @@ function AdvancedSettings() {
         title="Danger Zone"
         description="Permanently clear selected categories of local data. Professor Mari is always preserved."
         icon={<AlertTriangle size="0.875rem" />}
-        tone="danger"
       >
         <div className="flex flex-col gap-2">
           <div className="grid gap-2">
@@ -6423,7 +6452,7 @@ function AdvancedSettings() {
                   className={cn(
                     "flex cursor-pointer items-start gap-2 rounded-lg px-2.5 py-2 ring-1 transition-colors",
                     checked
-                      ? "bg-[var(--destructive)]/10 ring-[var(--destructive)]/25"
+                      ? "bg-[var(--primary)]/10 ring-[var(--primary)]/30"
                       : "bg-[var(--background)]/40 ring-[var(--border)] hover:bg-[var(--secondary)]/70",
                   )}
                 >
@@ -6432,10 +6461,12 @@ function AdvancedSettings() {
                     checked={checked}
                     disabled={isClearing}
                     onChange={() => toggleScope(scope.id)}
-                    className="mt-0.5 h-3.5 w-3.5 rounded border-[var(--border)] accent-[var(--destructive)]"
+                    className="mt-0.5 h-3.5 w-3.5 rounded border-[var(--border)] accent-[var(--primary)]"
                   />
                   <span className="min-w-0">
-                    <span className="block text-xs font-medium text-[var(--foreground)]">{scope.label}</span>
+                    <span className="block text-xs font-medium text-[var(--marinara-chat-chrome-panel-text)]">
+                      {scope.label}
+                    </span>
                     <span className="block text-[0.625rem] text-[var(--muted-foreground)]">{scope.description}</span>
                   </span>
                 </label>
@@ -6470,9 +6501,9 @@ function AdvancedSettings() {
             </button>
           </div>
           {confirmAction && (
-            <div className="flex flex-col gap-2 rounded-lg bg-[var(--destructive)]/12 p-2.5">
-              <div className="flex items-start gap-2 text-[0.6875rem] font-medium text-[var(--destructive)]">
-                <AlertTriangle size="0.875rem" className="mt-0.5 shrink-0" />
+            <div className="flex flex-col gap-2 rounded-lg bg-[var(--background)]/55 p-2.5 ring-1 ring-[var(--border)]">
+              <div className="flex items-start gap-2 text-[0.6875rem] font-medium text-[var(--marinara-chat-chrome-panel-text)]">
+                <AlertTriangle size="0.875rem" className="mt-0.5 shrink-0 text-[var(--marinara-chat-chrome-button-text-active)]" />
                 {confirmAction === "all"
                   ? "Delete all supported data categories except Professor Mari? There is no undo."
                   : `Delete ${selectedScopes.length} selected data categor${selectedScopes.length === 1 ? "y" : "ies"}? There is no undo.`}

--- a/packages/client/src/components/panels/settings/SettingControls.tsx
+++ b/packages/client/src/components/panels/settings/SettingControls.tsx
@@ -59,7 +59,7 @@ export function SettingsSection({
           <div
             className={cn(
               "inline-flex items-center gap-1 text-xs font-semibold",
-              tone === "danger" ? "text-[var(--destructive)]" : "text-[var(--foreground)]",
+              tone === "danger" ? "text-[var(--destructive)]" : "text-[var(--marinara-chat-chrome-panel-title)]",
             )}
           >
             {title}

--- a/packages/server/src/routes/chats.routes.ts
+++ b/packages/server/src/routes/chats.routes.ts
@@ -20,8 +20,6 @@ import {
   resolveMacros,
   stripMacroComments,
   summariesPatchSchema,
-  unwrapConversationInstructions,
-  wrapConversationInstructions,
   coerceGameStateTextValue,
   normalizeTrackerFieldLocks,
   parseTrackerFieldLocks,
@@ -74,6 +72,8 @@ import {
   resolveActiveCharacterIds,
   resolveVisibleGameStateAnchor,
   shouldEnableAgentsForGeneration,
+  formatConversationInstructionsForWrap,
+  normalizePromptWrapFormat,
 } from "./generate/generate-route-utils.js";
 import {
   filterGameInternalAgentIds,
@@ -2116,10 +2116,11 @@ export async function chatsRoutes(app: FastifyInstance) {
                 .replace(/\{\{userName\}\}/g, personaName),
               promptMacroContext,
             );
+            const wrapFormat = normalizePromptWrapFormat((preset as Record<string, unknown> | null)?.wrapFormat);
             const messages = [
               {
                 role: "system" as const,
-                content: wrapConversationInstructions(unwrapConversationInstructions(renderedConversationPrompt)),
+                content: formatConversationInstructionsForWrap(renderedConversationPrompt, wrapFormat),
               },
               ...mappedMessages,
             ];

--- a/packages/server/src/routes/generate.routes.ts
+++ b/packages/server/src/routes/generate.routes.ts
@@ -30,7 +30,6 @@ import {
   DEFAULT_CONVERSATION_PROMPT,
   CONVERSATION_COMMAND_KEYS,
   unwrapConversationInstructions,
-  wrapConversationInstructions,
   NARRATIVE_DIRECTOR_SECRET_PLOT_PROMPT,
   findKnownModel,
   LOCAL_SIDECAR_CONNECTION_ID,
@@ -54,6 +53,7 @@ import type {
   ChatMode,
   ThinkingTagPair,
   ConversationCommandKey,
+  WrapFormat,
 } from "@marinara-engine/shared";
 import { createChatsStorage } from "../services/storage/chats.storage.js";
 import { createConnectionsStorage } from "../services/storage/connections.storage.js";
@@ -211,6 +211,7 @@ import {
   dedupeLastMessageWrappers,
   findLastIndex,
   findTrackerContextInsertIndex,
+  formatConversationInstructionsForWrap,
   appendReadableAttachmentsToContent,
   extractFileAttachmentInputs,
   getAttachmentFilename,
@@ -228,6 +229,7 @@ import {
   isManualTrackerCharacterId,
   isMessageHiddenFromAI,
   mergeCustomParameters,
+  normalizePromptWrapFormat,
   parseExtra,
   parseJsonField,
   parseStoredGenerationParameters,
@@ -608,6 +610,34 @@ function formatSecretPlotSystemBlock(arcRaw: unknown, wrapFormat: "xml" | "markd
   const payload = JSON.stringify({ overarchingArc: arc }, null, 2);
   if (wrapFormat === "none") return `Secret plot\n${payload}`;
   return wrapContent(payload, "Secret plot", wrapFormat);
+}
+
+function formatConversationSummaryHistoryBlock(label: string, summary: string, wrapFormat: WrapFormat): string {
+  if (wrapFormat === "xml") return `<summary ${label}>\n${summary}\n</summary>`;
+  const displayLabel = label.replace(/="/g, ": ").replace(/"$/g, "");
+  if (wrapFormat === "markdown") return `## Summary (${displayLabel})\n${summary}`;
+  return `Summary (${displayLabel})\n${summary}`;
+}
+
+function formatConversationDateHistoryMessages(
+  messages: Array<{ role: "system" | "user" | "assistant"; author: string; content: string }>,
+  date: string,
+  wrapFormat: WrapFormat,
+): Array<{ role: "system" | "user" | "assistant"; content: string }> {
+  if (messages.length === 0) return [];
+  if (wrapFormat === "xml") {
+    return messages.map((message, idx) => {
+      let content = `${message.author}: ${message.content}`;
+      if (idx === 0) content = `<date="${date}">\n${content}`;
+      if (idx === messages.length - 1) content = `${content}\n</date>`;
+      return { role: message.role, content };
+    });
+  }
+
+  return messages.map((message, idx) => {
+    const prefix = idx === 0 ? (wrapFormat === "markdown" ? `## Date: ${date}\n` : `Date: ${date}\n`) : "";
+    return { role: message.role, content: `${prefix}${message.author}: ${message.content}` };
+  });
 }
 
 function appendSecretPlotSystemMessage(
@@ -2419,6 +2449,9 @@ export async function generateRoutes(app: FastifyInstance) {
         let enabledParameters: GenerationParameterSendMap | undefined;
         let stopSequences: string[] = [];
         let wrapFormat: "xml" | "markdown" | "none" = "xml";
+        if (chatMode === "conversation" && resolvedPreset) {
+          wrapFormat = normalizePromptWrapFormat(resolvedPreset.wrapFormat);
+        }
         const runtimeAgentSectionTypes = new Set<RuntimeAgentSectionType>();
         const runtimeAgentSectionTokens = new Map<RuntimeAgentSectionType, RuntimeAgentSectionTokens>();
         const modelAccessPolicy = resolveModelAccessPolicy({
@@ -3365,8 +3398,8 @@ export async function generateRoutes(app: FastifyInstance) {
             }
           }
 
-          // Flatten: consolidated weeks → single <summary week="..."> block,
-          // non-consolidated summarized days → <summary date="..."> block,
+          // Flatten: consolidated weeks/non-consolidated summarized days → one summary block
+          // in the selected preset wrapping format,
           // today → individual timestamped messages.
           // The tail block is spliced in at firstTodayIdx so it sits between
           // the last summary and today's first verbatim message.
@@ -3409,12 +3442,16 @@ export async function generateRoutes(app: FastifyInstance) {
                 const wEntry = weekSummaries[weekKey]!;
                 const monday = parseDateKey(weekKey);
                 const sunday = new Date(monday.getFullYear(), monday.getMonth(), monday.getDate() + 6);
-                // Key details are surfaced separately via <important_memories> in the system prompt.
+                // Key details are surfaced separately in the system prompt.
                 return [
                   ...prefix,
                   {
                     role: "system" as const,
-                    content: `<summary week="${weekKey} – ${fmtDateKey(sunday)}">\n${wEntry.summary}\n</summary>`,
+                    content: formatConversationSummaryHistoryBlock(
+                      `week="${weekKey} – ${fmtDateKey(sunday)}"`,
+                      wEntry.summary,
+                      wrapFormat,
+                    ),
                   },
                 ];
               }
@@ -3422,22 +3459,25 @@ export async function generateRoutes(app: FastifyInstance) {
               // Non-consolidated day with a summary
               const entry = daySummaries[bucket.date];
               if (entry) {
-                // Key details are surfaced separately via <important_memories> in the system prompt.
+                // Key details are surfaced separately in the system prompt.
                 return [
                   ...prefix,
                   {
                     role: "system" as const,
-                    content: `<summary date="${bucket.date}">\n${entry.summary}\n</summary>`,
+                    content: formatConversationSummaryHistoryBlock(`date="${bucket.date}"`, entry.summary, wrapFormat),
                   },
                 ];
               }
               // Unsummarized past day — keep each message as its own turn
-              const turns = bucket.msgs.map((m, idx) => {
-                let content = `${m.author}: ${m.content}`;
-                if (idx === 0) content = `<date="${bucket.date}">\n${content}`;
-                if (idx === bucket.msgs.length - 1) content = `${content}\n</date>`;
-                return { role: m.role as "user" | "assistant" | "system", content };
-              });
+              const turns = formatConversationDateHistoryMessages(
+                bucket.msgs.map((m) => ({
+                  role: m.role as "user" | "assistant" | "system",
+                  author: m.author,
+                  content: m.content,
+                })),
+                bucket.date,
+                wrapFormat,
+              );
               return [...prefix, ...turns];
             }
             return [...prefix, b as { role: "system" | "user" | "assistant"; content: string }];
@@ -3498,8 +3538,9 @@ export async function generateRoutes(app: FastifyInstance) {
             );
           }
 
-          let conversationSystemPrompt = wrapConversationInstructions(
+          let conversationSystemPrompt = formatConversationInstructionsForWrap(
             conversationInstructionParts.filter((part) => part.trim().length > 0).join("\n\n"),
+            wrapFormat,
           );
 
           // ── Character Commands: build a commands block if any features are enabled ──
@@ -3859,8 +3900,7 @@ export async function generateRoutes(app: FastifyInstance) {
               : null;
           const intentHint = isMessageIntent(input.autonomousIntentKey) ? getIntentHint(input.autonomousIntentKey) : "";
 
-          const contextBlock = [
-            `<context>`,
+          const contextLines = [
             `Your current status: ${statusLine}.`,
             ...(shouldIncludeUserStatus ? [`${personaName}'s status: ${userStatusLine}.`] : []),
             ...(proactiveTurnLine ? [proactiveTurnLine] : []),
@@ -3871,8 +3911,8 @@ export async function generateRoutes(app: FastifyInstance) {
             ...(isGroup && earlyGroupMode !== "individual"
               ? [`- Remember to prefix messages with \`Name: message\`!`]
               : []),
-            `</context>`,
-          ].join("\n");
+          ];
+          const contextBlock = wrapContent(contextLines.join("\n"), "Context", wrapFormat);
 
           // ── Cross-chat awareness: show messages from other chats this character is in ──
           // (awarenessBlock is injected later, after persona info)
@@ -4087,13 +4127,12 @@ export async function generateRoutes(app: FastifyInstance) {
               };
               return extractDate(a.label) - extractDate(b.label);
             });
-            const memoryLines = [`<important_memories>`, `Things you must remember from past conversations:`];
+            const memoryLines = [`Things you must remember from past conversations:`];
             for (const { label, details } of allKeyDetails) {
               memoryLines.push(`[${label}]`);
               for (const d of details) memoryLines.push(`- ${d}`);
             }
-            memoryLines.push(`</important_memories>`);
-            conversationSystemPrompt += "\n\n" + memoryLines.join("\n");
+            conversationSystemPrompt += "\n\n" + wrapContent(memoryLines.join("\n"), "Important Memories", wrapFormat);
           }
 
           conversationSystemPrompt = resolvePromptMacros(conversationSystemPrompt);
@@ -4148,7 +4187,7 @@ export async function generateRoutes(app: FastifyInstance) {
               .filter(Boolean)
               .join("\n");
             if (loreContent) {
-              const loreBlock = `<lore>\n${loreContent}\n</lore>`;
+              const loreBlock = wrapContent(loreContent, "Lore", wrapFormat);
               // Inject before the awareness block (or before first user/assistant message)
               const firstUserIdx = finalMessages.findIndex((m) => m.role === "user" || m.role === "assistant");
               const insertAt = firstUserIdx >= 0 ? firstUserIdx : finalMessages.length;

--- a/packages/server/src/routes/generate/dry-run-route.ts
+++ b/packages/server/src/routes/generate/dry-run-route.ts
@@ -7,8 +7,6 @@ import {
   stripMacroComments,
   DEFAULT_CONVERSATION_PROMPT,
   DEFAULT_GAME_SYSTEM_PROMPT,
-  wrapConversationInstructions,
-  unwrapConversationInstructions,
   type GenerationParameterSendMap,
   type LorebookEntryTimingState,
 } from "@marinara-engine/shared";
@@ -58,8 +56,10 @@ import {
   extractFileAttachmentInputs,
   extractImageAttachmentDataUrls,
   findTrackerContextInsertIndex,
+  formatConversationInstructionsForWrap,
   isMessageHiddenFromAI,
   mergeCustomParameters,
+  normalizePromptWrapFormat,
   parseExtra,
   parseStoredGenerationParameters,
   prefixGroupIndividualHistorySpeakers,
@@ -833,6 +833,9 @@ export async function registerDryRunRoute(app: FastifyInstance) {
     promptMacroContext.lastInput = [...mappedMessages].reverse().find((message) => message.role === "user")?.content;
 
     const usePromptParts = !!promptParts;
+    if (!usePromptParts && chatMode === "conversation" && effectivePreset) {
+      wrapFormat = normalizePromptWrapFormat(effectivePreset.wrapFormat);
+    }
     if (usePromptParts) {
       // Pick wrap format (default xml). If not specified, fall back to the selected preset's wrapFormat (if any).
       if (
@@ -840,9 +843,9 @@ export async function registerDryRunRoute(app: FastifyInstance) {
         promptParts.wrapFormat === "none" ||
         promptParts.wrapFormat === "xml"
       ) {
-        wrapFormat = promptParts.wrapFormat;
+        wrapFormat = normalizePromptWrapFormat(promptParts.wrapFormat);
       } else if (effectivePreset) {
-        wrapFormat = (effectivePreset.wrapFormat as "xml" | "markdown" | "none") || "xml";
+        wrapFormat = normalizePromptWrapFormat(effectivePreset.wrapFormat);
       }
 
       type PromptPartKey =
@@ -994,7 +997,7 @@ export async function registerDryRunRoute(app: FastifyInstance) {
         if (!includeChatSummary) return "";
         const summary = activeChatSummary ?? "";
         if (!summary) return "";
-        return wrapFormat === "xml" ? `<chat_summary>\n${summary}\n</chat_summary>` : `Chat summary:\n${summary}`;
+        return wrapContent(summary, "Chat Summary", wrapFormat);
       })();
 
       const lorebookPayload = includeLorebook
@@ -1038,7 +1041,7 @@ export async function registerDryRunRoute(app: FastifyInstance) {
             const loreContent = [lorebookResult.worldInfoBefore, lorebookResult.worldInfoAfter]
               .filter((content): content is string => typeof content === "string" && content.length > 0)
               .join("\n");
-            const loreBlock = loreContent ? `<lore>\n${loreContent}\n</lore>` : "";
+            const loreBlock = wrapContent(loreContent, "Lore", wrapFormat);
             return { loreBlock, depthEntries: lorebookResult.depthEntries };
           })()
         : { loreBlock: "", depthEntries: [] as any[] };
@@ -1152,7 +1155,6 @@ export async function registerDryRunRoute(app: FastifyInstance) {
         }
         if (key === "lorebook") {
           if (!lorebookPayload.loreBlock) continue;
-          // Lorebook already comes as `<lore> ... </lore>`.
           const insertChunks: Array<{ role: "system"; content: string }> = [
             { role: "system", content: lorebookPayload.loreBlock },
           ];
@@ -1179,7 +1181,7 @@ export async function registerDryRunRoute(app: FastifyInstance) {
       }
     } else if (effectivePresetId && effectivePreset && chatMode !== "conversation" && chatMode !== "game") {
       const preset = effectivePreset;
-      wrapFormat = (preset.wrapFormat as "xml" | "markdown" | "none") || "xml";
+      wrapFormat = normalizePromptWrapFormat(preset.wrapFormat);
       const [sections, groups, choiceBlocks] = await Promise.all([
         presets.listSections(effectivePresetId),
         presets.listGroups(effectivePresetId),
@@ -1315,7 +1317,7 @@ export async function registerDryRunRoute(app: FastifyInstance) {
           .replace(/\{\{userName\}\}/g, personaName),
       );
       finalMessages = [
-        { role: "system", content: wrapConversationInstructions(unwrapConversationInstructions(renderedConversationPrompt)) },
+        { role: "system", content: formatConversationInstructionsForWrap(renderedConversationPrompt, wrapFormat) },
         ...finalMessages,
       ];
     }
@@ -1345,8 +1347,7 @@ export async function registerDryRunRoute(app: FastifyInstance) {
     if (!usePromptParts && !effectivePresetId && resolvedInjectChatSummary) {
       const summary = activeChatSummary ?? "";
       if (summary) {
-        const block =
-          wrapFormat === "xml" ? `<chat_summary>\n${summary}\n</chat_summary>` : `Chat summary:\n${summary}`;
+        const block = wrapContent(summary, "Chat Summary", wrapFormat);
         const firstUserIdx = finalMessages.findIndex((m) => m.role === "user" || m.role === "assistant");
         const insertAt = firstUserIdx >= 0 ? firstUserIdx : finalMessages.length;
         finalMessages.splice(insertAt, 0, { role: "system", content: block });
@@ -1395,7 +1396,7 @@ export async function registerDryRunRoute(app: FastifyInstance) {
         .filter((content): content is string => typeof content === "string" && content.length > 0)
         .join("\n");
       if (loreContent) {
-        const loreBlock = `<lore>\n${loreContent}\n</lore>`;
+        const loreBlock = wrapContent(loreContent, "Lore", wrapFormat);
         const firstUserIdx = finalMessages.findIndex((m) => m.role === "user" || m.role === "assistant");
         const insertAt = firstUserIdx >= 0 ? firstUserIdx : finalMessages.length;
         finalMessages.splice(insertAt, 0, { role: "system", content: loreBlock });

--- a/packages/server/src/routes/generate/generate-route-utils.ts
+++ b/packages/server/src/routes/generate/generate-route-utils.ts
@@ -10,6 +10,8 @@ import {
   normalizeThinkingTagPairs,
   parseTrackerFieldLocks,
   resolveMacros,
+  unwrapConversationInstructions,
+  wrapConversationInstructions,
   type CharacterStat,
   type GameState,
   type GenerationParameterSendMap,
@@ -17,6 +19,7 @@ import {
   type InventoryItem,
   type MacroContext,
   type PlayerStats,
+  type WrapFormat,
 } from "@marinara-engine/shared";
 import { LOCAL_SIDECAR_MODEL } from "../../services/llm/local-sidecar.js";
 import { sidecarModelService } from "../../services/sidecar/sidecar-model.service.js";
@@ -70,6 +73,20 @@ export type LocalSidecarGenerationConnection = {
   createdAt: string;
   updatedAt: string;
 };
+
+const PROMPT_WRAP_FORMATS = new Set<WrapFormat>(["xml", "markdown", "none"]);
+
+export function normalizePromptWrapFormat(value: unknown): WrapFormat {
+  return typeof value === "string" && PROMPT_WRAP_FORMATS.has(value as WrapFormat) ? (value as WrapFormat) : "xml";
+}
+
+export function formatConversationInstructionsForWrap(prompt: string, wrapFormat: WrapFormat): string {
+  const body = unwrapConversationInstructions(prompt);
+  if (wrapFormat === "xml") return wrapConversationInstructions(body);
+  if (!body.trim()) return "";
+  if (wrapFormat === "markdown") return `## Instructions\n${body}`;
+  return body;
+}
 export type PromptAttachment = {
   type?: string | null;
   url?: string | null;

--- a/scripts/sync-credits.mjs
+++ b/scripts/sync-credits.mjs
@@ -1,0 +1,96 @@
+#!/usr/bin/env node
+import { readFile, writeFile } from "node:fs/promises";
+
+const CREDITS_MODAL_PATH = new URL("../packages/client/src/components/chat/HomeCreditsModal.tsx", import.meta.url);
+const CONTRIBUTORS_URL = "https://api.github.com/repos/Pasta-Devs/Marinara-Engine/contributors?per_page=100";
+
+const checkOnly = process.argv.includes("--check");
+
+async function fetchContributors() {
+  const headers = {
+    Accept: "application/vnd.github+json",
+    "User-Agent": "Marinara-Engine-Credits-Sync",
+  };
+  if (process.env.GITHUB_TOKEN) {
+    headers.Authorization = `Bearer ${process.env.GITHUB_TOKEN}`;
+  }
+
+  const contributors = [];
+  let nextUrl = CONTRIBUTORS_URL;
+
+  while (nextUrl) {
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), 15_000);
+    let res;
+    try {
+      res = await fetch(nextUrl, { headers, signal: controller.signal });
+    } catch (error) {
+      if (controller.signal.aborted) {
+        throw new Error("GitHub contributors request timed out after 15 seconds.");
+      }
+      throw error;
+    } finally {
+      clearTimeout(timeout);
+    }
+    if (!res.ok) {
+      throw new Error(`GitHub contributors request failed: ${res.status} ${res.statusText}`);
+    }
+    const page = await res.json();
+    if (!Array.isArray(page)) {
+      throw new Error("GitHub contributors response was not an array.");
+    }
+    contributors.push(
+      ...page.map((entry) => ({
+        login: String(entry.login ?? "").trim(),
+        url: String(entry.html_url ?? "").trim(),
+        contributions: Number(entry.contributions ?? 0),
+        type: String(entry.type ?? "User"),
+      })),
+    );
+
+    const link = res.headers.get("link") ?? "";
+    const nextMatch = link.match(/<([^>]+)>;\s*rel="next"/);
+    nextUrl = nextMatch?.[1] ?? "";
+  }
+
+  return contributors.filter(
+    (entry) =>
+      entry.login &&
+      entry.type !== "Bot" &&
+      entry.url.startsWith("https://github.com/") &&
+      Number.isFinite(entry.contributions),
+  );
+}
+
+function renderContributors(contributors) {
+  const rows = contributors.map(
+    (entry) =>
+      `  { login: ${JSON.stringify(entry.login)}, url: ${JSON.stringify(entry.url)}, contributions: ${entry.contributions} },`,
+  );
+  return `const CONTRIBUTORS = [\n${rows.join("\n")}\n];`;
+}
+
+function replaceContributors(source, contributorsBlock) {
+  const pattern = /const CONTRIBUTORS = \[\n[\s\S]*?\n\];/;
+  if (!pattern.test(source)) {
+    throw new Error("Could not find CONTRIBUTORS block in HomeCreditsModal.tsx.");
+  }
+  return source.replace(pattern, contributorsBlock);
+}
+
+const contributors = await fetchContributors();
+const source = await readFile(CREDITS_MODAL_PATH, "utf8");
+const nextSource = replaceContributors(source, renderContributors(contributors));
+
+if (nextSource === source) {
+  console.log(`Credits are up to date (${contributors.length} contributors).`);
+  process.exit(0);
+}
+
+if (checkOnly) {
+  console.error(`Credits are stale. Run pnpm credits:sync to refresh ${contributors.length} contributors.`);
+  process.exit(1);
+}
+
+await writeFile(CREDITS_MODAL_PATH, nextSource);
+console.log(`Updated Credits modal with ${contributors.length} GitHub contributors.`);


### PR DESCRIPTION
## Summary

This PR finishes the v2.1.1 settings/credits polish and fixes Conversation-mode prompt wrapping.

- Reorganizes Settings into Addons, Generations, Imports, and accent-styled Danger Zone behavior.
- Refreshes Credits from GitHub contributors and adds release workflow helpers for syncing/checking credits.
- Updates contributor/release docs around credits and the new Settings layout.
- Makes Conversation mode respect the selected preset wrap format for instructions, daily summaries/date blocks, context, memories, and lorebook injections.

## Why

Conversation mode had bespoke prompt assembly that bypassed the normal preset wrapper formatter, so users choosing Markdown or None still received XML-wrapped supplemental sections such as lore. The settings and credits changes keep v2.1.1 release surfaces aligned with the current UI and contributor list.

## Validation

- pnpm check
- pnpm regression:prompt
- pnpm credits:check

## Manual verification needed

- Manually verify the Settings navigation in the browser in light and dark themes.
- Manually verify Conversation prompt preview/send output for presets using XML, Markdown, and None wrap formats.

No linked issue was provided for the settings/credits work; one should be opened before final submission if maintainers require every PR to map to an issue.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a credits sync/check workflow for release preparation and refreshed the in-app contributors (Credits) list.

* **Bug Fixes**
  * Conversation mode now honors the user-selected prompt wrap format (XML, Markdown, or None) across instructions, summaries, memories, and lore content.

* **Improvements**
  * Reorganized Settings navigation with clearer **Generations** and **Addons** sections, plus updated Danger Zone and style profile editor defaults.

* **Documentation**
  * Updated guidance to match the new Settings navigation paths for themes/extensions and generation-related prompt templates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->