### PR TITLE
Show chat mode badges in Download Agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ An optional one-click catalog of 29 first-party agents and feature packages. Fre
 
 - **Writer Agents:** Prose Guardian, Continuity Checker, Narrative Director, Knowledge Retrieval, Knowledge Router, and Card Evolution Auditor.
 - **Tracker Agents:** World State, Expression Engine, Quest Tracker, Background, Character Tracker, Persona Stats, Custom Tracker, and Hierarchical Maps.
-- **Misc Agents:** Echo Chamber, Illustrator, Lorebook Keeper, Combat, Immersive HTML, Music DJ, Haptic Feedback, CYOA Choices, Conversation Calls, UNO, Chess, Poker, 8-Ball Pool, Tic-Tac-Toe, and Rock-Paper-Scissors.
+- **Misc Agents:** Echo Chamber, Illustrator, Lorebook Keeper, Combat, Immersive HTML, Music DJ, Haptic Feedback, CYOA Choices, Calls, UNO, Chess, Poker, 8-Ball Pool, Tic-Tac-Toe, and Rock-Paper-Scissors.
 
 See the [Downloadable Agents Reference](docs/agents/built-in-agents.md) for modes, behavior, and setup guidance for every package, or browse the [official Agent repository](https://github.com/Pasta-Devs/Marinara-Agents) directly.
 

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -159,7 +159,7 @@ To make them automatically, open **Chat Settings**, go to **Agents**, find the *
 
 Yes, in **Conversation** mode. Audio and video calls are a Conversation-only feature. To hear a character speak, first set up **Text to Speech** under the **Connections** panel.
 
-If you want to talk back with your microphone and the browser's own speech recognition is unreliable, first install **Conversation Calls** from **Agents > Download Agents**. Then open the **Connections** panel, expand the **Local Model** card, find **Local Speech Model**, pick **Whisper Tiny (Multilingual)** or **Whisper Base (Multilingual)**, and click **Download Whisper**. Uninstalling Conversation Calls also removes its Whisper downloads to reclaim disk space. For the full call setup, see [Conversation Calls](conversation/calls.md).
+If you want to talk back with your microphone and the browser's own speech recognition is unreliable, first install **Calls** from **Agents > Download Agents**. Then open the **Connections** panel, expand the **Local Model** card, find **Local Speech Model**, pick **Whisper Tiny (Multilingual)** or **Whisper Base (Multilingual)**, and click **Download Whisper**. Uninstalling Calls also removes its Whisper downloads to reclaim disk space. For the full call setup, see [Calls](conversation/calls.md).
 
 ## Can Marinara generate images?
 

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -200,7 +200,7 @@ If starting a game fails because the model returned broken JSON, Marinara opens 
 ## Voice, calls, and TTS
 
 - If characters do not speak during a call, Text to Speech is not set up. Open **Connections** > **Text to Speech**, enable it, choose a source, enter your key, pick a voice, and save. A character with no voice appears as text only.
-- If the microphone is not working, you may need the local speech model. Install **Conversation Calls** from **Agents > Download Agents**, then open **Connections** > **Local Model**, expand the card, find **Local Speech Model**, choose a Whisper model, and click **Download Whisper**. Firefox in particular needs this because it lacks browser speech recognition. Uninstalling Conversation Calls deletes its Whisper models to reclaim disk space.
+- If the microphone is not working, you may need the local speech model. Install **Calls** from **Agents > Download Agents**, then open **Connections** > **Local Model**, expand the card, find **Local Speech Model**, choose a Whisper model, and click **Download Whisper**. Firefox in particular needs this because it lacks browser speech recognition. Uninstalling Calls deletes its Whisper models to reclaim disk space.
 - On a Lite build, the message **Local Whisper is disabled in Lite mode** means that small build cannot run the local speech model. Use a full Marinara install instead.
 
 ### Music DJ Spotify login fails on a remote or network install

--- a/docs/agents/agents-overview.md
+++ b/docs/agents/agents-overview.md
@@ -61,7 +61,7 @@ This readout turns amber with a warning icon when the load gets heavy. The real 
 A fresh installation starts with no optional agents installed or active. Each chat mode shows only compatible packages you have installed.
 
 - **Roleplay**: install Roleplay agents from the catalog, then add them in Chat Settings. Hierarchical Maps appears there like any other supported agent.
-- **Conversation**: install Conversation Calls or individual table games from the catalog. Games appear in the games picker and register their slash commands; calls add their toolbar and Chat Settings controls.
+- **Conversation**: install Calls or individual table games from the catalog. Games appear in the games picker and register their slash commands; calls add their toolbar and Chat Settings controls.
 - **Game Mode**: installed Game-compatible agents can be selected during game creation or added later. Hierarchical Maps contributes its map workspace and world-map view only when it is active for that game.
 
 You can add or remove compatible agents at any time.

--- a/docs/agents/built-in-agents.md
+++ b/docs/agents/built-in-agents.md
@@ -206,13 +206,13 @@ Adds clickable "What will you do?" choice buttons after each reply, for a choose
 - **Where it works**: Roleplay.
 - **Key settings**: **Edit** to rewrite the choices and **Re-roll** to generate new ones.
 
-### Conversation Calls
+### Calls
 
 Adds live audio and video calls with Conversation characters, including user-started and incoming calls, call-only transcripts, text-to-speech, microphone input, and character video clips.
 
 - **Integration**: Conversation feature package; it adds toolbar, chat-surface, and Chat Settings controls instead of running as a normal generation-phase agent.
 - **Where it works**: Conversation.
-- **Key settings**: open **Chat Settings → Agents → Conversation Calls** to enable calls and choose speech, microphone, ringing, and video behavior. See [Conversation Audio and Video Calls](../conversation/calls.md). Installing or removing it requires a Marinara restart.
+- **Key settings**: open **Chat Settings → Agents → Calls** to enable calls and choose speech, microphone, ringing, and video behavior. See [Conversation Audio and Video Calls](../conversation/calls.md). Installing or removing it requires a Marinara restart.
 
 ### UNO
 

--- a/docs/connections/local-model.md
+++ b/docs/connections/local-model.md
@@ -158,9 +158,9 @@ Selecting it for a chat starts the local server on demand, even when both helper
 
 ## Local Speech Model for calls
 
-The **Local Speech Model** is an optional Conversation Calls download for offline microphone transcription. It powers Conversation calls when you choose to transcribe your voice on your own machine. It is a Whisper model, a speech-to-text model that turns your spoken words into text.
+The **Local Speech Model** is an optional Calls download for offline microphone transcription. It powers Conversation calls when you choose to transcribe your voice on your own machine. It is a Whisper model, a speech-to-text model that turns your spoken words into text.
 
-First install **Conversation Calls** from **Agents > Download Agents**. You can then manage Whisper from the **Local Model** card in Connections, under the **Local Speech Model** heading. The heading and download controls stay hidden when Conversation Calls is not installed.
+First install **Calls** from **Agents > Download Agents**. You can then manage Whisper from the **Local Model** card in Connections, under the **Local Speech Model** heading. The heading and download controls stay hidden when Calls is not installed.
 
 Two choices are offered:
 
@@ -174,7 +174,7 @@ To set it up:
 3. Click **Download Whisper**.
 4. When it reads **Ready**, it is set up.
 
-To remove only the selected model, click the trash button titled **Delete Local Whisper**. Uninstalling Conversation Calls removes all downloaded Whisper choices and their saved selection automatically to reclaim their disk space. If you reinstall Calls later, the Local Speech Model controls return and you can download Whisper again.
+To remove only the selected model, click the trash button titled **Delete Local Whisper**. Uninstalling Calls removes all downloaded Whisper choices and their saved selection automatically to reclaim their disk space. If you reinstall Calls later, the Local Speech Model controls return and you can download Whisper again.
 
 Your recorded audio never leaves your machine. Only the transcribed text is sent to your chosen chat connection. To use it in a call, set the call audio input mode to the Local Whisper option. See [Conversation Audio and Video Calls](../conversation/calls.md).
 

--- a/docs/conversation/calls.md
+++ b/docs/conversation/calls.md
@@ -4,7 +4,7 @@ This guide explains Conversation calls in Marinara Engine. You will learn how a 
 
 Calls exist only in Conversation Mode. Roleplay and Game chats do not have a call screen.
 
-Conversation Calls is an optional agent package. Install **Conversation Calls** from **Agents → Download Agents** before following the setup below, then restart Marinara when the catalog asks.
+Calls is an optional agent package. Install **Calls** from **Agents → Download Agents** before following the setup below, then restart Marinara when the catalog asks.
 
 ## What a call is
 
@@ -30,7 +30,7 @@ To run a working voice call, set up these pieces in order. You can skip the step
 3. **Audio/Video Calls** turned on for that chat (see the section "Turn calls on for a chat" below).
 4. **Call Audio Pipeline** turned on. This is required to start any call, even a call where you only type or only listen. It also enables microphone input.
 5. Text to Speech set up so characters can speak. Without it, every character joins as text only.
-6. Optional: Local Whisper downloaded from Connections after Conversation Calls is installed, if your browser cannot do reliable speech recognition (Firefox needs this).
+6. Optional: Local Whisper downloaded from Connections after Calls is installed, if your browser cannot do reliable speech recognition (Firefox needs this).
 7. Optional: a video connection and generated clips if you want **Character Video Presence**.
 8. Optional: an image connection set as the chat Selfie Connection if you want characters to send selfies in the call.
 
@@ -64,7 +64,7 @@ The camera and screen buttons appear only when **Camera and screen input** is on
 
 Local Whisper turns your speech into text on the machine running Marinara. Your microphone audio never leaves that machine for transcription. The resulting text is still sent to your Conversation model as part of the call.
 
-Local Whisper is owned by the Conversation Calls package and is the most reliable microphone path for browsers with weak speech support, including Firefox. After installing Conversation Calls, open **Connections**, open **Local Model**, expand the card, and find **Local Speech Model**. The section is hidden when Calls is not installed. For the general Local Model card, see [Local Model Setup](../connections/local-model.md).
+Local Whisper is owned by the Calls package and is the most reliable microphone path for browsers with weak speech support, including Firefox. After installing Calls, open **Connections**, open **Local Model**, expand the card, and find **Local Speech Model**. The section is hidden when Calls is not installed. For the general Local Model card, see [Local Model Setup](../connections/local-model.md).
 
 1. Choose a model. **Whisper Tiny (Multilingual)** is the default. It is about 180 MB to download and uses about 350 MB of memory while running. It is the best first choice for phones and older machines.
 2. Or choose **Whisper Base (Multilingual)** for better accuracy on messy speech. It is about 320 MB to download and uses about 650 MB of memory.
@@ -73,20 +73,20 @@ Local Whisper is owned by the Conversation Calls package and is the most reliabl
 
 After download, a **Delete Local Whisper** control (trash icon) appears if you want to remove the model.
 
-Uninstalling Conversation Calls also deletes every downloaded Whisper model and its saved selection. This reclaims the model's disk space. Reinstalling Calls restores the download controls, but does not redownload a model until you choose one.
+Uninstalling Calls also deletes every downloaded Whisper model and its saved selection. This reclaims the model's disk space. Reinstalling Calls restores the download controls, but does not redownload a model until you choose one.
 
 ## Turn calls on for a chat
 
 You can turn calls on while creating a new Conversation, or later from the chat settings.
 
-For a new Conversation, finish the setup wizard first, then open that chat's settings and follow the same steps below. The optional package settings are shown only after Conversation Calls is installed.
+For a new Conversation, finish the setup wizard first, then open that chat's settings and follow the same steps below. The optional package settings are shown only after Calls is installed.
 
 For an existing Conversation:
 
 1. Open the chat.
 2. Open **Chat Settings**.
 3. Go to the **Agents** section.
-4. Open **Conversation Calls**.
+4. Open **Calls**.
 5. Turn on **Audio/Video Calls**. You should now see a call button next to the conversation name.
 6. Turn on **Call Audio Pipeline**. No call can start without it, even if you never use a microphone.
 7. Pick an **Audio input mode**.
@@ -97,7 +97,7 @@ The **Agents** section also contains a master **Commands** toggle when a command
 
 ### Settings and defaults
 
-Most call settings live in **Chat Settings**, then **Agents**, then **Conversation Calls**. Some of them are global, which means changing them in one chat changes them for every Conversation call in the app.
+Most call settings live in **Chat Settings**, then **Agents**, then **Calls**. Some of them are global, which means changing them in one chat changes them for every Conversation call in the app.
 
 | Setting | Scope | Default |
 |---|---|---|
@@ -166,7 +166,7 @@ You can upload your own sound with the **Upload** button. Accepted formats are m
 
 ## Character Video Presence and video call clips
 
-**Character Video Presence** replaces a still avatar tile with a looping AI-generated video clip of the character. It is off by default. The toggle is **Character video presence** in **Chat Settings**, then **Agents**, then **Conversation Calls**.
+**Character Video Presence** replaces a still avatar tile with a looping AI-generated video clip of the character. It is off by default. The toggle is **Character video presence** in **Chat Settings**, then **Agents**, then **Calls**.
 
 To set up video call clips:
 
@@ -228,13 +228,13 @@ The detailed call transcript stays in separate call storage. Only the short summ
 
 ### Start call fails and says call audio is not enabled
 
-If you click **Start call** and see "Conversation call audio is not enabled in Chat Settings", turn on **Call Audio Pipeline**. Open **Chat Settings**, then **Agents**, then **Conversation Calls**, and turn it on. This setting is required for every call, even a call where you only type. It is global, so turning it on in one chat turns it on for all Conversation calls.
+If you click **Start call** and see "Conversation call audio is not enabled in Chat Settings", turn on **Call Audio Pipeline**. Open **Chat Settings**, then **Agents**, then **Calls**, and turn it on. This setting is required for every call, even a call where you only type. It is global, so turning it on in one chat turns it on for all Conversation calls.
 
 ### I can hear characters, but they cannot hear me
 
-Open **Chat Settings**, then **Agents**, then **Conversation Calls**, and confirm **Call Audio Pipeline** is on. Then confirm your browser has given the Marinara page permission to use the microphone.
+Open **Chat Settings**, then **Agents**, then **Calls**, and confirm **Call Audio Pipeline** is on. Then confirm your browser has given the Marinara page permission to use the microphone.
 
-If you are on Firefox, or browser speech recognition does not work, install Conversation Calls and download Local Whisper. Open **Connections**, then **Local Model**, then **Local Speech Model**. Then choose **Mic recording + Local Whisper**.
+If you are on Firefox, or browser speech recognition does not work, install Calls and download Local Whisper. Open **Connections**, then **Local Model**, then **Local Speech Model**. Then choose **Mic recording + Local Whisper**.
 
 ### Local Whisper says it is unavailable
 

--- a/docs/media/scene-video.md
+++ b/docs/media/scene-video.md
@@ -134,7 +134,7 @@ If a chat has no video connection of its own, Marinara falls back to the connect
 
 ## Video generation settings
 
-Some video defaults live in the app settings, not on a connection. Open **Settings**, then **Generations**, then the **Video Generation** section. It is described as "Set default clip lengths and edit reusable video prompts for Game, Gallery, and Conversation Calls."
+Some video defaults live in the app settings, not on a connection. Open **Settings**, then **Generations**, then the **Video Generation** section. It is described as "Set default clip lengths and edit reusable video prompts for Game, Gallery, and Calls."
 
 The main scene-video setting here is **Scene video fallback length**, which defaults to 10 seconds. It is used only when the selected video connection has no length of its own. You can set it from 1 to 60 seconds.
 

--- a/packages/client/src/components/agents/AgentCatalogView.tsx
+++ b/packages/client/src/components/agents/AgentCatalogView.tsx
@@ -35,6 +35,58 @@ const CATEGORY_SECTIONS = [
   { id: "misc", label: "Misc Agents" },
 ] as const;
 
+type CatalogMode = "conversation" | "roleplay" | "game";
+
+const OFFICIAL_PACKAGE_MODES: Readonly<Record<string, readonly CatalogMode[]>> = Object.freeze({
+  "card-evolution-auditor": ["roleplay"],
+  continuity: ["roleplay"],
+  "knowledge-retrieval": ["roleplay"],
+  "knowledge-router": ["roleplay"],
+  director: ["roleplay"],
+  "prose-guardian": ["roleplay"],
+  background: ["roleplay"],
+  "character-tracker": ["roleplay"],
+  "custom-tracker": ["roleplay"],
+  expression: ["roleplay"],
+  "hierarchical-maps": ["roleplay", "game"],
+  "persona-stats": ["roleplay"],
+  quest: ["roleplay"],
+  "world-state": ["roleplay"],
+  eightball: ["conversation"],
+  chess: ["conversation"],
+  combat: ["roleplay"],
+  "conversation-calls": ["conversation"],
+  cyoa: ["roleplay"],
+  "echo-chamber": ["roleplay"],
+  haptic: ["conversation", "roleplay"],
+  illustrator: ["conversation", "roleplay", "game"],
+  html: ["roleplay"],
+  "lorebook-keeper": ["roleplay", "game"],
+  spotify: ["conversation", "roleplay", "game"],
+  poker: ["conversation"],
+  "rock-paper-scissors": ["conversation"],
+  "tic-tac-toe": ["conversation"],
+  uno: ["conversation"],
+});
+
+const MODE_BADGES: Record<CatalogMode, { label: string; className: string }> = {
+  conversation: {
+    label: "Conversation",
+    className:
+      "border-[color-mix(in_srgb,var(--mari-logo-cyan)_55%,var(--border))] bg-[color-mix(in_srgb,var(--mari-logo-cyan)_18%,transparent)]",
+  },
+  roleplay: {
+    label: "Roleplay",
+    className:
+      "border-[color-mix(in_srgb,var(--mari-logo-orange)_55%,var(--border))] bg-[color-mix(in_srgb,var(--mari-logo-orange)_18%,transparent)]",
+  },
+  game: {
+    label: "Game",
+    className:
+      "border-[color-mix(in_srgb,var(--mari-logo-pink)_55%,var(--border))] bg-[color-mix(in_srgb,var(--mari-logo-pink)_18%,transparent)]",
+  },
+};
+
 type BulkActionProgress = {
   action: "install" | "uninstall";
   completed: number;
@@ -47,10 +99,14 @@ function formatBytes(bytes: number) {
 }
 
 function kindLabel(kind: CapabilityCatalogPackage["manifest"]["kind"][number]) {
-  if (kind === "conversation-calls") return "Conversation Calls";
+  if (kind === "conversation-calls") return "Calls";
   if (kind === "turn-game") return "Conversation Game";
   if (kind === "maps") return "Maps";
   return "Agent";
+}
+
+function packageModes(packageId: string): readonly CatalogMode[] {
+  return OFFICIAL_PACKAGE_MODES[packageId] ?? [];
 }
 
 export function AgentCatalogView() {
@@ -72,7 +128,14 @@ export function AgentCatalogView() {
     return (catalog.data?.packages ?? []).filter(
       ({ manifest, category }) =>
         !needle ||
-        [manifest.name, manifest.description, manifest.id, category, ...manifest.kind.map(kindLabel)]
+        [
+          manifest.name,
+          manifest.description,
+          manifest.id,
+          category,
+          ...manifest.kind.map(kindLabel),
+          ...packageModes(manifest.id).map((mode) => MODE_BADGES[mode].label),
+        ]
           .join(" ")
           .toLowerCase()
           .includes(needle),
@@ -476,6 +539,18 @@ export function AgentCatalogView() {
                         className="rounded-full border border-[var(--border)] px-2.5 py-1 text-[0.68rem]"
                       >
                         {kindLabel(kind)}
+                      </span>
+                    ))}
+                    {packageModes(selected.manifest.id).map((mode) => (
+                      <span
+                        key={mode}
+                        data-chat-mode={mode}
+                        className={cn(
+                          "rounded-full border px-2.5 py-1 text-[0.68rem] font-semibold text-[var(--foreground)]",
+                          MODE_BADGES[mode].className,
+                        )}
+                      >
+                        {MODE_BADGES[mode].label}
                       </span>
                     ))}
                   </div>

--- a/packages/client/src/components/chat/HomeFaq.tsx
+++ b/packages/client/src/components/chat/HomeFaq.tsx
@@ -501,11 +501,11 @@ const HOME_FAQ_ITEMS: HomeFaqItem[] = [
     category: "Misc",
     question: "How do I set up Conversation audio calls?",
     answer:
-      "Enable TTS first, then turn on Conversation Calls for the chat and pick how your microphone should be transcribed.",
+      "Enable TTS first, then turn on Calls for the chat and pick how your microphone should be transcribed.",
     bullets: [
       "Open Connections > Text to Speech, enable a TTS provider, save it, and confirm the preview plays.",
-      "After installing Conversation Calls, open Connections > Local Model, expand the card, choose Whisper Tiny (Multilingual) or Whisper Base (Multilingual) under Local Speech Model, then click Download Whisper. Uninstalling Calls removes the downloaded model.",
-      "In the Conversation chat, open Chat Settings > Commands > Conversation Calls, enable Audio/Video Calls, then enable Call Audio Pipeline.",
+      "After installing Calls, open Connections > Local Model, expand the card, choose Whisper Tiny (Multilingual) or Whisper Base (Multilingual) under Local Speech Model, then click Download Whisper. Uninstalling Calls removes the downloaded model.",
+      "In the Conversation chat, open Chat Settings > Commands > Calls, enable Audio/Video Calls, then enable Call Audio Pipeline.",
       "Use Mic recording + Local Whisper for Firefox or reliable local speech capture. Browser speech recognition depends on browser support.",
       "The Calls command toggle only controls whether characters can ring you first; you can still call them when Audio/Video Calls is enabled.",
     ],

--- a/packages/client/src/components/panels/SettingsPanel.tsx
+++ b/packages/client/src/components/panels/SettingsPanel.tsx
@@ -3162,7 +3162,7 @@ function VideoGenerationSettings() {
   return (
     <SettingsSection
       title="Video Generation"
-      description="Set default clip lengths and edit reusable video prompts for Game, Gallery, and Conversation Calls."
+      description="Set default clip lengths and edit reusable video prompts for Game, Gallery, and Calls."
       icon={<Film size="0.875rem" />}
       {...getSettingsSectionAnchorProps("video-generation")}
     >

--- a/packages/server/src/db/seed-mari.ts
+++ b/packages/server/src/db/seed-mari.ts
@@ -183,8 +183,8 @@ ${PROFESSOR_MARI_AGENT_CATALOG_KNOWLEDGE}
 ### Settings, Audio, and Notification Sounds
 - App-wide settings live in the Settings panel, opened from the right panel/top bar settings button.
 - Text to Speech lives in **Connections > Text to Speech**. Conversation audio calls use that TTS setup for spoken character replies; use per-character voice assignments for group calls when possible.
-- After the Conversation Calls package is installed, audio calls are configured per chat in **Chat Settings > Agents > Conversation Calls**. **Audio/Video Calls** shows the user's phone button. The separate **Calls** command toggle lets characters ring the user first.
-- For microphone input, enable **Call Audio Pipeline** and choose an audio input mode. **Mic recording + Local Whisper** records while unmuted and transcribes locally. The Local Speech Model section appears in **Connections > Local Model** only while Conversation Calls is installed. Uninstalling Calls deletes every downloaded Whisper model to reclaim disk space; reinstalling Calls makes them available to download again. **Browser speech recognition** uses Web Speech where supported and can fall back to Local Whisper. **Manual system dictation** only focuses the call input for OS dictation. **Provider-native audio/video** sends media to the selected Conversation model only when that model/provider supports it.
+- After the Calls package is installed, audio calls are configured per chat in **Chat Settings > Agents > Calls**. **Audio/Video Calls** shows the user's phone button. The separate **Calls** command toggle lets characters ring the user first.
+- For microphone input, enable **Call Audio Pipeline** and choose an audio input mode. **Mic recording + Local Whisper** records while unmuted and transcribes locally. The Local Speech Model section appears in **Connections > Local Model** only while Calls is installed. Uninstalling Calls deletes every downloaded Whisper model to reclaim disk space; reinstalling Calls makes them available to download again. **Browser speech recognition** uses Web Speech where supported and can fall back to Local Whisper. **Manual system dictation** only focuses the call input for OS dictation. **Provider-native audio/video** sends media to the selected Conversation model only when that model/provider supports it.
 - Notification pings are NOT browser-only. Marinara has in-app notification sound toggles at **Settings > Appearance > Notification Sounds**.
 - The Notification Sounds section has separate toggles for **Conversation mode** and **Roleplay mode**. Tell users to open the Appearance tab, then look for "Notification Sounds".
 - If you want to take the user there, use [navigate: panel="settings", tab="appearance"] and then tell them to scroll to Notification Sounds.
@@ -259,7 +259,7 @@ Use the complete official_agent_catalog block above as the source of truth for o
 ### Agent Configuration
 - Install official packages from **Agents → Download Agents** before trying to enable or configure them.
 - Each compatible pipeline agent can be toggled on or off per chat.
-- Feature packages such as Hierarchical Maps, Conversation Calls, and Conversation games add their own surfaces and controls after installation.
+- Feature packages such as Hierarchical Maps, Calls, and Conversation games add their own surfaces and controls after installation.
 - Agents have their own system prompts and can use separate models/connections
 - Configured in the Agents panel (right sidebar → sparkles icon)
 

--- a/packages/server/src/routes/sidecar.routes.ts
+++ b/packages/server/src/routes/sidecar.routes.ts
@@ -79,8 +79,8 @@ async function requireConversationCallsForSpeech(reply: FastifyReply): Promise<b
   );
   if (callsAvailable) return true;
   reply.status(409).send({
-    error: "Conversation Calls is not installed",
-    message: "Install Conversation Calls from Agents before managing the Local Speech Model.",
+    error: "Calls is not installed",
+    message: "Install Calls from Agents before managing the Local Speech Model.",
   });
   return false;
 }

--- a/packages/server/src/services/conversation/call-character-videos.service.ts
+++ b/packages/server/src/services/conversation/call-character-videos.service.ts
@@ -110,7 +110,7 @@ export class ConversationCallVideoClipUploadError extends Error {
 
 function requireProvider(): CharacterVideoService {
   const service = provider();
-  if (!service) throw new Error("Conversation Calls is not installed or active");
+  if (!service) throw new Error("Calls is not installed or active");
   return service;
 }
 

--- a/packages/server/src/services/professor-mari/official-agent-knowledge.ts
+++ b/packages/server/src/services/professor-mari/official-agent-knowledge.ts
@@ -123,14 +123,14 @@ export const OFFICIAL_AGENT_KNOWLEDGE_ENTRIES: readonly OfficialAgentKnowledgeEn
     id: "illustrator",
     name: "Illustrator",
     category: "misc",
-    modes: "Roleplay and Conversation media commands",
+    modes: "Conversation, Roleplay, and Game",
     summary: "Responsible for image and video generations.",
   },
   {
     id: "lorebook-keeper",
     name: "Lorebook Keeper",
     category: "misc",
-    modes: "Roleplay",
+    modes: "Roleplay and Game",
     summary: "creates and updates durable lorebook entries from important story facts",
   },
   {
@@ -151,14 +151,14 @@ export const OFFICIAL_AGENT_KNOWLEDGE_ENTRIES: readonly OfficialAgentKnowledgeEn
     id: "spotify",
     name: "Music DJ",
     category: "misc",
-    modes: "Roleplay, Game, and Conversation music commands",
+    modes: "Conversation, Roleplay, and Game",
     summary: "matches scene mood with Spotify, YouTube, or local Game Assets music",
   },
   {
     id: "haptic",
     name: "Haptic Feedback",
     category: "misc",
-    modes: "Roleplay and Conversation haptic commands",
+    modes: "Conversation and Roleplay",
     summary: "converts direct narrative contact into safe Intiface Central device commands",
   },
   {
@@ -170,7 +170,7 @@ export const OFFICIAL_AGENT_KNOWLEDGE_ENTRIES: readonly OfficialAgentKnowledgeEn
   },
   {
     id: "conversation-calls",
-    name: "Conversation Calls",
+    name: "Calls",
     category: "misc",
     modes: "Conversation",
     summary:

--- a/packages/server/src/services/sidecar/sidecar-speech.service.ts
+++ b/packages/server/src/services/sidecar/sidecar-speech.service.ts
@@ -352,7 +352,7 @@ class SidecarSpeechService {
     options: { localFilesOnly: boolean; progress?: (data: TransformersProgress) => void },
   ): Promise<AsrPipeline> {
     if (this.removingAllModels) {
-      throw new Error("Local Whisper is being removed with the Conversation Calls package.");
+      throw new Error("Local Whisper is being removed with the Calls package.");
     }
     if (this.pipeline && this.activeModelId === modelId) return this.pipeline;
     if (this.loadingPromise && this.activeModelId === modelId) return this.loadingPromise;


### PR DESCRIPTION
## Why this change

Download Agents shows what each package does but does not expose its supported chat modes at a glance. Users should be able to distinguish Conversation, Roleplay, and Game packages before installing them.

Closes #3676

Coordinated package descriptions and the Calls catalog rename are in Pasta-Devs/Marinara-Agents#40.

## What changed

- added Conversation, Roleplay, and Game badges beside the existing package-kind badges in Download Agents
- used the logo palette variables: cyan for Conversation, orange for Roleplay, and pink for Game
- made catalog search match mode labels
- preserved the strict v1 catalog wire format for existing 2.3.x clients by mapping the 29 stable official package IDs in the host UI
- renamed current user-facing Conversation Calls references to Calls across the catalog UI, setup documentation, Professor Mari knowledge, FAQ guidance, and visible package errors while preserving internal IDs and compatibility symbols
- aligned Professor Mari's supported-mode knowledge with the requested package matrix

## Validation

- `pnpm install --frozen-lockfile`
- `pnpm check` — Impeccable context, shared/server TypeScript, client ESLint, server build, client production build, and PWA generation passed
- `pnpm smoke:ui` — 60 passed, 38 intentionally viewport-skipped
- `git diff --check`
- programmatic cross-repository comparison confirmed the Engine and Marinara-Agents mode maps agree for all 29 package IDs

## Manual verification still required

- Verify Download Agents mode badges on desktop and mobile.
- Verify badge contrast in light and dark themes.
- Verify searching for Conversation, Roleplay, and Game filters to matching packages.
- Verify Calls wording after serving the coordinated Marinara-Agents catalog.
