### PR TITLE
Keep Hierarchical Maps inside the Agents menu

### DIFF
--- a/e2e/core-flows.e2e.ts
+++ b/e2e/core-flows.e2e.ts
@@ -2011,6 +2011,170 @@ test("Roleplay and Game chat settings link empty agent libraries to Download Age
   }
 });
 
+test("Hierarchical Maps settings stay inside the active agent entry", async ({ page, request }, testInfo) => {
+  test.skip(!testInfo.project.name.includes("desktop"), "Hierarchical Maps agent placement is covered on desktop.");
+  test.setTimeout(90_000);
+
+  const errors = collectUnexpectedErrors(page);
+  const chats: Array<{ id: string; mode: "roleplay" | "game" }> = [];
+  for (const mode of ["roleplay", "game"] as const) {
+    const response = await request.post("/api/chats", {
+      data: { name: `${mode} Hierarchical Maps Agent Menu Smoke`, mode, characterIds: [] },
+    });
+    expect(response.ok()).toBeTruthy();
+    const chat = (await response.json()) as { id: string };
+    const metadataResponse = await request.patch(`/api/chats/${chat.id}/metadata`, {
+      data: {
+        enableAgents: true,
+        activeAgentIds: ["hierarchical-maps"],
+        ...(mode === "game"
+          ? {
+              gameId: "hierarchical-maps-agent-menu-smoke",
+              gameSessionStatus: "active",
+              gameSessionNumber: 1,
+              gameIntroPresented: true,
+            }
+          : {}),
+      },
+    });
+    expect(metadataResponse.ok()).toBeTruthy();
+    if (mode === "game") {
+      const messageResponse = await request.post(`/api/chats/${chat.id}/messages`, {
+        data: { role: "assistant", content: "The party studies the map." },
+      });
+      expect(messageResponse.ok()).toBeTruthy();
+    }
+    chats.push({ id: chat.id, mode });
+  }
+
+  const agentManifest = {
+    id: "hierarchical-maps",
+    name: "Hierarchical Maps",
+    description: "Adds persistent hierarchical locations and spatial context.",
+    author: "Pasta Devs",
+    phase: "pre_generation",
+    enabledByDefault: false,
+    category: "tracker",
+    runtimeDisabled: true,
+    modeAllowlist: ["roleplay", "game"],
+    defaultPromptTemplate: "",
+    execution: "feature",
+  };
+  const packageManifest = {
+    schemaVersion: 1,
+    id: "hierarchical-maps",
+    name: "Hierarchical Maps",
+    version: "1.0.6",
+    description: agentManifest.description,
+    engine: { min: "2.3.0", maxExclusive: "2.4.0" },
+    kind: ["agent", "maps"],
+    entrypoints: { agents: "agents.json", client: "client.js" },
+    contributions: { slots: ["chat-settings", "spatial-workspace", "chat-runtime", "game-world-map"] },
+    files: [],
+    permissions: ["ui"],
+    restartRequired: true,
+  };
+
+  await page.route("**/api/capability-packages/agents", async (route) => {
+    await route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify([agentManifest]) });
+  });
+  await page.route("**/api/capability-packages/catalog", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ schemaVersion: 1, generatedAt: "2026-07-16T00:00:00.000Z", packages: [] }),
+    });
+  });
+  await page.route("**/api/capability-packages/installed", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify([
+        {
+          id: "hierarchical-maps",
+          version: packageManifest.version,
+          manifest: packageManifest,
+          installedAt: "2026-07-16T00:00:00.000Z",
+          status: "active",
+          error: null,
+          legacy: false,
+        },
+      ]),
+    });
+  });
+  await page.route("**/api/capability-packages/hierarchical-maps/client?*", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/javascript",
+      body: `
+        class HierarchicalMapsSmokeElement extends HTMLElement {
+          connectedCallback() {
+            this.innerHTML = '<div data-testid="hierarchical-maps-controls">Hierarchical map controls</div>';
+          }
+        }
+        if (!customElements.get('marinara-capability-hierarchical-maps')) {
+          customElements.define('marinara-capability-hierarchical-maps', HierarchicalMapsSmokeElement);
+        }
+        export {};
+      `,
+    });
+  });
+  await page.route("**/api/agents", async (route) => {
+    await route.fulfill({ status: 200, contentType: "application/json", body: "[]" });
+  });
+  await page.route("**/api/lorebooks/scan/**", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ entries: [], budgetSkippedEntries: [], totalTokens: 0, totalEntries: 0 }),
+    });
+  });
+  await page.route("**/api/game-assets/manifest", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ scannedAt: "2026-07-16T00:00:00.000Z", count: 0, assets: {}, byCategory: {} }),
+    });
+  });
+  await page.route("**/api/backgrounds/file/Black.jpg", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "image/gif",
+      body: Buffer.from(TRANSPARENT_GIF_BASE64, "base64"),
+    });
+  });
+
+  try {
+    await page.goto("/");
+    for (const chat of chats) {
+      await page.evaluate((chatId) => localStorage.setItem("marinara-active-chat-id", chatId), chat.id);
+      await page.reload();
+      await page.getByRole("button", { name: "Chat Settings" }).click();
+      const drawer = page.locator(".mari-chat-settings-drawer");
+      await expect(drawer).toBeVisible();
+      await expect(
+        drawer.locator('[role="button"][aria-expanded]').filter({ hasText: /^Hierarchical map/ }),
+        `${chat.mode} should not expose a top-level Hierarchical map section`,
+      ).toHaveCount(0);
+
+      const agentsSection = drawer.locator('[role="button"][aria-expanded]').filter({ hasText: /^Agents/ });
+      await agentsSection.click();
+      if (chat.mode === "roleplay") {
+        await drawer.getByRole("button", { name: /Tracker Agents/ }).click();
+      }
+
+      const agentEntry = drawer.locator('[data-chat-agent-entry="hierarchical-maps"]');
+      await expect(agentEntry, `${chat.mode} Hierarchical Maps agent entry`).toBeVisible();
+      await expect(agentEntry.getByTestId("hierarchical-maps-controls")).toBeVisible();
+      await expect(drawer.locator("marinara-capability-hierarchical-maps")).toHaveCount(1);
+      await expect(agentEntry.locator("marinara-capability-hierarchical-maps")).toHaveCount(1);
+    }
+    expect(errors).toEqual([]);
+  } finally {
+    await Promise.all(chats.map((chat) => request.delete(`/api/chats/${chat.id}`, { timeout: 10_000 })));
+  }
+});
+
 test("Roleplay setup points empty agent libraries to the Agents tab", async ({ page, request }, testInfo) => {
   test.skip(!testInfo.project.name.includes("desktop"), "Roleplay setup empty-state regression is covered on desktop.");
 

--- a/packages/client/src/components/chat/ChatSettingsDrawer.tsx
+++ b/packages/client/src/components/chat/ChatSettingsDrawer.tsx
@@ -741,7 +741,6 @@ const CHAT_SETTINGS_ORDER = {
   scopedRegex: -750,
   connectedChat: -700,
   connectedNotes: -690,
-  spatialMap: -650,
   lorebooks: -600,
   agents: -500,
   widgets: -450,
@@ -6071,15 +6070,6 @@ export function ChatSettingsDrawer({
             </Section>
           )}
 
-          {(chatMode === "roleplay" || chatMode === "game") && mapsPackage && (
-            <CapabilityElement
-              packageId={mapsPackage.id}
-              view="settings"
-              capabilityProps={{ chatId: chat.id, style: { order: CHAT_SETTINGS_ORDER.spatialMap } }}
-              className="contents"
-            />
-          )}
-
           <div style={{ order: CHAT_SETTINGS_ORDER.lorebooks }}>
             <LorebooksSection
               chatId={chat.id}
@@ -8105,7 +8095,7 @@ export function ChatSettingsDrawer({
                                 const active = activeAgentIds.includes(agent.id);
                                 const knowledgeAgentType = isKnowledgeAgentType(agent.id) ? agent.id : null;
                                 return (
-                                  <div key={agent.id} className="space-y-1.5">
+                                  <div key={agent.id} data-chat-agent-entry={agent.id} className="space-y-1.5">
                                     <button
                                       onClick={() => {
                                         const latestActiveAgentIds = readLatestActiveAgentIds();
@@ -8194,6 +8184,14 @@ export function ChatSettingsDrawer({
                                         />
                                       </AgentSettingsCard>
                                     )}
+                                    {active && agent.id === "hierarchical-maps" && mapsPackage && (
+                                      <CapabilityElement
+                                        packageId={mapsPackage.id}
+                                        view="settings"
+                                        capabilityProps={{ chatId: chat.id }}
+                                        className="block overflow-hidden rounded-lg border border-[var(--border)] bg-[var(--background)]/45"
+                                      />
+                                    )}
                                   </div>
                                 );
                               })}
@@ -8278,6 +8276,7 @@ export function ChatSettingsDrawer({
                                       return (
                                         <div
                                           key={agent.id}
+                                          data-chat-agent-entry={agent.id}
                                           className="rounded-lg bg-[var(--primary)]/10 px-3 py-2 ring-1 ring-[var(--primary)]/30"
                                         >
                                           <div className="flex items-start gap-2.5">
@@ -8311,6 +8310,14 @@ export function ChatSettingsDrawer({
                                               <Trash2 size="0.6875rem" />
                                             </button>
                                           </div>
+                                          {agent.id === "hierarchical-maps" && mapsPackage && (
+                                            <CapabilityElement
+                                              packageId={mapsPackage.id}
+                                              view="settings"
+                                              capabilityProps={{ chatId: chat.id }}
+                                              className="mt-2 block overflow-hidden rounded-lg border border-[var(--border)] bg-[var(--background)]/45"
+                                            />
+                                          )}
                                         </div>
                                       );
                                     })}


### PR DESCRIPTION
## Linked issue

Closes #3679

## Why this change

Enabling Hierarchical Maps currently creates a separate top-level **Hierarchical map** section in Chat Settings. Its enablement lives under **Agents**, so splitting its controls into another section makes the package inconsistent with the other downloadable agents and gives users two places to manage one feature.

## What changed

- removed the standalone Hierarchical Maps Chat Settings mount
- rendered the existing package-owned settings capability inside the active Hierarchical Maps agent entry in Roleplay and Game
- kept the capability hidden when the agent is not active by reusing the existing active-package resolution
- added a Roleplay/Game regression test that rejects top-level placement and requires exactly one nested map capability
- left the package payload, manifest, permissions, storage, and runtime unchanged

## Validation

- [ ] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed `CONTRIBUTING.md`

### Manual verification notes

- `pnpm install --frozen-lockfile`
- `pnpm check` — Impeccable context, shared/server TypeScript, client ESLint, server build, client production build, and PWA generation passed.
- Focused Playwright regression passed for active Hierarchical Maps in both Roleplay and Game.
- `pnpm smoke:ui` — 61 passed, 39 intentionally skipped by project/viewport conditions.
- `git diff --check`
- Real in-app visual verification and screenshots remain required. The available in-app browser connection failed during bootstrap before a tab could be selected, so light/dark theme and mobile appearance are not claimed here.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Version/release files updated (only if this PR includes a version bump)

No documentation or release files change because this only relocates existing controls within Chat Settings.

## UI evidence (if applicable)

Automated structural proof is included in `e2e/core-flows.e2e.ts`. Before/after screenshots remain a manual follow-up because the in-app browser connection was unavailable.
