### PR TITLE
Fix custom preset choice confirmation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 
 ### Fixed
 
+- Fixed custom and imported preset variables disabling **Confirm Choices** when a valid blank-valued option was selected (#3429).
 - Fixed turn-game bot table talk and dealer announcements leaking the model's chain-of-thought into chat when the connected model emits inline reasoning (e.g. a leading `<think>` block): narration now strips inline reasoning like the main generation pipeline, falls back to the factual event line when the output was all reasoning, and gets a larger output budget so reasoning models can still land the spoken line (#3427).
 - Fixed comma-separated lorebook activation-key input so pasted key lists are trimmed, split, and deduplicated into individual keys (#3422).
 - Fixed grouped Conversation reactions on mobile by keeping each speaker's reaction button visible and removing the ambiguous whole-block reaction target (#3424).

--- a/packages/client/src/components/presets/ChoiceSelectionModal.tsx
+++ b/packages/client/src/components/presets/ChoiceSelectionModal.tsx
@@ -10,6 +10,7 @@ import { usePresetFull, useUpdatePreset } from "../../hooks/use-presets";
 import { useUpdateChatMetadata } from "../../hooks/use-chats";
 import { CheckCircle2, Circle, CheckSquare2, Square, ListChecks, Shuffle, Save } from "lucide-react";
 import { cn } from "../../lib/utils";
+import { arePresetChoiceSelectionsComplete } from "../../lib/preset-choice-selection";
 import { SettingsSwitch } from "../panels/settings/SettingControls";
 
 interface ChoiceSelectionModalProps {
@@ -174,13 +175,7 @@ export function ChoiceSelectionModal({
   // Merged view: base + user overrides
   const selections = useMemo(() => ({ ...baseSelections, ...overrides }), [baseSelections, overrides]);
 
-  const allSelected = variables.every((v) => {
-    const sel = selections[v.variableName];
-    if (v.multiSelect) return Array.isArray(sel);
-    // Single-option variables are boolean toggles — both ON and OFF are valid
-    if (v.options.length === 1) return sel !== undefined;
-    return sel !== undefined && sel !== "";
-  });
+  const allSelected = arePresetChoiceSelectionsComplete(variables, selections);
 
   const handleConfirm = useCallback(() => {
     // Save selections to chat metadata

--- a/packages/client/src/lib/preset-choice-selection.ts
+++ b/packages/client/src/lib/preset-choice-selection.ts
@@ -1,0 +1,30 @@
+export type PresetChoiceSelections = Record<string, string | string[]>;
+
+interface PresetChoiceVariable {
+  variableName: string;
+  options: ReadonlyArray<{ value: string }>;
+  multiSelect: boolean;
+}
+
+/**
+ * Check whether every preset variable has a valid UI selection.
+ *
+ * An empty string is a valid single-select value: preset authors use blank
+ * options to mean "insert nothing". Boolean variables and empty multi-select
+ * arrays are also intentionally valid states.
+ */
+export function arePresetChoiceSelectionsComplete(
+  variables: readonly PresetChoiceVariable[],
+  selections: PresetChoiceSelections,
+): boolean {
+  return variables.every((variable) => {
+    const selection = selections[variable.variableName];
+
+    if (variable.multiSelect) return Array.isArray(selection);
+    if (variable.options.length === 1) return typeof selection === "string";
+
+    return (
+      typeof selection === "string" && variable.options.some((option) => option.value === selection)
+    );
+  });
+}

--- a/scripts/regressions/open-issues.regression.ts
+++ b/scripts/regressions/open-issues.regression.ts
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
 import { appendLorebookActivationKeys } from "../../packages/client/src/lib/lorebook-keys.js";
+import { arePresetChoiceSelectionsComplete } from "../../packages/client/src/lib/preset-choice-selection.js";
 import {
   isBundledGameAssetFolderPath,
   isBundledGameAssetPath,
@@ -24,5 +25,40 @@ assert.equal(isBundledGameAssetPath("../package.json"), false);
 assert.equal(isGitUpdateApplyAllowed({ updatesApplyEnabled: false, localChannelSwitchRequested: false }), false);
 assert.equal(isGitUpdateApplyAllowed({ updatesApplyEnabled: false, localChannelSwitchRequested: true }), true);
 assert.equal(isGitUpdateApplyAllowed({ updatesApplyEnabled: true, localChannelSwitchRequested: false }), true);
+
+const choiceVariables = [
+  {
+    variableName: "optional_instruction",
+    options: [{ value: "" }, { value: "Add the instruction" }],
+    multiSelect: false,
+  },
+  {
+    variableName: "boolean_toggle",
+    options: [{ value: "Enabled" }],
+    multiSelect: false,
+  },
+  {
+    variableName: "tags",
+    options: [{ value: "Action" }, { value: "Romance" }],
+    multiSelect: true,
+  },
+] as const;
+
+assert.equal(
+  arePresetChoiceSelectionsComplete(choiceVariables, {
+    optional_instruction: "",
+    boolean_toggle: "",
+    tags: [],
+  }),
+  true,
+);
+assert.equal(
+  arePresetChoiceSelectionsComplete(choiceVariables, {
+    optional_instruction: "not-an-option",
+    boolean_toggle: "",
+    tags: [],
+  }),
+  false,
+);
 
 console.info("Open-issue regressions passed.");


### PR DESCRIPTION
## Linked issue

Closes #3429

## Why

Custom and imported presets may intentionally use a blank option value to mean “insert nothing.” The choice modal treated that valid value as an incomplete selection, so choosing it disabled **Confirm Choices** and trapped the user in the editor.

## What changed

- Validate single-select choices by membership in the preset options instead of string truthiness.
- Keep blank-valued options, Boolean-off states, and empty multi-select arrays confirmable.
- Reject stale single-select values that are not present in the current preset.
- Add focused regression coverage and an Unreleased changelog entry.

## Validation performed

- `pnpm check`
- `pnpm test`
- `pnpm regression:issues`

## Manual verification requested

- Manually verify a custom/imported Roleplay preset can confirm a blank-valued option.
- Manually verify normal radio, Boolean, and multi-select preset choices still save correctly.