### PR TITLE
Refactor generation route runtimes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 - Bumped release metadata to v2.1.1 across packages, the PWA manifest, README release pointer, Windows installer sources, Android APK metadata, and the home-page-visible app version.
 - Reorganized Settings so Addons combines Themes and Extensions, Generations houses image/video generation and prompt overrides, Imports uses the plural label, generation prompt editors start collapsed, and Danger Zone uses accent-color selections with no default checked categories.
 - Refreshed the in-app Credits modal from the GitHub contributors list and added credits sync/check helpers to the release workflow.
+- Split the server generation route into focused prompt, provider, context, and command-runtime modules so Conversation commands, Professor Mari actions, turn games, provider setup, and post-processing paths are easier to review and maintain.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,8 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 - Fixed Conversation mode prompt assembly so selected preset wrap formats (XML, Markdown, or None) are respected for instructions, daily summary/date blocks, current context, memories, and lorebook injections instead of always wrapping supplemental sections in XML.
 - Restored the Echo Chamber chat as a collapsible panel instead of making close/collapse hide the chamber permanently for the chat (#3329).
 - Fixed manual group Conversation character triggers so the prompted character receives recent visible group transcript context and does not answer from profile/lorebook content alone (#3330).
+- Fixed Roleplay `/guided respond for <character>` in individual group chats so Manual mode asks for an explicit target instead of no-oping, and Smart mode honors the requested character instead of the queued responder badge.
+- Fixed first-turn lorebook activation so opening chat messages remain keyword-scannable during the first user generation even when the recent-message scan window would otherwise drop earlier group greetings (#3332).
 - Fixed Text to Speech character voice assignment so users can add character voices using provider default voices, including ElevenLabs defaults, even before custom/account voices are loaded.
 - Added a per-chat Conversation Calls setting to disable generated bracketed voice cues for TTS providers that do not accept `[whispering]`, `[laughing]`, `[sighs]`, and similar tags.
 

--- a/packages/client/src/components/chat/ChatInput.tsx
+++ b/packages/client/src/components/chat/ChatInput.tsx
@@ -623,6 +623,8 @@ export const ChatInput = memo(function ChatInput({
       invalidate: () => qc.invalidateQueries({ queryKey: chatKeys.all }),
       characterNames: activeCharacterNames,
       characters: activeChatCharacters,
+      requiresManualGuideTarget,
+      removeQueuedResponse: (characterId) => removeFromResponseQueue(activeChatId, characterId),
       latestAssistantMessageId: latestAssistantMessage?.id ?? null,
       lastMessageRole,
       setSpriteExpression: onExpressionChange
@@ -637,6 +639,8 @@ export const ChatInput = memo(function ChatInput({
     createMessage,
     activeCharacterNames,
     activeChatCharacters,
+    requiresManualGuideTarget,
+    removeFromResponseQueue,
     latestAssistantMessage,
     lastMessageRole,
     onExpressionChange,

--- a/packages/client/src/lib/slash-commands.ts
+++ b/packages/client/src/lib/slash-commands.ts
@@ -10,6 +10,7 @@ import { useGalleryStore } from "../stores/gallery.store";
 import { toast } from "sonner";
 import {
   SUPPORTED_MACROS,
+  buildGuidedGenerationInstructionMessage,
   buildNarratorInstructionMessage,
   normalizeTextForMatch,
   type SceneCreateResponse,
@@ -38,6 +39,8 @@ export interface SlashCommandContext {
     generationGuide?: string;
     generationGuideSource?: "narrator" | "guide" | "game_start";
     continueMessageId?: string;
+    mentionedCharacterNames?: string[];
+    forCharacterId?: string;
     impersonate?: boolean;
     attachments?: { type: string; data: string }[];
     impersonatePresetId?: string;
@@ -53,6 +56,10 @@ export interface SlashCommandContext {
   characterNames: string[];
   /** Characters available in the current roleplay scene */
   characters?: Array<{ id: string; name: string }>;
+  /** Manual individual group replies need a target character instead of an auto-selected responder. */
+  requiresManualGuideTarget?: boolean;
+  /** Clears a pending smart-response badge for a character after an explicit targeted command. */
+  removeQueuedResponse?: (characterId: string) => void;
   /** Latest assistant message, used when /continue appends to an unfinished reply */
   latestAssistantMessageId?: string | null;
   /** Role of the last message in the chat. /continue only appends to a trailing
@@ -88,6 +95,64 @@ function buildStatusCommandHelp(characters: Array<{ id: string; name: string }>)
   ]
     .filter(Boolean)
     .join("\n");
+}
+
+function formatGuidedTargetHelp(characters: Array<{ name: string }>): string {
+  const available = formatAvailableCharacterList(characters);
+  return `Use /guided respond for <character> <direction>${available ? `\nAvailable: ${available}` : ""}`;
+}
+
+function trimGuideSeparator(value: string): string {
+  return value.replace(/^\s*[:;,-]\s*/u, "").trim();
+}
+
+function guidedTargetRemainder(args: string): string | null {
+  const trimmed = args.trim();
+  const match =
+    trimmed.match(/^(?:respond|reply|answer)\s+(?:for|as|from)\s+/iu) ?? trimmed.match(/^(?:for|as|from)\s+/iu);
+  return match ? trimmed.slice(match[0].length).trim() : null;
+}
+
+function splitLeadingQuotedTarget(value: string): { targetName: string; rest: string } | null {
+  const match = value.match(/^["']([^"']+)["']([\s\S]*)$/u);
+  if (!match) return null;
+  return { targetName: match[1]!.trim(), rest: match[2] ?? "" };
+}
+
+function resolveGuidedCharacterTarget(
+  args: string,
+  characters: Array<{ id: string; name: string }> = [],
+): { character: { id: string; name: string }; guideText: string } | null {
+  const remainder = guidedTargetRemainder(args);
+  if (!remainder) return null;
+
+  const quotedTarget = splitLeadingQuotedTarget(remainder);
+  if (quotedTarget) {
+    const quotedName = normalizeTextForMatch(quotedTarget.targetName);
+    const character = characters.find((candidate) => normalizeTextForMatch(candidate.name) === quotedName);
+    return character ? { character, guideText: trimGuideSeparator(quotedTarget.rest) } : null;
+  }
+
+  const sortedCharacters = [...characters].sort(
+    (a, b) => normalizeTextForMatch(b.name).length - normalizeTextForMatch(a.name).length,
+  );
+  for (const character of sortedCharacters) {
+    const normalizedName = normalizeTextForMatch(character.name);
+    if (!normalizedName) continue;
+
+    const words = Array.from(remainder.matchAll(/\S+/gu));
+    for (const word of words) {
+      const end = (word.index ?? 0) + word[0].length;
+      const prefix = remainder.slice(0, end);
+      const normalizedPrefix = normalizeTextForMatch(prefix.replace(/[:;,-]+$/u, ""));
+      if (normalizedPrefix === normalizedName) {
+        return { character, guideText: trimGuideSeparator(remainder.slice(end)) };
+      }
+      if (!normalizedName.startsWith(normalizedPrefix)) break;
+    }
+  }
+
+  return null;
 }
 
 export interface SlashCommandResult {
@@ -520,9 +585,30 @@ const COMMANDS: SlashCommand[] = [
     name: "guided",
     aliases: ["narrator", "narrate", "nar"],
     description: "Steer the narrative — the AI will narrate events in the direction you describe",
-    usage: "/guided <direction>",
+    usage: "/guided [respond for <character>] <direction>",
     async execute(args, ctx) {
       if (!args.trim()) return { handled: true, feedback: "Usage: /guided <direction to steer the narrative>" };
+      const characters = ctx.characters ?? [];
+      const targetedResponse = resolveGuidedCharacterTarget(args, characters);
+      if (targetedResponse) {
+        const generationGuide = targetedResponse.guideText
+          ? buildGuidedGenerationInstructionMessage(targetedResponse.guideText)
+          : undefined;
+        ctx.removeQueuedResponse?.(targetedResponse.character.id);
+        await ctx.generate({
+          chatId: ctx.chatId,
+          connectionId: null,
+          forCharacterId: targetedResponse.character.id,
+          mentionedCharacterNames: [targetedResponse.character.name],
+          ...(generationGuide ? { generationGuide, generationGuideSource: "guide" as const } : {}),
+        });
+        return { handled: true };
+      }
+
+      if (guidedTargetRemainder(args) !== null || ctx.requiresManualGuideTarget) {
+        return { handled: true, feedback: formatGuidedTargetHelp(characters) };
+      }
+
       await ctx.generate({
         chatId: ctx.chatId,
         connectionId: null,

--- a/packages/server/src/routes/generate.routes.ts
+++ b/packages/server/src/routes/generate.routes.ts
@@ -7,7 +7,6 @@ import { join } from "path";
 import {
   generateRequestSchema,
   BUILT_IN_AGENTS,
-  DEFAULT_CHAT_SUMMARY_PROMPT,
   getDefaultBuiltInAgentSettings,
   resolveMacros,
   resolveDeferredCharacterMacros,
@@ -17,7 +16,6 @@ import {
   appendChatSummaryEntryToMetadata,
   applyQuestUpdatesToPlayerStats,
   buildQuestJournalData,
-  isClaudeAdaptiveOnlyNoSamplingModel,
   isAgentAvailableInChatMode,
   isAgentConfigDeleted,
   normalizeAgentPromptTemplateSelectionMap,
@@ -26,18 +24,12 @@ import {
   normalizeTrackerFieldLocksForState,
   trackerFieldLocksAreEmpty,
   customAgentHasCapability,
-  supportsXhighReasoningEffort,
   DEFAULT_CONVERSATION_PROMPT,
-  CONVERSATION_COMMAND_KEYS,
   unwrapConversationInstructions,
-  NARRATIVE_DIRECTOR_SECRET_PLOT_PROMPT,
   findKnownModel,
   LOCAL_SIDECAR_CONNECTION_ID,
   normalizeTextForMatch,
-  parseGroupedSpeakerSegments,
-  stripLeadingMessageTimestamps,
   type APIProvider,
-  type GroupedSegment,
 } from "@marinara-engine/shared";
 import type {
   AgentContext,
@@ -52,8 +44,6 @@ import type {
   ChatSummaryEntry,
   ChatMode,
   ThinkingTagPair,
-  ConversationCommandKey,
-  WrapFormat,
 } from "@marinara-engine/shared";
 import { createChatsStorage } from "../services/storage/chats.storage.js";
 import { createConnectionsStorage } from "../services/storage/connections.storage.js";
@@ -68,14 +58,10 @@ import { createCustomEmojisStorage } from "../services/storage/custom-emojis.sto
 import { createCustomStickersStorage } from "../services/storage/custom-stickers.storage.js";
 import { createCharacterGalleryStorage } from "../services/storage/character-gallery.storage.js";
 import { createPersonaGalleryStorage } from "../services/storage/persona-gallery.storage.js";
-import { createConversationCallsStorage } from "../services/storage/conversation-calls.storage.js";
-import { createAppSettingsStorage } from "../services/storage/app-settings.storage.js";
-import { localEmbed, isLocalEmbedderAvailable } from "../services/local-embedder.js";
-import { buildLorebookSemanticEmbeddingsById, cosineSimilarity } from "../services/lorebook/embeddings.js";
+import { buildLorebookSemanticEmbeddingsById } from "../services/lorebook/embeddings.js";
 import { applyRegexScriptsToPromptMessages } from "../services/regex/regex-application.js";
 import { createPromptOverridesStorage } from "../services/storage/prompt-overrides.storage.js";
-import { resolveConversationSelfieSystemPrompt } from "../services/conversation/selfie-prompt.js";
-import { filterRelevantLorebooks, processLorebooks, type LorebookScanResult } from "../services/lorebook/index.js";
+import { filterRelevantLorebooks, processLorebooks } from "../services/lorebook/index.js";
 import {
   filterGameInternalAgentIds,
   resolveLorebookScopeExclusions,
@@ -83,14 +69,12 @@ import {
 import { lorebookEntryPassesContextFilters, type GameStateForScanning } from "../services/lorebook/keyword-scanner.js";
 import { injectAtDepth } from "../services/lorebook/prompt-injector.js";
 import { createLLMProvider } from "../services/llm/provider-registry.js";
-import { getLocalSidecarProvider } from "../services/llm/local-sidecar.js";
 import { resolveChatSummaryConnection } from "../services/chat-summary/connection-resolution.js";
 import { resolveConnectionImageDefaults } from "../services/image/image-generation-defaults.js";
 import { loadImageGenerationUserSettings } from "../services/image/image-generation-settings.js";
 import { textRewriteDropsProtectedMarkup } from "../services/generation/text-rewrite-safety.js";
 import { compileImagePrompt } from "../services/image/image-prompt-compiler.js";
 import { extractLeadingThinkingBlocks } from "../services/llm/inline-thinking.js";
-import { resolveSpotifyCredentials, spotifyHasScope } from "../services/spotify/spotify.service.js";
 import { buildSpotifyDjConstraints } from "../services/spotify/spotify-dj-constraints.js";
 import {
   assemblePrompt,
@@ -106,7 +90,6 @@ import {
 import { wrapContent } from "../services/prompt/format-engine.js";
 import {
   yieldToEventLoop,
-  type BaseLLMProvider,
   type ChatMessage,
   type LLMUsage,
 } from "../services/llm/base-provider.js";
@@ -122,31 +105,8 @@ import {
   parseCharacterCommands,
   parseCharacterCommandsBySpeaker,
   parseDirectMessageCommands,
-  parseDuration,
   type CharacterCommand,
-  type ScheduleUpdateCommand,
-  type CrossPostCommand,
-  type SelfieCommand,
-  type MemoryCommand,
-  type CallCommand,
-  type InfluenceCommand,
-  type NoteCommand,
   type DirectMessageCommand,
-  type SceneCommand,
-  type HapticCommand,
-  type SpotifyCommand,
-  type YouTubeCommand,
-  type ReactCommand,
-  type CreatePersonaCommand,
-  type CreateCharacterCommand,
-  type UpdateCharacterCommand,
-  type UpdatePersonaCommand,
-  type CreateLorebookCommand,
-  type UpdateLorebookCommand,
-  type CreatePresetCommand,
-  type CreateChatCommand,
-  type NavigateCommand,
-  type FetchCommand,
 } from "../services/conversation/character-commands.js";
 import {
   ILLUSTRATOR_TEXT_NEGATIVE_PROMPT,
@@ -154,37 +114,22 @@ import {
   resolveIllustratorCharacterReferences,
 } from "./generate/illustrator-references.js";
 import {
-  ConversationSpotifyCommandError,
-  isSilentConversationSpotifyCommandError,
-  playConversationSpotifyCommand,
-} from "../services/spotify/conversation-spotify-command.service.js";
-import {
   buildAutonomousDailyBudgetPatch,
   clearGenerationInProgress,
-  dailyCapForCharacter,
-  getAutonomousDailyBudget,
   markGenerationInProgress,
   recordAssistantActivity,
   recordUserActivity,
 } from "../services/conversation/autonomous.service.js";
-import { buildIntentCooldownPatch, getIntentHint, isMessageIntent } from "../services/conversation/intent.service.js";
+import { buildIntentCooldownPatch, isMessageIntent } from "../services/conversation/intent.service.js";
 import { buildImpersonateInstruction } from "../services/conversation/impersonate-prompt.js";
 import { stripConversationPromptTimestamps } from "../services/conversation/transcript-sanitize.js";
 import {
   formatZonedConversationDate,
   formatZonedConversationTime,
-  getZonedWeekdayName,
-  isSameZonedLogicalDay,
   normalizePromptTimeZone,
   toZonedWallClockDate,
 } from "../services/conversation/timezone.js";
-import {
-  countUserMessagesAfterSummaryAnchor,
-  formatConversationDateKey,
-  generateMissingConversationSummaries,
-  parseConversationDateKey,
-} from "../services/conversation/auto-summary.service.js";
-import { MARI_ASSISTANT_PROMPT } from "../db/seed-mari.js";
+import { countUserMessagesAfterSummaryAnchor } from "../services/conversation/auto-summary.service.js";
 import { executeKnowledgeRetrieval } from "../services/agents/knowledge-retrieval.js";
 import { executeKnowledgeRouter } from "../services/agents/knowledge-router.js";
 import { extractFileText, getSourceFilePath } from "./knowledge-sources.routes.js";
@@ -194,9 +139,7 @@ import { eq } from "drizzle-orm";
 import {
   PROFESSOR_MARI_ID,
   normalizeCustomEmojiSelection,
-  type CustomEmojiSelectionPrefs,
   type GenerationParameterSendMap,
-  type MessageReaction,
 } from "@marinara-engine/shared";
 import { chunkAndEmbedMessages, embedMemoryRecallTexts } from "../services/memory-recall.js";
 import {
@@ -212,9 +155,7 @@ import {
   findLastIndex,
   findTrackerContextInsertIndex,
   formatConversationInstructionsForWrap,
-  appendReadableAttachmentsToContent,
   extractFileAttachmentInputs,
-  getAttachmentFilename,
   buildGenerationGuideInstruction,
   buildUserMessageRegenerationPromptFromSource,
   buildLockedPlayerStatsArrayPatch,
@@ -232,7 +173,6 @@ import {
   normalizePromptWrapFormat,
   parseExtra,
   parseJsonField,
-  parseStoredGenerationParameters,
   parseGameStateRow,
   parseSnapshotPlayerStats,
   isRoleplaySummaryMode,
@@ -248,17 +188,46 @@ import {
   resolveRoleplayChatSummary,
   resolveUserRegenerationPersistentAttachments,
   resolveVisibleGameStateAnchor,
-  resolveProviderTopK,
-  normalizeServiceTier,
   resolveKnowledgeSourceLorebookIds,
   shouldPreferLatestVisibleGameState,
   shouldAbortOnPassiveGenerationDisconnect,
   shouldEnableAgentsForGeneration,
   shouldInjectIdentityFallback,
-  escapeXmlAttribute,
   type PromptAttachment,
   type SimpleMessage,
 } from "./generate/generate-route-utils.js";
+import {
+  customAgentCanApplyResult,
+  customAgentCanEmitResult,
+  findResultAgent,
+  isAbortLikeError,
+} from "./generate/agent-result-capabilities.js";
+import {
+  appendConversationCustomAssetAdvertisements,
+} from "./generate/conversation-custom-assets.js";
+import { injectConnectedConversationPromptBlocks } from "./generate/connected-conversation-injections.js";
+import { resolveConversationConnectedChatContext } from "./generate/conversation-connected-context.js";
+import { buildConversationCurrentContextBlock } from "./generate/conversation-context-block.js";
+import { prepareConversationPromptHistory } from "./generate/conversation-history-runtime.js";
+import { resolveConversationPresenceRuntime } from "./generate/conversation-presence-runtime.js";
+import { resolveProfessorMariPromptContext } from "./generate/professor-mari-prompt-context.js";
+import {
+  appendToFirstSystemMessage,
+  conversationPromptHistoryContent,
+  latestHistoryUserContent,
+  resolvePresetModePrompt,
+} from "./generate/conversation-prompt-formatting.js";
+import {
+  normalizePromptAttachments,
+  resolveImageCaptioningRuntime,
+  resolvePromptAttachmentInputs,
+  type ImageCaptioningRuntime,
+} from "./generate/image-captioning-runtime.js";
+import {
+  emptyLorebookScanSnapshot,
+  toLorebookScanSnapshot,
+  type LorebookScanSnapshot,
+} from "./generate/lorebook-scan-snapshot.js";
 import {
   buildAvailableSpriteCharacter,
   completeRequiredSpriteExpressionEntries,
@@ -305,6 +274,50 @@ import {
   normalizeHapticAgentCommand,
   normalizeHapticAgentCommands,
 } from "../services/generation/haptic-runtime.js";
+import {
+  buildConversationCommandsReminder,
+  filterEnabledConversationCommands,
+  isConversationCommandEnabled,
+} from "../services/generation/conversation-command-runtime.js";
+import {
+  DIRECTOR_SECRET_PLOT_DEFAULT_RUN_INTERVAL,
+  DIRECTOR_SECRET_PLOT_LAST_MESSAGE_KEY,
+  appendSecretPlotSystemMessage,
+  buildDirectorSecretPlotAgent,
+  buildSecretPlotStateFromMemory,
+  formatSecretPlotSystemBlock,
+  resolveDirectorSecretPlotEnabled,
+  resolveDirectorSecretPlotRunInterval,
+  secretPlotArcIsCompleted,
+  shouldRunDirectorSecretPlotMaintenance,
+} from "../services/generation/director-secret-plot-runtime.js";
+import { applyPromptPatchOperations } from "../services/generation/prompt-patch-runtime.js";
+import { resolveGenerationProviderRuntime } from "../services/generation/provider-generation-runtime.js";
+import {
+  countProfessorMariCommands,
+  handleProfessorMariCommand,
+} from "../services/generation/professor-mari-command-runtime.js";
+import { handleTurnGameCommand } from "../services/generation/turn-game-command-runtime.js";
+import { handleConversationSideEffectCommand } from "../services/generation/conversation-side-effect-command-runtime.js";
+import { handleConversationCallCommand } from "../services/generation/conversation-call-command-runtime.js";
+import { handleConversationMusicCommand } from "../services/generation/conversation-music-command-runtime.js";
+import { handleConversationReactCommand } from "../services/generation/conversation-react-command-runtime.js";
+import { handleRoleplayDmCommand } from "../services/generation/roleplay-dm-command-runtime.js";
+import { handleConversationScheduleCommand } from "../services/generation/conversation-schedule-command-runtime.js";
+import { handleConversationCrossPostCommand } from "../services/generation/conversation-cross-post-command-runtime.js";
+import { handleHapticCommand } from "../services/generation/haptic-command-runtime.js";
+import { handleConversationSceneCommand } from "../services/generation/conversation-scene-command-runtime.js";
+import { handleConversationSelfieCommand } from "../services/generation/conversation-selfie-command-runtime.js";
+import {
+  CONTINUE_ASSISTANT_MESSAGE_PROMPT,
+  appendContinuationMessageContent,
+  clampRoleplaySummaryContextSize,
+  clampRoleplaySummaryInterval,
+  isAutomaticRoleplaySummaryEnabled,
+  parseChatSummaryText,
+  resolveChatSummaryPromptFromMetadata,
+  withoutRetiredChatSummaryAgentIds,
+} from "../services/generation/roleplay-summary-runtime.js";
 import { getMaxToolRounds } from "../config/runtime-config.js";
 import {
   REVIEWABLE_WRITER_AGENT_TYPES,
@@ -321,37 +334,19 @@ import {
 } from "../services/generation/runtime-agent-sections.js";
 import { applySpotifyAgentPlaybackFallbacks } from "../services/generation/spotify-agent-runtime.js";
 import {
-  MAX_MARI_FETCHED_PRESET_CONTEXT_CHARS,
-  normalizeAssistantPresetIdentifier,
-  normalizeAssistantPresetOptionId,
-  normalizeAssistantPresetVariableName,
-  parseMariJsonArray,
-  parseMariJsonRecord,
-  resolveAssistantPresetInjectionPosition,
-  resolveAssistantPresetRole,
-  resolveAssistantPresetWrapFormat,
-  truncateMariFetchedText,
-} from "../services/generation/assistant-preset-utils.js";
-import {
   formatUnresolvedRoleplayDmFallback,
-  parseChatCharacterIdsForDm,
   replaceRoleplayDmCommandText,
   resolveRoleplayDmTarget,
 } from "../services/generation/roleplay-dm-utils.js";
 import {
-  bumpCharacterVersion,
   cardPromptText,
-  formatConversationPromptTurn,
   getHiddenCompletionTokens,
   getVisibleCompletionTokens,
-  sanitizeConnectedGameTranscript,
   stripSpacesBeforeLineBreaks,
   trimIncompleteModelEnding,
 } from "../services/generation/generation-text-utils.js";
 import {
   areConversationSchedulesEnabled,
-  getEnabledConversationSchedules,
-  parseConversationStatusOverrides,
   parsePromptPresetChoices,
 } from "../services/generation/conversation-context-utils.js";
 import { recoverImplicitSelfieCommand } from "../services/generation/selfie-command-recovery.js";
@@ -388,7 +383,6 @@ import {
 import {
   applyProviderMaxTokensOverride,
   normalizeAgentMaxTokens,
-  normalizeChatTopP,
   readChatCompletionsReasoningMetadata,
   shouldReplayStoredChatCompletionsReasoning,
 } from "../services/generation/generation-parameters.js";
@@ -398,6 +392,7 @@ import {
   resolveModelAccessPolicy,
   resolveStoredModelContextLimit,
 } from "../services/generation/model-access-policy.js";
+import { promptPreviewForAgents, resolveCustomWritableLorebookIds } from "../services/generation/agent-prompt-runtime.js";
 import { resolveAgentPipelineAgents } from "../services/generation/agent-resolution.js";
 import { resolveGenerationTools } from "../services/generation/tool-resolution-runtime.js";
 import {
@@ -431,1239 +426,6 @@ import {
 } from "./generate/agent-write-approval.js";
 
 const PROFESSOR_MARI_INTERNAL_CHAT_MARKER = "professor-mari";
-
-type LorebookScanSnapshot = {
-  activatedEntries: LorebookScanResult["activatedEntries"];
-  budgetSkippedEntries: LorebookScanResult["budgetSkippedEntries"];
-  totalTokensEstimate: number;
-  totalEntries: number;
-};
-
-function emptyLorebookScanSnapshot(): LorebookScanSnapshot {
-  return {
-    activatedEntries: [],
-    budgetSkippedEntries: [],
-    totalTokensEstimate: 0,
-    totalEntries: 0,
-  };
-}
-
-function toLorebookScanSnapshot(result: LorebookScanResult | null | undefined): LorebookScanSnapshot {
-  if (!result) return emptyLorebookScanSnapshot();
-  return {
-    activatedEntries: result.activatedEntries,
-    budgetSkippedEntries: result.budgetSkippedEntries,
-    totalTokensEstimate: result.totalTokensEstimate,
-    totalEntries: result.totalEntries,
-  };
-}
-
-function findResultAgent(result: AgentResult, agents: ResolvedAgent[]): ResolvedAgent | null {
-  return agents.find((agent) => agent.id === result.agentId || agent.type === result.agentType) ?? null;
-}
-
-function isAbortLikeError(error: unknown): boolean {
-  return error instanceof Error && error.name === "AbortError";
-}
-
-function customAgentCanApplyResult(
-  result: AgentResult,
-  agents: ResolvedAgent[],
-  builtInAgentTypes: Set<string>,
-  capability: Parameters<typeof customAgentHasCapability>[1],
-): boolean {
-  if (builtInAgentTypes.has(result.agentType)) return true;
-  const agent = findResultAgent(result, agents);
-  return agent ? customAgentHasCapability(agent.settings, capability) : false;
-}
-
-function customAgentCanEmitResult(
-  result: AgentResult,
-  agents: ResolvedAgent[],
-  builtInAgentTypes: Set<string>,
-): boolean {
-  if (builtInAgentTypes.has(result.agentType)) return true;
-  switch (result.type) {
-    case "text_rewrite":
-      return customAgentCanApplyResult(result, agents, builtInAgentTypes, "edit_messages");
-    case "lorebook_update":
-      return (
-        customAgentCanApplyResult(result, agents, builtInAgentTypes, "edit_lorebooks") ||
-        customAgentCanApplyResult(result, agents, builtInAgentTypes, "create_lorebooks")
-      );
-    case "game_state_update":
-    case "character_tracker_update":
-    case "persona_stats_update":
-    case "custom_tracker_update":
-    case "quest_update":
-      return customAgentCanApplyResult(result, agents, builtInAgentTypes, "edit_trackers");
-    case "image_prompt":
-      return customAgentCanApplyResult(result, agents, builtInAgentTypes, "trigger_image_generation");
-    case "prompt_patch":
-      return customAgentCanApplyResult(result, agents, builtInAgentTypes, "edit_main_prompt");
-    case "frontend_theme_update":
-      return customAgentCanApplyResult(result, agents, builtInAgentTypes, "change_frontend_styling");
-    default:
-      return true;
-  }
-}
-
-function presetStringField(preset: Record<string, unknown> | null | undefined, field: string): string {
-  const value = preset?.[field];
-  return typeof value === "string" ? value.trim() : "";
-}
-
-function resolvePresetModePrompt(
-  preset: Record<string, unknown> | null | undefined,
-  mode: "conversation" | "game",
-): string {
-  return mode === "conversation"
-    ? presetStringField(preset, "conversationPrompt")
-    : presetStringField(preset, "gamePrompt");
-}
-
-const DIRECTOR_SECRET_PLOT_DEFAULT_RUN_INTERVAL = 8;
-const DIRECTOR_SECRET_PLOT_LAST_MESSAGE_KEY = "secretPlotLastAssistantMessageId";
-
-function normalizeDirectorSecretPlotRunInterval(value: unknown): number {
-  return resolveAgentRunInterval({ runInterval: value }, DIRECTOR_SECRET_PLOT_DEFAULT_RUN_INTERVAL);
-}
-
-function resolveDirectorSecretPlotEnabled(
-  settings: Record<string, unknown>,
-  chatMeta: Record<string, unknown>,
-  chatMode: ChatMode,
-): boolean {
-  if (chatMode !== "roleplay") return false;
-  if (typeof chatMeta.narrativeDirectorSecretPlotEnabled === "boolean") {
-    return chatMeta.narrativeDirectorSecretPlotEnabled;
-  }
-  return settings.secretPlotEnabled === true;
-}
-
-function resolveDirectorSecretPlotRunInterval(
-  settings: Record<string, unknown>,
-  chatMeta: Record<string, unknown>,
-): number {
-  return normalizeDirectorSecretPlotRunInterval(
-    chatMeta.narrativeDirectorSecretPlotRunInterval ?? settings.secretPlotRunInterval,
-  );
-}
-
-function normalizeSecretPlotArc(raw: unknown): Record<string, unknown> | null {
-  if (raw == null) return null;
-  if (typeof raw === "string") {
-    const description = raw.trim();
-    return description ? { description, completed: false } : null;
-  }
-  if (!raw || typeof raw !== "object" || Array.isArray(raw)) return null;
-  const arc = raw as Record<string, unknown>;
-  const description = typeof arc.description === "string" ? arc.description.trim() : "";
-  const protagonistArc = typeof arc.protagonistArc === "string" ? arc.protagonistArc.trim() : "";
-  const characterArc = typeof arc.characterArc === "string" ? arc.characterArc.trim() : "";
-  const normalized: Record<string, unknown> = {
-    ...(description ? { description } : {}),
-    ...(protagonistArc ? { protagonistArc } : {}),
-    ...(characterArc ? { characterArc } : {}),
-    completed: arc.completed === true,
-  };
-  return Object.keys(normalized).length > 1 || normalized.completed === true ? normalized : null;
-}
-
-function buildSecretPlotStateFromMemory(memory: Record<string, unknown>): Record<string, unknown> {
-  const state: Record<string, unknown> = {};
-  const arc = normalizeSecretPlotArc(memory.overarchingArc);
-  if (arc) state.overarchingArc = arc;
-  return state;
-}
-
-function secretPlotArcIsCompleted(data: unknown): boolean {
-  if (!data || typeof data !== "object" || Array.isArray(data)) return false;
-  const arc = normalizeSecretPlotArc((data as Record<string, unknown>).overarchingArc);
-  return arc?.completed === true;
-}
-
-function shouldRunDirectorSecretPlotMaintenance(args: {
-  memory: Record<string, unknown>;
-  runInterval: number;
-  messages: Array<{ id?: string | null; role?: string | null }>;
-}): boolean {
-  const state = buildSecretPlotStateFromMemory(args.memory);
-  const arc = normalizeSecretPlotArc(state.overarchingArc);
-  if (!arc) return true;
-  if (arc.completed === true) return true;
-  if (args.runInterval <= 1) return true;
-
-  const lastMessageId = args.memory[DIRECTOR_SECRET_PLOT_LAST_MESSAGE_KEY];
-  if (typeof lastMessageId !== "string" || !lastMessageId) return true;
-  const lastIndex = args.messages.findIndex((message) => message.id === lastMessageId);
-  if (lastIndex < 0) return true;
-  const assistantMessagesSince = args.messages
-    .slice(lastIndex + 1)
-    .filter((message) => message.role === "assistant").length;
-  return assistantMessagesSince + 1 >= args.runInterval;
-}
-
-function formatSecretPlotSystemBlock(arcRaw: unknown, wrapFormat: "xml" | "markdown" | "none"): string {
-  const arc = normalizeSecretPlotArc(arcRaw);
-  if (!arc) return "";
-  const payload = JSON.stringify({ overarchingArc: arc }, null, 2);
-  if (wrapFormat === "none") return `Secret plot\n${payload}`;
-  return wrapContent(payload, "Secret plot", wrapFormat);
-}
-
-function formatConversationSummaryHistoryBlock(label: string, summary: string, wrapFormat: WrapFormat): string {
-  if (wrapFormat === "xml") return `<summary ${label}>\n${summary}\n</summary>`;
-  const displayLabel = label.replace(/="/g, ": ").replace(/"$/g, "");
-  if (wrapFormat === "markdown") return `## Summary (${displayLabel})\n${summary}`;
-  return `Summary (${displayLabel})\n${summary}`;
-}
-
-function formatConversationDateHistoryMessages(
-  messages: Array<{ role: "system" | "user" | "assistant"; author: string; content: string }>,
-  date: string,
-  wrapFormat: WrapFormat,
-): Array<{ role: "system" | "user" | "assistant"; content: string }> {
-  if (messages.length === 0) return [];
-  if (wrapFormat === "xml") {
-    return messages.map((message, idx) => {
-      let content = `${message.author}: ${message.content}`;
-      if (idx === 0) content = `<date="${date}">\n${content}`;
-      if (idx === messages.length - 1) content = `${content}\n</date>`;
-      return { role: message.role, content };
-    });
-  }
-
-  return messages.map((message, idx) => {
-    const prefix = idx === 0 ? (wrapFormat === "markdown" ? `## Date: ${date}\n` : `Date: ${date}\n`) : "";
-    return { role: message.role, content: `${prefix}${message.author}: ${message.content}` };
-  });
-}
-
-function appendSecretPlotSystemMessage(
-  messages: Array<{ role: string; content: string; [key: string]: unknown }>,
-  content: string,
-): void {
-  if (!content.trim()) return;
-  const firstChatIndex = messages.findIndex((message) => message.role === "user" || message.role === "assistant");
-  const insertAt = firstChatIndex >= 0 ? firstChatIndex : messages.length;
-  messages.splice(insertAt, 0, { role: "system", content });
-}
-
-function buildDirectorSecretPlotAgent(agent: ResolvedAgent): ResolvedAgent {
-  return {
-    ...agent,
-    promptTemplate: NARRATIVE_DIRECTOR_SECRET_PLOT_PROMPT,
-    settings: {
-      ...agent.settings,
-      resultType: "secret_plot",
-    },
-  };
-}
-
-function resolveCustomWritableLorebookIds(settings: Record<string, unknown>): string[] | null {
-  const ids: string[] = [];
-  for (const key of ["writableLorebookId", "targetLorebookId"]) {
-    const value = settings[key];
-    if (typeof value === "string" && value.trim()) ids.push(value.trim());
-  }
-  const arrayValue = settings.writableLorebookIds;
-  if (Array.isArray(arrayValue)) {
-    for (const value of arrayValue) {
-      if (typeof value === "string" && value.trim()) ids.push(value.trim());
-    }
-  }
-  return ids.length > 0 ? Array.from(new Set(ids)) : null;
-}
-
-function promptPreviewForAgents(messages: ChatMessage[]): string {
-  const preview = messages
-    .map((message, index) => {
-      const content = String(message.content ?? "").slice(0, 3000);
-      return `<message index="${index}" role="${message.role}">\n${content}\n</message>`;
-    })
-    .join("\n\n");
-  return preview.slice(0, 24_000);
-}
-
-const RETIRED_CHAT_SUMMARY_AGENT_ID = "chat-summary";
-const DEFAULT_AUTOMATIC_SUMMARY_INTERVAL = 5;
-const MIN_AUTOMATIC_SUMMARY_INTERVAL = 1;
-const MAX_AUTOMATIC_SUMMARY_INTERVAL = 200;
-const MIN_SUMMARY_CONTEXT_SIZE = 5;
-const MAX_SUMMARY_CONTEXT_SIZE = 500;
-
-function clampRoleplaySummaryInterval(value: unknown): number {
-  const parsed = Number(value);
-  if (!Number.isFinite(parsed) || parsed <= 0) return DEFAULT_AUTOMATIC_SUMMARY_INTERVAL;
-  return Math.max(MIN_AUTOMATIC_SUMMARY_INTERVAL, Math.min(MAX_AUTOMATIC_SUMMARY_INTERVAL, Math.trunc(parsed)));
-}
-
-function clampRoleplaySummaryContextSize(value: unknown): number {
-  const parsed = Number(value);
-  if (!Number.isFinite(parsed) || parsed <= 0) return 50;
-  return Math.max(MIN_SUMMARY_CONTEXT_SIZE, Math.min(MAX_SUMMARY_CONTEXT_SIZE, Math.trunc(parsed)));
-}
-
-function appendContinuationMessageContent(existingContent: unknown, continuation: string): string {
-  const existing = typeof existingContent === "string" ? existingContent : "";
-  if (!existing) return continuation;
-  if (!continuation) return existing;
-  return `${existing}${continuation}`;
-}
-
-const CONTINUE_ASSISTANT_MESSAGE_PROMPT = "Your last message got cut off! Please, continue!";
-
-function isAutomaticRoleplaySummaryEnabled(chatMetadata: Record<string, unknown>): boolean {
-  if (chatMetadata.automaticSummaryEnabled === false) return false;
-  if (chatMetadata.automaticSummaryEnabled === true) return true;
-  const activeAgentIds = Array.isArray(chatMetadata.activeAgentIds) ? chatMetadata.activeAgentIds : [];
-  return chatMetadata.enableAgents === true && activeAgentIds.includes(RETIRED_CHAT_SUMMARY_AGENT_ID);
-}
-
-function withoutRetiredChatSummaryAgentIds(chatMetadata: Record<string, unknown>): string[] | undefined {
-  if (!Array.isArray(chatMetadata.activeAgentIds)) return undefined;
-  return chatMetadata.activeAgentIds.filter((agentId): agentId is string => {
-    return typeof agentId === "string" && agentId !== RETIRED_CHAT_SUMMARY_AGENT_ID;
-  });
-}
-
-function resolveChatSummaryPromptFromMetadata(chatMetadata: Record<string, unknown>): string {
-  const selectedId =
-    typeof chatMetadata.activeSummaryPromptTemplateId === "string"
-      ? chatMetadata.activeSummaryPromptTemplateId.trim()
-      : "";
-  const templates = Array.isArray(chatMetadata.summaryPromptTemplates) ? chatMetadata.summaryPromptTemplates : [];
-  const selected = selectedId
-    ? templates.find((template) => {
-        if (!template || typeof template !== "object" || Array.isArray(template)) return false;
-        const record = template as Record<string, unknown>;
-        return record.id === selectedId && typeof record.prompt === "string" && record.prompt.trim().length > 0;
-      })
-    : null;
-  if (selected && typeof (selected as Record<string, unknown>).prompt === "string") {
-    return ((selected as Record<string, unknown>).prompt as string).trim();
-  }
-  return DEFAULT_CHAT_SUMMARY_PROMPT;
-}
-
-function parseChatSummaryText(rawContent: string): string {
-  const cleaned = rawContent
-    .trim()
-    .replace(/```(?:json)?\s*/gi, "")
-    .replace(/```/g, "");
-  try {
-    const first = cleaned.indexOf("{");
-    const last = cleaned.lastIndexOf("}");
-    if (first >= 0 && last > first) {
-      const parsed = JSON.parse(cleaned.slice(first, last + 1)) as { summary?: unknown };
-      return typeof parsed.summary === "string" ? parsed.summary.trim() : cleaned.trim();
-    }
-  } catch {
-    // Fall through to raw text.
-  }
-  return cleaned.trim();
-}
-
-function findLastPromptMessageIndex(messages: ChatMessage[], role: ChatMessage["role"]): number {
-  for (let index = messages.length - 1; index >= 0; index--) {
-    if (messages[index]?.role === role) return index;
-  }
-  return -1;
-}
-
-function applyPromptPatchOperations(messages: ChatMessage[], data: unknown): number {
-  if (!data || typeof data !== "object") return 0;
-  const rawOperations = Array.isArray((data as Record<string, unknown>).operations)
-    ? ((data as Record<string, unknown>).operations as unknown[])
-    : [data];
-  let applied = 0;
-
-  for (const rawOperation of rawOperations.slice(0, 12)) {
-    if (!rawOperation || typeof rawOperation !== "object") continue;
-    const operation = rawOperation as Record<string, unknown>;
-    const content = typeof operation.content === "string" ? operation.content.slice(0, 12_000) : "";
-    if (!content.trim()) continue;
-    const target = typeof operation.target === "string" ? operation.target : "last_user";
-    const mode =
-      operation.mode === "replace" || operation.mode === "prepend" || operation.mode === "append"
-        ? operation.mode
-        : "append";
-
-    if (target === "append_system" || target === "prepend_system") {
-      const message = { role: "system" as const, content };
-      if (target === "prepend_system") messages.unshift(message);
-      else messages.push(message);
-      applied++;
-      continue;
-    }
-
-    const index =
-      target === "first_system"
-        ? messages.findIndex((message) => message.role === "system")
-        : target === "last_message"
-          ? messages.length - 1
-          : findLastPromptMessageIndex(messages, "user");
-    if (index < 0 || !messages[index]) continue;
-
-    const current = messages[index]!;
-    const nextContent =
-      mode === "replace"
-        ? content
-        : mode === "prepend"
-          ? `${content}\n\n${current.content}`
-          : `${current.content}\n\n${content}`;
-    messages[index] = { ...current, content: nextContent };
-    applied++;
-  }
-
-  return applied;
-}
-
-function readConversationCommandToggles(
-  metadata: Record<string, unknown>,
-): Partial<Record<ConversationCommandKey, boolean>> {
-  const raw = metadata.conversationCommandToggles;
-  if (!raw || typeof raw !== "object" || Array.isArray(raw)) return {};
-  const source = raw as Record<string, unknown>;
-  const toggles: Partial<Record<ConversationCommandKey, boolean>> = {};
-  for (const key of CONVERSATION_COMMAND_KEYS) {
-    if (typeof source[key] === "boolean") toggles[key] = source[key] as boolean;
-  }
-  return toggles;
-}
-
-function isConversationCommandEnabled(metadata: Record<string, unknown>, key: ConversationCommandKey): boolean {
-  return readConversationCommandToggles(metadata)[key] !== false;
-}
-
-function getConversationCommandKey(command: CharacterCommand): ConversationCommandKey | null {
-  switch (command.type) {
-    case "schedule_update":
-      return "schedule_update";
-    case "cross_post":
-      return "cross_post";
-    case "selfie":
-      return "selfie";
-    case "memory":
-      return "memory";
-    case "scene":
-      return "scene";
-    case "call":
-      return "call";
-    case "uno":
-      return "uno";
-    case "chess":
-      return "chess";
-    case "spotify":
-    case "youtube":
-      return "music";
-    case "haptic":
-      return "haptic";
-    case "influence":
-      return "influence";
-    case "note":
-      return "note";
-    case "react":
-      return "react";
-    default:
-      return null;
-  }
-}
-
-function filterEnabledConversationCommands(
-  commands: CharacterCommand[],
-  metadata: Record<string, unknown>,
-): CharacterCommand[] {
-  return commands.filter((command) => {
-    const key = getConversationCommandKey(command);
-    return key === null || isConversationCommandEnabled(metadata, key);
-  });
-}
-
-function parseStoredAgentSettingsValue(value: unknown): Record<string, unknown> {
-  if (!value) return {};
-  if (typeof value === "string") {
-    try {
-      const parsed = JSON.parse(value);
-      return parsed && typeof parsed === "object" && !Array.isArray(parsed) ? (parsed as Record<string, unknown>) : {};
-    } catch {
-      return {};
-    }
-  }
-  return typeof value === "object" && !Array.isArray(value) ? (value as Record<string, unknown>) : {};
-}
-
-async function isConversationYoutubeCommandAvailable(storage: {
-  getByType(type: string): Promise<{ settings?: unknown } | null>;
-}): Promise<boolean> {
-  const agent = (await storage.getByType("spotify")) ?? (await storage.getByType("youtube"));
-  const settings = parseStoredAgentSettingsValue(agent?.settings);
-  return typeof settings.youtubeApiKey === "string" && settings.youtubeApiKey.trim().length > 0;
-}
-
-function resolveKnownMaxOutputTokens(provider: APIProvider | string | null | undefined, model: string): number | null {
-  const knownModel = provider ? findKnownModel(provider as APIProvider, model.trim()) : undefined;
-  return knownModel?.maxOutput && knownModel.maxOutput > 0 ? Math.floor(knownModel.maxOutput) : null;
-}
-
-function clampGenerationMaxOutputTokens(args: {
-  provider: APIProvider | string | null | undefined;
-  model: string;
-  maxTokens: number;
-  maxTokensOverride?: number | null;
-}): number {
-  let capped = Math.max(1, Math.floor(args.maxTokens));
-  const knownMaxOutput = resolveKnownMaxOutputTokens(args.provider, args.model);
-  if (knownMaxOutput !== null) capped = Math.min(capped, knownMaxOutput);
-  if (
-    typeof args.maxTokensOverride === "number" &&
-    Number.isFinite(args.maxTokensOverride) &&
-    args.maxTokensOverride > 0
-  ) {
-    capped = Math.min(capped, Math.floor(args.maxTokensOverride));
-  }
-  return capped;
-}
-
-/** Fisher-Yates shuffle (in place); used for random emoji selection. */
-function shuffleInPlace<T>(items: T[]): T[] {
-  for (let i = items.length - 1; i > 0; i--) {
-    const j = Math.floor(Math.random() * (i + 1));
-    const tmp = items[i]!;
-    items[i] = items[j]!;
-    items[j] = tmp;
-  }
-  return items;
-}
-
-/** Order emoji names by semantic relevance to `query` via the local embedder. Returns null when unavailable. */
-async function rankEmojiNamesBySemantic(names: string[], query: string): Promise<string[] | null> {
-  if (names.length <= 1 || !query.trim() || !isLocalEmbedderAvailable()) return null;
-  try {
-    const vectors = await localEmbed([query, ...names.map((name) => name.replace(/_/g, " "))]);
-    if (!vectors || vectors.length !== names.length + 1) return null;
-    const queryVector = vectors[0]!;
-    return names
-      .map((name, index) => ({ name, score: cosineSimilarity(queryVector, vectors[index + 1]!) }))
-      .sort((a, b) => b.score - a.score)
-      .map((entry) => entry.name);
-  } catch (err) {
-    logger.debug(err, "[custom-emoji] semantic ranking failed; falling back to random");
-    return null;
-  }
-}
-
-/** Order a pool of emoji names per the selection mode (does NOT cap — the formatter slices to maxCount). */
-async function orderEmojiNames(names: string[], prefs: CustomEmojiSelectionPrefs, query: string): Promise<string[]> {
-  if (names.length <= 1) return names;
-  // Reached for random/semantic, and as the tool-call fallback path — rank semantically when possible.
-  if (prefs.mode === "semantic" || prefs.mode === "tool-call") {
-    const ranked = await rankEmojiNamesBySemantic(names, query);
-    if (ranked) return ranked;
-  }
-  return shuffleInPlace([...names]);
-}
-
-/**
- * Tool-call selection: one short auxiliary completion (on the chosen connection)
- * picks which candidate asset names fit the latest message. Returns the validated
- * picks (≤ maxCount), or null on any failure so the caller can fall back to
- * semantic/random. Never throws — generation must not depend on it.
- */
-async function selectCustomAssetNamesByToolCall(
-  assetLabel: string,
-  tokenExample: string,
-  candidates: string[],
-  query: string,
-  connectionId: string,
-  connections: ReturnType<typeof createConnectionsStorage>,
-  maxCount: number,
-): Promise<string[] | null> {
-  if (candidates.length === 0 || !query.trim()) return null;
-  const controller = new AbortController();
-  const timeout = setTimeout(() => controller.abort(new Error("custom-emoji tool-call timeout")), 5000);
-  try {
-    const conn = await connections.getWithKey(connectionId);
-    if (!conn?.model) return null;
-    const provider = createLLMProvider(
-      conn.provider,
-      resolveBaseUrl(conn),
-      conn.apiKey,
-      conn.maxContext,
-      conn.openrouterProvider,
-      conn.maxTokensOverride,
-    );
-    const result = await provider.chatComplete(
-      [
-        {
-          role: "system",
-          content:
-            `You select which custom ${assetLabel}s fit the current moment in a chat. You receive a list of available ${assetLabel} names and the latest message. ` +
-            `Reply with ONLY a comma-separated list of at most ${maxCount} names taken verbatim from the list (most fitting first), or "none". No other text. Do not include ${tokenExample} syntax.`,
-        },
-        {
-          role: "user",
-          content: `Available custom ${assetLabel}s: ${candidates.join(", ")}\n\nLatest message: "${query}"\n\nFitting ${assetLabel} names:`,
-        },
-      ],
-      { model: conn.model, temperature: 0.3, maxTokens: 200, signal: controller.signal },
-    );
-    const text = (result.content ?? "").toLowerCase().trim();
-    if (text.replace(/[^a-z0-9_]/g, "") === "none") return [];
-    const candidateSet = new Set(candidates);
-    const picked: string[] = [];
-    for (const token of text.split(/[\s,]+/)) {
-      const name = token.replace(/[^a-z0-9_]/g, "");
-      if (name && candidateSet.has(name) && !picked.includes(name)) {
-        picked.push(name);
-        if (picked.length >= maxCount) break;
-      }
-    }
-    return picked.length > 0 ? picked : null;
-  } catch (err) {
-    logger.debug(err, "[custom-%s] tool-call selection failed; falling back to semantic/random", assetLabel);
-    return null;
-  } finally {
-    clearTimeout(timeout);
-  }
-}
-
-function uniqueEmojiNames(names: Array<string | null | undefined>): string[] {
-  const seen = new Set<string>();
-  const result: string[] = [];
-  for (const raw of names) {
-    const name = typeof raw === "string" ? raw.trim() : "";
-    if (!name || seen.has(name)) continue;
-    seen.add(name);
-    result.push(name);
-  }
-  return result;
-}
-
-function appendToFirstSystemMessage(messages: GenerationPromptMessage[], content: string): void {
-  const systemMessage = messages.find((message) => message.role === "system");
-  if (systemMessage) {
-    systemMessage.content = systemMessage.content ? `${systemMessage.content}\n\n${content}` : content;
-    return;
-  }
-  messages.unshift({ role: "system", content });
-}
-
-function latestHistoryUserContent(messages: GenerationPromptMessage[]): string {
-  const historyTurn = [...messages]
-    .reverse()
-    .find((message) => message.role === "user" && message.contextKind === "history");
-  if (historyTurn) return historyTurn.content;
-  return [...messages].reverse().find((message) => message.role === "user")?.content ?? "";
-}
-
-function conversationPromptHistoryContent(
-  message: { role?: unknown; content?: unknown; extra?: unknown },
-  chatMode: string,
-): string {
-  if (chatMode === "conversation" && message.role === "assistant") {
-    const commandContent = parseExtra(message.extra).conversationCommandContent;
-    if (typeof commandContent === "string" && commandContent.trim()) {
-      return commandContent;
-    }
-  }
-  return typeof message.content === "string" ? message.content : "";
-}
-
-type ImageCaptionConnection = {
-  id?: string | null;
-  name?: string | null;
-  provider: string;
-  apiKey: string;
-  model: string;
-  maxContext?: number | null;
-  openrouterProvider?: string | null;
-  maxTokensOverride?: number | null;
-  claudeFastMode?: string | null;
-  treatAsLocalEndpoint?: string | null;
-  enableCaching?: string | null;
-  anthropicExtendedCacheTtl?: string | null;
-  cachingAtDepth?: number | null;
-};
-
-type ImageCaptioningRuntime = {
-  enabled: boolean;
-  connectionId: string | null;
-  connection: ImageCaptionConnection | null;
-  provider: BaseLLMProvider | null;
-};
-
-type PromptAttachmentResolution = {
-  content: string;
-  images: string[];
-  files: Array<{ type: string; data: string; filename: string }>;
-  updatedAttachments: PromptAttachment[] | null;
-};
-
-const DISABLED_IMAGE_CAPTIONING: ImageCaptioningRuntime = {
-  enabled: false,
-  connectionId: null,
-  connection: null,
-  provider: null,
-};
-const IMAGE_CAPTION_MAX_TOKENS = 700;
-const IMAGE_CAPTION_MAX_CHARS = 4_000;
-
-function normalizePromptAttachments(extra: unknown): PromptAttachment[] | undefined {
-  const rawAttachments = parseExtra(extra).attachments;
-  if (!Array.isArray(rawAttachments)) return undefined;
-  const attachments = rawAttachments.filter(
-    (attachment): attachment is PromptAttachment =>
-      !!attachment && typeof attachment === "object" && !Array.isArray(attachment),
-  );
-  return attachments.length ? attachments : undefined;
-}
-
-function normalizeImageCaptionText(value: unknown): string | null {
-  if (typeof value !== "string") return null;
-  const text = value
-    .replace(/^```(?:\w+)?\s*/i, "")
-    .replace(/```\s*$/i, "")
-    .trim();
-  if (!text) return null;
-  return text.length > IMAGE_CAPTION_MAX_CHARS ? `${text.slice(0, IMAGE_CAPTION_MAX_CHARS).trim()}...` : text;
-}
-
-function readCachedImageCaption(attachment: PromptAttachment, imageCaptioning: ImageCaptioningRuntime): string | null {
-  const caption = normalizeImageCaptionText(attachment.imageCaption);
-  if (!caption || !imageCaptioning.connection) return null;
-  if (attachment.imageCaptionConnectionId !== imageCaptioning.connectionId) return null;
-  if (attachment.imageCaptionModel !== imageCaptioning.connection.model) return null;
-  if (attachment.imageCaptionProvider !== imageCaptioning.connection.provider) return null;
-  return caption;
-}
-
-function formatImageCaptionBlock(attachment: PromptAttachment, caption: string): string {
-  const name = getAttachmentFilename(attachment);
-  const type = typeof attachment.type === "string" && attachment.type.trim() ? attachment.type.trim() : "image";
-  return [
-    `<attached_image name="${escapeXmlAttribute(name)}" type="${escapeXmlAttribute(type)}">`,
-    caption,
-    `</attached_image>`,
-  ].join("\n");
-}
-
-function appendImageCaptionBlocksToContent(content: string, blocks: string[]): string {
-  if (blocks.length === 0) return content;
-  return `${content}${content.trim() ? "\n\n" : ""}${blocks.join("\n\n")}`;
-}
-
-async function generateImageCaptionForAttachment(
-  attachment: PromptAttachment,
-  imageDataUrl: string,
-  imageCaptioning: ImageCaptioningRuntime,
-  signal: AbortSignal,
-): Promise<string | null> {
-  if (!imageCaptioning.provider || !imageCaptioning.connection) return null;
-  const filename = getAttachmentFilename(attachment);
-  try {
-    const result = await imageCaptioning.provider.chatComplete(
-      [
-        {
-          role: "system",
-          content:
-            "You describe image attachments for a downstream chat model that may not support vision. " +
-            "Write a faithful, concise description of the visible content, including readable text, subjects, setting, style, and any details important for conversation continuity. " +
-            "Do not answer the chat and do not add speculation beyond what is visible.",
-        },
-        {
-          role: "user",
-          content: `Describe this image attachment named "${filename}" for use inside a chat prompt. Return only the description.`,
-          images: [imageDataUrl],
-        },
-      ],
-      {
-        model: imageCaptioning.connection.model,
-        temperature: 0.2,
-        maxTokens: applyProviderMaxTokensOverride(imageCaptioning.provider, IMAGE_CAPTION_MAX_TOKENS),
-        enableCaching: imageCaptioning.connection.enableCaching === "true",
-        anthropicExtendedCacheTtl: imageCaptioning.connection.anthropicExtendedCacheTtl === "true",
-        cachingAtDepth: imageCaptioning.connection.cachingAtDepth ?? 5,
-        stream: false,
-        signal,
-      },
-    );
-    return normalizeImageCaptionText(result.content);
-  } catch (error) {
-    if (signal.aborted) throw error;
-    logger.warn(error, "[image-captioning] Failed to caption image attachment %s", filename);
-    return null;
-  }
-}
-
-async function resolvePromptAttachmentInputs(args: {
-  content: string;
-  attachments: PromptAttachment[] | undefined;
-  imageCaptioning: ImageCaptioningRuntime;
-  signal: AbortSignal;
-}): Promise<PromptAttachmentResolution> {
-  const { attachments, imageCaptioning, signal } = args;
-  const files = extractFileAttachmentInputs(attachments);
-  let content = appendReadableAttachmentsToContent(args.content, attachments);
-
-  if (!imageCaptioning.enabled || !imageCaptioning.provider || !imageCaptioning.connection) {
-    return {
-      content,
-      images: extractImageAttachmentDataUrls(attachments),
-      files,
-      updatedAttachments: null,
-    };
-  }
-
-  const captionBlocks: string[] = [];
-  const fallbackImages: string[] = [];
-  let updatedAttachments: PromptAttachment[] | null = null;
-  const sourceAttachments = attachments ?? [];
-  const captionConnection = imageCaptioning.connection;
-  const resolvedImages = await Promise.all(
-    sourceAttachments.map(async (attachment, index) => {
-      const imageDataUrl = extractImageAttachmentDataUrls([attachment])[0];
-      if (!imageDataUrl) return null;
-
-      let caption = readCachedImageCaption(attachment, imageCaptioning);
-      let updatedAttachment: PromptAttachment | null = null;
-      if (!caption) {
-        caption = await generateImageCaptionForAttachment(attachment, imageDataUrl, imageCaptioning, signal);
-        if (caption) {
-          updatedAttachment = {
-            ...attachment,
-            imageCaption: caption,
-            imageCaptionConnectionId: imageCaptioning.connectionId,
-            imageCaptionModel: captionConnection.model,
-            imageCaptionProvider: captionConnection.provider,
-            imageCaptionedAt: new Date().toISOString(),
-          };
-        }
-      }
-
-      return { index, attachment, imageDataUrl, caption, updatedAttachment };
-    }),
-  );
-
-  for (const result of resolvedImages) {
-    if (!result) continue;
-    const { index, attachment, imageDataUrl, caption, updatedAttachment } = result;
-    if (updatedAttachment) {
-      updatedAttachments ??= sourceAttachments.map((item) => ({ ...item }));
-      updatedAttachments[index] = updatedAttachment;
-    }
-    if (caption) {
-      captionBlocks.push(
-        formatImageCaptionBlock(updatedAttachment ?? updatedAttachments?.[index] ?? attachment, caption),
-      );
-    } else {
-      fallbackImages.push(imageDataUrl);
-    }
-  }
-
-  content = appendImageCaptionBlocksToContent(content, captionBlocks);
-  return {
-    content,
-    images: fallbackImages,
-    files,
-    updatedAttachments,
-  };
-}
-
-/**
- * Build the Conversation-mode system-prompt block that tells the responding
- * character(s) which custom emojis they may use (`:name:`). A character gets its
- * own gallery emojis first (weighted above global), then the global pool, capped
- * at maxCount; the name pools arrive already ordered by the active selection mode.
- * Returns null when there are no custom emojis to advertise.
- */
-function buildCustomEmojiAdvertisement(
-  responders: { charId: string; name: string }[],
-  orderedGlobal: string[],
-  orderedOwnByChar: Map<string, string[]>,
-  maxCount: number,
-): string | null {
-  const toTokens = (names: string[]) => names.map((name) => `:${name}:`).join(" ");
-  const lead =
-    "You can use custom emojis in your reply by writing their name between colons, e.g. :name: — they render as small inline images. Use them only where they fit naturally; do not overuse them.";
-
-  // Single responder (1:1 chats and individual-turn group mode): own first, then global, capped to maxCount total.
-  if (responders.length === 1) {
-    const merged = [...(orderedOwnByChar.get(responders[0]!.charId) ?? [])];
-    for (const name of orderedGlobal) {
-      if (merged.length >= maxCount) break;
-      if (!merged.includes(name)) merged.push(name);
-    }
-    const capped = merged.slice(0, maxCount);
-    if (capped.length === 0) return null;
-    return `${lead}\nBeyond the full standard emoji set, you may use these custom emojis: ${toTokens(capped)}`;
-  }
-
-  // Multiple responders (merged group mode): shared global pool + each character's own, each capped to maxCount.
-  const lines: string[] = [];
-  const global = orderedGlobal.slice(0, maxCount);
-  if (global.length > 0) lines.push(`Available to everyone: ${toTokens(global)}`);
-  for (const responder of responders) {
-    const own = (orderedOwnByChar.get(responder.charId) ?? []).slice(0, maxCount);
-    if (own.length > 0) lines.push(`${responder.name} also has: ${toTokens(own)}`);
-  }
-  if (lines.length === 0) return null;
-  return `${lead}\nBeyond the full standard emoji set, these custom emojis are available (use by typing :name:):\n${lines.join("\n")}`;
-}
-
-/**
- * Build the Conversation-mode system-prompt block telling the responding
- * character(s) which custom stickers they may send (`sticker:name:`, a block
- * image). Mirrors the emoji advertisement: own gallery stickers first, then the
- * global pool, capped at maxCount; pools arrive pre-ordered by the selection mode.
- * Returns null when there are no stickers to advertise.
- */
-function buildCustomStickerAdvertisement(
-  responders: { charId: string; name: string }[],
-  orderedGlobal: string[],
-  orderedOwnByChar: Map<string, string[]>,
-  maxCount: number,
-): string | null {
-  const toTokens = (names: string[]) => names.map((name) => `sticker:${name}:`).join(" ");
-  const lead =
-    "You can send a sticker by writing its name as sticker:name: — it posts as a large block image on its own line. Send one only when it genuinely fits the moment, not in every message.";
-
-  if (responders.length === 1) {
-    const merged = [...(orderedOwnByChar.get(responders[0]!.charId) ?? [])];
-    for (const name of orderedGlobal) {
-      if (merged.length >= maxCount) break;
-      if (!merged.includes(name)) merged.push(name);
-    }
-    const capped = merged.slice(0, maxCount);
-    if (capped.length === 0) return null;
-    return `${lead}\nAvailable stickers: ${toTokens(capped)}`;
-  }
-
-  const lines: string[] = [];
-  const global = orderedGlobal.slice(0, maxCount);
-  if (global.length > 0) lines.push(`Available to everyone: ${toTokens(global)}`);
-  for (const responder of responders) {
-    const own = (orderedOwnByChar.get(responder.charId) ?? []).slice(0, maxCount);
-    if (own.length > 0) lines.push(`${responder.name} also has: ${toTokens(own)}`);
-  }
-  if (lines.length === 0) return null;
-  return `${lead}\nAvailable stickers (send by writing sticker:name:):\n${lines.join("\n")}`;
-}
-
-/**
- * Build a compact reaction note for a message's prompt content so the responding
- * character perceives who reacted to it and with what. Reactions live on
- * `message.extra.reactions` (one `{ emoji, by[] }` entry per emoji); `emoji` is a
- * unicode emoji or a custom-emoji token (`:name:`, already advertised separately).
- * The note is appended to the message content (like the `[Sent a photo]` marker)
- * and is deliberately not timestamp-shaped, so the conversation timestamp stripper
- * leaves it intact. `resolveReactorName` maps a reactor id ("user" or a character
- * id) to a display name. Returns "" when there is nothing to annotate.
- */
-/** Single-line excerpt of a grouped segment's text for reaction attribution. */
-function excerptSegmentText(lines: string[]): string {
-  const text = lines.join(" ").replace(/\s+/g, " ").trim();
-  const MAX = 80;
-  // Truncate on code points, not UTF-16 units — a sliced surrogate pair would
-  // put a lone surrogate in the prompt payload.
-  const chars = Array.from(text);
-  if (chars.length <= MAX) return text;
-  return `${chars.slice(0, MAX).join("").trimEnd()}…`;
-}
-
-/**
- * Content cap for reaction-annotation segmentation. The tag parser backtracks
- * on unclosed `<speaker=` openers, so a pathological pasted message could stall
- * the prompt-build hot path; past the cap we skip attribution (plain wording).
- */
-const REACTION_ANNOTATION_CONTENT_CAP = 32_000;
-
-/** Whether a grouped segment is a reaction-attributable speaker part (has a speaker + text). */
-function isAttributableGroup(group: GroupedSegment): boolean {
-  return group.speaker != null && group.lines.some((line) => line.trim().length > 0);
-}
-
-/**
- * Annotate a prompt message with its reactions and return the new content.
- *
- * Segment-targeted reactions are injected INLINE — a `[X reacted with E]` line
- * directly under the part they were aimed at (position conveys the target, the
- * way a chat app renders reactions under a specific message) — grouped so one
- * part's reactions share a line: `[User reacted with 😹, Aurey reacted with 🙄]`.
- *
- * Because `promptContent` (regex-scripted, command-bearing) can be shaped
- * differently from the content the client stored the segment index against,
- * the target is resolved in two steps: the stored index is resolved against
- * `clientShapeContent` (timestamp-stripped stored content — client parity),
- * then mapped into `promptContent`'s segmentation by (speaker, ordinal). When
- * the mapping fails, the reaction falls back to an end-of-message note —
- * quoting the part when it resolved, naming just the speaker when only the
- * speaker matched, plain otherwise. Whole-message reactions always use the
- * end-of-message note. Only canonical character names are echoed; the stored
- * segmentSpeaker string is used solely for normalized matching.
- */
-function annotateContentWithReactions(
-  promptContent: string,
-  clientShapeContent: string,
-  reactions: unknown,
-  knownSpeakersByNorm: Map<string, string>,
-  resolveReactorName: (reactorId: string) => string,
-): string {
-  if (!Array.isArray(reactions) || reactions.length === 0) return promptContent;
-  const knownNames = new Set(knownSpeakersByNorm.keys());
-  const clientGroups: GroupedSegment[] | null =
-    clientShapeContent.length <= REACTION_ANNOTATION_CONTENT_CAP
-      ? parseGroupedSpeakerSegments(clientShapeContent, knownNames)
-      : null;
-  const promptGroups: GroupedSegment[] | null =
-    promptContent.length <= REACTION_ANNOTATION_CONTENT_CAP
-      ? parseGroupedSpeakerSegments(promptContent, knownNames)
-      : null;
-
-  // Map a resolved client-shape group onto the prompt-shape segmentation. The
-  // prompt side can carry extra attributable parts the client shape doesn't
-  // (command-only parts in conversationCommandContent, leaked-timestamp lines),
-  // so a plain per-speaker ordinal can drift — the mapped group must also
-  // CONTAIN the client part's identifying first line, or we scan the speaker's
-  // other prompt parts for it, or give up (end-note fallback). Position is the
-  // inline note's only targeting signal; never inject on an unverified match.
-  const promptGroupFor = (clientIndex: number): GroupedSegment | null => {
-    if (!clientGroups || !promptGroups) return null;
-    const target = clientGroups[clientIndex]!;
-    const norm = normalizeTextForMatch(target.speaker!);
-    const marker =
-      target.lines
-        .flatMap((chunk) => chunk.split("\n"))
-        .map((line) => line.trim())
-        .find((line) => line.length > 0) ?? "";
-    if (!marker) return null;
-    const sameSpeaker = promptGroups.filter(
-      (g) => isAttributableGroup(g) && normalizeTextForMatch(g.speaker!) === norm,
-    );
-    if (sameSpeaker.length === 0) return null;
-    let ordinal = 0;
-    for (let i = 0; i < clientIndex; i++) {
-      const g = clientGroups[i]!;
-      if (isAttributableGroup(g) && normalizeTextForMatch(g.speaker!) === norm) ordinal++;
-    }
-    // Whole-line equality, not substring: the marker line quoted inside another
-    // part (command args, a longer sentence) must not count as that part.
-    const hasMarkerLine = (g: GroupedSegment) =>
-      g.lines.some((chunk) => chunk.split("\n").some((line) => line.trim() === marker));
-    const ordinalPick = sameSpeaker[ordinal];
-    if (ordinalPick && hasMarkerLine(ordinalPick)) return ordinalPick;
-    // Several parts can repeat the marker line — prefer the one nearest the
-    // expected ordinal instead of the first hit.
-    let best: GroupedSegment | null = null;
-    let bestDistance = Infinity;
-    for (let ci = 0; ci < sameSpeaker.length; ci++) {
-      const candidate = sameSpeaker[ci]!;
-      if (!hasMarkerLine(candidate)) continue;
-      const distance = Math.abs(ci - ordinal);
-      if (distance < bestDistance) {
-        best = candidate;
-        bestDistance = distance;
-      }
-    }
-    return best;
-  };
-
-  type ResolvedNote =
-    | { kind: "inline"; phrase: string; speakerNorm: string; group: GroupedSegment }
-    | {
-        kind: "end";
-        phrase: string;
-        speakerNorm: string | null;
-        text: string;
-        /**
-         * True for the speaker-only stale-index tier — the shape a cross-swipe
-         * twin of an inlined reaction takes, safe to collapse into the inline
-         * note. Quoted-tier notes are client-resolved distinct reactions (the
-         * excerpt disambiguates) and must never be suppressed.
-         */
-        staleTwinShape: boolean;
-      };
-  const notes: ResolvedNote[] = [];
-  for (const entry of reactions as Array<{
-    emoji?: unknown;
-    by?: unknown;
-    segment?: unknown;
-    segmentSpeaker?: unknown;
-  }>) {
-    const emoji = typeof entry.emoji === "string" ? entry.emoji : null;
-    const reactors = Array.isArray(entry.by) ? entry.by.filter((id): id is string => typeof id === "string") : [];
-    if (!emoji || reactors.length === 0) continue;
-    const names = reactors.map(resolveReactorName);
-    const who =
-      names.length === 1
-        ? names[0]!
-        : names.length === 2
-          ? `${names[0]} and ${names[1]}`
-          : `${names.slice(0, -1).join(", ")} and ${names[names.length - 1]}`;
-    const phrase = `${who} reacted with ${emoji}`;
-
-    const storedSpeaker =
-      typeof entry.segmentSpeaker === "string" && entry.segmentSpeaker.trim() ? entry.segmentSpeaker : null;
-    const wanted = storedSpeaker !== null ? normalizeTextForMatch(storedSpeaker) : null;
-    const segIdx = typeof entry.segment === "number" && Number.isInteger(entry.segment) ? entry.segment : null;
-    const seg = clientGroups && segIdx !== null && segIdx >= 0 && segIdx < clientGroups.length
-      ? clientGroups[segIdx]
-      : undefined;
-    const segSpeakerNorm = seg?.speaker != null ? normalizeTextForMatch(seg.speaker) : null;
-    // Entries without a stored speaker align by index alone (client legacy branch).
-    const segAligned =
-      seg !== undefined &&
-      segSpeakerNorm !== null &&
-      (wanted === null || segSpeakerNorm === wanted) &&
-      isAttributableGroup(seg);
-
-    if (segAligned) {
-      const promptGroup = promptGroupFor(segIdx!);
-      if (promptGroup) {
-        notes.push({ kind: "inline", phrase, speakerNorm: segSpeakerNorm!, group: promptGroup });
-        continue;
-      }
-      // Part exists but isn't locatable in the prompt-shaped content — fall
-      // back to the quoted end note so the target stays unambiguous.
-      const canonical = knownSpeakersByNorm.get(segSpeakerNorm!);
-      if (canonical) {
-        notes.push({
-          kind: "end",
-          phrase,
-          speakerNorm: segSpeakerNorm!,
-          text: `${phrase} to ${canonical}'s part ("${excerptSegmentText(seg!.lines)}")`,
-          staleTwinShape: false,
-        });
-        continue;
-      }
-    } else if (wanted !== null && clientGroups) {
-      const speakerGroup = clientGroups.find(
-        (g) => isAttributableGroup(g) && normalizeTextForMatch(g.speaker!) === wanted,
-      );
-      const canonical = speakerGroup ? knownSpeakersByNorm.get(wanted) : undefined;
-      if (canonical) {
-        notes.push({
-          kind: "end",
-          phrase,
-          speakerNorm: wanted,
-          text: `${phrase} to ${canonical}'s part`,
-          staleTwinShape: true,
-        });
-        continue;
-      }
-    }
-    notes.push({ kind: "end", phrase, speakerNorm: null, text: phrase, staleTwinShape: false });
-  }
-
-  const inlineByGroup = new Map<GroupedSegment, string[]>();
-  const inlineKeys = new Set<string>();
-  for (const note of notes) {
-    if (note.kind !== "inline") continue;
-    const lines = inlineByGroup.get(note.group) ?? [];
-    if (!lines.includes(note.phrase)) lines.push(note.phrase);
-    inlineByGroup.set(note.group, lines);
-    inlineKeys.add(`${note.phrase}\u0000${note.speakerNorm}`);
-  }
-  const endParts: string[] = [];
-  for (const note of notes) {
-    if (note.kind !== "end") continue;
-    // A stale cross-swipe twin of an inlined reaction (same wording, same target
-    // speaker) would double-report it — the inline note already covers it.
-    // Quoted-tier notes are distinct client-resolved reactions and always stay.
-    if (
-      note.staleTwinShape &&
-      note.speakerNorm !== null &&
-      inlineKeys.has(`${note.phrase}\u0000${note.speakerNorm}`)
-    ) {
-      continue;
-    }
-    endParts.push(note.text);
-  }
-
-  // Inject inline notes back-to-front so earlier offsets stay valid. When the
-  // injection point isn't a line end (tag segments can have same-line trailing
-  // narration), push the following text onto its own line.
-  let annotated = promptContent;
-  const injections = [...inlineByGroup.entries()].sort((a, b) => b[0].end - a[0].end);
-  for (const [group, lines] of injections) {
-    const nextChar = annotated.charAt(group.end);
-    const trailingBreak = nextChar && nextChar !== "\n" && nextChar !== "\r" ? "\n" : "";
-    annotated = `${annotated.slice(0, group.end)}\n[${lines.join(", ")}]${trailingBreak}${annotated.slice(group.end)}`;
-  }
-  // Dedupe end notes: entries for the same emoji+speaker can exist at different
-  // stale indices (targets synced across swipes) and collapse to one wording.
-  const uniqueEndParts = [...new Set(endParts)];
-  if (uniqueEndParts.length > 0) annotated += `\n[${uniqueEndParts.join("; ")}]`;
-  return annotated;
-}
-
-/**
- * Add a reactor to a message's reactions (add-only, idempotent — a no-op if the
- * reactor already reacted with this emoji). Applies a character's `[react:]`
- * directive server-side. `imageUrl` is stored for a custom (`:name:`) reaction so
- * the chip renders without re-resolving the gallery. Pure — returns a new array.
- */
-function addMessageReactor(
-  reactions: unknown,
-  emoji: string,
-  reactor: string,
-  imageUrl: string | null,
-  target?: { segment: number; speaker: string | null } | null,
-): MessageReaction[] {
-  const current = Array.isArray(reactions) ? (reactions as MessageReaction[]) : [];
-  // Entry identity is (emoji, segment target) — the same rule as the client's
-  // toggleReaction (issue #3210): an untargeted character reaction only merges
-  // into a whole-message entry, a targeted one only into its own segment's.
-  const targetSegment = target?.segment ?? null;
-  const targetSpeakerNorm = target?.speaker != null ? normalizeTextForMatch(target.speaker) : null;
-  const index = current.findIndex((r) => {
-    if (r.emoji !== emoji) return false;
-    if ((r.segment ?? null) !== targetSegment) return false;
-    if (targetSegment === null) return true;
-    // Same-index leftovers from a different segmentation (other speaker) stay distinct.
-    if (r.segmentSpeaker === undefined) return true;
-    return (r.segmentSpeaker != null ? normalizeTextForMatch(r.segmentSpeaker) : null) === targetSpeakerNorm;
-  });
-  if (index === -1) {
-    const entry: MessageReaction = { emoji, by: [reactor] };
-    if (imageUrl) entry.imageUrl = imageUrl;
-    if (target) {
-      entry.segment = target.segment;
-      entry.segmentSpeaker = target.speaker ?? null;
-    }
-    return [...current, entry];
-  }
-  const entry = current[index]!;
-  if (entry.by.includes(reactor)) return current;
-  const next = [...current];
-  next[index] = { ...entry, by: [...entry.by, reactor], ...(imageUrl && !entry.imageUrl ? { imageUrl } : {}) };
-  return next;
-}
-
-function buildGlobalCustomEmojiUrl(filePath: string): string {
-  return `/api/custom-emojis/file/${encodeURIComponent(filePath)}`;
-}
-
-function buildConversationCustomEmojiKey(
-  scope: "global" | "persona" | "character",
-  scopeId: string | null,
-  name: string,
-): string {
-  return scopeId ? `${scope}:${scopeId}:${name}` : `${scope}:${name}`;
-}
-
-function getStoredFilename(filePath: string): string {
-  return filePath.split("/").pop() ?? filePath;
-}
-
-function buildCharacterGalleryEmojiUrl(characterId: string, filename: string): string {
-  return `/api/characters/${encodeURIComponent(characterId)}/gallery/file/${encodeURIComponent(filename)}`;
-}
-
-function buildPersonaGalleryEmojiUrl(personaId: string, filename: string): string {
-  return `/api/characters/personas/${encodeURIComponent(personaId)}/gallery/file/${encodeURIComponent(filename)}`;
-}
 
 export async function generateRoutes(app: FastifyInstance) {
   const isDebug = logger.isLevelEnabled("debug");
@@ -1910,71 +672,11 @@ export async function generateRoutes(app: FastifyInstance) {
       normalizePromptTimeZone(chatMeta.promptTimeZone) ?? normalizePromptTimeZone(input.userTimeZone);
     const promptNow = toZonedWallClockDate(new Date(), promptTimeZone);
     const excludePastReasoning = chatMeta.excludePastReasoning !== false;
-    const imageCaptioningRuntime: ImageCaptioningRuntime = await (async () => {
-      if (chatMeta.imageCaptioningEnabled !== true) return DISABLED_IMAGE_CAPTIONING;
-      try {
-        const configuredConnectionId =
-          typeof chatMeta.imageCaptioningConnectionId === "string" && chatMeta.imageCaptioningConnectionId.trim()
-            ? chatMeta.imageCaptioningConnectionId.trim()
-            : null;
-        const fallbackCaptionConnectionId = configuredConnectionId ?? connId;
-        if (!fallbackCaptionConnectionId) return DISABLED_IMAGE_CAPTIONING;
-        let captionConnectionId = fallbackCaptionConnectionId;
-        if (captionConnectionId === "random") {
-          const pool = await connections.listRandomPool();
-          if (!pool.length) {
-            logger.warn("[image-captioning] Random captioning connection requested but random pool is empty");
-            return DISABLED_IMAGE_CAPTIONING;
-          }
-          const randomCaptionConnectionId = pool[Math.floor(Math.random() * pool.length)]?.id;
-          if (!randomCaptionConnectionId) {
-            logger.warn("[image-captioning] Random captioning connection resolved without an id");
-            return DISABLED_IMAGE_CAPTIONING;
-          }
-          captionConnectionId = randomCaptionConnectionId;
-        }
-
-        const captionConnection =
-          captionConnectionId === LOCAL_SIDECAR_CONNECTION_ID
-            ? createLocalSidecarGenerationConnection()
-            : await connections.getWithKey(captionConnectionId);
-        if (!captionConnection?.model) {
-          logger.warn("[image-captioning] Captioning connection %s was not found", captionConnectionId);
-          return DISABLED_IMAGE_CAPTIONING;
-        }
-
-        let captionProvider: BaseLLMProvider;
-        if (captionConnectionId === LOCAL_SIDECAR_CONNECTION_ID) {
-          captionProvider = getLocalSidecarProvider();
-        } else {
-          const captionBaseUrl = resolveBaseUrl(captionConnection);
-          if (!captionBaseUrl) {
-            logger.warn("[image-captioning] Captioning connection %s has no base URL", captionConnectionId);
-            return DISABLED_IMAGE_CAPTIONING;
-          }
-          captionProvider = createLLMProvider(
-            captionConnection.provider,
-            captionBaseUrl,
-            captionConnection.apiKey,
-            captionConnection.maxContext,
-            captionConnection.openrouterProvider,
-            captionConnection.maxTokensOverride,
-            captionConnection.claudeFastMode === "true",
-            captionConnection.treatAsLocalEndpoint === "true",
-          );
-        }
-
-        return {
-          enabled: true,
-          connectionId: captionConnectionId,
-          connection: captionConnection,
-          provider: captionProvider,
-        };
-      } catch (error) {
-        logger.warn(error, "[image-captioning] Failed to resolve captioning connection; sending images normally");
-        return DISABLED_IMAGE_CAPTIONING;
-      }
-    })();
+    const imageCaptioningRuntime: ImageCaptioningRuntime = await resolveImageCaptioningRuntime({
+      chatMeta,
+      fallbackConnectionId: connId,
+      connections,
+    });
     let memoryRecallEmbeddingSource: Awaited<ReturnType<typeof resolveMemoryRecallEmbeddingSource>> | null = null;
     try {
       memoryRecallEmbeddingSource = await resolveMemoryRecallEmbeddingSource(app.db, {
@@ -2903,592 +1605,70 @@ export async function generateRoutes(app: FastifyInstance) {
         // ── Conversation mode: inject built-in DM-style system prompt ──
         let convoAwarenessBlock: string | null = null;
         if (chatMode === "conversation") {
-          // Gather character names and status for the prompt.
-          // If schedules exist in chat metadata, derive status dynamically.
-          const schedules: Record<string, import("../services/conversation/schedule.service.js").WeekSchedule> =
-            getEnabledConversationSchedules(chatMeta) as Record<
-              string,
-              import("../services/conversation/schedule.service.js").WeekSchedule
-            >;
-          const statusOverrides = parseConversationStatusOverrides(chatMeta.conversationStatusOverrides);
-          const convoCharInfo: {
-            charId: string;
-            name: string;
-            status: string;
-            activity: string;
-            todaySchedule: string;
-          }[] = [];
-          for (const cid of characterIds) {
-            const charRow = await chars.getById(cid);
-            if (charRow) {
-              const d = JSON.parse(charRow.data as string);
-              const schedSvc = await import("../services/conversation/schedule.service.js");
-              const override = statusOverrides[cid];
-              // Schedules are chat-scoped. If this chat has no schedule for the character,
-              // don't inherit a stale conversationStatus from some other chat.
-              const fallback = schedSvc.getEffectiveCurrentStatus(undefined, override, promptNow, "");
-              let status = fallback.status;
-              let activity = fallback.activity;
-              let todaySchedule = "";
-              const schedule = schedules[cid];
-              if (schedule) {
-                const derived = schedSvc.getEffectiveCurrentStatus(schedule, override, promptNow);
-                status = derived.status;
-                activity = derived.activity;
-                todaySchedule = schedSvc.getTodaySchedule(schedule, promptNow);
-              }
-              convoCharInfo.push({ charId: cid, name: d.name ?? "Unknown", status, activity, todaySchedule });
-            }
-          }
-          // Persist per-chat presence state so sidebar dots stay scoped to this chat.
-          if (convoCharInfo.length > 0) {
-            void chats
-              .patchMetadata(
-                input.chatId,
-                (current) => ({
-                  conversationCharacterStatuses: {
-                    ...(current.conversationCharacterStatuses ?? {}),
-                    ...Object.fromEntries(
-                      convoCharInfo.map((c) => [c.charId, { status: c.status, activity: c.activity }]),
-                    ),
-                  },
-                }),
-                { touchUpdatedAt: false },
-              )
-              .catch(() => {});
-          }
-          const convoCharNames = convoCharInfo.map((c) => c.name);
-          const charNameList = convoCharNames.length ? convoCharNames.join(", ") : "the character";
-          const manualTargetCharId =
-            typeof input.forCharacterId === "string" && characterIds.includes(input.forCharacterId)
-              ? input.forCharacterId
-              : null;
-          const requestedMentionNames = new Set(
-            (input.mentionedCharacterNames ?? []).map((name: string) => normalizeTextForMatch(name)),
-          );
-          const scopedConvoCharInfo = manualTargetCharId
-            ? convoCharInfo.filter((c) => c.charId === manualTargetCharId)
-            : requestedMentionNames.size > 0
-              ? convoCharInfo.filter((c) => requestedMentionNames.has(normalizeTextForMatch(c.name)))
-              : convoCharInfo;
-          let respondingConvoCharInfo = scopedConvoCharInfo.length > 0 ? scopedConvoCharInfo : convoCharInfo;
-
-          if (shouldAccountAutonomousGeneration && !input.regenerateMessageId && !input.impersonate) {
-            const budget = getAutonomousDailyBudget(chatMeta);
-            respondingConvoCharInfo = respondingConvoCharInfo.filter((character) => {
-              const count = budget.counts[character.charId] ?? 0;
-              const cap = dailyCapForCharacter(schedules[character.charId], chatMeta);
-              return count < cap;
-            });
-
-            if (respondingConvoCharInfo.length === 0) {
-              reply.raw.write(`data: ${JSON.stringify({ type: "done" })}\n\n`);
+          const presenceRuntime = await resolveConversationPresenceRuntime({
+            db: app.db,
+            chatId: input.chatId,
+            chatMeta,
+            characterIds,
+            chars,
+            chats,
+            promptNow,
+            forCharacterId: input.forCharacterId,
+            mentionedCharacterNames: input.mentionedCharacterNames,
+            shouldAccountAutonomousGeneration,
+            regenerateMessageId: input.regenerateMessageId,
+            impersonate: input.impersonate,
+            skipPresenceDelay: input.skipPresenceDelay,
+            supportsHiddenFromAI,
+            contextMessageLimit,
+            chatMessages,
+            finalMessages,
+            abortSignal: abortController.signal,
+            writeSse: (payload) => {
+              reply.raw.write(`data: ${JSON.stringify(payload)}\n\n`);
+            },
+            endSse: () => {
               reply.raw.end();
-              return;
-            }
-          }
-
-          const respondingConvoCharNames = respondingConvoCharInfo.map((c) => c.name);
-
-          // Characters seated at an ACTIVE turn-game are present at the table:
-          // treat them as online so their schedule's offline-skip + typing delay
-          // don't make a player at the table go silent or reply minutes late.
-          let seatedGameCharIds = new Set<string>();
-          {
-            const activeGameForSchedule = await getActiveTurnGame(app.db, input.chatId);
-            const seatOrder = activeGameForSchedule?.state?.seatOrder;
-            if (Array.isArray(seatOrder)) {
-              seatedGameCharIds = new Set(seatOrder.filter((x: unknown): x is string => typeof x === "string"));
-            }
-          }
-          const effectiveStatus = (c: { charId: string; status: string }): string =>
-            seatedGameCharIds.has(c.charId) ? "online" : c.status;
-
-          // ── Offline skip: if ALL characters are offline, don't generate ──
-          // The user message is already saved. When the character comes back online,
-          // the autonomous messaging system will trigger a catch-up generation.
-          const allOffline =
-            respondingConvoCharInfo.length > 0 &&
-            respondingConvoCharInfo.every((c) => effectiveStatus(c) === "offline");
-          if (allOffline && !input.regenerateMessageId && !input.impersonate) {
-            reply.raw.write(`data: ${JSON.stringify({ type: "offline", characters: respondingConvoCharNames })}\n\n`);
-            reply.raw.write(`data: ${JSON.stringify({ type: "done" })}\n\n`);
-            reply.raw.end();
+            },
+            mapChatHistoryMessageForPrompt,
+            resolveHistoryMessageMacros,
+          });
+          if (presenceRuntime.ended || presenceRuntime.aborted) {
             return;
           }
+          chatMessages = presenceRuntime.chatMessages;
+          finalMessages = presenceRuntime.finalMessages;
+          const { convoCharInfo, convoCharNames, charNameList, isGroup } = presenceRuntime;
 
-          // ── Typing delay: DND/idle characters don't respond instantly ──
-          if (!input.regenerateMessageId && !input.impersonate && !input.skipPresenceDelay) {
-            const schedSvc = await import("../services/conversation/schedule.service.js");
-            // Check if any characters were @mentioned
-            const hasMentions = requestedMentionNames.size > 0 || !!manualTargetCharId;
-            // Use the "worst" (longest-delay) status among all characters
-            const worstStatus = respondingConvoCharInfo.reduce((worst, c) => {
-              const rank = { online: 0, idle: 1, dnd: 2, offline: 3 } as Record<string, number>;
-              const cStatus = effectiveStatus(c);
-              return (rank[cStatus] ?? 0) > (rank[worst] ?? 0) ? cStatus : worst;
-            }, "online");
-            // If user @mentioned a character, use reduced mention delay instead.
-            // Otherwise use the slowest configured delay among the responding characters.
-            const delayMs = hasMentions
-              ? schedSvc.getMentionDelay(worstStatus as "online" | "idle" | "dnd" | "offline")
-              : respondingConvoCharInfo.reduce((maxDelay, character) => {
-                  const schedule = schedules[character.charId];
-                  return Math.max(
-                    maxDelay,
-                    schedSvc.getDirectMessageDelay(
-                      effectiveStatus(character) as "online" | "idle" | "dnd" | "offline",
-                      schedule,
-                    ),
-                  );
-                }, 0);
-            if (delayMs > 0) {
-              const characterStatuses = Object.fromEntries(
-                respondingConvoCharInfo.map((character) => [character.charId, character.status]),
-              );
-              // Send "delayed" event first — client shows "will respond in a moment" / "when they're back"
-              reply.raw.write(
-                `data: ${JSON.stringify({
-                  type: "delayed",
-                  characters: respondingConvoCharNames,
-                  characterIds: respondingConvoCharInfo.map((character) => character.charId),
-                  characterStatuses,
-                  status: worstStatus,
-                  delayMs,
-                })}\n\n`,
-              );
-              await new Promise<void>((resolve) => {
-                if (abortController.signal.aborted) {
-                  resolve();
-                  return;
-                }
-                const timeout = setTimeout(resolve, delayMs);
-                abortController.signal.addEventListener(
-                  "abort",
-                  () => {
-                    clearTimeout(timeout);
-                    resolve();
-                  },
-                  { once: true },
-                );
-              });
-              if (abortController.signal.aborted) return;
-
-              // Re-read messages after the delay — the user may have sent
-              // follow-up messages while the character was busy/idle.
-              const refreshed = await chats.listMessages(input.chatId);
-              let rStartIdx = 0;
-              for (let i = refreshed.length - 1; i >= 0; i--) {
-                const ex = parseExtra(refreshed[i]!.extra);
-                if (ex.isConversationStart) {
-                  rStartIdx = i;
-                  break;
-                }
-              }
-              const rScoped = rStartIdx > 0 ? refreshed.slice(rStartIdx) : refreshed;
-              chatMessages = supportsHiddenFromAI ? rScoped.filter((m: any) => !isMessageHiddenFromAI(m)) : rScoped;
-              if (contextMessageLimit && contextMessageLimit > 0 && chatMessages.length > contextMessageLimit) {
-                chatMessages = chatMessages.slice(-contextMessageLimit);
-              }
-              finalMessages = [];
-              for (const message of chatMessages) {
-                finalMessages.push(await mapChatHistoryMessageForPrompt(message));
-              }
-              finalMessages = resolveHistoryMessageMacros(finalMessages);
-            }
-            // Send "typing" event — client switches to "X is typing..."
-            reply.raw.write(`data: ${JSON.stringify({ type: "typing", characters: respondingConvoCharNames })}\n\n`);
-          }
-
-          // For regenerations, skip the delay but still send the typing indicator
-          if (input.regenerateMessageId) {
-            reply.raw.write(`data: ${JSON.stringify({ type: "typing", characters: convoCharNames })}\n\n`);
-          }
-
-          const isGroup = convoCharNames.length > 1;
-
-          // Inject timestamps: today's messages get [HH:MM] per message,
-          // older messages are grouped by date inside <date="DD.MM.YYYY"> blocks.
-          // The "day" boundary is shifted by dayRolloverHour so a late-night
-          // session doesn't get split when calendar midnight passes.
           const nowInstant = new Date();
-          const rolloverHour = Math.max(
-            0,
-            Math.min(11, Math.floor((chatMeta.dayRolloverHour as number | undefined) ?? 4)),
-          );
-          const isSameDay = (ts: Date) => isSameZonedLogicalDay(ts, nowInstant, promptTimeZone, rolloverHour);
-          const fmtDate = (ts: Date) => formatZonedConversationDate(ts, promptTimeZone, rolloverHour);
-          const todayDateKey = fmtDate(nowInstant);
-          const fmtTime = (ts: Date) => formatZonedConversationTime(ts, promptTimeZone);
-
-          // Strip leaked [HH:MM] or [DD.MM.YYYY] timestamps that models sometimes echo
-          const stripLeakedTimestamps = stripConversationPromptTimestamps;
-
-          // Build character name lookup for past-day author attribution
-          const charIdToName = new Map<string, string>();
-          for (let ci = 0; ci < characterIds.length; ci++) {
-            if (convoCharInfo[ci]) charIdToName.set(characterIds[ci]!, convoCharInfo[ci]!.name);
-          }
-
-          // Annotate each message with its reactions so the responding character
-          // perceives who reacted and with what. finalMessages[i] is index-aligned
-          // with chatMessages[i] here (same invariant the bucket loop below relies
-          // on); the note rides on the content through the formatting that follows.
-          // "user" is the human reactor (matches the client USER_REACTOR sentinel);
-          // any other id is a character.
-          const reactorDisplayName = (reactorId: string): string =>
-            reactorId === "user" ? personaName : (charIdToName.get(reactorId) ?? "a character");
-          const anyReactedMessage = chatMessages.some((m: any) => {
-            const r = parseExtra(m.extra).reactions;
-            return Array.isArray(r) && r.length > 0;
-          });
-          if (anyReactedMessage) {
-            // Canonical speaker names for reaction attribution, keyed by their
-            // normalized form. Must cover every speaker the CLIENT can segment
-            // against — all chat characters (the client's known-name set keeps
-            // disabled ones) plus each message's own author (still segmentable
-            // after removal from the chat) — or segment indexes drift.
-            const reactionSpeakersByNorm = new Map<string, string>();
-            const addReactionSpeaker = (name: unknown) => {
-              if (typeof name !== "string") return;
-              const norm = normalizeTextForMatch(name);
-              const canonical = name.replace(/\s+/g, " ").trim();
-              if (norm && canonical && !reactionSpeakersByNorm.has(norm)) reactionSpeakersByNorm.set(norm, canonical);
-            };
-            for (const name of charIdToName.values()) addReactionSpeaker(name);
-            const extraSpeakerIds = new Set<string>();
-            for (const cid of allCharacterIds) if (!charIdToName.has(cid)) extraSpeakerIds.add(cid);
-            for (const m of chatMessages as Array<{ characterId?: unknown }>) {
-              const cid = m.characterId;
-              if (typeof cid === "string" && cid && !charIdToName.has(cid)) extraSpeakerIds.add(cid);
-            }
-            for (const cid of extraSpeakerIds) {
-              const row = await chars.getById(cid);
-              if (!row) continue;
-              try {
-                addReactionSpeaker(JSON.parse(row.data as string)?.name);
-              } catch {
-                // Malformed character data — skip; that speaker just won't be attributable.
-              }
-            }
-            // Pair prompt messages with their stored rows by id (index pairing
-            // can misalign on a follow-up pass after a mid-delay history refresh).
-            const rawMessagesById = new Map<string, any>();
-            for (const m of chatMessages as Array<{ id?: unknown }>) {
-              if (typeof m.id === "string") rawMessagesById.set(m.id, m);
-            }
-            for (let i = 0; i < finalMessages.length; i++) {
-              const promptMsgId = (finalMessages[i] as { id?: unknown }).id;
-              const raw = typeof promptMsgId === "string" ? rawMessagesById.get(promptMsgId) : undefined;
-              if (!raw) continue;
-              // Segment indexes resolve against the DISPLAY shape of the stored
-              // content (shared stripLeadingMessageTimestamps — exactly what the
-              // client renders and segments), then map into the prompt-shaped
-              // content for the inline injection. Replace the message object
-              // rather than mutating it: finalMessages shares objects with the
-              // follow-up/agent message arrays, and a mutated object would get
-              // annotated a second time on a follow-up generation pass.
-              const rawContentStr = typeof raw.content === "string" ? raw.content : String(raw.content ?? "");
-              finalMessages[i] = {
-                ...finalMessages[i]!,
-                content: annotateContentWithReactions(
-                  finalMessages[i]!.content,
-                  // Oversized content skips segmentation inside annotate anyway —
-                  // don't pay the strip on it either.
-                  rawContentStr.length > REACTION_ANNOTATION_CONTENT_CAP
-                    ? rawContentStr
-                    : stripLeadingMessageTimestamps(rawContentStr),
-                  parseExtra(raw.extra).reactions,
-                  reactionSpeakersByNorm,
-                  reactorDisplayName,
-                ),
-              };
-            }
-          }
-
-          // Separate into past-day groups and today's messages, preserving order
-          type BucketMsg = { role: string; content: string; author: string; ts: Date };
-          type Bucket = { date: string; msgs: BucketMsg[] };
-          const buckets: Array<Bucket | { role: string; content: string }> = [];
-          let currentBucket: Bucket | null = null;
-          // Index of today's first verbatim message in the buckets array. Used
-          // to splice the tail block in immediately before today begins.
-          let firstTodayIdx: number | null = null;
-
-          for (let i = 0; i < finalMessages.length; i++) {
-            const msg = finalMessages[i]!;
-            const raw = chatMessages[i];
-            if (!raw?.createdAt || msg.role === "system") {
-              // Flush open bucket
-              if (currentBucket) {
-                buckets.push(currentBucket);
-                currentBucket = null;
-              }
-              buckets.push(msg);
-              continue;
-            }
-            const ts = new Date(raw.createdAt as string);
-            // Resolve author name for this message
-            const author =
-              msg.role === "user"
-                ? personaName
-                : ((raw.characterId ? charIdToName.get(raw.characterId as string) : null) ??
-                  convoCharNames[0] ??
-                  "Character");
-            if (isSameDay(ts)) {
-              // Flush open bucket
-              if (currentBucket) {
-                buckets.push(currentBucket);
-                currentBucket = null;
-              }
-              if (firstTodayIdx === null) firstTodayIdx = buckets.length;
-              const promptContent = formatConversationPromptTurn(
-                stripLeakedTimestamps(msg.content),
-                msg.role,
-                personaName,
-                msg.role === "assistant" ? author : null,
-              );
-              buckets.push({ ...msg, content: `[${fmtTime(ts)}] ${promptContent}` });
-            } else {
-              const dateKey = fmtDate(ts);
-              if (currentBucket && currentBucket.date === dateKey) {
-                currentBucket.msgs.push({ ...msg, content: stripLeakedTimestamps(msg.content), author, ts });
-              } else {
-                if (currentBucket) buckets.push(currentBucket);
-                currentBucket = {
-                  date: dateKey,
-                  msgs: [{ ...msg, content: stripLeakedTimestamps(msg.content), author, ts }],
-                };
-              }
-            }
-          }
-          if (currentBucket) buckets.push(currentBucket);
-
-          // ── Auto-summarize missing past days and completed weeks ──
-          // This scans the full scoped conversation, not the display/context-limited
-          // prompt slice, so a failed day can still be retried after it ages out of
-          // the latest visible window.
-          const parseDateKey = parseConversationDateKey;
-          const fmtDateKey = formatConversationDateKey;
-          const summarySourceMessages = input.regenerateMessageId
-            ? scopedMessages.filter((m: any) => m.id !== input.regenerateMessageId)
-            : scopedMessages;
-          const summaryProvider = createLLMProvider(
-            conn.provider,
-            baseUrl,
-            conn.apiKey,
-            conn.maxContext,
-            conn.openrouterProvider,
-            conn.maxTokensOverride,
-          );
-          const summaryRun = await generateMissingConversationSummaries({
-            messages: summarySourceMessages,
-            metadata: chatMeta,
-            provider: summaryProvider,
-            model: conn.model,
+          const preparedHistory = await prepareConversationPromptHistory({
+            finalMessages,
+            chatMessages,
+            scopedMessages,
+            regenerateMessageId: input.regenerateMessageId,
+            chatMeta,
+            chatId: input.chatId,
+            chats,
+            chars,
+            characterIds,
+            allCharacterIds,
+            convoCharInfo,
+            convoCharNames,
             personaName,
-            charIdToName,
-            now: nowInstant,
-            rolloverHour,
-            timeZone: promptTimeZone,
-            maxMissingDays: 2,
+            nowInstant,
+            promptTimeZone,
+            wrapFormat,
+            connection: {
+              provider: conn.provider,
+              apiKey: conn.apiKey,
+              model: conn.model,
+              maxContext: conn.maxContext,
+              openrouterProvider: conn.openrouterProvider,
+              maxTokensOverride: conn.maxTokensOverride,
+            },
+            baseUrl,
           });
-          for (const failure of summaryRun.failedDays) {
-            logger.warn(
-              { chatId: input.chatId, date: failure.date, err: failure.error },
-              "[conversation-summary] failed to generate day summary",
-            );
-          }
-          for (const failure of summaryRun.failedWeeks) {
-            logger.warn(
-              { chatId: input.chatId, weekKey: failure.weekKey, err: failure.error },
-              "[conversation-summary] failed to consolidate week summary",
-            );
-          }
-
-          const hasNewSummaries =
-            Object.keys(summaryRun.newlyGeneratedDays).length > 0 ||
-            Object.keys(summaryRun.newlyConsolidatedWeeks).length > 0;
-          if (hasNewSummaries || summaryRun.summaryFailureMetadataChanged) {
-            await chats.patchMetadata(input.chatId, (freshMeta) => {
-              const existingDaySummaries = (freshMeta.daySummaries as Record<string, unknown> | undefined) ?? {};
-              const existingWeekSummaries = (freshMeta.weekSummaries as Record<string, unknown> | undefined) ?? {};
-              return {
-                ...freshMeta,
-                daySummaries: { ...existingDaySummaries, ...summaryRun.newlyGeneratedDays },
-                weekSummaries: { ...existingWeekSummaries, ...summaryRun.newlyConsolidatedWeeks },
-                conversationSummaryFailures: summaryRun.summaryFailures,
-              };
-            });
-            chatMeta.daySummaries = {
-              ...((chatMeta.daySummaries as Record<string, unknown> | undefined) ?? {}),
-              ...summaryRun.newlyGeneratedDays,
-            };
-            chatMeta.weekSummaries = {
-              ...((chatMeta.weekSummaries as Record<string, unknown> | undefined) ?? {}),
-              ...summaryRun.newlyConsolidatedWeeks,
-            };
-            chatMeta.conversationSummaryFailures = summaryRun.summaryFailures;
-          }
-
-          const daySummaries = summaryRun.daySummaries;
-          const weekSummaries = summaryRun.weekSummaries;
-
-          // Build a lookup: dateKey → weekKey for days that belong to a consolidated week
-          const dayToWeek = new Map<string, string>();
-          for (const [weekKey] of Object.entries(weekSummaries)) {
-            const monday = parseDateKey(weekKey);
-            for (let i = 0; i < 7; i++) {
-              const d = new Date(monday.getFullYear(), monday.getMonth(), monday.getDate() + i);
-              dayToWeek.set(fmtDateKey(d), weekKey);
-            }
-          }
-
-          // Collect all key details for persistent memory injection
-          // Use week-level details for consolidated weeks, day-level for the rest
-          const allKeyDetails: { label: string; details: string[] }[] = [];
-          const weekDetailsEmitted = new Set<string>();
-          // First: week summaries (chronological by week start)
-          const sortedWeekKeys = Object.keys(weekSummaries).sort(
-            (a, b) => parseDateKey(a).getTime() - parseDateKey(b).getTime(),
-          );
-          for (const wk of sortedWeekKeys) {
-            const entry = weekSummaries[wk]!;
-            if (entry.keyDetails.length > 0) {
-              const monday = parseDateKey(wk);
-              const sunday = new Date(monday.getFullYear(), monday.getMonth(), monday.getDate() + 6);
-              allKeyDetails.push({
-                label: `Week of ${wk} – ${fmtDateKey(sunday)}`,
-                details: entry.keyDetails,
-              });
-            }
-            weekDetailsEmitted.add(wk);
-          }
-          // Then: non-consolidated day details
-          for (const [date, entry] of Object.entries(daySummaries)) {
-            if (dayToWeek.has(date)) continue; // covered by week summary
-            if (entry.keyDetails.length > 0) {
-              allKeyDetails.push({ label: date, details: entry.keyDetails });
-            }
-          }
-
-          // Tail messages: pull the last N messages from past-summarized buckets
-          // so the model has concrete recent dialogue to continue from, not just
-          // the gist of yesterday's summary. Walks across day boundaries when
-          // earlier buckets are short.
-          const tailCount = Math.max(
-            0,
-            Math.min(50, Math.floor((chatMeta.summaryTailMessages as number | undefined) ?? 10)),
-          );
-          const tailEntries: BucketMsg[] = [];
-          if (tailCount > 0) {
-            outer: for (let bi = buckets.length - 1; bi >= 0; bi--) {
-              const b = buckets[bi]!;
-              if (!("date" in b && "msgs" in b)) continue;
-              const bucket = b as Bucket;
-              // Pull only from summarized past days. Today's messages are already
-              // verbatim, and unsummarized past days will be emitted verbatim too,
-              // so neither needs duplicating into a tail block.
-              if (bucket.date === todayDateKey) continue;
-              if (!daySummaries[bucket.date]) continue;
-              for (let mi = bucket.msgs.length - 1; mi >= 0; mi--) {
-                tailEntries.unshift(bucket.msgs[mi]!);
-                if (tailEntries.length >= tailCount) break outer;
-              }
-            }
-          }
-
-          // Flatten: consolidated weeks/non-consolidated summarized days → one summary block
-          // in the selected preset wrapping format,
-          // today → individual timestamped messages.
-          // The tail block is spliced in at firstTodayIdx so it sits between
-          // the last summary and today's first verbatim message.
-          const weekBlocksEmitted = new Set<string>();
-          const fmtTailPrefix = (ts: Date) => {
-            const date = formatZonedConversationDate(ts, promptTimeZone).slice(0, 5);
-            return `[${date} ${formatZonedConversationTime(ts, promptTimeZone)}]`;
-          };
-          const buildTailTurns = () => {
-            if (tailEntries.length === 0) return [];
-            // Match today's verbatim format: timestamp prefix, with visible speaker labels.
-            // The [DD.MM HH:MM] prefix unambiguously distinguishes tail turns
-            // from today's [HH:MM] turns, so no wrapper tag is needed — the
-            // model can see from the timestamps alone where today begins.
-            return tailEntries.map((m) => ({
-              role: m.role as "user" | "assistant" | "system",
-              content: `${fmtTailPrefix(m.ts)} ${formatConversationPromptTurn(
-                m.content,
-                m.role,
-                personaName,
-                m.role === "assistant" ? m.author : null,
-              )}`,
-            }));
-          };
-
-          finalMessages = buckets.flatMap((b, bIdx) => {
-            // Splice the tail in immediately before today's first verbatim
-            // message. firstTodayIdx is null when today has no messages yet —
-            // in that case we fall through to the post-loop append below.
-            const prefix = bIdx === firstTodayIdx ? buildTailTurns() : [];
-
-            if ("date" in b && "msgs" in b) {
-              const bucket = b as Bucket;
-              const weekKey = dayToWeek.get(bucket.date);
-
-              // Day belongs to a consolidated week → emit one week summary block (first occurrence)
-              if (weekKey && weekSummaries[weekKey]) {
-                if (weekBlocksEmitted.has(weekKey)) return prefix; // already emitted for this week
-                weekBlocksEmitted.add(weekKey);
-                const wEntry = weekSummaries[weekKey]!;
-                const monday = parseDateKey(weekKey);
-                const sunday = new Date(monday.getFullYear(), monday.getMonth(), monday.getDate() + 6);
-                // Key details are surfaced separately in the system prompt.
-                return [
-                  ...prefix,
-                  {
-                    role: "system" as const,
-                    content: formatConversationSummaryHistoryBlock(
-                      `week="${weekKey} – ${fmtDateKey(sunday)}"`,
-                      wEntry.summary,
-                      wrapFormat,
-                    ),
-                  },
-                ];
-              }
-
-              // Non-consolidated day with a summary
-              const entry = daySummaries[bucket.date];
-              if (entry) {
-                // Key details are surfaced separately in the system prompt.
-                return [
-                  ...prefix,
-                  {
-                    role: "system" as const,
-                    content: formatConversationSummaryHistoryBlock(`date="${bucket.date}"`, entry.summary, wrapFormat),
-                  },
-                ];
-              }
-              // Unsummarized past day — keep each message as its own turn
-              const turns = formatConversationDateHistoryMessages(
-                bucket.msgs.map((m) => ({
-                  role: m.role as "user" | "assistant" | "system",
-                  author: m.author,
-                  content: m.content,
-                })),
-                bucket.date,
-                wrapFormat,
-              );
-              return [...prefix, ...turns];
-            }
-            return [...prefix, b as { role: "system" | "user" | "assistant"; content: string }];
-          });
-
-          // Edge case: today has no messages yet (firstTodayIdx is null).
-          // Append the tail at the end so it still bridges into the upcoming
-          // generation rather than being silently dropped.
-          if (firstTodayIdx === null && tailEntries.length > 0) {
-            finalMessages = [...finalMessages, ...buildTailTurns()];
-          }
+          finalMessages = preparedHistory.finalMessages;
 
           // Build the system prompt
           // Use custom system prompt if set, otherwise the built-in default
@@ -3543,212 +1723,21 @@ export async function generateRoutes(app: FastifyInstance) {
             wrapFormat,
           );
 
-          // ── Character Commands: build a commands block if any features are enabled ──
-          if (conversationCommandsEnabled) {
-            const scheduleCommandEnabled = isConversationCommandEnabled(chatMeta, "schedule_update");
-            const crossPostCommandEnabled = isConversationCommandEnabled(chatMeta, "cross_post");
-            const selfieCommandEnabled = isConversationCommandEnabled(chatMeta, "selfie");
-            const memoryCommandEnabled = isConversationCommandEnabled(chatMeta, "memory");
-            const sceneCommandEnabled = isConversationCommandEnabled(chatMeta, "scene");
-            const callCommandEnabled = isConversationCommandEnabled(chatMeta, "call");
-            const musicCommandEnabled = isConversationCommandEnabled(chatMeta, "music");
-            const hapticCommandEnabled = isConversationCommandEnabled(chatMeta, "haptic");
-            const activeMusicCommandSource =
-              input.musicPlayerEnabled === false
-                ? null
-                : input.musicPlayerSource === "youtube" || input.musicPlayerSource === "custom"
-                  ? input.musicPlayerSource
-                  : "spotify";
-
-            // Discover other chats this character is in (for cross_post targets + memory targets)
-            const allChatsForCrossPost = await chats.list();
-            const crossPostTargets: string[] = [];
-            const memoryTargetCharIds = new Set<string>();
-            for (const c of allChatsForCrossPost) {
-              if (c.id === input.chatId || c.mode !== "conversation") continue;
-              const cCharIds: string[] =
-                typeof c.characterIds === "string"
-                  ? JSON.parse(c.characterIds as string)
-                  : (c.characterIds as string[]);
-              if (characterIds.some((id) => cCharIds.includes(id))) {
-                crossPostTargets.push(c.name || c.id);
-                // Collect character IDs from shared group chats (groups = 2+ characters)
-                if (cCharIds.length > 1) {
-                  for (const id of cCharIds) {
-                    if (!characterIds.includes(id)) memoryTargetCharIds.add(id);
-                  }
-                }
-              }
-            }
-            // Also check if the CURRENT chat is a group — characters in this chat can target each other
-            if (characterIds.length > 1) {
-              for (const id of characterIds) memoryTargetCharIds.add(id);
-            }
-
-            // Resolve memory target names
-            const memoryTargetNames: string[] = [];
-            for (const tid of memoryTargetCharIds) {
-              const tRow = await chars.getById(tid);
-              if (tRow) {
-                const tData = JSON.parse(tRow.data as string);
-                if (tData.name) memoryTargetNames.push(tData.name);
-              }
-            }
-
-            // Check if selfie is enabled for this chat (user picked an image gen connection)
-            const hasImageGen = !!chatMeta.imageGenConnectionId;
-            let conversationSpotifyCommandsAvailable = false;
-            let conversationYoutubeCommandsAvailable = false;
-            if (chatMode === "conversation" && musicCommandEnabled && activeMusicCommandSource === "spotify") {
-              try {
-                const spotifyCredentials = await resolveSpotifyCredentials(agentsStore, { refreshSkewMs: 60_000 });
-                if (
-                  "accessToken" in spotifyCredentials &&
-                  spotifyHasScope(spotifyCredentials.scopes, "user-modify-playback-state")
-                ) {
-                  conversationSpotifyCommandsAvailable = true;
-                } else {
-                  const spotifyReason =
-                    "error" in spotifyCredentials
-                      ? spotifyCredentials.error
-                      : "missing user-modify-playback-state scope";
-                  logger.debug("[spotify/conversation] Song command unavailable: %s", spotifyReason);
-                }
-              } catch (err) {
-                logger.debug(err, "[spotify/conversation] Failed to check Spotify command availability");
-              }
-            } else if (chatMode === "conversation" && musicCommandEnabled && activeMusicCommandSource === "youtube") {
-              conversationYoutubeCommandsAvailable = await isConversationYoutubeCommandAvailable(agentsStore);
-            }
-
-            const commandLines: string[] = [
-              `<commands>`,
-              `Here are your optional, hidden commands you may use if you wish to, but only when they genuinely fit the conversation:`,
-              ``,
-            ];
-            let availableCommandCount = 0;
-            const addCommandLines = (...lines: string[]) => {
-              commandLines.push(...lines, ``);
-              availableCommandCount += 1;
-            };
-
-            if (scheduleCommandEnabled) {
-              addCommandLines(
-                `- [schedule_update: status="online|idle|dnd|offline", activity="activity name", duration="number of hours (e.g., 1h)"] - only if you change your own status/activity, for example, if the user asks you to stop what you're doing or if you decide to change them yourself.`,
-              );
-            }
-
-            if (crossPostCommandEnabled && crossPostTargets.length > 0) {
-              addCommandLines(
-                `- [cross_post: target="${crossPostTargets.map((t) => `"${t}"`).join("|")}"] - if you want to redirect your message to a different chat. Use this when the user suggests you say something in another chat, or when it makes sense to message someone else.`,
-                ` Example: ${personaName} says "maybe ask about that in the group chat?" → You respond: [cross_post: target="${crossPostTargets[0] ?? "group chat"}"] Hey guys, does anyone know about…`,
-              );
-            }
-
-            if (selfieCommandEnabled && hasImageGen) {
-              addCommandLines(
-                `- [selfie] or [selfie: context="description of what the selfie shows"] - you send a photo of yourself. Use this when the user asks for a selfie, photo, or pic, or when you want to share what you look like right now.`,
-                `   If you say you are sending, sharing, taking, or attaching a selfie/photo/pic, include [selfie] in that same response. Do not only narrate the action.`,
-              );
-            }
-
-            // Memory command — only available when there are valid targets (characters in shared group chats)
-            if (memoryCommandEnabled && memoryTargetNames.length > 0) {
-              addCommandLines(
-                `- [memory: target="${memoryTargetNames.map((n) => `"${n}"`).join("|")}", summary="brief description of what happened"] - create a memory that another character will remember. Use this when something notable happens between you and another character that they would naturally remember (e.g., shared a meal, had an argument, made plans). Don't overuse this; only for genuinely memorable moments.`,
-                `   Example: [memory: target="${memoryTargetNames[0]}", summary="watched a movie together and argued about the ending"]`,
-              );
-            }
-
-            // Scene command — only in conversation mode
-            if (sceneCommandEnabled && chatMode === "conversation") {
-              addCommandLines(
-                `- [scene: scenario="brief description of what happens in this scene", background="place"] - initiate a mini-roleplay scene branching from this conversation. The system will plan and create a complete immersive scene for you.`,
-                `   Example: You agree to go stargazing → include [scene: scenario="lying on a blanket in the park, looking at the stars together", background="park"]`,
-                `   WHEN TO USE: You SHOULD proactively trigger a scene whenever the conversation naturally leads to an activity, outing, or situation that would be more immersive as a scene. Examples:`,
-                `   - {{user}} says "I'm coming over" or "Let's go to the park" → trigger a scene for arriving/being at that location.`,
-                `   - You invite {{user}} somewhere and they accept → trigger a scene for that activity.`,
-                `   - A plan is made (date, trip, hangout, confrontation) and the moment arrives → trigger a scene.`,
-                `   Do NOT wait for {{user}} to explicitly ask for a scene. If the conversation implies you and {{user}} are about to DO something together, initiate the scene yourself.`,
-                `   EXCEPTION: Do NOT start a scene for playing UNO, chess, cards, or other board/table games — those have their own commands. Use [uno] for UNO and [chess] for chess, not [scene].`,
-              );
-            }
-
-            if (callCommandEnabled && chatMode === "conversation") {
-              addCommandLines(
-                `- [call], [call: reason="brief reason"], or [call: reason="brief reason", greeting="first thing to say after ${personaName} answers"] - ring ${personaName} for an audio call. Use this only when a live call naturally fits, such as when you urgently want to talk, when typing is awkward, or when ${personaName} asks you to call. The system will show an incoming call request; do not assume it was answered unless the call starts. If you include greeting, it will play only after ${personaName} accepts.`,
-              );
-            }
-
-            // Turn-games — conversation mode only, when no game is running yet
-            // and at least one other character is present to play with.
-            const unoAdvertisable =
-              chatMode === "conversation" && isConversationCommandEnabled(chatMeta, "uno") && characterIds.length >= 1;
-            const chessAdvertisable =
-              chatMode === "conversation" &&
-              isConversationCommandEnabled(chatMeta, "chess") &&
-              characterIds.length >= 1;
-            // One lookup shared by both game commands (only when a game could be offered).
-            const noActiveTurnGame =
-              (unoAdvertisable || chessAdvertisable) && !(await getActiveTurnGame(app.db, input.chatId));
-            if (unoAdvertisable && noActiveTurnGame) {
-              addCommandLines(
-                `- [uno] - start a game of UNO at the table. Include this ONLY when ${personaName} proposes playing UNO (or cards) and you are willing to play right now. The system deals the cards and runs the game — you do NOT narrate dealing or describe the hands.`,
-                `   If you are busy, tired, or simply don't feel like it, just say so in character and do NOT include [uno]. Agreeing to play IS including [uno].`,
-                `   Example: ${personaName} says "anyone up for a round of uno?" and you're in → "Oh, you're SO on. [uno]"`,
-              );
-            }
-            if (chessAdvertisable && noActiveTurnGame) {
-              addCommandLines(
-                `- [chess] - start a one-on-one chess game against ${personaName}. Include this ONLY when ${personaName} proposes playing chess and YOU are willing to play right now. Chess seats exactly two players: ${personaName} and you — whichever character includes [chess] takes the opponent's seat. The system sets up the board and runs the game — you do NOT describe the board or narrate setup.`,
-                `   If you'd rather not play, say so in character and do NOT include [chess]. Agreeing to play IS including [chess].`,
-                `   Example: ${personaName} says "up for a game of chess?" and you're in → "Prepare to lose your queen. [chess]"`,
-              );
-            }
-
-            if (conversationSpotifyCommandsAvailable) {
-              addCommandLines(
-                `- [spotify: title="Song title", artist="Artist"] - only if you want to play a selected song on the user's active Spotify player. Use this sparingly, when the song choice genuinely fits the moment.`,
-              );
-            }
-
-            if (conversationYoutubeCommandsAvailable) {
-              addCommandLines(
-                `- [youtube: query="Song title Artist"] - only if you want to play a selected song on the user's active YouTube player. Use this sparingly, when the song choice genuinely fits the moment.`,
-              );
-            }
-
-            // Haptic command — only when devices are connected and haptic feedback is enabled
-            const hapticEnabled = chatMeta.enableHapticFeedback === true;
-            if (hapticCommandEnabled && hapticEnabled) {
-              const { hapticService } = await import("../services/haptic/buttplug-service.js");
-              // Auto-connect to Intiface Central if not already connected
-              if (!hapticService.connected) {
-                try {
-                  await hapticService.connect(getChatHapticIntifaceUrl(chatMeta));
-                } catch {
-                  logger.warn("[haptic] Auto-connect to Intiface Central failed — is the server running?");
-                }
-              }
-              if (hapticService.connected && hapticService.devices.length > 0) {
-                const deviceNames = hapticService.devices.map((d) => d.name).join(", ");
-                addCommandLines(
-                  `- [haptic: action="vibrate|oscillate|rotate|position|stop", intensity=0.0-1.0, duration=seconds (0 = loop until next command)] or [haptic: action="stop"] - control or stop the user's connected intimate device(s) (${deviceNames}). Use this during physical/intimate/sensual moments to provide haptic feedback that matches the narrative. Vary intensity based on the scene.`,
-                  `   You can include multiple [haptic] commands in one message for patterns (e.g., escalating: 0.2 → 0.5 → 0.8).`,
-                  `   Example: *trails a finger slowly down your arm* [haptic: action="vibrate", intensity=0.3, duration=2]`,
-                );
-              }
-            }
-
-            if (availableCommandCount > 0) {
-              commandLines.push(
-                `IMPORTANT: Commands are stripped from your message before the user sees it. The rest of your message is shown normally. You can include multiple commands in one message, but you do not need to use any of them unless it makes sense in context.`,
-                `</commands>`,
-              );
-
-              conversationCommandsReminder = resolvePromptMacros(commandLines.join("\n"));
-            }
-          }
+          conversationCommandsReminder = await buildConversationCommandsReminder({
+            enabled: conversationCommandsEnabled,
+            chatMode,
+            chatMeta,
+            characterIds,
+            personaName,
+            chatId: input.chatId,
+            musicPlayerEnabled: input.musicPlayerEnabled,
+            musicPlayerSource: input.musicPlayerSource,
+            chats,
+            chars,
+            agentsStore,
+            db: app.db,
+            resolvePromptMacros,
+          });
 
           // ── React capability ──
           // Tell the character it can react to the user's latest message. Standard
@@ -3774,145 +1763,26 @@ export async function generateRoutes(app: FastifyInstance) {
           }
           // ── Home Professor Mari: inject assistant knowledge & commands ──
           if (isHomeProfessorMariAssistantChat) {
-            conversationSystemPrompt += "\n\n" + MARI_ASSISTANT_PROMPT;
-
-            // Inject names-only lists so Mari knows what's available (not full data)
-            try {
-              const allChars = await chars.list();
-              const allPersonasList = await chars.listPersonas();
-              const allLorebooks = await lorebooksStore.list();
-              const allChats = await chats.list();
-              const allPresets = await presets.list();
-
-              const charNames = allChars
-                .filter((c: any) => c.id !== PROFESSOR_MARI_ID)
-                .map((c: any) => {
-                  const d = typeof c.data === "string" ? JSON.parse(c.data) : c.data;
-                  return d.name;
-                })
-                .filter(Boolean);
-
-              const personaNames = allPersonasList.map((p: any) => p.name).filter(Boolean);
-              const lorebookNames = allLorebooks.map((lb: any) => lb.name).filter(Boolean);
-              const chatNames = allChats
-                .slice(0, 50)
-                .map((c: any) => c.name)
-                .filter(Boolean);
-              const presetNames = (allPresets as any[]).map((preset: any) => preset.name).filter(Boolean);
-
-              const namesSections: string[] = [];
-              if (charNames.length > 0)
-                namesSections.push(`<available_names type="character">\n${charNames.join(", ")}\n</available_names>`);
-              if (personaNames.length > 0)
-                namesSections.push(`<available_names type="persona">\n${personaNames.join(", ")}\n</available_names>`);
-              if (lorebookNames.length > 0)
-                namesSections.push(
-                  `<available_names type="lorebook">\n${lorebookNames.join(", ")}\n</available_names>`,
-                );
-              if (chatNames.length > 0)
-                namesSections.push(`<available_names type="chat">\n${chatNames.join(", ")}\n</available_names>`);
-              if (presetNames.length > 0)
-                namesSections.push(`<available_names type="preset">\n${presetNames.join(", ")}\n</available_names>`);
-
-              if (namesSections.length > 0) {
-                conversationSystemPrompt += "\n\n" + namesSections.join("\n\n");
-              }
-            } catch {
-              // Non-critical — continue without name lists
-            }
-
-            // Inject previously fetched context from chatMeta.mariContext
-            const mariContext = chatMeta.mariContext as Record<string, string> | undefined;
-            if (mariContext && Object.keys(mariContext).length > 0) {
-              const contextSections: string[] = [];
-              for (const [key, value] of Object.entries(mariContext)) {
-                contextSections.push(`<fetched_data key="${key}">\n${value}\n</fetched_data>`);
-              }
-              conversationSystemPrompt +=
-                "\n\n<loaded_context>\nThe following items were previously fetched and are available for reference:\n\n" +
-                contextSections.join("\n\n") +
-                "\n</loaded_context>";
-            }
+            conversationSystemPrompt +=
+              "\n\n" + (await resolveProfessorMariPromptContext({ chatMeta, chars, lorebooksStore, chats, presets }));
           }
 
           // Build the context injection (last user-role message before generation)
-          const timeStr = formatZonedConversationTime(nowInstant, promptTimeZone);
-          const dateStr = formatZonedConversationDate(nowInstant, promptTimeZone);
-          const dayName = getZonedWeekdayName(nowInstant, promptTimeZone);
-
-          const scheduleLines: string[] = [];
-          for (const c of convoCharInfo) {
-            if (c.todaySchedule) {
-              const prefix =
-                convoCharInfo.length > 1
-                  ? `${c.name}'s schedule today (${dayName}): `
-                  : `Your schedule today (${dayName}): `;
-              scheduleLines.push(prefix + c.todaySchedule);
-            }
-          }
-
-          // Build status line for the context injection
-          const statusLabels: Record<string, string> = {
-            online: "online and active",
-            idle: "idle / away",
-            dnd: "busy / do not disturb",
-            offline: "offline",
-          };
-          const buildCharStatus = (c: { name: string; status: string; activity: string }) => {
-            const label = statusLabels[c.status] ?? "online and active";
-            return c.activity ? `${label} (${c.activity})` : label;
-          };
-          const statusLine =
-            convoCharInfo.length === 1
-              ? buildCharStatus(convoCharInfo[0]!)
-              : convoCharInfo.map((c) => `${c.name}: ${buildCharStatus(c)}`).join("; ");
-
-          // Build user status label
-          const userStatusLabels: Record<string, string> = {
-            active: "active",
-            idle: "idle / away from the computer",
-            dnd: "do not disturb",
-          };
-          const shouldIncludeUserStatus = input.userStatus !== "invisible";
-          const userStatusLabel = userStatusLabels[input.userStatus ?? "active"] ?? "active";
-          const userActivity = input.userActivity?.replace(/\s+/g, " ").trim().slice(0, 120) ?? "";
-          const userStatusLine = userActivity ? `${userStatusLabel} - ${userActivity}` : userStatusLabel;
-
-          // Build @mention line — tells the LLM which characters were directly pinged
-          const mentionedNames = (input.mentionedCharacterNames ?? []).filter((n: string) =>
-            convoCharInfo.some((c) => normalizeTextForMatch(c.name) === normalizeTextForMatch(n)),
-          );
-          let mentionLine: string | null = null;
-          if (mentionedNames.length > 0) {
-            if (convoCharInfo.length === 1) {
-              mentionLine = `${personaName} @mentioned you directly — treat this as an urgent ping that demands your attention even if you are busy or away.`;
-            } else {
-              mentionLine = `${personaName} @mentioned: ${mentionedNames.join(", ")} — this is an urgent ping directed at ${mentionedNames.length === 1 ? "that person" : "those people"} specifically. The mentioned character(s) should feel compelled to respond promptly even if busy or away.`;
-            }
-          }
-
-          const latestVisiblePromptTurn = [...finalMessages]
-            .reverse()
-            .find((message) => message.role === "user" || message.role === "assistant");
-          const proactiveTurnLine =
-            latestVisiblePromptTurn?.role === "assistant" && !input.userMessage?.trim()
-              ? `No new message from ${personaName} was sent in this request; this is a proactive/autonomous turn. Do not write ${personaName}'s side of the conversation.`
-              : null;
-          const intentHint = isMessageIntent(input.autonomousIntentKey) ? getIntentHint(input.autonomousIntentKey) : "";
-
-          const contextLines = [
-            `Your current status: ${statusLine}.`,
-            ...(shouldIncludeUserStatus ? [`${personaName}'s status: ${userStatusLine}.`] : []),
-            ...(proactiveTurnLine ? [proactiveTurnLine] : []),
-            ...(mentionLine ? [mentionLine] : []),
-            ...(intentHint ? [`What prompted this message: ${intentHint}`] : []),
-            ...scheduleLines,
-            `The current time and date: ${timeStr}, ${dateStr}.`,
-            ...(isGroup && earlyGroupMode !== "individual"
-              ? [`- Remember to prefix messages with \`Name: message\`!`]
-              : []),
-          ];
-          const contextBlock = wrapContent(contextLines.join("\n"), "Context", wrapFormat);
+          const contextBlock = buildConversationCurrentContextBlock({
+            nowInstant,
+            promptTimeZone,
+            convoCharInfo,
+            finalMessages,
+            personaName,
+            userMessage: input.userMessage,
+            userStatus: input.userStatus,
+            userActivity: input.userActivity,
+            mentionedCharacterNames: input.mentionedCharacterNames,
+            autonomousIntentKey: input.autonomousIntentKey,
+            isGroup,
+            earlyGroupMode,
+            wrapFormat,
+          });
 
           // ── Cross-chat awareness: show messages from other chats this character is in ──
           // (awarenessBlock is injected later, after persona info)
@@ -3935,204 +1805,22 @@ export async function generateRoutes(app: FastifyInstance) {
             );
           }
 
-          // ── Connected chat context: inject linked roleplay/game details ──
-          let connectedChatBlock: string | null = null;
-          const connectedInfluenceCommandEnabled =
-            conversationCommandsEnabled && isConversationCommandEnabled(chatMeta, "influence");
-          const connectedNoteCommandEnabled =
-            conversationCommandsEnabled && isConversationCommandEnabled(chatMeta, "note");
-          if (chat.connectedChatId) {
-            const connectedChat = await chats.getById(chat.connectedChatId as string);
-            if (connectedChat && connectedChat.mode === "roleplay") {
-              const rpMessages = await chats.listMessages(connectedChat.id);
-              const recentRp = rpMessages.slice(-20);
-
-              // Resolve character names for the RP
-              const rpCharIds: string[] =
-                typeof connectedChat.characterIds === "string"
-                  ? JSON.parse(connectedChat.characterIds as string)
-                  : (connectedChat.characterIds as string[]);
-              const rpCharNames = new Map<string, string>();
-              for (const cid of rpCharIds) {
-                const row = await chars.getById(cid);
-                if (row) {
-                  const d = JSON.parse(row.data as string);
-                  rpCharNames.set(cid, d.name ?? "Unknown");
-                }
-              }
-
-              const rpLines: string[] = [`<connected_roleplay name="${connectedChat.name}">`];
-              rpLines.push(`<recent_messages>`);
-              for (const m of recentRp) {
-                const speaker =
-                  m.role === "user"
-                    ? personaName
-                    : m.characterId
-                      ? (rpCharNames.get(m.characterId) ?? "Character")
-                      : "Narrator";
-                rpLines.push(`[${speaker}]: ${(m.content as string).slice(0, 500)}`);
-              }
-              rpLines.push(`</recent_messages>`);
-              rpLines.push(`</connected_roleplay>`);
-
-              connectedChatBlock = rpLines.join("\n");
-
-              if (connectedInfluenceCommandEnabled || connectedNoteCommandEnabled) {
-                const connectedInstructionLines = [
-                  `<connected_roleplay_instructions>`,
-                  `You have access to context from a connected roleplay: "${connectedChat.name}".`,
-                  `Recent messages from that roleplay are provided so you can naturally reference or discuss events happening there.`,
-                ];
-                if (connectedInfluenceCommandEnabled) {
-                  connectedInstructionLines.push(
-                    ``,
-                    `If something said in THIS conversation should affect or influence the roleplay, you can create an influence tag:`,
-                    `<influence>description of what should happen or change in the roleplay based on this conversation</influence>`,
-                    `Example: if the user says "tell ${rpCharNames.values().next().value ?? "them"} to meet us at the tavern", you could respond normally AND include:`,
-                    `<influence>The group discussed meeting at the tavern. ${personaName} wants everyone to head there.</influence>`,
-                    ``,
-                    `Influences are injected into the roleplay's context before the next generation. Use them sparingly; only when conversation content genuinely should cross over into the roleplay.`,
-                    `The influence tag is stripped from your visible message. The rest of your response is shown normally.`,
-                  );
-                }
-                if (connectedNoteCommandEnabled) {
-                  connectedInstructionLines.push(
-                    ``,
-                    `If something said in this conversation should durably persist in the roleplay's context across many turns (a fact the character should keep remembering, a promise made, a secret revealed, a name learned), create a note tag instead of an influence:`,
-                    `<note>fact, decision, or detail the roleplay character should keep remembering</note>`,
-                    `Notes are shown to the roleplay character on every future turn until the user clears them. Use influences for one-shot mid-scene steering; use notes for things that should remain true going forward. Use notes sparingly; every saved note costs prompt budget on every roleplay turn.`,
-                    `The note tag is stripped from your visible message.`,
-                  );
-                }
-                connectedInstructionLines.push(`</connected_roleplay_instructions>`);
-                conversationSystemPrompt += "\n\n" + connectedInstructionLines.join("\n");
-              }
-            } else if (connectedChat && connectedChat.mode === "game") {
-              const gameMeta =
-                typeof connectedChat.metadata === "string"
-                  ? JSON.parse(connectedChat.metadata)
-                  : (connectedChat.metadata ?? {});
-              const sessionNumber = (gameMeta.gameSessionNumber as number) ?? 1;
-              const sessionStatus = (gameMeta.gameSessionStatus as string) ?? "setup";
-              const activeState = (gameMeta.gameActiveState as string) ?? "exploration";
-              const storedSummaries = Array.isArray(gameMeta.gamePreviousSessionSummaries)
-                ? (gameMeta.gamePreviousSessionSummaries as Array<{
-                    summary?: string;
-                    resumePoint?: string;
-                    partyDynamics?: string;
-                    keyDiscoveries?: string[];
-                  }>)
-                : [];
-              const latestSummary = storedSummaries[storedSummaries.length - 1] ?? null;
-              const gameMessages = await chats.listMessages(connectedChat.id);
-              const recentGame = gameMessages.slice(-20);
-              const latestConnectedState =
-                (await gameStateStore.getLatestCommitted(connectedChat.id)) ??
-                (await gameStateStore.getLatest(connectedChat.id));
-              const linkedGameState = latestConnectedState
-                ? parseGameStateRow(latestConnectedState as Record<string, unknown>)
-                : null;
-
-              const gameLines: string[] = [`<connected_game name="${connectedChat.name}">`];
-              gameLines.push(`<status>Session ${sessionNumber} (${sessionStatus}), state: ${activeState}</status>`);
-              if (linkedGameState) {
-                const sceneDetails = [
-                  linkedGameState.location ? `Location: ${linkedGameState.location}` : null,
-                  linkedGameState.time ? `Time: ${linkedGameState.time}` : null,
-                  linkedGameState.date ? `Date: ${linkedGameState.date}` : null,
-                  linkedGameState.weather ? `Weather: ${linkedGameState.weather}` : null,
-                  linkedGameState.temperature ? `Temperature: ${linkedGameState.temperature}` : null,
-                ].filter(Boolean);
-                if (sceneDetails.length > 0) {
-                  gameLines.push(`<scene>${sceneDetails.join(" | ")}</scene>`);
-                }
-                if (linkedGameState.presentCharacters.length > 0) {
-                  gameLines.push(
-                    `<present_characters>${linkedGameState.presentCharacters.map((c) => c.name).join(", ")}</present_characters>`,
-                  );
-                }
-                if (linkedGameState.recentEvents.length > 0) {
-                  gameLines.push(`<recent_events>`);
-                  for (const event of linkedGameState.recentEvents.slice(-5)) {
-                    gameLines.push(`- ${event.slice(0, 300)}`);
-                  }
-                  gameLines.push(`</recent_events>`);
-                }
-              }
-              if (latestSummary?.summary) {
-                gameLines.push(`<latest_session_summary>${latestSummary.summary}</latest_session_summary>`);
-                if (latestSummary.resumePoint) {
-                  gameLines.push(`<resume_point>${latestSummary.resumePoint}</resume_point>`);
-                }
-                if (latestSummary.partyDynamics) {
-                  gameLines.push(`<party_dynamics>${latestSummary.partyDynamics}</party_dynamics>`);
-                }
-                if (Array.isArray(latestSummary.keyDiscoveries) && latestSummary.keyDiscoveries.length > 0) {
-                  gameLines.push(`<key_discoveries>${latestSummary.keyDiscoveries.join("; ")}</key_discoveries>`);
-                }
-              }
-              gameLines.push(`<recent_messages>`);
-              for (const m of recentGame) {
-                const speaker = m.role === "user" ? personaName : m.role === "narrator" ? "Narrator" : "Game Master";
-                const content = sanitizeConnectedGameTranscript(m.content as string);
-                if (!content) continue;
-                gameLines.push(`[${speaker}]: ${content.slice(0, 500)}`);
-              }
-              gameLines.push(`</recent_messages>`);
-              gameLines.push(`</connected_game>`);
-
-              connectedChatBlock = gameLines.join("\n");
-
-              if (connectedInfluenceCommandEnabled || connectedNoteCommandEnabled) {
-                const connectedInstructionLines = [
-                  `<connected_game_instructions>`,
-                  `You have access to context from a connected game: "${connectedChat.name}".`,
-                  `The current scene, session summary, and recent game messages are provided so you can naturally answer questions or comment on what is happening in that game.`,
-                ];
-                if (connectedInfluenceCommandEnabled) {
-                  connectedInstructionLines.push(
-                    ``,
-                    `If something said in THIS conversation should affect or influence the game, you can create an influence tag:`,
-                    `<influence>description of what should happen or change in the game based on this conversation</influence>`,
-                    `Example: if the group agrees they want to visit the merchant district next, you could respond normally AND include:`,
-                    `<influence>The group agreed they want to head to the merchant district next and look for supplies.</influence>`,
-                    ``,
-                    `Influences are injected into the game's context before the next generation. Use them sparingly; only when conversation content genuinely should cross over into the game.`,
-                    `The influence tag is stripped from your visible message. The rest of your response is shown normally.`,
-                  );
-                }
-                if (connectedNoteCommandEnabled) {
-                  connectedInstructionLines.push(
-                    ``,
-                    `If something said in this conversation should durably persist in the game's context across many turns (an established world fact, an ongoing party dynamic, a recurring NPC trait, a secret the GM should keep remembering), create a note tag instead of an influence:`,
-                    `<note>fact, decision, or detail the game should keep remembering</note>`,
-                    `Notes are shown to the game on every future turn until the user clears them. Use influences for one-shot mid-scene steering; use notes for things that should remain true going forward. Use notes sparingly; every saved note costs prompt budget on every game turn.`,
-                    `The note tag is stripped from your visible message.`,
-                  );
-                }
-                connectedInstructionLines.push(`</connected_game_instructions>`);
-                conversationSystemPrompt += "\n\n" + connectedInstructionLines.join("\n");
-              }
-            }
+          const { connectedChatBlock, systemPromptAppend: connectedChatSystemPrompt } =
+            await resolveConversationConnectedChatContext({
+              connectedChatId: chat.connectedChatId,
+              conversationCommandsEnabled,
+              chatMeta,
+              personaName,
+              chats,
+              chars,
+              gameStateStore,
+            });
+          if (connectedChatSystemPrompt) {
+            conversationSystemPrompt += "\n\n" + connectedChatSystemPrompt;
           }
 
-          // Inject key details from past-day summaries as persistent memory
-          if (allKeyDetails.length > 0) {
-            // Sort chronologically so the model sees the most recent details last
-            allKeyDetails.sort((a, b) => {
-              // Parse the first date-like token from each label for ordering
-              const extractDate = (s: string) => {
-                const m = s.match(/(\d{2}\.\d{2}\.\d{4})/);
-                return m ? parseDateKey(m[1]!).getTime() : 0;
-              };
-              return extractDate(a.label) - extractDate(b.label);
-            });
-            const memoryLines = [`Things you must remember from past conversations:`];
-            for (const { label, details } of allKeyDetails) {
-              memoryLines.push(`[${label}]`);
-              for (const d of details) memoryLines.push(`- ${d}`);
-            }
-            conversationSystemPrompt += "\n\n" + wrapContent(memoryLines.join("\n"), "Important Memories", wrapFormat);
+          if (preparedHistory.importantMemoryBlock) {
+            conversationSystemPrompt += "\n\n" + preparedHistory.importantMemoryBlock;
           }
 
           conversationSystemPrompt = resolvePromptMacros(conversationSystemPrompt);
@@ -4275,254 +1963,73 @@ export async function generateRoutes(app: FastifyInstance) {
           ]);
         }
 
-        // ── Roleplay/Game: inject pending OOC influences from connected conversation ──
         // Skip OOC injection entirely for scene chats — scenes are self-contained
         const isSceneChat = chatMeta.sceneStatus === "active";
-        if ((chatMode === "roleplay" || chatMode === "game") && chat.connectedChatId && !isSceneChat) {
-          const pendingInfluences = await chats.listPendingInfluences(input.chatId);
-          if (pendingInfluences.length > 0) {
-            const influenceLines = pendingInfluences
-              .map((inf: any) => stripConversationPromptTimestamps(String(inf.content ?? "")))
-              .filter((content: string) => content.length > 0)
-              .map((content: string) => `- ${content}`);
+        await injectConnectedConversationPromptBlocks({
+          chatMode,
+          connectedChatId: chat.connectedChatId,
+          isSceneChat,
+          chatId: input.chatId,
+          chats,
+          finalMessages,
+        });
 
-            if (influenceLines.length > 0) {
-              const influenceBlock = [
-                `<ooc_influences>`,
-                chatMode === "game"
-                  ? `The following out-of-character notes come from a connected conversation. They represent things the players discussed or decided outside the game. Use them to steer the next scene, NPC reactions, objectives, or world state when appropriate — don't mention them explicitly as "OOC" in the narrative.`
-                  : `The following out-of-character notes come from a connected conversation. They represent things the players discussed or decided outside of the roleplay. Weave them naturally into the story — don't mention them explicitly as "OOC" in the narrative.`,
-                ...influenceLines,
-                `</ooc_influences>`,
-              ].join("\n");
-
-              // Inject before the last user message
-              const lastUserIdx = finalMessages.map((m) => m.role).lastIndexOf("user");
-              if (lastUserIdx >= 0) {
-                finalMessages.splice(lastUserIdx, 0, { role: "system" as const, content: influenceBlock });
-              } else {
-                finalMessages.push({ role: "system" as const, content: influenceBlock });
-              }
-            }
-
-            // Mark influences as consumed
-            for (const inf of pendingInfluences) {
-              await chats.markInfluenceConsumed(inf.id);
-            }
-          }
-        }
-
-        // ── Roleplay/Game: inject durable conversation notes (persist until cleared) ──
-        // Same scene bypass as influences — scenes are self-contained.
-        if ((chatMode === "roleplay" || chatMode === "game") && chat.connectedChatId && !isSceneChat) {
-          const persistentNotes = await chats.listNotes(input.chatId);
-          if (persistentNotes.length > 0) {
-            const noteLines = persistentNotes
-              .map((n: any) => stripConversationPromptTimestamps(String(n.content ?? "")))
-              .filter((content: string) => content.length > 0)
-              .map((content: string) => `- ${content}`);
-
-            if (noteLines.length > 0) {
-              const noteBlock = [
-                `<conversation_notes>`,
-                chatMode === "game"
-                  ? `Durable notes from a connected conversation. These persist across every turn until the user clears them and represent things the players have established as ongoing truth — character knowledge, world facts, recurring dynamics. Use them to inform NPC behavior, world state, and scene framing — don't reference them explicitly as "notes" in the narrative.`
-                  : `Durable notes from a connected conversation. These persist across every turn until the user clears them and represent things the character has been told to durably remember about themselves, the user, or the world. Use them to inform behavior, knowledge, and reactions naturally — don't reference them explicitly as "notes" in the narrative.`,
-                ...noteLines,
-                `</conversation_notes>`,
-              ].join("\n");
-
-              // Inject before the last user message (parallel to the influence block)
-              const lastUserIdx = finalMessages.map((m) => m.role).lastIndexOf("user");
-              if (lastUserIdx >= 0) {
-                finalMessages.splice(lastUserIdx, 0, { role: "system" as const, content: noteBlock });
-              } else {
-                finalMessages.push({ role: "system" as const, content: noteBlock });
-              }
-            }
-          }
-        }
-
-        if (chatMode === "roleplay" && chat.connectedChatId && !isSceneChat) {
-          // Add <ooc> instruction: characters can post comments to the connected conversation
-          const convChat = await chats.getById(chat.connectedChatId as string);
-          if (convChat && convChat.mode === "conversation") {
-            const oocInstruction = [
-              `<ooc_instruction>`,
-              `You have a connected out-of-character conversation: "${convChat.name}".`,
-              `If a character wants to break the fourth wall and comment on something happening in the roleplay, post a reaction, or chat casually with the user "outside" the story, they can use an <ooc> tag:`,
-              `<ooc>casual comment or reaction about what just happened in the RP</ooc>`,
-              ``,
-              `The <ooc> text is stripped from the roleplay response and posted as a message in the conversation chat.`,
-              `Use this very sparingly — only when a character would genuinely want to comment out-of-character. Most RP responses should NOT include <ooc> tags.`,
-              `</ooc_instruction>`,
-            ].join("\n");
-
-            // Inject early in the messages (after the first system message)
-            const firstSysIdx = finalMessages.findIndex((m) => m.role === "system");
-            if (firstSysIdx >= 0) {
-              finalMessages.splice(firstSysIdx + 1, 0, { role: "system" as const, content: oocInstruction });
-            } else {
-              finalMessages.unshift({ role: "system" as const, content: oocInstruction });
-            }
-          }
-        }
-
-        // ── Connection defaults + per-chat overrides (Chat Settings → Advanced Parameters) ──
-        const connectionParams = parseStoredGenerationParameters(conn.defaultParameters);
-        const chatParams = parseStoredGenerationParameters(chatMeta.chatParameters);
-
-        const applyParameterOverrides = (params: typeof connectionParams) => {
-          if (!params) return;
-          if (typeof params.temperature === "number") temperature = params.temperature;
-          if (typeof params.maxTokens === "number") maxTokens = params.maxTokens;
-          topP = normalizeChatTopP(params.topP) ?? topP;
-          if (typeof params.topK === "number") topK = params.topK;
-          if (typeof params.minP === "number") minP = params.minP;
-          if (typeof params.frequencyPenalty === "number") frequencyPenalty = params.frequencyPenalty;
-          if (typeof params.presencePenalty === "number") presencePenalty = params.presencePenalty;
-          if (typeof params.showThoughts === "boolean") showThoughts = params.showThoughts;
-          if (params.reasoningEffort !== undefined) reasoningEffort = params.reasoningEffort;
-          if (params.verbosity !== undefined) verbosity = params.verbosity;
-          if (params.serviceTier !== undefined) serviceTier = normalizeServiceTier(params.serviceTier);
-          if (typeof params.assistantPrefill === "string") assistantPrefill = params.assistantPrefill;
-          if (params.customThinkingTags !== undefined) {
-            customThinkingTags = normalizeThinkingTagPairs(params.customThinkingTags);
-          }
-          customParameters = mergeCustomParameters(customParameters, params.customParameters);
-          if (params.enabledParameters)
-            enabledParameters = { ...(enabledParameters ?? {}), ...params.enabledParameters };
-          if (Array.isArray(params.stopSequences)) {
-            stopSequences = params.stopSequences.map((value) => value.trim()).filter((value) => value.length > 0);
-          }
-
-          effectiveMaxContext = mergeModelContextLimit(
-            modelAccessPolicy,
+        const providerRuntime = resolveGenerationProviderRuntime({
+          connectionId: connId ?? "",
+          connection: conn,
+          baseUrl,
+          chatMode,
+          isSceneChat,
+          chatParameters: chatMeta.chatParameters,
+          modelAccessPolicy,
+          initial: {
+            temperature,
+            maxTokens,
+            topP,
+            topK,
+            minP,
+            frequencyPenalty,
+            presencePenalty,
+            showThoughts,
+            reasoningEffort,
+            verbosity,
+            serviceTier,
+            assistantPrefill,
+            customThinkingTags,
+            customParameters,
+            enabledParameters,
+            stopSequences,
             effectiveMaxContext,
-            resolveStoredModelContextLimit(modelAccessPolicy, params),
-          );
-        };
-
-        // Scene chats use roleplay-friendly defaults before applying user overrides
-        if (isSceneChat) {
-          maxTokens = 8192;
-          reasoningEffort = "maximum";
-          verbosity = "high";
-        }
-
-        const isLocalGemma = (conn.model ?? "").toLowerCase().includes("gemma");
-        // Connection defaults are the user's selected defaults for this model.
-        // Apply them after preset assembly so Roleplay presets don't mask saved
-        // output length/reasoning defaults, then let per-chat overrides win below.
-        applyParameterOverrides(connectionParams);
-        applyParameterOverrides(chatParams);
-
-        // Game mode: force optimal generation defaults after Advanced Parameters
-        // so leftover chat/connection overrides cannot sabotage structured GM output.
-        if (chatMode === "game" && !isLocalGemma) {
-          temperature = 1;
-          maxTokens = 16_384;
-          topP = 1;
-          topK = 0;
-          minP = 0;
-          frequencyPenalty = 0;
-          presencePenalty = 0;
-          reasoningEffort = "maximum";
-          verbosity = null;
-        } else if (chatMode === "game") {
-          // Local Gemma: just ensure generous output unless the chat set its own budget.
-          if (typeof chatParams?.maxTokens !== "number") {
-            maxTokens = Math.max(maxTokens, 16_384);
-          }
-        }
-
-        if (chatMode === "game") {
-          maxTokens = clampGenerationMaxOutputTokens({
-            provider: conn.provider,
-            model: conn.model,
-            maxTokens: Math.max(maxTokens, 16_384),
-            maxTokensOverride: conn.maxTokensOverride,
-          });
-        }
-
-        const modelLower = (conn.model ?? "").toLowerCase();
-        const providerLower = (conn.provider ?? "").toLowerCase();
-
-        // Resolve "xhigh" and "maximum" reasoning effort to provider-facing levels.
-        // Native Anthropic/Claude subscription adaptive-only models use "max";
-        // OpenAI-compatible Claude routes keep "xhigh". All other models get "high".
-        let resolvedEffort: "low" | "medium" | "high" | "xhigh" | "max" | null =
-          reasoningEffort !== "maximum" ? reasoningEffort : null;
-        const supportsXhigh = supportsXhighReasoningEffort(modelLower);
-        if (reasoningEffort === "xhigh" && !supportsXhigh) {
-          resolvedEffort = "high";
-        }
-        if (reasoningEffort === "maximum") {
-          const isNativeAnthropicAdaptiveOnly =
-            (providerLower === "anthropic" || providerLower === "claude_subscription") &&
-            isClaudeAdaptiveOnlyNoSamplingModel(modelLower);
-          resolvedEffort = isNativeAnthropicAdaptiveOnly ? "max" : supportsXhigh ? "xhigh" : "high";
-        }
-
-        const isXaiAutoReasoningModel =
-          (providerLower === "xai" && (modelLower.startsWith("grok-4.3") || modelLower.startsWith("grok-4-1-fast"))) ||
-          (providerLower === "openrouter" && modelLower.startsWith("x-ai/grok-"));
-        if (isXaiAutoReasoningModel) {
-          resolvedEffort = null;
-        }
-
-        // When reasoning effort is set, enable thinking so thoughts are captured/displayed
-        if (resolvedEffort && !showThoughts) {
-          showThoughts = true;
-        }
-
-        // enableThinking tells providers to activate reasoning mode (e.g. Anthropic
-        // extended thinking, Gemini thinkingConfig). Only true when the user has
-        // explicitly requested reasoning via reasoningEffort — showThoughts alone
-        // just controls whether thinking tokens are *displayed*, not whether
-        // reasoning mode is activated.
-        const enableThinking = !!resolvedEffort;
-
-        // ── Claude 4.5+ sampling parameter restrictions ──
-        const modelLc = (conn.model ?? "").toLowerCase();
-
-        // Claude adaptive-only models: ALL sampling params removed (temperature, top_p, top_k
-        // return 400). Strip everything regardless of provider (covers reverse proxies).
-        const isClaudeNoSampling = isClaudeAdaptiveOnlyNoSamplingModel(modelLc);
-        if (isClaudeNoSampling) {
-          temperature = undefined;
-          topP = undefined;
-          topK = 0;
-          frequencyPenalty = 0;
-          presencePenalty = 0;
-        }
-
-        // Claude 4.5/4.6: only temperature is supported — strip other sampling params.
-        const isClaudeTemperatureOnly =
-          !isClaudeNoSampling &&
-          (/claude-(opus|sonnet)-4-[56]/.test(modelLc) || /claude-(opus|sonnet)-4\.[56]/.test(modelLc));
-        if (isClaudeTemperatureOnly) {
-          topP = undefined;
-          topK = 0;
-          frequencyPenalty = 0;
-          presencePenalty = 0;
-        }
-        const providerTopK = resolveProviderTopK(conn.provider, topK);
-
-        // Create provider
-        const provider =
-          connId === LOCAL_SIDECAR_CONNECTION_ID
-            ? getLocalSidecarProvider()
-            : createLLMProvider(
-                conn.provider,
-                baseUrl,
-                conn.apiKey,
-                conn.maxContext,
-                conn.openrouterProvider,
-                conn.maxTokensOverride,
-                conn.claudeFastMode === "true",
-                conn.treatAsLocalEndpoint === "true",
-              );
+          },
+        });
+        const {
+          connectionParams,
+          chatParams,
+          resolvedEffort,
+          enableThinking,
+          isClaudeNoSampling,
+          providerTopK,
+          provider,
+        } = providerRuntime;
+        ({
+          temperature,
+          maxTokens,
+          topP,
+          topK,
+          minP,
+          frequencyPenalty,
+          presencePenalty,
+          showThoughts,
+          reasoningEffort,
+          verbosity,
+          serviceTier,
+          assistantPrefill,
+          customThinkingTags,
+          customParameters,
+          enabledParameters,
+          stopSequences,
+          effectiveMaxContext,
+        } = providerRuntime);
 
         const chatConnectionMaxParallelJobs = Number(conn.maxParallelJobs) || 1;
         const chatConnectionKnownModel = findKnownModel(conn.provider as APIProvider, conn.model.trim());
@@ -4609,204 +2116,22 @@ export async function generateRoutes(app: FastifyInstance) {
         }
         const characterMacroProfilesById = buildCharacterMacroProfilesById(charInfo);
 
-        // ── Custom emoji/sticker assets: advertise available tokens to Conversation responders ──
-        if (chatMode === "conversation") {
-          const mentionedNames = new Set(
-            (input.mentionedCharacterNames ?? [])
-              .map((name: string) => normalizeTextForMatch(name))
-              .filter((name: string) => name.length > 0),
-          );
-          const scopedResponders = promptTargetCharacterId
-            ? charInfo.filter((character) => character.id === promptTargetCharacterId)
-            : mentionedNames.size > 0
-              ? charInfo.filter((character) => mentionedNames.has(normalizeTextForMatch(character.name)))
-              : charInfo;
-          const respondingConversationChars = (scopedResponders.length > 0 ? scopedResponders : charInfo).map(
-            (character) => ({
-              charId: character.id,
-              name: character.name,
-            }),
-          );
-
-          const [globalEmojiRows, globalStickerRows, personaAssetRows] = await Promise.all([
-            customEmojisStore.list(),
-            customStickersStore.list(),
-            personaId ? personaGallery.listByPersonaId(personaId) : Promise.resolve([]),
-          ]);
-          for (const emoji of globalEmojiRows) {
-            if (emoji.name && emoji.filePath) {
-              conversationCustomEmojiUrlByName.set(
-                buildConversationCustomEmojiKey("global", null, String(emoji.name)),
-                buildGlobalCustomEmojiUrl(String(emoji.filePath)),
-              );
-            }
-          }
-          if (personaId) {
-            for (const img of personaAssetRows) {
-              if (img.customKind === "emoji" && img.customName && img.filePath) {
-                conversationCustomEmojiUrlByName.set(
-                  buildConversationCustomEmojiKey("persona", personaId, img.customName),
-                  buildPersonaGalleryEmojiUrl(personaId, getStoredFilename(String(img.filePath))),
-                );
-              }
-            }
-          }
-          const personaEmojiNames = uniqueEmojiNames(
-            personaAssetRows
-              .filter((img) => img.customKind === "emoji" && img.customName)
-              .map((img) => img.customName as string),
-          );
-          const personaStickerNames = uniqueEmojiNames(
-            personaAssetRows
-              .filter((img) => img.customKind === "sticker" && img.customName)
-              .map((img) => img.customName as string),
-          );
-          const sharedEmojiNames = uniqueEmojiNames([
-            ...personaEmojiNames,
-            ...globalEmojiRows.map((emoji) => emoji.name as string),
-          ]);
-          const sharedStickerNames = uniqueEmojiNames([
-            ...personaStickerNames,
-            ...globalStickerRows.map((sticker) => sticker.name as string),
-          ]);
-          const ownEmojisByChar = new Map<string, string[]>();
-          const ownStickersByChar = new Map<string, string[]>();
-          for (const info of respondingConversationChars) {
-            const images = await characterGallery.listByCharacterId(info.charId);
-            const emojiNames = uniqueEmojiNames(
-              images
-                .filter((img) => img.customKind === "emoji" && img.customName)
-                .map((img) => img.customName as string),
-            );
-            for (const img of images) {
-              if (img.customKind === "emoji" && img.customName && img.filePath) {
-                conversationCustomEmojiUrlByName.set(
-                  img.customName,
-                  buildCharacterGalleryEmojiUrl(info.charId, getStoredFilename(String(img.filePath))),
-                );
-              }
-            }
-            const stickerNames = uniqueEmojiNames(
-              images
-                .filter((img) => img.customKind === "sticker" && img.customName)
-                .map((img) => img.customName as string),
-            );
-            if (emojiNames.length > 0) ownEmojisByChar.set(info.charId, emojiNames);
-            if (stickerNames.length > 0) ownStickersByChar.set(info.charId, stickerNames);
-          }
-
-          const assetQuery = latestHistoryUserContent(finalMessages) || currentUserInputContent() || "";
-
-          if (sharedEmojiNames.length > 0 || ownEmojisByChar.size > 0) {
-            const emojiPrefs = normalizeCustomEmojiSelection(chatMeta.customEmojiSelection);
-            let emojiAdvertisement: string | null = null;
-            let toolSelectionHandled = false;
-
-            // Tool-call mode (single responder only): one model call picks from the full candidate set.
-            if (
-              emojiPrefs.mode === "tool-call" &&
-              emojiPrefs.toolConnectionId &&
-              respondingConversationChars.length === 1
-            ) {
-              const responder = respondingConversationChars[0]!;
-              const candidates = uniqueEmojiNames([
-                ...(ownEmojisByChar.get(responder.charId) ?? []),
-                ...sharedEmojiNames,
-              ]);
-              const picked = await selectCustomAssetNamesByToolCall(
-                "emoji",
-                ":name:",
-                candidates,
-                assetQuery,
-                emojiPrefs.toolConnectionId,
-                connections,
-                emojiPrefs.maxCount,
-              );
-              if (picked !== null) {
-                toolSelectionHandled = true;
-                if (picked.length > 0) {
-                  emojiAdvertisement = buildCustomEmojiAdvertisement(
-                    respondingConversationChars,
-                    [],
-                    new Map([[responder.charId, picked]]),
-                    emojiPrefs.maxCount,
-                  );
-                }
-              }
-            }
-
-            // Random/semantic — and the fallback when tool-call is unset, multi-responder, or failed.
-            if (!toolSelectionHandled && !emojiAdvertisement) {
-              const orderedShared = await orderEmojiNames(sharedEmojiNames, emojiPrefs, assetQuery);
-              const orderedOwnByChar = new Map<string, string[]>();
-              for (const [charId, names] of ownEmojisByChar) {
-                orderedOwnByChar.set(charId, await orderEmojiNames(names, emojiPrefs, assetQuery));
-              }
-              emojiAdvertisement = buildCustomEmojiAdvertisement(
-                respondingConversationChars,
-                orderedShared,
-                orderedOwnByChar,
-                emojiPrefs.maxCount,
-              );
-            }
-
-            if (emojiAdvertisement) appendToFirstSystemMessage(finalMessages, emojiAdvertisement);
-          }
-
-          if (sharedStickerNames.length > 0 || ownStickersByChar.size > 0) {
-            const stickerPrefs = normalizeCustomEmojiSelection(chatMeta.customEmojiSelection);
-            let stickerAdvertisement: string | null = null;
-            let toolSelectionHandled = false;
-
-            if (
-              stickerPrefs.mode === "tool-call" &&
-              stickerPrefs.toolConnectionId &&
-              respondingConversationChars.length === 1
-            ) {
-              const responder = respondingConversationChars[0]!;
-              const candidates = uniqueEmojiNames([
-                ...(ownStickersByChar.get(responder.charId) ?? []),
-                ...sharedStickerNames,
-              ]);
-              const picked = await selectCustomAssetNamesByToolCall(
-                "sticker",
-                "sticker:name:",
-                candidates,
-                assetQuery,
-                stickerPrefs.toolConnectionId,
-                connections,
-                stickerPrefs.maxCount,
-              );
-              if (picked !== null) {
-                toolSelectionHandled = true;
-                if (picked.length > 0) {
-                  stickerAdvertisement = buildCustomStickerAdvertisement(
-                    respondingConversationChars,
-                    [],
-                    new Map([[responder.charId, picked]]),
-                    stickerPrefs.maxCount,
-                  );
-                }
-              }
-            }
-
-            if (!toolSelectionHandled && !stickerAdvertisement) {
-              const orderedShared = await orderEmojiNames(sharedStickerNames, stickerPrefs, assetQuery);
-              const orderedOwnByChar = new Map<string, string[]>();
-              for (const [charId, names] of ownStickersByChar) {
-                orderedOwnByChar.set(charId, await orderEmojiNames(names, stickerPrefs, assetQuery));
-              }
-              stickerAdvertisement = buildCustomStickerAdvertisement(
-                respondingConversationChars,
-                orderedShared,
-                orderedOwnByChar,
-                stickerPrefs.maxCount,
-              );
-            }
-
-            if (stickerAdvertisement) appendToFirstSystemMessage(finalMessages, stickerAdvertisement);
-          }
-        }
+        await appendConversationCustomAssetAdvertisements({
+          chatMode,
+          mentionedCharacterNames: input.mentionedCharacterNames,
+          promptTargetCharacterId,
+          charInfo,
+          personaId,
+          chatMeta,
+          finalMessages,
+          currentUserInputContent,
+          customEmojisStore,
+          customStickersStore,
+          personaGallery,
+          characterGallery,
+          connections,
+          conversationCustomEmojiUrlByName,
+        });
 
         let resolvedGameDiscordSpeakerName: string | null = null;
         let gameDiscordSpeakerResolved = false;
@@ -10028,21 +7353,7 @@ export async function generateRoutes(app: FastifyInstance) {
         // Character Command Execution (Conversation mode)
         // ────────────────────────────────────────
         if (collectedCommands.length > 0 && !abortController.signal.aborted) {
-          const professorMariCommandTypes = new Set([
-            "create_persona",
-            "create_character",
-            "update_character",
-            "update_persona",
-            "create_lorebook",
-            "update_lorebook",
-            "create_preset",
-            "create_chat",
-            "navigate",
-            "fetch",
-          ]);
-          const professorMariCommandCount = collectedCommands.filter(({ command }) =>
-            professorMariCommandTypes.has(command.type),
-          ).length;
+          const professorMariCommandCount = countProfessorMariCommands(collectedCommands);
           trySendSseEvent(reply, {
             type: "assistant_commands_start",
             data: { count: collectedCommands.length, professorMariCommandCount },
@@ -10072,1988 +7383,195 @@ export async function generateRoutes(app: FastifyInstance) {
           try {
             for (const { command, characterId, messageId, swipeIndex } of collectedCommands) {
               try {
-                if (command.type === "schedule_update") {
-                  // ── Schedule Update: modify the character's current schedule block ──
-                  const schedCmd = command as ScheduleUpdateCommand;
-                  if (characterId && (schedCmd.status || schedCmd.activity)) {
-                    const freshChat = await chats.getById(input.chatId);
-                    const freshMeta =
-                      typeof freshChat?.metadata === "string"
-                        ? JSON.parse(freshChat.metadata)
-                        : (freshChat?.metadata ?? {});
-                    const schedules: Record<string, any> = getEnabledConversationSchedules(freshMeta);
-                    const schedule = schedules[characterId];
-                    if (schedule) {
-                      const nowDate = new Date();
-                      const DAYS_LIST = ["Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday", "Sunday"];
-                      const dayName = DAYS_LIST[(nowDate.getDay() + 6) % 7]!;
-                      const daySchedule: Array<{ time: string; activity: string; status: string }> =
-                        schedule.days?.[dayName] ?? [];
-                      const currentMinutes = nowDate.getHours() * 60 + nowDate.getMinutes();
+                await handleConversationScheduleCommand({
+                  command,
+                  characterId,
+                  chatId: input.chatId,
+                  chats,
+                  sendUpdated: (data) => {
+                    reply.raw.write(
+                      `data: ${JSON.stringify({
+                        type: "schedule_updated",
+                        data,
+                      })}\n\n`,
+                    );
+                  },
+                });
 
-                      // Find the current time block and update it
-                      let updated = false;
-                      for (const block of daySchedule) {
-                        const [startStr, endStr] = block.time.split("-");
-                        if (!startStr || !endStr) continue;
-                        const [sh, sm] = startStr.split(":").map(Number);
-                        const [eh, em] = endStr.split(":").map(Number);
-                        const startMin = (sh ?? 0) * 60 + (sm ?? 0);
-                        const endMin = (eh ?? 0) * 60 + (em ?? 0);
-                        if (startMin <= currentMinutes && currentMinutes < endMin) {
-                          if (schedCmd.status) block.status = schedCmd.status;
-                          if (schedCmd.activity) block.activity = schedCmd.activity;
-
-                          // If duration specified, split the block
-                          if (schedCmd.duration) {
-                            const durationMin = parseDuration(schedCmd.duration);
-                            if (durationMin && currentMinutes + durationMin < endMin) {
-                              const splitTime = currentMinutes + durationMin;
-                              const splitH = String(Math.floor(splitTime / 60)).padStart(2, "0");
-                              const splitM = String(splitTime % 60).padStart(2, "0");
-                              // Shorten current block to end at the split point
-                              block.time = `${startStr}-${splitH}:${splitM}`;
-                              // Insert a new block for the remainder with the original activity/status
-                              const idx = daySchedule.indexOf(block);
-                              daySchedule.splice(idx + 1, 0, {
-                                time: `${splitH}:${splitM}-${endStr}`,
-                                activity: "free time",
-                                status: "online",
-                              });
-                            }
-                          }
-                          updated = true;
-                          break;
-                        }
-                      }
-
-                      if (updated) {
-                        schedule.days[dayName] = daySchedule;
-                        schedules[characterId] = schedule;
-                        await chats.updateMetadata(input.chatId, { ...freshMeta, characterSchedules: schedules });
-
-                        reply.raw.write(
-                          `data: ${JSON.stringify({
-                            type: "schedule_updated",
-                            data: { characterId, status: schedCmd.status, activity: schedCmd.activity },
-                          })}\n\n`,
-                        );
-                        logger.info(
-                          `[commands] Schedule updated for ${characterId}: status=${schedCmd.status}, activity=${schedCmd.activity}`,
-                        );
-                      }
-                    }
-                  }
-                } else if (command.type === "cross_post") {
-                  // ── Cross-Post: copy/redirect message to another chat ──
-                  const crossCmd = command as CrossPostCommand;
-                  const targetName = normalizeTextForMatch(crossCmd.target);
-
-                  // Find the target chat by name
-                  const allChatsList = await chats.list();
-                  const targetChat = allChatsList.find(
-                    (c: any) =>
-                      c.mode === "conversation" &&
-                      c.id !== input.chatId &&
-                      (normalizeTextForMatch(c.name).includes(targetName) || c.id === crossCmd.target),
-                  );
-
-                  if (targetChat) {
-                    // Get the clean response (commands already stripped)
-                    const msgRow = messageId ? await chats.getMessage(messageId) : null;
-                    const msgContent = msgRow?.content ?? fullResponse;
-
-                    // Create the message in the target chat
-                    await chats.createMessage({
-                      chatId: targetChat.id,
-                      role: "assistant",
-                      characterId,
-                      content: msgContent,
-                    });
-
-                    // Remove the original message from the source chat (redirect, not copy)
-                    if (messageId) {
-                      await chats.removeMessage(messageId);
-                    }
-
+                await handleConversationCrossPostCommand({
+                  command,
+                  characterId,
+                  chatId: input.chatId,
+                  messageId,
+                  fullResponse,
+                  chats,
+                  sendCrossPost: (data) => {
                     reply.raw.write(
                       `data: ${JSON.stringify({
                         type: "cross_post",
-                        data: {
-                          targetChatId: targetChat.id,
-                          targetChatName: targetChat.name,
-                          sourceChatId: input.chatId,
-                          characterId,
-                        },
+                        data,
                       })}\n\n`,
                     );
-                    logger.info(`[commands] Cross-posted message to chat "${targetChat.name}" (${targetChat.id})`);
-                  } else {
-                    logger.warn(`[commands] Cross-post target "${crossCmd.target}" not found`);
-                  }
-                } else if (command.type === "selfie") {
-                  // ── Selfie: generate an image from the character's appearance ──
-                  const selfieCmd = command as SelfieCommand;
+                  },
+                });
 
-                  // Use the chat-level image gen connection (set by user in chat settings)
-                  const imgConnId = chatMeta.imageGenConnectionId as string | undefined;
-                  if (imgConnId) {
-                    // Show typing indicator while generating the selfie
-                    const charRow = characterId ? await chars.getById(characterId) : null;
-                    const charData = charRow ? JSON.parse(charRow.data as string) : null;
-                    const charName = charData?.name ?? "character";
-                    reply.raw.write(`data: ${JSON.stringify({ type: "typing", characters: [charName] })}\n\n`);
-
-                    try {
-                      const imgConnFull = await connections.getWithKey(imgConnId);
-                      if (!imgConnFull) throw new Error("Cannot decrypt image generation connection");
-
-                      // Build selfie prompt from character appearance + context
-                      const appearance = charData?.extensions?.appearance ?? charData?.description ?? "";
-
-                      // Use the LLM to build a proper image prompt
-                      const selfieTags: string[] = Array.isArray(chatMeta.selfieTags)
-                        ? (chatMeta.selfieTags as string[])
-                        : [];
-                      const selfiePositivePrompt =
-                        typeof chatMeta.selfiePositivePrompt === "string"
-                          ? chatMeta.selfiePositivePrompt.trim()
-                          : selfieTags.join(", ").trim();
-                      const selfieNegativePrompt = ((chatMeta.selfieNegativePrompt as string) ?? "").trim();
-                      const selfiePromptTemplate =
-                        typeof chatMeta.selfiePrompt === "string" ? chatMeta.selfiePrompt.trim() : "";
-                      const promptBuilder = createLLMProvider(
-                        conn.provider,
-                        baseUrl,
-                        conn.apiKey,
-                        conn.maxContext,
-                        conn.openrouterProvider,
-                        conn.maxTokensOverride,
-                      );
-                      const selfieSystemPrompt = await resolveConversationSelfieSystemPrompt({
-                        promptOverridesStorage: createPromptOverridesStorage(app.db),
-                        chatPromptTemplate: selfiePromptTemplate,
-                        appearance,
-                        charName,
-                      });
-                      const promptResult = await promptBuilder.chatComplete(
-                        [
-                          {
-                            role: "system",
-                            content: selfieSystemPrompt,
-                          },
-                          {
-                            role: "user",
-                            content: selfieCmd.context
-                              ? `Context for the selfie: ${selfieCmd.context}`
-                              : `Generate a casual selfie of ${charName} based on the current conversation context.`,
-                          },
-                        ],
-                        {
-                          model: conn.model,
-                          ...(suppressModelParameters ? {} : { temperature: 0.7, maxTokens: 8196, serviceTier }),
-                          suppressModelParameters,
-                        },
-                      );
-
-                      const imagePrompt = (promptResult.content ?? "").trim();
-                      if (imagePrompt) {
-                        const suppressReferencePromptLine = isNovelAiImageConnection({
-                          model: imgConnFull.model,
-                          baseUrl: imgConnFull.baseUrl,
-                          imageService: imgConnFull.imageService,
-                          imageGenerationSource: (imgConnFull as any).imageGenerationSource,
-                        });
-                        let finalSelfiePrompt = selfiePositivePrompt
-                          ? `${imagePrompt}, ${selfiePositivePrompt}`
-                          : imagePrompt;
-                        let selfieReferenceImages: string[] | undefined;
-                        const selfieUseAvatarReferences = chatMeta.selfieUseAvatarReferences === true;
-                        const selfieIncludeCharacterAppearance = chatMeta.selfieIncludeCharacterAppearance === true;
-                        if (selfieUseAvatarReferences || selfieIncludeCharacterAppearance) {
-                          const referenceResolution = await resolveIllustratorCharacterReferences({
-                            charactersStore: chars,
-                            chatCharacters: charInfo.map((character) => ({
-                              id: character.id,
-                              name: character.name,
-                              avatarPath: character.avatarPath,
-                              appearance: character.appearance,
-                            })),
-                            persona: persona
-                              ? {
-                                  id: personaId,
-                                  name: personaName,
-                                  avatarPath: persona.avatarPath as string | null,
-                                  appearance: personaFields.appearance,
-                                }
-                              : null,
-                            requestedNames: [charName],
-                            promptText: [charName, selfieCmd.context ?? "", imagePrompt].join("\n"),
-                            fallbackToChatCharacters: false,
-                            maxReferences: 1,
-                          });
-                          if (selfieIncludeCharacterAppearance && referenceResolution.appearanceBlock) {
-                            finalSelfiePrompt += `\n\n${referenceResolution.appearanceBlock}`;
-                            logger.debug(
-                              "[selfie] Added character appearance notes for: %s",
-                              referenceResolution.appearanceNames.join(", "),
-                            );
-                          }
-                          if (selfieUseAvatarReferences && referenceResolution.referenceImages.length > 0) {
-                            selfieReferenceImages = referenceResolution.referenceImages;
-                            if (referenceResolution.referenceLine && !suppressReferencePromptLine) {
-                              finalSelfiePrompt += `\n\n${referenceResolution.referenceLine}`;
-                            }
-                            logger.debug(
-                              "[selfie] Sending character reference for: %s",
-                              referenceResolution.referenceNames.join(", "),
-                            );
-                          }
-                        }
-                        const { generateImage, saveImageToDisk } =
-                          await import("../services/image/image-generation.js");
-                        const { createGalleryStorage } = await import("../services/storage/gallery.storage.js");
-                        const galleryStore = createGalleryStorage(app.db);
-
-                        const imgModel = imgConnFull.model || "";
-                        const imgBaseUrl = imgConnFull.baseUrl || "https://image.pollinations.ai";
-                        const imgApiKey = imgConnFull.apiKey || "";
-                        const imgSource = (imgConnFull as any).imageGenerationSource || imgModel;
-                        const imageDefaults = resolveConnectionImageDefaults(imgConnFull);
-                        const imageSettings = await loadImageGenerationUserSettings(app.db);
-                        const configuredStyleProfileId =
-                          ((chatMeta.gameSetupConfig as Record<string, unknown> | undefined)?.imageStyleProfileId as
-                            | string
-                            | undefined) ??
-                          (chatMeta.imageStyleProfileId as string | undefined) ??
-                          null;
-                        const styleProfileId =
-                          typeof configuredStyleProfileId === "string" && configuredStyleProfileId.trim()
-                            ? configuredStyleProfileId.trim()
-                            : imageSettings.styleProfiles.defaultProfileId;
-
-                        // Parse per-chat selfie resolution, otherwise use the global selfie canvas.
-                        const selfieRes = (chatMeta.selfieResolution as string) ?? "";
-                        const [selfieW, selfieH] = selfieRes.split("x").map(Number) as [number, number];
-
-                        const serviceHint = imgConnFull.imageService || "";
-                        const compiledSelfiePrompt = compileImagePrompt({
-                          kind: "selfie",
-                          prompt: finalSelfiePrompt,
-                          negativePrompt: selfieNegativePrompt || undefined,
-                          styleProfiles: imageSettings.styleProfiles,
-                          styleProfileId,
-                          imageDefaults,
-                        });
-                        const imageResult = await generateImage(
-                          imgModel,
-                          imgBaseUrl,
-                          imgApiKey,
-                          serviceHint || imgSource,
-                          {
-                            prompt: compiledSelfiePrompt.prompt,
-                            negativePrompt: compiledSelfiePrompt.negativePrompt || undefined,
-                            model: imgModel,
-                            width: selfieW || imageSettings.selfie.width,
-                            height: selfieH || imageSettings.selfie.height,
-                            imageEndpointId: imgConnFull.imageEndpointId || undefined,
-                            comfyWorkflow: imgConnFull.comfyuiWorkflow || undefined,
-                            imageDefaults,
-                            referenceImages: selfieReferenceImages,
-                          },
-                        );
-
-                        // Save to disk and DB
-                        const filePath = saveImageToDisk(input.chatId, imageResult.base64, imageResult.ext);
-                        const galleryEntry = await galleryStore.create({
-                          chatId: input.chatId,
-                          filePath,
-                          prompt: compiledSelfiePrompt.prompt,
-                          provider: imgConnFull.provider ?? "image_generation",
-                          model: imgModel || "unknown",
-                          width: selfieW || imageSettings.selfie.width,
-                          height: selfieH || imageSettings.selfie.height,
-                        });
-
-                        // Attach the image to the message
-                        const filename = filePath.split("/").pop()!;
-                        const imageUrl = `/api/gallery/file/${input.chatId}/${encodeURIComponent(filename)}`;
-                        if (messageId) {
-                          const generationSwipeIndex = Number.isInteger(swipeIndex) ? swipeIndex : 0;
-                          const attachment = {
-                            type: "image",
-                            url: imageUrl,
-                            filename: `selfie_${charName.toLowerCase().replace(/\s+/g, "_")}.${imageResult.ext}`,
-                            prompt: compiledSelfiePrompt.prompt,
-                            galleryId: (galleryEntry as any)?.id,
-                          };
-                          await chats.appendSwipeAttachment(messageId, generationSwipeIndex, attachment);
-
-                          const currentMsgRow = await chats.getMessage(messageId);
-                          if (currentMsgRow && (currentMsgRow.activeSwipeIndex ?? 0) === generationSwipeIndex) {
-                            await chats.appendMessageAttachment(messageId, attachment);
-                          }
-                        }
-
-                        // Send selfie event to client
-                        reply.raw.write(
-                          `data: ${JSON.stringify({
-                            type: "selfie",
-                            data: {
-                              characterId,
-                              characterName: charName,
-                              messageId,
-                              imageUrl,
-                              prompt: compiledSelfiePrompt.prompt,
-                              galleryId: (galleryEntry as any)?.id,
-                            },
-                          })}\n\n`,
-                        );
-                        logger.debug("[commands] Selfie generated for %s", charName);
+                await handleConversationSelfieCommand({
+                  command,
+                  characterId,
+                  chatId: input.chatId,
+                  messageId,
+                  swipeIndex,
+                  chatMeta,
+                  charInfo,
+                  persona: persona
+                    ? {
+                        id: personaId,
+                        name: personaName,
+                        avatarPath: persona.avatarPath as string | null,
+                        appearance: personaFields.appearance,
                       }
-                    } catch (imgErr) {
-                      logger.error(imgErr, "[commands] Selfie generation failed");
-                      reply.raw.write(
-                        `data: ${JSON.stringify({
-                          type: "selfie_error",
-                          data: {
-                            characterId,
-                            error: imgErr instanceof Error ? imgErr.message : "Image generation failed",
-                          },
-                        })}\n\n`,
-                      );
-                    }
-                  } else {
-                    logger.warn("[commands] Selfie requested but no imageGenConnectionId set on chat metadata");
-                    reply.raw.write(
-                      `data: ${JSON.stringify({
-                        type: "selfie_error",
-                        data: {
-                          characterId,
-                          error: "No image generation connection configured for this chat. Set one in Chat Settings.",
-                        },
-                      })}\n\n`,
-                    );
-                  }
-                } else if (command.type === "call") {
-                  // ── Call: create a ringing Conversation call request ──
-                  const callCmd = command as CallCommand;
-                  if (chatMode !== "conversation") continue;
-                  const freshChat = await chats.getById(input.chatId);
-                  const freshMeta =
-                    typeof freshChat?.metadata === "string"
-                      ? JSON.parse(freshChat.metadata)
-                      : (freshChat?.metadata ?? {});
-                  if (freshMeta.characterCommands === false || !isConversationCommandEnabled(freshMeta, "call")) {
-                    logger.debug(
-                      "[commands] Ignored call command because calls are disabled for chat %s",
-                      input.chatId,
-                    );
-                    continue;
-                  }
-                  const ttsSettingsRaw = await createAppSettingsStorage(app.db).get("tts");
-                  let ttsSettings: Record<string, unknown> = {};
-                  if (ttsSettingsRaw && typeof ttsSettingsRaw === "string") {
-                    try {
-                      const parsed = JSON.parse(ttsSettingsRaw);
-                      ttsSettings =
-                        parsed && typeof parsed === "object" && !Array.isArray(parsed)
-                          ? (parsed as Record<string, unknown>)
-                          : {};
-                    } catch {
-                      ttsSettings = {};
-                    }
-                  }
-                  if (ttsSettings.callAudioEnabled !== true) {
-                    logger.debug(
-                      "[commands] Ignored call command because Conversation call audio is globally disabled",
-                    );
-                    continue;
-                  }
-                  const callStore = createConversationCallsStorage(app.db);
-                  const existingActive = await callStore.getActiveForChat(input.chatId);
-                  const existingRinging = await callStore.getRingingForChat(input.chatId);
-                  const session =
-                    existingActive ??
-                    existingRinging ??
-                    (await callStore.createSession({
-                      chatId: input.chatId,
-                      mode: "audio",
-                      initiator: "character",
-                      initiatorCharacterId: characterId,
-                      metadata: {
-                        reason: callCmd.reason ?? null,
-                        greeting: callCmd.greeting ?? null,
-                        sourceMessageId: messageId ?? null,
-                      },
-                    }));
-                  if (session && !existingActive && !existingRinging) {
-                    await chats.createMessagesBatch(input.chatId, [
-                      {
-                        role: "system",
-                        characterId,
-                        content: "Incoming call",
-                        extra: {
-                          displayText: null,
-                          isGenerated: true,
-                          tokenCount: null,
-                          generationInfo: null,
-                          conversationCallEvent: {
-                            callId: session.id,
-                            status: session.status,
-                            mode: session.mode,
-                            initiator: session.initiator,
-                            reason: callCmd.reason ?? null,
-                            greeting: callCmd.greeting ?? null,
-                            sourceMessageId: messageId ?? null,
-                          },
-                        },
-                      },
-                    ]);
-                  }
-                  if (session) {
+                    : null,
+                  promptConnection: conn,
+                  baseUrl,
+                  suppressModelParameters,
+                  serviceTier,
+                  db: app.db,
+                  chars,
+                  chats,
+                  connections,
+                  sendEvent: (payload) => {
+                    reply.raw.write(`data: ${JSON.stringify(payload)}\n\n`);
+                  },
+                });
+
+                await handleConversationCallCommand({
+                  command,
+                  characterId,
+                  chatId: input.chatId,
+                  chatMode,
+                  messageId,
+                  db: app.db,
+                  chats,
+                  sendRingingEvent: (data) => {
                     trySendSseEvent(reply, {
                       type: "conversation_call_ringing",
-                      data: { session, reason: callCmd.reason ?? null, characterId },
+                      data,
                     });
-                    logger.info("[commands] Conversation call ringing for chat %s", input.chatId);
-                  }
-                } else if (command.type === "memory") {
-                  // ── Memory: store a fake memory on the target character ──
-                  const memCmd = command as MemoryCommand;
-                  const targetName = normalizeTextForMatch(memCmd.target);
+                  },
+                });
 
-                  // Resolve source character name
-                  const srcCharRow = characterId ? await chars.getById(characterId) : null;
-                  const srcCharData = srcCharRow ? JSON.parse(srcCharRow.data as string) : null;
-                  const srcCharName = srcCharData?.name ?? "Unknown";
+                await handleConversationSideEffectCommand({
+                  command,
+                  characterId,
+                  chatId: input.chatId,
+                  messageId,
+                  chars,
+                  chats,
+                });
 
-                  // Find target character by name across all characters
-                  const allCharsList = await chars.list();
-                  const targetChar = allCharsList.find((c: any) => {
-                    const d = typeof c.data === "string" ? JSON.parse(c.data) : c.data;
-                    return normalizeTextForMatch(d.name) === targetName;
-                  });
+                await handleConversationMusicCommand({
+                  command,
+                  chatId: input.chatId,
+                  chatMode,
+                  agentsStore,
+                  sendEvent: (event) => {
+                    trySendSseEvent(reply, event);
+                  },
+                });
 
-                  if (targetChar) {
-                    const targetData =
-                      typeof targetChar.data === "string" ? JSON.parse(targetChar.data as string) : targetChar.data;
-                    const extensions = { ...(targetData.extensions ?? {}) };
-                    const memories: Array<{ from: string; fromCharId: string; summary: string; createdAt: string }> =
-                      extensions.characterMemories ?? [];
+                await handleConversationReactCommand({
+                  command,
+                  characterId,
+                  sourceMessageId: messageId,
+                  chatMode,
+                  chatMessages,
+                  personaId,
+                  personaName,
+                  conversationCustomEmojiUrlByName,
+                  customEmojisStore,
+                  chars,
+                  chats,
+                  getReactChatMembers,
+                });
 
-                    memories.push({
-                      from: srcCharName,
-                      fromCharId: characterId ?? "",
-                      summary: memCmd.summary,
-                      createdAt: new Date().toISOString(),
-                    });
-
-                    extensions.characterMemories = memories;
-                    await chars.update(targetChar.id, { extensions } as any);
-
-                    logger.info(
-                      `[commands] Memory created: "${srcCharName}" → "${targetData.name}": ${memCmd.summary}`,
-                    );
-                  } else {
-                    logger.warn(`[commands] Memory target character "${memCmd.target}" not found`);
-                  }
-                }
-
-                if (command.type === "influence") {
-                  // ── Influence: queue OOC influence for the connected chat ──
-                  const infCmd = command as InfluenceCommand;
-                  const freshChat = await chats.getById(input.chatId);
-                  const connectedId = freshChat?.connectedChatId as string | null;
-                  if (connectedId) {
-                    const influenceContent = stripConversationPromptTimestamps(infCmd.content);
-                    if (!influenceContent) continue;
-                    await chats.createInfluence(input.chatId, connectedId, influenceContent, messageId);
-                    logger.info(
-                      `[commands] OOC influence queued for connected chat ${connectedId}: "${influenceContent.slice(0, 80)}..."`,
-                    );
-                  } else {
-                    logger.warn("[commands] Influence command used but no connected chat");
-                  }
-                }
-
-                if (command.type === "note") {
-                  // ── Note: persist a durable note in the connected roleplay's prompt ──
-                  const noteCmd = command as NoteCommand;
-                  const freshChat = await chats.getById(input.chatId);
-                  const connectedId = freshChat?.connectedChatId as string | null;
-                  if (connectedId) {
-                    const noteContent = stripConversationPromptTimestamps(noteCmd.content);
-                    if (!noteContent) continue;
-                    await chats.createNote(input.chatId, connectedId, noteContent, messageId);
-                    logger.info(
-                      `[commands] Conversation note saved for connected chat ${connectedId}: "${noteContent.slice(0, 80)}..."`,
-                    );
-                  } else {
-                    logger.warn("[commands] Note command used but no connected chat");
-                  }
-                }
-
-                if (command.type === "spotify") {
-                  // ── Spotify: play a selected track on the user's active Spotify player ──
-                  const spotifyCmd = command as SpotifyCommand;
-                  if (chatMode !== "conversation") {
-                    logger.debug("[spotify/conversation] Ignored song command outside conversation mode");
-                    continue;
-                  }
-                  try {
-                    const result = await playConversationSpotifyCommand({
-                      storage: agentsStore,
-                      title: spotifyCmd.title,
-                      artist: spotifyCmd.artist,
-                    });
-                    trySendSseEvent(reply, {
-                      type: "spotify_command",
-                      data: {
-                        title: spotifyCmd.title,
-                        artist: spotifyCmd.artist,
-                        track: result.track,
-                      },
-                    });
-                    logger.info(
-                      '[spotify/conversation] Played "%s" by "%s" for chat %s',
-                      result.track.name,
-                      result.track.artist,
-                      input.chatId,
-                    );
-                  } catch (err) {
-                    if (isSilentConversationSpotifyCommandError(err)) {
-                      logger.debug(
-                        '[spotify/conversation] Dropped unavailable song command: "%s" by "%s" - %s',
-                        spotifyCmd.title,
-                        spotifyCmd.artist,
-                        err.message,
-                      );
-                      continue;
-                    }
-                    const message = err instanceof Error ? err.message : "Spotify song command failed.";
-                    trySendSseEvent(reply, {
-                      type: "spotify_command_error",
-                      data: {
-                        title: spotifyCmd.title,
-                        artist: spotifyCmd.artist,
-                        error: message,
-                      },
-                    });
-                    if (err instanceof ConversationSpotifyCommandError) {
-                      logger.warn(
-                        '[spotify/conversation] Song command failed (%d): "%s" by "%s" - %s',
-                        err.status,
-                        spotifyCmd.title,
-                        spotifyCmd.artist,
-                        err.message,
-                      );
-                    } else {
-                      logger.warn(err, "[spotify/conversation] Song command failed");
-                    }
-                  }
-                }
-
-                if (command.type === "youtube") {
-                  const youtubeCmd = command as YouTubeCommand;
-                  if (chatMode !== "conversation") {
-                    logger.debug("[youtube/conversation] Ignored song command outside conversation mode");
-                    continue;
-                  }
-                  trySendSseEvent(reply, {
-                    type: "youtube_command",
-                    data: {
-                      searchQuery: youtubeCmd.query,
-                      mood: "Conversation music command",
-                    },
-                  });
-                  logger.info('[youtube/conversation] Requested "%s" for chat %s', youtubeCmd.query, input.chatId);
-                }
-
-                if (command.type === "react") {
-                  const reactCmd = command as ReactCommand;
-                  if (chatMode !== "conversation") {
-                    logger.debug("[react/conversation] Ignored react command outside conversation mode");
-                    continue;
-                  }
-                  if (characterId && reactCmd.emoji) {
-                    // Resolve a custom-emoji (:name:) image so the chip renders without
-                    // re-resolving the gallery on the client (same URL form the picker uses).
-                    let imageUrl: string | null = null;
-                    const customName = reactCmd.emoji.match(/^:([a-zA-Z0-9_]+):$/)?.[1];
-                    if (customName) {
-                      const emojiLookupKeys = [
-                        characterId ? buildConversationCustomEmojiKey("character", characterId, customName) : null,
-                        personaId ? buildConversationCustomEmojiKey("persona", personaId, customName) : null,
-                        buildConversationCustomEmojiKey("global", null, customName),
-                      ].filter((key): key is string => Boolean(key));
-                      for (const key of emojiLookupKeys) {
-                        imageUrl = conversationCustomEmojiUrlByName.get(key) ?? null;
-                        if (imageUrl) break;
-                      }
-                      if (!imageUrl) {
-                        const row = await customEmojisStore.getByName(customName);
-                        if (row?.filePath) imageUrl = buildGlobalCustomEmojiUrl(String(row.filePath));
-                      }
-                    }
-
-                    // Resolve the target. Default: the user's most recent message —
-                    // the turn being answered — as a whole-message reaction.
-                    // `[react: E to "Name"]`: that character's most recent part —
-                    // looked for in the reply this command came from first, then
-                    // backwards through recent history — as a segment reaction
-                    // (issue #3210). An unresolvable name falls back to the default.
-                    let targetId = [...chatMessages].reverse().find((m: any) => m.role === "user")?.id as
-                      | string
-                      | undefined;
-                    let segmentTarget: { segment: number; speaker: string | null } | null = null;
-                    // The saved reply row, prefetched when the targeted-resolution
-                    // path already loaded it — the write below reuses it instead
-                    // of re-scanning the messages table.
-                    let prefetchedTargetMsg: Awaited<ReturnType<typeof chats.getMessage>> | null = null;
-                    if (reactCmd.targetCharacter) {
-                      const chatMembers = await getReactChatMembers();
-                      const wanted = normalizeTextForMatch(reactCmd.targetCharacter);
-                      const targetChar = chatMembers.find((m) => normalizeTextForMatch(m.name) === wanted);
-                      if (!targetChar) {
-                        // Chat members take precedence; with none matching, a react
-                        // aimed at the human — the persona's name or "User" — IS the
-                        // default target, so keep it silently. Other unknown names
-                        // fall back the same way, with a log.
-                        const targetsPersona =
-                          wanted === normalizeTextForMatch(personaName) || wanted === "user";
-                        if (!targetsPersona) {
-                          logger.debug(
-                            '[react/conversation] Unknown react target "%s" — falling back to the user message',
-                            reactCmd.targetCharacter,
-                          );
-                        }
-                      } else {
-                        const baseNames = new Set(chatMembers.map((m) => normalizeTextForMatch(m.name)));
-                        // A walked message's author may have been removed from the
-                        // chat; the client still segments with their name (author
-                        // fallback), so include it. Cache store lookups by id.
-                        const authorNameCache = new Map<string, string | null>();
-                        const authorNameOf = async (cid: unknown): Promise<string | null> => {
-                          if (typeof cid !== "string" || !cid) return null;
-                          const member = chatMembers.find((m) => m.id === cid);
-                          if (member) return member.name;
-                          if (authorNameCache.has(cid)) return authorNameCache.get(cid)!;
-                          let name: string | null = null;
-                          const row = await chars.getById(cid);
-                          if (row) {
-                            try {
-                              const parsedName = JSON.parse(row.data as string)?.name;
-                              if (typeof parsedName === "string" && parsedName.trim()) name = parsedName;
-                            } catch {
-                              // Malformed character data — segment without the author name.
-                            }
-                          }
-                          authorNameCache.set(cid, name);
-                          return name;
-                        };
-                        // Last part by the target speaker in a message, or null.
-                        // Segments the DISPLAY shape (shared timestamp strip) with
-                        // the client's known-name set so the stored index lands on
-                        // the same part the client renders the chip under.
-                        // `beforePartByNorm`: only consider parts BEFORE that
-                        // speaker's first part — a reactor can't have been reacting
-                        // to something written after their own turn in the same reply.
-                        const lastPartBy = async (
-                          content: unknown,
-                          authorId: unknown,
-                          beforePartByNorm?: string | null,
-                        ): Promise<{ segment: number; speaker: string | null } | null> => {
-                          const rawText = typeof content === "string" ? content : String(content ?? "");
-                          // Cap BEFORE the strip so pathological content skips all
-                          // regex work, not just the segmentation.
-                          if (!rawText.trim() || rawText.length > REACTION_ANNOTATION_CONTENT_CAP) return null;
-                          const text = stripLeadingMessageTimestamps(rawText);
-                          if (!text) return null;
-                          const names = new Set(baseNames);
-                          const author = await authorNameOf(authorId);
-                          if (author) names.add(normalizeTextForMatch(author));
-                          const groups = parseGroupedSpeakerSegments(text, names);
-                          if (!groups) return null;
-                          let cutoff = groups.length;
-                          if (beforePartByNorm) {
-                            const reactorFirst = groups.findIndex(
-                              (g) => g.speaker != null && normalizeTextForMatch(g.speaker) === beforePartByNorm,
-                            );
-                            if (reactorFirst >= 0) cutoff = reactorFirst;
-                          }
-                          for (let gi = cutoff - 1; gi >= 0; gi--) {
-                            const g = groups[gi]!;
-                            if (
-                              g.speaker != null &&
-                              normalizeTextForMatch(g.speaker) === wanted &&
-                              g.lines.some((line) => line.trim().length > 0)
-                            ) {
-                              return { segment: gi, speaker: g.speaker };
-                            }
-                          }
-                          return null;
-                        };
-                        let resolved: {
-                          id: string;
-                          target: { segment: number; speaker: string | null } | null;
-                        } | null = null;
-                        // The reply this command came from (already saved) — same-turn
-                        // reactions like reacting to another speaker's part above
-                        // yours. Only parts before the reactor's own turn count;
-                        // otherwise the search falls through to earlier messages.
-                        if (messageId) {
-                          const ownMsg = await chats.getMessage(messageId);
-                          if (ownMsg) {
-                            const reactorName = chatMembers.find((m) => m.id === characterId)?.name ?? null;
-                            const part = await lastPartBy(
-                              ownMsg.content,
-                              (ownMsg as { characterId?: unknown }).characterId,
-                              reactorName ? normalizeTextForMatch(reactorName) : null,
-                            );
-                            if (part) {
-                              resolved = { id: messageId, target: part };
-                              prefetchedTargetMsg = ownMsg;
-                            }
-                          }
-                        }
-                        if (!resolved) {
-                          // Recent history, newest first: a merged part by the target,
-                          // or a message they authored outright (whole-message react).
-                          const recent = [...chatMessages].slice(-30).reverse() as Array<{
-                            id?: unknown;
-                            role?: unknown;
-                            content?: unknown;
-                            characterId?: unknown;
-                            extra?: unknown;
-                          }>;
-                          for (const m of recent) {
-                            if (typeof m.id !== "string" || m.role === "user") continue;
-                            // Hidden command-anchor rows never render — a reaction
-                            // written there would be invisible. Keep walking. An
-                            // empty-text message WITH attachments (image-only reply)
-                            // does render, so it stays a valid whole-message target.
-                            const mExtra = parseExtra(m.extra) as Record<string, unknown>;
-                            if (mExtra.hiddenFromUser === true || mExtra.commandOnly === true) continue;
-                            const contentStr = typeof m.content === "string" ? m.content : String(m.content ?? "");
-                            const hasAttachments = Array.isArray(mExtra.attachments) && mExtra.attachments.length > 0;
-                            if (!contentStr.trim() && !hasAttachments) continue;
-                            if (m.characterId === targetChar.id) {
-                              resolved = { id: m.id, target: await lastPartBy(m.content, m.characterId) };
-                              break;
-                            }
-                            const part = await lastPartBy(m.content, m.characterId);
-                            if (part) {
-                              resolved = { id: m.id, target: part };
-                              break;
-                            }
-                          }
-                        }
-                        if (resolved) {
-                          targetId = resolved.id;
-                          segmentTarget = resolved.target;
-                        } else {
-                          logger.debug(
-                            '[react/conversation] No recent part by "%s" to react to — skipping targeted react',
-                            targetChar.name,
-                          );
-                          continue;
-                        }
-                      }
-                    }
-
-                    if (targetId) {
-                      const targetMsg =
-                        prefetchedTargetMsg && targetId === messageId
-                          ? prefetchedTargetMsg
-                          : await chats.getMessage(targetId);
-                      if (targetMsg) {
-                        const ex = parseExtra(targetMsg.extra);
-                        const reactions = addMessageReactor(
-                          ex.reactions,
-                          reactCmd.emoji,
-                          characterId,
-                          imageUrl,
-                          segmentTarget,
-                        );
-                        // updateMessageExtra mirrors the ACTIVE swipe itself; the
-                        // loop below covers the remaining swipes so swiping the
-                        // target message doesn't drop the character's reaction
-                        // (same message-level semantics as the client PATCH route).
-                        await chats.updateMessageExtra(targetId, { reactions });
-                        const targetSwipes = await chats.getSwipes(targetId);
-                        for (const swipe of targetSwipes) {
-                          if (swipe.index === targetMsg.activeSwipeIndex) continue;
-                          await chats.updateSwipeExtra(targetId, swipe.index, { reactions });
-                        }
-                        logger.info(
-                          "[react/conversation] %s reacted with %s on message %s%s",
-                          characterId,
-                          reactCmd.emoji,
-                          targetId,
-                          segmentTarget ? ` (segment ${segmentTarget.segment})` : "",
-                        );
-                      }
-                    }
-                  }
-                }
-
-                if (command.type === "dm") {
-                  // ── Roleplay DM: post into the linked conversation when available; otherwise create a DM chat ──
-                  const dmCmd = command as DirectMessageCommand;
-                  try {
-                    const messageText = stripConversationPromptTimestamps(dmCmd.message).trim().slice(0, 4000);
-                    const targetCharId = dmCmd.resolvedCharacterId ?? null;
-                    const targetName = dmCmd.resolvedCharacterName ?? dmCmd.character.trim();
-
-                    if (!targetCharId) {
-                      logger.warn('[commands] DM target character "%s" not found', dmCmd.character);
-                      continue;
-                    }
-                    if (!messageText) continue;
-
-                    const sourceUserMessage = [...allChatMessages]
-                      .reverse()
-                      .find((m: any) => m.role === "user" && !isMessageHiddenFromAI(m));
-                    const sourceUserText = sourceUserMessage
-                      ? stripConversationPromptTimestamps(String(sourceUserMessage.content ?? ""))
-                          .trim()
-                          .slice(0, 4000)
-                      : "";
-                    const ensureSourceUserMessage = async (
-                      targetChatId: string,
-                      dedupePerTarget: boolean,
-                      chatStorage: typeof chats = chats,
-                    ) => {
-                      if (!sourceUserMessage?.id || !sourceUserText) return null;
-
-                      const targetMessages = await chatStorage.listMessages(targetChatId);
-                      const alreadyMirrored = targetMessages.some((m: any) => {
-                        const extra = parseExtra(m.extra) as Record<string, unknown>;
-                        if (
-                          extra.roleplayDmSourceChatId !== input.chatId ||
-                          extra.roleplayDmSourceUserMessageId !== sourceUserMessage.id
-                        ) {
-                          return false;
-                        }
-                        return !dedupePerTarget || extra.roleplayDmTargetCharacterId === targetCharId;
-                      });
-                      if (alreadyMirrored) return null;
-
-                      const userMsg = await chatStorage.createMessage({
-                        chatId: targetChatId,
-                        role: "user",
-                        characterId: null,
-                        content: sourceUserText,
-                      });
-                      if (userMsg?.id) {
-                        await chatStorage.updateMessageExtra(userMsg.id, {
-                          roleplayDmSourceChatId: input.chatId,
-                          roleplayDmSourceUserMessageId: sourceUserMessage.id,
-                          roleplayDmTargetCharacterId: targetCharId,
-                        });
-                      }
-                      recordUserActivity(targetChatId);
-                      return userMsg;
-                    };
-
-                    const freshChat = await chats.getById(input.chatId);
-                    const connectedId = freshChat?.connectedChatId as string | null;
-                    const connectedChat = connectedId ? await chats.getById(connectedId) : null;
-                    const linkedConversationId = connectedChat?.mode === "conversation" ? connectedChat.id : null;
-
-                    if (linkedConversationId) {
-                      const sourceUserDmMessage = await ensureSourceUserMessage(linkedConversationId, false);
-                      const dmMessage = await chats.createMessage({
-                        chatId: linkedConversationId,
-                        role: "assistant",
-                        characterId: targetCharId,
-                        content: messageText,
-                      });
-                      recordAssistantActivity(linkedConversationId, targetCharId);
-
-                      reply.raw.write(
-                        `data: ${JSON.stringify({
-                          type: "assistant_action",
-                          data: {
-                            action: "dm_posted",
-                            chatId: linkedConversationId,
-                            mode: "conversation",
-                            characterName: targetName,
-                            sourceChatId: input.chatId,
-                            sourceMessageId: messageId || null,
-                            sourceUserMessageId: sourceUserMessage?.id ?? null,
-                            userMessageId: sourceUserDmMessage?.id ?? null,
-                            messageId: dmMessage?.id ?? null,
-                          },
-                        })}\n\n`,
-                      );
-                      logger.info(
-                        '[commands] Roleplay DM from "%s" posted to linked conversation %s from chat %s',
-                        targetName,
-                        linkedConversationId,
-                        input.chatId,
-                      );
-                      continue;
-                    }
-
-                    const allChatsList = await chats.list();
-                    const existingDmChat = allChatsList.find((candidate: any) => {
-                      if (candidate.mode !== "conversation" || candidate.id === input.chatId) return false;
-                      const meta = parseExtra(candidate.metadata) as Record<string, unknown>;
-                      if (meta.dmOriginChatId !== input.chatId) return false;
-                      if (typeof meta.dmTargetCharacterId === "string" && meta.dmTargetCharacterId !== targetCharId) {
-                        return false;
-                      }
-                      return parseChatCharacterIdsForDm(candidate.characterIds).includes(targetCharId);
-                    });
-
-                    const createdNewChat = !existingDmChat;
-                    const targetChat =
-                      existingDmChat ??
-                      (await chats.create({
-                        name: `DM with ${targetName}`,
-                        mode: "conversation",
-                        characterIds: [targetCharId],
-                        groupId: null,
-                        personaId: (chat.personaId as string | null) ?? null,
-                        promptPresetId: null,
-                        connectionId: (chat.connectionId as string | null) ?? null,
-                      }));
-                    if (!targetChat) throw new Error("Failed to create DM conversation");
-
-                    let sourceUserDmMessage: Awaited<ReturnType<typeof chats.createMessage>> | null = null;
-                    let dmMessage: Awaited<ReturnType<typeof chats.createMessage>> | null = null;
-                    try {
-                      await chats.patchMetadata(targetChat.id, {
-                        dmOriginChatId: input.chatId,
-                        dmOriginChatName: chat.name ?? null,
-                        dmOriginMessageId: messageId || null,
-                        dmSourceUserMessageId: sourceUserMessage?.id ?? null,
-                        dmTargetCharacterId: targetCharId,
-                        roleplayDmThread: true,
-                      });
-                      sourceUserDmMessage = await ensureSourceUserMessage(targetChat.id, true);
-                      dmMessage = await chats.createMessage({
-                        chatId: targetChat.id,
-                        role: "assistant",
-                        characterId: targetCharId,
-                        content: messageText,
-                      });
-                      recordAssistantActivity(targetChat.id, targetCharId);
-                    } catch (dmWriteErr) {
-                      if (createdNewChat) {
-                        try {
-                          await chats.remove(targetChat.id);
-                          logger.warn(
-                            "[commands] Removed incomplete Roleplay DM conversation %s after failed setup",
-                            targetChat.id,
-                          );
-                        } catch (cleanupErr) {
-                          logger.error(
-                            cleanupErr,
-                            "[commands] Failed to remove incomplete Roleplay DM conversation %s",
-                            targetChat.id,
-                          );
-                        }
-                      }
-                      throw dmWriteErr;
-                    }
-
+                await handleRoleplayDmCommand({
+                  command,
+                  chatId: input.chatId,
+                  sourceChat: chat,
+                  messageId,
+                  allChatMessages,
+                  chats,
+                  sendAssistantAction: (data) => {
                     reply.raw.write(
                       `data: ${JSON.stringify({
                         type: "assistant_action",
-                        data: {
-                          action: createdNewChat ? "chat_created" : "dm_posted",
-                          chatId: targetChat.id,
-                          chatName: targetChat.name ?? `DM with ${targetName}`,
-                          mode: "conversation",
-                          characterName: targetName,
-                          sourceChatId: input.chatId,
-                          sourceMessageId: messageId || null,
-                          sourceUserMessageId: sourceUserMessage?.id ?? null,
-                          userMessageId: sourceUserDmMessage?.id ?? null,
-                          messageId: dmMessage?.id ?? null,
-                        },
+                        data,
                       })}\n\n`,
                     );
-                    logger.info(
-                      createdNewChat
-                        ? '[commands] Roleplay DM conversation created with "%s" (%s) from chat %s'
-                        : '[commands] Roleplay DM from "%s" reused conversation %s from chat %s',
-                      targetName,
-                      targetChat.id,
-                      input.chatId,
+                  },
+                });
+
+                await handleHapticCommand({
+                  command,
+                  sendEvent: (data) => {
+                    reply.raw.write(
+                      `data: ${JSON.stringify({
+                        type: "haptic_command",
+                        data,
+                      })}\n\n`,
                     );
-                  } catch (err) {
-                    logger.error(err, "[commands] Roleplay DM creation failed");
-                  }
-                }
+                  },
+                });
 
-                if (command.type === "haptic") {
-                  // ── Haptic: send command to connected intimate devices ──
-                  const hapCmd = command as HapticCommand;
-                  try {
-                    const { hapticService } = await import("../services/haptic/buttplug-service.js");
-                    if (hapticService.connected && hapticService.devices.length > 0) {
-                      await hapticService.executeCommand({
-                        deviceIndex: "all",
-                        action: hapCmd.action,
-                        intensity: hapCmd.intensity,
-                        duration: hapCmd.duration,
-                      });
-                      reply.raw.write(
-                        `data: ${JSON.stringify({
-                          type: "haptic_command",
-                          data: { action: hapCmd.action, intensity: hapCmd.intensity, duration: hapCmd.duration },
-                        })}\n\n`,
-                      );
-                      logger.info(
-                        `[commands] Haptic: ${hapCmd.action} intensity=${hapCmd.intensity ?? "default"} duration=${hapCmd.duration ?? "indefinite"}`,
-                      );
-                    } else if (!hapticService.connected) {
-                      logger.warn(
-                        `[commands] Haptic command [${hapCmd.action}] skipped — Intiface Central not connected`,
-                      );
-                    } else {
-                      logger.warn(`[commands] Haptic command [${hapCmd.action}] skipped — no devices found`);
-                    }
-                  } catch (hapErr) {
-                    logger.error(hapErr, "[commands] Haptic command failed");
-                  }
-                }
+                await handleConversationSceneCommand({
+                  command,
+                  characterId,
+                  chatId: input.chatId,
+                  app,
+                  chars,
+                  chats,
+                  sendSceneCreated: (data) => {
+                    reply.raw.write(
+                      `data: ${JSON.stringify({
+                        type: "scene_created",
+                        data,
+                      })}\n\n`,
+                    );
+                  },
+                });
 
-                if (command.type === "scene") {
-                  // ── Scene: plan + create a mini-roleplay branching from this conversation ──
-                  const scnCmd = command as SceneCommand;
-                  try {
-                    const originChat = await chats.getById(input.chatId);
-                    if (!originChat) throw new Error("Origin chat not found");
+                await handleTurnGameCommand({
+                  commandType: command.type,
+                  characterId,
+                  chatId: input.chatId,
+                  chatMeta,
+                  db: app.db,
+                  chats,
+                  conn,
+                  baseUrl,
+                  reply,
+                  signal: abortController.signal,
+                });
 
-                    const originCharIds: string[] =
-                      typeof originChat.characterIds === "string"
-                        ? JSON.parse(originChat.characterIds)
-                        : (originChat.characterIds as string[]);
-
-                    // Resolve initiator name
-                    const initiatorRow = characterId ? await chars.getById(characterId) : null;
-                    const initiatorData = initiatorRow
-                      ? typeof initiatorRow.data === "string"
-                        ? JSON.parse(initiatorRow.data as string)
-                        : initiatorRow.data
-                      : null;
-                    const initiatorName = initiatorData?.name ?? "Character";
-
-                    // Call /scene/plan internally to get a comprehensive plan
-                    const planRes = await app.inject({
-                      method: "POST",
-                      url: "/api/scene/plan",
-                      payload: {
-                        chatId: input.chatId,
-                        prompt: scnCmd.scenario,
-                        connectionId: null,
-                      },
-                    });
-                    const planBody = JSON.parse(planRes.body);
-                    if (!planBody.plan) throw new Error("Scene plan failed");
-
-                    // Override background if the character specified one
-                    if (scnCmd.background) {
-                      planBody.plan.background = scnCmd.background;
-                    }
-
-                    // Call /scene/create with the full plan
-                    const createRes = await app.inject({
-                      method: "POST",
-                      url: "/api/scene/create",
-                      payload: {
-                        originChatId: input.chatId,
-                        initiatorCharId: characterId,
-                        plan: planBody.plan,
-                        connectionId: null,
-                      },
-                    });
-                    const createBody = JSON.parse(createRes.body);
-
-                    if (createBody.chatId) {
-                      // Notify client
-                      reply.raw.write(
-                        `data: ${JSON.stringify({
-                          type: "scene_created",
-                          data: {
-                            sceneChatId: createBody.chatId,
-                            sceneChatName: createBody.chatName,
-                            description: createBody.description,
-                            background: createBody.background ?? null,
-                            initiatorCharId: characterId,
-                            initiatorCharName: initiatorName,
-                          },
-                        })}\n\n`,
-                      );
-                      logger.info(
-                        `[commands] Scene created: "${createBody.chatName}" (${createBody.chatId}) from chat ${input.chatId}`,
-                      );
-                    }
-                  } catch (sceneErr) {
-                    logger.error(sceneErr, "[commands] Scene creation failed");
-                  }
-                }
-
-                if (command.type === "uno") {
-                  // ── UNO: a character agreed to play — deal a game at the table ──
-                  try {
-                    const existingGame = await getActiveTurnGame(app.db, input.chatId);
-                    if (existingGame) {
-                      logger.info("[commands] UNO requested but a game is already active in chat %s", input.chatId);
-                    } else {
-                      const unoChat = await chats.getById(input.chatId);
-                      // Parse defensively so malformed chat metadata can't throw and
-                      // silently abort the command (mirrors resolveSeats).
-                      let unoCharIds: string[] = [];
-                      try {
-                        const rawCharIds = unoChat?.characterIds;
-                        const parsedCharIds = typeof rawCharIds === "string" ? JSON.parse(rawCharIds) : rawCharIds;
-                        if (Array.isArray(parsedCharIds)) {
-                          unoCharIds = parsedCharIds.filter((x): x is string => typeof x === "string");
-                        }
-                      } catch {
-                        unoCharIds = [];
-                      }
-                      // Seat the human + every character who isn't offline (asleep) right now.
-                      const unoSchedules = getEnabledConversationSchedules(chatMeta) as Record<
-                        string,
-                        import("../services/conversation/schedule.service.js").WeekSchedule
-                      >;
-                      const unoSchedSvc = await import("../services/conversation/schedule.service.js");
-                      const seatBotIds = unoCharIds.filter((cid) => {
-                        const sched = unoSchedules[cid];
-                        return !sched || unoSchedSvc.getCurrentStatus(sched).status !== "offline";
-                      });
-                      // The agreeing character is always seated, even if their schedule says otherwise.
-                      if (characterId && unoCharIds.includes(characterId) && !seatBotIds.includes(characterId)) {
-                        seatBotIds.push(characterId);
-                      }
-                      const outcome = await startTurnGame(app.db, input.chatId, {
-                        gameType: "uno",
-                        botCharacterIds: seatBotIds,
-                        humanFirst: true,
-                      });
-                      if (outcome.ok) {
-                        reply.raw.write(
-                          `data: ${JSON.stringify({ type: "turn_game_state_patch", data: outcome.view })}\n\n`,
-                        );
-                        logger.info(
-                          "[commands] UNO started in chat %s with %d player(s)",
-                          input.chatId,
-                          seatBotIds.length + 1,
-                        );
-                        // If the opening card landed the first turn on a bot (skip/reverse/draw2),
-                        // advance the bot seats now so the deal resolves to the human's turn.
-                        await runTurnGameBotTurns({
-                          db: app.db,
-                          chatId: input.chatId,
-                          conn,
-                          baseUrl,
-                          reply,
-                          signal: abortController.signal,
-                        });
-                      } else {
-                        logger.warn("[commands] UNO start failed in chat %s: %s", input.chatId, outcome.error ?? "");
-                      }
-                    }
-                  } catch (unoErr) {
-                    logger.error(unoErr, "[commands] UNO start failed");
-                  }
-                }
-
-                if (command.type === "chess") {
-                  // ── Chess: a character accepted a one-on-one challenge — set up the board ──
-                  try {
-                    const existingGame = await getActiveTurnGame(app.db, input.chatId);
-                    if (existingGame) {
-                      logger.info("[commands] chess requested but a game is already active in chat %s", input.chatId);
-                    } else if (!characterId) {
-                      logger.warn("[commands] chess requested without an agreeing character in chat %s", input.chatId);
-                    } else {
-                      // Chess seats exactly two players: the human persona and the
-                      // character who agreed (no schedule sweep — nobody else plays).
-                      const outcome = await startTurnGame(app.db, input.chatId, {
-                        gameType: "chess",
-                        botCharacterIds: [characterId],
-                        humanFirst: true,
-                      });
-                      if (outcome.ok) {
-                        reply.raw.write(
-                          `data: ${JSON.stringify({ type: "turn_game_state_patch", data: outcome.view })}\n\n`,
-                        );
-                        logger.info("[commands] chess started in chat %s against %s", input.chatId, characterId);
-                        // The default config assigns colors randomly from the seed — when the
-                        // bot drew white, play its opening move now instead of stalling.
-                        await runTurnGameBotTurns({
-                          db: app.db,
-                          chatId: input.chatId,
-                          conn,
-                          baseUrl,
-                          reply,
-                          signal: abortController.signal,
-                        });
-                      } else {
-                        logger.warn("[commands] chess start failed in chat %s: %s", input.chatId, outcome.error ?? "");
-                      }
-                    }
-                  } catch (chessErr) {
-                    logger.error(chessErr, "[commands] chess start failed");
-                  }
-                }
-
-                // ── Assistant commands (Professor Mari) ──
-                if (command.type === "create_persona") {
-                  const cpCmd = command as CreatePersonaCommand;
-                  try {
-                    const persona = await chars.createPersona(cpCmd.name, cpCmd.description ?? "", undefined, {
-                      personality: cpCmd.personality,
-                      appearance: cpCmd.appearance,
-                    });
+                const professorMariResult = await handleProfessorMariCommand({
+                  command,
+                  characterId,
+                  chatId: input.chatId,
+                  sourceChatMetadata: chat.metadata,
+                  isHomeProfessorMariAssistantChat,
+                  db: app.db,
+                  stores: { chars, chats, lorebooksStore, presets },
+                  sendAssistantAction: (data) => {
                     reply.raw.write(
                       `data: ${JSON.stringify({
                         type: "assistant_action",
-                        data: { action: "persona_created", id: persona?.id, name: cpCmd.name },
+                        data,
                       })}\n\n`,
                     );
-                    logger.info(`[commands] Assistant created persona: "${cpCmd.name}" (${persona?.id})`);
-                  } catch (err) {
-                    logger.error(err, "[commands] Create persona failed");
-                  }
-                }
-
-                if (command.type === "create_character") {
-                  const ccCmd = command as CreateCharacterCommand;
-                  try {
-                    const charData = {
-                      name: ccCmd.name,
-                      description: ccCmd.description ?? "",
-                      personality: ccCmd.personality ?? "",
-                      first_mes: ccCmd.firstMessage ?? "",
-                      scenario: ccCmd.scenario ?? "",
-                      mes_example: ccCmd.mesExample ?? "",
-                      creator_notes: ccCmd.creatorNotes ?? "",
-                      system_prompt: ccCmd.systemPrompt ?? "",
-                      post_history_instructions: ccCmd.postHistoryInstructions ?? "",
-                      tags: ccCmd.tags ?? ([] as string[]),
-                      creator: ccCmd.creator ?? "",
-                      character_version: ccCmd.characterVersion ?? "",
-                      alternate_greetings: ccCmd.alternateGreetings ?? ([] as string[]),
-                      extensions: {
-                        talkativeness: ccCmd.talkativeness ?? 0.5,
-                        fav: ccCmd.fav ?? false,
-                        world: ccCmd.world ?? "",
-                        depth_prompt: {
-                          prompt: ccCmd.depthPrompt ?? "",
-                          depth: ccCmd.depthPromptDepth ?? 4,
-                          role: ccCmd.depthPromptRole ?? "system",
-                        },
-                        backstory: ccCmd.backstory ?? "",
-                        appearance: ccCmd.appearance ?? "",
-                      },
-                      character_book: null,
-                    };
-                    const created = await chars.create(charData as any);
-                    if (created) {
-                      reply.raw.write(
-                        `data: ${JSON.stringify({
-                          type: "assistant_action",
-                          data: { action: "character_created", id: created.id, name: ccCmd.name },
-                        })}\n\n`,
-                      );
-                      logger.info(`[commands] Assistant created character: "${ccCmd.name}" (${created.id})`);
-                    }
-                  } catch (err) {
-                    logger.error(err, "[commands] Create character failed");
-                  }
-                }
-
-                if (command.type === "update_character") {
-                  const ucCmd = command as UpdateCharacterCommand;
-                  try {
-                    const allCharsList = await chars.list();
-                    const targetChar = allCharsList.find((c: any) => {
-                      const d = typeof c.data === "string" ? JSON.parse(c.data) : c.data;
-                      return normalizeTextForMatch(d.name) === normalizeTextForMatch(ucCmd.name);
-                    });
-                    if (targetChar) {
-                      const latestTargetChar = await chars.getById(targetChar.id);
-                      if (!latestTargetChar) {
-                        logger.warn(`[commands] Update character: "${ucCmd.name}" disappeared before update`);
-                        continue;
-                      }
-                      const existingData =
-                        typeof latestTargetChar.data === "string"
-                          ? JSON.parse(latestTargetChar.data as string)
-                          : latestTargetChar.data;
-                      const updates: Record<string, unknown> = {};
-                      const extensionUpdates: Record<string, unknown> = {};
-                      if (ucCmd.description !== undefined) updates.description = ucCmd.description;
-                      if (ucCmd.personality !== undefined) updates.personality = ucCmd.personality;
-                      if (ucCmd.firstMessage !== undefined) updates.first_mes = ucCmd.firstMessage;
-                      if (ucCmd.scenario !== undefined) updates.scenario = ucCmd.scenario;
-                      if (ucCmd.mesExample !== undefined) updates.mes_example = ucCmd.mesExample;
-                      if (ucCmd.creatorNotes !== undefined) updates.creator_notes = ucCmd.creatorNotes;
-                      if (ucCmd.systemPrompt !== undefined) updates.system_prompt = ucCmd.systemPrompt;
-                      if (ucCmd.postHistoryInstructions !== undefined) {
-                        updates.post_history_instructions = ucCmd.postHistoryInstructions;
-                      }
-                      if (ucCmd.creator !== undefined) updates.creator = ucCmd.creator;
-                      if (ucCmd.characterVersion !== undefined) updates.character_version = ucCmd.characterVersion;
-                      if (ucCmd.tags !== undefined) updates.tags = ucCmd.tags;
-                      if (ucCmd.alternateGreetings !== undefined) {
-                        updates.alternate_greetings = ucCmd.alternateGreetings;
-                      }
-                      if (ucCmd.backstory !== undefined) extensionUpdates.backstory = ucCmd.backstory;
-                      if (ucCmd.appearance !== undefined) extensionUpdates.appearance = ucCmd.appearance;
-                      if (ucCmd.talkativeness !== undefined) extensionUpdates.talkativeness = ucCmd.talkativeness;
-                      if (ucCmd.fav !== undefined) extensionUpdates.fav = ucCmd.fav;
-                      if (ucCmd.world !== undefined) extensionUpdates.world = ucCmd.world;
-                      if (
-                        ucCmd.depthPrompt !== undefined ||
-                        ucCmd.depthPromptDepth !== undefined ||
-                        ucCmd.depthPromptRole !== undefined
-                      ) {
-                        const existingDepthPrompt = existingData.extensions?.depth_prompt ?? {};
-                        extensionUpdates.depth_prompt = {
-                          ...existingDepthPrompt,
-                          ...(ucCmd.depthPrompt !== undefined ? { prompt: ucCmd.depthPrompt } : {}),
-                          ...(ucCmd.depthPromptDepth !== undefined ? { depth: ucCmd.depthPromptDepth } : {}),
-                          ...(ucCmd.depthPromptRole !== undefined ? { role: ucCmd.depthPromptRole } : {}),
-                        };
-                      }
-                      if (Object.keys(extensionUpdates).length > 0) {
-                        updates.extensions = { ...(existingData.extensions ?? {}), ...extensionUpdates };
-                      }
-                      if (ucCmd.characterVersion === undefined && Object.keys(updates).length > 0) {
-                        updates.character_version = bumpCharacterVersion(existingData.character_version);
-                      }
-                      await chars.update(targetChar.id, updates, undefined, {
-                        versionSource: "command",
-                        versionReason: "Assistant update_character command",
-                      });
-                      reply.raw.write(
-                        `data: ${JSON.stringify({
-                          type: "assistant_action",
-                          data: { action: "character_updated", id: targetChar.id, name: ucCmd.name },
-                        })}\n\n`,
-                      );
-                      logger.info(`[commands] Assistant updated character: "${ucCmd.name}" (${targetChar.id})`);
-                    } else {
-                      logger.warn(`[commands] Update character: "${ucCmd.name}" not found`);
-                    }
-                  } catch (err) {
-                    logger.error(err, "[commands] Update character failed");
-                  }
-                }
-
-                if (command.type === "update_persona") {
-                  const upCmd = command as UpdatePersonaCommand;
-                  try {
-                    const allPersonas = await chars.listPersonas();
-                    const targetPersona = allPersonas.find((p: any) => {
-                      return normalizeTextForMatch(p.name) === normalizeTextForMatch(upCmd.name);
-                    });
-                    if (targetPersona) {
-                      const sets: Record<string, unknown> = {};
-                      if (upCmd.description !== undefined) sets.description = upCmd.description;
-                      if (upCmd.personality !== undefined) sets.personality = upCmd.personality;
-                      if (upCmd.appearance !== undefined) sets.appearance = upCmd.appearance;
-                      if (upCmd.scenario !== undefined) sets.scenario = upCmd.scenario;
-                      if (upCmd.backstory !== undefined) sets.backstory = upCmd.backstory;
-                      await chars.updatePersona(targetPersona.id, sets as any);
-                      reply.raw.write(
-                        `data: ${JSON.stringify({
-                          type: "assistant_action",
-                          data: { action: "persona_updated", id: targetPersona.id, name: upCmd.name },
-                        })}\n\n`,
-                      );
-                      logger.info(`[commands] Assistant updated persona: "${upCmd.name}" (${targetPersona.id})`);
-                    } else {
-                      logger.warn(`[commands] Update persona: "${upCmd.name}" not found`);
-                    }
-                  } catch (err) {
-                    logger.error(err, "[commands] Update persona failed");
-                  }
-                }
-
-                if (command.type === "create_lorebook") {
-                  const clCmd = command as CreateLorebookCommand;
-                  try {
-                    const category =
-                      clCmd.category === "character" ||
-                      clCmd.category === "world" ||
-                      clCmd.category === "npc" ||
-                      clCmd.category === "spellbook"
-                        ? clCmd.category
-                        : "uncategorized";
-                    const created = await lorebooksStore.create({
-                      name: clCmd.name,
-                      description: clCmd.description ?? "",
-                      category,
-                      tags: clCmd.tags ?? [],
-                      enabled: true,
-                      generatedBy: "agent",
-                      sourceAgentId: PROFESSOR_MARI_ID,
-                    });
-
-                    if (created) {
-                      const createdLorebook = created as unknown as { id: string };
-                      let entryCount = 0;
-                      for (const entry of clCmd.entries ?? []) {
-                        await lorebooksStore.createEntry({
-                          lorebookId: createdLorebook.id,
-                          name: entry.name,
-                          content: entry.content ?? "",
-                          description: entry.description ?? "",
-                          keys: entry.keys ?? [],
-                          secondaryKeys: entry.secondaryKeys ?? [],
-                          tag: entry.tag ?? "",
-                          constant: entry.constant ?? false,
-                          selective: entry.selective ?? false,
-                          enabled: true,
-                        });
-                        entryCount += 1;
-                      }
-
-                      reply.raw.write(
-                        `data: ${JSON.stringify({
-                          type: "assistant_action",
-                          data: {
-                            action: "lorebook_created",
-                            id: createdLorebook.id,
-                            name: clCmd.name,
-                            entryCount,
-                          },
-                        })}\n\n`,
-                      );
-                      logger.info(
-                        '[commands] Assistant created lorebook: "%s" (%s) with %d entries',
-                        clCmd.name,
-                        createdLorebook.id,
-                        entryCount,
-                      );
-                    }
-                  } catch (err) {
-                    logger.error(err, "[commands] Create lorebook failed");
-                  }
-                }
-
-                if (command.type === "update_lorebook") {
-                  const ulCmd = command as UpdateLorebookCommand;
-                  try {
-                    const allLorebooks = await lorebooksStore.list();
-                    const targetLorebook = (allLorebooks as any[]).find((lb: any) => {
-                      if (lb.id === ulCmd.name) return true;
-                      return normalizeTextForMatch(lb.name) === normalizeTextForMatch(ulCmd.name);
-                    });
-
-                    if (!targetLorebook) {
-                      logger.warn('[commands] Update lorebook: "%s" not found', ulCmd.name);
-                    } else {
-                      const category =
-                        ulCmd.category === "character" ||
-                        ulCmd.category === "world" ||
-                        ulCmd.category === "npc" ||
-                        ulCmd.category === "spellbook" ||
-                        ulCmd.category === "uncategorized"
-                          ? ulCmd.category
-                          : undefined;
-                      const lorebookUpdates: Record<string, unknown> = {};
-                      if (ulCmd.newName !== undefined && ulCmd.newName.trim()) lorebookUpdates.name = ulCmd.newName;
-                      if (ulCmd.description !== undefined) lorebookUpdates.description = ulCmd.description;
-                      if (category !== undefined) lorebookUpdates.category = category;
-                      if (ulCmd.tags !== undefined) lorebookUpdates.tags = ulCmd.tags;
-                      if (Object.keys(lorebookUpdates).length > 0) {
-                        await lorebooksStore.update(targetLorebook.id, lorebookUpdates as any);
-                      }
-
-                      const existingEntries = (await lorebooksStore.listEntries(targetLorebook.id)) as any[];
-                      const existingByName = new Map(
-                        existingEntries.map((entry) => [
-                          String(entry.name ?? "")
-                            .trim()
-                            .toLowerCase(),
-                          entry,
-                        ]),
-                      );
-                      let updatedEntryCount = 0;
-                      let createdEntryCount = 0;
-
-                      for (const entry of ulCmd.entries ?? []) {
-                        const matchName = (entry.matchName || entry.name).trim().toLowerCase();
-                        const existingEntry = existingByName.get(matchName);
-                        if (existingEntry) {
-                          const entryUpdates: Record<string, unknown> = {};
-                          if (entry.name !== undefined) entryUpdates.name = entry.name;
-                          if (entry.content !== undefined) entryUpdates.content = entry.content;
-                          if (entry.description !== undefined) entryUpdates.description = entry.description;
-                          if (entry.keys !== undefined) entryUpdates.keys = entry.keys;
-                          if (entry.secondaryKeys !== undefined) entryUpdates.secondaryKeys = entry.secondaryKeys;
-                          if (entry.tag !== undefined) entryUpdates.tag = entry.tag;
-                          if (entry.constant !== undefined) entryUpdates.constant = entry.constant;
-                          if (entry.selective !== undefined) entryUpdates.selective = entry.selective;
-                          if (Object.keys(entryUpdates).length > 0) {
-                            const updatedEntry = await lorebooksStore.updateEntry(
-                              existingEntry.id,
-                              entryUpdates as any,
-                            );
-                            if (updatedEntry) {
-                              updatedEntryCount += 1;
-                              existingByName.delete(matchName);
-                              existingByName.set(entry.name.trim().toLowerCase(), updatedEntry);
-                            }
-                          }
-                        } else {
-                          const createdEntry = await lorebooksStore.createEntry({
-                            lorebookId: targetLorebook.id,
-                            name: entry.name,
-                            content: entry.content ?? "",
-                            description: entry.description ?? "",
-                            keys: entry.keys ?? [],
-                            secondaryKeys: entry.secondaryKeys ?? [],
-                            tag: entry.tag ?? "",
-                            constant: entry.constant ?? false,
-                            selective: entry.selective ?? false,
-                            enabled: true,
-                          });
-                          if (createdEntry) {
-                            createdEntryCount += 1;
-                            existingByName.set(entry.name.trim().toLowerCase(), createdEntry);
-                          }
-                        }
-                      }
-
-                      const finalName = ulCmd.newName?.trim() || targetLorebook.name || ulCmd.name;
-                      reply.raw.write(
-                        `data: ${JSON.stringify({
-                          type: "assistant_action",
-                          data: {
-                            action: "lorebook_updated",
-                            id: targetLorebook.id,
-                            name: finalName,
-                            updatedEntryCount,
-                            createdEntryCount,
-                          },
-                        })}\n\n`,
-                      );
-                      logger.info(
-                        '[commands] Assistant updated lorebook: "%s" (%s), entries updated=%d created=%d',
-                        finalName,
-                        targetLorebook.id,
-                        updatedEntryCount,
-                        createdEntryCount,
-                      );
-                    }
-                  } catch (err) {
-                    logger.error(err, "[commands] Update lorebook failed");
-                  }
-                }
-
-                if (command.type === "create_preset") {
-                  const presetCmd = command as CreatePresetCommand;
-                  try {
-                    const createdPresetAction = await app.db.transaction(async (tx) => {
-                      const txPresets = createPromptsStorage(tx as unknown as typeof app.db);
-                      const created = await txPresets.create({
-                        name: presetCmd.name,
-                        description: presetCmd.description ?? "",
-                        wrapFormat: resolveAssistantPresetWrapFormat(presetCmd.wrapFormat),
-                        isDefault: false,
-                        author: presetCmd.author ?? "Professor Mari",
-                      });
-
-                      if (!created) return null;
-
-                      const createdPreset = created as unknown as { id: string };
-                      const groupIds = new Map<string, string>();
-                      const groupKey = (name: string) => name.trim().toLowerCase();
-
-                      const ensureGroup = async (
-                        name: string,
-                        order?: number,
-                        enabled?: boolean,
-                      ): Promise<string | null> => {
-                        const trimmed = name.trim();
-                        if (!trimmed) return null;
-                        const key = groupKey(trimmed);
-                        const existing = groupIds.get(key);
-                        if (existing) return existing;
-                        const group = await txPresets.createGroup({
-                          presetId: createdPreset.id,
-                          name: trimmed,
-                          order: order ?? (groupIds.size + 1) * 100,
-                          enabled: enabled ?? true,
-                        });
-                        if (!group) return null;
-                        groupIds.set(key, group.id);
-                        return group.id;
-                      };
-
-                      for (const group of presetCmd.groups ?? []) {
-                        await ensureGroup(group.name, group.order, group.enabled);
-                      }
-
-                      for (const group of presetCmd.groups ?? []) {
-                        if (!group.parentGroupName) continue;
-                        const childId = groupIds.get(groupKey(group.name));
-                        const parentId = await ensureGroup(group.parentGroupName);
-                        if (childId && parentId) {
-                          await txPresets.updateGroup(childId, { parentGroupId: parentId });
-                        }
-                      }
-
-                      const usedIdentifiers = new Set<string>();
-                      let sectionCount = 0;
-                      for (const [index, section] of (presetCmd.sections ?? []).entries()) {
-                        const groupId = section.groupName ? await ensureGroup(section.groupName) : null;
-                        await txPresets.createSection({
-                          presetId: createdPreset.id,
-                          identifier: normalizeAssistantPresetIdentifier(
-                            section.identifier ?? section.name,
-                            index,
-                            usedIdentifiers,
-                          ),
-                          name: section.name,
-                          content: section.content ?? "",
-                          role: resolveAssistantPresetRole(section.role),
-                          enabled: section.enabled ?? true,
-                          isMarker: false,
-                          groupId,
-                          markerConfig: null,
-                          injectionPosition: resolveAssistantPresetInjectionPosition(section.injectionPosition),
-                          injectionDepth: Math.max(0, section.injectionDepth ?? 0),
-                          injectionOrder: section.injectionOrder ?? (index + 1) * 100,
-                          forbidOverrides: section.forbidOverrides ?? false,
-                        });
-                        sectionCount += 1;
-                      }
-
-                      const usedVariableNames = new Set<string>();
-                      let choiceBlockCount = 0;
-                      for (const [index, choiceBlock] of (presetCmd.choiceBlocks ?? []).entries()) {
-                        const optionIds = new Set<string>();
-                        await txPresets.createChoiceBlock({
-                          presetId: createdPreset.id,
-                          variableName: normalizeAssistantPresetVariableName(
-                            choiceBlock.variableName,
-                            index,
-                            usedVariableNames,
-                          ),
-                          question: choiceBlock.question,
-                          options: choiceBlock.options.map((option, optionIndex) => ({
-                            id: normalizeAssistantPresetOptionId(option.id ?? option.label, optionIndex, optionIds),
-                            label: option.label,
-                            value: option.value,
-                          })),
-                          multiSelect: choiceBlock.multiSelect ?? false,
-                          separator: choiceBlock.separator ?? ", ",
-                          randomPick: choiceBlock.randomPick ?? false,
-                          displayMode: choiceBlock.displayMode ?? "auto",
-                          optionSort: choiceBlock.optionSort ?? "manual",
-                        });
-                        choiceBlockCount += 1;
-                      }
-
-                      return {
-                        id: createdPreset.id,
-                        name: presetCmd.name,
-                        sectionCount,
-                        choiceBlockCount,
-                      };
-                    });
-
-                    if (createdPresetAction) {
-                      reply.raw.write(
-                        `data: ${JSON.stringify({
-                          type: "assistant_action",
-                          data: {
-                            action: "preset_created",
-                            id: createdPresetAction.id,
-                            name: createdPresetAction.name,
-                            sectionCount: createdPresetAction.sectionCount,
-                            choiceBlockCount: createdPresetAction.choiceBlockCount,
-                          },
-                        })}\n\n`,
-                      );
-                      logger.info(
-                        '[commands] Assistant created preset: "%s" (%s), sections=%d choiceBlocks=%d',
-                        createdPresetAction.name,
-                        createdPresetAction.id,
-                        createdPresetAction.sectionCount,
-                        createdPresetAction.choiceBlockCount,
-                      );
-                    }
-                  } catch (err) {
-                    logger.error(err, "[commands] Create preset failed");
-                  }
-                }
-
-                if (command.type === "create_chat") {
-                  const ctCmd = command as CreateChatCommand;
-                  try {
-                    // Resolve character by name or ID
-                    const allCharsList = await chars.list();
-                    const targetChar = allCharsList.find((c: any) => {
-                      if (c.id === ctCmd.character) return true;
-                      const d = typeof c.data === "string" ? JSON.parse(c.data) : c.data;
-                      return normalizeTextForMatch(d.name) === normalizeTextForMatch(ctCmd.character);
-                    });
-                    if (targetChar) {
-                      const targetData =
-                        typeof targetChar.data === "string" ? JSON.parse(targetChar.data as string) : targetChar.data;
-                      const mode = ctCmd.mode ?? "conversation";
-                      const newChat = await chats.create({
-                        name: `Chat with ${targetData.name}`,
-                        mode,
-                        characterIds: [targetChar.id],
-                        groupId: null,
-                        personaId: null,
-                        promptPresetId: null,
-                        connectionId: null,
-                      });
-                      if (newChat) {
-                        reply.raw.write(
-                          `data: ${JSON.stringify({
-                            type: "assistant_action",
-                            data: {
-                              action: "chat_created",
-                              chatId: newChat.id,
-                              chatName: newChat.name ?? `Chat with ${targetData.name}`,
-                              mode,
-                              characterName: targetData.name,
-                            },
-                          })}\n\n`,
-                        );
-                        logger.info(
-                          `[commands] Assistant created ${mode} chat with "${targetData.name}" (${newChat.id})`,
-                        );
-                      }
-                    } else {
-                      logger.warn(`[commands] Create chat: character "${ctCmd.character}" not found`);
-                    }
-                  } catch (err) {
-                    logger.error(err, "[commands] Create chat failed");
-                  }
-                }
-
-                if (command.type === "navigate") {
-                  const navCmd = command as NavigateCommand;
-                  reply.raw.write(
-                    `data: ${JSON.stringify({
-                      type: "assistant_action",
-                      data: { action: "navigate", panel: navCmd.panel, tab: navCmd.tab ?? null },
-                    })}\n\n`,
-                  );
-                  logger.info(`[commands] Assistant navigate: panel=${navCmd.panel}, tab=${navCmd.tab ?? "none"}`);
-                }
-
-                // ── Fetch command (Professor Mari) ──
-                if (command.type === "fetch") {
-                  const fetchCmd = command as FetchCommand;
-                  try {
-                    let fetchedContent = "";
-                    const contextKey = `${fetchCmd.fetchType}:${fetchCmd.name}`;
-
-                    if (fetchCmd.fetchType === "character") {
-                      const allCharsList = await chars.list();
-                      const found = allCharsList.find((c: any) => {
-                        const d = typeof c.data === "string" ? JSON.parse(c.data) : c.data;
-                        return normalizeTextForMatch(d.name) === normalizeTextForMatch(fetchCmd.name);
-                      });
-                      if (found) {
-                        const d = typeof found.data === "string" ? JSON.parse(found.data as string) : found.data;
-                        const parts = [`Name: ${d.name}`];
-                        if (d.description) parts.push(`Description: ${d.description}`);
-                        if (d.personality) parts.push(`Personality: ${d.personality}`);
-                        if (d.scenario) parts.push(`Scenario: ${d.scenario}`);
-                        if (d.mes_example) parts.push(`Example Messages: ${d.mes_example}`);
-                        if (d.system_prompt) parts.push(`System Prompt: ${d.system_prompt}`);
-                        if (d.post_history_instructions) {
-                          parts.push(`Post-History Instructions: ${d.post_history_instructions}`);
-                        }
-                        if (d.first_mes) parts.push(`First Message: ${d.first_mes}`);
-                        if (d.creator_notes) parts.push(`Creator Notes: ${d.creator_notes}`);
-                        if (d.extensions?.appearance) parts.push(`Appearance: ${d.extensions.appearance}`);
-                        if (d.extensions?.backstory) parts.push(`Backstory: ${d.extensions.backstory}`);
-                        fetchedContent = parts.join("\n");
-                      }
-                    } else if (fetchCmd.fetchType === "persona") {
-                      const allPersonasList = await chars.listPersonas();
-                      const found = allPersonasList.find(
-                        (p: any) => normalizeTextForMatch(p.name) === normalizeTextForMatch(fetchCmd.name),
-                      );
-                      if (found) {
-                        const parts = [`Name: ${found.name}`];
-                        if (found.description) parts.push(`Description: ${found.description}`);
-                        if (found.personality) parts.push(`Personality: ${found.personality}`);
-                        if (found.scenario) parts.push(`Scenario: ${found.scenario}`);
-                        if (found.appearance) parts.push(`Appearance: ${found.appearance}`);
-                        if (found.backstory) parts.push(`Backstory: ${found.backstory}`);
-                        fetchedContent = parts.join("\n");
-                      }
-                    } else if (fetchCmd.fetchType === "lorebook") {
-                      const allLorebooks = await lorebooksStore.list();
-                      const found = (allLorebooks as any[]).find(
-                        (lb: any) => normalizeTextForMatch(lb.name) === normalizeTextForMatch(fetchCmd.name),
-                      );
-                      if (found) {
-                        const entries = await lorebooksStore.listEntries(found.id);
-                        const parts = [`Lorebook: ${found.name}`];
-                        if (found.description) parts.push(`Description: ${found.description}`);
-                        if (found.category) parts.push(`Category: ${found.category}`);
-                        parts.push(`Entries (${entries.length}):`);
-                        for (const entry of entries as any[]) {
-                          parts.push(
-                            `\n  Entry: ${entry.name}\n  Keys: ${(Array.isArray(entry.keys) ? entry.keys : []).join(", ")}\n  Content: ${entry.content}`,
-                          );
-                        }
-                        fetchedContent = parts.join("\n");
-                      }
-                    } else if (fetchCmd.fetchType === "chat") {
-                      const allChats = await chats.list();
-                      const found = (allChats as any[]).find(
-                        (c: any) => normalizeTextForMatch(c.name) === normalizeTextForMatch(fetchCmd.name),
-                      );
-                      if (found) {
-                        const parts = [`Chat: ${found.name}`, `Mode: ${found.mode}`];
-                        const recentMsgs = await chats.listMessagesPaginated(found.id, 20);
-                        if (recentMsgs.length > 0) {
-                          parts.push(`Recent Messages (${recentMsgs.length}):`);
-                          for (const msg of recentMsgs) {
-                            const role =
-                              msg.role === "assistant" ? (msg.characterId ? "Character" : "Assistant") : "User";
-                            parts.push(`  [${role}]: ${(msg.content as string).slice(0, 300)}`);
-                          }
-                        }
-                        fetchedContent = parts.join("\n");
-                      }
-                    } else if (fetchCmd.fetchType === "preset") {
-                      const allPresetsList = await presets.list();
-                      const found = (allPresetsList as any[]).find(
-                        (p: any) =>
-                          p.id === fetchCmd.name ||
-                          normalizeTextForMatch(p.name) === normalizeTextForMatch(fetchCmd.name),
-                      );
-                      if (found) {
-                        const sections = await presets.listSections(found.id);
-                        const groups = await presets.listGroups(found.id);
-                        const choiceBlocks = await presets.listChoiceBlocksForPreset(found.id);
-                        const groupById = new Map((groups as any[]).map((group: any) => [group.id, group]));
-                        const parameters = parseMariJsonRecord(found.parameters);
-                        const defaultChoices = parseMariJsonRecord(found.defaultChoices);
-                        const parts = [`Preset: ${found.name}`];
-                        parts.push(`ID: ${found.id}`);
-                        if (found.description) parts.push(`Description: ${found.description}`);
-                        if (found.author) parts.push(`Author: ${found.author}`);
-                        parts.push(`Wrap Format: ${found.wrapFormat ?? "xml"}`);
-                        parts.push(`Default Preset: ${String(found.isDefault) === "true" ? "yes" : "no"}`);
-                        if (Object.keys(parameters).length > 0) {
-                          parts.push(
-                            `Generation Parameters: ${truncateMariFetchedText(JSON.stringify(parameters), 1200)}`,
-                          );
-                        }
-                        if (Object.keys(defaultChoices).length > 0) {
-                          parts.push(
-                            `Default Choices: ${truncateMariFetchedText(JSON.stringify(defaultChoices), 1200)}`,
-                          );
-                        }
-                        if ((groups as any[]).length > 0) {
-                          parts.push(`Groups (${(groups as any[]).length}):`);
-                          for (const group of groups as any[]) {
-                            const parent = group.parentGroupId ? groupById.get(group.parentGroupId) : null;
-                            parts.push(
-                              `  - ${group.name} (enabled=${String(group.enabled) === "true" ? "true" : "false"}, order=${group.order}, parent=${parent?.name ?? "none"})`,
-                            );
-                          }
-                        }
-                        parts.push(`Sections (${sections.length}):`);
-                        for (const sec of sections) {
-                          const group = sec.groupId ? groupById.get(sec.groupId) : null;
-                          parts.push(
-                            [
-                              `\n  Section: ${sec.name ?? "Untitled"}`,
-                              `  Identifier: ${sec.identifier}`,
-                              `  Role: ${sec.role}`,
-                              `  Enabled: ${String(sec.enabled) === "true" ? "true" : "false"}`,
-                              `  Group: ${group?.name ?? "none"}`,
-                              `  Injection: ${sec.injectionPosition} depth=${sec.injectionDepth} order=${sec.injectionOrder}`,
-                              `  Forbid Overrides: ${String(sec.forbidOverrides) === "true" ? "true" : "false"}`,
-                              `  Content:\n${truncateMariFetchedText(sec.content, 3000)}`,
-                            ].join("\n"),
-                          );
-                        }
-                        if ((choiceBlocks as any[]).length > 0) {
-                          parts.push(`Choice Blocks (${(choiceBlocks as any[]).length}):`);
-                          for (const block of choiceBlocks as any[]) {
-                            const options = parseMariJsonArray(block.options)
-                              .map((option) => {
-                                const data = parseMariJsonRecord(option);
-                                return `${data.label ?? "Option"} => ${truncateMariFetchedText(data.value, 500)}`;
-                              })
-                              .join(" | ");
-                            parts.push(
-                              [
-                                `\n  Variable: ${block.variableName}`,
-                                `  Question: ${block.question}`,
-                                `  Multi Select: ${String(block.multiSelect) === "true" ? "true" : "false"}`,
-                                `  Random Pick: ${String(block.randomPick) === "true" ? "true" : "false"}`,
-                                `  Separator: ${block.separator ?? ", "}`,
-                                `  Options: ${options}`,
-                              ].join("\n"),
-                            );
-                          }
-                        }
-                        fetchedContent = truncateMariFetchedText(
-                          parts.join("\n"),
-                          MAX_MARI_FETCHED_PRESET_CONTEXT_CHARS,
-                        );
-                      }
-                    }
-
-                    if (fetchedContent) {
-                      // Persist to chatMeta.mariContext so it's available in subsequent messages.
-                      // Re-fetch fresh metadata so concurrent writes (e.g. /game/start) aren't clobbered.
-                      const freshChat = await chats.getById(input.chatId);
-                      const currentMeta = freshChat
-                        ? (parseExtra(freshChat.metadata) as Record<string, unknown>)
-                        : (parseExtra(chat.metadata) as Record<string, unknown>);
-                      const mariContext = (currentMeta.mariContext as Record<string, string>) ?? {};
-                      mariContext[contextKey] = fetchedContent;
-                      currentMeta.mariContext = mariContext;
-                      await chats.updateMetadata(input.chatId, currentMeta);
-
-                      // Record success for the follow-up trigger only for the
-                      // internal Home Professor Mari assistant. Legacy Mari
-                      // character chats should stay personality-only.
-                      if (
-                        isHomeProfessorMariAssistantChat &&
-                        (characterId === PROFESSOR_MARI_ID || characterId === null)
-                      ) {
-                        mariFetchSucceededThisIteration = true;
-                      }
-
-                      reply.raw.write(
-                        `data: ${JSON.stringify({
-                          type: "assistant_action",
-                          data: {
-                            action: "data_fetched",
-                            fetchType: fetchCmd.fetchType,
-                            name: fetchCmd.name,
-                          },
-                        })}\n\n`,
-                      );
-                      logger.info(`[commands] Assistant fetched ${fetchCmd.fetchType}: "${fetchCmd.name}"`);
-                    } else {
-                      logger.warn(`[commands] Fetch: ${fetchCmd.fetchType} "${fetchCmd.name}" not found`);
-                    }
-                  } catch (err) {
-                    logger.error(err, "[commands] Fetch failed");
-                  }
+                  },
+                });
+                if (professorMariResult.fetchSucceeded) {
+                  mariFetchSucceededThisIteration = true;
                 }
               } catch (cmdErr) {
                 logger.error(cmdErr, `[commands] Error processing ${command.type} command`);

--- a/packages/server/src/routes/generate/agent-result-capabilities.ts
+++ b/packages/server/src/routes/generate/agent-result-capabilities.ts
@@ -1,0 +1,53 @@
+import { customAgentHasCapability, type AgentResult } from "@marinara-engine/shared";
+
+import type { ResolvedAgent } from "../../services/agents/agent-pipeline.js";
+
+export function findResultAgent(result: AgentResult, agents: ResolvedAgent[]): ResolvedAgent | null {
+  return agents.find((agent) => agent.id === result.agentId || agent.type === result.agentType) ?? null;
+}
+
+export function isAbortLikeError(error: unknown): boolean {
+  return error instanceof Error && error.name === "AbortError";
+}
+
+export function customAgentCanApplyResult(
+  result: AgentResult,
+  agents: ResolvedAgent[],
+  builtInAgentTypes: Set<string>,
+  capability: Parameters<typeof customAgentHasCapability>[1],
+): boolean {
+  if (builtInAgentTypes.has(result.agentType)) return true;
+  const agent = findResultAgent(result, agents);
+  return agent ? customAgentHasCapability(agent.settings, capability) : false;
+}
+
+export function customAgentCanEmitResult(
+  result: AgentResult,
+  agents: ResolvedAgent[],
+  builtInAgentTypes: Set<string>,
+): boolean {
+  if (builtInAgentTypes.has(result.agentType)) return true;
+  switch (result.type) {
+    case "text_rewrite":
+      return customAgentCanApplyResult(result, agents, builtInAgentTypes, "edit_messages");
+    case "lorebook_update":
+      return (
+        customAgentCanApplyResult(result, agents, builtInAgentTypes, "edit_lorebooks") ||
+        customAgentCanApplyResult(result, agents, builtInAgentTypes, "create_lorebooks")
+      );
+    case "game_state_update":
+    case "character_tracker_update":
+    case "persona_stats_update":
+    case "custom_tracker_update":
+    case "quest_update":
+      return customAgentCanApplyResult(result, agents, builtInAgentTypes, "edit_trackers");
+    case "image_prompt":
+      return customAgentCanApplyResult(result, agents, builtInAgentTypes, "trigger_image_generation");
+    case "prompt_patch":
+      return customAgentCanApplyResult(result, agents, builtInAgentTypes, "edit_main_prompt");
+    case "frontend_theme_update":
+      return customAgentCanApplyResult(result, agents, builtInAgentTypes, "change_frontend_styling");
+    default:
+      return true;
+  }
+}

--- a/packages/server/src/routes/generate/connected-conversation-injections.ts
+++ b/packages/server/src/routes/generate/connected-conversation-injections.ts
@@ -1,0 +1,108 @@
+import type { ChatMode } from "@marinara-engine/shared";
+
+import { stripConversationPromptTimestamps } from "../../services/conversation/transcript-sanitize.js";
+
+type PromptMessage = {
+  role: "system" | "user" | "assistant";
+  content: string;
+  [key: string]: unknown;
+};
+
+type ConnectedConversationStore = {
+  listPendingInfluences(chatId: string): Promise<Array<{ id: string; content?: unknown }>>;
+  markInfluenceConsumed(id: string): Promise<unknown>;
+  listNotes(chatId: string): Promise<Array<{ content?: unknown }>>;
+  getById(chatId: string): Promise<{ mode?: string | null; name?: string | null } | null>;
+};
+
+function injectBeforeLastUser(messages: PromptMessage[], content: string): void {
+  const lastUserIdx = messages.map((m) => m.role).lastIndexOf("user");
+  if (lastUserIdx >= 0) {
+    messages.splice(lastUserIdx, 0, { role: "system", content });
+  } else {
+    messages.push({ role: "system", content });
+  }
+}
+
+export async function injectConnectedConversationPromptBlocks(args: {
+  chatMode: ChatMode;
+  connectedChatId: unknown;
+  isSceneChat: boolean;
+  chatId: string;
+  chats: ConnectedConversationStore;
+  finalMessages: PromptMessage[];
+}): Promise<void> {
+  const { chatMode, connectedChatId, isSceneChat, chatId, chats, finalMessages } = args;
+  if ((chatMode === "roleplay" || chatMode === "game") && connectedChatId && !isSceneChat) {
+    const pendingInfluences = await chats.listPendingInfluences(chatId);
+    if (pendingInfluences.length > 0) {
+      const influenceLines = pendingInfluences
+        .map((inf) => stripConversationPromptTimestamps(String(inf.content ?? "")))
+        .filter((content) => content.length > 0)
+        .map((content) => `- ${content}`);
+
+      if (influenceLines.length > 0) {
+        const influenceBlock = [
+          `<ooc_influences>`,
+          chatMode === "game"
+            ? `The following out-of-character notes come from a connected conversation. They represent things the players discussed or decided outside the game. Use them to steer the next scene, NPC reactions, objectives, or world state when appropriate — don't mention them explicitly as "OOC" in the narrative.`
+            : `The following out-of-character notes come from a connected conversation. They represent things the players discussed or decided outside of the roleplay. Weave them naturally into the story — don't mention them explicitly as "OOC" in the narrative.`,
+          ...influenceLines,
+          `</ooc_influences>`,
+        ].join("\n");
+
+        injectBeforeLastUser(finalMessages, influenceBlock);
+      }
+
+      for (const inf of pendingInfluences) {
+        await chats.markInfluenceConsumed(inf.id);
+      }
+    }
+  }
+
+  if ((chatMode === "roleplay" || chatMode === "game") && connectedChatId && !isSceneChat) {
+    const persistentNotes = await chats.listNotes(chatId);
+    if (persistentNotes.length > 0) {
+      const noteLines = persistentNotes
+        .map((n) => stripConversationPromptTimestamps(String(n.content ?? "")))
+        .filter((content) => content.length > 0)
+        .map((content) => `- ${content}`);
+
+      if (noteLines.length > 0) {
+        const noteBlock = [
+          `<conversation_notes>`,
+          chatMode === "game"
+            ? `Durable notes from a connected conversation. These persist across every turn until the user clears them and represent things the players have established as ongoing truth — character knowledge, world facts, recurring dynamics. Use them to inform NPC behavior, world state, and scene framing — don't reference them explicitly as "notes" in the narrative.`
+            : `Durable notes from a connected conversation. These persist across every turn until the user clears them and represent things the character has been told to durably remember about themselves, the user, or the world. Use them to inform behavior, knowledge, and reactions naturally — don't reference them explicitly as "notes" in the narrative.`,
+          ...noteLines,
+          `</conversation_notes>`,
+        ].join("\n");
+
+        injectBeforeLastUser(finalMessages, noteBlock);
+      }
+    }
+  }
+
+  if (chatMode === "roleplay" && connectedChatId && !isSceneChat) {
+    const convChat = await chats.getById(connectedChatId as string);
+    if (convChat && convChat.mode === "conversation") {
+      const oocInstruction = [
+        `<ooc_instruction>`,
+        `You have a connected out-of-character conversation: "${convChat.name}".`,
+        `If a character wants to break the fourth wall and comment on something happening in the roleplay, post a reaction, or chat casually with the user "outside" the story, they can use an <ooc> tag:`,
+        `<ooc>casual comment or reaction about what just happened in the RP</ooc>`,
+        ``,
+        `The <ooc> text is stripped from the roleplay response and posted as a message in the conversation chat.`,
+        `Use this very sparingly — only when a character would genuinely want to comment out-of-character. Most RP responses should NOT include <ooc> tags.`,
+        `</ooc_instruction>`,
+      ].join("\n");
+
+      const firstSysIdx = finalMessages.findIndex((m) => m.role === "system");
+      if (firstSysIdx >= 0) {
+        finalMessages.splice(firstSysIdx + 1, 0, { role: "system", content: oocInstruction });
+      } else {
+        finalMessages.unshift({ role: "system", content: oocInstruction });
+      }
+    }
+  }
+}

--- a/packages/server/src/routes/generate/conversation-connected-context.ts
+++ b/packages/server/src/routes/generate/conversation-connected-context.ts
@@ -1,0 +1,226 @@
+import { sanitizeConnectedGameTranscript } from "../../services/generation/generation-text-utils.js";
+import { isConversationCommandEnabled } from "../../services/generation/conversation-command-runtime.js";
+import { parseGameStateRow } from "./generate-route-utils.js";
+
+type ConnectedChatRow = {
+  id: string;
+  name?: string | null;
+  mode?: string | null;
+  characterIds?: unknown;
+  metadata?: unknown;
+};
+
+type ConnectedChatMessage = {
+  role?: string | null;
+  characterId?: string | null;
+  content?: unknown;
+};
+
+type ConnectedCharacterRow = {
+  data?: unknown;
+};
+
+type ConnectedChatsStore = {
+  getById(id: string): Promise<ConnectedChatRow | null>;
+  listMessages(chatId: string): Promise<ConnectedChatMessage[]>;
+};
+
+type ConnectedCharactersStore = {
+  getById(id: string): Promise<ConnectedCharacterRow | null>;
+};
+
+type ConnectedGameStateStore = {
+  getLatestCommitted(chatId: string): Promise<Record<string, unknown> | null>;
+  getLatest(chatId: string): Promise<Record<string, unknown> | null>;
+};
+
+export async function resolveConversationConnectedChatContext(args: {
+  connectedChatId: unknown;
+  conversationCommandsEnabled: boolean;
+  chatMeta: Record<string, unknown>;
+  personaName: string;
+  chats: ConnectedChatsStore;
+  chars: ConnectedCharactersStore;
+  gameStateStore: ConnectedGameStateStore;
+}): Promise<{ connectedChatBlock: string | null; systemPromptAppend: string | null }> {
+  if (!args.connectedChatId) return { connectedChatBlock: null, systemPromptAppend: null };
+
+  let connectedChatBlock: string | null = null;
+  let systemPromptAppend: string | null = null;
+  const connectedInfluenceCommandEnabled =
+    args.conversationCommandsEnabled && isConversationCommandEnabled(args.chatMeta, "influence");
+  const connectedNoteCommandEnabled =
+    args.conversationCommandsEnabled && isConversationCommandEnabled(args.chatMeta, "note");
+  const connectedChat = await args.chats.getById(args.connectedChatId as string);
+
+  if (connectedChat && connectedChat.mode === "roleplay") {
+    const rpMessages = await args.chats.listMessages(connectedChat.id);
+    const recentRp = rpMessages.slice(-20);
+
+    const rpCharIds: string[] =
+      typeof connectedChat.characterIds === "string"
+        ? JSON.parse(connectedChat.characterIds as string)
+        : (connectedChat.characterIds as string[]);
+    const rpCharNames = new Map<string, string>();
+    for (const cid of rpCharIds) {
+      const row = await args.chars.getById(cid);
+      if (row) {
+        const d = JSON.parse(row.data as string);
+        rpCharNames.set(cid, d.name ?? "Unknown");
+      }
+    }
+
+    const rpLines: string[] = [`<connected_roleplay name="${connectedChat.name}">`];
+    rpLines.push(`<recent_messages>`);
+    for (const m of recentRp) {
+      const speaker =
+        m.role === "user"
+          ? args.personaName
+          : m.characterId
+            ? (rpCharNames.get(m.characterId) ?? "Character")
+            : "Narrator";
+      rpLines.push(`[${speaker}]: ${(m.content as string).slice(0, 500)}`);
+    }
+    rpLines.push(`</recent_messages>`);
+    rpLines.push(`</connected_roleplay>`);
+
+    connectedChatBlock = rpLines.join("\n");
+
+    if (connectedInfluenceCommandEnabled || connectedNoteCommandEnabled) {
+      const connectedInstructionLines = [
+        `<connected_roleplay_instructions>`,
+        `You have access to context from a connected roleplay: "${connectedChat.name}".`,
+        `Recent messages from that roleplay are provided so you can naturally reference or discuss events happening there.`,
+      ];
+      if (connectedInfluenceCommandEnabled) {
+        connectedInstructionLines.push(
+          ``,
+          `If something said in THIS conversation should affect or influence the roleplay, you can create an influence tag:`,
+          `<influence>description of what should happen or change in the roleplay based on this conversation</influence>`,
+          `Example: if the user says "tell ${rpCharNames.values().next().value ?? "them"} to meet us at the tavern", you could respond normally AND include:`,
+          `<influence>The group discussed meeting at the tavern. ${args.personaName} wants everyone to head there.</influence>`,
+          ``,
+          `Influences are injected into the roleplay's context before the next generation. Use them sparingly; only when conversation content genuinely should cross over into the roleplay.`,
+          `The influence tag is stripped from your visible message. The rest of your response is shown normally.`,
+        );
+      }
+      if (connectedNoteCommandEnabled) {
+        connectedInstructionLines.push(
+          ``,
+          `If something said in this conversation should durably persist in the roleplay's context across many turns (a fact the character should keep remembering, a promise made, a secret revealed, a name learned), create a note tag instead of an influence:`,
+          `<note>fact, decision, or detail the roleplay character should keep remembering</note>`,
+          `Notes are shown to the roleplay character on every future turn until the user clears them. Use influences for one-shot mid-scene steering; use notes for things that should remain true going forward. Use notes sparingly; every saved note costs prompt budget on every roleplay turn.`,
+          `The note tag is stripped from your visible message.`,
+        );
+      }
+      connectedInstructionLines.push(`</connected_roleplay_instructions>`);
+      systemPromptAppend = connectedInstructionLines.join("\n");
+    }
+  } else if (connectedChat && connectedChat.mode === "game") {
+    const gameMeta =
+      typeof connectedChat.metadata === "string"
+        ? JSON.parse(connectedChat.metadata)
+        : (connectedChat.metadata ?? {});
+    const sessionNumber = (gameMeta.gameSessionNumber as number) ?? 1;
+    const sessionStatus = (gameMeta.gameSessionStatus as string) ?? "setup";
+    const activeState = (gameMeta.gameActiveState as string) ?? "exploration";
+    const storedSummaries = Array.isArray(gameMeta.gamePreviousSessionSummaries)
+      ? (gameMeta.gamePreviousSessionSummaries as Array<{
+          summary?: string;
+          resumePoint?: string;
+          partyDynamics?: string;
+          keyDiscoveries?: string[];
+        }>)
+      : [];
+    const latestSummary = storedSummaries[storedSummaries.length - 1] ?? null;
+    const gameMessages = await args.chats.listMessages(connectedChat.id);
+    const recentGame = gameMessages.slice(-20);
+    const latestConnectedState =
+      (await args.gameStateStore.getLatestCommitted(connectedChat.id)) ??
+      (await args.gameStateStore.getLatest(connectedChat.id));
+    const linkedGameState = latestConnectedState ? parseGameStateRow(latestConnectedState) : null;
+
+    const gameLines: string[] = [`<connected_game name="${connectedChat.name}">`];
+    gameLines.push(`<status>Session ${sessionNumber} (${sessionStatus}), state: ${activeState}</status>`);
+    if (linkedGameState) {
+      const sceneDetails = [
+        linkedGameState.location ? `Location: ${linkedGameState.location}` : null,
+        linkedGameState.time ? `Time: ${linkedGameState.time}` : null,
+        linkedGameState.date ? `Date: ${linkedGameState.date}` : null,
+        linkedGameState.weather ? `Weather: ${linkedGameState.weather}` : null,
+        linkedGameState.temperature ? `Temperature: ${linkedGameState.temperature}` : null,
+      ].filter(Boolean);
+      if (sceneDetails.length > 0) {
+        gameLines.push(`<scene>${sceneDetails.join(" | ")}</scene>`);
+      }
+      if (linkedGameState.presentCharacters.length > 0) {
+        gameLines.push(
+          `<present_characters>${linkedGameState.presentCharacters.map((c) => c.name).join(", ")}</present_characters>`,
+        );
+      }
+      if (linkedGameState.recentEvents.length > 0) {
+        gameLines.push(`<recent_events>`);
+        for (const event of linkedGameState.recentEvents.slice(-5)) {
+          gameLines.push(`- ${event.slice(0, 300)}`);
+        }
+        gameLines.push(`</recent_events>`);
+      }
+    }
+    if (latestSummary?.summary) {
+      gameLines.push(`<latest_session_summary>${latestSummary.summary}</latest_session_summary>`);
+      if (latestSummary.resumePoint) {
+        gameLines.push(`<resume_point>${latestSummary.resumePoint}</resume_point>`);
+      }
+      if (latestSummary.partyDynamics) {
+        gameLines.push(`<party_dynamics>${latestSummary.partyDynamics}</party_dynamics>`);
+      }
+      if (Array.isArray(latestSummary.keyDiscoveries) && latestSummary.keyDiscoveries.length > 0) {
+        gameLines.push(`<key_discoveries>${latestSummary.keyDiscoveries.join("; ")}</key_discoveries>`);
+      }
+    }
+    gameLines.push(`<recent_messages>`);
+    for (const m of recentGame) {
+      const speaker = m.role === "user" ? args.personaName : m.role === "narrator" ? "Narrator" : "Game Master";
+      const content = sanitizeConnectedGameTranscript(m.content as string);
+      if (!content) continue;
+      gameLines.push(`[${speaker}]: ${content.slice(0, 500)}`);
+    }
+    gameLines.push(`</recent_messages>`);
+    gameLines.push(`</connected_game>`);
+
+    connectedChatBlock = gameLines.join("\n");
+
+    if (connectedInfluenceCommandEnabled || connectedNoteCommandEnabled) {
+      const connectedInstructionLines = [
+        `<connected_game_instructions>`,
+        `You have access to context from a connected game: "${connectedChat.name}".`,
+        `The current scene, session summary, and recent game messages are provided so you can naturally answer questions or comment on what is happening in that game.`,
+      ];
+      if (connectedInfluenceCommandEnabled) {
+        connectedInstructionLines.push(
+          ``,
+          `If something said in THIS conversation should affect or influence the game, you can create an influence tag:`,
+          `<influence>description of what should happen or change in the game based on this conversation</influence>`,
+          `Example: if the group agrees they want to visit the merchant district next, you could respond normally AND include:`,
+          `<influence>The group agreed they want to head to the merchant district next and look for supplies.</influence>`,
+          ``,
+          `Influences are injected into the game's context before the next generation. Use them sparingly; only when conversation content genuinely should cross over into the game.`,
+          `The influence tag is stripped from your visible message. The rest of your response is shown normally.`,
+        );
+      }
+      if (connectedNoteCommandEnabled) {
+        connectedInstructionLines.push(
+          ``,
+          `If something said in this conversation should durably persist in the game's context across many turns (an established world fact, an ongoing party dynamic, a recurring NPC trait, a secret the GM should keep remembering), create a note tag instead of an influence:`,
+          `<note>fact, decision, or detail the game should keep remembering</note>`,
+          `Notes are shown to the game on every future turn until the user clears them. Use influences for one-shot mid-scene steering; use notes for things that should remain true going forward. Use notes sparingly; every saved note costs prompt budget on every game turn.`,
+          `The note tag is stripped from your visible message.`,
+        );
+      }
+      connectedInstructionLines.push(`</connected_game_instructions>`);
+      systemPromptAppend = connectedInstructionLines.join("\n");
+    }
+  }
+
+  return { connectedChatBlock, systemPromptAppend };
+}

--- a/packages/server/src/routes/generate/conversation-context-block.ts
+++ b/packages/server/src/routes/generate/conversation-context-block.ts
@@ -1,0 +1,129 @@
+import { normalizeTextForMatch, type WrapFormat } from "@marinara-engine/shared";
+
+import { getIntentHint, isMessageIntent } from "../../services/conversation/intent.service.js";
+import {
+  formatZonedConversationDate,
+  formatZonedConversationTime,
+  getZonedWeekdayName,
+} from "../../services/conversation/timezone.js";
+import { wrapContent } from "../../services/prompt/format-engine.js";
+
+type ConversationContextCharacter = {
+  name: string;
+  status: string;
+  activity: string;
+  todaySchedule?: string | null;
+};
+
+type PromptRoleMessage = {
+  role: string;
+};
+
+export function buildConversationCurrentContextBlock(args: {
+  nowInstant: Date;
+  promptTimeZone?: string;
+  convoCharInfo: ConversationContextCharacter[];
+  finalMessages: PromptRoleMessage[];
+  personaName: string;
+  userMessage?: string | null;
+  userStatus?: string | null;
+  userActivity?: string | null;
+  mentionedCharacterNames?: string[] | null;
+  autonomousIntentKey?: unknown;
+  isGroup: boolean;
+  earlyGroupMode: string;
+  wrapFormat: WrapFormat;
+}): string {
+  const timeStr = formatZonedConversationTime(args.nowInstant, args.promptTimeZone);
+  const dateStr = formatZonedConversationDate(args.nowInstant, args.promptTimeZone);
+  const dayName = getZonedWeekdayName(args.nowInstant, args.promptTimeZone);
+
+  const scheduleLines: string[] = [];
+  for (const character of args.convoCharInfo) {
+    if (character.todaySchedule) {
+      const prefix =
+        args.convoCharInfo.length > 1
+          ? `${character.name}'s schedule today (${dayName}): `
+          : `Your schedule today (${dayName}): `;
+      scheduleLines.push(prefix + character.todaySchedule);
+    }
+  }
+
+  const statusLine = buildConversationStatusLine(args.convoCharInfo);
+
+  const userStatusLabels: Record<string, string> = {
+    active: "active",
+    idle: "idle / away from the computer",
+    dnd: "do not disturb",
+  };
+  const shouldIncludeUserStatus = args.userStatus !== "invisible";
+  const userStatusLabel = userStatusLabels[args.userStatus ?? "active"] ?? "active";
+  const userActivity = args.userActivity?.replace(/\s+/g, " ").trim().slice(0, 120) ?? "";
+  const userStatusLine = userActivity ? `${userStatusLabel} - ${userActivity}` : userStatusLabel;
+
+  const mentionLine = buildMentionLine({
+    mentionedCharacterNames: args.mentionedCharacterNames,
+    convoCharInfo: args.convoCharInfo,
+    personaName: args.personaName,
+  });
+
+  const latestVisiblePromptTurn = [...args.finalMessages]
+    .reverse()
+    .find((message) => message.role === "user" || message.role === "assistant");
+  const proactiveTurnLine =
+    latestVisiblePromptTurn?.role === "assistant" && !args.userMessage?.trim()
+      ? `No new message from ${args.personaName} was sent in this request; this is a proactive/autonomous turn. Do not write ${args.personaName}'s side of the conversation.`
+      : null;
+  const autonomousIntentKey = typeof args.autonomousIntentKey === "string" ? args.autonomousIntentKey : "";
+  const intentHint = isMessageIntent(autonomousIntentKey) ? getIntentHint(autonomousIntentKey) : "";
+
+  const contextLines = [
+    `Your current status: ${statusLine}.`,
+    ...(shouldIncludeUserStatus ? [`${args.personaName}'s status: ${userStatusLine}.`] : []),
+    ...(proactiveTurnLine ? [proactiveTurnLine] : []),
+    ...(mentionLine ? [mentionLine] : []),
+    ...(intentHint ? [`What prompted this message: ${intentHint}`] : []),
+    ...scheduleLines,
+    `The current time and date: ${timeStr}, ${dateStr}.`,
+    ...(args.isGroup && args.earlyGroupMode !== "individual"
+      ? [`- Remember to prefix messages with \`Name: message\`!`]
+      : []),
+  ];
+
+  return wrapContent(contextLines.join("\n"), "Context", args.wrapFormat);
+}
+
+function buildConversationStatusLine(convoCharInfo: ConversationContextCharacter[]): string {
+  const statusLabels: Record<string, string> = {
+    online: "online and active",
+    idle: "idle / away",
+    dnd: "busy / do not disturb",
+    offline: "offline",
+  };
+  const buildCharStatus = (character: ConversationContextCharacter) => {
+    const label = statusLabels[character.status] ?? "online and active";
+    return character.activity ? `${label} (${character.activity})` : label;
+  };
+  return convoCharInfo.length === 1
+    ? buildCharStatus(convoCharInfo[0]!)
+    : convoCharInfo.map((character) => `${character.name}: ${buildCharStatus(character)}`).join("; ");
+}
+
+function buildMentionLine(args: {
+  mentionedCharacterNames?: string[] | null;
+  convoCharInfo: ConversationContextCharacter[];
+  personaName: string;
+}): string | null {
+  const mentionedNames = (args.mentionedCharacterNames ?? []).filter((name) =>
+    args.convoCharInfo.some((character) => normalizeTextForMatch(character.name) === normalizeTextForMatch(name)),
+  );
+  if (mentionedNames.length === 0) return null;
+
+  if (args.convoCharInfo.length === 1) {
+    return `${args.personaName} @mentioned you directly — treat this as an urgent ping that demands your attention even if you are busy or away.`;
+  }
+
+  return `${args.personaName} @mentioned: ${mentionedNames.join(", ")} — this is an urgent ping directed at ${
+    mentionedNames.length === 1 ? "that person" : "those people"
+  } specifically. The mentioned character(s) should feel compelled to respond promptly even if busy or away.`;
+}

--- a/packages/server/src/routes/generate/conversation-custom-assets.ts
+++ b/packages/server/src/routes/generate/conversation-custom-assets.ts
@@ -1,0 +1,680 @@
+import {
+  normalizeCustomEmojiSelection,
+  normalizeTextForMatch,
+  parseGroupedSpeakerSegments,
+  type CustomEmojiSelectionPrefs,
+  type GroupedSegment,
+  type MessageReaction,
+} from "@marinara-engine/shared";
+
+import { logger } from "../../lib/logger.js";
+import { cosineSimilarity } from "../../services/lorebook/embeddings.js";
+import { isLocalEmbedderAvailable, localEmbed } from "../../services/local-embedder.js";
+import { createLLMProvider } from "../../services/llm/provider-registry.js";
+import type { GenerationPromptMessage } from "../../services/generation/prompt-message-scope.js";
+import type { createConnectionsStorage } from "../../services/storage/connections.storage.js";
+import { appendToFirstSystemMessage, latestHistoryUserContent } from "./conversation-prompt-formatting.js";
+import { resolveBaseUrl } from "./generate-route-utils.js";
+
+type NamedAssetRow = {
+  name?: unknown;
+  filePath?: unknown;
+};
+
+type GalleryAssetRow = {
+  customKind?: unknown;
+  customName?: unknown;
+  filePath?: unknown;
+};
+
+type ConversationCustomAssetStore = {
+  list(): Promise<NamedAssetRow[]>;
+};
+
+type GalleryAssetStore = {
+  listByPersonaId?(personaId: string): Promise<GalleryAssetRow[]>;
+  listByCharacterId?(characterId: string): Promise<GalleryAssetRow[]>;
+};
+
+type ConversationAssetCharacter = {
+  id: string;
+  name: string;
+};
+
+/** Fisher-Yates shuffle (in place); used for random emoji selection. */
+function shuffleInPlace<T>(items: T[]): T[] {
+  for (let i = items.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    const tmp = items[i]!;
+    items[i] = items[j]!;
+    items[j] = tmp;
+  }
+  return items;
+}
+
+/** Order emoji names by semantic relevance to `query` via the local embedder. Returns null when unavailable. */
+async function rankEmojiNamesBySemantic(names: string[], query: string): Promise<string[] | null> {
+  if (names.length <= 1 || !query.trim() || !isLocalEmbedderAvailable()) return null;
+  try {
+    const vectors = await localEmbed([query, ...names.map((name) => name.replace(/_/g, " "))]);
+    if (!vectors || vectors.length !== names.length + 1) return null;
+    const queryVector = vectors[0]!;
+    return names
+      .map((name, index) => ({ name, score: cosineSimilarity(queryVector, vectors[index + 1]!) }))
+      .sort((a, b) => b.score - a.score)
+      .map((entry) => entry.name);
+  } catch (err) {
+    logger.debug(err, "[custom-emoji] semantic ranking failed; falling back to random");
+    return null;
+  }
+}
+
+/** Order a pool of emoji names per the selection mode (does NOT cap; the formatter slices to maxCount). */
+export async function orderEmojiNames(
+  names: string[],
+  prefs: CustomEmojiSelectionPrefs,
+  query: string,
+): Promise<string[]> {
+  if (names.length <= 1) return names;
+  // Reached for random/semantic, and as the tool-call fallback path: rank semantically when possible.
+  if (prefs.mode === "semantic" || prefs.mode === "tool-call") {
+    const ranked = await rankEmojiNamesBySemantic(names, query);
+    if (ranked) return ranked;
+  }
+  return shuffleInPlace([...names]);
+}
+
+/**
+ * Tool-call selection: one short auxiliary completion (on the chosen connection)
+ * picks which candidate asset names fit the latest message. Returns the validated
+ * picks (<= maxCount), or null on any failure so the caller can fall back to
+ * semantic/random. Never throws: generation must not depend on it.
+ */
+export async function selectCustomAssetNamesByToolCall(
+  assetLabel: string,
+  tokenExample: string,
+  candidates: string[],
+  query: string,
+  connectionId: string,
+  connections: ReturnType<typeof createConnectionsStorage>,
+  maxCount: number,
+): Promise<string[] | null> {
+  if (candidates.length === 0 || !query.trim()) return null;
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(new Error("custom-emoji tool-call timeout")), 5000);
+  try {
+    const conn = await connections.getWithKey(connectionId);
+    if (!conn?.model) return null;
+    const provider = createLLMProvider(
+      conn.provider,
+      resolveBaseUrl(conn),
+      conn.apiKey,
+      conn.maxContext,
+      conn.openrouterProvider,
+      conn.maxTokensOverride,
+    );
+    const result = await provider.chatComplete(
+      [
+        {
+          role: "system",
+          content:
+            `You select which custom ${assetLabel}s fit the current moment in a chat. You receive a list of available ${assetLabel} names and the latest message. ` +
+            `Reply with ONLY a comma-separated list of at most ${maxCount} names taken verbatim from the list (most fitting first), or "none". No other text. Do not include ${tokenExample} syntax.`,
+        },
+        {
+          role: "user",
+          content: `Available custom ${assetLabel}s: ${candidates.join(", ")}\n\nLatest message: "${query}"\n\nFitting ${assetLabel} names:`,
+        },
+      ],
+      { model: conn.model, temperature: 0.3, maxTokens: 200, signal: controller.signal },
+    );
+    const text = (result.content ?? "").toLowerCase().trim();
+    if (text.replace(/[^a-z0-9_]/g, "") === "none") return [];
+    const candidateSet = new Set(candidates);
+    const picked: string[] = [];
+    for (const token of text.split(/[\s,]+/)) {
+      const name = token.replace(/[^a-z0-9_]/g, "");
+      if (name && candidateSet.has(name) && !picked.includes(name)) {
+        picked.push(name);
+        if (picked.length >= maxCount) break;
+      }
+    }
+    return picked.length > 0 ? picked : null;
+  } catch (err) {
+    logger.debug(err, "[custom-%s] tool-call selection failed; falling back to semantic/random", assetLabel);
+    return null;
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+export function uniqueEmojiNames(names: Array<string | null | undefined>): string[] {
+  const seen = new Set<string>();
+  const result: string[] = [];
+  for (const raw of names) {
+    const name = typeof raw === "string" ? raw.trim() : "";
+    if (!name || seen.has(name)) continue;
+    seen.add(name);
+    result.push(name);
+  }
+  return result;
+}
+
+export async function appendConversationCustomAssetAdvertisements(args: {
+  chatMode: string;
+  mentionedCharacterNames: string[] | undefined;
+  promptTargetCharacterId: string | null | undefined;
+  charInfo: ConversationAssetCharacter[];
+  personaId: string | null | undefined;
+  chatMeta: Record<string, unknown>;
+  finalMessages: GenerationPromptMessage[];
+  currentUserInputContent: () => string | undefined;
+  customEmojisStore: ConversationCustomAssetStore;
+  customStickersStore: ConversationCustomAssetStore;
+  personaGallery: Required<Pick<GalleryAssetStore, "listByPersonaId">>;
+  characterGallery: Required<Pick<GalleryAssetStore, "listByCharacterId">>;
+  connections: ReturnType<typeof createConnectionsStorage>;
+  conversationCustomEmojiUrlByName: Map<string, string>;
+}): Promise<void> {
+  if (args.chatMode !== "conversation") return;
+
+  const mentionedNames = new Set(
+    (args.mentionedCharacterNames ?? [])
+      .map((name: string) => normalizeTextForMatch(name))
+      .filter((name: string) => name.length > 0),
+  );
+  const scopedResponders = args.promptTargetCharacterId
+    ? args.charInfo.filter((character) => character.id === args.promptTargetCharacterId)
+    : mentionedNames.size > 0
+      ? args.charInfo.filter((character) => mentionedNames.has(normalizeTextForMatch(character.name)))
+      : args.charInfo;
+  const respondingConversationChars = (scopedResponders.length > 0 ? scopedResponders : args.charInfo).map(
+    (character) => ({
+      charId: character.id,
+      name: character.name,
+    }),
+  );
+
+  const [globalEmojiRows, globalStickerRows, personaAssetRows] = await Promise.all([
+    args.customEmojisStore.list(),
+    args.customStickersStore.list(),
+    args.personaId ? args.personaGallery.listByPersonaId(args.personaId) : Promise.resolve([]),
+  ]);
+  for (const emoji of globalEmojiRows) {
+    if (emoji.name && emoji.filePath) {
+      args.conversationCustomEmojiUrlByName.set(
+        buildConversationCustomEmojiKey("global", null, String(emoji.name)),
+        buildGlobalCustomEmojiUrl(String(emoji.filePath)),
+      );
+    }
+  }
+  if (args.personaId) {
+    for (const img of personaAssetRows) {
+      if (img.customKind === "emoji" && img.customName && img.filePath) {
+        args.conversationCustomEmojiUrlByName.set(
+          buildConversationCustomEmojiKey("persona", args.personaId, String(img.customName)),
+          buildPersonaGalleryEmojiUrl(args.personaId, getStoredFilename(String(img.filePath))),
+        );
+      }
+    }
+  }
+  const personaEmojiNames = uniqueEmojiNames(
+    personaAssetRows
+      .filter((img) => img.customKind === "emoji" && img.customName)
+      .map((img) => img.customName as string),
+  );
+  const personaStickerNames = uniqueEmojiNames(
+    personaAssetRows
+      .filter((img) => img.customKind === "sticker" && img.customName)
+      .map((img) => img.customName as string),
+  );
+  const sharedEmojiNames = uniqueEmojiNames([
+    ...personaEmojiNames,
+    ...globalEmojiRows.map((emoji) => emoji.name as string),
+  ]);
+  const sharedStickerNames = uniqueEmojiNames([
+    ...personaStickerNames,
+    ...globalStickerRows.map((sticker) => sticker.name as string),
+  ]);
+  const ownEmojisByChar = new Map<string, string[]>();
+  const ownStickersByChar = new Map<string, string[]>();
+  for (const info of respondingConversationChars) {
+    const images = await args.characterGallery.listByCharacterId(info.charId);
+    const emojiNames = uniqueEmojiNames(
+      images
+        .filter((img) => img.customKind === "emoji" && img.customName)
+        .map((img) => img.customName as string),
+    );
+    for (const img of images) {
+      if (img.customKind === "emoji" && img.customName && img.filePath) {
+        args.conversationCustomEmojiUrlByName.set(
+          String(img.customName),
+          buildCharacterGalleryEmojiUrl(info.charId, getStoredFilename(String(img.filePath))),
+        );
+      }
+    }
+    const stickerNames = uniqueEmojiNames(
+      images
+        .filter((img) => img.customKind === "sticker" && img.customName)
+        .map((img) => img.customName as string),
+    );
+    if (emojiNames.length > 0) ownEmojisByChar.set(info.charId, emojiNames);
+    if (stickerNames.length > 0) ownStickersByChar.set(info.charId, stickerNames);
+  }
+
+  const assetQuery = latestHistoryUserContent(args.finalMessages) || args.currentUserInputContent() || "";
+
+  if (sharedEmojiNames.length > 0 || ownEmojisByChar.size > 0) {
+    const emojiPrefs = normalizeCustomEmojiSelection(args.chatMeta.customEmojiSelection);
+    let emojiAdvertisement: string | null = null;
+    let toolSelectionHandled = false;
+
+    if (
+      emojiPrefs.mode === "tool-call" &&
+      emojiPrefs.toolConnectionId &&
+      respondingConversationChars.length === 1
+    ) {
+      const responder = respondingConversationChars[0]!;
+      const candidates = uniqueEmojiNames([...(ownEmojisByChar.get(responder.charId) ?? []), ...sharedEmojiNames]);
+      const picked = await selectCustomAssetNamesByToolCall(
+        "emoji",
+        ":name:",
+        candidates,
+        assetQuery,
+        emojiPrefs.toolConnectionId,
+        args.connections,
+        emojiPrefs.maxCount,
+      );
+      if (picked !== null) {
+        toolSelectionHandled = true;
+        if (picked.length > 0) {
+          emojiAdvertisement = buildCustomEmojiAdvertisement(
+            respondingConversationChars,
+            [],
+            new Map([[responder.charId, picked]]),
+            emojiPrefs.maxCount,
+          );
+        }
+      }
+    }
+
+    if (!toolSelectionHandled && !emojiAdvertisement) {
+      const orderedShared = await orderEmojiNames(sharedEmojiNames, emojiPrefs, assetQuery);
+      const orderedOwnByChar = new Map<string, string[]>();
+      for (const [charId, names] of ownEmojisByChar) {
+        orderedOwnByChar.set(charId, await orderEmojiNames(names, emojiPrefs, assetQuery));
+      }
+      emojiAdvertisement = buildCustomEmojiAdvertisement(
+        respondingConversationChars,
+        orderedShared,
+        orderedOwnByChar,
+        emojiPrefs.maxCount,
+      );
+    }
+
+    if (emojiAdvertisement) appendToFirstSystemMessage(args.finalMessages, emojiAdvertisement);
+  }
+
+  if (sharedStickerNames.length > 0 || ownStickersByChar.size > 0) {
+    const stickerPrefs = normalizeCustomEmojiSelection(args.chatMeta.customEmojiSelection);
+    let stickerAdvertisement: string | null = null;
+    let toolSelectionHandled = false;
+
+    if (
+      stickerPrefs.mode === "tool-call" &&
+      stickerPrefs.toolConnectionId &&
+      respondingConversationChars.length === 1
+    ) {
+      const responder = respondingConversationChars[0]!;
+      const candidates = uniqueEmojiNames([
+        ...(ownStickersByChar.get(responder.charId) ?? []),
+        ...sharedStickerNames,
+      ]);
+      const picked = await selectCustomAssetNamesByToolCall(
+        "sticker",
+        "sticker:name:",
+        candidates,
+        assetQuery,
+        stickerPrefs.toolConnectionId,
+        args.connections,
+        stickerPrefs.maxCount,
+      );
+      if (picked !== null) {
+        toolSelectionHandled = true;
+        if (picked.length > 0) {
+          stickerAdvertisement = buildCustomStickerAdvertisement(
+            respondingConversationChars,
+            [],
+            new Map([[responder.charId, picked]]),
+            stickerPrefs.maxCount,
+          );
+        }
+      }
+    }
+
+    if (!toolSelectionHandled && !stickerAdvertisement) {
+      const orderedShared = await orderEmojiNames(sharedStickerNames, stickerPrefs, assetQuery);
+      const orderedOwnByChar = new Map<string, string[]>();
+      for (const [charId, names] of ownStickersByChar) {
+        orderedOwnByChar.set(charId, await orderEmojiNames(names, stickerPrefs, assetQuery));
+      }
+      stickerAdvertisement = buildCustomStickerAdvertisement(
+        respondingConversationChars,
+        orderedShared,
+        orderedOwnByChar,
+        stickerPrefs.maxCount,
+      );
+    }
+
+    if (stickerAdvertisement) appendToFirstSystemMessage(args.finalMessages, stickerAdvertisement);
+  }
+}
+
+/**
+ * Build the Conversation-mode system-prompt block that tells the responding
+ * character(s) which custom emojis they may use (`:name:`).
+ */
+export function buildCustomEmojiAdvertisement(
+  responders: { charId: string; name: string }[],
+  orderedGlobal: string[],
+  orderedOwnByChar: Map<string, string[]>,
+  maxCount: number,
+): string | null {
+  const toTokens = (names: string[]) => names.map((name) => `:${name}:`).join(" ");
+  const lead =
+    "You can use custom emojis in your reply by writing their name between colons, e.g. :name: — they render as small inline images. Use them only where they fit naturally; do not overuse them.";
+
+  if (responders.length === 1) {
+    const merged = [...(orderedOwnByChar.get(responders[0]!.charId) ?? [])];
+    for (const name of orderedGlobal) {
+      if (merged.length >= maxCount) break;
+      if (!merged.includes(name)) merged.push(name);
+    }
+    const capped = merged.slice(0, maxCount);
+    if (capped.length === 0) return null;
+    return `${lead}\nBeyond the full standard emoji set, you may use these custom emojis: ${toTokens(capped)}`;
+  }
+
+  const lines: string[] = [];
+  const global = orderedGlobal.slice(0, maxCount);
+  if (global.length > 0) lines.push(`Available to everyone: ${toTokens(global)}`);
+  for (const responder of responders) {
+    const own = (orderedOwnByChar.get(responder.charId) ?? []).slice(0, maxCount);
+    if (own.length > 0) lines.push(`${responder.name} also has: ${toTokens(own)}`);
+  }
+  if (lines.length === 0) return null;
+  return `${lead}\nBeyond the full standard emoji set, these custom emojis are available (use by typing :name:):\n${lines.join("\n")}`;
+}
+
+/**
+ * Build the Conversation-mode system-prompt block telling the responding
+ * character(s) which custom stickers they may send (`sticker:name:`, a block image).
+ */
+export function buildCustomStickerAdvertisement(
+  responders: { charId: string; name: string }[],
+  orderedGlobal: string[],
+  orderedOwnByChar: Map<string, string[]>,
+  maxCount: number,
+): string | null {
+  const toTokens = (names: string[]) => names.map((name) => `sticker:${name}:`).join(" ");
+  const lead =
+    "You can send a sticker by writing its name as sticker:name: — it posts as a large block image on its own line. Send one only when it genuinely fits the moment, not in every message.";
+
+  if (responders.length === 1) {
+    const merged = [...(orderedOwnByChar.get(responders[0]!.charId) ?? [])];
+    for (const name of orderedGlobal) {
+      if (merged.length >= maxCount) break;
+      if (!merged.includes(name)) merged.push(name);
+    }
+    const capped = merged.slice(0, maxCount);
+    if (capped.length === 0) return null;
+    return `${lead}\nAvailable stickers: ${toTokens(capped)}`;
+  }
+
+  const lines: string[] = [];
+  const global = orderedGlobal.slice(0, maxCount);
+  if (global.length > 0) lines.push(`Available to everyone: ${toTokens(global)}`);
+  for (const responder of responders) {
+    const own = (orderedOwnByChar.get(responder.charId) ?? []).slice(0, maxCount);
+    if (own.length > 0) lines.push(`${responder.name} also has: ${toTokens(own)}`);
+  }
+  if (lines.length === 0) return null;
+  return `${lead}\nAvailable stickers (send by writing sticker:name:):\n${lines.join("\n")}`;
+}
+
+/** Single-line excerpt of a grouped segment's text for reaction attribution. */
+function excerptSegmentText(lines: string[]): string {
+  const text = lines.join(" ").replace(/\s+/g, " ").trim();
+  const MAX = 80;
+  const chars = Array.from(text);
+  if (chars.length <= MAX) return text;
+  return `${chars.slice(0, MAX).join("").trimEnd()}…`;
+}
+
+export const REACTION_ANNOTATION_CONTENT_CAP = 32_000;
+
+function isAttributableGroup(group: GroupedSegment): boolean {
+  return group.speaker != null && group.lines.some((line) => line.trim().length > 0);
+}
+
+/**
+ * Annotate a prompt message with its reactions and return the new content.
+ */
+export function annotateContentWithReactions(
+  promptContent: string,
+  clientShapeContent: string,
+  reactions: unknown,
+  knownSpeakersByNorm: Map<string, string>,
+  resolveReactorName: (reactorId: string) => string,
+): string {
+  if (!Array.isArray(reactions) || reactions.length === 0) return promptContent;
+  const knownNames = new Set(knownSpeakersByNorm.keys());
+  const clientGroups: GroupedSegment[] | null =
+    clientShapeContent.length <= REACTION_ANNOTATION_CONTENT_CAP
+      ? parseGroupedSpeakerSegments(clientShapeContent, knownNames)
+      : null;
+  const promptGroups: GroupedSegment[] | null =
+    promptContent.length <= REACTION_ANNOTATION_CONTENT_CAP
+      ? parseGroupedSpeakerSegments(promptContent, knownNames)
+      : null;
+
+  const promptGroupFor = (clientIndex: number): GroupedSegment | null => {
+    if (!clientGroups || !promptGroups) return null;
+    const target = clientGroups[clientIndex]!;
+    const norm = normalizeTextForMatch(target.speaker!);
+    const marker =
+      target.lines
+        .flatMap((chunk) => chunk.split("\n"))
+        .map((line) => line.trim())
+        .find((line) => line.length > 0) ?? "";
+    if (!marker) return null;
+    const sameSpeaker = promptGroups.filter(
+      (g) => isAttributableGroup(g) && normalizeTextForMatch(g.speaker!) === norm,
+    );
+    if (sameSpeaker.length === 0) return null;
+    let ordinal = 0;
+    for (let i = 0; i < clientIndex; i++) {
+      const g = clientGroups[i]!;
+      if (isAttributableGroup(g) && normalizeTextForMatch(g.speaker!) === norm) ordinal++;
+    }
+    const hasMarkerLine = (g: GroupedSegment) =>
+      g.lines.some((chunk) => chunk.split("\n").some((line) => line.trim() === marker));
+    const ordinalPick = sameSpeaker[ordinal];
+    if (ordinalPick && hasMarkerLine(ordinalPick)) return ordinalPick;
+    let best: GroupedSegment | null = null;
+    let bestDistance = Infinity;
+    for (let ci = 0; ci < sameSpeaker.length; ci++) {
+      const candidate = sameSpeaker[ci]!;
+      if (!hasMarkerLine(candidate)) continue;
+      const distance = Math.abs(ci - ordinal);
+      if (distance < bestDistance) {
+        best = candidate;
+        bestDistance = distance;
+      }
+    }
+    return best;
+  };
+
+  type ResolvedNote =
+    | { kind: "inline"; phrase: string; speakerNorm: string; group: GroupedSegment }
+    | { kind: "end"; phrase: string; speakerNorm: string | null; text: string; staleTwinShape: boolean };
+  const notes: ResolvedNote[] = [];
+  for (const entry of reactions as Array<{
+    emoji?: unknown;
+    by?: unknown;
+    segment?: unknown;
+    segmentSpeaker?: unknown;
+  }>) {
+    const emoji = typeof entry.emoji === "string" ? entry.emoji : null;
+    const reactors = Array.isArray(entry.by) ? entry.by.filter((id): id is string => typeof id === "string") : [];
+    if (!emoji || reactors.length === 0) continue;
+    const names = reactors.map(resolveReactorName);
+    const who =
+      names.length === 1
+        ? names[0]!
+        : names.length === 2
+          ? `${names[0]} and ${names[1]}`
+          : `${names.slice(0, -1).join(", ")} and ${names[names.length - 1]}`;
+    const phrase = `${who} reacted with ${emoji}`;
+
+    const storedSpeaker =
+      typeof entry.segmentSpeaker === "string" && entry.segmentSpeaker.trim() ? entry.segmentSpeaker : null;
+    const wanted = storedSpeaker !== null ? normalizeTextForMatch(storedSpeaker) : null;
+    const segIdx = typeof entry.segment === "number" && Number.isInteger(entry.segment) ? entry.segment : null;
+    const seg =
+      clientGroups && segIdx !== null && segIdx >= 0 && segIdx < clientGroups.length
+        ? clientGroups[segIdx]
+        : undefined;
+    const segSpeakerNorm = seg?.speaker != null ? normalizeTextForMatch(seg.speaker) : null;
+    const segAligned =
+      seg !== undefined &&
+      segSpeakerNorm !== null &&
+      (wanted === null || segSpeakerNorm === wanted) &&
+      isAttributableGroup(seg);
+
+    if (segAligned) {
+      const promptGroup = promptGroupFor(segIdx!);
+      if (promptGroup) {
+        notes.push({ kind: "inline", phrase, speakerNorm: segSpeakerNorm!, group: promptGroup });
+        continue;
+      }
+      const canonical = knownSpeakersByNorm.get(segSpeakerNorm!);
+      if (canonical) {
+        notes.push({
+          kind: "end",
+          phrase,
+          speakerNorm: segSpeakerNorm!,
+          text: `${phrase} to ${canonical}'s part ("${excerptSegmentText(seg!.lines)}")`,
+          staleTwinShape: false,
+        });
+        continue;
+      }
+    } else if (wanted !== null && clientGroups) {
+      const speakerGroup = clientGroups.find(
+        (g) => isAttributableGroup(g) && normalizeTextForMatch(g.speaker!) === wanted,
+      );
+      const canonical = speakerGroup ? knownSpeakersByNorm.get(wanted) : undefined;
+      if (canonical) {
+        notes.push({
+          kind: "end",
+          phrase,
+          speakerNorm: wanted,
+          text: `${phrase} to ${canonical}'s part`,
+          staleTwinShape: true,
+        });
+        continue;
+      }
+    }
+    notes.push({ kind: "end", phrase, speakerNorm: null, text: phrase, staleTwinShape: false });
+  }
+
+  const inlineByGroup = new Map<GroupedSegment, string[]>();
+  const inlineKeys = new Set<string>();
+  for (const note of notes) {
+    if (note.kind !== "inline") continue;
+    const lines = inlineByGroup.get(note.group) ?? [];
+    if (!lines.includes(note.phrase)) lines.push(note.phrase);
+    inlineByGroup.set(note.group, lines);
+    inlineKeys.add(`${note.phrase}\u0000${note.speakerNorm}`);
+  }
+  const endParts: string[] = [];
+  for (const note of notes) {
+    if (note.kind !== "end") continue;
+    if (
+      note.staleTwinShape &&
+      note.speakerNorm !== null &&
+      inlineKeys.has(`${note.phrase}\u0000${note.speakerNorm}`)
+    ) {
+      continue;
+    }
+    endParts.push(note.text);
+  }
+
+  let annotated = promptContent;
+  const injections = [...inlineByGroup.entries()].sort((a, b) => b[0].end - a[0].end);
+  for (const [group, lines] of injections) {
+    const nextChar = annotated.charAt(group.end);
+    const trailingBreak = nextChar && nextChar !== "\n" && nextChar !== "\r" ? "\n" : "";
+    annotated = `${annotated.slice(0, group.end)}\n[${lines.join(", ")}]${trailingBreak}${annotated.slice(group.end)}`;
+  }
+  const uniqueEndParts = [...new Set(endParts)];
+  if (uniqueEndParts.length > 0) annotated += `\n[${uniqueEndParts.join("; ")}]`;
+  return annotated;
+}
+
+export function addMessageReactor(
+  reactions: unknown,
+  emoji: string,
+  reactor: string,
+  imageUrl: string | null,
+  target?: { segment: number; speaker: string | null } | null,
+): MessageReaction[] {
+  const current = Array.isArray(reactions) ? (reactions as MessageReaction[]) : [];
+  const targetSegment = target?.segment ?? null;
+  const targetSpeakerNorm = target?.speaker != null ? normalizeTextForMatch(target.speaker) : null;
+  const index = current.findIndex((r) => {
+    if (r.emoji !== emoji) return false;
+    if ((r.segment ?? null) !== targetSegment) return false;
+    if (targetSegment === null) return true;
+    if (r.segmentSpeaker === undefined) return true;
+    return (r.segmentSpeaker != null ? normalizeTextForMatch(r.segmentSpeaker) : null) === targetSpeakerNorm;
+  });
+  if (index === -1) {
+    const entry: MessageReaction = { emoji, by: [reactor] };
+    if (imageUrl) entry.imageUrl = imageUrl;
+    if (target) {
+      entry.segment = target.segment;
+      entry.segmentSpeaker = target.speaker ?? null;
+    }
+    return [...current, entry];
+  }
+  const entry = current[index]!;
+  if (entry.by.includes(reactor)) return current;
+  const next = [...current];
+  next[index] = { ...entry, by: [...entry.by, reactor], ...(imageUrl && !entry.imageUrl ? { imageUrl } : {}) };
+  return next;
+}
+
+export function buildGlobalCustomEmojiUrl(filePath: string): string {
+  return `/api/custom-emojis/file/${encodeURIComponent(filePath)}`;
+}
+
+export function buildConversationCustomEmojiKey(
+  scope: "global" | "persona" | "character",
+  scopeId: string | null,
+  name: string,
+): string {
+  return scopeId ? `${scope}:${scopeId}:${name}` : `${scope}:${name}`;
+}
+
+export function getStoredFilename(filePath: string): string {
+  return filePath.split("/").pop() ?? filePath;
+}
+
+export function buildCharacterGalleryEmojiUrl(characterId: string, filename: string): string {
+  return `/api/characters/${encodeURIComponent(characterId)}/gallery/file/${encodeURIComponent(filename)}`;
+}
+
+export function buildPersonaGalleryEmojiUrl(personaId: string, filename: string): string {
+  return `/api/characters/personas/${encodeURIComponent(personaId)}/gallery/file/${encodeURIComponent(filename)}`;
+}

--- a/packages/server/src/routes/generate/conversation-history-runtime.ts
+++ b/packages/server/src/routes/generate/conversation-history-runtime.ts
@@ -1,0 +1,518 @@
+import type { WrapFormat } from "@marinara-engine/shared";
+import { normalizeTextForMatch, stripLeadingMessageTimestamps } from "@marinara-engine/shared";
+
+import { logger } from "../../lib/logger.js";
+import {
+  formatConversationDateKey,
+  generateMissingConversationSummaries,
+  parseConversationDateKey,
+} from "../../services/conversation/auto-summary.service.js";
+import { stripConversationPromptTimestamps } from "../../services/conversation/transcript-sanitize.js";
+import {
+  formatZonedConversationDate,
+  formatZonedConversationTime,
+  isSameZonedLogicalDay,
+} from "../../services/conversation/timezone.js";
+import { formatConversationPromptTurn } from "../../services/generation/generation-text-utils.js";
+import type { GenerationPromptMessage } from "../../services/generation/prompt-message-scope.js";
+import { createLLMProvider } from "../../services/llm/provider-registry.js";
+import { wrapContent } from "../../services/prompt/format-engine.js";
+import {
+  annotateContentWithReactions,
+  REACTION_ANNOTATION_CONTENT_CAP,
+} from "./conversation-custom-assets.js";
+import {
+  formatConversationDateHistoryMessages,
+  formatConversationSummaryHistoryBlock,
+} from "./conversation-prompt-formatting.js";
+import { parseExtra } from "./generate-route-utils.js";
+
+type ConversationHistoryMessage = {
+  id?: unknown;
+  role?: string | null;
+  content?: unknown;
+  characterId?: unknown;
+  createdAt?: unknown;
+  extra?: unknown;
+};
+
+type ConversationHistoryCharacterStore = {
+  getById(id: string): Promise<{ data?: unknown } | null>;
+};
+
+type ConversationHistoryChatsStore = {
+  patchMetadata(chatId: string, updater: (freshMeta: Record<string, unknown>) => Record<string, unknown>): Promise<unknown>;
+};
+
+type ConversationSummaryConnection = {
+  provider: string;
+  apiKey: string;
+  model: string;
+  maxContext?: number | null;
+  openrouterProvider?: string | null;
+  maxTokensOverride?: number | null;
+};
+
+type BucketMsg = { role: string; content: string; author: string; ts: Date };
+type Bucket = { date: string; msgs: BucketMsg[] };
+
+export async function prepareConversationPromptHistory(args: {
+  finalMessages: GenerationPromptMessage[];
+  chatMessages: ConversationHistoryMessage[];
+  scopedMessages: ConversationHistoryMessage[];
+  regenerateMessageId?: string | null;
+  chatMeta: Record<string, unknown>;
+  chatId: string;
+  chats: ConversationHistoryChatsStore;
+  chars: ConversationHistoryCharacterStore;
+  characterIds: string[];
+  allCharacterIds: string[];
+  convoCharInfo: Array<{ name: string }>;
+  convoCharNames: string[];
+  personaName: string;
+  nowInstant: Date;
+  promptTimeZone?: string;
+  wrapFormat: WrapFormat;
+  connection: ConversationSummaryConnection;
+  baseUrl: string;
+}): Promise<{ finalMessages: GenerationPromptMessage[]; importantMemoryBlock: string | null }> {
+  const rolloverHour = Math.max(
+    0,
+    Math.min(11, Math.floor((args.chatMeta.dayRolloverHour as number | undefined) ?? 4)),
+  );
+  const isSameDay = (ts: Date) => isSameZonedLogicalDay(ts, args.nowInstant, args.promptTimeZone, rolloverHour);
+  const fmtDate = (ts: Date) => formatZonedConversationDate(ts, args.promptTimeZone, rolloverHour);
+  const todayDateKey = fmtDate(args.nowInstant);
+  const fmtTime = (ts: Date) => formatZonedConversationTime(ts, args.promptTimeZone);
+
+  const charIdToName = new Map<string, string>();
+  for (let ci = 0; ci < args.characterIds.length; ci++) {
+    if (args.convoCharInfo[ci]) charIdToName.set(args.characterIds[ci]!, args.convoCharInfo[ci]!.name);
+  }
+
+  let finalMessages = await annotateConversationPromptReactions({
+    finalMessages: args.finalMessages,
+    chatMessages: args.chatMessages,
+    charIdToName,
+    allCharacterIds: args.allCharacterIds,
+    chars: args.chars,
+    personaName: args.personaName,
+  });
+
+  const historyBuckets = bucketConversationHistory({
+    finalMessages,
+    chatMessages: args.chatMessages,
+    charIdToName,
+    convoCharNames: args.convoCharNames,
+    personaName: args.personaName,
+    isSameDay,
+    fmtDate,
+    fmtTime,
+  });
+  const buckets = historyBuckets.buckets;
+
+  const parseDateKey = parseConversationDateKey;
+  const fmtDateKey = formatConversationDateKey;
+  const summarySourceMessages = args.regenerateMessageId
+    ? args.scopedMessages.filter((message) => message.id !== args.regenerateMessageId)
+    : args.scopedMessages;
+  const summaryProvider = createLLMProvider(
+    args.connection.provider,
+    args.baseUrl,
+    args.connection.apiKey,
+    args.connection.maxContext,
+    args.connection.openrouterProvider,
+    args.connection.maxTokensOverride,
+  );
+  const summaryRun = await generateMissingConversationSummaries({
+    messages: summarySourceMessages.map((message) => ({
+      id: typeof message.id === "string" ? message.id : undefined,
+      role: String(message.role ?? ""),
+      content: typeof message.content === "string" ? message.content : String(message.content ?? ""),
+      characterId: typeof message.characterId === "string" ? message.characterId : null,
+      createdAt: typeof message.createdAt === "string" ? message.createdAt : null,
+    })),
+    metadata: args.chatMeta,
+    provider: summaryProvider,
+    model: args.connection.model,
+    personaName: args.personaName,
+    charIdToName,
+    now: args.nowInstant,
+    rolloverHour,
+    timeZone: args.promptTimeZone,
+    maxMissingDays: 2,
+  });
+
+  for (const failure of summaryRun.failedDays) {
+    logger.warn({ chatId: args.chatId, date: failure.date, err: failure.error }, "[conversation-summary] failed to generate day summary");
+  }
+  for (const failure of summaryRun.failedWeeks) {
+    logger.warn(
+      { chatId: args.chatId, weekKey: failure.weekKey, err: failure.error },
+      "[conversation-summary] failed to consolidate week summary",
+    );
+  }
+
+  const hasNewSummaries =
+    Object.keys(summaryRun.newlyGeneratedDays).length > 0 ||
+    Object.keys(summaryRun.newlyConsolidatedWeeks).length > 0;
+  if (hasNewSummaries || summaryRun.summaryFailureMetadataChanged) {
+    await args.chats.patchMetadata(args.chatId, (freshMeta) => {
+      const existingDaySummaries = (freshMeta.daySummaries as Record<string, unknown> | undefined) ?? {};
+      const existingWeekSummaries = (freshMeta.weekSummaries as Record<string, unknown> | undefined) ?? {};
+      return {
+        ...freshMeta,
+        daySummaries: { ...existingDaySummaries, ...summaryRun.newlyGeneratedDays },
+        weekSummaries: { ...existingWeekSummaries, ...summaryRun.newlyConsolidatedWeeks },
+        conversationSummaryFailures: summaryRun.summaryFailures,
+      };
+    });
+    args.chatMeta.daySummaries = {
+      ...((args.chatMeta.daySummaries as Record<string, unknown> | undefined) ?? {}),
+      ...summaryRun.newlyGeneratedDays,
+    };
+    args.chatMeta.weekSummaries = {
+      ...((args.chatMeta.weekSummaries as Record<string, unknown> | undefined) ?? {}),
+      ...summaryRun.newlyConsolidatedWeeks,
+    };
+    args.chatMeta.conversationSummaryFailures = summaryRun.summaryFailures;
+  }
+
+  const daySummaries = summaryRun.daySummaries;
+  const weekSummaries = summaryRun.weekSummaries;
+  const dayToWeek = new Map<string, string>();
+  for (const [weekKey] of Object.entries(weekSummaries)) {
+    const monday = parseDateKey(weekKey);
+    for (let i = 0; i < 7; i++) {
+      const day = new Date(monday.getFullYear(), monday.getMonth(), monday.getDate() + i);
+      dayToWeek.set(fmtDateKey(day), weekKey);
+    }
+  }
+
+  const allKeyDetails = collectConversationKeyDetails({
+    daySummaries,
+    weekSummaries,
+    dayToWeek,
+    parseDateKey,
+    fmtDateKey,
+  });
+
+  const tailCount = Math.max(
+    0,
+    Math.min(50, Math.floor((args.chatMeta.summaryTailMessages as number | undefined) ?? 10)),
+  );
+  const tailEntries = collectConversationSummaryTail({
+    buckets,
+    tailCount,
+    todayDateKey,
+    daySummaries,
+  });
+
+  finalMessages = flattenConversationHistoryBuckets({
+    buckets,
+    tailEntries,
+    firstTodayIdx: historyBuckets.firstTodayIdx,
+    daySummaries,
+    weekSummaries,
+    dayToWeek,
+    parseDateKey,
+    fmtDateKey,
+    promptTimeZone: args.promptTimeZone,
+    personaName: args.personaName,
+    wrapFormat: args.wrapFormat,
+  });
+
+  const importantMemoryBlock = formatConversationImportantMemoryBlock(allKeyDetails, args.wrapFormat);
+  return { finalMessages, importantMemoryBlock };
+}
+
+async function annotateConversationPromptReactions(args: {
+  finalMessages: GenerationPromptMessage[];
+  chatMessages: ConversationHistoryMessage[];
+  charIdToName: Map<string, string>;
+  allCharacterIds: string[];
+  chars: ConversationHistoryCharacterStore;
+  personaName: string;
+}): Promise<GenerationPromptMessage[]> {
+  const anyReactedMessage = args.chatMessages.some((message) => {
+    const reactions = parseExtra(message.extra).reactions;
+    return Array.isArray(reactions) && reactions.length > 0;
+  });
+  if (!anyReactedMessage) return args.finalMessages;
+
+  const reactionSpeakersByNorm = new Map<string, string>();
+  const addReactionSpeaker = (name: unknown) => {
+    if (typeof name !== "string") return;
+    const norm = normalizeTextForMatch(name);
+    const canonical = name.replace(/\s+/g, " ").trim();
+    if (norm && canonical && !reactionSpeakersByNorm.has(norm)) reactionSpeakersByNorm.set(norm, canonical);
+  };
+  for (const name of args.charIdToName.values()) addReactionSpeaker(name);
+  const extraSpeakerIds = new Set<string>();
+  for (const cid of args.allCharacterIds) if (!args.charIdToName.has(cid)) extraSpeakerIds.add(cid);
+  for (const message of args.chatMessages) {
+    const cid = message.characterId;
+    if (typeof cid === "string" && cid && !args.charIdToName.has(cid)) extraSpeakerIds.add(cid);
+  }
+  for (const cid of extraSpeakerIds) {
+    const row = await args.chars.getById(cid);
+    if (!row) continue;
+    try {
+      const data = typeof row.data === "string" ? JSON.parse(row.data) : row.data;
+      addReactionSpeaker((data as { name?: unknown } | null)?.name);
+    } catch {
+      // Malformed character data — skip; that speaker just won't be attributable.
+    }
+  }
+
+  const rawMessagesById = new Map<string, ConversationHistoryMessage>();
+  for (const message of args.chatMessages) {
+    if (typeof message.id === "string") rawMessagesById.set(message.id, message);
+  }
+
+  const reactorDisplayName = (reactorId: string): string =>
+    reactorId === "user" ? args.personaName : (args.charIdToName.get(reactorId) ?? "a character");
+  return args.finalMessages.map((message) => {
+    const promptMsgId = (message as { id?: unknown }).id;
+    const raw = typeof promptMsgId === "string" ? rawMessagesById.get(promptMsgId) : undefined;
+    if (!raw) return message;
+
+    const rawContentStr = typeof raw.content === "string" ? raw.content : String(raw.content ?? "");
+    return {
+      ...message,
+      content: annotateContentWithReactions(
+        message.content,
+        rawContentStr.length > REACTION_ANNOTATION_CONTENT_CAP
+          ? rawContentStr
+          : stripLeadingMessageTimestamps(rawContentStr),
+        parseExtra(raw.extra).reactions,
+        reactionSpeakersByNorm,
+        reactorDisplayName,
+      ),
+    };
+  });
+}
+
+function bucketConversationHistory(args: {
+  finalMessages: GenerationPromptMessage[];
+  chatMessages: ConversationHistoryMessage[];
+  charIdToName: Map<string, string>;
+  convoCharNames: string[];
+  personaName: string;
+  isSameDay: (date: Date) => boolean;
+  fmtDate: (date: Date) => string;
+  fmtTime: (date: Date) => string;
+}): { buckets: Array<Bucket | GenerationPromptMessage>; firstTodayIdx: number | null } {
+  const buckets: Array<Bucket | GenerationPromptMessage> = [];
+  let currentBucket: Bucket | null = null;
+  let firstTodayIdx: number | null = null;
+
+  for (let i = 0; i < args.finalMessages.length; i++) {
+    const msg = args.finalMessages[i]!;
+    const raw = args.chatMessages[i];
+    if (!raw?.createdAt || msg.role === "system") {
+      if (currentBucket) {
+        buckets.push(currentBucket);
+        currentBucket = null;
+      }
+      buckets.push(msg);
+      continue;
+    }
+
+    const ts = new Date(raw.createdAt as string);
+    const author =
+      msg.role === "user"
+        ? args.personaName
+        : ((raw.characterId ? args.charIdToName.get(raw.characterId as string) : null) ??
+          args.convoCharNames[0] ??
+          "Character");
+
+    if (args.isSameDay(ts)) {
+      if (currentBucket) {
+        buckets.push(currentBucket);
+        currentBucket = null;
+      }
+      if (firstTodayIdx === null) firstTodayIdx = buckets.length;
+      const promptContent = formatConversationPromptTurn(
+        stripConversationPromptTimestamps(msg.content),
+        msg.role,
+        args.personaName,
+        msg.role === "assistant" ? author : null,
+      );
+      buckets.push({ ...msg, content: `[${args.fmtTime(ts)}] ${promptContent}` });
+      continue;
+    }
+
+    const dateKey = args.fmtDate(ts);
+    const bucketMessage = {
+      ...msg,
+      content: stripConversationPromptTimestamps(msg.content),
+      author,
+      ts,
+    };
+    if (currentBucket && currentBucket.date === dateKey) {
+      currentBucket.msgs.push(bucketMessage);
+    } else {
+      if (currentBucket) buckets.push(currentBucket);
+      currentBucket = { date: dateKey, msgs: [bucketMessage] };
+    }
+  }
+
+  if (currentBucket) buckets.push(currentBucket);
+  return { buckets, firstTodayIdx };
+}
+
+function collectConversationKeyDetails(args: {
+  daySummaries: Record<string, { keyDetails: string[] }>;
+  weekSummaries: Record<string, { keyDetails: string[] }>;
+  dayToWeek: Map<string, string>;
+  parseDateKey: (date: string) => Date;
+  fmtDateKey: (date: Date) => string;
+}): Array<{ label: string; details: string[] }> {
+  const allKeyDetails: { label: string; details: string[] }[] = [];
+  const sortedWeekKeys = Object.keys(args.weekSummaries).sort(
+    (a, b) => args.parseDateKey(a).getTime() - args.parseDateKey(b).getTime(),
+  );
+  for (const wk of sortedWeekKeys) {
+    const entry = args.weekSummaries[wk]!;
+    if (entry.keyDetails.length > 0) {
+      const monday = args.parseDateKey(wk);
+      const sunday = new Date(monday.getFullYear(), monday.getMonth(), monday.getDate() + 6);
+      allKeyDetails.push({
+        label: `Week of ${wk} – ${args.fmtDateKey(sunday)}`,
+        details: entry.keyDetails,
+      });
+    }
+  }
+  for (const [date, entry] of Object.entries(args.daySummaries)) {
+    if (args.dayToWeek.has(date)) continue;
+    if (entry.keyDetails.length > 0) allKeyDetails.push({ label: date, details: entry.keyDetails });
+  }
+  return allKeyDetails;
+}
+
+function collectConversationSummaryTail(args: {
+  buckets: Array<Bucket | GenerationPromptMessage>;
+  tailCount: number;
+  todayDateKey: string;
+  daySummaries: Record<string, unknown>;
+}): BucketMsg[] {
+  const tailEntries: BucketMsg[] = [];
+  if (args.tailCount <= 0) return tailEntries;
+
+  outer: for (let bi = args.buckets.length - 1; bi >= 0; bi--) {
+    const bucket = args.buckets[bi]!;
+    if (!("date" in bucket && "msgs" in bucket)) continue;
+    if (bucket.date === args.todayDateKey) continue;
+    if (!args.daySummaries[bucket.date]) continue;
+    for (let mi = bucket.msgs.length - 1; mi >= 0; mi--) {
+      tailEntries.unshift(bucket.msgs[mi]!);
+      if (tailEntries.length >= args.tailCount) break outer;
+    }
+  }
+  return tailEntries;
+}
+
+function flattenConversationHistoryBuckets(args: {
+  buckets: Array<Bucket | GenerationPromptMessage>;
+  tailEntries: BucketMsg[];
+  firstTodayIdx: number | null;
+  daySummaries: Record<string, { summary: string }>;
+  weekSummaries: Record<string, { summary: string }>;
+  dayToWeek: Map<string, string>;
+  parseDateKey: (date: string) => Date;
+  fmtDateKey: (date: Date) => string;
+  promptTimeZone?: string;
+  personaName: string;
+  wrapFormat: WrapFormat;
+}): GenerationPromptMessage[] {
+  const weekBlocksEmitted = new Set<string>();
+  const fmtTailPrefix = (ts: Date) => {
+    const date = formatZonedConversationDate(ts, args.promptTimeZone).slice(0, 5);
+    return `[${date} ${formatZonedConversationTime(ts, args.promptTimeZone)}]`;
+  };
+  const buildTailTurns = (): GenerationPromptMessage[] =>
+    args.tailEntries.map((message) => ({
+      role: message.role as "user" | "assistant" | "system",
+      content: `${fmtTailPrefix(message.ts)} ${formatConversationPromptTurn(
+        message.content,
+        message.role,
+        args.personaName,
+        message.role === "assistant" ? message.author : null,
+      )}`,
+    }));
+
+  const finalMessages = args.buckets.flatMap((bucket, bucketIndex): GenerationPromptMessage[] => {
+    const prefix = bucketIndex === args.firstTodayIdx ? buildTailTurns() : [];
+
+    if ("date" in bucket && "msgs" in bucket) {
+      const weekKey = args.dayToWeek.get(bucket.date);
+      if (weekKey && args.weekSummaries[weekKey]) {
+        if (weekBlocksEmitted.has(weekKey)) return prefix;
+        weekBlocksEmitted.add(weekKey);
+        const weekEntry = args.weekSummaries[weekKey]!;
+        const monday = args.parseDateKey(weekKey);
+        const sunday = new Date(monday.getFullYear(), monday.getMonth(), monday.getDate() + 6);
+        return [
+          ...prefix,
+          {
+            role: "system",
+            content: formatConversationSummaryHistoryBlock(
+              `week="${weekKey} – ${args.fmtDateKey(sunday)}"`,
+              weekEntry.summary,
+              args.wrapFormat,
+            ),
+          },
+        ];
+      }
+
+      const dayEntry = args.daySummaries[bucket.date];
+      if (dayEntry) {
+        return [
+          ...prefix,
+          {
+            role: "system",
+            content: formatConversationSummaryHistoryBlock(`date="${bucket.date}"`, dayEntry.summary, args.wrapFormat),
+          },
+        ];
+      }
+
+      const turns = formatConversationDateHistoryMessages(
+        bucket.msgs.map((message) => ({
+          role: message.role as "user" | "assistant" | "system",
+          author: message.author,
+          content: message.content,
+        })),
+        bucket.date,
+        args.wrapFormat,
+      );
+      return [...prefix, ...turns];
+    }
+    return [...prefix, bucket];
+  });
+
+  if (args.firstTodayIdx === null && args.tailEntries.length > 0) {
+    return [...finalMessages, ...buildTailTurns()];
+  }
+  return finalMessages;
+}
+
+function formatConversationImportantMemoryBlock(
+  allKeyDetails: Array<{ label: string; details: string[] }>,
+  wrapFormat: WrapFormat,
+): string | null {
+  if (allKeyDetails.length === 0) return null;
+  allKeyDetails.sort((a, b) => {
+    const extractDate = (label: string) => {
+      const match = label.match(/(\d{2}\.\d{2}\.\d{4})/);
+      return match ? parseConversationDateKey(match[1]!).getTime() : 0;
+    };
+    return extractDate(a.label) - extractDate(b.label);
+  });
+  const memoryLines = [`Things you must remember from past conversations:`];
+  for (const { label, details } of allKeyDetails) {
+    memoryLines.push(`[${label}]`);
+    for (const detail of details) memoryLines.push(`- ${detail}`);
+  }
+  return wrapContent(memoryLines.join("\n"), "Important Memories", wrapFormat);
+}

--- a/packages/server/src/routes/generate/conversation-presence-runtime.ts
+++ b/packages/server/src/routes/generate/conversation-presence-runtime.ts
@@ -211,7 +211,14 @@ async function resolveConversationPromptCharacters(args: {
     const charRow = await args.chars.getById(cid);
     if (!charRow) continue;
 
-    const data = typeof charRow.data === "string" ? JSON.parse(charRow.data) : charRow.data;
+    let data: unknown = charRow.data;
+    if (typeof charRow.data === "string") {
+      try {
+        data = JSON.parse(charRow.data);
+      } catch {
+        data = null;
+      }
+    }
     const override = args.statusOverrides[cid];
     const fallback = getEffectiveCurrentStatus(undefined, override, args.promptNow, "");
     let status = fallback.status;

--- a/packages/server/src/routes/generate/conversation-presence-runtime.ts
+++ b/packages/server/src/routes/generate/conversation-presence-runtime.ts
@@ -1,0 +1,317 @@
+import { normalizeTextForMatch } from "@marinara-engine/shared";
+
+import type { DB } from "../../db/connection.js";
+import {
+  dailyCapForCharacter,
+  getAutonomousDailyBudget,
+} from "../../services/conversation/autonomous.service.js";
+import {
+  getDirectMessageDelay,
+  getEffectiveCurrentStatus,
+  getMentionDelay,
+  getTodaySchedule,
+  type WeekSchedule,
+} from "../../services/conversation/schedule.service.js";
+import {
+  getEnabledConversationSchedules,
+  parseConversationStatusOverrides,
+} from "../../services/generation/conversation-context-utils.js";
+import type { GenerationPromptMessage } from "../../services/generation/prompt-message-scope.js";
+import { getActiveTurnGame } from "../../services/turn-games/turn-game-runner.service.js";
+import { isMessageHiddenFromAI, parseExtra } from "./generate-route-utils.js";
+
+export type ConversationPromptCharacterInfo = {
+  charId: string;
+  name: string;
+  status: string;
+  activity: string;
+  todaySchedule: string;
+};
+
+type ConversationPresenceChatsStore = {
+  patchMetadata(
+    chatId: string,
+    updater: (current: Record<string, unknown>) => Record<string, unknown>,
+    options?: { touchUpdatedAt?: boolean },
+  ): Promise<unknown>;
+  listMessages(chatId: string): Promise<any[]>;
+};
+
+type ConversationPresenceCharactersStore = {
+  getById(id: string): Promise<{ data?: unknown } | null>;
+};
+
+export async function resolveConversationPresenceRuntime(args: {
+  db: DB;
+  chatId: string;
+  chatMeta: Record<string, unknown>;
+  characterIds: string[];
+  chars: ConversationPresenceCharactersStore;
+  chats: ConversationPresenceChatsStore;
+  promptNow: Date;
+  forCharacterId?: string | null;
+  mentionedCharacterNames?: string[] | null;
+  shouldAccountAutonomousGeneration: boolean;
+  regenerateMessageId?: string | null;
+  impersonate?: boolean;
+  skipPresenceDelay?: boolean;
+  supportsHiddenFromAI: boolean;
+  contextMessageLimit: number | null | undefined;
+  chatMessages: any[];
+  finalMessages: GenerationPromptMessage[];
+  abortSignal: AbortSignal;
+  writeSse: (payload: unknown) => void;
+  endSse: () => void;
+  mapChatHistoryMessageForPrompt: (message: any) => Promise<GenerationPromptMessage>;
+  resolveHistoryMessageMacros: (messages: GenerationPromptMessage[]) => GenerationPromptMessage[];
+}): Promise<{
+  ended: boolean;
+  aborted: boolean;
+  convoCharInfo: ConversationPromptCharacterInfo[];
+  convoCharNames: string[];
+  charNameList: string;
+  isGroup: boolean;
+  chatMessages: any[];
+  finalMessages: GenerationPromptMessage[];
+}> {
+  const schedules = getEnabledConversationSchedules(args.chatMeta) as Record<string, WeekSchedule>;
+  const statusOverrides = parseConversationStatusOverrides(args.chatMeta.conversationStatusOverrides);
+  const convoCharInfo = await resolveConversationPromptCharacters({
+    characterIds: args.characterIds,
+    chars: args.chars,
+    schedules,
+    statusOverrides,
+    promptNow: args.promptNow,
+  });
+
+  persistConversationPresenceState(args.chats, args.chatId, convoCharInfo);
+
+  const convoCharNames = convoCharInfo.map((character) => character.name);
+  const charNameList = convoCharNames.length ? convoCharNames.join(", ") : "the character";
+  const manualTargetCharId =
+    typeof args.forCharacterId === "string" && args.characterIds.includes(args.forCharacterId)
+      ? args.forCharacterId
+      : null;
+  const requestedMentionNames = new Set(
+    (args.mentionedCharacterNames ?? []).map((name) => normalizeTextForMatch(name)),
+  );
+  const scopedConvoCharInfo = manualTargetCharId
+    ? convoCharInfo.filter((character) => character.charId === manualTargetCharId)
+    : requestedMentionNames.size > 0
+      ? convoCharInfo.filter((character) => requestedMentionNames.has(normalizeTextForMatch(character.name)))
+      : convoCharInfo;
+  let respondingConvoCharInfo = scopedConvoCharInfo.length > 0 ? scopedConvoCharInfo : convoCharInfo;
+
+  if (args.shouldAccountAutonomousGeneration && !args.regenerateMessageId && !args.impersonate) {
+    const budget = getAutonomousDailyBudget(args.chatMeta);
+    respondingConvoCharInfo = respondingConvoCharInfo.filter((character) => {
+      const count = budget.counts[character.charId] ?? 0;
+      const cap = dailyCapForCharacter(schedules[character.charId], args.chatMeta);
+      return count < cap;
+    });
+
+    if (respondingConvoCharInfo.length === 0) {
+      args.writeSse({ type: "done" });
+      args.endSse();
+      return buildPresenceResult({ ended: true, convoCharInfo, convoCharNames, charNameList, args });
+    }
+  }
+
+  const respondingConvoCharNames = respondingConvoCharInfo.map((character) => character.name);
+  const seatedGameCharIds = await resolveSeatedTurnGameCharacterIds(args.db, args.chatId);
+  const effectiveStatus = (character: { charId: string; status: string }): string =>
+    seatedGameCharIds.has(character.charId) ? "online" : character.status;
+
+  const allOffline =
+    respondingConvoCharInfo.length > 0 &&
+    respondingConvoCharInfo.every((character) => effectiveStatus(character) === "offline");
+  if (allOffline && !args.regenerateMessageId && !args.impersonate) {
+    args.writeSse({ type: "offline", characters: respondingConvoCharNames });
+    args.writeSse({ type: "done" });
+    args.endSse();
+    return buildPresenceResult({ ended: true, convoCharInfo, convoCharNames, charNameList, args });
+  }
+
+  let chatMessages = args.chatMessages;
+  let finalMessages = args.finalMessages;
+  if (!args.regenerateMessageId && !args.impersonate && !args.skipPresenceDelay) {
+    const hasMentions = requestedMentionNames.size > 0 || !!manualTargetCharId;
+    const worstStatus = respondingConvoCharInfo.reduce((worst, character) => {
+      const rank = { online: 0, idle: 1, dnd: 2, offline: 3 } as Record<string, number>;
+      const cStatus = effectiveStatus(character);
+      return (rank[cStatus] ?? 0) > (rank[worst] ?? 0) ? cStatus : worst;
+    }, "online");
+    const delayMs = hasMentions
+      ? getMentionDelay(worstStatus as "online" | "idle" | "dnd" | "offline")
+      : respondingConvoCharInfo.reduce((maxDelay, character) => {
+          const schedule = schedules[character.charId];
+          return Math.max(
+            maxDelay,
+            getDirectMessageDelay(effectiveStatus(character) as "online" | "idle" | "dnd" | "offline", schedule),
+          );
+        }, 0);
+
+    if (delayMs > 0) {
+      args.writeSse({
+        type: "delayed",
+        characters: respondingConvoCharNames,
+        characterIds: respondingConvoCharInfo.map((character) => character.charId),
+        characterStatuses: Object.fromEntries(
+          respondingConvoCharInfo.map((character) => [character.charId, character.status]),
+        ),
+        status: worstStatus,
+        delayMs,
+      });
+      await waitForConversationPresenceDelay(delayMs, args.abortSignal);
+      if (args.abortSignal.aborted) {
+        return buildPresenceResult({
+          ended: false,
+          aborted: true,
+          convoCharInfo,
+          convoCharNames,
+          charNameList,
+          args,
+          chatMessages,
+          finalMessages,
+        });
+      }
+
+      const refreshed = await args.chats.listMessages(args.chatId);
+      const rStartIdx = findLatestConversationStartIndex(refreshed);
+      const rScoped = rStartIdx > 0 ? refreshed.slice(rStartIdx) : refreshed;
+      chatMessages = args.supportsHiddenFromAI ? rScoped.filter((message) => !isMessageHiddenFromAI(message)) : rScoped;
+      if (args.contextMessageLimit && args.contextMessageLimit > 0 && chatMessages.length > args.contextMessageLimit) {
+        chatMessages = chatMessages.slice(-args.contextMessageLimit);
+      }
+      finalMessages = [];
+      for (const message of chatMessages) {
+        finalMessages.push(await args.mapChatHistoryMessageForPrompt(message));
+      }
+      finalMessages = args.resolveHistoryMessageMacros(finalMessages);
+    }
+    args.writeSse({ type: "typing", characters: respondingConvoCharNames });
+  }
+
+  if (args.regenerateMessageId) {
+    args.writeSse({ type: "typing", characters: convoCharNames });
+  }
+
+  return buildPresenceResult({ ended: false, convoCharInfo, convoCharNames, charNameList, args, chatMessages, finalMessages });
+}
+
+async function resolveConversationPromptCharacters(args: {
+  characterIds: string[];
+  chars: ConversationPresenceCharactersStore;
+  schedules: Record<string, WeekSchedule>;
+  statusOverrides: ReturnType<typeof parseConversationStatusOverrides>;
+  promptNow: Date;
+}): Promise<ConversationPromptCharacterInfo[]> {
+  const convoCharInfo: ConversationPromptCharacterInfo[] = [];
+  for (const cid of args.characterIds) {
+    const charRow = await args.chars.getById(cid);
+    if (!charRow) continue;
+
+    const data = typeof charRow.data === "string" ? JSON.parse(charRow.data) : charRow.data;
+    const override = args.statusOverrides[cid];
+    const fallback = getEffectiveCurrentStatus(undefined, override, args.promptNow, "");
+    let status = fallback.status;
+    let activity = fallback.activity;
+    let todaySchedule = "";
+    const schedule = args.schedules[cid];
+    if (schedule) {
+      const derived = getEffectiveCurrentStatus(schedule, override, args.promptNow);
+      status = derived.status;
+      activity = derived.activity;
+      todaySchedule = getTodaySchedule(schedule, args.promptNow);
+    }
+    convoCharInfo.push({
+      charId: cid,
+      name: (data as { name?: string } | null)?.name ?? "Unknown",
+      status,
+      activity,
+      todaySchedule,
+    });
+  }
+  return convoCharInfo;
+}
+
+function persistConversationPresenceState(
+  chats: ConversationPresenceChatsStore,
+  chatId: string,
+  convoCharInfo: ConversationPromptCharacterInfo[],
+): void {
+  if (convoCharInfo.length === 0) return;
+  void chats
+    .patchMetadata(
+      chatId,
+      (current) => ({
+        conversationCharacterStatuses: {
+          ...(current.conversationCharacterStatuses ?? {}),
+          ...Object.fromEntries(
+            convoCharInfo.map((character) => [
+              character.charId,
+              { status: character.status, activity: character.activity },
+            ]),
+          ),
+        },
+      }),
+      { touchUpdatedAt: false },
+    )
+    .catch(() => {});
+}
+
+async function resolveSeatedTurnGameCharacterIds(db: DB, chatId: string): Promise<Set<string>> {
+  const activeGameForSchedule = await getActiveTurnGame(db, chatId);
+  const seatOrder = activeGameForSchedule?.state?.seatOrder;
+  return Array.isArray(seatOrder)
+    ? new Set(seatOrder.filter((value: unknown): value is string => typeof value === "string"))
+    : new Set<string>();
+}
+
+async function waitForConversationPresenceDelay(delayMs: number, abortSignal: AbortSignal): Promise<void> {
+  await new Promise<void>((resolve) => {
+    if (abortSignal.aborted) {
+      resolve();
+      return;
+    }
+    const timeout = setTimeout(resolve, delayMs);
+    abortSignal.addEventListener(
+      "abort",
+      () => {
+        clearTimeout(timeout);
+        resolve();
+      },
+      { once: true },
+    );
+  });
+}
+
+function findLatestConversationStartIndex(messages: any[]): number {
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const extra = parseExtra(messages[i]!.extra);
+    if (extra.isConversationStart) return i;
+  }
+  return 0;
+}
+
+function buildPresenceResult(args: {
+  ended: boolean;
+  aborted?: boolean;
+  convoCharInfo: ConversationPromptCharacterInfo[];
+  convoCharNames: string[];
+  charNameList: string;
+  args: { chatMessages: any[]; finalMessages: GenerationPromptMessage[] };
+  chatMessages?: any[];
+  finalMessages?: GenerationPromptMessage[];
+}) {
+  return {
+    ended: args.ended,
+    aborted: args.aborted === true,
+    convoCharInfo: args.convoCharInfo,
+    convoCharNames: args.convoCharNames,
+    charNameList: args.charNameList,
+    isGroup: args.convoCharNames.length > 1,
+    chatMessages: args.chatMessages ?? args.args.chatMessages,
+    finalMessages: args.finalMessages ?? args.args.finalMessages,
+  };
+}

--- a/packages/server/src/routes/generate/conversation-prompt-formatting.ts
+++ b/packages/server/src/routes/generate/conversation-prompt-formatting.ts
@@ -1,0 +1,76 @@
+import type { WrapFormat } from "@marinara-engine/shared";
+
+import type { GenerationPromptMessage } from "../../services/generation/prompt-message-scope.js";
+import { parseExtra } from "./generate-route-utils.js";
+
+function presetStringField(preset: Record<string, unknown> | null | undefined, field: string): string {
+  const value = preset?.[field];
+  return typeof value === "string" ? value.trim() : "";
+}
+
+export function resolvePresetModePrompt(
+  preset: Record<string, unknown> | null | undefined,
+  mode: "conversation" | "game",
+): string {
+  return mode === "conversation"
+    ? presetStringField(preset, "conversationPrompt")
+    : presetStringField(preset, "gamePrompt");
+}
+
+export function formatConversationSummaryHistoryBlock(label: string, summary: string, wrapFormat: WrapFormat): string {
+  if (wrapFormat === "xml") return `<summary ${label}>\n${summary}\n</summary>`;
+  const displayLabel = label.replace(/="/g, ": ").replace(/"$/g, "");
+  if (wrapFormat === "markdown") return `## Summary (${displayLabel})\n${summary}`;
+  return `Summary (${displayLabel})\n${summary}`;
+}
+
+export function formatConversationDateHistoryMessages(
+  messages: Array<{ role: "system" | "user" | "assistant"; author: string; content: string }>,
+  date: string,
+  wrapFormat: WrapFormat,
+): Array<{ role: "system" | "user" | "assistant"; content: string }> {
+  if (messages.length === 0) return [];
+  if (wrapFormat === "xml") {
+    return messages.map((message, idx) => {
+      let content = `${message.author}: ${message.content}`;
+      if (idx === 0) content = `<date="${date}">\n${content}`;
+      if (idx === messages.length - 1) content = `${content}\n</date>`;
+      return { role: message.role, content };
+    });
+  }
+
+  return messages.map((message, idx) => {
+    const prefix = idx === 0 ? (wrapFormat === "markdown" ? `## Date: ${date}\n` : `Date: ${date}\n`) : "";
+    return { role: message.role, content: `${prefix}${message.author}: ${message.content}` };
+  });
+}
+
+export function appendToFirstSystemMessage(messages: GenerationPromptMessage[], content: string): void {
+  const systemMessage = messages.find((message) => message.role === "system");
+  if (systemMessage) {
+    systemMessage.content = systemMessage.content ? `${systemMessage.content}\n\n${content}` : content;
+    return;
+  }
+  messages.unshift({ role: "system", content });
+}
+
+export function latestHistoryUserContent(messages: GenerationPromptMessage[]): string {
+  const historyTurn = [...messages]
+    .reverse()
+    .find((message) => message.role === "user" && message.contextKind === "history");
+  if (historyTurn) return historyTurn.content;
+  return [...messages].reverse().find((message) => message.role === "user")?.content ?? "";
+}
+
+export function conversationPromptHistoryContent(
+  message: { role?: unknown; content?: unknown; extra?: unknown },
+  chatMode: string,
+): string {
+  if (chatMode === "conversation" && message.role === "assistant") {
+    const commandContent = parseExtra(message.extra).conversationCommandContent;
+    if (typeof commandContent === "string" && commandContent.trim()) {
+      return commandContent;
+    }
+  }
+  return typeof message.content === "string" ? message.content : "";
+}

--- a/packages/server/src/routes/generate/image-captioning-runtime.ts
+++ b/packages/server/src/routes/generate/image-captioning-runtime.ts
@@ -1,0 +1,294 @@
+import { LOCAL_SIDECAR_CONNECTION_ID } from "@marinara-engine/shared";
+
+import { logger } from "../../lib/logger.js";
+import { applyProviderMaxTokensOverride } from "../../services/generation/generation-parameters.js";
+import { getLocalSidecarProvider } from "../../services/llm/local-sidecar.js";
+import type { BaseLLMProvider } from "../../services/llm/base-provider.js";
+import { createLLMProvider } from "../../services/llm/provider-registry.js";
+import {
+  appendReadableAttachmentsToContent,
+  createLocalSidecarGenerationConnection,
+  escapeXmlAttribute,
+  extractFileAttachmentInputs,
+  extractImageAttachmentDataUrls,
+  getAttachmentFilename,
+  parseExtra,
+  resolveBaseUrl,
+  type PromptAttachment,
+} from "./generate-route-utils.js";
+
+export type ImageCaptionConnection = {
+  id?: string | null;
+  name?: string | null;
+  provider: string;
+  apiKey: string;
+  model: string;
+  baseUrl: string | null;
+  maxContext?: number | null;
+  openrouterProvider?: string | null;
+  maxTokensOverride?: number | null;
+  claudeFastMode?: string | null;
+  treatAsLocalEndpoint?: string | null;
+  enableCaching?: string | null;
+  anthropicExtendedCacheTtl?: string | null;
+  cachingAtDepth?: number | null;
+};
+
+export type ImageCaptioningRuntime = {
+  enabled: boolean;
+  connectionId: string | null;
+  connection: ImageCaptionConnection | null;
+  provider: BaseLLMProvider | null;
+};
+
+export type PromptAttachmentResolution = {
+  content: string;
+  images: string[];
+  files: Array<{ type: string; data: string; filename: string }>;
+  updatedAttachments: PromptAttachment[] | null;
+};
+
+export const DISABLED_IMAGE_CAPTIONING: ImageCaptioningRuntime = {
+  enabled: false,
+  connectionId: null,
+  connection: null,
+  provider: null,
+};
+
+const IMAGE_CAPTION_MAX_TOKENS = 700;
+const IMAGE_CAPTION_MAX_CHARS = 4_000;
+
+export async function resolveImageCaptioningRuntime(args: {
+  chatMeta: Record<string, unknown>;
+  fallbackConnectionId: string | null;
+  connections: {
+    listRandomPool(): Promise<Array<{ id?: string | null }>>;
+    getWithKey(connectionId: string): Promise<ImageCaptionConnection | null>;
+  };
+}): Promise<ImageCaptioningRuntime> {
+  const { chatMeta, connections } = args;
+  if (chatMeta.imageCaptioningEnabled !== true) return DISABLED_IMAGE_CAPTIONING;
+  try {
+    const configuredConnectionId =
+      typeof chatMeta.imageCaptioningConnectionId === "string" && chatMeta.imageCaptioningConnectionId.trim()
+        ? chatMeta.imageCaptioningConnectionId.trim()
+        : null;
+    const fallbackCaptionConnectionId = configuredConnectionId ?? args.fallbackConnectionId;
+    if (!fallbackCaptionConnectionId) return DISABLED_IMAGE_CAPTIONING;
+    let captionConnectionId = fallbackCaptionConnectionId;
+    if (captionConnectionId === "random") {
+      const pool = await connections.listRandomPool();
+      if (!pool.length) {
+        logger.warn("[image-captioning] Random captioning connection requested but random pool is empty");
+        return DISABLED_IMAGE_CAPTIONING;
+      }
+      const randomCaptionConnectionId = pool[Math.floor(Math.random() * pool.length)]?.id;
+      if (!randomCaptionConnectionId) {
+        logger.warn("[image-captioning] Random captioning connection resolved without an id");
+        return DISABLED_IMAGE_CAPTIONING;
+      }
+      captionConnectionId = randomCaptionConnectionId;
+    }
+
+    const captionConnection =
+      captionConnectionId === LOCAL_SIDECAR_CONNECTION_ID
+        ? createLocalSidecarGenerationConnection()
+        : await connections.getWithKey(captionConnectionId);
+    if (!captionConnection?.model) {
+      logger.warn("[image-captioning] Captioning connection %s was not found", captionConnectionId);
+      return DISABLED_IMAGE_CAPTIONING;
+    }
+
+    let captionProvider: BaseLLMProvider;
+    if (captionConnectionId === LOCAL_SIDECAR_CONNECTION_ID) {
+      captionProvider = getLocalSidecarProvider();
+    } else {
+      const captionBaseUrl = resolveBaseUrl(captionConnection);
+      if (!captionBaseUrl) {
+        logger.warn("[image-captioning] Captioning connection %s has no base URL", captionConnectionId);
+        return DISABLED_IMAGE_CAPTIONING;
+      }
+      captionProvider = createLLMProvider(
+        captionConnection.provider,
+        captionBaseUrl,
+        captionConnection.apiKey,
+        captionConnection.maxContext,
+        captionConnection.openrouterProvider,
+        captionConnection.maxTokensOverride,
+        captionConnection.claudeFastMode === "true",
+        captionConnection.treatAsLocalEndpoint === "true",
+      );
+    }
+
+    return {
+      enabled: true,
+      connectionId: captionConnectionId,
+      connection: captionConnection,
+      provider: captionProvider,
+    };
+  } catch (error) {
+    logger.warn(error, "[image-captioning] Failed to resolve captioning connection; sending images normally");
+    return DISABLED_IMAGE_CAPTIONING;
+  }
+}
+
+export function normalizePromptAttachments(extra: unknown): PromptAttachment[] | undefined {
+  const rawAttachments = parseExtra(extra).attachments;
+  if (!Array.isArray(rawAttachments)) return undefined;
+  const attachments = rawAttachments.filter(
+    (attachment): attachment is PromptAttachment =>
+      !!attachment && typeof attachment === "object" && !Array.isArray(attachment),
+  );
+  return attachments.length ? attachments : undefined;
+}
+
+function normalizeImageCaptionText(value: unknown): string | null {
+  if (typeof value !== "string") return null;
+  const text = value
+    .replace(/^```(?:\w+)?\s*/i, "")
+    .replace(/```\s*$/i, "")
+    .trim();
+  if (!text) return null;
+  return text.length > IMAGE_CAPTION_MAX_CHARS ? `${text.slice(0, IMAGE_CAPTION_MAX_CHARS).trim()}...` : text;
+}
+
+function readCachedImageCaption(attachment: PromptAttachment, imageCaptioning: ImageCaptioningRuntime): string | null {
+  const caption = normalizeImageCaptionText(attachment.imageCaption);
+  if (!caption || !imageCaptioning.connection) return null;
+  if (attachment.imageCaptionConnectionId !== imageCaptioning.connectionId) return null;
+  if (attachment.imageCaptionModel !== imageCaptioning.connection.model) return null;
+  if (attachment.imageCaptionProvider !== imageCaptioning.connection.provider) return null;
+  return caption;
+}
+
+function formatImageCaptionBlock(attachment: PromptAttachment, caption: string): string {
+  const name = getAttachmentFilename(attachment);
+  const type = typeof attachment.type === "string" && attachment.type.trim() ? attachment.type.trim() : "image";
+  return [
+    `<attached_image name="${escapeXmlAttribute(name)}" type="${escapeXmlAttribute(type)}">`,
+    caption,
+    `</attached_image>`,
+  ].join("\n");
+}
+
+function appendImageCaptionBlocksToContent(content: string, blocks: string[]): string {
+  if (blocks.length === 0) return content;
+  return `${content}${content.trim() ? "\n\n" : ""}${blocks.join("\n\n")}`;
+}
+
+async function generateImageCaptionForAttachment(
+  attachment: PromptAttachment,
+  imageDataUrl: string,
+  imageCaptioning: ImageCaptioningRuntime,
+  signal: AbortSignal,
+): Promise<string | null> {
+  if (!imageCaptioning.provider || !imageCaptioning.connection) return null;
+  const filename = getAttachmentFilename(attachment);
+  try {
+    const result = await imageCaptioning.provider.chatComplete(
+      [
+        {
+          role: "system",
+          content:
+            "You describe image attachments for a downstream chat model that may not support vision. " +
+            "Write a faithful, concise description of the visible content, including readable text, subjects, setting, style, and any details important for conversation continuity. " +
+            "Do not answer the chat and do not add speculation beyond what is visible.",
+        },
+        {
+          role: "user",
+          content: `Describe this image attachment named "${filename}" for use inside a chat prompt. Return only the description.`,
+          images: [imageDataUrl],
+        },
+      ],
+      {
+        model: imageCaptioning.connection.model,
+        temperature: 0.2,
+        maxTokens: applyProviderMaxTokensOverride(imageCaptioning.provider, IMAGE_CAPTION_MAX_TOKENS),
+        enableCaching: imageCaptioning.connection.enableCaching === "true",
+        anthropicExtendedCacheTtl: imageCaptioning.connection.anthropicExtendedCacheTtl === "true",
+        cachingAtDepth: imageCaptioning.connection.cachingAtDepth ?? 5,
+        stream: false,
+        signal,
+      },
+    );
+    return normalizeImageCaptionText(result.content);
+  } catch (error) {
+    if (signal.aborted) throw error;
+    logger.warn(error, "[image-captioning] Failed to caption image attachment %s", filename);
+    return null;
+  }
+}
+
+export async function resolvePromptAttachmentInputs(args: {
+  content: string;
+  attachments: PromptAttachment[] | undefined;
+  imageCaptioning: ImageCaptioningRuntime;
+  signal: AbortSignal;
+}): Promise<PromptAttachmentResolution> {
+  const { attachments, imageCaptioning, signal } = args;
+  const files = extractFileAttachmentInputs(attachments);
+  let content = appendReadableAttachmentsToContent(args.content, attachments);
+
+  if (!imageCaptioning.enabled || !imageCaptioning.provider || !imageCaptioning.connection) {
+    return {
+      content,
+      images: extractImageAttachmentDataUrls(attachments),
+      files,
+      updatedAttachments: null,
+    };
+  }
+
+  const captionBlocks: string[] = [];
+  const fallbackImages: string[] = [];
+  let updatedAttachments: PromptAttachment[] | null = null;
+  const sourceAttachments = attachments ?? [];
+  const captionConnection = imageCaptioning.connection;
+  const resolvedImages = await Promise.all(
+    sourceAttachments.map(async (attachment, index) => {
+      const imageDataUrl = extractImageAttachmentDataUrls([attachment])[0];
+      if (!imageDataUrl) return null;
+
+      let caption = readCachedImageCaption(attachment, imageCaptioning);
+      let updatedAttachment: PromptAttachment | null = null;
+      if (!caption) {
+        caption = await generateImageCaptionForAttachment(attachment, imageDataUrl, imageCaptioning, signal);
+        if (caption) {
+          updatedAttachment = {
+            ...attachment,
+            imageCaption: caption,
+            imageCaptionConnectionId: imageCaptioning.connectionId,
+            imageCaptionModel: captionConnection.model,
+            imageCaptionProvider: captionConnection.provider,
+            imageCaptionedAt: new Date().toISOString(),
+          };
+        }
+      }
+
+      return { index, attachment, imageDataUrl, caption, updatedAttachment };
+    }),
+  );
+
+  for (const result of resolvedImages) {
+    if (!result) continue;
+    const { index, attachment, imageDataUrl, caption, updatedAttachment } = result;
+    if (updatedAttachment) {
+      updatedAttachments ??= sourceAttachments.map((item) => ({ ...item }));
+      updatedAttachments[index] = updatedAttachment;
+    }
+    if (caption) {
+      captionBlocks.push(
+        formatImageCaptionBlock(updatedAttachment ?? updatedAttachments?.[index] ?? attachment, caption),
+      );
+    } else {
+      fallbackImages.push(imageDataUrl);
+    }
+  }
+
+  content = appendImageCaptionBlocksToContent(content, captionBlocks);
+  return {
+    content,
+    images: fallbackImages,
+    files,
+    updatedAttachments,
+  };
+}

--- a/packages/server/src/routes/generate/lorebook-scan-snapshot.ts
+++ b/packages/server/src/routes/generate/lorebook-scan-snapshot.ts
@@ -1,0 +1,27 @@
+import type { LorebookScanResult } from "../../services/lorebook/index.js";
+
+export type LorebookScanSnapshot = {
+  activatedEntries: LorebookScanResult["activatedEntries"];
+  budgetSkippedEntries: LorebookScanResult["budgetSkippedEntries"];
+  totalTokensEstimate: number;
+  totalEntries: number;
+};
+
+export function emptyLorebookScanSnapshot(): LorebookScanSnapshot {
+  return {
+    activatedEntries: [],
+    budgetSkippedEntries: [],
+    totalTokensEstimate: 0,
+    totalEntries: 0,
+  };
+}
+
+export function toLorebookScanSnapshot(result: LorebookScanResult | null | undefined): LorebookScanSnapshot {
+  if (!result) return emptyLorebookScanSnapshot();
+  return {
+    activatedEntries: result.activatedEntries,
+    budgetSkippedEntries: result.budgetSkippedEntries,
+    totalTokensEstimate: result.totalTokensEstimate,
+    totalEntries: result.totalEntries,
+  };
+}

--- a/packages/server/src/routes/generate/professor-mari-prompt-context.ts
+++ b/packages/server/src/routes/generate/professor-mari-prompt-context.ts
@@ -36,8 +36,12 @@ export async function resolveProfessorMariPromptContext(args: {
     const charNames = allChars
       .filter((c) => c.id !== PROFESSOR_MARI_ID)
       .map((c) => {
-        const d = typeof c.data === "string" ? JSON.parse(c.data) : c.data;
-        return d?.name;
+        try {
+          const d = typeof c.data === "string" ? JSON.parse(c.data) : c.data;
+          return d?.name;
+        } catch {
+          return null;
+        }
       })
       .filter(Boolean);
 

--- a/packages/server/src/routes/generate/professor-mari-prompt-context.ts
+++ b/packages/server/src/routes/generate/professor-mari-prompt-context.ts
@@ -1,0 +1,88 @@
+import { PROFESSOR_MARI_ID } from "@marinara-engine/shared";
+
+import { MARI_ASSISTANT_PROMPT } from "../../db/seed-mari.js";
+
+type ProfessorMariCharactersStore = {
+  list(): Promise<Array<{ id?: string | null; data?: unknown }>>;
+  listPersonas(): Promise<Array<{ name?: unknown }>>;
+};
+
+type NamedListStore = {
+  list(): Promise<unknown[]>;
+};
+
+function namedValue(row: unknown): string | null {
+  if (!row || typeof row !== "object") return null;
+  const name = (row as { name?: unknown }).name;
+  return typeof name === "string" && name.trim().length > 0 ? name : null;
+}
+
+export async function resolveProfessorMariPromptContext(args: {
+  chatMeta: Record<string, unknown>;
+  chars: ProfessorMariCharactersStore;
+  lorebooksStore: NamedListStore;
+  chats: NamedListStore;
+  presets: NamedListStore;
+}): Promise<string> {
+  const sections = [MARI_ASSISTANT_PROMPT];
+
+  try {
+    const allChars = await args.chars.list();
+    const allPersonasList = await args.chars.listPersonas();
+    const allLorebooks = await args.lorebooksStore.list();
+    const allChats = await args.chats.list();
+    const allPresets = await args.presets.list();
+
+    const charNames = allChars
+      .filter((c) => c.id !== PROFESSOR_MARI_ID)
+      .map((c) => {
+        const d = typeof c.data === "string" ? JSON.parse(c.data) : c.data;
+        return d?.name;
+      })
+      .filter(Boolean);
+
+    const personaNames = allPersonasList.map((p) => p.name).filter(Boolean);
+    const lorebookNames = allLorebooks.map(namedValue).filter(Boolean);
+    const chatNames = allChats
+      .slice(0, 50)
+      .map(namedValue)
+      .filter(Boolean);
+    const presetNames = allPresets.map(namedValue).filter(Boolean);
+
+    const namesSections: string[] = [];
+    if (charNames.length > 0) {
+      namesSections.push(`<available_names type="character">\n${charNames.join(", ")}\n</available_names>`);
+    }
+    if (personaNames.length > 0) {
+      namesSections.push(`<available_names type="persona">\n${personaNames.join(", ")}\n</available_names>`);
+    }
+    if (lorebookNames.length > 0) {
+      namesSections.push(`<available_names type="lorebook">\n${lorebookNames.join(", ")}\n</available_names>`);
+    }
+    if (chatNames.length > 0) {
+      namesSections.push(`<available_names type="chat">\n${chatNames.join(", ")}\n</available_names>`);
+    }
+    if (presetNames.length > 0) {
+      namesSections.push(`<available_names type="preset">\n${presetNames.join(", ")}\n</available_names>`);
+    }
+
+    if (namesSections.length > 0) sections.push(namesSections.join("\n\n"));
+  } catch {
+    // Non-critical: continue without name lists.
+  }
+
+  const mariContext = args.chatMeta.mariContext as Record<string, string> | undefined;
+  if (mariContext && Object.keys(mariContext).length > 0) {
+    const contextSections: string[] = [];
+    for (const [key, value] of Object.entries(mariContext)) {
+      contextSections.push(`<fetched_data key="${key}">\n${value}\n</fetched_data>`);
+    }
+    sections.push(
+      "<loaded_context>\nThe following items were previously fetched and are available for reference:\n\n" +
+        contextSections.join("\n\n") +
+        "\n</loaded_context>",
+    );
+  }
+
+  return sections.join("\n\n");
+}

--- a/packages/server/src/services/generation/agent-prompt-runtime.ts
+++ b/packages/server/src/services/generation/agent-prompt-runtime.ts
@@ -1,0 +1,26 @@
+import type { ChatMessage } from "../llm/base-provider.js";
+
+export function resolveCustomWritableLorebookIds(settings: Record<string, unknown>): string[] | null {
+  const ids: string[] = [];
+  for (const key of ["writableLorebookId", "targetLorebookId"]) {
+    const value = settings[key];
+    if (typeof value === "string" && value.trim()) ids.push(value.trim());
+  }
+  const arrayValue = settings.writableLorebookIds;
+  if (Array.isArray(arrayValue)) {
+    for (const value of arrayValue) {
+      if (typeof value === "string" && value.trim()) ids.push(value.trim());
+    }
+  }
+  return ids.length > 0 ? Array.from(new Set(ids)) : null;
+}
+
+export function promptPreviewForAgents(messages: ChatMessage[]): string {
+  const preview = messages
+    .map((message, index) => {
+      const content = String(message.content ?? "").slice(0, 3000);
+      return `<message index="${index}" role="${message.role}">\n${content}\n</message>`;
+    })
+    .join("\n\n");
+  return preview.slice(0, 24_000);
+}

--- a/packages/server/src/services/generation/conversation-call-command-runtime.ts
+++ b/packages/server/src/services/generation/conversation-call-command-runtime.ts
@@ -1,0 +1,117 @@
+import type { ChatMode } from "@marinara-engine/shared";
+
+import type { DB } from "../../db/connection.js";
+import { logger } from "../../lib/logger.js";
+import { createAppSettingsStorage } from "../storage/app-settings.storage.js";
+import { createConversationCallsStorage } from "../storage/conversation-calls.storage.js";
+import type { CallCommand, CharacterCommand } from "../conversation/character-commands.js";
+import { isConversationCommandEnabled } from "./conversation-command-runtime.js";
+
+type ChatsStore = {
+  getById(id: string): Promise<{ metadata?: unknown } | null>;
+  createMessagesBatch(chatId: string, messages: Array<Record<string, unknown>>): Promise<unknown>;
+};
+
+export async function handleConversationCallCommand(args: {
+  command: CharacterCommand;
+  characterId: string | null;
+  chatId: string;
+  chatMode: ChatMode;
+  messageId?: string | null;
+  db: DB;
+  chats: ChatsStore;
+  sendRingingEvent: (data: Record<string, unknown>) => void;
+}): Promise<boolean> {
+  if (args.command.type !== "call") return false;
+  if (args.chatMode !== "conversation") return true;
+
+  const command = args.command as CallCommand;
+  const freshChat = await args.chats.getById(args.chatId);
+  const freshMeta = parseRecord(freshChat?.metadata) ?? {};
+  if (freshMeta.characterCommands === false || !isConversationCommandEnabled(freshMeta, "call")) {
+    logger.debug("[commands] Ignored call command because calls are disabled for chat %s", args.chatId);
+    return true;
+  }
+
+  const ttsSettings = await loadTtsSettings(args.db);
+  if (ttsSettings.callAudioEnabled !== true) {
+    logger.debug("[commands] Ignored call command because Conversation call audio is globally disabled");
+    return true;
+  }
+
+  const callStore = createConversationCallsStorage(args.db);
+  const existingActive = await callStore.getActiveForChat(args.chatId);
+  const existingRinging = await callStore.getRingingForChat(args.chatId);
+  const session =
+    existingActive ??
+    existingRinging ??
+    (await callStore.createSession({
+      chatId: args.chatId,
+      mode: "audio",
+      initiator: "character",
+      initiatorCharacterId: args.characterId,
+      metadata: {
+        reason: command.reason ?? null,
+        greeting: command.greeting ?? null,
+        sourceMessageId: args.messageId ?? null,
+      },
+    }));
+
+  if (session && !existingActive && !existingRinging) {
+    await args.chats.createMessagesBatch(args.chatId, [
+      {
+        role: "system",
+        characterId: args.characterId,
+        content: "Incoming call",
+        extra: {
+          displayText: null,
+          isGenerated: true,
+          tokenCount: null,
+          generationInfo: null,
+          conversationCallEvent: {
+            callId: session.id,
+            status: session.status,
+            mode: session.mode,
+            initiator: session.initiator,
+            reason: command.reason ?? null,
+            greeting: command.greeting ?? null,
+            sourceMessageId: args.messageId ?? null,
+          },
+        },
+      },
+    ]);
+  }
+
+  if (session) {
+    args.sendRingingEvent({ session, reason: command.reason ?? null, characterId: args.characterId });
+    logger.info("[commands] Conversation call ringing for chat %s", args.chatId);
+  }
+
+  return true;
+}
+
+async function loadTtsSettings(db: DB): Promise<Record<string, unknown>> {
+  const ttsSettingsRaw = await createAppSettingsStorage(db).get("tts");
+  if (!ttsSettingsRaw || typeof ttsSettingsRaw !== "string") return {};
+  try {
+    const parsed = JSON.parse(ttsSettingsRaw);
+    return parsed && typeof parsed === "object" && !Array.isArray(parsed) ? (parsed as Record<string, unknown>) : {};
+  } catch {
+    return {};
+  }
+}
+
+function parseRecord(value: unknown): Record<string, unknown> | null {
+  if (!value) return null;
+  if (typeof value === "string") {
+    try {
+      const parsed = JSON.parse(value);
+      return parsed && typeof parsed === "object" && !Array.isArray(parsed)
+        ? (parsed as Record<string, unknown>)
+        : null;
+    } catch {
+      return null;
+    }
+  }
+  return typeof value === "object" && !Array.isArray(value) ? (value as Record<string, unknown>) : null;
+}

--- a/packages/server/src/services/generation/conversation-command-runtime.ts
+++ b/packages/server/src/services/generation/conversation-command-runtime.ts
@@ -1,0 +1,325 @@
+import {
+  CONVERSATION_COMMAND_KEYS,
+  type ChatMode,
+  type ConversationCommandKey,
+} from "@marinara-engine/shared";
+
+import { logger } from "../../lib/logger.js";
+import type { CharacterCommand } from "../conversation/character-commands.js";
+import { resolveSpotifyCredentials, spotifyHasScope } from "../spotify/spotify.service.js";
+import { getActiveTurnGame } from "../turn-games/turn-game-runner.service.js";
+import { getChatHapticIntifaceUrl } from "./haptic-runtime.js";
+
+type ChatRowForCommands = {
+  id: string;
+  mode?: string | null;
+  name?: string | null;
+  characterIds?: unknown;
+};
+
+type CharacterRowForCommands = {
+  data?: unknown;
+};
+
+type ConversationCommandsChatsStore = {
+  list(): Promise<ChatRowForCommands[]>;
+};
+
+type ConversationCommandsCharactersStore = {
+  getById(id: string): Promise<CharacterRowForCommands | null>;
+};
+
+export function readConversationCommandToggles(
+  metadata: Record<string, unknown>,
+): Partial<Record<ConversationCommandKey, boolean>> {
+  const raw = metadata.conversationCommandToggles;
+  if (!raw || typeof raw !== "object" || Array.isArray(raw)) return {};
+  const source = raw as Record<string, unknown>;
+  const toggles: Partial<Record<ConversationCommandKey, boolean>> = {};
+  for (const key of CONVERSATION_COMMAND_KEYS) {
+    if (typeof source[key] === "boolean") toggles[key] = source[key] as boolean;
+  }
+  return toggles;
+}
+
+export function isConversationCommandEnabled(metadata: Record<string, unknown>, key: ConversationCommandKey): boolean {
+  return readConversationCommandToggles(metadata)[key] !== false;
+}
+
+function getConversationCommandKey(command: CharacterCommand): ConversationCommandKey | null {
+  switch (command.type) {
+    case "schedule_update":
+      return "schedule_update";
+    case "cross_post":
+      return "cross_post";
+    case "selfie":
+      return "selfie";
+    case "memory":
+      return "memory";
+    case "scene":
+      return "scene";
+    case "call":
+      return "call";
+    case "uno":
+      return "uno";
+    case "chess":
+      return "chess";
+    case "spotify":
+    case "youtube":
+      return "music";
+    case "haptic":
+      return "haptic";
+    case "influence":
+      return "influence";
+    case "note":
+      return "note";
+    case "react":
+      return "react";
+    default:
+      return null;
+  }
+}
+
+export function filterEnabledConversationCommands(
+  commands: CharacterCommand[],
+  metadata: Record<string, unknown>,
+): CharacterCommand[] {
+  return commands.filter((command) => {
+    const key = getConversationCommandKey(command);
+    return key === null || isConversationCommandEnabled(metadata, key);
+  });
+}
+
+function parseStoredAgentSettingsValue(value: unknown): Record<string, unknown> {
+  if (!value) return {};
+  if (typeof value === "string") {
+    try {
+      const parsed = JSON.parse(value);
+      return parsed && typeof parsed === "object" && !Array.isArray(parsed) ? (parsed as Record<string, unknown>) : {};
+    } catch {
+      return {};
+    }
+  }
+  return typeof value === "object" && !Array.isArray(value) ? (value as Record<string, unknown>) : {};
+}
+
+export async function isConversationYoutubeCommandAvailable(storage: {
+  getByType(type: string): Promise<{ settings?: unknown } | null>;
+}): Promise<boolean> {
+  const agent = (await storage.getByType("spotify")) ?? (await storage.getByType("youtube"));
+  const settings = parseStoredAgentSettingsValue(agent?.settings);
+  return typeof settings.youtubeApiKey === "string" && settings.youtubeApiKey.trim().length > 0;
+}
+
+export async function buildConversationCommandsReminder(args: {
+  enabled: boolean;
+  chatMode: ChatMode;
+  chatMeta: Record<string, unknown>;
+  characterIds: string[];
+  personaName: string;
+  chatId: string;
+  musicPlayerEnabled?: boolean;
+  musicPlayerSource?: string | null;
+  chats: ConversationCommandsChatsStore;
+  chars: ConversationCommandsCharactersStore;
+  agentsStore: Parameters<typeof resolveSpotifyCredentials>[0];
+  db: Parameters<typeof getActiveTurnGame>[0];
+  resolvePromptMacros: (value: string) => string;
+}): Promise<string | null> {
+  if (!args.enabled) return null;
+  const { chatMeta, chatMode, characterIds, personaName } = args;
+  const scheduleCommandEnabled = isConversationCommandEnabled(chatMeta, "schedule_update");
+  const crossPostCommandEnabled = isConversationCommandEnabled(chatMeta, "cross_post");
+  const selfieCommandEnabled = isConversationCommandEnabled(chatMeta, "selfie");
+  const memoryCommandEnabled = isConversationCommandEnabled(chatMeta, "memory");
+  const sceneCommandEnabled = isConversationCommandEnabled(chatMeta, "scene");
+  const callCommandEnabled = isConversationCommandEnabled(chatMeta, "call");
+  const musicCommandEnabled = isConversationCommandEnabled(chatMeta, "music");
+  const hapticCommandEnabled = isConversationCommandEnabled(chatMeta, "haptic");
+  const activeMusicCommandSource =
+    args.musicPlayerEnabled === false
+      ? null
+      : args.musicPlayerSource === "youtube" || args.musicPlayerSource === "custom"
+        ? args.musicPlayerSource
+        : "spotify";
+
+  // Discover other chats this character is in (for cross_post targets + memory targets)
+  const allChatsForCrossPost = await args.chats.list();
+  const crossPostTargets: string[] = [];
+  const memoryTargetCharIds = new Set<string>();
+  for (const c of allChatsForCrossPost) {
+    if (c.id === args.chatId || c.mode !== "conversation") continue;
+    const cCharIds: string[] =
+      typeof c.characterIds === "string" ? JSON.parse(c.characterIds as string) : (c.characterIds as string[]);
+    if (characterIds.some((id) => cCharIds.includes(id))) {
+      crossPostTargets.push(c.name || c.id);
+      // Collect character IDs from shared group chats (groups = 2+ characters)
+      if (cCharIds.length > 1) {
+        for (const id of cCharIds) {
+          if (!characterIds.includes(id)) memoryTargetCharIds.add(id);
+        }
+      }
+    }
+  }
+  // Also check if the CURRENT chat is a group: characters in this chat can target each other
+  if (characterIds.length > 1) {
+    for (const id of characterIds) memoryTargetCharIds.add(id);
+  }
+
+  // Resolve memory target names
+  const memoryTargetNames: string[] = [];
+  for (const tid of memoryTargetCharIds) {
+    const tRow = await args.chars.getById(tid);
+    if (tRow) {
+      const tData = JSON.parse(tRow.data as string);
+      if (tData.name) memoryTargetNames.push(tData.name);
+    }
+  }
+
+  // Check if selfie is enabled for this chat (user picked an image gen connection)
+  const hasImageGen = !!chatMeta.imageGenConnectionId;
+  let conversationSpotifyCommandsAvailable = false;
+  let conversationYoutubeCommandsAvailable = false;
+  if (chatMode === "conversation" && musicCommandEnabled && activeMusicCommandSource === "spotify") {
+    try {
+      const spotifyCredentials = await resolveSpotifyCredentials(args.agentsStore, { refreshSkewMs: 60_000 });
+      if (
+        "accessToken" in spotifyCredentials &&
+        spotifyHasScope(spotifyCredentials.scopes, "user-modify-playback-state")
+      ) {
+        conversationSpotifyCommandsAvailable = true;
+      } else {
+        const spotifyReason =
+          "error" in spotifyCredentials ? spotifyCredentials.error : "missing user-modify-playback-state scope";
+        logger.debug("[spotify/conversation] Song command unavailable: %s", spotifyReason);
+      }
+    } catch (err) {
+      logger.debug(err, "[spotify/conversation] Failed to check Spotify command availability");
+    }
+  } else if (chatMode === "conversation" && musicCommandEnabled && activeMusicCommandSource === "youtube") {
+    conversationYoutubeCommandsAvailable = await isConversationYoutubeCommandAvailable(args.agentsStore);
+  }
+
+  const commandLines: string[] = [
+    `<commands>`,
+    `Here are your optional, hidden commands you may use if you wish to, but only when they genuinely fit the conversation:`,
+    ``,
+  ];
+  let availableCommandCount = 0;
+  const addCommandLines = (...lines: string[]) => {
+    commandLines.push(...lines, ``);
+    availableCommandCount += 1;
+  };
+
+  if (scheduleCommandEnabled) {
+    addCommandLines(
+      `- [schedule_update: status="online|idle|dnd|offline", activity="activity name", duration="number of hours (e.g., 1h)"] - only if you change your own status/activity, for example, if the user asks you to stop what you're doing or if you decide to change them yourself.`,
+    );
+  }
+
+  if (crossPostCommandEnabled && crossPostTargets.length > 0) {
+    addCommandLines(
+      `- [cross_post: target="${crossPostTargets.map((t) => `"${t}"`).join("|")}"] - if you want to redirect your message to a different chat. Use this when the user suggests you say something in another chat, or when it makes sense to message someone else.`,
+      ` Example: ${personaName} says "maybe ask about that in the group chat?" → You respond: [cross_post: target="${crossPostTargets[0] ?? "group chat"}"] Hey guys, does anyone know about…`,
+    );
+  }
+
+  if (selfieCommandEnabled && hasImageGen) {
+    addCommandLines(
+      `- [selfie] or [selfie: context="description of what the selfie shows"] - you send a photo of yourself. Use this when the user asks for a selfie, photo, or pic, or when you want to share what you look like right now.`,
+      `   If you say you are sending, sharing, taking, or attaching a selfie/photo/pic, include [selfie] in that same response. Do not only narrate the action.`,
+    );
+  }
+
+  // Memory command: only available when there are valid targets (characters in shared group chats)
+  if (memoryCommandEnabled && memoryTargetNames.length > 0) {
+    addCommandLines(
+      `- [memory: target="${memoryTargetNames.map((n) => `"${n}"`).join("|")}", summary="brief description of what happened"] - create a memory that another character will remember. Use this when something notable happens between you and another character that they would naturally remember (e.g., shared a meal, had an argument, made plans). Don't overuse this; only for genuinely memorable moments.`,
+      `   Example: [memory: target="${memoryTargetNames[0]}", summary="watched a movie together and argued about the ending"]`,
+    );
+  }
+
+  // Scene command: only in conversation mode
+  if (sceneCommandEnabled && chatMode === "conversation") {
+    addCommandLines(
+      `- [scene: scenario="brief description of what happens in this scene", background="place"] - initiate a mini-roleplay scene branching from this conversation. The system will plan and create a complete immersive scene for you.`,
+      `   Example: You agree to go stargazing → include [scene: scenario="lying on a blanket in the park, looking at the stars together", background="park"]`,
+      `   WHEN TO USE: You SHOULD proactively trigger a scene whenever the conversation naturally leads to an activity, outing, or situation that would be more immersive as a scene. Examples:`,
+      `   - {{user}} says "I'm coming over" or "Let's go to the park" → trigger a scene for arriving/being at that location.`,
+      `   - You invite {{user}} somewhere and they accept → trigger a scene for that activity.`,
+      `   - A plan is made (date, trip, hangout, confrontation) and the moment arrives → trigger a scene.`,
+      `   Do NOT wait for {{user}} to explicitly ask for a scene. If the conversation implies you and {{user}} are about to DO something together, initiate the scene yourself.`,
+      `   EXCEPTION: Do NOT start a scene for playing UNO, chess, cards, or other board/table games — those have their own commands. Use [uno] for UNO and [chess] for chess, not [scene].`,
+    );
+  }
+
+  if (callCommandEnabled && chatMode === "conversation") {
+    addCommandLines(
+      `- [call], [call: reason="brief reason"], or [call: reason="brief reason", greeting="first thing to say after ${personaName} answers"] - ring ${personaName} for an audio call. Use this only when a live call naturally fits, such as when you urgently want to talk, when typing is awkward, or when ${personaName} asks you to call. The system will show an incoming call request; do not assume it was answered unless the call starts. If you include greeting, it will play only after ${personaName} accepts.`,
+    );
+  }
+
+  // Turn-games: conversation mode only, when no game is running yet and at least one other character is present.
+  const unoAdvertisable =
+    chatMode === "conversation" && isConversationCommandEnabled(chatMeta, "uno") && characterIds.length >= 1;
+  const chessAdvertisable =
+    chatMode === "conversation" && isConversationCommandEnabled(chatMeta, "chess") && characterIds.length >= 1;
+  const noActiveTurnGame =
+    (unoAdvertisable || chessAdvertisable) && !(await getActiveTurnGame(args.db, args.chatId));
+  if (unoAdvertisable && noActiveTurnGame) {
+    addCommandLines(
+      `- [uno] - start a game of UNO at the table. Include this ONLY when ${personaName} proposes playing UNO (or cards) and you are willing to play right now. The system deals the cards and runs the game — you do NOT narrate dealing or describe the hands.`,
+      `   If you are busy, tired, or simply don't feel like it, just say so in character and do NOT include [uno]. Agreeing to play IS including [uno].`,
+      `   Example: ${personaName} says "anyone up for a round of uno?" and you're in → "Oh, you're SO on. [uno]"`,
+    );
+  }
+  if (chessAdvertisable && noActiveTurnGame) {
+    addCommandLines(
+      `- [chess] - start a one-on-one chess game against ${personaName}. Include this ONLY when ${personaName} proposes playing chess and YOU are willing to play right now. Chess seats exactly two players: ${personaName} and you — whichever character includes [chess] takes the opponent's seat. The system sets up the board and runs the game — you do NOT describe the board or narrate setup.`,
+      `   If you'd rather not play, say so in character and do NOT include [chess]. Agreeing to play IS including [chess].`,
+      `   Example: ${personaName} says "up for a game of chess?" and you're in → "Prepare to lose your queen. [chess]"`,
+    );
+  }
+
+  if (conversationSpotifyCommandsAvailable) {
+    addCommandLines(
+      `- [spotify: title="Song title", artist="Artist"] - only if you want to play a selected song on the user's active Spotify player. Use this sparingly, when the song choice genuinely fits the moment.`,
+    );
+  }
+
+  if (conversationYoutubeCommandsAvailable) {
+    addCommandLines(
+      `- [youtube: query="Song title Artist"] - only if you want to play a selected song on the user's active YouTube player. Use this sparingly, when the song choice genuinely fits the moment.`,
+    );
+  }
+
+  // Haptic command: only when devices are connected and haptic feedback is enabled
+  const hapticEnabled = chatMeta.enableHapticFeedback === true;
+  if (hapticCommandEnabled && hapticEnabled) {
+    const { hapticService } = await import("../haptic/buttplug-service.js");
+    // Auto-connect to Intiface Central if not already connected
+    if (!hapticService.connected) {
+      try {
+        await hapticService.connect(getChatHapticIntifaceUrl(chatMeta));
+      } catch {
+        logger.warn("[haptic] Auto-connect to Intiface Central failed — is the server running?");
+      }
+    }
+    if (hapticService.connected && hapticService.devices.length > 0) {
+      const deviceNames = hapticService.devices.map((d) => d.name).join(", ");
+      addCommandLines(
+        `- [haptic: action="vibrate|oscillate|rotate|position|stop", intensity=0.0-1.0, duration=seconds (0 = loop until next command)] or [haptic: action="stop"] - control or stop the user's connected intimate device(s) (${deviceNames}). Use this during physical/intimate/sensual moments to provide haptic feedback that matches the narrative. Vary intensity based on the scene.`,
+        `   You can include multiple [haptic] commands in one message for patterns (e.g., escalating: 0.2 → 0.5 → 0.8).`,
+        `   Example: *trails a finger slowly down your arm* [haptic: action="vibrate", intensity=0.3, duration=2]`,
+      );
+    }
+  }
+
+  if (availableCommandCount === 0) return null;
+  commandLines.push(
+    `IMPORTANT: Commands are stripped from your message before the user sees it. The rest of your message is shown normally. You can include multiple commands in one message, but you do not need to use any of them unless it makes sense in context.`,
+    `</commands>`,
+  );
+
+  return args.resolvePromptMacros(commandLines.join("\n"));
+}

--- a/packages/server/src/services/generation/conversation-cross-post-command-runtime.ts
+++ b/packages/server/src/services/generation/conversation-cross-post-command-runtime.ts
@@ -1,0 +1,72 @@
+import { normalizeTextForMatch } from "@marinara-engine/shared";
+
+import { logger } from "../../lib/logger.js";
+import type { CharacterCommand, CrossPostCommand } from "../conversation/character-commands.js";
+
+type ChatRow = {
+  id: string;
+  name?: string | null;
+  mode?: string | null;
+};
+
+type ChatsStore = {
+  list(): Promise<ChatRow[]>;
+  getMessage(id: string): Promise<{ content?: unknown } | null>;
+  createMessage(input: {
+    chatId: string;
+    role: string;
+    characterId: string | null;
+    content: string;
+  }): Promise<unknown>;
+  removeMessage(id: string): Promise<unknown>;
+};
+
+export async function handleConversationCrossPostCommand(args: {
+  command: CharacterCommand;
+  characterId: string | null;
+  chatId: string;
+  messageId?: string | null;
+  fullResponse: string;
+  chats: ChatsStore;
+  sendCrossPost: (data: Record<string, unknown>) => void;
+}): Promise<boolean> {
+  if (args.command.type !== "cross_post") return false;
+  const command = args.command as CrossPostCommand;
+  const targetName = normalizeTextForMatch(command.target);
+
+  const allChatsList = await args.chats.list();
+  const targetChat = allChatsList.find(
+    (chat) =>
+      chat.mode === "conversation" &&
+      chat.id !== args.chatId &&
+      (normalizeTextForMatch(chat.name ?? "").includes(targetName) || chat.id === command.target),
+  );
+
+  if (!targetChat) {
+    logger.warn('[commands] Cross-post target "%s" not found', command.target);
+    return true;
+  }
+
+  const msgRow = args.messageId ? await args.chats.getMessage(args.messageId) : null;
+  const msgContent = typeof msgRow?.content === "string" ? msgRow.content : args.fullResponse;
+  await args.chats.createMessage({
+    chatId: targetChat.id,
+    role: "assistant",
+    characterId: args.characterId,
+    content: msgContent,
+  });
+
+  if (args.messageId) {
+    await args.chats.removeMessage(args.messageId);
+  }
+
+  args.sendCrossPost({
+    targetChatId: targetChat.id,
+    targetChatName: targetChat.name,
+    sourceChatId: args.chatId,
+    characterId: args.characterId,
+  });
+  logger.info('[commands] Cross-posted message to chat "%s" (%s)', targetChat.name, targetChat.id);
+
+  return true;
+}

--- a/packages/server/src/services/generation/conversation-music-command-runtime.ts
+++ b/packages/server/src/services/generation/conversation-music-command-runtime.ts
@@ -1,0 +1,114 @@
+import type { ChatMode } from "@marinara-engine/shared";
+
+import { logger } from "../../lib/logger.js";
+import type {
+  CharacterCommand,
+  SpotifyCommand,
+  YouTubeCommand,
+} from "../conversation/character-commands.js";
+import {
+  ConversationSpotifyCommandError,
+  isSilentConversationSpotifyCommandError,
+  playConversationSpotifyCommand,
+} from "../spotify/conversation-spotify-command.service.js";
+
+type SpotifyStorage = Parameters<typeof playConversationSpotifyCommand>[0]["storage"];
+
+export async function handleConversationMusicCommand(args: {
+  command: CharacterCommand;
+  chatId: string;
+  chatMode: ChatMode;
+  agentsStore: SpotifyStorage;
+  sendEvent: (event: { type: string; data: Record<string, unknown> }) => void;
+}): Promise<boolean> {
+  if (args.command.type === "spotify") {
+    await handleSpotifyCommand(args.command as SpotifyCommand, args);
+    return true;
+  }
+  if (args.command.type === "youtube") {
+    handleYoutubeCommand(args.command as YouTubeCommand, args);
+    return true;
+  }
+  return false;
+}
+
+async function handleSpotifyCommand(
+  command: SpotifyCommand,
+  args: Parameters<typeof handleConversationMusicCommand>[0],
+): Promise<void> {
+  if (args.chatMode !== "conversation") {
+    logger.debug("[spotify/conversation] Ignored song command outside conversation mode");
+    return;
+  }
+
+  try {
+    const result = await playConversationSpotifyCommand({
+      storage: args.agentsStore,
+      title: command.title,
+      artist: command.artist,
+    });
+    args.sendEvent({
+      type: "spotify_command",
+      data: {
+        title: command.title,
+        artist: command.artist,
+        track: result.track,
+      },
+    });
+    logger.info(
+      '[spotify/conversation] Played "%s" by "%s" for chat %s',
+      result.track.name,
+      result.track.artist,
+      args.chatId,
+    );
+  } catch (err) {
+    if (isSilentConversationSpotifyCommandError(err)) {
+      logger.debug(
+        '[spotify/conversation] Dropped unavailable song command: "%s" by "%s" - %s',
+        command.title,
+        command.artist,
+        err.message,
+      );
+      return;
+    }
+
+    const message = err instanceof Error ? err.message : "Spotify song command failed.";
+    args.sendEvent({
+      type: "spotify_command_error",
+      data: {
+        title: command.title,
+        artist: command.artist,
+        error: message,
+      },
+    });
+    if (err instanceof ConversationSpotifyCommandError) {
+      logger.warn(
+        '[spotify/conversation] Song command failed (%d): "%s" by "%s" - %s',
+        err.status,
+        command.title,
+        command.artist,
+        err.message,
+      );
+    } else {
+      logger.warn(err, "[spotify/conversation] Song command failed");
+    }
+  }
+}
+
+function handleYoutubeCommand(
+  command: YouTubeCommand,
+  args: Parameters<typeof handleConversationMusicCommand>[0],
+): void {
+  if (args.chatMode !== "conversation") {
+    logger.debug("[youtube/conversation] Ignored song command outside conversation mode");
+    return;
+  }
+  args.sendEvent({
+    type: "youtube_command",
+    data: {
+      searchQuery: command.query,
+      mood: "Conversation music command",
+    },
+  });
+  logger.info('[youtube/conversation] Requested "%s" for chat %s', command.query, args.chatId);
+}

--- a/packages/server/src/services/generation/conversation-react-command-runtime.ts
+++ b/packages/server/src/services/generation/conversation-react-command-runtime.ts
@@ -1,0 +1,252 @@
+import {
+  normalizeTextForMatch,
+  parseGroupedSpeakerSegments,
+  stripLeadingMessageTimestamps,
+  type ChatMode,
+} from "@marinara-engine/shared";
+
+import { logger } from "../../lib/logger.js";
+import {
+  addMessageReactor,
+  buildConversationCustomEmojiKey,
+  buildGlobalCustomEmojiUrl,
+  REACTION_ANNOTATION_CONTENT_CAP,
+} from "../../routes/generate/conversation-custom-assets.js";
+import { parseExtra } from "../../routes/generate/generate-route-utils.js";
+import type { CharacterCommand, ReactCommand } from "../conversation/character-commands.js";
+
+type MessageRow = {
+  id?: unknown;
+  role?: unknown;
+  content?: unknown;
+  characterId?: unknown;
+  extra?: unknown;
+  activeSwipeIndex?: number | null;
+};
+
+type ChatsStore = {
+  getMessage(id: string): Promise<MessageRow | null>;
+  getSwipes(messageId: string): Promise<Array<{ index: number }>>;
+  updateMessageExtra(id: string, partial: Record<string, unknown>): Promise<unknown>;
+  updateSwipeExtra(messageId: string, swipeIndex: number, partial: Record<string, unknown>): Promise<unknown>;
+};
+
+type CharactersStore = {
+  getById(id: string): Promise<{ data: unknown } | null>;
+};
+
+type CustomEmojiStore = {
+  getByName(name: string): Promise<{ filePath?: unknown } | null>;
+};
+
+type ChatMember = { id: string; name: string };
+type SegmentTarget = { segment: number; speaker: string | null };
+
+export async function handleConversationReactCommand(args: {
+  command: CharacterCommand;
+  characterId: string | null;
+  sourceMessageId?: string | null;
+  chatMode: ChatMode;
+  chatMessages: MessageRow[];
+  personaId: string | null;
+  personaName: string;
+  conversationCustomEmojiUrlByName: Map<string, string>;
+  customEmojisStore: CustomEmojiStore;
+  chars: CharactersStore;
+  chats: ChatsStore;
+  getReactChatMembers: () => Promise<ChatMember[]>;
+}): Promise<boolean> {
+  if (args.command.type !== "react") return false;
+  const command = args.command as ReactCommand;
+  if (args.chatMode !== "conversation") {
+    logger.debug("[react/conversation] Ignored react command outside conversation mode");
+    return true;
+  }
+  if (!args.characterId || !command.emoji) return true;
+
+  const imageUrl = await resolveCustomEmojiImageUrl(command, args);
+  const target = await resolveReactionTarget(command, args);
+  if (!target) return true;
+
+  const targetMsg =
+    target.prefetchedMessage && target.id === target.prefetchedMessage.id
+      ? target.prefetchedMessage
+      : await args.chats.getMessage(target.id);
+  if (!targetMsg) return true;
+
+  const ex = parseExtra(targetMsg.extra);
+  const reactions = addMessageReactor(ex.reactions, command.emoji, args.characterId, imageUrl, target.segmentTarget);
+  await args.chats.updateMessageExtra(target.id, { reactions });
+
+  const targetSwipes = await args.chats.getSwipes(target.id);
+  for (const swipe of targetSwipes) {
+    if (swipe.index === targetMsg.activeSwipeIndex) continue;
+    await args.chats.updateSwipeExtra(target.id, swipe.index, { reactions });
+  }
+
+  logger.info(
+    "[react/conversation] %s reacted with %s on message %s%s",
+    args.characterId,
+    command.emoji,
+    target.id,
+    target.segmentTarget ? ` (segment ${target.segmentTarget.segment})` : "",
+  );
+
+  return true;
+}
+
+async function resolveCustomEmojiImageUrl(
+  command: ReactCommand,
+  args: Parameters<typeof handleConversationReactCommand>[0],
+): Promise<string | null> {
+  const customName = command.emoji.match(/^:([a-zA-Z0-9_]+):$/)?.[1];
+  if (!customName) return null;
+
+  const emojiLookupKeys = [
+    args.characterId ? buildConversationCustomEmojiKey("character", args.characterId, customName) : null,
+    args.personaId ? buildConversationCustomEmojiKey("persona", args.personaId, customName) : null,
+    buildConversationCustomEmojiKey("global", null, customName),
+  ].filter((key): key is string => Boolean(key));
+
+  for (const key of emojiLookupKeys) {
+    const imageUrl = args.conversationCustomEmojiUrlByName.get(key) ?? null;
+    if (imageUrl) return imageUrl;
+  }
+
+  const row = await args.customEmojisStore.getByName(customName);
+  return row?.filePath ? buildGlobalCustomEmojiUrl(String(row.filePath)) : null;
+}
+
+async function resolveReactionTarget(
+  command: ReactCommand,
+  args: Parameters<typeof handleConversationReactCommand>[0],
+): Promise<{ id: string; segmentTarget: SegmentTarget | null; prefetchedMessage: MessageRow | null } | null> {
+  let targetId = [...args.chatMessages].reverse().find((m) => m.role === "user")?.id;
+  let segmentTarget: SegmentTarget | null = null;
+  let prefetchedMessage: MessageRow | null = null;
+
+  if (command.targetCharacter) {
+    const chatMembers = await args.getReactChatMembers();
+    const wanted = normalizeTextForMatch(command.targetCharacter);
+    const targetChar = chatMembers.find((m) => normalizeTextForMatch(m.name) === wanted);
+    if (!targetChar) {
+      const targetsPersona = wanted === normalizeTextForMatch(args.personaName) || wanted === "user";
+      if (!targetsPersona) {
+        logger.debug(
+          '[react/conversation] Unknown react target "%s" - falling back to the user message',
+          command.targetCharacter,
+        );
+      }
+    } else {
+      const resolved = await resolveTargetedCharacterReaction(command, args, chatMembers, targetChar, wanted);
+      if (!resolved) return null;
+      targetId = resolved.id;
+      segmentTarget = resolved.target;
+      prefetchedMessage = resolved.prefetchedMessage;
+    }
+  }
+
+  return typeof targetId === "string" ? { id: targetId, segmentTarget, prefetchedMessage } : null;
+}
+
+async function resolveTargetedCharacterReaction(
+  command: ReactCommand,
+  args: Parameters<typeof handleConversationReactCommand>[0],
+  chatMembers: ChatMember[],
+  targetChar: ChatMember,
+  wanted: string,
+): Promise<{ id: string; target: SegmentTarget | null; prefetchedMessage: MessageRow | null } | null> {
+  const baseNames = new Set(chatMembers.map((m) => normalizeTextForMatch(m.name)));
+  const authorNameCache = new Map<string, string | null>();
+  const authorNameOf = async (cid: unknown): Promise<string | null> => {
+    if (typeof cid !== "string" || !cid) return null;
+    const member = chatMembers.find((m) => m.id === cid);
+    if (member) return member.name;
+    if (authorNameCache.has(cid)) return authorNameCache.get(cid)!;
+    let name: string | null = null;
+    const row = await args.chars.getById(cid);
+    if (row) {
+      try {
+        const parsed = typeof row.data === "string" ? JSON.parse(row.data) : row.data;
+        const parsedName = parsed && typeof parsed === "object" ? (parsed as Record<string, unknown>).name : null;
+        if (typeof parsedName === "string" && parsedName.trim()) name = parsedName;
+      } catch {
+        // Malformed character data; segment matching can proceed without this author.
+      }
+    }
+    authorNameCache.set(cid, name);
+    return name;
+  };
+
+  const lastPartBy = async (
+    content: unknown,
+    authorId: unknown,
+    beforePartByNorm?: string | null,
+  ): Promise<SegmentTarget | null> => {
+    const rawText = typeof content === "string" ? content : String(content ?? "");
+    if (!rawText.trim() || rawText.length > REACTION_ANNOTATION_CONTENT_CAP) return null;
+    const text = stripLeadingMessageTimestamps(rawText);
+    if (!text) return null;
+    const names = new Set(baseNames);
+    const author = await authorNameOf(authorId);
+    if (author) names.add(normalizeTextForMatch(author));
+    const groups = parseGroupedSpeakerSegments(text, names);
+    if (!groups) return null;
+    let cutoff = groups.length;
+    if (beforePartByNorm) {
+      const reactorFirst = groups.findIndex(
+        (group) => group.speaker != null && normalizeTextForMatch(group.speaker) === beforePartByNorm,
+      );
+      if (reactorFirst >= 0) cutoff = reactorFirst;
+    }
+    for (let gi = cutoff - 1; gi >= 0; gi--) {
+      const group = groups[gi]!;
+      if (
+        group.speaker != null &&
+        normalizeTextForMatch(group.speaker) === wanted &&
+        group.lines.some((line) => line.trim().length > 0)
+      ) {
+        return { segment: gi, speaker: group.speaker };
+      }
+    }
+    return null;
+  };
+
+  if (typeof args.sourceMessageId === "string") {
+    const ownMsg = await args.chats.getMessage(args.sourceMessageId);
+    if (ownMsg) {
+      const reactorName = chatMembers.find((member) => member.id === args.characterId)?.name ?? null;
+      const part = await lastPartBy(
+        ownMsg.content,
+        ownMsg.characterId,
+        reactorName ? normalizeTextForMatch(reactorName) : null,
+      );
+      if (part) {
+        return { id: args.sourceMessageId, target: part, prefetchedMessage: ownMsg };
+      }
+    }
+  }
+
+  const recent = [...args.chatMessages].slice(-30).reverse();
+  for (const message of recent) {
+    if (typeof message.id !== "string" || message.role === "user") continue;
+    const messageExtra = parseExtra(message.extra) as Record<string, unknown>;
+    if (messageExtra.hiddenFromUser === true || messageExtra.commandOnly === true) continue;
+    const contentStr = typeof message.content === "string" ? message.content : String(message.content ?? "");
+    const hasAttachments = Array.isArray(messageExtra.attachments) && messageExtra.attachments.length > 0;
+    if (!contentStr.trim() && !hasAttachments) continue;
+    if (message.characterId === targetChar.id) {
+      return { id: message.id, target: await lastPartBy(message.content, message.characterId), prefetchedMessage: null };
+    }
+    const part = await lastPartBy(message.content, message.characterId);
+    if (part) {
+      return { id: message.id, target: part, prefetchedMessage: null };
+    }
+  }
+
+  logger.debug(
+    '[react/conversation] No recent part by "%s" to react to - skipping targeted react',
+    targetChar.name,
+  );
+  return null;
+}

--- a/packages/server/src/services/generation/conversation-scene-command-runtime.ts
+++ b/packages/server/src/services/generation/conversation-scene-command-runtime.ts
@@ -75,6 +75,8 @@ export async function handleConversationSceneCommand(args: {
         createBody.chatId,
         args.chatId,
       );
+    } else {
+      logger.warn("[commands] Scene create returned no chatId for chat %s: %j", args.chatId, createBody);
     }
   } catch (err) {
     logger.error(err, "[commands] Scene creation failed");

--- a/packages/server/src/services/generation/conversation-scene-command-runtime.ts
+++ b/packages/server/src/services/generation/conversation-scene-command-runtime.ts
@@ -1,0 +1,99 @@
+import type { FastifyInstance } from "fastify";
+
+import { logger } from "../../lib/logger.js";
+import type { CharacterCommand, SceneCommand } from "../conversation/character-commands.js";
+
+type ChatsStore = {
+  getById(id: string): Promise<{ id?: string; characterIds?: unknown } | null>;
+};
+
+type CharactersStore = {
+  getById(id: string): Promise<{ data: unknown } | null>;
+};
+
+export async function handleConversationSceneCommand(args: {
+  command: CharacterCommand;
+  characterId: string | null;
+  chatId: string;
+  app: FastifyInstance;
+  chars: CharactersStore;
+  chats: ChatsStore;
+  sendSceneCreated: (data: Record<string, unknown>) => void;
+}): Promise<boolean> {
+  if (args.command.type !== "scene") return false;
+  const command = args.command as SceneCommand;
+
+  try {
+    const originChat = await args.chats.getById(args.chatId);
+    if (!originChat) throw new Error("Origin chat not found");
+
+    const initiatorRow = args.characterId ? await args.chars.getById(args.characterId) : null;
+    const initiatorData = parseRecord(initiatorRow?.data);
+    const initiatorName =
+      typeof initiatorData?.name === "string" && initiatorData.name.trim() ? initiatorData.name : "Character";
+
+    const planRes = await args.app.inject({
+      method: "POST",
+      url: "/api/scene/plan",
+      payload: {
+        chatId: args.chatId,
+        prompt: command.scenario,
+        connectionId: null,
+      },
+    });
+    const planBody = JSON.parse(planRes.body);
+    if (!planBody.plan) throw new Error("Scene plan failed");
+
+    if (command.background) {
+      planBody.plan.background = command.background;
+    }
+
+    const createRes = await args.app.inject({
+      method: "POST",
+      url: "/api/scene/create",
+      payload: {
+        originChatId: args.chatId,
+        initiatorCharId: args.characterId,
+        plan: planBody.plan,
+        connectionId: null,
+      },
+    });
+    const createBody = JSON.parse(createRes.body);
+
+    if (createBody.chatId) {
+      args.sendSceneCreated({
+        sceneChatId: createBody.chatId,
+        sceneChatName: createBody.chatName,
+        description: createBody.description,
+        background: createBody.background ?? null,
+        initiatorCharId: args.characterId,
+        initiatorCharName: initiatorName,
+      });
+      logger.info(
+        '[commands] Scene created: "%s" (%s) from chat %s',
+        createBody.chatName,
+        createBody.chatId,
+        args.chatId,
+      );
+    }
+  } catch (err) {
+    logger.error(err, "[commands] Scene creation failed");
+  }
+
+  return true;
+}
+
+function parseRecord(value: unknown): Record<string, unknown> | null {
+  if (!value) return null;
+  if (typeof value === "string") {
+    try {
+      const parsed = JSON.parse(value);
+      return parsed && typeof parsed === "object" && !Array.isArray(parsed)
+        ? (parsed as Record<string, unknown>)
+        : null;
+    } catch {
+      return null;
+    }
+  }
+  return typeof value === "object" && !Array.isArray(value) ? (value as Record<string, unknown>) : null;
+}

--- a/packages/server/src/services/generation/conversation-schedule-command-runtime.ts
+++ b/packages/server/src/services/generation/conversation-schedule-command-runtime.ts
@@ -1,0 +1,115 @@
+import {
+  parseDuration,
+  type CharacterCommand,
+  type ScheduleUpdateCommand,
+} from "../conversation/character-commands.js";
+import { logger } from "../../lib/logger.js";
+import { getEnabledConversationSchedules } from "./conversation-context-utils.js";
+
+type ChatsStore = {
+  getById(id: string): Promise<{ metadata?: unknown } | null>;
+  updateMetadata(id: string, patch: Record<string, unknown>): Promise<unknown>;
+};
+
+type ScheduleBlock = {
+  time: string;
+  activity: string;
+  status: string;
+};
+
+type WeekScheduleRecord = {
+  days?: Record<string, ScheduleBlock[]>;
+};
+
+const DAYS_LIST = ["Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday", "Sunday"] as const;
+
+export async function handleConversationScheduleCommand(args: {
+  command: CharacterCommand;
+  characterId: string | null;
+  chatId: string;
+  chats: ChatsStore;
+  sendUpdated: (data: Record<string, unknown>) => void;
+}): Promise<boolean> {
+  if (args.command.type !== "schedule_update") return false;
+  const command = args.command as ScheduleUpdateCommand;
+  if (!args.characterId || (!command.status && !command.activity)) return true;
+
+  const freshChat = await args.chats.getById(args.chatId);
+  const freshMeta = parseRecord(freshChat?.metadata) ?? {};
+  const schedules = getEnabledConversationSchedules(freshMeta) as Record<string, WeekScheduleRecord>;
+  const schedule = schedules[args.characterId];
+  if (!schedule) return true;
+
+  const nowDate = new Date();
+  const dayName = DAYS_LIST[(nowDate.getDay() + 6) % 7]!;
+  const daySchedule = schedule.days?.[dayName] ?? [];
+  const currentMinutes = nowDate.getHours() * 60 + nowDate.getMinutes();
+  const updated = updateCurrentScheduleBlock(daySchedule, currentMinutes, command);
+  if (!updated) return true;
+
+  schedule.days = { ...(schedule.days ?? {}), [dayName]: daySchedule };
+  schedules[args.characterId] = schedule;
+  await args.chats.updateMetadata(args.chatId, { ...freshMeta, characterSchedules: schedules });
+
+  args.sendUpdated({ characterId: args.characterId, status: command.status, activity: command.activity });
+  logger.info(
+    "[commands] Schedule updated for %s: status=%s, activity=%s",
+    args.characterId,
+    command.status,
+    command.activity,
+  );
+
+  return true;
+}
+
+function updateCurrentScheduleBlock(
+  daySchedule: ScheduleBlock[],
+  currentMinutes: number,
+  command: ScheduleUpdateCommand,
+): boolean {
+  for (const block of daySchedule) {
+    const [startStr, endStr] = block.time.split("-");
+    if (!startStr || !endStr) continue;
+    const [sh, sm] = startStr.split(":").map(Number);
+    const [eh, em] = endStr.split(":").map(Number);
+    const startMin = (sh ?? 0) * 60 + (sm ?? 0);
+    const endMin = (eh ?? 0) * 60 + (em ?? 0);
+    if (startMin > currentMinutes || currentMinutes >= endMin) continue;
+
+    if (command.status) block.status = command.status;
+    if (command.activity) block.activity = command.activity;
+
+    if (command.duration) {
+      const durationMin = parseDuration(command.duration);
+      if (durationMin && currentMinutes + durationMin < endMin) {
+        const splitTime = currentMinutes + durationMin;
+        const splitH = String(Math.floor(splitTime / 60)).padStart(2, "0");
+        const splitM = String(splitTime % 60).padStart(2, "0");
+        block.time = `${startStr}-${splitH}:${splitM}`;
+        const idx = daySchedule.indexOf(block);
+        daySchedule.splice(idx + 1, 0, {
+          time: `${splitH}:${splitM}-${endStr}`,
+          activity: "free time",
+          status: "online",
+        });
+      }
+    }
+    return true;
+  }
+  return false;
+}
+
+function parseRecord(value: unknown): Record<string, unknown> | null {
+  if (!value) return null;
+  if (typeof value === "string") {
+    try {
+      const parsed = JSON.parse(value);
+      return parsed && typeof parsed === "object" && !Array.isArray(parsed)
+        ? (parsed as Record<string, unknown>)
+        : null;
+    } catch {
+      return null;
+    }
+  }
+  return typeof value === "object" && !Array.isArray(value) ? (value as Record<string, unknown>) : null;
+}

--- a/packages/server/src/services/generation/conversation-schedule-command-runtime.ts
+++ b/packages/server/src/services/generation/conversation-schedule-command-runtime.ts
@@ -72,6 +72,7 @@ function updateCurrentScheduleBlock(
     if (!startStr || !endStr) continue;
     const [sh, sm] = startStr.split(":").map(Number);
     const [eh, em] = endStr.split(":").map(Number);
+    if (![sh, sm, eh, em].every((part) => Number.isFinite(part))) continue;
     const startMin = (sh ?? 0) * 60 + (sm ?? 0);
     const endMin = (eh ?? 0) * 60 + (em ?? 0);
     if (startMin > currentMinutes || currentMinutes >= endMin) continue;

--- a/packages/server/src/services/generation/conversation-selfie-command-runtime.ts
+++ b/packages/server/src/services/generation/conversation-selfie-command-runtime.ts
@@ -1,0 +1,311 @@
+import type { DB } from "../../db/connection.js";
+import { logger } from "../../lib/logger.js";
+import {
+  isNovelAiImageConnection,
+  resolveIllustratorCharacterReferences,
+} from "../../routes/generate/illustrator-references.js";
+import { compileImagePrompt } from "../image/image-prompt-compiler.js";
+import { resolveConnectionImageDefaults } from "../image/image-generation-defaults.js";
+import { generateImage, saveImageToDisk } from "../image/image-generation.js";
+import { loadImageGenerationUserSettings } from "../image/image-generation-settings.js";
+import { createLLMProvider } from "../llm/provider-registry.js";
+import { resolveConversationSelfieSystemPrompt } from "../conversation/selfie-prompt.js";
+import type { CharacterCommand, SelfieCommand } from "../conversation/character-commands.js";
+import { createGalleryStorage } from "../storage/gallery.storage.js";
+import { createPromptOverridesStorage } from "../storage/prompt-overrides.storage.js";
+
+type CharactersStore = {
+  getById(id: string): Promise<{ data: unknown } | null>;
+  list(): Promise<Array<{ id: string; data: unknown; avatarPath?: string | null }>>;
+};
+
+type ChatsStore = {
+  appendSwipeAttachment(messageId: string, swipeIndex: number, attachment: Record<string, unknown>): Promise<unknown>;
+  appendMessageAttachment(messageId: string, attachment: Record<string, unknown>): Promise<unknown>;
+  getMessage(id: string): Promise<{ activeSwipeIndex?: number | null } | null>;
+};
+
+type ConnectionsStore = {
+  getWithKey(id: string): Promise<Record<string, any> | null>;
+};
+
+type PromptConnection = {
+  provider: string;
+  apiKey: string;
+  model: string;
+  maxContext?: number | null;
+  openrouterProvider?: string | null;
+  maxTokensOverride?: number | null;
+};
+
+type PromptCharacter = {
+  id: string;
+  name: string;
+  avatarPath?: string | null;
+  appearance?: string | null;
+};
+
+type PersonaReference = {
+  id: string | null;
+  name: string;
+  avatarPath?: string | null;
+  appearance?: string | null;
+} | null;
+
+export async function handleConversationSelfieCommand(args: {
+  command: CharacterCommand;
+  characterId: string | null;
+  chatId: string;
+  messageId?: string | null;
+  swipeIndex?: number | null;
+  chatMeta: Record<string, unknown>;
+  charInfo: PromptCharacter[];
+  persona: PersonaReference;
+  promptConnection: PromptConnection;
+  baseUrl: string;
+  suppressModelParameters: boolean;
+  serviceTier: "flex" | "priority" | null;
+  db: DB;
+  chars: CharactersStore;
+  chats: ChatsStore;
+  connections: ConnectionsStore;
+  sendEvent: (payload: Record<string, unknown>) => void;
+}): Promise<boolean> {
+  if (args.command.type !== "selfie") return false;
+  const command = args.command as SelfieCommand;
+
+  const imgConnId = typeof args.chatMeta.imageGenConnectionId === "string" ? args.chatMeta.imageGenConnectionId : "";
+  if (!imgConnId) {
+    logger.warn("[commands] Selfie requested but no imageGenConnectionId set on chat metadata");
+    args.sendEvent({
+      type: "selfie_error",
+      data: {
+        characterId: args.characterId,
+        error: "No image generation connection configured for this chat. Set one in Chat Settings.",
+      },
+    });
+    return true;
+  }
+
+  const charRow = args.characterId ? await args.chars.getById(args.characterId) : null;
+  const charData = parseRecord(charRow?.data);
+  const charName = typeof charData?.name === "string" && charData.name.trim() ? charData.name : "character";
+  args.sendEvent({ type: "typing", characters: [charName] });
+
+  try {
+    await generateSelfie({ ...args, command, imgConnId, charData, charName });
+  } catch (err) {
+    logger.error(err, "[commands] Selfie generation failed");
+    args.sendEvent({
+      type: "selfie_error",
+      data: {
+        characterId: args.characterId,
+        error: err instanceof Error ? err.message : "Image generation failed",
+      },
+    });
+  }
+
+  return true;
+}
+
+async function generateSelfie(args: Parameters<typeof handleConversationSelfieCommand>[0] & {
+  command: SelfieCommand;
+  imgConnId: string;
+  charData: Record<string, unknown> | null;
+  charName: string;
+}): Promise<void> {
+  const imgConnFull = await args.connections.getWithKey(args.imgConnId);
+  if (!imgConnFull) throw new Error("Cannot decrypt image generation connection");
+
+  const extensions = parseRecord(args.charData?.extensions);
+  const appearance =
+    (typeof extensions?.appearance === "string" && extensions.appearance) ||
+    (typeof args.charData?.description === "string" ? args.charData.description : "");
+
+  const selfieTags = Array.isArray(args.chatMeta.selfieTags) ? (args.chatMeta.selfieTags as string[]) : [];
+  const selfiePositivePrompt =
+    typeof args.chatMeta.selfiePositivePrompt === "string"
+      ? args.chatMeta.selfiePositivePrompt.trim()
+      : selfieTags.join(", ").trim();
+  const selfieNegativePrompt =
+    typeof args.chatMeta.selfieNegativePrompt === "string" ? args.chatMeta.selfieNegativePrompt.trim() : "";
+  const selfiePromptTemplate =
+    typeof args.chatMeta.selfiePrompt === "string" ? args.chatMeta.selfiePrompt.trim() : "";
+
+  const promptBuilder = createLLMProvider(
+    args.promptConnection.provider,
+    args.baseUrl,
+    args.promptConnection.apiKey,
+    args.promptConnection.maxContext,
+    args.promptConnection.openrouterProvider,
+    args.promptConnection.maxTokensOverride,
+  );
+  const selfieSystemPrompt = await resolveConversationSelfieSystemPrompt({
+    promptOverridesStorage: createPromptOverridesStorage(args.db),
+    chatPromptTemplate: selfiePromptTemplate,
+    appearance,
+    charName: args.charName,
+  });
+  const promptResult = await promptBuilder.chatComplete(
+    [
+      {
+        role: "system",
+        content: selfieSystemPrompt,
+      },
+      {
+        role: "user",
+        content: args.command.context
+          ? `Context for the selfie: ${args.command.context}`
+          : `Generate a casual selfie of ${args.charName} based on the current conversation context.`,
+      },
+    ],
+    {
+      model: args.promptConnection.model,
+      ...(args.suppressModelParameters ? {} : { temperature: 0.7, maxTokens: 8196, serviceTier: args.serviceTier }),
+      suppressModelParameters: args.suppressModelParameters,
+    },
+  );
+
+  const imagePrompt = (promptResult.content ?? "").trim();
+  if (!imagePrompt) return;
+
+  const suppressReferencePromptLine = isNovelAiImageConnection({
+    model: imgConnFull.model,
+    baseUrl: imgConnFull.baseUrl,
+    imageService: imgConnFull.imageService,
+    imageGenerationSource: imgConnFull.imageGenerationSource,
+  });
+  let finalSelfiePrompt = selfiePositivePrompt ? `${imagePrompt}, ${selfiePositivePrompt}` : imagePrompt;
+  let selfieReferenceImages: string[] | undefined;
+  const selfieUseAvatarReferences = args.chatMeta.selfieUseAvatarReferences === true;
+  const selfieIncludeCharacterAppearance = args.chatMeta.selfieIncludeCharacterAppearance === true;
+  if (selfieUseAvatarReferences || selfieIncludeCharacterAppearance) {
+    const referenceResolution = await resolveIllustratorCharacterReferences({
+      charactersStore: args.chars,
+      chatCharacters: args.charInfo.map((character) => ({
+        id: character.id,
+        name: character.name,
+        avatarPath: character.avatarPath,
+        appearance: character.appearance,
+      })),
+      persona: args.persona,
+      requestedNames: [args.charName],
+      promptText: [args.charName, args.command.context ?? "", imagePrompt].join("\n"),
+      fallbackToChatCharacters: false,
+      maxReferences: 1,
+    });
+    if (selfieIncludeCharacterAppearance && referenceResolution.appearanceBlock) {
+      finalSelfiePrompt += `\n\n${referenceResolution.appearanceBlock}`;
+      logger.debug("[selfie] Added character appearance notes for: %s", referenceResolution.appearanceNames.join(", "));
+    }
+    if (selfieUseAvatarReferences && referenceResolution.referenceImages.length > 0) {
+      selfieReferenceImages = referenceResolution.referenceImages;
+      if (referenceResolution.referenceLine && !suppressReferencePromptLine) {
+        finalSelfiePrompt += `\n\n${referenceResolution.referenceLine}`;
+      }
+      logger.debug("[selfie] Sending character reference for: %s", referenceResolution.referenceNames.join(", "));
+    }
+  }
+
+  const galleryStore = createGalleryStorage(args.db);
+  const imgModel = imgConnFull.model || "";
+  const imgBaseUrl = imgConnFull.baseUrl || "https://image.pollinations.ai";
+  const imgApiKey = imgConnFull.apiKey || "";
+  const imgSource = imgConnFull.imageGenerationSource || imgModel;
+  const imageDefaults = resolveConnectionImageDefaults(imgConnFull);
+  const imageSettings = await loadImageGenerationUserSettings(args.db);
+  const configuredStyleProfileId =
+    readNestedString(args.chatMeta.gameSetupConfig, "imageStyleProfileId") ??
+    (typeof args.chatMeta.imageStyleProfileId === "string" ? args.chatMeta.imageStyleProfileId : null);
+  const styleProfileId =
+    typeof configuredStyleProfileId === "string" && configuredStyleProfileId.trim()
+      ? configuredStyleProfileId.trim()
+      : imageSettings.styleProfiles.defaultProfileId;
+
+  const selfieRes = typeof args.chatMeta.selfieResolution === "string" ? args.chatMeta.selfieResolution : "";
+  const [selfieW, selfieH] = selfieRes.split("x").map(Number) as [number, number];
+  const serviceHint = imgConnFull.imageService || "";
+  const compiledSelfiePrompt = compileImagePrompt({
+    kind: "selfie",
+    prompt: finalSelfiePrompt,
+    negativePrompt: selfieNegativePrompt || undefined,
+    styleProfiles: imageSettings.styleProfiles,
+    styleProfileId,
+    imageDefaults,
+  });
+  const imageResult = await generateImage(imgModel, imgBaseUrl, imgApiKey, serviceHint || imgSource, {
+    prompt: compiledSelfiePrompt.prompt,
+    negativePrompt: compiledSelfiePrompt.negativePrompt || undefined,
+    model: imgModel,
+    width: selfieW || imageSettings.selfie.width,
+    height: selfieH || imageSettings.selfie.height,
+    imageEndpointId: imgConnFull.imageEndpointId || undefined,
+    comfyWorkflow: imgConnFull.comfyuiWorkflow || undefined,
+    imageDefaults,
+    referenceImages: selfieReferenceImages,
+  });
+
+  const filePath = saveImageToDisk(args.chatId, imageResult.base64, imageResult.ext);
+  const galleryEntry = await galleryStore.create({
+    chatId: args.chatId,
+    filePath,
+    prompt: compiledSelfiePrompt.prompt,
+    provider: imgConnFull.provider ?? "image_generation",
+    model: imgModel || "unknown",
+    width: selfieW || imageSettings.selfie.width,
+    height: selfieH || imageSettings.selfie.height,
+  });
+
+  const filename = filePath.split("/").pop()!;
+  const imageUrl = `/api/gallery/file/${args.chatId}/${encodeURIComponent(filename)}`;
+  if (args.messageId) {
+    const generationSwipeIndex = Number.isInteger(args.swipeIndex) ? args.swipeIndex! : 0;
+    const attachment = {
+      type: "image",
+      url: imageUrl,
+      filename: `selfie_${args.charName.toLowerCase().replace(/\s+/g, "_")}.${imageResult.ext}`,
+      prompt: compiledSelfiePrompt.prompt,
+      galleryId: galleryEntry?.id,
+    };
+    await args.chats.appendSwipeAttachment(args.messageId, generationSwipeIndex, attachment);
+
+    const currentMsgRow = await args.chats.getMessage(args.messageId);
+    if (currentMsgRow && (currentMsgRow.activeSwipeIndex ?? 0) === generationSwipeIndex) {
+      await args.chats.appendMessageAttachment(args.messageId, attachment);
+    }
+  }
+
+  args.sendEvent({
+    type: "selfie",
+    data: {
+      characterId: args.characterId,
+      characterName: args.charName,
+      messageId: args.messageId,
+      imageUrl,
+      prompt: compiledSelfiePrompt.prompt,
+      galleryId: galleryEntry?.id,
+    },
+  });
+  logger.debug("[commands] Selfie generated for %s", args.charName);
+}
+
+function readNestedString(value: unknown, key: string): string | null {
+  const record = parseRecord(value);
+  const nested = record?.[key];
+  return typeof nested === "string" ? nested : null;
+}
+
+function parseRecord(value: unknown): Record<string, unknown> | null {
+  if (!value) return null;
+  if (typeof value === "string") {
+    try {
+      const parsed = JSON.parse(value);
+      return parsed && typeof parsed === "object" && !Array.isArray(parsed)
+        ? (parsed as Record<string, unknown>)
+        : null;
+    } catch {
+      return null;
+    }
+  }
+  return typeof value === "object" && !Array.isArray(value) ? (value as Record<string, unknown>) : null;
+}

--- a/packages/server/src/services/generation/conversation-side-effect-command-runtime.ts
+++ b/packages/server/src/services/generation/conversation-side-effect-command-runtime.ts
@@ -90,7 +90,12 @@ async function handleMemoryCommand(
 
   const targetDisplayName =
     typeof targetData.name === "string" && targetData.name.trim() ? targetData.name : targetChar.id;
-  logger.info('[commands] Memory created: "%s" -> "%s": %s', srcCharName, targetDisplayName, command.summary);
+  logger.info(
+    '[commands] Memory created: "%s" -> "%s" (summaryLength=%d)',
+    srcCharName,
+    targetDisplayName,
+    command.summary.length,
+  );
 }
 
 async function handleInfluenceCommand(
@@ -109,9 +114,9 @@ async function handleInfluenceCommand(
 
   await args.chats.createInfluence(args.chatId, connectedId, influenceContent, args.messageId ?? undefined);
   logger.info(
-    '[commands] OOC influence queued for connected chat %s: "%s..."',
+    "[commands] OOC influence queued for connected chat %s (contentLength=%d)",
     connectedId,
-    influenceContent.slice(0, 80),
+    influenceContent.length,
   );
 }
 
@@ -131,9 +136,9 @@ async function handleNoteCommand(
 
   await args.chats.createNote(args.chatId, connectedId, noteContent, args.messageId ?? undefined);
   logger.info(
-    '[commands] Conversation note saved for connected chat %s: "%s..."',
+    "[commands] Conversation note saved for connected chat %s (contentLength=%d)",
     connectedId,
-    noteContent.slice(0, 80),
+    noteContent.length,
   );
 }
 

--- a/packages/server/src/services/generation/conversation-side-effect-command-runtime.ts
+++ b/packages/server/src/services/generation/conversation-side-effect-command-runtime.ts
@@ -1,0 +1,153 @@
+import { normalizeTextForMatch } from "@marinara-engine/shared";
+
+import { logger } from "../../lib/logger.js";
+import { stripConversationPromptTimestamps } from "../conversation/transcript-sanitize.js";
+import {
+  type CharacterCommand,
+  type InfluenceCommand,
+  type MemoryCommand,
+  type NoteCommand,
+} from "../conversation/character-commands.js";
+
+type CharactersStore = {
+  getById(id: string): Promise<{ data: unknown } | null>;
+  list(): Promise<Array<{ id: string; data: unknown }>>;
+  update(id: string, data: Record<string, unknown>): Promise<unknown>;
+};
+
+type ChatsStore = {
+  getById(id: string): Promise<{ connectedChatId?: unknown } | null>;
+  createInfluence(sourceChatId: string, targetChatId: string, content: string, anchorMessageId?: string): Promise<unknown>;
+  createNote(sourceChatId: string, targetChatId: string, content: string, anchorMessageId?: string): Promise<unknown>;
+};
+
+type CharacterMemory = {
+  from: string;
+  fromCharId: string;
+  summary: string;
+  createdAt: string;
+};
+
+export async function handleConversationSideEffectCommand(args: {
+  command: CharacterCommand;
+  characterId: string | null;
+  chatId: string;
+  messageId?: string | null;
+  chars: CharactersStore;
+  chats: ChatsStore;
+}): Promise<boolean> {
+  if (args.command.type === "memory") {
+    await handleMemoryCommand(args.command as MemoryCommand, args);
+    return true;
+  }
+  if (args.command.type === "influence") {
+    await handleInfluenceCommand(args.command as InfluenceCommand, args);
+    return true;
+  }
+  if (args.command.type === "note") {
+    await handleNoteCommand(args.command as NoteCommand, args);
+    return true;
+  }
+  return false;
+}
+
+async function handleMemoryCommand(
+  command: MemoryCommand,
+  args: Parameters<typeof handleConversationSideEffectCommand>[0],
+): Promise<void> {
+  const targetName = normalizeTextForMatch(command.target);
+
+  const srcCharRow = args.characterId ? await args.chars.getById(args.characterId) : null;
+  const srcCharData = parseRecord(srcCharRow?.data);
+  const srcCharName = typeof srcCharData?.name === "string" && srcCharData.name.trim() ? srcCharData.name : "Unknown";
+
+  const allCharsList = await args.chars.list();
+  const targetChar = allCharsList.find((character) => {
+    const data = parseRecord(character.data);
+    return typeof data?.name === "string" && normalizeTextForMatch(data.name) === targetName;
+  });
+
+  if (!targetChar) {
+    logger.warn('[commands] Memory target character "%s" not found', command.target);
+    return;
+  }
+
+  const targetData = parseRecord(targetChar.data) ?? {};
+  const extensions = { ...(parseRecord(targetData.extensions) ?? {}) };
+  const memories = Array.isArray(extensions.characterMemories)
+    ? ([...extensions.characterMemories] as CharacterMemory[])
+    : [];
+
+  memories.push({
+    from: srcCharName,
+    fromCharId: args.characterId ?? "",
+    summary: command.summary,
+    createdAt: new Date().toISOString(),
+  });
+
+  extensions.characterMemories = memories;
+  await args.chars.update(targetChar.id, { extensions });
+
+  const targetDisplayName =
+    typeof targetData.name === "string" && targetData.name.trim() ? targetData.name : targetChar.id;
+  logger.info('[commands] Memory created: "%s" -> "%s": %s', srcCharName, targetDisplayName, command.summary);
+}
+
+async function handleInfluenceCommand(
+  command: InfluenceCommand,
+  args: Parameters<typeof handleConversationSideEffectCommand>[0],
+): Promise<void> {
+  const freshChat = await args.chats.getById(args.chatId);
+  const connectedId = typeof freshChat?.connectedChatId === "string" ? freshChat.connectedChatId : null;
+  if (!connectedId) {
+    logger.warn("[commands] Influence command used but no connected chat");
+    return;
+  }
+
+  const influenceContent = stripConversationPromptTimestamps(command.content);
+  if (!influenceContent) return;
+
+  await args.chats.createInfluence(args.chatId, connectedId, influenceContent, args.messageId ?? undefined);
+  logger.info(
+    '[commands] OOC influence queued for connected chat %s: "%s..."',
+    connectedId,
+    influenceContent.slice(0, 80),
+  );
+}
+
+async function handleNoteCommand(
+  command: NoteCommand,
+  args: Parameters<typeof handleConversationSideEffectCommand>[0],
+): Promise<void> {
+  const freshChat = await args.chats.getById(args.chatId);
+  const connectedId = typeof freshChat?.connectedChatId === "string" ? freshChat.connectedChatId : null;
+  if (!connectedId) {
+    logger.warn("[commands] Note command used but no connected chat");
+    return;
+  }
+
+  const noteContent = stripConversationPromptTimestamps(command.content);
+  if (!noteContent) return;
+
+  await args.chats.createNote(args.chatId, connectedId, noteContent, args.messageId ?? undefined);
+  logger.info(
+    '[commands] Conversation note saved for connected chat %s: "%s..."',
+    connectedId,
+    noteContent.slice(0, 80),
+  );
+}
+
+function parseRecord(value: unknown): Record<string, unknown> | null {
+  if (!value) return null;
+  if (typeof value === "string") {
+    try {
+      const parsed = JSON.parse(value);
+      return parsed && typeof parsed === "object" && !Array.isArray(parsed)
+        ? (parsed as Record<string, unknown>)
+        : null;
+    } catch {
+      return null;
+    }
+  }
+  return typeof value === "object" && !Array.isArray(value) ? (value as Record<string, unknown>) : null;
+}

--- a/packages/server/src/services/generation/director-secret-plot-runtime.ts
+++ b/packages/server/src/services/generation/director-secret-plot-runtime.ts
@@ -1,0 +1,119 @@
+import {
+  NARRATIVE_DIRECTOR_SECRET_PLOT_PROMPT,
+  type ChatMode,
+} from "@marinara-engine/shared";
+
+import type { ResolvedAgent } from "../agents/agent-pipeline.js";
+import { wrapContent } from "../prompt/format-engine.js";
+import { resolveAgentRunInterval } from "./agent-cadence.js";
+
+export const DIRECTOR_SECRET_PLOT_DEFAULT_RUN_INTERVAL = 8;
+export const DIRECTOR_SECRET_PLOT_LAST_MESSAGE_KEY = "secretPlotLastAssistantMessageId";
+
+export function normalizeDirectorSecretPlotRunInterval(value: unknown): number {
+  return resolveAgentRunInterval({ runInterval: value }, DIRECTOR_SECRET_PLOT_DEFAULT_RUN_INTERVAL);
+}
+
+export function resolveDirectorSecretPlotEnabled(
+  settings: Record<string, unknown>,
+  chatMeta: Record<string, unknown>,
+  chatMode: ChatMode,
+): boolean {
+  if (chatMode !== "roleplay") return false;
+  if (typeof chatMeta.narrativeDirectorSecretPlotEnabled === "boolean") {
+    return chatMeta.narrativeDirectorSecretPlotEnabled;
+  }
+  return settings.secretPlotEnabled === true;
+}
+
+export function resolveDirectorSecretPlotRunInterval(
+  settings: Record<string, unknown>,
+  chatMeta: Record<string, unknown>,
+): number {
+  return normalizeDirectorSecretPlotRunInterval(
+    chatMeta.narrativeDirectorSecretPlotRunInterval ?? settings.secretPlotRunInterval,
+  );
+}
+
+function normalizeSecretPlotArc(raw: unknown): Record<string, unknown> | null {
+  if (raw == null) return null;
+  if (typeof raw === "string") {
+    const description = raw.trim();
+    return description ? { description, completed: false } : null;
+  }
+  if (!raw || typeof raw !== "object" || Array.isArray(raw)) return null;
+  const arc = raw as Record<string, unknown>;
+  const description = typeof arc.description === "string" ? arc.description.trim() : "";
+  const protagonistArc = typeof arc.protagonistArc === "string" ? arc.protagonistArc.trim() : "";
+  const characterArc = typeof arc.characterArc === "string" ? arc.characterArc.trim() : "";
+  const normalized: Record<string, unknown> = {
+    ...(description ? { description } : {}),
+    ...(protagonistArc ? { protagonistArc } : {}),
+    ...(characterArc ? { characterArc } : {}),
+    completed: arc.completed === true,
+  };
+  return Object.keys(normalized).length > 1 || normalized.completed === true ? normalized : null;
+}
+
+export function buildSecretPlotStateFromMemory(memory: Record<string, unknown>): Record<string, unknown> {
+  const state: Record<string, unknown> = {};
+  const arc = normalizeSecretPlotArc(memory.overarchingArc);
+  if (arc) state.overarchingArc = arc;
+  return state;
+}
+
+export function secretPlotArcIsCompleted(data: unknown): boolean {
+  if (!data || typeof data !== "object" || Array.isArray(data)) return false;
+  const arc = normalizeSecretPlotArc((data as Record<string, unknown>).overarchingArc);
+  return arc?.completed === true;
+}
+
+export function shouldRunDirectorSecretPlotMaintenance(args: {
+  memory: Record<string, unknown>;
+  runInterval: number;
+  messages: Array<{ id?: string | null; role?: string | null }>;
+}): boolean {
+  const state = buildSecretPlotStateFromMemory(args.memory);
+  const arc = normalizeSecretPlotArc(state.overarchingArc);
+  if (!arc) return true;
+  if (arc.completed === true) return true;
+  if (args.runInterval <= 1) return true;
+
+  const lastMessageId = args.memory[DIRECTOR_SECRET_PLOT_LAST_MESSAGE_KEY];
+  if (typeof lastMessageId !== "string" || !lastMessageId) return true;
+  const lastIndex = args.messages.findIndex((message) => message.id === lastMessageId);
+  if (lastIndex < 0) return true;
+  const assistantMessagesSince = args.messages
+    .slice(lastIndex + 1)
+    .filter((message) => message.role === "assistant").length;
+  return assistantMessagesSince + 1 >= args.runInterval;
+}
+
+export function formatSecretPlotSystemBlock(arcRaw: unknown, wrapFormat: "xml" | "markdown" | "none"): string {
+  const arc = normalizeSecretPlotArc(arcRaw);
+  if (!arc) return "";
+  const payload = JSON.stringify({ overarchingArc: arc }, null, 2);
+  if (wrapFormat === "none") return `Secret plot\n${payload}`;
+  return wrapContent(payload, "Secret plot", wrapFormat);
+}
+
+export function appendSecretPlotSystemMessage(
+  messages: Array<{ role: string; content: string; [key: string]: unknown }>,
+  content: string,
+): void {
+  if (!content.trim()) return;
+  const firstChatIndex = messages.findIndex((message) => message.role === "user" || message.role === "assistant");
+  const insertAt = firstChatIndex >= 0 ? firstChatIndex : messages.length;
+  messages.splice(insertAt, 0, { role: "system", content });
+}
+
+export function buildDirectorSecretPlotAgent(agent: ResolvedAgent): ResolvedAgent {
+  return {
+    ...agent,
+    promptTemplate: NARRATIVE_DIRECTOR_SECRET_PLOT_PROMPT,
+    settings: {
+      ...agent.settings,
+      resultType: "secret_plot",
+    },
+  };
+}

--- a/packages/server/src/services/generation/haptic-command-runtime.ts
+++ b/packages/server/src/services/generation/haptic-command-runtime.ts
@@ -1,0 +1,37 @@
+import { logger } from "../../lib/logger.js";
+import type { CharacterCommand, HapticCommand } from "../conversation/character-commands.js";
+
+export async function handleHapticCommand(args: {
+  command: CharacterCommand;
+  sendEvent: (data: Record<string, unknown>) => void;
+}): Promise<boolean> {
+  if (args.command.type !== "haptic") return false;
+  const command = args.command as HapticCommand;
+
+  try {
+    const { hapticService } = await import("../haptic/buttplug-service.js");
+    if (hapticService.connected && hapticService.devices.length > 0) {
+      await hapticService.executeCommand({
+        deviceIndex: "all",
+        action: command.action,
+        intensity: command.intensity,
+        duration: command.duration,
+      });
+      args.sendEvent({ action: command.action, intensity: command.intensity, duration: command.duration });
+      logger.info(
+        "[commands] Haptic: %s intensity=%s duration=%s",
+        command.action,
+        command.intensity ?? "default",
+        command.duration ?? "indefinite",
+      );
+    } else if (!hapticService.connected) {
+      logger.warn("[commands] Haptic command [%s] skipped - Intiface Central not connected", command.action);
+    } else {
+      logger.warn("[commands] Haptic command [%s] skipped - no devices found", command.action);
+    }
+  } catch (err) {
+    logger.error(err, "[commands] Haptic command failed");
+  }
+
+  return true;
+}

--- a/packages/server/src/services/generation/output-token-limits.ts
+++ b/packages/server/src/services/generation/output-token-limits.ts
@@ -1,0 +1,25 @@
+import { findKnownModel, type APIProvider } from "@marinara-engine/shared";
+
+function resolveKnownMaxOutputTokens(provider: APIProvider | string | null | undefined, model: string): number | null {
+  const knownModel = provider ? findKnownModel(provider as APIProvider, model.trim()) : undefined;
+  return knownModel?.maxOutput && knownModel.maxOutput > 0 ? Math.floor(knownModel.maxOutput) : null;
+}
+
+export function clampGenerationMaxOutputTokens(args: {
+  provider: APIProvider | string | null | undefined;
+  model: string;
+  maxTokens: number;
+  maxTokensOverride?: number | null;
+}): number {
+  let capped = Math.max(1, Math.floor(args.maxTokens));
+  const knownMaxOutput = resolveKnownMaxOutputTokens(args.provider, args.model);
+  if (knownMaxOutput !== null) capped = Math.min(capped, knownMaxOutput);
+  if (
+    typeof args.maxTokensOverride === "number" &&
+    Number.isFinite(args.maxTokensOverride) &&
+    args.maxTokensOverride > 0
+  ) {
+    capped = Math.min(capped, Math.floor(args.maxTokensOverride));
+  }
+  return capped;
+}

--- a/packages/server/src/services/generation/professor-mari-command-runtime.ts
+++ b/packages/server/src/services/generation/professor-mari-command-runtime.ts
@@ -1,0 +1,733 @@
+import { PROFESSOR_MARI_ID, normalizeTextForMatch } from "@marinara-engine/shared";
+
+import type { DB } from "../../db/connection.js";
+import { logger } from "../../lib/logger.js";
+import { createPromptsStorage } from "../storage/prompts.storage.js";
+import {
+  type CharacterCommand,
+  type CreateCharacterCommand,
+  type CreateChatCommand,
+  type CreateLorebookCommand,
+  type CreatePersonaCommand,
+  type CreatePresetCommand,
+  type FetchCommand,
+  type NavigateCommand,
+  type UpdateCharacterCommand,
+  type UpdateLorebookCommand,
+  type UpdatePersonaCommand,
+} from "../conversation/character-commands.js";
+import { bumpCharacterVersion } from "./generation-text-utils.js";
+import {
+  MAX_MARI_FETCHED_PRESET_CONTEXT_CHARS,
+  normalizeAssistantPresetIdentifier,
+  normalizeAssistantPresetOptionId,
+  normalizeAssistantPresetVariableName,
+  parseMariJsonArray,
+  parseMariJsonRecord,
+  resolveAssistantPresetInjectionPosition,
+  resolveAssistantPresetRole,
+  resolveAssistantPresetWrapFormat,
+  truncateMariFetchedText,
+} from "./assistant-preset-utils.js";
+import { parseExtra } from "../../routes/generate/generate-route-utils.js";
+
+const PROFESSOR_MARI_COMMAND_TYPES = new Set([
+  "create_persona",
+  "create_character",
+  "update_character",
+  "update_persona",
+  "create_lorebook",
+  "update_lorebook",
+  "create_preset",
+  "create_chat",
+  "navigate",
+  "fetch",
+]);
+
+type ProfessorMariCommandStores = {
+  chars: any;
+  chats: any;
+  lorebooksStore: any;
+  presets: any;
+};
+
+export function isProfessorMariCommandType(type: string): boolean {
+  return PROFESSOR_MARI_COMMAND_TYPES.has(type);
+}
+
+export function countProfessorMariCommands(commands: Array<{ command: CharacterCommand }>): number {
+  return commands.filter(({ command }) => isProfessorMariCommandType(command.type)).length;
+}
+
+export async function handleProfessorMariCommand(args: {
+  command: CharacterCommand;
+  characterId: string | null;
+  chatId: string;
+  sourceChatMetadata: unknown;
+  isHomeProfessorMariAssistantChat: boolean;
+  db: DB;
+  stores: ProfessorMariCommandStores;
+  sendAssistantAction: (data: Record<string, unknown>) => void;
+}): Promise<{ handled: boolean; fetchSucceeded: boolean }> {
+  if (!isProfessorMariCommandType(args.command.type)) return { handled: false, fetchSucceeded: false };
+
+  switch (args.command.type) {
+    case "create_persona":
+      await createPersona(args.command as CreatePersonaCommand, args);
+      break;
+    case "create_character":
+      await createCharacter(args.command as CreateCharacterCommand, args);
+      break;
+    case "update_character":
+      await updateCharacter(args.command as UpdateCharacterCommand, args);
+      break;
+    case "update_persona":
+      await updatePersona(args.command as UpdatePersonaCommand, args);
+      break;
+    case "create_lorebook":
+      await createLorebook(args.command as CreateLorebookCommand, args);
+      break;
+    case "update_lorebook":
+      await updateLorebook(args.command as UpdateLorebookCommand, args);
+      break;
+    case "create_preset":
+      await createPreset(args.command as CreatePresetCommand, args);
+      break;
+    case "create_chat":
+      await createChat(args.command as CreateChatCommand, args);
+      break;
+    case "navigate":
+      navigate(args.command as NavigateCommand, args);
+      break;
+    case "fetch":
+      return {
+        handled: true,
+        fetchSucceeded: await fetchProfessorMariContext(args.command as FetchCommand, args),
+      };
+  }
+
+  return { handled: true, fetchSucceeded: false };
+}
+
+async function createPersona(command: CreatePersonaCommand, args: Parameters<typeof handleProfessorMariCommand>[0]) {
+  try {
+    const persona = await args.stores.chars.createPersona(command.name, command.description ?? "", undefined, {
+      personality: command.personality,
+      appearance: command.appearance,
+    });
+    args.sendAssistantAction({ action: "persona_created", id: persona?.id, name: command.name });
+    logger.info('[commands] Assistant created persona: "%s" (%s)', command.name, persona?.id);
+  } catch (err) {
+    logger.error(err, "[commands] Create persona failed");
+  }
+}
+
+async function createCharacter(command: CreateCharacterCommand, args: Parameters<typeof handleProfessorMariCommand>[0]) {
+  try {
+    const charData = {
+      name: command.name,
+      description: command.description ?? "",
+      personality: command.personality ?? "",
+      first_mes: command.firstMessage ?? "",
+      scenario: command.scenario ?? "",
+      mes_example: command.mesExample ?? "",
+      creator_notes: command.creatorNotes ?? "",
+      system_prompt: command.systemPrompt ?? "",
+      post_history_instructions: command.postHistoryInstructions ?? "",
+      tags: command.tags ?? [],
+      creator: command.creator ?? "",
+      character_version: command.characterVersion ?? "",
+      alternate_greetings: command.alternateGreetings ?? [],
+      extensions: {
+        talkativeness: command.talkativeness ?? 0.5,
+        fav: command.fav ?? false,
+        world: command.world ?? "",
+        depth_prompt: {
+          prompt: command.depthPrompt ?? "",
+          depth: command.depthPromptDepth ?? 4,
+          role: command.depthPromptRole ?? "system",
+        },
+        backstory: command.backstory ?? "",
+        appearance: command.appearance ?? "",
+      },
+      character_book: null,
+    };
+    const created = await args.stores.chars.create(charData);
+    if (created) {
+      args.sendAssistantAction({ action: "character_created", id: created.id, name: command.name });
+      logger.info('[commands] Assistant created character: "%s" (%s)', command.name, created.id);
+    }
+  } catch (err) {
+    logger.error(err, "[commands] Create character failed");
+  }
+}
+
+async function updateCharacter(command: UpdateCharacterCommand, args: Parameters<typeof handleProfessorMariCommand>[0]) {
+  try {
+    const allCharsList = await args.stores.chars.list();
+    const targetChar = allCharsList.find((character: any) => {
+      const data = typeof character.data === "string" ? JSON.parse(character.data) : character.data;
+      return normalizeTextForMatch(data.name) === normalizeTextForMatch(command.name);
+    });
+    if (!targetChar) {
+      logger.warn('[commands] Update character: "%s" not found', command.name);
+      return;
+    }
+
+    const latestTargetChar = await args.stores.chars.getById(targetChar.id);
+    if (!latestTargetChar) {
+      logger.warn('[commands] Update character: "%s" disappeared before update', command.name);
+      return;
+    }
+    const existingData =
+      typeof latestTargetChar.data === "string" ? JSON.parse(latestTargetChar.data) : latestTargetChar.data;
+    const updates: Record<string, unknown> = {};
+    const extensionUpdates: Record<string, unknown> = {};
+    if (command.description !== undefined) updates.description = command.description;
+    if (command.personality !== undefined) updates.personality = command.personality;
+    if (command.firstMessage !== undefined) updates.first_mes = command.firstMessage;
+    if (command.scenario !== undefined) updates.scenario = command.scenario;
+    if (command.mesExample !== undefined) updates.mes_example = command.mesExample;
+    if (command.creatorNotes !== undefined) updates.creator_notes = command.creatorNotes;
+    if (command.systemPrompt !== undefined) updates.system_prompt = command.systemPrompt;
+    if (command.postHistoryInstructions !== undefined) updates.post_history_instructions = command.postHistoryInstructions;
+    if (command.creator !== undefined) updates.creator = command.creator;
+    if (command.characterVersion !== undefined) updates.character_version = command.characterVersion;
+    if (command.tags !== undefined) updates.tags = command.tags;
+    if (command.alternateGreetings !== undefined) updates.alternate_greetings = command.alternateGreetings;
+    if (command.backstory !== undefined) extensionUpdates.backstory = command.backstory;
+    if (command.appearance !== undefined) extensionUpdates.appearance = command.appearance;
+    if (command.talkativeness !== undefined) extensionUpdates.talkativeness = command.talkativeness;
+    if (command.fav !== undefined) extensionUpdates.fav = command.fav;
+    if (command.world !== undefined) extensionUpdates.world = command.world;
+    if (
+      command.depthPrompt !== undefined ||
+      command.depthPromptDepth !== undefined ||
+      command.depthPromptRole !== undefined
+    ) {
+      const existingDepthPrompt = existingData.extensions?.depth_prompt ?? {};
+      extensionUpdates.depth_prompt = {
+        ...existingDepthPrompt,
+        ...(command.depthPrompt !== undefined ? { prompt: command.depthPrompt } : {}),
+        ...(command.depthPromptDepth !== undefined ? { depth: command.depthPromptDepth } : {}),
+        ...(command.depthPromptRole !== undefined ? { role: command.depthPromptRole } : {}),
+      };
+    }
+    if (Object.keys(extensionUpdates).length > 0) {
+      updates.extensions = { ...(existingData.extensions ?? {}), ...extensionUpdates };
+    }
+    if (command.characterVersion === undefined && Object.keys(updates).length > 0) {
+      updates.character_version = bumpCharacterVersion(existingData.character_version);
+    }
+    await args.stores.chars.update(targetChar.id, updates, undefined, {
+      versionSource: "command",
+      versionReason: "Assistant update_character command",
+    });
+    args.sendAssistantAction({ action: "character_updated", id: targetChar.id, name: command.name });
+    logger.info('[commands] Assistant updated character: "%s" (%s)', command.name, targetChar.id);
+  } catch (err) {
+    logger.error(err, "[commands] Update character failed");
+  }
+}
+
+async function updatePersona(command: UpdatePersonaCommand, args: Parameters<typeof handleProfessorMariCommand>[0]) {
+  try {
+    const allPersonas = await args.stores.chars.listPersonas();
+    const targetPersona = allPersonas.find(
+      (persona: any) => normalizeTextForMatch(persona.name) === normalizeTextForMatch(command.name),
+    );
+    if (!targetPersona) {
+      logger.warn('[commands] Update persona: "%s" not found', command.name);
+      return;
+    }
+
+    const sets: Record<string, unknown> = {};
+    if (command.description !== undefined) sets.description = command.description;
+    if (command.personality !== undefined) sets.personality = command.personality;
+    if (command.appearance !== undefined) sets.appearance = command.appearance;
+    if (command.scenario !== undefined) sets.scenario = command.scenario;
+    if (command.backstory !== undefined) sets.backstory = command.backstory;
+    await args.stores.chars.updatePersona(targetPersona.id, sets);
+    args.sendAssistantAction({ action: "persona_updated", id: targetPersona.id, name: command.name });
+    logger.info('[commands] Assistant updated persona: "%s" (%s)', command.name, targetPersona.id);
+  } catch (err) {
+    logger.error(err, "[commands] Update persona failed");
+  }
+}
+
+async function createLorebook(command: CreateLorebookCommand, args: Parameters<typeof handleProfessorMariCommand>[0]) {
+  try {
+    const category = ["character", "world", "npc", "spellbook"].includes(command.category ?? "")
+      ? command.category
+      : "uncategorized";
+    const created = await args.stores.lorebooksStore.create({
+      name: command.name,
+      description: command.description ?? "",
+      category,
+      tags: command.tags ?? [],
+      enabled: true,
+      generatedBy: "agent",
+      sourceAgentId: PROFESSOR_MARI_ID,
+    });
+    if (!created) return;
+
+    let entryCount = 0;
+    for (const entry of command.entries ?? []) {
+      await args.stores.lorebooksStore.createEntry({
+        lorebookId: created.id,
+        name: entry.name,
+        content: entry.content ?? "",
+        description: entry.description ?? "",
+        keys: entry.keys ?? [],
+        secondaryKeys: entry.secondaryKeys ?? [],
+        tag: entry.tag ?? "",
+        constant: entry.constant ?? false,
+        selective: entry.selective ?? false,
+        enabled: true,
+      });
+      entryCount += 1;
+    }
+
+    args.sendAssistantAction({ action: "lorebook_created", id: created.id, name: command.name, entryCount });
+    logger.info('[commands] Assistant created lorebook: "%s" (%s) with %d entries', command.name, created.id, entryCount);
+  } catch (err) {
+    logger.error(err, "[commands] Create lorebook failed");
+  }
+}
+
+async function updateLorebook(command: UpdateLorebookCommand, args: Parameters<typeof handleProfessorMariCommand>[0]) {
+  try {
+    const allLorebooks = await args.stores.lorebooksStore.list();
+    const targetLorebook = allLorebooks.find((lorebook: any) => {
+      if (lorebook.id === command.name) return true;
+      return normalizeTextForMatch(lorebook.name) === normalizeTextForMatch(command.name);
+    });
+
+    if (!targetLorebook) {
+      logger.warn('[commands] Update lorebook: "%s" not found', command.name);
+      return;
+    }
+
+    const category = ["character", "world", "npc", "spellbook", "uncategorized"].includes(command.category ?? "")
+      ? command.category
+      : undefined;
+    const lorebookUpdates: Record<string, unknown> = {};
+    if (command.newName !== undefined && command.newName.trim()) lorebookUpdates.name = command.newName;
+    if (command.description !== undefined) lorebookUpdates.description = command.description;
+    if (category !== undefined) lorebookUpdates.category = category;
+    if (command.tags !== undefined) lorebookUpdates.tags = command.tags;
+    if (Object.keys(lorebookUpdates).length > 0) {
+      await args.stores.lorebooksStore.update(targetLorebook.id, lorebookUpdates);
+    }
+
+    const existingEntries = (await args.stores.lorebooksStore.listEntries(targetLorebook.id)) as any[];
+    const existingByName = new Map(
+      existingEntries.map((entry: any) => [
+        String(entry.name ?? "")
+          .trim()
+          .toLowerCase(),
+        entry,
+      ]),
+    );
+    let updatedEntryCount = 0;
+    let createdEntryCount = 0;
+
+    for (const entry of command.entries ?? []) {
+      const matchName = (entry.matchName || entry.name).trim().toLowerCase();
+      const existingEntry = existingByName.get(matchName);
+      if (existingEntry) {
+        const entryUpdates: Record<string, unknown> = {};
+        if (entry.name !== undefined) entryUpdates.name = entry.name;
+        if (entry.content !== undefined) entryUpdates.content = entry.content;
+        if (entry.description !== undefined) entryUpdates.description = entry.description;
+        if (entry.keys !== undefined) entryUpdates.keys = entry.keys;
+        if (entry.secondaryKeys !== undefined) entryUpdates.secondaryKeys = entry.secondaryKeys;
+        if (entry.tag !== undefined) entryUpdates.tag = entry.tag;
+        if (entry.constant !== undefined) entryUpdates.constant = entry.constant;
+        if (entry.selective !== undefined) entryUpdates.selective = entry.selective;
+        if (Object.keys(entryUpdates).length > 0) {
+          const updatedEntry = await args.stores.lorebooksStore.updateEntry(existingEntry.id, entryUpdates);
+          if (updatedEntry) {
+            updatedEntryCount += 1;
+            existingByName.delete(matchName);
+            existingByName.set(entry.name.trim().toLowerCase(), updatedEntry);
+          }
+        }
+      } else {
+        const createdEntry = await args.stores.lorebooksStore.createEntry({
+          lorebookId: targetLorebook.id,
+          name: entry.name,
+          content: entry.content ?? "",
+          description: entry.description ?? "",
+          keys: entry.keys ?? [],
+          secondaryKeys: entry.secondaryKeys ?? [],
+          tag: entry.tag ?? "",
+          constant: entry.constant ?? false,
+          selective: entry.selective ?? false,
+          enabled: true,
+        });
+        if (createdEntry) {
+          createdEntryCount += 1;
+          existingByName.set(entry.name.trim().toLowerCase(), createdEntry);
+        }
+      }
+    }
+
+    const finalName = command.newName?.trim() || targetLorebook.name || command.name;
+    args.sendAssistantAction({
+      action: "lorebook_updated",
+      id: targetLorebook.id,
+      name: finalName,
+      updatedEntryCount,
+      createdEntryCount,
+    });
+    logger.info(
+      '[commands] Assistant updated lorebook: "%s" (%s), entries updated=%d created=%d',
+      finalName,
+      targetLorebook.id,
+      updatedEntryCount,
+      createdEntryCount,
+    );
+  } catch (err) {
+    logger.error(err, "[commands] Update lorebook failed");
+  }
+}
+
+async function createPreset(command: CreatePresetCommand, args: Parameters<typeof handleProfessorMariCommand>[0]) {
+  try {
+    const createdPresetAction = await args.db.transaction(async (tx) => {
+      const txPresets = createPromptsStorage(tx as unknown as DB);
+      const created = await txPresets.create({
+        name: command.name,
+        description: command.description ?? "",
+        wrapFormat: resolveAssistantPresetWrapFormat(command.wrapFormat),
+        isDefault: false,
+        author: command.author ?? "Professor Mari",
+      });
+      if (!created) return null;
+
+      const groupIds = new Map<string, string>();
+      const groupKey = (name: string) => name.trim().toLowerCase();
+      const ensureGroup = async (name: string, order?: number, enabled?: boolean): Promise<string | null> => {
+        const trimmed = name.trim();
+        if (!trimmed) return null;
+        const key = groupKey(trimmed);
+        const existing = groupIds.get(key);
+        if (existing) return existing;
+        const group = await txPresets.createGroup({
+          presetId: created.id,
+          name: trimmed,
+          order: order ?? (groupIds.size + 1) * 100,
+          enabled: enabled ?? true,
+        });
+        if (!group) return null;
+        groupIds.set(key, group.id);
+        return group.id;
+      };
+
+      for (const group of command.groups ?? []) await ensureGroup(group.name, group.order, group.enabled);
+      for (const group of command.groups ?? []) {
+        if (!group.parentGroupName) continue;
+        const childId = groupIds.get(groupKey(group.name));
+        const parentId = await ensureGroup(group.parentGroupName);
+        if (childId && parentId) await txPresets.updateGroup(childId, { parentGroupId: parentId });
+      }
+
+      const usedIdentifiers = new Set<string>();
+      let sectionCount = 0;
+      for (const [index, section] of (command.sections ?? []).entries()) {
+        const groupId = section.groupName ? await ensureGroup(section.groupName) : null;
+        await txPresets.createSection({
+          presetId: created.id,
+          identifier: normalizeAssistantPresetIdentifier(section.identifier ?? section.name, index, usedIdentifiers),
+          name: section.name,
+          content: section.content ?? "",
+          role: resolveAssistantPresetRole(section.role),
+          enabled: section.enabled ?? true,
+          isMarker: false,
+          groupId,
+          markerConfig: null,
+          injectionPosition: resolveAssistantPresetInjectionPosition(section.injectionPosition),
+          injectionDepth: Math.max(0, section.injectionDepth ?? 0),
+          injectionOrder: section.injectionOrder ?? (index + 1) * 100,
+          forbidOverrides: section.forbidOverrides ?? false,
+        });
+        sectionCount += 1;
+      }
+
+      const usedVariableNames = new Set<string>();
+      let choiceBlockCount = 0;
+      for (const [index, choiceBlock] of (command.choiceBlocks ?? []).entries()) {
+        const optionIds = new Set<string>();
+        await txPresets.createChoiceBlock({
+          presetId: created.id,
+          variableName: normalizeAssistantPresetVariableName(choiceBlock.variableName, index, usedVariableNames),
+          question: choiceBlock.question,
+          options: choiceBlock.options.map((option, optionIndex) => ({
+            id: normalizeAssistantPresetOptionId(option.id ?? option.label, optionIndex, optionIds),
+            label: option.label,
+            value: option.value,
+          })),
+          multiSelect: choiceBlock.multiSelect ?? false,
+          separator: choiceBlock.separator ?? ", ",
+          randomPick: choiceBlock.randomPick ?? false,
+          displayMode: choiceBlock.displayMode ?? "auto",
+          optionSort: choiceBlock.optionSort ?? "manual",
+        });
+        choiceBlockCount += 1;
+      }
+
+      return { id: created.id, name: command.name, sectionCount, choiceBlockCount };
+    });
+
+    if (createdPresetAction) {
+      args.sendAssistantAction({
+        action: "preset_created",
+        id: createdPresetAction.id,
+        name: createdPresetAction.name,
+        sectionCount: createdPresetAction.sectionCount,
+        choiceBlockCount: createdPresetAction.choiceBlockCount,
+      });
+      logger.info(
+        '[commands] Assistant created preset: "%s" (%s), sections=%d choiceBlocks=%d',
+        createdPresetAction.name,
+        createdPresetAction.id,
+        createdPresetAction.sectionCount,
+        createdPresetAction.choiceBlockCount,
+      );
+    }
+  } catch (err) {
+    logger.error(err, "[commands] Create preset failed");
+  }
+}
+
+async function createChat(command: CreateChatCommand, args: Parameters<typeof handleProfessorMariCommand>[0]) {
+  try {
+    const allCharsList = await args.stores.chars.list();
+    const targetChar = allCharsList.find((character: any) => {
+      if (character.id === command.character) return true;
+      const data = typeof character.data === "string" ? JSON.parse(character.data) : character.data;
+      return normalizeTextForMatch(data.name) === normalizeTextForMatch(command.character);
+    });
+    if (!targetChar) {
+      logger.warn('[commands] Create chat: character "%s" not found', command.character);
+      return;
+    }
+
+    const targetData = typeof targetChar.data === "string" ? JSON.parse(targetChar.data) : targetChar.data;
+    const mode = command.mode ?? "conversation";
+    const newChat = await args.stores.chats.create({
+      name: `Chat with ${targetData.name}`,
+      mode,
+      characterIds: [targetChar.id],
+      groupId: null,
+      personaId: null,
+      promptPresetId: null,
+      connectionId: null,
+    });
+    if (newChat) {
+      args.sendAssistantAction({
+        action: "chat_created",
+        chatId: newChat.id,
+        chatName: newChat.name ?? `Chat with ${targetData.name}`,
+        mode,
+        characterName: targetData.name,
+      });
+      logger.info('[commands] Assistant created %s chat with "%s" (%s)', mode, targetData.name, newChat.id);
+    }
+  } catch (err) {
+    logger.error(err, "[commands] Create chat failed");
+  }
+}
+
+function navigate(command: NavigateCommand, args: Parameters<typeof handleProfessorMariCommand>[0]) {
+  args.sendAssistantAction({ action: "navigate", panel: command.panel, tab: command.tab ?? null });
+  logger.info("[commands] Assistant navigate: panel=%s, tab=%s", command.panel, command.tab ?? "none");
+}
+
+async function fetchProfessorMariContext(
+  command: FetchCommand,
+  args: Parameters<typeof handleProfessorMariCommand>[0],
+): Promise<boolean> {
+  try {
+    const fetchedContent = await resolveFetchedContent(command, args);
+    if (!fetchedContent) {
+      logger.warn("[commands] Fetch: %s %s not found", command.fetchType, command.name);
+      return false;
+    }
+
+    const freshChat = await args.stores.chats.getById(args.chatId);
+    const currentMeta = freshChat
+      ? (parseExtra(freshChat.metadata) as Record<string, unknown>)
+      : (parseExtra(args.sourceChatMetadata) as Record<string, unknown>);
+    const mariContext = (currentMeta.mariContext as Record<string, string>) ?? {};
+    mariContext[`${command.fetchType}:${command.name}`] = fetchedContent;
+    currentMeta.mariContext = mariContext;
+    await args.stores.chats.updateMetadata(args.chatId, currentMeta);
+
+    args.sendAssistantAction({ action: "data_fetched", fetchType: command.fetchType, name: command.name });
+    logger.info('[commands] Assistant fetched %s: "%s"', command.fetchType, command.name);
+    return args.isHomeProfessorMariAssistantChat && (args.characterId === PROFESSOR_MARI_ID || args.characterId === null);
+  } catch (err) {
+    logger.error(err, "[commands] Fetch failed");
+    return false;
+  }
+}
+
+async function resolveFetchedContent(command: FetchCommand, args: Parameters<typeof handleProfessorMariCommand>[0]) {
+  if (command.fetchType === "character") return fetchCharacterContent(command, args);
+  if (command.fetchType === "persona") return fetchPersonaContent(command, args);
+  if (command.fetchType === "lorebook") return fetchLorebookContent(command, args);
+  if (command.fetchType === "chat") return fetchChatContent(command, args);
+  if (command.fetchType === "preset") return fetchPresetContent(command, args);
+  return "";
+}
+
+async function fetchCharacterContent(command: FetchCommand, args: Parameters<typeof handleProfessorMariCommand>[0]) {
+  const allCharsList = await args.stores.chars.list();
+  const found = allCharsList.find((character: any) => {
+    const data = typeof character.data === "string" ? JSON.parse(character.data) : character.data;
+    return normalizeTextForMatch(data.name) === normalizeTextForMatch(command.name);
+  });
+  if (!found) return "";
+
+  const data = typeof found.data === "string" ? JSON.parse(found.data) : found.data;
+  const parts = [`Name: ${data.name}`];
+  if (data.description) parts.push(`Description: ${data.description}`);
+  if (data.personality) parts.push(`Personality: ${data.personality}`);
+  if (data.scenario) parts.push(`Scenario: ${data.scenario}`);
+  if (data.mes_example) parts.push(`Example Messages: ${data.mes_example}`);
+  if (data.system_prompt) parts.push(`System Prompt: ${data.system_prompt}`);
+  if (data.post_history_instructions) parts.push(`Post-History Instructions: ${data.post_history_instructions}`);
+  if (data.first_mes) parts.push(`First Message: ${data.first_mes}`);
+  if (data.creator_notes) parts.push(`Creator Notes: ${data.creator_notes}`);
+  if (data.extensions?.appearance) parts.push(`Appearance: ${data.extensions.appearance}`);
+  if (data.extensions?.backstory) parts.push(`Backstory: ${data.extensions.backstory}`);
+  return parts.join("\n");
+}
+
+async function fetchPersonaContent(command: FetchCommand, args: Parameters<typeof handleProfessorMariCommand>[0]) {
+  const allPersonasList = await args.stores.chars.listPersonas();
+  const found = allPersonasList.find(
+    (persona: any) => normalizeTextForMatch(persona.name) === normalizeTextForMatch(command.name),
+  );
+  if (!found) return "";
+
+  const parts = [`Name: ${found.name}`];
+  if (found.description) parts.push(`Description: ${found.description}`);
+  if (found.personality) parts.push(`Personality: ${found.personality}`);
+  if (found.scenario) parts.push(`Scenario: ${found.scenario}`);
+  if (found.appearance) parts.push(`Appearance: ${found.appearance}`);
+  if (found.backstory) parts.push(`Backstory: ${found.backstory}`);
+  return parts.join("\n");
+}
+
+async function fetchLorebookContent(command: FetchCommand, args: Parameters<typeof handleProfessorMariCommand>[0]) {
+  const allLorebooks = await args.stores.lorebooksStore.list();
+  const found = allLorebooks.find(
+    (lorebook: any) => normalizeTextForMatch(lorebook.name) === normalizeTextForMatch(command.name),
+  );
+  if (!found) return "";
+
+  const entries = await args.stores.lorebooksStore.listEntries(found.id);
+  const parts = [`Lorebook: ${found.name}`];
+  if (found.description) parts.push(`Description: ${found.description}`);
+  if (found.category) parts.push(`Category: ${found.category}`);
+  parts.push(`Entries (${entries.length}):`);
+  for (const entry of entries) {
+    parts.push(
+      `\n  Entry: ${entry.name}\n  Keys: ${(Array.isArray(entry.keys) ? entry.keys : []).join(", ")}\n  Content: ${entry.content}`,
+    );
+  }
+  return parts.join("\n");
+}
+
+async function fetchChatContent(command: FetchCommand, args: Parameters<typeof handleProfessorMariCommand>[0]) {
+  const allChats = await args.stores.chats.list();
+  const found = allChats.find((chat: any) => normalizeTextForMatch(chat.name) === normalizeTextForMatch(command.name));
+  if (!found) return "";
+
+  const parts = [`Chat: ${found.name}`, `Mode: ${found.mode}`];
+  const recentMsgs = await args.stores.chats.listMessagesPaginated(found.id, 20);
+  if (recentMsgs.length > 0) {
+    parts.push(`Recent Messages (${recentMsgs.length}):`);
+    for (const msg of recentMsgs) {
+      const role = msg.role === "assistant" ? (msg.characterId ? "Character" : "Assistant") : "User";
+      parts.push(`  [${role}]: ${(msg.content as string).slice(0, 300)}`);
+    }
+  }
+  return parts.join("\n");
+}
+
+async function fetchPresetContent(command: FetchCommand, args: Parameters<typeof handleProfessorMariCommand>[0]) {
+  const allPresetsList = await args.stores.presets.list();
+  const found = allPresetsList.find(
+    (preset: any) => preset.id === command.name || normalizeTextForMatch(preset.name) === normalizeTextForMatch(command.name),
+  );
+  if (!found) return "";
+
+  const sections = (await args.stores.presets.listSections(found.id)) as any[];
+  const groups = (await args.stores.presets.listGroups(found.id)) as any[];
+  const choiceBlocks = (await args.stores.presets.listChoiceBlocksForPreset(found.id)) as any[];
+  const groupById = new Map<string, any>(groups.map((group: any) => [group.id, group]));
+  const parameters = parseMariJsonRecord(found.parameters);
+  const defaultChoices = parseMariJsonRecord(found.defaultChoices);
+  const parts = [`Preset: ${found.name}`, `ID: ${found.id}`];
+  if (found.description) parts.push(`Description: ${found.description}`);
+  if (found.author) parts.push(`Author: ${found.author}`);
+  parts.push(`Wrap Format: ${found.wrapFormat ?? "xml"}`);
+  parts.push(`Default Preset: ${String(found.isDefault) === "true" ? "yes" : "no"}`);
+  if (Object.keys(parameters).length > 0) {
+    parts.push(`Generation Parameters: ${truncateMariFetchedText(JSON.stringify(parameters), 1200)}`);
+  }
+  if (Object.keys(defaultChoices).length > 0) {
+    parts.push(`Default Choices: ${truncateMariFetchedText(JSON.stringify(defaultChoices), 1200)}`);
+  }
+  if (groups.length > 0) {
+    parts.push(`Groups (${groups.length}):`);
+    for (const group of groups) {
+      const parent = group.parentGroupId ? groupById.get(group.parentGroupId) : null;
+      parts.push(
+        `  - ${group.name} (enabled=${String(group.enabled) === "true" ? "true" : "false"}, order=${group.order}, parent=${parent?.name ?? "none"})`,
+      );
+    }
+  }
+  parts.push(`Sections (${sections.length}):`);
+  for (const section of sections) {
+    const group = section.groupId ? groupById.get(section.groupId) : null;
+    parts.push(
+      [
+        `\n  Section: ${section.name ?? "Untitled"}`,
+        `  Identifier: ${section.identifier}`,
+        `  Role: ${section.role}`,
+        `  Enabled: ${String(section.enabled) === "true" ? "true" : "false"}`,
+        `  Group: ${group?.name ?? "none"}`,
+        `  Injection: ${section.injectionPosition} depth=${section.injectionDepth} order=${section.injectionOrder}`,
+        `  Forbid Overrides: ${String(section.forbidOverrides) === "true" ? "true" : "false"}`,
+        `  Content:\n${truncateMariFetchedText(section.content, 3000)}`,
+      ].join("\n"),
+    );
+  }
+  if (choiceBlocks.length > 0) {
+    parts.push(`Choice Blocks (${choiceBlocks.length}):`);
+    for (const block of choiceBlocks) {
+      const options = parseMariJsonArray(block.options)
+        .map((option) => {
+          const data = parseMariJsonRecord(option);
+          return `${data.label ?? "Option"} => ${truncateMariFetchedText(data.value, 500)}`;
+        })
+        .join(" | ");
+      parts.push(
+        [
+          `\n  Variable: ${block.variableName}`,
+          `  Question: ${block.question}`,
+          `  Multi Select: ${String(block.multiSelect) === "true" ? "true" : "false"}`,
+          `  Random Pick: ${String(block.randomPick) === "true" ? "true" : "false"}`,
+          `  Separator: ${block.separator ?? ", "}`,
+          `  Options: ${options}`,
+        ].join("\n"),
+      );
+    }
+  }
+  return truncateMariFetchedText(parts.join("\n"), MAX_MARI_FETCHED_PRESET_CONTEXT_CHARS);
+}

--- a/packages/server/src/services/generation/professor-mari-command-runtime.ts
+++ b/packages/server/src/services/generation/professor-mari-command-runtime.ts
@@ -333,7 +333,9 @@ async function updateLorebook(command: UpdateLorebookCommand, args: Parameters<t
     let createdEntryCount = 0;
 
     for (const entry of command.entries ?? []) {
-      const matchName = (entry.matchName || entry.name).trim().toLowerCase();
+      const matchName = String(entry.matchName || entry.name || "")
+        .trim()
+        .toLowerCase();
       const existingEntry = existingByName.get(matchName);
       if (existingEntry) {
         const entryUpdates: Record<string, unknown> = {};

--- a/packages/server/src/services/generation/prompt-patch-runtime.ts
+++ b/packages/server/src/services/generation/prompt-patch-runtime.ts
@@ -1,0 +1,56 @@
+import type { ChatMessage } from "../llm/base-provider.js";
+
+function findLastPromptMessageIndex(messages: ChatMessage[], role: ChatMessage["role"]): number {
+  for (let index = messages.length - 1; index >= 0; index--) {
+    if (messages[index]?.role === role) return index;
+  }
+  return -1;
+}
+
+export function applyPromptPatchOperations(messages: ChatMessage[], data: unknown): number {
+  if (!data || typeof data !== "object") return 0;
+  const rawOperations = Array.isArray((data as Record<string, unknown>).operations)
+    ? ((data as Record<string, unknown>).operations as unknown[])
+    : [data];
+  let applied = 0;
+
+  for (const rawOperation of rawOperations.slice(0, 12)) {
+    if (!rawOperation || typeof rawOperation !== "object") continue;
+    const operation = rawOperation as Record<string, unknown>;
+    const content = typeof operation.content === "string" ? operation.content.slice(0, 12_000) : "";
+    if (!content.trim()) continue;
+    const target = typeof operation.target === "string" ? operation.target : "last_user";
+    const mode =
+      operation.mode === "replace" || operation.mode === "prepend" || operation.mode === "append"
+        ? operation.mode
+        : "append";
+
+    if (target === "append_system" || target === "prepend_system") {
+      const message = { role: "system" as const, content };
+      if (target === "prepend_system") messages.unshift(message);
+      else messages.push(message);
+      applied++;
+      continue;
+    }
+
+    const index =
+      target === "first_system"
+        ? messages.findIndex((message) => message.role === "system")
+        : target === "last_message"
+          ? messages.length - 1
+          : findLastPromptMessageIndex(messages, "user");
+    if (index < 0 || !messages[index]) continue;
+
+    const current = messages[index]!;
+    const nextContent =
+      mode === "replace"
+        ? content
+        : mode === "prepend"
+          ? `${content}\n\n${current.content}`
+          : `${current.content}\n\n${content}`;
+    messages[index] = { ...current, content: nextContent };
+    applied++;
+  }
+
+  return applied;
+}

--- a/packages/server/src/services/generation/provider-generation-runtime.ts
+++ b/packages/server/src/services/generation/provider-generation-runtime.ts
@@ -1,0 +1,219 @@
+import {
+  isClaudeAdaptiveOnlyNoSamplingModel,
+  normalizeThinkingTagPairs,
+  supportsXhighReasoningEffort,
+  type GenerationParameterSendMap,
+  type ThinkingTagPair,
+} from "@marinara-engine/shared";
+
+import { LOCAL_SIDECAR_CONNECTION_ID } from "@marinara-engine/shared";
+import { createLLMProvider } from "../llm/provider-registry.js";
+import { getLocalSidecarProvider } from "../llm/local-sidecar.js";
+import type { BaseLLMProvider } from "../llm/base-provider.js";
+import {
+  mergeCustomParameters,
+  normalizeServiceTier,
+  parseStoredGenerationParameters,
+  resolveProviderTopK,
+} from "../../routes/generate/generate-route-utils.js";
+import {
+  mergeModelContextLimit,
+  resolveStoredModelContextLimit,
+} from "./model-access-policy.js";
+import {
+  normalizeChatTopP,
+} from "./generation-parameters.js";
+import { clampGenerationMaxOutputTokens } from "./output-token-limits.js";
+
+type GenerationConnection = {
+  provider: string;
+  model: string;
+  apiKey: string;
+  maxContext?: number | null;
+  openrouterProvider?: string | null;
+  maxTokensOverride?: number | null;
+  defaultParameters?: unknown;
+  claudeFastMode?: unknown;
+  treatAsLocalEndpoint?: unknown;
+};
+
+type GenerationProviderRuntimeArgs = {
+  connectionId: string;
+  connection: GenerationConnection;
+  baseUrl: string;
+  chatMode: string;
+  isSceneChat: boolean;
+  chatParameters: unknown;
+  modelAccessPolicy: Parameters<typeof mergeModelContextLimit>[0];
+  initial: {
+    temperature: number | undefined;
+    maxTokens: number;
+    topP: number | undefined;
+    topK: number;
+    minP: number;
+    frequencyPenalty: number;
+    presencePenalty: number;
+    showThoughts: boolean;
+    reasoningEffort: "low" | "medium" | "high" | "xhigh" | "maximum" | null;
+    verbosity: "low" | "medium" | "high" | null;
+    serviceTier: "flex" | "priority" | null;
+    assistantPrefill: string;
+    customThinkingTags: ThinkingTagPair[];
+    customParameters: Record<string, unknown>;
+    enabledParameters: GenerationParameterSendMap | undefined;
+    stopSequences: string[];
+    effectiveMaxContext: number | undefined;
+  };
+};
+
+export type GenerationProviderRuntime = GenerationProviderRuntimeArgs["initial"] & {
+  connectionParams: ReturnType<typeof parseStoredGenerationParameters>;
+  chatParams: ReturnType<typeof parseStoredGenerationParameters>;
+  resolvedEffort: "low" | "medium" | "high" | "xhigh" | "max" | null;
+  enableThinking: boolean;
+  isClaudeNoSampling: boolean;
+  providerTopK: number | undefined;
+  provider: BaseLLMProvider;
+};
+
+export function resolveGenerationProviderRuntime(args: GenerationProviderRuntimeArgs): GenerationProviderRuntime {
+  const connectionParams = parseStoredGenerationParameters(args.connection.defaultParameters);
+  const chatParams = parseStoredGenerationParameters(args.chatParameters);
+  const runtime = { ...args.initial };
+
+  const applyParameterOverrides = (params: ReturnType<typeof parseStoredGenerationParameters>) => {
+    if (!params) return;
+    if (typeof params.temperature === "number") runtime.temperature = params.temperature;
+    if (typeof params.maxTokens === "number") runtime.maxTokens = params.maxTokens;
+    runtime.topP = normalizeChatTopP(params.topP) ?? runtime.topP;
+    if (typeof params.topK === "number") runtime.topK = params.topK;
+    if (typeof params.minP === "number") runtime.minP = params.minP;
+    if (typeof params.frequencyPenalty === "number") runtime.frequencyPenalty = params.frequencyPenalty;
+    if (typeof params.presencePenalty === "number") runtime.presencePenalty = params.presencePenalty;
+    if (typeof params.showThoughts === "boolean") runtime.showThoughts = params.showThoughts;
+    if (params.reasoningEffort !== undefined) runtime.reasoningEffort = params.reasoningEffort;
+    if (params.verbosity !== undefined) runtime.verbosity = params.verbosity;
+    if (params.serviceTier !== undefined) runtime.serviceTier = normalizeServiceTier(params.serviceTier);
+    if (typeof params.assistantPrefill === "string") runtime.assistantPrefill = params.assistantPrefill;
+    if (params.customThinkingTags !== undefined) {
+      runtime.customThinkingTags = normalizeThinkingTagPairs(params.customThinkingTags);
+    }
+    runtime.customParameters = mergeCustomParameters(runtime.customParameters, params.customParameters);
+    if (params.enabledParameters) {
+      runtime.enabledParameters = { ...(runtime.enabledParameters ?? {}), ...params.enabledParameters };
+    }
+    if (Array.isArray(params.stopSequences)) {
+      runtime.stopSequences = params.stopSequences.map((value) => value.trim()).filter((value) => value.length > 0);
+    }
+
+    runtime.effectiveMaxContext = mergeModelContextLimit(
+      args.modelAccessPolicy,
+      runtime.effectiveMaxContext,
+      resolveStoredModelContextLimit(args.modelAccessPolicy, params),
+    );
+  };
+
+  if (args.isSceneChat) {
+    runtime.maxTokens = 8192;
+    runtime.reasoningEffort = "maximum";
+    runtime.verbosity = "high";
+  }
+
+  const isLocalGemma = (args.connection.model ?? "").toLowerCase().includes("gemma");
+  applyParameterOverrides(connectionParams);
+  applyParameterOverrides(chatParams);
+
+  if (args.chatMode === "game" && !isLocalGemma) {
+    runtime.temperature = 1;
+    runtime.maxTokens = 16_384;
+    runtime.topP = 1;
+    runtime.topK = 0;
+    runtime.minP = 0;
+    runtime.frequencyPenalty = 0;
+    runtime.presencePenalty = 0;
+    runtime.reasoningEffort = "maximum";
+    runtime.verbosity = null;
+  } else if (args.chatMode === "game" && typeof chatParams?.maxTokens !== "number") {
+    runtime.maxTokens = Math.max(runtime.maxTokens, 16_384);
+  }
+
+  if (args.chatMode === "game") {
+    runtime.maxTokens = clampGenerationMaxOutputTokens({
+      provider: args.connection.provider,
+      model: args.connection.model,
+      maxTokens: Math.max(runtime.maxTokens, 16_384),
+      maxTokensOverride: args.connection.maxTokensOverride,
+    });
+  }
+
+  const modelLower = (args.connection.model ?? "").toLowerCase();
+  const providerLower = (args.connection.provider ?? "").toLowerCase();
+  let resolvedEffort: "low" | "medium" | "high" | "xhigh" | "max" | null =
+    runtime.reasoningEffort !== "maximum" ? runtime.reasoningEffort : null;
+  const supportsXhigh = supportsXhighReasoningEffort(modelLower);
+  if (runtime.reasoningEffort === "xhigh" && !supportsXhigh) {
+    resolvedEffort = "high";
+  }
+  if (runtime.reasoningEffort === "maximum") {
+    const isNativeAnthropicAdaptiveOnly =
+      (providerLower === "anthropic" || providerLower === "claude_subscription") &&
+      isClaudeAdaptiveOnlyNoSamplingModel(modelLower);
+    resolvedEffort = isNativeAnthropicAdaptiveOnly ? "max" : supportsXhigh ? "xhigh" : "high";
+  }
+
+  const isXaiAutoReasoningModel =
+    (providerLower === "xai" && (modelLower.startsWith("grok-4.3") || modelLower.startsWith("grok-4-1-fast"))) ||
+    (providerLower === "openrouter" && modelLower.startsWith("x-ai/grok-"));
+  if (isXaiAutoReasoningModel) {
+    resolvedEffort = null;
+  }
+  if (resolvedEffort && !runtime.showThoughts) {
+    runtime.showThoughts = true;
+  }
+
+  const enableThinking = !!resolvedEffort;
+  const isClaudeNoSampling = isClaudeAdaptiveOnlyNoSamplingModel(modelLower);
+  if (isClaudeNoSampling) {
+    runtime.temperature = undefined;
+    runtime.topP = undefined;
+    runtime.topK = 0;
+    runtime.frequencyPenalty = 0;
+    runtime.presencePenalty = 0;
+  }
+
+  const isClaudeTemperatureOnly =
+    !isClaudeNoSampling &&
+    (/claude-(opus|sonnet)-4-[56]/.test(modelLower) || /claude-(opus|sonnet)-4\.[56]/.test(modelLower));
+  if (isClaudeTemperatureOnly) {
+    runtime.topP = undefined;
+    runtime.topK = 0;
+    runtime.frequencyPenalty = 0;
+    runtime.presencePenalty = 0;
+  }
+
+  const providerTopK = resolveProviderTopK(args.connection.provider, runtime.topK);
+  const provider =
+    args.connectionId === LOCAL_SIDECAR_CONNECTION_ID
+      ? getLocalSidecarProvider()
+      : createLLMProvider(
+          args.connection.provider,
+          args.baseUrl,
+          args.connection.apiKey,
+          args.connection.maxContext,
+          args.connection.openrouterProvider,
+          args.connection.maxTokensOverride,
+          args.connection.claudeFastMode === "true",
+          args.connection.treatAsLocalEndpoint === "true",
+        );
+
+  return {
+    ...runtime,
+    connectionParams,
+    chatParams,
+    resolvedEffort,
+    enableThinking,
+    isClaudeNoSampling,
+    providerTopK,
+    provider,
+  };
+}

--- a/packages/server/src/services/generation/provider-generation-runtime.ts
+++ b/packages/server/src/services/generation/provider-generation-runtime.ts
@@ -113,15 +113,15 @@ export function resolveGenerationProviderRuntime(args: GenerationProviderRuntime
     );
   };
 
+  const isLocalGemma = (args.connection.model ?? "").toLowerCase().includes("gemma");
+  applyParameterOverrides(connectionParams);
+  applyParameterOverrides(chatParams);
+
   if (args.isSceneChat) {
     runtime.maxTokens = 8192;
     runtime.reasoningEffort = "maximum";
     runtime.verbosity = "high";
   }
-
-  const isLocalGemma = (args.connection.model ?? "").toLowerCase().includes("gemma");
-  applyParameterOverrides(connectionParams);
-  applyParameterOverrides(chatParams);
 
   if (args.chatMode === "game" && !isLocalGemma) {
     runtime.temperature = 1;

--- a/packages/server/src/services/generation/roleplay-dm-command-runtime.ts
+++ b/packages/server/src/services/generation/roleplay-dm-command-runtime.ts
@@ -1,0 +1,234 @@
+import { logger } from "../../lib/logger.js";
+import { parseExtra, isMessageHiddenFromAI } from "../../routes/generate/generate-route-utils.js";
+import { recordAssistantActivity, recordUserActivity } from "../conversation/autonomous.service.js";
+import type { CharacterCommand, DirectMessageCommand } from "../conversation/character-commands.js";
+import { stripConversationPromptTimestamps } from "../conversation/transcript-sanitize.js";
+import { parseChatCharacterIdsForDm } from "./roleplay-dm-utils.js";
+
+type ChatRow = {
+  id: string;
+  name?: string | null;
+  mode?: string | null;
+  metadata?: unknown;
+  characterIds?: unknown;
+  personaId?: unknown;
+  connectionId?: unknown;
+  connectedChatId?: unknown;
+};
+
+type MessageRow = {
+  id?: unknown;
+  role?: unknown;
+  content?: unknown;
+  extra?: unknown;
+};
+
+type ChatsStore = {
+  getById(id: string): Promise<ChatRow | null>;
+  list(): Promise<ChatRow[]>;
+  listMessages(chatId: string): Promise<MessageRow[]>;
+  create(input: {
+    name: string;
+    mode: string;
+    characterIds: string[];
+    groupId: string | null;
+    personaId: string | null;
+    promptPresetId: string | null;
+    connectionId: string | null;
+  }): Promise<ChatRow | null>;
+  createMessage(input: {
+    chatId: string;
+    role: string;
+    characterId: string | null;
+    content: string;
+  }): Promise<{ id?: unknown } | null>;
+  updateMessageExtra(id: string, partial: Record<string, unknown>): Promise<unknown>;
+  patchMetadata(id: string, patch: Record<string, unknown>): Promise<unknown>;
+  remove(id: string): Promise<unknown>;
+};
+
+export async function handleRoleplayDmCommand(args: {
+  command: CharacterCommand;
+  chatId: string;
+  sourceChat: ChatRow;
+  messageId?: string | null;
+  allChatMessages: MessageRow[];
+  chats: ChatsStore;
+  sendAssistantAction: (data: Record<string, unknown>) => void;
+}): Promise<boolean> {
+  if (args.command.type !== "dm") return false;
+  const command = args.command as DirectMessageCommand;
+
+  try {
+    await runRoleplayDmCommand(command, args);
+  } catch (err) {
+    logger.error(err, "[commands] Roleplay DM creation failed");
+  }
+
+  return true;
+}
+
+async function runRoleplayDmCommand(
+  command: DirectMessageCommand,
+  args: Parameters<typeof handleRoleplayDmCommand>[0],
+): Promise<void> {
+  const messageText = stripConversationPromptTimestamps(command.message).trim().slice(0, 4000);
+  const targetCharId = command.resolvedCharacterId ?? null;
+  const targetName = command.resolvedCharacterName ?? command.character.trim();
+
+  if (!targetCharId) {
+    logger.warn('[commands] DM target character "%s" not found', command.character);
+    return;
+  }
+  if (!messageText) return;
+
+  const sourceUserMessage = [...args.allChatMessages]
+    .reverse()
+    .find((message) => message.role === "user" && !isMessageHiddenFromAI(message));
+  const sourceUserText = sourceUserMessage
+    ? stripConversationPromptTimestamps(String(sourceUserMessage.content ?? "")).trim().slice(0, 4000)
+    : "";
+
+  const ensureSourceUserMessage = async (targetChatId: string, dedupePerTarget: boolean) => {
+    if (!sourceUserMessage?.id || !sourceUserText) return null;
+
+    const targetMessages = await args.chats.listMessages(targetChatId);
+    const alreadyMirrored = targetMessages.some((message) => {
+      const extra = parseExtra(message.extra) as Record<string, unknown>;
+      if (
+        extra.roleplayDmSourceChatId !== args.chatId ||
+        extra.roleplayDmSourceUserMessageId !== sourceUserMessage.id
+      ) {
+        return false;
+      }
+      return !dedupePerTarget || extra.roleplayDmTargetCharacterId === targetCharId;
+    });
+    if (alreadyMirrored) return null;
+
+    const userMsg = await args.chats.createMessage({
+      chatId: targetChatId,
+      role: "user",
+      characterId: null,
+      content: sourceUserText,
+    });
+    if (typeof userMsg?.id === "string") {
+      await args.chats.updateMessageExtra(userMsg.id, {
+        roleplayDmSourceChatId: args.chatId,
+        roleplayDmSourceUserMessageId: sourceUserMessage.id,
+        roleplayDmTargetCharacterId: targetCharId,
+      });
+    }
+    recordUserActivity(targetChatId);
+    return userMsg;
+  };
+
+  const freshChat = await args.chats.getById(args.chatId);
+  const connectedId = typeof freshChat?.connectedChatId === "string" ? freshChat.connectedChatId : null;
+  const connectedChat = connectedId ? await args.chats.getById(connectedId) : null;
+  const linkedConversationId = connectedChat?.mode === "conversation" ? connectedChat.id : null;
+
+  if (linkedConversationId) {
+    const sourceUserDmMessage = await ensureSourceUserMessage(linkedConversationId, false);
+    const dmMessage = await args.chats.createMessage({
+      chatId: linkedConversationId,
+      role: "assistant",
+      characterId: targetCharId,
+      content: messageText,
+    });
+    recordAssistantActivity(linkedConversationId, targetCharId);
+
+    args.sendAssistantAction({
+      action: "dm_posted",
+      chatId: linkedConversationId,
+      mode: "conversation",
+      characterName: targetName,
+      sourceChatId: args.chatId,
+      sourceMessageId: args.messageId || null,
+      sourceUserMessageId: sourceUserMessage?.id ?? null,
+      userMessageId: sourceUserDmMessage?.id ?? null,
+      messageId: dmMessage?.id ?? null,
+    });
+    logger.info(
+      '[commands] Roleplay DM from "%s" posted to linked conversation %s from chat %s',
+      targetName,
+      linkedConversationId,
+      args.chatId,
+    );
+    return;
+  }
+
+  const allChatsList = await args.chats.list();
+  const existingDmChat = allChatsList.find((candidate) => {
+    if (candidate.mode !== "conversation" || candidate.id === args.chatId) return false;
+    const meta = parseExtra(candidate.metadata) as Record<string, unknown>;
+    if (meta.dmOriginChatId !== args.chatId) return false;
+    if (typeof meta.dmTargetCharacterId === "string" && meta.dmTargetCharacterId !== targetCharId) return false;
+    return parseChatCharacterIdsForDm(candidate.characterIds).includes(targetCharId);
+  });
+
+  const createdNewChat = !existingDmChat;
+  const targetChat =
+    existingDmChat ??
+    (await args.chats.create({
+      name: `DM with ${targetName}`,
+      mode: "conversation",
+      characterIds: [targetCharId],
+      groupId: null,
+      personaId: typeof args.sourceChat.personaId === "string" ? args.sourceChat.personaId : null,
+      promptPresetId: null,
+      connectionId: typeof args.sourceChat.connectionId === "string" ? args.sourceChat.connectionId : null,
+    }));
+  if (!targetChat) throw new Error("Failed to create DM conversation");
+
+  let sourceUserDmMessage: Awaited<ReturnType<ChatsStore["createMessage"]>> | null = null;
+  let dmMessage: Awaited<ReturnType<ChatsStore["createMessage"]>> | null = null;
+  try {
+    await args.chats.patchMetadata(targetChat.id, {
+      dmOriginChatId: args.chatId,
+      dmOriginChatName: args.sourceChat.name ?? null,
+      dmOriginMessageId: args.messageId || null,
+      dmSourceUserMessageId: sourceUserMessage?.id ?? null,
+      dmTargetCharacterId: targetCharId,
+      roleplayDmThread: true,
+    });
+    sourceUserDmMessage = await ensureSourceUserMessage(targetChat.id, true);
+    dmMessage = await args.chats.createMessage({
+      chatId: targetChat.id,
+      role: "assistant",
+      characterId: targetCharId,
+      content: messageText,
+    });
+    recordAssistantActivity(targetChat.id, targetCharId);
+  } catch (dmWriteErr) {
+    if (createdNewChat) {
+      try {
+        await args.chats.remove(targetChat.id);
+        logger.warn("[commands] Removed incomplete Roleplay DM conversation %s after failed setup", targetChat.id);
+      } catch (cleanupErr) {
+        logger.error(cleanupErr, "[commands] Failed to remove incomplete Roleplay DM conversation %s", targetChat.id);
+      }
+    }
+    throw dmWriteErr;
+  }
+
+  args.sendAssistantAction({
+    action: createdNewChat ? "chat_created" : "dm_posted",
+    chatId: targetChat.id,
+    chatName: targetChat.name ?? `DM with ${targetName}`,
+    mode: "conversation",
+    characterName: targetName,
+    sourceChatId: args.chatId,
+    sourceMessageId: args.messageId || null,
+    sourceUserMessageId: sourceUserMessage?.id ?? null,
+    userMessageId: sourceUserDmMessage?.id ?? null,
+    messageId: dmMessage?.id ?? null,
+  });
+  logger.info(
+    createdNewChat
+      ? '[commands] Roleplay DM conversation created with "%s" (%s) from chat %s'
+      : '[commands] Roleplay DM from "%s" reused conversation %s from chat %s',
+    targetName,
+    targetChat.id,
+    args.chatId,
+  );
+}

--- a/packages/server/src/services/generation/roleplay-summary-runtime.ts
+++ b/packages/server/src/services/generation/roleplay-summary-runtime.ts
@@ -1,0 +1,80 @@
+import { DEFAULT_CHAT_SUMMARY_PROMPT } from "@marinara-engine/shared";
+
+const RETIRED_CHAT_SUMMARY_AGENT_ID = "chat-summary";
+const DEFAULT_AUTOMATIC_SUMMARY_INTERVAL = 5;
+const MIN_AUTOMATIC_SUMMARY_INTERVAL = 1;
+const MAX_AUTOMATIC_SUMMARY_INTERVAL = 200;
+const MIN_SUMMARY_CONTEXT_SIZE = 5;
+const MAX_SUMMARY_CONTEXT_SIZE = 500;
+
+export const CONTINUE_ASSISTANT_MESSAGE_PROMPT = "Your last message got cut off! Please, continue!";
+
+export function clampRoleplaySummaryInterval(value: unknown): number {
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed) || parsed <= 0) return DEFAULT_AUTOMATIC_SUMMARY_INTERVAL;
+  return Math.max(MIN_AUTOMATIC_SUMMARY_INTERVAL, Math.min(MAX_AUTOMATIC_SUMMARY_INTERVAL, Math.trunc(parsed)));
+}
+
+export function clampRoleplaySummaryContextSize(value: unknown): number {
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed) || parsed <= 0) return 50;
+  return Math.max(MIN_SUMMARY_CONTEXT_SIZE, Math.min(MAX_SUMMARY_CONTEXT_SIZE, Math.trunc(parsed)));
+}
+
+export function appendContinuationMessageContent(existingContent: unknown, continuation: string): string {
+  const existing = typeof existingContent === "string" ? existingContent : "";
+  if (!existing) return continuation;
+  if (!continuation) return existing;
+  return `${existing}${continuation}`;
+}
+
+export function isAutomaticRoleplaySummaryEnabled(chatMetadata: Record<string, unknown>): boolean {
+  if (chatMetadata.automaticSummaryEnabled === false) return false;
+  if (chatMetadata.automaticSummaryEnabled === true) return true;
+  const activeAgentIds = Array.isArray(chatMetadata.activeAgentIds) ? chatMetadata.activeAgentIds : [];
+  return chatMetadata.enableAgents === true && activeAgentIds.includes(RETIRED_CHAT_SUMMARY_AGENT_ID);
+}
+
+export function withoutRetiredChatSummaryAgentIds(chatMetadata: Record<string, unknown>): string[] | undefined {
+  if (!Array.isArray(chatMetadata.activeAgentIds)) return undefined;
+  return chatMetadata.activeAgentIds.filter((agentId): agentId is string => {
+    return typeof agentId === "string" && agentId !== RETIRED_CHAT_SUMMARY_AGENT_ID;
+  });
+}
+
+export function resolveChatSummaryPromptFromMetadata(chatMetadata: Record<string, unknown>): string {
+  const selectedId =
+    typeof chatMetadata.activeSummaryPromptTemplateId === "string"
+      ? chatMetadata.activeSummaryPromptTemplateId.trim()
+      : "";
+  const templates = Array.isArray(chatMetadata.summaryPromptTemplates) ? chatMetadata.summaryPromptTemplates : [];
+  const selected = selectedId
+    ? templates.find((template) => {
+        if (!template || typeof template !== "object" || Array.isArray(template)) return false;
+        const record = template as Record<string, unknown>;
+        return record.id === selectedId && typeof record.prompt === "string" && record.prompt.trim().length > 0;
+      })
+    : null;
+  if (selected && typeof (selected as Record<string, unknown>).prompt === "string") {
+    return ((selected as Record<string, unknown>).prompt as string).trim();
+  }
+  return DEFAULT_CHAT_SUMMARY_PROMPT;
+}
+
+export function parseChatSummaryText(rawContent: string): string {
+  const cleaned = rawContent
+    .trim()
+    .replace(/```(?:json)?\s*/gi, "")
+    .replace(/```/g, "");
+  try {
+    const first = cleaned.indexOf("{");
+    const last = cleaned.lastIndexOf("}");
+    if (first >= 0 && last > first) {
+      const parsed = JSON.parse(cleaned.slice(first, last + 1)) as { summary?: unknown };
+      return typeof parsed.summary === "string" ? parsed.summary.trim() : cleaned.trim();
+    }
+  } catch {
+    // Fall through to raw text.
+  }
+  return cleaned.trim();
+}

--- a/packages/server/src/services/generation/turn-game-command-runtime.ts
+++ b/packages/server/src/services/generation/turn-game-command-runtime.ts
@@ -1,0 +1,120 @@
+import type { FastifyReply } from "fastify";
+
+import type { DB } from "../../db/connection.js";
+import { logger } from "../../lib/logger.js";
+import { getEnabledConversationSchedules } from "./conversation-context-utils.js";
+import { getCurrentStatus, type WeekSchedule } from "../conversation/schedule.service.js";
+import { runTurnGameBotTurns } from "../turn-games/turn-game-bot-runner.service.js";
+import { getActiveTurnGame, startTurnGame } from "../turn-games/turn-game-runner.service.js";
+
+export async function handleTurnGameCommand(args: {
+  commandType: string;
+  characterId: string | null;
+  chatId: string;
+  chatMeta: Record<string, unknown>;
+  db: DB;
+  chats: { getById(id: string): Promise<{ characterIds?: unknown } | null> };
+  conn: unknown;
+  baseUrl: string;
+  reply: FastifyReply;
+  signal: AbortSignal;
+}): Promise<boolean> {
+  if (args.commandType === "uno") {
+    await startUnoFromCommand(args);
+    return true;
+  }
+  if (args.commandType === "chess") {
+    await startChessFromCommand(args);
+    return true;
+  }
+  return false;
+}
+
+async function startUnoFromCommand(args: Parameters<typeof handleTurnGameCommand>[0]): Promise<void> {
+  try {
+    const existingGame = await getActiveTurnGame(args.db, args.chatId);
+    if (existingGame) {
+      logger.info("[commands] UNO requested but a game is already active in chat %s", args.chatId);
+      return;
+    }
+
+    const unoChat = await args.chats.getById(args.chatId);
+    let unoCharIds: string[] = [];
+    try {
+      const rawCharIds = unoChat?.characterIds;
+      const parsedCharIds = typeof rawCharIds === "string" ? JSON.parse(rawCharIds) : rawCharIds;
+      if (Array.isArray(parsedCharIds)) {
+        unoCharIds = parsedCharIds.filter((value): value is string => typeof value === "string");
+      }
+    } catch {
+      unoCharIds = [];
+    }
+
+    const unoSchedules = getEnabledConversationSchedules(args.chatMeta) as Record<string, WeekSchedule>;
+    const seatBotIds = unoCharIds.filter((cid) => {
+      const sched = unoSchedules[cid];
+      return !sched || getCurrentStatus(sched).status !== "offline";
+    });
+    if (args.characterId && unoCharIds.includes(args.characterId) && !seatBotIds.includes(args.characterId)) {
+      seatBotIds.push(args.characterId);
+    }
+
+    const outcome = await startTurnGame(args.db, args.chatId, {
+      gameType: "uno",
+      botCharacterIds: seatBotIds,
+      humanFirst: true,
+    });
+    if (outcome.ok) {
+      args.reply.raw.write(`data: ${JSON.stringify({ type: "turn_game_state_patch", data: outcome.view })}\n\n`);
+      logger.info("[commands] UNO started in chat %s with %d player(s)", args.chatId, seatBotIds.length + 1);
+      await runTurnGameBotTurns({
+        db: args.db,
+        chatId: args.chatId,
+        conn: args.conn,
+        baseUrl: args.baseUrl,
+        reply: args.reply,
+        signal: args.signal,
+      });
+    } else {
+      logger.warn("[commands] UNO start failed in chat %s: %s", args.chatId, outcome.error ?? "");
+    }
+  } catch (err) {
+    logger.error(err, "[commands] UNO start failed");
+  }
+}
+
+async function startChessFromCommand(args: Parameters<typeof handleTurnGameCommand>[0]): Promise<void> {
+  try {
+    const existingGame = await getActiveTurnGame(args.db, args.chatId);
+    if (existingGame) {
+      logger.info("[commands] chess requested but a game is already active in chat %s", args.chatId);
+      return;
+    }
+    if (!args.characterId) {
+      logger.warn("[commands] chess requested without an agreeing character in chat %s", args.chatId);
+      return;
+    }
+
+    const outcome = await startTurnGame(args.db, args.chatId, {
+      gameType: "chess",
+      botCharacterIds: [args.characterId],
+      humanFirst: true,
+    });
+    if (outcome.ok) {
+      args.reply.raw.write(`data: ${JSON.stringify({ type: "turn_game_state_patch", data: outcome.view })}\n\n`);
+      logger.info("[commands] chess started in chat %s against %s", args.chatId, args.characterId);
+      await runTurnGameBotTurns({
+        db: args.db,
+        chatId: args.chatId,
+        conn: args.conn,
+        baseUrl: args.baseUrl,
+        reply: args.reply,
+        signal: args.signal,
+      });
+    } else {
+      logger.warn("[commands] chess start failed in chat %s: %s", args.chatId, outcome.error ?? "");
+    }
+  } catch (err) {
+    logger.error(err, "[commands] chess start failed");
+  }
+}

--- a/packages/server/src/services/lorebook/index.ts
+++ b/packages/server/src/services/lorebook/index.ts
@@ -128,6 +128,28 @@ function readStringArray(value: unknown): string[] {
   return uniqueStrings(safeJsonParse<string[]>(value, []));
 }
 
+function resolveOpeningPinnedScanMessages(messages: ScanMessage[], scanDepth: number): ScanMessage[] {
+  if (scanDepth <= 0) return [];
+
+  const indexedMessages = messages
+    .map((message) => ({ message, content: message.content.trim() }))
+    .filter((item) => item.content.length > 0);
+  if (indexedMessages.length <= scanDepth) return [];
+
+  const userMessageCount = indexedMessages.filter((item) => item.message.role === "user").length;
+  if (userMessageCount > 1) return [];
+
+  const firstUserIndex = indexedMessages.findIndex((item) => item.message.role === "user");
+  const openingEndIndex = firstUserIndex >= 0 ? firstUserIndex : indexedMessages.length;
+  if (openingEndIndex <= 0) return [];
+
+  const recentStartIndex = Math.max(0, indexedMessages.length - scanDepth);
+  return indexedMessages
+    .slice(0, openingEndIndex)
+    .filter((_, index) => index < recentStartIndex)
+    .map((item) => item.message);
+}
+
 function resolveLorebookCharacterIds(book: Pick<RelevantLorebook, "characterId" | "characterIds">): string[] {
   return uniqueStrings([...(book.characterIds ?? []), book.characterId]);
 }
@@ -802,6 +824,7 @@ export function resolveBudgetAndRecursivelyActivateLorebookEntriesWithDiagnostic
 
     frontier = scanForActivatedEntries([{ role: "system", content: recursiveContent }], remaining, {
       ...scanOptions,
+      pinnedScanMessages: [],
       recursionPass: true,
     });
   }
@@ -974,6 +997,7 @@ export async function processLorebooks(
     activeCharacterTags: matchingContext.activeCharacterTags,
     generationTriggers: options?.generationTriggers ?? ["chat"],
     additionalMatchingSourceText: matchingContext.additionalMatchingSourceText,
+    pinnedScanMessages: resolveOpeningPinnedScanMessages(messages, LIMITS.LOREBOOK_DEFAULT_SCAN_DEPTH),
     timingStates,
     currentMessageIndex,
     ...(options?.random ? { random: options.random } : {}),

--- a/packages/server/src/services/lorebook/keyword-scanner.ts
+++ b/packages/server/src/services/lorebook/keyword-scanner.ts
@@ -398,6 +398,8 @@ export interface ScanOptions {
   generationTriggers?: string[];
   /** Extra source text entries may opt into scanning. */
   additionalMatchingSourceText?: Partial<Record<LorebookMatchingSource, string>>;
+  /** Opening messages that should remain scannable even when recent-message depth trims them out. */
+  pinnedScanMessages?: ScanMessage[];
   /** Ignore sticky/cooldown/delay runtime state for preview/debug scans. */
   ignoreTiming?: boolean;
   /** True while scanning content surfaced by a prior lorebook activation. */
@@ -431,6 +433,7 @@ export function scanForActivatedEntries(
     activeCharacterTags = [],
     generationTriggers = ["chat"],
     additionalMatchingSourceText = {},
+    pinnedScanMessages = [],
     ignoreTiming = false,
     recursionPass = false,
     probabilityDecisions = new Map<string, boolean>(),
@@ -442,9 +445,18 @@ export function scanForActivatedEntries(
     generationTriggers: makeValueSet(generationTriggers.length > 0 ? generationTriggers : ["chat"]),
   };
 
+  const pinnedScanText = pinnedScanMessages
+    .map((message) => message.content.trim())
+    .filter(Boolean)
+    .join("\n");
+  const appendPinnedScanText = (baseText: string, includePinned: boolean = true) => {
+    if (!includePinned || !pinnedScanText) return baseText;
+    return baseText ? `${baseText}\n${pinnedScanText}` : pinnedScanText;
+  };
+
   // Build the text to scan from recent messages
   const messagesToScan = scanDepth > 0 ? messages.slice(-scanDepth) : messages;
-  const combinedText = messagesToScan.map((m) => m.content).join("\n");
+  const combinedText = appendPinnedScanText(messagesToScan.map((m) => m.content).join("\n"));
   const latestUserMessage = [...messages].reverse().find((message) => message.role === "user");
   const latestUserText = latestUserMessage?.content ?? "";
 
@@ -464,12 +476,14 @@ export function scanForActivatedEntries(
     //   null = inherit the bounded global default (combinedText)
     const baseEntryScanText =
       entry.scanDepth === 0
-        ? messages.map((m) => m.content).join("\n")
+        ? appendPinnedScanText(messages.map((m) => m.content).join("\n"), false)
         : entry.scanDepth !== null && entry.scanDepth > 0
-          ? messages
-              .slice(-entry.scanDepth)
-              .map((m) => m.content)
-              .join("\n")
+          ? appendPinnedScanText(
+              messages
+                .slice(-entry.scanDepth)
+                .map((m) => m.content)
+                .join("\n"),
+            )
           : combinedText;
     const extraMatchingText = getAdditionalMatchingText(entry, additionalMatchingSourceText);
     return extraMatchingText ? `${baseEntryScanText}\n${extraMatchingText}` : baseEntryScanText;
@@ -638,6 +652,7 @@ export function recursiveScan(
     const newMessages: ScanMessage[] = [{ role: "system", content: newContent }];
     const newActivated = scanForActivatedEntries(newMessages, remaining, {
       ...scanOptions,
+      pinnedScanMessages: [],
       chatEmbedding: null,
       recursionPass: true,
     });

--- a/scripts/regressions/prompt.regression.ts
+++ b/scripts/regressions/prompt.regression.ts
@@ -192,6 +192,70 @@ const cases: RegressionCase[] = [
     },
   },
   {
+    name: "lorebook keyword matching can pin opening messages outside recent scan depth",
+    run() {
+      const entry = {
+        id: "entry-opening",
+        lorebookId: "book-opening",
+        name: "Opening mention",
+        content: "Sandrone profile",
+        description: "",
+        keys: ["Sandrone"],
+        secondaryKeys: [],
+        enabled: true,
+        constant: false,
+        selective: false,
+        selectiveLogic: "and",
+        probability: null,
+        scanDepth: null,
+        matchWholeWords: false,
+        caseSensitive: false,
+        useRegex: false,
+        characterFilterMode: "any",
+        characterFilterIds: [],
+        characterTagFilterMode: "any",
+        characterTagFilters: [],
+        generationTriggerFilterMode: "any",
+        generationTriggerFilters: [],
+        additionalMatchingSources: [],
+        position: 0,
+        depth: 4,
+        order: 100,
+        role: "system",
+        sticky: null,
+        cooldown: null,
+        delay: null,
+        ephemeral: null,
+        group: "",
+        groupWeight: null,
+        folderId: null,
+        locked: false,
+        preventRecursion: true,
+        excludeRecursion: false,
+        delayUntilRecursion: false,
+        tag: "",
+        relationships: {},
+        dynamicState: {},
+        activationConditions: [],
+        schedule: null,
+        excludeFromVectorization: false,
+        embedding: null,
+      } as any;
+      const messages = [
+        { role: "assistant", content: "Sandrone waits in the workshop." },
+        { role: "assistant", content: "Columbina hums nearby." },
+        { role: "assistant", content: "Arlecchino closes the door." },
+        { role: "user", content: "What happens next?" },
+      ];
+
+      assert.equal(scanForActivatedEntries(messages, [entry], { scanDepth: 2 }).length, 0);
+      assert.equal(
+        scanForActivatedEntries(messages, [entry], { scanDepth: 2, pinnedScanMessages: [messages[0]!] }).length,
+        1,
+      );
+    },
+  },
+  {
     name: "save_lorebook_entry tool preserves large entry content",
     async run() {
       const longContent = `entry-start\n${"0123456789".repeat(8_000)}\nentry-end`;


### PR DESCRIPTION
## Linked issue

Fixes #3332.

Also includes a maintainer-reported Roleplay `/guided` regression in individual group chats.

## Why this change

`packages/server/src/routes/generate.routes.ts` had grown into a very large route file with prompt setup, provider runtime setup, conversation context building, agent handling, and command side effects all interleaved. This made v2.1.1 generation work harder to review and riskier to maintain.

While validating the branch, two Roleplay regressions surfaced:

- Typed `/guided` in Individual-Manual group chats could no-op because no explicit responder was sent.
- Smart group queues could make the queued `(1)` responder win over `/guided respond for <character>` intent.

Issue #3332 also showed that first-turn lorebook scans could miss opening group greetings once the recent-message scan window trimmed earlier starter messages.

## What changed

- Split provider setup, prompt patching, output token limits, roleplay summary helpers, Director Secret Plot helpers, and agent-result capability helpers out of `generate.routes.ts`.
- Extracted Conversation prompt/context helpers for history formatting, current context, connected chat injections, presence, custom assets, image captioning, lorebook scan snapshots, and Professor Mari prompt context.
- Extracted command/runtime handlers for Conversation calls, music, reactions, schedules, cross-posts, selfies, memory/influence/notes, scenes, haptics, turn games, Roleplay DMs, and Professor Mari workspace actions.
- Fixed Roleplay `/guided respond for <character> <direction>` so it sends an explicit `forCharacterId`, clears that character's pending smart queue badge, and prompts for a target in Individual-Manual groups instead of silently doing nothing.
- Fixed first-turn lorebook keyword activation by pinning opening chat messages during the first user generation when the normal recent scan depth would otherwise drop earlier group greetings.
- Added v2.1.1 changelog notes for the generation route refactor and the follow-up fixes.

## Validation

- [ ] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed `CONTRIBUTING.md`

### Manual verification notes

AI-run validation completed, boxes intentionally left unchecked for human verification:

- `pnpm --filter @marinara-engine/client exec tsc --noEmit`
- `pnpm --filter @marinara-engine/client lint`
- `pnpm --filter @marinara-engine/server exec tsc --noEmit`
- `pnpm check`
- `pnpm regression:prompt`
- `git diff --check`

No browser/manual UI pass was performed; the `/guided` change is client request routing and the lorebook fix is covered by a prompt regression.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Version/release files updated (only if this PR includes a version bump)

Updated `CHANGELOG.md` for v2.1.1. No version files changed.

## UI evidence (if applicable)

N/A — no visual UI changes.
