### PR TITLE
Honor selected chroma and explain missing client builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 ### Fixed
 
 - Fixed the root recovery screen hydrating the legacy default pink before the selected app accent could mount; crash details, borders, focus rings, and recovery actions now inherit the saved chroma color, and remaining old pink application-chrome fallbacks use semantic accent tokens.
+- Added an actionable startup warning when the compiled client is missing, identifying the expected build path and the `pnpm build` command instead of silently serving only the API (#3529).
 - Fixed Illustrator defaulting to the Background prompt in new and existing Roleplay chats after the staging update; normal Illustration is restored as the default, affected stored agent configs are repaired once, and explicit per-chat Background choices remain intact (#3517).
 - Fixed the Windows uninstaller deleting current-layout user data under `packages/server/data`; uninstall now asks before application cleanup, safely preserves and restores retained data, supports the legacy root data folder, and removes the current `win` directory instead of a stale path (#3484).
 - Fixed semantic Lorebook search being unreachable for ordinary keyed entries; vector similarity now acts as the documented fallback when keyword matching misses while retaining score thresholds, maximum results, filters, and probability gates (#3511).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 
 ### Fixed
 
+- Fixed the root recovery screen hydrating the legacy default pink before the selected app accent could mount; crash details, borders, focus rings, and recovery actions now inherit the saved chroma color, and remaining old pink application-chrome fallbacks use semantic accent tokens.
 - Fixed Illustrator defaulting to the Background prompt in new and existing Roleplay chats after the staging update; normal Illustration is restored as the default, affected stored agent configs are repaired once, and explicit per-chat Background choices remain intact (#3517).
 - Fixed the Windows uninstaller deleting current-layout user data under `packages/server/data`; uninstall now asks before application cleanup, safely preserves and restores retained data, supports the legacy root data folder, and removes the current `win` directory instead of a stale path (#3484).
 - Fixed semantic Lorebook search being unreachable for ordinary keyed entries; vector similarity now acts as the documented fallback when keyword matching misses while retaining score thresholds, maximum results, filters, and probability gates (#3511).

--- a/packages/client/src/App.tsx
+++ b/packages/client/src/App.tsx
@@ -91,13 +91,25 @@ function formatRecoveryError(error: unknown) {
   }
 }
 
-function getRecoveryChromeTextStyle(): CSSProperties | undefined {
-  const { chatChromeTextColor, theme } = useUIStore.getState();
+function getRecoveryChromeStyle(): CSSProperties {
+  const { appAccentColor, chatChromeTextColor, theme } = useUIStore.getState();
+  const defaultAccent = getDefaultAppAccentColor(theme);
+  const accentSource = appAccentColor.trim() || defaultAccent;
+  const accent = getCssColorFallback(accentSource, defaultAccent);
+  const accentGradient = isCssGradient(accentSource) ? accentSource : getSolidAccentGradient(accent);
   const textColor = chatChromeTextColor.trim();
-  if (!textColor) return undefined;
+  const chromeText = textColor
+    ? getCssColorFallback(textColor, getDefaultChatChromeTextColor(theme))
+    : getDefaultChatChromeTextColor(theme);
 
   return {
-    "--marinara-chat-chrome-text": getCssColorFallback(textColor, getDefaultChatChromeTextColor(theme)),
+    "--primary": accent,
+    "--ring": accent,
+    "--marinara-app-accent-solid": accent,
+    "--marinara-app-accent-gradient": accentGradient,
+    "--marinara-chat-chrome-accent": accent,
+    "--marinara-chat-chrome-accent-gradient": accentGradient,
+    "--marinara-chat-chrome-text": chromeText,
   } as CSSProperties;
 }
 
@@ -127,12 +139,12 @@ export class AppRecoveryBoundary extends Component<{ children: ReactNode }, { er
   render() {
     if (!this.state.hasError) return this.props.children;
     const errorMessage = formatRecoveryError(this.state.error);
-    const recoveryChromeTextStyle = getRecoveryChromeTextStyle();
+    const recoveryChromeStyle = getRecoveryChromeStyle();
 
     return (
       <div
         className="mari-chrome-token-scope flex min-h-screen items-center justify-center bg-[var(--background)] px-4 text-[var(--marinara-chat-chrome-panel-text)]"
-        style={recoveryChromeTextStyle}
+        style={recoveryChromeStyle}
       >
         <div className="w-full max-w-lg rounded-xl border border-[var(--marinara-chat-chrome-accent)] bg-[var(--marinara-chat-chrome-panel-bg)] p-5 shadow-2xl ring-1 ring-[var(--marinara-chat-chrome-focus-ring)]">
           <h1 className="text-lg font-semibold text-[var(--marinara-chat-chrome-panel-title)]">
@@ -142,7 +154,7 @@ export class AppRecoveryBoundary extends Component<{ children: ReactNode }, { er
             The app shell crashed while rendering. Reload first; reset local UI state only if the same screen keeps
             returning after restart.
           </p>
-          <pre className="mt-3 max-h-32 overflow-auto rounded-lg border border-[var(--marinara-chat-chrome-panel-border)] bg-[var(--marinara-chat-chrome-highlight-bg)] p-2 text-xs text-[var(--marinara-chat-chrome-panel-muted)]">
+          <pre className="mt-3 max-h-32 overflow-auto rounded-lg border border-[var(--marinara-chat-chrome-panel-border)] bg-[var(--marinara-chat-chrome-highlight-bg)] p-2 text-xs text-[var(--marinara-chat-chrome-accent)]">
             {errorMessage}
           </pre>
           <div className="mt-4 flex flex-wrap gap-2">
@@ -279,7 +291,7 @@ function resolveCursorColor(color: string, fallback: string) {
 }
 
 function getAccentCursorColors(accent: string, theme: "dark" | "light") {
-  const fill = resolveCursorColor(accent, theme === "light" ? "#e0709a" : "#d4acfb");
+  const fill = resolveCursorColor(accent, getDefaultAppAccentColor(theme));
   const stroke = theme === "light" ? "#1a1025" : "#050312";
 
   return { fill, stroke };

--- a/packages/client/src/components/game/GameCombatUI.tsx
+++ b/packages/client/src/components/game/GameCombatUI.tsx
@@ -3077,7 +3077,9 @@ function CombatantCard({
                 title={`${effect.name} (${effect.turnsLeft} turns)`}
                 className={cn(
                   "relative flex h-5 min-w-5 items-center justify-center rounded-full border px-0.5 text-[0.65rem] shadow-[0_4px_12px_rgba(0,0,0,0.35)] backdrop-blur-sm",
-                  effect.modifier > 0 ? "border-emerald-300/35 bg-emerald-500/25" : "border-rose-300/35 bg-rose-500/25",
+                  effect.modifier > 0
+                    ? "border-emerald-300/35 bg-emerald-500/25"
+                    : "border-[color-mix(in_srgb,var(--destructive)_35%,transparent)] bg-[color-mix(in_srgb,var(--destructive)_25%,transparent)]",
                 )}
               >
                 <span aria-hidden="true">{getStatusEffectEmoji(effect)}</span>

--- a/packages/client/src/components/game/GameNarration.tsx
+++ b/packages/client/src/components/game/GameNarration.tsx
@@ -4088,7 +4088,7 @@ export function GameNarration({
             seg.partyType === "thought"
               ? "border-purple-400/10 bg-purple-950/15"
               : seg.partyType === "whisper"
-                ? "border-rose-400/10 bg-rose-950/15"
+                ? "border-[var(--marinara-chat-chrome-panel-border)] bg-[var(--marinara-chat-chrome-highlight-bg)]"
                 : seg.partyType === "side" || seg.partyType === "extra"
                   ? "border-sky-400/10 bg-sky-950/15"
                   : "border-[var(--border)] bg-[var(--muted)]/20 dark:border-white/5 dark:bg-black/20",
@@ -4581,7 +4581,7 @@ export function GameNarration({
                             active.partyType === "thought"
                               ? "border-purple-400/10 bg-purple-950/20"
                               : active.partyType === "whisper"
-                                ? "border-rose-400/10 bg-rose-950/20"
+                                ? "border-[var(--marinara-chat-chrome-panel-border)] bg-[var(--marinara-chat-chrome-highlight-bg)]"
                                 : "border-[var(--border)] bg-[var(--muted)]/20 dark:border-white/10 dark:bg-black/35",
                             activeSegmentActionButtons && "pr-16",
                           )}
@@ -5313,7 +5313,7 @@ export function GameNarration({
                               seg.partyType === "thought"
                                 ? "border-purple-400/10 bg-purple-950/15"
                                 : seg.partyType === "whisper"
-                                  ? "border-rose-400/10 bg-rose-950/15"
+                                  ? "border-[var(--marinara-chat-chrome-panel-border)] bg-[var(--marinara-chat-chrome-highlight-bg)]"
                                   : seg.partyType === "side" || seg.partyType === "extra"
                                     ? "border-sky-400/10 bg-sky-950/15"
                                     : "border-white/5 bg-black/20",

--- a/packages/client/src/components/game/GameWidgetPanel.tsx
+++ b/packages/client/src/components/game/GameWidgetPanel.tsx
@@ -1016,7 +1016,7 @@ function RelationshipMeterWidget({ widget }: { widget: HudWidget }) {
   const value = getNumericWidgetValue(widget);
   const milestones = Array.isArray(widget.config.milestones) ? widget.config.milestones : [];
   const pct = Math.max(0, Math.min(100, (value / Math.max(1, max)) * 100));
-  const accent = widget.accent ?? "#ec4899";
+  const accent = widget.accent ?? "var(--marinara-chat-chrome-accent)";
 
   // Find current milestone
   const currentMilestone = [...milestones].sort((a, b) => b.at - a.at).find((m) => value >= m.at);
@@ -1033,7 +1033,7 @@ function RelationshipMeterWidget({ widget }: { widget: HudWidget }) {
           className="h-full rounded-full transition-all duration-700"
           style={{
             width: `${pct}%`,
-            background: `linear-gradient(90deg, ${accent}80, ${accent})`,
+            background: `linear-gradient(90deg, color-mix(in srgb, ${accent} 50%, transparent), ${accent})`,
           }}
         />
         {/* Milestone markers */}

--- a/packages/client/src/components/layout/RightPanel.tsx
+++ b/packages/client/src/components/layout/RightPanel.tsx
@@ -33,7 +33,11 @@ const PANEL_CONFIG: Record<string, { title: string; icon: ReactNode; gradient?: 
     icon: <Bot size="0.875rem" />,
     gradient: "from-lime-400 via-green-500 to-cyan-500",
   },
-  characters: { title: "Characters", icon: <Users size="0.875rem" />, gradient: "from-pink-400 to-rose-500" },
+  characters: {
+    title: "Characters",
+    icon: <Users size="0.875rem" />,
+    gradientClass: "bg-[image:var(--marinara-app-accent-gradient)] text-[var(--primary-foreground)]",
+  },
   lorebooks: { title: "Lorebooks", icon: <BookOpen size="0.875rem" />, gradient: "from-amber-400 to-orange-500" },
   presets: {
     title: "Presets",

--- a/packages/client/src/components/layout/TopBar.tsx
+++ b/packages/client/src/components/layout/TopBar.tsx
@@ -376,17 +376,18 @@ export function TopBar() {
           className={cn(
             TOPBAR_PANEL_BUTTON_CLASS,
             isCharactersPanelActive
-              ? cn(TOPBAR_ACTIVE_BUTTON_CLASS, "text-rose-300")
+              ? TOPBAR_ACTIVE_BUTTON_CLASS
               : cn(
-                  "text-[var(--muted-foreground)] hover:text-rose-300",
-                  isTopbarHovered("characters") && cn(TOPBAR_FORCE_HOVER_CLASS, "text-rose-300"),
+                  "text-[var(--muted-foreground)] hover:text-[var(--marinara-chat-chrome-button-text-hover)]",
+                  isTopbarHovered("characters") &&
+                    cn(TOPBAR_FORCE_HOVER_CLASS, "text-[var(--marinara-chat-chrome-button-text-hover)]"),
                 ),
           )}
           title="Characters"
         >
           <Users size={15} className={TOPBAR_ACCENT_ICON_CLASS} />
           {isCharactersPanelActive && (
-            <span className="absolute -bottom-0.5 left-1/2 h-0.5 w-3 -translate-x-1/2 rounded-full bg-gradient-to-r from-pink-400 to-rose-500" />
+            <span className="mari-topbar-active-underline absolute -bottom-0.5 left-1/2 h-0.5 w-3 -translate-x-1/2 rounded-full" />
           )}
         </button>
 

--- a/packages/client/src/styles/globals.css
+++ b/packages/client/src/styles/globals.css
@@ -3287,8 +3287,9 @@ strong {
 }
 
 .pastel-gradient {
-  background: linear-gradient(90deg, #ff69b4, #ff8c42, #ff6b9d, #ff6f61, #ff69b4, #ff8c42, #ff6b9d, #ff6f61, #ff69b4) 0
-    0 / 400% 100%;
+  background-image: var(--marinara-app-accent-gradient);
+  background-position: 0;
+  background-size: 400% 100%;
   animation: pastel-gradient-cycle 25s linear infinite;
 }
 
@@ -3403,7 +3404,7 @@ strong {
 }
 
 .os-window-btn.close {
-  background: linear-gradient(135deg, #ff6b9d, #ff8fab);
+  background: var(--destructive);
 }
 .os-window-btn.minimize {
   background: linear-gradient(135deg, #ffd88a, #ffe4a8);

--- a/packages/server/src/app.ts
+++ b/packages/server/src/app.ts
@@ -209,6 +209,8 @@ export async function buildApp(https?: { cert: Buffer; key: Buffer }) {
       reply.header("Expires", "0");
       return reply.sendFile("index.html", clientDist);
     });
+  } else {
+    app.log.warn("Client build not found at %s; serving API only. Run `pnpm build` to build the frontend.", clientDist);
   }
 
   // ── Health Check ──


### PR DESCRIPTION
## Why

The root recovery screen could render before the normal accent effect mounted, causing crash details and leftover application chrome to fall back to the old pink palette instead of the user's saved chroma color.

Separately, when `packages/client/dist` was missing, the server silently started API-only. Opening the app then showed a bare Fastify 404 without any startup explanation.

Closes #3529.

## What changed

- Hydrate the saved app accent directly inside the root recovery boundary, including gradient accents and early-crash rendering.
- Replace remaining old pink application-chrome fallbacks with semantic accent or destructive tokens.
- Log an actionable startup warning when the compiled client is absent, including the resolved path and `pnpm build` recovery command.
- Document both fixes in the v2.2.0 changelog.

## Automated verification

- `pnpm check`
- Reproduced the missing-build path with isolated temporary data and `packages/client/dist` temporarily unavailable.
- Confirmed the warning is emitted before the expected API-only 404 and names both the missing path and recovery command.

## Manual verification requested

- [ ] Verify the recovery screen with a non-pink saved solid accent.
- [ ] Verify the recovery screen with a saved gradient accent.
- [ ] Start the packaged server without `packages/client/dist` and confirm the launcher window shows the warning.