### PR TITLE
fix: preserve Prose Guardian settings-based rules in merged rewrite prompt

### DIFF
--- a/packages/server/src/services/generation/prose-guardian-settings.ts
+++ b/packages/server/src/services/generation/prose-guardian-settings.ts
@@ -135,7 +135,40 @@ function getRewritePromptLabel(agentType: string): string {
 function buildMergedRewritePrompt(agents: ResolvedAgent[]): string {
   const agentBlocks = agents.flatMap((agent) => {
     const label = getRewritePromptLabel(agent.type);
-    return [`<${label}>`, `Agent: ${agent.name}`, agent.promptTemplate, `</${label}>`, ``];
+    const parts = [`<${label}>`, `Agent: ${agent.name}`];
+    
+    // Include promptTemplate if non-empty
+    if (agent.promptTemplate) {
+      parts.push(agent.promptTemplate);
+    }
+    
+    // For prose-guardian, include settings-based rules (banned, avoid, prefer)
+    if (agent.type === "prose-guardian") {
+      const settings = agent.settings as Record<string, unknown>;
+      const rules: string[] = [];
+      
+      const banned = typeof settings.banned === "string" ? settings.banned : null;
+      if (banned) {
+        rules.push(`BANNED WORDS/PHRASES: ${banned}`);
+      }
+      
+      const avoid = typeof settings.avoid === "string" ? settings.avoid : null;
+      if (avoid) {
+        rules.push(`AVOID: ${avoid}`);
+      }
+      
+      const prefer = typeof settings.prefer === "string" ? settings.prefer : null;
+      if (prefer) {
+        rules.push(`PREFER: ${prefer}`);
+      }
+      
+      if (rules.length > 0) {
+        parts.push(rules.join("\n"));
+      }
+    }
+    
+    parts.push(`</${label}>`, ``);
+    return parts;
   });
 
   return [


### PR DESCRIPTION
## Summary

When multiple rewrite agents are merged, Prose Guardian's settings-based rules (banned, avoid, prefer) were silently dropped because `buildMergedRewritePrompt` only included `promptTemplate` — which is empty by design for Prose Guardian.

## Changes

Updated `buildMergedRewritePrompt` in `prose-guardian-settings.ts` to:

1. Only include `promptTemplate` if non-empty (avoids empty blocks)
2. For Prose Guardian agents, explicitly include settings-based rules:
   - `banned` words/phrases
   - `avoid` instructions
   - `prefer` style instructions

## Problem

When Prose Guardian was merged with another rewrite agent (e.g., Continuity Checker), the merged prompt had an empty instruction body. This caused:
- The merged rewrite agent to return `editNeeded:false` in ~27 tokens
- Prose Guardian's banned patterns (e.g., "A beat.") to pass through untouched
- No prose-guardian agent-run to be recorded

## Example

Before (broken):
```xml
<style_editor>
Agent: Prose Guardian

</style_editor>
```

After (fixed):
```xml
<style_editor>
Agent: Prose Guardian
BANNED WORDS/PHRASES: ozone
AVOID: no repetition of any phrases or sentence structure from the last messages
PREFER: concise, vivid prose
</style_editor>
```

Closes #3352

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved how rewrite prompts are assembled for agents, making them more consistent and selective.
  * Prose-guardian agents now include configured guidance lines for banned words/phrases, avoid, and prefer rules when available.

* **Bug Fixes**
  * Prompt blocks now only include optional agent prompt text when present, reducing unnecessary or empty content in generated output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->