### PR TITLE
fix(lorebooks): add unembed action + clarify embedded-lorebook UX

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 - Fixed Conversation-created scene chats so their Prompt Preset selector remains visible while still defaulting to None.
 - Made the Connections panel's unfiled/root drop area more forgiving so desktop users, including Windows users, can reliably drag connections out of folders without hitting a tiny target.
 - Fixed native lorebook import so nested folders keep their parent/child hierarchy instead of being flattened to the top level (#3347).
+- Fixed the character Lorebook tab so an embedded lorebook can be removed from the card: added a **Remove from card** action (including for cards with no linked copy), clarified that the row delete only unlinks the standalone while the embedded copy stays, and renamed **Edit Linked Lorebook** to **Edit Embedded Lorebook** (#3359).
 
 ## [2.1.0]
 

--- a/packages/client/src/components/characters/CharacterEditor.tsx
+++ b/packages/client/src/components/characters/CharacterEditor.tsx
@@ -274,6 +274,7 @@ export function CharacterEditor() {
     lorebookEmbedInFlightRef.current = inFlight;
     setLorebookEmbedding(inFlight);
   }, []);
+  const isLorebookEmbeddingInFlight = useCallback(() => lorebookEmbedInFlightRef.current, []);
   const markDirty = useCallback(() => {
     editRevisionRef.current += 1;
     setDirtyState(true);
@@ -375,6 +376,10 @@ export function CharacterEditor() {
   // Save would resend the stale pre-remove data and silently re-embed it. The
   // linked standalone lorebook, if any, is left untouched.
   const handleLorebookUnembedded = useCallback(() => {
+    if (lorebookEmbedInFlightRef.current) {
+      toast.error("Wait for the embedded lorebook update to finish before removing it from the card.");
+      return;
+    }
     if (!dirtyRef.current) return;
     setFormData((prev) => {
       if (!prev) return prev;
@@ -1063,6 +1068,8 @@ export function CharacterEditor() {
               <LorebookTab
                 characterId={characterId}
                 formData={formData}
+                embedding={lorebookEmbedding}
+                isEmbeddingInFlight={isLorebookEmbeddingInFlight}
                 onEmbedded={handleLorebookEmbedded}
                 onEmbeddingChange={setLorebookEmbedInFlight}
                 onUnembed={handleLorebookUnembedded}
@@ -4096,12 +4103,16 @@ function ColorsTab({
 function LorebookTab({
   characterId,
   formData,
+  embedding,
+  isEmbeddingInFlight,
   onEmbedded,
   onEmbeddingChange,
   onUnembed,
 }: {
   characterId: string | null;
   formData: CharacterData;
+  embedding?: boolean;
+  isEmbeddingInFlight?: () => boolean;
   onEmbedded?: (lorebookId: string, characterBook: unknown) => void;
   onEmbeddingChange?: (embedding: boolean) => void;
   onUnembed?: () => void;
@@ -4134,6 +4145,14 @@ function LorebookTab({
     rawLinkedLorebookId && (linkedLorebookQuery.isLoading || linkedLorebookQuery.data) ? rawLinkedLorebookId : null;
   const hasEmbeddedLorebook = entries.length > 0 || embeddedLorebookMetadata.hasEmbeddedLorebook === true;
 
+  const isRemoveBlockedByEmbedding = () => {
+    if (embedding || isEmbeddingInFlight?.()) {
+      toast.error("Wait for the embedded lorebook update to finish before removing it from the card.");
+      return true;
+    }
+    return false;
+  };
+
   const handleImportEmbeddedLorebook = async () => {
     if (!characterId) return;
     setImporting(true);
@@ -4161,13 +4180,19 @@ function LorebookTab({
   };
 
   const handleRemoveFromCard = async () => {
-    if (!characterId) return;
+    if (!characterId || removing) return;
+    if (isRemoveBlockedByEmbedding()) return;
     if (
-      !window.confirm(
-        "Remove the embedded lorebook from this character's card? Its entries will no longer be baked into the card. Any linked standalone lorebook is kept.",
-      )
+      !(await showConfirmDialog({
+        title: "Remove Embedded Lorebook",
+        message:
+          "Remove the embedded lorebook from this character's card? Its entries will no longer be baked into the card. Any linked standalone lorebook is kept.",
+        confirmLabel: "Remove from card",
+        tone: "destructive",
+      }))
     )
       return;
+    if (isRemoveBlockedByEmbedding()) return;
     setRemoving(true);
     try {
       await api.delete(`/characters/${characterId}/embedded-lorebook`);
@@ -4231,11 +4256,15 @@ function LorebookTab({
           <button
             type="button"
             onClick={handleRemoveFromCard}
-            disabled={!characterId || removing}
+            disabled={!characterId || removing || embedding}
             className="inline-flex items-center gap-1.5 rounded-lg bg-[var(--destructive)]/10 px-3 py-1.5 text-xs font-medium text-[var(--destructive)] transition-all hover:bg-[var(--destructive)]/20 disabled:cursor-not-allowed disabled:opacity-50"
-            title="Remove the embedded lorebook (data.character_book) from the card"
+            title={
+              embedding
+                ? "Wait for the embedded lorebook update to finish."
+                : "Remove the embedded lorebook (data.character_book) from the card"
+            }
           >
-            {removing ? <Loader2 size="0.75rem" className="animate-spin" /> : <Trash2 size="0.75rem" />}
+            {removing || embedding ? <Loader2 size="0.75rem" className="animate-spin" /> : <Trash2 size="0.75rem" />}
             Remove from card
           </button>
           <span className="text-[0.6875rem] text-[var(--muted-foreground)]">

--- a/packages/client/src/components/characters/CharacterEditor.tsx
+++ b/packages/client/src/components/characters/CharacterEditor.tsx
@@ -367,14 +367,15 @@ export function CharacterEditor() {
     });
   }, []);
 
-  // Remove the embedded lorebook from the card: drop `data.character_book` and
-  // the `embeddedLorebook` pointer. Staged in formData so a later Save persists
-  // it (clearing character_book is a plain card-field edit). Clearing the
-  // pointer also stops the standalone -> character_book sync from re-baking it
-  // (syncCharacterBookFromLorebook bails when the pointer no longer matches).
-  // Any linked standalone lorebook is left untouched — this only unbakes the
-  // copy embedded in the card.
+  // "Remove from card" clears the embedded lorebook server-side
+  // (data.character_book + the embeddedLorebook pointer) immediately. Mirror
+  // handleLorebookEmbedded's reconciliation: when the editor is clean the
+  // detail-query refetch re-syncs formData for us; when it is dirty the parse
+  // effect skips that re-sync, so patch formData directly — otherwise a later
+  // Save would resend the stale pre-remove data and silently re-embed it. The
+  // linked standalone lorebook, if any, is left untouched.
   const handleLorebookUnembedded = useCallback(() => {
+    if (!dirtyRef.current) return;
     setFormData((prev) => {
       if (!prev) return prev;
       const extensions = { ...(prev.extensions ?? {}) } as Record<string, unknown>;
@@ -392,8 +393,7 @@ export function CharacterEditor() {
         extensions: extensions as CharacterData["extensions"],
       };
     });
-    markDirty();
-  }, [markDirty]);
+  }, []);
 
   const updateExtension = useCallback(
     (key: string, value: unknown) => {
@@ -4111,6 +4111,7 @@ function LorebookTab({
   const qc = useQueryClient();
   const openLorebookDetail = useUIStore((s) => s.openLorebookDetail);
   const [importing, setImporting] = useState(false);
+  const [removing, setRemoving] = useState(false);
   const importMetadata =
     formData.extensions.importMetadata && typeof formData.extensions.importMetadata === "object"
       ? (formData.extensions.importMetadata as Record<string, unknown>)
@@ -4156,6 +4157,30 @@ function LorebookTab({
       toast.error(error instanceof Error ? error.message : "Failed to import embedded lorebook");
     } finally {
       setImporting(false);
+    }
+  };
+
+  const handleRemoveFromCard = async () => {
+    if (!characterId) return;
+    if (
+      !window.confirm(
+        "Remove the embedded lorebook from this character's card? Its entries will no longer be baked into the card. Any linked standalone lorebook is kept.",
+      )
+    )
+      return;
+    setRemoving(true);
+    try {
+      await api.delete(`/characters/${characterId}/embedded-lorebook`);
+      // Reconcile the editor (patches formData when dirty) then refresh caches so
+      // the tab, entries list, and Embedded badge update from server state.
+      onUnembed?.();
+      qc.invalidateQueries({ queryKey: ["characters", "detail", characterId] });
+      qc.invalidateQueries({ queryKey: lorebookKeys.all });
+      toast.success("Removed the embedded lorebook from the card.");
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : "Failed to remove embedded lorebook.");
+    } finally {
+      setRemoving(false);
     }
   };
 
@@ -4205,19 +4230,12 @@ function LorebookTab({
           )}
           <button
             type="button"
-            onClick={() => {
-              if (
-                !window.confirm(
-                  "Remove the embedded lorebook from this character's card? Its entries will no longer be baked into the card (Save to apply). Any linked standalone lorebook is kept.",
-                )
-              )
-                return;
-              onUnembed?.();
-            }}
-            className="inline-flex items-center gap-1.5 rounded-lg bg-[var(--destructive)]/10 px-3 py-1.5 text-xs font-medium text-[var(--destructive)] transition-all hover:bg-[var(--destructive)]/20"
-            title="Drop data.character_book from the card (the embedded copy)"
+            onClick={handleRemoveFromCard}
+            disabled={!characterId || removing}
+            className="inline-flex items-center gap-1.5 rounded-lg bg-[var(--destructive)]/10 px-3 py-1.5 text-xs font-medium text-[var(--destructive)] transition-all hover:bg-[var(--destructive)]/20 disabled:cursor-not-allowed disabled:opacity-50"
+            title="Remove the embedded lorebook (data.character_book) from the card"
           >
-            <Trash2 size="0.75rem" />
+            {removing ? <Loader2 size="0.75rem" className="animate-spin" /> : <Trash2 size="0.75rem" />}
             Remove from card
           </button>
           <span className="text-[0.6875rem] text-[var(--muted-foreground)]">

--- a/packages/client/src/components/characters/CharacterEditor.tsx
+++ b/packages/client/src/components/characters/CharacterEditor.tsx
@@ -4155,6 +4155,10 @@ function LorebookTab({
 
   const handleImportEmbeddedLorebook = async () => {
     if (!characterId) return;
+    if (removing) {
+      toast.error("Wait for the embedded lorebook removal to finish before importing.");
+      return;
+    }
     setImporting(true);
     try {
       const result = await api.post<{
@@ -4181,6 +4185,10 @@ function LorebookTab({
 
   const handleRemoveFromCard = async () => {
     if (!characterId || removing) return;
+    if (importing) {
+      toast.error("Wait for the embedded lorebook import to finish before removing it from the card.");
+      return;
+    }
     if (isRemoveBlockedByEmbedding()) return;
     if (
       !(await showConfirmDialog({
@@ -4232,10 +4240,10 @@ function LorebookTab({
           <button
             type="button"
             onClick={handleImportEmbeddedLorebook}
-            disabled={!characterId || importing}
+            disabled={!characterId || importing || removing}
             className={cn(
               "inline-flex items-center gap-1.5 rounded-lg px-3 py-1.5 text-xs font-medium transition-all",
-              importing || !characterId
+              importing || removing || !characterId
                 ? "cursor-not-allowed bg-[var(--accent)] text-[var(--muted-foreground)]"
                 : "bg-[var(--primary)]/15 text-[var(--primary)] hover:bg-[var(--primary)]/25",
             )}
@@ -4256,7 +4264,7 @@ function LorebookTab({
           <button
             type="button"
             onClick={handleRemoveFromCard}
-            disabled={!characterId || removing || embedding}
+            disabled={!characterId || removing || importing || embedding}
             className="inline-flex items-center gap-1.5 rounded-lg bg-[var(--destructive)]/10 px-3 py-1.5 text-xs font-medium text-[var(--destructive)] transition-all hover:bg-[var(--destructive)]/20 disabled:cursor-not-allowed disabled:opacity-50"
             title={
               embedding

--- a/packages/client/src/components/characters/CharacterEditor.tsx
+++ b/packages/client/src/components/characters/CharacterEditor.tsx
@@ -367,6 +367,34 @@ export function CharacterEditor() {
     });
   }, []);
 
+  // Remove the embedded lorebook from the card: drop `data.character_book` and
+  // the `embeddedLorebook` pointer. Staged in formData so a later Save persists
+  // it (clearing character_book is a plain card-field edit). Clearing the
+  // pointer also stops the standalone -> character_book sync from re-baking it
+  // (syncCharacterBookFromLorebook bails when the pointer no longer matches).
+  // Any linked standalone lorebook is left untouched — this only unbakes the
+  // copy embedded in the card.
+  const handleLorebookUnembedded = useCallback(() => {
+    setFormData((prev) => {
+      if (!prev) return prev;
+      const extensions = { ...(prev.extensions ?? {}) } as Record<string, unknown>;
+      const importMetadata =
+        extensions.importMetadata && typeof extensions.importMetadata === "object"
+          ? { ...(extensions.importMetadata as Record<string, unknown>) }
+          : null;
+      if (importMetadata) {
+        delete importMetadata.embeddedLorebook;
+        extensions.importMetadata = importMetadata;
+      }
+      return {
+        ...prev,
+        character_book: null,
+        extensions: extensions as CharacterData["extensions"],
+      };
+    });
+    markDirty();
+  }, [markDirty]);
+
   const updateExtension = useCallback(
     (key: string, value: unknown) => {
       setExtensionValue(key, formatCharacterExtensionValue(key, value, formatQuotes));
@@ -1037,6 +1065,7 @@ export function CharacterEditor() {
                 formData={formData}
                 onEmbedded={handleLorebookEmbedded}
                 onEmbeddingChange={setLorebookEmbedInFlight}
+                onUnembed={handleLorebookUnembedded}
               />
             )}
           </div>
@@ -4069,11 +4098,13 @@ function LorebookTab({
   formData,
   onEmbedded,
   onEmbeddingChange,
+  onUnembed,
 }: {
   characterId: string | null;
   formData: CharacterData;
   onEmbedded?: (lorebookId: string, characterBook: unknown) => void;
   onEmbeddingChange?: (embedding: boolean) => void;
+  onUnembed?: () => void;
 }) {
   const book = formData.character_book;
   const entries = book?.entries ?? [];
@@ -4094,7 +4125,7 @@ function LorebookTab({
   // another Marinara instance can carry a stale `lorebookId` in their
   // extensions, and an auto-import that errored silently can leave the
   // pointer set without a real DB row. If we trust the raw pointer the
-  // "Edit Linked Lorebook" button opens an editor that can never resolve
+  // "Edit Embedded Lorebook" button opens an editor that can never resolve
   // (its loading state is `isLoading || !lorebook`, and a 404'd query
   // satisfies the second clause forever), so verify before showing it.
   const linkedLorebookQuery = useLorebook(rawLinkedLorebookId);
@@ -4169,13 +4200,30 @@ function LorebookTab({
               className="inline-flex items-center gap-1.5 rounded-lg bg-[var(--primary)]/15 px-3 py-1.5 text-xs font-medium text-[var(--primary)] transition-all hover:bg-[var(--primary)]/25"
             >
               <Library size="0.75rem" />
-              Edit Linked Lorebook
+              Edit Embedded Lorebook
             </button>
           )}
+          <button
+            type="button"
+            onClick={() => {
+              if (
+                !window.confirm(
+                  "Remove the embedded lorebook from this character's card? Its entries will no longer be baked into the card (Save to apply). Any linked standalone lorebook is kept.",
+                )
+              )
+                return;
+              onUnembed?.();
+            }}
+            className="inline-flex items-center gap-1.5 rounded-lg bg-[var(--destructive)]/10 px-3 py-1.5 text-xs font-medium text-[var(--destructive)] transition-all hover:bg-[var(--destructive)]/20"
+            title="Drop data.character_book from the card (the embedded copy)"
+          >
+            <Trash2 size="0.75rem" />
+            Remove from card
+          </button>
           <span className="text-[0.6875rem] text-[var(--muted-foreground)]">
             {linkedLorebookId
-              ? "Opens the lorebook editor where you can add, edit, or delete entries."
-              : "Imports this embedded lorebook into Marinara as a linked lorebook."}
+              ? "Edit opens the lorebook editor; changes sync back into the card's embedded copy."
+              : "Import bakes this embedded lorebook into Marinara as an editable linked lorebook."}
           </span>
         </div>
       )}

--- a/packages/client/src/components/lorebooks/LorebookAssignmentSection.tsx
+++ b/packages/client/src/components/lorebooks/LorebookAssignmentSection.tsx
@@ -177,12 +177,17 @@ export function LorebookAssignmentSection({
   const unassignLorebook = async (lorebook: Lorebook) => {
     if (!ownerId) return;
     const nextOwnerIds = getOwnerIds(lorebook, ownerType).filter((id) => id !== ownerId);
+    const isEmbedded = ownerType === "character" && lorebook.id === embeddedLorebookId;
     try {
       await updateLorebook.mutateAsync({
         id: lorebook.id,
         ...(ownerType === "character" ? { characterIds: nextOwnerIds } : { personaIds: nextOwnerIds }),
       });
-      toast.success(`Removed ${lorebook.name}.`);
+      toast.success(
+        isEmbedded
+          ? `Unlinked ${lorebook.name}. It's still embedded in the card — use "Remove from card" to unbake the embedded copy.`
+          : `Removed ${lorebook.name}.`,
+      );
     } catch (error) {
       toast.error(error instanceof Error ? error.message : "Failed to remove lorebook.");
     }
@@ -294,7 +299,11 @@ export function LorebookAssignmentSection({
                   onClick={() => unassignLorebook(lorebook)}
                   disabled={updateLorebook.isPending}
                   className="rounded-lg p-1.5 text-[var(--muted-foreground)] transition-colors hover:bg-[var(--destructive)]/15 hover:text-[var(--destructive)] disabled:opacity-50"
-                  title="Remove lorebook"
+                  title={
+                    ownerType === "character" && lorebook.id === embeddedLorebookId
+                      ? "Unlink lorebook (the card's embedded copy stays — use Remove from card)"
+                      : "Remove lorebook"
+                  }
                 >
                   <Trash2 size="0.75rem" />
                 </button>

--- a/packages/client/src/hooks/use-lorebooks.ts
+++ b/packages/client/src/hooks/use-lorebooks.ts
@@ -206,7 +206,7 @@ export function useDeleteLorebook() {
       // marking them stale. `useLorebook`/`useLorebookEntries` set
       // staleTime to 5 minutes, and TanStack returns cached `data` even
       // after a refetch errors — so without explicit removal the next
-      // "Edit Linked Lorebook" click would render a ghost editor with
+      // "Edit Embedded Lorebook" click would render a ghost editor with
       // the deleted lorebook's name and metadata while the entries
       // query reports 0 entries from the server.
       qc.removeQueries({ queryKey: lorebookKeys.detail(id) });
@@ -218,7 +218,7 @@ export function useDeleteLorebook() {
       // characterId client-side (the detail cache may already be gone
       // by this point), so blanket-invalidate character queries —
       // missing this lets the character editor keep rendering stale
-      // entries and a broken "Edit Linked Lorebook" button.
+      // entries and a broken "Edit Embedded Lorebook" button.
       qc.invalidateQueries({ queryKey: characterKeys.all });
     },
   });

--- a/packages/server/src/routes/characters.routes.ts
+++ b/packages/server/src/routes/characters.routes.ts
@@ -47,7 +47,11 @@ import { assertInsideDir, extensionFromImageMime, isAllowedImageBuffer } from ".
 import { logger } from "../lib/logger.js";
 import { parseLibraryPageQuery } from "../utils/list-pagination.js";
 import { importSTLorebook } from "../services/import/st-lorebook.importer.js";
-import { embedLorebookIntoCharacter, getEmbeddedLorebookId } from "../services/lorebook/character-book-sync.js";
+import {
+  clearEmbeddedLorebookFromCharacter,
+  embedLorebookIntoCharacter,
+  getEmbeddedLorebookId,
+} from "../services/lorebook/character-book-sync.js";
 import AdmZip from "adm-zip";
 import { extname } from "path";
 import { pipeline } from "stream/promises";
@@ -1344,6 +1348,15 @@ export async function charactersRoutes(app: FastifyInstance) {
       entriesImported: result.entriesImported,
       reimported: result.reimported ?? false,
     };
+  });
+
+  // Remove the embedded lorebook from this character's card: drop
+  // data.character_book and the embeddedLorebook pointer. The user-initiated
+  // inverse of embed/import; the linked standalone lorebook (if any) is kept.
+  app.delete<{ Params: { id: string } }>("/:id/embedded-lorebook", async (req, reply) => {
+    const cleared = await clearEmbeddedLorebookFromCharacter(app.db, req.params.id);
+    if (!cleared) return reply.status(404).send({ error: "Character not found" });
+    return { success: true };
   });
 
   // Embed a standalone/linked character lorebook INTO this character's card

--- a/packages/server/src/services/lorebook/character-book-sync.ts
+++ b/packages/server/src/services/lorebook/character-book-sync.ts
@@ -288,7 +288,7 @@ export async function syncCharacterBookFromLorebook(db: DB, lorebookId: string):
  * `extensions.importMetadata.embeddedLorebook` pointer. Called when the
  * standalone lorebook is being deleted, so the V2 `character_book` cannot
  * resurrect on the next character open and the dangling
- * `lorebookId` pointer cannot leave a broken "Edit Linked Lorebook"
+ * `lorebookId` pointer cannot leave a broken "Edit Embedded Lorebook"
  * button behind.
  *
  * The character storage layer's `update` does a shallow merge of

--- a/packages/server/src/services/lorebook/character-book-sync.ts
+++ b/packages/server/src/services/lorebook/character-book-sync.ts
@@ -331,3 +331,41 @@ export async function clearCharacterEmbeddedLorebook(db: DB, characterId: string
     logger.error(err, "Failed to clear embedded lorebook for character %s", characterId);
   }
 }
+
+/**
+ * Unconditionally clear a character's embedded-lorebook footprint — drop
+ * `data.character_book` and the `extensions.importMetadata.embeddedLorebook`
+ * pointer — regardless of whether a standalone still exists or the pointer still
+ * matches. Backs the user-initiated "Remove from card" action; the linked
+ * standalone lorebook, if any, is left untouched. Returns false when the
+ * character does not exist. Unlike `clearCharacterEmbeddedLorebook` (a
+ * fire-and-forget side effect of deleting a standalone), this is user-driven, so
+ * DB errors propagate to the route instead of being swallowed.
+ */
+export async function clearEmbeddedLorebookFromCharacter(db: DB, characterId: string): Promise<boolean> {
+  const charactersStorage = createCharactersStorage(db);
+  const character = await charactersStorage.getById(characterId);
+  if (!character) return false;
+
+  const currentData = parseCharacterData(character.data);
+  const extensions =
+    currentData.extensions && typeof currentData.extensions === "object"
+      ? ({ ...(currentData.extensions as Record<string, unknown>) } as Record<string, unknown>)
+      : {};
+  const importMetadata =
+    extensions.importMetadata && typeof extensions.importMetadata === "object"
+      ? ({ ...(extensions.importMetadata as Record<string, unknown>) } as Record<string, unknown>)
+      : null;
+  if (importMetadata && "embeddedLorebook" in importMetadata) {
+    delete importMetadata.embeddedLorebook;
+    extensions.importMetadata = importMetadata;
+  }
+
+  await charactersStorage.update(
+    characterId,
+    { character_book: null, extensions: extensions as never },
+    undefined,
+    { skipVersionSnapshot: true },
+  );
+  return true;
+}


### PR DESCRIPTION
## Linked issue

Closes #3359

## Why this change

The Character editor's **Lorebook** tab gave no way to *unembed* a lorebook. Once a lorebook was baked into a card (`data.character_book`), the row's 🗑️ only **unlinked the standalone copy** — it never cleared `character_book`, so the embedded lorebook silently persisted in the card (still listed, still exported), and "Removed …" implied it was gone. Separately, **"Edit Linked Lorebook"** opens the standalone mirror (which syncs into `character_book`), muddling the embedded-vs-linked distinction.

Verified beforehand (see #3359): this was purely a UX/management gap, **not** a data-integrity or double-injection bug — an embedded `character_book` is inert at runtime; only the standalone activates.

## What changed

- **New "Remove from card" action** in the Lorebook tab, shown whenever the card has an embedded lorebook — including the orphaned case where no standalone exists. It's an **immediate server write** (new `DELETE /characters/:id/embedded-lorebook` → `clearEmbeddedLorebookFromCharacter`, which drops `data.character_book` and the `extensions.importMetadata.embeddedLorebook` pointer), reconciled with the editor exactly the way **Embed / Import / Reimport** already are: patch `formData` when the editor is dirty (so other unsaved edits survive and a later Save can't re-embed it) and re-sync from the detail refetch when it's clean. Clearing the pointer also stops the standalone→`character_book` sync from re-baking it. The linked standalone lorebook, if any, is left intact. Destructive → gated behind a `window.confirm`, shows a spinner while working, and toasts on success.
- **Renamed "Edit Linked Lorebook" → "Edit Embedded Lorebook"** and clarified the helper text ("Edit opens the lorebook editor; changes sync back into the card's embedded copy"). Also refreshed the four stale code comments that referenced the old button label (in `CharacterEditor.tsx`, `use-lorebooks.ts`, and `character-book-sync.ts`).
- **Clearer 🗑️ feedback:** when the row being unlinked is the embedded lorebook, the toast and tooltip now say it only unlinks and the embedded copy stays — pointing to "Remove from card."

Server: one new `DELETE` route + `clearEmbeddedLorebookFromCharacter` (a sibling of the existing `clearCharacterEmbeddedLorebook`). No shared-package or schema changes.

> Note: an earlier revision of this PR staged the removal in `formData` (apply-on-Save). Live testing showed that was confusing — a hard refresh before Save reloaded server state and appeared to "restore" the embedded lorebook — so removal is now an immediate server write, consistent with the other embedded-lorebook actions.

## Validation

- [ ] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed `CONTRIBUTING.md`

### Manual verification notes

- Client build (tsc) and ESLint pass: `pnpm --filter @marinara-engine/client build`, `pnpm --filter @marinara-engine/client lint`. (Full `pnpm check` is blocked on Windows by the pre-existing server `build.mjs` issue, unrelated to this change.)
- **Manually verify the click-through** (needs a real app + a character with an embedded lorebook):
  1. Open a character that has an embedded lorebook; confirm **Remove from card** appears in the Lorebook tab.
  2. Click it → confirm → it removes immediately with a toast; the embedded entries + Reimport/Edit row disappear, and a hard refresh (Ctrl+Shift+R) shows it stays gone (no Save needed). Then edit the still-linked standalone (if any) and confirm the embedded copy does not resurrect.
  3. With **other unsaved edits** in the editor, click **Remove from card** → confirm the other edits are preserved (editor stays dirty) and Save persists everything without re-embedding.
  4. With a *linked-but-not-embedded* lorebook, confirm **Remove from card** is not shown for it and "Embed into card" still works.
  5. Verify **Remove from card** also appears + works for a character whose card has `character_book` but **no** standalone (orphaned case).
  6. Unlink the embedded row via 🗑️ → confirm the toast says it only unlinked and the embedded copy stays.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Version/release files updated (only if this PR includes a version bump)

CHANGELOG updated (Fixed). No version bump.

## UI evidence (if applicable)

<img width="807" height="561" alt="{655CFF28-8E61-427F-8164-28C5C66EFA39}" src="https://github.com/user-attachments/assets/f31b95cf-0b38-4bf3-aff3-c7dcf817d77c" />

<img width="808" height="597" alt="{BB3345DE-B25B-426F-8191-8BC3F3AA1EA3}" src="https://github.com/user-attachments/assets/a3608edd-5f46-4073-bb87-61c1d30d2f03" />

<img width="806" height="599" alt="{7E26D522-B03D-45A7-A438-A74CD25626D9}" src="https://github.com/user-attachments/assets/333f5422-378c-40b9-ac72-51035d8efb9b" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a **Remove from card** action for embedded lorebooks on character cards.
  * Updated labels and messaging to distinguish **embedded** vs. **linked** lorebooks.

* **Bug Fixes**
  * Removing a lorebook from a character card now leaves any standalone lorebook copy intact.
  * Success and confirmation messages now clearly explain what is removed and what remains.
  * The remove action is blocked while a related update is still in progress.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->