### PR TITLE
Fix gallery delete confirmation in chat drawer

### DIFF
--- a/packages/client/src/components/chat/ChatGallery.tsx
+++ b/packages/client/src/components/chat/ChatGallery.tsx
@@ -721,7 +721,10 @@ export function ChatGallery({
       {portalRoot &&
         assetBrowserOpen &&
         createPortal(
-          <div className="fixed inset-0 z-[10000] flex items-center justify-center bg-black/55 p-3 backdrop-blur-sm max-md:pt-[env(safe-area-inset-top)]">
+          <div
+            data-chat-floating-panel
+            className="fixed inset-0 z-[10000] flex items-center justify-center bg-black/55 p-3 backdrop-blur-sm max-md:pt-[env(safe-area-inset-top)]"
+          >
             <div className="flex max-h-[88vh] w-[min(58rem,calc(100vw-1.5rem))] flex-col overflow-hidden rounded-xl bg-[var(--background)] shadow-2xl ring-1 ring-[var(--border)]">
               <div className="flex items-center justify-between border-b border-[var(--border)] px-4 py-3">
                 <h3 className="flex items-center gap-2 text-sm font-semibold">
@@ -808,7 +811,10 @@ export function ChatGallery({
       {portalRoot &&
         confirmDeleteId &&
         createPortal(
-          <div className="fixed inset-0 z-[10000] flex items-center justify-center bg-black/50 backdrop-blur-sm max-md:pt-[env(safe-area-inset-top)]">
+          <div
+            data-chat-floating-panel
+            className="fixed inset-0 z-[10000] flex items-center justify-center bg-black/50 backdrop-blur-sm max-md:pt-[env(safe-area-inset-top)]"
+          >
             <div className="mx-4 rounded-xl bg-[var(--background)] p-5 shadow-2xl ring-1 ring-[var(--border)]">
               <p className="mb-4 text-sm font-medium">Delete this image?</p>
               <div className="flex gap-2">

--- a/packages/server/src/routes/characters.routes.ts
+++ b/packages/server/src/routes/characters.routes.ts
@@ -19,6 +19,7 @@ import { createPersonaGalleryStorage } from "../services/storage/persona-gallery
 import { createChatsStorage } from "../services/storage/chats.storage.js";
 import { createGameSceneVideosStorage } from "../services/storage/game-scene-videos.storage.js";
 import { createConnectionsStorage } from "../services/storage/connections.storage.js";
+import { createLorebooksStorage } from "../services/storage/lorebooks.storage.js";
 import { generateImage } from "../services/image/image-generation.js";
 import { resolveConnectionImageDefaults } from "../services/image/image-generation-defaults.js";
 import { loadImageGenerationUserSettings } from "../services/image/image-generation-settings.js";
@@ -542,6 +543,7 @@ export async function charactersRoutes(app: FastifyInstance) {
   const storage = createCharactersStorage(app.db);
   const characterGallery = createCharacterGalleryStorage(app.db);
   const personaGallery = createPersonaGalleryStorage(app.db);
+  const lorebooksStorage = createLorebooksStorage(app.db);
 
   // ── Characters ──
 


### PR DESCRIPTION
## Summary

Fixes chat Gallery image deletion from the floating Gallery drawer. The delete confirmation is rendered in a portal, and the drawer's outside-click handler treated that portal as outside the drawer, closing/unmounting it on pointerdown before the Delete button click could fire.

This PR marks the Gallery's portaled delete confirmation and asset browser overlays with the existing `data-chat-floating-panel` escape hatch so their controls remain interactive. It also restores the missing `lorebooksStorage` binding in `characters.routes.ts`, which was blocking `pnpm check` on current `staging`.

No linked issue is attached yet; per contributor guidance, one should be opened for the reported Gallery delete regression.

## Verification

- `pnpm check`
- Injected backend delete proof: chat gallery DELETE removes the row and file.
- Playwright event proof: clicking the portaled Delete button no longer closes the drawer first; the click handler fires.

## Manual verification needed

- [ ] Manually verify deleting a Gallery image from Roleplay mode removes it and it stays gone after closing/reopening Gallery.
- [ ] Manually verify the Gallery image browser overlay still opens and closes correctly in Roleplay mode.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the character page’s embedded lorebook flow so linked lorebooks can be embedded more reliably.
  * Fixed floating panel handling for the asset browser and delete confirmation modal, helping overlays behave more consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->