### PR TITLE
Fix v2.1.2 roleplay and call followups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,12 +15,14 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 - Added Grok 4.5 to the xAI / Grok model list and made new xAI connections default to it.
 - Added Conversation prompt relocation macros for auto-inserted context: `{{context}}`/`{{status}}`, `{{commands}}`, `{{reactRules}}`, `{{memories}}`, and `{{lorebook}}`.
 - Added a TTS cache export control in Text to Speech settings so generated cached voice clips can be downloaded from IndexedDB.
+- Added a Roleplay Chat Summary maximum output size setting under Summary Connection, defaulting to 4096 tokens for manual and automatic summaries.
 
 ### Changed
 
 - Bumped release metadata to v2.1.2 across packages, the PWA manifest, README release pointer, Windows installer sources, Android APK metadata, and the home-page-visible app version.
 - Android `versionName` is `2.1.2` with `versionCode 31`.
 - Reworked Settings with search-first navigation, compact pinned controls, fixed top-level categories, and finer section shortcuts for faster navigation.
+- Updated the default Illustrator prompt rules so generated image prompts carry available character builds, clothing/outfits, and appearance details instead of relying on the image model to infer them.
 
 ### Fixed
 
@@ -37,6 +39,8 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 - Fixed Conversation command reminders so preset wrap format `None` no longer emits a literal `<commands>` XML wrapper (#3378).
 - Fixed roleplay streaming recovery so parallel agent events are deferred until the main assistant stream finishes, preventing late agent updates from replacing the streamed message.
 - Fixed the recovery/error page so **Internal Server Error** uses the configured chat chrome text color instead of a hard-coded pink.
+- Fixed Conversation Calls on Chromium browsers by allowing same-origin microphone, camera, and screen-capture access in the server permissions policy instead of blocking the browser permission prompt.
+- Fixed the Roleplay setup wizard's **Use Settings Presets** shortcut so system "joined the chat" notices no longer block seeding the selected character's first message (#3392).
 
 ## [2.1.1]
 

--- a/docs/CONVERSATION_CALLS.md
+++ b/docs/CONVERSATION_CALLS.md
@@ -163,6 +163,8 @@ The detailed call transcript remains stored separately for call handling and deb
 
 Check **Chat Settings -> Commands -> Conversation Calls** and make sure **Call Audio Pipeline** is enabled. Then confirm your browser has microphone permission for the Marinara page.
 
+If Edge or Chrome logs `Permissions policy violation: microphone is not allowed in this document`, update Marinara. Older builds sent a browser policy that blocked microphone and camera access before the normal permission prompt could appear.
+
 If you are on Firefox or browser speech recognition is unavailable, download Local Whisper from **Connections -> Local Model -> Local Speech Model** and use **Mic recording + Local Whisper**.
 
 ### Local Whisper says it is unavailable

--- a/packages/client/src/components/chat/ChatRoleplaySurface.tsx
+++ b/packages/client/src/components/chat/ChatRoleplaySurface.tsx
@@ -713,6 +713,7 @@ function SummaryButton({
   summaryPromptTemplates,
   activeSummaryPromptTemplateId,
   summaryConnectionId,
+  summaryMaxTokens,
   automaticSummaryEnabled,
   activeAgentIds,
   summaryRunInterval,
@@ -729,6 +730,7 @@ function SummaryButton({
   summaryPromptTemplates?: ComponentProps<typeof SummaryPopover>["promptTemplates"];
   activeSummaryPromptTemplateId?: string | null;
   summaryConnectionId?: string | null;
+  summaryMaxTokens?: number;
   automaticSummaryEnabled: boolean;
   activeAgentIds: string[];
   summaryRunInterval?: number;
@@ -815,6 +817,7 @@ function SummaryButton({
             promptTemplates={summaryPromptTemplates}
             activePromptTemplateId={activeSummaryPromptTemplateId}
             summaryConnectionId={summaryConnectionId}
+            summaryMaxTokens={summaryMaxTokens}
             automaticSummaryEnabled={automaticSummaryEnabled}
             activeAgentIds={activeAgentIds}
             summaryRunInterval={summaryRunInterval}
@@ -1464,6 +1467,10 @@ export function ChatRoleplaySurface({
     typeof chatMeta.summaryRunInterval === "number" && Number.isFinite(chatMeta.summaryRunInterval)
       ? chatMeta.summaryRunInterval
       : undefined;
+  const summaryMaxTokens =
+    typeof chatMeta.summaryMaxTokens === "number" && Number.isFinite(chatMeta.summaryMaxTokens)
+      ? chatMeta.summaryMaxTokens
+      : undefined;
   const hideSummarisedMessages =
     typeof chatMeta.hideSummarisedMessages === "boolean" ? chatMeta.hideSummarisedMessages : undefined;
   const summaryTailMessages =
@@ -1565,6 +1572,7 @@ export function ChatRoleplaySurface({
                       summaryConnectionId={
                         typeof chatMeta.summaryConnectionId === "string" ? chatMeta.summaryConnectionId : null
                       }
+                      summaryMaxTokens={summaryMaxTokens}
                       automaticSummaryEnabled={automaticSummaryEnabled}
                       activeAgentIds={summaryActiveAgentIds}
                       summaryRunInterval={summaryRunInterval}
@@ -1670,6 +1678,7 @@ export function ChatRoleplaySurface({
                           summaryConnectionId={
                             typeof chatMeta.summaryConnectionId === "string" ? chatMeta.summaryConnectionId : null
                           }
+                          summaryMaxTokens={summaryMaxTokens}
                           automaticSummaryEnabled={automaticSummaryEnabled}
                           activeAgentIds={summaryActiveAgentIds}
                           summaryRunInterval={summaryRunInterval}
@@ -1740,6 +1749,7 @@ export function ChatRoleplaySurface({
                         summaryConnectionId={
                           typeof chatMeta.summaryConnectionId === "string" ? chatMeta.summaryConnectionId : null
                         }
+                        summaryMaxTokens={summaryMaxTokens}
                         automaticSummaryEnabled={automaticSummaryEnabled}
                         activeAgentIds={summaryActiveAgentIds}
                         summaryRunInterval={summaryRunInterval}

--- a/packages/client/src/components/chat/ChatSetupWizard.tsx
+++ b/packages/client/src/components/chat/ChatSetupWizard.tsx
@@ -66,6 +66,7 @@ import {
   type CharacterGroup,
   type ConversationCommandKey,
   type Lorebook,
+  type Message,
 } from "@marinara-engine/shared";
 import { useQueryClient } from "@tanstack/react-query";
 import {
@@ -1998,8 +1999,9 @@ function RoleplaySetupWizard({ chat, onFinish }: ChatSetupWizardProps) {
   const seedInitialGreetingsIfEmpty = useCallback(async () => {
     if (chatCharIds.length === 0) return;
     try {
-      const { count } = await api.get<{ count: number }>(`/chats/${chat.id}/message-count`);
-      if (count > 0) return;
+      const messages = await api.get<Array<Pick<Message, "role">>>(`/chats/${chat.id}/messages`);
+      const hasNonSystemMessage = messages.some((message) => message.role !== "system");
+      if (hasNonSystemMessage) return;
     } catch {
       return;
     }

--- a/packages/client/src/components/chat/SummaryPopover.tsx
+++ b/packages/client/src/components/chat/SummaryPopover.tsx
@@ -51,6 +51,7 @@ import {
 } from "./roleplay-popover-styles";
 import {
   type APIConnection,
+  CHAT_SUMMARY_OUTPUT_TOKENS,
   DEFAULT_CHAT_SUMMARY_PROMPT,
   SUMMARY_TAIL_MESSAGES,
   estimateChatSummaryTokens,
@@ -68,6 +69,7 @@ interface SummaryPopoverProps {
   promptTemplates?: ChatSummaryPromptTemplate[];
   activePromptTemplateId?: string | null;
   summaryConnectionId?: string | null;
+  summaryMaxTokens?: number;
   automaticSummaryEnabled?: boolean;
   activeAgentIds?: string[];
   summaryRunInterval?: number;
@@ -106,6 +108,15 @@ const SUMMARY_TOKEN_WARNING_THRESHOLD = 1800;
 const SUMMARY_HEADING_PATTERN = /^(?:#{1,6}\s*)?(?:\*\*)?([^:\n]{3,80})(?:\*\*)?:\s*$/;
 const SUMMARY_BULLET_PATTERN = /^[-*•]\s+/;
 const MOBILE_SUMMARY_PADDING = 8;
+
+function clampSummaryMaxTokens(value: unknown): number {
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed) || parsed <= 0) return CHAT_SUMMARY_OUTPUT_TOKENS.DEFAULT;
+  return Math.max(
+    CHAT_SUMMARY_OUTPUT_TOKENS.MIN,
+    Math.min(CHAT_SUMMARY_OUTPUT_TOKENS.MAX, Math.trunc(parsed)),
+  );
+}
 
 function getMobileSummaryFrame(anchor: SummaryPopoverAnchor | null | undefined) {
   if (typeof window === "undefined") return null;
@@ -263,6 +274,7 @@ export function SummaryPopover({
   promptTemplates = [],
   activePromptTemplateId = null,
   summaryConnectionId = null,
+  summaryMaxTokens,
   automaticSummaryEnabled = false,
   activeAgentIds = [],
   summaryRunInterval,
@@ -288,7 +300,9 @@ export function SummaryPopover({
   const persistedContextSize = summaryPopoverSettings.contextSize ?? contextSize;
   const [localSize, setLocalSize] = useState(String(persistedContextSize || ""));
   const normalizedAutomaticSummaryInterval = clampAutomaticSummaryInterval(summaryRunInterval);
+  const normalizedSummaryMaxTokens = clampSummaryMaxTokens(summaryMaxTokens);
   const [automaticIntervalDraft, setAutomaticIntervalDraft] = useState(String(normalizedAutomaticSummaryInterval));
+  const [summaryMaxTokensDraft, setSummaryMaxTokensDraft] = useState(String(normalizedSummaryMaxTokens));
   const sourceMode = summaryPopoverSettings.sourceMode;
   const [rangeStart, setRangeStart] = useState(() =>
     String(summaryPopoverSettings.rangeStart ?? Math.max(1, totalMessageCount - persistedContextSize + 1)),
@@ -299,6 +313,8 @@ export function SummaryPopover({
   const sizeInputFocused = useRef(false);
   const rangeInputFocused = useRef(false);
   const automaticIntervalFocused = useRef(false);
+  const summaryMaxTokensFocused = useRef(false);
+  const summaryMaxTokensSaveRef = useRef<{ key: string; promise: Promise<void> } | null>(null);
   const generateSummary = useGenerateSummary();
   const updateMeta = useUpdateChatMetadata();
   const { data: connectionsData } = useConnections();
@@ -469,6 +485,12 @@ export function SummaryPopover({
     }
   }, [normalizedAutomaticSummaryInterval]);
 
+  useEffect(() => {
+    if (!summaryMaxTokensFocused.current) {
+      setSummaryMaxTokensDraft(String(normalizedSummaryMaxTokens));
+    }
+  }, [normalizedSummaryMaxTokens]);
+
   const persistAutomaticSummaryInterval = useCallback(
     (value: number) => {
       const clamped = clampAutomaticSummaryInterval(value);
@@ -500,6 +522,38 @@ export function SummaryPopover({
     [chatId, updateMeta],
   );
 
+  const persistSummaryMaxTokens = useCallback(
+    async (value: string) => {
+      const clamped = clampSummaryMaxTokens(value || CHAT_SUMMARY_OUTPUT_TOKENS.DEFAULT);
+      setSummaryMaxTokensDraft(String(clamped));
+      if (normalizedSummaryMaxTokens !== clamped) {
+        const key = String(clamped);
+        if (summaryMaxTokensSaveRef.current?.key === key) {
+          await summaryMaxTokensSaveRef.current.promise;
+          return;
+        }
+        const promise = updateMeta
+          .mutateAsync({
+            id: chatId,
+            summaryMaxTokens: clamped,
+          })
+          .then(() => undefined)
+          .catch((error) => {
+            toast.error("Could not save summary output size.");
+            throw error;
+          })
+          .finally(() => {
+            if (summaryMaxTokensSaveRef.current?.promise === promise) {
+              summaryMaxTokensSaveRef.current = null;
+            }
+          });
+        summaryMaxTokensSaveRef.current = { key, promise };
+        await promise;
+      }
+    },
+    [chatId, normalizedSummaryMaxTokens, updateMeta],
+  );
+
   const handleSourceModeChange = useCallback(
     (mode: SummarySourceMode) => {
       if (mode === "range") {
@@ -513,8 +567,13 @@ export function SummaryPopover({
     [rangeHigh, rangeLow, setSummaryPopoverSettings],
   );
 
-  const handleGenerate = useCallback(() => {
+  const handleGenerate = useCallback(async () => {
     if (!canGenerate) return;
+    try {
+      await persistSummaryMaxTokens(summaryMaxTokensDraft);
+    } catch {
+      return;
+    }
     // The server hides the tail-excluded subset itself (when the chat opts in)
     // and the generate-summary mutation refreshes the message list, so there is
     // no separate client-side hide to keep in sync.
@@ -561,6 +620,32 @@ export function SummaryPopover({
     persistSummaryContextSize,
     sourceMode,
     activePromptTemplateId,
+    persistSummaryMaxTokens,
+    summaryMaxTokensDraft,
+  ]);
+
+  const handleBackfill = useCallback(async () => {
+    try {
+      await persistSummaryMaxTokens(summaryMaxTokensDraft);
+    } catch {
+      return;
+    }
+    startBackfill({
+      chatId,
+      summaryEntries: displayEntries,
+      batchSize: normalizedAutomaticSummaryInterval,
+      maxMessagesPerBatch: persistedContextSize,
+      promptTemplateId: activePromptTemplateId,
+    });
+  }, [
+    activePromptTemplateId,
+    chatId,
+    displayEntries,
+    normalizedAutomaticSummaryInterval,
+    persistedContextSize,
+    persistSummaryMaxTokens,
+    startBackfill,
+    summaryMaxTokensDraft,
   ]);
 
   const handleToggleExpanded = useCallback((entryId: string) => {
@@ -1013,15 +1098,7 @@ export function SummaryPopover({
                     ) : (
                       <button
                         type="button"
-                        onClick={() => {
-                          startBackfill({
-                            chatId,
-                            summaryEntries: displayEntries,
-                            batchSize: normalizedAutomaticSummaryInterval,
-                            maxMessagesPerBatch: persistedContextSize,
-                            promptTemplateId: activePromptTemplateId,
-                          });
-                        }}
+                        onClick={() => void handleBackfill()}
                         disabled={
                           totalMessageCount === 0
                         }
@@ -1219,6 +1296,36 @@ export function SummaryPopover({
                   </option>
                 ))}
               </select>
+              <label className="space-y-1">
+                <span className="text-[0.625rem] font-semibold text-[var(--muted-foreground)]">
+                  Maximum output size
+                </span>
+                <input
+                  type="number"
+                  min={CHAT_SUMMARY_OUTPUT_TOKENS.MIN}
+                  max={CHAT_SUMMARY_OUTPUT_TOKENS.MAX}
+                  step={1}
+                  value={summaryMaxTokensDraft}
+                  onFocus={() => {
+                    summaryMaxTokensFocused.current = true;
+                  }}
+                  onChange={(event) => {
+                    setSummaryMaxTokensDraft(event.target.value);
+                  }}
+                  onBlur={() => {
+                    summaryMaxTokensFocused.current = false;
+                    void persistSummaryMaxTokens(summaryMaxTokensDraft).catch(() => undefined);
+                  }}
+                  onKeyDown={(event) => {
+                    if (event.key === "Enter") {
+                      event.currentTarget.blur();
+                    }
+                  }}
+                  disabled={updateMeta.isPending}
+                  className="w-full rounded-md bg-[var(--card)] px-2 py-1.5 text-xs font-semibold text-[var(--foreground)] ring-1 ring-[var(--border)] focus:outline-none focus:ring-2 focus:ring-[var(--ring)] disabled:cursor-not-allowed disabled:opacity-50"
+                  aria-label="Summary maximum output size"
+                />
+              </label>
             </div>
           </div>
 

--- a/packages/client/src/components/ui/ChibiProfessorMariEasterEgg.tsx
+++ b/packages/client/src/components/ui/ChibiProfessorMariEasterEgg.tsx
@@ -38,16 +38,14 @@ function showChibiProfessorMariToast() {
         >
           <X className="h-3.5 w-3.5" aria-hidden="true" />
         </button>
-        <div className="flex h-24 w-20 shrink-0 items-end justify-center overflow-hidden rounded-md border border-[var(--border)] bg-[var(--accent)]/45">
-          <img
-            src={CHIBI_PROFESSOR_MARI_IMAGE}
-            alt="Chibi Professor Mari"
-            className="h-full w-full object-contain p-1"
-            onError={(event) => {
-              event.currentTarget.hidden = true;
-            }}
-          />
-        </div>
+        <img
+          src={CHIBI_PROFESSOR_MARI_IMAGE}
+          alt="Chibi Professor Mari"
+          className="h-24 w-20 shrink-0 self-end object-contain drop-shadow-[0_4px_10px_rgb(0_0_0/0.25)]"
+          onError={(event) => {
+            event.currentTarget.hidden = true;
+          }}
+        />
         <div className="space-y-2 text-sm leading-relaxed">
           <p>
             If you see this image while scrolling through Marinara Engine, you've been visited by the rare Chibi

--- a/packages/server/src/middleware/security-headers.ts
+++ b/packages/server/src/middleware/security-headers.ts
@@ -11,8 +11,9 @@ const SECURITY_HEADERS: Record<string, string> = {
 };
 
 const PERMISSIONS_POLICY = [
-  "camera=()",
-  "microphone=()",
+  "camera=(self)",
+  "microphone=(self)",
+  "display-capture=(self)",
   "geolocation=()",
   "payment=()",
   "usb=()",

--- a/packages/server/src/routes/chats.routes.ts
+++ b/packages/server/src/routes/chats.routes.ts
@@ -90,6 +90,7 @@ import { sanitizeGameNpcAvatarUrls } from "../services/game/npc-avatar-utils.js"
 import { buildCommittedTrackerContextBlock } from "../services/generation/committed-tracker-context.js";
 import { parseLorebookWriteApprovalText } from "./generate/agent-write-approval.js";
 import { persistLorebookKeeperUpdates } from "./generate/lorebook-keeper-utils.js";
+import { clampRoleplaySummaryMaxTokens } from "../services/generation/roleplay-summary-runtime.js";
 
 type TrackerWrapFormat = "xml" | "markdown" | "none";
 type EntryStateOverrides = Record<string, { ephemeral?: number | null; enabled?: boolean }>;
@@ -785,6 +786,9 @@ export async function chatsRoutes(app: FastifyInstance) {
       await clearConversationScheduleState(chat);
       incoming.characterSchedules = undefined;
       incoming.scheduleWeekStart = undefined;
+    }
+    if (Object.prototype.hasOwnProperty.call(incoming, "summaryMaxTokens")) {
+      incoming.summaryMaxTokens = clampRoleplaySummaryMaxTokens(incoming.summaryMaxTokens);
     }
     if (
       Object.prototype.hasOwnProperty.call(incoming, "hideSummarisedMessages") &&
@@ -3295,6 +3299,7 @@ export async function chatsRoutes(app: FastifyInstance) {
     const hasRangeByMessageId = !!requestedRangeStartMessageId && !!requestedRangeEndMessageId;
     const hasRangeByIndex = requestedRangeStartIndex !== null && requestedRangeEndIndex !== null;
     const hasRange = hasRangeByMessageId || hasRangeByIndex;
+    const summaryMaxTokens = clampRoleplaySummaryMaxTokens(chatMeta.summaryMaxTokens);
 
     const connections = createConnectionsStorage(app.db);
 
@@ -3406,7 +3411,7 @@ export async function chatsRoutes(app: FastifyInstance) {
     const result = await provider.chatComplete(messages, {
       model,
       temperature: 0.5,
-      maxTokens: 2048,
+      maxTokens: summaryMaxTokens,
     });
 
     if (!result.content) {

--- a/packages/server/src/routes/generate.routes.ts
+++ b/packages/server/src/routes/generate.routes.ts
@@ -307,6 +307,7 @@ import {
   appendContinuationMessageContent,
   clampRoleplaySummaryContextSize,
   clampRoleplaySummaryInterval,
+  clampRoleplaySummaryMaxTokens,
   isAutomaticRoleplaySummaryEnabled,
   parseChatSummaryText,
   resolveChatSummaryPromptFromMetadata,
@@ -5809,6 +5810,7 @@ export async function generateRoutes(app: FastifyInstance) {
           if (messagesSinceLastSummary < interval) return;
 
           const contextSize = clampRoleplaySummaryContextSize(chatMeta.summaryContextSize);
+          const summaryMaxTokens = clampRoleplaySummaryMaxTokens(chatMeta.summaryMaxTokens);
           const selectedMessages = selectRollingSummaryMessages({
             messages: freshMessages,
             contextSize,
@@ -5860,7 +5862,7 @@ export async function generateRoutes(app: FastifyInstance) {
             {
               model: summaryModel,
               temperature: 0.5,
-              maxTokens: 2048,
+              maxTokens: summaryMaxTokens,
               signal: abortController.signal,
             },
           );

--- a/packages/server/src/services/generation/roleplay-summary-runtime.ts
+++ b/packages/server/src/services/generation/roleplay-summary-runtime.ts
@@ -1,4 +1,4 @@
-import { DEFAULT_CHAT_SUMMARY_PROMPT } from "@marinara-engine/shared";
+import { CHAT_SUMMARY_OUTPUT_TOKENS, DEFAULT_CHAT_SUMMARY_PROMPT } from "@marinara-engine/shared";
 
 const RETIRED_CHAT_SUMMARY_AGENT_ID = "chat-summary";
 const DEFAULT_AUTOMATIC_SUMMARY_INTERVAL = 5;
@@ -19,6 +19,15 @@ export function clampRoleplaySummaryContextSize(value: unknown): number {
   const parsed = Number(value);
   if (!Number.isFinite(parsed) || parsed <= 0) return 50;
   return Math.max(MIN_SUMMARY_CONTEXT_SIZE, Math.min(MAX_SUMMARY_CONTEXT_SIZE, Math.trunc(parsed)));
+}
+
+export function clampRoleplaySummaryMaxTokens(value: unknown): number {
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed) || parsed <= 0) return CHAT_SUMMARY_OUTPUT_TOKENS.DEFAULT;
+  return Math.max(
+    CHAT_SUMMARY_OUTPUT_TOKENS.MIN,
+    Math.min(CHAT_SUMMARY_OUTPUT_TOKENS.MAX, Math.trunc(parsed)),
+  );
 }
 
 export function appendContinuationMessageContent(existingContent: unknown, continuation: string): string {

--- a/packages/shared/src/constants/agent-prompts.ts
+++ b/packages/shared/src/constants/agent-prompts.ts
@@ -157,7 +157,7 @@ Return valid JSON only:
   "aspectRatio": "landscape|portrait|square",
   "characters": ["visible character name"]
 }
-Prompt rules: describe composition, lighting, mood, environment, and every visible character/persona directly. Put all visible names in characters. Include no UI, watermark, logo, signature, captions, speech bubbles, subtitles, manga SFX, or meta-instructions.`,
+Prompt rules: describe composition, lighting, mood, environment, and every visible character/persona directly. For each visible character/persona, include available body build (chubby, slim, muscular, etc.), clothing/outfit, hair, face, distinguishing features, and other appearance details from context. Do not invent missing traits. Put all visible names in characters. Include no UI, watermark, logo, signature, captions, speech bubbles, subtitles, manga SFX, or meta-instructions.`,
 
   /* ────────────────────────────────────────── */
   "lorebook-keeper": `You are Lorebook Keeper for chat/roleplay continuity. Record only durable facts from the latest assistant response that will help future generations remember the world, characters, factions, locations, items, events, powers, relationships, or reusable history.

--- a/packages/shared/src/features/agents/illustrator/manifest.ts
+++ b/packages/shared/src/features/agents/illustrator/manifest.ts
@@ -13,7 +13,7 @@ const illustratorOutputFormat = `Return valid JSON only:
 
 const baseDecisionRules = `Anchor the decision to <assistant_response>, the latest assistant turn. Use recent context only for continuity.
 Generate only for a visually important moment: dramatic action, key emotion, major reveal, transformation, important location, or newly described character. If not worth illustrating, set shouldGenerate false and keep prompt empty.
-Describe every visible character/persona directly in the prompt. The image model has no memory. Put all visible names in characters.`;
+Describe every visible character/persona directly in the prompt. Include available body build (chubby, slim, muscular, etc.), clothing/outfit, hair, face, distinguishing features, and other appearance details from context. Do not invent missing traits. The image model has no memory. Put all visible names in characters.`;
 
 function createIllustratorPrompt(style: string, rules: string): string {
   return `${baseDecisionRules}

--- a/packages/shared/src/types/chat.ts
+++ b/packages/shared/src/types/chat.ts
@@ -190,6 +190,7 @@ export interface ChatMemoryChunk {
  * value is unset; an explicit `MIN` (0) means "hide the whole batch".
  */
 export const SUMMARY_TAIL_MESSAGES = { MIN: 0, MAX: 50, DEFAULT: 10 } as const;
+export const CHAT_SUMMARY_OUTPUT_TOKENS = { MIN: 1, MAX: 32768, DEFAULT: 4096 } as const;
 
 export type GameStoryboardViewerDisplayMode = "floating" | "background";
 
@@ -213,6 +214,8 @@ export interface ChatMetadata {
   activeSummaryPromptTemplateId?: string | null;
   /** Optional text connection used for manual and automatic Roleplay chat summaries. Null uses the agent default. */
   summaryConnectionId?: string | null;
+  /** Maximum output tokens requested from the model for manual and automatic Roleplay chat summaries. */
+  summaryMaxTokens?: number;
   /**
    * When true, the automatic roleplay/visual-novel rolling summary hides the
    * messages it summarized (hiddenFromAI=true) except the most-recent


### PR DESCRIPTION
## Linked issue

Closes #3392

## Why this change

- Fixes the Roleplay setup wizard shortcut path where system "joined the chat" notices made the chat look non-empty, so first messages were skipped.
- Bundles the v2.1.2 follow-up fixes requested in this working branch: summary output sizing, Illustrator prompt guidance, Conversation Calls permissions policy, and Mini Mari toast polish.

## What changed

- Checks for non-system chat messages before skipping Roleplay initial greeting seeding in the **Use Settings Presets** shortcut.
- Adds a Roleplay Chat Summary maximum output size setting and uses it for manual and automatic summaries.
- Updates the default Illustrator prompt rules to include character build, clothing, and appearance details.
- Allows same-origin microphone, camera, and screen capture for Conversation Calls via the server permissions policy.
- Removes the extra framed border around the Mini Mari surprise toast image.
- Updates CHANGELOG and Conversation Calls troubleshooting docs.

## Validation

- [ ] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed `CONTRIBUTING.md`

### Manual verification notes

- Automated validation run: `pnpm check`.
- Browser/manual verification still needed for the RP wizard shortcut, Edge microphone prompt, and Mini Mari toast appearance.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Version/release files updated (only if this PR includes a version bump)

## UI evidence (if applicable)

- Not captured.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new “Maximum output size” setting for chat summaries, available in the Summary Connection area for both manual and automatic summaries.
  * Roleplay setup now seeds initial greetings more reliably when a chat is still empty.

* **Bug Fixes**
  * Fixed microphone, camera, and screen-capture access in Chromium-based browsers for conversation calls.
  * Fixed the Roleplay setup shortcut so earlier notices no longer block the first seeded character message.

* **Documentation**
  * Updated troubleshooting guidance for browser microphone permission issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->