### PR TITLE
feat(lorebooks): embed a linked character lorebook into the card (#3341)

### DIFF
--- a/packages/client/src/components/characters/CharacterEditor.tsx
+++ b/packages/client/src/components/characters/CharacterEditor.tsx
@@ -4079,7 +4079,12 @@ function LorebookTab({ characterId, formData }: { characterId: string | null; fo
         helpText={CHARACTER_LOREBOOK_HELP}
       />
 
-      <LorebookAssignmentSection ownerType="character" ownerId={characterId} ownerName={formData.name} />
+      <LorebookAssignmentSection
+        ownerType="character"
+        ownerId={characterId}
+        ownerName={formData.name}
+        embeddedLorebookId={linkedLorebookId}
+      />
 
       {hasEmbeddedLorebook && (
         <div className="flex flex-wrap items-center gap-2 rounded-xl border border-[var(--border)] bg-[var(--secondary)] px-3 py-2.5">

--- a/packages/client/src/components/characters/CharacterEditor.tsx
+++ b/packages/client/src/components/characters/CharacterEditor.tsx
@@ -339,6 +339,28 @@ export function CharacterEditor() {
     });
   }, []);
 
+  // Embedding a lorebook into the card mutates the character server-side
+  // (data.character_book + the embeddedLorebook pointer). When the editor is
+  // clean, the detail-query refetch re-syncs formData for us; when it is dirty
+  // the parse effect skips that re-sync, so patch formData directly — otherwise
+  // a later Save would send the stale pre-embed data and silently revert it.
+  const handleLorebookEmbedded = useCallback((lorebookId: string, characterBook: unknown) => {
+    if (!dirtyRef.current) return;
+    setFormData((prev) => {
+      if (!prev) return prev;
+      const extensions = { ...(prev.extensions ?? {}) } as Record<string, unknown>;
+      const importMetadata = { ...((extensions.importMetadata as Record<string, unknown>) ?? {}) };
+      const embeddedLorebook = { ...((importMetadata.embeddedLorebook as Record<string, unknown>) ?? {}) };
+      importMetadata.embeddedLorebook = { ...embeddedLorebook, hasEmbeddedLorebook: true, lorebookId };
+      extensions.importMetadata = importMetadata;
+      return {
+        ...prev,
+        character_book: characterBook as CharacterData["character_book"],
+        extensions: extensions as CharacterData["extensions"],
+      };
+    });
+  }, []);
+
   const updateExtension = useCallback(
     (key: string, value: unknown) => {
       setExtensionValue(key, formatCharacterExtensionValue(key, value, formatQuotes));
@@ -991,7 +1013,9 @@ export function CharacterEditor() {
               <ColorsTab formData={formData} updateExtension={updateExtension} avatarUrl={avatarPreview} />
             )}
             {activeTab === "stats" && <StatsTab formData={formData} updateExtension={updateExtension} />}
-            {activeTab === "lorebook" && <LorebookTab characterId={characterId} formData={formData} />}
+            {activeTab === "lorebook" && (
+              <LorebookTab characterId={characterId} formData={formData} onEmbedded={handleLorebookEmbedded} />
+            )}
           </div>
         </div>
       </div>
@@ -4017,7 +4041,15 @@ function ColorsTab({
   );
 }
 
-function LorebookTab({ characterId, formData }: { characterId: string | null; formData: CharacterData }) {
+function LorebookTab({
+  characterId,
+  formData,
+  onEmbedded,
+}: {
+  characterId: string | null;
+  formData: CharacterData;
+  onEmbedded?: (lorebookId: string, characterBook: unknown) => void;
+}) {
   const book = formData.character_book;
   const entries = book?.entries ?? [];
   const qc = useQueryClient();
@@ -4084,6 +4116,8 @@ function LorebookTab({ characterId, formData }: { characterId: string | null; fo
         ownerId={characterId}
         ownerName={formData.name}
         embeddedLorebookId={linkedLorebookId}
+        slotOccupied={hasEmbeddedLorebook}
+        onEmbedded={(result) => onEmbedded?.(result.lorebookId, result.characterBook)}
       />
 
       {hasEmbeddedLorebook && (

--- a/packages/client/src/components/characters/CharacterEditor.tsx
+++ b/packages/client/src/components/characters/CharacterEditor.tsx
@@ -264,9 +264,15 @@ export function CharacterEditor() {
   const dirtyRef = useRef(false);
   const editRevisionRef = useRef(0);
   const setEditorDirty = useUIStore((s) => s.setEditorDirty);
+  const lorebookEmbedInFlightRef = useRef(false);
+  const [lorebookEmbedding, setLorebookEmbedding] = useState(false);
   const setDirtyState = useCallback((nextDirty: boolean) => {
     dirtyRef.current = nextDirty;
     setDirty(nextDirty);
+  }, []);
+  const setLorebookEmbedInFlight = useCallback((inFlight: boolean) => {
+    lorebookEmbedInFlightRef.current = inFlight;
+    setLorebookEmbedding(inFlight);
   }, []);
   const markDirty = useCallback(() => {
     editRevisionRef.current += 1;
@@ -397,6 +403,10 @@ export function CharacterEditor() {
     if (!characterId || !formData) return false;
     if (avatarUploadInFlightRef.current) {
       toast.error("Wait for the current avatar upload to finish before saving.");
+      return false;
+    }
+    if (lorebookEmbedInFlightRef.current) {
+      toast.error("Wait for the embedded lorebook update to finish before saving.");
       return false;
     }
     setSaving(true);
@@ -692,22 +702,30 @@ export function CharacterEditor() {
       toast.error("Wait for the current avatar upload to finish.");
       return;
     }
+    if (lorebookEmbedding) {
+      toast.error("Wait for the embedded lorebook update to finish.");
+      return;
+    }
     if (dirty) {
       setShowUnsavedWarning(true);
       return;
     }
     closeDetail();
-  }, [avatarUploading, dirty, closeDetail]);
+  }, [avatarUploading, dirty, closeDetail, lorebookEmbedding]);
 
   const forceClose = useCallback(() => {
     if (avatarUploading) {
       toast.error("Wait for the current avatar upload to finish.");
       return;
     }
+    if (lorebookEmbedding) {
+      toast.error("Wait for the embedded lorebook update to finish.");
+      return;
+    }
     setShowUnsavedWarning(false);
     setDirtyState(false);
     closeDetail();
-  }, [avatarUploading, closeDetail, setDirtyState]);
+  }, [avatarUploading, closeDetail, lorebookEmbedding, setDirtyState]);
 
   const addTag = () => {
     if (!formData) return;
@@ -742,8 +760,8 @@ export function CharacterEditor() {
   }
 
   const headerActionButtonClass = "mari-editor-action inline-flex";
-  const saveDisabled = !dirty || saving || avatarUploading;
-  const saveLabel = avatarUploading ? "Uploading…" : saving ? "Saving…" : "Save";
+  const saveDisabled = !dirty || saving || avatarUploading || lorebookEmbedding;
+  const saveLabel = avatarUploading ? "Uploading…" : lorebookEmbedding ? "Embedding…" : saving ? "Saving…" : "Save";
   const saveButtonClass = cn(
     "mari-editor-action mari-editor-action--primary mari-editor-action--save inline-flex",
     saveDisabled && "cursor-not-allowed opacity-50",
@@ -1014,7 +1032,12 @@ export function CharacterEditor() {
             )}
             {activeTab === "stats" && <StatsTab formData={formData} updateExtension={updateExtension} />}
             {activeTab === "lorebook" && (
-              <LorebookTab characterId={characterId} formData={formData} onEmbedded={handleLorebookEmbedded} />
+              <LorebookTab
+                characterId={characterId}
+                formData={formData}
+                onEmbedded={handleLorebookEmbedded}
+                onEmbeddingChange={setLorebookEmbedInFlight}
+              />
             )}
           </div>
         </div>
@@ -4045,10 +4068,12 @@ function LorebookTab({
   characterId,
   formData,
   onEmbedded,
+  onEmbeddingChange,
 }: {
   characterId: string | null;
   formData: CharacterData;
   onEmbedded?: (lorebookId: string, characterBook: unknown) => void;
+  onEmbeddingChange?: (embedding: boolean) => void;
 }) {
   const book = formData.character_book;
   const entries = book?.entries ?? [];
@@ -4118,6 +4143,7 @@ function LorebookTab({
         embeddedLorebookId={linkedLorebookId}
         slotOccupied={hasEmbeddedLorebook}
         onEmbedded={(result) => onEmbedded?.(result.lorebookId, result.characterBook)}
+        onEmbeddingChange={onEmbeddingChange}
       />
 
       {hasEmbeddedLorebook && (

--- a/packages/client/src/components/lorebooks/LorebookAssignmentSection.tsx
+++ b/packages/client/src/components/lorebooks/LorebookAssignmentSection.tsx
@@ -24,6 +24,10 @@ interface LorebookAssignmentSectionProps {
   ownerName: string;
   /** The lorebook currently embedded in the character card (character owners only). */
   embeddedLorebookId?: string | null;
+  /** True when the card's single character_book slot is already occupied (may be an unpointered baked book). */
+  slotOccupied?: boolean;
+  /** Called after a successful embed so the parent editor can patch its local state. */
+  onEmbedded?: (result: { lorebookId: string; characterBook: unknown }) => void;
 }
 
 interface AssignmentDraft {
@@ -76,6 +80,8 @@ export function LorebookAssignmentSection({
   ownerId,
   ownerName,
   embeddedLorebookId,
+  slotOccupied,
+  onEmbedded,
 }: LorebookAssignmentSectionProps) {
   const openModal = useUIStore((state) => state.openModal);
   const openLorebookDetail = useUIStore((state) => state.openLorebookDetail);
@@ -88,6 +94,7 @@ export function LorebookAssignmentSection({
     if (!ownerId) return;
     try {
       const res = await embedLorebook.mutateAsync({ characterId: ownerId, lorebookId: lorebook.id });
+      onEmbedded?.({ lorebookId: lorebook.id, characterBook: res.characterBook });
       toast.success(res.refreshed ? `Refreshed embedded ${lorebook.name}.` : `Embedded ${lorebook.name} into the card.`);
     } catch (error) {
       toast.error(error instanceof Error ? error.message : "Failed to embed lorebook.");
@@ -256,7 +263,7 @@ export function LorebookAssignmentSection({
                         Refresh
                       </button>
                     </>
-                  ) : embeddedLorebookId ? (
+                  ) : embeddedLorebookId || slotOccupied ? (
                     <button
                       type="button"
                       disabled

--- a/packages/client/src/components/lorebooks/LorebookAssignmentSection.tsx
+++ b/packages/client/src/components/lorebooks/LorebookAssignmentSection.tsx
@@ -10,7 +10,7 @@ import {
   type LorebookScopeMode,
 } from "@marinara-engine/shared";
 import { useChats } from "../../hooks/use-chats";
-import { useLorebooks, useUpdateLorebook } from "../../hooks/use-lorebooks";
+import { useEmbedLorebook, useLorebooks, useUpdateLorebook } from "../../hooks/use-lorebooks";
 import { DEFAULT_LOREBOOK_SCOPE, normalizeLorebookScope } from "../../lib/lorebook-scope";
 import { cn } from "../../lib/utils";
 import { useUIStore } from "../../stores/ui.store";
@@ -22,6 +22,8 @@ interface LorebookAssignmentSectionProps {
   ownerType: LorebookOwnerType;
   ownerId: string | null;
   ownerName: string;
+  /** The lorebook currently embedded in the character card (character owners only). */
+  embeddedLorebookId?: string | null;
 }
 
 interface AssignmentDraft {
@@ -69,12 +71,28 @@ function matchesOwnerChat(chat: Chat, ownerType: LorebookOwnerType, ownerId: str
   return chat.personaId === ownerId;
 }
 
-export function LorebookAssignmentSection({ ownerType, ownerId, ownerName }: LorebookAssignmentSectionProps) {
+export function LorebookAssignmentSection({
+  ownerType,
+  ownerId,
+  ownerName,
+  embeddedLorebookId,
+}: LorebookAssignmentSectionProps) {
   const openModal = useUIStore((state) => state.openModal);
   const openLorebookDetail = useUIStore((state) => state.openLorebookDetail);
   const { data: lorebooks = [], isLoading } = useLorebooks("character");
   const { data: chats = [] } = useChats();
   const updateLorebook = useUpdateLorebook();
+  const embedLorebook = useEmbedLorebook();
+
+  const handleEmbed = async (lorebook: Lorebook) => {
+    if (!ownerId) return;
+    try {
+      const res = await embedLorebook.mutateAsync({ characterId: ownerId, lorebookId: lorebook.id });
+      toast.success(res.refreshed ? `Refreshed embedded ${lorebook.name}.` : `Embedded ${lorebook.name} into the card.`);
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : "Failed to embed lorebook.");
+    }
+  };
   const [draft, setDraft] = useState<AssignmentDraft | null>(null);
 
   const eligibleChats = useMemo(
@@ -222,6 +240,42 @@ export function LorebookAssignmentSection({ ownerType, ownerId, ownerName }: Lor
                 >
                   Scope
                 </button>
+                {ownerType === "character" &&
+                  (lorebook.id === embeddedLorebookId ? (
+                    <>
+                      <span className="rounded-lg bg-emerald-500/15 px-2 py-1 text-[0.625rem] font-medium text-emerald-500">
+                        Embedded
+                      </span>
+                      <button
+                        type="button"
+                        onClick={() => handleEmbed(lorebook)}
+                        disabled={embedLorebook.isPending}
+                        className="rounded-lg px-2 py-1 text-[0.625rem] font-medium text-[var(--muted-foreground)] transition-colors hover:bg-[var(--accent)] hover:text-[var(--foreground)] disabled:opacity-50"
+                        title="Rewrite the card's embedded copy from this lorebook's current entries"
+                      >
+                        Refresh
+                      </button>
+                    </>
+                  ) : embeddedLorebookId ? (
+                    <button
+                      type="button"
+                      disabled
+                      className="cursor-not-allowed rounded-lg px-2 py-1 text-[0.625rem] font-medium text-[var(--muted-foreground)] opacity-50"
+                      title="Remove the current embedded lorebook first"
+                    >
+                      Embed into card
+                    </button>
+                  ) : (
+                    <button
+                      type="button"
+                      onClick={() => handleEmbed(lorebook)}
+                      disabled={embedLorebook.isPending}
+                      className="rounded-lg px-2 py-1 text-[0.625rem] font-medium text-[var(--primary)] transition-colors hover:bg-[var(--primary)]/15 disabled:opacity-50"
+                      title="Write this lorebook into the character card so it exports with the character"
+                    >
+                      Embed into card
+                    </button>
+                  ))}
                 <button
                   type="button"
                   onClick={() => unassignLorebook(lorebook)}

--- a/packages/client/src/components/lorebooks/LorebookAssignmentSection.tsx
+++ b/packages/client/src/components/lorebooks/LorebookAssignmentSection.tsx
@@ -28,6 +28,8 @@ interface LorebookAssignmentSectionProps {
   slotOccupied?: boolean;
   /** Called after a successful embed so the parent editor can patch its local state. */
   onEmbedded?: (result: { lorebookId: string; characterBook: unknown }) => void;
+  /** Reports embed/refresh progress so the parent editor can block racing saves. */
+  onEmbeddingChange?: (embedding: boolean) => void;
 }
 
 interface AssignmentDraft {
@@ -82,6 +84,7 @@ export function LorebookAssignmentSection({
   embeddedLorebookId,
   slotOccupied,
   onEmbedded,
+  onEmbeddingChange,
 }: LorebookAssignmentSectionProps) {
   const openModal = useUIStore((state) => state.openModal);
   const openLorebookDetail = useUIStore((state) => state.openLorebookDetail);
@@ -92,12 +95,15 @@ export function LorebookAssignmentSection({
 
   const handleEmbed = async (lorebook: Lorebook) => {
     if (!ownerId) return;
+    onEmbeddingChange?.(true);
     try {
       const res = await embedLorebook.mutateAsync({ characterId: ownerId, lorebookId: lorebook.id });
       onEmbedded?.({ lorebookId: lorebook.id, characterBook: res.characterBook });
       toast.success(res.refreshed ? `Refreshed embedded ${lorebook.name}.` : `Embedded ${lorebook.name} into the card.`);
     } catch (error) {
       toast.error(error instanceof Error ? error.message : "Failed to embed lorebook.");
+    } finally {
+      onEmbeddingChange?.(false);
     }
   };
   const [draft, setDraft] = useState<AssignmentDraft | null>(null);

--- a/packages/client/src/hooks/use-lorebooks.ts
+++ b/packages/client/src/hooks/use-lorebooks.ts
@@ -153,6 +153,22 @@ export function useCreateLorebook() {
   });
 }
 
+export function useEmbedLorebook() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: ({ characterId, lorebookId }: { characterId: string; lorebookId: string }) =>
+      api.post<{ success: boolean; lorebookId: string; entriesEmbedded: number; refreshed: boolean }>(
+        `/characters/${characterId}/embedded-lorebook/embed`,
+        { lorebookId },
+      ),
+    onSuccess: (_data, variables) => {
+      qc.invalidateQueries({ queryKey: lorebookKeys.all });
+      qc.invalidateQueries({ queryKey: lorebookKeys.active() });
+      qc.invalidateQueries({ queryKey: characterKeys.detail(variables.characterId) });
+    },
+  });
+}
+
 export function useUpdateLorebook() {
   const qc = useQueryClient();
   return useMutation({

--- a/packages/client/src/hooks/use-lorebooks.ts
+++ b/packages/client/src/hooks/use-lorebooks.ts
@@ -157,7 +157,7 @@ export function useEmbedLorebook() {
   const qc = useQueryClient();
   return useMutation({
     mutationFn: ({ characterId, lorebookId }: { characterId: string; lorebookId: string }) =>
-      api.post<{ success: boolean; lorebookId: string; entriesEmbedded: number; refreshed: boolean }>(
+      api.post<{ success: boolean; lorebookId: string; entriesEmbedded: number; refreshed: boolean; characterBook: unknown }>(
         `/characters/${characterId}/embedded-lorebook/embed`,
         { lorebookId },
       ),

--- a/packages/server/src/routes/characters.routes.ts
+++ b/packages/server/src/routes/characters.routes.ts
@@ -1403,14 +1403,17 @@ export async function charactersRoutes(app: FastifyInstance) {
       const char = await storage.getById(req.params.id);
       if (!char) return reply.status(404).send({ error: "Character not found" });
 
-      const lorebooksStorage = createLorebooksStorage(app.db);
       const lorebook = (await lorebooksStorage.getById(lorebookId)) as Record<string, unknown> | null;
       if (!lorebook) return reply.status(404).send({ error: "Lorebook not found" });
 
       // A character card only carries a character-scoped book. Persona
       // lorebooks are identified by persona links and have no card slot.
       const personaIds = Array.isArray(lorebook.personaIds) ? (lorebook.personaIds as unknown[]) : [];
-      if (personaIds.length > 0 || typeof lorebook.personaId === "string") {
+      if (
+        personaIds.length > 0 ||
+        typeof lorebook.personaId === "string" ||
+        (typeof lorebook.category === "string" && lorebook.category !== "character")
+      ) {
         return reply.status(400).send({ error: "Only character lorebooks can be embedded into a character card." });
       }
 
@@ -1444,6 +1447,7 @@ export async function charactersRoutes(app: FastifyInstance) {
         lorebookId,
         entriesEmbedded: result.entriesEmbedded,
         refreshed: result.refreshed,
+        characterBook: result.characterBook,
       };
     },
   );

--- a/packages/server/src/routes/characters.routes.ts
+++ b/packages/server/src/routes/characters.routes.ts
@@ -47,6 +47,7 @@ import { assertInsideDir, extensionFromImageMime, isAllowedImageBuffer } from ".
 import { logger } from "../lib/logger.js";
 import { parseLibraryPageQuery } from "../utils/list-pagination.js";
 import { importSTLorebook } from "../services/import/st-lorebook.importer.js";
+import { embedLorebookIntoCharacter, getEmbeddedLorebookId } from "../services/lorebook/character-book-sync.js";
 import AdmZip from "adm-zip";
 import { extname } from "path";
 import { pipeline } from "stream/promises";
@@ -1388,6 +1389,64 @@ export async function charactersRoutes(app: FastifyInstance) {
       reimported: result.reimported ?? false,
     };
   });
+
+  // Embed a standalone/linked character lorebook INTO this character's card
+  // (data.character_book) so it exports with the card — the inverse of the
+  // import above. Writes the lorebook's current entries and the forward
+  // pointer; future /lorebooks edits then keep the embedded copy in sync.
+  app.post<{ Params: { id: string }; Body: { lorebookId?: string } }>(
+    "/:id/embedded-lorebook/embed",
+    async (req, reply) => {
+      const lorebookId = typeof req.body?.lorebookId === "string" ? req.body.lorebookId.trim() : "";
+      if (!lorebookId) return reply.status(400).send({ error: "lorebookId is required" });
+
+      const char = await storage.getById(req.params.id);
+      if (!char) return reply.status(404).send({ error: "Character not found" });
+
+      const lorebooksStorage = createLorebooksStorage(app.db);
+      const lorebook = (await lorebooksStorage.getById(lorebookId)) as Record<string, unknown> | null;
+      if (!lorebook) return reply.status(404).send({ error: "Lorebook not found" });
+
+      // A character card only carries a character-scoped book. Persona
+      // lorebooks are identified by persona links and have no card slot.
+      const personaIds = Array.isArray(lorebook.personaIds) ? (lorebook.personaIds as unknown[]) : [];
+      if (personaIds.length > 0 || typeof lorebook.personaId === "string") {
+        return reply.status(400).send({ error: "Only character lorebooks can be embedded into a character card." });
+      }
+
+      // A card has a single character_book slot. Allow only when the slot is
+      // empty or already belongs to this lorebook (refresh); never clobber a
+      // different embedded book or an unpointered baked snapshot.
+      const charData = JSON.parse(char.data) as Record<string, unknown>;
+      const currentEmbeddedId = getEmbeddedLorebookId(charData);
+      const existingBook = charData.character_book as { entries?: unknown[] } | null | undefined;
+      const hasBook = (Array.isArray(existingBook?.entries) ? existingBook!.entries!.length : 0) > 0;
+      const slotBelongsToThis = currentEmbeddedId === lorebookId;
+      const slotEmpty = !currentEmbeddedId && !hasBook;
+      if (!slotBelongsToThis && !slotEmpty) {
+        return reply
+          .status(409)
+          .send({ error: "This character already has an embedded lorebook. Remove it first, then embed this one." });
+      }
+
+      // Ensure the book is linked to this character so it auto-activates and
+      // stays live-syncable — additively (union), never replacing other links.
+      const linkedIds = Array.isArray(lorebook.characterIds) ? (lorebook.characterIds as string[]) : [];
+      if (!linkedIds.includes(req.params.id)) {
+        await lorebooksStorage.update(lorebookId, {
+          characterIds: Array.from(new Set([...linkedIds, req.params.id])),
+        });
+      }
+
+      const result = await embedLorebookIntoCharacter(app.db, req.params.id, lorebookId);
+      return {
+        success: true,
+        lorebookId,
+        entriesEmbedded: result.entriesEmbedded,
+        refreshed: result.refreshed,
+      };
+    },
+  );
 
   // ── Export as PNG ──
 

--- a/packages/server/src/routes/characters.routes.ts
+++ b/packages/server/src/routes/characters.routes.ts
@@ -1422,8 +1422,7 @@ export async function charactersRoutes(app: FastifyInstance) {
       // different embedded book or an unpointered baked snapshot.
       const charData = JSON.parse(char.data) as Record<string, unknown>;
       const currentEmbeddedId = getEmbeddedLorebookId(charData);
-      const existingBook = charData.character_book as { entries?: unknown[] } | null | undefined;
-      const hasBook = (Array.isArray(existingBook?.entries) ? existingBook!.entries!.length : 0) > 0;
+      const hasBook = charData.character_book !== null && charData.character_book !== undefined;
       const slotBelongsToThis = currentEmbeddedId === lorebookId;
       const slotEmpty = !currentEmbeddedId && !hasBook;
       if (!slotBelongsToThis && !slotEmpty) {
@@ -1435,13 +1434,26 @@ export async function charactersRoutes(app: FastifyInstance) {
       // Ensure the book is linked to this character so it auto-activates and
       // stays live-syncable — additively (union), never replacing other links.
       const linkedIds = Array.isArray(lorebook.characterIds) ? (lorebook.characterIds as string[]) : [];
-      if (!linkedIds.includes(req.params.id)) {
+      const linkAdded = !linkedIds.includes(req.params.id);
+      if (linkAdded) {
         await lorebooksStorage.update(lorebookId, {
           characterIds: Array.from(new Set([...linkedIds, req.params.id])),
         });
       }
 
-      const result = await embedLorebookIntoCharacter(app.db, req.params.id, lorebookId);
+      let result: Awaited<ReturnType<typeof embedLorebookIntoCharacter>>;
+      try {
+        result = await embedLorebookIntoCharacter(app.db, req.params.id, lorebookId);
+      } catch (err) {
+        if (linkAdded) {
+          try {
+            await lorebooksStorage.update(lorebookId, { characterIds: linkedIds });
+          } catch (rollbackErr) {
+            logger.error(rollbackErr, "Failed to roll back lorebook link after embedded lorebook write failed");
+          }
+        }
+        throw err;
+      }
       return {
         success: true,
         lorebookId,

--- a/packages/server/src/routes/lorebooks.routes.ts
+++ b/packages/server/src/routes/lorebooks.routes.ts
@@ -40,6 +40,7 @@ import { parseGameStateRow, resolveVisibleGameStateAnchor } from "./generate/gen
 import {
   syncCharacterBookFromLorebook,
   clearCharacterEmbeddedLorebook,
+  resolveEmbeddedCharacterId,
 } from "../services/lorebook/character-book-sync.js";
 import { createLLMProvider } from "../services/llm/provider-registry.js";
 import { getLocalSidecarProvider, LOCAL_SIDECAR_MODEL } from "../services/llm/local-sidecar.js";
@@ -479,12 +480,13 @@ export async function lorebooksRoutes(app: FastifyInstance) {
   });
 
   app.delete<{ Params: { id: string } }>("/:id", async (req, reply) => {
-    // Capture the linked characterId BEFORE removal — once the row is gone
-    // we can no longer recover it, and the character still holds a stale
-    // pointer at extensions.importMetadata.embeddedLorebook that needs
-    // clearing alongside the V2 character_book mirror.
-    const lorebook = (await storage.getById(req.params.id)) as Record<string, unknown> | null;
-    const linkedCharacterId = lorebook && typeof lorebook.characterId === "string" ? lorebook.characterId : null;
+    // Resolve the embedding character BEFORE removal — once the row is gone we
+    // can no longer recover it, and the character still holds a pointer at
+    // extensions.importMetadata.embeddedLorebook that needs clearing alongside
+    // the V2 character_book mirror. Resolve via the authoritative forward
+    // pointer (not the lorebook's alphabetically-first link) so a book embedded
+    // into a non-first-linked character is cleared from the right card.
+    const linkedCharacterId = await resolveEmbeddedCharacterId(app.db, req.params.id);
 
     const chatsStorage = createChatsStorage(app.db);
     await chatsStorage.removeLorebookFromChatMetadata(req.params.id);

--- a/packages/server/src/services/lorebook/character-book-sync.ts
+++ b/packages/server/src/services/lorebook/character-book-sync.ts
@@ -18,8 +18,10 @@
 // These helpers mirror standalone-lorebook mutations back into the
 // character's `data.character_book` so the two stores stay coherent.
 
+import { like } from "drizzle-orm";
 import type { DB } from "../../db/connection.js";
 import type { CharacterBook, CharacterBookEntry } from "@marinara-engine/shared";
+import { characters } from "../../db/schema/index.js";
 import { createLorebooksStorage } from "../storage/lorebooks.storage.js";
 import { createCharactersStorage } from "../storage/characters.storage.js";
 import { logger } from "../../lib/logger.js";
@@ -101,7 +103,7 @@ function toCharacterBookEntry(entry: LoreEntryRow, index: number): CharacterBook
   };
 }
 
-function toCharacterBook(lorebook: LorebookRow, entries: LoreEntryRow[]): CharacterBook {
+export function toCharacterBook(lorebook: LorebookRow, entries: LoreEntryRow[]): CharacterBook {
   return {
     name: asString(lorebook.name, "Character Lorebook"),
     description: asString(lorebook.description),
@@ -118,7 +120,7 @@ function parseCharacterData(data: unknown): Record<string, unknown> {
   return data && typeof data === "object" ? (data as Record<string, unknown>) : {};
 }
 
-function getEmbeddedLorebookId(characterData: Record<string, unknown>): string | null {
+export function getEmbeddedLorebookId(characterData: Record<string, unknown>): string | null {
   const extensions =
     characterData.extensions && typeof characterData.extensions === "object"
       ? (characterData.extensions as Record<string, unknown>)
@@ -135,12 +137,108 @@ function getEmbeddedLorebookId(characterData: Record<string, unknown>): string |
 }
 
 /**
+ * Resolve which character actually embeds this lorebook — the one whose
+ * `extensions.importMetadata.embeddedLorebook.lorebookId` names it (the
+ * authoritative forward pointer).
+ *
+ * The lorebook's hydrated `characterId` is only the alphabetically-first
+ * *linked* character (lorebooks.storage `parseLorebookRow`), which is not
+ * necessarily the embedding one for a lorebook linked to several characters.
+ * So it is used only as a fast path — confirmed against the forward pointer
+ * (identical to the previous behaviour, and the only case for the single-link
+ * import path) — before falling back to a prefiltered scan. The `LIKE` is a
+ * cheap prefilter on a unique lorebook id; `getEmbeddedLorebookId` is the
+ * authority.
+ */
+export async function resolveEmbeddedCharacterId(
+  db: DB,
+  lorebookId: string,
+  lorebookHint?: LorebookRow | null,
+): Promise<string | null> {
+  const charactersStorage = createCharactersStorage(db);
+
+  const lorebook =
+    lorebookHint ?? ((await createLorebooksStorage(db).getById(lorebookId)) as LorebookRow | null);
+  const derived = typeof lorebook?.characterId === "string" ? lorebook.characterId : null;
+  if (derived) {
+    const character = await charactersStorage.getById(derived);
+    if (character && getEmbeddedLorebookId(parseCharacterData(character.data)) === lorebookId) {
+      return derived;
+    }
+  }
+
+  const rows = await db.select().from(characters).where(like(characters.data, `%"${lorebookId}"%`));
+  for (const row of rows) {
+    if (getEmbeddedLorebookId(parseCharacterData(row.data)) === lorebookId) return row.id;
+  }
+  return null;
+}
+
+/**
+ * Embed a standalone/linked character lorebook INTO a character's card: write
+ * its current entries to `data.character_book` and set the
+ * `extensions.importMetadata.embeddedLorebook` forward pointer, so the lorebook
+ * travels with the card on export and future edits keep syncing. The inverse of
+ * the embedded-lorebook import (card → standalone). Eligibility (category,
+ * already-occupied slot) is gated by the caller; this is a pure writer.
+ *
+ * `refreshed` is true when the character already embedded this same lorebook —
+ * the write regenerates `character_book` from the lorebook's *current* entries.
+ */
+export async function embedLorebookIntoCharacter(
+  db: DB,
+  characterId: string,
+  lorebookId: string,
+): Promise<{ entriesEmbedded: number; refreshed: boolean }> {
+  const lorebookStorage = createLorebooksStorage(db);
+  const lorebook = (await lorebookStorage.getById(lorebookId)) as LorebookRow | null;
+  if (!lorebook) throw new Error("Lorebook not found");
+
+  const charactersStorage = createCharactersStorage(db);
+  const character = await charactersStorage.getById(characterId);
+  if (!character) throw new Error("Character not found");
+
+  const currentData = parseCharacterData(character.data);
+  const refreshed = getEmbeddedLorebookId(currentData) === lorebookId;
+
+  const entries = (await lorebookStorage.listEntries(lorebookId)) as LoreEntryRow[];
+  const nextBook = toCharacterBook(lorebook, entries);
+
+  // Read-modify-write the extensions subtree (the storage layer only shallow-
+  // merges CharacterData), preserving sibling importMetadata/extension keys.
+  const extensions =
+    currentData.extensions && typeof currentData.extensions === "object"
+      ? ({ ...(currentData.extensions as Record<string, unknown>) } as Record<string, unknown>)
+      : {};
+  const importMetadata =
+    extensions.importMetadata && typeof extensions.importMetadata === "object"
+      ? ({ ...(extensions.importMetadata as Record<string, unknown>) } as Record<string, unknown>)
+      : {};
+  const existingEmbedded =
+    importMetadata.embeddedLorebook && typeof importMetadata.embeddedLorebook === "object"
+      ? (importMetadata.embeddedLorebook as Record<string, unknown>)
+      : {};
+  importMetadata.embeddedLorebook = { ...existingEmbedded, hasEmbeddedLorebook: true, lorebookId };
+  extensions.importMetadata = importMetadata;
+
+  await charactersStorage.update(
+    characterId,
+    { character_book: nextBook, extensions: extensions as never },
+    undefined,
+    { skipVersionSnapshot: true },
+  );
+
+  return { entriesEmbedded: nextBook.entries.length, refreshed };
+}
+
+/**
  * Mirror the current state of a standalone lorebook into its source
- * character's `data.character_book`. No-op when the lorebook has no
- * `characterId`, or when the character's embedded-lorebook metadata does
- * not point at this lorebook. Ordinary character-scoped lorebooks also use
- * `characterId` for auto-activation, but they must not overwrite the V2
- * embedded `character_book`.
+ * character's `data.character_book`. No-op when no character embeds this
+ * lorebook (via the authoritative forward pointer), or when the resolved
+ * character's embedded-lorebook metadata does not point at this lorebook.
+ * Ordinary character-scoped lorebooks also use `characterId` for
+ * auto-activation, but they must not overwrite the V2 embedded
+ * `character_book`.
  *
  * Sync errors are logged but never thrown — the user's primary mutation
  * (entry create/update/delete) has already succeeded by the time this is
@@ -151,7 +249,7 @@ export async function syncCharacterBookFromLorebook(db: DB, lorebookId: string):
     const lorebookStorage = createLorebooksStorage(db);
     const lorebook = (await lorebookStorage.getById(lorebookId)) as LorebookRow | null;
     if (!lorebook) return;
-    const characterId = typeof lorebook.characterId === "string" ? lorebook.characterId : null;
+    const characterId = await resolveEmbeddedCharacterId(db, lorebookId, lorebook);
     if (!characterId) return;
 
     const charactersStorage = createCharactersStorage(db);

--- a/packages/server/src/services/lorebook/character-book-sync.ts
+++ b/packages/server/src/services/lorebook/character-book-sync.ts
@@ -116,8 +116,14 @@ export function toCharacterBook(lorebook: LorebookRow, entries: LoreEntryRow[]):
 }
 
 function parseCharacterData(data: unknown): Record<string, unknown> {
-  if (typeof data === "string") return JSON.parse(data) as Record<string, unknown>;
-  return data && typeof data === "object" ? (data as Record<string, unknown>) : {};
+  try {
+    if (typeof data === "string") return JSON.parse(data) as Record<string, unknown>;
+    return data && typeof data === "object" ? (data as Record<string, unknown>) : {};
+  } catch {
+    // A corrupt character row must not abort a lorebook mutation or delete —
+    // treat it as having no embedded pointer.
+    return {};
+  }
 }
 
 export function getEmbeddedLorebookId(characterData: Record<string, unknown>): string | null {
@@ -167,6 +173,14 @@ export async function resolveEmbeddedCharacterId(
     }
   }
 
+  // Only a lorebook linked to MORE THAN ONE character can be embedded in a
+  // character other than its derived (first-linked) one; for 0/1 links the fast
+  // path above is authoritative, so skip the table scan. This keeps the common
+  // path (world lorebooks, single-linked character lorebooks) scan-free —
+  // identical cost to the pre-fix behaviour.
+  const linkCount = Array.isArray(lorebook?.characterIds) ? (lorebook.characterIds as unknown[]).length : 0;
+  if (linkCount <= 1) return null;
+
   const rows = await db.select().from(characters).where(like(characters.data, `%"${lorebookId}"%`));
   for (const row of rows) {
     if (getEmbeddedLorebookId(parseCharacterData(row.data)) === lorebookId) return row.id;
@@ -189,7 +203,7 @@ export async function embedLorebookIntoCharacter(
   db: DB,
   characterId: string,
   lorebookId: string,
-): Promise<{ entriesEmbedded: number; refreshed: boolean }> {
+): Promise<{ entriesEmbedded: number; refreshed: boolean; characterBook: CharacterBook }> {
   const lorebookStorage = createLorebooksStorage(db);
   const lorebook = (await lorebookStorage.getById(lorebookId)) as LorebookRow | null;
   if (!lorebook) throw new Error("Lorebook not found");
@@ -228,7 +242,7 @@ export async function embedLorebookIntoCharacter(
     { skipVersionSnapshot: true },
   );
 
-  return { entriesEmbedded: nextBook.entries.length, refreshed };
+  return { entriesEmbedded: nextBook.entries.length, refreshed, characterBook: nextBook };
 }
 
 /**

--- a/packages/server/src/services/lorebook/character-book-sync.ts
+++ b/packages/server/src/services/lorebook/character-book-sync.ts
@@ -117,8 +117,8 @@ export function toCharacterBook(lorebook: LorebookRow, entries: LoreEntryRow[]):
 
 function parseCharacterData(data: unknown): Record<string, unknown> {
   try {
-    if (typeof data === "string") return JSON.parse(data) as Record<string, unknown>;
-    return data && typeof data === "object" ? (data as Record<string, unknown>) : {};
+    const parsed = typeof data === "string" ? JSON.parse(data) : data;
+    return parsed && typeof parsed === "object" && !Array.isArray(parsed) ? (parsed as Record<string, unknown>) : {};
   } catch {
     // A corrupt character row must not abort a lorebook mutation or delete —
     // treat it as having no embedded pointer.


### PR DESCRIPTION
## Linked issue

Closes #3341.

## Why this change

Character cards can carry an **embedded** lorebook (V2 `data.character_book`) that exports with the card, but there was no way to *create* that from inside Marinara. A lorebook attached via **Assign Lorebook** is only *linked* — a separate row referenced by the character — and linked lorebooks are **not** written into the card, so they get dropped on export (`/characters/:id/export` serializes `charData` as-is). The only characters that exported with a working lorebook were ones imported with an embedded book already; anything you authored couldn't be shared as a self-contained card.

## What changed

Adds an **"Embed into card"** action — the inverse of the existing *Import Embedded Lorebook* (card → standalone). After embedding, the lorebook exports with the character (native + compatible) and future `/lorebooks` edits keep the embedded copy in sync, exactly like an imported embedded book.

**Server**
- `character-book-sync.ts`: export the existing `toCharacterBook`; add `embedLorebookIntoCharacter` (writes `character_book` + the `extensions.importMetadata.embeddedLorebook` forward pointer in one atomic, `skipVersionSnapshot` update) and `resolveEmbeddedCharacterId`.
- `POST /characters/:id/embedded-lorebook/embed` with guards: reject persona / non-`character`-category books (400); refuse to clobber a *different* embedded book in the single `character_book` slot (409); additively **union** the character into the lorebook's links (never a bare replace) so it auto-activates and stays syncable. Returns the written `character_book`.

**Latent bug fixed in the same area** (this touches the recently-fixed embedded-lorebook sync — #554/#1551/#2971): `syncCharacterBookFromLorebook` and the lorebook `DELETE` resolved the target character from the lorebook's *hydrated* `characterId`, which is only the **alphabetically-first linked** character — wrong for a book linked to several characters. Both now resolve the embedding character via the authoritative forward pointer (`resolveEmbeddedCharacterId`). It's fast-path-first (the derived id, identical to the old behaviour on the common single-link path) and only scans the characters table when the book has **>1** character link — so world / single-linked lorebook edits stay scan-free.

**Client**
- `useEmbedLorebook` hook.
- An **"Embed into card"** / **"Embedded" + "Refresh"** / disabled-when-slot-taken affordance on assigned character lorebooks, gated to character owners (personas never show it). On embed, the editor patches its local `formData` from the returned `character_book` so a dirty editor's next Save can't revert the embed.

### Hardening from an adversarial self-review (2nd commit)
- **Silent-data-loss fix:** embedding while the editor was dirty could let a later Save send stale pre-embed data and revert the write — now the editor patches `formData` on embed.
- Kept the sync path scan-free on the common case (only >1-link books scan).
- `parseCharacterData` is `try/catch`-guarded so a corrupt character row can't 500 a lorebook delete.
- Client affordance matches the server 409 (disabled when the slot holds an unpointered baked book).

### Accepted limitation (documented, not silent)
There's no reverse lorebook→characters index, so two cards *can* each embed the same standalone book (e.g. via character duplication, or embedding a book already embedded elsewhere). Each keeps its own `character_book` snapshot; a later entry edit refreshes the first forward-pointer match, so a second card's copy can drift until its **Refresh**. This matches the pre-existing multi-embed behaviour; a real exclusivity index is follow-up scope.

## Validation

- [ ] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed `CONTRIBUTING.md`

### Manual verification notes

Done by the agent:
- Server typecheck (`tsc -b ../shared && tsc --noEmit`), shared typecheck, client build (`tsc -b && vite build`), and client ESLint all pass.
- ⚠️ Full `pnpm check` currently fails at the **server build** step on Windows — a **pre-existing v2.1.0 bug** in `packages/server/scripts/build.mjs` (spawns Node via an unquoted `"C:\Program Files\…"` path), reproduced on clean `staging` with this branch's changes stashed. Not caused by this PR; flagged separately.

Still needs manual verification (no automated server test suite in-repo):
- **Embed (empty slot):** assign a 3-entry character lorebook, click *Embed into card* → toast, row shows *Embedded*; reopen the character → `character_book` has 3 entries; export the card → the lorebook is present.
- **Dirty-editor safety:** edit a character field, *Embed into card*, then **Save** → the embed survives (character_book + pointer intact, not reverted).
- **Refresh:** edit an entry via *Edit Linked Lorebook*, click *Refresh* → `character_book` reflects the edit.
- **Reject different / persona:** with book A embedded, *Embed* on book B is disabled (server 409s); a persona lorebook is 400-rejected via direct API.
- **Multi-link preserved:** a lorebook linked to X and Y (Y alphabetically first), embed into X → links still contain both X and Y (not collapsed), and adding an entry then reopening X shows it in `character_book` (regression: the old code synced to Y).
- **Delete/clear:** delete a lorebook embedded into a non-first-linked character → that card's `character_book` and pointer are cleared.
- **Personas unaffected:** a persona editor's lorebook section shows no embed/refresh/badge.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Version/release files updated (only if this PR includes a version bump)

## UI evidence (if applicable)

New per-lorebook affordance on the character Lorebook tab: *Embed into card* → *Embedded* + *Refresh*. No other visual change. (Screenshots to be added on manual verification.)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Characters can now embed a lorebook directly into a card from the editor.
  * The lorebook list now shows embed status and offers embed/refresh actions for character cards.

* **Bug Fixes**
  * Improved handling of embedded lorebooks when a character has unsaved edits, so changes are preserved correctly.
  * Lorebook updates and removals now stay in sync more reliably, even when a lorebook is linked to multiple characters.
  * Better resilience when character data is malformed, preventing related actions from failing unexpectedly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->