### PR TITLE
fix(macros): resolve #3449 relocation-{{#if}} regressions (context dup, slot over-match, else spacing)

### DIFF
--- a/packages/server/src/routes/generate.routes.ts
+++ b/packages/server/src/routes/generate.routes.ts
@@ -12,6 +12,7 @@ import {
   resolveDeferredCharacterMacros,
   hasDeferredCharacterMacros,
   hasDeferredRelocationConditionals,
+  collectDeferredRelocationConditionOperands,
   DEFERRED_RELOCATION_CONDITIONAL_TOKEN_RE,
   parseDeferredConditionalPayload,
   selectConditionalPayloadBranch,
@@ -492,40 +493,40 @@ function conversationContextMacroPattern(key: ConversationContextMacroKey): RegE
   return new RegExp(`\\{\\{\\s*(?:${aliases.join("|")})\\s*\\}\\}`, "gi");
 }
 
-// Matches a relocation alias used as a BARE {{#if}}/{{else if}} operand, e.g.
-// `{{#if memories != ""}}` (the braced `{{#if {{memories}}}}` form is already
-// caught by conversationContextMacroPattern). Used so a header-only conditional
-// block still triggers the underlying retrieval (#3448).
-function conversationContextMacroConditionPattern(key: ConversationContextMacroKey): RegExp {
-  const aliases = CONVERSATION_CONTEXT_MACRO_ALIASES[key].map((alias) => alias.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"));
-  return new RegExp(`\\{\\{\\s*(?:#if|else\\s+if)\\b[^}]*\\b(?:${aliases.join("|")})\\b[^}]*\\}\\}`, "gi");
-}
-
-// Lowercased relocation aliases, for the deferConditionalOperand predicate.
-const RELOCATION_CONDITION_OPERANDS: ReadonlySet<string> = new Set(
-  CONVERSATION_RELOCATION_MACRO_KEYS.flatMap((key) => CONVERSATION_CONTEXT_MACRO_ALIASES[key]).map((alias) =>
-    alias.toLowerCase(),
-  ),
-);
-
-// True when a {{#if}} operand references a relocation macro (bare `memories` or
-// braced `{{memories}}`). A quoted literal like `"memories"` is NOT a reference.
-function isRelocationConditionOperand(operand: string): boolean {
+// Maps a {{#if}} operand (bare `memories` or braced `{{memories}}`) back to its
+// relocation key, or null. A quoted literal (`"memories"`) or a dotted/prefixed
+// operand (`user.status`) is NOT a reference; About-me fields are excluded (they
+// are engine-resolved convo fields, not route-filled). Drives BOTH the defer
+// predicate and the token-based slot detection so the two can never disagree —
+// which a loose {{#if}}-body regex could not guarantee (#3449).
+function relocationKeyForOperand(operand: string): ConversationRelocationMacroKey | null {
   const normalized = operand
     .trim()
     .replace(/^\{\{\s*|\s*\}\}$/g, "")
     .replace(/^@/, "")
     .trim()
     .toLowerCase();
-  return RELOCATION_CONDITION_OPERANDS.has(normalized);
+  if (!normalized) return null;
+  for (const key of CONVERSATION_RELOCATION_MACRO_KEYS) {
+    if (CONVERSATION_CONTEXT_MACRO_ALIASES[key].some((alias) => alias.toLowerCase() === normalized)) return key;
+  }
+  return null;
 }
 
+function isRelocationConditionOperand(operand: string): boolean {
+  return relocationKeyForOperand(operand) !== null;
+}
+
+// Bare-placeholder detection only. Conditional references are OR'd in afterward
+// from the ACTUAL deferred tokens (collectDeferredRelocationConditionOperands +
+// relocationKeyForOperand), so slot detection stays in lock-step with the defer
+// decision — the previous loose regex over `{{#if …}}` bodies over-matched a
+// relocation word inside a quoted literal / dotted operand and dropped the
+// underlying retrieval (#3449).
 function resolveConversationContextMacroSlots(template: string): ConversationContextMacroSlots {
   const slots: ConversationContextMacroSlots = { ...EMPTY_CONVERSATION_CONTEXT_MACRO_SLOTS };
   for (const key of Object.keys(CONVERSATION_CONTEXT_MACRO_ALIASES) as ConversationContextMacroKey[]) {
-    slots[key] =
-      conversationContextMacroPattern(key).test(template) ||
-      (key !== "aboutMe" && conversationContextMacroConditionPattern(key).test(template));
+    slots[key] = conversationContextMacroPattern(key).test(template);
   }
   return slots;
 }
@@ -1939,6 +1940,14 @@ export async function generateRoutes(app: FastifyInstance) {
             // filled in later; the decode pass below evaluates them (#3448).
             { deferConditionalOperand: isRelocationConditionOperand },
           );
+          // Mark each relocation macro a deferred conditional actually references
+          // as "used" so its retrieval runs and its value is captured for the
+          // decode. Reads the real tokens (not a regex), so it agrees exactly
+          // with what was deferred above — no over/under-match (#3449).
+          for (const operand of collectDeferredRelocationConditionOperands(renderedConversationPrompt)) {
+            const key = relocationKeyForOperand(operand);
+            if (key) conversationContextMacroSlots[key] = true;
+          }
           const conversationInstructionParts = [unwrapConversationInstructions(renderedConversationPrompt)];
 
           if (isGroup && earlyGroupMode !== "individual") {
@@ -2098,10 +2107,15 @@ export async function generateRoutes(app: FastifyInstance) {
               ? [{ role: "user" as const, content: convoProfileBlocks.behaviorPostHistoryBlock }]
               : []),
           ];
-          const conversationContextInserted = conversationContextMacroSlots.context
-            ? replaceConversationContextMacro(finalMessages, "context", contextBlock)
-            : false;
-          if (!conversationContextInserted) {
+          if (conversationContextMacroSlots.context) {
+            // The preset references {{context}} — as a literal placeholder or a
+            // deferred {{#if context}} conditional. Rendering is owned by the
+            // in-place replace or the later decode pass; don't ALSO push the tail
+            // fallback, which would double-inject the context block (#3449). (A
+            // deferred token has no literal to replace, so the replace() return
+            // is not a reliable "inserted" signal — key on the slot instead.)
+            replaceConversationContextMacro(finalMessages, "context", contextBlock);
+          } else {
             finalMessages.push({ role: "user" as const, content: contextBlock });
           }
           if (conversationContextMacroSlots.reactRules) {

--- a/packages/shared/src/utils/macro-engine.ts
+++ b/packages/shared/src/utils/macro-engine.ts
@@ -255,6 +255,32 @@ export function hasDeferredRelocationConditionals(template: string): boolean {
   return template.includes(DEFERRED_RELOCATION_CONDITIONAL_TOKEN_PREFIX);
 }
 
+/**
+ * Extract the condition operands (left/right of each branch) from every deferred
+ * relocation conditional token in `text`. Lets the caller decide which of its
+ * slots the deferred blocks actually reference using the SAME parse the deferral
+ * used — so slot detection can never disagree with the defer decision (#3449).
+ */
+export function collectDeferredRelocationConditionOperands(text: string): string[] {
+  if (!text.includes(DEFERRED_RELOCATION_CONDITIONAL_TOKEN_PREFIX)) return [];
+  const operands: string[] = [];
+  for (const match of text.matchAll(DEFERRED_RELOCATION_CONDITIONAL_TOKEN_RE)) {
+    const payload = parseDeferredConditionalPayload(match[1]!);
+    if (!payload) continue;
+    const chainBranches = (payload as ConditionalChainPayload).branches;
+    const branches = Array.isArray(chainBranches)
+      ? chainBranches
+      : [{ condition: (payload as ConditionalBlockPayload).condition, content: "" }];
+    for (const branch of branches) {
+      if (branch.condition === null) continue;
+      const parsed = parseConditionExpression(branch.condition);
+      operands.push(parsed.left);
+      if (parsed.right !== undefined) operands.push(parsed.right);
+    }
+  }
+  return operands;
+}
+
 export const SUPPORTED_MACROS: readonly SupportedMacroDefinition[] = [
   { category: "Identity", syntax: "{{user}}", description: "Current user or persona name" },
   { category: "Identity", syntax: "{{userName}}", description: "Alias for {{user}}" },
@@ -984,8 +1010,13 @@ function branchDependsOnDeferredOperand(
 /**
  * Bake the standalone-block whitespace trim into a deferred block's branch
  * contents so the later-filled value collapses onto the surrounding lines the
- * same way an evaluated block would (leading newline after {{#if}}/{{else}}
- * dropped; the {{/if}} line's indent dropped). Best-effort for else chains.
+ * same way an evaluated block would. Each branch's content starts right after
+ * its governing tag ({{#if}}/{{else}}/{{else if}}), so under a standalone
+ * opening the leading newline of WHICHEVER branch is later selected must be
+ * dropped — matching the evaluate-now path, which strips the selected branch's
+ * leading newline regardless of which one it is (#3449). The trailing {{/if}}
+ * indent trim applies only to the last branch (only its line's standalone-ness
+ * was measured).
  */
 function trimDeferredStandaloneBranches(
   branches: ConditionalBranchPayload[],
@@ -995,7 +1026,7 @@ function trimDeferredStandaloneBranches(
   if (!openStandalone && !closeStandalone) return branches;
   return branches.map((branch, index) => {
     let content = branch.content;
-    if (openStandalone && index === 0) content = content.replace(/^[ \t]*\n/, "");
+    if (openStandalone) content = content.replace(/^[ \t]*\n/, "");
     if (closeStandalone && index === branches.length - 1) content = content.replace(/\n[ \t]*$/, "\n");
     return { condition: branch.condition, content };
   });


### PR DESCRIPTION
<!-- Target branch: `staging`. -->

## Linked issue

Closes #3450 (fast-follow to the merged #3449 / #3448)

## Why this change

A post-merge adversarial review of #3449 (relocation macros in `{{#if}}`) found three regressions that shipped to `staging`:

1. **Context double-injection (medium).** A preset referencing `{{context}}` only inside a deferred conditional leaves no literal `{{context}}` after deferral. The context tail-fallback keyed on `replaceConversationContextMacro`'s return — which is `false` for a deferred token — so it pushed the context block as a trailing user message **and** the decode pass inlined it. The current-context block (latest user message, status, activity, timestamp, mentions) was sent **twice, every turn**.
2. **Slot-detection over-match drops retrieval (medium).** Slot detection used a loose regex over `{{#if …}}` bodies. `{{#if topic == "memories"}}` (string literal) or `{{#if user.status == "x"}}` (dotted operand) matched the alias word and flipped the slot true, while the parser-based defer predicate correctly declined. With the slot wrongly set, the code took the "macro placed" branch (replacing a bare `{{memories}}` that isn't there) instead of the normal recall injection — **silently dropping memory recall / react rules / commands / lorebook**.
3. **Deferred else-branch blank line (low).** `trimDeferredStandaloneBranches` trimmed the leading newline only for branch 0, so a selected `{{else}}`/`{{else if}}` branch kept a stray blank line the evaluate-now path strips.

## What changed

Root cause of #1 and #2 is a slot-detection path that disagreed with the parser-based defer decision. Fix makes them share one parser:

- `packages/shared/src/utils/macro-engine.ts`:
  - New `collectDeferredRelocationConditionOperands(text)` — reads the **actual** deferred tokens and returns their condition operands (same `parseConditionExpression` the deferral uses).
  - `trimDeferredStandaloneBranches`: trim the leading newline of **whichever** branch is selected, not just branch 0.
- `packages/server/src/routes/generate.routes.ts`:
  - Replaced the loose `conversationContextMacroConditionPattern` regex with token-driven slot detection: after the conversation macro pass, map each deferred-token operand back to its key via `relocationKeyForOperand` (now shared with the defer predicate) and OR into the slots. Slot detection and deferral can no longer disagree — fixing both the over-match (dropped retrieval) and the inverse braced-operand miss. `relocationKeyForOperand` stays scoped to `CONVERSATION_RELOCATION_MACRO_KEYS`, preserving the About-me exclusion and covering `replyRules`.
  - The context fallback now keys on `conversationContextMacroSlots.context` instead of the `replace()` return, so a deferred `{{#if context}}` no longer double-injects.

## Validation

<!-- Required: include commands run and/or manual checks performed -->

- [ ] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed `CONTRIBUTING.md`

### Manual verification notes

Automated checks I ran locally (green):

- `pnpm --filter @marinara-engine/shared build` + `pnpm --filter @marinara-engine/server lint` (tsc) — clean
- `pnpm regression:prompt` — full suite passes (61 checks, incl. the deferred-relocation cases added with #3449)
- A throwaway targeted script (not committed) confirming: deferred else/else-if branch collapses with no leading blank line; `{{#if topic == "memories"}}` and `{{#if user.status …}}` do **not** defer and yield no relocation operand (so retrieval is unaffected); `{{#if char_about}}` (about-me field) is not deferred; real bare / braced-mixed / `{{#if replyRules}}` references defer and collect their key operand.

Still to verify manually in the app (please tick above once done):

1. Preset with `{{#if context != ""}}…{{context}}…{{/if}}` and no bare `{{context}}` → context block appears **once**.
2. Preset with `{{#if topic == "memories"}}…{{/if}}` and no bare `{{memories}}` → memory recall still injected.
3. Deferred `{{#if memories != ""}}…{{else}}…{{/if}}` with empty memories → else branch renders with no leading blank line.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Version/release files updated (only if this PR includes a version bump)

No docs/version changes; behavior-only bug fixes.

## UI evidence (if applicable)

N/A (prompt-assembly logic).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved conversation prompt handling for relocation macros used inside deferred conditional blocks.
  * Prevented duplicate context insertion when context is referenced conditionally.
  * Improved whitespace and newline handling across deferred conditional branches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->