### PR TITLE
Remove manual group transcript prompt

### DIFF
--- a/packages/server/src/routes/generate.routes.ts
+++ b/packages/server/src/routes/generate.routes.ts
@@ -5260,29 +5260,6 @@ export async function generateRoutes(app: FastifyInstance) {
             `You may address ${personaName} or another character if that is what the context calls for, but do not speak or act for them.`,
           ].join("\n");
         };
-        const buildManualGroupRecentTranscript = (targetCharId: string) => {
-          if (!isGroupChat || groupResponseOrder !== "manual" || !targetCharId) return null;
-          const recentLines = chatMessages
-            .filter((message: any) => message.role === "user" || message.role === "assistant")
-            .slice(-12)
-            .map((message: any) => {
-              const speaker = resolveMessageSpeakerName(message);
-              const text = stripConversationPromptTimestamps(conversationPromptHistoryContent(message, chatMode))
-                .replace(/\s+/g, " ")
-                .trim()
-                .slice(0, 1200);
-              return text ? `${speaker}: ${text}` : "";
-            })
-            .filter(Boolean);
-          if (recentLines.length === 0) return null;
-          return [
-            `Recent visible group transcript for this manual character trigger:`,
-            `<recent_group_transcript>`,
-            recentLines.join("\n"),
-            `</recent_group_transcript>`,
-            `Use this transcript as the current scene context. Do not restart the chat, ignore the user's latest visible reply, or answer from lorebook/profile content alone.`,
-          ].join("\n");
-        };
 
         if (useIndividualLoop) {
           // Individual group mode: generate one response per character
@@ -5306,10 +5283,6 @@ export async function generateRoutes(app: FastifyInstance) {
             // Append "Respond ONLY as [name]" instruction
             const charInstruction = buildCharacterInstruction(charId, charName);
             const messagesWithInstruction = [...filterManualTargetProfileBlocks(runningMessages, charId)];
-            const manualTranscript = buildManualGroupRecentTranscript(charId);
-            if (manualTranscript) {
-              messagesWithInstruction.push({ role: "system", content: manualTranscript });
-            }
             // Add as a system message at the end (just before any trailing user message)
             if (charInstruction) {
               messagesWithInstruction.push({ role: "system", content: charInstruction });
@@ -5364,12 +5337,6 @@ export async function generateRoutes(app: FastifyInstance) {
 
           if (generationGuideInstruction) {
             sentMessages.push({ role: "system", content: generationGuideInstruction });
-          }
-          if (targetCharId) {
-            const manualTranscript = buildManualGroupRecentTranscript(targetCharId);
-            if (manualTranscript) {
-              sentMessages.push({ role: "system", content: manualTranscript });
-            }
           }
 
           if (mentionedConversationCharacters.length > 0 && !regenGroupChatIndividual) {

--- a/scripts/regressions/prompt.regression.ts
+++ b/scripts/regressions/prompt.regression.ts
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
 import {
   applyRegexReplacement,
   buildNarratorInstructionMessage,
@@ -591,6 +592,25 @@ const cases: RegressionCase[] = [
       assert.match(instruction, /Dottore reassuring Mari/);
       assert.equal(instruction.includes("{{user}}"), false);
       assert.equal(instruction.includes("{{char}}"), false);
+    },
+  },
+  {
+    name: "manual group generation does not inject a duplicate recent transcript prompt",
+    run() {
+      const routeSource = readFileSync(
+        new URL("../../packages/server/src/routes/generate.routes.ts", import.meta.url),
+        "utf8",
+      );
+      const forbiddenFragments = [
+        ["recent", "_group", "_transcript"].join(""),
+        ["Recent visible", " group transcript"].join(""),
+        ["ignore the user's latest", " visible reply"].join(""),
+        ["buildManual", "GroupRecent", "Transcript"].join(""),
+      ];
+
+      for (const fragment of forbiddenFragments) {
+        assert.equal(routeSource.includes(fragment), false, `${fragment} must not be present in generate.routes.ts`);
+      }
     },
   },
   {


### PR DESCRIPTION
## Linked issue

No linked issue yet. This was opened as an urgent prompt-pipeline bugfix from maintainer/user report; an issue should be opened or linked before this PR is submitted for review.

## Why this change

Manual group character triggers were appending a hidden duplicated recent transcript system block to the generation prompt. That block could override the normal chat history and included an instruction to ignore the latest visible reply, causing characters to respond to stale or confusing context.

## What changed

- Removed the manual group recent transcript prompt builder from generation routing.
- Removed both prompt insertion points that appended the hidden `<recent_group_transcript>` block.
- Added a prompt regression guard so the duplicate transcript prompt and exact leaked instruction do not return unnoticed.

## Validation

- [ ] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed `CONTRIBUTING.md`

### Manual verification notes

Automated checks run locally by Codex:

- `rg "recent_group_transcript|Recent visible group transcript|manual character trigger|ignore the user's latest visible reply|buildManualGroupRecentTranscript|buildManualGroupTranscriptInstruction" packages scripts` returned no matches.
- `pnpm regression:prompt` passed.
- `pnpm check` passed.

No browser/manual click-through was performed; this is a server prompt assembly change with a regression guard.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Version/release files updated (only if this PR includes a version bump)

Prompt behavior only; no user-facing docs or release metadata updated.

## UI evidence (if applicable)

Not applicable; no UI changes.
