### PR TITLE
feat(turn-games): add No-Limit Texas Hold'em poker as the third conversation-mode table game

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,9 +22,6 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 - Added Conversation prompt relocation macros for auto-inserted context: `{{context}}`/`{{status}}`, `{{commands}}`, `{{reactRules}}`, `{{memories}}`, and `{{lorebook}}`.
 - Added a TTS cache export control in Text to Speech settings so generated cached voice clips can be downloaded from IndexedDB.
 - Added a Roleplay Chat Summary maximum output size setting under Summary Connection, defaulting to 4096 tokens for manual and automatic summaries.
-- Turn-game bots now choose their moves in character (#3308): move selection is steered by the character's personality, mood, and grudges instead of pure game logic, and UNO board summaries include a "What just happened" recap of recent plays so reactions track the actual game.
-- Characters seated in a turn game now carry their own seat's perspective into normal chat (#3308): mid-game replies know their own UNO hand or chess color and last move, spectators and unseated characters keep a hands-hidden view, and each generation request loads the game state once instead of once per responding character.
-- Turn-game hand secrecy is now personality-gated (#3308): in hidden-information games a seated character knows their hand is private and may deflect, tease, bluff, or let something slip according to their personality, while in open-information games like chess the same treatment applies to their plans.
 
 ### Changed
 
@@ -121,6 +118,9 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 - Added Gallery **Images** and **Videos** tabs so generated videos are reachable without scrolling through every still image first.
 - Added an optional Game Illustrator toggle for Dynamic LLM Prompt Generation, letting the selected prompt model rewrite Game Mode NPC portrait, location background, and key-moment illustration prompts before image generation (#3225).
 - Added `/illustrate` in Conversation, Roleplay, and Game chats to trigger the same illustration action as the Gallery **Illustrate** button without opening the Gallery first.
+- Turn-game bots now choose their moves in character (#3308): move selection is steered by the character's personality, mood, and grudges instead of pure game logic, and UNO board summaries include a "What just happened" recap of recent plays so reactions track the actual game.
+- Characters seated in a turn game now carry their own seat's perspective into normal chat (#3308): mid-game replies know their own UNO hand or chess color and last move, spectators and unseated characters keep a hands-hidden view, and each generation request loads the game state once instead of once per responding character.
+- Turn-game hand secrecy is now personality-gated (#3308): in hidden-information games a seated character knows their hand is private and may deflect, tease, bluff, or let something slip according to their personality, while in open-information games like chess the same treatment applies to their plans.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 
 ## [Unreleased]
 
+### Added
+
+- Added Poker (No-Limit Texas Hold'em) as a Conversation-mode table game for 2-8 players: seeded fair dealing, full no-limit betting with all-ins and side pots, showdown hand ranking with natural-language labels, and multi-hand sessions with a rotating dealer button, optional blind escalation, an optional hand limit, and player-paced "Next hand" breaks between hands.
+- Added a selectable poker dealer: choose the silent house dealer or seat any chat character as the croupier, who announces hand starts, flop/turn/river reveals, showdowns, and blind increases in their own voice and personality — narration only, with dealing always seeded and fair.
+- Poker joins the `[poker]` Conversation command family alongside `[uno]` and `[chess]`, with a `/poker` slash command, natural-language launcher, per-chat command toggle, and a setup modal for players, dealer, and stakes.
+
 ## [2.1.2]
 
 ### Added
@@ -16,6 +22,9 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 - Added Conversation prompt relocation macros for auto-inserted context: `{{context}}`/`{{status}}`, `{{commands}}`, `{{reactRules}}`, `{{memories}}`, and `{{lorebook}}`.
 - Added a TTS cache export control in Text to Speech settings so generated cached voice clips can be downloaded from IndexedDB.
 - Added a Roleplay Chat Summary maximum output size setting under Summary Connection, defaulting to 4096 tokens for manual and automatic summaries.
+- Turn-game bots now choose their moves in character (#3308): move selection is steered by the character's personality, mood, and grudges instead of pure game logic, and UNO board summaries include a "What just happened" recap of recent plays so reactions track the actual game.
+- Characters seated in a turn game now carry their own seat's perspective into normal chat (#3308): mid-game replies know their own UNO hand or chess color and last move, spectators and unseated characters keep a hands-hidden view, and each generation request loads the game state once instead of once per responding character.
+- Turn-game hand secrecy is now personality-gated (#3308): in hidden-information games a seated character knows their hand is private and may deflect, tease, bluff, or let something slip according to their personality, while in open-information games like chess the same treatment applies to their plans.
 
 ### Changed
 

--- a/packages/client/src/components/chat/ChatSettingsDrawer.tsx
+++ b/packages/client/src/components/chat/ChatSettingsDrawer.tsx
@@ -615,6 +615,11 @@ const CONVERSATION_COMMAND_TOGGLE_OPTIONS: Array<{
     label: "Chess",
     description: "Let characters accept a one-on-one chess challenge at the table.",
   },
+  {
+    id: "poker",
+    label: "Poker",
+    description: "Let characters sit down for a game of Texas Hold'em poker at the table.",
+  },
 ];
 
 function normalizeSpotifySourceType(value: unknown): SpotifySourceType {

--- a/packages/client/src/components/chat/ChatSetupWizard.tsx
+++ b/packages/client/src/components/chat/ChatSetupWizard.tsx
@@ -171,6 +171,7 @@ const CONVERSATION_COMMAND_TOGGLE_OPTIONS: Array<{
   { id: "react", label: "Reactions", description: "Let characters react to messages with emoji badges." },
   { id: "uno", label: "UNO", description: "Let characters start a game of UNO at the table when you agree to play." },
   { id: "chess", label: "Chess", description: "Let characters accept a one-on-one chess challenge at the table." },
+  { id: "poker", label: "Poker", description: "Let characters sit down for a game of Texas Hold'em poker at the table." },
 ];
 
 // ─── Main component ───────────────────────────

--- a/packages/client/src/components/chat/ConversationInput.tsx
+++ b/packages/client/src/components/chat/ConversationInput.tsx
@@ -24,6 +24,7 @@ import { useChatStore } from "../../stores/chat.store";
 import { useUIStore } from "../../stores/ui.store";
 import { useUnoGameStore } from "../../stores/uno-game.store";
 import { useChessGameStore } from "../../stores/chess-game.store";
+import { usePokerGameStore } from "../../stores/poker-game.store";
 import { useGenerate } from "../../hooks/use-generate";
 import { useApplyRegex } from "../../hooks/use-apply-regex";
 import { useCreateMessage, useDeleteMessage, useUpdateMessageExtra, useChat, chatKeys } from "../../hooks/use-chats";
@@ -925,8 +926,9 @@ export function ConversationInput({
       return;
     }
 
-    // Natural-language launchers: "let's play uno" / "let's play chess" open the game
-    // setup. The message still sends normally, so the characters can react too.
+    // Natural-language launchers: "let's play uno" / "let's play chess" / "let's
+    // play poker" open the game setup. The message still sends normally, so the
+    // characters can react too.
     {
       const activeUno = useUnoGameStore.getState().current;
       const unoActive = !!activeUno && activeUno.chatId === activeChatId && activeUno.status !== "finished";
@@ -937,6 +939,11 @@ export function ConversationInput({
       const chessActive = !!activeChess && activeChess.chatId === activeChatId && activeChess.status !== "finished";
       if (!chessActive && /\b(?:play|start)\b[^.!?\n]{0,16}\bchess\b/i.test(raw)) {
         useChessGameStore.getState().openSetup(activeChatId);
+      }
+      const activePoker = usePokerGameStore.getState().current;
+      const pokerActive = !!activePoker && activePoker.chatId === activeChatId && activePoker.status !== "finished";
+      if (!pokerActive && /\b(?:play|start|deal)\b[^.!?\n]{0,24}\bpoker\b/i.test(raw)) {
+        usePokerGameStore.getState().openSetup(activeChatId);
       }
     }
 

--- a/packages/client/src/components/chat/ConversationView.tsx
+++ b/packages/client/src/components/chat/ConversationView.tsx
@@ -30,6 +30,8 @@ import { UnoBoard } from "./UnoBoard";
 import { UnoSetup } from "./UnoSetup";
 import { ChessBoard } from "./ChessBoard";
 import { ChessSetup } from "./ChessSetup";
+import { PokerBoard } from "./PokerBoard";
+import { PokerSetup } from "./PokerSetup";
 import { SceneBanner, EndSceneBar } from "./SceneBanner";
 import { ChatBranchSelector } from "./ChatBranchSelector";
 import { ActiveLorebookEntriesButton } from "./ActiveLorebookEntriesButton";
@@ -42,6 +44,7 @@ import { ConversationCallSurface } from "./ConversationCallSurface";
 import { useChatStore } from "../../stores/chat.store";
 import { useUnoGameStore } from "../../stores/uno-game.store";
 import { useChessGameStore } from "../../stores/chess-game.store";
+import { usePokerGameStore } from "../../stores/poker-game.store";
 import { useUIStore } from "../../stores/ui.store";
 import { playConfiguredNotificationPing } from "../../lib/notification-sound";
 import { playConversationCallRingingSoundOnce } from "../../lib/conversation-call-sounds";
@@ -321,6 +324,9 @@ export function ConversationView({
   const chessGameActive = useChessGameStore((s) => s.current?.chatId === chatId && s.current?.status !== "finished");
   const chessSetupOpen = useChessGameStore((s) => s.setupChatId === chatId);
   const closeChessSetup = useChessGameStore((s) => s.closeSetup);
+  const pokerGameActive = usePokerGameStore((s) => s.current?.chatId === chatId && s.current?.status !== "finished");
+  const pokerSetupOpen = usePokerGameStore((s) => s.setupChatId === chatId);
+  const closePokerSetup = usePokerGameStore((s) => s.closeSetup);
   const isStreamCommitted = useChatStore((s) => s.committedStreamChatIds.has(chatId));
   const hasLiveStream = isStreaming && !isStreamCommitted;
   const streamBuffer = useThrottledStreamBuffer();
@@ -1464,7 +1470,7 @@ export function ConversationView({
         )}
 
         {/* Scene banner — inline at bottom of messages (origin variant only); hidden during a turn-game */}
-        {sceneInfo?.variant === "origin" && !unoGameActive && !chessGameActive && (
+        {sceneInfo?.variant === "origin" && !unoGameActive && !chessGameActive && !pokerGameActive && (
           <SceneBanner variant="origin" sceneChatId={sceneInfo.sceneChatId} sceneChatName={sceneInfo.sceneChatName} />
         )}
 
@@ -1495,9 +1501,10 @@ export function ConversationView({
         />
       )}
 
-      {/* ── Turn-game boards (UNO, chess) — each self-hides when no game is active ── */}
+      {/* ── Turn-game boards (UNO, chess, poker) — each self-hides when no game is active ── */}
       <UnoBoard chatId={chatId} />
       <ChessBoard chatId={chatId} />
+      <PokerBoard chatId={chatId} />
       {renderIncomingCallBanner()}
       {/* Setup modals mounted once here (stable position) so they never double-render.
           Keyed by chatId so their internal selection state resets on a chat switch
@@ -1508,6 +1515,7 @@ export function ConversationView({
           duplicate/orphan the setup modals (stuck un-closable "Start UNO"). */}
       <UnoSetup key={`uno-${chatId}`} chatId={chatId} open={unoSetupOpen} onClose={closeUnoSetup} />
       <ChessSetup key={`chess-${chatId}`} chatId={chatId} open={chessSetupOpen} onClose={closeChessSetup} />
+      <PokerSetup key={`poker-${chatId}`} chatId={chatId} open={pokerSetupOpen} onClose={closePokerSetup} />
 
       {/* ── Input area ── */}
       <ConversationInput

--- a/packages/client/src/components/chat/PokerBoard.tsx
+++ b/packages/client/src/components/chat/PokerBoard.tsx
@@ -183,7 +183,10 @@ export function PokerBoard({ chatId }: Props) {
   const minFloor = yourActions ? (yourActions.canBet ? yourActions.minBet : yourActions.minRaiseTo) : 0;
   const maxTo = yourActions?.maxTo ?? 0;
 
-  const [betAmount, setBetAmount] = useState(0);
+  // The field holds a RAW string so partial entries survive typing (clamping on
+  // every keystroke would snap "1" up to the minimum before "150" can be typed);
+  // it is clamped into the legal range only on blur, quick-pick, and submit.
+  const [betInput, setBetInput] = useState("0");
   // Reset the bet/raise field whenever a fresh decision point arrives (a new
   // street, a new hand, or turn passing back to you) — a stale amount from a
   // prior street could exceed the new maxTo. Depending on the whole `view`
@@ -191,13 +194,14 @@ export function PokerBoard({ chatId }: Props) {
   useEffect(() => {
     if (!view) return;
     const a = view.yourActions;
-    setBetAmount(a.canBet ? a.minBet : a.minRaiseTo);
+    setBetInput(String(a.canBet ? a.minBet : a.minRaiseTo));
   }, [view]);
 
   const clampBet = useMemo(
     () => (n: number) => Math.max(minFloor, Math.min(maxTo, Math.floor(Number.isFinite(n) ? n : minFloor))),
     [minFloor, maxTo],
   );
+  const betAmount = clampBet(Number(betInput));
 
   if (!view) return null;
 
@@ -208,9 +212,8 @@ export function PokerBoard({ chatId }: Props) {
 
   const submitBetOrRaise = () => {
     if (disabled || !yourActions) return;
-    const amount = clampBet(betAmount);
-    if (yourActions.canBet) submit({ type: "bet", amount });
-    else if (yourActions.canRaise) submit({ type: "raise", toAmount: amount });
+    if (yourActions.canBet) submit({ type: "bet", amount: betAmount });
+    else if (yourActions.canRaise) submit({ type: "raise", toAmount: betAmount });
   };
 
   const currentSeat = view.seats.find((s) => s.seatId === view.currentSeatId) ?? null;
@@ -362,41 +365,42 @@ export function PokerBoard({ chatId }: Props) {
                 type="number"
                 min={minFloor}
                 max={maxTo}
-                value={betAmount}
-                onChange={(e) => setBetAmount(clampBet(Number(e.target.value)))}
+                value={betInput}
+                onChange={(e) => setBetInput(e.target.value)}
+                onBlur={() => setBetInput(String(betAmount))}
                 aria-label={yourActions?.canBet ? "Bet amount" : "Raise amount"}
                 className="w-20 rounded-lg border border-[var(--border)] bg-[var(--background)] px-2 py-1 text-sm text-[var(--foreground)]"
               />
               <button
                 type="button"
-                onClick={() => setBetAmount(clampBet(minFloor))}
+                onClick={() => setBetInput(String(clampBet(minFloor)))}
                 className="rounded px-1.5 py-1 text-xs text-[var(--muted-foreground)] hover:bg-[var(--muted)]"
               >
                 Min
               </button>
               <button
                 type="button"
-                onClick={() => setBetAmount(clampBet(potHalf))}
+                onClick={() => setBetInput(String(clampBet(potHalf)))}
                 className="rounded px-1.5 py-1 text-xs text-[var(--muted-foreground)] hover:bg-[var(--muted)]"
               >
                 ½ pot
               </button>
               <button
                 type="button"
-                onClick={() => setBetAmount(clampBet(view.potTotal))}
+                onClick={() => setBetInput(String(clampBet(view.potTotal)))}
                 className="rounded px-1.5 py-1 text-xs text-[var(--muted-foreground)] hover:bg-[var(--muted)]"
               >
                 Pot
               </button>
               <button
                 type="button"
-                onClick={() => setBetAmount(clampBet(maxTo))}
+                onClick={() => setBetInput(String(clampBet(maxTo)))}
                 className="rounded px-1.5 py-1 text-xs text-[var(--muted-foreground)] hover:bg-[var(--muted)]"
               >
                 All-in
               </button>
               <ActionButton highlight onClick={submitBetOrRaise}>
-                {yourActions?.canBet ? `Bet ${clampBet(betAmount)}` : `Raise to ${clampBet(betAmount)}`}
+                {yourActions?.canBet ? `Bet ${betAmount}` : `Raise to ${betAmount}`}
               </ActionButton>
             </div>
           )}

--- a/packages/client/src/components/chat/PokerBoard.tsx
+++ b/packages/client/src/components/chat/PokerBoard.tsx
@@ -187,15 +187,17 @@ export function PokerBoard({ chatId }: Props) {
   // every keystroke would snap "1" up to the minimum before "150" can be typed);
   // it is clamped into the legal range only on blur, quick-pick, and submit.
   const [betInput, setBetInput] = useState("0");
-  // Reset the bet/raise field whenever a fresh decision point arrives (a new
-  // street, a new hand, or turn passing back to you) — a stale amount from a
-  // prior street could exceed the new maxTo. Depending on the whole `view`
-  // covers every field read inside without an exhaustive-deps override.
+  // Reset the bet/raise field only when a fresh DECISION POINT arrives (a new
+  // hand, a new street, turn passing, or the legal bet/raise window moving) —
+  // a stale amount from a prior street could exceed the new maxTo. Keyed off
+  // those fields rather than the whole `view` so an unrelated state patch
+  // (e.g. a dealer-announcement drain) can't wipe a partially typed amount
+  // mid-turn.
   useEffect(() => {
-    if (!view) return;
-    const a = view.yourActions;
-    setBetInput(String(a.canBet ? a.minBet : a.minRaiseTo));
-  }, [view]);
+    if (!yourActions) return;
+    setBetInput(String(minFloor));
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [view?.handNumber, view?.street, view?.currentSeatId, yourActions?.canBet, minFloor]);
 
   const clampBet = useMemo(
     () => (n: number) => Math.max(minFloor, Math.min(maxTo, Math.floor(Number.isFinite(n) ? n : minFloor))),

--- a/packages/client/src/components/chat/PokerBoard.tsx
+++ b/packages/client/src/components/chat/PokerBoard.tsx
@@ -1,0 +1,470 @@
+// ──────────────────────────────────────────────
+// PokerBoard — live, interactive Texas Hold'em table (conversation mode)
+// ──────────────────────────────────────────────
+// A real React component driven by the poker-game store (fed by
+// turn_game_state_patch SSE + an initial fetch). Renders the community cards,
+// every seat around the table, the viewer's own hole cards, a betting action
+// bar, and a showdown recap. Cards are pure CSS (no image assets), matching
+// the visual language of ChessBoard / UnoBoard.
+import { type ReactNode, useEffect, useMemo, useState } from "react";
+import { X } from "lucide-react";
+import type { PokerMove, PokerStreet } from "@marinara-engine/shared";
+import { useChatStore } from "../../stores/chat.store";
+import { usePokerGameStore } from "../../stores/poker-game.store";
+import { usePokerMove, usePokerState, useResignPoker } from "../../hooks/use-poker";
+
+interface Props {
+  chatId: string;
+}
+
+interface CardLike {
+  rank: number;
+  suit: string;
+}
+
+const SUIT_SYMBOL: Record<string, string> = { c: "♣", d: "♦", h: "♥", s: "♠" };
+const SUIT_NAME: Record<string, string> = { c: "clubs", d: "diamonds", h: "hearts", s: "spades" };
+const RED_SUITS = new Set(["h", "d"]);
+
+const RANK_CODE: Record<number, string> = {
+  2: "2",
+  3: "3",
+  4: "4",
+  5: "5",
+  6: "6",
+  7: "7",
+  8: "8",
+  9: "9",
+  10: "T",
+  11: "J",
+  12: "Q",
+  13: "K",
+  14: "A",
+};
+
+// Slightly friendlier than the raw "T" notation used in compact card codes.
+const RANK_GLYPH: Record<string, string> = { T: "10" };
+
+const RANK_NAME: Record<string, string> = {
+  "2": "two",
+  "3": "three",
+  "4": "four",
+  "5": "five",
+  "6": "six",
+  "7": "seven",
+  "8": "eight",
+  "9": "nine",
+  T: "ten",
+  J: "jack",
+  Q: "queen",
+  K: "king",
+  A: "ace",
+};
+
+const STREET_LABEL: Record<PokerStreet, string> = {
+  preflop: "Preflop",
+  flop: "Flop",
+  turn: "Turn",
+  river: "River",
+};
+
+/** Compact two-character code, e.g. "Ah", matching the server's `cardCode()`. */
+function codeFromCard(card: CardLike): string {
+  return `${RANK_CODE[card.rank] ?? "?"}${card.suit}`;
+}
+
+function cardLabelFromCode(code: string): string {
+  const rank = code.slice(0, -1);
+  const suit = code.slice(-1);
+  const rankName = RANK_NAME[rank] ?? rank;
+  const capitalized = rankName.charAt(0).toUpperCase() + rankName.slice(1);
+  return `${capitalized} of ${SUIT_NAME[suit] ?? suit}`;
+}
+
+// ── card face ────────────────────────────────────────────────────────────────
+
+function CardFace({
+  code,
+  size = "md",
+  highlight = false,
+}: {
+  code?: string | null;
+  size?: "sm" | "md" | "lg" | "xl";
+  highlight?: boolean;
+}) {
+  const dims = {
+    sm: "h-9 w-6 text-[0.6rem]",
+    md: "h-12 w-8 text-xs",
+    lg: "h-16 w-11 text-base",
+    xl: "h-20 w-14 text-xl",
+  }[size];
+
+  if (!code) {
+    return (
+      <div
+        className={`${dims} shrink-0 rounded-md border-2 border-dashed border-[var(--border)] bg-[var(--muted)]/20`}
+        aria-hidden="true"
+      />
+    );
+  }
+
+  const rank = code.slice(0, -1);
+  const suit = code.slice(-1);
+  const isRed = RED_SUITS.has(suit);
+  const ring = highlight ? "ring-2 ring-amber-400" : "ring-1 ring-black/20";
+
+  return (
+    <div
+      className={`relative flex ${dims} shrink-0 flex-col items-center justify-center gap-0 rounded-md bg-white shadow-sm ${ring}`}
+      role="img"
+      aria-label={cardLabelFromCode(code)}
+    >
+      <span className="font-extrabold leading-none" style={{ color: isRed ? "#c81e3a" : "#1c1c1c" }}>
+        {RANK_GLYPH[rank] ?? rank}
+      </span>
+      <span className="leading-none" style={{ color: isRed ? "#c81e3a" : "#1c1c1c" }}>
+        {SUIT_SYMBOL[suit] ?? suit}
+      </span>
+    </div>
+  );
+}
+
+// ── action button ────────────────────────────────────────────────────────────
+
+function ActionButton({
+  children,
+  onClick,
+  disabled,
+  highlight,
+  ariaLabel,
+}: {
+  children: ReactNode;
+  onClick: () => void;
+  disabled?: boolean;
+  highlight?: boolean;
+  ariaLabel?: string;
+}) {
+  return (
+    <button
+      type="button"
+      disabled={disabled}
+      onClick={onClick}
+      aria-label={ariaLabel}
+      className={`rounded-lg px-3 py-1 text-sm font-medium transition-transform active:scale-95 disabled:opacity-40 ${
+        highlight
+          ? "bg-[var(--primary)] text-[var(--primary-foreground)]"
+          : "border border-[var(--border)] bg-[var(--background)] text-[var(--foreground)] hover:bg-[var(--muted)]"
+      }`}
+    >
+      {children}
+    </button>
+  );
+}
+
+// ── component ─────────────────────────────────────────────────────────────────
+
+export function PokerBoard({ chatId }: Props) {
+  const current = usePokerGameStore((s) => s.current);
+  const streaming = useChatStore((s) => s.isStreaming);
+  const streamingChatId = useChatStore((s) => s.streamingChatId);
+  const isStreaming = streaming && streamingChatId === chatId;
+  const move = usePokerMove(chatId);
+  const resign = useResignPoker(chatId);
+
+  // Hydrate the table on mount / chat switch (no-op if no active game).
+  const active = !!current && current.chatId === chatId;
+  usePokerState(active ? null : chatId);
+
+  const view = active ? current : null;
+  const disabled = isStreaming || move.isPending || resign.isPending;
+  const isMyTurn = !!view && view.status === "active" && view.currentSeatId === view.yourSeatId;
+
+  const yourActions = view?.yourActions ?? null;
+  const minFloor = yourActions ? (yourActions.canBet ? yourActions.minBet : yourActions.minRaiseTo) : 0;
+  const maxTo = yourActions?.maxTo ?? 0;
+
+  const [betAmount, setBetAmount] = useState(0);
+  // Reset the bet/raise field whenever a fresh decision point arrives (a new
+  // street, a new hand, or turn passing back to you) — a stale amount from a
+  // prior street could exceed the new maxTo. Depending on the whole `view`
+  // covers every field read inside without an exhaustive-deps override.
+  useEffect(() => {
+    if (!view) return;
+    const a = view.yourActions;
+    setBetAmount(a.canBet ? a.minBet : a.minRaiseTo);
+  }, [view]);
+
+  const clampBet = useMemo(
+    () => (n: number) => Math.max(minFloor, Math.min(maxTo, Math.floor(Number.isFinite(n) ? n : minFloor))),
+    [minFloor, maxTo],
+  );
+
+  if (!view) return null;
+
+  const submit = (m: PokerMove) => {
+    if (disabled) return;
+    move.mutate({ move: m });
+  };
+
+  const submitBetOrRaise = () => {
+    if (disabled || !yourActions) return;
+    const amount = clampBet(betAmount);
+    if (yourActions.canBet) submit({ type: "bet", amount });
+    else if (yourActions.canRaise) submit({ type: "raise", toAmount: amount });
+  };
+
+  const currentSeat = view.seats.find((s) => s.seatId === view.currentSeatId) ?? null;
+  const winnerSeat = view.winnerSeatId ? view.seats.find((s) => s.seatId === view.winnerSeatId) : null;
+  const potHalf = Math.floor(view.potTotal / 2);
+
+  return (
+    <div className="mx-2 mb-1 rounded-xl border border-[var(--border)] bg-[var(--card)] p-2 shadow-sm">
+      {/* Header: hand/street/blinds + pot chip + turn indicator + end control */}
+      <div className="mb-2 flex flex-wrap items-center gap-2 text-xs text-[var(--muted-foreground)]">
+        <span className="font-semibold text-[var(--foreground)]">
+          Poker — Hand #{view.handNumber} · {STREET_LABEL[view.street]} · Blinds {view.blinds.smallBlind}/{view.blinds.bigBlind}
+        </span>
+        <span className="rounded-full bg-amber-500/15 px-2 py-0.5 text-[0.7rem] font-semibold text-amber-600">
+          Pot {view.potTotal}
+        </span>
+        <div className="ml-auto flex items-center gap-2">
+          {view.status === "active" && (
+            <span className={isMyTurn ? "font-semibold text-[var(--primary)] animate-pulse" : ""}>
+              {isMyTurn ? "Your turn" : `${currentSeat?.displayName ?? "…"} is thinking…`}
+            </span>
+          )}
+          <button
+            type="button"
+            onClick={() => {
+              if (view.status === "finished" || window.confirm("End this poker game?")) resign.mutate();
+            }}
+            className="rounded p-1 text-[var(--muted-foreground)] hover:bg-[var(--muted)] active:scale-90"
+            title={view.status === "finished" ? "Close" : "End game"}
+            aria-label={view.status === "finished" ? "Close game" : "End game"}
+          >
+            <X className="h-3.5 w-3.5" />
+          </button>
+        </div>
+      </div>
+
+      {/* Finished banner + final stacks */}
+      {view.status === "finished" && (
+        <>
+          <div className="mb-1.5 rounded-lg bg-[var(--primary)]/10 px-3 py-2 text-center text-sm font-semibold text-[var(--primary)]">
+            {winnerSeat ? `🏆 ${winnerSeat.displayName} wins the session!` : "Game over"}
+          </div>
+          <div className="mb-2 flex flex-wrap justify-center gap-x-3 gap-y-0.5 text-[0.7rem] text-[var(--muted-foreground)]">
+            {view.seats.map((s) => (
+              <span key={s.seatId}>
+                {s.displayName}: {s.stack}
+              </span>
+            ))}
+          </div>
+        </>
+      )}
+
+      {/* Community cards */}
+      <div className="mx-auto mb-2 flex items-center justify-center gap-1.5">
+        {Array.from({ length: 5 }, (_, i) => (
+          <CardFace key={i} code={view.communityCodes[i]} size="lg" />
+        ))}
+      </div>
+
+      {/* Seats, in table order */}
+      <div className="mb-2 flex flex-wrap items-center gap-2">
+        {view.seats.map((seat) => {
+          const isYou = seat.seatId === view.yourSeatId;
+          const isDealingChar = !!view.dealerCharacterId && seat.seatId === view.dealerCharacterId;
+          const dim = seat.busted ? "opacity-35" : seat.folded ? "opacity-50" : "";
+          return (
+            <div
+              key={seat.seatId}
+              className={`rounded-lg px-1.5 py-1 ${dim} ${
+                seat.isCurrent
+                  ? "ring-2 ring-[var(--primary)] animate-pulse"
+                  : isYou
+                    ? "ring-1 ring-[var(--border)]"
+                    : "ring-1 ring-transparent"
+              }`}
+            >
+              <div className="flex items-center gap-1 text-xs font-medium text-[var(--foreground)]">
+                <span className="truncate">{seat.displayName}</span>
+                {isYou && <span className="text-[0.6rem] font-semibold text-[var(--muted-foreground)]">(you)</span>}
+                {seat.isButton && (
+                  <span
+                    className="rounded-full bg-[var(--foreground)]/10 px-1 text-[0.6rem] font-bold text-[var(--foreground)]"
+                    title="Dealer button"
+                    aria-label="Dealer button"
+                  >
+                    D
+                  </span>
+                )}
+                {seat.isSmallBlind && (
+                  <span className="text-[0.6rem] font-semibold text-[var(--muted-foreground)]" title="Small blind">
+                    SB
+                  </span>
+                )}
+                {seat.isBigBlind && (
+                  <span className="text-[0.6rem] font-semibold text-[var(--muted-foreground)]" title="Big blind">
+                    BB
+                  </span>
+                )}
+                {isDealingChar && (
+                  <span className="text-[0.65rem]" title={`${seat.displayName} is dealing`} aria-label={`${seat.displayName} is dealing`}>
+                    🎴
+                  </span>
+                )}
+              </div>
+              <div className="text-[0.7rem] text-[var(--muted-foreground)]">
+                {seat.stack} chips
+                {seat.streetBet > 0 && <span> · bet {seat.streetBet}</span>}
+                {seat.folded && <span> · folded</span>}
+                {seat.allIn && <span> · all in</span>}
+                {seat.busted && <span> · busted</span>}
+              </div>
+            </div>
+          );
+        })}
+      </div>
+
+      {/* Your hole cards + hand label */}
+      {view.yourSeatId && (
+        <div className="mb-2 flex items-center gap-3 rounded-lg bg-[var(--muted)]/25 p-2">
+          <div className="flex gap-1.5">
+            <CardFace code={view.yourHoleCards[0]?.code} size="xl" />
+            <CardFace code={view.yourHoleCards[1]?.code} size="xl" />
+          </div>
+          <div className="leading-tight">
+            <div className="text-[0.7rem] text-[var(--muted-foreground)]">Your hand</div>
+            {view.yourHandLabel && (
+              <div className="text-sm font-semibold text-[var(--foreground)]">{view.yourHandLabel}</div>
+            )}
+          </div>
+        </div>
+      )}
+
+      {/* Action bar */}
+      {isMyTurn && !disabled && (
+        <div className="flex flex-wrap items-center gap-2">
+          {yourActions?.canFold && <ActionButton onClick={() => submit({ type: "fold" })}>Fold</ActionButton>}
+          {yourActions?.canCheck && <ActionButton onClick={() => submit({ type: "check" })}>Check</ActionButton>}
+          {yourActions?.canCall && (
+            <ActionButton onClick={() => submit({ type: "call" })}>Call {yourActions.callAmount}</ActionButton>
+          )}
+          {yourActions?.canAllIn && (
+            <ActionButton highlight ariaLabel="Go all in" onClick={() => submit({ type: "all_in" })}>
+              All in
+            </ActionButton>
+          )}
+          {(yourActions?.canBet || yourActions?.canRaise) && (
+            <div className="flex flex-wrap items-center gap-1.5 rounded-lg border border-[var(--border)] p-1.5">
+              <input
+                type="number"
+                min={minFloor}
+                max={maxTo}
+                value={betAmount}
+                onChange={(e) => setBetAmount(clampBet(Number(e.target.value)))}
+                aria-label={yourActions?.canBet ? "Bet amount" : "Raise amount"}
+                className="w-20 rounded-lg border border-[var(--border)] bg-[var(--background)] px-2 py-1 text-sm text-[var(--foreground)]"
+              />
+              <button
+                type="button"
+                onClick={() => setBetAmount(clampBet(minFloor))}
+                className="rounded px-1.5 py-1 text-xs text-[var(--muted-foreground)] hover:bg-[var(--muted)]"
+              >
+                Min
+              </button>
+              <button
+                type="button"
+                onClick={() => setBetAmount(clampBet(potHalf))}
+                className="rounded px-1.5 py-1 text-xs text-[var(--muted-foreground)] hover:bg-[var(--muted)]"
+              >
+                ½ pot
+              </button>
+              <button
+                type="button"
+                onClick={() => setBetAmount(clampBet(view.potTotal))}
+                className="rounded px-1.5 py-1 text-xs text-[var(--muted-foreground)] hover:bg-[var(--muted)]"
+              >
+                Pot
+              </button>
+              <button
+                type="button"
+                onClick={() => setBetAmount(clampBet(maxTo))}
+                className="rounded px-1.5 py-1 text-xs text-[var(--muted-foreground)] hover:bg-[var(--muted)]"
+              >
+                All-in
+              </button>
+              <ActionButton highlight onClick={submitBetOrRaise}>
+                {yourActions?.canBet ? `Bet ${clampBet(betAmount)}` : `Raise to ${clampBet(betAmount)}`}
+              </ActionButton>
+            </div>
+          )}
+        </div>
+      )}
+
+      {/* Showdown recap */}
+      {view.status === "hand_over" && view.handResults && (
+        <div className="mt-2 space-y-2 rounded-lg border border-[var(--border)] bg-[var(--muted)]/25 p-2">
+          <div className="text-xs font-semibold text-[var(--foreground)]">Showdown</div>
+          {view.handResults.reveals.length > 0 && (
+            <div className="space-y-1.5">
+              {view.handResults.reveals.map((reveal) => {
+                const seat = view.seats.find((s) => s.seatId === reveal.seatId);
+                return (
+                  <div key={reveal.seatId} className="flex flex-wrap items-center gap-2 text-xs">
+                    <span className="w-24 shrink-0 truncate font-medium text-[var(--foreground)]">
+                      {seat?.displayName ?? reveal.seatId}
+                    </span>
+                    <div className="flex gap-1">
+                      {reveal.holeCards.map((card, i) => {
+                        const code = codeFromCard(card);
+                        return <CardFace key={i} code={code} size="sm" highlight={reveal.bestFiveCodes.includes(code)} />;
+                      })}
+                    </div>
+                    <span className="text-[var(--muted-foreground)]">{reveal.label}</span>
+                  </div>
+                );
+              })}
+            </div>
+          )}
+          <div className="space-y-0.5">
+            {view.handResults.potAwards.map((award, i) => {
+              const seat = view.seats.find((s) => s.seatId === award.seatId);
+              return (
+                <div key={i} className="text-xs text-[var(--foreground)]">
+                  {seat?.displayName ?? award.seatId} wins {award.amount} ({award.label})
+                </div>
+              );
+            })}
+          </div>
+          {yourActions?.canNextHand && (
+            <ActionButton highlight onClick={() => submit({ type: "next_hand" })}>
+              Next hand
+            </ActionButton>
+          )}
+        </div>
+      )}
+
+      {/* Last action ticker + recent log */}
+      {view.status !== "finished" && (view.lastAction || view.recentLog.length > 0) && (
+        <div className="mt-1.5 space-y-0.5 text-[0.7rem] text-[var(--muted-foreground)]">
+          {view.lastAction && (
+            <div className="truncate">
+              {view.seats.find((s) => s.seatId === view.lastAction!.seatId)?.displayName ?? "—"} {view.lastAction.summary}
+            </div>
+          )}
+          {view.recentLog.length > 0 && (
+            <ul className="space-y-0.5">
+              {view.recentLog.slice(-4).map((entry, i) => (
+                <li key={i} className="truncate opacity-70">
+                  {entry.message}
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/packages/client/src/components/chat/PokerSetup.tsx
+++ b/packages/client/src/components/chat/PokerSetup.tsx
@@ -1,0 +1,228 @@
+// ──────────────────────────────────────────────
+// PokerSetup — game configuration modal (conversation mode)
+// ──────────────────────────────────────────────
+// Opened from the /poker command or the natural-language launcher. Lets the
+// player pick which characters sit down as bots, an optional character to
+// voice the dealer, and the table's starting stakes.
+import { useEffect, useMemo, useState } from "react";
+import { Spade } from "lucide-react";
+import { DEFAULT_POKER_CONFIG } from "@marinara-engine/shared";
+import { Modal } from "../ui/Modal";
+import { useCharacters } from "../../hooks/use-characters";
+import { useChats } from "../../hooks/use-chats";
+import { parseCharacterDisplayData } from "../../lib/character-display";
+import { getChatCharacterIds } from "../../lib/chat-macros";
+import { useStartPoker } from "../../hooks/use-poker";
+import { usePokerGameStore } from "../../stores/poker-game.store";
+
+interface Props {
+  chatId: string;
+  open: boolean;
+  onClose: () => void;
+}
+
+// 8 seats total (you + up to this many bots).
+const MAX_BOTS = 7;
+
+export function PokerSetup({ chatId, open, onClose }: Props) {
+  const { data: chats } = useChats();
+  const { data: characters } = useCharacters(open);
+  const start = useStartPoker(chatId);
+
+  // A game can start underneath the open modal — e.g. the user's "let's play
+  // poker" message opens this setup AND a character accepts via [poker].
+  // Finished games linger in the store, so exclude them or a rematch's setup
+  // modal closes itself on the same frame it opens.
+  const activeGame = usePokerGameStore((s) => s.current);
+  useEffect(() => {
+    if (open && activeGame?.chatId === chatId && activeGame.status !== "finished") onClose();
+  }, [open, activeGame, chatId, onClose]);
+
+  const chat = useMemo(() => (chats ?? []).find((c) => c.id === chatId), [chats, chatId]);
+  const charIds = useMemo(() => getChatCharacterIds(chat), [chat]);
+
+  const nameById = useMemo(() => {
+    const map = new Map<string, string>();
+    for (const c of characters ?? []) {
+      const item = c as { id?: string; data?: unknown; comment?: string | null };
+      if (typeof item.id === "string") map.set(item.id, parseCharacterDisplayData({ data: item.data, comment: item.comment }).name);
+    }
+    return map;
+  }, [characters]);
+
+  const [selected, setSelected] = useState<Set<string> | null>(null);
+  const [dealerCharacterId, setDealerCharacterId] = useState<string | null>(null);
+  const [startingStack, setStartingStack] = useState(DEFAULT_POKER_CONFIG.startingStack);
+  const [smallBlind, setSmallBlind] = useState(DEFAULT_POKER_CONFIG.smallBlind);
+  const [blindIncreaseEveryHands, setBlindIncreaseEveryHands] = useState(DEFAULT_POKER_CONFIG.blindIncreaseEveryHands);
+  const [handLimit, setHandLimit] = useState(DEFAULT_POKER_CONFIG.handLimit);
+
+  // Default selection = every character in the chat, capped at the 7-bot seat
+  // limit (recomputed lazily once ids are known).
+  const selectedIds = selected ?? new Set(charIds.slice(0, MAX_BOTS));
+
+  const toggleSelected = (id: string) =>
+    // Derive from the updater's `current` (not the render-time `selectedIds`) so
+    // batched toggles don't clobber each other; fall back to the capped default
+    // only before the user's first selection (current === null).
+    setSelected((current) => {
+      const base = current ?? new Set(charIds.slice(0, MAX_BOTS));
+      const next = new Set(base);
+      if (next.has(id)) next.delete(id);
+      else if (next.size < MAX_BOTS) next.add(id);
+      return next;
+    });
+
+  const botCount = selectedIds.size;
+  const canStart = botCount >= 1 && !start.isPending;
+  const bigBlind = Math.max(1, Math.floor(smallBlind)) * 2;
+
+  const startGame = () => {
+    if (!canStart) return;
+    start.mutate(
+      {
+        gameType: "poker",
+        config: {
+          startingStack,
+          smallBlind,
+          blindIncreaseEveryHands,
+          handLimit,
+          dealerCharacterId,
+        },
+        botCharacterIds: charIds.filter((id) => selectedIds.has(id)),
+        humanFirst: true,
+      },
+      { onSuccess: () => onClose() },
+    );
+  };
+
+  return (
+    <Modal open={open} onClose={onClose} title="Start Poker" width="max-w-md">
+      <div className="space-y-4 p-1">
+        {/* Players */}
+        <section>
+          <h3 className="mb-2 text-sm font-semibold text-[var(--foreground)]">Players</h3>
+          {charIds.length === 0 ? (
+            <p className="text-sm text-[var(--muted-foreground)]">Add at least one character to this chat to play.</p>
+          ) : (
+            <div className="space-y-1">
+              {charIds.map((id) => {
+                const checked = selectedIds.has(id);
+                const capped = !checked && selectedIds.size >= MAX_BOTS;
+                return (
+                  <label
+                    key={id}
+                    className={`flex items-center gap-2 rounded-lg px-2 py-1.5 hover:bg-[var(--muted)] ${
+                      capped ? "cursor-not-allowed opacity-50" : "cursor-pointer"
+                    }`}
+                  >
+                    <input
+                      type="checkbox"
+                      checked={checked}
+                      disabled={capped}
+                      onChange={() => toggleSelected(id)}
+                      className="accent-[var(--primary)]"
+                    />
+                    <span className="text-sm text-[var(--foreground)]">{nameById.get(id) ?? id}</span>
+                  </label>
+                );
+              })}
+            </div>
+          )}
+          <p className="mt-1 text-xs text-[var(--muted-foreground)]">8 seats max (you + up to {MAX_BOTS} characters).</p>
+        </section>
+
+        {/* Dealer */}
+        <section>
+          <h3 className="mb-2 text-sm font-semibold text-[var(--foreground)]">Dealer</h3>
+          <select
+            value={dealerCharacterId ?? ""}
+            onChange={(e) => setDealerCharacterId(e.target.value || null)}
+            className="w-full rounded-lg border border-[var(--border)] bg-[var(--background)] px-2 py-1.5 text-sm text-[var(--foreground)]"
+          >
+            <option value="">House dealer (silent)</option>
+            {charIds.map((id) => (
+              <option key={id} value={id}>
+                {nameById.get(id) ?? id}
+              </option>
+            ))}
+          </select>
+          <p className="mt-1 text-xs text-[var(--muted-foreground)]">
+            A character dealer announces hands, flops and showdowns in their own voice. The house dealer deals silently.
+            The cards are dealt fairly either way.
+          </p>
+        </section>
+
+        {/* Stakes */}
+        <section>
+          <h3 className="mb-2 text-sm font-semibold text-[var(--foreground)]">Stakes</h3>
+          <div className="grid grid-cols-2 gap-3">
+            <label className="text-sm text-[var(--foreground)]">
+              Starting stack
+              <input
+                type="number"
+                min={100}
+                max={1_000_000}
+                value={startingStack}
+                onChange={(e) => setStartingStack(Math.max(100, Number(e.target.value) || DEFAULT_POKER_CONFIG.startingStack))}
+                className="mt-1 w-full rounded-lg border border-[var(--border)] bg-[var(--background)] px-2 py-1 text-sm text-[var(--foreground)]"
+              />
+            </label>
+            <label className="text-sm text-[var(--foreground)]">
+              Small blind
+              <input
+                type="number"
+                min={1}
+                value={smallBlind}
+                onChange={(e) => setSmallBlind(Math.max(1, Number(e.target.value) || DEFAULT_POKER_CONFIG.smallBlind))}
+                className="mt-1 w-full rounded-lg border border-[var(--border)] bg-[var(--background)] px-2 py-1 text-sm text-[var(--foreground)]"
+              />
+              <span className="mt-0.5 block text-xs text-[var(--muted-foreground)]">Big blind is double ({bigBlind}).</span>
+            </label>
+            <label className="text-sm text-[var(--foreground)]">
+              Blinds double every
+              <input
+                type="number"
+                min={0}
+                value={blindIncreaseEveryHands}
+                onChange={(e) => setBlindIncreaseEveryHands(Math.max(0, Number(e.target.value) || 0))}
+                className="mt-1 w-full rounded-lg border border-[var(--border)] bg-[var(--background)] px-2 py-1 text-sm text-[var(--foreground)]"
+              />
+              <span className="mt-0.5 block text-xs text-[var(--muted-foreground)]">Hands (0 = never).</span>
+            </label>
+            <label className="text-sm text-[var(--foreground)]">
+              Hand limit
+              <input
+                type="number"
+                min={0}
+                value={handLimit}
+                onChange={(e) => setHandLimit(Math.max(0, Number(e.target.value) || 0))}
+                className="mt-1 w-full rounded-lg border border-[var(--border)] bg-[var(--background)] px-2 py-1 text-sm text-[var(--foreground)]"
+              />
+              <span className="mt-0.5 block text-xs text-[var(--muted-foreground)]">0 = play until someone busts.</span>
+            </label>
+          </div>
+        </section>
+
+        <div className="flex items-center justify-end gap-2 pt-1">
+          <button
+            type="button"
+            onClick={onClose}
+            className="rounded-lg px-3 py-1.5 text-sm text-[var(--muted-foreground)] hover:bg-[var(--muted)]"
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            disabled={!canStart}
+            onClick={startGame}
+            className="flex items-center gap-1.5 rounded-lg bg-[var(--primary)] px-4 py-1.5 text-sm font-semibold text-[var(--primary-foreground)] transition-transform active:scale-95 disabled:opacity-50"
+          >
+            <Spade className="h-4 w-4" />
+            {start.isPending ? "Dealing…" : `Deal (${botCount + 1}p)`}
+          </button>
+        </div>
+      </div>
+    </Modal>
+  );
+}

--- a/packages/client/src/hooks/use-generate.ts
+++ b/packages/client/src/hooks/use-generate.ts
@@ -409,6 +409,7 @@ import { useGameModeStore } from "../stores/game-mode.store";
 import { useGameStateStore } from "../stores/game-state.store";
 import { useUnoGameStore } from "../stores/uno-game.store";
 import { useChessGameStore } from "../stores/chess-game.store";
+import { usePokerGameStore } from "../stores/poker-game.store";
 import { useTranslationStore } from "../stores/translation.store";
 import { useUIStore } from "../stores/ui.store";
 import {
@@ -1843,6 +1844,7 @@ export function useGenerate() {
                 // returning to the chat refetches the board.
                 if (turnGameType === "chess") useChessGameStore.getState().clearChess(params.chatId);
                 else if (turnGameType === "uno") useUnoGameStore.getState().clearUno(params.chatId);
+                else if (turnGameType === "poker") usePokerGameStore.getState().clearPoker(params.chatId);
                 void qc.invalidateQueries({ queryKey: turnGameKeys.state(params.chatId) });
                 break;
               }
@@ -1850,6 +1852,8 @@ export function useGenerate() {
                 useChessGameStore.getState().setChess(event.data as never, params.chatId);
               } else if (turnGameType === "uno") {
                 useUnoGameStore.getState().setUno(event.data as never, params.chatId);
+              } else if (turnGameType === "poker") {
+                usePokerGameStore.getState().setPoker(event.data as never, params.chatId);
               }
               break;
             }
@@ -3002,6 +3006,7 @@ export function useGenerate() {
                 // returning to the chat refetches the board.
                 if (turnGameType === "chess") useChessGameStore.getState().clearChess(chatId);
                 else if (turnGameType === "uno") useUnoGameStore.getState().clearUno(chatId);
+                else if (turnGameType === "poker") usePokerGameStore.getState().clearPoker(chatId);
                 void qc.invalidateQueries({ queryKey: turnGameKeys.state(chatId) });
                 break;
               }
@@ -3009,6 +3014,8 @@ export function useGenerate() {
                 useChessGameStore.getState().setChess(event.data as never, chatId);
               } else if (turnGameType === "uno") {
                 useUnoGameStore.getState().setUno(event.data as never, chatId);
+              } else if (turnGameType === "poker") {
+                usePokerGameStore.getState().setPoker(event.data as never, chatId);
               }
               break;
             }

--- a/packages/client/src/hooks/use-poker.ts
+++ b/packages/client/src/hooks/use-poker.ts
@@ -1,0 +1,146 @@
+// ──────────────────────────────────────────────
+// Hook: Turn-Game (Poker) API
+// ──────────────────────────────────────────────
+// Mirrors use-chess.ts against the same game-agnostic /turn-games REST surface.
+// Reuses turnGameKeys' query-key root (one chat has at most one active turn-game,
+// so every board shares the /state resource and invalidation stays coherent).
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { toast } from "sonner";
+import { ApiError, api } from "../lib/api-client";
+import { chatKeys } from "./use-chats";
+import { useGenerate } from "./use-generate";
+import { usePokerGameStore } from "../stores/poker-game.store";
+import { turnGameKeys } from "./turn-game-keys";
+import type { PokerConfig, PokerMove, PokerPublicView } from "@marinara-engine/shared";
+
+interface StateResponse {
+  view: PokerPublicView | { gameType?: string };
+}
+
+interface OutcomeResponse {
+  ok: boolean;
+  view?: PokerPublicView;
+  error?: string;
+  finished?: boolean;
+  winnerSeatId?: string | null;
+  currentSeatId?: string | null;
+  legalMoves?: unknown[];
+}
+
+export interface StartPokerBody {
+  gameType: "poker";
+  config?: Partial<PokerConfig>;
+  botCharacterIds: string[];
+  humanFirst?: boolean;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === "object" && !Array.isArray(value);
+}
+
+function isPokerView(view: unknown): view is PokerPublicView {
+  return isRecord(view) && view.gameType === "poker";
+}
+
+/**
+ * Open a generate request to drive the bot seats, but only when the resulting
+ * turn belongs to a bot (not the human, and not a finished game) — OR when the
+ * dealer has queued announcements that still need draining. Poker queues
+ * dealer narration (hand start, street deals, showdown) that the bot loop is
+ * responsible for draining even when it's the human's turn — e.g. the human's
+ * own call closes the betting round and reveals the flop, which queues a
+ * "flop is dealt" announcement with nobody's move pending. The server loop
+ * no-ops harmlessly if there's nothing to do, so firing it speculatively here
+ * is safe.
+ */
+function maybeFireBotTurns(
+  qc: ReturnType<typeof useQueryClient>,
+  generate: ReturnType<typeof useGenerate>["generate"],
+  chatId: string,
+  res: OutcomeResponse | undefined,
+): void {
+  const view = res?.view;
+  if (!view || res?.finished) return;
+  const botTurn = !!res?.currentSeatId && res.currentSeatId !== view.yourSeatId;
+  const pendingAnnouncements = isPokerView(view) && view.hasPendingAnnouncements === true;
+  if (!botTurn && !pendingAnnouncements) return;
+  const chat =
+    qc.getQueryData<{ connectionId?: string | null }>(chatKeys.detail(chatId)) ??
+    (qc.getQueryData<Array<{ id: string; connectionId?: string | null }>>(chatKeys.list()) ?? []).find(
+      (c) => c.id === chatId,
+    );
+  generate({ chatId, connectionId: chat?.connectionId ?? null, turnGameBots: true });
+}
+
+/** Fetch the current table for a chat (404 = no active game). Feeds the poker store
+ * only when the active turn-game IS poker; other game types are left alone. */
+export function usePokerState(chatId: string | null) {
+  return useQuery({
+    queryKey: chatId ? [...turnGameKeys.state(chatId), "poker"] : [...turnGameKeys.all, "state", "none", "poker"],
+    enabled: !!chatId,
+    staleTime: 30_000,
+    retry: false,
+    queryFn: async () => {
+      if (!chatId) return null;
+      try {
+        const res = await api.get<StateResponse>(`/turn-games/${chatId}/state`);
+        if (isPokerView(res?.view)) usePokerGameStore.getState().setPoker(res.view, chatId);
+        else if (res?.view) usePokerGameStore.getState().clearPoker(chatId); // another game type is active
+        return res;
+      } catch (err) {
+        if (err instanceof ApiError && err.status === 404) {
+          usePokerGameStore.getState().clearPoker(chatId);
+          return null;
+        }
+        throw err;
+      }
+    },
+  });
+}
+
+export function useStartPoker(chatId: string) {
+  const qc = useQueryClient();
+  const { generate } = useGenerate();
+  return useMutation({
+    mutationFn: (body: StartPokerBody) => api.post<OutcomeResponse>(`/turn-games/${chatId}/start`, body),
+    onSuccess: (res) => {
+      if (isPokerView(res?.view)) usePokerGameStore.getState().setPoker(res.view, chatId);
+      qc.invalidateQueries({ queryKey: turnGameKeys.state(chatId) });
+      // Blinds post automatically and hole cards deal on start, so the bot loop
+      // (and any dealer announcements) may need to run right away.
+      maybeFireBotTurns(qc, generate, chatId, res);
+    },
+    onError: (err: unknown) => toast.error(err instanceof Error ? err.message : "Failed to start the game"),
+  });
+}
+
+export function usePokerMove(chatId: string) {
+  const qc = useQueryClient();
+  const { generate } = useGenerate();
+  return useMutation({
+    mutationFn: (vars: { move: PokerMove }) => api.post<OutcomeResponse>(`/turn-games/${chatId}/move`, vars),
+    onSuccess: (res) => {
+      if (isPokerView(res?.view)) usePokerGameStore.getState().setPoker(res.view, chatId);
+      // Open a generate request so the server drives the bot seats over SSE.
+      maybeFireBotTurns(qc, generate, chatId, res);
+    },
+    onError: (err: unknown) => {
+      // The server returns 409 with { error, legalMoves, view } for an illegal move.
+      if (err instanceof ApiError && isRecord(err.payload) && isPokerView(err.payload.view)) {
+        usePokerGameStore.getState().setPoker(err.payload.view, chatId);
+      }
+      toast.error(err instanceof Error ? err.message : "Illegal move");
+    },
+  });
+}
+
+export function useResignPoker(chatId: string) {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: () => api.post(`/turn-games/${chatId}/resign`, {}),
+    onSuccess: () => {
+      usePokerGameStore.getState().clearPoker(chatId);
+      qc.invalidateQueries({ queryKey: turnGameKeys.state(chatId) });
+    },
+  });
+}

--- a/packages/client/src/lib/slash-commands.ts
+++ b/packages/client/src/lib/slash-commands.ts
@@ -6,6 +6,7 @@ import { useChatStore } from "../stores/chat.store";
 import { useUIStore } from "../stores/ui.store";
 import { useUnoGameStore } from "../stores/uno-game.store";
 import { useChessGameStore } from "../stores/chess-game.store";
+import { usePokerGameStore } from "../stores/poker-game.store";
 import { useGalleryStore } from "../stores/gallery.store";
 import { toast } from "sonner";
 import {
@@ -575,6 +576,19 @@ const COMMANDS: SlashCommand[] = [
         return { handled: true, feedback: "Chess can only be played in conversation chats." };
       }
       useChessGameStore.getState().openSetup(ctx.chatId);
+      return { handled: true };
+    },
+  },
+  {
+    name: "poker",
+    description: "Start a game of Texas Hold'em poker with the characters in this chat",
+    usage: "/poker",
+    local: true,
+    async execute(_args, ctx) {
+      if (ctx.mode === "roleplay") {
+        return { handled: true, feedback: "Poker can only be played in conversation chats." };
+      }
+      usePokerGameStore.getState().openSetup(ctx.chatId);
       return { handled: true };
     },
   },

--- a/packages/client/src/stores/poker-game.store.ts
+++ b/packages/client/src/stores/poker-game.store.ts
@@ -1,0 +1,36 @@
+// ──────────────────────────────────────────────
+// Zustand Store: Poker Table (turn-game #3)
+// ──────────────────────────────────────────────
+// Holds the live, per-viewer poker snapshot pushed by the server
+// (turn_game_state_patch SSE, dispatched by gameType) or fetched on mount.
+// chatId-guarded so a background chat's game can never paint over the visible
+// table. Synchronous only — all async lives in use-poker.ts.
+import { create } from "zustand";
+import type { PokerPublicView } from "@marinara-engine/shared";
+
+export type PokerBoardSnapshot = PokerPublicView & { chatId: string };
+
+interface PokerGameStore {
+  current: PokerBoardSnapshot | null;
+  /** Chat whose setup modal is open (null = closed). Driven by the /poker command. */
+  setupChatId: string | null;
+  /** Replace the table with a fresh server snapshot for a chat. */
+  setPoker: (view: PokerPublicView, chatId: string) => void;
+  /** Clear the table (optionally only if it belongs to a given chat). */
+  clearPoker: (chatId?: string) => void;
+  /** Open the game-setup modal for a chat. */
+  openSetup: (chatId: string) => void;
+  closeSetup: () => void;
+  reset: () => void;
+}
+
+export const usePokerGameStore = create<PokerGameStore>((set) => ({
+  current: null,
+  setupChatId: null,
+  setPoker: (view, chatId) => set({ current: { ...view, chatId } }),
+  clearPoker: (chatId) =>
+    set((state) => (!chatId || state.current?.chatId === chatId ? { current: null } : {})),
+  openSetup: (chatId) => set({ setupChatId: chatId }),
+  closeSetup: () => set({ setupChatId: null }),
+  reset: () => set({ current: null, setupChatId: null }),
+}));

--- a/packages/server/src/routes/conversation-calls.routes.ts
+++ b/packages/server/src/routes/conversation-calls.routes.ts
@@ -480,6 +480,8 @@ function getCallConversationCommandKey(command: CharacterCommand): ConversationC
       return "uno";
     case "chess":
       return "chess";
+    case "poker":
+      return "poker";
     case "spotify":
     case "youtube":
       return "music";

--- a/packages/server/src/services/conversation/character-commands.ts
+++ b/packages/server/src/services/conversation/character-commands.ts
@@ -14,6 +14,7 @@
 // - [call] or [call: reason="..."] (ring the user for an audio call; Conversation mode)
 // - [uno] (start a game of UNO at the table; Conversation mode)
 // - [chess] (start a one-on-one chess game against the user; Conversation mode)
+// - [poker] (start a game of Texas Hold'em poker at the table; Conversation mode)
 // - [spotify: title="Song title", artist="Artist"] (play a song on the user's active Spotify player)
 // - [youtube: query="Song title Artist"] (play a song on the user's active YouTube player)
 // - [react: emoji="😂"] or [react: emoji=":custom_name:"] (react to the user's latest message; Conversation mode)
@@ -92,6 +93,11 @@ export interface UnoCommand {
 export interface ChessCommand {
   /** Start a one-on-one chess game against the user. Param-less; the system sets up + runs the board. */
   type: "chess";
+}
+
+export interface PokerCommand {
+  /** Start a game of Texas Hold'em poker at the table. Param-less; the system seats + runs the game. */
+  type: "poker";
 }
 
 export interface InfluenceCommand {
@@ -352,6 +358,7 @@ export type CharacterCommand =
   | CallCommand
   | UnoCommand
   | ChessCommand
+  | PokerCommand
   | InfluenceCommand
   | NoteCommand
   | DirectMessageCommand
@@ -380,6 +387,8 @@ const CALL_RE = new RegExp(`\\[call(?::\\s*(${QUOTED_PARAM_BLOCK}))?\\]`, "gi");
 const UNO_RE = /\[uno(?::[^\]\r\n]*)?\]/gi;
 // Param-less chess trigger. Same tolerant shape as UNO_RE.
 const CHESS_RE = /\[chess(?::[^\]\r\n]*)?\]/gi;
+// Param-less poker trigger. Same tolerant shape as UNO_RE.
+const POKER_RE = /\[poker(?::[^\]\r\n]*)?\]/gi;
 const HAPTIC_RE = new RegExp(`\\[haptic:\\s*(${QUOTED_PARAM_BLOCK})\\]`, "gi");
 const SPOTIFY_RE = new RegExp(`\\[spotify:\\s*(${QUOTED_PARAM_BLOCK})\\]`, "gi");
 const YOUTUBE_RE = new RegExp(`\\[youtube:\\s*(${QUOTED_PARAM_BLOCK})\\]`, "gi");
@@ -1012,6 +1021,12 @@ export function parseCharacterCommands(content: string): {
     break;
   }
 
+  // Parse poker command — start a game of Texas Hold'em. Param-less; only one per message.
+  for (const _pokerMatch of content.matchAll(POKER_RE)) {
+    commands.push({ type: "poker" });
+    break;
+  }
+
   // Parse influence commands (<influence>text</influence>)
   for (const match of content.matchAll(INFLUENCE_RE)) {
     const text = stripConversationPromptTimestamps(match[1]!.trim());
@@ -1216,6 +1231,7 @@ export function parseCharacterCommands(content: string): {
     .replace(CALL_RE, "")
     .replace(UNO_RE, "")
     .replace(CHESS_RE, "")
+    .replace(POKER_RE, "")
     .replace(HAPTIC_RE, "")
     .replace(SPOTIFY_RE, "")
     .replace(YOUTUBE_RE, "")

--- a/packages/server/src/services/generation/conversation-command-runtime.ts
+++ b/packages/server/src/services/generation/conversation-command-runtime.ts
@@ -66,6 +66,8 @@ function getConversationCommandKey(command: CharacterCommand): ConversationComma
       return "uno";
     case "chess":
       return "chess";
+    case "poker":
+      return "poker";
     case "spotify":
     case "youtube":
       return "music";
@@ -251,7 +253,7 @@ export async function buildConversationCommandsReminder(args: {
       `   - You invite {{user}} somewhere and they accept → trigger a scene for that activity.`,
       `   - A plan is made (date, trip, hangout, confrontation) and the moment arrives → trigger a scene.`,
       `   Do NOT wait for {{user}} to explicitly ask for a scene. If the conversation implies you and {{user}} are about to DO something together, initiate the scene yourself.`,
-      `   EXCEPTION: Do NOT start a scene for playing UNO, chess, cards, or other board/table games — those have their own commands. Use [uno] for UNO and [chess] for chess, not [scene].`,
+      `   EXCEPTION: Do NOT start a scene for playing UNO, chess, poker, cards, or other board/table games — those have their own commands. Use [uno] for UNO, [chess] for chess, and [poker] for poker, not [scene].`,
     );
   }
 
@@ -266,7 +268,10 @@ export async function buildConversationCommandsReminder(args: {
     chatMode === "conversation" && isConversationCommandEnabled(chatMeta, "uno") && characterIds.length >= 1;
   const chessAdvertisable =
     chatMode === "conversation" && isConversationCommandEnabled(chatMeta, "chess") && characterIds.length >= 1;
-  const noActiveTurnGame = (unoAdvertisable || chessAdvertisable) && !(await getActiveTurnGame(args.db, args.chatId));
+  const pokerAdvertisable =
+    chatMode === "conversation" && isConversationCommandEnabled(chatMeta, "poker") && characterIds.length >= 1;
+  const noActiveTurnGame =
+    (unoAdvertisable || chessAdvertisable || pokerAdvertisable) && !(await getActiveTurnGame(args.db, args.chatId));
   if (unoAdvertisable && noActiveTurnGame) {
     addCommandLines(
       `- [uno] - start a game of UNO at the table. Include this ONLY when ${personaName} proposes playing UNO (or cards) and you are willing to play right now. The system deals the cards and runs the game — you do NOT narrate dealing or describe the hands.`,
@@ -279,6 +284,13 @@ export async function buildConversationCommandsReminder(args: {
       `- [chess] - start a one-on-one chess game against ${personaName}. Include this ONLY when ${personaName} proposes playing chess and YOU are willing to play right now. Chess seats exactly two players: ${personaName} and you — whichever character includes [chess] takes the opponent's seat. The system sets up the board and runs the game — you do NOT describe the board or narrate setup.`,
       `   If you'd rather not play, say so in character and do NOT include [chess]. Agreeing to play IS including [chess].`,
       `   Example: ${personaName} says "up for a game of chess?" and you're in → "Prepare to lose your queen. [chess]"`,
+    );
+  }
+  if (pokerAdvertisable && noActiveTurnGame) {
+    addCommandLines(
+      `- [poker] - start a game of Texas Hold'em poker at the table. Include this ONLY when ${personaName} proposes playing poker and you are willing to play right now. The system seats ${personaName} plus every willing character at the table and runs the game — you do NOT narrate dealing, blinds, or describe anyone's cards.`,
+      `   If you are busy, tired, or simply don't feel like it, just say so in character and do NOT include [poker]. Agreeing to play IS including [poker].`,
+      `   Example: ${personaName} says "who's up for some poker?" and you're in → "Deal me in. [poker]"`,
     );
   }
 

--- a/packages/server/src/services/generation/turn-game-command-runtime.ts
+++ b/packages/server/src/services/generation/turn-game-command-runtime.ts
@@ -1,5 +1,7 @@
 import type { FastifyReply } from "fastify";
 
+import { pokerEngine } from "@marinara-engine/shared";
+
 import type { DB } from "../../db/connection.js";
 import { logger } from "../../lib/logger.js";
 import { getEnabledConversationSchedules } from "./conversation-context-utils.js";
@@ -25,6 +27,10 @@ export async function handleTurnGameCommand(args: {
   }
   if (args.commandType === "chess") {
     await startChessFromCommand(args);
+    return true;
+  }
+  if (args.commandType === "poker") {
+    await startPokerFromCommand(args);
     return true;
   }
   return false;
@@ -116,5 +122,70 @@ async function startChessFromCommand(args: Parameters<typeof handleTurnGameComma
     }
   } catch (err) {
     logger.error(err, "[commands] chess start failed");
+  }
+}
+
+async function startPokerFromCommand(args: Parameters<typeof handleTurnGameCommand>[0]): Promise<void> {
+  try {
+    const existingGame = await getActiveTurnGame(args.db, args.chatId);
+    if (existingGame) {
+      logger.info("[commands] poker requested but a game is already active in chat %s", args.chatId);
+      return;
+    }
+
+    const pokerChat = await args.chats.getById(args.chatId);
+    let pokerCharIds: string[] = [];
+    try {
+      const rawCharIds = pokerChat?.characterIds;
+      const parsedCharIds = typeof rawCharIds === "string" ? JSON.parse(rawCharIds) : rawCharIds;
+      if (Array.isArray(parsedCharIds)) {
+        pokerCharIds = parsedCharIds.filter((value): value is string => typeof value === "string");
+      }
+    } catch {
+      pokerCharIds = [];
+    }
+
+    const pokerSchedules = getEnabledConversationSchedules(args.chatMeta) as Record<string, WeekSchedule>;
+    const seatBotIds = pokerCharIds.filter((cid) => {
+      const sched = pokerSchedules[cid];
+      return !sched || getCurrentStatus(sched).status !== "offline";
+    });
+    if (args.characterId && pokerCharIds.includes(args.characterId) && !seatBotIds.includes(args.characterId)) {
+      seatBotIds.push(args.characterId);
+    }
+
+    // Poker seats at most pokerEngine.maxPlayers total (human + bots). If more
+    // willing characters exist than fit, trim the extras — keeping the agreeing
+    // character first so the character that just said yes always gets a seat.
+    const maxBotSeats = Math.max(0, pokerEngine.maxPlayers - 1);
+    let seatedBotIds = seatBotIds;
+    if (seatBotIds.length > maxBotSeats) {
+      const ordered = args.characterId
+        ? [args.characterId, ...seatBotIds.filter((id) => id !== args.characterId)]
+        : seatBotIds;
+      seatedBotIds = ordered.slice(0, maxBotSeats);
+    }
+
+    const outcome = await startTurnGame(args.db, args.chatId, {
+      gameType: "poker",
+      botCharacterIds: seatedBotIds,
+      humanFirst: true,
+    });
+    if (outcome.ok) {
+      args.reply.raw.write(`data: ${JSON.stringify({ type: "turn_game_state_patch", data: outcome.view })}\n\n`);
+      logger.info("[commands] poker started in chat %s with %d player(s)", args.chatId, seatedBotIds.length + 1);
+      await runTurnGameBotTurns({
+        db: args.db,
+        chatId: args.chatId,
+        conn: args.conn,
+        baseUrl: args.baseUrl,
+        reply: args.reply,
+        signal: args.signal,
+      });
+    } else {
+      logger.warn("[commands] poker start failed in chat %s: %s", args.chatId, outcome.error ?? "");
+    }
+  } catch (err) {
+    logger.error(err, "[commands] poker start failed");
   }
 }

--- a/packages/server/src/services/turn-games/turn-game-bot-runner.service.ts
+++ b/packages/server/src/services/turn-games/turn-game-bot-runner.service.ts
@@ -22,10 +22,13 @@ import { trySendSseEvent } from "../../routes/generate/sse.js";
 import { createCharactersStorage } from "../storage/characters.storage.js";
 import { createChatsStorage } from "../storage/chats.storage.js";
 import { createGameEngineStateStorage } from "../storage/game-engine-state.storage.js";
-import { getActiveTurnGame } from "./turn-game-runner.service.js";
+import { getActiveTurnGame, loadTurnGameForDrain } from "./turn-game-runner.service.js";
 
 const MAX_BOT_TURNS = 100;
 const HUMAN_FALLBACK_SEAT = "human";
+
+/** The non-null shape `getActiveTurnGame` / `loadTurnGameForDrain` resolve to. */
+type ActiveTurnGame = NonNullable<Awaited<ReturnType<typeof getActiveTurnGame>>>;
 
 interface RunBotTurnsArgs {
   db: DB;
@@ -114,6 +117,135 @@ async function buildRecentContext(
 }
 
 /**
+ * Drain any dealer-narration events an engine has queued on `active.state` (e.g.
+ * poker's hand-start / street-deal / showdown / blinds-up / game-over milestones)
+ * and persist the queue-cleared snapshot. Game-agnostic: engines that don't
+ * implement `drainAnnouncements` (UNO, chess) make this a no-op via the optional-
+ * method guard below, so nothing about their behavior changes.
+ *
+ * When the engine names a dealer character (`announcerCharacterId`), the queued
+ * events are voiced as ONE short in-character line and persisted as a real
+ * assistant message (mirroring the move loop's narration persistence exactly,
+ * including its message-save-failure fallback). A silent "house" dealer
+ * (`announcerCharacterId` returns null) still drains + persists the state and
+ * pushes the board patch — it just never creates a message.
+ *
+ * STALL-GUARD NOTE: this is called at the very top of every loop iteration,
+ * before the loop's `lastSignature` stall-detection signature is computed. That
+ * is safe from a live-lock: draining clears `pendingAnnouncements`, which is
+ * itself part of the state the signature hashes, so the FIRST drain after a
+ * move always changes the signature (queue: [...] -> []) and the loop proceeds
+ * normally. `drainAnnouncements` is idempotent once the queue is empty — it
+ * returns `null` and this function no-ops — so a second consecutive iteration
+ * on the same (already-drained) state reproduces the SAME signature as before,
+ * which is exactly what should trip the stall guard for a genuinely stuck seat.
+ * Draining can therefore never itself be the cause of an infinite loop; it can
+ * only ever make the existing stall guard fire one iteration later than before.
+ */
+async function drainAndVoiceAnnouncements(args: {
+  chatId: string;
+  active: ActiveTurnGame;
+  humanSeatId: string;
+  chats: ReturnType<typeof createChatsStorage>;
+  characters: ReturnType<typeof createCharactersStorage>;
+  engineStorage: ReturnType<typeof createGameEngineStateStorage>;
+  provider: BaseLLMProvider;
+  model: string;
+  reply: FastifyReply;
+  turnIndex: number;
+  signal?: AbortSignal;
+}): Promise<{ state: unknown } | null> {
+  const { chatId, active, humanSeatId, chats, characters, engineStorage, provider, model, reply, turnIndex, signal } = args;
+  const { engine, state } = active;
+
+  if (typeof engine.drainAnnouncements !== "function") return null;
+  const drained = engine.drainAnnouncements(state);
+  if (!drained) return null;
+
+  const { state: nextState, announcements } = drained;
+  const eventSummary = announcements
+    .map((e: { message?: string }) => e.message)
+    .filter(Boolean)
+    .join(" ");
+
+  const dealerCharId =
+    typeof engine.announcerCharacterId === "function" ? engine.announcerCharacterId(nextState) : null;
+
+  let dealerLine = "";
+  if (dealerCharId && eventSummary) {
+    const seatNames = (nextState as { seatNames?: Record<string, string> }).seatNames ?? {};
+    let fallbackName = seatNames[dealerCharId] ?? dealerCharId;
+    if (!seatNames[dealerCharId]) {
+      try {
+        const row = await characters.getById(dealerCharId);
+        if (row?.data) {
+          const data = JSON.parse(row.data) as { name?: unknown };
+          if (typeof data.name === "string" && data.name.trim()) fallbackName = data.name.trim();
+        }
+      } catch {
+        // best-effort — fall back to the id
+      }
+    }
+
+    // Whose-turn marker before the voiced dealer line, matching the loop's
+    // existing group_turn marker for bot moves.
+    trySendSseEvent(reply, {
+      type: "group_turn",
+      data: { characterId: dealerCharId, characterName: fallbackName, index: turnIndex },
+    });
+
+    const persona = await buildPersonaBlock(characters, dealerCharId, fallbackName);
+    dealerLine = await narrateAnnouncements(provider, model, persona, engine.label, eventSummary, signal);
+  }
+  if (!dealerLine) dealerLine = eventSummary;
+
+  if (dealerCharId && dealerLine) {
+    const saved = await chats.createMessage({ chatId, role: "assistant", characterId: dealerCharId, content: dealerLine });
+    if (saved) {
+      await engineStorage.create({
+        chatId,
+        messageId: saved.id,
+        swipeIndex: saved.activeSwipeIndex ?? 0,
+        gameType: engine.gameType,
+        schemaVersion: engine.schemaVersion,
+        state: JSON.stringify(nextState),
+        committed: true,
+      });
+      trySendSseEvent(reply, { type: "message_saved", data: saved });
+    } else {
+      // Persistence of the dealer message failed — still advance engine state so
+      // the queue doesn't grow unbounded and the game keeps moving.
+      await engineStorage.create({
+        chatId,
+        messageId: "",
+        swipeIndex: 0,
+        gameType: engine.gameType,
+        schemaVersion: engine.schemaVersion,
+        state: JSON.stringify(nextState),
+        committed: true,
+      });
+    }
+  } else {
+    // Silent house dealer (or nothing worth saying) — persist the drained state
+    // with no message, single-live-row idiom.
+    await engineStorage.create({
+      chatId,
+      messageId: "",
+      swipeIndex: 0,
+      gameType: engine.gameType,
+      schemaVersion: engine.schemaVersion,
+      state: JSON.stringify(nextState),
+      committed: true,
+    });
+  }
+
+  // Push the redacted human-perspective board so the client clears
+  // hasPendingAnnouncements and sees the drained state live.
+  trySendSseEvent(reply, { type: "turn_game_state_patch", data: engine.publicView(nextState, humanSeatId) });
+  return { state: nextState };
+}
+
+/**
  * Run every pending bot seat for the chat's active turn-game. No-ops if there
  * is no active game or it is currently the human's turn.
  */
@@ -146,8 +278,31 @@ export async function runTurnGameBotTurns(args: RunBotTurnsArgs): Promise<void> 
   for (; turn < MAX_BOT_TURNS; turn++) {
     if (signal?.aborted) break;
 
-    const active = await getActiveTurnGame(db, chatId);
+    let active = await getActiveTurnGame(db, chatId);
     if (!active) break; // no game, or game finished
+
+    // Drain + voice any dealer announcements queued on this state BEFORE deciding
+    // whose turn it is. This must run even when control is about to go straight
+    // back to the human — e.g. a street-closing move BY the human queues a
+    // "Flop: ..." announcement but leaves currentSeat pointed at the human, so
+    // draining here (not after the human-turn break below) is what gets it
+    // voiced. See drainAndVoiceAnnouncements' doc comment for why this can't
+    // create a live-lock with the stall guard below.
+    const drained = await drainAndVoiceAnnouncements({
+      chatId,
+      active,
+      humanSeatId,
+      chats,
+      characters,
+      engineStorage,
+      provider,
+      model,
+      reply,
+      turnIndex: turn,
+      signal,
+    });
+    if (drained) active = { ...active, state: drained.state };
+
     const { engine, state } = active;
     const seatId = engine.currentSeat(state);
     if (!seatId || seatId === humanSeatId) break; // hand control back to the human
@@ -280,6 +435,30 @@ export async function runTurnGameBotTurns(args: RunBotTurnsArgs): Promise<void> 
     trySendSseEvent(reply, { type: "turn_game_state_patch", data: engine.publicView(nextState, humanSeatId) });
   }
 
+  // Final drain: a showdown/game_over (or any other) announcement queued by the
+  // LAST bot move in the loop above never gets its own top-of-loop iteration —
+  // once the game finishes, `getActiveTurnGame` returns null and the loop breaks
+  // BEFORE draining; an aborted signal can likewise break the loop right after a
+  // queueing move was persisted. Load unconditionally (finished games included,
+  // via loadTurnGameForDrain) and drain once more so nothing is left stranded in
+  // the queue. Idempotent/cheap when there's nothing to drain.
+  const finalActive = await loadTurnGameForDrain(db, chatId);
+  if (finalActive) {
+    await drainAndVoiceAnnouncements({
+      chatId,
+      active: finalActive,
+      humanSeatId,
+      chats,
+      characters,
+      engineStorage,
+      provider,
+      model,
+      reply,
+      turnIndex: turn,
+      signal,
+    });
+  }
+
   // Reaching the cap (rather than handing control back / finishing / aborting)
   // means a bot is still on seat after MAX_BOT_TURNS consecutive bot moves —
   // effectively unreachable in real UNO (a finite deck can't skip the human that
@@ -322,6 +501,38 @@ async function narrateOutcome(
       { role: "user", content: `(You just ${did}.) Say your one line.` },
     ];
     const res = await provider.chatComplete(messages, { model, temperature: 0.9, maxTokens: 100, ...(signal ? { signal } : {}) });
+    return (res.content ?? "").trim();
+  } catch {
+    return "";
+  }
+}
+
+/** Voice a batch of queued dealer-announcement events as ONE short in-character line. */
+async function narrateAnnouncements(
+  provider: BaseLLMProvider,
+  model: string,
+  persona: string,
+  gameLabel: string,
+  eventSummary: string,
+  signal?: AbortSignal,
+): Promise<string> {
+  try {
+    const messages: ChatMessage[] = [
+      {
+        role: "system",
+        content:
+          `${persona}\n\n` +
+          `You are the dealer at this table's game of ${gameLabel}. Announce the following to the table in ONE ` +
+          `short line, fully in character — you may add flourish, teasing, or ceremony, but every fact below must ` +
+          `come through accurately. Facts: ${eventSummary}`,
+      },
+    ];
+    const res = await provider.chatComplete(messages, {
+      model,
+      temperature: 0.85,
+      maxTokens: 120,
+      ...(signal ? { signal } : {}),
+    });
     return (res.content ?? "").trim();
   } catch {
     return "";

--- a/packages/server/src/services/turn-games/turn-game-bot-runner.service.ts
+++ b/packages/server/src/services/turn-games/turn-game-bot-runner.service.ts
@@ -15,7 +15,8 @@
 // so it can never affect a normal conversation/roleplay generation.
 import type { FastifyReply } from "fastify";
 import type { DB } from "../../db/connection.js";
-import { logger } from "../../lib/logger.js";
+import { logDebugOverride, logger } from "../../lib/logger.js";
+import { isDebugAgentsEnabled } from "../../config/runtime-config.js";
 import type { BaseLLMProvider, ChatMessage, LLMToolDefinition } from "../llm/base-provider.js";
 import { createLLMProvider } from "../llm/provider-registry.js";
 import { trySendSseEvent } from "../../routes/generate/sse.js";
@@ -527,6 +528,14 @@ async function narrateAnnouncements(
           `come through accurately. Facts: ${eventSummary}`,
       },
     ];
+    // Prompt visibility for the new dealer-narration call: honors DEBUG_AGENTS
+    // (elevated via logDebugOverride so it shows even at the default warn level).
+    logDebugOverride(
+      isDebugAgentsEnabled(),
+      "[turn-game] dealer announcement prompt (model %s): %s",
+      model,
+      messages[0]?.content ?? "",
+    );
     const res = await provider.chatComplete(messages, {
       model,
       temperature: 0.85,

--- a/packages/server/src/services/turn-games/turn-game-runner.service.ts
+++ b/packages/server/src/services/turn-games/turn-game-runner.service.ts
@@ -346,6 +346,17 @@ export async function getActiveTurnGame(db: DB, chatId: string): Promise<LoadedG
 }
 
 /**
+ * Load the chat's latest game snapshot regardless of terminal status — unlike
+ * `getActiveTurnGame`, this returns a FINISHED game too. Used by the bot-turn
+ * loop's post-loop announcement drain: a showdown/game_over event queued by the
+ * last bot move needs to be voiced even though the game is now finished (at
+ * which point `getActiveTurnGame` would return null and hide it).
+ */
+export async function loadTurnGameForDrain(db: DB, chatId: string): Promise<LoadedGame | null> {
+  return loadGame(db, chatId, null);
+}
+
+/**
  * Load the chat's game once and return a per-seat context builder for it, so a
  * multi-character generation pays the game load (message-anchor scan + state
  * parse) once per request instead of once per responding character. Returns

--- a/packages/shared/scripts/generate-feature-registries.mjs
+++ b/packages/shared/scripts/generate-feature-registries.mjs
@@ -116,7 +116,7 @@ async function writeRegistry({
   await writeFile(outputPath, `${lines.join("\n")}\n`, "utf8");
 }
 
-const TURN_GAME_ORDER = ["uno", "chess"];
+const TURN_GAME_ORDER = ["uno", "chess", "poker"];
 
 await writeRegistry({
   baseDir: join(srcDir, "features", "agents"),

--- a/packages/shared/src/features/turn-games/engine.types.ts
+++ b/packages/shared/src/features/turn-games/engine.types.ts
@@ -151,6 +151,26 @@ export interface TurnGameEngine<TState, TMove, TConfig, TPublic = unknown> {
    * should still return a best-effort move that `applyMove` will reject.
    */
   parseToolCall(name: string, args: Record<string, unknown>): TMove | null;
+
+  /**
+   * OPTIONAL. The character that should voice this game's narration events
+   * (e.g. a poker dealer announcing blinds and street deals), or `null` for a
+   * silent/house narrator. Games without a narrator concept simply omit this
+   * method — the runner treats a missing method the same as always returning
+   * `null`. Purely a narration hint; it must never affect rules or dealing.
+   */
+  announcerCharacterId?(state: TState): string | null;
+
+  /**
+   * OPTIONAL. Drain any narration events an engine has queued on `state`
+   * (e.g. "Hand #3 — blinds 20/40", "Flop: A♥ T♦ 4♣ — pot 240") since they
+   * were last drained. Returns `null` when the queue is empty, otherwise the
+   * queue-cleared state plus the events, in the order they were queued. The
+   * runner calls this after every move and, when `announcerCharacterId` names
+   * a character, voices the returned events in that character's persona.
+   * Games without queued narration simply omit this method.
+   */
+  drainAnnouncements?(state: TState): { state: TState; announcements: GameEvent[] } | null;
 }
 
 /** A game engine with its generics erased — for registry storage and runner glue. */

--- a/packages/shared/src/features/turn-games/poker/deck.ts
+++ b/packages/shared/src/features/turn-games/poker/deck.ts
@@ -1,0 +1,128 @@
+// ──────────────────────────────────────────────
+// Poker — standard 52-card deck
+// ──────────────────────────────────────────────
+
+/** A suit letter: clubs, diamonds, hearts, spades. */
+export type Suit = "c" | "d" | "h" | "s";
+
+/** A single playing card. `rank` runs 2..14, where 14 is the ace. */
+export interface Card {
+  rank: number;
+  suit: Suit;
+}
+
+export const SUITS: readonly Suit[] = ["c", "d", "h", "s"];
+
+/** Ranks low to high: 2..10, then jack (11), queen (12), king (13), ace (14). */
+export const RANKS: readonly number[] = [2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14];
+
+/** Singular rank name, e.g. RANK_NAMES[14] === "ace". */
+export const RANK_NAMES: Readonly<Record<number, string>> = {
+  2: "two",
+  3: "three",
+  4: "four",
+  5: "five",
+  6: "six",
+  7: "seven",
+  8: "eight",
+  9: "nine",
+  10: "ten",
+  11: "jack",
+  12: "queen",
+  13: "king",
+  14: "ace",
+};
+
+/** Single-character rank code used in compact card codes, e.g. RANK_CODE[10] === "T". */
+const RANK_CODE: Readonly<Record<number, string>> = {
+  2: "2",
+  3: "3",
+  4: "4",
+  5: "5",
+  6: "6",
+  7: "7",
+  8: "8",
+  9: "9",
+  10: "T",
+  11: "J",
+  12: "Q",
+  13: "K",
+  14: "A",
+};
+
+const SUIT_NAMES: Readonly<Record<Suit, string>> = {
+  c: "Clubs",
+  d: "Diamonds",
+  h: "Hearts",
+  s: "Spades",
+};
+
+const SUIT_SYMBOLS: Readonly<Record<Suit, string>> = {
+  c: "♣",
+  d: "♦",
+  h: "♥",
+  s: "♠",
+};
+
+/** Plurals that don't just take a trailing "s" (e.g. "six" -> "sixes", not "sixs"). */
+const IRREGULAR_PLURALS: Readonly<Partial<Record<number, string>>> = {
+  6: "sixes",
+};
+
+/** Build a fresh, ORDERED standard 52-card deck (caller shuffles). Deterministic order: suit-major, rank-minor. */
+export function buildDeck(): Card[] {
+  const deck: Card[] = [];
+  for (const suit of SUITS) {
+    for (const rank of RANKS) {
+      deck.push({ rank, suit });
+    }
+  }
+  return deck;
+}
+
+/** Compact two-character code, e.g. "Ah", "Td", "9c". Rank is uppercase, suit is lowercase. */
+export function cardCode(card: Card): string {
+  return `${RANK_CODE[card.rank] ?? "?"}${card.suit}`;
+}
+
+/**
+ * Parse a compact card code. Tolerant of case ("ah" === "AH") and accepts
+ * "10" as an alternate spelling of "T" for ten (e.g. "10h"). Returns `null`
+ * for anything that doesn't resolve to a real card.
+ */
+export function cardFromCode(code: string): Card | null {
+  const trimmed = code.trim();
+  if (trimmed.length < 2) return null;
+
+  const suitChar = trimmed.slice(-1).toLowerCase();
+  const suit = SUITS.find((s) => s === suitChar);
+  if (!suit) return null;
+
+  let rankPart = trimmed.slice(0, -1).toUpperCase();
+  if (rankPart === "10") rankPart = "T";
+
+  const rank = RANKS.find((r) => RANK_CODE[r] === rankPart);
+  if (rank === undefined) return null;
+
+  return { rank, suit };
+}
+
+/** Full English label, e.g. "Ace of Hearts", "Ten of Diamonds". */
+export function cardLabel(card: Card): string {
+  const name = RANK_NAMES[card.rank] ?? "unknown";
+  const capitalized = name.charAt(0).toUpperCase() + name.slice(1);
+  return `${capitalized} of ${SUIT_NAMES[card.suit]}`;
+}
+
+/** Compact display with a unicode suit glyph, e.g. "A♥", "T♦". */
+export function cardShort(card: Card): string {
+  return `${RANK_CODE[card.rank] ?? "?"}${SUIT_SYMBOLS[card.suit]}`;
+}
+
+/** Plural rank name for hand labels, e.g. rankPluralName(13) === "kings", rankPluralName(6) === "sixes". */
+export function rankPluralName(rank: number): string {
+  const irregular = IRREGULAR_PLURALS[rank];
+  if (irregular) return irregular;
+  const base = RANK_NAMES[rank] ?? "unknown";
+  return `${base}s`;
+}

--- a/packages/shared/src/features/turn-games/poker/engine.manifest.ts
+++ b/packages/shared/src/features/turn-games/poker/engine.manifest.ts
@@ -1,0 +1,5 @@
+// Registry entry for the poker engine. The codegen scans turn-games/<game>/engine.manifest.ts
+// and collects the single exported const into TURN_GAME_ENGINES.
+import { pokerEngine } from "./engine.js";
+
+export const pokerGameEngine = pokerEngine;

--- a/packages/shared/src/features/turn-games/poker/engine.ts
+++ b/packages/shared/src/features/turn-games/poker/engine.ts
@@ -507,8 +507,11 @@ function dealNewHand(state: PokerState, events: GameEvent[]): void {
 
 /**
  * Layer `committedTotal` into main + side pots. Folded seats' chips count toward pot
- * amounts (dead money) but folded seats are never eligible to win. Pure — exported for
- * direct unit testing against hand-crafted commitment maps.
+ * amounts (dead money) but folded seats are never eligible to win. Layers whose
+ * ELIGIBLE set is identical are coalesced into one pot: a folder's dead money sitting
+ * below the callers' totals must not manufacture a "side pot" — real side pots exist
+ * only where an all-in actually splits who can win what. Pure — exported for direct
+ * unit testing against hand-crafted commitment maps.
  */
 export function buildPots(
   committedTotal: Record<string, number>,
@@ -528,7 +531,14 @@ export function buildPots(
     const amount = layerHeight * contributors.length;
     if (amount <= 0) continue;
     const eligibleSeatIds = contributors.filter((id) => contenders.includes(id));
-    pots.push({ amount, eligibleSeatIds });
+    // Eligible sets shrink (weakly) monotonically as the level rises, so layers with
+    // an identical eligible set are always adjacent — merging here is exhaustive.
+    const prev = pots[pots.length - 1];
+    if (prev && prev.eligibleSeatIds.length === eligibleSeatIds.length && prev.eligibleSeatIds.every((id, i) => id === eligibleSeatIds[i])) {
+      prev.amount += amount;
+    } else {
+      pots.push({ amount, eligibleSeatIds });
+    }
   }
   return pots;
 }

--- a/packages/shared/src/features/turn-games/poker/engine.ts
+++ b/packages/shared/src/features/turn-games/poker/engine.ts
@@ -1,0 +1,1097 @@
+// ──────────────────────────────────────────────
+// Poker (No-Limit Texas Hold'em) — deterministic engine (server-authoritative)
+// ──────────────────────────────────────────────
+// Pure functions over PokerState. The single source of truth for legality,
+// betting-round closure, and win conditions. The LLM only proposes moves
+// (validated here) and narrates the engine-confirmed outcome; it never deals
+// cards or adjudicates showdowns. All randomness flows through the seeded RNG
+// (rng.ts) so every hand's deck — `deterministicShuffle(buildDeck(), seed,
+// handNumber)` — is reproducible without ever persisting the deck itself.
+//
+// ROUND-CLOSURE INVARIANT (read this before touching betting logic):
+// `state.actedSeatIds` holds every seat that has acted (check/call/bet/raise/
+// fold/all-in) since the last FULL bet/raise this street. It is cleared and
+// reseeded with just the aggressor on every FULL bet/raise, but deliberately
+// NOT cleared by an incomplete (short all-in) raise. A betting round is
+// closed once every seat still in the hand and not all-in is BOTH in this set
+// AND has `currentBets[seat] === betToMatch`. This single rule gives the big
+// blind its preflop option for free (nobody — not even the BB — starts in the
+// set) and is exactly what stops an incomplete raise from reopening full
+// raising rights for seats that already acted this cycle (see `handleRaise`).
+
+import type {
+  GameEvent,
+  ModelTurnView,
+  MoveResult,
+  Seat,
+  TerminalResult,
+  TurnGameEngine,
+} from "../engine.types.js";
+import { buildDeck, cardCode, cardLabel, cardShort, type Card } from "./deck.js";
+import { compareHands, evaluateBest, handLabel, type HandRank } from "./hand-eval.js";
+import { deterministicShuffle } from "./rng.js";
+import { parsePokerToolCall, POKER_TOOL_MANIFESTS } from "./tools.js";
+import {
+  clampPokerConfig,
+  DEFAULT_POKER_CONFIG,
+  pokerConfigSchema,
+  POKER_LOG_CAP,
+  POKER_MAX_PLAYERS,
+  POKER_MIN_PLAYERS,
+  type PokerConfig,
+  type PokerMove,
+  type PokerPotAward,
+  type PokerPublicSeat,
+  type PokerPublicView,
+  type PokerReveal,
+  type PokerState,
+  type PokerStreet,
+  type PokerYourActions,
+} from "./types.js";
+
+// ── small helpers ───────────────────────────────────────────────────────────
+
+function clone(state: PokerState): PokerState {
+  return JSON.parse(JSON.stringify(state)) as PokerState;
+}
+
+function nameOf(state: PokerState, seatId: string): string {
+  return state.seatNames[seatId] ?? seatId;
+}
+
+function fail(error: string, legalMoves: PokerMove[] = []): MoveResult<PokerState, PokerMove> {
+  return { ok: false, error, legalMoves };
+}
+
+/** Append `event` to both the returned move-events list and the capped board log. */
+function record(state: PokerState, events: GameEvent[], event: GameEvent): void {
+  events.push(event);
+  state.log.push(event);
+  if (state.log.length > POKER_LOG_CAP) state.log.splice(0, state.log.length - POKER_LOG_CAP);
+}
+
+/** Like `record`, but also queues the event for the dealer to narrate. Used ONLY for the
+ * five milestone categories: hand start, street deals, showdown/hand end, blinds up, game over. */
+function announce(state: PokerState, events: GameEvent[], event: GameEvent): void {
+  record(state, events, event);
+  state.pendingAnnouncements.push(event);
+}
+
+function setLast(state: PokerState, seatId: string, summary: string): void {
+  state.lastAction = { seatId, summary };
+}
+
+// ── deck / dealing ──────────────────────────────────────────────────────────
+
+/** This hand's full shuffled deck. Cheap to recompute; deliberately never persisted (see file header). */
+function handDeck(state: PokerState): Card[] {
+  return deterministicShuffle(buildDeck(), state.seed, state.handNumber);
+}
+
+function drawCards(state: PokerState, n: number): Card[] {
+  const deck = handDeck(state);
+  const out = deck.slice(state.deckCursor, state.deckCursor + n);
+  state.deckCursor += n;
+  return out;
+}
+
+// ── seat / hand-membership helpers ──────────────────────────────────────────
+
+function isBusted(state: PokerState, seatId: string): boolean {
+  return state.bustedSeatIds.includes(seatId);
+}
+function isFolded(state: PokerState, seatId: string): boolean {
+  return state.foldedSeatIds.includes(seatId);
+}
+function isAllIn(state: PokerState, seatId: string): boolean {
+  return state.allInSeatIds.includes(seatId);
+}
+function stackOf(state: PokerState, seatId: string): number {
+  return state.stacks[seatId] ?? 0;
+}
+function currentBet(state: PokerState, seatId: string): number {
+  return state.currentBets[seatId] ?? 0;
+}
+function committed(state: PokerState, seatId: string): number {
+  return state.committedTotal[seatId] ?? 0;
+}
+
+/** Seats dealt into the CURRENT hand (not busted before it started). */
+function handSeats(state: PokerState): string[] {
+  return state.seatOrder.filter((s) => !isBusted(state, s));
+}
+
+/** Seats dealt into this hand who haven't folded (includes all-in seats). */
+function contenders(state: PokerState): string[] {
+  return handSeats(state).filter((s) => !isFolded(state, s));
+}
+
+/** Contenders who can still voluntarily act (not all-in). */
+function activeActors(state: PokerState): string[] {
+  return contenders(state).filter((s) => !isAllIn(state, s));
+}
+
+/** Count of active actors OTHER than `seatId` — 0 means nobody left could ever call a bet/raise from them. */
+function othersActive(state: PokerState, seatId: string): number {
+  return activeActors(state).filter((s) => s !== seatId).length;
+}
+
+/** Next seat after `fromSeatId` in table order, cyclically, skipping busted seats. */
+function nextHandSeat(state: PokerState, fromSeatId: string): string {
+  const order = state.seatOrder;
+  const n = order.length;
+  const startIdx = order.indexOf(fromSeatId);
+  for (let step = 1; step <= n; step++) {
+    const candidate = order[(startIdx + step) % n]!;
+    if (!isBusted(state, candidate)) return candidate;
+  }
+  return fromSeatId; // unreachable while >= 2 seats remain unbusted
+}
+
+/** Next seat, strictly after `fromSeatId`, eligible to act right now (not folded/all-in/busted). */
+function nextToAct(state: PokerState, fromSeatId: string): string | null {
+  const order = state.seatOrder;
+  const n = order.length;
+  const startIdx = order.indexOf(fromSeatId);
+  for (let step = 1; step <= n; step++) {
+    const candidate = order[(startIdx + step) % n]!;
+    if (isBusted(state, candidate) || isFolded(state, candidate) || isAllIn(state, candidate)) continue;
+    return candidate;
+  }
+  return null;
+}
+
+/** First seat, walking forward from (and including) `fromSeatId`, eligible to act right now. */
+function firstEligibleFrom(state: PokerState, fromSeatId: string): string | null {
+  const order = state.seatOrder;
+  const n = order.length;
+  const startIdx = order.indexOf(fromSeatId);
+  for (let step = 0; step < n; step++) {
+    const candidate = order[(startIdx + step) % n]!;
+    if (isBusted(state, candidate) || isFolded(state, candidate) || isAllIn(state, candidate)) continue;
+    return candidate;
+  }
+  return null;
+}
+
+function smallBlindSeatId(state: PokerState): string {
+  // Heads-up: the button posts the small blind and acts first preflop.
+  return handSeats(state).length === 2 ? state.buttonSeatId : nextHandSeat(state, state.buttonSeatId);
+}
+function bigBlindSeatId(state: PokerState): string {
+  return handSeats(state).length === 2 ? nextHandSeat(state, state.buttonSeatId) : nextHandSeat(state, smallBlindSeatId(state));
+}
+
+function potTotal(state: PokerState): number {
+  let sum = 0;
+  for (const s of state.seatOrder) sum += committed(state, s);
+  return sum;
+}
+
+function orderClosestLeftOfButton(state: PokerState, seatIds: string[]): string[] {
+  const order = state.seatOrder;
+  const n = order.length;
+  const buttonIdx = order.indexOf(state.buttonSeatId);
+  return [...seatIds].sort((a, b) => {
+    const da = (order.indexOf(a) - buttonIdx + n) % n;
+    const db = (order.indexOf(b) - buttonIdx + n) % n;
+    return da - db;
+  });
+}
+
+// ── chip movement ────────────────────────────────────────────────────────────
+
+/** Move up to `n` chips (capped by the seat's stack) from stack into the pot for the current street. */
+function commitChips(state: PokerState, seatId: string, n: number): void {
+  const amt = Math.max(0, Math.min(n, stackOf(state, seatId)));
+  state.stacks[seatId] = stackOf(state, seatId) - amt;
+  state.currentBets[seatId] = currentBet(state, seatId) + amt;
+  state.committedTotal[seatId] = committed(state, seatId) + amt;
+  if (state.stacks[seatId] === 0 && !isAllIn(state, seatId)) state.allInSeatIds.push(seatId);
+}
+
+function markActed(state: PokerState, seatId: string): void {
+  if (!state.actedSeatIds.includes(seatId)) state.actedSeatIds.push(seatId);
+}
+
+/** FULL bet/raise: everyone must act again — reset the set to just the aggressor. */
+function clearActedExcept(state: PokerState, seatId: string): void {
+  state.actedSeatIds = [seatId];
+}
+
+// ── betting-round closure ───────────────────────────────────────────────────
+
+function roundClosed(state: PokerState): boolean {
+  if (contenders(state).length <= 1) return true;
+  const actors = activeActors(state);
+  if (actors.length === 0) return true;
+  return actors.every((s) => state.actedSeatIds.includes(s) && currentBet(state, s) === state.betToMatch);
+}
+
+// ── move handlers (operate on the already-cloned state `state`) ──────────────
+
+function handleFold(state: PokerState, seatId: string, events: GameEvent[]): MoveResult<PokerState, PokerMove> {
+  state.foldedSeatIds.push(seatId);
+  markActed(state, seatId);
+  record(state, events, { type: "fold", seatId, message: `${nameOf(state, seatId)} folds.` });
+  setLast(state, seatId, "folds");
+  return closeOrContinue(state, events);
+}
+
+function handleCheck(state: PokerState, seatId: string, events: GameEvent[]): MoveResult<PokerState, PokerMove> {
+  if (currentBet(state, seatId) !== state.betToMatch) {
+    return fail("You can't check — there's a bet to call.");
+  }
+  markActed(state, seatId);
+  record(state, events, { type: "check", seatId, message: `${nameOf(state, seatId)} checks.` });
+  setLast(state, seatId, "checks");
+  return closeOrContinue(state, events);
+}
+
+function handleCall(state: PokerState, seatId: string, events: GameEvent[]): MoveResult<PokerState, PokerMove> {
+  const toCall = state.betToMatch - currentBet(state, seatId);
+  if (toCall <= 0) return handleCheck(state, seatId, events); // leniency: nothing to call -> check
+  const amt = Math.min(toCall, stackOf(state, seatId));
+  commitChips(state, seatId, amt);
+  markActed(state, seatId);
+  const note = stackOf(state, seatId) === 0 ? " (all in)" : "";
+  record(state, events, { type: "call", seatId, message: `${nameOf(state, seatId)} calls ${amt}${note}.` });
+  setLast(state, seatId, `calls ${amt}`);
+  return closeOrContinue(state, events);
+}
+
+function handleBet(state: PokerState, seatId: string, rawAmount: number, events: GameEvent[]): MoveResult<PokerState, PokerMove> {
+  if (state.betToMatch > 0) return handleRaise(state, seatId, rawAmount, events); // leniency: bet w/ a bet outstanding -> raise toAmount=amount
+  const stack = stackOf(state, seatId);
+  if (stack <= 0) return fail("You have no chips left to bet.");
+  const min = Math.min(state.blinds.bigBlind, stack);
+  const max = stack;
+  const requested = Number.isFinite(rawAmount) ? Math.floor(rawAmount) : min;
+  const clamped = Math.min(max, Math.max(min, requested));
+
+  commitChips(state, seatId, clamped);
+  state.betToMatch = clamped;
+  // A short all-in bet below the big blind still opens the street (nothing existed to call
+  // before it) but doesn't shrink the increment future raises must meet.
+  if (clamped >= state.blinds.bigBlind) state.lastRaiseSize = clamped;
+  clearActedExcept(state, seatId);
+
+  const note = stackOf(state, seatId) === 0 ? " (all in)" : "";
+  record(state, events, { type: "bet", seatId, message: `${nameOf(state, seatId)} bets ${clamped}${note}.` });
+  setLast(state, seatId, `bets ${clamped}`);
+  return closeOrContinue(state, events);
+}
+
+function handleRaise(state: PokerState, seatId: string, rawToAmount: number, events: GameEvent[]): MoveResult<PokerState, PokerMove> {
+  if (state.betToMatch === 0) return handleBet(state, seatId, rawToAmount, events); // leniency: raise w/ nothing outstanding -> bet
+  const stack = stackOf(state, seatId);
+  if (stack <= 0) return fail("You have no chips left to raise.");
+
+  const already = currentBet(state, seatId);
+  const cap = already + stack; // max achievable street-total for this seat
+  if (cap <= state.betToMatch) return handleCall(state, seatId, events); // can't even exceed betToMatch -> call
+
+  if (state.actedSeatIds.includes(seatId)) {
+    // Already acted since the last FULL raise: an incomplete raise doesn't reopen full
+    // raising rights (see file header). This seat may only call or fold right now — any
+    // raise attempt (including one arriving via all_in, whose stack would otherwise exceed
+    // betToMatch) is downgraded to a call rather than rejected, consistent with the engine's
+    // other leniency mappings (and required so `all_in` — always legal per legalMovesFor
+    // whenever stack > 0 — can never be rejected here).
+    return handleCall(state, seatId, events);
+  }
+  if (othersActive(state, seatId) === 0) {
+    // Nobody left who could respond to a bigger number — raising further would only ever
+    // create an uncalled excess, so treat it as a call instead (deliberate simplification;
+    // see the engine's return-value notes).
+    return handleCall(state, seatId, events);
+  }
+
+  const oldBetToMatch = state.betToMatch;
+  const minTo = oldBetToMatch + state.lastRaiseSize;
+  const requested = Number.isFinite(rawToAmount) ? Math.floor(rawToAmount) : minTo;
+  const clampedTo = Math.min(cap, Math.max(minTo, requested));
+  const isFullRaise = clampedTo >= minTo;
+
+  commitChips(state, seatId, clampedTo - already);
+  state.betToMatch = clampedTo;
+  if (isFullRaise) {
+    state.lastRaiseSize = clampedTo - oldBetToMatch;
+    clearActedExcept(state, seatId);
+  } else {
+    // Incomplete (short all-in) raise: betToMatch still rises so others must respond, but
+    // lastRaiseSize (and everyone else's already-acted status) is left untouched — see file header.
+    markActed(state, seatId);
+  }
+
+  const note = stackOf(state, seatId) === 0 ? " (all in)" : "";
+  record(state, events, { type: "raise", seatId, message: `${nameOf(state, seatId)} raises to ${clampedTo}${note}.` });
+  setLast(state, seatId, `raises to ${clampedTo}`);
+  return closeOrContinue(state, events);
+}
+
+function handleAllIn(state: PokerState, seatId: string, events: GameEvent[]): MoveResult<PokerState, PokerMove> {
+  const stack = stackOf(state, seatId);
+  if (stack <= 0) return fail("You have no chips left.");
+  const total = currentBet(state, seatId) + stack;
+  if (state.betToMatch === 0) return handleBet(state, seatId, stack, events);
+  if (total <= state.betToMatch) return handleCall(state, seatId, events);
+  return handleRaise(state, seatId, total, events);
+}
+
+function closeOrContinue(state: PokerState, events: GameEvent[]): MoveResult<PokerState, PokerMove> {
+  if (contenders(state).length <= 1) {
+    finishHandByFold(state, events);
+    return { ok: true, state, events };
+  }
+  if (!roundClosed(state)) {
+    const from = state.currentSeatId!;
+    state.currentSeatId = nextToAct(state, from) ?? from;
+    return { ok: true, state, events };
+  }
+  advanceStreetOrShowdown(state, events);
+  return { ok: true, state, events };
+}
+
+// ── street / hand progression ───────────────────────────────────────────────
+
+function nextStreetOf(street: PokerStreet): PokerStreet {
+  return street === "preflop" ? "flop" : street === "flop" ? "turn" : "river";
+}
+
+/** Deals `street`'s community cards (if any) and resets the street's betting fields.
+ * No burn cards — the deck is already a single seeded shuffle, so "burning" would just
+ * be discarding a known card for no security purpose; keeping it simple is deliberate. */
+function dealBoardCardsFor(state: PokerState, street: PokerStreet, events: GameEvent[]): void {
+  const n = street === "flop" ? 3 : street === "turn" || street === "river" ? 1 : 0;
+  if (n > 0) state.community.push(...drawCards(state, n));
+  state.street = street;
+  state.currentBets = {};
+  state.betToMatch = 0;
+  state.lastRaiseSize = state.blinds.bigBlind;
+  state.actedSeatIds = [];
+
+  const label = street.charAt(0).toUpperCase() + street.slice(1);
+  announce(state, events, {
+    type: "street_dealt",
+    message: `${label}: ${state.community.map(cardShort).join(" ")} — pot ${potTotal(state)}.`,
+    data: { street, community: state.community.map(cardCode), pot: potTotal(state) },
+  });
+}
+
+function firstToActPreflop(state: PokerState): string {
+  // Heads-up: button/SB acts first preflop. 3+: first seat left of the big blind (UTG).
+  return handSeats(state).length === 2 ? state.buttonSeatId : nextHandSeat(state, bigBlindSeatId(state));
+}
+
+function firstToActPostflop(state: PokerState): string {
+  // Heads-up: the non-button seat (BB) acts first on every street after preflop.
+  // 3+: the first seat left of the button. Both are exactly "the next hand-seat after the button".
+  return nextHandSeat(state, state.buttonSeatId);
+}
+
+/** Entry point into a fresh betting round: hand-ends if the fold-out already happened,
+ * fast-forwards to showdown if fewer than two seats could still voluntarily act, otherwise
+ * hands the turn to the first eligible actor. Shared by preflop start and every street advance. */
+function settleActionOrFastForward(state: PokerState, events: GameEvent[], intendedFirstActor: string): void {
+  if (contenders(state).length <= 1) {
+    finishHandByFold(state, events);
+    return;
+  }
+  if (activeActors(state).length < 2) {
+    fastForwardToShowdown(state, events);
+    return;
+  }
+  state.currentSeatId = firstEligibleFrom(state, intendedFirstActor);
+  state.status = "active";
+}
+
+function fastForwardToShowdown(state: PokerState, events: GameEvent[]): void {
+  while (state.street !== "river") dealBoardCardsFor(state, nextStreetOf(state.street), events);
+  state.currentSeatId = null;
+  resolveShowdown(state, events);
+}
+
+function advanceStreetOrShowdown(state: PokerState, events: GameEvent[]): void {
+  if (state.street === "river") {
+    resolveShowdown(state, events);
+    return;
+  }
+  dealBoardCardsFor(state, nextStreetOf(state.street), events);
+  settleActionOrFastForward(state, events, firstToActPostflop(state));
+}
+
+function startPreflop(state: PokerState, events: GameEvent[]): void {
+  const sbSeatId = smallBlindSeatId(state);
+  const bbSeatId = bigBlindSeatId(state);
+  const sbAmt = Math.min(state.blinds.smallBlind, stackOf(state, sbSeatId));
+  const bbAmt = Math.min(state.blinds.bigBlind, stackOf(state, bbSeatId));
+  commitChips(state, sbSeatId, sbAmt);
+  commitChips(state, bbSeatId, bbAmt);
+  state.betToMatch = bbAmt;
+  state.lastRaiseSize = state.blinds.bigBlind;
+  state.actedSeatIds = [];
+
+  announce(state, events, {
+    type: "hand_start",
+    message:
+      `Hand #${state.handNumber} — blinds ${state.blinds.smallBlind}/${state.blinds.bigBlind}. ` +
+      `${nameOf(state, sbSeatId)} posts small blind${sbAmt < state.blinds.smallBlind ? ` (${sbAmt}, all in)` : ""}, ` +
+      `${nameOf(state, bbSeatId)} posts big blind${bbAmt < state.blinds.bigBlind ? ` (${bbAmt}, all in)` : ""}.`,
+    data: { handNumber: state.handNumber, sbSeatId, bbSeatId, smallBlind: state.blinds.smallBlind, bigBlind: state.blinds.bigBlind },
+  });
+
+  settleActionOrFastForward(state, events, firstToActPreflop(state));
+}
+
+/** Deal order starts left of the button (small blind position) and wraps through dealt-in seats. */
+function dealOrder(state: PokerState, seats: string[]): string[] {
+  const n = state.seatOrder.length;
+  const startIdx = state.seatOrder.indexOf(nextHandSeat(state, state.buttonSeatId));
+  const rotated: string[] = [];
+  for (let i = 0; i < n; i++) {
+    const seatId = state.seatOrder[(startIdx + i) % n]!;
+    if (seats.includes(seatId)) rotated.push(seatId);
+  }
+  return rotated;
+}
+
+function dealHoleCards(state: PokerState): void {
+  const seats = handSeats(state);
+  const order = dealOrder(state, seats);
+  for (const s of seats) state.holeCards[s] = [];
+  for (let round = 0; round < 2; round++) {
+    for (const seatId of order) {
+      const [card] = drawCards(state, 1);
+      if (card) state.holeCards[seatId]!.push(card);
+    }
+  }
+}
+
+function dealNewHand(state: PokerState, events: GameEvent[]): void {
+  if (
+    state.config.blindIncreaseEveryHands > 0 &&
+    state.handsCompleted > 0 &&
+    state.handsCompleted % state.config.blindIncreaseEveryHands === 0
+  ) {
+    state.blinds = { smallBlind: state.blinds.smallBlind * 2, bigBlind: state.blinds.bigBlind * 2 };
+    announce(state, events, {
+      type: "blinds_up",
+      message: `Blinds up — now ${state.blinds.smallBlind}/${state.blinds.bigBlind}!`,
+      data: { smallBlind: state.blinds.smallBlind, bigBlind: state.blinds.bigBlind },
+    });
+  }
+
+  state.handNumber += 1;
+  state.buttonSeatId = nextHandSeat(state, state.buttonSeatId);
+  state.holeCards = {};
+  state.community = [];
+  state.street = "preflop";
+  state.deckCursor = 0;
+  state.currentBets = {};
+  state.committedTotal = {};
+  state.foldedSeatIds = [];
+  state.allInSeatIds = [];
+  state.actedSeatIds = [];
+  state.betToMatch = 0;
+  state.lastRaiseSize = state.blinds.bigBlind;
+  state.winnerSeatId = null;
+  // handResults is intentionally left as the PREVIOUS hand's outcome (for the recap) until
+  // this new hand concludes and overwrites it via resolveShowdown / finishHandByFold.
+
+  dealHoleCards(state);
+  startPreflop(state, events);
+}
+
+// ── showdown / hand end ─────────────────────────────────────────────────────
+
+/**
+ * Layer `committedTotal` into main + side pots. Folded seats' chips count toward pot
+ * amounts (dead money) but folded seats are never eligible to win. Pure — exported for
+ * direct unit testing against hand-crafted commitment maps.
+ */
+export function buildPots(
+  committedTotal: Record<string, number>,
+  contenders: string[],
+): Array<{ amount: number; eligibleSeatIds: string[] }> {
+  const seatIds = Object.keys(committedTotal).filter((id) => (committedTotal[id] ?? 0) > 0);
+  if (seatIds.length === 0) return [];
+
+  const levels = [...new Set(seatIds.map((id) => committedTotal[id]!))].sort((a, b) => a - b);
+  const pots: Array<{ amount: number; eligibleSeatIds: string[] }> = [];
+  let floor = 0;
+  for (const level of levels) {
+    const layerHeight = level - floor;
+    floor = level;
+    if (layerHeight <= 0) continue;
+    const contributors = seatIds.filter((id) => (committedTotal[id] ?? 0) >= level);
+    const amount = layerHeight * contributors.length;
+    if (amount <= 0) continue;
+    const eligibleSeatIds = contributors.filter((id) => contenders.includes(id));
+    pots.push({ amount, eligibleSeatIds });
+  }
+  return pots;
+}
+
+function resolveShowdown(state: PokerState, events: GameEvent[]): void {
+  const eligible = contenders(state);
+  const pots = buildPots(state.committedTotal, eligible);
+
+  const ranked = eligible.map((seatId) => {
+    const hole = state.holeCards[seatId] ?? [];
+    const { rank, bestFive } = evaluateBest([...hole, ...state.community]);
+    return { seatId, hole, rank, bestFive };
+  });
+  const rankBySeat = new Map<string, HandRank>(ranked.map((r) => [r.seatId, r.rank]));
+
+  const potAwards: PokerPotAward[] = [];
+  pots.forEach((pot, i) => {
+    const label = i === 0 ? "main pot" : `side pot ${i}`;
+    // Defensive fallback: a real hand can never produce an empty-eligible layer (any live
+    // contender's final commitment is always >= any folded seat's, since folding only ever
+    // happens below the eventual live betToMatch) — see buildPots's doc. Falling back to
+    // every contender keeps chip conservation intact even if that proof is ever wrong.
+    const eligibleSeatIds = pot.eligibleSeatIds.length ? pot.eligibleSeatIds : eligible;
+
+    let bestRank: HandRank | null = null;
+    for (const seatId of eligibleSeatIds) {
+      const r = rankBySeat.get(seatId);
+      if (r && (!bestRank || compareHands(r, bestRank) > 0)) bestRank = r;
+    }
+    const winners = eligibleSeatIds.filter((seatId) => {
+      const r = rankBySeat.get(seatId);
+      return !!r && !!bestRank && compareHands(r, bestRank) === 0;
+    });
+
+    const ordered = orderClosestLeftOfButton(state, winners);
+    const share = Math.floor(pot.amount / ordered.length);
+    let remainder = pot.amount - share * ordered.length;
+    for (const seatId of ordered) {
+      const amount = share + (remainder > 0 ? 1 : 0);
+      if (remainder > 0) remainder -= 1;
+      if (amount <= 0) continue;
+      potAwards.push({ seatId, amount, label });
+      state.stacks[seatId] = stackOf(state, seatId) + amount;
+    }
+  });
+
+  const reveals: PokerReveal[] = ranked.map((r) => ({
+    seatId: r.seatId,
+    holeCards: r.hole,
+    label: handLabel(r.rank),
+    bestFiveCodes: r.bestFive.map(cardCode),
+  }));
+  state.handResults = { potAwards, reveals };
+
+  announce(state, events, {
+    type: "showdown",
+    message:
+      `Showdown — ${reveals.map((r) => `${nameOf(state, r.seatId)}: ${r.label}`).join(", ")}. ` +
+      `${potAwards.map((a) => `${nameOf(state, a.seatId)} wins ${a.amount} (${a.label})`).join("; ")}.`,
+    data: { potAwards, reveals },
+  });
+
+  finishHandCommon(state, events);
+}
+
+function finishHandByFold(state: PokerState, events: GameEvent[]): void {
+  const winnerSeatId = contenders(state)[0] ?? null;
+  if (winnerSeatId) {
+    const amount = potTotal(state);
+    state.stacks[winnerSeatId] = stackOf(state, winnerSeatId) + amount;
+    const potAwards: PokerPotAward[] = amount > 0 ? [{ seatId: winnerSeatId, amount, label: "main pot" }] : [];
+    state.handResults = { potAwards, reveals: [] };
+    announce(state, events, {
+      type: "showdown",
+      message: `${nameOf(state, winnerSeatId)} wins the pot (${amount}) — everyone else folded.`,
+      data: { potAwards, reveals: [] },
+    });
+  } else {
+    state.handResults = { potAwards: [], reveals: [] };
+  }
+  finishHandCommon(state, events);
+}
+
+function finishHandCommon(state: PokerState, events: GameEvent[]): void {
+  state.currentSeatId = null;
+  state.handsCompleted += 1;
+  // The pot has been fully paid out into stacks (buildPots/finishHandByFold already
+  // consumed the ledger) — clear it so no view can double-count chips during
+  // hand_over/finished: potTotal() must read 0 once the hand is settled.
+  state.currentBets = {};
+  state.committedTotal = {};
+  state.betToMatch = 0;
+
+  for (const seatId of handSeats(state)) {
+    if (stackOf(state, seatId) <= 0 && !isBusted(state, seatId)) state.bustedSeatIds.push(seatId);
+  }
+
+  const remainingSeats = state.seatOrder.filter((s) => !isBusted(state, s));
+  const humanSeat = state.seats.find((s) => s.kind === "human")?.seatId ?? state.seatOrder[0]!;
+  const chipLeader = (): string => {
+    let best = state.seatOrder[0]!;
+    for (const s of state.seatOrder) if (stackOf(state, s) > stackOf(state, best)) best = s;
+    return best;
+  };
+
+  let winnerSeatId: string | null = null;
+  let sessionOver = false;
+
+  if (remainingSeats.length <= 1) {
+    sessionOver = true;
+    winnerSeatId = remainingSeats[0] ?? chipLeader();
+  } else if (isBusted(state, humanSeat)) {
+    // The human busting ends the session — bots don't keep playing on alone.
+    sessionOver = true;
+    winnerSeatId = chipLeader();
+  } else if (state.config.handLimit > 0 && state.handsCompleted >= state.config.handLimit) {
+    sessionOver = true;
+    winnerSeatId = chipLeader();
+  }
+
+  if (sessionOver) {
+    state.status = "finished";
+    state.winnerSeatId = winnerSeatId;
+    announce(state, events, {
+      type: "game_over",
+      ...(winnerSeatId ? { seatId: winnerSeatId } : {}),
+      message: winnerSeatId ? `${nameOf(state, winnerSeatId)} wins the session!` : "The session has ended.",
+    });
+    return;
+  }
+
+  state.status = "hand_over";
+  // The human paces the session between hands — their only legal move is next_hand.
+  state.currentSeatId = humanSeat;
+}
+
+// ── legal-move enumeration ────────────────────────────────────────────────────
+
+function legalMovesFor(state: PokerState, seatId: string): PokerMove[] {
+  if (state.status === "hand_over") {
+    return state.currentSeatId === seatId ? [{ type: "next_hand" }] : [];
+  }
+  if (state.status !== "active" || state.currentSeatId !== seatId) return [];
+  if (isFolded(state, seatId) || isAllIn(state, seatId) || isBusted(state, seatId)) return [];
+
+  const moves: PokerMove[] = [{ type: "fold" }];
+  const toCall = state.betToMatch - currentBet(state, seatId);
+  moves.push(toCall <= 0 ? { type: "check" } : { type: "call" });
+
+  const stack = stackOf(state, seatId);
+  const already = currentBet(state, seatId);
+  const cap = already + stack;
+  const responders = othersActive(state, seatId);
+
+  if (stack > 0 && responders > 0) {
+    if (state.betToMatch === 0) {
+      moves.push({ type: "bet", amount: Math.min(state.blinds.bigBlind, stack) });
+    } else if (cap > state.betToMatch && !state.actedSeatIds.includes(seatId)) {
+      moves.push({ type: "raise", toAmount: Math.min(cap, state.betToMatch + state.lastRaiseSize) });
+    }
+  }
+  if (stack > 0) moves.push({ type: "all_in" });
+  return moves;
+}
+
+// ── prompt + view builders ────────────────────────────────────────────────────
+
+function communitySummary(state: PokerState): string {
+  return state.community.length ? state.community.map(cardShort).join(" ") : "(no community cards yet)";
+}
+
+function yourBestLabel(state: PokerState, seatId: string): string | null {
+  if (state.community.length < 3) return null;
+  const hole = state.holeCards[seatId];
+  if (!hole || hole.length < 2) return null;
+  return handLabel(evaluateBest([...hole, ...state.community]).rank);
+}
+
+function recentActionLines(state: PokerState, max: number): string[] {
+  return state.log
+    .filter((e) => typeof e.message === "string" && e.message.trim().length > 0)
+    .slice(-max)
+    .map((e) => `  • ${e.message}`);
+}
+
+function buildBoardSummary(state: PokerState, seatId: string): string {
+  const lines: string[] = [];
+  lines.push(
+    `Texas Hold'em — Hand #${state.handNumber}, ${state.street}. Community: ${communitySummary(state)}. ` +
+      `Pot: ${potTotal(state)}. Blinds ${state.blinds.smallBlind}/${state.blinds.bigBlind}.`,
+  );
+  lines.push(`Your stack: ${stackOf(state, seatId)}.`);
+  const hole = state.holeCards[seatId] ?? [];
+  if (hole.length) lines.push(`Your hole cards: ${hole.map(cardShort).join(" ")} (${hole.map(cardLabel).join(", ")}).`);
+  const best = yourBestLabel(state, seatId);
+  if (best) lines.push(`Your best right now: ${best}.`);
+  const toCall = state.betToMatch - currentBet(state, seatId);
+  lines.push(
+    toCall > 0
+      ? `${toCall} to call (you've put in ${currentBet(state, seatId)} this street, ${state.betToMatch} to match).`
+      : `Nothing to call — you may check.`,
+  );
+  lines.push("Table:");
+  for (const s of state.seatOrder) {
+    if (s === seatId || isBusted(state, s)) continue;
+    const flags: string[] = [];
+    if (isFolded(state, s)) flags.push("folded");
+    if (isAllIn(state, s)) flags.push("all in");
+    if (s === state.buttonSeatId) flags.push("button");
+    lines.push(`  • ${nameOf(state, s)}: stack ${stackOf(state, s)}, street bet ${currentBet(state, s)}${flags.length ? ` (${flags.join(", ")})` : ""}`);
+  }
+  const recent = recentActionLines(state, 5);
+  if (recent.length) lines.push("What just happened:", ...recent);
+  return lines.join("\n");
+}
+
+function buildInstructions(state: PokerState, seatId: string): string {
+  const actions: string[] = ["fold"];
+  const toCall = state.betToMatch - currentBet(state, seatId);
+  const stack = stackOf(state, seatId);
+  const cap = currentBet(state, seatId) + stack;
+  actions.push(toCall <= 0 ? "check" : `call ${Math.min(toCall, stack)}`);
+  if (stack > 0 && othersActive(state, seatId) > 0) {
+    if (state.betToMatch === 0) {
+      actions.push(`bet: min ${Math.min(state.blinds.bigBlind, stack)} max ${stack} — amount = chips you put in`);
+    } else if (cap > state.betToMatch && !state.actedSeatIds.includes(seatId)) {
+      const minTo = Math.min(cap, state.betToMatch + state.lastRaiseSize);
+      actions.push(`raise: min-to ${minTo}, max-to ${cap} (all-in) — toAmount = TOTAL you raise to`);
+    }
+  }
+  if (stack > 0) actions.push("all_in");
+
+  return (
+    `Legal actions: ${actions.join(" | ")}. ` +
+    "Choose like YOUR character, not like a solver: a bold or reckless character bluffs, pressures, and " +
+    "over-bets; a cautious one folds marginal hands and only commits with strength; a cunning one slow-plays " +
+    "monsters and springs traps; a proud one refuses to be pushed off a pot; grudges are real — re-raising " +
+    "whoever just bullied you is excellent poker. Bluffing is allowed and encouraged when it fits your " +
+    "personality. Pot odds matter, but personality decides. " +
+    "Never invent cards. Call the tool with exactly one action."
+  );
+}
+
+function buildSpectatorSummary(state: PokerState): string {
+  if (state.status === "finished") {
+    const standings = [...state.seatOrder]
+      .sort((a, b) => stackOf(state, b) - stackOf(state, a))
+      .map((s) => `${nameOf(state, s)} (${stackOf(state, s)} chips)`)
+      .join(", ");
+    const winner = state.winnerSeatId ? nameOf(state, state.winnerSeatId) : null;
+    return [
+      `The poker session just finished${winner ? ` — ${winner} came out on top` : ""}.`,
+      `Final chip counts: ${standings}.`,
+    ].join("\n");
+  }
+  const lines: string[] = [
+    `A game of No-Limit Hold'em is in progress at the table — hand #${state.handNumber}, ${state.street}.`,
+    `Community: ${communitySummary(state)}. Pot: ${potTotal(state)}. Blinds ${state.blinds.smallBlind}/${state.blinds.bigBlind}.`,
+  ];
+  const seatLines = state.seatOrder
+    .filter((s) => !isBusted(state, s))
+    .map((s) => {
+      const flags: string[] = [];
+      if (isFolded(state, s)) flags.push("folded");
+      if (isAllIn(state, s)) flags.push("all in");
+      return `${nameOf(state, s)}: ${stackOf(state, s)} chips${flags.length ? ` (${flags.join(", ")})` : ""}`;
+    });
+  lines.push(`Players: ${seatLines.join(", ")}.`);
+  if (state.status === "hand_over") lines.push("The hand just ended — waiting for the next hand to start.");
+  else if (state.currentSeatId) lines.push(`It's currently ${nameOf(state, state.currentSeatId)}'s turn to act.`);
+  const recent = recentActionLines(state, 6);
+  if (recent.length) lines.push("Recent action:", ...recent);
+  return lines.join("\n");
+}
+
+function buildParticipantSummary(state: PokerState, seatId: string): string {
+  const base = buildSpectatorSummary(state);
+  if (!state.seatOrder.includes(seatId)) return base;
+  const lines: string[] = [base, `You are ${nameOf(state, seatId)} in this game.`];
+  if (state.status !== "finished" && !isBusted(state, seatId)) {
+    const hole = state.holeCards[seatId];
+    if (hole?.length) lines.push(`Your hole cards (only you can see them): ${hole.map(cardShort).join(" ")}.`);
+    const best = yourBestLabel(state, seatId);
+    if (best) lines.push(`Your best hand right now: ${best}.`);
+    if (state.currentSeatId === seatId) {
+      if (state.status === "hand_over") lines.push("It's your turn to start the next hand.");
+      else {
+        const toCall = state.betToMatch - currentBet(state, seatId);
+        lines.push(toCall > 0 ? `It's YOUR turn — ${toCall} to call.` : "It's YOUR turn — you may check.");
+      }
+    }
+  }
+  return lines.join("\n");
+}
+
+// ── the engine object ──────────────────────────────────────────────────────────
+
+export const pokerEngine: TurnGameEngine<PokerState, PokerMove, PokerConfig, PokerPublicView> = {
+  gameType: "poker",
+  schemaVersion: 1,
+  label: "Poker",
+  minPlayers: POKER_MIN_PLAYERS,
+  maxPlayers: POKER_MAX_PLAYERS,
+  hiddenInformation: true,
+
+  defaultConfig() {
+    return { ...DEFAULT_POKER_CONFIG };
+  },
+
+  normalizeConfig(config) {
+    const direct = pokerConfigSchema.safeParse(config);
+    const merged = direct.success
+      ? direct.data
+      : { ...DEFAULT_POKER_CONFIG, ...(config && typeof config === "object" ? (config as object) : {}) };
+    return clampPokerConfig(merged as Partial<PokerConfig>);
+  },
+
+  setup(config, seatsIn: Seat[], seed) {
+    const seatOrder = seatsIn.map((s) => s.seatId);
+    const seatNames: Record<string, string> = {};
+    const stacks: Record<string, number> = {};
+    for (const s of seatsIn) {
+      seatNames[s.seatId] = s.displayName;
+      stacks[s.seatId] = config.startingStack;
+    }
+
+    const state: PokerState = {
+      config,
+      seed,
+      seats: seatsIn.map((s) => ({ seatId: s.seatId, displayName: s.displayName, kind: s.kind })),
+      seatOrder,
+      seatNames,
+      stacks,
+      status: "active",
+      handNumber: 1,
+      buttonSeatId: seatOrder[0]!,
+      blinds: { smallBlind: config.smallBlind, bigBlind: config.smallBlind * 2 },
+      holeCards: {},
+      community: [],
+      street: "preflop",
+      deckCursor: 0,
+      currentBets: {},
+      committedTotal: {},
+      betToMatch: 0,
+      lastRaiseSize: config.smallBlind * 2,
+      currentSeatId: null,
+      actedSeatIds: [],
+      foldedSeatIds: [],
+      allInSeatIds: [],
+      bustedSeatIds: [],
+      handsCompleted: 0,
+      winnerSeatId: null,
+      handResults: null,
+      pendingAnnouncements: [],
+      lastAction: null,
+      log: [],
+    };
+
+    const events: GameEvent[] = [];
+    dealHoleCards(state);
+    startPreflop(state, events);
+    return state;
+  },
+
+  currentSeat(state) {
+    return state.status === "finished" ? null : state.currentSeatId;
+  },
+
+  interruptibleSeats() {
+    return [];
+  },
+
+  legalMoves(state, seatId) {
+    return legalMovesFor(state, seatId);
+  },
+
+  applyMove(state, seatId, move): MoveResult<PokerState, PokerMove> {
+    if (state.status === "finished") return fail("The game is already over.");
+
+    if (move?.type === "next_hand") {
+      if (state.status !== "hand_over" || state.currentSeatId !== seatId) {
+        return { ok: false, error: "It's not time for the next hand yet.", legalMoves: legalMovesFor(state, seatId) };
+      }
+      const s = clone(state);
+      const events: GameEvent[] = [];
+      dealNewHand(s, events);
+      return { ok: true, state: s, events };
+    }
+
+    if (state.status !== "active" || state.currentSeatId !== seatId) {
+      return { ok: false, error: "It's not your turn.", legalMoves: legalMovesFor(state, seatId) };
+    }
+    if (isFolded(state, seatId) || isAllIn(state, seatId) || isBusted(state, seatId)) {
+      return { ok: false, error: "You can't act right now.", legalMoves: [] };
+    }
+
+    const s = clone(state);
+    const events: GameEvent[] = [];
+    let result: MoveResult<PokerState, PokerMove>;
+    switch (move?.type) {
+      case "fold":
+        result = handleFold(s, seatId, events);
+        break;
+      case "check":
+        result = handleCheck(s, seatId, events);
+        break;
+      case "call":
+        result = handleCall(s, seatId, events);
+        break;
+      case "bet":
+        result = handleBet(s, seatId, move.amount, events);
+        break;
+      case "raise":
+        result = handleRaise(s, seatId, move.toAmount, events);
+        break;
+      case "all_in":
+        result = handleAllIn(s, seatId, events);
+        break;
+      default:
+        result = fail("Unknown move.");
+    }
+
+    if (!result.ok) {
+      return { ok: false, error: result.error, legalMoves: legalMovesFor(state, seatId) };
+    }
+    return result;
+  },
+
+  isTerminal(state): TerminalResult {
+    return state.status === "finished"
+      ? { done: true, ...(state.winnerSeatId ? { winnerSeatId: state.winnerSeatId } : {}) }
+      : { done: false };
+  },
+
+  describeForModel(state, seatId): ModelTurnView<PokerMove> {
+    return {
+      boardSummary: buildBoardSummary(state, seatId),
+      legalMoves: legalMovesFor(state, seatId),
+      instructions: buildInstructions(state, seatId),
+    };
+  },
+
+  spectatorSummary(state): string {
+    return buildSpectatorSummary(state);
+  },
+
+  participantSummary(state, seatId): string {
+    return buildParticipantSummary(state, seatId);
+  },
+
+  publicView(state, viewerSeatId): PokerPublicView {
+    const seats: PokerPublicSeat[] = state.seatOrder.map((s) => {
+      const seat = state.seats.find((x) => x.seatId === s)!;
+      return {
+        seatId: s,
+        displayName: nameOf(state, s),
+        kind: seat.kind,
+        stack: stackOf(state, s),
+        streetBet: currentBet(state, s),
+        committed: committed(state, s),
+        folded: isFolded(state, s),
+        allIn: isAllIn(state, s),
+        busted: isBusted(state, s),
+        isButton: s === state.buttonSeatId,
+        isSmallBlind: s === smallBlindSeatId(state),
+        isBigBlind: s === bigBlindSeatId(state),
+        isCurrent: state.currentSeatId === s,
+      };
+    });
+
+    let yourHoleCards: PokerPublicView["yourHoleCards"] = [];
+    let yourHandLabel: string | null = null;
+    const yourActions: PokerYourActions = {
+      canFold: false,
+      canCheck: false,
+      canCall: false,
+      callAmount: 0,
+      canBet: false,
+      minBet: 0,
+      canRaise: false,
+      minRaiseTo: 0,
+      maxTo: 0,
+      canAllIn: false,
+      canNextHand: false,
+    };
+
+    if (viewerSeatId) {
+      const hole = state.holeCards[viewerSeatId];
+      if (hole) {
+        yourHoleCards = hole.map((c) => ({ code: cardCode(c), short: cardShort(c), label: cardLabel(c) }));
+        yourHandLabel = yourBestLabel(state, viewerSeatId);
+      }
+      if (state.status === "hand_over" && state.currentSeatId === viewerSeatId) {
+        yourActions.canNextHand = true;
+      } else {
+        for (const m of legalMovesFor(state, viewerSeatId)) {
+          if (m.type === "fold") yourActions.canFold = true;
+          else if (m.type === "check") yourActions.canCheck = true;
+          else if (m.type === "call") {
+            yourActions.canCall = true;
+            yourActions.callAmount = Math.min(state.betToMatch - currentBet(state, viewerSeatId), stackOf(state, viewerSeatId));
+          } else if (m.type === "bet") {
+            yourActions.canBet = true;
+            yourActions.minBet = m.amount;
+          } else if (m.type === "raise") {
+            yourActions.canRaise = true;
+            yourActions.minRaiseTo = m.toAmount;
+          } else if (m.type === "all_in") {
+            yourActions.canAllIn = true;
+          }
+        }
+        yourActions.maxTo = currentBet(state, viewerSeatId) + stackOf(state, viewerSeatId);
+      }
+    }
+
+    return {
+      gameType: "poker",
+      status: state.status,
+      handNumber: state.handNumber,
+      street: state.street,
+      communityCodes: state.community.map(cardCode),
+      communityShort: state.community.map(cardShort),
+      potTotal: potTotal(state),
+      blinds: { ...state.blinds },
+      seats,
+      currentSeatId: state.currentSeatId,
+      yourSeatId: viewerSeatId,
+      yourHoleCards,
+      yourHandLabel,
+      yourActions,
+      handResults: state.handResults,
+      winnerSeatId: state.winnerSeatId,
+      lastAction: state.lastAction,
+      recentLog: state.log.slice(-8),
+      config: state.config,
+      dealerCharacterId: state.config.dealerCharacterId,
+      hasPendingAnnouncements: state.pendingAnnouncements.length > 0,
+    };
+  },
+
+  pickFallbackMove(state, seatId) {
+    if (state.status === "hand_over") return { type: "next_hand" };
+    const toCall = state.betToMatch - currentBet(state, seatId);
+    return toCall <= 0 ? { type: "check" } : { type: "fold" };
+  },
+
+  toolManifests() {
+    return [...POKER_TOOL_MANIFESTS];
+  },
+
+  parseToolCall(name, args) {
+    return parsePokerToolCall(name, args);
+  },
+
+  announcerCharacterId(state) {
+    return state.config.dealerCharacterId;
+  },
+
+  drainAnnouncements(state) {
+    if (state.pendingAnnouncements.length === 0) return null;
+    const s = clone(state);
+    const announcements = s.pendingAnnouncements;
+    s.pendingAnnouncements = [];
+    return { state: s, announcements };
+  },
+};

--- a/packages/shared/src/features/turn-games/poker/hand-eval.ts
+++ b/packages/shared/src/features/turn-games/poker/hand-eval.ts
@@ -1,0 +1,203 @@
+// ──────────────────────────────────────────────
+// Poker — hand evaluator
+// ──────────────────────────────────────────────
+// Pure, dependency-free hand ranking. `evaluate5` scores an exact 5-card hand;
+// `evaluateBest` enumerates all C(n,5) combinations out of a 5-7 card pool
+// (hole cards + board) and keeps the maximum, which is how Texas Hold'em
+// determines the best hand available to each seat at showdown. `HandRank` is
+// a comparable, JSON-safe value: two hands compare by `category` first, then
+// by `tiebreak` lexicographically — no hand-specific comparison logic lives
+// outside `compareHands`.
+
+import { RANK_NAMES, rankPluralName, type Card } from "./deck.js";
+
+/** Hand categories, low to high. Mirrors standard poker hand ranking order. */
+export const HAND_CATEGORY = {
+  HIGH_CARD: 0,
+  PAIR: 1,
+  TWO_PAIR: 2,
+  THREE_OF_A_KIND: 3,
+  STRAIGHT: 4,
+  FLUSH: 5,
+  FULL_HOUSE: 6,
+  FOUR_OF_A_KIND: 7,
+  STRAIGHT_FLUSH: 8,
+} as const;
+
+/**
+ * A comparable hand score. `tiebreak` has a fixed, category-specific meaning
+ * so lexicographic comparison of the array alone resolves any tie within the
+ * category:
+ *   straight_flush / straight  -> [straight-top-rank]  (wheel top-rank is 5, not 14)
+ *   four_of_a_kind             -> [quad-rank, kicker]
+ *   full_house                 -> [trip-rank, pair-rank]
+ *   flush / high_card          -> [rank, rank, rank, rank, rank] (all 5, descending)
+ *   three_of_a_kind            -> [trip-rank, kicker, kicker]
+ *   two_pair                   -> [high-pair-rank, low-pair-rank, kicker]
+ *   pair                       -> [pair-rank, kicker, kicker, kicker]
+ */
+export interface HandRank {
+  category: number;
+  tiebreak: number[];
+}
+
+/** Ranks of a hand, descending, e.g. [14, 14, 9, 5, 2]. */
+function descendingRanks(cards: readonly Card[]): number[] {
+  return cards.map((c) => c.rank).sort((a, b) => b - a);
+}
+
+/**
+ * Top card of a straight formed by exactly 5 distinct, sorted-descending
+ * ranks, or `null` if they aren't consecutive. The ace-low "wheel"
+ * (A-2-3-4-5) plays as a 5-high straight, so its top card is 5, not 14 — this
+ * is what keeps it (and the "steel wheel" straight flush) below every
+ * higher-topped straight in `compareHands`.
+ */
+function straightHigh(uniqueDescRanks: readonly number[]): number | null {
+  if (uniqueDescRanks.length !== 5) return null;
+  const [r0, r1, r2, r3, r4] = uniqueDescRanks as [number, number, number, number, number];
+  if (r0 === 14 && r1 === 5 && r2 === 4 && r3 === 3 && r4 === 2) return 5;
+  if (r0 - r4 === 4) return r0;
+  return null;
+}
+
+/** Rank groups sorted by (count desc, rank desc) — e.g. [[13,3],[9,2]] for K-K-K-9-9. */
+function rankGroups(ranks: readonly number[]): Array<[rank: number, count: number]> {
+  const counts = new Map<number, number>();
+  for (const r of ranks) counts.set(r, (counts.get(r) ?? 0) + 1);
+  return [...counts.entries()].sort((a, b) => b[1] - a[1] || b[0] - a[0]);
+}
+
+/** Score an exact 5-card hand. Throws if `cards.length !== 5`. */
+export function evaluate5(cards: Card[]): HandRank {
+  if (cards.length !== 5) {
+    throw new Error(`evaluate5 requires exactly 5 cards, got ${cards.length}`);
+  }
+
+  const ranks = descendingRanks(cards);
+  const isFlush = cards.every((c) => c.suit === cards[0]!.suit);
+  const straightTop = straightHigh([...new Set(ranks)].sort((a, b) => b - a));
+  const groups = rankGroups(ranks);
+  const g0 = groups[0]!;
+
+  if (isFlush && straightTop !== null) {
+    return { category: HAND_CATEGORY.STRAIGHT_FLUSH, tiebreak: [straightTop] };
+  }
+  if (g0[1] === 4) {
+    const kicker = groups[1]![0];
+    return { category: HAND_CATEGORY.FOUR_OF_A_KIND, tiebreak: [g0[0], kicker] };
+  }
+  if (g0[1] === 3 && groups[1]![1] === 2) {
+    return { category: HAND_CATEGORY.FULL_HOUSE, tiebreak: [g0[0], groups[1]![0]] };
+  }
+  if (isFlush) {
+    return { category: HAND_CATEGORY.FLUSH, tiebreak: ranks };
+  }
+  if (straightTop !== null) {
+    return { category: HAND_CATEGORY.STRAIGHT, tiebreak: [straightTop] };
+  }
+  if (g0[1] === 3) {
+    const kickers = groups.slice(1).map(([r]) => r);
+    return { category: HAND_CATEGORY.THREE_OF_A_KIND, tiebreak: [g0[0], ...kickers] };
+  }
+  if (g0[1] === 2 && groups[1]![1] === 2) {
+    const kicker = groups[2]![0];
+    return { category: HAND_CATEGORY.TWO_PAIR, tiebreak: [g0[0], groups[1]![0], kicker] };
+  }
+  if (g0[1] === 2) {
+    const kickers = groups.slice(1).map(([r]) => r);
+    return { category: HAND_CATEGORY.PAIR, tiebreak: [g0[0], ...kickers] };
+  }
+  return { category: HAND_CATEGORY.HIGH_CARD, tiebreak: ranks };
+}
+
+/** Compare two hand ranks. Positive when `a` wins, negative when `b` wins, 0 on an exact tie. */
+export function compareHands(a: HandRank, b: HandRank): number {
+  if (a.category !== b.category) return a.category - b.category;
+  const len = Math.max(a.tiebreak.length, b.tiebreak.length);
+  for (let i = 0; i < len; i++) {
+    const diff = (a.tiebreak[i] ?? 0) - (b.tiebreak[i] ?? 0);
+    if (diff !== 0) return diff;
+  }
+  return 0;
+}
+
+/** All 5-index combinations out of `n` items, in ascending lexicographic order (n choose 5). */
+function combinations5Indices(n: number): Array<[number, number, number, number, number]> {
+  const out: Array<[number, number, number, number, number]> = [];
+  for (let a = 0; a < n; a++) {
+    for (let b = a + 1; b < n; b++) {
+      for (let c = b + 1; c < n; c++) {
+        for (let d = c + 1; d < n; d++) {
+          for (let e = d + 1; e < n; e++) {
+            out.push([a, b, c, d, e]);
+          }
+        }
+      }
+    }
+  }
+  return out;
+}
+
+/**
+ * Best 5-card hand out of a 5-7 card pool (hole cards + board). Enumerates
+ * every 5-card combination and keeps the maximum by `compareHands`; on a tie
+ * the FIRST combination reached wins (indices walked in ascending order over
+ * the input array), so `bestFive` is a deterministic, reproducible function
+ * of the input order — stable for UI highlighting across identical inputs.
+ */
+export function evaluateBest(cards: Card[]): { rank: HandRank; bestFive: Card[] } {
+  if (cards.length < 5) {
+    throw new Error(`evaluateBest requires at least 5 cards, got ${cards.length}`);
+  }
+  if (cards.length === 5) {
+    return { rank: evaluate5(cards), bestFive: cards.slice() };
+  }
+
+  let bestRank: HandRank | null = null;
+  let bestFive: Card[] | null = null;
+  for (const [a, b, c, d, e] of combinations5Indices(cards.length)) {
+    const five = [cards[a]!, cards[b]!, cards[c]!, cards[d]!, cards[e]!];
+    const rank = evaluate5(five);
+    if (bestRank === null || compareHands(rank, bestRank) > 0) {
+      bestRank = rank;
+      bestFive = five;
+    }
+  }
+  return { rank: bestRank!, bestFive: bestFive! };
+}
+
+/** Lowercase, comma-joined hand description body (everything after capitalization is applied by `handLabel`). */
+function describe(category: number, top: number, second: number | undefined): string {
+  switch (category) {
+    case HAND_CATEGORY.STRAIGHT_FLUSH:
+      return top === 14 ? "royal flush" : `straight flush, ${RANK_NAMES[top] ?? "unknown"} high`;
+    case HAND_CATEGORY.FOUR_OF_A_KIND:
+      return `four of a kind, ${rankPluralName(top)}`;
+    case HAND_CATEGORY.FULL_HOUSE:
+      return `full house, ${rankPluralName(top)} over ${rankPluralName(second ?? 0)}`;
+    case HAND_CATEGORY.FLUSH:
+      return `flush, ${RANK_NAMES[top] ?? "unknown"} high`;
+    case HAND_CATEGORY.STRAIGHT:
+      return `straight, ${RANK_NAMES[top] ?? "unknown"} high`;
+    case HAND_CATEGORY.THREE_OF_A_KIND:
+      return `three of a kind, ${rankPluralName(top)}`;
+    case HAND_CATEGORY.TWO_PAIR:
+      return `two pair, ${rankPluralName(top)} and ${rankPluralName(second ?? 0)}`;
+    case HAND_CATEGORY.PAIR:
+      return `pair of ${rankPluralName(top)}`;
+    default:
+      return `${RANK_NAMES[top] ?? "unknown"} high`;
+  }
+}
+
+/**
+ * Natural-English showdown label, e.g. "Full house, kings over nines",
+ * "Straight flush, nine high", "Ace high". Royal flush is the straight flush
+ * whose tiebreak top is the ace (14) — the only same-suit ace-high straight.
+ */
+export function handLabel(rank: HandRank): string {
+  const [top, second] = rank.tiebreak;
+  const lower = describe(rank.category, top ?? 0, second);
+  return lower.charAt(0).toUpperCase() + lower.slice(1);
+}

--- a/packages/shared/src/features/turn-games/poker/rng.ts
+++ b/packages/shared/src/features/turn-games/poker/rng.ts
@@ -1,0 +1,51 @@
+// ──────────────────────────────────────────────
+// Deterministic seeded RNG
+// ──────────────────────────────────────────────
+// All poker randomness is the per-hand deck shuffle, and it all flows through
+// here so deals are reproducible from (seed, cursor). The cursor is the hand
+// number, so rewinding to hand N and replaying from the same seed deals the
+// identical deck for that hand — this is what lets message edits /
+// regenerations rewind the game correctly. Intentionally independent of
+// dice.service.ts (which uses unseeded Math.random).
+
+/** mulberry32: tiny, fast, well-distributed 32-bit PRNG. Returns a [0,1) stream. */
+export function mulberry32(seed: number): () => number {
+  let a = seed >>> 0;
+  return () => {
+    a |= 0;
+    a = (a + 0x6d2b79f5) | 0;
+    let t = Math.imul(a ^ (a >>> 15), 1 | a);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+/**
+ * Derive an independent 32-bit sub-seed from a base seed and a cursor position,
+ * via splitmix32 finalization. Each distinct cursor yields an uncorrelated
+ * stream, so one "randomness draw" (a full hand's shuffle) costs exactly one
+ * cursor tick regardless of how many random numbers it internally consumes.
+ */
+export function deriveSubSeed(seed: number, cursor: number): number {
+  let z = (seed + Math.imul(cursor + 1, 0x9e3779b9)) >>> 0;
+  z = Math.imul(z ^ (z >>> 16), 0x21f0aaad) >>> 0;
+  z = Math.imul(z ^ (z >>> 15), 0x735a2d97) >>> 0;
+  return (z ^ (z >>> 15)) >>> 0;
+}
+
+/** Fisher-Yates using the supplied [0,1) generator. Returns a NEW array; does not mutate input. */
+export function shuffleWith<T>(items: readonly T[], rng: () => number): T[] {
+  const out = items.slice();
+  for (let i = out.length - 1; i > 0; i--) {
+    const j = Math.floor(rng() * (i + 1));
+    const tmp = out[i]!;
+    out[i] = out[j]!;
+    out[j] = tmp;
+  }
+  return out;
+}
+
+/** Deterministically shuffle `items` from (seed, cursor). Pure. */
+export function deterministicShuffle<T>(items: readonly T[], seed: number, cursor: number): T[] {
+  return shuffleWith(items, mulberry32(deriveSubSeed(seed, cursor)));
+}

--- a/packages/shared/src/features/turn-games/poker/tools.ts
+++ b/packages/shared/src/features/turn-games/poker/tools.ts
@@ -1,0 +1,72 @@
+// ──────────────────────────────────────────────
+// Poker — model-facing move tool
+// ──────────────────────────────────────────────
+// NOT registered in the global tool registry. The runner injects this only on
+// a bot seat's turn (scoped per active game). The human never uses it — the
+// board UI posts moves to the REST endpoint directly. One flat tool covers the
+// whole action space; `describeForModel` tells the model exactly which of
+// these are legal right now and the min/max for `amount`. There is no
+// `next_hand` tool — pacing the session between hands is a human/UI-only move.
+
+import type { ToolDefinition } from "../../function-calls/tool-definitions.js";
+import type { PokerMove } from "./types.js";
+
+export const pokerActionToolManifest = {
+  name: "poker_action",
+  description:
+    "Take your poker action. Pick ONE of the legal actions listed in your instructions " +
+    '(e.g. "check", "call 40", "bet: min 20 max 980", "raise: min-to 80, max-to 1020", "fold", "all_in"). ' +
+    "For bet, `amount` is the chips you put in. For raise, `amount` is the TOTAL you raise the street's bet to " +
+    "(not the increment). `amount` is ignored for fold/check/call/all_in. Copy amounts from within the stated " +
+    "min/max range — out-of-range amounts are clamped, not rejected, but stay inside the range you were given.",
+  parameters: {
+    type: "object",
+    properties: {
+      action: {
+        type: "string",
+        description: "The action to take.",
+        enum: ["fold", "check", "call", "bet", "raise", "all_in"],
+      },
+      amount: {
+        type: "number",
+        description:
+          "For bet: the chips you put in. For raise: the TOTAL amount you raise the street's bet to. Ignored otherwise.",
+      },
+    },
+    required: ["action"],
+  },
+} satisfies ToolDefinition;
+
+/** All poker tools. */
+export const POKER_TOOL_MANIFESTS: readonly ToolDefinition[] = [pokerActionToolManifest];
+
+/** Map a raw `poker_action` tool call onto a typed move. Returns `null` for any other tool name.
+ * An unknown/missing `action` still returns a best-effort move (`applyMove` rejects it and the
+ * runner's deterministic fallback kicks in), per the engine contract. */
+export function parsePokerToolCall(name: string, args: Record<string, unknown>): PokerMove | null {
+  if (name !== "poker_action") return null;
+  const action = typeof args.action === "string" ? args.action.trim().toLowerCase() : "";
+  const rawAmount = args.amount;
+  const amount = typeof rawAmount === "number" && Number.isFinite(rawAmount) ? Math.floor(rawAmount) : 0;
+
+  switch (action) {
+    case "fold":
+      return { type: "fold" };
+    case "check":
+      return { type: "check" };
+    case "call":
+      return { type: "call" };
+    case "bet":
+      return { type: "bet", amount };
+    case "raise":
+      return { type: "raise", toAmount: amount };
+    case "all_in":
+    case "allin":
+    case "all-in":
+      return { type: "all_in" };
+    default:
+      // Best-effort fallback for a garbled/missing action — applyMove will reject
+      // it (check facing a bet fails) and the runner falls back deterministically.
+      return { type: "check" };
+  }
+}

--- a/packages/shared/src/features/turn-games/poker/types.ts
+++ b/packages/shared/src/features/turn-games/poker/types.ts
@@ -1,0 +1,256 @@
+// ──────────────────────────────────────────────
+// Poker (No-Limit Texas Hold'em) — State, Moves, Config
+// ──────────────────────────────────────────────
+
+import { z } from "zod";
+import type { GameEvent } from "../engine.types.js";
+import type { Card } from "./deck.js";
+
+// ── Config ───────────────────────────────────────────────────────────────────
+
+export interface PokerConfig {
+  /** Chips each seat starts (and re-buys, if ever added) with. */
+  startingStack: number;
+  /**
+   * The small blind. The big blind is ALWAYS 2x this value — derived at setup
+   * time (`state.blinds.bigBlind`), never stored in config, so the two can
+   * never drift apart.
+   */
+  smallBlind: number;
+  /** Blinds double after every N completed hands. 0 disables escalation. */
+  blindIncreaseEveryHands: number;
+  /** Session ends after this many completed hands (chip leader wins). 0 = unlimited. */
+  handLimit: number;
+  /**
+   * Character that voices dealer announcements (hand start, street deals,
+   * showdown, blinds-up, game over) — narration only. `null` = a silent
+   * "house" dealer; the engine still queues the same announcements either way,
+   * it's the runner's choice whether/how to voice them. NEVER affects dealing,
+   * shuffling, or any rule — see `pokerEngine.announcerCharacterId`.
+   */
+  dealerCharacterId: string | null;
+}
+
+export const pokerConfigSchema = z.object({
+  startingStack: z.number(),
+  smallBlind: z.number(),
+  blindIncreaseEveryHands: z.number(),
+  handLimit: z.number(),
+  dealerCharacterId: z.string().nullable(),
+});
+
+export const DEFAULT_POKER_CONFIG: PokerConfig = {
+  startingStack: 1000,
+  smallBlind: 10,
+  blindIncreaseEveryHands: 0,
+  handLimit: 0,
+  dealerCharacterId: null,
+};
+
+/** Integer-clamp a raw config into house-rule bounds. `smallBlind`'s ceiling depends
+ * on the (already-clamped) `startingStack`, so the two fields must be clamped in order. */
+export function clampPokerConfig(raw: Partial<PokerConfig> | Record<string, unknown> | null | undefined): PokerConfig {
+  const r = (raw ?? {}) as Partial<PokerConfig>;
+  const intOr = (v: unknown, fallback: number): number => {
+    const n = typeof v === "number" && Number.isFinite(v) ? Math.floor(v) : fallback;
+    return n;
+  };
+  const clamp = (n: number, min: number, max: number): number => Math.min(max, Math.max(min, n));
+
+  const startingStack = clamp(intOr(r.startingStack, DEFAULT_POKER_CONFIG.startingStack), 100, 1_000_000);
+  const smallBlind = clamp(intOr(r.smallBlind, DEFAULT_POKER_CONFIG.smallBlind), 1, Math.max(1, Math.floor(startingStack / 4)));
+  const blindIncreaseEveryHands = Math.max(0, intOr(r.blindIncreaseEveryHands, DEFAULT_POKER_CONFIG.blindIncreaseEveryHands));
+  const handLimit = Math.max(0, intOr(r.handLimit, DEFAULT_POKER_CONFIG.handLimit));
+  const dealerCharacterId = typeof r.dealerCharacterId === "string" && r.dealerCharacterId.trim() ? r.dealerCharacterId : null;
+
+  return { startingStack, smallBlind, blindIncreaseEveryHands, handLimit, dealerCharacterId };
+}
+
+export const POKER_MIN_PLAYERS = 2;
+export const POKER_MAX_PLAYERS = 8;
+export const POKER_LOG_CAP = 30;
+
+// ── Moves ────────────────────────────────────────────────────────────────────
+
+export type PokerMove =
+  | { type: "fold" }
+  | { type: "check" }
+  | { type: "call" }
+  /** `amount` is the chips put in (this street's bet total, since currentBets[seat] was 0). */
+  | { type: "bet"; amount: number }
+  /** `toAmount` is the TOTAL this street's bet becomes (not the increment). */
+  | { type: "raise"; toAmount: number }
+  /** Push the entire remaining stack in — resolves to a bet/raise/call for the full stack. */
+  | { type: "all_in" }
+  /** Human-only pacing move: legal only in `hand_over`, only for the seat `currentSeat` points to. */
+  | { type: "next_hand" };
+
+export const pokerMoveSchema: z.ZodType<PokerMove> = z.discriminatedUnion("type", [
+  z.object({ type: z.literal("fold") }),
+  z.object({ type: z.literal("check") }),
+  z.object({ type: z.literal("call") }),
+  z.object({ type: z.literal("bet"), amount: z.number() }),
+  z.object({ type: z.literal("raise"), toAmount: z.number() }),
+  z.object({ type: z.literal("all_in") }),
+  z.object({ type: z.literal("next_hand") }),
+]);
+
+// ── State ────────────────────────────────────────────────────────────────────
+
+export type PokerStatus = "active" | "hand_over" | "finished";
+export type PokerStreet = "preflop" | "flop" | "turn" | "river";
+
+export interface PokerPotAward {
+  seatId: string;
+  amount: number;
+  /** "main pot" / "side pot 1" / "side pot 2" ... */
+  label: string;
+}
+
+export interface PokerReveal {
+  seatId: string;
+  holeCards: Card[];
+  /** e.g. "Full house, kings over nines". */
+  label: string;
+  /** The best 5 cards used, as compact codes (e.g. ["Kh","Kc","Kd","9s","9h"]). */
+  bestFiveCodes: string[];
+}
+
+/** Outcome of the last completed hand — drives the board recap and dealer narration. */
+export interface PokerHandResults {
+  potAwards: PokerPotAward[];
+  /** Every non-folded seat at showdown. Empty when the hand ended by everyone-folds
+   * (no reveal happens in that case — the last seat standing wins uncontested). */
+  reveals: PokerReveal[];
+}
+
+export interface PokerState {
+  config: PokerConfig;
+  /** Seeded RNG root. Each hand's deck is `deterministicShuffle(buildDeck(), seed, handNumber)`
+   * — reproducible and rewind-safe without persisting the deck itself. */
+  seed: number;
+  seats: Array<{ seatId: string; displayName: string; kind: "human" | "bot" }>;
+  /** Table seating order (fixed for the session). Framework-compatibility name: the
+   * bot runner and context builder duck-type on this exact field name. */
+  seatOrder: string[];
+  /** Framework-compatibility name: duck-typed by the bot runner / context builder. */
+  seatNames: Record<string, string>;
+  stacks: Record<string, number>;
+  status: PokerStatus;
+  /** 1-based. */
+  handNumber: number;
+  buttonSeatId: string;
+  /** Current blinds (may have escalated from config via `blindIncreaseEveryHands`). */
+  blinds: { smallBlind: number; bigBlind: number };
+
+  // ── per-hand fields (reset by setup / dealNewHand) ──
+  holeCards: Record<string, Card[]>;
+  community: Card[];
+  street: PokerStreet;
+  /** Cards consumed so far from this hand's derived deck (see `seed` above). */
+  deckCursor: number;
+
+  // ── betting (per-street unless noted) ──
+  /** This street's bet-so-far per seat. Reset to {} at the start of each street. */
+  currentBets: Record<string, number>;
+  /** This HAND's total committed per seat (all streets) — the source for side-pot math. */
+  committedTotal: Record<string, number>;
+  betToMatch: number;
+  /** Size of the last FULL raise this street (bigBlind at the start of every street). */
+  lastRaiseSize: number;
+  currentSeatId: string | null;
+  /**
+   * Seats that have acted (check/call/bet/raise/fold/all-in) since the last FULL
+   * bet/raise this street. Cleared and reseeded with just the aggressor on every
+   * FULL bet/raise; deliberately NOT cleared by an incomplete (short all-in) raise
+   * — that's what stops an incomplete raise from reopening full raising rights for
+   * seats that already acted (see `engine.ts`'s raise handler). The betting round
+   * closes once every seat still in the hand and not all-in is BOTH in this set
+   * AND has `currentBets[seat] === betToMatch`. Starting a street (or the blinds
+   * at hand setup) does NOT put anyone in this set — that's what gives the big
+   * blind its preflop option even when everyone else has limped to it.
+   */
+  actedSeatIds: string[];
+  foldedSeatIds: string[];
+  allInSeatIds: string[];
+  /** Seats out of future hands (busted to 0 chips). */
+  bustedSeatIds: string[];
+  handsCompleted: number;
+  winnerSeatId: string | null;
+  /** The last completed hand's outcome, for the board recap. Null before the first hand ends. */
+  handResults: PokerHandResults | null;
+  /** Queued dealer narration events, drained by `drainAnnouncements`. */
+  pendingAnnouncements: GameEvent[];
+  lastAction: { seatId: string; summary: string } | null;
+  /** Capped ring buffer of recent events (newest last) for the board log. */
+  log: GameEvent[];
+}
+
+// ── Public (per-viewer) view rendered by the client board ───────────────────
+
+export interface PokerPublicSeat {
+  seatId: string;
+  displayName: string;
+  kind: "human" | "bot";
+  stack: number;
+  /** This street's bet so far. */
+  streetBet: number;
+  /** This hand's total committed (all streets). */
+  committed: number;
+  folded: boolean;
+  allIn: boolean;
+  busted: boolean;
+  isButton: boolean;
+  isSmallBlind: boolean;
+  isBigBlind: boolean;
+  isCurrent: boolean;
+}
+
+export interface PokerYourActions {
+  canFold: boolean;
+  canCheck: boolean;
+  canCall: boolean;
+  /** Chips it costs to call (0 when check is available). */
+  callAmount: number;
+  canBet: boolean;
+  minBet: number;
+  canRaise: boolean;
+  minRaiseTo: number;
+  /** The maximum you can put your street total to, for either a bet or a raise
+   * (i.e. your full stack, expressed as a street-total). */
+  maxTo: number;
+  canAllIn: boolean;
+  canNextHand: boolean;
+}
+
+export interface PokerPublicView {
+  gameType: "poker";
+  status: PokerStatus;
+  handNumber: number;
+  street: PokerStreet;
+  communityCodes: string[];
+  communityShort: string[];
+  /** Sum of `committedTotal` across all seats. */
+  potTotal: number;
+  blinds: { smallBlind: number; bigBlind: number };
+  /** In `seatOrder` order. */
+  seats: PokerPublicSeat[];
+  currentSeatId: string | null;
+  yourSeatId: string | null;
+  /** The viewer's own hole cards only — never another seat's. */
+  yourHoleCards: Array<{ code: string; short: string; label: string }>;
+  /** The viewer's current best hand using the visible community cards, or null
+   * before the flop (evaluateBest needs >= 5 cards, so it's only meaningful
+   * once `community.length >= 3`). */
+  yourHandLabel: string | null;
+  yourActions: PokerYourActions;
+  /** The last completed hand's outcome (reveals + pot awards). Public — the whole
+   * table sees showdown reveals once a hand concludes. */
+  handResults: PokerHandResults | null;
+  winnerSeatId: string | null;
+  lastAction: { seatId: string; summary: string } | null;
+  recentLog: GameEvent[];
+  config: PokerConfig;
+  dealerCharacterId: string | null;
+  hasPendingAnnouncements: boolean;
+}

--- a/packages/shared/src/features/turn-games/registry.generated.ts
+++ b/packages/shared/src/features/turn-games/registry.generated.ts
@@ -4,9 +4,11 @@ import type { AnyTurnGameEngine } from "./engine.types.js";
 
 import { unoGameEngine } from "./uno/engine.manifest.js";
 import { chessGameEngine } from "./chess/engine.manifest.js";
+import { pokerGameEngine } from "./poker/engine.manifest.js";
 
 export const TURN_GAME_ENGINES: readonly AnyTurnGameEngine[] = [
   unoGameEngine,
   chessGameEngine,
+  pokerGameEngine,
 ];
 

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -84,6 +84,9 @@ export { unoEngine, cardLabel } from "./features/turn-games/uno/engine.js";
 export * from "./features/turn-games/chess/types.js";
 export * from "./features/turn-games/chess/tools.js";
 export { chessEngine } from "./features/turn-games/chess/engine.js";
+export * from "./features/turn-games/poker/types.js";
+export * from "./features/turn-games/poker/tools.js";
+export { pokerEngine, buildPots } from "./features/turn-games/poker/engine.js";
 
 // Utils
 export * from "./utils/macro-engine.js";

--- a/packages/shared/src/types/chat.ts
+++ b/packages/shared/src/types/chat.ts
@@ -38,6 +38,7 @@ export const CONVERSATION_COMMAND_KEYS = [
   "call",
   "uno",
   "chess",
+  "poker",
   "music",
   "haptic",
   "influence",


### PR DESCRIPTION
## Linked issue

Closes #3407

## Why this change

Conversation mode had two table games (UNO, chess) but no betting game — and poker is where character personality matters most: bluffing, needling, folding under pressure, and shoving all-in are in-character acts, not just game logic. This adds No-Limit Texas Hold'em as the third turn-game on the existing conversation-mode framework, giving group chats a reason to gather at a table where each character's temperament actually changes how they play. It also introduces a **selectable dealer** so a chosen character (or a silent house dealer) narrates the hand in their own voice while the engine deals fairly.

## What changed

**Shared — deterministic poker engine (`packages/shared/src/features/turn-games/poker/`)**
- Pure, server-authoritative No-Limit Hold'em engine: seeded fair dealing (each hand's deck is `deterministicShuffle(seed, handNumber)`, so message edits / regenerations rewind to identical deals), full no-limit betting with all-ins, incomplete-raise capping, the big-blind option, and layered side pots.
- Hand-rolled 5-of-7 evaluator with natural-English showdown labels ("Full house, kings over nines").
- Multi-hand sessions: rotating dealer button, optional blind escalation, optional hand limit, and a human-paced `next_hand` step between hands. `hiddenInformation: true`, so the framework keeps each seat's hole cards private.
- Two new **optional** methods on the `TurnGameEngine` contract — `announcerCharacterId` and `drainAnnouncements` — for the dealer-narration feature. UNO and chess implement neither and are entirely unaffected.

**Server — dealer announcements + `[poker]` command**
- The bot-turn runner drains engine-queued dealer announcements (hand start, street deals, showdown, blinds up, game over): a configured dealer character voices them as one short in-character line; a silent house dealer just advances state. Optional-method-guarded, so UNO/chess paths are unchanged.
- New `[poker]` conversation command (advertise + dispatch, seats human + non-offline characters capped at 8) mirroring `[uno]`/`[chess]`.

**Client — table board + setup**
- `PokerBoard` (community cards, seat strip with button/blind/status badges, hole cards + live hand label, fold/check/call/bet-raise/all-in action bar, showdown recap with best-five highlighting, `Next hand` pacing) and `PokerSetup` (player picker, dealer dropdown — house or any character, stakes).
- Wiring: poker store into both `turn_game_state_patch` handlers, `/poker`, the natural-language launcher, and the conversation command toggles.

**Docs**
- `CHANGELOG.md`: poker under `[Unreleased]`; also back-filled the previously-undocumented turn-game framework work (#3308 personality-driven bot moves, seat-aware in-chat game context, personality-gated hand/plan secrecy) under its shipped release **`[2.1.0]`** (verified via tag ancestry). No version bump in this PR.

## Validation

<!-- Required: include commands run and/or manual checks performed -->

- [x] `pnpm check` passes locally
- [x] Container (Docker / Podman) built and ran without issue
- [x] Ran the app, clicked through the changes manually
- [x] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [x] Above manual verification completed (describe below)
- [x] Read and followed `CONTRIBUTING.md`

### Manual verification notes

What the author ran and verified:

- `pnpm check` (shared + server + client build + lint) — exited 0 (including after merging current `staging` in to resolve a `CHANGELOG.md` conflict).
- Local gitignored engine/runner suites (via `tsx --test`): poker hand-evaluator (21 cases incl. a 2000-hand brute-force fuzz), poker engine (21 cases incl. a chip-conservation invariant fuzz across 30+ full sessions), poker server runner (5 cases incl. a no-hidden-information-leak assertion and voiced/silent dealer drains). UNO/chess/framework regression suites all green, re-run after the staging merge.
- Deployed the branch to a live server (Docker build via the host panel) and drove a full real-LLM game (human + 3 characters, one character as dealer): setup modal → board render → betting through preflop/flop/turn/river → showdown with correct reveals, hand labels, and payouts → `next_hand`. The dealer character announced each street in character with accurate facts; bots played in character; a UI fold fired the bot loop; a page reload rehydrated the board; the game survived a container restart mid-hand.
- Edge cases exercised: **empty states** (a fold-around "walk" — pot awarded with no reveals, board resets to Pot 0) and **error paths** (illegal moves rejected by the engine with the legal set returned; oversized/negative bet inputs clamped client- and server-side). Zero server-log and console errors across the session.

Partial coverage (why the edge-cases box is left unticked): a dedicated **light/dark theme toggle sweep and mobile-viewport pass** of the poker board specifically was not performed by the author — the board reuses the same theme-token (`var(--…)`) and `flex-wrap` responsive patterns as the already-shipped UNO/chess boards, but this has not been independently re-verified for poker. A maintainer should tick that box after their own light/dark + mobile check.

To manually verify in a browser: enable the **Poker** command toggle in a conversation chat with 1+ characters, run `/poker`, pick a character dealer and stakes, and play a hand — check the action bar (fold/check/call/bet/raise/all-in), the showdown recap, `Next hand`, and dealer narration; also glance at light + dark theme and a mobile width.

## Docs and release impact

- [ ] No docs changes needed
- [x] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Version/release files updated (only if this PR includes a version bump)

<!-- Updated CHANGELOG.md: poker under [Unreleased]; also back-filled the previously-undocumented #3308 turn-game work to its shipped release [2.1.0] (verified by tag ancestry). No version bump in this PR. -->



## UI evidence (if applicable)

<img width="1031" height="625" alt="image" src="https://github.com/user-attachments/assets/730fe975-cc9c-45ea-8c12-c816c25a5b84" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new Poker game in conversation mode, with setup, playable table UI, betting controls, showdown recap, and multi-hand sessions.
  * Users can now start Poker from chat using a command or phrases like “let’s play poker.”
  * Added an option to choose between a silent dealer or a character-led dealer experience.
  * Poker now appears in the chat commands toggle list and setup flow.

* **Bug Fixes**
  * Improved game-state handling so Poker sessions stay in sync during chat updates and resets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->