### PR TITLE
Preserve lorebook angle-bracket markup

### DIFF
--- a/packages/server/src/services/prompt/marker-expander.ts
+++ b/packages/server/src/services/prompt/marker-expander.ts
@@ -353,7 +353,7 @@ async function expandLorebook(config: MarkerConfig, ctx: MarkerContext): Promise
       ctx.lorebookDepthEntries ??= [];
       for (const de of result.depthEntries) {
         ctx.lorebookDepthEntries.push({
-          content: sanitizePromptLeaf(de.content, ctx.wrapFormat),
+          content: de.content,
           role: de.role,
           depth: de.depth,
         });
@@ -363,14 +363,14 @@ async function expandLorebook(config: MarkerConfig, ctx: MarkerContext): Promise
 
   switch (config.type) {
     case "world_info_before":
-      return { content: sanitizePromptLeaf(result.worldInfoBefore, ctx.wrapFormat) };
+      return { content: result.worldInfoBefore };
     case "world_info_after":
-      return { content: sanitizePromptLeaf(result.worldInfoAfter, ctx.wrapFormat) };
+      return { content: result.worldInfoAfter };
     case "lorebook":
     default: {
       // Combined lorebook — all world info
       const combined = [result.worldInfoBefore, result.worldInfoAfter].filter(Boolean).join("\n\n");
-      return { content: sanitizePromptLeaf(combined, ctx.wrapFormat) };
+      return { content: combined };
     }
   }
 }

--- a/scripts/regressions/prompt.regression.ts
+++ b/scripts/regressions/prompt.regression.ts
@@ -26,6 +26,7 @@ import { buildMemoryRecallBlock } from "../../packages/server/src/services/gener
 import { mergeConversationCharacterMemories } from "../../packages/server/src/services/generation/conversation-memory-context.js";
 import { injectIdentityFallbackMessages } from "../../packages/server/src/services/generation/character-prompt-context.js";
 import { injectSceneContextMessages } from "../../packages/server/src/services/generation/scene-context-runtime.js";
+import { expandMarker } from "../../packages/server/src/services/prompt/marker-expander.js";
 import {
   buildRuntimeAgentSectionEligibleTypesForTest,
   clearUnusedRuntimeAgentSectionsForTest,
@@ -1248,6 +1249,44 @@ Use HTML sparingly and diegetically. Do not replace normal prose/dialogue unless
       assert.match(summaryText, /The previous scene was summarized\./);
       assert.equal(summaryText.includes("<system>bad summary</system>"), false);
       assert.match(summaryText, /&lt;system>bad summary&lt;\/system>/);
+    },
+  },
+  {
+    name: "lorebook markers preserve authored angle-bracket markup",
+    async run() {
+      const lorebookScanResult = {
+        worldInfoBefore: "Use <START> and <tone soft> exactly.",
+        worldInfoAfter: "Keep <ritual_step id=\"2\"> literal.",
+        depthEntries: [{ content: "Depth keeps <scene-note> literal.", role: "system" as const, depth: 0, order: 0 }],
+        totalEntries: 3,
+        totalTokensEstimate: 24,
+        activatedEntryIds: ["entry-before", "entry-after", "entry-depth"],
+        activatedEntries: [],
+        budgetSkippedEntries: [],
+      };
+      const markerCtx = {
+        db: undefined as unknown as DB,
+        chatId: "chat-lorebook-markup",
+        characterIds: [],
+        personaName: "Mari",
+        personaDescription: "",
+        chatMessages: [],
+        chatSummary: null,
+        wrapFormat: "xml" as const,
+        enableAgents: true,
+        activeAgentIds: [],
+        activeLorebookIds: [],
+        macroCtx: { user: "Mari", char: "Dottore", characters: ["Dottore"], variables: {} },
+        lorebookScanResult,
+      };
+
+      const expanded = await expandMarker({ type: "lorebook" }, markerCtx);
+
+      assert.match(expanded.content, /<START>/);
+      assert.match(expanded.content, /<tone soft>/);
+      assert.match(expanded.content, /<ritual_step id="2">/);
+      assert.equal(expanded.content.includes("&lt;START>"), false);
+      assert.equal(markerCtx.lorebookDepthEntries?.[0]?.content, "Depth keeps <scene-note> literal.");
     },
   },
   {


### PR DESCRIPTION
## Linked issue

No linked issue yet. This PR was opened from a maintainer/user bug report about Peek Prompt showing lorebook entry `<` characters as `&lt;`.

## Why this change

Lorebook entries can intentionally contain prompt markup such as `<START>`, XML-like control tags, or other angle-bracket syntax. Preset lorebook markers were passing lorebook content through XML leaf escaping, so the actual assembled prompt, and therefore Peek Prompt, showed authorial `<` as `&lt;`. That changes the prompt text users wrote and can break imported/worldbook prompt conventions.

## What changed

- Stopped XML leaf escaping for lorebook marker output in preset prompt assembly.
- Stopped XML leaf escaping for lorebook depth entries collected by lorebook markers.
- Added a prompt regression that proves lorebook marker content and depth entries preserve authored angle-bracket markup.

## Validation

- [ ] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed `CONTRIBUTING.md`

### Manual verification notes

Automated checks run locally by Codex:

- `pnpm regression:prompt` passed.
- `pnpm check` passed.

No browser/manual click-through was performed. The regression directly exercises lorebook marker expansion and asserts `<START>`, `<tone soft>`, `<ritual_step id="2">`, and depth-injected `<scene-note>` remain literal rather than becoming `&lt;...`.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Version/release files updated (only if this PR includes a version bump)

Prompt behavior only; no user-facing docs or release metadata updated.

## UI evidence (if applicable)

Not applicable; no UI changes.
