### PR TITLE
fix(ui): correct copy that mismatches actual labels and behavior (fixes #3492)

### DIFF
--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -132,9 +132,9 @@ Chat summaries need a working text connection to write them.
 - If your chat requires agent write approval, an AI summary waits for your review before it takes effect.
 - A summary that keeps failing (for example, a bad API key) is retried on a delay. Fix the connection, then use **Backfill**.
 
-## Character Browser problems
+## Bot Browser problems
 
-The **Browser** lets you search public character sites and import characters. Open it from the **Browser** icon in the top bar.
+The **Bot Browser** lets you search public character sites and import characters. Open it from the **Bot Browser** icon in the top bar.
 
 - If JannyAI search or a character page fails with a Cloudflare block, Marinara shows a message. It asks you to visit the JannyAI site once in the same browser to clear the challenge, then retry.
 - If your CharacterTavern or Pygmalion login stops working after you restart the server, that is expected. Those logins live only in server memory and clear on restart. Open the login window and paste your cookie or token again.

--- a/docs/characters/bot-browser.md
+++ b/docs/characters/bot-browser.md
@@ -1,31 +1,31 @@
-# Browser: Finding and Importing Characters
+# Bot Browser: Finding and Importing Characters
 
-This guide explains the **Browser** in Marinara Engine, the built-in tool for finding character cards on public sites and importing them into your library. It covers the six sources, how to search and filter, and how adult content works on each source. It also covers how to import a character or save it as a file. In the code and in older docs this feature is also called the **Bot Browser**, but the app itself always labels it **Browser**.
+This guide explains the **Bot Browser** in Marinara Engine, the built-in tool for finding character cards on public sites and importing them into your library. It covers the six sources, how to search and filter, and how adult content works on each source. It also covers how to import a character or save it as a file. Older versions of the app labeled this feature **Browser**, so some older guides may still use that shorter name.
 
-A character card is a file that holds one character's name, personality, greeting, and other details. Normally you would download a card from a website and then upload it into Marinara. The **Browser** does both steps for you in one place.
+A character card is a file that holds one character's name, personality, greeting, and other details. Normally you would download a card from a website and then upload it into Marinara. The **Bot Browser** does both steps for you in one place.
 
-## What the Browser is
+## What the Bot Browser is
 
-The **Browser** searches several public character-card sites from inside Marinara. It supports six sources: **ChubAI**, **JannyAI**, **CharacterTavern**, **Pygmalion**, **Wyvern**, and **DataCat**. You can search a source, filter the results, and preview a character's full details. Then you can import that character into your library or save it as a PNG file. You do not need an account or an API key to browse and import character cards at the default settings.
+The **Bot Browser** searches several public character-card sites from inside Marinara. It supports six sources: **ChubAI**, **JannyAI**, **CharacterTavern**, **Pygmalion**, **Wyvern**, and **DataCat**. You can search a source, filter the results, and preview a character's full details. Then you can import that character into your library or save it as a PNG file. You do not need an account or an API key to browse and import character cards at the default settings.
 
-## Opening the Browser
+## Opening the Bot Browser
 
-There are two ways to open the **Browser**.
+There are two ways to open the **Bot Browser**.
 
-1. Click the **Browser** icon in the top bar. It sits in the row of panel buttons on the right side.
-2. Or open the **Browser** panel in the right sidebar, then click the **Browse Online** button at the top of that panel.
+1. Click the **Bot Browser** icon in the top bar. It sits in the row of panel buttons on the right side.
+2. Or open the **Bot Browser** panel in the right sidebar, then click the **Browse Online** button at the top of that panel.
 
-Either way, the whole content area switches to the full **Browser** view. This view replaces the chat area. It is not a small pop-up window.
+Either way, the whole content area switches to the full **Bot Browser** view. This view replaces the chat area. It is not a small pop-up window.
 
-To leave, click the back-arrow button in the top-left of the **Browser** header. You should return to the screen you came from.
+To leave, click the back-arrow button in the top-left of the **Bot Browser** header. You should return to the screen you came from.
 
-The **Browser** stays loaded while the app is open. If you close it and open it again, your last search, filters, and selected character are still there. Reloading the whole app resets it.
+The **Bot Browser** stays loaded while the app is open. If you close it and open it again, your last search, filters, and selected character are still there. Reloading the whole app resets it.
 
 ## Choosing a source
 
 Click the source button in the header. It shows the current source name and a small arrow. A menu opens with all six sources in this order: **ChubAI**, **JannyAI**, **CharacterTavern**, **Pygmalion**, **Wyvern**, and **DataCat**.
 
-**ChubAI** is selected the first time you open the **Browser**. When you switch sources, your search text, tags, and filters are cleared. Each source remembers its own adult-content setting and login separately, so a change on one source does not affect the others.
+**ChubAI** is selected the first time you open the **Bot Browser**. When you switch sources, your search text, tags, and filters are cleared. Each source remembers its own adult-content setting and login separately, so a change on one source does not affect the others.
 
 One naming note: the menu lists **ChubAI**, but on a character's detail page the outside link reads **View on Chub**. That is the site's own name for itself. The other five sources use the same name in both places.
 
@@ -161,9 +161,9 @@ JSON and PNG are two common formats for the same character data. JSON is a plain
 
 ## Your imported characters
 
-The **Browser** panel in the right sidebar keeps a separate list of characters you imported through the **Browser**. Characters you made by hand or imported another way do not appear here. All of them still appear in the main **Characters** library.
+The **Bot Browser** panel in the right sidebar keeps a separate list of characters you imported through the **Bot Browser**. Characters you made by hand or imported another way do not appear here. All of them still appear in the main **Characters** library.
 
-- The **Browse Online** button opens the full **Browser** view.
+- The **Browse Online** button opens the full **Bot Browser** view.
 - The **Search imported...** box filters this list.
 - The sort dropdown offers **A-Z**, **Z-A**, **Newest**, and **Oldest**.
 - Right-click a row, or use its buttons, to find **Quick Start Roleplay** and **Quick Start Conversation**. These open a new chat with that character. You can also delete the character from this list here.

--- a/docs/game/party-and-npcs.md
+++ b/docs/game/party-and-npcs.md
@@ -78,13 +78,15 @@ Your notes save on their own a moment after you stop typing. A small label shows
 
 The **NPCs** tab of the Adventure Journal tracks how each NPC feels about you. Every listed NPC shows a portrait, a name, and a reputation label.
 
-The reputation label changes as you act in the story. It is one of these five, from best to worst:
+The reputation label changes as you act in the story. It is one of these seven, from best to worst:
 
 | Label | Meaning |
 |---|---|
+| **Devoted** | Deeply loyal to you |
 | **Allied** | Strong ally |
 | **Friendly** | Positive |
 | **Neutral** | No strong feeling |
+| **Unfriendly** | Negative |
 | **Hostile** | Turned against you |
 | **Enemy** | Actively opposed |
 

--- a/docs/home/tutorial.md
+++ b/docs/home/tutorial.md
@@ -15,7 +15,7 @@ The tour also does more than talk. As you move forward, some steps open the matc
 The tour has 15 steps. Here they are in order, with the exact title of each card and what it points at.
 
 1. **Welcome to Marinara Engine!** A centered welcome card. Professor Mari waves and offers to show you around.
-2. **Browser** Highlights the **Browser** panel button, where you find and import ready-made characters.
+2. **Bot Browser** Highlights the **Bot Browser** panel button, where you find and import ready-made characters.
 3. **Characters** Highlights the **Characters** panel button, where your characters live.
 4. **Lorebooks** Highlights the **Lorebooks** panel button, which holds extra world and character details.
 5. **Presets** Highlights the **Presets** panel button, which controls how the prompt is built.

--- a/packages/client/src/components/agents/AgentEditor.tsx
+++ b/packages/client/src/components/agents/AgentEditor.tsx
@@ -3570,7 +3570,7 @@ export function AgentEditor() {
                   ))}
                 </div>
                 <p className="mt-2 text-[0.625rem] text-[var(--muted-foreground)]">
-                  Tool-use must also be enabled per chat via Chat Settings → "Enable Function Calling".
+                  Tool-use must also be enabled per chat via Chat Settings → Function Calling → "Enable Tool Use".
                 </p>
               </>
             )}

--- a/packages/client/src/components/chat/HomeFaq.tsx
+++ b/packages/client/src/components/chat/HomeFaq.tsx
@@ -504,7 +504,7 @@ const HOME_FAQ_ITEMS: HomeFaqItem[] = [
       "Enable TTS first, then turn on Conversation Calls for the chat and pick how your microphone should be transcribed.",
     bullets: [
       "Open Connections > Text to Speech, enable a TTS provider, save it, and confirm the preview plays.",
-      "For local mic transcription, open Connections > Local Model, expand the card, choose Whisper Tiny or Whisper Base under Local Speech Model, then click Download Whisper.",
+      "For local mic transcription, open Connections > Local Model, expand the card, choose Whisper Tiny (Multilingual) or Whisper Base (Multilingual) under Local Speech Model, then click Download Whisper.",
       "In the Conversation chat, open Chat Settings > Commands > Conversation Calls, enable Audio/Video Calls, then enable Call Audio Pipeline.",
       "Use Mic recording + Local Whisper for Firefox or reliable local speech capture. Browser speech recognition depends on browser support.",
       "The Calls command toggle only controls whether characters can ring you first; you can still call them when Audio/Video Calls is enabled.",

--- a/packages/client/src/components/game/GameJournal.tsx
+++ b/packages/client/src/components/game/GameJournal.tsx
@@ -365,11 +365,14 @@ function TimelineView({ entries }: { entries: JournalEntry[] }) {
   );
 }
 
+// Thresholds must match getReputationTier in packages/server/src/services/game/reputation.service.ts
 function reputationLabel(rep: number): { text: string; color: string } {
+  if (rep >= 80) return { text: "Devoted", color: "text-emerald-300" };
   if (rep >= 50) return { text: "Allied", color: "text-emerald-400" };
   if (rep >= 20) return { text: "Friendly", color: "text-green-400" };
   if (rep >= -20) return { text: "Neutral", color: "text-gray-400" };
-  if (rep >= -50) return { text: "Hostile", color: "text-orange-400" };
+  if (rep >= -50) return { text: "Unfriendly", color: "text-amber-400" };
+  if (rep >= -80) return { text: "Hostile", color: "text-orange-400" };
   return { text: "Enemy", color: "text-red-400" };
 }
 

--- a/packages/client/src/components/layout/RightPanel.tsx
+++ b/packages/client/src/components/layout/RightPanel.tsx
@@ -29,7 +29,7 @@ const BotBrowserPanel = lazy(() =>
 
 const PANEL_CONFIG: Record<string, { title: string; icon: ReactNode; gradient?: string; gradientClass?: string }> = {
   "bot-browser": {
-    title: "Browser",
+    title: "Bot Browser",
     icon: <Bot size="0.875rem" />,
     gradient: "from-lime-400 via-green-500 to-cyan-500",
   },

--- a/packages/client/src/components/layout/TopBar.tsx
+++ b/packages/client/src/components/layout/TopBar.tsx
@@ -347,7 +347,7 @@ export function TopBar() {
         aria-label="Panel navigation"
         className="mari-topbar-panel-nav mari-rgb-icon-scope flex shrink-0 items-center justify-end gap-0.5 rounded-xl p-1 max-sm:gap-0 max-sm:p-0.5"
       >
-        {/* Browser */}
+        {/* Bot Browser */}
         <button
           onClick={() => handleRightPanelClick("bot-browser")}
           data-tour="panel-bot-browser"
@@ -361,7 +361,7 @@ export function TopBar() {
                   isTopbarHovered("browser") && cn(TOPBAR_FORCE_HOVER_CLASS, "text-lime-300"),
                 ),
           )}
-          title="Browser"
+          title="Bot Browser"
         >
           <Bot size={15} className={TOPBAR_ACCENT_ICON_CLASS} />
           {isBotBrowserActive && (

--- a/packages/client/src/components/onboarding/OnboardingTutorial.tsx
+++ b/packages/client/src/components/onboarding/OnboardingTutorial.tsx
@@ -49,8 +49,8 @@ const STEPS: TourStep[] = [
   },
   {
     target: "panel-bot-browser",
-    title: "Browser",
-    body: "The Browser allows you to browse and import downloadable character cards and resources. Start here when you want new characters or ready-made material to bring into your library.",
+    title: "Bot Browser",
+    body: "The Bot Browser allows you to browse and import downloadable character cards and resources. Start here when you want new characters or ready-made material to bring into your library.",
     side: "bottom",
     openPanel: "bot-browser",
     sprite: { src: "/sprites/mari/Mari_point_up_left.png", flip: true },

--- a/packages/client/src/components/panels/SettingsPanel.tsx
+++ b/packages/client/src/components/panels/SettingsPanel.tsx
@@ -5887,6 +5887,7 @@ function ExtensionsSettings({ showIntro = true }: { showIntro?: boolean } = {}) 
     fallbackName: string,
   ) => {
     let imported = 0;
+    let importedEnabled = 0;
     let failed = 0;
     let skipped = 0;
     const failureMessages: string[] = [];
@@ -5903,6 +5904,7 @@ function ExtensionsSettings({ showIntro = true }: { showIntro?: boolean } = {}) 
           installedAt,
         });
         imported++;
+        if (normalized.enabled) importedEnabled++;
       } catch (err) {
         failed++;
         failureMessages.push(describeExtensionImportError(err, normalized.name));
@@ -5911,6 +5913,12 @@ function ExtensionsSettings({ showIntro = true }: { showIntro?: boolean } = {}) 
     }
     if (imported === 0 && failed === 0 && skipped === 0) throw new Error("No valid extensions found in file");
     const skipNote = skipped > 0 ? ` (${skipped} skipped — no importable entry)` : "";
+    // "Review before enabling" would be misleading when a manifest imported
+    // with enabled:true — those extensions are already running.
+    const reviewNote =
+      importedEnabled > 0
+        ? ` ${importedEnabled === imported ? "They are" : `${importedEnabled} of them are`} already enabled — review in the Extension Library.`
+        : " Review before enabling.";
     if (failed > 0) {
       const more = failureMessages.length > 1 ? ` (+${failureMessages.length - 1} more)` : "";
       toast.error(
@@ -5922,7 +5930,7 @@ function ExtensionsSettings({ showIntro = true }: { showIntro?: boolean } = {}) 
     } else if (skipped > 0) {
       toast.warning(
         imported > 0
-          ? `Imported ${imported} extension${imported === 1 ? "" : "s"}${skipNote}. Review before enabling.`
+          ? `Imported ${imported} extension${imported === 1 ? "" : "s"}${skipNote}.${reviewNote}`
           : `Skipped ${skipped} extension entr${skipped === 1 ? "y" : "ies"}.`,
         {
           description: failureMessages[0],
@@ -5930,7 +5938,7 @@ function ExtensionsSettings({ showIntro = true }: { showIntro?: boolean } = {}) 
         },
       );
     } else {
-      toast.success(`Imported ${imported} extension${imported === 1 ? "" : "s"}${skipNote}. Review before enabling.`);
+      toast.success(`Imported ${imported} extension${imported === 1 ? "" : "s"}${skipNote}.${reviewNote}`);
     }
   };
 

--- a/packages/client/src/stores/ui.store.ts
+++ b/packages/client/src/stores/ui.store.ts
@@ -507,7 +507,7 @@ interface UIState {
   lorebookPanelActiveTag: string | null;
   /** Whether the compact Lorebooks panel tag/category shelf is expanded */
   lorebookPanelTagsExpanded: boolean;
-  /** Sort order for imported characters in the Browser panel */
+  /** Sort order for imported characters in the Bot Browser panel */
   botBrowserPanelSort: ResourcePanelSort;
   /** Sort order for the compact Presets panel */
   presetPanelSort: ResourcePanelSort;


### PR DESCRIPTION
## Linked issue

Fixes #3492. The three objective mismatches shipped in the first commit; the two items previously flagged for a ruling have now been decided (use the feature's common name **Bot Browser**; render all seven server reputation tiers) and are included in the second commit, completing the issue.

## Why this change

Copy that contradicts the actual UI breaks the find-what-you-read loop: helper text pointing at a switch that does not exist sends users hunting, a toast claiming imports need enabling misleads when they are already running, and FAQ option names that do not match the dropdown make the (label-exact) in-app doc search miss.

The panel label and reputation display were the same class of problem in the other direction: the code, docs, and tour anchor all call the feature the Bot Browser while the UI said "Browser", and the journal's 5-tier reputation mapping actively disagreed with the server's 7-tier scale — an NPC at reputation −30 rendered as "Hostile" while server-generated narration called it "unfriendly".

## What changed

- **AgentEditor tool hint**: told users to enable "Enable Function Calling" per chat; no switch has that label. Now names the real path: Chat Settings → Function Calling → **"Enable Tool Use"** (verified against `FunctionCallingSection.tsx`).
- **Extensions import toast**: always said "Review before enabling", but the browser-runtime import normalizer preserves `enabled: true` from manifests, so imported extensions can already be running. The toast now counts enabled imports ("They are / N of them are already enabled — review in the Extension Library.") and only says "Review before enabling." when everything imported disabled. Server-runtime imports always arrive disabled (normalizer hardcodes it), so their copy is unchanged in practice.
- **Home FAQ calls answer**: named the Whisper options without the "(Multilingual)" suffix the actual **Local Speech Model** dropdown uses (labels in `shared/types/sidecar.ts:381,389`). The FAQ now quotes the exact labels, matching the in-app documentation.
- **Bot Browser naming** (second commit): the right-panel title, top-bar tooltip, and onboarding tour step now say **Bot Browser**, matching the feature's common name used by the code, the in-app guide, and the tour anchor (`panel-bot-browser`). The extension runtime badge in Settings ("Server"/"Browser") means the JS runtime, not this feature, and is deliberately untouched.
- **Reputation tiers** (second commit): `GameJournal`'s `reputationLabel()` now mirrors all seven server tiers from `getReputationTier` in `reputation.service.ts` — adds **Devoted** (≥ 80, emerald-300) and **Unfriendly** (≥ −50, amber-400), and corrects **Hostile** to ≥ −80. The old 5-tier mapping mislabeled reputations in [−50, −21] as "Hostile" and [−80, −51] as "Enemy", contradicting the server's milestone narration which already uses the 7-tier vocabulary (the journal and game-surface parsers already accept all seven names). A comment now pins the server function as the threshold source of truth.
- **In-app docs aligned** (second commit): the bot-browser guide (title and the now-false "the app itself always labels it Browser" claim), the tutorial step list, the troubleshooting section heading, and the NPC reputation table (five rows → seven) all updated to match.

## Validation

- [x] `pnpm check` passes locally
- [x] Container (Docker / Podman) built and ran without issue
- [x] Ran the app, clicked through the changes manually
- [x] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [x] Above manual verification completed (describe below)
- [x] Read and followed `CONTRIBUTING.md`

### Manual verification notes

The checked boxes above cover the first commit. Two of those three changes are string-only (helper text, FAQ bullet) verified against the source labels they quote; the toast change adds one counter increment on the existing success path and a computed suffix, which cannot change import behavior.

The second commit (`pnpm check` re-run and passing) is string renames plus a threshold table verified line-by-line against `getReputationTier`; its manual browser checks are still outstanding:

- [ ] Manually verify the top-bar tooltip and right-panel header read "Bot Browser"
- [ ] Manually verify onboarding tour step 2 is titled "Bot Browser"
- [ ] Manually verify an NPC in the Adventure Journal NPCs tab shows "Devoted" at reputation ≥ 80 and "Unfriendly" between −50 and −21

## Docs and release impact

- [ ] No docs changes needed
- [x] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Version/release files updated (only if this PR includes a version bump)

(In-app guides under `docs/` were updated in the second commit to match the new labels: `characters/bot-browser.md`, `home/tutorial.md`, `TROUBLESHOOTING.md`, `game/party-and-npcs.md`. No README/CHANGELOG impact.)

## UI evidence (if applicable)

Text-only changes; before/after strings are quoted in full above.
