### PR TITLE
Stabilize Connections text during accent pulse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 
 ### Fixed
 
+- Fixed dense Connections editor text flickering or shifting in Chromium browsers at the accent pulse's 500 ms update cadence. Editor reading surfaces now retain the selected base accent while headers and explicit accent chrome continue to pulse (#3599).
 - Fixed recalled-memory truncation splitting supplementary Unicode characters such as emoji or Lydian text into invalid UTF-16 surrogate halves, which caused strict provider JSON parsers to reject otherwise valid Conversation generations (#3596).
 - Fixed selected background-library images immediately disappearing in Roleplay mode because the renderer probed the GET-only image route with an unsupported HEAD request (#3592).
 - Fixed Noodle profile text edits resetting character avatars from their configured crop to the full source image. Unchanged avatars now preserve their crop, and previously lost crops recover from the matching character card on the next profile save.

--- a/packages/client/src/App.tsx
+++ b/packages/client/src/App.tsx
@@ -589,6 +589,12 @@ export function App() {
     const accentAnimationEnabled = appAccentRgbMode || appAccentPulseMode || themeAccentPulseConfig.enabled;
     const usesTimerDrivenAccentAnimation = accentAnimationEnabled;
 
+    root.style.setProperty("--marinara-app-accent-static", solidAccent);
+    root.style.setProperty(
+      "--marinara-app-accent-static-gradient",
+      accentIsGradient ? accentSource : getSolidAccentGradient(solidAccent),
+    );
+
     let accentAnimationTimer: ReturnType<typeof window.setTimeout> | null = null;
     let cursorRecolorFreezeTimer: ReturnType<typeof window.setTimeout> | null = null;
     let cursorRecolorFrozen = false;

--- a/packages/client/src/styles/globals.css
+++ b/packages/client/src/styles/globals.css
@@ -239,12 +239,14 @@
   --marinara-app-accent-static: var(--primary);
   --marinara-app-accent-gradient: linear-gradient(
     90deg,
+    color-mix(in srgb, var(--marinara-app-accent-solid) 72%, var(--background) 28%),
     var(--marinara-app-accent-solid),
     color-mix(in srgb, var(--marinara-app-accent-solid) 76%, var(--foreground) 24%),
     var(--marinara-app-accent-solid)
   );
   --marinara-app-accent-static-gradient: linear-gradient(
     90deg,
+    color-mix(in srgb, var(--marinara-app-accent-static) 72%, var(--background) 28%),
     var(--marinara-app-accent-static),
     color-mix(in srgb, var(--marinara-app-accent-static) 76%, var(--foreground) 24%),
     var(--marinara-app-accent-static)

--- a/packages/client/src/styles/globals.css
+++ b/packages/client/src/styles/globals.css
@@ -236,11 +236,18 @@
   --mari-logo-title-orange: #fb923c;
   --mari-logo-title-pink: #ec4899;
   --marinara-app-accent-solid: var(--primary);
+  --marinara-app-accent-static: var(--primary);
   --marinara-app-accent-gradient: linear-gradient(
     90deg,
     var(--marinara-app-accent-solid),
     color-mix(in srgb, var(--marinara-app-accent-solid) 76%, var(--foreground) 24%),
     var(--marinara-app-accent-solid)
+  );
+  --marinara-app-accent-static-gradient: linear-gradient(
+    90deg,
+    var(--marinara-app-accent-static),
+    color-mix(in srgb, var(--marinara-app-accent-static) 76%, var(--foreground) 24%),
+    var(--marinara-app-accent-static)
   );
   --marinara-chat-chrome-accent: var(--marinara-app-accent-solid);
   --marinara-chat-chrome-accent-gradient: var(--marinara-app-accent-gradient);
@@ -1677,6 +1684,18 @@
   min-height: 0;
   overflow-y: auto;
   padding: 1.5rem;
+}
+
+/* Pulse ticks update root accent variables every 500ms. Keep dense editor reading
+   surfaces on the selected base accent so Chromium does not rerasterize their text
+   on every tick; headers and explicitly animated chrome continue to pulse. */
+[data-marinara-accent-animation] .mari-editor-content {
+  --primary: var(--marinara-app-accent-static);
+  --ring: var(--marinara-app-accent-static);
+  --marinara-app-accent-solid: var(--marinara-app-accent-static);
+  --marinara-app-accent-gradient: var(--marinara-app-accent-static-gradient);
+  --marinara-chat-chrome-accent: var(--marinara-app-accent-static);
+  --marinara-chat-chrome-accent-gradient: var(--marinara-app-accent-static-gradient);
 }
 
 .mari-editor-content-inner {

--- a/scripts/regressions/open-issues.regression.ts
+++ b/scripts/regressions/open-issues.regression.ts
@@ -169,6 +169,14 @@ assert.doesNotMatch(termuxLauncher, /run_pnpm install --force/u);
 assert.match(termuxLauncher, /run_pnpm store prune/u);
 assert.match(termuxLauncher, /TERMUX_REBUILD_REQUIRED/u);
 
+const appSource = readFileSync(new URL("../../packages/client/src/App.tsx", import.meta.url), "utf8");
+const globalStyles = readFileSync(new URL("../../packages/client/src/styles/globals.css", import.meta.url), "utf8");
+assert.match(appSource, /--marinara-app-accent-static-gradient/u);
+assert.match(
+  globalStyles,
+  /\[data-marinara-accent-animation\] \.mari-editor-content \{[\s\S]*--primary: var\(--marinara-app-accent-static\);[\s\S]*--marinara-chat-chrome-accent: var\(--marinara-app-accent-static\);[\s\S]*\}/u,
+);
+
 assert.equal(stripLeadingMessageTimestamps("[11.07 15:53] Character: Hello!"), "Character: Hello!");
 assert.equal(stripLeadingMessageTimestamps("[11.07.2026 15:53] Character: Hello!"), "Character: Hello!");
 assert.equal(stripConversationPromptTimestamps("[11.07 15:53] Character: Hello!"), "Character: Hello!");


### PR DESCRIPTION
Closes #3599

## Why

The accent pulse updates root color variables every 500 ms. Dense editor reading surfaces inherited those live variables even when their text color was visually unchanged, forcing Chromium browsers to rerasterize the Connections form at the pulse cadence. In the reporter's recording this appeared as intermittent text flicker and vertical movement.

## What changed

- Preserve the selected base accent and its gradient separately from the live pulse value.
- Pin dense editor content to those stable tokens during accent animation.
- Keep editor headers and explicitly animated accent chrome pulsing normally.
- Add an open-issue regression for the stable editor token boundary.
- Document the fix in the v2.2.2 changelog.

## Validation

- [ ] Run `pnpm regression:issues`
- [ ] Run `pnpm check`
- [ ] Run `pnpm smoke:ui`
- [ ] Manually verify Connections text remains stable with Accent Pulse enabled in Opera or Edge on Windows.
- [ ] Manually verify header and explicit accent chrome continue changing color during the pulse.

## Risk

This changes the paint boundary for animated theme tokens. Automated checks prove the token isolation remains present, the application builds, and the browser smoke suite remains green. The reporter's precise Windows 10 Opera/Edge environment is not available locally, so hardware-specific compositor verification remains manual.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed text flickering and shifting in the Connections editor when accent animations pulse in Chromium.
  * Editor reading areas now maintain a consistent accent while surrounding accent effects continue animating.

* **Tests**
  * Added regression coverage to help prevent the issue from recurring.

* **Documentation**
  * Updated the unreleased changelog with details of the fix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->