### PR TITLE
Fix Echo delivery, advanced prompts, Noodle profiles, and galleries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 
 ### Fixed
 
+- Fixed Noodle profile setup failing an entire refresh when one model-generated profile contains an overlong or malformed field. Generated profile text is safely bounded, invalid rows are skipped independently, and valid accounts from the same batch still apply (#3533).
+- Fixed Noodle forgetting the last selected persona after a browser refresh or app restart; the account choice now persists per browser and falls back safely when that persona no longer exists (#3535).
+- Fixed renamed character cards retaining their former Noodle display name. Bootstrap now refreshes entity-owned character names and avatars while preserving generated handles, bios, locations, and other Noodle profile data (#3537).
+- Fixed generated chat images being saved only to the chat gallery. Illustrator generations and retries across Roleplay/Game, Conversation command and Gallery selfies, and Conversation Call selfies now also create independent copies in every depicted character or persona gallery (#3538).
 - Restored Echo Chamber's queued Roleplay delivery: newly generated reactions now arrive one at a time with short delays, persistence races cannot reveal a whole batch, stale reveal counters are clamped, and inactive-chat retries cannot write into the visible chat's Echo panel.
 - Fixed character Advanced prompt controls being dropped from live Conversation and Game requests. System Prompts, Post-History Instructions, and Depth Prompts now cover Conversation participants plus Game party/character-GM cards, using the same shared injection path in preset assembly, direct mode assembly, and Prompt Preview.
 - Fixed Roleplay Illustrator comic and manga prompts being contradicted by an unconditional negative prompt that banned speech bubbles, captions, readable lettering, and SFX. Text suppression now remains enabled for ordinary illustrations but yields to explicit lettering requests in the final compiled prompt.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 
 ### Fixed
 
+- Restored Echo Chamber's queued Roleplay delivery: newly generated reactions now arrive one at a time with short delays, persistence races cannot reveal a whole batch, stale reveal counters are clamped, and inactive-chat retries cannot write into the visible chat's Echo panel.
+- Fixed character Advanced prompt controls being dropped from live Conversation and Game requests. System Prompts, Post-History Instructions, and Depth Prompts now cover Conversation participants plus Game party/character-GM cards, using the same shared injection path in preset assembly, direct mode assembly, and Prompt Preview.
 - Fixed Roleplay Illustrator comic and manga prompts being contradicted by an unconditional negative prompt that banned speech bubbles, captions, readable lettering, and SFX. Text suppression now remains enabled for ordinary illustrations but yields to explicit lettering requests in the final compiled prompt.
 - Fixed Roleplay Text to Speech replaying the previous assistant message whenever a new output generation failed. Autoplay now requires a successful generation with a genuinely new assistant-message revision, and failed partial outputs are never queued for automatic playback.
 

--- a/docs/characters/creating-and-editing-characters.md
+++ b/docs/characters/creating-and-editing-characters.md
@@ -113,7 +113,9 @@ The picture size comes from the **Portraits** image-size setting in the image-ge
 
 The **Advanced** tab holds prompt controls for advanced users. You can leave all of these empty for a normal character.
 
-- **System Prompt**. Character-specific instructions added through the active preset's character block. This does not replace the chat's main system prompt.
+These character-authored prompt controls apply in Conversation, Roleplay, Visual Novel, and Game modes. A selected Conversation or Game preset changes the surrounding prompt, but does not disable the character's Post-History Instructions or Depth Prompt.
+
+- **System Prompt**. Character-specific instructions added through the active preset's character block, Conversation character context, or Game character/GM card as appropriate. This does not replace the chat's main system prompt.
 - **Post-History Instructions**. Text placed near the end of the prompt, close to generation. A common use is a short reminder like "Stay in character".
 - **Depth Prompt**. Text injected at a chosen point in the chat history. **Depth** sets how many messages back it goes. Depth 0 is right after the latest message, and depth 4 is four messages back. The default depth is 4. **Role** sets whether the text is inserted as **System**, **User**, or **Assistant**. The default role is System.
 

--- a/e2e/core-flows.e2e.ts
+++ b/e2e/core-flows.e2e.ts
@@ -14,6 +14,7 @@ function collectUnexpectedErrors(page: Page) {
 
 async function prepareFreshClient(page: Page) {
   await page.addInitScript(() => {
+    if (localStorage.getItem("marinara-engine-ui")) return;
     localStorage.setItem(
       "marinara-engine-ui",
       JSON.stringify({
@@ -1049,6 +1050,50 @@ test("Noodle settings persist through refetch and reload", async ({ page }, test
         refreshesPerDay: initial.settings.refreshesPerDay,
       },
     });
+  }
+});
+
+test("Noodle restores the last selected persona after reload", async ({ page }, testInfo) => {
+  test.skip(!testInfo.project.name.includes("desktop"), "Noodle persona persistence is covered on desktop.");
+
+  const createdPersonaIds: string[] = [];
+  try {
+    for (const name of ["Noodle Persona One", "Noodle Persona Two"]) {
+      const response = await page.request.post("/api/characters/personas", {
+        data: { name, description: "Temporary Noodle account persistence regression persona." },
+      });
+      expect(response.ok()).toBe(true);
+      createdPersonaIds.push(((await response.json()) as { id: string }).id);
+    }
+    const selectedPersonaId = createdPersonaIds[1]!;
+    expect((await page.request.get("/api/noodle")).ok()).toBe(true);
+
+    await page.goto("/");
+    await page.locator('[data-tour="noodle-tab"]').click();
+    const noodle = page.locator('[data-component="NoodleView"]');
+    const accountSwitcher = noodle.locator('[data-component="NoodleView.AccountSwitcher"]');
+    await accountSwitcher.click();
+    await noodle.locator(`[data-noodle-persona-id="${selectedPersonaId}"]`).click();
+
+    await expect
+      .poll(() =>
+        page.evaluate(() => {
+          const raw = localStorage.getItem("marinara-engine-ui");
+          if (!raw) return null;
+          return (JSON.parse(raw) as { state?: { noodleSelectedPersonaId?: string | null } }).state
+            ?.noodleSelectedPersonaId ?? null;
+        }),
+      )
+      .toBe(selectedPersonaId);
+
+    await page.reload();
+    await page.locator('[data-tour="noodle-tab"]').click();
+    await expect(noodle).toBeVisible();
+    await expect(accountSwitcher).toContainText("Noodle Persona Two");
+  } finally {
+    for (const personaId of createdPersonaIds) {
+      await page.request.delete(`/api/characters/personas/${personaId}`, { timeout: 5_000 }).catch(() => undefined);
+    }
   }
 });
 

--- a/packages/client/src/components/chat/EchoChamberPanel.tsx
+++ b/packages/client/src/components/chat/EchoChamberPanel.tsx
@@ -1,6 +1,6 @@
 // ──────────────────────────────────────────────
 // Echo Chamber Overlay — compact translucent stream-chat widget
-// Messages appear one-by-one every 30 s, auto-scrolling.
+// Messages appear one-by-one with a short stream-chat delay, auto-scrolling.
 // Positions itself within the chat area, respecting sidebar, right panel,
 // HUD widget position (top/left/right), and the top bar.
 // ──────────────────────────────────────────────
@@ -15,8 +15,11 @@ import { useGenerate } from "../../hooks/use-generate";
 import { api } from "../../lib/api-client";
 import { cn } from "../../lib/utils";
 import { ROLEPLAY_POPOVER_SHELL } from "./roleplay-popover-styles";
+import {
+  ECHO_CHAMBER_MESSAGE_INTERVAL_MS,
+  resolveEchoChamberPersistedBaseline,
+} from "../../lib/echo-chamber-queue";
 
-const MESSAGE_INTERVAL_MS = 30_000; // 30 s between reveals
 const NAME_COLORS = [
   "text-red-400",
   "text-blue-400",
@@ -173,7 +176,7 @@ export function EchoChamberPanel({ hiddenOnMobile = false }: EchoChamberPanelPro
     return activeAgentIds.includes("echo-chamber");
   }, [chat]);
 
-  // ── Timed reveal: show one more message every 30 s ──
+  // ── Timed reveal: show one more message after each short chat-like delay ──
   // visibleCount and baseline live in the Zustand store so they survive
   // component remounts (e.g. when the panel is toggled or the HUD re-renders).
   const visibleCount = useAgentStore((s) => s.echoVisibleCount);
@@ -193,13 +196,15 @@ export function EchoChamberPanel({ hiddenOnMobile = false }: EchoChamberPanelPro
     if (echoLoadedChatId === activeChatId) return;
 
     const previousChatId = echoLoadedChatId;
-    setEchoLoadedChatId(activeChatId);
 
     // Only clear + reset when switching to a *different* chat
     if (previousChatId !== null && previousChatId !== activeChatId) {
       clearEchoMessages();
     }
+    // clearEchoMessages resets the loaded ID, so claim the new chat after it.
+    setEchoLoadedChatId(activeChatId);
 
+    const loadStartedAt = Date.now();
     api
       .get<Array<{ characterName: string; reaction: string; timestamp: number }>>(
         `/agents/echo-messages/${activeChatId}`,
@@ -216,9 +221,10 @@ export function EchoChamberPanel({ hiddenOnMobile = false }: EchoChamberPanelPro
             // Read the actual store length (may be capped) rather than the API
             // response length — a mismatch causes the stagger guard to skip,
             // making new messages dump all at once instead of one-by-one.
-            const loaded = useAgentStore.getState().echoMessages.length;
-            setEchoVisibleCount(loaded);
-            setEchoBaseline(loaded);
+            const loadedMessages = useAgentStore.getState().echoMessages;
+            const persistedBaseline = resolveEchoChamberPersistedBaseline(loadedMessages, loadStartedAt);
+            setEchoVisibleCount(persistedBaseline);
+            setEchoBaseline(persistedBaseline);
           }
         }
       })
@@ -244,7 +250,10 @@ export function EchoChamberPanel({ hiddenOnMobile = false }: EchoChamberPanelPro
       setEchoVisibleCount(baseline);
       return;
     }
-    const id = setTimeout(() => setEchoVisibleCount(visibleCount + 1), MESSAGE_INTERVAL_MS);
+    const id = setTimeout(
+      () => setEchoVisibleCount(visibleCount + 1),
+      ECHO_CHAMBER_MESSAGE_INTERVAL_MS,
+    );
     return () => clearTimeout(id);
   }, [visibleCount, echoMessages.length, baseline, setEchoVisibleCount]);
 

--- a/packages/client/src/components/noodle/NoodleView.tsx
+++ b/packages/client/src/components/noodle/NoodleView.tsx
@@ -101,6 +101,7 @@ import {
   useUpdateNoodlePost,
   useUpdateNoodleSettings,
 } from "../../hooks/use-noodle";
+import { useUIStore } from "../../stores/ui.store";
 
 type RawCharacter = { id?: unknown; data?: unknown; avatarPath?: unknown };
 type RawCharacterGroup = { id?: unknown; name?: unknown; description?: unknown; characterIds?: unknown };
@@ -846,6 +847,8 @@ function NoodleToolPopover({
 }
 
 export function NoodleView() {
+  const selectedPersonaId = useUIStore((state) => state.noodleSelectedPersonaId) ?? "";
+  const setSelectedPersonaId = useUIStore((state) => state.setNoodleSelectedPersonaId);
   const { data, isLoading } = useNoodle();
   const { data: activePersona } = useActivePersona();
   const { data: personasRaw } = usePersonas();
@@ -917,7 +920,6 @@ export function NoodleView() {
     [allConnections],
   );
 
-  const [selectedPersonaId, setSelectedPersonaId] = useState("");
   const [composer, setComposer] = useState("");
   const [composerHasText, setComposerHasText] = useState(false);
   const [activeMention, setActiveMention] = useState<ActiveComposerMention | null>(null);
@@ -1046,12 +1048,15 @@ export function NoodleView() {
   const viewingOwnProfile = Boolean(personaAccount && viewedProfileAccount?.id === personaAccount.id);
 
   useEffect(() => {
+    // Do not erase the persisted choice while the account/persona queries are
+    // still empty during initial hydration.
+    if (!data || personas === null) return;
     if (selectedPersonaId && personaAccounts.some((account) => account.entityId === selectedPersonaId)) return;
     const activeId = readString((activePersona as RawPersona | null)?.id);
     const activeAccount = personaAccounts.find((account) => account.entityId === activeId);
     const nextPersonaId = activeAccount?.entityId ?? sortedPersonaAccounts[0]?.entityId ?? "";
     if (selectedPersonaId !== nextPersonaId) setSelectedPersonaId(nextPersonaId);
-  }, [activePersona, personaAccounts, selectedPersonaId, sortedPersonaAccounts]);
+  }, [activePersona, data, personaAccounts, personas, selectedPersonaId, setSelectedPersonaId, sortedPersonaAccounts]);
 
   useEffect(() => {
     if (accountSwitcherOpen) setPersonaAccountLimit(NOODLE_PERSONA_SWITCHER_PAGE_SIZE);
@@ -4232,6 +4237,7 @@ export function NoodleView() {
                           return (
                             <button
                               key={account.id}
+                              data-noodle-persona-id={account.entityId}
                               type="button"
                               onClick={() => {
                                 setSelectedPersonaId(account.entityId);
@@ -4265,6 +4271,7 @@ export function NoodleView() {
                   </div>
                 )}
                 <button
+                  data-component="NoodleView.MobileAccountSwitcher"
                   type="button"
                   onClick={() => setMobileAccountSwitcherOpen((current) => !current)}
                   aria-expanded={mobileAccountSwitcherOpen}
@@ -4375,6 +4382,7 @@ export function NoodleView() {
                           return (
                             <button
                               key={account.id}
+                              data-noodle-persona-id={account.entityId}
                               type="button"
                               onClick={() => {
                                 setSelectedPersonaId(account.entityId);
@@ -4418,6 +4426,7 @@ export function NoodleView() {
                   </div>
                 )}
                 <button
+                  data-component="NoodleView.AccountSwitcher"
                   type="button"
                   onClick={() => setAccountSwitcherOpen((current) => !current)}
                   className="flex min-h-16 w-full items-center gap-3 rounded-full px-3 text-left transition-colors hover:bg-[var(--accent)]"

--- a/packages/client/src/hooks/use-generate.ts
+++ b/packages/client/src/hooks/use-generate.ts
@@ -981,7 +981,7 @@ export function useGenerate() {
   const addDebugEntry = useAgentStore((s) => s.addDebugEntry);
   const addThoughtBubble = useAgentStore((s) => s.addThoughtBubble);
   const clearThoughtBubbles = useAgentStore((s) => s.clearThoughtBubbles);
-  const addEchoMessage = useAgentStore((s) => s.addEchoMessage);
+  const enqueueEchoMessages = useAgentStore((s) => s.enqueueEchoMessages);
   const setCyoaChoices = useAgentStore((s) => s.setCyoaChoices);
   const clearCyoaChoices = useAgentStore((s) => s.clearCyoaChoices);
   const setMariChips = useAgentStore((s) => s.setMariChips);
@@ -1586,9 +1586,7 @@ export function useGenerate() {
                 if (result.agentType === "echo-chamber") {
                   const d = result.data as Record<string, unknown>;
                   const reactions = (d.reactions as Array<{ characterName: string; reaction: string }>) ?? [];
-                  for (const r of reactions) {
-                    addEchoMessage(r.characterName, r.reaction);
-                  }
+                  enqueueEchoMessages(reactions);
                 }
 
                 // Push CYOA choices to the dedicated store
@@ -2777,7 +2775,7 @@ export function useGenerate() {
       addDebugEntry,
       addThoughtBubble,
       clearThoughtBubbles,
-      addEchoMessage,
+      enqueueEchoMessages,
       setCyoaChoices,
       clearCyoaChoices,
       setMariChips,
@@ -2931,7 +2929,7 @@ export function useGenerate() {
                 if (result.agentType === "echo-chamber") {
                   const d = result.data as Record<string, unknown>;
                   const reactions = (d.reactions as Array<{ characterName: string; reaction: string }>) ?? [];
-                  for (const r of reactions) addEchoMessage(r.characterName, r.reaction);
+                  if (isActiveChat()) enqueueEchoMessages(reactions);
                 }
                 // CYOA re-roll: push the freshly generated choices into the store
                 // so the buttons in CyoaChoices.tsx swap in immediately.
@@ -3159,7 +3157,7 @@ export function useGenerate() {
       addResult,
       addDebugEntry,
       addThoughtBubble,
-      addEchoMessage,
+      enqueueEchoMessages,
       enqueuePendingCardUpdate,
       enqueuePendingAgentWriteApproval,
       clearFailedAgentTypes,

--- a/packages/client/src/lib/echo-chamber-queue.ts
+++ b/packages/client/src/lib/echo-chamber-queue.ts
@@ -1,0 +1,58 @@
+export const ECHO_CHAMBER_MESSAGE_INTERVAL_MS = 1_800;
+export const ECHO_CHAMBER_MESSAGE_LIMIT = 500;
+
+export type EchoChamberMessage = {
+  characterName: string;
+  reaction: string;
+  timestamp: number;
+};
+
+export type EchoChamberQueueState = {
+  messages: EchoChamberMessage[];
+  visibleCount: number;
+  baseline: number;
+};
+
+/**
+ * Append one complete Echo Chamber result atomically while keeping every new
+ * reaction behind the current reveal cursor. Clamping stale counters here is
+ * what prevents a remount or persistence race from dumping the whole batch.
+ */
+export function enqueueEchoChamberMessages(
+  state: EchoChamberQueueState,
+  reactions: Array<{ characterName: string; reaction: string }>,
+  now = Date.now(),
+): EchoChamberQueueState {
+  if (reactions.length === 0) return state;
+
+  const currentMessages = state.messages.slice(-ECHO_CHAMBER_MESSAGE_LIMIT);
+  const visibleBefore = Math.min(Math.max(0, state.visibleCount), currentMessages.length);
+  const baselineBefore = Math.min(Math.max(0, state.baseline), currentMessages.length);
+  const incoming = reactions.map((reaction, index) => ({
+    characterName: reaction.characterName,
+    reaction: reaction.reaction,
+    timestamp: now + index,
+  }));
+  const uncapped = [...currentMessages, ...incoming];
+  const droppedCount = Math.max(0, uncapped.length - ECHO_CHAMBER_MESSAGE_LIMIT);
+
+  return {
+    messages: uncapped.slice(-ECHO_CHAMBER_MESSAGE_LIMIT),
+    visibleCount: Math.max(0, visibleBefore - droppedCount),
+    baseline: Math.max(0, baselineBefore - droppedCount),
+  };
+}
+
+/**
+ * Persisted reactions from before the request began are history and can appear
+ * immediately. Rows created while that request was in flight belong to the
+ * just-finished agent batch and must remain queued for staggered reveal.
+ */
+export function resolveEchoChamberPersistedBaseline(
+  messages: EchoChamberMessage[],
+  loadStartedAt: number,
+): number {
+  return messages.filter(
+    (message) => !Number.isFinite(message.timestamp) || message.timestamp < loadStartedAt,
+  ).length;
+}

--- a/packages/client/src/stores/agent.store.ts
+++ b/packages/client/src/stores/agent.store.ts
@@ -2,6 +2,11 @@
 // Zustand Store: Agent Slice
 // ──────────────────────────────────────────────
 import { create } from "zustand";
+import {
+  ECHO_CHAMBER_MESSAGE_LIMIT,
+  enqueueEchoChamberMessages,
+  type EchoChamberMessage,
+} from "../lib/echo-chamber-queue";
 import type {
   AgentCallDebugEvent,
   AgentResult,
@@ -109,11 +114,7 @@ interface AgentState {
     content: string;
     timestamp: number;
   }>;
-  echoMessages: Array<{
-    characterName: string;
-    reaction: string;
-    timestamp: number;
-  }>;
+  echoMessages: EchoChamberMessage[];
   /** How many echo messages are currently revealed (stagger counter) */
   echoVisibleCount: number;
   /** Baseline: messages at or below this count are shown without stagger */
@@ -160,6 +161,7 @@ interface AgentState {
   dismissThoughtBubble: (index: number) => void;
   clearThoughtBubbles: () => void;
   addEchoMessage: (characterName: string, reaction: string) => void;
+  enqueueEchoMessages: (reactions: Array<{ characterName: string; reaction: string }>) => void;
   setEchoMessages: (messages: Array<{ characterName: string; reaction: string; timestamp: number }>) => void;
   clearEchoMessages: () => void;
   setEchoVisibleCount: (count: number) => void;
@@ -334,11 +336,48 @@ export const useAgentStore = create<AgentState>((set, get) => ({
   clearThoughtBubbles: () => set({ thoughtBubbles: [] }),
 
   addEchoMessage: (characterName, reaction) =>
-    set((s) => ({
-      echoMessages: [...s.echoMessages, { characterName, reaction, timestamp: Date.now() }].slice(-500),
-    })),
+    set((s) => {
+      const queued = enqueueEchoChamberMessages(
+        {
+          messages: s.echoMessages,
+          visibleCount: s.echoVisibleCount,
+          baseline: s.echoBaseline,
+        },
+        [{ characterName, reaction }],
+      );
+      return {
+        echoMessages: queued.messages,
+        echoVisibleCount: queued.visibleCount,
+        echoBaseline: queued.baseline,
+      };
+    }),
 
-  setEchoMessages: (messages) => set({ echoMessages: messages.slice(-500) }),
+  enqueueEchoMessages: (reactions) =>
+    set((s) => {
+      const queued = enqueueEchoChamberMessages(
+        {
+          messages: s.echoMessages,
+          visibleCount: s.echoVisibleCount,
+          baseline: s.echoBaseline,
+        },
+        reactions,
+      );
+      return {
+        echoMessages: queued.messages,
+        echoVisibleCount: queued.visibleCount,
+        echoBaseline: queued.baseline,
+      };
+    }),
+
+  setEchoMessages: (messages) =>
+    set((state) => {
+      const nextMessages = messages.slice(-ECHO_CHAMBER_MESSAGE_LIMIT);
+      return {
+        echoMessages: nextMessages,
+        echoVisibleCount: Math.min(state.echoVisibleCount, nextMessages.length),
+        echoBaseline: Math.min(state.echoBaseline, nextMessages.length),
+      };
+    }),
 
   clearEchoMessages: () => set({ echoMessages: [], echoVisibleCount: 0, echoBaseline: 0, echoLoadedChatId: null }),
 

--- a/packages/client/src/stores/ui.store.ts
+++ b/packages/client/src/stores/ui.store.ts
@@ -477,6 +477,8 @@ interface UIState {
   gameAssetsBrowserOpen: boolean;
   /** When true, the main area shows the Noodle social timeline */
   noodleOpen: boolean;
+  /** Last persona selected inside Noodle, persisted per browser. */
+  noodleSelectedPersonaId: string | null;
   /** When true, the main area shows the full-page character library */
   characterLibraryOpen: boolean;
   /** Last selected character card inside the full-page character library */
@@ -827,6 +829,7 @@ interface UIState {
   closeGameAssetsBrowser: () => void;
   openNoodle: () => void;
   closeNoodle: () => void;
+  setNoodleSelectedPersonaId: (id: string | null) => void;
 
   /** Returns true if any full-page detail editor is currently open */
   hasAnyDetailOpen: () => boolean;
@@ -1191,6 +1194,7 @@ export const useUIStore = create<UIState>()(
       botBrowserOpen: false,
       gameAssetsBrowserOpen: false,
       noodleOpen: false,
+      noodleSelectedPersonaId: null,
       characterLibraryOpen: false,
       characterLibrarySelectedId: null,
       characterLibrarySort: "name-asc" as CharacterLibrarySort,
@@ -1727,6 +1731,7 @@ export const useUIStore = create<UIState>()(
           ...(window.innerWidth < 768 && { rightPanelOpen: false }),
         }),
       closeNoodle: () => set({ noodleOpen: false }),
+      setNoodleSelectedPersonaId: (id) => set({ noodleSelectedPersonaId: id }),
 
       hasAnyDetailOpen: () => {
         const s = get();
@@ -2587,6 +2592,7 @@ export const useUIStore = create<UIState>()(
         botBrowserOpen: state.botBrowserOpen,
         gameAssetsBrowserOpen: state.gameAssetsBrowserOpen,
         noodleOpen: state.noodleOpen,
+        noodleSelectedPersonaId: state.noodleSelectedPersonaId,
         characterLibraryOpen: state.characterLibraryOpen,
         characterLibrarySelectedId: state.characterLibrarySelectedId,
         characterLibrarySort: state.characterLibrarySort,

--- a/packages/server/src/routes/conversation-calls.routes.ts
+++ b/packages/server/src/routes/conversation-calls.routes.ts
@@ -33,6 +33,8 @@ import { createLorebooksStorage } from "../services/storage/lorebooks.storage.js
 import { createAgentsStorage } from "../services/storage/agents.storage.js";
 import { createCustomEmojisStorage } from "../services/storage/custom-emojis.storage.js";
 import { createGalleryStorage } from "../services/storage/gallery.storage.js";
+import { createCharacterGalleryStorage } from "../services/storage/character-gallery.storage.js";
+import { createPersonaGalleryStorage } from "../services/storage/persona-gallery.storage.js";
 import { createPromptOverridesStorage } from "../services/storage/prompt-overrides.storage.js";
 import { createLLMProvider } from "../services/llm/provider-registry.js";
 import { sidecarSpeechService } from "../services/sidecar/sidecar-speech.service.js";
@@ -66,6 +68,7 @@ import { resolveConnectionImageDefaults } from "../services/image/image-generati
 import { loadImageGenerationUserSettings } from "../services/image/image-generation-settings.js";
 import { compileImagePrompt } from "../services/image/image-prompt-compiler.js";
 import { generateImage, saveImageToDisk } from "../services/image/image-generation.js";
+import { persistGeneratedImageToEntityGalleries } from "../services/image/generated-image-entity-gallery.js";
 import { isNovelAiImageConnection, resolveIllustratorCharacterReferences } from "./generate/illustrator-references.js";
 import { getChatHapticIntifaceUrl } from "../services/generation/haptic-runtime.js";
 import { resolveSpotifyCredentials, spotifyHasScope } from "../services/spotify/spotify.service.js";
@@ -1793,6 +1796,17 @@ async function applyCallSelfieCommand(input: {
   const galleryEntry = await createGalleryStorage(input.app.db).create({
     chatId: input.chat.id,
     filePath,
+    prompt: compiledPrompt.prompt,
+    provider: imageConn.provider ?? "image_generation",
+    model: imageConn.model || "unknown",
+    width: selfieW || imageSettings.selfie.width,
+    height: selfieH || imageSettings.selfie.height,
+  });
+  await persistGeneratedImageToEntityGalleries({
+    sourceFilePath: filePath,
+    characterIds: [input.characterId],
+    characterGallery: createCharacterGalleryStorage(input.app.db),
+    personaGallery: createPersonaGalleryStorage(input.app.db),
     prompt: compiledPrompt.prompt,
     provider: imageConn.provider ?? "image_generation",
     model: imageConn.model || "unknown",

--- a/packages/server/src/routes/gallery.routes.ts
+++ b/packages/server/src/routes/gallery.routes.ts
@@ -34,6 +34,7 @@ import { generateImage, saveImageToDisk } from "../services/image/image-generati
 import { resolveConnectionImageDefaults } from "../services/image/image-generation-defaults.js";
 import { loadImageGenerationUserSettings } from "../services/image/image-generation-settings.js";
 import { compileImagePrompt } from "../services/image/image-prompt-compiler.js";
+import { persistGeneratedImageToEntityGalleries } from "../services/image/generated-image-entity-gallery.js";
 import { createLLMProvider } from "../services/llm/provider-registry.js";
 import { getLocalSidecarProvider, LOCAL_SIDECAR_MODEL } from "../services/llm/local-sidecar.js";
 import { resolveConversationSelfieSystemPrompt } from "../services/conversation/selfie-prompt.js";
@@ -1024,6 +1025,17 @@ export async function galleryRoutes(app: FastifyInstance) {
         height,
       });
       if (!image) throw new Error("Generated selfie metadata could not be saved");
+      await persistGeneratedImageToEntityGalleries({
+        sourceFilePath: filePath,
+        characterIds: [character.id],
+        characterGallery,
+        personaGallery,
+        prompt: compiledPrompt.prompt,
+        provider: imageConn.provider ?? "image_generation",
+        model: imageModel || "unknown",
+        width,
+        height,
+      });
       logger.info("[gallery/selfie] Generated selfie for %s in chat %s", characterName, chatId);
       return {
         ...image,

--- a/packages/server/src/routes/generate.routes.ts
+++ b/packages/server/src/routes/generate.routes.ts
@@ -86,6 +86,7 @@ import { resolveConnectionImageDefaults } from "../services/image/image-generati
 import { loadImageGenerationUserSettings } from "../services/image/image-generation-settings.js";
 import { textRewriteDropsProtectedMarkup } from "../services/generation/text-rewrite-safety.js";
 import { compileImagePrompt } from "../services/image/image-prompt-compiler.js";
+import { persistGeneratedImageToEntityGalleries } from "../services/image/generated-image-entity-gallery.js";
 import { extractLeadingThinkingBlocks } from "../services/llm/inline-thinking.js";
 import { buildSpotifyDjConstraints } from "../services/spotify/spotify-dj-constraints.js";
 import {
@@ -7668,49 +7669,48 @@ export async function generateRoutes(app: FastifyInstance) {
                           ? chatMeta.illustratorIncludeCharacterAppearance
                           : illustratorAgent?.settings?.includeCharacterAppearance === true;
                       let illustratorRefImages: string[] | undefined;
-                      if (useAvatarRefs || includeCharacterAppearance) {
-                        const referenceResolution = await resolveIllustratorCharacterReferences({
-                          charactersStore: chars,
-                          chatCharacters: charInfo.map((character) => ({
-                            id: character.id,
-                            name: character.name,
-                            avatarPath: character.avatarPath,
-                            appearance: character.appearance,
-                          })),
-                          persona: persona
-                            ? {
-                                id: personaId,
-                                name: personaName,
-                                avatarPath: persona.avatarPath as string | null,
-                                appearance: personaFields.appearance,
-                              }
-                            : null,
-                          requestedNames: illCharacters.filter((name): name is string => typeof name === "string"),
-                          promptText: [
-                            imagePrompt,
-                            style,
-                            typeof illData.reason === "string" ? illData.reason : "",
-                            combinedResponse,
-                          ].join("\n"),
-                          fallbackToChatCharacters: false,
-                        });
-                        if (includeCharacterAppearance && referenceResolution.appearanceBlock) {
-                          fullPrompt += `\n\n${referenceResolution.appearanceBlock}`;
-                          logger.debug(
-                            "[illustrator] Added character appearance notes for: %s",
-                            referenceResolution.appearanceNames.join(", "),
-                          );
-                        }
-                        if (useAvatarRefs && referenceResolution.referenceImages.length > 0) {
-                          illustratorRefImages = referenceResolution.referenceImages;
-                          if (referenceResolution.referenceLine && !suppressReferencePromptLine)
-                            fullPrompt += `\n\n${referenceResolution.referenceLine}`;
-                          logger.debug(
-                            "[illustrator] Sending %d character reference(s) for: %s",
-                            referenceResolution.referenceImages.length,
-                            referenceResolution.referenceNames.join(", "),
-                          );
-                        }
+                      const referenceResolution = await resolveIllustratorCharacterReferences({
+                        charactersStore: chars,
+                        chatCharacters: charInfo.map((character) => ({
+                          id: character.id,
+                          name: character.name,
+                          avatarPath: character.avatarPath,
+                          appearance: character.appearance,
+                        })),
+                        persona: persona
+                          ? {
+                              id: personaId,
+                              name: personaName,
+                              avatarPath: persona.avatarPath as string | null,
+                              appearance: personaFields.appearance,
+                            }
+                          : null,
+                        requestedNames: illCharacters.filter((name): name is string => typeof name === "string"),
+                        promptText: [
+                          imagePrompt,
+                          style,
+                          typeof illData.reason === "string" ? illData.reason : "",
+                          combinedResponse,
+                        ].join("\n"),
+                        fallbackToChatCharacters: false,
+                        includeReferenceImages: useAvatarRefs,
+                      });
+                      if (includeCharacterAppearance && referenceResolution.appearanceBlock) {
+                        fullPrompt += `\n\n${referenceResolution.appearanceBlock}`;
+                        logger.debug(
+                          "[illustrator] Added character appearance notes for: %s",
+                          referenceResolution.appearanceNames.join(", "),
+                        );
+                      }
+                      if (useAvatarRefs && referenceResolution.referenceImages.length > 0) {
+                        illustratorRefImages = referenceResolution.referenceImages;
+                        if (referenceResolution.referenceLine && !suppressReferencePromptLine)
+                          fullPrompt += `\n\n${referenceResolution.referenceLine}`;
+                        logger.debug(
+                          "[illustrator] Sending %d character reference(s) for: %s",
+                          referenceResolution.referenceImages.length,
+                          referenceResolution.referenceNames.join(", "),
+                        );
                       }
 
                       const compiledPrompt = compileImagePrompt({
@@ -7749,6 +7749,18 @@ export async function generateRoutes(app: FastifyInstance) {
                         filePath,
                         prompt: fullPrompt,
                         provider: "image_generation",
+                        model: imgModel || "unknown",
+                        width: imgWidth,
+                        height: imgHeight,
+                      });
+                      await persistGeneratedImageToEntityGalleries({
+                        sourceFilePath: filePath,
+                        characterIds: referenceResolution.characterIds,
+                        personaIds: referenceResolution.personaId ? [referenceResolution.personaId] : [],
+                        characterGallery,
+                        personaGallery,
+                        prompt: fullPrompt,
+                        provider: imgConnFull.provider ?? "image_generation",
                         model: imgModel || "unknown",
                         width: imgWidth,
                         height: imgHeight,

--- a/packages/server/src/routes/generate.routes.ts
+++ b/packages/server/src/routes/generate.routes.ts
@@ -91,7 +91,8 @@ import { buildSpotifyDjConstraints } from "../services/spotify/spotify-dj-constr
 import {
   assemblePrompt,
   buildPromptMacroContext,
-  collectCharacterDepthPromptEntries,
+  collectCharacterAdvancedPromptEntries,
+  resolveCharacterAdvancedPromptIds,
   resolveCharacterMacroData,
   resolveMacrosWithVariableSnapshot,
   resolvePromptIdleDuration,
@@ -1419,6 +1420,7 @@ export async function generateRoutes(app: FastifyInstance) {
         const lorebookScopeExclusions = resolveLorebookScopeExclusions(chatMode, chatMeta);
         let lorebookScanSnapshot: LorebookScanSnapshot = emptyLorebookScanSnapshot();
         let presetHandledLorebooks = false;
+        let characterAdvancedPromptsInjected = false;
         const presetHasLorebookMarker = (sections: Array<{ isMarker: string; markerConfig: string | null }>) =>
           sections.some((section) => {
             if (section.isMarker !== "true" || !section.markerConfig) return false;
@@ -1443,6 +1445,11 @@ export async function generateRoutes(app: FastifyInstance) {
             ? input.forCharacterId
             : null;
         const promptCharacterIds = resolvePromptCharacterIdsForTarget(characterIds, promptTargetCharacterId);
+        const characterAdvancedPromptIds = resolveCharacterAdvancedPromptIds(
+          promptCharacterIds,
+          chatMode,
+          chatMeta,
+        );
         const deferCharacterMacros =
           characterIds.length > 1 &&
           promptGroupChatMode === "individual" &&
@@ -1569,6 +1576,19 @@ export async function generateRoutes(app: FastifyInstance) {
             })),
             input,
           );
+        const injectCharacterAdvancedPrompts = async () => {
+          if (characterAdvancedPromptsInjected) return;
+          const entries = await collectCharacterAdvancedPromptEntries(
+            app.db,
+            characterAdvancedPromptIds,
+            promptMacroContext,
+            wrapFormat,
+          );
+          if (entries.length > 0) {
+            finalMessages = injectAtDepth(finalMessages, entries);
+          }
+          characterAdvancedPromptsInjected = true;
+        };
         let promptScopedLorebookIdSetPromise: Promise<Set<string>> | null = null;
         const getPromptScopedLorebookIdSet = () => {
           promptScopedLorebookIdSetPromise ??= (async () => {
@@ -1758,6 +1778,7 @@ export async function generateRoutes(app: FastifyInstance) {
             knowledgeRouterActivationPassCompleted = true;
           }
           finalMessages = assembled.messages;
+          characterAdvancedPromptsInjected = true;
           temperature = assembled.parameters.temperature;
           maxTokens = assembled.parameters.maxTokens;
           topP = assembled.parameters.topP ?? 1;
@@ -2257,15 +2278,8 @@ export async function generateRoutes(app: FastifyInstance) {
           }
         }
 
-        if (!presetId && chatMode !== "game") {
-          const characterDepthEntries = await collectCharacterDepthPromptEntries(
-            app.db,
-            promptCharacterIds,
-            promptMacroContext,
-          );
-          if (characterDepthEntries.length > 0) {
-            finalMessages = injectAtDepth(finalMessages, characterDepthEntries);
-          }
+        if (chatMode !== "game") {
+          await injectCharacterAdvancedPrompts();
         }
 
         // ── Author's Notes injection ──
@@ -2620,6 +2634,11 @@ export async function generateRoutes(app: FastifyInstance) {
               finalMessages = injectAtDepth(finalMessages, lorebookResult.depthEntries);
             }
           }
+
+          // Game bypasses the preset assembler, so card-authored depth and
+          // post-history instructions must be injected explicitly before the
+          // final GM format reminder claims the generation tail.
+          await injectCharacterAdvancedPrompts();
 
           // LOG_LEVEL=debug or Settings -> Advanced -> Debug mode: log game-mode prompt details.
           if (isDebug || requestDebug) {

--- a/packages/server/src/routes/generate/dry-run-route.ts
+++ b/packages/server/src/routes/generate/dry-run-route.ts
@@ -27,7 +27,8 @@ import { getLocalSidecarProvider } from "../../services/llm/local-sidecar.js";
 import {
   assemblePrompt,
   buildPromptMacroContext,
-  collectCharacterDepthPromptEntries,
+  collectCharacterAdvancedPromptEntries,
+  resolveCharacterAdvancedPromptIds,
   resolveCharacterMacroData,
   resolveMacrosWithVariableSnapshot,
   resolvePromptIdleDuration,
@@ -1413,13 +1414,19 @@ export async function registerDryRunRoute(app: FastifyInstance) {
     }
 
     if (usePromptParts || !effectivePresetId) {
-      const characterDepthEntries = await collectCharacterDepthPromptEntries(
-        app.db,
+      const characterAdvancedPromptIds = resolveCharacterAdvancedPromptIds(
         promptCharacterIds,
-        promptMacroContext,
+        chatMode,
+        chatMeta,
       );
-      if (characterDepthEntries.length > 0) {
-        finalMessages = injectAtDepth(finalMessages as any, characterDepthEntries) as any;
+      const characterAdvancedPromptEntries = await collectCharacterAdvancedPromptEntries(
+        app.db,
+        characterAdvancedPromptIds,
+        promptMacroContext,
+        wrapFormat,
+      );
+      if (characterAdvancedPromptEntries.length > 0) {
+        finalMessages = injectAtDepth(finalMessages as any, characterAdvancedPromptEntries) as any;
       }
     }
 

--- a/packages/server/src/routes/generate/illustrator-references.ts
+++ b/packages/server/src/routes/generate/illustrator-references.ts
@@ -33,6 +33,8 @@ export type IllustratorChatCharacterReference = {
 };
 
 export type IllustratorReferenceResolution = {
+  characterIds: string[];
+  personaId: string | null;
   referenceImages: string[];
   referenceNames: string[];
   referenceLine: string | null;
@@ -182,6 +184,7 @@ export async function resolveIllustratorCharacterReferences(args: {
   promptText: string;
   fallbackToChatCharacters?: boolean;
   maxReferences?: number;
+  includeReferenceImages?: boolean;
 }): Promise<IllustratorReferenceResolution> {
   const maxReferences = Math.max(1, Math.min(args.maxReferences ?? MAX_ILLUSTRATOR_REFERENCE_IMAGES, 12));
   const allRows = await args.charactersStore.list().catch(() => []);
@@ -265,13 +268,19 @@ export async function resolveIllustratorCharacterReferences(args: {
   }
 
   for (const source of orderedSources) {
+    if (args.includeReferenceImages === false) continue;
     const b64 = readBestReferenceImage(source.id, source.avatarPath);
     if (!b64) continue;
     referenceImages.push(b64);
     referenceNames.push(source.name);
   }
 
-  if (args.persona && personaRequested && referenceImages.length < maxReferences) {
+  if (
+    args.includeReferenceImages !== false &&
+    args.persona &&
+    personaRequested &&
+    referenceImages.length < maxReferences
+  ) {
     const b64 = readBestReferenceImage(args.persona.id, args.persona.avatarPath ?? null);
     if (b64) {
       referenceImages.push(b64);
@@ -283,6 +292,8 @@ export async function resolveIllustratorCharacterReferences(args: {
   }
 
   return {
+    characterIds: orderedSources.map((source) => source.id),
+    personaId: args.persona && personaRequested ? args.persona.id : null,
     referenceImages,
     referenceNames,
     referenceLine:

--- a/packages/server/src/routes/generate/illustrator-references.ts
+++ b/packages/server/src/routes/generate/illustrator-references.ts
@@ -248,9 +248,8 @@ export async function resolveIllustratorCharacterReferences(args: {
     }
   }
 
-  const orderedSources = [...selected.values()]
-    .sort((a, b) => a.sourceOrder - b.sourceOrder)
-    .slice(0, maxReferences);
+  const orderedSelectedSources = [...selected.values()].sort((a, b) => a.sourceOrder - b.sourceOrder);
+  const orderedSources = orderedSelectedSources.slice(0, maxReferences);
   const referenceImages: string[] = [];
   const referenceNames: string[] = [];
   const appearanceLines: string[] = [];
@@ -292,7 +291,10 @@ export async function resolveIllustratorCharacterReferences(args: {
   }
 
   return {
-    characterIds: orderedSources.map((source) => source.id),
+    // Gallery persistence is not constrained by the reference-image cap: every
+    // depicted character should receive the generated image even when only the
+    // first few likeness references can be sent to the provider.
+    characterIds: orderedSelectedSources.map((source) => source.id),
     personaId: args.persona && personaRequested ? args.persona.id : null,
     referenceImages,
     referenceNames,

--- a/packages/server/src/routes/generate/retry-agents-route.ts
+++ b/packages/server/src/routes/generate/retry-agents-route.ts
@@ -57,12 +57,15 @@ import { createAgentsStorage } from "../../services/storage/agents.storage.js";
 import { createCharactersStorage } from "../../services/storage/characters.storage.js";
 import { createChatsStorage } from "../../services/storage/chats.storage.js";
 import { createConnectionsStorage } from "../../services/storage/connections.storage.js";
+import { createCharacterGalleryStorage } from "../../services/storage/character-gallery.storage.js";
+import { createPersonaGalleryStorage } from "../../services/storage/persona-gallery.storage.js";
 import { createPromptsStorage } from "../../services/storage/prompts.storage.js";
 import { findLastUserMessageIdBefore } from "../../services/generation/message-history.js";
 import { textRewriteDropsProtectedMarkup } from "../../services/generation/text-rewrite-safety.js";
 import { resolveConnectionImageDefaults } from "../../services/image/image-generation-defaults.js";
 import { loadImageGenerationUserSettings } from "../../services/image/image-generation-settings.js";
 import { compileImagePrompt } from "../../services/image/image-prompt-compiler.js";
+import { persistGeneratedImageToEntityGalleries } from "../../services/image/generated-image-entity-gallery.js";
 import { createGameStateStorage } from "../../services/storage/game-state.storage.js";
 import { createLorebooksStorage } from "../../services/storage/lorebooks.storage.js";
 import { syncGameMapMetaPartyPosition } from "../../services/game/map-position.service.js";
@@ -2960,51 +2963,50 @@ async function applyRetryResultEffects(args: {
                 ? chatMeta.illustratorIncludeCharacterAppearance
                 : illustratorAgent?.resolved.settings?.includeCharacterAppearance === true;
             let referenceImages: string[] | undefined;
-            if (useAvatarRefs || includeCharacterAppearance) {
-              const referenceResolution = await resolveIllustratorCharacterReferences({
-                charactersStore: chars,
-                chatCharacters: agentContext.characters.map((character) => ({
-                  id: character.id,
-                  name: character.name,
-                  appearance: character.appearance,
-                })),
-                persona: agentContext.persona
-                  ? {
-                      id: typeof agentContext.memory._personaId === "string" ? agentContext.memory._personaId : null,
-                      name: agentContext.persona.name,
-                      avatarPath:
-                        typeof agentContext.memory._personaAvatarPath === "string"
-                          ? agentContext.memory._personaAvatarPath
-                          : null,
-                      appearance: agentContext.persona.appearance,
-                    }
-                  : null,
-                requestedNames: illCharacters.filter((name): name is string => typeof name === "string"),
-                promptText: [
-                  imagePrompt,
-                  style,
-                  typeof illData.reason === "string" ? illData.reason : "",
-                  agentContext.mainResponse ?? "",
-                ].join("\n"),
-                fallbackToChatCharacters: false,
-              });
-              if (includeCharacterAppearance && referenceResolution.appearanceBlock) {
-                fullPrompt += `\n\n${referenceResolution.appearanceBlock}`;
-                logger.debug(
-                  "[retry-agents] Illustrator added character appearance notes for: %s",
-                  referenceResolution.appearanceNames.join(", "),
-                );
-              }
-              if (useAvatarRefs && referenceResolution.referenceImages.length > 0) {
-                referenceImages = referenceResolution.referenceImages;
-                if (referenceResolution.referenceLine && !suppressReferencePromptLine)
-                  fullPrompt += `\n\n${referenceResolution.referenceLine}`;
-                logger.debug(
-                  "[retry-agents] Illustrator sending %d character reference(s) for: %s",
-                  referenceResolution.referenceImages.length,
-                  referenceResolution.referenceNames.join(", "),
-                );
-              }
+            const referenceResolution = await resolveIllustratorCharacterReferences({
+              charactersStore: chars,
+              chatCharacters: agentContext.characters.map((character) => ({
+                id: character.id,
+                name: character.name,
+                appearance: character.appearance,
+              })),
+              persona: agentContext.persona
+                ? {
+                    id: typeof agentContext.memory._personaId === "string" ? agentContext.memory._personaId : null,
+                    name: agentContext.persona.name,
+                    avatarPath:
+                      typeof agentContext.memory._personaAvatarPath === "string"
+                        ? agentContext.memory._personaAvatarPath
+                        : null,
+                    appearance: agentContext.persona.appearance,
+                  }
+                : null,
+              requestedNames: illCharacters.filter((name): name is string => typeof name === "string"),
+              promptText: [
+                imagePrompt,
+                style,
+                typeof illData.reason === "string" ? illData.reason : "",
+                agentContext.mainResponse ?? "",
+              ].join("\n"),
+              fallbackToChatCharacters: false,
+              includeReferenceImages: useAvatarRefs,
+            });
+            if (includeCharacterAppearance && referenceResolution.appearanceBlock) {
+              fullPrompt += `\n\n${referenceResolution.appearanceBlock}`;
+              logger.debug(
+                "[retry-agents] Illustrator added character appearance notes for: %s",
+                referenceResolution.appearanceNames.join(", "),
+              );
+            }
+            if (useAvatarRefs && referenceResolution.referenceImages.length > 0) {
+              referenceImages = referenceResolution.referenceImages;
+              if (referenceResolution.referenceLine && !suppressReferencePromptLine)
+                fullPrompt += `\n\n${referenceResolution.referenceLine}`;
+              logger.debug(
+                "[retry-agents] Illustrator sending %d character reference(s) for: %s",
+                referenceResolution.referenceImages.length,
+                referenceResolution.referenceNames.join(", "),
+              );
             }
 
             const compiledPrompt = compileImagePrompt({
@@ -3039,6 +3041,18 @@ async function applyRetryResultEffects(args: {
               filePath,
               prompt: compiledPrompt.prompt,
               provider: "image_generation",
+              model: imgModel || "unknown",
+              width: imgWidth,
+              height: imgHeight,
+            });
+            await persistGeneratedImageToEntityGalleries({
+              sourceFilePath: filePath,
+              characterIds: referenceResolution.characterIds,
+              personaIds: referenceResolution.personaId ? [referenceResolution.personaId] : [],
+              characterGallery: createCharacterGalleryStorage(app.db),
+              personaGallery: createPersonaGalleryStorage(app.db),
+              prompt: compiledPrompt.prompt,
+              provider: imgConnFull.provider ?? "image_generation",
               model: imgModel || "unknown",
               width: imgWidth,
               height: imgHeight,

--- a/packages/server/src/routes/noodle.routes.ts
+++ b/packages/server/src/routes/noodle.routes.ts
@@ -14,7 +14,6 @@ import {
   noodleBulkInviteSchema,
   noodleCreateInteractionSchema,
   noodleCreatePostSchema,
-  noodleGeneratedProfilesSchema,
   noodleGeneratedRefreshSchema,
   noodleInviteSchema,
   noodleInteractionOwnerSchema,
@@ -84,6 +83,7 @@ import {
 } from "../services/noodle/noodle-vision.js";
 import { chooseNoodleParticipantAccounts } from "../services/noodle/noodle-participant-selection.js";
 import { canCreateGeneratedNoodleInteraction } from "../services/noodle/noodle-interaction-policy.js";
+import { parseNoodleGeneratedProfiles } from "../services/noodle/noodle-generated-profiles.js";
 
 const NOODLE_ROUTE_DIR = dirname(fileURLToPath(import.meta.url));
 const CLIENT_PUBLIC_DIR = resolve(NOODLE_ROUTE_DIR, "../../../client/public");
@@ -412,6 +412,7 @@ async function ensureProfessorMariAccount(
     avatarCrop: row ? characterAvatarCrop(row) : null,
     bio: PROFESSOR_MARI_NOODLE_BIO,
     invited: true,
+    syncIdentity: true,
   });
   if (account.bio !== PROFESSOR_MARI_NOODLE_BIO || !isProfileGenerated(account) || !account.settings.location) {
     await noodle.updateAccount(account.id, {
@@ -448,6 +449,7 @@ async function ensureSelectedGroupCharacterAccounts(
       avatarUrl: row.avatarPath ?? null,
       avatarCrop: characterAvatarCrop(row),
       bio: String(parseRecord(row.data).description ?? ""),
+      syncIdentity: true,
     });
   }
   return selectedCharacterIds;
@@ -489,6 +491,22 @@ async function bootstrapVisibleNoodle(
 ) {
   const livePersonaIds = await ensurePersonaAccounts(noodle, characters);
   await ensureProfessorMariAccount(noodle, characters);
+  const existingCharacterAccounts = (await noodle.listAccounts()).filter(
+    (account) => account.kind === "character" && account.entityId !== PROFESSOR_MARI_ID,
+  );
+  const characterRowsById = new Map((await characters.list()).map((row) => [row.id, row]));
+  for (const account of existingCharacterAccounts) {
+    const row = characterRowsById.get(account.entityId);
+    if (!row) continue;
+    await noodle.upsertAccountFromProfile({
+      kind: "character",
+      entityId: row.id,
+      displayName: characterNameFromRow(row),
+      avatarUrl: row.avatarPath ?? null,
+      avatarCrop: characterAvatarCrop(row),
+      syncIdentity: true,
+    });
+  }
   return filterStalePersonaAccounts(await noodle.bootstrap(), livePersonaIds);
 }
 
@@ -941,7 +959,13 @@ async function generateMissingNoodleProfiles(input: {
     debugMode: input.debugMode,
     responseFormat: noodleResponseFormat(input.connection.model, "profiles"),
   });
-  const generated = noodleGeneratedProfilesSchema.parse(parseGameJsonish(result.content ?? ""));
+  const generated = parseNoodleGeneratedProfiles(parseGameJsonish(result.content ?? ""));
+  if (generated.rejected.length > 0) {
+    logger.warn(
+      "[noodle] Skipped %d invalid generated profile row(s); valid profiles will still be applied",
+      generated.rejected.length,
+    );
+  }
   const profileByEntityId = new Map(generated.profiles.map((profile) => [profile.entityId, profile]));
 
   for (const target of targets) {
@@ -1209,6 +1233,7 @@ export async function noodleRoutes(app: FastifyInstance) {
       avatarCrop: characterAvatarCrop(row),
       bio: String(parseRecord(row.data).description ?? ""),
       invited: true,
+      syncIdentity: true,
     });
   });
 
@@ -1229,6 +1254,7 @@ export async function noodleRoutes(app: FastifyInstance) {
           avatarCrop: characterAvatarCrop(row),
           bio: String(parseRecord(row.data).description ?? ""),
           invited: true,
+          syncIdentity: true,
         }),
       );
     }

--- a/packages/server/src/services/generation/character-prompt-context.ts
+++ b/packages/server/src/services/generation/character-prompt-context.ts
@@ -254,15 +254,17 @@ export function injectIdentityFallbackMessages(args: {
         ? `Conversation display name: ${sanitizePromptLeaf(convoName, args.wrapFormat)}\n`
         : "";
 
-    const fieldsToInject = namedProfilePresent
-      ? []
-      : CHARACTER_FALLBACK_FIELDS.flatMap((field) => {
-          const value = resolvedFields[field.key];
-          if (!value.trim()) return [];
-          if (sourceReferencesAnyMacro(promptTemplateSources, field.macroAliases)) return [];
-          if (contentIncludesResolvedField(allContent, value)) return [];
-          return [{ label: field.label, value }];
-        });
+    const fieldsToInject = CHARACTER_FALLBACK_FIELDS.flatMap((field) => {
+      // A custom Conversation prompt may already provide a named profile while
+      // omitting the card's Advanced System Prompt. Preserve the custom profile,
+      // but never let its presence suppress character-authored instructions.
+      if (namedProfilePresent && field.key !== "systemPrompt") return [];
+      const value = resolvedFields[field.key];
+      if (!value.trim()) return [];
+      if (sourceReferencesAnyMacro(promptTemplateSources, field.macroAliases)) return [];
+      if (contentIncludesResolvedField(allContent, value)) return [];
+      return [{ label: field.label, value }];
+    });
     const fieldParts = wrapFieldEntries(fieldsToInject, args.wrapFormat);
     if (fieldParts.length === 0 && !convoNameLine) continue;
 

--- a/packages/server/src/services/generation/conversation-selfie-command-runtime.ts
+++ b/packages/server/src/services/generation/conversation-selfie-command-runtime.ts
@@ -5,6 +5,7 @@ import {
   resolveIllustratorCharacterReferences,
 } from "../../routes/generate/illustrator-references.js";
 import { compileImagePrompt } from "../image/image-prompt-compiler.js";
+import { persistGeneratedImageToEntityGalleries } from "../image/generated-image-entity-gallery.js";
 import { resolveConnectionImageDefaults } from "../image/image-generation-defaults.js";
 import { generateImage, saveImageToDisk } from "../image/image-generation.js";
 import { loadImageGenerationUserSettings } from "../image/image-generation-settings.js";
@@ -12,6 +13,8 @@ import { createLLMProvider } from "../llm/provider-registry.js";
 import { resolveConversationSelfieSystemPrompt } from "../conversation/selfie-prompt.js";
 import type { CharacterCommand, SelfieCommand } from "../conversation/character-commands.js";
 import { createGalleryStorage } from "../storage/gallery.storage.js";
+import { createCharacterGalleryStorage } from "../storage/character-gallery.storage.js";
+import { createPersonaGalleryStorage } from "../storage/persona-gallery.storage.js";
 import { createPromptOverridesStorage } from "../storage/prompt-overrides.storage.js";
 
 type CharactersStore = {
@@ -249,6 +252,17 @@ async function generateSelfie(args: Parameters<typeof handleConversationSelfieCo
   const galleryEntry = await galleryStore.create({
     chatId: args.chatId,
     filePath,
+    prompt: compiledSelfiePrompt.prompt,
+    provider: imgConnFull.provider ?? "image_generation",
+    model: imgModel || "unknown",
+    width: selfieW || imageSettings.selfie.width,
+    height: selfieH || imageSettings.selfie.height,
+  });
+  await persistGeneratedImageToEntityGalleries({
+    sourceFilePath: filePath,
+    characterIds: args.characterId ? [args.characterId] : [],
+    characterGallery: createCharacterGalleryStorage(args.db),
+    personaGallery: createPersonaGalleryStorage(args.db),
     prompt: compiledSelfiePrompt.prompt,
     provider: imgConnFull.provider ?? "image_generation",
     model: imgModel || "unknown",

--- a/packages/server/src/services/generation/game-gm-prompt-runtime.ts
+++ b/packages/server/src/services/generation/game-gm-prompt-runtime.ts
@@ -108,10 +108,12 @@ function buildLibraryCardParts(data: any, fallbackName = "Unknown"): { name: str
   const description = cardPromptText(data.description);
   const backstory = cardPromptText(data.extensions?.backstory || data.backstory);
   const appearance = cardPromptText(data.extensions?.appearance || data.appearance);
+  const systemPrompt = cardPromptText(data.system_prompt);
   if (personality) parts.push(`Personality: ${personality}`);
   if (description) parts.push(`Description: ${description}`);
   if (backstory) parts.push(`Backstory: ${backstory}`);
   if (appearance) parts.push(`Appearance: ${appearance}`);
+  if (systemPrompt) parts.push(`Character System Instructions: ${systemPrompt}`);
   return { name, parts };
 }
 

--- a/packages/server/src/services/image/generated-image-entity-gallery.ts
+++ b/packages/server/src/services/image/generated-image-entity-gallery.ts
@@ -1,0 +1,115 @@
+import { copyFileSync, existsSync, mkdirSync, renameSync, unlinkSync } from "node:fs";
+import { extname, join } from "node:path";
+import { logger } from "../../lib/logger.js";
+import { newId } from "../../utils/id-generator.js";
+import { DATA_DIR } from "../../utils/data-dir.js";
+import { assertInsideDir } from "../../utils/security.js";
+import type { CreateCharacterImageInput } from "../storage/character-gallery.storage.js";
+import type { CreatePersonaImageInput } from "../storage/persona-gallery.storage.js";
+
+type CharacterGalleryStore = {
+  create(input: CreateCharacterImageInput): Promise<unknown>;
+};
+type PersonaGalleryStore = {
+  create(input: CreatePersonaImageInput): Promise<unknown>;
+};
+
+export type GeneratedImageEntityGalleryInput = {
+  sourceFilePath: string;
+  characterIds?: string[];
+  personaIds?: string[];
+  characterGallery: CharacterGalleryStore;
+  personaGallery: PersonaGalleryStore;
+  prompt: string;
+  provider: string;
+  model: string;
+  width: number;
+  height: number;
+  /** Test-only filesystem override. */
+  galleryRoot?: string;
+};
+
+function safeEntityIds(ids: string[] | undefined): string[] {
+  return Array.from(
+    new Set(
+      (ids ?? []).filter(
+        (id) => id.length > 0 && id !== "." && id !== ".." && !id.includes("/") && !id.includes("\\"),
+      ),
+    ),
+  );
+}
+
+/**
+ * Copy one chat-gallery image into every explicitly depicted character/persona
+ * gallery. Each destination owns its copy, so deleting one gallery item cannot
+ * break the chat attachment or another entity's gallery.
+ */
+export async function persistGeneratedImageToEntityGalleries(
+  input: GeneratedImageEntityGalleryInput,
+): Promise<{ characterCount: number; personaCount: number }> {
+  const galleryRoot = input.galleryRoot ?? join(DATA_DIR, "gallery");
+  const sourcePath = assertInsideDir(galleryRoot, join(galleryRoot, input.sourceFilePath));
+  if (!existsSync(sourcePath)) {
+    logger.warn("[image-gallery] Generated source image is missing: %s", input.sourceFilePath);
+    return { characterCount: 0, personaCount: 0 };
+  }
+
+  const extension = extname(sourcePath).toLowerCase() || ".png";
+  const metadata = {
+    prompt: input.prompt,
+    provider: input.provider,
+    model: input.model,
+    width: input.width,
+    height: input.height,
+  };
+
+  const persistOne = async (
+    kind: "characters" | "personas",
+    entityId: string,
+    createMetadata: (filePath: string) => Promise<unknown>,
+  ): Promise<boolean> => {
+    const entityDir = assertInsideDir(galleryRoot, join(galleryRoot, kind, entityId));
+    if (!existsSync(entityDir)) mkdirSync(entityDir, { recursive: true });
+    const filename = `${newId()}${extension}`;
+    const destinationPath = assertInsideDir(entityDir, join(entityDir, filename));
+    const temporaryPath = assertInsideDir(entityDir, `${destinationPath}.${process.pid}.${Date.now()}.tmp`);
+    try {
+      copyFileSync(sourcePath, temporaryPath);
+      renameSync(temporaryPath, destinationPath);
+      const created = await createMetadata(`${kind}/${entityId}/${filename}`);
+      if (!created) throw new Error("Gallery metadata row was not created");
+      return true;
+    } catch (error) {
+      try {
+        if (existsSync(temporaryPath)) unlinkSync(temporaryPath);
+        if (existsSync(destinationPath)) unlinkSync(destinationPath);
+      } catch {
+        /* best-effort cleanup */
+      }
+      logger.warn(error, "[image-gallery] Could not save generated image for %s %s", kind, entityId);
+      return false;
+    }
+  };
+
+  let characterCount = 0;
+  for (const characterId of safeEntityIds(input.characterIds)) {
+    if (
+      await persistOne("characters", characterId, (filePath) =>
+        input.characterGallery.create({ characterId, filePath, ...metadata }),
+      )
+    ) {
+      characterCount += 1;
+    }
+  }
+  let personaCount = 0;
+  for (const personaId of safeEntityIds(input.personaIds)) {
+    if (
+      await persistOne("personas", personaId, (filePath) =>
+        input.personaGallery.create({ personaId, filePath, ...metadata }),
+      )
+    ) {
+      personaCount += 1;
+    }
+  }
+  return { characterCount, personaCount };
+}

--- a/packages/server/src/services/noodle/noodle-generated-profiles.ts
+++ b/packages/server/src/services/noodle/noodle-generated-profiles.ts
@@ -1,0 +1,37 @@
+import {
+  noodleGeneratedProfileSchema,
+  noodleGeneratedProfilesSchema,
+  type NoodleGeneratedProfile,
+} from "@marinara-engine/shared";
+
+export type RejectedNoodleGeneratedProfile = {
+  index: number;
+  issueCount: number;
+};
+
+/**
+ * Parse model-generated profile rows independently so one malformed account
+ * cannot discard valid profiles from the same Noodle setup batch.
+ */
+export function parseNoodleGeneratedProfiles(value: unknown): {
+  profiles: NoodleGeneratedProfile[];
+  rejected: RejectedNoodleGeneratedProfile[];
+} {
+  const record = value && typeof value === "object" && !Array.isArray(value) ? value as Record<string, unknown> : null;
+  const rawProfiles = record?.profiles;
+  if (!Array.isArray(rawProfiles)) {
+    // Preserve the useful top-level validation error for a wholly malformed
+    // response. Only individual profile failures are recoverable.
+    noodleGeneratedProfilesSchema.parse(value);
+    return { profiles: [], rejected: [] };
+  }
+
+  const profiles: NoodleGeneratedProfile[] = [];
+  const rejected: RejectedNoodleGeneratedProfile[] = [];
+  rawProfiles.forEach((rawProfile, index) => {
+    const parsed = noodleGeneratedProfileSchema.safeParse(rawProfile);
+    if (parsed.success) profiles.push(parsed.data);
+    else rejected.push({ index, issueCount: parsed.error.issues.length });
+  });
+  return { profiles, rejected };
+}

--- a/packages/server/src/services/prompt/assembler.ts
+++ b/packages/server/src/services/prompt/assembler.ts
@@ -27,8 +27,7 @@ import { injectAtDepth } from "../lorebook/prompt-injector.js";
 import type { LorebookScanResult } from "../lorebook/index.js";
 import {
   buildPromptMacroContext,
-  collectCharacterDepthPromptEntries,
-  collectCharacterPostHistoryEntries,
+  collectCharacterAdvancedPromptEntries,
   resolveMacrosWithVariableSnapshot,
 } from "./macro-context.js";
 
@@ -485,19 +484,14 @@ export async function assemblePrompt(input: AssemblerInput): Promise<AssemblerOu
     allDepthEntries.push(markerCtx.lorebookDepthEntries);
   }
 
-  const characterDepthEntries = await collectCharacterDepthPromptEntries(input.db, input.characterIds, macroCtx);
-  if (characterDepthEntries.length > 0) {
-    allDepthEntries.push(characterDepthEntries);
-  }
-
-  const characterPostHistoryEntries = await collectCharacterPostHistoryEntries(
+  const characterAdvancedPromptEntries = await collectCharacterAdvancedPromptEntries(
     input.db,
     input.characterIds,
     macroCtx,
     wrapFormat,
   );
-  if (characterPostHistoryEntries.length > 0) {
-    allDepthEntries.push(characterPostHistoryEntries);
+  if (characterAdvancedPromptEntries.length > 0) {
+    allDepthEntries.push(characterAdvancedPromptEntries);
   }
 
   const combinedDepthEntries = allDepthEntries.flat();

--- a/packages/server/src/services/prompt/index.ts
+++ b/packages/server/src/services/prompt/index.ts
@@ -6,9 +6,11 @@ export { wrapContent, wrapGroup } from "./format-engine.js";
 export { expandMarker, type MarkerContext, type ExpandedMarker } from "./marker-expander.js";
 export {
   buildPromptMacroContext,
+  collectCharacterAdvancedPromptEntries,
   collectCharacterDepthPromptEntries,
   collectCharacterPostHistoryEntries,
   resolvePromptMessageMacros,
+  resolveCharacterAdvancedPromptIds,
   resolvePromptIdleDuration,
   resolvePromptLastGenerationType,
   resolveMacrosWithVariableSnapshot,

--- a/packages/server/src/services/prompt/macro-context.ts
+++ b/packages/server/src/services/prompt/macro-context.ts
@@ -435,3 +435,35 @@ export async function collectCharacterPostHistoryEntries(
 
   return entries;
 }
+
+export async function collectCharacterAdvancedPromptEntries(
+  db: DB,
+  characterIds: string[],
+  macroCtx: MacroContext,
+  wrapFormat: WrapFormat,
+): Promise<PromptDepthEntry[]> {
+  const [depthEntries, postHistoryEntries] = await Promise.all([
+    collectCharacterDepthPromptEntries(db, characterIds, macroCtx),
+    collectCharacterPostHistoryEntries(db, characterIds, macroCtx, wrapFormat),
+  ]);
+  return [...depthEntries, ...postHistoryEntries];
+}
+
+export function resolveCharacterAdvancedPromptIds(
+  characterIds: string[],
+  chatMode: string,
+  chatMetadata: Record<string, unknown>,
+): string[] {
+  const resolved = new Set(characterIds.filter((id) => id && !id.startsWith("npc:")));
+  if (chatMode !== "game") return [...resolved];
+
+  const partyIds = Array.isArray(chatMetadata.gamePartyCharacterIds)
+    ? chatMetadata.gamePartyCharacterIds
+    : [];
+  for (const id of partyIds) {
+    if (typeof id === "string" && id && !id.startsWith("npc:")) resolved.add(id);
+  }
+  const gmCharacterId = chatMetadata.gameGmCharacterId;
+  if (typeof gmCharacterId === "string" && gmCharacterId) resolved.add(gmCharacterId);
+  return [...resolved];
+}

--- a/packages/server/src/services/storage/noodle.storage.ts
+++ b/packages/server/src/services/storage/noodle.storage.ts
@@ -373,13 +373,20 @@ export function createNoodleStorage(db: DB) {
       avatarCrop?: NoodleAvatarCrop | null;
       bio?: string | null;
       invited?: boolean;
+      /** Keep entity-owned identity fields current without replacing generated profile copy. */
+      syncIdentity?: boolean;
     }): Promise<NoodleAccount> {
       const existing = await this.getAccountByEntity(input.kind, input.entityId);
       if (existing) {
         const updates: Record<string, unknown> = { updatedAt: now() };
-        if (!existing.displayName.trim()) updates.displayName = input.displayName || existing.handle;
+        if (input.syncIdentity) {
+          updates.displayName = input.displayName.trim().slice(0, 120) || existing.handle;
+          if (input.avatarUrl !== undefined) updates.avatarUrl = input.avatarUrl;
+        } else if (!existing.displayName.trim()) {
+          updates.displayName = input.displayName || existing.handle;
+        }
         if (!existing.bio.trim() && input.bio) updates.bio = input.bio;
-        if (!existing.avatarUrl && input.avatarUrl) updates.avatarUrl = input.avatarUrl;
+        if (!input.syncIdentity && !existing.avatarUrl && input.avatarUrl) updates.avatarUrl = input.avatarUrl;
         if (input.avatarCrop !== undefined) {
           updates.settings = JSON.stringify({ ...existing.settings, avatarCrop: input.avatarCrop });
         }

--- a/packages/shared/src/schemas/noodle.schema.ts
+++ b/packages/shared/src/schemas/noodle.schema.ts
@@ -300,12 +300,24 @@ export const noodleGeneratedDigestSchema = z.object({
   content: z.string().min(1).max(1200),
 });
 
+function boundedGeneratedProfileText(maxLength: number, minimumLength = 0) {
+  return z
+    .string()
+    .transform((value) => {
+      if (value.length <= maxLength) return value;
+      const truncated = value.slice(0, maxLength);
+      // Avoid leaving a dangling UTF-16 high surrogate when truncating emoji.
+      return /[\uD800-\uDBFF]$/.test(truncated) ? truncated.slice(0, -1) : truncated;
+    })
+    .pipe(z.string().min(minimumLength).max(maxLength));
+}
+
 export const noodleGeneratedProfileSchema = z.object({
   entityId: z.string().min(1),
-  name: z.string().min(1).max(120),
-  handle: z.string().min(1).max(40),
-  bio: z.string().max(500).default(""),
-  location: z.string().max(120).default(""),
+  name: boundedGeneratedProfileText(120, 1),
+  handle: boundedGeneratedProfileText(40, 1),
+  bio: boundedGeneratedProfileText(500).default(""),
+  location: boundedGeneratedProfileText(120).default(""),
 });
 
 export const noodleGeneratedRefreshSchema = z.object({
@@ -336,3 +348,4 @@ export type NoodleRefreshInput = z.infer<typeof noodleRefreshSchema>;
 export type NoodleRescheduleRefreshInput = z.infer<typeof noodleRescheduleRefreshSchema>;
 export type NoodleGeneratedRefresh = z.infer<typeof noodleGeneratedRefreshSchema>;
 export type NoodleGeneratedProfiles = z.infer<typeof noodleGeneratedProfilesSchema>;
+export type NoodleGeneratedProfile = z.infer<typeof noodleGeneratedProfileSchema>;

--- a/scripts/regressions/noodle-prompt.regression.ts
+++ b/scripts/regressions/noodle-prompt.regression.ts
@@ -15,6 +15,7 @@ import {
 } from "../../packages/server/src/services/noodle/noodle-prompt.js";
 import { chooseNoodleParticipantAccounts } from "../../packages/server/src/services/noodle/noodle-participant-selection.js";
 import { canCreateGeneratedNoodleInteraction } from "../../packages/server/src/services/noodle/noodle-interaction-policy.js";
+import { parseNoodleGeneratedProfiles } from "../../packages/server/src/services/noodle/noodle-generated-profiles.js";
 import { collectNoodlePriorityAccountIds } from "../../packages/server/src/routes/noodle.routes.js";
 
 const makeAccount = (id: string): NoodleAccount => ({
@@ -358,5 +359,32 @@ assert.deepEqual(
   sampleNoodlePastMemories(["a", "b", "c", "d"], 99, () => 0),
   ["a", "b", "c"],
 );
+
+const boundedGeneratedProfiles = parseNoodleGeneratedProfiles({
+  profiles: [
+    {
+      entityId: "formatted-character",
+      name: `Who̶̥͛ is…she…?${" very mysterious".repeat(20)}`,
+      handle: "formatted_character_handle_that_is_far_too_long_for_noodle",
+      bio: "bio ".repeat(150),
+      location: "somewhere ".repeat(30),
+    },
+  ],
+});
+assert.equal(boundedGeneratedProfiles.rejected.length, 0);
+assert.equal(boundedGeneratedProfiles.profiles.length, 1);
+assert.ok(boundedGeneratedProfiles.profiles[0]!.name.length <= 120);
+assert.ok(boundedGeneratedProfiles.profiles[0]!.handle.length <= 40);
+assert.ok(boundedGeneratedProfiles.profiles[0]!.bio.length <= 500);
+assert.ok(boundedGeneratedProfiles.profiles[0]!.location.length <= 120);
+
+const partiallyInvalidGeneratedProfiles = parseNoodleGeneratedProfiles({
+  profiles: [
+    { entityId: "invalid", name: "Missing handle" },
+    { entityId: "valid", name: "Valid Character", handle: "valid_character", bio: "", location: "" },
+  ],
+});
+assert.deepEqual(partiallyInvalidGeneratedProfiles.profiles.map((profile) => profile.entityId), ["valid"]);
+assert.deepEqual(partiallyInvalidGeneratedProfiles.rejected, [{ index: 0, issueCount: 1 }]);
 
 console.info("Noodle prompt and memory regression passed.");

--- a/scripts/regressions/noodle-settings.regression.ts
+++ b/scripts/regressions/noodle-settings.regression.ts
@@ -20,6 +20,33 @@ try {
   assert.equal(updated.maxImagesPerRefresh, 9);
   assert.equal(updated.allowRandomUsers, true);
   assert.equal(updated.maxGeneratedPostsPerRefresh, 11);
+  const characterAccount = await firstNoodle.upsertAccountFromProfile({
+    kind: "character",
+    entityId: "renamed-character",
+    displayName: "Old Card Name",
+    avatarUrl: "/old-avatar.png",
+    bio: "Generated Noodle biography",
+    invited: true,
+    syncIdentity: true,
+  });
+  await firstNoodle.updateAccount(characterAccount.id, {
+    displayName: "Generated Social Name",
+    handle: "custom_handle",
+    bio: "Keep this generated biography",
+    settings: { profileGenerated: true, location: "Snezhnaya" },
+  });
+  const renamedCharacterAccount = await firstNoodle.upsertAccountFromProfile({
+    kind: "character",
+    entityId: "renamed-character",
+    displayName: "New Card Name",
+    avatarUrl: "/new-avatar.png",
+    syncIdentity: true,
+  });
+  assert.equal(renamedCharacterAccount.displayName, "New Card Name");
+  assert.equal(renamedCharacterAccount.avatarUrl, "/new-avatar.png");
+  assert.equal(renamedCharacterAccount.handle, "custom_handle");
+  assert.equal(renamedCharacterAccount.bio, "Keep this generated biography");
+  assert.deepEqual(renamedCharacterAccount.settings, { profileGenerated: true, location: "Snezhnaya" });
   await firstDb._fileStore.close();
 
   const reopenedDb = await createFileNativeDB();

--- a/scripts/regressions/open-issues.regression.ts
+++ b/scripts/regressions/open-issues.regression.ts
@@ -1,4 +1,7 @@
 import assert from "node:assert/strict";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, unlinkSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import type { Chat, Message } from "../../packages/shared/src/types/chat.js";
 import {
   parseGroupedSpeakerSegments,
@@ -48,6 +51,7 @@ import {
 } from "../../packages/client/src/lib/emoji-shortcodes.js";
 import { unoEngine } from "../../packages/shared/src/features/turn-games/uno/engine.js";
 import { DEFAULT_UNO_CONFIG, type UnoState } from "../../packages/shared/src/features/turn-games/uno/types.js";
+import { persistGeneratedImageToEntityGalleries } from "../../packages/server/src/services/image/generated-image-entity-gallery.js";
 
 assert.equal(resolveInitialGameGmConnectionId(undefined, "chat-connection"), "chat-connection");
 assert.equal(resolveInitialGameGmConnectionId("explicit-connection", "chat-connection"), "explicit-connection");
@@ -453,5 +457,49 @@ assert.equal(
 assert.equal(characterAssignedDuplicate.vectorQueryDepth, characterAssignedLorebook.vectorQueryDepth);
 assert.equal(characterAssignedDuplicate.vectorScoreThreshold, characterAssignedLorebook.vectorScoreThreshold);
 assert.equal(characterAssignedDuplicate.vectorMaxResults, characterAssignedLorebook.vectorMaxResults);
+
+const entityGalleryRoot = mkdtempSync(join(tmpdir(), "marinara-generated-entity-gallery-"));
+try {
+  const sourceDir = join(entityGalleryRoot, "chat-id");
+  mkdirSync(sourceDir, { recursive: true });
+  writeFileSync(join(sourceDir, "generated.png"), Buffer.from("generated-image"));
+  const characterRows: Array<Record<string, unknown>> = [];
+  const personaRows: Array<Record<string, unknown>> = [];
+  const persisted = await persistGeneratedImageToEntityGalleries({
+    sourceFilePath: "chat-id/generated.png",
+    characterIds: ["character-1", "character-1"],
+    personaIds: ["persona-1"],
+    characterGallery: {
+      create: async (input) => {
+        characterRows.push(input as unknown as Record<string, unknown>);
+        return input;
+      },
+    },
+    personaGallery: {
+      create: async (input) => {
+        personaRows.push(input as unknown as Record<string, unknown>);
+        return input;
+      },
+    },
+    prompt: "A generated scene with both identities.",
+    provider: "image_generation",
+    model: "regression-image-model",
+    width: 1024,
+    height: 1024,
+    galleryRoot: entityGalleryRoot,
+  });
+  assert.deepEqual(persisted, { characterCount: 1, personaCount: 1 });
+  assert.equal(characterRows.length, 1);
+  assert.equal(personaRows.length, 1);
+  const characterFile = join(entityGalleryRoot, String(characterRows[0]!.filePath));
+  const personaFile = join(entityGalleryRoot, String(personaRows[0]!.filePath));
+  assert.equal(readFileSync(characterFile, "utf8"), "generated-image");
+  assert.equal(readFileSync(personaFile, "utf8"), "generated-image");
+  unlinkSync(characterFile);
+  assert.equal(existsSync(join(sourceDir, "generated.png")), true);
+  assert.equal(existsSync(personaFile), true);
+} finally {
+  rmSync(entityGalleryRoot, { recursive: true, force: true });
+}
 
 console.info("Open-issue regressions passed.");

--- a/scripts/regressions/prompt.regression.ts
+++ b/scripts/regressions/prompt.regression.ts
@@ -124,6 +124,7 @@ import { resolveCharacterAdvancedPromptIds } from "../../packages/server/src/ser
 import {
   illustratorPromptRequestsRenderedText,
   mergeIllustratorNegativePrompt,
+  resolveIllustratorCharacterReferences,
 } from "../../packages/server/src/routes/generate/illustrator-references.js";
 
 type RegressionCase = {
@@ -1124,6 +1125,32 @@ const cases: RegressionCase[] = [
         false,
       );
       assert.equal(illustratorPromptRequestsRenderedText('shopfront sign reading "OPEN ALL NIGHT"'), true);
+    },
+  },
+  {
+    name: "Illustrator resolves depicted character and persona gallery targets without loading references",
+    async run() {
+      const resolution = await resolveIllustratorCharacterReferences({
+        charactersStore: {
+          list: async () => [
+            {
+              id: "character-maukie",
+              data: { name: "Maukie", extensions: { appearance: "Wet brown hair." } },
+              avatarPath: null,
+            },
+          ],
+        },
+        chatCharacters: [
+          { id: "character-maukie", name: "Maukie", avatarPath: null, appearance: "Wet brown hair." },
+        ],
+        persona: { id: "persona-mari", name: "Mari", avatarPath: null, appearance: "Chubby woman." },
+        requestedNames: ["Maukie", "Mari"],
+        promptText: "Maukie carries Mari through the reeds.",
+        includeReferenceImages: false,
+      });
+      assert.deepEqual(resolution.characterIds, ["character-maukie"]);
+      assert.equal(resolution.personaId, "persona-mari");
+      assert.deepEqual(resolution.referenceImages, []);
     },
   },
   {

--- a/scripts/regressions/prompt.regression.ts
+++ b/scripts/regressions/prompt.regression.ts
@@ -1138,17 +1138,24 @@ const cases: RegressionCase[] = [
               data: { name: "Maukie", extensions: { appearance: "Wet brown hair." } },
               avatarPath: null,
             },
+            {
+              id: "character-dottore",
+              data: { name: "Dottore", extensions: { appearance: "A masked scientist." } },
+              avatarPath: null,
+            },
           ],
         },
         chatCharacters: [
           { id: "character-maukie", name: "Maukie", avatarPath: null, appearance: "Wet brown hair." },
+          { id: "character-dottore", name: "Dottore", avatarPath: null, appearance: "A masked scientist." },
         ],
         persona: { id: "persona-mari", name: "Mari", avatarPath: null, appearance: "Chubby woman." },
-        requestedNames: ["Maukie", "Mari"],
-        promptText: "Maukie carries Mari through the reeds.",
+        requestedNames: ["Maukie", "Dottore", "Mari"],
+        promptText: "Maukie and Dottore carry Mari through the reeds.",
         includeReferenceImages: false,
+        maxReferences: 1,
       });
-      assert.deepEqual(resolution.characterIds, ["character-maukie"]);
+      assert.deepEqual(resolution.characterIds, ["character-maukie", "character-dottore"]);
       assert.equal(resolution.personaId, "persona-mari");
       assert.deepEqual(resolution.referenceImages, []);
     },

--- a/scripts/regressions/prompt.regression.ts
+++ b/scripts/regressions/prompt.regression.ts
@@ -120,6 +120,7 @@ import {
   extractDialogueUtterances,
   resolveTTSVoiceForSpeaker,
 } from "../../packages/client/src/lib/tts-dialogue.js";
+import { resolveCharacterAdvancedPromptIds } from "../../packages/server/src/services/prompt/macro-context.js";
 import {
   illustratorPromptRequestsRenderedText,
   mergeIllustratorNegativePrompt,
@@ -282,6 +283,50 @@ const cases: RegressionCase[] = [
       assert.equal(
         normalized.some((message, index) => index > 0 && message.role === "system"),
         false,
+      );
+    },
+  },
+  {
+    name: "character advanced prompts stay wired into Conversation and Game runtime assembly",
+    run() {
+      const generateRouteSource = readFileSync(
+        new URL("../../packages/server/src/routes/generate.routes.ts", import.meta.url),
+        "utf8",
+      );
+      const dryRunRouteSource = readFileSync(
+        new URL("../../packages/server/src/routes/generate/dry-run-route.ts", import.meta.url),
+        "utf8",
+      );
+      const assemblerSource = readFileSync(
+        new URL("../../packages/server/src/services/prompt/assembler.ts", import.meta.url),
+        "utf8",
+      );
+      const gamePromptRuntimeSource = readFileSync(
+        new URL(
+          "../../packages/server/src/services/generation/game-gm-prompt-runtime.ts",
+          import.meta.url,
+        ),
+        "utf8",
+      );
+
+      assert.match(generateRouteSource, /collectCharacterAdvancedPromptEntries/);
+      assert.match(generateRouteSource, /if \(chatMode !== "game"\) \{\s*await injectCharacterAdvancedPrompts\(\)/);
+      const gameInjectionIndex = generateRouteSource.indexOf("Game bypasses the preset assembler");
+      const gameFormatReminderIndex = generateRouteSource.indexOf(
+        "const formatReminder = resolvePromptMacros",
+        gameInjectionIndex,
+      );
+      assert.ok(gameInjectionIndex >= 0 && gameFormatReminderIndex > gameInjectionIndex);
+      assert.doesNotMatch(generateRouteSource, /if \(!presetId && chatMode !== "game"\)/);
+      assert.match(dryRunRouteSource, /collectCharacterAdvancedPromptEntries/);
+      assert.match(assemblerSource, /collectCharacterAdvancedPromptEntries/);
+      assert.match(gamePromptRuntimeSource, /Character System Instructions/);
+      assert.deepEqual(
+        resolveCharacterAdvancedPromptIds(["chat-character"], "game", {
+          gamePartyCharacterIds: ["party-character", "npc:temporary-companion"],
+          gameGmCharacterId: "gm-character",
+        }),
+        ["chat-character", "party-character", "gm-character"],
       );
     },
   },
@@ -1762,6 +1807,59 @@ Use HTML sparingly and diegetically. Do not replace normal prose/dialogue unless
       assert.equal(promptText.includes("&lt;START>"), false);
       assert.equal(promptText.includes("<system>bad example</system>"), false);
       assert.match(promptText, /&lt;system>bad example&lt;\/system>/);
+    },
+  },
+  {
+    name: "Conversation named profiles cannot suppress character System Prompts",
+    run() {
+      const messages: ChatMLMessage[] = [
+        {
+          role: "system",
+          content: "<injected_character><description>Custom profile.</description></injected_character>",
+        },
+        { role: "user", content: "Hello." },
+      ];
+
+      injectIdentityFallbackMessages({
+        messages,
+        charInfo: [
+          {
+            id: "char-injected",
+            name: "Injected Character",
+            description: "Original profile that should remain omitted.",
+            personality: "",
+            scenario: "",
+            creatorNotes: "",
+            systemPrompt: "Always preserve this character-authored instruction.",
+            backstory: "",
+            appearance: "",
+            mesExample: "",
+            firstMes: "",
+            postHistoryInstructions: "",
+            tags: [],
+            talkativeness: 0.5,
+            avatarPath: null,
+            avatarCrop: null,
+          },
+        ],
+        promptTargetCharacterId: null,
+        promptMacroContext: {
+          user: "Mari",
+          char: "Injected Character",
+          characters: ["Injected Character"],
+          variables: {},
+        },
+        wrapFormat: "xml",
+        personaName: "Mari",
+        personaDescription: "",
+        personaFields: {},
+        persona: null,
+        resolvePromptMacros: (value) => value,
+      });
+
+      const promptText = messages.map((message) => message.content).join("\n");
+      assert.match(promptText, /Always preserve this character-authored instruction\./);
+      assert.equal(promptText.includes("Original profile that should remain omitted."), false);
     },
   },
   {

--- a/scripts/regressions/roleplay-streaming.regression.ts
+++ b/scripts/regressions/roleplay-streaming.regression.ts
@@ -14,6 +14,11 @@ import { getAgentBatchLane, type ResolvedAgent } from "../../packages/server/src
 import { mergePairedBuiltInRewriteAgents } from "../../packages/server/src/services/generation/prose-guardian-settings.js";
 import { aboutMeKeeperAgentManifest } from "../../packages/shared/src/features/agents/about-me-keeper/manifest.js";
 import { estimateAgentLoadCost } from "../../packages/shared/src/utils/agent-cost.js";
+import {
+  ECHO_CHAMBER_MESSAGE_INTERVAL_MS,
+  enqueueEchoChamberMessages,
+  resolveEchoChamberPersistedBaseline,
+} from "../../packages/client/src/lib/echo-chamber-queue.js";
 
 assert.equal(
   shouldKeepStreamLiveThroughPostProcessing({
@@ -149,6 +154,43 @@ assert.equal(
   "rewrite editors should count as one call separate from the tracker call",
 );
 assert.equal(aboutMeKeeperAgentManifest.libraryHidden, true);
+
+const queuedEchoBatch = enqueueEchoChamberMessages(
+  {
+    messages: [{ characterName: "Watcher", reaction: "The old reaction.", timestamp: 1 }],
+    visibleCount: 1,
+    baseline: 1,
+  },
+  [
+    { characterName: "Watcher A", reaction: "First new reaction." },
+    { characterName: "Watcher B", reaction: "Second new reaction." },
+    { characterName: "Watcher C", reaction: "Third new reaction." },
+  ],
+  100,
+);
+assert.equal(queuedEchoBatch.messages.length, 4);
+assert.equal(queuedEchoBatch.visibleCount, 1, "a fresh Echo result must remain behind the reveal cursor");
+assert.equal(queuedEchoBatch.baseline, 1);
+assert.ok(ECHO_CHAMBER_MESSAGE_INTERVAL_MS >= 1_000 && ECHO_CHAMBER_MESSAGE_INTERVAL_MS <= 3_000);
+
+const staleEchoCursor = enqueueEchoChamberMessages(
+  { messages: [], visibleCount: 99, baseline: 99 },
+  [{ characterName: "Watcher", reaction: "Do not dump me." }],
+  200,
+);
+assert.equal(staleEchoCursor.visibleCount, 0, "stale reveal counters must clamp before a new batch is queued");
+assert.equal(
+  resolveEchoChamberPersistedBaseline(
+    [
+      { characterName: "Old", reaction: "Persisted history.", timestamp: 50 },
+      { characterName: "New A", reaction: "Generated during load.", timestamp: 101 },
+      { characterName: "New B", reaction: "Also generated during load.", timestamp: 101 },
+    ],
+    100,
+  ),
+  1,
+  "an Echo result persisted during the initial load must stay queued instead of appearing all at once",
+);
 
 const legacyRewrite = resolveMessageRewriteVersions(
   "The polished rewritten reply.",


### PR DESCRIPTION
## Why

Several independent regressions were making Roleplay agent output feel abrupt, dropping character-authored prompt controls in Conversation/Game, breaking Noodle profile lifecycle behavior, and leaving generated character art outside entity galleries.

Closes #3533
Closes #3535
Closes #3537
Closes #3538

## What changed

- Restored atomic, staggered Echo Chamber delivery with persistence-race and inactive-chat guards.
- Injected character System Prompts, Post-History Instructions, and Depth Prompts into live Conversation and Game generation as well as Prompt Preview.
- Bounded generated Noodle profile fields and isolated malformed rows so valid profiles still apply.
- Persisted the last selected Noodle persona without clearing it during async hydration.
- Synchronized renamed character-card names and avatars into Noodle while preserving generated profile copy and settings.
- Copied generated Illustrator and Conversation selfie images into each depicted character/persona gallery, including retry and Conversation Call paths.
- Updated CHANGELOG and character prompt documentation.

## Automated validation completed

- pnpm regression:roleplay
- pnpm regression:noodle
- pnpm regression:issues
- pnpm regression:prompt
- pnpm check
- pnpm smoke:ui (35 passed, 23 intentional viewport skips)

## Manual verification for reviewers

- [ ] Manually verify Echo reactions arrive one at a time in a live Roleplay provider run.
- [ ] Manually inspect Conversation and Game Peek Prompt output with all three character Advanced fields populated.
- [ ] Manually refresh Noodle with a provider returning an overlong formatted profile name.
- [ ] Manually rename an invited character and confirm old/new Noodle timeline surfaces use the live account name.
- [ ] Manually generate Roleplay, Game, Conversation, and Conversation Call images and inspect each target gallery.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Noodle profile refreshes now tolerate malformed or overly long generated fields.
  * The last selected Noodle persona now persists across refreshes and restarts.
  * Character renames correctly refresh names and avatars.
  * Generated chat and illustration images now appear in relevant character and persona galleries.
  * Echo Chamber reactions are restored with ordered, one-at-a-time delivery.
  * Advanced character prompts now apply consistently in Conversation and Game modes.

* **Documentation**
  * Clarified Advanced prompt behavior across supported chat modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->