### PR TITLE
Fix Unicode surrogate splitting in recalled memory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 
 ### Fixed
 
+- Fixed recalled-memory truncation splitting supplementary Unicode characters such as emoji or Lydian text into invalid UTF-16 surrogate halves, which caused strict provider JSON parsers to reject otherwise valid Conversation generations (#3596).
 - Fixed selected background-library images immediately disappearing in Roleplay mode because the renderer probed the GET-only image route with an unsupported HEAD request (#3592).
 - Fixed Noodle profile text edits resetting character avatars from their configured crop to the full source image. Unchanged avatars now preserve their crop, and previously lost crops recover from the matching character card on the next profile save.
 - Fixed a blank `TZ=` forcing server-side schedules and date-sensitive Conversation context into the synthetic `Etc/Unknown` UTC timezone. Blank values now inherit the host timezone, Noodle warns when timezone detection is unresolved, and chats remember the browser timezone for autonomous scheduling, temporal awareness, daily memories, and tool macros (#3590).

--- a/packages/server/src/services/generation/memory-recall-pack.ts
+++ b/packages/server/src/services/generation/memory-recall-pack.ts
@@ -12,18 +12,35 @@ function estimateTextTokens(content: string): number {
   return Math.max(1, Math.ceil(trimmed.length / 4));
 }
 
-function truncateRecalledMemory(content: string, tokenBudget: number): string {
+function sliceAtCodePointBoundaries(content: string, start: number, end: number): string {
+  let safeStart = Math.max(0, start);
+  let safeEnd = Math.min(content.length, end);
+
+  const startsWithLowSurrogate = safeStart > 0 && safeStart < content.length
+    && content.charCodeAt(safeStart) >= 0xdc00 && content.charCodeAt(safeStart) <= 0xdfff;
+  if (startsWithLowSurrogate) safeStart += 1;
+
+  const endsWithHighSurrogate = safeEnd > 0 && safeEnd < content.length
+    && content.charCodeAt(safeEnd - 1) >= 0xd800 && content.charCodeAt(safeEnd - 1) <= 0xdbff;
+  if (endsWithHighSurrogate) safeEnd -= 1;
+
+  return content.slice(safeStart, safeEnd);
+}
+
+export function truncateRecalledMemory(content: string, tokenBudget: number): string {
   const maxChars = Math.max(32, tokenBudget * 4);
   if (content.length <= maxChars) return content;
 
   const availableChars = maxChars - RECALL_TRUNCATION_MARKER.length;
   if (availableChars <= 0) {
-    return content.slice(0, maxChars);
+    return sliceAtCodePointBoundaries(content, 0, maxChars);
   }
 
   const headChars = Math.max(16, Math.ceil(availableChars * 0.7));
   const tailChars = Math.max(16, availableChars - headChars);
-  return `${content.slice(0, headChars).trimEnd()}${RECALL_TRUNCATION_MARKER}${content.slice(-tailChars).trimStart()}`;
+  const head = sliceAtCodePointBoundaries(content, 0, headChars).trimEnd();
+  const tail = sliceAtCodePointBoundaries(content, content.length - tailChars, content.length).trimStart();
+  return `${head}${RECALL_TRUNCATION_MARKER}${tail}`;
 }
 
 export function packRecalledMemories(

--- a/scripts/regressions/prompt.regression.ts
+++ b/scripts/regressions/prompt.regression.ts
@@ -81,6 +81,7 @@ import { buildNpcPortraitProviderPrompt } from "../../packages/server/src/servic
 import { resolveNpcPortraitAppearance } from "../../packages/server/src/routes/game.routes.js";
 import { buildLegacyDefaultAgentConfigUpdate } from "../../packages/server/src/services/agents/default-prompt-migration.js";
 import { buildMemoryRecallBlock } from "../../packages/server/src/services/generation/memory-recall-context.js";
+import { truncateRecalledMemory } from "../../packages/server/src/services/generation/memory-recall-pack.js";
 import { mergeConversationCharacterMemories } from "../../packages/server/src/services/generation/conversation-memory-context.js";
 import { injectIdentityFallbackMessages } from "../../packages/server/src/services/generation/character-prompt-context.js";
 import { injectSceneContextMessages } from "../../packages/server/src/services/generation/scene-context-runtime.js";
@@ -1641,6 +1642,24 @@ const cases: RegressionCase[] = [
       assert.equal(block.includes("{{user}}"), false);
       assert.equal(block.includes("<system>bad</system>"), false);
       assert.match(block, /&lt;system>bad&lt;\/system>/);
+    },
+  },
+  {
+    name: "memory recall truncation preserves supplementary Unicode characters",
+    run() {
+      const tokenBudget = 96;
+      const maxChars = tokenBudget * 4;
+      const marker = "\n...[recalled memory truncated]...\n";
+      const headChars = Math.ceil((maxChars - marker.length) * 0.7);
+      const tailChars = maxChars - marker.length - headChars;
+      const cutsHeadPair = `${"a".repeat(headChars - 1)}\u{10920}${"b".repeat(maxChars)}`;
+      const cutsTailPair = `${"a".repeat(maxChars)}😀${"b".repeat(tailChars - 1)}`;
+
+      for (const memory of [cutsHeadPair, cutsTailPair]) {
+        const truncated = truncateRecalledMemory(memory, tokenBudget);
+        assert.match(truncated, /\[recalled memory truncated]/);
+        assert.doesNotMatch(JSON.stringify(truncated), /\\u(?:d[89ab][0-9a-f]{2}(?!\\ud[c-f][0-9a-f]{2})|d[c-f][0-9a-f]{2})/i);
+      }
     },
   },
   {


### PR DESCRIPTION
Closes #3596

## Why

Long Conversation memories containing supplementary Unicode characters (including emoji and Lydian text) could be truncated between their UTF-16 surrogate halves. The isolated surrogate was then serialized into the provider request, which strict JSON parsers such as llama.cpp reject.

## What changed

- Make both recalled-memory truncation cuts retreat past split surrogate-pair boundaries while preserving the existing code-unit budget.
- Cover both the retained head and retained tail boundaries with supplementary-Unicode prompt regressions.
- Document the fix in the v2.2.2 changelog.

## Validation

- [ ] Run `pnpm regression:prompt`
- [ ] Run `pnpm check`
- [ ] Manually verify a long Conversation memory containing emoji and Lydian text completes through llama.cpp without a JSON parse error.

## Risk

This touches prompt assembly. Automated coverage proves that truncation no longer creates isolated UTF-16 surrogates at either boundary and that the broader prompt regression suite remains green. Live llama.cpp verification remains a manual check because no configured local provider is available in this workspace.
