### PR TITLE
Polish Noodle, lorebooks, image prompts, and saved commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 
 ### Added
 
+- Added prefix-matched `@handle` suggestions to Noodle post and reply composers, with click, touch, and keyboard insertion.
 - Added OpenAI GPT-5.6 Sol/Terra/Luna model support, including the `gpt-5.6` Sol alias, a `gpt-5.6-sol-pro` pro-mode alias, Responses API routing, GPT-5.6 `max` reasoning effort mapping, and reuse of the existing Exclude Past Reasoning toggle for GPT-5.6 reasoning context.
 - Added the first Noodle fake-social-media surface: a top-bar Noodle tab, persona-linked user profiles, character invites, a scrollable fake timeline with posts/replies/likes/reposts, configurable refresh generation, stored image-prompt slots, and optional recent-social activity carryover into Conversation, Roleplay/VN, and Game prompts using the chat preset wrapper.
 - Added long-term Noodle timeline recall: refreshes can now sample up to three posts older than 48 hours so characters may naturally remember, revisit, or interact with past activity.
@@ -24,11 +25,14 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 
 - Restyled Noodle around the Klusek blue logo asset, replacing the always-visible settings column with a profile-triggered drawer and a more Twitter-like central feed.
 - Updated Noodle image prompt generation so character posts may request either character-focused images or in-character memes when image generation is enabled.
+- Updated Noodle timeline generation guidance so characters and random users know they may occasionally create and vote in polls and naturally use Unicode emoji in posts and replies; when random users are enabled, they may also very occasionally post clearly fictional parody ads or absurd fake crypto scams.
 - Updated Noodle settings so selected character folders can be bulk-invited directly, and automated refreshes can be disabled by setting refreshes per day to `0`.
 - Updated Noodle posts with edit/delete actions for every post, toggleable likes/reposts, a confirmed timeline reset control, multi-character image references, and automatic character-gallery saves for generated character post images.
 
 ### Fixed
 
+- Fixed the Noodle reply image picker separator inheriting a pink chrome accent instead of using Noodle blue.
+- Fixed character-authored Noodle comments being read-only; their edit and delete controls now use the same flow as persona comments, while generated random-user comments remain protected.
 - Fixed custom and imported preset variables disabling **Confirm Choices** when a valid blank-valued option was selected (#3429).
 - Fixed turn-game bot table talk and dealer announcements leaking the model's chain-of-thought into chat when the connected model emits inline reasoning (e.g. a leading `<think>` block): narration now strips inline reasoning like the main generation pipeline, falls back to the factual event line when the output was all reasoning, and gets a larger output budget so reasoning models can still land the spoken line (#3427).
 - Fixed comma-separated lorebook activation-key input so pasted key lists are trimmed, split, and deduplicated into individual keys (#3422).

--- a/e2e/core-flows.e2e.ts
+++ b/e2e/core-flows.e2e.ts
@@ -542,9 +542,7 @@ test("liking one Noodle post leaves unrelated reaction controls visually stable"
   }
 });
 
-test("Noodle persona comments can be edited and deleted without exposing character comments", async ({
-  page,
-}, testInfo) => {
+test("Noodle persona and character comments can be edited and deleted", async ({ page }, testInfo) => {
   test.skip(!testInfo.project.name.includes("desktop"), "Comment ownership controls are covered on desktop.");
 
   const errors = collectUnexpectedErrors(page);
@@ -616,12 +614,6 @@ test("Noodle persona comments can be edited and deleted without exposing charact
     expect(childReplyResponse.ok()).toBe(true);
     const childReply = (await childReplyResponse.json()) as { id: string };
 
-    const unauthorizedEditResponse = await page.request.patch(
-      `/api/noodle/posts/${postId}/interactions/${childReply.id}`,
-      { data: { personaId, content: "This must be rejected." } },
-    );
-    expect(unauthorizedEditResponse.status()).toBe(403);
-
     await page.goto("/");
     await page.locator('[data-tour="noodle-tab"]').click();
 
@@ -641,8 +633,21 @@ test("Noodle persona comments can be edited and deleted without exposing charact
     ).toBe(true);
     await expect(ownComment.getByRole("button", { name: "Edit comment" })).toBeVisible();
     await expect(ownComment.getByRole("button", { name: "Delete comment" })).toBeVisible();
-    await expect(characterComment.getByRole("button", { name: "Edit comment" })).toHaveCount(0);
-    await expect(characterComment.getByRole("button", { name: "Delete comment" })).toHaveCount(0);
+    await expect(characterComment.getByRole("button", { name: "Edit comment" })).toBeVisible();
+    await expect(characterComment.getByRole("button", { name: "Delete comment" })).toBeVisible();
+
+    await characterComment.getByRole("button", { name: "Edit comment" }).click();
+    const characterEditor = characterComment.locator('[data-component="NoodleView.CommentEditor"]');
+    await characterEditor.getByRole("textbox", { name: "Edit comment" }).fill("Edited character reply.");
+    await characterEditor.getByRole("button", { name: "Save" }).click();
+    await expect(characterComment).toContainText("Edited character reply.");
+
+    await characterComment.getByRole("button", { name: "Delete comment" }).click();
+    const characterDeleteDialog = page.getByRole("dialog", { name: "Delete Noodle Comment" });
+    await expect(characterDeleteDialog).toBeVisible();
+    await characterDeleteDialog.getByRole("button", { name: "Delete comment" }).click();
+    await expect(characterComment).toHaveCount(0);
+    await expect(ownComment).toBeVisible();
 
     await ownComment.getByRole("button", { name: "Edit comment" }).click();
     const editor = ownComment.locator('[data-component="NoodleView.CommentEditor"]');
@@ -664,6 +669,110 @@ test("Noodle persona comments can be edited and deleted without exposing charact
     }
     if (controlPostId) {
       await page.request.delete(`/api/noodle/posts/${controlPostId}`, { timeout: 5_000 }).catch(() => undefined);
+    }
+    if (createdPersonaId) {
+      await page.request
+        .delete(`/api/characters/personas/${createdPersonaId}`, { timeout: 5_000 })
+        .catch(() => undefined);
+    }
+  }
+});
+
+test("Noodle post and reply composers autocomplete character handles", async ({ page }) => {
+  const errors = collectUnexpectedErrors(page);
+  let personaId: string | null = null;
+  let createdPersonaId: string | null = null;
+  let postId: string | null = null;
+
+  try {
+    const activePersonaResponse = await page.request.get("/api/characters/personas/active");
+    const activePersona = activePersonaResponse.ok()
+      ? ((await activePersonaResponse.json()) as { id?: string } | null)
+      : null;
+    personaId = activePersona?.id ?? null;
+    if (!personaId) {
+      const personaResponse = await page.request.post("/api/characters/personas", {
+        data: { name: "Noodle Mention Tester", description: "Temporary browser regression persona." },
+      });
+      expect(personaResponse.ok()).toBe(true);
+      const createdPersona = (await personaResponse.json()) as { id: string };
+      personaId = createdPersona.id;
+      createdPersonaId = createdPersona.id;
+      const activateResponse = await page.request.put(`/api/characters/personas/${createdPersona.id}/activate`);
+      expect(activateResponse.ok()).toBe(true);
+    }
+
+    const bootstrapResponse = await page.request.get("/api/noodle");
+    expect(bootstrapResponse.ok()).toBe(true);
+    const bootstrap = (await bootstrapResponse.json()) as {
+      accounts: Array<{ entityId: string; handle: string; kind: string; invited: boolean }>;
+    };
+    const mentionAccount = bootstrap.accounts.find(
+      (account) => account.kind === "character" && account.invited && account.handle.length > 0,
+    );
+    expect(mentionAccount).toBeDefined();
+
+    const postResponse = await page.request.post("/api/noodle/posts", {
+      data: {
+        authorKind: "character",
+        authorEntityId: mentionAccount!.entityId,
+        content: `Mention autocomplete regression ${Date.now()}`,
+      },
+    });
+    expect(postResponse.ok()).toBe(true);
+    const post = (await postResponse.json()) as { id: string };
+    postId = post.id;
+    const commentResponse = await page.request.post(`/api/noodle/posts/${post.id}/interactions`, {
+      data: {
+        actorKind: "character",
+        actorEntityId: mentionAccount!.entityId,
+        type: "reply",
+        content: "A comment waiting for a tagged response.",
+      },
+    });
+    expect(commentResponse.ok()).toBe(true);
+    const comment = (await commentResponse.json()) as { id: string };
+
+    await page.goto("/");
+    await page.locator('[data-tour="noodle-tab"]').click();
+
+    const noodle = page.locator('[data-component="NoodleView"]');
+    const mentionPrefix = mentionAccount!.handle.slice(0, Math.min(2, mentionAccount!.handle.length));
+    const inlineComposer = noodle.locator('[data-component="NoodleView.InlineComposer"]');
+    const postTextarea = inlineComposer.getByPlaceholder("What's simmering?");
+    await postTextarea.fill(`Hello @${mentionPrefix}`);
+
+    const postMentionList = page.locator("#noodle-inline-mention-list");
+    await expect(postMentionList).toBeVisible();
+    const postMentionOption = postMentionList
+      .getByRole("option")
+      .filter({ hasText: `@${mentionAccount!.handle}` });
+    await expect(postMentionOption).toBeVisible();
+    await postMentionOption.click();
+    await expect(postTextarea).toHaveValue(`Hello @${mentionAccount!.handle} `);
+
+    const activePost = noodle.locator(`[data-noodle-post-id="${postId}"]`);
+    const targetComment = activePost.locator(`[data-noodle-interaction-id="${comment.id}"]`);
+    await targetComment.getByTitle("Reply").click();
+    const replyComposer = activePost.locator(
+      `[data-component="NoodleView.ReplyComposer"][data-noodle-reply-parent-id="${comment.id}"]`,
+    );
+    const replyTextarea = replyComposer.getByPlaceholder("Leave a comment…");
+    await replyTextarea.fill(`Replying @${mentionAccount!.handle}`);
+
+    const replyMentionList = page.locator("#noodle-reply-mention-list");
+    await expect(replyMentionList).toBeVisible();
+    const replyMentionOption = replyMentionList
+      .getByRole("option")
+      .filter({ hasText: `@${mentionAccount!.handle}` });
+    await expect(replyMentionOption).toBeVisible();
+    await replyTextarea.press("Tab");
+    await expect(replyTextarea).toHaveValue(`Replying @${mentionAccount!.handle} `);
+
+    expect(errors).toEqual([]);
+  } finally {
+    if (postId) {
+      await page.request.delete(`/api/noodle/posts/${postId}`, { timeout: 5_000 }).catch(() => undefined);
     }
     if (createdPersonaId) {
       await page.request
@@ -754,6 +863,11 @@ test("Noodle reply notifications focus the actionable timeline reply", async ({ 
         return Boolean(target && target.compareDocumentPosition(composer) & Node.DOCUMENT_POSITION_FOLLOWING);
       }, reply.id),
     ).toBe(true);
+
+    await nestedComposer.getByTitle("Attach image").click();
+    const replyImageDivider = page.locator('[data-component="NoodleView.ReplyImageDivider"]');
+    await expect(replyImageDivider).toBeVisible();
+    await expect(replyImageDivider).toHaveCSS("color", "rgb(126, 167, 255)");
 
     expect(errors).toEqual([]);
   } finally {

--- a/packages/client/src/components/noodle/NoodleView.tsx
+++ b/packages/client/src/components/noodle/NoodleView.tsx
@@ -46,6 +46,7 @@ import {
 import { createPortal } from "react-dom";
 import { toast } from "sonner";
 import {
+  canManageNoodleReply,
   findNoodleTextMentions,
   noodleTextMentionsHandle as textMentionsHandle,
   readNoodlePollFromMetadata,
@@ -112,6 +113,7 @@ const NOODLE_NOTIFICATIONS_READ_AT_KEY = "notificationsReadAt";
 const NOODLE_FOLLOWED_AT_BY_ACCOUNT_KEY = "followingAccountTimestamps";
 const NOODLE_INVITE_PAGE_SIZE = 50;
 const NOODLE_PERSONA_SWITCHER_PAGE_SIZE = 5;
+const NOODLE_MENTION_SUGGESTION_LIMIT = 8;
 const NOODLE_CARRYOVER_TARGETS: NoodleCarryoverTarget[] = ["conversation", "roleplay", "game"];
 const NOODLE_MEDIA_PICKER_TABS: ConversationMediaPickerTab[] = [
   { id: "emoji", label: "Emoji" },
@@ -270,6 +272,14 @@ function activeComposerMention(value: string, caret: number): ActiveComposerMent
   return { handle: query.toLowerCase(), query: query.toLowerCase(), start, end: caret };
 }
 
+function matchingMentionAccounts(accounts: NoodleAccount[], activeMention: ActiveComposerMention | null) {
+  if (!activeMention) return [];
+  return accounts
+    .filter((account) => account.handle.toLowerCase().startsWith(activeMention.query))
+    .sort((left, right) => left.handle.localeCompare(right.handle))
+    .slice(0, NOODLE_MENTION_SUGGESTION_LIMIT);
+}
+
 function characterName(character: RawCharacter) {
   const data = parseRecord(character.data);
   return readString(data.name).trim() || "Character";
@@ -374,6 +384,58 @@ function Avatar({
       )}
     >
       {initials(account.displayName)}
+    </div>
+  );
+}
+
+function NoodleMentionSuggestions({
+  activeMention,
+  activeIndex,
+  accounts,
+  listboxId,
+  onSelect,
+}: {
+  activeMention: ActiveComposerMention | null;
+  activeIndex: number;
+  accounts: NoodleAccount[];
+  listboxId: string;
+  onSelect: (account: NoodleAccount) => void;
+}) {
+  if (!activeMention) return null;
+  return (
+    <div
+      id={listboxId}
+      role="listbox"
+      aria-label="Tag a character"
+      className="relative z-40 mt-1 max-h-56 overflow-y-auto rounded-xl border border-[var(--noodle-divider)] bg-[var(--background)] p-1 shadow-xl shadow-black/25"
+    >
+      {accounts.length > 0 ? (
+        accounts.map((account, index) => (
+          <button
+            key={account.id}
+            id={`${listboxId}-option-${index}`}
+            type="button"
+            role="option"
+            aria-selected={index === activeIndex}
+            onPointerDown={(event) => event.preventDefault()}
+            onClick={() => onSelect(account)}
+            className={cn(
+              "flex min-h-11 w-full items-center gap-3 rounded-lg px-2 py-1.5 text-left transition-colors",
+              index === activeIndex ? "bg-[var(--noodle-blue)]/15" : "hover:bg-[var(--noodle-blue)]/10",
+            )}
+          >
+            <Avatar account={account} size="sm" />
+            <span className="min-w-0 flex-1">
+              <span className="block truncate text-xs font-semibold">{account.displayName}</span>
+              <span className="block truncate text-[0.68rem] text-[var(--noodle-blue)]">@{account.handle}</span>
+            </span>
+          </button>
+        ))
+      ) : (
+        <p className="px-3 py-2 text-xs text-[var(--muted-foreground)]">
+          No invited character matches @{activeMention.query}.
+        </p>
+      )}
     </div>
   );
 }
@@ -760,6 +822,7 @@ export function NoodleView() {
   const imageFileRef = useRef<HTMLInputElement | null>(null);
   const inlineComposerRef = useRef<HTMLTextAreaElement | null>(null);
   const modalComposerRef = useRef<HTMLTextAreaElement | null>(null);
+  const replyComposerRef = useRef<HTMLTextAreaElement | null>(null);
   const replyImageFileRef = useRef<HTMLInputElement | null>(null);
   const avatarFileRef = useRef<HTMLInputElement | null>(null);
   const bannerFileRef = useRef<HTMLInputElement | null>(null);
@@ -824,6 +887,8 @@ export function NoodleView() {
   const [replyPostId, setReplyPostId] = useState<string | null>(null);
   const [replyParentInteractionId, setReplyParentInteractionId] = useState<string | null>(null);
   const [replyText, setReplyText] = useState("");
+  const [activeReplyMention, setActiveReplyMention] = useState<ActiveComposerMention | null>(null);
+  const [activeReplyMentionIndex, setActiveReplyMentionIndex] = useState(0);
   const [replyImageUrl, setReplyImageUrl] = useState("");
   const [replyImageUrlDraft, setReplyImageUrlDraft] = useState("");
   const [activeReplyComposerTool, setActiveReplyComposerTool] = useState<ReplyComposerTool | null>(null);
@@ -1152,6 +1217,8 @@ export function NoodleView() {
     setReplyPostId(null);
     setReplyParentInteractionId(null);
     setReplyText("");
+    setActiveReplyMention(null);
+    setActiveReplyMentionIndex(0);
     setReplyImageUrl("");
     setReplyImageUrlDraft("");
     setActiveReplyComposerTool(null);
@@ -1165,6 +1232,8 @@ export function NoodleView() {
     setReplyPostId(postId);
     setReplyParentInteractionId(parentInteractionId);
     setReplyText("");
+    setActiveReplyMention(null);
+    setActiveReplyMentionIndex(0);
     setReplyImageUrl("");
     setReplyImageUrlDraft("");
     setActiveReplyComposerTool(null);
@@ -1297,15 +1366,12 @@ export function NoodleView() {
     [accounts, folderInvitedCharacterIds],
   );
   const mentionSuggestions = useMemo(() => {
-    if (!activeMention) return [];
-    const query = activeMention.query;
-    return mentionableCharacterAccounts
-      .filter(
-        (account) =>
-          !query || account.handle.toLowerCase().includes(query) || account.displayName.toLowerCase().includes(query),
-      )
-      .slice(0, 6);
+    return matchingMentionAccounts(mentionableCharacterAccounts, activeMention);
   }, [activeMention, mentionableCharacterAccounts]);
+  const replyMentionSuggestions = useMemo(
+    () => matchingMentionAccounts(mentionableCharacterAccounts, activeReplyMention),
+    [activeReplyMention, mentionableCharacterAccounts],
+  );
   const selectedFolderCharacterIds = useMemo(() => Array.from(folderInvitedCharacterIds), [folderInvitedCharacterIds]);
   const uninvitedSelectedFolderCharacterIds = useMemo(
     () => selectedFolderCharacterIds.filter((id) => characterAccountByEntity.get(id)?.invited !== true),
@@ -1710,43 +1776,61 @@ export function NoodleView() {
   };
 
   const renderComposerMentionSuggestions = (listboxId: string) => {
-    if (!activeMention) return null;
     return (
-      <div
-        id={listboxId}
-        role="listbox"
-        aria-label="Tag a character"
-        className="relative z-40 mt-1 max-h-56 overflow-y-auto rounded-xl border border-[var(--noodle-divider)] bg-[var(--background)] p-1 shadow-xl shadow-black/25"
-      >
-        {mentionSuggestions.length > 0 ? (
-          mentionSuggestions.map((account, index) => (
-            <button
-              key={account.id}
-              id={`${listboxId}-option-${index}`}
-              type="button"
-              role="option"
-              aria-selected={index === activeMentionIndex}
-              onPointerDown={(event) => event.preventDefault()}
-              onClick={() => selectComposerMention(account)}
-              className={cn(
-                "flex min-h-11 w-full items-center gap-3 rounded-lg px-2 py-1.5 text-left transition-colors",
-                index === activeMentionIndex ? "bg-[var(--noodle-blue)]/15" : "hover:bg-[var(--noodle-blue)]/10",
-              )}
-            >
-              <Avatar account={account} size="sm" />
-              <span className="min-w-0 flex-1">
-                <span className="block truncate text-xs font-semibold">{account.displayName}</span>
-                <span className="block truncate text-[0.68rem] text-[var(--noodle-blue)]">@{account.handle}</span>
-              </span>
-            </button>
-          ))
-        ) : (
-          <p className="px-3 py-2 text-xs text-[var(--muted-foreground)]">
-            No invited character matches @{activeMention.query}.
-          </p>
-        )}
-      </div>
+      <NoodleMentionSuggestions
+        activeMention={activeMention}
+        activeIndex={activeMentionIndex}
+        accounts={mentionSuggestions}
+        listboxId={listboxId}
+        onSelect={selectComposerMention}
+      />
     );
+  };
+
+  const handleReplyChange = (event: ChangeEvent<HTMLTextAreaElement>) => {
+    const value = event.target.value;
+    setReplyText(value);
+    setActiveReplyMention(activeComposerMention(value, event.target.selectionStart ?? value.length));
+    setActiveReplyMentionIndex(0);
+  };
+
+  const selectReplyMention = (account: NoodleAccount) => {
+    if (!activeReplyMention) return;
+    const insertedMention = `@${account.handle} `;
+    const nextReply =
+      replyText.slice(0, activeReplyMention.start) + insertedMention + replyText.slice(activeReplyMention.end);
+    const nextCaret = activeReplyMention.start + insertedMention.length;
+    setReplyText(nextReply);
+    setActiveReplyMention(null);
+    setActiveReplyMentionIndex(0);
+    window.requestAnimationFrame(() => {
+      replyComposerRef.current?.focus();
+      replyComposerRef.current?.setSelectionRange(nextCaret, nextCaret);
+    });
+  };
+
+  const handleReplyKeyDown = (event: React.KeyboardEvent<HTMLTextAreaElement>) => {
+    if (!activeReplyMention) return;
+    if (event.key === "Escape") {
+      event.preventDefault();
+      event.stopPropagation();
+      setActiveReplyMention(null);
+      return;
+    }
+    if (replyMentionSuggestions.length === 0) return;
+    if (event.key === "ArrowDown" || event.key === "ArrowUp") {
+      event.preventDefault();
+      const direction = event.key === "ArrowDown" ? 1 : -1;
+      setActiveReplyMentionIndex(
+        (current) => (current + direction + replyMentionSuggestions.length) % replyMentionSuggestions.length,
+      );
+      return;
+    }
+    if (event.key === "Enter" || event.key === "Tab") {
+      event.preventDefault();
+      const account = replyMentionSuggestions[Math.min(activeReplyMentionIndex, replyMentionSuggestions.length - 1)];
+      if (account) selectReplyMention(account);
+    }
   };
 
   const updateFollowedAccount = (account: NoodleAccount, followed: boolean) => {
@@ -2880,10 +2964,30 @@ export function NoodleView() {
           </p>
         )}
         <textarea
+          ref={replyComposerRef}
           value={replyText}
-          onChange={(event) => setReplyText(event.target.value)}
+          onChange={handleReplyChange}
+          onKeyDown={handleReplyKeyDown}
           className={cn(textareaClass, "min-h-16 resize-none bg-transparent")}
           placeholder="Leave a comment…"
+          aria-autocomplete="list"
+          aria-controls={activeReplyMention ? "noodle-reply-mention-list" : undefined}
+          aria-expanded={Boolean(activeReplyMention)}
+          aria-activedescendant={
+            activeReplyMention && replyMentionSuggestions.length > 0
+              ? `noodle-reply-mention-list-option-${Math.min(
+                  activeReplyMentionIndex,
+                  replyMentionSuggestions.length - 1,
+                )}`
+              : undefined
+          }
+        />
+        <NoodleMentionSuggestions
+          activeMention={activeReplyMention}
+          activeIndex={activeReplyMentionIndex}
+          accounts={replyMentionSuggestions}
+          listboxId="noodle-reply-mention-list"
+          onSelect={selectReplyMention}
         />
         {replyImageUrl && (
           <div className="relative mt-2 overflow-hidden rounded-xl border border-[var(--noodle-divider)]">
@@ -2961,7 +3065,10 @@ export function NoodleView() {
               >
                 {uploadGlobalImages.isPending ? "Uploading..." : "Upload From Device"}
               </button>
-              <div className="flex items-center gap-2 text-[0.625rem] font-semibold uppercase tracking-normal text-[var(--muted-foreground)]">
+              <div
+                data-component="NoodleView.ReplyImageDivider"
+                className="flex items-center gap-2 text-[0.625rem] font-semibold uppercase tracking-normal text-[var(--noodle-blue)]"
+              >
                 <span className="h-px flex-1 bg-[var(--noodle-divider)]" />
                 or
                 <span className="h-px flex-1 bg-[var(--noodle-divider)]" />
@@ -3204,7 +3311,14 @@ export function NoodleView() {
                   const likedReplyByPersona = personaAccount
                     ? replyLikes.some((interaction) => interaction.actorAccountId === personaAccount.id)
                     : false;
-                  const canManageReply = Boolean(personaAccount && reply.actorAccountId === personaAccount.id);
+                  const canManageReply = Boolean(
+                    personaAccount &&
+                      canManageNoodleReply({
+                        actorKind: actorAccount?.kind ?? reply.actorSnapshot?.kind,
+                        actorAccountId: reply.actorAccountId,
+                        personaAccountId: personaAccount.id,
+                      }),
+                  );
                   return (
                     <Fragment key={reply.id}>
                       <div

--- a/packages/server/src/routes/noodle.routes.ts
+++ b/packages/server/src/routes/noodle.routes.ts
@@ -7,6 +7,7 @@ import { basename, dirname, resolve } from "path";
 import { fileURLToPath } from "url";
 import {
   createNoodlePoll,
+  canManageNoodleReply,
   extractNoodleMentionHandles,
   noodleAccountUpdateSchema,
   noodleBulkInviteSchema,
@@ -60,6 +61,7 @@ import {
   noodlePastMemoryCutoff,
   noodlePastMemorySampleSize,
   noodlePersonaCommentPostIds,
+  NOODLE_CREATIVE_FORMAT_INSTRUCTIONS,
   NOODLE_PERSONA_AUTHORSHIP_INSTRUCTION,
   noodleTimelineFeatureInstructions,
   sampleNoodlePastMemories,
@@ -653,6 +655,7 @@ async function buildRefreshPrompt(input: {
     "- Generated interactions may target existing posts included in this prompt or posts you create in this response.",
     "- To respond directly to an existing comment, create a reply interaction for its post and set parentInteractionId to that comment's exact replyId.",
     NOODLE_PERSONA_AUTHORSHIP_INSTRUCTION,
+    ...NOODLE_CREATIVE_FORMAT_INSTRUCTIONS,
     "- For each interaction, set either targetTempId or targetPostId. The unused target field may be omitted or null.",
     "- pollOptionIndex is required only for votes and must be a zero-based integer. For other interactions, omit it or use null.",
     "- An exact @handle in post or reply text tags that active account. Preserve the @handle exactly when mentioning someone.",
@@ -1226,8 +1229,17 @@ export async function noodleRoutes(app: FastifyInstance) {
     await ensurePersonaAccounts(noodle, characters);
     const persona = await noodle.getAccountByEntity("persona", parsed.data.personaId);
     if (!persona) return reply.code(404).send({ error: "Noodle persona not found" });
-    if (interaction.type !== "reply" || interaction.actorAccountId !== persona.id) {
-      return reply.code(403).send({ error: "You can only edit comments from this persona." });
+    const interactionActor = await noodle.getAccountById(interaction.actorAccountId);
+    const actorKind = interactionActor?.kind ?? interaction.actorSnapshot?.kind;
+    if (
+      interaction.type !== "reply" ||
+      !canManageNoodleReply({
+        actorKind,
+        actorAccountId: interaction.actorAccountId,
+        personaAccountId: persona.id,
+      })
+    ) {
+      return reply.code(403).send({ error: "You can only edit comments from this persona or a character." });
     }
     const content = parsed.data.content === undefined ? interaction.content : parsed.data.content?.trim() || null;
     const imageUrl = parsed.data.imageUrl === undefined ? interaction.imageUrl : parsed.data.imageUrl?.trim() || null;
@@ -1248,8 +1260,17 @@ export async function noodleRoutes(app: FastifyInstance) {
     await ensurePersonaAccounts(noodle, characters);
     const persona = await noodle.getAccountByEntity("persona", parsed.data.personaId);
     if (!persona) return reply.code(404).send({ error: "Noodle persona not found" });
-    if (interaction.type !== "reply" || interaction.actorAccountId !== persona.id) {
-      return reply.code(403).send({ error: "You can only delete comments from this persona." });
+    const interactionActor = await noodle.getAccountById(interaction.actorAccountId);
+    const actorKind = interactionActor?.kind ?? interaction.actorSnapshot?.kind;
+    if (
+      interaction.type !== "reply" ||
+      !canManageNoodleReply({
+        actorKind,
+        actorAccountId: interaction.actorAccountId,
+        personaAccountId: persona.id,
+      })
+    ) {
+      return reply.code(403).send({ error: "You can only delete comments from this persona or a character." });
     }
     const deleted = await noodle.deleteInteractionById(interactionId);
     if (deleted.length === 0) return reply.code(404).send({ error: "Noodle comment not found" });

--- a/packages/server/src/services/noodle/noodle-prompt.ts
+++ b/packages/server/src/services/noodle/noodle-prompt.ts
@@ -14,6 +14,10 @@ export const NOODLE_PAST_MEMORY_MAX_ITEMS = 3;
 export const NOODLE_PAST_MEMORY_INCLUSION_CHANCE = 0.5;
 export const NOODLE_PERSONA_AUTHORSHIP_INSTRUCTION =
   "- The user persona is controlled exclusively by the user. Never generate posts, replies, likes, reposts, poll votes, or follows as a persona. Personas may only be mentioned or targeted by other accounts.";
+export const NOODLE_CREATIVE_FORMAT_INSTRUCTIONS = [
+  "- Characters and random users may create polls in their own posts and vote in polls. Occasionally use a poll when an audience question or set of choices fits naturally with the account and current activity; polls are optional, not a quota.",
+  "- Standard Unicode emojis are allowed in post and reply content. Use them naturally when they fit the account's voice or reaction; emojis are optional, and not every post or reply needs one.",
+] as const;
 
 type NoodleTimelineFeatureSettings = Pick<
   NoodleSettings,
@@ -153,7 +157,10 @@ export function sampleNoodlePastMemories<T>(
 export function noodleTimelineFeatureInstructions(settings: NoodleTimelineFeatureSettings): string[] {
   return [
     ...(settings.allowRandomUsers
-      ? ["- Use only the active accounts listed by entityId. Do not invent accounts."]
+      ? [
+          "- Use only the active accounts listed by entityId. Do not invent accounts.",
+          "- A small minority of posts from random_user accounts may be obvious parody advertisements or absurd fake crypto scams. Usually generate none and never more than one per refresh. Keep every company, product, coin, ticker, price, and financial claim invented, visibly ridiculous, and non-actionable. Never imitate a real company or include real or usable links, wallet addresses, financial advice, or scam instructions.",
+        ]
       : []),
     ...(settings.enableImagePrompts
       ? [

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -119,3 +119,4 @@ export * from "./utils/sprite-labels.js";
 export * from "./utils/conversation-presence.js";
 export * from "./utils/noodle-mentions.js";
 export * from "./utils/noodle-polls.js";
+export * from "./utils/noodle-interactions.js";

--- a/packages/shared/src/utils/noodle-interactions.ts
+++ b/packages/shared/src/utils/noodle-interactions.ts
@@ -1,0 +1,20 @@
+import type { NoodleAccountKind } from "../types/noodle.js";
+
+interface NoodleReplyManagementInput {
+  actorKind: NoodleAccountKind | null | undefined;
+  actorAccountId: string;
+  personaAccountId: string | null | undefined;
+}
+
+/**
+ * Users may manage their current persona's replies and replies authored by
+ * their characters. Generated random-user replies remain read-only.
+ */
+export function canManageNoodleReply({
+  actorKind,
+  actorAccountId,
+  personaAccountId,
+}: NoodleReplyManagementInput): boolean {
+  if (actorKind === "character") return true;
+  return actorKind === "persona" && Boolean(personaAccountId) && actorAccountId === personaAccountId;
+}

--- a/scripts/regressions/noodle-prompt.regression.ts
+++ b/scripts/regressions/noodle-prompt.regression.ts
@@ -1,10 +1,12 @@
 import assert from "node:assert/strict";
+import { canManageNoodleReply } from "../../packages/shared/src/utils/noodle-interactions.js";
 import {
   canGenerateNoodleActivityForAccountKind,
   formatNoodleTimelineForPrompt,
   noodlePastMemoryCutoff,
   noodlePastMemorySampleSize,
   noodlePersonaCommentPostIds,
+  NOODLE_CREATIVE_FORMAT_INSTRUCTIONS,
   NOODLE_PERSONA_AUTHORSHIP_INSTRUCTION,
   noodleTimelineFeatureInstructions,
   sampleNoodlePastMemories,
@@ -17,6 +19,44 @@ assert.match(NOODLE_PERSONA_AUTHORSHIP_INSTRUCTION, /controlled exclusively by t
 assert.match(
   NOODLE_PERSONA_AUTHORSHIP_INSTRUCTION,
   /Never generate posts, replies, likes, reposts, poll votes, or follows/u,
+);
+assert.equal(NOODLE_CREATIVE_FORMAT_INSTRUCTIONS.length, 2);
+assert.match(NOODLE_CREATIVE_FORMAT_INSTRUCTIONS[0], /create polls in their own posts and vote in polls/u);
+assert.match(NOODLE_CREATIVE_FORMAT_INSTRUCTIONS[0], /polls are optional, not a quota/u);
+assert.match(NOODLE_CREATIVE_FORMAT_INSTRUCTIONS[1], /Standard Unicode emojis are allowed in post and reply content/u);
+assert.match(NOODLE_CREATIVE_FORMAT_INSTRUCTIONS[1], /not every post or reply needs one/u);
+
+assert.equal(
+  canManageNoodleReply({
+    actorKind: "persona",
+    actorAccountId: "persona-account",
+    personaAccountId: "persona-account",
+  }),
+  true,
+);
+assert.equal(
+  canManageNoodleReply({
+    actorKind: "persona",
+    actorAccountId: "other-persona-account",
+    personaAccountId: "persona-account",
+  }),
+  false,
+);
+assert.equal(
+  canManageNoodleReply({
+    actorKind: "character",
+    actorAccountId: "character-account",
+    personaAccountId: "persona-account",
+  }),
+  true,
+);
+assert.equal(
+  canManageNoodleReply({
+    actorKind: "random_user",
+    actorAccountId: "random-account",
+    personaAccountId: "persona-account",
+  }),
+  false,
 );
 
 const threadedTimeline = formatNoodleTimelineForPrompt(
@@ -76,6 +116,8 @@ assert.deepEqual(
 );
 
 const activeAccountsInstruction = "- Use only the active accounts listed by entityId. Do not invent accounts.";
+const randomUserParodyInstruction =
+  "- A small minority of posts from random_user accounts may be obvious parody advertisements or absurd fake crypto scams. Usually generate none and never more than one per refresh. Keep every company, product, coin, ticker, price, and financial claim invented, visibly ridiculous, and non-actionable. Never imitate a real company or include real or usable links, wallet addresses, financial advice, or scam instructions.";
 const imageGenerationInstruction =
   "- When image generation is enabled, imagePrompt should be a concrete visual idea for the attached image: either a character-focused image of the author/their scene/selfie, or an in-character meme they would plausibly post.";
 const galleryAttachmentInstruction =
@@ -93,12 +135,12 @@ const instructions = (input: {
   });
 
 assert.deepEqual(instructions({}), []);
-assert.deepEqual(instructions({ allowRandomUsers: true }), [activeAccountsInstruction]);
+assert.deepEqual(instructions({ allowRandomUsers: true }), [activeAccountsInstruction, randomUserParodyInstruction]);
 assert.deepEqual(instructions({ enableImagePrompts: true }), [imageGenerationInstruction]);
 assert.deepEqual(instructions({ allowGalleryImageAttachments: true }), [galleryAttachmentInstruction]);
 assert.deepEqual(
   instructions({ allowRandomUsers: true, enableImagePrompts: true, allowGalleryImageAttachments: true }),
-  [activeAccountsInstruction, imageGenerationInstruction, galleryAttachmentInstruction],
+  [activeAccountsInstruction, randomUserParodyInstruction, imageGenerationInstruction, galleryAttachmentInstruction],
 );
 
 const cutoffAnchor = new Date("2026-07-10T12:00:00.000Z");


### PR DESCRIPTION
## Why

This combines the current Noodle polish with fixes for several adjacent generation and editing workflows. In particular, character-assigned lorebooks should duplicate exactly like unassigned lorebooks, image-prompt review should honor its global Settings toggle at every image-generation entrypoint, and saved slash commands should retain command semantics when sent.

Closes #3433

## What changes

- Improve Noodle replies, mention completion, media styling, prompt variety, and character-owned comment controls.
- Fix duplication of character-assigned lorebooks.
- Apply **Expose image prompts before sending** across all image-generation flows and clarify its tooltip.
- Move **Quote Replies** from Advanced to **General → Input & Editing** without changing the stored preference.
- Execute saved messages beginning with a recognized slash command through command dispatch.

## Validation

- [ ] Run focused Noodle regressions.
- [ ] Reproduce and verify character-assigned lorebook duplication.
- [ ] Verify prompt review across image-generation entrypoints.
- [ ] Verify Quote Replies in General → Input & Editing.
- [ ] Verify saved recognized slash commands execute as commands.
- [ ] Run `pnpm check`.
- [ ] Manually verify affected desktop and mobile UI paths.

> Draft: implementation and validation are still in progress.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added `@handle` autocomplete to post and reply composers, with click, touch, and keyboard selection.
  - Added polls, Unicode emoji, and occasional clearly fictional parody content to generated timelines.
  - Added bulk character-folder invitations and multi-character image references.

- **Improvements**
  - Added post editing, deletion, like/repost toggles, timeline reset confirmation, and automatic gallery saves.
  - Character-authored comments can now be edited or deleted.

- **Bug Fixes**
  - Corrected reply image-picker styling and improved comment management controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->