### PR TITLE
Fix Roleplay background selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 
 ### Fixed
 
+- Fixed selected background-library images immediately disappearing in Roleplay mode because the renderer probed the GET-only image route with an unsupported HEAD request (#3592).
 - Fixed Noodle profile text edits resetting character avatars from their configured crop to the full source image. Unchanged avatars now preserve their crop, and previously lost crops recover from the matching character card on the next profile save.
 - Fixed a blank `TZ=` forcing server-side schedules and date-sensitive Conversation context into the synthetic `Etc/Unknown` UTC timezone. Blank values now inherit the host timezone, Noodle warns when timezone detection is unresolved, and chats remember the browser timezone for autonomous scheduling, temporal awareness, daily memories, and tool macros (#3590).
 

--- a/e2e/core-flows.e2e.ts
+++ b/e2e/core-flows.e2e.ts
@@ -2249,8 +2249,7 @@ test("mobile topbar remains reachable while sidebars switch", async ({ page }, t
   expect(errors).toEqual([]);
 });
 
-test("Roleplay displays a selected background when its file route is GET-only", async ({ page }, testInfo) => {
-  test.skip(!testInfo.project.name.includes("desktop"), "Roleplay background selection is covered on desktop.");
+test("Roleplay displays a selected background when its file route is GET-only", async ({ page }) => {
   const chatResponse = await page.request.post("/api/chats", {
     data: { name: "Roleplay Background Smoke", mode: "roleplay", characterIds: [] },
   });

--- a/e2e/core-flows.e2e.ts
+++ b/e2e/core-flows.e2e.ts
@@ -2249,6 +2249,74 @@ test("mobile topbar remains reachable while sidebars switch", async ({ page }, t
   expect(errors).toEqual([]);
 });
 
+test("Roleplay displays a selected background when its file route is GET-only", async ({ page }, testInfo) => {
+  test.skip(!testInfo.project.name.includes("desktop"), "Roleplay background selection is covered on desktop.");
+  const chatResponse = await page.request.post("/api/chats", {
+    data: { name: "Roleplay Background Smoke", mode: "roleplay", characterIds: [] },
+  });
+  expect(chatResponse.ok()).toBeTruthy();
+  const chat = (await chatResponse.json()) as { id: string };
+  const backgroundUrl = "/api/backgrounds/file/rp-background-smoke.png";
+  const requestedMethods: string[] = [];
+
+  try {
+    await page.route("**/api/backgrounds", async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify([
+          {
+            filename: "rp-background-smoke.png",
+            url: backgroundUrl,
+            originalName: "Roleplay background smoke",
+            tags: [],
+            source: "user",
+          },
+        ]),
+      });
+    });
+    await page.route(`**${backgroundUrl}`, async (route) => {
+      requestedMethods.push(route.request().method());
+      if (route.request().method() !== "GET") {
+        await route.fulfill({ status: 405, body: "" });
+        return;
+      }
+      await route.fulfill({
+        status: 200,
+        contentType: "image/svg+xml",
+        body: '<svg xmlns="http://www.w3.org/2000/svg" width="2" height="2"><path fill="#47234f" d="M0 0h2v2H0z"/></svg>',
+      });
+    });
+    await page.addInitScript((chatId) => {
+      localStorage.setItem("marinara-active-chat-id", chatId);
+    }, chat.id);
+    await page.goto("/");
+
+    await page.locator('[data-tour="panel-settings"]').click();
+    await page.getByPlaceholder("Search settings").fill("Backgrounds");
+    await page.getByRole("button", { name: /Backgrounds Section/ }).click();
+    await page.locator(`img[src="${backgroundUrl}"]`).locator("..").click();
+
+    await expect
+      .poll(async () =>
+        page.locator(".mari-background").evaluateAll(
+          (layers, expectedUrl) =>
+            layers.some(
+              (layer) =>
+                (layer as HTMLElement).style.backgroundImage.includes(expectedUrl) &&
+                (layer as HTMLElement).style.opacity === "1",
+            ),
+          backgroundUrl,
+        ),
+      )
+      .toBe(true);
+    expect(requestedMethods).toContain("GET");
+    expect(requestedMethods).not.toContain("HEAD");
+  } finally {
+    await page.request.delete(`/api/chats/${chat.id}`);
+  }
+});
+
 test("hierarchical map editor creates and saves an oriented location tree", async ({ page }, testInfo) => {
   test.setTimeout(90_000);
   const errors = collectUnexpectedErrors(page);

--- a/packages/client/src/components/chat/ChatRoleplaySurface.tsx
+++ b/packages/client/src/components/chat/ChatRoleplaySurface.tsx
@@ -240,23 +240,27 @@ function CrossfadeBackground({
     const currentUrl = activeSlot.current === "a" ? bgA : bgB;
     if (url === currentUrl) return;
 
-    if (url && (url.startsWith("/api/backgrounds/") || url.startsWith("/api/game-assets/"))) {
-      fetch(url, { method: "HEAD" })
-        .then((res) => {
-          if (res.ok) {
-            applyUrl(url);
-          } else {
-            console.warn(`[Background] "${url}" not found — clearing`);
-            useUIStore.getState().setChatBackground(null);
-          }
-        })
-        .catch(() => {
-          applyUrl(url);
-        });
+    if (!url) {
+      applyUrl(null);
       return;
     }
 
-    applyUrl(url);
+    let cancelled = false;
+    const image = document.createElement("img");
+    image.onload = () => {
+      if (!cancelled) applyUrl(url);
+    };
+    image.onerror = () => {
+      if (cancelled || useUIStore.getState().chatBackground !== url) return;
+      console.warn(`[Background] "${url}" could not be loaded — clearing`);
+      useUIStore.getState().setChatBackground(null);
+    };
+    image.src = url;
+    return () => {
+      cancelled = true;
+      image.onload = null;
+      image.onerror = null;
+    };
 
     function applyUrl(nextUrl: string | null) {
       if (activeSlot.current === "a") {


### PR DESCRIPTION
## Linked issue

Closes #3592

## Why this change

- Selecting a background-library image in Roleplay immediately cleared it because the renderer sent a HEAD probe to a GET-only file route.

## What changed

- Preload selected Roleplay backgrounds through the browser image loader before crossfading them.
- Ignore stale load callbacks so an older failed request cannot clear a newer selection.
- Add a browser regression where GET succeeds and HEAD is rejected.
- Record the fix in the v2.2.2 changelog.

## Validation

- [ ] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed `CONTRIBUTING.md`

### Manual verification notes

- Automated browser proof selects a managed background whose endpoint rejects HEAD, verifies GET loading, and confirms the selected image becomes the visible Roleplay background layer.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Version/release files updated (only if this PR includes a version bump)

## UI evidence (if applicable)

- No visual redesign; this restores the existing selected-background behavior.