### PR TITLE
Update credits for v2.1.1 release

### DIFF
--- a/packages/client/src/components/chat/HomeCreditsModal.tsx
+++ b/packages/client/src/components/chat/HomeCreditsModal.tsx
@@ -2,7 +2,7 @@ import { ExternalLink } from "lucide-react";
 import { Modal } from "../ui/Modal";
 
 const CONTRIBUTORS = [
-  { login: "SpicyMarinara", url: "https://github.com/SpicyMarinara", contributions: 1079 },
+  { login: "SpicyMarinara", url: "https://github.com/SpicyMarinara", contributions: 1080 },
   { login: "cha1latte", url: "https://github.com/cha1latte", contributions: 319 },
   { login: "Romuromylus", url: "https://github.com/Romuromylus", contributions: 175 },
   { login: "kolacheee", url: "https://github.com/kolacheee", contributions: 143 },
@@ -39,6 +39,7 @@ const CONTRIBUTORS = [
   { login: "BahamutRU", url: "https://github.com/BahamutRU", contributions: 2 },
   { login: "smurfboyyessir", url: "https://github.com/smurfboyyessir", contributions: 1 },
   { login: "taiman724", url: "https://github.com/taiman724", contributions: 1 },
+  { login: "abhi-0203", url: "https://github.com/abhi-0203", contributions: 1 },
   { login: "Yasyasyasvil", url: "https://github.com/Yasyasyasvil", contributions: 1 },
   { login: "vanta-jack", url: "https://github.com/vanta-jack", contributions: 1 },
   { login: "pwildani", url: "https://github.com/pwildani", contributions: 1 },


### PR DESCRIPTION
## Why

Prepare the v2.1.1 release by refreshing the in-app Credits modal from the current GitHub contributors list. This keeps the release metadata and visible contributor credits aligned before promoting staging to main.

No linked issue; this is release preparation work.

## What changed

- Refreshed `HomeCreditsModal` via `pnpm credits:sync`.
- Adds the newly detected contributor and updates the latest contribution count.

## Validation

- pnpm install --frozen-lockfile
- pnpm credits:check
- pnpm version:check
- pnpm guard:installer-artifacts
- pnpm release:notes -- 2.1.1
- pnpm check
- pnpm regression:prompt
- pnpm test
- pnpm smoke:ui
- docker build --build-arg BUILD_COMMIT=$(git rev-parse HEAD) -t marinara-engine:release-verify .
- docker build -f Dockerfile.lite --build-arg BUILD_COMMIT=$(git rev-parse HEAD) -t marinara-engine:release-lite-verify .
- Windows NSIS installer compiled locally

## Manual verification still needed

- Manually verify the GitHub release workflows attach the Windows installer and Android Termux bootstrap APK after the `v2.1.1` tag is pushed.
- Manually verify the published GHCR tags after the release workflows complete.