### PR TITLE
Add storyboard background display mode

### DIFF
--- a/packages/client/src/components/chat/ChatSettingsDrawer.tsx
+++ b/packages/client/src/components/chat/ChatSettingsDrawer.tsx
@@ -157,6 +157,7 @@ import type {
   ConversationCommandKey,
   ConversationNote,
   ExportEnvelope,
+  GameStoryboardViewerDisplayMode,
   HapticFeedbackSensitivity,
   HudWidget,
   KnowledgeAgentSourceSettings,
@@ -1519,6 +1520,8 @@ export function ChatSettingsDrawer({
   const gameImageDynamicPromptEnabled = metadata.gameImageDynamicPromptEnabled === true;
   const gameStoryboardAutoIllustrationsEnabled = metadata.gameStoryboardAutoIllustrationsEnabled === true;
   const gameStoryboardAutoAnimationsEnabled = metadata.gameStoryboardAutoGenerationEnabled === true;
+  const gameStoryboardViewerDisplayMode: GameStoryboardViewerDisplayMode =
+    metadata.gameStoryboardViewerDisplayMode === "background" ? "background" : "floating";
   const gameStoryboardPromptTemplates = useMemo(
     () => normalizeGameStoryboardPromptTemplates(metadata.gameStoryboardPromptTemplates),
     [metadata.gameStoryboardPromptTemplates],
@@ -7528,6 +7531,33 @@ export function ChatSettingsDrawer({
                         });
                       }}
                     />
+                    <div className="space-y-1">
+                      <div className="flex items-center gap-1 text-[0.625rem] font-medium text-[var(--foreground)]">
+                        Viewer Display
+                        <HelpTooltip text="Floating keeps the draggable storyboard panel. Background places the active storyboard frame behind the game UI, above the normal scene background." />
+                      </div>
+                      <AgentSettingsSegmentedControl<GameStoryboardViewerDisplayMode>
+                        value={gameStoryboardViewerDisplayMode}
+                        options={[
+                          {
+                            id: "floating",
+                            label: "Floating",
+                            description: "Draggable panel above the game.",
+                          },
+                          {
+                            id: "background",
+                            label: "Background",
+                            description: "Visual layer behind controls.",
+                          },
+                        ]}
+                        onChange={(mode) =>
+                          updateMeta.mutate({
+                            id: chat.id,
+                            gameStoryboardViewerDisplayMode: mode === "floating" ? null : mode,
+                          })
+                        }
+                      />
+                    </div>
                     <div className="grid gap-2 md:grid-cols-2">
                       <GamePromptTemplateSelect
                         label="Illustration Prompt"

--- a/packages/client/src/components/chat/ChatSettingsDrawer.tsx
+++ b/packages/client/src/components/chat/ChatSettingsDrawer.tsx
@@ -7343,7 +7343,11 @@ export function ChatSettingsDrawer({
                       <div className="space-y-2">
                         <AgentSettingsToggle
                           label="Automatic Visuals"
-                          description="Let Game Mode automatically request backgrounds, NPC portraits, and scene illustrations. Manual buttons stay available when this is off."
+                          description={
+                            gameStoryboardViewerDisplayMode === "background"
+                              ? "Automatically request NPC portraits and scene illustrations. Location background generation is disabled while storyboard visuals are used as the background."
+                              : "Let Game Mode automatically request backgrounds, NPC portraits, and scene illustrations. Manual buttons stay available when this is off."
+                          }
                           enabled={gameImageAutoGenerationEnabled}
                           onToggle={() =>
                             updateMeta.mutate({
@@ -7534,7 +7538,7 @@ export function ChatSettingsDrawer({
                     <div className="space-y-1">
                       <div className="flex items-center gap-1 text-[0.625rem] font-medium text-[var(--foreground)]">
                         Viewer Display
-                        <HelpTooltip text="Floating keeps the draggable storyboard panel. Background places the active storyboard frame behind the game UI, above the normal scene background." />
+                        <HelpTooltip text="Floating keeps the draggable storyboard panel. Background places the active storyboard frame behind the game UI and disables generated location backgrounds." />
                       </div>
                       <AgentSettingsSegmentedControl<GameStoryboardViewerDisplayMode>
                         value={gameStoryboardViewerDisplayMode}

--- a/packages/client/src/components/game/GameSurface.tsx
+++ b/packages/client/src/components/game/GameSurface.tsx
@@ -9740,7 +9740,7 @@ function GameSurfaceComponent({
     return (
       <div
         data-game-skip-bg-nav="true"
-        className="pointer-events-none absolute inset-0 z-[1] overflow-hidden"
+        className="pointer-events-none absolute inset-0 z-[1] overflow-hidden bg-black"
         aria-hidden="true"
       >
         {frame.video ? (
@@ -9751,13 +9751,13 @@ function GameSurfaceComponent({
             loop
             muted
             playsInline
-            className="h-full w-full bg-black object-cover transition-opacity duration-500"
+            className="h-full w-full bg-black object-contain transition-opacity duration-500"
           />
         ) : frame.image ? (
           <img
             src={frame.image.url}
             alt=""
-            className="h-full w-full bg-black object-cover transition-opacity duration-500"
+            className="h-full w-full bg-black object-contain transition-opacity duration-500"
             draggable={false}
           />
         ) : null}

--- a/packages/client/src/components/game/GameSurface.tsx
+++ b/packages/client/src/components/game/GameSurface.tsx
@@ -181,7 +181,7 @@ import {
   ROLEPLAY_POPOVER_TITLE,
 } from "../chat/roleplay-popover-styles";
 import type { ReadableTag } from "../../lib/game-tag-parser";
-import type { DirectionCommand, GameNpc } from "@marinara-engine/shared";
+import type { DirectionCommand, GameNpc, GameStoryboardViewerDisplayMode } from "@marinara-engine/shared";
 
 type JournalReadable = ReadableTag & {
   sourceMessageId?: string | null;
@@ -3506,6 +3506,8 @@ function GameSurfaceComponent({
     () => findStoryboardKeyframeForSegment(latestTurnStoryboard?.keyframes ?? [], activeStoryboardSegmentIndex),
     [activeStoryboardSegmentIndex, latestTurnStoryboard?.keyframes],
   );
+  const gameStoryboardViewerDisplayMode: GameStoryboardViewerDisplayMode =
+    chatMeta.gameStoryboardViewerDisplayMode === "background" ? "background" : "floating";
   const latestStoryboardViewerTurnKey = useMemo(() => {
     if (!latestAssistantMsg?.id) return null;
     return activeChatId ? `${activeChatId}:${latestAssistantMsg.id}:${latestAssistantSwipeIndex}` : latestAssistantMsg.id;
@@ -9502,6 +9504,7 @@ function GameSurfaceComponent({
   };
 
   const renderStoryboardInlineViewer = () => {
+    if (gameStoryboardViewerDisplayMode !== "floating") return null;
     if (!latestAssistantMsg?.id) return null;
     if (!latestTurnStoryboard && !storyboardGenerating) return null;
     if (storyboardViewerDismissed) return null;
@@ -9680,6 +9683,43 @@ function GameSurfaceComponent({
     );
   };
 
+  const renderStoryboardBackgroundVisual = () => {
+    if (gameStoryboardViewerDisplayMode !== "background") return null;
+    if (!latestAssistantMsg?.id) return null;
+    if (!latestTurnStoryboard && !storyboardGenerating) return null;
+    if (storyboardViewerDismissed) return null;
+
+    const frame = activeStoryboardKeyframe;
+    if (!frame?.video && !frame?.image) return null;
+
+    return (
+      <div
+        data-game-skip-bg-nav="true"
+        className="pointer-events-none absolute inset-0 z-[1] overflow-hidden"
+        aria-hidden="true"
+      >
+        {frame.video ? (
+          <video
+            key={frame.video.id}
+            src={frame.video.url}
+            autoPlay
+            loop
+            muted
+            playsInline
+            className="h-full w-full bg-black object-cover transition-opacity duration-500"
+          />
+        ) : frame.image ? (
+          <img
+            src={frame.image.url}
+            alt=""
+            className="h-full w-full bg-black object-cover transition-opacity duration-500"
+            draggable={false}
+          />
+        ) : null}
+      </div>
+    );
+  };
+
   const renderGameAssetsPanel = (mobile = false) => {
     const panel = (
       <div
@@ -9760,7 +9800,11 @@ function GameSurfaceComponent({
                       type="button"
                       onClick={handleReopenStoryboardViewer}
                       className="marinara-chat-popover__item flex items-center gap-1.5 rounded-md border border-[var(--marinara-chat-chrome-panel-divider)] px-2 py-1 text-[0.6875rem] font-medium text-[var(--marinara-chat-chrome-panel-text)] transition-colors hover:bg-[var(--marinara-chat-chrome-highlight-bg-hover)] hover:text-[var(--marinara-chat-chrome-highlight-text)]"
-                      title="Show the floating storyboard viewer"
+                      title={
+                        gameStoryboardViewerDisplayMode === "background"
+                          ? "Show storyboard background"
+                          : "Show the floating storyboard viewer"
+                      }
                     >
                       <PanelsTopLeft size={12} />
                       Show viewer
@@ -9825,6 +9869,8 @@ function GameSurfaceComponent({
             if (!playing && introCinematicActive) setIntroCinematicActive(false);
           }}
         >
+          {renderStoryboardBackgroundVisual()}
+
           {/* Full-body VN sprite — active speaker only */}
           <div
             className="transition-opacity duration-700 ease-in-out"

--- a/packages/client/src/components/game/GameSurface.tsx
+++ b/packages/client/src/components/game/GameSurface.tsx
@@ -3670,6 +3670,10 @@ function GameSurfaceComponent({
     typeof chatMeta.gameVideoConnectionId === "string" && chatMeta.gameVideoConnectionId.trim().length > 0;
   const gameImageAutoGenerationEnabled =
     gameImageGenerationEnabled && chatMeta.gameImageAutoGenerationEnabled !== false;
+  const gameStoryboardBackgroundVisualEnabled = gameStoryboardViewerDisplayMode === "background";
+  const gameBackgroundGenerationEnabled = gameImageGenerationEnabled && !gameStoryboardBackgroundVisualEnabled;
+  const gameBackgroundAutoGenerationEnabled =
+    gameImageAutoGenerationEnabled && !gameStoryboardBackgroundVisualEnabled;
   const gameStoryboardAutoIllustrationsEnabled = chatMeta.gameStoryboardAutoIllustrationsEnabled === true;
   const gameStoryboardAutoAnimationsEnabled = chatMeta.gameStoryboardAutoGenerationEnabled === true;
   const gameStoryboardAutoGenerationEnabled =
@@ -3680,6 +3684,7 @@ function GameSurfaceComponent({
   const missingSceneAssetGeneration = useMemo(() => {
     return buildMissingSceneAssetGenerationPayload({
       gameImageGenerationEnabled: gameImageAutoGenerationEnabled,
+      gameBackgroundGenerationEnabled: gameBackgroundAutoGenerationEnabled,
       activeChatId,
       currentBackground,
       savedSceneBackground: chatMeta.gameSceneBackground as string | undefined,
@@ -3694,6 +3699,7 @@ function GameSurfaceComponent({
     scopedAssetMap,
     chatMeta.gameSceneBackground,
     currentBackground,
+    gameBackgroundAutoGenerationEnabled,
     gameImageAutoGenerationEnabled,
     failedNpcAvatarNames,
     npcAvatarLookup,
@@ -4592,7 +4598,7 @@ function GameSurfaceComponent({
       setting:
         ((chatMeta.gameSetupConfig as Record<string, unknown> | undefined)?.setting as string | undefined) ?? null,
       worldOverview: (chatMeta.gameWorldOverview as string | undefined) ?? null,
-      canGenerateBackgrounds: gameImageAutoGenerationEnabled,
+      canGenerateBackgrounds: gameBackgroundAutoGenerationEnabled,
       canGenerateIllustrations: gameImageAutoGenerationEnabled,
       artStylePrompt:
         ((chatMeta.gameSetupConfig as Record<string, unknown> | undefined)?.artStylePrompt as string | undefined) ??
@@ -4832,10 +4838,30 @@ function GameSurfaceComponent({
       assetPayload: GameAssetGenerationPayload,
       options?: Pick<GameAssetGenerationOptions, "allowPromptReview">,
     ): Promise<GameAssetGenerationResult | null> => {
+      const requestedBackground = !!assetPayload.backgroundTag?.trim();
+      const backgroundSafePayload =
+        gameStoryboardBackgroundVisualEnabled && requestedBackground
+          ? {
+              ...assetPayload,
+              backgroundTag: undefined,
+              backgroundDescription: undefined,
+              forceBackground: undefined,
+            }
+          : assetPayload;
+      if (
+        requestedBackground &&
+        gameStoryboardBackgroundVisualEnabled &&
+        !backgroundSafePayload.illustration &&
+        !backgroundSafePayload.npcsNeedingAvatars?.length
+      ) {
+        return null;
+      }
+
       const payload: GameAssetGenerationPayload = {
-        ...assetPayload,
-        useAvatarReferences: assetPayload.useAvatarReferences ?? gameImageUseAvatarReferences,
-        includeCharacterAppearance: assetPayload.includeCharacterAppearance ?? gameImageIncludeCharacterAppearance,
+        ...backgroundSafePayload,
+        useAvatarReferences: backgroundSafePayload.useAvatarReferences ?? gameImageUseAvatarReferences,
+        includeCharacterAppearance:
+          backgroundSafePayload.includeCharacterAppearance ?? gameImageIncludeCharacterAppearance,
         debugMode: useUIStore.getState().debugMode,
         queueImageGenerationRequests: useUIStore.getState().queueImageGenerationRequests,
         imageSizes: getConfiguredGameAssetImageSizes(),
@@ -4895,7 +4921,13 @@ function GameSurfaceComponent({
         },
       );
     },
-    [closeImagePromptReview, gameImageIncludeCharacterAppearance, gameImageUseAvatarReferences, openImagePromptReview],
+    [
+      closeImagePromptReview,
+      gameImageIncludeCharacterAppearance,
+      gameImageUseAvatarReferences,
+      gameStoryboardBackgroundVisualEnabled,
+      openImagePromptReview,
+    ],
   );
 
   const applyGeneratedAssets = useCallback(
@@ -5050,11 +5082,13 @@ function GameSurfaceComponent({
       ].filter((t): t is string => !!t && t !== "black" && t !== "none");
 
       const generatedIllustrationTag = result.generatedIllustration?.tag;
-      const unresolvedBg = allBgTags.find((t) => {
-        if (t === generatedIllustrationTag || latestAssetMap[t]) return false;
-        const resolved = resolveAssetTag(t, "backgrounds", latestAssetMap);
-        return !latestAssetMap[resolved];
-      });
+      const unresolvedBg = gameBackgroundAutoGenerationEnabled
+        ? allBgTags.find((t) => {
+            if (t === generatedIllustrationTag || latestAssetMap[t]) return false;
+            const resolved = resolveAssetTag(t, "backgrounds", latestAssetMap);
+            return !latestAssetMap[resolved];
+          })
+        : undefined;
       // Pre-cache portraits for any tracked named NPC with a description, even if not
       // met yet — by the time the party encounters them their avatar is ready, and the
       // /generate-assets schema already caps this at 10 per turn so cost stays bounded.
@@ -5208,7 +5242,11 @@ function GameSurfaceComponent({
 
   const handleManualSceneBackground = useCallback(async () => {
     if (!activeChatId || manualBackgroundGenerating) return;
-    if (!gameImageGenerationEnabled) {
+    if (gameStoryboardBackgroundVisualEnabled) {
+      toast.error("Scene background generation is disabled while storyboard visuals are shown as the background.");
+      return;
+    }
+    if (!gameBackgroundGenerationEnabled) {
       toast.error("Enable Game Illustrator and choose an image connection first.");
       return;
     }
@@ -5271,7 +5309,8 @@ function GameSurfaceComponent({
     chatMeta.gameSetupConfig,
     chatMeta.gameWorldOverview,
     chat.name,
-    gameImageGenerationEnabled,
+    gameBackgroundGenerationEnabled,
+    gameStoryboardBackgroundVisualEnabled,
     gameSnapshot?.location,
     gameSnapshot?.time,
     gameSnapshot?.weather,
@@ -5845,7 +5884,7 @@ function GameSurfaceComponent({
       genre: (setupConfig?.genre as string | undefined) ?? null,
       setting: (setupConfig?.setting as string | undefined) ?? null,
       worldOverview: (chatMeta.gameWorldOverview as string | undefined) ?? null,
-      canGenerateBackgrounds: gameImageAutoGenerationEnabled,
+      canGenerateBackgrounds: gameBackgroundAutoGenerationEnabled,
       canGenerateIllustrations: gameImageAutoGenerationEnabled,
       artStylePrompt:
         ((chatMeta.gameSetupConfig as Record<string, unknown> | undefined)?.artStylePrompt as string | undefined) ??
@@ -5904,6 +5943,7 @@ function GameSurfaceComponent({
     chatMeta.gameWorldOverview,
     currentBackground,
     fetchSpotifySceneCandidates,
+    gameBackgroundAutoGenerationEnabled,
     gameImageAutoGenerationEnabled,
     gameSnapshot?.location,
     gameSnapshot?.time,
@@ -7265,9 +7305,11 @@ function GameSurfaceComponent({
             .filter((enemy) => enemy.name && enemy.description)
             .slice(0, 10);
           const shouldGenerateBossVisuals = !!visuals?.isBossFight && gameImageAutoGenerationEnabled;
+          const shouldGenerateBossBackground = shouldGenerateBossVisuals && gameBackgroundAutoGenerationEnabled;
           const shouldGenerateEnemyAvatars = gameImageAutoGenerationEnabled && enemyAvatarRequests.length > 0;
           if (
-            (shouldGenerateBossVisuals && (visuals?.backgroundPrompt || visuals?.illustrationPrompt)) ||
+            (shouldGenerateBossVisuals &&
+              ((shouldGenerateBossBackground && visuals?.backgroundPrompt) || visuals?.illustrationPrompt)) ||
             shouldGenerateEnemyAvatars
           ) {
             const illustrationPrompt = visuals?.illustrationPrompt?.trim() || "";
@@ -7278,7 +7320,8 @@ function GameSurfaceComponent({
                 : "";
             const assetPayload = {
               chatId: activeChatId,
-              backgroundTag: backgroundPrompt ? `boss fight: ${backgroundPrompt}` : undefined,
+              backgroundTag:
+                shouldGenerateBossBackground && backgroundPrompt ? `boss fight: ${backgroundPrompt}` : undefined,
               illustration:
                 illustrationPrompt.length >= 40
                   ? {
@@ -7338,6 +7381,7 @@ function GameSurfaceComponent({
     [
       activeChatId,
       combatGenerationPending,
+      gameBackgroundAutoGenerationEnabled,
       gameImageAutoGenerationEnabled,
       hydrateGeneratedCombatState,
       requestAssetGeneration,
@@ -8832,7 +8876,7 @@ function GameSurfaceComponent({
       genre: (setupConfig?.genre as string | undefined) ?? null,
       setting: (setupConfig?.setting as string | undefined) ?? null,
       worldOverview: (chatMeta.gameWorldOverview as string | undefined) ?? null,
-      canGenerateBackgrounds: gameImageAutoGenerationEnabled,
+      canGenerateBackgrounds: gameBackgroundAutoGenerationEnabled,
       canGenerateIllustrations: gameImageAutoGenerationEnabled,
       artStylePrompt: (setupConfig?.artStylePrompt as string | undefined) ?? null,
       imagePromptInstructions:
@@ -8869,6 +8913,7 @@ function GameSurfaceComponent({
     hudWidgets,
     npcs,
     currentBackground,
+    gameBackgroundAutoGenerationEnabled,
     gameImageAutoGenerationEnabled,
     gameSnapshot,
     chatMeta,
@@ -9737,9 +9782,13 @@ function GameSurfaceComponent({
           <button
             type="button"
             onClick={handleManualSceneBackground}
-            disabled={manualBackgroundGenerating || !gameImageGenerationEnabled}
+            disabled={manualBackgroundGenerating || !gameBackgroundGenerationEnabled}
             className="marinara-chat-popover__item flex items-center gap-2 rounded-lg px-3 py-2 text-xs font-medium text-[var(--marinara-chat-chrome-panel-text)] transition-colors hover:bg-[var(--marinara-chat-chrome-highlight-bg-hover)] hover:text-[var(--marinara-chat-chrome-highlight-text)] disabled:cursor-not-allowed disabled:opacity-40 disabled:hover:bg-transparent"
-            title="Generate a background for the current scene"
+            title={
+              gameStoryboardBackgroundVisualEnabled
+                ? "Storyboard background display is active, so scene background generation is disabled"
+                : "Generate a background for the current scene"
+            }
           >
             {manualBackgroundGenerating ? <Loader2 size={14} className="animate-spin" /> : <ImagePlus size={14} />}
             Generate background

--- a/packages/client/src/components/game/game-asset-generation-payload.ts
+++ b/packages/client/src/components/game/game-asset-generation-payload.ts
@@ -19,6 +19,7 @@ type MissingSceneAssetGenerationPayload = {
 
 type MissingSceneAssetGenerationInput = {
   gameImageGenerationEnabled: boolean;
+  gameBackgroundGenerationEnabled?: boolean;
   activeChatId: string | null;
   currentBackground: string | null;
   savedSceneBackground: string | undefined;
@@ -45,6 +46,7 @@ export function getMissingBackgroundTag(
 
 export function buildMissingSceneAssetGenerationPayload({
   gameImageGenerationEnabled,
+  gameBackgroundGenerationEnabled = gameImageGenerationEnabled,
   activeChatId,
   currentBackground,
   savedSceneBackground,
@@ -57,7 +59,9 @@ export function buildMissingSceneAssetGenerationPayload({
   if (!gameImageGenerationEnabled) return null;
   if (!activeChatId) return null;
 
-  const unresolvedBackground = getMissingBackgroundTag(currentBackground || savedSceneBackground, assetMap);
+  const unresolvedBackground = gameBackgroundGenerationEnabled
+    ? getMissingBackgroundTag(currentBackground || savedSceneBackground, assetMap)
+    : null;
   const savedGeneratedBackgroundMissing =
     !!savedSceneBackground &&
     unresolvedBackground === savedSceneBackground &&

--- a/packages/server/src/routes/game.routes.ts
+++ b/packages/server/src/routes/game.routes.ts
@@ -8897,6 +8897,8 @@ export async function gameRoutes(app: FastifyInstance) {
     const gameGenerationParameters = resolveStoredGameGenerationParameters(meta, defaultGenerationParameters);
     const enableGen = !!meta.enableSpriteGeneration;
     const enableAutoGen = enableGen && meta.gameImageAutoGenerationEnabled !== false;
+    const storyboardBackgroundVisualEnabled = meta.gameStoryboardViewerDisplayMode === "background";
+    const enableAutoBackgroundGen = enableAutoGen && !storyboardBackgroundVisualEnabled;
     const imgConnId = await resolveGameImageConnectionId(meta, agents);
     const setupCfgForScene = meta.gameSetupConfig as Record<string, unknown> | null;
     const artStyleForScene = (setupCfgForScene?.artStylePrompt as string) || "";
@@ -8915,7 +8917,7 @@ export async function gameRoutes(app: FastifyInstance) {
     const sceneCtx = {
       ...(input.context as unknown as SceneAnalyzerContext),
       turnNumber: approxTurnNumber,
-      canGenerateBackgrounds: enableAutoGen && !!imgConnId,
+      canGenerateBackgrounds: enableAutoBackgroundGen && !!imgConnId,
       canGenerateIllustrations:
         enableAutoGen && !!imgConnId && isIllustrationAllowed(meta, approxTurnNumber, sessionNumber),
       artStylePrompt: artStyleForScene || null,
@@ -9100,6 +9102,8 @@ export async function gameRoutes(app: FastifyInstance) {
         logger.debug("[game/scene-wrap] asset-gen skipped: enableSpriteGeneration=false");
       } else if (!enableAutoGen) {
         logger.debug("[game/scene-wrap] automatic visual generation skipped: gameImageAutoGenerationEnabled=false");
+      } else if (storyboardBackgroundVisualEnabled) {
+        logger.debug("[game/scene-wrap] background generation skipped: storyboard background display mode active");
       } else if (!imgConnId) {
         logger.debug("[game/scene-wrap] asset-gen skipped: no Illustrator image connection configured");
       }
@@ -10413,6 +10417,7 @@ export async function gameRoutes(app: FastifyInstance) {
 
     const meta = parseMeta(chat.metadata);
     const enableGen = !!meta.enableSpriteGeneration;
+    const backgroundGenerationEnabled = meta.gameStoryboardViewerDisplayMode !== "background";
     const imgConnId = await resolveGameImageConnectionId(meta, agents);
     if (!enableGen || !imgConnId) return { items: [] };
 
@@ -10476,7 +10481,7 @@ export async function gameRoutes(app: FastifyInstance) {
       height: number;
     }> = [];
 
-    if (input.backgroundTag) {
+    if (backgroundGenerationEnabled && input.backgroundTag) {
       const slug = generatedBackgroundSlug(input.backgroundTag);
       const backgroundDescription =
         input.backgroundDescription?.trim() || input.backgroundTag.replace(/:/g, " ").replace(/-/g, " ");
@@ -10767,6 +10772,7 @@ export async function gameRoutes(app: FastifyInstance) {
 
       const meta = parseMeta(chat.metadata);
       const enableGen = !!meta.enableSpriteGeneration;
+      const backgroundGenerationEnabled = meta.gameStoryboardViewerDisplayMode !== "background";
       const imgConnId = await resolveGameImageConnectionId(meta, agents);
 
       if (!enableGen || !imgConnId) {
@@ -10848,7 +10854,7 @@ export async function gameRoutes(app: FastifyInstance) {
       const generatedNpcAvatars: Array<{ name: string; avatarUrl: string }> = [];
 
       // ── Generate background ──
-      if (!assetAbortSignal.aborted && input.backgroundTag) {
+      if (!assetAbortSignal.aborted && backgroundGenerationEnabled && input.backgroundTag) {
         const slug = generatedBackgroundSlug(input.backgroundTag);
         const backgroundDescription =
           input.backgroundDescription?.trim() || input.backgroundTag.replace(/:/g, " ").replace(/-/g, " ");

--- a/packages/server/src/routes/generate.routes.ts
+++ b/packages/server/src/routes/generate.routes.ts
@@ -2801,12 +2801,15 @@ export async function generateRoutes(app: FastifyInstance) {
         // If the background agent is enabled, load available backgrounds + tags into context
         const backgroundAgent = resolvedAgents.find((a) => a.type === "background");
         if (backgroundAgent) {
+          const backgroundGenerationEnabled =
+            backgroundAgent.settings?.autoGenerateBackgrounds === true &&
+            chatMeta.gameStoryboardViewerDisplayMode !== "background";
           agentContext.memory._availableBackgrounds = [];
           agentContext.memory._currentBackground = chatMeta.background ?? null;
-          if (backgroundAgent.settings?.autoGenerateBackgrounds === true) {
+          if (backgroundGenerationEnabled) {
             agentContext.memory._backgroundGenerationEnabled = true;
           }
-          if (backgroundAgent.settings?.autoGenerateBackgrounds === true) {
+          if (backgroundGenerationEnabled) {
             const setupConfigForBackground =
               chatMeta.gameSetupConfig &&
               typeof chatMeta.gameSetupConfig === "object" &&
@@ -5994,7 +5997,9 @@ export async function generateRoutes(app: FastifyInstance) {
               const currentBackgroundAgent = resolvedAgents.find(
                 (a) => a.id === result.agentId || a.type === "background",
               );
-              const canGenerateBackground = currentBackgroundAgent?.settings?.autoGenerateBackgrounds === true;
+              const canGenerateBackground =
+                currentBackgroundAgent?.settings?.autoGenerateBackgrounds === true &&
+                chatMeta.gameStoryboardViewerDisplayMode !== "background";
               if (!bgData.chosen && canGenerateBackground && generationRequest) {
                 const promptText =
                   typeof generationRequest.prompt === "string" && generationRequest.prompt.trim()

--- a/packages/server/src/services/generation/game-gm-prompt-runtime.ts
+++ b/packages/server/src/services/generation/game-gm-prompt-runtime.ts
@@ -298,6 +298,7 @@ export async function injectGameGmPromptRuntime(args: {
     canGenerateBackgrounds:
       !!args.chatMetadata.enableSpriteGeneration &&
       args.chatMetadata.gameImageAutoGenerationEnabled !== false &&
+      args.chatMetadata.gameStoryboardViewerDisplayMode !== "background" &&
       !!args.chatMetadata.gameImageConnectionId,
     artStylePrompt: (setupConfig?.artStylePrompt as string) || undefined,
     gameTime,

--- a/packages/shared/src/types/chat.ts
+++ b/packages/shared/src/types/chat.ts
@@ -191,6 +191,8 @@ export interface ChatMemoryChunk {
  */
 export const SUMMARY_TAIL_MESSAGES = { MIN: 0, MAX: 50, DEFAULT: 10 } as const;
 
+export type GameStoryboardViewerDisplayMode = "floating" | "background";
+
 /** Extra metadata stored on a chat. */
 export interface ChatMetadata {
   /** Compiled enabled rolling summary text for context injection. Derived from summaryEntries when present. */
@@ -481,6 +483,8 @@ export interface ChatMetadata {
   gameStoryboardAutoIllustrationsEnabled?: boolean;
   /** When true, completed Game Mode GM turns automatically create storyboard keyframe videos. */
   gameStoryboardAutoGenerationEnabled?: boolean;
+  /** How the Game Mode storyboard viewer is displayed in the game surface. */
+  gameStoryboardViewerDisplayMode?: GameStoryboardViewerDisplayMode;
   /** Selected Game Mode storyboard prompt template for image-only auto storyboards. */
   gameStoryboardIllustrationPromptTemplateId?: string | null;
   /** Selected Game Mode storyboard prompt template for animation-ready auto storyboards. */

--- a/start-e377a9df.bat
+++ b/start-e377a9df.bat
@@ -1,0 +1,318 @@
+@echo off
+setlocal enabledelayedexpansion
+cd /d "%~dp0"
+title Marinara Engine (e377a9df)
+color 0A
+echo.
+echo  +==========================================+
+echo  ^| Marinara Engine - Pinned e377a9df Launch ^|
+echo  +==========================================+
+echo.
+set "PINNED_COMMIT=e377a9df9fdc316bd2dcb0e643c1325c2d8f4da7"
+
+
+:: Check for Node.js
+where node >nul 2>&1
+if errorlevel 1 (
+    echo  [ERROR] Node.js is not installed or not in PATH.
+    echo  Please install Node.js 24 LTS or newer from https://nodejs.org
+    echo.
+    pause
+    exit /b 1
+)
+
+for /f "tokens=1 delims=." %%a in ('node -v') do set "NODE_RAW=%%a"
+set "NODE_MAJOR=!NODE_RAW:v=!"
+if not defined NODE_MAJOR (
+    echo  [ERROR] Could not determine Node.js version.
+    pause
+    exit /b 1
+)
+if !NODE_MAJOR! LSS 24 (
+    echo  [ERROR] Node.js 24 LTS or newer is required. You have v!NODE_MAJOR!.
+    echo  Please update Node.js from https://nodejs.org
+    echo.
+    pause
+    exit /b 1
+)
+
+:: Resolve the repo-pinned pnpm version from package.json
+set "PNPM_VERSION=10.33.2"
+for /f "usebackq delims=" %%i in (`node -p "JSON.parse(require('fs').readFileSync('package.json','utf8')).packageManager?.split('@')[1] || '10.33.2'"`) do set "PNPM_VERSION=%%i"
+set "PNPM_RUNNER=pnpm"
+set "CURRENT_PNPM_VERSION="
+
+:: Ensure pnpm is available before any update/install path uses it
+where corepack >nul 2>&1
+if not errorlevel 1 (
+    echo  [..] Aligning pnpm to %PNPM_VERSION% via Corepack...
+    for /f "usebackq delims=" %%i in (`corepack pnpm@%PNPM_VERSION% --version 2^>nul`) do set "CURRENT_PNPM_VERSION=%%i"
+    if /I "!CURRENT_PNPM_VERSION!"=="%PNPM_VERSION%" (
+        set "PNPM_RUNNER=corepack"
+    ) else (
+        set "CURRENT_PNPM_VERSION="
+    )
+)
+
+if not defined CURRENT_PNPM_VERSION (
+    where pnpm >nul 2>&1
+    if not errorlevel 1 (
+        for /f "usebackq delims=" %%i in (`pnpm --version 2^>nul`) do set "CURRENT_PNPM_VERSION=%%i"
+        if /I "!CURRENT_PNPM_VERSION!"=="%PNPM_VERSION%" (
+            echo  [..] Using installed pnpm !CURRENT_PNPM_VERSION!
+        ) else (
+            if defined CURRENT_PNPM_VERSION echo  [..] Installed pnpm !CURRENT_PNPM_VERSION! does not match required %PNPM_VERSION%; trying a pinned temporary runner...
+            set "CURRENT_PNPM_VERSION="
+        )
+    )
+)
+
+if not defined CURRENT_PNPM_VERSION (
+    echo  [..] Using temporary pnpm %PNPM_VERSION% via npx...
+    for /f "usebackq delims=" %%i in (`npx --yes pnpm@%PNPM_VERSION% --version 2^>nul`) do set "CURRENT_PNPM_VERSION=%%i"
+    if /I "!CURRENT_PNPM_VERSION!"=="%PNPM_VERSION%" (
+        set "PNPM_RUNNER=npx"
+    ) else (
+        set "CURRENT_PNPM_VERSION="
+    )
+)
+
+if not defined CURRENT_PNPM_VERSION (
+    echo  [ERROR] Failed to make pnpm %PNPM_VERSION% available.
+    echo          Marinara can run without a global pnpm install, but Node.js must provide Corepack or npx/npm.
+    echo          Reinstall Node.js 24 LTS with npm enabled, or run: npm install -g pnpm
+    pause
+    exit /b 1
+)
+
+goto :after_restore_helper
+
+:restore_stashed_changes
+if not "!STASHED!"=="1" goto :eof
+if "!STASH_REF!"=="" goto :eof
+git stash apply -q "!STASH_REF!" >nul 2>&1
+if errorlevel 1 (
+    echo  [WARN] Auto-update could not reapply your local changes cleanly.
+    echo         Your changes are preserved in !STASH_REF!.
+    echo         Review them with: git stash show -p !STASH_REF!
+    echo         Reapply them manually with: git stash pop !STASH_REF!
+    git reset --hard HEAD >nul 2>&1
+    goto :eof
+)
+git stash drop -q "!STASH_REF!" >nul 2>&1
+goto :eof
+
+:after_restore_helper
+set "INSTALL_REQUIRED=0"
+set "BUILD_REQUIRED=0"
+
+:: Pin this checkout to the requested commit instead of following origin/staging.
+if not exist ".git" goto :skip_update
+echo  [..] Pinning checkout to %PINNED_COMMIT%
+for /f "tokens=*" %%i in ('git rev-parse HEAD 2^>nul') do set "OLD_HEAD=%%i"
+git rev-parse --verify "%PINNED_COMMIT%^{commit}" >nul 2>&1
+if errorlevel 1 (
+    echo  [..] Fetching pinned commit...
+    git fetch origin "%PINNED_COMMIT%" --quiet >nul 2>&1
+    if errorlevel 1 (
+        echo  [ERROR] Could not fetch pinned commit %PINNED_COMMIT%.
+        echo          Check your network connection, then try again.
+        pause
+        exit /b 1
+    )
+)
+for /f "tokens=*" %%i in ('git rev-parse "%PINNED_COMMIT%" 2^>nul') do set "TARGET_HEAD=%%i"
+if /I "!OLD_HEAD!"=="!TARGET_HEAD!" (
+    echo  [OK] Already pinned to e377a9df
+    goto :skip_update
+)
+
+:: Stash tracked changes only. Untracked installer files and this launcher are left in place.
+set "STASHED=0"
+set "STASH_REF="
+set "DIRTY=0"
+git diff --quiet >nul 2>&1
+if errorlevel 1 set "DIRTY=1"
+git diff --cached --quiet >nul 2>&1
+if errorlevel 1 set "DIRTY=1"
+if "!DIRTY!"=="1" (
+    git stash push -q -m "auto-stash before pinned e377a9df launch" >nul 2>&1 && set "STASHED=1"
+    if not "!STASHED!"=="1" (
+        echo  [ERROR] Could not stash tracked local changes. Refusing to move checkout.
+        echo          Commit, stash, or discard tracked changes, then run this launcher again.
+        pause
+        exit /b 1
+    )
+    for /f "tokens=*" %%i in ('git stash list -1 --format^=%%gd 2^>nul') do set "STASH_REF=%%i"
+)
+
+set "PIN_LOG=%TEMP%\marinara-pin-e377-!RANDOM!-!RANDOM!.log"
+if exist "!PIN_LOG!" del /q "!PIN_LOG!" >nul 2>&1
+git checkout --detach "!TARGET_HEAD!" >"!PIN_LOG!" 2>&1
+if errorlevel 1 (
+    if "!STASHED!"=="1" call :restore_stashed_changes
+    echo  [ERROR] Could not checkout pinned commit !TARGET_HEAD!.
+    if exist "!PIN_LOG!" (
+        for %%A in ("!PIN_LOG!") do if %%~zA GTR 0 (
+            echo         Git reported:
+            for /f "usebackq delims=" %%i in ("!PIN_LOG!") do echo         %%i
+        )
+        del /q "!PIN_LOG!" >nul 2>&1
+    )
+    pause
+    exit /b 1
+)
+if "!STASHED!"=="1" call :restore_stashed_changes
+if exist "!PIN_LOG!" del /q "!PIN_LOG!" >nul 2>&1
+echo  [OK] Pinned to e377a9df
+echo  [..] Dependencies and build will be refreshed before startup.
+set "INSTALL_REQUIRED=1"
+set "BUILD_REQUIRED=1"
+
+:skip_update
+echo  [OK] Node.js found:
+node -v
+echo  [OK] pnpm !CURRENT_PNPM_VERSION! ready
+
+:: Detect stale dist (source updated but dist not rebuilt)
+if not exist "packages\shared\dist\constants\defaults.js" goto :skip_version_check
+for /f "usebackq delims=" %%i in (`node -p "require('./package.json').version" 2^>nul`) do set "SOURCE_VER=%%i"
+for /f "usebackq delims=" %%i in (`node -e "try{const m=require('./packages/shared/dist/constants/defaults.js');console.log(m.APP_VERSION)}catch{}" 2^>nul`) do set "DIST_VER=%%i"
+for /f "usebackq delims=" %%i in (`git rev-parse --short=12 HEAD 2^>nul`) do set "SOURCE_COMMIT=%%i"
+for /f "usebackq delims=" %%i in (`node -e "try{const m=require('./packages/server/dist/config/build-meta.json');console.log(m.commit || '')}catch{}" 2^>nul`) do set "DIST_COMMIT=%%i"
+if not "!SOURCE_VER!"=="" if not "!DIST_VER!"=="" if not "!SOURCE_VER!"=="!DIST_VER!" (
+    echo  [WARN] Version mismatch: source v!SOURCE_VER! but dist has v!DIST_VER!
+    echo  [..] Dependencies and build will be refreshed before startup.
+    set "INSTALL_REQUIRED=1"
+    set "BUILD_REQUIRED=1"
+)
+if not "!SOURCE_COMMIT!"=="" if /I not "!SOURCE_COMMIT!"=="!DIST_COMMIT!" (
+    echo  [WARN] Build commit mismatch: source !SOURCE_COMMIT! but dist has !DIST_COMMIT!
+    echo  [..] Dependencies and build will be refreshed before startup.
+    set "INSTALL_REQUIRED=1"
+    set "BUILD_REQUIRED=1"
+)
+:skip_version_check
+
+:: Install dependencies if needed
+if not exist "node_modules" set "INSTALL_REQUIRED=1"
+node scripts\check-workspace-install.mjs >nul 2>&1
+if errorlevel 1 set "INSTALL_REQUIRED=1"
+if not "!INSTALL_REQUIRED!"=="1" goto :skip_install
+echo.
+echo  [..] Installing dependencies...
+echo      This may take a few minutes.
+echo.
+call :run_pnpm install --force
+if errorlevel 1 echo  [ERROR] Failed to install dependencies. & pause & exit /b 1
+
+:skip_install
+
+:: Load .env if present (respects user overrides)
+if not exist .env goto :skip_env
+for /f "usebackq eol=# tokens=1,* delims==" %%A in (".env") do (
+    if not "%%A"=="" if not "%%B"=="" set "%%A=%%~B"
+)
+
+:skip_env
+:: Optional AI sprite background remover
+if defined BACKGROUNDREMOVER_AUTO_INSTALL (
+    if /I "%BACKGROUNDREMOVER_AUTO_INSTALL%"=="1" goto install_bgremover
+    if /I "%BACKGROUNDREMOVER_AUTO_INSTALL%"=="true" goto install_bgremover
+    if /I "%BACKGROUNDREMOVER_AUTO_INSTALL%"=="yes" goto install_bgremover
+    if /I "%BACKGROUNDREMOVER_AUTO_INSTALL%"=="on" goto install_bgremover
+)
+goto skip_bgremover
+:install_bgremover
+echo  [..] Ensuring optional AI background remover runtime...
+call :run_pnpm backgroundremover:install -- --if-missing
+if errorlevel 1 echo  [WARN] Optional background remover install failed; built-in cleanup will still work.
+:skip_bgremover
+
+:: Build if needed
+if not exist "packages\shared\dist\constants\defaults.js" set "BUILD_REQUIRED=1"
+if not exist "packages\server\dist\index.js" set "BUILD_REQUIRED=1"
+if not exist "packages\client\dist\index.html" set "BUILD_REQUIRED=1"
+if "!BUILD_REQUIRED!"=="1" (
+    echo  [..] Cleaning stale build artifacts...
+    call :run_pnpm clean:stale-client
+    if errorlevel 1 echo  [ERROR] Failed to clean stale client artifacts. & pause & exit /b 1
+    call :run_pnpm --filter @marinara-engine/shared clean
+    if errorlevel 1 echo  [ERROR] Failed to clean shared build artifacts. & pause & exit /b 1
+    call :run_pnpm --filter @marinara-engine/server clean
+    if errorlevel 1 echo  [ERROR] Failed to clean server build artifacts. & pause & exit /b 1
+    call :run_pnpm --filter @marinara-engine/client clean
+    if errorlevel 1 echo  [ERROR] Failed to clean client build artifacts. & pause & exit /b 1
+    echo  [..] Building Marinara Engine...
+    call :run_pnpm --filter @marinara-engine/shared build
+    if errorlevel 1 echo  [ERROR] Failed to build shared package. & pause & exit /b 1
+    call :run_pnpm --filter @marinara-engine/server --filter @marinara-engine/client --parallel run build
+    if errorlevel 1 echo  [ERROR] Failed to build server or client package. & pause & exit /b 1
+)
+
+:: Database migrations are handled automatically at server startup by runMigrations()
+
+:: Set defaults only if not already set
+set NODE_ENV=production
+if not defined PORT set PORT=7860
+if not defined HOST set HOST=0.0.0.0
+if not defined SIDECAR_RUNTIME_INSTALL_ENABLED set SIDECAR_RUNTIME_INSTALL_ENABLED=true
+
+set PROTOCOL=http
+if defined SSL_CERT if defined SSL_KEY set PROTOCOL=https
+set "BROWSER_HOST=%HOST%"
+if "%BROWSER_HOST%"=="" set "BROWSER_HOST=127.0.0.1"
+if "%BROWSER_HOST%"=="0.0.0.0" set "BROWSER_HOST=127.0.0.1"
+if "%BROWSER_HOST%"=="::" set "BROWSER_HOST=127.0.0.1"
+
+set "AUTO_OPEN_BROWSER_ENABLED=1"
+if defined AUTO_OPEN_BROWSER (
+    if /I "%AUTO_OPEN_BROWSER%"=="0" set "AUTO_OPEN_BROWSER_ENABLED="
+    if /I "%AUTO_OPEN_BROWSER%"=="false" set "AUTO_OPEN_BROWSER_ENABLED="
+    if /I "%AUTO_OPEN_BROWSER%"=="no" set "AUTO_OPEN_BROWSER_ENABLED="
+    if /I "%AUTO_OPEN_BROWSER%"=="off" set "AUTO_OPEN_BROWSER_ENABLED="
+)
+
+node scripts\check-port-available.mjs
+if errorlevel 1 (
+    pause
+    goto :eof
+)
+
+echo.
+echo  ==========================================
+echo    Starting Marinara Engine on %PROTOCOL%://%HOST%:%PORT%
+if not "%BROWSER_HOST%"=="%HOST%" echo    Local browser URL: %PROTOCOL%://%BROWSER_HOST%:%PORT%
+echo    Press Ctrl+C to stop
+echo  ==========================================
+echo.
+
+:: Open browser after a short delay (use explorer.exe as fallback)
+if defined AUTO_OPEN_BROWSER_ENABLED (
+    start "" cmd /c "timeout /t 4 /nobreak >nul && start %PROTOCOL%://%BROWSER_HOST%:%PORT% || explorer %PROTOCOL%://%BROWSER_HOST%:%PORT%"
+) else (
+    echo  [OK] Auto-open disabled ^(AUTO_OPEN_BROWSER=%AUTO_OPEN_BROWSER%^)
+)
+
+:: Start server
+cd packages\server
+node dist/index.js
+if errorlevel 1 (
+    echo.
+    echo  [ERROR] Server exited unexpectedly. See the error above.
+    echo.
+    pause
+)
+goto :eof
+
+:run_pnpm
+if /I "%PNPM_RUNNER%"=="corepack" (
+    call corepack pnpm@%PNPM_VERSION% --config.trustPolicy=off --config.confirmModulesPurge=false %*
+) else (
+    if /I "%PNPM_RUNNER%"=="npx" (
+        call npx --yes pnpm@%PNPM_VERSION% --config.trustPolicy=off --config.confirmModulesPurge=false %*
+    ) else (
+        call pnpm --config.trustPolicy=off --config.confirmModulesPurge=false %*
+    )
+)
+exit /b %errorlevel%

--- a/start-local.bat
+++ b/start-local.bat
@@ -1,0 +1,193 @@
+@echo off
+setlocal enabledelayedexpansion
+cd /d "%~dp0"
+title Marinara Engine (Local Build)
+color 0A
+echo.
+echo  +==========================================+
+echo  ^| Marinara Engine - Local Build Launcher   ^|
+echo  +==========================================+
+echo.
+
+:: This launcher intentionally does not run git or install dependencies.
+:: It rebuilds the current local checkout before launch.
+
+where node >nul 2>&1
+if errorlevel 1 (
+    echo  [ERROR] Node.js is not installed or not in PATH.
+    echo  Please install Node.js 24 LTS or newer from https://nodejs.org
+    echo.
+    pause
+    exit /b 1
+)
+
+for /f "tokens=1 delims=." %%a in ('node -v') do set "NODE_RAW=%%a"
+set "NODE_MAJOR=!NODE_RAW:v=!"
+if not defined NODE_MAJOR (
+    echo  [ERROR] Could not determine Node.js version.
+    pause
+    exit /b 1
+)
+if !NODE_MAJOR! LSS 24 (
+    echo  [ERROR] Node.js 24 LTS or newer is required. You have v!NODE_MAJOR!.
+    echo  Please update Node.js from https://nodejs.org
+    echo.
+    pause
+    exit /b 1
+)
+
+set "PNPM_VERSION=10.33.2"
+for /f "usebackq delims=" %%i in (`node -p "JSON.parse(require('fs').readFileSync('package.json','utf8')).packageManager?.split('@')[1] || '10.33.2'"`) do set "PNPM_VERSION=%%i"
+set "PNPM_RUNNER=pnpm"
+set "CURRENT_PNPM_VERSION="
+
+where corepack >nul 2>&1
+if not errorlevel 1 (
+    echo  [..] Aligning pnpm to %PNPM_VERSION% via Corepack...
+    for /f "usebackq delims=" %%i in (`corepack pnpm@%PNPM_VERSION% --version 2^>nul`) do set "CURRENT_PNPM_VERSION=%%i"
+    if /I "!CURRENT_PNPM_VERSION!"=="%PNPM_VERSION%" (
+        set "PNPM_RUNNER=corepack"
+    ) else (
+        set "CURRENT_PNPM_VERSION="
+    )
+)
+
+if not defined CURRENT_PNPM_VERSION (
+    where pnpm.cmd >nul 2>&1
+    if not errorlevel 1 (
+        for /f "usebackq delims=" %%i in (`pnpm.cmd --version 2^>nul`) do set "CURRENT_PNPM_VERSION=%%i"
+        if /I "!CURRENT_PNPM_VERSION!"=="%PNPM_VERSION%" (
+            echo  [..] Using installed pnpm !CURRENT_PNPM_VERSION!
+        ) else (
+            if defined CURRENT_PNPM_VERSION echo  [..] Installed pnpm !CURRENT_PNPM_VERSION! does not match required %PNPM_VERSION%; trying a pinned temporary runner...
+            set "CURRENT_PNPM_VERSION="
+        )
+    )
+)
+
+if not defined CURRENT_PNPM_VERSION (
+    echo  [..] Using temporary pnpm %PNPM_VERSION% via npx...
+    for /f "usebackq delims=" %%i in (`npx --yes pnpm@%PNPM_VERSION% --version 2^>nul`) do set "CURRENT_PNPM_VERSION=%%i"
+    if /I "!CURRENT_PNPM_VERSION!"=="%PNPM_VERSION%" (
+        set "PNPM_RUNNER=npx"
+    ) else (
+        set "CURRENT_PNPM_VERSION="
+    )
+)
+
+if not defined CURRENT_PNPM_VERSION (
+    echo  [ERROR] Failed to make pnpm %PNPM_VERSION% available.
+    echo          Node.js must provide Corepack or npx/npm.
+    echo          Reinstall Node.js 24 LTS with npm enabled, or run: npm install -g pnpm
+    pause
+    exit /b 1
+)
+
+echo  [OK] Node.js found:
+node -v
+echo  [OK] pnpm !CURRENT_PNPM_VERSION! ready
+echo.
+echo  [..] Rebuilding local checkout...
+call :run_pnpm build
+if errorlevel 1 (
+    echo.
+    echo  [ERROR] Local build failed. Fix the build error above, then run this launcher again.
+    echo.
+    pause
+    exit /b 1
+)
+echo  [OK] Local build completed
+echo.
+
+if not exist "packages\shared\dist\constants\defaults.js" (
+    echo  [ERROR] Shared build output is missing.
+    echo          Run: pnpm.cmd build
+    echo.
+    pause
+    exit /b 1
+)
+
+if not exist "packages\server\dist\index.js" (
+    echo  [ERROR] Server build output is missing.
+    echo          Run: pnpm.cmd build
+    echo.
+    pause
+    exit /b 1
+)
+
+if not exist "packages\client\dist\index.html" (
+    echo  [ERROR] Client build output is missing.
+    echo          Run: pnpm.cmd build
+    echo.
+    pause
+    exit /b 1
+)
+
+:: Load .env if present (respects values already set by the caller)
+if not exist .env goto :skip_env
+for /f "usebackq eol=# tokens=1,* delims==" %%A in (".env") do (
+    if not "%%A"=="" if not "%%B"=="" if not defined %%A set "%%A=%%~B"
+)
+
+:skip_env
+set NODE_ENV=production
+if not defined PORT set PORT=7860
+if not defined HOST set HOST=127.0.0.1
+if not defined SIDECAR_RUNTIME_INSTALL_ENABLED set SIDECAR_RUNTIME_INSTALL_ENABLED=true
+
+set PROTOCOL=http
+if defined SSL_CERT if defined SSL_KEY set PROTOCOL=https
+set "BROWSER_HOST=%HOST%"
+if "%BROWSER_HOST%"=="" set "BROWSER_HOST=127.0.0.1"
+if "%BROWSER_HOST%"=="0.0.0.0" set "BROWSER_HOST=127.0.0.1"
+if "%BROWSER_HOST%"=="::" set "BROWSER_HOST=127.0.0.1"
+
+set "AUTO_OPEN_BROWSER_ENABLED=1"
+if defined AUTO_OPEN_BROWSER (
+    if /I "%AUTO_OPEN_BROWSER%"=="0" set "AUTO_OPEN_BROWSER_ENABLED="
+    if /I "%AUTO_OPEN_BROWSER%"=="false" set "AUTO_OPEN_BROWSER_ENABLED="
+    if /I "%AUTO_OPEN_BROWSER%"=="no" set "AUTO_OPEN_BROWSER_ENABLED="
+    if /I "%AUTO_OPEN_BROWSER%"=="off" set "AUTO_OPEN_BROWSER_ENABLED="
+)
+
+node scripts\check-port-available.mjs
+if errorlevel 1 (
+    pause
+    goto :eof
+)
+
+echo.
+echo  ==========================================
+echo    Starting local build on %PROTOCOL%://%HOST%:%PORT%
+if not "%BROWSER_HOST%"=="%HOST%" echo    Local browser URL: %PROTOCOL%://%BROWSER_HOST%:%PORT%
+echo    Press Ctrl+C to stop
+echo  ==========================================
+echo.
+
+if defined AUTO_OPEN_BROWSER_ENABLED (
+    start "" cmd /c "timeout /t 4 /nobreak >nul && start %PROTOCOL%://%BROWSER_HOST%:%PORT% || explorer %PROTOCOL%://%BROWSER_HOST%:%PORT%"
+) else (
+    echo  [OK] Auto-open disabled ^(AUTO_OPEN_BROWSER=%AUTO_OPEN_BROWSER%^)
+)
+
+cd packages\server
+node dist/index.js
+if errorlevel 1 (
+    echo.
+    echo  [ERROR] Server exited unexpectedly. See the error above.
+    echo.
+    pause
+)
+goto :eof
+
+:run_pnpm
+if /I "%PNPM_RUNNER%"=="corepack" (
+    call corepack pnpm@%PNPM_VERSION% --config.trustPolicy=off --config.confirmModulesPurge=false %*
+) else (
+    if /I "%PNPM_RUNNER%"=="npx" (
+        call npx --yes pnpm@%PNPM_VERSION% --config.trustPolicy=off --config.confirmModulesPurge=false %*
+    ) else (
+        call pnpm.cmd --config.trustPolicy=off --config.confirmModulesPurge=false %*
+    )
+)
+exit /b %errorlevel%


### PR DESCRIPTION
## Linked issue

Closes #3354

## Why this change

Storyboard visuals can feel disconnected or get in the way when they only appear as a floating viewer. The requested background display mode lets storyboard media act like a scene visual while keeping the normal game UI, sprites, and controls above it.

This also fixes the follow-up visual mismatch: background-mode storyboard media now renders opaque and without the extra dark overlay/gradient, so the image or video is not dimmed compared with the Gallery view.

## What changed

- Added shared chat metadata for `gameStoryboardViewerDisplayMode` with `floating` and `background` modes.
- Added a Storyboards settings control for choosing `Floating` or `Background` display.
- Rendered background-mode storyboard images/videos as a pointer-events-none layer above the normal game background and below game UI/sprites.
- Kept floating viewer behavior as the default for existing chats.
- Added opt-in Windows launcher helpers: `start-e377a9df.bat` for the pinned e377 checkout and `start-local.bat` for rebuilding/running the local checkout without Git updates.

## Validation

- [ ] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed `CONTRIBUTING.md`

### Manual verification notes

- `pnpm.cmd --filter @marinara-engine/shared build` passed locally.
- `pnpm.cmd --filter @marinara-engine/client build` passed locally.
- `pnpm.cmd check` passed before the final no-filter visual tweak; the final tweak was revalidated with the focused client build.
- Human manual verification still needed: set Storyboards > Viewer Display to Background, open Game Mode fullscreen, compare storyboard visual brightness against Gallery, and confirm UI/sprites remain above the storyboard layer.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Version/release files updated (only if this PR includes a version bump)

## UI evidence (if applicable)

Manual screenshots or recordings still need to be attached by a human verifier.