### PR TITLE
Add a Professor Mari participation toggle to Noodle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 
 ### Added
 
+- Added a default-on Noodle setting that can exclude Professor Mari from account discovery and future generated activity without deleting existing timeline history ([#3598](https://github.com/Pasta-Devs/Marinara-Engine/issues/3598)).
+
 - Added separate opt-in browser and Android generation-completion notifications for manually started Conversation, Roleplay, Visual Novel, and Game replies that finish while Marinara is unfocused, without changing autonomous-message background notification preferences (#3588).
 
 ### Changed

--- a/docs/noodle/settings.md
+++ b/docs/noodle/settings.md
@@ -16,6 +16,7 @@ All Noodle settings are global. They apply to every persona and every chat, not 
 
 The **Invites** section chooses which characters can take part in a Noodle refresh. A refresh is when the AI writes a batch of posts, replies, reposts, and likes for the invited accounts.
 
+- **Professor Mari participates**: a toggle, default **on**. Turn it off to hide Professor Mari from Noodle account discovery and exclude her from future generated posts, replies, reactions, mentions, profile generation, and chat carryover. Existing timeline history is preserved, and turning the toggle back on restores her account.
 - **Characters to Invite**: a search box. Type here to filter both the folder list and the character list below it.
 - **Add from Folder**: click to expand a list of your character folders. Check one or more folders, then click the invite button at the bottom. The button label changes with your selection:
   - **Select folders to invite** when nothing is checked.
@@ -47,7 +48,7 @@ The **Active Accounts** section sets how many eligible accounts take part in one
 - With **Exact count**, one field appears: **Active count** (1 to 100). It sets a fixed number of accounts.
 - With **All invited**, every eligible account takes part, with no cap.
 
-Your active persona and Professor Mari are always eligible on top of these accounts.
+Your active persona is always eligible on top of these accounts. Professor Mari is eligible while **Professor Mari participates** is on.
 
 ## Activity
 
@@ -148,6 +149,7 @@ This table lists every Noodle setting with its default and range.
 | Setting | Default | Range or options |
 |---|---|---|
 | **Generation connection** | none | any text connection (required for refresh) |
+| **Professor Mari participates** | on | on or off |
 | **Refreshes/day** | 2 | 0 to 24 (0 turns automatic refreshes off) |
 | **Active selection** | Random range | Random range, Exact count, All invited |
 | **Min active** | 2 | 1 to 100 (Random range only) |

--- a/packages/client/src/components/noodle/NoodleView.tsx
+++ b/packages/client/src/components/noodle/NoodleView.tsx
@@ -50,6 +50,7 @@ import {
   canManageNoodleReply,
   findNoodleTextMentions,
   noodleTextMentionsHandle as textMentionsHandle,
+  PROFESSOR_MARI_ID,
   readNoodlePollFromMetadata,
   type NoodleTextMention,
   type APIConnection,
@@ -1014,7 +1015,17 @@ export function NoodleView() {
   const [pollOptions, setPollOptions] = useState(["", ""]);
   const [draftPoll, setDraftPoll] = useState<NoodlePollInput | null>(null);
 
-  const accounts = useMemo(() => data?.accounts ?? [], [data?.accounts]);
+  const settings = data?.settings;
+  const accounts = useMemo(
+    () =>
+      (data?.accounts ?? []).filter(
+        (account) =>
+          (settings?.allowProfessorMari ?? true) ||
+          account.kind !== "character" ||
+          account.entityId !== PROFESSOR_MARI_ID,
+      ),
+    [data?.accounts, settings?.allowProfessorMari],
+  );
   const livePersonaIds = useMemo(() => {
     const ids = new Set<string>();
     for (const persona of personas ?? []) {
@@ -1055,7 +1066,6 @@ export function NoodleView() {
   const hasMorePersonaAccounts = visiblePersonaAccounts.length < sortedPersonaAccounts.length;
   const posts = useMemo(() => data?.posts ?? [], [data?.posts]);
   const interactions = useMemo(() => data?.interactions ?? [], [data?.interactions]);
-  const settings = data?.settings;
   const scheduler = data?.scheduler;
   const accountById = useMemo(() => new Map(accounts.map((account) => [account.id, account])), [accounts]);
   const accountByHandle = useMemo(
@@ -2461,9 +2471,10 @@ export function NoodleView() {
     () =>
       characters
         .filter((character) => readString(character.id))
+        .filter((character) => (settings?.allowProfessorMari ?? true) || readString(character.id) !== PROFESSOR_MARI_ID)
         .filter((character) => characterName(character).toLowerCase().includes(normalizedInviteSearch))
         .sort((left, right) => characterName(left).localeCompare(characterName(right))),
-    [characters, normalizedInviteSearch],
+    [characters, normalizedInviteSearch, settings?.allowProfessorMari],
   );
   const visibleInviteCharacters = filteredCharacters.slice(0, inviteCharacterLimit);
   const hasMoreInviteCharacters = filteredCharacters.length > visibleInviteCharacters.length;
@@ -2549,6 +2560,14 @@ export function NoodleView() {
         help="Choose who can participate in Noodle refreshes. Direct character invites, selected character folders, and optional random users form the pool the generator can draw from."
       >
         <div className="space-y-4">
+          <ToggleSetting
+            label="Professor Mari participates"
+            help="When off, Professor Mari is hidden from Noodle account discovery and excluded from future generated posts, replies, reactions, mentions, profiles, and chat carryover. Existing timeline history is preserved."
+            checked={settings?.allowProfessorMari ?? true}
+            disabled={!settings || updateSettings.isPending}
+            onChange={(checked) => saveSettings({ allowProfessorMari: checked })}
+          />
+
           <label className="block space-y-1.5">
             <FieldLabel help="Filters both character folders and individual characters in this invite section.">
               Characters to Invite

--- a/packages/server/src/routes/noodle.routes.ts
+++ b/packages/server/src/routes/noodle.routes.ts
@@ -523,12 +523,23 @@ function filterStalePersonaAccounts(bootstrap: NoodleBootstrap, livePersonaIds: 
   };
 }
 
+function filterExcludedNoodleAccounts(bootstrap: NoodleBootstrap, settings: NoodleSettings): NoodleBootstrap {
+  if (settings.allowProfessorMari) return bootstrap;
+  return {
+    ...bootstrap,
+    accounts: bootstrap.accounts.filter(
+      (account) => account.kind !== "character" || account.entityId !== PROFESSOR_MARI_ID,
+    ),
+  };
+}
+
 async function bootstrapVisibleNoodle(
   noodle: ReturnType<typeof createNoodleStorage>,
   characters: ReturnType<typeof createCharactersStorage>,
 ) {
+  const settings = await noodle.getSettings();
   const livePersonaIds = await ensurePersonaAccounts(noodle, characters);
-  await ensureProfessorMariAccount(noodle, characters);
+  if (settings.allowProfessorMari) await ensureProfessorMariAccount(noodle, characters);
   const existingCharacterAccounts = (await noodle.listAccounts()).filter(
     (account) => account.kind === "character" && account.entityId !== PROFESSOR_MARI_ID,
   );
@@ -545,7 +556,7 @@ async function bootstrapVisibleNoodle(
       syncIdentity: true,
     });
   }
-  return filterStalePersonaAccounts(await noodle.bootstrap(), livePersonaIds);
+  return filterExcludedNoodleAccounts(filterStalePersonaAccounts(await noodle.bootstrap(), livePersonaIds), settings);
 }
 
 async function resolvePersonaAccount(
@@ -1739,7 +1750,7 @@ export async function noodleRoutes(app: FastifyInstance) {
         category: "main",
       });
       await ensurePersonaAccounts(noodle, characters);
-      await ensureProfessorMariAccount(noodle, characters);
+      if (settings.allowProfessorMari) await ensureProfessorMariAccount(noodle, characters);
       const personaAccount = await resolvePersonaAccount(noodle, characters, parsed.data.personaId);
       const selectedGroupCharacterIds = await ensureSelectedGroupCharacterAccounts(
         noodle,
@@ -1750,7 +1761,9 @@ export async function noodleRoutes(app: FastifyInstance) {
       const eligibleAccounts = await noodle.listAccounts();
       const eligibleCharacterAccounts = eligibleAccounts.filter(
         (account) =>
-          account.kind === "character" && (account.invited || selectedGroupCharacterIds.has(account.entityId)),
+          account.kind === "character" &&
+          (settings.allowProfessorMari || account.entityId !== PROFESSOR_MARI_ID) &&
+          (account.invited || selectedGroupCharacterIds.has(account.entityId)),
       );
       await generateMissingNoodleProfiles({
         noodle,

--- a/packages/server/src/services/noodle/noodle-context.ts
+++ b/packages/server/src/services/noodle/noodle-context.ts
@@ -1,7 +1,7 @@
 // ──────────────────────────────────────────────
 // Noodle Prompt Context
 // ──────────────────────────────────────────────
-import type { ChatMode, NoodleCarryoverTarget } from "@marinara-engine/shared";
+import { PROFESSOR_MARI_ID, type ChatMode, type NoodleCarryoverTarget } from "@marinara-engine/shared";
 import type { DB } from "../../db/connection.js";
 import { wrapContent } from "../prompt/format-engine.js";
 import { createNoodleStorage } from "../storage/noodle.storage.js";
@@ -31,6 +31,7 @@ export async function buildRecentSocialMediaActivityBlock(input: {
   const accountIds = new Set<string>();
   const characterAccounts = await noodle.getAccountsByEntities("character", input.characterIds);
   for (const account of characterAccounts) {
+    if (account.entityId === PROFESSOR_MARI_ID && !settings.allowProfessorMari) continue;
     if (account.invited) accountIds.add(account.id);
   }
   if (input.personaId) {

--- a/packages/server/src/services/noodle/noodle-participant-selection.ts
+++ b/packages/server/src/services/noodle/noodle-participant-selection.ts
@@ -1,4 +1,4 @@
-import type { NoodleAccount, NoodleSettings } from "@marinara-engine/shared";
+import { PROFESSOR_MARI_ID, type NoodleAccount, type NoodleSettings } from "@marinara-engine/shared";
 
 type RandomSource = () => number;
 
@@ -28,6 +28,7 @@ export function chooseNoodleParticipantAccounts(input: {
   const priorityAccountIds = input.priorityAccountIds ?? new Set<string>();
   const candidates = input.accounts.filter((account) => {
     if (account.kind === "character") {
+      if (account.entityId === PROFESSOR_MARI_ID && !input.settings.allowProfessorMari) return false;
       return account.invited || input.selectedGroupCharacterIds.has(account.entityId);
     }
     return account.kind === "random_user" && input.settings.allowRandomUsers;

--- a/packages/shared/src/schemas/noodle.schema.ts
+++ b/packages/shared/src/schemas/noodle.schema.ts
@@ -31,6 +31,7 @@ export const DEFAULT_NOODLE_SETTINGS = {
   imageCaptioningConnectionId: null,
   enableLorebookContext: false,
   enableEnhancedTimelineWriting: false,
+  allowProfessorMari: true,
   allowRandomUsers: false,
   invitedCharacterGroupIds: [],
   carryoverMode: "off",
@@ -76,6 +77,7 @@ export const noodleSettingsSchema = z.object({
     .default(DEFAULT_NOODLE_SETTINGS.imageCaptioningConnectionId),
   enableLorebookContext: z.boolean().default(DEFAULT_NOODLE_SETTINGS.enableLorebookContext),
   enableEnhancedTimelineWriting: z.boolean().default(DEFAULT_NOODLE_SETTINGS.enableEnhancedTimelineWriting),
+  allowProfessorMari: z.boolean().default(DEFAULT_NOODLE_SETTINGS.allowProfessorMari),
   allowRandomUsers: z.boolean().default(DEFAULT_NOODLE_SETTINGS.allowRandomUsers),
   invitedCharacterGroupIds: z
     .array(z.string().min(1))

--- a/packages/shared/src/types/noodle.ts
+++ b/packages/shared/src/types/noodle.ts
@@ -42,6 +42,7 @@ export interface NoodleSettings {
   imageCaptioningConnectionId: string | null;
   enableLorebookContext: boolean;
   enableEnhancedTimelineWriting: boolean;
+  allowProfessorMari: boolean;
   allowRandomUsers: boolean;
   invitedCharacterGroupIds: string[];
   carryoverMode: NoodleCarryoverMode;

--- a/scripts/regressions/noodle-prompt.regression.ts
+++ b/scripts/regressions/noodle-prompt.regression.ts
@@ -2,7 +2,7 @@ import assert from "node:assert/strict";
 import { DEFAULT_NOODLE_SETTINGS, noodleRefreshSchema } from "../../packages/shared/src/schemas/noodle.schema.js";
 import { canManageNoodleReply } from "../../packages/shared/src/utils/noodle-interactions.js";
 import type { NoodleAccount, NoodleInteraction, NoodlePost } from "../../packages/shared/src/types/noodle.js";
-import { LIMITS } from "../../packages/shared/src/constants/defaults.js";
+import { LIMITS, PROFESSOR_MARI_ID } from "../../packages/shared/src/constants/defaults.js";
 import {
   canGenerateNoodleActivityForAccountKind,
   formatNoodleTimelineForPrompt,
@@ -59,6 +59,7 @@ const participantSettings = {
   participantMax: 2,
 };
 const participantAccounts = [makeAccount("alpha"), makeAccount("beta"), makeAccount("gamma")];
+const professorMariAccount = { ...makeAccount("professor-mari"), entityId: PROFESSOR_MARI_ID };
 const selectionPersona: NoodleAccount = {
   ...makeAccount("persona-account"),
   kind: "persona",
@@ -137,6 +138,22 @@ assert.deepEqual(
     random: () => 0,
   }).map((account) => account.id),
   ["alpha", "gamma"],
+);
+assert.equal(
+  chooseNoodleParticipantAccounts({
+    accounts: [professorMariAccount],
+    settings: { ...participantSettings, allowProfessorMari: false },
+    selectedGroupCharacterIds: new Set(),
+  }).length,
+  0,
+);
+assert.equal(
+  chooseNoodleParticipantAccounts({
+    accounts: [professorMariAccount],
+    settings: participantSettings,
+    selectedGroupCharacterIds: new Set(),
+  })[0]?.entityId,
+  PROFESSOR_MARI_ID,
 );
 
 const randomParticipant = { ...makeAccount("ambient"), kind: "random_user" as const };


### PR DESCRIPTION
## Why

Some users want Noodle without Professor Mari’s built-in account or generated activity. This adds an explicit opt-out while preserving existing timeline history and keeping the current behavior by default.

Closes #3598

## What changed

- add a persisted, default-on `allowProfessorMari` Noodle setting
- expose **Professor Mari participates** in Noodle Settings > Invites
- exclude her from discovery, invite search, profile generation, participant selection, mentions, and chat carryover when disabled
- preserve historical posts and account data so re-enabling is lossless
- document the setting and add v2.2.2 release notes
- add regression coverage for participant exclusion

## Test plan

- [ ] Manually verify the toggle is enabled by default in Noodle settings
- [ ] Manually disable it and verify Professor Mari disappears from account discovery and invite search
- [ ] Manually refresh Noodle and verify no new Professor Mari activity is generated
- [ ] Manually re-enable it and verify her account returns without losing historical posts
- [ ] Run `pnpm regression:noodle`
- [ ] Run `pnpm check`
- [ ] Run `pnpm smoke:ui`

## Automated validation performed

- `pnpm regression:noodle`
- `pnpm check`
- `pnpm smoke:ui` (54 passed, 26 intentionally skipped)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a “Professor Mari participates” Noodle setting, enabled by default.
  - Turning it off removes Professor Mari from account discovery, invitations, generated activity, and future chat content.
  - Existing timeline history remains preserved and returns when the setting is re-enabled.

- **Documentation**
  - Updated Noodle settings guidance, defaults, and account eligibility details.

- **Bug Fixes**
  - Ensured Professor Mari consistently follows the participation setting across discovery, refresh, suggestions, and activity generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->