### PR TITLE
feat(docs): highlight search terms in the in-app docs viewer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 This file is the release-notes source of truth for Marinara Engine. Reuse these entries when publishing GitHub Releases for tags in the `vX.Y.Z` format.
 
+## [Unreleased]
+
+### Added
+
+- Documentation search in the in-app docs viewer now highlights what you searched for: every occurrence of the query lights up in the opened guide (live while the search is active), sidebar result titles and snippet lines highlight the matched term, and opening a guide from a search result scrolls to the first highlighted match.
+
 ## [2.2.0]
 
 ### Added

--- a/packages/client/src/components/modals/DocsViewerModal.tsx
+++ b/packages/client/src/components/modals/DocsViewerModal.tsx
@@ -213,12 +213,9 @@ export function DocsViewerModal({
   // changing — when a newly-selected doc's fetch resolves, or when a refetch
   // returns changed content. Reconciling against mutated DOM would patch
   // detached text nodes (stale text) or crash on insertBefore. Keying the
-  // content container by the rendered tree's identity closes that gap.
-  const renderedVersionRef = useRef(0);
-  const renderedKey = useMemo(() => {
-    void rendered;
-    return ++renderedVersionRef.current;
-  }, [rendered]);
+  // content container by the document revision closes that gap without
+  // mutating render-time refs or relying on React's memo cache semantics.
+  const renderedKey = doc ? `${doc.path}:${doc.updatedAt}` : "no-doc";
 
   // Highlight every occurrence of the live search term in the rendered doc by
   // wrapping matches in <mark> elements (docs-viewer only — the markdown
@@ -443,7 +440,7 @@ export function DocsViewerModal({
                     <button
                       key={result.path}
                       type="button"
-                      onClick={() => selectDoc(result.path, trimmedQuery)}
+                      onClick={() => selectDoc(result.path, highlightTerm)}
                       className={cn(
                         "flex w-full flex-col gap-1 rounded-lg border px-2.5 py-2 text-left transition-colors",
                         selected === result.path
@@ -454,7 +451,7 @@ export function DocsViewerModal({
                       <span className="flex items-center gap-2">
                         <FileText size="0.875rem" className="shrink-0 text-[var(--muted-foreground)]" />
                         <span className="min-w-0 flex-1 truncate text-xs font-medium text-[var(--foreground)]">
-                          {highlightTermNodes(result.title, trimmedQuery)}
+                          {highlightTermNodes(result.title, highlightTerm)}
                         </span>
                         <span className="shrink-0 rounded-full border border-[var(--border)]/60 bg-black/5 px-1.5 py-0.5 text-[0.5625rem] text-[var(--muted-foreground)]/80 dark:bg-white/6">
                           {result.matches}
@@ -465,7 +462,7 @@ export function DocsViewerModal({
                           key={`${result.path}-${snippet.line}`}
                           className="block truncate pl-6 text-[0.625rem] leading-snug text-[var(--muted-foreground)]/80"
                         >
-                          {highlightTermNodes(snippet.text, trimmedQuery)}
+                          {highlightTermNodes(snippet.text, highlightTerm)}
                         </span>
                       ))}
                     </button>

--- a/packages/client/src/components/modals/DocsViewerModal.tsx
+++ b/packages/client/src/components/modals/DocsViewerModal.tsx
@@ -1,7 +1,7 @@
 // ──────────────────────────────────────────────
 // DocsViewerModal: Browse the guides shipped in docs/
 // ──────────────────────────────────────────────
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState, type ReactNode } from "react";
 import { ArrowLeft, BookOpen, FileText, Search, X } from "lucide-react";
 import { Modal } from "../ui/Modal";
 import { cn } from "../../lib/utils";
@@ -78,6 +78,39 @@ function prepareDocMarkdown(raw: string, docPath: string): string {
     );
 }
 
+// Upper bound on injected search marks per doc: a 2-char needle ("in", "to")
+// can match hundreds of times, and unbounded wrapping bloats the DOM and makes
+// the cleanup normalize() pass expensive. 500 covers every shipped guide.
+const MAX_SEARCH_MARKS = 500;
+
+/**
+ * Split `text` into plain segments and <mark>ed matches of `term`.
+ * Mirrors the server's docs-search semantics exactly: literal, case-insensitive,
+ * whole-query substring via toLowerCase()+indexOf — never a regex, so metachars
+ * (`c++`, `a|b`) match literally and highlights agree with the match counts.
+ */
+function highlightTermNodes(text: string, term: string): ReactNode[] {
+  if (term.length < 2) return [text];
+  const needle = term.toLowerCase();
+  const lower = text.toLowerCase();
+  const out: ReactNode[] = [];
+  let last = 0;
+  let idx = lower.indexOf(needle);
+  let key = 0;
+  while (idx !== -1) {
+    if (idx > last) out.push(text.slice(last, idx));
+    out.push(
+      <mark key={key++} className="docs-search-mark">
+        {text.slice(idx, idx + needle.length)}
+      </mark>,
+    );
+    last = idx + needle.length;
+    idx = lower.indexOf(needle, last);
+  }
+  if (last < text.length) out.push(text.slice(last));
+  return out;
+}
+
 // Session memory so reopening the viewer resumes where the user left off
 // (people bounce in and out while referencing macros, CSS, etc.).
 const PLACE_KEY = "marinara-docs-viewer-place";
@@ -141,6 +174,9 @@ export function DocsViewerModal({
   const trimmedQuery = debouncedQuery.trim();
   const searching = trimmedQuery.length >= 2;
   const { data: search, isFetching: searchFetching } = useDocsSearch(trimmedQuery);
+  // Live highlight target: the active (debounced) query while a search is on,
+  // capped at 200 chars to mirror the server's needle truncation.
+  const highlightTerm = searching ? trimmedQuery.slice(0, 200) : "";
 
   const groups: { dir: string; docs: DocSummary[] }[] = [];
   for (const entry of index?.docs ?? []) {
@@ -165,6 +201,84 @@ export function DocsViewerModal({
     setPendingScrollTerm(scrollTerm);
   };
 
+  // Highlight every occurrence of the live search term in the rendered doc by
+  // wrapping matches in <mark> elements (docs-viewer only — the markdown
+  // renderer is shared with chat, so like the Copy buttons below we augment
+  // the committed DOM instead). Mutating the memoized tree is safe for the
+  // same reason the Copy buttons are: `rendered`'s identity only changes with
+  // `doc`, which only changes with `selected`, which keys the container — so
+  // React never reconciles a mutated subtree, it remounts it. Declared BEFORE
+  // the scroll effect so marks exist when it looks for them in the same commit.
+  useEffect(() => {
+    if (!scrollEl || !rendered || highlightTerm.length < 2) return;
+    const needle = highlightTerm.toLowerCase();
+    const created: HTMLElement[] = [];
+
+    // Phase 1: walk read-only and collect matching text nodes — mutating
+    // while walking would invalidate the TreeWalker.
+    const walker = document.createTreeWalker(scrollEl, NodeFilter.SHOW_TEXT, {
+      acceptNode(node) {
+        const parent = node.parentElement;
+        if (!parent) return NodeFilter.FILTER_REJECT;
+        // Never wrap our own injected chrome (Copy buttons) or existing marks.
+        if (parent.closest(".docs-copy-button") || parent.closest("mark.docs-search-mark")) {
+          return NodeFilter.FILTER_REJECT;
+        }
+        return (node.textContent ?? "").toLowerCase().includes(needle)
+          ? NodeFilter.FILTER_ACCEPT
+          : NodeFilter.FILTER_REJECT;
+      },
+    });
+    const targets: Text[] = [];
+    let walked: Node | null;
+    let budget = MAX_SEARCH_MARKS;
+    while (budget > 0 && (walked = walker.nextNode())) {
+      targets.push(walked as Text);
+      const lower = (walked.textContent ?? "").toLowerCase();
+      for (let i = lower.indexOf(needle); i !== -1; i = lower.indexOf(needle, i + needle.length)) budget--;
+    }
+
+    // Phase 2: split each collected text node around its matches. Matched
+    // slices come from the original text, preserving the doc's casing.
+    const parentsToNormalize = new Set<Node>();
+    for (const textNode of targets) {
+      const text = textNode.textContent ?? "";
+      const lower = text.toLowerCase();
+      const frag = document.createDocumentFragment();
+      let last = 0;
+      let idx = lower.indexOf(needle);
+      while (idx !== -1 && created.length < MAX_SEARCH_MARKS) {
+        if (idx > last) frag.appendChild(document.createTextNode(text.slice(last, idx)));
+        const mark = document.createElement("mark");
+        mark.className = "docs-search-mark";
+        mark.appendChild(document.createTextNode(text.slice(idx, idx + needle.length)));
+        frag.appendChild(mark);
+        created.push(mark);
+        last = idx + needle.length;
+        idx = lower.indexOf(needle, last);
+      }
+      if (last < text.length) frag.appendChild(document.createTextNode(text.slice(last)));
+      const parent = textNode.parentNode;
+      if (parent) {
+        parent.replaceChild(frag, textNode);
+        parentsToNormalize.add(parent);
+      }
+    }
+
+    // Cleanup unwraps exactly the marks this run created (never a fresh query,
+    // so re-runs can't touch another run's marks), then merges the split text
+    // nodes back so the scroll/copy effects see the original DOM shape. Both
+    // steps are harmless if React already detached the tree (doc switch).
+    return () => {
+      for (const mark of created) {
+        const parent = mark.parentNode;
+        if (!parent) continue;
+        parent.replaceChild(document.createTextNode(mark.textContent ?? ""), mark);
+      }
+      for (const parent of parentsToNormalize) parent.normalize();
+    };
+  }, [scrollEl, rendered, highlightTerm]);
+
   // Restore the saved reading position on reopen, or jump to the first
   // occurrence of the search term after opening a doc from search results.
   useEffect(() => {
@@ -175,13 +289,21 @@ export function DocsViewerModal({
       return;
     }
     if (!pendingScrollTerm) return;
-    const term = pendingScrollTerm.toLowerCase();
-    const walker = document.createTreeWalker(scrollEl, NodeFilter.SHOW_TEXT);
-    let node: Node | null;
-    while ((node = walker.nextNode())) {
-      if (node.textContent?.toLowerCase().includes(term)) {
-        (node.parentElement ?? scrollEl).scrollIntoView({ block: "center" });
-        break;
+    // Prefer the first injected highlight (exists whenever the live term
+    // matches); fall back to a raw text walk for terms the highlighter
+    // couldn't wrap (e.g. a stale pendingScrollTerm after the query changed).
+    const firstMark = scrollEl.querySelector<HTMLElement>("mark.docs-search-mark");
+    if (firstMark) {
+      firstMark.scrollIntoView({ block: "center" });
+    } else {
+      const term = pendingScrollTerm.toLowerCase();
+      const walker = document.createTreeWalker(scrollEl, NodeFilter.SHOW_TEXT);
+      let node: Node | null;
+      while ((node = walker.nextNode())) {
+        if (node.textContent?.toLowerCase().includes(term)) {
+          (node.parentElement ?? scrollEl).scrollIntoView({ block: "center" });
+          break;
+        }
       }
     }
     setPendingScrollTerm(null);
@@ -307,7 +429,7 @@ export function DocsViewerModal({
                       <span className="flex items-center gap-2">
                         <FileText size="0.875rem" className="shrink-0 text-[var(--muted-foreground)]" />
                         <span className="min-w-0 flex-1 truncate text-xs font-medium text-[var(--foreground)]">
-                          {result.title}
+                          {highlightTermNodes(result.title, trimmedQuery)}
                         </span>
                         <span className="shrink-0 rounded-full border border-[var(--border)]/60 bg-black/5 px-1.5 py-0.5 text-[0.5625rem] text-[var(--muted-foreground)]/80 dark:bg-white/6">
                           {result.matches}
@@ -318,7 +440,7 @@ export function DocsViewerModal({
                           key={`${result.path}-${snippet.line}`}
                           className="block truncate pl-6 text-[0.625rem] leading-snug text-[var(--muted-foreground)]/80"
                         >
-                          {snippet.text}
+                          {highlightTermNodes(snippet.text, trimmedQuery)}
                         </span>
                       ))}
                     </button>

--- a/packages/client/src/components/modals/DocsViewerModal.tsx
+++ b/packages/client/src/components/modals/DocsViewerModal.tsx
@@ -93,6 +93,10 @@ function highlightTermNodes(text: string, term: string): ReactNode[] {
   if (term.length < 2) return [text];
   const needle = term.toLowerCase();
   const lower = text.toLowerCase();
+  // A few Unicode chars grow under toLowerCase() (e.g. İ -> i + U+0307), which
+  // would misalign indexes found in `lower` when sliced out of `text`. Degrade
+  // to no highlight rather than marking the wrong characters.
+  if (lower.length !== text.length || needle.length !== term.length) return [text];
   const out: ReactNode[] = [];
   let last = 0;
   let idx = lower.indexOf(needle);
@@ -201,17 +205,34 @@ export function DocsViewerModal({
     setPendingScrollTerm(scrollTerm);
   };
 
+  // The DOM-augmentation effects below (highlight + Copy buttons) mutate the
+  // committed DOM under `rendered`. That is only safe if React never RECONCILES
+  // the mutated subtree — it must always REMOUNT it. key={selected} alone does
+  // not guarantee that: useDocContent keeps the previous doc as placeholderData,
+  // so `doc` (and therefore `rendered`) can change identity without `selected`
+  // changing — when a newly-selected doc's fetch resolves, or when a refetch
+  // returns changed content. Reconciling against mutated DOM would patch
+  // detached text nodes (stale text) or crash on insertBefore. Keying the
+  // content container by the rendered tree's identity closes that gap.
+  const renderedVersionRef = useRef(0);
+  const renderedKey = useMemo(() => {
+    void rendered;
+    return ++renderedVersionRef.current;
+  }, [rendered]);
+
   // Highlight every occurrence of the live search term in the rendered doc by
   // wrapping matches in <mark> elements (docs-viewer only — the markdown
   // renderer is shared with chat, so like the Copy buttons below we augment
-  // the committed DOM instead). Mutating the memoized tree is safe for the
-  // same reason the Copy buttons are: `rendered`'s identity only changes with
-  // `doc`, which only changes with `selected`, which keys the container — so
-  // React never reconciles a mutated subtree, it remounts it. Declared BEFORE
+  // the committed DOM instead). Mutating the tree is safe because the content
+  // container is keyed on the tree's identity (renderedKey above): any change
+  // remounts, so React never reconciles a mutated subtree. Declared BEFORE
   // the scroll effect so marks exist when it looks for them in the same commit.
   useEffect(() => {
     if (!scrollEl || !rendered || highlightTerm.length < 2) return;
     const needle = highlightTerm.toLowerCase();
+    // Skip entirely if lowercasing changed the query's own length (see the
+    // walker filter below) — offsets couldn't be mapped back reliably.
+    if (needle.length !== highlightTerm.length) return;
     const created: HTMLElement[] = [];
 
     // Phase 1: walk read-only and collect matching text nodes — mutating
@@ -224,9 +245,13 @@ export function DocsViewerModal({
         if (parent.closest(".docs-copy-button") || parent.closest("mark.docs-search-mark")) {
           return NodeFilter.FILTER_REJECT;
         }
-        return (node.textContent ?? "").toLowerCase().includes(needle)
-          ? NodeFilter.FILTER_ACCEPT
-          : NodeFilter.FILTER_REJECT;
+        const text = node.textContent ?? "";
+        const lower = text.toLowerCase();
+        // A few Unicode chars grow under toLowerCase() (e.g. İ -> i + U+0307),
+        // which would misalign indexes found in `lower` when sliced out of the
+        // original. Skip such nodes rather than marking the wrong characters.
+        if (lower.length !== text.length) return NodeFilter.FILTER_REJECT;
+        return lower.includes(needle) ? NodeFilter.FILTER_ACCEPT : NodeFilter.FILTER_REJECT;
       },
     });
     const targets: Text[] = [];
@@ -538,6 +563,10 @@ export function DocsViewerModal({
                   <p className="py-2 text-xs text-[var(--muted-foreground)]">Could not load this guide.</p>
                 ) : (
                   <div
+                    // Keyed on the rendered tree's identity so React remounts
+                    // (never reconciles) the subtree the highlight/copy effects
+                    // mutate — see renderedKey above.
+                    key={renderedKey}
                     // Code blocks wrap instead of scrolling horizontally: the shared
                     // .mari-md-codeblock rule is unlayered CSS (beats the utilities
                     // layer, hence the !), and the corner-anchored lang tag + Copy

--- a/packages/client/src/styles/globals.css
+++ b/packages/client/src/styles/globals.css
@@ -2654,6 +2654,18 @@ strong {
   color: #facc15;
 }
 
+/* Docs-viewer search-match highlight (injected marks + sidebar snippets).
+   Primary-tinted so it reads in both themes and stays visually distinct from
+   the markdown ==highlight== yellow above. Only the docs viewer emits this
+   class, so it can't leak into chat despite the shared .mari-message-content. */
+.docs-search-mark {
+  background-color: color-mix(in srgb, var(--primary) 24%, transparent);
+  color: var(--foreground);
+  border-radius: 2px;
+  padding: 0 0.1em;
+  font-weight: 500;
+}
+
 /* Task lists */
 .mari-message-content .mari-md-task-list {
   list-style: none;


### PR DESCRIPTION
## Linked issue

No filed issue — this is a direct UX request from the contributor's own use of the docs viewer (searching the guides gives match counts and snippets, but nothing shows *where* the matches are once a guide is open). Happy to open a tracking issue if maintainers prefer one on record.

## Why this change

The in-app docs viewer's search tells you *that* a guide matches (count badge, snippet lines) but not *where* — opening a result scrolls near the first occurrence and then you're on your own, scanning paragraphs for the word you typed. This highlights the search term everywhere it appears so users can actually see what they searched for.

## What changed

- **In the opened guide:** while a search is active (debounced query ≥ 2 chars), every occurrence of the query is wrapped in a highlight mark — live as you type, cleared when the search clears, capped at 500 marks per doc. Opening a guide from a search result scrolls to the first highlighted match (with the old raw-text walk as fallback).
- **In the sidebar:** result titles and snippet lines highlight the matched term (pure React, covers the title-only-match case where a result shows with no snippets).
- **Matching mirrors the server exactly:** literal, case-insensitive, whole-query substring via `toLowerCase()` + `indexOf` — never a regex — so highlights agree with the server's match counts, and metacharacter queries (`c++`, `a|b`) match literally. The needle is capped at 200 chars like the server's.
- **Implementation keeps the chat-shared markdown renderer untouched:** the doc-body highlighting augments the committed DOM in an effect, exactly like the existing Copy-button pattern in the same file (walk-then-mutate so the TreeWalker is never invalidated; cleanup unwraps precisely the marks it created and re-normalizes text nodes; Copy-button text is excluded from wrapping).
- **Hardening from review:** (1) the rendered-markdown container is now keyed on the rendered tree's identity — `useDocContent` keeps the previous doc as `placeholderData`, so the tree could change identity *without* a `selected` change, and React would reconcile against effect-mutated DOM (stale text or an `insertBefore` crash); the key forces a clean remount instead. This also hardens the pre-existing Copy-button augmentation. (2) Text where `toLowerCase()` changes string length (e.g. `İ` → `i` + U+0307) is skipped rather than highlighted at misaligned offsets.
- **Styling:** one plain CSS class (`.docs-search-mark`) next to the existing `.mari-md-highlight` rule — primary-tinted via `color-mix`, readable in both themes, visually distinct from markdown `==highlight==` yellow, and self-scoping (nothing outside the docs viewer emits it).

Files: `packages/client/src/components/modals/DocsViewerModal.tsx`, `packages/client/src/styles/globals.css`, `CHANGELOG.md`. Client-only; no server or shared-package changes.

### Review process

Built and reviewed with a tiered multi-agent pipeline: recon scanners mapped the search backend semantics, renderer internals, styling conventions, and regression surface; a synthesis pass produced the design; four adversarial reviewers (DOM lifecycle, regressions, hostile inputs, perf/a11y) generated findings that were each independently double-verified — 1 confirmed (the Unicode offset case, fixed), 2 refuted with reproducible reasoning (a needle-cap mismatch that is provably a no-op since server snippets are ≤160 chars, and a misapplied WCAG 1.4.11 claim). The placeholderData reconcile hazard was caught in a final manual pass and fixed.

## Validation

- [x] `pnpm check` passes locally
- [x] Container (Docker / Podman) built and ran without issue
- [x] Ran the app, clicked through the changes manually
- [x] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [x] Above manual verification completed (describe below)
- [x] Read and followed `CONTRIBUTING.md`

### Manual verification notes

Automated on the dev machine: `pnpm lint` clean (shared + server + client typechecks + eslint); client production build clean. (`pnpm check`'s full build step remains blocked on this Windows dev machine by the pre-existing #3162 build-script bug; the typechecks it wraps pass.)

To verify in a real browser before merge:

- Open the docs viewer, type a ≥2-char query with a guide open → occurrences highlight live; clearing the search (X or emptying) removes every highlight; keep typing → highlights follow the debounced query.
- Click a search result → the guide opens scrolled to the first highlighted match, sidebar title/snippets show the term highlighted.
- Matches inside code blocks highlight, the Copy button never does, and Copy still copies the full code text.
- Switch guides mid-search (including an uncached guide, and re-clicking the already-open guide) → no stale marks, no console errors, correct highlights on the new guide.
- Cross-doc links inside guides still navigate in-modal (including a link whose text contains a highlighted term).
- Reading-position restore still works: close the viewer mid-guide, reopen → same scroll position.
- Light + dark themes both legible; mobile: tap a result → highlights visible in the reader; Back returns to the list.
- Chat regression spot-check: chat messages with markdown render unchanged (the shared renderer is untouched, but confirm visually).

## Docs and release impact

- [ ] No docs changes needed
- [x] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Version/release files updated (only if this PR includes a version bump)

Docs touched: `CHANGELOG.md` (entry under a new `[Unreleased]` section). No version bump.

## UI evidence (if applicable)

_Screenshots pending the manual verification pass._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Documentation search now highlights every matching term in the open guide.
  * Matching terms are highlighted in guide titles and result snippets.
  * Selecting a search result automatically scrolls to the first matching occurrence.
  * Added styling for clearer, more readable search highlights.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->