### PR TITLE
Organize storyboard planners and generation prompts

### DIFF
--- a/docs/game/getting-started.md
+++ b/docs/game/getting-started.md
@@ -55,18 +55,18 @@ These are the starting values in the **World**, **Party**, and **Features** step
 | Automatic Storyboard Illustrations | On | Only active once Visual Generation is on |
 | Automatic Storyboard Animations | Off | Needs a video generation connection |
 | Keyframes per Turn | 3 | Available with storyboard illustrations; range 1 to 6 |
-| Presentation | Standard | **Anime Episode** coordinates the Anime GM prompt with Comic Page Animation and Video prompts |
+| Game Presentation | Standard | **Storyboard Optimized** coordinates the Storyboard Game Prompt, Comic Page Animation planner, Storyboard Illustration, and Comic Page Video prompts |
 | Music DJ | Off | Needs Spotify or a local music folder |
 | Custom HUD Widgets | On | Uses AI-made status widgets from the new world |
 | Start Muted | Off | Begins the game with audio muted |
 
 New to Game Mode? Leave **Game Master Mode** on **Standalone GM**. Marinara builds a fair, slightly snarky GM for you, and you can feel out the mode before writing a custom GM card.
 
-Choose **Anime Episode** on the final step when you want GM turns written as filmable visual beats. It selects the built-in **Anime Game Prompt**, **Comic Page Animation**, and **Comic Page Video** presets, and sends storyboard image prompts directly to the image provider. Comic Page Animation uses the clip duration to limit the number of chronological panels, while Comic Page Video treats those panels as ordered animation references. It does not turn image or video generation on and does not change your selected connections. The GM uses the wizard's **Keyframes per Turn** value as a target for strong visual anchor moments, but it can write fewer for a short exchange and can use more narration paragraphs when the story needs them.
+Choose **Storyboard Optimized** on the final step when you want GM turns written as filmable visual beats. It selects the built-in **Storyboard Game Prompt**, **Comic Page Animation** planner, **Storyboard Illustration**, and **Comic Page Video** presets. Comic Page Animation uses the clip duration to limit the number of chronological panels, Storyboard Illustration formats each planned keyframe for the image model, and Comic Page Video treats those panels as ordered animation references. It does not turn image or video generation on and does not change your selected connections. The GM uses the wizard's **Keyframes per Turn** value as a target for strong visual anchor moments, but it can write fewer for a short exchange and can use more narration paragraphs when the story needs them.
 
-The alternative still-shot combination remains available after setup: choose **Anime Episode Director** for the Animation Prompt and **Anime Game Video** for the Storyboard Video Prompt.
+The alternative anime single-shot combination remains available after setup: choose **Anime Episode Director** for the Animation Planner and **Anime Game Video** for the Storyboard Video Prompt.
 
-The **GM Prompt** editor previews the effective prompt for the selected presentation. With **Anime Episode** selected, opening the editor shows the Anime Game Prompt, including its keyframe-count macro. Leaving that text unchanged keeps the built-in preset selected; editing it creates a custom prompt that overrides the presentation preset.
+The **GM Prompt** editor previews the effective prompt for the selected presentation. With **Storyboard Optimized** selected, opening the editor shows the Storyboard Game Prompt, including its keyframe-count macro. Leaving that text unchanged keeps the built-in preset selected; editing it creates a custom prompt that overrides the presentation preset.
 
 ## The three kinds of AI call
 

--- a/docs/game/storyboard.md
+++ b/docs/game/storyboard.md
@@ -82,8 +82,9 @@ All of these live in the **Storyboards** card. Open **Chat Settings**, go to **A
 | **Keyframes per Turn** | 3 (range 1 to 6) | How many keyframes each turn plans |
 | **Animation Clip Duration** | 6 seconds (range 1 to 15) | Length of each clip |
 | **Viewer Display** | Floating | Floating panel or full background |
-| **Illustration Prompt** | Still Keyframes | Style preset for still-only storyboards |
-| **Animation Prompt** | Comic Page | Style preset when animations are on |
+| **Illustration Planner** | Still Keyframes | Plans finished still keyframes and their image descriptions |
+| **Animation Planner** | Comic Page Animation | Plans animation-ready source images and motion directions |
+| **Storyboard Illustration Prompt** | Game Scene Illustration | Formats each planned keyframe for the image model |
 | **Storyboard Video Prompt** | Same as Game Video Prompt | Motion prompt used only for storyboard keyframe clips |
 
 **Keyframes per Turn** is a slider. The engine tries to plan this many keyframes. A short turn may get fewer. It never plans more than 6.
@@ -92,32 +93,40 @@ All of these live in the **Storyboards** card. Open **Chat Settings**, go to **A
 
 In **Background** viewer mode, each animation starts once with sound when its story beat becomes active. Narration can display while it plays, but narration auto-play waits for the clip to finish. The animation then stays paused on its final frame. The game toolbar provides replay, play/pause, and mute controls on desktop and mobile. Floating storyboard videos also play once and can be replayed instead of looping indefinitely.
 
-**Storyboard Video Prompt** is separate from the general **Game Video Prompt** in the **Scene Videos** card. Leave it on the inherited choice to reuse the general prompt, or select **Anime Game Video** for keyframe clips without changing manual Gallery or Game Assets videos.
+The two planners create the visual plan. **Illustration Planner** is used for still storyboards. **Animation Planner** is used when videos are generated and produces both an animation-ready image description and a compact motion direction.
+
+**Storyboard Illustration Prompt** then formats the planner's image description into the final request sent to the image model. Existing chats default to **Game Scene Illustration**. **Storyboard Illustration** keeps the planner result primary while adding character references, appearance notes, campaign art direction, and image instructions.
+
+**Storyboard Video Prompt** is separate from the general **Game Video Prompt** in the **Scene Videos** card. It combines the generated keyframe, the Animation Planner's motion direction, and the current scene context into the final request sent to the video model. Leave it on the inherited choice to reuse the general prompt, or select **Anime Game Video** for keyframe clips without changing manual Gallery or Game Assets videos.
 
 Select **Comic Page Animation** for the duration-aware comic source pages, then choose **Comic Page Video** to interpret those panels as ordered visual reference beats for one clip. The original **Comic Page** remains available for ordinary illustrations. The separate video choice leaves the inherited **Game Video Prompt** plus manual Gallery and Game Assets videos unchanged.
 
-New games created with the **Anime Episode** presentation select **Comic Page Animation** and **Comic Page Video** by default. You can switch that chat to the still-shot combination at any time by selecting **Anime Episode Director** and **Anime Game Video**.
+New games created with the **Storyboard Optimized** presentation select the **Storyboard Game Prompt**, **Comic Page Animation** planner, **Storyboard Illustration**, and **Comic Page Video**. You can switch that chat to the single-shot combination at any time by selecting **Still Keyframe Animation** and **Anime Game Video**.
 
 ## Style presets
 
-The style presets shape how each keyframe looks. Two selectors pick them:
+The planner presets shape how each keyframe is selected and described. Two selectors pick them:
 
-- **Illustration Prompt** is used when storyboards make still keyframes without videos. Default: **Still Keyframes**.
-- **Animation Prompt** is used when **Automatic Storyboard Animations** is on. Default: **Comic Page**.
+- **Illustration Planner** is used when storyboards make still keyframes without videos. Default: **Still Keyframes**.
+- **Animation Planner** is used when **Automatic Storyboard Animations** is on. Default: **Comic Page Animation**.
 
-There are seven built-in presets. They are for Game Mode storyboards only. They are separate from Roleplay illustrator presets.
+The two selectors have separate preset lists. Illustration presets describe finished stills and can include reader-facing comic or manga lettering. Animation presets describe a stable first frame plus duration-aware motion direction. An illustration preset never appears in the Animation Planner menu, and an animation preset never appears in the Illustration Planner menu.
 
-| Preset | Best for |
-| --- | --- |
-| **Still Keyframes** | Normal reading. Single-scene keyframes. Avoids comic panels, speech bubbles, captions, and SFX text, so the viewer does not spoil later beats. |
-| **NovelAI Keyframes** | Compact tag prompts tuned for NovelAI V4 and V4.5. Best paired with **Use Storyboard Prompt Directly**. |
-| **Anime Episode Director** | Ordered, animation-ready single shots. It plans the exact first frame, one main movement, simple camera behavior, environmental motion, and an ending hold. |
-| **Comic Page** | Original comic-page illustration prompt with 2-6 panels, dialogue bubbles, captions, and lettering. |
-| **Comic Page Animation** | Duration-aware comic source pages for animation. Each page uses a small number of chronological panels as ordered visual references for one clip. |
-| **Colored Manga** | Colored manga staging, cell shading, screentones, speech bubbles, and SFX. |
-| **B&W Manga** | Black-and-white manga inks, screentones, heavy blacks, speech bubbles, and SFX. |
+| Lane | Preset | Best for |
+| --- | --- | --- |
+| Illustration | **Still Keyframes** | Normal reading. Single-scene keyframes without comic panels, speech bubbles, captions, or SFX text. |
+| Illustration | **NovelAI Keyframes** | Compact still-image tag prompts tuned for NovelAI V4 and V4.5. Best paired with **Use Storyboard Prompt Directly**. |
+| Illustration | **Comic Page** | Finished comic-page illustrations with 2-6 panels, dialogue bubbles, captions, and lettering. |
+| Illustration | **Colored Manga** | Finished colored manga staging with cell shading, screentones, speech bubbles, and SFX. |
+| Illustration | **B&W Manga** | Finished black-and-white manga inks, screentones, heavy blacks, speech bubbles, and SFX. |
+| Animation | **Still Keyframe Animation** | Ordered single shots with an exact first frame, one main movement, simple camera behavior, environmental motion, and an ending hold. |
+| Animation | **Anime Episode Director** | Broadcast-anime single shots with first-frame continuity, compact motion direction, and provider-safe staging. |
+| Animation | **NovelAI Keyframe Animation** | NovelAI tag-based first frames with timing and motion kept in a separate animation direction. |
+| Animation | **Comic Page Animation** | Duration-aware comic source pages whose chronological panels act as ordered visual references for one clip. |
+| Animation | **Colored Manga Animation** | Text-free colored manga first frames with motion that preserves linework and cel shading. |
+| Animation | **B&W Manga Animation** | Text-free monochrome first frames with motion that preserves inks and screentones. |
 
-The **Anime Episode Director** pairs with **Anime Game Video** and **Use Storyboard Prompt Directly** when you want the generated still to be the exact first frame of a continuous clip. The director keeps severe violence non-graphic and stages it through anticipation, obstruction, reaction, or aftermath where possible, which can reduce provider safety rejections without changing the GM's canonical story.
+The **Still Keyframe Animation** preset is the style-neutral motion counterpart to **Still Keyframes**. The **Anime Episode Director** is a separate specialized option that pairs with **Anime Game Video** and **Use Storyboard Prompt Directly** when you want broadcast-anime shot planning. It keeps severe violence non-graphic and stages it through anticipation, obstruction, reaction, or aftermath where possible, which can reduce provider safety rejections without changing the GM's canonical story.
 
 The **Comic Page Animation** preset uses the animation clip duration to control page density. It defaults to 2 panels for a 6-7 second clip, allowing a third only for three simple beats with about 2 seconds each; it uses 2-3 panels for 8-10 seconds and no more than 4 for longer clips. Animation pages prioritize visual timing over comic lettering, keep each panel focused, and reserve a short ending hold. Panels follow cause and effect in reading order. **Comic Page Video** normally enters panel 1 immediately; it permits only a very brief full-page establish when doing so cannot reveal a later consequence early.
 
@@ -133,9 +142,9 @@ With **Expose image prompts before sending** enabled in **Settings > Generation*
 
 ## Editing storyboard presets
 
-The built-in presets are read-only. To make your own, open the **Edit Storyboard Presets** section inside the **Storyboards** card. It shows a count of your custom copies.
+The built-in presets are read-only. To make your own, open **Edit Illustration Planner Presets**, **Edit Animation Planner Presets**, **Edit Illustration Prompt Presets**, or **Edit Video Prompt Presets** inside the **Storyboards** card. Each section shows only the built-ins and custom copies for that stage.
 
-You copy a built-in into a chat-only editable template, then pick that copy in either selector. The copy controls include the built-in still, anime episode, comic illustration, comic animation, NovelAI, colored manga, and black-and-white manga templates. **Edit Video Presets** likewise offers copies of Cinematic Scene Video, Anime Game Video, and Comic Page Video for either video selector.
+Copy a built-in into a chat-only editable template, then pick that copy in the matching selector. Illustration Planner copies cannot be selected as Animation Planners, and Animation Planner copies cannot be selected as Illustration Planners. Storyboard Illustration Prompt copies affect only storyboard images. Video prompt copies remain shared with the general Game Video Prompt so either video selector can use them.
 
 Each custom copy has a name, a short description, and the prompt body you edit. A trash button removes a copy after a confirm dialog. These copies are stored on that one chat, not across your whole app.
 

--- a/docs/prompts/macros.md
+++ b/docs/prompts/macros.md
@@ -108,7 +108,7 @@ These macros describe the current chat and the current request.
 
 The value of `{{lastGenerationType}}` is a plain label. Example values seen in the app include `normal`, `continue`, `regenerate`, `impersonate`, `guided`, `autonomous`, `turn_game`, `preview`, `game_setup`, `lorebook_scan`, and `retry_agents`. This list can grow, so treat it as examples, not a fixed set.
 
-`{{gameStoryboardKeyframeCount}}` is supplied to Game Mode GM prompts, including the built-in **Anime Game Prompt**. It is a narrative target, not a demand for exactly that many paragraphs. The storyboard director still returns fewer shots when a turn does not contain enough distinct visual moments.
+`{{gameStoryboardKeyframeCount}}` is supplied to Game Mode GM prompts, including the built-in **Storyboard Game Prompt**. It is a narrative target, not a demand for exactly that many paragraphs. The storyboard planner still returns fewer shots when a turn does not contain enough distinct visual moments.
 
 The `{{agent::TYPE}}` macro inserts the saved output of an agent (a background helper that fills in things like a scene tracker). The easiest way to add it is inside the **Preset Editor**: click **Add Section**, open the **Agent Sections** group, and pick an agent. Marinara creates a section that already contains the right `{{agent::TYPE}}` tag. This macro is resolved last, so agent text cannot inject more macros into your prompt.
 

--- a/packages/client/src/components/chat/ChatSettingsDrawer.tsx
+++ b/packages/client/src/components/chat/ChatSettingsDrawer.tsx
@@ -8313,7 +8313,7 @@ export function ChatSettingsDrawer({
                           onRemoveTemplate={removeGameStoryboardImagePromptTemplate}
                         />
                         <GameProviderPromptLibrary
-                          title="Edit Video Prompt Presets"
+                          title="Edit Storyboard Video Prompt Presets"
                           description="Built-in video prompts are read-only. Add a chat-local copy to change how storyboard motion plans are formatted for the video model."
                           emptyDescription="Add a copy, edit it here, then choose it from Storyboard Video Prompt above."
                           builtInTemplates={GAME_VIDEO_BUILT_IN_PROMPT_TEMPLATES}

--- a/packages/client/src/components/chat/ChatSettingsDrawer.tsx
+++ b/packages/client/src/components/chat/ChatSettingsDrawer.tsx
@@ -162,6 +162,7 @@ import type {
   ConversationCommandKey,
   ConversationNote,
   ExportEnvelope,
+  GameStoryboardPromptTemplateKind,
   GameStoryboardViewerDisplayMode,
   HapticFeedbackSensitivity,
   HudWidget,
@@ -185,22 +186,22 @@ import {
   DEFAULT_AGENT_PROMPTS,
   GAME_GM_BUILT_IN_PROMPT_TEMPLATES,
   GAME_STORYBOARD_ANIMATION_PROMPT_TEMPLATE_ID,
+  GAME_STORYBOARD_ANIMATION_PROMPT_TEMPLATES,
   GAME_STORYBOARD_ANIMATION_DURATION_SECONDS_DEFAULT,
   GAME_STORYBOARD_ANIMATION_DURATION_SECONDS_MAX,
   GAME_STORYBOARD_ANIMATION_DURATION_SECONDS_MIN,
-  GAME_STORYBOARD_ANIME_EPISODE_PROMPT_TEMPLATE_ID,
-  GAME_STORYBOARD_BW_MANGA_PROMPT_TEMPLATE_ID,
   GAME_STORYBOARD_BUILT_IN_PROMPT_TEMPLATES,
-  GAME_STORYBOARD_COLORED_MANGA_PROMPT_TEMPLATE_ID,
-  GAME_STORYBOARD_COMIC_ANIMATION_PROMPT_TEMPLATE_ID,
   GAME_STORYBOARD_ILLUSTRATION_PROMPT_TEMPLATE_ID,
+  GAME_STORYBOARD_ILLUSTRATION_PROMPT_TEMPLATES,
+  GAME_STORYBOARD_IMAGE_BUILT_IN_PROMPT_TEMPLATES,
+  GAME_STORYBOARD_IMAGE_PROMPT_TEMPLATE_ID,
   GAME_STORYBOARD_KEYFRAME_COUNT_DEFAULT,
   GAME_STORYBOARD_KEYFRAME_COUNT_MAX,
   GAME_STORYBOARD_KEYFRAME_COUNT_MIN,
-  GAME_STORYBOARD_NOVELAI_PROMPT_TEMPLATE_ID,
   GAME_VIDEO_BUILT_IN_PROMPT_TEMPLATES,
   GAME_VIDEO_PROMPT_TEMPLATE_ID,
   getChatModeCapabilities,
+  getGameStoryboardPromptTemplateKind,
   LIMITS,
   MIN_AGENT_MAX_TOKENS,
   PROFESSOR_MARI_ID,
@@ -209,8 +210,6 @@ import {
   includesTextForMatch,
   AGENT_COST_HIGH_CALLS,
   AGENT_COST_HIGH_TOKENS,
-  ANIME_GAME_VIDEO_PROMPT_TEMPLATE_ID,
-  COMIC_PAGE_GAME_VIDEO_PROMPT_TEMPLATE_ID,
   CONVERSATION_COMMAND_KEYS,
   getDefaultBuiltInAgentSettings,
   isAgentAvailableInChatMode,
@@ -400,8 +399,19 @@ function normalizeGameStoryboardPromptTemplates(value: unknown): AgentPromptTemp
 
 function getGameStoryboardPromptTemplateOptions(
   customTemplates: AgentPromptTemplateOption[],
+  kind: GameStoryboardPromptTemplateKind,
+  selectedAnimationTemplateId?: string | null,
 ): AgentPromptTemplateOption[] {
-  return [...GAME_STORYBOARD_BUILT_IN_PROMPT_TEMPLATES, ...customTemplates];
+  const builtInTemplates =
+    kind === "animation"
+      ? GAME_STORYBOARD_ANIMATION_PROMPT_TEMPLATES
+      : GAME_STORYBOARD_ILLUSTRATION_PROMPT_TEMPLATES;
+  return [
+    ...builtInTemplates,
+    ...customTemplates.filter(
+      (template) => getGameStoryboardPromptTemplateKind(template, selectedAnimationTemplateId) === kind,
+    ),
+  ];
 }
 
 function resolveSelectedGameStoryboardPromptTemplateId(
@@ -416,6 +426,7 @@ function resolveSelectedGameStoryboardPromptTemplateId(
 
 function createGameStoryboardCustomPromptTemplate(
   existingTemplates: AgentPromptTemplateOption[],
+  kind: GameStoryboardPromptTemplateKind,
   sourceTemplate?: AgentPromptTemplateOption,
 ): AgentPromptTemplateOption {
   const usedIds = new Set([
@@ -425,13 +436,17 @@ function createGameStoryboardCustomPromptTemplate(
   const sourceName = sourceTemplate?.name?.trim() || "Storyboard Prompt";
   return {
     id: getUniqueGameStoryboardPromptTemplateId(
-      `custom-${sourceName}-${Date.now().toString(36)}`,
+      `custom-${kind}-${sourceName}-${Date.now().toString(36)}`,
       usedIds,
-      "custom-storyboard-prompt",
+      `custom-${kind}-storyboard-prompt`,
     ),
     name: `Custom ${sourceName}`,
     description: sourceTemplate?.description ?? "",
-    promptTemplate: sourceTemplate?.promptTemplate ?? GAME_STORYBOARD_BUILT_IN_PROMPT_TEMPLATES[0]!.promptTemplate,
+    promptTemplate:
+      sourceTemplate?.promptTemplate ??
+      (kind === "animation"
+        ? GAME_STORYBOARD_ANIMATION_PROMPT_TEMPLATES[0]!.promptTemplate
+        : GAME_STORYBOARD_ILLUSTRATION_PROMPT_TEMPLATES[0]!.promptTemplate),
   };
 }
 
@@ -505,6 +520,42 @@ function createGameVideoCustomPromptTemplate(
     name: `Custom ${sourceName}`,
     description: sourceTemplate?.description ?? "",
     promptTemplate: sourceTemplate?.promptTemplate ?? GAME_VIDEO_BUILT_IN_PROMPT_TEMPLATES[0]!.promptTemplate,
+  };
+}
+
+const GAME_STORYBOARD_IMAGE_BUILT_IN_PROMPT_TEMPLATE_IDS = new Set(
+  GAME_STORYBOARD_IMAGE_BUILT_IN_PROMPT_TEMPLATES.map((template) => template.id),
+);
+
+function normalizeGameStoryboardImagePromptTemplates(value: unknown): AgentPromptTemplateOption[] {
+  const usedIds = new Set(GAME_STORYBOARD_IMAGE_BUILT_IN_PROMPT_TEMPLATE_IDS);
+  return normalizeAgentPromptTemplateOptions(value)
+    .map((template) => ({
+      ...template,
+      id: getUniqueGameVideoPromptTemplateId(template.id, usedIds, "custom-storyboard-image-prompt"),
+    }))
+    .slice(0, 20);
+}
+
+function createGameStoryboardImageCustomPromptTemplate(
+  existingTemplates: AgentPromptTemplateOption[],
+  sourceTemplate?: AgentPromptTemplateOption,
+): AgentPromptTemplateOption {
+  const usedIds = new Set([
+    ...GAME_STORYBOARD_IMAGE_BUILT_IN_PROMPT_TEMPLATE_IDS,
+    ...existingTemplates.map((template) => template.id),
+  ]);
+  const sourceName = sourceTemplate?.name?.trim() || "Storyboard Illustration";
+  return {
+    id: getUniqueGameVideoPromptTemplateId(
+      `custom-${sourceName}-${Date.now().toString(36)}`,
+      usedIds,
+      "custom-storyboard-image-prompt",
+    ),
+    name: `Custom ${sourceName}`,
+    description: sourceTemplate?.description ?? "",
+    promptTemplate:
+      sourceTemplate?.promptTemplate ?? GAME_STORYBOARD_IMAGE_BUILT_IN_PROMPT_TEMPLATES[0]!.promptTemplate,
   };
 }
 
@@ -1690,27 +1741,59 @@ export function ChatSettingsDrawer({
     () => normalizeGameStoryboardPromptTemplates(metadata.gameStoryboardPromptTemplates),
     [metadata.gameStoryboardPromptTemplates],
   );
-  const gameStoryboardPromptOptions = useMemo(
-    () => getGameStoryboardPromptTemplateOptions(gameStoryboardPromptTemplates),
-    [gameStoryboardPromptTemplates],
+  const configuredGameStoryboardAnimationPromptTemplateId =
+    typeof metadata.gameStoryboardAnimationPromptTemplateId === "string"
+      ? metadata.gameStoryboardAnimationPromptTemplateId.trim()
+      : null;
+  const gameStoryboardIllustrationPromptOptions = useMemo(
+    () =>
+      getGameStoryboardPromptTemplateOptions(
+        gameStoryboardPromptTemplates,
+        "illustration",
+        configuredGameStoryboardAnimationPromptTemplateId,
+      ),
+    [configuredGameStoryboardAnimationPromptTemplateId, gameStoryboardPromptTemplates],
+  );
+  const gameStoryboardAnimationPromptOptions = useMemo(
+    () =>
+      getGameStoryboardPromptTemplateOptions(
+        gameStoryboardPromptTemplates,
+        "animation",
+        configuredGameStoryboardAnimationPromptTemplateId,
+      ),
+    [configuredGameStoryboardAnimationPromptTemplateId, gameStoryboardPromptTemplates],
+  );
+  const customGameStoryboardIllustrationPromptTemplates = useMemo(
+    () =>
+      gameStoryboardIllustrationPromptOptions.filter(
+        (template) => !GAME_STORYBOARD_BUILT_IN_PROMPT_TEMPLATE_IDS.has(template.id),
+      ),
+    [gameStoryboardIllustrationPromptOptions],
+  );
+  const customGameStoryboardAnimationPromptTemplates = useMemo(
+    () =>
+      gameStoryboardAnimationPromptOptions.filter(
+        (template) => !GAME_STORYBOARD_BUILT_IN_PROMPT_TEMPLATE_IDS.has(template.id),
+      ),
+    [gameStoryboardAnimationPromptOptions],
   );
   const selectedGameStoryboardIllustrationPromptTemplateId = useMemo(
     () =>
       resolveSelectedGameStoryboardPromptTemplateId(
         metadata.gameStoryboardIllustrationPromptTemplateId,
         GAME_STORYBOARD_ILLUSTRATION_PROMPT_TEMPLATE_ID,
-        gameStoryboardPromptOptions,
+        gameStoryboardIllustrationPromptOptions,
       ),
-    [gameStoryboardPromptOptions, metadata.gameStoryboardIllustrationPromptTemplateId],
+    [gameStoryboardIllustrationPromptOptions, metadata.gameStoryboardIllustrationPromptTemplateId],
   );
   const selectedGameStoryboardAnimationPromptTemplateId = useMemo(
     () =>
       resolveSelectedGameStoryboardPromptTemplateId(
         metadata.gameStoryboardAnimationPromptTemplateId,
         GAME_STORYBOARD_ANIMATION_PROMPT_TEMPLATE_ID,
-        gameStoryboardPromptOptions,
+        gameStoryboardAnimationPromptOptions,
       ),
-    [gameStoryboardPromptOptions, metadata.gameStoryboardAnimationPromptTemplateId],
+    [gameStoryboardAnimationPromptOptions, metadata.gameStoryboardAnimationPromptTemplateId],
   );
   const updateGameStoryboardPromptSelection = useCallback(
     (
@@ -1728,39 +1811,59 @@ export function ChatSettingsDrawer({
   const updateGameStoryboardPromptTemplates = useCallback(
     (templates: AgentPromptTemplateOption[]) => {
       const normalized = normalizeGameStoryboardPromptTemplates(templates);
-      const availableIds = new Set([
-        ...GAME_STORYBOARD_BUILT_IN_PROMPT_TEMPLATE_IDS,
-        ...normalized.map((template) => template.id),
-      ]);
+      const illustrationIds = new Set(
+        getGameStoryboardPromptTemplateOptions(
+          normalized,
+          "illustration",
+          configuredGameStoryboardAnimationPromptTemplateId,
+        ).map((template) => template.id),
+      );
+      const animationIds = new Set(
+        getGameStoryboardPromptTemplateOptions(
+          normalized,
+          "animation",
+          configuredGameStoryboardAnimationPromptTemplateId,
+        ).map((template) => template.id),
+      );
       updateMeta.mutate({
         id: chat.id,
         gameStoryboardPromptTemplates: normalized,
-        ...(availableIds.has(selectedGameStoryboardIllustrationPromptTemplateId)
+        ...(illustrationIds.has(selectedGameStoryboardIllustrationPromptTemplateId)
           ? {}
           : { gameStoryboardIllustrationPromptTemplateId: null }),
-        ...(availableIds.has(selectedGameStoryboardAnimationPromptTemplateId)
+        ...(animationIds.has(selectedGameStoryboardAnimationPromptTemplateId)
           ? {}
           : { gameStoryboardAnimationPromptTemplateId: null }),
       });
     },
     [
       chat.id,
+      configuredGameStoryboardAnimationPromptTemplateId,
       selectedGameStoryboardAnimationPromptTemplateId,
       selectedGameStoryboardIllustrationPromptTemplateId,
       updateMeta,
     ],
   );
   const addGameStoryboardPromptTemplate = useCallback(
-    (sourceTemplateId: string) => {
+    (kind: GameStoryboardPromptTemplateKind, sourceTemplateId: string) => {
+      const promptOptions =
+        kind === "animation" ? gameStoryboardAnimationPromptOptions : gameStoryboardIllustrationPromptOptions;
       const source =
-        gameStoryboardPromptOptions.find((option) => option.id === sourceTemplateId) ??
-        GAME_STORYBOARD_BUILT_IN_PROMPT_TEMPLATES[0];
+        promptOptions.find((option) => option.id === sourceTemplateId) ??
+        (kind === "animation"
+          ? GAME_STORYBOARD_ANIMATION_PROMPT_TEMPLATES[0]
+          : GAME_STORYBOARD_ILLUSTRATION_PROMPT_TEMPLATES[0]);
       updateGameStoryboardPromptTemplates([
         ...gameStoryboardPromptTemplates,
-        createGameStoryboardCustomPromptTemplate(gameStoryboardPromptTemplates, source),
+        createGameStoryboardCustomPromptTemplate(gameStoryboardPromptTemplates, kind, source),
       ]);
     },
-    [gameStoryboardPromptOptions, gameStoryboardPromptTemplates, updateGameStoryboardPromptTemplates],
+    [
+      gameStoryboardAnimationPromptOptions,
+      gameStoryboardIllustrationPromptOptions,
+      gameStoryboardPromptTemplates,
+      updateGameStoryboardPromptTemplates,
+    ],
   );
   const patchGameStoryboardPromptTemplate = useCallback(
     (templateId: string, patch: Partial<Pick<AgentPromptTemplateOption, "name" | "description" | "promptTemplate">>) => {
@@ -1785,6 +1888,92 @@ export function ChatSettingsDrawer({
       updateGameStoryboardPromptTemplates(gameStoryboardPromptTemplates.filter((entry) => entry.id !== templateId));
     },
     [gameStoryboardPromptTemplates, updateGameStoryboardPromptTemplates],
+  );
+  const gameStoryboardImagePromptTemplates = useMemo(
+    () => normalizeGameStoryboardImagePromptTemplates(metadata.gameStoryboardImagePromptTemplates),
+    [metadata.gameStoryboardImagePromptTemplates],
+  );
+  const gameStoryboardImagePromptOptions = useMemo(
+    () => [...GAME_STORYBOARD_IMAGE_BUILT_IN_PROMPT_TEMPLATES, ...gameStoryboardImagePromptTemplates],
+    [gameStoryboardImagePromptTemplates],
+  );
+  const selectedGameStoryboardImagePromptTemplateId = useMemo(() => {
+    const selected =
+      typeof metadata.gameStoryboardImagePromptTemplateId === "string"
+        ? metadata.gameStoryboardImagePromptTemplateId.trim()
+        : "";
+    return selected && gameStoryboardImagePromptOptions.some((option) => option.id === selected)
+      ? selected
+      : GAME_STORYBOARD_IMAGE_PROMPT_TEMPLATE_ID;
+  }, [gameStoryboardImagePromptOptions, metadata.gameStoryboardImagePromptTemplateId]);
+  const updateGameStoryboardImagePromptSelection = useCallback(
+    (promptTemplateId: string) => {
+      updateMeta.mutate({
+        id: chat.id,
+        gameStoryboardImagePromptTemplateId:
+          promptTemplateId === GAME_STORYBOARD_IMAGE_PROMPT_TEMPLATE_ID ? null : promptTemplateId,
+      });
+    },
+    [chat.id, updateMeta],
+  );
+  const updateGameStoryboardImagePromptTemplates = useCallback(
+    (templates: AgentPromptTemplateOption[]) => {
+      const normalized = normalizeGameStoryboardImagePromptTemplates(templates);
+      const availableIds = new Set([
+        ...GAME_STORYBOARD_IMAGE_BUILT_IN_PROMPT_TEMPLATE_IDS,
+        ...normalized.map((template) => template.id),
+      ]);
+      updateMeta.mutate({
+        id: chat.id,
+        gameStoryboardImagePromptTemplates: normalized,
+        ...(availableIds.has(selectedGameStoryboardImagePromptTemplateId)
+          ? {}
+          : { gameStoryboardImagePromptTemplateId: null }),
+      });
+    },
+    [chat.id, selectedGameStoryboardImagePromptTemplateId, updateMeta],
+  );
+  const addGameStoryboardImagePromptTemplate = useCallback(
+    (sourceTemplateId: string) => {
+      const source =
+        gameStoryboardImagePromptOptions.find((option) => option.id === sourceTemplateId) ??
+        GAME_STORYBOARD_IMAGE_BUILT_IN_PROMPT_TEMPLATES[0];
+      updateGameStoryboardImagePromptTemplates([
+        ...gameStoryboardImagePromptTemplates,
+        createGameStoryboardImageCustomPromptTemplate(gameStoryboardImagePromptTemplates, source),
+      ]);
+    },
+    [
+      gameStoryboardImagePromptOptions,
+      gameStoryboardImagePromptTemplates,
+      updateGameStoryboardImagePromptTemplates,
+    ],
+  );
+  const patchGameStoryboardImagePromptTemplate = useCallback(
+    (templateId: string, patch: Partial<Pick<AgentPromptTemplateOption, "name" | "description" | "promptTemplate">>) => {
+      updateGameStoryboardImagePromptTemplates(
+        gameStoryboardImagePromptTemplates.map((template) =>
+          template.id === templateId ? { ...template, ...patch } : template,
+        ),
+      );
+    },
+    [gameStoryboardImagePromptTemplates, updateGameStoryboardImagePromptTemplates],
+  );
+  const removeGameStoryboardImagePromptTemplate = useCallback(
+    async (templateId: string) => {
+      const template = gameStoryboardImagePromptTemplates.find((entry) => entry.id === templateId);
+      const ok = await showConfirmDialog({
+        title: "Remove Storyboard Illustration Prompt",
+        message: `Remove "${template?.name ?? "this prompt"}" from this chat?`,
+        confirmLabel: "Remove",
+        tone: "destructive",
+      });
+      if (!ok) return;
+      updateGameStoryboardImagePromptTemplates(
+        gameStoryboardImagePromptTemplates.filter((entry) => entry.id !== templateId),
+      );
+    },
+    [gameStoryboardImagePromptTemplates, updateGameStoryboardImagePromptTemplates],
   );
   const gameVideoPromptTemplates = useMemo(
     () => normalizeGameVideoPromptTemplates(metadata.gameVideoPromptTemplates),
@@ -7831,8 +8020,14 @@ export function ChatSettingsDrawer({
                       fallbackId={GAME_VIDEO_PROMPT_TEMPLATE_ID}
                       onChange={updateGameVideoPromptSelection}
                     />
-                    <GameVideoPromptLibrary
+                    <GameProviderPromptLibrary
+                      title="Edit Video Prompt Presets"
+                      description="Built-in Game Video presets are read-only. Add a copy to edit the motion prompt for this chat's scene videos and storyboard clips."
+                      emptyDescription="Add a copy, edit it here, then choose it from the Game Video or Storyboard Video Prompt selector above."
+                      builtInTemplates={GAME_VIDEO_BUILT_IN_PROMPT_TEMPLATES}
                       customTemplates={gameVideoPromptTemplates}
+                      customFallbackName="Custom Game Video Prompt"
+                      promptPlaceholder="Write the game video prompt template..."
                       onAddTemplate={addGameVideoPromptTemplate}
                       onPatchTemplate={patchGameVideoPromptTemplate}
                       onRemoveTemplate={removeGameVideoPromptTemplate}
@@ -7886,7 +8081,7 @@ export function ChatSettingsDrawer({
                     />
                     <AgentSettingsToggle
                       label="Use Storyboard Prompt Directly"
-                      description="Send each illustrator imagePrompt directly to the image model with global style tags. Character references are attached only when Send Avatar References is enabled. Bypasses the Game Scene Illustration prompt override and prevents tag distillation."
+                      description="Send each planner imagePrompt directly to the image model with global style tags. Character references are attached only when Send Avatar References is enabled. Bypasses Storyboard Illustration Prompt and prevents tag distillation."
                       enabled={gameStoryboardUseDirectScenePrompt}
                       onToggle={() =>
                         updateMeta.mutate({
@@ -8018,55 +8213,122 @@ export function ChatSettingsDrawer({
                         }
                       />
                     </div>
-                    <div className="grid gap-2 md:grid-cols-2">
-                      <GamePromptTemplateSelect
-                        label="Illustration Prompt"
-                        description="Used when storyboards create still keyframes without videos."
-                        options={gameStoryboardPromptOptions}
-                        selectedId={selectedGameStoryboardIllustrationPromptTemplateId}
-                        fallbackId={GAME_STORYBOARD_ILLUSTRATION_PROMPT_TEMPLATE_ID}
-                        onChange={(promptTemplateId) =>
-                          updateGameStoryboardPromptSelection(
-                            "gameStoryboardIllustrationPromptTemplateId",
-                            promptTemplateId,
-                          )
-                        }
-                      />
-                      <GamePromptTemplateSelect
-                        label="Animation Prompt"
-                        description="Used when automatic storyboard animations are enabled."
-                        options={gameStoryboardPromptOptions}
-                        selectedId={selectedGameStoryboardAnimationPromptTemplateId}
-                        fallbackId={GAME_STORYBOARD_ANIMATION_PROMPT_TEMPLATE_ID}
-                        onChange={(promptTemplateId) =>
-                          updateGameStoryboardPromptSelection(
-                            "gameStoryboardAnimationPromptTemplateId",
-                            promptTemplateId,
-                          )
-                        }
-                      />
+                    <div className="space-y-2">
+                      <div>
+                        <p className="text-[0.6875rem] font-semibold text-[var(--foreground)]">Storyboard Planners</p>
+                        <p className="mt-0.5 text-[0.5625rem] leading-snug text-[var(--muted-foreground)]">
+                          Planners split a completed GM turn into ordered keyframes and write the visual plan for each
+                          one.
+                        </p>
+                      </div>
+                      <div className="grid gap-2 md:grid-cols-2">
+                        <div className="space-y-2 rounded-lg bg-[var(--secondary)]/35 p-2 ring-1 ring-[var(--border)]">
+                          <p className="text-[0.625rem] font-semibold text-[var(--foreground)]">Still Storyboards</p>
+                          <GamePromptTemplateSelect
+                            label="Illustration Planner"
+                            description="Plans finished still keyframes and writes their image descriptions when videos are not being generated."
+                            options={gameStoryboardIllustrationPromptOptions}
+                            selectedId={selectedGameStoryboardIllustrationPromptTemplateId}
+                            fallbackId={GAME_STORYBOARD_ILLUSTRATION_PROMPT_TEMPLATE_ID}
+                            onChange={(promptTemplateId) =>
+                              updateGameStoryboardPromptSelection(
+                                "gameStoryboardIllustrationPromptTemplateId",
+                                promptTemplateId,
+                              )
+                            }
+                          />
+                          <GameStoryboardPromptLibrary
+                            kind="illustration"
+                            builtInTemplates={GAME_STORYBOARD_ILLUSTRATION_PROMPT_TEMPLATES}
+                            customTemplates={customGameStoryboardIllustrationPromptTemplates}
+                            onAddTemplate={addGameStoryboardPromptTemplate}
+                            onPatchTemplate={patchGameStoryboardPromptTemplate}
+                            onRemoveTemplate={removeGameStoryboardPromptTemplate}
+                          />
+                        </div>
+                        <div className="space-y-2 rounded-lg bg-[var(--secondary)]/35 p-2 ring-1 ring-[var(--border)]">
+                          <p className="text-[0.625rem] font-semibold text-[var(--foreground)]">Animated Storyboards</p>
+                          <GamePromptTemplateSelect
+                            label="Animation Planner"
+                            description="Plans animation-ready source images and a motion direction for each generated clip."
+                            options={gameStoryboardAnimationPromptOptions}
+                            selectedId={selectedGameStoryboardAnimationPromptTemplateId}
+                            fallbackId={GAME_STORYBOARD_ANIMATION_PROMPT_TEMPLATE_ID}
+                            onChange={(promptTemplateId) =>
+                              updateGameStoryboardPromptSelection(
+                                "gameStoryboardAnimationPromptTemplateId",
+                                promptTemplateId,
+                              )
+                            }
+                          />
+                          <GameStoryboardPromptLibrary
+                            kind="animation"
+                            builtInTemplates={GAME_STORYBOARD_ANIMATION_PROMPT_TEMPLATES}
+                            customTemplates={customGameStoryboardAnimationPromptTemplates}
+                            onAddTemplate={addGameStoryboardPromptTemplate}
+                            onPatchTemplate={patchGameStoryboardPromptTemplate}
+                            onRemoveTemplate={removeGameStoryboardPromptTemplate}
+                          />
+                        </div>
+                      </div>
                     </div>
-                    <GamePromptTemplateSelect
-                      label="Storyboard Video Prompt"
-                      description="Used only for storyboard keyframe clips. Manual scene videos keep the Game Video Prompt above."
-                      options={gameVideoPromptOptions}
-                      selectedId={selectedGameStoryboardVideoPromptTemplateId}
-                      fallbackId={selectedGameVideoPromptTemplateId}
-                      onChange={updateGameStoryboardVideoPromptSelection}
-                    />
-                    <GameStoryboardPromptLibrary
-                      customTemplates={gameStoryboardPromptTemplates}
-                      onAddTemplate={addGameStoryboardPromptTemplate}
-                      onPatchTemplate={patchGameStoryboardPromptTemplate}
-                      onRemoveTemplate={removeGameStoryboardPromptTemplate}
-                    />
-                    <p className="text-[0.625rem] text-[var(--muted-foreground)]">
-                      These prompt presets are specific to Game Mode storyboards; the roleplay Illustrator presets stay
-                      separate.
-                    </p>
-                    <p className="text-[0.625rem] text-[var(--muted-foreground)]">
-                      Still keyframes avoid comic text so normal storyboards do not reveal later panels. Comic page
-                      keyframes are meant for the animation path.
+                    <div className="space-y-2">
+                      <div>
+                        <p className="text-[0.6875rem] font-semibold text-[var(--foreground)]">
+                          Final Generation Prompts
+                        </p>
+                        <p className="mt-0.5 text-[0.5625rem] leading-snug text-[var(--muted-foreground)]">
+                          These format each planner result into the final request sent to the image or video model.
+                        </p>
+                      </div>
+                      <div className="grid gap-2 md:grid-cols-2">
+                        <GamePromptTemplateSelect
+                          label="Storyboard Illustration Prompt"
+                          description="Formats each planned keyframe into the final prompt sent to the image model."
+                          options={gameStoryboardImagePromptOptions}
+                          selectedId={selectedGameStoryboardImagePromptTemplateId}
+                          fallbackId={GAME_STORYBOARD_IMAGE_PROMPT_TEMPLATE_ID}
+                          onChange={updateGameStoryboardImagePromptSelection}
+                        />
+                        <GamePromptTemplateSelect
+                          label="Storyboard Video Prompt"
+                          description="Combines the generated keyframe and motion plan into the final prompt sent to the video model."
+                          options={gameVideoPromptOptions}
+                          selectedId={selectedGameStoryboardVideoPromptTemplateId}
+                          fallbackId={selectedGameVideoPromptTemplateId}
+                          onChange={updateGameStoryboardVideoPromptSelection}
+                        />
+                      </div>
+                      <div className="grid gap-2 md:grid-cols-2">
+                        <GameProviderPromptLibrary
+                          title="Edit Illustration Prompt Presets"
+                          description="Built-in storyboard illustration prompts are read-only. Add a chat-local copy to change how planned keyframes are formatted for the image model."
+                          emptyDescription="Add a copy, edit it here, then choose it from Storyboard Illustration Prompt above."
+                          builtInTemplates={GAME_STORYBOARD_IMAGE_BUILT_IN_PROMPT_TEMPLATES}
+                          customTemplates={gameStoryboardImagePromptTemplates}
+                          customFallbackName="Custom Storyboard Illustration Prompt"
+                          promptPlaceholder="Write the storyboard illustration prompt template..."
+                          onAddTemplate={addGameStoryboardImagePromptTemplate}
+                          onPatchTemplate={patchGameStoryboardImagePromptTemplate}
+                          onRemoveTemplate={removeGameStoryboardImagePromptTemplate}
+                        />
+                        <GameProviderPromptLibrary
+                          title="Edit Video Prompt Presets"
+                          description="Built-in video prompts are read-only. Add a chat-local copy to change how storyboard motion plans are formatted for the video model."
+                          emptyDescription="Add a copy, edit it here, then choose it from Storyboard Video Prompt above."
+                          builtInTemplates={GAME_VIDEO_BUILT_IN_PROMPT_TEMPLATES}
+                          customTemplates={gameVideoPromptTemplates}
+                          customFallbackName="Custom Game Video Prompt"
+                          promptPlaceholder="Write the storyboard video prompt template..."
+                          onAddTemplate={addGameVideoPromptTemplate}
+                          onPatchTemplate={patchGameVideoPromptTemplate}
+                          onRemoveTemplate={removeGameVideoPromptTemplate}
+                        />
+                      </div>
+                    </div>
+                    <p className="text-[0.625rem] leading-relaxed text-[var(--muted-foreground)]">
+                      Flow: the selected planner creates each keyframe plan, Storyboard Illustration Prompt formats the
+                      image request, and Storyboard Video Prompt formats the animation request when videos are enabled.
                     </p>
                   </AgentSettingsCard>
                 )}
@@ -9653,20 +9915,25 @@ function GamePromptTemplateSelect({
         </select>
       </label>
       <p className="mt-1.5 text-[0.5625rem] leading-snug text-[var(--muted-foreground)]">
-        {activeOption?.description || description}
+        {description}
+        {activeOption?.description ? ` ${activeOption.description}` : ""}
       </p>
     </div>
   );
 }
 
 function GameStoryboardPromptLibrary({
+  kind,
+  builtInTemplates,
   customTemplates,
   onAddTemplate,
   onPatchTemplate,
   onRemoveTemplate,
 }: {
+  kind: GameStoryboardPromptTemplateKind;
+  builtInTemplates: AgentPromptTemplateOption[];
   customTemplates: AgentPromptTemplateOption[];
-  onAddTemplate: (sourceTemplateId: string) => void;
+  onAddTemplate: (kind: GameStoryboardPromptTemplateKind, sourceTemplateId: string) => void;
   onPatchTemplate: (
     templateId: string,
     patch: Partial<Pick<AgentPromptTemplateOption, "name" | "description" | "promptTemplate">>,
@@ -9674,6 +9941,7 @@ function GameStoryboardPromptLibrary({
   onRemoveTemplate: (templateId: string) => void | Promise<void>;
 }) {
   const [open, setOpen] = useState(false);
+  const laneLabel = kind === "animation" ? "Animation" : "Illustration";
 
   return (
     <div className="rounded-lg bg-[var(--background)]/45 ring-1 ring-[var(--border)]">
@@ -9685,7 +9953,7 @@ function GameStoryboardPromptLibrary({
       >
         <FileText size="0.75rem" className="shrink-0 text-[var(--primary)]" />
         <span className="min-w-0 flex-1 text-[0.6875rem] font-semibold text-[var(--foreground)]">
-          Edit Storyboard Presets
+          Edit {laneLabel} Planner Presets
         </span>
         <span className="rounded-md bg-[var(--secondary)] px-1.5 py-0.5 text-[0.5625rem] text-[var(--muted-foreground)] ring-1 ring-[var(--border)]">
           {customTemplates.length} custom
@@ -9698,70 +9966,25 @@ function GameStoryboardPromptLibrary({
       {open && (
         <div className="space-y-2 border-t border-[var(--border)] px-2.5 py-2.5">
           <p className="text-[0.625rem] leading-relaxed text-[var(--muted-foreground)]">
-            Built-in Game Mode presets are read-only. Add a copy here to edit its name, description, and prompt body for
-            this chat.
+            Built-in {laneLabel.toLowerCase()} planner presets are read-only. Add a copy here to edit its name,
+            description, and prompt body for this chat.
           </p>
           <div className="flex flex-wrap gap-1.5">
-            <button
-              type="button"
-              onClick={() => onAddTemplate(GAME_STORYBOARD_ILLUSTRATION_PROMPT_TEMPLATE_ID)}
-              className="inline-flex items-center gap-1.5 rounded-lg bg-[var(--secondary)] px-2.5 py-1.5 text-[0.625rem] font-medium text-[var(--foreground)] ring-1 ring-[var(--border)] transition-colors hover:bg-[var(--accent)]"
-            >
-              <Plus size="0.6875rem" />
-              Add Still Copy
-            </button>
-            <button
-              type="button"
-              onClick={() => onAddTemplate(GAME_STORYBOARD_ANIMATION_PROMPT_TEMPLATE_ID)}
-              className="inline-flex items-center gap-1.5 rounded-lg bg-[var(--secondary)] px-2.5 py-1.5 text-[0.625rem] font-medium text-[var(--foreground)] ring-1 ring-[var(--border)] transition-colors hover:bg-[var(--accent)]"
-            >
-              <FilePlus2 size="0.6875rem" />
-              Add Comic Copy
-            </button>
-            <button
-              type="button"
-              onClick={() => onAddTemplate(GAME_STORYBOARD_COMIC_ANIMATION_PROMPT_TEMPLATE_ID)}
-              className="inline-flex items-center gap-1.5 rounded-lg bg-[var(--secondary)] px-2.5 py-1.5 text-[0.625rem] font-medium text-[var(--foreground)] ring-1 ring-[var(--border)] transition-colors hover:bg-[var(--accent)]"
-            >
-              <FilePlus2 size="0.6875rem" />
-              Add Comic Animation Copy
-            </button>
-            <button
-              type="button"
-              onClick={() => onAddTemplate(GAME_STORYBOARD_ANIME_EPISODE_PROMPT_TEMPLATE_ID)}
-              className="inline-flex items-center gap-1.5 rounded-lg bg-[var(--secondary)] px-2.5 py-1.5 text-[0.625rem] font-medium text-[var(--foreground)] ring-1 ring-[var(--border)] transition-colors hover:bg-[var(--accent)]"
-            >
-              <FilePlus2 size="0.6875rem" />
-              Add Anime Episode Copy
-            </button>
-            <button
-              type="button"
-              onClick={() => onAddTemplate(GAME_STORYBOARD_NOVELAI_PROMPT_TEMPLATE_ID)}
-              className="inline-flex items-center gap-1.5 rounded-lg bg-[var(--secondary)] px-2.5 py-1.5 text-[0.625rem] font-medium text-[var(--foreground)] ring-1 ring-[var(--border)] transition-colors hover:bg-[var(--accent)]"
-            >
-              <FilePlus2 size="0.6875rem" />
-              Add NovelAI Copy
-            </button>
-            <button
-              type="button"
-              onClick={() => onAddTemplate(GAME_STORYBOARD_COLORED_MANGA_PROMPT_TEMPLATE_ID)}
-              className="inline-flex items-center gap-1.5 rounded-lg bg-[var(--secondary)] px-2.5 py-1.5 text-[0.625rem] font-medium text-[var(--foreground)] ring-1 ring-[var(--border)] transition-colors hover:bg-[var(--accent)]"
-            >
-              <FilePlus2 size="0.6875rem" />
-              Add Colored Manga Copy
-            </button>
-            <button
-              type="button"
-              onClick={() => onAddTemplate(GAME_STORYBOARD_BW_MANGA_PROMPT_TEMPLATE_ID)}
-              className="inline-flex items-center gap-1.5 rounded-lg bg-[var(--secondary)] px-2.5 py-1.5 text-[0.625rem] font-medium text-[var(--foreground)] ring-1 ring-[var(--border)] transition-colors hover:bg-[var(--accent)]"
-            >
-              <FilePlus2 size="0.6875rem" />
-              Add B&W Manga Copy
-            </button>
+            {builtInTemplates.map((template) => (
+              <button
+                key={template.id}
+                type="button"
+                onClick={() => onAddTemplate(kind, template.id)}
+                className="inline-flex items-center gap-1.5 rounded-lg bg-[var(--secondary)] px-2.5 py-1.5 text-[0.625rem] font-medium text-[var(--foreground)] ring-1 ring-[var(--border)] transition-colors hover:bg-[var(--accent)]"
+              >
+                <Plus size="0.6875rem" />
+                Copy {template.name}
+              </button>
+            ))}
           </div>
           {customTemplates.length === 0 ? (
             <p className="rounded-lg bg-[var(--secondary)]/55 px-2.5 py-2 text-[0.625rem] leading-relaxed text-[var(--muted-foreground)] ring-1 ring-[var(--border)]">
-              Add a copy, edit it here, then choose it from either storyboard prompt selector above.
+              Add a copy, edit it here, then choose it from the {laneLabel.toLowerCase()} planner above.
             </p>
           ) : (
             <div className="space-y-2">
@@ -9814,7 +10037,7 @@ function GameStoryboardPromptLibrary({
                     }}
                     rows={7}
                     className="min-h-[9rem] w-full resize-y rounded-md bg-[var(--background)] px-2.5 py-2 font-mono text-[0.6875rem] leading-relaxed text-[var(--foreground)] ring-1 ring-[var(--border)] placeholder:text-[var(--muted-foreground)] focus:outline-none focus:ring-2 focus:ring-[var(--ring)]"
-                    placeholder="Write the storyboard prompt template..."
+                    placeholder={`Write the storyboard ${laneLabel.toLowerCase()} prompt template...`}
                   />
                 </div>
               ))}
@@ -9826,13 +10049,25 @@ function GameStoryboardPromptLibrary({
   );
 }
 
-function GameVideoPromptLibrary({
+function GameProviderPromptLibrary({
+  title,
+  description,
+  emptyDescription,
+  builtInTemplates,
   customTemplates,
+  customFallbackName,
+  promptPlaceholder,
   onAddTemplate,
   onPatchTemplate,
   onRemoveTemplate,
 }: {
+  title: string;
+  description: string;
+  emptyDescription: string;
+  builtInTemplates: AgentPromptTemplateOption[];
   customTemplates: AgentPromptTemplateOption[];
+  customFallbackName: string;
+  promptPlaceholder: string;
   onAddTemplate: (sourceTemplateId: string) => void;
   onPatchTemplate: (
     templateId: string,
@@ -9851,9 +10086,7 @@ function GameVideoPromptLibrary({
         aria-expanded={open}
       >
         <FileText size="0.75rem" className="shrink-0 text-[var(--primary)]" />
-        <span className="min-w-0 flex-1 text-[0.6875rem] font-semibold text-[var(--foreground)]">
-          Edit Video Presets
-        </span>
+        <span className="min-w-0 flex-1 text-[0.6875rem] font-semibold text-[var(--foreground)]">{title}</span>
         <span className="rounded-md bg-[var(--secondary)] px-1.5 py-0.5 text-[0.5625rem] text-[var(--muted-foreground)] ring-1 ring-[var(--border)]">
           {customTemplates.length} custom
         </span>
@@ -9865,38 +10098,24 @@ function GameVideoPromptLibrary({
       {open && (
         <div className="space-y-2 border-t border-[var(--border)] px-2.5 py-2.5">
           <p className="text-[0.625rem] leading-relaxed text-[var(--muted-foreground)]">
-            Built-in Game Video presets are read-only. Add a copy to edit the motion prompt for this chat's scene
-            videos and storyboard clips.
+            {description}
           </p>
           <div className="flex flex-wrap gap-1.5">
-            <button
-              type="button"
-              onClick={() => onAddTemplate(GAME_VIDEO_PROMPT_TEMPLATE_ID)}
-              className="inline-flex items-center gap-1.5 rounded-lg bg-[var(--secondary)] px-2.5 py-1.5 text-[0.625rem] font-medium text-[var(--foreground)] ring-1 ring-[var(--border)] transition-colors hover:bg-[var(--accent)]"
-            >
-              <Plus size="0.6875rem" />
-              Add Video Copy
-            </button>
-            <button
-              type="button"
-              onClick={() => onAddTemplate(ANIME_GAME_VIDEO_PROMPT_TEMPLATE_ID)}
-              className="inline-flex items-center gap-1.5 rounded-lg bg-[var(--secondary)] px-2.5 py-1.5 text-[0.625rem] font-medium text-[var(--foreground)] ring-1 ring-[var(--border)] transition-colors hover:bg-[var(--accent)]"
-            >
-              <FilePlus2 size="0.6875rem" />
-              Add Anime Video Copy
-            </button>
-            <button
-              type="button"
-              onClick={() => onAddTemplate(COMIC_PAGE_GAME_VIDEO_PROMPT_TEMPLATE_ID)}
-              className="inline-flex items-center gap-1.5 rounded-lg bg-[var(--secondary)] px-2.5 py-1.5 text-[0.625rem] font-medium text-[var(--foreground)] ring-1 ring-[var(--border)] transition-colors hover:bg-[var(--accent)]"
-            >
-              <FilePlus2 size="0.6875rem" />
-              Add Comic Video Copy
-            </button>
+            {builtInTemplates.map((template) => (
+              <button
+                key={template.id}
+                type="button"
+                onClick={() => onAddTemplate(template.id)}
+                className="inline-flex items-center gap-1.5 rounded-lg bg-[var(--secondary)] px-2.5 py-1.5 text-[0.625rem] font-medium text-[var(--foreground)] ring-1 ring-[var(--border)] transition-colors hover:bg-[var(--accent)]"
+              >
+                <Plus size="0.6875rem" />
+                Copy {template.name}
+              </button>
+            ))}
           </div>
           {customTemplates.length === 0 ? (
             <p className="rounded-lg bg-[var(--secondary)]/55 px-2.5 py-2 text-[0.625rem] leading-relaxed text-[var(--muted-foreground)] ring-1 ring-[var(--border)]">
-              Add a copy, edit it here, then choose it from the Game Video or Storyboard Video Prompt selector above.
+              {emptyDescription}
             </p>
           ) : (
             <div className="space-y-2">
@@ -9912,7 +10131,7 @@ function GameVideoPromptLibrary({
                     <input
                       defaultValue={template.name}
                       onBlur={(event) => {
-                        const next = event.target.value.trim() || "Custom Game Video Prompt";
+                        const next = event.target.value.trim() || customFallbackName;
                         if (next !== template.name) onPatchTemplate(template.id, { name: next });
                       }}
                       className="min-w-0 flex-1 rounded-md bg-[var(--background)] px-2 py-1.5 text-xs text-[var(--foreground)] ring-1 ring-[var(--border)] placeholder:text-[var(--muted-foreground)] focus:outline-none focus:ring-2 focus:ring-[var(--ring)]"
@@ -9949,7 +10168,7 @@ function GameVideoPromptLibrary({
                     }}
                     rows={7}
                     className="min-h-[9rem] w-full resize-y rounded-md bg-[var(--background)] px-2.5 py-2 font-mono text-[0.6875rem] leading-relaxed text-[var(--foreground)] ring-1 ring-[var(--border)] placeholder:text-[var(--muted-foreground)] focus:outline-none focus:ring-2 focus:ring-[var(--ring)]"
-                    placeholder="Write the game video prompt template..."
+                    placeholder={promptPlaceholder}
                   />
                 </div>
               ))}

--- a/packages/client/src/components/game/GameSetupWizard.tsx
+++ b/packages/client/src/components/game/GameSetupWizard.tsx
@@ -31,6 +31,7 @@ import {
   ANIME_GAME_SYSTEM_PROMPT,
   COMIC_PAGE_GAME_VIDEO_PROMPT_TEMPLATE_ID,
   DEFAULT_GAME_SYSTEM_PROMPT,
+  STORYBOARD_OPTIMIZED_IMAGE_PROMPT_TEMPLATE_ID,
   GAME_STORYBOARD_COMIC_ANIMATION_PROMPT_TEMPLATE_ID,
   GAME_STORYBOARD_KEYFRAME_COUNT_DEFAULT,
   GAME_STORYBOARD_KEYFRAME_COUNT_MAX,
@@ -830,9 +831,10 @@ export function GameSetupWizard({ onComplete, onCancel, isLoading, characters }:
         gameGmPromptTemplateId: gamePresentation === "anime" ? ANIME_GAME_PROMPT_TEMPLATE_ID : null,
         gameStoryboardAnimationPromptTemplateId:
           gamePresentation === "anime" ? GAME_STORYBOARD_COMIC_ANIMATION_PROMPT_TEMPLATE_ID : null,
+        gameStoryboardImagePromptTemplateId:
+          gamePresentation === "anime" ? STORYBOARD_OPTIMIZED_IMAGE_PROMPT_TEMPLATE_ID : null,
         gameStoryboardVideoPromptTemplateId:
           gamePresentation === "anime" ? COMIC_PAGE_GAME_VIDEO_PROMPT_TEMPLATE_ID : null,
-        gameStoryboardUseDirectScenePrompt: gamePresentation === "anime" || undefined,
         activeLorebookIds: activeLorebookIds.length > 0 ? activeLorebookIds : undefined,
         enableCustomWidgets,
         customHudWidgets:
@@ -2241,7 +2243,7 @@ export function GameSetupWizard({ onComplete, onCancel, isLoading, characters }:
             <div>
               <label className="mb-1.5 flex items-center gap-1.5 text-xs font-medium text-[var(--foreground)]">
                 <Sparkles size={12} />
-                Presentation
+                Game Presentation
               </label>
               <select
                 value={gamePresentation}
@@ -2249,18 +2251,35 @@ export function GameSetupWizard({ onComplete, onCancel, isLoading, characters }:
                 className={GAME_SETUP_INPUT_CLASS}
               >
                 <option value="standard">Standard</option>
-                <option value="anime">Anime Episode</option>
+                <option value="anime">Storyboard Optimized</option>
               </select>
               <p className="mt-1 text-[0.575rem] leading-relaxed text-[var(--muted-foreground)]">
                 {gamePresentation === "anime"
-                  ? "Shapes narration like an anime episode and pairs Comic Page Animation with Comic Page Video for storyboard animations. It does not enable image or video generation or change your connections."
+                  ? "Coordinates the game narration, storyboard planning, image formatting, and video formatting without enabling media generation or changing your connections."
                   : "Uses the standard flexible Game Mode narration and media prompts."}
               </p>
+              {gamePresentation === "anime" && (
+                <dl className="mt-2 grid gap-1.5 rounded-lg bg-[var(--secondary)]/55 p-2 ring-1 ring-[var(--border)] sm:grid-cols-2">
+                  {[
+                    ["Game Prompt", "Storyboard Game Prompt"],
+                    ["Animation Planner", "Comic Page Animation"],
+                    ["Storyboard Illustration Prompt", "Storyboard Illustration"],
+                    ["Storyboard Video Prompt", "Comic Page Video"],
+                  ].map(([label, value]) => (
+                    <div key={label} className="min-w-0 rounded-md bg-[var(--background)]/65 px-2 py-1.5">
+                      <dt className="text-[0.525rem] font-medium uppercase tracking-wide text-[var(--muted-foreground)]">
+                        {label}
+                      </dt>
+                      <dd className="truncate text-[0.625rem] font-semibold text-[var(--foreground)]">{value}</dd>
+                    </div>
+                  ))}
+                </dl>
+              )}
             </div>
             <div>
               <label className="mb-1.5 flex items-center gap-1.5 text-xs font-medium text-[var(--foreground)]">
                 <Feather size={12} />
-                Game Prompt Preset
+                Base Prompt Preset
               </label>
               <select
                 value={promptPresetId ?? ""}
@@ -2276,7 +2295,7 @@ export function GameSetupWizard({ onComplete, onCancel, isLoading, characters }:
               </select>
               <p className="mt-1 text-[0.575rem] leading-relaxed text-[var(--muted-foreground)]">
                 {gamePresentation === "anime"
-                  ? "The Anime Game Prompt replaces the selected preset's Game prompt. Other preset settings remain available."
+                  ? "The Storyboard Game Prompt replaces the selected preset's Game prompt. Other preset settings remain available."
                   : "Uses the Game mode prompt from the selected preset unless the custom GM prompt below is enabled."}
               </p>
             </div>
@@ -2318,7 +2337,7 @@ export function GameSetupWizard({ onComplete, onCancel, isLoading, characters }:
                           ? "Custom prompt will override the selected prompt"
                           : "Previewing the selected prompt; edit it to override"
                         : gamePresentation === "anime"
-                          ? "Using Anime Game Prompt"
+                          ? "Using Storyboard Game Prompt"
                           : selectedPromptPresetName
                           ? `Using ${selectedPromptPresetName}`
                           : "Using default game prompt"}
@@ -2332,7 +2351,7 @@ export function GameSetupWizard({ onComplete, onCancel, isLoading, characters }:
                         ? "Custom"
                         : "Preview"
                       : gamePresentation === "anime"
-                        ? "Anime"
+                        ? "Storyboard"
                         : selectedPromptPresetName
                           ? "Preset"
                           : "Default"}

--- a/packages/client/src/lib/game-setup-share.ts
+++ b/packages/client/src/lib/game-setup-share.ts
@@ -1,7 +1,8 @@
-import type {
-  GameInitialSetupConnectionSnapshot,
-  GameSetupConfig,
-  GenerationParameters,
+import {
+  STORYBOARD_OPTIMIZED_IMAGE_PROMPT_TEMPLATE_ID,
+  type GameInitialSetupConnectionSnapshot,
+  type GameSetupConfig,
+  type GenerationParameters,
 } from "@marinara-engine/shared";
 
 export interface GameSetupShareLabels {
@@ -119,15 +120,18 @@ function formatPresentation(config: GameSetupConfig): string {
   const selectedIds = [
     config.gameGmPromptTemplateId,
     config.gameStoryboardAnimationPromptTemplateId,
+    config.gameStoryboardImagePromptTemplateId,
     config.gameStoryboardVideoPromptTemplateId,
   ].filter((value): value is string => typeof value === "string" && value.trim().length > 0);
   if (selectedIds.length === 0) return "Standard";
   if (
     config.gameGmPromptTemplateId === "anime-game-prompt" &&
     config.gameStoryboardAnimationPromptTemplateId === "comic-page-animation" &&
+    (!config.gameStoryboardImagePromptTemplateId ||
+      config.gameStoryboardImagePromptTemplateId === STORYBOARD_OPTIMIZED_IMAGE_PROMPT_TEMPLATE_ID) &&
     config.gameStoryboardVideoPromptTemplateId === "comic-page-game-video"
   ) {
-    return "Anime Episode";
+    return "Storyboard Optimized";
   }
   return `Custom (${selectedIds.map(titleCaseToken).join(" + ")})`;
 }

--- a/packages/client/src/lib/game-setup-share.ts
+++ b/packages/client/src/lib/game-setup-share.ts
@@ -1,4 +1,7 @@
 import {
+  ANIME_GAME_PROMPT_TEMPLATE_ID,
+  COMIC_PAGE_GAME_VIDEO_PROMPT_TEMPLATE_ID,
+  GAME_STORYBOARD_COMIC_ANIMATION_PROMPT_TEMPLATE_ID,
   STORYBOARD_OPTIMIZED_IMAGE_PROMPT_TEMPLATE_ID,
   type GameInitialSetupConnectionSnapshot,
   type GameSetupConfig,
@@ -125,11 +128,11 @@ function formatPresentation(config: GameSetupConfig): string {
   ].filter((value): value is string => typeof value === "string" && value.trim().length > 0);
   if (selectedIds.length === 0) return "Standard";
   if (
-    config.gameGmPromptTemplateId === "anime-game-prompt" &&
-    config.gameStoryboardAnimationPromptTemplateId === "comic-page-animation" &&
+    config.gameGmPromptTemplateId === ANIME_GAME_PROMPT_TEMPLATE_ID &&
+    config.gameStoryboardAnimationPromptTemplateId === GAME_STORYBOARD_COMIC_ANIMATION_PROMPT_TEMPLATE_ID &&
     (!config.gameStoryboardImagePromptTemplateId ||
       config.gameStoryboardImagePromptTemplateId === STORYBOARD_OPTIMIZED_IMAGE_PROMPT_TEMPLATE_ID) &&
-    config.gameStoryboardVideoPromptTemplateId === "comic-page-game-video"
+    config.gameStoryboardVideoPromptTemplateId === COMIC_PAGE_GAME_VIDEO_PROMPT_TEMPLATE_ID
   ) {
     return "Storyboard Optimized";
   }

--- a/packages/server/src/routes/game.routes.ts
+++ b/packages/server/src/routes/game.routes.ts
@@ -102,15 +102,18 @@ import {
   generationParametersSchema,
   VIDEO_GENERATION_SETTINGS_KEY,
   GAME_STORYBOARD_ANIMATION_PROMPT_TEMPLATE_ID,
+  GAME_STORYBOARD_ANIMATION_PROMPT_TEMPLATES,
   GAME_STORYBOARD_ANIMATION_DURATION_SECONDS_DEFAULT,
   GAME_STORYBOARD_ANIMATION_DURATION_SECONDS_MAX,
   GAME_STORYBOARD_ANIMATION_DURATION_SECONDS_MIN,
   GAME_STORYBOARD_BUILT_IN_PROMPT_TEMPLATES,
   GAME_STORYBOARD_ILLUSTRATION_PROMPT_TEMPLATE_ID,
+  GAME_STORYBOARD_ILLUSTRATION_PROMPT_TEMPLATES,
   GAME_STORYBOARD_KEYFRAME_COUNT_DEFAULT,
   GAME_STORYBOARD_KEYFRAME_COUNT_MAX,
   GAME_STORYBOARD_KEYFRAME_COUNT_MIN,
   normalizeVideoGenerationUserSettings,
+  getGameStoryboardPromptTemplateKind,
   normalizeAgentPromptTemplateOptions,
   isClaudeAdaptiveOnlyNoSamplingModel,
   localAuthProviderBaseUrl,
@@ -1534,6 +1537,7 @@ const gameSetupConfigSchema = z.object({
     .optional(),
   gameGmPromptTemplateId: z.string().max(200).nullable().optional(),
   gameStoryboardAnimationPromptTemplateId: z.string().max(200).nullable().optional(),
+  gameStoryboardImagePromptTemplateId: z.string().max(200).nullable().optional(),
   gameStoryboardVideoPromptTemplateId: z.string().max(200).nullable().optional(),
   gameStoryboardUseDirectScenePrompt: z.boolean().optional(),
   artStylePrompt: z.string().max(500).optional(),
@@ -5249,9 +5253,16 @@ async function loadStoryboardIllustratorSystemPrompt(args: {
   generateVideos: boolean;
   ctx: GameStoryboardIllustratorCtx;
 }): Promise<string> {
+  const kind = args.generateVideos ? "animation" : "illustration";
+  const selectedAnimationTemplateId = readTrimmedString(args.meta.gameStoryboardAnimationPromptTemplateId);
+  const builtInTemplates = args.generateVideos
+    ? GAME_STORYBOARD_ANIMATION_PROMPT_TEMPLATES
+    : GAME_STORYBOARD_ILLUSTRATION_PROMPT_TEMPLATES;
   const options = [
-    ...GAME_STORYBOARD_BUILT_IN_PROMPT_TEMPLATES,
-    ...normalizeGameStoryboardPromptTemplates(args.meta.gameStoryboardPromptTemplates),
+    ...builtInTemplates,
+    ...normalizeGameStoryboardPromptTemplates(args.meta.gameStoryboardPromptTemplates).filter(
+      (template) => getGameStoryboardPromptTemplateKind(template, selectedAnimationTemplateId) === kind,
+    ),
   ];
   const templateId = resolveGameStoryboardPromptTemplateId({
     meta: args.meta,
@@ -5263,7 +5274,7 @@ async function loadStoryboardIllustratorSystemPrompt(args: {
     : GAME_STORYBOARD_ILLUSTRATION_PROMPT_TEMPLATE_ID;
   const selectedTemplate =
     options.find((template) => template.id === templateId) ??
-    GAME_STORYBOARD_BUILT_IN_PROMPT_TEMPLATES.find((template) => template.id === fallbackTemplateId);
+    builtInTemplates.find((template) => template.id === fallbackTemplateId);
   if (!selectedTemplate?.promptTemplate.trim()) {
     return loadPrompt(args.promptOverridesStorage, GAME_STORYBOARD_ILLUSTRATION_DIRECTOR, args.ctx);
   }
@@ -5999,6 +6010,7 @@ export async function gameRoutes(app: FastifyInstance) {
       gameStoryboardKeyframeCount: storyboardKeyframeCount,
       gameGmPromptTemplateId: setupConfig.gameGmPromptTemplateId || null,
       gameStoryboardAnimationPromptTemplateId: setupConfig.gameStoryboardAnimationPromptTemplateId || null,
+      gameStoryboardImagePromptTemplateId: setupConfig.gameStoryboardImagePromptTemplateId || null,
       gameStoryboardVideoPromptTemplateId: setupConfig.gameStoryboardVideoPromptTemplateId || null,
       gameStoryboardUseDirectScenePrompt: setupConfig.gameStoryboardUseDirectScenePrompt === true,
       gameLastSceneVideoId: null,
@@ -10167,6 +10179,8 @@ export async function gameRoutes(app: FastifyInstance) {
               promptOverridesStorage,
               size: backgroundSize,
               useDirectScenePrompt: meta.gameStoryboardUseDirectScenePrompt === true,
+              storyboardImagePromptTemplateId: readTrimmedString(meta.gameStoryboardImagePromptTemplateId),
+              storyboardImagePromptTemplates: meta.gameStoryboardImagePromptTemplates,
               preserveFullScenePrompt: true,
             });
             if (debugLogsEnabled) {
@@ -10324,6 +10338,8 @@ export async function gameRoutes(app: FastifyInstance) {
             promptOverride: promptOverride?.prompt,
             negativePromptOverride: promptOverride?.negativePrompt,
             useDirectScenePrompt: meta.gameStoryboardUseDirectScenePrompt === true,
+            storyboardImagePromptTemplateId: readTrimmedString(meta.gameStoryboardImagePromptTemplateId),
+            storyboardImagePromptTemplates: meta.gameStoryboardImagePromptTemplates,
             preserveFullScenePrompt: true,
             onCompiledPrompt: (compiled) => {
               sentIllustrationPrompt = compiled.prompt;

--- a/packages/server/src/services/game/game-asset-generation.ts
+++ b/packages/server/src/services/game/game-asset-generation.ts
@@ -24,6 +24,7 @@ import {
 } from "@marinara-engine/shared";
 import type { ImageGenerationSize } from "../image/image-generation-settings.js";
 import { compileImagePrompt } from "../image/image-prompt-compiler.js";
+import { loadGameStoryboardImagePrompt } from "../image/game-storyboard-image-prompt.js";
 
 const NPC_AVATAR_DIR = join(DATA_DIR, "avatars", "npc");
 const CHAT_BACKGROUND_DIR = join(DATA_DIR, "backgrounds");
@@ -822,6 +823,10 @@ export interface SceneIllustrationGenRequest {
   onCompiledPrompt?: (compiled: CompiledGameImagePrompt) => void;
   /** Use the storyboard illustrator's imagePrompt as the complete scene source, bypassing the scene-illustration prompt template. */
   useDirectScenePrompt?: boolean;
+  /** Selected provider-facing storyboard image prompt template. */
+  storyboardImagePromptTemplateId?: string | null;
+  /** Chat-local provider-facing storyboard image prompt templates. */
+  storyboardImagePromptTemplates?: unknown;
   /** Preserve the full generated scene prompt instead of distilling it into the selected tagged prompt grammar. */
   preserveFullScenePrompt?: boolean;
   /** Optional request-scoped abort signal. */
@@ -934,11 +939,20 @@ async function buildSceneIllustrationRawPrompt(req: SceneIllustrationGenRequest)
     artDirectionLine: styleHint ? `Art direction: ${styleHint}.` : "",
     imagePromptInstructionsLine,
   };
+  const hasStoryboardImagePromptSelection =
+    req.storyboardImagePromptTemplateId != null || req.storyboardImagePromptTemplates != null;
   const rawIllustrationPrompt = req.useDirectScenePrompt
     ? req.prompt.trim()
-    : req.promptOverridesStorage
-      ? await loadPrompt(req.promptOverridesStorage, GAME_SCENE_ILLUSTRATION, sceneIllustrationVars)
-      : GAME_SCENE_ILLUSTRATION.defaultBuilder(sceneIllustrationVars);
+    : hasStoryboardImagePromptSelection
+      ? await loadGameStoryboardImagePrompt({
+          promptOverridesStorage: req.promptOverridesStorage,
+          templateId: req.storyboardImagePromptTemplateId,
+          customTemplates: req.storyboardImagePromptTemplates,
+          ctx: sceneIllustrationVars,
+        })
+      : req.promptOverridesStorage
+        ? await loadPrompt(req.promptOverridesStorage, GAME_SCENE_ILLUSTRATION, sceneIllustrationVars)
+        : GAME_SCENE_ILLUSTRATION.defaultBuilder(sceneIllustrationVars);
   const finalPrompt =
     imagePromptInstructionsLine && !rawIllustrationPrompt.includes(imagePromptInstructionsLine)
       ? `${rawIllustrationPrompt}\n${imagePromptInstructionsLine}`

--- a/packages/server/src/services/image/game-storyboard-image-prompt.ts
+++ b/packages/server/src/services/image/game-storyboard-image-prompt.ts
@@ -1,0 +1,99 @@
+import {
+  GAME_STORYBOARD_IMAGE_BUILT_IN_PROMPT_TEMPLATES,
+  GAME_STORYBOARD_IMAGE_PROMPT_TEMPLATE_ID,
+  normalizeAgentPromptTemplateOptions,
+  type AgentPromptTemplateOption,
+} from "@marinara-engine/shared";
+import {
+  GAME_SCENE_ILLUSTRATION,
+  renderTemplate,
+  type GameSceneIllustrationCtx,
+} from "../prompt-overrides/index.js";
+import type { PromptOverridesStorage } from "../storage/prompt-overrides.storage.js";
+import { logger } from "../../lib/logger.js";
+
+const GAME_STORYBOARD_IMAGE_BUILT_IN_PROMPT_TEMPLATE_IDS = new Set(
+  GAME_STORYBOARD_IMAGE_BUILT_IN_PROMPT_TEMPLATES.map((template) => template.id),
+);
+
+function readTrimmedString(value: unknown): string | null {
+  return typeof value === "string" && value.trim() ? value.trim() : null;
+}
+
+function ensureUniqueStoryboardImagePromptTemplateId(id: string, usedIds: Set<string>): string {
+  const fallback = "custom-storyboard-image-prompt";
+  const base =
+    id
+      .trim()
+      .toLowerCase()
+      .replace(/[^a-z0-9_-]+/g, "-")
+      .replace(/(^-|-$)/g, "") || fallback;
+  let candidate = base;
+  let attempt = 2;
+  while (usedIds.has(candidate)) {
+    candidate = `${base}-${attempt}`;
+    attempt++;
+  }
+  usedIds.add(candidate);
+  return candidate;
+}
+
+export function normalizeGameStoryboardImagePromptTemplates(value: unknown): AgentPromptTemplateOption[] {
+  const usedIds = new Set(GAME_STORYBOARD_IMAGE_BUILT_IN_PROMPT_TEMPLATE_IDS);
+  return normalizeAgentPromptTemplateOptions(value)
+    .map((template) => ({
+      ...template,
+      id: ensureUniqueStoryboardImagePromptTemplateId(template.id, usedIds),
+    }))
+    .slice(0, 20);
+}
+
+function renderSelectedStoryboardImagePrompt(
+  template: AgentPromptTemplateOption | undefined,
+  ctx: GameSceneIllustrationCtx,
+): string {
+  if (!template?.promptTemplate.trim()) return GAME_SCENE_ILLUSTRATION.defaultBuilder(ctx);
+  const declared = GAME_SCENE_ILLUSTRATION.variables.map((variable) => variable.name);
+  return renderTemplate(template.promptTemplate, ctx, declared);
+}
+
+async function loadStoredSceneIllustrationOverride(
+  promptOverridesStorage: PromptOverridesStorage,
+  ctx: GameSceneIllustrationCtx,
+): Promise<string | null> {
+  const declared = GAME_SCENE_ILLUSTRATION.variables.map((variable) => variable.name);
+  try {
+    const row = await promptOverridesStorage.get(GAME_SCENE_ILLUSTRATION.key);
+    if (!row) return null;
+    return row.enabled ? renderTemplate(row.template, ctx, declared) : null;
+  } catch (error) {
+    logger.warn(error, "[game-storyboard-image] Failed to load stored scene illustration override");
+    return null;
+  }
+}
+
+export async function loadGameStoryboardImagePrompt(args: {
+  promptOverridesStorage?: PromptOverridesStorage;
+  templateId?: string | null;
+  customTemplates?: unknown;
+  ctx: GameSceneIllustrationCtx;
+}): Promise<string> {
+  const options = [
+    ...GAME_STORYBOARD_IMAGE_BUILT_IN_PROMPT_TEMPLATES,
+    ...normalizeGameStoryboardImagePromptTemplates(args.customTemplates),
+  ];
+  const selectedId = readTrimmedString(args.templateId);
+  const selectedTemplate = selectedId ? options.find((template) => template.id === selectedId) : undefined;
+
+  if (selectedTemplate) return renderSelectedStoryboardImagePrompt(selectedTemplate, args.ctx);
+
+  if (args.promptOverridesStorage) {
+    const storedOverride = await loadStoredSceneIllustrationOverride(args.promptOverridesStorage, args.ctx);
+    if (storedOverride) return storedOverride;
+  }
+
+  return renderSelectedStoryboardImagePrompt(
+    options.find((template) => template.id === GAME_STORYBOARD_IMAGE_PROMPT_TEMPLATE_ID),
+    args.ctx,
+  );
+}

--- a/packages/shared/src/constants/game-prompt.ts
+++ b/packages/shared/src/constants/game-prompt.ts
@@ -38,7 +38,7 @@ export const GAME_GM_BUILT_IN_PROMPT_TEMPLATES: AgentPromptTemplateOption[] = [
   },
   {
     id: ANIME_GAME_PROMPT_TEMPLATE_ID,
-    name: "Anime Game Prompt",
+    name: "Storyboard Game Prompt",
     description: "Shapes GM turns into filmable anime narration with visual anchors for storyboards.",
     promptTemplate: ANIME_GAME_SYSTEM_PROMPT,
   },

--- a/packages/shared/src/constants/game-storyboard-image-prompts.ts
+++ b/packages/shared/src/constants/game-storyboard-image-prompts.ts
@@ -1,0 +1,52 @@
+import type { AgentPromptTemplateOption } from "../types/agent.js";
+
+export const GAME_STORYBOARD_IMAGE_PROMPT_TEMPLATE_ID = "game-scene-illustration";
+export const STORYBOARD_OPTIMIZED_IMAGE_PROMPT_TEMPLATE_ID = "storyboard-illustration";
+
+export const GAME_STORYBOARD_IMAGE_PROMPT_TEMPLATE_VARIABLES = [
+  "sceneTitleLine",
+  "scenePrompt",
+  "narrativePurposeLine",
+  "charactersLine",
+  "referenceHandlingLine",
+  "appearanceNotesBlock",
+  "artDirectionLine",
+  "imagePromptInstructionsLine",
+] as const;
+
+export const GAME_STORYBOARD_IMAGE_PROMPT_TEMPLATE = [
+  "${sceneTitleLine}",
+  "Scene moment: ${scenePrompt}",
+  "${narrativePurposeLine}",
+  "${charactersLine}",
+  "${referenceHandlingLine}",
+  "${appearanceNotesBlock}",
+  "${artDirectionLine}",
+  "${imagePromptInstructionsLine}",
+].join("\n");
+
+export const STORYBOARD_OPTIMIZED_IMAGE_PROMPT_TEMPLATE = [
+  "${sceneTitleLine}",
+  "Storyboard keyframe: ${scenePrompt}",
+  "${referenceHandlingLine}",
+  "${appearanceNotesBlock}",
+  "${artDirectionLine}",
+  "${imagePromptInstructionsLine}",
+].join("\n");
+
+export const GAME_STORYBOARD_IMAGE_BUILT_IN_PROMPT_TEMPLATES: AgentPromptTemplateOption[] = [
+  {
+    id: GAME_STORYBOARD_IMAGE_PROMPT_TEMPLATE_ID,
+    name: "Game Scene Illustration",
+    description:
+      "Uses the standard Game Mode scene-illustration formatter. Existing chats keep this behavior by default.",
+    promptTemplate: GAME_STORYBOARD_IMAGE_PROMPT_TEMPLATE,
+  },
+  {
+    id: STORYBOARD_OPTIMIZED_IMAGE_PROMPT_TEMPLATE_ID,
+    name: "Storyboard Illustration",
+    description:
+      "Keeps the planner's keyframe description primary while adding character references, appearance, campaign art direction, and image instructions.",
+    promptTemplate: STORYBOARD_OPTIMIZED_IMAGE_PROMPT_TEMPLATE,
+  },
+];

--- a/packages/shared/src/constants/game-storyboard-prompts.ts
+++ b/packages/shared/src/constants/game-storyboard-prompts.ts
@@ -42,6 +42,9 @@ export const GAME_STORYBOARD_PROMPT_TEMPLATE_VARIABLES = [
   "aspectRatio",
 ] as const;
 
+export const GAME_STORYBOARD_KEYFRAME_JSON_SHAPE_LINE =
+  '{ "title": string, "keyframes": [ { "title": string, "sectionStartIndex": number, "sectionEndIndex": number, "anchorQuote": string, "anchorKind": "narration" | "dialogue" | "readable" | "system", "narrationBeat": string, "imagePrompt": string, "characters": string[] } ] }';
+
 const GAME_STORYBOARD_SHARED_STILL_PROMPT_LINES = [
   "Create exactly ${keyframeCount} ordered keyframes unless the narration is too short to support that many; never create more than 6.",
   "Every keyframe is a still ${aspectRatio} illustration prompt. Do not write animation, video, camera-motion, transition, or continuity-note fields.",
@@ -57,7 +60,7 @@ export const GAME_STORYBOARD_STILL_PROMPT_TEMPLATE = [
   "Image prompts must be compact and concrete: visible characters, action, expression, pose, camera angle, composition, setting, lighting, mood, and key props.",
   "Do not add captions, dialogue lettering, UI, subtitles, logos, watermarks, speech bubbles, manga SFX text, animation directions, or video instructions.",
   "Return strict JSON only with this shape:",
-  '{ "title": string, "keyframes": [ { "title": string, "sectionStartIndex": number, "sectionEndIndex": number, "anchorQuote": string, "anchorKind": "narration" | "dialogue" | "readable" | "system", "narrationBeat": string, "imagePrompt": string, "characters": string[] } ] }',
+  GAME_STORYBOARD_KEYFRAME_JSON_SHAPE_LINE,
 ].join("\n");
 
 export const GAME_STORYBOARD_NOVELAI_PROMPT_TEMPLATE = [
@@ -71,7 +74,7 @@ export const GAME_STORYBOARD_NOVELAI_PROMPT_TEMPLATE = [
   "Do not put the keyframe title, keyframe number, narrationBeat, commentary, Scene moment, Narrative purpose, Characters label, or any sentence inside imagePrompt.",
   "Do not add captions, dialogue lettering, UI, subtitles, logos, watermarks, speech bubbles, manga SFX text, or borders.",
   "Return strict JSON only with this shape:",
-  '{ "title": string, "keyframes": [ { "title": string, "sectionStartIndex": number, "sectionEndIndex": number, "anchorQuote": string, "anchorKind": "narration" | "dialogue" | "readable" | "system", "narrationBeat": string, "imagePrompt": string, "characters": string[] } ] }',
+  GAME_STORYBOARD_KEYFRAME_JSON_SHAPE_LINE,
 ].join("\n");
 
 export const GAME_STORYBOARD_COMIC_PROMPT_TEMPLATE = [
@@ -89,7 +92,7 @@ export const GAME_STORYBOARD_COMIC_PROMPT_TEMPLATE = [
   "The prompt must include a short readable text plan: dialogue bubbles for spoken lines, captions for narration/reaction beats, and SFX lettering for action. Draw text from the scene and keep it brief.",
   "Use the negativePrompt: watermark, logo, signature, UI chrome, unreadable text, broken lettering, malformed speech bubbles, blurry, low quality.",
   "Return strict JSON only with this shape:",
-  '{ "title": string, "keyframes": [ { "title": string, "sectionStartIndex": number, "sectionEndIndex": number, "anchorQuote": string, "anchorKind": "narration" | "dialogue" | "readable" | "system", "narrationBeat": string, "imagePrompt": string, "characters": string[] } ] }',
+  GAME_STORYBOARD_KEYFRAME_JSON_SHAPE_LINE,
 ].join("\n");
 
 export const GAME_STORYBOARD_COMIC_ANIMATION_PROMPT_TEMPLATE = [
@@ -112,7 +115,7 @@ export const GAME_STORYBOARD_COMIC_ANIMATION_PROMPT_TEMPLATE = [
   "Write narrationBeat as a complete, compact animation plan that uses the comic page as an ordered temporal reference. Allocate the full ${durationSeconds} seconds with natural-language time ranges, identify the primary subject motion, one simple camera move or panel transition at a time, and subtle secondary environmental motion. Reserve the final 0.4-0.7 seconds for the last panel's ending pose, expression, composition, or dramatic hold. Do not ask the video model to animate every panel at once, and never omit the final timed beat.",
   'End imagePrompt with this compact exclusion line: "Avoid: watermark, logo, signature, UI chrome, unreadable text, broken lettering, malformed speech bubbles, blurry, low quality, duplicated characters, merged panels, collapsed gutters, scrambled panel order."',
   "Return strict JSON only with this shape:",
-  '{ "title": string, "keyframes": [ { "title": string, "sectionStartIndex": number, "sectionEndIndex": number, "anchorQuote": string, "anchorKind": "narration" | "dialogue" | "readable" | "system", "narrationBeat": string, "imagePrompt": string, "characters": string[] } ] }',
+  GAME_STORYBOARD_KEYFRAME_JSON_SHAPE_LINE,
 ].join("\n");
 
 export const GAME_STORYBOARD_ANIME_EPISODE_PROMPT_TEMPLATE = [
@@ -150,7 +153,7 @@ export const GAME_STORYBOARD_ANIME_EPISODE_PROMPT_TEMPLATE = [
   "",
   "Anchor every keyframe to the supplied turn_sections using sectionStartIndex, sectionEndIndex, anchorQuote, and anchorKind.",
   "Return strict JSON only with this shape:",
-  '{ "title": string, "keyframes": [ { "title": string, "sectionStartIndex": number, "sectionEndIndex": number, "anchorQuote": string, "anchorKind": "narration" | "dialogue" | "readable" | "system", "narrationBeat": string, "imagePrompt": string, "characters": string[] } ] }',
+  GAME_STORYBOARD_KEYFRAME_JSON_SHAPE_LINE,
 ].join("\n");
 
 const GAME_STORYBOARD_SHARED_SINGLE_SHOT_ANIMATION_PROMPT_LINES = [
@@ -176,7 +179,7 @@ export const GAME_STORYBOARD_STILL_ANIMATION_PROMPT_TEMPLATE = [
   "Keep imagePrompt style-neutral so the campaign art style and Image Style profile can control the final rendering.",
   "Do not add captions, dialogue lettering, UI, subtitles, logos, watermarks, speech bubbles, manga SFX text, borders, multiple panels, animation directions, or video instructions to imagePrompt.",
   "Return strict JSON only with this shape:",
-  '{ "title": string, "keyframes": [ { "title": string, "sectionStartIndex": number, "sectionEndIndex": number, "anchorQuote": string, "anchorKind": "narration" | "dialogue" | "readable" | "system", "narrationBeat": string, "imagePrompt": string, "characters": string[] } ] }',
+  GAME_STORYBOARD_KEYFRAME_JSON_SHAPE_LINE,
 ].join("\n");
 
 export const GAME_STORYBOARD_NOVELAI_ANIMATION_PROMPT_TEMPLATE = [
@@ -189,7 +192,7 @@ export const GAME_STORYBOARD_NOVELAI_ANIMATION_PROMPT_TEMPLATE = [
   "Keep motion directions and timing in narrationBeat only. Do not put the keyframe title, keyframe number, narrationBeat, commentary, labels, sentences, later action states, or ending consequences inside imagePrompt.",
   "Do not add captions, dialogue lettering, UI, subtitles, logos, watermarks, speech bubbles, manga SFX text, borders, or multiple panels.",
   "Return strict JSON only with this shape:",
-  '{ "title": string, "keyframes": [ { "title": string, "sectionStartIndex": number, "sectionEndIndex": number, "anchorQuote": string, "anchorKind": "narration" | "dialogue" | "readable" | "system", "narrationBeat": string, "imagePrompt": string, "characters": string[] } ] }',
+  GAME_STORYBOARD_KEYFRAME_JSON_SHAPE_LINE,
 ].join("\n");
 
 export const GAME_STORYBOARD_COLORED_MANGA_ANIMATION_PROMPT_TEMPLATE = [
@@ -201,7 +204,7 @@ export const GAME_STORYBOARD_COLORED_MANGA_ANIMATION_PROMPT_TEMPLATE = [
   "Keep dialogue, captions, SFX, lettering, subtitles, logos, watermarks, UI, gutters, and multi-panel layouts out of imagePrompt so the video model receives one stable frame to animate.",
   "In narrationBeat, preserve the colored manga rendering while animating one dominant action, one simple camera behavior, subtle hair, fabric, particles, or lighting, and a clear ending hold.",
   "Return strict JSON only with this shape:",
-  '{ "title": string, "keyframes": [ { "title": string, "sectionStartIndex": number, "sectionEndIndex": number, "anchorQuote": string, "anchorKind": "narration" | "dialogue" | "readable" | "system", "narrationBeat": string, "imagePrompt": string, "characters": string[] } ] }',
+  GAME_STORYBOARD_KEYFRAME_JSON_SHAPE_LINE,
 ].join("\n");
 
 export const GAME_STORYBOARD_BW_MANGA_ANIMATION_PROMPT_TEMPLATE = [
@@ -213,7 +216,7 @@ export const GAME_STORYBOARD_BW_MANGA_ANIMATION_PROMPT_TEMPLATE = [
   "Keep color, dialogue, captions, SFX, lettering, subtitles, logos, watermarks, UI, gutters, and multi-panel layouts out of imagePrompt so the video model receives one stable frame to animate.",
   "In narrationBeat, preserve monochrome inks and screentone placement while animating one dominant action, one simple camera behavior, subtle hair, fabric, particles, or lighting, and a clear ending hold. Do not introduce color during the clip.",
   "Return strict JSON only with this shape:",
-  '{ "title": string, "keyframes": [ { "title": string, "sectionStartIndex": number, "sectionEndIndex": number, "anchorQuote": string, "anchorKind": "narration" | "dialogue" | "readable" | "system", "narrationBeat": string, "imagePrompt": string, "characters": string[] } ] }',
+  GAME_STORYBOARD_KEYFRAME_JSON_SHAPE_LINE,
 ].join("\n");
 
 export const GAME_STORYBOARD_COLORED_MANGA_PROMPT_TEMPLATE = [
@@ -231,7 +234,7 @@ export const GAME_STORYBOARD_COLORED_MANGA_PROMPT_TEMPLATE = [
   "The prompt must include a short readable text plan: manga dialogue bubbles for spoken lines, captions for narration/reaction beats, and SFX for action. Use text from the scene and keep it brief.",
   "Use the negativePrompt: watermark, logo, signature, UI chrome, unreadable text, broken lettering, malformed speech bubbles, blurry, low quality.",
   "Return strict JSON only with this shape:",
-  '{ "title": string, "keyframes": [ { "title": string, "sectionStartIndex": number, "sectionEndIndex": number, "anchorQuote": string, "anchorKind": "narration" | "dialogue" | "readable" | "system", "narrationBeat": string, "imagePrompt": string, "characters": string[] } ] }',
+  GAME_STORYBOARD_KEYFRAME_JSON_SHAPE_LINE,
 ].join("\n");
 
 export const GAME_STORYBOARD_BW_MANGA_PROMPT_TEMPLATE = [
@@ -249,7 +252,7 @@ export const GAME_STORYBOARD_BW_MANGA_PROMPT_TEMPLATE = [
   "The prompt must include a short readable text plan: dialogue bubbles for spoken lines, captions for narration/reaction beats, and SFX for action. Use text from the scene and keep it brief.",
   "Use the negativePrompt: watermark, logo, signature, UI chrome, unreadable text, broken lettering, malformed speech bubbles, blurry, low quality, color painting, full-color render.",
   "Return strict JSON only with this shape:",
-  '{ "title": string, "keyframes": [ { "title": string, "sectionStartIndex": number, "sectionEndIndex": number, "anchorQuote": string, "anchorKind": "narration" | "dialogue" | "readable" | "system", "narrationBeat": string, "imagePrompt": string, "characters": string[] } ] }',
+  GAME_STORYBOARD_KEYFRAME_JSON_SHAPE_LINE,
 ].join("\n");
 
 export const GAME_STORYBOARD_ILLUSTRATION_PROMPT_TEMPLATES: AgentPromptTemplateOption[] = [

--- a/packages/shared/src/constants/game-storyboard-prompts.ts
+++ b/packages/shared/src/constants/game-storyboard-prompts.ts
@@ -1,12 +1,17 @@
 import type { AgentPromptTemplateOption } from "../types/agent.js";
 
 export const GAME_STORYBOARD_ILLUSTRATION_PROMPT_TEMPLATE_ID = "still-keyframes";
-export const GAME_STORYBOARD_ANIMATION_PROMPT_TEMPLATE_ID = "comic-page-keyframes";
+export const GAME_STORYBOARD_COMIC_PROMPT_TEMPLATE_ID = "comic-page-keyframes";
+export const GAME_STORYBOARD_STILL_ANIMATION_PROMPT_TEMPLATE_ID = "still-keyframes-animation";
 export const GAME_STORYBOARD_COMIC_ANIMATION_PROMPT_TEMPLATE_ID = "comic-page-animation";
+export const GAME_STORYBOARD_ANIMATION_PROMPT_TEMPLATE_ID = GAME_STORYBOARD_COMIC_ANIMATION_PROMPT_TEMPLATE_ID;
 export const GAME_STORYBOARD_ANIME_EPISODE_PROMPT_TEMPLATE_ID = "anime-episode-director";
 export const GAME_STORYBOARD_COLORED_MANGA_PROMPT_TEMPLATE_ID = "colored-manga-keyframes";
 export const GAME_STORYBOARD_BW_MANGA_PROMPT_TEMPLATE_ID = "bw-manga-keyframes";
 export const GAME_STORYBOARD_NOVELAI_PROMPT_TEMPLATE_ID = "novelai-keyframes";
+export const GAME_STORYBOARD_NOVELAI_ANIMATION_PROMPT_TEMPLATE_ID = "novelai-keyframes-animation";
+export const GAME_STORYBOARD_COLORED_MANGA_ANIMATION_PROMPT_TEMPLATE_ID = "colored-manga-keyframes-animation";
+export const GAME_STORYBOARD_BW_MANGA_ANIMATION_PROMPT_TEMPLATE_ID = "bw-manga-keyframes-animation";
 export const GAME_STORYBOARD_KEYFRAME_COUNT_MIN = 1;
 export const GAME_STORYBOARD_KEYFRAME_COUNT_MAX = 6;
 export const GAME_STORYBOARD_KEYFRAME_COUNT_DEFAULT = 3;
@@ -148,6 +153,69 @@ export const GAME_STORYBOARD_ANIME_EPISODE_PROMPT_TEMPLATE = [
   '{ "title": string, "keyframes": [ { "title": string, "sectionStartIndex": number, "sectionEndIndex": number, "anchorQuote": string, "anchorKind": "narration" | "dialogue" | "readable" | "system", "narrationBeat": string, "imagePrompt": string, "characters": string[] } ] }',
 ].join("\n");
 
+const GAME_STORYBOARD_SHARED_SINGLE_SHOT_ANIMATION_PROMPT_LINES = [
+  "Create exactly ${keyframeCount} ordered shots when the narration contains enough distinct visual beats. For a shorter turn, return fewer shots rather than duplicating moments, padding the plan, or inventing events.",
+  "Each keyframe becomes one continuous ${durationSeconds}-second image-to-video clip, not a comic page, montage, or collection of simultaneous panels.",
+  "Use only the GM narration as the story source. Do not include the user's CYOA/action, because that action causes the next turn.",
+  "Use the supplied turn_sections indices to anchor every keyframe to the story text. Prefer contiguous section ranges that cover the whole turn in order.",
+  "For each keyframe, set sectionStartIndex and sectionEndIndex to the first and last covered section indices. Set anchorQuote to a short exact phrase from those sections, and anchorKind to the dominant section kind.",
+  "Select one visually important action, reaction, reveal, transformation, emotional turn, establishing moment, or consequence per shot. Follow the narration chronologically and do not invent connective action, dialogue, characters, props, locations, or outcomes.",
+  "Keep character identity, face, hair, clothing, anatomy, injuries, equipment, carried objects, positions, environment, lighting, weather, and damage continuous between shots unless the narration visibly changes them.",
+  "imagePrompt describes only time T=0: the exact first frame immediately before or as the primary action begins. Include visible characters, expression, pose, camera angle, composition, setting, lighting, mood, and key props.",
+  "Choose a starting pose that naturally leads into the intended movement. Do not place consequences, final poses, displaced objects, opened mechanisms, new damage, or environmental changes in imagePrompt when they occur later in the clip.",
+  "narrationBeat is a compact animation direction in this order: Start: exact initial pose and state. Action: one primary character or object movement. Camera: one simple move or a locked camera. Environment: subtle secondary motion. End: final pose, expression, composition, or dramatic hold.",
+  "Allocate the full ${durationSeconds} seconds, keep the motion physically achievable from the generated first frame, and reserve the final 0.4-0.7 seconds for the ending hold.",
+  "Avoid abrupt cuts, scene changes, teleportation, simultaneous unrelated actions, new characters, costume changes, and transformations not supported by the narration.",
+] as const;
+
+export const GAME_STORYBOARD_STILL_ANIMATION_PROMPT_TEMPLATE = [
+  "You are Marinara's Game Mode Storyboard Animation Director.",
+  "Turn exactly one completed GM narration into a concise sequence of animation-ready visual shots.",
+  ...GAME_STORYBOARD_SHARED_SINGLE_SHOT_ANIMATION_PROMPT_LINES,
+  "Write imagePrompt as one compact, concrete ${aspectRatio} first-frame illustration: visible characters, starting action, expression, pose, camera angle, composition, setting, lighting, mood, and key props.",
+  "Keep imagePrompt style-neutral so the campaign art style and Image Style profile can control the final rendering.",
+  "Do not add captions, dialogue lettering, UI, subtitles, logos, watermarks, speech bubbles, manga SFX text, borders, multiple panels, animation directions, or video instructions to imagePrompt.",
+  "Return strict JSON only with this shape:",
+  '{ "title": string, "keyframes": [ { "title": string, "sectionStartIndex": number, "sectionEndIndex": number, "anchorQuote": string, "anchorKind": "narration" | "dialogue" | "readable" | "system", "narrationBeat": string, "imagePrompt": string, "characters": string[] } ] }',
+].join("\n");
+
+export const GAME_STORYBOARD_NOVELAI_ANIMATION_PROMPT_TEMPLATE = [
+  "You are Marinara's NovelAI Storyboard Animation Director.",
+  "Convert one completed GM narration into ordered, animation-ready anime shots with NovelAI V4/V4.5 first frames.",
+  ...GAME_STORYBOARD_SHARED_SINGLE_SHOT_ANIMATION_PROMPT_LINES,
+  "Write imagePrompt as one compact ASCII-only comma-separated NovelAI/Danbooru tag list, never prose or labelled sections.",
+  "Begin with concrete subject counts, then visible character identity or appearance, clothing, the T=0 starting action or pose, expression, camera framing, composition, setting, lighting, mood, and key props.",
+  "Use canonical character tags when known and concrete visual traits when a canonical tag is unavailable. Keep every named visible character synchronized with the characters array.",
+  "Keep motion directions and timing in narrationBeat only. Do not put the keyframe title, keyframe number, narrationBeat, commentary, labels, sentences, later action states, or ending consequences inside imagePrompt.",
+  "Do not add captions, dialogue lettering, UI, subtitles, logos, watermarks, speech bubbles, manga SFX text, borders, or multiple panels.",
+  "Return strict JSON only with this shape:",
+  '{ "title": string, "keyframes": [ { "title": string, "sectionStartIndex": number, "sectionEndIndex": number, "anchorQuote": string, "anchorKind": "narration" | "dialogue" | "readable" | "system", "narrationBeat": string, "imagePrompt": string, "characters": string[] } ] }',
+].join("\n");
+
+export const GAME_STORYBOARD_COLORED_MANGA_ANIMATION_PROMPT_TEMPLATE = [
+  "You are Marinara's Colored Manga Storyboard Animation Director.",
+  "Convert one completed GM narration into ordered, animation-ready colored manga shots.",
+  ...GAME_STORYBOARD_SHARED_SINGLE_SHOT_ANIMATION_PROMPT_LINES,
+  "Build imagePrompt as one clean ${aspectRatio} colored manga first frame with expressive linework, cel shading, flat color, controlled screentone texture, crisp silhouettes, and cinematic panel-inspired composition without drawing panel borders.",
+  "Use restrained speed lines, impact accents, or cloth and hair anticipation only when they belong to the T=0 starting state and can lead naturally into the planned motion.",
+  "Keep dialogue, captions, SFX, lettering, subtitles, logos, watermarks, UI, gutters, and multi-panel layouts out of imagePrompt so the video model receives one stable frame to animate.",
+  "In narrationBeat, preserve the colored manga rendering while animating one dominant action, one simple camera behavior, subtle hair, fabric, particles, or lighting, and a clear ending hold.",
+  "Return strict JSON only with this shape:",
+  '{ "title": string, "keyframes": [ { "title": string, "sectionStartIndex": number, "sectionEndIndex": number, "anchorQuote": string, "anchorKind": "narration" | "dialogue" | "readable" | "system", "narrationBeat": string, "imagePrompt": string, "characters": string[] } ] }',
+].join("\n");
+
+export const GAME_STORYBOARD_BW_MANGA_ANIMATION_PROMPT_TEMPLATE = [
+  "You are Marinara's Black-and-White Manga Storyboard Animation Director.",
+  "Convert one completed GM narration into ordered, animation-ready black-and-white manga shots.",
+  ...GAME_STORYBOARD_SHARED_SINGLE_SHOT_ANIMATION_PROMPT_LINES,
+  "Build imagePrompt as one clean ${aspectRatio} monochrome manga first frame with inked line art, strong line weight, stable screentones, heavy blacks, crisp silhouettes, and cinematic panel-inspired composition without drawing panel borders.",
+  "Use restrained speed lines, impact accents, or ink effects only when they belong to the T=0 starting state and can lead naturally into the planned motion.",
+  "Keep color, dialogue, captions, SFX, lettering, subtitles, logos, watermarks, UI, gutters, and multi-panel layouts out of imagePrompt so the video model receives one stable frame to animate.",
+  "In narrationBeat, preserve monochrome inks and screentone placement while animating one dominant action, one simple camera behavior, subtle hair, fabric, particles, or lighting, and a clear ending hold. Do not introduce color during the clip.",
+  "Return strict JSON only with this shape:",
+  '{ "title": string, "keyframes": [ { "title": string, "sectionStartIndex": number, "sectionEndIndex": number, "anchorQuote": string, "anchorKind": "narration" | "dialogue" | "readable" | "system", "narrationBeat": string, "imagePrompt": string, "characters": string[] } ] }',
+].join("\n");
+
 export const GAME_STORYBOARD_COLORED_MANGA_PROMPT_TEMPLATE = [
   "You are Marinara's Game Mode Storyboard Illustrator.",
   "Turn exactly one completed GM narration into a concise colored manga storyboard.",
@@ -184,7 +252,7 @@ export const GAME_STORYBOARD_BW_MANGA_PROMPT_TEMPLATE = [
   '{ "title": string, "keyframes": [ { "title": string, "sectionStartIndex": number, "sectionEndIndex": number, "anchorQuote": string, "anchorKind": "narration" | "dialogue" | "readable" | "system", "narrationBeat": string, "imagePrompt": string, "characters": string[] } ] }',
 ].join("\n");
 
-export const GAME_STORYBOARD_BUILT_IN_PROMPT_TEMPLATES: AgentPromptTemplateOption[] = [
+export const GAME_STORYBOARD_ILLUSTRATION_PROMPT_TEMPLATES: AgentPromptTemplateOption[] = [
   {
     id: GAME_STORYBOARD_ILLUSTRATION_PROMPT_TEMPLATE_ID,
     name: "Still Keyframes",
@@ -200,25 +268,11 @@ export const GAME_STORYBOARD_BUILT_IN_PROMPT_TEMPLATES: AgentPromptTemplateOptio
     promptTemplate: GAME_STORYBOARD_NOVELAI_PROMPT_TEMPLATE,
   },
   {
-    id: GAME_STORYBOARD_ANIMATION_PROMPT_TEMPLATE_ID,
+    id: GAME_STORYBOARD_COMIC_PROMPT_TEMPLATE_ID,
     name: "Comic Page",
     description:
       "Game Mode illustration preset with comic panels, dialogue, captions, and SFX.",
     promptTemplate: GAME_STORYBOARD_COMIC_PROMPT_TEMPLATE,
-  },
-  {
-    id: GAME_STORYBOARD_COMIC_ANIMATION_PROMPT_TEMPLATE_ID,
-    name: "Comic Page Animation",
-    description:
-      "Plans duration-aware comic pages as ordered visual references for automatic animations.",
-    promptTemplate: GAME_STORYBOARD_COMIC_ANIMATION_PROMPT_TEMPLATE,
-  },
-  {
-    id: GAME_STORYBOARD_ANIME_EPISODE_PROMPT_TEMPLATE_ID,
-    name: "Anime Episode Director",
-    description:
-      "Plans single-shot first frames and compact motion direction from each completed GM turn.",
-    promptTemplate: GAME_STORYBOARD_ANIME_EPISODE_PROMPT_TEMPLATE,
   },
   {
     id: GAME_STORYBOARD_COLORED_MANGA_PROMPT_TEMPLATE_ID,
@@ -235,3 +289,66 @@ export const GAME_STORYBOARD_BUILT_IN_PROMPT_TEMPLATES: AgentPromptTemplateOptio
     promptTemplate: GAME_STORYBOARD_BW_MANGA_PROMPT_TEMPLATE,
   },
 ];
+
+export const GAME_STORYBOARD_ANIMATION_PROMPT_TEMPLATES: AgentPromptTemplateOption[] = [
+  {
+    id: GAME_STORYBOARD_STILL_ANIMATION_PROMPT_TEMPLATE_ID,
+    name: "Still Keyframe Animation",
+    description: "Plans one style-neutral first frame and one achievable continuous motion direction per clip.",
+    promptTemplate: GAME_STORYBOARD_STILL_ANIMATION_PROMPT_TEMPLATE,
+  },
+  {
+    id: GAME_STORYBOARD_ANIME_EPISODE_PROMPT_TEMPLATE_ID,
+    name: "Anime Episode Director",
+    description:
+      "Plans broadcast-anime single shots with first-frame continuity, compact motion direction, and provider-safe staging.",
+    promptTemplate: GAME_STORYBOARD_ANIME_EPISODE_PROMPT_TEMPLATE,
+  },
+  {
+    id: GAME_STORYBOARD_NOVELAI_ANIMATION_PROMPT_TEMPLATE_ID,
+    name: "NovelAI Keyframe Animation",
+    description:
+      "Plans NovelAI V4/V4.5 tag-based first frames while keeping timing and motion in a separate animation direction.",
+    promptTemplate: GAME_STORYBOARD_NOVELAI_ANIMATION_PROMPT_TEMPLATE,
+  },
+  {
+    id: GAME_STORYBOARD_COMIC_ANIMATION_PROMPT_TEMPLATE_ID,
+    name: "Comic Page Animation",
+    description: "Plans duration-aware comic pages as ordered visual references for automatic animations.",
+    promptTemplate: GAME_STORYBOARD_COMIC_ANIMATION_PROMPT_TEMPLATE,
+  },
+  {
+    id: GAME_STORYBOARD_COLORED_MANGA_ANIMATION_PROMPT_TEMPLATE_ID,
+    name: "Colored Manga Animation",
+    description: "Plans a text-free colored manga first frame with motion that preserves linework and cel shading.",
+    promptTemplate: GAME_STORYBOARD_COLORED_MANGA_ANIMATION_PROMPT_TEMPLATE,
+  },
+  {
+    id: GAME_STORYBOARD_BW_MANGA_ANIMATION_PROMPT_TEMPLATE_ID,
+    name: "B&W Manga Animation",
+    description: "Plans a text-free monochrome first frame with motion that preserves inks and screentones.",
+    promptTemplate: GAME_STORYBOARD_BW_MANGA_ANIMATION_PROMPT_TEMPLATE,
+  },
+];
+
+export const GAME_STORYBOARD_BUILT_IN_PROMPT_TEMPLATES: AgentPromptTemplateOption[] = [
+  ...GAME_STORYBOARD_ILLUSTRATION_PROMPT_TEMPLATES,
+  ...GAME_STORYBOARD_ANIMATION_PROMPT_TEMPLATES,
+];
+
+export type GameStoryboardPromptTemplateKind = "illustration" | "animation";
+
+const GAME_STORYBOARD_ANIMATION_PROMPT_TEMPLATE_IDS = new Set(
+  GAME_STORYBOARD_ANIMATION_PROMPT_TEMPLATES.map((template) => template.id),
+);
+
+export function getGameStoryboardPromptTemplateKind(
+  template: AgentPromptTemplateOption,
+  selectedAnimationTemplateId?: string | null,
+): GameStoryboardPromptTemplateKind {
+  if (GAME_STORYBOARD_ANIMATION_PROMPT_TEMPLATE_IDS.has(template.id)) return "animation";
+  if (template.id.startsWith("custom-animation-")) return "animation";
+  if (template.id.startsWith("custom-illustration-")) return "illustration";
+  if (selectedAnimationTemplateId?.trim() === template.id) return "animation";
+  return template.promptTemplate.includes("${durationSeconds}") ? "animation" : "illustration";
+}

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -66,6 +66,7 @@ export * from "./constants/image-style-profiles.js";
 export * from "./constants/security.js";
 export * from "./constants/game-assets.js";
 export * from "./constants/game-storyboard-prompts.js";
+export * from "./constants/game-storyboard-image-prompts.js";
 export * from "./constants/game-video-prompts.js";
 export * from "./constants/conversation-prompt.js";
 export * from "./constants/game-prompt.js";

--- a/packages/shared/src/types/chat.ts
+++ b/packages/shared/src/types/chat.ts
@@ -506,6 +506,10 @@ export interface ChatMetadata {
   gameStoryboardVideoPromptTemplateId?: string | null;
   /** Chat-local Game Mode scene/storyboard video prompt templates. */
   gameVideoPromptTemplates?: import("./agent.js").AgentPromptTemplateOption[];
+  /** Selected provider-facing image prompt template for storyboard keyframes. */
+  gameStoryboardImagePromptTemplateId?: string | null;
+  /** Chat-local provider-facing storyboard image prompt templates. */
+  gameStoryboardImagePromptTemplates?: import("./agent.js").AgentPromptTemplateOption[];
   /** When true, completed Game Mode GM turns automatically create storyboard keyframe illustrations. */
   gameStoryboardAutoIllustrationsEnabled?: boolean;
   /** When true, completed Game Mode GM turns automatically create storyboard keyframe videos. */

--- a/packages/shared/src/types/game.ts
+++ b/packages/shared/src/types/game.ts
@@ -191,6 +191,8 @@ export interface GameSetupConfig {
   gameGmPromptTemplateId?: string | null;
   /** Selected animation-ready storyboard director template. */
   gameStoryboardAnimationPromptTemplateId?: string | null;
+  /** Selected provider-facing image prompt template for storyboard keyframes. */
+  gameStoryboardImagePromptTemplateId?: string | null;
   /** Selected prompt template used only for storyboard keyframe videos. */
   gameStoryboardVideoPromptTemplateId?: string | null;
   /** Send storyboard imagePrompt directly to the image compiler/provider. */

--- a/scripts/regressions/open-issues.regression.ts
+++ b/scripts/regressions/open-issues.regression.ts
@@ -429,7 +429,7 @@ const sharedGameSetup = formatGameSetupShareText({
     personaName: "Player Persona",
   },
 });
-assert.match(sharedGameSetup, /Presentation: Anime Episode/u);
+assert.match(sharedGameSetup, /Presentation: Storyboard Optimized/u);
 assert.match(sharedGameSetup, /Temperature: 1\.1/u);
 assert.match(sharedGameSetup, /Max Tokens: 16384/u);
 assert.match(sharedGameSetup, /gpt-5\.6-sol/iu);

--- a/scripts/regressions/prompt.regression.ts
+++ b/scripts/regressions/prompt.regression.ts
@@ -33,15 +33,29 @@ import {
   GAME_VIDEO_BUILT_IN_PROMPT_TEMPLATES,
   GAME_VIDEO_PROMPT_TEMPLATE,
   GAME_STORYBOARD_ANIMATION_PROMPT_TEMPLATE_ID,
+  GAME_STORYBOARD_ANIMATION_PROMPT_TEMPLATES,
   GAME_STORYBOARD_ANIME_EPISODE_PROMPT_TEMPLATE_ID,
+  GAME_STORYBOARD_BW_MANGA_ANIMATION_PROMPT_TEMPLATE,
   GAME_STORYBOARD_BUILT_IN_PROMPT_TEMPLATES,
   GAME_STORYBOARD_COMIC_ANIMATION_PROMPT_TEMPLATE,
   GAME_STORYBOARD_COMIC_ANIMATION_PROMPT_TEMPLATE_ID,
+  GAME_STORYBOARD_COMIC_PROMPT_TEMPLATE_ID,
   GAME_STORYBOARD_COMIC_PROMPT_TEMPLATE,
+  GAME_STORYBOARD_COLORED_MANGA_ANIMATION_PROMPT_TEMPLATE,
+  GAME_STORYBOARD_ILLUSTRATION_PROMPT_TEMPLATES,
+  GAME_STORYBOARD_IMAGE_BUILT_IN_PROMPT_TEMPLATES,
+  GAME_STORYBOARD_IMAGE_PROMPT_TEMPLATE_ID,
+  STORYBOARD_OPTIMIZED_IMAGE_PROMPT_TEMPLATE,
+  STORYBOARD_OPTIMIZED_IMAGE_PROMPT_TEMPLATE_ID,
+  GAME_STORYBOARD_NOVELAI_ANIMATION_PROMPT_TEMPLATE,
+  GAME_STORYBOARD_NOVELAI_ANIMATION_PROMPT_TEMPLATE_ID,
   GAME_STORYBOARD_NOVELAI_PROMPT_TEMPLATE,
   GAME_STORYBOARD_NOVELAI_PROMPT_TEMPLATE_ID,
+  GAME_STORYBOARD_STILL_ANIMATION_PROMPT_TEMPLATE,
+  GAME_STORYBOARD_STILL_ANIMATION_PROMPT_TEMPLATE_ID,
   DEFERRED_RELOCATION_CONDITIONAL_TOKEN_RE,
   hasDeferredRelocationConditionals,
+  getGameStoryboardPromptTemplateKind,
   normalizeGameStoryboardKeyframeCount,
   parseDeferredConditionalPayload,
   selectConditionalPayloadBranch,
@@ -54,6 +68,7 @@ import {
 } from "../../packages/server/src/services/agents/agent-executor.js";
 import type { ResolvedAgent } from "../../packages/server/src/services/agents/agent-pipeline.js";
 import { loadGameVideoPrompt } from "../../packages/server/src/services/video/game-video-prompt.js";
+import { loadGameStoryboardImagePrompt } from "../../packages/server/src/services/image/game-storyboard-image-prompt.js";
 import { formatAgentFailuresToast, toAgentFailure } from "../../packages/client/src/lib/agent-failures.js";
 import { formatGenerationParameterError } from "../../packages/client/src/lib/generation-parameter-errors.js";
 import {
@@ -945,7 +960,7 @@ const cases: RegressionCase[] = [
     },
   },
   {
-    name: "Anime Game presets stay keyframe-aware and causally animation-ready",
+    name: "Storyboard Game presets stay keyframe-aware and causally animation-ready",
     run() {
       const gameSetupWizardSource = readFileSync(
         new URL("../../packages/client/src/components/game/GameSetupWizard.tsx", import.meta.url),
@@ -972,6 +987,7 @@ const cases: RegressionCase[] = [
       assert.equal(normalizeGameStoryboardKeyframeCount(0), 1);
       assert.equal(normalizeGameStoryboardKeyframeCount(12), 6);
       assert.equal(gmPreset?.promptTemplate, ANIME_GAME_SYSTEM_PROMPT);
+      assert.equal(gmPreset?.name, "Storyboard Game Prompt");
       assert.match(resolvedGmPrompt, /Aim to include 5 strong visual anchor moments/);
       assert.doesNotMatch(resolvedGmPrompt, /\{\{gameStoryboardKeyframeCount\}\}/);
       assert.match(directorPreset?.promptTemplate ?? "", /time T=0: the exact first frame/);
@@ -982,13 +998,18 @@ const cases: RegressionCase[] = [
         gameSetupWizardSource,
         /gamePresentation === "anime"\s*\? GAME_STORYBOARD_COMIC_ANIMATION_PROMPT_TEMPLATE_ID/,
       );
+      assert.match(
+        gameSetupWizardSource,
+        /gamePresentation === "anime"\s*\? STORYBOARD_OPTIMIZED_IMAGE_PROMPT_TEMPLATE_ID/,
+      );
       assert.match(gameSetupWizardSource, /gamePresentation === "anime"\s*\? COMIC_PAGE_GAME_VIDEO_PROMPT_TEMPLATE_ID/);
+      assert.doesNotMatch(gameSetupWizardSource, /gameStoryboardUseDirectScenePrompt:\s*gamePresentation === "anime"/);
       assert.match(gameSetupWizardSource, /trimmedGameSystemPrompt !== effectiveGameSystemPrompt\.trim\(\)/);
       assert.match(gameSetupWizardSource, /Reset to selected/);
     },
   },
   {
-    name: "custom Game GM text wins over a selected Anime Game preset",
+    name: "custom Game GM text wins over a selected Storyboard Game preset",
     run() {
       assert.equal(
         resolveGameGmPromptTemplate({
@@ -1088,10 +1109,86 @@ const cases: RegressionCase[] = [
     },
   },
   {
-    name: "Comic Page illustration and animation presets remain separate prompt contracts",
+    name: "Storyboard Illustration Prompt preserves legacy fallback and supports selected chat templates",
+    async run() {
+      const promptOverridesStorage = {
+        async get(key: string) {
+          if (key !== "game.sceneIllustration") return null;
+          return {
+            key,
+            template: "GLOBAL SCENE ${scenePrompt}",
+            enabled: true,
+            updatedAt: "2026-01-01T00:00:00.000Z",
+          };
+        },
+        async list() {
+          return [];
+        },
+        async upsert(input) {
+          return {
+            key: input.key,
+            template: input.template,
+            enabled: input.enabled,
+            updatedAt: "2026-01-01T00:00:00.000Z",
+          };
+        },
+        async remove() {},
+      } satisfies PromptOverridesStorage;
+      const ctx = {
+        sceneTitleLine: "Mira at the gate.",
+        scenePrompt: "Mira braces beneath a storm-lit archway.",
+        narrativePurposeLine: "Narrative purpose: arrival.",
+        charactersLine: "Characters: Mira.",
+        referenceHandlingLine: "Reference handling: match the attached portrait.",
+        appearanceNotesBlock: "",
+        artDirectionLine: "Art direction: painterly fantasy.",
+        imagePromptInstructionsLine: "User image instructions: keep the silver cloak.",
+      };
+
+      const legacyPrompt = await loadGameStoryboardImagePrompt({ promptOverridesStorage, ctx });
+      const optimizedPrompt = await loadGameStoryboardImagePrompt({
+        promptOverridesStorage,
+        templateId: STORYBOARD_OPTIMIZED_IMAGE_PROMPT_TEMPLATE_ID,
+        ctx,
+      });
+      const customPrompt = await loadGameStoryboardImagePrompt({
+        promptOverridesStorage,
+        templateId: "custom-storyboard-image",
+        customTemplates: [
+          {
+            id: "custom-storyboard-image",
+            name: "Custom Storyboard Image",
+            promptTemplate: "CUSTOM ${scenePrompt} ${artDirectionLine}",
+          },
+        ],
+        ctx,
+      });
+
+      assert.equal(legacyPrompt, "GLOBAL SCENE Mira braces beneath a storm-lit archway.");
+      assert.match(optimizedPrompt, /Storyboard keyframe: Mira braces beneath a storm-lit archway/);
+      assert.match(optimizedPrompt, /Reference handling: match the attached portrait/);
+      assert.match(optimizedPrompt, /Art direction: painterly fantasy/);
+      assert.doesNotMatch(optimizedPrompt, /GLOBAL SCENE/);
+      assert.equal(customPrompt, "CUSTOM Mira braces beneath a storm-lit archway. Art direction: painterly fantasy.");
+      assert.equal(GAME_STORYBOARD_IMAGE_BUILT_IN_PROMPT_TEMPLATES.length, 2);
+      assert.equal(
+        GAME_STORYBOARD_IMAGE_BUILT_IN_PROMPT_TEMPLATES.find(
+          (template) => template.id === STORYBOARD_OPTIMIZED_IMAGE_PROMPT_TEMPLATE_ID,
+        )?.promptTemplate,
+        STORYBOARD_OPTIMIZED_IMAGE_PROMPT_TEMPLATE,
+      );
+      assert.equal(GAME_STORYBOARD_IMAGE_PROMPT_TEMPLATE_ID, "game-scene-illustration");
+    },
+  },
+  {
+    name: "Storyboard illustration and animation lanes remain separate prompt contracts",
     run() {
       const drawerSource = readFileSync(
         new URL("../../packages/client/src/components/chat/ChatSettingsDrawer.tsx", import.meta.url),
+        "utf8",
+      );
+      const gameRouteSource = readFileSync(
+        new URL("../../packages/server/src/routes/game.routes.ts", import.meta.url),
         "utf8",
       );
       const gameSurfaceSource = readFileSync(
@@ -1102,14 +1199,39 @@ const cases: RegressionCase[] = [
         new URL("../../packages/client/src/components/game/StoryboardBackgroundControls.tsx", import.meta.url),
         "utf8",
       );
-      const illustrationPreset = GAME_STORYBOARD_BUILT_IN_PROMPT_TEMPLATES.find(
-        (template) => template.id === "comic-page-keyframes",
+      const illustrationPreset = GAME_STORYBOARD_ILLUSTRATION_PROMPT_TEMPLATES.find(
+        (template) => template.id === GAME_STORYBOARD_COMIC_PROMPT_TEMPLATE_ID,
       );
-      const animationPreset = GAME_STORYBOARD_BUILT_IN_PROMPT_TEMPLATES.find(
+      const animationPreset = GAME_STORYBOARD_ANIMATION_PROMPT_TEMPLATES.find(
         (template) => template.id === GAME_STORYBOARD_COMIC_ANIMATION_PROMPT_TEMPLATE_ID,
       );
+      const stillAnimationPreset = GAME_STORYBOARD_ANIMATION_PROMPT_TEMPLATES.find(
+        (template) => template.id === GAME_STORYBOARD_STILL_ANIMATION_PROMPT_TEMPLATE_ID,
+      );
+      const illustrationIds = new Set(GAME_STORYBOARD_ILLUSTRATION_PROMPT_TEMPLATES.map((template) => template.id));
+      const animationIds = new Set(GAME_STORYBOARD_ANIMATION_PROMPT_TEMPLATES.map((template) => template.id));
 
+      assert.equal(GAME_STORYBOARD_ILLUSTRATION_PROMPT_TEMPLATES.length, 5);
+      assert.equal(GAME_STORYBOARD_ANIMATION_PROMPT_TEMPLATES.length, 6);
+      assert.equal(GAME_STORYBOARD_ANIMATION_PROMPT_TEMPLATE_ID, GAME_STORYBOARD_COMIC_ANIMATION_PROMPT_TEMPLATE_ID);
+      assert.notEqual(
+        GAME_STORYBOARD_STILL_ANIMATION_PROMPT_TEMPLATE_ID,
+        GAME_STORYBOARD_ANIME_EPISODE_PROMPT_TEMPLATE_ID,
+      );
+      assert.deepEqual([...illustrationIds].filter((id) => animationIds.has(id)), []);
+      assert.ok(
+        GAME_STORYBOARD_ILLUSTRATION_PROMPT_TEMPLATES.every(
+          (template) => !template.promptTemplate.includes("${durationSeconds}"),
+        ),
+      );
+      assert.ok(
+        GAME_STORYBOARD_ANIMATION_PROMPT_TEMPLATES.every((template) =>
+          template.promptTemplate.includes("${durationSeconds}"),
+        ),
+      );
       assert.equal(illustrationPreset?.promptTemplate, GAME_STORYBOARD_COMIC_PROMPT_TEMPLATE);
+      assert.equal(stillAnimationPreset?.promptTemplate, GAME_STORYBOARD_STILL_ANIMATION_PROMPT_TEMPLATE);
+      assert.match(stillAnimationPreset?.promptTemplate ?? "", /style-neutral/);
       assert.match(illustrationPreset?.promptTemplate ?? "", /2-6 panels per illustration/);
       assert.doesNotMatch(illustrationPreset?.promptTemplate ?? "", /\$\{durationSeconds\}-second/);
       assert.equal(animationPreset?.promptTemplate, GAME_STORYBOARD_COMIC_ANIMATION_PROMPT_TEMPLATE);
@@ -1125,12 +1247,42 @@ const cases: RegressionCase[] = [
       assert.match(animationPreset?.promptTemplate ?? "", /Reserve the final 0.4-0.7 seconds/);
       assert.match(animationPreset?.promptTemplate ?? "", /Do not ask the video model to animate every panel at once/);
       assert.doesNotMatch(animationPreset?.promptTemplate ?? "", /2-6 panels per illustration/);
+      assert.match(GAME_STORYBOARD_NOVELAI_ANIMATION_PROMPT_TEMPLATE, /timing in narrationBeat only/);
+      assert.match(GAME_STORYBOARD_COLORED_MANGA_ANIMATION_PROMPT_TEMPLATE, /one stable frame to animate/);
+      assert.match(GAME_STORYBOARD_BW_MANGA_ANIMATION_PROMPT_TEMPLATE, /Do not introduce color during the clip/);
+      assert.equal(
+        getGameStoryboardPromptTemplateKind({
+          id: "custom-animation-example",
+          name: "Example",
+          promptTemplate: "Custom prompt",
+        }),
+        "animation",
+      );
+      assert.equal(
+        getGameStoryboardPromptTemplateKind({
+          id: "legacy-custom",
+          name: "Legacy",
+          promptTemplate: "Plan a ${durationSeconds}-second clip",
+        }),
+        "animation",
+      );
       assert.match(COMIC_PAGE_GAME_VIDEO_PROMPT_TEMPLATE, /no more than 0.35 seconds/);
       assert.match(COMIC_PAGE_GAME_VIDEO_PROMPT_TEMPLATE, /reveal a later consequence before its cause/);
-      assert.match(drawerSource, /onAddTemplate\(GAME_STORYBOARD_COMIC_ANIMATION_PROMPT_TEMPLATE_ID\)/);
-      assert.match(drawerSource, /Add Comic Animation Copy/);
-      assert.match(drawerSource, /onAddTemplate\(COMIC_PAGE_GAME_VIDEO_PROMPT_TEMPLATE_ID\)/);
-      assert.match(drawerSource, /Add Comic Video Copy/);
+      assert.match(drawerSource, /options=\{gameStoryboardIllustrationPromptOptions\}/);
+      assert.match(drawerSource, /options=\{gameStoryboardAnimationPromptOptions\}/);
+      assert.match(drawerSource, /label="Illustration Planner"/);
+      assert.match(drawerSource, /label="Animation Planner"/);
+      assert.match(drawerSource, /label="Storyboard Illustration Prompt"/);
+      assert.match(drawerSource, /options=\{gameStoryboardImagePromptOptions\}/);
+      assert.match(drawerSource, /label="Storyboard Video Prompt"/);
+      assert.match(drawerSource, /kind="illustration"/);
+      assert.match(drawerSource, /kind="animation"/);
+      assert.match(drawerSource, /builtInTemplates\.map\(\(template\) =>/);
+      assert.match(gameRouteSource, /getGameStoryboardPromptTemplateKind\(template, selectedAnimationTemplateId\)/);
+      assert.match(gameRouteSource, /const builtInTemplates = args\.generateVideos/);
+      assert.match(gameRouteSource, /storyboardImagePromptTemplateId: readTrimmedString\(meta\.gameStoryboardImagePromptTemplateId\)/);
+      assert.match(drawerSource, /title="Edit Illustration Prompt Presets"/);
+      assert.match(drawerSource, /title="Edit Video Prompt Presets"/);
       const backgroundViewerStart = gameSurfaceSource.indexOf("const renderStoryboardBackgroundVisual");
       const backgroundViewerEnd = gameSurfaceSource.indexOf("const renderGameAssetsPanel", backgroundViewerStart);
       const backgroundViewerSource = gameSurfaceSource.slice(backgroundViewerStart, backgroundViewerEnd);
@@ -1252,6 +1404,9 @@ const cases: RegressionCase[] = [
       const preset = GAME_STORYBOARD_BUILT_IN_PROMPT_TEMPLATES.find(
         (template) => template.id === GAME_STORYBOARD_NOVELAI_PROMPT_TEMPLATE_ID,
       );
+      const animationPreset = GAME_STORYBOARD_ANIMATION_PROMPT_TEMPLATES.find(
+        (template) => template.id === GAME_STORYBOARD_NOVELAI_ANIMATION_PROMPT_TEMPLATE_ID,
+      );
 
       assert.equal(preset?.promptTemplate, GAME_STORYBOARD_NOVELAI_PROMPT_TEMPLATE);
       assert.match(preset?.promptTemplate ?? "", /ASCII-only comma-separated NovelAI\/Danbooru tag list/);
@@ -1259,9 +1414,11 @@ const cases: RegressionCase[] = [
       assert.match(preset?.promptTemplate ?? "", /Do not put the keyframe title/);
       assert.match(preset?.promptTemplate ?? "", /\$\{keyframeCount\}/);
       assert.match(preset?.promptTemplate ?? "", /\$\{aspectRatio\}/);
+      assert.equal(animationPreset?.promptTemplate, GAME_STORYBOARD_NOVELAI_ANIMATION_PROMPT_TEMPLATE);
+      assert.match(animationPreset?.promptTemplate ?? "", /\$\{durationSeconds\}-second/);
       assert.match(drawerSource, /label="Use NovelAI Character Prompts"/);
-      assert.match(drawerSource, /onAddTemplate\(GAME_STORYBOARD_NOVELAI_PROMPT_TEMPLATE_ID\)/);
-      assert.match(drawerSource, /Add NovelAI Copy/);
+      assert.match(drawerSource, /builtInTemplates=\{GAME_STORYBOARD_ILLUSTRATION_PROMPT_TEMPLATES\}/);
+      assert.match(drawerSource, /builtInTemplates=\{GAME_STORYBOARD_ANIMATION_PROMPT_TEMPLATES\}/);
       assert.match(gameRouteSource, /meta\.gameStoryboardUseNovelAiCharacterPrompts !== false/);
       assert.match(gameRouteSource, /useNovelAiCharacterPrompts\s*&&\s*providerSupportsStructuredCharacterPrompts/);
     },


### PR DESCRIPTION
## Linked issue

Closes #3568

## Why this change

- Storyboard settings mixed still-image planning, animation planning, and final provider requests in the same selectors and editors. Users could not easily tell which prompt controlled the keyframe plan versus the image or video request ultimately sent to a model.
- The Anime Episode presentation label described only one style even though the profile coordinates several storyboard-specific prompts.

## What changed

- Split storyboard planning into **Still Storyboards / Illustration Planner** and **Animated Storyboards / Animation Planner**, with lane-specific built-ins and custom copies.
- Added a selectable and chat-editable **Storyboard Illustration Prompt**, including a storyboard-optimized built-in and a compatibility fallback for existing games.
- Kept **Anime Episode Director** as a distinct Animation Planner while renaming the coordinated presentation to **Storyboard Optimized**.
- Made Storyboard Optimized select Storyboard Game Prompt, Comic Page Animation, Storyboard Illustration, and Comic Page Video.
- Updated server routing, shared metadata/types, docs, setup sharing, and regression coverage.

## Validation

- [x] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [x] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed `CONTRIBUTING.md`

Commands and automated checks completed:

- `pnpm check`
- `pnpm regression:prompt`
- `pnpm regression:issues`
- `pnpm smoke:ui` equivalent against an explicitly initialized isolated stack: 36 passed, 24 intentionally skipped
- `git diff --check`
- Shared, server, and client package builds

### Manual verification notes

- Agent browser QA: opened New Game, selected **Storyboard Optimized**, and confirmed the four-part coordinated summary.
- Agent browser QA: opened an existing game's Chat Settings and confirmed Illustration Planner, Animation Planner, Storyboard Illustration Prompt, and Storyboard Video Prompt are presented in separate stages.
- Human manual verification remains required; the checklist above is intentionally left unchecked.

## Docs and release impact

- [ ] No docs changes needed
- [x] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Version/release files updated (only if this PR includes a version bump)

Docs updated:

- `docs/game/storyboard.md`
- `docs/game/getting-started.md`
- `docs/prompts/macros.md`

No version or release files were changed.

## UI evidence (if applicable)

- Agent browser QA completed for the Game Presentation summary and Storyboards settings layout.
- No screenshots are attached; maintainers can add before/after evidence during manual verification.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the **Storyboard Optimized** game presentation option.
  * Added separate storyboard planners for still illustrations and animations.
  * Added customizable final-generation prompts for storyboard images and videos.
  * Expanded storyboard style presets, including manga and NovelAI options.
  * Added support for chat-local storyboard prompt copies and custom templates.

* **Documentation**
  * Updated setup, storyboard, and macro guidance to reflect the new presentation and prompt workflows.
  * Clarified keyframe targeting, prompt selection, and image/video generation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->