### PR TITLE
fix(lorebooks): preserve nested folders on native import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 - Added Lorebook entry-status sorting, fixed continued assistant messages so appended text starts after a blank line, and removed the obsolete tracked `pr-evidence/` artifacts while ignoring future evidence folders (#3336).
 - Fixed Conversation-created scene chats so their Prompt Preset selector remains visible while still defaulting to None, and native Character/Persona exports now include attached lorebooks that re-import linked to the new owner.
 - Made the Connections panel's unfiled/root drop area more forgiving so desktop users, including Windows users, can reliably drag connections out of folders without hitting a tiny target.
+- Fixed native lorebook import so nested folders keep their parent/child hierarchy instead of being flattened to the top level (#3347).
 
 ## [2.1.0]
 

--- a/packages/server/src/db/schema/lorebooks.ts
+++ b/packages/server/src/db/schema/lorebooks.ts
@@ -65,8 +65,9 @@ export const lorebookPersonaLinks = sqliteTable(
 
 /**
  * Lorebook folders — collapsible containers that group entries to reduce
- * visual clutter in the editor. Folders are flat in v1; `parentFolderId` is
- * reserved (always null) for a future nested-folder PR. When a folder's
+ * visual clutter in the editor. Folders may nest via `parentFolderId`
+ * (`null` = a root-level folder; see `canReparentFolder` / `buildFolderForest`
+ * in shared for the tree rules). When a folder's
  * `enabled` flag is "false", every entry whose `folderId` matches is
  * excluded from activation regardless of the entry's own enabled flag —
  * gating happens at `listActiveEntries` time, not by mutating entry rows.
@@ -79,7 +80,7 @@ export const lorebookFolders = sqliteTable("lorebook_folders", {
   name: text("name").notNull(),
   /** SQLite-style "true"/"false" string, matches the rest of this schema. */
   enabled: text("enabled").notNull().default("true"),
-  /** Reserved for future nesting; always NULL in v1. */
+  /** Parent folder for nesting; NULL for a root-level folder. */
   parentFolderId: text("parent_folder_id"),
   /** Display order among sibling folders (lower = higher in the list). */
   order: integer("order").notNull().default(0),

--- a/packages/server/src/services/import/marinara.importer.ts
+++ b/packages/server/src/services/import/marinara.importer.ts
@@ -3,6 +3,7 @@
 // ──────────────────────────────────────────────
 import type { DB } from "../../db/connection.js";
 import {
+  canReparentFolder,
   getFolderImportEntries,
   getFolderManifestConfig,
   isJsonRecord,
@@ -495,20 +496,49 @@ async function importLorebookPayload(data: unknown, db: DB, owner?: BundledLoreb
     readTimestampOverrides(lb),
   )) as Record<string, unknown> | null;
 
-  // Re-create folders first so we can remap old folder IDs → new folder IDs
-  // before mapping entries. Older exports without `folders` simply skip this
-  // step and every entry lands at root.
+  // Re-create folders in two passes so nesting survives the round-trip. A child
+  // folder can be listed before its parent, so pass 1 creates every folder at
+  // root and builds the old-ID → new-ID remap; pass 2 re-parents each folder
+  // through that remap. Every move is validated with canReparentFolder (the same
+  // guard the PATCH route uses), so a malformed/hand-edited export can never
+  // persist a cycle — an unresolvable or cyclic parent just leaves that folder at
+  // root. Older exports without `folders` skip both passes and entries land at root.
   const folderIdRemap = new Map<string, string>();
   if (newLb && Array.isArray(d.folders) && d.folders.length > 0) {
+    const lorebookId = newLb.id as string;
+    // Pass 1 — create at root, remembering each folder's exported parent (old ID).
+    const pendingReparents: Array<{ newId: string; oldParentId: string }> = [];
     for (const f of d.folders) {
       const oldId = typeof f.id === "string" ? f.id : null;
-      const created = (await storage.createFolder(newLb.id as string, {
+      const created = (await storage.createFolder(lorebookId, {
         name: String(f.name ?? "Folder"),
         enabled: f.enabled !== false,
-        parentFolderId: null, // v1 ignores nesting on import
+        parentFolderId: null,
         order: Number(f.order ?? 0),
       })) as Record<string, unknown> | null;
-      if (oldId && created?.id) folderIdRemap.set(oldId, created.id as string);
+      const newId = created?.id;
+      if (oldId && typeof newId === "string") {
+        folderIdRemap.set(oldId, newId);
+        const oldParentId = typeof f.parentFolderId === "string" ? f.parentFolderId : null;
+        if (oldParentId) pendingReparents.push({ newId, oldParentId });
+      }
+    }
+    // Pass 2 — re-parent through the remap. `folderRows` mirrors the DB state so
+    // canReparentFolder sees each applied move; an invalid move (dangling or
+    // cyclic parent) is skipped, leaving that folder at root like the editor does.
+    const folderRows = Array.from(folderIdRemap.values()).map((id) => ({
+      id,
+      lorebookId,
+      parentFolderId: null as string | null,
+    }));
+    const rowById = new Map(folderRows.map((row) => [row.id, row]));
+    for (const { newId, oldParentId } of pendingReparents) {
+      const newParentId = folderIdRemap.get(oldParentId);
+      if (!newParentId) continue; // parent wasn't part of the export → leave at root
+      if (!canReparentFolder(folderRows, newId, newParentId).ok) continue;
+      await storage.updateFolder(newId, { parentFolderId: newParentId }, lorebookId);
+      const row = rowById.get(newId);
+      if (row) row.parentFolderId = newParentId;
     }
   }
 

--- a/packages/server/src/services/storage/lorebooks.storage.ts
+++ b/packages/server/src/services/storage/lorebooks.storage.ts
@@ -963,7 +963,8 @@ export function createLorebooksStorage(db: DB) {
         lorebookId,
         name: input.name,
         enabled: String(input.enabled ?? true),
-        // v1 ignores any non-null parentFolderId — caller is the route layer.
+        // Honors input.parentFolderId (null = root); the route layer validates
+        // the parent (exists, same lorebook, no cycle) before calling.
         parentFolderId: input.parentFolderId ?? null,
         order,
         createdAt: timestamp,

--- a/packages/shared/src/schemas/lorebook.schema.ts
+++ b/packages/shared/src/schemas/lorebook.schema.ts
@@ -84,10 +84,11 @@ function addLorebookScopeConflictIssues(value: LorebookScopeConflictInput, ctx: 
 }
 
 // ──────────────────────────────────────────────
-// Folders — collapsible containers for entries
-// `parentFolderId` is reserved for a future nested-folder PR; v1 enforces
-// `null` at the route layer so the schema accepts the field but the server
-// rejects non-null values.
+// Folders — collapsible containers for entries.
+// Folders may nest via `parentFolderId` (`null` = a root-level folder). The
+// POST route verifies the parent exists in the same lorebook; PATCH validates
+// the full move (no self-parent, same lorebook, no descendant cycle) via
+// `canReparentFolder` before persisting.
 // ──────────────────────────────────────────────
 export const createLorebookFolderSchema = z.object({
   name: z.string().min(1).max(200),


### PR DESCRIPTION
## Linked issue

Closes #3347

## Why this change

Lorebook folders can be **nested** — you drag one folder into another in the editor, the server validates the move with `canReparentFolder`, and `cloneFolder` deep-copies subtrees. A native (`.marinara.json`) lorebook export records every folder's `parentFolderId`, so the nesting is present in the exported file. But the importer hardcoded `parentFolderId: null`, so on import every nested folder was flattened to the top level — silently losing structure the user built. This hits the standalone lorebook native round-trip (and any path through `importLorebookPayload`).

## What changed

- `packages/server/src/services/import/marinara.importer.ts` — folder restore is now **two passes**: pass 1 creates every folder at root and builds the old→new id remap (a child can be listed before its parent, so parents can't be set inline); pass 2 re-parents each folder through the remap. Every move is validated with `canReparentFolder` (the same guard the folder `PATCH` route uses), so a malformed or hand-edited export can never persist a cycle — an unresolvable or cyclic parent just leaves that folder at root, matching the editor's `buildFolderForest` behavior.
- Refreshed four now-stale comments that claimed folders are "flat in v1 / reserved / always null": the DB schema (`db/schema/lorebooks.ts`), the canonical shared Zod folder schema (`packages/shared/src/schemas/lorebook.schema.ts`), `createFolder` in `lorebooks.storage.ts`, and the importer. Nesting shipped after those comments were written.

No schema or API change. Entries' folder assignment already round-tripped correctly (via the same `folderIdRemap`) and is unchanged.

## Validation

- [ ] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed `CONTRIBUTING.md`

### Manual verification notes

- Server typecheck passes locally: `pnpm --filter @marinara-engine/server lint` (tsc). Full `pnpm check` is blocked on Windows by the pre-existing v2.1.0 `build.mjs` execPath spawn bug, which is unrelated to this change.
- Manually verify in-app: create a lorebook, make a folder "Cities" and nest it inside "Locations", export in **Native** format, import into a fresh instance, and confirm "Cities" is still nested inside "Locations" (not a root-level sibling).
- Manually verify an **older** export (no `folders`, or folders without `parentFolderId`) still imports with all entries at root and no error.
- Manually verify a hand-edited export containing a **cyclic** `parentFolderId` imports without hanging — the cyclic folder lands at root.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Version/release files updated (only if this PR includes a version bump)

CHANGELOG updated with a Fixed entry. No version bump.

## UI evidence (if applicable)

N/A — server-side import logic; no UI change.
