### PR TITLE
Harden Noodle persona safety and interaction flows

### DIFF
--- a/e2e/core-flows.e2e.ts
+++ b/e2e/core-flows.e2e.ts
@@ -576,6 +576,15 @@ test("Noodle persona comments can be edited and deleted without exposing charact
   });
   expect(postResponse.ok()).toBe(true);
   const post = (await postResponse.json()) as { id: string };
+  const controlPostResponse = await page.request.post("/api/noodle/posts", {
+    data: {
+      authorKind: "character",
+      authorEntityId: "__professor_mari__",
+      content: `Newer control post ${Date.now()}`,
+    },
+  });
+  expect(controlPostResponse.ok()).toBe(true);
+  const controlPost = (await controlPostResponse.json()) as { id: string };
 
   try {
     const ownReplyResponse = await page.request.post(`/api/noodle/posts/${post.id}/interactions`, {
@@ -611,10 +620,19 @@ test("Noodle persona comments can be edited and deleted without exposing charact
     await page.locator('[data-tour="noodle-tab"]').click();
 
     const noodle = page.locator('[data-component="NoodleView"]');
+    const activePost = noodle.locator(`[data-noodle-post-id="${post.id}"]`);
+    const newerControlPost = noodle.locator(`[data-noodle-post-id="${controlPost.id}"]`);
     const ownComment = noodle.locator(`[data-noodle-interaction-id="${ownReply.id}"]`);
     const characterComment = noodle.locator(`[data-noodle-interaction-id="${childReply.id}"]`);
+    await expect(newerControlPost).toBeVisible();
     await expect(ownComment).toBeVisible();
     await expect(characterComment).toBeVisible();
+    expect(
+      await activePost.evaluate((element, controlPostId) => {
+        const control = document.querySelector(`[data-noodle-post-id="${controlPostId}"]`);
+        return Boolean(control && element.compareDocumentPosition(control) & Node.DOCUMENT_POSITION_FOLLOWING);
+      }, controlPost.id),
+    ).toBe(true);
     await expect(ownComment.getByRole("button", { name: "Edit comment" })).toBeVisible();
     await expect(ownComment.getByRole("button", { name: "Delete comment" })).toBeVisible();
     await expect(characterComment.getByRole("button", { name: "Edit comment" })).toHaveCount(0);
@@ -636,6 +654,7 @@ test("Noodle persona comments can be edited and deleted without exposing charact
     expect(errors).toEqual([]);
   } finally {
     await page.request.delete(`/api/noodle/posts/${post.id}`, { timeout: 5_000 }).catch(() => undefined);
+    await page.request.delete(`/api/noodle/posts/${controlPost.id}`, { timeout: 5_000 }).catch(() => undefined);
     if (createdPersonaId) {
       await page.request
         .delete(`/api/characters/personas/${createdPersonaId}`, { timeout: 5_000 })

--- a/e2e/core-flows.e2e.ts
+++ b/e2e/core-flows.e2e.ts
@@ -588,7 +588,10 @@ test("Noodle reply notifications focus the actionable timeline reply", async ({ 
     await page.locator('[data-tour="noodle-tab"]').click();
 
     const noodle = page.locator('[data-component="NoodleView"]');
-    await noodle.getByRole("button", { name: "Noodle notifications" }).click();
+    const notificationsButton = noodle.getByRole("button", { name: "Noodle notifications" });
+    await expect(notificationsButton.locator('[data-component="NoodleView.NotificationBadge"]')).toBeVisible();
+    await notificationsButton.click();
+    await expect(noodle.locator('[data-component="NoodleView.NotificationBadge"]')).toHaveCount(0);
     await noodle.getByRole("button", { name: "Replies", exact: true }).click();
 
     const notification = noodle.locator(`[data-noodle-notification-target="${reply.id}"]`);
@@ -600,6 +603,23 @@ test("Noodle reply notifications focus the actionable timeline reply", async ({ 
     await expect(focusedReply).toBeFocused();
     await expect(focusedReply.getByTitle(/Like comment|Unlike comment/)).toBeVisible();
     await expect(focusedReply.getByTitle("Reply")).toBeVisible();
+
+    await focusedReply.getByTitle("Reply").click();
+    const nestedComposer = noodle.locator(
+      `[data-component="NoodleView.ReplyComposer"][data-noodle-reply-parent-id="${reply.id}"]`,
+    );
+    await expect(nestedComposer).toBeVisible();
+    await expect(nestedComposer).toContainText("Replying to");
+    const [replyRect, composerRect] = await Promise.all([focusedReply.boundingBox(), nestedComposer.boundingBox()]);
+    expect(replyRect).not.toBeNull();
+    expect(composerRect).not.toBeNull();
+    expect(composerRect!.y).toBeGreaterThanOrEqual(replyRect!.y + replyRect!.height - 1);
+    expect(
+      await nestedComposer.evaluate((composer, interactionId) => {
+        const target = document.querySelector(`[data-noodle-interaction-id="${interactionId}"]`);
+        return Boolean(target && target.compareDocumentPosition(composer) & Node.DOCUMENT_POSITION_FOLLOWING);
+      }, reply.id),
+    ).toBe(true);
 
     expect(errors).toEqual([]);
   } finally {

--- a/e2e/core-flows.e2e.ts
+++ b/e2e/core-flows.e2e.ts
@@ -548,46 +548,52 @@ test("Noodle persona comments can be edited and deleted without exposing charact
   test.skip(!testInfo.project.name.includes("desktop"), "Comment ownership controls are covered on desktop.");
 
   const errors = collectUnexpectedErrors(page);
-  const activePersonaResponse = await page.request.get("/api/characters/personas/active");
-  const activePersona = activePersonaResponse.ok()
-    ? ((await activePersonaResponse.json()) as { id?: string } | null)
-    : null;
-  let personaId = activePersona?.id ?? null;
+  let personaId: string | null = null;
   let createdPersonaId: string | null = null;
-  if (!personaId) {
-    const personaResponse = await page.request.post("/api/characters/personas", {
-      data: { name: "Noodle Comment Owner", description: "Temporary browser regression persona." },
-    });
-    expect(personaResponse.ok()).toBe(true);
-    const createdPersona = (await personaResponse.json()) as { id: string };
-    personaId = createdPersona.id;
-    createdPersonaId = createdPersona.id;
-    const activateResponse = await page.request.put(`/api/characters/personas/${createdPersona.id}/activate`);
-    expect(activateResponse.ok()).toBe(true);
-  }
-
-  await page.request.get("/api/noodle");
-  const postResponse = await page.request.post("/api/noodle/posts", {
-    data: {
-      authorKind: "character",
-      authorEntityId: "__professor_mari__",
-      content: `Comment ownership regression ${Date.now()}`,
-    },
-  });
-  expect(postResponse.ok()).toBe(true);
-  const post = (await postResponse.json()) as { id: string };
-  const controlPostResponse = await page.request.post("/api/noodle/posts", {
-    data: {
-      authorKind: "character",
-      authorEntityId: "__professor_mari__",
-      content: `Newer control post ${Date.now()}`,
-    },
-  });
-  expect(controlPostResponse.ok()).toBe(true);
-  const controlPost = (await controlPostResponse.json()) as { id: string };
+  let postId: string | null = null;
+  let controlPostId: string | null = null;
 
   try {
-    const ownReplyResponse = await page.request.post(`/api/noodle/posts/${post.id}/interactions`, {
+    const activePersonaResponse = await page.request.get("/api/characters/personas/active");
+    const activePersona = activePersonaResponse.ok()
+      ? ((await activePersonaResponse.json()) as { id?: string } | null)
+      : null;
+    personaId = activePersona?.id ?? null;
+    if (!personaId) {
+      const personaResponse = await page.request.post("/api/characters/personas", {
+        data: { name: "Noodle Comment Owner", description: "Temporary browser regression persona." },
+      });
+      expect(personaResponse.ok()).toBe(true);
+      const createdPersona = (await personaResponse.json()) as { id: string };
+      personaId = createdPersona.id;
+      createdPersonaId = createdPersona.id;
+      const activateResponse = await page.request.put(`/api/characters/personas/${createdPersona.id}/activate`);
+      expect(activateResponse.ok()).toBe(true);
+    }
+
+    await page.request.get("/api/noodle");
+    const postResponse = await page.request.post("/api/noodle/posts", {
+      data: {
+        authorKind: "character",
+        authorEntityId: "__professor_mari__",
+        content: `Comment ownership regression ${Date.now()}`,
+      },
+    });
+    expect(postResponse.ok()).toBe(true);
+    const post = (await postResponse.json()) as { id: string };
+    postId = post.id;
+    const controlPostResponse = await page.request.post("/api/noodle/posts", {
+      data: {
+        authorKind: "character",
+        authorEntityId: "__professor_mari__",
+        content: `Newer control post ${Date.now()}`,
+      },
+    });
+    expect(controlPostResponse.ok()).toBe(true);
+    const controlPost = (await controlPostResponse.json()) as { id: string };
+    controlPostId = controlPost.id;
+
+    const ownReplyResponse = await page.request.post(`/api/noodle/posts/${postId}/interactions`, {
       data: {
         actorKind: "persona",
         actorEntityId: personaId,
@@ -598,7 +604,7 @@ test("Noodle persona comments can be edited and deleted without exposing charact
     expect(ownReplyResponse.ok()).toBe(true);
     const ownReply = (await ownReplyResponse.json()) as { id: string };
 
-    const childReplyResponse = await page.request.post(`/api/noodle/posts/${post.id}/interactions`, {
+    const childReplyResponse = await page.request.post(`/api/noodle/posts/${postId}/interactions`, {
       data: {
         actorKind: "character",
         actorEntityId: "__professor_mari__",
@@ -611,7 +617,7 @@ test("Noodle persona comments can be edited and deleted without exposing charact
     const childReply = (await childReplyResponse.json()) as { id: string };
 
     const unauthorizedEditResponse = await page.request.patch(
-      `/api/noodle/posts/${post.id}/interactions/${childReply.id}`,
+      `/api/noodle/posts/${postId}/interactions/${childReply.id}`,
       { data: { personaId, content: "This must be rejected." } },
     );
     expect(unauthorizedEditResponse.status()).toBe(403);
@@ -620,8 +626,8 @@ test("Noodle persona comments can be edited and deleted without exposing charact
     await page.locator('[data-tour="noodle-tab"]').click();
 
     const noodle = page.locator('[data-component="NoodleView"]');
-    const activePost = noodle.locator(`[data-noodle-post-id="${post.id}"]`);
-    const newerControlPost = noodle.locator(`[data-noodle-post-id="${controlPost.id}"]`);
+    const activePost = noodle.locator(`[data-noodle-post-id="${postId}"]`);
+    const newerControlPost = noodle.locator(`[data-noodle-post-id="${controlPostId}"]`);
     const ownComment = noodle.locator(`[data-noodle-interaction-id="${ownReply.id}"]`);
     const characterComment = noodle.locator(`[data-noodle-interaction-id="${childReply.id}"]`);
     await expect(newerControlPost).toBeVisible();
@@ -631,7 +637,7 @@ test("Noodle persona comments can be edited and deleted without exposing charact
       await activePost.evaluate((element, controlPostId) => {
         const control = document.querySelector(`[data-noodle-post-id="${controlPostId}"]`);
         return Boolean(control && element.compareDocumentPosition(control) & Node.DOCUMENT_POSITION_FOLLOWING);
-      }, controlPost.id),
+      }, controlPostId),
     ).toBe(true);
     await expect(ownComment.getByRole("button", { name: "Edit comment" })).toBeVisible();
     await expect(ownComment.getByRole("button", { name: "Delete comment" })).toBeVisible();
@@ -653,8 +659,12 @@ test("Noodle persona comments can be edited and deleted without exposing charact
 
     expect(errors).toEqual([]);
   } finally {
-    await page.request.delete(`/api/noodle/posts/${post.id}`, { timeout: 5_000 }).catch(() => undefined);
-    await page.request.delete(`/api/noodle/posts/${controlPost.id}`, { timeout: 5_000 }).catch(() => undefined);
+    if (postId) {
+      await page.request.delete(`/api/noodle/posts/${postId}`, { timeout: 5_000 }).catch(() => undefined);
+    }
+    if (controlPostId) {
+      await page.request.delete(`/api/noodle/posts/${controlPostId}`, { timeout: 5_000 }).catch(() => undefined);
+    }
     if (createdPersonaId) {
       await page.request
         .delete(`/api/characters/personas/${createdPersonaId}`, { timeout: 5_000 })

--- a/e2e/core-flows.e2e.ts
+++ b/e2e/core-flows.e2e.ts
@@ -484,6 +484,7 @@ test("liking one Noodle post leaves unrelated reaction controls visually stable"
 
     const targetLike = targetPost.getByRole("button", { name: "Like post" });
     const unrelatedLike = unrelatedPost.getByRole("button", { name: "Like post" });
+    await expect(targetLike.locator("svg")).toHaveAttribute("fill", "none");
     const unrelatedClass = await unrelatedLike.getAttribute("class");
     const unrelatedText = await unrelatedLike.textContent();
     let markReactionRequestStarted: (() => void) | null = null;
@@ -520,7 +521,9 @@ test("liking one Noodle post leaves unrelated reaction controls visually stable"
 
     releaseReactionRequest?.();
     releaseReactionRequest = null;
-    await expect(targetPost.getByRole("button", { name: "Unlike post" })).toBeEnabled();
+    const targetUnlike = targetPost.getByRole("button", { name: "Unlike post" });
+    await expect(targetUnlike).toBeEnabled();
+    await expect(targetUnlike.locator("svg")).toHaveAttribute("fill", "currentColor");
     await expect(targetPost.locator('[data-noodle-reaction="like"]')).toContainText("1");
     await expect(unrelatedLike).toBeEnabled();
     await page.waitForTimeout(150);

--- a/e2e/core-flows.e2e.ts
+++ b/e2e/core-flows.e2e.ts
@@ -542,6 +542,108 @@ test("liking one Noodle post leaves unrelated reaction controls visually stable"
   }
 });
 
+test("Noodle persona comments can be edited and deleted without exposing character comments", async ({
+  page,
+}, testInfo) => {
+  test.skip(!testInfo.project.name.includes("desktop"), "Comment ownership controls are covered on desktop.");
+
+  const errors = collectUnexpectedErrors(page);
+  const activePersonaResponse = await page.request.get("/api/characters/personas/active");
+  const activePersona = activePersonaResponse.ok()
+    ? ((await activePersonaResponse.json()) as { id?: string } | null)
+    : null;
+  let personaId = activePersona?.id ?? null;
+  let createdPersonaId: string | null = null;
+  if (!personaId) {
+    const personaResponse = await page.request.post("/api/characters/personas", {
+      data: { name: "Noodle Comment Owner", description: "Temporary browser regression persona." },
+    });
+    expect(personaResponse.ok()).toBe(true);
+    const createdPersona = (await personaResponse.json()) as { id: string };
+    personaId = createdPersona.id;
+    createdPersonaId = createdPersona.id;
+    const activateResponse = await page.request.put(`/api/characters/personas/${createdPersona.id}/activate`);
+    expect(activateResponse.ok()).toBe(true);
+  }
+
+  await page.request.get("/api/noodle");
+  const postResponse = await page.request.post("/api/noodle/posts", {
+    data: {
+      authorKind: "character",
+      authorEntityId: "__professor_mari__",
+      content: `Comment ownership regression ${Date.now()}`,
+    },
+  });
+  expect(postResponse.ok()).toBe(true);
+  const post = (await postResponse.json()) as { id: string };
+
+  try {
+    const ownReplyResponse = await page.request.post(`/api/noodle/posts/${post.id}/interactions`, {
+      data: {
+        actorKind: "persona",
+        actorEntityId: personaId,
+        type: "reply",
+        content: "Original persona comment.",
+      },
+    });
+    expect(ownReplyResponse.ok()).toBe(true);
+    const ownReply = (await ownReplyResponse.json()) as { id: string };
+
+    const childReplyResponse = await page.request.post(`/api/noodle/posts/${post.id}/interactions`, {
+      data: {
+        actorKind: "character",
+        actorEntityId: "__professor_mari__",
+        type: "reply",
+        content: "Character-owned child reply.",
+        parentInteractionId: ownReply.id,
+      },
+    });
+    expect(childReplyResponse.ok()).toBe(true);
+    const childReply = (await childReplyResponse.json()) as { id: string };
+
+    const unauthorizedEditResponse = await page.request.patch(
+      `/api/noodle/posts/${post.id}/interactions/${childReply.id}`,
+      { data: { personaId, content: "This must be rejected." } },
+    );
+    expect(unauthorizedEditResponse.status()).toBe(403);
+
+    await page.goto("/");
+    await page.locator('[data-tour="noodle-tab"]').click();
+
+    const noodle = page.locator('[data-component="NoodleView"]');
+    const ownComment = noodle.locator(`[data-noodle-interaction-id="${ownReply.id}"]`);
+    const characterComment = noodle.locator(`[data-noodle-interaction-id="${childReply.id}"]`);
+    await expect(ownComment).toBeVisible();
+    await expect(characterComment).toBeVisible();
+    await expect(ownComment.getByRole("button", { name: "Edit comment" })).toBeVisible();
+    await expect(ownComment.getByRole("button", { name: "Delete comment" })).toBeVisible();
+    await expect(characterComment.getByRole("button", { name: "Edit comment" })).toHaveCount(0);
+    await expect(characterComment.getByRole("button", { name: "Delete comment" })).toHaveCount(0);
+
+    await ownComment.getByRole("button", { name: "Edit comment" }).click();
+    const editor = ownComment.locator('[data-component="NoodleView.CommentEditor"]');
+    await editor.getByRole("textbox", { name: "Edit comment" }).fill("Edited persona comment.");
+    await editor.getByRole("button", { name: "Save" }).click();
+    await expect(ownComment).toContainText("Edited persona comment.");
+
+    await ownComment.getByRole("button", { name: "Delete comment" }).click();
+    const deleteDialog = page.getByRole("dialog", { name: "Delete Noodle Comment" });
+    await expect(deleteDialog).toBeVisible();
+    await deleteDialog.getByRole("button", { name: "Delete comment" }).click();
+    await expect(ownComment).toHaveCount(0);
+    await expect(characterComment).toHaveCount(0);
+
+    expect(errors).toEqual([]);
+  } finally {
+    await page.request.delete(`/api/noodle/posts/${post.id}`, { timeout: 5_000 }).catch(() => undefined);
+    if (createdPersonaId) {
+      await page.request
+        .delete(`/api/characters/personas/${createdPersonaId}`, { timeout: 5_000 })
+        .catch(() => undefined);
+    }
+  }
+});
+
 test("Noodle reply notifications focus the actionable timeline reply", async ({ page }, testInfo) => {
   test.skip(!testInfo.project.name.includes("mobile"), "Reply notification focus is covered on mobile.");
 

--- a/packages/client/src/components/noodle/NoodleView.tsx
+++ b/packages/client/src/components/noodle/NoodleView.tsx
@@ -32,6 +32,7 @@ import {
 } from "lucide-react";
 import { AnimatePresence, motion, useReducedMotion } from "framer-motion";
 import {
+  Fragment,
   useCallback,
   useEffect,
   useLayoutEffect,
@@ -105,6 +106,7 @@ const iconButtonClass =
 const NOODLE_BLUE = "#7EA7FF";
 const NOODLE_ICON_SCOPE_CLASS = "[&_svg]:!text-[var(--noodle-blue)]";
 const NOODLE_LOGO_SRC = "/noodle-klusek.png";
+const NOODLE_NOTIFICATIONS_READ_AT_KEY = "notificationsReadAt";
 const NOODLE_INVITE_PAGE_SIZE = 50;
 const NOODLE_PERSONA_SWITCHER_PAGE_SIZE = 5;
 const NOODLE_CARRYOVER_TARGETS: NoodleCarryoverTarget[] = ["conversation", "roleplay", "game"];
@@ -815,6 +817,7 @@ export function NoodleView() {
   const [imageLightbox, setImageLightbox] = useState<ChatImage | null>(null);
   const [notificationFocusTarget, setNotificationFocusTarget] = useState<NoodleNotificationFocusTarget | null>(null);
   const [highlightedInteractionId, setHighlightedInteractionId] = useState<string | null>(null);
+  const [notificationReadOverrides, setNotificationReadOverrides] = useState<Record<string, string>>({});
   const [editingRefreshTime, setEditingRefreshTime] = useState<string | null>(null);
   const [refreshTimeDraft, setRefreshTimeDraft] = useState("");
   const [postMenuId, setPostMenuId] = useState<string | null>(null);
@@ -1559,8 +1562,16 @@ export function NoodleView() {
     return () => window.clearTimeout(timeout);
   }, [highlightedInteractionId]);
 
+  const notificationReadAt = personaAccount
+    ? (notificationReadOverrides[personaAccount.id] ??
+      readAccountSetting(personaAccount, NOODLE_NOTIFICATIONS_READ_AT_KEY))
+    : "";
+  const notificationReadTime = Date.parse(notificationReadAt) || 0;
   const notificationCount =
-    notificationLikes.length + notificationFollowAccounts.length + notificationReplyItems.length;
+    notificationLikes.filter((item) => new Date(item.interaction.createdAt).getTime() > notificationReadTime).length +
+    notificationFollowAccounts.filter((account) => new Date(account.updatedAt).getTime() > notificationReadTime)
+      .length +
+    notificationReplyItems.filter((item) => new Date(item.createdAt).getTime() > notificationReadTime).length;
   const notificationBadgeLabel = notificationCount > 99 ? "99+" : String(notificationCount);
   const followableCharacterAccounts = useMemo(
     () =>
@@ -2001,6 +2012,23 @@ export function NoodleView() {
   };
 
   const openNotifications = () => {
+    if (personaAccount) {
+      const readAt = new Date().toISOString();
+      setNotificationReadOverrides((current) => ({ ...current, [personaAccount.id]: readAt }));
+      updateAccount.mutate(
+        {
+          id: personaAccount.id,
+          settings: {
+            ...personaAccount.settings,
+            [NOODLE_NOTIFICATIONS_READ_AT_KEY]: readAt,
+          },
+        },
+        {
+          onError: (error) =>
+            toast.error(error instanceof Error ? error.message : "Could not mark Noodle notifications as read."),
+        },
+      );
+    }
     setActiveNoodleView("notifications");
     setAccountSwitcherOpen(false);
     setMobileDrawerOpen(false);
@@ -2718,6 +2746,145 @@ export function NoodleView() {
     const postRepostPending = reactionPendingFor(post.id, "repost");
     const postReplyPending = createInteractionPendingFor(post.id, "reply", replyParentInteractionId);
     const pollVotePending = createInteractionPendingFor(post.id, "vote");
+    const renderReplyComposer = (nested: boolean) => (
+      <div
+        data-component="NoodleView.ReplyComposer"
+        data-noodle-reply-parent-id={replyParentInteractionId ?? ""}
+        className={cn("border-[var(--noodle-divider)] py-3", nested ? "ml-10 border-b" : "mt-3 border-y")}
+      >
+        {replyParentInteractionId && replyTargetActor && (
+          <p className="mb-2 text-xs text-[var(--muted-foreground)]">
+            Replying to <span className="font-semibold text-[var(--noodle-blue)]">@{replyTargetActor.handle}</span>
+          </p>
+        )}
+        <textarea
+          value={replyText}
+          onChange={(event) => setReplyText(event.target.value)}
+          className={cn(textareaClass, "min-h-16 resize-none bg-transparent")}
+          placeholder="Leave a comment…"
+        />
+        {replyImageUrl && (
+          <div className="relative mt-2 overflow-hidden rounded-xl border border-[var(--noodle-divider)]">
+            <button
+              type="button"
+              onClick={() => setImageLightbox(createNoodleLightboxImage(`reply-draft-${post.id}`, replyImageUrl))}
+              className="block w-full"
+              title="Open attached image"
+            >
+              <img src={replyImageUrl} alt="Attached reply preview" className="max-h-52 w-full object-cover" />
+            </button>
+            <button
+              type="button"
+              onClick={() => setReplyImageUrl("")}
+              className="absolute right-2 top-2 flex h-7 w-7 items-center justify-center rounded-full bg-black/65 text-white transition-colors hover:bg-black/80"
+              title="Remove image"
+              aria-label="Remove reply image"
+            >
+              <X size={14} />
+            </button>
+          </div>
+        )}
+        <div className="mt-2 flex items-center justify-between gap-2">
+          <div className="flex items-center gap-1">
+            <div ref={replyImageToolRef} className="relative">
+              <NoodleToolButton
+                title="Attach image"
+                active={activeReplyComposerTool === "image"}
+                onClick={() => setActiveReplyComposerTool((current) => (current === "image" ? null : "image"))}
+              >
+                <ImageIcon size={17} />
+              </NoodleToolButton>
+            </div>
+            <div ref={replyMediaToolRef} className="relative">
+              <NoodleToolButton
+                title="Emoji, GIFs and stickers"
+                active={activeReplyComposerTool === "media"}
+                onClick={() => setActiveReplyComposerTool((current) => (current === "media" ? null : "media"))}
+              >
+                <Smile size={17} />
+              </NoodleToolButton>
+            </div>
+          </div>
+          <div className="flex items-center gap-2">
+            <button
+              type="button"
+              onClick={clearReplyComposer}
+              className="h-8 rounded-full px-3 text-xs font-semibold text-[var(--muted-foreground)] transition-colors hover:bg-[var(--accent)] hover:text-[var(--foreground)]"
+            >
+              Cancel
+            </button>
+            <button
+              type="button"
+              className="h-8 rounded-full bg-[var(--noodle-blue)] px-4 text-xs font-bold text-zinc-950 transition-opacity hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-50"
+              disabled={(!replyText.trim() && !replyImageUrl.trim()) || postReplyPending}
+              onClick={() => submitReply(post)}
+            >
+              {postReplyPending ? "Replying…" : "Reply"}
+            </button>
+          </div>
+        </div>
+        {activeReplyComposerTool === "image" && (
+          <NoodleToolPopover
+            title="Attach image"
+            anchorRef={replyImageToolRef}
+            onClose={() => setActiveReplyComposerTool(null)}
+            wide
+          >
+            <div className="space-y-3">
+              <button
+                type="button"
+                onClick={() => replyImageFileRef.current?.click()}
+                disabled={uploadGlobalImages.isPending}
+                className="h-9 w-full rounded-full bg-[var(--noodle-blue)] px-4 text-xs font-bold text-zinc-950 transition-opacity hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-50"
+              >
+                {uploadGlobalImages.isPending ? "Uploading..." : "Upload From Device"}
+              </button>
+              <div className="flex items-center gap-2 text-[0.625rem] font-semibold uppercase tracking-normal text-[var(--muted-foreground)]">
+                <span className="h-px flex-1 bg-[var(--noodle-divider)]" />
+                or
+                <span className="h-px flex-1 bg-[var(--noodle-divider)]" />
+              </div>
+              <label className="block space-y-1.5">
+                <span className={labelClass}>Image URL</span>
+                <input
+                  value={replyImageUrlDraft}
+                  onChange={(event) => setReplyImageUrlDraft(event.target.value)}
+                  placeholder="https://..."
+                  className={fieldClass}
+                />
+              </label>
+              <button
+                type="button"
+                onClick={applyReplyImageUrl}
+                className="h-9 w-full rounded-full border border-[var(--noodle-divider)] px-4 text-xs font-bold text-[var(--noodle-blue)] transition-colors hover:bg-[var(--noodle-blue)]/10"
+              >
+                Attach URL
+              </button>
+            </div>
+          </NoodleToolPopover>
+        )}
+        {activeReplyComposerTool === "media" && (
+          <NoodleAnchoredPopover anchorRef={replyMediaToolRef} wide>
+            <ConversationMediaPickerPanel
+              tabs={NOODLE_MEDIA_PICKER_TABS}
+              activeTab={mediaPickerTab}
+              onActiveTabChange={setMediaPickerTab}
+              onClose={() => setActiveReplyComposerTool(null)}
+              onEmojiSelect={appendToReply}
+              onGifSelect={(gifUrl) => {
+                setReplyImageUrl(gifUrl);
+                setActiveReplyComposerTool(null);
+              }}
+              onStickerSelect={(name) => {
+                appendToReply(`sticker:${name}:`);
+                setActiveReplyComposerTool(null);
+              }}
+              className="w-full !border-[var(--marinara-chat-chrome-panel-border)] !bg-[var(--background)] !text-[var(--foreground)] shadow-2xl shadow-black/35"
+            />
+          </NoodleAnchoredPopover>
+        )}
+      </div>
+    );
     return (
       <article
         key={post.id}
@@ -2888,144 +3055,7 @@ export function NoodleView() {
               </button>
             </div>
 
-            {replyPostId === post.id && (
-              <div className="mt-3 border-y border-[var(--noodle-divider)] py-3">
-                {replyParentInteractionId && replyTargetActor && (
-                  <p className="mb-2 text-xs text-[var(--muted-foreground)]">
-                    Replying to{" "}
-                    <span className="font-semibold text-[var(--noodle-blue)]">@{replyTargetActor.handle}</span>
-                  </p>
-                )}
-                <textarea
-                  value={replyText}
-                  onChange={(event) => setReplyText(event.target.value)}
-                  className={cn(textareaClass, "min-h-16 resize-none bg-transparent")}
-                  placeholder="Leave a comment…"
-                />
-                {replyImageUrl && (
-                  <div className="relative mt-2 overflow-hidden rounded-xl border border-[var(--noodle-divider)]">
-                    <button
-                      type="button"
-                      onClick={() =>
-                        setImageLightbox(createNoodleLightboxImage(`reply-draft-${post.id}`, replyImageUrl))
-                      }
-                      className="block w-full"
-                      title="Open attached image"
-                    >
-                      <img src={replyImageUrl} alt="Attached reply preview" className="max-h-52 w-full object-cover" />
-                    </button>
-                    <button
-                      type="button"
-                      onClick={() => setReplyImageUrl("")}
-                      className="absolute right-2 top-2 flex h-7 w-7 items-center justify-center rounded-full bg-black/65 text-white transition-colors hover:bg-black/80"
-                      title="Remove image"
-                      aria-label="Remove reply image"
-                    >
-                      <X size={14} />
-                    </button>
-                  </div>
-                )}
-                <div className="mt-2 flex items-center justify-between gap-2">
-                  <div className="flex items-center gap-1">
-                    <div ref={replyImageToolRef} className="relative">
-                      <NoodleToolButton
-                        title="Attach image"
-                        active={activeReplyComposerTool === "image"}
-                        onClick={() => setActiveReplyComposerTool((current) => (current === "image" ? null : "image"))}
-                      >
-                        <ImageIcon size={17} />
-                      </NoodleToolButton>
-                    </div>
-                    <div ref={replyMediaToolRef} className="relative">
-                      <NoodleToolButton
-                        title="Emoji, GIFs and stickers"
-                        active={activeReplyComposerTool === "media"}
-                        onClick={() => setActiveReplyComposerTool((current) => (current === "media" ? null : "media"))}
-                      >
-                        <Smile size={17} />
-                      </NoodleToolButton>
-                    </div>
-                  </div>
-                  <div className="flex items-center gap-2">
-                    <button
-                      type="button"
-                      onClick={clearReplyComposer}
-                      className="h-8 rounded-full px-3 text-xs font-semibold text-[var(--muted-foreground)] transition-colors hover:bg-[var(--accent)] hover:text-[var(--foreground)]"
-                    >
-                      Cancel
-                    </button>
-                    <button
-                      type="button"
-                      className="h-8 rounded-full bg-[var(--noodle-blue)] px-4 text-xs font-bold text-zinc-950 transition-opacity hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-50"
-                      disabled={(!replyText.trim() && !replyImageUrl.trim()) || postReplyPending}
-                      onClick={() => submitReply(post)}
-                    >
-                      {postReplyPending ? "Replying…" : "Reply"}
-                    </button>
-                  </div>
-                </div>
-                {activeReplyComposerTool === "image" && (
-                  <NoodleToolPopover
-                    title="Attach image"
-                    anchorRef={replyImageToolRef}
-                    onClose={() => setActiveReplyComposerTool(null)}
-                    wide
-                  >
-                    <div className="space-y-3">
-                      <button
-                        type="button"
-                        onClick={() => replyImageFileRef.current?.click()}
-                        disabled={uploadGlobalImages.isPending}
-                        className="h-9 w-full rounded-full bg-[var(--noodle-blue)] px-4 text-xs font-bold text-zinc-950 transition-opacity hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-50"
-                      >
-                        {uploadGlobalImages.isPending ? "Uploading..." : "Upload From Device"}
-                      </button>
-                      <div className="flex items-center gap-2 text-[0.625rem] font-semibold uppercase tracking-normal text-[var(--muted-foreground)]">
-                        <span className="h-px flex-1 bg-[var(--noodle-divider)]" />
-                        or
-                        <span className="h-px flex-1 bg-[var(--noodle-divider)]" />
-                      </div>
-                      <label className="block space-y-1.5">
-                        <span className={labelClass}>Image URL</span>
-                        <input
-                          value={replyImageUrlDraft}
-                          onChange={(event) => setReplyImageUrlDraft(event.target.value)}
-                          placeholder="https://..."
-                          className={fieldClass}
-                        />
-                      </label>
-                      <button
-                        type="button"
-                        onClick={applyReplyImageUrl}
-                        className="h-9 w-full rounded-full border border-[var(--noodle-divider)] px-4 text-xs font-bold text-[var(--noodle-blue)] transition-colors hover:bg-[var(--noodle-blue)]/10"
-                      >
-                        Attach URL
-                      </button>
-                    </div>
-                  </NoodleToolPopover>
-                )}
-                {activeReplyComposerTool === "media" && (
-                  <NoodleAnchoredPopover anchorRef={replyMediaToolRef} wide>
-                    <ConversationMediaPickerPanel
-                      tabs={NOODLE_MEDIA_PICKER_TABS}
-                      activeTab={mediaPickerTab}
-                      onActiveTabChange={setMediaPickerTab}
-                      onClose={() => setActiveReplyComposerTool(null)}
-                      onEmojiSelect={appendToReply}
-                      onGifSelect={(gifUrl) => {
-                        setReplyImageUrl(gifUrl);
-                        setActiveReplyComposerTool(null);
-                      }}
-                      onStickerSelect={(name) => {
-                        appendToReply(`sticker:${name}:`);
-                        setActiveReplyComposerTool(null);
-                      }}
-                      className="w-full !border-[var(--marinara-chat-chrome-panel-border)] !bg-[var(--background)] !text-[var(--foreground)] shadow-2xl shadow-black/35"
-                    />
-                  </NoodleAnchoredPopover>
-                )}
-              </div>
-            )}
+            {replyPostId === post.id && !replyParentInteractionId && renderReplyComposer(false)}
 
             {replies.length > 0 && (
               <div className="mt-3 border-t border-[var(--noodle-divider)]">
@@ -3045,97 +3075,103 @@ export function NoodleView() {
                     ? replyLikes.some((interaction) => interaction.actorAccountId === personaAccount.id)
                     : false;
                   return (
-                    <div
-                      key={reply.id}
-                      data-noodle-interaction-id={reply.id}
-                      tabIndex={-1}
-                      className={cn(
-                        "grid grid-cols-[2rem_minmax(0,1fr)] items-start gap-2 border-b border-[var(--noodle-divider)] bg-transparent py-3 text-xs outline-none transition-shadow duration-300 last:border-b-0",
-                        highlightedInteractionId === reply.id &&
-                          "rounded-lg ring-1 ring-inset ring-[var(--noodle-blue)]/70",
-                      )}
-                    >
-                      <button
-                        type="button"
-                        onClick={() => openProfile(actorAccount)}
-                        disabled={!actorAccount}
-                        className="h-8 w-8 shrink-0 rounded-full text-left transition-opacity enabled:hover:opacity-80 disabled:cursor-default"
-                        title={actorAccount ? `View @${actorAccount.handle}` : undefined}
+                    <Fragment key={reply.id}>
+                      <div
+                        data-noodle-interaction-id={reply.id}
+                        tabIndex={-1}
+                        className={cn(
+                          "grid grid-cols-[2rem_minmax(0,1fr)] items-start gap-2 border-b border-[var(--noodle-divider)] bg-transparent py-3 text-xs outline-none transition-shadow duration-300 last:border-b-0",
+                          highlightedInteractionId === reply.id &&
+                            "rounded-lg ring-1 ring-inset ring-[var(--noodle-blue)]/70",
+                        )}
                       >
-                        <Avatar
-                          account={{
-                            displayName: actor?.displayName ?? "Noodle User",
-                            avatarUrl: actor?.avatarUrl ?? null,
-                          }}
-                          size="sm"
-                        />
-                      </button>
-                      <div className="min-w-0 bg-transparent">
-                        <div className="flex min-w-0 flex-wrap items-center gap-x-1.5 gap-y-0.5">
-                          <button
-                            type="button"
-                            onClick={() => openProfile(actorAccount)}
-                            disabled={!actorAccount}
-                            className="max-w-full truncate font-semibold transition-colors enabled:hover:text-[var(--noodle-blue)] disabled:cursor-default"
-                          >
-                            {actor?.displayName ?? "Noodle User"}
-                          </button>
-                          <span className="truncate text-[var(--muted-foreground)]">@{actor?.handle ?? "noodle"}</span>
-                          <span className="text-[var(--muted-foreground)]">· {formatTime(reply.createdAt)}</span>
-                        </div>
-                        {parentActor && (
-                          <p className="mt-0.5 text-[var(--muted-foreground)]">
-                            Replying to <span className="text-[var(--noodle-blue)]">@{parentActor.handle}</span>
-                          </p>
-                        )}
-                        {reply.content && <p className="mt-1 whitespace-pre-wrap text-sm leading-5">{reply.content}</p>}
-                        {reply.imageUrl && (
-                          <button
-                            type="button"
-                            onClick={() =>
-                              setImageLightbox(
-                                createNoodleLightboxImage(reply.id, reply.imageUrl!, reply.content ?? ""),
-                              )
-                            }
-                            className="mt-2 block w-full overflow-hidden rounded-xl text-left ring-offset-[var(--background)] transition-opacity hover:opacity-95 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--noodle-blue)] focus-visible:ring-offset-2"
-                            title="Open image"
-                            aria-label="Open comment image"
-                          >
-                            <img
-                              src={reply.imageUrl}
-                              alt={`Image in ${actor?.displayName ?? "Noodle user"}'s comment`}
-                              className="max-h-72 w-full object-cover"
-                            />
-                          </button>
-                        )}
-                        <div className="mt-1.5 flex items-center gap-3">
-                          <button
-                            type="button"
-                            onClick={() => reactToReply(post, reply, likedReplyByPersona)}
-                            disabled={!personaAccount || reactionPendingFor(post.id, "like", reply.id)}
-                            className={cn(
-                              "inline-flex h-7 items-center gap-1 rounded-full px-2 font-medium text-[var(--noodle-blue)] transition-colors hover:bg-[var(--noodle-blue)]/10 disabled:cursor-not-allowed disabled:opacity-50",
-                              likedReplyByPersona && "bg-[var(--noodle-blue)]/10",
-                            )}
-                            title={likedReplyByPersona ? "Unlike comment" : "Like comment"}
-                            aria-busy={reactionPendingFor(post.id, "like", reply.id)}
-                          >
-                            <Heart size={14} />
-                            {replyLikes.length > 0 && replyLikes.length}
-                          </button>
-                          <button
-                            type="button"
-                            onClick={() => openReplyComposer(post.id, reply.id)}
-                            disabled={!personaAccount}
-                            className="inline-flex h-7 w-7 items-center justify-center rounded-full text-[var(--noodle-blue)] transition-colors hover:bg-[var(--noodle-blue)]/10 disabled:cursor-not-allowed disabled:opacity-50"
-                            title="Reply"
-                            aria-label="Reply"
-                          >
-                            <MessageCircle size={14} />
-                          </button>
+                        <button
+                          type="button"
+                          onClick={() => openProfile(actorAccount)}
+                          disabled={!actorAccount}
+                          className="h-8 w-8 shrink-0 rounded-full text-left transition-opacity enabled:hover:opacity-80 disabled:cursor-default"
+                          title={actorAccount ? `View @${actorAccount.handle}` : undefined}
+                        >
+                          <Avatar
+                            account={{
+                              displayName: actor?.displayName ?? "Noodle User",
+                              avatarUrl: actor?.avatarUrl ?? null,
+                            }}
+                            size="sm"
+                          />
+                        </button>
+                        <div className="min-w-0 bg-transparent">
+                          <div className="flex min-w-0 flex-wrap items-center gap-x-1.5 gap-y-0.5">
+                            <button
+                              type="button"
+                              onClick={() => openProfile(actorAccount)}
+                              disabled={!actorAccount}
+                              className="max-w-full truncate font-semibold transition-colors enabled:hover:text-[var(--noodle-blue)] disabled:cursor-default"
+                            >
+                              {actor?.displayName ?? "Noodle User"}
+                            </button>
+                            <span className="truncate text-[var(--muted-foreground)]">
+                              @{actor?.handle ?? "noodle"}
+                            </span>
+                            <span className="text-[var(--muted-foreground)]">· {formatTime(reply.createdAt)}</span>
+                          </div>
+                          {parentActor && (
+                            <p className="mt-0.5 text-[var(--muted-foreground)]">
+                              Replying to <span className="text-[var(--noodle-blue)]">@{parentActor.handle}</span>
+                            </p>
+                          )}
+                          {reply.content && (
+                            <p className="mt-1 whitespace-pre-wrap text-sm leading-5">{reply.content}</p>
+                          )}
+                          {reply.imageUrl && (
+                            <button
+                              type="button"
+                              onClick={() =>
+                                setImageLightbox(
+                                  createNoodleLightboxImage(reply.id, reply.imageUrl!, reply.content ?? ""),
+                                )
+                              }
+                              className="mt-2 block w-full overflow-hidden rounded-xl text-left ring-offset-[var(--background)] transition-opacity hover:opacity-95 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--noodle-blue)] focus-visible:ring-offset-2"
+                              title="Open image"
+                              aria-label="Open comment image"
+                            >
+                              <img
+                                src={reply.imageUrl}
+                                alt={`Image in ${actor?.displayName ?? "Noodle user"}'s comment`}
+                                className="max-h-72 w-full object-cover"
+                              />
+                            </button>
+                          )}
+                          <div className="mt-1.5 flex items-center gap-3">
+                            <button
+                              type="button"
+                              onClick={() => reactToReply(post, reply, likedReplyByPersona)}
+                              disabled={!personaAccount || reactionPendingFor(post.id, "like", reply.id)}
+                              className={cn(
+                                "inline-flex h-7 items-center gap-1 rounded-full px-2 font-medium text-[var(--noodle-blue)] transition-colors hover:bg-[var(--noodle-blue)]/10 disabled:cursor-not-allowed disabled:opacity-50",
+                                likedReplyByPersona && "bg-[var(--noodle-blue)]/10",
+                              )}
+                              title={likedReplyByPersona ? "Unlike comment" : "Like comment"}
+                              aria-busy={reactionPendingFor(post.id, "like", reply.id)}
+                            >
+                              <Heart size={14} />
+                              {replyLikes.length > 0 && replyLikes.length}
+                            </button>
+                            <button
+                              type="button"
+                              onClick={() => openReplyComposer(post.id, reply.id)}
+                              disabled={!personaAccount}
+                              className="inline-flex h-7 w-7 items-center justify-center rounded-full text-[var(--noodle-blue)] transition-colors hover:bg-[var(--noodle-blue)]/10 disabled:cursor-not-allowed disabled:opacity-50"
+                              title="Reply"
+                              aria-label="Reply"
+                            >
+                              <MessageCircle size={14} />
+                            </button>
+                          </div>
                         </div>
                       </div>
-                    </div>
+                      {replyPostId === post.id && replyParentInteractionId === reply.id && renderReplyComposer(true)}
+                    </Fragment>
                   );
                 })}
               </div>
@@ -3784,7 +3820,10 @@ export function NoodleView() {
                   <span className="relative flex h-6 w-6 shrink-0 items-center justify-center">
                     <Bell size={22} className="!text-[var(--noodle-blue)]" />
                     {notificationCount > 0 && (
-                      <span className="absolute -right-2 -top-2 min-w-4 rounded-full bg-[var(--noodle-blue)] px-1 text-center text-[0.58rem] font-black leading-4 text-zinc-950 ring-2 ring-[var(--background)]">
+                      <span
+                        data-component="NoodleView.NotificationBadge"
+                        className="absolute -right-2 -top-2 min-w-4 rounded-full bg-[var(--noodle-blue)] px-1 text-center text-[0.58rem] font-black leading-4 text-zinc-950 ring-2 ring-[var(--background)]"
+                      >
                         {notificationBadgeLabel}
                       </span>
                     )}
@@ -4530,7 +4569,10 @@ export function NoodleView() {
             <span className="relative flex h-6 w-6 items-center justify-center">
               <Bell size={22} strokeWidth={activeNoodleView === "notifications" ? 2.8 : 2} />
               {notificationCount > 0 && (
-                <span className="absolute -right-2 -top-2 min-w-4 rounded-full bg-[var(--noodle-blue)] px-1 text-center text-[0.58rem] font-black leading-4 text-zinc-950 ring-2 ring-[var(--background)]">
+                <span
+                  data-component="NoodleView.NotificationBadge"
+                  className="absolute -right-2 -top-2 min-w-4 rounded-full bg-[var(--noodle-blue)] px-1 text-center text-[0.58rem] font-black leading-4 text-zinc-950 ring-2 ring-[var(--background)]"
+                >
                   {notificationBadgeLabel}
                 </span>
               )}

--- a/packages/client/src/components/noodle/NoodleView.tsx
+++ b/packages/client/src/components/noodle/NoodleView.tsx
@@ -109,6 +109,7 @@ const NOODLE_BLUE = "#7EA7FF";
 const NOODLE_ICON_SCOPE_CLASS = "[&_svg]:!text-[var(--noodle-blue)]";
 const NOODLE_LOGO_SRC = "/noodle-klusek.png";
 const NOODLE_NOTIFICATIONS_READ_AT_KEY = "notificationsReadAt";
+const NOODLE_FOLLOWED_AT_BY_ACCOUNT_KEY = "followingAccountTimestamps";
 const NOODLE_INVITE_PAGE_SIZE = 50;
 const NOODLE_PERSONA_SWITCHER_PAGE_SIZE = 5;
 const NOODLE_CARRYOVER_TARGETS: NoodleCarryoverTarget[] = ["conversation", "roleplay", "game"];
@@ -1493,12 +1494,14 @@ export function NoodleView() {
   const notificationFollowAccounts = useMemo(() => {
     if (!personaAccount) return [];
     return accounts
-      .filter((account) => {
-        if (account.id === personaAccount.id) return false;
+      .flatMap((account) => {
+        if (account.id === personaAccount.id) return [];
         const followingAccountIds = readStringArray(account.settings?.followingAccountIds);
-        return followingAccountIds.includes(personaAccount.id);
+        if (!followingAccountIds.includes(personaAccount.id)) return [];
+        const followedAtByAccount = parseRecord(account.settings?.[NOODLE_FOLLOWED_AT_BY_ACCOUNT_KEY]);
+        return [{ account, followedAt: readString(followedAtByAccount[personaAccount.id]) }];
       })
-      .sort((left, right) => new Date(right.updatedAt).getTime() - new Date(left.updatedAt).getTime());
+      .sort((left, right) => (Date.parse(right.followedAt) || 0) - (Date.parse(left.followedAt) || 0));
   }, [accounts, personaAccount]);
   const notificationReplyItems = useMemo(() => {
     if (!personaAccount) return [];
@@ -1602,7 +1605,7 @@ export function NoodleView() {
   const notificationReadTime = Date.parse(notificationReadAt) || 0;
   const notificationCount =
     notificationLikes.filter((item) => new Date(item.interaction.createdAt).getTime() > notificationReadTime).length +
-    notificationFollowAccounts.filter((account) => new Date(account.updatedAt).getTime() > notificationReadTime)
+    notificationFollowAccounts.filter((item) => (Date.parse(item.followedAt) || 0) > notificationReadTime)
       .length +
     notificationReplyItems.filter((item) => new Date(item.createdAt).getTime() > notificationReadTime).length;
   const notificationBadgeLabel = notificationCount > 99 ? "99+" : String(notificationCount);
@@ -1752,10 +1755,19 @@ export function NoodleView() {
     const nextFollowingAccountIds = followed
       ? Array.from(new Set([...currentFollowingAccountIds, account.id]))
       : currentFollowingAccountIds.filter((id) => id !== account.id);
+    const nextFollowedAtByAccount = {
+      ...parseRecord(personaAccount.settings?.[NOODLE_FOLLOWED_AT_BY_ACCOUNT_KEY]),
+    };
+    if (followed) nextFollowedAtByAccount[account.id] = new Date().toISOString();
+    else delete nextFollowedAtByAccount[account.id];
     updateAccount.mutate(
       {
         id: personaAccount.id,
-        settings: { ...personaAccount.settings, followingAccountIds: nextFollowingAccountIds },
+        settings: {
+          ...personaAccount.settings,
+          followingAccountIds: nextFollowingAccountIds,
+          [NOODLE_FOLLOWED_AT_BY_ACCOUNT_KEY]: nextFollowedAtByAccount,
+        },
       },
       {
         onError: (error) => toast.error(error instanceof Error ? error.message : "Could not update followed accounts."),
@@ -2105,19 +2117,37 @@ export function NoodleView() {
 
   const openNotifications = () => {
     if (personaAccount) {
+      const accountId = personaAccount.id;
+      const previousOverride = notificationReadOverrides[accountId];
       const readAt = new Date().toISOString();
-      setNotificationReadOverrides((current) => ({ ...current, [personaAccount.id]: readAt }));
+      setNotificationReadOverrides((current) => ({ ...current, [accountId]: readAt }));
       updateAccount.mutate(
         {
-          id: personaAccount.id,
+          id: accountId,
           settings: {
             ...personaAccount.settings,
             [NOODLE_NOTIFICATIONS_READ_AT_KEY]: readAt,
           },
         },
         {
-          onError: (error) =>
-            toast.error(error instanceof Error ? error.message : "Could not mark Noodle notifications as read."),
+          onSuccess: () => {
+            setNotificationReadOverrides((current) => {
+              if (current[accountId] !== readAt) return current;
+              const next = { ...current };
+              delete next[accountId];
+              return next;
+            });
+          },
+          onError: (error) => {
+            setNotificationReadOverrides((current) => {
+              if (current[accountId] !== readAt) return current;
+              const next = { ...current };
+              if (previousOverride) next[accountId] = previousOverride;
+              else delete next[accountId];
+              return next;
+            });
+            toast.error(error instanceof Error ? error.message : "Could not mark Noodle notifications as read.");
+          },
         },
       );
     }
@@ -3386,23 +3416,26 @@ export function NoodleView() {
     );
   };
 
-  const renderFollowNotification = (account: NoodleAccount) => (
-    <div key={account.id} className="flex items-start gap-3 border-b border-[var(--noodle-divider)] px-4 py-4">
+  const renderFollowNotification = (item: (typeof notificationFollowAccounts)[number]) => (
+    <div
+      key={item.account.id}
+      className="flex items-start gap-3 border-b border-[var(--noodle-divider)] px-4 py-4"
+    >
       <button
         type="button"
-        onClick={() => openProfile(account)}
+        onClick={() => openProfile(item.account)}
         className="rounded-full transition-opacity hover:opacity-80"
-        title={`View @${account.handle}`}
+        title={`View @${item.account.handle}`}
       >
-        <Avatar account={account} />
+        <Avatar account={item.account} />
       </button>
       <button
         type="button"
-        onClick={() => openProfile(account)}
+        onClick={() => openProfile(item.account)}
         className="min-w-0 flex-1 text-left transition-colors hover:text-[var(--noodle-blue)]"
       >
-        <span className="block truncate text-sm font-bold">{account.displayName}</span>
-        <span className="block truncate text-sm text-[var(--muted-foreground)]">@{account.handle}</span>
+        <span className="block truncate text-sm font-bold">{item.account.displayName}</span>
+        <span className="block truncate text-sm text-[var(--muted-foreground)]">@{item.account.handle}</span>
         <span className="mt-1 block text-sm leading-5">followed you</span>
       </button>
     </div>

--- a/packages/client/src/components/noodle/NoodleView.tsx
+++ b/packages/client/src/components/noodle/NoodleView.tsx
@@ -3028,7 +3028,15 @@ export function NoodleView() {
                 aria-busy={postLikePending}
                 data-noodle-reaction="like"
               >
-                <Heart size={18} />
+                <Heart
+                  size={18}
+                  fill={likedByPersona ? "currentColor" : "none"}
+                  strokeWidth={likedByPersona ? 2.4 : 2}
+                  className={cn(
+                    "transition-[fill,transform] duration-200 ease-[cubic-bezier(0.22,1,0.36,1)]",
+                    likedByPersona && "scale-110",
+                  )}
+                />
                 {countInteractions(rootPostInteractions, "like")}
               </button>
               <button
@@ -3154,7 +3162,15 @@ export function NoodleView() {
                               title={likedReplyByPersona ? "Unlike comment" : "Like comment"}
                               aria-busy={reactionPendingFor(post.id, "like", reply.id)}
                             >
-                              <Heart size={14} />
+                              <Heart
+                                size={14}
+                                fill={likedReplyByPersona ? "currentColor" : "none"}
+                                strokeWidth={likedReplyByPersona ? 2.4 : 2}
+                                className={cn(
+                                  "transition-[fill,transform] duration-200 ease-[cubic-bezier(0.22,1,0.36,1)]",
+                                  likedReplyByPersona && "scale-110",
+                                )}
+                              />
                               {replyLikes.length > 0 && replyLikes.length}
                             </button>
                             <button

--- a/packages/client/src/components/noodle/NoodleView.tsx
+++ b/packages/client/src/components/noodle/NoodleView.tsx
@@ -1353,13 +1353,30 @@ export function NoodleView() {
       ),
     [accounts, folderInvitedCharacterIds, followedAccountIds],
   );
-  const baseTimelinePosts = useMemo(
-    () =>
+  const latestReplyAtByPostId = useMemo(() => {
+    const latest = new Map<string, number>();
+    for (const interaction of interactions) {
+      if (interaction.type !== "reply") continue;
+      const createdAt = new Date(interaction.createdAt).getTime();
+      if (!Number.isFinite(createdAt)) continue;
+      latest.set(interaction.postId, Math.max(latest.get(interaction.postId) ?? 0, createdAt));
+    }
+    return latest;
+  }, [interactions]);
+  const baseTimelinePosts = useMemo(() => {
+    const visiblePosts =
       timelineTab === "following"
         ? posts.filter((post) => followedCharacterAccountIds.has(post.authorAccountId))
-        : posts,
-    [followedCharacterAccountIds, posts, timelineTab],
-  );
+        : posts;
+    return visiblePosts.slice().sort((left, right) => {
+      const leftActivityAt = Math.max(new Date(left.createdAt).getTime() || 0, latestReplyAtByPostId.get(left.id) ?? 0);
+      const rightActivityAt = Math.max(
+        new Date(right.createdAt).getTime() || 0,
+        latestReplyAtByPostId.get(right.id) ?? 0,
+      );
+      return rightActivityAt - leftActivityAt;
+    });
+  }, [followedCharacterAccountIds, latestReplyAtByPostId, posts, timelineTab]);
   const timelinePosts = useMemo(() => {
     if (!normalizedPostSearch || isAccountSearch) return baseTimelinePosts;
     return baseTimelinePosts.filter((post) => {

--- a/packages/client/src/components/noodle/NoodleView.tsx
+++ b/packages/client/src/components/noodle/NoodleView.tsx
@@ -77,6 +77,7 @@ import { Modal } from "../ui/Modal";
 import {
   useCreateNoodleInteraction,
   useCreateNoodlePost,
+  useDeleteNoodleInteraction,
   useDeleteNoodlePost,
   useInviteNoodleCharacter,
   useInviteNoodleCharacters,
@@ -87,6 +88,7 @@ import {
   useRescheduleNoodleRefresh,
   useResetNoodleTimeline,
   useUpdateNoodleAccount,
+  useUpdateNoodleInteraction,
   useUpdateNoodlePost,
   useUpdateNoodleSettings,
 } from "../../hooks/use-noodle";
@@ -138,6 +140,14 @@ type NoodleConfirmAction =
     }
   | {
       kind: "reset-timeline";
+      title: string;
+      message: string;
+      confirmLabel: string;
+    }
+  | {
+      kind: "delete-reply";
+      postId: string;
+      interactionId: string;
       title: string;
       message: string;
       confirmLabel: string;
@@ -739,6 +749,8 @@ export function NoodleView() {
   const deletePost = useDeleteNoodlePost();
   const createInteraction = useCreateNoodleInteraction();
   const removeInteraction = useRemoveNoodleInteraction();
+  const updateInteraction = useUpdateNoodleInteraction();
+  const deleteInteraction = useDeleteNoodleInteraction();
   const rescheduleRefresh = useRescheduleNoodleRefresh();
   const refreshNoodle = useRefreshNoodle();
   const resetNoodleTimeline = useResetNoodleTimeline();
@@ -823,6 +835,8 @@ export function NoodleView() {
   const [postMenuId, setPostMenuId] = useState<string | null>(null);
   const [editingPostId, setEditingPostId] = useState<string | null>(null);
   const [editingPostContent, setEditingPostContent] = useState("");
+  const [editingReplyId, setEditingReplyId] = useState<string | null>(null);
+  const [editingReplyContent, setEditingReplyContent] = useState("");
   const [confirmAction, setConfirmAction] = useState<NoodleConfirmAction | null>(null);
   const [composeOpen, setComposeOpen] = useState(false);
   const [accountSwitcherOpen, setAccountSwitcherOpen] = useState(false);
@@ -1228,9 +1242,11 @@ export function NoodleView() {
   const confirmActionPending =
     confirmAction?.kind === "delete-post"
       ? deletePost.isPending
-      : confirmAction?.kind === "reset-timeline"
-        ? resetNoodleTimeline.isPending
-        : false;
+      : confirmAction?.kind === "delete-reply"
+        ? deleteInteraction.isPending
+        : confirmAction?.kind === "reset-timeline"
+          ? resetNoodleTimeline.isPending
+          : false;
   const normalizedProfileHandle = profileHandle.trim().replace(/^@+/, "");
   const isEditingOwnProfile = viewingOwnProfile && profileEditing;
   const profileDisplayName = viewingOwnProfile
@@ -1895,6 +1911,48 @@ export function NoodleView() {
     );
   };
 
+  const startEditingReply = (reply: NoodleInteraction) => {
+    setEditingReplyId(reply.id);
+    setEditingReplyContent(reply.content ?? "");
+  };
+
+  const cancelEditingReply = () => {
+    setEditingReplyId(null);
+    setEditingReplyContent("");
+  };
+
+  const saveEditedReply = (post: NoodlePost, reply: NoodleInteraction) => {
+    if (!personaAccount) return;
+    const content = editingReplyContent.trim();
+    if (!content && !reply.imageUrl) {
+      toast.error("Comments need text or an image.");
+      return;
+    }
+    updateInteraction.mutate(
+      {
+        postId: post.id,
+        interactionId: reply.id,
+        personaId: personaAccount.entityId,
+        content,
+      },
+      {
+        onSuccess: cancelEditingReply,
+        onError: (error) => toast.error(error instanceof Error ? error.message : "Could not edit Noodle comment."),
+      },
+    );
+  };
+
+  const deleteNoodleReply = (post: NoodlePost, reply: NoodleInteraction) => {
+    setConfirmAction({
+      kind: "delete-reply",
+      postId: post.id,
+      interactionId: reply.id,
+      title: "Delete Noodle Comment",
+      message: "This removes the comment and any replies or likes attached to it.",
+      confirmLabel: "Delete comment",
+    });
+  };
+
   const deleteNoodlePost = (post: NoodlePost) => {
     setPostMenuId(null);
     setConfirmAction({
@@ -1932,11 +1990,28 @@ export function NoodleView() {
       });
       return;
     }
+    if (confirmAction.kind === "delete-reply") {
+      if (!personaAccount) return;
+      const { postId, interactionId } = confirmAction;
+      deleteInteraction.mutate(
+        { postId, interactionId, personaId: personaAccount.entityId },
+        {
+          onSuccess: () => {
+            if (editingReplyId === interactionId) cancelEditingReply();
+            if (replyParentInteractionId === interactionId) clearReplyComposer();
+            setConfirmAction(null);
+          },
+          onError: (error) => toast.error(error instanceof Error ? error.message : "Could not delete Noodle comment."),
+        },
+      );
+      return;
+    }
     resetNoodleTimeline.mutate(undefined, {
       onSuccess: () => {
         clearReplyComposer();
         setPostMenuId(null);
         cancelEditingPost();
+        cancelEditingReply();
         setConfirmAction(null);
         toast.success("Noodle timeline reset.");
       },
@@ -3082,6 +3157,7 @@ export function NoodleView() {
                   const likedReplyByPersona = personaAccount
                     ? replyLikes.some((interaction) => interaction.actorAccountId === personaAccount.id)
                     : false;
+                  const canManageReply = Boolean(personaAccount && reply.actorAccountId === personaAccount.id);
                   return (
                     <Fragment key={reply.id}>
                       <div
@@ -3128,9 +3204,39 @@ export function NoodleView() {
                               Replying to <span className="text-[var(--noodle-blue)]">@{parentActor.handle}</span>
                             </p>
                           )}
-                          {reply.content && (
+                          {editingReplyId === reply.id ? (
+                            <div className="mt-2 space-y-2" data-component="NoodleView.CommentEditor">
+                              <textarea
+                                value={editingReplyContent}
+                                onChange={(event) => setEditingReplyContent(event.target.value)}
+                                className={cn(textareaClass, "min-h-20 resize-y")}
+                                placeholder="Edit comment"
+                                autoFocus
+                              />
+                              <div className="flex justify-end gap-2">
+                                <button
+                                  type="button"
+                                  onClick={cancelEditingReply}
+                                  disabled={updateInteraction.isPending}
+                                  className="h-8 rounded-full px-3 text-xs font-semibold text-[var(--muted-foreground)] transition-colors hover:bg-[var(--accent)] hover:text-[var(--foreground)] disabled:opacity-50"
+                                >
+                                  Cancel
+                                </button>
+                                <button
+                                  type="button"
+                                  onClick={() => saveEditedReply(post, reply)}
+                                  disabled={
+                                    (!editingReplyContent.trim() && !reply.imageUrl) || updateInteraction.isPending
+                                  }
+                                  className="h-8 rounded-full bg-[var(--noodle-blue)] px-4 text-xs font-bold text-zinc-950 transition-opacity hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-50"
+                                >
+                                  {updateInteraction.isPending ? "Saving" : "Save"}
+                                </button>
+                              </div>
+                            </div>
+                          ) : reply.content ? (
                             <p className="mt-1 whitespace-pre-wrap text-sm leading-5">{reply.content}</p>
-                          )}
+                          ) : null}
                           {reply.imageUrl && (
                             <button
                               type="button"
@@ -3183,6 +3289,30 @@ export function NoodleView() {
                             >
                               <MessageCircle size={14} />
                             </button>
+                            {canManageReply && editingReplyId !== reply.id && (
+                              <>
+                                <button
+                                  type="button"
+                                  onClick={() => startEditingReply(reply)}
+                                  disabled={updateInteraction.isPending || deleteInteraction.isPending}
+                                  className="inline-flex h-7 w-7 items-center justify-center rounded-full text-[var(--noodle-blue)] transition-colors hover:bg-[var(--noodle-blue)]/10 disabled:cursor-not-allowed disabled:opacity-50"
+                                  title="Edit comment"
+                                  aria-label="Edit comment"
+                                >
+                                  <Pencil size={14} />
+                                </button>
+                                <button
+                                  type="button"
+                                  onClick={() => deleteNoodleReply(post, reply)}
+                                  disabled={updateInteraction.isPending || deleteInteraction.isPending}
+                                  className="inline-flex h-7 w-7 items-center justify-center rounded-full text-[var(--noodle-blue)] transition-colors hover:bg-[var(--noodle-blue)]/10 disabled:cursor-not-allowed disabled:opacity-50"
+                                  title="Delete comment"
+                                  aria-label="Delete comment"
+                                >
+                                  <Trash2 size={14} />
+                                </button>
+                              </>
+                            )}
                           </div>
                         </div>
                       </div>

--- a/packages/client/src/hooks/use-noodle.ts
+++ b/packages/client/src/hooks/use-noodle.ts
@@ -11,6 +11,7 @@ import type {
   NoodleCreateInteractionInput,
   NoodleCreatePostInput,
   NoodleInteraction,
+  NoodleInteractionUpdateInput,
   NoodlePost,
   NoodlePostUpdateInput,
   NoodleRemoveInteractionInput,
@@ -214,6 +215,52 @@ export function useRemoveNoodleInteraction() {
           ? {
               ...current,
               interactions: current.interactions.filter((item) => item.id !== interaction.id),
+            }
+          : current,
+      );
+    },
+  });
+}
+
+export function useUpdateNoodleInteraction() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: ({
+      postId,
+      interactionId,
+      ...input
+    }: NoodleInteractionUpdateInput & { postId: string; interactionId: string }) =>
+      api.patch<NoodleInteraction>(
+        `/noodle/posts/${encodeURIComponent(postId)}/interactions/${encodeURIComponent(interactionId)}`,
+        input,
+      ),
+    onSuccess: (interaction) => {
+      qc.setQueryData<NoodleBootstrap | undefined>(noodleKeys.bootstrap(), (current) =>
+        current
+          ? {
+              ...current,
+              interactions: current.interactions.map((item) => (item.id === interaction.id ? interaction : item)),
+            }
+          : current,
+      );
+    },
+  });
+}
+
+export function useDeleteNoodleInteraction() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: ({ postId, interactionId, personaId }: { postId: string; interactionId: string; personaId: string }) =>
+      api.delete<NoodleInteraction[]>(
+        `/noodle/posts/${encodeURIComponent(postId)}/interactions/${encodeURIComponent(interactionId)}?personaId=${encodeURIComponent(personaId)}`,
+      ),
+    onSuccess: (interactions) => {
+      const deletedIds = new Set(interactions.map((interaction) => interaction.id));
+      qc.setQueryData<NoodleBootstrap | undefined>(noodleKeys.bootstrap(), (current) =>
+        current
+          ? {
+              ...current,
+              interactions: current.interactions.filter((item) => !deletedIds.has(item.id)),
             }
           : current,
       );

--- a/packages/server/src/routes/noodle.routes.ts
+++ b/packages/server/src/routes/noodle.routes.ts
@@ -59,6 +59,7 @@ import {
   formatNoodleTimelineForPrompt,
   noodlePastMemoryCutoff,
   noodlePastMemorySampleSize,
+  noodlePersonaCommentPostIds,
   NOODLE_PERSONA_AUTHORSHIP_INSTRUCTION,
   noodleTimelineFeatureInstructions,
   sampleNoodlePastMemories,
@@ -593,9 +594,26 @@ async function buildRefreshPrompt(input: {
   const selectedCharacterIds = activeCharacters.map((account) => account.entityId);
   const characterRows = await Promise.all(selectedCharacterIds.map((id) => input.characters.getById(id)));
   const personaRow = input.personaAccount ? await input.characters.getPersona(input.personaAccount.entityId) : null;
-  const recentPosts = await input.noodle.listPosts({ since: sinceHoursIso(48), limit: 100 });
+  const recentCutoff = sinceHoursIso(48);
+  const [recentCreatedPosts, recentPersonaComments] = await Promise.all([
+    input.noodle.listPosts({ since: recentCutoff, limit: 100 }),
+    input.personaAccount
+      ? input.noodle.listRepliesByActorSince(input.personaAccount.id, recentCutoff, 100)
+      : Promise.resolve([]),
+  ]);
+  const recentlyCommentedPostIds = noodlePersonaCommentPostIds(recentPersonaComments, input.personaAccount?.id);
+  const recentlyCommentedPosts = (
+    await Promise.all(recentlyCommentedPostIds.map((postId) => input.noodle.getPostById(postId)))
+  ).filter((post): post is NoodlePost => Boolean(post));
+  const recentPostById = new Map([...recentCreatedPosts, ...recentlyCommentedPosts].map((post) => [post.id, post]));
+  const recentPosts = [...recentPostById.values()].sort(
+    (left, right) => new Date(right.createdAt).getTime() - new Date(left.createdAt).getTime(),
+  );
   const pastMemorySampleSize = noodlePastMemorySampleSize();
-  const olderPosts = pastMemorySampleSize > 0 ? await input.noodle.listPostsBefore(noodlePastMemoryCutoff()) : [];
+  const olderPosts =
+    pastMemorySampleSize > 0
+      ? (await input.noodle.listPostsBefore(noodlePastMemoryCutoff())).filter((post) => !recentPostById.has(post.id))
+      : [];
   const recalledPosts = sampleNoodlePastMemories(olderPosts, pastMemorySampleSize);
   const [chatContext, recentInteractions, recalledInteractions] = await Promise.all([
     buildOptedInChatContext(input.chats, input.characters, selectedCharacterIds),

--- a/packages/server/src/routes/noodle.routes.ts
+++ b/packages/server/src/routes/noodle.routes.ts
@@ -67,6 +67,7 @@ import {
 
 const NOODLE_ROUTE_DIR = dirname(fileURLToPath(import.meta.url));
 const CLIENT_PUBLIC_DIR = resolve(NOODLE_ROUTE_DIR, "../../../client/public");
+const NOODLE_FOLLOWED_AT_BY_ACCOUNT_KEY = "followingAccountTimestamps";
 const PROFESSOR_MARI_REFERENCE_ASSETS = [
   "sprites/mari/Mari_profile.png",
   "sprites/mari/chibi-professor-mari.png",
@@ -1551,9 +1552,14 @@ export async function noodleRoutes(app: FastifyInstance) {
         const actorSettings = mutableAccountSettings.get(actor.id) ?? actor.settings;
         const currentFollowingAccountIds = parseStringArray(actorSettings.followingAccountIds);
         if (currentFollowingAccountIds.includes(target.id)) continue;
+        const followedAtByAccount = parseRecord(actorSettings[NOODLE_FOLLOWED_AT_BY_ACCOUNT_KEY]);
         const nextSettings = {
           ...actorSettings,
           followingAccountIds: [...currentFollowingAccountIds, target.id],
+          [NOODLE_FOLLOWED_AT_BY_ACCOUNT_KEY]: {
+            ...followedAtByAccount,
+            [target.id]: new Date().toISOString(),
+          },
         };
         mutableAccountSettings.set(actor.id, nextSettings);
         await noodle.updateAccount(actor.id, { settings: nextSettings });

--- a/packages/server/src/routes/noodle.routes.ts
+++ b/packages/server/src/routes/noodle.routes.ts
@@ -656,6 +656,8 @@ async function buildRefreshPrompt(input: {
     "- Random user accounts are not characters. Treat them as ordinary fictional Noodle profiles that may follow, like, reply, repost, gossip, or casually join public drama.",
     "- Structured actions are limited to posts, polls, follows, likes, reposts, replies, and poll votes.",
     "- Generated interactions may target existing posts included in this prompt or posts you create in this response.",
+    "- For each interaction, set either targetTempId or targetPostId. The unused target field may be omitted or null.",
+    "- pollOptionIndex is required only for votes and must be a zero-based integer. For other interactions, omit it or use null.",
     "- An exact @handle in post or reply text tags that active account. Preserve the @handle exactly when mentioning someone.",
     ...noodleTimelineFeatureInstructions(input.settings),
     "- Return JSON only. No prose outside the JSON object.",

--- a/packages/server/src/routes/noodle.routes.ts
+++ b/packages/server/src/routes/noodle.routes.ts
@@ -56,6 +56,7 @@ import {
 } from "../services/noodle/noodle-refresh-schedule.js";
 import {
   canGenerateNoodleActivityForAccountKind,
+  formatNoodleTimelineForPrompt,
   noodlePastMemoryCutoff,
   noodlePastMemorySampleSize,
   NOODLE_PERSONA_AUTHORSHIP_INSTRUCTION,
@@ -417,37 +418,6 @@ async function ensureSelectedGroupCharacterAccounts(
   return selectedCharacterIds;
 }
 
-function formatTimelineForPrompt(
-  posts: NoodlePost[],
-  interactions: Array<{ postId: string; type: string; content: string | null }>,
-  options: { emptyMessage?: string; includeTimestamp?: boolean } = {},
-) {
-  if (posts.length === 0) return options.emptyMessage ?? "No Noodle posts yet today.";
-  return posts
-    .slice()
-    .reverse()
-    .map((post) => {
-      const author = post.authorSnapshot?.displayName ?? post.authorAccountId;
-      const poll = readNoodlePollFromMetadata(post.metadata);
-      const pollSummary = poll
-        ? ` [poll: ${poll.question}; ${poll.options
-            .map((option, index) => {
-              const votes = interactions.filter(
-                (interaction) =>
-                  interaction.postId === post.id && interaction.type === "vote" && interaction.content === option.id,
-              ).length;
-              return `option ${index}: ${option.label} (${votes} vote${votes === 1 ? "" : "s"})`;
-            })
-            .join("; ")}]`
-        : "";
-      const timestamp = options.includeTimestamp ? ` at ${post.createdAt}` : "";
-      return `- ${post.id} by ${author}${timestamp}: ${post.content}${pollSummary}${
-        post.imagePrompt ? ` [image prompt: ${post.imagePrompt}]` : ""
-      }`;
-    })
-    .join("\n");
-}
-
 async function ensurePersonaAccounts(
   noodle: ReturnType<typeof createNoodleStorage>,
   characters: ReturnType<typeof createCharactersStorage>,
@@ -623,13 +593,13 @@ async function buildRefreshPrompt(input: {
   const selectedCharacterIds = activeCharacters.map((account) => account.entityId);
   const characterRows = await Promise.all(selectedCharacterIds.map((id) => input.characters.getById(id)));
   const personaRow = input.personaAccount ? await input.characters.getPersona(input.personaAccount.entityId) : null;
-  const todayPosts = await input.noodle.listPosts({ since: dayStartIso(), limit: 100 });
+  const recentPosts = await input.noodle.listPosts({ since: sinceHoursIso(48), limit: 100 });
   const pastMemorySampleSize = noodlePastMemorySampleSize();
   const olderPosts = pastMemorySampleSize > 0 ? await input.noodle.listPostsBefore(noodlePastMemoryCutoff()) : [];
   const recalledPosts = sampleNoodlePastMemories(olderPosts, pastMemorySampleSize);
-  const [chatContext, todayInteractions, recalledInteractions] = await Promise.all([
+  const [chatContext, recentInteractions, recalledInteractions] = await Promise.all([
     buildOptedInChatContext(input.chats, input.characters, selectedCharacterIds),
-    input.noodle.listInteractions(todayPosts.map((post) => post.id)),
+    input.noodle.listInteractions(recentPosts.map((post) => post.id)),
     input.noodle.listInteractions(recalledPosts.map((post) => post.id)),
   ]);
 
@@ -662,6 +632,7 @@ async function buildRefreshPrompt(input: {
     "- Random user accounts are not characters. Treat them as ordinary fictional Noodle profiles that may follow, like, reply, repost, gossip, or casually join public drama.",
     "- Structured actions are limited to posts, polls, follows, likes, reposts, replies, and poll votes.",
     "- Generated interactions may target existing posts included in this prompt or posts you create in this response.",
+    "- To respond directly to an existing comment, create a reply interaction for its post and set parentInteractionId to that comment's exact replyId.",
     NOODLE_PERSONA_AUTHORSHIP_INSTRUCTION,
     "- For each interaction, set either targetTempId or targetPostId. The unused target field may be omitted or null.",
     "- pollOptionIndex is required only for votes and must be a zero-based integer. For other interactions, omit it or use null.",
@@ -687,16 +658,20 @@ async function buildRefreshPrompt(input: {
     "Only chats whose Chat Settings allow Noodle references are included here.",
     chatContext,
     "",
-    "# Today's Existing Noodle Timeline",
-    formatTimelineForPrompt(todayPosts, todayInteractions),
+    "# Recent Noodle Timeline",
+    "Recent persona comments are especially relevant. Characters may naturally respond to them by using the comment replyId as parentInteractionId.",
+    formatNoodleTimelineForPrompt(recentPosts, recentInteractions, {
+      priorityActorAccountId: input.personaAccount?.id,
+    }),
     ...(recalledPosts.length > 0
       ? [
           "",
           "# Randomly Recalled Older Noodle Activity",
           "These posts are more than 48 hours old and are optional long-term memories. Active accounts may naturally remember, revisit, like, repost, reply to, or build on them, but do not force a reference.",
-          formatTimelineForPrompt(recalledPosts, recalledInteractions, {
+          formatNoodleTimelineForPrompt(recalledPosts, recalledInteractions, {
             emptyMessage: "No older Noodle activity was recalled.",
             includeTimestamp: true,
+            priorityActorAccountId: input.personaAccount?.id,
           }),
         ]
       : []),
@@ -734,6 +709,7 @@ async function buildRefreshPrompt(input: {
             actorEntityId: "exact non-persona entityId allowed to perform generated activity",
             targetTempId: "tempId from posts, if targeting a newly created post",
             targetPostId: "existing post id, if targeting an existing post",
+            parentInteractionId: "existing replyId when directly answering a comment, otherwise null",
             type: "like | repost | reply | vote",
             content: "required for reply, optional/null otherwise",
             pollOptionIndex: 1,
@@ -1390,6 +1366,12 @@ export async function noodleRoutes(app: FastifyInstance) {
       );
       const freshPosts = await noodle.listPosts({ since: sinceHoursIso(48), limit: 200 });
       const allowedExistingPostIds = new Set([...freshPosts.map((post) => post.id), ...recalledPostIds]);
+      const existingInteractionById = new Map(
+        (await noodle.listInteractions([...allowedExistingPostIds])).map((interaction) => [
+          interaction.id,
+          interaction,
+        ]),
+      );
       const todayPosts = await noodle.listPosts({ since: dayStartIso(), limit: 200 });
       let remainingImagePrompts = settings.enableImagePrompts
         ? Math.max(0, settings.maxImagePromptsPerDay - todayPosts.filter((post) => !!post.imagePrompt).length)
@@ -1496,6 +1478,15 @@ export async function noodleRoutes(app: FastifyInstance) {
         }
         const targetPost = await noodle.getPostById(targetPostId);
         if (!targetPost) continue;
+        const parentInteraction = generatedInteraction.parentInteractionId
+          ? (existingInteractionById.get(generatedInteraction.parentInteractionId) ?? null)
+          : null;
+        if (
+          generatedInteraction.parentInteractionId &&
+          (!parentInteraction || parentInteraction.postId !== targetPostId || parentInteraction.type !== "reply")
+        ) {
+          continue;
+        }
         const poll = readNoodlePollFromMetadata(targetPost.metadata);
         const selectedPollOption =
           generatedInteraction.type === "vote" ? poll?.options[generatedInteraction.pollOptionIndex ?? -1] : undefined;
@@ -1504,6 +1495,7 @@ export async function noodleRoutes(app: FastifyInstance) {
           actorAccountId: actor.id,
           type: generatedInteraction.type,
           content: selectedPollOption?.id ?? generatedInteraction.content ?? null,
+          parentInteractionId: parentInteraction?.id ?? null,
         });
         if (!interaction) continue;
         quotas[generatedInteraction.type] -= 1;
@@ -1513,7 +1505,9 @@ export async function noodleRoutes(app: FastifyInstance) {
               ? `${poll.question}: ${selectedPollOption.label}`
               : interaction.content || targetPost.content;
           await noodle.createDigest({
-            accountIds: Array.from(new Set([actor.id, targetPost.authorAccountId])).filter(Boolean),
+            accountIds: Array.from(
+              new Set([actor.id, targetPost.authorAccountId, parentInteraction?.actorAccountId]),
+            ).filter((accountId): accountId is string => Boolean(accountId)),
             content: `${actor.displayName} ${interactionDigestVerb(
               generatedInteraction.type,
             )} a Noodle post: ${interactionSummary}`,

--- a/packages/server/src/routes/noodle.routes.ts
+++ b/packages/server/src/routes/noodle.routes.ts
@@ -15,6 +15,8 @@ import {
   noodleGeneratedProfilesSchema,
   noodleGeneratedRefreshSchema,
   noodleInviteSchema,
+  noodleInteractionOwnerSchema,
+  noodleInteractionUpdateSchema,
   noodlePostUpdateSchema,
   noodleRemoveInteractionSchema,
   noodleRescheduleRefreshSchema,
@@ -53,8 +55,10 @@ import {
   rescheduleNoodleRefreshTime,
 } from "../services/noodle/noodle-refresh-schedule.js";
 import {
+  canGenerateNoodleActivityForAccountKind,
   noodlePastMemoryCutoff,
   noodlePastMemorySampleSize,
+  NOODLE_PERSONA_AUTHORSHIP_INSTRUCTION,
   noodleTimelineFeatureInstructions,
   sampleNoodlePastMemories,
 } from "../services/noodle/noodle-prompt.js";
@@ -645,7 +649,9 @@ async function buildRefreshPrompt(input: {
   const activeAccountList = [...input.activeAccounts, ...(input.personaAccount ? [input.personaAccount] : [])]
     .map(
       (account) =>
-        `- ${account.displayName} (@${account.handle}) kind=${account.kind} entityId=${account.entityId} accountId=${account.id}`,
+        `- ${account.displayName} (@${account.handle}) kind=${account.kind} entityId=${account.entityId} accountId=${account.id} generationRole=${
+          account.kind === "persona" ? "reference-target-only" : "allowed-author-and-actor"
+        }`,
     )
     .join("\n");
 
@@ -656,6 +662,7 @@ async function buildRefreshPrompt(input: {
     "- Random user accounts are not characters. Treat them as ordinary fictional Noodle profiles that may follow, like, reply, repost, gossip, or casually join public drama.",
     "- Structured actions are limited to posts, polls, follows, likes, reposts, replies, and poll votes.",
     "- Generated interactions may target existing posts included in this prompt or posts you create in this response.",
+    NOODLE_PERSONA_AUTHORSHIP_INSTRUCTION,
     "- For each interaction, set either targetTempId or targetPostId. The unused target field may be omitted or null.",
     "- pollOptionIndex is required only for votes and must be a zero-based integer. For other interactions, omit it or use null.",
     "- An exact @handle in post or reply text tags that active account. Preserve the @handle exactly when mentioning someone.",
@@ -715,7 +722,7 @@ async function buildRefreshPrompt(input: {
         posts: [
           {
             tempId: "local id used only inside this response",
-            authorEntityId: "exact entityId from Active Noodle Accounts",
+            authorEntityId: "exact non-persona entityId allowed to author generated activity",
             content: "post text",
             poll: { question: "optional poll question", options: ["first answer", "second answer"] },
             imagePrompt: "optional image prompt or null",
@@ -724,7 +731,7 @@ async function buildRefreshPrompt(input: {
         ],
         interactions: [
           {
-            actorEntityId: "exact entityId from Active Noodle Accounts",
+            actorEntityId: "exact non-persona entityId allowed to perform generated activity",
             targetTempId: "tempId from posts, if targeting a newly created post",
             targetPostId: "existing post id, if targeting an existing post",
             type: "like | repost | reply | vote",
@@ -734,7 +741,7 @@ async function buildRefreshPrompt(input: {
         ],
         follows: [
           {
-            actorEntityId: "exact entityId from Active Noodle Accounts",
+            actorEntityId: "exact non-persona entityId allowed to perform generated activity",
             targetEntityId: "exact entityId from Active Noodle Accounts",
           },
         ],
@@ -1213,6 +1220,47 @@ export async function noodleRoutes(app: FastifyInstance) {
     return interaction;
   });
 
+  app.patch("/posts/:postId/interactions/:interactionId", async (req, reply) => {
+    const { postId, interactionId } = req.params as { postId: string; interactionId: string };
+    const parsed = noodleInteractionUpdateSchema.safeParse(req.body);
+    if (!parsed.success) return reply.code(400).send({ error: parsed.error.flatten() });
+    const interaction = await noodle.getInteractionById(interactionId);
+    if (!interaction || interaction.postId !== postId) {
+      return reply.code(404).send({ error: "Noodle comment not found" });
+    }
+    await ensurePersonaAccounts(noodle, characters);
+    const persona = await noodle.getAccountByEntity("persona", parsed.data.personaId);
+    if (!persona) return reply.code(404).send({ error: "Noodle persona not found" });
+    if (interaction.type !== "reply" || interaction.actorAccountId !== persona.id) {
+      return reply.code(403).send({ error: "You can only edit comments from this persona." });
+    }
+    const content = parsed.data.content === undefined ? interaction.content : parsed.data.content?.trim() || null;
+    const imageUrl = parsed.data.imageUrl === undefined ? interaction.imageUrl : parsed.data.imageUrl?.trim() || null;
+    if (!content && !imageUrl) return reply.code(400).send({ error: "Comments need text or an image." });
+    const updated = await noodle.updateInteraction(interactionId, { content, imageUrl });
+    if (!updated) return reply.code(404).send({ error: "Noodle comment not found" });
+    return updated;
+  });
+
+  app.delete("/posts/:postId/interactions/:interactionId", async (req, reply) => {
+    const { postId, interactionId } = req.params as { postId: string; interactionId: string };
+    const parsed = noodleInteractionOwnerSchema.safeParse(req.query);
+    if (!parsed.success) return reply.code(400).send({ error: parsed.error.flatten() });
+    const interaction = await noodle.getInteractionById(interactionId);
+    if (!interaction || interaction.postId !== postId) {
+      return reply.code(404).send({ error: "Noodle comment not found" });
+    }
+    await ensurePersonaAccounts(noodle, characters);
+    const persona = await noodle.getAccountByEntity("persona", parsed.data.personaId);
+    if (!persona) return reply.code(404).send({ error: "Noodle persona not found" });
+    if (interaction.type !== "reply" || interaction.actorAccountId !== persona.id) {
+      return reply.code(403).send({ error: "You can only delete comments from this persona." });
+    }
+    const deleted = await noodle.deleteInteractionById(interactionId);
+    if (deleted.length === 0) return reply.code(404).send({ error: "Noodle comment not found" });
+    return deleted;
+  });
+
   app.delete("/posts/:id/interactions", async (req, reply) => {
     const { id } = req.params as { id: string };
     const parsed = noodleRemoveInteractionSchema.safeParse(req.query);
@@ -1353,6 +1401,10 @@ export async function noodleRoutes(app: FastifyInstance) {
       for (const generatedPost of generated.posts.slice(0, settings.maxGeneratedPostsPerRefresh)) {
         const account = entityToAccount.get(generatedPost.authorEntityId);
         if (!account) continue;
+        if (!canGenerateNoodleActivityForAccountKind(account.kind)) {
+          logger.warn("[noodle] Ignoring generated post attributed to persona %s", account.entityId);
+          continue;
+        }
         const imagePrompt =
           remainingImagePrompts > 0 && generatedPost.imagePrompt?.trim() ? generatedPost.imagePrompt.trim() : null;
         if (imagePrompt) remainingImagePrompts -= 1;
@@ -1429,6 +1481,14 @@ export async function noodleRoutes(app: FastifyInstance) {
         if (quotas[generatedInteraction.type] <= 0) continue;
         const actor = entityToAccount.get(generatedInteraction.actorEntityId);
         if (!actor) continue;
+        if (!canGenerateNoodleActivityForAccountKind(actor.kind)) {
+          logger.warn(
+            "[noodle] Ignoring generated %s interaction attributed to persona %s",
+            generatedInteraction.type,
+            actor.entityId,
+          );
+          continue;
+        }
         const targetPostId =
           generatedInteraction.targetPostId ?? tempIdToPostId.get(generatedInteraction.targetTempId ?? "");
         if (!targetPostId || (!allowedExistingPostIds.has(targetPostId) && !createdPostIds.includes(targetPostId))) {
@@ -1468,7 +1528,11 @@ export async function noodleRoutes(app: FastifyInstance) {
       for (const generatedFollow of generated.follows.slice(0, maxGeneratedFollows)) {
         const actor = entityToAccount.get(generatedFollow.actorEntityId);
         const target = entityToAccount.get(generatedFollow.targetEntityId);
-        if (!actor || !target || actor.id === target.id || actor.kind === "persona") continue;
+        if (!actor || !target || actor.id === target.id) continue;
+        if (!canGenerateNoodleActivityForAccountKind(actor.kind)) {
+          logger.warn("[noodle] Ignoring generated follow attributed to persona %s", actor.entityId);
+          continue;
+        }
         const followKey = `${actor.id}:${target.id}`;
         if (seenGeneratedFollows.has(followKey)) continue;
         seenGeneratedFollows.add(followKey);

--- a/packages/server/src/services/noodle/noodle-prompt.ts
+++ b/packages/server/src/services/noodle/noodle-prompt.ts
@@ -44,6 +44,20 @@ export function canGenerateNoodleActivityForAccountKind(kind: NoodleAccountKind)
   return kind === "character" || kind === "random_user";
 }
 
+export function noodlePersonaCommentPostIds(
+  interactions: Array<Pick<NoodleInteraction, "postId" | "actorAccountId" | "type">>,
+  personaAccountId?: string,
+): string[] {
+  if (!personaAccountId) return [];
+  return Array.from(
+    new Set(
+      interactions
+        .filter((interaction) => interaction.type === "reply" && interaction.actorAccountId === personaAccountId)
+        .map((interaction) => interaction.postId),
+    ),
+  );
+}
+
 function promptRepliesForPost(
   interactions: NoodlePromptInteraction[],
   postId: string,

--- a/packages/server/src/services/noodle/noodle-prompt.ts
+++ b/packages/server/src/services/noodle/noodle-prompt.ts
@@ -1,7 +1,13 @@
 // ──────────────────────────────────────────────
 // Noodle Prompt Instructions
 // ──────────────────────────────────────────────
-import type { NoodleAccountKind, NoodleSettings } from "@marinara-engine/shared";
+import {
+  readNoodlePollFromMetadata,
+  type NoodleAccountKind,
+  type NoodleInteraction,
+  type NoodlePost,
+  type NoodleSettings,
+} from "@marinara-engine/shared";
 
 export const NOODLE_PAST_MEMORY_MIN_AGE_MS = 48 * 60 * 60 * 1000;
 export const NOODLE_PAST_MEMORY_MAX_ITEMS = 3;
@@ -15,9 +21,89 @@ type NoodleTimelineFeatureSettings = Pick<
 >;
 
 type RandomSource = () => number;
+type NoodlePromptPost = Pick<
+  NoodlePost,
+  "id" | "authorAccountId" | "authorSnapshot" | "content" | "imagePrompt" | "metadata" | "createdAt"
+>;
+type NoodlePromptInteraction = Pick<
+  NoodleInteraction,
+  | "id"
+  | "postId"
+  | "parentInteractionId"
+  | "actorAccountId"
+  | "actorSnapshot"
+  | "type"
+  | "content"
+  | "imageUrl"
+  | "createdAt"
+>;
+
+const NOODLE_PROMPT_REPLIES_PER_POST = 12;
 
 export function canGenerateNoodleActivityForAccountKind(kind: NoodleAccountKind): boolean {
   return kind === "character" || kind === "random_user";
+}
+
+function promptRepliesForPost(
+  interactions: NoodlePromptInteraction[],
+  postId: string,
+  priorityActorAccountId?: string,
+) {
+  const replies = interactions.filter((interaction) => interaction.postId === postId && interaction.type === "reply");
+  const prioritized = priorityActorAccountId
+    ? replies.filter((interaction) => interaction.actorAccountId === priorityActorAccountId).reverse()
+    : [];
+  const newest = replies.slice().reverse();
+  const selected = new Map<string, NoodlePromptInteraction>();
+  for (const reply of [...prioritized, ...newest]) {
+    if (selected.size >= NOODLE_PROMPT_REPLIES_PER_POST) break;
+    selected.set(reply.id, reply);
+  }
+  return [...selected.values()].sort(
+    (left, right) => new Date(left.createdAt).getTime() - new Date(right.createdAt).getTime(),
+  );
+}
+
+export function formatNoodleTimelineForPrompt(
+  posts: NoodlePromptPost[],
+  interactions: NoodlePromptInteraction[],
+  options: { emptyMessage?: string; includeTimestamp?: boolean; priorityActorAccountId?: string } = {},
+) {
+  if (posts.length === 0) return options.emptyMessage ?? "No recent Noodle posts.";
+  return posts
+    .slice()
+    .reverse()
+    .map((post) => {
+      const author = post.authorSnapshot?.displayName ?? post.authorAccountId;
+      const poll = readNoodlePollFromMetadata(post.metadata);
+      const pollSummary = poll
+        ? ` [poll: ${poll.question}; ${poll.options
+            .map((option, index) => {
+              const votes = interactions.filter(
+                (interaction) =>
+                  interaction.postId === post.id && interaction.type === "vote" && interaction.content === option.id,
+              ).length;
+              return `option ${index}: ${option.label} (${votes} vote${votes === 1 ? "" : "s"})`;
+            })
+            .join("; ")}]`
+        : "";
+      const timestamp = options.includeTimestamp ? ` at ${post.createdAt}` : "";
+      const replyLines = promptRepliesForPost(interactions, post.id, options.priorityActorAccountId).map((reply) => {
+        const replyAuthor = reply.actorSnapshot?.displayName ?? reply.actorAccountId;
+        const replyHandle = reply.actorSnapshot?.handle ? ` (@${reply.actorSnapshot.handle})` : "";
+        const parent = reply.parentInteractionId ? ` parentReplyId=${reply.parentInteractionId}` : "";
+        return `  - replyId=${reply.id}${parent} by ${replyAuthor}${replyHandle} at ${reply.createdAt}: ${
+          reply.content || (reply.imageUrl ? "[image reply]" : "[empty reply]")
+        }`;
+      });
+      return [
+        `- ${post.id} by ${author}${timestamp}: ${post.content}${pollSummary}${
+          post.imagePrompt ? ` [image prompt: ${post.imagePrompt}]` : ""
+        }`,
+        ...replyLines,
+      ].join("\n");
+    })
+    .join("\n");
 }
 
 function normalizedRandom(random: RandomSource): number {

--- a/packages/server/src/services/noodle/noodle-prompt.ts
+++ b/packages/server/src/services/noodle/noodle-prompt.ts
@@ -1,11 +1,13 @@
 // ──────────────────────────────────────────────
 // Noodle Prompt Instructions
 // ──────────────────────────────────────────────
-import type { NoodleSettings } from "@marinara-engine/shared";
+import type { NoodleAccountKind, NoodleSettings } from "@marinara-engine/shared";
 
 export const NOODLE_PAST_MEMORY_MIN_AGE_MS = 48 * 60 * 60 * 1000;
 export const NOODLE_PAST_MEMORY_MAX_ITEMS = 3;
 export const NOODLE_PAST_MEMORY_INCLUSION_CHANCE = 0.5;
+export const NOODLE_PERSONA_AUTHORSHIP_INSTRUCTION =
+  "- The user persona is controlled exclusively by the user. Never generate posts, replies, likes, reposts, poll votes, or follows as a persona. Personas may only be mentioned or targeted by other accounts.";
 
 type NoodleTimelineFeatureSettings = Pick<
   NoodleSettings,
@@ -13,6 +15,10 @@ type NoodleTimelineFeatureSettings = Pick<
 >;
 
 type RandomSource = () => number;
+
+export function canGenerateNoodleActivityForAccountKind(kind: NoodleAccountKind): boolean {
+  return kind === "character" || kind === "random_user";
+}
 
 function normalizedRandom(random: RandomSource): number {
   const value = random();

--- a/packages/server/src/services/storage/noodle.storage.ts
+++ b/packages/server/src/services/storage/noodle.storage.ts
@@ -504,6 +504,22 @@ export function createNoodleStorage(db: DB) {
       return rows.map(mapInteraction);
     },
 
+    async listRepliesByActorSince(actorAccountId: string, since: string, limit = 100): Promise<NoodleInteraction[]> {
+      const rows = await db
+        .select()
+        .from(noodleInteractions)
+        .where(
+          and(
+            eq(noodleInteractions.actorAccountId, actorAccountId),
+            eq(noodleInteractions.type, "reply"),
+            gt(noodleInteractions.createdAt, since),
+          ),
+        )
+        .orderBy(desc(noodleInteractions.createdAt))
+        .limit(Math.max(1, Math.min(200, Math.floor(limit))));
+      return rows.map(mapInteraction);
+    },
+
     async getInteractionById(id: string): Promise<NoodleInteraction | null> {
       const rows = await db.select().from(noodleInteractions).where(eq(noodleInteractions.id, id));
       return rows[0] ? mapInteraction(rows[0]) : null;

--- a/packages/server/src/services/storage/noodle.storage.ts
+++ b/packages/server/src/services/storage/noodle.storage.ts
@@ -504,6 +504,46 @@ export function createNoodleStorage(db: DB) {
       return rows.map(mapInteraction);
     },
 
+    async getInteractionById(id: string): Promise<NoodleInteraction | null> {
+      const rows = await db.select().from(noodleInteractions).where(eq(noodleInteractions.id, id));
+      return rows[0] ? mapInteraction(rows[0]) : null;
+    },
+
+    async updateInteraction(
+      id: string,
+      input: { content?: string | null; imageUrl?: string | null },
+    ): Promise<NoodleInteraction | null> {
+      const existing = await this.getInteractionById(id);
+      if (!existing) return null;
+      await db
+        .update(noodleInteractions)
+        .set({
+          ...(input.content !== undefined && { content: input.content?.trim() || null }),
+          ...(input.imageUrl !== undefined && { imageUrl: input.imageUrl?.trim() || null }),
+        })
+        .where(eq(noodleInteractions.id, id));
+      return this.getInteractionById(id);
+    },
+
+    async deleteInteractionById(id: string): Promise<NoodleInteraction[]> {
+      const existing = await this.getInteractionById(id);
+      if (!existing) return [];
+      const rows = await db.select().from(noodleInteractions).where(eq(noodleInteractions.postId, existing.postId));
+      const deletedIds = new Set([id]);
+      let changed = true;
+      while (changed) {
+        changed = false;
+        for (const row of rows) {
+          if (deletedIds.has(row.id) || !row.parentInteractionId || !deletedIds.has(row.parentInteractionId)) continue;
+          deletedIds.add(row.id);
+          changed = true;
+        }
+      }
+      const deletedRows = rows.filter((row) => deletedIds.has(row.id));
+      await db.delete(noodleInteractions).where(inArray(noodleInteractions.id, [...deletedIds]));
+      return deletedRows.map(mapInteraction);
+    },
+
     async createInteraction(
       postId: string,
       input: Omit<NoodleCreateInteractionInput, "actorKind" | "actorEntityId"> & { actorAccountId: string },

--- a/packages/shared/src/schemas/noodle.schema.ts
+++ b/packages/shared/src/schemas/noodle.schema.ts
@@ -221,11 +221,25 @@ export const noodleGeneratedPostSchema = z.object({
 export const noodleGeneratedInteractionSchema = z
   .object({
     actorEntityId: z.string().min(1),
-    targetTempId: z.string().min(1).optional(),
-    targetPostId: z.string().min(1).optional(),
+    targetTempId: z
+      .string()
+      .min(1)
+      .nullish()
+      .transform((value) => value ?? undefined),
+    targetPostId: z
+      .string()
+      .min(1)
+      .nullish()
+      .transform((value) => value ?? undefined),
     type: noodleInteractionTypeSchema,
     content: z.string().max(2000).nullable().optional(),
-    pollOptionIndex: z.number().int().min(0).max(3).optional(),
+    pollOptionIndex: z
+      .number()
+      .int()
+      .min(0)
+      .max(3)
+      .nullish()
+      .transform((value) => value ?? undefined),
   })
   .superRefine((interaction, ctx) => {
     if (interaction.type === "vote" && interaction.pollOptionIndex === undefined) {

--- a/packages/shared/src/schemas/noodle.schema.ts
+++ b/packages/shared/src/schemas/noodle.schema.ts
@@ -244,6 +244,11 @@ export const noodleGeneratedInteractionSchema = z
       .min(1)
       .nullish()
       .transform((value) => value ?? undefined),
+    parentInteractionId: z
+      .string()
+      .min(1)
+      .nullish()
+      .transform((value) => value ?? undefined),
     type: noodleInteractionTypeSchema,
     content: z.string().max(2000).nullable().optional(),
     pollOptionIndex: z
@@ -260,6 +265,13 @@ export const noodleGeneratedInteractionSchema = z
         code: z.ZodIssueCode.custom,
         path: ["pollOptionIndex"],
         message: "Poll votes require a poll option index.",
+      });
+    }
+    if (interaction.type !== "reply" && interaction.parentInteractionId !== undefined) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["parentInteractionId"],
+        message: "Only replies can target an existing comment.",
       });
     }
   });

--- a/packages/shared/src/schemas/noodle.schema.ts
+++ b/packages/shared/src/schemas/noodle.schema.ts
@@ -198,6 +198,19 @@ export const noodleRemoveInteractionSchema = z
     }
   });
 
+export const noodleInteractionOwnerSchema = z.object({
+  personaId: z.string().min(1),
+});
+
+export const noodleInteractionUpdateSchema = noodleInteractionOwnerSchema
+  .extend({
+    content: z.string().max(2000).nullable().optional(),
+    imageUrl: z.string().max(2000).nullable().optional(),
+  })
+  .refine((input) => input.content !== undefined || input.imageUrl !== undefined, {
+    message: "Provide comment text or an image update.",
+  });
+
 export const noodleRefreshSchema = z.object({
   personaId: z.string().min(1).optional(),
   connectionId: z.string().min(1).optional(),
@@ -291,6 +304,8 @@ export type NoodleCreatePostInput = z.infer<typeof noodleCreatePostSchema>;
 export type NoodlePostUpdateInput = z.infer<typeof noodlePostUpdateSchema>;
 export type NoodleCreateInteractionInput = z.infer<typeof noodleCreateInteractionSchema>;
 export type NoodleRemoveInteractionInput = z.infer<typeof noodleRemoveInteractionSchema>;
+export type NoodleInteractionOwnerInput = z.infer<typeof noodleInteractionOwnerSchema>;
+export type NoodleInteractionUpdateInput = z.infer<typeof noodleInteractionUpdateSchema>;
 export type NoodleRefreshInput = z.infer<typeof noodleRefreshSchema>;
 export type NoodleRescheduleRefreshInput = z.infer<typeof noodleRescheduleRefreshSchema>;
 export type NoodleGeneratedRefresh = z.infer<typeof noodleGeneratedRefreshSchema>;

--- a/scripts/regressions/noodle-polls.regression.ts
+++ b/scripts/regressions/noodle-polls.regression.ts
@@ -32,10 +32,18 @@ const generated = noodleGeneratedRefreshSchema.parse({
       type: "vote",
       pollOptionIndex: 1,
     },
+    {
+      actorEntityId: "character-1",
+      targetPostId: "existing-post-1",
+      parentInteractionId: "persona-comment-1",
+      type: "reply",
+      content: "A direct answer to the persona comment.",
+    },
   ],
 });
 assert.equal(generated.posts[0]?.poll?.options.length, 2);
 assert.equal(generated.interactions[0]?.pollOptionIndex, 1);
+assert.equal(generated.interactions[1]?.parentInteractionId, "persona-comment-1");
 
 const generatedWithNullPlaceholders = noodleGeneratedRefreshSchema.parse({
   interactions: [
@@ -54,6 +62,19 @@ assert.equal(generatedWithNullPlaceholders.interactions[0]?.pollOptionIndex, und
 assert.equal(
   noodleGeneratedRefreshSchema.safeParse({
     interactions: [{ actorEntityId: "character-2", targetPostId: "post-1", type: "vote" }],
+  }).success,
+  false,
+);
+assert.equal(
+  noodleGeneratedRefreshSchema.safeParse({
+    interactions: [
+      {
+        actorEntityId: "character-2",
+        targetPostId: "post-1",
+        parentInteractionId: "comment-1",
+        type: "like",
+      },
+    ],
   }).success,
   false,
 );

--- a/scripts/regressions/noodle-polls.regression.ts
+++ b/scripts/regressions/noodle-polls.regression.ts
@@ -36,9 +36,30 @@ const generated = noodleGeneratedRefreshSchema.parse({
 });
 assert.equal(generated.posts[0]?.poll?.options.length, 2);
 assert.equal(generated.interactions[0]?.pollOptionIndex, 1);
+
+const generatedWithNullPlaceholders = noodleGeneratedRefreshSchema.parse({
+  interactions: [
+    {
+      actorEntityId: "character-2",
+      targetTempId: "poll-1",
+      targetPostId: null,
+      type: "like",
+      content: null,
+      pollOptionIndex: null,
+    },
+  ],
+});
+assert.equal(generatedWithNullPlaceholders.interactions[0]?.targetPostId, undefined);
+assert.equal(generatedWithNullPlaceholders.interactions[0]?.pollOptionIndex, undefined);
 assert.equal(
   noodleGeneratedRefreshSchema.safeParse({
     interactions: [{ actorEntityId: "character-2", targetPostId: "post-1", type: "vote" }],
+  }).success,
+  false,
+);
+assert.equal(
+  noodleGeneratedRefreshSchema.safeParse({
+    interactions: [{ actorEntityId: "character-2", targetPostId: "post-1", type: "vote", pollOptionIndex: null }],
   }).success,
   false,
 );

--- a/scripts/regressions/noodle-prompt.regression.ts
+++ b/scripts/regressions/noodle-prompt.regression.ts
@@ -4,6 +4,7 @@ import {
   formatNoodleTimelineForPrompt,
   noodlePastMemoryCutoff,
   noodlePastMemorySampleSize,
+  noodlePersonaCommentPostIds,
   NOODLE_PERSONA_AUTHORSHIP_INSTRUCTION,
   noodleTimelineFeatureInstructions,
   sampleNoodlePastMemories,
@@ -62,6 +63,17 @@ const threadedTimeline = formatNoodleTimelineForPrompt(
 assert.match(threadedTimeline, /replyId=persona-comment-1/u);
 assert.match(threadedTimeline, /@smarinara_spaghetti/u);
 assert.match(threadedTimeline, /Mari asks a follow-up question/u);
+assert.deepEqual(
+  noodlePersonaCommentPostIds(
+    [
+      { postId: "old-post-with-new-comment", actorAccountId: "persona-account", type: "reply" },
+      { postId: "other-post", actorAccountId: "character-account", type: "reply" },
+      { postId: "old-post-with-new-comment", actorAccountId: "persona-account", type: "reply" },
+    ],
+    "persona-account",
+  ),
+  ["old-post-with-new-comment"],
+);
 
 const activeAccountsInstruction = "- Use only the active accounts listed by entityId. Do not invent accounts.";
 const imageGenerationInstruction =

--- a/scripts/regressions/noodle-prompt.regression.ts
+++ b/scripts/regressions/noodle-prompt.regression.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import {
   canGenerateNoodleActivityForAccountKind,
+  formatNoodleTimelineForPrompt,
   noodlePastMemoryCutoff,
   noodlePastMemorySampleSize,
   NOODLE_PERSONA_AUTHORSHIP_INSTRUCTION,
@@ -16,6 +17,51 @@ assert.match(
   NOODLE_PERSONA_AUTHORSHIP_INSTRUCTION,
   /Never generate posts, replies, likes, reposts, poll votes, or follows/u,
 );
+
+const threadedTimeline = formatNoodleTimelineForPrompt(
+  [
+    {
+      id: "post-1",
+      authorAccountId: "character-account",
+      authorSnapshot: {
+        id: "character-account",
+        kind: "character",
+        entityId: "character-1",
+        handle: "character_one",
+        displayName: "Character One",
+        avatarUrl: null,
+      },
+      content: "A character post.",
+      imagePrompt: null,
+      metadata: {},
+      createdAt: "2026-07-10T10:00:00.000Z",
+    },
+  ],
+  [
+    {
+      id: "persona-comment-1",
+      postId: "post-1",
+      parentInteractionId: null,
+      actorAccountId: "persona-account",
+      actorSnapshot: {
+        id: "persona-account",
+        kind: "persona",
+        entityId: "persona-1",
+        handle: "smarinara_spaghetti",
+        displayName: "Mari",
+        avatarUrl: null,
+      },
+      type: "reply",
+      content: "Mari asks a follow-up question.",
+      imageUrl: null,
+      createdAt: "2026-07-10T10:05:00.000Z",
+    },
+  ],
+  { priorityActorAccountId: "persona-account" },
+);
+assert.match(threadedTimeline, /replyId=persona-comment-1/u);
+assert.match(threadedTimeline, /@smarinara_spaghetti/u);
+assert.match(threadedTimeline, /Mari asks a follow-up question/u);
 
 const activeAccountsInstruction = "- Use only the active accounts listed by entityId. Do not invent accounts.";
 const imageGenerationInstruction =

--- a/scripts/regressions/noodle-prompt.regression.ts
+++ b/scripts/regressions/noodle-prompt.regression.ts
@@ -1,10 +1,21 @@
 import assert from "node:assert/strict";
 import {
+  canGenerateNoodleActivityForAccountKind,
   noodlePastMemoryCutoff,
   noodlePastMemorySampleSize,
+  NOODLE_PERSONA_AUTHORSHIP_INSTRUCTION,
   noodleTimelineFeatureInstructions,
   sampleNoodlePastMemories,
 } from "../../packages/server/src/services/noodle/noodle-prompt.js";
+
+assert.equal(canGenerateNoodleActivityForAccountKind("persona"), false);
+assert.equal(canGenerateNoodleActivityForAccountKind("character"), true);
+assert.equal(canGenerateNoodleActivityForAccountKind("random_user"), true);
+assert.match(NOODLE_PERSONA_AUTHORSHIP_INSTRUCTION, /controlled exclusively by the user/u);
+assert.match(
+  NOODLE_PERSONA_AUTHORSHIP_INSTRUCTION,
+  /Never generate posts, replies, likes, reposts, poll votes, or follows/u,
+);
 
 const activeAccountsInstruction = "- Use only the active accounts listed by entityId. Do not invent accounts.";
 const imageGenerationInstruction =


### PR DESCRIPTION
## Why

Noodle needed a hard persona-ownership boundary and reliable continuing interactions:

- Timeline generation could attribute activity to the user persona. The persona must remain exclusively user-controlled.
- Characters could not see or directly answer existing persona comments during later refreshes.
- Posts receiving new replies stayed buried at their original creation position.
- Persona-authored comments could not be edited or deleted.
- Replying to a comment opened the composer above the selected comment.
- The Notifications badge counted full history rather than unread activity.
- Poll refreshes could fail on valid optional `null` placeholders.
- Liked hearts were too subtle.

## What changed

- Mark personas as reference-target-only and reject every model-generated persona post, reply, like, repost, vote, or follow server-side.
- Include recent 48-hour thread context in refresh prompts, prioritizing persona comments with exact `replyId`, author, handle, content, and parent information.
- Allow generated replies to target a validated existing comment through `parentInteractionId`.
- Sort the main and following timelines by latest reply activity so active threads rise naturally.
- Add persona-owned comment editing and deletion with ownership checks and nested-reply/like cleanup.
- Render reply composers directly beneath selected comments.
- Track per-persona Notifications read timestamps while preserving history.
- Normalize harmless generated optional nulls while retaining vote validation.
- Fill liked post and comment hearts with Noodle blue.
- Add regressions for persona generation policy, threaded prompt context, parent-comment validation, activity bumping, comment ownership, reply placement, unread badges, poll parsing, and liked-heart state.

## Impact

The model can mention or respond to the persona but can never act as the persona. Characters can continue conversations from the user comments visible in recent or recalled Noodle history, and posts with new replies return to the top of the timeline. Users can also edit or remove their own comments without resetting the timeline.

## Validation

- `pnpm check`
- `pnpm regression:noodle`
- `pnpm exec playwright test -c playwright.config.ts e2e/core-flows.e2e.ts --project=desktop-chromium --grep "Noodle persona comments"`
- `pnpm exec playwright test -c playwright.config.ts e2e/core-flows.e2e.ts --project=mobile-chromium --grep "Noodle reply notifications"`
- `pnpm exec playwright test -c playwright.config.ts e2e/core-flows.e2e.ts --project=desktop-chromium --grep "liking one Noodle post"`

## Manual verification requested

- Manually refresh Noodle and confirm no generated activity is authored by a persona.
- Reply as a persona to an existing character post, refresh, and confirm a character can answer that specific comment.
- Confirm a post with a fresh reply rises above newer inactive posts.
- Verify persona comments can be edited and deleted while character comments expose neither control.
- Verify comment reply placement, unread badge clearing, solid liked hearts, and generated poll votes.

No linked issue was provided; link or open one before review if required by project policy.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Notification badges now show only unread activity and clear when notifications are opened.
  * Persona-authored comments can be edited or deleted, while other authors’ comments remain protected.
  * Reply composers are more consistently positioned and connected to the selected comment.
  * Timelines better prioritize recent posts, replies, polls, and threaded conversations.

* **Bug Fixes**
  * Improved reaction-state visuals and notification navigation.
  * Prevented unauthorized comment modifications and invalid generated interactions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->