### PR TITLE
Fix Conversation scene summary compaction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 
 ### Fixed
 
+- Fixed concluded Conversation scene summaries bypassing daily and weekly compaction because narrator history is represented as system-role prompt messages. Past scene summaries now fold into their normal day/week summaries and stay out of the verbatim recent-message tail, while current-day scene context and genuine system instructions remain intact ([#3641](https://github.com/Pasta-Devs/Marinara-Engine/issues/3641)).
 - Replaced stale Spotify, YouTube, or Custom player controls with clear **Download Music DJ Agent to configure** guidance and a direct **Download Agents** action on desktop and mobile whenever the always-available **Music Player** toggle is enabled without Music DJ installed.
 - Fixed Conversation selfie prompt generation ignoring the per-chat **Prompt Model** selection. Automatic character selfies and Gallery selfies now route their prompt-writing request through the selected text connection, including its provider, model, caching behavior, and local-sidecar support (#3638).
 - Applied downloaded package artwork to matching installed agents in the Agents sidebar, while preserving user-uploaded pictures and the star fallback for missing or failed images.

--- a/packages/server/src/routes/generate/conversation-history-runtime.ts
+++ b/packages/server/src/routes/generate/conversation-history-runtime.ts
@@ -332,7 +332,13 @@ function bucketConversationHistory(args: {
   for (let i = 0; i < args.finalMessages.length; i++) {
     const msg = args.finalMessages[i]!;
     const raw = args.chatMessages[i];
-    if (!raw?.createdAt || msg.role === "system") {
+    const narratorTimestamp = raw?.role === "narrator" && raw.createdAt ? new Date(raw.createdAt as string) : null;
+    const isPastNarratorHistory =
+      msg.role === "system" &&
+      narratorTimestamp !== null &&
+      Number.isFinite(narratorTimestamp.getTime()) &&
+      !args.isSameDay(narratorTimestamp);
+    if (!raw?.createdAt || (msg.role === "system" && !isPastNarratorHistory)) {
       if (currentBucket) {
         buckets.push(currentBucket);
         currentBucket = null;
@@ -342,12 +348,15 @@ function bucketConversationHistory(args: {
     }
 
     const ts = new Date(raw.createdAt as string);
-    const author =
-      msg.role === "user"
-        ? args.personaName
-        : ((raw.characterId ? args.charIdToName.get(raw.characterId as string) : null) ??
-          args.convoCharNames[0] ??
-          "Character");
+    let author = "Character";
+    if (raw.role === "narrator") author = "Narrator";
+    else if (msg.role === "user") author = args.personaName;
+    else {
+      author =
+        (raw.characterId ? args.charIdToName.get(raw.characterId as string) : null) ??
+        args.convoCharNames[0] ??
+        "Character";
+    }
 
     if (args.isSameDay(ts)) {
       if (currentBucket) {
@@ -428,7 +437,12 @@ function collectConversationSummaryTail(args: {
     if (bucket.date === args.todayDateKey) continue;
     if (!args.daySummaries[bucket.date]) continue;
     for (let mi = bucket.msgs.length - 1; mi >= 0; mi--) {
-      tailEntries.unshift(bucket.msgs[mi]!);
+      const message = bucket.msgs[mi]!;
+      // Timestamped narrator messages (including concluded scene summaries) are represented as
+      // system-role history. Once their day is summarized, do not resurrect those generated blocks
+      // through the verbatim conversation tail; keep filling the tail with real conversation turns.
+      if (message.role === "system") continue;
+      tailEntries.unshift(message);
       if (tailEntries.length >= args.tailCount) break outer;
     }
   }

--- a/scripts/regressions/prompt.regression.ts
+++ b/scripts/regressions/prompt.regression.ts
@@ -121,6 +121,7 @@ import {
 } from "../../packages/server/src/services/video/prompt-context.js";
 import { resolveGameGmPromptTemplate } from "../../packages/server/src/services/generation/game-gm-prompt-runtime.js";
 import { countUserMessagesAfterSummaryAnchor } from "../../packages/server/src/services/conversation/auto-summary.service.js";
+import { prepareConversationPromptHistory } from "../../packages/server/src/routes/generate/conversation-history-runtime.js";
 import {
   buildNpcPortraitProviderPrompt,
   buildSceneIllustrationProviderPrompt,
@@ -3139,6 +3140,77 @@ Use HTML sparingly and diegetically. Do not replace normal prose/dialogue unless
       assert.equal(countUserMessagesAfterSummaryAnchor(messages, null), 2);
       assert.equal(countUserMessagesAfterSummaryAnchor(messages, "missing"), 2);
       assert.equal(countUserMessagesAfterSummaryAnchor(messages, "a1"), 1);
+    },
+  },
+  {
+    name: "past Conversation scene summaries compact into day and week summaries",
+    async run() {
+      const oldCreatedAt = "2026-06-23T12:00:00.000Z";
+      const currentCreatedAt = "2026-07-15T12:00:00.000Z";
+      const oldSceneSummary = "OLD_SCENE_SUMMARY_MUST_NOT_REMAIN_VERBATIM";
+      const currentSceneSummary = "CURRENT_SCENE_SUMMARY_MUST_REMAIN_VERBATIM";
+      const authoredSystemInstruction = "AUTHORED_SYSTEM_INSTRUCTION_MUST_REMAIN";
+      const chatMessages = [
+        { id: "old-user", role: "user", content: "An older conversation turn.", createdAt: oldCreatedAt },
+        { id: "old-scene", role: "narrator", content: oldSceneSummary, createdAt: oldCreatedAt },
+        { id: "authored-system", role: "system", content: authoredSystemInstruction, createdAt: oldCreatedAt },
+        { id: "current-scene", role: "narrator", content: currentSceneSummary, createdAt: currentCreatedAt },
+      ];
+      const finalMessages = [
+        { id: "old-user", role: "user" as const, content: "An older conversation turn.", contextKind: "history" as const },
+        { id: "old-scene", role: "system" as const, content: oldSceneSummary, contextKind: "history" as const },
+        {
+          id: "authored-system",
+          role: "system" as const,
+          content: authoredSystemInstruction,
+          contextKind: "history" as const,
+        },
+        { id: "current-scene", role: "system" as const, content: currentSceneSummary, contextKind: "history" as const },
+      ];
+
+      const prepared = await prepareConversationPromptHistory({
+        finalMessages,
+        chatMessages,
+        scopedMessages: chatMessages,
+        chatMeta: {
+          summaryTailMessages: 1,
+          daySummaries: {
+            "23.06.2026": { summary: "Compact day summary.", keyDetails: [] },
+          },
+          weekSummaries: {
+            "22.06.2026": { summary: "COMPACT_WEEK_SUMMARY", keyDetails: [] },
+          },
+        },
+        chatId: "conversation-scene-summary-regression",
+        chats: {
+          async patchMetadata() {
+            throw new Error("Existing day and week summaries should not require a metadata patch");
+          },
+        },
+        chars: {
+          async getById() {
+            return null;
+          },
+        },
+        characterIds: ["char-echo"],
+        allCharacterIds: ["char-echo"],
+        convoCharInfo: [{ name: "Echo" }],
+        convoCharNames: ["Echo"],
+        personaName: "User",
+        nowInstant: new Date("2026-07-15T18:00:00.000Z"),
+        promptTimeZone: "UTC",
+        wrapFormat: "xml",
+        connection: { provider: "openai", apiKey: "", model: "regression-model" },
+        connectionId: "regression-connection",
+        baseUrl: "https://example.invalid/v1",
+      });
+      const promptText = prepared.finalMessages.map((message) => message.content).join("\n");
+
+      assert.match(promptText, /COMPACT_WEEK_SUMMARY/u);
+      assert.equal(promptText.includes(oldSceneSummary), false, promptText);
+      assert.match(promptText, /An older conversation turn\./u);
+      assert.match(promptText, new RegExp(currentSceneSummary, "u"));
+      assert.match(promptText, new RegExp(authoredSystemInstruction, "u"));
     },
   },
   {


### PR DESCRIPTION
## Linked issue

Closes #3641

## Why this change

- Concluded Conversation-mode scene summaries are stored as timestamped narrator messages, but prompt mapping represents narrator history as system-role messages. Conversation history therefore kept every old scene summary verbatim instead of replacing it with its existing day/week summary, allowing the prompt to grow indefinitely.
- The recent-message tail also reinserted summarized narrator blocks after compaction.

## What changed

- Treat timestamped narrator history from past conversation days as summarizable history while preserving current-day narrator context and genuine system instructions verbatim.
- Keep summarized narrator/system history out of the recent-message tail, while continuing to fill the configured tail with real user and character turns.
- Add a regression covering weekly compaction, recent-tail behavior, current-day scene context, and authored system instructions.
- Document the fix in the v2.3.0 changelog.

## Validation

- [ ] `pnpm check` passes locally
- [ ] `pnpm regression:prompt` passes locally
- [ ] `pnpm version:check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed `CONTRIBUTING.md`

### Manual verification notes

- Manual browser verification remains for the maintainer. The deterministic regression reconstructs the assembled-prompt failure from #3641 and verifies that an old scene summary is removed while its compact week summary, a real conversation tail turn, the current-day scene summary, and an authored system instruction remain.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Version/release files updated (only if this PR includes a version bump)

## UI evidence (if applicable)

Not applicable; this changes server-side Conversation prompt assembly.
