### PR TITLE
fix(gallery): keep image/video preview open on a text-selection drag

### DIFF
--- a/packages/client/src/components/chat/ChatImageLightbox.tsx
+++ b/packages/client/src/components/chat/ChatImageLightbox.tsx
@@ -58,6 +58,7 @@ export function ChatImageLightbox({
 }: ChatImageLightboxProps) {
   const pinImage = useGalleryStore((s) => s.pinImage);
   const closeButtonRef = useRef<HTMLButtonElement>(null);
+  const backdropPointerDownRef = useRef(false);
   const portalRoot = typeof document !== "undefined" ? document.body : null;
   const prompt = image.prompt.trim();
   const meta = formatChatImageMeta(image);
@@ -76,8 +77,15 @@ export function ChatImageLightbox({
       aria-modal="true"
       aria-label="Image preview"
       tabIndex={-1}
+      onPointerDown={(event) => {
+        backdropPointerDownRef.current = event.target === event.currentTarget;
+      }}
       onClick={(event) => {
-        if (event.target === event.currentTarget) onClose();
+        // Close only on a genuine backdrop click — not when a text-selection drag
+        // that began inside the preview happens to release on the backdrop (the
+        // click target then resolves to the backdrop, which would otherwise close).
+        if (event.target === event.currentTarget && backdropPointerDownRef.current) onClose();
+        backdropPointerDownRef.current = false;
       }}
       onKeyDown={(event) => {
         if (event.key === "Escape") {
@@ -165,6 +173,7 @@ export function ChatVideoLightbox({
 }: ChatVideoLightboxProps) {
   const pinVideo = useGalleryStore((s) => s.pinVideo);
   const closeButtonRef = useRef<HTMLButtonElement>(null);
+  const backdropPointerDownRef = useRef(false);
   const portalRoot = typeof document !== "undefined" ? document.body : null;
   const prompt = video.prompt.trim();
   const meta = formatSceneVideoMeta(video);
@@ -183,8 +192,15 @@ export function ChatVideoLightbox({
       aria-modal="true"
       aria-label="Video preview"
       tabIndex={-1}
+      onPointerDown={(event) => {
+        backdropPointerDownRef.current = event.target === event.currentTarget;
+      }}
       onClick={(event) => {
-        if (event.target === event.currentTarget) onClose();
+        // Close only on a genuine backdrop click — not when a text-selection drag
+        // that began inside the preview happens to release on the backdrop (the
+        // click target then resolves to the backdrop, which would otherwise close).
+        if (event.target === event.currentTarget && backdropPointerDownRef.current) onClose();
+        backdropPointerDownRef.current = false;
       }}
       onKeyDown={(event) => {
         if (event.key === "Escape") {


### PR DESCRIPTION
## Linked issue

Closes #3363.

**Important:** the **primary** symptom in #3363 — the whole in-chat Gallery *drawer* closing on any lightbox interaction (Copy prompt, selecting text, clicking the image), plus the missing *"Prompt copied."* toast — was **already fixed on `staging`** by `8f677f789` ("Fix message and agent image prompt edges", #3361), which tags the lightbox portal with `data-chat-floating-panel` so the drawer's document-level outside-click listener excludes it. This PR handles the **one remaining** way an image interaction can still dismiss the preview.

## Why this change

With the drawer-close fixed, one residual remains. The image/video preview (`ChatImageLightbox`) closes on a backdrop click via `onClick={(e) => { if (e.target === e.currentTarget) onClose() }}`. When a **text-selection drag** starts inside the preview and *releases on the backdrop*, the browser resolves the `click` target to the backdrop (the common ancestor of the drag's start and end), so `e.target === e.currentTarget` is true and the preview closes. So highlighting the prompt text and dragging slightly past the panel still dismisses the image — and #3363 explicitly asks that selecting text not dismiss anything.

## What changed

- `packages/client/src/components/chat/ChatImageLightbox.tsx` (both the **image** and **video** lightbox) — the backdrop now records, on `pointerdown`, whether the press landed on the backdrop itself, and only closes on `click` when **both** the pointer-down and the click are on the backdrop. A genuine backdrop click still closes the preview; a text-selection drag that merely releases on the backdrop does not.

No server, shared, or drawer changes (the drawer fix is already on `staging`).

## Validation

- [ ] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed `CONTRIBUTING.md`

### Manual verification notes

- Client build (tsc) and ESLint pass: `pnpm --filter @marinara-engine/client build`, `pnpm --filter @marinara-engine/client lint`.
- Manually verify in a chat's Gallery:
  1. Open an image → drag to select the prompt text, including dragging past the prompt panel onto the black area → the preview **stays open** and the selection works.
  2. Click the black backdrop normally → the preview **closes** (unchanged).
  3. **Copy prompt** → copies with a *"Prompt copied."* toast, preview and Gallery stay open (this already works after `8f677f789` — worth re-confirming).
  4. Same checks for a **video** preview.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Version/release files updated (only if this PR includes a version bump)

Event-handling-only change; no docs or version impact.

## UI evidence (if applicable)

N/A — pointer/click event handling only; no visual change.
