### PR TITLE
Fix duplicate Game Mode NPC portrait descriptions

### DIFF
--- a/packages/server/src/routes/game.routes.ts
+++ b/packages/server/src/routes/game.routes.ts
@@ -4053,35 +4053,38 @@ function normalizePortraitAppearancePart(value: string): string {
   return value.toLowerCase().replace(/\s+/g, " ").trim();
 }
 
-function addPortraitAppearancePart(parts: string[], value: unknown, label?: string): void {
+function addPortraitAppearancePart(parts: string[], seenValues: Set<string>, value: unknown, label?: string): void {
   const trimmed = optionalTrimmedString(value);
   if (!trimmed) return;
 
+  const normalizedValue = normalizePortraitAppearancePart(trimmed);
+  if (!normalizedValue || seenValues.has(normalizedValue)) return;
+  seenValues.add(normalizedValue);
+
   const part = label ? `${label}: ${trimmed}` : trimmed;
-  const normalized = normalizePortraitAppearancePart(part);
-  if (!normalized || parts.some((existing) => normalizePortraitAppearancePart(existing) === normalized)) return;
   parts.push(part);
 }
 
-function addPortraitAppearanceNotes(parts: string[], notes: unknown): void {
+function addPortraitAppearanceNotes(parts: string[], seenValues: Set<string>, notes: unknown): void {
   if (!Array.isArray(notes)) return;
 
   const noteText = notes
     .map((note) => optionalTrimmedString(note))
     .filter((note): note is string => Boolean(note))
     .join("; ");
-  addPortraitAppearancePart(parts, noteText, "Notable details");
+  addPortraitAppearancePart(parts, seenValues, noteText, "Notable details");
 }
 
 function addPresentCharacterPortraitAppearance(
   parts: string[],
+  seenValues: Set<string>,
   presentCharacter: Record<string, unknown> | null,
 ): void {
   if (!presentCharacter) return;
 
-  addPortraitAppearancePart(parts, presentCharacter.appearance);
-  addPortraitAppearancePart(parts, presentCharacter.outfit, "Current outfit");
-  addPortraitAppearancePart(parts, presentCharacter.mood, "Current expression or mood");
+  addPortraitAppearancePart(parts, seenValues, presentCharacter.appearance);
+  addPortraitAppearancePart(parts, seenValues, presentCharacter.outfit, "Current outfit");
+  addPortraitAppearancePart(parts, seenValues, presentCharacter.mood, "Current expression or mood");
 }
 
 function findNpcRecordByName(npcs: GameNpc[], name: string): GameNpc | null {
@@ -4100,29 +4103,30 @@ function findRecordByName(records: Array<Record<string, unknown>>, name: string)
   );
 }
 
-function resolveNpcPortraitAppearance(
+export function resolveNpcPortraitAppearance(
   npc: { description?: string | null },
   metadataNpc: GameNpc | null,
   presentCharacter: Record<string, unknown> | null,
 ): string {
   const parts: string[] = [];
+  const seenValues = new Set<string>();
   const metadataDescriptionIsCanonical =
     metadataNpc?.descriptionSource === "model" ||
     metadataNpc?.descriptionSource === "library" ||
     metadataNpc?.descriptionSource === "user";
 
   if (metadataDescriptionIsCanonical) {
-    addPortraitAppearancePart(parts, metadataNpc?.description, "Canonical NPC profile");
+    addPortraitAppearancePart(parts, seenValues, metadataNpc?.description, "Canonical NPC profile");
   }
 
-  addPortraitAppearancePart(parts, npc.description);
+  addPortraitAppearancePart(parts, seenValues, npc.description);
 
   if (!metadataDescriptionIsCanonical) {
-    addPortraitAppearancePart(parts, metadataNpc?.description);
+    addPortraitAppearancePart(parts, seenValues, metadataNpc?.description);
   }
 
-  addPresentCharacterPortraitAppearance(parts, presentCharacter);
-  addPortraitAppearanceNotes(parts, metadataNpc?.notes);
+  addPresentCharacterPortraitAppearance(parts, seenValues, presentCharacter);
+  addPortraitAppearanceNotes(parts, seenValues, metadataNpc?.notes);
 
   return parts.join(" ");
 }

--- a/packages/server/src/services/game/game-asset-generation.ts
+++ b/packages/server/src/services/game/game-asset-generation.ts
@@ -583,12 +583,19 @@ function compileGameImagePrompt(
   negativePrompt?: string | null,
 ) {
   const canonicalAppearance = kind === "portrait" && typeof req.appearance === "string" ? req.appearance.trim() : "";
-  const canonicalPrefix = canonicalAppearance
-    ? `Required canonical NPC visual profile: ${canonicalAppearance.slice(0, 700)}`
+  const protectedCanonicalAppearance = canonicalAppearance.slice(0, 700);
+  const canonicalPrefix = protectedCanonicalAppearance
+    ? `Required canonical NPC visual profile: ${protectedCanonicalAppearance}`
     : "";
   if (!req.styleProfiles) {
     return {
-      prompt: [canonicalPrefix, prompt].filter(Boolean).join(". ").slice(0, maxLength),
+      prompt: prependCanonicalAppearanceIfMissing(
+        prompt,
+        protectedCanonicalAppearance,
+        canonicalPrefix,
+        maxLength,
+        ". ",
+      ),
       negativePrompt: [negativePrompt, hardNegative].filter(Boolean).join(", "),
     };
   }
@@ -621,11 +628,40 @@ function compileGameImagePrompt(
     generatedStyle: req.artStyle,
     applyPromptModeToSourcePrompt: kind === "background" || (kind === "illustration" && !req.preserveFullScenePrompt),
   });
-  const protectedPrompt = [canonicalPrefix, compiled.prompt].filter(Boolean).join(", ");
   return {
-    prompt: protectedPrompt.slice(0, maxLength),
+    prompt: prependCanonicalAppearanceIfMissing(
+      compiled.prompt,
+      protectedCanonicalAppearance,
+      canonicalPrefix,
+      maxLength,
+      ", ",
+    ),
     negativePrompt: compiled.negativePrompt,
   };
+}
+
+function prependCanonicalAppearanceIfMissing(
+  prompt: string,
+  canonicalAppearance: string,
+  canonicalPrefix: string,
+  maxLength: number,
+  separator: string,
+): string {
+  const truncatedPrompt = prompt.slice(0, maxLength);
+  if (!canonicalPrefix || promptContainsCanonicalAppearance(truncatedPrompt, canonicalAppearance)) {
+    return truncatedPrompt;
+  }
+  return [canonicalPrefix, prompt].filter(Boolean).join(separator).slice(0, maxLength);
+}
+
+function promptContainsCanonicalAppearance(prompt: string, canonicalAppearance: string): boolean {
+  const normalizedAppearance = normalizedPromptText(canonicalAppearance);
+  if (!normalizedAppearance) return false;
+  return ` ${normalizedPromptText(prompt)} `.includes(` ${normalizedAppearance} `);
+}
+
+function normalizedPromptText(value: string): string {
+  return value.toLowerCase().replace(/[^\p{L}\p{N}]+/gu, " ").trim();
 }
 
 async function maybeGenerateDynamicGameImagePrompt(

--- a/packages/server/src/services/game/game-asset-generation.ts
+++ b/packages/server/src/services/game/game-asset-generation.ts
@@ -647,6 +647,8 @@ function prependCanonicalAppearanceIfMissing(
   maxLength: number,
   separator: string,
 ): string {
+  // Inspect the provider-visible slice. If identity is missing, rebuild from the original
+  // prompt so prefixing still happens before the single final maxLength truncation.
   const truncatedPrompt = prompt.slice(0, maxLength);
   if (!canonicalPrefix || promptContainsCanonicalAppearance(truncatedPrompt, canonicalAppearance)) {
     return truncatedPrompt;
@@ -655,6 +657,8 @@ function prependCanonicalAppearanceIfMissing(
 }
 
 function promptContainsCanonicalAppearance(prompt: string, canonicalAppearance: string): boolean {
+  // Whole-word matching can still treat short or generic appearances as incidental matches;
+  // changing this behavior trades duplicate suppression against identity preservation.
   const normalizedAppearance = normalizedPromptText(canonicalAppearance);
   if (!normalizedAppearance) return false;
   return ` ${normalizedPromptText(prompt)} `.includes(` ${normalizedAppearance} `);

--- a/scripts/regressions/prompt.regression.ts
+++ b/scripts/regressions/prompt.regression.ts
@@ -62,6 +62,8 @@ import {
 } from "../../packages/server/src/services/video/prompt-context.js";
 import { resolveGameGmPromptTemplate } from "../../packages/server/src/services/generation/game-gm-prompt-runtime.js";
 import { countUserMessagesAfterSummaryAnchor } from "../../packages/server/src/services/conversation/auto-summary.service.js";
+import { buildNpcPortraitProviderPrompt } from "../../packages/server/src/services/game/game-asset-generation.js";
+import { resolveNpcPortraitAppearance } from "../../packages/server/src/routes/game.routes.js";
 import { buildLegacyDefaultAgentConfigUpdate } from "../../packages/server/src/services/agents/default-prompt-migration.js";
 import { buildMemoryRecallBlock } from "../../packages/server/src/services/generation/memory-recall-context.js";
 import { mergeConversationCharacterMemories } from "../../packages/server/src/services/generation/conversation-memory-context.js";
@@ -1748,6 +1750,84 @@ Use HTML sparingly and diegetically. Do not replace normal prose/dialogue unless
       assert.match(last.content, /"character-tracker": null/);
       assert.doesNotMatch(last.content, /"quest": null/);
       assert.equal(last.content.trim().endsWith("</output_format>"), true);
+    },
+  },
+  {
+    name: "game portrait appearance aggregation deduplicates raw values before labels",
+    run() {
+      const description = "A silver-furred fox-woman in a persimmon kimono.";
+      const appearance = resolveNpcPortraitAppearance(
+        { description: `  ${description.toUpperCase()}  ` },
+        {
+          description,
+          descriptionSource: "model",
+          notes: ["Carries a debt-scroll."],
+        } as any,
+        {
+          appearance: description,
+          outfit: "Persimmon kimono",
+          mood: "Warm smile",
+        },
+      );
+
+      assert.equal(appearance.toLowerCase().split(description.toLowerCase()).length - 1, 1);
+      assert.match(appearance, /^Canonical NPC profile:/);
+      assert.match(appearance, /Current outfit: Persimmon kimono/);
+      assert.match(appearance, /Current expression or mood: Warm smile/);
+      assert.match(appearance, /Notable details: Carries a debt-scroll/);
+    },
+  },
+  {
+    name: "game portrait prompts preserve one canonical description across compilation paths",
+    async run() {
+      const appearance = "silver-furred fox-woman, persimmon kimono, debt-scroll tucked in her sleeve";
+      const request = {
+        chatId: "prompt-regression",
+        npcName: "Lyra",
+        appearance,
+        imgModel: "unused",
+        imgBaseUrl: "",
+        imgApiKey: "",
+      };
+      const countAppearance = (prompt: string) => prompt.toLowerCase().split(appearance.toLowerCase()).length - 1;
+
+      const unstyled = await buildNpcPortraitProviderPrompt(request);
+      assert.equal(countAppearance(unstyled.prompt), 1);
+
+      const zImage = await buildNpcPortraitProviderPrompt({
+        ...request,
+        styleProfiles: createDefaultImageStyleProfileSettings(),
+        styleProfileId: "z-image-turbo",
+      });
+      assert.equal(countAppearance(zImage.prompt), 1);
+
+      const tagged = await buildNpcPortraitProviderPrompt({
+        ...request,
+        styleProfiles: createDefaultImageStyleProfileSettings(),
+        styleProfileId: "danbooru",
+      });
+      assert.equal(countAppearance(tagged.prompt), 1);
+      assert.match(tagged.prompt, /silver-furred fox-woman/);
+
+      const dynamicPreserved = await buildNpcPortraitProviderPrompt({
+        ...request,
+        dynamicPromptGenerator: async () =>
+          `Centered portrait of Lyra, ${appearance}, readable expression, single subject.`,
+      });
+      assert.equal(countAppearance(dynamicPreserved.prompt), 1);
+
+      const dynamicOmitted = await buildNpcPortraitProviderPrompt({
+        ...request,
+        dynamicPromptGenerator: async () => "Centered portrait of Lyra with a readable expression and clean lighting.",
+      });
+      assert.equal(countAppearance(dynamicOmitted.prompt), 1);
+
+      const shortDescription = await buildNpcPortraitProviderPrompt({
+        ...request,
+        appearance: "man",
+        dynamicPromptGenerator: async () => "Centered portrait of a woman with clean lighting and a readable expression.",
+      });
+      assert.match(shortDescription.prompt, /^Required canonical NPC visual profile: man\./);
     },
   },
   {

--- a/scripts/regressions/prompt.regression.ts
+++ b/scripts/regressions/prompt.regression.ts
@@ -1828,6 +1828,26 @@ Use HTML sparingly and diegetically. Do not replace normal prose/dialogue unless
         dynamicPromptGenerator: async () => "Centered portrait of a woman with clean lighting and a readable expression.",
       });
       assert.match(shortDescription.prompt, /^Required canonical NPC visual profile: man\./);
+
+      const narrationDescription = "A rain-soaked courier in a patched green cloak.";
+      const narrationAppearance = resolveNpcPortraitAppearance(
+        { description: null },
+        {
+          description: narrationDescription,
+          descriptionSource: "narration",
+          notes: [],
+        } as any,
+        null,
+      );
+      const narrationPrompt = await buildNpcPortraitProviderPrompt({
+        ...request,
+        appearance: narrationAppearance,
+      });
+      assert.equal(
+        narrationPrompt.prompt.toLowerCase().split(narrationDescription.toLowerCase()).length - 1,
+        1,
+      );
+      assert.doesNotMatch(narrationPrompt.prompt, /Canonical NPC profile:/);
     },
   },
   {


### PR DESCRIPTION
## Linked issue

Closes #3561

## Why this change

- Game Mode NPC portrait prompts can repeat the same canonical character description during server-side appearance aggregation and again after image prompt compilation. Besides wasting prompt space, the duplication can overemphasize individual traits and reduce the room available for composition and style guidance.
- The existing canonical prefix cannot simply be removed because it protects identity details that tagged prompt compilation may otherwise distill away.

## What changed

- Deduplicate NPC appearance inputs by their normalized raw values before applying source labels.
- Add the protected canonical appearance prefix only when the compiled provider prompt no longer contains that appearance.
- Add prompt regressions covering metadata/request/tracker aggregation, unstyled and Z-Image prompts, tagged prompts, dynamic prompt rewrites, omitted identity details, and short-description token boundaries.

## Validation

- [x] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [x] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed `CONTRIBUTING.md`

### Manual verification notes

- `pnpm regression:prompt` passes, including the new Game Mode portrait prompt cases.
- `pnpm check` passes, including TypeScript, ESLint, and production builds.
- The contributor confirmed in the app that Game Mode portrait generation no longer duplicates the character description.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Version/release files updated (only if this PR includes a version bump)

No documentation or release metadata changes are needed; this is an internal prompt-assembly bug fix.

## UI evidence (if applicable)

Not applicable. The UI is unchanged; the affected behavior is the server-generated image prompt.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved NPC portrait generation by removing repeated appearance details across descriptions, outfits, moods, and notes.
  - Prevented canonical NPC visual profiles from being duplicated in generated image prompts.
  - Improved consistency of NPC appearances across portrait generation styles and prompt formats.

- **Tests**
  - Added regression coverage to verify deduplication and consistent canonical NPC descriptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->