### PR TITLE
Fix Grok CLI model selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 - Fixed first-turn lorebook activation so opening chat messages remain keyword-scannable during the first user generation even when the recent-message scan window would otherwise drop earlier group greetings (#3332).
 - Fixed Text to Speech character voice assignment so users can add character voices using provider default voices, including ElevenLabs defaults, even before custom/account voices are loaded.
 - Added a per-chat Conversation Calls setting to disable generated bracketed voice cues for TTS providers that do not accept `[whispering]`, `[laughing]`, `[sighs]`, and similar tags.
+- Fixed Grok CLI (Subscription) connections so they no longer seed stale `grok-build-*` model aliases, can use the local CLI default model with a blank model field, and fetch selectable model IDs from `grok models`.
 
 ## [2.1.0]
 

--- a/packages/client/src/components/connections/ConnectionEditor.tsx
+++ b/packages/client/src/components/connections/ConnectionEditor.tsx
@@ -123,6 +123,7 @@ const DEFAULT_CACHING_AT_DEPTH = 5;
 const MAX_CACHING_AT_DEPTH = 100;
 const DEFAULT_MAX_PARALLEL_JOBS = 1;
 const MAX_PARALLEL_JOBS = 16;
+const STALE_GROK_CLI_MODEL_IDS = new Set(["grok-build-latest", "grok-build-0.1"]);
 const DEFAULT_VIDEO_MODELS: Record<VideoDefaultsService, string> = {
   gemini_omni: "gemini-omni-flash-preview",
   google_veo: "veo-3.1-generate-preview",
@@ -195,11 +196,7 @@ function normalizeEndpointUrlInput(raw: string, label: string): { value: string;
 }
 
 function canProviderTreatAsLocalEndpoint(provider: APIProvider): boolean {
-  return (
-    provider !== "image_generation" &&
-    provider !== "video_generation" &&
-    !isLocalAuthConnectionProvider(provider)
-  );
+  return provider !== "image_generation" && provider !== "video_generation" && !isLocalAuthConnectionProvider(provider);
 }
 
 function providerSupportsDirectEmbeddingConfig(provider: APIProvider): boolean {
@@ -209,6 +206,10 @@ function providerSupportsDirectEmbeddingConfig(provider: APIProvider): boolean {
     provider !== "anthropic" &&
     !isLocalAuthConnectionProvider(provider)
   );
+}
+
+function normalizeGrokCliEditorModel(provider: APIProvider, model: string): string {
+  return provider === "grok_subscription" && STALE_GROK_CLI_MODEL_IDS.has(model.trim()) ? "" : model;
 }
 
 function normalizeCachingAtDepth(value: unknown): number {
@@ -345,7 +346,7 @@ export function ConnectionEditor() {
     setLocalBaseUrl((c.baseUrl as string) ?? "");
     setLocalApiKey(""); // never pre-fill (it's masked)
     setClearStoredApiKeyOnSave(false);
-    setLocalModel((c.model as string) ?? "");
+    setLocalModel(normalizeGrokCliEditorModel((c.provider as APIProvider) ?? "openai", (c.model as string) ?? ""));
     setLocalMaxContext(Number(c.maxContext) || 128000);
     setLocalMaxParallelJobs(normalizeMaxParallelJobs(c.maxParallelJobs));
     setLocalEnableCaching(c.enableCaching === "true" || c.enableCaching === true);
@@ -607,12 +608,13 @@ export function ConnectionEditor() {
     const canTreatAsLocalEndpoint = canProviderTreatAsLocalEndpoint(localProvider);
     const existingEmbeddingModel = (conn as { embeddingModel?: string | null } | undefined)?.embeddingModel ?? "";
     const existingEmbeddingBaseUrl = (conn as { embeddingBaseUrl?: string | null } | undefined)?.embeddingBaseUrl ?? "";
+    const normalizedModel = normalizeGrokCliEditorModel(localProvider, localModel);
     const payload: Record<string, unknown> = {
       id: connectionDetailId,
       name: localName,
       provider: localProvider,
       baseUrl: isLocalAuthProvider ? "" : baseUrlValidation.value,
-      model: localModel,
+      model: normalizedModel,
       maxContext: localMaxContext,
       maxParallelJobs: localMaxParallelJobs,
       enableCaching: localEnableCaching,
@@ -679,6 +681,9 @@ export function ConnectionEditor() {
         setLocalBaseUrl("");
       } else if (baseUrlValidation.value !== localBaseUrl.trim()) {
         setLocalBaseUrl(baseUrlValidation.value);
+      }
+      if (normalizedModel !== localModel) {
+        setLocalModel(normalizedModel);
       }
       if (supportsDirectEmbeddings && embeddingBaseUrlValidation.value !== localEmbeddingBaseUrl.trim()) {
         setLocalEmbeddingBaseUrl(embeddingBaseUrlValidation.value);
@@ -792,7 +797,7 @@ export function ConnectionEditor() {
       name: localName,
       provider: localProvider,
       baseUrl: isLocalAuthProvider ? "" : localBaseUrl,
-      model: localModel,
+      model: normalizeGrokCliEditorModel(localProvider, localModel),
       maxContext: localMaxContext,
       maxTokensOverride: localMaxTokensOverride ?? null,
       maxParallelJobs: localMaxParallelJobs,
@@ -1071,6 +1076,10 @@ export function ConnectionEditor() {
   const isLocalAuthProvider = isLocalAuthConnectionProvider(localProvider);
   const supportsDirectEmbeddingConfig = providerSupportsDirectEmbeddingConfig(localProvider);
   const canTreatAsLocalEndpoint = canProviderTreatAsLocalEndpoint(localProvider);
+  const modelFetchSourceLabel = isGrokSubscriptionProvider ? "Grok CLI" : "API";
+  const modelFetchButtonLabel = isGrokSubscriptionProvider ? "Fetch Models from Grok CLI" : "Fetch Models from API";
+  const emptyModelLabel = isGrokSubscriptionProvider ? "Use Grok CLI default model" : "Select a model…";
+  const canSendTestMessage = isGrokSubscriptionProvider || Boolean(localModel.trim());
 
   if (!connectionDetailId) return null;
 
@@ -1231,14 +1240,12 @@ export function ConnectionEditor() {
                     setLocalProvider(key);
                     // Auto-fill base URL
                     setLocalBaseUrl(info.defaultBaseUrl);
-                    // Seed known Grok selectors; leave other providers blank
-                    // so users deliberately pick their preferred model.
+                    // Leave Grok CLI blank so the local CLI can use its
+                    // account/default model until the user fetches
+                    // `grok models`. Other providers keep their usual seeded
+                    // default model when we know one.
                     setLocalModel(
-                      key === "xai"
-                        ? (defaultModel?.id ?? "grok-4.3")
-                        : key === "grok_subscription"
-                          ? (defaultModel?.id ?? "grok-build-latest")
-                          : "",
+                      key === "grok_subscription" ? "" : (defaultModel?.id ?? (key === "xai" ? "grok-4.3" : "")),
                     );
                     setLocalMaxContext(Number(defaultModel?.context) || 128000);
                     setLocalMaxTokensOverride(null);
@@ -1471,9 +1478,9 @@ export function ConnectionEditor() {
                 {localProvider === "custom" && (
                   <p className="mt-1.5 text-[0.625rem] text-[var(--muted-foreground)]">
                     Local model examples: Ollama →{" "}
-                    <code className="rounded bg-[var(--secondary)] px-1">http://localhost:11434/v1</code> · LM Studio
-                    → <code className="rounded bg-[var(--secondary)] px-1">http://localhost:1234/v1</code> · KoboldCpp
-                    → <code className="rounded bg-[var(--secondary)] px-1">http://localhost:5001/v1</code>
+                    <code className="rounded bg-[var(--secondary)] px-1">http://localhost:11434/v1</code> · LM Studio →{" "}
+                    <code className="rounded bg-[var(--secondary)] px-1">http://localhost:1234/v1</code> · KoboldCpp →{" "}
+                    <code className="rounded bg-[var(--secondary)] px-1">http://localhost:5001/v1</code>
                   </p>
                 )}
                 <p className="mt-1.5 flex items-start gap-1 text-[0.625rem] text-amber-400/80">
@@ -1645,7 +1652,7 @@ export function ConnectionEditor() {
                       ? selectedModelInfo
                         ? `${selectedModelInfo.name} (${selectedModelInfo.id})`
                         : localModel
-                      : "Select a model…"}
+                      : emptyModelLabel}
                   </span>
                 )}
                 <ChevronDown
@@ -1674,12 +1681,13 @@ export function ConnectionEditor() {
                       ) : (
                         <Globe size="0.75rem" />
                       )}
-                      {fetchModels.isPending ? "Fetching…" : "Fetch Models from API"}
+                      {fetchModels.isPending ? "Fetching…" : modelFetchButtonLabel}
                     </button>
                     {fetchError && <p className="mt-1.5 text-[0.625rem] text-[var(--destructive)]">{fetchError}</p>}
                     {remoteModels.length > 0 && !fetchError && (
                       <p className="mt-1 text-[0.625rem] text-emerald-400">
-                        {remoteModels.length} model{remoteModels.length !== 1 ? "s" : ""} available from API
+                        {remoteModels.length} model{remoteModels.length !== 1 ? "s" : ""} available from{" "}
+                        {modelFetchSourceLabel}
                       </p>
                     )}
                   </div>
@@ -1721,7 +1729,7 @@ export function ConnectionEditor() {
                                   <span className="text-[0.625rem] text-[var(--muted-foreground)]">{m.id}</span>
                                 </div>
                                 <span className="shrink-0 rounded-md bg-sky-400/10 px-1.5 py-0.5 text-[0.5625rem] font-medium text-sky-400">
-                                  API
+                                  {modelFetchSourceLabel}
                                 </span>
                               </button>
                             ))}
@@ -1762,7 +1770,7 @@ export function ConnectionEditor() {
                             <span className="text-sm font-medium">{m.name}</span>
                             {m.isRemote && (
                               <span className="rounded-md bg-sky-400/10 px-1.5 py-0.5 text-[0.5625rem] font-medium text-sky-400">
-                                API
+                                {modelFetchSourceLabel}
                               </span>
                             )}
                             {localModel === m.id && <Check size="0.75rem" className="text-sky-400" />}
@@ -1795,7 +1803,11 @@ export function ConnectionEditor() {
                     handleManualModelChange(e.target.value);
                   }}
                   className="flex-1 rounded-lg bg-[var(--secondary)] px-3 py-2 text-xs ring-1 ring-[var(--border)] focus:outline-none focus:ring-[var(--ring)]"
-                  placeholder="Or type model ID directly…"
+                  placeholder={
+                    isGrokSubscriptionProvider
+                      ? "Optional: type a Grok CLI model ID, or leave blank for CLI default"
+                      : "Or type model ID directly…"
+                  }
                 />
               </div>
             )}
@@ -2457,7 +2469,7 @@ export function ConnectionEditor() {
               {!isMediaGenerationProvider && (
                 <button
                   onClick={handleTestMessage}
-                  disabled={testMessage.isPending || !localModel}
+                  disabled={testMessage.isPending || !canSendTestMessage}
                   className="flex items-center gap-1.5 rounded-xl bg-emerald-400/10 px-4 py-2.5 text-xs font-medium text-emerald-400 ring-1 ring-emerald-400/20 transition-all hover:bg-emerald-400/20 active:scale-[0.98] disabled:opacity-50"
                 >
                   {testMessage.isPending ? (

--- a/packages/server/src/routes/connections.routes.ts
+++ b/packages/server/src/routes/connections.routes.ts
@@ -22,6 +22,7 @@ import { createConnectionsStorage } from "../services/storage/connections.storag
 import { resetMemoryRecallVectorizerCache } from "../services/memory-recall-embedding.js";
 import { createLLMProvider } from "../services/llm/provider-registry.js";
 import { fetchOpenAIChatGPTModels, getOpenAIChatGPTAuth } from "../services/llm/openai-chatgpt-auth.js";
+import { fetchGrokCliModels } from "../services/llm/providers/grok-subscription.provider.js";
 import { buildGoogleVertexModelUrl, googleAuthHeadersForVertex } from "../services/llm/providers/google.provider.js";
 import { resolveConnectionImageDefaults } from "../services/image/image-generation-defaults.js";
 import { isImageLocalUrlsEnabled, isProviderLocalUrlsEnabled } from "../config/runtime-config.js";
@@ -440,14 +441,6 @@ export async function connectionsRoutes(app: FastifyInstance) {
       }
 
       if (conn.provider === "grok_subscription") {
-        if (!conn.model) {
-          return {
-            success: false,
-            message: "No model configured. Set a Grok CLI model first.",
-            latencyMs: Date.now() - start,
-            modelName: null,
-          };
-        }
         const provider = createLLMProvider(
           conn.provider,
           // Grok CLI subscription auth is local-only: the CLI reads the
@@ -461,7 +454,7 @@ export async function connectionsRoutes(app: FastifyInstance) {
         );
         let responseText = "";
         for await (const chunk of provider.chat([{ role: "user", content: "Reply with OK." }], {
-          model: conn.model,
+          model: conn.model ?? "",
           maxTokens: 32,
           stream: false,
         })) {
@@ -471,7 +464,7 @@ export async function connectionsRoutes(app: FastifyInstance) {
           success: true,
           message: `Grok CLI completed a real request: ${responseText.trim().slice(0, 120) || "OK"}`,
           latencyMs: Date.now() - start,
-          modelName: conn.model,
+          modelName: conn.model || "Grok CLI default",
         };
       }
 
@@ -615,7 +608,8 @@ export async function connectionsRoutes(app: FastifyInstance) {
       }
 
       if (conn.provider === "grok_subscription") {
-        return { models: MODEL_LISTS.grok_subscription.map((m) => ({ id: m.id, name: m.name })) };
+        const models = await fetchGrokCliModels();
+        return { models };
       }
 
       if (conn.provider === "video_generation") {
@@ -979,11 +973,11 @@ export async function connectionsRoutes(app: FastifyInstance) {
         ? DEFAULT_XAI_VIDEO_BASE_URL
         : isGoogleVeoVideo
           ? DEFAULT_GOOGLE_VEO_VIDEO_BASE_URL
-        : isOpenRouterVideo
-          ? DEFAULT_OPENROUTER_VIDEO_BASE_URL
-        : isSeedanceVideo
-          ? DEFAULT_SEEDANCE_VIDEO_BASE_URL
-          : providerDef?.defaultBaseUrl || DEFAULT_GEMINI_OMNI_VIDEO_BASE_URL)
+          : isOpenRouterVideo
+            ? DEFAULT_OPENROUTER_VIDEO_BASE_URL
+            : isSeedanceVideo
+              ? DEFAULT_SEEDANCE_VIDEO_BASE_URL
+              : providerDef?.defaultBaseUrl || DEFAULT_GEMINI_OMNI_VIDEO_BASE_URL)
     ).replace(/\/+$/, "");
     const videoModel =
       conn.model ||
@@ -991,20 +985,20 @@ export async function connectionsRoutes(app: FastifyInstance) {
         ? DEFAULT_XAI_VIDEO_MODEL
         : isGoogleVeoVideo
           ? DEFAULT_GOOGLE_VEO_VIDEO_MODEL
-        : isOpenRouterVideo
-          ? DEFAULT_OPENROUTER_VIDEO_MODEL
-        : isSeedanceVideo
-          ? DEFAULT_SEEDANCE_VIDEO_MODEL
-          : DEFAULT_GEMINI_OMNI_VIDEO_MODEL);
+          : isOpenRouterVideo
+            ? DEFAULT_OPENROUTER_VIDEO_MODEL
+            : isSeedanceVideo
+              ? DEFAULT_SEEDANCE_VIDEO_MODEL
+              : DEFAULT_GEMINI_OMNI_VIDEO_MODEL);
     const activeDefaults = isXaiVideo
       ? defaults.xai
       : isGoogleVeoVideo
         ? defaults.googleVeo
         : isOpenRouterVideo
           ? defaults.openrouter
-        : isSeedanceVideo
-          ? defaults.seedance
-          : defaults.geminiOmni;
+          : isSeedanceVideo
+            ? defaults.seedance
+            : defaults.geminiOmni;
 
     const prompt =
       "Create a concise cinematic 16:9 game scene video: a plate of spaghetti with marinara sauce on a table, gentle steam rising, warm kitchen light, slow push-in camera, no text or logos.";
@@ -1021,11 +1015,11 @@ export async function connectionsRoutes(app: FastifyInstance) {
           ? defaults.xai.resolution
           : isGoogleVeoVideo
             ? defaults.googleVeo.resolution
-          : isOpenRouterVideo
-            ? defaults.openrouter.resolution
-          : isSeedanceVideo
-            ? defaults.seedance.resolution
-            : undefined,
+            : isOpenRouterVideo
+              ? defaults.openrouter.resolution
+              : isSeedanceVideo
+                ? defaults.seedance.resolution
+                : undefined,
       });
       return {
         success: true,
@@ -1146,7 +1140,7 @@ export async function connectionsRoutes(app: FastifyInstance) {
       return reply.status(400).send({ error: "This provider does not support chat test messages." });
     }
 
-    if (!conn.model) {
+    if (!conn.model && conn.provider !== "grok_subscription") {
       return reply.status(400).send({ error: "No model configured. Set a model first." });
     }
 
@@ -1163,9 +1157,10 @@ export async function connectionsRoutes(app: FastifyInstance) {
     const start = Date.now();
     const requestDebug = readDebugMode(req.body);
     const debugLog = (message: string, ...args: any[]) => logDebugOverride(requestDebug, message, ...args);
-    const targetUrl = describeTestMessageTarget(conn.provider, baseUrl, conn.model);
+    const model = conn.model ?? "";
+    const targetUrl = describeTestMessageTarget(conn.provider, baseUrl, model);
     try {
-      debugLog("[connections/test-message] provider=%s model=%s url=%s", conn.provider, conn.model, targetUrl);
+      debugLog("[connections/test-message] provider=%s model=%s url=%s", conn.provider, model, targetUrl);
       const provider = createLLMProvider(
         conn.provider,
         localAuthProviderBaseUrl(conn.provider) ?? baseUrl,
@@ -1178,7 +1173,7 @@ export async function connectionsRoutes(app: FastifyInstance) {
 
       let fullResponse = "";
       for await (const chunk of provider.chat([{ role: "user", content: "hi" }], {
-        model: conn.model,
+        model,
         temperature: 0.7,
         maxTokens: 200,
         stream: false,
@@ -1197,13 +1192,13 @@ export async function connectionsRoutes(app: FastifyInstance) {
         success: true,
         response: fullResponse.slice(0, 500),
         latencyMs,
-        model: conn.model,
+        model: model || "Grok CLI default",
       };
     } catch (err) {
       debugLog(
         "[connections/test-message] provider=%s model=%s url=%s failed: %s",
         conn.provider,
-        conn.model,
+        model,
         targetUrl,
         err instanceof Error ? err.message : "Unknown error",
       );
@@ -1212,7 +1207,7 @@ export async function connectionsRoutes(app: FastifyInstance) {
         response: "",
         latencyMs: Date.now() - start,
         error: err instanceof Error ? err.message : "Unknown error",
-        model: conn.model,
+        model: model || "Grok CLI default",
       };
     }
   });

--- a/packages/server/src/services/llm/providers/grok-subscription.provider.ts
+++ b/packages/server/src/services/llm/providers/grok-subscription.provider.ts
@@ -16,8 +16,33 @@ import { DATA_DIR } from "../../../utils/data-dir.js";
 
 const GROK_SCRATCH_DIR = join(DATA_DIR, "grok-cli");
 const GROK_ERROR_PREVIEW_CHARS = 2000;
+const GROK_MODELS_TIMEOUT_MS = 30 * 1000;
 const GROK_REQUEST_TIMEOUT_MS = 10 * 60 * 1000;
 const GROK_TOKENS_PER_CHAR = 4;
+const STALE_GROK_CLI_MODEL_IDS = new Set(["grok-build-latest", "grok-build-0.1"]);
+
+export interface GrokCliModel {
+  id: string;
+  name: string;
+}
+
+interface GrokCliCommandResult {
+  code: number | null;
+  signal: NodeJS.Signals | null;
+  stdout: string;
+  stderr: string;
+}
+
+class GrokCliCommandError extends Error {
+  constructor(
+    message: string,
+    readonly stdout: string,
+    readonly stderr: string,
+    readonly code: number | null,
+  ) {
+    super(message);
+  }
+}
 
 function estimateTokens(text: string): number {
   return Math.ceil(Array.from(text).length / GROK_TOKENS_PER_CHAR);
@@ -25,6 +50,74 @@ function estimateTokens(text: string): number {
 
 function stripAnsi(value: string): string {
   return value.replace(/\x1B(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])/g, "");
+}
+
+function normalizeGrokCliModelForFlag(model: string): string {
+  const trimmed = model.trim();
+  return STALE_GROK_CLI_MODEL_IDS.has(trimmed) ? "" : trimmed;
+}
+
+function titleCaseModelId(id: string): string {
+  return id
+    .split(/[-_:/.]+/)
+    .filter(Boolean)
+    .map((part) => (/^\d+$/.test(part) ? part : part.charAt(0).toUpperCase() + part.slice(1)))
+    .join(" ");
+}
+
+function normalizeModelToken(value: string): string | null {
+  const token = value
+    .trim()
+    .replace(/^["'`([{<]+/, "")
+    .replace(/[)"'`,\]}>:;]+$/, "");
+  return /^grok[a-z0-9._:/-]*$/i.test(token) ? token : null;
+}
+
+function parseGrokCliModelsOutput(output: string): GrokCliModel[] {
+  const models: GrokCliModel[] = [];
+  const seen = new Set<string>();
+  const addModel = (id: string, label?: string) => {
+    if (seen.has(id)) return;
+    seen.add(id);
+    const name = label?.trim() && !/^grok[a-z0-9._:/-]*$/i.test(label.trim()) ? label.trim() : titleCaseModelId(id);
+    models.push({ id, name });
+  };
+
+  for (const rawLine of stripAnsi(output).split(/\r?\n/)) {
+    const line = rawLine.trim();
+    if (!line || /^[-|+\s]+$/.test(line) || /^(available\s+)?models?$/i.test(line)) continue;
+
+    if (line.includes("|")) {
+      const cells = line
+        .split("|")
+        .map((cell) => cell.trim())
+        .filter(Boolean);
+      const modelCellIndex = cells.findIndex((cell) => normalizeModelToken(cell));
+      if (modelCellIndex >= 0) {
+        const modelCell = cells[modelCellIndex];
+        const id = modelCell ? normalizeModelToken(modelCell) : null;
+        if (id) addModel(id, cells.filter((_, index) => index !== modelCellIndex).join(" "));
+      }
+      continue;
+    }
+
+    const tokens = line.split(/\s+/);
+    const tokenIndex = tokens.findIndex((token) => normalizeModelToken(token));
+    if (tokenIndex < 0) continue;
+
+    const token = tokens[tokenIndex];
+    if (!token) continue;
+    const id = normalizeModelToken(token);
+    if (!id) continue;
+    const label = line
+      .slice(line.indexOf(token) + token.length)
+      .replace(/^\s*[-–—:]\s*/, "")
+      .replace(/\s*\(.*?\)\s*/g, " ")
+      .trim();
+    addModel(id, label);
+  }
+
+  return models;
 }
 
 function roleLabel(role: ChatMessage["role"]): string {
@@ -42,9 +135,12 @@ function roleLabel(role: ChatMessage["role"]): string {
 
 function attachmentNotice(message: ChatMessage): string {
   const notices: string[] = [];
-  if (message.images?.length) notices.push(`[${message.images.length} image attachment(s) omitted: Grok CLI provider is text-only.]`);
-  if (message.files?.length) notices.push(`[${message.files.length} file attachment(s) omitted: Grok CLI provider is text-only.]`);
-  if (message.media?.length) notices.push(`[${message.media.length} media attachment(s) omitted: Grok CLI provider is text-only.]`);
+  if (message.images?.length)
+    notices.push(`[${message.images.length} image attachment(s) omitted: Grok CLI provider is text-only.]`);
+  if (message.files?.length)
+    notices.push(`[${message.files.length} file attachment(s) omitted: Grok CLI provider is text-only.]`);
+  if (message.media?.length)
+    notices.push(`[${message.media.length} media attachment(s) omitted: Grok CLI provider is text-only.]`);
   return notices.length ? `\n${notices.join("\n")}` : "";
 }
 
@@ -70,6 +166,111 @@ function compactGrokError(stderr: string, stdout: string, fallback: string): str
   return (combined || fallback).replace(/\s+/g, " ").slice(0, GROK_ERROR_PREVIEW_CHARS);
 }
 
+function grokInstallHint(): string {
+  return "Confirm `grok` is installed and `grok login` was run by the same OS user/HOME as the Marinara server.";
+}
+
+async function runGrokCliCommand(
+  args: string[],
+  options: { timeoutMs: number; signal?: AbortSignal; timeoutLabel: string },
+): Promise<GrokCliCommandResult> {
+  await mkdir(GROK_SCRATCH_DIR, { recursive: true });
+
+  const child = spawn("grok", args, {
+    cwd: GROK_SCRATCH_DIR,
+    env: { ...process.env },
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+
+  let stdout = "";
+  let stderr = "";
+  let aborted = false;
+  let timedOut = false;
+  let requestTimer: NodeJS.Timeout | null = null;
+  let killTimer: NodeJS.Timeout | null = null;
+
+  child.stdout?.on("data", (chunk: Buffer) => {
+    stdout += chunk.toString("utf8");
+  });
+  child.stderr?.on("data", (chunk: Buffer) => {
+    stderr += chunk.toString("utf8");
+  });
+
+  const terminateChild = () => {
+    child.kill("SIGTERM");
+    if (killTimer) return;
+    killTimer = setTimeout(() => child.kill("SIGKILL"), 2_000);
+    killTimer.unref?.();
+  };
+  const onAbort = () => {
+    aborted = true;
+    terminateChild();
+  };
+
+  requestTimer = setTimeout(() => {
+    timedOut = true;
+    terminateChild();
+  }, options.timeoutMs);
+  requestTimer.unref?.();
+
+  if (options.signal) {
+    if (options.signal.aborted) onAbort();
+    else options.signal.addEventListener("abort", onAbort, { once: true });
+  }
+
+  try {
+    const result = await new Promise<{ code: number | null; signal: NodeJS.Signals | null }>((resolve, reject) => {
+      child.once("error", reject);
+      child.once("close", (code, signal) => resolve({ code, signal }));
+    });
+
+    if (timedOut) {
+      throw new GrokCliCommandError(
+        `Grok CLI ${options.timeoutLabel} timed out after ${Math.round(options.timeoutMs / 1000)}s.`,
+        stdout,
+        stderr,
+        result.code,
+      );
+    }
+    if (aborted || options.signal?.aborted) {
+      throw new GrokCliCommandError(`Grok CLI ${options.timeoutLabel} was aborted.`, stdout, stderr, result.code);
+    }
+    return { ...result, stdout, stderr };
+  } catch (err) {
+    if (err instanceof Error && /ENOENT/.test(err.message)) {
+      throw new Error(
+        "Grok CLI is not installed or not on PATH. Install it with `curl -fsSL https://x.ai/cli/install.sh | bash`, then run `grok login` as the same OS user that starts Marinara.",
+      );
+    }
+    throw err;
+  } finally {
+    if (requestTimer) clearTimeout(requestTimer);
+    if (killTimer) clearTimeout(killTimer);
+    if (options.signal) options.signal.removeEventListener("abort", onAbort);
+  }
+}
+
+export async function fetchGrokCliModels(): Promise<GrokCliModel[]> {
+  const result = await runGrokCliCommand(["models"], {
+    timeoutMs: GROK_MODELS_TIMEOUT_MS,
+    timeoutLabel: "models lookup",
+  });
+  if (result.code !== 0) {
+    const detail = compactGrokError(
+      result.stderr,
+      result.stdout,
+      `grok models exited with code ${result.code ?? "unknown"}`,
+    );
+    throw new Error(`Failed to fetch Grok CLI models: ${detail}. ${grokInstallHint()}`);
+  }
+
+  const models = parseGrokCliModelsOutput([result.stdout, result.stderr].filter((part) => part.trim()).join("\n"));
+  if (!models.length) {
+    throw new Error("Grok CLI did not return any model IDs. Run `grok models` in a terminal to inspect the output.");
+  }
+  return models;
+}
+
 export class GrokSubscriptionProvider extends BaseLLMProvider {
   async *chat(messages: ChatMessage[], options: ChatOptions): AsyncGenerator<string, LLMUsage | void, unknown> {
     const configuredMaxTokens = this.applyMaxTokensCap(options.maxTokens ?? 4096);
@@ -82,7 +283,7 @@ export class GrokSubscriptionProvider extends BaseLLMProvider {
     this.logContextTrim(contextFit, options.model);
 
     const prompt = buildGrokPrompt(contextFit.messages);
-    await mkdir(GROK_SCRATCH_DIR, { recursive: true });
+    const cliModel = normalizeGrokCliModelForFlag(options.model);
 
     const debugOverrideEnabled = options.debugMode === true || isDebugAgentsEnabled();
     const args = [
@@ -102,73 +303,41 @@ export class GrokSubscriptionProvider extends BaseLLMProvider {
       "--cwd",
       GROK_SCRATCH_DIR,
     ];
-    if (options.model.trim()) args.push("-m", options.model.trim());
+    if (cliModel) args.push("-m", cliModel);
 
-    logger.debug("[grok-subscription] running grok CLI model=%s promptChars=%d", options.model, prompt.length);
+    logger.debug(
+      "[grok-subscription] running grok CLI model=%s promptChars=%d",
+      cliModel || "(cli default)",
+      prompt.length,
+    );
     logDebugOverride(debugOverrideEnabled, "[debug/grok-subscription] final prompt:\n%s", prompt);
 
-    const child = spawn("grok", args, {
-      cwd: GROK_SCRATCH_DIR,
-      env: { ...process.env },
-      stdio: ["ignore", "pipe", "pipe"],
-    });
-
-    let stdout = "";
-    let stderr = "";
-    let aborted = false;
-    let timedOut = false;
-    let requestTimer: NodeJS.Timeout | null = null;
-    let killTimer: NodeJS.Timeout | null = null;
-
-    child.stdout?.on("data", (chunk: Buffer) => {
-      stdout += chunk.toString("utf8");
-    });
-    child.stderr?.on("data", (chunk: Buffer) => {
-      stderr += chunk.toString("utf8");
-    });
-
-    const terminateChild = () => {
-      child.kill("SIGTERM");
-      if (killTimer) return;
-      killTimer = setTimeout(() => child.kill("SIGKILL"), 2_000);
-      killTimer.unref?.();
-    };
-    const onAbort = () => {
-      aborted = true;
-      terminateChild();
-    };
-    requestTimer = setTimeout(() => {
-      timedOut = true;
-      terminateChild();
-    }, GROK_REQUEST_TIMEOUT_MS);
-    requestTimer.unref?.();
-    if (options.signal) {
-      if (options.signal.aborted) onAbort();
-      else options.signal.addEventListener("abort", onAbort, { once: true });
-    }
-
     try {
-      const result = await new Promise<{ code: number | null; signal: NodeJS.Signals | null }>((resolve, reject) => {
-        child.once("error", reject);
-        child.once("close", (code, signal) => resolve({ code, signal }));
+      const result = await runGrokCliCommand(args, {
+        timeoutMs: GROK_REQUEST_TIMEOUT_MS,
+        signal: options.signal,
+        timeoutLabel: "request",
       });
 
-      if (timedOut) {
-        throw new Error(`Grok CLI request timed out after ${Math.round(GROK_REQUEST_TIMEOUT_MS / 1000)}s.`);
-      }
-      if (aborted || options.signal?.aborted) {
-        throw new Error("Grok CLI request was aborted.");
-      }
       if (result.code !== 0) {
-        const detail = compactGrokError(stderr, stdout, `grok exited with code ${result.code ?? "unknown"}`);
+        const detail = compactGrokError(
+          result.stderr,
+          result.stdout,
+          `grok exited with code ${result.code ?? "unknown"}`,
+        );
+        if (cliModel && /unknown model id|couldn'?t set model|run `?grok models`?/i.test(detail)) {
+          throw new Error(
+            `Selected Grok CLI model "${cliModel}" is not available to this local CLI login. Click "Fetch Models from Grok CLI" and pick one of those IDs, or clear the model field to use the CLI default. Details: ${detail}`,
+          );
+        }
         throw new Error(
-          `Grok CLI request failed: ${detail}. Confirm \`grok\` is installed and \`grok login\` was run by the same OS user/HOME as the Marinara server. HOME=${process.env.HOME ?? "unset"}.`,
+          `Grok CLI request failed: ${detail}. ${grokInstallHint()} HOME=${process.env.HOME ?? "unset"}.`,
         );
       }
 
-      const text = stripAnsi(stdout).trim();
+      const text = stripAnsi(result.stdout).trim();
       if (!text) {
-        const detail = compactGrokError(stderr, stdout, "empty response");
+        const detail = compactGrokError(result.stderr, result.stdout, "empty response");
         throw new Error(`Grok CLI returned no content (${detail}).`);
       }
 
@@ -182,17 +351,8 @@ export class GrokSubscriptionProvider extends BaseLLMProvider {
         finishReason: "stop",
       };
     } catch (err) {
-      logger.error(err, "Grok CLI request failed for model %s", options.model);
-      if (err instanceof Error && /ENOENT/.test(err.message)) {
-        throw new Error(
-          "Grok CLI is not installed or not on PATH. Install it with `curl -fsSL https://x.ai/cli/install.sh | bash`, then run `grok login` as the same OS user that starts Marinara.",
-        );
-      }
+      logger.error(err, "Grok CLI request failed for model %s", cliModel || "(cli default)");
       throw err;
-    } finally {
-      if (requestTimer) clearTimeout(requestTimer);
-      if (killTimer) clearTimeout(killTimer);
-      if (options.signal) options.signal.removeEventListener("abort", onAbort);
     }
   }
 

--- a/packages/shared/src/constants/model-lists.ts
+++ b/packages/shared/src/constants/model-lists.ts
@@ -387,20 +387,10 @@ export const XAI_MODELS: KnownModel[] = [
 ];
 
 // ── Grok CLI (Subscription via local Grok Build auth) ──
-// The CLI can list account-specific availability with `grok models`, but
-// Marinara keeps this curated fallback so the selector is usable before a
-// model fetch. Grok Build is first because the local CLI is explicitly the
-// Grok Build surface.
-export const GROK_SUBSCRIPTION_MODELS: KnownModel[] = [
-  { id: "grok-build-latest", name: "Grok Build Latest", context: 256000, maxOutput: 0 },
-  { id: "grok-build-0.1", name: "Grok Build 0.1", context: 256000, maxOutput: 0 },
-  { id: "grok-4.3", name: "Grok 4.3", context: 1000000, maxOutput: 0 },
-  { id: "grok-4.3-latest", name: "Grok 4.3 Latest", context: 1000000, maxOutput: 0 },
-  { id: "grok-latest", name: "Grok Latest", context: 1000000, maxOutput: 0 },
-  { id: "grok-fast-latest", name: "Grok Fast Latest", context: 2000000, maxOutput: 0 },
-  { id: "grok-4-fast-reasoning", name: "Grok 4 Fast Reasoning", context: 2000000, maxOutput: 0 },
-  { id: "grok-4-fast-non-reasoning", name: "Grok 4 Fast Non-Reasoning", context: 2000000, maxOutput: 0 },
-];
+// Account-tier availability is discovered from the installed CLI with
+// `grok models`. Keep this empty so Marinara does not hand the CLI stale API
+// aliases such as `grok-build-latest` that some Grok CLI installs reject.
+export const GROK_SUBSCRIPTION_MODELS: KnownModel[] = [];
 
 // ── Additional providers with static lists in SillyTavern ──
 


### PR DESCRIPTION
## Summary

Fix Grok CLI (Subscription) connections so Marinara no longer seeds or sends stale `grok-build-*` aliases that local Grok CLI installs can reject. The connection can now leave the model blank to use the CLI default, and model fetching calls `grok models` so users select IDs their local CLI actually supports.

## Why

A user reported that the connection fetched models but test requests failed with `unknown model id` for `grok-build-latest`. That alias came from Marinara's static fallback list, not from the installed CLI account/model surface.

## Changes

- Remove the static Grok CLI model fallback list so stale aliases are not seeded.
- Normalize older saved `grok-build-*` aliases to a blank model field.
- Fetch Grok CLI models through `grok models`.
- Allow Grok CLI connection tests/test messages to run with a blank model and use the local CLI default.
- Improve the unavailable-model error with a direct fetch/clear-model recovery path.
- Update the v2.1.1 changelog.

## Validation

- `pnpm check`
- `git diff --check`

## Manual Verification Needed

- Verify on a machine with `grok` installed and authenticated that “Fetch Models from Grok CLI” returns selectable IDs.
- Verify a blank Grok CLI model field sends a test request using the local CLI default.
- Verify selecting a fetched model sends a test request with that exact ID.

## Notes

Live Grok CLI execution was not available on this machine because `grok` is not installed locally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Grok CLI subscriptions now detect available models automatically and support testing with the local default model when no model is selected.
* **Bug Fixes**
  * Fixed Grok CLI connections from showing or saving outdated model aliases.
  * Improved connection saving and export so blank or invalid Grok model values are handled correctly.
  * Test requests now work for Grok CLI subscriptions even when no model is configured.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->