### PR TITLE
test: align TTS regression with simplified API

### DIFF
--- a/scripts/regressions/prompt.regression.ts
+++ b/scripts/regressions/prompt.regression.ts
@@ -513,7 +513,6 @@ const cases: RegressionCase[] = [
       const htmlCard = `<div style="max-width:340px;font-family:Georgia,'Times New Roman',serif;color:#3a2f1e;"><div class="label">read a hundred times</div><div>Your name is <span style="font-weight:bold">Maukie</span>.</div></div>`;
       const utterances = extractDialogueUtterances(
         `${htmlCard}\nDottore said, "Stay behind me."`,
-        { dialogueScope: "all", dialogueCharacterName: "" },
         "Dottore",
       );
 
@@ -527,7 +526,6 @@ const cases: RegressionCase[] = [
       assert.deepEqual(
         extractDialogueUtterances(
           '<div class="frame"></div><speaker="Dottore">"Do not move."</speaker>',
-          { dialogueScope: "all", dialogueCharacterName: "" },
           "Narrator",
         ),
         [{ text: "Do not move.", speaker: "Dottore" }],


### PR DESCRIPTION
## Why

Follow-up integration fix for #3507 and #3508. #3508 removed the obsolete TTS dialogue-scope argument, while #3507 added two regression calls using the previous signature. Once both PRs were merged, the combined prompt regression passed the removed config object as a speaker and failed.

## What changed

- update the two HTML-safe TTS regression calls to use the current (text, fallbackSpeaker) signature
- production TTS behavior is unchanged

## Validation

- [ ] pnpm regression:prompt
- [ ] pnpm regression:roleplay
- [ ] pnpm check

All commands above were run locally and passed; checkboxes remain for maintainer verification.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated regression tests to reflect the current dialogue extraction interface.
  * Preserved existing expected dialogue extraction results for speaker-scoped and narrator cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->