### PR TITLE
Rename active Conversation status to online

### DIFF
--- a/packages/server/src/routes/generate/conversation-context-block.ts
+++ b/packages/server/src/routes/generate/conversation-context-block.ts
@@ -52,7 +52,7 @@ export function buildConversationCurrentContextBlock(args: {
   const statusLine = buildConversationStatusLine(args.convoCharInfo);
 
   const userStatusLabels: Record<string, string> = {
-    active: "active",
+    active: "online",
     idle: "idle / away from the computer",
     dnd: "do not disturb",
   };
@@ -95,13 +95,13 @@ export function buildConversationCurrentContextBlock(args: {
 
 function buildConversationStatusLine(convoCharInfo: ConversationContextCharacter[]): string {
   const statusLabels: Record<string, string> = {
-    online: "online and active",
+    online: "online",
     idle: "idle / away",
     dnd: "busy / do not disturb",
     offline: "offline",
   };
   const buildCharStatus = (character: ConversationContextCharacter) => {
-    const label = statusLabels[character.status] ?? "online and active";
+    const label = statusLabels[character.status] ?? "online";
     return character.activity ? `${label} (${character.activity})` : label;
   };
   return convoCharInfo.length === 1

--- a/packages/server/src/routes/generate/conversation-context-block.ts
+++ b/packages/server/src/routes/generate/conversation-context-block.ts
@@ -57,7 +57,7 @@ export function buildConversationCurrentContextBlock(args: {
     dnd: "do not disturb",
   };
   const shouldIncludeUserStatus = args.userStatus !== "invisible";
-  const userStatusLabel = userStatusLabels[args.userStatus ?? "active"] ?? "active";
+  const userStatusLabel = userStatusLabels[args.userStatus ?? "active"] ?? "online";
   const userActivity = args.userActivity?.replace(/\s+/g, " ").trim().slice(0, 120) ?? "";
   const userStatusLine = userActivity ? `${userStatusLabel} - ${userActivity}` : userStatusLabel;
 


### PR DESCRIPTION
## Why

Conversation prompt context currently describes an active persona as `active` and an online character as `online and active`. The display should use the simpler, consistent term `online`.

No linked issue; this is a maintainer-requested wording adjustment.

## What changed

- map the active persona status to `online`
- map online character status and its fallback label to `online`
- keep idle, do-not-disturb, offline, and activity text unchanged

## Validation

- `pnpm --filter @marinara-engine/server lint`
- `pnpm regression:prompt`

## Manual verification requested

- [ ] Manually inspect a Conversation prompt with online persona and character presence.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated conversation context labels to display user status as “online.”
  * Simplified character status labels by displaying “online” instead of “online and active.”

<!-- end of auto-generated comment: release notes by coderabbit.ai -->