### PR TITLE
Fix connected game scenes and summary prompts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 - Added Conversation prompt relocation macros for auto-inserted context: `{{context}}`/`{{status}}`, `{{commands}}`, `{{reactRules}}`, `{{memories}}`, and `{{lorebook}}`.
 - Added a TTS cache export control in Text to Speech settings so generated cached voice clips can be downloaded from IndexedDB.
 - Added a Roleplay Chat Summary maximum output size setting under Summary Connection, defaulting to 4096 tokens for manual and automatic summaries.
+- Added a connected-chat shortcut to Game mode so connected Conversation and Game chats can switch back and forth like Conversation/Roleplay links.
+- Added a scene prompt setup dialog for user- and character-initiated scenes, remembering POV, tense, and optional prompt wishes for the next scene generation.
 
 ### Changed
 
@@ -23,6 +25,7 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 - Android `versionName` is `2.1.2` with `versionCode 31`.
 - Reworked Settings with search-first navigation, compact pinned controls, fixed top-level categories, and finer section shortcuts for faster navigation.
 - Updated the default Illustrator prompt rules so generated image prompts carry available character builds, clothing/outfits, and appearance details instead of relying on the image model to infer them.
+- Changed custom Roleplay Chat Summary prompts to apply globally across roleplay chats instead of only the currently open chat.
 
 ### Fixed
 
@@ -41,6 +44,7 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 - Fixed the recovery/error page so **Internal Server Error** uses the configured chat chrome text color instead of a hard-coded pink.
 - Fixed Conversation Calls on Chromium browsers by allowing same-origin microphone, camera, and screen-capture access in the server permissions policy instead of blocking the browser permission prompt.
 - Fixed the Roleplay setup wizard's **Use Settings Presets** shortcut so system "joined the chat" notices no longer block seeding the selected character's first message (#3392).
+- Fixed Conversation-mode prompt assembly so the user's visible status and activity are always included in context unless the persona is set to Invisible, even when a relocated context macro is configured but not present after prompt resolution.
 
 ## [2.1.1]
 

--- a/packages/client/src/components/characters/CharacterEditor.tsx
+++ b/packages/client/src/components/characters/CharacterEditor.tsx
@@ -1818,7 +1818,7 @@ function DialogueTab({
           rows={6}
           title="First Message"
           className="w-full resize-y rounded-xl border border-[var(--border)] bg-[var(--secondary)] p-4 text-sm leading-relaxed outline-none placeholder:text-[var(--muted-foreground)]/40 focus:border-[var(--primary)]/40 focus:ring-1 focus:ring-[var(--primary)]/20"
-          placeholder="What does the character say when they first meet someone? Use *asterisks* for actions…"
+          placeholder="What is the character's first message when a new chat starts?"
         />
       </div>
 

--- a/packages/client/src/components/chat/ChatArea.tsx
+++ b/packages/client/src/components/chat/ChatArea.tsx
@@ -2746,8 +2746,10 @@ export function ChatArea() {
             characters={gameCharacters}
             personaInfo={personaInfo}
             chatBackground={chatBackground}
+            connectedChatName={connectedChatName}
             onOpenSettings={handleOpenSettingsPanel}
             onCloseSettings={handleCloseSettingsPanel}
+            onSwitchChat={chat.connectedChatId ? () => setActiveChatId(chat.connectedChatId!) : undefined}
             onDeleteMessage={handleDelete}
             multiSelectMode={multiSelectMode}
             selectedMessageIds={selectedMessageIds}

--- a/packages/client/src/components/chat/SummaryPopover.tsx
+++ b/packages/client/src/components/chat/SummaryPopover.tsx
@@ -21,6 +21,10 @@ import {
   useUpdateChatMetadata,
   useUpdateSummaryEntry,
 } from "../../hooks/use-chats";
+import {
+  useChatSummaryPromptSettings,
+  useUpdateChatSummaryPromptSettings,
+} from "../../hooks/use-chat-summary-prompts";
 import { useRollingBackfillStore } from "../../stores/backfill.store";
 import {
   Check,
@@ -317,6 +321,8 @@ export function SummaryPopover({
   const summaryMaxTokensSaveRef = useRef<{ key: string; promise: Promise<void> } | null>(null);
   const generateSummary = useGenerateSummary();
   const updateMeta = useUpdateChatMetadata();
+  const globalPromptSettings = useChatSummaryPromptSettings();
+  const updateGlobalPromptSettings = useUpdateChatSummaryPromptSettings();
   const { data: connectionsData } = useConnections();
   const updateSummaryEntry = useUpdateSummaryEntry();
   const deleteSummaryEntry = useDeleteSummaryEntry();
@@ -413,7 +419,8 @@ export function SummaryPopover({
   const selectedRangeCount = rangeHigh - rangeLow + 1;
   const hasMessages = totalMessageCount > 0;
   const rangeTooLarge = sourceMode === "range" && selectedRangeCount > MAX_SUMMARY_MESSAGES;
-  const canGenerate = hasMessages && !rangeTooLarge;
+  const globalPromptSettingsReady = globalPromptSettings.isSuccess;
+  const canGenerate = hasMessages && !rangeTooLarge && globalPromptSettingsReady;
   const sourceSummary =
     sourceMode === "range"
       ? `Messages ${rangeLow}-${rangeHigh}`
@@ -425,7 +432,20 @@ export function SummaryPopover({
         ? `Using ${Math.min(normalizedLastSize, totalMessageCount)} of ${totalMessageCount} messages`
         : "No messages yet";
   const rangeErrorText = `Choose ${MAX_SUMMARY_MESSAGES} messages or fewer.`;
-  const cleanedPromptTemplates = promptTemplates.filter(
+  const globalTemplates = globalPromptSettings.data?.templates ?? [];
+  const globalActivePromptTemplateId = globalPromptSettings.data?.activeTemplateId ?? null;
+  const hasGlobalPromptSettings = globalPromptSettings.data?.hasPersistedSettings === true;
+  const sourcePromptTemplates = !globalPromptSettingsReady
+    ? []
+    : hasGlobalPromptSettings
+      ? globalTemplates
+      : promptTemplates;
+  const resolvedActivePromptTemplateId = !globalPromptSettingsReady
+    ? null
+    : hasGlobalPromptSettings
+      ? globalActivePromptTemplateId
+      : activePromptTemplateId;
+  const cleanedPromptTemplates = sourcePromptTemplates.filter(
     (template) =>
       typeof template.id === "string" &&
       template.id.trim().length > 0 &&
@@ -433,8 +453,8 @@ export function SummaryPopover({
       typeof template.prompt === "string" &&
       template.prompt.trim().length > 0,
   );
-  const activePromptTemplate = activePromptTemplateId
-    ? cleanedPromptTemplates.find((template) => template.id === activePromptTemplateId)
+  const activePromptTemplate = resolvedActivePromptTemplateId
+    ? cleanedPromptTemplates.find((template) => template.id === resolvedActivePromptTemplateId)
     : null;
   const promptTemplateSummary = activePromptTemplate?.name ?? "Built-in default";
   const isEditingExistingTemplate = !!editingTemplateId;
@@ -581,7 +601,12 @@ export function SummaryPopover({
       setRangeStart(String(rangeLow));
       setRangeEnd(String(rangeHigh));
       generateSummary.mutate(
-        { chatId, rangeStartIndex: rangeLow, rangeEndIndex: rangeHigh, promptTemplateId: activePromptTemplateId },
+        {
+          chatId,
+          rangeStartIndex: rangeLow,
+          rangeEndIndex: rangeHigh,
+          promptTemplateId: resolvedActivePromptTemplateId,
+        },
         {
           onSuccess: (data) => {
             if (data.entry?.id) {
@@ -598,7 +623,7 @@ export function SummaryPopover({
     setLocalSize(String(normalizedLastSize));
     persistSummaryContextSize(normalizedLastSize);
     generateSummary.mutate(
-      { chatId, contextSize: normalizedLastSize, promptTemplateId: activePromptTemplateId },
+      { chatId, contextSize: normalizedLastSize, promptTemplateId: resolvedActivePromptTemplateId },
       {
         onSuccess: (data) => {
           if (data.entry?.id) {
@@ -619,12 +644,13 @@ export function SummaryPopover({
     rangeLow,
     persistSummaryContextSize,
     sourceMode,
-    activePromptTemplateId,
+    resolvedActivePromptTemplateId,
     persistSummaryMaxTokens,
     summaryMaxTokensDraft,
   ]);
 
   const handleBackfill = useCallback(async () => {
+    if (!globalPromptSettingsReady) return;
     try {
       await persistSummaryMaxTokens(summaryMaxTokensDraft);
     } catch {
@@ -635,12 +661,13 @@ export function SummaryPopover({
       summaryEntries: displayEntries,
       batchSize: normalizedAutomaticSummaryInterval,
       maxMessagesPerBatch: persistedContextSize,
-      promptTemplateId: activePromptTemplateId,
+      promptTemplateId: resolvedActivePromptTemplateId,
     });
   }, [
-    activePromptTemplateId,
+    resolvedActivePromptTemplateId,
     chatId,
     displayEntries,
+    globalPromptSettingsReady,
     normalizedAutomaticSummaryInterval,
     persistedContextSize,
     persistSummaryMaxTokens,
@@ -769,19 +796,26 @@ export function SummaryPopover({
   );
 
   const persistPromptTemplates = useCallback(
-    (templates: ChatSummaryPromptTemplate[], activeId: string | null) => {
-      updateMeta.mutate({
-        id: chatId,
-        summaryPromptTemplates: templates,
-        activeSummaryPromptTemplateId: activeId,
-      });
+    async (templates: ChatSummaryPromptTemplate[], activeId: string | null): Promise<boolean> => {
+      if (!globalPromptSettingsReady) return false;
+      try {
+        await updateGlobalPromptSettings.mutateAsync({
+          templates,
+          activeTemplateId: activeId,
+        });
+        return true;
+      } catch {
+        toast.error("Could not save global summary prompt settings.");
+        return false;
+      }
     },
-    [chatId, updateMeta],
+    [globalPromptSettingsReady, updateGlobalPromptSettings],
   );
 
   const handleSelectPromptTemplate = useCallback(
-    (templateId: string | null) => {
-      persistPromptTemplates(cleanedPromptTemplates, templateId);
+    async (templateId: string | null) => {
+      const saved = await persistPromptTemplates(cleanedPromptTemplates, templateId);
+      if (!saved) return;
       setTemplateSelectOpen(false);
     },
     [cleanedPromptTemplates, persistPromptTemplates],
@@ -822,7 +856,7 @@ export function SummaryPopover({
     handleDuplicatePromptTemplate(null);
   }, [activePromptTemplate, handleDuplicatePromptTemplate, handleEditPromptTemplate]);
 
-  const handleSavePromptTemplate = useCallback(() => {
+  const handleSavePromptTemplate = useCallback(async () => {
     if (!hasTemplateDraft) return;
     const trimmedName = templateNameDraft.trim().slice(0, 80);
     const trimmedPrompt = templatePromptDraft.trim();
@@ -839,12 +873,13 @@ export function SummaryPopover({
           },
         ];
     const nextActiveId = isEditingExistingTemplate
-      ? activePromptTemplateId
+      ? resolvedActivePromptTemplateId
       : nextTemplates[nextTemplates.length - 1]!.id;
-    persistPromptTemplates(nextTemplates, nextActiveId ?? null);
+    const saved = await persistPromptTemplates(nextTemplates, nextActiveId ?? null);
+    if (!saved) return;
     resetTemplateDraft();
   }, [
-    activePromptTemplateId,
+    resolvedActivePromptTemplateId,
     cleanedPromptTemplates,
     editingTemplateId,
     hasTemplateDraft,
@@ -861,17 +896,27 @@ export function SummaryPopover({
       if (!target) return;
       const confirmed = await showConfirmDialog({
         title: "Delete summary template?",
-        message: `Delete "${target.name}" from this chat? Existing summaries will stay unchanged.`,
+        message: `Delete "${target.name}" from global Roleplay summary prompts? Existing summaries will stay unchanged.`,
         confirmLabel: "Delete",
         cancelLabel: "Cancel",
         tone: "destructive",
       });
       if (!confirmed) return;
       const nextTemplates = cleanedPromptTemplates.filter((template) => template.id !== templateId);
-      persistPromptTemplates(nextTemplates, activePromptTemplateId === templateId ? null : activePromptTemplateId);
+      const saved = await persistPromptTemplates(
+        nextTemplates,
+        resolvedActivePromptTemplateId === templateId ? null : resolvedActivePromptTemplateId,
+      );
+      if (!saved) return;
       if (editingTemplateId === templateId) resetTemplateDraft();
     },
-    [activePromptTemplateId, cleanedPromptTemplates, editingTemplateId, persistPromptTemplates, resetTemplateDraft],
+    [
+      cleanedPromptTemplates,
+      editingTemplateId,
+      persistPromptTemplates,
+      resetTemplateDraft,
+      resolvedActivePromptTemplateId,
+    ],
   );
 
   const isGenerating = generateSummary.isPending;
@@ -1099,9 +1144,7 @@ export function SummaryPopover({
                       <button
                         type="button"
                         onClick={() => void handleBackfill()}
-                        disabled={
-                          totalMessageCount === 0
-                        }
+                        disabled={totalMessageCount === 0 || !globalPromptSettingsReady}
                         className="flex items-center gap-1.5 rounded-md bg-[var(--secondary)] px-2.5 py-1.5 text-[0.6875rem] font-medium text-[var(--foreground)] ring-1 ring-[var(--border)] transition-colors hover:bg-[var(--accent)] disabled:cursor-not-allowed disabled:opacity-50"
                       >
                         <RefreshCw size="0.75rem" />
@@ -1126,7 +1169,8 @@ export function SummaryPopover({
                     <button
                       type="button"
                       onClick={handleEditActivePrompt}
-                      className="rounded-md px-2 py-1 text-xs text-[var(--muted-foreground)] transition-colors hover:bg-[var(--accent)] hover:text-[var(--foreground)]"
+                      disabled={!globalPromptSettingsReady || updateGlobalPromptSettings.isPending}
+                      className="rounded-md px-2 py-1 text-xs text-[var(--muted-foreground)] transition-colors hover:bg-[var(--accent)] hover:text-[var(--foreground)] disabled:cursor-not-allowed disabled:opacity-50"
                     >
                       Edit
                     </button>
@@ -1136,11 +1180,13 @@ export function SummaryPopover({
                         setTemplateEditorOpen((open) => !open);
                         if (templateEditorOpen) resetTemplateDraft();
                       }}
+                      disabled={!globalPromptSettingsReady}
                       className={cn(
                         "shrink-0 rounded-md px-2 py-1 text-xs transition-colors",
                         templateEditorOpen
                           ? "bg-[var(--accent)] text-[var(--foreground)] ring-1 ring-[var(--border)]"
                           : "text-[var(--muted-foreground)] hover:bg-[var(--accent)] hover:text-[var(--foreground)]",
+                        !globalPromptSettingsReady && "cursor-not-allowed opacity-50",
                       )}
                     >
                       {templateEditorOpen ? "Done" : "Templates"}
@@ -1152,7 +1198,8 @@ export function SummaryPopover({
                     <button
                       type="button"
                       onClick={() => setTemplateSelectOpen((open) => !open)}
-                      className="flex w-full min-w-0 items-center justify-between gap-2 rounded-md bg-[var(--card)] py-1 pl-2 pr-2 text-left truncate text-xs font-semibold text-[var(--foreground)] ring-1 ring-[var(--border)] transition-colors hover:bg-[var(--accent)] focus:outline-none focus:ring-2 focus:ring-[var(--ring)]"
+                      disabled={!globalPromptSettingsReady}
+                      className="flex w-full min-w-0 items-center justify-between gap-2 rounded-md bg-[var(--card)] py-1 pl-2 pr-2 text-left truncate text-xs font-semibold text-[var(--foreground)] ring-1 ring-[var(--border)] transition-colors hover:bg-[var(--accent)] focus:outline-none focus:ring-2 focus:ring-[var(--ring)] disabled:cursor-not-allowed disabled:opacity-50"
                       aria-haspopup="listbox"
                       aria-expanded={templateSelectOpen}
                       aria-label="Summary prompt template"
@@ -1172,16 +1219,16 @@ export function SummaryPopover({
                         className="mt-1 max-h-40 overflow-y-auto rounded-md border border-[var(--border)] bg-[var(--popover)] p-1 text-[var(--popover-foreground)] shadow-xl shadow-black/25"
                       >
                         <SummaryPromptSelectOption
-                          active={!activePromptTemplateId}
+                          active={!resolvedActivePromptTemplateId}
                           label="Built-in default"
-                          onSelect={() => handleSelectPromptTemplate(null)}
+                          onSelect={() => void handleSelectPromptTemplate(null)}
                         />
                         {cleanedPromptTemplates.map((template) => (
                           <SummaryPromptSelectOption
                             key={template.id}
-                            active={activePromptTemplateId === template.id}
+                            active={resolvedActivePromptTemplateId === template.id}
                             label={template.name}
-                            onSelect={() => handleSelectPromptTemplate(template.id)}
+                            onSelect={() => void handleSelectPromptTemplate(template.id)}
                           />
                         ))}
                       </div>
@@ -1190,7 +1237,8 @@ export function SummaryPopover({
                   <button
                     type="button"
                     onClick={() => handleDuplicatePromptTemplate(activePromptTemplate ?? null)}
-                    className="rounded-md p-1.5 text-[var(--muted-foreground)] transition-colors hover:bg-[var(--accent)] hover:text-[var(--foreground)]"
+                    disabled={!globalPromptSettingsReady}
+                    className="rounded-md p-1.5 text-[var(--muted-foreground)] transition-colors hover:bg-[var(--accent)] hover:text-[var(--foreground)] disabled:cursor-not-allowed disabled:opacity-50"
                     title="Copy current prompt to a new template"
                     aria-label="Copy current prompt to a new template"
                   >
@@ -1202,19 +1250,19 @@ export function SummaryPopover({
                   <div className="space-y-2 border-t border-[var(--border)] pt-2">
                     <div className="max-h-28 space-y-1 overflow-y-auto pr-0.5">
                       <SummaryPromptTemplateRow
-                        active={!activePromptTemplateId}
+                        active={!resolvedActivePromptTemplateId}
                         name="Built-in default"
                         detail="App default"
-                        onSelect={() => persistPromptTemplates(cleanedPromptTemplates, null)}
+                        onSelect={() => void persistPromptTemplates(cleanedPromptTemplates, null)}
                         onCopy={() => handleDuplicatePromptTemplate(null)}
                       />
                       {cleanedPromptTemplates.map((template) => (
                         <SummaryPromptTemplateRow
                           key={template.id}
-                          active={activePromptTemplateId === template.id}
+                          active={resolvedActivePromptTemplateId === template.id}
                           name={template.name}
                           detail={`${Math.ceil(template.prompt.length / 4)} tokens est.`}
-                          onSelect={() => persistPromptTemplates(cleanedPromptTemplates, template.id)}
+                          onSelect={() => void persistPromptTemplates(cleanedPromptTemplates, template.id)}
                           onCopy={() => handleDuplicatePromptTemplate(template)}
                           onEdit={() => handleEditPromptTemplate(template)}
                           onDelete={() => void handleDeletePromptTemplate(template.id)}
@@ -1225,7 +1273,8 @@ export function SummaryPopover({
                     <button
                       type="button"
                       onClick={handleNewPromptTemplate}
-                      className="flex w-full items-center justify-center gap-1.5 rounded-md border border-dashed border-[var(--border)] bg-[var(--accent)]/35 px-2 py-1.5 text-[0.625rem] font-semibold text-[var(--foreground)] transition-colors hover:bg-[var(--accent)]"
+                      disabled={!globalPromptSettingsReady}
+                      className="flex w-full items-center justify-center gap-1.5 rounded-md border border-dashed border-[var(--border)] bg-[var(--accent)]/35 px-2 py-1.5 text-[0.625rem] font-semibold text-[var(--foreground)] transition-colors hover:bg-[var(--accent)] disabled:cursor-not-allowed disabled:opacity-50"
                     >
                       <Plus size="0.6875rem" />
                       New template
@@ -1257,8 +1306,12 @@ export function SummaryPopover({
                           </button>
                           <button
                             type="button"
-                            onClick={handleSavePromptTemplate}
-                            disabled={!hasTemplateDraft || updateMeta.isPending}
+                            onClick={() => void handleSavePromptTemplate()}
+                            disabled={
+                              !hasTemplateDraft ||
+                              updateGlobalPromptSettings.isPending ||
+                              !globalPromptSettingsReady
+                            }
                             className="flex items-center gap-1 rounded-md bg-[var(--secondary)] px-2 py-1 text-[0.625rem] font-semibold text-[var(--foreground)] ring-1 ring-[var(--border)] transition-colors hover:bg-[var(--accent)] disabled:cursor-not-allowed disabled:opacity-50"
                           >
                             <Save size="0.625rem" />

--- a/packages/client/src/components/game/GameSurface.tsx
+++ b/packages/client/src/components/game/GameSurface.tsx
@@ -1894,6 +1894,7 @@ function renameInventoryItem<T extends { name: string; quantity: number }>(
 
 import {
   AlertTriangle,
+  ArrowRightLeft,
   BookOpen,
   CircleHelp,
   Feather,
@@ -2244,8 +2245,10 @@ interface GameSurfaceProps {
   }>;
   personaInfo?: PersonaInfo;
   chatBackground?: string | null;
+  connectedChatName?: string;
   onOpenSettings: (event?: ReactMouseEvent<HTMLElement>) => void;
   onCloseSettings: () => void;
+  onSwitchChat?: () => void;
   onDeleteMessage: (messageId: string) => void;
   multiSelectMode?: boolean;
   selectedMessageIds?: Set<string>;
@@ -2261,8 +2264,10 @@ function GameSurfaceComponent({
   characters,
   personaInfo,
   chatBackground,
+  connectedChatName,
   onOpenSettings,
   onCloseSettings,
+  onSwitchChat,
   onDeleteMessage,
   multiSelectMode = false,
   selectedMessageIds,
@@ -2567,6 +2572,10 @@ function GameSurfaceComponent({
     },
     [closeLocalFloatingWindows, onOpenSettings],
   );
+  const handleSwitchConnectedChat = useCallback(() => {
+    dismissOtherFloatingWindows();
+    onSwitchChat?.();
+  }, [dismissOtherFloatingWindows, onSwitchChat]);
   const handleCloseGalleryPanel = useCallback(() => {
     setGalleryOpen(false);
     setGalleryAnchor(null);
@@ -10184,6 +10193,16 @@ function GameSurfaceComponent({
                   <button onClick={handleOpenGalleryPanel} className={GAME_TOP_ICON_BUTTON} title="Gallery">
                     <Image size={14} />
                   </button>
+                  {onSwitchChat ? (
+                    <button
+                      onClick={handleSwitchConnectedChat}
+                      className={GAME_TOP_ICON_BUTTON}
+                      title={connectedChatName ? `Switch to ${connectedChatName}` : "Switch to connected chat"}
+                      aria-label={connectedChatName ? `Switch to ${connectedChatName}` : "Switch to connected chat"}
+                    >
+                      <ArrowRightLeft size={14} />
+                    </button>
+                  ) : null}
                   <button onClick={handleOpenSettingsPanel} className={GAME_TOP_ICON_BUTTON} title="Chat Settings">
                     <Settings2 size={14} />
                   </button>
@@ -10443,6 +10462,21 @@ function GameSurfaceComponent({
                         >
                           <Image size={14} />
                         </button>
+                        {onSwitchChat ? (
+                          <button
+                            onClick={() => {
+                              setMobileActionsOpen(false);
+                              handleSwitchConnectedChat();
+                            }}
+                            className={GAME_MOBILE_ICON_BUTTON}
+                            title={connectedChatName ? `Switch to ${connectedChatName}` : "Switch to connected chat"}
+                            aria-label={
+                              connectedChatName ? `Switch to ${connectedChatName}` : "Switch to connected chat"
+                            }
+                          >
+                            <ArrowRightLeft size={14} />
+                          </button>
+                        ) : null}
                         <button
                           onClick={(event) => {
                             handleOpenSettingsPanel(event);

--- a/packages/client/src/components/layout/ModalRenderer.tsx
+++ b/packages/client/src/components/layout/ModalRenderer.tsx
@@ -4,7 +4,7 @@
 import { lazy, Suspense } from "react";
 import { useUIStore } from "../../stores/ui.store";
 import type { AgentData } from "../modals/EditAgentModal";
-import type { LorebookCategory, LorebookScope } from "@marinara-engine/shared";
+import type { LorebookCategory, LorebookScope, ScenePromptPreferences } from "@marinara-engine/shared";
 
 const CreateCharacterModal = lazy(() =>
   import("../modals/CreateCharacterModal").then((module) => ({ default: module.CreateCharacterModal })),
@@ -53,6 +53,11 @@ const DocsViewerModal = lazy(() =>
 );
 const AboutMeViewerModal = lazy(() =>
   import("../modals/AboutMeViewerModal").then((module) => ({ default: module.AboutMeViewerModal })),
+);
+const ScenePromptPreferencesModal = lazy(() =>
+  import("../modals/ScenePromptPreferencesModal").then((module) => ({
+    default: module.ScenePromptPreferencesModal,
+  })),
 );
 
 export function ModalRenderer() {
@@ -142,6 +147,18 @@ export function ModalRenderer() {
           nameColor={(modal?.props?.nameColor as string | null) ?? null}
           status={(modal?.props?.status as "online" | "idle" | "dnd" | "offline" | null) ?? null}
           activity={(modal?.props?.activity as string | null) ?? null}
+        />
+      );
+      break;
+    case "scene-prompt-preferences":
+      content = (
+        <ScenePromptPreferencesModal
+          open
+          onClose={closeModal}
+          initialPreferences={modal?.props?.initialPreferences as ScenePromptPreferences}
+          sourceLabel={(modal?.props?.sourceLabel as string | null) ?? null}
+          onSubmit={modal?.props?.onSubmit as (preferences: ScenePromptPreferences) => void}
+          onCancel={modal?.props?.onCancel as (() => void) | undefined}
         />
       );
       break;

--- a/packages/client/src/components/modals/ScenePromptPreferencesModal.tsx
+++ b/packages/client/src/components/modals/ScenePromptPreferencesModal.tsx
@@ -1,0 +1,154 @@
+import { useEffect, useState, type ReactNode } from "react";
+import type { ScenePromptPreferences, ScenePromptPov, ScenePromptTense } from "@marinara-engine/shared";
+import { Modal } from "../ui/Modal";
+import { normalizeScenePromptPreferences } from "../../stores/ui.store";
+
+interface ScenePromptPreferencesModalProps {
+  open: boolean;
+  onClose: () => void;
+  initialPreferences: ScenePromptPreferences;
+  sourceLabel?: string | null;
+  onSubmit: (preferences: ScenePromptPreferences) => void;
+  onCancel?: () => void;
+}
+
+const POV_OPTIONS: Array<{ id: ScenePromptPov; label: string }> = [
+  { id: "first_person", label: "First Person" },
+  { id: "second_person", label: "Second Person" },
+  { id: "third_person", label: "Third Person" },
+];
+
+const TENSE_OPTIONS: Array<{ id: ScenePromptTense; label: string }> = [
+  { id: "past", label: "Past" },
+  { id: "present", label: "Present" },
+  { id: "future", label: "Future" },
+];
+
+export function ScenePromptPreferencesModal({
+  open,
+  onClose,
+  initialPreferences,
+  sourceLabel,
+  onSubmit,
+  onCancel,
+}: ScenePromptPreferencesModalProps) {
+  const initial = normalizeScenePromptPreferences(initialPreferences);
+  const [pov, setPov] = useState<ScenePromptPov>(initial.pov);
+  const [tense, setTense] = useState<ScenePromptTense>(initial.tense);
+  const [extraInstructions, setExtraInstructions] = useState(initial.extraInstructions ?? "");
+
+  useEffect(() => {
+    const next = normalizeScenePromptPreferences(initialPreferences);
+    setPov(next.pov);
+    setTense(next.tense);
+    setExtraInstructions(next.extraInstructions ?? "");
+  }, [initialPreferences]);
+
+  const handleClose = () => {
+    onCancel?.();
+    onClose();
+  };
+
+  const handleSubmit = () => {
+    onSubmit(
+      normalizeScenePromptPreferences({
+        pov,
+        tense,
+        extraInstructions,
+      }),
+    );
+  };
+
+  return (
+    <Modal open={open} onClose={handleClose} title="Scene Prompt Setup" width="max-w-lg">
+      <div className="flex flex-col gap-4 p-4">
+        <div className="space-y-1">
+          <p className="text-sm font-semibold text-[var(--foreground)]">
+            {sourceLabel ? `${sourceLabel} wants to start a scene.` : "Start a scene."}
+          </p>
+          <p className="text-xs leading-relaxed text-[var(--muted-foreground)]">
+            Pick the writing shape before Marinara plans the scene.
+          </p>
+        </div>
+
+        <OptionGroup label="POV">
+          {POV_OPTIONS.map((option) => (
+            <OptionButton
+              key={option.id}
+              active={pov === option.id}
+              label={option.label}
+              onClick={() => setPov(option.id)}
+            />
+          ))}
+        </OptionGroup>
+
+        <OptionGroup label="Tense">
+          {TENSE_OPTIONS.map((option) => (
+            <OptionButton
+              key={option.id}
+              active={tense === option.id}
+              label={option.label}
+              onClick={() => setTense(option.id)}
+            />
+          ))}
+        </OptionGroup>
+
+        <label className="space-y-1.5">
+          <span className="text-xs font-semibold text-[var(--foreground)]">Extra instructions</span>
+          <textarea
+            value={extraInstructions}
+            onChange={(event) => setExtraInstructions(event.target.value)}
+            maxLength={2000}
+            rows={4}
+            placeholder="Optional notes for the generated scene prompt."
+            className="min-h-24 w-full resize-y rounded-lg border border-[var(--border)] bg-[var(--secondary)] p-3 text-sm leading-relaxed text-[var(--foreground)] outline-none placeholder:text-[var(--muted-foreground)]/50 focus:border-[var(--primary)]/45 focus:ring-1 focus:ring-[var(--primary)]/25"
+          />
+        </label>
+
+        <div className="flex items-center justify-end gap-2 border-t border-[var(--border)] pt-3">
+          <button
+            type="button"
+            onClick={handleClose}
+            className="rounded-lg border border-[var(--border)] px-3 py-2 text-sm font-semibold text-[var(--muted-foreground)] transition-colors hover:bg-[var(--accent)] hover:text-[var(--foreground)]"
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            onClick={handleSubmit}
+            className="rounded-lg bg-[var(--primary)] px-3 py-2 text-sm font-semibold text-[var(--primary-foreground)] transition-opacity hover:opacity-90"
+          >
+            Plan Scene
+          </button>
+        </div>
+      </div>
+    </Modal>
+  );
+}
+
+function OptionGroup({ label, children }: { label: string; children: ReactNode }) {
+  return (
+    <div className="space-y-1.5">
+      <p className="text-xs font-semibold text-[var(--foreground)]">{label}</p>
+      <div className="grid grid-cols-3 gap-1.5">{children}</div>
+    </div>
+  );
+}
+
+function OptionButton({ active, label, onClick }: { active: boolean; label: string; onClick: () => void }) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      aria-pressed={active}
+      className={[
+        "min-h-10 rounded-lg border px-2 text-xs font-semibold transition-colors",
+        active
+          ? "border-[var(--primary)] bg-[var(--primary)]/20 text-[var(--foreground)]"
+          : "border-[var(--border)] bg-[var(--secondary)] text-[var(--muted-foreground)] hover:bg-[var(--accent)] hover:text-[var(--foreground)]",
+      ].join(" ")}
+    >
+      {label}
+    </button>
+  );
+}

--- a/packages/client/src/components/panels/SettingsPanel.tsx
+++ b/packages/client/src/components/panels/SettingsPanel.tsx
@@ -1313,7 +1313,7 @@ const TRACKER_PANEL_CARD_OPTIONS: Record<TrackerDataPanelSection, { label: strin
 };
 
 const QUOTE_FORMAT_OPTIONS: Array<{ id: QuoteFormat; label: string; sample: string }> = [
-  { id: "straight", label: "Straight", sample: '"Hello", it\'s me.' },
+  { id: "straight", label: "Straight", sample: '"Hello," it\'s me.' },
   { id: "typographic", label: "Typographic", sample: "\u201cHello,\u201d it\u2019s me." },
 ];
 

--- a/packages/client/src/hooks/use-chat-summary-prompts.ts
+++ b/packages/client/src/hooks/use-chat-summary-prompts.ts
@@ -1,0 +1,90 @@
+// ──────────────────────────────────────────────
+// Hook: Global Roleplay Chat Summary prompt settings
+// ──────────────────────────────────────────────
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import {
+  CHAT_SUMMARY_PROMPT_SETTINGS_KEY,
+  type ChatSummaryPromptSettings,
+  type ChatSummaryPromptTemplate,
+} from "@marinara-engine/shared";
+import { api } from "../lib/api-client";
+
+type AppSettingResponse = { value: string | null };
+type ChatSummaryPromptSettingsState = ChatSummaryPromptSettings & {
+  hasPersistedSettings: boolean;
+};
+
+export const chatSummaryPromptKeys = {
+  settings: ["app-settings", CHAT_SUMMARY_PROMPT_SETTINGS_KEY] as const,
+};
+
+function normalizeTemplates(value: unknown): ChatSummaryPromptTemplate[] {
+  if (!Array.isArray(value)) return [];
+  const seen = new Set<string>();
+  const templates: ChatSummaryPromptTemplate[] = [];
+  for (const item of value) {
+    if (!item || typeof item !== "object" || Array.isArray(item)) continue;
+    const record = item as Record<string, unknown>;
+    const id = typeof record.id === "string" ? record.id.trim() : "";
+    const name = typeof record.name === "string" ? record.name.trim() : "";
+    const prompt = typeof record.prompt === "string" ? record.prompt.trim() : "";
+    if (!id || !name || !prompt || seen.has(id)) continue;
+    seen.add(id);
+    templates.push({ id, name, prompt });
+  }
+  return templates;
+}
+
+export function normalizeChatSummaryPromptSettings(value: unknown): ChatSummaryPromptSettings {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return { templates: [], activeTemplateId: null };
+  }
+  const record = value as Record<string, unknown>;
+  const templates = normalizeTemplates(record.templates);
+  const activeTemplateId =
+    typeof record.activeTemplateId === "string" && record.activeTemplateId.trim()
+      ? record.activeTemplateId.trim()
+      : null;
+  return {
+    templates,
+    activeTemplateId:
+      activeTemplateId && templates.some((template) => template.id === activeTemplateId) ? activeTemplateId : null,
+  };
+}
+
+function parseSettingsValue(value: string | null): ChatSummaryPromptSettingsState {
+  const hasPersistedSettings = typeof value === "string" && value.trim().length > 0;
+  if (!hasPersistedSettings) return { templates: [], activeTemplateId: null, hasPersistedSettings };
+  try {
+    return { ...normalizeChatSummaryPromptSettings(JSON.parse(value) as unknown), hasPersistedSettings };
+  } catch {
+    return { templates: [], activeTemplateId: null, hasPersistedSettings };
+  }
+}
+
+export function useChatSummaryPromptSettings() {
+  return useQuery({
+    queryKey: chatSummaryPromptKeys.settings,
+    queryFn: async () => {
+      const result = await api.get<AppSettingResponse>(`/app-settings/${CHAT_SUMMARY_PROMPT_SETTINGS_KEY}`);
+      return parseSettingsValue(result.value);
+    },
+    staleTime: 5 * 60_000,
+  });
+}
+
+export function useUpdateChatSummaryPromptSettings() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: async (settings: ChatSummaryPromptSettings) => {
+      const normalized = normalizeChatSummaryPromptSettings(settings);
+      await api.put(`/app-settings/${CHAT_SUMMARY_PROMPT_SETTINGS_KEY}`, {
+        value: JSON.stringify(normalized),
+      });
+      return normalized;
+    },
+    onSuccess: (settings) => {
+      qc.setQueryData(chatSummaryPromptKeys.settings, { ...settings, hasPersistedSettings: true });
+    },
+  });
+}

--- a/packages/client/src/hooks/use-generate.ts
+++ b/packages/client/src/hooks/use-generate.ts
@@ -10,6 +10,7 @@ import { formatAgentFailuresToast, toAgentFailure, type AgentFailure } from "../
 import { chatBackgroundMetadataToUrl } from "../lib/backgrounds";
 import { formatGenerationParameterError } from "../lib/generation-parameter-errors";
 import { requestChatScrollToBottom } from "../lib/chat-scroll-events";
+import { startSceneWithPromptPreferences } from "../lib/scene-generation";
 import { agentKeys } from "./use-agents";
 import { discardPendingGameStatePatch } from "./use-game-state-patcher";
 import { turnGameKeys } from "./turn-game-keys";
@@ -2233,6 +2234,36 @@ export function useGenerate() {
                   .getState()
                   .setChatBackground(`/api/backgrounds/file/${encodeURIComponent(sceneData.background)}`);
               }
+              break;
+            }
+
+            case "scene_requested": {
+              const sceneData = event.data as {
+                originChatId?: string;
+                prompt?: string;
+                background?: string | null;
+                plan?: string | null;
+                initiatorCharId?: string | null;
+                initiatorCharName?: string | null;
+              };
+              const sceneOriginChatId = sceneData.originChatId || params.chatId;
+              if (!isChatSurfaceVisible(sceneOriginChatId)) {
+                break;
+              }
+              void startSceneWithPromptPreferences({
+                chatId: sceneOriginChatId,
+                prompt: sceneData.prompt ?? "",
+                background: sceneData.background ?? null,
+                planHint: sceneData.plan ?? null,
+                initiatorCharId: sceneData.initiatorCharId ?? null,
+                initiatorCharName: sceneData.initiatorCharName ?? "Character",
+                connectionId: params.connectionId,
+                onCreated: () => {
+                  qc.invalidateQueries({ queryKey: chatKeys.all });
+                },
+              }).catch((error) => {
+                console.warn("[scene] Failed to handle requested scene:", error);
+              });
               break;
             }
 

--- a/packages/client/src/hooks/use-settings-sync.ts
+++ b/packages/client/src/hooks/use-settings-sync.ts
@@ -20,6 +20,7 @@ import {
   normalizeTrackerPanelSizeProfile,
   normalizeTrackerTemperatureUnit,
   normalizeTrackerThoughtBubbleDisplay,
+  normalizeScenePromptPreferences,
   pickSyncedSettings,
   useUIStore,
 } from "../stores/ui.store";
@@ -197,6 +198,9 @@ export function useSettingsSync() {
               parsed.settings.quoteFormat = normalizeQuoteFormat(parsed.settings.quoteFormat);
               parsed.settings.imageStyleProfiles = normalizeImageStyleProfileSettings(
                 parsed.settings.imageStyleProfiles,
+              );
+              parsed.settings.scenePromptPreferences = normalizeScenePromptPreferences(
+                parsed.settings.scenePromptPreferences,
               );
 
               const serverUpdatedAt = parsed.updatedAt;

--- a/packages/client/src/lib/scene-generation.ts
+++ b/packages/client/src/lib/scene-generation.ts
@@ -1,0 +1,109 @@
+import { toast } from "sonner";
+import type {
+  SceneCreateResponse,
+  SceneFullPlan,
+  ScenePlanResponse,
+  ScenePromptPreferences,
+} from "@marinara-engine/shared";
+import { api } from "./api-client";
+import { useChatStore } from "../stores/chat.store";
+import { normalizeScenePromptPreferences, useUIStore } from "../stores/ui.store";
+
+export interface StartSceneOptions {
+  chatId: string;
+  prompt: string;
+  initiatorCharId?: string | null;
+  initiatorCharName?: string | null;
+  background?: string | null;
+  planHint?: string | null;
+  connectionId?: string | null;
+  onCreated?: (response: SceneCreateResponse) => void;
+}
+
+let pendingScenePromptPreferencesSettle: ((preferences: ScenePromptPreferences | null) => void) | null = null;
+
+export function requestScenePromptPreferences(sourceLabel?: string | null): Promise<ScenePromptPreferences | null> {
+  return new Promise((resolve) => {
+    let settled = false;
+    const settle = (preferences: ScenePromptPreferences | null) => {
+      if (settled) return;
+      settled = true;
+      if (pendingScenePromptPreferencesSettle === settle) {
+        pendingScenePromptPreferencesSettle = null;
+      }
+      resolve(preferences);
+    };
+
+    pendingScenePromptPreferencesSettle?.(null);
+    pendingScenePromptPreferencesSettle = settle;
+
+    const ui = useUIStore.getState();
+    ui.openModal("scene-prompt-preferences", {
+      sourceLabel: sourceLabel ?? null,
+      initialPreferences: ui.scenePromptPreferences,
+      onSubmit: (preferences: ScenePromptPreferences) => {
+        const normalized = normalizeScenePromptPreferences(preferences);
+        useUIStore.getState().setScenePromptPreferences(normalized);
+        useUIStore.getState().closeModal();
+        settle(normalized);
+      },
+      onCancel: () => {
+        useUIStore.getState().closeModal();
+        settle(null);
+      },
+    });
+  });
+}
+
+export async function startSceneWithPromptPreferences(options: StartSceneOptions): Promise<SceneCreateResponse | null> {
+  const preferences = await requestScenePromptPreferences(options.initiatorCharName ?? null);
+  if (!preferences) return null;
+
+  const toastId = toast.loading("Planning scene...", { icon: "🎬" });
+  let plan: SceneFullPlan | null = null;
+  try {
+    const planningPrompt = [options.prompt, options.planHint ? `Suggested plot plan:\n${options.planHint}` : ""]
+      .map((part) => part.trim())
+      .filter(Boolean)
+      .join("\n\n");
+    const planRes = await api.post<ScenePlanResponse>("/scene/plan", {
+      chatId: options.chatId,
+      prompt: planningPrompt,
+      connectionId: options.connectionId ?? null,
+      promptPreferences: preferences,
+    });
+    plan = planRes.plan;
+    if (!plan) {
+      toast.error(planRes.error || "Scene planning returned empty result. Try again.", { id: toastId });
+      return null;
+    }
+  } catch {
+    toast.error("Failed to plan scene. Check your API connection.", { id: toastId });
+    return null;
+  }
+
+  if (options.background) {
+    plan.background = options.background;
+  }
+
+  toast.loading("Creating scene...", { id: toastId, icon: "🎬" });
+  try {
+    const response = await api.post<SceneCreateResponse>("/scene/create", {
+      originChatId: options.chatId,
+      initiatorCharId: options.initiatorCharId ?? null,
+      plan,
+      connectionId: options.connectionId ?? null,
+    });
+
+    useChatStore.getState().setActiveChatId(response.chatId);
+    if (response.background) {
+      useUIStore.getState().setChatBackground(`/api/backgrounds/file/${encodeURIComponent(response.background)}`);
+    }
+    options.onCreated?.(response);
+    toast.success(`Scene created: ${response.chatName}`, { id: toastId, icon: "🎬" });
+    return response;
+  } catch {
+    toast.error("Failed to create scene chat.", { id: toastId });
+    return null;
+  }
+}

--- a/packages/client/src/lib/slash-commands.ts
+++ b/packages/client/src/lib/slash-commands.ts
@@ -8,13 +8,12 @@ import { useUnoGameStore } from "../stores/uno-game.store";
 import { useChessGameStore } from "../stores/chess-game.store";
 import { useGalleryStore } from "../stores/gallery.store";
 import { toast } from "sonner";
+import { startSceneWithPromptPreferences } from "./scene-generation";
 import {
   SUPPORTED_MACROS,
   buildGuidedGenerationInstructionMessage,
   buildNarratorInstructionMessage,
   normalizeTextForMatch,
-  type SceneCreateResponse,
-  type ScenePlanResponse,
 } from "@marinara-engine/shared";
 
 export interface SlashCommand {
@@ -1074,50 +1073,17 @@ const COMMANDS: SlashCommand[] = [
         }
       }
 
-      // Step 1: Ask the LLM to plan the scene (comprehensive plan)
-      const planToastId = toast.loading("Planning scene...", { icon: "🎬" });
-      let planRes: ScenePlanResponse;
-      try {
-        planRes = await api.post<ScenePlanResponse>("/scene/plan", {
-          chatId: ctx.chatId,
-          prompt,
-          connectionId: null,
-        });
-      } catch {
-        toast.dismiss(planToastId);
-        return { handled: true, feedback: "Failed to plan scene. Check your API connection." };
-      }
-
-      if (!planRes.plan) {
-        toast.dismiss(planToastId);
-        return { handled: true, feedback: planRes.error || "Scene planning returned empty result. Try again." };
-      }
-
-      // Step 2: Create the scene chat using the full plan
-      toast.loading("Creating scene...", { id: planToastId, icon: "🎬" });
-      try {
-        const res = await api.post<SceneCreateResponse>("/scene/create", {
-          originChatId: ctx.chatId,
-          initiatorCharId: null, // user-initiated
-          plan: planRes.plan,
-          connectionId: null,
-        });
-
-        // Invalidate chats so the new scene appears + navigate to it
-        ctx.invalidate();
-        useChatStore.getState().setActiveChatId(res.chatId);
-
-        // Apply background if the plan chose one
-        if (res.background) {
-          useUIStore.getState().setChatBackground(`/api/backgrounds/file/${encodeURIComponent(res.background)}`);
-        }
-
-        toast.success(`Scene created: ${res.chatName}`, { id: planToastId, icon: "🎬" });
-        return { handled: true };
-      } catch {
-        toast.dismiss(planToastId);
-        return { handled: true, feedback: "Failed to create scene chat." };
-      }
+      await startSceneWithPromptPreferences({
+        chatId: ctx.chatId,
+        prompt,
+        initiatorCharId: null,
+        connectionId: null,
+        onCreated: () => {
+          // Invalidate chats so the new scene appears in the sidebar.
+          ctx.invalidate();
+        },
+      });
+      return { handled: true };
     },
   },
   {

--- a/packages/client/src/stores/ui.store.ts
+++ b/packages/client/src/stores/ui.store.ts
@@ -10,6 +10,7 @@ import {
   type ImageStyleProfileSettings,
   type LorebookCategory,
   type QuoteFormat,
+  type ScenePromptPreferences,
 } from "@marinara-engine/shared";
 import { isCssGradient, RAINBOW_GRADIENT_PRESET } from "../lib/css-colors";
 import { announceChatFloatingUiDismiss } from "../lib/chat-floating-ui-events";
@@ -159,6 +160,11 @@ const DEFAULT_SUMMARY_POPOVER_SETTINGS: SummaryPopoverSettings = {
   rangeEnd: null,
   hideSummarisedMessages: false,
   collapseHiddenMessages: false,
+};
+const DEFAULT_SCENE_PROMPT_PREFERENCES: ScenePromptPreferences = {
+  pov: "third_person",
+  tense: "present",
+  extraInstructions: "",
 };
 
 function normalizeUserActivity(activity: string): string {
@@ -310,6 +316,21 @@ function normalizeSummaryPopoverSettings(value: unknown): SummaryPopoverSettings
     hideSummarisedMessages: raw.hideSummarisedMessages === true,
     collapseHiddenMessages: raw.collapseHiddenMessages === true,
   };
+}
+
+export function normalizeScenePromptPreferences(value: unknown): ScenePromptPreferences {
+  const raw = typeof value === "object" && value !== null ? (value as Record<string, unknown>) : {};
+  const pov =
+    raw.pov === "first_person" || raw.pov === "second_person" || raw.pov === "third_person"
+      ? raw.pov
+      : DEFAULT_SCENE_PROMPT_PREFERENCES.pov;
+  const tense =
+    raw.tense === "past" || raw.tense === "present" || raw.tense === "future"
+      ? raw.tense
+      : DEFAULT_SCENE_PROMPT_PREFERENCES.tense;
+  const extraInstructions =
+    typeof raw.extraInstructions === "string" ? raw.extraInstructions.trim().slice(0, 2000) : "";
+  return { pov, tense, extraInstructions };
 }
 
 export function normalizeConversationMessageStyle(value: unknown): ConversationMessageStyle {
@@ -599,6 +620,8 @@ interface UIState {
   editMessageOnDoubleClick: boolean;
   /** Persisted controls shown in the Chat Summary popover settings window. */
   summaryPopoverSettings: SummaryPopoverSettings;
+  /** Last-used preferences for generating character/user-initiated roleplay scenes. */
+  scenePromptPreferences: ScenePromptPreferences;
 
   // ── Text Appearance ──
   /** Color for narrator text in RP mode (empty = default amber) */
@@ -864,6 +887,7 @@ interface UIState {
   setEditLastMessageOnArrowUp: (v: boolean) => void;
   setEditMessageOnDoubleClick: (v: boolean) => void;
   setSummaryPopoverSettings: (settings: Partial<SummaryPopoverSettings>) => void;
+  setScenePromptPreferences: (preferences: ScenePromptPreferences) => void;
   setNarrationFontColor: (v: string) => void;
   setNarrationOpacity: (v: number) => void;
   setChatFontColor: (v: string) => void;
@@ -1064,6 +1088,7 @@ export function pickSyncedSettings(state: UIState) {
     editLastMessageOnArrowUp: state.editLastMessageOnArrowUp,
     editMessageOnDoubleClick: state.editMessageOnDoubleClick,
     summaryPopoverSettings: state.summaryPopoverSettings,
+    scenePromptPreferences: state.scenePromptPreferences,
     narrationFontColor: state.narrationFontColor,
     narrationOpacity: state.narrationOpacity,
     chatFontColor: state.chatFontColor,
@@ -1240,6 +1265,7 @@ export const useUIStore = create<UIState>()(
       editLastMessageOnArrowUp: true,
       editMessageOnDoubleClick: true,
       summaryPopoverSettings: DEFAULT_SUMMARY_POPOVER_SETTINGS,
+      scenePromptPreferences: DEFAULT_SCENE_PROMPT_PREFERENCES,
       narrationFontColor: "",
       narrationOpacity: 80,
       chatFontColor: "",
@@ -1815,6 +1841,8 @@ export const useUIStore = create<UIState>()(
             ...settings,
           }),
         })),
+      setScenePromptPreferences: (preferences) =>
+        set({ scenePromptPreferences: normalizeScenePromptPreferences(preferences) }),
       setNarrationFontColor: (v) => set({ narrationFontColor: v }),
       setNarrationOpacity: (v) => set({ narrationOpacity: Math.max(0, Math.min(100, v)) }),
       setChatFontColor: (v) => set({ chatFontColor: v }),
@@ -1979,7 +2007,7 @@ export const useUIStore = create<UIState>()(
     }),
     {
       name: "marinara-engine-ui",
-      version: 69,
+      version: 70,
       // Debounce localStorage writes to avoid sync I/O on every state change
       storage: createJSONStorage(() => {
         let timer: ReturnType<typeof setTimeout> | null = null;
@@ -2360,6 +2388,8 @@ export const useUIStore = create<UIState>()(
           persisted.ttsLineVolume = 50;
         }
         persisted.ttsLineVolume = Math.max(0, Math.min(100, Math.round(persisted.ttsLineVolume)));
+        // v69 -> v70: remember scene prompt setup choices.
+        persisted.scenePromptPreferences = normalizeScenePromptPreferences(persisted.scenePromptPreferences);
         // v42 -> v44: reconcile parallel v43 UI preference additions.
         if (version <= 43 && persisted.youtubePlayerEnabled === undefined) {
           persisted.youtubePlayerEnabled = true;
@@ -2609,6 +2639,7 @@ export const useUIStore = create<UIState>()(
         editLastMessageOnArrowUp: state.editLastMessageOnArrowUp,
         editMessageOnDoubleClick: state.editMessageOnDoubleClick,
         summaryPopoverSettings: state.summaryPopoverSettings,
+        scenePromptPreferences: state.scenePromptPreferences,
         narrationFontColor: state.narrationFontColor,
         narrationOpacity: state.narrationOpacity,
         chatFontColor: state.chatFontColor,

--- a/packages/server/src/routes/app-settings.routes.ts
+++ b/packages/server/src/routes/app-settings.routes.ts
@@ -2,10 +2,14 @@
 // Routes: Synced App Settings (key/value)
 // ──────────────────────────────────────────────
 import type { FastifyInstance } from "fastify";
-import { VIDEO_GENERATION_SETTINGS_KEY, appSettingsUpdateSchema } from "@marinara-engine/shared";
+import {
+  CHAT_SUMMARY_PROMPT_SETTINGS_KEY,
+  VIDEO_GENERATION_SETTINGS_KEY,
+  appSettingsUpdateSchema,
+} from "@marinara-engine/shared";
 import { createAppSettingsStorage } from "../services/storage/app-settings.storage.js";
 
-const ALLOWED_KEYS = new Set(["ui", VIDEO_GENERATION_SETTINGS_KEY]);
+const ALLOWED_KEYS = new Set(["ui", CHAT_SUMMARY_PROMPT_SETTINGS_KEY, VIDEO_GENERATION_SETTINGS_KEY]);
 
 export async function appSettingsRoutes(app: FastifyInstance) {
   const storage = createAppSettingsStorage(app.db);

--- a/packages/server/src/routes/chats.routes.ts
+++ b/packages/server/src/routes/chats.routes.ts
@@ -9,11 +9,11 @@ import {
   createChatSchema,
   createMessageSchema,
   appendChatSummaryEntryToMetadata,
+  CHAT_SUMMARY_PROMPT_SETTINGS_KEY,
   compileChatSummaryEntries,
   createChatSummaryEntry,
   DEFAULT_CONVERSATION_PROMPT,
   DEFAULT_GAME_SYSTEM_PROMPT,
-  DEFAULT_CHAT_SUMMARY_PROMPT,
   markAutonomousUnreadSchema,
   nameToXmlTag,
   normalizeChatSummaryEntries,
@@ -40,6 +40,7 @@ import type {
   RPGStatsConfig,
 } from "@marinara-engine/shared";
 import { createChatsStorage } from "../services/storage/chats.storage.js";
+import { createAppSettingsStorage } from "../services/storage/app-settings.storage.js";
 import { createCharactersStorage } from "../services/storage/characters.storage.js";
 import { createConnectionsStorage } from "../services/storage/connections.storage.js";
 import { createLorebooksStorage } from "../services/storage/lorebooks.storage.js";
@@ -90,7 +91,10 @@ import { sanitizeGameNpcAvatarUrls } from "../services/game/npc-avatar-utils.js"
 import { buildCommittedTrackerContextBlock } from "../services/generation/committed-tracker-context.js";
 import { parseLorebookWriteApprovalText } from "./generate/agent-write-approval.js";
 import { persistLorebookKeeperUpdates } from "./generate/lorebook-keeper-utils.js";
-import { clampRoleplaySummaryMaxTokens } from "../services/generation/roleplay-summary-runtime.js";
+import {
+  clampRoleplaySummaryMaxTokens,
+  resolveChatSummaryPrompt,
+} from "../services/generation/roleplay-summary-runtime.js";
 
 type TrackerWrapFormat = "xml" | "markdown" | "none";
 type EntryStateOverrides = Record<string, { ephemeral?: number | null; enabled?: boolean }>;
@@ -402,6 +406,7 @@ function resolveEntryStateOverrides(value: unknown): EntryStateOverrides | undef
 
 export async function chatsRoutes(app: FastifyInstance) {
   const storage = createChatsStorage(app.db);
+  const appSettings = createAppSettingsStorage(app.db);
 
   const cleanupEmptyRoleplayDmChats = async () => {
     const allChats = await storage.list();
@@ -3383,21 +3388,12 @@ export async function chatsRoutes(app: FastifyInstance) {
         : typeof chatMeta.activeSummaryPromptTemplateId === "string" && chatMeta.activeSummaryPromptTemplateId.trim()
           ? chatMeta.activeSummaryPromptTemplateId.trim()
           : null;
-    const summaryPromptTemplates = Array.isArray(chatMeta.summaryPromptTemplates)
-      ? (chatMeta.summaryPromptTemplates as Array<Record<string, unknown>>)
-      : [];
-    const selectedSummaryPrompt = requestedPromptTemplateId
-      ? summaryPromptTemplates.find(
-          (template) =>
-            template.id === requestedPromptTemplateId &&
-            typeof template.prompt === "string" &&
-            template.prompt.trim().length > 0,
-        )
-      : null;
-    const summaryPrompt =
-      typeof selectedSummaryPrompt?.prompt === "string"
-        ? selectedSummaryPrompt.prompt.trim()
-        : DEFAULT_CHAT_SUMMARY_PROMPT;
+    const globalSummaryPromptSettings = await appSettings.get(CHAT_SUMMARY_PROMPT_SETTINGS_KEY);
+    const summaryPrompt = resolveChatSummaryPrompt({
+      requestedTemplateId: requestedPromptTemplateId,
+      chatMetadata: chatMeta,
+      globalSettingsValue: globalSummaryPromptSettings,
+    });
 
     const messages: Array<{ role: "system" | "user"; content: string }> = [
       { role: "system", content: summaryPrompt },

--- a/packages/server/src/routes/generate.routes.ts
+++ b/packages/server/src/routes/generate.routes.ts
@@ -24,6 +24,7 @@ import {
   normalizeTrackerFieldLocksForState,
   trackerFieldLocksAreEmpty,
   customAgentHasCapability,
+  CHAT_SUMMARY_PROMPT_SETTINGS_KEY,
   DEFAULT_CONVERSATION_PROMPT,
   unwrapConversationInstructions,
   findKnownModel,
@@ -58,6 +59,7 @@ import { createCustomEmojisStorage } from "../services/storage/custom-emojis.sto
 import { createCustomStickersStorage } from "../services/storage/custom-stickers.storage.js";
 import { createCharacterGalleryStorage } from "../services/storage/character-gallery.storage.js";
 import { createPersonaGalleryStorage } from "../services/storage/persona-gallery.storage.js";
+import { createAppSettingsStorage } from "../services/storage/app-settings.storage.js";
 import { buildLorebookSemanticEmbeddingsById } from "../services/lorebook/embeddings.js";
 import { applyRegexScriptsToPromptMessages } from "../services/regex/regex-application.js";
 import { createPromptOverridesStorage } from "../services/storage/prompt-overrides.storage.js";
@@ -310,7 +312,7 @@ import {
   clampRoleplaySummaryMaxTokens,
   isAutomaticRoleplaySummaryEnabled,
   parseChatSummaryText,
-  resolveChatSummaryPromptFromMetadata,
+  resolveChatSummaryPrompt,
   withoutRetiredChatSummaryAgentIds,
 } from "../services/generation/roleplay-summary-runtime.js";
 import { getMaxToolRounds } from "../config/runtime-config.js";
@@ -500,6 +502,7 @@ export async function generateRoutes(app: FastifyInstance) {
   const customStickersStore = createCustomStickersStorage(app.db);
   const characterGallery = createCharacterGalleryStorage(app.db);
   const personaGallery = createPersonaGalleryStorage(app.db);
+  const appSettings = createAppSettingsStorage(app.db);
 
   /**
    * In-memory cache for OpenAI Responses API encrypted reasoning items.
@@ -1970,10 +1973,12 @@ export async function generateRoutes(app: FastifyInstance) {
             ...(convoProfileBlocks.behaviorPostHistoryBlock
               ? [{ role: "user" as const, content: convoProfileBlocks.behaviorPostHistoryBlock }]
               : []),
-            ...(conversationContextMacroSlots.context ? [] : [{ role: "user" as const, content: contextBlock }]),
           ];
-          if (conversationContextMacroSlots.context) {
-            replaceConversationContextMacro(finalMessages, "context", contextBlock);
+          const conversationContextInserted = conversationContextMacroSlots.context
+            ? replaceConversationContextMacro(finalMessages, "context", contextBlock)
+            : false;
+          if (!conversationContextInserted) {
+            finalMessages.push({ role: "user" as const, content: contextBlock });
           }
           if (conversationContextMacroSlots.reactRules) {
             replaceConversationContextMacro(finalMessages, "reactRules", conversationReactRules);
@@ -5849,9 +5854,16 @@ export async function generateRoutes(app: FastifyInstance) {
             .map((message: any) => `[${message.role}]: ${(message.content as string).slice(0, 2000)}`)
             .join("\n\n");
           const previousSummary = typeof chatMeta.summary === "string" ? chatMeta.summary.trim() : "";
+          const globalSummaryPromptSettings = await appSettings.get(CHAT_SUMMARY_PROMPT_SETTINGS_KEY);
           const result = await summaryProvider.chatComplete(
             [
-              { role: "system", content: resolveChatSummaryPromptFromMetadata(chatMeta) },
+              {
+                role: "system",
+                content: resolveChatSummaryPrompt({
+                  chatMetadata: chatMeta,
+                  globalSettingsValue: globalSummaryPromptSettings,
+                }),
+              },
               {
                 role: "user",
                 content:
@@ -7883,13 +7895,11 @@ export async function generateRoutes(app: FastifyInstance) {
                   command,
                   characterId,
                   chatId: input.chatId,
-                  app,
                   chars,
-                  chats,
-                  sendSceneCreated: (data) => {
+                  sendSceneRequested: (data) => {
                     reply.raw.write(
                       `data: ${JSON.stringify({
-                        type: "scene_created",
+                        type: "scene_requested",
                         data,
                       })}\n\n`,
                     );

--- a/packages/server/src/routes/scene.routes.ts
+++ b/packages/server/src/routes/scene.routes.ts
@@ -28,6 +28,7 @@ import type {
   SceneForkResponse,
   ScenePlanRequest,
   ScenePlanResponse,
+  ScenePromptPreferences,
   SceneFullPlan,
 } from "@marinara-engine/shared";
 
@@ -43,6 +44,43 @@ const SCENE_GUIDELINES = [
   `    - Portray violence in gory detail, blood squirting around like in a slasher movie.`,
   `</guidelines>`,
 ].join("\n");
+
+function normalizeScenePromptPreferences(value: unknown): ScenePromptPreferences | null {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return null;
+  const record = value as Record<string, unknown>;
+  const pov =
+    record.pov === "first_person" || record.pov === "second_person" || record.pov === "third_person"
+      ? record.pov
+      : null;
+  const tense =
+    record.tense === "past" || record.tense === "present" || record.tense === "future" ? record.tense : null;
+  if (!pov || !tense) return null;
+  const extraInstructions =
+    typeof record.extraInstructions === "string" ? record.extraInstructions.trim().slice(0, 2000) : "";
+  return { pov, tense, extraInstructions };
+}
+
+function formatScenePromptPreferences(preferences: ScenePromptPreferences | null): string {
+  if (!preferences) return "";
+  const povLabel: Record<ScenePromptPreferences["pov"], string> = {
+    first_person: "First Person",
+    second_person: "Second Person",
+    third_person: "Third Person",
+  };
+  const tenseLabel: Record<ScenePromptPreferences["tense"], string> = {
+    past: "Past",
+    present: "Present",
+    future: "Future",
+  };
+  return [
+    `User scene-writing preferences:`,
+    `- POV: ${povLabel[preferences.pov]}`,
+    `- Tense: ${tenseLabel[preferences.tense]}`,
+    preferences.extraInstructions ? `- Extra instructions: ${preferences.extraInstructions}` : "",
+  ]
+    .filter(Boolean)
+    .join("\n");
+}
 
 // ──────────────────────────────────────────────
 // Helpers (reused from encounter pattern)
@@ -704,6 +742,8 @@ export async function sceneRoutes(app: FastifyInstance) {
   // including system prompt, first message, background, rating, etc.
   app.post<{ Body: ScenePlanRequest }>("/plan", async (req, reply) => {
     const { chatId, prompt, connectionId } = req.body;
+    const promptPreferences = normalizeScenePromptPreferences(req.body.promptPreferences);
+    const promptPreferencesText = formatScenePromptPreferences(promptPreferences);
 
     const chat = await chats.getById(chatId);
     if (!chat) return reply.status(404).send({ error: "Chat not found" });
@@ -769,6 +809,7 @@ export async function sceneRoutes(app: FastifyInstance) {
           prompt
             ? `Plan a complete roleplay scene based on this request: "${prompt}"`
             : `Plan a complete roleplay scene based purely on the recent conversation above. Invent a compelling scenario that naturally extends the current situation, characters, and mood.`,
+          promptPreferencesText ? `\n${promptPreferencesText}` : "",
           ``,
           `Return ONLY a JSON object with ALL of the following fields:`,
           `{`,
@@ -778,7 +819,7 @@ export async function sceneRoutes(app: FastifyInstance) {
           `  "firstMessage": "The first in-character message from the main character that kicks off the scene. Write 2-4 paragraphs of immersive roleplay prose. This should feel like the opening of a story — set the scene through the character's actions, dialogue, and inner thoughts.",`,
           `  "background": "Pick a background filename from the available list that best matches the scene, or null if none fit.",`,
           `  "characterIds": ["array of character IDs to include in the scene — use the IDs from available_character_ids"],`,
-          `  "systemPrompt": "A custom system prompt for this specific scene. Include: writing style (e.g. literary, casual, poetic), narration POV, tense (past, present), and what the AI should focus on. Tailor it to the mood and genre of the scene. Choose ONE POV and use it consistently in both this prompt AND the firstMessage: first-person (from character's perspective, using 'I'), second-person (from user's perspective, addressing the user as 'you'), or third-person limited (from user's or character's perspective, using 'he/she/they'). 3-6 sentences.",`,
+          `  "systemPrompt": "A custom system prompt for this specific scene. Include: writing style (e.g. literary, casual, poetic), narration POV, tense (past, present, future), and what the AI should focus on. Tailor it to the mood and genre of the scene. Use the user's selected POV and tense when provided; otherwise choose ONE POV and use it consistently in both this prompt AND the firstMessage: first-person (from character's perspective, using 'I'), second-person (from user's perspective, addressing the user as 'you'), or third-person limited (from user's or character's perspective, using 'he/she/they'). 3-6 sentences.",`,
           `  "rating": "sfw" or "nsfw" — based on whether the scene's themes require mature content`,
           `  "relationshipHistory": "A concise 2-4 sentence summary of who the characters are to each other and their shared history so far — their dynamic, rapport, tensions, and key events. This gives the scene writer awareness of the relationship context.",`,
           `  "participationGuide": "A short (1-3 sentence), fun, second-person note telling the USER how to play this scene. Examples: 'This is freeform — do whatever feels right!', 'You will face tough choices. Think carefully before you act.', 'Try to keep your cool — one wrong word could set them off.', 'Explore the environment. There are secrets to find.' Be creative and match the scene tone."`,
@@ -790,6 +831,9 @@ export async function sceneRoutes(app: FastifyInstance) {
           `- The "background" must be an EXACT filename from the available backgrounds list (case-sensitive, including extension). If no background fits, set it to null. Do NOT invent or modify filenames.`,
           `- The "firstMessage" should be written in character, not as a narrator. Make it engaging.`,
           `- The "systemPrompt" defines HOW the roleplay is written. Be specific about style.`,
+          promptPreferences
+            ? `- The user's selected POV and tense are mandatory. Use them consistently in both "systemPrompt" and "firstMessage".`
+            : "",
           `- The POV chosen in "systemPrompt" MUST match the POV used in "firstMessage". Do not say "third-person limited" in the prompt and then write "firstMessage" in second-person.`,
           `- Do NOT use asterisks or markdown formatting in any field. Write plain prose.`,
           `- Only return the JSON object, no other text.`,

--- a/packages/server/src/services/generation/conversation-command-runtime.ts
+++ b/packages/server/src/services/generation/conversation-command-runtime.ts
@@ -244,7 +244,7 @@ export async function buildConversationCommandsReminder(args: {
   // Scene command: only in conversation mode
   if (sceneCommandEnabled && chatMode === "conversation") {
     addCommandLines(
-      `- [scene: scenario="brief description of what happens in this scene", background="place"] - initiate a mini-roleplay scene branching from this conversation. The system will plan and create a complete immersive scene for you.`,
+      `- [scene: scenario="brief description of what happens in this scene", background="place"] - request a mini-roleplay scene branching from this conversation. The user will be asked for POV, tense, and optional prompt wishes before the system plans and creates the scene.`,
       `   Example: You agree to go stargazing → include [scene: scenario="lying on a blanket in the park, looking at the stars together", background="park"]`,
       `   WHEN TO USE: You SHOULD proactively trigger a scene whenever the conversation naturally leads to an activity, outing, or situation that would be more immersive as a scene. Examples:`,
       `   - {{user}} says "I'm coming over" or "Let's go to the park" → trigger a scene for arriving/being at that location.`,

--- a/packages/server/src/services/generation/conversation-scene-command-runtime.ts
+++ b/packages/server/src/services/generation/conversation-scene-command-runtime.ts
@@ -1,11 +1,5 @@
-import type { FastifyInstance } from "fastify";
-
 import { logger } from "../../lib/logger.js";
 import type { CharacterCommand, SceneCommand } from "../conversation/character-commands.js";
-
-type ChatsStore = {
-  getById(id: string): Promise<{ id?: string; characterIds?: unknown } | null>;
-};
 
 type CharactersStore = {
   getById(id: string): Promise<{ data: unknown } | null>;
@@ -15,71 +9,29 @@ export async function handleConversationSceneCommand(args: {
   command: CharacterCommand;
   characterId: string | null;
   chatId: string;
-  app: FastifyInstance;
   chars: CharactersStore;
-  chats: ChatsStore;
-  sendSceneCreated: (data: Record<string, unknown>) => void;
+  sendSceneRequested: (data: Record<string, unknown>) => void;
 }): Promise<boolean> {
   if (args.command.type !== "scene") return false;
   const command = args.command as SceneCommand;
 
   try {
-    const originChat = await args.chats.getById(args.chatId);
-    if (!originChat) throw new Error("Origin chat not found");
-
     const initiatorRow = args.characterId ? await args.chars.getById(args.characterId) : null;
     const initiatorData = parseRecord(initiatorRow?.data);
     const initiatorName =
       typeof initiatorData?.name === "string" && initiatorData.name.trim() ? initiatorData.name : "Character";
 
-    const planRes = await args.app.inject({
-      method: "POST",
-      url: "/api/scene/plan",
-      payload: {
-        chatId: args.chatId,
-        prompt: command.scenario,
-        connectionId: null,
-      },
+    args.sendSceneRequested({
+      originChatId: args.chatId,
+      prompt: command.scenario,
+      background: command.background ?? null,
+      plan: command.plan ?? null,
+      initiatorCharId: args.characterId,
+      initiatorCharName: initiatorName,
     });
-    const planBody = JSON.parse(planRes.body);
-    if (!planBody.plan) throw new Error("Scene plan failed");
-
-    if (command.background) {
-      planBody.plan.background = command.background;
-    }
-
-    const createRes = await args.app.inject({
-      method: "POST",
-      url: "/api/scene/create",
-      payload: {
-        originChatId: args.chatId,
-        initiatorCharId: args.characterId,
-        plan: planBody.plan,
-        connectionId: null,
-      },
-    });
-    const createBody = JSON.parse(createRes.body);
-
-    if (createBody.chatId) {
-      args.sendSceneCreated({
-        sceneChatId: createBody.chatId,
-        sceneChatName: createBody.chatName,
-        description: createBody.description,
-        background: createBody.background ?? null,
-        initiatorCharId: args.characterId,
-        initiatorCharName: initiatorName,
-      });
-      logger.info(
-        '[commands] Scene created: "%s" (%s) from chat %s',
-        createBody.chatName,
-        createBody.chatId,
-        args.chatId,
-      );
-    } else {
-      logger.warn("[commands] Scene create returned no chatId for chat %s: %j", args.chatId, createBody);
-    }
+    logger.info('[commands] Scene requested by "%s" from chat %s', initiatorName, args.chatId);
   } catch (err) {
-    logger.error(err, "[commands] Scene creation failed");
+    logger.error(err, "[commands] Scene request failed");
   }
 
   return true;

--- a/packages/server/src/services/generation/roleplay-summary-runtime.ts
+++ b/packages/server/src/services/generation/roleplay-summary-runtime.ts
@@ -1,4 +1,9 @@
-import { CHAT_SUMMARY_OUTPUT_TOKENS, DEFAULT_CHAT_SUMMARY_PROMPT } from "@marinara-engine/shared";
+import {
+  CHAT_SUMMARY_OUTPUT_TOKENS,
+  DEFAULT_CHAT_SUMMARY_PROMPT,
+  type ChatSummaryPromptSettings,
+  type ChatSummaryPromptTemplate,
+} from "@marinara-engine/shared";
 
 const RETIRED_CHAT_SUMMARY_AGENT_ID = "chat-summary";
 const DEFAULT_AUTOMATIC_SUMMARY_INTERVAL = 5;
@@ -54,22 +59,96 @@ export function withoutRetiredChatSummaryAgentIds(chatMetadata: Record<string, u
 }
 
 export function resolveChatSummaryPromptFromMetadata(chatMetadata: Record<string, unknown>): string {
+  return resolveChatSummaryPrompt({
+    requestedTemplateId: null,
+    chatMetadata,
+    globalSettingsValue: null,
+  });
+}
+
+export function resolveChatSummaryPrompt(args: {
+  requestedTemplateId?: string | null;
+  chatMetadata: Record<string, unknown>;
+  globalSettingsValue?: string | null;
+}): string {
+  const hasGlobalSettingsValue =
+    typeof args.globalSettingsValue === "string" && args.globalSettingsValue.trim().length > 0;
+  const globalSettings = parseChatSummaryPromptSettings(args.globalSettingsValue);
+  const requestedId = typeof args.requestedTemplateId === "string" ? args.requestedTemplateId.trim() : "";
   const selectedId =
-    typeof chatMetadata.activeSummaryPromptTemplateId === "string"
-      ? chatMetadata.activeSummaryPromptTemplateId.trim()
-      : "";
-  const templates = Array.isArray(chatMetadata.summaryPromptTemplates) ? chatMetadata.summaryPromptTemplates : [];
-  const selected = selectedId
-    ? templates.find((template) => {
-        if (!template || typeof template !== "object" || Array.isArray(template)) return false;
-        const record = template as Record<string, unknown>;
-        return record.id === selectedId && typeof record.prompt === "string" && record.prompt.trim().length > 0;
-      })
-    : null;
-  if (selected && typeof (selected as Record<string, unknown>).prompt === "string") {
-    return ((selected as Record<string, unknown>).prompt as string).trim();
-  }
+    requestedId ||
+    globalSettings.activeTemplateId ||
+    (!hasGlobalSettingsValue && typeof args.chatMetadata.activeSummaryPromptTemplateId === "string"
+      ? args.chatMetadata.activeSummaryPromptTemplateId.trim()
+      : "");
+
+  const globalPrompt = resolvePromptFromTemplates(globalSettings.templates, selectedId);
+  if (globalPrompt) return globalPrompt;
+  // A saved global settings row is authoritative across roleplay chats.
+  // Legacy chat-local templates remain a fallback only until the user has saved
+  // global summary prompt settings, so old per-chat choices do not silently
+  // override the selected global built-in/default behavior.
+  if (hasGlobalSettingsValue) return DEFAULT_CHAT_SUMMARY_PROMPT;
+
+  const chatTemplates = Array.isArray(args.chatMetadata.summaryPromptTemplates)
+    ? (args.chatMetadata.summaryPromptTemplates as unknown[])
+    : [];
+  const chatPrompt = resolvePromptFromTemplates(chatTemplates, selectedId);
+  if (chatPrompt) return chatPrompt;
+
   return DEFAULT_CHAT_SUMMARY_PROMPT;
+}
+
+export function parseChatSummaryPromptSettings(raw: string | null | undefined): ChatSummaryPromptSettings {
+  if (!raw) return { templates: [], activeTemplateId: null };
+  try {
+    const parsed = JSON.parse(raw) as unknown;
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+      return { templates: [], activeTemplateId: null };
+    }
+    const record = parsed as Record<string, unknown>;
+    const templates = normalizeChatSummaryPromptTemplates(record.templates);
+    const activeTemplateIdRaw =
+      typeof record.activeTemplateId === "string" && record.activeTemplateId.trim()
+        ? record.activeTemplateId.trim()
+        : null;
+    const activeTemplateId =
+      activeTemplateIdRaw && templates.some((template) => template.id === activeTemplateIdRaw)
+        ? activeTemplateIdRaw
+        : null;
+    return { templates, activeTemplateId };
+  } catch {
+    return { templates: [], activeTemplateId: null };
+  }
+}
+
+function normalizeChatSummaryPromptTemplates(value: unknown): ChatSummaryPromptTemplate[] {
+  if (!Array.isArray(value)) return [];
+  const templates: ChatSummaryPromptTemplate[] = [];
+  const seen = new Set<string>();
+  for (const item of value) {
+    if (!item || typeof item !== "object" || Array.isArray(item)) continue;
+    const record = item as Record<string, unknown>;
+    const id = typeof record.id === "string" ? record.id.trim() : "";
+    const name = typeof record.name === "string" ? record.name.trim() : "";
+    const prompt = typeof record.prompt === "string" ? record.prompt.trim() : "";
+    if (!id || !name || !prompt || seen.has(id)) continue;
+    seen.add(id);
+    templates.push({ id, name, prompt });
+  }
+  return templates;
+}
+
+function resolvePromptFromTemplates(templates: unknown[], selectedId: string): string | null {
+  if (!selectedId) return null;
+  for (const template of templates) {
+    if (!template || typeof template !== "object" || Array.isArray(template)) continue;
+    const record = template as Record<string, unknown>;
+    if (record.id !== selectedId) continue;
+    const prompt = typeof record.prompt === "string" ? record.prompt.trim() : "";
+    if (prompt) return prompt;
+  }
+  return null;
 }
 
 export function parseChatSummaryText(rawContent: string): string {

--- a/packages/shared/src/types/chat.ts
+++ b/packages/shared/src/types/chat.ts
@@ -133,6 +133,15 @@ export interface ChatSummaryPromptTemplate {
   prompt: string;
 }
 
+/** Server app-setting key for Roleplay Chat Summary prompt templates shared across all roleplays. */
+export const CHAT_SUMMARY_PROMPT_SETTINGS_KEY = "chat-summary-prompts";
+
+/** Global Roleplay Chat Summary prompt template settings. */
+export interface ChatSummaryPromptSettings {
+  templates: ChatSummaryPromptTemplate[];
+  activeTemplateId: string | null;
+}
+
 /** Rolling summary entry category. Extensible beyond rolling summaries later. */
 export type ChatSummaryEntryKind = "rolling";
 

--- a/packages/shared/src/types/scene.ts
+++ b/packages/shared/src/types/scene.ts
@@ -54,6 +54,15 @@ export interface SceneFullPlan {
   participationGuide: string;
 }
 
+export type ScenePromptPov = "first_person" | "second_person" | "third_person";
+export type ScenePromptTense = "past" | "present" | "future";
+
+export interface ScenePromptPreferences {
+  pov: ScenePromptPov;
+  tense: ScenePromptTense;
+  extraInstructions?: string;
+}
+
 /** Request body for POST /scene/create. */
 export interface SceneCreateRequest {
   /** The conversation chat to branch from. */
@@ -143,6 +152,8 @@ export interface ScenePlanRequest {
   prompt: string;
   /** Connection override. */
   connectionId?: string | null;
+  /** Optional user preferences for the generated scene prompt and opening message. */
+  promptPreferences?: ScenePromptPreferences | null;
 }
 
 /** Response from POST /scene/plan — the LLM plans everything. */


### PR DESCRIPTION
## Linked issue

None. Maintainer-requested in chat; a tracking issue should be opened before final submission if the project requires one.

## Why this change

- Conversation-connected Game chats needed the same quick switch affordance that Conversation/Roleplay links already have.
- Scene initiation could generate first-person or tense choices the user did not want, with no chance to guide the scene prompt.
- Roleplay Chat Summary custom prompts were effectively chat-local, but the intended behavior is one global override across roleplays.
- Conversation prompt context could lose the user's visible status/activity when a relocated context macro was detected but not actually present after prompt resolution.

## What changed

- Added Game-mode connected-chat switch buttons on desktop and mobile toolbars.
- Added a scene prompt setup modal for user `/scene` and character `[scene]` initiation with remembered POV, tense, and optional instructions.
- Moved Roleplay Chat Summary prompt template settings into synced app settings and updated manual/automatic summary generation to resolve the global setting.
- Made Conversation context insertion append the status/activity block when macro replacement does not occur.
- Updated v2.1.2 changelog entries and preserved the small editor/settings UI copy tweaks from the branch.

## Validation

- [ ] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed `CONTRIBUTING.md`

Agent-run validation:

- `pnpm check`
- `pnpm regression:prompt`
- `pnpm version:check`
- `git diff --check`
- `pnpm smoke:ui` (6 passed, 2 skipped by suite)

### Manual verification notes

- Manual browser verification still needs maintainer pass-through for connected Conversation/Game switching, the scene setup modal, and global summary prompt behavior.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Version/release files updated (only if this PR includes a version bump)

CHANGELOG.md was updated under v2.1.2. Version files were already at 2.1.2 and `pnpm version:check` passed.

## UI evidence (if applicable)

Not captured in this agent run; `pnpm smoke:ui` covered the browser shell smoke suite.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a connected-chat shortcut in Game mode.
  * Added a scene setup dialog with POV, tense, and optional prompt instructions.
  * Made scene creation follow the selected prompt preferences.

* **Changes**
  * Roleplay summary prompt templates can now be managed globally across chats.
  * Scene prompt preferences are now remembered between sessions.

* **Bug Fixes**
  * Conversation mode now always includes visible status/activity when appropriate.
  * Improved prompt wording and example text in editor/settings screens.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->