### PR TITLE
fix: polish tracker panel layout

### DIFF
--- a/packages/client/src/components/layout/AppShell.tsx
+++ b/packages/client/src/components/layout/AppShell.tsx
@@ -90,7 +90,6 @@ const PANEL_RESIZE_STEP = 16;
 const PANEL_RESIZE_LARGE_STEP = 48;
 const SHARED_SIDEBAR_WIDTH_MIN = Math.max(SIDEBAR_WIDTH_MIN, RIGHT_PANEL_WIDTH_MIN);
 const SHARED_SIDEBAR_WIDTH_MAX = Math.min(SIDEBAR_WIDTH_MAX, RIGHT_PANEL_WIDTH_MAX);
-const RESIZER_HITBOX = 10;
 const TRACKER_PANEL_EDGE_OFFSET = 8;
 const TRACKER_PANEL_HUD_GAP = 6;
 const TRACKER_PANEL_DESKTOP_MOTION_MS = 260;
@@ -602,15 +601,17 @@ export function AppShell() {
     const topBarRect = topBar ? readVisibleElementRect(topBar) : null;
     if (topBarRect) topCandidates.push(Math.ceil(topBarRect.bottom + TRACKER_PANEL_HUD_GAP));
 
-    const anchors = Array.from(document.querySelectorAll<HTMLElement>(TRACKER_PANEL_ANCHOR_SELECTOR));
-    anchors.forEach((anchor) => {
-      const rect = readVisibleElementRect(anchor);
-      if (rect) topCandidates.push(Math.ceil(rect.bottom + TRACKER_PANEL_HUD_GAP));
-    });
+    if (!trackerPanelDockToEdge) {
+      const anchors = Array.from(document.querySelectorAll<HTMLElement>(TRACKER_PANEL_ANCHOR_SELECTOR));
+      anchors.forEach((anchor) => {
+        const rect = readVisibleElementRect(anchor);
+        if (rect) topCandidates.push(Math.ceil(rect.bottom + TRACKER_PANEL_HUD_GAP));
+      });
+    }
 
     const nextTop = Math.max(...topCandidates);
     setTrackerPanelTop((current) => (current === nextTop ? current : nextTop));
-  }, []);
+  }, [trackerPanelDockToEdge]);
 
   useLayoutEffect(() => {
     if (shellOverlayMode || trackerPanelVisible || !trackerPanelSurfaceAvailable) return;
@@ -786,8 +787,8 @@ export function AppShell() {
             Math.min(56, (trackerPanelToggleAnchorY ?? trackerPanelTop) - trackerPanelTop),
           )}px`,
           ...(side === "left"
-            ? { left: sidebarOpen ? liveSidebarWidth + RESIZER_HITBOX : 0 }
-            : { right: rightPanelOpen ? liveRightPanelWidth + RESIZER_HITBOX : 0 }),
+            ? { left: sidebarOpen ? liveSidebarWidth : 0 }
+            : { right: rightPanelOpen ? liveRightPanelWidth : 0 }),
           ...(trackerPanelBackgroundStyle ?? {}),
         }}
       >
@@ -859,7 +860,7 @@ export function AppShell() {
           tabIndex={0}
           onMouseDown={startSidebarResize}
           onKeyDown={adjustSidebarWidth}
-          className="absolute inset-y-0 z-20 hidden w-1 cursor-col-resize bg-transparent transition-colors hover:bg-[var(--primary)]/30 focus-visible:bg-[var(--primary)]/40 focus-visible:outline-none md:block"
+          className="absolute inset-y-0 z-40 hidden w-1 cursor-col-resize bg-transparent transition-colors hover:bg-[var(--primary)]/30 focus-visible:bg-[var(--primary)]/40 focus-visible:outline-none md:block"
           style={{ left: sidebarOpen ? liveSidebarWidth : 0 }}
         />
       )}
@@ -1055,7 +1056,7 @@ export function AppShell() {
           tabIndex={0}
           onMouseDown={startRightPanelResize}
           onKeyDown={adjustRightPanelWidth}
-          className="absolute inset-y-0 z-20 hidden w-1 cursor-col-resize bg-transparent transition-colors hover:bg-[var(--primary)]/30 focus-visible:bg-[var(--primary)]/40 focus-visible:outline-none md:block"
+          className="absolute inset-y-0 z-40 hidden w-1 cursor-col-resize bg-transparent transition-colors hover:bg-[var(--primary)]/30 focus-visible:bg-[var(--primary)]/40 focus-visible:outline-none md:block"
           style={{ right: rightPanelOpen ? liveRightPanelWidth : 0 }}
         />
       )}

--- a/packages/client/src/features/tracker-panel/components/character-card/CharacterTrackerCard.tsx
+++ b/packages/client/src/features/tracker-panel/components/character-card/CharacterTrackerCard.tsx
@@ -431,6 +431,7 @@ export function CharacterTrackerCard({
                 />
               ) : (
                 <span
+                  title={value}
                   className={cn(
                     "min-w-0 text-[color:var(--tracker-profile-text)]",
                     readableCustomFields ? "line-clamp-2 whitespace-normal break-words" : "truncate",

--- a/packages/client/src/features/tracker-panel/components/character-card/CharacterTrackerField.tsx
+++ b/packages/client/src/features/tracker-panel/components/character-card/CharacterTrackerField.tsx
@@ -90,6 +90,7 @@ export function CompactCharacterField({
         />
       ) : (
         <span
+          title={visibleText(value, placeholder)}
           className={cn(
             "relative z-[1] min-w-0 text-[color:var(--tracker-profile-text)]",
             readable ? "line-clamp-2 whitespace-normal break-words leading-[1.15]" : "truncate",

--- a/packages/client/src/features/tracker-panel/components/character-card/FeaturedCharacterFields.tsx
+++ b/packages/client/src/features/tracker-panel/components/character-card/FeaturedCharacterFields.tsx
@@ -1,10 +1,6 @@
 import { type ReactNode } from "react";
 import { Eye, HeartPulse, Shirt } from "lucide-react";
-import {
-  characterTrackerLockKey,
-  type CharacterStat,
-  type PresentCharacter,
-} from "@marinara-engine/shared";
+import { characterTrackerLockKey, type CharacterStat, type PresentCharacter } from "@marinara-engine/shared";
 import type { TrackerPanelSizeProfile } from "../../../../stores/ui.store";
 import { cn } from "../../../../lib/utils";
 import type { TrackerStatDensity } from "../../tracker-panel.types";
@@ -14,7 +10,8 @@ import { StatList } from "../controls/StatList";
 import { TRACKER_PROFILE_FIELD_TILE_CLASS } from "../controls/TrackerProfileChrome";
 import { useTrackerFieldLock } from "../TrackerLockContext";
 
-const FEATURED_FIELD_LIST_CLASS = "relative z-[1] grid h-full min-h-0 grid-cols-1 gap-1 overflow-hidden p-1";
+const FEATURED_FIELD_LIST_CLASS =
+  "relative z-[1] grid h-full min-h-0 grid-cols-1 gap-0.5 overflow-hidden px-1 py-0.5";
 const FEATURED_FIELD_ICON_CLASS =
   "relative flex h-4 w-4 shrink-0 items-center justify-center rounded-full text-[color-mix(in_srgb,var(--tracker-profile-icon)_58%,var(--tracker-profile-text)_42%)] opacity-[0.82] ring-1 ring-inset ring-[color-mix(in_srgb,var(--tracker-profile-dialogue-border)_18%,transparent)] transition-colors before:absolute before:inset-[3px] before:rounded-full before:bg-[color-mix(in_srgb,var(--tracker-profile-accent-solid)_3%,transparent)] before:content-[''] group-hover/field:text-[color-mix(in_srgb,var(--tracker-profile-icon)_78%,var(--tracker-profile-text)_22%)] group-hover/field:ring-[color-mix(in_srgb,var(--tracker-profile-dialogue-border)_34%,transparent)] group-hover/field:before:bg-[color-mix(in_srgb,var(--tracker-profile-accent-solid)_6%,transparent)] [&>svg]:relative [&>svg]:z-[1] [&>svg]:stroke-[1.85]";
 type FeaturedFieldTone = "mood" | "appearance" | "outfit";
@@ -29,7 +26,7 @@ const FEATURED_FIELD_ICON_TONE_CLASS = {
 const FEATURED_FIELD_TILE_CLASS_BY_PROFILE = {
   compact: "py-0.5",
   standard: "py-1",
-  expanded: "py-1.5",
+  expanded: "py-1",
 } satisfies Record<TrackerPanelSizeProfile, string>;
 const FEATURED_FIELD_TEXT_CLASS_BY_PROFILE = {
   compact: "text-[0.625rem] leading-[1.12]",
@@ -39,15 +36,15 @@ const FEATURED_FIELD_TEXT_CLASS_BY_PROFILE = {
 const FEATURED_FIELD_PREVIEW_LINES_BY_PROFILE = {
   compact: 2,
   standard: 3,
-  expanded: 4,
+  expanded: 3,
 } satisfies Record<TrackerPanelSizeProfile, 2 | 3 | 4>;
 const FEATURED_FIELD_PREVIEW_CLASS_BY_PROFILE = {
   compact: "line-clamp-2",
   standard: "line-clamp-3",
-  expanded: "line-clamp-4",
+  expanded: "line-clamp-3",
 } satisfies Record<TrackerPanelSizeProfile, string>;
 const FEATURED_STAT_SHELF_CLASS = cn(
-  "group/statbox relative isolate flex min-h-0 flex-col overflow-x-hidden border-t border-[color-mix(in_srgb,var(--tracker-profile-dialogue-border)_38%,transparent)] bg-[image:var(--tracker-profile-material)] px-1 py-1.5 shadow-[inset_0_1px_0_color-mix(in_srgb,var(--foreground)_4%,transparent),inset_0_8px_14px_color-mix(in_srgb,var(--background)_22%,transparent)] [background-blend-mode:var(--tracker-profile-material-blend)] before:pointer-events-none before:absolute before:inset-x-3 before:top-0 before:z-[1] before:h-px before:bg-[linear-gradient(90deg,transparent,color-mix(in_srgb,var(--tracker-profile-dialogue-border)_34%,transparent),transparent)] before:opacity-55 before:content-['']",
+  "group/statbox relative isolate flex min-h-0 flex-col overflow-x-hidden border-t border-[color-mix(in_srgb,var(--tracker-profile-dialogue-border)_38%,transparent)] bg-[image:var(--tracker-profile-material)] p-1 shadow-[inset_0_1px_0_color-mix(in_srgb,var(--foreground)_4%,transparent),inset_0_8px_14px_color-mix(in_srgb,var(--background)_22%,transparent)] [background-blend-mode:var(--tracker-profile-material-blend)] before:pointer-events-none before:absolute before:inset-x-3 before:top-0 before:z-[1] before:h-px before:bg-[linear-gradient(90deg,transparent,color-mix(in_srgb,var(--tracker-profile-dialogue-border)_34%,transparent),transparent)] before:opacity-55 before:content-['']",
   "max-h-[7.75rem] @min-[380px]:max-h-[9.25rem]",
 );
 
@@ -102,6 +99,7 @@ function FeaturedFieldTile({
         />
       ) : (
         <span
+          title={displayValue}
           className={cn(
             "self-center text-[color:var(--tracker-profile-text)]",
             readable ? "min-h-0 break-words [align-content:start]" : "block truncate text-[0.625rem]",
@@ -162,6 +160,7 @@ export function FeaturedFieldList({
     },
   ].filter((field) => field.show);
   if (fields.length === 0) return null;
+  const fieldSizeProfile = readableRows ? sizeProfile : "compact";
 
   return (
     <div className={FEATURED_FIELD_LIST_CLASS} style={{ gridTemplateRows: `repeat(${fields.length}, minmax(0, 1fr))` }}>
@@ -173,8 +172,8 @@ export function FeaturedFieldList({
           value={field.value}
           placeholder={field.placeholder}
           onSave={field.onSave}
-          readable={readableRows}
-          sizeProfile={sizeProfile}
+          readable={readableRows || field.key !== "mood"}
+          sizeProfile={fieldSizeProfile}
           tone={field.tone}
           lockKey={characterTrackerLockKey(character, characterIndex, field.key as FeaturedCharacterFieldKey)}
         />

--- a/packages/client/src/features/tracker-panel/components/controls/InlineControls.tsx
+++ b/packages/client/src/features/tracker-panel/components/controls/InlineControls.tsx
@@ -69,7 +69,7 @@ export function FittedText({
         {children}
       </span>
       <span
-        className="block min-w-0 max-w-full overflow-hidden whitespace-nowrap"
+        className="block min-w-0 max-w-full overflow-hidden text-ellipsis whitespace-nowrap"
         style={scale < 0.999 ? { fontSize: `calc(1em * ${scale.toFixed(3)})` } : undefined}
       >
         {children}
@@ -315,7 +315,53 @@ export function InlineNumber({
   onToggleLock?: () => void;
 }) {
   const numericValue = coerceStatNumber(value);
-  const width = getNumberValueWidth(numericValue);
+  const [draft, setDraft] = useState(String(numericValue));
+  const [focused, setFocused] = useState(false);
+  const cancelledRef = useRef(false);
+  const pendingValueRef = useRef<number | null>(null);
+  const lastExternalValueRef = useRef(numericValue);
+  const displayedValue = pendingValueRef.current ?? numericValue;
+  const committedValue = String(displayedValue);
+  // Keep keystrokes as text until commit so clearing `0` does not immediately coerce back to `0`.
+  const width = getNumberValueWidth(focused ? draft : committedValue);
+
+  useEffect(() => {
+    const externalValueChanged = lastExternalValueRef.current !== numericValue;
+    lastExternalValueRef.current = numericValue;
+
+    if (pendingValueRef.current !== null) {
+      if (numericValue === pendingValueRef.current) {
+        pendingValueRef.current = null;
+      } else if (!externalValueChanged) {
+        return;
+      } else {
+        pendingValueRef.current = null;
+      }
+    }
+
+    if (!focused) setDraft(String(numericValue));
+  }, [numericValue, focused]);
+
+  const commit = () => {
+    setFocused(false);
+    if (cancelledRef.current) {
+      cancelledRef.current = false;
+      setDraft(committedValue);
+      return;
+    }
+
+    const trimmed = draft.trim();
+    const parsed = trimmed ? Number(trimmed) : Number.NaN;
+    if (!Number.isFinite(parsed)) {
+      setDraft(committedValue);
+      return;
+    }
+
+    const next = min === undefined ? parsed : Math.max(min, parsed);
+    pendingValueRef.current = next === numericValue ? null : next;
+    setDraft(String(next));
+    if (next !== numericValue) onChange(next);
+  };
 
   if (lockMode && onToggleLock) {
     return (
@@ -343,13 +389,24 @@ export function InlineNumber({
   return (
     <input
       type="number"
-      value={numericValue}
-      onChange={(event) => {
-        const numeric = Number(event.target.value);
-        const next = Number.isFinite(numeric) ? numeric : 0;
-        onChange(min === undefined ? next : Math.max(min, next));
+      value={draft}
+      onFocus={(event) => {
+        cancelledRef.current = false;
+        setFocused(true);
+        event.currentTarget.select();
+      }}
+      onChange={(event) => setDraft(event.target.value)}
+      onBlur={commit}
+      onKeyDown={(event) => {
+        if (event.key === "Enter") event.currentTarget.blur();
+        if (event.key === "Escape") {
+          cancelledRef.current = true;
+          setDraft(committedValue);
+          event.currentTarget.blur();
+        }
       }}
       title={title}
+      aria-label={title}
       style={{ width }}
       className={cn(
         "rounded bg-transparent px-1 py-0.5 text-right text-[0.625rem] tabular-nums text-[color:var(--tracker-inline-number,var(--tracker-inline-foreground,var(--foreground)))] outline-none transition-colors hover:bg-[var(--accent)]/45 focus:bg-[var(--background)] focus:ring-1 focus:ring-[var(--border)] [appearance:textfield] [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none",

--- a/packages/client/src/features/tracker-panel/components/sections/CustomTrackerPanel.tsx
+++ b/packages/client/src/features/tracker-panel/components/sections/CustomTrackerPanel.tsx
@@ -19,7 +19,11 @@ import { useTrackerLockContext } from "../TrackerLockContext";
 function isLongCustomField(field: CustomTrackerField): boolean {
   const name = visibleText(field.name, "");
   const value = visibleText(field.value, "");
-  return name.length > 16 || value.length > 22 || (/\s/.test(value) && value.length > 14);
+  return name.length > 24 || value.length > 32 || (/\s/.test(value) && value.length > 26);
+}
+
+function isNumericCustomFieldValue(value: string): boolean {
+  return /^[+-]?(?:\d+(?:[.,]\d+)?|\.\d+)(?:\s*%|\s*\/\s*[+-]?\d+(?:[.,]\d+)?)?$/.test(value.trim());
 }
 
 function shouldUseCustomFieldColumns(
@@ -79,15 +83,15 @@ function CustomFieldList({
       ) : (
         <div
           className={cn(
-            "grid grid-cols-1 border-t border-[var(--border)]/30",
+            "grid grid-cols-1 border-t border-[var(--border)]/30 px-1",
             useFieldColumns && "@min-[300px]:grid-cols-2",
           )}
         >
           {fields.map((field, index) => {
             const allowWrap = readableValues && isLongCustomField(field);
             const valueText = visibleText(field.value, "");
-            const valueIsLong = valueText.length > 18 || valueText.includes(" ");
-            const valueAlignment = allowWrap && valueIsLong ? "text-left" : "text-right tabular-nums";
+            const numericValue = isNumericCustomFieldValue(valueText);
+            const valueTypography = numericValue ? "tabular-nums" : undefined;
             const valueLockKey = customTrackerLockKey(field, "value", index);
             const valueLocked = isTrackerFieldLocked(fieldLocks, valueLockKey);
             const toggleValueLock = () => {
@@ -99,9 +103,10 @@ function CustomFieldList({
               <div
                 key={`${field.name}-${index}`}
                 className={cn(
-                  "group/field relative grid min-h-6 grid-cols-[minmax(3rem,0.42fr)_minmax(0,1fr)] items-center gap-1 border-b border-[var(--border)]/28 px-1 py-0.5 text-[0.6875rem] leading-[0.875rem]",
-                  trackerPanelSizeProfile !== "compact" && "grid-cols-[minmax(3.5rem,0.42fr)_minmax(0,1fr)]",
-                  allowWrap && "min-h-8 items-start py-1 leading-[0.95rem]",
+                  "group/field relative grid min-h-7 grid-cols-[minmax(5.5rem,0.42fr)_minmax(0,1fr)] items-center gap-2 border-b border-[var(--border)]/28 px-1 py-1 text-[0.6875rem] leading-[0.875rem] transition-colors hover:bg-[color-mix(in_srgb,var(--foreground)_3%,transparent)]",
+                  trackerPanelSizeProfile !== "compact" &&
+                    "grid-cols-[minmax(7rem,0.45fr)_minmax(0,1fr)]",
+                  allowWrap && "leading-[0.95rem]",
                   useFieldColumns &&
                     index % 2 === 0 &&
                     !(fields.length % 2 === 1 && index === fields.length - 1) &&
@@ -110,7 +115,6 @@ function CustomFieldList({
                     fields.length % 2 === 1 &&
                     index === fields.length - 1 &&
                     "@min-[300px]:col-span-2",
-                  onUpdate && "pr-5",
                   deleteMode && "pr-9",
                 )}
               >
@@ -119,8 +123,9 @@ function CustomFieldList({
                     value={field.name}
                     onSave={(name) => updateField(index, { ...field, name: name || "Field" })}
                     placeholder="Field"
-                    className={cn("min-w-0 px-0.5 py-0 font-medium", allowWrap && "min-h-5")}
+                    className={cn("min-w-0 px-0.5 py-0 font-semibold", allowWrap && "min-h-5")}
                     previewLineCount={allowWrap ? 2 : undefined}
+                    previewClassName={allowWrap ? "leading-[1.25]" : undefined}
                     scrollOnHover={!allowWrap}
                     showEditHint={false}
                     locked={isTrackerFieldLocked(fieldLocks, customTrackerLockKey(field, "name", index))}
@@ -130,7 +135,7 @@ function CustomFieldList({
                 ) : (
                   <span
                     className={cn(
-                      "min-w-0 px-0.5 font-medium text-[var(--muted-foreground)]",
+                      "min-w-0 px-0.5 font-semibold text-[var(--muted-foreground)]",
                       allowWrap ? "line-clamp-2 break-words" : "truncate",
                     )}
                   >
@@ -143,12 +148,13 @@ function CustomFieldList({
                     onSave={(value) => updateField(index, { ...field, value })}
                     placeholder="Value"
                     className={cn(
-                      "min-w-0 px-0.5 py-0",
-                      valueAlignment,
-                      allowWrap ? "min-h-5 justify-start leading-[1.15]" : "justify-end",
+                      "min-w-0 justify-start px-0.5 py-0 text-left",
+                      valueTypography,
+                      allowWrap ? "min-h-5 leading-[1.15]" : undefined,
                     )}
                     twoLinePreview={allowWrap}
                     previewLineCount={allowWrap ? 2 : undefined}
+                    previewClassName={allowWrap ? "leading-[1.25]" : undefined}
                     scrollOnHover={!allowWrap}
                     showEditHint={false}
                     locked={valueLocked || field.locked}
@@ -158,27 +164,25 @@ function CustomFieldList({
                 ) : (
                   <span
                     className={cn(
-                      "min-w-0 px-0.5 text-[var(--foreground)]",
-                      valueAlignment,
+                      "min-w-0 px-0.5 py-0 text-left text-[var(--foreground)]",
+                      valueTypography,
                       allowWrap ? "line-clamp-2 break-words leading-[1.15]" : "truncate",
                     )}
                   >
                     {visibleText(field.value, "Empty")}
                   </span>
                 )}
-                {onUpdate && (
+                {onUpdate && deleteMode && (
                   <span className="absolute right-1 top-1/2 flex -translate-y-1/2 items-center gap-0.5">
-                    {deleteMode && (
-                      <button
-                        type="button"
-                        onClick={() => removeField(index)}
-                        className="flex h-4 w-4 items-center justify-center rounded-full bg-[var(--background)]/85 text-[var(--destructive)] shadow-sm ring-1 ring-[var(--border)]/70 backdrop-blur-sm transition-all hover:bg-[var(--accent)] focus-visible:outline-none focus-visible:ring-[var(--border)] active:scale-90"
-                        title="Remove field"
-                        aria-label={`Remove ${visibleText(field.name, "field")}`}
-                      >
-                        <X size="0.5625rem" />
-                      </button>
-                    )}
+                    <button
+                      type="button"
+                      onClick={() => removeField(index)}
+                      className="flex h-4 w-4 items-center justify-center rounded-full bg-[var(--background)]/85 text-[var(--destructive)] shadow-sm ring-1 ring-[var(--border)]/70 backdrop-blur-sm transition-all hover:bg-[var(--accent)] focus-visible:outline-none focus-visible:ring-[var(--border)] active:scale-90"
+                      title="Remove field"
+                      aria-label={`Remove ${visibleText(field.name, "field")}`}
+                    >
+                      <X size="0.5625rem" />
+                    </button>
                   </span>
                 )}
               </div>

--- a/packages/client/src/features/tracker-panel/components/sections/WorldDateTimeTiles.tsx
+++ b/packages/client/src/features/tracker-panel/components/sections/WorldDateTimeTiles.tsx
@@ -1,6 +1,7 @@
 import { Clock } from "lucide-react";
 import { cn } from "../../../../lib/utils";
 import { getWorldDateDisplay, getWorldTimeDisplay, type WorldDateDisplay } from "../../lib/world-state-display";
+import { FittedText } from "../controls/InlineControls";
 import { useTrackerFieldLock } from "../TrackerLockContext";
 import { WorldRenderedEdit, WorldTileShell } from "./WorldEditableTile";
 
@@ -107,6 +108,7 @@ export function WorldTimeTile({
   const lock = useTrackerFieldLock(lockKey);
   const display = getWorldTimeDisplay(value);
   const isPhraseTime = display.kind === "phrase";
+  const clockLabel = `${display.main}${display.suffix ? ` ${display.suffix}` : ""}`;
 
   return (
     <WorldTileShell label="Time">
@@ -119,7 +121,7 @@ export function WorldTimeTile({
           "overflow-hidden text-center",
           isPhraseTime
             ? "flex flex-col items-center justify-center px-0.5 py-1"
-            : "grid grid-rows-[minmax(0,1fr)_0.625rem] px-1 pb-0.5 pt-0.5",
+            : "grid grid-rows-[minmax(0,1fr)_0.6875rem] px-0.5 pb-0.5 pt-0.5",
         )}
         inputClassName="text-center"
         showEditHint={false}
@@ -139,16 +141,14 @@ export function WorldTimeTile({
             <div className="flex min-h-0 items-center justify-center overflow-visible">
               <WorldClockFace hour={display.hour} minute={display.minute} />
             </div>
-            <div className="flex min-w-0 max-w-full translate-y-px items-baseline justify-center gap-0.5">
-              <span className="truncate text-[0.5625rem] font-black leading-[0.625rem] text-[var(--foreground)]">
-                {display.main}
-              </span>
-              {display.suffix && (
-                <span className="shrink-0 text-[0.4375rem] font-bold leading-none text-[var(--muted-foreground)]">
-                  {display.suffix}
-                </span>
-              )}
-            </div>
+            <FittedText
+              align="center"
+              minScale={0.62}
+              title={clockLabel}
+              className="w-full max-w-full translate-y-px text-[0.625rem] font-black leading-[0.6875rem] text-[var(--foreground)]"
+            >
+              {clockLabel}
+            </FittedText>
           </>
         )}
       </WorldRenderedEdit>

--- a/packages/client/src/features/tracker-panel/components/sections/WorldEditableTile.tsx
+++ b/packages/client/src/features/tracker-panel/components/sections/WorldEditableTile.tsx
@@ -21,7 +21,6 @@ export function WorldTileShell({
       title={label}
     >
       <div className="pointer-events-none absolute inset-0 bg-[linear-gradient(135deg,color-mix(in_srgb,var(--foreground)_5%,transparent),transparent_42%,color-mix(in_srgb,var(--foreground)_7%,transparent))]" />
-      <div className="pointer-events-none absolute inset-x-1 top-1 h-px bg-[linear-gradient(90deg,transparent,color-mix(in_srgb,var(--foreground)_18%,transparent),transparent)]" />
       <div className="pointer-events-none absolute inset-x-1 bottom-1 h-px bg-[linear-gradient(90deg,transparent,color-mix(in_srgb,var(--foreground)_14%,transparent),transparent)] opacity-70" />
       <span className="sr-only">{label}</span>
       <div className="relative z-[1] h-full min-w-0">{children}</div>

--- a/packages/client/src/features/tracker-panel/components/sections/WorldForecastTile.tsx
+++ b/packages/client/src/features/tracker-panel/components/sections/WorldForecastTile.tsx
@@ -1,7 +1,12 @@
 import type { CSSProperties } from "react";
 import type { TrackerPanelSizeProfile, TrackerTemperatureUnit } from "../../../../stores/ui.store";
 import { cn } from "../../../../lib/utils";
-import { getTemperatureColor, getTemperatureGaugeDisplay, getWeatherEmoji } from "../../lib/world-state-display";
+import {
+  getTemperatureColor,
+  getTemperatureGaugeDisplay,
+  getWeatherEmoji,
+  parseTemperatureValue,
+} from "../../lib/world-state-display";
 import { visibleText } from "../../lib/tracker-display";
 import { FittedText } from "../controls/InlineControls";
 import { useTrackerFieldLock } from "../TrackerLockContext";
@@ -30,7 +35,12 @@ export function WorldForecastTile({
   const temperatureLock = useTrackerFieldLock(temperatureLockKey);
   const weatherText = visibleText(weather, "Set weather");
   const temperatureDisplay = getTemperatureGaugeDisplay(temperature, trackerTemperatureUnit);
+  const temperatureText = temperature?.trim() ?? "";
+  const useDescriptiveTempRail =
+    parseTemperatureValue(temperatureText) === null &&
+    (temperatureText.includes(" ") || temperatureText.length > 7);
   const useHorizontalTempRail = trackerPanelSizeProfile !== "compact";
+  const useHorizontalTempLayout = useHorizontalTempRail || useDescriptiveTempRail;
   return (
     <WorldTileShell label="Forecast" className="min-h-[3.125rem]">
       <div className="@container relative h-full min-w-0 overflow-hidden">
@@ -38,7 +48,9 @@ export function WorldForecastTile({
           aria-hidden="true"
           className={cn(
             "pointer-events-none absolute top-1/2 z-0 -translate-y-1/2 select-none text-[2.75rem] leading-none opacity-[0.085] saturate-125 @min-[7rem]:text-[3.25rem] @min-[10rem]:text-[4rem] @min-[14rem]:text-[4.65rem]",
-            useHorizontalTempRail
+            useDescriptiveTempRail
+              ? "right-[46%] @min-[10rem]:right-[44%] @min-[14rem]:right-[42%]"
+              : useHorizontalTempRail
               ? "right-[4rem] @min-[7rem]:right-[4.15rem] @min-[10rem]:right-[4.25rem] @min-[14rem]:right-[4.35rem]"
               : "right-[2rem] @min-[7rem]:right-[2.3rem] @min-[10rem]:right-[2.7rem] @min-[14rem]:right-[3.05rem]",
           )}
@@ -54,18 +66,24 @@ export function WorldForecastTile({
           placeholder="Set weather"
           className={cn(
             "relative z-[2] flex h-full min-w-0 flex-col justify-center overflow-hidden px-1.5 py-1 text-left @min-[10rem]:px-2",
-            useHorizontalTempRail
+            useDescriptiveTempRail
+              ? "pr-[48%] @min-[10rem]:pr-[46%] @min-[14rem]:pr-[44%]"
+              : useHorizontalTempRail
               ? "pr-[4.75rem] @min-[7rem]:pr-[4.9rem] @min-[10rem]:pr-[5rem] @min-[14rem]:pr-[5.1rem]"
               : "pr-[2.65rem] @min-[7rem]:pr-[2.95rem] @min-[10rem]:pr-[3.35rem] @min-[14rem]:pr-[3.85rem]",
           )}
           inputClassName={cn(
             "text-left text-[0.75rem]",
-            useHorizontalTempRail
+            useDescriptiveTempRail
+              ? "pr-[48%] @min-[10rem]:pr-[46%] @min-[14rem]:pr-[44%]"
+              : useHorizontalTempRail
               ? "pr-[4.75rem] @min-[7rem]:pr-[4.9rem] @min-[10rem]:pr-[5rem] @min-[14rem]:pr-[5.1rem]"
               : "pr-[2.65rem] @min-[7rem]:pr-[2.95rem] @min-[10rem]:pr-[3.35rem] @min-[14rem]:pr-[3.85rem]",
           )}
           editHintClassName={cn(
-            useHorizontalTempRail
+            useDescriptiveTempRail
+              ? "right-[47%] @min-[10rem]:right-[45%] @min-[14rem]:right-[43%]"
+              : useHorizontalTempRail
               ? "right-[4.45rem] @min-[7rem]:right-[4.6rem] @min-[10rem]:right-[4.7rem] @min-[14rem]:right-[4.8rem]"
               : "right-[2.45rem] @min-[7rem]:right-[2.65rem] @min-[10rem]:right-[2.95rem] @min-[14rem]:right-[3.25rem]",
           )}
@@ -76,7 +94,9 @@ export function WorldForecastTile({
         <div
           className={cn(
             "absolute bottom-0.5 right-0.5 top-0.5 z-[3]",
-            useHorizontalTempRail
+            useDescriptiveTempRail
+              ? "w-[46%] @min-[10rem]:w-[44%] @min-[14rem]:w-[42%]"
+              : useHorizontalTempRail
               ? "w-[4.15rem] @min-[7rem]:w-[4.25rem] @min-[10rem]:w-[4.35rem] @min-[14rem]:w-[4.45rem]"
               : "w-[2.3rem] @min-[7rem]:w-[2.45rem] @min-[10rem]:bottom-0.5 @min-[10rem]:top-auto @min-[10rem]:h-[2.95rem] @min-[10rem]:w-[2.7rem] @min-[14rem]:w-[3rem]",
           )}
@@ -88,20 +108,26 @@ export function WorldForecastTile({
             placeholder="Set temp"
             className={cn(
               "h-full w-full rounded-[3px] bg-[color-mix(in_srgb,var(--background)_38%,transparent)] text-center shadow-[inset_0_1px_0_color-mix(in_srgb,var(--foreground)_8%,transparent),0_0_8px_color-mix(in_srgb,var(--background)_30%,transparent)] ring-1 ring-[var(--border)]/24 hover:!bg-[color-mix(in_srgb,var(--background)_46%,transparent)]",
-              useHorizontalTempRail
+              useHorizontalTempLayout
                 ? "grid grid-cols-[minmax(0,1fr)_1.4rem] items-center gap-0.5 py-0.5 pl-0.5 pr-1 @min-[10rem]:grid-cols-[minmax(0,1fr)_1.5rem] @min-[14rem]:gap-1 @min-[14rem]:pl-1 @min-[14rem]:pr-1.5"
                 : "flex flex-col items-center justify-center gap-[0.125rem] px-0 pb-0.5 pt-0.5 @min-[10rem]:gap-0.5 @min-[10rem]:pt-0.5",
             )}
-            inputClassName={cn("text-center text-[0.625rem]", useHorizontalTempRail && "text-[0.6875rem]")}
+            inputClassName={cn(
+              "text-center text-[0.625rem]",
+              useHorizontalTempRail && "text-[0.6875rem]",
+              useDescriptiveTempRail && "text-left",
+            )}
             showEditHint={false}
             {...temperatureLock}
           >
             <span
               className={cn(
-                "min-w-0 truncate font-black leading-none tracking-normal drop-shadow-sm",
-                useHorizontalTempRail
-                  ? "justify-self-end text-right text-[0.625rem] @min-[10rem]:text-[0.6875rem] @min-[14rem]:text-[0.75rem]"
-                  : "text-[0.5625rem] @min-[10rem]:text-[0.625rem]",
+                "min-w-0 font-black tracking-normal drop-shadow-sm",
+                useDescriptiveTempRail
+                  ? "line-clamp-3 w-full justify-self-stretch whitespace-normal break-words text-left text-[0.5625rem] leading-[1.05] @min-[10rem]:text-[0.625rem]"
+                  : useHorizontalTempLayout
+                    ? "truncate justify-self-end text-right text-[0.625rem] leading-none @min-[10rem]:text-[0.6875rem] @min-[14rem]:text-[0.75rem]"
+                    : "truncate text-[0.5625rem] leading-none @min-[10rem]:text-[0.625rem]",
                 getTemperatureColor(temperature),
               )}
             >
@@ -110,12 +136,14 @@ export function WorldForecastTile({
             <span
               className={cn(
                 "flex min-w-0 items-center justify-center overflow-visible",
-                useHorizontalTempRail ? "h-full w-full" : "order-first h-[1.55rem] w-full @min-[14rem]:h-[1.6rem]",
+                useHorizontalTempLayout
+                  ? "h-full w-full"
+                  : "order-first h-[1.55rem] w-full @min-[14rem]:h-[1.6rem]",
               )}
             >
               <WorldThermometerGauge
                 display={temperatureDisplay}
-                variant={useHorizontalTempRail ? "expanded" : "compact"}
+                variant={useHorizontalTempLayout ? "expanded" : "compact"}
               />
             </span>
           </WorldRenderedEdit>

--- a/packages/client/src/features/tracker-panel/components/sections/WorldForecastTile.tsx
+++ b/packages/client/src/features/tracker-panel/components/sections/WorldForecastTile.tsx
@@ -5,7 +5,7 @@ import {
   getTemperatureColor,
   getTemperatureGaugeDisplay,
   getWeatherEmoji,
-  parseTemperatureValue,
+  parsePureTemperatureValue,
 } from "../../lib/world-state-display";
 import { visibleText } from "../../lib/tracker-display";
 import { FittedText } from "../controls/InlineControls";
@@ -36,9 +36,7 @@ export function WorldForecastTile({
   const weatherText = visibleText(weather, "Set weather");
   const temperatureDisplay = getTemperatureGaugeDisplay(temperature, trackerTemperatureUnit);
   const temperatureText = temperature?.trim() ?? "";
-  const useDescriptiveTempRail =
-    parseTemperatureValue(temperatureText) === null &&
-    (temperatureText.includes(" ") || temperatureText.length > 7);
+  const useDescriptiveTempRail = temperatureText.length > 0 && parsePureTemperatureValue(temperatureText) === null;
   const useHorizontalTempRail = trackerPanelSizeProfile !== "compact";
   const useHorizontalTempLayout = useHorizontalTempRail || useDescriptiveTempRail;
   return (
@@ -51,8 +49,8 @@ export function WorldForecastTile({
             useDescriptiveTempRail
               ? "right-[46%] @min-[10rem]:right-[44%] @min-[14rem]:right-[42%]"
               : useHorizontalTempRail
-              ? "right-[4rem] @min-[7rem]:right-[4.15rem] @min-[10rem]:right-[4.25rem] @min-[14rem]:right-[4.35rem]"
-              : "right-[2rem] @min-[7rem]:right-[2.3rem] @min-[10rem]:right-[2.7rem] @min-[14rem]:right-[3.05rem]",
+                ? "right-[4rem] @min-[7rem]:right-[4.15rem] @min-[10rem]:right-[4.25rem] @min-[14rem]:right-[4.35rem]"
+                : "right-[2rem] @min-[7rem]:right-[2.3rem] @min-[10rem]:right-[2.7rem] @min-[14rem]:right-[3.05rem]",
           )}
         >
           {getWeatherEmoji(weather)}
@@ -69,23 +67,23 @@ export function WorldForecastTile({
             useDescriptiveTempRail
               ? "pr-[48%] @min-[10rem]:pr-[46%] @min-[14rem]:pr-[44%]"
               : useHorizontalTempRail
-              ? "pr-[4.75rem] @min-[7rem]:pr-[4.9rem] @min-[10rem]:pr-[5rem] @min-[14rem]:pr-[5.1rem]"
-              : "pr-[2.65rem] @min-[7rem]:pr-[2.95rem] @min-[10rem]:pr-[3.35rem] @min-[14rem]:pr-[3.85rem]",
+                ? "pr-[4.75rem] @min-[7rem]:pr-[4.9rem] @min-[10rem]:pr-[5rem] @min-[14rem]:pr-[5.1rem]"
+                : "pr-[2.65rem] @min-[7rem]:pr-[2.95rem] @min-[10rem]:pr-[3.35rem] @min-[14rem]:pr-[3.85rem]",
           )}
           inputClassName={cn(
             "text-left text-[0.75rem]",
             useDescriptiveTempRail
               ? "pr-[48%] @min-[10rem]:pr-[46%] @min-[14rem]:pr-[44%]"
               : useHorizontalTempRail
-              ? "pr-[4.75rem] @min-[7rem]:pr-[4.9rem] @min-[10rem]:pr-[5rem] @min-[14rem]:pr-[5.1rem]"
-              : "pr-[2.65rem] @min-[7rem]:pr-[2.95rem] @min-[10rem]:pr-[3.35rem] @min-[14rem]:pr-[3.85rem]",
+                ? "pr-[4.75rem] @min-[7rem]:pr-[4.9rem] @min-[10rem]:pr-[5rem] @min-[14rem]:pr-[5.1rem]"
+                : "pr-[2.65rem] @min-[7rem]:pr-[2.95rem] @min-[10rem]:pr-[3.35rem] @min-[14rem]:pr-[3.85rem]",
           )}
           editHintClassName={cn(
             useDescriptiveTempRail
               ? "right-[47%] @min-[10rem]:right-[45%] @min-[14rem]:right-[43%]"
               : useHorizontalTempRail
-              ? "right-[4.45rem] @min-[7rem]:right-[4.6rem] @min-[10rem]:right-[4.7rem] @min-[14rem]:right-[4.8rem]"
-              : "right-[2.45rem] @min-[7rem]:right-[2.65rem] @min-[10rem]:right-[2.95rem] @min-[14rem]:right-[3.25rem]",
+                ? "right-[4.45rem] @min-[7rem]:right-[4.6rem] @min-[10rem]:right-[4.7rem] @min-[14rem]:right-[4.8rem]"
+                : "right-[2.45rem] @min-[7rem]:right-[2.65rem] @min-[10rem]:right-[2.95rem] @min-[14rem]:right-[3.25rem]",
           )}
           {...weatherLock}
         >
@@ -97,8 +95,8 @@ export function WorldForecastTile({
             useDescriptiveTempRail
               ? "w-[46%] @min-[10rem]:w-[44%] @min-[14rem]:w-[42%]"
               : useHorizontalTempRail
-              ? "w-[4.15rem] @min-[7rem]:w-[4.25rem] @min-[10rem]:w-[4.35rem] @min-[14rem]:w-[4.45rem]"
-              : "w-[2.3rem] @min-[7rem]:w-[2.45rem] @min-[10rem]:bottom-0.5 @min-[10rem]:top-auto @min-[10rem]:h-[2.95rem] @min-[10rem]:w-[2.7rem] @min-[14rem]:w-[3rem]",
+                ? "w-[4.15rem] @min-[7rem]:w-[4.25rem] @min-[10rem]:w-[4.35rem] @min-[14rem]:w-[4.45rem]"
+                : "w-[2.3rem] @min-[7rem]:w-[2.45rem] @min-[10rem]:bottom-0.5 @min-[10rem]:top-auto @min-[10rem]:h-[2.95rem] @min-[10rem]:w-[2.7rem] @min-[14rem]:w-[3rem]",
           )}
         >
           <WorldRenderedEdit
@@ -136,9 +134,7 @@ export function WorldForecastTile({
             <span
               className={cn(
                 "flex min-w-0 items-center justify-center overflow-visible",
-                useHorizontalTempLayout
-                  ? "h-full w-full"
-                  : "order-first h-[1.55rem] w-full @min-[14rem]:h-[1.6rem]",
+                useHorizontalTempLayout ? "h-full w-full" : "order-first h-[1.55rem] w-full @min-[14rem]:h-[1.6rem]",
               )}
             >
               <WorldThermometerGauge

--- a/packages/client/src/features/tracker-panel/components/sections/WorldStatePanel.tsx
+++ b/packages/client/src/features/tracker-panel/components/sections/WorldStatePanel.tsx
@@ -62,9 +62,7 @@ export function WorldStatePanel({
       />
 
       {!collapsed && (
-        <div
-          className={cn("relative grid gap-px p-1 @min-[380px]:gap-1 @min-[380px]:p-1.5", gridColumnsClass)}
-        >
+        <div className={cn("relative grid gap-0.5 p-1", gridColumnsClass)}>
           <WorldDateTile
             value={state?.date}
             display={dateDisplay}

--- a/packages/client/src/features/tracker-panel/lib/tracker-display.ts
+++ b/packages/client/src/features/tracker-panel/lib/tracker-display.ts
@@ -8,7 +8,7 @@ export function clampNumber(value: number, min: number, max: number) {
   return Math.min(max, Math.max(min, value));
 }
 
-export function getNumberValueWidth(value: number) {
-  const text = Number.isFinite(value) ? String(value) : "0";
-  return `${Math.min(7, Math.max(1.15, text.length + 0.1))}ch`;
+export function getNumberValueWidth(value: number | string) {
+  const text = typeof value === "number" ? (Number.isFinite(value) ? String(value) : "0") : value.trim() || "0";
+  return `${Math.min(10, Math.max(1.35, text.length + 0.35))}ch`;
 }

--- a/packages/client/src/features/tracker-panel/lib/tracker-panel.constants.ts
+++ b/packages/client/src/features/tracker-panel/lib/tracker-panel.constants.ts
@@ -25,7 +25,6 @@ export const TRACKER_FEATURED_CHARACTER_META_KEY = "trackerFeaturedCharacterKeys
 export const TRACKER_TEXT_ROW = "text-[0.6875rem] leading-[0.875rem]";
 export const TRACKER_TEXT_MICRO = "text-[0.625rem] leading-[0.75rem]";
 export const TRACKER_BAR = "h-[3px] rounded-[1px]";
-export const TRACKER_SPLIT_WIDTH = 260;
 export const TRACKER_PROFILE_PORTRAIT_COLUMN_RIGHT_CLASS =
   "grid-cols-[minmax(0,1fr)_clamp(5.25rem,38cqw,6.75rem)] @min-[380px]:grid-cols-[minmax(0,1fr)_9.25rem]";
 export const TRACKER_PROFILE_PORTRAIT_COLUMN_LEFT_CLASS =

--- a/packages/client/src/features/tracker-panel/lib/world-state-display.ts
+++ b/packages/client/src/features/tracker-panel/lib/world-state-display.ts
@@ -8,10 +8,10 @@ import { visibleText } from "./tracker-display";
 // full-width row below (see WorldStatePanel), so no per-tile width balancing is
 // needed. Word-based times ("Afternoon") get a wider Time column so the word
 // stays readable and wraps on spaces instead of shrinking; clock times keep the
-// compact 2.5rem column.
-export const WORLD_GRID_BASE_CLASS = "grid-cols-[2.5rem_2.5rem_minmax(0,1fr)]";
+// compact 3.25rem column.
+export const WORLD_GRID_BASE_CLASS = "grid-cols-[2.5rem_3.25rem_minmax(0,1fr)]";
 export const WORLD_GRID_PHRASE_TIME_CLASS = "grid-cols-[2.5rem_4.5rem_minmax(0,1fr)]";
-export const WORLD_FREEFORM_DATE_GRID_BASE_CLASS = "grid-cols-[minmax(3.8rem,4.45rem)_2.5rem_minmax(0,1fr)]";
+export const WORLD_FREEFORM_DATE_GRID_BASE_CLASS = "grid-cols-[minmax(3.8rem,4.45rem)_3.25rem_minmax(0,1fr)]";
 export const WORLD_FREEFORM_DATE_GRID_PHRASE_TIME_CLASS =
   "grid-cols-[minmax(3.8rem,4.45rem)_4.5rem_minmax(0,1fr)]";
 

--- a/packages/client/src/features/tracker-panel/lib/world-state-display.ts
+++ b/packages/client/src/features/tracker-panel/lib/world-state-display.ts
@@ -12,8 +12,7 @@ import { visibleText } from "./tracker-display";
 export const WORLD_GRID_BASE_CLASS = "grid-cols-[2.5rem_3.25rem_minmax(0,1fr)]";
 export const WORLD_GRID_PHRASE_TIME_CLASS = "grid-cols-[2.5rem_4.5rem_minmax(0,1fr)]";
 export const WORLD_FREEFORM_DATE_GRID_BASE_CLASS = "grid-cols-[minmax(3.8rem,4.45rem)_3.25rem_minmax(0,1fr)]";
-export const WORLD_FREEFORM_DATE_GRID_PHRASE_TIME_CLASS =
-  "grid-cols-[minmax(3.8rem,4.45rem)_4.5rem_minmax(0,1fr)]";
+export const WORLD_FREEFORM_DATE_GRID_PHRASE_TIME_CLASS = "grid-cols-[minmax(3.8rem,4.45rem)_4.5rem_minmax(0,1fr)]";
 
 export const WORLD_MONTH_LABELS = ["JAN", "FEB", "MAR", "APR", "MAY", "JUN", "JUL", "AUG", "SEP", "OCT", "NOV", "DEC"];
 export const WORLD_MONTH_ALIASES: Record<string, number> = {
@@ -237,6 +236,14 @@ export function parseTemperatureValue(temperature: string | null | undefined) {
   return numeric;
 }
 
+/** Parse a temperature only when the entire value is numeric, with an optional unit. */
+export function parsePureTemperatureValue(temperature: string | null | undefined) {
+  const match = (temperature ?? "").match(/^\s*([+-]?\d+(?:\.\d+)?)\s*°?\s*(f(?:ahrenheit)?|c(?:elsius)?)?\s*$/i);
+  if (!match) return null;
+  const numeric = parseFloat(match[1]!);
+  return match[2]?.toLowerCase().startsWith("f") ? (numeric - 32) * (5 / 9) : numeric;
+}
+
 function formatTemperatureValue(celsius: number, unit: TrackerTemperatureUnit) {
   if (unit === "fahrenheit") return `${Math.round(celsius * (9 / 5) + 32)}°F`;
   return `${Math.round(celsius)}°C`;
@@ -268,6 +275,7 @@ export function getTemperatureGaugeDisplay(
   unit: TrackerTemperatureUnit = "celsius",
 ) {
   const parsed = parseTemperatureValue(temperature);
+  const pureParsed = parsePureTemperatureValue(temperature);
   const hinted = getTemperatureKeywordHint(temperature);
   const value = parsed ?? hinted;
   const percent =
@@ -285,7 +293,7 @@ export function getTemperatureGaugeDisplay(
 
   return {
     color,
-    label: parsed !== null ? formatTemperatureValue(parsed, unit) : visibleText(temperature, "--"),
+    label: pureParsed !== null ? formatTemperatureValue(pureParsed, unit) : visibleText(temperature, "--"),
     percent,
   };
 }

--- a/packages/client/src/styles/globals.css
+++ b/packages/client/src/styles/globals.css
@@ -2807,12 +2807,11 @@ strong {
 }
 
 .mari-tracker-panel-scroll {
-  scrollbar-gutter: stable;
   scrollbar-color: color-mix(in srgb, var(--primary) 42%, transparent) transparent;
 }
 
 .mari-tracker-panel-scroll::-webkit-scrollbar {
-  width: 0.5rem;
+  width: 0.25rem;
 }
 
 .mari-tracker-panel-scroll::-webkit-scrollbar-track {
@@ -2822,7 +2821,7 @@ strong {
 .mari-tracker-panel-scroll::-webkit-scrollbar-thumb {
   background: color-mix(in srgb, var(--primary) 44%, transparent);
   background-clip: padding-box;
-  border: 0.1875rem solid transparent;
+  border: 0.0625rem solid transparent;
   border-radius: 999px;
 }
 

--- a/scripts/regressions/open-issues.regression.ts
+++ b/scripts/regressions/open-issues.regression.ts
@@ -17,6 +17,18 @@ import { parseNoodleAvatarCrop } from "../../packages/server/src/services/storag
 import { sanitizeExampleDialoguePromptLeaf } from "../../packages/server/src/services/prompt/prompt-escaping.js";
 import { buildGameSessionReplayTurns } from "../../packages/client/src/lib/game-session-replay.js";
 import { findReplayableGameSessionChat } from "../../packages/client/src/lib/game-session-resolution.js";
+import {
+  getTemperatureGaugeDisplay,
+  parsePureTemperatureValue,
+} from "../../packages/client/src/features/tracker-panel/lib/world-state-display.js";
+
+assert.equal(parsePureTemperatureValue("15°C"), 15);
+assert.equal(parsePureTemperatureValue("59 Fahrenheit"), 15);
+assert.equal(parsePureTemperatureValue("Around 15°C, windy skies ahead"), null);
+assert.equal(
+  getTemperatureGaugeDisplay("Around 15°C, windy skies ahead", "celsius").label,
+  "Around 15°C, windy skies ahead",
+);
 
 const replayMessages = [
   { id: "start", chatId: "session-1", role: "user", content: "[start game]" },


### PR DESCRIPTION
## Linked issue

Fixes #3470

## Why this change

The tracker sidebar presented dense information with inconsistent spacing, clipped values, awkward numeric editing, and layout gaps around the sidebar and HUD replacement modes. These issues made otherwise useful tracker data harder to scan and edit.

## What changed

- Improve inline numeric editing so draft values replace cleanly and commit predictably.
- Let time, temperature, character fields, and custom stats use available space without clipping or unnecessary truncation.
- Tighten world-state and promoted-character spacing while preserving the existing visual direction.
- Remove unwanted sidebar seams and make HUD-icon replacement reclaim the vacated vertical space.
- Deduplicate tracker display sizing and normalization helpers where behavior could be preserved.

## Validation

Automated validation completed by Codex:

- `pnpm check` (lint, TypeScript, and production builds) passed.
- `git diff --check` passed.

The repository reserves the following checkboxes for human verification, so they are intentionally left unchecked:

- [x] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [x] Ran the app, clicked through the changes manually
- [x] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [x] Above manual verification completed (describe below)
- [x] Read and followed `CONTRIBUTING.md`

### Manual verification notes

- [x] Verify the tracker beside the Chats menu with no seam or gap.
- [x] Verify “Replace tracker HUD icons” moves the tracker into the reclaimed HUD space while respecting the top bar.
- [x] Exercise time, descriptive temperature, and numeric stat editing with short and long values.
- [x] Check promoted-character cards, custom stats, and world-state tiles at representative sidebar widths.
- [ ] Capture and attach before/after UI evidence before marking the PR ready.

## Docs and release impact

- [x] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Version/release files updated (only if this PR includes a version bump)

No version or release metadata changes are included.

## UI evidence (if applicable)

<img width="641" height="1590" alt="image" src="https://github.com/user-attachments/assets/4748a1f2-8c0d-42fb-b84d-70d8a90623f7" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tracker panel positioning, resizing controls, and layering.
  * Fixed inline number editing, including validation, minimum values, Enter/Escape behavior, and external updates.
  * Improved handling of long and descriptive weather, time, and custom field values.
  * Added hover tooltips for read-only tracker values.

* **UI Improvements**
  * Refined tracker panel spacing, typography, grids, gradients, scrollbars, and field layouts.
  * Improved numeric value alignment and text truncation.
  * Adjusted world-state columns and temperature display layouts for better readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->