### PR TITLE
Keep desktop chat tools open beside shell panels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 
 ### Fixed
 
+- Fixed desktop top-bar navigation dismissing open chat tools such as Chat Settings, Gallery, Branches, Active Context, and Conversation Presence. Desktop shell panels now reflow those tools alongside the chat, while mobile navigation continues to dismiss floating chat UI.
+- Fixed Presets list metadata wrapping Regex AI/User badges above their patterns and Function badges below their names. Patterns and function names now truncate first so their badges remain beside them on one line.
 - Fixed Professor Mari's chat opening below the usable mobile viewport and hiding its composer on iPhones. The expanded chat now fills the app content area beneath the top bar and reserves the device's bottom safe area (#3569).
 - Fixed Professor Mari's structured `persona.create` action and `mari personas create` helper omitting required Conversation profile columns. Both creation paths now supply safe defaults and accept phonetic name, Convo display name, About Me, and Convo behavior values; the corresponding update helpers and command guidance were synchronized as well (#3571).
 - Hardened generation fallbacks so output already emitted through streaming callbacks is never replaced, failed toast delivery cannot cancel a working fallback, Roleplay background generation participates in Illustrator fallback routing, and Conversation selfie galleries record the connection and model that actually produced the image.

--- a/packages/client/src/components/chat/ActiveLorebookEntriesButton.tsx
+++ b/packages/client/src/components/chat/ActiveLorebookEntriesButton.tsx
@@ -4,7 +4,7 @@ import { BookOpen, Loader2 } from "lucide-react";
 import { cn } from "../../lib/utils";
 import { useActiveLorebookEntries } from "../../hooks/use-lorebooks";
 import { useUIStore } from "../../stores/ui.store";
-import { CHAT_FLOATING_UI_DISMISS_EVENT } from "../../lib/chat-floating-ui-events";
+import { CHAT_FLOATING_UI_DISMISS_EVENT, isDesktopShellNavigationTarget } from "../../lib/chat-floating-ui-events";
 import { ROLEPLAY_POPOVER_SCROLL_AREA, ROLEPLAY_POPOVER_SHELL } from "./roleplay-popover-styles";
 import {
   CHAT_FLOATING_PANEL_SELECTOR,
@@ -126,6 +126,7 @@ export function ActiveLorebookEntriesButton({
   useEffect(() => {
     if (!open) return;
     const handle = (e: MouseEvent) => {
+      if (isDesktopShellNavigationTarget(e.target)) return;
       const target = e.target as Node;
       const targetElement = target instanceof Element ? target : target.parentElement;
       if (targetElement?.closest(CHAT_FLOATING_PANEL_SELECTOR)) return;

--- a/packages/client/src/components/chat/ChatBranchSelector.tsx
+++ b/packages/client/src/components/chat/ChatBranchSelector.tsx
@@ -23,7 +23,7 @@ import {
   useUpdateChatMetadata,
 } from "../../hooks/use-chats";
 import { showConfirmDialog, showPromptDialog } from "../../lib/app-dialogs";
-import { CHAT_FLOATING_UI_DISMISS_EVENT } from "../../lib/chat-floating-ui-events";
+import { CHAT_FLOATING_UI_DISMISS_EVENT, isDesktopShellNavigationTarget } from "../../lib/chat-floating-ui-events";
 import { getChatDisplayName } from "../../lib/chat-display";
 import { compareChatsByActivityDesc } from "../../lib/chat-recency";
 import { useChatStore } from "../../stores/chat.store";
@@ -202,6 +202,7 @@ export function ChatBranchSelector({
     if (!open) return;
 
     const handlePointerDown = (event: MouseEvent) => {
+      if (isDesktopShellNavigationTarget(event.target)) return;
       const target = event.target as Node;
       if (buttonRef.current?.contains(target) || popoverRef.current?.contains(target)) return;
       setOpen(false);
@@ -281,7 +282,11 @@ export function ChatBranchSelector({
             ref={popoverRef}
             data-chat-branch-popover
             className={cn(ROLEPLAY_POPOVER_SHELL, "fixed z-[9999] overflow-hidden")}
-            style={{ top: position.top, left: position.left, width: position.width }}
+            style={{
+              top: position.top,
+              left: `max(calc(var(--mari-chat-ui-inset-left, 0px) + 0.75rem), min(${position.left}px, calc(100vw - var(--mari-chat-ui-inset-right, 0px) - ${position.width}px - 0.75rem)))`,
+              width: position.width,
+            }}
           >
             <div className="border-b border-[var(--border)] px-3 py-2">
               <div className="flex items-start justify-between gap-3">

--- a/packages/client/src/components/chat/ChatGalleryDrawer.tsx
+++ b/packages/client/src/components/chat/ChatGalleryDrawer.tsx
@@ -15,6 +15,7 @@ import {
 } from "./roleplay-popover-styles";
 import type { Chat } from "@marinara-engine/shared";
 import type { ChatImage } from "../../hooks/use-gallery";
+import { isDesktopShellNavigationTarget } from "../../lib/chat-floating-ui-events";
 
 interface ChatGalleryDrawerProps {
   chat: Chat;
@@ -59,6 +60,7 @@ export function ChatGalleryDrawer({
 
     const handlePointerDown = (event: PointerEvent) => {
       const target = event.target;
+      if (isDesktopShellNavigationTarget(target)) return;
       if (!(target instanceof Node)) return;
       if (panelRef.current?.contains(target)) return;
       if (target instanceof Element && target.closest("[data-chat-floating-panel]")) return;
@@ -71,7 +73,10 @@ export function ChatGalleryDrawer({
 
   if (!open) return null;
   const panelStyle: CSSProperties | undefined = anchor
-    ? { right: `${anchor.right}px`, top: `${anchor.top}px` }
+    ? {
+        right: `max(${anchor.right}px, calc(var(--mari-chat-ui-inset-right, 0px) + 0.75rem))`,
+        top: `${anchor.top}px`,
+      }
     : undefined;
 
   return (

--- a/packages/client/src/components/chat/ChatRoleplaySurface.tsx
+++ b/packages/client/src/components/chat/ChatRoleplaySurface.tsx
@@ -38,7 +38,7 @@ import {
 } from "lucide-react";
 import { cn } from "../../lib/utils";
 import { useRenderTimer } from "../../lib/perf-diagnostics";
-import { CHAT_FLOATING_UI_DISMISS_EVENT } from "../../lib/chat-floating-ui-events";
+import { CHAT_FLOATING_UI_DISMISS_EVENT, isDesktopShellNavigationTarget } from "../../lib/chat-floating-ui-events";
 import { getConnectedChatDisplayName } from "../../lib/chat-display";
 import { playConfiguredNotificationPing } from "../../lib/notification-sound";
 import { messageHasPendingPostProcessing } from "../../lib/chat-message-extra";
@@ -470,6 +470,7 @@ function ActiveContextLinksButton({
   useEffect(() => {
     if (!open) return;
     const handle = (event: MouseEvent) => {
+      if (isDesktopShellNavigationTarget(event.target)) return;
       const target = event.target as Node;
       if (ref.current?.contains(target) || panelRef.current?.contains(target)) return;
       setOpen(false);

--- a/packages/client/src/components/chat/ChatSettingsDrawer.tsx
+++ b/packages/client/src/components/chat/ChatSettingsDrawer.tsx
@@ -140,6 +140,7 @@ import { extractCreatorNotesCss } from "../../lib/creator-notes-css";
 import { isLorebookScopeActiveForChat } from "../../lib/lorebook-scope";
 import { addSilentGreetingSwipes } from "../../lib/message-swipes";
 import { useUIStore } from "../../stores/ui.store";
+import { isDesktopShellNavigationTarget } from "../../lib/chat-floating-ui-events";
 import { useTouchFolderDrag } from "../../hooks/use-touch-folder-drag";
 import {
   useChatPresets,
@@ -3812,6 +3813,7 @@ export function ChatSettingsDrawer({
 
     const handlePointerDown = (event: PointerEvent) => {
       const target = event.target;
+      if (isDesktopShellNavigationTarget(target)) return;
       if (!(target instanceof Node)) return;
       if (panelRef.current?.contains(target)) return;
       if (target instanceof Element && target.closest("[data-chat-floating-panel]")) return;
@@ -3834,7 +3836,10 @@ export function ChatSettingsDrawer({
           top: `${anchor.top}px`,
           width: `min(34rem, calc(100vw - ${anchor.right}px - 0.75rem))`,
         }
-      : { right: `${anchor.right}px`, top: `${anchor.top}px` }
+      : {
+          right: `max(${anchor.right}px, calc(var(--mari-chat-ui-inset-right, 0px) + 0.75rem))`,
+          top: `${anchor.top}px`,
+        }
     : undefined;
 
   return (

--- a/packages/client/src/components/chat/ConversationPresenceCard.tsx
+++ b/packages/client/src/components/chat/ConversationPresenceCard.tsx
@@ -12,6 +12,7 @@ import { api } from "../../lib/api-client";
 import { cn, getAvatarCropStyle } from "../../lib/utils";
 import { useChatStore } from "../../stores/chat.store";
 import { useUIStore } from "../../stores/ui.store";
+import { isDesktopShellNavigationTarget } from "../../lib/chat-floating-ui-events";
 import type { CharacterMap } from "./chat-area.types";
 import {
   CHAT_TOOLBAR_IDENTITY_PILL_SIZE_CLASS,
@@ -269,6 +270,7 @@ export function ConversationPresenceCard({
   useEffect(() => {
     if (!open) return;
     const handleMouseDown = (event: MouseEvent) => {
+      if (isDesktopShellNavigationTarget(event.target)) return;
       const target = event.target as Node;
       if (
         buttonRef.current?.contains(target) ||
@@ -603,7 +605,11 @@ export function ConversationPresenceCard({
           <div
             ref={popoverRef}
             className={cn(ROLEPLAY_POPOVER_SHELL, "fixed z-[9999] overflow-hidden")}
-            style={{ top: position.top, left: position.left, width: position.width }}
+            style={{
+              top: position.top,
+              left: `max(calc(var(--mari-chat-ui-inset-left, 0px) + 0.75rem), min(${position.left}px, calc(100vw - var(--mari-chat-ui-inset-right, 0px) - ${position.width}px - 0.75rem)))`,
+              width: position.width,
+            }}
           >
             <div className={ROLEPLAY_POPOVER_HEADER}>
               <div className="flex items-start justify-between gap-3">

--- a/packages/client/src/components/panels/PresetsPanel.tsx
+++ b/packages/client/src/components/panels/PresetsPanel.tsx
@@ -1456,18 +1456,21 @@ function RegexSection({
                   onClick={() => openRegexDetail(script.id)}
                 >
                   <div className="text-xs font-medium">{script.name}</div>
-                  <div className="mt-0.5 flex min-w-0 flex-wrap items-center gap-1">
+                  <div className="mt-0.5 flex min-w-0 items-center gap-1">
+                    <span
+                      className="min-w-0 flex-1 truncate font-mono text-[0.5625rem] text-[var(--muted-foreground)]"
+                      title={`/${script.findRegex}/${script.flags}`}
+                    >
+                      /{script.findRegex}/{script.flags}
+                    </span>
                     {placements.map((placement) => (
                       <span
                         key={placement}
-                        className="rounded bg-[var(--secondary)] px-1 py-0.5 text-[0.5rem] text-[var(--muted-foreground)]"
+                        className="shrink-0 rounded bg-[var(--secondary)] px-1 py-0.5 text-[0.5rem] text-[var(--muted-foreground)]"
                       >
                         {placement === "ai_output" ? "AI" : "User"}
                       </span>
                     ))}
-                    <span className="min-w-0 max-w-full truncate font-mono text-[0.5625rem] text-[var(--muted-foreground)]">
-                      /{script.findRegex}/{script.flags}
-                    </span>
                   </div>
                 </button>
                 <div className="ml-auto flex shrink-0 items-center gap-1">
@@ -1704,16 +1707,18 @@ function FunctionsSection({
                   className="min-w-0 flex-1 basis-[min(100%,10rem)] text-left"
                   onClick={() => openToolDetail(tool.id)}
                 >
-                  <div className="truncate font-mono text-xs font-medium">{tool.name}</div>
-                  <div className="mt-0.5 flex min-w-0 flex-wrap items-center gap-1">
-                    <span className="rounded bg-[var(--secondary)] px-1 py-0.5 text-[0.5rem] text-[var(--muted-foreground)]">
+                  <div className="flex min-w-0 items-center gap-1">
+                    <span className="min-w-0 flex-1 truncate font-mono text-xs font-medium" title={tool.name}>
+                      {tool.name}
+                    </span>
+                    <span className="shrink-0 rounded bg-[var(--secondary)] px-1 py-0.5 text-[0.5rem] text-[var(--muted-foreground)]">
                       {formatFunctionExecutionType(tool.executionType)}
                     </span>
-                    <span className="rounded bg-[var(--secondary)] px-1 py-0.5 text-[0.5rem] text-[var(--muted-foreground)]">
+                    <span className="shrink-0 rounded bg-[var(--secondary)] px-1 py-0.5 text-[0.5rem] text-[var(--muted-foreground)]">
                       {parameterCount} param{parameterCount === 1 ? "" : "s"}
                     </span>
                     {scriptUnavailable && (
-                      <span className="rounded bg-amber-500/10 px-1 py-0.5 text-[0.5rem] text-amber-400">
+                      <span className="shrink-0 rounded bg-amber-500/10 px-1 py-0.5 text-[0.5rem] text-amber-400">
                         Script disabled
                       </span>
                     )}

--- a/packages/client/src/lib/chat-floating-ui-events.ts
+++ b/packages/client/src/lib/chat-floating-ui-events.ts
@@ -4,3 +4,9 @@ export function announceChatFloatingUiDismiss() {
   if (typeof window === "undefined") return;
   window.dispatchEvent(new Event(CHAT_FLOATING_UI_DISMISS_EVENT));
 }
+
+export function isDesktopShellNavigationTarget(target: EventTarget | null) {
+  if (typeof window === "undefined" || window.matchMedia("(max-width: 767px)").matches) return false;
+  const element = target instanceof Element ? target : target instanceof Node ? target.parentElement : null;
+  return Boolean(element?.closest('[data-component="TopBar"]'));
+}


### PR DESCRIPTION
## Linked issue

No linked issue. This is a maintainer-requested desktop UI regression fix and Presets consistency cleanup.

## Why this change

- Desktop top-bar navigation treated chat-owned floating tools like mobile overlays and dismissed them, preventing workflows such as keeping Chat Settings visible while inspecting Agents.
- Regex and Function metadata badges wrapped inconsistently, sometimes appearing above or below the value they describe.

## What changed

- Preserve Chat Settings, Gallery, Branches, Active Context, and Conversation Presence when desktop shell navigation is clicked, while retaining mobile dismissal behavior.
- Constrain fixed chat tools to the desktop shell insets so side panels push them aside instead of overlapping them.
- Keep Regex AI/User badges beside the pattern and Function badges beside the function name, truncating the primary text first when space is limited.
- Document both fixes in the Unreleased changelog.

## Validation

- [ ] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed `CONTRIBUTING.md`

### Manual verification notes

- Automated browser shell smoke suite completed: 37 passed, 25 intentionally skipped.
- Manual verification requested: open each chat tool in Conversation, Roleplay, and Game on desktop, then open Characters, Agents, or Settings and confirm both surfaces remain usable. On mobile, confirm shell navigation still dismisses the floating chat tool.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Version/release files updated (only if this PR includes a version bump)

## UI evidence (if applicable)

No screenshots attached.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Desktop top-bar navigation no longer unintentionally closes open chat tools such as Settings, Gallery, Branches, Active Context, and Conversation Presence.
  * Chat tools now reposition more reliably alongside the conversation while remaining dismissible through mobile interactions.
  * Presets metadata now stays aligned: long regex and function names are truncated before badges wrap.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->