### PR TITLE
fix(lorebooks): drop the embedded-unlink toast clarifier

### DIFF
--- a/packages/client/src/components/lorebooks/LorebookAssignmentSection.tsx
+++ b/packages/client/src/components/lorebooks/LorebookAssignmentSection.tsx
@@ -177,17 +177,12 @@ export function LorebookAssignmentSection({
   const unassignLorebook = async (lorebook: Lorebook) => {
     if (!ownerId) return;
     const nextOwnerIds = getOwnerIds(lorebook, ownerType).filter((id) => id !== ownerId);
-    const isEmbedded = ownerType === "character" && lorebook.id === embeddedLorebookId;
     try {
       await updateLorebook.mutateAsync({
         id: lorebook.id,
         ...(ownerType === "character" ? { characterIds: nextOwnerIds } : { personaIds: nextOwnerIds }),
       });
-      toast.success(
-        isEmbedded
-          ? `Unlinked ${lorebook.name}. It's still embedded in the card — use "Remove from card" to unbake the embedded copy.`
-          : `Removed ${lorebook.name}.`,
-      );
+      toast.success(`Removed ${lorebook.name}.`);
     } catch (error) {
       toast.error(error instanceof Error ? error.message : "Failed to remove lorebook.");
     }


### PR DESCRIPTION
## Linked issue

Follow-up to #3360 (merged) / #3359. No new issue — this is a one-line copy tweak whose commit was authored on the #3360 branch but didn't land, because the PR was merged before the push arrived.

## Why this change

After #3360 landed, the 🗑️ on an embedded lorebook's row shows a verbose toast: *"Unlinked &lt;name&gt;. It's still embedded in the card — use Remove from card to unbake the embedded copy."* That clarifier predates the **Remove from card** action; now that Remove from card exists (also shipped in #3360), the per-click message is just noise. Revert it to the plain *"Removed &lt;name&gt;."* toast used for every other row.

## What changed

- `packages/client/src/components/lorebooks/LorebookAssignmentSection.tsx` — `unassignLorebook` now toasts `Removed <name>.` for all rows (dropped the embedded-only "Unlinked… still embedded…" branch and its unused `isEmbedded` local). The hover tooltip on the embedded row still notes it only unlinks and points to Remove from card, so the distinction stays discoverable without the per-click message.

## Validation

- [ ] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed `CONTRIBUTING.md`

### Manual verification notes

- Client build (tsc) and ESLint pass: `pnpm --filter @marinara-engine/client build`, `pnpm --filter @marinara-engine/client lint`.
- Manually verify: unlink (🗑️) an **embedded** lorebook's row → the toast reads *"Removed &lt;name&gt;."* (no "Unlinked… still embedded" text). Hovering the 🗑️ still shows the tooltip explaining it only unlinks and the embedded copy stays.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Version/release files updated (only if this PR includes a version bump)

Toast-copy-only change; no docs or version impact.

## UI evidence (if applicable)

N/A — toast text only.
