### PR TITLE
Validate folder API request contracts

### DIFF
--- a/packages/client/src/hooks/use-chat-folders.ts
+++ b/packages/client/src/hooks/use-chat-folders.ts
@@ -3,7 +3,14 @@
 // ──────────────────────────────────────────────
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { api } from "../lib/api-client";
-import type { ChatFolder } from "@marinara-engine/shared";
+import type {
+  ChatFolder,
+  CreateChatFolderInput,
+  MoveChatToFolderInput,
+  ReorderChatsInFolderInput,
+  ReorderFoldersInput,
+  UpdateFolderInput,
+} from "@marinara-engine/shared";
 import { chatKeys } from "./use-chats";
 
 export const folderKeys = {
@@ -23,7 +30,7 @@ export function useChatFolders() {
 export function useCreateFolder() {
   const qc = useQueryClient();
   return useMutation({
-    mutationFn: (data: { name: string; mode: string; color?: string }) => api.post<ChatFolder>("/chat-folders", data),
+    mutationFn: (data: CreateChatFolderInput) => api.post<ChatFolder>("/chat-folders", data),
     onSuccess: () => qc.invalidateQueries({ queryKey: folderKeys.list() }),
   });
 }
@@ -34,13 +41,7 @@ export function useUpdateFolder() {
     mutationFn: ({
       id,
       ...data
-    }: {
-      id: string;
-      name?: string;
-      color?: string;
-      sortOrder?: number;
-      collapsed?: boolean;
-    }) => api.patch<ChatFolder>(`/chat-folders/${id}`, data),
+    }: UpdateFolderInput & { id: string }) => api.patch<ChatFolder>(`/chat-folders/${id}`, data),
     onSuccess: () => qc.invalidateQueries({ queryKey: folderKeys.list() }),
   });
 }
@@ -59,7 +60,8 @@ export function useDeleteFolder() {
 export function useReorderFolders() {
   const qc = useQueryClient();
   return useMutation({
-    mutationFn: (orderedIds: string[]) => api.post("/chat-folders/reorder", { orderedIds }),
+    mutationFn: (orderedIds: ReorderFoldersInput["orderedIds"]) =>
+      api.post("/chat-folders/reorder", { orderedIds } satisfies ReorderFoldersInput),
     onSuccess: () => qc.invalidateQueries({ queryKey: folderKeys.list() }),
   });
 }
@@ -67,7 +69,7 @@ export function useReorderFolders() {
 export function useMoveChat() {
   const qc = useQueryClient();
   return useMutation({
-    mutationFn: (data: { chatId: string; folderId: string | null }) => api.post("/chat-folders/move-chat", data),
+    mutationFn: (data: MoveChatToFolderInput) => api.post("/chat-folders/move-chat", data),
     onSuccess: () => qc.invalidateQueries({ queryKey: chatKeys.list() }),
   });
 }
@@ -75,8 +77,7 @@ export function useMoveChat() {
 export function useReorderChats() {
   const qc = useQueryClient();
   return useMutation({
-    mutationFn: (data: { orderedChatIds: string[]; folderId: string | null }) =>
-      api.post("/chat-folders/reorder-chats", data),
+    mutationFn: (data: ReorderChatsInFolderInput) => api.post("/chat-folders/reorder-chats", data),
     onSuccess: () => qc.invalidateQueries({ queryKey: chatKeys.list() }),
   });
 }

--- a/packages/client/src/hooks/use-connection-folders.ts
+++ b/packages/client/src/hooks/use-connection-folders.ts
@@ -3,7 +3,14 @@
 // ──────────────────────────────────────────────
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { api } from "../lib/api-client";
-import type { ConnectionFolder } from "@marinara-engine/shared";
+import type {
+  ConnectionFolder,
+  CreateConnectionFolderInput,
+  MoveConnectionToFolderInput,
+  ReorderConnectionsInFolderInput,
+  ReorderFoldersInput,
+  UpdateFolderInput,
+} from "@marinara-engine/shared";
 import { connectionKeys } from "./use-connections";
 
 export const connectionFolderKeys = {
@@ -22,7 +29,7 @@ export function useConnectionFolders() {
 export function useCreateConnectionFolder() {
   const qc = useQueryClient();
   return useMutation({
-    mutationFn: (data: { name: string; color?: string }) => api.post<ConnectionFolder>("/connection-folders", data),
+    mutationFn: (data: CreateConnectionFolderInput) => api.post<ConnectionFolder>("/connection-folders", data),
     onSuccess: () => qc.invalidateQueries({ queryKey: connectionFolderKeys.list() }),
   });
 }
@@ -33,13 +40,7 @@ export function useUpdateConnectionFolder() {
     mutationFn: ({
       id,
       ...data
-    }: {
-      id: string;
-      name?: string;
-      color?: string;
-      sortOrder?: number;
-      collapsed?: boolean;
-    }) => api.patch<ConnectionFolder>(`/connection-folders/${id}`, data),
+    }: UpdateFolderInput & { id: string }) => api.patch<ConnectionFolder>(`/connection-folders/${id}`, data),
     onSuccess: () => qc.invalidateQueries({ queryKey: connectionFolderKeys.list() }),
   });
 }
@@ -58,7 +59,8 @@ export function useDeleteConnectionFolder() {
 export function useReorderConnectionFolders() {
   const qc = useQueryClient();
   return useMutation({
-    mutationFn: (orderedIds: string[]) => api.post("/connection-folders/reorder", { orderedIds }),
+    mutationFn: (orderedIds: ReorderFoldersInput["orderedIds"]) =>
+      api.post("/connection-folders/reorder", { orderedIds } satisfies ReorderFoldersInput),
     onSuccess: () => qc.invalidateQueries({ queryKey: connectionFolderKeys.list() }),
   });
 }
@@ -66,8 +68,7 @@ export function useReorderConnectionFolders() {
 export function useMoveConnection() {
   const qc = useQueryClient();
   return useMutation({
-    mutationFn: (data: { connectionId: string; folderId: string | null }) =>
-      api.post("/connection-folders/move-connection", data),
+    mutationFn: (data: MoveConnectionToFolderInput) => api.post("/connection-folders/move-connection", data),
     onSuccess: () => qc.invalidateQueries({ queryKey: connectionKeys.list() }),
   });
 }
@@ -75,8 +76,7 @@ export function useMoveConnection() {
 export function useReorderConnections() {
   const qc = useQueryClient();
   return useMutation({
-    mutationFn: (data: { orderedConnectionIds: string[]; folderId: string | null }) =>
-      api.post("/connection-folders/reorder-connections", data),
+    mutationFn: (data: ReorderConnectionsInFolderInput) => api.post("/connection-folders/reorder-connections", data),
     onSuccess: () => qc.invalidateQueries({ queryKey: connectionKeys.list() }),
   });
 }

--- a/packages/server/src/routes/chat-folders.routes.ts
+++ b/packages/server/src/routes/chat-folders.routes.ts
@@ -2,77 +2,24 @@
 // Routes: Chat Folders
 // ──────────────────────────────────────────────
 import type { FastifyInstance } from "fastify";
+import {
+  createChatFolderSchema,
+  moveChatToFolderSchema,
+  reorderChatsInFolderSchema,
+} from "@marinara-engine/shared";
 import { createChatFoldersStorage } from "../services/storage/chat-folders.storage.js";
 import { createChatsStorage } from "../services/storage/chats.storage.js";
+import { registerFolderCrudRoutes } from "./folder-routes.shared.js";
 
 export async function chatFoldersRoutes(app: FastifyInstance) {
   const storage = createChatFoldersStorage(app.db);
   const chatsStorage = createChatsStorage(app.db);
 
-  // ── List all folders ──
-  app.get("/", async (_req, reply) => {
-    const folders = await storage.list();
-    // Normalise collapsed from "true"/"false" string to boolean
-    return reply.send(
-      folders.map((f) => ({
-        ...f,
-        collapsed: f.collapsed === "true",
-      })),
-    );
-  });
-
-  // ── Create a folder ──
-  app.post<{
-    Body: { name: string; mode: string; color?: string };
-  }>("/", async (req, reply) => {
-    const { name, mode, color } = req.body;
-    if (!name?.trim()) return reply.status(400).send({ error: "Name is required" });
-    if (!["conversation", "roleplay", "visual_novel", "game"].includes(mode)) {
-      return reply.status(400).send({ error: "Invalid mode" });
-    }
-    const folder = await storage.create({ name: name.trim(), mode, color });
-    if (!folder) return reply.status(500).send({ error: "Failed to create folder" });
-    return reply.send({ ...folder, collapsed: folder.collapsed === "true" });
-  });
-
-  // ── Update a folder ──
-  app.patch<{
-    Params: { id: string };
-    Body: Partial<{ name: string; color: string; sortOrder: number; collapsed: boolean }>;
-  }>("/:id", async (req, reply) => {
-    const existing = await storage.getById(req.params.id);
-    if (!existing) return reply.status(404).send({ error: "Folder not found" });
-    const folder = await storage.update(req.params.id, req.body);
-    if (!folder) return reply.status(500).send({ error: "Failed to update folder" });
-    return reply.send({ ...folder, collapsed: folder.collapsed === "true" });
-  });
-
-  // ── Delete a folder (chats are moved to root) ──
-  app.delete<{
-    Params: { id: string };
-  }>("/:id", async (req, reply) => {
-    const existing = await storage.getById(req.params.id);
-    if (!existing) return reply.status(404).send({ error: "Folder not found" });
-    await storage.remove(req.params.id);
-    return reply.send({ ok: true });
-  });
-
-  // ── Reorder folders ──
-  app.post<{
-    Body: { orderedIds: string[] };
-  }>("/reorder", async (req, reply) => {
-    const { orderedIds } = req.body;
-    if (!Array.isArray(orderedIds)) return reply.status(400).send({ error: "orderedIds must be an array" });
-    await storage.reorder(orderedIds);
-    return reply.send({ ok: true });
-  });
+  registerFolderCrudRoutes(app, createChatFolderSchema, storage);
 
   // ── Move a chat into (or out of) a folder ──
-  app.post<{
-    Body: { chatId: string; folderId: string | null };
-  }>("/move-chat", async (req, reply) => {
-    const { chatId, folderId } = req.body;
-    if (!chatId) return reply.status(400).send({ error: "chatId is required" });
+  app.post("/move-chat", async (req, reply) => {
+    const { chatId, folderId } = moveChatToFolderSchema.parse(req.body);
     // Validate folder exists if non-null
     if (folderId) {
       const folder = await storage.getById(folderId);
@@ -85,11 +32,8 @@ export async function chatFoldersRoutes(app: FastifyInstance) {
   });
 
   // ── Reorder chats within a folder (or root) ──
-  app.post<{
-    Body: { orderedChatIds: string[]; folderId: string | null };
-  }>("/reorder-chats", async (req, reply) => {
-    const { orderedChatIds, folderId } = req.body;
-    if (!Array.isArray(orderedChatIds)) return reply.status(400).send({ error: "orderedChatIds must be an array" });
+  app.post("/reorder-chats", async (req, reply) => {
+    const { orderedChatIds, folderId } = reorderChatsInFolderSchema.parse(req.body);
     // Atomic: a partial failure mid-loop would leave chats with a mix of
     // old and new sort_order / folder_id values across siblings of the
     // same group. Chats-per-folder counts are O(dozens), well under the

--- a/packages/server/src/routes/connection-folders.routes.ts
+++ b/packages/server/src/routes/connection-folders.routes.ts
@@ -2,71 +2,22 @@
 // Routes: API Connection Folders
 // ──────────────────────────────────────────────
 import type { FastifyInstance } from "fastify";
+import {
+  createConnectionFolderSchema,
+  moveConnectionToFolderSchema,
+  reorderConnectionsInFolderSchema,
+} from "@marinara-engine/shared";
 import { createConnectionFoldersStorage } from "../services/storage/connection-folders.storage.js";
+import { registerFolderCrudRoutes } from "./folder-routes.shared.js";
 
 export async function connectionFoldersRoutes(app: FastifyInstance) {
   const storage = createConnectionFoldersStorage(app.db);
 
-  // ── List all folders ──
-  app.get("/", async (_req, reply) => {
-    const folders = await storage.list();
-    return reply.send(
-      folders.map((f) => ({
-        ...f,
-        collapsed: f.collapsed === "true",
-      })),
-    );
-  });
-
-  // ── Create a folder ──
-  app.post<{
-    Body: { name: string; color?: string };
-  }>("/", async (req, reply) => {
-    const { name, color } = req.body;
-    if (!name?.trim()) return reply.status(400).send({ error: "Name is required" });
-    const folder = await storage.create({ name: name.trim(), color });
-    if (!folder) return reply.status(500).send({ error: "Failed to create folder" });
-    return reply.send({ ...folder, collapsed: folder.collapsed === "true" });
-  });
-
-  // ── Update a folder ──
-  app.patch<{
-    Params: { id: string };
-    Body: Partial<{ name: string; color: string; sortOrder: number; collapsed: boolean }>;
-  }>("/:id", async (req, reply) => {
-    const existing = await storage.getById(req.params.id);
-    if (!existing) return reply.status(404).send({ error: "Folder not found" });
-    const folder = await storage.update(req.params.id, req.body);
-    if (!folder) return reply.status(500).send({ error: "Failed to update folder" });
-    return reply.send({ ...folder, collapsed: folder.collapsed === "true" });
-  });
-
-  // ── Delete a folder (connections are moved to root) ──
-  app.delete<{
-    Params: { id: string };
-  }>("/:id", async (req, reply) => {
-    const existing = await storage.getById(req.params.id);
-    if (!existing) return reply.status(404).send({ error: "Folder not found" });
-    await storage.remove(req.params.id);
-    return reply.send({ ok: true });
-  });
-
-  // ── Reorder folders ──
-  app.post<{
-    Body: { orderedIds: string[] };
-  }>("/reorder", async (req, reply) => {
-    const { orderedIds } = req.body;
-    if (!Array.isArray(orderedIds)) return reply.status(400).send({ error: "orderedIds must be an array" });
-    await storage.reorder(orderedIds);
-    return reply.send({ ok: true });
-  });
+  registerFolderCrudRoutes(app, createConnectionFolderSchema, storage);
 
   // ── Move a connection into (or out of) a folder ──
-  app.post<{
-    Body: { connectionId: string; folderId: string | null };
-  }>("/move-connection", async (req, reply) => {
-    const { connectionId, folderId } = req.body;
-    if (!connectionId) return reply.status(400).send({ error: "connectionId is required" });
+  app.post("/move-connection", async (req, reply) => {
+    const { connectionId, folderId } = moveConnectionToFolderSchema.parse(req.body);
     if (folderId) {
       const folder = await storage.getById(folderId);
       if (!folder) return reply.status(404).send({ error: "Folder not found" });
@@ -76,12 +27,8 @@ export async function connectionFoldersRoutes(app: FastifyInstance) {
   });
 
   // ── Reorder connections within a folder (or root) ──
-  app.post<{
-    Body: { orderedConnectionIds: string[]; folderId: string | null };
-  }>("/reorder-connections", async (req, reply) => {
-    const { orderedConnectionIds, folderId } = req.body;
-    if (!Array.isArray(orderedConnectionIds))
-      return reply.status(400).send({ error: "orderedConnectionIds must be an array" });
+  app.post("/reorder-connections", async (req, reply) => {
+    const { orderedConnectionIds, folderId } = reorderConnectionsInFolderSchema.parse(req.body);
     await storage.reorderConnections(orderedConnectionIds, folderId);
     return reply.send({ ok: true });
   });

--- a/packages/server/src/routes/folder-routes.shared.ts
+++ b/packages/server/src/routes/folder-routes.shared.ts
@@ -1,0 +1,70 @@
+import {
+  folderIdParamsSchema,
+  reorderFoldersSchema,
+  updateFolderSchema,
+  type UpdateFolderInput,
+} from "@marinara-engine/shared";
+import type { FastifyInstance } from "fastify";
+import type { ZodType } from "zod";
+
+type StoredFolder = {
+  collapsed: string;
+};
+
+type FolderCrudStorage<TCreate, TFolder extends StoredFolder> = {
+  list(): Promise<TFolder[]>;
+  getById(id: string): Promise<TFolder | null>;
+  create(input: TCreate): Promise<TFolder | null>;
+  update(id: string, input: UpdateFolderInput): Promise<TFolder | null>;
+  remove(id: string): Promise<void>;
+  reorder(orderedIds: string[]): Promise<void>;
+};
+
+function serializeFolder<TFolder extends StoredFolder>(folder: TFolder) {
+  return {
+    ...folder,
+    collapsed: folder.collapsed === "true",
+  };
+}
+
+export function registerFolderCrudRoutes<TCreate, TFolder extends StoredFolder>(
+  app: FastifyInstance,
+  createSchema: ZodType<TCreate>,
+  storage: FolderCrudStorage<TCreate, TFolder>,
+) {
+  app.get("/", async (_req, reply) => {
+    const folders = await storage.list();
+    return reply.send(folders.map(serializeFolder));
+  });
+
+  app.post("/", async (req, reply) => {
+    const input = createSchema.parse(req.body);
+    const folder = await storage.create(input);
+    if (!folder) return reply.status(500).send({ error: "Failed to create folder" });
+    return reply.send(serializeFolder(folder));
+  });
+
+  app.patch("/:id", async (req, reply) => {
+    const { id } = folderIdParamsSchema.parse(req.params);
+    const input = updateFolderSchema.parse(req.body);
+    const existing = await storage.getById(id);
+    if (!existing) return reply.status(404).send({ error: "Folder not found" });
+    const folder = await storage.update(id, input);
+    if (!folder) return reply.status(500).send({ error: "Failed to update folder" });
+    return reply.send(serializeFolder(folder));
+  });
+
+  app.delete("/:id", async (req, reply) => {
+    const { id } = folderIdParamsSchema.parse(req.params);
+    const existing = await storage.getById(id);
+    if (!existing) return reply.status(404).send({ error: "Folder not found" });
+    await storage.remove(id);
+    return reply.send({ ok: true });
+  });
+
+  app.post("/reorder", async (req, reply) => {
+    const { orderedIds } = reorderFoldersSchema.parse(req.body);
+    await storage.reorder(orderedIds);
+    return reply.send({ ok: true });
+  });
+}

--- a/packages/server/src/routes/folder-routes.shared.ts
+++ b/packages/server/src/routes/folder-routes.shared.ts
@@ -6,6 +6,7 @@ import {
 } from "@marinara-engine/shared";
 import type { FastifyInstance } from "fastify";
 import type { ZodType } from "zod";
+import { logger } from "../lib/logger.js";
 
 type StoredFolder = {
   collapsed: string;
@@ -40,7 +41,10 @@ export function registerFolderCrudRoutes<TCreate, TFolder extends StoredFolder>(
   app.post("/", async (req, reply) => {
     const input = createSchema.parse(req.body);
     const folder = await storage.create(input);
-    if (!folder) return reply.status(500).send({ error: "Failed to create folder" });
+    if (!folder) {
+      logger.error("Folder storage.create returned no folder");
+      return reply.status(500).send({ error: "Failed to create folder" });
+    }
     return reply.send(serializeFolder(folder));
   });
 
@@ -50,7 +54,10 @@ export function registerFolderCrudRoutes<TCreate, TFolder extends StoredFolder>(
     const existing = await storage.getById(id);
     if (!existing) return reply.status(404).send({ error: "Folder not found" });
     const folder = await storage.update(id, input);
-    if (!folder) return reply.status(500).send({ error: "Failed to update folder" });
+    if (!folder) {
+      logger.error("Folder storage.update returned no folder for %s", id);
+      return reply.status(500).send({ error: "Failed to update folder" });
+    }
     return reply.send(serializeFolder(folder));
   });
 

--- a/packages/server/src/services/storage/chat-folders.storage.ts
+++ b/packages/server/src/services/storage/chat-folders.storage.ts
@@ -2,6 +2,7 @@
 // Storage: Chat Folders
 // ──────────────────────────────────────────────
 import { eq } from "drizzle-orm";
+import type { CreateChatFolderInput, UpdateFolderInput } from "@marinara-engine/shared";
 import type { DB } from "../../db/connection.js";
 import { chatFolders, chats } from "../../db/schema/index.js";
 import { newId, now } from "../../utils/id-generator.js";
@@ -17,7 +18,7 @@ export function createChatFoldersStorage(db: DB) {
       return rows[0] ?? null;
     },
 
-    async create(input: { name: string; mode: string; color?: string }) {
+    async create(input: CreateChatFolderInput) {
       const id = newId();
       const timestamp = now();
       // Shift existing folders down and place new folder at the top.
@@ -25,16 +26,16 @@ export function createChatFoldersStorage(db: DB) {
       // half-shifted state with no new folder.
       await db.transaction(async (tx) => {
         const existing = await tx.select().from(chatFolders);
-        for (const f of existing) {
+        for (const folder of existing) {
           await tx
             .update(chatFolders)
-            .set({ sortOrder: f.sortOrder + 1 })
-            .where(eq(chatFolders.id, f.id));
+            .set({ sortOrder: folder.sortOrder + 1 })
+            .where(eq(chatFolders.id, folder.id));
         }
         await tx.insert(chatFolders).values({
           id,
           name: input.name,
-          mode: input.mode as "conversation" | "roleplay" | "visual_novel" | "game",
+          mode: input.mode,
           color: input.color ?? "",
           sortOrder: 0,
           collapsed: "false",
@@ -45,7 +46,7 @@ export function createChatFoldersStorage(db: DB) {
       return this.getById(id);
     },
 
-    async update(id: string, data: Partial<{ name: string; color: string; sortOrder: number; collapsed: boolean }>) {
+    async update(id: string, data: UpdateFolderInput) {
       await db
         .update(chatFolders)
         .set({
@@ -72,11 +73,11 @@ export function createChatFoldersStorage(db: DB) {
       // use-after-free noted in chats.storage.ts:984-986.
       const timestamp = now();
       await db.transaction(async (tx) => {
-        for (let i = 0; i < orderedIds.length; i++) {
+        for (let index = 0; index < orderedIds.length; index++) {
           await tx
             .update(chatFolders)
-            .set({ sortOrder: i, updatedAt: timestamp })
-            .where(eq(chatFolders.id, orderedIds[i]!));
+            .set({ sortOrder: index, updatedAt: timestamp })
+            .where(eq(chatFolders.id, orderedIds[index]!));
         }
       });
     },

--- a/packages/server/src/services/storage/connection-folders.storage.ts
+++ b/packages/server/src/services/storage/connection-folders.storage.ts
@@ -2,6 +2,7 @@
 // Storage: API Connection Folders
 // ──────────────────────────────────────────────
 import { eq } from "drizzle-orm";
+import type { CreateConnectionFolderInput, UpdateFolderInput } from "@marinara-engine/shared";
 import type { DB } from "../../db/connection.js";
 import { apiConnectionFolders, apiConnections } from "../../db/schema/index.js";
 import { newId, now } from "../../utils/id-generator.js";
@@ -17,7 +18,7 @@ export function createConnectionFoldersStorage(db: DB) {
       return rows[0] ?? null;
     },
 
-    async create(input: { name: string; color?: string }) {
+    async create(input: CreateConnectionFolderInput) {
       const id = newId();
       const timestamp = now();
       // Shift existing folders down and place new folder at the top.
@@ -25,11 +26,11 @@ export function createConnectionFoldersStorage(db: DB) {
       // half-shifted state with no new folder.
       await db.transaction(async (tx) => {
         const existing = await tx.select().from(apiConnectionFolders);
-        for (const f of existing) {
+        for (const folder of existing) {
           await tx
             .update(apiConnectionFolders)
-            .set({ sortOrder: f.sortOrder + 1 })
-            .where(eq(apiConnectionFolders.id, f.id));
+            .set({ sortOrder: folder.sortOrder + 1 })
+            .where(eq(apiConnectionFolders.id, folder.id));
         }
         await tx.insert(apiConnectionFolders).values({
           id,
@@ -44,7 +45,7 @@ export function createConnectionFoldersStorage(db: DB) {
       return this.getById(id);
     },
 
-    async update(id: string, data: Partial<{ name: string; color: string; sortOrder: number; collapsed: boolean }>) {
+    async update(id: string, data: UpdateFolderInput) {
       await db
         .update(apiConnectionFolders)
         .set({
@@ -69,11 +70,11 @@ export function createConnectionFoldersStorage(db: DB) {
       // would leave the folder list with mixed sort orders.
       const timestamp = now();
       await db.transaction(async (tx) => {
-        for (let i = 0; i < orderedIds.length; i++) {
+        for (let index = 0; index < orderedIds.length; index++) {
           await tx
             .update(apiConnectionFolders)
-            .set({ sortOrder: i, updatedAt: timestamp })
-            .where(eq(apiConnectionFolders.id, orderedIds[i]!));
+            .set({ sortOrder: index, updatedAt: timestamp })
+            .where(eq(apiConnectionFolders.id, orderedIds[index]!));
         }
       });
     },

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -51,6 +51,7 @@ export * from "./schemas/app-settings.schema.js";
 export * from "./schemas/conversation-call.schema.js";
 export * from "./schemas/noodle.schema.js";
 export * from "./schemas/spatial-context.schema.js";
+export * from "./schemas/folder.schema.js";
 
 // Constants
 export * from "./constants/providers.js";

--- a/packages/shared/src/schemas/folder.schema.ts
+++ b/packages/shared/src/schemas/folder.schema.ts
@@ -1,0 +1,69 @@
+import { z } from "zod";
+import { chatModeSchema } from "./chat.schema.js";
+
+const nonEmptyIdSchema = z.string().min(1);
+const createFolderNameSchema = z.string().trim().min(1);
+const updateFolderNameSchema = z.string().refine((name) => name.trim().length > 0, "Name is required");
+const folderColorSchema = z.string();
+
+const uniqueIdsSchema = z.array(nonEmptyIdSchema).superRefine((ids, ctx) => {
+  if (new Set(ids).size !== ids.length) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: "IDs must be unique",
+    });
+  }
+});
+
+export const folderIdParamsSchema = z.object({
+  id: nonEmptyIdSchema,
+});
+
+export const createConnectionFolderSchema = z.object({
+  name: createFolderNameSchema,
+  color: folderColorSchema.optional(),
+});
+
+export const createChatFolderSchema = createConnectionFolderSchema.extend({
+  mode: chatModeSchema,
+});
+
+export const updateFolderSchema = z.object({
+  name: updateFolderNameSchema.optional(),
+  color: folderColorSchema.optional(),
+  sortOrder: z.number().int().nonnegative().optional(),
+  collapsed: z.boolean().optional(),
+});
+
+export const reorderFoldersSchema = z.object({
+  orderedIds: uniqueIdsSchema,
+});
+
+export const moveChatToFolderSchema = z.object({
+  chatId: nonEmptyIdSchema,
+  folderId: nonEmptyIdSchema.nullable(),
+});
+
+export const reorderChatsInFolderSchema = z.object({
+  orderedChatIds: uniqueIdsSchema,
+  folderId: nonEmptyIdSchema.nullable(),
+});
+
+export const moveConnectionToFolderSchema = z.object({
+  connectionId: nonEmptyIdSchema,
+  folderId: nonEmptyIdSchema.nullable(),
+});
+
+export const reorderConnectionsInFolderSchema = z.object({
+  orderedConnectionIds: uniqueIdsSchema,
+  folderId: nonEmptyIdSchema.nullable(),
+});
+
+export type CreateConnectionFolderInput = z.infer<typeof createConnectionFolderSchema>;
+export type CreateChatFolderInput = z.infer<typeof createChatFolderSchema>;
+export type UpdateFolderInput = z.infer<typeof updateFolderSchema>;
+export type ReorderFoldersInput = z.infer<typeof reorderFoldersSchema>;
+export type MoveChatToFolderInput = z.infer<typeof moveChatToFolderSchema>;
+export type ReorderChatsInFolderInput = z.infer<typeof reorderChatsInFolderSchema>;
+export type MoveConnectionToFolderInput = z.infer<typeof moveConnectionToFolderSchema>;
+export type ReorderConnectionsInFolderInput = z.infer<typeof reorderConnectionsInFolderSchema>;

--- a/packages/shared/src/schemas/folder.schema.ts
+++ b/packages/shared/src/schemas/folder.schema.ts
@@ -3,7 +3,7 @@ import { chatModeSchema } from "./chat.schema.js";
 
 const nonEmptyIdSchema = z.string().min(1);
 const createFolderNameSchema = z.string().trim().min(1);
-const updateFolderNameSchema = z.string().refine((name) => name.trim().length > 0, "Name is required");
+const updateFolderNameSchema = z.string().trim().min(1, "Name is required");
 const folderColorSchema = z.string();
 
 const uniqueIdsSchema = z.array(nonEmptyIdSchema).superRefine((ids, ctx) => {


### PR DESCRIPTION
## Linked issue

Closes #3614

## Why this change

The chat-folder and connection-folder APIs duplicated their request contracts and only partially validated bodies at runtime. Malformed values could reach route or storage logic, including a numeric `name` reaching `.trim()` and becoming a `500`, while reorder and move payloads accepted unchecked values.

## What changed

- Added shared Zod schemas and inferred request types for folder create, update, move, and reorder operations.
- Added a narrow shared CRUD route registrar for behavior common to chat and connection folders.
- Kept entity-specific chat/connection movement and storage behavior separate.
- Reused the canonical request types in the client hooks and storage interfaces.
- Rejects empty IDs, invalid update values, and duplicate reorder IDs before storage writes.

## Validation

- [x] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [x] Ran the app, clicked through the changes manually
- [x] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [x] Above manual verification completed (describe below)
- [x] Read and followed `CONTRIBUTING.md`

`pnpm check` passed locally after commit, including TypeScript, ESLint, and production builds. The validation checkbox remains unchecked for human confirmation as required by the repository workflow.

### Manual verification notes

- In Google Chrome, created, renamed, collapsed, refreshed, and deleted temporary chat and connection folders; all observed API responses were `200`.
- Reordered chat folders and moved an existing chat into and back out of the temporary folder; its original folder and exact order were restored.
- Confirmed folder names and collapsed states survived a browser refresh.
- Confirmed no temporary folders remained and no browser console warnings/errors were recorded.
- A temporary Fastify proof also covered create/update compatibility, duplicate reorder rejection without state changes, missing-folder deletion, and response serialization; no test files were retained.
- Not manually verified: connection drag/reorder, populated-folder deletion, color changes (no current UI control), full process restart, Docker, mobile, or light-mode behavior.

## Docs and release impact

- [x] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Version/release files updated (only if this PR includes a version bump)

No documentation or release metadata changes are needed; this is an internal API validation/refactor change.

## UI evidence (if applicable)

Not applicable: no visual UI behavior or styling changed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added consistent validation for creating, updating, moving, and reordering chat and connection folders.
  * Prevented invalid or duplicate folder and item ordering submissions.
  * Standardized folder management behavior across chat and connection folders.

* **Bug Fixes**
  * Improved handling of invalid folder requests with clearer validation and error responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->