### PR TITLE
[codex] Add Grok CLI subscription provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,12 +6,17 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 
 ## [2.1.1]
 
+### Added
+
+- Added a **Grok CLI (Subscription)** connection provider that routes chat requests through a local `grok` CLI login for SuperGrok / X Premium+ users, with in-app setup instructions and no API key or base URL fields.
+
 ### Changed
 
 - Bumped release metadata to v2.1.1 across packages, the PWA manifest, README release pointer, Windows installer sources, Android APK metadata, and the home-page-visible app version.
 - Reorganized Settings so Addons combines Themes and Extensions, Generations houses image/video generation and prompt overrides, Imports uses the plural label, generation prompt editors start collapsed, and Danger Zone uses accent-color selections with no default checked categories.
 - Refreshed the in-app Credits modal from the GitHub contributors list and added credits sync/check helpers to the release workflow.
 - Split the server generation route into focused prompt, provider, context, and command-runtime modules so Conversation commands, Professor Mari actions, turn games, provider setup, and post-processing paths are easier to review and maintain.
+- Removed unused API Key and Base URL fields from local subscription/auth providers such as Claude Subscription, ChatGPT/Codex auth, and Grok CLI.
 
 ### Fixed
 

--- a/packages/client/src/components/connections/ConnectionEditor.tsx
+++ b/packages/client/src/components/connections/ConnectionEditor.tsx
@@ -75,6 +75,7 @@ import {
   VIDEO_GENERATION_SOURCES,
   inferImageSource,
   inferVideoSource,
+  isLocalAuthProvider as isLocalAuthConnectionProvider,
   IMAGE_DEFAULTS_STORAGE_KEY,
   VIDEO_DEFAULTS_STORAGE_KEY,
   COMFYUI_SAMPLER_OPTIONS,
@@ -197,8 +198,7 @@ function canProviderTreatAsLocalEndpoint(provider: APIProvider): boolean {
   return (
     provider !== "image_generation" &&
     provider !== "video_generation" &&
-    provider !== "claude_subscription" &&
-    provider !== "openai_chatgpt"
+    !isLocalAuthConnectionProvider(provider)
   );
 }
 
@@ -207,8 +207,7 @@ function providerSupportsDirectEmbeddingConfig(provider: APIProvider): boolean {
     provider !== "image_generation" &&
     provider !== "video_generation" &&
     provider !== "anthropic" &&
-    provider !== "claude_subscription" &&
-    provider !== "openai_chatgpt"
+    !isLocalAuthConnectionProvider(provider)
   );
 }
 
@@ -325,7 +324,13 @@ export function ConnectionEditor() {
   // Remote models fetched from provider API
   const [remoteModels, setRemoteModels] = useState<RemoteConnectionModel[]>([]);
   const [fetchError, setFetchError] = useState<string | null>(null);
-  const baseUrlValidation = useMemo(() => normalizeEndpointUrlInput(localBaseUrl, "Base URL"), [localBaseUrl]);
+  const baseUrlValidation = useMemo(
+    () =>
+      isLocalAuthConnectionProvider(localProvider)
+        ? { value: "", error: null }
+        : normalizeEndpointUrlInput(localBaseUrl, "Base URL"),
+    [localBaseUrl, localProvider],
+  );
   const embeddingBaseUrlValidation = useMemo(
     () => normalizeEndpointUrlInput(localEmbeddingBaseUrl, "Embedding endpoint URL"),
     [localEmbeddingBaseUrl],
@@ -598,6 +603,7 @@ export function ConnectionEditor() {
     const isImageProvider = localProvider === "image_generation";
     const isVideoProvider = localProvider === "video_generation";
     const isMediaProvider = isImageProvider || isVideoProvider;
+    const isLocalAuthProvider = isLocalAuthConnectionProvider(localProvider);
     const canTreatAsLocalEndpoint = canProviderTreatAsLocalEndpoint(localProvider);
     const existingEmbeddingModel = (conn as { embeddingModel?: string | null } | undefined)?.embeddingModel ?? "";
     const existingEmbeddingBaseUrl = (conn as { embeddingBaseUrl?: string | null } | undefined)?.embeddingBaseUrl ?? "";
@@ -605,7 +611,7 @@ export function ConnectionEditor() {
       id: connectionDetailId,
       name: localName,
       provider: localProvider,
-      baseUrl: baseUrlValidation.value,
+      baseUrl: isLocalAuthProvider ? "" : baseUrlValidation.value,
       model: localModel,
       maxContext: localMaxContext,
       maxParallelJobs: localMaxParallelJobs,
@@ -631,7 +637,9 @@ export function ConnectionEditor() {
       treatAsLocalEndpoint: canTreatAsLocalEndpoint ? localTreatAsLocalEndpoint : false,
     };
     // Only send API key if user typed a new one
-    if (localApiKey.trim()) {
+    if (isLocalAuthProvider) {
+      payload.apiKey = "";
+    } else if (localApiKey.trim()) {
       payload.apiKey = localApiKey;
     } else if (clearStoredApiKeyOnSave) {
       payload.apiKey = "";
@@ -667,7 +675,9 @@ export function ConnectionEditor() {
           ),
         });
       }
-      if (baseUrlValidation.value !== localBaseUrl.trim()) {
+      if (isLocalAuthProvider && localBaseUrl) {
+        setLocalBaseUrl("");
+      } else if (baseUrlValidation.value !== localBaseUrl.trim()) {
         setLocalBaseUrl(baseUrlValidation.value);
       }
       if (supportsDirectEmbeddings && embeddingBaseUrlValidation.value !== localEmbeddingBaseUrl.trim()) {
@@ -752,6 +762,7 @@ export function ConnectionEditor() {
     const isImageProvider = localProvider === "image_generation";
     const isVideoProvider = localProvider === "video_generation";
     const isMediaProvider = isImageProvider || isVideoProvider;
+    const isLocalAuthProvider = isLocalAuthConnectionProvider(localProvider);
     const defaultParameters = isImageProvider
       ? buildImageDefaultParameters(
           currentConnection.defaultParameters,
@@ -780,7 +791,7 @@ export function ConnectionEditor() {
       ...currentConnection,
       name: localName,
       provider: localProvider,
-      baseUrl: localBaseUrl,
+      baseUrl: isLocalAuthProvider ? "" : localBaseUrl,
       model: localModel,
       maxContext: localMaxContext,
       maxTokensOverride: localMaxTokensOverride ?? null,
@@ -1056,7 +1067,8 @@ export function ConnectionEditor() {
   const isMediaGenerationProvider = isImageGenerationProvider || isVideoGenerationProvider;
   const isClaudeSubscriptionProvider = localProvider === "claude_subscription";
   const isOpenAIChatGPTProvider = localProvider === "openai_chatgpt";
-  const isLocalAuthProvider = isClaudeSubscriptionProvider || isOpenAIChatGPTProvider;
+  const isGrokSubscriptionProvider = localProvider === "grok_subscription";
+  const isLocalAuthProvider = isLocalAuthConnectionProvider(localProvider);
   const supportsDirectEmbeddingConfig = providerSupportsDirectEmbeddingConfig(localProvider);
   const canTreatAsLocalEndpoint = canProviderTreatAsLocalEndpoint(localProvider);
 
@@ -1219,9 +1231,15 @@ export function ConnectionEditor() {
                     setLocalProvider(key);
                     // Auto-fill base URL
                     setLocalBaseUrl(info.defaultBaseUrl);
-                    // Clear model when switching providers, except xAI where
-                    // we can seed the newest supported Grok model.
-                    setLocalModel(key === "xai" ? (defaultModel?.id ?? "grok-4.3") : "");
+                    // Seed known Grok selectors; leave other providers blank
+                    // so users deliberately pick their preferred model.
+                    setLocalModel(
+                      key === "xai"
+                        ? (defaultModel?.id ?? "grok-4.3")
+                        : key === "grok_subscription"
+                          ? (defaultModel?.id ?? "grok-build-latest")
+                          : "",
+                    );
                     setLocalMaxContext(Number(defaultModel?.context) || 128000);
                     setLocalMaxTokensOverride(null);
                     setLocalDefaultParametersEnabled(false);
@@ -1246,7 +1264,7 @@ export function ConnectionEditor() {
           </FieldGroup>
 
           {/* ── Claude (Subscription) — prerequisites notice ── */}
-          {localProvider === "claude_subscription" && (
+          {isClaudeSubscriptionProvider && (
             <div className="rounded-xl bg-sky-400/5 px-3 py-2.5 ring-1 ring-sky-400/30">
               <p className="flex items-start gap-1.5 text-[0.6875rem] text-sky-300">
                 <AlertCircle size="0.75rem" className="mt-px shrink-0" />
@@ -1263,7 +1281,7 @@ export function ConnectionEditor() {
                 <li>
                   Sign in once: <code className="rounded bg-[var(--secondary)] px-1">claude login</code>
                 </li>
-                <li>API Key and Base URL are not required — leave them blank.</li>
+                <li>API Key and Base URL are not required for this provider.</li>
               </ol>
               <p className="mt-1.5 text-[0.625rem] text-[var(--muted-foreground)]">
                 Subscription auth is the same mechanism Visual Studio Code and other Anthropic-endorsed IDE integrations
@@ -1289,11 +1307,42 @@ export function ConnectionEditor() {
                 <li>
                   Sign in once: <code className="rounded bg-[var(--secondary)] px-1">codex login</code>
                 </li>
-                <li>API Key and Base URL are not required - leave them blank.</li>
+                <li>API Key and Base URL are not required for this provider.</li>
               </ol>
               <p className="mt-1.5 text-[0.625rem] text-[var(--muted-foreground)]">
                 Marinara reads the local Codex auth file and refreshes the ChatGPT session when possible. Embeddings are
                 not available on this provider; configure a separate connection for embedding work.
+              </p>
+            </div>
+          )}
+
+          {/* ── Grok CLI (Subscription) — prerequisites notice ── */}
+          {isGrokSubscriptionProvider && (
+            <div className="rounded-xl bg-sky-400/5 px-3 py-2.5 ring-1 ring-sky-400/30">
+              <p className="flex items-start gap-1.5 text-[0.6875rem] text-sky-300">
+                <AlertCircle size="0.75rem" className="mt-px shrink-0" />
+                <span>
+                  Routes chat through your local <strong>Grok CLI</strong> install so it uses your signed-in{" "}
+                  <strong>SuperGrok / X Premium+</strong> account instead of an xAI API key. Prerequisites on the
+                  Marinara host:
+                </span>
+              </p>
+              <ol className="mt-1.5 ml-4 list-decimal space-y-0.5 text-[0.625rem] text-[var(--muted-foreground)]">
+                <li>
+                  Install Grok CLI:{" "}
+                  <code className="rounded bg-[var(--secondary)] px-1">
+                    curl -fsSL https://x.ai/cli/install.sh | bash
+                  </code>
+                </li>
+                <li>
+                  Sign in once: <code className="rounded bg-[var(--secondary)] px-1">grok login</code>
+                </li>
+                <li>API Key and Base URL are not required for this provider.</li>
+              </ol>
+              <p className="mt-1.5 text-[0.625rem] text-[var(--muted-foreground)]">
+                Marinara runs <code className="rounded bg-[var(--secondary)] px-1">grok</code> headlessly with Grok-side
+                tools, memory, web search, plans, and subagents disabled. Embeddings are not available on this provider;
+                configure a separate connection for embedding work.
               </p>
             </div>
           )}
@@ -1348,143 +1397,106 @@ export function ConnectionEditor() {
             </FieldGroup>
           )}
 
-          {/* ── API Key ── */}
-          <FieldGroup
-            label="API Key"
-            icon={<Key size="0.875rem" className="text-sky-400" />}
-            help="Your authentication key from the AI provider. You can get one from their website. It's like a password that lets Marinara talk to the AI service."
-          >
-            <input
-              value={localApiKey}
-              onChange={(e) => {
-                setLocalApiKey(e.target.value);
-                markDirty();
-              }}
-              type="password"
-              className="w-full rounded-xl bg-[var(--secondary)] px-3 py-2.5 text-sm ring-1 ring-[var(--border)] placeholder:text-[var(--muted-foreground)] focus:outline-none focus:ring-2 focus:ring-[var(--ring)] disabled:cursor-not-allowed disabled:opacity-70"
-              placeholder={
-                isClaudeSubscriptionProvider
-                  ? "Not used — managed by the Claude Agent SDK"
-                  : isOpenAIChatGPTProvider
-                    ? "Not used - read from local Codex ChatGPT login"
-                    : "••••••••  (leave empty to keep existing key)"
-              }
-              disabled={isLocalAuthProvider}
-            />
-            {!isLocalAuthProvider && (
-              <p className="mt-1 text-[0.625rem] text-[var(--muted-foreground)]">
-                Your key is encrypted at rest. Leave blank when editing to keep the existing key.
-              </p>
-            )}
-            {!isLocalAuthProvider && apiKeyLink && (
-              <a
-                href={apiKeyLink.url}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="mt-1.5 inline-flex items-center gap-1 text-[0.6875rem] font-medium text-sky-400 transition-colors hover:text-sky-300"
+          {!isLocalAuthProvider && (
+            <>
+              {/* ── API Key ── */}
+              <FieldGroup
+                label="API Key"
+                icon={<Key size="0.875rem" className="text-sky-400" />}
+                help="Your authentication key from the AI provider. You can get one from their website. It's like a password that lets Marinara talk to the AI service."
               >
-                <ExternalLink size="0.625rem" />
-                {apiKeyLink.label}
-              </a>
-            )}
-            {localProvider === "custom" && (
-              <p className="mt-1.5 text-[0.625rem] text-[var(--muted-foreground)]">
-                For local models (Ollama, LM Studio, KoboldCpp, etc.) you can leave this empty — just set the Base URL
-                below.
-              </p>
-            )}
-            {localProvider === "claude_subscription" && (
-              <p className="mt-1 text-[0.625rem] text-[var(--muted-foreground)]">
-                Authentication is read from your local{" "}
-                <code className="rounded bg-[var(--secondary)] px-1">claude</code> CLI session.
-              </p>
-            )}
-            {isOpenAIChatGPTProvider && (
-              <p className="mt-1 text-[0.625rem] text-[var(--muted-foreground)]">
-                Authentication is read from your local{" "}
-                <code className="rounded bg-[var(--secondary)] px-1">codex login</code> session.
-              </p>
-            )}
-          </FieldGroup>
+                <input
+                  value={localApiKey}
+                  onChange={(e) => {
+                    setLocalApiKey(e.target.value);
+                    markDirty();
+                  }}
+                  type="password"
+                  className="w-full rounded-xl bg-[var(--secondary)] px-3 py-2.5 text-sm ring-1 ring-[var(--border)] placeholder:text-[var(--muted-foreground)] focus:outline-none focus:ring-2 focus:ring-[var(--ring)]"
+                  placeholder="••••••••  (leave empty to keep existing key)"
+                />
+                <p className="mt-1 text-[0.625rem] text-[var(--muted-foreground)]">
+                  Your key is encrypted at rest. Leave blank when editing to keep the existing key.
+                </p>
+                {apiKeyLink && (
+                  <a
+                    href={apiKeyLink.url}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="mt-1.5 inline-flex items-center gap-1 text-[0.6875rem] font-medium text-sky-400 transition-colors hover:text-sky-300"
+                  >
+                    <ExternalLink size="0.625rem" />
+                    {apiKeyLink.label}
+                  </a>
+                )}
+                {localProvider === "custom" && (
+                  <p className="mt-1.5 text-[0.625rem] text-[var(--muted-foreground)]">
+                    For local models (Ollama, LM Studio, KoboldCpp, etc.) you can leave this empty — just set the Base
+                    URL below.
+                  </p>
+                )}
+              </FieldGroup>
 
-          {/* ── Base URL ── */}
-          <FieldGroup
-            label="Base URL"
-            icon={<Globe size="0.875rem" className="text-sky-400" />}
-            help="The API endpoint URL. Usually auto-filled for known providers. Only change this if you're using a proxy, local server, or custom endpoint."
-          >
-            <input
-              value={localBaseUrl}
-              onChange={(e) => {
-                setLocalBaseUrl(e.target.value);
-                markDirty();
-              }}
-              className={cn(
-                "w-full rounded-xl bg-[var(--secondary)] px-3 py-2.5 text-sm font-mono ring-1 placeholder:text-[var(--muted-foreground)] focus:outline-none focus:ring-2 focus:ring-[var(--ring)] disabled:cursor-not-allowed disabled:opacity-70",
-                baseUrlValidation.error ? "ring-[var(--destructive)]" : "ring-[var(--border)]",
-              )}
-              placeholder={
-                isClaudeSubscriptionProvider
-                  ? "Not used — managed by the Claude Agent SDK"
-                  : isOpenAIChatGPTProvider
-                    ? "Not used - ChatGPT Codex endpoint is selected automatically"
-                    : providerDef?.defaultBaseUrl || "https://api.example.com/v1"
-              }
-              disabled={isLocalAuthProvider}
-            />
-            {providerDef?.defaultBaseUrl && !localBaseUrl && !isLocalAuthProvider && (
-              <p className="mt-1 text-[0.625rem] text-[var(--muted-foreground)]">
-                Default: {providerDef.defaultBaseUrl}
-              </p>
-            )}
-            {baseUrlValidation.error && (
-              <p className="mt-1 text-[0.625rem] text-[var(--destructive)]">{baseUrlValidation.error}</p>
-            )}
-            {!baseUrlValidation.error && baseUrlValidation.value !== localBaseUrl.trim() && (
-              <p className="mt-1 text-[0.625rem] text-[var(--muted-foreground)]">
-                Will save as {baseUrlValidation.value}
-              </p>
-            )}
-            {localProvider === "claude_subscription" && (
-              <p className="mt-1 text-[0.625rem] text-[var(--muted-foreground)]">
-                The Claude Agent SDK selects the endpoint automatically based on your local{" "}
-                <code className="rounded bg-[var(--secondary)] px-1">claude</code> CLI auth.
-              </p>
-            )}
-            {isOpenAIChatGPTProvider && (
-              <p className="mt-1 text-[0.625rem] text-[var(--muted-foreground)]">
-                Marinara sends requests to the ChatGPT Codex endpoint automatically using your local Codex auth.
-              </p>
-            )}
-            {localProvider === "custom" && (
-              <p className="mt-1.5 text-[0.625rem] text-[var(--muted-foreground)]">
-                Local model examples: Ollama →{" "}
-                <code className="rounded bg-[var(--secondary)] px-1">http://localhost:11434/v1</code> · LM Studio →{" "}
-                <code className="rounded bg-[var(--secondary)] px-1">http://localhost:1234/v1</code> · KoboldCpp →{" "}
-                <code className="rounded bg-[var(--secondary)] px-1">http://localhost:5001/v1</code>
-              </p>
-            )}
-            {!isLocalAuthProvider && (
-              <p className="mt-1.5 flex items-start gap-1 text-[0.625rem] text-amber-400/80">
-                <AlertCircle size="0.625rem" className="mt-px shrink-0" />
-                <span>
-                  Only use URLs from providers you trust. A malicious endpoint could intercept your messages and API
-                  keys.
-                </span>
-              </p>
-            )}
-            {localProvider === "custom" && (
-              <p className="mt-1.5 flex items-start gap-1 text-[0.625rem] text-sky-400/80">
-                <AlertCircle size="0.625rem" className="mt-px shrink-0" />
-                <span>
-                  <strong>Windows users:</strong> If your proxy or local server isn't detected, Windows Defender
-                  Firewall may be blocking the connection. Open{" "}
-                  <em>Windows Security → Firewall & network protection → Allow an app through firewall</em> and add
-                  Node.js or your proxy application.
-                </span>
-              </p>
-            )}
-          </FieldGroup>
+              {/* ── Base URL ── */}
+              <FieldGroup
+                label="Base URL"
+                icon={<Globe size="0.875rem" className="text-sky-400" />}
+                help="The API endpoint URL. Usually auto-filled for known providers. Only change this if you're using a proxy, local server, or custom endpoint."
+              >
+                <input
+                  value={localBaseUrl}
+                  onChange={(e) => {
+                    setLocalBaseUrl(e.target.value);
+                    markDirty();
+                  }}
+                  className={cn(
+                    "w-full rounded-xl bg-[var(--secondary)] px-3 py-2.5 text-sm font-mono ring-1 placeholder:text-[var(--muted-foreground)] focus:outline-none focus:ring-2 focus:ring-[var(--ring)]",
+                    baseUrlValidation.error ? "ring-[var(--destructive)]" : "ring-[var(--border)]",
+                  )}
+                  placeholder={providerDef?.defaultBaseUrl || "https://api.example.com/v1"}
+                />
+                {providerDef?.defaultBaseUrl && !localBaseUrl && (
+                  <p className="mt-1 text-[0.625rem] text-[var(--muted-foreground)]">
+                    Default: {providerDef.defaultBaseUrl}
+                  </p>
+                )}
+                {baseUrlValidation.error && (
+                  <p className="mt-1 text-[0.625rem] text-[var(--destructive)]">{baseUrlValidation.error}</p>
+                )}
+                {!baseUrlValidation.error && baseUrlValidation.value !== localBaseUrl.trim() && (
+                  <p className="mt-1 text-[0.625rem] text-[var(--muted-foreground)]">
+                    Will save as {baseUrlValidation.value}
+                  </p>
+                )}
+                {localProvider === "custom" && (
+                  <p className="mt-1.5 text-[0.625rem] text-[var(--muted-foreground)]">
+                    Local model examples: Ollama →{" "}
+                    <code className="rounded bg-[var(--secondary)] px-1">http://localhost:11434/v1</code> · LM Studio
+                    → <code className="rounded bg-[var(--secondary)] px-1">http://localhost:1234/v1</code> · KoboldCpp
+                    → <code className="rounded bg-[var(--secondary)] px-1">http://localhost:5001/v1</code>
+                  </p>
+                )}
+                <p className="mt-1.5 flex items-start gap-1 text-[0.625rem] text-amber-400/80">
+                  <AlertCircle size="0.625rem" className="mt-px shrink-0" />
+                  <span>
+                    Only use URLs from providers you trust. A malicious endpoint could intercept your messages and API
+                    keys.
+                  </span>
+                </p>
+                {localProvider === "custom" && (
+                  <p className="mt-1.5 flex items-start gap-1 text-[0.625rem] text-sky-400/80">
+                    <AlertCircle size="0.625rem" className="mt-px shrink-0" />
+                    <span>
+                      <strong>Windows users:</strong> If your proxy or local server isn't detected, Windows Defender
+                      Firewall may be blocking the connection. Open{" "}
+                      <em>Windows Security → Firewall & network protection → Allow an app through firewall</em> and add
+                      Node.js or your proxy application.
+                    </span>
+                  </p>
+                )}
+              </FieldGroup>
+            </>
+          )}
 
           {/* ── Image Service (only for image_generation provider) ── */}
           {localProvider === "image_generation" && (
@@ -2271,7 +2283,7 @@ export function ConnectionEditor() {
           </FieldGroup>
 
           {/* ── Claude (Subscription) — Fast Mode toggle ── */}
-          {localProvider === "claude_subscription" && (
+          {isClaudeSubscriptionProvider && (
             <FieldGroup
               label="Fast Mode"
               icon={<Zap size="0.875rem" className="text-amber-400" />}
@@ -2486,7 +2498,7 @@ export function ConnectionEditor() {
                   Test Video
                 </button>
               )}
-              {localProvider === "claude_subscription" && (
+              {isClaudeSubscriptionProvider && (
                 <button
                   onClick={handleDiagnoseClaudeSubscription}
                   disabled={diagnoseClaudeSubscription.isPending || !localModel}
@@ -2523,7 +2535,7 @@ export function ConnectionEditor() {
                   <strong>Test Video</strong> generates a short MP4 test clip (requires saving first).
                 </>
               )}
-              {localProvider === "claude_subscription" && (
+              {isClaudeSubscriptionProvider && (
                 <>
                   {" "}
                   <strong>Diagnose Model Routing</strong> sends a real prompt through the Claude Agent SDK and reports

--- a/packages/client/src/components/panels/ConnectionsPanel.tsx
+++ b/packages/client/src/components/panels/ConnectionsPanel.tsx
@@ -90,6 +90,7 @@ const PROVIDER_COLORS: Record<string, { from: string; to: string; ring: string; 
   openai_chatgpt: CONNECTION_ICON_COLORS,
   anthropic: CONNECTION_ICON_COLORS,
   claude_subscription: CONNECTION_ICON_COLORS,
+  grok_subscription: CONNECTION_ICON_COLORS,
   google: CONNECTION_ICON_COLORS,
   google_vertex: CONNECTION_ICON_COLORS,
   mistral: CONNECTION_ICON_COLORS,

--- a/packages/server/src/db/schema/connections.ts
+++ b/packages/server/src/db/schema/connections.ts
@@ -12,6 +12,7 @@ export const apiConnections = sqliteTable("api_connections", {
       "openai_chatgpt",
       "anthropic",
       "claude_subscription",
+      "grok_subscription",
       "google",
       "google_vertex",
       "mistral",

--- a/packages/server/src/routes/agents.routes.ts
+++ b/packages/server/src/routes/agents.routes.ts
@@ -13,6 +13,7 @@ import {
   DEFAULT_AGENT_TOOLS,
   PROVIDERS,
   getDefaultBuiltInAgentSettings,
+  localAuthProviderBaseUrl,
   normalizeAgentPhaseForType,
 } from "@marinara-engine/shared";
 import { createAgentsStorage } from "../services/storage/agents.storage.js";
@@ -454,9 +455,8 @@ export async function agentsRoutes(app: FastifyInstance) {
       const providerDef = PROVIDERS[conn.provider as keyof typeof PROVIDERS];
       baseUrl = providerDef?.defaultBaseUrl ?? "";
     }
-    // Claude (Subscription) uses the local Claude Agent SDK; no HTTP endpoint.
-    if (!baseUrl && conn.provider === "claude_subscription") baseUrl = "claude-agent-sdk://local";
-    if (!baseUrl && conn.provider === "openai_chatgpt") baseUrl = "openai-chatgpt://codex-auth";
+    const localAuthBaseUrl = localAuthProviderBaseUrl(conn.provider);
+    if (!baseUrl && localAuthBaseUrl) baseUrl = localAuthBaseUrl;
     if (!baseUrl) {
       throw Object.assign(new Error("No base URL configured for this connection"), { statusCode: 400 });
     }

--- a/packages/server/src/routes/chats.routes.ts
+++ b/packages/server/src/routes/chats.routes.ts
@@ -25,6 +25,7 @@ import {
   parseTrackerFieldLocks,
   normalizeTextForMatch,
   formatRpgStatsForPrompt,
+  localAuthProviderBaseUrl,
 } from "@marinara-engine/shared";
 import type {
   CharacterData,
@@ -1111,8 +1112,8 @@ export async function chatsRoutes(app: FastifyInstance) {
       const providerDef = PROVIDERS[conn.provider as keyof typeof PROVIDERS];
       baseUrl = providerDef?.defaultBaseUrl ?? "";
     }
-    if (!baseUrl && conn.provider === "claude_subscription") baseUrl = "claude-agent-sdk://local";
-    if (!baseUrl && conn.provider === "openai_chatgpt") baseUrl = "openai-chatgpt://codex-auth";
+    const localAuthBaseUrl = localAuthProviderBaseUrl(conn.provider);
+    if (!baseUrl && localAuthBaseUrl) baseUrl = localAuthBaseUrl;
     if (!baseUrl) return reply.status(400).send({ error: "No base URL for this connection" });
 
     const characterIds: string[] = Array.isArray(chat.characterIds)

--- a/packages/server/src/routes/connections.routes.ts
+++ b/packages/server/src/routes/connections.routes.ts
@@ -14,6 +14,8 @@ import {
   generationParametersSchema,
   inferImageSource,
   inferVideoSource,
+  isLocalAuthProvider,
+  localAuthProviderBaseUrl,
   normalizeVideoGenerationProfile,
 } from "@marinara-engine/shared";
 import { createConnectionsStorage } from "../services/storage/connections.storage.js";
@@ -120,6 +122,7 @@ function usesResponsesEndpointForTestMessage(provider: string, model: string): b
 function describeTestMessageTarget(provider: string, baseUrl: string, model: string): string {
   if (provider === "claude_subscription") return "Claude Agent SDK";
   if (provider === "openai_chatgpt") return "local ChatGPT session";
+  if (provider === "grok_subscription") return "local Grok CLI session";
   if (!baseUrl) return "(no base URL)";
   if (provider === "google_vertex") return buildGoogleVertexModelUrl(baseUrl, model, "generateContent");
   if (isOpenAICompatibleProvider(provider)) {
@@ -436,6 +439,39 @@ export async function connectionsRoutes(app: FastifyInstance) {
         };
       }
 
+      if (conn.provider === "grok_subscription") {
+        if (!conn.model) {
+          return {
+            success: false,
+            message: "No model configured. Set a Grok CLI model first.",
+            latencyMs: Date.now() - start,
+            modelName: null,
+          };
+        }
+        const provider = createLLMProvider(
+          conn.provider,
+          "",
+          "",
+          conn.maxContext,
+          conn.openrouterProvider,
+          conn.maxTokensOverride,
+        );
+        let responseText = "";
+        for await (const chunk of provider.chat([{ role: "user", content: "Reply with OK." }], {
+          model: conn.model,
+          maxTokens: 32,
+          stream: false,
+        })) {
+          responseText += chunk;
+        }
+        return {
+          success: true,
+          message: `Grok CLI completed a real request: ${responseText.trim().slice(0, 120) || "OK"}`,
+          latencyMs: Date.now() - start,
+          modelName: conn.model,
+        };
+      }
+
       // Simple models list fetch to verify the key works
       const { PROVIDERS } = await import("@marinara-engine/shared");
       const provider = PROVIDERS[conn.provider as keyof typeof PROVIDERS];
@@ -573,6 +609,10 @@ export async function connectionsRoutes(app: FastifyInstance) {
           // before the host has run `codex login`.
         }
         return { models: MODEL_LISTS.openai_chatgpt.map((m) => ({ id: m.id, name: m.name })) };
+      }
+
+      if (conn.provider === "grok_subscription") {
+        return { models: MODEL_LISTS.grok_subscription.map((m) => ({ id: m.id, name: m.name })) };
       }
 
       if (conn.provider === "video_generation") {
@@ -1113,7 +1153,7 @@ export async function connectionsRoutes(app: FastifyInstance) {
 
     // Local subscription/session providers manage their own endpoint, so skip
     // the baseUrl precondition. Every HTTP provider still requires one.
-    if (!baseUrl && conn.provider !== "claude_subscription" && conn.provider !== "openai_chatgpt") {
+    if (!baseUrl && !isLocalAuthProvider(conn.provider)) {
       return reply.status(400).send({ error: "No base URL configured" });
     }
 
@@ -1125,7 +1165,7 @@ export async function connectionsRoutes(app: FastifyInstance) {
       debugLog("[connections/test-message] provider=%s model=%s url=%s", conn.provider, conn.model, targetUrl);
       const provider = createLLMProvider(
         conn.provider,
-        baseUrl,
+        localAuthProviderBaseUrl(conn.provider) ?? baseUrl,
         conn.apiKey,
         conn.maxContext,
         conn.openrouterProvider,

--- a/packages/server/src/routes/connections.routes.ts
+++ b/packages/server/src/routes/connections.routes.ts
@@ -450,6 +450,9 @@ export async function connectionsRoutes(app: FastifyInstance) {
         }
         const provider = createLLMProvider(
           conn.provider,
+          // Grok CLI subscription auth is local-only: the CLI reads the
+          // cached `grok login` session, so API key/base URL are intentionally
+          // unused here and in normal generation.
           "",
           "",
           conn.maxContext,

--- a/packages/server/src/routes/conversation.routes.ts
+++ b/packages/server/src/routes/conversation.routes.ts
@@ -10,7 +10,7 @@ import { createChatsStorage } from "../services/storage/chats.storage.js";
 import { createCharactersStorage } from "../services/storage/characters.storage.js";
 import { createConnectionsStorage } from "../services/storage/connections.storage.js";
 import { createLLMProvider } from "../services/llm/provider-registry.js";
-import { CONVERSATION_SCHEDULE_DAYS, PROVIDERS } from "@marinara-engine/shared";
+import { CONVERSATION_SCHEDULE_DAYS, PROVIDERS, localAuthProviderBaseUrl } from "@marinara-engine/shared";
 import type { CharacterData, ConversationStatusOverride } from "@marinara-engine/shared";
 import {
   generateCharacterSchedule,
@@ -50,8 +50,8 @@ function resolveBaseUrl(connection: { baseUrl: string | null; provider: string }
   if (connection.baseUrl) return connection.baseUrl;
   // Login-backed providers own their endpoint internally; return sentinels so
   // downstream baseUrl gates pass.
-  if (connection.provider === "claude_subscription") return "claude-agent-sdk://local";
-  if (connection.provider === "openai_chatgpt") return "openai-chatgpt://codex-auth";
+  const localAuthBaseUrl = localAuthProviderBaseUrl(connection.provider);
+  if (localAuthBaseUrl) return localAuthBaseUrl;
   const providerDef = PROVIDERS[connection.provider as keyof typeof PROVIDERS];
   return providerDef?.defaultBaseUrl ?? "";
 }

--- a/packages/server/src/routes/encounter.routes.ts
+++ b/packages/server/src/routes/encounter.routes.ts
@@ -11,7 +11,7 @@ import { mapSheetAttributesToRPG } from "../services/game/skill-check.service.js
 import { createLLMProvider } from "../services/llm/provider-registry.js";
 import type { ChatMessage } from "../services/llm/base-provider.js";
 import { logger, logDebugOverride } from "../lib/logger.js";
-import { normalizeRpgStatPools, stripMacroComments } from "@marinara-engine/shared";
+import { localAuthProviderBaseUrl, normalizeRpgStatPools, stripMacroComments } from "@marinara-engine/shared";
 import type {
   EncounterInitRequest,
   EncounterActionRequest,
@@ -66,10 +66,8 @@ async function resolveConnection(
     const providerDef = PROVIDERS[conn.provider as keyof typeof PROVIDERS];
     baseUrl = providerDef?.defaultBaseUrl ?? "";
   }
-  // Claude (Subscription) uses the local Claude Agent SDK and has no HTTP
-  // endpoint — return a sentinel so the gate passes. The provider ignores it.
-  if (!baseUrl && conn.provider === "claude_subscription") baseUrl = "claude-agent-sdk://local";
-  if (!baseUrl && conn.provider === "openai_chatgpt") baseUrl = "openai-chatgpt://codex-auth";
+  const localAuthBaseUrl = localAuthProviderBaseUrl(conn.provider);
+  if (!baseUrl && localAuthBaseUrl) baseUrl = localAuthBaseUrl;
   if (!baseUrl) throw new Error("No base URL configured for this connection");
 
   return { conn, baseUrl };

--- a/packages/server/src/routes/game.routes.ts
+++ b/packages/server/src/routes/game.routes.ts
@@ -107,6 +107,7 @@ import {
   normalizeVideoGenerationProfile,
   normalizeAgentPromptTemplateOptions,
   isClaudeAdaptiveOnlyNoSamplingModel,
+  localAuthProviderBaseUrl,
   supportsXhighReasoningEffort,
   scoreMusic,
   scoreAmbient,
@@ -2406,10 +2407,8 @@ async function resolveConnection(
     const providerDef = PROVIDERS[conn.provider as keyof typeof PROVIDERS];
     baseUrl = providerDef?.defaultBaseUrl ?? "";
   }
-  // Claude (Subscription) uses the local Claude Agent SDK and has no HTTP
-  // endpoint — return a sentinel so the gate passes. The provider ignores it.
-  if (!baseUrl && conn.provider === "claude_subscription") baseUrl = "claude-agent-sdk://local";
-  if (!baseUrl && conn.provider === "openai_chatgpt") baseUrl = "openai-chatgpt://codex-auth";
+  const localAuthBaseUrl = localAuthProviderBaseUrl(conn.provider);
+  if (!baseUrl && localAuthBaseUrl) baseUrl = localAuthBaseUrl;
   if (!baseUrl) throw new Error("No base URL configured for this connection");
 
   return { conn, baseUrl, defaultGenerationParameters: parseStoredGenerationParameters(conn.defaultParameters) };

--- a/packages/server/src/routes/generate/generate-route-utils.ts
+++ b/packages/server/src/routes/generate/generate-route-utils.ts
@@ -6,6 +6,7 @@ import {
   SUMMARY_TAIL_MESSAGES,
   applyTrackerFieldLocksToGameStatePatch,
   generationParametersSchema,
+  localAuthProviderBaseUrl,
   normalizeTextForMatch,
   normalizeThinkingTagPairs,
   parseTrackerFieldLocks,
@@ -1129,8 +1130,8 @@ export function resolveBaseUrl(connection: { baseUrl: string | null; provider: s
   // Subscription/login-backed providers own their endpoint internally, but
   // downstream callers gate on a non-empty baseUrl. Return a sentinel so the
   // gate passes; the provider ignores the value.
-  if (connection.provider === "claude_subscription") return "claude-agent-sdk://local";
-  if (connection.provider === "openai_chatgpt") return "openai-chatgpt://codex-auth";
+  const localAuthBaseUrl = localAuthProviderBaseUrl(connection.provider);
+  if (localAuthBaseUrl) return localAuthBaseUrl;
   const providerDef = PROVIDERS[connection.provider as keyof typeof PROVIDERS];
   return providerDef?.defaultBaseUrl ?? "";
 }

--- a/packages/server/src/routes/scene.routes.ts
+++ b/packages/server/src/routes/scene.routes.ts
@@ -18,6 +18,7 @@ import { createLLMProvider } from "../services/llm/provider-registry.js";
 import { stripConversationPromptTimestamps } from "../services/conversation/transcript-sanitize.js";
 import { DATA_DIR } from "../utils/data-dir.js";
 import type { ChatCompletionResult, ChatMessage } from "../services/llm/base-provider.js";
+import { localAuthProviderBaseUrl } from "@marinara-engine/shared";
 import type {
   SceneCreateRequest,
   SceneCreateResponse,
@@ -68,10 +69,8 @@ async function resolveConnection(
     const providerDef = PROVIDERS[conn.provider as keyof typeof PROVIDERS];
     baseUrl = providerDef?.defaultBaseUrl ?? "";
   }
-  // Claude (Subscription) uses the local Claude Agent SDK and has no HTTP
-  // endpoint — return a sentinel so the gate passes. The provider ignores it.
-  if (!baseUrl && conn.provider === "claude_subscription") baseUrl = "claude-agent-sdk://local";
-  if (!baseUrl && conn.provider === "openai_chatgpt") baseUrl = "openai-chatgpt://codex-auth";
+  const localAuthBaseUrl = localAuthProviderBaseUrl(conn.provider);
+  if (!baseUrl && localAuthBaseUrl) baseUrl = localAuthBaseUrl;
   if (!baseUrl) throw new Error("No base URL configured for this connection");
 
   return { conn, baseUrl };

--- a/packages/server/src/routes/translate.routes.ts
+++ b/packages/server/src/routes/translate.routes.ts
@@ -5,7 +5,7 @@ import type { FastifyInstance } from "fastify";
 import { z } from "zod";
 import { createConnectionsStorage } from "../services/storage/connections.storage.js";
 import { createLLMProvider } from "../services/llm/provider-registry.js";
-import { DEFAULT_TRANSLATION_SYSTEM_PROMPT, PROVIDERS } from "@marinara-engine/shared";
+import { DEFAULT_TRANSLATION_SYSTEM_PROMPT, PROVIDERS, localAuthProviderBaseUrl } from "@marinara-engine/shared";
 import { isDeeplxLocalUrlsEnabled } from "../config/runtime-config.js";
 import { safeFetch, validateOutboundUrl } from "../utils/security.js";
 
@@ -71,9 +71,8 @@ async function translateWithAI(
     const providerDef = PROVIDERS[conn.provider as keyof typeof PROVIDERS];
     baseUrl = providerDef?.defaultBaseUrl ?? "";
   }
-  // Claude (Subscription) uses the local Claude Agent SDK; no HTTP endpoint.
-  if (!baseUrl && conn.provider === "claude_subscription") baseUrl = "claude-agent-sdk://local";
-  if (!baseUrl && conn.provider === "openai_chatgpt") baseUrl = "openai-chatgpt://codex-auth";
+  const localAuthBaseUrl = localAuthProviderBaseUrl(conn.provider);
+  if (!baseUrl && localAuthBaseUrl) baseUrl = localAuthBaseUrl;
   if (!baseUrl) {
     throw Object.assign(new Error("No base URL configured for this connection"), { statusCode: 400 });
   }

--- a/packages/server/src/services/llm/base-provider.ts
+++ b/packages/server/src/services/llm/base-provider.ts
@@ -126,6 +126,8 @@ export interface ChatOptions {
   reasoningEffort?: "low" | "medium" | "high" | "xhigh" | "max";
   /** Output verbosity for GPT-5+ models */
   verbosity?: "low" | "medium" | "high";
+  /** Emit provider prompt debug logs even when normal debug logging is disabled. */
+  debugMode?: boolean;
   /** OpenRouter-only service tier. */
   serviceTier?: "flex" | "priority" | null;
   /** Abort signal — when triggered, the in-flight LLM request should be cancelled. */

--- a/packages/server/src/services/llm/provider-registry.ts
+++ b/packages/server/src/services/llm/provider-registry.ts
@@ -5,6 +5,7 @@ import { OpenAIProvider } from "./providers/openai.provider.js";
 import { OpenAIChatGPTProvider } from "./providers/openai-chatgpt.provider.js";
 import { AnthropicProvider } from "./providers/anthropic.provider.js";
 import { ClaudeSubscriptionProvider } from "./providers/claude-subscription.provider.js";
+import { GrokSubscriptionProvider } from "./providers/grok-subscription.provider.js";
 import { GoogleProvider } from "./providers/google.provider.js";
 import type { BaseLLMProvider } from "./base-provider.js";
 
@@ -105,6 +106,14 @@ export function createLLMProvider(
         openrouterProvider,
         normalizedMaxTokensOverride,
         claudeFastMode ?? false,
+      );
+    case "grok_subscription":
+      return new GrokSubscriptionProvider(
+        baseUrl,
+        apiKey,
+        normalizedMaxContext,
+        openrouterProvider,
+        normalizedMaxTokensOverride,
       );
     case "google":
       return new GoogleProvider(baseUrl, apiKey, normalizedMaxContext, openrouterProvider, normalizedMaxTokensOverride);

--- a/packages/server/src/services/llm/providers/grok-subscription.provider.ts
+++ b/packages/server/src/services/llm/providers/grok-subscription.provider.ts
@@ -10,11 +10,13 @@ import { spawn } from "node:child_process";
 import { mkdir } from "node:fs/promises";
 import { join } from "node:path";
 import { BaseLLMProvider, type ChatMessage, type ChatOptions, type LLMUsage } from "../base-provider.js";
-import { logger } from "../../../lib/logger.js";
+import { isDebugAgentsEnabled } from "../../../config/runtime-config.js";
+import { logger, logDebugOverride } from "../../../lib/logger.js";
 import { DATA_DIR } from "../../../utils/data-dir.js";
 
 const GROK_SCRATCH_DIR = join(DATA_DIR, "grok-cli");
 const GROK_ERROR_PREVIEW_CHARS = 2000;
+const GROK_REQUEST_TIMEOUT_MS = 10 * 60 * 1000;
 const GROK_TOKENS_PER_CHAR = 4;
 
 function estimateTokens(text: string): number {
@@ -82,6 +84,7 @@ export class GrokSubscriptionProvider extends BaseLLMProvider {
     const prompt = buildGrokPrompt(contextFit.messages);
     await mkdir(GROK_SCRATCH_DIR, { recursive: true });
 
+    const debugOverrideEnabled = options.debugMode === true || isDebugAgentsEnabled();
     const args = [
       "--no-auto-update",
       "-p",
@@ -92,6 +95,8 @@ export class GrokSubscriptionProvider extends BaseLLMProvider {
       "--no-subagents",
       "--no-memory",
       "--disable-web-search",
+      "--disallowed-tools",
+      "run_terminal_command",
       "--max-turns",
       "1",
       "--cwd",
@@ -100,6 +105,7 @@ export class GrokSubscriptionProvider extends BaseLLMProvider {
     if (options.model.trim()) args.push("-m", options.model.trim());
 
     logger.debug("[grok-subscription] running grok CLI model=%s promptChars=%d", options.model, prompt.length);
+    logDebugOverride(debugOverrideEnabled, "[debug/grok-subscription] final prompt:\n%s", prompt);
 
     const child = spawn("grok", args, {
       cwd: GROK_SCRATCH_DIR,
@@ -110,6 +116,8 @@ export class GrokSubscriptionProvider extends BaseLLMProvider {
     let stdout = "";
     let stderr = "";
     let aborted = false;
+    let timedOut = false;
+    let requestTimer: NodeJS.Timeout | null = null;
     let killTimer: NodeJS.Timeout | null = null;
 
     child.stdout?.on("data", (chunk: Buffer) => {
@@ -119,11 +127,21 @@ export class GrokSubscriptionProvider extends BaseLLMProvider {
       stderr += chunk.toString("utf8");
     });
 
+    const terminateChild = () => {
+      child.kill("SIGTERM");
+      if (killTimer) return;
+      killTimer = setTimeout(() => child.kill("SIGKILL"), 2_000);
+      killTimer.unref?.();
+    };
     const onAbort = () => {
       aborted = true;
-      child.kill("SIGTERM");
-      killTimer = setTimeout(() => child.kill("SIGKILL"), 2_000);
+      terminateChild();
     };
+    requestTimer = setTimeout(() => {
+      timedOut = true;
+      terminateChild();
+    }, GROK_REQUEST_TIMEOUT_MS);
+    requestTimer.unref?.();
     if (options.signal) {
       if (options.signal.aborted) onAbort();
       else options.signal.addEventListener("abort", onAbort, { once: true });
@@ -135,6 +153,9 @@ export class GrokSubscriptionProvider extends BaseLLMProvider {
         child.once("close", (code, signal) => resolve({ code, signal }));
       });
 
+      if (timedOut) {
+        throw new Error(`Grok CLI request timed out after ${Math.round(GROK_REQUEST_TIMEOUT_MS / 1000)}s.`);
+      }
       if (aborted || options.signal?.aborted) {
         throw new Error("Grok CLI request was aborted.");
       }
@@ -169,6 +190,7 @@ export class GrokSubscriptionProvider extends BaseLLMProvider {
       }
       throw err;
     } finally {
+      if (requestTimer) clearTimeout(requestTimer);
       if (killTimer) clearTimeout(killTimer);
       if (options.signal) options.signal.removeEventListener("abort", onAbort);
     }

--- a/packages/server/src/services/llm/providers/grok-subscription.provider.ts
+++ b/packages/server/src/services/llm/providers/grok-subscription.provider.ts
@@ -1,0 +1,182 @@
+// ──────────────────────────────────────────────
+// LLM Provider — Grok CLI (Subscription via local Grok Build auth)
+// ──────────────────────────────────────────────
+//
+// Routes chat requests through the locally-installed `grok` CLI so users can
+// use their SuperGrok / X Premium+ CLI subscription without an xAI API key.
+// This provider deliberately runs Grok in one-shot, no-tool mode: Marinara owns
+// the prompt pipeline, command parsing, and tool execution.
+import { spawn } from "node:child_process";
+import { mkdir } from "node:fs/promises";
+import { join } from "node:path";
+import { BaseLLMProvider, type ChatMessage, type ChatOptions, type LLMUsage } from "../base-provider.js";
+import { logger } from "../../../lib/logger.js";
+import { DATA_DIR } from "../../../utils/data-dir.js";
+
+const GROK_SCRATCH_DIR = join(DATA_DIR, "grok-cli");
+const GROK_ERROR_PREVIEW_CHARS = 2000;
+const GROK_TOKENS_PER_CHAR = 4;
+
+function estimateTokens(text: string): number {
+  return Math.ceil(Array.from(text).length / GROK_TOKENS_PER_CHAR);
+}
+
+function stripAnsi(value: string): string {
+  return value.replace(/\x1B(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])/g, "");
+}
+
+function roleLabel(role: ChatMessage["role"]): string {
+  switch (role) {
+    case "system":
+      return "System";
+    case "assistant":
+      return "Assistant";
+    case "tool":
+      return "Tool";
+    default:
+      return "User";
+  }
+}
+
+function attachmentNotice(message: ChatMessage): string {
+  const notices: string[] = [];
+  if (message.images?.length) notices.push(`[${message.images.length} image attachment(s) omitted: Grok CLI provider is text-only.]`);
+  if (message.files?.length) notices.push(`[${message.files.length} file attachment(s) omitted: Grok CLI provider is text-only.]`);
+  if (message.media?.length) notices.push(`[${message.media.length} media attachment(s) omitted: Grok CLI provider is text-only.]`);
+  return notices.length ? `\n${notices.join("\n")}` : "";
+}
+
+function buildGrokPrompt(messages: ChatMessage[]): string {
+  const transcript = messages
+    .map((message) => {
+      const content = message.content?.trim() || "(empty)";
+      return `<${roleLabel(message.role)}>\n${content}${attachmentNotice(message)}\n</${roleLabel(message.role)}>`;
+    })
+    .join("\n\n");
+
+  return [
+    "You are responding as the assistant for Marinara Engine.",
+    "Follow the system/developer/user instructions in the transcript exactly.",
+    "Return only the assistant response for the latest user turn. Do not describe these wrapper tags.",
+    "",
+    transcript,
+  ].join("\n");
+}
+
+function compactGrokError(stderr: string, stdout: string, fallback: string): string {
+  const combined = stripAnsi([stderr, stdout].filter((part) => part.trim()).join("\n")).trim();
+  return (combined || fallback).replace(/\s+/g, " ").slice(0, GROK_ERROR_PREVIEW_CHARS);
+}
+
+export class GrokSubscriptionProvider extends BaseLLMProvider {
+  async *chat(messages: ChatMessage[], options: ChatOptions): AsyncGenerator<string, LLMUsage | void, unknown> {
+    const configuredMaxTokens = this.applyMaxTokensCap(options.maxTokens ?? 4096);
+    const contextFit = this.fitMessagesToContext(messages, {
+      ...options,
+      maxTokens: configuredMaxTokens,
+      tools: undefined,
+      suppressModelParameters: true,
+    });
+    this.logContextTrim(contextFit, options.model);
+
+    const prompt = buildGrokPrompt(contextFit.messages);
+    await mkdir(GROK_SCRATCH_DIR, { recursive: true });
+
+    const args = [
+      "--no-auto-update",
+      "-p",
+      prompt,
+      "--output-format",
+      "plain",
+      "--no-plan",
+      "--no-subagents",
+      "--no-memory",
+      "--disable-web-search",
+      "--max-turns",
+      "1",
+      "--cwd",
+      GROK_SCRATCH_DIR,
+    ];
+    if (options.model.trim()) args.push("-m", options.model.trim());
+
+    logger.debug("[grok-subscription] running grok CLI model=%s promptChars=%d", options.model, prompt.length);
+
+    const child = spawn("grok", args, {
+      cwd: GROK_SCRATCH_DIR,
+      env: { ...process.env },
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+
+    let stdout = "";
+    let stderr = "";
+    let aborted = false;
+    let killTimer: NodeJS.Timeout | null = null;
+
+    child.stdout?.on("data", (chunk: Buffer) => {
+      stdout += chunk.toString("utf8");
+    });
+    child.stderr?.on("data", (chunk: Buffer) => {
+      stderr += chunk.toString("utf8");
+    });
+
+    const onAbort = () => {
+      aborted = true;
+      child.kill("SIGTERM");
+      killTimer = setTimeout(() => child.kill("SIGKILL"), 2_000);
+    };
+    if (options.signal) {
+      if (options.signal.aborted) onAbort();
+      else options.signal.addEventListener("abort", onAbort, { once: true });
+    }
+
+    try {
+      const result = await new Promise<{ code: number | null; signal: NodeJS.Signals | null }>((resolve, reject) => {
+        child.once("error", reject);
+        child.once("close", (code, signal) => resolve({ code, signal }));
+      });
+
+      if (aborted || options.signal?.aborted) {
+        throw new Error("Grok CLI request was aborted.");
+      }
+      if (result.code !== 0) {
+        const detail = compactGrokError(stderr, stdout, `grok exited with code ${result.code ?? "unknown"}`);
+        throw new Error(
+          `Grok CLI request failed: ${detail}. Confirm \`grok\` is installed and \`grok login\` was run by the same OS user/HOME as the Marinara server. HOME=${process.env.HOME ?? "unset"}.`,
+        );
+      }
+
+      const text = stripAnsi(stdout).trim();
+      if (!text) {
+        const detail = compactGrokError(stderr, stdout, "empty response");
+        throw new Error(`Grok CLI returned no content (${detail}).`);
+      }
+
+      yield text;
+      const completionTokens = estimateTokens(text);
+      const promptTokens = estimateTokens(prompt);
+      return {
+        promptTokens,
+        completionTokens,
+        totalTokens: promptTokens + completionTokens,
+        finishReason: "stop",
+      };
+    } catch (err) {
+      logger.error(err, "Grok CLI request failed for model %s", options.model);
+      if (err instanceof Error && /ENOENT/.test(err.message)) {
+        throw new Error(
+          "Grok CLI is not installed or not on PATH. Install it with `curl -fsSL https://x.ai/cli/install.sh | bash`, then run `grok login` as the same OS user that starts Marinara.",
+        );
+      }
+      throw err;
+    } finally {
+      if (killTimer) clearTimeout(killTimer);
+      if (options.signal) options.signal.removeEventListener("abort", onAbort);
+    }
+  }
+
+  override async embed(_texts: string[], _model: string, _signal?: AbortSignal): Promise<number[][]> {
+    throw new Error(
+      "The Grok CLI (Subscription) provider does not support embeddings. Configure a separate embedding connection (OpenAI, Google, or local).",
+    );
+  }
+}

--- a/packages/server/src/services/memory-recall-embedding.ts
+++ b/packages/server/src/services/memory-recall-embedding.ts
@@ -1,4 +1,4 @@
-import { LOCAL_SIDECAR_CONNECTION_ID, PROVIDERS } from "@marinara-engine/shared";
+import { LOCAL_SIDECAR_CONNECTION_ID, PROVIDERS, localAuthProviderBaseUrl } from "@marinara-engine/shared";
 import type { DB } from "../db/connection.js";
 import { logger } from "../lib/logger.js";
 import { isLocalEmbedderAvailable } from "./local-embedder.js";
@@ -47,8 +47,8 @@ function parseMetadata(raw: unknown): Record<string, unknown> {
 
 function resolveBaseUrl(connection: { baseUrl: string | null; provider: string }): string {
   if (connection.baseUrl) return connection.baseUrl.replace(/\/+$/, "");
-  if (connection.provider === "claude_subscription") return "claude-agent-sdk://local";
-  if (connection.provider === "openai_chatgpt") return "openai-chatgpt://codex-auth";
+  const localAuthBaseUrl = localAuthProviderBaseUrl(connection.provider);
+  if (localAuthBaseUrl) return localAuthBaseUrl;
   const providerDef = PROVIDERS[connection.provider as keyof typeof PROVIDERS];
   return providerDef?.defaultBaseUrl ?? "";
 }

--- a/packages/server/src/services/spotify/dj-mari-playlist.service.ts
+++ b/packages/server/src/services/spotify/dj-mari-playlist.service.ts
@@ -1,5 +1,5 @@
 // DJ Mari - Spotify playlist composer
-import { PROVIDERS } from "@marinara-engine/shared";
+import { PROVIDERS, localAuthProviderBaseUrl } from "@marinara-engine/shared";
 import type { DB } from "../../db/connection.js";
 import { logger } from "../../lib/logger.js";
 import { createLLMProvider } from "../llm/provider-registry.js";
@@ -447,8 +447,8 @@ async function resolveProviderConnection(db: DB) {
     const provider = PROVIDERS[conn.provider as keyof typeof PROVIDERS];
     baseUrl = provider?.defaultBaseUrl ?? "";
   }
-  if (!baseUrl && conn.provider === "claude_subscription") baseUrl = "claude-agent-sdk://local";
-  if (!baseUrl && conn.provider === "openai_chatgpt") baseUrl = "openai-chatgpt://codex-auth";
+  const localAuthBaseUrl = localAuthProviderBaseUrl(conn.provider);
+  if (!baseUrl && localAuthBaseUrl) baseUrl = localAuthBaseUrl;
   if (!baseUrl) fail(400, "The selected model connection has no base URL configured.");
 
   return { conn, baseUrl };

--- a/packages/shared/src/constants/model-lists.ts
+++ b/packages/shared/src/constants/model-lists.ts
@@ -386,6 +386,22 @@ export const XAI_MODELS: KnownModel[] = [
   { id: "grok-code-fast-1-0831", name: "Grok Code Fast 1 0831", context: 256000, maxOutput: 0 },
 ];
 
+// ── Grok CLI (Subscription via local Grok Build auth) ──
+// The CLI can list account-specific availability with `grok models`, but
+// Marinara keeps this curated fallback so the selector is usable before a
+// model fetch. Grok Build is first because the local CLI is explicitly the
+// Grok Build surface.
+export const GROK_SUBSCRIPTION_MODELS: KnownModel[] = [
+  { id: "grok-build-latest", name: "Grok Build Latest", context: 256000, maxOutput: 0 },
+  { id: "grok-build-0.1", name: "Grok Build 0.1", context: 256000, maxOutput: 0 },
+  { id: "grok-4.3", name: "Grok 4.3", context: 1000000, maxOutput: 0 },
+  { id: "grok-4.3-latest", name: "Grok 4.3 Latest", context: 1000000, maxOutput: 0 },
+  { id: "grok-latest", name: "Grok Latest", context: 1000000, maxOutput: 0 },
+  { id: "grok-fast-latest", name: "Grok Fast Latest", context: 2000000, maxOutput: 0 },
+  { id: "grok-4-fast-reasoning", name: "Grok 4 Fast Reasoning", context: 2000000, maxOutput: 0 },
+  { id: "grok-4-fast-non-reasoning", name: "Grok 4 Fast Non-Reasoning", context: 2000000, maxOutput: 0 },
+];
+
 // ── Additional providers with static lists in SillyTavern ──
 
 // Groq (from #model_groq_select)
@@ -768,6 +784,7 @@ export const MODEL_LISTS: Record<APIProvider, KnownModel[]> = {
   openai_chatgpt: OPENAI_CHATGPT_MODELS,
   anthropic: ANTHROPIC_MODELS,
   claude_subscription: CLAUDE_SUBSCRIPTION_MODELS,
+  grok_subscription: GROK_SUBSCRIPTION_MODELS,
   google: GOOGLE_MODELS,
   google_vertex: GOOGLE_MODELS,
   mistral: MISTRAL_MODELS,

--- a/packages/shared/src/constants/providers.ts
+++ b/packages/shared/src/constants/providers.ts
@@ -15,6 +15,25 @@ export interface ProviderDefinition {
   apiKeyHeader: string | null;
 }
 
+export const LOCAL_AUTH_PROVIDERS = ["openai_chatgpt", "claude_subscription", "grok_subscription"] as const;
+
+export function isLocalAuthProvider(provider: string | null | undefined): boolean {
+  return LOCAL_AUTH_PROVIDERS.includes(provider as (typeof LOCAL_AUTH_PROVIDERS)[number]);
+}
+
+export function localAuthProviderBaseUrl(provider: string | null | undefined): string | null {
+  switch (provider) {
+    case "claude_subscription":
+      return "claude-agent-sdk://local";
+    case "openai_chatgpt":
+      return "openai-chatgpt://codex-auth";
+    case "grok_subscription":
+      return "grok-cli://local";
+    default:
+      return null;
+  }
+}
+
 export const PROVIDERS: Record<APIProvider, ProviderDefinition> = {
   openai: {
     id: "openai",
@@ -54,6 +73,17 @@ export const PROVIDERS: Record<APIProvider, ProviderDefinition> = {
     defaultBaseUrl: "",
     modelsEndpoint: "",
     supportsStreaming: true,
+    usesAuthHeader: false,
+    apiKeyHeader: null,
+  },
+  grok_subscription: {
+    id: "grok_subscription",
+    name: "Grok CLI (Subscription)",
+    // No user-entered endpoint or API key. Marinara shells out to the local
+    // Grok Build CLI, which reads credentials from `grok login`.
+    defaultBaseUrl: "",
+    modelsEndpoint: "",
+    supportsStreaming: false,
     usesAuthHeader: false,
     apiKeyHeader: null,
   },

--- a/packages/shared/src/schemas/connection.schema.ts
+++ b/packages/shared/src/schemas/connection.schema.ts
@@ -8,6 +8,7 @@ export const apiProviderSchema = z.enum([
   "openai_chatgpt",
   "anthropic",
   "claude_subscription",
+  "grok_subscription",
   "google",
   "google_vertex",
   "mistral",

--- a/packages/shared/src/types/connection.ts
+++ b/packages/shared/src/types/connection.ts
@@ -8,6 +8,7 @@ export type APIProvider =
   | "openai_chatgpt"
   | "anthropic"
   | "claude_subscription"
+  | "grok_subscription"
   | "google"
   | "google_vertex"
   | "mistral"


### PR DESCRIPTION
## Summary
- Adds a Grok CLI (Subscription) chat provider so users can route requests through a local `grok` CLI login for SuperGrok / X Premium+ accounts.
- Hides API Key and Base URL fields for local-auth providers, including Claude Subscription, ChatGPT/Codex auth, and Grok CLI.
- Reuses local-auth base URL handling across generation, conversation, game, scene, translation, agent, memory, and Spotify DJ paths.
- Updates the v2.1.1 changelog.

## Rationale
Claude Subscription already exposes a subscription-style local provider. Grok CLI users need the same kind of setup: install the CLI, log in locally, then select the provider in Marinara without entering API credentials that are not used.

No linked issue; this is a maintainer-requested provider feature.

## Validation
- `pnpm check`
- `pnpm --filter @marinara-engine/server lint`
- `pnpm --filter @marinara-engine/client lint`

## Manual Verification Needed
- Manually verify a saved Grok CLI connection on a host with `grok` installed and `grok login` completed.
- Manually verify Claude Subscription and ChatGPT/Codex auth no longer show API Key/Base URL fields in the Connections editor.
