### PR TITLE
Refresh Keeper vectors and extend Illustrator timeout

### DIFF
--- a/packages/server/src/routes/generate.routes.ts
+++ b/packages/server/src/routes/generate.routes.ts
@@ -60,7 +60,10 @@ import { createCustomStickersStorage } from "../services/storage/custom-stickers
 import { createCharacterGalleryStorage } from "../services/storage/character-gallery.storage.js";
 import { createPersonaGalleryStorage } from "../services/storage/persona-gallery.storage.js";
 import { createAppSettingsStorage } from "../services/storage/app-settings.storage.js";
-import { buildLorebookSemanticEmbeddingsById } from "../services/lorebook/embeddings.js";
+import {
+  buildLorebookSemanticEmbeddingsById,
+  warmLorebookEntryEmbeddings,
+} from "../services/lorebook/embeddings.js";
 import { applyRegexScriptsToPromptMessages } from "../services/regex/regex-application.js";
 import { createPromptOverridesStorage } from "../services/storage/prompt-overrides.storage.js";
 import { filterRelevantLorebooks, processLorebooks } from "../services/lorebook/index.js";
@@ -7199,6 +7202,12 @@ export async function generateRoutes(app: FastifyInstance) {
                     preferredTargetLorebookId,
                     writableLorebookIds,
                     updates,
+                    revectorizeEntry: async (entry) => {
+                      await warmLorebookEntryEmbeddings(app.db, [entry], {
+                        embeddingSource: memoryRecallEmbeddingSource,
+                        signal: abortController.signal,
+                      });
+                    },
                   });
                 }
               } catch {

--- a/packages/server/src/routes/generate.routes.ts
+++ b/packages/server/src/routes/generate.routes.ts
@@ -7202,12 +7202,14 @@ export async function generateRoutes(app: FastifyInstance) {
                     preferredTargetLorebookId,
                     writableLorebookIds,
                     updates,
-                    revectorizeEntry: async (entry) => {
-                      await warmLorebookEntryEmbeddings(app.db, [entry], {
-                        embeddingSource: memoryRecallEmbeddingSource,
-                        signal: abortController.signal,
-                      });
-                    },
+                    revectorizeEntry: memoryRecallVectorizerAvailable
+                      ? async (entry) => {
+                          await warmLorebookEntryEmbeddings(app.db, [entry], {
+                            embeddingSource: memoryRecallEmbeddingSource,
+                            signal: abortController.signal,
+                          });
+                        }
+                      : undefined,
                   });
                 }
               } catch {

--- a/packages/server/src/routes/generate/lorebook-keeper-utils.ts
+++ b/packages/server/src/routes/generate/lorebook-keeper-utils.ts
@@ -1,4 +1,5 @@
-import type { AgentContext } from "@marinara-engine/shared";
+import type { AgentContext, LorebookEntry } from "@marinara-engine/shared";
+import { logger } from "../../lib/logger.js";
 import { createLorebooksStorage } from "../../services/storage/lorebooks.storage.js";
 
 export interface LorebookKeeperSettings {
@@ -350,8 +351,10 @@ export async function persistLorebookKeeperUpdates(args: {
   preferredTargetLorebookId: string | null;
   writableLorebookIds: string[] | null;
   updates: Array<Record<string, unknown>>;
+  revectorizeEntry?: (entry: LorebookEntry) => Promise<void>;
 }): Promise<string | null> {
-  const { lorebooksStore, chatId, chatName, preferredTargetLorebookId, writableLorebookIds, updates } = args;
+  const { lorebooksStore, chatId, chatName, preferredTargetLorebookId, writableLorebookIds, updates, revectorizeEntry } =
+    args;
 
   let targetLorebookId = preferredTargetLorebookId ?? writableLorebookIds?.[0] ?? null;
   if (!targetLorebookId) {
@@ -404,11 +407,18 @@ export async function persistLorebookKeeperUpdates(args: {
       });
       const mergedKeys = mergeLorebookKeys(existing.keys, keys);
       const mergedTag = tag || existing.tag || "";
-      await lorebooksStore.updateEntry(existing.id, {
+      const updated = await lorebooksStore.updateEntry(existing.id, {
         content: mergedContent,
         keys: mergedKeys,
         tag: mergedTag,
       });
+      if (revectorizeEntry && updated) {
+        try {
+          await revectorizeEntry(updated as LorebookEntry);
+        } catch (err) {
+          logger.warn(err, "[lorebook-keeper] Failed to refresh embedding for updated entry %s", existing.id);
+        }
+      }
       entryByName.set(rawName.toLowerCase(), {
         ...existing,
         content: mergedContent,

--- a/packages/server/src/services/agents/agent-executor.ts
+++ b/packages/server/src/services/agents/agent-executor.ts
@@ -37,6 +37,7 @@ const CHARACTER_LORE_DESCRIPTION_LIMIT = 2000;
 const CHARACTER_LORE_FIELD_LIMIT = 1200;
 const DEFAULT_AGENT_TEMPERATURE = 0.3;
 const DEFAULT_AGENT_CALL_TIMEOUT_MS = 5 * 60_000;
+const ILLUSTRATOR_AGENT_CALL_TIMEOUT_MS = 30 * 60_000;
 const AGENT_BATCH_FALLBACK_MAX_CONCURRENT = 4;
 
 /** Strip HTML/XML-style tags (e.g. <div style="..."> <br> <speaker>) from text to save tokens. */
@@ -452,8 +453,9 @@ function combineAbortSignals(signals: AbortSignal[]): AbortSignal {
   return controller.signal;
 }
 
-function agentCallSignal(parentSignal?: AbortSignal): AbortSignal {
-  const timeoutSignal = AbortSignal.timeout(DEFAULT_AGENT_CALL_TIMEOUT_MS);
+function agentCallSignal(parentSignal?: AbortSignal, agentType?: string): AbortSignal {
+  const timeoutMs = agentType === "illustrator" ? ILLUSTRATOR_AGENT_CALL_TIMEOUT_MS : DEFAULT_AGENT_CALL_TIMEOUT_MS;
+  const timeoutSignal = AbortSignal.timeout(timeoutMs);
   return parentSignal ? combineAbortSignals([parentSignal, timeoutSignal]) : timeoutSignal;
 }
 
@@ -621,7 +623,7 @@ export async function executeAgent(
             responseText += chunk;
           }
         : undefined,
-      signal: agentCallSignal(context.signal),
+      signal: agentCallSignal(context.signal, config.type),
     });
 
     if (!responseText && result.content) responseText = result.content;
@@ -667,7 +669,7 @@ export async function executeAgent(
               retryResponseText += chunk;
             }
           : undefined,
-        signal: agentCallSignal(context.signal),
+        signal: agentCallSignal(context.signal, config.type),
       });
       totalTokens += retryResult.usage?.totalTokens ?? 0;
       if (!retryResponseText && retryResult.content) retryResponseText = retryResult.content;
@@ -740,7 +742,7 @@ async function executeAgentWithTools(
   let totalTokens = 0;
   const debugAgentsEnabled = isDebugAgentsEnabled() && logger.isLevelEnabled("debug");
   const customParameters = agentCustomParameters(config);
-  const toolLoopSignal = agentCallSignal(context.signal);
+  const toolLoopSignal = agentCallSignal(context.signal, config.type);
 
   for (let round = 0; round < maxToolRounds; round++) {
     emitAgentDebug(context, {
@@ -1029,7 +1031,7 @@ export async function executeAgentBatch(
             responseText += chunk;
           }
         : undefined,
-      signal: agentCallSignal(context.signal),
+      signal: agentCallSignal(context.signal, configs.some((config) => config.type === "illustrator") ? "illustrator" : undefined),
     });
 
     // chatComplete also accumulates content, but streaming via onToken is

--- a/packages/server/src/services/agents/agent-executor.ts
+++ b/packages/server/src/services/agents/agent-executor.ts
@@ -453,7 +453,7 @@ function combineAbortSignals(signals: AbortSignal[]): AbortSignal {
   return controller.signal;
 }
 
-function agentCallSignal(parentSignal?: AbortSignal, agentType?: string): AbortSignal {
+function agentCallSignal(parentSignal?: AbortSignal, agentType?: "illustrator"): AbortSignal {
   const timeoutMs = agentType === "illustrator" ? ILLUSTRATOR_AGENT_CALL_TIMEOUT_MS : DEFAULT_AGENT_CALL_TIMEOUT_MS;
   const timeoutSignal = AbortSignal.timeout(timeoutMs);
   return parentSignal ? combineAbortSignals([parentSignal, timeoutSignal]) : timeoutSignal;
@@ -623,7 +623,7 @@ export async function executeAgent(
             responseText += chunk;
           }
         : undefined,
-      signal: agentCallSignal(context.signal, config.type),
+      signal: agentCallSignal(context.signal, config.type === "illustrator" ? "illustrator" : undefined),
     });
 
     if (!responseText && result.content) responseText = result.content;
@@ -669,7 +669,7 @@ export async function executeAgent(
               retryResponseText += chunk;
             }
           : undefined,
-        signal: agentCallSignal(context.signal, config.type),
+        signal: agentCallSignal(context.signal, config.type === "illustrator" ? "illustrator" : undefined),
       });
       totalTokens += retryResult.usage?.totalTokens ?? 0;
       if (!retryResponseText && retryResult.content) retryResponseText = retryResult.content;
@@ -742,7 +742,7 @@ async function executeAgentWithTools(
   let totalTokens = 0;
   const debugAgentsEnabled = isDebugAgentsEnabled() && logger.isLevelEnabled("debug");
   const customParameters = agentCustomParameters(config);
-  const toolLoopSignal = agentCallSignal(context.signal, config.type);
+  const toolLoopSignal = agentCallSignal(context.signal, config.type === "illustrator" ? "illustrator" : undefined);
 
   for (let round = 0; round < maxToolRounds; round++) {
     emitAgentDebug(context, {


### PR DESCRIPTION
## Linked issue

Closes #3415
Closes #3416

## Why this change

Lorebook Keeper updates invalidate an entry's previous embedding but leave it unvectorized, forcing users to run the bulk re-vectorization action manually. The Illustrator's LLM planning call also inherits the generic five-minute agent watchdog, which is too short for some local models even though image generation itself permits much longer work.

## What changed

- Re-vectorize each eligible lorebook entry immediately after Lorebook Keeper updates it.
- Keep Keeper persistence successful when an embedding provider is temporarily unavailable, while logging the refresh failure.
- Give standalone and batched Illustrator planning calls a 30-minute timeout while preserving the five-minute default for other agents.

## Validation

- [ ] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed `CONTRIBUTING.md`

### Manual verification notes

- Automated validation completed with `pnpm check` (TypeScript, ESLint, and production builds).
- Manually verify a vector-enabled Keeper-managed entry receives a new embedding after an update.
- Manually verify a local Illustrator planning request can continue beyond five minutes.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Version/release files updated (only if this PR includes a version bump)

## UI evidence (if applicable)

Not applicable; this is server-side behavior.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated lorebook embeddings after existing entries are changed, improving the accuracy of future semantic recall.
  * Prevented embedding refresh failures from interrupting lorebook updates.

* **Improvements**
  * Increased the available processing time for illustration-related AI requests, reducing failures caused by longer-running generations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->