### PR TITLE
chore: finalize v2.3.1 release announcement

### DIFF
--- a/e2e/core-flows.e2e.ts
+++ b/e2e/core-flows.e2e.ts
@@ -81,12 +81,8 @@ test("What's New opens once for each Marinara Engine version", async ({ page }) 
   const announcement = page.getByRole("dialog", { name: "What's New?" });
   await expect(announcement).toBeVisible();
   await expect(announcement.getByText(`Version ${APP_VERSION}`)).toBeVisible();
-  await expect(announcement.getByRole("heading", { name: "Marinara Engine has been updated." })).toBeVisible();
-  await expect(
-    announcement.getByText(
-      "Marinara Engine has been updated! Read the release notes for everything included in this version.",
-    ),
-  ).toBeVisible();
+  await expect(announcement.getByRole("heading", { name: "A quick patch with bug fixes!" })).toBeVisible();
+  await expect(announcement.getByText("Marinara Engine has been updated.", { exact: true })).toHaveCount(0);
   await expect(announcement.getByText("Hierarchical Maps")).toHaveCount(0);
   await expect(announcement.getByText("Tactical Combat Mode in Games")).toHaveCount(0);
   await expect(announcement.getByRole("link", { name: "View release" })).toHaveAttribute(

--- a/packages/client/src/components/modals/WhatsNewModal.tsx
+++ b/packages/client/src/components/modals/WhatsNewModal.tsx
@@ -19,13 +19,17 @@ type ReleaseHighlight = {
 
 type ReleaseAnnouncement = {
   headline: string;
-  intro: string;
+  intro?: string;
   highlights: ReleaseHighlight[];
 };
 
 // Add each release here before its version ships. Versions without a tailored
 // entry still get a one-time update notice and a link to their full release.
 const RELEASE_ANNOUNCEMENTS: Record<string, ReleaseAnnouncement> = {
+  "2.3.1": {
+    headline: "A quick patch with bug fixes!",
+    highlights: [],
+  },
   "2.3.0": {
     headline: "Choose the Agents you want.",
     intro:
@@ -118,9 +122,11 @@ export function WhatsNewModal({ presentationAllowed }: { presentationAllowed: bo
             <h3 className="mt-3 text-balance text-2xl font-bold tracking-tight text-[var(--marinara-chat-chrome-panel-title)] sm:text-3xl">
               {announcement.headline}
             </h3>
-            <p className="mt-2 text-sm leading-6 text-[var(--marinara-chat-chrome-panel-muted)]">
-              {announcement.intro}
-            </p>
+            {announcement.intro ? (
+              <p className="mt-2 text-sm leading-6 text-[var(--marinara-chat-chrome-panel-muted)]">
+                {announcement.intro}
+              </p>
+            ) : null}
           </header>
 
           {announcement.highlights.length > 0 ? (


### PR DESCRIPTION
## Linked issue

Maintainer-directed v2.3.1 release preparation; no separate issue.

## Why this change

v2.3.1 needs a deliberately concise in-app announcement before the release-ready staging tree is promoted to main. Without a tailored entry, users would see the generic fallback instead of the approved patch message.

## What changed

- Add a v2.3.1 What's New announcement containing exactly: "A quick patch with bug fixes!"
- Omit the optional introduction and all feature highlights for this release.
- Update the desktop and mobile browser regression to assert the exact v2.3.1 copy and reject fallback/older-release content.

## Validation

- [ ] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed `CONTRIBUTING.md`

Commands completed locally:

- `pnpm install --frozen-lockfile`
- `pnpm check`
- `pnpm test`
- `pnpm regression` (60 applicable Playwright rows passed; 38 project/viewport rows skipped by design)
- `pnpm version:check`
- `pnpm credits:check`
- `pnpm guard:installer-artifacts`
- `pnpm release:notes -- 2.3.1`
- `git diff --check`

### Manual verification notes

The in-app browser surface was unavailable in this session. The production app flow was exercised by Playwright on desktop and mobile Chromium: the modal opens once, shows the exact message and release link, records the seen version, closes, and stays closed after reload.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Version/release files updated (only if this PR includes a version bump)

The version, changelog, installer metadata, PWA manifest, platform update documentation, and release workflow changes are already present on `staging` from the v2.3.1 preparation PRs. This final PR changes only the approved in-app announcement.

## UI evidence (if applicable)

No screenshot attached because the in-app browser surface was unavailable; desktop and mobile Playwright coverage is documented above.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a “What’s New” announcement for version 2.3.1 featuring a bug-fix update.

* **Bug Fixes**
  * Updated the announcement dialog to hide empty introductory text.
  * Refined the dialog’s displayed messaging for the latest release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->