### PR TITLE
fix(lorebooks): stop exporting linked lorebooks in native format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,7 +41,7 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 - Fixed Grok CLI (Subscription) connections so they no longer seed stale `grok-build-*` model aliases, can use the local CLI default model with a blank model field, and fetch selectable model IDs from `grok models`.
 - Fixed Grok CLI (Subscription) roleplay requests by preferring the safe headless Composer model when discovered, starting Grok CLI connections with a safer 32k context window, and surfacing a clearer context-limit hint when the CLI reports `max turns reached`.
 - Added Lorebook entry-status sorting, fixed continued assistant messages so appended text starts after a blank line, and removed the obsolete tracked `pr-evidence/` artifacts while ignoring future evidence folders (#3336).
-- Fixed Conversation-created scene chats so their Prompt Preset selector remains visible while still defaulting to None, and native Character/Persona exports now include attached lorebooks that re-import linked to the new owner.
+- Fixed Conversation-created scene chats so their Prompt Preset selector remains visible while still defaulting to None.
 - Made the Connections panel's unfiled/root drop area more forgiving so desktop users, including Windows users, can reliably drag connections out of folders without hitting a tiny target.
 
 ## [2.1.0]

--- a/packages/server/src/routes/characters.routes.ts
+++ b/packages/server/src/routes/characters.routes.ts
@@ -19,7 +19,6 @@ import { createPersonaGalleryStorage } from "../services/storage/persona-gallery
 import { createChatsStorage } from "../services/storage/chats.storage.js";
 import { createGameSceneVideosStorage } from "../services/storage/game-scene-videos.storage.js";
 import { createConnectionsStorage } from "../services/storage/connections.storage.js";
-import { createLorebooksStorage } from "../services/storage/lorebooks.storage.js";
 import { generateImage } from "../services/image/image-generation.js";
 import { resolveConnectionImageDefaults } from "../services/image/image-generation-defaults.js";
 import { loadImageGenerationUserSettings } from "../services/image/image-generation-settings.js";
@@ -373,12 +372,6 @@ async function resolveAvatarGenerationConnection(app: FastifyInstance, body: Ava
 }
 
 type ExportFormat = "native" | "compatible";
-type LorebooksStore = ReturnType<typeof createLorebooksStorage>;
-type NativeLorebookBundle = {
-  lorebook: Record<string, unknown>;
-  entries: Array<Record<string, unknown>>;
-  folders: Array<Record<string, unknown>>;
-};
 
 // Read an image file and return it as a base64 data URL, or null if the file
 // is missing, outside the expected dir, or not a recognized image type. Used
@@ -463,50 +456,15 @@ async function readGalleryForCharacter(
   return result;
 }
 
-async function readAttachedLorebooksForCharacter(
-  characterId: string,
-  lorebooksStorage: LorebooksStore,
-): Promise<NativeLorebookBundle[]> {
-  const books = (await lorebooksStorage.listByCharacter(characterId)) as Array<Record<string, unknown>>;
-  return readLorebookBundles(books, lorebooksStorage);
-}
-
-async function readAttachedLorebooksForPersona(
-  personaId: string,
-  lorebooksStorage: LorebooksStore,
-): Promise<NativeLorebookBundle[]> {
-  const books = (await lorebooksStorage.listByPersona(personaId)) as Array<Record<string, unknown>>;
-  return readLorebookBundles(books, lorebooksStorage);
-}
-
-async function readLorebookBundles(
-  books: Array<Record<string, unknown>>,
-  lorebooksStorage: LorebooksStore,
-): Promise<NativeLorebookBundle[]> {
-  const bundles: NativeLorebookBundle[] = [];
-  for (const lorebook of books) {
-    const id = typeof lorebook.id === "string" ? lorebook.id : "";
-    if (!id) continue;
-    const [entries, folders] = await Promise.all([
-      lorebooksStorage.listEntries(id) as Promise<Array<Record<string, unknown>>>,
-      lorebooksStorage.listFolders(id) as Promise<Array<Record<string, unknown>>>,
-    ]);
-    bundles.push({ lorebook, entries, folders });
-  }
-  return bundles;
-}
-
 async function buildNativeCharacterEnvelope(
   char: { id: string; createdAt: string; updatedAt: string; comment?: string | null; avatarPath?: string | null },
   data: any,
   galleryStorage: { listByCharacterId: (id: string) => Promise<any[]> },
-  lorebooksStorage: LorebooksStore,
 ) {
-  const [avatar, sprites, gallery, lorebooks] = await Promise.all([
+  const [avatar, sprites, gallery] = await Promise.all([
     readAvatarDataUrl(char.avatarPath),
     readSpritesForId(char.id),
     readGalleryForCharacter(char.id, galleryStorage),
-    readAttachedLorebooksForCharacter(char.id, lorebooksStorage),
   ]);
   return {
     type: "marinara_character",
@@ -519,7 +477,6 @@ async function buildNativeCharacterEnvelope(
       ...(avatar ? { avatar } : {}),
       ...(sprites.length > 0 ? { sprites } : {}),
       ...(gallery.length > 0 ? { gallery } : {}),
-      ...(lorebooks.length > 0 ? { lorebooks } : {}),
       metadata: {
         createdAt: char.createdAt,
         updatedAt: char.updatedAt,
@@ -537,13 +494,12 @@ function buildCompatibleCharacterExport(data: any) {
   };
 }
 
-async function buildNativePersonaEnvelope(persona: Record<string, unknown>, lorebooksStorage: LorebooksStore) {
+async function buildNativePersonaEnvelope(persona: Record<string, unknown>) {
   const { id: _id, createdAt, updatedAt, avatarPath, isActive: _isActive, ...personaData } = persona;
   const personaId = typeof _id === "string" ? _id : "";
-  const [avatar, sprites, lorebooks] = await Promise.all([
+  const [avatar, sprites] = await Promise.all([
     readAvatarDataUrl(typeof avatarPath === "string" ? avatarPath : null),
     personaId ? readSpritesForId(personaId) : Promise.resolve([] as Array<{ filename: string; data: string }>),
-    personaId ? readAttachedLorebooksForPersona(personaId, lorebooksStorage) : Promise.resolve([]),
   ]);
   return {
     type: "marinara_persona",
@@ -553,7 +509,6 @@ async function buildNativePersonaEnvelope(persona: Record<string, unknown>, lore
       ...personaData,
       ...(avatar ? { avatar } : {}),
       ...(sprites.length > 0 ? { sprites } : {}),
-      ...(lorebooks.length > 0 ? { lorebooks } : {}),
       metadata: {
         createdAt,
         updatedAt,
@@ -586,7 +541,6 @@ export async function charactersRoutes(app: FastifyInstance) {
   const storage = createCharactersStorage(app.db);
   const characterGallery = createCharacterGalleryStorage(app.db);
   const personaGallery = createPersonaGalleryStorage(app.db);
-  const lorebooksStorage = createLorebooksStorage(app.db);
 
   // ── Characters ──
 
@@ -1280,7 +1234,7 @@ export async function charactersRoutes(app: FastifyInstance) {
     const compatible = req.query.format === "compatible";
     const payload = compatible
       ? buildCompatibleCharacterExport(charData)
-      : await buildNativeCharacterEnvelope(char, charData, characterGallery, lorebooksStorage);
+      : await buildNativeCharacterEnvelope(char, charData, characterGallery);
     return reply
       .header(
         "Content-Disposition",
@@ -1304,7 +1258,7 @@ export async function charactersRoutes(app: FastifyInstance) {
       const payload =
         format === "compatible"
           ? buildCompatibleCharacterExport(charData)
-          : await buildNativeCharacterEnvelope(char, charData, characterGallery, lorebooksStorage);
+          : await buildNativeCharacterEnvelope(char, charData, characterGallery);
       zip.addFile(
         `${toSafeExportName(String(charData.name ?? "character"), `character-${exportedCount + 1}`)}.${format === "compatible" ? "json" : "marinara.json"}`,
         Buffer.from(JSON.stringify(payload, null, 2), "utf-8"),
@@ -2119,7 +2073,7 @@ export async function charactersRoutes(app: FastifyInstance) {
       const compatible = req.query.format === "compatible";
       const payload = compatible
         ? buildCompatiblePersonaExport(persona as Record<string, unknown>)
-        : await buildNativePersonaEnvelope(persona as Record<string, unknown>, lorebooksStorage);
+        : await buildNativePersonaEnvelope(persona as Record<string, unknown>);
       return reply
         .header(
           "Content-Disposition",
@@ -2143,7 +2097,7 @@ export async function charactersRoutes(app: FastifyInstance) {
       const payload =
         format === "compatible"
           ? buildCompatiblePersonaExport(persona as Record<string, unknown>)
-          : await buildNativePersonaEnvelope(persona as Record<string, unknown>, lorebooksStorage);
+          : await buildNativePersonaEnvelope(persona as Record<string, unknown>);
       zip.addFile(
         `${toSafeExportName(String(persona.name ?? "persona"), `persona-${exportedCount + 1}`)}.${format === "compatible" ? "json" : "marinara.json"}`,
         Buffer.from(JSON.stringify(payload, null, 2), "utf-8"),

--- a/packages/server/src/services/import/marinara.importer.ts
+++ b/packages/server/src/services/import/marinara.importer.ts
@@ -204,11 +204,6 @@ const VALID_MATCHING_SOURCES = new Set<LorebookMatchingSource>([
   "persona_tags",
 ]);
 
-type BundledLorebookOwner = {
-  characterId?: string;
-  personaId?: string;
-};
-
 function readMatchingSources(value: unknown): LorebookMatchingSource[] {
   if (!Array.isArray(value)) return [];
   return value.filter((source): source is LorebookMatchingSource =>
@@ -285,7 +280,6 @@ async function importCharacter(data: unknown, db: DB) {
     avatar?: unknown;
     sprites?: unknown;
     gallery?: unknown;
-    lorebooks?: unknown;
   };
   const charData = d?.data ? { ...(d.data as Record<string, unknown>) } : undefined;
   const metadata = d?.metadata && typeof d.metadata === "object" ? (d.metadata as Record<string, unknown>) : null;
@@ -347,7 +341,6 @@ async function importCharacter(data: unknown, db: DB) {
     }
     await restoreSprites(d.sprites, result.id);
     await restoreCharacterGallery(d.gallery, result.id, galleryStorage);
-    await importBundledLorebooks(d.lorebooks, db, { characterId: result.id });
   }
   return {
     success: true,
@@ -418,7 +411,6 @@ async function importPersona(data: unknown, db: DB) {
       await storage.updatePersona(result.id, { avatarPath });
     }
     await restoreSprites(d.sprites, result.id);
-    await importBundledLorebooks(d.lorebooks, db, { personaId: result.id });
   }
   return {
     success: true,
@@ -434,14 +426,7 @@ async function importLorebook(data: unknown, db: DB) {
   return importLorebookPayload(data, db);
 }
 
-async function importBundledLorebooks(lorebooks: unknown, db: DB, owner: BundledLorebookOwner): Promise<void> {
-  if (!Array.isArray(lorebooks) || lorebooks.length === 0) return;
-  for (const lorebook of lorebooks) {
-    await importLorebookPayload(lorebook, db, owner);
-  }
-}
-
-async function importLorebookPayload(data: unknown, db: DB, owner?: BundledLorebookOwner) {
+async function importLorebookPayload(data: unknown, db: DB) {
   const storage = createLorebooksStorage(db);
   const d = data as {
     lorebook?: Record<string, unknown>;
@@ -452,8 +437,6 @@ async function importLorebookPayload(data: unknown, db: DB, owner?: BundledLoreb
     return { success: false, type: "marinara_lorebook" as const, error: "Invalid lorebook data" };
   }
   const lb = d.lorebook;
-  const ownerCharacterIds = owner?.characterId ? [owner.characterId] : null;
-  const ownerPersonaIds = owner?.personaId ? [owner.personaId] : null;
   const newLb = (await storage.create(
     {
       name: String(lb.name ?? "Imported Lorebook"),
@@ -468,24 +451,20 @@ async function importLorebookPayload(data: unknown, db: DB, owner?: BundledLoreb
       vectorQueryDepth: Number(lb.vectorQueryDepth ?? 10),
       vectorScoreThreshold: Number(lb.vectorScoreThreshold ?? 0.3),
       vectorMaxResults: Number(lb.vectorMaxResults ?? 10),
-      characterId: owner ? null : typeof lb.characterId === "string" ? lb.characterId : null,
-      characterIds: owner
-        ? (ownerCharacterIds ?? [])
-        : Array.isArray(lb.characterIds)
-          ? lb.characterIds.filter((value): value is string => typeof value === "string")
-          : typeof lb.characterId === "string"
-            ? [lb.characterId]
-            : [],
-      personaId: owner ? null : typeof lb.personaId === "string" ? lb.personaId : null,
-      personaIds: owner
-        ? (ownerPersonaIds ?? [])
-        : Array.isArray(lb.personaIds)
-          ? lb.personaIds.filter((value): value is string => typeof value === "string")
-          : typeof lb.personaId === "string"
-            ? [lb.personaId]
-            : [],
-      chatId: owner ? null : typeof lb.chatId === "string" ? lb.chatId : null,
-      isGlobal: owner ? false : lb.isGlobal === true || lb.isGlobal === "true",
+      characterId: typeof lb.characterId === "string" ? lb.characterId : null,
+      characterIds: Array.isArray(lb.characterIds)
+        ? lb.characterIds.filter((value): value is string => typeof value === "string")
+        : typeof lb.characterId === "string"
+          ? [lb.characterId]
+          : [],
+      personaId: typeof lb.personaId === "string" ? lb.personaId : null,
+      personaIds: Array.isArray(lb.personaIds)
+        ? lb.personaIds.filter((value): value is string => typeof value === "string")
+        : typeof lb.personaId === "string"
+          ? [lb.personaId]
+          : [],
+      chatId: typeof lb.chatId === "string" ? lb.chatId : null,
+      isGlobal: lb.isGlobal === true || lb.isGlobal === "true",
       enabled: lb.enabled !== false,
       scope: readLorebookScope(lb.scope),
       tags: Array.isArray(lb.tags) ? lb.tags.map(String) : [],


### PR DESCRIPTION
## Linked issue

Closes #3345

## Why this change

#3342 made native Character/Persona export bundle every **linked (assigned)** lorebook and re-link it on import. Linked lorebooks are shared, standalone entities — they are not supposed to travel with a card in any format. The bundling forks a genuinely-shared lorebook into a private copy on every import (a "World Rules" book assigned to 3 characters becomes a fresh copy per imported character, while the original is untouched), and it exports an embedded lorebook **twice** (once as `character_book`, once as the bundle — the double-count reported in #3344). Only an embedded lorebook (`data.character_book`) should export with a card; the intended, user-driven way to bake a lorebook in is **Embed into card** (#3341 / #3343). Compatible export already carried only `character_book`, so this restores native export to match.

## What changed

- `packages/server/src/routes/characters.routes.ts` — removed the native-export lorebook bundling added in #3342: the `createLorebooksStorage` import, the `LorebooksStore`/`NativeLorebookBundle` types, the `readAttachedLorebooksForCharacter` / `readAttachedLorebooksForPersona` / `readLorebookBundles` helpers, the `lorebooksStorage` param + `Promise.all` entry + `lorebooks` spread in both native envelope builders, the module-level `lorebooksStorage` const, and all four call-site args. This file is now identical to its pre-#3342 state.
- `packages/server/src/services/import/marinara.importer.ts` — removed `importBundledLorebooks` and its two call sites in `importCharacter`/`importPersona`, plus the `owner`-threading in `importLorebookPayload` (ownership links revert to being read from the lorebook's own exported fields, exactly as before #3342). Kept the harmless `importLorebook → importLorebookPayload` split so this change stays in a different region of the function than #3347's folder-nesting fix — avoiding a needless conflict between the two PRs.
- CHANGELOG — dropped the "native … exports now include attached lorebooks" clause from #3342's (unreleased) 2.1.1 entry; the scene-preset clause is untouched.
- Scene-preset and Connections-panel changes from #3342 live in client files and are **not** touched here.
- Supersedes #3344 (the embedded double-count is one symptom of the same root cause).
- Rebase note for reviewers: the in-flight embed PR #3343 adds an "Embed into card" endpoint to `characters.routes.ts` that reintroduces a module-level `lorebooksStorage` (+ `createLorebooksStorage` import). If #3345 merges first, #3343 rebases to re-add them; if #3343 merges first, #3345 keeps that const/import (still used by embed) and removes only the bundling. Called out so the merge order is intentional, not a mistake.

## Validation

- [ ] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed `CONTRIBUTING.md`

### Manual verification notes

- Server typecheck passes locally: `pnpm --filter @marinara-engine/server lint` (tsc). Full `pnpm check` is blocked on Windows by the pre-existing v2.1.0 `build.mjs` execPath spawn bug, unrelated to this change.
- Manually verify: assign a shared lorebook to two characters, export character A in **Native** format, and confirm the `.marinara.json` no longer contains a top-level `lorebooks` bundle; import into a fresh instance and confirm no forked standalone lorebook is created.
- Manually verify: a character with an **embedded** lorebook (`character_book`) still exports and re-imports its embedded book exactly once (no duplicate assigned row).
- Manually verify: a native file exported during the #3342 window (which carries a `lorebooks` bundle) still imports the character/persona successfully, with the stray bundle simply ignored (no crash).

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Version/release files updated (only if this PR includes a version bump)

CHANGELOG updated (edited the #3342 2.1.1 entry). No version bump.

## UI evidence (if applicable)

N/A — server-side export/import logic; no UI change.
