### PR TITLE
Fix current issue queue across Windows, lorebooks, conversation, games, emoji, and Illustrator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 
 ### Fixed
 
+- Fixed Illustrator defaulting to the Background prompt in new and existing Roleplay chats after the staging update; normal Illustration is restored as the default, affected stored agent configs are repaired once, and explicit per-chat Background choices remain intact (#3517).
 - Fixed the Windows uninstaller deleting current-layout user data under `packages/server/data`; uninstall now asks before application cleanup, safely preserves and restores retained data, supports the legacy root data folder, and removes the current `win` directory instead of a stale path (#3484).
 - Fixed semantic Lorebook search being unreachable for ordinary keyed entries; vector similarity now acts as the documented fallback when keyword matching misses while retaining score thresholds, maximum results, filters, and probability gates (#3511).
 - Fixed partially speaker-prefixed Conversation replies rendering their leading model text as narration beneath the user's message; the leading block now inherits the saved assistant character while edit and reaction attribution remain aligned (#3514).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 
 ### Added
 
+- Added batch editing for selected Lorebook entries, letting one boolean setting such as recursion, case sensitivity, whole-word matching, vector exclusion, or enabled state be applied to thousands of entries in one atomic update (#3513).
+- Added Discord-style standard emoji shortcodes and Conversation autocomplete, so names such as `:crying:` render as Unicode emoji and `:cry…` suggestions appear alongside custom emoji (#3515).
 - Added visible Game setup progress with an elapsed timer and indeterminate progress bar while the Game Master builds the initial world, plus live phase labels during the first turn (#3495).
 - Added optional Noodle image captioning with a selectable vision connection so text-only timeline models can understand images attached to posts and replies (#3505).
 - Added an **Initial Game Setup** section to Game Mode Session History so players can review, copy, or download a `.txt` file containing the complete setup that created a successful campaign, including preferences, prompt choices, visual/storyboard options, safe model descriptors, and effective generation parameters without credentials or local IDs.
@@ -33,6 +35,7 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 
 ### Changed
 
+- Updated UNO bot instructions and Wild tool guidance to expose the bot's remaining color counts and prefer its strongest held color instead of reflexively repeating the active color (#3512).
 - Changed random and exact Noodle participant selection to prioritize directly involved accounts, then accounts absent from the previous refresh, while retaining recently active accounts as a fallback when the pool is small (#3505).
 - Changed post-processing orchestration so Prose Guardian, Continuity Checker, and Immersive HTML share a dedicated rewrite call that is isolated from tracker batches, and hid the legacy About Me Keeper from the manually addable Agents library.
 - Changed Noodle's generated-image quota from a daily cap to **Images/refresh**, applied independently to every manual and automatic timeline refresh while preserving each user's saved limit.
@@ -49,6 +52,9 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 
 ### Fixed
 
+- Fixed the Windows uninstaller deleting current-layout user data under `packages/server/data`; uninstall now asks before application cleanup, safely preserves and restores retained data, supports the legacy root data folder, and removes the current `win` directory instead of a stale path (#3484).
+- Fixed semantic Lorebook search being unreachable for ordinary keyed entries; vector similarity now acts as the documented fallback when keyword matching misses while retaining score thresholds, maximum results, filters, and probability gates (#3511).
+- Fixed partially speaker-prefixed Conversation replies rendering their leading model text as narration beneath the user's message; the leading block now inherits the saved assistant character while edit and reaction attribution remain aligned (#3514).
 - Fixed Conversation and other non-assembled generation paths silently disabling reasoning when the UI showed the default **Maximum** effort; shared and server runtime defaults now agree while an explicit disabled value remains respected (#3498).
 - Fixed Noodle accounts repeatedly interacting with the same post or replying to their own comments without new involvement, while still allowing a return after an explicit tag or direct reply; also fixed profile validation errors rendering as `[object Object]` (#3505).
 - Fixed pending persona portrait focus and zoom changes being lost when a tab was refreshed or closed before the debounce completed by flushing the save on `pagehide` with a keepalive request (#3506).

--- a/e2e/core-flows.e2e.ts
+++ b/e2e/core-flows.e2e.ts
@@ -768,7 +768,7 @@ test("Conversation autocompletes and renders standard emoji shortcodes", async (
 
   try {
     const messageResponse = await page.request.post(`/api/chats/${chat.id}/messages`, {
-      data: { role: "assistant", characterId: character.id, content: "Model sent :crying:" },
+      data: { role: "assistant", characterId: character.id, content: "Model sent :CRYING:" },
     });
     expect(messageResponse.ok()).toBeTruthy();
     await page.addInitScript((chatId) => localStorage.setItem("marinara-active-chat-id", chatId), chat.id);
@@ -776,7 +776,7 @@ test("Conversation autocompletes and renders standard emoji shortcodes", async (
 
     await expect(page.getByText("Model sent 😢", { exact: true })).toBeVisible();
     const input = page.locator('textarea[placeholder*="Message"]').last();
-    await input.fill(":cry");
+    await input.fill(":CRY");
     const cryingSuggestion = page.getByRole("button", { name: /:crying:.*Standard/i });
     await expect(cryingSuggestion).toBeVisible();
     await cryingSuggestion.click();

--- a/e2e/core-flows.e2e.ts
+++ b/e2e/core-flows.e2e.ts
@@ -712,6 +712,81 @@ test("Lorebook Save keeps Overview stable while the updated detail cache settles
   }
 });
 
+test("selected Lorebook entries accept one batch setting update", async ({ page }, testInfo) => {
+  test.skip(testInfo.project.name.includes("mobile"), "Desktop editor batch controls are covered on desktop.");
+
+  const name = `Lorebook batch edit ${Date.now()}`;
+  const createResponse = await page.request.post("/api/lorebooks", {
+    data: { name, description: "Temporary batch-edit regression lorebook.", category: "world", enabled: true },
+  });
+  expect(createResponse.ok()).toBeTruthy();
+  const lorebook = (await createResponse.json()) as { id: string };
+
+  try {
+    for (const entryName of ["Batch Entry One", "Batch Entry Two"]) {
+      const entryResponse = await page.request.post(`/api/lorebooks/${lorebook.id}/entries`, {
+        data: { name: entryName, content: `${entryName} content`, preventRecursion: true },
+      });
+      expect(entryResponse.ok()).toBeTruthy();
+    }
+
+    await page.goto("/");
+    await page.locator('[data-tour="panel-lorebooks"]').click();
+    await page.getByText(name, { exact: true }).click();
+    await page.getByRole("button", { name: /^Entries/ }).click();
+    await page.getByTitle("Select entries to copy or move").click();
+    await page.getByRole("button", { name: "Select all", exact: true }).click();
+    await expect(page.getByText("2 selected", { exact: true })).toBeVisible();
+    await page.getByLabel("Setting to apply to selected entries").selectOption("preventRecursion");
+    await page.getByLabel("Value to apply to selected entries").selectOption("false");
+    await page.getByRole("button", { name: "Apply", exact: true }).click();
+    await expect(page.getByText("Prevent recursion updated for 2 entries.")).toBeVisible();
+
+    const entriesResponse = await page.request.get(`/api/lorebooks/${lorebook.id}/entries`);
+    expect(entriesResponse.ok()).toBeTruthy();
+    const entries = (await entriesResponse.json()) as Array<{ preventRecursion: boolean }>;
+    expect(entries).toHaveLength(2);
+    expect(entries.every((entry) => entry.preventRecursion === false)).toBe(true);
+  } finally {
+    await page.request.delete(`/api/lorebooks/${lorebook.id}`).catch(() => undefined);
+  }
+});
+
+test("Conversation autocompletes and renders standard emoji shortcodes", async ({ page }, testInfo) => {
+  test.skip(testInfo.project.name.includes("mobile"), "Desktop Conversation autocomplete is covered on desktop.");
+
+  const characterResponse = await page.request.post("/api/characters", {
+    data: { data: { name: `Emoji Character ${Date.now()}` } },
+  });
+  expect(characterResponse.ok()).toBeTruthy();
+  const character = (await characterResponse.json()) as { id: string };
+  const chatResponse = await page.request.post("/api/chats", {
+    data: { name: "Standard emoji autocomplete", mode: "conversation", characterIds: [character.id] },
+  });
+  expect(chatResponse.ok()).toBeTruthy();
+  const chat = (await chatResponse.json()) as { id: string };
+
+  try {
+    const messageResponse = await page.request.post(`/api/chats/${chat.id}/messages`, {
+      data: { role: "assistant", characterId: character.id, content: "Model sent :crying:" },
+    });
+    expect(messageResponse.ok()).toBeTruthy();
+    await page.addInitScript((chatId) => localStorage.setItem("marinara-active-chat-id", chatId), chat.id);
+    await page.goto("/");
+
+    await expect(page.getByText("Model sent 😢", { exact: true })).toBeVisible();
+    const input = page.locator('textarea[placeholder*="Message"]').last();
+    await input.fill(":cry");
+    const cryingSuggestion = page.getByRole("button", { name: /:crying:.*Standard/i });
+    await expect(cryingSuggestion).toBeVisible();
+    await cryingSuggestion.click();
+    await expect(input).toHaveValue("😢 ");
+  } finally {
+    await page.request.delete(`/api/chats/${chat.id}`).catch(() => undefined);
+    await page.request.delete(`/api/characters/${character.id}`).catch(() => undefined);
+  }
+});
+
 test("home page stays fitted while FAQ behavior matches the viewport", async ({ page }, testInfo) => {
   const errors = collectUnexpectedErrors(page);
   const mobile = testInfo.project.name.includes("mobile");

--- a/packages/client/src/components/chat/ConversationInput.tsx
+++ b/packages/client/src/components/chat/ConversationInput.tsx
@@ -1597,7 +1597,7 @@ export function ConversationInput({
       }
 
       // :emoji: detection — a `:partial` at a word boundary, just before the cursor
-      const emojiMatch = textBefore.match(/(?:^|\s):([a-z0-9_]+)$/);
+      const emojiMatch = textBefore.match(/(?:^|\s):([a-z0-9_]+)$/i);
       if (emojiMatch) {
         const eq = emojiMatch[1]!.toLowerCase();
         const customMatches: EmojiCompletion[] = (customEmojiList ?? [])

--- a/packages/client/src/components/chat/ConversationInput.tsx
+++ b/packages/client/src/components/chat/ConversationInput.tsx
@@ -47,6 +47,7 @@ import { translateDraftText } from "../../lib/draft-translation";
 import { prepareImageAttachment } from "../../lib/chat-attachment-images";
 import { CARD_ASSET_INSERT_EVENT, type CardAssetInsertDetail } from "../../lib/card-asset-links";
 import { requestChatScrollToBottom } from "../../lib/chat-scroll-events";
+import { searchStandardEmojiShortcodes, type StandardEmojiShortcode } from "../../lib/emoji-shortcodes";
 import { QuickConnectionSwitcher } from "./QuickConnectionSwitcher";
 import { QuickPersonaSwitcher } from "./QuickPersonaSwitcher";
 import { QuickSwitcherMobile } from "./QuickSwitcherMobile";
@@ -79,6 +80,10 @@ interface Attachment {
   data: string;
   name: string;
 }
+
+type EmojiCompletion =
+  | ({ kind: "custom" } & ConversationCustomEmoji)
+  | ({ kind: "standard"; source: "Standard" } & StandardEmojiShortcode);
 
 const TEXT_ATTACHMENT_EXTENSIONS = new Set([
   "csv",
@@ -336,7 +341,7 @@ export function ConversationInput({
   const [selectedMention, setSelectedMention] = useState(0);
   const [mentionStartPos, setMentionStartPos] = useState(0);
   // :emoji: autocomplete
-  const [emojiCompletions, setEmojiCompletions] = useState<ConversationCustomEmoji[]>([]);
+  const [emojiCompletions, setEmojiCompletions] = useState<EmojiCompletion[]>([]);
   const [selectedEmojiCompletion, setSelectedEmojiCompletion] = useState(0);
   const [emojiStartPos, setEmojiStartPos] = useState(0);
   const { list: customEmojiList } = useConversationCustomEmojis();
@@ -444,13 +449,14 @@ export function ConversationInput({
   const messagesData = qc.getQueryData<InfiniteData<Message[]>>(chatKeys.messages(activeChatId ?? ""));
   const isProfessorMariChat = activeChatCharacters?.some((character) => character.id === PROFESSOR_MARI_ID) ?? false;
   const hasMessages = (messagesData?.pages ?? []).some((page) => page.length > 0);
-  const visibleMariChips = isProfessorMariChat && professorMariSuggestionsEnabled
-    ? mariChipsChatId === activeChatId && mariChips.length > 0
-      ? mariChips
-      : !hasMessages
-        ? MARI_STARTER_CHIPS
-        : []
-    : [];
+  const visibleMariChips =
+    isProfessorMariChat && professorMariSuggestionsEnabled
+      ? mariChipsChatId === activeChatId && mariChips.length > 0
+        ? mariChips
+        : !hasMessages
+          ? MARI_STARTER_CHIPS
+          : []
+      : [];
   const lastMessage = useMemo(() => {
     const firstPage = messagesData?.pages?.[0];
     return firstPage?.[firstPage.length - 1] ?? null;
@@ -832,13 +838,14 @@ export function ConversationInput({
 
   /** Insert an emoji completion into the textarea, replacing the :query. */
   const insertEmoji = useCallback(
-    (name: string) => {
+    (completion: EmojiCompletion) => {
       const el = textareaRef.current;
       if (!el) return;
       const before = el.value.slice(0, emojiStartPos);
       const after = el.value.slice(el.selectionStart);
-      el.value = `${before}:${name}: ${after}`;
-      const cursorPos = before.length + name.length + 3; // ':' + name + ':' + space
+      const inserted = completion.kind === "standard" ? completion.emoji : `:${completion.name}:`;
+      el.value = `${before}${inserted} ${after}`;
+      const cursorPos = before.length + inserted.length + 1;
       el.selectionStart = el.selectionEnd = cursorPos;
       syncInputState(el.value);
       if (activeChatId) setInputDraft(activeChatId, el.value);
@@ -1467,7 +1474,7 @@ export function ConversationInput({
         if (e.key === "Tab" || e.key === "Enter") {
           e.preventDefault();
           const em = emojiCompletions[selectedEmojiCompletion];
-          if (em) insertEmoji(em.name);
+          if (em) insertEmoji(em);
           return;
         }
         if (e.key === "Escape") {
@@ -1591,12 +1598,17 @@ export function ConversationInput({
 
       // :emoji: detection — a `:partial` at a word boundary, just before the cursor
       const emojiMatch = textBefore.match(/(?:^|\s):([a-z0-9_]+)$/);
-      if (emojiMatch && customEmojiList && customEmojiList.length > 0) {
+      if (emojiMatch) {
         const eq = emojiMatch[1]!.toLowerCase();
-        const matches = customEmojiList
+        const customMatches: EmojiCompletion[] = (customEmojiList ?? [])
           .filter((em) => em.name.includes(eq))
           .sort((a, b) => Number(b.name.startsWith(eq)) - Number(a.name.startsWith(eq)))
-          .slice(0, 10);
+          .map((em) => ({ ...em, kind: "custom" as const }));
+        const customNames = new Set(customMatches.map((em) => em.name));
+        const standardMatches: EmojiCompletion[] = searchStandardEmojiShortcodes(eq, 10)
+          .filter((em) => !customNames.has(em.name))
+          .map((em) => ({ ...em, kind: "standard" as const, source: "Standard" as const }));
+        const matches = [...customMatches, ...standardMatches].slice(0, 10);
         if (matches.length > 0) {
           setEmojiCompletions(matches);
           setSelectedEmojiCompletion(0);
@@ -2128,14 +2140,20 @@ export function ConversationInput({
               key={em.name}
               onMouseDown={(e) => {
                 e.preventDefault();
-                insertEmoji(em.name);
+                insertEmoji(em);
               }}
               className={cn(
                 "flex w-full items-center gap-2 px-3 py-1.5 text-left text-sm transition-colors",
                 i === selectedEmojiCompletion ? "bg-foreground/10 text-foreground" : "hover:bg-foreground/10",
               )}
             >
-              <img src={em.url} alt={`:${em.name}:`} className="h-5 w-5 shrink-0 object-contain" />
+              {em.kind === "custom" ? (
+                <img src={em.url} alt={`:${em.name}:`} className="h-5 w-5 shrink-0 object-contain" />
+              ) : (
+                <span className="flex h-5 w-5 shrink-0 items-center justify-center text-base" aria-hidden="true">
+                  {em.emoji}
+                </span>
+              )}
               <span className="min-w-0 flex-1 truncate font-medium">:{em.name}:</span>
               <span className="hidden shrink-0 text-xs text-foreground/40 sm:inline">{em.source}</span>
             </button>

--- a/packages/client/src/components/chat/ConversationMessage.tsx
+++ b/packages/client/src/components/chat/ConversationMessage.tsx
@@ -453,8 +453,9 @@ export const ConversationMessage = memo(function ConversationMessage({
   const groupedSegments = useMemo(() => {
     if (isUser || !renderedContent) return null;
     const knownNames = charByName ? new Set(charByName.keys()) : new Set<string>();
-    return parseGroupedSpeakerSegments(renderedContent, knownNames);
-  }, [isUser, renderedContent, charByName]);
+    const leadingSpeaker = message.characterId ? scopedCharacterMap?.get(message.characterId)?.name : null;
+    return parseGroupedSpeakerSegments(renderedContent, knownNames, leadingSpeaker);
+  }, [isUser, renderedContent, charByName, message.characterId, scopedCharacterMap]);
 
   // Segment-targeted reactions render inline under their speaker's segment; the
   // remainder (whole-message entries + orphans from a re-segmentation) keeps the

--- a/packages/client/src/components/chat/ConversationMessageShared.tsx
+++ b/packages/client/src/components/chat/ConversationMessageShared.tsx
@@ -21,6 +21,8 @@ import { SwipeJumpControl } from "./SwipeJumpControl";
 import { AnimatedDiceRoll, isDiceRollResult, shouldAnimateDiceRollMessage } from "../dice/AnimatedDiceRoll";
 import type { CharacterMap } from "./chat-area.types";
 
+const EMPTY_INLINE_EMOJI_MAP = new Map<string, string>();
+
 // ── Types ────────────────────────────────────────
 
 export type CharInfo = NonNullable<ReturnType<CharacterMap["get"]>>;
@@ -383,10 +385,8 @@ export function MessageContent({
   const baseInline = mentionNames?.length
     ? (text: string, kp: string) => highlightMentions(applyInlineMarkdown(text, kp), mentionNames, kp)
     : applyInlineMarkdown;
-  const renderInline =
-    emojiMap && emojiMap.size > 0
-      ? (text: string, kp: string) => renderInlineWithCustomEmojis(text, kp, emojiMap, baseInline)
-      : baseInline;
+  const renderInline = (text: string, kp: string) =>
+    renderInlineWithCustomEmojis(text, kp, emojiMap ?? EMPTY_INLINE_EMOJI_MAP, baseInline);
   const renderTextBlock = (text: string, kp: string) => (
     <Fragment key={kp}>{renderMarkdownBlocks(text, renderInline)}</Fragment>
   );

--- a/packages/client/src/components/lorebooks/LorebookEditor.tsx
+++ b/packages/client/src/components/lorebooks/LorebookEditor.tsx
@@ -32,6 +32,7 @@ import {
   useLorebookFolders,
   useCreateLorebookFolder,
   useUpdateLorebookEntry,
+  useBulkUpdateLorebookEntries,
   useReorderLorebookFolders,
   useUpdateLorebookFolder,
   useTransferLorebookEntries,
@@ -320,6 +321,21 @@ const SORT_OPTIONS: Array<{ value: EntrySortKey; label: string }> = [
   { value: "oldest", label: "Oldest" },
 ];
 
+const BATCH_ENTRY_SETTING_OPTIONS = [
+  { value: "enabled", label: "Entry enabled" },
+  { value: "constant", label: "Always active" },
+  { value: "selective", label: "Selective matching" },
+  { value: "matchWholeWords", label: "Match whole words" },
+  { value: "caseSensitive", label: "Case sensitive" },
+  { value: "useRegex", label: "Use regex" },
+  { value: "preventRecursion", label: "Prevent recursion" },
+  { value: "excludeRecursion", label: "Exclude from recursion" },
+  { value: "delayUntilRecursion", label: "Delay until recursion" },
+  { value: "excludeFromVectorization", label: "Exclude from vectors" },
+  { value: "locked", label: "Locked" },
+] as const;
+type BatchEntrySetting = (typeof BATCH_ENTRY_SETTING_OPTIONS)[number]["value"];
+
 function entryStatusSortRank(entry: LorebookEntry): number {
   if (!entry.enabled) return 3;
   if (entry.constant) return 0;
@@ -342,6 +358,7 @@ export function LorebookEditor() {
   const createEntry = useCreateLorebookEntry();
   const deleteEntry = useDeleteLorebookEntry();
   const updateEntry = useUpdateLorebookEntry();
+  const bulkUpdateEntries = useBulkUpdateLorebookEntries();
   const reorderEntries = useReorderLorebookEntries();
   const createFolder = useCreateLorebookFolder();
   const updateFolder = useUpdateLorebookFolder();
@@ -418,6 +435,8 @@ export function LorebookEditor() {
   const [entrySelectionMode, setEntrySelectionMode] = useState(false);
   const [selectedEntryIds, setSelectedEntryIds] = useState<Set<string>>(new Set());
   const [entryTransferTargetId, setEntryTransferTargetId] = useState("");
+  const [batchEntrySetting, setBatchEntrySetting] = useState<BatchEntrySetting | "">("");
+  const [batchEntryValue, setBatchEntryValue] = useState<"true" | "false">("true");
 
   // ── Folder UI state ──
   // Collapse state: persisted in localStorage, keyed per-lorebook. Loaded
@@ -759,6 +778,22 @@ export function LorebookEditor() {
       transferTargetLorebooks,
     ],
   );
+
+  const handleBatchUpdateEntries = useCallback(async () => {
+    if (!lorebookId || selectedEntryIds.size === 0 || !batchEntrySetting) return;
+    try {
+      const result = await bulkUpdateEntries.mutateAsync({
+        lorebookId,
+        entryIds: Array.from(selectedEntryIds),
+        changes: { [batchEntrySetting]: batchEntryValue === "true" },
+      });
+      const settingLabel =
+        BATCH_ENTRY_SETTING_OPTIONS.find((option) => option.value === batchEntrySetting)?.label ?? "Setting";
+      toast.success(`${settingLabel} updated for ${result.updated} ${result.updated === 1 ? "entry" : "entries"}.`);
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : "Failed to update selected entries.");
+    }
+  }, [batchEntrySetting, batchEntryValue, bulkUpdateEntries, lorebookId, selectedEntryIds]);
 
   const handleDeleteSelectedEntries = useCallback(async () => {
     if (!lorebookId || selectedEntryIds.size === 0) return;
@@ -1684,11 +1719,7 @@ export function LorebookEditor() {
               <rect x="3" y="15" width="14" height="2" rx="1" fill="currentColor" />
             </svg>
           </button>
-          <button
-            onClick={handleDelete}
-            className="mari-editor-action inline-flex"
-            title="Delete lorebook"
-          >
+          <button onClick={handleDelete} className="mari-editor-action inline-flex" title="Delete lorebook">
             <Trash2 size="0.875rem" />
           </button>
         </div>
@@ -2263,6 +2294,40 @@ export function LorebookEditor() {
                       Clear
                     </button>
                     <select
+                      value={batchEntrySetting}
+                      onChange={(event) => setBatchEntrySetting(event.target.value as BatchEntrySetting | "")}
+                      className="mari-editor-field min-h-8 min-w-[10rem] px-2.5 py-1.5 text-xs"
+                      aria-label="Setting to apply to selected entries"
+                    >
+                      <option value="">Batch setting…</option>
+                      {BATCH_ENTRY_SETTING_OPTIONS.map((option) => (
+                        <option key={option.value} value={option.value}>
+                          {option.label}
+                        </option>
+                      ))}
+                    </select>
+                    <select
+                      value={batchEntryValue}
+                      onChange={(event) => setBatchEntryValue(event.target.value as "true" | "false")}
+                      className="mari-editor-field min-h-8 px-2.5 py-1.5 text-xs"
+                      aria-label="Value to apply to selected entries"
+                    >
+                      <option value="true">On</option>
+                      <option value="false">Off</option>
+                    </select>
+                    <button
+                      onClick={() => void handleBatchUpdateEntries()}
+                      disabled={selectedEntryIds.size === 0 || !batchEntrySetting || bulkUpdateEntries.isPending}
+                      className="mari-editor-action mari-editor-action--primary mari-editor-action--compact inline-flex items-center gap-1 px-2.5 py-1.5 text-[0.625rem] disabled:opacity-40"
+                    >
+                      {bulkUpdateEntries.isPending ? (
+                        <Loader2 size="0.6875rem" className="animate-spin" />
+                      ) : (
+                        <Check size="0.6875rem" />
+                      )}
+                      Apply
+                    </button>
+                    <select
                       value={entryTransferTargetId}
                       onChange={(e) => setEntryTransferTargetId(e.target.value)}
                       disabled={transferTargetLorebooks.length === 0}
@@ -2700,9 +2765,8 @@ function VectorizeSection({
       await queryClient.invalidateQueries({ queryKey: lorebookKeys.entries(lorebookId) });
       setResult({
         success: true,
-        message: mode === "all"
-          ? `Re-vectorized ${data.vectorized} entries`
-          : `Vectorized ${data.vectorized} missing entries`,
+        message:
+          mode === "all" ? `Re-vectorized ${data.vectorized} entries` : `Vectorized ${data.vectorized} missing entries`,
       });
     } catch (err) {
       setResult({ success: false, message: err instanceof Error ? err.message : "Vectorization failed" });
@@ -2772,10 +2836,7 @@ function VectorizeSection({
             value={vectorQueryDepth}
             onChange={(e) =>
               onVectorQueryDepthChange(
-                Math.max(
-                  0,
-                  Math.min(LIMITS.LOREBOOK_VECTOR_QUERY_DEPTH_MAX, Number.parseInt(e.target.value, 10) || 0),
-                ),
+                Math.max(0, Math.min(LIMITS.LOREBOOK_VECTOR_QUERY_DEPTH_MAX, Number.parseInt(e.target.value, 10) || 0)),
               )
             }
             min={0}

--- a/packages/client/src/components/lorebooks/LorebookEditor.tsx
+++ b/packages/client/src/components/lorebooks/LorebookEditor.tsx
@@ -2317,7 +2317,13 @@ export function LorebookEditor() {
                     </select>
                     <button
                       onClick={() => void handleBatchUpdateEntries()}
-                      disabled={selectedEntryIds.size === 0 || !batchEntrySetting || bulkUpdateEntries.isPending}
+                      disabled={
+                        selectedEntryIds.size === 0 ||
+                        !batchEntrySetting ||
+                        bulkUpdateEntries.isPending ||
+                        transferEntries.isPending ||
+                        deleteEntry.isPending
+                      }
                       className="mari-editor-action mari-editor-action--primary mari-editor-action--compact inline-flex items-center gap-1 px-2.5 py-1.5 text-[0.625rem] disabled:opacity-40"
                     >
                       {bulkUpdateEntries.isPending ? (
@@ -2349,6 +2355,7 @@ export function LorebookEditor() {
                         selectedEntryIds.size === 0 ||
                         !entryTransferTargetId ||
                         transferEntries.isPending ||
+                        bulkUpdateEntries.isPending ||
                         deleteEntry.isPending
                       }
                       className="mari-editor-action mari-editor-action--primary mari-editor-action--compact inline-flex items-center gap-1 px-2.5 py-1.5 text-[0.625rem] disabled:opacity-40"
@@ -2366,6 +2373,7 @@ export function LorebookEditor() {
                         selectedEntryIds.size === 0 ||
                         !entryTransferTargetId ||
                         transferEntries.isPending ||
+                        bulkUpdateEntries.isPending ||
                         deleteEntry.isPending
                       }
                       className="inline-flex items-center gap-1 rounded-lg bg-[var(--destructive)]/12 px-2.5 py-1.5 text-[0.625rem] font-medium text-[var(--destructive)] transition-all hover:bg-[var(--destructive)]/20 disabled:opacity-40"
@@ -2379,7 +2387,12 @@ export function LorebookEditor() {
                     </button>
                     <button
                       onClick={() => void handleDeleteSelectedEntries()}
-                      disabled={selectedEntryIds.size === 0 || transferEntries.isPending || deleteEntry.isPending}
+                      disabled={
+                        selectedEntryIds.size === 0 ||
+                        transferEntries.isPending ||
+                        bulkUpdateEntries.isPending ||
+                        deleteEntry.isPending
+                      }
                       className="mari-editor-action mari-editor-action--compact inline-flex items-center gap-1 px-2.5 py-1.5 text-[0.625rem] disabled:opacity-40"
                     >
                       {deleteEntry.isPending ? (

--- a/packages/client/src/hooks/use-lorebooks.ts
+++ b/packages/client/src/hooks/use-lorebooks.ts
@@ -80,7 +80,8 @@ export function useLorebookPages(options: {
       if (sort) params.set("sort", sort);
       if (options.active) {
         params.set("active", "true");
-        if (options.active.lorebookIds.length > 0) params.set("activeLorebookIds", options.active.lorebookIds.join(","));
+        if (options.active.lorebookIds.length > 0)
+          params.set("activeLorebookIds", options.active.lorebookIds.join(","));
         if (options.active.characterIds.length > 0) params.set("characterIds", options.active.characterIds.join(","));
         if (options.active.personaId) params.set("personaId", options.active.personaId);
         if (options.active.chatId) params.set("chatId", options.active.chatId);
@@ -96,17 +97,19 @@ export function flattenLorebookPages(data: { pages?: Array<PaginatedList<Loreboo
   return flattenPaginatedItems(data?.pages);
 }
 
-export function fetchAllLorebookPages(options: {
-  category?: string;
-  search?: string;
-  sort?: string;
-  active?: {
-    lorebookIds: string[];
-    characterIds: string[];
-    personaId?: string | null;
-    chatId?: string | null;
-  };
-} = {}) {
+export function fetchAllLorebookPages(
+  options: {
+    category?: string;
+    search?: string;
+    sort?: string;
+    active?: {
+      lorebookIds: string[];
+      characterIds: string[];
+      personaId?: string | null;
+      chatId?: string | null;
+    };
+  } = {},
+) {
   const category = options.category ?? "";
   const search = (options.search ?? "").trim();
   const sort = options.sort ?? "";
@@ -157,10 +160,13 @@ export function useEmbedLorebook() {
   const qc = useQueryClient();
   return useMutation({
     mutationFn: ({ characterId, lorebookId }: { characterId: string; lorebookId: string }) =>
-      api.post<{ success: boolean; lorebookId: string; entriesEmbedded: number; refreshed: boolean; characterBook: unknown }>(
-        `/characters/${characterId}/embedded-lorebook/embed`,
-        { lorebookId },
-      ),
+      api.post<{
+        success: boolean;
+        lorebookId: string;
+        entriesEmbedded: number;
+        refreshed: boolean;
+        characterBook: unknown;
+      }>(`/characters/${characterId}/embedded-lorebook/embed`, { lorebookId }),
     onSuccess: (_data, variables) => {
       qc.invalidateQueries({ queryKey: lorebookKeys.all });
       qc.invalidateQueries({ queryKey: lorebookKeys.active() });
@@ -303,6 +309,25 @@ export function useUpdateLorebookEntry() {
     onSuccess: (_data, variables) => {
       qc.invalidateQueries({ queryKey: lorebookKeys.entries(variables.lorebookId) });
       qc.invalidateQueries({ queryKey: lorebookKeys.entry(variables.entryId) });
+      qc.invalidateQueries({ queryKey: lorebookKeys.active() });
+    },
+  });
+}
+
+export function useBulkUpdateLorebookEntries() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: ({
+      lorebookId,
+      entryIds,
+      changes,
+    }: {
+      lorebookId: string;
+      entryIds: string[];
+      changes: Record<string, boolean>;
+    }) => api.patch<{ updated: number }>(`/lorebooks/${lorebookId}/entries/bulk`, { entryIds, changes }),
+    onSuccess: (_data, variables) => {
+      qc.invalidateQueries({ queryKey: lorebookKeys.entries(variables.lorebookId) });
       qc.invalidateQueries({ queryKey: lorebookKeys.active() });
     },
   });

--- a/packages/client/src/lib/custom-emoji-render.tsx
+++ b/packages/client/src/lib/custom-emoji-render.tsx
@@ -7,7 +7,7 @@
 import { type CSSProperties, type ReactNode } from "react";
 import { resolveStandardEmojiShortcode } from "./emoji-shortcodes";
 
-const CUSTOM_EMOJI_TOKEN_RE = /:([a-z0-9_]+):/g;
+const CUSTOM_EMOJI_TOKEN_RE = /:([a-z0-9_]+):/gi;
 
 const customEmojiStyle: CSSProperties = {
   display: "inline-block",

--- a/packages/client/src/lib/custom-emoji-render.tsx
+++ b/packages/client/src/lib/custom-emoji-render.tsx
@@ -5,6 +5,7 @@
 // the `.mari-message-content img` rule (rounding/margins) without !important.
 // ──────────────────────────────────────────────
 import { type CSSProperties, type ReactNode } from "react";
+import { resolveStandardEmojiShortcode } from "./emoji-shortcodes";
 
 const CUSTOM_EMOJI_TOKEN_RE = /:([a-z0-9_]+):/g;
 
@@ -38,17 +39,20 @@ export function renderInlineWithCustomEmojis(
   emojiMap: Map<string, string>,
   baseRender: (text: string, keyPrefix: string) => ReactNode[],
 ): ReactNode[] {
-  if (emojiMap.size === 0 || !text.includes(":")) return baseRender(text, keyPrefix);
+  if (!text.includes(":")) return baseRender(text, keyPrefix);
 
   // Jumbo when the whole segment is only known custom emojis (+ whitespace).
   let knownCount = 0;
-  const remainder = text.replace(new RegExp(CUSTOM_EMOJI_TOKEN_RE.source, CUSTOM_EMOJI_TOKEN_RE.flags), (full, name) => {
-    if (name && emojiMap.has(name)) {
-      knownCount++;
-      return "";
-    }
-    return full;
-  });
+  const remainder = text.replace(
+    new RegExp(CUSTOM_EMOJI_TOKEN_RE.source, CUSTOM_EMOJI_TOKEN_RE.flags),
+    (full, name) => {
+      if (name && emojiMap.has(name)) {
+        knownCount++;
+        return "";
+      }
+      return full;
+    },
+  );
   const style = knownCount > 0 && remainder.trim().length === 0 ? customEmojiJumboStyle : customEmojiStyle;
 
   const parts: ReactNode[] = [];
@@ -58,14 +62,18 @@ export function renderInlineWithCustomEmojis(
   let match: RegExpExecArray | null;
 
   while ((match = re.exec(text)) !== null) {
-    const url = match[1] ? emojiMap.get(match[1]) : undefined;
-    if (!url) continue; // not a known emoji — leave the token for the surrounding text
+    const name = match[1];
+    const url = name ? emojiMap.get(name) : undefined;
+    const standardEmoji = !url && name ? resolveStandardEmojiShortcode(name) : null;
+    if (!url && !standardEmoji) continue; // not a known emoji — leave the token for the surrounding text
     if (match.index > lastIndex) {
       parts.push(baseRender(text.slice(lastIndex, match.index), `${keyPrefix}-t${segment}`));
     }
-    parts.push(
-      <img key={`${keyPrefix}-e${segment}`} src={url} alt={match[0]} title={match[0]} style={style} />,
-    );
+    if (url) {
+      parts.push(<img key={`${keyPrefix}-e${segment}`} src={url} alt={match[0]} title={match[0]} style={style} />);
+    } else {
+      parts.push(baseRender(standardEmoji!, `${keyPrefix}-e${segment}`));
+    }
     lastIndex = match.index + match[0].length;
     segment++;
   }

--- a/packages/client/src/lib/emoji-shortcodes.ts
+++ b/packages/client/src/lib/emoji-shortcodes.ts
@@ -63,7 +63,7 @@ for (const [emoji, unicodeName] of Object.entries(EMOJI_SEARCH_NAMES)) {
 export const STANDARD_EMOJI_SHORTCODES: readonly StandardEmojiShortcode[] = Array.from(byName.values());
 
 export function resolveStandardEmojiShortcode(name: string): string | null {
-  return byName.get(name.toLowerCase())?.emoji ?? null;
+  return byName.get(toShortcode(name))?.emoji ?? null;
 }
 
 export function searchStandardEmojiShortcodes(query: string, limit = 10): StandardEmojiShortcode[] {

--- a/packages/client/src/lib/emoji-shortcodes.ts
+++ b/packages/client/src/lib/emoji-shortcodes.ts
@@ -1,0 +1,88 @@
+import { EMOJI_SEARCH_NAMES } from "./emoji-catalog.generated";
+
+export interface StandardEmojiShortcode {
+  name: string;
+  emoji: string;
+  searchText: string;
+}
+
+const COMMON_SHORTCODES: Readonly<Record<string, string>> = {
+  crying: "😢",
+  sob: "😭",
+  joy: "😂",
+  laughing: "😂",
+  smile: "😄",
+  grin: "😁",
+  wink: "😉",
+  heart: "❤️",
+  broken_heart: "💔",
+  thumbs_up: "👍",
+  thumbs_down: "👎",
+  clap: "👏",
+  pray: "🙏",
+  fire: "🔥",
+  eyes: "👀",
+  skull: "💀",
+  test_tube: "🧪",
+  tada: "🎉",
+  thinking: "🤔",
+  angry: "😠",
+  rage: "😡",
+  scream: "😱",
+  blush: "😊",
+  kiss: "😘",
+  sunglasses: "😎",
+  shrug: "🤷",
+  wave: "👋",
+  rocket: "🚀",
+  warning: "⚠️",
+  check: "✅",
+  x: "❌",
+};
+
+function toShortcode(value: string): string {
+  return value
+    .toLowerCase()
+    .replace(/['’]/gu, "")
+    .replace(/[^a-z0-9]+/gu, "_")
+    .replace(/^_+|_+$/gu, "");
+}
+
+const byName = new Map<string, StandardEmojiShortcode>();
+
+for (const [name, emoji] of Object.entries(COMMON_SHORTCODES)) {
+  byName.set(name, { name, emoji, searchText: `${name.replaceAll("_", " ")} ${EMOJI_SEARCH_NAMES[emoji] ?? ""}` });
+}
+
+for (const [emoji, unicodeName] of Object.entries(EMOJI_SEARCH_NAMES)) {
+  const name = toShortcode(unicodeName);
+  if (!name || byName.has(name)) continue;
+  byName.set(name, { name, emoji, searchText: `${name.replaceAll("_", " ")} ${unicodeName}` });
+}
+
+export const STANDARD_EMOJI_SHORTCODES: readonly StandardEmojiShortcode[] = Array.from(byName.values());
+
+export function resolveStandardEmojiShortcode(name: string): string | null {
+  return byName.get(name.toLowerCase())?.emoji ?? null;
+}
+
+export function searchStandardEmojiShortcodes(query: string, limit = 10): StandardEmojiShortcode[] {
+  const normalized = toShortcode(query);
+  if (!normalized) return [];
+  const matches = STANDARD_EMOJI_SHORTCODES.filter(
+    (entry) => entry.name.includes(normalized) || entry.searchText.includes(normalized.replaceAll("_", " ")),
+  ).sort((a, b) => {
+    const aStarts = a.name.startsWith(normalized) ? 1 : 0;
+    const bStarts = b.name.startsWith(normalized) ? 1 : 0;
+    return bStarts - aStarts || a.name.length - b.name.length || a.name.localeCompare(b.name);
+  });
+
+  const seenEmoji = new Set<string>();
+  return matches
+    .filter((entry) => {
+      if (seenEmoji.has(entry.emoji)) return false;
+      seenEmoji.add(entry.emoji);
+      return true;
+    })
+    .slice(0, limit);
+}

--- a/packages/server/src/routes/generate/conversation-custom-assets.ts
+++ b/packages/server/src/routes/generate/conversation-custom-assets.ts
@@ -248,9 +248,7 @@ export async function appendConversationCustomAssetAdvertisements(args: {
   for (const info of respondingConversationChars) {
     const images = await args.characterGallery.listByCharacterId(info.charId);
     const emojiNames = uniqueEmojiNames(
-      images
-        .filter((img) => img.customKind === "emoji" && img.customName)
-        .map((img) => img.customName as string),
+      images.filter((img) => img.customKind === "emoji" && img.customName).map((img) => img.customName as string),
     );
     for (const img of images) {
       if (img.customKind === "emoji" && img.customName && img.filePath) {
@@ -261,9 +259,7 @@ export async function appendConversationCustomAssetAdvertisements(args: {
       }
     }
     const stickerNames = uniqueEmojiNames(
-      images
-        .filter((img) => img.customKind === "sticker" && img.customName)
-        .map((img) => img.customName as string),
+      images.filter((img) => img.customKind === "sticker" && img.customName).map((img) => img.customName as string),
     );
     if (emojiNames.length > 0) ownEmojisByChar.set(info.charId, emojiNames);
     if (stickerNames.length > 0) ownStickersByChar.set(info.charId, stickerNames);
@@ -280,11 +276,7 @@ export async function appendConversationCustomAssetAdvertisements(args: {
     const emojiPrefs = normalizeCustomEmojiSelection(args.chatMeta.customEmojiSelection);
     let toolSelectionHandled = false;
 
-    if (
-      emojiPrefs.mode === "tool-call" &&
-      emojiPrefs.toolConnectionId &&
-      respondingConversationChars.length === 1
-    ) {
+    if (emojiPrefs.mode === "tool-call" && emojiPrefs.toolConnectionId && respondingConversationChars.length === 1) {
       const responder = respondingConversationChars[0]!;
       const candidates = uniqueEmojiNames([...(ownEmojisByChar.get(responder.charId) ?? []), ...sharedEmojiNames]);
       const picked = await selectCustomAssetNamesByToolCall(
@@ -334,10 +326,7 @@ export async function appendConversationCustomAssetAdvertisements(args: {
       respondingConversationChars.length === 1
     ) {
       const responder = respondingConversationChars[0]!;
-      const candidates = uniqueEmojiNames([
-        ...(ownStickersByChar.get(responder.charId) ?? []),
-        ...sharedStickerNames,
-      ]);
+      const candidates = uniqueEmojiNames([...(ownStickersByChar.get(responder.charId) ?? []), ...sharedStickerNames]);
       const picked = await selectCustomAssetNamesByToolCall(
         "sticker",
         "sticker:name:",
@@ -484,16 +473,17 @@ export function annotateContentWithReactions(
   reactions: unknown,
   knownSpeakersByNorm: Map<string, string>,
   resolveReactorName: (reactorId: string) => string,
+  leadingSpeaker?: string | null,
 ): string {
   if (!Array.isArray(reactions) || reactions.length === 0) return promptContent;
   const knownNames = new Set(knownSpeakersByNorm.keys());
   const clientGroups: GroupedSegment[] | null =
     clientShapeContent.length <= REACTION_ANNOTATION_CONTENT_CAP
-      ? parseGroupedSpeakerSegments(clientShapeContent, knownNames)
+      ? parseGroupedSpeakerSegments(clientShapeContent, knownNames, leadingSpeaker)
       : null;
   const promptGroups: GroupedSegment[] | null =
     promptContent.length <= REACTION_ANNOTATION_CONTENT_CAP
-      ? parseGroupedSpeakerSegments(promptContent, knownNames)
+      ? parseGroupedSpeakerSegments(promptContent, knownNames, leadingSpeaker)
       : null;
 
   const promptGroupFor = (clientIndex: number): GroupedSegment | null => {
@@ -560,9 +550,7 @@ export function annotateContentWithReactions(
     const wanted = storedSpeaker !== null ? normalizeTextForMatch(storedSpeaker) : null;
     const segIdx = typeof entry.segment === "number" && Number.isInteger(entry.segment) ? entry.segment : null;
     const seg =
-      clientGroups && segIdx !== null && segIdx >= 0 && segIdx < clientGroups.length
-        ? clientGroups[segIdx]
-        : undefined;
+      clientGroups && segIdx !== null && segIdx >= 0 && segIdx < clientGroups.length ? clientGroups[segIdx] : undefined;
     const segSpeakerNorm = seg?.speaker != null ? normalizeTextForMatch(seg.speaker) : null;
     const segAligned =
       seg !== undefined &&
@@ -618,11 +606,7 @@ export function annotateContentWithReactions(
   const endParts: string[] = [];
   for (const note of notes) {
     if (note.kind !== "end") continue;
-    if (
-      note.staleTwinShape &&
-      note.speakerNorm !== null &&
-      inlineKeys.has(`${note.phrase}\u0000${note.speakerNorm}`)
-    ) {
+    if (note.staleTwinShape && note.speakerNorm !== null && inlineKeys.has(`${note.phrase}\u0000${note.speakerNorm}`)) {
       continue;
     }
     endParts.push(note.text);

--- a/packages/server/src/routes/generate/conversation-history-runtime.ts
+++ b/packages/server/src/routes/generate/conversation-history-runtime.ts
@@ -17,10 +17,7 @@ import { formatConversationPromptTurn } from "../../services/generation/generati
 import type { GenerationPromptMessage } from "../../services/generation/prompt-message-scope.js";
 import { createLLMProvider } from "../../services/llm/provider-registry.js";
 import { wrapContent } from "../../services/prompt/format-engine.js";
-import {
-  annotateContentWithReactions,
-  REACTION_ANNOTATION_CONTENT_CAP,
-} from "./conversation-custom-assets.js";
+import { annotateContentWithReactions, REACTION_ANNOTATION_CONTENT_CAP } from "./conversation-custom-assets.js";
 import {
   formatConversationDateHistoryMessages,
   formatConversationSummaryHistoryBlock,
@@ -41,7 +38,10 @@ type ConversationHistoryCharacterStore = {
 };
 
 type ConversationHistoryChatsStore = {
-  patchMetadata(chatId: string, updater: (freshMeta: Record<string, unknown>) => Record<string, unknown>): Promise<unknown>;
+  patchMetadata(
+    chatId: string,
+    updater: (freshMeta: Record<string, unknown>) => Record<string, unknown>,
+  ): Promise<unknown>;
 };
 
 type ConversationSummaryConnection = {
@@ -144,7 +144,10 @@ export async function prepareConversationPromptHistory(args: {
   });
 
   for (const failure of summaryRun.failedDays) {
-    logger.warn({ chatId: args.chatId, date: failure.date, err: failure.error }, "[conversation-summary] failed to generate day summary");
+    logger.warn(
+      { chatId: args.chatId, date: failure.date, err: failure.error },
+      "[conversation-summary] failed to generate day summary",
+    );
   }
   for (const failure of summaryRun.failedWeeks) {
     logger.warn(
@@ -154,8 +157,7 @@ export async function prepareConversationPromptHistory(args: {
   }
 
   const hasNewSummaries =
-    Object.keys(summaryRun.newlyGeneratedDays).length > 0 ||
-    Object.keys(summaryRun.newlyConsolidatedWeeks).length > 0;
+    Object.keys(summaryRun.newlyGeneratedDays).length > 0 || Object.keys(summaryRun.newlyConsolidatedWeeks).length > 0;
   if (hasNewSummaries || summaryRun.summaryFailureMetadataChanged) {
     await args.chats.patchMetadata(args.chatId, (freshMeta) => {
       const existingDaySummaries = (freshMeta.daySummaries as Record<string, unknown> | undefined) ?? {};
@@ -288,6 +290,7 @@ async function annotateConversationPromptReactions(args: {
         parseExtra(raw.extra).reactions,
         reactionSpeakersByNorm,
         reactorDisplayName,
+        typeof raw.characterId === "string" ? (args.charIdToName.get(raw.characterId) ?? null) : null,
       ),
     };
   });

--- a/packages/server/src/routes/generate/conversation-history-runtime.ts
+++ b/packages/server/src/routes/generate/conversation-history-runtime.ts
@@ -242,6 +242,7 @@ async function annotateConversationPromptReactions(args: {
   });
   if (!anyReactedMessage) return args.finalMessages;
 
+  const reactionNameById = new Map(args.charIdToName);
   const reactionSpeakersByNorm = new Map<string, string>();
   const addReactionSpeaker = (name: unknown) => {
     if (typeof name !== "string") return;
@@ -261,7 +262,11 @@ async function annotateConversationPromptReactions(args: {
     if (!row) continue;
     try {
       const data = typeof row.data === "string" ? JSON.parse(row.data) : row.data;
-      addReactionSpeaker((data as { name?: unknown } | null)?.name);
+      const name = (data as { name?: unknown } | null)?.name;
+      if (typeof name === "string" && name.trim()) {
+        reactionNameById.set(cid, name);
+        addReactionSpeaker(name);
+      }
     } catch {
       // Malformed character data — skip; that speaker just won't be attributable.
     }
@@ -290,7 +295,7 @@ async function annotateConversationPromptReactions(args: {
         parseExtra(raw.extra).reactions,
         reactionSpeakersByNorm,
         reactorDisplayName,
-        typeof raw.characterId === "string" ? (args.charIdToName.get(raw.characterId) ?? null) : null,
+        typeof raw.characterId === "string" ? (reactionNameById.get(raw.characterId) ?? null) : null,
       ),
     };
   });

--- a/packages/server/src/routes/lorebooks.routes.ts
+++ b/packages/server/src/routes/lorebooks.routes.ts
@@ -11,6 +11,7 @@ import {
   updateLorebookSchema,
   createLorebookEntrySchema,
   updateLorebookEntrySchema,
+  bulkUpdateLorebookEntriesSchema,
   createLorebookFolderSchema,
   updateLorebookFolderSchema,
   LOCAL_SIDECAR_CONNECTION_ID,
@@ -598,6 +599,20 @@ export async function lorebooksRoutes(app: FastifyInstance) {
       return created;
     } catch (err) {
       if (err instanceof Error && err.message === "folderId does not belong to this lorebook") {
+        return reply.status(400).send({ error: err.message });
+      }
+      throw err;
+    }
+  });
+
+  app.patch<{ Params: { id: string } }>("/:id/entries/bulk", async (req, reply) => {
+    const input = bulkUpdateLorebookEntriesSchema.parse(req.body);
+    try {
+      const result = await storage.bulkUpdateEntries(req.params.id, input.entryIds, input.changes);
+      await syncCharacterBookFromLorebook(app.db, req.params.id);
+      return result;
+    } catch (err) {
+      if (err instanceof Error && err.message === "One or more selected entries do not belong to this lorebook") {
         return reply.status(400).send({ error: err.message });
       }
       throw err;

--- a/packages/server/src/services/agents/default-prompt-migration.ts
+++ b/packages/server/src/services/agents/default-prompt-migration.ts
@@ -46,6 +46,8 @@ const LEGACY_BUILT_IN_AGENT_DESCRIPTIONS: Record<string, readonly string[]> = {
   ],
 };
 
+const ILLUSTRATOR_DEFAULT_PROMPT_TEMPLATE_MIGRATION_VERSION = 2;
+
 function normalizedPromptHash(value: string): string {
   return createHash("sha256").update(value.trim().replace(/\r\n/g, "\n")).digest("hex");
 }
@@ -127,8 +129,26 @@ export function buildLegacyDefaultAgentConfigUpdate(row: typeof agentConfigs.$in
 
     const defaults = getDefaultBuiltInAgentSettings(builtIn.id);
     let settingsChanged = settingsMigration.changed;
-    // Illustrator now defaults to the Background named template. Existing configs with a custom
-    // raw prompt must remain on the legacy Default option unless the user selects another mode.
+    // A staging release accidentally persisted Background as Illustrator's global
+    // default. Repair it once; the marker prevents later explicit user choices
+    // from being overwritten on every startup. Per-chat selections live in chat
+    // metadata and are intentionally unaffected.
+    if (
+      row.type === "illustrator" &&
+      settings.illustratorDefaultPromptTemplateMigrationVersion !==
+        ILLUSTRATOR_DEFAULT_PROMPT_TEMPLATE_MIGRATION_VERSION
+    ) {
+      settings = {
+        ...settings,
+        ...(settings.defaultPromptTemplateId === "background"
+          ? { defaultPromptTemplateId: DEFAULT_AGENT_PROMPT_TEMPLATE_ID }
+          : {}),
+        illustratorDefaultPromptTemplateMigrationVersion: ILLUSTRATOR_DEFAULT_PROMPT_TEMPLATE_MIGRATION_VERSION,
+      };
+      settingsChanged = true;
+    }
+    // Existing configs with a custom raw prompt remain on the legacy Default
+    // option unless the user selects another named prompt mode.
     if (
       row.type === "illustrator" &&
       row.promptTemplate.trim() &&

--- a/packages/server/src/services/generation/conversation-react-command-runtime.ts
+++ b/packages/server/src/services/generation/conversation-react-command-runtime.ts
@@ -190,7 +190,7 @@ async function resolveTargetedCharacterReaction(
     const names = new Set(baseNames);
     const author = await authorNameOf(authorId);
     if (author) names.add(normalizeTextForMatch(author));
-    const groups = parseGroupedSpeakerSegments(text, names);
+    const groups = parseGroupedSpeakerSegments(text, names, author);
     if (!groups) return null;
     let cutoff = groups.length;
     if (beforePartByNorm) {
@@ -236,7 +236,11 @@ async function resolveTargetedCharacterReaction(
     const hasAttachments = Array.isArray(messageExtra.attachments) && messageExtra.attachments.length > 0;
     if (!contentStr.trim() && !hasAttachments) continue;
     if (message.characterId === targetChar.id) {
-      return { id: message.id, target: await lastPartBy(message.content, message.characterId), prefetchedMessage: null };
+      return {
+        id: message.id,
+        target: await lastPartBy(message.content, message.characterId),
+        prefetchedMessage: null,
+      };
     }
     const part = await lastPartBy(message.content, message.characterId);
     if (part) {
@@ -244,9 +248,6 @@ async function resolveTargetedCharacterReaction(
     }
   }
 
-  logger.debug(
-    '[react/conversation] No recent part by "%s" to react to - skipping targeted react',
-    targetChar.name,
-  );
+  logger.debug('[react/conversation] No recent part by "%s" to react to - skipping targeted react', targetChar.name);
   return null;
 }

--- a/packages/server/src/services/lorebook/keyword-scanner.ts
+++ b/packages/server/src/services/lorebook/keyword-scanner.ts
@@ -563,9 +563,6 @@ export function scanForActivatedEntries(
 
     for (const entry of entries) {
       if (!entry.enabled || entry.constant || activatedIds.has(entry.id)) continue;
-      // Explicit primary keys mean the entry is keyword-gated. Vectorization is
-      // still useful for router/search flows, but it must not bypass those keys.
-      if (entry.keys.some((key) => key.trim().length > 0)) continue;
       if (entry.delayUntilRecursion && !recursionPass) continue;
       if (entry.excludeRecursion && recursionPass) continue;
       if (entry.excludeFromVectorization) continue;
@@ -600,8 +597,7 @@ export function scanForActivatedEntries(
     const semanticCountsByLorebookId = new Map<string, number>();
     for (const candidate of semanticCandidates.sort((a, b) => b.similarity - a.similarity)) {
       const lorebookId = candidate.entry.lorebookId;
-      const maxMatches =
-        semanticMaxMatchesByLorebookId.get(lorebookId) ?? LIMITS.LOREBOOK_VECTOR_MAX_RESULTS_DEFAULT;
+      const maxMatches = semanticMaxMatchesByLorebookId.get(lorebookId) ?? LIMITS.LOREBOOK_VECTOR_MAX_RESULTS_DEFAULT;
       const selectedCount = semanticCountsByLorebookId.get(lorebookId) ?? 0;
       if (selectedCount >= maxMatches) continue;
       activated.push({

--- a/packages/server/src/services/storage/lorebooks.storage.ts
+++ b/packages/server/src/services/storage/lorebooks.storage.ts
@@ -20,6 +20,7 @@ import {
   type UpdateLorebookInput,
   type CreateLorebookEntryInput,
   type UpdateLorebookEntryInput,
+  type BulkUpdateLorebookEntriesInput,
   type CreateLorebookFolderInput,
   type UpdateLorebookFolderInput,
 } from "@marinara-engine/shared";
@@ -31,10 +32,7 @@ import { toPaginatedList } from "../../utils/list-pagination.js";
 function normalizeLorebookEntryLimit(value: unknown): number {
   const parsed = typeof value === "number" ? value : Number(value);
   if (!Number.isFinite(parsed)) return LIMITS.LOREBOOK_ENTRY_LIMIT_DEFAULT;
-  return Math.max(
-    LIMITS.LOREBOOK_ENTRY_LIMIT_MIN,
-    Math.min(LIMITS.LOREBOOK_ENTRY_LIMIT_MAX, Math.trunc(parsed)),
-  );
+  return Math.max(LIMITS.LOREBOOK_ENTRY_LIMIT_MIN, Math.min(LIMITS.LOREBOOK_ENTRY_LIMIT_MAX, Math.trunc(parsed)));
 }
 
 function normalizeNonNegativeLorebookInteger(value: unknown, fallback: number): number {
@@ -182,7 +180,11 @@ function parseLorebookRow(row: Record<string, unknown>) {
 }
 
 function parseStringArray(value: unknown): string[] {
-  const normalize = (items: unknown[]) => items.map(String).map((item) => item.trim()).filter(Boolean);
+  const normalize = (items: unknown[]) =>
+    items
+      .map(String)
+      .map((item) => item.trim())
+      .filter(Boolean);
   if (Array.isArray(value)) return normalize(value);
   if (typeof value !== "string" || !value.trim()) return [];
   try {
@@ -838,14 +840,40 @@ export function createLorebooksStorage(db: DB) {
       if (input.locked !== undefined) updates.locked = String(input.locked);
       if (input.preventRecursion !== undefined) updates.preventRecursion = String(input.preventRecursion);
       if (input.excludeRecursion !== undefined) updates.excludeRecursion = String(input.excludeRecursion);
-      if (input.delayUntilRecursion !== undefined)
-        updates.delayUntilRecursion = String(input.delayUntilRecursion);
+      if (input.delayUntilRecursion !== undefined) updates.delayUntilRecursion = String(input.delayUntilRecursion);
       if (input.excludeFromVectorization !== undefined)
         updates.excludeFromVectorization = String(input.excludeFromVectorization);
       if (shouldClearEmbedding) updates.embedding = null;
 
       await db.update(lorebookEntries).set(updates).where(eq(lorebookEntries.id, id));
       return this.getEntry(id);
+    },
+
+    async bulkUpdateEntries(
+      lorebookId: string,
+      entryIds: string[],
+      changes: BulkUpdateLorebookEntriesInput["changes"],
+    ) {
+      const uniqueEntryIds = Array.from(new Set(entryIds));
+      const rows = await db
+        .select({ id: lorebookEntries.id })
+        .from(lorebookEntries)
+        .where(and(eq(lorebookEntries.lorebookId, lorebookId), inArray(lorebookEntries.id, uniqueEntryIds)));
+      if (rows.length !== uniqueEntryIds.length) {
+        throw new Error("One or more selected entries do not belong to this lorebook");
+      }
+
+      const updates: Record<string, unknown> = { updatedAt: now() };
+      for (const [field, value] of Object.entries(changes)) {
+        if (value !== undefined) updates[field] = String(value);
+      }
+      if (changes.excludeFromVectorization === true) updates.embedding = null;
+
+      await db
+        .update(lorebookEntries)
+        .set(updates)
+        .where(and(eq(lorebookEntries.lorebookId, lorebookId), inArray(lorebookEntries.id, uniqueEntryIds)));
+      return { updated: rows.length };
     },
 
     /** Update just the embedding vector for an entry. */

--- a/packages/shared/src/features/agents/illustrator/manifest.ts
+++ b/packages/shared/src/features/agents/illustrator/manifest.ts
@@ -37,7 +37,6 @@ export const illustratorAgentManifest = {
   category: "misc",
   defaultTools: [],
   defaultSettings: {
-    defaultPromptTemplateId: "background",
     defaultPromptTemplateName: "Illustration",
     defaultPromptTemplateDescription: "Polished single-scene illustration for important visual beats.",
     useAvatarReferences: false,

--- a/packages/shared/src/features/turn-games/uno/engine.ts
+++ b/packages/shared/src/features/turn-games/uno/engine.ts
@@ -6,14 +6,7 @@
 // narrates the engine-confirmed result; it never enforces rules or shuffles.
 // All randomness flows through the seeded RNG so deals replay identically.
 
-import type {
-  GameEvent,
-  ModelTurnView,
-  MoveResult,
-  Seat,
-  TerminalResult,
-  TurnGameEngine,
-} from "../engine.types.js";
+import type { GameEvent, ModelTurnView, MoveResult, Seat, TerminalResult, TurnGameEngine } from "../engine.types.js";
 import { buildStandardDeck, isWildValue } from "./deck.js";
 import { deterministicShuffle } from "./rng.js";
 import { UNO_TOOL_MANIFESTS } from "./tools.js";
@@ -397,11 +390,7 @@ function handlePlayDrawn(
   return resolvePlay(state, seatId, card, move, events);
 }
 
-function handleDraw(
-  state: UnoState,
-  seatId: string,
-  events: GameEvent[],
-): MoveResult<UnoState, UnoMove> {
+function handleDraw(state: UnoState, seatId: string, events: GameEvent[]): MoveResult<UnoState, UnoMove> {
   // Calling draw while a penalty is pending resolves the penalty.
   if (state.pendingDraw > 0) return handleDrawPenalty(state, seatId, events);
 
@@ -443,11 +432,7 @@ function handleDraw(
   return { ok: true, state, events };
 }
 
-function handlePass(
-  state: UnoState,
-  _seatId: string,
-  events: GameEvent[],
-): MoveResult<UnoState, UnoMove> {
+function handlePass(state: UnoState, _seatId: string, events: GameEvent[]): MoveResult<UnoState, UnoMove> {
   if (state.status !== "awaiting_post_draw") return fail("There's nothing to pass on — play or draw.");
   const drawn = state.drawnCardId ? state.hands[_seatId]?.find((c) => c.id === state.drawnCardId) : null;
   if (state.config.forcePlay && drawn && isNormallyPlayable(drawn, state)) {
@@ -461,11 +446,7 @@ function handlePass(
   return { ok: true, state, events };
 }
 
-function handleDrawPenalty(
-  state: UnoState,
-  seatId: string,
-  events: GameEvent[],
-): MoveResult<UnoState, UnoMove> {
+function handleDrawPenalty(state: UnoState, seatId: string, events: GameEvent[]): MoveResult<UnoState, UnoMove> {
   if (state.pendingDraw <= 0) return fail("There is no draw penalty to take.");
   const n = state.pendingDraw;
   drawN(state, seatId, n);
@@ -531,11 +512,7 @@ function handleCallOut(
   return { ok: true, state, events };
 }
 
-function handleDeclareUno(
-  state: UnoState,
-  seatId: string,
-  events: GameEvent[],
-): MoveResult<UnoState, UnoMove> {
+function handleDeclareUno(state: UnoState, seatId: string, events: GameEvent[]): MoveResult<UnoState, UnoMove> {
   if ((state.hands[seatId]?.length ?? 0) !== 1) return fail("You can only call UNO when you hold exactly one card.");
   state.mustCallUno[seatId] = false;
   events.push({ type: "uno_called", seatId, message: `${nameOf(state, seatId)} calls UNO!` });
@@ -556,20 +533,13 @@ function pushCatchMoves(state: UnoState, seatId: string, moves: UnoMove[]): void
 }
 
 /** Expand a playable card into directly-applicable moves (color variants for wilds, swap targets for 7s). */
-function expandPlay(
-  state: UnoState,
-  seatId: string,
-  card: UnoCard,
-  kind: "play" | "play_drawn",
-): UnoMove[] {
+function expandPlay(state: UnoState, seatId: string, card: UnoCard, kind: "play" | "play_drawn"): UnoMove[] {
   const out: UnoMove[] = [];
   const isWild = card.color === "wild";
   const willWin = (state.hands[seatId]?.length ?? 0) === 1;
   const needsSwap = state.config.sevenZero && card.value === "7" && !willWin;
   const colorVariants: Array<UnoColor | undefined> = isWild ? [...ALL_COLORS] : [undefined];
-  const swapTargets: Array<string | undefined> = needsSwap
-    ? state.seatOrder.filter((s) => s !== seatId)
-    : [undefined];
+  const swapTargets: Array<string | undefined> = needsSwap ? state.seatOrder.filter((s) => s !== seatId) : [undefined];
   for (const declaredColor of colorVariants) {
     for (const swapTargetSeatId of swapTargets) {
       if (kind === "play") {
@@ -689,8 +659,7 @@ function pickFallback(state: UnoState, seatId: string): UnoMove {
       moves.find((m) => m.type === "call_out") ??
       moves.find((m) => m.type === "declare_uno") ??
       moves.find((m) => m.type === "jump_in") ??
-      moves[0] ??
-      { type: "declare_uno" }
+      moves[0] ?? { type: "declare_uno" }
     );
   }
 
@@ -753,7 +722,8 @@ function buildBoardSummary(state: UnoState, seatId: string): string {
   lines.push(`Your hand: ${hand.length ? hand.map(cardLabel).join(", ") : "(empty)"}.`);
   if (state.status === "awaiting_post_draw" && state.drawnCardId) {
     const drawn = hand.find((c) => c.id === state.drawnCardId);
-    if (drawn) lines.push(`You just drew ${cardLabel(drawn)} — it's the only card you may play right now (or pass to keep it).`);
+    if (drawn)
+      lines.push(`You just drew ${cardLabel(drawn)} — it's the only card you may play right now (or pass to keep it).`);
   }
   const plays = recentPlayLines(state, 5);
   if (plays.length) lines.push("What just happened:", ...plays);
@@ -762,15 +732,32 @@ function buildBoardSummary(state: UnoState, seatId: string): string {
 
 function buildInstructions(state: UnoState, seatId: string): string {
   const parts: string[] = [];
+  const hand = state.hands[seatId] ?? [];
   if (state.status === "awaiting_post_draw") {
-    parts.push("You just drew (see 'You just drew …' above). Either play_card with that exact card or pass_turn to keep it.");
+    parts.push(
+      "You just drew (see 'You just drew …' above). Either play_card with that exact card or pass_turn to keep it.",
+    );
   } else if (state.pendingDraw > 0) {
-    parts.push("Resolve the draw penalty: draw_card to take it" + (state.config.stacking ? ", or stack a matching draw card with play_card." : "."));
+    parts.push(
+      "Resolve the draw penalty: draw_card to take it" +
+        (state.config.stacking ? ", or stack a matching draw card with play_card." : "."),
+    );
   } else {
     parts.push("Play a legal card with play_card, or draw_card if you cannot or choose not to play.");
   }
   if ((state.hands[seatId]?.length ?? 0) === 2) {
     parts.push("If this play leaves you with one card, set say_uno=true (or call_uno).");
+  }
+  if (hand.some((card) => card.color === "wild")) {
+    const counts = colorCounts(hand);
+    const heldColors = ALL_COLORS.filter((color) => counts[color] > 0)
+      .map((color) => `${cap(color)} ${counts[color]}`)
+      .join(", ");
+    parts.push(
+      heldColors
+        ? `If you play a Wild, choose declared_color from the colored cards left in your hand (${heldColors}); prefer your most-held color, and do not simply repeat the current ${cap(state.activeColor)} unless it is tied for strongest.`
+        : "If you play a Wild with no colored cards left, choose any declared_color.",
+    );
   }
   parts.push("Then narrate your move briefly, in character.");
   return parts.join(" ");
@@ -833,7 +820,9 @@ function buildParticipantSummary(state: UnoState, seatId: string): string {
   }
   const lastOwn = [...state.log]
     .reverse()
-    .find((e) => e.seatId === seatId && e.type !== "deal" && typeof e.message === "string" && e.message.trim().length > 0);
+    .find(
+      (e) => e.seatId === seatId && e.type !== "deal" && typeof e.message === "string" && e.message.trim().length > 0,
+    );
   if (lastOwn) lines.push(`Your most recent action: ${lastOwn.message}`);
   return lines.join("\n");
 }

--- a/packages/shared/src/features/turn-games/uno/engine.ts
+++ b/packages/shared/src/features/turn-games/uno/engine.ts
@@ -745,7 +745,7 @@ function buildInstructions(state: UnoState, seatId: string): string {
   } else {
     parts.push("Play a legal card with play_card, or draw_card if you cannot or choose not to play.");
   }
-  if ((state.hands[seatId]?.length ?? 0) === 2) {
+  if (hand.length === 2) {
     parts.push("If this play leaves you with one card, set say_uno=true (or call_uno).");
   }
   if (hand.some((card) => card.color === "wild")) {

--- a/packages/shared/src/features/turn-games/uno/tools.ts
+++ b/packages/shared/src/features/turn-games/uno/tools.ts
@@ -24,11 +24,23 @@ export const playCardToolManifest = {
   parameters: {
     type: "object",
     properties: {
-      color: { type: "string", description: "The card's color (use 'wild' for Wild / Wild Draw Four).", enum: COLOR_ENUM },
+      color: {
+        type: "string",
+        description: "The card's color (use 'wild' for Wild / Wild Draw Four).",
+        enum: COLOR_ENUM,
+      },
       value: { type: "string", description: "The card's value/face.", enum: VALUE_ENUM },
-      declared_color: { type: "string", description: "Required when playing a wild: the color you choose.", enum: DECLARED_COLOR_ENUM },
+      declared_color: {
+        type: "string",
+        description:
+          "Required when playing a wild: choose the color best represented among the colored cards remaining in your hand; do not default to the current color.",
+        enum: DECLARED_COLOR_ENUM,
+      },
       say_uno: { type: "boolean", description: "Set true when this play leaves you holding exactly one card." },
-      swap_target: { type: "string", description: "When playing a 7 under the 7-0 rule: the exact name of the player to swap hands with." },
+      swap_target: {
+        type: "string",
+        description: "When playing a 7 under the 7-0 rule: the exact name of the player to swap hands with.",
+      },
     },
     required: ["color", "value"],
   },

--- a/packages/shared/src/schemas/lorebook.schema.ts
+++ b/packages/shared/src/schemas/lorebook.schema.ts
@@ -135,11 +135,7 @@ export const createLorebookSchema = z
       .min(0)
       .max(LIMITS.LOREBOOK_VECTOR_QUERY_DEPTH_MAX)
       .default(LIMITS.LOREBOOK_VECTOR_QUERY_DEPTH_DEFAULT),
-    vectorScoreThreshold: z
-      .number()
-      .min(0)
-      .max(1)
-      .default(LIMITS.LOREBOOK_VECTOR_SCORE_THRESHOLD_DEFAULT),
+    vectorScoreThreshold: z.number().min(0).max(1).default(LIMITS.LOREBOOK_VECTOR_SCORE_THRESHOLD_DEFAULT),
     vectorMaxResults: z
       .number()
       .int()
@@ -168,12 +164,7 @@ export const updateLorebookSchema = z
     imagePath: z.string().nullable().optional(),
     scanDepth: z.number().int().min(0).optional(),
     tokenBudget: z.number().int().min(0).optional(),
-    entryLimit: z
-      .number()
-      .int()
-      .min(LIMITS.LOREBOOK_ENTRY_LIMIT_MIN)
-      .max(LIMITS.LOREBOOK_ENTRY_LIMIT_MAX)
-      .optional(),
+    entryLimit: z.number().int().min(LIMITS.LOREBOOK_ENTRY_LIMIT_MIN).max(LIMITS.LOREBOOK_ENTRY_LIMIT_MAX).optional(),
     recursiveScanning: z.boolean().optional(),
     maxRecursionDepth: z.number().int().min(1).max(10).optional(),
     excludeFromVectorization: z.boolean().optional(),
@@ -291,9 +282,31 @@ export const updateLorebookEntrySchema = z.object({
   excludeFromVectorization: z.boolean().optional(),
 });
 
+export const bulkUpdateLorebookEntriesSchema = z.object({
+  entryIds: z.array(z.string().min(1)).min(1).max(5000),
+  changes: z
+    .object({
+      enabled: z.boolean().optional(),
+      constant: z.boolean().optional(),
+      selective: z.boolean().optional(),
+      matchWholeWords: z.boolean().optional(),
+      caseSensitive: z.boolean().optional(),
+      useRegex: z.boolean().optional(),
+      preventRecursion: z.boolean().optional(),
+      excludeRecursion: z.boolean().optional(),
+      delayUntilRecursion: z.boolean().optional(),
+      excludeFromVectorization: z.boolean().optional(),
+      locked: z.boolean().optional(),
+    })
+    .refine((changes) => Object.values(changes).some((value) => value !== undefined), {
+      message: "Choose at least one setting to update",
+    }),
+});
+
 export type CreateLorebookInput = z.input<typeof createLorebookSchema>;
 export type UpdateLorebookInput = z.infer<typeof updateLorebookSchema>;
 export type CreateLorebookEntryInput = z.input<typeof createLorebookEntrySchema>;
 export type UpdateLorebookEntryInput = z.infer<typeof updateLorebookEntrySchema>;
+export type BulkUpdateLorebookEntriesInput = z.infer<typeof bulkUpdateLorebookEntriesSchema>;
 export type CreateLorebookFolderInput = z.input<typeof createLorebookFolderSchema>;
 export type UpdateLorebookFolderInput = z.infer<typeof updateLorebookFolderSchema>;

--- a/packages/shared/src/schemas/lorebook.schema.ts
+++ b/packages/shared/src/schemas/lorebook.schema.ts
@@ -282,25 +282,27 @@ export const updateLorebookEntrySchema = z.object({
   excludeFromVectorization: z.boolean().optional(),
 });
 
+const bulkUpdateLorebookEntryChangesSchema = updateLorebookEntrySchema
+  .pick({
+    enabled: true,
+    constant: true,
+    selective: true,
+    matchWholeWords: true,
+    caseSensitive: true,
+    useRegex: true,
+    preventRecursion: true,
+    excludeRecursion: true,
+    delayUntilRecursion: true,
+    excludeFromVectorization: true,
+    locked: true,
+  })
+  .refine((changes) => Object.values(changes).some((value) => value !== undefined), {
+    message: "Choose at least one setting to update",
+  });
+
 export const bulkUpdateLorebookEntriesSchema = z.object({
   entryIds: z.array(z.string().min(1)).min(1).max(5000),
-  changes: z
-    .object({
-      enabled: z.boolean().optional(),
-      constant: z.boolean().optional(),
-      selective: z.boolean().optional(),
-      matchWholeWords: z.boolean().optional(),
-      caseSensitive: z.boolean().optional(),
-      useRegex: z.boolean().optional(),
-      preventRecursion: z.boolean().optional(),
-      excludeRecursion: z.boolean().optional(),
-      delayUntilRecursion: z.boolean().optional(),
-      excludeFromVectorization: z.boolean().optional(),
-      locked: z.boolean().optional(),
-    })
-    .refine((changes) => Object.values(changes).some((value) => value !== undefined), {
-      message: "Choose at least one setting to update",
-    }),
+  changes: bulkUpdateLorebookEntryChangesSchema,
 });
 
 export type CreateLorebookInput = z.input<typeof createLorebookSchema>;

--- a/packages/shared/src/utils/speaker-segments.ts
+++ b/packages/shared/src/utils/speaker-segments.ts
@@ -19,9 +19,7 @@ const LEADING_CONVERSATION_TIMESTAMPS_RE = new RegExp(
 );
 
 function decodeSpeakerTagAttributeEntities(value: string): string {
-  return value
-    .replace(/&quot;|&#0*34;|&#x0*22;/gi, '"')
-    .replace(/&apos;|&#0*39;|&#x0*27;/gi, "'");
+  return value.replace(/&quot;|&#0*34;|&#x0*22;/gi, '"').replace(/&apos;|&#0*39;|&#x0*27;/gi, "'");
 }
 
 export function decodeEncodedSpeakerTags(value: string): string {
@@ -117,7 +115,11 @@ export function parseSpeakerTags(content: string, knownNames: Set<string>): Spea
  * tags are present). Returns null when no known name prefixes any line.
  * `knownNames` holds normalizeTextForMatch()-normalized character names.
  */
-export function parseNamePrefixFormat(content: string, knownNames: Set<string>): SpeakerSegment[] | null {
+export function parseNamePrefixFormat(
+  content: string,
+  knownNames: Set<string>,
+  leadingSpeaker?: string | null,
+): SpeakerSegment[] | null {
   if (!knownNames.size) return null;
   const lines = content.split("\n");
   // Start offset of each line in `content` (lines are separated by exactly "\n").
@@ -166,7 +168,12 @@ export function parseNamePrefixFormat(content: string, knownNames: Set<string>):
   }
   flush();
   if (!found) return null;
-  return segments.filter((s) => s.text.trim());
+  const visibleSegments = segments.filter((s) => s.text.trim());
+  const normalizedLeadingSpeaker = leadingSpeaker ? normalizeTextForMatch(leadingSpeaker) : "";
+  if (visibleSegments[0]?.speaker === null && normalizedLeadingSpeaker && knownNames.has(normalizedLeadingSpeaker)) {
+    visibleSegments[0] = { ...visibleSegments[0], speaker: leadingSpeaker!.trim() };
+  }
+  return visibleSegments;
 }
 
 /** Merge consecutive segments by the same speaker into one grouped segment. */
@@ -197,10 +204,14 @@ export function groupConsecutiveSegments(segments: SpeakerSegment[]): GroupedSeg
  * canonical definition of "segment index N" — both the client's grouped layout
  * and the server's reaction attribution must derive indexes through it.
  */
-export function parseGroupedSpeakerSegments(content: string, knownNames: Set<string>): GroupedSegment[] | null {
+export function parseGroupedSpeakerSegments(
+  content: string,
+  knownNames: Set<string>,
+  leadingSpeaker?: string | null,
+): GroupedSegment[] | null {
   const speakerSegs = parseSpeakerTags(content, knownNames);
   if (speakerSegs) return groupConsecutiveSegments(speakerSegs);
-  const nameSegs = parseNamePrefixFormat(content, knownNames);
+  const nameSegs = parseNamePrefixFormat(content, knownNames, leadingSpeaker);
   if (nameSegs) return groupConsecutiveSegments(nameSegs);
   return null;
 }

--- a/scripts/check-windows-installer-layout.mjs
+++ b/scripts/check-windows-installer-layout.mjs
@@ -33,6 +33,28 @@ try {
 
   const failures = unsafePatterns.filter(({ pattern }) => pattern.test(code));
 
+  const uninstallStart = code.indexOf('Section "Uninstall"');
+  const packageRemoval = code.indexOf('RMDir /r "$INSTDIR\\packages"', uninstallStart);
+  const canonicalDataDecision = code.indexOf("$INSTDIR\\packages\\server\\data", uninstallStart);
+  if (uninstallStart < 0 || packageRemoval < 0 || canonicalDataDecision < 0 || canonicalDataDecision > packageRemoval) {
+    failures.push({
+      message:
+        'The uninstaller must decide how to preserve "$INSTDIR\\packages\\server\\data" before removing packages.',
+    });
+  }
+  if (!code.includes('Rename "$INSTDIR\\packages\\server\\data" "$INSTDIR\\.__marinara-preserved-data"')) {
+    failures.push({ message: "The uninstaller must move current-layout user data out of packages before cleanup." });
+  }
+  if (!code.includes('Rename "$INSTDIR\\.__marinara-preserved-data" "$INSTDIR\\packages\\server\\data"')) {
+    failures.push({ message: "The uninstaller must restore preserved current-layout user data after cleanup." });
+  }
+  if (/RMDir\s+\/r\s+"\$INSTDIR\\installer"/i.test(code)) {
+    failures.push({ message: 'The uninstaller still targets the stale "$INSTDIR\\installer" directory.' });
+  }
+  if (!/RMDir\s+\/r\s+"\$INSTDIR\\win"/i.test(code)) {
+    failures.push({ message: 'The uninstaller must remove the current "$INSTDIR\\win" directory.' });
+  }
+
   const unsafeVariableAssignments = [
     {
       pattern: /\bStrCpy\s+(\$[A-Za-z0-9_]+)\s+"?\$INSTDIR\\repo-temp"?\b/i,

--- a/scripts/check-windows-installer-layout.mjs
+++ b/scripts/check-windows-installer-layout.mjs
@@ -48,6 +48,16 @@ try {
   if (!code.includes('Rename "$INSTDIR\\.__marinara-preserved-data" "$INSTDIR\\packages\\server\\data"')) {
     failures.push({ message: "The uninstaller must restore preserved current-layout user data after cleanup." });
   }
+  const interruptedDataDecision = code.indexOf(
+    '${ElseIf} ${FileExists} "$INSTDIR\\.__marinara-preserved-data\\*.*"',
+    uninstallStart,
+  );
+  if (interruptedDataDecision < 0 || interruptedDataDecision > packageRemoval) {
+    failures.push({ message: "The uninstaller must detect data staged by an interrupted previous uninstall." });
+  }
+  if (!code.includes('RMDir /r "$INSTDIR\\.__marinara-preserved-data"')) {
+    failures.push({ message: "The delete-data path must remove data staged by an interrupted previous uninstall." });
+  }
   if (/RMDir\s+\/r\s+"\$INSTDIR\\installer"/i.test(code)) {
     failures.push({ message: 'The uninstaller still targets the stale "$INSTDIR\\installer" directory.' });
   }

--- a/scripts/regressions/emoji-catalog.regression.ts
+++ b/scripts/regressions/emoji-catalog.regression.ts
@@ -1,8 +1,9 @@
 import assert from "node:assert/strict";
+import { EMOJI_CATEGORIES, EMOJI_SEARCH_NAMES } from "../../packages/client/src/lib/emoji-catalog.generated.js";
 import {
-  EMOJI_CATEGORIES,
-  EMOJI_SEARCH_NAMES,
-} from "../../packages/client/src/lib/emoji-catalog.generated.js";
+  resolveStandardEmojiShortcode,
+  searchStandardEmojiShortcodes,
+} from "../../packages/client/src/lib/emoji-shortcodes.js";
 
 const allEmoji = EMOJI_CATEGORIES.flatMap((category) => [...category.emojis]);
 assert.ok(allEmoji.length >= 1_900, `Expected the full base emoji catalog, received ${allEmoji.length}`);
@@ -12,6 +13,15 @@ assert.ok(EMOJI_CATEGORIES.some((category) => category.label === "Activities"));
 assert.ok(EMOJI_CATEGORIES.some((category) => category.label === "Flags"));
 assert.ok(EMOJI_CATEGORIES.find((category) => category.label === "Objects")?.emojis.includes("🧪"));
 assert.match(EMOJI_SEARCH_NAMES["🧪"] ?? "", /test tube/u);
-assert.equal(allEmoji.some((emoji) => /[\u{1F3FB}-\u{1F3FF}]/u.test(emoji)), false);
+assert.equal(
+  allEmoji.some((emoji) => /[\u{1F3FB}-\u{1F3FF}]/u.test(emoji)),
+  false,
+);
+assert.equal(resolveStandardEmojiShortcode("crying"), "😢");
+assert.equal(resolveStandardEmojiShortcode("test_tube"), "🧪");
+assert.equal(
+  searchStandardEmojiShortcodes("cry").some((entry) => entry.name === "crying"),
+  true,
+);
 
 process.stdout.write("Emoji catalog regression passed.\n");

--- a/scripts/regressions/emoji-catalog.regression.ts
+++ b/scripts/regressions/emoji-catalog.regression.ts
@@ -19,6 +19,7 @@ assert.equal(
 );
 assert.equal(resolveStandardEmojiShortcode("crying"), "😢");
 assert.equal(resolveStandardEmojiShortcode("test_tube"), "🧪");
+assert.equal(resolveStandardEmojiShortcode("TEST-TUBE"), "🧪");
 assert.equal(
   searchStandardEmojiShortcodes("cry").some((entry) => entry.name === "crying"),
   true,

--- a/scripts/regressions/open-issues.regression.ts
+++ b/scripts/regressions/open-issues.regression.ts
@@ -1,9 +1,13 @@
 import assert from "node:assert/strict";
 import type { Chat, Message } from "../../packages/shared/src/types/chat.js";
-import { stripLeadingMessageTimestamps } from "../../packages/shared/src/utils/speaker-segments.js";
+import {
+  parseGroupedSpeakerSegments,
+  stripLeadingMessageTimestamps,
+} from "../../packages/shared/src/utils/speaker-segments.js";
 import type { Lorebook } from "../../packages/shared/src/types/lorebook.js";
 import {
   createLorebookSchema,
+  bulkUpdateLorebookEntriesSchema,
   normalizeLorebookCategory,
   updateLorebookSchema,
 } from "../../packages/shared/src/schemas/lorebook.schema.js";
@@ -37,6 +41,12 @@ import {
   getTemperatureGaugeDisplay,
   parsePureTemperatureValue,
 } from "../../packages/client/src/features/tracker-panel/lib/world-state-display.js";
+import {
+  resolveStandardEmojiShortcode,
+  searchStandardEmojiShortcodes,
+} from "../../packages/client/src/lib/emoji-shortcodes.js";
+import { unoEngine } from "../../packages/shared/src/features/turn-games/uno/engine.js";
+import { DEFAULT_UNO_CONFIG, type UnoState } from "../../packages/shared/src/features/turn-games/uno/types.js";
 
 assert.equal(resolveInitialGameGmConnectionId(undefined, "chat-connection"), "chat-connection");
 assert.equal(resolveInitialGameGmConnectionId("explicit-connection", "chat-connection"), "explicit-connection");
@@ -49,10 +59,7 @@ assert.equal(
   ),
   "Handle must contain at most 40 characters.",
 );
-assert.equal(
-  getApiErrorMessage({ code: "USER_NOT_FOUND", requestId: "abc-123" }, "Request failed"),
-  "Request failed",
-);
+assert.equal(getApiErrorMessage({ code: "USER_NOT_FOUND", requestId: "abc-123" }, "Request failed"), "Request failed");
 
 assert.equal(stripLeadingMessageTimestamps("[11.07 15:53] Character: Hello!"), "Character: Hello!");
 assert.equal(stripLeadingMessageTimestamps("[11.07.2026 15:53] Character: Hello!"), "Character: Hello!");
@@ -72,6 +79,63 @@ assert.equal(
   stripLeadingMessageTimestamps("We meet at [11.07 15:53] by the station."),
   "We meet at [11.07 15:53] by the station.",
 );
+
+const partiallyPrefixedConversationReply = "lol you're such a rebel!!\nPaige: Are you powered by pure caffeine?";
+const parsedWithoutAuthor = parseGroupedSpeakerSegments(partiallyPrefixedConversationReply, new Set(["paige"]));
+assert.equal(parsedWithoutAuthor?.[0]?.speaker, null);
+const parsedWithAuthor = parseGroupedSpeakerSegments(partiallyPrefixedConversationReply, new Set(["paige"]), "Paige");
+assert.equal(parsedWithAuthor?.length, 1);
+assert.equal(parsedWithAuthor?.[0]?.speaker, "Paige");
+assert.deepEqual(parsedWithAuthor?.[0]?.lines, ["lol you're such a rebel!!", "Are you powered by pure caffeine?"]);
+
+assert.equal(resolveStandardEmojiShortcode("crying"), "😢");
+assert.equal(resolveStandardEmojiShortcode("test_tube"), "🧪");
+assert.equal(
+  searchStandardEmojiShortcodes("cry", 5).some((entry) => entry.name === "crying"),
+  true,
+);
+
+assert.equal(
+  bulkUpdateLorebookEntriesSchema.safeParse({
+    entryIds: ["entry-1", "entry-2"],
+    changes: { preventRecursion: false, caseSensitive: true },
+  }).success,
+  true,
+);
+assert.equal(bulkUpdateLorebookEntriesSchema.safeParse({ entryIds: ["entry-1"], changes: {} }).success, false);
+
+const unoColorStrategyState: UnoState = {
+  config: { ...DEFAULT_UNO_CONFIG },
+  seatOrder: ["bot", "user"],
+  seatNames: { bot: "Bot", user: "User" },
+  drawPile: [{ id: "yellow-1", color: "yellow", value: "1" }],
+  discardPile: [{ id: "red-5", color: "red", value: "5" }],
+  activeColor: "red",
+  hands: {
+    bot: [
+      { id: "wild", color: "wild", value: "wild" },
+      { id: "blue-1", color: "blue", value: "1" },
+      { id: "blue-2", color: "blue", value: "2" },
+      { id: "red-2", color: "red", value: "2" },
+    ],
+    user: [{ id: "green-1", color: "green", value: "1" }],
+  },
+  turnIndex: 0,
+  direction: 1,
+  pendingDraw: 0,
+  pendingDrawType: null,
+  mustCallUno: { bot: false, user: false },
+  drawnCardId: null,
+  status: "awaiting_move",
+  seed: 1,
+  rngCursor: 1,
+  turnCount: 0,
+  lastAction: null,
+  log: [],
+};
+const unoInstructions = unoEngine.describeForModel(unoColorStrategyState, "bot").instructions;
+assert.match(unoInstructions, /Blue 2/u);
+assert.match(unoInstructions, /do not simply repeat the current Red/u);
 
 assert.equal(parsePureTemperatureValue("15°C"), 15);
 assert.equal(parsePureTemperatureValue("59 Fahrenheit"), 15);

--- a/scripts/regressions/open-issues.regression.ts
+++ b/scripts/regressions/open-issues.regression.ts
@@ -31,6 +31,7 @@ import {
   stripConversationResponseEnvelope,
 } from "../../packages/server/src/services/conversation/transcript-sanitize.js";
 import { resolveInitialGameGmConnectionId } from "../../packages/server/src/services/game/initial-game-setup.js";
+import { annotateContentWithReactions } from "../../packages/server/src/routes/generate/conversation-custom-assets.js";
 import {
   buildGameSessionReplayTurns,
   findReplayStoryboardKeyframe,
@@ -87,6 +88,15 @@ const parsedWithAuthor = parseGroupedSpeakerSegments(partiallyPrefixedConversati
 assert.equal(parsedWithAuthor?.length, 1);
 assert.equal(parsedWithAuthor?.[0]?.speaker, "Paige");
 assert.deepEqual(parsedWithAuthor?.[0]?.lines, ["lol you're such a rebel!!", "Are you powered by pure caffeine?"]);
+const annotatedPartiallyPrefixedReply = annotateContentWithReactions(
+  partiallyPrefixedConversationReply,
+  partiallyPrefixedConversationReply,
+  [{ emoji: "🔥", by: ["user"], segment: 0, segmentSpeaker: "Paige" }],
+  new Map([["paige", "Paige"]]),
+  (reactorId) => (reactorId === "user" ? "Mari" : reactorId),
+  "Paige",
+);
+assert.equal(annotatedPartiallyPrefixedReply, `${partiallyPrefixedConversationReply}\n[Mari reacted with 🔥]`);
 
 assert.equal(resolveStandardEmojiShortcode("crying"), "😢");
 assert.equal(resolveStandardEmojiShortcode("test_tube"), "🧪");

--- a/scripts/regressions/prompt.regression.ts
+++ b/scripts/regressions/prompt.regression.ts
@@ -1069,28 +1069,46 @@ const cases: RegressionCase[] = [
     },
   },
   {
-    name: "Illustrator defaults to Background without overriding an explicit mode",
+    name: "Illustrator defaults to Illustration and preserves explicit Background selections",
     run() {
       const executorSource = readFileSync(
         new URL("../../packages/server/src/services/agents/agent-executor.ts", import.meta.url),
         "utf8",
       );
       const settings = getDefaultBuiltInAgentSettings("illustrator");
-      const backgroundPrompt = resolveAgentPromptTemplate({
+      const illustrationPrompt = resolveAgentPromptTemplate({
         agentType: "illustrator",
         promptTemplate: "BASE ILLUSTRATION PROMPT",
         settings,
       });
-      const explicitIllustrationPrompt = resolveAgentPromptTemplate({
+      const explicitBackgroundPrompt = resolveAgentPromptTemplate({
         agentType: "illustrator",
         promptTemplate: "BASE ILLUSTRATION PROMPT",
         settings,
-        selectedPromptTemplateId: DEFAULT_AGENT_PROMPT_TEMPLATE_ID,
+        selectedPromptTemplateId: "background",
       });
 
-      assert.equal(resolveDefaultAgentPromptTemplateId(settings), "background");
-      assert.match(backgroundPrompt, /background-only prompt/);
-      assert.equal(explicitIllustrationPrompt, "BASE ILLUSTRATION PROMPT");
+      assert.equal(resolveDefaultAgentPromptTemplateId(settings), DEFAULT_AGENT_PROMPT_TEMPLATE_ID);
+      assert.equal(illustrationPrompt, "BASE ILLUSTRATION PROMPT");
+      assert.match(explicitBackgroundPrompt, /background-only prompt/);
+
+      const migrationUpdate = buildLegacyDefaultAgentConfigUpdate({
+        id: "builtin:illustrator",
+        type: "illustrator",
+        name: "Illustrator",
+        description: "Generates image prompts for key scenes (requires image generation API).",
+        phase: "post_processing",
+        enabled: "false",
+        connectionId: null,
+        imagePath: null,
+        promptTemplate: DEFAULT_AGENT_PROMPTS.illustrator,
+        settings: JSON.stringify({ defaultPromptTemplateId: "background" }),
+        createdAt: "2026-01-01T00:00:00.000Z",
+        updatedAt: "2026-01-01T00:00:00.000Z",
+      });
+      const migratedSettings = JSON.parse(String(migrationUpdate.settings)) as Record<string, unknown>;
+      assert.equal(migratedSettings.defaultPromptTemplateId, DEFAULT_AGENT_PROMPT_TEMPLATE_ID);
+      assert.equal(migratedSettings.illustratorDefaultPromptTemplateMigrationVersion, 2);
       assert.match(executorSource, /Follow the selected Illustrator prompt mode exactly/);
       assert.match(executorSource, /Background stays an environment-only plate/);
       assert.doesNotMatch(executorSource, /not a selfie, comic page, manga panel, or background-only plate/);

--- a/scripts/regressions/prompt.regression.ts
+++ b/scripts/regressions/prompt.regression.ts
@@ -511,10 +511,7 @@ const cases: RegressionCase[] = [
     name: "TTS dialogue extraction ignores HTML and CSS attributes",
     run() {
       const htmlCard = `<div style="max-width:340px;font-family:Georgia,'Times New Roman',serif;color:#3a2f1e;"><div class="label">read a hundred times</div><div>Your name is <span style="font-weight:bold">Maukie</span>.</div></div>`;
-      const utterances = extractDialogueUtterances(
-        `${htmlCard}\nDottore said, "Stay behind me."`,
-        "Dottore",
-      );
+      const utterances = extractDialogueUtterances(`${htmlCard}\nDottore said, "Stay behind me."`, "Dottore");
 
       assert.deepEqual(utterances, [{ text: "Stay behind me.", speaker: "Dottore" }]);
       const cleaned = cleanTTSInputText(`<style>.note { color: red; }</style>${htmlCard}`);
@@ -524,10 +521,7 @@ const cases: RegressionCase[] = [
       assert.match(cleaned, /Your name is Maukie\./);
 
       assert.deepEqual(
-        extractDialogueUtterances(
-          '<div class="frame"></div><speaker="Dottore">"Do not move."</speaker>',
-          "Narrator",
-        ),
+        extractDialogueUtterances('<div class="frame"></div><speaker="Dottore">"Do not move."</speaker>', "Narrator"),
         [{ text: "Do not move.", speaker: "Dottore" }],
       );
     },
@@ -840,7 +834,10 @@ const cases: RegressionCase[] = [
       const providerMessage = "Provider concurrency limit exceeded for this account";
       assert.match(formatGenerationParameterError(providerMessage), /Provider message: Provider concurrency limit/);
       assert.match(formatGenerationParameterError("Too many parallel requests"), /concurrency limit was reached/);
-      assert.match(formatGenerationParameterError("Simultaneous generations limit reached"), /concurrency limit was reached/);
+      assert.match(
+        formatGenerationParameterError("Simultaneous generations limit reached"),
+        /concurrency limit was reached/,
+      );
       assert.equal(
         formatAgentFailuresToast([
           toAgentFailure({ agentType: "illustrator", agentName: "Illustrator", error: providerMessage }),
@@ -922,10 +919,7 @@ const cases: RegressionCase[] = [
         gameSetupWizardSource,
         /gamePresentation === "anime"\s*\? GAME_STORYBOARD_COMIC_ANIMATION_PROMPT_TEMPLATE_ID/,
       );
-      assert.match(
-        gameSetupWizardSource,
-        /gamePresentation === "anime"\s*\? COMIC_PAGE_GAME_VIDEO_PROMPT_TEMPLATE_ID/,
-      );
+      assert.match(gameSetupWizardSource, /gamePresentation === "anime"\s*\? COMIC_PAGE_GAME_VIDEO_PROMPT_TEMPLATE_ID/);
       assert.match(gameSetupWizardSource, /trimmedGameSystemPrompt !== effectiveGameSystemPrompt\.trim\(\)/);
       assert.match(gameSetupWizardSource, /Reset to selected/);
     },
@@ -1002,16 +996,16 @@ const cases: RegressionCase[] = [
       assert.match(animationPreset?.promptTemplate ?? "", /third panel is allowed in a 6-7 second clip only/);
       assert.match(animationPreset?.promptTemplate ?? "", /2-3 panels for 8-10 seconds/);
       assert.match(animationPreset?.promptTemplate ?? "", /Never show a consequence before its cause/);
-      assert.match(animationPreset?.promptTemplate ?? "", /Omit speech bubbles, captions, and SFX lettering by default/);
+      assert.match(
+        animationPreset?.promptTemplate ?? "",
+        /Omit speech bubbles, captions, and SFX lettering by default/,
+      );
       assert.match(animationPreset?.promptTemplate ?? "", /Reserve the final 0.4-0.7 seconds/);
       assert.match(animationPreset?.promptTemplate ?? "", /Do not ask the video model to animate every panel at once/);
       assert.doesNotMatch(animationPreset?.promptTemplate ?? "", /2-6 panels per illustration/);
       assert.match(COMIC_PAGE_GAME_VIDEO_PROMPT_TEMPLATE, /no more than 0.35 seconds/);
       assert.match(COMIC_PAGE_GAME_VIDEO_PROMPT_TEMPLATE, /reveal a later consequence before its cause/);
-      assert.match(
-        drawerSource,
-        /onAddTemplate\(GAME_STORYBOARD_COMIC_ANIMATION_PROMPT_TEMPLATE_ID\)/,
-      );
+      assert.match(drawerSource, /onAddTemplate\(GAME_STORYBOARD_COMIC_ANIMATION_PROMPT_TEMPLATE_ID\)/);
       assert.match(drawerSource, /Add Comic Animation Copy/);
       assert.match(drawerSource, /onAddTemplate\(COMIC_PAGE_GAME_VIDEO_PROMPT_TEMPLATE_ID\)/);
       assert.match(drawerSource, /Add Comic Video Copy/);
@@ -1023,10 +1017,7 @@ const cases: RegressionCase[] = [
       assert.match(gameSurfaceSource, /storyboardViewerPlayingVideoId === activeStoryboardKeyframe\.video\.id/);
       assert.match(gameSurfaceSource, /video\.playbackRate = 1/);
       assert.match(gameSurfaceSource, /setStoryboardViewerMuted\(false\)/);
-      assert.match(
-        gameSurfaceSource,
-        /setStoryboardViewerPlayingVideoId\(activeStoryboardKeyframe\.video\.id\)/,
-      );
+      assert.match(gameSurfaceSource, /setStoryboardViewerPlayingVideoId\(activeStoryboardKeyframe\.video\.id\)/);
       assert.match(backgroundViewerSource, /onEnded=\{\(\) =>/);
       assert.doesNotMatch(backgroundViewerSource, /\bloop\b/);
     },
@@ -2225,7 +2216,7 @@ Use HTML sparingly and diegetically. Do not replace normal prose/dialogue unless
     },
   },
   {
-    name: "semantic lorebook scan can activate keyless vector entries",
+    name: "semantic lorebook scan activates vector matches even when entries have primary keys",
     run() {
       const entry = {
         id: "entry-semantic",
@@ -2233,7 +2224,7 @@ Use HTML sparingly and diegetically. Do not replace normal prose/dialogue unless
         enabled: true,
         constant: false,
         selective: false,
-        keys: [],
+        keys: ["keyword that is absent"],
         secondaryKeys: [],
         selectiveLogic: "and",
         useRegex: false,
@@ -2274,6 +2265,16 @@ Use HTML sparingly and diegetically. Do not replace normal prose/dialogue unless
       assert.equal(activated.length, 1);
       assert.equal(activated[0]?.entry.id, "entry-semantic");
       assert.match(activated[0]?.matchedKeys[0] ?? "", /^\[semantic:/);
+
+      const belowThreshold = scanForActivatedEntries(
+        [{ role: "user", content: "nearby query" }],
+        [{ ...entry, id: "entry-below-threshold", keys: [], embedding: [0, 1] } as any],
+        {
+          chatEmbedding: [1, 0],
+          semanticThresholdByLorebookId: new Map([["book-semantic", 0.9]]),
+        },
+      );
+      assert.equal(belowThreshold.length, 0);
     },
   },
 ];

--- a/win/installer/installer.nsi
+++ b/win/installer/installer.nsi
@@ -1,6 +1,6 @@
 ; ──────────────────────────────────────────────
 ; Marinara Engine — Windows Installer
-; Cross-compiled from macOS via NSIS (makensis)
+; Built in CI via NSIS (makensis)
 ; ──────────────────────────────────────────────
 
 !include "MUI2.nsh"
@@ -810,6 +810,43 @@ SectionEnd
 Section "Uninstall"
   SetDetailsPrint both
 
+  ; User data lives inside packages/server/data in current installs. Decide
+  ; whether to preserve it BEFORE removing any application directories.
+  ; Older installs used $INSTDIR\data, so keep supporting that location too.
+  StrCpy $0 "delete"
+  ${If} ${FileExists} "$INSTDIR\packages\server\data\*.*"
+    Goto un_confirmData
+  ${ElseIf} ${FileExists} "$INSTDIR\data\*.*"
+    Goto un_confirmData
+  ${Else}
+    Goto un_removeApplication
+  ${EndIf}
+
+  un_confirmData:
+    MessageBox MB_YESNO|MB_ICONQUESTION "\
+${APP_NAME} stores your chats, characters, personas, and other user data inside its installation folder.$\r$\n$\r$\n\
+Would you like to delete your data too?$\r$\n$\r$\n\
+Choose No to preserve it for a future reinstall." IDYES un_removeApplication IDNO un_preserveData
+
+  un_preserveData:
+    StrCpy $0 "keep"
+    ${If} ${FileExists} "$INSTDIR\packages\server\data\*.*"
+      ${If} ${FileExists} "$INSTDIR\.__marinara-preserved-data\*.*"
+        MessageBox MB_OK|MB_ICONSTOP "Uninstall stopped because the temporary preservation folder already exists:$\r$\n$INSTDIR\.__marinara-preserved-data$\r$\n$\r$\nMove or rename that folder, then run the uninstaller again. No application files were removed."
+        Abort
+      ${EndIf}
+      ClearErrors
+      Rename "$INSTDIR\packages\server\data" "$INSTDIR\.__marinara-preserved-data"
+      IfErrors un_preserveFailed un_removeApplication
+    ${EndIf}
+    Goto un_removeApplication
+
+  un_preserveFailed:
+    MessageBox MB_OK|MB_ICONSTOP "Uninstall stopped because your user data could not be moved to a safe temporary location. No application files were removed."
+    Abort
+
+  un_removeApplication:
+
   DetailPrint "Removing desktop shortcut..."
   Delete "$DESKTOP\${APP_NAME}.lnk"
 
@@ -827,7 +864,7 @@ Section "Uninstall"
   RMDir /r "$INSTDIR\packages"
   RMDir /r "$INSTDIR\android"
   RMDir /r "$INSTDIR\docs"
-  RMDir /r "$INSTDIR\installer"
+  RMDir /r "$INSTDIR\win"
   RMDir /r "$INSTDIR\.git"
   Delete "$INSTDIR\*.json"
   Delete "$INSTDIR\*.yaml"
@@ -842,24 +879,34 @@ Section "Uninstall"
   Delete "$INSTDIR\Dockerfile"
   Delete "$INSTDIR\uninstall.exe"
 
-  ; Keep the data/ directory (user chats, characters, etc.)
-  ; Show a message about it
-  ${If} ${FileExists} "$INSTDIR\data\*.*"
-    MessageBox MB_YESNO|MB_ICONQUESTION "\
-${APP_NAME} has been uninstalled.$\r$\n$\r$\n\
-Your data (chats, characters, personas, etc.) is still in:$\r$\n\
-$INSTDIR\data$\r$\n$\r$\n\
-Would you like to delete your data too?" IDYES deleteData IDNO keepData
-    deleteData:
-      RMDir /r "$INSTDIR\data"
-      RMDir /r "$INSTDIR"
-      Goto doneUninstall
-    keepData:
-      DetailPrint "User data preserved in $INSTDIR\data"
-      Goto doneUninstall
+  ${If} $0 == "keep"
+    ; Restore current-layout data after packages/ has been removed. If restore
+    ; fails, the data remains intact in the explicitly reported safe folder.
+    ${If} ${FileExists} "$INSTDIR\.__marinara-preserved-data\*.*"
+      CreateDirectory "$INSTDIR\packages\server"
+      ClearErrors
+      Rename "$INSTDIR\.__marinara-preserved-data" "$INSTDIR\packages\server\data"
+      IfErrors un_restoreFailed un_dataPreserved
+    ${EndIf}
+    Goto un_dataPreserved
   ${Else}
-    RMDir /r "$INSTDIR"
+    RMDir /r "$INSTDIR\data"
+    RMDir "$INSTDIR"
   ${EndIf}
+
+  Goto doneUninstall
+
+  un_restoreFailed:
+    MessageBox MB_OK|MB_ICONEXCLAMATION "${APP_NAME} was removed, but your preserved data could not be restored to its usual location. It remains safe in:$\r$\n$INSTDIR\.__marinara-preserved-data"
+    Goto doneUninstall
+
+  un_dataPreserved:
+    ${If} ${FileExists} "$INSTDIR\packages\server\data\*.*"
+      DetailPrint "User data preserved in $INSTDIR\packages\server\data"
+    ${EndIf}
+    ${If} ${FileExists} "$INSTDIR\data\*.*"
+      DetailPrint "Legacy user data preserved in $INSTDIR\data"
+    ${EndIf}
 
   doneUninstall:
   DetailPrint "Uninstallation complete."

--- a/win/installer/installer.nsi
+++ b/win/installer/installer.nsi
@@ -818,6 +818,9 @@ Section "Uninstall"
     Goto un_confirmData
   ${ElseIf} ${FileExists} "$INSTDIR\data\*.*"
     Goto un_confirmData
+  ${ElseIf} ${FileExists} "$INSTDIR\.__marinara-preserved-data\*.*"
+    ; Recover data left staged by an interrupted previous uninstall.
+    Goto un_confirmData
   ${Else}
     Goto un_removeApplication
   ${EndIf}
@@ -891,6 +894,7 @@ Choose No to preserve it for a future reinstall." IDYES un_removeApplication IDN
     Goto un_dataPreserved
   ${Else}
     RMDir /r "$INSTDIR\data"
+    RMDir /r "$INSTDIR\.__marinara-preserved-data"
     RMDir "$INSTDIR"
   ${EndIf}
 


### PR DESCRIPTION
## Why

This PR resolves the complete open issue queue identified for this pass: a Windows uninstaller data-loss risk, unreachable semantic Lorebook matching for keyed entries, weak UNO Wild color guidance, missing Lorebook batch editing, incorrect Conversation speaker grouping, missing standard emoji shortcodes/autocomplete, and Illustrator incorrectly defaulting existing roleplay chats to the Background prompt.

Closes #3484
Closes #3511
Closes #3512
Closes #3513
Closes #3514
Closes #3515
Closes #3517

## What changed

- preserves current and legacy user-data layouts before Windows application cleanup, restores kept data, handles interrupted preserved-data folders, and validates plus compiles the NSIS source
- allows vector similarity to activate keyed Lorebook entries when keyword matching misses while retaining thresholds and selection gates
- gives UNO bots remaining-hand color counts and explicit Wild declaration strategy
- adds atomic batch updates for selected Lorebook entry boolean settings through the existing Select toolbar
- attributes the unprefixed leading block of a partially prefixed Conversation reply to its saved assistant character, keeping reactions aligned
- renders Discord-style standard emoji names and merges standard Unicode emoji into Conversation autocomplete alongside custom emoji
- restores Illustrator's Illustration/Default prompt as the default and applies a one-time migration to repair the accidental stored Background default without overriding later explicit choices
- applies CodeRabbit's first review suggestions and adds matching regressions
- records the behavior changes in the v2.2.0 changelog

## Automated validation run

- `pnpm check`
- `pnpm test`
- `pnpm regression:issues`
- `pnpm regression:prompt`
- `pnpm regression:emoji`
- `node scripts/check-windows-installer-layout.mjs`
- `makensis -V3 installer.nsi` from a disposable copy
- serial Playwright: selected Lorebook batch update
- serial Playwright: Conversation standard emoji render and autocomplete

## Maintainer verification

- [ ] Manually verify uninstall keep-data and delete-data choices on a disposable Windows installation.
- [ ] Manually verify the batch setting toolbar with a large imported Lorebook.
- [ ] Manually verify standard and custom emoji suggestions together in an existing Conversation.
- [ ] Manually verify an existing affected roleplay chat now uses Illustrator's Illustration prompt and still permits explicitly selecting Background.

Validation boxes intentionally remain unchecked for maintainer verification.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Batch-edit settings across multiple Lorebook entries at once.
  * Use standard Discord-style emoji shortcodes with autocomplete in conversations.
* **Bug Fixes**
  * Improved Conversation rendering and reaction attribution for partially speaker-prefixed replies.
  * Semantic Lorebook search now falls back to similarity matching when keywords miss.
  * Corrected Illustrator default prompt behavior after updates.
  * Improved Windows uninstall handling for preserving or deleting user data safely.
  * Updated UNO guidance to show remaining color counts and favor the strongest available color.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->