### PR TITLE
Fix lorebook vectors, sidebar folders, and Noodle vision fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,9 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 
 ### Fixed
 
+- Calibrated Lorebook semantic similarity against an unrelated-text baseline so embedding models whose raw cosine scores cluster around 0.97 no longer inject unrelated entries at every usable threshold or suppress relevant entries near 1.0 (#3627).
+- Replaced the nested presence animation used by expandable right-sidebar folders with an accessible grid transition, preventing Connections and Lorebooks folders from crashing the app shell with React hook-order errors (#3630).
+- Recognized OpenRouter's positive-form `No endpoints found that support image input` rejection as a non-vision model response, allowing Noodle timeline refreshes to retry once with the existing text-only prompt (#3631).
 - Moved the Game Assets manifest and rescan lifecycle out of Zustand into one React Query cache shared by Game surfaces and the Asset Browser, consolidated model/runtime and Whisper download SSE parsing, and made failed sidecar delete/unload actions propagate instead of silently succeeding (#3616).
 - Fixed Game Journal tabs refusing to scroll on desktop and iOS by giving the embedded journal a bounded flex viewport, and made replaced/generated NPC portraits refresh immediately even when the server reuses the same image URL (#3624).
 - Updated the Character Colors preview to render the active card's cropped avatar with an icon fallback, while keeping its sample narration free of formatting asterisks (#3622).

--- a/docs/lorebooks/semantic-search.md
+++ b/docs/lorebooks/semantic-search.md
@@ -53,12 +53,14 @@ The panel has three number settings.
 | Setting | What it does | Default | Range |
 |---|---|---|---|
 | **Query Messages** | How many recent chat messages to embed when searching this lorebook. | 10 | 0 to 100 |
-| **Score Threshold** | Minimum similarity an entry needs before it activates. Higher is stricter. | 0.3 | 0 to 1 |
+| **Score Threshold** | Minimum calibrated similarity an entry needs before it activates. Higher is stricter. | 0.3 | 0 to 1 |
 | **Vector Limit** | Most semantic matches this lorebook can add to one generation. | 10 | 1 to 100 |
 
 Set **Query Messages** to 0 to search against the full chat history instead of a recent window.
 
 **Score Threshold** controls how close the meaning must be. A low value like 0.2 lets more entries in but risks off-topic matches. A high value like 0.5 is stricter and matches only close meanings. Start at the default and adjust if you get too many or too few matches.
+
+Marinara calibrates this score against several unrelated neutral passages from the same embedding model. This removes the unusually high common cosine floor produced by some local and OpenAI-compatible embedding backends, where unrelated texts can otherwise all score around 0.95 or higher. The setting therefore remains useful across embedding models instead of requiring a model-specific cutoff near 1.0.
 
 **Vector Limit** caps semantic matches only. Your normal token budgets still apply on top of it.
 

--- a/e2e/core-flows.e2e.ts
+++ b/e2e/core-flows.e2e.ts
@@ -1935,7 +1935,7 @@ test("desktop Connections and Lorebooks folders expand without a React hook erro
             id: "folder-expansion-regression",
             scope: "lorebooks",
             name: folderName,
-            collapsed: false,
+            collapsed: true,
             sortOrder: 0,
             itemIds: [lorebookId],
             createdAt: now,

--- a/e2e/core-flows.e2e.ts
+++ b/e2e/core-flows.e2e.ts
@@ -1881,6 +1881,106 @@ test("desktop resource editors open beside their source sidebars", async ({ page
   }
 });
 
+test("desktop Connections and Lorebooks folders expand without a React hook error", async ({ page }, testInfo) => {
+  test.skip(testInfo.project.name.includes("mobile"), "Desktop right-sidebar folder regression.");
+  await page.setViewportSize({ width: 1360, height: 900 });
+
+  const suffix = Date.now().toString(36);
+  const connectionName = `Folder Connection ${suffix}`;
+  const connectionFolderName = `Connection Folder ${suffix}`;
+  const lorebookName = `Folder Lorebook ${suffix}`;
+  const lorebookFolderName = `Lorebook Folder ${suffix}`;
+  const connectionResponse = await page.request.post("/api/connections", {
+    data: { name: connectionName, provider: "custom" },
+  });
+  expect(connectionResponse.ok()).toBeTruthy();
+  const connection = (await connectionResponse.json()) as { id: string };
+  const connectionFolderResponse = await page.request.post("/api/connection-folders", {
+    data: { name: connectionFolderName },
+  });
+  expect(connectionFolderResponse.ok()).toBeTruthy();
+  const connectionFolder = (await connectionFolderResponse.json()) as { id: string };
+  expect(
+    (
+      await page.request.post("/api/connection-folders/move-connection", {
+        data: { connectionId: connection.id, folderId: connectionFolder.id },
+      })
+    ).ok(),
+  ).toBeTruthy();
+  expect(
+    (
+      await page.request.patch(`/api/connection-folders/${connectionFolder.id}`, {
+        data: { collapsed: true },
+      })
+    ).ok(),
+  ).toBeTruthy();
+
+  const lorebookResponse = await page.request.post("/api/lorebooks", {
+    data: {
+      name: lorebookName,
+      description: "Folder expansion regression fixture.",
+      category: "world",
+      enabled: true,
+    },
+  });
+  expect(lorebookResponse.ok()).toBeTruthy();
+  const lorebook = (await lorebookResponse.json()) as { id: string };
+  await page.addInitScript(
+    ({ folderName, lorebookId }) => {
+      const now = new Date().toISOString();
+      localStorage.setItem(
+        "marinara-library-folders-v1",
+        JSON.stringify([
+          {
+            id: "folder-expansion-regression",
+            scope: "lorebooks",
+            name: folderName,
+            collapsed: false,
+            sortOrder: 0,
+            itemIds: [lorebookId],
+            createdAt: now,
+            updatedAt: now,
+          },
+        ]),
+      );
+    },
+    { folderName: lorebookFolderName, lorebookId: lorebook.id },
+  );
+
+  const errors = collectUnexpectedErrors(page);
+  try {
+    await page.goto("/");
+
+    await page.locator('[data-tour="panel-connections"]').click();
+    const resourceSidebar = page.locator('[data-component="RightPanelDesktop"]');
+    const connectionFolderToggle = resourceSidebar.locator(
+      `[data-connection-folder-id="${connectionFolder.id}"] > [role="button"]`,
+    );
+    await expect(connectionFolderToggle).toBeVisible();
+    await connectionFolderToggle.click();
+    await expect(connectionFolderToggle).toHaveAttribute("aria-expanded", "true");
+    await expect(resourceSidebar.getByText(connectionName, { exact: true })).toBeVisible();
+
+    await page.locator('[data-tour="panel-lorebooks"]').click();
+    const lorebookFolderToggle = resourceSidebar.locator(
+      '[data-lorebook-folder-id="folder-expansion-regression"] > [role="button"]',
+    );
+    await expect(lorebookFolderToggle).toBeVisible();
+    await lorebookFolderToggle.click();
+    await expect(lorebookFolderToggle).toHaveAttribute("aria-expanded", "true");
+    await expect(resourceSidebar.getByText(lorebookName, { exact: true })).toBeVisible();
+    expect(errors).toEqual([]);
+  } finally {
+    if (!page.isClosed()) {
+      await Promise.all([
+        page.request.delete(`/api/connections/${connection.id}`),
+        page.request.delete(`/api/connection-folders/${connectionFolder.id}`),
+        page.request.delete(`/api/lorebooks/${lorebook.id}`),
+      ]);
+    }
+  }
+});
+
 test("Professor Mari chat fills the mobile home viewport and keeps its composer visible", async ({
   page,
 }, testInfo) => {

--- a/packages/client/src/components/lorebooks/LorebookEditor.tsx
+++ b/packages/client/src/components/lorebooks/LorebookEditor.tsx
@@ -2884,7 +2884,7 @@ function VectorizeSection({
         <label className="space-y-1 text-[0.625rem] font-medium text-[var(--muted-foreground)]">
           <span className="flex items-center gap-1">
             Score Threshold
-            <HelpTooltip text="Minimum semantic similarity required before a vectorized entry activates. Higher values are stricter." />
+            <HelpTooltip text="Minimum calibrated semantic similarity required before a vectorized entry activates. Higher values are stricter." />
           </span>
           <input
             type="number"

--- a/packages/client/src/components/ui/SmoothFolderContent.tsx
+++ b/packages/client/src/components/ui/SmoothFolderContent.tsx
@@ -1,4 +1,3 @@
-import { AnimatePresence, motion, useReducedMotion } from "framer-motion";
 import type { ReactNode } from "react";
 import { cn } from "../../lib/utils";
 
@@ -9,28 +8,19 @@ interface SmoothFolderContentProps {
   innerClassName?: string;
 }
 
-const folderContentTransition = {
-  height: { duration: 0.2, ease: [0.25, 0.8, 0.25, 1] },
-  opacity: { duration: 0.14, ease: "easeOut" },
-} as const;
-
 export function SmoothFolderContent({ open, children, className, innerClassName }: SmoothFolderContentProps) {
-  const reduceMotion = useReducedMotion();
-
   return (
-    <AnimatePresence initial={false}>
-      {open && (
-        <motion.div
-          key="folder-content"
-          initial={reduceMotion ? false : { height: 0, opacity: 0 }}
-          animate={reduceMotion ? { opacity: 1 } : { height: "auto", opacity: 1 }}
-          exit={reduceMotion ? { opacity: 0 } : { height: 0, opacity: 0 }}
-          transition={reduceMotion ? { duration: 0.01 } : folderContentTransition}
-          className={cn("overflow-hidden will-change-[height,opacity]", className)}
-        >
-          <div className={innerClassName}>{children}</div>
-        </motion.div>
+    <div
+      aria-hidden={!open}
+      inert={!open}
+      className={cn(
+        "grid overflow-hidden transition-[grid-template-rows,opacity] duration-200 ease-out motion-reduce:transition-none",
+        open ? "grid-rows-[1fr] opacity-100" : "pointer-events-none grid-rows-[0fr] opacity-0",
       )}
-    </AnimatePresence>
+    >
+      <div className={cn("min-h-0 overflow-hidden", className)}>
+        <div className={innerClassName}>{children}</div>
+      </div>
+    </div>
   );
 }

--- a/packages/server/src/routes/generate.routes.ts
+++ b/packages/server/src/routes/generate.routes.ts
@@ -1715,6 +1715,7 @@ export async function generateRoutes(app: FastifyInstance) {
         const _tEmbed = Date.now();
         let chatContextEmbedding: number[] | null = null;
         let lorebookSemanticEmbeddingsById: Map<string, number[] | null> | undefined;
+        let lorebookSemanticSimilarityBaseline = 0;
         const knowledgeRouterActivatedLorebookEntryIds = new Set<string>();
         const knowledgeRouterExcludedLorebookEntryIds = new Set<string>();
         let knowledgeRouterActivationPassCompleted = false;
@@ -1745,6 +1746,7 @@ export async function generateRoutes(app: FastifyInstance) {
             });
             chatContextEmbedding = semanticEmbeddings.defaultEmbedding;
             lorebookSemanticEmbeddingsById = semanticEmbeddings.embeddingsByLorebookId;
+            lorebookSemanticSimilarityBaseline = semanticEmbeddings.similarityBaseline;
           }
         } catch {
           // Embedding generation is optional — if it fails, fall back to keyword-only matching
@@ -1825,6 +1827,7 @@ export async function generateRoutes(app: FastifyInstance) {
             lorebookTokenBudget: resolveLorebookTokenBudget(chatMeta),
             chatEmbedding: chatContextEmbedding,
             semanticEmbeddingsByLorebookId: lorebookSemanticEmbeddingsById,
+            semanticSimilarityBaseline: lorebookSemanticSimilarityBaseline,
             entryStateOverrides:
               (chatMeta.entryStateOverrides as Record<string, { ephemeral?: number | null; enabled?: boolean }>) ??
               undefined,
@@ -2274,6 +2277,7 @@ export async function generateRoutes(app: FastifyInstance) {
               tokenBudget: resolveLorebookTokenBudget(chatMeta),
               chatEmbedding: chatContextEmbedding,
               semanticEmbeddingsByLorebookId: lorebookSemanticEmbeddingsById,
+              semanticSimilarityBaseline: lorebookSemanticSimilarityBaseline,
               entryStateOverrides:
                 (chatMeta.entryStateOverrides as Record<string, { ephemeral?: number | null; enabled?: boolean }>) ??
                 undefined,
@@ -2340,6 +2344,7 @@ export async function generateRoutes(app: FastifyInstance) {
             tokenBudget: resolveLorebookTokenBudget(chatMeta),
             chatEmbedding: chatContextEmbedding,
             semanticEmbeddingsByLorebookId: lorebookSemanticEmbeddingsById,
+            semanticSimilarityBaseline: lorebookSemanticSimilarityBaseline,
             entryStateOverrides:
               (chatMeta.entryStateOverrides as Record<string, { ephemeral?: number | null; enabled?: boolean }>) ??
               undefined,
@@ -2698,6 +2703,7 @@ export async function generateRoutes(app: FastifyInstance) {
                 tokenBudget: resolveLorebookTokenBudget(chatMeta),
                 chatEmbedding: chatContextEmbedding,
                 semanticEmbeddingsByLorebookId: lorebookSemanticEmbeddingsById,
+                semanticSimilarityBaseline: lorebookSemanticSimilarityBaseline,
                 entryStateOverrides:
                   (chatMeta.entryStateOverrides as Record<string, { ephemeral?: number | null; enabled?: boolean }>) ??
                   undefined,

--- a/packages/server/src/routes/lorebooks.routes.ts
+++ b/packages/server/src/routes/lorebooks.routes.ts
@@ -1056,6 +1056,7 @@ export async function lorebooksRoutes(app: FastifyInstance) {
     };
     let chatEmbedding: number[] | null = null;
     let semanticEmbeddingsByLorebookId: Map<string, number[] | null> | undefined;
+    let semanticSimilarityBaseline = 0;
     try {
       const activeEntries = (await storage.listActiveEntries(lorebookScopeFilters)) as unknown as LorebookEntry[];
       if (activeEntries.some((entry) => Array.isArray(entry.embedding) && entry.embedding.length > 0)) {
@@ -1073,6 +1074,7 @@ export async function lorebooksRoutes(app: FastifyInstance) {
         });
         chatEmbedding = semanticEmbeddings.defaultEmbedding;
         semanticEmbeddingsByLorebookId = semanticEmbeddings.embeddingsByLorebookId;
+        semanticSimilarityBaseline = semanticEmbeddings.similarityBaseline;
       }
     } catch (err) {
       logger.debug(err, "[lorebooks] Semantic scan preview failed; falling back to keyword-only preview");
@@ -1089,6 +1091,7 @@ export async function lorebooksRoutes(app: FastifyInstance) {
       excludedSourceAgentIds: lorebookScopeExclusions.excludedSourceAgentIds,
       chatEmbedding,
       semanticEmbeddingsByLorebookId,
+      semanticSimilarityBaseline,
       forcedEntryIds:
         chat?.mode === "conversation" ? [] : (ownerSpatialProjection?.lorebookEntryIds ?? []),
       tokenBudget: typeof chatMeta.lorebookTokenBudget === "number" ? chatMeta.lorebookTokenBudget : undefined,

--- a/packages/server/src/services/lorebook/embeddings.ts
+++ b/packages/server/src/services/lorebook/embeddings.ts
@@ -85,16 +85,19 @@ export function cosineSimilarity(a: number[], b: number[]): number {
  */
 export function lorebookSimilarityBaseline(embeddings: number[][]): number {
   if (embeddings.length < 2) return 0;
-  const similarities: number[] = [];
+  let similaritySum = 0;
+  let similarityCount = 0;
   for (let left = 0; left < embeddings.length; left += 1) {
     for (let right = left + 1; right < embeddings.length; right += 1) {
       const similarity = cosineSimilarity(embeddings[left]!, embeddings[right]!);
-      if (Number.isFinite(similarity)) similarities.push(similarity);
+      if (Number.isFinite(similarity)) {
+        similaritySum += similarity;
+        similarityCount += 1;
+      }
     }
   }
-  if (similarities.length === 0) return 0;
-  const average = similarities.reduce((sum, similarity) => sum + similarity, 0) / similarities.length;
-  return Math.max(0, Math.min(0.999, average));
+  if (similarityCount === 0) return 0;
+  return Math.max(0, Math.min(0.999, similaritySum / similarityCount));
 }
 
 export function calibrateLorebookSimilarity(similarity: number, baseline = 0): number {

--- a/packages/server/src/services/lorebook/embeddings.ts
+++ b/packages/server/src/services/lorebook/embeddings.ts
@@ -7,6 +7,11 @@ import { createLorebooksStorage } from "../storage/lorebooks.storage.js";
 
 const DEFAULT_SEMANTIC_TOP_K = 40;
 const DEFAULT_WARMUP_BATCH_SIZE = 32;
+const SEMANTIC_CALIBRATION_TEXTS = [
+  "A recipe explains how to bake a loaf of bread.",
+  "A spacecraft studies distant galaxies and nebulae.",
+  "A city council reviews municipal zoning regulations.",
+] as const;
 
 export type LorebookEmbeddingOptions = MemoryRecallEmbeddingOptions;
 
@@ -71,6 +76,32 @@ export function cosineSimilarity(a: number[], b: number[]): number {
   }
   const denom = Math.sqrt(magA) * Math.sqrt(magB);
   return denom === 0 ? 0 : dot / denom;
+}
+
+/**
+ * Estimate the model's common cosine floor from deliberately unrelated text.
+ * Some embedding backends produce raw cosine scores around 0.95+ for nearly
+ * every pair; subtracting that floor keeps the user-facing 0-1 threshold useful.
+ */
+export function lorebookSimilarityBaseline(embeddings: number[][]): number {
+  if (embeddings.length < 2) return 0;
+  const similarities: number[] = [];
+  for (let left = 0; left < embeddings.length; left += 1) {
+    for (let right = left + 1; right < embeddings.length; right += 1) {
+      const similarity = cosineSimilarity(embeddings[left]!, embeddings[right]!);
+      if (Number.isFinite(similarity)) similarities.push(similarity);
+    }
+  }
+  if (similarities.length === 0) return 0;
+  const average = similarities.reduce((sum, similarity) => sum + similarity, 0) / similarities.length;
+  return Math.max(0, Math.min(0.999, average));
+}
+
+export function calibrateLorebookSimilarity(similarity: number, baseline = 0): number {
+  if (!Number.isFinite(similarity)) return 0;
+  const safeBaseline = Number.isFinite(baseline) ? Math.max(0, Math.min(0.999, baseline)) : 0;
+  const calibrated = (Math.max(-1, Math.min(1, similarity)) - safeBaseline) / (1 - safeBaseline);
+  return Math.max(0, Math.min(1, calibrated));
 }
 
 function normalizePositiveInteger(value: unknown, fallback: number): number {
@@ -148,9 +179,10 @@ export async function semanticShortlistLorebookEntries(
   const queryText = query.trim();
   if (!queryText) return null;
 
-  const queryEmbeddings = await embedLorebookTexts([queryText], options);
+  const queryEmbeddings = await embedLorebookTexts([queryText, ...SEMANTIC_CALIBRATION_TEXTS], options);
   const queryEmbedding = queryEmbeddings[0];
   if (!queryEmbedding || queryEmbedding.length === 0) return null;
+  const similarityBaseline = lorebookSimilarityBaseline(queryEmbeddings.slice(1));
 
   let dimensionMismatchLogged = false;
   const matches = entries
@@ -168,7 +200,10 @@ export async function semanticShortlistLorebookEntries(
         }
         return null;
       }
-      return { entry, similarity: cosineSimilarity(queryEmbedding, embedding) };
+      return {
+        entry,
+        similarity: calibrateLorebookSimilarity(cosineSimilarity(queryEmbedding, embedding), similarityBaseline),
+      };
     })
     .filter((match): match is SemanticLorebookMatch => match !== null)
     .sort((a, b) => b.similarity - a.similarity)
@@ -188,7 +223,11 @@ export async function buildLorebookSemanticEmbeddingsById({
   scanMessages: Array<{ content: string }>;
   embeddingSource: MemoryRecallEmbeddingOptions["embeddingSource"];
   signal?: AbortSignal;
-}): Promise<{ defaultEmbedding: number[] | null; embeddingsByLorebookId?: Map<string, number[] | null> }> {
+}): Promise<{
+  defaultEmbedding: number[] | null;
+  embeddingsByLorebookId?: Map<string, number[] | null>;
+  similarityBaseline: number;
+}> {
   const lorebookIdsWithVectors = new Set(
     entries
       .filter(
@@ -196,24 +235,30 @@ export async function buildLorebookSemanticEmbeddingsById({
       )
       .map((entry) => entry.lorebookId),
   );
-  if (lorebookIdsWithVectors.size === 0) return { defaultEmbedding: null };
+  if (lorebookIdsWithVectors.size === 0) return { defaultEmbedding: null, similarityBaseline: 0 };
 
   const vectorLorebooks = lorebooks.filter(
     (lorebook) => !lorebook.excludeFromVectorization && lorebookIdsWithVectors.has(lorebook.id),
   );
-  if (vectorLorebooks.length === 0) return { defaultEmbedding: null };
+  if (vectorLorebooks.length === 0) return { defaultEmbedding: null, similarityBaseline: 0 };
 
-  const depths = Array.from(new Set(vectorLorebooks.map((lorebook) => normalizeLorebookVectorQueryDepth(lorebook.vectorQueryDepth))));
+  const depths = Array.from(
+    new Set(vectorLorebooks.map((lorebook) => normalizeLorebookVectorQueryDepth(lorebook.vectorQueryDepth))),
+  );
   const embeddingsByDepth = new Map<number, number[] | null>();
+  const queryTextsByDepth = new Map(
+    depths.map((depth) => [depth, selectLorebookVectorQueryText(scanMessages, depth)] as const),
+  );
+  const populatedDepths = depths.filter((depth) => queryTextsByDepth.get(depth));
+  const queryAndCalibrationEmbeddings = await embedMemoryRecallTexts(
+    [...populatedDepths.map((depth) => queryTextsByDepth.get(depth)!), ...SEMANTIC_CALIBRATION_TEXTS],
+    { embeddingSource, signal },
+  );
   for (const depth of depths) {
-    const queryText = selectLorebookVectorQueryText(scanMessages, depth);
-    if (!queryText) {
-      embeddingsByDepth.set(depth, null);
-      continue;
-    }
-    const embeddings = await embedMemoryRecallTexts([queryText], { embeddingSource, signal });
-    embeddingsByDepth.set(depth, embeddings[0] ?? null);
+    const queryIndex = populatedDepths.indexOf(depth);
+    embeddingsByDepth.set(depth, queryIndex >= 0 ? (queryAndCalibrationEmbeddings[queryIndex] ?? null) : null);
   }
+  const similarityBaseline = lorebookSimilarityBaseline(queryAndCalibrationEmbeddings.slice(populatedDepths.length));
 
   const embeddingsByLorebookId = new Map<string, number[] | null>();
   for (const lorebook of vectorLorebooks) {
@@ -229,5 +274,6 @@ export async function buildLorebookSemanticEmbeddingsById({
       Array.from(embeddingsByDepth.values()).find((embedding) => embedding && embedding.length > 0) ??
       null,
     embeddingsByLorebookId,
+    similarityBaseline,
   };
 }

--- a/packages/server/src/services/lorebook/index.ts
+++ b/packages/server/src/services/lorebook/index.ts
@@ -952,6 +952,8 @@ export async function processLorebooks(
     semanticEmbeddingsByLorebookId?: ReadonlyMap<string, number[] | null>;
     /** Cosine similarity threshold for semantic matching (0-1, default 0.3). */
     semanticThreshold?: number;
+    /** Unrelated-text cosine floor used to calibrate clustered embedding models. */
+    semanticSimilarityBaseline?: number;
     /** Per-chat entry state overrides (from chat metadata). When provided, ephemeral
      *  countdown is tracked here instead of modifying the global entry row. */
     entryStateOverrides?: Record<string, { ephemeral?: number | null; enabled?: boolean }>;
@@ -1072,6 +1074,7 @@ export async function processLorebooks(
     gameState: gameState ?? null,
     chatEmbedding: options?.chatEmbedding ?? null,
     semanticThreshold: options?.semanticThreshold,
+    semanticSimilarityBaseline: options?.semanticSimilarityBaseline,
     semanticEmbeddingsByLorebookId: options?.semanticEmbeddingsByLorebookId,
     semanticThresholdByLorebookId: new Map(
       effectiveLorebooks.map((book) => [book.id, normalizeLorebookVectorScoreThreshold(book.vectorScoreThreshold)]),

--- a/packages/server/src/services/lorebook/keyword-scanner.ts
+++ b/packages/server/src/services/lorebook/keyword-scanner.ts
@@ -13,6 +13,7 @@ import type {
   LorebookSchedule,
 } from "@marinara-engine/shared";
 import { LIMITS, testPrimaryKeys, testSecondaryKeys } from "@marinara-engine/shared";
+import { calibrateLorebookSimilarity } from "./embeddings.js";
 import { vmRegexExecutor } from "./regex-timeout.js";
 
 /** Compute cosine similarity between two vectors. Returns 0 for empty/mismatched vectors. */
@@ -416,6 +417,8 @@ export interface ScanOptions {
   semanticEmbeddingsByLorebookId?: ReadonlyMap<string, number[] | null>;
   /** Cosine similarity threshold for semantic matching (0-1, default 0.3). */
   semanticThreshold?: number;
+  /** Unrelated-text cosine floor used to calibrate clustered embedding models. */
+  semanticSimilarityBaseline?: number;
   /** Per-lorebook cosine similarity thresholds for semantic matching. */
   semanticThresholdByLorebookId?: ReadonlyMap<string, number>;
   /** Per-lorebook maximum semantic matches. */
@@ -457,6 +460,7 @@ export function scanForActivatedEntries(
     chatEmbedding = null,
     semanticEmbeddingsByLorebookId = new Map<string, number[] | null>(),
     semanticThreshold = 0.3,
+    semanticSimilarityBaseline = 0,
     semanticThresholdByLorebookId = new Map<string, number>(),
     semanticMaxMatchesByLorebookId = new Map<string, number>(),
     activeCharacterIds = [],
@@ -606,7 +610,10 @@ export function scanForActivatedEntries(
       if (!passesActivationGate(entry, timingState, filterContext, gameState, ignoreTiming)) continue;
 
       const threshold = semanticThresholdByLorebookId.get(entry.lorebookId) ?? semanticThreshold;
-      const similarity = cosineSimilarity(queryEmbedding, entry.embedding);
+      const similarity = calibrateLorebookSimilarity(
+        cosineSimilarity(queryEmbedding, entry.embedding),
+        semanticSimilarityBaseline,
+      );
       if (similarity >= threshold) {
         const entryScanText = getEntryScanText(entry);
         const matchOptions = {

--- a/packages/server/src/services/noodle/noodle-vision.ts
+++ b/packages/server/src/services/noodle/noodle-vision.ts
@@ -156,6 +156,7 @@ export function isUnsupportedNoodleVisionInputError(error: unknown): boolean {
     /(?:not supported|unsupported|does not support|invalid content type).{0,100}(?:image|vision|multimodal|image_url)/i.test(
       message,
     ) ||
+    /no (?:available )?endpoints? found.{0,80}(?:image|vision|multimodal|image_url)/i.test(message) ||
     /(?:expected|must be).{0,60}(?:content|message).{0,60}(?:string|text)|(?:expected|must be).{0,60}(?:string|text).{0,60}(?:content|message)|(?:content|message).{0,60}(?:expected|must be).{0,60}(?:string|text)/i.test(message)
   );
 }

--- a/packages/server/src/services/prompt/assembler.ts
+++ b/packages/server/src/services/prompt/assembler.ts
@@ -170,6 +170,8 @@ export interface AssemblerInput {
   chatEmbedding?: number[] | null;
   /** Per-lorebook pre-computed embeddings for semantic lorebook matching. */
   semanticEmbeddingsByLorebookId?: ReadonlyMap<string, number[] | null>;
+  /** Unrelated-text cosine floor used to calibrate clustered embedding models. */
+  semanticSimilarityBaseline?: number;
   /** Per-chat ephemeral state overrides for lorebook entries (from chat metadata). */
   entryStateOverrides?: Record<string, { ephemeral?: number | null; enabled?: boolean }>;
   /** Per-chat sticky/cooldown/delay timing state for lorebook entries. */
@@ -345,6 +347,7 @@ export async function assemblePrompt(input: AssemblerInput): Promise<AssemblerOu
     disableLorebooks: input.disableLorebooks === true,
     chatEmbedding: input.chatEmbedding ?? null,
     semanticEmbeddingsByLorebookId: input.semanticEmbeddingsByLorebookId,
+    semanticSimilarityBaseline: input.semanticSimilarityBaseline,
     entryStateOverrides: input.entryStateOverrides,
     entryTimingStates: input.entryTimingStates,
     lorebookTokenBudget: input.lorebookTokenBudget,

--- a/packages/server/src/services/prompt/marker-expander.ts
+++ b/packages/server/src/services/prompt/marker-expander.ts
@@ -62,6 +62,8 @@ export interface MarkerContext {
   chatEmbedding?: number[] | null;
   /** Per-lorebook pre-computed embeddings for semantic lorebook matching. */
   semanticEmbeddingsByLorebookId?: ReadonlyMap<string, number[] | null>;
+  /** Unrelated-text cosine floor used to calibrate clustered embedding models. */
+  semanticSimilarityBaseline?: number;
   /** Per-chat ephemeral state overrides for lorebook entries (from chat metadata). */
   entryStateOverrides?: Record<string, { ephemeral?: number | null; enabled?: boolean }>;
   /** Per-chat sticky/cooldown/delay timing state for lorebook entries. */
@@ -330,6 +332,7 @@ async function expandLorebook(config: MarkerConfig, ctx: MarkerContext): Promise
         tokenBudget: ctx.lorebookTokenBudget,
         chatEmbedding: ctx.chatEmbedding ?? null,
         semanticEmbeddingsByLorebookId: ctx.semanticEmbeddingsByLorebookId,
+        semanticSimilarityBaseline: ctx.semanticSimilarityBaseline,
         entryStateOverrides: ctx.entryStateOverrides,
         entryTimingStates: ctx.entryTimingStates,
         generationTriggers: ctx.generationTriggers ?? ["chat"],

--- a/scripts/regressions/noodle-vision.regression.ts
+++ b/scripts/regressions/noodle-vision.regression.ts
@@ -85,6 +85,8 @@ assert.equal(resolveNoodleImagePath("/api/global-gallery/file/%2E%2E%2Fsecret.pn
 assert.equal(resolveNoodleImagePath("https://example.com/image.png"), null);
 
 assert.equal(isUnsupportedNoodleVisionInputError(new Error("This model does not support image_url inputs")), true);
+assert.equal(isUnsupportedNoodleVisionInputError(new Error("No endpoints found that support image input")), true);
+assert.equal(isUnsupportedNoodleVisionInputError(new Error("No endpoints found for text generation")), false);
 assert.equal(isUnsupportedNoodleVisionInputError(new Error("Expected message content to be a string")), true);
 assert.equal(isUnsupportedNoodleVisionInputError(new Error("Provider rate limit exceeded")), false);
 

--- a/scripts/regressions/prompt.regression.ts
+++ b/scripts/regressions/prompt.regression.ts
@@ -160,6 +160,10 @@ import {
   type SimpleMessage,
 } from "../../packages/server/src/routes/generate/generate-route-utils.js";
 import { resolveGenerationPromptPresetChoices } from "../../packages/server/src/routes/generate/prompt-preset-selection.js";
+import {
+  calibrateLorebookSimilarity,
+  lorebookSimilarityBaseline,
+} from "../../packages/server/src/services/lorebook/embeddings.js";
 import { scanForActivatedEntries } from "../../packages/server/src/services/lorebook/keyword-scanner.js";
 import { fitMessagesForModelAccess } from "../../packages/server/src/services/generation/model-access-policy.js";
 import { assemblePrompt, type AssemblerInput } from "../../packages/server/src/services/prompt/index.js";
@@ -3178,6 +3182,35 @@ Use HTML sparingly and diegetically. Do not replace normal prose/dialogue unless
         },
       );
       assert.equal(belowThreshold.length, 0);
+
+      assert.equal(calibrateLorebookSimilarity(0.97, 0.97), 0);
+      assert.ok(calibrateLorebookSimilarity(0.99, 0.97) > 0.6);
+      assert.ok(
+        Math.abs(lorebookSimilarityBaseline([[1, 0], [0.97, Math.sqrt(1 - 0.97 ** 2)]]) - 0.97) < 1e-12,
+      );
+
+      const clusteredIrrelevant = scanForActivatedEntries(
+        [{ role: "user", content: "unrelated query" }],
+        [{ ...entry, id: "entry-clustered-irrelevant", keys: [], embedding: [0.97, Math.sqrt(1 - 0.97 ** 2)] } as any],
+        {
+          chatEmbedding: [1, 0],
+          semanticSimilarityBaseline: 0.97,
+          semanticThresholdByLorebookId: new Map([["book-semantic", 0.3]]),
+        },
+      );
+      assert.equal(clusteredIrrelevant.length, 0);
+
+      const clusteredRelevant = scanForActivatedEntries(
+        [{ role: "user", content: "related query" }],
+        [{ ...entry, id: "entry-clustered-relevant", keys: [], embedding: [0.99, Math.sqrt(1 - 0.99 ** 2)] } as any],
+        {
+          chatEmbedding: [1, 0],
+          semanticSimilarityBaseline: 0.97,
+          semanticThresholdByLorebookId: new Map([["book-semantic", 0.3]]),
+        },
+      );
+      assert.equal(clusteredRelevant.length, 1);
+      assert.match(clusteredRelevant[0]?.matchedKeys[0] ?? "", /^\[semantic:0\.66/u);
     },
   },
 ];


### PR DESCRIPTION
## Why

This fixes the current open issue queue affecting semantic lorebook matching, desktop sidebar folders, and Noodle image fallback behavior.

## What changed

- Calibrate semantic lorebook similarity against a neutral embedding baseline so clustered embedding models no longer make the threshold behave like all-or-nothing.
- Keep shared folder contents mounted and animate their CSS grid rows, avoiding the conditional Framer Motion hook path that crashed Connections and Lorebooks folders.
- Recognize the OpenRouter "No endpoints found that support image input" response and retry Noodle generation with text-only messages.
- Add focused regression coverage and document the semantic threshold behavior.
- Record all three fixes in the v2.3.0 changelog.

Closes #3627
Closes #3630
Closes #3631

## Automated validation

- pnpm check
- pnpm version:check
- pnpm regression:prompt
- pnpm regression:noodle
- pnpm exec playwright test e2e/core-flows.e2e.ts --project=desktop-chromium --grep "desktop Connections and Lorebooks folders expand without a React hook error"
- git diff --check

## Maintainer verification

- [ ] Manually compare unrelated and relevant lorebook entries using the clustered embedding provider reported in #3627.
- [ ] Manually expand and collapse existing and new Connections and Lorebooks folders on desktop.
- [ ] Manually refresh Noodle with a non-vision OpenRouter model while the timeline contains an image.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved lorebook semantic matching to reduce unrelated entries while preserving relevant results.
  * Prevented Connections and Lorebooks folder expansion crashes and improved accessibility of folder transitions.
  * Noodle timeline refreshes can retry with text-only prompts when image-capable endpoints are unavailable.

* **Documentation**
  * Clarified that semantic search thresholds use calibrated similarity for more consistent results across embedding models.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->