### PR TITLE
fix(security): handle missing content-type and gzip in safeFetch JSON…

### DIFF
--- a/packages/server/src/services/bot-browser/fetch-json.ts
+++ b/packages/server/src/services/bot-browser/fetch-json.ts
@@ -39,6 +39,7 @@ export async function fetchBotBrowserJson(url: string | URL, options: BotBrowser
       signal: controller.signal,
       policy: { allowedProtocols: ["https:"], maxRedirects: 0 },
       allowedContentTypes: JSON_CONTENT_TYPES,
+      decodeCompressedResponse: true,
       maxResponseBytes,
     });
     if (!response.ok) {

--- a/packages/server/src/services/capability-packages/package-manager.service.ts
+++ b/packages/server/src/services/capability-packages/package-manager.service.ts
@@ -112,6 +112,7 @@ export const capabilityPackageManager = {
       policy: { allowedProtocols: ["https:"] },
       maxResponseBytes: 2 * 1024 * 1024,
       allowedContentTypes: ["application/json", "text/plain"],
+      decodeCompressedResponse: true,
     });
     if (!response.ok) throw new Error(`Catalog request failed with HTTP ${response.status}`);
     const catalog = capabilityCatalogSchema.parse(await response.json());

--- a/packages/server/src/utils/security.ts
+++ b/packages/server/src/utils/security.ts
@@ -609,7 +609,7 @@ export async function safeFetch(url: string | URL, options: SafeFetchOptions = {
 
     if (allowedContentTypes?.length) {
       const contentType = response.headers.get("content-type")?.toLowerCase() ?? "";
-      if (!contentType || !allowedContentTypes.some((allowed) => contentType.includes(allowed.toLowerCase()))) {
+      if (contentType && !allowedContentTypes.some((allowed) => contentType.includes(allowed.toLowerCase()))) {
         await internalDispatcher?.close().catch(() => undefined);
         await response.body?.cancel().catch(() => undefined);
         throw new Error(`Outbound response content type is not allowed: ${contentType}`);


### PR DESCRIPTION
## Linked issue

Closes #3660

## Why this change

- `safeFetch`'s `allowedContentTypes` guard used `!contentType ||` which rejects responses that omit the `Content-Type` header entirely, even when the body is valid content. Card browser API calls (`fetchBotBrowserJson`) and the capability package catalog both hit this, logging "Outbound response content type is not allowed: " on startup and during browsing.
- `readCappedResponse` reads the raw response byte stream via `response.body.getReader()`, bypassing undici's built-in `Content-Encoding` decompression. GitHub raw content (capability catalog) and some card browser APIs return gzip-compressed responses, causing `response.json()` to throw a `SyntaxError` with raw gzip bytes.

## What changed

- `packages/server/src/utils/security.ts` — change `!contentType ||` to `contentType &&` in the `allowedContentTypes` guard so only explicitly wrong content types are rejected; missing headers are allowed through
- `packages/server/src/services/bot-browser/fetch-json.ts` — add `decodeCompressedResponse: true` so gzip API responses are decompressed before parsing
- `packages/server/src/services/capability-packages/package-manager.service.ts` — add `decodeCompressedResponse: true` to the catalog fetch for the same reason

## Validation

- [x] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [x] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [x] Above manual verification completed (describe below)
- [x] Read and followed `CONTRIBUTING.md`

### Manual verification notes

- Verified card browser (ChubAI) loads character listings without "content type not allowed" errors in server log
- Verified capability package catalog loads on startup without SyntaxError gzip parse failure in server log

## Docs and release impact

- [x] No docs changes needed
- [ ] Updated docs as needed
- [ ] Version/release files updated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved retrieval of bot browser data and capability catalogs by supporting compressed server responses.
  * Fixed response validation so valid responses without a `Content-Type` header are no longer rejected unnecessarily.
  * Improved compatibility with a wider range of servers and response formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->