### PR TITLE
Fix active agent output format routing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 
 ## [Unreleased]
 
+## [2.1.2]
+
+### Changed
+
+- Bumped release metadata to v2.1.2 across packages, the PWA manifest, README release pointer, Windows installer sources, Android APK metadata, and the home-page-visible app version.
+- Android `versionName` is `2.1.2` with `versionCode 31`.
+
+### Fixed
+
+- Fixed manual agent retry/rerun requests so only agents currently added to the chat can be resolved, preventing removed agents from being prompted by stale retry requests.
+- Fixed agent prompt assembly so the required output format is appended to the terminal user message after chat history using the selected chat prompt preset wrapper (`<output_format>`, `## Output Format`, or raw text).
+- Fixed non-Quest agents receiving active quest progress in current game-state context while keeping compact quest state available to the Quest Tracker when it is active.
+
 ## [2.1.1]
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@
 
 ## Latest Release
 
-Current stable release: **[v2.1.1](https://github.com/Pasta-Devs/Marinara-Engine/releases/tag/v2.1.1)**.
+Current stable release: **[v2.1.2](https://github.com/Pasta-Devs/Marinara-Engine/releases/tag/v2.1.2)**.
 
 See [CHANGELOG.md](CHANGELOG.md) for detailed release notes. Tagged releases use the `vX.Y.Z` format and are published on the [Releases](https://github.com/Pasta-Devs/Marinara-Engine/releases) page. Android APKs are Termux bootstrap + WebView shells: they can download Termux from F-Droid, launch Android's installer, start the Termux setup flow after required permission prompts, then open the local Marinara server on the same device.
 

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -22,10 +22,10 @@ android {
         applicationId "com.marinara.engine"
         minSdk 24
         targetSdk 34
-        versionCode 30
-        versionName "2.1.1"
+        versionCode 31
+        versionName "2.1.2"
         buildConfigField "String", "MARINARA_SERVER_URL", "\"http://127.0.0.1:${marinaraPort}\""
-        buildConfigField "String", "MARINARA_RELEASE_TAG", "\"v2.1.1\""
+        buildConfigField "String", "MARINARA_RELEASE_TAG", "\"v2.1.2\""
     }
 
     signingConfigs {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "marinara-engine",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "private": true,
   "description": "AI Chat & Roleplay Frontend — Conversation, Roleplay, Visual Novel",
   "author": "Marianna",

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@marinara-engine/client",
   "private": true,
-  "version": "2.1.1",
+  "version": "2.1.2",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/packages/client/public/manifest.json
+++ b/packages/client/public/manifest.json
@@ -2,7 +2,7 @@
   "name": "Marinara Engine",
   "short_name": "Marinara",
   "description": "AI Chat & Roleplay Frontend — Conversation, Roleplay, Visual Novel",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "start_url": "/",
   "display": "standalone",
   "background_color": "#0a0a0f",

--- a/packages/client/src/components/chat/HomeCreditsModal.tsx
+++ b/packages/client/src/components/chat/HomeCreditsModal.tsx
@@ -2,17 +2,17 @@ import { ExternalLink } from "lucide-react";
 import { Modal } from "../ui/Modal";
 
 const CONTRIBUTORS = [
-  { login: "SpicyMarinara", url: "https://github.com/SpicyMarinara", contributions: 1080 },
+  { login: "SpicyMarinara", url: "https://github.com/SpicyMarinara", contributions: 1116 },
   { login: "cha1latte", url: "https://github.com/cha1latte", contributions: 319 },
   { login: "Romuromylus", url: "https://github.com/Romuromylus", contributions: 175 },
-  { login: "kolacheee", url: "https://github.com/kolacheee", contributions: 143 },
+  { login: "kolacheee", url: "https://github.com/kolacheee", contributions: 150 },
   { login: "LukaTheHero", url: "https://github.com/LukaTheHero", contributions: 86 },
   { login: "Xelvanis", url: "https://github.com/Xelvanis", contributions: 70 },
   { login: "TheLonelyDevil9", url: "https://github.com/TheLonelyDevil9", contributions: 69 },
   { login: "Promansis", url: "https://github.com/Promansis", contributions: 64 },
   { login: "coxde", url: "https://github.com/coxde", contributions: 60 },
-  { login: "thetopham", url: "https://github.com/thetopham", contributions: 49 },
-  { login: "Gunterlie", url: "https://github.com/Gunterlie", contributions: 48 },
+  { login: "thetopham", url: "https://github.com/thetopham", contributions: 52 },
+  { login: "Gunterlie", url: "https://github.com/Gunterlie", contributions: 49 },
   { login: "munimunigamer", url: "https://github.com/munimunigamer", contributions: 30 },
   { login: "Minsklatte", url: "https://github.com/Minsklatte", contributions: 16 },
   { login: "aeriondyseti", url: "https://github.com/aeriondyseti", contributions: 15 },

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@marinara-engine/server",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "private": true,
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/server/src/routes/generate/retry-agents-route.ts
+++ b/packages/server/src/routes/generate/retry-agents-route.ts
@@ -351,6 +351,31 @@ function normalizeWrapFormat(value: unknown): WrapFormat {
   return value === "markdown" || value === "none" || value === "xml" ? value : "xml";
 }
 
+function isChatAgentsEnabled(chatMeta: Record<string, unknown>): boolean {
+  if (chatMeta.enableAgents === true || chatMeta.enableAgents === "true") return true;
+  if (chatMeta.enableAgents === false || chatMeta.enableAgents === "false") return false;
+  return Array.isArray(chatMeta.activeAgentIds)
+    ? chatMeta.activeAgentIds.some((id) => typeof id === "string" && id.trim().length > 0)
+    : false;
+}
+
+function normalizeRetryAgentTypeId(agentType: string): string {
+  return agentType === "youtube" ? "spotify" : agentType;
+}
+
+function resolveActiveRetryAgentTypes(chatMode: ChatMode, chatMeta: Record<string, unknown>): Set<string> {
+  if (!isChatAgentsEnabled(chatMeta)) return new Set();
+  const activeAgentIds = Array.isArray(chatMeta.activeAgentIds)
+    ? chatMeta.activeAgentIds.filter((id): id is string => typeof id === "string" && id.trim().length > 0)
+    : [];
+  const normalizedActiveIds = activeAgentIds.map((agentType) => normalizeRetryAgentTypeId(agentType.trim()));
+  return new Set(
+    filterGameInternalAgentIds(chatMode, normalizedActiveIds).filter((agentType) =>
+      isAgentAvailableInChatMode(chatMode, agentType),
+    ),
+  );
+}
+
 async function resolveRetryAgentWrapFormat(args: {
   chat: any;
   chatMode: ChatMode;
@@ -970,11 +995,12 @@ async function resolveRetryAgents(args: {
   const chatMode = ((chat as { mode?: ChatMode }).mode ?? "conversation") as ChatMode;
   const chatMeta = parseExtra((chat as { metadata?: unknown }).metadata);
   const agentPromptTemplateSelections = normalizeAgentPromptTemplateSelectionMap(chatMeta.agentPromptTemplateIds);
-  const normalizedAgentTypes = agentTypes.map((agentType) => (agentType === "youtube" ? "spotify" : agentType));
+  const activeAgentTypeSet = resolveActiveRetryAgentTypes(chatMode, chatMeta);
+  const normalizedAgentTypes = agentTypes.map(normalizeRetryAgentTypeId);
   const agentTypeSet = new Set(
-    filterGameInternalAgentIds(chatMode, normalizedAgentTypes).filter((agentType) =>
-      isAgentAvailableInChatMode(chatMode, agentType),
-    ),
+    filterGameInternalAgentIds(chatMode, normalizedAgentTypes)
+      .filter((agentType) => isAgentAvailableInChatMode(chatMode, agentType))
+      .filter((agentType) => activeAgentTypeSet.has(agentType)),
   );
   const configs = await agentsStore.list();
   const deletedBuiltInTypes = new Set(

--- a/packages/server/src/services/agents/agent-executor.ts
+++ b/packages/server/src/services/agents/agent-executor.ts
@@ -25,6 +25,7 @@ import {
 import { getMaxToolRounds, isDebugAgentsEnabled } from "../../config/runtime-config.js";
 import { logger } from "../../lib/logger.js";
 import { wrapContent } from "../prompt/format-engine.js";
+import { sanitizePromptLeaf } from "../prompt/prompt-escaping.js";
 import { settleAgentJobsWithConcurrencyLimit } from "./agent-concurrency.js";
 import { getAssetManifest } from "../game/asset-manifest.service.js";
 
@@ -257,13 +258,17 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return !!value && typeof value === "object" && !Array.isArray(value);
 }
 
-function shouldCompactQuestContext(agentTypes: string[]): boolean {
+function shouldIncludeQuestContext(agentTypes: string[]): boolean {
   return agentTypes.includes("quest");
 }
 
 function compactQuestPlayerStatsForContext(playerStats: unknown, agentTypes: string[]): unknown {
-  if (!shouldCompactQuestContext(agentTypes) || !isRecord(playerStats) || playerStats.activeQuests === undefined) {
+  if (!isRecord(playerStats) || playerStats.activeQuests === undefined) {
     return playerStats;
+  }
+
+  if (!shouldIncludeQuestContext(agentTypes)) {
+    return Object.fromEntries(Object.entries(playerStats).filter(([key]) => key !== "activeQuests"));
   }
 
   return {
@@ -272,15 +277,124 @@ function compactQuestPlayerStatsForContext(playerStats: unknown, agentTypes: str
   };
 }
 
-function compactQuestGameStateForContext(gameState: unknown, agentTypes: string[]): unknown {
-  if (!shouldCompactQuestContext(agentTypes) || !isRecord(gameState) || !isRecord(gameState.playerStats)) {
+function omitQuestFieldLocksForContext(fieldLocks: unknown): unknown {
+  if (!isRecord(fieldLocks)) return fieldLocks;
+
+  let changed = false;
+  const nextEntries = Object.entries(fieldLocks).filter(([key]) => {
+    const keep = !key.startsWith("quests.");
+    if (!keep) changed = true;
+    return keep;
+  });
+
+  return changed ? Object.fromEntries(nextEntries) : fieldLocks;
+}
+
+export function compactGameStateForAgentContext(gameState: unknown, agentTypes: string[]): unknown {
+  if (!isRecord(gameState)) {
     return gameState;
   }
 
-  return {
-    ...gameState,
-    playerStats: compactQuestPlayerStatsForContext(gameState.playerStats, agentTypes),
-  };
+  const playerStats = compactQuestPlayerStatsForContext(gameState.playerStats, agentTypes);
+  const fieldLocks = shouldIncludeQuestContext(agentTypes)
+    ? gameState.fieldLocks
+    : omitQuestFieldLocksForContext(gameState.fieldLocks);
+
+  if (playerStats === gameState.playerStats && fieldLocks === gameState.fieldLocks) {
+    return gameState;
+  }
+
+  const next = { ...gameState };
+  if (playerStats !== gameState.playerStats) next.playerStats = playerStats;
+  if (fieldLocks !== gameState.fieldLocks) next.fieldLocks = fieldLocks;
+  return next;
+}
+
+type RenderedAgentTemplateMap = Map<string, string>;
+
+function renderAgentTemplatesForOutput(
+  configs: AgentExecConfig[],
+  context: AgentContext,
+  options: { escapeValues?: boolean } = {},
+): RenderedAgentTemplateMap {
+  const templates: RenderedAgentTemplateMap = new Map();
+  const renderOptions = options.escapeValues === undefined ? {} : { escapeValues: options.escapeValues };
+  for (const config of configs) {
+    templates.set(
+      config.type,
+      renderAgentPromptTemplate(
+        config.promptTemplate || getDefaultPromptForAgent(config),
+        config.settings,
+        context,
+        renderOptions,
+      ),
+    );
+  }
+  return templates;
+}
+
+function getAgentOutputTemplate(
+  config: AgentExecConfig,
+  context: AgentContext,
+  renderedTemplates?: RenderedAgentTemplateMap,
+): string {
+  return (
+    renderedTemplates?.get(config.type) ??
+    renderAgentPromptTemplate(config.promptTemplate || getDefaultPromptForAgent(config), config.settings, context)
+  );
+}
+
+function buildAgentOutputFormatBody(
+  configs: AgentExecConfig[],
+  context: AgentContext,
+  renderedTemplates?: RenderedAgentTemplateMap,
+): string {
+  if (configs.length === 0) return "";
+
+  const parts: string[] = [];
+  if (configs.length > 1) {
+    const quotedAgentIds = configs.map((config) => JSON.stringify(config.type)).join(", ");
+    parts.push("Return ONLY one valid JSON object with one property per active agent ID.");
+    parts.push(`Active agent IDs in this request: ${quotedAgentIds}.`);
+    parts.push("Use this exact top-level property layout; replace each null with that agent's output:");
+    parts.push("{");
+    configs.forEach((config, index) => {
+      const comma = index === configs.length - 1 ? "" : ",";
+      parts.push(`  ${JSON.stringify(config.type)}: null${comma}`);
+    });
+    parts.push("}");
+    parts.push("When an agent asks for JSON, put that requested JSON directly as that agent property's value.");
+    parts.push("Do not add properties for agents not listed above.");
+  } else {
+    const config = configs[0]!;
+    const jsonInstruction = agentResponseIsJson(config)
+      ? "Return ONLY one valid JSON object"
+      : "Return ONLY the requested output";
+    parts.push(`${jsonInstruction} for active agent ${JSON.stringify(config.type)}.`);
+  }
+
+  parts.push("Do not include markdown fences, commentary, explanations, or any text outside the requested output.");
+  parts.push("");
+  parts.push("Active agent output contracts:");
+
+  for (const config of configs) {
+    const template = getAgentOutputTemplate(config, context, renderedTemplates).trim();
+    parts.push("");
+    parts.push(`Agent ${JSON.stringify(config.type)} (${config.name}):`);
+    parts.push(template || "Return the requested output for this agent.");
+  }
+
+  return parts.join("\n");
+}
+
+function buildAgentOutputFormatBlock(
+  configs: AgentExecConfig[],
+  context: AgentContext,
+  renderedTemplates?: RenderedAgentTemplateMap,
+): string {
+  const wrapFormat = normalizeAgentContextWrapFormat(context.wrapFormat);
+  const body = buildAgentOutputFormatBody(configs, context, renderedTemplates);
+  return wrapContent(sanitizePromptLeaf(body, wrapFormat), "Output Format", wrapFormat);
 }
 
 export function formatToolPayloadForLog(payload: string, maxLength = 400): string {
@@ -442,7 +556,7 @@ export async function executeAgent(
 
     const messages =
       config.type === "expression"
-        ? buildExpressionAgentMessages(template, context)
+        ? buildExpressionAgentMessages(config, template, context)
         : config.type === "knowledge-retrieval"
           ? buildKnowledgeRetrievalAgentMessages(config, template, context)
           : config.type === "spotify"
@@ -850,7 +964,8 @@ export async function executeAgentBatch(
 
   try {
     // Build merged system prompt (includes lore + agent extras)
-    const systemPrompt = buildBatchSystemPrompt(configs, context);
+    const renderedTemplates = renderAgentTemplatesForOutput(configs, context, { escapeValues: true });
+    const systemPrompt = buildBatchSystemPrompt(configs, context, renderedTemplates);
     // Batch uses the max contextSize among its members
     const batchContextSize = Math.max(...configs.map((c) => normalizeAgentContextSize(c.settings.contextSize)));
     const messages = buildAgentMessages(
@@ -859,6 +974,7 @@ export async function executeAgentBatch(
       "__batch__",
       batchContextSize,
       configs.map((config) => config.type),
+      { outputFormatBlock: buildAgentOutputFormatBlock(configs, context, renderedTemplates) },
     );
 
     // Each agent reserves its own configured output budget. The context fitter
@@ -1010,7 +1126,11 @@ export async function executeAgentBatch(
  * Build a combined system prompt for a batch of agents.
  * Structure: <role> + <lore> + <agents> + extras
  */
-function buildBatchSystemPrompt(configs: AgentExecConfig[], context: AgentContext): string {
+function buildBatchSystemPrompt(
+  configs: AgentExecConfig[],
+  context: AgentContext,
+  renderedTemplates?: RenderedAgentTemplateMap,
+): string {
   const parts: string[] = [];
 
   // ── Role ──
@@ -1032,12 +1152,7 @@ function buildBatchSystemPrompt(configs: AgentExecConfig[], context: AgentContex
   parts.push(`<agents>`);
   parts.push(`Fulfill each of the requested tasks here and return the outputs in the formats they're specified:`);
   for (const config of configs) {
-    const template = renderAgentPromptTemplate(
-      config.promptTemplate || getDefaultPromptForAgent(config),
-      config.settings,
-      context,
-      { escapeValues: true },
-    );
+    const template = getAgentOutputTemplate(config, context, renderedTemplates);
     parts.push(``);
     parts.push(`<agent_task id="${escapeXmlAttribute(config.type)}" name="${escapeXmlAttribute(config.name)}">`);
     parts.push(template);
@@ -1054,29 +1169,6 @@ function buildBatchSystemPrompt(configs: AgentExecConfig[], context: AgentContex
     parts.push(``);
     parts.push(extras);
   }
-
-  // ── Output format ──
-  parts.push(``);
-  parts.push(`─── REQUIRED OUTPUT FORMAT ───`);
-  parts.push(
-    `Return ONLY one valid JSON object using this property layout; replace each null with that agent's output:`,
-  );
-  parts.push(`{`);
-  configs.forEach((config, index) => {
-    const comma = index === configs.length - 1 ? "" : ",";
-    parts.push(`  ${JSON.stringify(config.type)}: null${comma}`);
-  });
-  parts.push(`}`);
-  parts.push(``);
-  const quotedAgentIds = configs.map((config) => JSON.stringify(config.type)).join(", ");
-  parts.push(
-    [
-      `CRITICAL: Output ALL ${configs.length} agent properties.`,
-      `Use exact JSON property names: ${quotedAgentIds}.`,
-      "When an agent asks for JSON, put that requested JSON directly as that agent property's value.",
-      "Do not use XML tags, markdown fences, commentary, explanations, or text outside the JSON object.",
-    ].join(" "),
-  );
 
   return parts.join("\n");
 }
@@ -1420,9 +1512,11 @@ function buildStandardAgentMessages(config: AgentExecConfig, template: string, c
   // Build multi-turn message array for this agent (sliced to its own contextSize)
   const agentContextSize = normalizeAgentContextSize(config.settings.contextSize);
   const resultType = resolveAgentResultType(config);
+  const renderedTemplates = new Map([[config.type, template]]);
   return buildAgentMessages(systemParts.join("\n"), context, config.type, agentContextSize, [config.type], {
     includeMessageIds: normalizeCustomAgentCapabilities(config.settings).edit_messages === true,
     preserveAssistantResponseMarkup: resultType === "text_rewrite",
+    outputFormatBlock: buildAgentOutputFormatBlock([config], context, renderedTemplates),
   });
 }
 
@@ -1473,6 +1567,8 @@ function buildKnowledgeRetrievalAgentMessages(
     `Use the conversation messages only to identify which source-material facts are relevant. Return a concise factual summary from <source_material>. If no source material is relevant, output: "No relevant information found."`,
   );
   userParts.push(`Now return the requested format.`);
+  userParts.push(``);
+  userParts.push(buildAgentOutputFormatBlock([config], context, new Map([[config.type, template]])));
 
   return [
     { role: "system", content: systemParts.join("\n"), contextKind: "prompt" },
@@ -1724,6 +1820,8 @@ function buildSpotifyAgentMessages(config: AgentExecConfig, template: string, co
     );
   }
   userParts.push(`Now return the requested format.`);
+  userParts.push(``);
+  userParts.push(buildAgentOutputFormatBlock([config], context, new Map([[config.type, template]])));
 
   return [
     { role: "system", content: systemParts.join("\n"), contextKind: "prompt" },
@@ -1731,7 +1829,7 @@ function buildSpotifyAgentMessages(config: AgentExecConfig, template: string, co
   ];
 }
 
-function buildExpressionAgentMessages(template: string, context: AgentContext): ChatMessage[] {
+function buildExpressionAgentMessages(config: AgentExecConfig, template: string, context: AgentContext): ChatMessage[] {
   const systemParts: string[] = [];
   systemParts.push(`<role>`);
   systemParts.push(`You are a specialized expression-selection agent. Keep the request compact and return only JSON.`);
@@ -1785,6 +1883,8 @@ function buildExpressionAgentMessages(template: string, context: AgentContext): 
   userParts.push(
     `Now return the requested format with exactly one expression entry for every owner listed in <available_sprites>.`,
   );
+  userParts.push(``);
+  userParts.push(buildAgentOutputFormatBlock([config], context, new Map([[config.type, template]])));
 
   return [
     { role: "system", content: systemParts.join("\n"), contextKind: "prompt" },
@@ -1856,7 +1956,7 @@ function buildCommittedTrackerStateContext(
  *      last 3 assistant messages that have tracker snapshots)
  *
  *   FINAL USER MESSAGE:
- *     assistant_response (if post-processing) + "Now return the requested format(s)."
+ *     assistant_response (if post-processing) + "Now return..." + wrapped Output Format contract
  */
 function buildAgentMessages(
   systemPrompt: string,
@@ -1864,7 +1964,7 @@ function buildAgentMessages(
   agentType: string,
   contextSize = 5,
   contextAgentTypes: string[] = [agentType],
-  options: { includeMessageIds?: boolean; preserveAssistantResponseMarkup?: boolean } = {},
+  options: { includeMessageIds?: boolean; preserveAssistantResponseMarkup?: boolean; outputFormatBlock?: string } = {},
 ): ChatMessage[] {
   // ── 1. System message — already contains <role>, <lore>, <agents>, and extras ──
   const messages: ChatMessage[] = [{ role: "system", content: systemPrompt }];
@@ -1950,11 +2050,16 @@ function buildAgentMessages(
   // Echo Chamber prompts can be assembled from group-chat history that ends on
   // assistant. Anthropic treats a trailing assistant turn as prefill and rejects
   // some models, so add a terminal user instruction for that agent type too.
-  const requiresTerminalUserInstruction = finalParts.length > 0 || contextAgentTypes.includes("echo-chamber");
+  const outputFormatBlock = options.outputFormatBlock?.trim() ?? "";
+  const requiresTerminalUserInstruction =
+    finalParts.length > 0 || contextAgentTypes.includes("echo-chamber") || !!outputFormatBlock;
 
   if (requiresTerminalUserInstruction) {
     const instruction = "Now return the requested format(s).";
     finalParts.push(finalParts.length > 0 ? `\n${instruction}` : instruction);
+    if (outputFormatBlock) {
+      finalParts.push(`\n${outputFormatBlock}`);
+    }
     const finalContent = finalParts.join("\n");
     const last = messages[messages.length - 1]!;
     if (last.role === "user") {
@@ -2088,7 +2193,7 @@ function buildAgentExtras(context: AgentContext, agentTypes: string[] = []): str
 
   if (context.gameState) {
     parts.push(`<current_game_state>`);
-    parts.push(JSON.stringify(compactQuestGameStateForContext(context.gameState, agentTypes)));
+    parts.push(JSON.stringify(compactGameStateForAgentContext(context.gameState, agentTypes)));
     parts.push(`</current_game_state>`);
   }
 

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@marinara-engine/shared",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "private": true,
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/shared/src/constants/defaults.ts
+++ b/packages/shared/src/constants/defaults.ts
@@ -4,7 +4,7 @@
 import type { GenerationParameters } from "../types/prompt.js";
 
 /** App version — single source of truth. */
-export const APP_VERSION = "2.1.1";
+export const APP_VERSION = "2.1.2";
 
 /** Stable synthetic connection id for the built-in local llama sidecar. */
 export const LOCAL_SIDECAR_CONNECTION_ID = "__local_sidecar__";

--- a/scripts/regressions/prompt.regression.ts
+++ b/scripts/regressions/prompt.regression.ts
@@ -17,7 +17,12 @@ import {
   type ChatMLMessage,
   DEFAULT_AGENT_PROMPTS,
 } from "../../packages/shared/src/index.js";
-import { renderAgentPromptTemplate } from "../../packages/server/src/services/agents/agent-executor.js";
+import {
+  compactGameStateForAgentContext,
+  executeAgent,
+  executeAgentBatch,
+  renderAgentPromptTemplate,
+} from "../../packages/server/src/services/agents/agent-executor.js";
 import type { ResolvedAgent } from "../../packages/server/src/services/agents/agent-pipeline.js";
 import { loadGameVideoPrompt } from "../../packages/server/src/services/video/game-video-prompt.js";
 import { countUserMessagesAfterSummaryAnchor } from "../../packages/server/src/services/conversation/auto-summary.service.js";
@@ -70,6 +75,69 @@ type RegressionCase = {
 };
 
 type RegressionPromptSection = AssemblerInput["sections"][number];
+
+function makeCapturingProvider(response: string) {
+  const calls: any[][] = [];
+  return {
+    calls,
+    provider: {
+      maxTokensOverrideValue: null,
+      async chatComplete(messages: any[]) {
+        calls.push(messages);
+        return {
+          content: response,
+          usage: { promptTokens: 0, completionTokens: 0, totalTokens: 0 },
+        };
+      },
+    },
+  };
+}
+
+function makeRegressionAgentContext(overrides: Partial<AgentContext> = {}): AgentContext {
+  return {
+    chatId: "chat-agent-output-format",
+    chatMode: "roleplay",
+    recentMessages: [
+      { role: "user", content: "Check the street behind us." },
+      { role: "assistant", content: "The street is quiet, but the rain keeps falling." },
+    ],
+    mainResponse: null,
+    gameState: null,
+    characters: [{ id: "char-dottore", name: "Dottore", description: "A precise researcher." }],
+    persona: { name: "Mari", description: "The active user persona." },
+    memory: {},
+    activatedLorebookEntries: null,
+    writableLorebookIds: null,
+    chatSummary: null,
+    wrapFormat: "markdown",
+    streaming: false,
+    ...overrides,
+  };
+}
+
+function makeRegressionAgentConfig(overrides: Record<string, unknown> = {}) {
+  const type = typeof overrides.type === "string" ? overrides.type : "background";
+  const name = typeof overrides.name === "string" ? overrides.name : "Background";
+  const settings =
+    overrides.settings && typeof overrides.settings === "object" && !Array.isArray(overrides.settings)
+      ? (overrides.settings as Record<string, unknown>)
+      : {};
+  return {
+    id: `builtin:${type}`,
+    type,
+    name,
+    phase: "post_processing",
+    promptTemplate: 'Return JSON: {"chosen": null}',
+    connectionId: null,
+    ...overrides,
+    settings: {
+      contextSize: 5,
+      maxTokens: 256,
+      resultType: "background_change",
+      ...settings,
+    },
+  };
+}
 
 function promptSection(
   overrides: Pick<RegressionPromptSection, "id" | "identifier" | "name"> & Partial<RegressionPromptSection>,
@@ -380,7 +448,10 @@ const cases: RegressionCase[] = [
   {
     name: "ElevenLabs TTS input does not prepend sprite tone tags",
     run() {
-      assert.equal(buildElevenLabsTextInput("Reserved. Tomorrow afternoon.", "neutral"), "Reserved. Tomorrow afternoon.");
+      assert.equal(
+        buildElevenLabsTextInput("Reserved. Tomorrow afternoon.", "neutral"),
+        "Reserved. Tomorrow afternoon.",
+      );
       assert.equal(buildElevenLabsTextInput("Your ribs require rest.", "thinking"), "Your ribs require rest.");
       assert.equal(buildElevenLabsTextInput("A bold strategy.", "smirk"), "A bold strategy.");
     },
@@ -675,7 +746,8 @@ const cases: RegressionCase[] = [
     run() {
       const ctx = {
         gameContextBlock: "<game_context>\nMode: exploration\n</game_context>",
-        sourceSectionsBlock: '<turn_sections>\n<section index="0" kind="narration">A door opens.</section>\n</turn_sections>',
+        sourceSectionsBlock:
+          '<turn_sections>\n<section index="0" kind="narration">A door opens.</section>\n</turn_sections>',
         sourceNarration: "A door opens.",
         keyframeCount: 4,
         durationSeconds: 6,
@@ -711,7 +783,12 @@ const cases: RegressionCase[] = [
           return [];
         },
         async upsert(input) {
-          return { key: input.key, template: input.template, enabled: input.enabled, updatedAt: "2026-01-01T00:00:00.000Z" };
+          return {
+            key: input.key,
+            template: input.template,
+            enabled: input.enabled,
+            updatedAt: "2026-01-01T00:00:00.000Z",
+          };
         },
         async remove() {},
       } satisfies PromptOverridesStorage;
@@ -890,6 +967,114 @@ Use HTML sparingly and diegetically. Do not replace normal prose/dialogue unless
         rendered,
         "Do NOT include the player's Mari. Track Dottore with care. Latest: Track the current party.",
       );
+    },
+  },
+  {
+    name: "agent current game state hides quest progress from non-quest agents",
+    run() {
+      const gameState = {
+        date: "Day 1",
+        playerStats: {
+          status: "Recognized by the northern clerk",
+          inventory: [{ name: "glass earring", description: "A dangerous token", quantity: 1, location: "on_person" }],
+          activeQuests: [
+            {
+              questEntryId: "The Man Called Maukie",
+              name: "The Man Called Maukie",
+              currentStage: 1,
+              objectives: [{ text: "Secure passage north", completed: false }],
+              completed: false,
+            },
+          ],
+        },
+        fieldLocks: {
+          "quests.id:The%20Man%20Called%20Maukie.name": true,
+          "playerStats.status": true,
+        },
+      };
+
+      const backgroundState = compactGameStateForAgentContext(gameState, ["background"]) as {
+        playerStats: Record<string, unknown>;
+        fieldLocks: Record<string, unknown>;
+      };
+      assert.equal("activeQuests" in backgroundState.playerStats, false);
+      assert.equal(backgroundState.playerStats.status, "Recognized by the northern clerk");
+      assert.equal(backgroundState.fieldLocks["quests.id:The%20Man%20Called%20Maukie.name"], undefined);
+      assert.equal(backgroundState.fieldLocks["playerStats.status"], true);
+
+      const questState = compactGameStateForAgentContext(gameState, ["quest"]) as {
+        playerStats: { activeQuests?: Array<{ name?: string }> };
+        fieldLocks: Record<string, unknown>;
+      };
+      assert.equal(Array.isArray(questState.playerStats.activeQuests), true);
+      assert.equal(questState.playerStats.activeQuests?.[0]?.name, "The Man Called Maukie");
+      assert.equal(questState.fieldLocks["quests.id:The%20Man%20Called%20Maukie.name"], true);
+    },
+  },
+  {
+    name: "single agent output format is terminal user message using selected wrapper",
+    async run() {
+      const { calls, provider } = makeCapturingProvider(`{"chosen":null,"generate":null}`);
+      const config = makeRegressionAgentConfig();
+      const context = makeRegressionAgentContext({
+        wrapFormat: "markdown",
+        mainResponse: "Dottore studies the rain-slick street and chooses a darker alley backdrop.",
+      });
+
+      const result = await executeAgent(config as any, context, provider as any, "regression-model");
+      assert.equal(result.success, true);
+      const messages = calls[0]!;
+      const last = messages[messages.length - 1]!;
+      assert.equal(last.role, "user");
+      assert.match(last.content, /<assistant_response>/);
+      assert.match(last.content, /Now return the requested format/);
+      assert.match(last.content, /## Output Format/);
+      assert.match(last.content, /Return ONLY one valid JSON object for active agent "background"\./);
+      assert.match(last.content, /Agent "background" \(Background\):/);
+      assert.doesNotMatch(last.content, /Agent "quest"/);
+      assert.equal(last.content.trim().endsWith('Return JSON: {"chosen": null}'), true);
+    },
+  },
+  {
+    name: "batched agent output format lists only active requested agents in terminal user message",
+    async run() {
+      const { calls, provider } = makeCapturingProvider(
+        `{"background":{"chosen":null,"generate":null},"character-tracker":{"updates":[]}}`,
+      );
+      const background = makeRegressionAgentConfig();
+      const characterTracker = makeRegressionAgentConfig({
+        id: "builtin:character-tracker",
+        type: "character-tracker",
+        name: "Character Tracker",
+        promptTemplate: 'Return JSON: {"updates": []}',
+        settings: {
+          contextSize: 5,
+          maxTokens: 256,
+          resultType: "character_tracker_update",
+        },
+      });
+      const context = makeRegressionAgentContext({
+        wrapFormat: "xml",
+        mainResponse: "Dottore notices Mari tense when the door opens.",
+      });
+
+      const results = await executeAgentBatch(
+        [background, characterTracker] as any,
+        context,
+        provider as any,
+        "regression-model",
+      );
+      assert.equal(results.length, 2);
+      const messages = calls[0]!;
+      const system = messages[0]!;
+      const last = messages[messages.length - 1]!;
+      assert.equal(last.role, "user");
+      assert.doesNotMatch(system.content, /REQUIRED OUTPUT FORMAT/);
+      assert.match(last.content, /<output_format>/);
+      assert.match(last.content, /"background": null/);
+      assert.match(last.content, /"character-tracker": null/);
+      assert.doesNotMatch(last.content, /"quest": null/);
+      assert.equal(last.content.trim().endsWith("</output_format>"), true);
     },
   },
   {
@@ -1256,7 +1441,7 @@ Use HTML sparingly and diegetically. Do not replace normal prose/dialogue unless
     async run() {
       const lorebookScanResult = {
         worldInfoBefore: "Use <START> and <tone soft> exactly.",
-        worldInfoAfter: "Keep <ritual_step id=\"2\"> literal.",
+        worldInfoAfter: 'Keep <ritual_step id="2"> literal.',
         depthEntries: [{ content: "Depth keeps <scene-note> literal.", role: "system" as const, depth: 0, order: 0 }],
         totalEntries: 3,
         totalTokensEstimate: 24,

--- a/win/installer/install.bat
+++ b/win/installer/install.bat
@@ -11,14 +11,14 @@ set "NODE_DOWNLOAD_URL=https://nodejs.org/dist/v24.15.0/node-v24.15.0-x64.msi"
 set "NODE_SHA256=feffb8e5cb5ac47f793666636d496ef3e975be82c84c4da5d20e6aa8fa4eb806"
 set "GIT_DOWNLOAD_URL=https://github.com/git-for-windows/git/releases/download/v2.54.0.windows.1/Git-2.54.0-64-bit.exe"
 set "GIT_SHA256=2b96e7854f0520f0f6b709c21041d9801b1be44d5e1a0d9fa621b2fbc40f1983"
-set "RELEASE_TAG=v2.1.1"
+set "RELEASE_TAG=v2.1.2"
 if not defined MARINARA_RELEASE_COMMIT set "MARINARA_RELEASE_COMMIT="
 set "RELEASE_COMMIT=%MARINARA_RELEASE_COMMIT%"
 
 echo.
 echo  +==========================================+
 echo  ^|   Marinara Engine - Windows Installer     ^|
-echo  ^|   v2.1.1                                  ^|
+echo  ^|   v2.1.2                                  ^|
 
 echo  +==========================================+
 echo.

--- a/win/installer/installer.nsi
+++ b/win/installer/installer.nsi
@@ -13,7 +13,7 @@
 
 ; ── App metadata ──
 !define APP_NAME "Marinara Engine"
-!define APP_VERSION "2.1.1"
+!define APP_VERSION "2.1.2"
 !define APP_PUBLISHER "Pasta-Devs"
 !define APP_URL "https://github.com/Pasta-Devs/Marinara-Engine"
 !define REPO_URL "https://github.com/Pasta-Devs/Marinara-Engine.git"
@@ -27,7 +27,7 @@
 !define NODE_DOWNLOAD_URL "https://nodejs.org/dist/v24.15.0/node-v24.15.0-x64.msi"
 !define GIT_SHA256 "2b96e7854f0520f0f6b709c21041d9801b1be44d5e1a0d9fa621b2fbc40f1983"
 !define NODE_SHA256 "feffb8e5cb5ac47f793666636d496ef3e975be82c84c4da5d20e6aa8fa4eb806"
-!define RELEASE_TAG "v2.1.1"
+!define RELEASE_TAG "v2.1.2"
 !ifndef RELEASE_COMMIT
 !define RELEASE_COMMIT ""
 !endif


### PR DESCRIPTION
## Summary
- Gate manual agent retry/rerun resolution to agents currently added to the chat.
- Move concrete agent output-format contracts into the terminal user message using the selected chat prompt preset wrapper.
- Hide active quest progress from non-Quest agent context while preserving compact quest state for Quest Tracker.
- Bump release metadata to v2.1.2 and refresh Credits.

## Why
Removed agents could still be requested through stale retry/rerun paths, and non-Quest agents could infer quest-like output from current game-state context. The output contract also needed to be the model's final user-facing instruction after chat history.

## Validation
- pnpm regression:prompt
- pnpm version:check
- pnpm credits:check
- git diff --check
- pnpm check

## Manual Verification
Manual browser verification not run; this change is server prompt/routing plus release metadata.

## Issue
No linked issue; one should be opened before PR submission per CONTRIBUTING.
