### PR TITLE
Fix recurring tracker character continuity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 
 ### Fixed
 
+- Fixed recurring Roleplay characters losing tracker stats, custom fields, or their character-card avatar after being absent for several scenes. Character Tracker now receives card RPG configuration and bounded historical continuity, restores omitted prior values, and enforces card identity and artwork in normal and retry runs (#3606).
 - Fixed graceful shutdown completing before a file-native storage flush could drain newer writes queued during its active disk write, and made persistent close-time I/O failures reject shutdown instead of silently reporting success (#3602).
 - Fixed the Agent Editor custom-music folder picker omitting saved remote-admin and CSRF credentials by routing its privileged request through the shared API client (#3603).
 - Fixed dense Connections editor text flickering or shifting in Chromium browsers at the accent pulse's 500 ms update cadence. Editor reading surfaces now retain the selected base accent while headers and explicit accent chrome continue to pulse (#3599).

--- a/docs/agents/built-in-agents.md
+++ b/docs/agents/built-in-agents.md
@@ -100,6 +100,8 @@ Picks the best matching background image for the current scene from your uploade
 
 Tracks the characters present, plus their mood, actions, appearance, outfit, thoughts, and per-character stats such as HP. It can also create portrait images for new characters that have none.
 
+When a recurring character returns after leaving the scene, Character Tracker reuses their latest saved stats and custom fields for continuity. Characters backed by cards also receive their configured RPG pools and attributes as grounding, and always retain the card's avatar and crop. Automatically generated portraits remain limited to NPCs without a matching character card.
+
 - **Phase**: Post-Processing.
 - **Where it works**: Roleplay.
 - **Key settings**: **Add as Prompt Section** (on by default) and an optional **Auto-Generate NPC Avatars** setting with its own image connection picker.

--- a/packages/server/src/routes/generate.routes.ts
+++ b/packages/server/src/routes/generate.routes.ts
@@ -3032,7 +3032,9 @@ export async function generateRoutes(app: FastifyInstance) {
           agentSlice.filter((m: any) => m.role === "assistant"),
         );
         const characterTrackerHistory = resolvedAgents.some((agent) => agent.type === "character-tracker")
-          ? collectLatestTrackerCharacterHistory(await gameStateStore.getRecent(input.chatId))
+          ? collectLatestTrackerCharacterHistory(
+              await gameStateStore.getRecent(input.chatId, 100, latestGameState?.createdAt),
+            )
           : [];
         const visibleHistorySnapshot =
           latestGameState &&
@@ -7179,6 +7181,7 @@ export async function generateRoutes(app: FastifyInstance) {
                   trackerBaseGameStateSnapshot ??
                   (allowLatestGameStateFallback ? await gameStateStore.getLatest(input.chatId) : null);
                 const oldChars = parseJsonField<any[]>(previousCharacterSnapshot?.presentCharacters, []);
+                preserveTrackerCharacterUiFields(chars, oldChars);
                 preserveTrackerCharacterUiFields(chars, characterTrackerHistory);
                 const characterLockState = previousCharacterSnapshot
                   ? parseGameStateRow(previousCharacterSnapshot as Record<string, unknown>)

--- a/packages/server/src/routes/generate.routes.ts
+++ b/packages/server/src/routes/generate.routes.ts
@@ -184,6 +184,8 @@ import {
   buildUserMessageRegenerationPromptFromSource,
   buildLockedPlayerStatsArrayPatch,
   buildLockedPersonaTrackerPatch,
+  applyTrackerCharacterCardIdentity,
+  collectLatestTrackerCharacterHistory,
   createLocalSidecarGenerationConnection,
   extractImageAttachmentDataUrls,
   appendNonLeadingSystemMessagesToLastUser,
@@ -3029,6 +3031,9 @@ export async function generateRoutes(app: FastifyInstance) {
         const committedSnapshots = await gameStateStore.getCommittedForMessages(
           agentSlice.filter((m: any) => m.role === "assistant"),
         );
+        const characterTrackerHistory = resolvedAgents.some((agent) => agent.type === "character-tracker")
+          ? collectLatestTrackerCharacterHistory(await gameStateStore.getRecent(input.chatId))
+          : [];
         const visibleHistorySnapshot =
           latestGameState &&
           visibleGameStateAnchor &&
@@ -3075,6 +3080,7 @@ export async function generateRoutes(app: FastifyInstance) {
           mainResponse: null,
           gameState,
           characters: charInfo,
+          characterTrackerHistory: characterTrackerHistory as unknown as AgentContext["characterTrackerHistory"],
           persona:
             personaName !== "User"
               ? {
@@ -7173,7 +7179,7 @@ export async function generateRoutes(app: FastifyInstance) {
                   trackerBaseGameStateSnapshot ??
                   (allowLatestGameStateFallback ? await gameStateStore.getLatest(input.chatId) : null);
                 const oldChars = parseJsonField<any[]>(previousCharacterSnapshot?.presentCharacters, []);
-                preserveTrackerCharacterUiFields(chars, oldChars);
+                preserveTrackerCharacterUiFields(chars, characterTrackerHistory);
                 const characterLockState = previousCharacterSnapshot
                   ? parseGameStateRow(previousCharacterSnapshot as Record<string, unknown>)
                   : null;
@@ -7190,6 +7196,7 @@ export async function generateRoutes(app: FastifyInstance) {
                 // 2. Fall back to stored NPC avatars (per-chat generated/uploaded)
                 const NPC_AVATAR_DIR = join(DATA_DIR, "avatars", "npc");
                 const storedNpcAvatarByName = new Map<string, string>();
+                const cardCharacterIds = applyTrackerCharacterCardIdentity(chars, charInfo);
                 const gameNpcs = sanitizeGameNpcAvatarUrls((chatMeta.gameNpcs as GameNpc[]) ?? []);
                 if (gameNpcs !== chatMeta.gameNpcs) {
                   chatMeta.gameNpcs = gameNpcs;
@@ -7201,6 +7208,7 @@ export async function generateRoutes(app: FastifyInstance) {
 
                 for (const char of chars) {
                   if (isManualTrackerCharacterId(char.characterId)) continue;
+                  if (cardCharacterIds.has(String(char.characterId))) continue;
                   const name = (char.name as string) ?? "";
                   // Try matching against the chat's character cards (case-insensitive)
                   const matched = charInfo.find((c) => normalizeTextForMatch(c.name) === normalizeTextForMatch(name));

--- a/packages/server/src/routes/generate/generate-route-utils.ts
+++ b/packages/server/src/routes/generate/generate-route-utils.ts
@@ -1389,6 +1389,9 @@ function mergeTrackerStats(previous: unknown, next: unknown) {
   ];
 }
 
+const MAX_TRACKER_CHARACTER_HISTORY = 50;
+
+/** Collect the most recently seen distinct tracker characters within a prompt-safe bound. */
 export function collectLatestTrackerCharacterHistory(
   snapshots: Array<{ presentCharacters?: unknown }>,
 ): Array<Record<string, unknown>> {
@@ -1405,6 +1408,7 @@ export function collectLatestTrackerCharacterHistory(
       history.push(value);
       if (id) seenIds.add(id);
       if (name) seenNames.add(name);
+      if (history.length >= MAX_TRACKER_CHARACTER_HISTORY) return history;
     }
   }
   return history;

--- a/packages/server/src/routes/generate/generate-route-utils.ts
+++ b/packages/server/src/routes/generate/generate-route-utils.ts
@@ -1374,11 +1374,74 @@ export function isManualTrackerCharacterId(value: unknown): boolean {
   return typeof value === "string" && value.trim().startsWith("manual-");
 }
 
-function canUseManualTrackerNameFallback(character: Record<string, unknown>) {
-  const id = trackerCharacterIdKey(character);
-  if (!id || isManualTrackerCharacterId(id)) return true;
-  const name = trackerCharacterNameKey(character);
-  return !!name && id === name;
+function mergeTrackerStats(previous: unknown, next: unknown) {
+  if (!Array.isArray(previous) || previous.length === 0) return next;
+  const nextStats = Array.isArray(next) ? next : [];
+  const nextNames = new Set(
+    nextStats.map((stat) => normalizeTextForMatch(isPlainRecord(stat) ? stat.name : "")).filter(Boolean),
+  );
+  return [
+    ...nextStats,
+    ...previous.filter((stat) => {
+      const name = normalizeTextForMatch(isPlainRecord(stat) ? stat.name : "");
+      return name && !nextNames.has(name);
+    }),
+  ];
+}
+
+export function collectLatestTrackerCharacterHistory(
+  snapshots: Array<{ presentCharacters?: unknown }>,
+): Array<Record<string, unknown>> {
+  const history: Array<Record<string, unknown>> = [];
+  const seenIds = new Set<string>();
+  const seenNames = new Set<string>();
+  for (const snapshot of snapshots) {
+    const characters = parseJsonField<unknown[]>(snapshot.presentCharacters, []);
+    for (const value of characters) {
+      if (!isPlainRecord(value)) continue;
+      const id = trackerCharacterIdKey(value);
+      const name = trackerCharacterNameKey(value);
+      if ((id && seenIds.has(id)) || (!id && name && seenNames.has(name))) continue;
+      history.push(value);
+      if (id) seenIds.add(id);
+      if (name) seenNames.add(name);
+    }
+  }
+  return history;
+}
+
+type TrackerCharacterCardIdentity = {
+  id: string;
+  name: string;
+  avatarPath?: string | null;
+  avatarCrop?: unknown;
+};
+
+export function applyTrackerCharacterCardIdentity(
+  characters: Array<Record<string, unknown>>,
+  cards: TrackerCharacterCardIdentity[],
+): Set<string> {
+  const cardsById = new Map(cards.map((card) => [card.id.trim().toLowerCase(), card]));
+  const cardsByName = new Map<string, TrackerCharacterCardIdentity>();
+  const duplicateNames = new Set<string>();
+  for (const card of cards) {
+    const name = normalizeTextForMatch(card.name);
+    if (!name) continue;
+    if (cardsByName.has(name)) duplicateNames.add(name);
+    else cardsByName.set(name, card);
+  }
+  for (const name of duplicateNames) cardsByName.delete(name);
+
+  const matchedIds = new Set<string>();
+  for (const character of characters) {
+    const card = cardsById.get(trackerCharacterIdKey(character)) ?? cardsByName.get(trackerCharacterNameKey(character));
+    if (!card) continue;
+    character.characterId = card.id;
+    character.avatarPath = card.avatarPath ?? null;
+    character.avatarCrop = card.avatarCrop ?? null;
+    matchedIds.add(card.id);
+  }
+  return matchedIds;
 }
 
 export function preserveTrackerCharacterUiFields(
@@ -1386,16 +1449,14 @@ export function preserveTrackerCharacterUiFields(
   previousCharacters: Array<Record<string, unknown>>,
 ): void {
   const previousByKey = new Map<string, Record<string, unknown>>();
-  const previousManualByName = new Map<string, Record<string, unknown>>();
+  const previousByName = new Map<string, Record<string, unknown>>();
   const previousNameCounts = new Map<string, number>();
   for (const character of previousCharacters) {
     const key = trackerCharacterKey(character);
     if (key) previousByKey.set(key, character);
     const name = trackerCharacterNameKey(character);
     if (name) previousNameCounts.set(name, (previousNameCounts.get(name) ?? 0) + 1);
-    if (name && isManualTrackerCharacterId(character.characterId)) {
-      previousManualByName.set(name, character);
-    }
+    if (name) previousByName.set(name, character);
   }
 
   for (const character of nextCharacters) {
@@ -1403,9 +1464,7 @@ export function preserveTrackerCharacterUiFields(
     const name = trackerCharacterNameKey(character);
     const previous =
       (key ? previousByKey.get(key) : null) ??
-      (name && previousNameCounts.get(name) === 1 && canUseManualTrackerNameFallback(character)
-        ? previousManualByName.get(name)
-        : null);
+      (name && previousNameCounts.get(name) === 1 ? previousByName.get(name) : null);
     const previousPortraitFocusX = previous?.portraitFocusX;
     const previousPortraitFocusY = previous?.portraitFocusY;
     const previousPortraitZoom = previous?.portraitZoom;
@@ -1418,6 +1477,7 @@ export function preserveTrackerCharacterUiFields(
       // values over it so an omitted field cannot erase the user's configuration.
       character.customFields = { ...previousCustomFields, ...(nextCustomFields ?? {}) };
     }
+    character.stats = mergeTrackerStats(previous?.stats, character.stats);
     if (
       (typeof character.avatarPath !== "string" || !character.avatarPath.trim()) &&
       isNpcTrackerAvatarPath(previousAvatarPath)

--- a/packages/server/src/routes/generate/retry-agents-route.ts
+++ b/packages/server/src/routes/generate/retry-agents-route.ts
@@ -78,6 +78,7 @@ import {
   type IllustratorPromptReviewOverride,
 } from "../../services/image/illustrator-prompt-review.js";
 import { createGameStateStorage } from "../../services/storage/game-state.storage.js";
+import { normalizeCharacterRpgStats } from "../../services/generation/character-prompt-context.js";
 import { createLorebooksStorage } from "../../services/storage/lorebooks.storage.js";
 import { syncGameMapMetaPartyPosition } from "../../services/game/map-position.service.js";
 import {
@@ -611,7 +612,7 @@ async function buildRetryAgentContext(args: {
       postHistoryInstructions: cardPromptText(charData.post_history_instructions) || undefined,
       avatarPath: typeof charRow.avatarPath === "string" ? charRow.avatarPath : null,
       avatarCrop: extensions.avatarCrop ?? null,
-      rpgStats: extensions.rpgStats as AgentContext["characters"][number]["rpgStats"],
+      rpgStats: normalizeCharacterRpgStats(extensions.rpgStats),
     });
   }
 
@@ -2731,9 +2732,10 @@ async function applyRetryResultEffects(args: {
             previousCharacters = [];
           }
         }
+        preserveTrackerCharacterUiFields(presentCharacters, previousCharacters);
         preserveTrackerCharacterUiFields(
           presentCharacters,
-          agentContext.characterTrackerHistory?.length ? agentContext.characterTrackerHistory : previousCharacters,
+          (agentContext.characterTrackerHistory ?? []) as unknown as Array<Record<string, unknown>>,
         );
         applyTrackerCharacterCardIdentity(presentCharacters, agentContext.characters);
         const lockedCharacterPatch = applyTrackerFieldLocksToGameStatePatch(

--- a/packages/server/src/routes/generate/retry-agents-route.ts
+++ b/packages/server/src/routes/generate/retry-agents-route.ts
@@ -90,6 +90,8 @@ import { gameStateSnapshots as gameStateSnapshotsTable } from "../../db/schema/i
 import {
   buildLockedPlayerStatsArrayPatch,
   buildLockedPersonaTrackerPatch,
+  applyTrackerCharacterCardIdentity,
+  collectLatestTrackerCharacterHistory,
   isMessageHiddenFromAI,
   parseExtra,
   parseStoredGenerationParameters,
@@ -607,6 +609,9 @@ async function buildRetryAgentContext(args: {
       mesExample: cardPromptText(charData.mes_example) || undefined,
       firstMes: cardPromptText(charData.first_mes) || undefined,
       postHistoryInstructions: cardPromptText(charData.post_history_instructions) || undefined,
+      avatarPath: typeof charRow.avatarPath === "string" ? charRow.avatarPath : null,
+      avatarCrop: extensions.avatarCrop ?? null,
+      rpgStats: extensions.rpgStats as AgentContext["characters"][number]["rpgStats"],
     });
   }
 
@@ -674,6 +679,11 @@ async function buildRetryAgentContext(args: {
   const retryVisibleHistorySnapshot = retryVisibleAnchor
     ? await gameStateStore.getByChatAndMessage(chatId, retryVisibleAnchor.messageId, retryVisibleAnchor.swipeIndex)
     : null;
+  const characterTrackerHistory = resolvedAgentTypes.has("character-tracker")
+    ? collectLatestTrackerCharacterHistory(
+        await gameStateStore.getRecent(chatId, 100, retryVisibleHistorySnapshot?.createdAt),
+      )
+    : [];
   const retryOwnerSpatialProjection = retryVisibleAnchor
     ? ((await resolveOwnerSpatialProjection(db, chatId, { exactAnchor: retryVisibleAnchor })) ??
       (await resolveOwnerSpatialProjection(db, chatId, { throughMessageId: retryVisibleAnchor.messageId })))
@@ -730,6 +740,7 @@ async function buildRetryAgentContext(args: {
     mainResponse: resolvedLastAssistantContent,
     gameState: null,
     characters: charInfo,
+    characterTrackerHistory: characterTrackerHistory as unknown as AgentContext["characterTrackerHistory"],
     persona:
       personaContext.personaName !== "User"
         ? {
@@ -2720,7 +2731,11 @@ async function applyRetryResultEffects(args: {
             previousCharacters = [];
           }
         }
-        preserveTrackerCharacterUiFields(presentCharacters, previousCharacters);
+        preserveTrackerCharacterUiFields(
+          presentCharacters,
+          agentContext.characterTrackerHistory?.length ? agentContext.characterTrackerHistory : previousCharacters,
+        );
+        applyTrackerCharacterCardIdentity(presentCharacters, agentContext.characters);
         const lockedCharacterPatch = applyTrackerFieldLocksToGameStatePatch(
           { presentCharacters },
           previousSnapshot ? parseGameStateRow(previousSnapshot as Record<string, unknown>) : null,

--- a/packages/server/src/services/agents/agent-executor.ts
+++ b/packages/server/src/services/agents/agent-executor.ts
@@ -2158,7 +2158,7 @@ function buildLoreBlock(context: AgentContext): string {
         if (pools.length > 0) {
           parts.push(`Configured RPG pools: ${pools.map((pool) => `${pool.name}: ${pool.value}/${pool.max}`).join(", ")}`);
         }
-        if (char.rpgStats.attributes.length > 0) {
+        if (Array.isArray(char.rpgStats.attributes) && char.rpgStats.attributes.length > 0) {
           parts.push(
             `Configured RPG attributes: ${char.rpgStats.attributes
               .map((attribute) => `${attribute.name}: ${attribute.value}`)

--- a/packages/server/src/services/agents/agent-executor.ts
+++ b/packages/server/src/services/agents/agent-executor.ts
@@ -2153,6 +2153,19 @@ function buildLoreBlock(context: AgentContext): string {
       pushLoreField(parts, "Personality", char.personality, CHARACTER_LORE_FIELD_LIMIT);
       pushLoreField(parts, "Backstory", char.backstory, CHARACTER_LORE_FIELD_LIMIT);
       pushLoreField(parts, "Scenario", char.scenario, CHARACTER_LORE_FIELD_LIMIT);
+      if (char.rpgStats?.enabled) {
+        const pools = normalizeRpgStatPools(char.rpgStats);
+        if (pools.length > 0) {
+          parts.push(`Configured RPG pools: ${pools.map((pool) => `${pool.name}: ${pool.value}/${pool.max}`).join(", ")}`);
+        }
+        if (char.rpgStats.attributes.length > 0) {
+          parts.push(
+            `Configured RPG attributes: ${char.rpgStats.attributes
+              .map((attribute) => `${attribute.name}: ${attribute.value}`)
+              .join(", ")}`,
+          );
+        }
+      }
       parts.push(`</character>`);
     }
     parts.push(`</characters>`);
@@ -2279,6 +2292,15 @@ function buildAgentExtras(context: AgentContext, agentTypes: string[] = []): str
     parts.push(`<current_game_state>`);
     parts.push(JSON.stringify(compactGameStateForAgentContext(context.gameState, agentTypes)));
     parts.push(`</current_game_state>`);
+  }
+
+  if (agentTypes.includes("character-tracker") && context.characterTrackerHistory?.length) {
+    parts.push(`<character_tracker_history>`);
+    parts.push(
+      "Latest known state for recurring characters, including characters currently absent. Use it for continuity when someone returns; this list does not mean everyone is present now.",
+    );
+    parts.push(JSON.stringify(context.characterTrackerHistory));
+    parts.push(`</character_tracker_history>`);
   }
 
   const gameImageStylePrompt =

--- a/packages/server/src/services/generation/character-prompt-context.ts
+++ b/packages/server/src/services/generation/character-prompt-context.ts
@@ -1,6 +1,7 @@
 import {
   formatRpgStatsForPrompt,
   nameToXmlTag,
+  normalizeRpgStatPools,
   resolveMacros,
   type CharacterMacroProfile,
   type MacroContext,
@@ -43,6 +44,34 @@ type GenerationPromptMessage = {
 };
 
 type WrapFormat = "xml" | "markdown" | "none";
+
+/** Normalize persisted character-card RPG data before prompt consumers access it. */
+export function normalizeCharacterRpgStats(value: unknown): RPGStatsConfig | undefined {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return undefined;
+  const raw = value as Partial<RPGStatsConfig>;
+  if (raw.enabled !== true) return undefined;
+  const pools = normalizeRpgStatPools(raw as RPGStatsConfig);
+  const attributes = Array.isArray(raw.attributes)
+    ? raw.attributes
+        .filter(
+          (attribute): attribute is { name: string; value: number } =>
+            !!attribute &&
+            typeof attribute.name === "string" &&
+            !!attribute.name.trim() &&
+            typeof attribute.value === "number" &&
+            Number.isFinite(attribute.value),
+        )
+        .map((attribute) => ({ name: attribute.name.trim(), value: attribute.value }))
+    : [];
+  const hpPool = pools[0] ?? { value: 100, max: 100 };
+  return {
+    enabled: true,
+    attributes,
+    hp: { value: hpPool.value, max: hpPool.max },
+    pools,
+  };
+}
+
 type CharacterFallbackFieldKey =
   | "description"
   | "personality"
@@ -129,7 +158,7 @@ export async function loadCharacterPromptInfo({
       talkativeness: Math.max(0, Math.min(1, Number(charData.extensions?.talkativeness ?? 0.5))),
       avatarPath: (charRow.avatarPath as string) ?? null,
       avatarCrop: charData.extensions?.avatarCrop ?? null,
-      rpgStats: charData.extensions?.rpgStats as RPGStatsConfig | undefined,
+      rpgStats: normalizeCharacterRpgStats(charData.extensions?.rpgStats),
       convoDisplayName:
         typeof charData.extensions?.convoDisplayName === "string" ? charData.extensions.convoDisplayName : undefined,
       convoDisplayNameInCard: charData.extensions?.convoDisplayNameInCard === true,

--- a/packages/server/src/services/generation/character-prompt-context.ts
+++ b/packages/server/src/services/generation/character-prompt-context.ts
@@ -55,7 +55,8 @@ export function normalizeCharacterRpgStats(value: unknown): RPGStatsConfig | und
     ? raw.attributes
         .filter(
           (attribute): attribute is { name: string; value: number } =>
-            !!attribute &&
+            typeof attribute === "object" &&
+            attribute !== null &&
             typeof attribute.name === "string" &&
             !!attribute.name.trim() &&
             typeof attribute.value === "number" &&

--- a/packages/server/src/services/generation/character-prompt-context.ts
+++ b/packages/server/src/services/generation/character-prompt-context.ts
@@ -27,6 +27,7 @@ export type CharacterPromptInfo = {
   talkativeness: number;
   avatarPath: string | null;
   avatarCrop: unknown | null;
+  rpgStats?: RPGStatsConfig;
   /** Conversation-only: cosmetic display name + whether to declare it on the card. */
   convoDisplayName?: string;
   convoDisplayNameInCard?: boolean;
@@ -128,6 +129,7 @@ export async function loadCharacterPromptInfo({
       talkativeness: Math.max(0, Math.min(1, Number(charData.extensions?.talkativeness ?? 0.5))),
       avatarPath: (charRow.avatarPath as string) ?? null,
       avatarCrop: charData.extensions?.avatarCrop ?? null,
+      rpgStats: charData.extensions?.rpgStats as RPGStatsConfig | undefined,
       convoDisplayName:
         typeof charData.extensions?.convoDisplayName === "string" ? charData.extensions.convoDisplayName : undefined,
       convoDisplayNameInCard: charData.extensions?.convoDisplayNameInCard === true,

--- a/packages/server/src/services/storage/game-state.storage.ts
+++ b/packages/server/src/services/storage/game-state.storage.ts
@@ -149,8 +149,12 @@ export function createGameStateStorage(db: DB) {
         .from(gameStateSnapshots)
         .where(
           throughCreatedAt
-            ? and(eq(gameStateSnapshots.chatId, chatId), lte(gameStateSnapshots.createdAt, throughCreatedAt))
-            : eq(gameStateSnapshots.chatId, chatId),
+            ? and(
+                eq(gameStateSnapshots.chatId, chatId),
+                eq(gameStateSnapshots.committed, 1),
+                lte(gameStateSnapshots.createdAt, throughCreatedAt),
+              )
+            : and(eq(gameStateSnapshots.chatId, chatId), eq(gameStateSnapshots.committed, 1)),
         )
         .orderBy(desc(gameStateSnapshots.createdAt))
         .limit(Math.max(1, Math.min(500, limit)));

--- a/packages/server/src/services/storage/game-state.storage.ts
+++ b/packages/server/src/services/storage/game-state.storage.ts
@@ -1,7 +1,7 @@
 // ──────────────────────────────────────────────
 // Storage: Game State Snapshots
 // ──────────────────────────────────────────────
-import { eq, and, ne, desc, inArray } from "drizzle-orm";
+import { eq, and, ne, desc, inArray, lte } from "drizzle-orm";
 import type { DB } from "../../db/connection.js";
 import { gameStateSnapshots } from "../../db/schema/index.js";
 import { newId, now } from "../../utils/id-generator.js";
@@ -141,6 +141,19 @@ export function createGameStateStorage(db: DB) {
         .orderBy(desc(gameStateSnapshots.createdAt))
         .limit(1);
       return rows[0] ?? null;
+    },
+
+    async getRecent(chatId: string, limit = 100, throughCreatedAt?: string | null) {
+      return db
+        .select()
+        .from(gameStateSnapshots)
+        .where(
+          throughCreatedAt
+            ? and(eq(gameStateSnapshots.chatId, chatId), lte(gameStateSnapshots.createdAt, throughCreatedAt))
+            : eq(gameStateSnapshots.chatId, chatId),
+        )
+        .orderBy(desc(gameStateSnapshots.createdAt))
+        .limit(Math.max(1, Math.min(500, limit)));
     },
 
     async getById(id: string) {

--- a/packages/shared/src/types/agent.ts
+++ b/packages/shared/src/types/agent.ts
@@ -359,7 +359,12 @@ export interface AgentContext {
     mesExample?: string;
     firstMes?: string;
     postHistoryInstructions?: string;
+    avatarPath?: string | null;
+    avatarCrop?: unknown;
+    rpgStats?: import("./character.js").RPGStatsConfig;
   }>;
+  /** Latest known tracker entries, including recurring characters that are currently absent. */
+  characterTrackerHistory?: import("./game-state.js").PresentCharacter[];
   /** User persona info */
   persona: {
     name: string;

--- a/scripts/regressions/prompt.regression.ts
+++ b/scripts/regressions/prompt.regression.ts
@@ -106,8 +106,10 @@ import {
 import {
   appendNonLeadingSystemMessagesToLastUser,
   appendReadableAttachmentsToContent,
+  applyTrackerCharacterCardIdentity,
   buildGenerationGuideInstruction,
   appendSeparateAgentInjectionMessage,
+  collectLatestTrackerCharacterHistory,
   preserveTrackerCharacterUiFields,
   shouldEnableAgentsForGeneration,
   shouldInjectIdentityFallback,
@@ -2879,6 +2881,43 @@ Use HTML sparingly and diegetically. Do not replace normal prose/dialogue unless
         Goal: "Find the atlas",
       });
 
+      const recurringHistory = collectLatestTrackerCharacterHistory([
+        { presentCharacters: [] },
+        {
+          presentCharacters: JSON.stringify([
+            {
+              characterId: "mira-card",
+              name: "Mira",
+              customFields: { Goal: "Find the atlas" },
+              stats: [
+                { name: "HP", value: 72, max: 100, color: "#ef4444" },
+                { name: "MP", value: 31, max: 80, color: "#3b82f6" },
+              ],
+            },
+          ]),
+        },
+      ]);
+      const returningCharacters: Array<Record<string, unknown>> = [
+        {
+          characterId: "Mira",
+          name: "Mira",
+          stats: [{ name: "HP", value: 65, max: 100, color: "#ef4444" }],
+          avatarPath: "/api/avatars/npc/chat/mira.png",
+        },
+      ];
+      preserveTrackerCharacterUiFields(returningCharacters, recurringHistory);
+      const matchedCards = applyTrackerCharacterCardIdentity(returningCharacters, [
+        { id: "mira-card", name: "Mira", avatarPath: "/api/avatars/file/mira.png", avatarCrop: { zoom: 2, offsetX: 1, offsetY: 1 } },
+      ]);
+      assert.deepEqual(returningCharacters[0]?.stats, [
+        { name: "HP", value: 65, max: 100, color: "#ef4444" },
+        { name: "MP", value: 31, max: 80, color: "#3b82f6" },
+      ]);
+      assert.deepEqual(returningCharacters[0]?.customFields, { Goal: "Find the atlas" });
+      assert.equal(returningCharacters[0]?.characterId, "mira-card");
+      assert.equal(returningCharacters[0]?.avatarPath, "/api/avatars/file/mira.png");
+      assert.equal(matchedCards.has("mira-card"), true);
+
       assert.equal(resolveCharacterCustomFieldName("  ", "Goal"), "Goal");
       assert.equal(makeUniqueCharacterCustomFieldName({ "New Field": "", "new   field 2": "" }), "New Field 3");
 
@@ -2913,6 +2952,54 @@ Use HTML sparingly and diegetically. Do not replace normal prose/dialogue unless
       assert.doesNotMatch(promptBlock ?? "", /Duplicate mood/);
       assert.match(promptBlock ?? "", /Field 62: 62/);
       assert.doesNotMatch(promptBlock ?? "", /Field 63: 63/);
+    },
+  },
+  {
+    name: "character tracker receives card RPG configuration and recurring-character history",
+    async run() {
+      const { calls, provider } = makeCapturingProvider(`{"presentCharacters":[]}`);
+      const config = makeRegressionAgentConfig({
+        id: "builtin:character-tracker",
+        type: "character-tracker",
+        name: "Character Tracker",
+        promptTemplate: DEFAULT_AGENT_PROMPTS["character-tracker"] ?? "Track characters.",
+        settings: { resultType: "character_tracker_update" },
+      });
+      const context = makeRegressionAgentContext({
+        characters: [
+          {
+            id: "mira-card",
+            name: "Mira",
+            description: "A recurring alchemist.",
+            rpgStats: {
+              enabled: true,
+              hp: { value: 90, max: 100 },
+              pools: [{ name: "HP", value: 90, max: 100, color: "#ef4444" }],
+              attributes: [{ name: "INT", value: 18 }],
+            },
+          },
+        ],
+        characterTrackerHistory: [
+          {
+            characterId: "mira-card",
+            name: "Mira",
+            emoji: "⚗️",
+            mood: "Focused",
+            appearance: null,
+            outfit: null,
+            thoughts: null,
+            customFields: {},
+            stats: [{ name: "HP", value: 72, max: 100, color: "#ef4444" }],
+          },
+        ],
+      });
+      await executeAgent(config as any, context, provider as any, "regression-model");
+      const system = calls[0]?.[0]?.content ?? "";
+      assert.match(system, /Configured RPG pools: HP: 90\/100/u);
+      assert.match(system, /Configured RPG attributes: INT: 18/u);
+      assert.match(system, /<character_tracker_history>/u);
+      assert.match(system, /this list does not mean everyone is present now/u);
+      assert.match(system, /"value":72/u);
     },
   },
   {


### PR DESCRIPTION
## Why

Issue #3606 reports that recurring Character Tracker characters lose prior tracker data and can receive the wrong avatar after leaving and returning to a scene. Character-card RPG configuration was also absent from the tracker prompt, and retry generation did not share the normal route's identity handling.

## What changed

- Provide the tracker with bounded, newest-first character history so returning characters can recover omitted stats and custom fields.
- Keep freshly generated values authoritative while filling only missing named stats from history.
- Include character-card RPG pools and attributes in tracker context.
- Resolve card identity by stable ID first, then by an unambiguous normalized name, and enforce the card avatar/crop over NPC fallbacks.
- Apply the same continuity and identity rules to agent retries, bounded to the retry snapshot.
- Document the behavior and update the v2.2.2 changelog.

Closes #3606

## Validation

- [ ] Manually verify a character leaves a scene, returns later, and retains omitted tracker fields.
- [ ] Manually verify fresh tracker stat values override older history values.
- [ ] Manually verify character-card avatars remain authoritative in normal generation and retry.
- [ ] Manually verify card RPG pools and attributes appear in tracker behavior.
- [ ] Run `pnpm regression:prompt`.
- [ ] Run `pnpm check`.

Automated validation run locally: `pnpm regression:prompt`, `pnpm check`, focused server/shared lint.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Recurring roleplay characters now consistently retain tracker stats and custom fields, and keep their character-card avatar after multiple scenes and across retry updates.
  * Character-card identity and artwork now match reliably, and RPG settings/attributes are preserved.
  * Auto-generated portraits are still restricted to NPCs without a matching character card.

* **Documentation**
  * Expanded Character Tracker guidance to clarify recurring continuity, RPG settings, and avatar behavior.

* **Tests**
  * Added regression coverage for recurring history handling and RPG configuration in the Character Tracker prompt.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->