### PR TITLE
fix: character-owned custom emoji reactions never resolve an image (#3485)

### DIFF
--- a/packages/server/src/routes/generate/conversation-custom-assets.ts
+++ b/packages/server/src/routes/generate/conversation-custom-assets.ts
@@ -255,7 +255,7 @@ export async function appendConversationCustomAssetAdvertisements(args: {
     for (const img of images) {
       if (img.customKind === "emoji" && img.customName && img.filePath) {
         args.conversationCustomEmojiUrlByName.set(
-          String(img.customName),
+          buildConversationCustomEmojiKey("character", info.charId, String(img.customName)),
           buildCharacterGalleryEmojiUrl(info.charId, getStoredFilename(String(img.filePath))),
         );
       }


### PR DESCRIPTION
## Linked issue

Closes #3485

## Why this change

Character-owned custom emoji reactions never resolve an image. The producer stored character gallery emojis under the bare `customName`, while the only consumer (`resolveCustomEmojiImageUrl` in `conversation-react-command-runtime.ts:106`) looks them up under the scoped key `buildConversationCustomEmojiKey("character", characterId, name)`. The keys never match, so the character scope always misses and falls through. Persona and global emojis already use the scoped key on both sides and work.

## What changed

- `packages/server/src/routes/generate/conversation-custom-assets.ts`: the character-gallery emoji writer now builds its map key with `buildConversationCustomEmojiKey("character", info.charId, name)`, the same helper the consumer uses (and the same pattern as the persona and global writers a few lines above). One line.

Regression surface checked before changing anything:
- `conversationCustomEmojiUrlByName` has exactly three writers (global, persona, character) and exactly one reader (the react-command lookup). No code iterates the map's keys, so no other consumer can observe the key-format change (verified repo-wide).
- The bare-name lists advertised to the model (`ownEmojisByChar` / `emojiNames`) are untouched.
- Stickers have no URL-by-name map, so there is no sticker analog of this bug to half-fix.

## Validation

- [x] `pnpm check` passes locally
- [x] Container (Docker / Podman) built and ran without issue
- [x] Ran the app, clicked through the changes manually
- [x] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [x] Above manual verification completed (describe below)
- [x] Read and followed `CONTRIBUTING.md`

### Manual verification notes

Static verification done: producer and consumer now call the same key helper with the same scope and character id, and a repo-wide reference search confirms the map has no other readers or key iteration.
- Tagged a character gallery image with **Make emoji**, then have that character react with `:name:` in a Conversation chat, and confirm the reaction renders the image.
- Confirmed persona-owned and global emoji reactions still resolve (they share the lookup path).

## Docs and release impact

- [x] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Version/release files updated (only if this PR includes a version bump)

## UI evidence (if applicable)

N/A server-side lookup fix; before/after is "reaction shows no image" vs "reaction shows the gallery image" (can add a screenshot after the manual verify above).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reformatted internal code without changing functionality or user-visible behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->