### PR TITLE
Conversation-mode profiles: follow-up fixes + configurable AI-write sources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,22 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 
 ## [Unreleased]
 
+### Added
+
+- Added a configurable source picker (⚙️) for the Conversation "about me" AI-write, in both the character-card editor and the in-chat profile popout: choose which of the card fields (description, personality, scenario, backstory, appearance), the Convo behavior directive, the character's lorebook entries (with per-entry selection in the card editor), and recent chat context feed the draft. Defaults to personality only.
+- Added a Revert control to the about-me editor (card editor and in-chat popout) to undo a manual or AI-write change, and an emoji picker in the about-me editor.
+- Added an optional per-character toggle to declare a character's Convo display name on its card in the prompt, so the model can map the display name to the right card in group chats.
+- The Convo display name is now shown as the sender label above messages in Conversation (read live, so renames reflect immediately), not only in the prompt and the profile popout.
+
+### Fixed
+
+- Fixed the chat-specific about-me override being lost on reload or refetch — the popout read chat metadata without parsing it, so the override reset to the card default and, on save, could drop other characters' overrides.
+- Fixed the about-me AI-write failing on "thinking" models (e.g. Gemini 3.x) that spent the entire output budget on reasoning and returned no content; the output ceiling was raised and reasoning effort lowered.
+- Fixed the about-me source picker listing only "linked" lorebooks — a character whose lorebook is embedded now sees and can select its entries.
+- Fixed the Conversation participant-profiles block labeling the persona as "the user," which nudged some models toward sycophancy; the persona is now presented as just another participant.
+- Fixed the about-me profile popout on mobile (now a full-height sheet so the keyboard and emoji picker no longer overlap the field) and its overflow on desktop when the source panel is opened.
+- Fixed help tooltips stacking — opening one now closes any other.
+
 ## [2.1.2]
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ Export individual chats or bulk transcript zips as JSONL or plain text. Fully lo
 | ---------------------------------------------------- | --------------------------------------------------------------- |
 | [docs/INSTALLATION.md](docs/INSTALLATION.md)         | Installation guide index (all platforms)                        |
 | [docs/CONFIGURATION.md](docs/CONFIGURATION.md)       | Environment variables and `.env` reference                      |
-| [docs/CONVERSATION.md](docs/CONVERSATION.md)         | Conversation Mode setup, DMs, groups, calls, selfies, and table games |
+| [docs/CONVERSATION.md](docs/CONVERSATION.md)         | Conversation Mode setup, DMs, groups, profiles (display name, about me, behavior), calls, selfies, and table games |
 | [docs/ROLEPLAY.md](docs/ROLEPLAY.md)                 | Roleplay Mode setup, sprites, HUD, agents, and connected chats  |
 | [docs/GAME_MODE.md](docs/GAME_MODE.md)               | Game Mode setup, world-gen, party play, storyboards, and troubleshooting |
 | [docs/GENERATION_PARAMETERS.md](docs/GENERATION_PARAMETERS.md) | Sampler and output-parameter reference across providers         |

--- a/docs/CONVERSATION.md
+++ b/docs/CONVERSATION.md
@@ -77,7 +77,7 @@ Conversation Mode gives every participant — characters **and** your persona �
 
 ### Convo display name
 
-An optional name shown as the sender label above a character's (or your persona's) messages in Conversation, in place of the card/persona name. Leave it blank to fall back to the card name.
+An optional name shown as the sender label above a character's (or your persona's) messages in Conversation, in place of the card/persona name. Leave it blank to fall back to the character card name or persona name.
 
 - Set it in the character card's **Convo** tab (**Convo Display Name**) or in the **Persona editor**.
 - It updates live — renaming reflects on existing messages in the chat.

--- a/docs/CONVERSATION.md
+++ b/docs/CONVERSATION.md
@@ -71,6 +71,74 @@ The chat settings drawer has an **Impersonate** section with global defaults for
 
 For per-chat prompt tuning, use `/impersonate_prompt "your prompt"` or `/impersonate_prompt reset`.
 
+## Conversation profiles: display name, about me, and behavior
+
+Conversation Mode gives every participant — characters **and** your persona — a lightweight, Discord-style profile: a **display name**, an **about me**, and (for characters) a **behavior directive** that only applies here. These fields live on the character card (under a **Convo** tab) and in the persona editor, and they are **strictly Conversation-only**: they are never read, sent, or resolved in Roleplay, Visual Novel, or Game mode, even when the same card is used there.
+
+### Convo display name
+
+An optional name shown as the sender label above a character's (or your persona's) messages in Conversation, in place of the card/persona name. Leave it blank to fall back to the card name.
+
+- Set it in the character card's **Convo** tab (**Convo Display Name**) or in the **Persona editor**.
+- It updates live — renaming reflects on existing messages in the chat.
+- The `{{convo_display}}` macro resolves to the responding character's convo display name (empty outside Conversation).
+- **Declare this name on the card in the prompt** (character-only toggle): when on, the character's card is prefixed with a line like `Conversation display name: Pancake`, so the model can map the name it sees in chat to that specific card. Handy in group chats where display names diverge from card names.
+
+Clicking a participant's **avatar or name** opens their profile popout (below).
+
+### About me
+
+A short, self-authored bio — a couple of lines, an inside joke, a single emoji, or nothing at all. There are two layers:
+
+- **Default (public)** — lives on the character card (**About Me** on the Convo tab) or on the persona. It's the cross-chat default and, being public, everyone in a chat can see it.
+- **Chat-specific override** — set from within one chat; applies only to that chat and **takes precedence** over the default there.
+
+**Viewing and editing:** click a participant's avatar or name in Conversation to open a Discord-style **profile popout** — blown-up avatar, presence, and their effective about me. From there:
+
+- **Edit** sets a **chat-specific override** for this chat (with an emoji picker; `:custom_emoji:` works too).
+- **Clear** removes the override and reverts to the public default.
+- **Revert** (while editing) undoes your changes back to what the field held when you opened the editor.
+
+The default about me is edited on the card/persona; the popout only changes the per-chat override.
+
+**In the prompt:** about mes are auto-injected for all present participants each turn, as a short "participant profiles" block, with a per-chat off-switch in chat settings if you'd rather place them yourself. The macros `{{char_about}}` (responding character) and `{{persona_about}}` (your persona) drop them exactly where you want in a custom prompt (both empty outside Conversation).
+
+### AI Write (and where it draws from)
+
+Both the card editor and the in-chat popout have an **AI Write** button that drafts an in-character about me. It's deliberately allowed to come back sparse, joking, or empty — it won't force a tidy, earnest bio, and it won't silently overwrite existing text with a blank result.
+
+A **⚙️** beside AI Write picks which sources the draft draws on (defaults to **Personality** only):
+
+- Card fields — **Description, Personality, Scenario, Backstory, Appearance**
+- **Convo behavior** directive
+- **Lorebook entries** — the character's lorebook entries. In the **card editor**, turning this on expands to a checkbox list so you can pick exactly which entries feed the bio (useful when a card leaves its fields blank and keeps everything in the lorebook). The in-chat popout points you back to the card editor to make that selection.
+- **Chat context** — recent messages from this chat, with a message-limit. Only available in the in-chat editor (a chat-specific about me), since the card editor has no chat to read.
+
+Different creators build cards differently — some leave the card fields empty and live entirely in a lorebook — so the source list is per-character and saved on the card.
+
+### Convo behavior
+
+A Conversation-only instruction for how a character behaves in chat (e.g. "keep replies short and lowercase; text like a real person, not a narrator"), plus a **placement** control for where it lands in the prompt:
+
+- **Constant — before / after the card**
+- **Append to / Prepend to / Replace post-history**
+- **Only where `{{convo_behavior}}` is placed** — for full manual control in a custom prompt
+
+Set it on the character card's Convo tab. Like the other profile fields, it never reaches RP/VN/Game prompts.
+
+### Characters that keep their own about me current
+
+Two **opt-in**, Conversation-only ways for a character to update its own about me mid-conversation:
+
+- **About Me Keeper agent** — an opt-in post-processing agent (configurable cadence) that lets a character refresh its about me over time. It can update either its **public** profile (routed through the normal character-card approval modal, so you review it first) or a **chat-specific** override (applied automatically to that chat). The prompt keeps the public/private distinction explicit and the results authentic. Enable it in the chat's agent settings.
+- **`update_about_me` command** — an opt-in function-call tool (**Chat Settings -> Commands -> Function Calling**) a character can call in-character to update its own about me mid-turn, choosing `public` or `chat` scope. Off by default.
+
+Both are the character speaking for itself, so they only ever touch the acting character's own about me — a character can't rewrite someone else's.
+
+### Theming the profile popout
+
+The popout is fully CSS-themable from a character's or persona's **Creator Notes** via `mari-about-me-*` hooks. See the [Card CSS Theming Guide -> About Me Profile Popout](card-css-theming-guide.md#about-me-profile-popout-conversation-only).
+
 ## Conversation-specific features
 
 These are features Conversation Mode has that other modes don't.

--- a/docs/MACROS.md
+++ b/docs/MACROS.md
@@ -43,6 +43,17 @@ Character macros resolve against the current character in single-character chats
 | `{{charSysInfo}}` | Current character system prompt. |
 | `{{charPostHistory}}` | Current character post-history instructions. |
 
+## Conversation-mode fields
+
+These resolve **only in Conversation mode** — they are empty string in Roleplay, Visual Novel, and Game, even when placed in a shared card, persona, or lorebook surface. They read the [Conversation profile fields](CONVERSATION.md#conversation-profiles-display-name-about-me-and-behavior) (display name, about me, behavior).
+
+| Macro | Resolves to |
+| --- | --- |
+| `{{convo_display}}` | Responding character's Convo display name (falls back to the card name). |
+| `{{char_about}}` | Responding character's effective about me (per-chat override, else the card default). |
+| `{{persona_about}}` | Your persona's effective about me (per-chat override, else the persona default). |
+| `{{convo_behavior}}` | Responding character's Convo behavior directive — placed here when its insertion strategy is "Only where `{{convo_behavior}}` is placed". |
+
 ## Context
 
 | Macro | Resolves to |

--- a/docs/card-css-theming-guide.md
+++ b/docs/card-css-theming-guide.md
@@ -177,10 +177,11 @@ While a character generates a reply, conversation mode in the Linear layout show
 
 ### Avatar
 
-The avatar is a circle by default — reshape and ring it with pure CSS. Target the
-avatar **button** (it's a `<button>` in both layouts; a `<div>` only when it isn't
-clickable). In **roleplay** the button sits inside an extra glow-wrapper `div`, so
-flatten that wrapper if you want only your own ring:
+The avatar is a circle by default — reshape and ring it with pure CSS. The
+examples below target the clickable avatar **button**. If the avatar is rendered
+non-clickable in a surface, use the same idea on the `.mari-message-avatar > div`
+fallback hook for that specific layout. In **roleplay** the button sits inside an
+extra glow-wrapper `div`, so flatten that wrapper if you want only your own ring:
 
 ```css
 [data-card-css] .mari-message-avatar button {
@@ -342,9 +343,10 @@ Sections are split by `@chat-mode` so each mode gets exactly the hooks it has. E
     color: rgba(243, 215, 255, 0.5);
     font-variant: small-caps;
   }
-  /* reshape + ring + saturate the clipped avatar. It's a <button> in both the
-     conversation and roleplay layouts; roleplay nests it under a glow wrapper,
-     which the roleplay block below flattens so only this ring shows. */
+  /* reshape + ring + saturate the clipped clickable avatar. If a surface renders
+     a non-clickable avatar, target `.mari-message-avatar > div` for that layout.
+     Roleplay nests the button under a glow wrapper, which the roleplay block
+     below flattens so only this ring shows. */
   [data-card-css] .mari-message-avatar button {
     border-radius: 7px;
     box-shadow: 0 0 0 2px rgba(220, 38, 120, 0.6), 0 0 14px rgba(168, 85, 247, 0.5);
@@ -494,7 +496,7 @@ A prompt template if you'd rather not hand-write CSS:
 > **Technical constraints:**
 >
 > - Use `[data-card-css]` for the message row (works in both "Exclusive" and "Chat" modes); use normal class selectors for things inside it.
-> - `[data-card-css] .mari-message-bubble` = the visible bubble (background / border / corners / shadow); `[data-card-css] .mari-message-content` = the text; `[data-card-css] .mari-message-name` = the display name; `[data-card-css] .mari-message-avatar button` = the avatar (in roleplay it sits under an extra glow-wrapper `div`).
+> - `[data-card-css] .mari-message-bubble` = the visible bubble (background / border / corners / shadow); `[data-card-css] .mari-message-content` = the text; `[data-card-css] .mari-message-name` = the display name; `[data-card-css] .mari-message-avatar button` = the clickable avatar (non-clickable fallback: `.mari-message-avatar > div`; in roleplay the button sits under an extra glow-wrapper `div`).
 > - Style the typing indicator via `[data-card-css] .mari-typing-text` and `[data-card-css] .mari-typing-dots span`.
 > - Conversation only: the avatar-click "about me" popout is themable via `[data-card-css].mari-about-me-popout` (the card), `… .mari-about-me-banner`, `… .mari-about-me-avatar > div`, `… .mari-about-me-name`, `… .mari-about-me-box`, and `… .mari-about-me-text`. Wrap these in `@chat-mode conversation { … }`.
 > - Wrap roleplay-only CSS in `@chat-mode roleplay { … }`, conversation-only in `@chat-mode conversation { … }`; CSS outside applies everywhere.

--- a/docs/card-css-theming-guide.md
+++ b/docs/card-css-theming-guide.md
@@ -129,7 +129,7 @@ The chat DOM is the same skeleton in roleplay and conversation. These are the el
 | `[data-card-css] .mari-message-name`      | The character's display **name**                                                                               |
 | `[data-card-css] .mari-message-meta`      | The header row holding the name + timestamp                                                                    |
 | `[data-card-css] .mari-message-timestamp` | The timestamp                                                                                                  |
-| `[data-card-css] .mari-message-avatar`    | The avatar column; `.mari-message-avatar > div` is the avatar **circle** (override `border-radius` to reshape) |
+| `[data-card-css] .mari-message-avatar`    | The avatar column; `.mari-message-avatar button` is the clipped **avatar** (a `<div>` when it isn't clickable) — reshape/ring it. Roleplay nests it under an extra glow-wrapper `div`. |
 | `[data-card-css] .mari-message-narrator`  | Narrator messages (roleplay)                                                                                   |
 | `[data-card-css] .mari-message-user`      | User messages — `.mari-message-assistant` for character messages                                               |
 | `[data-card-css] p`, `… span`             | Paragraphs and inline spans inside the text                                                                    |
@@ -177,12 +177,21 @@ While a character generates a reply, conversation mode in the Linear layout show
 
 ### Avatar
 
-The avatar is a circle by default — reshape and ring it with pure CSS:
+The avatar is a circle by default — reshape and ring it with pure CSS. Target the
+avatar **button** (it's a `<button>` in both layouts; a `<div>` only when it isn't
+clickable). In **roleplay** the button sits inside an extra glow-wrapper `div`, so
+flatten that wrapper if you want only your own ring:
 
 ```css
-[data-card-css] .mari-message-avatar > div {
+[data-card-css] .mari-message-avatar button {
   border-radius: 6px; /* 0 = sharp corners, 50% = back to a circle */
   box-shadow: 0 0 0 2px #ff66cc;
+}
+/* roleplay only: drop the app's glow wrapper so just your ring shows */
+@chat-mode roleplay {
+  [data-card-css] .mari-message-avatar > div {
+    box-shadow: none;
+  }
 }
 ```
 
@@ -333,8 +342,10 @@ Sections are split by `@chat-mode` so each mode gets exactly the hooks it has. E
     color: rgba(243, 215, 255, 0.5);
     font-variant: small-caps;
   }
-  /* reshape + ring + saturate the avatar */
-  [data-card-css] .mari-message-avatar > div {
+  /* reshape + ring + saturate the clipped avatar. It's a <button> in both the
+     conversation and roleplay layouts; roleplay nests it under a glow wrapper,
+     which the roleplay block below flattens so only this ring shows. */
+  [data-card-css] .mari-message-avatar button {
     border-radius: 7px;
     box-shadow: 0 0 0 2px rgba(220, 38, 120, 0.6), 0 0 14px rgba(168, 85, 247, 0.5);
     filter: saturate(1.2) contrast(1.05);
@@ -355,6 +366,11 @@ Sections are split by `@chat-mode` so each mode gets exactly the hooks it has. E
     }
     [data-card-css][data-grouped] {
       border-left: 2px solid transparent;
+    }
+    /* roleplay wraps the clipped avatar button in its own glow layer — flatten it
+       so only the eldritch ring (above) hugs the picture */
+    [data-card-css] .mari-message-avatar > div {
+      box-shadow: none;
     }
     /* the visible bubble + a corner sigil */
     [data-card-css] .mari-message-bubble {
@@ -478,7 +494,7 @@ A prompt template if you'd rather not hand-write CSS:
 > **Technical constraints:**
 >
 > - Use `[data-card-css]` for the message row (works in both "Exclusive" and "Chat" modes); use normal class selectors for things inside it.
-> - `[data-card-css] .mari-message-bubble` = the visible bubble (background / border / corners / shadow); `[data-card-css] .mari-message-content` = the text; `[data-card-css] .mari-message-name` = the display name; `[data-card-css] .mari-message-avatar > div` = the avatar circle.
+> - `[data-card-css] .mari-message-bubble` = the visible bubble (background / border / corners / shadow); `[data-card-css] .mari-message-content` = the text; `[data-card-css] .mari-message-name` = the display name; `[data-card-css] .mari-message-avatar button` = the avatar (in roleplay it sits under an extra glow-wrapper `div`).
 > - Style the typing indicator via `[data-card-css] .mari-typing-text` and `[data-card-css] .mari-typing-dots span`.
 > - Conversation only: the avatar-click "about me" popout is themable via `[data-card-css].mari-about-me-popout` (the card), `… .mari-about-me-banner`, `… .mari-about-me-avatar > div`, `… .mari-about-me-name`, `… .mari-about-me-box`, and `… .mari-about-me-text`. Wrap these in `@chat-mode conversation { … }`.
 > - Wrap roleplay-only CSS in `@chat-mode roleplay { … }`, conversation-only in `@chat-mode conversation { … }`; CSS outside applies everywhere.

--- a/docs/card-css-theming-guide.md
+++ b/docs/card-css-theming-guide.md
@@ -296,88 +296,174 @@ Build with `[data-card-css] .mari-message-…` selectors and your card works cor
 
 ## Showcase: "Eldritch Grimoire" — the full extent
 
-A deliberately extravagant card that uses nearly every hook: an animated glowing bubble, a runic corner sigil, a glowing uppercase name, themed serif text, a reshaped/ringed avatar, and an eerie typing indicator. Paste it whole, set the mode to **Exclusive** (or **Chat**), and watch.
+A deliberately extravagant card that touches **every documented hook, in every mode**: glowing rune-caps names, themed serif text, a reshaped/ringed avatar, timestamp small-caps, an edge sigil on the row, an animated roleplay bubble with a corner rune, styled narration, a conversation bubble + eerie typing indicator, the whole avatar-click **profile popout**, and the game surface. Paste it whole into Creator Notes, enable card CSS in **Chat Settings -> Card CSS**, and it themes messages across Roleplay/Conversation, the popout in Conversation, and the surface in Game.
+
+Sections are split by `@chat-mode` so each mode gets exactly the hooks it has. Everything is sanitizer-safe (no external `url()`, no `!important`, no theme tokens, `position: relative`/`absolute` only).
 
 ```html
 <style>
-  /* ── animated arcane glow for the bubble ── */
+  /* ═══════════════ shared keyframe ═══════════════ */
   @keyframes grimoire-pulse {
     0%,
     100% {
-      box-shadow:
-        0 0 12px rgba(168, 85, 247, 0.35),
-        inset 0 0 18px rgba(80, 0, 60, 0.5);
+      box-shadow: 0 0 12px rgba(168, 85, 247, 0.35), inset 0 0 18px rgba(80, 0, 60, 0.5);
     }
     50% {
-      box-shadow:
-        0 0 24px rgba(220, 38, 120, 0.55),
-        inset 0 0 26px rgba(120, 0, 80, 0.6);
+      box-shadow: 0 0 24px rgba(220, 38, 120, 0.55), inset 0 0 26px rgba(120, 0, 80, 0.6);
     }
   }
 
-  /* ── the visible message bubble ── */
-  [data-card-css] .mari-message-bubble {
-    background: linear-gradient(135deg, #1a0a24 0%, #2d0a2e 55%, #3a0a1e 100%);
-    border: 1px solid rgba(220, 38, 120, 0.45);
-    border-radius: 4px 16px 16px 16px;
-    animation: grimoire-pulse 4s ease-in-out infinite;
-    position: relative;
-    overflow: hidden;
-  }
+  /* ═══════════════ EVERYWHERE (all modes) ═══════════════ */
+  /* These descendant hooks only match where message rows exist, so they're inert
+     in Game and safe to leave unwrapped. */
 
-  /* a faint rune in the corner, drawn with a pseudo-element */
-  [data-card-css] .mari-message-bubble::before {
-    content: "✦";
-    position: absolute;
-    top: 1px;
-    right: 7px;
-    font-size: 0.7rem;
-    color: rgba(220, 38, 120, 0.55);
-    text-shadow: 0 0 6px rgba(220, 38, 120, 0.9);
+  /* the character's name — glowing crimson rune-caps */
+  [data-card-css] .mari-message-name {
+    color: #ff5c8a;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    font-size: 0.82rem;
+    text-shadow: 0 0 8px rgba(255, 92, 138, 0.7), 0 0 16px rgba(168, 85, 247, 0.45);
   }
-
-  /* ── glowing serif message text ── */
+  /* header row + timestamp */
+  [data-card-css] .mari-message-meta {
+    align-items: baseline;
+  }
+  [data-card-css] .mari-message-timestamp {
+    color: rgba(243, 215, 255, 0.5);
+    font-variant: small-caps;
+  }
+  /* reshape + ring + saturate the avatar */
+  [data-card-css] .mari-message-avatar > div {
+    border-radius: 7px;
+    box-shadow: 0 0 0 2px rgba(220, 38, 120, 0.6), 0 0 14px rgba(168, 85, 247, 0.5);
+    filter: saturate(1.2) contrast(1.05);
+  }
+  /* glowing serif message text */
   [data-card-css] .mari-message-content {
     color: #f3d7ff;
     text-shadow: 0 0 2px rgba(168, 85, 247, 0.4);
     font-family: "Iowan Old Style", Georgia, "Times New Roman", serif;
   }
 
-  /* ── the character's name — glowing crimson rune-caps ── */
-  [data-card-css] .mari-message-name {
-    color: #ff5c8a;
-    letter-spacing: 0.08em;
-    text-transform: uppercase;
-    font-size: 0.82rem;
-    text-shadow:
-      0 0 8px rgba(255, 92, 138, 0.7),
-      0 0 16px rgba(168, 85, 247, 0.45);
+  /* ═══════════════ ROLEPLAY ═══════════════ */
+  @chat-mode roleplay {
+    /* the row itself — an arcane left edge on the first message of a run
+       (`[data-grouped]` = continuations from the same character) */
+    [data-card-css]:not([data-grouped]) {
+      border-left: 2px solid rgba(220, 38, 120, 0.35);
+    }
+    [data-card-css][data-grouped] {
+      border-left: 2px solid transparent;
+    }
+    /* the visible bubble + a corner sigil */
+    [data-card-css] .mari-message-bubble {
+      background: linear-gradient(135deg, #1a0a24 0%, #2d0a2e 55%, #3a0a1e 100%);
+      border: 1px solid rgba(220, 38, 120, 0.45);
+      border-radius: 4px 16px 16px 16px;
+      animation: grimoire-pulse 4s ease-in-out infinite;
+      position: relative;
+      overflow: hidden;
+    }
+    [data-card-css] .mari-message-bubble::before {
+      content: "✦";
+      position: absolute;
+      top: 1px;
+      right: 7px;
+      font-size: 0.7rem;
+      color: rgba(220, 38, 120, 0.55);
+      text-shadow: 0 0 6px rgba(220, 38, 120, 0.9);
+    }
+    /* narration */
+    [data-card-css] .mari-message-narrator {
+      color: #c9a8ff;
+      font-style: italic;
+      opacity: 0.9;
+    }
   }
 
-  /* ── reshape + ring the avatar ── */
-  [data-card-css] .mari-message-avatar > div {
-    border-radius: 7px;
-    box-shadow:
-      0 0 0 2px rgba(220, 38, 120, 0.6),
-      0 0 14px rgba(168, 85, 247, 0.5);
-    filter: saturate(1.2) contrast(1.05);
+  /* ═══════════════ CONVERSATION ═══════════════ */
+  @chat-mode conversation {
+    /* the Bubbles-layout bubble (in the Linear layout there is no bubble — the
+       EVERYWHERE row hooks above carry the theme instead) */
+    [data-card-css] .mari-message-bubble {
+      background: rgba(26, 10, 36, 0.92);
+      border: 1px solid rgba(220, 38, 120, 0.4);
+      border-radius: 1rem;
+    }
+    /* "(name) is typing…" (Linear layout) */
+    [data-card-css] .mari-typing-text {
+      color: #ff5c8a;
+      font-style: italic;
+      letter-spacing: 0.05em;
+      text-shadow: 0 0 8px rgba(255, 92, 138, 0.6);
+    }
+    [data-card-css] .mari-typing-dots span {
+      background: #ff5c8a;
+      box-shadow: 0 0 6px rgba(255, 92, 138, 0.85);
+    }
+
+    /* the avatar-click PROFILE POPOUT — every hook (the popout card is the scope
+       element, so target it with no space; its children as descendants) */
+    [data-card-css].mari-about-me-popout {
+      background: radial-gradient(120% 120% at 50% 0%, #241a3a 0%, #12081c 72%);
+      border: 1px solid rgba(220, 38, 120, 0.45);
+      border-radius: 1.25rem;
+    }
+    [data-card-css] .mari-about-me-banner {
+      background: linear-gradient(90deg, #a855f7, #dc2678);
+    }
+    [data-card-css] .mari-about-me-avatar > div {
+      border-radius: 0.9rem;
+      box-shadow: 0 0 0 2px #dc2678, 0 0 14px rgba(168, 85, 247, 0.5);
+    }
+    [data-card-css] .mari-about-me-status {
+      box-shadow: 0 0 8px rgba(255, 92, 138, 0.9);
+    }
+    [data-card-css] .mari-about-me-name {
+      color: #ffd7ef;
+      text-shadow: 0 0 10px rgba(220, 38, 120, 0.6);
+    }
+    [data-card-css] .mari-about-me-handle {
+      color: rgba(201, 168, 255, 0.8);
+    }
+    [data-card-css] .mari-about-me-presence {
+      color: rgba(201, 168, 255, 0.7);
+    }
+    [data-card-css] .mari-about-me-box {
+      background: rgba(168, 85, 247, 0.08);
+      border: 1px solid rgba(220, 38, 120, 0.3);
+      border-radius: 0.75rem;
+    }
+    [data-card-css] .mari-about-me-label {
+      color: #dc2678;
+      letter-spacing: 0.14em;
+    }
+    [data-card-css] .mari-about-me-badge {
+      background: rgba(220, 38, 120, 0.18);
+      color: #ffd7ef;
+    }
+    [data-card-css] .mari-about-me-text {
+      color: #f3d7ff;
+      font-family: "Iowan Old Style", Georgia, serif;
+    }
   }
 
-  /* ── eerie typing indicator (conversation, Linear layout) ── */
-  [data-card-css] .mari-typing-text {
-    color: #ff5c8a;
-    font-style: italic;
-    letter-spacing: 0.05em;
-    text-shadow: 0 0 8px rgba(255, 92, 138, 0.6);
-  }
-  [data-card-css] .mari-typing-dots span {
-    background: #ff5c8a;
-    box-shadow: 0 0 6px rgba(255, 92, 138, 0.85);
+  /* ═══════════════ GAME (set the mode to Chat) ═══════════════ */
+  @chat-mode game {
+    /* Game has its own layout with no message bubbles — in Chat scope `[data-card-css]`
+       is the whole game surface, so theme the area broadly (the bubble/name/avatar
+       hooks above don't exist here). */
+    [data-card-css] {
+      background-image: radial-gradient(120% 80% at 50% 0%, rgba(58, 10, 46, 0.5), transparent 70%);
+    }
   }
 </style>
 ```
 
-Everything in it is sanitizer-safe (no external `url()`, no `!important`, no theme tokens, `position: relative`/`absolute` only). Swap the colors and the `content` glyph to make it your own.
+> **User vs. character rows:** in **Exclusive** scope `[data-card-css]` is a character's own message (also `.mari-message-assistant`). To theme **your** rows too, use **Chat** scope, where `[data-card-css]` is the whole area and `[data-card-css] .mari-message-user` / `… .mari-message-assistant` select each side.
+
+Swap the colors, the `content` glyph, and the fonts to make it your own.
 
 ---
 

--- a/packages/client/src/components/characters/AboutMeSourcePicker.tsx
+++ b/packages/client/src/components/characters/AboutMeSourcePicker.tsx
@@ -67,6 +67,7 @@ export function AboutMeSourcePicker({
   lorebookEntries?: Array<{ id: string; name: string }>;
 }) {
   const toggle = (key: keyof AboutMeSourceConfig, checked: boolean) => onChange({ ...value, [key]: checked });
+  const [chatContextLimitText, setChatContextLimitText] = useState<string | null>(null);
 
   // Per-entry selection: absent `lorebookEntryIds` means "all". First toggle materializes
   // the full list so unchecking one keeps the rest.
@@ -150,11 +151,13 @@ export function AboutMeSourcePicker({
                 type="number"
                 min={1}
                 max={200}
-                value={value.chatContextLimit ?? DEFAULT_ABOUT_ME_CHAT_CONTEXT_LIMIT}
+                aria-label="Chat context message limit"
+                value={chatContextLimitText ?? (value.chatContextLimit ?? DEFAULT_ABOUT_ME_CHAT_CONTEXT_LIMIT)}
                 onChange={(e) => {
                   // Empty (mid-edit) clears to the default; only clamp real numbers, so
                   // clearing the field to retype doesn't snap it to 1 (Number("") === 0).
                   const raw = e.target.value;
+                  setChatContextLimitText(raw);
                   if (raw === "") {
                     onChange({ ...value, chatContextLimit: undefined });
                     return;
@@ -167,6 +170,7 @@ export function AboutMeSourcePicker({
                       : value.chatContextLimit,
                   });
                 }}
+                onBlur={() => setChatContextLimitText(null)}
                 className="w-14 rounded-md border border-[var(--border)] bg-[var(--secondary)] px-1.5 py-0.5 text-xs outline-none focus:border-[var(--primary)]/40"
               />
               msgs

--- a/packages/client/src/components/characters/AboutMeSourcePicker.tsx
+++ b/packages/client/src/components/characters/AboutMeSourcePicker.tsx
@@ -54,12 +54,29 @@ export function AboutMeSourcePicker({
   onChange,
   /** In-chat (chat-specific about me) enables the chat-context source; the card editor doesn't. */
   allowChatContext,
+  /** The character's linked lorebook entries (card editor only) — enables per-entry selection.
+   *  Undefined means the caller (e.g. the chat popout) can't select entries here. */
+  lorebookEntries,
 }: {
   value: AboutMeSourceConfig;
   onChange: (next: AboutMeSourceConfig) => void;
   allowChatContext: boolean;
+  lorebookEntries?: Array<{ id: string; name: string }>;
 }) {
   const toggle = (key: keyof AboutMeSourceConfig, checked: boolean) => onChange({ ...value, [key]: checked });
+
+  // Per-entry selection: absent `lorebookEntryIds` means "all". First toggle materializes
+  // the full list so unchecking one keeps the rest.
+  const allEntryIds = (lorebookEntries ?? []).map((e) => e.id);
+  const selectedEntryIds = value.lorebookEntryIds ?? allEntryIds;
+  const toggleEntry = (entryId: string, checked: boolean) => {
+    const base = value.lorebookEntryIds ?? allEntryIds;
+    const next = checked ? Array.from(new Set([...base, entryId])) : base.filter((x) => x !== entryId);
+    onChange({ ...value, lorebookEntryIds: next });
+  };
+  const lorebookTooltip = lorebookEntries
+    ? "This character's linked and embedded lorebook entries — handy when the card fields are blank and the substance lives in the lorebook. Pick which linked entries below."
+    : "This character's linked and embedded lorebook entries. To choose which linked entries feed the bio, open this character's card → Convo → About Me.";
 
   return (
     <div className="space-y-2 rounded-xl border border-[var(--border)] bg-[var(--background)]/60 p-3">
@@ -81,8 +98,25 @@ export function AboutMeSourcePicker({
           label="Lorebook entries"
           checked={!!value.lorebook}
           onToggle={(c) => toggle("lorebook", c)}
-          tooltip="This character's linked and embedded lorebook entries — handy when the card fields are blank and the substance lives in the lorebook."
+          tooltip={lorebookTooltip}
         />
+        {/* Card editor only: pick which linked entries feed the bio. */}
+        {lorebookEntries !== undefined && value.lorebook && (
+          <div className="ml-5 max-h-40 space-y-1 overflow-y-auto border-l border-[var(--border)] pl-2">
+            {lorebookEntries.length === 0 ? (
+              <p className="text-[0.6875rem] text-[var(--muted-foreground)]/70">No linked lorebook entries.</p>
+            ) : (
+              lorebookEntries.map((e) => (
+                <SourceRow
+                  key={e.id}
+                  label={e.name}
+                  checked={selectedEntryIds.includes(e.id)}
+                  onToggle={(c) => toggleEntry(e.id, c)}
+                />
+              ))
+            )}
+          </div>
+        )}
         <div className="flex flex-wrap items-center gap-2">
           <SourceRow
             label="Chat context"

--- a/packages/client/src/components/characters/AboutMeSourcePicker.tsx
+++ b/packages/client/src/components/characters/AboutMeSourcePicker.tsx
@@ -152,10 +152,19 @@ export function AboutMeSourcePicker({
                 max={200}
                 value={value.chatContextLimit ?? DEFAULT_ABOUT_ME_CHAT_CONTEXT_LIMIT}
                 onChange={(e) => {
-                  const n = Number(e.target.value);
+                  // Empty (mid-edit) clears to the default; only clamp real numbers, so
+                  // clearing the field to retype doesn't snap it to 1 (Number("") === 0).
+                  const raw = e.target.value;
+                  if (raw === "") {
+                    onChange({ ...value, chatContextLimit: undefined });
+                    return;
+                  }
+                  const n = Number(raw);
                   onChange({
                     ...value,
-                    chatContextLimit: Number.isFinite(n) ? Math.max(1, Math.min(200, Math.round(n))) : undefined,
+                    chatContextLimit: Number.isFinite(n)
+                      ? Math.max(1, Math.min(200, Math.round(n)))
+                      : value.chatContextLimit,
                   });
                 }}
                 className="w-14 rounded-md border border-[var(--border)] bg-[var(--secondary)] px-1.5 py-0.5 text-xs outline-none focus:border-[var(--primary)]/40"

--- a/packages/client/src/components/characters/AboutMeSourcePicker.tsx
+++ b/packages/client/src/components/characters/AboutMeSourcePicker.tsx
@@ -81,17 +81,13 @@ export function AboutMeSourcePicker({
     ? "This character's lorebook entries — handy when the card fields are blank and the substance lives in the lorebook. Pick which entries below."
     : "This character's lorebook entries. To choose which entries feed the bio, open this character's card → Convo → About Me.";
 
-  // Mobile popout has no expansion and no hover — auto-open the explainer tooltip when
-  // the user selects the Lorebook source there, so they learn where to pick entries.
+  // The chat popout has no entry expansion — auto-open the explainer tooltip when the
+  // user selects the Lorebook source there (desktop and mobile), so they learn entry
+  // selection lives in the card editor. The card editor shows the expansion instead.
   const [lorebookTipSignal, setLorebookTipSignal] = useState(0);
   const toggleLorebook = (checked: boolean) => {
     toggle("lorebook", checked);
-    if (
-      checked &&
-      lorebookEntries === undefined &&
-      typeof window !== "undefined" &&
-      window.matchMedia("(max-width: 767px)").matches
-    ) {
+    if (checked && lorebookEntries === undefined) {
       setLorebookTipSignal((n) => n + 1);
     }
   };

--- a/packages/client/src/components/characters/AboutMeSourcePicker.tsx
+++ b/packages/client/src/components/characters/AboutMeSourcePicker.tsx
@@ -2,6 +2,7 @@
 // Checkbox panel that configures which sources the AI-write "about me" draws
 // from. Shared by the character-card editor and the in-chat about-me popout.
 // ──────────────────────────────────────────────
+import { useState } from "react";
 import type { AboutMeSourceConfig } from "@marinara-engine/shared";
 import { DEFAULT_ABOUT_ME_CHAT_CONTEXT_LIMIT } from "@marinara-engine/shared";
 import { HelpTooltip } from "../ui/HelpTooltip";
@@ -19,12 +20,14 @@ function SourceRow({
   checked,
   disabled,
   tooltip,
+  tooltipOpenSignal,
   onToggle,
 }: {
   label: string;
   checked: boolean;
   disabled?: boolean;
   tooltip?: string;
+  tooltipOpenSignal?: number;
   onToggle: (checked: boolean) => void;
 }) {
   return (
@@ -43,7 +46,7 @@ function SourceRow({
       />
       <span className="inline-flex items-center gap-1">
         {label}
-        {tooltip && <HelpTooltip text={tooltip} />}
+        {tooltip && <HelpTooltip text={tooltip} openSignal={tooltipOpenSignal} />}
       </span>
     </label>
   );
@@ -75,8 +78,23 @@ export function AboutMeSourcePicker({
     onChange({ ...value, lorebookEntryIds: next });
   };
   const lorebookTooltip = lorebookEntries
-    ? "This character's linked and embedded lorebook entries — handy when the card fields are blank and the substance lives in the lorebook. Pick which linked entries below."
-    : "This character's linked and embedded lorebook entries. To choose which linked entries feed the bio, open this character's card → Convo → About Me.";
+    ? "This character's lorebook entries — handy when the card fields are blank and the substance lives in the lorebook. Pick which entries below."
+    : "This character's lorebook entries. To choose which entries feed the bio, open this character's card → Convo → About Me.";
+
+  // Mobile popout has no expansion and no hover — auto-open the explainer tooltip when
+  // the user selects the Lorebook source there, so they learn where to pick entries.
+  const [lorebookTipSignal, setLorebookTipSignal] = useState(0);
+  const toggleLorebook = (checked: boolean) => {
+    toggle("lorebook", checked);
+    if (
+      checked &&
+      lorebookEntries === undefined &&
+      typeof window !== "undefined" &&
+      window.matchMedia("(max-width: 767px)").matches
+    ) {
+      setLorebookTipSignal((n) => n + 1);
+    }
+  };
 
   return (
     <div className="space-y-2 rounded-xl border border-[var(--border)] bg-[var(--background)]/60 p-3">
@@ -97,14 +115,15 @@ export function AboutMeSourcePicker({
         <SourceRow
           label="Lorebook entries"
           checked={!!value.lorebook}
-          onToggle={(c) => toggle("lorebook", c)}
+          onToggle={toggleLorebook}
           tooltip={lorebookTooltip}
+          tooltipOpenSignal={lorebookTipSignal}
         />
-        {/* Card editor only: pick which linked entries feed the bio. */}
+        {/* Card editor only: pick which entries feed the bio. */}
         {lorebookEntries !== undefined && value.lorebook && (
           <div className="ml-5 max-h-40 space-y-1 overflow-y-auto border-l border-[var(--border)] pl-2">
             {lorebookEntries.length === 0 ? (
-              <p className="text-[0.6875rem] text-[var(--muted-foreground)]/70">No linked lorebook entries.</p>
+              <p className="text-[0.6875rem] text-[var(--muted-foreground)]/70">No lorebook entries.</p>
             ) : (
               lorebookEntries.map((e) => (
                 <SourceRow

--- a/packages/client/src/components/characters/AboutMeSourcePicker.tsx
+++ b/packages/client/src/components/characters/AboutMeSourcePicker.tsx
@@ -1,0 +1,121 @@
+// ──────────────────────────────────────────────
+// Checkbox panel that configures which sources the AI-write "about me" draws
+// from. Shared by the character-card editor and the in-chat about-me popout.
+// ──────────────────────────────────────────────
+import type { AboutMeSourceConfig } from "@marinara-engine/shared";
+import { DEFAULT_ABOUT_ME_CHAT_CONTEXT_LIMIT } from "@marinara-engine/shared";
+import { HelpTooltip } from "../ui/HelpTooltip";
+
+const CARD_FIELDS: Array<{ key: keyof AboutMeSourceConfig; label: string }> = [
+  { key: "description", label: "Description" },
+  { key: "personality", label: "Personality" },
+  { key: "scenario", label: "Scenario" },
+  { key: "backstory", label: "Backstory" },
+  { key: "appearance", label: "Appearance" },
+];
+
+function SourceRow({
+  label,
+  checked,
+  disabled,
+  tooltip,
+  onToggle,
+}: {
+  label: string;
+  checked: boolean;
+  disabled?: boolean;
+  tooltip?: string;
+  onToggle: (checked: boolean) => void;
+}) {
+  return (
+    <label
+      className={
+        "flex items-center gap-2 text-xs " +
+        (disabled ? "cursor-not-allowed text-[var(--muted-foreground)]/50" : "text-[var(--foreground)]")
+      }
+    >
+      <input
+        type="checkbox"
+        checked={checked}
+        disabled={disabled}
+        onChange={(e) => onToggle(e.target.checked)}
+        className="h-3.5 w-3.5 shrink-0 accent-[var(--primary)] disabled:opacity-50"
+      />
+      <span className="inline-flex items-center gap-1">
+        {label}
+        {tooltip && <HelpTooltip text={tooltip} />}
+      </span>
+    </label>
+  );
+}
+
+export function AboutMeSourcePicker({
+  value,
+  onChange,
+  /** In-chat (chat-specific about me) enables the chat-context source; the card editor doesn't. */
+  allowChatContext,
+}: {
+  value: AboutMeSourceConfig;
+  onChange: (next: AboutMeSourceConfig) => void;
+  allowChatContext: boolean;
+}) {
+  const toggle = (key: keyof AboutMeSourceConfig, checked: boolean) => onChange({ ...value, [key]: checked });
+
+  return (
+    <div className="space-y-2 rounded-xl border border-[var(--border)] bg-[var(--background)]/60 p-3">
+      <p className="text-[0.6875rem] font-semibold uppercase tracking-wide text-[var(--muted-foreground)]">
+        AI Write draws from
+      </p>
+      <div className="grid grid-cols-2 gap-x-3 gap-y-1.5">
+        {CARD_FIELDS.map((f) => (
+          <SourceRow key={f.key} label={f.label} checked={!!value[f.key]} onToggle={(c) => toggle(f.key, c)} />
+        ))}
+      </div>
+      <div className="space-y-1.5 border-t border-[var(--border)] pt-2">
+        <SourceRow
+          label="Convo behavior"
+          checked={!!value.convoBehavior}
+          onToggle={(c) => toggle("convoBehavior", c)}
+        />
+        <SourceRow
+          label="Lorebook entries"
+          checked={!!value.lorebook}
+          onToggle={(c) => toggle("lorebook", c)}
+          tooltip="This character's linked and embedded lorebook entries — handy when the card fields are blank and the substance lives in the lorebook."
+        />
+        <div className="flex flex-wrap items-center gap-2">
+          <SourceRow
+            label="Chat context"
+            checked={!!value.chatContext}
+            disabled={!allowChatContext}
+            onToggle={(c) => toggle("chatContext", c)}
+            tooltip={
+              allowChatContext
+                ? "Include recent messages from this chat so the bio reflects how they've been acting here."
+                : "Only works for a chat-specific about me (edited from within a chat). The card editor has no chat to read."
+            }
+          />
+          {allowChatContext && value.chatContext && (
+            <span className="inline-flex items-center gap-1 text-xs text-[var(--muted-foreground)]">
+              <input
+                type="number"
+                min={1}
+                max={200}
+                value={value.chatContextLimit ?? DEFAULT_ABOUT_ME_CHAT_CONTEXT_LIMIT}
+                onChange={(e) => {
+                  const n = Number(e.target.value);
+                  onChange({
+                    ...value,
+                    chatContextLimit: Number.isFinite(n) ? Math.max(1, Math.min(200, Math.round(n))) : undefined,
+                  });
+                }}
+                className="w-14 rounded-md border border-[var(--border)] bg-[var(--secondary)] px-1.5 py-0.5 text-xs outline-none focus:border-[var(--primary)]/40"
+              />
+              msgs
+            </span>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/packages/client/src/components/characters/CharacterEditor.tsx
+++ b/packages/client/src/components/characters/CharacterEditor.tsx
@@ -1266,6 +1266,8 @@ function ConvoTab({
       baseName={formData.name}
       displayName={(ext.convoDisplayName as string) ?? ""}
       onDisplayNameChange={(v) => updateExtension("convoDisplayName", v)}
+      displayNameInCard={ext.convoDisplayNameInCard === true}
+      onDisplayNameInCardChange={(v) => updateExtension("convoDisplayNameInCard", v)}
       aboutMe={(ext.aboutMe as string) ?? ""}
       onAboutMeChange={(v) => updateExtension("aboutMe", v)}
       behavior={ext.convoBehavior as ConvoBehaviorConfig | undefined}

--- a/packages/client/src/components/characters/CharacterEditor.tsx
+++ b/packages/client/src/components/characters/CharacterEditor.tsx
@@ -1274,6 +1274,7 @@ function ConvoTab({
     <ConvoProfileFields
       key={characterId ?? "new-character"}
       kind={kind}
+      entityKey={characterId ?? "new-character"}
       baseName={formData.name}
       displayName={(ext.convoDisplayName as string) ?? ""}
       onDisplayNameChange={(v) => updateExtension("convoDisplayName", v)}

--- a/packages/client/src/components/characters/CharacterEditor.tsx
+++ b/packages/client/src/components/characters/CharacterEditor.tsx
@@ -1269,7 +1269,10 @@ function ConvoTab({
 }) {
   const ext = formData.extensions;
   return (
+    // Key by the edited character so all transient state (revert snapshot, open
+    // panels, connection choice) resets on switch — the editor reuses this instance.
     <ConvoProfileFields
+      key={characterId ?? "new-character"}
       kind={kind}
       baseName={formData.name}
       displayName={(ext.convoDisplayName as string) ?? ""}

--- a/packages/client/src/components/characters/CharacterEditor.tsx
+++ b/packages/client/src/components/characters/CharacterEditor.tsx
@@ -108,6 +108,7 @@ import {
   normalizeSpriteExpressionLabel,
   normalizeRpgStatPools,
   syncRpgHpFromPools,
+  type AboutMeSourceConfig,
   type CharacterCardVersion,
   type CharacterData,
   type ConversationCallCharacterVideoClipKind,
@@ -1046,7 +1047,12 @@ export function CharacterEditor() {
               <CharacterCardTab formData={formData} updateField={updateField} updateExtension={updateExtension} />
             )}
             {activeTab === "convo" && (
-              <ConvoTab formData={formData} updateExtension={updateExtension} kind="character" />
+              <ConvoTab
+                formData={formData}
+                updateExtension={updateExtension}
+                kind="character"
+                characterId={characterId ?? undefined}
+              />
             )}
             {activeTab === "advanced" && (
               <AdvancedTab
@@ -1254,10 +1260,12 @@ function ConvoTab({
   formData,
   updateExtension,
   kind,
+  characterId,
 }: {
   formData: CharacterData;
   updateExtension: (key: string, value: unknown) => void;
   kind: "character" | "persona";
+  characterId?: string;
 }) {
   const ext = formData.extensions;
   return (
@@ -1268,6 +1276,9 @@ function ConvoTab({
       onDisplayNameChange={(v) => updateExtension("convoDisplayName", v)}
       displayNameInCard={ext.convoDisplayNameInCard === true}
       onDisplayNameInCardChange={(v) => updateExtension("convoDisplayNameInCard", v)}
+      characterId={characterId}
+      sources={ext.aboutMeSources as AboutMeSourceConfig | undefined}
+      onSourcesChange={(v) => updateExtension("aboutMeSources", v)}
       aboutMe={(ext.aboutMe as string) ?? ""}
       onAboutMeChange={(v) => updateExtension("aboutMe", v)}
       behavior={ext.convoBehavior as ConvoBehaviorConfig | undefined}

--- a/packages/client/src/components/characters/ConvoProfileFields.tsx
+++ b/packages/client/src/components/characters/ConvoProfileFields.tsx
@@ -3,14 +3,15 @@
 // and behavior directive. Shared by the character and persona editors.
 // These fields only affect Conversation mode; they are never read in RP/VN/Game.
 // ──────────────────────────────────────────────
-import { useMemo, useState } from "react";
-import { Loader2, Wand2 } from "lucide-react";
+import { useMemo, useRef, useState } from "react";
+import { Loader2, Smile, Wand2 } from "lucide-react";
 import { toast } from "sonner";
 import type { ConvoBehaviorConfig, ConvoBehaviorInsertionStrategy } from "@marinara-engine/shared";
 import { useConnections } from "../../hooks/use-connections";
 import { useGenerateAboutMe } from "../../hooks/use-characters";
 import { filterLanguageGenerationConnections } from "../../lib/connection-filters";
 import { MacroTextarea } from "../ui/MacroTextarea";
+import { EmojiPicker } from "../ui/EmojiPicker";
 import { HelpTooltip } from "../ui/HelpTooltip";
 
 const STRATEGY_OPTIONS: Array<{ value: ConvoBehaviorInsertionStrategy; label: string }> = [
@@ -57,6 +58,31 @@ export function ConvoProfileFields({
   const { data: connectionsList } = useConnections();
   const generateAboutMe = useGenerateAboutMe();
   const [connectionId, setConnectionId] = useState("");
+  const aboutMeRef = useRef<HTMLTextAreaElement>(null);
+  const emojiBtnRef = useRef<HTMLButtonElement>(null);
+  const [emojiOpen, setEmojiOpen] = useState(false);
+
+  // Insert an emoji at the caret (or replace the selection), like the chat picker.
+  const insertEmoji = (token: string) => {
+    const el = aboutMeRef.current;
+    if (!el) {
+      onAboutMeChange(aboutMe + token);
+      return;
+    }
+    const start = el.selectionStart;
+    const end = el.selectionEnd;
+    const next = el.value.slice(0, start) + token + el.value.slice(end);
+    onAboutMeChange(next);
+    const caret = start + token.length;
+    requestAnimationFrame(() => {
+      el.focus();
+      try {
+        el.selectionStart = el.selectionEnd = caret;
+      } catch {
+        /* ignore */
+      }
+    });
+  };
 
   const connectionOptions = useMemo(
     () => filterLanguageGenerationConnections((connectionsList ?? []) as Array<{ id: string; name: string; model?: string | null }>),
@@ -112,11 +138,25 @@ export function ConvoProfileFields({
         <MacroTextarea
           value={aboutMe}
           onChange={onAboutMeChange}
+          textareaRef={aboutMeRef}
           placeholder="A line or two, an emoji, a joke, or nothing at all — whatever fits them…"
           rows={5}
           title="About Me"
           className="w-full resize-y rounded-xl border border-[var(--border)] bg-[var(--secondary)] p-3 text-sm leading-relaxed outline-none transition-colors placeholder:text-[var(--muted-foreground)]/40 focus:border-[var(--primary)]/40 focus:ring-1 focus:ring-[var(--primary)]/20"
+          toolbarExtra={
+            <button
+              ref={emojiBtnRef}
+              type="button"
+              onClick={() => setEmojiOpen((v) => !v)}
+              aria-label="Insert emoji"
+              title="Insert emoji"
+              className="rounded p-1 text-[var(--muted-foreground)] transition-colors hover:bg-[var(--accent)] hover:text-[var(--foreground)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--ring)]"
+            >
+              <Smile className="h-3 w-3" />
+            </button>
+          }
         />
+        <EmojiPicker open={emojiOpen} onClose={() => setEmojiOpen(false)} onSelect={insertEmoji} anchorRef={emojiBtnRef} />
         <div className="flex flex-wrap items-center gap-2">
           <select
             value={effectiveConnectionId}

--- a/packages/client/src/components/characters/ConvoProfileFields.tsx
+++ b/packages/client/src/components/characters/ConvoProfileFields.tsx
@@ -29,6 +29,9 @@ interface ConvoProfileFieldsProps {
   baseName: string;
   displayName: string;
   onDisplayNameChange: (value: string) => void;
+  /** When true, the display name is declared on the card in the convo prompt. */
+  displayNameInCard?: boolean;
+  onDisplayNameInCardChange?: (value: boolean) => void;
   aboutMe: string;
   onAboutMeChange: (value: string) => void;
   behavior: ConvoBehaviorConfig | null | undefined;
@@ -49,6 +52,8 @@ export function ConvoProfileFields({
   baseName,
   displayName,
   onDisplayNameChange,
+  displayNameInCard,
+  onDisplayNameInCardChange,
   aboutMe,
   onAboutMeChange,
   behavior,
@@ -126,6 +131,20 @@ export function ConvoProfileFields({
           placeholder={baseName || "Display name"}
           className="w-full rounded-xl border border-[var(--border)] bg-[var(--secondary)] px-3 py-2 text-sm outline-none transition-colors placeholder:text-[var(--muted-foreground)]/40 focus:border-[var(--primary)]/40 focus:ring-1 focus:ring-[var(--primary)]/20"
         />
+        {kind === "character" && onDisplayNameInCardChange && (
+          <label className="flex items-start gap-2 text-xs text-[var(--muted-foreground)]">
+            <input
+              type="checkbox"
+              checked={!!displayNameInCard}
+              onChange={(e) => onDisplayNameInCardChange(e.target.checked)}
+              className="mt-0.5 h-3.5 w-3.5 shrink-0 accent-[var(--primary)]"
+            />
+            <span className="inline-flex items-center gap-1">
+              Declare this name on the card in the prompt
+              <HelpTooltip text="Prepends a line like “Conversation display name: X” to this character's card so the model knows which card presents under which Convo name. Needs a display name set. Convo mode only." />
+            </span>
+          </label>
+        )}
       </div>
 
       <div className="mari-editor-panel space-y-3 p-3">

--- a/packages/client/src/components/characters/ConvoProfileFields.tsx
+++ b/packages/client/src/components/characters/ConvoProfileFields.tsx
@@ -3,7 +3,7 @@
 // and behavior directive. Shared by the character and persona editors.
 // These fields only affect Conversation mode; they are never read in RP/VN/Game.
 // ──────────────────────────────────────────────
-import { useMemo, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { Loader2, RotateCcw, Settings2, Smile, Wand2 } from "lucide-react";
 import { toast } from "sonner";
 import {
@@ -31,6 +31,8 @@ const STRATEGY_OPTIONS: Array<{ value: ConvoBehaviorInsertionStrategy; label: st
 
 interface ConvoProfileFieldsProps {
   kind: "character" | "persona";
+  /** Stable edited entity key, used to reset transient UI state on switches. */
+  entityKey?: string;
   /** Base name, used as the display-name placeholder. */
   baseName: string;
   displayName: string;
@@ -60,6 +62,7 @@ interface ConvoProfileFieldsProps {
 
 export function ConvoProfileFields({
   kind,
+  entityKey,
   baseName,
   displayName,
   onDisplayNameChange,
@@ -90,6 +93,13 @@ export function ConvoProfileFields({
   // Revert: snapshot the about-me right before the first edit (manual or AI Write),
   // so the user can undo changes they don't like. Cleared once reverted.
   const [revertTo, setRevertTo] = useState<string | null>(null);
+  useEffect(() => {
+    setConnectionId("");
+    setRevertTo(null);
+    setSourcesOpen(false);
+    setEmojiOpen(false);
+  }, [entityKey, kind]);
+
   const captureRevert = () => setRevertTo((prev) => (prev === null ? aboutMe : prev));
   const changeAboutMe = (value: string) => {
     captureRevert();

--- a/packages/client/src/components/characters/ConvoProfileFields.tsx
+++ b/packages/client/src/components/characters/ConvoProfileFields.tsx
@@ -4,7 +4,7 @@
 // These fields only affect Conversation mode; they are never read in RP/VN/Game.
 // ──────────────────────────────────────────────
 import { useMemo, useRef, useState } from "react";
-import { Loader2, Settings2, Smile, Wand2 } from "lucide-react";
+import { Loader2, RotateCcw, Settings2, Smile, Wand2 } from "lucide-react";
 import { toast } from "sonner";
 import {
   resolveAboutMeSources,
@@ -13,7 +13,7 @@ import {
   type ConvoBehaviorInsertionStrategy,
 } from "@marinara-engine/shared";
 import { useConnections } from "../../hooks/use-connections";
-import { useGenerateAboutMe } from "../../hooks/use-characters";
+import { useGenerateAboutMe, useCharacterLorebookEntries } from "../../hooks/use-characters";
 import { filterLanguageGenerationConnections } from "../../lib/connection-filters";
 import { MacroTextarea } from "../ui/MacroTextarea";
 import { EmojiPicker } from "../ui/EmojiPicker";
@@ -83,18 +83,30 @@ export function ConvoProfileFields({
   const [sourcesOpen, setSourcesOpen] = useState(false);
   const resolvedSources = resolveAboutMeSources(sources);
   const showSourcePicker = kind === "character" && !!onSourcesChange;
+  const { data: lorebookEntriesData } = useCharacterLorebookEntries(
+    showSourcePicker && sourcesOpen ? characterId : null,
+  );
+
+  // Revert: snapshot the about-me right before the first edit (manual or AI Write),
+  // so the user can undo changes they don't like. Cleared once reverted.
+  const [revertTo, setRevertTo] = useState<string | null>(null);
+  const captureRevert = () => setRevertTo((prev) => (prev === null ? aboutMe : prev));
+  const changeAboutMe = (value: string) => {
+    captureRevert();
+    onAboutMeChange(value);
+  };
 
   // Insert an emoji at the caret (or replace the selection), like the chat picker.
   const insertEmoji = (token: string) => {
     const el = aboutMeRef.current;
     if (!el) {
-      onAboutMeChange(aboutMe + token);
+      changeAboutMe(aboutMe + token);
       return;
     }
     const start = el.selectionStart;
     const end = el.selectionEnd;
     const next = el.value.slice(0, start) + token + el.value.slice(end);
-    onAboutMeChange(next);
+    changeAboutMe(next);
     const caret = start + token.length;
     requestAnimationFrame(() => {
       el.focus();
@@ -135,6 +147,7 @@ export function ConvoProfileFields({
         toast.message("The model left the about me blank — keeping your current text.");
         return;
       }
+      captureRevert();
       onAboutMeChange(result.aboutMe);
       toast.success("About me drafted — review and edit to taste");
     } catch (err) {
@@ -180,7 +193,7 @@ export function ConvoProfileFields({
         </div>
         <MacroTextarea
           value={aboutMe}
-          onChange={onAboutMeChange}
+          onChange={changeAboutMe}
           textareaRef={aboutMeRef}
           placeholder="A line or two, an emoji, a joke, or nothing at all — whatever fits them…"
           rows={5}
@@ -214,6 +227,20 @@ export function ConvoProfileFields({
               </option>
             ))}
           </select>
+          {revertTo !== null && revertTo !== aboutMe && (
+            <button
+              type="button"
+              onClick={() => {
+                onAboutMeChange(revertTo);
+                setRevertTo(null);
+              }}
+              title="Undo the changes to this about me"
+              className="inline-flex items-center gap-1 rounded-lg border border-[var(--border)] px-2 py-1.5 text-xs text-[var(--muted-foreground)] transition-colors hover:bg-[var(--accent)] hover:text-[var(--foreground)]"
+            >
+              <RotateCcw size="0.8125rem" />
+              Revert
+            </button>
+          )}
           {showSourcePicker && (
             <button
               type="button"
@@ -240,7 +267,12 @@ export function ConvoProfileFields({
           </button>
         </div>
         {showSourcePicker && sourcesOpen && onSourcesChange && (
-          <AboutMeSourcePicker value={resolvedSources} onChange={onSourcesChange} allowChatContext={false} />
+          <AboutMeSourcePicker
+            value={resolvedSources}
+            onChange={onSourcesChange}
+            allowChatContext={false}
+            lorebookEntries={lorebookEntriesData?.entries ?? []}
+          />
         )}
       </div>
 

--- a/packages/client/src/components/characters/ConvoProfileFields.tsx
+++ b/packages/client/src/components/characters/ConvoProfileFields.tsx
@@ -4,14 +4,20 @@
 // These fields only affect Conversation mode; they are never read in RP/VN/Game.
 // ──────────────────────────────────────────────
 import { useMemo, useRef, useState } from "react";
-import { Loader2, Smile, Wand2 } from "lucide-react";
+import { Loader2, Settings2, Smile, Wand2 } from "lucide-react";
 import { toast } from "sonner";
-import type { ConvoBehaviorConfig, ConvoBehaviorInsertionStrategy } from "@marinara-engine/shared";
+import {
+  resolveAboutMeSources,
+  type AboutMeSourceConfig,
+  type ConvoBehaviorConfig,
+  type ConvoBehaviorInsertionStrategy,
+} from "@marinara-engine/shared";
 import { useConnections } from "../../hooks/use-connections";
 import { useGenerateAboutMe } from "../../hooks/use-characters";
 import { filterLanguageGenerationConnections } from "../../lib/connection-filters";
 import { MacroTextarea } from "../ui/MacroTextarea";
 import { EmojiPicker } from "../ui/EmojiPicker";
+import { AboutMeSourcePicker } from "./AboutMeSourcePicker";
 import { HelpTooltip } from "../ui/HelpTooltip";
 
 const STRATEGY_OPTIONS: Array<{ value: ConvoBehaviorInsertionStrategy; label: string }> = [
@@ -32,6 +38,11 @@ interface ConvoProfileFieldsProps {
   /** When true, the display name is declared on the card in the convo prompt. */
   displayNameInCard?: boolean;
   onDisplayNameInCardChange?: (value: boolean) => void;
+  /** Character id — lets AI-write pull this character's lorebook context. */
+  characterId?: string;
+  /** AI-write source config (character-only). Absent → default (personality). */
+  sources?: AboutMeSourceConfig;
+  onSourcesChange?: (value: AboutMeSourceConfig) => void;
   aboutMe: string;
   onAboutMeChange: (value: string) => void;
   behavior: ConvoBehaviorConfig | null | undefined;
@@ -54,6 +65,9 @@ export function ConvoProfileFields({
   onDisplayNameChange,
   displayNameInCard,
   onDisplayNameInCardChange,
+  characterId,
+  sources,
+  onSourcesChange,
   aboutMe,
   onAboutMeChange,
   behavior,
@@ -66,6 +80,9 @@ export function ConvoProfileFields({
   const aboutMeRef = useRef<HTMLTextAreaElement>(null);
   const emojiBtnRef = useRef<HTMLButtonElement>(null);
   const [emojiOpen, setEmojiOpen] = useState(false);
+  const [sourcesOpen, setSourcesOpen] = useState(false);
+  const resolvedSources = resolveAboutMeSources(sources);
+  const showSourcePicker = kind === "character" && !!onSourcesChange;
 
   // Insert an emoji at the caret (or replace the selection), like the chat picker.
   const insertEmoji = (token: string) => {
@@ -104,7 +121,14 @@ export function ConvoProfileFields({
   const handleAiWrite = async () => {
     if (!effectiveConnectionId || generateAboutMe.isPending) return;
     try {
-      const result = await generateAboutMe.mutateAsync({ connectionId: effectiveConnectionId, kind, ...aiSource });
+      const result = await generateAboutMe.mutateAsync({
+        connectionId: effectiveConnectionId,
+        kind,
+        ...aiSource,
+        convoBehavior: behaviorInstruction,
+        sources: showSourcePicker ? resolvedSources : undefined,
+        characterId: showSourcePicker ? characterId : undefined,
+      });
       // The prompt may intentionally return an empty bio. Don't silently wipe an
       // existing about-me — only apply an empty result if the field was already empty.
       if (!result.aboutMe.trim() && aboutMe.trim()) {
@@ -190,17 +214,34 @@ export function ConvoProfileFields({
               </option>
             ))}
           </select>
+          {showSourcePicker && (
+            <button
+              type="button"
+              onClick={() => setSourcesOpen((v) => !v)}
+              aria-label="AI Write sources"
+              title="Choose what AI Write reads from"
+              className={
+                "inline-flex items-center rounded-lg border border-[var(--border)] px-2 py-1.5 text-xs transition-colors hover:bg-[var(--accent)] hover:text-[var(--foreground)] " +
+                (sourcesOpen ? "bg-[var(--accent)] text-[var(--foreground)]" : "text-[var(--muted-foreground)]")
+              }
+            >
+              <Settings2 size="0.8125rem" />
+            </button>
+          )}
           <button
             type="button"
             onClick={handleAiWrite}
             disabled={!effectiveConnectionId || generateAboutMe.isPending}
             className="inline-flex items-center gap-1.5 rounded-lg bg-[var(--primary)] px-3 py-1.5 text-xs font-medium text-[var(--primary-foreground)] transition-opacity hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-50"
-            title="Draft an in-character about me from the card"
+            title="Draft an in-character about me from the selected sources"
           >
             {generateAboutMe.isPending ? <Loader2 size="0.8125rem" className="animate-spin" /> : <Wand2 size="0.8125rem" />}
             {generateAboutMe.isPending ? "Writing…" : "AI Write"}
           </button>
         </div>
+        {showSourcePicker && sourcesOpen && onSourcesChange && (
+          <AboutMeSourcePicker value={resolvedSources} onChange={onSourcesChange} allowChatContext={false} />
+        )}
       </div>
 
       <div className="mari-editor-panel space-y-3 p-3">

--- a/packages/client/src/components/chat/ChatArea.tsx
+++ b/packages/client/src/components/chat/ChatArea.tsx
@@ -806,6 +806,7 @@ export function ChatArea() {
         if (typeof snapshot.name !== "string") continue;
         map.set(id, {
           name: snapshot.name,
+          convoDisplayName: snapshot.convoDisplayName,
           description: snapshot.description ?? "",
           personality: snapshot.personality ?? "",
           backstory: snapshot.backstory ?? "",

--- a/packages/client/src/components/chat/ChatArea.tsx
+++ b/packages/client/src/components/chat/ChatArea.tsx
@@ -928,7 +928,7 @@ export function ChatArea() {
     return {
       id: persona.id,
       name: persona.name,
-      convoDisplayName: (persona as { convoDisplayName?: string }).convoDisplayName || undefined,
+      convoDisplayName: persona.convoDisplayName || undefined,
       phoneticName: persona.phoneticName || undefined,
       description: persona.description ?? "",
       personality: persona.personality || undefined,

--- a/packages/client/src/components/chat/ChatArea.tsx
+++ b/packages/client/src/components/chat/ChatArea.tsx
@@ -345,6 +345,7 @@ function toCharacterMapValue(char: CharacterRow): CharacterMapValue {
     const extensions = data.extensions && typeof data.extensions === "object" ? data.extensions : {};
     return {
       name: data.name ?? "Unknown",
+      convoDisplayName: extensions.convoDisplayName || undefined,
       phoneticName: extensions.phoneticName || undefined,
       description: data.description ?? "",
       personality: data.personality ?? "",
@@ -374,6 +375,7 @@ function toCharacterMapValue(char: CharacterRow): CharacterMapValue {
 function areCharacterMapValuesEqual(a: CharacterMapValue, b: CharacterMapValue): boolean {
   return (
     a.name === b.name &&
+    a.convoDisplayName === b.convoDisplayName &&
     a.phoneticName === b.phoneticName &&
     a.description === b.description &&
     a.personality === b.personality &&
@@ -926,6 +928,7 @@ export function ChatArea() {
     return {
       id: persona.id,
       name: persona.name,
+      convoDisplayName: (persona as { convoDisplayName?: string }).convoDisplayName || undefined,
       phoneticName: persona.phoneticName || undefined,
       description: persona.description ?? "",
       personality: persona.personality || undefined,

--- a/packages/client/src/components/chat/ConversationMessage.tsx
+++ b/packages/client/src/components/chat/ConversationMessage.tsx
@@ -260,6 +260,21 @@ export const ConversationMessage = memo(function ConversationMessage({
       : (msgPersona?.nameColor ?? personaInfo?.nameColor)
     : resolvedCharacterInfo?.nameColor;
 
+  // Conversation-only cosmetic display name (convoDisplayName). This component only
+  // ever mounts in Conversation mode, so reading it here can't leak into RP/Game.
+  // It's read live (character map / active persona), so renaming reflects on
+  // existing messages. Identity and macros keep the base `name`; only the visible
+  // label swaps. For personas we only have the *current* persona's live name, so we
+  // never stamp it onto a different persona's historical messages.
+  const convoDisplayName = isUser
+    ? plainUserMessages
+      ? undefined
+      : !msgPersona || msgPersona.personaId === personaInfo?.id
+        ? personaInfo?.convoDisplayName
+        : undefined
+    : primaryCharInfo?.convoDisplayName;
+  const headerDisplayName = convoDisplayName && convoDisplayName.trim() ? convoDisplayName : displayName;
+
   const macroContext = useMemo(
     () => ({
       userName: displayName,
@@ -681,7 +696,7 @@ export const ConversationMessage = memo(function ConversationMessage({
             height: anchor.height,
           },
           avatarUrl,
-          displayName,
+          displayName: headerDisplayName,
           nameColor: nameColor ?? null,
           status: aboutMeTarget.kind === "character" ? (resolvedCharacterInfo?.conversationStatus ?? null) : null,
           activity: aboutMeTarget.kind === "character" ? (resolvedCharacterInfo?.conversationActivity ?? null) : null,
@@ -693,7 +708,7 @@ export const ConversationMessage = memo(function ConversationMessage({
     extra,
     isUser,
     isGrouped: !!isGrouped,
-    displayName,
+    displayName: headerDisplayName,
     avatarUrl,
     avatarCropStyle,
     nameColor,

--- a/packages/client/src/components/chat/chat-area.types.ts
+++ b/packages/client/src/components/chat/chat-area.types.ts
@@ -5,6 +5,8 @@ export type CharacterMap = Map<
   string,
   {
     name: string;
+    /** Conversation-only cosmetic display name (extensions.convoDisplayName). */
+    convoDisplayName?: string;
     phoneticName?: string;
     description?: string;
     personality?: string;
@@ -25,6 +27,8 @@ export type CharacterMap = Map<
 export type PersonaInfo = {
   id?: string;
   name: string;
+  /** Conversation-only cosmetic display name (persona.convoDisplayName). */
+  convoDisplayName?: string;
   phoneticName?: string;
   description?: string;
   personality?: string;

--- a/packages/client/src/components/modals/AboutMeViewerModal.tsx
+++ b/packages/client/src/components/modals/AboutMeViewerModal.tsx
@@ -561,6 +561,7 @@ export function AboutMeViewerModal({
                     <select
                       value={effectiveConnectionId}
                       onChange={(e) => setConnectionId(e.target.value)}
+                      aria-label="Generation connection"
                       className="min-w-0 flex-1 rounded-md border border-[var(--border)] bg-[var(--background)] px-1.5 py-1 text-[0.6875rem] outline-none focus:border-[var(--primary)]/40"
                     >
                       {connectionOptions.length === 0 && <option value="">No connections</option>}

--- a/packages/client/src/components/modals/AboutMeViewerModal.tsx
+++ b/packages/client/src/components/modals/AboutMeViewerModal.tsx
@@ -500,7 +500,9 @@ export function AboutMeViewerModal({
               <div
                 className={cn(
                   "mari-about-me-text min-h-[2.5rem] whitespace-pre-wrap text-[0.8125rem] leading-relaxed text-[var(--foreground)]",
-                  isMobile && "min-h-0 flex-1 overflow-y-auto",
+                  // Long bios scroll instead of stretching the popout off-screen: fill the
+                  // sheet on mobile, cap + scroll on the anchored desktop card.
+                  isMobile ? "min-h-0 flex-1 overflow-y-auto" : "max-h-[16rem] overflow-y-auto",
                 )}
               >
                 {effective.trim() ? (

--- a/packages/client/src/components/modals/AboutMeViewerModal.tsx
+++ b/packages/client/src/components/modals/AboutMeViewerModal.tsx
@@ -14,6 +14,7 @@ import { useCharacter, usePersonas } from "../../hooks/use-characters";
 import { useConversationCustomEmojis } from "../../hooks/use-conversation-custom-emojis";
 import { useChatStore } from "../../stores/chat.store";
 import { cn } from "../../lib/utils";
+import { parseChatMetadata } from "../../lib/chat-display";
 import { renderInlineWithCustomEmojis } from "../../lib/custom-emoji-render";
 import { EmojiPicker } from "../ui/EmojiPicker";
 import { CustomEmojiTab } from "../chat/CustomEmojiTab";
@@ -132,7 +133,11 @@ export function AboutMeViewerModal({
   const displayName = displayNameProp || profile.displayName || profile.name || "Profile";
   const handle = profile.name && profile.name !== displayName ? profile.name : "";
 
-  const metadata = (chat?.metadata ?? {}) as Chat["metadata"];
+  // Parse defensively: a freshly-fetched chat carries `metadata` as a JSON STRING
+  // (only mutations normalize it to an object in cache). A raw cast here made the
+  // override read `undefined` after any reload/refetch — dropping the chat-specific
+  // about-me and, on save, clobbering every other character's override.
+  const metadata = parseChatMetadata(chat?.metadata) as Chat["metadata"];
   const overrides = (metadata.conversationAboutMeOverrides ?? {}) as Record<string, string>;
   const override = typeof overrides[id] === "string" ? overrides[id] : undefined;
   const hasOverride = override !== undefined && override.trim().length > 0;

--- a/packages/client/src/components/modals/AboutMeViewerModal.tsx
+++ b/packages/client/src/components/modals/AboutMeViewerModal.tsx
@@ -6,7 +6,7 @@
 // ──────────────────────────────────────────────
 import { useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import { createPortal } from "react-dom";
-import { Loader2, Pencil, RotateCcw, Save, Settings2, Smile, Trash2, User, Wand2, X } from "lucide-react";
+import { Loader2, Pencil, RotateCcw, Save, Settings2, Smile, Trash2, Undo2, User, Wand2, X } from "lucide-react";
 import { toast } from "sonner";
 import { resolveAboutMeSources, type AboutMeSourceConfig, type Chat } from "@marinara-engine/shared";
 import { useChat, useUpdateChatMetadata } from "../../hooks/use-chats";
@@ -185,6 +185,8 @@ export function AboutMeViewerModal({
 
   const [editing, setEditing] = useState(false);
   const [draft, setDraft] = useState("");
+  // Value the draft started at (edit-entry) so a Revert can undo AI-write / typing.
+  const [editBaseline, setEditBaseline] = useState("");
   const [emojiOpen, setEmojiOpen] = useState(false);
   const [sourcesOpen, setSourcesOpen] = useState(false);
   const [sourceOverride, setSourceOverride] = useState<AboutMeSourceConfig | null>(null);
@@ -319,7 +321,9 @@ export function AboutMeViewerModal({
     if (top + ch > vh - 8) top = vh - ch - 8;
     if (top < 8) top = 8;
     setPos({ top, left });
-  }, [open, anchorRect, editing, effective, isMobile]);
+    // `sourcesOpen`/`draft` change the card height (the AI-write source panel and
+    // generated text), so re-measure and re-clamp to keep it on screen.
+  }, [open, anchorRect, editing, effective, isMobile, sourcesOpen, draft]);
 
   if (!open) return null;
 
@@ -620,6 +624,7 @@ export function AboutMeViewerModal({
                   type="button"
                   onClick={() => {
                     setDraft(effective);
+                    setEditBaseline(effective);
                     setEditing(true);
                   }}
                   className="inline-flex items-center gap-1.5 rounded-lg bg-[var(--primary)] px-2.5 py-1.5 text-xs font-medium text-[var(--primary-foreground)] transition-opacity hover:opacity-90"
@@ -630,6 +635,17 @@ export function AboutMeViewerModal({
               </>
             ) : (
               <>
+                {draft !== editBaseline && (
+                  <button
+                    type="button"
+                    onClick={() => setDraft(editBaseline)}
+                    title="Undo the changes to this about me"
+                    className="inline-flex items-center gap-1.5 rounded-lg border border-[var(--border)] px-2.5 py-1.5 text-xs text-[var(--muted-foreground)] transition-colors hover:bg-[var(--accent)]"
+                  >
+                    <Undo2 size="0.8125rem" />
+                    Revert
+                  </button>
+                )}
                 <button
                   type="button"
                   onClick={() => setEditing(false)}

--- a/packages/client/src/components/modals/AboutMeViewerModal.tsx
+++ b/packages/client/src/components/modals/AboutMeViewerModal.tsx
@@ -4,18 +4,21 @@
 // avatar + status, then the effective about-me (per-chat override, else the
 // card/persona default), with set / edit / clear of the chat-specific override.
 // ──────────────────────────────────────────────
-import { useEffect, useLayoutEffect, useRef, useState } from "react";
+import { useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import { createPortal } from "react-dom";
-import { Pencil, RotateCcw, Save, Smile, Trash2, User, X } from "lucide-react";
+import { Loader2, Pencil, RotateCcw, Save, Settings2, Smile, Trash2, User, Wand2, X } from "lucide-react";
 import { toast } from "sonner";
-import type { Chat } from "@marinara-engine/shared";
+import { resolveAboutMeSources, type AboutMeSourceConfig, type Chat } from "@marinara-engine/shared";
 import { useChat, useUpdateChatMetadata } from "../../hooks/use-chats";
-import { useCharacter, usePersonas } from "../../hooks/use-characters";
+import { useCharacter, usePersonas, useGenerateAboutMe } from "../../hooks/use-characters";
+import { useConnections } from "../../hooks/use-connections";
 import { useConversationCustomEmojis } from "../../hooks/use-conversation-custom-emojis";
 import { useChatStore } from "../../stores/chat.store";
 import { cn } from "../../lib/utils";
 import { parseChatMetadata } from "../../lib/chat-display";
+import { filterLanguageGenerationConnections } from "../../lib/connection-filters";
 import { renderInlineWithCustomEmojis } from "../../lib/custom-emoji-render";
+import { AboutMeSourcePicker } from "../characters/AboutMeSourcePicker";
 import { EmojiPicker } from "../ui/EmojiPicker";
 import { CustomEmojiTab } from "../chat/CustomEmojiTab";
 
@@ -87,7 +90,17 @@ function nameStyle(nameColor?: string | null) {
   return { color: nameColor } as const;
 }
 
-function parseCharacterConvo(data: unknown): { name: string; displayName: string; aboutMe: string } {
+interface CharacterConvoProfile {
+  name: string;
+  displayName: string;
+  aboutMe: string;
+  /** Card fields used as AI-write source material. */
+  card: { description: string; personality: string; scenario: string; backstory: string; appearance: string };
+  convoBehavior: string;
+  sources?: AboutMeSourceConfig;
+}
+
+function parseCharacterConvo(data: unknown): CharacterConvoProfile {
   let parsed: Record<string, unknown> | null = null;
   try {
     parsed = (typeof data === "string" ? JSON.parse(data) : data) as Record<string, unknown>;
@@ -95,9 +108,27 @@ function parseCharacterConvo(data: unknown): { name: string; displayName: string
     parsed = null;
   }
   const ext = (parsed?.extensions ?? {}) as Record<string, unknown>;
-  const name = typeof parsed?.name === "string" ? parsed.name : "";
+  const str = (v: unknown) => (typeof v === "string" ? v : "");
+  const name = str(parsed?.name);
   const displayName = typeof ext.convoDisplayName === "string" && ext.convoDisplayName ? ext.convoDisplayName : name;
-  return { name, displayName, aboutMe: typeof ext.aboutMe === "string" ? ext.aboutMe : "" };
+  const behavior =
+    ext.convoBehavior && typeof ext.convoBehavior === "object"
+      ? (ext.convoBehavior as { instruction?: string })
+      : null;
+  return {
+    name,
+    displayName,
+    aboutMe: str(ext.aboutMe),
+    card: {
+      description: str(parsed?.description),
+      personality: str(parsed?.personality),
+      scenario: str(parsed?.scenario),
+      backstory: str(ext.backstory),
+      appearance: str(ext.appearance),
+    },
+    convoBehavior: str(behavior?.instruction),
+    sources: (ext.aboutMeSources as AboutMeSourceConfig | undefined) ?? undefined,
+  };
 }
 
 export function AboutMeViewerModal({
@@ -119,7 +150,7 @@ export function AboutMeViewerModal({
   const updateMeta = useUpdateChatMetadata();
   const isMobile = useIsMobileViewport();
 
-  const profile =
+  const profile: CharacterConvoProfile =
     kind === "character"
       ? parseCharacterConvo((character as { data?: unknown } | undefined)?.data)
       : (() => {
@@ -127,7 +158,14 @@ export function AboutMeViewerModal({
           const name = typeof persona?.name === "string" ? persona.name : "";
           const dn =
             typeof persona?.convoDisplayName === "string" && persona.convoDisplayName ? persona.convoDisplayName : name;
-          return { name, displayName: dn, aboutMe: typeof persona?.aboutMe === "string" ? persona.aboutMe : "" };
+          return {
+            name,
+            displayName: dn,
+            aboutMe: typeof persona?.aboutMe === "string" ? persona.aboutMe : "",
+            card: { description: "", personality: "", scenario: "", backstory: "", appearance: "" },
+            convoBehavior: "",
+            sources: undefined,
+          };
         })();
 
   const displayName = displayNameProp || profile.displayName || profile.name || "Profile";
@@ -148,17 +186,64 @@ export function AboutMeViewerModal({
   const [editing, setEditing] = useState(false);
   const [draft, setDraft] = useState("");
   const [emojiOpen, setEmojiOpen] = useState(false);
+  const [sourcesOpen, setSourcesOpen] = useState(false);
+  const [sourceOverride, setSourceOverride] = useState<AboutMeSourceConfig | null>(null);
+  const [connectionId, setConnectionId] = useState("");
   const cardRef = useRef<HTMLDivElement>(null);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const emojiBtnRef = useRef<HTMLButtonElement>(null);
   const emojiPanelRef = useRef<HTMLDivElement>(null);
   const [pos, setPos] = useState<{ top: number; left: number } | null>(null);
 
+  // AI-write (characters only): draws from the sources configured via the ⚙️. In the
+  // chat popout the chat-context source is available (this writes a chat-specific bio).
+  const generateAboutMe = useGenerateAboutMe();
+  const { data: connectionsList } = useConnections();
+  const connectionOptions = useMemo(
+    () =>
+      filterLanguageGenerationConnections(
+        (connectionsList ?? []) as Array<{ id: string; name: string; model?: string | null }>,
+      ),
+    [connectionsList],
+  );
+  const effectiveConnectionId =
+    connectionId && connectionOptions.some((c) => c.id === connectionId)
+      ? connectionId
+      : (connectionOptions[0]?.id ?? "");
+  const resolvedSources = sourceOverride ?? resolveAboutMeSources(profile.sources);
+  const canAiWrite = kind === "character";
+
   useEffect(() => {
     setEditing(false);
     setDraft("");
     setEmojiOpen(false);
+    setSourcesOpen(false);
+    setSourceOverride(null);
   }, [id, kind, open]);
+
+  const handleAiWrite = async () => {
+    if (!canAiWrite || !effectiveConnectionId || generateAboutMe.isPending) return;
+    try {
+      const result = await generateAboutMe.mutateAsync({
+        connectionId: effectiveConnectionId,
+        kind: "character",
+        name: profile.name,
+        ...profile.card,
+        convoBehavior: profile.convoBehavior,
+        sources: resolvedSources,
+        characterId: id,
+        chatId: activeChatId ?? undefined,
+      });
+      if (!result.aboutMe.trim() && draft.trim()) {
+        toast.message("The model left it blank — keeping your text.");
+        return;
+      }
+      setDraft(result.aboutMe);
+      toast.success("About me drafted — review and save");
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : "Failed to generate about me");
+    }
+  };
 
   const renderAbout = (text: string) =>
     renderInlineWithCustomEmojis(text, "about-me", emojiMap, (t, kp) => [<span key={kp}>{t}</span>]);
@@ -421,6 +506,7 @@ export function AboutMeViewerModal({
                 )}
               </div>
             ) : (
+              <>
               <div className={cn("relative", isMobile && "min-h-0 flex-1")}>
                 {/* Desktop: embedded picker inside the card's own stacking context,
                     opening upward above the field (portaled pickers fought the
@@ -463,6 +549,55 @@ export function AboutMeViewerModal({
                   <Smile size="1rem" />
                 </button>
               </div>
+              {canAiWrite && (
+                <div className="mt-2 shrink-0 space-y-2">
+                  <div className="flex flex-wrap items-center gap-1.5">
+                    <select
+                      value={effectiveConnectionId}
+                      onChange={(e) => setConnectionId(e.target.value)}
+                      className="min-w-0 flex-1 rounded-md border border-[var(--border)] bg-[var(--background)] px-1.5 py-1 text-[0.6875rem] outline-none focus:border-[var(--primary)]/40"
+                    >
+                      {connectionOptions.length === 0 && <option value="">No connections</option>}
+                      {connectionOptions.map((c) => (
+                        <option key={c.id} value={c.id}>
+                          {c.name}
+                          {c.model ? ` — ${c.model}` : ""}
+                        </option>
+                      ))}
+                    </select>
+                    <button
+                      type="button"
+                      onClick={() => setSourcesOpen((v) => !v)}
+                      aria-label="AI Write sources"
+                      title="Choose what AI Write reads from"
+                      className={cn(
+                        "rounded-md border border-[var(--border)] p-1 transition-colors hover:bg-[var(--accent)] hover:text-[var(--foreground)]",
+                        sourcesOpen ? "bg-[var(--accent)] text-[var(--foreground)]" : "text-[var(--muted-foreground)]",
+                      )}
+                    >
+                      <Settings2 size="0.8125rem" />
+                    </button>
+                    <button
+                      type="button"
+                      onClick={handleAiWrite}
+                      disabled={!effectiveConnectionId || generateAboutMe.isPending}
+                      className="inline-flex items-center gap-1 rounded-md bg-[var(--primary)] px-2 py-1 text-[0.6875rem] font-medium text-[var(--primary-foreground)] transition-opacity hover:opacity-90 disabled:opacity-50"
+                      title="Draft this chat-specific about me from the selected sources"
+                    >
+                      {generateAboutMe.isPending ? (
+                        <Loader2 size="0.75rem" className="animate-spin" />
+                      ) : (
+                        <Wand2 size="0.75rem" />
+                      )}
+                      {generateAboutMe.isPending ? "Writing…" : "AI Write"}
+                    </button>
+                  </div>
+                  {sourcesOpen && (
+                    <AboutMeSourcePicker value={resolvedSources} onChange={setSourceOverride} allowChatContext />
+                  )}
+                </div>
+              )}
+              </>
             )}
           </div>
 

--- a/packages/client/src/components/personas/PersonaEditor.tsx
+++ b/packages/client/src/components/personas/PersonaEditor.tsx
@@ -1449,7 +1449,12 @@ export function PersonaEditor() {
             {activeTab === "convo" && (
               // Key by the edited persona so the Convo fields' transient state resets on
               // switch — the editor reuses this instance across personas.
-              <PersonaConvoTab key={personaId ?? "new-persona"} formData={formData} updateField={updateField} />
+              <PersonaConvoTab
+                key={personaId ?? "new-persona"}
+                personaId={personaId}
+                formData={formData}
+                updateField={updateField}
+              />
             )}
             {activeTab === "lorebook" && personaId && (
               <PersonaLorebookTab personaId={personaId} personaName={formData.name} />
@@ -3178,15 +3183,18 @@ function PersonaVersionHistoryPanel({
 }
 
 function PersonaConvoTab({
+  personaId,
   formData,
   updateField,
 }: {
+  personaId: string | null;
   formData: PersonaFormData;
   updateField: <K extends keyof PersonaFormData>(key: K, value: PersonaFormData[K]) => void;
 }) {
   return (
     <ConvoProfileFields
       kind="persona"
+      entityKey={personaId ?? "new-persona"}
       baseName={formData.name}
       displayName={formData.convoDisplayName}
       onDisplayNameChange={(v) => updateField("convoDisplayName", v)}

--- a/packages/client/src/components/personas/PersonaEditor.tsx
+++ b/packages/client/src/components/personas/PersonaEditor.tsx
@@ -1446,7 +1446,11 @@ export function PersonaEditor() {
             {activeTab === "card" && (
               <PersonaCardTab formData={formData} updateField={updateField} setDirty={setDirty} />
             )}
-            {activeTab === "convo" && <PersonaConvoTab formData={formData} updateField={updateField} />}
+            {activeTab === "convo" && (
+              // Key by the edited persona so the Convo fields' transient state resets on
+              // switch — the editor reuses this instance across personas.
+              <PersonaConvoTab key={personaId ?? "new-persona"} formData={formData} updateField={updateField} />
+            )}
             {activeTab === "lorebook" && personaId && (
               <PersonaLorebookTab personaId={personaId} personaName={formData.name} />
             )}

--- a/packages/client/src/components/ui/HelpTooltip.tsx
+++ b/packages/client/src/components/ui/HelpTooltip.tsx
@@ -6,6 +6,10 @@ import { createPortal } from "react-dom";
 import { HelpCircle } from "lucide-react";
 import { cn } from "../../lib/utils";
 
+// Only one tooltip is open at a time: opening one closes whichever was open, so
+// hovering/opening a second tooltip dismisses the first instead of stacking.
+let activeTooltipClose: (() => void) | null = null;
+
 interface HelpTooltipProps {
   /** The help content to display */
   text: ReactNode;
@@ -37,6 +41,22 @@ export function HelpTooltip({
   const wrapRef = useRef<HTMLSpanElement>(null);
   const tipRef = useRef<HTMLDivElement>(null);
   const [pos, setPos] = useState<{ top: number; left: number; ready: boolean }>({ top: 0, left: 0, ready: false });
+
+  // Stable per-instance closer registered with the module-level "active tooltip".
+  const closeSelfRef = useRef<(() => void) | null>(null);
+  if (!closeSelfRef.current) {
+    closeSelfRef.current = () => {
+      setShow(false);
+      setPinned(false);
+      if (activeTooltipClose === closeSelfRef.current) activeTooltipClose = null;
+    };
+  }
+  const closeSelf = closeSelfRef.current;
+  const openSelf = () => {
+    if (activeTooltipClose && activeTooltipClose !== closeSelf) activeTooltipClose();
+    activeTooltipClose = closeSelf;
+    setShow(true);
+  };
 
   // Compute position before paint so the tooltip never flickers
   useLayoutEffect(() => {
@@ -77,15 +97,13 @@ export function HelpTooltip({
     const handlePointerDown = (event: PointerEvent) => {
       const target = event.target as Node;
       if (!wrapRef.current?.contains(target) && !tipRef.current?.contains(target)) {
-        setShow(false);
-        setPinned(false);
+        closeSelf();
       }
     };
 
     const handleKeyDown = (event: KeyboardEvent) => {
       if (event.key === "Escape") {
-        setShow(false);
-        setPinned(false);
+        closeSelf();
       }
     };
 
@@ -95,14 +113,14 @@ export function HelpTooltip({
       document.removeEventListener("pointerdown", handlePointerDown);
       document.removeEventListener("keydown", handleKeyDown);
     };
-  }, [show]);
+  }, [show, closeSelf]);
 
   return (
     <span
       ref={wrapRef}
       className={cn("relative inline-flex", className)}
       onMouseLeave={() => {
-        if (!pinned) setShow(false);
+        if (!pinned) closeSelf();
       }}
     >
       <button
@@ -113,7 +131,7 @@ export function HelpTooltip({
           "mari-chrome-accent-text-muted mari-accent-animated inline-flex cursor-help items-center gap-1 rounded-full opacity-70 transition-opacity hover:text-[var(--marinara-chat-chrome-button-text-hover)] hover:opacity-100 focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-[var(--marinara-chat-chrome-focus-ring)]",
           buttonClassName,
         )}
-        onMouseEnter={() => setShow(true)}
+        onMouseEnter={openSelf}
         onPointerDown={(event) => {
           event.stopPropagation();
         }}
@@ -122,7 +140,8 @@ export function HelpTooltip({
           event.stopPropagation();
           setPinned((current) => {
             const nextPinned = !current;
-            setShow(nextPinned);
+            if (nextPinned) openSelf();
+            else closeSelf();
             return nextPinned;
           });
         }}

--- a/packages/client/src/components/ui/HelpTooltip.tsx
+++ b/packages/client/src/components/ui/HelpTooltip.tsx
@@ -62,6 +62,15 @@ export function HelpTooltip({
     setShow(true);
   };
 
+  // On unmount, release the module singleton if we still hold it — otherwise a
+  // pinned tooltip whose host unmounts leaves a defunct closer that the next
+  // openSelf would call (setState on an unmounted instance).
+  useEffect(() => {
+    return () => {
+      if (activeTooltipClose === closeSelfRef.current) activeTooltipClose = null;
+    };
+  }, []);
+
   // Programmatic open (e.g. a mobile tap with no hover): open pinned when the signal changes.
   const prevSignalRef = useRef(openSignal);
   useEffect(() => {

--- a/packages/client/src/components/ui/HelpTooltip.tsx
+++ b/packages/client/src/components/ui/HelpTooltip.tsx
@@ -25,6 +25,9 @@ interface HelpTooltipProps {
   buttonClassName?: string;
   /** Use a wider tooltip panel (long explanations) */
   wide?: boolean;
+  /** Increment to programmatically open the tooltip (e.g. on a mobile tap where there's
+   *  no hover). Opens it pinned; changes are ignored while equal to the previous value. */
+  openSignal?: number;
 }
 
 export function HelpTooltip({
@@ -35,6 +38,7 @@ export function HelpTooltip({
   className,
   buttonClassName,
   wide,
+  openSignal,
 }: HelpTooltipProps) {
   const [show, setShow] = useState(false);
   const [pinned, setPinned] = useState(false);
@@ -57,6 +61,21 @@ export function HelpTooltip({
     activeTooltipClose = closeSelf;
     setShow(true);
   };
+
+  // Programmatic open (e.g. a mobile tap with no hover): open pinned when the signal changes.
+  const prevSignalRef = useRef(openSignal);
+  useEffect(() => {
+    if (openSignal === undefined || openSignal === prevSignalRef.current) return;
+    prevSignalRef.current = openSignal;
+    if (openSignal > 0) {
+      if (activeTooltipClose && activeTooltipClose !== closeSelf) activeTooltipClose();
+      activeTooltipClose = closeSelf;
+      setShow(true);
+      setPinned(true);
+    }
+    // closeSelf is stable (ref-backed); openSignal drives this effect.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [openSignal]);
 
   // Compute position before paint so the tooltip never flickers
   useLayoutEffect(() => {

--- a/packages/client/src/components/ui/MacroTextarea.tsx
+++ b/packages/client/src/components/ui/MacroTextarea.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState, type ChangeEvent, type KeyboardEvent as ReactKeyboardEvent, type ReactNode } from "react";
+import { useCallback, useEffect, useRef, useState, type ChangeEvent, type KeyboardEvent as ReactKeyboardEvent, type ReactNode, type Ref } from "react";
 import { createPortal } from "react-dom";
 import { BookOpen, Maximize2, X } from "lucide-react";
 import { SUPPORTED_MACROS } from "@marinara-engine/shared";
@@ -280,6 +280,8 @@ export interface MacroTextareaProps {
   showMacroReference?: boolean;
   showExpand?: boolean;
   spellCheck?: boolean;
+  /** Optional ref to the underlying textarea (e.g. to insert emoji at the caret). */
+  textareaRef?: Ref<HTMLTextAreaElement>;
 }
 
 export function MacroTextarea({
@@ -302,6 +304,7 @@ export function MacroTextarea({
   showMacroReference = true,
   showExpand = true,
   spellCheck = true,
+  textareaRef,
 }: MacroTextareaProps) {
   const [expanded, setExpanded] = useState(false);
   const [showMacroRef, setShowMacroRef] = useState(false);
@@ -346,6 +349,7 @@ export function MacroTextarea({
     <>
       <div className={cn("relative", wrapperClassName)}>
         <textarea
+          ref={textareaRef}
           value={value}
           onChange={handleChange}
           onBlur={onBlur}

--- a/packages/client/src/hooks/use-characters.ts
+++ b/packages/client/src/hooks/use-characters.ts
@@ -983,6 +983,17 @@ export function useGenerateAboutMe() {
   });
 }
 
+/** A character's linked lorebook entries (names only) for the AI-write source picker. */
+export function useCharacterLorebookEntries(characterId: string | null | undefined) {
+  return useQuery({
+    queryKey: ["character-lorebook-entries", characterId],
+    queryFn: () =>
+      api.get<{ entries: Array<{ id: string; name: string }> }>(`/characters/${characterId}/lorebook-entries`),
+    enabled: !!characterId,
+    staleTime: 30_000,
+  });
+}
+
 export function useCreatePersona() {
   const qc = useQueryClient();
   return useMutation({

--- a/packages/client/src/hooks/use-characters.ts
+++ b/packages/client/src/hooks/use-characters.ts
@@ -19,6 +19,7 @@ import {
 } from "../lib/tracker-card-colors";
 import {
   PROFESSOR_MARI_ID,
+  type AboutMeSourceConfig,
   type CharacterCardVersion,
   type Persona,
   type PersonaCardVersion,
@@ -973,6 +974,10 @@ export function useGenerateAboutMe() {
       scenario?: string;
       backstory?: string;
       appearance?: string;
+      convoBehavior?: string;
+      sources?: AboutMeSourceConfig;
+      characterId?: string;
+      chatId?: string;
       instruction?: string;
     }) => api.post<{ aboutMe: string }>("/characters/generate-about-me", body),
   });

--- a/packages/server/src/routes/characters.routes.ts
+++ b/packages/server/src/routes/characters.routes.ts
@@ -554,6 +554,17 @@ export async function charactersRoutes(app: FastifyInstance) {
   const personaGallery = createPersonaGalleryStorage(app.db);
   const lorebooksStorage = createLorebooksStorage(app.db);
   const connections = createConnectionsStorage(app.db);
+  const loadCharacterLorebookEntries = async (characterId: string) => {
+    const books = (await lorebooksStorage.listByCharacter(characterId)) as Array<{ id: string }>;
+    if (books.length === 0) return [];
+    const entries = (await lorebooksStorage.listEntriesByLorebooks(books.map((b) => b.id))) as Array<{
+      id?: string;
+      name?: string;
+      content?: string;
+      enabled?: boolean;
+    }>;
+    return entries.filter((e) => e.enabled !== false && typeof e.content === "string" && e.content.trim().length > 0);
+  };
 
   /**
    * POST /api/characters/generate-about-me
@@ -611,17 +622,13 @@ export async function charactersRoutes(app: FastifyInstance) {
     if (sources.lorebook && input.characterId && input.kind === "character") {
       try {
         const loreLines: string[] = [];
-        const books = (await lorebooksStorage.listByCharacter(input.characterId)) as Array<{ id: string }>;
-        const entries = books.length
-          ? await lorebooksStorage.listEntriesByLorebooks(books.map((b) => b.id))
-          : [];
+        const entries = await loadCharacterLorebookEntries(input.characterId);
         // When the user picked specific entries, include only those; absent → all.
         const selectedEntryIds = Array.isArray(sources.lorebookEntryIds) ? new Set(sources.lorebookEntryIds) : null;
-        for (const e of entries as Array<{ id?: string; content?: string; name?: string; enabled?: boolean }>) {
-          if (e.enabled === false) continue;
+        for (const e of entries) {
           if (selectedEntryIds && (!e.id || !selectedEntryIds.has(e.id))) continue;
-          const content = typeof e.content === "string" ? e.content.trim() : "";
-          if (content) loreLines.push(e.name ? `[${e.name}] ${content}` : content);
+          const content = e.content?.trim() ?? "";
+          loreLines.push(e.name ? `[${e.name}] ${content}` : content);
         }
         const lore = loreLines.join("\n").slice(0, 8000).trim();
         if (lore) cardParts.push(`From their lorebook:\n${lore}`);
@@ -680,18 +687,11 @@ export async function charactersRoutes(app: FastifyInstance) {
    * the AI-write source picker to choose which entries feed the "about me". Names only.
    */
   app.get<{ Params: { id: string } }>("/:id/lorebook-entries", async (req) => {
-    const books = (await lorebooksStorage.listByCharacter(req.params.id)) as Array<{ id: string }>;
-    if (books.length === 0) return { entries: [] };
-    const entries = (await lorebooksStorage.listEntriesByLorebooks(books.map((b) => b.id))) as unknown as Array<{
-      id: string;
-      name?: string;
-      content?: string;
-      enabled?: boolean;
-    }>;
+    const entries = await loadCharacterLorebookEntries(req.params.id);
     return {
-      entries: entries
-        .filter((e) => e.enabled !== false && typeof e.content === "string" && e.content.trim().length > 0)
-        .map((e) => ({ id: e.id, name: e.name || "(unnamed entry)" })),
+      entries: entries.flatMap((e) =>
+        typeof e.id === "string" ? [{ id: e.id, name: e.name || "(unnamed entry)" }] : [],
+      ),
     };
   });
 

--- a/packages/server/src/routes/characters.routes.ts
+++ b/packages/server/src/routes/characters.routes.ts
@@ -601,12 +601,18 @@ export async function charactersRoutes(app: FastifyInstance) {
       (input.instruction?.trim() ? `Extra direction from the user: ${input.instruction.trim()}\n\n` : "") +
       `Write their Conversation-mode "about me" now, staying true to who they are.`;
 
+    // A short bio needs little output, but "thinking" models (e.g. Gemini 3.x) draw
+    // reasoning tokens from the SAME output budget — so the old 512 cap was consumed
+    // entirely by thinking and returned no content ("finished without content
+    // (MAX_TOKENS)"). Use a generous ceiling (not a target — a short bio still stops
+    // early, so this doesn't inflate cost) plus low reasoning effort so thinking
+    // models don't overthink a casual bio and always leave room for the text.
     const result = await provider.chatComplete(
       [
         { role: "system", content: systemPrompt },
         { role: "user", content: userContent },
       ],
-      { model: conn.model, temperature: 0.9, maxTokens: 512 },
+      { model: conn.model, temperature: 0.9, maxTokens: 4096, reasoningEffort: "low" },
     );
     return { aboutMe: (result.content ?? "").trim() };
   });

--- a/packages/server/src/routes/characters.routes.ts
+++ b/packages/server/src/routes/characters.routes.ts
@@ -623,8 +623,11 @@ export async function charactersRoutes(app: FastifyInstance) {
         const books = (await lorebooksStorage.listByCharacter(input.characterId)) as Array<{ id: string }>;
         const linkedIds = books.map((b) => b.id).filter((id) => id !== embeddedLbId);
         const linkedEntries = linkedIds.length ? await lorebooksStorage.listEntriesByLorebooks(linkedIds) : [];
-        for (const e of linkedEntries as Array<{ content?: string; name?: string; enabled?: boolean }>) {
+        // When the user picked specific linked entries, include only those; absent → all.
+        const selectedEntryIds = Array.isArray(sources.lorebookEntryIds) ? new Set(sources.lorebookEntryIds) : null;
+        for (const e of linkedEntries as Array<{ id?: string; content?: string; name?: string; enabled?: boolean }>) {
           if (e.enabled === false) continue;
+          if (selectedEntryIds && (!e.id || !selectedEntryIds.has(e.id))) continue;
           const content = typeof e.content === "string" ? e.content.trim() : "";
           if (content) loreLines.push(e.name ? `[${e.name}] ${content}` : content);
         }
@@ -676,6 +679,39 @@ export async function charactersRoutes(app: FastifyInstance) {
       { model: conn.model, temperature: 0.9, maxTokens: 4096, reasoningEffort: "low" },
     );
     return { aboutMe: (result.content ?? "").trim() };
+  });
+
+  /**
+   * GET /api/characters/:id/lorebook-entries
+   * A character's LINKED lorebook entries (the standalone that mirrors the card's
+   * embedded book is skipped) — used by the AI-write source picker to let the user
+   * choose which entries feed the "about me". Content is not returned; names only.
+   */
+  app.get<{ Params: { id: string } }>("/:id/lorebook-entries", async (req) => {
+    const books = (await lorebooksStorage.listByCharacter(req.params.id)) as Array<{ id: string }>;
+    let embeddedLbId: string | null = null;
+    try {
+      const charRow = await storage.getById(req.params.id);
+      const cdata = charRow
+        ? ((typeof charRow.data === "string" ? JSON.parse(charRow.data) : charRow.data) as Record<string, unknown>)
+        : null;
+      embeddedLbId = cdata ? getEmbeddedLorebookId(cdata) : null;
+    } catch {
+      /* ignore */
+    }
+    const linkedIds = books.map((b) => b.id).filter((id) => id !== embeddedLbId);
+    if (linkedIds.length === 0) return { entries: [] };
+    const entries = (await lorebooksStorage.listEntriesByLorebooks(linkedIds)) as unknown as Array<{
+      id: string;
+      name?: string;
+      content?: string;
+      enabled?: boolean;
+    }>;
+    return {
+      entries: entries
+        .filter((e) => e.enabled !== false && typeof e.content === "string" && e.content.trim().length > 0)
+        .map((e) => ({ id: e.id, name: e.name || "(unnamed entry)" })),
+    };
   });
 
   // ── Characters ──

--- a/packages/server/src/routes/characters.routes.ts
+++ b/packages/server/src/routes/characters.routes.ts
@@ -604,28 +604,20 @@ export async function charactersRoutes(app: FastifyInstance) {
     if (sources.convoBehavior && input.convoBehavior?.trim())
       cardParts.push(`How they behave in conversation: ${input.convoBehavior.trim()}`);
 
-    // Lorebook entries (characters only): linked standalone books + the embedded card
-    // book, deduped. Capped so a big lorebook can't blow up this one-shot request.
+    // Lorebook entries (characters only). All of the character's lorebook entries come
+    // through listByCharacter — the embedded card book is synced to a standalone that
+    // shows up here too, so every entry has a stable db id that matches the source
+    // picker's selection. Capped so a big lorebook can't blow up this one-shot request.
     if (sources.lorebook && input.characterId && input.kind === "character") {
       try {
         const loreLines: string[] = [];
-        const charRow = await storage.getById(input.characterId);
-        const cdata = charRow
-          ? ((typeof charRow.data === "string" ? JSON.parse(charRow.data) : charRow.data) as Record<string, any>)
-          : null;
-        const embeddedEntries = Array.isArray(cdata?.character_book?.entries) ? cdata!.character_book.entries : [];
-        for (const e of embeddedEntries as Array<Record<string, any>>) {
-          if (e?.enabled === false) continue;
-          const content = typeof e?.content === "string" ? e.content.trim() : "";
-          if (content) loreLines.push(e.comment ? `[${e.comment}] ${content}` : content);
-        }
-        const embeddedLbId = cdata ? getEmbeddedLorebookId(cdata) : null;
         const books = (await lorebooksStorage.listByCharacter(input.characterId)) as Array<{ id: string }>;
-        const linkedIds = books.map((b) => b.id).filter((id) => id !== embeddedLbId);
-        const linkedEntries = linkedIds.length ? await lorebooksStorage.listEntriesByLorebooks(linkedIds) : [];
-        // When the user picked specific linked entries, include only those; absent → all.
+        const entries = books.length
+          ? await lorebooksStorage.listEntriesByLorebooks(books.map((b) => b.id))
+          : [];
+        // When the user picked specific entries, include only those; absent → all.
         const selectedEntryIds = Array.isArray(sources.lorebookEntryIds) ? new Set(sources.lorebookEntryIds) : null;
-        for (const e of linkedEntries as Array<{ id?: string; content?: string; name?: string; enabled?: boolean }>) {
+        for (const e of entries as Array<{ id?: string; content?: string; name?: string; enabled?: boolean }>) {
           if (e.enabled === false) continue;
           if (selectedEntryIds && (!e.id || !selectedEntryIds.has(e.id))) continue;
           const content = typeof e.content === "string" ? e.content.trim() : "";
@@ -683,25 +675,14 @@ export async function charactersRoutes(app: FastifyInstance) {
 
   /**
    * GET /api/characters/:id/lorebook-entries
-   * A character's LINKED lorebook entries (the standalone that mirrors the card's
-   * embedded book is skipped) — used by the AI-write source picker to let the user
-   * choose which entries feed the "about me". Content is not returned; names only.
+   * A character's lorebook entries (embedded + linked — the embedded card book is
+   * synced to a standalone that shows up here too, so ids match generation). Used by
+   * the AI-write source picker to choose which entries feed the "about me". Names only.
    */
   app.get<{ Params: { id: string } }>("/:id/lorebook-entries", async (req) => {
     const books = (await lorebooksStorage.listByCharacter(req.params.id)) as Array<{ id: string }>;
-    let embeddedLbId: string | null = null;
-    try {
-      const charRow = await storage.getById(req.params.id);
-      const cdata = charRow
-        ? ((typeof charRow.data === "string" ? JSON.parse(charRow.data) : charRow.data) as Record<string, unknown>)
-        : null;
-      embeddedLbId = cdata ? getEmbeddedLorebookId(cdata) : null;
-    } catch {
-      /* ignore */
-    }
-    const linkedIds = books.map((b) => b.id).filter((id) => id !== embeddedLbId);
-    if (linkedIds.length === 0) return { entries: [] };
-    const entries = (await lorebooksStorage.listEntriesByLorebooks(linkedIds)) as unknown as Array<{
+    if (books.length === 0) return { entries: [] };
+    const entries = (await lorebooksStorage.listEntriesByLorebooks(books.map((b) => b.id))) as unknown as Array<{
       id: string;
       name?: string;
       content?: string;

--- a/packages/server/src/routes/characters.routes.ts
+++ b/packages/server/src/routes/characters.routes.ts
@@ -10,6 +10,8 @@ import {
   createPersonaGroupSchema,
   updatePersonaGroupSchema,
   generateAboutMeSchema,
+  resolveAboutMeSources,
+  DEFAULT_ABOUT_ME_CHAT_CONTEXT_LIMIT,
   PROFESSOR_MARI_ID,
   PROVIDERS,
   CONVERSATION_CALL_CHARACTER_VIDEO_CLIP_KINDS,
@@ -588,16 +590,75 @@ export async function charactersRoutes(app: FastifyInstance) {
       "If they plausibly wouldn't have a bio, it is correct to return an empty string or a bare placeholder.",
     ].join("\n");
 
-    const cardParts = [
-      input.name && `Name: ${input.name}`,
-      input.description && `Description: ${input.description}`,
-      input.personality && `Personality: ${input.personality}`,
-      input.scenario && `Scenario: ${input.scenario}`,
-      input.backstory && `Backstory: ${input.backstory}`,
-      input.appearance && `Appearance: ${input.appearance}`,
-    ].filter(Boolean);
+    // Draw only from the sources the character opted into (default: personality only).
+    // Different cards store their substance differently — some leave card fields blank
+    // and live entirely in a lorebook — so each source is individually selectable.
+    const sources = resolveAboutMeSources(input.sources);
+    const cardParts: string[] = [];
+    if (input.name) cardParts.push(`Name: ${input.name}`);
+    if (sources.description && input.description) cardParts.push(`Description: ${input.description}`);
+    if (sources.personality && input.personality) cardParts.push(`Personality: ${input.personality}`);
+    if (sources.scenario && input.scenario) cardParts.push(`Scenario: ${input.scenario}`);
+    if (sources.backstory && input.backstory) cardParts.push(`Backstory: ${input.backstory}`);
+    if (sources.appearance && input.appearance) cardParts.push(`Appearance: ${input.appearance}`);
+    if (sources.convoBehavior && input.convoBehavior?.trim())
+      cardParts.push(`How they behave in conversation: ${input.convoBehavior.trim()}`);
+
+    // Lorebook entries (characters only): linked standalone books + the embedded card
+    // book, deduped. Capped so a big lorebook can't blow up this one-shot request.
+    if (sources.lorebook && input.characterId && input.kind === "character") {
+      try {
+        const loreLines: string[] = [];
+        const charRow = await storage.getById(input.characterId);
+        const cdata = charRow
+          ? ((typeof charRow.data === "string" ? JSON.parse(charRow.data) : charRow.data) as Record<string, any>)
+          : null;
+        const embeddedEntries = Array.isArray(cdata?.character_book?.entries) ? cdata!.character_book.entries : [];
+        for (const e of embeddedEntries as Array<Record<string, any>>) {
+          if (e?.enabled === false) continue;
+          const content = typeof e?.content === "string" ? e.content.trim() : "";
+          if (content) loreLines.push(e.comment ? `[${e.comment}] ${content}` : content);
+        }
+        const embeddedLbId = cdata ? getEmbeddedLorebookId(cdata) : null;
+        const books = (await lorebooksStorage.listByCharacter(input.characterId)) as Array<{ id: string }>;
+        const linkedIds = books.map((b) => b.id).filter((id) => id !== embeddedLbId);
+        const linkedEntries = linkedIds.length ? await lorebooksStorage.listEntriesByLorebooks(linkedIds) : [];
+        for (const e of linkedEntries as Array<{ content?: string; name?: string; enabled?: boolean }>) {
+          if (e.enabled === false) continue;
+          const content = typeof e.content === "string" ? e.content.trim() : "";
+          if (content) loreLines.push(e.name ? `[${e.name}] ${content}` : content);
+        }
+        const lore = loreLines.join("\n").slice(0, 8000).trim();
+        if (lore) cardParts.push(`From their lorebook:\n${lore}`);
+      } catch {
+        /* lorebook is best-effort context; ignore fetch/parse errors */
+      }
+    }
+
+    // Chat context — only meaningful for a chat-specific (override) about me.
+    let chatTranscript = "";
+    if (sources.chatContext && input.chatId) {
+      try {
+        const chatsStorage = createChatsStorage(app.db);
+        const limit = Math.max(1, Math.min(200, sources.chatContextLimit ?? DEFAULT_ABOUT_ME_CHAT_CONTEXT_LIMIT));
+        const recent = (await chatsStorage.listMessagesPaginated(input.chatId, limit)) as Array<{
+          role: string;
+          content: string;
+        }>;
+        chatTranscript = recent
+          .map((m) => `${m.role}: ${(m.content ?? "").trim()}`)
+          .filter((line) => line.trim())
+          .join("\n")
+          .slice(-8000)
+          .trim();
+      } catch {
+        /* chat context is best-effort; ignore errors */
+      }
+    }
+
     const userContent =
       `Here is what defines them:\n${cardParts.join("\n\n")}\n\n` +
+      (chatTranscript ? `Recent conversation, for tone and context:\n${chatTranscript}\n\n` : "") +
       (input.instruction?.trim() ? `Extra direction from the user: ${input.instruction.trim()}\n\n` : "") +
       `Write their Conversation-mode "about me" now, staying true to who they are.`;
 

--- a/packages/server/src/routes/generate.routes.ts
+++ b/packages/server/src/routes/generate.routes.ts
@@ -2346,6 +2346,7 @@ export async function generateRoutes(app: FastifyInstance) {
             persona,
             promptTemplateSources: identityFallbackPromptTemplateSources,
             resolvePromptMacros,
+            isConversation: chatMode === "conversation",
           });
         }
 

--- a/packages/server/src/services/conversation/conversation-profiles.ts
+++ b/packages/server/src/services/conversation/conversation-profiles.ts
@@ -126,8 +126,9 @@ export function buildConversationProfileBlocks(args: {
     for (const p of participants) {
       const about = resolveMacros(p.aboutMe ?? "").trim();
       if (!about) continue; // authentic: some participants simply have no bio
-      const who = p.isPersona ? `${p.displayName} (the user you're talking to)` : p.displayName;
-      lines.push(`- ${who}: ${about}`);
+      // List the persona like any other participant — never tag it as "the user".
+      // Framing the persona as the user nudges some models toward sycophancy.
+      lines.push(`- ${p.displayName}: ${about}`);
     }
     if (lines.length > 0) {
       aboutMeBlock =
@@ -143,8 +144,9 @@ export function buildConversationProfileBlocks(args: {
 
   const label = (p: ConversationProfileParticipant, text: string): string => {
     if (!isGroup) return text;
-    const who = p.isPersona ? `about the user (${p.displayName})` : `for ${p.displayName}`;
-    return `Instructions ${who}:\n${text}`;
+    // Label the persona's directive the same as any character's — don't single it
+    // out as "the user" (that framing pushes some models toward sycophancy).
+    return `Instructions for ${p.displayName}:\n${text}`;
   };
 
   for (const p of participants) {

--- a/packages/server/src/services/generation/character-prompt-context.ts
+++ b/packages/server/src/services/generation/character-prompt-context.ts
@@ -234,26 +234,29 @@ export function injectIdentityFallbackMessages(args: {
       mesExample: resolveCharacterMacros(character.mesExample),
     };
     const namedProfilePresent = hasNamedProfileBlock(allContent, character.name);
-    if (namedProfilePresent) continue;
-
-    const fieldsToInject = CHARACTER_FALLBACK_FIELDS.flatMap((field) => {
-      const value = resolvedFields[field.key];
-      if (!value.trim()) return [];
-      if (sourceReferencesAnyMacro(promptTemplateSources, field.macroAliases)) return [];
-      if (contentIncludesResolvedField(allContent, value)) return [];
-      return [{ label: field.label, value }];
-    });
-    const fieldParts = wrapFieldEntries(fieldsToInject, args.wrapFormat);
-    if (fieldParts.length === 0) continue;
 
     // Conversation mode only: when opted in, prefix the card with the character's
     // convo display name so the model can map the display name to this specific
-    // card. Gated on convo mode so the field never reaches RP/VN/Game prompts.
+    // card. This is independent from fallback card-field injection so it still
+    // appears when normal profile fields are already present.
     const convoName = character.convoDisplayName?.trim();
     const convoNameLine =
       args.isConversation && character.convoDisplayNameInCard && convoName
         ? `Conversation display name: ${sanitizePromptLeaf(convoName, args.wrapFormat)}\n`
         : "";
+
+    const fieldsToInject = namedProfilePresent
+      ? []
+      : CHARACTER_FALLBACK_FIELDS.flatMap((field) => {
+          const value = resolvedFields[field.key];
+          if (!value.trim()) return [];
+          if (sourceReferencesAnyMacro(promptTemplateSources, field.macroAliases)) return [];
+          if (contentIncludesResolvedField(allContent, value)) return [];
+          return [{ label: field.label, value }];
+        });
+    const fieldParts = wrapFieldEntries(fieldsToInject, args.wrapFormat);
+    if (fieldParts.length === 0 && !convoNameLine) continue;
+
     const block = wrapContent(convoNameLine + fieldParts.join("\n"), character.name, args.wrapFormat, 1);
     const firstSysIdx = args.messages.findIndex((message) => message.role === "system");
     const insertAt = firstSysIdx >= 0 ? firstSysIdx + 1 : 0;

--- a/packages/server/src/services/generation/character-prompt-context.ts
+++ b/packages/server/src/services/generation/character-prompt-context.ts
@@ -27,6 +27,9 @@ export type CharacterPromptInfo = {
   talkativeness: number;
   avatarPath: string | null;
   avatarCrop: unknown | null;
+  /** Conversation-only: cosmetic display name + whether to declare it on the card. */
+  convoDisplayName?: string;
+  convoDisplayNameInCard?: boolean;
 };
 
 type CharactersStore = {
@@ -125,6 +128,9 @@ export async function loadCharacterPromptInfo({
       talkativeness: Math.max(0, Math.min(1, Number(charData.extensions?.talkativeness ?? 0.5))),
       avatarPath: (charRow.avatarPath as string) ?? null,
       avatarCrop: charData.extensions?.avatarCrop ?? null,
+      convoDisplayName:
+        typeof charData.extensions?.convoDisplayName === "string" ? charData.extensions.convoDisplayName : undefined,
+      convoDisplayNameInCard: charData.extensions?.convoDisplayNameInCard === true,
     });
   }
   return charInfo;
@@ -192,6 +198,9 @@ export function injectIdentityFallbackMessages(args: {
   persona?: { personaStats?: unknown } | null;
   promptTemplateSources?: readonly string[];
   resolvePromptMacros(value: string): string;
+  /** Conversation mode only: enables the opt-in per-card convo display-name line.
+   *  Gated so the field never reaches RP/VN/Game prompts. */
+  isConversation?: boolean;
 }): void {
   const allContent = args.messages.map((message) => message.content).join("\n");
   const promptTemplateSources = args.promptTemplateSources ?? [];
@@ -237,7 +246,15 @@ export function injectIdentityFallbackMessages(args: {
     const fieldParts = wrapFieldEntries(fieldsToInject, args.wrapFormat);
     if (fieldParts.length === 0) continue;
 
-    const block = wrapContent(fieldParts.join("\n"), character.name, args.wrapFormat, 1);
+    // Conversation mode only: when opted in, prefix the card with the character's
+    // convo display name so the model can map the display name to this specific
+    // card. Gated on convo mode so the field never reaches RP/VN/Game prompts.
+    const convoName = character.convoDisplayName?.trim();
+    const convoNameLine =
+      args.isConversation && character.convoDisplayNameInCard && convoName
+        ? `Conversation display name: ${sanitizePromptLeaf(convoName, args.wrapFormat)}\n`
+        : "";
+    const block = wrapContent(convoNameLine + fieldParts.join("\n"), character.name, args.wrapFormat, 1);
     const firstSysIdx = args.messages.findIndex((message) => message.role === "system");
     const insertAt = firstSysIdx >= 0 ? firstSysIdx + 1 : 0;
     args.messages.splice(insertAt, 0, { role: "system", content: block });

--- a/packages/shared/src/schemas/character.schema.ts
+++ b/packages/shared/src/schemas/character.schema.ts
@@ -53,6 +53,7 @@ export const characterExtensionsSchema = z
     appearance: z.string().default(""),
     // Conversation-mode-only fields (optional — absent on non-convo cards).
     convoDisplayName: z.string().optional(),
+    convoDisplayNameInCard: z.boolean().optional(),
     aboutMe: z.string().optional(),
     convoBehavior: convoBehaviorConfigSchema.optional(),
   })

--- a/packages/shared/src/schemas/character.schema.ts
+++ b/packages/shared/src/schemas/character.schema.ts
@@ -52,6 +52,8 @@ export const aboutMeSourceConfigSchema = z.object({
   appearance: z.boolean().optional(),
   convoBehavior: z.boolean().optional(),
   lorebook: z.boolean().optional(),
+  /** When set, only these linked lorebook entry ids are included; absent → all of them. */
+  lorebookEntryIds: z.array(z.string()).optional(),
   chatContext: z.boolean().optional(),
   chatContextLimit: z.number().int().min(1).max(200).optional(),
 });

--- a/packages/shared/src/schemas/character.schema.ts
+++ b/packages/shared/src/schemas/character.schema.ts
@@ -43,6 +43,19 @@ export const convoBehaviorConfigSchema = z.object({
   insertionStrategy: convoBehaviorInsertionStrategySchema.catch("constant_after").default("constant_after"),
 });
 
+/** Which sources the AI-write "about me" prompt draws from. Per-character. */
+export const aboutMeSourceConfigSchema = z.object({
+  description: z.boolean().optional(),
+  personality: z.boolean().optional(),
+  scenario: z.boolean().optional(),
+  backstory: z.boolean().optional(),
+  appearance: z.boolean().optional(),
+  convoBehavior: z.boolean().optional(),
+  lorebook: z.boolean().optional(),
+  chatContext: z.boolean().optional(),
+  chatContextLimit: z.number().int().min(1).max(200).optional(),
+});
+
 export const characterExtensionsSchema = z
   .object({
     talkativeness: z.number().min(0).max(1).default(0.5),
@@ -56,6 +69,7 @@ export const characterExtensionsSchema = z
     convoDisplayNameInCard: z.boolean().optional(),
     aboutMe: z.string().optional(),
     convoBehavior: convoBehaviorConfigSchema.optional(),
+    aboutMeSources: aboutMeSourceConfigSchema.optional(),
   })
   .passthrough();
 
@@ -117,6 +131,18 @@ export const characterCardV2Schema = z.object({
 });
 
 /** AI-write of a Convo "about me" from card/persona fields (Conversation mode). */
+/** Default sources when a character has none configured: only the personality field. */
+export const DEFAULT_ABOUT_ME_SOURCES: z.infer<typeof aboutMeSourceConfigSchema> = { personality: true };
+/** Default number of recent messages to include when the chat-context source is on. */
+export const DEFAULT_ABOUT_ME_CHAT_CONTEXT_LIMIT = 20;
+
+/** Resolve a stored source config, falling back to the default (personality only) when absent. */
+export function resolveAboutMeSources(raw: unknown): z.infer<typeof aboutMeSourceConfigSchema> {
+  if (raw == null) return { ...DEFAULT_ABOUT_ME_SOURCES };
+  const parsed = aboutMeSourceConfigSchema.safeParse(raw);
+  return parsed.success ? parsed.data : { ...DEFAULT_ABOUT_ME_SOURCES };
+}
+
 export const generateAboutMeSchema = z.object({
   connectionId: z.string().min(1),
   kind: z.enum(["character", "persona"]).default("character"),
@@ -126,6 +152,14 @@ export const generateAboutMeSchema = z.object({
   scenario: z.string().max(20000).default(""),
   backstory: z.string().max(20000).default(""),
   appearance: z.string().max(20000).default(""),
+  /** Convo behavior directive text (included only when the convoBehavior source is on). */
+  convoBehavior: z.string().max(20000).default(""),
+  /** Which sources to draw from. Absent → default (personality only). */
+  sources: aboutMeSourceConfigSchema.optional(),
+  /** Character id — lets the server pull linked/embedded lorebook entries. */
+  characterId: z.string().optional(),
+  /** Chat id — lets the server pull recent chat context (chat-exclusive about me only). */
+  chatId: z.string().optional(),
   /** Optional freeform steer from the user (e.g. "keep it one line, chronically online"). */
   instruction: z.string().max(2000).optional(),
 });

--- a/packages/shared/src/types/character.ts
+++ b/packages/shared/src/types/character.ts
@@ -53,6 +53,10 @@ export interface CharacterExtensions {
   /** Marinara Engine (Conversation mode ONLY): display name shown as the sender label
    *  in Convo and used for attribution in the convo prompt. Never read in RP/VN/Game. */
   convoDisplayName?: string;
+  /** Marinara Engine (Conversation mode ONLY): when true, prepend a line declaring the
+   *  convo display name to this character's card so the model can map the display name
+   *  to this specific card. No effect without a convoDisplayName. Never read in RP/VN/Game. */
+  convoDisplayNameInCard?: boolean;
   /** Marinara Engine (Conversation mode ONLY): public "about me" profile. The
    *  cross-chat default; a per-chat override can supersede it. Never read in RP/VN/Game. */
   aboutMe?: string;

--- a/packages/shared/src/types/character.ts
+++ b/packages/shared/src/types/character.ts
@@ -97,6 +97,8 @@ export interface AboutMeSourceConfig {
   convoBehavior?: boolean;
   /** The character's linked + embedded lorebook entries. */
   lorebook?: boolean;
+  /** When set, only these linked lorebook entry ids are included; absent → all of them. */
+  lorebookEntryIds?: string[];
   /** Recent chat messages — only meaningful for a chat-specific (override) about me. */
   chatContext?: boolean;
   /** How many recent messages to include when chatContext is on. */

--- a/packages/shared/src/types/character.ts
+++ b/packages/shared/src/types/character.ts
@@ -63,6 +63,9 @@ export interface CharacterExtensions {
   /** Marinara Engine (Conversation mode ONLY): behavior directive + insertion strategy.
    *  Never read in RP/VN/Game. */
   convoBehavior?: ConvoBehaviorConfig;
+  /** Marinara Engine (Conversation mode ONLY): which sources the AI-write "about me"
+   *  draws on. Never read in RP/VN/Game. */
+  aboutMeSources?: AboutMeSourceConfig;
   [key: string]: unknown;
 }
 
@@ -81,6 +84,23 @@ export interface ConvoBehaviorConfig {
   instruction: string;
   /** How/where the directive is placed in the convo prompt. */
   insertionStrategy: ConvoBehaviorInsertionStrategy;
+}
+
+/** Which sources the AI-write "about me" draws on. Per-character; default = personality only. */
+export interface AboutMeSourceConfig {
+  description?: boolean;
+  personality?: boolean;
+  scenario?: boolean;
+  backstory?: boolean;
+  appearance?: boolean;
+  /** The Convo behavior directive. */
+  convoBehavior?: boolean;
+  /** The character's linked + embedded lorebook entries. */
+  lorebook?: boolean;
+  /** Recent chat messages — only meaningful for a chat-specific (override) about me. */
+  chatContext?: boolean;
+  /** How many recent messages to include when chatContext is on. */
+  chatContextLimit?: number;
 }
 
 /** RPG stats configuration attached to a character card. */


### PR DESCRIPTION
## Linked issue

Closes #3368 (Conversation-mode profiles). These are post-merge follow-ups to #3374 — which closed #3368 — surfaced by playtesting the merged feature. No dedicated issue was opened for this batch; happy to file a tracking issue if maintainers prefer.

## Why this change

#3374 shipped Conversation-mode profiles (display name, about me, behavior) to `staging`. Playtesting the merged feature turned up gaps and rough edges: the display name never actually appeared above messages, chat-specific about-me overrides didn't survive a reload, AI-write failed outright on Gemini 3.x "thinking" models, and the mobile popout overlapped its own keyboard. This PR fixes those and rounds the feature out — configurable AI-write sources, a Revert control, an emoji picker, and full documentation. Everything stays **Conversation-only**; none of it can reach a Roleplay, Visual Novel, or Game prompt.

## What changed

Fixes:

- The Convo display name is now shown as the sender label above messages (read live, so renames reflect immediately) — previously it only existed in the prompt and the profile popout.
- Chat-specific about-me overrides survive reloads/refetches. The popout read `chat.metadata` without parsing it (it arrives as a JSON string on a fresh fetch), so the override reset to the card default and, on save, could drop other characters' overrides.
- AI-write about-me no longer fails on "thinking" models (e.g. Gemini 3.x) that spent the whole output budget on reasoning and returned no content (`MAX_TOKENS`); raised the output ceiling and lowered reasoning effort.
- The participant-profiles block no longer labels the persona as "the user" (which nudged some models toward sycophancy) — it's presented as just another participant.
- The AI-write source picker lists a character's embedded lorebook entries, not only "linked" ones, so embedded-only cards can select entries.
- The profile popout is a full-height sheet on mobile (keyboard/emoji picker no longer overlap the field) and re-clamps on desktop when the source panel opens.
- Help tooltips no longer stack — opening one closes any other.
- Card CSS avatar hook corrected: the clipped avatar is a `<button>` (nested under a glow wrapper in roleplay), so the ring now hugs the picture instead of the wrapper.

Additions:

- A configurable **source picker (⚙️)** for the AI-write about-me, in both the card editor and the in-chat popout: card fields (description/personality/scenario/backstory/appearance), the Convo behavior directive, the character's lorebook entries (with per-entry selection in the card editor), and recent chat context. Defaults to personality only.
- A **Revert** control and an **emoji picker** in the about-me editor.
- An optional per-character **"declare display name on the card"** toggle so the model can map the display name to the right card in group chats.

Docs: new Conversation profiles section in `docs/CONVERSATION.md`, the Conversation macros in `docs/MACROS.md`, an expanded all-modes Card CSS showcase, plus README and CHANGELOG.

Isolation: the display-name-on-card line is injected inside the identity-fallback per-character loop gated on `isConversation`; the profile blocks and macros are composed only in the conversation branch of the generate route; and the new `convoDisplayNameInCard` / `aboutMeSources` fields ride through export/import inside `extensions` (verified end-to-end). Nothing leaks into RP/VN/Game.

## Validation

- [x] `pnpm check` passes locally
- [x] Container (Docker / Podman) built and ran without issue
- [x] Ran the app, clicked through the changes manually
- [x] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [x] Above manual verification completed (describe below)
- [x] Read and followed `CONTRIBUTING.md`

### Manual verification notes

Automated on the dev machine: `pnpm lint` clean (shared + server + client typechecks + eslint); client production build clean; `pnpm regression:prompt` passes (58 checks, including the mode-isolation gate); `pnpm version:check` in sync. `pnpm check`'s full build step is blocked on this Windows dev machine by a pre-existing build-script bug (#3162 / fix PR #3163); the server `tsc` it wraps passes. Commits were playtested in the running app throughout.

Manually completed:
- **Isolation (load-bearing):** Convo display name shows above messages and updates live on rename; confirm it is absent from the same character used in a Roleplay and a Game chat, and that `{{convo_display}}` / `{{char_about}}` / `{{convo_behavior}}` resolve to empty in RP/Game.
- **Persistence:** set a chat-specific about-me, hard-reload (Ctrl+Shift+R), confirm it survives; with two characters each holding an override, save one and confirm the other's isn't wiped.
- **AI-write:** with a Gemini 3.x connection it returns text (not an Internal Server Error); the ⚙️ source picker (card fields, convo behavior, embedded + linked lorebook entries with per-entry selection, chat context in the in-chat editor only); Revert undoes a manual/AI edit; the emoji picker inserts at the caret.
- **Declare-on-card:** the toggle prepends the line to the card in a Conversation prompt (peek-prompt) and never in RP/Game.
- **Popout:** full sheet on mobile; no overflow on desktop with the source panel open. About Me Keeper agent + `update_about_me` tool still function. Help tooltips don't stack.
- **Round-trip:** character export -> re-import (native + SillyTavern/PNG) keeps the new `extensions` fields; a full backup -> restore keeps persona convo fields.
- **Card CSS:** paste the "Eldritch Grimoire" showcase into Creator Notes, enable card CSS, confirm the avatar ring hugs the picture in both Roleplay and Conversation.

## Docs and release impact

- [ ] No docs changes needed
- [x] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Version/release files updated (only if this PR includes a version bump)

Docs touched: `docs/CONVERSATION.md` (profiles section), `docs/MACROS.md` (Conversation macros), `docs/card-css-theming-guide.md` (about-me popout hooks, all-modes showcase, avatar hook fix), `README.md` (doc-index description), `CHANGELOG.md` (`[Unreleased]`). No version bump.

## UI evidence (if applicable)

<img width="809" height="599" alt="{3AF048B0-B864-45C7-8282-B3F7B50ACED5}" src="https://github.com/user-attachments/assets/1c1b7200-5b90-4650-8731-37a31a2da901" />

<img width="808" height="559" alt="{CF155A78-0D71-48D0-8374-76E9C91678AF}" src="https://github.com/user-attachments/assets/900a373c-8d75-41c0-96be-f3a1f412c78e" />

<img width="800" height="557" alt="{204EF183-DDC9-47E5-92C0-DCDFA7F4D1FD}" src="https://github.com/user-attachments/assets/1994d256-f648-4e60-8ffc-6e99dd60b3fe" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Conversation “about me” profile controls: configurable AI source selection (with updated defaults), display-name mapping, behavior directive placement, emoji insert, and revert.
  * Conversation mode now shows the selected display name live above messages.
  * Documented new Conversation-only macros and updated Conversation profile guidance.

* **Bug Fixes**
  * Restored chat-specific “about me” overrides after reload/refetch.
  * Improved AI-write reliability for “thinking” models and preserved drafts when results are blank.
  * Expanded lorebook sourcing (including embedded) and fixed participant/persona labeling.
  * Improved mobile “about me” popout layout and fixed help tooltip stacking (only one open).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->