### PR TITLE
Fix message rendering and agent image prompt edges

### DIFF
--- a/packages/client/src/components/chat/ChatImageLightbox.tsx
+++ b/packages/client/src/components/chat/ChatImageLightbox.tsx
@@ -70,6 +70,7 @@ export function ChatImageLightbox({
 
   return createPortal(
     <div
+      data-chat-floating-panel
       className="fixed inset-0 z-[10000] flex items-center justify-center bg-black/80 max-md:pt-[env(safe-area-inset-top)]"
       role="dialog"
       aria-modal="true"
@@ -176,6 +177,7 @@ export function ChatVideoLightbox({
 
   return createPortal(
     <div
+      data-chat-floating-panel
       className="fixed inset-0 z-[10000] flex items-center justify-center bg-black/80 max-md:pt-[env(safe-area-inset-top)]"
       role="dialog"
       aria-modal="true"

--- a/packages/client/src/components/chat/ChatMessage.tsx
+++ b/packages/client/src/components/chat/ChatMessage.tsx
@@ -41,7 +41,7 @@ import {
   EyeOff,
   Shield,
 } from "lucide-react";
-import { formatTextQuotes, type Message, type QuoteFormat } from "@marinara-engine/shared";
+import { decodeEncodedSpeakerTags, formatTextQuotes, type Message, type QuoteFormat } from "@marinara-engine/shared";
 import { memo, useState, useMemo, useRef, useEffect, useLayoutEffect, useCallback, type ReactNode } from "react";
 import { createPortal } from "react-dom";
 import { useQueryClient, type InfiniteData } from "@tanstack/react-query";
@@ -756,7 +756,7 @@ function renderContent(
   htmlScopeClass = "mari-html-message-content",
   quoteFormat: QuoteFormat = "straight",
 ): ReactNode {
-  const normalized = decodeEncodedChatHtmlTags(formatTextQuotes(text, quoteFormat));
+  const normalized = decodeEncodedSpeakerTags(decodeEncodedChatHtmlTags(formatTextQuotes(text, quoteFormat)));
 
   // Strip speaker tags before HTML detection (they aren't real HTML)
   const withoutSpeakerTags = normalized.replace(/<\/?speaker(?:="[^"]*")?>/g, "");

--- a/packages/client/src/hooks/use-generate.ts
+++ b/packages/client/src/hooks/use-generate.ts
@@ -65,10 +65,35 @@ const BUILT_IN_TRACKER_AGENT_TYPE_SET = new Set(
   BUILT_IN_AGENTS.filter((agent) => agent.category === "tracker" && !agent.libraryHidden).map((agent) => agent.id),
 );
 
-function showAgentWarning(raw: unknown) {
-  const data = raw && typeof raw === "object" ? (raw as { code?: unknown; message?: unknown }) : null;
+type AgentWarningToastData = {
+  code?: unknown;
+  message?: unknown;
+  connectionId?: unknown;
+  connectionName?: unknown;
+  model?: unknown;
+};
+
+function readAgentWarningString(value: unknown): string | null {
+  return typeof value === "string" && value.trim().length > 0 ? value.trim() : null;
+}
+
+function getAgentWarningToastKey(data: AgentWarningToastData | null, chatId: string, message: string): string {
+  const code = readAgentWarningString(data?.code) ?? "agent_warning";
+
+  if (code === "default_agent_connection_active") {
+    const connectionSignature =
+      readAgentWarningString(data?.connectionId) ?? readAgentWarningString(data?.connectionName) ?? "unknown";
+    const modelSignature = readAgentWarningString(data?.model) ?? "unknown";
+    return `${chatId}:${code}:${connectionSignature}:${modelSignature}`;
+  }
+
+  return `${code}:${message}`;
+}
+
+function showAgentWarning(raw: unknown, chatId: string) {
+  const data = raw && typeof raw === "object" ? (raw as AgentWarningToastData) : null;
   const message = typeof data?.message === "string" ? data.message : "Agent warning";
-  const warningKey = `${typeof data?.code === "string" ? data.code : "agent_warning"}:${message}`;
+  const warningKey = getAgentWarningToastKey(data, chatId, message);
   console.warn("[Agent warning]", raw);
   if (shownAgentWarnings.has(warningKey)) return;
   shownAgentWarnings.add(warningKey);
@@ -1428,7 +1453,7 @@ export function useGenerate() {
             }
 
             case "agent_warning": {
-              showAgentWarning(event.data);
+              showAgentWarning(event.data, params.chatId);
               break;
             }
 
@@ -2745,7 +2770,7 @@ export function useGenerate() {
         )) {
           switch (event.type) {
             case "agent_warning": {
-              showAgentWarning(event.data);
+              showAgentWarning(event.data, chatId);
               break;
             }
 

--- a/packages/client/src/lib/tts-dialogue.ts
+++ b/packages/client/src/lib/tts-dialogue.ts
@@ -1,4 +1,4 @@
-import type { TTSConfig } from "@marinara-engine/shared";
+import { decodeEncodedSpeakerTags, type TTSConfig } from "@marinara-engine/shared";
 import { DIALOGUE_QUOTE_CAPTURE_GROUP_PATTERN_SOURCE, stripSurroundingDialogueQuotes } from "./dialogue-quotes";
 
 export interface TTSUtterance {
@@ -351,8 +351,9 @@ export function splitTTSChunks(value: string): string[] {
 }
 
 export function buildTTSMessageText(text: string, config: TTSConfig, fallbackSpeaker?: string | null): string {
-  if (!config.dialogueOnly) return cleanTTSInputText(text);
-  return extractDialogueUtterances(text, config, fallbackSpeaker)
+  const normalized = decodeEncodedSpeakerTags(text);
+  if (!config.dialogueOnly) return cleanTTSInputText(normalized);
+  return extractDialogueUtterances(normalized, config, fallbackSpeaker)
     .map((utterance) => utterance.text)
     .join("\n");
 }
@@ -364,14 +365,15 @@ export function buildTTSVoiceRequests(
   fallbackCharacterId?: string | null,
   resolveCharacterIdForSpeaker?: (speaker?: string | null) => string | null | undefined,
 ): TTSVoiceRequest[] {
-  const hasSpeakerTags = /<speaker="[^"]*">/i.test(text);
+  const normalized = decodeEncodedSpeakerTags(text);
+  const hasSpeakerTags = /<speaker="[^"]*">/i.test(normalized);
   const shouldExtractUtterances = config.dialogueOnly || hasSpeakerTags;
   const utterances =
     hasSpeakerTags && !config.dialogueOnly
-      ? extractSpeakerTaggedUtterances(text, config, fallbackSpeaker, true)
+      ? extractSpeakerTaggedUtterances(normalized, config, fallbackSpeaker, true)
       : shouldExtractUtterances
-        ? extractDialogueUtterances(text, config, fallbackSpeaker)
-        : [{ text: cleanTTSInputText(text), speaker: fallbackSpeaker || undefined } satisfies TTSUtterance];
+        ? extractDialogueUtterances(normalized, config, fallbackSpeaker)
+        : [{ text: cleanTTSInputText(normalized), speaker: fallbackSpeaker || undefined } satisfies TTSUtterance];
 
   const fallbackSpeakerKey = normalizeTTSCharacterName(fallbackSpeaker);
   return utterances.flatMap((utterance) => {

--- a/packages/server/src/routes/generate/agent-connection-guards.ts
+++ b/packages/server/src/routes/generate/agent-connection-guards.ts
@@ -6,6 +6,7 @@ export type AgentConnectionWarning = {
   message: string;
   agentNames: string[];
   fallbackPrevented?: true;
+  connectionId?: string;
   connectionName?: string;
   model?: string;
 };
@@ -48,6 +49,7 @@ export function buildLocalSidecarUnavailableWarning(agentNames: string[]): Agent
 
 export function buildDefaultAgentConnectionWarning(args: {
   agentNames: string[];
+  connectionId: string;
   connectionName: string;
   model: string;
 }): AgentConnectionWarning {
@@ -59,6 +61,7 @@ export function buildDefaultAgentConnectionWarning(args: {
     code: "default_agent_connection_active",
     severity: "warning",
     agentNames: normalizedNames,
+    connectionId: args.connectionId,
     connectionName: args.connectionName,
     model: args.model,
     message: `${agentList} ${noun} using the default agent connection "${args.connectionName}" (${args.model}). If this is a paid API model, agent calls may bill that provider.`,

--- a/packages/server/src/routes/generate/retry-agents-route.ts
+++ b/packages/server/src/routes/generate/retry-agents-route.ts
@@ -1313,6 +1313,7 @@ async function resolveRetryAgents(args: {
     warnings.push(
       buildDefaultAgentConnectionWarning({
         agentNames: defaultAgentConnectionAgents,
+        connectionId: defaultAgentConn.id,
         connectionName: defaultAgentConn.name,
         model: String(defaultAgentConn.model ?? "").trim(),
       }),

--- a/packages/server/src/services/game/game-asset-generation.ts
+++ b/packages/server/src/services/game/game-asset-generation.ts
@@ -515,6 +515,7 @@ function compileGameImagePrompt(
     styleProfileId: req.styleProfileId,
     imageDefaults: req.imgDefaults,
     generatedStyle: req.artStyle,
+    applyPromptModeToSourcePrompt: kind === "background" || kind === "illustration",
   });
   const protectedPrompt = [canonicalPrefix, compiled.prompt].filter(Boolean).join(", ");
   return {

--- a/packages/server/src/services/generation/agent-resolution.ts
+++ b/packages/server/src/services/generation/agent-resolution.ts
@@ -538,6 +538,7 @@ export async function resolveAgentPipelineAgents({
     agentConnectionWarnings.push(
       buildDefaultAgentConnectionWarning({
         agentNames: defaultAgentConnectionAgents,
+        connectionId: defaultAgentConn.id,
         connectionName: defaultAgentConn.name,
         model: String(defaultAgentConn.model ?? "").trim(),
       }),

--- a/packages/shared/src/utils/image-prompt-compiler.ts
+++ b/packages/shared/src/utils/image-prompt-compiler.ts
@@ -24,6 +24,8 @@ export interface CompileImagePromptInput {
   userPositive?: string | null;
   userNegative?: string | null;
   hardNegative?: string | null;
+  /** Apply the selected grammar to generated prose that is normally preserved for review/readability. */
+  applyPromptModeToSourcePrompt?: boolean;
 }
 
 export function compileImagePrompt(input: CompileImagePromptInput): CompiledImagePrompt {
@@ -40,9 +42,11 @@ export function compileImagePrompt(input: CompileImagePromptInput): CompiledImag
   const promptPrefix = imagePromptPrefixFromDefaults(input.imageDefaults);
   const negativePromptPrefix = imageNegativePromptPrefixFromDefaults(input.imageDefaults);
   const taggedPromptMode = promptMode === "tagged" || promptMode === "danbooru";
+  const applyPromptModeToSourcePrompt = input.applyPromptModeToSourcePrompt === true;
   const preserveGeneratedPrompt =
-    input.kind === "illustration" || input.kind === "background" || input.kind === "selfie";
-  const compactTags = !preserveGeneratedPrompt && taggedPromptMode;
+    !applyPromptModeToSourcePrompt &&
+    (input.kind === "illustration" || input.kind === "background" || input.kind === "selfie");
+  const compactTags = !applyPromptModeToSourcePrompt && !preserveGeneratedPrompt && taggedPromptMode;
   const compactVisualPrompt =
     profile.baseStyle !== "z_image_turbo" && ["avatar", "portrait", "sprite"].includes(input.kind);
   const compactPrompt = compactTags || compactVisualPrompt;
@@ -328,6 +332,7 @@ function splitPromptFragments(
     .replace(/\r\n?/g, "\n")
     .replace(/[.!?]\s+(?=(?:avoid|no|without|exclude|do not include|don't include)\b)/gi, "\n")
     .replace(/\b(?:avoid|negative prompt|undesired content)\s*:/gi, "\navoid ")
+    .replace(/\b(?:SD|Stable Diffusion)\/Illustrious\s+tags?\s*:/gi, "\n")
     .replace(/\b(?:positive prompt|tags?)\s*:/gi, "\n");
 
   if (promptMode === "natural") {

--- a/packages/shared/src/utils/speaker-segments.ts
+++ b/packages/shared/src/utils/speaker-segments.ts
@@ -8,6 +8,25 @@
 // ──────────────────────────────────────────────
 import { normalizeTextForMatch } from "./text-matching.js";
 
+const ENCODED_SPEAKER_TAG_RE = /&(?:lt|#0*60|#x0*3c);([^<>]*?\bspeaker\b[^<>]*?)&(?:gt|#0*62|#x0*3e);/gi;
+
+function decodeSpeakerTagAttributeEntities(value: string): string {
+  return value
+    .replace(/&quot;|&#0*34;|&#x0*22;/gi, '"')
+    .replace(/&apos;|&#0*39;|&#x0*27;/gi, "'");
+}
+
+export function decodeEncodedSpeakerTags(value: string): string {
+  return value.replace(ENCODED_SPEAKER_TAG_RE, (match, tagBody: string) => {
+    const decoded = decodeSpeakerTagAttributeEntities(tagBody).trim();
+    if (/^\/\s*speaker\s*$/i.test(decoded)) return "</speaker>";
+
+    const open = decoded.match(/^speaker\s*=\s*(["'])([^"']*)\1\s*$/i);
+    if (!open?.[2]) return match;
+    return `<speaker="${open[2].trim()}">`;
+  });
+}
+
 /**
  * Strip leaked line-leading `[HH:MM]` / `[DD.MM.YYYY]` timestamp tokens — the
  * display shape the conversation client renders and segments. The server strips
@@ -58,17 +77,18 @@ export interface GroupedSegment {
  * `knownNames` holds normalizeTextForMatch()-normalized character names.
  */
 export function parseSpeakerTags(content: string, knownNames: Set<string>): SpeakerSegment[] | null {
+  const decodedContent = decodeEncodedSpeakerTags(content);
   const regex = /<speaker="([^"]*)">([\s\S]*?)<\/speaker>/g;
   let match: RegExpExecArray | null;
   const segments: SpeakerSegment[] = [];
   let lastIndex = 0;
   let foundTag = false;
-  while ((match = regex.exec(content)) !== null) {
+  while ((match = regex.exec(decodedContent)) !== null) {
     foundTag = true;
     const speakerName = match[1]!.trim();
     const knownSpeaker = knownNames.has(normalizeTextForMatch(speakerName));
     if (match.index > lastIndex) {
-      const before = content.slice(lastIndex, match.index).trim();
+      const before = decodedContent.slice(lastIndex, match.index).trim();
       if (before) segments.push({ speaker: null, text: before, start: lastIndex, end: match.index });
     }
     segments.push({
@@ -79,9 +99,9 @@ export function parseSpeakerTags(content: string, knownNames: Set<string>): Spea
     });
     lastIndex = regex.lastIndex;
   }
-  if (lastIndex < content.length) {
-    const after = content.slice(lastIndex).trim();
-    if (after) segments.push({ speaker: null, text: after, start: lastIndex, end: content.length });
+  if (lastIndex < decodedContent.length) {
+    const after = decodedContent.slice(lastIndex).trim();
+    if (after) segments.push({ speaker: null, text: after, start: lastIndex, end: decodedContent.length });
   }
   return foundTag ? segments : null;
 }


### PR DESCRIPTION
## Summary
- Keep gallery lightbox interactions from closing the gallery drawer while copying prompt text or using lightbox controls.
- Suppress repeated default-agent-connection model warning toasts per chat until the agent connection/model changes.
- Apply Style Profile prompt grammar to hardcoded Game Mode background and scene illustration prompts so Danbooru/Tags/Hybrid modes shape the whole provider prompt.
- Decode encoded `<speaker>` tags in message rendering, grouping, and TTS so group dialogue coloring and speaker attribution keep working when tags arrive as `&lt;...&gt;`.

## Why
Users reported gallery prompt interactions closing the gallery, noisy repeated agent model toasts, GM image prompts staying prose-first despite tag grammar settings, and encoded speaker tags breaking group chat dialogue coloring.

Related: #3225

## Validation
- pnpm check

## Manual verification needed
- Manually verify gallery lightbox prompt copy/select interactions keep the gallery open.
- Manually verify default agent connection warning appears once per chat/connection/model and reappears after changing the agent connection/model.
- Manually verify Game Mode image prompt review/provider prompts follow Danbooru/Tags/Natural/Hybrid profile grammar for background and scene illustration generation.
- Manually verify encoded speaker tags display and color group chat dialogue correctly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved handling of speaker-tagged content across chat, text-to-speech, and related message processing.
  * Image prompt generation now better supports certain prompt modes and tag formats.

* **Bug Fixes**
  * Fixed duplicated agent warning notifications by making toast handling more consistent.
  * Improved parsing of encoded speaker tags and HTML-escaped content in messages and dialogue.
  * Better preserves intended prompt text for background and illustration generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->