### PR TITLE
Honor Conversation selfie prompt model overrides

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 
 ### Fixed
 
+- Fixed Conversation selfie prompt generation ignoring the per-chat **Prompt Model** selection. Automatic character selfies and Gallery selfies now route their prompt-writing request through the selected text connection, including its provider, model, caching behavior, and local-sidecar support (#3638).
 - Applied downloaded package artwork to matching installed agents in the Agents sidebar, while preserving user-uploaded pictures and the star fallback for missing or failed images.
 - Restored the Characters sidebar header icon to the same pink-to-rose gradient used by the New Character action while keeping its topbar icon on the selected chroma accent.
 - Calibrated Lorebook semantic similarity against an unrelated-text baseline so embedding models whose raw cosine scores cluster around 0.97 no longer inject unrelated entries at every usable threshold or suppress relevant entries near 1.0 (#3627).

--- a/packages/server/src/routes/gallery.routes.ts
+++ b/packages/server/src/routes/gallery.routes.ts
@@ -41,9 +41,7 @@ import {
   resolveImageConnectionFallback,
   resolveVideoConnectionFallback,
 } from "../services/generation/media-connection-fallback.js";
-import { createLLMProvider } from "../services/llm/provider-registry.js";
-import { withConnectionFallbackProvider } from "../services/llm/connection-fallback-provider.js";
-import { getLocalSidecarProvider, LOCAL_SIDECAR_MODEL } from "../services/llm/local-sidecar.js";
+import { resolveIllustratorPromptRuntime } from "../services/generation/illustrator-prompt-runtime.js";
 import { resolveConversationSelfieSystemPrompt } from "../services/conversation/selfie-prompt.js";
 import { isNovelAiImageConnection, resolveIllustratorCharacterReferences } from "./generate/illustrator-references.js";
 import { resolveBaseUrl } from "./generate/generate-route-utils.js";
@@ -907,12 +905,6 @@ export async function galleryRoutes(app: FastifyInstance) {
         error: "No image generation connection configured for this chat. Set one in Conversation Chat Settings.",
       });
     }
-    if (!chat.connectionId) {
-      return reply.status(400).send({
-        error: "No conversation connection configured for this chat. Set one before generating selfies.",
-      });
-    }
-
     const connections = createConnectionsStorage(app.db);
     const imageConn = await connections.getWithKey(imageConnectionId);
     if (!imageConn) return reply.status(404).send({ error: "Image generation connection not found." });
@@ -920,9 +912,10 @@ export async function galleryRoutes(app: FastifyInstance) {
       return reply.status(400).send({ error: "Selected selfie connection is not an image generation connection." });
     }
 
-    const useLocalSidecar = chat.connectionId === LOCAL_SIDECAR_CONNECTION_ID;
-    const chatConn = useLocalSidecar ? null : await connections.getWithKey(chat.connectionId);
-    if (!useLocalSidecar && !chatConn) return reply.status(404).send({ error: "Conversation connection not found." });
+    const defaultPromptConnection =
+      chat.connectionId && chat.connectionId !== LOCAL_SIDECAR_CONNECTION_ID
+        ? await connections.getWithKey(chat.connectionId)
+        : null;
 
     const characterData = parseJsonRecord(character.data);
     const characterName = readTrimmedString(characterData.name) ?? "character";
@@ -940,26 +933,20 @@ export async function galleryRoutes(app: FastifyInstance) {
     });
 
     const selfieAbortSignal = createResponseAbortSignal(reply, SCENE_VIDEO_GENERATION_TIMEOUT_MS, "Selfie generation");
-    const promptFallbackConnection = await connections.getFallbackForAgents();
-    const primaryPromptBuilder = useLocalSidecar
-      ? getLocalSidecarProvider()
-      : createLLMProvider(
-          chatConn!.provider,
-          resolveBaseUrl(chatConn!),
-          chatConn!.apiKey,
-          chatConn!.maxContext,
-          chatConn!.openrouterProvider,
-          chatConn!.maxTokensOverride,
-          chatConn!.claudeFastMode === "true",
-          chatConn!.treatAsLocalEndpoint === "true",
-        );
-    const promptBuilder = withConnectionFallbackProvider({
-      primary: primaryPromptBuilder,
-      primaryConnectionId: useLocalSidecar ? LOCAL_SIDECAR_CONNECTION_ID : chatConn!.id,
-      fallbackConnection: promptFallbackConnection,
-      fallbackBaseUrl: promptFallbackConnection ? resolveBaseUrl(promptFallbackConnection) : "",
-      category: "agents",
-    });
+    let promptRuntime;
+    try {
+      promptRuntime = await resolveIllustratorPromptRuntime({
+        chatMetadata: meta,
+        defaultConnection: defaultPromptConnection,
+        defaultConnectionId: chat.connectionId,
+        connections,
+        resolveBaseUrl,
+      });
+    } catch (err) {
+      const message = err instanceof Error ? err.message : "Selfie Prompt Model connection is unavailable.";
+      return reply.status(400).send({ error: message });
+    }
+    const promptBuilder = promptRuntime.provider;
     const promptContext = input.context?.trim()
       ? `Context for the selfie: ${input.context.trim()}`
       : `Generate a casual selfie of ${characterName} based on the current conversation context.`;
@@ -978,12 +965,12 @@ export async function galleryRoutes(app: FastifyInstance) {
             { role: "user", content: promptContext },
           ],
           {
-            model: useLocalSidecar ? LOCAL_SIDECAR_MODEL : chatConn!.model,
-            temperature: 0.7,
-            maxTokens: 8196,
+            model: promptRuntime.model,
+            ...(promptRuntime.suppressModelParameters ? {} : { temperature: 0.7, maxTokens: 8196 }),
+            suppressModelParameters: promptRuntime.suppressModelParameters,
             signal: selfieAbortSignal,
-            enableCaching: !useLocalSidecar && chatConn!.enableCaching === "true",
-            anthropicExtendedCacheTtl: !useLocalSidecar && chatConn!.anthropicExtendedCacheTtl === "true",
+            enableCaching: promptRuntime.enableCaching,
+            anthropicExtendedCacheTtl: promptRuntime.anthropicExtendedCacheTtl,
           },
         );
         imagePrompt = (promptResult.content ?? "").trim();

--- a/packages/server/src/routes/generate.routes.ts
+++ b/packages/server/src/routes/generate.routes.ts
@@ -8321,8 +8321,6 @@ export async function generateRoutes(app: FastifyInstance) {
                     : null,
                   promptConnection: conn,
                   promptConnectionId: conn.id,
-                  baseUrl,
-                  suppressModelParameters,
                   serviceTier,
                   db: app.db,
                   chars,

--- a/packages/server/src/routes/generate.routes.ts
+++ b/packages/server/src/routes/generate.routes.ts
@@ -8321,6 +8321,7 @@ export async function generateRoutes(app: FastifyInstance) {
                     : null,
                   promptConnection: conn,
                   promptConnectionId: conn.id,
+                  debugMode: input.debugMode,
                   serviceTier,
                   db: app.db,
                   chars,

--- a/packages/server/src/services/generation/conversation-selfie-command-runtime.ts
+++ b/packages/server/src/services/generation/conversation-selfie-command-runtime.ts
@@ -9,17 +9,17 @@ import { persistGeneratedImageToEntityGalleries } from "../image/generated-image
 import { resolveConnectionImageDefaults } from "../image/image-generation-defaults.js";
 import { generateImage, saveImageToDisk } from "../image/image-generation.js";
 import { loadImageGenerationUserSettings } from "../image/image-generation-settings.js";
-import { createLLMProvider } from "../llm/provider-registry.js";
-import {
-  withConnectionFallbackProvider,
-  type FallbackConnection,
-} from "../llm/connection-fallback-provider.js";
 import { resolveConversationSelfieSystemPrompt } from "../conversation/selfie-prompt.js";
 import type { CharacterCommand, SelfieCommand } from "../conversation/character-commands.js";
 import { createGalleryStorage } from "../storage/gallery.storage.js";
 import { createCharacterGalleryStorage } from "../storage/character-gallery.storage.js";
 import { createPersonaGalleryStorage } from "../storage/persona-gallery.storage.js";
 import { createPromptOverridesStorage } from "../storage/prompt-overrides.storage.js";
+import {
+  resolveIllustratorPromptRuntime,
+  type IllustratorPromptConnection,
+  type IllustratorPromptConnectionsStore,
+} from "./illustrator-prompt-runtime.js";
 import { resolveImageConnectionFallback } from "./media-connection-fallback.js";
 import { resolveBaseUrl } from "../../routes/generate/generate-route-utils.js";
 
@@ -34,19 +34,8 @@ type ChatsStore = {
   getMessage(id: string): Promise<{ activeSwipeIndex?: number | null } | null>;
 };
 
-type ConnectionsStore = {
-  getWithKey(id: string): Promise<Record<string, any> | null>;
-  getFallbackForAgents(): Promise<FallbackConnection | null>;
+type ConnectionsStore = IllustratorPromptConnectionsStore & {
   getFallbackForImageGeneration(): Promise<Record<string, any> | null>;
-};
-
-type PromptConnection = {
-  provider: string;
-  apiKey: string;
-  model: string;
-  maxContext?: number | null;
-  openrouterProvider?: string | null;
-  maxTokensOverride?: number | null;
 };
 
 type PromptCharacter = {
@@ -72,10 +61,8 @@ export async function handleConversationSelfieCommand(args: {
   chatMeta: Record<string, unknown>;
   charInfo: PromptCharacter[];
   persona: PersonaReference;
-  promptConnection: PromptConnection;
+  promptConnection: IllustratorPromptConnection;
   promptConnectionId: string;
-  baseUrl: string;
-  suppressModelParameters: boolean;
   serviceTier: "flex" | "priority" | null;
   db: DB;
   chars: CharactersStore;
@@ -145,26 +132,18 @@ async function generateSelfie(
     typeof args.chatMeta.selfieNegativePrompt === "string" ? args.chatMeta.selfieNegativePrompt.trim() : "";
   const selfiePromptTemplate = typeof args.chatMeta.selfiePrompt === "string" ? args.chatMeta.selfiePrompt.trim() : "";
 
-  const promptFallbackConnection = await args.connections.getFallbackForAgents();
   const reportFallback = (notice: {
     category: "main" | "agents" | "illustrator" | "video";
     connectionId: string;
     connectionName: string;
     model: string;
   }) => args.sendEvent({ type: "fallback_used", data: notice });
-  const promptBuilder = withConnectionFallbackProvider({
-    primary: createLLMProvider(
-      args.promptConnection.provider,
-      args.baseUrl,
-      args.promptConnection.apiKey,
-      args.promptConnection.maxContext,
-      args.promptConnection.openrouterProvider,
-      args.promptConnection.maxTokensOverride,
-    ),
-    primaryConnectionId: args.promptConnectionId,
-    fallbackConnection: promptFallbackConnection,
-    fallbackBaseUrl: promptFallbackConnection ? resolveBaseUrl(promptFallbackConnection) : "",
-    category: "agents",
+  const promptRuntime = await resolveIllustratorPromptRuntime({
+    chatMetadata: args.chatMeta,
+    defaultConnection: args.promptConnection,
+    defaultConnectionId: args.promptConnectionId,
+    connections: args.connections,
+    resolveBaseUrl,
     onFallback: reportFallback,
   });
   const selfieSystemPrompt = await resolveConversationSelfieSystemPrompt({
@@ -173,7 +152,7 @@ async function generateSelfie(
     appearance,
     charName: args.charName,
   });
-  const promptResult = await promptBuilder.chatComplete(
+  const promptResult = await promptRuntime.provider.chatComplete(
     [
       {
         role: "system",
@@ -187,9 +166,13 @@ async function generateSelfie(
       },
     ],
     {
-      model: args.promptConnection.model,
-      ...(args.suppressModelParameters ? {} : { temperature: 0.7, maxTokens: 8196, serviceTier: args.serviceTier }),
-      suppressModelParameters: args.suppressModelParameters,
+      model: promptRuntime.model,
+      ...(promptRuntime.suppressModelParameters
+        ? {}
+        : { temperature: 0.7, maxTokens: 8196, serviceTier: args.serviceTier }),
+      suppressModelParameters: promptRuntime.suppressModelParameters,
+      enableCaching: promptRuntime.enableCaching,
+      anthropicExtendedCacheTtl: promptRuntime.anthropicExtendedCacheTtl,
     },
   );
 

--- a/packages/server/src/services/generation/conversation-selfie-command-runtime.ts
+++ b/packages/server/src/services/generation/conversation-selfie-command-runtime.ts
@@ -1,5 +1,6 @@
 import type { DB } from "../../db/connection.js";
-import { logger } from "../../lib/logger.js";
+import { isDebugAgentsEnabled } from "../../config/runtime-config.js";
+import { logger, logDebugOverride } from "../../lib/logger.js";
 import {
   isNovelAiImageConnection,
   resolveIllustratorCharacterReferences,
@@ -63,6 +64,7 @@ export async function handleConversationSelfieCommand(args: {
   persona: PersonaReference;
   promptConnection: IllustratorPromptConnection;
   promptConnectionId: string;
+  debugMode?: boolean;
   serviceTier: "flex" | "priority" | null;
   db: DB;
   chars: CharactersStore;
@@ -152,6 +154,18 @@ async function generateSelfie(
     appearance,
     charName: args.charName,
   });
+  const userPrompt = args.command.context
+    ? `Context for the selfie: ${args.command.context}`
+    : `Generate a casual selfie of ${args.charName} based on the current conversation context.`;
+  const debugOverrideEnabled = args.debugMode === true || isDebugAgentsEnabled();
+  if (debugOverrideEnabled || logger.isLevelEnabled("debug")) {
+    logDebugOverride(
+      debugOverrideEnabled,
+      "[debug/commands/selfie] prompt-builder system:\n%s",
+      selfieSystemPrompt,
+    );
+    logDebugOverride(debugOverrideEnabled, "[debug/commands/selfie] prompt-builder user:\n%s", userPrompt);
+  }
   const promptResult = await promptRuntime.provider.chatComplete(
     [
       {
@@ -160,9 +174,7 @@ async function generateSelfie(
       },
       {
         role: "user",
-        content: args.command.context
-          ? `Context for the selfie: ${args.command.context}`
-          : `Generate a casual selfie of ${args.charName} based on the current conversation context.`,
+        content: userPrompt,
       },
     ],
     {

--- a/packages/server/src/services/generation/illustrator-prompt-runtime.ts
+++ b/packages/server/src/services/generation/illustrator-prompt-runtime.ts
@@ -1,0 +1,127 @@
+import { LOCAL_SIDECAR_CONNECTION_ID } from "@marinara-engine/shared";
+import type { BaseLLMProvider } from "../llm/base-provider.js";
+import { withConnectionFallbackProvider, type FallbackConnection } from "../llm/connection-fallback-provider.js";
+import { getLocalSidecarProvider, LOCAL_SIDECAR_MODEL } from "../llm/local-sidecar.js";
+import { createLLMProvider } from "../llm/provider-registry.js";
+import type { GenerationFallbackNotifier } from "./fallback-notification.js";
+import { resolveModelAccessPolicy } from "./model-access-policy.js";
+
+export type IllustratorPromptConnection = FallbackConnection & {
+  defaultParameters?: string | Record<string, unknown> | null;
+  enableCaching?: string | boolean | null;
+  anthropicExtendedCacheTtl?: string | boolean | null;
+  imageGenerationSource?: string | null;
+  imageService?: string | null;
+  imageEndpointId?: string | null;
+  comfyuiWorkflow?: string | null;
+};
+
+export type IllustratorPromptConnectionsStore = {
+  getWithKey(id: string): Promise<IllustratorPromptConnection | null>;
+  getFallbackForAgents(): Promise<FallbackConnection | null>;
+};
+
+export type IllustratorPromptRuntime = {
+  provider: BaseLLMProvider;
+  model: string;
+  connectionId: string;
+  suppressModelParameters: boolean;
+  enableCaching: boolean;
+  anthropicExtendedCacheTtl: boolean;
+};
+
+function readConnectionId(value: unknown): string | null {
+  return typeof value === "string" && value.trim() ? value.trim() : null;
+}
+
+function isEnabled(value: unknown): boolean {
+  return value === true || value === "true";
+}
+
+/**
+ * Resolve the text-generation runtime that writes Illustrator prompts.
+ * A per-chat Prompt Model selection takes precedence over the chat's main
+ * connection for every caller, including Conversation selfie generation.
+ */
+export async function resolveIllustratorPromptRuntime(args: {
+  chatMetadata: Record<string, unknown>;
+  defaultConnection: IllustratorPromptConnection | null;
+  defaultConnectionId: string | null;
+  connections: IllustratorPromptConnectionsStore;
+  resolveBaseUrl(connection: Pick<IllustratorPromptConnection, "baseUrl" | "provider">): string;
+  onFallback?: GenerationFallbackNotifier;
+}): Promise<IllustratorPromptRuntime> {
+  const overrideConnectionId = readConnectionId(args.chatMetadata.illustratorPromptConnectionId);
+  const defaultConnectionId = readConnectionId(args.defaultConnectionId);
+  const connectionId = overrideConnectionId ?? defaultConnectionId;
+  if (!connectionId) {
+    throw new Error("No text connection is configured for selfie prompt generation.");
+  }
+
+  const fallbackConnection = await args.connections.getFallbackForAgents();
+  const wrapWithFallback = (provider: BaseLLMProvider) =>
+    withConnectionFallbackProvider({
+      primary: provider,
+      primaryConnectionId: connectionId,
+      fallbackConnection,
+      fallbackBaseUrl: fallbackConnection ? args.resolveBaseUrl(fallbackConnection) : "",
+      category: "agents",
+      onFallback: args.onFallback,
+    });
+
+  if (connectionId === LOCAL_SIDECAR_CONNECTION_ID) {
+    return {
+      provider: wrapWithFallback(getLocalSidecarProvider()),
+      model: LOCAL_SIDECAR_MODEL,
+      connectionId,
+      suppressModelParameters: false,
+      enableCaching: false,
+      anthropicExtendedCacheTtl: false,
+    };
+  }
+
+  const connection =
+    args.defaultConnection?.id === connectionId
+      ? args.defaultConnection
+      : await args.connections.getWithKey(connectionId);
+  if (!connection) {
+    throw new Error(
+      overrideConnectionId
+        ? "The selected selfie Prompt Model connection could not be found."
+        : "The conversation connection could not be found.",
+    );
+  }
+  if (connection.provider === "image_generation" || connection.provider === "video_generation") {
+    throw new Error("The selected selfie Prompt Model must be a text-generation connection.");
+  }
+
+  const model = connection.model.trim();
+  if (!model) throw new Error("The selected selfie Prompt Model has no model configured.");
+  const baseUrl = args.resolveBaseUrl(connection);
+  if (!baseUrl) throw new Error("The selected selfie Prompt Model has no usable Base URL.");
+
+  const modelAccessPolicy = resolveModelAccessPolicy({
+    provider: connection.provider,
+    model,
+    maxContext: connection.maxContext,
+  });
+  return {
+    provider: wrapWithFallback(
+      createLLMProvider(
+        connection.provider,
+        baseUrl,
+        connection.apiKey,
+        connection.maxContext,
+        connection.openrouterProvider,
+        connection.maxTokensOverride,
+        isEnabled(connection.claudeFastMode),
+        isEnabled(connection.treatAsLocalEndpoint),
+      ),
+    ),
+    model,
+    connectionId,
+    suppressModelParameters: modelAccessPolicy.suppressModelParameters,
+    enableCaching: isEnabled(connection.enableCaching),
+    anthropicExtendedCacheTtl: isEnabled(connection.anthropicExtendedCacheTtl),
+  };
+}

--- a/scripts/regressions/open-issues.regression.ts
+++ b/scripts/regressions/open-issues.regression.ts
@@ -48,6 +48,10 @@ import {
   stripConversationResponseEnvelope,
 } from "../../packages/server/src/services/conversation/transcript-sanitize.js";
 import { resolveInitialGameGmConnectionId } from "../../packages/server/src/services/game/initial-game-setup.js";
+import {
+  resolveIllustratorPromptRuntime,
+  type IllustratorPromptConnection,
+} from "../../packages/server/src/services/generation/illustrator-prompt-runtime.js";
 import { annotateContentWithReactions } from "../../packages/server/src/routes/generate/conversation-custom-assets.js";
 import {
   buildGameSessionReplayTurns,
@@ -114,6 +118,64 @@ assert.equal(resolveInitialGameGmConnectionId(undefined, "chat-connection"), "ch
 assert.equal(resolveInitialGameGmConnectionId("explicit-connection", "chat-connection"), "explicit-connection");
 assert.equal(resolveInitialGameGmConnectionId(undefined, null), null);
 assert.equal(DEFAULT_GENERATION_PARAMS.reasoningEffort, "maximum");
+
+const mainPromptConnection: IllustratorPromptConnection = {
+  id: "main-prompt-connection",
+  name: "Main prompt connection",
+  provider: "openai",
+  baseUrl: "https://main.example.test/v1",
+  apiKey: "main-key",
+  model: "gpt-4o",
+};
+const selfiePromptConnection: IllustratorPromptConnection = {
+  id: "selfie-prompt-connection",
+  name: "Selfie prompt connection",
+  provider: "openai",
+  baseUrl: "https://selfie.example.test/v1",
+  apiKey: "selfie-key",
+  model: "gpt-4.1-mini",
+};
+const requestedSelfiePromptConnections: string[] = [];
+const selfiePromptConnections = {
+  async getWithKey(id: string) {
+    requestedSelfiePromptConnections.push(id);
+    return id === selfiePromptConnection.id ? selfiePromptConnection : null;
+  },
+  async getFallbackForAgents() {
+    return null;
+  },
+};
+const overriddenSelfiePromptRuntime = await resolveIllustratorPromptRuntime({
+  chatMetadata: { illustratorPromptConnectionId: selfiePromptConnection.id },
+  defaultConnection: mainPromptConnection,
+  defaultConnectionId: mainPromptConnection.id,
+  connections: selfiePromptConnections,
+  resolveBaseUrl: (connection) => connection.baseUrl ?? "",
+});
+assert.equal(overriddenSelfiePromptRuntime.connectionId, selfiePromptConnection.id);
+assert.equal(overriddenSelfiePromptRuntime.model, selfiePromptConnection.model);
+assert.deepEqual(requestedSelfiePromptConnections, [selfiePromptConnection.id]);
+
+const defaultSelfiePromptRuntime = await resolveIllustratorPromptRuntime({
+  chatMetadata: {},
+  defaultConnection: mainPromptConnection,
+  defaultConnectionId: mainPromptConnection.id,
+  connections: selfiePromptConnections,
+  resolveBaseUrl: (connection) => connection.baseUrl ?? "",
+});
+assert.equal(defaultSelfiePromptRuntime.connectionId, mainPromptConnection.id);
+assert.equal(defaultSelfiePromptRuntime.model, mainPromptConnection.model);
+
+await assert.rejects(
+  resolveIllustratorPromptRuntime({
+    chatMetadata: { illustratorPromptConnectionId: "deleted-selfie-prompt-connection" },
+    defaultConnection: mainPromptConnection,
+    defaultConnectionId: mainPromptConnection.id,
+    connections: selfiePromptConnections,
+    resolveBaseUrl: (connection) => connection.baseUrl ?? "",
+  }),
+  /selected selfie Prompt Model connection could not be found/u,
+);
 
 const autonomousSchedule = (talkativeness: number, cap: number): WeekSchedule => ({
   weekStart: "2026-07-13",
@@ -221,6 +283,14 @@ const connectionsPanelSource = readFileSync(
   "utf8",
 );
 const globalStyles = readFileSync(new URL("../../packages/client/src/styles/globals.css", import.meta.url), "utf8");
+const galleryRoutesSource = readFileSync(
+  new URL("../../packages/server/src/routes/gallery.routes.ts", import.meta.url),
+  "utf8",
+);
+const conversationSelfieRuntimeSource = readFileSync(
+  new URL("../../packages/server/src/services/generation/conversation-selfie-command-runtime.ts", import.meta.url),
+  "utf8",
+);
 assert.match(appSource, /--marinara-app-accent-static-gradient/u);
 assert.match(appSource, /swipeDirections=\{\["left", "right", "top"\]\}/u);
 assert.doesNotMatch(agentEditorSource, /fetch\(["']\/api\/game-assets\/pick-local-music-folder/u);
@@ -235,6 +305,11 @@ assert.doesNotMatch(gameAssetStoreSource, /api\.|fetchManifest|rescanAssets|\/ga
 assert.match(sidecarStoreSource, /consumeSidecarDownloadStream/u);
 assert.doesNotMatch(sidecarStoreSource, /readSseData|Best-effort delete|Best-effort unload/u);
 assert.match(connectionsPanelSource, /Failed to delete the Local Whisper model/u);
+assert.match(galleryRoutesSource, /resolveIllustratorPromptRuntime\(\{[\s\S]*chatMetadata: meta/u);
+assert.match(
+  conversationSelfieRuntimeSource,
+  /resolveIllustratorPromptRuntime\(\{[\s\S]*chatMetadata: args\.chatMeta/u,
+);
 assert.match(
   globalStyles,
   /\[data-marinara-accent-animation\] \.mari-editor-content \{[\s\S]*--primary: var\(--marinara-app-accent-static\);[\s\S]*--marinara-chat-chrome-accent: var\(--marinara-app-accent-static\);[\s\S]*\}/u,

--- a/scripts/regressions/open-issues.regression.ts
+++ b/scripts/regressions/open-issues.regression.ts
@@ -311,6 +311,10 @@ assert.match(
   /resolveIllustratorPromptRuntime\(\{[\s\S]*chatMetadata: args\.chatMeta/u,
 );
 assert.match(
+  conversationSelfieRuntimeSource,
+  /logDebugOverride\([\s\S]*\[debug\/commands\/selfie\] prompt-builder system/u,
+);
+assert.match(
   globalStyles,
   /\[data-marinara-accent-animation\] \.mari-editor-content \{[\s\S]*--primary: var\(--marinara-app-accent-static\);[\s\S]*--marinara-chat-chrome-accent: var\(--marinara-app-accent-static\);[\s\S]*\}/u,
 );


### PR DESCRIPTION
## Why

Conversation selfie prompt generation ignored the chat's **Prompt Model** selection and reused the main chat connection. That made the setting ineffective and could charge the wrong provider for both automatic character selfies and Gallery selfies.

Closes #3638

## What changed

- resolve the per-chat Illustrator prompt connection through one shared server runtime
- use the selected provider, model, Base URL, caching flags, model-access policy, and local sidecar support in both Conversation selfie entry points
- retain the main chat connection as the default only when no Prompt Model override is selected
- return a clear error for a deleted or invalid selected prompt connection instead of silently falling back to the main model
- add issue regression coverage and a v2.3.0 changelog entry

## Test plan

- [ ] Manually verify an automatic Conversation `[selfie]` request records one chat-model request and one request against the separately selected selfie Prompt Model.
- [ ] Manually verify a Gallery selfie uses the separately selected selfie Prompt Model.
- [ ] Manually verify **Main chat model** continues to work when no override is selected.
- [ ] Manually verify a local-sidecar Prompt Model selection works when the local model is installed.

## Automated validation

- `pnpm --filter @marinara-engine/server lint`
- `pnpm regression:issues`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Conversation and Gallery selfies now use the selected per-chat **Prompt Model** for prompt generation.
  * Supports configured provider behavior, caching, and local-sidecar connections.
* **Bug Fixes**
  * Fixed an issue where the selected Prompt Model was ignored when generating automatic character or Gallery selfies.
  * Added clearer error handling when the selected prompt runtime is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->