### PR TITLE
Preserve Noodle refresh model attempts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 
 ### Fixed
 
+- Logged every Noodle timeline refresh model response in debug mode, including correction attempts, and persisted each raw attempt with its full rejection reason so malformed first responses remain auditable after a successful retry ([#3655](https://github.com/Pasta-Devs/Marinara-Engine/issues/3655)).
 - Fixed Conversation **About Me → AI Write** sending literal card macros such as `{{user}}` to the model. The one-shot draft now resolves selected card fields, lorebook entries, recent chat context, and extra direction with the active Conversation persona and character before provider submission ([#3646](https://github.com/Pasta-Devs/Marinara-Engine/issues/3646)).
 - Unified the online Card Browser with the Character, Persona, and Agent library shell: it now opens as **Cards Library**, introduces **Browse character cards online**, keeps the familiar back navigation and chroma-aware library background, and renders search failures in the selected chroma text color instead of legacy pink.
 - Changed **Uninvite everybody** and its confirmation action from destructive red to Noodle blue, and made the disabled custom mouse-pointer preference persist immediately so Firefox, PWAs, and quickly closed sessions do not silently turn it back on.

--- a/packages/server/src/db/schema/noodle.ts
+++ b/packages/server/src/db/schema/noodle.ts
@@ -72,6 +72,7 @@ export const noodleRefreshRuns = fileTable("noodle_refresh_runs", {
   prompt: text("prompt").notNull().default(""),
   result: text("result"),
   error: text("error"),
+  attempts: text("attempts").notNull().default("[]"),
   createdAt: text("created_at").notNull(),
   updatedAt: text("updated_at").notNull(),
 });

--- a/packages/server/src/routes/noodle.routes.ts
+++ b/packages/server/src/routes/noodle.routes.ts
@@ -30,6 +30,7 @@ import {
   type NoodleInteraction,
   type NoodleInteractionType,
   type NoodlePost,
+  type NoodleRefreshAttemptKind,
   type NoodleSettings,
 } from "@marinara-engine/shared";
 import type { ChatMessage } from "../services/llm/base-provider.js";
@@ -1879,6 +1880,7 @@ export async function noodleRoutes(app: FastifyInstance) {
         responseFormat: noodleResponseFormat(conn.model, "timeline"),
       } as const;
       let requestMessages: ChatMessage[] = messages;
+      let firstAttemptKind: NoodleRefreshAttemptKind = "initial";
       let result: Awaited<ReturnType<typeof provider.chatComplete>>;
       try {
         result = await provider.chatComplete(messages, completionOptions);
@@ -1894,9 +1896,17 @@ export async function noodleRoutes(app: FastifyInstance) {
           textOnlyPromptForLog,
         );
         requestMessages = textOnlyMessages;
+        firstAttemptKind = "text_only_fallback";
         result = await provider.chatComplete(textOnlyMessages, completionOptions);
       }
       let content = result.content ?? "";
+      logDebugOverride(
+        debugMode,
+        "[debug/noodle] Raw model response (%s attempt %d):\n%s",
+        firstAttemptKind,
+        1,
+        content,
+      );
       let parsedGenerated: ReturnType<typeof parseNoodleGeneratedRefresh> | null = null;
       let retryReason: string | null = null;
       const allowedActorHandles = new Set(selectedParticipants.map((account) => normalizeNoodleHandle(account.handle)));
@@ -1905,8 +1915,15 @@ export async function noodleRoutes(app: FastifyInstance) {
         parsedGenerated = parseNoodleGeneratedRefresh(parseGameJsonish(content));
         retryReason = validateNoodleGeneratedRefresh(parsedGenerated.refresh, allowedActorHandles, knownHandles);
       } catch (error) {
-        retryReason = `the response was not valid timeline JSON (${getErrorMessage(error).slice(0, 180)})`;
+        retryReason = `the response was not valid timeline JSON (${getErrorMessage(error)})`;
       }
+      await noodle.recordRefreshAttempt(runId, {
+        sequence: 1,
+        kind: firstAttemptKind,
+        response: content,
+        rejectionReason: retryReason,
+        createdAt: new Date().toISOString(),
+      });
 
       if (retryReason) {
         const allowedHandles = selectedParticipants.map((account) => `@${account.handle}`);
@@ -1921,12 +1938,32 @@ export async function noodleRoutes(app: FastifyInstance) {
         ].join("\n");
         result = await provider.chatComplete([...requestMessages, { role: "user", content: correction }], completionOptions);
         content = result.content ?? "";
-        parsedGenerated = parseNoodleGeneratedRefresh(parseGameJsonish(content));
-        const correctedRetryReason = validateNoodleGeneratedRefresh(
-          parsedGenerated.refresh,
-          allowedActorHandles,
-          knownHandles,
+        logDebugOverride(
+          debugMode,
+          "[debug/noodle] Raw model response (%s attempt %d):\n%s",
+          "correction",
+          2,
+          content,
         );
+        parsedGenerated = null;
+        let correctedRetryReason: string | null = null;
+        try {
+          parsedGenerated = parseNoodleGeneratedRefresh(parseGameJsonish(content));
+          correctedRetryReason = validateNoodleGeneratedRefresh(
+            parsedGenerated.refresh,
+            allowedActorHandles,
+            knownHandles,
+          );
+        } catch (error) {
+          correctedRetryReason = `the response was not valid timeline JSON (${getErrorMessage(error)})`;
+        }
+        await noodle.recordRefreshAttempt(runId, {
+          sequence: 2,
+          kind: "correction",
+          response: content,
+          rejectionReason: correctedRetryReason,
+          createdAt: new Date().toISOString(),
+        });
         if (correctedRetryReason) {
           throw new Error(`Noodle timeline correction could not be used because ${correctedRetryReason}.`);
         }

--- a/packages/server/src/services/storage/noodle.storage.ts
+++ b/packages/server/src/services/storage/noodle.storage.ts
@@ -21,6 +21,7 @@ import {
   type NoodlePost,
   type NoodlePostUpdateInput,
   type NoodlePostSource,
+  type NoodleRefreshAttempt,
   type NoodleRefreshRun,
   type NoodleRemoveInteractionInput,
   type NoodleSettings,
@@ -66,6 +67,43 @@ function parseRecord(value: unknown): Record<string, unknown> {
     }
   }
   return typeof value === "object" && !Array.isArray(value) ? (value as Record<string, unknown>) : {};
+}
+
+function parseRefreshAttempts(value: unknown): NoodleRefreshAttempt[] {
+  let parsed = value;
+  if (typeof parsed === "string") {
+    try {
+      parsed = JSON.parse(parsed);
+    } catch {
+      return [];
+    }
+  }
+  if (!Array.isArray(parsed)) return [];
+  return parsed.flatMap((entry): NoodleRefreshAttempt[] => {
+    if (!entry || typeof entry !== "object" || Array.isArray(entry)) return [];
+    const candidate = entry as Record<string, unknown>;
+    const kind = candidate.kind;
+    if (kind !== "initial" && kind !== "text_only_fallback" && kind !== "correction") return [];
+    if (
+      typeof candidate.sequence !== "number" ||
+      !Number.isInteger(candidate.sequence) ||
+      candidate.sequence < 1 ||
+      typeof candidate.response !== "string" ||
+      (candidate.rejectionReason !== null && typeof candidate.rejectionReason !== "string") ||
+      typeof candidate.createdAt !== "string"
+    ) {
+      return [];
+    }
+    return [
+      {
+        sequence: candidate.sequence,
+        kind,
+        response: candidate.response,
+        rejectionReason: candidate.rejectionReason,
+        createdAt: candidate.createdAt,
+      },
+    ];
+  });
 }
 
 export function parseNoodleAvatarCrop(value: unknown): NoodleAvatarCrop | null {
@@ -283,6 +321,7 @@ function mapRefreshRun(row: RefreshRunRow): NoodleRefreshRun {
     prompt: row.prompt ?? "",
     result: row.result ?? null,
     error: row.error ?? null,
+    attempts: parseRefreshAttempts(row.attempts),
     createdAt: row.createdAt,
     updatedAt: row.updatedAt,
   };
@@ -851,6 +890,7 @@ export function createNoodleStorage(db: DB) {
         prompt: input.prompt,
         result: null,
         error: null,
+        attempts: "[]",
         createdAt: timestamp,
         updatedAt: timestamp,
       });
@@ -868,6 +908,21 @@ export function createNoodleStorage(db: DB) {
             .limit(limit)
         : await baseQuery.orderBy(desc(noodleRefreshRuns.createdAt)).limit(limit);
       return rows.map(mapRefreshRun);
+    },
+
+    async recordRefreshAttempt(id: string, attempt: NoodleRefreshAttempt): Promise<NoodleRefreshRun | null> {
+      const rows = await db.select().from(noodleRefreshRuns).where(eq(noodleRefreshRuns.id, id));
+      const current = rows[0];
+      if (!current) return null;
+      await db
+        .update(noodleRefreshRuns)
+        .set({
+          attempts: JSON.stringify([...parseRefreshAttempts(current.attempts), attempt]),
+          updatedAt: now(),
+        })
+        .where(eq(noodleRefreshRuns.id, id));
+      const updatedRows = await db.select().from(noodleRefreshRuns).where(eq(noodleRefreshRuns.id, id));
+      return updatedRows[0] ? mapRefreshRun(updatedRows[0]) : null;
     },
 
     async finishRefreshRun(

--- a/packages/shared/src/types/noodle.ts
+++ b/packages/shared/src/types/noodle.ts
@@ -115,6 +115,16 @@ export interface NoodleDigestEntry {
   createdAt: string;
 }
 
+export type NoodleRefreshAttemptKind = "initial" | "text_only_fallback" | "correction";
+
+export interface NoodleRefreshAttempt {
+  sequence: number;
+  kind: NoodleRefreshAttemptKind;
+  response: string;
+  rejectionReason: string | null;
+  createdAt: string;
+}
+
 export interface NoodleRefreshRun {
   id: string;
   status: "running" | "completed" | "failed";
@@ -122,6 +132,7 @@ export interface NoodleRefreshRun {
   prompt: string;
   result: string | null;
   error: string | null;
+  attempts: NoodleRefreshAttempt[];
   createdAt: string;
   updatedAt: string;
 }

--- a/scripts/regressions/noodle-settings.regression.ts
+++ b/scripts/regressions/noodle-settings.regression.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { mkdtempSync, rmSync } from "node:fs";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { DB } from "../../packages/server/src/db/connection.js";
@@ -90,6 +90,11 @@ try {
     createdAt: "2026-07-15T19:00:01.000Z",
   });
   await firstNoodle.finishRefreshRun(refreshRun.id, { status: "completed", result: correctedResponse });
+  const legacyRefreshRun = await firstNoodle.createRefreshRun({
+    activeAccountIds: ["legacy"],
+    prompt: "Legacy refresh prompt.",
+  });
+  await firstNoodle.finishRefreshRun(legacyRefreshRun.id, { status: "completed", result: "legacy result" });
   const characterAccount = await firstNoodle.upsertAccountFromProfile({
     kind: "character",
     entityId: "renamed-character",
@@ -119,13 +124,21 @@ try {
   assert.deepEqual(renamedCharacterAccount.settings, { profileGenerated: true, location: "Snezhnaya" });
   await firstDb._fileStore.close();
 
+  const refreshRunsPath = join(storageDir, "tables", "noodle_refresh_runs.json");
+  const persistedRefreshRuns = JSON.parse(readFileSync(refreshRunsPath, "utf8")) as Array<Record<string, unknown>>;
+  const legacyPersistedRun = persistedRefreshRuns.find((entry) => entry.id === legacyRefreshRun.id);
+  assert.ok(legacyPersistedRun);
+  delete legacyPersistedRun.attempts;
+  writeFileSync(refreshRunsPath, JSON.stringify(persistedRefreshRuns));
+
   const reopenedDb = await createFileNativeDB();
   const reopenedNoodle = createNoodleStorage(reopenedDb as unknown as DB);
   const reopenedSettings = await reopenedNoodle.getSettings();
   assert.equal(reopenedSettings.maxImagesPerRefresh, 9);
   assert.equal(reopenedSettings.allowRandomUsers, true);
   assert.equal(reopenedSettings.maxGeneratedPostsPerRefresh, 11);
-  const [reopenedRun] = await reopenedNoodle.listRefreshRuns({ status: "completed", limit: 1 });
+  const reopenedRuns = await reopenedNoodle.listRefreshRuns({ status: "completed", limit: 2 });
+  const reopenedRun = reopenedRuns.find((entry) => entry.id === refreshRun.id);
   assert.equal(reopenedRun?.result, correctedResponse);
   assert.deepEqual(reopenedRun?.attempts, [
     {
@@ -143,6 +156,10 @@ try {
       createdAt: "2026-07-15T19:00:01.000Z",
     },
   ]);
+  assert.deepEqual(
+    reopenedRuns.find((entry) => entry.id === legacyRefreshRun.id)?.attempts,
+    [],
+  );
   await reopenedDb._fileStore.close();
 } finally {
   rmSync(storageDir, { recursive: true, force: true });

--- a/scripts/regressions/noodle-settings.regression.ts
+++ b/scripts/regressions/noodle-settings.regression.ts
@@ -67,6 +67,29 @@ try {
   assert.equal(updated.maxImagesPerRefresh, 9);
   assert.equal(updated.allowRandomUsers, true);
   assert.equal(updated.maxGeneratedPostsPerRefresh, 11);
+  const refreshRun = await firstNoodle.createRefreshRun({
+    activeAccountIds: ["alpha"],
+    prompt: "Generate a Noodle timeline.",
+  });
+  assert.deepEqual(refreshRun.attempts, []);
+  const rejectedResponse = "{not valid timeline JSON";
+  const rejectionReason = "the response was not valid timeline JSON (full parser detail)";
+  await firstNoodle.recordRefreshAttempt(refreshRun.id, {
+    sequence: 1,
+    kind: "initial",
+    response: rejectedResponse,
+    rejectionReason,
+    createdAt: "2026-07-15T19:00:00.000Z",
+  });
+  const correctedResponse = '{"posts":[{"authorHandle":"alpha","content":"Valid"}]}';
+  await firstNoodle.recordRefreshAttempt(refreshRun.id, {
+    sequence: 2,
+    kind: "correction",
+    response: correctedResponse,
+    rejectionReason: null,
+    createdAt: "2026-07-15T19:00:01.000Z",
+  });
+  await firstNoodle.finishRefreshRun(refreshRun.id, { status: "completed", result: correctedResponse });
   const characterAccount = await firstNoodle.upsertAccountFromProfile({
     kind: "character",
     entityId: "renamed-character",
@@ -97,10 +120,29 @@ try {
   await firstDb._fileStore.close();
 
   const reopenedDb = await createFileNativeDB();
-  const reopenedSettings = await createNoodleStorage(reopenedDb as unknown as DB).getSettings();
+  const reopenedNoodle = createNoodleStorage(reopenedDb as unknown as DB);
+  const reopenedSettings = await reopenedNoodle.getSettings();
   assert.equal(reopenedSettings.maxImagesPerRefresh, 9);
   assert.equal(reopenedSettings.allowRandomUsers, true);
   assert.equal(reopenedSettings.maxGeneratedPostsPerRefresh, 11);
+  const [reopenedRun] = await reopenedNoodle.listRefreshRuns({ status: "completed", limit: 1 });
+  assert.equal(reopenedRun?.result, correctedResponse);
+  assert.deepEqual(reopenedRun?.attempts, [
+    {
+      sequence: 1,
+      kind: "initial",
+      response: rejectedResponse,
+      rejectionReason,
+      createdAt: "2026-07-15T19:00:00.000Z",
+    },
+    {
+      sequence: 2,
+      kind: "correction",
+      response: correctedResponse,
+      rejectionReason: null,
+      createdAt: "2026-07-15T19:00:01.000Z",
+    },
+  ]);
   await reopenedDb._fileStore.close();
 } finally {
   rmSync(storageDir, { recursive: true, force: true });


### PR DESCRIPTION
## Linked issue

Closes #3655

## Why this change

Noodle refresh debug mode logged the outgoing prompt but not the model reply. When the first response failed validation and a correction succeeded, the rejected response and full validation reason disappeared, leaving no durable evidence for diagnosing malformed generations.

## What changed

- Log each successful Noodle timeline model response in debug mode with its attempt kind and sequence.
- Persist initial, text-only fallback, and correction responses with their full rejection reason on the refresh run.
- Keep the existing final `result` field for backward compatibility.
- Default older file-native refresh rows to an empty attempt list without a migration.
- Add persistence/restart regression coverage and a v2.3.0 changelog entry.

## Validation

- [ ] Manually verify an initial successful refresh logs one raw response in debug mode.
- [ ] Manually force a rejected first response and verify both raw attempts appear in debug output and `mari db get noodle_refresh_runs <id>`.

Automated evidence:

- `pnpm regression:noodle`
- `git diff --check`

## Risk

This changes persistent Noodle refresh-run data. Existing rows normalize `attempts` to `[]`; the existing `prompt`, `result`, and `error` fields remain unchanged.
