### PR TITLE
Fix Grok CLI roleplay context handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 - Fixed Text to Speech character voice assignment so users can add character voices using provider default voices, including ElevenLabs defaults, even before custom/account voices are loaded.
 - Added a per-chat Conversation Calls setting to disable generated bracketed voice cues for TTS providers that do not accept `[whispering]`, `[laughing]`, `[sighs]`, and similar tags.
 - Fixed Grok CLI (Subscription) connections so they no longer seed stale `grok-build-*` model aliases, can use the local CLI default model with a blank model field, and fetch selectable model IDs from `grok models`.
+- Fixed Grok CLI (Subscription) roleplay requests by preferring the safe headless Composer model when discovered, starting Grok CLI connections with a safer 32k context window, and surfacing a clearer context-limit hint when the CLI reports `max turns reached`.
 - Added Lorebook entry-status sorting, fixed continued assistant messages so appended text starts after a blank line, and removed the obsolete tracked `pr-evidence/` artifacts while ignoring future evidence folders (#3336).
 
 ## [2.1.0]

--- a/packages/client/src/components/connections/ConnectionEditor.tsx
+++ b/packages/client/src/components/connections/ConnectionEditor.tsx
@@ -124,7 +124,6 @@ const MAX_CACHING_AT_DEPTH = 100;
 const DEFAULT_MAX_PARALLEL_JOBS = 1;
 const MAX_PARALLEL_JOBS = 16;
 const GROK_CLI_DEFAULT_CONTEXT_TOKENS = 32_000;
-const GROK_CLI_UNSAFE_INHERITED_CONTEXT_TOKENS = 128_000;
 const STALE_GROK_CLI_MODEL_IDS = new Set(["grok-build-latest", "grok-build-0.1"]);
 const DEFAULT_VIDEO_MODELS: Record<VideoDefaultsService, string> = {
   gemini_omni: "gemini-omni-flash-preview",
@@ -216,11 +215,7 @@ function normalizeGrokCliEditorModel(provider: APIProvider, model: string): stri
 
 function normalizeConnectionMaxContext(provider: APIProvider, value: unknown): number {
   const numericValue = typeof value === "number" && Number.isFinite(value) ? Math.floor(value) : 0;
-  if (provider === "grok_subscription") {
-    return numericValue > 0 && numericValue < GROK_CLI_UNSAFE_INHERITED_CONTEXT_TOKENS
-      ? numericValue
-      : GROK_CLI_DEFAULT_CONTEXT_TOKENS;
-  }
+  if (provider === "grok_subscription") return numericValue > 0 ? numericValue : GROK_CLI_DEFAULT_CONTEXT_TOKENS;
   return numericValue || 128000;
 }
 
@@ -1996,7 +1991,7 @@ export function ConnectionEditor() {
               </div>
               <p className="mt-1 text-[0.625rem] text-[var(--muted-foreground)]">
                 {isGrokSubscriptionProvider
-                  ? "Grok CLI starts at a safer 32k window because very large roleplay prompts can make the local CLI hit its own turn limit. Raise it only if your local login handles larger prompts."
+                  ? "Grok CLI starts at a safer 32k window because very large roleplay prompts can make the local CLI hit its own turn limit. Larger saved values are kept in settings, but requests are capped conservatively."
                   : "This is auto-set when selecting a model from the list. Override manually if needed."}
               </p>
             </FieldGroup>

--- a/packages/client/src/components/connections/ConnectionEditor.tsx
+++ b/packages/client/src/components/connections/ConnectionEditor.tsx
@@ -123,6 +123,8 @@ const DEFAULT_CACHING_AT_DEPTH = 5;
 const MAX_CACHING_AT_DEPTH = 100;
 const DEFAULT_MAX_PARALLEL_JOBS = 1;
 const MAX_PARALLEL_JOBS = 16;
+const GROK_CLI_DEFAULT_CONTEXT_TOKENS = 32_000;
+const GROK_CLI_UNSAFE_INHERITED_CONTEXT_TOKENS = 128_000;
 const STALE_GROK_CLI_MODEL_IDS = new Set(["grok-build-latest", "grok-build-0.1"]);
 const DEFAULT_VIDEO_MODELS: Record<VideoDefaultsService, string> = {
   gemini_omni: "gemini-omni-flash-preview",
@@ -210,6 +212,16 @@ function providerSupportsDirectEmbeddingConfig(provider: APIProvider): boolean {
 
 function normalizeGrokCliEditorModel(provider: APIProvider, model: string): string {
   return provider === "grok_subscription" && STALE_GROK_CLI_MODEL_IDS.has(model.trim()) ? "" : model;
+}
+
+function normalizeConnectionMaxContext(provider: APIProvider, value: unknown): number {
+  const numericValue = typeof value === "number" && Number.isFinite(value) ? Math.floor(value) : 0;
+  if (provider === "grok_subscription") {
+    return numericValue > 0 && numericValue < GROK_CLI_UNSAFE_INHERITED_CONTEXT_TOKENS
+      ? numericValue
+      : GROK_CLI_DEFAULT_CONTEXT_TOKENS;
+  }
+  return numericValue || 128000;
 }
 
 function normalizeCachingAtDepth(value: unknown): number {
@@ -342,12 +354,13 @@ export function ConnectionEditor() {
     if (!conn) return;
     const c = conn as Record<string, unknown>;
     setLocalName((c.name as string) ?? "");
-    setLocalProvider((c.provider as APIProvider) ?? "openai");
+    const provider = (c.provider as APIProvider) ?? "openai";
+    setLocalProvider(provider);
     setLocalBaseUrl((c.baseUrl as string) ?? "");
     setLocalApiKey(""); // never pre-fill (it's masked)
     setClearStoredApiKeyOnSave(false);
-    setLocalModel(normalizeGrokCliEditorModel((c.provider as APIProvider) ?? "openai", (c.model as string) ?? ""));
-    setLocalMaxContext(Number(c.maxContext) || 128000);
+    setLocalModel(normalizeGrokCliEditorModel(provider, (c.model as string) ?? ""));
+    setLocalMaxContext(normalizeConnectionMaxContext(provider, c.maxContext));
     setLocalMaxParallelJobs(normalizeMaxParallelJobs(c.maxParallelJobs));
     setLocalEnableCaching(c.enableCaching === "true" || c.enableCaching === true);
     setLocalAnthropicExtendedCacheTtl(c.anthropicExtendedCacheTtl === "true" || c.anthropicExtendedCacheTtl === true);
@@ -1247,7 +1260,11 @@ export function ConnectionEditor() {
                     setLocalModel(
                       key === "grok_subscription" ? "" : (defaultModel?.id ?? (key === "xai" ? "grok-4.3" : "")),
                     );
-                    setLocalMaxContext(Number(defaultModel?.context) || 128000);
+                    setLocalMaxContext(
+                      key === "grok_subscription"
+                        ? GROK_CLI_DEFAULT_CONTEXT_TOKENS
+                        : Number(defaultModel?.context) || 128000,
+                    );
                     setLocalMaxTokensOverride(null);
                     setLocalDefaultParametersEnabled(false);
                     setLocalDefaultParameters(CONNECTION_PARAMETER_DEFAULTS);
@@ -1349,7 +1366,9 @@ export function ConnectionEditor() {
               <p className="mt-1.5 text-[0.625rem] text-[var(--muted-foreground)]">
                 Marinara runs <code className="rounded bg-[var(--secondary)] px-1">grok</code> headlessly with Grok-side
                 tools, memory, web search, plans, and subagents disabled. Embeddings are not available on this provider;
-                configure a separate connection for embedding work.
+                configure a separate connection for embedding work. The safest roleplay model is usually{" "}
+                <code className="rounded bg-[var(--secondary)] px-1">grok-composer-2.5-fast</code>; leave the model
+                blank to use the CLI default when unsure.
               </p>
             </div>
           )}
@@ -1976,7 +1995,9 @@ export function ConnectionEditor() {
                 <span className="text-xs text-[var(--muted-foreground)]">{formatContext(localMaxContext)} tokens</span>
               </div>
               <p className="mt-1 text-[0.625rem] text-[var(--muted-foreground)]">
-                This is auto-set when selecting a model from the list. Override manually if needed.
+                {isGrokSubscriptionProvider
+                  ? "Grok CLI starts at a safer 32k window because very large roleplay prompts can make the local CLI hit its own turn limit. Raise it only if your local login handles larger prompts."
+                  : "This is auto-set when selecting a model from the list. Override manually if needed."}
               </p>
             </FieldGroup>
           )}

--- a/packages/server/src/services/llm/providers/grok-subscription.provider.ts
+++ b/packages/server/src/services/llm/providers/grok-subscription.provider.ts
@@ -20,7 +20,6 @@ const GROK_MODELS_TIMEOUT_MS = 30 * 1000;
 const GROK_REQUEST_TIMEOUT_MS = 10 * 60 * 1000;
 const GROK_TOKENS_PER_CHAR = 4;
 const GROK_CLI_DEFAULT_CONTEXT_TOKENS = 32_000;
-const GROK_CLI_UNSAFE_INHERITED_CONTEXT_TOKENS = 128_000;
 const GROK_CLI_MAX_TURNS = 8;
 const GROK_CLI_SAFE_HEADLESS_MODEL_ID = "grok-composer-2.5-fast";
 const GROK_CLI_SYSTEM_PROMPT =
@@ -67,7 +66,7 @@ function normalizeGrokCliModelForFlag(model: string): string {
 function normalizeGrokCliContextWindow(value: unknown): number {
   if (typeof value !== "number" || !Number.isFinite(value) || value <= 0) return GROK_CLI_DEFAULT_CONTEXT_TOKENS;
   const context = Math.floor(value);
-  return context >= GROK_CLI_UNSAFE_INHERITED_CONTEXT_TOKENS ? GROK_CLI_DEFAULT_CONTEXT_TOKENS : context;
+  return Math.min(context, GROK_CLI_DEFAULT_CONTEXT_TOKENS);
 }
 
 function titleCaseModelId(id: string): string {
@@ -87,7 +86,7 @@ function normalizeModelToken(value: string): string | null {
 }
 
 function isLikelyUnavailableModelLine(line: string): boolean {
-  return /\b(unavailable|not\s+available|no\s+access|unauthori[sz]ed|disabled|not\s+enabled|requires?|waitlist|coming\s+soon|denied)\b/i.test(
+  return /\b(no\s+access|access\s+denied|unauthori[sz]ed|forbidden|not\s+available\s+(?:to|for)\s+(?:this\s+)?(?:account|login|user|subscription|plan)|unavailable\s+(?:to|for)\s+(?:this\s+)?(?:account|login|user|subscription|plan)|not\s+enabled\s+(?:for|on)\s+(?:this\s+)?(?:account|login|user|subscription|plan))\b/i.test(
     line,
   );
 }
@@ -144,10 +143,11 @@ function preferHeadlessGrokCliModels(models: GrokCliModel[]): GrokCliModel[] {
   const safeHeadlessModel = models.find((model) => model.id === GROK_CLI_SAFE_HEADLESS_MODEL_ID);
   if (safeHeadlessModel) return [safeHeadlessModel];
 
-  const composerModels = models.filter((model) => model.id.toLowerCase().startsWith("grok-composer-"));
-  if (!composerModels.length) return models;
-
-  return [...composerModels].sort((a, b) => a.name.localeCompare(b.name) || a.id.localeCompare(b.id));
+  return [...models].sort((a, b) => {
+    const aComposer = a.id.toLowerCase().startsWith("grok-composer-") ? 0 : 1;
+    const bComposer = b.id.toLowerCase().startsWith("grok-composer-") ? 0 : 1;
+    return aComposer - bComposer || a.name.localeCompare(b.name) || a.id.localeCompare(b.id);
+  });
 }
 
 function roleLabel(role: ChatMessage["role"]): string {

--- a/packages/server/src/services/llm/providers/grok-subscription.provider.ts
+++ b/packages/server/src/services/llm/providers/grok-subscription.provider.ts
@@ -19,11 +19,18 @@ const GROK_ERROR_PREVIEW_CHARS = 2000;
 const GROK_MODELS_TIMEOUT_MS = 30 * 1000;
 const GROK_REQUEST_TIMEOUT_MS = 10 * 60 * 1000;
 const GROK_TOKENS_PER_CHAR = 4;
+const GROK_CLI_DEFAULT_CONTEXT_TOKENS = 32_000;
+const GROK_CLI_UNSAFE_INHERITED_CONTEXT_TOKENS = 128_000;
+const GROK_CLI_MAX_TURNS = 8;
+const GROK_CLI_SAFE_HEADLESS_MODEL_ID = "grok-composer-2.5-fast";
+const GROK_CLI_SYSTEM_PROMPT =
+  "You are Marinara Engine's one-shot chat completion backend. Return exactly one assistant response for the transcript. Do not inspect files, run tools, ask clarifying questions, plan, or continue beyond the final answer.";
 const STALE_GROK_CLI_MODEL_IDS = new Set(["grok-build-latest", "grok-build-0.1"]);
 
 export interface GrokCliModel {
   id: string;
   name: string;
+  context?: number;
 }
 
 interface GrokCliCommandResult {
@@ -57,6 +64,12 @@ function normalizeGrokCliModelForFlag(model: string): string {
   return STALE_GROK_CLI_MODEL_IDS.has(trimmed) ? "" : trimmed;
 }
 
+function normalizeGrokCliContextWindow(value: unknown): number {
+  if (typeof value !== "number" || !Number.isFinite(value) || value <= 0) return GROK_CLI_DEFAULT_CONTEXT_TOKENS;
+  const context = Math.floor(value);
+  return context >= GROK_CLI_UNSAFE_INHERITED_CONTEXT_TOKENS ? GROK_CLI_DEFAULT_CONTEXT_TOKENS : context;
+}
+
 function titleCaseModelId(id: string): string {
   return id
     .split(/[-_:/.]+/)
@@ -73,6 +86,12 @@ function normalizeModelToken(value: string): string | null {
   return /^grok[a-z0-9._:/-]*$/i.test(token) ? token : null;
 }
 
+function isLikelyUnavailableModelLine(line: string): boolean {
+  return /\b(unavailable|not\s+available|no\s+access|unauthori[sz]ed|disabled|not\s+enabled|requires?|waitlist|coming\s+soon|denied)\b/i.test(
+    line,
+  );
+}
+
 function parseGrokCliModelsOutput(output: string): GrokCliModel[] {
   const models: GrokCliModel[] = [];
   const seen = new Set<string>();
@@ -80,12 +99,13 @@ function parseGrokCliModelsOutput(output: string): GrokCliModel[] {
     if (seen.has(id)) return;
     seen.add(id);
     const name = label?.trim() && !/^grok[a-z0-9._:/-]*$/i.test(label.trim()) ? label.trim() : titleCaseModelId(id);
-    models.push({ id, name });
+    models.push({ id, name, context: GROK_CLI_DEFAULT_CONTEXT_TOKENS });
   };
 
   for (const rawLine of stripAnsi(output).split(/\r?\n/)) {
     const line = rawLine.trim();
     if (!line || /^[-|+\s]+$/.test(line) || /^(available\s+)?models?$/i.test(line)) continue;
+    if (isLikelyUnavailableModelLine(line)) continue;
 
     if (line.includes("|")) {
       const cells = line
@@ -118,6 +138,16 @@ function parseGrokCliModelsOutput(output: string): GrokCliModel[] {
   }
 
   return models;
+}
+
+function preferHeadlessGrokCliModels(models: GrokCliModel[]): GrokCliModel[] {
+  const safeHeadlessModel = models.find((model) => model.id === GROK_CLI_SAFE_HEADLESS_MODEL_ID);
+  if (safeHeadlessModel) return [safeHeadlessModel];
+
+  const composerModels = models.filter((model) => model.id.toLowerCase().startsWith("grok-composer-"));
+  if (!composerModels.length) return models;
+
+  return [...composerModels].sort((a, b) => a.name.localeCompare(b.name) || a.id.localeCompare(b.id));
 }
 
 function roleLabel(role: ChatMessage["role"]): string {
@@ -268,14 +298,16 @@ export async function fetchGrokCliModels(): Promise<GrokCliModel[]> {
   if (!models.length) {
     throw new Error("Grok CLI did not return any model IDs. Run `grok models` in a terminal to inspect the output.");
   }
-  return models;
+  return preferHeadlessGrokCliModels(models);
 }
 
 export class GrokSubscriptionProvider extends BaseLLMProvider {
   async *chat(messages: ChatMessage[], options: ChatOptions): AsyncGenerator<string, LLMUsage | void, unknown> {
     const configuredMaxTokens = this.applyMaxTokensCap(options.maxTokens ?? 4096);
+    const maxContext = normalizeGrokCliContextWindow(options.maxContext ?? this.maxContextValue ?? undefined);
     const contextFit = this.fitMessagesToContext(messages, {
       ...options,
+      maxContext,
       maxTokens: configuredMaxTokens,
       tools: undefined,
       suppressModelParameters: true,
@@ -292,6 +324,8 @@ export class GrokSubscriptionProvider extends BaseLLMProvider {
       prompt,
       "--output-format",
       "plain",
+      "--system-prompt-override",
+      GROK_CLI_SYSTEM_PROMPT,
       "--no-plan",
       "--no-subagents",
       "--no-memory",
@@ -299,16 +333,17 @@ export class GrokSubscriptionProvider extends BaseLLMProvider {
       "--disallowed-tools",
       "run_terminal_command",
       "--max-turns",
-      "1",
+      String(GROK_CLI_MAX_TURNS),
       "--cwd",
       GROK_SCRATCH_DIR,
     ];
     if (cliModel) args.push("-m", cliModel);
 
     logger.debug(
-      "[grok-subscription] running grok CLI model=%s promptChars=%d",
+      "[grok-subscription] running grok CLI model=%s promptChars=%d maxContext=%d",
       cliModel || "(cli default)",
       prompt.length,
+      maxContext,
     );
     logDebugOverride(debugOverrideEnabled, "[debug/grok-subscription] final prompt:\n%s", prompt);
 
@@ -327,7 +362,12 @@ export class GrokSubscriptionProvider extends BaseLLMProvider {
         );
         if (cliModel && /unknown model id|couldn'?t set model|run `?grok models`?/i.test(detail)) {
           throw new Error(
-            `Selected Grok CLI model "${cliModel}" is not available to this local CLI login. Click "Fetch Models from Grok CLI" and pick one of those IDs, or clear the model field to use the CLI default. Details: ${detail}`,
+            `Selected Grok CLI model "${cliModel}" is not available to this local CLI login. Click "Fetch Models from Grok CLI" and pick ${GROK_CLI_SAFE_HEADLESS_MODEL_ID} when it appears, or clear the model field to use the CLI default. Details: ${detail}`,
+          );
+        }
+        if (/max turns reached/i.test(detail)) {
+          throw new Error(
+            `Grok CLI hit its headless turn limit after ${GROK_CLI_MAX_TURNS} turns. This usually happens when the CLI receives more context than the local subscription model can complete cleanly. Lower this connection's Max Context Window, leave the model blank, or select ${GROK_CLI_SAFE_HEADLESS_MODEL_ID}. Details: ${detail}`,
           );
         }
         throw new Error(


### PR DESCRIPTION
## Linked issue

No linked issue. User-reported Grok CLI subscription regression during roleplay testing.

## Why this change

Grok CLI subscription connections could expose model IDs that the user's local CLI login could not actually run, and large roleplay prompts could make the local CLI fail with `max turns reached`. The test message path was small enough to pass, which made the roleplay-only failure confusing.

## What changed

- Prefer `grok-composer-2.5-fast` from fetched Grok CLI models when available, and filter obviously unavailable model rows.
- Start Grok CLI subscription connections with a safer 32k context window, including old connections that inherited the unsafe 128k default.
- Run the CLI with a stricter one-shot system override and a clearer `max turns reached` diagnostic that points users toward lowering context or using the Composer model/default CLI model.
- Updated the v2.1.1 changelog entry.

## Validation

- [ ] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed `CONTRIBUTING.md`

### Manual verification notes

- Ran `pnpm check` locally; it passed.
- Ran `git diff --check`; it passed.
- Could not perform a live Grok CLI request on this machine because `grok` is not installed on PATH.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Version/release files updated (only if this PR includes a version bump)

CHANGELOG.md was updated for v2.1.1. No version bump or user-facing docs change was needed.

## UI evidence (if applicable)

N/A. This is connection behavior and helper copy only.
