### PR TITLE
Fix chat, weather, media, and mobile regressions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,15 +7,25 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 ### Added
 
 - Added a compact, expandable **Defaults** section to Connections for Main, Agents, Illustrator, and Videos. Each category now supports an optional fallback connection; failed generations retry once through that category's fallback while user cancellations and already-visible partial text streams remain protected from duplicate output. A toast identifies the fallback connection and model whenever the engine switches over.
+- Added drag-to-resize controls for the Echo Chamber on desktop and touch devices, with responsive text wrapping and correctly oriented handles in every screen corner.
+- Added native Android notification permission and delivery support to the APK wrapper so autonomous Conversation messages can notify mobile users while the app is backgrounded (#3572).
+- Added expandable Noodle poll vote details so tapping or clicking a vote count reveals which accounts selected each option (#3566).
 
 ### Changed
 
 - Moved **Title / comment** into the primary identity fields directly below **Name** in both Character and Persona Metadata, while keeping it synchronized with the matching editor-header field.
 - Changed Noodle participant selection so invited characters remain the primary cast while random-user accounts appear only occasionally as supporting activity.
+- Moved media-wide queueing and prompt-review controls into a new **Overall Generations** settings group, renamed the queue option to **Queue media generation requests**, extended it to video generation, and added a Conversation toolbar hint linking users to generation settings.
+- Moved weather particle rendering off the main UI thread where supported, capped canvas resolution and mobile particle density, and reduced background polling/animation work to improve foreground smoothness and mobile battery use (#3567).
 
 ### Fixed
 
 - Hardened generation fallbacks so output already emitted through streaming callbacks is never replaced, failed toast delivery cannot cancel a working fallback, Roleplay background generation participates in Illustrator fallback routing, and Conversation selfie galleries record the connection and model that actually produced the image.
+- Fixed Present Characters tracker values crashing React when generated stats used structured `{ name, value, max, color }` objects; tracker displays now normalize those values safely (#3563).
+- Fixed autonomous group Conversation exchanges stopping at one capped or cooling-down character, sequential turns leaking other speakers, valid target replies being removed by wrong-speaker pruning, and OpenAI-compatible SSE responses losing content delivered through final message frames (#3573).
+- Fixed Roleplay chats opening at the oldest history position instead of the latest message, and updated **Show newer** and **Latest** controls to inherit the selected chroma text color.
+- Fixed Echo Chamber batches appearing all at once or too quickly by revealing queued reactions individually at randomized 10–30 second intervals, while protecting the active chat from stale delivery writes.
+- Fixed Echo Chamber corner controls pointing in the wrong vertical direction when the panel is anchored along the bottom edge.
 - Fixed image and video connections retaining or claiming the language-only **Fallback for Main** role after creation or provider changes.
 - Fixed corrected Noodle refreshes bypassing the same activity and authorship validation as the first attempt, empty refreshes being accepted without retry, persona IDs being offered as generated authors, and JSON-shaped image prompts without a usable prompt field being sent verbatim to image providers.
 - Fixed Android/Termux updates repeatedly forcing the entire dependency store to reinstall for the same stale build. The launcher now performs one rebuild, prunes unreferenced packages left by older releases, avoids irrelevant cross-platform binary downloads, and accepts the current Node 26 Termux runtime (#3540).

--- a/android/README.md
+++ b/android/README.md
@@ -26,6 +26,7 @@ The Android app is a Termux bootstrap + WebView shell for Marinara Engine. It is
 - First-run bootstrap actions for Termux install/start handoff
 - Automatic retry while the local server is still starting
 - File upload support for character cards, images, and similar assets
+- Native Android notifications for background Conversation replies, enabled from **Settings > General > Notifications**
 - Back button navigation inside the WebView
 - External links open in your default browser
 - Android backup is disabled for the wrapper app, and the WebView disallows file URL access and mixed-content loading.
@@ -116,6 +117,8 @@ To skip the update check and start the already-installed local copy, run `./star
 Then open the **Marinara Engine** app from your home screen. The app shows "Connecting..." until the local server is ready, then loads automatically.
 
 Because the APK points at `http://127.0.0.1:<PORT>`, it only works while the Marinara Engine server is running on the same Android device and using the same port value.
+
+On Android 13 and newer, enabling **Mobile app** under **Background Notifications** opens Android's notification permission prompt. Browser notifications remain a separate setting. Notifications conceal reply content and ask the user to open Marinara to read the message.
 
 ## Pre-built APKs
 

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -3,6 +3,7 @@
     package="com.marinara.engine">
 
     <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
     <uses-permission android:name="android.permission.REQUEST_INSTALL_PACKAGES" />
     <uses-permission android:name="com.termux.permission.RUN_COMMAND" />
 

--- a/android/app/src/main/java/com/marinara/engine/MainActivity.java
+++ b/android/app/src/main/java/com/marinara/engine/MainActivity.java
@@ -56,6 +56,8 @@ public class MainActivity extends Activity {
     private static final int UNKNOWN_APP_SOURCES_REQUEST = 1003;
     private static final int TERMUX_INSTALL_STATUS_REQUEST = 1004;
     private static final int NOTIFICATION_PERMISSION_REQUEST = 1005;
+    private static final String NOTIFICATION_PERMISSION_PREFS = "marinara_notification_permission";
+    private static final String NOTIFICATION_PERMISSION_REQUESTED = "requested";
     private static final String MESSAGE_NOTIFICATION_CHANNEL_ID = "marinara_messages";
     private static final String TERMUX_PACKAGE = "com.termux";
     private static final String TERMUX_RUN_COMMAND_PERMISSION = "com.termux.permission.RUN_COMMAND";
@@ -683,6 +685,10 @@ public class MainActivity extends Activity {
                     dispatchNotificationPermissionStatus("granted");
                     return;
                 }
+                getSharedPreferences(NOTIFICATION_PERMISSION_PREFS, MODE_PRIVATE)
+                        .edit()
+                        .putBoolean(NOTIFICATION_PERMISSION_REQUESTED, true)
+                        .apply();
                 requestPermissions(
                         new String[]{Manifest.permission.POST_NOTIFICATIONS},
                         NOTIFICATION_PERMISSION_REQUEST
@@ -736,7 +742,9 @@ public class MainActivity extends Activity {
         if (checkSelfPermission(Manifest.permission.POST_NOTIFICATIONS) == PackageManager.PERMISSION_GRANTED) {
             return "granted";
         }
-        return shouldShowRequestPermissionRationale(Manifest.permission.POST_NOTIFICATIONS) ? "denied" : "default";
+        boolean requested = getSharedPreferences(NOTIFICATION_PERMISSION_PREFS, MODE_PRIVATE)
+                .getBoolean(NOTIFICATION_PERMISSION_REQUESTED, false);
+        return requested ? "denied" : "default";
     }
 
     private void dispatchNotificationPermissionStatus(String status) {

--- a/android/app/src/main/java/com/marinara/engine/MainActivity.java
+++ b/android/app/src/main/java/com/marinara/engine/MainActivity.java
@@ -1,7 +1,11 @@
 package com.marinara.engine;
 
 import android.annotation.SuppressLint;
+import android.Manifest;
 import android.app.Activity;
+import android.app.Notification;
+import android.app.NotificationChannel;
+import android.app.NotificationManager;
 import android.app.PendingIntent;
 import android.content.ActivityNotFoundException;
 import android.content.ClipData;
@@ -51,6 +55,8 @@ public class MainActivity extends Activity {
     private static final int TERMUX_PERMISSION_REQUEST = 1002;
     private static final int UNKNOWN_APP_SOURCES_REQUEST = 1003;
     private static final int TERMUX_INSTALL_STATUS_REQUEST = 1004;
+    private static final int NOTIFICATION_PERMISSION_REQUEST = 1005;
+    private static final String MESSAGE_NOTIFICATION_CHANNEL_ID = "marinara_messages";
     private static final String TERMUX_PACKAGE = "com.termux";
     private static final String TERMUX_RUN_COMMAND_PERMISSION = "com.termux.permission.RUN_COMMAND";
     private static final String TERMUX_DOWNLOAD_PAGE = "https://f-droid.org/en/packages/com.termux/";
@@ -110,6 +116,7 @@ public class MainActivity extends Activity {
 
         setContentView(root);
 
+        createMessageNotificationChannel();
         configureWebView();
         tryConnect();
         handleTermuxInstallStatus(getIntent());
@@ -663,6 +670,32 @@ public class MainActivity extends Activity {
 
     private class MarinaraAndroidBridge {
         @JavascriptInterface
+        public String getNotificationPermission() {
+            return getNotificationPermissionStatus();
+        }
+
+        @JavascriptInterface
+        public void requestNotificationPermission() {
+            runOnUiThread(() -> {
+                if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU
+                        || checkSelfPermission(Manifest.permission.POST_NOTIFICATIONS)
+                        == PackageManager.PERMISSION_GRANTED) {
+                    dispatchNotificationPermissionStatus("granted");
+                    return;
+                }
+                requestPermissions(
+                        new String[]{Manifest.permission.POST_NOTIFICATIONS},
+                        NOTIFICATION_PERMISSION_REQUEST
+                );
+            });
+        }
+
+        @JavascriptInterface
+        public void showNotification(String title, String body, String tag) {
+            runOnUiThread(() -> showNativeMessageNotification(title, body, tag));
+        }
+
+        @JavascriptInterface
         public void openConsole() {
             runOnUiThread(() -> {
                 if (!isTermuxInstalled()) {
@@ -683,6 +716,74 @@ public class MainActivity extends Activity {
                 }
             });
         }
+    }
+
+    private void createMessageNotificationChannel() {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) return;
+        NotificationManager manager = (NotificationManager) getSystemService(Context.NOTIFICATION_SERVICE);
+        if (manager == null) return;
+        NotificationChannel channel = new NotificationChannel(
+                MESSAGE_NOTIFICATION_CHANNEL_ID,
+                "Background messages",
+                NotificationManager.IMPORTANCE_DEFAULT
+        );
+        channel.setDescription("Notifications for new Marinara character messages");
+        manager.createNotificationChannel(channel);
+    }
+
+    private String getNotificationPermissionStatus() {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) return "granted";
+        if (checkSelfPermission(Manifest.permission.POST_NOTIFICATIONS) == PackageManager.PERMISSION_GRANTED) {
+            return "granted";
+        }
+        return shouldShowRequestPermissionRationale(Manifest.permission.POST_NOTIFICATIONS) ? "denied" : "default";
+    }
+
+    private void dispatchNotificationPermissionStatus(String status) {
+        if (webView == null) return;
+        webView.evaluateJavascript(
+                "window.dispatchEvent(new CustomEvent('marinara:native-notification-permission',{detail:'"
+                        + status
+                        + "'}));",
+                null
+        );
+    }
+
+    private void showNativeMessageNotification(String rawTitle, String rawBody, String rawTag) {
+        if (!"granted".equals(getNotificationPermissionStatus())) return;
+        NotificationManager manager = (NotificationManager) getSystemService(Context.NOTIFICATION_SERVICE);
+        if (manager == null) return;
+
+        String title = truncateNotificationText(rawTitle, "New Marinara message", 100);
+        String body = truncateNotificationText(rawBody, "Open Marinara to read it.", 180);
+        String tag = truncateNotificationText(rawTag, "marinara-message", 120);
+        Intent openIntent = new Intent(this, MainActivity.class)
+                .addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP | Intent.FLAG_ACTIVITY_SINGLE_TOP);
+        PendingIntent contentIntent = PendingIntent.getActivity(
+                this,
+                tag.hashCode(),
+                openIntent,
+                PendingIntent.FLAG_UPDATE_CURRENT | PendingIntent.FLAG_IMMUTABLE
+        );
+
+        Notification.Builder builder = Build.VERSION.SDK_INT >= Build.VERSION_CODES.O
+                ? new Notification.Builder(this, MESSAGE_NOTIFICATION_CHANNEL_ID)
+                : new Notification.Builder(this);
+        Notification notification = builder
+                .setSmallIcon(R.drawable.ic_notification)
+                .setContentTitle(title)
+                .setContentText(body)
+                .setContentIntent(contentIntent)
+                .setAutoCancel(true)
+                .setCategory(Notification.CATEGORY_MESSAGE)
+                .build();
+        manager.notify(tag, 1, notification);
+    }
+
+    private String truncateNotificationText(String value, String fallback, int maxLength) {
+        String normalized = value == null ? "" : value.trim();
+        if (normalized.isEmpty()) normalized = fallback;
+        return normalized.length() <= maxLength ? normalized : normalized.substring(0, maxLength);
     }
 
     private void openUri(String url) {
@@ -742,6 +843,11 @@ public class MainActivity extends Activity {
     @Override
     public void onRequestPermissionsResult(int requestCode, String[] permissions, int[] grantResults) {
         super.onRequestPermissionsResult(requestCode, permissions, grantResults);
+        if (requestCode == NOTIFICATION_PERMISSION_REQUEST) {
+            boolean granted = grantResults.length > 0 && grantResults[0] == PackageManager.PERMISSION_GRANTED;
+            dispatchNotificationPermissionStatus(granted ? "granted" : "denied");
+            return;
+        }
         if (requestCode != TERMUX_PERMISSION_REQUEST) return;
         if (grantResults.length > 0 && grantResults[0] == PackageManager.PERMISSION_GRANTED) {
             sendTermuxSetupCommand();

--- a/android/app/src/main/res/drawable/ic_notification.xml
+++ b/android/app/src/main/res/drawable/ic_notification.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#FFFFFFFF"
+        android:pathData="M4,4h16c1.1,0 2,0.9 2,2v10c0,1.1 -0.9,2 -2,2H8l-5,4v-4H4c-1.1,0 -2,-0.9 -2,-2V6c0,-1.1 0.9,-2 2,-2zM7,9h10V7H7v2zM7,13h7v-2H7v2z" />
+</vector>

--- a/android/build-apk.sh
+++ b/android/build-apk.sh
@@ -63,10 +63,10 @@ else
 fi
 
 if [ "$BUILD_TYPE" = "release" ]; then
-    $GRADLE_CMD "${GRADLE_ARGS[@]}" assembleRelease
+    "$GRADLE_CMD" ${GRADLE_ARGS[@]+"${GRADLE_ARGS[@]}"} assembleRelease
     APK_PATH=$(find app/build/outputs/apk/release -name "*.apk" | head -n1)
 else
-    $GRADLE_CMD "${GRADLE_ARGS[@]}" assembleDebug
+    "$GRADLE_CMD" ${GRADLE_ARGS[@]+"${GRADLE_ARGS[@]}"} assembleDebug
     APK_PATH="app/build/outputs/apk/debug/app-debug.apk"
 fi
 

--- a/docs/settings/settings-overview.md
+++ b/docs/settings/settings-overview.md
@@ -31,7 +31,7 @@ Here is where to read more about each tab:
 The **General** tab holds six sections. This page owns two of them in full: **App Behavior** and **Text Rules**. The others are summarized here and covered in detail in their own guides.
 
 - **App Behavior**: language, delete safety, and show/hide toggles. Covered below.
-- **Notifications**: notification sounds and browser notifications by mode.
+- **Notifications**: notification sounds plus separate browser and Android app notifications for background replies.
 - **Responses**: how replies stream, save, and paginate. See [Sending and Streaming Messages](../chats/sending-and-streaming.md).
 - **Input & Editing**: message input and fast edit controls. See [Message Actions](../chats/messages.md).
 - **Text Rules**: formatting applied to chat text. Covered below.

--- a/packages/client/src/App.tsx
+++ b/packages/client/src/App.tsx
@@ -587,6 +587,7 @@ export function App() {
       ? getCssGradientColorStops(animatedAccentSource, animatedSolidAccent)
       : [animatedSolidAccent];
     const accentAnimationEnabled = appAccentRgbMode || appAccentPulseMode || themeAccentPulseConfig.enabled;
+    const usesTimerDrivenAccentAnimation = accentAnimationEnabled;
 
     let accentAnimationTimer: ReturnType<typeof window.setTimeout> | null = null;
     let cursorRecolorFreezeTimer: ReturnType<typeof window.setTimeout> | null = null;
@@ -673,14 +674,27 @@ export function App() {
           ? getGradientRgbAccent(animatedGradientStops)
           : getSolidRgbAccent(animatedSolidAccent);
 
-      applyAppAccentVariables({
-        root,
-        accent: liveAccent,
-        gradient: getSolidAccentGradient(liveAccent),
-        surfaceAccent: accentIsGradient ? solidAccent : liveAccent,
-        theme,
-        updateCursor: false,
-      });
+      const liveGradient = getSolidAccentGradient(liveAccent);
+      if (appAccentRgbMode) {
+        applyAppAccentVariables({
+          root,
+          accent: liveAccent,
+          gradient: liveGradient,
+          surfaceAccent: accentIsGradient ? solidAccent : liveAccent,
+          theme,
+          updateCursor: false,
+        });
+      } else {
+        // Pulse only the foreground-facing accent tokens. Recomputing surface,
+        // sidebar, and glow tokens on every tick forces Firefox to restyle most
+        // of the app and can briefly starve an otherwise independent canvas.
+        root.style.setProperty("--primary", liveAccent);
+        root.style.setProperty("--ring", liveAccent);
+        root.style.setProperty("--marinara-app-accent-solid", liveAccent);
+        root.style.setProperty("--marinara-app-accent-gradient", liveGradient);
+        root.style.setProperty("--marinara-chat-chrome-accent", liveAccent);
+        root.style.setProperty("--marinara-chat-chrome-accent-gradient", liveGradient);
+      }
       applyCursorAccent(liveAccent, { slow: true });
       setAccentModeDataset();
     };
@@ -712,8 +726,10 @@ export function App() {
     const startAccentAnimation = () => {
       root.dataset.marinaraAccentAnimation =
         animatedAccentIsGradient && animatedGradientStops.length > 1 ? "gradient" : "solid";
-      applyLiveAccent();
-      queueAccentAnimationTick();
+      if (usesTimerDrivenAccentAnimation) {
+        applyLiveAccent();
+        queueAccentAnimationTick();
+      }
     };
 
     const syncAccentAnimationState = () => {

--- a/packages/client/src/components/chat/ChatArea.tsx
+++ b/packages/client/src/components/chat/ChatArea.tsx
@@ -176,6 +176,7 @@ type GenerateSceneBackgroundPayload = {
 type GenerateRoleplaySceneVideoPayload = {
   chatId: string;
   galleryImageId?: string;
+  queueMediaGenerationRequests: boolean;
   debugMode: boolean;
   promptOverride?: string;
 };
@@ -1393,6 +1394,7 @@ export function ChatArea() {
       const payload: GenerateRoleplaySceneVideoPayload = {
         chatId: activeChatId,
         ...(galleryImageId ? { galleryImageId } : {}),
+        queueMediaGenerationRequests: useUIStore.getState().queueImageGenerationRequests,
         debugMode: useUIStore.getState().debugMode,
       };
       roleplaySceneVideoGeneratingRef.current = true;
@@ -2522,10 +2524,21 @@ export function ChatArea() {
     if (openedAtBottomChatIdRef.current === activeChatId) return;
     if (isLoading && loadedMessageCount === 0) return;
 
-    openedAtBottomChatIdRef.current = activeChatId;
-    userScrolledAwayRef.current = false;
-    isNearBottomRef.current = true;
-    scheduleScrollToMessagesBottom("auto");
+    let frame = 0;
+    const scrollWhenSurfaceIsReady = () => {
+      if (!scrollRef.current && !messagesEndRef.current) {
+        frame = requestAnimationFrame(scrollWhenSurfaceIsReady);
+        return;
+      }
+
+      openedAtBottomChatIdRef.current = activeChatId;
+      userScrolledAwayRef.current = false;
+      isNearBottomRef.current = true;
+      scheduleScrollToMessagesBottom("auto");
+    };
+
+    scrollWhenSurfaceIsReady();
+    return () => cancelAnimationFrame(frame);
   }, [activeChatId, isFetchingNextPage, isLoading, loadedMessageCount, scheduleScrollToMessagesBottom]);
 
   useEffect(() => {

--- a/packages/client/src/components/chat/ChatRoleplaySurface.tsx
+++ b/packages/client/src/components/chat/ChatRoleplaySurface.tsx
@@ -1942,6 +1942,7 @@ export function ChatRoleplaySurface({
                   hiddenAfterCount={transcriptWindow.hiddenAfterCount}
                   onShowNewer={transcriptWindow.hiddenAfterCount > 0 ? showNewerTranscriptMessages : undefined}
                   onJumpToLatest={transcriptWindow.hiddenAfterCount > 0 ? jumpToLatestTranscriptMessages : undefined}
+                  buttonClassName="border-[var(--marinara-chat-chrome-button-border-active)] bg-[var(--marinara-chat-chrome-button-bg-active)] text-[var(--marinara-chat-chrome-button-text-active)] hover:border-[var(--marinara-chat-chrome-button-border-hover)] hover:bg-[var(--marinara-chat-chrome-button-bg-hover)] hover:text-[var(--marinara-chat-chrome-button-text-hover)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--marinara-chat-chrome-focus-ring)]"
                 />
 
                 {!isStreaming && <CyoaChoices messages={visibleMessages} />}

--- a/packages/client/src/components/chat/ChatSettingsDrawer.tsx
+++ b/packages/client/src/components/chat/ChatSettingsDrawer.tsx
@@ -873,6 +873,8 @@ export function ChatSettingsDrawer({
   const imageSelfieWidth = useUIStore((s) => s.imageSelfieWidth);
   const imageSelfieHeight = useUIStore((s) => s.imageSelfieHeight);
   const imageStyleProfiles = useUIStore((s) => s.imageStyleProfiles);
+  const openRightPanel = useUIStore((s) => s.openRightPanel);
+  const setSettingsTab = useUIStore((s) => s.setSettingsTab);
   const musicPlayerSource = useUIStore((s) => s.musicPlayerSource);
   const setMusicPlayerSource = useUIStore((s) => s.setMusicPlayerSource);
   const openToolDetail = useUIStore((s) => s.openToolDetail);
@@ -1141,6 +1143,10 @@ export function ChatSettingsDrawer({
       },
     });
   }, [chat.id, conversationCommandToggles, selfieFeatureEnabled, updateMeta]);
+  const openGenerationSettings = useCallback(() => {
+    setSettingsTab("generations");
+    openRightPanel("settings");
+  }, [openRightPanel, setSettingsTab]);
   const inactiveCharacterIds = useMemo<string[]>(
     () =>
       Array.isArray(metadata.inactiveCharacterIds)
@@ -5639,6 +5645,24 @@ export function ChatSettingsDrawer({
                       </p>
                     </div>
                   </div>
+
+                  <button
+                    type="button"
+                    onClick={openGenerationSettings}
+                    className="mari-chat-option-field flex w-full items-center gap-2 rounded-lg px-2.5 py-2 text-left transition-colors hover:bg-[var(--secondary)]/60"
+                    title="Open Settings, Generations"
+                  >
+                    <Settings2 size="0.8125rem" className="shrink-0 text-[var(--primary)]" />
+                    <span className="min-w-0 flex-1">
+                      <span className="block text-[0.6875rem] font-medium text-[var(--foreground)]">
+                        Image generation settings
+                      </span>
+                      <span className="mt-0.5 block text-[0.59375rem] leading-snug text-[var(--muted-foreground)]">
+                        Adjust generation behavior, image sizes, and styles in Settings → Generations.
+                      </span>
+                    </span>
+                    <ChevronRight size="0.75rem" className="shrink-0 text-[var(--muted-foreground)]" />
+                  </button>
 
                   <button
                     type="button"

--- a/packages/client/src/components/chat/EchoChamberPanel.tsx
+++ b/packages/client/src/components/chat/EchoChamberPanel.tsx
@@ -4,7 +4,16 @@
 // Positions itself within the chat area, respecting sidebar, right panel,
 // HUD widget position (top/left/right), and the top bar.
 // ──────────────────────────────────────────────
-import { useRef, useEffect, useMemo, useState, type CSSProperties } from "react";
+import {
+  useRef,
+  useEffect,
+  useMemo,
+  useState,
+  useCallback,
+  type CSSProperties,
+  type KeyboardEvent as ReactKeyboardEvent,
+  type PointerEvent as ReactPointerEvent,
+} from "react";
 import { ChevronDown, MessageCircle, Trash2, RefreshCw } from "lucide-react";
 import { useAgentStore } from "../../stores/agent.store";
 import { useUIStore } from "../../stores/ui.store";
@@ -16,7 +25,7 @@ import { api } from "../../lib/api-client";
 import { cn } from "../../lib/utils";
 import { ROLEPLAY_POPOVER_SHELL } from "./roleplay-popover-styles";
 import {
-  ECHO_CHAMBER_MESSAGE_INTERVAL_MS,
+  getEchoChamberMessageInterval,
   resolveEchoChamberPersistedBaseline,
 } from "../../lib/echo-chamber-queue";
 
@@ -44,6 +53,9 @@ const HUD_EDGE_GAP = 16; // Aligns with the roleplay HUD edge padding.
 const FLOATING_EDGE_GAP = 16;
 const TOP_BUTTON_GAP = 6; // Matches the tracker panel gap below the top controls.
 const DESKTOP_PANEL_WIDTH = 236;
+const MIN_PANEL_WIDTH = 176;
+const MIN_PANEL_HEIGHT = 96;
+const RESIZE_KEYBOARD_STEP = 24;
 const ROLEPLAY_AREA_SELECTOR = ".rpg-chat-area";
 const ROLEPLAY_TOP_ANCHOR_SELECTOR = '[data-tracker-panel-anchor="roleplay-hud"]';
 const ROLEPLAY_TOP_RIGHT_CONTROLS_SELECTOR = '[data-roleplay-top-controls="right"]';
@@ -150,6 +162,9 @@ export function EchoChamberPanel({ hiddenOnMobile = false }: EchoChamberPanelPro
   const toggleEchoChamber = useUIStore((s) => s.toggleEchoChamber);
   const echoMessages = useAgentStore((s) => s.echoMessages);
   const scrollRef = useRef<HTMLDivElement>(null);
+  const panelRef = useRef<HTMLDivElement>(null);
+  const resizeRef = useRef<{ startX: number; startY: number; width: number; height: number } | null>(null);
+  const [panelSize, setPanelSize] = useState<{ width: number; height: number } | null>(null);
 
   const activeChatId = useChatStore((s) => s.activeChatId);
   const isAgentProcessing = useAgentStore((s) =>
@@ -182,6 +197,7 @@ export function EchoChamberPanel({ hiddenOnMobile = false }: EchoChamberPanelPro
   const visibleCount = useAgentStore((s) => s.echoVisibleCount);
   const baseline = useAgentStore((s) => s.echoBaseline);
   const setEchoVisibleCount = useAgentStore((s) => s.setEchoVisibleCount);
+  const revealNextEchoMessage = useAgentStore((s) => s.revealNextEchoMessage);
   const setEchoBaseline = useAgentStore((s) => s.setEchoBaseline);
 
   // ── Load persisted echo messages when chat changes ──
@@ -250,12 +266,9 @@ export function EchoChamberPanel({ hiddenOnMobile = false }: EchoChamberPanelPro
       setEchoVisibleCount(baseline);
       return;
     }
-    const id = setTimeout(
-      () => setEchoVisibleCount(visibleCount + 1),
-      ECHO_CHAMBER_MESSAGE_INTERVAL_MS,
-    );
+    const id = setTimeout(revealNextEchoMessage, getEchoChamberMessageInterval());
     return () => clearTimeout(id);
-  }, [visibleCount, echoMessages.length, baseline, setEchoVisibleCount]);
+  }, [visibleCount, echoMessages.length, baseline, revealNextEchoMessage, setEchoVisibleCount]);
 
   // Auto-scroll when a new message becomes visible
   useEffect(() => {
@@ -281,6 +294,64 @@ export function EchoChamberPanel({ hiddenOnMobile = false }: EchoChamberPanelPro
   // ── Compute position style relative to the chat area container ──
   const [posStyle, setPosStyle] = useState<CSSProperties>({});
   const isMobile = typeof window !== "undefined" && window.innerWidth < 768;
+  const resizeFromLeft = !isMobile && echoChamberSide.endsWith("right");
+  const resizeFromTop = !isMobile && echoChamberSide.startsWith("bottom");
+
+  const clampPanelSize = useCallback((width: number, height: number) => {
+    const area = getRoleplayAreaRect();
+    const maxWidth = Math.max(MIN_PANEL_WIDTH, (area?.width ?? window.innerWidth) - FLOATING_EDGE_GAP * 2);
+    const maxHeight = Math.max(MIN_PANEL_HEIGHT, (area?.height ?? window.innerHeight) - INPUT_BOX_H - FLOATING_EDGE_GAP);
+    return {
+      width: Math.round(Math.min(maxWidth, Math.max(MIN_PANEL_WIDTH, width))),
+      height: Math.round(Math.min(maxHeight, Math.max(MIN_PANEL_HEIGHT, height))),
+    };
+  }, []);
+
+  const handleResizeStart = useCallback((event: ReactPointerEvent<HTMLButtonElement>) => {
+    const rect = panelRef.current?.getBoundingClientRect();
+    if (!rect) return;
+    event.preventDefault();
+    event.stopPropagation();
+    resizeRef.current = { startX: event.clientX, startY: event.clientY, width: rect.width, height: rect.height };
+    event.currentTarget.setPointerCapture(event.pointerId);
+  }, []);
+
+  const handleResizeMove = useCallback(
+    (event: ReactPointerEvent<HTMLButtonElement>) => {
+      const start = resizeRef.current;
+      if (!start) return;
+      event.preventDefault();
+      event.stopPropagation();
+      const horizontalDelta = (event.clientX - start.startX) * (resizeFromLeft ? -1 : 1);
+      const verticalDelta = (event.clientY - start.startY) * (resizeFromTop ? -1 : 1);
+      setPanelSize(clampPanelSize(start.width + horizontalDelta, start.height + verticalDelta));
+    },
+    [clampPanelSize, resizeFromLeft, resizeFromTop],
+  );
+
+  const handleResizeEnd = useCallback((event: ReactPointerEvent<HTMLButtonElement>) => {
+    resizeRef.current = null;
+    if (event.currentTarget.hasPointerCapture(event.pointerId)) event.currentTarget.releasePointerCapture(event.pointerId);
+  }, []);
+
+  const handleResizeKeyDown = useCallback(
+    (event: ReactKeyboardEvent<HTMLButtonElement>) => {
+      if (!["ArrowLeft", "ArrowRight", "ArrowUp", "ArrowDown"].includes(event.key)) return;
+      event.preventDefault();
+      const rect = panelRef.current?.getBoundingClientRect();
+      if (!rect) return;
+      const widthDelta = event.key === "ArrowRight" ? RESIZE_KEYBOARD_STEP : event.key === "ArrowLeft" ? -RESIZE_KEYBOARD_STEP : 0;
+      const heightDelta = event.key === "ArrowDown" ? RESIZE_KEYBOARD_STEP : event.key === "ArrowUp" ? -RESIZE_KEYBOARD_STEP : 0;
+      setPanelSize(clampPanelSize(rect.width + widthDelta, rect.height + heightDelta));
+    },
+    [clampPanelSize],
+  );
+
+  useEffect(() => {
+    const clampCurrentSize = () => setPanelSize((size) => (size ? clampPanelSize(size.width, size.height) : null));
+    window.addEventListener("resize", clampCurrentSize);
+    return () => window.removeEventListener("resize", clampCurrentSize);
+  }, [clampPanelSize]);
 
   useEffect(() => {
     if (!echoEnabled) return;
@@ -407,12 +478,14 @@ export function EchoChamberPanel({ hiddenOnMobile = false }: EchoChamberPanelPro
 
   return (
     <div
+      ref={panelRef}
       className={cn(
         ROLEPLAY_POPOVER_SHELL,
-        "absolute z-[60] flex flex-col",
-        "pointer-events-auto max-md:w-auto md:w-[14.75rem] md:max-h-[22rem] max-md:max-h-28",
+        "absolute z-[60] flex min-w-0 flex-col",
+        "pointer-events-auto max-md:w-auto md:w-[14.75rem]",
+        !panelSize && "max-md:max-h-28 md:max-h-[22rem]",
       )}
-      style={posStyle}
+      style={{ ...posStyle, ...(panelSize && { width: panelSize.width, height: panelSize.height }) }}
     >
       {/* Header — live dot, corner picker, close */}
       <div className="flex items-center justify-between px-2 py-1">
@@ -474,7 +547,7 @@ export function EchoChamberPanel({ hiddenOnMobile = false }: EchoChamberPanelPro
       </div>
 
       {/* Scrollable message area */}
-      <div ref={scrollRef} className="flex-1 overflow-y-auto px-2 pb-1.5 scrollbar-thin">
+      <div ref={scrollRef} className="min-h-0 flex-1 overflow-y-auto px-2 pb-1.5 scrollbar-thin">
         {visibleMessages.length === 0 ? (
           <p className="py-1.5 text-center text-[0.625rem] text-[var(--marinara-chat-chrome-panel-muted)]">
             Waiting for reactions…
@@ -482,7 +555,7 @@ export function EchoChamberPanel({ hiddenOnMobile = false }: EchoChamberPanelPro
         ) : (
           <div className="flex flex-col gap-0.5">
             {visibleMessages.map((msg, i) => (
-              <div key={i} className="animate-in fade-in slide-in-from-bottom-1 duration-300">
+              <div key={i} className="min-w-0 animate-in fade-in slide-in-from-bottom-1 duration-300 break-words">
                 <span className={cn("text-[0.6875rem] font-bold", nameColorMap.get(msg.characterName))}>
                   {msg.characterName}
                 </span>
@@ -495,6 +568,30 @@ export function EchoChamberPanel({ hiddenOnMobile = false }: EchoChamberPanelPro
           </div>
         )}
       </div>
+      <button
+        type="button"
+        aria-label="Resize Echo Chamber"
+        title="Drag to resize Echo Chamber"
+        className={cn(
+          "absolute z-20 flex h-7 w-7 touch-none items-center justify-center rounded-md border border-[var(--marinara-chat-chrome-button-border)] bg-[var(--marinara-chat-chrome-button-bg)] text-[var(--marinara-chat-chrome-button-text)] shadow-md transition-colors hover:border-[var(--marinara-chat-chrome-button-border-hover)] hover:bg-[var(--marinara-chat-chrome-button-bg-hover)] hover:text-[var(--marinara-chat-chrome-button-text-hover)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--marinara-chat-chrome-focus-ring)] md:h-6 md:w-6",
+          resizeFromLeft ? "-left-2 cursor-nesw-resize" : "-right-2 cursor-nwse-resize",
+          resizeFromTop ? "-top-2" : "-bottom-2",
+        )}
+        onPointerDown={handleResizeStart}
+        onPointerMove={handleResizeMove}
+        onPointerUp={handleResizeEnd}
+        onPointerCancel={handleResizeEnd}
+        onKeyDown={handleResizeKeyDown}
+      >
+        <span
+          aria-hidden="true"
+          className={cn(
+            "h-2.5 w-2.5 border-current",
+            resizeFromTop ? "border-t-2" : "border-b-2",
+            resizeFromLeft ? "border-l-2" : "border-r-2",
+          )}
+        />
+      </button>
     </div>
   );
 }

--- a/packages/client/src/components/chat/RoleplayHUDPanels.tsx
+++ b/packages/client/src/components/chat/RoleplayHUDPanels.tsx
@@ -72,6 +72,7 @@ import {
 } from "@marinara-engine/shared";
 import { useTrackerLockContext } from "../../features/tracker-panel/components/TrackerLockContext";
 import { WorldCustomFieldIcon } from "../../features/tracker-panel/lib/world-custom-field-icons";
+import { trackerEditableText } from "../../features/tracker-panel/lib/tracker-display";
 
 interface CombinedPlayerPanelProps {
   showPersona: boolean;
@@ -542,7 +543,7 @@ export function CombinedPlayerPanel({
                           <LabeledEdit
                             key={name}
                             label={name}
-                            value={value}
+                            value={trackerEditableText(value)}
                             onSave={(nextValue) =>
                               updateCharacter(idx, {
                                 ...char,
@@ -1106,7 +1107,7 @@ export function CharactersPanel({
                     <LabeledEdit
                       key={name}
                       label={name}
-                      value={value}
+                      value={trackerEditableText(value)}
                       onSave={(nextValue) =>
                         updateCharacter(idx, {
                           ...char,

--- a/packages/client/src/components/chat/TranscriptWindowControls.tsx
+++ b/packages/client/src/components/chat/TranscriptWindowControls.tsx
@@ -8,6 +8,7 @@ type TranscriptWindowControlsProps = {
   onShowNewer?: () => void;
   onJumpToLatest?: () => void;
   className?: string;
+  buttonClassName?: string;
 };
 
 export function TranscriptWindowControls({
@@ -17,6 +18,7 @@ export function TranscriptWindowControls({
   onShowNewer,
   onJumpToLatest,
   className,
+  buttonClassName,
 }: TranscriptWindowControlsProps) {
   if (!onShowOlder && !onShowNewer && !onJumpToLatest) return null;
 
@@ -26,7 +28,10 @@ export function TranscriptWindowControls({
         <button
           type="button"
           onClick={onShowOlder}
-          className="inline-flex items-center gap-1.5 rounded-lg border border-[var(--border)] bg-[var(--secondary)] px-3 py-1.5 text-xs font-medium text-[var(--muted-foreground)] transition-all hover:bg-[var(--accent)]"
+          className={cn(
+            "inline-flex items-center gap-1.5 rounded-lg border border-[var(--border)] bg-[var(--secondary)] px-3 py-1.5 text-xs font-medium text-[var(--muted-foreground)] transition-all hover:bg-[var(--accent)]",
+            buttonClassName,
+          )}
         >
           <ChevronUp size="0.75rem" />
           Show older ({hiddenBeforeCount})
@@ -36,7 +41,10 @@ export function TranscriptWindowControls({
         <button
           type="button"
           onClick={onShowNewer}
-          className="inline-flex items-center gap-1.5 rounded-lg border border-[var(--border)] bg-[var(--secondary)] px-3 py-1.5 text-xs font-medium text-[var(--muted-foreground)] transition-all hover:bg-[var(--accent)]"
+          className={cn(
+            "inline-flex items-center gap-1.5 rounded-lg border border-[var(--border)] bg-[var(--secondary)] px-3 py-1.5 text-xs font-medium text-[var(--muted-foreground)] transition-all hover:bg-[var(--accent)]",
+            buttonClassName,
+          )}
         >
           <ChevronDown size="0.75rem" />
           Show newer ({hiddenAfterCount})
@@ -46,7 +54,10 @@ export function TranscriptWindowControls({
         <button
           type="button"
           onClick={onJumpToLatest}
-          className="inline-flex items-center gap-1.5 rounded-lg border border-[var(--border)] bg-[var(--secondary)] px-3 py-1.5 text-xs font-medium text-[var(--muted-foreground)] transition-all hover:bg-[var(--accent)]"
+          className={cn(
+            "inline-flex items-center gap-1.5 rounded-lg border border-[var(--border)] bg-[var(--secondary)] px-3 py-1.5 text-xs font-medium text-[var(--muted-foreground)] transition-all hover:bg-[var(--accent)]",
+            buttonClassName,
+          )}
         >
           Latest
         </button>

--- a/packages/client/src/components/chat/WeatherEffects.tsx
+++ b/packages/client/src/components/chat/WeatherEffects.tsx
@@ -2,10 +2,21 @@
 // Chat: Dynamic Weather Effects — ambient particles
 // that change based on roleplay weather + time of day
 // ──────────────────────────────────────────────
-import { useEffect, useRef, useMemo } from "react";
+import { useEffect, useRef, useMemo, useState } from "react";
+import { advanceWeatherFrameClock } from "../../lib/weather-frame-clock";
+import {
+  createWeatherParticle,
+  drawWeatherMoon,
+  drawWeatherParticle,
+  drawWeatherSun,
+  resolveWeatherRenderConfig,
+  weatherCelestialX,
+  weatherCelestialY,
+  type WeatherParticle,
+} from "../../lib/weather-renderer";
 
-const MAX_CANVAS_DPR = 1.5;
-const TARGET_FRAME_MS = 1000 / 30;
+const MAX_CANVAS_DPR = 1;
+const MAX_CANVAS_PIXELS = 1920 * 1080;
 const BASE_FRAME_MS = 1000 / 60;
 const FIREFLY_COUNT = 10;
 const STAR_COUNT = 18;
@@ -16,669 +27,6 @@ interface WeatherEffectsProps {
   showCelestial?: boolean;
 }
 
-// ── Particle types ──
-interface Particle {
-  x: number;
-  y: number;
-  vx: number;
-  vy: number;
-  size: number;
-  opacity: number;
-  type:
-    | "rain"
-    | "snow"
-    | "leaf"
-    | "firefly"
-    | "star"
-    | "fog"
-    | "dust"
-    | "petal"
-    | "ember"
-    | "ash"
-    | "sand"
-    | "hail"
-    | "aurora";
-  wobble: number;
-  life: number;
-  maxLife: number;
-  /** Pre-computed fill colour (ash, sand) to avoid Math.random() in draw */
-  color: string;
-}
-
-// ── Map weather string → effect config ──
-function parseWeather(weather?: string | null): {
-  type: Particle["type"];
-  count: number;
-  overlay: string;
-  lightning: boolean;
-} {
-  if (!weather) return { type: "dust", count: 0, overlay: "", lightning: false };
-
-  const w = weather.toLowerCase();
-
-  // Thunderstorm / lightning
-  if (w.includes("thunder") || w.includes("lightning")) {
-    return { type: "rain", count: 120, overlay: "rgba(50,80,120,0.10)", lightning: true };
-  }
-  if (w.includes("hail")) {
-    return { type: "hail", count: 40, overlay: "rgba(180,200,230,0.06)", lightning: false };
-  }
-  if (w.includes("blizzard")) {
-    return { type: "snow", count: 90, overlay: "rgba(200,220,255,0.10)", lightning: false };
-  }
-  if (w.includes("snow") || w.includes("sleet")) {
-    const isHeavy = w.includes("heavy");
-    return { type: "snow", count: isHeavy ? 75 : 35, overlay: "rgba(200,220,255,0.06)", lightning: false };
-  }
-  if (w.includes("frost") || w.includes("cold") || w.includes("freez")) {
-    return { type: "snow", count: 12, overlay: "rgba(180,210,240,0.06)", lightning: false };
-  }
-  if (w.includes("fog") || w.includes("mist") || w.includes("haze")) {
-    return { type: "fog", count: 12, overlay: "rgba(180,180,200,0.12)", lightning: false };
-  }
-  if (w.includes("sand") || w.includes("dust storm") || w.includes("sirocco")) {
-    return { type: "sand", count: 65, overlay: "rgba(180,150,100,0.12)", lightning: false };
-  }
-  if (w.includes("ash") || w.includes("volcanic") || w.includes("smoke")) {
-    return { type: "ash", count: 30, overlay: "rgba(80,60,60,0.10)", lightning: false };
-  }
-  if (w.includes("ember") || w.includes("fire") || w.includes("inferno")) {
-    return { type: "ember", count: 24, overlay: "rgba(120,40,10,0.08)", lightning: false };
-  }
-  if (w.includes("wind") || w.includes("breez") || w.includes("gust")) {
-    return { type: "leaf", count: 18, overlay: "", lightning: false };
-  }
-  if (w.includes("cherry") || w.includes("blossom") || w.includes("petal")) {
-    return { type: "petal", count: 22, overlay: "rgba(255,180,200,0.04)", lightning: false };
-  }
-  if (w.includes("aurora") || w.includes("northern light") || w.includes("polar light")) {
-    return { type: "aurora", count: 6, overlay: "rgba(20,60,40,0.08)", lightning: false };
-  }
-  if (w.includes("rain") || w.includes("storm") || w.includes("downpour")) {
-    const isHeavy = w.includes("heavy") || w.includes("storm") || w.includes("downpour");
-    return {
-      type: "rain",
-      count: isHeavy ? 120 : 55,
-      overlay: "rgba(50,80,120,0.08)",
-      lightning: isHeavy && w.includes("storm"),
-    };
-  }
-  if (w.includes("clear") || w.includes("sunny") || w.includes("bright")) {
-    return { type: "dust", count: 8, overlay: "", lightning: false };
-  }
-  if (w.includes("cloud") || w.includes("overcast") || w.includes("grey") || w.includes("gray")) {
-    return { type: "dust", count: 6, overlay: "rgba(100,100,120,0.05)", lightning: false };
-  }
-
-  return { type: "dust", count: 8, overlay: "", lightning: false };
-}
-
-// ── Map time of day → tint + fireflies ──
-type CelestialBody = "sun" | "moon" | "none";
-
-function parseTime(
-  timeOfDay?: string | null,
-  baseType?: Particle["type"],
-): {
-  tint: string;
-  addFireflies: boolean;
-  addStars: boolean;
-  celestial: CelestialBody;
-  hour: number; // 0-24, -1 if unknown
-  sunRays: boolean;
-  sunsetGlow: boolean;
-  isClearSky: boolean; // derived later; default false here
-} {
-  const base = {
-    tint: "",
-    addFireflies: false,
-    addStars: false,
-    celestial: "none" as CelestialBody,
-    hour: -1,
-    sunRays: false,
-    sunsetGlow: false,
-    isClearSky: false,
-  };
-
-  if (!timeOfDay) return base;
-
-  const t = timeOfDay.toLowerCase();
-
-  // Try to extract a numeric hour from the time string ("14:30", "2 PM", "1400", etc.)
-  const hour = extractHour(t);
-  base.hour = hour;
-
-  if (t.includes("night") || t.includes("midnight")) {
-    return {
-      ...base,
-      tint: "rgba(10,10,40,0.15)",
-      addFireflies: baseType !== "rain" && baseType !== "snow",
-      addStars: baseType !== "fog" && baseType !== "snow",
-      celestial: "moon",
-      hour: hour >= 0 ? hour : 0,
-    };
-  }
-  if (t.includes("dusk") || t.includes("sunset") || t.includes("twilight") || t.includes("evening")) {
-    return {
-      ...base,
-      tint: "rgba(80,30,20,0.10)",
-      addFireflies: baseType !== "rain",
-      addStars: false,
-      celestial: "sun",
-      hour: hour >= 0 ? hour : 18,
-      sunsetGlow: true,
-    };
-  }
-  if (t.includes("dawn") || t.includes("sunrise") || t.includes("morning")) {
-    return {
-      ...base,
-      tint: "rgba(120,80,40,0.06)",
-      celestial: "sun",
-      hour: hour >= 0 ? hour : 7,
-      sunRays: true,
-    };
-  }
-
-  // Numeric hour fallback — determine time period from hour
-  if (hour >= 0) {
-    if (hour >= 21 || hour < 5) {
-      return {
-        ...base,
-        tint: "rgba(10,10,40,0.15)",
-        addFireflies: baseType !== "rain" && baseType !== "snow",
-        addStars: baseType !== "fog" && baseType !== "snow",
-        celestial: "moon",
-      };
-    }
-    if (hour >= 17 && hour < 21) {
-      return {
-        ...base,
-        tint: "rgba(80,30,20,0.10)",
-        addFireflies: baseType !== "rain",
-        celestial: "sun",
-        sunsetGlow: hour >= 17,
-      };
-    }
-    if (hour >= 5 && hour < 9) {
-      return {
-        ...base,
-        tint: "rgba(120,80,40,0.06)",
-        celestial: "sun",
-        sunRays: true,
-      };
-    }
-    // Daytime (9-17)
-    return {
-      ...base,
-      celestial: "sun",
-      sunRays: true,
-    };
-  }
-
-  // If it just says "afternoon", "day", "noon", etc.
-  if (t.includes("noon") || t.includes("midday") || t.includes("afternoon") || t.includes("day")) {
-    return {
-      ...base,
-      celestial: "sun",
-      hour: t.includes("afternoon") ? 15 : 12,
-      sunRays: true,
-    };
-  }
-
-  return base;
-}
-
-/** Try to extract an hour (0-23) from a time string. Returns -1 if not found. */
-function extractHour(t: string): number {
-  // "14:30", "2:00 PM", "14h30", "1400"
-  const match24 = t.match(/\b(\d{1,2})[:.h](\d{2})\b/);
-  if (match24) {
-    let h = parseInt(match24[1]!, 10);
-    if (t.includes("pm") && h < 12) h += 12;
-    if (t.includes("am") && h === 12) h = 0;
-    if (h >= 0 && h < 24) return h;
-  }
-  // "2 PM", "11 AM"
-  const matchAmPm = t.match(/\b(\d{1,2})\s*(am|pm)\b/);
-  if (matchAmPm) {
-    let h = parseInt(matchAmPm[1]!, 10);
-    if (matchAmPm[2] === "pm" && h < 12) h += 12;
-    if (matchAmPm[2] === "am" && h === 12) h = 0;
-    if (h >= 0 && h < 24) return h;
-  }
-  // Military "1400", "0800"
-  const matchMil = t.match(/\b(\d{4})\s*(?:hours?|hrs?)?\b/);
-  if (matchMil) {
-    const h = parseInt(matchMil[1]!.slice(0, 2), 10);
-    if (h >= 0 && h < 24) return h;
-  }
-  return -1;
-}
-
-// ── Create particle ──
-function createParticle(type: Particle["type"], w: number, h: number, fromTop = false): Particle {
-  const base: Particle = {
-    x: Math.random() * w,
-    y: fromTop ? -10 : Math.random() * h,
-    vx: 0,
-    vy: 0,
-    size: 2,
-    opacity: 0.5,
-    type,
-    wobble: Math.random() * Math.PI * 2,
-    life: 0,
-    maxLife: 600 + Math.random() * 400,
-    color: "",
-  };
-
-  switch (type) {
-    case "rain":
-      base.vy = 8 + Math.random() * 6;
-      base.vx = -1 + Math.random() * -2;
-      base.size = 1.5;
-      base.opacity = 0.25 + Math.random() * 0.2;
-      base.maxLife = 200;
-      break;
-    case "snow":
-      base.vy = 0.5 + Math.random() * 1.2;
-      base.vx = -0.3 + Math.random() * 0.6;
-      base.size = 2 + Math.random() * 3;
-      base.opacity = 0.4 + Math.random() * 0.3;
-      base.maxLife = 800;
-      break;
-    case "leaf":
-      base.vy = 0.8 + Math.random() * 1;
-      base.vx = 1.5 + Math.random() * 2;
-      base.size = 4 + Math.random() * 3;
-      base.opacity = 0.5 + Math.random() * 0.3;
-      base.maxLife = 500;
-      break;
-    case "petal":
-      base.vy = 0.4 + Math.random() * 0.8;
-      base.vx = 0.5 + Math.random() * 1;
-      base.size = 3 + Math.random() * 3;
-      base.opacity = 0.4 + Math.random() * 0.3;
-      base.maxLife = 600;
-      break;
-    case "firefly":
-      base.vy = -0.2 + Math.random() * 0.4;
-      base.vx = -0.3 + Math.random() * 0.6;
-      base.size = 2 + Math.random() * 2;
-      base.opacity = 0;
-      base.maxLife = 300 + Math.random() * 300;
-      break;
-    case "star":
-      base.vy = 0;
-      base.vx = 0;
-      base.size = 1 + Math.random() * 1.5;
-      base.opacity = 0;
-      base.maxLife = 400 + Math.random() * 400;
-      base.y = Math.random() * h * 0.4; // upper portion
-      break;
-    case "fog":
-      base.vy = 0;
-      base.vx = 0.2 + Math.random() * 0.4;
-      base.size = 60 + Math.random() * 80;
-      base.opacity = 0.03 + Math.random() * 0.04;
-      base.maxLife = 1000;
-      break;
-    case "dust":
-      base.vy = -0.1 + Math.random() * 0.2;
-      base.vx = -0.1 + Math.random() * 0.2;
-      base.size = 1 + Math.random() * 2;
-      base.opacity = 0.15 + Math.random() * 0.15;
-      base.maxLife = 600 + Math.random() * 400;
-      break;
-    case "ember":
-      base.vy = -1.5 + Math.random() * -1.5;
-      base.vx = -0.5 + Math.random() * 1;
-      base.size = 2 + Math.random() * 2;
-      base.opacity = 0.6 + Math.random() * 0.3;
-      base.maxLife = 300 + Math.random() * 200;
-      base.y = h + 10; // rise from bottom
-      break;
-    case "ash":
-      base.vy = 0.3 + Math.random() * 0.6;
-      base.vx = -0.4 + Math.random() * 0.8;
-      base.size = 2 + Math.random() * 3;
-      base.opacity = 0.2 + Math.random() * 0.2;
-      base.maxLife = 700 + Math.random() * 300;
-      base.color = `rgba(${(100 + Math.random() * 40) | 0},${(90 + Math.random() * 30) | 0},${(90 + Math.random() * 30) | 0},0.6)`;
-      break;
-    case "sand":
-      base.vy = 0.5 + Math.random() * 1;
-      base.vx = 4 + Math.random() * 4;
-      base.size = 1 + Math.random() * 2;
-      base.opacity = 0.3 + Math.random() * 0.3;
-      base.maxLife = 250 + Math.random() * 150;
-      base.x = -10; // enter from left
-      base.color = `rgba(${(200 + Math.random() * 30) | 0},${(170 + Math.random() * 30) | 0},${(110 + Math.random() * 20) | 0},0.7)`;
-      break;
-    case "hail":
-      base.vy = 10 + Math.random() * 6;
-      base.vx = -1 + Math.random() * -1;
-      base.size = 2 + Math.random() * 3;
-      base.opacity = 0.4 + Math.random() * 0.3;
-      base.maxLife = 150;
-      break;
-    case "aurora":
-      base.vy = 0;
-      base.vx = 0.1 + Math.random() * 0.2;
-      base.size = 80 + Math.random() * 120;
-      base.opacity = 0.04 + Math.random() * 0.03;
-      base.maxLife = 1200 + Math.random() * 600;
-      base.y = Math.random() * h * 0.35; // upper sky
-      break;
-  }
-
-  return base;
-}
-
-// ── Draw helpers ──
-function drawParticle(ctx: CanvasRenderingContext2D, p: Particle) {
-  const fadeIn = Math.min(p.life / 60, 1);
-  const fadeOut = Math.max(1 - p.life / p.maxLife, 0);
-  const alpha = p.opacity * fadeIn * fadeOut;
-  if (alpha <= 0) return;
-
-  ctx.globalAlpha = alpha;
-
-  switch (p.type) {
-    case "rain": {
-      ctx.strokeStyle = "rgba(180,210,255,0.8)";
-      ctx.lineWidth = p.size;
-      ctx.beginPath();
-      ctx.moveTo(p.x, p.y);
-      ctx.lineTo(p.x + p.vx * 2, p.y + p.vy * 2);
-      ctx.stroke();
-      break;
-    }
-    case "snow": {
-      ctx.fillStyle = "rgba(255,255,255,0.82)";
-      ctx.beginPath();
-      ctx.arc(p.x, p.y, p.size, 0, Math.PI * 2);
-      ctx.fill();
-      break;
-    }
-    case "leaf": {
-      ctx.fillStyle = `hsl(${100 + Math.sin(p.wobble) * 30}, 60%, 45%)`;
-      ctx.save();
-      ctx.translate(p.x, p.y);
-      ctx.rotate(p.wobble);
-      ctx.beginPath();
-      ctx.ellipse(0, 0, p.size, p.size * 0.4, 0, 0, Math.PI * 2);
-      ctx.fill();
-      ctx.restore();
-      break;
-    }
-    case "petal": {
-      ctx.fillStyle = `hsl(${340 + Math.sin(p.wobble) * 15}, 80%, 80%)`;
-      ctx.save();
-      ctx.translate(p.x, p.y);
-      ctx.rotate(p.wobble);
-      ctx.beginPath();
-      ctx.ellipse(0, 0, p.size, p.size * 0.5, 0, 0, Math.PI * 2);
-      ctx.fill();
-      ctx.restore();
-      break;
-    }
-    case "firefly": {
-      const pulse = Math.sin(p.life * 0.05) * 0.5 + 0.5;
-      ctx.globalAlpha = alpha * 0.28 * pulse;
-      ctx.fillStyle = "rgba(180,255,80,0.7)";
-      ctx.beginPath();
-      ctx.arc(p.x, p.y, p.size * 3, 0, Math.PI * 2);
-      ctx.fill();
-      ctx.globalAlpha = alpha * (0.65 + pulse * 0.35);
-      ctx.fillStyle = "rgba(220,255,130,0.95)";
-      ctx.beginPath();
-      ctx.arc(p.x, p.y, p.size, 0, Math.PI * 2);
-      ctx.fill();
-      break;
-    }
-    case "star": {
-      const twinkle = Math.sin(p.life * 0.04 + p.wobble) * 0.5 + 0.5;
-      ctx.fillStyle = `rgba(255,255,240,${twinkle * 0.7})`;
-      ctx.beginPath();
-      ctx.arc(p.x, p.y, p.size, 0, Math.PI * 2);
-      ctx.fill();
-      // cross sparkle
-      ctx.strokeStyle = `rgba(255,255,240,${twinkle * 0.3})`;
-      ctx.lineWidth = 0.5;
-      ctx.beginPath();
-      ctx.moveTo(p.x - p.size * 2, p.y);
-      ctx.lineTo(p.x + p.size * 2, p.y);
-      ctx.moveTo(p.x, p.y - p.size * 2);
-      ctx.lineTo(p.x, p.y + p.size * 2);
-      ctx.stroke();
-      break;
-    }
-    case "fog": {
-      ctx.globalAlpha = alpha * 0.7;
-      ctx.fillStyle = "rgba(200,200,220,0.08)";
-      ctx.beginPath();
-      ctx.ellipse(p.x, p.y, p.size * 1.5, p.size * 0.45, 0, 0, Math.PI * 2);
-      ctx.fill();
-      break;
-    }
-    case "dust": {
-      ctx.fillStyle = "rgba(255,240,220,0.6)";
-      ctx.beginPath();
-      ctx.arc(p.x, p.y, p.size, 0, Math.PI * 2);
-      ctx.fill();
-      break;
-    }
-    case "ember": {
-      const emberPulse = Math.sin(p.life * 0.08) * 0.3 + 0.7;
-      ctx.globalAlpha = alpha * 0.32 * emberPulse;
-      ctx.fillStyle = "rgba(255,80,20,0.7)";
-      ctx.beginPath();
-      ctx.arc(p.x, p.y, p.size * 2.5, 0, Math.PI * 2);
-      ctx.fill();
-      ctx.globalAlpha = alpha * emberPulse;
-      ctx.fillStyle = "rgba(255,205,70,0.92)";
-      ctx.beginPath();
-      ctx.arc(p.x, p.y, p.size, 0, Math.PI * 2);
-      ctx.fill();
-      break;
-    }
-    case "ash": {
-      ctx.fillStyle = p.color;
-      ctx.save();
-      ctx.translate(p.x, p.y);
-      ctx.rotate(p.wobble);
-      ctx.beginPath();
-      ctx.ellipse(0, 0, p.size, p.size * 0.3, 0, 0, Math.PI * 2);
-      ctx.fill();
-      ctx.restore();
-      break;
-    }
-    case "sand": {
-      ctx.fillStyle = p.color;
-      ctx.beginPath();
-      ctx.arc(p.x, p.y, p.size, 0, Math.PI * 2);
-      ctx.fill();
-      break;
-    }
-    case "hail": {
-      ctx.fillStyle = "rgba(230,240,255,0.85)";
-      ctx.beginPath();
-      ctx.arc(p.x, p.y, p.size, 0, Math.PI * 2);
-      ctx.fill();
-      break;
-    }
-    case "aurora": {
-      // Tall vertical ribbon of colour that sways gently
-      const hue = (p.wobble * 60 + p.life * 0.3) % 360;
-      const auroraGrad = ctx.createLinearGradient(p.x, p.y - p.size, p.x, p.y + p.size);
-      auroraGrad.addColorStop(0, `hsla(${hue},80%,60%,0)`);
-      auroraGrad.addColorStop(0.3, `hsla(${hue},80%,60%,0.08)`);
-      auroraGrad.addColorStop(0.5, `hsla(${(hue + 40) % 360},70%,55%,0.12)`);
-      auroraGrad.addColorStop(0.7, `hsla(${(hue + 80) % 360},80%,60%,0.08)`);
-      auroraGrad.addColorStop(1, `hsla(${(hue + 80) % 360},80%,60%,0)`);
-      ctx.fillStyle = auroraGrad;
-      ctx.beginPath();
-      const ribbonW = p.size * 0.6;
-      const sway = Math.sin(p.life * 0.008 + p.wobble) * 30;
-      ctx.moveTo(p.x + sway - ribbonW, p.y - p.size);
-      ctx.quadraticCurveTo(p.x + sway * 0.5, p.y, p.x + sway + ribbonW, p.y + p.size);
-      ctx.lineTo(p.x + sway - ribbonW, p.y + p.size);
-      ctx.quadraticCurveTo(p.x + sway * 0.5, p.y, p.x + sway + ribbonW, p.y - p.size);
-      ctx.closePath();
-      ctx.fill();
-      break;
-    }
-  }
-
-  ctx.globalAlpha = 1;
-}
-
-// ── Celestial drawing helpers ──
-
-/** Get sun/moon X position based on hour. Maps 6:00→left edge, 12:00→center, 18:00→right edge. */
-function celestialX(hour: number, w: number): number {
-  // Sun arc: 6h = 0%, 12h = 50%, 18h = 100% of width
-  const t = Math.max(0, Math.min(1, (hour - 6) / 12));
-  return w * 0.08 + t * w * 0.84; // 8%-92% of width
-}
-
-/** Get sun Y position — arc from bottom-ish up to top and back down. */
-function celestialY(hour: number, h: number, isMoon: boolean): number {
-  if (isMoon) {
-    // Moon arc: highest at midnight (hour 0/24), lower at 21h and 5h
-    const t = hour >= 12 ? (hour - 21) / 7 : (hour + 3) / 7; // normalized 0-1
-    const arc = Math.sin(Math.max(0, Math.min(1, t)) * Math.PI);
-    return h * 0.05 + (1 - arc) * h * 0.2;
-  }
-  // Sun: lowest at 6h/18h, highest at noon
-  const t = Math.max(0, Math.min(1, (hour - 6) / 12));
-  const arc = Math.sin(t * Math.PI); // 0 at edges, 1 at noon
-  return h * 0.05 + (1 - arc) * h * 0.25; // 5%-30% from top
-}
-
-function drawSun(
-  ctx: CanvasRenderingContext2D,
-  x: number,
-  y: number,
-  radius: number,
-  w: number,
-  h: number,
-  sunRays: boolean,
-  sunsetGlow: boolean,
-  frameCount: number,
-) {
-  ctx.save();
-
-  if (sunsetGlow) {
-    // Warm gradient sky wash at bottom
-    const glowGrad = ctx.createRadialGradient(x, y, radius, x, y + radius * 6, radius * 12);
-    glowGrad.addColorStop(0, "rgba(255,140,50,0.12)");
-    glowGrad.addColorStop(0.4, "rgba(255,80,30,0.06)");
-    glowGrad.addColorStop(1, "rgba(255,40,20,0)");
-    ctx.fillStyle = glowGrad;
-    ctx.fillRect(0, 0, w, h);
-  }
-
-  // Outer glow
-  const outerGlow = ctx.createRadialGradient(x, y, radius * 0.5, x, y, radius * 4);
-  outerGlow.addColorStop(0, sunsetGlow ? "rgba(255,120,40,0.15)" : "rgba(255,240,180,0.12)");
-  outerGlow.addColorStop(0.5, sunsetGlow ? "rgba(255,80,20,0.05)" : "rgba(255,240,180,0.04)");
-  outerGlow.addColorStop(1, "rgba(255,240,180,0)");
-  ctx.globalAlpha = 1;
-  ctx.fillStyle = outerGlow;
-  ctx.beginPath();
-  ctx.arc(x, y, radius * 4, 0, Math.PI * 2);
-  ctx.fill();
-
-  // Sun disc
-  const discGrad = ctx.createRadialGradient(x, y, 0, x, y, radius);
-  if (sunsetGlow) {
-    discGrad.addColorStop(0, "rgba(255,200,100,0.9)");
-    discGrad.addColorStop(0.7, "rgba(255,120,40,0.7)");
-    discGrad.addColorStop(1, "rgba(255,80,20,0.3)");
-  } else {
-    discGrad.addColorStop(0, "rgba(255,250,220,0.8)");
-    discGrad.addColorStop(0.7, "rgba(255,240,180,0.5)");
-    discGrad.addColorStop(1, "rgba(255,230,150,0.2)");
-  }
-  ctx.globalAlpha = 0.8;
-  ctx.fillStyle = discGrad;
-  ctx.beginPath();
-  ctx.arc(x, y, radius, 0, Math.PI * 2);
-  ctx.fill();
-
-  // Animated light rays
-  if (sunRays) {
-    const rayCount = 12;
-    const rotOffset = frameCount * 0.002;
-    ctx.globalAlpha = 0.06;
-    for (let i = 0; i < rayCount; i++) {
-      const angle = (i / rayCount) * Math.PI * 2 + rotOffset;
-      const pulse = 0.8 + Math.sin(frameCount * 0.01 + i * 1.5) * 0.2;
-      const rayLen = radius * (3.5 + pulse * 2);
-      const spread = 0.08;
-      ctx.fillStyle = sunsetGlow ? "rgba(255,160,60,0.5)" : "rgba(255,250,200,0.4)";
-      ctx.beginPath();
-      ctx.moveTo(x, y);
-      ctx.lineTo(x + Math.cos(angle - spread) * rayLen, y + Math.sin(angle - spread) * rayLen);
-      ctx.lineTo(x + Math.cos(angle + spread) * rayLen, y + Math.sin(angle + spread) * rayLen);
-      ctx.closePath();
-      ctx.fill();
-    }
-  }
-
-  ctx.restore();
-}
-
-function drawMoon(ctx: CanvasRenderingContext2D, x: number, y: number, radius: number, _frameCount: number) {
-  ctx.save();
-
-  // Soft moonlight glow
-  const glow = ctx.createRadialGradient(x, y, radius * 0.5, x, y, radius * 5);
-  glow.addColorStop(0, "rgba(180,200,255,0.10)");
-  glow.addColorStop(0.4, "rgba(150,180,255,0.04)");
-  glow.addColorStop(1, "rgba(150,180,255,0)");
-  ctx.globalAlpha = 1;
-  ctx.fillStyle = glow;
-  ctx.beginPath();
-  ctx.arc(x, y, radius * 5, 0, Math.PI * 2);
-  ctx.fill();
-
-  // Moon disc (bright side)
-  const discGrad = ctx.createRadialGradient(x - radius * 0.15, y - radius * 0.15, 0, x, y, radius);
-  discGrad.addColorStop(0, "rgba(230,235,255,0.85)");
-  discGrad.addColorStop(0.8, "rgba(200,210,240,0.6)");
-  discGrad.addColorStop(1, "rgba(180,190,220,0.3)");
-  ctx.globalAlpha = 0.7;
-  ctx.fillStyle = discGrad;
-  ctx.beginPath();
-  ctx.arc(x, y, radius, 0, Math.PI * 2);
-  ctx.fill();
-
-  // Crescent shadow (dark side) — offset circle to create crescent shape
-  ctx.globalCompositeOperation = "destination-out";
-  ctx.globalAlpha = 0.65;
-  ctx.fillStyle = "black";
-  ctx.beginPath();
-  ctx.arc(x + radius * 0.45, y - radius * 0.1, radius * 0.85, 0, Math.PI * 2);
-  ctx.fill();
-  ctx.globalCompositeOperation = "source-over";
-
-  // Subtle crater hints
-  ctx.globalAlpha = 0.06;
-  ctx.fillStyle = "rgba(150,160,190,1)";
-  ctx.beginPath();
-  ctx.arc(x - radius * 0.25, y - radius * 0.15, radius * 0.12, 0, Math.PI * 2);
-  ctx.fill();
-  ctx.beginPath();
-  ctx.arc(x - radius * 0.4, y + radius * 0.25, radius * 0.08, 0, Math.PI * 2);
-  ctx.fill();
-  ctx.beginPath();
-  ctx.arc(x - radius * 0.05, y + radius * 0.35, radius * 0.1, 0, Math.PI * 2);
-  ctx.fill();
-
-  ctx.restore();
-}
 
 // ═══════════════════════════════════════════════
 // Main component
@@ -686,18 +34,12 @@ function drawMoon(ctx: CanvasRenderingContext2D, x: number, y: number, radius: n
 
 export function WeatherEffects({ weather, timeOfDay, showCelestial = true }: WeatherEffectsProps) {
   const canvasRef = useRef<HTMLCanvasElement>(null);
-  const particlesRef = useRef<Particle[]>([]);
+  const particlesRef = useRef<WeatherParticle[]>([]);
   const frameRef = useRef<number>(0);
+  const [workerFailed, setWorkerFailed] = useState(false);
 
   const config = useMemo(() => {
-    const wc = parseWeather(weather);
-    const tc = parseTime(timeOfDay, wc.type);
-    // Clear sky = not rain/snow/fog/hail/sand and no dense overlay
-    const isClearSky =
-      !weather ||
-      /clear|sunny|bright/i.test(weather) ||
-      !/(rain|storm|snow|blizzard|fog|mist|haze|hail|sand|ash|smoke|overcast|cloud|grey|gray)/i.test(weather);
-    return { ...wc, ...tc, isClearSky };
+    return resolveWeatherRenderConfig(weather, timeOfDay);
   }, [weather, timeOfDay]);
 
   // Render when we have particles, celestial bodies, or time-based ambient effects
@@ -711,6 +53,81 @@ export function WeatherEffects({ weather, timeOfDay, showCelestial = true }: Wea
     const canvas = canvasRef.current;
     if (!canvas) return;
 
+    if (!workerFailed && typeof Worker !== "undefined" && "transferControlToOffscreen" in canvas) {
+      let worker: Worker | null = null;
+      let resizeObserver: ResizeObserver | null = null;
+      let visibilityHandler: (() => void) | null = null;
+      let readinessTimer: ReturnType<typeof window.setTimeout> | null = null;
+
+      // Deferring the irreversible transfer also makes this safe under React's
+      // development StrictMode effect probe: its first mount is cleaned up
+      // before the canvas ownership changes.
+      const initializeTimer = window.setTimeout(() => {
+        const rect = canvas.parentElement?.getBoundingClientRect();
+        if (!rect || rect.width <= 0 || rect.height <= 0) return;
+
+        worker = new Worker(new URL("../../workers/weather-effects.worker.ts", import.meta.url), { type: "module" });
+        const failWorker = () => setWorkerFailed(true);
+        worker.onerror = failWorker;
+        worker.onmessage = (event: MessageEvent<{ type?: string }>) => {
+          if (event.data.type === "render-error") {
+            failWorker();
+            return;
+          }
+          if (event.data.type !== "ready") return;
+          if (readinessTimer !== null) window.clearTimeout(readinessTimer);
+
+          const getScale = (width: number, height: number) => {
+            const pixelBudgetScale = Math.sqrt(MAX_CANVAS_PIXELS / (width * height));
+            return Math.min(window.devicePixelRatio || 1, MAX_CANVAS_DPR, pixelBudgetScale);
+          };
+          try {
+            const offscreen = canvas.transferControlToOffscreen();
+            worker?.postMessage(
+              {
+                type: "init",
+                canvas: offscreen,
+                config,
+                showCelestial,
+                width: rect.width,
+                height: rect.height,
+                scale: getScale(rect.width, rect.height),
+              },
+              [offscreen],
+            );
+          } catch {
+            failWorker();
+            return;
+          }
+
+          resizeObserver = new ResizeObserver((entries) => {
+            const size = entries[0]?.contentRect;
+            if (!size || size.width <= 0 || size.height <= 0) return;
+            worker?.postMessage({
+              type: "resize",
+              width: size.width,
+              height: size.height,
+              scale: getScale(size.width, size.height),
+            });
+          });
+          if (canvas.parentElement) resizeObserver.observe(canvas.parentElement);
+
+          visibilityHandler = () => worker?.postMessage({ type: "visibility", hidden: document.hidden });
+          document.addEventListener("visibilitychange", visibilityHandler);
+          visibilityHandler();
+        };
+        readinessTimer = window.setTimeout(failWorker, 3_000);
+      }, 0);
+
+      return () => {
+        window.clearTimeout(initializeTimer);
+        if (readinessTimer !== null) window.clearTimeout(readinessTimer);
+        resizeObserver?.disconnect();
+        if (visibilityHandler) document.removeEventListener("visibilitychange", visibilityHandler);
+        worker?.terminate();
+      };
+    }
+
     const ctx = canvas.getContext("2d");
     if (!ctx) return;
 
@@ -718,36 +135,38 @@ export function WeatherEffects({ weather, timeOfDay, showCelestial = true }: Wea
     let lightningAlpha = 0; // for lightning flash
     let nextLightning = config.lightning ? 200 + Math.random() * 400 : Infinity;
     let frameCount = 0;
-    let lastFrameTime = 0;
+    let previousFrameTime = 0;
+    let accumulatedFrameTime = 0;
 
-    const dpr = Math.min(window.devicePixelRatio || 1, MAX_CANVAS_DPR);
-
+    let canvasScale = 1;
     const resize = () => {
       const rect = canvas.parentElement?.getBoundingClientRect();
-      if (!rect) return;
-      canvas.width = rect.width * dpr;
-      canvas.height = rect.height * dpr;
-      ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+      if (!rect || rect.width <= 0 || rect.height <= 0) return;
+      const pixelBudgetScale = Math.sqrt(MAX_CANVAS_PIXELS / (rect.width * rect.height));
+      canvasScale = Math.min(window.devicePixelRatio || 1, MAX_CANVAS_DPR, pixelBudgetScale);
+      canvas.width = Math.max(1, Math.round(rect.width * canvasScale));
+      canvas.height = Math.max(1, Math.round(rect.height * canvasScale));
+      ctx.setTransform(canvasScale, 0, 0, canvasScale, 0, 0);
     };
     resize();
     window.addEventListener("resize", resize);
 
     // Initialize particles — use CSS pixel dimensions (not canvas resolution)
     particlesRef.current = [];
-    const w = canvas.width / dpr;
-    const h = canvas.height / dpr;
+    const w = canvas.width / canvasScale;
+    const h = canvas.height / canvasScale;
 
     for (let i = 0; i < config.count; i++) {
-      particlesRef.current.push(createParticle(config.type, w, h));
+      particlesRef.current.push(createWeatherParticle(config.type, w, h));
     }
     if (config.addFireflies) {
       for (let i = 0; i < FIREFLY_COUNT; i++) {
-        particlesRef.current.push(createParticle("firefly", w, h));
+        particlesRef.current.push(createWeatherParticle("firefly", w, h));
       }
     }
     if (config.addStars) {
       for (let i = 0; i < STAR_COUNT; i++) {
-        particlesRef.current.push(createParticle("star", w, h));
+        particlesRef.current.push(createWeatherParticle("star", w, h));
       }
     }
 
@@ -756,30 +175,33 @@ export function WeatherEffects({ weather, timeOfDay, showCelestial = true }: Wea
     const tick = (timestamp: number) => {
       if (!running) return;
       if (paused) {
-        lastFrameTime = timestamp;
+        previousFrameTime = timestamp;
+        accumulatedFrameTime = 0;
         frameRef.current = requestAnimationFrame(tick);
         return;
       }
 
-      if (lastFrameTime === 0) lastFrameTime = timestamp;
-      const elapsed = timestamp - lastFrameTime;
-      if (elapsed < TARGET_FRAME_MS) {
+      if (previousFrameTime === 0) previousFrameTime = timestamp;
+      const elapsed = Math.min(100, timestamp - previousFrameTime);
+      previousFrameTime = timestamp;
+      const frameStep = advanceWeatherFrameClock(accumulatedFrameTime, elapsed);
+      accumulatedFrameTime = frameStep.accumulatedMs;
+      if (!frameStep.shouldDraw) {
         frameRef.current = requestAnimationFrame(tick);
         return;
       }
-      lastFrameTime = timestamp;
-      const frameScale = Math.min(3, Math.max(0.5, elapsed / BASE_FRAME_MS));
+      const frameScale = Math.min(3, Math.max(0.5, frameStep.frameElapsedMs / BASE_FRAME_MS));
 
-      ctx.clearRect(0, 0, canvas.width / dpr, canvas.height / dpr);
+      ctx.clearRect(0, 0, canvas.width / canvasScale, canvas.height / canvasScale);
 
       // Draw ambient overlay tint
       if (config.tint) {
         ctx.fillStyle = config.tint;
-        ctx.fillRect(0, 0, canvas.width / dpr, canvas.height / dpr);
+        ctx.fillRect(0, 0, canvas.width / canvasScale, canvas.height / canvasScale);
       }
       if (config.overlay) {
         ctx.fillStyle = config.overlay;
-        ctx.fillRect(0, 0, canvas.width / dpr, canvas.height / dpr);
+        ctx.fillRect(0, 0, canvas.width / canvasScale, canvas.height / canvasScale);
       }
 
       // Lightning flash (epilepsy-safe: capped alpha, gentle decay, long gap between flashes)
@@ -791,29 +213,29 @@ export function WeatherEffects({ weather, timeOfDay, showCelestial = true }: Wea
         }
         if (lightningAlpha > 0) {
           ctx.fillStyle = `rgba(220,230,255,${lightningAlpha})`;
-          ctx.fillRect(0, 0, canvas.width / dpr, canvas.height / dpr);
+          ctx.fillRect(0, 0, canvas.width / canvasScale, canvas.height / canvasScale);
           lightningAlpha *= Math.pow(0.88, frameScale); // gentle decay
           if (lightningAlpha < 0.01) lightningAlpha = 0;
         }
       }
 
       // ── Celestial bodies (sun / moon) ──
-      const cw = canvas.width / dpr;
-      const ch = canvas.height / dpr;
+      const cw = canvas.width / canvasScale;
+      const ch = canvas.height / canvasScale;
       if (shouldDrawCelestial && config.isClearSky) {
         const bodyRadius = Math.min(cw, ch) * 0.035; // ~3.5% of smallest dimension
         const hour = config.hour >= 0 ? config.hour : 12;
 
         if (config.celestial === "sun") {
-          const sx = celestialX(hour, cw);
-          const sy = celestialY(hour, ch, false);
-          drawSun(ctx, sx, sy, bodyRadius, cw, ch, config.sunRays, config.sunsetGlow, frameCount);
+          const sx = weatherCelestialX(hour, cw);
+          const sy = weatherCelestialY(hour, ch, false);
+          drawWeatherSun(ctx, sx, sy, bodyRadius, cw, ch, config.sunRays, config.sunsetGlow, frameCount);
         } else if (config.celestial === "moon") {
           // Moon position: map 21h→left, 0h→center, 5h→right
           const moonNorm = hour >= 12 ? ((hour - 21 + 24) % 24) / 10 : (hour + 3) / 10;
           const mx = cw * 0.1 + Math.min(1, Math.max(0, moonNorm)) * cw * 0.8;
-          const my = celestialY(hour, ch, true);
-          drawMoon(ctx, mx, my, bodyRadius * 1.1, frameCount);
+          const my = weatherCelestialY(hour, ch, true);
+          drawWeatherMoon(ctx, mx, my, bodyRadius * 1.1, frameCount);
         }
       }
 
@@ -842,12 +264,12 @@ export function WeatherEffects({ weather, timeOfDay, showCelestial = true }: Wea
           p.y += Math.cos(p.wobble * 0.7) * 0.4 * frameScale;
         }
 
-        drawParticle(ctx, p);
+        drawWeatherParticle(ctx, p);
 
         // Respawn if off-screen or expired
         const offScreen = p.y > ch + 20 || p.y < -20 || p.x > cw + 20 || p.x < -20;
         if (offScreen || p.life > p.maxLife) {
-          particles[i] = createParticle(p.type, cw, ch, true);
+          particles[i] = createWeatherParticle(p.type, cw, ch, true);
         }
       }
 
@@ -867,9 +289,15 @@ export function WeatherEffects({ weather, timeOfDay, showCelestial = true }: Wea
       window.removeEventListener("resize", resize);
       document.removeEventListener("visibilitychange", onVisibilityChange);
     };
-  }, [config, shouldDrawCelestial, shouldRender]);
+  }, [config, shouldDrawCelestial, shouldRender, showCelestial, workerFailed]);
 
   if (!shouldRender) return null;
 
-  return <canvas ref={canvasRef} className="pointer-events-none absolute inset-0 z-0 h-full w-full" />;
+  return (
+    <canvas
+      key={`${weather ?? ""}:${timeOfDay ?? ""}:${showCelestial ? "celestial" : "particles"}:${workerFailed ? "fallback" : "worker"}`}
+      ref={canvasRef}
+      className="pointer-events-none absolute inset-0 z-0 h-full w-full transform-gpu [contain:strict] [will-change:transform]"
+    />
+  );
 }

--- a/packages/client/src/components/game/GameSurface.tsx
+++ b/packages/client/src/components/game/GameSurface.tsx
@@ -226,6 +226,7 @@ type GameSceneVideoPayload = {
   galleryImageId?: string;
   promptOverride?: string;
   previewOnly?: boolean;
+  queueMediaGenerationRequests: boolean;
   debugMode: boolean;
 };
 
@@ -5668,6 +5669,7 @@ function GameSurfaceComponent({
         const payload: GameSceneVideoPayload = {
           chatId: activeChatId,
           ...(galleryImageId ? { galleryImageId } : { illustrationTag }),
+          queueMediaGenerationRequests: useUIStore.getState().queueImageGenerationRequests,
           debugMode: useUIStore.getState().debugMode,
         };
         if (useUIStore.getState().reviewImagePromptsBeforeSend) {

--- a/packages/client/src/components/noodle/NoodleView.tsx
+++ b/packages/client/src/components/noodle/NoodleView.tsx
@@ -535,30 +535,36 @@ function NoodlePostContent({
 function NoodlePollCard({
   poll,
   votes,
+  accountById,
   selectedOptionId,
   disabled,
   pending,
   onVote,
+  onOpenProfile,
 }: {
   poll: NoodlePoll;
   votes: NoodleInteraction[];
+  accountById: Map<string, NoodleAccount>;
   selectedOptionId: string | null;
   disabled: boolean;
   pending: boolean;
   onVote: (optionId: string) => void;
+  onOpenProfile: (account: NoodleAccount) => void;
 }) {
   const totalVotes = votes.length;
+  const [showVoters, setShowVoters] = useState(false);
   return (
     <section className="mt-3" aria-label={`Poll: ${poll.question}`} data-noodle-poll>
       <h3 className="text-sm font-bold leading-5">{poll.question}</h3>
       <div className="mt-2 space-y-2">
         {poll.options.map((option) => {
-          const optionVotes = votes.filter((vote) => vote.content === option.id).length;
+          const matchingVotes = votes.filter((vote) => vote.content === option.id);
+          const optionVotes = matchingVotes.length;
           const percentage = totalVotes > 0 ? Math.round((optionVotes / totalVotes) * 100) : 0;
           const selected = selectedOptionId === option.id;
           return (
-            <button
-              key={option.id}
+            <Fragment key={option.id}>
+              <button
               type="button"
               onClick={() => onVote(option.id)}
               disabled={disabled || pending}
@@ -582,15 +588,44 @@ function NoodlePollCard({
                 <span className="min-w-0 flex-1 break-words">{option.label}</span>
                 <span className="shrink-0 text-[var(--muted-foreground)]">{percentage}%</span>
               </span>
-            </button>
+              </button>
+              {showVoters && optionVotes > 0 && (
+                <div className="flex flex-wrap gap-1 px-1" aria-label={`Voters for ${option.label}`}>
+                  {matchingVotes.map((vote) => {
+                    const voterAccount = accountById.get(vote.actorAccountId) ?? null;
+                    const voter = voterAccount ?? vote.actorSnapshot;
+                    return voter ? (
+                      <button
+                        key={vote.id}
+                        type="button"
+                        onClick={() => {
+                          if (voterAccount) onOpenProfile(voterAccount);
+                        }}
+                        disabled={!voterAccount}
+                        className="inline-flex min-h-9 max-w-full items-center gap-1.5 rounded-full bg-[var(--noodle-blue)]/8 pr-2 text-[0.6875rem] font-medium text-[var(--muted-foreground)] transition-colors hover:bg-[var(--noodle-blue)]/15 hover:text-[var(--foreground)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--noodle-blue)]/70 disabled:cursor-default"
+                      >
+                        <Avatar account={voter} size="sm" />
+                        <span className="max-w-32 truncate">@{voter.handle}</span>
+                      </button>
+                    ) : null;
+                  })}
+                </div>
+              )}
+            </Fragment>
           );
         })}
       </div>
-      <p className="mt-2 text-[0.68rem] text-[var(--muted-foreground)]">
+      <button
+        type="button"
+        onClick={() => setShowVoters((visible) => !visible)}
+        aria-expanded={showVoters}
+        className="mt-2 rounded-sm text-[0.68rem] text-[var(--muted-foreground)] transition-colors hover:text-[var(--noodle-blue)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--noodle-blue)]/70"
+      >
         {totalVotes} {totalVotes === 1 ? "vote" : "votes"}
         {selectedOptionId ? " · You voted" : ""}
         {pending ? " · Saving…" : ""}
-      </p>
+        {totalVotes > 0 ? (showVoters ? " · Hide voters" : " · View voters") : ""}
+      </button>
     </section>
   );
 }
@@ -3452,10 +3487,12 @@ export function NoodleView() {
               <NoodlePollCard
                 poll={poll}
                 votes={pollVotes}
+                accountById={accountById}
                 selectedOptionId={personaPollVote}
                 disabled={!personaAccount}
                 pending={pollVotePending}
                 onVote={(optionId) => voteInPoll(post, optionId, personaPollVote)}
+                onOpenProfile={openProfile}
               />
             )}
             {post.imageUrl ? (

--- a/packages/client/src/components/panels/SettingsPanel.tsx
+++ b/packages/client/src/components/panels/SettingsPanel.tsx
@@ -194,6 +194,7 @@ type SettingsSectionId =
   | "input-editing"
   | "text-rules"
   | "game-playback"
+  | "overall-generations"
   | "image-generation"
   | "video-generation"
   | "game-assets"
@@ -252,7 +253,7 @@ const SETTINGS_SECTIONS: readonly SettingsSectionMeta[] = [
     id: "notifications",
     tab: "general",
     label: "Notifications",
-    description: "Notification sounds and browser notifications by mode.",
+    description: "Notification sounds and background notifications by mode.",
     aliases: ["notifications", "sound", "ping", "browser", "background replies", "conversation", "roleplay", "game"],
   },
   {
@@ -297,11 +298,18 @@ const SETTINGS_SECTIONS: readonly SettingsSectionMeta[] = [
     aliases: ["game", "text speed", "auto play", "middle mouse", "navigation", "vn"],
   },
   {
+    id: "overall-generations",
+    tab: "generations",
+    label: "Overall Generations",
+    description: "Shared behavior for image and video generation requests.",
+    aliases: ["media", "image", "video", "queue", "prompt review", "generation"],
+  },
+  {
     id: "image-generation",
     tab: "generations",
     label: "Image Generation",
-    description: "Prompt review, image canvas defaults, and style profiles.",
-    aliases: ["image", "background", "portrait", "selfie", "style profiles", "prompt review"],
+    description: "Image canvas defaults and style profiles.",
+    aliases: ["image", "background", "portrait", "selfie", "style profiles"],
   },
   {
     id: "video-generation",
@@ -546,6 +554,14 @@ const SETTINGS_SEARCHABLE_CONTROLS: readonly SettingsSearchableControlMeta[] = [
     kind: "Toggle",
   },
   {
+    id: "mobile-background-notifications",
+    sectionId: "notifications",
+    label: "Background replies mobile notifications",
+    description: "Show native Android notifications for background Conversation replies.",
+    aliases: ["mobile", "android", "notifications", "conversation"],
+    kind: "Toggle",
+  },
+  {
     id: "enable-streaming",
     sectionId: "responses",
     label: "Enable streaming",
@@ -674,16 +690,16 @@ const SETTINGS_SEARCHABLE_CONTROLS: readonly SettingsSearchableControlMeta[] = [
     kind: "Slider",
   },
   {
-    id: "queue-image-generation",
-    sectionId: "image-generation",
-    label: "Queue image generation requests",
-    description: "Send image generation jobs one at a time.",
-    aliases: ["image", "queue", "generation"],
+    id: "queue-media-generation",
+    sectionId: "overall-generations",
+    label: "Queue media generation requests",
+    description: "Send image and video generation jobs one at a time per connection.",
+    aliases: ["media", "image", "video", "queue", "generation"],
     kind: "Toggle",
   },
   {
     id: "image-prompt-review",
-    sectionId: "image-generation",
+    sectionId: "overall-generations",
     label: "Expose media prompts before sending",
     description: "Review generated image and Gallery video prompts before sending.",
     aliases: [
@@ -2665,7 +2681,7 @@ function GeneralSettings() {
 
       <SettingsSection
         title="Notifications"
-        description="Notification sounds and browser notifications by mode."
+        description="Notification sounds and background notifications by mode."
         icon={<Bell size="0.875rem" />}
         {...getSettingsSectionAnchorProps("notifications")}
       >
@@ -2967,11 +2983,40 @@ function GeneralSettings() {
   );
 }
 
-function ImageGenerationSettings() {
+function OverallGenerationSettings() {
   const queueImageGenerationRequests = useUIStore((s) => s.queueImageGenerationRequests);
   const setQueueImageGenerationRequests = useUIStore((s) => s.setQueueImageGenerationRequests);
   const reviewImagePromptsBeforeSend = useUIStore((s) => s.reviewImagePromptsBeforeSend);
   const setReviewImagePromptsBeforeSend = useUIStore((s) => s.setReviewImagePromptsBeforeSend);
+
+  return (
+    <SettingsSection
+      title="Overall Generations"
+      description="Choose behavior shared by image and video generation."
+      icon={<WandSparkles size="0.875rem" />}
+      {...getSettingsSectionAnchorProps("overall-generations")}
+    >
+      <div className="flex flex-col gap-2.5">
+        <ToggleSetting
+          anchorId={getSettingsControlAnchorId("queue-media-generation")}
+          label="Queue media generation requests"
+          checked={queueImageGenerationRequests}
+          onChange={setQueueImageGenerationRequests}
+          help="Sends supported image and video generation jobs one at a time per connection. Keep this on for providers that reject simultaneous requests."
+        />
+        <ToggleSetting
+          anchorId={getSettingsControlAnchorId("image-prompt-review")}
+          label="Expose media prompts before sending"
+          checked={reviewImagePromptsBeforeSend}
+          onChange={setReviewImagePromptsBeforeSend}
+          help="Pauses supported user-started media generation so you can review and edit the final prompt before provider submission. This applies across Game and Roleplay images, Conversation Gallery selfies, Gallery Video and Animate actions, manual Noodle refreshes, avatars, portraits, sprites, and animated expressions. Unattended automatic generations continue without waiting for a modal."
+        />
+      </div>
+    </SettingsSection>
+  );
+}
+
+function ImageGenerationSettings() {
   const imageBackgroundWidth = useUIStore((s) => s.imageBackgroundWidth);
   const imageBackgroundHeight = useUIStore((s) => s.imageBackgroundHeight);
   const setImageBackgroundDimensions = useUIStore((s) => s.setImageBackgroundDimensions);
@@ -2990,26 +3035,11 @@ function ImageGenerationSettings() {
   return (
     <SettingsSection
       title="Image Generation"
-      description="Review generated prompts, set image canvas defaults, and tune prompt style profiles."
+      description="Set image canvas defaults and tune prompt style profiles."
       icon={<Image size="0.875rem" />}
       {...getSettingsSectionAnchorProps("image-generation")}
     >
       <div className="flex flex-col gap-2.5">
-        <ToggleSetting
-          anchorId={getSettingsControlAnchorId("queue-image-generation")}
-          label="Queue image generation requests"
-          checked={queueImageGenerationRequests}
-          onChange={setQueueImageGenerationRequests}
-          help="Sends supported image generation jobs one at a time, including Game assets and Roleplay Gallery illustrations. Keep this on for providers that reject simultaneous requests."
-        />
-        <ToggleSetting
-          anchorId={getSettingsControlAnchorId("image-prompt-review")}
-          label="Expose media prompts before sending"
-          checked={reviewImagePromptsBeforeSend}
-          onChange={setReviewImagePromptsBeforeSend}
-          help="Pauses supported user-started media generation so you can review and edit the final prompt before provider submission. This applies across Game and Roleplay images, Conversation Gallery selfies, Gallery Video and Animate actions, manual Noodle refreshes, avatars, portraits, sprites, and animated expressions. Unattended automatic generations continue without waiting for a modal."
-        />
-
         <ImageDimensionRow
           controlId="image-background-size"
           label="Backgrounds"
@@ -5135,6 +5165,7 @@ function GenerationsSettings() {
         Global defaults for generated images, generated videos, and reusable prompt templates.
       </SettingsIntro>
 
+      <OverallGenerationSettings />
       <ImageGenerationSettings />
       <VideoGenerationSettings />
       <div id={getSettingsSectionAnchorId("prompt-overrides")} className="flex flex-col gap-3">

--- a/packages/client/src/components/panels/settings/SettingControls.tsx
+++ b/packages/client/src/components/panels/settings/SettingControls.tsx
@@ -154,20 +154,25 @@ export function ConversationSoundSetting() {
       setConversationMobileNotifications(false);
       return;
     }
-    void requestNativeNotificationPermission().then((permission) => {
-      setNativePermission(permission);
-      if (permission === "granted") {
-        setConversationMobileNotifications(true);
-        toast.success("Mobile notifications enabled for background replies.");
-        return;
-      }
-      setConversationMobileNotifications(false);
-      toast.error(
-        permission === "unsupported"
-          ? "Mobile notifications require the Marinara Android app."
-          : "Android notification permission was not granted.",
-      );
-    });
+    void requestNativeNotificationPermission()
+      .then((permission) => {
+        setNativePermission(permission);
+        if (permission === "granted") {
+          setConversationMobileNotifications(true);
+          toast.success("Mobile notifications enabled for background replies.");
+          return;
+        }
+        setConversationMobileNotifications(false);
+        toast.error(
+          permission === "unsupported"
+            ? "Mobile notifications require the Marinara Android app."
+            : "Android notification permission was not granted.",
+        );
+      })
+      .catch(() => {
+        setConversationMobileNotifications(false);
+        toast.error("Android notification permission could not be requested.");
+      });
   };
 
   return (

--- a/packages/client/src/components/panels/settings/SettingControls.tsx
+++ b/packages/client/src/components/panels/settings/SettingControls.tsx
@@ -4,8 +4,12 @@ import { toast } from "sonner";
 import { useUIStore } from "../../../stores/ui.store";
 import {
   getLocalNotificationPermission,
+  getNativeNotificationPermission,
+  hasNativeNotificationBridge,
   requestLocalNotificationPermission,
+  requestNativeNotificationPermission,
   type LocalNotificationPermission,
+  type NativeNotificationPermission,
 } from "../../../lib/local-notifications";
 import { playNotificationPing } from "../../../lib/notification-sound";
 import { cn } from "../../../lib/utils";
@@ -94,7 +98,13 @@ export function ConversationSoundSetting() {
   const setNotificationSoundsOnlyWhenUnfocused = useUIStore((s) => s.setNotificationSoundsOnlyWhenUnfocused);
   const conversationBrowserNotifications = useUIStore((s) => s.conversationBrowserNotifications);
   const setConversationBrowserNotifications = useUIStore((s) => s.setConversationBrowserNotifications);
+  const conversationMobileNotifications = useUIStore((s) => s.conversationMobileNotifications);
+  const setConversationMobileNotifications = useUIStore((s) => s.setConversationMobileNotifications);
   const [browserPermission, setBrowserPermission] = useState<LocalNotificationPermission>("default");
+  const nativeNotificationsAvailable = hasNativeNotificationBridge();
+  const [nativePermission, setNativePermission] = useState<NativeNotificationPermission>(() =>
+    getNativeNotificationPermission(),
+  );
 
   useEffect(() => {
     let cancelled = false;
@@ -105,6 +115,17 @@ export function ConversationSoundSetting() {
       cancelled = true;
     };
   }, []);
+
+  useEffect(() => {
+    if (!nativeNotificationsAvailable) return;
+    const refreshPermission = () => setNativePermission(getNativeNotificationPermission());
+    window.addEventListener("focus", refreshPermission);
+    document.addEventListener("visibilitychange", refreshPermission);
+    return () => {
+      window.removeEventListener("focus", refreshPermission);
+      document.removeEventListener("visibilitychange", refreshPermission);
+    };
+  }, [nativeNotificationsAvailable]);
 
   const handleBrowserNotificationToggle = (enabled: boolean) => {
     if (!enabled) {
@@ -124,6 +145,27 @@ export function ConversationSoundSetting() {
         permission === "unsupported"
           ? "Browser notifications are not available in this environment."
           : "Browser notification permission was not granted.",
+      );
+    });
+  };
+
+  const handleMobileNotificationToggle = (enabled: boolean) => {
+    if (!enabled) {
+      setConversationMobileNotifications(false);
+      return;
+    }
+    void requestNativeNotificationPermission().then((permission) => {
+      setNativePermission(permission);
+      if (permission === "granted") {
+        setConversationMobileNotifications(true);
+        toast.success("Mobile notifications enabled for background replies.");
+        return;
+      }
+      setConversationMobileNotifications(false);
+      toast.error(
+        permission === "unsupported"
+          ? "Mobile notifications require the Marinara Android app."
+          : "Android notification permission was not granted.",
       );
     });
   };
@@ -170,14 +212,27 @@ export function ConversationSoundSetting() {
       />
       <div className="mt-1 flex items-center gap-1.5">
         <Bell size="0.75rem" className="text-[var(--muted-foreground)]" />
-        <span className="text-xs font-medium">Browser Notifications</span>
-        <HelpTooltip text="Show an operating-system browser notification when a background Conversation reply arrives while Marinara is not focused. Message content is hidden." />
+        <span className="text-xs font-medium">Background Notifications</span>
+        <HelpTooltip text="Show a private operating-system notification when a background Conversation reply arrives while Marinara is not focused. Message content is hidden." />
       </div>
       <ToggleSetting
         anchorId="settings-control-browser-background-notifications"
-        label="Background replies"
+        label="Browser"
         checked={conversationBrowserNotifications && browserPermission === "granted"}
         onChange={handleBrowserNotificationToggle}
+        help="Uses your browser's notification permission."
+      />
+      <ToggleSetting
+        anchorId="settings-control-mobile-background-notifications"
+        label="Mobile app"
+        checked={conversationMobileNotifications && nativePermission === "granted"}
+        onChange={handleMobileNotificationToggle}
+        disabled={!nativeNotificationsAvailable}
+        help={
+          nativeNotificationsAvailable
+            ? "Uses native Android notifications from the installed Marinara app."
+            : "Available in the updated Marinara Android APK. Browser and PWA installations use the Browser toggle above."
+        }
       />
     </div>
   );

--- a/packages/client/src/features/tracker-panel/components/character-card/CharacterTrackerCard.tsx
+++ b/packages/client/src/features/tracker-panel/components/character-card/CharacterTrackerCard.tsx
@@ -223,15 +223,16 @@ export function CharacterTrackerCard({
     );
   }
 
-  const customFields = Object.entries(character.customFields ?? {}).map(
-    ([name, value]) => [name, trackerEditableText(value)] as const,
+  const customFields = Object.entries((character.customFields ?? {}) as Record<string, unknown>).map(
+    ([name, value]) => [name, value, trackerEditableText(value)] as const,
   );
   const characterStats = Array.isArray(character.stats) ? character.stats : [];
   const hasDeleteAction = !!onRemove && deleteMode;
   const avatarMedia = characterPicture ?? character.avatarPath ?? null;
   const compactAvatarUpload = characterPicture ? undefined : onUploadAvatar;
   const hasEditableCustomFieldAdd = !!onUpdate && addMode;
-  const characterFieldKey = (field: HideableCharacterField) => characterTrackerLockKey(character, characterIndex, field);
+  const characterFieldKey = (field: HideableCharacterField) =>
+    characterTrackerLockKey(character, characterIndex, field);
   const fieldHidden = (field: HideableCharacterField) =>
     isTrackerFieldHidden(hiddenTrackerFields, characterFieldKey(field));
   const toggleCharacterFieldHidden = (field: HideableCharacterField) => {
@@ -269,9 +270,9 @@ export function CharacterTrackerCard({
     ? "z-[5] mt-0 w-[clamp(2.25rem,28%,3rem)] -translate-y-0.5"
     : "z-[5] mt-0 w-[clamp(3rem,36%,3.75rem)] -translate-y-0.5";
   const avatarSocketSize = hasDenseContent ? "dense" : "regular";
-  const updateCustomField = (oldName: string, nextName: string, nextValue: string) => {
+  const updateCustomField = (oldName: string, nextName: string, nextValue: unknown) => {
     if (!onUpdate) return;
-    const nextFields = { ...(character.customFields ?? {}) };
+    const nextFields: Record<string, unknown> = { ...(character.customFields ?? {}) };
     const trimmedName = resolveCharacterCustomFieldName(nextName, oldName);
     if (
       trimmedName !== oldName &&
@@ -294,7 +295,7 @@ export function CharacterTrackerCard({
     }
     delete nextFields[oldName];
     nextFields[trimmedName] = nextValue;
-    onUpdate({ ...character, customFields: nextFields });
+    onUpdate({ ...character, customFields: nextFields as Record<string, string> });
   };
   const addCharacterStat = () => {
     if (!onUpdate) return;
@@ -481,7 +482,7 @@ export function CharacterTrackerCard({
 
       {(customFields.length > 0 || hasEditableCustomFieldAdd) && (
         <div className={CHARACTER_CUSTOM_FIELD_LIST_CLASS}>
-          {customFields.map(([name, value]) => (
+          {customFields.map(([name, rawValue, displayValue]) => (
             <div
               key={name}
               className={cn(
@@ -493,7 +494,7 @@ export function CharacterTrackerCard({
               {onUpdate ? (
                 <InlineEdit
                   value={name}
-                  onSave={(nextName) => updateCustomField(name, nextName, value)}
+                  onSave={(nextName) => updateCustomField(name, nextName, rawValue)}
                   placeholder="Field"
                   ariaLabel={`${name} field name`}
                   className="min-w-0 px-0.5 py-0 font-medium"
@@ -515,7 +516,7 @@ export function CharacterTrackerCard({
               )}
               {onUpdate ? (
                 <InlineEdit
-                  value={value}
+                  value={displayValue}
                   onSave={(nextValue) => updateCustomField(name, name, nextValue)}
                   placeholder="Value"
                   ariaLabel={`${name} value`}
@@ -538,13 +539,13 @@ export function CharacterTrackerCard({
                 />
               ) : (
                 <span
-                  title={value}
+                  title={displayValue}
                   className={cn(
                     "min-w-0 text-[color:var(--tracker-profile-text)]",
                     readableCustomFields ? "line-clamp-2 whitespace-normal break-words" : "truncate",
                   )}
                 >
-                  {value}
+                  {displayValue}
                 </span>
               )}
               {deleteMode && onUpdate && (

--- a/packages/client/src/features/tracker-panel/components/character-card/CharacterTrackerCard.tsx
+++ b/packages/client/src/features/tracker-panel/components/character-card/CharacterTrackerCard.tsx
@@ -18,7 +18,7 @@ import type {
   TrackerThoughtBubbleDisplay,
 } from "../../../../stores/ui.store";
 import { cn } from "../../../../lib/utils";
-import { visibleText } from "../../lib/tracker-display";
+import { trackerEditableText, visibleText } from "../../lib/tracker-display";
 import {
   makeUniqueCharacterCustomFieldName,
   normalizeCharacterCustomFieldName,
@@ -223,7 +223,9 @@ export function CharacterTrackerCard({
     );
   }
 
-  const customFields = Object.entries(character.customFields ?? {});
+  const customFields = Object.entries(character.customFields ?? {}).map(
+    ([name, value]) => [name, trackerEditableText(value)] as const,
+  );
   const characterStats = Array.isArray(character.stats) ? character.stats : [];
   const hasDeleteAction = !!onRemove && deleteMode;
   const avatarMedia = characterPicture ?? character.avatarPath ?? null;

--- a/packages/client/src/features/tracker-panel/components/character-card/FeaturedCharacterTrackerCard.tsx
+++ b/packages/client/src/features/tracker-panel/components/character-card/FeaturedCharacterTrackerCard.tsx
@@ -127,8 +127,8 @@ export function FeaturedCharacterTrackerCard({
   const thoughtBubbleRef = useRef<HTMLDivElement | null>(null);
   const thoughtControlRef = useRef<HTMLButtonElement | null>(null);
   const [thoughtsOpen, setThoughtsOpen] = useState(false);
-  const customFields = Object.entries(character.customFields ?? {}).map(
-    ([name, value]) => [name, trackerEditableText(value)] as const,
+  const customFields = Object.entries((character.customFields ?? {}) as Record<string, unknown>).map(
+    ([name, value]) => [name, value, trackerEditableText(value)] as const,
   );
   const characterStats = Array.isArray(character.stats) ? character.stats : [];
   const hasEditableStatAdd = !!onUpdate && addMode;
@@ -235,7 +235,7 @@ export function FeaturedCharacterTrackerCard({
   };
   const removeCustomField = (name: string) => {
     if (!onUpdate) return;
-    const nextFields = { ...(character.customFields ?? {}) };
+    const nextFields: Record<string, unknown> = { ...(character.customFields ?? {}) };
     delete nextFields[name];
     onUpdateFieldLocks?.((locks) =>
       removeTrackerFieldLockPrefix(
@@ -243,11 +243,11 @@ export function FeaturedCharacterTrackerCard({
         characterCustomFieldTrackerLockKey(character, characterIndex, name, "name").replace(/\.name$/, ""),
       ),
     );
-    onUpdate({ ...character, customFields: nextFields });
+    onUpdate({ ...character, customFields: nextFields as Record<string, string> });
   };
-  const updateCustomField = (oldName: string, nextName: string, nextValue: string) => {
+  const updateCustomField = (oldName: string, nextName: string, nextValue: unknown) => {
     if (!onUpdate) return;
-    const nextFields = { ...(character.customFields ?? {}) };
+    const nextFields: Record<string, unknown> = { ...(character.customFields ?? {}) };
     const trimmedName = resolveCharacterCustomFieldName(nextName, oldName);
     if (
       trimmedName !== oldName &&
@@ -270,7 +270,7 @@ export function FeaturedCharacterTrackerCard({
     }
     delete nextFields[oldName];
     nextFields[trimmedName] = nextValue;
-    onUpdate({ ...character, customFields: nextFields });
+    onUpdate({ ...character, customFields: nextFields as Record<string, string> });
   };
 
   return (
@@ -413,7 +413,7 @@ export function FeaturedCharacterTrackerCard({
 
       {(customFields.length > 0 || hasEditableCustomFieldAdd) && (
         <div className={FEATURED_CUSTOM_FIELD_LIST_CLASS}>
-          {customFields.map(([name, value]) => (
+          {customFields.map(([name, rawValue, displayValue]) => (
             <div
               key={name}
               className={cn(
@@ -424,7 +424,7 @@ export function FeaturedCharacterTrackerCard({
               {onUpdate ? (
                 <InlineEdit
                   value={name}
-                  onSave={(nextName) => updateCustomField(name, nextName, value)}
+                  onSave={(nextName) => updateCustomField(name, nextName, rawValue)}
                   placeholder="Field"
                   ariaLabel={`${name} field name`}
                   className="min-w-0 px-0.5 py-0 font-medium"
@@ -446,7 +446,7 @@ export function FeaturedCharacterTrackerCard({
               )}
               {onUpdate ? (
                 <InlineEdit
-                  value={value}
+                  value={displayValue}
                   onSave={(nextValue) => updateCustomField(name, name, nextValue)}
                   placeholder="Value"
                   ariaLabel={`${name} value`}
@@ -467,7 +467,7 @@ export function FeaturedCharacterTrackerCard({
                   }
                 />
               ) : (
-                <span className="min-w-0 truncate text-[color:var(--tracker-profile-text)]">{value}</span>
+                <span className="min-w-0 truncate text-[color:var(--tracker-profile-text)]">{displayValue}</span>
               )}
               {deleteMode && onUpdate && (
                 <button

--- a/packages/client/src/features/tracker-panel/components/character-card/FeaturedCharacterTrackerCard.tsx
+++ b/packages/client/src/features/tracker-panel/components/character-card/FeaturedCharacterTrackerCard.tsx
@@ -18,6 +18,7 @@ import type {
   TrackerThoughtBubbleDisplay,
 } from "../../../../stores/ui.store";
 import { cn } from "../../../../lib/utils";
+import { trackerEditableText } from "../../lib/tracker-display";
 import {
   makeUniqueCharacterCustomFieldName,
   normalizeCharacterCustomFieldName,
@@ -126,7 +127,9 @@ export function FeaturedCharacterTrackerCard({
   const thoughtBubbleRef = useRef<HTMLDivElement | null>(null);
   const thoughtControlRef = useRef<HTMLButtonElement | null>(null);
   const [thoughtsOpen, setThoughtsOpen] = useState(false);
-  const customFields = Object.entries(character.customFields ?? {});
+  const customFields = Object.entries(character.customFields ?? {}).map(
+    ([name, value]) => [name, trackerEditableText(value)] as const,
+  );
   const characterStats = Array.isArray(character.stats) ? character.stats : [];
   const hasEditableStatAdd = !!onUpdate && addMode;
   const hasEditableCustomFieldAdd = !!onUpdate && addMode;

--- a/packages/client/src/features/tracker-panel/lib/tracker-display.ts
+++ b/packages/client/src/features/tracker-panel/lib/tracker-display.ts
@@ -4,6 +4,24 @@ export function visibleText(value: string | number | null | undefined, fallback 
   return text.length > 0 ? text : fallback;
 }
 
+export function trackerEditableText(value: unknown) {
+  if (value === null || value === undefined) return "";
+  if (typeof value === "string") return value;
+  if (typeof value === "number" || typeof value === "boolean" || typeof value === "bigint") return String(value);
+  if (typeof value === "object" && !Array.isArray(value)) {
+    const record = value as Record<string, unknown>;
+    const name = typeof record.name === "string" ? record.name.trim() : "";
+    const statValue = typeof record.value === "number" || typeof record.value === "string" ? record.value : null;
+    const statMax = typeof record.max === "number" || typeof record.max === "string" ? record.max : null;
+    if (name && statValue !== null) return statMax !== null ? `${name}: ${statValue}/${statMax}` : `${name}: ${statValue}`;
+  }
+  try {
+    return JSON.stringify(value) ?? String(value);
+  } catch {
+    return String(value);
+  }
+}
+
 export function clampNumber(value: number, min: number, max: number) {
   return Math.min(max, Math.max(min, value));
 }

--- a/packages/client/src/hooks/use-background-autonomous.ts
+++ b/packages/client/src/hooks/use-background-autonomous.ts
@@ -14,7 +14,7 @@ import { api } from "../lib/api-client";
 import { toAutonomousPresenceStatus } from "../lib/user-status";
 import { useChatStore } from "../stores/chat.store";
 import { useUIStore } from "../stores/ui.store";
-import { showConversationLocalNotification } from "../lib/local-notifications";
+import { showConversationLocalNotification, showConversationNativeNotification } from "../lib/local-notifications";
 import { playConfiguredNotificationPing } from "../lib/notification-sound";
 import { chatKeys } from "./use-chats";
 import { characterKeys } from "./use-characters";
@@ -242,6 +242,11 @@ export function useBackgroundAutonomousPolling() {
 
                 void showConversationLocalNotification({
                   enabled: useUIStore.getState().conversationBrowserNotifications,
+                  characterName: charName,
+                  tag: `marinara-conversation-${chat.id}`,
+                });
+                showConversationNativeNotification({
+                  enabled: useUIStore.getState().conversationMobileNotifications,
                   characterName: charName,
                   tag: `marinara-conversation-${chat.id}`,
                 });

--- a/packages/client/src/lib/echo-chamber-queue.ts
+++ b/packages/client/src/lib/echo-chamber-queue.ts
@@ -1,5 +1,12 @@
-export const ECHO_CHAMBER_MESSAGE_INTERVAL_MS = 1_800;
+export const ECHO_CHAMBER_MESSAGE_INTERVAL_MIN_MS = 10_000;
+export const ECHO_CHAMBER_MESSAGE_INTERVAL_MAX_MS = 30_000;
 export const ECHO_CHAMBER_MESSAGE_LIMIT = 500;
+
+export function getEchoChamberMessageInterval(randomValue = Math.random()): number {
+  const normalizedRandom = Math.min(1, Math.max(0, randomValue));
+  const intervalRange = ECHO_CHAMBER_MESSAGE_INTERVAL_MAX_MS - ECHO_CHAMBER_MESSAGE_INTERVAL_MIN_MS;
+  return ECHO_CHAMBER_MESSAGE_INTERVAL_MIN_MS + Math.floor(normalizedRandom * intervalRange);
+}
 
 export type EchoChamberMessage = {
   characterName: string;

--- a/packages/client/src/lib/keep-alive.ts
+++ b/packages/client/src/lib/keep-alive.ts
@@ -16,6 +16,9 @@ let started = false;
 
 export function startKeepAlive() {
   if (started) return;
+  // Mobile browsers need to suspend idle pages to protect battery and thermal
+  // headroom. This exists only to defeat desktop sleeping-tab heuristics.
+  if (window.matchMedia("(hover: none) and (pointer: coarse)").matches) return;
   started = true;
 
   // ── Web Lock (primary defense) ──

--- a/packages/client/src/lib/local-notifications.ts
+++ b/packages/client/src/lib/local-notifications.ts
@@ -57,7 +57,9 @@ export async function requestNativeNotificationPermission(): Promise<NativeNotif
     const handlePermission = (event: Event) => {
       finish(normalizeNativePermission((event as CustomEvent<string>).detail));
     };
-    const timeoutId = window.setTimeout(() => finish(getNativeNotificationPermission()), 30_000);
+    // Resolve a slow bridge request for the current caller, but leave the one-shot
+    // listener installed so a late Android result is still consumed and cleaned up.
+    const timeoutId = window.setTimeout(() => resolve(getNativeNotificationPermission()), 30_000);
     window.addEventListener("marinara:native-notification-permission", handlePermission, { once: true });
     bridge.requestNotificationPermission?.();
   });

--- a/packages/client/src/lib/local-notifications.ts
+++ b/packages/client/src/lib/local-notifications.ts
@@ -1,4 +1,11 @@
 export type LocalNotificationPermission = NotificationPermission | "unsupported";
+export type NativeNotificationPermission = "default" | "denied" | "granted" | "unsupported";
+
+type MarinaraAndroidNotificationBridge = {
+  getNotificationPermission?: () => string;
+  requestNotificationPermission?: () => void;
+  showNotification?: (title: string, body: string, tag: string) => void;
+};
 
 export type ConversationLocalNotificationOptions = {
   enabled: boolean;
@@ -9,6 +16,51 @@ export type ConversationLocalNotificationOptions = {
 function getBrowserNotificationPermission(): LocalNotificationPermission {
   if (typeof window === "undefined" || !("Notification" in window)) return "unsupported";
   return window.Notification.permission;
+}
+
+function getAndroidNotificationBridge(): MarinaraAndroidNotificationBridge | null {
+  if (typeof window === "undefined") return null;
+  return (window as Window & { MarinaraAndroid?: MarinaraAndroidNotificationBridge }).MarinaraAndroid ?? null;
+}
+
+export function hasNativeNotificationBridge(): boolean {
+  const bridge = getAndroidNotificationBridge();
+  return (
+    typeof bridge?.getNotificationPermission === "function" &&
+    typeof bridge.requestNotificationPermission === "function" &&
+    typeof bridge.showNotification === "function"
+  );
+}
+
+function normalizeNativePermission(value: string | undefined): NativeNotificationPermission {
+  return value === "default" || value === "denied" || value === "granted" ? value : "unsupported";
+}
+
+export function getNativeNotificationPermission(): NativeNotificationPermission {
+  const bridge = getAndroidNotificationBridge();
+  if (typeof bridge?.getNotificationPermission !== "function") return "unsupported";
+  return normalizeNativePermission(bridge.getNotificationPermission());
+}
+
+export async function requestNativeNotificationPermission(): Promise<NativeNotificationPermission> {
+  const bridge = getAndroidNotificationBridge();
+  if (typeof bridge?.requestNotificationPermission !== "function") return "unsupported";
+  const current = getNativeNotificationPermission();
+  if (current === "granted") return current;
+
+  return new Promise((resolve) => {
+    const finish = (permission: NativeNotificationPermission) => {
+      window.removeEventListener("marinara:native-notification-permission", handlePermission);
+      window.clearTimeout(timeoutId);
+      resolve(permission);
+    };
+    const handlePermission = (event: Event) => {
+      finish(normalizeNativePermission((event as CustomEvent<string>).detail));
+    };
+    const timeoutId = window.setTimeout(() => finish(getNativeNotificationPermission()), 30_000);
+    window.addEventListener("marinara:native-notification-permission", handlePermission, { once: true });
+    bridge.requestNotificationPermission?.();
+  });
 }
 
 async function requestBrowserNotificationPermission(): Promise<LocalNotificationPermission> {
@@ -51,5 +103,20 @@ export async function showConversationLocalNotification({
     notification.close();
   };
 
+  return true;
+}
+
+export function showConversationNativeNotification({
+  enabled,
+  characterName,
+  tag,
+}: ConversationLocalNotificationOptions): boolean {
+  if (!enabled || isAppFocusedForNotifications()) return false;
+  const bridge = getAndroidNotificationBridge();
+  if (typeof bridge?.showNotification !== "function" || getNativeNotificationPermission() !== "granted") {
+    return false;
+  }
+  const name = typeof characterName === "string" && characterName.trim() ? characterName.trim() : "Character";
+  bridge.showNotification(`New message from ${name.slice(0, 80)}`, "Open Marinara to read it.", tag ?? "message");
   return true;
 }

--- a/packages/client/src/lib/weather-frame-clock.ts
+++ b/packages/client/src/lib/weather-frame-clock.ts
@@ -1,0 +1,20 @@
+export const WEATHER_TARGET_FRAME_MS = 1000 / 30;
+
+export type WeatherFrameStep = {
+  accumulatedMs: number;
+  frameElapsedMs: number;
+  shouldDraw: boolean;
+};
+
+export function advanceWeatherFrameClock(accumulatedMs: number, elapsedMs: number): WeatherFrameStep {
+  const nextAccumulated = accumulatedMs + Math.min(100, Math.max(0, elapsedMs));
+  if (nextAccumulated < WEATHER_TARGET_FRAME_MS) {
+    return { accumulatedMs: nextAccumulated, frameElapsedMs: 0, shouldDraw: false };
+  }
+
+  return {
+    accumulatedMs: nextAccumulated % WEATHER_TARGET_FRAME_MS,
+    frameElapsedMs: nextAccumulated,
+    shouldDraw: true,
+  };
+}

--- a/packages/client/src/lib/weather-renderer.ts
+++ b/packages/client/src/lib/weather-renderer.ts
@@ -1,0 +1,704 @@
+// ── Particle types ──
+export interface WeatherParticle {
+  x: number;
+  y: number;
+  vx: number;
+  vy: number;
+  size: number;
+  opacity: number;
+  type:
+    | "rain"
+    | "snow"
+    | "leaf"
+    | "firefly"
+    | "star"
+    | "fog"
+    | "dust"
+    | "petal"
+    | "ember"
+    | "ash"
+    | "sand"
+    | "hail"
+    | "aurora";
+  wobble: number;
+  life: number;
+  maxLife: number;
+  /** Pre-computed fill colour (ash, sand) to avoid Math.random() in draw */
+  color: string;
+}
+
+type WeatherCanvasContext = CanvasRenderingContext2D | OffscreenCanvasRenderingContext2D;
+
+export interface WeatherRenderConfig {
+  type: WeatherParticle["type"];
+  count: number;
+  overlay: string;
+  lightning: boolean;
+  tint: string;
+  addFireflies: boolean;
+  addStars: boolean;
+  celestial: CelestialBody;
+  hour: number;
+  sunRays: boolean;
+  sunsetGlow: boolean;
+  isClearSky: boolean;
+}
+
+// ── Map weather string → effect config ──
+function parseWeather(weather?: string | null): {
+  type: WeatherParticle["type"];
+  count: number;
+  overlay: string;
+  lightning: boolean;
+} {
+  if (!weather) return { type: "dust", count: 0, overlay: "", lightning: false };
+
+  const w = weather.toLowerCase();
+
+  // Thunderstorm / lightning
+  if (w.includes("thunder") || w.includes("lightning")) {
+    return { type: "rain", count: 120, overlay: "rgba(50,80,120,0.10)", lightning: true };
+  }
+  if (w.includes("hail")) {
+    return { type: "hail", count: 40, overlay: "rgba(180,200,230,0.06)", lightning: false };
+  }
+  if (w.includes("blizzard")) {
+    return { type: "snow", count: 90, overlay: "rgba(200,220,255,0.10)", lightning: false };
+  }
+  if (w.includes("snow") || w.includes("sleet")) {
+    const isHeavy = w.includes("heavy");
+    return { type: "snow", count: isHeavy ? 75 : 35, overlay: "rgba(200,220,255,0.06)", lightning: false };
+  }
+  if (w.includes("frost") || w.includes("cold") || w.includes("freez")) {
+    return { type: "snow", count: 12, overlay: "rgba(180,210,240,0.06)", lightning: false };
+  }
+  if (w.includes("fog") || w.includes("mist") || w.includes("haze")) {
+    return { type: "fog", count: 12, overlay: "rgba(180,180,200,0.12)", lightning: false };
+  }
+  if (w.includes("sand") || w.includes("dust storm") || w.includes("sirocco")) {
+    return { type: "sand", count: 65, overlay: "rgba(180,150,100,0.12)", lightning: false };
+  }
+  if (w.includes("ash") || w.includes("volcanic") || w.includes("smoke")) {
+    return { type: "ash", count: 30, overlay: "rgba(80,60,60,0.10)", lightning: false };
+  }
+  if (w.includes("ember") || w.includes("fire") || w.includes("inferno")) {
+    return { type: "ember", count: 24, overlay: "rgba(120,40,10,0.08)", lightning: false };
+  }
+  if (w.includes("wind") || w.includes("breez") || w.includes("gust")) {
+    return { type: "leaf", count: 18, overlay: "", lightning: false };
+  }
+  if (w.includes("cherry") || w.includes("blossom") || w.includes("petal")) {
+    return { type: "petal", count: 22, overlay: "rgba(255,180,200,0.04)", lightning: false };
+  }
+  if (w.includes("aurora") || w.includes("northern light") || w.includes("polar light")) {
+    return { type: "aurora", count: 6, overlay: "rgba(20,60,40,0.08)", lightning: false };
+  }
+  if (w.includes("rain") || w.includes("storm") || w.includes("downpour")) {
+    const isHeavy = w.includes("heavy") || w.includes("storm") || w.includes("downpour");
+    return {
+      type: "rain",
+      count: isHeavy ? 120 : 55,
+      overlay: "rgba(50,80,120,0.08)",
+      lightning: isHeavy && w.includes("storm"),
+    };
+  }
+  if (w.includes("clear") || w.includes("sunny") || w.includes("bright")) {
+    return { type: "dust", count: 8, overlay: "", lightning: false };
+  }
+  if (w.includes("cloud") || w.includes("overcast") || w.includes("grey") || w.includes("gray")) {
+    return { type: "dust", count: 6, overlay: "rgba(100,100,120,0.05)", lightning: false };
+  }
+
+  return { type: "dust", count: 8, overlay: "", lightning: false };
+}
+
+// ── Map time of day → tint + fireflies ──
+type CelestialBody = "sun" | "moon" | "none";
+
+function parseTime(
+  timeOfDay?: string | null,
+  baseType?: WeatherParticle["type"],
+): {
+  tint: string;
+  addFireflies: boolean;
+  addStars: boolean;
+  celestial: CelestialBody;
+  hour: number; // 0-24, -1 if unknown
+  sunRays: boolean;
+  sunsetGlow: boolean;
+  isClearSky: boolean; // derived later; default false here
+} {
+  const base = {
+    tint: "",
+    addFireflies: false,
+    addStars: false,
+    celestial: "none" as CelestialBody,
+    hour: -1,
+    sunRays: false,
+    sunsetGlow: false,
+    isClearSky: false,
+  };
+
+  if (!timeOfDay) return base;
+
+  const t = timeOfDay.toLowerCase();
+
+  // Try to extract a numeric hour from the time string ("14:30", "2 PM", "1400", etc.)
+  const hour = extractHour(t);
+  base.hour = hour;
+
+  if (t.includes("night") || t.includes("midnight")) {
+    return {
+      ...base,
+      tint: "rgba(10,10,40,0.15)",
+      addFireflies: baseType !== "rain" && baseType !== "snow",
+      addStars: baseType !== "fog" && baseType !== "snow",
+      celestial: "moon",
+      hour: hour >= 0 ? hour : 0,
+    };
+  }
+  if (t.includes("dusk") || t.includes("sunset") || t.includes("twilight") || t.includes("evening")) {
+    return {
+      ...base,
+      tint: "rgba(80,30,20,0.10)",
+      addFireflies: baseType !== "rain",
+      addStars: false,
+      celestial: "sun",
+      hour: hour >= 0 ? hour : 18,
+      sunsetGlow: true,
+    };
+  }
+  if (t.includes("dawn") || t.includes("sunrise") || t.includes("morning")) {
+    return {
+      ...base,
+      tint: "rgba(120,80,40,0.06)",
+      celestial: "sun",
+      hour: hour >= 0 ? hour : 7,
+      sunRays: true,
+    };
+  }
+
+  // Numeric hour fallback — determine time period from hour
+  if (hour >= 0) {
+    if (hour >= 21 || hour < 5) {
+      return {
+        ...base,
+        tint: "rgba(10,10,40,0.15)",
+        addFireflies: baseType !== "rain" && baseType !== "snow",
+        addStars: baseType !== "fog" && baseType !== "snow",
+        celestial: "moon",
+      };
+    }
+    if (hour >= 17 && hour < 21) {
+      return {
+        ...base,
+        tint: "rgba(80,30,20,0.10)",
+        addFireflies: baseType !== "rain",
+        celestial: "sun",
+        sunsetGlow: hour >= 17,
+      };
+    }
+    if (hour >= 5 && hour < 9) {
+      return {
+        ...base,
+        tint: "rgba(120,80,40,0.06)",
+        celestial: "sun",
+        sunRays: true,
+      };
+    }
+    // Daytime (9-17)
+    return {
+      ...base,
+      celestial: "sun",
+      sunRays: true,
+    };
+  }
+
+  // If it just says "afternoon", "day", "noon", etc.
+  if (t.includes("noon") || t.includes("midday") || t.includes("afternoon") || t.includes("day")) {
+    return {
+      ...base,
+      celestial: "sun",
+      hour: t.includes("afternoon") ? 15 : 12,
+      sunRays: true,
+    };
+  }
+
+  return base;
+}
+
+/** Try to extract an hour (0-23) from a time string. Returns -1 if not found. */
+function extractHour(t: string): number {
+  // "14:30", "2:00 PM", "14h30", "1400"
+  const match24 = t.match(/\b(\d{1,2})[:.h](\d{2})\b/);
+  if (match24) {
+    let h = parseInt(match24[1]!, 10);
+    if (t.includes("pm") && h < 12) h += 12;
+    if (t.includes("am") && h === 12) h = 0;
+    if (h >= 0 && h < 24) return h;
+  }
+  // "2 PM", "11 AM"
+  const matchAmPm = t.match(/\b(\d{1,2})\s*(am|pm)\b/);
+  if (matchAmPm) {
+    let h = parseInt(matchAmPm[1]!, 10);
+    if (matchAmPm[2] === "pm" && h < 12) h += 12;
+    if (matchAmPm[2] === "am" && h === 12) h = 0;
+    if (h >= 0 && h < 24) return h;
+  }
+  // Military "1400", "0800"
+  const matchMil = t.match(/\b(\d{4})\s*(?:hours?|hrs?)?\b/);
+  if (matchMil) {
+    const h = parseInt(matchMil[1]!.slice(0, 2), 10);
+    if (h >= 0 && h < 24) return h;
+  }
+  return -1;
+}
+
+export function resolveWeatherRenderConfig(
+  weather?: string | null,
+  timeOfDay?: string | null,
+): WeatherRenderConfig {
+  const weatherConfig = parseWeather(weather);
+  const timeConfig = parseTime(timeOfDay, weatherConfig.type);
+  const isClearSky =
+    !weather ||
+    /clear|sunny|bright/i.test(weather) ||
+    !/(rain|storm|snow|blizzard|fog|mist|haze|hail|sand|ash|smoke|overcast|cloud|grey|gray)/i.test(weather);
+  return { ...weatherConfig, ...timeConfig, isClearSky };
+}
+
+// ── Create particle ──
+export function createWeatherParticle(
+  type: WeatherParticle["type"],
+  w: number,
+  h: number,
+  fromTop = false,
+): WeatherParticle {
+  const base: WeatherParticle = {
+    x: Math.random() * w,
+    y: fromTop ? -10 : Math.random() * h,
+    vx: 0,
+    vy: 0,
+    size: 2,
+    opacity: 0.5,
+    type,
+    wobble: Math.random() * Math.PI * 2,
+    life: 0,
+    maxLife: 600 + Math.random() * 400,
+    color: "",
+  };
+
+  switch (type) {
+    case "rain":
+      base.vy = 8 + Math.random() * 6;
+      base.vx = -1 + Math.random() * -2;
+      base.size = 1.5;
+      base.opacity = 0.25 + Math.random() * 0.2;
+      base.maxLife = 200;
+      break;
+    case "snow":
+      base.vy = 0.5 + Math.random() * 1.2;
+      base.vx = -0.3 + Math.random() * 0.6;
+      base.size = 2 + Math.random() * 3;
+      base.opacity = 0.4 + Math.random() * 0.3;
+      base.maxLife = 800;
+      break;
+    case "leaf":
+      base.vy = 0.8 + Math.random() * 1;
+      base.vx = 1.5 + Math.random() * 2;
+      base.size = 4 + Math.random() * 3;
+      base.opacity = 0.5 + Math.random() * 0.3;
+      base.maxLife = 500;
+      break;
+    case "petal":
+      base.vy = 0.4 + Math.random() * 0.8;
+      base.vx = 0.5 + Math.random() * 1;
+      base.size = 3 + Math.random() * 3;
+      base.opacity = 0.4 + Math.random() * 0.3;
+      base.maxLife = 600;
+      break;
+    case "firefly":
+      base.vy = -0.2 + Math.random() * 0.4;
+      base.vx = -0.3 + Math.random() * 0.6;
+      base.size = 2 + Math.random() * 2;
+      base.opacity = 0;
+      base.maxLife = 300 + Math.random() * 300;
+      break;
+    case "star":
+      base.vy = 0;
+      base.vx = 0;
+      base.size = 1 + Math.random() * 1.5;
+      base.opacity = 0;
+      base.maxLife = 400 + Math.random() * 400;
+      base.y = Math.random() * h * 0.4; // upper portion
+      break;
+    case "fog":
+      base.vy = 0;
+      base.vx = 0.2 + Math.random() * 0.4;
+      base.size = 60 + Math.random() * 80;
+      base.opacity = 0.03 + Math.random() * 0.04;
+      base.maxLife = 1000;
+      break;
+    case "dust":
+      base.vy = -0.1 + Math.random() * 0.2;
+      base.vx = -0.1 + Math.random() * 0.2;
+      base.size = 1 + Math.random() * 2;
+      base.opacity = 0.15 + Math.random() * 0.15;
+      base.maxLife = 600 + Math.random() * 400;
+      break;
+    case "ember":
+      base.vy = -1.5 + Math.random() * -1.5;
+      base.vx = -0.5 + Math.random() * 1;
+      base.size = 2 + Math.random() * 2;
+      base.opacity = 0.6 + Math.random() * 0.3;
+      base.maxLife = 300 + Math.random() * 200;
+      base.y = h + 10; // rise from bottom
+      break;
+    case "ash":
+      base.vy = 0.3 + Math.random() * 0.6;
+      base.vx = -0.4 + Math.random() * 0.8;
+      base.size = 2 + Math.random() * 3;
+      base.opacity = 0.2 + Math.random() * 0.2;
+      base.maxLife = 700 + Math.random() * 300;
+      base.color = `rgba(${(100 + Math.random() * 40) | 0},${(90 + Math.random() * 30) | 0},${(90 + Math.random() * 30) | 0},0.6)`;
+      break;
+    case "sand":
+      base.vy = 0.5 + Math.random() * 1;
+      base.vx = 4 + Math.random() * 4;
+      base.size = 1 + Math.random() * 2;
+      base.opacity = 0.3 + Math.random() * 0.3;
+      base.maxLife = 250 + Math.random() * 150;
+      base.x = -10; // enter from left
+      base.color = `rgba(${(200 + Math.random() * 30) | 0},${(170 + Math.random() * 30) | 0},${(110 + Math.random() * 20) | 0},0.7)`;
+      break;
+    case "hail":
+      base.vy = 10 + Math.random() * 6;
+      base.vx = -1 + Math.random() * -1;
+      base.size = 2 + Math.random() * 3;
+      base.opacity = 0.4 + Math.random() * 0.3;
+      base.maxLife = 150;
+      break;
+    case "aurora":
+      base.vy = 0;
+      base.vx = 0.1 + Math.random() * 0.2;
+      base.size = 80 + Math.random() * 120;
+      base.opacity = 0.04 + Math.random() * 0.03;
+      base.maxLife = 1200 + Math.random() * 600;
+      base.y = Math.random() * h * 0.35; // upper sky
+      break;
+  }
+
+  return base;
+}
+
+// ── Draw helpers ──
+export function drawWeatherParticle(ctx: WeatherCanvasContext, p: WeatherParticle) {
+  const fadeIn = Math.min(p.life / 60, 1);
+  const fadeOut = Math.max(1 - p.life / p.maxLife, 0);
+  const alpha = p.opacity * fadeIn * fadeOut;
+  if (alpha <= 0) return;
+
+  ctx.globalAlpha = alpha;
+
+  switch (p.type) {
+    case "rain": {
+      ctx.strokeStyle = "rgba(180,210,255,0.8)";
+      ctx.lineWidth = p.size;
+      ctx.beginPath();
+      ctx.moveTo(p.x, p.y);
+      ctx.lineTo(p.x + p.vx * 2, p.y + p.vy * 2);
+      ctx.stroke();
+      break;
+    }
+    case "snow": {
+      ctx.fillStyle = "rgba(255,255,255,0.82)";
+      ctx.beginPath();
+      ctx.arc(p.x, p.y, p.size, 0, Math.PI * 2);
+      ctx.fill();
+      break;
+    }
+    case "leaf": {
+      ctx.fillStyle = `hsl(${100 + Math.sin(p.wobble) * 30}, 60%, 45%)`;
+      ctx.save();
+      ctx.translate(p.x, p.y);
+      ctx.rotate(p.wobble);
+      ctx.beginPath();
+      ctx.ellipse(0, 0, p.size, p.size * 0.4, 0, 0, Math.PI * 2);
+      ctx.fill();
+      ctx.restore();
+      break;
+    }
+    case "petal": {
+      ctx.fillStyle = `hsl(${340 + Math.sin(p.wobble) * 15}, 80%, 80%)`;
+      ctx.save();
+      ctx.translate(p.x, p.y);
+      ctx.rotate(p.wobble);
+      ctx.beginPath();
+      ctx.ellipse(0, 0, p.size, p.size * 0.5, 0, 0, Math.PI * 2);
+      ctx.fill();
+      ctx.restore();
+      break;
+    }
+    case "firefly": {
+      const pulse = Math.sin(p.life * 0.05) * 0.5 + 0.5;
+      ctx.globalAlpha = alpha * 0.28 * pulse;
+      ctx.fillStyle = "rgba(180,255,80,0.7)";
+      ctx.beginPath();
+      ctx.arc(p.x, p.y, p.size * 3, 0, Math.PI * 2);
+      ctx.fill();
+      ctx.globalAlpha = alpha * (0.65 + pulse * 0.35);
+      ctx.fillStyle = "rgba(220,255,130,0.95)";
+      ctx.beginPath();
+      ctx.arc(p.x, p.y, p.size, 0, Math.PI * 2);
+      ctx.fill();
+      break;
+    }
+    case "star": {
+      const twinkle = Math.sin(p.life * 0.04 + p.wobble) * 0.5 + 0.5;
+      ctx.fillStyle = `rgba(255,255,240,${twinkle * 0.7})`;
+      ctx.beginPath();
+      ctx.arc(p.x, p.y, p.size, 0, Math.PI * 2);
+      ctx.fill();
+      // cross sparkle
+      ctx.strokeStyle = `rgba(255,255,240,${twinkle * 0.3})`;
+      ctx.lineWidth = 0.5;
+      ctx.beginPath();
+      ctx.moveTo(p.x - p.size * 2, p.y);
+      ctx.lineTo(p.x + p.size * 2, p.y);
+      ctx.moveTo(p.x, p.y - p.size * 2);
+      ctx.lineTo(p.x, p.y + p.size * 2);
+      ctx.stroke();
+      break;
+    }
+    case "fog": {
+      ctx.globalAlpha = alpha * 0.7;
+      ctx.fillStyle = "rgba(200,200,220,0.08)";
+      ctx.beginPath();
+      ctx.ellipse(p.x, p.y, p.size * 1.5, p.size * 0.45, 0, 0, Math.PI * 2);
+      ctx.fill();
+      break;
+    }
+    case "dust": {
+      ctx.fillStyle = "rgba(255,240,220,0.6)";
+      ctx.beginPath();
+      ctx.arc(p.x, p.y, p.size, 0, Math.PI * 2);
+      ctx.fill();
+      break;
+    }
+    case "ember": {
+      const emberPulse = Math.sin(p.life * 0.08) * 0.3 + 0.7;
+      ctx.globalAlpha = alpha * 0.32 * emberPulse;
+      ctx.fillStyle = "rgba(255,80,20,0.7)";
+      ctx.beginPath();
+      ctx.arc(p.x, p.y, p.size * 2.5, 0, Math.PI * 2);
+      ctx.fill();
+      ctx.globalAlpha = alpha * emberPulse;
+      ctx.fillStyle = "rgba(255,205,70,0.92)";
+      ctx.beginPath();
+      ctx.arc(p.x, p.y, p.size, 0, Math.PI * 2);
+      ctx.fill();
+      break;
+    }
+    case "ash": {
+      ctx.fillStyle = p.color;
+      ctx.save();
+      ctx.translate(p.x, p.y);
+      ctx.rotate(p.wobble);
+      ctx.beginPath();
+      ctx.ellipse(0, 0, p.size, p.size * 0.3, 0, 0, Math.PI * 2);
+      ctx.fill();
+      ctx.restore();
+      break;
+    }
+    case "sand": {
+      ctx.fillStyle = p.color;
+      ctx.beginPath();
+      ctx.arc(p.x, p.y, p.size, 0, Math.PI * 2);
+      ctx.fill();
+      break;
+    }
+    case "hail": {
+      ctx.fillStyle = "rgba(230,240,255,0.85)";
+      ctx.beginPath();
+      ctx.arc(p.x, p.y, p.size, 0, Math.PI * 2);
+      ctx.fill();
+      break;
+    }
+    case "aurora": {
+      // Tall vertical ribbon of colour that sways gently
+      const hue = (p.wobble * 60 + p.life * 0.3) % 360;
+      const auroraGrad = ctx.createLinearGradient(p.x, p.y - p.size, p.x, p.y + p.size);
+      auroraGrad.addColorStop(0, `hsla(${hue},80%,60%,0)`);
+      auroraGrad.addColorStop(0.3, `hsla(${hue},80%,60%,0.08)`);
+      auroraGrad.addColorStop(0.5, `hsla(${(hue + 40) % 360},70%,55%,0.12)`);
+      auroraGrad.addColorStop(0.7, `hsla(${(hue + 80) % 360},80%,60%,0.08)`);
+      auroraGrad.addColorStop(1, `hsla(${(hue + 80) % 360},80%,60%,0)`);
+      ctx.fillStyle = auroraGrad;
+      ctx.beginPath();
+      const ribbonW = p.size * 0.6;
+      const sway = Math.sin(p.life * 0.008 + p.wobble) * 30;
+      ctx.moveTo(p.x + sway - ribbonW, p.y - p.size);
+      ctx.quadraticCurveTo(p.x + sway * 0.5, p.y, p.x + sway + ribbonW, p.y + p.size);
+      ctx.lineTo(p.x + sway - ribbonW, p.y + p.size);
+      ctx.quadraticCurveTo(p.x + sway * 0.5, p.y, p.x + sway + ribbonW, p.y - p.size);
+      ctx.closePath();
+      ctx.fill();
+      break;
+    }
+  }
+
+  ctx.globalAlpha = 1;
+}
+
+// ── Celestial drawing helpers ──
+
+/** Get sun/moon X position based on hour. Maps 6:00→left edge, 12:00→center, 18:00→right edge. */
+export function weatherCelestialX(hour: number, w: number): number {
+  // Sun arc: 6h = 0%, 12h = 50%, 18h = 100% of width
+  const t = Math.max(0, Math.min(1, (hour - 6) / 12));
+  return w * 0.08 + t * w * 0.84; // 8%-92% of width
+}
+
+/** Get sun Y position — arc from bottom-ish up to top and back down. */
+export function weatherCelestialY(hour: number, h: number, isMoon: boolean): number {
+  if (isMoon) {
+    // Moon arc: highest at midnight (hour 0/24), lower at 21h and 5h
+    const t = hour >= 12 ? (hour - 21) / 7 : (hour + 3) / 7; // normalized 0-1
+    const arc = Math.sin(Math.max(0, Math.min(1, t)) * Math.PI);
+    return h * 0.05 + (1 - arc) * h * 0.2;
+  }
+  // Sun: lowest at 6h/18h, highest at noon
+  const t = Math.max(0, Math.min(1, (hour - 6) / 12));
+  const arc = Math.sin(t * Math.PI); // 0 at edges, 1 at noon
+  return h * 0.05 + (1 - arc) * h * 0.25; // 5%-30% from top
+}
+
+export function drawWeatherSun(
+  ctx: WeatherCanvasContext,
+  x: number,
+  y: number,
+  radius: number,
+  w: number,
+  h: number,
+  sunRays: boolean,
+  sunsetGlow: boolean,
+  frameCount: number,
+) {
+  ctx.save();
+
+  if (sunsetGlow) {
+    // Warm gradient sky wash at bottom
+    const glowGrad = ctx.createRadialGradient(x, y, radius, x, y + radius * 6, radius * 12);
+    glowGrad.addColorStop(0, "rgba(255,140,50,0.12)");
+    glowGrad.addColorStop(0.4, "rgba(255,80,30,0.06)");
+    glowGrad.addColorStop(1, "rgba(255,40,20,0)");
+    ctx.fillStyle = glowGrad;
+    ctx.fillRect(0, 0, w, h);
+  }
+
+  // Outer glow
+  const outerGlow = ctx.createRadialGradient(x, y, radius * 0.5, x, y, radius * 4);
+  outerGlow.addColorStop(0, sunsetGlow ? "rgba(255,120,40,0.15)" : "rgba(255,240,180,0.12)");
+  outerGlow.addColorStop(0.5, sunsetGlow ? "rgba(255,80,20,0.05)" : "rgba(255,240,180,0.04)");
+  outerGlow.addColorStop(1, "rgba(255,240,180,0)");
+  ctx.globalAlpha = 1;
+  ctx.fillStyle = outerGlow;
+  ctx.beginPath();
+  ctx.arc(x, y, radius * 4, 0, Math.PI * 2);
+  ctx.fill();
+
+  // Sun disc
+  const discGrad = ctx.createRadialGradient(x, y, 0, x, y, radius);
+  if (sunsetGlow) {
+    discGrad.addColorStop(0, "rgba(255,200,100,0.9)");
+    discGrad.addColorStop(0.7, "rgba(255,120,40,0.7)");
+    discGrad.addColorStop(1, "rgba(255,80,20,0.3)");
+  } else {
+    discGrad.addColorStop(0, "rgba(255,250,220,0.8)");
+    discGrad.addColorStop(0.7, "rgba(255,240,180,0.5)");
+    discGrad.addColorStop(1, "rgba(255,230,150,0.2)");
+  }
+  ctx.globalAlpha = 0.8;
+  ctx.fillStyle = discGrad;
+  ctx.beginPath();
+  ctx.arc(x, y, radius, 0, Math.PI * 2);
+  ctx.fill();
+
+  // Animated light rays
+  if (sunRays) {
+    const rayCount = 12;
+    const rotOffset = frameCount * 0.002;
+    ctx.globalAlpha = 0.06;
+    for (let i = 0; i < rayCount; i++) {
+      const angle = (i / rayCount) * Math.PI * 2 + rotOffset;
+      const pulse = 0.8 + Math.sin(frameCount * 0.01 + i * 1.5) * 0.2;
+      const rayLen = radius * (3.5 + pulse * 2);
+      const spread = 0.08;
+      ctx.fillStyle = sunsetGlow ? "rgba(255,160,60,0.5)" : "rgba(255,250,200,0.4)";
+      ctx.beginPath();
+      ctx.moveTo(x, y);
+      ctx.lineTo(x + Math.cos(angle - spread) * rayLen, y + Math.sin(angle - spread) * rayLen);
+      ctx.lineTo(x + Math.cos(angle + spread) * rayLen, y + Math.sin(angle + spread) * rayLen);
+      ctx.closePath();
+      ctx.fill();
+    }
+  }
+
+  ctx.restore();
+}
+
+export function drawWeatherMoon(
+  ctx: WeatherCanvasContext,
+  x: number,
+  y: number,
+  radius: number,
+  _frameCount: number,
+) {
+  ctx.save();
+
+  // Soft moonlight glow
+  const glow = ctx.createRadialGradient(x, y, radius * 0.5, x, y, radius * 5);
+  glow.addColorStop(0, "rgba(180,200,255,0.10)");
+  glow.addColorStop(0.4, "rgba(150,180,255,0.04)");
+  glow.addColorStop(1, "rgba(150,180,255,0)");
+  ctx.globalAlpha = 1;
+  ctx.fillStyle = glow;
+  ctx.beginPath();
+  ctx.arc(x, y, radius * 5, 0, Math.PI * 2);
+  ctx.fill();
+
+  // Moon disc (bright side)
+  const discGrad = ctx.createRadialGradient(x - radius * 0.15, y - radius * 0.15, 0, x, y, radius);
+  discGrad.addColorStop(0, "rgba(230,235,255,0.85)");
+  discGrad.addColorStop(0.8, "rgba(200,210,240,0.6)");
+  discGrad.addColorStop(1, "rgba(180,190,220,0.3)");
+  ctx.globalAlpha = 0.7;
+  ctx.fillStyle = discGrad;
+  ctx.beginPath();
+  ctx.arc(x, y, radius, 0, Math.PI * 2);
+  ctx.fill();
+
+  // Crescent shadow (dark side) — offset circle to create crescent shape
+  ctx.globalCompositeOperation = "destination-out";
+  ctx.globalAlpha = 0.65;
+  ctx.fillStyle = "black";
+  ctx.beginPath();
+  ctx.arc(x + radius * 0.45, y - radius * 0.1, radius * 0.85, 0, Math.PI * 2);
+  ctx.fill();
+  ctx.globalCompositeOperation = "source-over";
+
+  // Subtle crater hints
+  ctx.globalAlpha = 0.06;
+  ctx.fillStyle = "rgba(150,160,190,1)";
+  ctx.beginPath();
+  ctx.arc(x - radius * 0.25, y - radius * 0.15, radius * 0.12, 0, Math.PI * 2);
+  ctx.fill();
+  ctx.beginPath();
+  ctx.arc(x - radius * 0.4, y + radius * 0.25, radius * 0.08, 0, Math.PI * 2);
+  ctx.fill();
+  ctx.beginPath();
+  ctx.arc(x - radius * 0.05, y + radius * 0.35, radius * 0.1, 0, Math.PI * 2);
+  ctx.fill();
+
+  ctx.restore();
+}

--- a/packages/client/src/main.tsx
+++ b/packages/client/src/main.tsx
@@ -58,9 +58,11 @@ function registerServiceWorker() {
               return;
             }
 
+            const isMobile = window.matchMedia("(hover: none) and (pointer: coarse)").matches;
+            const updateIntervalMs = isMobile ? 6 * 60 * 60_000 : 60 * 60_000;
             window.setInterval(() => {
-              void registration.update();
-            }, 60_000);
+              if (document.visibilityState === "visible") void registration.update();
+            }, updateIntervalMs);
           },
         });
       })

--- a/packages/client/src/stores/agent.store.ts
+++ b/packages/client/src/stores/agent.store.ts
@@ -165,6 +165,7 @@ interface AgentState {
   setEchoMessages: (messages: Array<{ characterName: string; reaction: string; timestamp: number }>) => void;
   clearEchoMessages: () => void;
   setEchoVisibleCount: (count: number) => void;
+  revealNextEchoMessage: () => void;
   setEchoBaseline: (count: number) => void;
   setEchoLoadedChatId: (chatId: string | null) => void;
   setCyoaChoices: (choices: Array<{ label: string; text: string }>, chatId?: string | null) => void;
@@ -382,6 +383,10 @@ export const useAgentStore = create<AgentState>((set, get) => ({
   clearEchoMessages: () => set({ echoMessages: [], echoVisibleCount: 0, echoBaseline: 0, echoLoadedChatId: null }),
 
   setEchoVisibleCount: (count) => set({ echoVisibleCount: count }),
+  revealNextEchoMessage: () =>
+    set((state) => ({
+      echoVisibleCount: Math.min(state.echoVisibleCount + 1, state.echoMessages.length),
+    })),
   setEchoBaseline: (count) => set({ echoBaseline: count }),
   setEchoLoadedChatId: (chatId) => set({ echoLoadedChatId: chatId }),
 

--- a/packages/client/src/stores/ui.store.ts
+++ b/packages/client/src/stores/ui.store.ts
@@ -672,6 +672,7 @@ interface UIState {
   gameNotificationSound: boolean;
   notificationSoundsOnlyWhenUnfocused: boolean;
   conversationBrowserNotifications: boolean;
+  conversationMobileNotifications: boolean;
 
   // ── Custom Conversation Prompt ──
   /** User's custom default system prompt for new conversations (null = built-in default). */
@@ -921,6 +922,7 @@ interface UIState {
   setGameNotificationSound: (v: boolean) => void;
   setNotificationSoundsOnlyWhenUnfocused: (v: boolean) => void;
   setConversationBrowserNotifications: (v: boolean) => void;
+  setConversationMobileNotifications: (v: boolean) => void;
   setCustomConversationPrompt: (v: string | null) => void;
   setScheduleGenerationPreferences: (v: string) => void;
   rememberGameSetupOptions: (
@@ -1133,6 +1135,7 @@ export function pickSyncedSettings(state: UIState) {
     gameNotificationSound: state.gameNotificationSound,
     notificationSoundsOnlyWhenUnfocused: state.notificationSoundsOnlyWhenUnfocused,
     conversationBrowserNotifications: state.conversationBrowserNotifications,
+    conversationMobileNotifications: state.conversationMobileNotifications,
     customConversationPrompt: state.customConversationPrompt,
     scheduleGenerationPreferences: state.scheduleGenerationPreferences,
     impersonatePromptTemplate: state.impersonatePromptTemplate,
@@ -1304,6 +1307,7 @@ export const useUIStore = create<UIState>()(
       gameNotificationSound: true,
       notificationSoundsOnlyWhenUnfocused: false,
       conversationBrowserNotifications: false,
+      conversationMobileNotifications: false,
       customConversationPrompt: null,
       scheduleGenerationPreferences: "",
       learnedGameSetupOptions: DEFAULT_GAME_SETUP_LEARNED_OPTIONS,
@@ -1970,6 +1974,7 @@ export const useUIStore = create<UIState>()(
       setGameNotificationSound: (v) => set({ gameNotificationSound: v }),
       setNotificationSoundsOnlyWhenUnfocused: (v) => set({ notificationSoundsOnlyWhenUnfocused: v }),
       setConversationBrowserNotifications: (v) => set({ conversationBrowserNotifications: v }),
+      setConversationMobileNotifications: (v) => set({ conversationMobileNotifications: v }),
       setCustomConversationPrompt: (v) => set({ customConversationPrompt: v }),
       setScheduleGenerationPreferences: (v) => set({ scheduleGenerationPreferences: v }),
       rememberGameSetupOptions: (options, text) =>
@@ -2057,7 +2062,7 @@ export const useUIStore = create<UIState>()(
     }),
     {
       name: "marinara-engine-ui",
-      version: 71,
+      version: 72,
       // Debounce localStorage writes to avoid sync I/O on every state change
       storage: createJSONStorage(() => {
         let timer: ReturnType<typeof setTimeout> | null = null;
@@ -2391,6 +2396,9 @@ export const useUIStore = create<UIState>()(
         // v38 -> v39: opt-in browser notifications for background replies.
         if (version <= 38 && persisted.conversationBrowserNotifications === undefined) {
           persisted.conversationBrowserNotifications = false;
+        }
+        if (version <= 71 && persisted.conversationMobileNotifications === undefined) {
+          persisted.conversationMobileNotifications = false;
         }
         // v39 -> v40: selectable Conversation message layout.
         persisted.conversationMessageStyle = normalizeConversationMessageStyle(persisted.conversationMessageStyle);
@@ -2735,6 +2743,7 @@ export const useUIStore = create<UIState>()(
         gameNotificationSound: state.gameNotificationSound,
         notificationSoundsOnlyWhenUnfocused: state.notificationSoundsOnlyWhenUnfocused,
         conversationBrowserNotifications: state.conversationBrowserNotifications,
+        conversationMobileNotifications: state.conversationMobileNotifications,
         customConversationPrompt: state.customConversationPrompt,
         scheduleGenerationPreferences: state.scheduleGenerationPreferences,
         impersonatePromptTemplate: state.impersonatePromptTemplate,

--- a/packages/client/src/styles/globals.css
+++ b/packages/client/src/styles/globals.css
@@ -3773,6 +3773,24 @@ strong {
   animation: pulse-ring 2s ease-out infinite;
 }
 
+/* Phones reserve continuous compositing for meaningful live content.
+   Loading and progress animations remain active. */
+@media (hover: none) and (pointer: coarse) {
+  .animate-ping,
+  .animate-pulse,
+  .animate-float,
+  .animate-pulse-ring,
+  .pulse-glow,
+  .bunny-glow,
+  .retro-card,
+  .y2k-star,
+  .y2k-star-md,
+  .y2k-star-lg,
+  .gradient-border::before {
+    animation-play-state: paused !important;
+  }
+}
+
 @keyframes fadeSlideIn {
   from {
     opacity: 0;

--- a/packages/client/src/workers/weather-effects.worker.ts
+++ b/packages/client/src/workers/weather-effects.worker.ts
@@ -1,0 +1,185 @@
+import {
+  createWeatherParticle,
+  drawWeatherMoon,
+  drawWeatherParticle,
+  drawWeatherSun,
+  weatherCelestialX,
+  weatherCelestialY,
+  type WeatherParticle,
+  type WeatherRenderConfig,
+} from "../lib/weather-renderer";
+
+type InitMessage = {
+  type: "init";
+  canvas: OffscreenCanvas;
+  config: WeatherRenderConfig;
+  showCelestial: boolean;
+  width: number;
+  height: number;
+  scale: number;
+};
+
+type ResizeMessage = Pick<InitMessage, "width" | "height" | "scale"> & { type: "resize" };
+type VisibilityMessage = { type: "visibility"; hidden: boolean };
+type WeatherWorkerMessage = InitMessage | ResizeMessage | VisibilityMessage;
+
+const FRAME_MS = 1000 / 30;
+const BASE_FRAME_MS = 1000 / 60;
+const FIREFLY_COUNT = 10;
+const STAR_COUNT = 18;
+
+let canvas: OffscreenCanvas | null = null;
+let context: OffscreenCanvasRenderingContext2D | null = null;
+let config: WeatherRenderConfig | null = null;
+let showCelestial = true;
+let width = 1;
+let height = 1;
+let scale = 1;
+let particles: WeatherParticle[] = [];
+let hidden = false;
+let timer: ReturnType<typeof setTimeout> | null = null;
+let previousTime = 0;
+let frameCount = 0;
+let lightningAlpha = 0;
+let nextLightning = Infinity;
+
+function populateParticles() {
+  if (!config) return;
+  particles = [];
+  for (let index = 0; index < config.count; index += 1) {
+    particles.push(createWeatherParticle(config.type, width, height));
+  }
+  if (config.addFireflies) {
+    for (let index = 0; index < FIREFLY_COUNT; index += 1) {
+      particles.push(createWeatherParticle("firefly", width, height));
+    }
+  }
+  if (config.addStars) {
+    for (let index = 0; index < STAR_COUNT; index += 1) {
+      particles.push(createWeatherParticle("star", width, height));
+    }
+  }
+}
+
+function resizeSurface(nextWidth: number, nextHeight: number, nextScale: number) {
+  if (!canvas || !context) return;
+  width = Math.max(1, nextWidth);
+  height = Math.max(1, nextHeight);
+  scale = Math.max(0.1, nextScale);
+  canvas.width = Math.max(1, Math.round(width * scale));
+  canvas.height = Math.max(1, Math.round(height * scale));
+  context.setTransform(scale, 0, 0, scale, 0, 0);
+}
+
+function drawFrame(now: number) {
+  if (!context || !config || hidden) {
+    previousTime = now;
+    return;
+  }
+
+  const elapsed = previousTime === 0 ? FRAME_MS : Math.min(100, now - previousTime);
+  previousTime = now;
+  const frameScale = Math.min(3, Math.max(0.5, elapsed / BASE_FRAME_MS));
+  frameCount += frameScale;
+  context.clearRect(0, 0, width, height);
+
+  if (config.tint) {
+    context.fillStyle = config.tint;
+    context.fillRect(0, 0, width, height);
+  }
+  if (config.overlay) {
+    context.fillStyle = config.overlay;
+    context.fillRect(0, 0, width, height);
+  }
+
+  if (config.lightning) {
+    if (frameCount >= nextLightning) {
+      lightningAlpha = 0.45 + Math.random() * 0.15;
+      nextLightning = frameCount + 400 + Math.random() * 800;
+    }
+    if (lightningAlpha > 0) {
+      context.fillStyle = `rgba(220,230,255,${lightningAlpha})`;
+      context.fillRect(0, 0, width, height);
+      lightningAlpha *= Math.pow(0.88, frameScale);
+      if (lightningAlpha < 0.01) lightningAlpha = 0;
+    }
+  }
+
+  if (showCelestial && config.isClearSky && config.celestial !== "none") {
+    const radius = Math.min(width, height) * 0.035;
+    const hour = config.hour >= 0 ? config.hour : 12;
+    if (config.celestial === "sun") {
+      drawWeatherSun(
+        context,
+        weatherCelestialX(hour, width),
+        weatherCelestialY(hour, height, false),
+        radius,
+        width,
+        height,
+        config.sunRays,
+        config.sunsetGlow,
+        frameCount,
+      );
+    } else {
+      const moonPosition = hour >= 12 ? ((hour - 21 + 24) % 24) / 10 : (hour + 3) / 10;
+      const moonX = width * 0.1 + Math.min(1, Math.max(0, moonPosition)) * width * 0.8;
+      drawWeatherMoon(context, moonX, weatherCelestialY(hour, height, true), radius * 1.1, frameCount);
+    }
+  }
+
+  for (let index = particles.length - 1; index >= 0; index -= 1) {
+    const particle = particles[index]!;
+    particle.life += frameScale;
+    particle.x += particle.vx * frameScale;
+    particle.y += particle.vy * frameScale;
+    if (["snow", "leaf", "petal", "ash"].includes(particle.type)) {
+      particle.wobble += 0.02 * frameScale;
+      particle.x += Math.sin(particle.wobble) * 0.5 * frameScale;
+    } else if (particle.type === "ember") {
+      particle.wobble += 0.04 * frameScale;
+      particle.x += Math.sin(particle.wobble) * 0.6 * frameScale;
+    } else if (particle.type === "firefly") {
+      particle.wobble += 0.03 * frameScale;
+      particle.x += Math.sin(particle.wobble) * 0.8 * frameScale;
+      particle.y += Math.cos(particle.wobble * 0.7) * 0.4 * frameScale;
+    }
+    drawWeatherParticle(context, particle);
+    const outside = particle.y > height + 20 || particle.y < -20 || particle.x > width + 20 || particle.x < -20;
+    if (outside || particle.life > particle.maxLife) {
+      particles[index] = createWeatherParticle(particle.type, width, height, true);
+    }
+  }
+}
+
+function scheduleFrame() {
+  timer = setTimeout(() => {
+    try {
+      drawFrame(performance.now());
+      scheduleFrame();
+    } catch {
+      timer = null;
+      self.postMessage({ type: "render-error" });
+    }
+  }, FRAME_MS);
+}
+
+self.onmessage = (event: MessageEvent<WeatherWorkerMessage>) => {
+  const message = event.data;
+  if (message.type === "init") {
+    canvas = message.canvas;
+    context = canvas.getContext("2d");
+    config = message.config;
+    showCelestial = message.showCelestial;
+    nextLightning = config.lightning ? 200 + Math.random() * 400 : Infinity;
+    resizeSurface(message.width, message.height, message.scale);
+    populateParticles();
+    if (timer === null) scheduleFrame();
+  } else if (message.type === "resize") {
+    resizeSurface(message.width, message.height, message.scale);
+  } else {
+    hidden = message.hidden;
+    previousTime = performance.now();
+  }
+};
+
+self.postMessage({ type: "ready" });

--- a/packages/server/src/routes/conversation.routes.ts
+++ b/packages/server/src/routes/conversation.routes.ts
@@ -28,9 +28,8 @@ import {
 import {
   checkAutonomousMessaging,
   checkCharacterExchange,
-  dailyCapForCharacter,
   getActivityState,
-  getAutonomousDailyBudget,
+  isAutonomousDailyBudgetExhausted,
   recordUserActivity,
   recordAssistantActivity,
   recordAutonomousClientPresence,
@@ -158,10 +157,9 @@ function evaluateAutonomousCandidate(
   schedule: WeekSchedule | undefined,
   meta: Record<string, unknown>,
 ): AutonomousCandidateEvaluation {
-  const budget = getAutonomousDailyBudget(meta);
-  const sent = budget.counts[characterId] ?? 0;
-  const cap = dailyCapForCharacter(schedule, meta);
-  if (sent >= cap) return { ok: false, reason: "daily_budget_exhausted" };
+  if (isAutonomousDailyBudgetExhausted(characterId, schedule, meta)) {
+    return { ok: false, reason: "daily_budget_exhausted" };
+  }
 
   const intent = resolveAutonomousIntentPayload(chatId, characterId, schedule, meta);
   if (intent.onCooldown) return { ok: false, reason: "intent_cooldown" };
@@ -197,10 +195,7 @@ function resolveLongAbsenceCandidate(
     const intent = resolveAutonomousIntentPayload(chatId, characterId, schedule, meta);
     if (intent.autonomousIntentKey !== "long_absence_check_in") continue;
 
-    const budget = getAutonomousDailyBudget(meta);
-    const sent = budget.counts[characterId] ?? 0;
-    const cap = dailyCapForCharacter(schedule, meta);
-    if (sent >= cap) {
+    if (isAutonomousDailyBudgetExhausted(characterId, schedule, meta)) {
       blockedReason = blockedReason ?? "daily_budget_exhausted";
       continue;
     }
@@ -954,13 +949,17 @@ export async function conversationRoutes(app: FastifyInstance) {
     if (result.reason === "generation_in_progress") return reply.send(result);
 
     if (result.shouldTrigger) {
-      const characterId = result.characterIds[0];
-      if (characterId) {
+      let blockedReason: "daily_budget_exhausted" | "intent_cooldown" | null = null;
+      for (const characterId of result.characterIds) {
         const evaluation = evaluateAutonomousCandidate(chatId, characterId, autonomySchedules[characterId], meta);
-        if (!evaluation.ok) return reply.send(blockedAutonomousResponse(evaluation.reason));
+        if (!evaluation.ok) {
+          blockedReason = blockedReason ?? evaluation.reason;
+          continue;
+        }
         const generationStartedAt = markGenerationInProgress(chatId);
-        return reply.send({ ...result, generationStartedAt, ...evaluation.intent });
+        return reply.send({ ...result, characterIds: [characterId], generationStartedAt, ...evaluation.intent });
       }
+      if (blockedReason) return reply.send(blockedAutonomousResponse(blockedReason));
     }
 
     const longAbsence = resolveLongAbsenceCandidate(chatId, filteredSchedules, statusOverrides, meta);
@@ -993,29 +992,29 @@ export async function conversationRoutes(app: FastifyInstance) {
         // Check if the last message (or consecutive last messages) are all from the user
         const last = messages[messages.length - 1]!;
         if (last.role === "user") {
-          const catchUpCharacterId = onlineCharIds[0];
-          if (!catchUpCharacterId) {
-            return reply.send(result);
+          let blockedReason: "daily_budget_exhausted" | "intent_cooldown" | null = null;
+          for (const catchUpCharacterId of onlineCharIds) {
+            const evaluation = evaluateAutonomousCandidate(
+              chatId,
+              catchUpCharacterId,
+              autonomySchedules[catchUpCharacterId],
+              meta,
+            );
+            if (!evaluation.ok) {
+              blockedReason = blockedReason ?? evaluation.reason;
+              continue;
+            }
+            const generationStartedAt = markGenerationInProgress(chatId);
+            return reply.send({
+              shouldTrigger: true,
+              characterIds: [catchUpCharacterId],
+              reason: "user_inactivity",
+              inactivityMs: 0,
+              generationStartedAt,
+              ...evaluation.intent,
+            });
           }
-
-          const evaluation = evaluateAutonomousCandidate(
-            chatId,
-            catchUpCharacterId,
-            autonomySchedules[catchUpCharacterId],
-            meta,
-          );
-          if (!evaluation.ok) return reply.send(blockedAutonomousResponse(evaluation.reason));
-
-          // Character is online but hasn't responded — trigger catch-up
-          const generationStartedAt = markGenerationInProgress(chatId);
-          return reply.send({
-            shouldTrigger: true,
-            characterIds: [catchUpCharacterId],
-            reason: "user_inactivity",
-            inactivityMs: 0,
-            generationStartedAt,
-            ...evaluation.intent,
-          });
+          if (blockedReason) return reply.send(blockedAutonomousResponse(blockedReason));
         }
       }
     }
@@ -1100,22 +1099,19 @@ export async function conversationRoutes(app: FastifyInstance) {
 
     const result = checkCharacterExchange(chatId, lastSpeakerCharId, filteredSchedules, statusOverrides);
     if (result.shouldTrigger) {
-      const characterId = result.characterIds[0];
-      if (characterId) {
-        const budget = getAutonomousDailyBudget(meta);
-        const sent = budget.counts[characterId] ?? 0;
-        const cap = dailyCapForCharacter(schedules[characterId], meta);
-        if (sent >= cap) {
-          return reply.send({
-            shouldTrigger: false,
-            characterIds: [],
-            reason: "daily_budget_exhausted",
-            inactivityMs: 0,
-          });
-        }
+      const allowedCharacterId = result.characterIds.find(
+        (characterId) => !isAutonomousDailyBudgetExhausted(characterId, schedules[characterId], meta),
+      );
+      if (!allowedCharacterId) {
+        return reply.send({
+          shouldTrigger: false,
+          characterIds: [],
+          reason: "daily_budget_exhausted",
+          inactivityMs: 0,
+        });
       }
       const generationStartedAt = markGenerationInProgress(chatId);
-      return reply.send({ ...result, generationStartedAt });
+      return reply.send({ ...result, characterIds: [allowedCharacterId], generationStartedAt });
     }
     return reply.send(result);
   });

--- a/packages/server/src/routes/gallery.routes.ts
+++ b/packages/server/src/routes/gallery.routes.ts
@@ -93,6 +93,7 @@ const generateSceneVideoSchema = z.object({
   durationSeconds: z.number().int().min(1).max(60).optional(),
   aspectRatio: z.enum(["16:9", "9:16"]).optional(),
   promptOverride: z.string().trim().min(1).max(20_000).optional(),
+  queueMediaGenerationRequests: z.boolean().optional().default(true),
   debugMode: z.boolean().optional().default(false),
 });
 
@@ -833,6 +834,8 @@ export async function galleryRoutes(app: FastifyInstance) {
         resolution,
         referenceImage,
         publicReferenceUpload,
+        queue: input.queueMediaGenerationRequests,
+        connectionKey: videoConnectionId,
         signal: sceneVideoAbortSignal,
         fallback: videoFallback,
       });

--- a/packages/server/src/routes/game.routes.ts
+++ b/packages/server/src/routes/game.routes.ts
@@ -9807,6 +9807,7 @@ export async function gameRoutes(app: FastifyInstance) {
     aspectRatio: z.enum(["16:9", "9:16"]).optional(),
     promptOverride: z.string().trim().min(1).max(20_000).optional(),
     previewOnly: z.boolean().optional().default(false),
+    queueMediaGenerationRequests: z.boolean().optional().default(true),
     debugMode: z.boolean().optional().default(false),
   });
 
@@ -10750,6 +10751,8 @@ export async function gameRoutes(app: FastifyInstance) {
         resolution,
         referenceImage,
         publicReferenceUpload,
+        queue: input.queueMediaGenerationRequests,
+        connectionKey: videoConnectionId,
         fallback: videoFallback,
         signal: sceneVideoAbortSignal,
       });

--- a/packages/server/src/routes/generate.routes.ts
+++ b/packages/server/src/routes/generate.routes.ts
@@ -5501,7 +5501,7 @@ export async function generateRoutes(app: FastifyInstance) {
                   stripTargetPrefix();
                   continue;
                 }
-                const paragraphBreak = fullResponse.search(/\n\s*\n/);
+                const paragraphBreak = fullResponse.search(/\n(?:\s*\n)?/);
                 if (paragraphBreak < 0) {
                   logger.warn(
                     {
@@ -5877,7 +5877,9 @@ export async function generateRoutes(app: FastifyInstance) {
             return groupTurnPromptEnabled ? `Respond ONLY as ${charName}.` : null;
           }
           if (groupResponseOrder !== "manual") {
-            const otherNames = charInfo.filter((character) => character.id !== charId).map((character) => character.name);
+            const otherNames = charInfo
+              .filter((character) => character.id !== charId)
+              .map((character) => character.name);
             return [
               `Respond ONLY as ${charName}.`,
               `Your entire answer is ${charName}'s next message only.`,
@@ -5934,7 +5936,10 @@ export async function generateRoutes(app: FastifyInstance) {
               messagesWithInstruction,
               ci === respondingCharIds.length - 1,
             );
-            if (!genResult) break; // aborted
+            if (!genResult) {
+              if (abortController.signal.aborted) break;
+              continue;
+            }
             firstSavedMsg ??= genResult.savedMsg;
             lastSavedMsg = genResult.savedMsg;
             recordExpressionTarget(genResult.savedMsg, charId);

--- a/packages/server/src/routes/generate.routes.ts
+++ b/packages/server/src/routes/generate.routes.ts
@@ -4521,9 +4521,11 @@ export async function generateRoutes(app: FastifyInstance) {
         // ── Determine characters to generate for ──
         // Individual group mode: each character responds separately
         // Merged/single: one generation for the first (or mentioned) character
+        const usesIndividualGroupGeneration =
+          groupChatMode === "individual" || (chatMode === "conversation" && groupResponseOrder === "sequential");
         const useIndividualLoop =
-          isGroupChat && groupChatMode === "individual" && !input.regenerateMessageId && !input.impersonate; // regeneration/impersonate always target one message
-        const regenGroupChatIndividual = isGroupChat && groupChatMode === "individual" && input.regenerateMessageId;
+          isGroupChat && usesIndividualGroupGeneration && !input.regenerateMessageId && !input.impersonate;
+        const regenGroupChatIndividual = isGroupChat && usesIndividualGroupGeneration && input.regenerateMessageId;
         const mentionedConversationCharacters =
           chatMode === "conversation" && isGroupChat && !input.impersonate
             ? charInfo.filter((character) =>
@@ -4646,7 +4648,7 @@ export async function generateRoutes(app: FastifyInstance) {
             }
           }
           const scopedMessagesForGen =
-            isGroupChat && groupChatMode === "individual" && chatMode !== "conversation" && targetCharId
+            isGroupChat && usesIndividualGroupGeneration && targetCharId
               ? scopeIndividualGroupMessagesForTarget(gameAwareMessagesForGen, targetCharId, charInfo)
               : gameAwareMessagesForGen;
           const targetScopedMessagesForGen =
@@ -5450,11 +5452,19 @@ export async function generateRoutes(app: FastifyInstance) {
           // ── Strip character name prefix in individual group mode ──
           // LLMs often prefix the response with the character name even when told not to.
           // Also strip any leftover <speaker> tags from individual mode responses.
-          if (isGroupChat && groupChatMode === "individual" && targetCharId) {
+          if (isGroupChat && usesIndividualGroupGeneration && targetCharId) {
             const charRow = charInfo.find((c) => c.id === targetCharId);
             if (charRow) {
               const cName = charRow.name;
               const escapedName = cName.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+              if (chatMode === "conversation") {
+                const beforeTimestampStrip = fullResponse;
+                fullResponse = fullResponse
+                  .replace(/^(\s*\[\d{1,2}[:.]\d{2}\]\s*)+/g, "")
+                  .replace(/^(\s*\[\d{1,2}\.\d{1,2}\.\d{4}\]\s*)+/g, "")
+                  .trimStart();
+                if (fullResponse !== beforeTimestampStrip) contentReplaced = true;
+              }
               // Strip <speaker="Name">...</speaker> wrapper if present
               const speakerWrap = new RegExp(`^\\s*<speaker="${escapedName}">[\\s\\S]*?<\\/speaker>\\s*$`, "i");
               const speakerMatch = fullResponse.match(speakerWrap);
@@ -5467,10 +5477,47 @@ export async function generateRoutes(app: FastifyInstance) {
               }
               // Strip plain name prefixes: "Dottore: text" or "Dottore\ntext".
               const beforeNamePrefixStrip = fullResponse;
-              fullResponse = fullResponse
-                .replace(new RegExp(`^\\s*${escapedName}\\s*:\\s*`, "i"), "")
-                .replace(new RegExp(`^\\s*${escapedName}\\s*\\n+`, "i"), "")
-                .trimStart();
+              const targetPrefix = new RegExp(`^\\s*${escapedName}\\s*:\\s*`, "i");
+              const targetLinePrefix = new RegExp(`^\\s*${escapedName}\\s*\\n+`, "i");
+              const stripTargetPrefix = () => {
+                fullResponse = fullResponse.replace(targetPrefix, "").replace(targetLinePrefix, "").trimStart();
+              };
+              const otherNames = charInfo
+                .filter((character) => character.id !== targetCharId)
+                .map((character) => character.name)
+                .filter((name): name is string => Boolean(name))
+                .filter((name) => name.trim().toLocaleLowerCase() !== cName.trim().toLocaleLowerCase())
+                .map((name) => name.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"));
+              const otherSpeakerPrefix =
+                otherNames.length > 0 ? new RegExp(`^\\s*(?:${otherNames.join("|")})\\s*:\\s*`, "i") : null;
+
+              stripTargetPrefix();
+              let prunePasses = 0;
+              while (otherSpeakerPrefix?.test(fullResponse) && prunePasses++ < 6) {
+                const embeddedTargetPrefix = new RegExp(`(?:^|\\n\\s*\\n)\\s*${escapedName}\\s*:\\s*`, "i");
+                const targetMatch = fullResponse.match(embeddedTargetPrefix);
+                if (targetMatch?.index != null && targetMatch.index > 0) {
+                  fullResponse = fullResponse.slice(targetMatch.index).trimStart();
+                  stripTargetPrefix();
+                  continue;
+                }
+                const paragraphBreak = fullResponse.search(/\n\s*\n/);
+                if (paragraphBreak < 0) {
+                  logger.warn(
+                    {
+                      chatId: input.chatId,
+                      targetCharId,
+                      targetName: cName,
+                      responsePreview: fullResponse.slice(0, 240),
+                    },
+                    "[generate] Dropping wrong-speaker-only individual group response",
+                  );
+                  sendSseEvent(reply, { type: "content_replace", data: "" });
+                  return null;
+                }
+                fullResponse = fullResponse.slice(paragraphBreak).trimStart();
+                stripTargetPrefix();
+              }
               if (fullResponse !== beforeNamePrefixStrip) {
                 contentReplaced = true;
               }
@@ -5488,7 +5535,7 @@ export async function generateRoutes(app: FastifyInstance) {
               : null;
             fullResponse = stripConversationResponseEnvelope(fullResponse, {
               speakerName: conversationSpeakerName,
-              preserveSpeakerPrefix: isGroupChat && groupChatMode !== "individual",
+              preserveSpeakerPrefix: isGroupChat && !usesIndividualGroupGeneration,
             });
             if (fullResponse !== beforeStrip) {
               contentReplaced = true;
@@ -5528,6 +5575,20 @@ export async function generateRoutes(app: FastifyInstance) {
           // no surrounding prose, treat the commands as the useful output. Skip saving
           // a blank assistant bubble but still return the commands so they execute.
           if (!fullResponse.trim()) {
+            logger.warn(
+              {
+                chatId: input.chatId,
+                targetCharId,
+                parsedCommandCount: parsedCommands.length,
+                parsedRawCommandCount,
+                providerThinkingLength: providerThinking.length,
+                fullThinkingLength: fullThinking.length,
+                contentReplaced,
+                chatMode,
+                groupChatMode,
+              },
+              "[generate] Empty response after post-processing",
+            );
             if (!input.impersonate && (parsedCommands.length > 0 || parsedRawCommandCount > 0)) {
               logger.info(
                 "[generate] Model emitted %d enabled command(s) (%d parsed) with no visible prose for chat %s; saving hidden command anchor",
@@ -5802,8 +5863,8 @@ export async function generateRoutes(app: FastifyInstance) {
         // are declared above the follow-up loop so they survive iterations.)
 
         const generationGuideInstruction = buildGenerationGuideInstruction(input.generationGuide, promptMacroContext);
-        const filterManualTargetProfileBlocks = (messages: typeof finalMessages, targetCharId: string) => {
-          if (groupResponseOrder !== "manual") return messages;
+        const filterTargetProfileBlocks = (messages: typeof finalMessages, targetCharId: string) => {
+          if (chatMode !== "conversation") return messages;
           const otherNames = charInfo.filter((c) => c.id !== targetCharId).map((c) => c.name);
           if (otherNames.length === 0) return messages;
           return messages.filter((message) => {
@@ -5815,7 +5876,20 @@ export async function generateRoutes(app: FastifyInstance) {
           if (chatMode !== "conversation") {
             return groupTurnPromptEnabled ? `Respond ONLY as ${charName}.` : null;
           }
-          if (groupResponseOrder !== "manual") return `Respond ONLY as ${charName}.`;
+          if (groupResponseOrder !== "manual") {
+            const otherNames = charInfo.filter((character) => character.id !== charId).map((character) => character.name);
+            return [
+              `Respond ONLY as ${charName}.`,
+              `Your entire answer is ${charName}'s next message only.`,
+              `Do not write dialogue, narration, labels, or actions for anyone except ${charName}.`,
+              otherNames.length > 0
+                ? `Forbidden speaker labels for this turn: ${otherNames.join(", ")}. Do not start any line with those names.`
+                : null,
+              `If another character should react, stop after ${charName}'s message and let their own turn handle it.`,
+            ]
+              .filter(Boolean)
+              .join("\n");
+          }
           const latestOtherSender = latestVisibleSenderOtherThan(charId);
           return [
             `Respond ONLY as ${charName}.`,
@@ -5849,7 +5923,7 @@ export async function generateRoutes(app: FastifyInstance) {
 
             // Append "Respond ONLY as [name]" instruction
             const charInstruction = buildCharacterInstruction(charId, charName);
-            const messagesWithInstruction = [...filterManualTargetProfileBlocks(runningMessages, charId)];
+            const messagesWithInstruction = [...filterTargetProfileBlocks(runningMessages, charId)];
             // Add as a system message at the end (just before any trailing user message)
             if (charInstruction) {
               messagesWithInstruction.push({ role: "system", content: charInstruction });

--- a/packages/server/src/services/conversation/autonomous.service.ts
+++ b/packages/server/src/services/conversation/autonomous.service.ts
@@ -123,6 +123,16 @@ export function dailyCapForCharacter(schedule: WeekSchedule | undefined, chatMet
   return 2;
 }
 
+export function isAutonomousDailyBudgetExhausted(
+  characterId: string,
+  schedule: WeekSchedule | undefined,
+  chatMeta: Record<string, unknown>,
+  now: Date = new Date(),
+): boolean {
+  const budget = getAutonomousDailyBudget(chatMeta, now);
+  return (budget.counts[characterId] ?? 0) >= dailyCapForCharacter(schedule, chatMeta);
+}
+
 export function buildAutonomousDailyBudgetPatch(
   chatMeta: Record<string, unknown>,
   characterId: string,
@@ -404,9 +414,12 @@ export function checkAutonomousMessaging(
   const reason: AutonomousCheckResult["reason"] = top.reactionDriven ? "user_reaction" : "user_inactivity";
 
   if (isGroupChat) {
-    // In group chats, potentially multiple characters can exchange
-    // but start with just the top character
-    return { shouldTrigger: true, characterIds: [top.id], reason, inactivityMs };
+    return {
+      shouldTrigger: true,
+      characterIds: eligibleCharacters.map((candidate) => candidate.id),
+      reason,
+      inactivityMs,
+    };
   }
 
   // In DMs, only one character
@@ -462,13 +475,18 @@ export function checkCharacterExchange(
 
   // Probabilistic: roll dice weighted by talkativeness
   // A character with talkativeness 80 has an 80% chance of responding
-  const candidate = eligible[Math.floor(Math.random() * eligible.length)]!;
+  const shuffledEligible = [...eligible];
+  for (let index = shuffledEligible.length - 1; index > 0; index--) {
+    const swapIndex = Math.floor(Math.random() * (index + 1));
+    [shuffledEligible[index], shuffledEligible[swapIndex]] = [shuffledEligible[swapIndex]!, shuffledEligible[index]!];
+  }
+  const candidate = shuffledEligible[0]!;
   const roll = Math.random() * 100;
   if (roll > candidate.weight) return noTrigger;
 
   return {
     shouldTrigger: true,
-    characterIds: [candidate.id],
+    characterIds: shuffledEligible.map((entry) => entry.id),
     reason: "character_exchange",
     inactivityMs,
   };

--- a/packages/server/src/services/image/image-generation-queue.ts
+++ b/packages/server/src/services/image/image-generation-queue.ts
@@ -1,18 +1,18 @@
-type ImageGenerationQueueTask<T> = () => Promise<T>;
+type MediaGenerationQueueTask<T> = () => Promise<T>;
 
-const imageGenerationQueueTails = new Map<string, Promise<void>>();
+const mediaGenerationQueueTails = new Map<string, Promise<void>>();
 
-function imageGenerationAbortError(signal: AbortSignal): Error {
-  return signal.reason instanceof Error ? signal.reason : new Error("Image generation request aborted");
+function mediaGenerationAbortError(signal: AbortSignal): Error {
+  return signal.reason instanceof Error ? signal.reason : new Error("Media generation request aborted");
 }
 
-async function waitForImageGenerationTurn(previous: Promise<void>, signal?: AbortSignal): Promise<void> {
+async function waitForMediaGenerationTurn(previous: Promise<void>, signal?: AbortSignal): Promise<void> {
   const settledPrevious = previous.catch(() => undefined);
   if (!signal) {
     await settledPrevious;
     return;
   }
-  if (signal.aborted) throw imageGenerationAbortError(signal);
+  if (signal.aborted) throw mediaGenerationAbortError(signal);
 
   await new Promise<void>((resolve, reject) => {
     let settled = false;
@@ -22,7 +22,7 @@ async function waitForImageGenerationTurn(previous: Promise<void>, signal?: Abor
       signal.removeEventListener("abort", onAbort);
       callback();
     };
-    const onAbort = () => finish(() => reject(imageGenerationAbortError(signal)));
+    const onAbort = () => finish(() => reject(mediaGenerationAbortError(signal)));
 
     signal.addEventListener("abort", onAbort, { once: true });
     void settledPrevious.then(() => finish(resolve));
@@ -30,40 +30,43 @@ async function waitForImageGenerationTurn(previous: Promise<void>, signal?: Abor
 }
 
 /**
- * Serialize image provider requests per configured connection when the caller's
+ * Serialize media provider requests per configured connection when the caller's
  * global queue preference is enabled. Callers that disable the preference
  * bypass the queue entirely, while queued callers retain FIFO ordering.
  */
-export async function runImageGenerationRequest<T>(args: {
+export async function runMediaGenerationRequest<T>(args: {
   connectionKey: string;
   queue: boolean;
-  task: ImageGenerationQueueTask<T>;
+  task: MediaGenerationQueueTask<T>;
   signal?: AbortSignal;
 }): Promise<T> {
   if (!args.queue) {
-    if (args.signal?.aborted) throw imageGenerationAbortError(args.signal);
+    if (args.signal?.aborted) throw mediaGenerationAbortError(args.signal);
     return args.task();
   }
 
   const connectionKey = args.connectionKey.trim() || "default";
-  const previous = imageGenerationQueueTails.get(connectionKey) ?? Promise.resolve();
+  const previous = mediaGenerationQueueTails.get(connectionKey) ?? Promise.resolve();
   let releaseCurrent: () => void = () => undefined;
   const current = new Promise<void>((resolve) => {
     releaseCurrent = resolve;
   });
   const queuedTail = previous.catch(() => undefined).then(() => current);
-  imageGenerationQueueTails.set(connectionKey, queuedTail);
+  mediaGenerationQueueTails.set(connectionKey, queuedTail);
 
   try {
-    await waitForImageGenerationTurn(previous, args.signal);
-    if (args.signal?.aborted) throw imageGenerationAbortError(args.signal);
+    await waitForMediaGenerationTurn(previous, args.signal);
+    if (args.signal?.aborted) throw mediaGenerationAbortError(args.signal);
     return await args.task();
   } finally {
     releaseCurrent();
     void queuedTail.finally(() => {
-      if (imageGenerationQueueTails.get(connectionKey) === queuedTail) {
-        imageGenerationQueueTails.delete(connectionKey);
+      if (mediaGenerationQueueTails.get(connectionKey) === queuedTail) {
+        mediaGenerationQueueTails.delete(connectionKey);
       }
     });
   }
 }
+
+/** Backward-compatible image-specific entry point for existing callers. */
+export const runImageGenerationRequest = runMediaGenerationRequest;

--- a/packages/server/src/services/llm/providers/openai.provider.ts
+++ b/packages/server/src/services/llm/providers/openai.provider.ts
@@ -205,14 +205,27 @@ export class OpenAIProvider extends BaseLLMProvider {
 
   private static extractSseJsonPayload(raw: string): string | null {
     const lines = raw.split(/\r?\n/);
+    let fallbackPayload: string | null = null;
     for (const line of lines) {
       const trimmed = line.trim();
       const payload = OpenAIProvider.extractSseData(trimmed);
       if (payload == null) continue;
       if (!payload || payload === "[DONE]") continue;
-      return payload;
+      fallbackPayload = payload;
+      try {
+        const parsed = JSON.parse(payload) as Record<string, unknown>;
+        const firstChoice = Array.isArray(parsed.choices)
+          ? (parsed.choices[0] as { message?: { content?: unknown }; delta?: { content?: unknown } } | undefined)
+          : undefined;
+        const content = firstChoice?.message?.content ?? firstChoice?.delta?.content;
+        if ((typeof content === "string" && content.trim()) || (Array.isArray(content) && content.length > 0)) {
+          return payload;
+        }
+      } catch {
+        // Keep scanning. parseJsonBody reports the detailed error if recovery fails.
+      }
     }
-    return null;
+    return fallbackPayload;
   }
 
   private static extractSseData(trimmedLine: string): string | null {
@@ -1176,27 +1189,35 @@ export class OpenAIProvider extends BaseLLMProvider {
             }
             continue;
           }
-          const choice0 = parsed.choices[0] as { finish_reason?: string | null } | undefined;
+          const choice0 = parsed.choices[0] as
+            | {
+                finish_reason?: string | null;
+                delta?: Record<string, unknown> & { content?: string | unknown[]; refusal?: string };
+                message?: Record<string, unknown> & { content?: string | unknown[] | null; refusal?: string };
+              }
+            | undefined;
           if (choice0?.finish_reason) finishReason = choice0.finish_reason;
-          const delta = (
-            parsed.choices[0] as
-              | { delta?: Record<string, unknown> & { content?: string | unknown[]; refusal?: string } }
-              | undefined
-          )?.delta;
-          OpenAIProvider.appendReasoningMetadata(reasoningMetadata, delta);
-          const reasoning = OpenAIProvider.extractReasoning(delta);
+          const delta = choice0?.delta;
+          const message = choice0?.message;
+          OpenAIProvider.appendReasoningMetadata(reasoningMetadata, delta ?? message);
+          const reasoning = OpenAIProvider.extractReasoning(delta ?? message);
           if (reasoning && options.onThinking) {
             options.onThinking(reasoning);
           }
           // Handle OpenRouter content block arrays (Anthropic-style)
-          const blocks = OpenAIProvider.extractContentBlocks(delta?.content);
+          const content = delta?.content ?? message?.content;
+          const refusal =
+            (typeof delta?.refusal === "string" && delta.refusal) ||
+            (typeof message?.refusal === "string" && message.refusal) ||
+            "";
+          const blocks = OpenAIProvider.extractContentBlocks(content);
           if (blocks) {
             if (!reasoning && blocks.thinking && options.onThinking) options.onThinking(blocks.thinking);
             if (blocks.text) yield blocks.text;
-          } else if (delta?.content) {
-            yield delta.content as string;
-          } else if (typeof delta?.refusal === "string" && delta.refusal) {
-            yield delta.refusal;
+          } else if (typeof content === "string" && content) {
+            yield content;
+          } else if (refusal) {
+            yield refusal;
           }
         }
         if (done) break;
@@ -1462,9 +1483,14 @@ export class OpenAIProvider extends BaseLLMProvider {
 
           const choice = (
             parsed.choices as Array<{
-              delta: Record<string, unknown> & {
+              delta?: Record<string, unknown> & {
                 content?: string | unknown[];
+                refusal?: string;
                 tool_calls?: unknown;
+              };
+              message?: Record<string, unknown> & {
+                content?: string | unknown[] | null;
+                refusal?: string;
               };
               finish_reason?: string;
             }>
@@ -1476,28 +1502,34 @@ export class OpenAIProvider extends BaseLLMProvider {
           }
 
           const delta = choice.delta;
-          OpenAIProvider.appendReasoningMetadata(reasoningMetadata, delta);
+          const message = choice.message;
+          OpenAIProvider.appendReasoningMetadata(reasoningMetadata, delta ?? message);
 
           // Stream reasoning/thinking
-          const reasoning = OpenAIProvider.extractReasoning(delta);
+          const reasoning = OpenAIProvider.extractReasoning(delta ?? message);
           if (reasoning && options.onThinking) {
             options.onThinking(reasoning);
           }
 
           // Handle OpenRouter content block arrays (Anthropic-style)
-          const blocks = OpenAIProvider.extractContentBlocks(delta?.content);
+          const textContent = delta?.content ?? message?.content;
+          const refusal =
+            (typeof delta?.refusal === "string" && delta.refusal) ||
+            (typeof message?.refusal === "string" && message.refusal) ||
+            "";
+          const blocks = OpenAIProvider.extractContentBlocks(textContent);
           if (blocks) {
             if (!reasoning && blocks.thinking && options.onThinking) options.onThinking(blocks.thinking);
             if (blocks.text) {
               content += blocks.text;
               await options.onToken?.(blocks.text);
             }
-          } else if (delta?.content) {
-            content += delta.content as string;
-            await options.onToken?.(delta.content as string);
-          } else if (typeof delta?.refusal === "string" && delta.refusal) {
-            content += delta.refusal;
-            await options.onToken?.(delta.refusal);
+          } else if (typeof textContent === "string" && textContent) {
+            content += textContent;
+            await options.onToken?.(textContent);
+          } else if (refusal) {
+            content += refusal;
+            await options.onToken?.(refusal);
           }
 
           // Accumulate tool call deltas. Some OpenAI-compatible backends (including llama.cpp)

--- a/packages/server/src/services/video/video-generation.ts
+++ b/packages/server/src/services/video/video-generation.ts
@@ -99,6 +99,8 @@ export async function generateVideo(
   serviceHint: string,
   request: VideoGenerationRequest,
 ): Promise<VideoGenerationResult> {
+  // The request deadline begins when the queued task starts; queue wait time is
+  // governed separately by the shared media-generation queue.
   return runMediaGenerationRequest({
     connectionKey: request.connectionKey ?? `${serviceHint || source}:${baseUrl}`,
     queue: request.queue === true,
@@ -162,10 +164,11 @@ async function generateVideoUnqueued(
     } catch (noticeError) {
       logger.warn(noticeError, "[video-fallback] Failed to report fallback activation");
     }
-    return generateVideoUnqueued(fallback.source, fallback.baseUrl, fallback.apiKey, fallback.serviceHint, {
+    return generateVideo(fallback.source, fallback.baseUrl, fallback.apiKey, fallback.serviceHint, {
       ...request,
       fallback: undefined,
       model: fallback.model,
+      connectionKey: fallback.connectionId,
     });
   }
 }

--- a/packages/server/src/services/video/video-generation.ts
+++ b/packages/server/src/services/video/video-generation.ts
@@ -5,6 +5,7 @@ import { newId } from "../../utils/id-generator.js";
 import { logger } from "../../lib/logger.js";
 import { assertInsideDir, safeFetch } from "../../utils/security.js";
 import { notifyGenerationFallback, type GenerationFallbackNotifier } from "../generation/fallback-notification.js";
+import { runMediaGenerationRequest } from "../image/image-generation-queue.js";
 
 export interface VideoReferenceImage {
   base64: string;
@@ -30,6 +31,10 @@ export interface VideoGenerationRequest {
   lastFrameImage?: VideoReferenceImage | null;
   publicReferenceUpload?: VideoReferencePublicUploadOptions | null;
   signal?: AbortSignal;
+  /** Serialize this request with other media jobs using the same configured connection. */
+  queue?: boolean;
+  /** Stable configured connection ID used to scope queued media jobs. */
+  connectionKey?: string;
   /** Called immediately before a configured fallback connection is attempted. */
   onFallback?: GenerationFallbackNotifier;
   /** Optional one-shot backup connection used only when the primary video request fails. */
@@ -94,6 +99,21 @@ export async function generateVideo(
   serviceHint: string,
   request: VideoGenerationRequest,
 ): Promise<VideoGenerationResult> {
+  return runMediaGenerationRequest({
+    connectionKey: request.connectionKey ?? `${serviceHint || source}:${baseUrl}`,
+    queue: request.queue === true,
+    signal: request.signal,
+    task: () => generateVideoUnqueued(source, baseUrl, apiKey, serviceHint, request),
+  });
+}
+
+async function generateVideoUnqueued(
+  source: string,
+  baseUrl: string,
+  apiKey: string,
+  serviceHint: string,
+  request: VideoGenerationRequest,
+): Promise<VideoGenerationResult> {
   const resolvedService = normalizeVideoService(serviceHint || source);
   const primaryRequest = { ...request, fallback: undefined };
   try {
@@ -142,7 +162,7 @@ export async function generateVideo(
     } catch (noticeError) {
       logger.warn(noticeError, "[video-fallback] Failed to report fallback activation");
     }
-    return generateVideo(fallback.source, fallback.baseUrl, fallback.apiKey, fallback.serviceHint, {
+    return generateVideoUnqueued(fallback.source, fallback.baseUrl, fallback.apiKey, fallback.serviceHint, {
       ...request,
       fallback: undefined,
       model: fallback.model,

--- a/scripts/regressions/open-issues.regression.ts
+++ b/scripts/regressions/open-issues.regression.ts
@@ -63,11 +63,54 @@ import {
 } from "../../packages/server/src/services/image/illustrator-prompt-review.js";
 import { resolveReviewedImagePromptSubmission } from "../../packages/server/src/services/image/image-prompt-review.js";
 import { resolveSceneVideoPrompt } from "../../packages/server/src/services/video/scene-video-prompt-review.js";
+import {
+  checkAutonomousMessaging,
+  clearChatActivity,
+  initializeActivityFromMessages,
+  isAutonomousDailyBudgetExhausted,
+} from "../../packages/server/src/services/conversation/autonomous.service.js";
+import type { WeekSchedule } from "../../packages/server/src/services/conversation/schedule.service.js";
 
 assert.equal(resolveInitialGameGmConnectionId(undefined, "chat-connection"), "chat-connection");
 assert.equal(resolveInitialGameGmConnectionId("explicit-connection", "chat-connection"), "explicit-connection");
 assert.equal(resolveInitialGameGmConnectionId(undefined, null), null);
 assert.equal(DEFAULT_GENERATION_PARAMS.reasoningEffort, "maximum");
+
+const autonomousSchedule = (talkativeness: number, cap: number): WeekSchedule => ({
+  weekStart: "2026-07-13",
+  days: {},
+  inactivityThresholdMinutes: 1,
+  autonomousDailyCapOverride: cap,
+  talkativeness,
+});
+const autonomousChatId = "regression-autonomous-candidates";
+initializeActivityFromMessages(autonomousChatId, [
+  { role: "user", createdAt: new Date(Date.now() - 5 * 60_000).toISOString() },
+]);
+const autonomousCandidates = checkAutonomousMessaging(
+  autonomousChatId,
+  {
+    capped: autonomousSchedule(90, 1),
+    fallback: autonomousSchedule(70, 3),
+  },
+  true,
+);
+assert.deepEqual(autonomousCandidates.characterIds, ["capped", "fallback"]);
+const today = new Date();
+const dateKey = `${today.getFullYear()}-${String(today.getMonth() + 1).padStart(2, "0")}-${String(today.getDate()).padStart(2, "0")}`;
+assert.equal(
+  isAutonomousDailyBudgetExhausted("capped", autonomousSchedule(90, 1), {
+    autonomousDailyBudget: { date: dateKey, counts: { capped: 1 } },
+  }),
+  true,
+);
+assert.equal(
+  isAutonomousDailyBudgetExhausted("fallback", autonomousSchedule(70, 3), {
+    autonomousDailyBudget: { date: dateKey, counts: { fallback: 1 } },
+  }),
+  false,
+);
+clearChatActivity(autonomousChatId);
 assert.equal(
   getApiErrorMessage(
     { formErrors: [], fieldErrors: { handle: ["Handle must contain at most 40 characters."] } },

--- a/scripts/regressions/provider-compat.regression.ts
+++ b/scripts/regressions/provider-compat.regression.ts
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { createServer } from "node:http";
 import { findKnownModel } from "../../packages/shared/src/constants/model-lists.js";
 import {
   applyGlmThinkingParameters,
@@ -8,7 +9,10 @@ import {
   NOODLE_JSON_OUTPUT_HEADING,
   noodleResponseFormat,
 } from "../../packages/server/src/services/noodle/noodle-response-format.js";
-import { normalizeOpenAIChatCompletionsResponseFormat } from "../../packages/server/src/services/llm/providers/openai.provider.js";
+import {
+  normalizeOpenAIChatCompletionsResponseFormat,
+  OpenAIProvider,
+} from "../../packages/server/src/services/llm/providers/openai.provider.js";
 import {
   isOpenRouterApiUrl,
   OPENROUTER_APP_REFERER,
@@ -67,6 +71,42 @@ async function collectProviderOutput(provider: BaseLLMProvider, options: ChatOpt
   let output = "";
   for await (const chunk of provider.chat([{ role: "user", content: "test" }], options)) output += chunk;
   return output;
+}
+
+const gatewaySseBody = [
+  ": x-omniroute-cache-hit=false",
+  'data: {"choices":[{"delta":{},"finish_reason":null}]}',
+  'data: {"choices":[{"message":{"content":"recovered final message"},"finish_reason":"stop"}]}',
+  "data: [DONE]",
+].join("\n");
+const gatewayServer = createServer((_request, response) => {
+  response.writeHead(200, { "content-type": "text/event-stream" });
+  response.end(gatewaySseBody);
+});
+await new Promise<void>((resolve) => gatewayServer.listen(0, "127.0.0.1", resolve));
+try {
+  const address = gatewayServer.address();
+  assert.ok(address && typeof address === "object");
+  const provider = new OpenAIProvider(
+    `http://127.0.0.1:${address.port}/v1`,
+    "test",
+    undefined,
+    undefined,
+    undefined,
+    "custom",
+  );
+  assert.equal(
+    await collectProviderOutput(provider, { model: "custom-model", stream: true }),
+    "recovered final message",
+  );
+  assert.equal(
+    await collectProviderOutput(provider, { model: "custom-model", stream: false }),
+    "recovered final message",
+  );
+} finally {
+  await new Promise<void>((resolve, reject) =>
+    gatewayServer.close((error) => (error ? reject(error) : resolve())),
+  );
 }
 
 function assertStrictObjects(value: unknown): void {

--- a/scripts/regressions/roleplay-streaming.regression.ts
+++ b/scripts/regressions/roleplay-streaming.regression.ts
@@ -15,10 +15,22 @@ import { mergePairedBuiltInRewriteAgents } from "../../packages/server/src/servi
 import { aboutMeKeeperAgentManifest } from "../../packages/shared/src/features/agents/about-me-keeper/manifest.js";
 import { estimateAgentLoadCost } from "../../packages/shared/src/utils/agent-cost.js";
 import {
-  ECHO_CHAMBER_MESSAGE_INTERVAL_MS,
+  ECHO_CHAMBER_MESSAGE_INTERVAL_MAX_MS,
+  ECHO_CHAMBER_MESSAGE_INTERVAL_MIN_MS,
   enqueueEchoChamberMessages,
+  getEchoChamberMessageInterval,
   resolveEchoChamberPersistedBaseline,
 } from "../../packages/client/src/lib/echo-chamber-queue.js";
+import { useAgentStore } from "../../packages/client/src/stores/agent.store.js";
+import { advanceWeatherFrameClock } from "../../packages/client/src/lib/weather-frame-clock.js";
+import { trackerEditableText } from "../../packages/client/src/features/tracker-panel/lib/tracker-display.js";
+
+assert.equal(
+  trackerEditableText({ name: "HP", value: 75, max: 100, color: "#ef4444" }),
+  "HP: 75/100",
+  "object-shaped tracker values must become editable text instead of invalid React children",
+);
+assert.equal(trackerEditableText({ nested: true }), '{"nested":true}');
 
 assert.equal(
   shouldKeepStreamLiveThroughPostProcessing({
@@ -171,7 +183,10 @@ const queuedEchoBatch = enqueueEchoChamberMessages(
 assert.equal(queuedEchoBatch.messages.length, 4);
 assert.equal(queuedEchoBatch.visibleCount, 1, "a fresh Echo result must remain behind the reveal cursor");
 assert.equal(queuedEchoBatch.baseline, 1);
-assert.ok(ECHO_CHAMBER_MESSAGE_INTERVAL_MS >= 1_000 && ECHO_CHAMBER_MESSAGE_INTERVAL_MS <= 3_000);
+assert.equal(getEchoChamberMessageInterval(0), ECHO_CHAMBER_MESSAGE_INTERVAL_MIN_MS);
+assert.equal(getEchoChamberMessageInterval(0.5), 20_000);
+assert.ok(getEchoChamberMessageInterval(0.999999) < ECHO_CHAMBER_MESSAGE_INTERVAL_MAX_MS);
+assert.equal(getEchoChamberMessageInterval(1), ECHO_CHAMBER_MESSAGE_INTERVAL_MAX_MS);
 
 const staleEchoCursor = enqueueEchoChamberMessages(
   { messages: [], visibleCount: 99, baseline: 99 },
@@ -191,6 +206,25 @@ assert.equal(
   1,
   "an Echo result persisted during the initial load must stay queued instead of appearing all at once",
 );
+
+useAgentStore.setState({
+  echoMessages: queuedEchoBatch.messages,
+  echoVisibleCount: queuedEchoBatch.visibleCount,
+  echoBaseline: queuedEchoBatch.baseline,
+});
+useAgentStore.getState().revealNextEchoMessage();
+assert.equal(useAgentStore.getState().echoVisibleCount, 2, "one Echo timer tick must reveal exactly one reaction");
+useAgentStore.getState().revealNextEchoMessage();
+assert.equal(useAgentStore.getState().echoVisibleCount, 3, "a second Echo timer tick must reveal only the next reaction");
+
+let weatherAccumulator = 0;
+let weatherDraws = 0;
+for (let frame = 0; frame < 6; frame++) {
+  const step = advanceWeatherFrameClock(weatherAccumulator, 1000 / 60);
+  weatherAccumulator = step.accumulatedMs;
+  if (step.shouldDraw) weatherDraws++;
+}
+assert.equal(weatherDraws, 3, "60 Hz foreground callbacks should produce an even 30 FPS weather cadence");
 
 const legacyRewrite = resolveMessageRewriteVersions(
   "The polished rewritten reply.",


### PR DESCRIPTION
## Why

This patch collects the user-facing regressions and companion improvements reported during the post-2.2.1 testing pass. Weather particles stuttered badly alongside accent pulse animations, mobile clients consumed excessive battery, Android APK users could not receive native autonomous-message notifications, and several Roleplay, Echo Chamber, Noodle, tracker, media-generation, and autonomous Conversation paths behaved incorrectly.

The weather root cause was main-thread contention between canvas rendering and UI animation. The autonomous Conversation failure was a chain across candidate selection, sequential speaker scoping, wrong-speaker pruning, and OpenAI-compatible SSE parsing rather than one isolated scheduler fault.

## What changed

- Move weather particle rendering to an OffscreenCanvas worker where supported, retain a main-thread fallback, share the render clock, cap DPR/pixel work, and reduce mobile/background activity.
- Restore Echo Chamber's randomized 10–30 second message delivery, prevent stale chat writes, add mouse/touch resizing, correct bottom-corner controls, and apply chroma-aware navigation styling.
- Open Roleplay chats at the latest history position.
- Add native Android notification permission and bridge delivery, including the APK notification icon and build-script compatibility fix.
- Normalize structured tracker values to prevent Present Characters crashes.
- Let users inspect Noodle poll voter identities.
- Introduce Overall Generations settings, extend queued media generation to video, and expose the generation-settings hint beside Conversation Selfies.
- Make autonomous group Conversation selection fall through blocked candidates, enforce sequential target-speaker scope, preserve valid target output, and recover final-message content from OpenAI-compatible SSE responses.
- Add regression coverage and update the Unreleased changelog.

## Issues

Resolves #3563
Resolves #3566
Resolves #3567
Resolves #3572
Resolves #3573

## Validation

- `pnpm check`
- `pnpm version:check`
- `pnpm regression:prompt`
- `pnpm regression:roleplay`
- `pnpm regression:providers`
- `pnpm regression:issues`
- `pnpm smoke:ui` — 36 passed, 24 project-configured skips
- Android debug APK compilation completed successfully during implementation.
- `git diff --check`

## Manual review checklist

- [ ] Manually verify weather particles remain smooth with accent pulse enabled in foreground Firefox on macOS.
- [ ] Manually verify Echo Chamber resize handles, corner orientation, wrapping, and randomized delivery on desktop and touch hardware.
- [ ] Manually verify the Android notification permission prompt and background notification delivery on a physical device.
- [ ] Manually verify mobile battery and thermal behavior during an extended foreground session.
- [ ] Manually verify sequential autonomous multi-character Conversation turns against a configured OpenAI-compatible gateway.

## Risk notes

The weather worker has a feature-detected main-thread fallback. Android notification and battery behavior still require physical-device confirmation. Provider compatibility is covered with a real local SSE endpoint, including empty metadata frames and final `message.content` recovery.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added native Android notifications for background Conversation replies, with separate browser and mobile notification controls.
  * Added voter visibility controls to Noodle polls.
  * Added an Overall Generations settings group and direct access to generation settings from Selfies.
  * Added resizable Echo Chamber panels and more varied message reveal timing.

* **Bug Fixes**
  * Improved streamed response recovery, autonomous exchanges, roleplay history controls, tracker display, and media-generation attribution.

* **Performance**
  * Weather effects now use background rendering where supported and adapt to device resource limits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->