### PR TITLE
Fix Professor Mari mobile chat and persona helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 
 ### Fixed
 
+- Fixed Professor Mari's chat opening below the usable mobile viewport and hiding its composer on iPhones. The expanded chat now fills the app content area beneath the top bar and reserves the device's bottom safe area (#3569).
+- Fixed Professor Mari's structured `persona.create` action and `mari personas create` helper omitting required Conversation profile columns. Both creation paths now supply safe defaults and accept phonetic name, Convo display name, About Me, and Convo behavior values; the corresponding update helpers and command guidance were synchronized as well (#3571).
 - Hardened generation fallbacks so output already emitted through streaming callbacks is never replaced, failed toast delivery cannot cancel a working fallback, Roleplay background generation participates in Illustrator fallback routing, and Conversation selfie galleries record the connection and model that actually produced the image.
 - Fixed image and video connections retaining or claiming the language-only **Fallback for Main** role after creation or provider changes.
 - Fixed corrected Noodle refreshes bypassing the same activity and authorship validation as the first attempt, empty refreshes being accepted without retry, persona IDs being offered as generated authors, and JSON-shaped image prompts without a usable prompt field being sent verbatim to image providers.

--- a/e2e/core-flows.e2e.ts
+++ b/e2e/core-flows.e2e.ts
@@ -701,6 +701,39 @@ test("home shell and primary topbar panels open without client errors", async ({
   expect(errors).toEqual([]);
 });
 
+test("Professor Mari chat fills the mobile home viewport and keeps its composer visible", async ({ page }, testInfo) => {
+  test.skip(!testInfo.project.name.includes("mobile"), "Professor Mari mobile viewport regression.");
+  await page.goto("/");
+
+  await page
+    .locator('[data-component="HomeProfessorMariChat.MariPanel"]')
+    .getByRole("button", { name: "Ask Professor Mari" })
+    .click();
+
+  const topBar = page.locator('[data-component="TopBar"]');
+  const window = page.locator('[data-component="HomeProfessorMariChat.Window"]');
+  const composer = window.getByPlaceholder("Ask Professor Mari...");
+  await expect(window).toBeVisible();
+  await expect(composer).toBeVisible();
+  await expect
+    .poll(async () => {
+      const [topBarBox, windowBox, composerBox] = await Promise.all([
+        topBar.boundingBox(),
+        window.boundingBox(),
+        composer.boundingBox(),
+      ]);
+      const viewport = page.viewportSize();
+      if (!topBarBox || !windowBox || !composerBox || !viewport) return false;
+      const contentTop = topBarBox.y + topBarBox.height;
+      return (
+        Math.abs(windowBox.y - contentTop) <= 1 &&
+        Math.abs(windowBox.y + windowBox.height - viewport.height) <= 1 &&
+        composerBox.y + composerBox.height <= viewport.height + 1
+      );
+    })
+    .toBe(true);
+});
+
 test("Lorebook Save keeps Overview stable while the updated detail cache settles", async ({ page }, testInfo) => {
   test.skip(testInfo.project.name.includes("mobile"), "Desktop editor regression");
 

--- a/packages/client/src/components/chat/HomeProfessorMariChat.tsx
+++ b/packages/client/src/components/chat/HomeProfessorMariChat.tsx
@@ -13,6 +13,7 @@ import {
   useState,
 } from "react";
 import { useQueryClient } from "@tanstack/react-query";
+import { createPortal } from "react-dom";
 import { AnimatePresence, motion } from "framer-motion";
 import {
   AlertTriangle,
@@ -187,6 +188,20 @@ function rememberConnectionId(id: string) {
 
 function isProfessorMariDesktopViewport() {
   return typeof window !== "undefined" && window.matchMedia("(min-width: 640px)").matches;
+}
+
+function ProfessorMariMobilePortal({ children }: { children: ReactNode }) {
+  const [mobile, setMobile] = useState(() => !isProfessorMariDesktopViewport());
+
+  useEffect(() => {
+    const query = window.matchMedia("(max-width: 639px)");
+    const sync = () => setMobile(query.matches);
+    sync();
+    query.addEventListener("change", sync);
+    return () => query.removeEventListener("change", sync);
+  }, []);
+
+  return mobile ? createPortal(children, document.body) : children;
 }
 
 function getProfessorMariFileExtension(fileName: string): string {
@@ -3274,13 +3289,15 @@ export function HomeProfessorMariChat({
 
       <AnimatePresence onExitComplete={onChatWindowExitComplete}>
         {chatWindowOpen && (
-          <motion.div
+          <ProfessorMariMobilePortal>
+            <motion.div
             key="professor-mari-window"
+            data-component="HomeProfessorMariChat.Window"
             initial={{ opacity: 0 }}
             animate={{ opacity: 1 }}
             exit={{ opacity: 0 }}
             transition={PROFESSOR_MARI_PANE_TRANSITION}
-            className="fixed inset-x-0 top-[calc(3rem_+_env(safe-area-inset-top))] z-[80] flex h-[calc(100vh_-_3rem_-_env(safe-area-inset-top))] max-h-[calc(100vh_-_3rem_-_env(safe-area-inset-top))] items-stretch justify-center bg-[var(--background)] supports-[height:100dvh]:h-[calc(100dvh_-_3rem_-_env(safe-area-inset-top))] supports-[height:100dvh]:max-h-[calc(100dvh_-_3rem_-_env(safe-area-inset-top))] sm:static sm:z-auto sm:h-full sm:max-h-none sm:w-full sm:flex-1 sm:items-stretch sm:bg-transparent sm:p-0 sm:supports-[height:100dvh]:h-full sm:supports-[height:100dvh]:max-h-none"
+            className="fixed inset-x-0 bottom-0 top-[calc(env(safe-area-inset-top)_+_3rem)] z-[80] flex min-h-0 items-stretch justify-center bg-[var(--background)] pb-[env(safe-area-inset-bottom)] sm:static sm:z-auto sm:h-full sm:max-h-none sm:w-full sm:flex-1 sm:items-stretch sm:bg-transparent sm:p-0"
           >
             <div className="h-full w-full max-w-none sm:min-h-0 sm:max-w-5xl">
               <AnimatePresence mode="wait" initial={false}>
@@ -3728,7 +3745,8 @@ export function HomeProfessorMariChat({
                 )}
               </AnimatePresence>
             </div>
-          </motion.div>
+            </motion.div>
+          </ProfessorMariMobilePortal>
         )}
       </AnimatePresence>
     </>

--- a/packages/server/src/services/mari-db/mari-db.service.ts
+++ b/packages/server/src/services/mari-db/mari-db.service.ts
@@ -783,6 +783,51 @@ function normalizeCharacterActionData(input: Row): Row {
   return out;
 }
 
+function normalizePersonaConvoBehavior(value: unknown): unknown {
+  if (isRecord(value)) return clone(value);
+  if (typeof value !== "string") return "";
+  const trimmed = value.trim();
+  if (!trimmed) return "";
+  try {
+    const parsed = JSON.parse(trimmed) as unknown;
+    if (isRecord(parsed)) return parsed;
+  } catch {
+    // A plain directive is still useful input from Professor Mari or the CLI.
+  }
+  return { instruction: trimmed, insertionStrategy: "constant_after" };
+}
+
+export function buildPersonaCreateRow(data: Row, id: string, timestamp: string): Row {
+  return {
+    id,
+    name: requiredString(data, ["name"], "persona name"),
+    comment: firstString(data, ["comment"]) ?? "",
+    creator: firstString(data, ["creator"]) ?? "",
+    personaVersion: firstString(data, ["personaVersion", "persona_version"]) ?? "1.0",
+    creatorNotes: firstString(data, ["creatorNotes", "creator_notes", "creator-notes"]) ?? "",
+    phoneticName: firstString(data, ["phoneticName", "phonetic_name", "phonetic-name"]) ?? "",
+    description: firstString(data, ["description"]) ?? "",
+    personality: firstString(data, ["personality"]) ?? "",
+    scenario: firstString(data, ["scenario"]) ?? "",
+    backstory: firstString(data, ["backstory"]) ?? "",
+    appearance: firstString(data, ["appearance"]) ?? "",
+    isActive: "false",
+    nameColor: "",
+    dialogueColor: "",
+    boxColor: "",
+    trackerCardColors: { mode: "chat" },
+    personaStats: "",
+    tags: firstStringList(data, ["tags"]) ?? [],
+    savedStatusOptions: [],
+    avatarCrop: "",
+    convoDisplayName: firstString(data, ["convoDisplayName", "convo_display_name", "convo-display-name"]) ?? "",
+    aboutMe: firstString(data, ["aboutMe", "about_me", "about-me"]) ?? "",
+    convoBehavior: normalizePersonaConvoBehavior(data.convoBehavior ?? data.convo_behavior ?? data["convo-behavior"]),
+    createdAt: timestamp,
+    updatedAt: timestamp,
+  };
+}
+
 function jsonString(value: unknown, fallback: unknown): string {
   if (typeof value === "string") {
     const trimmed = value.trim();
@@ -1765,34 +1810,18 @@ export class MariDbService {
           "creatorNotes",
           "creator_notes",
           "tags",
+          "phoneticName",
+          "phonetic_name",
+          "convoDisplayName",
+          "convo_display_name",
+          "aboutMe",
+          "about_me",
+          "convoBehavior",
+          "convo_behavior",
         ]);
-        const name = requiredString(data, ["name"], "persona name");
         const timestamp = now();
         const id = firstString(args, ["id", "personaId"]) ?? newId();
-        const row: Row = {
-          id,
-          name,
-          comment: firstString(data, ["comment"]) ?? "",
-          creator: firstString(data, ["creator"]) ?? "",
-          personaVersion: firstString(data, ["personaVersion", "persona_version"]) ?? "1.0",
-          creatorNotes: firstString(data, ["creatorNotes", "creator_notes", "creator-notes"]) ?? "",
-          description: firstString(data, ["description"]) ?? "",
-          personality: firstString(data, ["personality"]) ?? "",
-          scenario: firstString(data, ["scenario"]) ?? "",
-          backstory: firstString(data, ["backstory"]) ?? "",
-          appearance: firstString(data, ["appearance"]) ?? "",
-          isActive: "false",
-          nameColor: "",
-          dialogueColor: "",
-          boxColor: "",
-          trackerCardColors: { mode: "chat" },
-          personaStats: "",
-          tags: firstStringList(data, ["tags"]) ?? [],
-          savedStatusOptions: [],
-          avatarCrop: "",
-          createdAt: timestamp,
-          updatedAt: timestamp,
-        };
+        const row = buildPersonaCreateRow(data, id, timestamp);
         return this.executeMutation(
           {
             kind: "insert",
@@ -1823,6 +1852,14 @@ export class MariDbService {
           "creatorNotes",
           "creator_notes",
           "tags",
+          "phoneticName",
+          "phonetic_name",
+          "convoDisplayName",
+          "convo_display_name",
+          "aboutMe",
+          "about_me",
+          "convoBehavior",
+          "convo_behavior",
         ]);
         const patch: Row = { updatedAt: now() };
         assignStringField(patch, data, ["name"], "name");
@@ -1834,6 +1871,19 @@ export class MariDbService {
         assignStringField(patch, data, ["comment"], "comment");
         assignStringField(patch, data, ["creator"], "creator");
         assignStringField(patch, data, ["creatorNotes", "creator_notes", "creator-notes"], "creatorNotes");
+        assignStringField(patch, data, ["phoneticName", "phonetic_name", "phonetic-name"], "phoneticName");
+        assignStringField(
+          patch,
+          data,
+          ["convoDisplayName", "convo_display_name", "convo-display-name"],
+          "convoDisplayName",
+        );
+        assignStringField(patch, data, ["aboutMe", "about_me", "about-me"], "aboutMe");
+        if (data.convoBehavior !== undefined || data.convo_behavior !== undefined || data["convo-behavior"] !== undefined) {
+          patch.convoBehavior = normalizePersonaConvoBehavior(
+            data.convoBehavior ?? data.convo_behavior ?? data["convo-behavior"],
+          );
+        }
         assignListField(patch, data, ["tags"], "tags");
         if (Object.keys(patch).length <= 1) {
           throw new Error("persona.update needs a patch field such as name, description, personality, scenario, backstory, appearance, tags, comment, creator, or creatorNotes");
@@ -3174,38 +3224,34 @@ export class MariDbService {
         const name = flagString(flags, "name")?.trim();
         if (!name) {
           throw new Error(
-            "Usage: mari personas create --name <name> [--description <text>] [--personality <text>] [--scenario <text>] [--backstory <text>] [--appearance <text>] [--comment <text>] [--creator <text>] [--creator-notes <text>] [--apply] [--reason <text>]",
+            "Usage: mari personas create --name <name> [--description <text>] [--personality <text>] [--scenario <text>] [--backstory <text>] [--appearance <text>] [--phonetic-name <text>] [--convo-display-name <text>] [--about-me <text>] [--convo-behavior <text-or-json>] [--comment <text>] [--creator <text>] [--creator-notes <text>] [--apply] [--reason <text>]",
           );
         }
         const timestamp = now();
-        const row: Row = {
-          id: flagString(flags, "id") ?? newId(),
-          name,
-          comment: flagString(flags, "comment") ?? "",
-          creator: flagString(flags, "creator") ?? "",
-          personaVersion: "1.0",
-          creatorNotes: flagString(flags, "creator-notes") ?? "",
-          description: flagString(flags, "description") ?? "",
-          personality: flagString(flags, "personality") ?? "",
-          scenario: flagString(flags, "scenario") ?? "",
-          backstory: flagString(flags, "backstory") ?? "",
-          appearance: flagString(flags, "appearance") ?? "",
-          isActive: "false",
-          nameColor: "",
-          dialogueColor: "",
-          boxColor: "",
-          trackerCardColors: { mode: "chat" },
-          personaStats: "",
-          tags: [],
-          savedStatusOptions: [],
-          avatarCrop: "",
-          createdAt: timestamp,
-          updatedAt: timestamp,
-        };
+        const id = flagString(flags, "id") ?? newId();
+        const row = buildPersonaCreateRow(
+          {
+            name,
+            comment: flagString(flags, "comment"),
+            creator: flagString(flags, "creator"),
+            creatorNotes: flagString(flags, "creator-notes"),
+            phoneticName: flagString(flags, "phonetic-name"),
+            description: flagString(flags, "description"),
+            personality: flagString(flags, "personality"),
+            scenario: flagString(flags, "scenario"),
+            backstory: flagString(flags, "backstory"),
+            appearance: flagString(flags, "appearance"),
+            convoDisplayName: flagString(flags, "convo-display-name"),
+            aboutMe: flagString(flags, "about-me"),
+            convoBehavior: flagString(flags, "convo-behavior"),
+          },
+          id,
+          timestamp,
+        );
         const request: ParsedMutationRequest = {
           kind: "insert",
           table: "personas",
-          id: String(row.id),
+          id,
           row,
           apply: hasFlag(flags, "apply"),
           cascade: false,
@@ -3218,7 +3264,7 @@ export class MariDbService {
         const id = parsed.positionals[0];
         if (!id)
           throw new Error(
-            "Usage: mari personas update <id> [--name <name>] [--description <text>] [--personality <text>] [--scenario <text>] [--backstory <text>] [--appearance <text>] [--tags <t1,t2,...>] [--comment <text>] [--creator <text>] [--creator-notes <text>] [--apply] [--reason <text>]",
+            "Usage: mari personas update <id> [--name <name>] [--description <text>] [--personality <text>] [--scenario <text>] [--backstory <text>] [--appearance <text>] [--phonetic-name <text>] [--convo-display-name <text>] [--about-me <text>] [--convo-behavior <text-or-json>] [--tags <t1,t2,...>] [--comment <text>] [--creator <text>] [--creator-notes <text>] [--apply] [--reason <text>]",
           );
         const patch: Row = { updatedAt: now() };
         const fieldMap: Array<[string, string]> = [
@@ -3231,6 +3277,9 @@ export class MariDbService {
           ["comment", "comment"],
           ["creator", "creator"],
           ["creator-notes", "creatorNotes"],
+          ["phonetic-name", "phoneticName"],
+          ["convo-display-name", "convoDisplayName"],
+          ["about-me", "aboutMe"],
         ];
         for (const [flagName, fieldName] of fieldMap) {
           const val = flagString(flags, flagName);
@@ -3242,9 +3291,11 @@ export class MariDbService {
             ? personaTagsRaw.split(/[,|]/).map((t) => t.trim()).filter(Boolean)
             : [];
         }
+        const convoBehaviorRaw = flagString(flags, "convo-behavior");
+        if (convoBehaviorRaw !== undefined) patch.convoBehavior = normalizePersonaConvoBehavior(convoBehaviorRaw);
         if (Object.keys(patch).length <= 1) {
           throw new Error(
-            "Provide at least one field to update (--name, --description, --personality, --scenario, --backstory, --appearance, --tags, --comment, --creator, --creator-notes)",
+            "Provide at least one field to update (--name, --description, --personality, --scenario, --backstory, --appearance, --phonetic-name, --convo-display-name, --about-me, --convo-behavior, --tags, --comment, --creator, --creator-notes)",
           );
         }
         const request: ParsedMutationRequest = {
@@ -4679,8 +4730,8 @@ export class MariDbService {
       "Read:  active",
       "Read:  get <id>",
       "Read:  search <query> [--limit <n>]",
-      "Write: create --name <name> [--description <text>] [--personality <text>] [--scenario <text>] [--backstory <text>] [--appearance <text>] [--comment <text>] [--creator <text>] [--creator-notes <text>] [--apply] [--reason <text>]",
-      "Write: update <id> [--name <name>] [--description <text>] [--personality <text>] [--scenario <text>] [--backstory <text>] [--appearance <text>] [--tags <t1,t2,...>] [--comment <text>] [--creator <text>] [--creator-notes <text>] [--apply] [--reason <text>]",
+      "Write: create --name <name> [--description <text>] [--personality <text>] [--scenario <text>] [--backstory <text>] [--appearance <text>] [--phonetic-name <text>] [--convo-display-name <text>] [--about-me <text>] [--convo-behavior <text-or-json>] [--comment <text>] [--creator <text>] [--creator-notes <text>] [--apply] [--reason <text>]",
+      "Write: update <id> [--name <name>] [--description <text>] [--personality <text>] [--scenario <text>] [--backstory <text>] [--appearance <text>] [--phonetic-name <text>] [--convo-display-name <text>] [--about-me <text>] [--convo-behavior <text-or-json>] [--tags <t1,t2,...>] [--comment <text>] [--creator <text>] [--creator-notes <text>] [--apply] [--reason <text>]",
       "Write: delete <id> [--apply] [--reason <text>]",
       "Writes dry-run by default; --apply saves reversible changes and shows a Keep/Restore review card.",
     ].join("\n");

--- a/scripts/regressions/open-issues.regression.ts
+++ b/scripts/regressions/open-issues.regression.ts
@@ -63,6 +63,36 @@ import {
 } from "../../packages/server/src/services/image/illustrator-prompt-review.js";
 import { resolveReviewedImagePromptSubmission } from "../../packages/server/src/services/image/image-prompt-review.js";
 import { resolveSceneVideoPrompt } from "../../packages/server/src/services/video/scene-video-prompt-review.js";
+import { buildPersonaCreateRow } from "../../packages/server/src/services/mari-db/mari-db.service.js";
+
+const minimalProfessorMariPersona = buildPersonaCreateRow(
+  { name: "Minimal helper persona" },
+  "persona-minimal",
+  "2026-07-13T00:00:00.000Z",
+);
+assert.equal(minimalProfessorMariPersona.phoneticName, "");
+assert.equal(minimalProfessorMariPersona.convoDisplayName, "");
+assert.equal(minimalProfessorMariPersona.aboutMe, "");
+assert.equal(minimalProfessorMariPersona.convoBehavior, "");
+
+const completeProfessorMariPersona = buildPersonaCreateRow(
+  {
+    name: "Complete helper persona",
+    phoneticName: "Professor Mah-ree",
+    convoDisplayName: "Prof. Mari",
+    aboutMe: "I help people build worlds.",
+    convoBehavior: "Speak warmly and precisely.",
+  },
+  "persona-complete",
+  "2026-07-13T00:00:00.000Z",
+);
+assert.equal(completeProfessorMariPersona.phoneticName, "Professor Mah-ree");
+assert.equal(completeProfessorMariPersona.convoDisplayName, "Prof. Mari");
+assert.equal(completeProfessorMariPersona.aboutMe, "I help people build worlds.");
+assert.deepEqual(completeProfessorMariPersona.convoBehavior, {
+  instruction: "Speak warmly and precisely.",
+  insertionStrategy: "constant_after",
+});
 
 assert.equal(resolveInitialGameGmConnectionId(undefined, "chat-connection"), "chat-connection");
 assert.equal(resolveInitialGameGmConnectionId("explicit-connection", "chat-connection"), "explicit-connection");


### PR DESCRIPTION
## Why

Professor Mari's expanded chat regressed on mobile after the responsive home changes. A transformed home ancestor captured the fixed panel, leaving it inset and shortened so the composer could become inaccessible on iPhones. Separately, the persona schema gained required Conversation profile columns while Professor Mari's structured and CLI creation helpers continued constructing the older row shape.

## What changed

- Portal the expanded Professor Mari chat to the document shell on mobile so transformed home content cannot constrain it.
- Anchor the mobile chat beneath the safe-area-aware top bar, extend it to the viewport bottom, and reserve the iPhone bottom inset.
- Keep the desktop Professor Mari chat inline with its existing layout.
- Add a shared persona row builder used by both `app_data persona.create` and `mari personas create`.
- Always populate required `phoneticName`, `convoDisplayName`, `aboutMe`, and `convoBehavior` columns with safe defaults.
- Accept those fields through both create and update helpers, including plain-text or JSON Convo behavior input.
- Synchronize CLI help and Professor Mari helper guidance.
- Audit character and lorebook creation against their current schemas; their existing builders already populate all required fields.
- Add mobile browser and helper regression coverage, plus Unreleased changelog notes.

## Issues

Resolves #3569
Resolves #3571

## Validation

- `pnpm check`
- `pnpm regression:issues`
- Targeted Playwright mobile regression for Professor Mari viewport and composer visibility
- `pnpm version:check`
- `git diff --check`

## Manual review checklist

- [ ] Manually verify Professor Mari fills the usable viewport beneath the top bar on an iPhone with a display cutout and home indicator.
- [ ] Manually verify focusing the Professor Mari composer with the iOS keyboard open keeps the input reachable.
- [ ] Manually create a persona through Professor Mari's `app_data` helper and confirm all Conversation profile fields persist.
- [ ] Manually create a persona through `mari personas create` with both plain-text and JSON Convo behavior input.

## Risk notes

The mobile layout is covered in Chromium with explicit top-bar, viewport-bottom, and composer geometry assertions. Physical iOS keyboard and safe-area behavior still require device confirmation. Persona creation is covered at the shared row-construction boundary used by both helpers; character and lorebook helpers were audited but not changed.
