### PR TITLE
Fix Noodle attribution, participant rotation, and branch safety

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,10 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 
 ### Fixed
 
+- Fixed NovelAI connection tests calling a retired subscription endpoint. Connection setup now directs users to Test Image, which verifies the real generation path (#3582).
+- Added a confirmation step before branching a chat from a message, preventing accidental branch creation from tightly spaced mobile Roleplay controls (#3583).
+- Fixed Noodle timeline prompts exposing internal character and account IDs, mentioning disabled random users, and repeatedly favoring the same early invited characters. Timeline generation now identifies accounts only by handle, omits random-user guidance when disabled, rotates the eligible roster fairly, and still prioritizes accounts involved in recent persona mentions or replies (#3584).
+
 - Fixed desktop top-bar navigation dismissing open chat tools such as Chat Settings, Gallery, Branches, Active Context, and Conversation Presence. Desktop shell panels now reflow those tools alongside the chat, while mobile navigation continues to dismiss floating chat UI.
 - Fixed Presets list metadata wrapping Regex AI/User badges above their patterns and Function badges below their names. Patterns and function names now truncate first so their badges remain beside them on one line.
 - Fixed Professor Mari's chat opening below the usable mobile viewport and hiding its composer on iPhones. The expanded chat now fills the app content area beneath the top bar and reserves the device's bottom safe area (#3569).

--- a/packages/client/src/components/chat/ChatArea.tsx
+++ b/packages/client/src/components/chat/ChatArea.tsx
@@ -2168,8 +2168,14 @@ export function ChatArea() {
   );
 
   const handleBranch = useCallback(
-    (messageId: string) => {
+    async (messageId: string) => {
       if (!activeChatId || branchChat.isPending) return;
+      const confirmed = await showConfirmDialog({
+        title: "Create a new branch?",
+        message: "This will copy the chat through this message and open the new branch.",
+        confirmLabel: "Create branch",
+      });
+      if (!confirmed || !activeChatId || branchChat.isPending) return;
       const branchToastId = toast.loading("Creating branch...");
       branchChat.mutate(
         { chatId: activeChatId, upToMessageId: messageId },

--- a/packages/client/src/components/chat/ChatArea.tsx
+++ b/packages/client/src/components/chat/ChatArea.tsx
@@ -791,6 +791,7 @@ export function ChatArea() {
   const updateMessageExtra = useUpdateMessageExtra(activeChatId);
   const peekPrompt = usePeekPrompt();
   const branchChat = useBranchChat();
+  const branchPendingRef = useRef(false);
   const { generate, retryAgents } = useGenerate();
   const generateGallerySelfie = useGenerateGallerySelfie(activeChatId ?? "");
   const setActiveSwipe = useSetActiveSwipe(activeChatId);
@@ -2169,16 +2170,25 @@ export function ChatArea() {
 
   const handleBranch = useCallback(
     async (messageId: string) => {
-      if (!activeChatId || branchChat.isPending) return;
+      const chatId = activeChatId;
+      if (!chatId || branchChat.isPending || branchPendingRef.current) return;
+      branchPendingRef.current = true;
       const confirmed = await showConfirmDialog({
         title: "Create a new branch?",
         message: "This will copy the chat through this message and open the new branch.",
         confirmLabel: "Create branch",
       });
-      if (!confirmed || !activeChatId || branchChat.isPending) return;
+      if (
+        !confirmed ||
+        useChatStore.getState().activeChatId !== chatId ||
+        branchChat.isPending
+      ) {
+        branchPendingRef.current = false;
+        return;
+      }
       const branchToastId = toast.loading("Creating branch...");
       branchChat.mutate(
-        { chatId: activeChatId, upToMessageId: messageId },
+        { chatId, upToMessageId: messageId },
         {
           onSuccess: (newChat) => {
             if (newChat) useChatStore.getState().setActiveChatId(newChat.id);
@@ -2188,6 +2198,7 @@ export function ChatArea() {
             toast.error(error instanceof Error ? `Branch failed: ${error.message}` : "Branch failed.");
           },
           onSettled: () => {
+            branchPendingRef.current = false;
             toast.dismiss(branchToastId);
           },
         },

--- a/packages/server/src/routes/connections.routes.ts
+++ b/packages/server/src/routes/connections.routes.ts
@@ -510,8 +510,12 @@ export async function connectionsRoutes(app: FastifyInstance) {
       // image_generation has no standard modelsEndpoint — use provider-specific checks
       let testUrl: string;
       if (conn.provider === "image_generation" && imageSource === "novelai") {
-        // NovelAI: validate the API key via the user subscription endpoint
-        testUrl = "https://api.novelai.net/user/subscription";
+        return {
+          success: true,
+          message: "NovelAI connection configured. Use 'Test Image' to verify generation works.",
+          latencyMs: Date.now() - start,
+          modelName: conn.model,
+        };
       } else if (conn.provider === "image_generation" && imageSource === "horde") {
         // Horde: heartbeat is the lightweight health endpoint for the public API.
         testUrl = buildHordeUrl(baseUrl, "status/heartbeat");

--- a/packages/server/src/routes/noodle.routes.ts
+++ b/packages/server/src/routes/noodle.routes.ts
@@ -152,6 +152,10 @@ function escapePromptAttribute(value: string) {
   return value.replace(/&/g, "&amp;").replace(/"/g, "&quot;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
 }
 
+function normalizeNoodleHandle(value: string): string {
+  return value.trim().replace(/^@/u, "").toLowerCase();
+}
+
 /**
  * Reads the chat's already-derived `conversationCharacterStatuses` (updated on each generation in
  * that chat), keyed by characterId. This is a plain metadata read, not a schedule recomputation —
@@ -196,7 +200,7 @@ function characterContextFromRow(row: { id: string; data: unknown; avatarPath?: 
   const data = parseRecord(row.data);
   const extensions = parseRecord(data.extensions);
   const name = typeof data.name === "string" && data.name.trim() ? data.name.trim() : "Character";
-  const lines = [`<character id="${row.id}" name="${name}">`];
+  const lines = [`<character name="${escapePromptAttribute(name)}">`];
   for (const [label, value] of [
     ["Description", data.description],
     ["Personality", data.personality],
@@ -220,7 +224,7 @@ function personaContextFromRow(row: {
   backstory?: string | null;
   appearance?: string | null;
 }) {
-  const lines = [`<persona id="${row.id}" name="${row.name || "User"}">`];
+  const lines = [`<persona name="${escapePromptAttribute(row.name || "User")}">`];
   for (const [label, value] of [
     ["Description", row.description],
     ["Personality", row.personality],
@@ -633,8 +637,8 @@ async function buildOptedInChatContext(
     if (messages.length === 0) continue;
     const speakerNameByCharacterId = new Map(characterNames.map((character) => [character.id, character.name]));
     const participantLines = [
-      `- User persona: ${personaName}${chat.personaId ? ` (id=${chat.personaId})` : " (no persona id)"}`,
-      ...characterNames.map((character) => `- Character: ${character.name} (id=${character.id})`),
+      `- User persona: ${personaName}`,
+      ...characterNames.map((character) => `- Character: ${character.name}`),
     ];
     // Attach each character's current status/activity from this chat's own schedule, if this chat
     // has one. Read-only metadata lookup already updated by that chat's own generation — no new
@@ -660,8 +664,7 @@ async function buildOptedInChatContext(
           .replace(/\s+/g, " ")
           .trim()
           .slice(0, 900);
-        const characterId = message.characterId ? `, characterId=${message.characterId}` : "";
-        return `- ${speaker} (${role}${characterId}): ${content}`;
+        return `- ${speaker} (${role}): ${content}`;
       }),
     );
     blocks.push(
@@ -757,7 +760,7 @@ async function buildRefreshPrompt(input: {
   const randomUserContext = activeRandomUsers
     .map(
       (account) =>
-        `<random_user entityId="${account.entityId}" name="${account.displayName}" handle="${account.handle}">\nBio: ${
+        `<random_user name="${escapePromptAttribute(account.displayName)}" handle="${escapePromptAttribute(account.handle)}">\nBio: ${
           account.bio || "A casual Noodle user."
         }\n</random_user>`,
     )
@@ -766,7 +769,7 @@ async function buildRefreshPrompt(input: {
   const activeAccountList = [...input.activeAccounts, ...(input.personaAccount ? [input.personaAccount] : [])]
     .map(
       (account) =>
-        `- ${account.displayName} (@${account.handle}) kind=${account.kind} entityId=${account.entityId} accountId=${account.id} generationRole=${
+        `- ${account.displayName} (@${account.handle}) kind=${account.kind} generationRole=${
           account.kind === "persona" ? "reference-target-only" : "allowed-author-and-actor"
         }`,
     )
@@ -811,6 +814,7 @@ async function buildRefreshPrompt(input: {
   // can never break the noodleGeneratedRefreshSchema output contract.
   const timelineVoiceText = await loadPrompt(input.promptOverrides, NOODLE_TIMELINE_VOICE, {
     enhanced: String(enhancedTimelineWriting),
+    allowRandomUsers: String(input.settings.allowRandomUsers),
   });
 
   const system = [
@@ -931,7 +935,7 @@ async function buildRefreshPrompt(input: {
         posts: [
           {
             tempId: "local id used only inside this response",
-            authorEntityId: "exact non-persona entityId allowed to author generated activity",
+            authorHandle: "exact @handle of a non-persona account allowed to author generated activity",
             content: "post text",
             poll: { question: "optional poll question", options: ["first answer", "second answer"] },
             imagePrompt: "optional image prompt or null",
@@ -940,7 +944,7 @@ async function buildRefreshPrompt(input: {
         ],
         interactions: [
           {
-            actorEntityId: "exact non-persona entityId allowed to perform generated activity",
+            actorHandle: "exact @handle of a non-persona account allowed to perform generated activity",
             targetTempId: "tempId from posts, if targeting a newly created post",
             targetPostId: "existing post id, if targeting an existing post",
             parentInteractionId: "existing replyId when directly answering a comment, otherwise null",
@@ -951,8 +955,8 @@ async function buildRefreshPrompt(input: {
         ],
         follows: [
           {
-            actorEntityId: "exact non-persona entityId allowed to perform generated activity",
-            targetEntityId: "exact entityId from Active Noodle Accounts",
+            actorHandle: "exact @handle of a non-persona account allowed to perform generated activity",
+            targetHandle: "exact @handle from Active Noodle Accounts",
           },
         ],
       },
@@ -1877,33 +1881,33 @@ export async function noodleRoutes(app: FastifyInstance) {
       let content = result.content ?? "";
       let parsedGenerated: ReturnType<typeof parseNoodleGeneratedRefresh> | null = null;
       let retryReason: string | null = null;
-      const allowedActorEntityIds = new Set(selectedParticipants.map((account) => account.entityId));
-      const knownEntityIds = new Set(activeAccounts.map((account) => account.entityId));
+      const allowedActorHandles = new Set(selectedParticipants.map((account) => account.handle.toLowerCase()));
+      const knownHandles = new Set(activeAccounts.map((account) => account.handle.toLowerCase()));
       try {
         parsedGenerated = parseNoodleGeneratedRefresh(parseGameJsonish(content));
-        retryReason = validateNoodleGeneratedRefresh(parsedGenerated.refresh, allowedActorEntityIds, knownEntityIds);
+        retryReason = validateNoodleGeneratedRefresh(parsedGenerated.refresh, allowedActorHandles, knownHandles);
       } catch (error) {
         retryReason = `the response was not valid timeline JSON (${getErrorMessage(error).slice(0, 180)})`;
       }
 
       if (retryReason) {
-        const allowedActorIds = selectedParticipants.map((account) => account.entityId);
-        const knownTargetIds = activeAccounts.map((account) => account.entityId);
+        const allowedHandles = selectedParticipants.map((account) => `@${account.handle}`);
+        const knownTargetHandles = activeAccounts.map((account) => `@${account.handle}`);
         logger.warn("[noodle] Retrying timeline generation because %s", retryReason);
         const correction = [
           "Your previous timeline response could not be used.",
           `Reason: ${retryReason}.`,
-          `Regenerate the complete JSON object now. Authors and actors must use only these selected participant entityId values: ${allowedActorIds.join(", ")}.`,
-          `Follow targets may additionally use these known entityId values: ${knownTargetIds.join(", ")}.`,
-          "Do not invent, rename, or omit an authorEntityId, actorEntityId, or targetEntityId. Return JSON only.",
+          `Regenerate the complete JSON object now. Authors and actors must use only these selected participant handles: ${allowedHandles.join(", ")}.`,
+          `Follow targets may additionally use these known handles: ${knownTargetHandles.join(", ")}.`,
+          "Do not invent, rename, or omit an authorHandle, actorHandle, or targetHandle. Return JSON only.",
         ].join("\n");
         result = await provider.chatComplete([...requestMessages, { role: "user", content: correction }], completionOptions);
         content = result.content ?? "";
         parsedGenerated = parseNoodleGeneratedRefresh(parseGameJsonish(content));
         const correctedRetryReason = validateNoodleGeneratedRefresh(
           parsedGenerated.refresh,
-          allowedActorEntityIds,
-          knownEntityIds,
+          allowedActorHandles,
+          knownHandles,
         );
         if (correctedRetryReason) {
           throw new Error(`Noodle timeline correction could not be used because ${correctedRetryReason}.`);
@@ -1921,7 +1925,7 @@ export async function noodleRoutes(app: FastifyInstance) {
           rejected.issueCount === 1 ? "" : "s",
         );
       }
-      const entityToAccount = new Map(activeAccounts.map((account) => [account.entityId, account]));
+      const handleToAccount = new Map(activeAccounts.map((account) => [account.handle.toLowerCase(), account]));
       const mutableAccountSettings = new Map(
         activeAccounts.map((account) => [account.id, { ...account.settings }] as const),
       );
@@ -1949,7 +1953,7 @@ export async function noodleRoutes(app: FastifyInstance) {
       const activeCharacterReferenceAccounts = activeAccounts.filter((account) => account.kind === "character");
 
       for (const generatedPost of generated.posts.slice(0, settings.maxGeneratedPostsPerRefresh)) {
-        const account = entityToAccount.get(generatedPost.authorEntityId);
+        const account = handleToAccount.get(normalizeNoodleHandle(generatedPost.authorHandle));
         if (!account) continue;
         if (!canGenerateNoodleActivityForAccountKind(account.kind)) {
           logger.warn("[noodle] Ignoring generated post attributed to persona %s", account.entityId);
@@ -2048,7 +2052,7 @@ export async function noodleRoutes(app: FastifyInstance) {
       };
       for (const generatedInteraction of generated.interactions) {
         if (quotas[generatedInteraction.type] <= 0) continue;
-        const actor = entityToAccount.get(generatedInteraction.actorEntityId);
+        const actor = handleToAccount.get(normalizeNoodleHandle(generatedInteraction.actorHandle));
         if (!actor) continue;
         if (!canGenerateNoodleActivityForAccountKind(actor.kind)) {
           logger.warn(
@@ -2120,8 +2124,8 @@ export async function noodleRoutes(app: FastifyInstance) {
       const maxGeneratedFollows = Math.max(12, activeAccounts.length * 2);
       const seenGeneratedFollows = new Set<string>();
       for (const generatedFollow of generated.follows.slice(0, maxGeneratedFollows)) {
-        const actor = entityToAccount.get(generatedFollow.actorEntityId);
-        const target = entityToAccount.get(generatedFollow.targetEntityId);
+        const actor = handleToAccount.get(normalizeNoodleHandle(generatedFollow.actorHandle));
+        const target = handleToAccount.get(normalizeNoodleHandle(generatedFollow.targetHandle));
         if (!actor || !target || actor.id === target.id) continue;
         if (!canGenerateNoodleActivityForAccountKind(actor.kind)) {
           logger.warn("[noodle] Ignoring generated follow attributed to persona %s", actor.entityId);

--- a/packages/server/src/routes/noodle.routes.ts
+++ b/packages/server/src/routes/noodle.routes.ts
@@ -97,6 +97,7 @@ import {
   validateNoodleGeneratedRefresh,
 } from "../services/noodle/noodle-generated-refresh.js";
 import { normalizeNoodleImagePrompt } from "../services/noodle/noodle-image-prompt.js";
+import { normalizeNoodleHandle } from "../services/noodle/noodle-handle.js";
 
 const NOODLE_ROUTE_DIR = dirname(fileURLToPath(import.meta.url));
 const CLIENT_PUBLIC_DIR = resolve(NOODLE_ROUTE_DIR, "../../../client/public");
@@ -150,10 +151,6 @@ function parseStringArray(value: unknown): string[] {
 
 function escapePromptAttribute(value: string) {
   return value.replace(/&/g, "&amp;").replace(/"/g, "&quot;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
-}
-
-function normalizeNoodleHandle(value: string): string {
-  return value.trim().replace(/^@/u, "").toLowerCase();
 }
 
 /**
@@ -1881,8 +1878,8 @@ export async function noodleRoutes(app: FastifyInstance) {
       let content = result.content ?? "";
       let parsedGenerated: ReturnType<typeof parseNoodleGeneratedRefresh> | null = null;
       let retryReason: string | null = null;
-      const allowedActorHandles = new Set(selectedParticipants.map((account) => account.handle.toLowerCase()));
-      const knownHandles = new Set(activeAccounts.map((account) => account.handle.toLowerCase()));
+      const allowedActorHandles = new Set(selectedParticipants.map((account) => normalizeNoodleHandle(account.handle)));
+      const knownHandles = new Set(activeAccounts.map((account) => normalizeNoodleHandle(account.handle)));
       try {
         parsedGenerated = parseNoodleGeneratedRefresh(parseGameJsonish(content));
         retryReason = validateNoodleGeneratedRefresh(parsedGenerated.refresh, allowedActorHandles, knownHandles);
@@ -1925,7 +1922,12 @@ export async function noodleRoutes(app: FastifyInstance) {
           rejected.issueCount === 1 ? "" : "s",
         );
       }
-      const handleToAccount = new Map(activeAccounts.map((account) => [account.handle.toLowerCase(), account]));
+      const handleToAccount = new Map(
+        [...(personaAccount ? [personaAccount] : []), ...selectedParticipants].map((account) => [
+          normalizeNoodleHandle(account.handle),
+          account,
+        ]),
+      );
       const mutableAccountSettings = new Map(
         activeAccounts.map((account) => [account.id, { ...account.settings }] as const),
       );

--- a/packages/server/src/services/noodle/noodle-generated-refresh.ts
+++ b/packages/server/src/services/noodle/noodle-generated-refresh.ts
@@ -6,6 +6,7 @@ import {
   noodleGeneratedRefreshSchema,
   type NoodleGeneratedRefresh,
 } from "@marinara-engine/shared";
+import { normalizeNoodleHandle } from "./noodle-handle.js";
 
 type RefreshCollection = keyof NoodleGeneratedRefresh;
 
@@ -14,10 +15,6 @@ export type RejectedNoodleGeneratedRefreshItem = {
   index: number;
   issueCount: number;
 };
-
-function normalizeGeneratedHandle(handle: string): string {
-  return handle.trim().replace(/^@/u, "").toLowerCase();
-}
 
 /**
  * Require a refresh to contain usable activity attributed to the exact cast
@@ -34,12 +31,12 @@ export function validateNoodleGeneratedRefresh(
   if (!hasActivity) return "the response contained no timeline activity";
 
   const hasUsableAttribution =
-    refresh.posts.some((post) => allowedActorHandles.has(normalizeGeneratedHandle(post.authorHandle))) ||
-    refresh.interactions.some((interaction) => allowedActorHandles.has(normalizeGeneratedHandle(interaction.actorHandle))) ||
+    refresh.posts.some((post) => allowedActorHandles.has(normalizeNoodleHandle(post.authorHandle))) ||
+    refresh.interactions.some((interaction) => allowedActorHandles.has(normalizeNoodleHandle(interaction.actorHandle))) ||
     refresh.follows.some(
       (follow) =>
-        allowedActorHandles.has(normalizeGeneratedHandle(follow.actorHandle)) &&
-        knownHandles.has(normalizeGeneratedHandle(follow.targetHandle)),
+        allowedActorHandles.has(normalizeNoodleHandle(follow.actorHandle)) &&
+        knownHandles.has(normalizeNoodleHandle(follow.targetHandle)),
     );
   return hasUsableAttribution ? null : "the response used no selected participant handle";
 }

--- a/packages/server/src/services/noodle/noodle-generated-refresh.ts
+++ b/packages/server/src/services/noodle/noodle-generated-refresh.ts
@@ -15,6 +15,10 @@ export type RejectedNoodleGeneratedRefreshItem = {
   issueCount: number;
 };
 
+function normalizeGeneratedHandle(handle: string): string {
+  return handle.trim().replace(/^@/u, "").toLowerCase();
+}
+
 /**
  * Require a refresh to contain usable activity attributed to the exact cast
  * selected for this run. The persona may be a follow target, but generations
@@ -22,20 +26,22 @@ export type RejectedNoodleGeneratedRefreshItem = {
  */
 export function validateNoodleGeneratedRefresh(
   refresh: NoodleGeneratedRefresh,
-  allowedActorEntityIds: ReadonlySet<string>,
-  knownEntityIds: ReadonlySet<string>,
+  allowedActorHandles: ReadonlySet<string>,
+  knownHandles: ReadonlySet<string>,
 ): string | null {
   const hasActivity =
     refresh.posts.length + refresh.interactions.length + refresh.follows.length + refresh.digests.length > 0;
   if (!hasActivity) return "the response contained no timeline activity";
 
   const hasUsableAttribution =
-    refresh.posts.some((post) => allowedActorEntityIds.has(post.authorEntityId)) ||
-    refresh.interactions.some((interaction) => allowedActorEntityIds.has(interaction.actorEntityId)) ||
+    refresh.posts.some((post) => allowedActorHandles.has(normalizeGeneratedHandle(post.authorHandle))) ||
+    refresh.interactions.some((interaction) => allowedActorHandles.has(normalizeGeneratedHandle(interaction.actorHandle))) ||
     refresh.follows.some(
-      (follow) => allowedActorEntityIds.has(follow.actorEntityId) && knownEntityIds.has(follow.targetEntityId),
+      (follow) =>
+        allowedActorHandles.has(normalizeGeneratedHandle(follow.actorHandle)) &&
+        knownHandles.has(normalizeGeneratedHandle(follow.targetHandle)),
     );
-  return hasUsableAttribution ? null : "the response used no selected participant entityId";
+  return hasUsableAttribution ? null : "the response used no selected participant handle";
 }
 
 const collectionSchemas = {

--- a/packages/server/src/services/noodle/noodle-handle.ts
+++ b/packages/server/src/services/noodle/noodle-handle.ts
@@ -1,0 +1,3 @@
+export function normalizeNoodleHandle(value: string): string {
+  return value.trim().replace(/^@/u, "").toLowerCase();
+}

--- a/packages/server/src/services/noodle/noodle-participant-selection.ts
+++ b/packages/server/src/services/noodle/noodle-participant-selection.ts
@@ -48,18 +48,12 @@ export function chooseNoodleParticipantAccounts(input: {
     const inactiveOthers = ordinary.filter(
       (account) => !followedAccountIds.has(account.id) && !recentlyActiveAccountIds.has(account.id),
     );
-    const recentFollowed = ordinary.filter(
-      (account) => followedAccountIds.has(account.id) && recentlyActiveAccountIds.has(account.id),
-    );
-    const recentOthers = ordinary.filter(
-      (account) => !followedAccountIds.has(account.id) && recentlyActiveAccountIds.has(account.id),
-    );
+    const recent = ordinary.filter((account) => recentlyActiveAccountIds.has(account.id));
     return [
       ...shuffleWith(priority, random),
-      ...shuffleWith(inactiveFollowed, random),
       ...shuffleWith(inactiveOthers, random),
-      ...shuffleWith(recentFollowed, random),
-      ...shuffleWith(recentOthers, random),
+      ...shuffleWith(inactiveFollowed, random),
+      ...shuffleWith(recent, random),
     ];
   };
 

--- a/packages/server/src/services/noodle/noodle-prompt.ts
+++ b/packages/server/src/services/noodle/noodle-prompt.ts
@@ -49,10 +49,10 @@ export const NOODLE_RANDOM_USER_TREATMENT_INSTRUCTION =
  * only affects the UNEDITED default — once a user customizes the override, their text is used
  * regardless of the setting.
  */
-export function noodleTimelineVoiceDefaultText(enhanced: boolean): string {
+export function noodleTimelineVoiceDefaultText(enhanced: boolean, allowRandomUsers = true): string {
   return [
     ...(enhanced ? NOODLE_TONE_INSTRUCTIONS : [NOODLE_LEGACY_TONE_INSTRUCTION]),
-    NOODLE_RANDOM_USER_TREATMENT_INSTRUCTION,
+    ...(allowRandomUsers ? [NOODLE_RANDOM_USER_TREATMENT_INSTRUCTION] : []),
     ...NOODLE_CREATIVE_FORMAT_INSTRUCTIONS,
     ...(enhanced ? [NOODLE_CONGRUENCY_INSTRUCTION] : []),
   ].join("\n");
@@ -322,7 +322,7 @@ export function noodleTimelineFeatureInstructions(settings: NoodleTimelineFeatur
   return [
     ...(settings.allowRandomUsers
       ? [
-          "- Use only the active accounts listed by entityId. Do not invent accounts.",
+          "- Use only the active accounts listed by @handle. Do not invent accounts.",
           "- Character accounts are the primary cast. Random-user activity should be occasional supporting texture and must never dominate the generated posts or interactions.",
           "- A small minority of posts from random_user accounts may be obvious parody advertisements or absurd fake crypto scams. Usually generate none and never more than one per refresh. Keep every company, product, coin, ticker, price, and financial claim invented, visibly ridiculous, and non-actionable. Never imitate a real company or include real or usable links, wallet addresses, financial advice, or scam instructions.",
         ]

--- a/packages/server/src/services/noodle/noodle-response-format.ts
+++ b/packages/server/src/services/noodle/noodle-response-format.ts
@@ -29,13 +29,13 @@ const timelineSchema = {
         type: "object",
         properties: {
           tempId: { type: "string" },
-          authorEntityId: { type: "string" },
+          authorHandle: { type: "string" },
           content: { type: "string" },
           imagePrompt: nullableString,
           attachGalleryImage: { type: "boolean" },
           poll: pollSchema,
         },
-        required: ["tempId", "authorEntityId", "content", "imagePrompt", "attachGalleryImage", "poll"],
+        required: ["tempId", "authorHandle", "content", "imagePrompt", "attachGalleryImage", "poll"],
         additionalProperties: false,
       },
     },
@@ -44,7 +44,7 @@ const timelineSchema = {
       items: {
         type: "object",
         properties: {
-          actorEntityId: { type: "string" },
+          actorHandle: { type: "string" },
           targetTempId: nullableString,
           targetPostId: nullableString,
           parentInteractionId: nullableString,
@@ -53,7 +53,7 @@ const timelineSchema = {
           pollOptionIndex: nullableInteger,
         },
         required: [
-          "actorEntityId",
+          "actorHandle",
           "targetTempId",
           "targetPostId",
           "parentInteractionId",
@@ -69,10 +69,10 @@ const timelineSchema = {
       items: {
         type: "object",
         properties: {
-          actorEntityId: { type: "string" },
-          targetEntityId: { type: "string" },
+          actorHandle: { type: "string" },
+          targetHandle: { type: "string" },
         },
-        required: ["actorEntityId", "targetEntityId"],
+        required: ["actorHandle", "targetHandle"],
         additionalProperties: false,
       },
     },

--- a/packages/server/src/services/prompt-overrides/registry/noodle.ts
+++ b/packages/server/src/services/prompt-overrides/registry/noodle.ts
@@ -62,6 +62,7 @@ export interface NoodleTimelineVoiceCtx extends Record<string, string | number |
   /** Mirrors the Noodle setting `enableEnhancedTimelineWriting` ("true"/"false"). Only affects the
    *  unedited default text — once a user customizes this override, their text always wins. */
   enhanced: string;
+  allowRandomUsers?: string;
 }
 
 export const NOODLE_TIMELINE_VOICE: PromptOverrideKeyDef<NoodleTimelineVoiceCtx> = {
@@ -70,6 +71,6 @@ export const NOODLE_TIMELINE_VOICE: PromptOverrideKeyDef<NoodleTimelineVoiceCtx>
   description:
     "Tone and creative-freedom instructions for Noodle timeline refreshes: how much personality/attitude each account's voice should carry, and how much accounts may banter, joke, or clash with each other. This does not control which structured actions (posts, replies, likes, polls) are allowed or their JSON shape — those rules always stay enforced regardless of this text, so editing it cannot break refresh generation.",
   variables: [],
-  defaultBuilder: (ctx) => noodleTimelineVoiceDefaultText(ctx.enhanced === "true"),
-  exampleContext: { enhanced: "false" },
+  defaultBuilder: (ctx) => noodleTimelineVoiceDefaultText(ctx.enhanced === "true", ctx.allowRandomUsers !== "false"),
+  exampleContext: { enhanced: "false", allowRandomUsers: "true" },
 };

--- a/packages/shared/src/schemas/noodle.schema.ts
+++ b/packages/shared/src/schemas/noodle.schema.ts
@@ -242,7 +242,7 @@ export const noodleRescheduleRefreshSchema = z.object({
 
 export const noodleGeneratedPostSchema = z.object({
   tempId: z.string().min(1).optional(),
-  authorEntityId: z.string().min(1),
+  authorHandle: z.string().min(1),
   content: z.string().min(1).max(4000),
   imagePrompt: z.string().max(2000).nullable().optional(),
   attachGalleryImage: z.boolean().optional().default(false),
@@ -251,7 +251,7 @@ export const noodleGeneratedPostSchema = z.object({
 
 export const noodleGeneratedInteractionSchema = z
   .object({
-    actorEntityId: z.string().min(1),
+    actorHandle: z.string().min(1),
     targetTempId: z
       .string()
       .min(1)
@@ -295,8 +295,8 @@ export const noodleGeneratedInteractionSchema = z
   });
 
 export const noodleGeneratedFollowSchema = z.object({
-  actorEntityId: z.string().min(1),
-  targetEntityId: z.string().min(1),
+  actorHandle: z.string().min(1),
+  targetHandle: z.string().min(1),
 });
 
 export const noodleGeneratedDigestSchema = z.object({

--- a/scripts/regressions/noodle-polls.regression.ts
+++ b/scripts/regressions/noodle-polls.regression.ts
@@ -57,20 +57,20 @@ const generated = noodleGeneratedRefreshSchema.parse({
   posts: [
     {
       tempId: "poll-1",
-      authorEntityId: "character-1",
+      authorHandle: "character_one",
       content: "Settle this for me.",
       poll: { question: "Choose", options: ["One", "Two"] },
     },
   ],
   interactions: [
     {
-      actorEntityId: "character-2",
+      actorHandle: "character_two",
       targetTempId: "poll-1",
       type: "vote",
       pollOptionIndex: 1,
     },
     {
-      actorEntityId: "character-1",
+      actorHandle: "character_one",
       targetPostId: "existing-post-1",
       parentInteractionId: "persona-comment-1",
       type: "reply",
@@ -85,7 +85,7 @@ assert.equal(generated.interactions[1]?.parentInteractionId, "persona-comment-1"
 const generatedWithNullPlaceholders = noodleGeneratedRefreshSchema.parse({
   interactions: [
     {
-      actorEntityId: "character-2",
+      actorHandle: "character_two",
       targetTempId: "poll-1",
       targetPostId: null,
       type: "like",
@@ -98,7 +98,7 @@ assert.equal(generatedWithNullPlaceholders.interactions[0]?.targetPostId, undefi
 assert.equal(generatedWithNullPlaceholders.interactions[0]?.pollOptionIndex, undefined);
 assert.equal(
   noodleGeneratedRefreshSchema.safeParse({
-    interactions: [{ actorEntityId: "character-2", targetPostId: "post-1", type: "vote" }],
+    interactions: [{ actorHandle: "character_two", targetPostId: "post-1", type: "vote" }],
   }).success,
   false,
 );
@@ -106,7 +106,7 @@ assert.equal(
   noodleGeneratedRefreshSchema.safeParse({
     interactions: [
       {
-        actorEntityId: "character-2",
+        actorHandle: "character_two",
         targetPostId: "post-1",
         parentInteractionId: "comment-1",
         type: "like",
@@ -117,7 +117,7 @@ assert.equal(
 );
 assert.equal(
   noodleGeneratedRefreshSchema.safeParse({
-    interactions: [{ actorEntityId: "character-2", targetPostId: "post-1", type: "vote", pollOptionIndex: null }],
+    interactions: [{ actorHandle: "character_two", targetPostId: "post-1", type: "vote", pollOptionIndex: null }],
   }).success,
   false,
 );

--- a/scripts/regressions/noodle-prompt.regression.ts
+++ b/scripts/regressions/noodle-prompt.regression.ts
@@ -351,7 +351,7 @@ assert.deepEqual(
   ["old-post-with-new-comment"],
 );
 
-const activeAccountsInstruction = "- Use only the active accounts listed by entityId. Do not invent accounts.";
+const activeAccountsInstruction = "- Use only the active accounts listed by @handle. Do not invent accounts.";
 const randomUserSupportingInstruction =
   "- Character accounts are the primary cast. Random-user activity should be occasional supporting texture and must never dominate the generated posts or interactions.";
 const randomUserParodyInstruction =
@@ -392,10 +392,10 @@ assert.deepEqual(
 );
 
 const resilientRefresh = parseNoodleGeneratedRefresh({
-  posts: [{ authorEntityId: "entity-alpha", content: "A valid post." }],
+  posts: [{ authorHandle: "alpha", content: "A valid post." }],
   interactions: [
     {
-      actorEntityId: "entity-beta",
+      actorHandle: "beta",
       targetPostId: "post-1",
       type: "like",
       parentInteractionId: "comment-that-must-not-be-here",
@@ -410,34 +410,34 @@ assert.deepEqual(resilientRefresh.rejected, [{ collection: "interactions", index
 assert.equal(
   validateNoodleGeneratedRefresh(
     { posts: [], interactions: [], follows: [], digests: [] },
-    new Set(["entity-alpha"]),
-    new Set(["entity-alpha", "persona"]),
+    new Set(["alpha"]),
+    new Set(["alpha", "persona"]),
   ),
   "the response contained no timeline activity",
 );
 assert.equal(
   validateNoodleGeneratedRefresh(
     {
-      posts: [{ authorEntityId: "persona", content: "The model must not post as the user.", attachGalleryImage: false }],
+      posts: [{ authorHandle: "persona", content: "The model must not post as the user.", attachGalleryImage: false }],
       interactions: [],
       follows: [],
       digests: [],
     },
-    new Set(["entity-alpha"]),
-    new Set(["entity-alpha", "persona"]),
+    new Set(["alpha"]),
+    new Set(["alpha", "persona"]),
   ),
-  "the response used no selected participant entityId",
+  "the response used no selected participant handle",
 );
 assert.equal(
   validateNoodleGeneratedRefresh(
     {
-      posts: [{ authorEntityId: "entity-alpha", content: "A valid cast post.", attachGalleryImage: false }],
+      posts: [{ authorHandle: "alpha", content: "A valid cast post.", attachGalleryImage: false }],
       interactions: [],
       follows: [],
       digests: [],
     },
-    new Set(["entity-alpha"]),
-    new Set(["entity-alpha", "persona"]),
+    new Set(["alpha"]),
+    new Set(["alpha", "persona"]),
   ),
   null,
 );
@@ -591,9 +591,17 @@ const expectedEnhancedVoiceText = [
 ].join("\n");
 assert.equal(noodleTimelineVoiceDefaultText(false), expectedLegacyVoiceText);
 assert.equal(noodleTimelineVoiceDefaultText(true), expectedEnhancedVoiceText);
+assert.equal(
+  noodleTimelineVoiceDefaultText(false, false),
+  [NOODLE_LEGACY_TONE_INSTRUCTION, ...NOODLE_CREATIVE_FORMAT_INSTRUCTIONS].join("\n"),
+);
 assert.equal(NOODLE_TIMELINE_VOICE.key, "noodle.timelineVoice");
 assert.equal(NOODLE_TIMELINE_VOICE.defaultBuilder({ enhanced: "false" }), expectedLegacyVoiceText);
 assert.equal(NOODLE_TIMELINE_VOICE.defaultBuilder({ enhanced: "true" }), expectedEnhancedVoiceText);
+assert.doesNotMatch(
+  NOODLE_TIMELINE_VOICE.defaultBuilder({ enhanced: "false", allowRandomUsers: "false" }),
+  /Random user accounts/u,
+);
 assert.equal(NOODLE_TIMELINE_VOICE.defaultBuilder({ enhanced: "garbage" }), expectedLegacyVoiceText);
 assert.match(NOODLE_LEGACY_RECALLED_MEMORY_INSTRUCTION, /optional long-term memories/u);
 assert.match(NOODLE_LEGACY_RECALLED_MEMORY_INSTRUCTION, /do not force a reference/u);


### PR DESCRIPTION
## Why

Three user-facing defects made connection setup misleading, mobile Roleplay branching too easy to trigger accidentally, and Noodle refreshes leak internal character identifiers while selecting an unfair subset of invited characters.

## What changed

- Replaced NovelAI’s retired subscription-endpoint probe with clear Test Image guidance.
- Added a themed confirmation dialog before message-scoped branch creation.
- Replaced generated Noodle timeline attribution IDs with case-insensitive handles and removed character, persona, account, and chat-message character IDs from timeline prompt context.
- Omitted default random-user writing guidance whenever random users are disabled.
- Randomized eligible participant rotation while preserving recent mention/reply priority and deprioritizing the immediately previous refresh.
- Documented all three fixes under v2.2.2.

Closes #3582
Closes #3583
Closes #3584

## Automated validation

- `pnpm check`
- `pnpm regression:noodle`
- `pnpm regression:providers`
- `pnpm smoke:ui` (37 passed, 25 viewport-specific skips)

## Manual verification still requested

- [ ] Manually verify branch confirmation in Roleplay on a physical phone.
- [ ] Manually verify NovelAI Test Image with live credentials.
- [ ] Manually inspect a live Noodle refresh with a roster larger than the participant cap.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added confirmation before branching a chat to help prevent accidental actions, especially on mobile.
  - NovelAI connection checks now direct users to **Test Image** for a complete generation test.
  - Noodle timeline generation now uses account handles and avoids exposing internal identifiers.
  - Improved timeline participant rotation and support for disabling random accounts.

- **Bug Fixes**
  - Updated Noodle timeline validation and interactions to reliably use handles instead of internal IDs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->