### PR TITLE
fix(macros): resolve flat-pass macros in {{#if}} conditions + trim standalone blocks

### DIFF
--- a/packages/shared/src/utils/macro-engine.ts
+++ b/packages/shared/src/utils/macro-engine.ts
@@ -690,6 +690,18 @@ function resolveConditionalOperand(raw: string, ctx: MacroContext): string {
       return ctx.characterFields?.systemPrompt ?? "";
     case "charposthistory":
       return ctx.characterFields?.postHistoryInstructions ?? "";
+    // Conversation-mode-only macros. Resolve them the same way the flat {{...}}
+    // pass does (from convoFields) so `{{#if char_about != ""}}` compares the
+    // real value instead of the unresolved literal token (#3435). Kept in sync
+    // with the flat-pass replacements below.
+    case "convo_display":
+      return ctx.convoFields?.charDisplayName ?? "";
+    case "char_about":
+      return ctx.convoFields?.charAbout ?? "";
+    case "persona_about":
+      return ctx.convoFields?.personaAbout ?? "";
+    case "convo_behavior":
+      return ctx.convoFields?.convoBehavior ?? "";
     default:
       if (/^var[:.]/i.test(token)) {
         const name = token.replace(/^var[:.]/i, "").trim();
@@ -972,14 +984,45 @@ function resolveConditionalBlocks(input: string, ctx: MacroContext, options: Res
       content: input.slice(branch.contentStart, branch.contentEnd),
     }));
 
-    result += resolveVariableOperationMacros(input.slice(index, blockStart), ctx, options);
+    const preTag = input.slice(index, blockStart);
+    // Resolve the pre-tag text first so its side effects (e.g. {{setvar}}) are
+    // applied before the condition is evaluated — preserves original ordering.
+    const resolvedPreTag = resolveVariableOperationMacros(preTag, ctx, options);
     if (options.deferCharacterMacros && branchDependsOnCharacter(branches)) {
+      result += resolvedPreTag;
       result += encodeDeferredConditional({ branches });
+      index = blockEnd.endEnd;
     } else {
       const selected = selectConditionalPayloadBranch({ branches }, ctx, options);
-      result += resolveConditionalBlocks(selected, ctx, options);
+      const resolvedBlock = resolveConditionalBlocks(selected, ctx, options);
+      // Standalone-block whitespace control (Jinja trim_blocks / lstrip_blocks):
+      // when the {{#if}} and/or {{/if}} tag occupies its own line, collapse that
+      // tag line so a block — whether removed or rendered — never leaves a stray
+      // blank line (#3435). Standalone-ness is judged from the raw layout, so an
+      // empty (removed) block is handled the same as a rendered one. Each side is
+      // decided independently, so inline tags stay exactly as authored.
+      const openLineStart = /(^|\n)[ \t]*$/.test(preTag);
+      const openLineEnd = /^[ \t]*\n/.test(input.slice(contentStart));
+      const openStandalone = openLineStart && openLineEnd;
+      const closeLineIndentStart = input.lastIndexOf("\n", blockEnd.endStart - 1) + 1;
+      const closeLineStart = /^[ \t]*$/.test(input.slice(closeLineIndentStart, blockEnd.endStart));
+      const closeTrailing = input.slice(blockEnd.endEnd).match(/^[ \t]*\n/);
+      const closeStandalone = closeLineStart && closeTrailing !== null;
+
+      let emittedPre = resolvedPreTag;
+      let emittedBlock = resolvedBlock;
+      let nextIndex = blockEnd.endEnd;
+      if (openStandalone) {
+        emittedPre = emittedPre.replace(/[ \t]*$/, ""); // lstrip {{#if}} indent
+        emittedBlock = emittedBlock.replace(/^[ \t]*\n/, ""); // trim newline after {{#if}}
+      }
+      if (closeStandalone) {
+        emittedBlock = emittedBlock.replace(/[ \t]*$/, ""); // lstrip {{/if}} indent
+        nextIndex = blockEnd.endEnd + closeTrailing![0].length; // trim newline after {{/if}}
+      }
+      result += emittedPre + emittedBlock;
+      index = nextIndex;
     }
-    index = blockEnd.endEnd;
   }
 
   return result;

--- a/packages/shared/src/utils/macro-engine.ts
+++ b/packages/shared/src/utils/macro-engine.ts
@@ -631,7 +631,7 @@ function resolvePersonaText(ctx: MacroContext): string {
     .join("\n");
 }
 
-function resolveConditionalOperand(raw: string, ctx: MacroContext): string {
+function resolveConditionalOperand(raw: string, ctx: MacroContext, options: ResolveMacroOptions): string {
   const quoted = stripOuterQuotes(raw);
   if (quoted !== null) return quoted;
 
@@ -690,22 +690,29 @@ function resolveConditionalOperand(raw: string, ctx: MacroContext): string {
       return ctx.characterFields?.systemPrompt ?? "";
     case "charposthistory":
       return ctx.characterFields?.postHistoryInstructions ?? "";
-    // Conversation-mode-only macros. Resolve them the same way the flat {{...}}
-    // pass does (from convoFields) so `{{#if char_about != ""}}` compares the
-    // real value instead of the unresolved literal token (#3435). Kept in sync
-    // with the flat-pass replacements below.
-    case "convo_display":
-      return ctx.convoFields?.charDisplayName ?? "";
-    case "char_about":
-      return ctx.convoFields?.charAbout ?? "";
-    case "persona_about":
-      return ctx.convoFields?.personaAbout ?? "";
-    case "convo_behavior":
-      return ctx.convoFields?.convoBehavior ?? "";
     default:
       if (/^var[:.]/i.test(token)) {
         const name = token.replace(/^var[:.]/i, "").trim();
         return ctx.variables[name] ?? "";
+      }
+      // Resolve any other bare operand through the same flat pass used for
+      // {{token}}, so every read macro valid in {{...}} is also testable bare in
+      // {{#if}} — conversation macros ({{char_about}} …), {{date}}/{{time}},
+      // {{agent::TYPE}}, {{lastGenerationType}}, etc. — instead of drifting out
+      // of sync with a hand-maintained switch (#3435). Guards:
+      //   • never run a variable-WRITE macro (side effect) as an operand;
+      //   • unknown tokens stay literal (the flat pass leaves them as-is), so a
+      //     plain word or number still compares as itself — unchanged behavior;
+      //   • force concrete resolution (deferCharacterMacros off) so a group chat
+      //     compares the real value, not a deferred per-character placeholder.
+      if (!/^(setvar|addvar|incvar|decvar)\b/i.test(token)) {
+        const braced = `{{${token}}}`;
+        const resolved = resolveMacros(braced, ctx, {
+          ...nestedMacroOptions(options),
+          trimResult: false,
+          deferCharacterMacros: undefined,
+        });
+        if (resolved !== braced) return resolved;
       }
       return ctx.variables[token] ?? token;
   }
@@ -789,9 +796,9 @@ function resolveConditionMacros(condition: string, ctx: MacroContext, options: R
 
 function evaluateCondition(condition: string, ctx: MacroContext, options: ResolveMacroOptions = {}): boolean {
   const parsed = parseConditionExpression(resolveConditionMacros(condition, ctx, options));
-  const left = resolveConditionalOperand(parsed.left, ctx);
+  const left = resolveConditionalOperand(parsed.left, ctx, options);
   if (parsed.operator === "truthy") return left.trim().length > 0 && !/^(false|0|no|off|null|undefined)$/i.test(left);
-  const right = resolveConditionalOperand(parsed.right ?? "", ctx);
+  const right = resolveConditionalOperand(parsed.right ?? "", ctx, options);
   return compareConditionValues(left, parsed.operator, right);
 }
 


### PR DESCRIPTION
<!-- Target branch: `staging`. -->

## Linked issue

Closes #3435

## Why this change

Two problems with the new (and old) preset macros inside `{{#if}}` blocks:

1. **(functional)** `{{#if MACRO != ""}}` was **always true** for a whole class of macros. The `{{#if}}` condition evaluator resolved bare operands from a **hand-maintained switch** in `resolveConditionalOperand`, and any macro not listed fell through to the literal-token fallback (`"MACRO" != ""` → always true). That switch had drifted out of sync with the flat `{{...}}` pass. The reported case was the conversation macros (`{{char_about}}`, `{{persona_about}}`, `{{convo_display}}`, `{{convo_behavior}}`), but an audit found the same bug for `{{date}}`/`{{time}}`/`{{weekday}}`/`{{timezone}}`/`{{datetime}}`, `{{lastGenerationType}}`, `{{idle_duration}}`, `{{agent::TYPE}}`, `{{random}}`/`{{roll}}`, and `{{getvar::name}}` — all broken in **bare** form (they worked only in the braced `{{ {{macro}} }}` form).

2. **(cosmetic)** A standalone `{{#if}}` block left an extra **blank line** — whether removed or rendered.

## What changed

`packages/shared/src/utils/macro-engine.ts`:

- **General fix for #1:** instead of adding switch cases one by one (which is how the drift happened), `resolveConditionalOperand` now routes any unresolved bare operand through the **same flat pass** used for `{{token}}`. So every read macro valid in `{{...}}` is automatically testable bare in `{{#if}}`, and it stays in sync forever. Guards:
  - never runs a variable **write** macro (`setvar`/`addvar`/`incvar`/`decvar`) as an operand side-effect;
  - unknown tokens stay literal (the flat pass leaves them as-is), so plain words/numbers still compare as themselves — unchanged behavior;
  - forces concrete resolution (`deferCharacterMacros` off) so a group chat compares the real value, not a deferred per-character placeholder.
- **Fix for #2:** standalone `{{#if}}`/`{{/if}}` tags get Jinja-style `trim_blocks`/`lstrip_blocks`, judged from the raw layout, so a removed **or** rendered block no longer leaves a blank line. Inline tags and `else` branches are left as authored. Pre-tag text is resolved before the condition, preserving `{{setvar}}`-before-condition ordering.

**Out of scope (handled separately):** the **relocation** macros (`{{memories}}`, `{{lorebook}}`, `{{commands}}`, `{{context}}`, `{{reactRules}}`) still can't be `{{#if}}`-tested here — their value is injected by the route *after* macro resolution, so there's nothing to compare at this layer. That needs route-level handling and is being done in a follow-up.

## Validation

<!-- Required: include commands run and/or manual checks performed -->

- [ ] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed `CONTRIBUTING.md`

### Manual verification notes

Automated checks I ran locally (green):

- `pnpm --filter @marinara-engine/shared build` (tsc) and `… lint` — clean
- `pnpm regression:prompt` — full prompt/macro regression suite passes
- A throwaway targeted script (not committed) exercising the fix directly:
  - bare `{{#if char_about != ""}}` / `persona_about` / `convo_behavior`, `{{#if lastGenerationType == "regenerate"}}`, `{{#if idle_duration != ""}}`, `{{#if agent::tracker != ""}}`, `{{#if date != ""}}` all test the real value now
  - guards: unknown bare word still always-true (unchanged); `{{#if setvar::x::1}}` does **not** execute the write; set variables resolve; `{{#if var:mood == "happy"}}` and `{{#if char == "Kat"}}` unchanged; braced form still works
  - Bug 4: removed/rendered standalone blocks leave no blank line

Still to verify manually in the app (please tick above once done):

1. In a Conversation-mode preset, gate a block on `{{#if char_about != ""}}` and generate with an empty vs. non-empty about-me — confirm hide vs. render and no blank-line gaps.
2. Confirm `{{#if lastGenerationType == "regenerate"}}` / `{{#if {{weekday}} == "Monday"}}` behave as expected.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Version/release files updated (only if this PR includes a version bump)

Macro-reference docs (including which macros are `{{#if}}`-testable) are tracked in #3437; no version bump here.

## UI evidence (if applicable)

N/A (prompt-assembly logic; no UI surface changed).
