### PR TITLE
Add Card Browser, Persona Library, and agent artwork

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,11 +14,13 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 - Published first-party downloadable agents in the new [Pasta-Devs/Marinara-Agents](https://github.com/Pasta-Devs/Marinara-Agents) repository as individually verified packages. Its README now lists every Writer, Tracker, and Misc package, while repository contribution rules, issue and PR templates, catalog validation, protected review flow, and automatic CodeRabbit review keep future package work complete and reviewable. Conversation mode's About Me profile and `update_about_me` tool remain built into the Engine and are not downloadable agents.
 - Moved Hierarchical Maps, Conversation audio/video calls, UNO, Chess, Poker, 8-Ball Pool, Tic-Tac-Toe, and Rock-Paper-Scissors into optional packages with package-owned server runtimes and responsive client surfaces. Maps can be enabled as an agent in Roleplay and during or after Game creation.
 - Added a default-on Noodle setting that can exclude Professor Mari from account discovery and future generated activity without deleting existing timeline history ([#3598](https://github.com/Pasta-Devs/Marinara-Engine/issues/3598)).
-
+- Added **Open Full Library** to Personas, with the same responsive card grid, search, sorting, preview pane, paging, scroll restoration, and editor return flow as the Character Library.
 - Added separate opt-in browser and Android generation-completion notifications for manually started Conversation, Roleplay, Visual Novel, and Game replies that finish while Marinara is unfocused, without changing autonomous-message background notification preferences (#3588).
 
 ### Changed
 
+- Renamed **Bot Browser** to **Card Browser** throughout the interface, documentation, onboarding tutorial, and Professor Mari guidance, and renamed **Browse Online** to **Download Cards**.
+- Updated the Character and Persona full libraries to use the chroma text color selected in Settings for headings, counts, descriptions, metadata, tags, previews, and empty states instead of legacy fixed-color text.
 - Made Local Whisper a Conversation Calls-owned download. Connections now shows Local Speech Model controls only while the Conversation Calls package is installed, and uninstalling Conversation Calls removes every downloaded Whisper model and its saved selection to reclaim disk space. Reinstalling Calls makes the models available to download again.
 - Removed the retired database compatibility stack, including its runtime backend switch, startup migrations, one-time importer and repair readers, old migration scripts, database-file backup handling, and external ORM/runtime dependencies. Storage schemas and query expressions are now file-native throughout the Engine.
 - Made file-native primary and natural-key constraints enforceable during atomic inserts and updates, preventing concurrent custom-media names, Noodle toggles, and lorebook links from persisting ambiguous duplicates.
@@ -31,6 +33,7 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 
 ### Fixed
 
+- Restored the Characters sidebar header icon to the same pink-to-rose gradient used by the New Character action while keeping its topbar icon on the selected chroma accent.
 - Calibrated Lorebook semantic similarity against an unrelated-text baseline so embedding models whose raw cosine scores cluster around 0.97 no longer inject unrelated entries at every usable threshold or suppress relevant entries near 1.0 (#3627).
 - Replaced the nested presence animation used by expandable right-sidebar folders with an accessible grid transition, preventing Connections and Lorebooks folders from crashing the app shell with React hook-order errors (#3630).
 - Recognized OpenRouter's positive-form `No endpoints found that support image input` rejection as a non-vision model response, allowing Noodle timeline refreshes to retry once with the existing text-only prompt (#3631).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 
 ### Fixed
 
+- Applied downloaded package artwork to matching installed agents in the Agents sidebar, while preserving user-uploaded pictures and the star fallback for missing or failed images.
 - Restored the Characters sidebar header icon to the same pink-to-rose gradient used by the New Character action while keeping its topbar icon on the selected chroma accent.
 - Calibrated Lorebook semantic similarity against an unrelated-text baseline so embedding models whose raw cosine scores cluster around 0.97 no longer inject unrelated entries at every usable threshold or suppress relevant entries near 1.0 (#3627).
 - Replaced the nested presence animation used by expandable right-sidebar folders with an accessible grid transition, preventing Connections and Lorebooks folders from crashing the app shell with React hook-order errors (#3630).

--- a/README.md
+++ b/README.md
@@ -64,9 +64,9 @@
 </p>
 
 <p align="center">
-  <img src="docs/screenshots/Browser_Tab.png" width="90%" alt="Bot Browser" />
+  <img src="docs/screenshots/Browser_Tab.png" width="90%" alt="Card Browser" />
   <br/>
-  <em>Bot Browser — Search and import characters from Chub.ai, JannyAI, CharacterTavern, Pygmalion, Wyvern, and more</em>
+  <em>Card Browser — Search and import character cards from Chub.ai, JannyAI, CharacterTavern, Pygmalion, Wyvern, and more</em>
 </p>
 
 <p align="center">
@@ -120,14 +120,14 @@ More detailed public [roadmap](https://github.com/orgs/Pasta-Devs/projects/1).
 
 ## Installation
 
-| Platform                     | Guide                                                                                           |
-| ---------------------------- | ----------------------------------------------------------------------------------------------- |
-| 🐳 Docker / Podman           | [Container Installation Guide](docs/installation/containers.md) — recommended                   |
-| 🪟 Windows                   | [Windows Installation Guide](docs/installation/windows.md)                                      |
-| 🍎🐧 macOS / Linux           | [macOS / Linux Installation Guide](docs/installation/macos-linux.md)                            |
-| 🤖 Android APK Bootstrap     | [Android APK Guide](android/README.md) — guided tap-through install/start shell                 |
-| 🤖 Android Manual Termux     | [Android (Termux) Installation Guide](docs/installation/android-termux.md) — manual fallback    |
-| 📱 iOS / iPadOS              | [iOS / iPadOS PWA Guide](docs/installation/ios-pwa.md)                                          |
+| Platform                 | Guide                                                                                        |
+| ------------------------ | -------------------------------------------------------------------------------------------- |
+| 🐳 Docker / Podman       | [Container Installation Guide](docs/installation/containers.md) — recommended                |
+| 🪟 Windows               | [Windows Installation Guide](docs/installation/windows.md)                                   |
+| 🍎🐧 macOS / Linux       | [macOS / Linux Installation Guide](docs/installation/macos-linux.md)                         |
+| 🤖 Android APK Bootstrap | [Android APK Guide](android/README.md) — guided tap-through install/start shell              |
+| 🤖 Android Manual Termux | [Android (Termux) Installation Guide](docs/installation/android-termux.md) — manual fallback |
+| 📱 iOS / iPadOS          | [iOS / iPadOS PWA Guide](docs/installation/ios-pwa.md)                                       |
 
 > **Recommended Android path:** download the Android APK from the latest GitHub Release, open it, then tap **Install / Start Marinara**. The APK can download Termux from F-Droid, hand it to Android's installer, request Termux command permission, start the setup command, and open the local Marinara server when it is ready. If Android blocks that handoff, the APK copies a fresh-Termux setup command that can be pasted into Termux manually. Android still shows its required install/permission prompts.
 
@@ -143,7 +143,7 @@ Security defaults are intentionally local-first: loopback access works out of th
 
 ### Chat & Roleplay
 
-Three chat modes — **Conversation** (Discord-style DMs), **Roleplay** (immersive RPG with sprites and backgrounds), and **Game** (AI Game Master with party, quests, and combat). Characters can share memory across modes. Create or import characters, search the multi-site Bot Browser (Chub.ai, JannyAI, CharacterTavern, Pygmalion, Wyvern, and more), organize chats into folders, branch conversations, swipe between alternate responses, and import from SillyTavern.
+Three chat modes — **Conversation** (Discord-style DMs), **Roleplay** (immersive RPG with sprites and backgrounds), and **Game** (AI Game Master with party, quests, and combat). Characters can share memory across modes. Create or import characters, search the multi-site Card Browser (Chub.ai, JannyAI, CharacterTavern, Pygmalion, Wyvern, and more), organize chats into folders, branch conversations, swipe between alternate responses, and import from SillyTavern.
 
 ### Visual & Immersive
 
@@ -177,42 +177,42 @@ Export individual chats or bulk transcript zips as JSONL or plain text. Fully lo
 
 The full guide library is browsable inside the app: open **Documentation** from the Home screen to search every guide, organized by category. Highlights:
 
-| Document                                             | Description                                                     |
-| ---------------------------------------------------- | --------------------------------------------------------------- |
-| [docs/INSTALLATION.md](docs/INSTALLATION.md)         | Installation guide index (all platforms)                        |
-| [docs/CONFIGURATION.md](docs/CONFIGURATION.md)       | Environment variables and `.env` reference                      |
+| Document                                                                             | Description                                                                                                        |
+| ------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------ |
+| [docs/INSTALLATION.md](docs/INSTALLATION.md)                                         | Installation guide index (all platforms)                                                                           |
+| [docs/CONFIGURATION.md](docs/CONFIGURATION.md)                                       | Environment variables and `.env` reference                                                                         |
 | [docs/conversation/getting-started.md](docs/conversation/getting-started.md)         | Conversation Mode setup, DMs, groups, profiles (display name, about me, behavior), calls, selfies, and table games |
-| [docs/roleplay/getting-started.md](docs/roleplay/getting-started.md)                 | Roleplay Mode setup, sprites, HUD, agents, and connected chats  |
-| [docs/game/getting-started.md](docs/game/getting-started.md)               | Game Mode setup, world-gen, party play, storyboards, and troubleshooting |
-| [docs/agents/built-in-agents.md](docs/agents/built-in-agents.md)           | Complete reference for all 29 downloadable first-party agents and feature packages |
-| [docs/noodle/overview.md](docs/noodle/overview.md)   | Noodle social timeline: setup, posting, interactions, images, and chat carryover |
-| [docs/prompts/generation-parameters.md](docs/prompts/generation-parameters.md) | Sampler and output-parameter reference across providers         |
-| [docs/REMOTE_ACCESS.md](docs/REMOTE_ACCESS.md)       | Remote access, Basic Auth, IP allowlists, and admin access      |
-| [docs/conversation/calls.md](docs/conversation/calls.md) | Conversation audio-call setup, Local Whisper, TTS, and troubleshooting |
-| [docs/media/image-providers.md](docs/media/image-providers.md) | Image generation provider setup                                 |
-| [docs/media/style-profiles.md](docs/media/style-profiles.md) | Image style profiles and prompt grammar                         |
-| [docs/media/tts-setup.md](docs/media/tts-setup.md)   | Text to speech (TTS) setup and voices                           |
-| [docs/media/scene-video.md](docs/media/scene-video.md) | Scene-video provider setup and the Gallery animation workflow   |
-| [docs/game/storyboard.md](docs/game/storyboard.md) | Step-by-step guide to manual and automatic Game Mode storyboards |
-| [docs/agents/agents-overview.md](docs/agents/agents-overview.md)         | Agent system overview: phases, per-chat enablement, built-in and custom agents |
-| [docs/extending/custom-tools.md](docs/extending/custom-tools.md)         | Function calling, custom tools, webhooks, scripts, and agent tool enablement |
-| [docs/prompts/presets.md](docs/prompts/presets.md)                   | Preset editor, prompt sections, groups, ordering, and variables |
-| [docs/extending/regex-scripts.md](docs/extending/regex-scripts.md)       | Regex scripts, prompt/display scope, depth, order, and safety   |
-| [docs/agents/knowledge-sources.md](docs/agents/knowledge-sources.md) | Knowledge Sources, RAG, Retrieval vs Router, and embedder notes |
-| [docs/characters/bot-browser.md](docs/characters/bot-browser.md)           | Multi-site Bot Browser search and character import guide        |
-| [docs/conversation/emoji-stickers-gifs.md](docs/conversation/emoji-stickers-gifs.md) | Custom emoji/sticker uploads and selection modes                |
-| [docs/extending/extensions.md](docs/extending/extensions.md)             | Installing and managing browser and server extensions           |
-| [docs/development/writing-extensions.md](docs/development/writing-extensions.md) | Writing extensions: manifest format and the marinara API        |
-| [docs/TROUBLESHOOTING.md](docs/TROUBLESHOOTING.md)   | Common issues and fixes                                         |
-| [docs/FAQ.md](docs/FAQ.md)                           | Frequently asked questions (LAN access, etc.)                   |
-| [docs/prompts/macros.md](docs/prompts/macros.md)                     | Prompt macro syntax, including weighted random choices          |
-| [docs/home/professor-mari.md](docs/home/professor-mari.md)     | Built-in assistant capabilities, limits, and safety notes       |
-| [docs/development/frontend.md](docs/development/frontend.md)                 | Frontend architecture, components, hooks, and API reference     |
-| [docs/development/architecture-map.md](docs/development/architecture-map.md) | Code ownership map and module-boundary refactor groundwork      |
-| [android/README.md](android/README.md)               | Android Termux bootstrap + WebView shell guide                  |
-| [CONTRIBUTING.md](CONTRIBUTING.md)                   | Contributor workflow, validation, versioning, and release steps |
-| [CHANGELOG.md](CHANGELOG.md)                         | Release notes                                                   |
-| [CLAUDE.md](CLAUDE.md)                               | Maintainer notes for contributors using Claude                  |
+| [docs/roleplay/getting-started.md](docs/roleplay/getting-started.md)                 | Roleplay Mode setup, sprites, HUD, agents, and connected chats                                                     |
+| [docs/game/getting-started.md](docs/game/getting-started.md)                         | Game Mode setup, world-gen, party play, storyboards, and troubleshooting                                           |
+| [docs/agents/built-in-agents.md](docs/agents/built-in-agents.md)                     | Complete reference for all 29 downloadable first-party agents and feature packages                                 |
+| [docs/noodle/overview.md](docs/noodle/overview.md)                                   | Noodle social timeline: setup, posting, interactions, images, and chat carryover                                   |
+| [docs/prompts/generation-parameters.md](docs/prompts/generation-parameters.md)       | Sampler and output-parameter reference across providers                                                            |
+| [docs/REMOTE_ACCESS.md](docs/REMOTE_ACCESS.md)                                       | Remote access, Basic Auth, IP allowlists, and admin access                                                         |
+| [docs/conversation/calls.md](docs/conversation/calls.md)                             | Conversation audio-call setup, Local Whisper, TTS, and troubleshooting                                             |
+| [docs/media/image-providers.md](docs/media/image-providers.md)                       | Image generation provider setup                                                                                    |
+| [docs/media/style-profiles.md](docs/media/style-profiles.md)                         | Image style profiles and prompt grammar                                                                            |
+| [docs/media/tts-setup.md](docs/media/tts-setup.md)                                   | Text to speech (TTS) setup and voices                                                                              |
+| [docs/media/scene-video.md](docs/media/scene-video.md)                               | Scene-video provider setup and the Gallery animation workflow                                                      |
+| [docs/game/storyboard.md](docs/game/storyboard.md)                                   | Step-by-step guide to manual and automatic Game Mode storyboards                                                   |
+| [docs/agents/agents-overview.md](docs/agents/agents-overview.md)                     | Agent system overview: phases, per-chat enablement, built-in and custom agents                                     |
+| [docs/extending/custom-tools.md](docs/extending/custom-tools.md)                     | Function calling, custom tools, webhooks, scripts, and agent tool enablement                                       |
+| [docs/prompts/presets.md](docs/prompts/presets.md)                                   | Preset editor, prompt sections, groups, ordering, and variables                                                    |
+| [docs/extending/regex-scripts.md](docs/extending/regex-scripts.md)                   | Regex scripts, prompt/display scope, depth, order, and safety                                                      |
+| [docs/agents/knowledge-sources.md](docs/agents/knowledge-sources.md)                 | Knowledge Sources, RAG, Retrieval vs Router, and embedder notes                                                    |
+| [docs/characters/bot-browser.md](docs/characters/bot-browser.md)                     | Multi-site Card Browser search and character import guide                                                          |
+| [docs/conversation/emoji-stickers-gifs.md](docs/conversation/emoji-stickers-gifs.md) | Custom emoji/sticker uploads and selection modes                                                                   |
+| [docs/extending/extensions.md](docs/extending/extensions.md)                         | Installing and managing browser and server extensions                                                              |
+| [docs/development/writing-extensions.md](docs/development/writing-extensions.md)     | Writing extensions: manifest format and the marinara API                                                           |
+| [docs/TROUBLESHOOTING.md](docs/TROUBLESHOOTING.md)                                   | Common issues and fixes                                                                                            |
+| [docs/FAQ.md](docs/FAQ.md)                                                           | Frequently asked questions (LAN access, etc.)                                                                      |
+| [docs/prompts/macros.md](docs/prompts/macros.md)                                     | Prompt macro syntax, including weighted random choices                                                             |
+| [docs/home/professor-mari.md](docs/home/professor-mari.md)                           | Built-in assistant capabilities, limits, and safety notes                                                          |
+| [docs/development/frontend.md](docs/development/frontend.md)                         | Frontend architecture, components, hooks, and API reference                                                        |
+| [docs/development/architecture-map.md](docs/development/architecture-map.md)         | Code ownership map and module-boundary refactor groundwork                                                         |
+| [android/README.md](android/README.md)                                               | Android Termux bootstrap + WebView shell guide                                                                     |
+| [CONTRIBUTING.md](CONTRIBUTING.md)                                                   | Contributor workflow, validation, versioning, and release steps                                                    |
+| [CHANGELOG.md](CHANGELOG.md)                                                         | Release notes                                                                                                      |
+| [CLAUDE.md](CLAUDE.md)                                                               | Maintainer notes for contributors using Claude                                                                     |
 
 ---
 

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -142,9 +142,9 @@ Chat summaries need a working text connection to write them.
 - If your chat requires agent write approval, an AI summary waits for your review before it takes effect.
 - A summary that keeps failing (for example, a bad API key) is retried on a delay. Fix the connection, then use **Backfill**.
 
-## Bot Browser problems
+## Card Browser problems
 
-The **Bot Browser** lets you search public character sites and import characters. Open it from the **Bot Browser** icon in the top bar.
+The **Card Browser** lets you search public character sites and import characters. Open it from the **Card Browser** icon in the top bar, then click **Download Cards**.
 
 - If JannyAI search or a character page fails with a Cloudflare block, Marinara shows a message. It asks you to visit the JannyAI site once in the same browser to clear the challenge, then retry.
 - If your CharacterTavern or Pygmalion login stops working after you restart the server, that is expected. Those logins live only in server memory and clear on restart. Open the login window and paste your cookie or token again.

--- a/docs/characters/bot-browser.md
+++ b/docs/characters/bot-browser.md
@@ -1,31 +1,31 @@
-# Bot Browser: Finding and Importing Characters
+# Card Browser: Finding and Importing Characters
 
-This guide explains the **Bot Browser** in Marinara Engine, the built-in tool for finding character cards on public sites and importing them into your library. It covers the six sources, how to search and filter, and how adult content works on each source. It also covers how to import a character or save it as a file. Older versions of the app labeled this feature **Browser**, so some older guides may still use that shorter name.
+This guide explains the **Card Browser** in Marinara Engine, the built-in tool for finding character cards on public sites and importing them into your library. It covers the six sources, how to search and filter, and how adult content works on each source. It also covers how to import a character or save it as a file. Older versions called this tab **Bot Browser** or **Browser**.
 
-A character card is a file that holds one character's name, personality, greeting, and other details. Normally you would download a card from a website and then upload it into Marinara. The **Bot Browser** does both steps for you in one place.
+A character card is a file that holds one character's name, personality, greeting, and other details. Normally you would download a card from a website and then upload it into Marinara. The **Card Browser** does both steps for you in one place.
 
-## What the Bot Browser is
+## What the Card Browser is
 
-The **Bot Browser** searches several public character-card sites from inside Marinara. It supports six sources: **ChubAI**, **JannyAI**, **CharacterTavern**, **Pygmalion**, **Wyvern**, and **DataCat**. You can search a source, filter the results, and preview a character's full details. Then you can import that character into your library or save it as a PNG file. You do not need an account or an API key to browse and import character cards at the default settings.
+The **Card Browser** searches several public character-card sites from inside Marinara. It supports six sources: **ChubAI**, **JannyAI**, **CharacterTavern**, **Pygmalion**, **Wyvern**, and **DataCat**. You can search a source, filter the results, and preview a character's full details. Then you can import that character into your library or save it as a PNG file. You do not need an account or an API key to browse and import character cards at the default settings.
 
-## Opening the Bot Browser
+## Opening the Card Browser
 
-There are two ways to open the **Bot Browser**.
+There are two ways to open the **Card Browser**.
 
-1. Click the **Bot Browser** icon in the top bar. It sits in the row of panel buttons on the right side.
-2. Or open the **Bot Browser** panel in the right sidebar, then click the **Browse Online** button at the top of that panel.
+1. Click the **Card Browser** icon in the top bar. It sits in the row of panel buttons on the right side.
+2. Or open the **Card Browser** panel in the right sidebar, then click the **Download Cards** button at the top of that panel.
 
-Either way, the whole content area switches to the full **Bot Browser** view. This view replaces the chat area. It is not a small pop-up window.
+Either way, the whole content area switches to the full **Card Browser** view. This view replaces the chat area. It is not a small pop-up window.
 
-To leave, click the back-arrow button in the top-left of the **Bot Browser** header. You should return to the screen you came from.
+To leave, click the back-arrow button in the top-left of the **Card Browser** header. You should return to the screen you came from.
 
-The **Bot Browser** stays loaded while the app is open. If you close it and open it again, your last search, filters, and selected character are still there. Reloading the whole app resets it.
+The **Card Browser** stays loaded while the app is open. If you close it and open it again, your last search, filters, and selected character are still there. Reloading the whole app resets it.
 
 ## Choosing a source
 
 Click the source button in the header. It shows the current source name and a small arrow. A menu opens with all six sources in this order: **ChubAI**, **JannyAI**, **CharacterTavern**, **Pygmalion**, **Wyvern**, and **DataCat**.
 
-**ChubAI** is selected the first time you open the **Bot Browser**. When you switch sources, your search text, tags, and filters are cleared. Each source remembers its own adult-content setting and login separately, so a change on one source does not affect the others.
+**ChubAI** is selected the first time you open the **Card Browser**. When you switch sources, your search text, tags, and filters are cleared. Each source remembers its own adult-content setting and login separately, so a change on one source does not affect the others.
 
 One naming note: the menu lists **ChubAI**, but on a character's detail page the outside link reads **View on Chub**. That is the site's own name for itself. The other five sources use the same name in both places.
 
@@ -35,14 +35,14 @@ Type in the **Search characters...** box to search. You do not need to press Ent
 
 Next to the search box is a sort dropdown. The options are different on each source, and each source starts on its own default sort:
 
-| Source | Default sort |
-|---|---|
-| ChubAI | Most Downloaded |
-| JannyAI | Newest |
-| CharacterTavern | Most Popular |
-| Pygmalion | Downloads |
-| Wyvern | Popular |
-| DataCat | Relevance |
+| Source          | Default sort    |
+| --------------- | --------------- |
+| ChubAI          | Most Downloaded |
+| JannyAI         | Newest          |
+| CharacterTavern | Most Popular    |
+| Pygmalion       | Downloads       |
+| Wyvern          | Popular         |
+| DataCat         | Relevance       |
 
 Click the **Refresh** button (the circular-arrow icon) to run the current search again.
 
@@ -143,10 +143,10 @@ The imported character behaves like any other character. To actually chat with i
 
 The **Imported tags** panel next to the avatar controls which tags come along with the character. The default is **All tags**.
 
-| Option | What it does |
-|---|---|
-| All tags | Keeps the source's tags. |
-| No tags | Skips the source's tags. |
+| Option        | What it does                                 |
+| ------------- | -------------------------------------------- |
+| All tags      | Keeps the source's tags.                     |
+| No tags       | Skips the source's tags.                     |
 | Existing only | Keeps only tags you already use in Marinara. |
 
 ### Embedded lorebook prompt
@@ -161,9 +161,9 @@ JSON and PNG are two common formats for the same character data. JSON is a plain
 
 ## Your imported characters
 
-The **Bot Browser** panel in the right sidebar keeps a separate list of characters you imported through the **Bot Browser**. Characters you made by hand or imported another way do not appear here. All of them still appear in the main **Characters** library.
+The **Card Browser** panel in the right sidebar keeps a separate list of characters you imported through the **Card Browser**. Characters you made by hand or imported another way do not appear here. All of them still appear in the main **Characters** library.
 
-- The **Browse Online** button opens the full **Bot Browser** view.
+- The **Download Cards** button opens the full **Card Browser** view.
 - The **Search imported...** box filters this list.
 - The sort dropdown offers **A-Z**, **Z-A**, **Newest**, and **Oldest**.
 - Right-click a row, or use its buttons, to find **Quick Start Roleplay** and **Quick Start Conversation**. These open a new chat with that character. You can also delete the character from this list here.

--- a/docs/characters/library-organization.md
+++ b/docs/characters/library-organization.md
@@ -11,6 +11,8 @@ The **Characters panel** is the character list in the side panel. It holds every
 - Click the **Import** button (the download icon) to import a character file.
 - Click the **Select** button (the check icon) to turn on multi-select mode for bulk actions.
 
+The full library uses the chroma text color selected in **Settings**, and keeps your selected card, sort order, and scroll position when you open a character for editing and return.
+
 Each character row shows the avatar, name, an optional title line, the creator and version, up to 3 tags, and a rough token estimate. A small star badge marks a favorite. When you hover a row, a **Duplicate** button and a **Delete** button appear.
 
 If you have many characters, a **Load more** button appears at the bottom. Click it to load the next page of characters.
@@ -39,12 +41,12 @@ You can combine plain text and exclusion in the same box. For example, `mage -ta
 
 Next to the search box is the sort dropdown. Pick one of these orders:
 
-| Option | What it does |
-| --- | --- |
-| **A-Z** | Names from A to Z. |
-| **Z-A** | Names from Z to A. |
-| **Newest** | Most recently created first. |
-| **Oldest** | Oldest created first. |
+| Option        | What it does                    |
+| ------------- | ------------------------------- |
+| **A-Z**       | Names from A to Z.              |
+| **Z-A**       | Names from Z to A.              |
+| **Newest**    | Most recently created first.    |
+| **Oldest**    | Oldest created first.           |
 | **Favorites** | Favorites first, then the rest. |
 
 ## Folders

--- a/docs/characters/personas.md
+++ b/docs/characters/personas.md
@@ -20,6 +20,7 @@ The **Personas** panel is your persona library. Open it from the person icon in 
 
 The panel gives you these controls:
 
+- **Open Full Library** opens the responsive full-page Persona Library. It uses the same grid-and-preview layout as the Character Library, with persona descriptions, card sections, tags, token estimates, and active-persona badges.
 - **New** creates a persona.
 - **Import** opens the **Import Persona** window.
 - **Select** turns on bulk-selection mode so you can act on many personas at once.

--- a/docs/development/optional-agent-packages.md
+++ b/docs/development/optional-agent-packages.md
@@ -78,7 +78,7 @@ Every uninstall requires confirmation. Affected chats fall back to their ordinar
 
 ## Catalog interface
 
-The Agents panel contains a `Download Agents` control matching Bot Browser's `Browse Online` affordance. It opens a full-screen responsive library with search, package kinds, compatibility information, install/update state, permissions, storage cost, documentation, and uninstall controls.
+The Agents panel contains a `Download Agents` control matching the Card Browser's `Download Cards` affordance. It opens a full-screen responsive library with search, package kinds, compatibility information, install/update state, permissions, storage cost, documentation, and uninstall controls.
 
 Desktop uses a browse list with an adjacent detail region. Mobile uses one pane with explicit back navigation and touch-sized actions. Empty, offline, incompatible, corrupt-download, interrupted-install, update, rollback, and restart-required states are first-class.
 

--- a/docs/home/tutorial.md
+++ b/docs/home/tutorial.md
@@ -15,7 +15,7 @@ The tour also does more than talk. As you move forward, some steps open the matc
 The tour has 15 steps. Here they are in order, with the exact title of each card and what it points at.
 
 1. **Welcome to Marinara Engine!** A centered welcome card. Professor Mari waves and offers to show you around.
-2. **Bot Browser** Highlights the **Bot Browser** panel button, where you find and import ready-made characters.
+2. **Card Browser** Highlights the **Card Browser** panel button, where you can click **Download Cards** to find and import ready-made characters.
 3. **Characters** Highlights the **Characters** panel button, where your characters live.
 4. **Lorebooks** Highlights the **Lorebooks** panel button, which holds extra world and character details.
 5. **Presets** Highlights the **Presets** panel button, which controls how the prompt is built.

--- a/docs/noodle/overview.md
+++ b/docs/noodle/overview.md
@@ -27,7 +27,7 @@ Noodle lives in the top bar, not in a settings panel.
 2. Click **Noodle**.
 3. The main chat area is replaced by the Noodle timeline.
 
-You should see a fake browser address bar reading `https://noodle.local` with a small **Noodle** badge. This is just for flavor. Opening Noodle closes any other open panel, such as the character library or the bot browser.
+You should see a fake browser address bar reading `https://noodle.local` with a small **Noodle** badge. This is just for flavor. Opening Noodle closes any other open panel, such as the character library or the Card Browser.
 
 To leave Noodle, click the **Noodle** button again or open any other panel.
 

--- a/e2e/core-flows.e2e.ts
+++ b/e2e/core-flows.e2e.ts
@@ -725,6 +725,9 @@ test("home shell and primary topbar panels open without client errors", async ({
   await expect(page.locator('[data-component="TopBar"]')).toBeVisible();
   await expect(page.getByRole("heading", { name: "Marinara Engine" })).toBeVisible();
 
+  const charactersButton = page.locator('[data-tour="panel-characters"]');
+  await expect(charactersButton.locator("svg")).toHaveClass(/mari-topbar-accent-icon/);
+
   for (const selector of [
     '[data-tour="sidebar-toggle"]',
     '[data-tour="panel-bot-browser"]',
@@ -738,10 +741,34 @@ test("home shell and primary topbar panels open without client errors", async ({
   ]) {
     await page.locator(selector).click();
     await expect(page.locator('[data-component="TopBar"]')).toBeVisible();
+    if (selector === '[data-tour="panel-characters"]') {
+      await expect(page.locator('[data-component="RightPanelHeaderIcon"]')).toHaveClass(
+        /mari-panel-gradient--characters/,
+      );
+    }
   }
 
   const health = await page.request.get("/api/health");
   expect(health.ok()).toBeTruthy();
+  expect(errors).toEqual([]);
+});
+
+test("Card Browser labels and the Persona full library stay available across viewports", async ({ page }) => {
+  const errors = collectUnexpectedErrors(page);
+  await page.goto("/");
+
+  await page.locator('[data-tour="panel-bot-browser"]').click();
+  await expect(page.getByText("Card Browser", { exact: true })).toBeVisible();
+  await expect(page.getByRole("button", { name: "Download Cards" })).toBeVisible();
+
+  await page.locator('[data-tour="panel-personas"]').click();
+  const openPersonaLibrary = page.getByRole("button", { name: "Open Full Library" });
+  await expect(openPersonaLibrary).toBeVisible();
+  await openPersonaLibrary.click();
+
+  await expect(page.getByText("Persona Library", { exact: true })).toBeVisible();
+  await expect(page.getByRole("heading", { name: "Browse your personas" })).toBeVisible();
+  await expect(page.getByRole("button", { name: "New persona" })).toBeVisible();
   expect(errors).toEqual([]);
 });
 
@@ -1390,7 +1417,8 @@ test("Conversation feature packages expose commands and settings without per-cha
     expect(
       await illustratorSettings.evaluate(
         (illustrator, calls) =>
-          calls instanceof Node && Boolean(illustrator.compareDocumentPosition(calls) & Node.DOCUMENT_POSITION_FOLLOWING),
+          calls instanceof Node &&
+          Boolean(illustrator.compareDocumentPosition(calls) & Node.DOCUMENT_POSITION_FOLLOWING),
         callsSettingsHandle,
       ),
     ).toBe(true);

--- a/e2e/core-flows.e2e.ts
+++ b/e2e/core-flows.e2e.ts
@@ -1,5 +1,7 @@
 import { expect, test, type Page } from "@playwright/test";
 
+const TRANSPARENT_GIF_BASE64 = "R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw==";
+
 function collectUnexpectedErrors(page: Page) {
   const errors: string[] = [];
   page.on("pageerror", (error) => errors.push(error.message));
@@ -769,6 +771,9 @@ test("Card Browser labels and the Persona full library stay available across vie
   await expect(page.getByText("Persona Library", { exact: true })).toBeVisible();
   await expect(page.getByRole("heading", { name: "Browse your personas" })).toBeVisible();
   await expect(page.getByRole("button", { name: "New persona" })).toBeVisible();
+  await expect(page.locator('[data-component="CharacterLibraryView"]').getByPlaceholder("Search personas")).toBeVisible();
+  await expect(page.locator('[data-tour="panel-personas"]')).toHaveClass(/mari-topbar-panel-icon--active/);
+  await expect(page.locator('[data-tour="panel-characters"]')).not.toHaveClass(/bg-\[var\(--accent\)\]/);
   expect(errors).toEqual([]);
 });
 
@@ -847,6 +852,9 @@ test("downloadable agent catalog is usable on desktop and mobile", async ({ page
   await page.locator('[data-tour="panel-characters"]').click();
   await page.getByRole("button", { name: "Open Full Library" }).click();
   await expect(page.getByRole("heading", { name: "Browse your characters" })).toBeVisible();
+  await expect(
+    page.locator('[data-component="CharacterLibraryView"]').getByPlaceholder('Search characters or -tag:"tag name"'),
+  ).toBeVisible();
   if (testInfo.project.name.includes("mobile")) {
     await expect(page.locator('[data-component="RightPanelMobile"]')).toHaveCount(0);
   } else {
@@ -1214,7 +1222,7 @@ test("installed package artwork appears in the sidebar and clears immediately on
     await route.fulfill({
       status: 200,
       contentType: "image/gif",
-      body: Buffer.from("R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw==", "base64"),
+      body: Buffer.from(TRANSPARENT_GIF_BASE64, "base64"),
     });
   });
   await page.route("**/api/capability-packages/prose-guardian", async (route) => {
@@ -1606,7 +1614,7 @@ test("Game setup only shows features owned by installed agents", async ({ page, 
     await route.fulfill({
       status: 200,
       contentType: "image/gif",
-      body: Buffer.from("R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw==", "base64"),
+      body: Buffer.from(TRANSPARENT_GIF_BASE64, "base64"),
     });
   });
   await page.addInitScript((chatId) => {
@@ -1735,7 +1743,7 @@ test("Roleplay and Game chat settings link empty agent libraries to Download Age
     await route.fulfill({
       status: 200,
       contentType: "image/gif",
-      body: Buffer.from("R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw==", "base64"),
+      body: Buffer.from(TRANSPARENT_GIF_BASE64, "base64"),
     });
   });
 
@@ -1788,7 +1796,7 @@ test("Roleplay setup points empty agent libraries to the Agents tab", async ({ p
     await route.fulfill({
       status: 200,
       contentType: "image/gif",
-      body: Buffer.from("R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw==", "base64"),
+      body: Buffer.from(TRANSPARENT_GIF_BASE64, "base64"),
     });
   });
 

--- a/e2e/core-flows.e2e.ts
+++ b/e2e/core-flows.e2e.ts
@@ -1126,7 +1126,7 @@ test("agent catalog can install and uninstall every package", async ({ page }, t
   expect(errors).toEqual([]);
 });
 
-test("uninstalling a package immediately removes its agent from the open desktop sidebar", async ({
+test("installed package artwork appears in the sidebar and clears immediately on uninstall", async ({
   page,
 }, testInfo) => {
   test.skip(!testInfo.project.name.includes("desktop"), "The persistent Agents sidebar is a desktop workflow.");
@@ -1167,6 +1167,7 @@ test("uninstalling a package immediately removes its agent from the open desktop
         packages: [
           {
             category: "writer",
+            iconUrl: "https://example.com/prose-guardian-artwork.gif",
             manifest: packageManifest,
             artifact: {
               url: "https://example.com/prose-guardian.zip",
@@ -1209,6 +1210,13 @@ test("uninstalling a package immediately removes its agent from the open desktop
   await page.route("**/api/agents", async (route) => {
     await route.fulfill({ status: 200, contentType: "application/json", body: "[]" });
   });
+  await page.route("https://example.com/prose-guardian-artwork.gif", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "image/gif",
+      body: Buffer.from("R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw==", "base64"),
+    });
+  });
   await page.route("**/api/capability-packages/prose-guardian", async (route) => {
     if (route.request().method() !== "DELETE") {
       await route.fallback();
@@ -1225,7 +1233,12 @@ test("uninstalling a package immediately removes its agent from the open desktop
   await page.goto("/");
   await page.locator('[data-tour="panel-agents"]').click();
   const agentsSidebar = page.locator('[data-component="RightPanelDesktop"]');
-  await expect(agentsSidebar.getByText("Prose Guardian", { exact: true })).toBeVisible();
+  const proseGuardianCard = agentsSidebar.locator('[data-agent-name="Prose Guardian"]');
+  await expect(proseGuardianCard).toBeVisible();
+  await expect(proseGuardianCard.locator('[data-component="AgentArtwork"]')).toHaveAttribute(
+    "src",
+    "https://example.com/prose-guardian-artwork.gif",
+  );
 
   await agentsSidebar.getByRole("button", { name: "Download Agents" }).click();
   const catalogView = page.locator('[data-component="AgentCatalogView"]');

--- a/packages/client/src/components/agents/AgentArtwork.tsx
+++ b/packages/client/src/components/agents/AgentArtwork.tsx
@@ -1,0 +1,29 @@
+import { useEffect, useState } from "react";
+import { Sparkles } from "lucide-react";
+
+interface AgentArtworkProps {
+  imageUrl?: string | null;
+  alt: string;
+  iconSize: string;
+}
+
+export function AgentArtwork({ imageUrl, alt, iconSize }: AgentArtworkProps) {
+  const [imageFailed, setImageFailed] = useState(false);
+
+  useEffect(() => setImageFailed(false), [imageUrl]);
+
+  if (imageUrl && !imageFailed) {
+    return (
+      <img
+        src={imageUrl}
+        alt={alt}
+        className="h-full w-full object-cover"
+        draggable={false}
+        data-component="AgentArtwork"
+        onError={() => setImageFailed(true)}
+      />
+    );
+  }
+
+  return <Sparkles size={iconSize} aria-hidden="true" data-component="AgentArtworkFallback" />;
+}

--- a/packages/client/src/components/agents/AgentArtwork.tsx
+++ b/packages/client/src/components/agents/AgentArtwork.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import { Sparkles } from "lucide-react";
 
 interface AgentArtworkProps {
@@ -7,12 +7,10 @@ interface AgentArtworkProps {
   iconSize: string;
 }
 
-export function AgentArtwork({ imageUrl, alt, iconSize }: AgentArtworkProps) {
+function AgentArtworkImage({ imageUrl, alt, iconSize }: Omit<AgentArtworkProps, "imageUrl"> & { imageUrl: string }) {
   const [imageFailed, setImageFailed] = useState(false);
 
-  useEffect(() => setImageFailed(false), [imageUrl]);
-
-  if (imageUrl && !imageFailed) {
+  if (!imageFailed) {
     return (
       <img
         src={imageUrl}
@@ -26,4 +24,12 @@ export function AgentArtwork({ imageUrl, alt, iconSize }: AgentArtworkProps) {
   }
 
   return <Sparkles size={iconSize} aria-hidden="true" data-component="AgentArtworkFallback" />;
+}
+
+export function AgentArtwork({ imageUrl, alt, iconSize }: AgentArtworkProps) {
+  if (!imageUrl) {
+    return <Sparkles size={iconSize} aria-hidden="true" data-component="AgentArtworkFallback" />;
+  }
+
+  return <AgentArtworkImage key={imageUrl} imageUrl={imageUrl} alt={alt} iconSize={iconSize} />;
 }

--- a/packages/client/src/components/agents/AgentCatalogView.tsx
+++ b/packages/client/src/components/agents/AgentCatalogView.tsx
@@ -27,6 +27,7 @@ import { getPrivilegedActionErrorMessage } from "../../lib/api-client";
 import { showConfirmDialog } from "../../lib/app-dialogs";
 import { cn } from "../../lib/utils";
 import { useUIStore } from "../../stores/ui.store";
+import { AgentArtwork } from "./AgentArtwork";
 
 const CATEGORY_SECTIONS = [
   { id: "writer", label: "Writer Agents" },
@@ -50,25 +51,6 @@ function kindLabel(kind: CapabilityCatalogPackage["manifest"]["kind"][number]) {
   if (kind === "turn-game") return "Conversation Game";
   if (kind === "maps") return "Maps";
   return "Agent";
-}
-
-function AgentArtwork({ entry, iconSize }: { entry: CapabilityCatalogPackage; iconSize: string }) {
-  const [imageFailed, setImageFailed] = useState(false);
-
-  useEffect(() => setImageFailed(false), [entry.iconUrl]);
-
-  if (entry.iconUrl && !imageFailed) {
-    return (
-      <img
-        src={entry.iconUrl}
-        alt={`${entry.manifest.name} artwork`}
-        className="h-full w-full object-cover"
-        onError={() => setImageFailed(true)}
-      />
-    );
-  }
-
-  return <Sparkles size={iconSize} aria-hidden="true" />;
 }
 
 export function AgentCatalogView() {
@@ -425,7 +407,11 @@ export function AgentCatalogView() {
                                       )}
                                     >
                                       <span className="mari-panel-gradient-surface mari-panel-gradient--agents flex h-11 w-11 shrink-0 items-center justify-center overflow-hidden rounded-xl">
-                                        <AgentArtwork entry={entry} iconSize="1.15rem" />
+                                        <AgentArtwork
+                                          imageUrl={entry.iconUrl}
+                                          alt={`${entry.manifest.name} artwork`}
+                                          iconSize="1.15rem"
+                                        />
                                       </span>
                                       <span className="min-w-0 flex-1">
                                         <span className="flex items-center gap-2">
@@ -469,7 +455,7 @@ export function AgentCatalogView() {
 
               <div className="flex items-start gap-4 md:gap-5">
                 <div className="mari-panel-gradient-surface mari-panel-gradient--agents flex h-20 w-20 shrink-0 items-center justify-center overflow-hidden rounded-2xl md:h-24 md:w-24">
-                  <AgentArtwork entry={selected} iconSize="2rem" />
+                  <AgentArtwork imageUrl={selected.iconUrl} alt={`${selected.manifest.name} artwork`} iconSize="2rem" />
                 </div>
                 <div className="min-w-0 pt-1">
                   <p className="text-xs font-semibold text-[var(--muted-foreground)]">

--- a/packages/client/src/components/characters/CharacterLibraryView.tsx
+++ b/packages/client/src/components/characters/CharacterLibraryView.tsx
@@ -1,17 +1,25 @@
 import { Fragment, useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState, type UIEvent } from "react";
-import { ArrowLeft, ArrowUpDown, Download, Hash, Pencil, Plus, Search, Star, User } from "lucide-react";
-import { flattenCharacterPages, useCharacterPages } from "../../hooks/use-characters";
+import { ArrowLeft, ArrowUpDown, Check, Download, Hash, Pencil, Plus, Search, Star, User } from "lucide-react";
+import { includesTextForMatch, normalizeTextForMatch, type CharacterData } from "@marinara-engine/shared";
+import {
+  flattenCharacterPages,
+  flattenPersonaPages,
+  useCharacterPages,
+  usePersonaPages,
+} from "../../hooks/use-characters";
 import { getCharacterTitle } from "../../lib/character-display";
 import { estimateCharacterCardTokens, formatEstimatedTokens } from "../../lib/character-token-count";
-import { cn, getAvatarCropStyle, type AvatarCropValue } from "../../lib/utils";
-import { useUIStore, type CharacterLibrarySort } from "../../stores/ui.store";
-import { includesTextForMatch, normalizeTextForMatch, type CharacterData } from "@marinara-engine/shared";
+import { cn, getAvatarCropStyle, parseAvatarCropJson, type AvatarCropValue } from "../../lib/utils";
+import {
+  useUIStore,
+  type CardLibraryKind,
+  type CharacterLibrarySort,
+  type ResourcePanelSort,
+} from "../../stores/ui.store";
 
 const libraryToolbarButtonClass =
   "mari-chrome-control mari-chrome-control--primary h-10 min-h-10 min-w-0 px-3 text-[0.75rem]";
 const libraryToolbarFieldClass = "mari-chrome-field h-10 w-full text-[0.75rem] md:h-9";
-const libraryNewCharacterButtonClass =
-  "mari-panel-gradient-button mari-panel-gradient--characters h-10 min-h-10 min-w-0 px-3 text-[0.75rem]";
 
 type CharacterRow = {
   id: string;
@@ -26,6 +34,68 @@ type ParsedCharacterRow = CharacterRow & {
   parsed: Partial<CharacterData> & {
     extensions?: Record<string, unknown>;
   };
+};
+
+type PersonaRow = {
+  id: string;
+  name: string;
+  comment?: string | null;
+  creator?: string | null;
+  personaVersion?: string | null;
+  creatorNotes?: string | null;
+  description?: string | null;
+  personality?: string | null;
+  scenario?: string | null;
+  backstory?: string | null;
+  appearance?: string | null;
+  avatarPath: string | null;
+  avatarCrop?: string | AvatarCropValue | null;
+  isActive?: boolean | string;
+  tags?: string | string[] | null;
+  createdAt: string;
+  updatedAt: string;
+};
+
+type LibrarySection = { title: string; content: string };
+
+type LibraryCard = {
+  id: string;
+  name: string;
+  title: string | null;
+  meta: string | null;
+  summary: string;
+  avatarPath: string | null;
+  avatarCrop?: AvatarCropValue;
+  createdAt: string;
+  updatedAt: string;
+  tags: string[];
+  tokenEstimate: number;
+  favorite: boolean;
+  active: boolean;
+  creatorNotes: string;
+  sections: LibrarySection[];
+};
+
+type LibraryCopy = {
+  singular: "character" | "persona";
+  plural: "characters" | "personas";
+  title: "Character Library" | "Persona Library";
+  heading: string;
+};
+
+const LIBRARY_COPY: Record<CardLibraryKind, LibraryCopy> = {
+  characters: {
+    singular: "character",
+    plural: "characters",
+    title: "Character Library",
+    heading: "Browse your characters",
+  },
+  personas: {
+    singular: "persona",
+    plural: "personas",
+    title: "Persona Library",
+    heading: "Browse your personas",
+  },
 };
 
 function parseCharacterRow(char: CharacterRow): ParsedCharacterRow {
@@ -47,7 +117,22 @@ function getCharacterTags(char: ParsedCharacterRow): string[] {
   );
 }
 
-function parseCharacterSearchQuery(value: string) {
+function getPersonaTags(persona: PersonaRow): string[] {
+  if (Array.isArray(persona.tags)) {
+    return persona.tags.filter((tag): tag is string => typeof tag === "string" && tag.trim().length > 0);
+  }
+  if (!persona.tags) return [];
+  try {
+    const parsed = JSON.parse(persona.tags);
+    return Array.isArray(parsed)
+      ? parsed.filter((tag): tag is string => typeof tag === "string" && tag.trim().length > 0)
+      : [];
+  } catch {
+    return [];
+  }
+}
+
+function parseLibrarySearchQuery(value: string) {
   const excludedTags: string[] = [];
   const text = value
     .replace(/(?:^|\s)(?:-|!)(?:tag:|#)?(?:"([^"]+)"|(\S+))/gi, (_match, quoted: string, bare: string) => {
@@ -65,26 +150,30 @@ function parseCharacterSearchQuery(value: string) {
 }
 
 function getCharacterSummary(char: ParsedCharacterRow) {
-  const creatorNotes = getText(char.parsed.creator_notes);
-  if (creatorNotes) return creatorNotes;
-
-  const description = getText(char.parsed.description);
-  if (description) return description;
-
-  const personality = getText(char.parsed.personality);
-  if (personality) return personality;
-
-  return "No creator notes yet.";
+  return (
+    getText(char.parsed.creator_notes) ||
+    getText(char.parsed.description) ||
+    getText(char.parsed.personality) ||
+    "No creator notes yet."
+  );
 }
 
-function getCharacterMeta(char: ParsedCharacterRow): string | null {
+function getPersonaSummary(persona: PersonaRow) {
+  return (
+    getText(persona.creatorNotes) ||
+    getText(persona.description) ||
+    getText(persona.personality) ||
+    getText(persona.backstory) ||
+    "No creator notes yet."
+  );
+}
+
+function getCardMeta(creator: unknown, version: unknown): string | null {
   const parts: string[] = [];
-  const creator = getText(char.parsed.creator);
-  const version = getText(char.parsed.character_version);
-
-  if (creator) parts.push(creator);
-  if (version) parts.push(`v${version}`);
-
+  const creatorText = getText(creator);
+  const versionText = getText(version);
+  if (creatorText) parts.push(creatorText);
+  if (versionText) parts.push(`v${versionText}`);
   return parts.join(" · ") || null;
 }
 
@@ -93,7 +182,7 @@ function truncateText(content: string, maxLength: number) {
   return `${content.slice(0, maxLength - 3).trimEnd()}...`;
 }
 
-function getCharacterSections(char: ParsedCharacterRow) {
+function getCharacterSections(char: ParsedCharacterRow): LibrarySection[] {
   return [
     { title: "Description", content: getText(char.parsed.description) },
     { title: "Personality", content: getText(char.parsed.personality) },
@@ -102,33 +191,97 @@ function getCharacterSections(char: ParsedCharacterRow) {
   ].filter((section) => section.content);
 }
 
-function CharacterLibraryDetailCard({
-  character,
+function getPersonaSections(persona: PersonaRow): LibrarySection[] {
+  return [
+    { title: "Description", content: getText(persona.description) },
+    { title: "Personality", content: getText(persona.personality) },
+    { title: "Scenario", content: getText(persona.scenario) },
+    { title: "Backstory", content: getText(persona.backstory) },
+    { title: "Appearance", content: getText(persona.appearance) },
+  ].filter((section) => section.content);
+}
+
+function estimatePersonaTokens(persona: PersonaRow) {
+  return Math.ceil(
+    [persona.description, persona.personality, persona.scenario, persona.backstory, persona.appearance]
+      .map(getText)
+      .join("").length / 4,
+  );
+}
+
+function parsePersonaAvatarCrop(value: PersonaRow["avatarCrop"]): AvatarCropValue | undefined {
+  if (!value) return undefined;
+  if (typeof value === "string") return parseAvatarCropJson(value) ?? undefined;
+  return value;
+}
+
+function toCharacterLibraryCard(char: ParsedCharacterRow): LibraryCard {
+  const name = getText(char.parsed.name) || "Unnamed";
+  return {
+    id: char.id,
+    name,
+    title: getCharacterTitle({ name, comment: char.comment }),
+    meta: getCardMeta(char.parsed.creator, char.parsed.character_version),
+    summary: getCharacterSummary(char),
+    avatarPath: char.avatarPath,
+    avatarCrop: char.parsed.extensions?.avatarCrop as AvatarCropValue | undefined,
+    createdAt: char.createdAt,
+    updatedAt: char.updatedAt,
+    tags: getCharacterTags(char),
+    tokenEstimate: estimateCharacterCardTokens(char.parsed),
+    favorite: !!char.parsed.extensions?.fav,
+    active: false,
+    creatorNotes: getText(char.parsed.creator_notes),
+    sections: getCharacterSections(char),
+  };
+}
+
+function toPersonaLibraryCard(persona: PersonaRow): LibraryCard {
+  return {
+    id: persona.id,
+    name: getText(persona.name) || "Unnamed",
+    title: getText(persona.comment) || null,
+    meta: getCardMeta(persona.creator, persona.personaVersion),
+    summary: getPersonaSummary(persona),
+    avatarPath: persona.avatarPath,
+    avatarCrop: parsePersonaAvatarCrop(persona.avatarCrop),
+    createdAt: persona.createdAt,
+    updatedAt: persona.updatedAt,
+    tags: getPersonaTags(persona),
+    tokenEstimate: estimatePersonaTokens(persona),
+    favorite: false,
+    active: persona.isActive === true || persona.isActive === "true",
+    creatorNotes: getText(persona.creatorNotes),
+    sections: getPersonaSections(persona),
+  };
+}
+
+function CardLibraryDetailCard({
+  card,
+  kind,
   onEdit,
 }: {
-  character: ParsedCharacterRow;
+  card: LibraryCard;
+  kind: CardLibraryKind;
   onEdit: (id: string) => void;
 }) {
-  const characterName = getText(character.parsed.name) || "Unnamed";
-  const characterTitle = getCharacterTitle({ name: characterName, comment: character.comment });
-  const characterMeta = getCharacterMeta(character);
-  const creatorNotes = getText(character.parsed.creator_notes);
-  const sections = getCharacterSections(character);
-  const tokenEstimate = estimateCharacterCardTokens(character.parsed);
+  const copy = LIBRARY_COPY[kind];
+  const placeholderClass =
+    kind === "characters" ? "mari-avatar-placeholder--character" : "mari-avatar-placeholder--persona";
 
   return (
     <div className="space-y-4">
-      <div className="overflow-hidden rounded-[1.5rem] border border-[var(--border)]/50 bg-[var(--background)]/70 shadow-[0_24px_70px_-40px_rgba(15,23,42,0.95)] sm:rounded-[2rem]">
-        <div className="mari-avatar-placeholder mari-avatar-placeholder--character relative aspect-square overflow-hidden">
-          {character.avatarPath ? (
+      <div className="overflow-hidden rounded-[1.5rem] border border-[var(--marinara-chat-chrome-panel-border)] bg-[var(--background)]/70 shadow-[0_24px_70px_-40px_rgba(15,23,42,0.95)] sm:rounded-[2rem]">
+        <div className={cn("mari-avatar-placeholder relative aspect-square overflow-hidden", placeholderClass)}>
+          {card.avatarPath ? (
             <img
-              src={character.avatarPath}
-              alt={characterName || "Selected character"}
+              src={card.avatarPath}
+              alt={card.name}
               className="h-full w-full object-cover"
-              style={getAvatarCropStyle(character.parsed.extensions?.avatarCrop as AvatarCropValue | undefined)}
+              style={getAvatarCropStyle(card.avatarCrop)}
             />
           ) : (
-            <div className="flex h-full w-full items-center justify-center text-white/85">
+            <div className="flex h-full w-full items-center justify-center text-[var(--marinara-chat-chrome-panel-title)]">
               <User size="2.5rem" />
             </div>
           )}
@@ -138,62 +291,71 @@ function CharacterLibraryDetailCard({
           <div>
             <div className="flex items-start justify-between gap-3">
               <div className="min-w-0">
-                <h2 className="truncate text-xl font-semibold text-[var(--foreground)] sm:text-2xl">{characterName}</h2>
-                {characterTitle && (
-                  <p className="mt-1 truncate text-sm italic text-[var(--muted-foreground)]">{characterTitle}</p>
+                <h2 className="truncate text-xl font-semibold text-[var(--marinara-chat-chrome-panel-title)] sm:text-2xl">
+                  {card.name}
+                </h2>
+                {card.title && (
+                  <p className="mt-1 truncate text-sm italic text-[var(--marinara-chat-chrome-panel-muted)]">
+                    {card.title}
+                  </p>
                 )}
-                {characterMeta && (
-                  <p className="mt-1 text-xs font-semibold uppercase tracking-[0.22em] text-[var(--muted-foreground)]">
-                    {characterMeta}
+                {card.meta && (
+                  <p className="mt-1 text-xs font-semibold uppercase tracking-[0.22em] text-[var(--marinara-chat-chrome-panel-muted)]">
+                    {card.meta}
                   </p>
                 )}
               </div>
               <div className="flex shrink-0 flex-col items-end gap-1.5">
                 <span
                   className="mari-chrome-muted-badge gap-1 px-2.5 py-1 text-[0.6875rem]"
-                  title="Estimated from character card text fields; actual tokenizer counts vary by model."
+                  title={`Estimated from ${copy.singular} card text fields; actual tokenizer counts vary by model.`}
                 >
                   <Hash size="0.75rem" />
-                  {formatEstimatedTokens(tokenEstimate)}
+                  {formatEstimatedTokens(card.tokenEstimate)}
                 </span>
-                {character.parsed.extensions?.fav && (
+                {card.favorite && (
                   <span className="inline-flex items-center gap-1 rounded-full bg-amber-500/10 px-2.5 py-1 text-[0.6875rem] font-medium text-amber-300">
                     <Star size="0.75rem" className="fill-current" /> Favorite
+                  </span>
+                )}
+                {card.active && (
+                  <span className="mari-chrome-muted-badge mari-chrome-accent-surface gap-1 px-2.5 py-1 text-[0.6875rem]">
+                    <Check size="0.75rem" /> Active
                   </span>
                 )}
               </div>
             </div>
 
-            {creatorNotes && (
-              <p className="mt-4 rounded-[1.5rem] border border-[var(--border)]/50 bg-[var(--secondary)]/70 px-4 py-3 text-sm leading-6 text-[var(--muted-foreground)]">
-                {creatorNotes}
+            {card.creatorNotes && (
+              <p className="mt-4 rounded-[1.5rem] border border-[var(--marinara-chat-chrome-panel-border)] bg-[var(--marinara-chat-chrome-highlight-bg)] px-4 py-3 text-sm leading-6 text-[var(--marinara-chat-chrome-panel-text)]">
+                {card.creatorNotes}
               </p>
             )}
 
             <div className="mt-4 flex flex-wrap gap-2">
               <button
-                onClick={() => onEdit(character.id)}
+                onClick={() => onEdit(card.id)}
                 className="mari-chrome-control mari-chrome-control--primary px-4 py-2.5 text-sm"
               >
                 <Pencil size="0.875rem" />
-                Edit Character
+                Edit {copy.singular === "character" ? "Character" : "Persona"}
               </button>
             </div>
           </div>
         </div>
       </div>
 
-      {sections.length > 0 && (
+      {card.sections.length > 0 && (
         <div className="space-y-3">
-          {sections.map((section) => (
+          {card.sections.map((section) => (
             <section
               key={section.title}
-              className="rounded-[1.5rem] border border-[var(--border)]/50 bg-[var(--background)]/65 p-4"
+              className="rounded-[1.5rem] border border-[var(--marinara-chat-chrome-panel-border)] bg-[var(--background)]/65 p-4"
             >
-              <h3 className="text-xs font-semibold uppercase tracking-[0.18em] text-[var(--muted-foreground)]">
+              <h3 className="text-xs font-semibold uppercase tracking-[0.18em] text-[var(--marinara-chat-chrome-panel-muted)]">
                 {section.title}
               </h3>
-              <p className="mt-3 whitespace-pre-wrap text-sm leading-6 text-[var(--foreground)]/88">
+              <p className="mt-3 whitespace-pre-wrap text-sm leading-6 text-[var(--marinara-chat-chrome-panel-text)]">
                 {truncateText(section.content, section.title === "Opening Message" ? 420 : 620)}
               </p>
             </section>
@@ -205,85 +367,100 @@ function CharacterLibraryDetailCard({
 }
 
 export function CharacterLibraryView() {
-  const closeCharacterLibrary = useUIStore((s) => s.closeCharacterLibrary);
+  const kind = useUIStore((s) => s.cardLibraryKind);
+  const copy = LIBRARY_COPY[kind];
+  const isPersonaLibrary = kind === "personas";
+  const closeLibrary = useUIStore((s) => s.closeCharacterLibrary);
   const openCharacterDetail = useUIStore((s) => s.openCharacterDetail);
+  const openPersonaDetail = useUIStore((s) => s.openPersonaDetail);
   const openModal = useUIStore((s) => s.openModal);
-  const selectedCharacterId = useUIStore((s) => s.characterLibrarySelectedId);
-  const setSelectedCharacterId = useUIStore((s) => s.setCharacterLibrarySelectedId);
-  const sort = useUIStore((s) => s.characterLibrarySort);
-  const setCharacterLibrarySort = useUIStore((s) => s.setCharacterLibrarySort);
-  const setCharacterLibraryScrollTop = useUIStore((s) => s.setCharacterLibraryScrollTop);
+  const characterSelectedId = useUIStore((s) => s.characterLibrarySelectedId);
+  const personaSelectedId = useUIStore((s) => s.personaLibrarySelectedId);
+  const setCharacterSelectedId = useUIStore((s) => s.setCharacterLibrarySelectedId);
+  const setPersonaSelectedId = useUIStore((s) => s.setPersonaLibrarySelectedId);
+  const characterSort = useUIStore((s) => s.characterLibrarySort);
+  const personaSort = useUIStore((s) => s.personaLibrarySort);
+  const setCharacterSort = useUIStore((s) => s.setCharacterLibrarySort);
+  const setPersonaSort = useUIStore((s) => s.setPersonaLibrarySort);
+  const setCharacterScrollTop = useUIStore((s) => s.setCharacterLibraryScrollTop);
+  const setPersonaScrollTop = useUIStore((s) => s.setPersonaLibraryScrollTop);
 
+  const selectedId = isPersonaLibrary ? personaSelectedId : characterSelectedId;
+  const sort = isPersonaLibrary ? personaSort : characterSort;
   const [search, setSearch] = useState("");
-  const serverSearch = useMemo(() => parseCharacterSearchQuery(search).text, [search]);
-  const characterPages = useCharacterPages({ search: serverSearch, sort });
+  const serverSearch = useMemo(() => parseLibrarySearchQuery(search).text, [search]);
+  const characterPages = useCharacterPages({ enabled: !isPersonaLibrary, search: serverSearch, sort: characterSort });
+  const personaPages = usePersonaPages({ enabled: isPersonaLibrary, search: serverSearch, sort: personaSort });
   const characters = useMemo(() => flattenCharacterPages(characterPages.data), [characterPages.data]);
-  const isLoading = characterPages.isLoading;
+  const personas = useMemo(() => flattenPersonaPages(personaPages.data), [personaPages.data]);
+  const isLoading = isPersonaLibrary ? personaPages.isLoading : characterPages.isLoading;
+  const hasNextPage = isPersonaLibrary ? personaPages.hasNextPage : characterPages.hasNextPage;
+  const isFetchingNextPage = isPersonaLibrary ? personaPages.isFetchingNextPage : characterPages.isFetchingNextPage;
   const libraryRootScrollRef = useRef<HTMLDivElement | null>(null);
   const libraryListScrollRef = useRef<HTMLElement | null>(null);
   const pendingLibraryScrollTopRef = useRef(0);
   const libraryScrollFrameRef = useRef<number | null>(null);
 
-  const parsedCharacters = useMemo(() => {
-    if (!characters) return [];
-    return (characters as CharacterRow[]).map(parseCharacterRow);
-  }, [characters]);
+  const cards = useMemo<LibraryCard[]>(() => {
+    if (isPersonaLibrary) return (personas as PersonaRow[]).map(toPersonaLibraryCard);
+    return (characters as CharacterRow[]).map(parseCharacterRow).map(toCharacterLibraryCard);
+  }, [characters, isPersonaLibrary, personas]);
 
-  const filteredCharacters = useMemo(() => {
-    const query = parseCharacterSearchQuery(search);
-
-    return parsedCharacters.filter((char) => {
-      const tags = getCharacterTags(char);
-      const tagSet = new Set(tags.map((tag) => normalizeTextForMatch(tag)));
+  const filteredCards = useMemo(() => {
+    const query = parseLibrarySearchQuery(search);
+    return cards.filter((card) => {
+      const tagSet = new Set(card.tags.map((tag) => normalizeTextForMatch(tag)));
       if (query.excludedTags.some((tag) => tagSet.has(tag))) return false;
       if (!query.text) return true;
-
-      const fields = [
-        getText(char.parsed.name),
-        getText(char.comment),
-        getText(char.parsed.creator),
-        getText(char.parsed.description),
-        getText(char.parsed.creator_notes),
-        getText(char.parsed.personality),
-        ...tags,
-      ];
-
-      return fields.some((value) => includesTextForMatch(value, query.text));
+      return [
+        card.name,
+        card.title,
+        card.meta,
+        card.summary,
+        ...card.tags,
+        ...card.sections.map((section) => section.content),
+      ]
+        .filter((value): value is string => typeof value === "string")
+        .some((value) => includesTextForMatch(value, query.text));
     });
-  }, [parsedCharacters, search]);
+  }, [cards, search]);
 
-  const sortedCharacters = useMemo(() => {
-    const list = [...filteredCharacters];
-
+  const sortedCards = useMemo(() => {
+    const list = [...filteredCards];
     switch (sort) {
       case "name-asc":
-        return list.sort((left, right) => getText(left.parsed.name).localeCompare(getText(right.parsed.name)));
+        return list.sort((left, right) => left.name.localeCompare(right.name));
       case "name-desc":
-        return list.sort((left, right) => getText(right.parsed.name).localeCompare(getText(left.parsed.name)));
+        return list.sort((left, right) => right.name.localeCompare(left.name));
       case "newest":
         return list.sort((left, right) => (right.createdAt ?? "").localeCompare(left.createdAt ?? ""));
       case "oldest":
         return list.sort((left, right) => (left.createdAt ?? "").localeCompare(right.createdAt ?? ""));
       case "favorites":
-        return list.sort((left, right) => {
-          const leftFavorite = left.parsed.extensions?.fav ? 1 : 0;
-          const rightFavorite = right.parsed.extensions?.fav ? 1 : 0;
-          if (rightFavorite !== leftFavorite) return rightFavorite - leftFavorite;
-          return getText(left.parsed.name).localeCompare(getText(right.parsed.name));
-        });
+        return list.sort(
+          (left, right) => Number(right.favorite) - Number(left.favorite) || left.name.localeCompare(right.name),
+        );
       default:
         return list;
     }
-  }, [filteredCharacters, sort]);
+  }, [filteredCards, sort]);
+
+  const setSelectedId = useCallback(
+    (id: string | null) => {
+      if (isPersonaLibrary) setPersonaSelectedId(id);
+      else setCharacterSelectedId(id);
+    },
+    [isPersonaLibrary, setCharacterSelectedId, setPersonaSelectedId],
+  );
 
   useEffect(() => {
-    if (selectedCharacterId && sortedCharacters.some((char) => char.id === selectedCharacterId)) return;
-    setSelectedCharacterId(sortedCharacters[0]?.id ?? null);
-  }, [selectedCharacterId, setSelectedCharacterId, sortedCharacters]);
+    if (selectedId && sortedCards.some((card) => card.id === selectedId)) return;
+    setSelectedId(sortedCards[0]?.id ?? null);
+  }, [selectedId, setSelectedId, sortedCards]);
 
-  const selectedCharacter = useMemo(
-    () => sortedCharacters.find((char) => char.id === selectedCharacterId) ?? null,
-    [selectedCharacterId, sortedCharacters],
+  const selectedCard = useMemo(
+    () => sortedCards.find((card) => card.id === selectedId) ?? null,
+    [selectedId, sortedCards],
   );
 
   const getActiveLibraryScrollNode = useCallback(() => {
@@ -299,12 +476,20 @@ export function CharacterLibraryView() {
     );
   }, []);
 
+  const saveScrollTop = useCallback(
+    (scrollTop: number) => {
+      if (isPersonaLibrary) setPersonaScrollTop(scrollTop);
+      else setCharacterScrollTop(scrollTop);
+    },
+    [isPersonaLibrary, setCharacterScrollTop, setPersonaScrollTop],
+  );
+
   const rememberLibraryScroll = useCallback(() => {
     const node = getActiveLibraryScrollNode();
     if (!node) return;
     pendingLibraryScrollTopRef.current = node.scrollTop;
-    setCharacterLibraryScrollTop(node.scrollTop);
-  }, [getActiveLibraryScrollNode, setCharacterLibraryScrollTop]);
+    saveScrollTop(node.scrollTop);
+  }, [getActiveLibraryScrollNode, saveScrollTop]);
 
   const handleLibraryScroll = useCallback(
     (event: UIEvent<HTMLElement>) => {
@@ -313,16 +498,17 @@ export function CharacterLibraryView() {
       if (libraryScrollFrameRef.current !== null) return;
       libraryScrollFrameRef.current = window.requestAnimationFrame(() => {
         libraryScrollFrameRef.current = null;
-        setCharacterLibraryScrollTop(pendingLibraryScrollTopRef.current);
+        saveScrollTop(pendingLibraryScrollTopRef.current);
       });
     },
-    [setCharacterLibraryScrollTop],
+    [saveScrollTop],
   );
 
   useLayoutEffect(() => {
     if (isLoading) return;
     const restoreScroll = () => {
-      const scrollTop = useUIStore.getState().characterLibraryScrollTop;
+      const state = useUIStore.getState();
+      const scrollTop = isPersonaLibrary ? state.personaLibraryScrollTop : state.characterLibraryScrollTop;
       for (const node of [libraryRootScrollRef.current, libraryListScrollRef.current]) {
         if (!node) continue;
         const maxScrollTop = Math.max(0, node.scrollHeight - node.clientHeight);
@@ -332,71 +518,81 @@ export function CharacterLibraryView() {
     restoreScroll();
     const frame = window.requestAnimationFrame(restoreScroll);
     return () => window.cancelAnimationFrame(frame);
-  }, [isLoading, sortedCharacters.length]);
+  }, [isLoading, isPersonaLibrary, sortedCards.length]);
 
   useLayoutEffect(
     () => () => {
-      if (libraryScrollFrameRef.current !== null) {
-        window.cancelAnimationFrame(libraryScrollFrameRef.current);
-      }
+      if (libraryScrollFrameRef.current !== null) window.cancelAnimationFrame(libraryScrollFrameRef.current);
     },
     [],
   );
 
-  const openCharacterDetailFromLibrary = (id: string) => {
+  const openDetailFromLibrary = (id: string) => {
     rememberLibraryScroll();
-    setSelectedCharacterId(id);
-    openCharacterDetail(id, { preserveCharacterLibrary: true });
+    setSelectedId(id);
+    if (isPersonaLibrary) openPersonaDetail(id, { preservePersonaLibrary: true });
+    else openCharacterDetail(id, { preserveCharacterLibrary: true });
   };
 
   const handleSortChange = (value: string) => {
-    setCharacterLibrarySort(value as CharacterLibrarySort);
+    if (isPersonaLibrary) setPersonaSort(value as ResourcePanelSort);
+    else setCharacterSort(value as CharacterLibrarySort);
   };
+
+  const fetchNextPage = () => {
+    if (isPersonaLibrary) void personaPages.fetchNextPage();
+    else void characterPages.fetchNextPage();
+  };
+
+  const placeholderClass = isPersonaLibrary ? "mari-avatar-placeholder--persona" : "mari-avatar-placeholder--character";
+  const newCardButtonClass = cn(
+    "mari-panel-gradient-button h-10 min-h-10 min-w-0 px-3 text-[0.75rem]",
+    isPersonaLibrary ? "mari-panel-gradient--personas" : "mari-panel-gradient--characters",
+  );
 
   return (
     <div
       ref={libraryRootScrollRef}
       onScroll={handleLibraryScroll}
-      className="flex h-full min-h-0 flex-col overflow-y-auto overflow-x-hidden bg-[radial-gradient(circle_at_top_left,_color-mix(in_srgb,var(--primary)_14%,transparent),_transparent_30%),radial-gradient(circle_at_top_right,_rgba(56,189,248,0.14),_transparent_26%),var(--background)] lg:overflow-hidden"
+      className="mari-chrome-token-scope flex h-full min-h-0 flex-col overflow-y-auto overflow-x-hidden bg-[radial-gradient(circle_at_top_left,_color-mix(in_srgb,var(--marinara-chat-chrome-accent)_14%,transparent),_transparent_30%),radial-gradient(circle_at_top_right,_color-mix(in_srgb,var(--marinara-chat-chrome-text)_10%,transparent),_transparent_26%),var(--background)] text-[var(--marinara-chat-chrome-panel-text)] lg:overflow-hidden"
     >
-      <div className="sticky top-0 z-10 border-b border-[var(--border)]/40 bg-[var(--card)]/85 backdrop-blur-xl">
+      <div className="sticky top-0 z-10 border-b border-[var(--marinara-chat-chrome-panel-divider)] bg-[var(--card)]/85 backdrop-blur-xl">
         <div className="flex flex-col gap-2 px-3 py-2 md:px-6 md:py-3 lg:flex-row lg:items-start lg:justify-between">
           <div className="flex min-w-0 items-center gap-3">
             <button
-              onClick={closeCharacterLibrary}
+              onClick={closeLibrary}
               className="mari-chrome-control h-9 w-9 rounded-2xl p-0 md:h-10 md:w-10"
               title="Close library"
             >
               <ArrowLeft size="0.95rem" />
             </button>
             <div className="min-w-0">
-              <p className="text-[0.625rem] font-semibold uppercase tracking-[0.28em] text-[var(--muted-foreground)]">
-                Character Library
+              <p className="text-[0.625rem] font-semibold uppercase tracking-[0.28em] text-[var(--marinara-chat-chrome-panel-muted)]">
+                {copy.title}
               </p>
-              <h1 className="truncate text-base font-semibold text-[var(--foreground)] md:text-2xl">
-                Browse your characters
+              <h1 className="truncate text-base font-semibold text-[var(--marinara-chat-chrome-panel-title)] md:text-2xl">
+                {copy.heading}
               </h1>
-              <p className="text-xs text-[var(--muted-foreground)] md:text-sm">
-                {filteredCharacters.length} out of {parsedCharacters.length} card
-                {parsedCharacters.length === 1 ? "" : "s"}
+              <p className="text-xs text-[var(--marinara-chat-chrome-panel-muted)] md:text-sm">
+                {filteredCards.length} out of {cards.length} card{cards.length === 1 ? "" : "s"}
               </p>
             </div>
           </div>
 
           <div className="grid w-full grid-cols-2 gap-1.5 sm:ml-auto sm:w-72 lg:w-80">
             <button
-              onClick={() => openModal("create-character")}
-              className={libraryNewCharacterButtonClass}
-              title="New character"
-              aria-label="New character"
+              onClick={() => openModal(isPersonaLibrary ? "create-persona" : "create-character")}
+              className={newCardButtonClass}
+              title={`New ${copy.singular}`}
+              aria-label={`New ${copy.singular}`}
             >
               <Plus size="0.75rem" />
             </button>
             <button
-              onClick={() => openModal("import-character")}
+              onClick={() => openModal(isPersonaLibrary ? "import-persona" : "import-character")}
               className={libraryToolbarButtonClass}
-              title="Import character"
-              aria-label="Import character"
+              title={`Import ${copy.singular}`}
+              aria-label={`Import ${copy.singular}`}
             >
               <Download size="0.75rem" />
             </button>
@@ -409,8 +605,8 @@ export function CharacterLibraryView() {
               <input
                 value={search}
                 onChange={(event) => setSearch(event.target.value)}
-                placeholder="Search characters"
-                className={cn(libraryToolbarFieldClass, "pl-7 pr-2.5 placeholder:text-[var(--muted-foreground)]/70")}
+                placeholder={`Search ${copy.plural}`}
+                className={cn(libraryToolbarFieldClass, "pl-7 pr-2.5")}
               />
             </div>
 
@@ -427,7 +623,7 @@ export function CharacterLibraryView() {
                 <option value="name-desc">Name Z-A</option>
                 <option value="newest">Newest</option>
                 <option value="oldest">Oldest</option>
-                <option value="favorites">Favorites first</option>
+                {!isPersonaLibrary && <option value="favorites">Favorites first</option>}
               </select>
               <ArrowUpDown
                 size="0.6875rem"
@@ -452,115 +648,121 @@ export function CharacterLibraryView() {
             </div>
           )}
 
-          {!isLoading && sortedCharacters.length === 0 && (
-            <div className="flex min-h-[18rem] flex-col items-center justify-center gap-3 rounded-[2rem] border border-dashed border-[var(--border)]/60 bg-[var(--card)]/50 p-6 text-center">
-              <div className="mari-avatar-placeholder mari-avatar-placeholder--character flex h-14 w-14 items-center justify-center rounded-3xl">
+          {!isLoading && sortedCards.length === 0 && (
+            <div className="flex min-h-[18rem] flex-col items-center justify-center gap-3 rounded-[2rem] border border-dashed border-[var(--marinara-chat-chrome-panel-border)] bg-[var(--card)]/50 p-6 text-center">
+              <div
+                className={cn(
+                  "mari-avatar-placeholder flex h-14 w-14 items-center justify-center rounded-3xl",
+                  placeholderClass,
+                )}
+              >
                 <User size="1.5rem" />
               </div>
               <div>
-                <h2 className="text-lg font-semibold text-[var(--foreground)]">No matching characters</h2>
-                <p className="mt-1 max-w-md text-sm text-[var(--muted-foreground)]">
+                <h2 className="text-lg font-semibold text-[var(--marinara-chat-chrome-panel-title)]">
+                  No matching {copy.plural}
+                </h2>
+                <p className="mt-1 max-w-md text-sm text-[var(--marinara-chat-chrome-panel-muted)]">
                   Try a different search, adjust sorting, or import a new card into the library.
                 </p>
               </div>
             </div>
           )}
 
-          {!isLoading && sortedCharacters.length > 0 && (
+          {!isLoading && sortedCards.length > 0 && (
             <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 sm:gap-3 xl:grid-cols-3 2xl:grid-cols-4">
-              {sortedCharacters.map((char) => {
-                const charName = getText(char.parsed.name) || "Unnamed";
-                const charTitle = getCharacterTitle({ name: charName, comment: char.comment });
-                const cardSummary = truncateText(getCharacterSummary(char), 180);
-                const cardMeta = getCharacterMeta(char);
-                const tokenEstimate = estimateCharacterCardTokens(char.parsed);
-                const isFavorite = !!char.parsed.extensions?.fav;
-                const tags = getCharacterTags(char);
-                const isActive = selectedCharacterId === char.id;
-
+              {sortedCards.map((card) => {
+                const cardSummary = truncateText(card.summary, 180);
+                const isSelected = selectedId === card.id;
                 return (
-                  <Fragment key={char.id}>
+                  <Fragment key={card.id}>
                     <button
                       type="button"
-                      onClick={() => setSelectedCharacterId(char.id)}
+                      onClick={() => setSelectedId(card.id)}
                       className={cn(
-                        "group flex h-full items-stretch overflow-hidden rounded-[1.25rem] border bg-[var(--card)]/70 text-left shadow-[0_20px_50px_-32px_rgba(15,23,42,0.75)] transition-all hover:border-[var(--primary)]/35 hover:shadow-[0_24px_60px_-32px_color-mix(in_srgb,var(--primary)_45%,transparent)] sm:flex-col sm:rounded-[1.75rem] sm:hover:-translate-y-0.5",
-                        isActive
-                          ? "border-[var(--primary)]/45 ring-1 ring-[var(--primary)]/25"
-                          : "border-[var(--border)]/50",
+                        "group flex h-full items-stretch overflow-hidden rounded-[1.25rem] border bg-[var(--card)]/70 text-left shadow-[0_20px_50px_-32px_rgba(15,23,42,0.75)] transition-all hover:border-[var(--marinara-chat-chrome-button-border-hover)] hover:shadow-[0_24px_60px_-32px_color-mix(in_srgb,var(--marinara-chat-chrome-accent)_35%,transparent)] sm:flex-col sm:rounded-[1.75rem] sm:hover:-translate-y-0.5",
+                        isSelected
+                          ? "border-[var(--marinara-chat-chrome-button-border-active)] ring-1 ring-[var(--marinara-chat-chrome-focus-ring)]"
+                          : "border-[var(--marinara-chat-chrome-panel-border)]",
                       )}
                     >
-                      <div className="mari-avatar-placeholder mari-avatar-placeholder--character relative h-24 w-24 shrink-0 overflow-hidden sm:h-auto sm:w-full sm:aspect-square">
-                        {char.avatarPath ? (
+                      <div
+                        className={cn(
+                          "mari-avatar-placeholder relative h-24 w-24 shrink-0 overflow-hidden sm:h-auto sm:w-full sm:aspect-square",
+                          placeholderClass,
+                        )}
+                      >
+                        {card.avatarPath ? (
                           <img
-                            src={char.avatarPath}
-                            alt={charName}
+                            src={card.avatarPath}
+                            alt={card.name}
                             loading="lazy"
                             className="h-full w-full object-cover transition-transform duration-300 group-hover:scale-[1.03]"
-                            style={getAvatarCropStyle(char.parsed.extensions?.avatarCrop as AvatarCropValue | undefined)}
+                            style={getAvatarCropStyle(card.avatarCrop)}
                           />
                         ) : (
-                          <div className="flex h-full w-full items-center justify-center text-white/85">
+                          <div className="flex h-full w-full items-center justify-center text-[var(--marinara-chat-chrome-panel-title)]">
                             <User size="1.5rem" className="sm:h-8 sm:w-8" />
                           </div>
                         )}
-
-                        {isFavorite && (
+                        {card.favorite && (
                           <div className="absolute right-2 top-2 inline-flex items-center gap-1 rounded-full bg-black/55 px-2 py-1 text-[0.5625rem] font-medium text-amber-200 backdrop-blur-sm sm:right-3 sm:top-3 sm:text-[0.625rem]">
                             <Star size="0.625rem" className="fill-current sm:h-[0.6875rem] sm:w-[0.6875rem]" /> Favorite
+                          </div>
+                        )}
+                        {card.active && (
+                          <div className="mari-chrome-accent-surface absolute right-2 top-2 inline-flex items-center gap-1 rounded-full px-2 py-1 text-[0.5625rem] font-medium backdrop-blur-sm sm:right-3 sm:top-3 sm:text-[0.625rem]">
+                            <Check size="0.625rem" /> Active
                           </div>
                         )}
                       </div>
 
                       <div className="flex min-w-0 flex-1 flex-col gap-2 p-3 sm:gap-3 sm:p-4">
                         <div className="min-w-0">
-                          <div className="truncate text-sm font-semibold text-[var(--foreground)] sm:text-base">
-                            {charName}
+                          <div className="truncate text-sm font-semibold text-[var(--marinara-chat-chrome-panel-title)] sm:text-base">
+                            {card.name}
                           </div>
-                          {charTitle && (
-                            <div className="mt-0.5 truncate text-[0.625rem] italic text-[var(--muted-foreground)] sm:mt-1 sm:text-[0.6875rem]">
-                              {charTitle}
+                          {card.title && (
+                            <div className="mt-0.5 truncate text-[0.625rem] italic text-[var(--marinara-chat-chrome-panel-muted)] sm:mt-1 sm:text-[0.6875rem]">
+                              {card.title}
                             </div>
                           )}
-                          {cardMeta && (
-                            <div className="mt-0.5 truncate text-[0.5625rem] font-semibold uppercase tracking-[0.14em] text-[var(--muted-foreground)] sm:mt-1 sm:text-[0.625rem] sm:tracking-[0.18em]">
-                              {cardMeta}
+                          {card.meta && (
+                            <div className="mt-0.5 truncate text-[0.5625rem] font-semibold uppercase tracking-[0.14em] text-[var(--marinara-chat-chrome-panel-muted)] sm:mt-1 sm:text-[0.625rem] sm:tracking-[0.18em]">
+                              {card.meta}
                             </div>
                           )}
                         </div>
-
-                        <p className="line-clamp-3 text-[0.6875rem] leading-4 text-[var(--muted-foreground)] sm:line-clamp-4 sm:text-xs sm:leading-5">
+                        <p className="line-clamp-3 text-[0.6875rem] leading-4 text-[var(--marinara-chat-chrome-panel-muted)] sm:line-clamp-4 sm:text-xs sm:leading-5">
                           {cardSummary}
                         </p>
-
                         <div className="mt-auto flex flex-wrap gap-1 sm:gap-1.5">
                           <span
                             className="mari-chrome-muted-badge gap-1 px-1.5 py-0.5 text-[0.5625rem] sm:px-2 sm:py-1 sm:text-[0.625rem]"
-                            title="Estimated from character card text fields; actual tokenizer counts vary by model."
+                            title={`Estimated from ${copy.singular} card text fields; actual tokenizer counts vary by model.`}
                           >
-                            <Hash size="0.5625rem" />
-                            {formatEstimatedTokens(tokenEstimate)}
+                            <Hash size="0.5625rem" /> {formatEstimatedTokens(card.tokenEstimate)}
                           </span>
-                          {tags.slice(0, 2).map((tag) => (
+                          {card.tags.slice(0, 2).map((tag) => (
                             <span
                               key={tag}
-                              className="rounded-full bg-[var(--primary)]/8 px-1.5 py-0.5 text-[0.5625rem] font-medium text-[var(--primary)]/85 sm:px-2 sm:py-1 sm:text-[0.625rem]"
+                              className="rounded-full bg-[var(--marinara-chat-chrome-highlight-bg)] px-1.5 py-0.5 text-[0.5625rem] font-medium text-[var(--marinara-chat-chrome-panel-text)] sm:px-2 sm:py-1 sm:text-[0.625rem]"
                             >
                               {tag}
                             </span>
                           ))}
-                          {tags.length > 2 && (
-                            <span className="rounded-full bg-[var(--secondary)] px-1.5 py-0.5 text-[0.5625rem] text-[var(--muted-foreground)] sm:px-2 sm:py-1 sm:text-[0.625rem]">
-                              +{tags.length - 2}
+                          {card.tags.length > 2 && (
+                            <span className="rounded-full bg-[var(--marinara-chat-chrome-button-bg)] px-1.5 py-0.5 text-[0.5625rem] text-[var(--marinara-chat-chrome-panel-muted)] sm:px-2 sm:py-1 sm:text-[0.625rem]">
+                              +{card.tags.length - 2}
                             </span>
                           )}
                         </div>
                       </div>
                     </button>
 
-                    {isActive && (
+                    {isSelected && (
                       <div className="col-span-full lg:hidden">
-                        <CharacterLibraryDetailCard character={char} onEdit={openCharacterDetailFromLibrary} />
+                        <CardLibraryDetailCard card={card} kind={kind} onEdit={openDetailFromLibrary} />
                       </div>
                     )}
                   </Fragment>
@@ -569,33 +771,40 @@ export function CharacterLibraryView() {
             </div>
           )}
 
-          {!isLoading && characterPages.hasNextPage && (
-            <div className="sticky bottom-0 z-20 -mx-4 mt-4 flex justify-center border-t border-[var(--border)]/45 bg-[var(--background)]/92 px-4 py-3 backdrop-blur-md md:-mx-6 md:px-6">
+          {!isLoading && hasNextPage && (
+            <div className="sticky bottom-0 z-20 -mx-4 mt-4 flex justify-center border-t border-[var(--marinara-chat-chrome-panel-divider)] bg-[var(--background)]/92 px-4 py-3 backdrop-blur-md md:-mx-6 md:px-6">
               <button
                 type="button"
-                onClick={() => void characterPages.fetchNextPage()}
-                disabled={characterPages.isFetchingNextPage}
+                onClick={fetchNextPage}
+                disabled={isFetchingNextPage}
                 className="mari-chrome-control mari-chrome-control--primary px-5 py-2 text-sm"
               >
-                {characterPages.isFetchingNextPage ? "Loading..." : `Load more (${parsedCharacters.length} loaded)`}
+                {isFetchingNextPage ? "Loading..." : `Load more (${cards.length} loaded)`}
               </button>
             </div>
           )}
         </section>
 
-        <aside className="hidden min-h-0 overflow-visible border-t border-[var(--border)]/40 bg-[var(--card)]/65 backdrop-blur-xl lg:block lg:overflow-y-auto lg:border-l lg:border-t-0">
+        <aside className="hidden min-h-0 overflow-visible border-t border-[var(--marinara-chat-chrome-panel-divider)] bg-[var(--card)]/65 backdrop-blur-xl lg:block lg:overflow-y-auto lg:border-l lg:border-t-0">
           <div className="space-y-4 p-4 md:p-6">
-            {selectedCharacter ? (
-              <CharacterLibraryDetailCard character={selectedCharacter} onEdit={openCharacterDetailFromLibrary} />
+            {selectedCard ? (
+              <CardLibraryDetailCard card={selectedCard} kind={kind} onEdit={openDetailFromLibrary} />
             ) : (
-              <div className="flex min-h-[18rem] flex-col items-center justify-center gap-3 rounded-[2rem] border border-dashed border-[var(--border)]/60 bg-[var(--background)]/65 p-6 text-center">
-                <div className="mari-avatar-placeholder mari-avatar-placeholder--character flex h-14 w-14 items-center justify-center rounded-3xl">
+              <div className="flex min-h-[18rem] flex-col items-center justify-center gap-3 rounded-[2rem] border border-dashed border-[var(--marinara-chat-chrome-panel-border)] bg-[var(--background)]/65 p-6 text-center">
+                <div
+                  className={cn(
+                    "mari-avatar-placeholder flex h-14 w-14 items-center justify-center rounded-3xl",
+                    placeholderClass,
+                  )}
+                >
                   <User size="1.5rem" />
                 </div>
                 <div>
-                  <h2 className="text-lg font-semibold text-[var(--foreground)]">Select a card</h2>
-                  <p className="mt-1 text-sm text-[var(--muted-foreground)]">
-                    Pick a character from the grid to see a larger overview before editing.
+                  <h2 className="text-lg font-semibold text-[var(--marinara-chat-chrome-panel-title)]">
+                    Select a card
+                  </h2>
+                  <p className="mt-1 text-sm text-[var(--marinara-chat-chrome-panel-muted)]">
+                    Pick a {copy.singular} from the grid to see a larger overview before editing.
                   </p>
                 </div>
               </div>

--- a/packages/client/src/components/characters/CharacterLibraryView.tsx
+++ b/packages/client/src/components/characters/CharacterLibraryView.tsx
@@ -553,6 +553,7 @@ export function CharacterLibraryView() {
   return (
     <div
       ref={libraryRootScrollRef}
+      data-component="CharacterLibraryView"
       onScroll={handleLibraryScroll}
       className="mari-chrome-token-scope flex h-full min-h-0 flex-col overflow-y-auto overflow-x-hidden bg-[radial-gradient(circle_at_top_left,_color-mix(in_srgb,var(--marinara-chat-chrome-accent)_14%,transparent),_transparent_30%),radial-gradient(circle_at_top_right,_color-mix(in_srgb,var(--marinara-chat-chrome-text)_10%,transparent),_transparent_26%),var(--background)] text-[var(--marinara-chat-chrome-panel-text)] lg:overflow-hidden"
     >
@@ -605,7 +606,7 @@ export function CharacterLibraryView() {
               <input
                 value={search}
                 onChange={(event) => setSearch(event.target.value)}
-                placeholder={`Search ${copy.plural}`}
+                placeholder={isPersonaLibrary ? "Search personas" : 'Search characters or -tag:"tag name"'}
                 className={cn(libraryToolbarFieldClass, "pl-7 pr-2.5")}
               />
             </div>

--- a/packages/client/src/components/layout/AppShell.tsx
+++ b/packages/client/src/components/layout/AppShell.tsx
@@ -387,6 +387,7 @@ export function AppShell() {
 
   const characterDetailId = useUIStore((s) => s.characterDetailId);
   const characterLibraryOpen = useUIStore((s) => s.characterLibraryOpen);
+  const cardLibraryKind = useUIStore((s) => s.cardLibraryKind);
   const agentCatalogOpen = useUIStore((s) => s.agentCatalogOpen);
   const lorebookDetailId = useUIStore((s) => s.lorebookDetailId);
   const presetDetailId = useUIStore((s) => s.presetDetailId);
@@ -561,7 +562,7 @@ export function AppShell() {
   ) : characterDetailId ? (
     <CharacterEditor />
   ) : characterLibraryOpen ? (
-    <CharacterLibraryView />
+    <CharacterLibraryView key={cardLibraryKind} />
   ) : agentCatalogOpen ? (
     <AgentCatalogView />
   ) : lorebookDetailId ? (
@@ -918,7 +919,7 @@ export function AppShell() {
         <div className="flex-shrink-0 md:hidden h-[env(safe-area-inset-top)] bg-[var(--marinara-topbar-surface)] backdrop-blur-sm" />
         <TopBar />
         <div className="mari-app-background-paint relative flex flex-1 flex-col overflow-hidden">
-          {/* Bot Browser — kept mounted once opened so state persists across close/reopen */}
+          {/* Card Browser — kept mounted once opened so state persists across close/reopen */}
           <MountOnceWhenOpened open={botBrowserOpen} overlay>
             <BotBrowserView />
           </MountOnceWhenOpened>
@@ -1057,9 +1058,7 @@ export function AppShell() {
               inert={!rightPanelOpen}
               className={cn(
                 "mari-right-panel mari-shell-panel-motion mari-shell-panel-edge mari-shell-panel-edge--left absolute inset-y-0 right-0 overflow-hidden bg-[var(--background)]/95",
-                rightPanelOpen
-                  ? "mari-shell-panel-enter-right"
-                  : "mari-shell-panel-exit-right pointer-events-none",
+                rightPanelOpen ? "mari-shell-panel-enter-right" : "mari-shell-panel-exit-right pointer-events-none",
               )}
               style={{ width: liveRightPanelWidth }}
             >

--- a/packages/client/src/components/layout/RightPanel.tsx
+++ b/packages/client/src/components/layout/RightPanel.tsx
@@ -29,14 +29,14 @@ const BotBrowserPanel = lazy(() =>
 
 const PANEL_CONFIG: Record<string, { title: string; icon: ReactNode; gradient?: string; gradientClass?: string }> = {
   "bot-browser": {
-    title: "Bot Browser",
+    title: "Card Browser",
     icon: <Bot size="0.875rem" />,
     gradient: "from-lime-400 via-green-500 to-cyan-500",
   },
   characters: {
     title: "Characters",
     icon: <Users size="0.875rem" />,
-    gradientClass: "bg-[image:var(--marinara-app-accent-gradient)] text-[var(--primary-foreground)]",
+    gradientClass: "mari-panel-gradient-surface mari-panel-gradient--characters",
   },
   lorebooks: { title: "Lorebooks", icon: <BookOpen size="0.875rem" />, gradient: "from-amber-400 to-orange-500" },
   presets: {
@@ -89,9 +89,11 @@ export function RightPanel() {
         <div className="absolute inset-x-0 bottom-0 h-px bg-[var(--border)]/30" />
         <div className="flex items-center gap-2.5">
           <div
+            data-component="RightPanelHeaderIcon"
             className={cn(
               "flex h-6 w-6 items-center justify-center rounded-md shadow-sm",
-              config.gradientClass ?? `bg-gradient-to-br ${config.gradient ?? "from-slate-400 to-slate-500"} text-white`,
+              config.gradientClass ??
+                `bg-gradient-to-br ${config.gradient ?? "from-slate-400 to-slate-500"} text-white`,
             )}
           >
             {config.icon}

--- a/packages/client/src/components/layout/TopBar.tsx
+++ b/packages/client/src/components/layout/TopBar.tsx
@@ -247,7 +247,10 @@ export function TopBar() {
 
       {/* Left section: window controls + chat info */}
       <div className="mari-topbar-left flex min-w-0 flex-1 items-center gap-2">
-        <div ref={leftControlsRef} className="mari-topbar-left-controls mari-rgb-icon-scope flex shrink-0 items-center gap-2">
+        <div
+          ref={leftControlsRef}
+          className="mari-topbar-left-controls mari-rgb-icon-scope flex shrink-0 items-center gap-2"
+        >
           <button
             onClick={handleSidebarClick}
             data-tour="sidebar-toggle"
@@ -347,7 +350,7 @@ export function TopBar() {
         aria-label="Panel navigation"
         className="mari-topbar-panel-nav mari-rgb-icon-scope flex shrink-0 items-center justify-end gap-0.5 rounded-xl p-1 max-sm:gap-0 max-sm:p-0.5"
       >
-        {/* Bot Browser */}
+        {/* Card Browser */}
         <button
           onClick={() => handleRightPanelClick("bot-browser")}
           data-tour="panel-bot-browser"
@@ -361,7 +364,7 @@ export function TopBar() {
                   isTopbarHovered("browser") && cn(TOPBAR_FORCE_HOVER_CLASS, "text-lime-300"),
                 ),
           )}
-          title="Bot Browser"
+          title="Card Browser"
         >
           <Bot size={15} className={TOPBAR_ACCENT_ICON_CLASS} />
           {isBotBrowserActive && (

--- a/packages/client/src/components/layout/TopBar.tsx
+++ b/packages/client/src/components/layout/TopBar.tsx
@@ -105,6 +105,7 @@ export function TopBar() {
   const gameAssetsBrowserOpen = useUIStore((s) => s.gameAssetsBrowserOpen);
   const noodleOpen = useUIStore((s) => s.noodleOpen);
   const characterLibraryOpen = useUIStore((s) => s.characterLibraryOpen);
+  const cardLibraryKind = useUIStore((s) => s.cardLibraryKind);
   const headerRef = useRef<HTMLElement | null>(null);
   const leftControlsRef = useRef<HTMLDivElement | null>(null);
   const rightNavRef = useRef<HTMLElement | null>(null);
@@ -114,7 +115,9 @@ export function TopBar() {
 
   const isBotBrowserActive = (rightPanelOpen && rightPanel === "bot-browser") || botBrowserOpen;
   const isCharactersPanelActive =
-    (rightPanelOpen && rightPanel === "characters") || Boolean(characterDetailId) || characterLibraryOpen;
+    (rightPanelOpen && rightPanel === "characters") ||
+    Boolean(characterDetailId) ||
+    (characterLibraryOpen && cardLibraryKind === "characters");
   const panelContextActive: Record<RightPanelButtonPanel, boolean> = {
     lorebooks: (rightPanelOpen && rightPanel === "lorebooks") || Boolean(lorebookDetailId),
     presets:
@@ -124,7 +127,10 @@ export function TopBar() {
       Boolean(toolDetailId),
     connections: (rightPanelOpen && rightPanel === "connections") || Boolean(connectionDetailId),
     agents: (rightPanelOpen && rightPanel === "agents") || Boolean(agentDetailId),
-    personas: (rightPanelOpen && rightPanel === "personas") || Boolean(personaDetailId),
+    personas:
+      (rightPanelOpen && rightPanel === "personas") ||
+      Boolean(personaDetailId) ||
+      (characterLibraryOpen && cardLibraryKind === "personas"),
   };
   const isHomeActive =
     !activeChatId &&

--- a/packages/client/src/components/onboarding/OnboardingTutorial.tsx
+++ b/packages/client/src/components/onboarding/OnboardingTutorial.tsx
@@ -49,8 +49,8 @@ const STEPS: TourStep[] = [
   },
   {
     target: "panel-bot-browser",
-    title: "Bot Browser",
-    body: "The Bot Browser allows you to browse and import downloadable character cards and resources. Start here when you want new characters or ready-made material to bring into your library.",
+    title: "Card Browser",
+    body: "The Card Browser lets you find and import downloadable character cards. Start here when you want new characters to add to your library.",
     side: "bottom",
     openPanel: "bot-browser",
     sprite: { src: "/sprites/mari/Mari_point_up_left.png", flip: true },
@@ -451,16 +451,10 @@ function TourCardContent({
 
       {/* Buttons */}
       <div className="flex items-center justify-between">
-        <button
-          onClick={onSkip}
-          className={TUTORIAL_SECONDARY_BUTTON_CLASS}
-        >
+        <button onClick={onSkip} className={TUTORIAL_SECONDARY_BUTTON_CLASS}>
           {step === 0 ? "Skip Tutorial" : "Skip"}
         </button>
-        <button
-          onClick={onNext}
-          className={TUTORIAL_PRIMARY_BUTTON_CLASS}
-        >
+        <button onClick={onNext} className={TUTORIAL_PRIMARY_BUTTON_CLASS}>
           {isLast ? "Get Started" : "Next"}
           {!isLast && <ChevronRight size="0.75rem" />}
         </button>

--- a/packages/client/src/components/panels/AgentsPanel.tsx
+++ b/packages/client/src/components/panels/AgentsPanel.tsx
@@ -30,7 +30,7 @@ import {
   useUploadAgentImage,
   type AgentConfigRow,
 } from "../../hooks/use-agents";
-import { useCapabilityAgentRegistry } from "../../hooks/use-capability-packages";
+import { useCapabilityAgentRegistry, useCapabilityCatalog } from "../../hooks/use-capability-packages";
 import { useCreateCustomTool, useCustomTools, type CustomToolRow } from "../../hooks/use-custom-tools";
 import {
   BUILT_IN_AGENTS,
@@ -75,6 +75,7 @@ import {
 } from "../../hooks/use-library-folders";
 import { handleFolderRenameKeyDown, useFolderRenameGesture } from "../../hooks/use-folder-rename-gesture";
 import { SmoothFolderContent } from "../ui/SmoothFolderContent";
+import { AgentArtwork } from "../agents/AgentArtwork";
 
 type JsonRecord = Record<string, unknown>;
 const AGENT_GRADIENT_SURFACE =
@@ -250,6 +251,7 @@ function getReferencedCustomTools(agents: AgentConfigRow[], customTools: CustomT
 export function AgentsPanel() {
   const { data: agentConfigs, isLoading } = useAgentConfigs();
   const { data: capabilityAgents } = useCapabilityAgentRegistry();
+  const { data: capabilityCatalog } = useCapabilityCatalog();
   const { data: customTools } = useCustomTools();
   const createAgent = useCreateAgent();
   const createCustomTool = useCreateCustomTool();
@@ -292,6 +294,13 @@ export function AgentsPanel() {
   const builtInAgentIds = useMemo(
     () => new Set(availableBuiltInAgents.map((agent) => agent.id)),
     [availableBuiltInAgents],
+  );
+  const catalogArtworkByAgentId = useMemo(
+    () =>
+      new Map(
+        (capabilityCatalog?.packages ?? []).map((entry) => [entry.manifest.id, entry.iconUrl ?? null] as const),
+      ),
+    [capabilityCatalog],
   );
   const customToolRows = useMemo(() => (customTools ?? []) as CustomToolRow[], [customTools]);
   const visibleAgentConfigs = useMemo(
@@ -668,7 +677,7 @@ export function AgentsPanel() {
         name: getAgentLibraryDisplayName(agent),
         description: agent.description,
         category,
-        imagePath: agent.imagePath ?? null,
+        imagePath: agent.imagePath || (builtInMeta ? catalogArtworkByAgentId.get(agent.type) : null) || null,
         custom,
         openAgentDetail,
         onDuplicate: () => void handleDuplicateAgent(agent),
@@ -707,6 +716,7 @@ export function AgentsPanel() {
     },
     [
       availableBuiltInAgents,
+      catalogArtworkByAgentId,
       deleteAgent,
       draggedAgentId,
       getDraggedAgentIds,
@@ -1070,7 +1080,7 @@ export function AgentsPanel() {
                   name: agent.name,
                   description: agent.description,
                   category: agent.category,
-                  imagePath: sourceAgent.imagePath,
+                  imagePath: sourceAgent.imagePath || catalogArtworkByAgentId.get(agent.id) || null,
                   custom: false,
                   openAgentDetail,
                   onDuplicate: () => void handleDuplicateAgent(sourceAgent),
@@ -1217,14 +1227,9 @@ function renderAgentCard({
   touchSafeDragMode?: boolean;
   suppressClickRef?: { current: boolean };
 }) {
-  const iconContent = imagePath ? (
-    <img src={imagePath} alt="" className="h-full w-full object-cover" draggable={false} />
-  ) : (
-    <Sparkles size="1rem" />
-  );
   const iconClasses = cn(
     "relative flex h-10 w-10 shrink-0 items-center justify-center overflow-hidden rounded-xl shadow-sm",
-    imagePath ? "bg-[var(--muted)]" : AGENT_GRADIENT_SURFACE,
+    AGENT_GRADIENT_SURFACE,
   );
 
   return (
@@ -1304,7 +1309,7 @@ function renderAgentCard({
         title={selectionMode ? "Select agent" : imagePath ? "Replace agent picture" : "Upload agent picture"}
         aria-label={selectionMode ? "Select agent" : imagePath ? "Replace agent picture" : "Upload agent picture"}
       >
-        {iconContent}
+        <AgentArtwork imageUrl={imagePath} alt="" iconSize="1rem" />
         {!selectionMode && (
           <span className="absolute inset-0 flex items-center justify-center bg-black/45 opacity-0 transition-opacity group-hover:opacity-100">
             <Camera size="0.875rem" />

--- a/packages/client/src/components/panels/BotBrowserPanel.tsx
+++ b/packages/client/src/components/panels/BotBrowserPanel.tsx
@@ -62,7 +62,13 @@ export function BotBrowserPanel() {
   }, [parsed, search]);
 
   const sorted = useMemo(
-    () => sortBasicPanelItems(filtered, sort, (char) => char.name, (char) => char.createdAt || char.updatedAt),
+    () =>
+      sortBasicPanelItems(
+        filtered,
+        sort,
+        (char) => char.name,
+        (char) => char.createdAt || char.updatedAt,
+      ),
     [filtered, sort],
   );
 
@@ -106,7 +112,7 @@ export function BotBrowserPanel() {
 
   return (
     <div className="flex flex-col gap-2 p-3">
-      {/* Browse online button */}
+      {/* Download cards button */}
       <button
         onClick={openBotBrowser}
         className={cn(
@@ -115,7 +121,7 @@ export function BotBrowserPanel() {
         )}
       >
         <Bot size="0.875rem" />
-        Browse Online
+        Download Cards
       </button>
 
       {/* Search + Sort */}

--- a/packages/client/src/components/panels/PersonasPanel.tsx
+++ b/packages/client/src/components/panels/PersonasPanel.tsx
@@ -138,6 +138,7 @@ export function PersonasPanel() {
   const updatePGroup = useUpdatePersonaGroup();
   const deletePGroup = useDeletePersonaGroup();
   const openPersonaDetail = useUIStore((s) => s.openPersonaDetail);
+  const openPersonaLibrary = useUIStore((s) => s.openPersonaLibrary);
   const openModal = useUIStore((s) => s.openModal);
 
   const fileRef = useRef<HTMLInputElement>(null);
@@ -491,25 +492,22 @@ export function PersonasPanel() {
     });
   }, []);
 
-  const handleExportSelected = useCallback(
-    async () => {
-      if (selectedPersonaIds.size === 0) return;
-      setExportingSelected(true);
-      try {
-        await api.downloadPost(
-          "/characters/personas/export-bulk",
-          { ids: [...selectedPersonaIds], format: "native" },
-          "marinara-personas.zip",
-        );
-        toast.success(`Exported ${selectedPersonaIds.size} persona${selectedPersonaIds.size === 1 ? "" : "s"}`);
-      } catch (error) {
-        toast.error(error instanceof Error ? error.message : "Failed to export personas");
-      } finally {
-        setExportingSelected(false);
-      }
-    },
-    [selectedPersonaIds],
-  );
+  const handleExportSelected = useCallback(async () => {
+    if (selectedPersonaIds.size === 0) return;
+    setExportingSelected(true);
+    try {
+      await api.downloadPost(
+        "/characters/personas/export-bulk",
+        { ids: [...selectedPersonaIds], format: "native" },
+        "marinara-personas.zip",
+      );
+      toast.success(`Exported ${selectedPersonaIds.size} persona${selectedPersonaIds.size === 1 ? "" : "s"}`);
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : "Failed to export personas");
+    } finally {
+      setExportingSelected(false);
+    }
+  }, [selectedPersonaIds]);
 
   const handleDeleteSelected = useCallback(async () => {
     const ids = [...selectedPersonaIds];
@@ -545,6 +543,15 @@ export function PersonasPanel() {
 
   return (
     <div className="flex min-h-full flex-col gap-2 p-3">
+      <button
+        onClick={openPersonaLibrary}
+        className="mari-chrome-control mari-chrome-control--primary w-full text-xs"
+        title="Open full persona library"
+      >
+        <User size="0.875rem" />
+        Open Full Library
+      </button>
+
       {/* Actions */}
       <div className="flex gap-2">
         <button
@@ -579,10 +586,7 @@ export function PersonasPanel() {
       {/* Search + Sort */}
       <div className="flex gap-1.5">
         <div className="relative flex-1">
-          <Search
-            size="0.8125rem"
-            className="mari-chrome-field-icon absolute left-3 top-1/2 -translate-y-1/2"
-          />
+          <Search size="0.8125rem" className="mari-chrome-field-icon absolute left-3 top-1/2 -translate-y-1/2" />
           <input
             value={search}
             onChange={(e) => setSearch(e.target.value)}
@@ -620,7 +624,9 @@ export function PersonasPanel() {
             New Folder
           </button>
         </div>
-        {parsedGroups.length > 0 && <p className="mari-folder-helper">Drag and drop personas to folders, double-click or double-tap to rename</p>}
+        {parsedGroups.length > 0 && (
+          <p className="mari-folder-helper">Drag and drop personas to folders, double-click or double-tap to rename</p>
+        )}
       </div>
 
       {/* Filters */}
@@ -796,9 +802,9 @@ export function PersonasPanel() {
                       e.stopPropagation();
                       void handleDeleteGroup(group);
                     }}
-		                    className="mari-chrome-control mari-chrome-control--small p-1"
-		                    title="Delete folder"
-		                  >
+                    className="mari-chrome-control mari-chrome-control--small p-1"
+                    title="Delete folder"
+                  >
                     <Trash2 size="0.6875rem" />
                   </button>
                 </div>
@@ -815,131 +821,131 @@ export function PersonasPanel() {
                 ) : (
                   <div className="flex flex-col gap-0.5">
                     {folderMemberIds.map((pid) => {
-                        const p = personaMap.get(pid);
-                        if (!p) return null;
-                        const isBulkSelected = selectedPersonaIds.has(pid);
-                        const personaMetadata = getPersonaPreviewMetadata(p);
-                        return (
-                          <div
-                            key={pid}
-                            data-touch-drag-card="persona"
-                            onClick={() => {
-                              if (suppressPersonaClickRef.current) return;
+                      const p = personaMap.get(pid);
+                      if (!p) return null;
+                      const isBulkSelected = selectedPersonaIds.has(pid);
+                      const personaMetadata = getPersonaPreviewMetadata(p);
+                      return (
+                        <div
+                          key={pid}
+                          data-touch-drag-card="persona"
+                          onClick={() => {
+                            if (suppressPersonaClickRef.current) return;
+                            if (selectionMode) {
+                              toggleSelection(pid);
+                              return;
+                            }
+                            openPersonaDetail(pid);
+                          }}
+                          onKeyDown={(e) => {
+                            if (e.key === "Enter" || e.key === " ") {
+                              e.preventDefault();
                               if (selectionMode) {
                                 toggleSelection(pid);
                                 return;
                               }
                               openPersonaDetail(pid);
-                            }}
-                            onKeyDown={(e) => {
-                              if (e.key === "Enter" || e.key === " ") {
-                                e.preventDefault();
-                                if (selectionMode) {
-                                  toggleSelection(pid);
-                                  return;
-                                }
-                                openPersonaDetail(pid);
-                              }
-                            }}
-                            draggable={nativePersonaDragEnabled}
-                            onContextMenu={(event) => {
-                              if (touchSafePersonaDragMode) event.preventDefault();
-                            }}
-                            onDragStart={(event) => {
-                              if (!nativePersonaDragEnabled) {
-                                event.preventDefault();
-                                return;
-                              }
-                              const ids = getDraggedPersonaIds(pid);
-                              setDraggedPersonaId(pid);
-                              event.dataTransfer.effectAllowed = "move";
-                              event.dataTransfer.setData("application/x-marinara-persona-ids", JSON.stringify(ids));
-                              event.dataTransfer.setData("text/plain", pid);
-                            }}
-                            onDragEnd={() => setDraggedPersonaId(null)}
-                            role="button"
-                            tabIndex={0}
-                            className={cn(
-                              "group group/member flex touch-pan-y cursor-pointer items-center gap-2 rounded-lg p-1.5 text-xs transition-all hover:bg-[var(--sidebar-accent)]",
-                              touchSafePersonaDragMode && "select-none",
-                              selectionMode &&
-                                isBulkSelected &&
-                                "bg-[var(--marinara-chat-chrome-highlight-bg)] ring-1 ring-[var(--marinara-chat-chrome-button-border-active)]",
-                              draggedPersonaId === pid && "opacity-50",
-                            )}
-                          >
-                            {selectionMode && (
-                              <button
-                                type="button"
-                                onClick={(e) => {
-                                  e.stopPropagation();
-                                  toggleSelection(pid);
-                                }}
-                                className={cn(
-                                  "flex h-5 w-5 shrink-0 items-center justify-center rounded border-2 transition-colors",
-                                  isBulkSelected
-                                    ? "border-[var(--marinara-chat-chrome-button-border-active)] bg-[var(--marinara-chat-chrome-button-bg-active)] text-[var(--marinara-chat-chrome-button-text-active)]"
-                                    : "border-[var(--muted-foreground)]/40 bg-[var(--secondary)] text-transparent",
-                                )}
-                                aria-label={isBulkSelected ? "Deselect persona" : "Select persona"}
-                              >
-                                <Check size="0.75rem" />
-                              </button>
-                            )}
-                            <TouchDragHandle
-                              label="Drag persona"
-                              size="0.75rem"
-                              onTouchStart={(event) => {
-                                startPersonaTouchDrag(event, pid, {
-                                  allowInteractiveTarget: true,
-                                  sourceElement: event.currentTarget.closest<HTMLElement>(
-                                    '[data-touch-drag-card="persona"]',
-                                  ),
-                                });
+                            }
+                          }}
+                          draggable={nativePersonaDragEnabled}
+                          onContextMenu={(event) => {
+                            if (touchSafePersonaDragMode) event.preventDefault();
+                          }}
+                          onDragStart={(event) => {
+                            if (!nativePersonaDragEnabled) {
+                              event.preventDefault();
+                              return;
+                            }
+                            const ids = getDraggedPersonaIds(pid);
+                            setDraggedPersonaId(pid);
+                            event.dataTransfer.effectAllowed = "move";
+                            event.dataTransfer.setData("application/x-marinara-persona-ids", JSON.stringify(ids));
+                            event.dataTransfer.setData("text/plain", pid);
+                          }}
+                          onDragEnd={() => setDraggedPersonaId(null)}
+                          role="button"
+                          tabIndex={0}
+                          className={cn(
+                            "group group/member flex touch-pan-y cursor-pointer items-center gap-2 rounded-lg p-1.5 text-xs transition-all hover:bg-[var(--sidebar-accent)]",
+                            touchSafePersonaDragMode && "select-none",
+                            selectionMode &&
+                              isBulkSelected &&
+                              "bg-[var(--marinara-chat-chrome-highlight-bg)] ring-1 ring-[var(--marinara-chat-chrome-button-border-active)]",
+                            draggedPersonaId === pid && "opacity-50",
+                          )}
+                        >
+                          {selectionMode && (
+                            <button
+                              type="button"
+                              onClick={(e) => {
+                                e.stopPropagation();
+                                toggleSelection(pid);
                               }}
-                            />
-                            <div className="mari-avatar-placeholder mari-avatar-placeholder--persona relative flex h-7 w-7 shrink-0 items-center justify-center overflow-hidden rounded-lg">
-                              {p.avatarPath ? (
-                                <img
-                                  src={p.avatarPath}
-                                  alt=""
-                                  className="h-full w-full rounded-lg object-cover"
-                                  style={getAvatarCropStyle(parseAvatarCropJson(p.avatarCrop))}
-                                />
-                              ) : (
-                                <User size="0.625rem" />
+                              className={cn(
+                                "flex h-5 w-5 shrink-0 items-center justify-center rounded border-2 transition-colors",
+                                isBulkSelected
+                                  ? "border-[var(--marinara-chat-chrome-button-border-active)] bg-[var(--marinara-chat-chrome-button-bg-active)] text-[var(--marinara-chat-chrome-button-text-active)]"
+                                  : "border-[var(--muted-foreground)]/40 bg-[var(--secondary)] text-transparent",
                               )}
-                            </div>
-                            <div className="min-w-0 flex-1">
-                              <div className="truncate text-[0.75rem] font-medium">{p.name}</div>
-                              {p.comment && (
-                                <div className="truncate text-[0.5625rem] italic text-[var(--muted-foreground)]">
-                                  {p.comment}
-                                </div>
-                              )}
-                              {personaMetadata && (
-                                <div className="truncate text-[0.5625rem] text-[var(--muted-foreground)]">
-                                  {personaMetadata}
-                                </div>
-                              )}
-                              <div className="truncate text-[0.625rem] text-[var(--muted-foreground)]">
-                                {p.description || "No description"}
-                              </div>
-                            </div>
-                            {!selectionMode && (
-                              <button
-                                onClick={(e) => {
-                                  e.stopPropagation();
-                                  void movePersonasToFolder([pid], null);
-                                }}
-                                className="rounded p-0.5 text-[var(--muted-foreground)] opacity-0 transition-all hover:bg-[var(--destructive)]/10 hover:text-[var(--destructive)] group-hover/member:opacity-100 max-md:opacity-100"
-                                title="Remove from folder"
-                              >
-                                <UserMinus size="0.625rem" />
-                              </button>
+                              aria-label={isBulkSelected ? "Deselect persona" : "Select persona"}
+                            >
+                              <Check size="0.75rem" />
+                            </button>
+                          )}
+                          <TouchDragHandle
+                            label="Drag persona"
+                            size="0.75rem"
+                            onTouchStart={(event) => {
+                              startPersonaTouchDrag(event, pid, {
+                                allowInteractiveTarget: true,
+                                sourceElement: event.currentTarget.closest<HTMLElement>(
+                                  '[data-touch-drag-card="persona"]',
+                                ),
+                              });
+                            }}
+                          />
+                          <div className="mari-avatar-placeholder mari-avatar-placeholder--persona relative flex h-7 w-7 shrink-0 items-center justify-center overflow-hidden rounded-lg">
+                            {p.avatarPath ? (
+                              <img
+                                src={p.avatarPath}
+                                alt=""
+                                className="h-full w-full rounded-lg object-cover"
+                                style={getAvatarCropStyle(parseAvatarCropJson(p.avatarCrop))}
+                              />
+                            ) : (
+                              <User size="0.625rem" />
                             )}
                           </div>
-                        );
+                          <div className="min-w-0 flex-1">
+                            <div className="truncate text-[0.75rem] font-medium">{p.name}</div>
+                            {p.comment && (
+                              <div className="truncate text-[0.5625rem] italic text-[var(--muted-foreground)]">
+                                {p.comment}
+                              </div>
+                            )}
+                            {personaMetadata && (
+                              <div className="truncate text-[0.5625rem] text-[var(--muted-foreground)]">
+                                {personaMetadata}
+                              </div>
+                            )}
+                            <div className="truncate text-[0.625rem] text-[var(--muted-foreground)]">
+                              {p.description || "No description"}
+                            </div>
+                          </div>
+                          {!selectionMode && (
+                            <button
+                              onClick={(e) => {
+                                e.stopPropagation();
+                                void movePersonasToFolder([pid], null);
+                              }}
+                              className="rounded p-0.5 text-[var(--muted-foreground)] opacity-0 transition-all hover:bg-[var(--destructive)]/10 hover:text-[var(--destructive)] group-hover/member:opacity-100 max-md:opacity-100"
+                              title="Remove from folder"
+                            >
+                              <UserMinus size="0.625rem" />
+                            </button>
+                          )}
+                        </div>
+                      );
                     })}
                   </div>
                 )}
@@ -1116,10 +1122,10 @@ export function PersonasPanel() {
                       onClick={(e) => {
                         e.stopPropagation();
                         activatePersona.mutate(persona.id);
-	                      }}
-	                      className="mari-chrome-control mari-chrome-control--small mari-chrome-control--selected p-1.5"
-	                      title="Set as active"
-	                    >
+                      }}
+                      className="mari-chrome-control mari-chrome-control--small mari-chrome-control--selected p-1.5"
+                      title="Set as active"
+                    >
                       <Check size="0.75rem" />
                     </button>
                   )}
@@ -1131,10 +1137,10 @@ export function PersonasPanel() {
                           toast.success(`Duplicated "${persona.name}"`);
                         },
                       });
-	                      }}
-	                    className="mari-chrome-control mari-chrome-control--small p-1.5"
-	                    title="Duplicate"
-	                  >
+                    }}
+                    className="mari-chrome-control mari-chrome-control--small p-1.5"
+                    title="Duplicate"
+                  >
                     <Copy size="0.75rem" />
                   </button>
                   <button
@@ -1152,9 +1158,9 @@ export function PersonasPanel() {
                       }
                       deletePersona.mutate(persona.id);
                     }}
-		                    className="mari-chrome-control mari-chrome-control--small p-1.5"
-		                    title="Delete"
-		                  >
+                    className="mari-chrome-control mari-chrome-control--small p-1.5"
+                    title="Delete"
+                  >
                     <Trash2 size="0.75rem" />
                   </button>
                 </div>

--- a/packages/client/src/stores/ui.store.ts
+++ b/packages/client/src/stores/ui.store.ts
@@ -30,6 +30,7 @@ type Panel =
 export type ChatModeShortcut = "conversation" | "roleplay" | "game";
 export const CHARACTER_LIBRARY_SORT_OPTIONS = ["name-asc", "name-desc", "newest", "oldest", "favorites"] as const;
 export type CharacterLibrarySort = (typeof CHARACTER_LIBRARY_SORT_OPTIONS)[number];
+export type CardLibraryKind = "characters" | "personas";
 export const CHARACTER_PANEL_FAVORITE_FILTER_OPTIONS = ["all", "favorites", "non-favorites"] as const;
 export type CharacterPanelFavoriteFilter = (typeof CHARACTER_PANEL_FAVORITE_FILTER_OPTIONS)[number];
 export const LOREBOOK_PANEL_CATEGORY_OPTIONS = [
@@ -223,7 +224,12 @@ function normalizePanelText(value: unknown) {
 function normalizePanelStringArray(value: unknown) {
   if (!Array.isArray(value)) return [];
   return Array.from(
-    new Set(value.filter((item): item is string => typeof item === "string").map((item) => item.trim()).filter(Boolean)),
+    new Set(
+      value
+        .filter((item): item is string => typeof item === "string")
+        .map((item) => item.trim())
+        .filter(Boolean),
+    ),
   );
 }
 
@@ -492,12 +498,18 @@ interface UIState {
   noodleSelectedPersonaId: string | null;
   /** When true, the main area shows the full-page character library */
   characterLibraryOpen: boolean;
+  /** Which resource collection the shared full-page card library displays */
+  cardLibraryKind: CardLibraryKind;
   /** When true, the main area shows the full-page downloadable agent catalog */
   agentCatalogOpen: boolean;
   /** Last selected character card inside the full-page character library */
   characterLibrarySelectedId: string | null;
+  /** Last selected persona card inside the full-page card library */
+  personaLibrarySelectedId: string | null;
   /** Last selected sort order for character lists and the full-page character library */
   characterLibrarySort: CharacterLibrarySort;
+  /** Last selected sort order for the full-page persona library */
+  personaLibrarySort: ResourcePanelSort;
   /** Search text for the compact Characters panel */
   characterPanelSearch: string;
   /** Included tag filters for the compact Characters panel */
@@ -512,6 +524,8 @@ interface UIState {
   characterPanelScrollTop: number;
   /** Last scroll offset for the full-page Character Library list */
   characterLibraryScrollTop: number;
+  /** Last scroll offset for the full-page Persona Library list */
+  personaLibraryScrollTop: number;
   /** Selected category for the compact Lorebooks panel */
   lorebookPanelCategory: LorebookPanelCategory;
   /** Search text for the compact Lorebooks panel */
@@ -522,7 +536,7 @@ interface UIState {
   lorebookPanelActiveTag: string | null;
   /** Whether the compact Lorebooks panel tag/category shelf is expanded */
   lorebookPanelTagsExpanded: boolean;
-  /** Sort order for imported characters in the Bot Browser panel */
+  /** Sort order for imported characters in the Card Browser panel */
   botBrowserPanelSort: ResourcePanelSort;
   /** Sort order for the compact Presets panel */
   presetPanelSort: ResourcePanelSort;
@@ -801,7 +815,9 @@ interface UIState {
   setDefaultRoleplayBackground: (url: string) => void;
   setChatBackgroundBlur: (v: number) => void;
   setCharacterLibrarySelectedId: (id: string | null) => void;
+  setPersonaLibrarySelectedId: (id: string | null) => void;
   setCharacterLibrarySort: (sort: CharacterLibrarySort) => void;
+  setPersonaLibrarySort: (sort: ResourcePanelSort) => void;
   setCharacterPanelSearch: (search: string) => void;
   setCharacterPanelIncludedTags: (tags: string[]) => void;
   setCharacterPanelExcludedTags: (tags: string[]) => void;
@@ -809,6 +825,7 @@ interface UIState {
   setCharacterPanelFavoriteFilter: (filter: CharacterPanelFavoriteFilter) => void;
   setCharacterPanelScrollTop: (scrollTop: number) => void;
   setCharacterLibraryScrollTop: (scrollTop: number) => void;
+  setPersonaLibraryScrollTop: (scrollTop: number) => void;
   setLorebookPanelCategory: (category: LorebookPanelCategory) => void;
   setLorebookPanelSearch: (search: string) => void;
   setLorebookPanelSort: (sort: LorebookPanelSort) => void;
@@ -830,7 +847,7 @@ interface UIState {
   closeAgentDetail: () => void;
   openToolDetail: (id: string) => void;
   closeToolDetail: () => void;
-  openPersonaDetail: (id: string) => void;
+  openPersonaDetail: (id: string, options?: { preservePersonaLibrary?: boolean }) => void;
   closePersonaDetail: () => void;
   openRegexDetail: (
     id: string,
@@ -842,6 +859,7 @@ interface UIState {
   clearPendingSpatialMapDraftReview: () => void;
   closeSpatialMapDetail: () => void;
   openCharacterLibrary: () => void;
+  openPersonaLibrary: () => void;
   closeCharacterLibrary: () => void;
   openAgentCatalog: () => void;
   closeAgentCatalog: () => void;
@@ -1226,9 +1244,12 @@ export const useUIStore = create<UIState>()(
       noodleOpen: false,
       noodleSelectedPersonaId: null,
       characterLibraryOpen: false,
+      cardLibraryKind: "characters" as CardLibraryKind,
       agentCatalogOpen: false,
       characterLibrarySelectedId: null,
+      personaLibrarySelectedId: null,
       characterLibrarySort: "name-asc" as CharacterLibrarySort,
+      personaLibrarySort: "name-asc" as ResourcePanelSort,
       characterPanelSearch: "",
       characterPanelIncludedTags: [],
       characterPanelExcludedTags: [],
@@ -1236,6 +1257,7 @@ export const useUIStore = create<UIState>()(
       characterPanelFavoriteFilter: "all" as CharacterPanelFavoriteFilter,
       characterPanelScrollTop: 0,
       characterLibraryScrollTop: 0,
+      personaLibraryScrollTop: 0,
       lorebookPanelCategory: "all" as LorebookPanelCategory,
       lorebookPanelSearch: "",
       lorebookPanelSort: "name-asc" as LorebookPanelSort,
@@ -1473,10 +1495,13 @@ export const useUIStore = create<UIState>()(
       setAppAccentRgbMode: (enabled) => set({ appAccentRgbMode: enabled }),
       setCustomCursorEnabled: (enabled) => set({ customCursorEnabled: enabled }),
       setChatBackground: (url) => set({ chatBackground: url }),
-      setDefaultRoleplayBackground: (url) => set({ defaultRoleplayBackground: normalizeDefaultRoleplayBackground(url) }),
+      setDefaultRoleplayBackground: (url) =>
+        set({ defaultRoleplayBackground: normalizeDefaultRoleplayBackground(url) }),
       setChatBackgroundBlur: (v) => set({ chatBackgroundBlur: Math.max(0, Math.min(24, Math.round(v))) }),
       setCharacterLibrarySelectedId: (id) => set({ characterLibrarySelectedId: id }),
+      setPersonaLibrarySelectedId: (id) => set({ personaLibrarySelectedId: id }),
       setCharacterLibrarySort: (sort) => set({ characterLibrarySort: normalizeCharacterLibrarySort(sort) }),
+      setPersonaLibrarySort: (sort) => set({ personaLibrarySort: normalizeBasicPanelSort(sort) }),
       setCharacterPanelSearch: (search) => set({ characterPanelSearch: normalizePanelText(search) }),
       setCharacterPanelIncludedTags: (tags) => set({ characterPanelIncludedTags: normalizePanelStringArray(tags) }),
       setCharacterPanelExcludedTags: (tags) => set({ characterPanelExcludedTags: normalizePanelStringArray(tags) }),
@@ -1485,6 +1510,7 @@ export const useUIStore = create<UIState>()(
         set({ characterPanelFavoriteFilter: normalizeCharacterPanelFavoriteFilter(filter) }),
       setCharacterPanelScrollTop: (scrollTop) => set({ characterPanelScrollTop: normalizeScrollTop(scrollTop) }),
       setCharacterLibraryScrollTop: (scrollTop) => set({ characterLibraryScrollTop: normalizeScrollTop(scrollTop) }),
+      setPersonaLibraryScrollTop: (scrollTop) => set({ personaLibraryScrollTop: normalizeScrollTop(scrollTop) }),
       setLorebookPanelCategory: (category) => set({ lorebookPanelCategory: normalizeLorebookPanelCategory(category) }),
       setLorebookPanelSearch: (search) => set({ lorebookPanelSearch: normalizePanelText(search) }),
       setLorebookPanelSort: (sort) => set({ lorebookPanelSort: normalizeLorebookPanelSort(sort) }),
@@ -1496,7 +1522,8 @@ export const useUIStore = create<UIState>()(
       setAgentPanelSort: (sort) => set({ agentPanelSort: normalizeBasicPanelSort(sort) }),
       openCharacterDetail: (id, options) =>
         set((s) => {
-          const preserveCharacterLibrary = options?.preserveCharacterLibrary ?? s.characterLibraryOpen;
+          const preserveCharacterLibrary =
+            options?.preserveCharacterLibrary ?? (s.characterLibraryOpen && s.cardLibraryKind === "characters");
           return {
             characterDetailId: id,
             characterDetailInitialTab: null,
@@ -1643,24 +1670,29 @@ export const useUIStore = create<UIState>()(
           editorDirty: false,
           ...restoreMobileDetailReturnPanel(s.detailReturnRightPanel),
         })),
-      openPersonaDetail: (id) =>
-        set((s) => ({
-          personaDetailId: id,
-          characterLibraryOpen: false,
-          agentCatalogOpen: false,
-          botBrowserOpen: false,
-          gameAssetsBrowserOpen: false,
-          noodleOpen: false,
-          characterDetailId: null,
-          lorebookDetailId: null,
-          presetDetailId: null,
-          connectionDetailId: null,
-          agentDetailId: null,
-          toolDetailId: null,
-          regexDetailId: null,
-          spatialMapDetailChatId: null,
-          ...getMobileDetailReturnState(s),
-        })),
+      openPersonaDetail: (id, options) =>
+        set((s) => {
+          const preservePersonaLibrary =
+            options?.preservePersonaLibrary ?? (s.characterLibraryOpen && s.cardLibraryKind === "personas");
+          return {
+            personaDetailId: id,
+            characterLibraryOpen: preservePersonaLibrary ? s.characterLibraryOpen : false,
+            personaLibrarySelectedId: preservePersonaLibrary ? id : s.personaLibrarySelectedId,
+            agentCatalogOpen: false,
+            botBrowserOpen: false,
+            gameAssetsBrowserOpen: false,
+            noodleOpen: false,
+            characterDetailId: null,
+            lorebookDetailId: null,
+            presetDetailId: null,
+            connectionDetailId: null,
+            agentDetailId: null,
+            toolDetailId: null,
+            regexDetailId: null,
+            spatialMapDetailChatId: null,
+            ...getMobileDetailReturnState(s),
+          };
+        }),
       closePersonaDetail: () =>
         set((s) => ({
           personaDetailId: null,
@@ -1756,6 +1788,7 @@ export const useUIStore = create<UIState>()(
       openCharacterLibrary: () =>
         set((state) => ({
           characterLibraryOpen: true,
+          cardLibraryKind: "characters",
           agentCatalogOpen: false,
           characterDetailId: null,
           lorebookDetailId: null,
@@ -1768,6 +1801,29 @@ export const useUIStore = create<UIState>()(
           spatialMapDetailChatId: null,
           pendingSpatialMapDraftReview: null,
           botBrowserOpen: false,
+          gameAssetsBrowserOpen: false,
+          noodleOpen: false,
+          editorDirty: false,
+          detailReturnRightPanel: null,
+          rightPanelOpen: isMobileShellViewport() ? false : state.rightPanelOpen,
+        })),
+      openPersonaLibrary: () =>
+        set((state) => ({
+          characterLibraryOpen: true,
+          cardLibraryKind: "personas",
+          agentCatalogOpen: false,
+          characterDetailId: null,
+          lorebookDetailId: null,
+          presetDetailId: null,
+          connectionDetailId: null,
+          agentDetailId: null,
+          toolDetailId: null,
+          personaDetailId: null,
+          regexDetailId: null,
+          spatialMapDetailChatId: null,
+          pendingSpatialMapDraftReview: null,
+          botBrowserOpen: false,
+          gameAssetsBrowserOpen: false,
           noodleOpen: false,
           editorDirty: false,
           detailReturnRightPanel: null,
@@ -2192,7 +2248,7 @@ export const useUIStore = create<UIState>()(
     }),
     {
       name: "marinara-engine-ui",
-      version: 73,
+      version: 74,
       // Debounce localStorage writes to avoid sync I/O on every state change
       storage: createJSONStorage(() => {
         let timer: ReturnType<typeof setTimeout> | null = null;
@@ -2662,13 +2718,18 @@ export const useUIStore = create<UIState>()(
           persisted.appAccentColorBeforeRgbMode = null;
         }
         persisted.characterLibrarySort = normalizeCharacterLibrarySort(persisted.characterLibrarySort);
+        persisted.cardLibraryKind = persisted.cardLibraryKind === "personas" ? "personas" : "characters";
+        persisted.personaLibrarySort = normalizeBasicPanelSort(persisted.personaLibrarySort);
         persisted.characterPanelSearch = normalizePanelText(persisted.characterPanelSearch);
         persisted.characterPanelIncludedTags = normalizePanelStringArray(persisted.characterPanelIncludedTags);
         persisted.characterPanelExcludedTags = normalizePanelStringArray(persisted.characterPanelExcludedTags);
         persisted.characterPanelTagsExpanded = persisted.characterPanelTagsExpanded === true;
-        persisted.characterPanelFavoriteFilter = normalizeCharacterPanelFavoriteFilter(persisted.characterPanelFavoriteFilter);
+        persisted.characterPanelFavoriteFilter = normalizeCharacterPanelFavoriteFilter(
+          persisted.characterPanelFavoriteFilter,
+        );
         persisted.characterPanelScrollTop = normalizeScrollTop(persisted.characterPanelScrollTop);
         persisted.characterLibraryScrollTop = normalizeScrollTop(persisted.characterLibraryScrollTop);
+        persisted.personaLibraryScrollTop = normalizeScrollTop(persisted.personaLibraryScrollTop);
         persisted.lorebookPanelCategory = normalizeLorebookPanelCategory(persisted.lorebookPanelCategory);
         persisted.lorebookPanelSearch = normalizePanelText(persisted.lorebookPanelSearch);
         persisted.lorebookPanelSort = normalizeLorebookPanelSort(persisted.lorebookPanelSort);
@@ -2742,9 +2803,12 @@ export const useUIStore = create<UIState>()(
         noodleOpen: state.noodleOpen,
         noodleSelectedPersonaId: state.noodleSelectedPersonaId,
         characterLibraryOpen: state.characterLibraryOpen,
+        cardLibraryKind: state.cardLibraryKind,
         agentCatalogOpen: state.agentCatalogOpen,
         characterLibrarySelectedId: state.characterLibrarySelectedId,
+        personaLibrarySelectedId: state.personaLibrarySelectedId,
         characterLibrarySort: state.characterLibrarySort,
+        personaLibrarySort: state.personaLibrarySort,
         characterPanelSearch: state.characterPanelSearch,
         characterPanelIncludedTags: state.characterPanelIncludedTags,
         characterPanelExcludedTags: state.characterPanelExcludedTags,
@@ -2752,6 +2816,7 @@ export const useUIStore = create<UIState>()(
         characterPanelFavoriteFilter: state.characterPanelFavoriteFilter,
         characterPanelScrollTop: state.characterPanelScrollTop,
         characterLibraryScrollTop: state.characterLibraryScrollTop,
+        personaLibraryScrollTop: state.personaLibraryScrollTop,
         lorebookPanelCategory: state.lorebookPanelCategory,
         lorebookPanelSearch: state.lorebookPanelSearch,
         lorebookPanelSort: state.lorebookPanelSort,

--- a/packages/server/src/db/seed-mari.ts
+++ b/packages/server/src/db/seed-mari.ts
@@ -137,6 +137,11 @@ Characters automatically know what's happening in their other chats. When the us
 
 ## Key Features
 
+### Card Browser and Card Libraries
+- The **Card Browser** is the top-bar panel for finding character cards on public sites. Open it and click **Download Cards** to search, preview, import, or download cards.
+- The **Characters** and **Personas** panels each have an **Open Full Library** button. Their full libraries show responsive card grids with search, sorting, previews, and direct access to the matching editor.
+- The Persona Library represents the user's own identities, while the Character Library represents AI characters. Do not tell users to look for personas in the Card Browser.
+
 ### Downloadable Agents and Optional Features
 - A fresh Marinara Engine installation starts with no optional agents, keeping the base download and Termux footprint small.
 - Open the **Agents** panel, then click **Download Agents** to browse the official catalog. Each item has a description, permissions, size, documentation, and one-click install, update, or uninstall controls.

--- a/packages/server/src/db/seed-mari.ts
+++ b/packages/server/src/db/seed-mari.ts
@@ -140,7 +140,7 @@ Characters automatically know what's happening in their other chats. When the us
 ### Card Browser and Card Libraries
 - The **Card Browser** is the top-bar panel for finding character cards on public sites. Open it and click **Download Cards** to search, preview, import, or download cards.
 - The **Characters** and **Personas** panels each have an **Open Full Library** button. Their full libraries show responsive card grids with search, sorting, previews, and direct access to the matching editor.
-- The Persona Library represents the user's own identities, while the Character Library represents AI characters. Do not tell users to look for personas in the Card Browser.
+- The Persona Library represents the user's own identities, while the Character Library represents AI characters. Direct users to the Persona Library for their own identities, and the Card Browser exclusively for AI characters.
 
 ### Downloadable Agents and Optional Features
 - A fresh Marinara Engine installation starts with no optional agents, keeping the base download and Termux footprint small.

--- a/packages/server/src/services/bot-browser/fetch-json.ts
+++ b/packages/server/src/services/bot-browser/fetch-json.ts
@@ -4,17 +4,16 @@ const DEFAULT_TIMEOUT_MS = 30_000;
 const DEFAULT_MAX_RESPONSE_BYTES = 4 * 1024 * 1024;
 const JSON_CONTENT_TYPES = ["application/json", "+json"];
 
-export interface BotBrowserJsonFetchOptions
-  extends Omit<SafeFetchOptions, "allowedContentTypes" | "bufferResponse" | "maxResponseBytes" | "policy"> {
+export interface BotBrowserJsonFetchOptions extends Omit<
+  SafeFetchOptions,
+  "allowedContentTypes" | "bufferResponse" | "maxResponseBytes" | "policy"
+> {
   allowedHosts: readonly string[];
   maxResponseBytes?: number;
   timeoutMs?: number;
 }
 
-export async function fetchBotBrowserJson(
-  url: string | URL,
-  options: BotBrowserJsonFetchOptions,
-): Promise<unknown> {
+export async function fetchBotBrowserJson(url: string | URL, options: BotBrowserJsonFetchOptions): Promise<unknown> {
   const {
     allowedHosts,
     maxResponseBytes = DEFAULT_MAX_RESPONSE_BYTES,
@@ -25,14 +24,14 @@ export async function fetchBotBrowserJson(
   const target = new URL(url);
   const normalizedHosts = new Set(allowedHosts.map((host) => host.toLowerCase()));
   if (target.protocol !== "https:" || !normalizedHosts.has(target.hostname)) {
-    throw new Error(`Bot Browser JSON request rejected untrusted host: ${target.hostname || "(missing)"}`);
+    throw new Error(`Card Browser JSON request rejected untrusted host: ${target.hostname || "(missing)"}`);
   }
 
   const controller = new AbortController();
   const abortFromCaller = () => controller.abort(callerSignal?.reason);
   if (callerSignal?.aborted) abortFromCaller();
   else callerSignal?.addEventListener("abort", abortFromCaller, { once: true });
-  const timeout = setTimeout(() => controller.abort(new Error("Bot Browser request timed out")), timeoutMs);
+  const timeout = setTimeout(() => controller.abort(new Error("Card Browser request timed out")), timeoutMs);
 
   try {
     const response = await safeFetch(target, {


### PR DESCRIPTION
## Linked issue

No linked issue. This is a maintainer-requested Card Browser, library, and agent-sidebar refinement.

## Why this change

The former Bot Browser naming no longer matched its purpose as a downloadable character-card catalog, Personas lacked the full-library workflow already available to Characters, library text still contained hard-coded pink styling, and downloaded agent artwork stopped at the catalog instead of carrying into the installed Agents sidebar.

## What changed

- Renamed Bot Browser to Card Browser and Browse Online to Download Cards across the UI, documentation, onboarding, and Professor Mari guidance.
- Generalized the responsive full-library experience for both Characters and Personas, including search, sorting, pagination, preview, and desktop sidebar-preserving navigation.
- Replaced legacy fixed-pink library text with the selected chroma text styling and restored the intended Characters sidebar gradient while keeping topbar icons chroma-aware.
- Added a shared failure-safe agent-artwork renderer and applied catalog artwork to installed sidebar agents, while preserving uploaded images as the first priority and the Agents star as fallback.
- Updated the v2.3.0 changelog and browser regression coverage.

## Validation

- [ ] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed `CONTRIBUTING.md`

### Manual verification notes

- Automated desktop Playwright regression passed for package artwork appearing in the open Agents sidebar and clearing immediately after uninstall.
- Human browser verification remains requested for the Character and Persona full-library paths on desktop and mobile, including light/dark themes.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Version/release files updated (only if this PR includes a version bump)

Documentation and `CHANGELOG.md` are included. This PR does not bump the application version.

## UI evidence (if applicable)

No screenshots are attached; the automated browser regression covers the new agent-artwork behavior.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an **Open Full Library** option for Personas, with responsive browsing and preserved selection, sorting, and scroll position.
  * Unified Character and Persona library browsing with shared search, sorting, details, badges, and responsive layouts.
  * Added downloaded artwork support for installed agents.

* **Bug Fixes**
  * Improved fallback artwork handling and restored the Characters sidebar gradient icon styling.

* **Documentation**
  * Updated terminology from “Bot Browser” to **Card Browser** and “Browse Online” to **Download Cards** across the interface, onboarding, tutorials, and guides.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->