### PR TITLE
Prevent capability package downgrades

### DIFF
--- a/packages/client/src/components/agents/AgentCatalogView.tsx
+++ b/packages/client/src/components/agents/AgentCatalogView.tsx
@@ -13,7 +13,7 @@ import {
   Trash2,
   WifiOff,
 } from "lucide-react";
-import type { CapabilityCatalogPackage } from "@marinara-engine/shared";
+import { compareCapabilityPackageVersions, type CapabilityCatalogPackage } from "@marinara-engine/shared";
 import { toast } from "sonner";
 import {
   useCapabilityCatalog,
@@ -105,6 +105,10 @@ export function AgentCatalogView() {
   const packageActionPending = install.isPending || uninstall.isPending || bulkActionPending;
   const selected =
     (catalog.data?.packages ?? []).find((item) => item.manifest.id === selectedId) ?? packages[0] ?? null;
+  const selectedInstalled = selected ? installedById.get(selected.manifest.id) : undefined;
+  const selectedVersionComparison = selectedInstalled
+    ? compareCapabilityPackageVersions(selected.manifest.version, selectedInstalled.version)
+    : 0;
 
   useEffect(() => {
     if (!selectedId && packages[0]) setSelectedId(packages[0].manifest.id);
@@ -485,7 +489,15 @@ export function AgentCatalogView() {
                 <span className="flex items-center gap-1.5">
                   <ShieldCheck size="0.8rem" /> Official verified package
                 </span>
-                <span>Agent v{selected.manifest.version}</span>
+                {selectedInstalled ? (
+                  <>
+                    <span>Installed v{selectedInstalled.version}</span>
+                    {selectedVersionComparison > 0 && <span>Catalog v{selected.manifest.version} available</span>}
+                    {selectedVersionComparison < 0 && <span>Catalog v{selected.manifest.version} (older)</span>}
+                  </>
+                ) : (
+                  <span>Agent v{selected.manifest.version}</span>
+                )}
                 <span>Marinara Engine v{selected.manifest.engine.min}+</span>
               </div>
 
@@ -528,7 +540,7 @@ export function AgentCatalogView() {
                         )}
                         Uninstall
                       </button>
-                      {installedById.get(selected.manifest.id)?.version !== selected.manifest.version && (
+                      {selectedVersionComparison > 0 && (
                         <button
                           type="button"
                           className="mari-chrome-control mari-chrome-control--primary px-4 py-2.5 max-sm:flex-1"

--- a/packages/server/src/services/capability-packages/package-manager.service.ts
+++ b/packages/server/src/services/capability-packages/package-manager.service.ts
@@ -7,6 +7,7 @@ import {
   APP_VERSION,
   capabilityCatalogSchema,
   capabilityPackageManifestSchema,
+  compareCapabilityPackageVersions,
   isInstalledCapabilityReady,
   installedCapabilityRegistrySchema,
   packagedAgentDefinitionsSchema,
@@ -56,22 +57,16 @@ function inside(root: string, candidate: string): string {
   return target;
 }
 
-function versionParts(value: string): number[] {
-  return value.split("-")[0]!.split(".").map((part) => Number.parseInt(part, 10) || 0);
-}
-
-function compareVersions(left: string, right: string): number {
-  const a = versionParts(left);
-  const b = versionParts(right);
-  for (let i = 0; i < Math.max(a.length, b.length); i += 1) {
-    const delta = (a[i] ?? 0) - (b[i] ?? 0);
-    if (delta) return delta;
-  }
-  return 0;
-}
-
 function runtimeBlockReason(installed: InstalledCapabilityPackage): string | null {
   return KNOWN_INCOMPATIBLE_RUNTIMES.get(`${installed.id}@${installed.version}`) ?? null;
+}
+
+function assertNotDowngrade(current: InstalledCapabilityPackage | undefined, nextVersion: string) {
+  if (current && compareCapabilityPackageVersions(nextVersion, current.version) < 0) {
+    throw new Error(
+      `Installed ${current.id} ${current.version} is newer than catalog version ${nextVersion}; refusing to downgrade`,
+    );
+  }
 }
 
 async function readRegistry() {
@@ -277,7 +272,12 @@ export const capabilityPackageManager = {
     const entry = catalog.packages.find((candidate) => candidate.manifest.id === packageId);
     if (!entry) throw new Error("Package is not present in the official catalog");
     const { manifest, artifact } = entry;
-    if (compareVersions(APP_VERSION, manifest.engine.min) < 0 || compareVersions(APP_VERSION, manifest.engine.maxExclusive) >= 0) {
+    const initiallyInstalled = (await readRegistry()).packages.find((item) => item.id === manifest.id);
+    assertNotDowngrade(initiallyInstalled, manifest.version);
+    if (
+      compareCapabilityPackageVersions(APP_VERSION, manifest.engine.min) < 0 ||
+      compareCapabilityPackageVersions(APP_VERSION, manifest.engine.maxExclusive) >= 0
+    ) {
       throw new Error(`Package requires Marinara Engine ${manifest.engine.min} to below ${manifest.engine.maxExclusive}`);
     }
     const archive = await fetchBytes(artifact.url, Math.min(artifact.bytes + 1, MAX_ARTIFACT_BYTES));
@@ -340,6 +340,7 @@ export const capabilityPackageManager = {
       await rename(temporary, destination);
       const registry = await readRegistry();
       const previous = registry.packages.find((item) => item.id === manifest.id);
+      assertNotDowngrade(previous, manifest.version);
       const installed: InstalledCapabilityPackage = {
         id: manifest.id,
         version: manifest.version,

--- a/packages/shared/src/schemas/capability-package.schema.ts
+++ b/packages/shared/src/schemas/capability-package.schema.ts
@@ -137,6 +137,38 @@ export type CapabilityCatalog = z.infer<typeof capabilityCatalogSchema>;
 export type InstalledCapabilityPackage = z.infer<typeof installedCapabilityPackageSchema>;
 export type PackagedAgentDefinition = z.infer<typeof packagedAgentDefinitionSchema>;
 
+function parseCapabilityPackageVersion(value: string) {
+  const prereleaseSeparator = value.indexOf("-");
+  const core = prereleaseSeparator >= 0 ? value.slice(0, prereleaseSeparator) : value;
+  const prerelease = prereleaseSeparator >= 0 ? value.slice(prereleaseSeparator + 1).split(".") : [];
+  return { core: core.split(".").map((part) => Number.parseInt(part, 10)), prerelease };
+}
+
+export function compareCapabilityPackageVersions(left: string, right: string): number {
+  const a = parseCapabilityPackageVersion(left);
+  const b = parseCapabilityPackageVersion(right);
+  for (let index = 0; index < Math.max(a.core.length, b.core.length); index += 1) {
+    const difference = (a.core[index] ?? 0) - (b.core[index] ?? 0);
+    if (difference !== 0) return difference > 0 ? 1 : -1;
+  }
+  if (a.prerelease.length === 0 || b.prerelease.length === 0) {
+    if (a.prerelease.length === b.prerelease.length) return 0;
+    return a.prerelease.length === 0 ? 1 : -1;
+  }
+  for (let index = 0; index < Math.max(a.prerelease.length, b.prerelease.length); index += 1) {
+    const leftPart = a.prerelease[index];
+    const rightPart = b.prerelease[index];
+    if (leftPart === undefined || rightPart === undefined) return leftPart === undefined ? -1 : 1;
+    if (leftPart === rightPart) continue;
+    const leftNumeric = /^\d+$/u.test(leftPart);
+    const rightNumeric = /^\d+$/u.test(rightPart);
+    if (leftNumeric && rightNumeric) return Number(leftPart) > Number(rightPart) ? 1 : -1;
+    if (leftNumeric !== rightNumeric) return leftNumeric ? -1 : 1;
+    return leftPart > rightPart ? 1 : -1;
+  }
+  return 0;
+}
+
 export function isInstalledCapabilityReady(installed: InstalledCapabilityPackage): boolean {
   if (installed.status !== "active") return false;
   return !installed.manifest.entrypoints.server || installed.readiness === "ready";

--- a/scripts/regressions/capability-package-lifecycle.regression.ts
+++ b/scripts/regressions/capability-package-lifecycle.regression.ts
@@ -59,6 +59,15 @@ function seedWhisperModels() {
 }
 
 try {
+  const { compareCapabilityPackageVersions } = await import(
+    "../../packages/shared/src/schemas/capability-package.schema.js"
+  );
+  assert.equal(compareCapabilityPackageVersions("1.0.1", "1.0.0"), 1);
+  assert.equal(compareCapabilityPackageVersions("1.0.0", "1.0.1"), -1);
+  assert.equal(compareCapabilityPackageVersions("1.0.1", "1.0.1"), 0);
+  assert.equal(compareCapabilityPackageVersions("1.0.1", "1.0.1-beta.2"), 1);
+  assert.equal(compareCapabilityPackageVersions("1.0.1-beta.10", "1.0.1-beta.2"), 1);
+
   writeRegistry([installedPackage("conversation-calls", ["agent", "conversation-calls"])]);
   seedWhisperModels();
 


### PR DESCRIPTION
## Linked issue

Closes #3648

## Why this change

The Agent Catalog treated every installed/catalog version mismatch as an available update. A locally installed Hierarchical Maps 1.0.1 therefore appeared as `Agent v1.0.0` with an Update button while the published catalog was still older. With privileged access, that action could select the 1.0.0 artifact and downgrade the working package.

## What changed

- Added shared capability-package version ordering, including prerelease precedence.
- Made the installed version the primary detail label for installed packages.
- Labeled a differing catalog version as available or older based on direction.
- Showed Update only when the catalog version is newer than the installed version.
- Rejected downgrade attempts in the server package manager before download and again before registry replacement.
- Added focused version-ordering regression coverage.

## Validation

Automated evidence:

- `pnpm regression:issues` passed, including capability lifecycle and version-ordering cases.
- `pnpm check` passed, including Impeccable context, TypeScript, ESLint, server build, client build, and PWA generation.
- Live post-build restart kept Hierarchical Maps 1.0.1 active and ready with overall capability health `ok`.
- The rebuilt Agent Catalog chunk containing the installed/catalog labels returned HTTP 200.
- The production server build contains the downgrade refusal path.

- [ ] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed `CONTRIBUTING.md`

### Manual verification notes

- Refresh the browser and verify Hierarchical Maps reads `Installed v1.0.1` and `Catalog v1.0.0 (older)` with no Update button.
- Verify an actually newer catalog package still shows Update.
- Verify equal installed/catalog versions show one installed version label and no Update button.
- Verify remote privileged package management still behaves normally for genuine upgrades.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Version/release files updated (only if this PR includes a version bump)

## UI evidence (if applicable)

Small state-copy correction only. No layout, theme, or responsive structure changes.
