### PR TITLE
fix(client): auto-recover from stale-chunk dynamic-import failures

### DIFF
--- a/packages/client/src/lib/browser-runtime.ts
+++ b/packages/client/src/lib/browser-runtime.ts
@@ -75,7 +75,10 @@ export function registerPreloadErrorRecovery() {
       sessionStorage.setItem(PRELOAD_RECOVERY_AT_KEY, Date.now().toString());
       // We handle recovery via a full reload; stop Vite from also rethrowing.
       event.preventDefault();
-      void forceRefreshSpa({ queryParamKey: "chunk_reload" });
+      void forceRefreshSpa({ queryParamKey: "chunk_reload" }).catch(() => {
+        // Cache clearing failed; attempt a plain reload as a last resort.
+        window.location.reload();
+      });
     } catch {
       // sessionStorage unavailable or recovery failed → let Vite rethrow the error.
     }

--- a/packages/client/src/lib/browser-runtime.ts
+++ b/packages/client/src/lib/browser-runtime.ts
@@ -44,3 +44,40 @@ export async function forceRefreshSpa({
   await clearBrowserRuntimeCaches();
   replaceCurrentUrl(queryParamKey, queryParamValue);
 }
+
+const PRELOAD_RECOVERY_AT_KEY = "mari-preload-recovery-at";
+const PRELOAD_RECOVERY_COOLDOWN_MS = 20_000;
+
+/**
+ * Recover from a failed dynamic import — a lazy route/chunk that fails to load
+ * because a newer build deleted the hashed file the running page still references
+ * (or a stale service-worker precache is serving an old one). Vite dispatches a
+ * `vite:preloadError` window event in this case; clear the service worker +
+ * caches and reload so the browser fetches the current build's assets — the same
+ * recovery the version-skew path already uses.
+ *
+ * Guarded by a short cooldown so a genuinely broken build — or a page that
+ * re-triggers the same import immediately after reload — can't reload-loop: after
+ * one attempt within the window the error is allowed to surface (Vite rethrows,
+ * and the app's recovery boundary shows its Reload button).
+ */
+export function registerPreloadErrorRecovery() {
+  if (typeof window === "undefined") {
+    return;
+  }
+
+  window.addEventListener("vite:preloadError", (event: Event) => {
+    try {
+      const lastAt = Number(sessionStorage.getItem(PRELOAD_RECOVERY_AT_KEY) ?? "0");
+      if (Number.isFinite(lastAt) && Date.now() - lastAt < PRELOAD_RECOVERY_COOLDOWN_MS) {
+        return; // already tried recently → let Vite rethrow so the failure stays visible
+      }
+      sessionStorage.setItem(PRELOAD_RECOVERY_AT_KEY, Date.now().toString());
+      // We handle recovery via a full reload; stop Vite from also rethrowing.
+      event.preventDefault();
+      void forceRefreshSpa({ queryParamKey: "chunk_reload" });
+    } catch {
+      // sessionStorage unavailable or recovery failed → let Vite rethrow the error.
+    }
+  });
+}

--- a/packages/client/src/main.tsx
+++ b/packages/client/src/main.tsx
@@ -4,11 +4,16 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { App, AppRecoveryBoundary } from "./App";
 import { startKeepAlive } from "./lib/keep-alive";
 import { installCsrfFetchShim } from "./lib/csrf-fetch";
+import { registerPreloadErrorRecovery } from "./lib/browser-runtime";
 import "./styles/globals.css";
 
 // Prevent Chrome/Edge from sleeping this tab
 startKeepAlive();
 installCsrfFetchShim();
+// Auto-recover from stale-chunk dynamic-import failures (e.g. a lazy route that
+// 404s after an update) instead of surfacing "Failed to fetch dynamically
+// imported module" to the user.
+registerPreloadErrorRecovery();
 
 const queryClient = new QueryClient({
   defaultOptions: {


### PR DESCRIPTION
## Linked issue

Closes #3370

## Why this change

Lazy routes are code-split (`CharacterEditor = lazy(() => import(...))`) and the PWA precaches the JS chunks (`registerType: "autoUpdate"`, `globPatterns: ["**/*.{js,css,…}"]`). After an update, a still-running page — or a sticky service-worker precache — can reference a hashed chunk the new build already deleted (`clean:stale-client` removes old hashes). The lazy `import()` then 404s and surfaces:

```
Failed to fetch dynamically imported module: http://127.0.0.1:7860/assets/CharacterEditor-<hash>.js
```

There's no recovery for this: the app only auto-heals on a health-check **version** mismatch (`recoverFromVersionSkew`), which a bare chunk-load failure doesn't trigger (client and server can report the same version yet a sticky SW still serves a stale chunk). So users hit it repeatedly across updates until they manually clear the service worker / site data.

## What changed

- `packages/client/src/lib/browser-runtime.ts` — add `registerPreloadErrorRecovery()`, a `vite:preloadError` window listener that reuses the existing `forceRefreshSpa` recovery (unregister the service worker, clear caches, reload with a cache-busting query param — the same thing the version-skew path already does). Guarded by a short **sessionStorage cooldown** (20 s) so a genuinely broken build — or a page that re-triggers the same import right after reload — can't reload-loop: after one attempt within the window, `preventDefault` is skipped so Vite rethrows and the app's recovery boundary shows its Reload button.
- `packages/client/src/main.tsx` — call `registerPreloadErrorRecovery()` at startup.

Client-only; no server / shared / schema changes.

## Validation

- [ ] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed `CONTRIBUTING.md`

### Manual verification notes

- Client build (tsc) and ESLint pass: `pnpm --filter @marinara-engine/client build`, `pnpm --filter @marinara-engine/client lint`.
- Simulate the failure without needing a mid-session update — in the running app's DevTools console:
  1. `window.dispatchEvent(new Event("vite:preloadError", { cancelable: true }))` → the page should clear caches/SW and reload with a `?chunk_reload=…` param (check the URL after reload, and Application → Service Workers / Cache Storage are cleared).
  2. Immediately dispatch it again (within 20 s) → it should **not** reload again (cooldown guard); confirm via `sessionStorage.getItem("mari-preload-recovery-at")`.
- Real-world check: with a tab open, rebuild the client (`pnpm build`), then open the Character editor in the stale tab → instead of the "Failed to fetch dynamically imported module" error, the app should reload once and recover.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Version/release files updated (only if this PR includes a version bump)

Robustness fix; no docs or version impact.

## UI evidence (if applicable)

N/A — startup recovery hook; no visual change (it replaces an error screen with a one-time reload).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling for failed dynamic imports so the app can recover automatically instead of showing a hard error.
  * Added a browser-side refresh recovery path for stale chunks, helping pages load correctly after updates.
  * Reduced repeated reload loops by adding a short cooldown between recovery attempts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->