### PR TITLE
fix(lorebooks): restore lorebooksStorage in characters.routes (unbreak staging build)

### DIFF
--- a/packages/server/src/routes/characters.routes.ts
+++ b/packages/server/src/routes/characters.routes.ts
@@ -19,6 +19,7 @@ import { createPersonaGalleryStorage } from "../services/storage/persona-gallery
 import { createChatsStorage } from "../services/storage/chats.storage.js";
 import { createGameSceneVideosStorage } from "../services/storage/game-scene-videos.storage.js";
 import { createConnectionsStorage } from "../services/storage/connections.storage.js";
+import { createLorebooksStorage } from "../services/storage/lorebooks.storage.js";
 import { generateImage } from "../services/image/image-generation.js";
 import { resolveConnectionImageDefaults } from "../services/image/image-generation-defaults.js";
 import { loadImageGenerationUserSettings } from "../services/image/image-generation-settings.js";
@@ -542,6 +543,7 @@ export async function charactersRoutes(app: FastifyInstance) {
   const storage = createCharactersStorage(app.db);
   const characterGallery = createCharacterGalleryStorage(app.db);
   const personaGallery = createPersonaGalleryStorage(app.db);
+  const lorebooksStorage = createLorebooksStorage(app.db);
 
   // ── Characters ──
 


### PR DESCRIPTION
## Linked issue

Closes #3356

## Why this change

The server package fails to build on `staging`: `TS2304: Cannot find name 'lorebooksStorage'` ×3 in `characters.routes.ts` (lines 1360/1393/1404), so `pnpm build` and `pnpm check` exit 2 for everyone on staging. Root cause — a semantic merge that git could not detect:

- #3349 (revert linked-lorebook native export) **removed** the module-level `const lorebooksStorage = createLorebooksStorage(app.db)` and its import (they only fed the export bundling that PR reverts).
- #3343 ("Embed into card") **added** the `POST /:id/embedded-lorebook/embed` handler, which **uses** `lorebooksStorage`, and merged **after** #3349 without a rebase.
- The removed-declaration lines and the added-usage lines are in different parts of the file, so git auto-merged with **no textual conflict** — landing code that references an undeclared symbol.

## What changed

- `packages/server/src/routes/characters.routes.ts` — re-added the `createLorebooksStorage` import and `const lorebooksStorage = createLorebooksStorage(app.db)` next to the other storage consts. This is the storage handle the Embed-into-card endpoint legitimately needs; the revert only needed to drop the export-bundling *helpers*, not this handle.

## Validation

- [ ] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed `CONTRIBUTING.md`

### Manual verification notes

- `pnpm build` passes (exit 0) — the exact command from the bug report; the three `TS2304` errors are gone. Server package build (`node ./scripts/build.mjs`) and client build both complete.
- `pnpm --filter @marinara-engine/server lint` (`tsc`) passes.
- Manually verify the **Embed into card** action still works end-to-end in the app (`POST /:id/embedded-lorebook/embed`) — it was the only endpoint referencing the previously-missing symbol.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Version/release files updated (only if this PR includes a version bump)

Build-only fix — no user-facing behavior change, no version bump. (No CHANGELOG entry, since it repairs unreleased staging work rather than changing shipped behavior.)

## UI evidence (if applicable)

N/A — server build fix; no UI change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Character embedded lorebooks now use persistent storage, enabling the embed action to fetch and update saved lorebook data reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->