### PR TITLE
Fix turn-game narration leaking model chain-of-thought into chat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 
 ### Fixed
 
+- Fixed turn-game bot table talk and dealer announcements leaking the model's chain-of-thought into chat when the connected model emits inline reasoning (e.g. a leading `<think>` block): narration now strips inline reasoning like the main generation pipeline, falls back to the factual event line when the output was all reasoning, and gets a larger output budget so reasoning models can still land the spoken line (#3427).
 - Completed Noodle's automatic timeline refresh scheduling: daily refresh times are now distributed across persisted local-day windows, survive restarts, collapse overdue slots into one catch-up refresh, retry safely after failures, and update an open Noodle timeline automatically.
 - Fixed PocketTTS voice refresh so built-in and custom voices returned by the provider `/v1/voices` endpoint are listed, including custom voices identified by URL/path fields (#3410).
 - Fixed Conversation Call live-mic input so Local Whisper/provider media submissions cannot queue unbounded speech segments and lock the call UI behind repeated "too many requests" failures (#3411).

--- a/packages/server/src/services/turn-games/turn-game-bot-runner.service.ts
+++ b/packages/server/src/services/turn-games/turn-game-bot-runner.service.ts
@@ -14,11 +14,13 @@
 // Invoked from the /api/generate handler ONLY when input.turnGameBots is set,
 // so it can never affect a normal conversation/roleplay generation.
 import type { FastifyReply } from "fastify";
+import { BUILT_IN_THINKING_TAG_PAIRS } from "@marinara-engine/shared";
 import type { DB } from "../../db/connection.js";
 import { logDebugOverride, logger } from "../../lib/logger.js";
 import { isDebugAgentsEnabled } from "../../config/runtime-config.js";
 import type { BaseLLMProvider, ChatMessage, LLMToolDefinition } from "../llm/base-provider.js";
 import { createLLMProvider } from "../llm/provider-registry.js";
+import { extractLeadingThinkingBlocks } from "../llm/inline-thinking.js";
 import { trySendSseEvent } from "../../routes/generate/sse.js";
 import { createCharactersStorage } from "../storage/characters.storage.js";
 import { createChatsStorage } from "../storage/chats.storage.js";
@@ -476,6 +478,23 @@ export async function runTurnGameBotTurns(args: RunBotTurnsArgs): Promise<void> 
   }
 }
 
+/**
+ * Reasoning models can emit their chain-of-thought inline in `content` (e.g. a
+ * leading `<think>` block) instead of a provider-native thinking channel. The
+ * generation pipeline strips these before persisting; narration must too, or
+ * the reasoning gets saved verbatim as the character's table talk. When the
+ * closing tag never arrived (maxTokens ran out mid-thought), extraction leaves
+ * the opening tag at the front — everything after it is reasoning, so the line
+ * is unusable and we return "" to let the caller's fallback run.
+ * Exported for tests.
+ */
+export function stripInlineThinking(raw: string): string {
+  const trimmed = extractLeadingThinkingBlocks(raw).content.trim();
+  const lower = trimmed.toLocaleLowerCase();
+  if (BUILT_IN_THINKING_TAG_PAIRS.some((pair) => lower.startsWith(pair.open.toLocaleLowerCase()))) return "";
+  return trimmed;
+}
+
 async function narrateOutcome(
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   provider: any,
@@ -496,13 +515,16 @@ async function narrateOutcome(
           `${persona}\n\n` +
           `You are playing ${gameLabel} with friends. Speak ONE short, natural line as ${name}, fully in character. ` +
           `You may react to the table talk and/or to your own move — like a real person at the table (a quip, a taunt, a groan, a little flourish). ` +
-          `Hard rules: do NOT reveal your hand or any hidden information, do NOT recite the board state, and do NOT explain the rules or your strategy. Just talk.`,
+          `Hard rules: do NOT reveal your hand or any hidden information, do NOT recite the board state, and do NOT explain the rules or your strategy. ` +
+          `Reply with the spoken line ONLY — no reasoning, no preamble, no notes about what you are doing. Just talk.`,
       },
       ...(recent ? [{ role: "user" as const, content: `Recent table talk:\n${recent}` }] : []),
       { role: "user", content: `(You just ${did}.) Say your one line.` },
     ];
-    const res = await provider.chatComplete(messages, { model, temperature: 0.9, maxTokens: 100, ...(signal ? { signal } : {}) });
-    return (res.content ?? "").trim();
+    // maxTokens leaves headroom for reasoning models that think before the line;
+    // stripInlineThinking removes what they emit inline.
+    const res = await provider.chatComplete(messages, { model, temperature: 0.9, maxTokens: 300, ...(signal ? { signal } : {}) });
+    return stripInlineThinking(res.content ?? "");
   } catch {
     return "";
   }
@@ -525,7 +547,7 @@ async function narrateAnnouncements(
           `${persona}\n\n` +
           `You are the dealer at this table's game of ${gameLabel}. Announce the following to the table in ONE ` +
           `short line, fully in character — you may add flourish, teasing, or ceremony, but every fact below must ` +
-          `come through accurately. Facts: ${eventSummary}`,
+          `come through accurately. Reply with the announcement ONLY — no reasoning, no preamble. Facts: ${eventSummary}`,
       },
     ];
     // Prompt visibility for the new dealer-narration call: honors DEBUG_AGENTS
@@ -539,10 +561,10 @@ async function narrateAnnouncements(
     const res = await provider.chatComplete(messages, {
       model,
       temperature: 0.85,
-      maxTokens: 120,
+      maxTokens: 300,
       ...(signal ? { signal } : {}),
     });
-    return (res.content ?? "").trim();
+    return stripInlineThinking(res.content ?? "");
   } catch {
     return "";
   }


### PR DESCRIPTION
## Linked issue

Closes #3427

## Why this change

When the connected model is a reasoning model that emits its chain-of-thought inline in `content` (a leading `<think>`/`<thinking>` block) instead of a provider-native thinking channel, turn-game narration saves that reasoning verbatim as the character's chat message. With the previous 100/120-token narration budgets the reasoning routinely ate the whole budget, so what landed in chat was a truncated meta monologue ("The user wants me to say one short, natural line as … Let me think of something she would say -") instead of a spoken line. This affects all four turn games (UNO, chess, poker, 8-ball): both the bot's post-move table talk and the dealer/announcer lines.

The main generation pipeline already strips these blocks (`extractLeadingThinkingBlocks` in `generate.routes.ts` / `game.routes.ts`); the turn-game bot runner predates none of that but never adopted it.

## What changed

All changes are in `packages/server/src/services/turn-games/turn-game-bot-runner.service.ts` (plus a CHANGELOG entry):

- New `stripInlineThinking()` helper applied to both narration paths (`narrateOutcome`, `narrateAnnouncements`): strips leading inline thinking blocks using the same shared extractor as the generation pipeline, and — the case a plain strip cannot recover — returns an empty line when an **unclosed** opening tag remains at the front (maxTokens ran out mid-thought, so everything present is reasoning). Both call sites already fall back to the factual event summary on an empty line, so the worst case is now a dry-but-correct line instead of leaked chain-of-thought.
- Narration `maxTokens` raised from 100/120 to 300 so reasoning models have headroom to finish thinking and still produce the spoken line.
- Prompt hardening on both narration prompts: "Reply with the spoken line ONLY — no reasoning, no preamble."
- The bot **move** call is untouched — it only consumes `res.toolCalls`, so inline reasoning there was never persisted.

## Validation

- [ ] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed `CONTRIBUTING.md`

### Manual verification notes

Done so far:

- `pnpm check` (typecheck + lint + build) passes locally.
- Local unit tests on `stripInlineThinking` (11 cases): plain lines pass through; closed `<think>`/`<thinking>`/`[think]` blocks stripped (case-insensitive, multiple consecutive blocks); the exact truncated-unclosed-block shape from the bug report returns empty (fallback path); tags mentioned mid-line are not treated as thinking.

Still to verify manually before promoting:

- Live turn-game session with a reasoning model: bot table talk and announcer lines contain only the spoken line.
- Live session with a non-reasoning model: narration behavior unchanged.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Version/release files updated (only if this PR includes a version bump)

CHANGELOG entry added under [Unreleased] → Fixed. No version bump; no other docs reference turn-game narration internals.

## UI evidence (if applicable)

Server-side narration fix — the user-visible effect is the *absence* of leaked reasoning in chat. The linked issue quotes the leaked message this fixes.
