### PR TITLE
fix(server): keep Grok CLI scratch cwd outside any git checkout

### DIFF
--- a/packages/server/src/services/llm/providers/grok-subscription.provider.ts
+++ b/packages/server/src/services/llm/providers/grok-subscription.provider.ts
@@ -9,13 +9,21 @@
 import { spawn } from "node:child_process";
 import { randomUUID } from "node:crypto";
 import { mkdir, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { BaseLLMProvider, type ChatMessage, type ChatOptions, type LLMUsage } from "../base-provider.js";
 import { isDebugAgentsEnabled } from "../../../config/runtime-config.js";
 import { logger, logDebugOverride } from "../../../lib/logger.js";
 import { DATA_DIR } from "../../../utils/data-dir.js";
 
-const GROK_SCRATCH_DIR = join(DATA_DIR, "grok-cli");
+// The scratch cwd must live OUTSIDE any git checkout: the grok CLI walks up
+// from its working directory to the nearest repo root and indexes the whole
+// working tree on every one-shot call (45k+ file opens and ~10s of startup
+// CPU on a full Marinara checkout — paid by every chat AND agent request
+// when this lived under DATA_DIR). The OS temp dir is never inside a repo;
+// the uid suffix keeps per-user paths distinct on shared multi-user hosts.
+const GROK_SCRATCH_OWNER = typeof process.getuid === "function" ? `-${process.getuid()}` : "";
+const GROK_SCRATCH_DIR = join(tmpdir(), `marinara-grok-cli${GROK_SCRATCH_OWNER}`);
 const GROK_PROMPT_DIR = join(DATA_DIR, "grok-cli-prompts");
 const GROK_ERROR_PREVIEW_CHARS = 2000;
 const GROK_MODELS_TIMEOUT_MS = 30 * 1000;
@@ -214,7 +222,7 @@ async function runGrokCliCommand(
   args: string[],
   options: { timeoutMs: number; signal?: AbortSignal; timeoutLabel: string },
 ): Promise<GrokCliCommandResult> {
-  await mkdir(GROK_SCRATCH_DIR, { recursive: true });
+  await mkdir(GROK_SCRATCH_DIR, { recursive: true, mode: 0o700 });
 
   const child = spawn("grok", args, {
     cwd: GROK_SCRATCH_DIR,

--- a/packages/server/src/services/llm/providers/grok-subscription.provider.ts
+++ b/packages/server/src/services/llm/providers/grok-subscription.provider.ts
@@ -8,7 +8,7 @@
 // the prompt pipeline, command parsing, and tool execution.
 import { spawn } from "node:child_process";
 import { randomUUID } from "node:crypto";
-import { mkdir, rm, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { BaseLLMProvider, type ChatMessage, type ChatOptions, type LLMUsage } from "../base-provider.js";
@@ -21,9 +21,10 @@ import { DATA_DIR } from "../../../utils/data-dir.js";
 // working tree on every one-shot call (45k+ file opens and ~10s of startup
 // CPU on a full Marinara checkout — paid by every chat AND agent request
 // when this lived under DATA_DIR). The OS temp dir is never inside a repo;
-// the uid suffix keeps per-user paths distinct on shared multi-user hosts.
-const GROK_SCRATCH_OWNER = typeof process.getuid === "function" ? `-${process.getuid()}` : "";
-const GROK_SCRATCH_DIR = join(tmpdir(), `marinara-grok-cli${GROK_SCRATCH_OWNER}`);
+// a unique process-local directory prevents another local user from pre-creating
+// the cwd or replacing a predictable path with a symlink.
+const GROK_SCRATCH_PREFIX = join(tmpdir(), "marinara-grok-cli-");
+let grokScratchDirPromise: Promise<string> | null = null;
 const GROK_PROMPT_DIR = join(DATA_DIR, "grok-cli-prompts");
 const GROK_ERROR_PREVIEW_CHARS = 2000;
 const GROK_MODELS_TIMEOUT_MS = 30 * 1000;
@@ -40,6 +41,11 @@ const GROK_CLI_SAFE_HEADLESS_MODEL_ID = "grok-composer-2.5-fast";
 const GROK_CLI_SYSTEM_PROMPT =
   "You are Marinara Engine's one-shot chat completion backend. Return exactly one assistant response for the transcript. Do not inspect files, run tools, ask clarifying questions, plan, or continue beyond the final answer.";
 const STALE_GROK_CLI_MODEL_IDS = new Set(["grok-build-latest", "grok-build-0.1"]);
+
+function getGrokScratchDir(): Promise<string> {
+  grokScratchDirPromise ??= mkdtemp(GROK_SCRATCH_PREFIX);
+  return grokScratchDirPromise;
+}
 
 export interface GrokCliModel {
   id: string;
@@ -222,10 +228,10 @@ async function runGrokCliCommand(
   args: string[],
   options: { timeoutMs: number; signal?: AbortSignal; timeoutLabel: string },
 ): Promise<GrokCliCommandResult> {
-  await mkdir(GROK_SCRATCH_DIR, { recursive: true, mode: 0o700 });
+  const grokScratchDir = await getGrokScratchDir();
 
   const child = spawn("grok", args, {
-    cwd: GROK_SCRATCH_DIR,
+    cwd: grokScratchDir,
     env: { ...process.env },
     stdio: ["ignore", "pipe", "pipe"],
   });
@@ -345,6 +351,7 @@ export class GrokSubscriptionProvider extends BaseLLMProvider {
     // prompt files outside --cwd so the model's file tools cannot discover the
     // transcript by listing the CLI workspace.
     await mkdir(GROK_PROMPT_DIR, { recursive: true, mode: 0o700 });
+    const grokScratchDir = await getGrokScratchDir();
     const promptFile = join(GROK_PROMPT_DIR, `prompt-${randomUUID()}.txt`);
     await writeFile(promptFile, prompt, { encoding: "utf8", mode: 0o600 });
     const args = [
@@ -364,7 +371,7 @@ export class GrokSubscriptionProvider extends BaseLLMProvider {
       "--max-turns",
       String(GROK_CLI_MAX_TURNS),
       "--cwd",
-      GROK_SCRATCH_DIR,
+      grokScratchDir,
     ];
     if (cliModel) args.push("-m", cliModel);
 


### PR DESCRIPTION
## Linked issue

Closes #3474

## Why this change

The Grok CLI provider spawned `grok` with `DATA_DIR/grok-cli` as its working directory. On source installations inside a Git checkout, Grok walks upward to the repository root and indexes the entire Marinara tree for every one-shot chat, tracker, or agent request. Measurements showed 45,000+ file opens and roughly 10 seconds of avoidable startup CPU per call.

Docker and installer deployments generally hide the problem because their data directory has no Git repository above it.

## What changed

- Move the Grok CLI scratch working directory outside the application checkout into the operating-system temporary directory.
- Create one unpredictable process-local directory with `mkdtemp`, preventing another local user from pre-creating the path or substituting a symlink.
- Keep prompt files in their existing protected directory and continue passing them by absolute path and deleting them after each request.
- Preserve the existing Grok CLI arguments and request behavior.

Alternatives tested by the contributor: `--verbatim` does not skip discovery; a stub `.git` directory is not accepted as a repository boundary; `git init` works but adds an unnecessary Git binary dependency.

## Validation

- [ ] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed `CONTRIBUTING.md`

Automated validation completed:

- `pnpm check`
- GitHub `pnpm-validate`
- GitHub `container-build-test`

### Manual verification notes

Contributor measurements for an identical one-line prompt using Grok 0.2.14 on Linux:

| Scenario | Wall time |
| --- | ---: |
| `grok -p` outside any repository | 4.7 s |
| `grok -p` from `data/grok-cli` inside the checkout | 15.6 s |
| Connection test before this fix | 12.1 s |
| Connection test after this fix | **5.4 s** |

Before merging, manually verify chat generation and tracker/agent runs with an authenticated Grok CLI connection and confirm its scratch directory is created under the OS temporary directory.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Version/release files updated (only if this PR includes a version bump)

No version bump is included. The implementation is isolated to the Grok subscription provider.

## UI evidence (if applicable)

Not applicable; this is a server-only provider performance and security fix.

Ownership: @myaiexp (agent-assisted).
