### PR TITLE
Add roleplay TTS volume controls and editor chroma overlays

### DIFF
--- a/packages/client/src/components/chat/ChatArea.tsx
+++ b/packages/client/src/components/chat/ChatArea.tsx
@@ -516,6 +516,7 @@ export function ChatArea() {
   const intuitiveSwipeNavigation = useUIStore((s) => s.intuitiveSwipeNavigation);
   const intuitiveSwipeRerollLatest = useUIStore((s) => s.intuitiveSwipeRerollLatest);
   const editLastMessageOnArrowUp = useUIStore((s) => s.editLastMessageOnArrowUp);
+  const ttsLineVolume = useUIStore((s) => s.ttsLineVolume);
   const messagesEndRef = useRef<HTMLDivElement>(null);
   const scrollRef = useRef<HTMLDivElement>(null);
   const prevScrollHeightRef = useRef(0);
@@ -2278,8 +2279,9 @@ export function ChatArea() {
 
     void ttsService.speakSequence(withTTSVoiceRequestCacheKeys(ttsRequests, cfg, lastMsg.id), lastMsg.id, {
       progressive: cfg.progressivePlayback,
+      volume: ttsLineVolume / 100,
     });
-  }, [characterMap, isStreaming, resolveTTSCharacterId]);
+  }, [characterMap, isStreaming, resolveTTSCharacterId, ttsLineVolume]);
 
   const newestMsgId = msgData?.pages[0]?.[msgData.pages[0].length - 1]?.id;
   const newestMsgSwipeIndex = msgData?.pages[0]?.[msgData.pages[0].length - 1]?.activeSwipeIndex;

--- a/packages/client/src/components/chat/ChatMessage.tsx
+++ b/packages/client/src/components/chat/ChatMessage.tsx
@@ -32,6 +32,8 @@ import {
   Languages,
   Volume2,
   VolumeX,
+  Mic,
+  MicOff,
   Loader2,
   Pause,
   Play,
@@ -936,6 +938,8 @@ export const ChatMessage = memo(function ChatMessage({
     boldDialogue,
     editMessageOnDoubleClick,
     quoteFormat,
+    ttsLineVolume,
+    setTTSLineVolume,
   } = useUIStore(
     useShallow((s) => ({
       chatFontSize: s.chatFontSize,
@@ -953,6 +957,8 @@ export const ChatMessage = memo(function ChatMessage({
       boldDialogue: s.boldDialogue ?? true,
       editMessageOnDoubleClick: s.editMessageOnDoubleClick,
       quoteFormat: s.quoteFormat,
+      ttsLineVolume: s.ttsLineVolume,
+      setTTSLineVolume: s.setTTSLineVolume,
     })),
   );
   const isGuided = guideGenerations && hasDraftInput;
@@ -1099,6 +1105,20 @@ export const ChatMessage = memo(function ChatMessage({
   const isSpeakingThis = ttsActiveId === message.id;
   const isLoadingThis = isSpeakingThis && ttsState === "loading";
   const isPausedThis = isSpeakingThis && ttsState === "paused";
+  const ttsLinePlaybackVolume = ttsLineVolume / 100;
+
+  useEffect(() => {
+    if (ttsActiveId !== message.id) return;
+    ttsService.setCurrentPlaybackVolume(ttsLinePlaybackVolume);
+  }, [message.id, ttsActiveId, ttsLinePlaybackVolume, ttsState]);
+
+  const handleTTSLineVolumeChange = useCallback(
+    (volume: number) => {
+      setTTSLineVolume(volume);
+      ttsService.setCurrentPlaybackVolume(volume / 100);
+    },
+    [setTTSLineVolume],
+  );
 
   const handleSpeak = useCallback(() => {
     // Read directly from the singleton so we never act on stale React state
@@ -1111,9 +1131,12 @@ export const ChatMessage = memo(function ChatMessage({
       ttsService.stop();
     } else {
       if (!hasTTSContent) return;
-      void ttsService.speakSequence(ttsVoiceRequests, message.id, { progressive: ttsConfig?.progressivePlayback });
+      void ttsService.speakSequence(ttsVoiceRequests, message.id, {
+        progressive: ttsConfig?.progressivePlayback,
+        volume: ttsLinePlaybackVolume,
+      });
     }
-  }, [hasTTSContent, message.id, ttsConfig?.progressivePlayback, ttsVoiceRequests]);
+  }, [hasTTSContent, message.id, ttsConfig?.progressivePlayback, ttsLinePlaybackVolume, ttsVoiceRequests]);
 
   const handlePauseResumeTTS = useCallback(() => {
     if (ttsService.getActiveId() !== message.id) return;
@@ -2430,9 +2453,9 @@ export const ChatMessage = memo(function ChatMessage({
                       isLoadingThis ? (
                         <Loader2 size={MESSAGE_ACTION_ICON_SIZE} className="animate-spin" />
                       ) : isSpeakingThis ? (
-                        <VolumeX size={MESSAGE_ACTION_ICON_SIZE} />
+                        <MicOff size={MESSAGE_ACTION_ICON_SIZE} />
                       ) : (
-                        <Volume2 size={MESSAGE_ACTION_ICON_SIZE} />
+                        <Mic size={MESSAGE_ACTION_ICON_SIZE} />
                       )
                     }
                     onClick={handleSpeak}
@@ -2448,6 +2471,7 @@ export const ChatMessage = memo(function ChatMessage({
                     disabled={!hasTTSContent || (ttsBusy && !isSpeakingThis)}
                     dark
                   />
+                  <TTSLineVolumeControl volume={ttsLineVolume} onVolumeChange={handleTTSLineVolumeChange} dark />
                 </>
               )}
             </div>
@@ -2944,6 +2968,97 @@ function ThinkingModal({ thinking, onClose }: { thinking: string; onClose: () =>
   );
 }
 
+function TTSLineVolumeControl({
+  volume,
+  onVolumeChange,
+  dark,
+}: {
+  volume: number;
+  onVolumeChange: (volume: number) => void;
+  dark?: boolean;
+}) {
+  const [open, setOpen] = useState(false);
+  const wrapperRef = useRef<HTMLDivElement | null>(null);
+  const muted = volume <= 0;
+  const label = `Line volume: ${volume}%`;
+
+  useEffect(() => {
+    if (!open) return;
+
+    const handlePointerDown = (event: PointerEvent) => {
+      if (wrapperRef.current?.contains(event.target as Node)) return;
+      setOpen(false);
+    };
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") setOpen(false);
+    };
+
+    document.addEventListener("pointerdown", handlePointerDown, true);
+    document.addEventListener("keydown", handleKeyDown);
+    return () => {
+      document.removeEventListener("pointerdown", handlePointerDown, true);
+      document.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [open]);
+
+  return (
+    <div ref={wrapperRef} className="relative inline-flex">
+      {open && (
+        <div
+          role="dialog"
+          aria-label="Line volume"
+          className={cn(
+            "absolute bottom-full left-1/2 z-40 mb-2 flex w-44 max-w-[calc(100vw-1.5rem)] -translate-x-1/2 flex-col gap-2.5 rounded-lg border p-2.5 shadow-xl",
+            dark
+              ? "border-[var(--marinara-chat-chrome-panel-border)] bg-[var(--marinara-chat-chrome-panel-bg)] text-[var(--marinara-chat-chrome-panel-title)] shadow-black/30"
+              : "border-[var(--border)] bg-[var(--popover)] text-[var(--popover-foreground)] shadow-black/20",
+          )}
+        >
+          <div className="flex items-center justify-between gap-2 text-[0.6875rem]">
+            <span className={dark ? "text-[var(--marinara-chat-chrome-panel-title)]" : "text-[var(--foreground)]"}>
+              Line volume
+            </span>
+            <span
+              className={cn(
+                "tabular-nums",
+                dark ? "text-[var(--marinara-chat-chrome-panel-muted)]" : "text-[var(--muted-foreground)]",
+              )}
+            >
+              {volume}%
+            </span>
+          </div>
+          <input
+            type="range"
+            min={0}
+            max={100}
+            step={1}
+            value={volume}
+            onChange={(event) => onVolumeChange(Number(event.currentTarget.value))}
+            className="mari-tts-line-volume-slider w-full"
+            aria-label="Line volume"
+            title="Line volume"
+            style={{ "--range-progress": `${volume}%` } as React.CSSProperties}
+          />
+        </div>
+      )}
+      <ActionBtn
+        icon={muted ? <VolumeX size={MESSAGE_ACTION_ICON_SIZE} /> : <Volume2 size={MESSAGE_ACTION_ICON_SIZE} />}
+        onClick={() => setOpen((value) => !value)}
+        title={label}
+        dark={dark}
+        ariaPressed={open}
+        className={
+          open
+            ? dark
+              ? MESSAGE_CHROME_ACTIVE_ICON_CLASS
+              : "bg-[var(--accent)] text-[var(--foreground)]"
+            : undefined
+        }
+      />
+    </div>
+  );
+}
+
 // ── Action button ──
 function ActionBtn({
   icon,
@@ -2952,6 +3067,7 @@ function ActionBtn({
   className,
   dark,
   disabled,
+  ariaPressed,
 }: {
   icon: React.ReactNode;
   onClick: () => void;
@@ -2959,6 +3075,7 @@ function ActionBtn({
   className?: string;
   dark?: boolean;
   disabled?: boolean;
+  ariaPressed?: boolean;
 }) {
   return (
     <button
@@ -2966,6 +3083,7 @@ function ActionBtn({
       onClick={onClick}
       title={title}
       aria-label={title}
+      aria-pressed={ariaPressed}
       disabled={disabled}
       className={cn(
         "inline-flex h-[1.7em] w-[1.7em] shrink-0 items-center justify-center rounded-md p-0 text-[0.8125rem] leading-none transition-all active:scale-90 disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-30",

--- a/packages/client/src/components/chat/ChatMessage.tsx
+++ b/packages/client/src/components/chat/ChatMessage.tsx
@@ -2903,6 +2903,7 @@ export const ChatMessage = memo(function ChatMessage({
                   }
                   disabled={!hasTTSContent || (ttsBusy && !isSpeakingThis)}
                 />
+                <TTSLineVolumeControl volume={ttsLineVolume} onVolumeChange={handleTTSLineVolumeChange} />
               </>
             )}
           </div>
@@ -2979,6 +2980,7 @@ function TTSLineVolumeControl({
 }) {
   const [open, setOpen] = useState(false);
   const wrapperRef = useRef<HTMLDivElement | null>(null);
+  const inputRef = useRef<HTMLInputElement | null>(null);
   const muted = volume <= 0;
   const label = `Line volume: ${volume}%`;
 
@@ -3001,8 +3003,27 @@ function TTSLineVolumeControl({
     };
   }, [open]);
 
+  useEffect(() => {
+    if (!open) return;
+    requestAnimationFrame(() => inputRef.current?.focus());
+  }, [open]);
+
   return (
     <div ref={wrapperRef} className="relative inline-flex">
+      <ActionBtn
+        icon={muted ? <VolumeX size={MESSAGE_ACTION_ICON_SIZE} /> : <Volume2 size={MESSAGE_ACTION_ICON_SIZE} />}
+        onClick={() => setOpen((value) => !value)}
+        title={label}
+        dark={dark}
+        ariaPressed={open}
+        className={
+          open
+            ? dark
+              ? MESSAGE_CHROME_ACTIVE_ICON_CLASS
+              : "bg-[var(--accent)] text-[var(--foreground)]"
+            : undefined
+        }
+      />
       {open && (
         <div
           role="dialog"
@@ -3028,6 +3049,7 @@ function TTSLineVolumeControl({
             </span>
           </div>
           <input
+            ref={inputRef}
             type="range"
             min={0}
             max={100}
@@ -3041,20 +3063,6 @@ function TTSLineVolumeControl({
           />
         </div>
       )}
-      <ActionBtn
-        icon={muted ? <VolumeX size={MESSAGE_ACTION_ICON_SIZE} /> : <Volume2 size={MESSAGE_ACTION_ICON_SIZE} />}
-        onClick={() => setOpen((value) => !value)}
-        title={label}
-        dark={dark}
-        ariaPressed={open}
-        className={
-          open
-            ? dark
-              ? MESSAGE_CHROME_ACTIVE_ICON_CLASS
-              : "bg-[var(--accent)] text-[var(--foreground)]"
-            : undefined
-        }
-      />
     </div>
   );
 }

--- a/packages/client/src/components/chat/ChatSettingsDrawer.tsx
+++ b/packages/client/src/components/chat/ChatSettingsDrawer.tsx
@@ -4765,6 +4765,7 @@ export function ChatSettingsDrawer({
                     value={groupScenarioDraft}
                     onChange={setGroupScenarioDraft}
                     placeholder="Replace individual character scenarios with a shared scenario for this group chat or leave empty to keep them…"
+                    surface="chat"
                   />
                 </div>
               )}

--- a/packages/client/src/components/ui/MacroTextarea.tsx
+++ b/packages/client/src/components/ui/MacroTextarea.tsx
@@ -16,6 +16,24 @@ const MACRO_REFERENCE = Array.from(
   }, new Map()),
 );
 
+const EDITOR_MODAL_SURFACE_VARIABLES = [
+  "[--accent:var(--marinara-editor-control-bg-hover)]",
+  "[--accent-foreground:var(--marinara-editor-text)]",
+  "[--background:var(--marinara-editor-bg)]",
+  "[--border:var(--marinara-editor-border)]",
+  "[--card:var(--marinara-editor-surface-bg)]",
+  "[--foreground:var(--marinara-editor-text)]",
+  "[--input:var(--marinara-editor-border)]",
+  "[--muted:var(--marinara-editor-control-bg)]",
+  "[--muted-foreground:var(--marinara-editor-muted)]",
+  "[--popover:var(--marinara-editor-surface-bg)]",
+  "[--popover-foreground:var(--marinara-editor-text)]",
+  "[--primary:var(--marinara-editor-accent)]",
+  "[--primary-foreground:var(--marinara-editor-bg)]",
+  "[--ring:var(--marinara-editor-focus-ring)]",
+  "[--secondary:var(--marinara-editor-control-bg)]",
+].join(" ");
+
 interface MacroModalPortalProps {
   children: ReactNode;
 }
@@ -117,7 +135,12 @@ function ExpandedMacroEditor({
 
   return (
     <MacroModalPortal>
-      <div className="fixed inset-0 z-[140] flex items-center justify-center bg-black/70 p-3 pb-[max(env(safe-area-inset-bottom),0.75rem)] pt-[max(env(safe-area-inset-top),0.75rem)] backdrop-blur-sm sm:p-4">
+      <div
+        className={cn(
+          "fixed inset-0 z-[140] flex items-center justify-center bg-black/70 p-3 pb-[max(env(safe-area-inset-bottom),0.75rem)] pt-[max(env(safe-area-inset-top),0.75rem)] backdrop-blur-sm sm:p-4",
+          EDITOR_MODAL_SURFACE_VARIABLES,
+        )}
+      >
         <div className="flex h-[min(92vh,56rem)] max-h-[calc(100vh-1.5rem)] w-full max-w-5xl flex-col overflow-hidden rounded-2xl border border-[var(--border)] bg-[var(--background)] shadow-2xl supports-[height:100dvh]:h-[min(92dvh,56rem)] supports-[height:100dvh]:max-h-[calc(100dvh-1.5rem)]">
           <div className="flex items-center justify-between border-b border-[var(--border)] px-4 py-3">
             <div>
@@ -130,7 +153,7 @@ function ExpandedMacroEditor({
                 onChange(localValue);
                 onClose();
               }}
-              className="rounded-lg border border-[var(--border)] bg-[var(--secondary)] p-2 text-[var(--muted-foreground)] transition hover:border-[var(--foreground)] hover:text-[var(--foreground)]"
+              className="rounded-lg border border-[var(--border)] bg-[var(--secondary)] p-2 text-[var(--muted-foreground)] transition hover:border-[var(--primary)] hover:bg-[var(--accent)] hover:text-[var(--foreground)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--ring)]"
               aria-label="Close expanded editor"
               title="Close"
             >
@@ -179,7 +202,12 @@ function MacrosReferenceModal({ open, onClose }: MacrosReferenceModalProps) {
 
   return (
     <MacroModalPortal>
-      <div className="fixed inset-0 z-[145] flex items-center justify-center bg-black/70 p-3 pb-[max(env(safe-area-inset-bottom),0.75rem)] pt-[max(env(safe-area-inset-top),0.75rem)] backdrop-blur-sm sm:p-4">
+      <div
+        className={cn(
+          "fixed inset-0 z-[145] flex items-center justify-center bg-black/70 p-3 pb-[max(env(safe-area-inset-bottom),0.75rem)] pt-[max(env(safe-area-inset-top),0.75rem)] backdrop-blur-sm sm:p-4",
+          EDITOR_MODAL_SURFACE_VARIABLES,
+        )}
+      >
         <div className="max-h-[88vh] w-full max-w-4xl overflow-hidden rounded-2xl border border-[var(--border)] bg-[var(--background)] shadow-2xl supports-[height:100dvh]:max-h-[88dvh]">
           <div className="flex items-center justify-between border-b border-[var(--border)] px-4 py-3">
             <div>
@@ -189,7 +217,7 @@ function MacrosReferenceModal({ open, onClose }: MacrosReferenceModalProps) {
             <button
               type="button"
               onClick={onClose}
-              className="rounded-lg border border-[var(--border)] bg-[var(--secondary)] p-2 text-[var(--muted-foreground)] transition hover:border-[var(--foreground)] hover:text-[var(--foreground)]"
+              className="rounded-lg border border-[var(--border)] bg-[var(--secondary)] p-2 text-[var(--muted-foreground)] transition hover:border-[var(--primary)] hover:bg-[var(--accent)] hover:text-[var(--foreground)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--ring)]"
               aria-label="Close macro reference"
               title="Close"
             >

--- a/packages/client/src/features/chat-settings/sections/SceneInstructionsSection.tsx
+++ b/packages/client/src/features/chat-settings/sections/SceneInstructionsSection.tsx
@@ -58,6 +58,7 @@ export function SceneInstructionsSection({
         value={value}
         onChange={onValueChange}
         placeholder="Scene system prompt..."
+        surface="chat"
       />
     </ChatSettingsSection>
   );

--- a/packages/client/src/lib/tts-service.ts
+++ b/packages/client/src/lib/tts-service.ts
@@ -73,6 +73,8 @@ class TTSService {
   /** ID of the entity (e.g. message id) currently being spoken */
   private activeId: string | null = null;
   private listeners = new Set<StateListener>();
+  private livePlaybackVolume: number | null = null;
+  private livePlaybackMuted: boolean | null = null;
 
   // ── Listeners ─────────────────────────────────
 
@@ -121,13 +123,25 @@ class TTSService {
 
   // ── Playback ──────────────────────────────────
 
+  private beginPlaybackOptions(options: Pick<TTSSpeakOptions, "volume" | "muted">): void {
+    this.livePlaybackVolume = typeof options.volume === "number" ? clampPlaybackVolume(options.volume) : null;
+    this.livePlaybackMuted = typeof options.muted === "boolean" ? options.muted : null;
+  }
+
+  private clearPlaybackOptions(): void {
+    this.livePlaybackVolume = null;
+    this.livePlaybackMuted = null;
+  }
+
   private applyPlaybackOptions(audio: HTMLAudioElement, options: Pick<TTSSpeakOptions, "volume" | "muted">): void {
-    const volume = clampPlaybackVolume(options.volume);
+    const volume = this.livePlaybackVolume ?? clampPlaybackVolume(options.volume);
     audio.volume = volume;
-    audio.muted = options.muted === true || volume <= 0;
+    audio.muted = (this.livePlaybackMuted ?? options.muted) === true || volume <= 0;
   }
 
   setCurrentPlaybackVolume(volume: number, muted = false): void {
+    this.livePlaybackVolume = clampPlaybackVolume(volume);
+    this.livePlaybackMuted = muted;
     if (!this.audio) return;
     this.applyPlaybackOptions(this.audio, { volume, muted });
   }
@@ -165,6 +179,7 @@ class TTSService {
   /** Speak the given text. `id` is an optional caller-supplied key (e.g. message id) so callers can track which item is active. */
   async speak(text: string, id?: string, options: TTSSpeakOptions = {}): Promise<void> {
     this.stop();
+    this.beginPlaybackOptions(options);
     const sequence = ++this.sequence;
     this.lastError = null;
 
@@ -241,6 +256,7 @@ class TTSService {
     if (playableRequests.length === 0) return;
 
     this.stop();
+    this.beginPlaybackOptions(options);
     const sequence = ++this.sequence;
     this.lastError = null;
 
@@ -454,6 +470,7 @@ class TTSService {
     this.sequence += 1;
     this.abortController?.abort();
     this.abortController = null;
+    this.clearPlaybackOptions();
 
     if (this.audio) {
       this.audio.pause();

--- a/packages/client/src/stores/ui.store.ts
+++ b/packages/client/src/stores/ui.store.ts
@@ -563,6 +563,8 @@ interface UIState {
   trimIncompleteModelOutput: boolean;
   /** When true, chat inputs show a microphone button for browser speech-to-text dictation. */
   speechToTextEnabled: boolean;
+  /** User-set TTS line playback volume (0-100). */
+  ttsLineVolume: number;
   /** When true, allow the rare Chibi Professor Mari scroll toast. */
   chibiProfessorMariEnabled: boolean;
   /** When true, achievements appear on Home and announce unlocks. Backend tracking stays silent either way. */
@@ -844,6 +846,7 @@ interface UIState {
   setConvertLatexSymbols: (v: boolean) => void;
   setTrimIncompleteModelOutput: (v: boolean) => void;
   setSpeechToTextEnabled: (v: boolean) => void;
+  setTTSLineVolume: (v: number) => void;
   setChibiProfessorMariEnabled: (v: boolean) => void;
   setAchievementsEnabled: (v: boolean) => void;
   setMusicPlayerEnabled: (v: boolean) => void;
@@ -1043,6 +1046,7 @@ export function pickSyncedSettings(state: UIState) {
     convertLatexSymbols: state.convertLatexSymbols,
     trimIncompleteModelOutput: state.trimIncompleteModelOutput,
     speechToTextEnabled: state.speechToTextEnabled,
+    ttsLineVolume: state.ttsLineVolume,
     chibiProfessorMariEnabled: state.chibiProfessorMariEnabled,
     achievementsEnabled: state.achievementsEnabled,
     musicPlayerEnabled: state.musicPlayerEnabled,
@@ -1218,6 +1222,7 @@ export const useUIStore = create<UIState>()(
       convertLatexSymbols: true,
       trimIncompleteModelOutput: false,
       speechToTextEnabled: false,
+      ttsLineVolume: 50,
       chibiProfessorMariEnabled: true,
       achievementsEnabled: true,
       musicPlayerEnabled: true,
@@ -1768,6 +1773,7 @@ export const useUIStore = create<UIState>()(
       setConvertLatexSymbols: (v) => set({ convertLatexSymbols: v }),
       setTrimIncompleteModelOutput: (v) => set({ trimIncompleteModelOutput: v }),
       setSpeechToTextEnabled: (v) => set({ speechToTextEnabled: v }),
+      setTTSLineVolume: (v) => set({ ttsLineVolume: Math.max(0, Math.min(100, Math.round(v))) }),
       setChibiProfessorMariEnabled: (v) => set({ chibiProfessorMariEnabled: v }),
       setAchievementsEnabled: (v) => set({ achievementsEnabled: v }),
       setMusicPlayerEnabled: (v) =>
@@ -1973,7 +1979,7 @@ export const useUIStore = create<UIState>()(
     }),
     {
       name: "marinara-engine-ui",
-      version: 68,
+      version: 69,
       // Debounce localStorage writes to avoid sync I/O on every state change
       storage: createJSONStorage(() => {
         let timer: ReturnType<typeof setTimeout> | null = null;
@@ -2349,6 +2355,11 @@ export const useUIStore = create<UIState>()(
         if (typeof persisted.conversationCallVoiceMuted !== "boolean") {
           persisted.conversationCallVoiceMuted = false;
         }
+        // v68 -> v69: persist message TTS line playback volume.
+        if (typeof persisted.ttsLineVolume !== "number") {
+          persisted.ttsLineVolume = 50;
+        }
+        persisted.ttsLineVolume = Math.max(0, Math.min(100, Math.round(persisted.ttsLineVolume)));
         // v42 -> v44: reconcile parallel v43 UI preference additions.
         if (version <= 43 && persisted.youtubePlayerEnabled === undefined) {
           persisted.youtubePlayerEnabled = true;
@@ -2580,6 +2591,7 @@ export const useUIStore = create<UIState>()(
         convertLatexSymbols: state.convertLatexSymbols,
         trimIncompleteModelOutput: state.trimIncompleteModelOutput,
         speechToTextEnabled: state.speechToTextEnabled,
+        ttsLineVolume: state.ttsLineVolume,
         chibiProfessorMariEnabled: state.chibiProfessorMariEnabled,
         achievementsEnabled: state.achievementsEnabled,
         musicPlayerEnabled: state.musicPlayerEnabled,

--- a/packages/client/src/styles/globals.css
+++ b/packages/client/src/styles/globals.css
@@ -2219,6 +2219,27 @@ input[type="range"].mari-local-music-volume-slider::-moz-range-thumb {
   background: var(--range-thumb-color);
 }
 
+input[type="range"].mari-tts-line-volume-slider {
+  --range-track-color: color-mix(in srgb, var(--marinara-chat-chrome-panel-muted) 28%, transparent);
+  --range-fill-color: var(--marinara-chat-chrome-accent);
+  --range-thumb-color: var(--marinara-chat-chrome-accent);
+  --range-thumb-size: 0.75rem;
+  --range-track-height: 0.25rem;
+  --range-thumb-shadow: 0 0 0 0.125rem var(--marinara-chat-chrome-panel-bg);
+
+  accent-color: var(--range-fill-color);
+}
+
+input[type="range"].mari-tts-line-volume-slider::-webkit-slider-thumb {
+  background: var(--range-thumb-color);
+  opacity: 1;
+}
+
+input[type="range"].mari-tts-line-volume-slider::-moz-range-thumb {
+  background: var(--range-thumb-color);
+  opacity: 1;
+}
+
 @font-face {
   font-family: "Straight Quotes";
   src:


### PR DESCRIPTION
## Linked issue

Closes #

No linked issue yet. Per contributor guidance, an issue or feature request should be opened before this PR is submitted for final review.

## Why this change

- Expanded text editors opened from Presets and other editor surfaces were escaping their local chroma token scope through portals, which made them fall back to older global pink-themed colors.
- Roleplay TTS message controls needed clearer speak/volume affordances and a persistent per-line playback volume control.

## What changed

- Scoped shared macro editor and macro reference portals to editor chroma variables so text, borders, backgrounds, and hover states use `--marinara-editor-*` tokens.
- Set chat expanded text editor callers to the chat chroma surface where they were missing it.
- Changed Roleplay message TTS speak/stop iconography to mic/mic-off.
- Added a speaker button beside the Roleplay TTS control that opens a compact volume slider above the icon on desktop and mobile.
- Added persisted `ttsLineVolume`, defaulting to 50%, and applied it to manual TTS playback and autoplay.
- Updated the TTS service so live volume changes apply to the current audio element and continue across multi-chunk playback.

## Validation

- [ ] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed `CONTRIBUTING.md`

Validation performed by Codex:

- `pnpm check` passed.
- `pnpm smoke:ui` passed, 6 passed and 2 skipped by the suite.
- `git diff --check` passed.

### Manual verification notes

- Not manually verified against a real configured TTS provider. Provider-backed audio playback depends on local TTS credentials/provider state.
- Browser smoke covered desktop and mobile shell reachability, but did not deeply exercise the new Roleplay TTS slider path.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Version/release files updated (only if this PR includes a version bump)

## UI evidence (if applicable)

- No screenshots attached.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a per-line text-to-speech volume control in chat, letting you adjust playback volume directly from message actions.
  * TTS playback now respects the selected volume during streaming and after messages finish.
  * Improved modal and text area styling for a more consistent chat/settings editing experience.

* **Bug Fixes**
  * Playback volume and mute behavior now stay consistent while TTS is running.
  * Enhanced accessibility for action buttons with proper pressed-state support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->