### PR TITLE
Polish connection type defaults

### DIFF
--- a/packages/client/src/components/panels/ConnectionsPanel.tsx
+++ b/packages/client/src/components/panels/ConnectionsPanel.tsx
@@ -87,42 +87,30 @@ import { SelectionActionBar } from "../ui/SelectionActionBar";
 import { SmoothFolderContent } from "../ui/SmoothFolderContent";
 import { TouchDragHandle } from "../ui/TouchDragHandle";
 
-const TEXT_CONNECTION_ICON_COLORS = {
+const CONNECTION_ICON_COLORS = {
   from: "from-sky-400",
   to: "to-blue-500",
   ring: "ring-sky-400/40",
   badge: "bg-sky-400",
 };
-const IMAGE_CONNECTION_ICON_COLORS = {
-  from: "from-emerald-400",
-  to: "to-teal-500",
-  ring: "ring-emerald-400/40",
-  badge: "bg-emerald-400",
-};
-const VIDEO_CONNECTION_ICON_COLORS = {
-  from: "from-rose-400",
-  to: "to-orange-500",
-  ring: "ring-rose-400/40",
-  badge: "bg-rose-400",
-};
 const PROVIDER_COLORS: Record<string, { from: string; to: string; ring: string; badge: string }> = {
-  openai: TEXT_CONNECTION_ICON_COLORS,
-  openai_chatgpt: TEXT_CONNECTION_ICON_COLORS,
-  anthropic: TEXT_CONNECTION_ICON_COLORS,
-  claude_subscription: TEXT_CONNECTION_ICON_COLORS,
-  grok_subscription: TEXT_CONNECTION_ICON_COLORS,
-  google: TEXT_CONNECTION_ICON_COLORS,
-  google_vertex: TEXT_CONNECTION_ICON_COLORS,
-  mistral: TEXT_CONNECTION_ICON_COLORS,
-  cohere: TEXT_CONNECTION_ICON_COLORS,
-  openrouter: TEXT_CONNECTION_ICON_COLORS,
-  nanogpt: TEXT_CONNECTION_ICON_COLORS,
-  xai: TEXT_CONNECTION_ICON_COLORS,
-  custom: TEXT_CONNECTION_ICON_COLORS,
-  image_generation: IMAGE_CONNECTION_ICON_COLORS,
-  video_generation: VIDEO_CONNECTION_ICON_COLORS,
+  openai: CONNECTION_ICON_COLORS,
+  openai_chatgpt: CONNECTION_ICON_COLORS,
+  anthropic: CONNECTION_ICON_COLORS,
+  claude_subscription: CONNECTION_ICON_COLORS,
+  grok_subscription: CONNECTION_ICON_COLORS,
+  google: CONNECTION_ICON_COLORS,
+  google_vertex: CONNECTION_ICON_COLORS,
+  mistral: CONNECTION_ICON_COLORS,
+  cohere: CONNECTION_ICON_COLORS,
+  openrouter: CONNECTION_ICON_COLORS,
+  nanogpt: CONNECTION_ICON_COLORS,
+  xai: CONNECTION_ICON_COLORS,
+  custom: CONNECTION_ICON_COLORS,
+  image_generation: CONNECTION_ICON_COLORS,
+  video_generation: CONNECTION_ICON_COLORS,
 };
-const DEFAULT_COLOR = TEXT_CONNECTION_ICON_COLORS;
+const DEFAULT_COLOR = CONNECTION_ICON_COLORS;
 
 function getConnectionFallbackIcon(provider: string) {
   if (provider === "image_generation") return <ImageIcon size="1rem" />;
@@ -709,9 +697,9 @@ function DefaultAgentConnectionCard({ connectionsList }: { connectionsList: Conn
   };
 
   return (
-    <div className="rounded-xl border border-violet-400/20 bg-gradient-to-br from-violet-400/5 to-purple-500/5 p-3">
+    <div className="rounded-xl border border-sky-400/20 bg-gradient-to-br from-sky-400/5 to-blue-500/5 p-3">
       <div className="flex items-center gap-2.5 max-sm:items-start">
-        <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-xl bg-gradient-to-br from-violet-400 to-purple-500 text-white shadow-sm">
+        <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-xl bg-gradient-to-br from-sky-400 to-blue-500 text-white shadow-sm">
           <Sparkles size="1rem" />
         </div>
         <div className="min-w-0 flex-1">
@@ -778,9 +766,9 @@ function DefaultIllustratorConnectionCard({ connectionsList }: { connectionsList
   };
 
   return (
-    <div className="rounded-xl border border-emerald-400/20 bg-gradient-to-br from-emerald-400/5 to-teal-500/5 p-3">
+    <div className="rounded-xl border border-sky-400/20 bg-gradient-to-br from-sky-400/5 to-blue-500/5 p-3">
       <div className="flex items-center gap-2.5 max-sm:items-start">
-        <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-xl bg-gradient-to-br from-emerald-400 to-teal-500 text-white shadow-sm">
+        <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-xl bg-gradient-to-br from-sky-400 to-blue-500 text-white shadow-sm">
           <ImageIcon size="1rem" />
         </div>
         <div className="min-w-0 flex-1">
@@ -849,9 +837,9 @@ function DefaultVideoConnectionCard({ connectionsList }: { connectionsList: Conn
   };
 
   return (
-    <div className="rounded-xl border border-rose-400/20 bg-gradient-to-br from-rose-400/5 to-orange-500/5 p-3">
+    <div className="rounded-xl border border-sky-400/20 bg-gradient-to-br from-sky-400/5 to-blue-500/5 p-3">
       <div className="flex items-center gap-2.5 max-sm:items-start">
-        <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-xl bg-gradient-to-br from-rose-400 to-orange-500 text-white shadow-sm">
+        <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-xl bg-gradient-to-br from-sky-400 to-blue-500 text-white shadow-sm">
           <Film size="1rem" />
         </div>
         <div className="min-w-0 flex-1">

--- a/packages/client/src/components/panels/ConnectionsPanel.tsx
+++ b/packages/client/src/components/panels/ConnectionsPanel.tsx
@@ -87,31 +87,48 @@ import { SelectionActionBar } from "../ui/SelectionActionBar";
 import { SmoothFolderContent } from "../ui/SmoothFolderContent";
 import { TouchDragHandle } from "../ui/TouchDragHandle";
 
-/** Provider color pair for connection icons. Kept as one blue family by design. */
-const CONNECTION_ICON_COLORS = {
+const TEXT_CONNECTION_ICON_COLORS = {
   from: "from-sky-400",
   to: "to-blue-500",
   ring: "ring-sky-400/40",
   badge: "bg-sky-400",
 };
-const PROVIDER_COLORS: Record<string, { from: string; to: string; ring: string; badge: string }> = {
-  openai: CONNECTION_ICON_COLORS,
-  openai_chatgpt: CONNECTION_ICON_COLORS,
-  anthropic: CONNECTION_ICON_COLORS,
-  claude_subscription: CONNECTION_ICON_COLORS,
-  grok_subscription: CONNECTION_ICON_COLORS,
-  google: CONNECTION_ICON_COLORS,
-  google_vertex: CONNECTION_ICON_COLORS,
-  mistral: CONNECTION_ICON_COLORS,
-  cohere: CONNECTION_ICON_COLORS,
-  openrouter: CONNECTION_ICON_COLORS,
-  nanogpt: CONNECTION_ICON_COLORS,
-  xai: CONNECTION_ICON_COLORS,
-  custom: CONNECTION_ICON_COLORS,
-  image_generation: CONNECTION_ICON_COLORS,
-  video_generation: CONNECTION_ICON_COLORS,
+const IMAGE_CONNECTION_ICON_COLORS = {
+  from: "from-emerald-400",
+  to: "to-teal-500",
+  ring: "ring-emerald-400/40",
+  badge: "bg-emerald-400",
 };
-const DEFAULT_COLOR = CONNECTION_ICON_COLORS;
+const VIDEO_CONNECTION_ICON_COLORS = {
+  from: "from-rose-400",
+  to: "to-orange-500",
+  ring: "ring-rose-400/40",
+  badge: "bg-rose-400",
+};
+const PROVIDER_COLORS: Record<string, { from: string; to: string; ring: string; badge: string }> = {
+  openai: TEXT_CONNECTION_ICON_COLORS,
+  openai_chatgpt: TEXT_CONNECTION_ICON_COLORS,
+  anthropic: TEXT_CONNECTION_ICON_COLORS,
+  claude_subscription: TEXT_CONNECTION_ICON_COLORS,
+  grok_subscription: TEXT_CONNECTION_ICON_COLORS,
+  google: TEXT_CONNECTION_ICON_COLORS,
+  google_vertex: TEXT_CONNECTION_ICON_COLORS,
+  mistral: TEXT_CONNECTION_ICON_COLORS,
+  cohere: TEXT_CONNECTION_ICON_COLORS,
+  openrouter: TEXT_CONNECTION_ICON_COLORS,
+  nanogpt: TEXT_CONNECTION_ICON_COLORS,
+  xai: TEXT_CONNECTION_ICON_COLORS,
+  custom: TEXT_CONNECTION_ICON_COLORS,
+  image_generation: IMAGE_CONNECTION_ICON_COLORS,
+  video_generation: VIDEO_CONNECTION_ICON_COLORS,
+};
+const DEFAULT_COLOR = TEXT_CONNECTION_ICON_COLORS;
+
+function getConnectionFallbackIcon(provider: string) {
+  if (provider === "image_generation") return <ImageIcon size="1rem" />;
+  if (provider === "video_generation") return <Film size="1rem" />;
+  return <Link size="1rem" />;
+}
 
 function formatBytes(bytes: number): string {
   if (bytes < 1024 * 1024 * 1024) return `${(bytes / (1024 * 1024)).toFixed(0)} MB`;
@@ -692,9 +709,9 @@ function DefaultAgentConnectionCard({ connectionsList }: { connectionsList: Conn
   };
 
   return (
-    <div className="rounded-xl border border-sky-400/20 bg-gradient-to-br from-sky-400/5 to-blue-500/5 p-3">
+    <div className="rounded-xl border border-violet-400/20 bg-gradient-to-br from-violet-400/5 to-purple-500/5 p-3">
       <div className="flex items-center gap-2.5 max-sm:items-start">
-        <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-xl bg-gradient-to-br from-sky-400 to-blue-500 text-white shadow-sm">
+        <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-xl bg-gradient-to-br from-violet-400 to-purple-500 text-white shadow-sm">
           <Sparkles size="1rem" />
         </div>
         <div className="min-w-0 flex-1">
@@ -761,9 +778,9 @@ function DefaultIllustratorConnectionCard({ connectionsList }: { connectionsList
   };
 
   return (
-    <div className="rounded-xl border border-sky-400/20 bg-gradient-to-br from-sky-400/5 to-blue-500/5 p-3">
+    <div className="rounded-xl border border-emerald-400/20 bg-gradient-to-br from-emerald-400/5 to-teal-500/5 p-3">
       <div className="flex items-center gap-2.5 max-sm:items-start">
-        <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-xl bg-gradient-to-br from-sky-400 to-blue-500 text-white shadow-sm">
+        <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-xl bg-gradient-to-br from-emerald-400 to-teal-500 text-white shadow-sm">
           <ImageIcon size="1rem" />
         </div>
         <div className="min-w-0 flex-1">
@@ -832,9 +849,9 @@ function DefaultVideoConnectionCard({ connectionsList }: { connectionsList: Conn
   };
 
   return (
-    <div className="rounded-xl border border-sky-400/20 bg-gradient-to-br from-sky-400/5 to-blue-500/5 p-3">
+    <div className="rounded-xl border border-rose-400/20 bg-gradient-to-br from-rose-400/5 to-orange-500/5 p-3">
       <div className="flex items-center gap-2.5 max-sm:items-start">
-        <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-xl bg-gradient-to-br from-sky-400 to-blue-500 text-white shadow-sm">
+        <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-xl bg-gradient-to-br from-rose-400 to-orange-500 text-white shadow-sm">
           <Film size="1rem" />
         </div>
         <div className="min-w-0 flex-1">
@@ -908,7 +925,7 @@ function ConnectionRow({
   const iconContent = conn.imagePath ? (
     <img src={conn.imagePath} alt="" className="h-full w-full object-cover" draggable={false} />
   ) : (
-    <Link size="1rem" />
+    getConnectionFallbackIcon(conn.provider)
   );
   const iconFrameClasses = cn(
     "relative flex h-full w-full items-center justify-center overflow-hidden rounded-xl bg-gradient-to-br text-white shadow-sm",


### PR DESCRIPTION
Polish 🇵🇱, hehe.

## Linked issue

Closes #

No linked issue yet; one should be opened before this PR is submitted if maintainers want issue tracking for this small UI polish.

## Why this change

- Connections were visually hard to distinguish by type because image and video rows used the same fallback link icon as text/LLM rows.

## What changed

- Kept the Connections panel's intentional blue color family across text, image, and video connection defaults.
- Added type-specific fallback row icons: text/LLM keeps the link icon, image uses the image icon, and video uses the film icon.
- Preserved the existing distinct default-card icons for Agents, Illustrator, and Videos.
- Preserved custom uploaded connection pictures as the row icon override.

## Validation

- [x] `pnpm check` passes locally
- [x] Container (Docker / Podman) built and ran without issue
- [x] Ran the app, clicked through the changes manually
- [x] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [x] Above manual verification completed (describe below)
- [x] Read and followed `CONTRIBUTING.md`

### Manual verification notes

- [x] Clicked on things.

## Docs and release impact

- [x] No docs changes needed
- Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- Version/release files updated (only if this PR includes a version bump)

## UI evidence (if applicable)

before
<img width="406" height="202" alt="Bildschirmfoto 2026-07-08 um 23 06 10" src="https://github.com/user-attachments/assets/ef767f34-054a-4011-8460-4aee979dc741" />

after

<same, but with video or image icons for these connections>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the default icon shown for connections when a provider image is unavailable, making the display more relevant by provider type.
* **Style**
  * Removed an unnecessary inline comment from the connections panel.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->