### PR TITLE
Fix shutdown write drain and remote admin folder picker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 
 ### Fixed
 
+- Fixed graceful shutdown completing before a file-native storage flush could drain newer writes queued during its active disk write, and made persistent close-time I/O failures reject shutdown instead of silently reporting success (#3602).
+- Fixed the Agent Editor custom-music folder picker omitting saved remote-admin and CSRF credentials by routing its privileged request through the shared API client (#3603).
 - Fixed dense Connections editor text flickering or shifting in Chromium browsers at the accent pulse's 500 ms update cadence. Editor reading surfaces now retain the selected base accent while headers and explicit accent chrome continue to pulse (#3599).
 - Fixed recalled-memory truncation splitting supplementary Unicode characters such as emoji or Lydian text into invalid UTF-16 surrogate halves, which caused strict provider JSON parsers to reject otherwise valid Conversation generations (#3596).
 - Fixed selected background-library images immediately disappearing in Roleplay mode because the renderer probed the GET-only image route with an unsupported HEAD request (#3592).

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "regression:providers": "pnpm build:shared && pnpm --filter @marinara-engine/server exec tsx ../../scripts/regressions/provider-compat.regression.ts",
     "regression:jsonish": "pnpm --filter @marinara-engine/server exec tsx ../../scripts/regressions/jsonish-output.regression.ts",
     "regression:tts": "pnpm build:shared && pnpm --filter @marinara-engine/server exec tsx ../../scripts/regressions/tts-source-persistence.regression.ts",
-    "regression:issues": "pnpm --filter @marinara-engine/server exec tsx ../../scripts/regressions/open-issues.regression.ts",
+    "regression:issues": "pnpm --filter @marinara-engine/server exec tsx ../../scripts/regressions/open-issues.regression.ts && pnpm --filter @marinara-engine/server exec tsx ../../scripts/regressions/file-backed-shutdown.regression.ts",
     "regression:roleplay": "pnpm build:shared && pnpm --filter @marinara-engine/server exec tsx ../../scripts/regressions/roleplay-streaming.regression.ts",
     "smoke:ui": "playwright test -c playwright.config.ts",
     "test": "node ./scripts/check-windows-installer-layout.mjs && pnpm -r run test",

--- a/packages/client/src/components/agents/AgentEditor.tsx
+++ b/packages/client/src/components/agents/AgentEditor.tsx
@@ -7,6 +7,7 @@ import { useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
 import { useUIStore } from "../../stores/ui.store";
 import { showConfirmDialog } from "../../lib/app-dialogs";
+import { api } from "../../lib/api-client";
 import {
   agentKeys,
   useAgentConfigs,
@@ -1343,14 +1344,8 @@ export function AgentEditor() {
 
   const handleSelectCustomMusicFolder = useCallback(async () => {
     try {
-      const res = await fetch("/api/game-assets/pick-local-music-folder", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-      });
-      const data = (await res.json().catch(() => ({}))) as { success?: boolean; path?: string; error?: string };
-      if (!res.ok || data.success !== true || !data.path) {
-        throw new Error(data.error ?? "No folder selected.");
-      }
+      const data = await api.post<{ success: boolean; path: string }>("/game-assets/pick-local-music-folder");
+      if (data.success !== true || !data.path) throw new Error("No folder selected.");
       setLocalCustomMusicExternalFolder(data.path);
       setLocalCustomMusicSource("folder");
       setDirty(true);

--- a/packages/server/src/db/file-backed-store.ts
+++ b/packages/server/src/db/file-backed-store.ts
@@ -104,6 +104,10 @@ export type FileNativeDB = {
   _fileStore: FileNativeStoreController;
 };
 
+export type FileNativeStoreTestHooks = {
+  beforeTableWrite?: (table: string, serializedRows: string) => Promise<void> | void;
+};
+
 type SelectFromBuilder = {
   from: (table: Table) => SelectQueryBuilder;
 };
@@ -1002,7 +1006,8 @@ class FileTableStore {
   private dirtyTables = new Set<string>();
   private backupRecoveredPaths = new Set<string>();
   private dirty = false;
-  private saving = false;
+  private activeFlush: Promise<void> | null = null;
+  private lastFlushError: unknown = null;
   private debounceTimer: NodeJS.Timeout | null = null;
   private safetyTimer: NodeJS.Timeout | null = null;
   private beforeExitHandler: (() => void) | null = null;
@@ -1020,6 +1025,7 @@ class FileTableStore {
   constructor(
     private readonly rootDir: string,
     private readonly legacyDbPaths: string[],
+    private readonly testHooks?: FileNativeStoreTestHooks,
   ) {
     for (const table of FILE_BACKED_TABLES) {
       this.tables.set(table, []);
@@ -1196,12 +1202,12 @@ class FileTableStore {
   }
 
   async flush(force = false) {
-    if (this.saving) {
-      this.dirty = true;
+    if (this.activeFlush) {
+      await this.activeFlush;
+      if (this.dirty || this.dirtyTables.size > 0) await this.flush(force);
       return;
     }
     if (!force && !this.dirty && this.dirtyTables.size === 0) return;
-    this.saving = true;
     this.dirty = false;
     // Snapshot the dirty set and reset it BEFORE the async write. saveFileSnapshots
     // now yields the event loop, so a markDirty() that interleaves during the I/O
@@ -1209,16 +1215,24 @@ class FileTableStore {
     // clear() — the synchronous version had a zero-width window here.
     const dirtyTables = this.dirtyTables;
     this.dirtyTables = new Set();
+    const flush = (async () => {
+      try {
+        await this.saveFileSnapshots(dirtyTables);
+        this.lastFlushError = null;
+      } catch (err) {
+        this.lastFlushError = err;
+        this.dirty = true;
+        // Re-mark the tables we failed to persist so they retry on the next flush
+        // (without clobbering any tables marked dirty during the failed write).
+        for (const table of dirtyTables) this.dirtyTables.add(table);
+        logger.error(err, "[file-storage] Failed to persist file-native storage");
+      }
+    })();
+    this.activeFlush = flush;
     try {
-      await this.saveFileSnapshots(dirtyTables);
-    } catch (err) {
-      this.dirty = true;
-      // Re-mark the tables we failed to persist so they retry on the next flush
-      // (without clobbering any tables marked dirty during the failed write).
-      for (const table of dirtyTables) this.dirtyTables.add(table);
-      logger.error(err, "[file-storage] Failed to persist file-native storage");
+      await flush;
     } finally {
-      this.saving = false;
+      if (this.activeFlush === flush) this.activeFlush = null;
     }
   }
 
@@ -1235,7 +1249,11 @@ class FileTableStore {
       process.off("beforeExit", this.beforeExitHandler);
       this.beforeExitHandler = null;
     }
-    await this.flush(true);
+    if (this.activeFlush) await this.activeFlush;
+    while (this.dirty || this.dirtyTables.size > 0) {
+      await this.flush(true);
+      if (this.lastFlushError) throw this.lastFlushError;
+    }
   }
 
   getQuarantinedTables() {
@@ -1536,7 +1554,9 @@ class FileTableStore {
       tables[table] = rows.length;
       const path = tableFilePath(this.rootDir, table);
       if (dirtyTables.has(table) || !existsSync(path)) {
-        await atomicWriteFile(path, JSON.stringify(rows), { refreshBackup: !this.backupRecoveredPaths.has(path) });
+        const serializedRows = JSON.stringify(rows);
+        await this.testHooks?.beforeTableWrite?.(table, serializedRows);
+        await atomicWriteFile(path, serializedRows, { refreshBackup: !this.backupRecoveredPaths.has(path) });
       }
     }
 
@@ -1657,9 +1677,12 @@ class SelectQuery implements SelectQueryBuilder {
   }
 }
 
-export async function createFileNativeDB(legacyDbPaths: string[] = []): Promise<FileNativeDB> {
+export async function createFileNativeDB(
+  legacyDbPaths: string[] = [],
+  testHooks?: FileNativeStoreTestHooks,
+): Promise<FileNativeDB> {
   const rootDir = getFileStorageDir();
-  const store = new FileTableStore(rootDir, legacyDbPaths);
+  const store = new FileTableStore(rootDir, legacyDbPaths, testHooks);
   await store.initialize();
 
   const controller: FileNativeStoreController = {

--- a/scripts/regressions/file-backed-shutdown.regression.ts
+++ b/scripts/regressions/file-backed-shutdown.regression.ts
@@ -1,0 +1,57 @@
+import assert from "node:assert/strict";
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { createFileNativeDB } from "../../packages/server/src/db/file-backed-store.js";
+import { appSettings } from "../../packages/server/src/db/schema/index.js";
+
+const storageDir = mkdtempSync(join(tmpdir(), "marinara-file-close-"));
+process.env.FILE_STORAGE_DIR = storageDir;
+
+let releaseWrite!: () => void;
+const writeGate = new Promise<void>((resolve) => {
+  releaseWrite = resolve;
+});
+let capturedWrite!: () => void;
+const writeCaptured = new Promise<void>((resolve) => {
+  capturedWrite = resolve;
+});
+let blockedFirstSettingsWrite = false;
+
+try {
+  const db = await createFileNativeDB([], {
+    beforeTableWrite: async (table) => {
+      if (table !== "app_settings" || blockedFirstSettingsWrite) return;
+      blockedFirstSettingsWrite = true;
+      capturedWrite();
+      await writeGate;
+    },
+  });
+
+  await db.insert(appSettings).values({ key: "before-active-flush", value: "one", updatedAt: "2026-07-14" });
+  const activeFlush = db._fileStore.flush();
+  await writeCaptured;
+
+  await db.insert(appSettings).values({ key: "queued-during-flush", value: "two", updatedAt: "2026-07-14" });
+  let closeResolved = false;
+  const close = db._fileStore.close().then(() => {
+    closeResolved = true;
+  });
+  await Promise.resolve();
+  assert.equal(closeResolved, false, "close must wait for the active table write");
+
+  releaseWrite();
+  await Promise.all([activeFlush, close]);
+
+  const persisted = JSON.parse(readFileSync(join(storageDir, "tables", "app_settings.json"), "utf8")) as Array<{
+    key: string;
+  }>;
+  assert.deepEqual(
+    persisted.map((row) => row.key).sort(),
+    ["before-active-flush", "queued-during-flush"],
+  );
+  console.info("File-backed graceful shutdown regression passed.");
+} finally {
+  releaseWrite();
+  rmSync(storageDir, { recursive: true, force: true });
+}

--- a/scripts/regressions/file-backed-shutdown.regression.ts
+++ b/scripts/regressions/file-backed-shutdown.regression.ts
@@ -55,3 +55,18 @@ try {
   releaseWrite();
   rmSync(storageDir, { recursive: true, force: true });
 }
+
+const failingStorageDir = mkdtempSync(join(tmpdir(), "marinara-file-close-failure-"));
+process.env.FILE_STORAGE_DIR = failingStorageDir;
+try {
+  const expectedFailure = new Error("simulated persistent write failure");
+  const db = await createFileNativeDB([], {
+    beforeTableWrite: (table) => {
+      if (table === "app_settings") throw expectedFailure;
+    },
+  });
+  await db.insert(appSettings).values({ key: "must-report-failure", value: "one", updatedAt: "2026-07-14" });
+  await assert.rejects(db._fileStore.close(), expectedFailure);
+} finally {
+  rmSync(failingStorageDir, { recursive: true, force: true });
+}

--- a/scripts/regressions/open-issues.regression.ts
+++ b/scripts/regressions/open-issues.regression.ts
@@ -170,8 +170,14 @@ assert.match(termuxLauncher, /run_pnpm store prune/u);
 assert.match(termuxLauncher, /TERMUX_REBUILD_REQUIRED/u);
 
 const appSource = readFileSync(new URL("../../packages/client/src/App.tsx", import.meta.url), "utf8");
+const agentEditorSource = readFileSync(
+  new URL("../../packages/client/src/components/agents/AgentEditor.tsx", import.meta.url),
+  "utf8",
+);
 const globalStyles = readFileSync(new URL("../../packages/client/src/styles/globals.css", import.meta.url), "utf8");
 assert.match(appSource, /--marinara-app-accent-static-gradient/u);
+assert.doesNotMatch(agentEditorSource, /fetch\(["']\/api\/game-assets\/pick-local-music-folder/u);
+assert.match(agentEditorSource, /api\.post<[^>]+>\(["']\/game-assets\/pick-local-music-folder["']\)/u);
 assert.match(
   globalStyles,
   /\[data-marinara-accent-animation\] \.mari-editor-content \{[\s\S]*--primary: var\(--marinara-app-accent-static\);[\s\S]*--marinara-chat-chrome-accent: var\(--marinara-app-accent-static\);[\s\S]*\}/u,


### PR DESCRIPTION
## Why

Graceful shutdown could report success before a newer file-native mutation reached disk, and the Agent Editor folder picker bypassed the shared API client, causing legitimate remote administrators to receive a 403 despite saving the correct admin secret.

Closes #3602
Closes #3603

## What changed

- track and await the active file-native flush
- drain writes queued during that flush before shutdown completes
- propagate a persistent close-time write failure instead of looping or silently succeeding
- route the privileged custom-music folder picker through `api.post` so admin and CSRF headers are attached
- add deterministic active-flush shutdown coverage and a regression guard for the privileged client call
- update the v2.2.2 changelog

## Risk boundary

- Entrypoints: file-native `flush()` / `close()`, Agent Editor custom-music folder selection
- File format: unchanged
- Normal debounced flush behavior: retained
- Negative controls: close cannot resolve while the captured write is blocked; persistent close-time I/O failure rejects
- Positive proof: a mutation queued after snapshot capture is present on disk after close
- Remote-device manual reproduction: still required

## Test plan

- [ ] Manually delay an active file-native write, mutate during it, close Marinara, and verify both mutations persist after restart
- [ ] Manually simulate a persistent close-time I/O failure and verify shutdown reports failure
- [ ] Manually use the custom-music folder picker from a non-loopback browser with matching `ADMIN_SECRET`
- [ ] Manually verify the picker still works from localhost
- [ ] Run `pnpm regression:issues`
- [ ] Run `pnpm check`
- [ ] Run `pnpm smoke:ui`

## Automated validation performed

- `pnpm regression:issues`
- `pnpm check`
- `pnpm smoke:ui` (54 passed, 26 intentionally skipped)