### PR TITLE
Fix scene presets and native lorebook exports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,8 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 - Fixed Grok CLI (Subscription) connections so they no longer seed stale `grok-build-*` model aliases, can use the local CLI default model with a blank model field, and fetch selectable model IDs from `grok models`.
 - Fixed Grok CLI (Subscription) roleplay requests by preferring the safe headless Composer model when discovered, starting Grok CLI connections with a safer 32k context window, and surfacing a clearer context-limit hint when the CLI reports `max turns reached`.
 - Added Lorebook entry-status sorting, fixed continued assistant messages so appended text starts after a blank line, and removed the obsolete tracked `pr-evidence/` artifacts while ignoring future evidence folders (#3336).
+- Fixed Conversation-created scene chats so their Prompt Preset selector remains visible while still defaulting to None, and native Character/Persona exports now include attached lorebooks that re-import linked to the new owner.
+- Made the Connections panel's unfiled/root drop area more forgiving so desktop users, including Windows users, can reliably drag connections out of folders without hitting a tiny target.
 
 ## [2.1.0]
 

--- a/packages/client/src/components/characters/CharacterEditor.tsx
+++ b/packages/client/src/components/characters/CharacterEditor.tsx
@@ -805,7 +805,7 @@ export function CharacterEditor() {
       <ExportFormatDialog
         open={exportDialogOpen}
         title="Export Character"
-        description="Native keeps Marinara metadata. Compatible exports direct Chara Card V2 JSON for other platforms."
+        description="Native keeps Marinara metadata, sprites, gallery images, and attached lorebooks. Compatible exports direct Chara Card V2 JSON for other platforms."
         compatibleDescription="Exports direct Chara Card V2 JSON without the Marinara wrapper."
         showPngOption
         onClose={() => setExportDialogOpen(false)}

--- a/packages/client/src/components/chat/ChatSettingsDrawer.tsx
+++ b/packages/client/src/components/chat/ChatSettingsDrawer.tsx
@@ -3638,7 +3638,7 @@ export function ChatSettingsDrawer({
           </div>
 
           {/* Roleplay prompt preset */}
-          {modeCapabilities.supportsPromptPresets && isRoleplayMode && !metadata.sceneSystemPrompt && (
+          {modeCapabilities.supportsPromptPresets && isRoleplayMode && (
             <div style={{ order: CHAT_SETTINGS_ORDER.promptPreset }}>
               <PromptPresetSection
                 promptPresetId={chat.promptPresetId ?? null}

--- a/packages/client/src/components/panels/ConnectionsPanel.tsx
+++ b/packages/client/src/components/panels/ConnectionsPanel.tsx
@@ -1,7 +1,16 @@
 // ──────────────────────────────────────────────
 // Panel: API Connections (polished, with folders)
 // ──────────────────────────────────────────────
-import { useState, useEffect, useMemo, useCallback, useRef, type ChangeEvent, type TouchEvent } from "react";
+import {
+  useState,
+  useEffect,
+  useMemo,
+  useCallback,
+  useRef,
+  type ChangeEvent,
+  type DragEvent,
+  type TouchEvent,
+} from "react";
 import { Reorder, useDragControls } from "framer-motion";
 import { useQueryClient } from "@tanstack/react-query";
 import {
@@ -146,6 +155,28 @@ function getNextUnnamedFolderName(existingFolders: Array<{ name: string }>): str
   let index = 2;
   while (names.has(`unnamed ${index}`)) index += 1;
   return `unnamed ${index}`;
+}
+
+function getDroppedConnectionIds(event: DragEvent<HTMLElement>, fallbackId: string | null): string[] {
+  const payload = event.dataTransfer.getData("application/x-marinara-connection-ids");
+  if (payload) {
+    try {
+      const parsed = JSON.parse(payload);
+      if (Array.isArray(parsed)) {
+        return parsed.filter((id): id is string => typeof id === "string" && id.length > 0);
+      }
+    } catch {
+      // Fall through to single-id payloads. Some desktop drag providers can
+      // expose partial data while moving between native drop targets.
+    }
+  }
+
+  const singleId =
+    event.dataTransfer.getData("application/x-marinara-connection-id") ||
+    event.dataTransfer.getData("text/plain") ||
+    fallbackId ||
+    "";
+  return singleId ? [singleId] : [];
 }
 
 function SidecarCard() {
@@ -1072,12 +1103,7 @@ function ConnectionFolderRow({
       onDrop={(event) => {
         if (!draggedConnectionId) return;
         event.preventDefault();
-        const connectionId =
-          event.dataTransfer.getData("application/x-marinara-connection-id") ||
-          event.dataTransfer.getData("text/plain") ||
-          draggedConnectionId;
-        const payload = event.dataTransfer.getData("application/x-marinara-connection-ids");
-        const connectionIds = payload ? (JSON.parse(payload) as string[]) : [connectionId];
+        const connectionIds = getDroppedConnectionIds(event, draggedConnectionId);
         if (connectionIds.length > 0) onDropConnection(connectionIds, folder.id);
         setIsDropTarget(false);
       }}
@@ -1341,6 +1367,29 @@ export function ConnectionsPanel() {
     [reorderConnectionsInFolder],
   );
 
+  const handleRootConnectionDragOver = useCallback(
+    (event: DragEvent<HTMLElement>) => {
+      if (!draggedConnectionId) return;
+      const target = event.target instanceof Element ? event.target.closest("[data-connection-id]") : null;
+      if (target) return;
+      event.preventDefault();
+      event.dataTransfer.dropEffect = "move";
+    },
+    [draggedConnectionId],
+  );
+
+  const handleRootConnectionDrop = useCallback(
+    (event: DragEvent<HTMLElement>) => {
+      if (!draggedConnectionId) return;
+      const target = event.target instanceof Element ? event.target.closest("[data-connection-id]") : null;
+      if (target) return;
+      event.preventDefault();
+      event.stopPropagation();
+      handleDropConnectionsToFolder(getDroppedConnectionIds(event, draggedConnectionId), null);
+    },
+    [draggedConnectionId, handleDropConnectionsToFolder],
+  );
+
   const handleDropConnectionsOnRow = useCallback(
     (connectionIds: string[], targetConnectionId: string) => {
       const targetConnection = connectionsList.find((connection) => connection.id === targetConnectionId);
@@ -1540,15 +1589,7 @@ export function ConnectionsPanel() {
         onDropOnRow={(event) => {
           event.preventDefault();
           event.stopPropagation();
-          const payload = event.dataTransfer.getData("application/x-marinara-connection-ids");
-          const fallbackId =
-            event.dataTransfer.getData("application/x-marinara-connection-id") ||
-            event.dataTransfer.getData("text/plain") ||
-            draggedConnectionId;
-          handleDropConnectionsOnRow(
-            payload ? (JSON.parse(payload) as string[]) : fallbackId ? [fallbackId] : [],
-            conn.id,
-          );
+          handleDropConnectionsOnRow(getDroppedConnectionIds(event, draggedConnectionId), conn.id);
         }}
         onTouchStart={(event) => {
           startConnectionTouchDrag(event, conn.id, {
@@ -1763,32 +1804,21 @@ export function ConnectionsPanel() {
       )}
 
       {/* Unfiled connections */}
-      {draggedConnectionId && (
-        <div
-          data-connection-folder-root
-          onDragOver={(event) => {
-            event.preventDefault();
-            event.dataTransfer.dropEffect = "move";
-          }}
-          onDrop={(event) => {
-            event.preventDefault();
-            const payload = event.dataTransfer.getData("application/x-marinara-connection-ids");
-            const fallbackId =
-              event.dataTransfer.getData("application/x-marinara-connection-id") ||
-              event.dataTransfer.getData("text/plain") ||
-              draggedConnectionId;
-            handleDropConnectionsToFolder(
-              payload ? (JSON.parse(payload) as string[]) : fallbackId ? [fallbackId] : [],
-              null,
-            );
-          }}
-          className="rounded-xl border border-dashed border-[var(--marinara-chat-chrome-button-border-active)] bg-[var(--marinara-chat-chrome-highlight-bg)] px-3 py-2 text-[0.625rem] text-[var(--marinara-chat-chrome-button-text-active)]"
-        >
-          Drop here to move out of folder
-        </div>
-      )}
-
-      <div className="stagger-children flex min-h-8 flex-col gap-1 rounded-xl transition-colors">
+      <div
+        data-connection-folder-root
+        onDragOver={handleRootConnectionDragOver}
+        onDrop={handleRootConnectionDrop}
+        className={cn(
+          "stagger-children flex min-h-8 flex-col gap-1 rounded-xl transition-colors",
+          draggedConnectionId &&
+            "min-h-16 border border-dashed border-[var(--marinara-chat-chrome-button-border-active)] bg-[var(--marinara-chat-chrome-highlight-bg)] p-1",
+        )}
+      >
+        {draggedConnectionId && (
+          <div className="pointer-events-none px-2 py-1 text-[0.625rem] text-[var(--marinara-chat-chrome-button-text-active)]">
+            Drop here to move out of folder
+          </div>
+        )}
         {unfiledConnections.map(renderConnectionRow)}
       </div>
 

--- a/packages/client/src/components/personas/PersonaEditor.tsx
+++ b/packages/client/src/components/personas/PersonaEditor.tsx
@@ -1278,7 +1278,7 @@ export function PersonaEditor() {
       <ExportFormatDialog
         open={exportDialogOpen}
         title="Export Persona"
-        description="Native keeps Marinara persona metadata. Compatible exports simple persona JSON for other tools."
+        description="Native keeps Marinara persona metadata, sprites, and attached lorebooks. Compatible exports simple persona JSON for other tools."
         compatibleDescription="Exports persona fields directly without the Marinara wrapper."
         onClose={() => setExportDialogOpen(false)}
         onSelect={(format: ExportFormatChoice) => {

--- a/packages/server/src/routes/characters.routes.ts
+++ b/packages/server/src/routes/characters.routes.ts
@@ -19,6 +19,7 @@ import { createPersonaGalleryStorage } from "../services/storage/persona-gallery
 import { createChatsStorage } from "../services/storage/chats.storage.js";
 import { createGameSceneVideosStorage } from "../services/storage/game-scene-videos.storage.js";
 import { createConnectionsStorage } from "../services/storage/connections.storage.js";
+import { createLorebooksStorage } from "../services/storage/lorebooks.storage.js";
 import { generateImage } from "../services/image/image-generation.js";
 import { resolveConnectionImageDefaults } from "../services/image/image-generation-defaults.js";
 import { loadImageGenerationUserSettings } from "../services/image/image-generation-settings.js";
@@ -372,6 +373,12 @@ async function resolveAvatarGenerationConnection(app: FastifyInstance, body: Ava
 }
 
 type ExportFormat = "native" | "compatible";
+type LorebooksStore = ReturnType<typeof createLorebooksStorage>;
+type NativeLorebookBundle = {
+  lorebook: Record<string, unknown>;
+  entries: Array<Record<string, unknown>>;
+  folders: Array<Record<string, unknown>>;
+};
 
 // Read an image file and return it as a base64 data URL, or null if the file
 // is missing, outside the expected dir, or not a recognized image type. Used
@@ -456,15 +463,50 @@ async function readGalleryForCharacter(
   return result;
 }
 
+async function readAttachedLorebooksForCharacter(
+  characterId: string,
+  lorebooksStorage: LorebooksStore,
+): Promise<NativeLorebookBundle[]> {
+  const books = (await lorebooksStorage.listByCharacter(characterId)) as Array<Record<string, unknown>>;
+  return readLorebookBundles(books, lorebooksStorage);
+}
+
+async function readAttachedLorebooksForPersona(
+  personaId: string,
+  lorebooksStorage: LorebooksStore,
+): Promise<NativeLorebookBundle[]> {
+  const books = (await lorebooksStorage.listByPersona(personaId)) as Array<Record<string, unknown>>;
+  return readLorebookBundles(books, lorebooksStorage);
+}
+
+async function readLorebookBundles(
+  books: Array<Record<string, unknown>>,
+  lorebooksStorage: LorebooksStore,
+): Promise<NativeLorebookBundle[]> {
+  const bundles: NativeLorebookBundle[] = [];
+  for (const lorebook of books) {
+    const id = typeof lorebook.id === "string" ? lorebook.id : "";
+    if (!id) continue;
+    const [entries, folders] = await Promise.all([
+      lorebooksStorage.listEntries(id) as Promise<Array<Record<string, unknown>>>,
+      lorebooksStorage.listFolders(id) as Promise<Array<Record<string, unknown>>>,
+    ]);
+    bundles.push({ lorebook, entries, folders });
+  }
+  return bundles;
+}
+
 async function buildNativeCharacterEnvelope(
   char: { id: string; createdAt: string; updatedAt: string; comment?: string | null; avatarPath?: string | null },
   data: any,
   galleryStorage: { listByCharacterId: (id: string) => Promise<any[]> },
+  lorebooksStorage: LorebooksStore,
 ) {
-  const [avatar, sprites, gallery] = await Promise.all([
+  const [avatar, sprites, gallery, lorebooks] = await Promise.all([
     readAvatarDataUrl(char.avatarPath),
     readSpritesForId(char.id),
     readGalleryForCharacter(char.id, galleryStorage),
+    readAttachedLorebooksForCharacter(char.id, lorebooksStorage),
   ]);
   return {
     type: "marinara_character",
@@ -477,6 +519,7 @@ async function buildNativeCharacterEnvelope(
       ...(avatar ? { avatar } : {}),
       ...(sprites.length > 0 ? { sprites } : {}),
       ...(gallery.length > 0 ? { gallery } : {}),
+      ...(lorebooks.length > 0 ? { lorebooks } : {}),
       metadata: {
         createdAt: char.createdAt,
         updatedAt: char.updatedAt,
@@ -494,12 +537,13 @@ function buildCompatibleCharacterExport(data: any) {
   };
 }
 
-async function buildNativePersonaEnvelope(persona: Record<string, unknown>) {
+async function buildNativePersonaEnvelope(persona: Record<string, unknown>, lorebooksStorage: LorebooksStore) {
   const { id: _id, createdAt, updatedAt, avatarPath, isActive: _isActive, ...personaData } = persona;
   const personaId = typeof _id === "string" ? _id : "";
-  const [avatar, sprites] = await Promise.all([
+  const [avatar, sprites, lorebooks] = await Promise.all([
     readAvatarDataUrl(typeof avatarPath === "string" ? avatarPath : null),
     personaId ? readSpritesForId(personaId) : Promise.resolve([] as Array<{ filename: string; data: string }>),
+    personaId ? readAttachedLorebooksForPersona(personaId, lorebooksStorage) : Promise.resolve([]),
   ]);
   return {
     type: "marinara_persona",
@@ -509,6 +553,7 @@ async function buildNativePersonaEnvelope(persona: Record<string, unknown>) {
       ...personaData,
       ...(avatar ? { avatar } : {}),
       ...(sprites.length > 0 ? { sprites } : {}),
+      ...(lorebooks.length > 0 ? { lorebooks } : {}),
       metadata: {
         createdAt,
         updatedAt,
@@ -541,6 +586,7 @@ export async function charactersRoutes(app: FastifyInstance) {
   const storage = createCharactersStorage(app.db);
   const characterGallery = createCharacterGalleryStorage(app.db);
   const personaGallery = createPersonaGalleryStorage(app.db);
+  const lorebooksStorage = createLorebooksStorage(app.db);
 
   // ── Characters ──
 
@@ -1234,7 +1280,7 @@ export async function charactersRoutes(app: FastifyInstance) {
     const compatible = req.query.format === "compatible";
     const payload = compatible
       ? buildCompatibleCharacterExport(charData)
-      : await buildNativeCharacterEnvelope(char, charData, characterGallery);
+      : await buildNativeCharacterEnvelope(char, charData, characterGallery, lorebooksStorage);
     return reply
       .header(
         "Content-Disposition",
@@ -1258,7 +1304,7 @@ export async function charactersRoutes(app: FastifyInstance) {
       const payload =
         format === "compatible"
           ? buildCompatibleCharacterExport(charData)
-          : await buildNativeCharacterEnvelope(char, charData, characterGallery);
+          : await buildNativeCharacterEnvelope(char, charData, characterGallery, lorebooksStorage);
       zip.addFile(
         `${toSafeExportName(String(charData.name ?? "character"), `character-${exportedCount + 1}`)}.${format === "compatible" ? "json" : "marinara.json"}`,
         Buffer.from(JSON.stringify(payload, null, 2), "utf-8"),
@@ -2073,7 +2119,7 @@ export async function charactersRoutes(app: FastifyInstance) {
       const compatible = req.query.format === "compatible";
       const payload = compatible
         ? buildCompatiblePersonaExport(persona as Record<string, unknown>)
-        : await buildNativePersonaEnvelope(persona as Record<string, unknown>);
+        : await buildNativePersonaEnvelope(persona as Record<string, unknown>, lorebooksStorage);
       return reply
         .header(
           "Content-Disposition",
@@ -2097,7 +2143,7 @@ export async function charactersRoutes(app: FastifyInstance) {
       const payload =
         format === "compatible"
           ? buildCompatiblePersonaExport(persona as Record<string, unknown>)
-          : await buildNativePersonaEnvelope(persona as Record<string, unknown>);
+          : await buildNativePersonaEnvelope(persona as Record<string, unknown>, lorebooksStorage);
       zip.addFile(
         `${toSafeExportName(String(persona.name ?? "persona"), `persona-${exportedCount + 1}`)}.${format === "compatible" ? "json" : "marinara.json"}`,
         Buffer.from(JSON.stringify(payload, null, 2), "utf-8"),

--- a/packages/server/src/services/import/marinara.importer.ts
+++ b/packages/server/src/services/import/marinara.importer.ts
@@ -204,6 +204,11 @@ const VALID_MATCHING_SOURCES = new Set<LorebookMatchingSource>([
   "persona_tags",
 ]);
 
+type BundledLorebookOwner = {
+  characterId?: string;
+  personaId?: string;
+};
+
 function readMatchingSources(value: unknown): LorebookMatchingSource[] {
   if (!Array.isArray(value)) return [];
   return value.filter((source): source is LorebookMatchingSource =>
@@ -280,6 +285,7 @@ async function importCharacter(data: unknown, db: DB) {
     avatar?: unknown;
     sprites?: unknown;
     gallery?: unknown;
+    lorebooks?: unknown;
   };
   const charData = d?.data ? { ...(d.data as Record<string, unknown>) } : undefined;
   const metadata = d?.metadata && typeof d.metadata === "object" ? (d.metadata as Record<string, unknown>) : null;
@@ -341,6 +347,7 @@ async function importCharacter(data: unknown, db: DB) {
     }
     await restoreSprites(d.sprites, result.id);
     await restoreCharacterGallery(d.gallery, result.id, galleryStorage);
+    await importBundledLorebooks(d.lorebooks, db, { characterId: result.id });
   }
   return {
     success: true,
@@ -411,6 +418,7 @@ async function importPersona(data: unknown, db: DB) {
       await storage.updatePersona(result.id, { avatarPath });
     }
     await restoreSprites(d.sprites, result.id);
+    await importBundledLorebooks(d.lorebooks, db, { personaId: result.id });
   }
   return {
     success: true,
@@ -423,6 +431,17 @@ async function importPersona(data: unknown, db: DB) {
 // ── Lorebook ─────────────────────────────────
 
 async function importLorebook(data: unknown, db: DB) {
+  return importLorebookPayload(data, db);
+}
+
+async function importBundledLorebooks(lorebooks: unknown, db: DB, owner: BundledLorebookOwner): Promise<void> {
+  if (!Array.isArray(lorebooks) || lorebooks.length === 0) return;
+  for (const lorebook of lorebooks) {
+    await importLorebookPayload(lorebook, db, owner);
+  }
+}
+
+async function importLorebookPayload(data: unknown, db: DB, owner?: BundledLorebookOwner) {
   const storage = createLorebooksStorage(db);
   const d = data as {
     lorebook?: Record<string, unknown>;
@@ -433,6 +452,8 @@ async function importLorebook(data: unknown, db: DB) {
     return { success: false, type: "marinara_lorebook" as const, error: "Invalid lorebook data" };
   }
   const lb = d.lorebook;
+  const ownerCharacterIds = owner?.characterId ? [owner.characterId] : null;
+  const ownerPersonaIds = owner?.personaId ? [owner.personaId] : null;
   const newLb = (await storage.create(
     {
       name: String(lb.name ?? "Imported Lorebook"),
@@ -447,20 +468,24 @@ async function importLorebook(data: unknown, db: DB) {
       vectorQueryDepth: Number(lb.vectorQueryDepth ?? 10),
       vectorScoreThreshold: Number(lb.vectorScoreThreshold ?? 0.3),
       vectorMaxResults: Number(lb.vectorMaxResults ?? 10),
-      characterId: typeof lb.characterId === "string" ? lb.characterId : null,
-      characterIds: Array.isArray(lb.characterIds)
-        ? lb.characterIds.filter((value): value is string => typeof value === "string")
-        : typeof lb.characterId === "string"
-          ? [lb.characterId]
-          : [],
-      personaId: typeof lb.personaId === "string" ? lb.personaId : null,
-      personaIds: Array.isArray(lb.personaIds)
-        ? lb.personaIds.filter((value): value is string => typeof value === "string")
-        : typeof lb.personaId === "string"
-          ? [lb.personaId]
-          : [],
-      chatId: typeof lb.chatId === "string" ? lb.chatId : null,
-      isGlobal: lb.isGlobal === true || lb.isGlobal === "true",
+      characterId: owner ? null : typeof lb.characterId === "string" ? lb.characterId : null,
+      characterIds: owner
+        ? (ownerCharacterIds ?? [])
+        : Array.isArray(lb.characterIds)
+          ? lb.characterIds.filter((value): value is string => typeof value === "string")
+          : typeof lb.characterId === "string"
+            ? [lb.characterId]
+            : [],
+      personaId: owner ? null : typeof lb.personaId === "string" ? lb.personaId : null,
+      personaIds: owner
+        ? (ownerPersonaIds ?? [])
+        : Array.isArray(lb.personaIds)
+          ? lb.personaIds.filter((value): value is string => typeof value === "string")
+          : typeof lb.personaId === "string"
+            ? [lb.personaId]
+            : [],
+      chatId: owner ? null : typeof lb.chatId === "string" ? lb.chatId : null,
+      isGlobal: owner ? false : lb.isGlobal === true || lb.isGlobal === "true",
       enabled: lb.enabled !== false,
       scope: readLorebookScope(lb.scope),
       tags: Array.isArray(lb.tags) ? lb.tags.map(String) : [],


### PR DESCRIPTION
## Summary

- Keeps the Prompt Preset selector visible for Roleplay scenes created from Conversation while preserving the default-to-None behavior.
- Includes attached lorebooks in native Character and Persona exports, then re-links those lorebooks to the imported owner.
- Makes the Connections panel root/unfiled drop area more forgiving so desktop users can drag connections out of folders reliably.
- Updates v2.1.1 changelog entries and export-dialog copy for the new native export behavior.

## Why

Scene chats should allow users to override the automatically cleared preset when they want one, native exports should preserve attached owner lorebooks, and the Connections folder UI should not depend on a tiny root drop target that can be unreliable on Windows desktop drag/drop.

## Validation

- pnpm check
- git diff --check

## Manual Verification Needed

- Manually verify a Conversation-created Roleplay scene still defaults Prompt Preset to None but allows selecting a preset in Chat Settings.
- Manually verify native Character and Persona exports with attached lorebooks import with those lorebooks linked to the imported owner.
- Manually verify dragging a connection from a folder into the unfiled/root area on Windows or desktop Chromium.
