### PR TITLE
fix: address v3.2.2 issue batch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 
 ### Fixed
 
+- Fixed the downloadable Conversation Calls package persisting a hardcoded assistant reply when typed-message generation failed. Package v1.0.3 no longer requires provider-native JSON mode and reports genuine provider failures instead of inventing character dialogue (#3685).
+- Made native profile imports atomic across file-storage rows and assets. Present archive assets are now fully decompressed, CRC-checked, and staged before live mutation; table upserts run in a serialized transaction; and promoted files roll back if a later write or durable database flush fails, while missing assets remain warning-only (#3683).
 - Fixed generated and manually replaced Game Journal NPC portraits failing to update when a reputation label was appended to the NPC name. Portrait matching now treats the display label and the tracked NPC as the same character throughout the live session (#3681).
 - Increased the final Game setup generation watchdog from 300 to 500 seconds so large GM blueprints have enough time to finish without extending unrelated in-session generation limits (#3684).
 - Fixed merged Roleplay group prompts stripping every historical speaker-tag example. The latest assistant message now keeps its `<speaker>` wrappers while older tags are still trimmed, and the instruction remains inside `<output_format>` when available or otherwise appends to the last user message (#3673).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 
 ### Fixed
 
-- Fixed the downloadable Conversation Calls package persisting a hardcoded assistant reply when typed-message generation failed. Package v1.0.3 no longer requires provider-native JSON mode and reports genuine provider failures instead of inventing character dialogue (#3685).
+- Fixed the downloadable Conversation Calls package persisting a hardcoded assistant reply when typed-message generation failed. Package v1.0.4 no longer requires provider-native JSON mode and reports genuine provider failures instead of inventing character dialogue (#3685).
 - Made native profile imports atomic across file-storage rows and assets. Present archive assets are now fully decompressed, CRC-checked, and staged before live mutation; table upserts run in a serialized transaction; and promoted files roll back if a later write or durable database flush fails, while missing assets remain warning-only (#3683).
 - Fixed generated and manually replaced Game Journal NPC portraits failing to update when a reputation label was appended to the NPC name. Portrait matching now treats the display label and the tracked NPC as the same character throughout the live session (#3681).
 - Increased the final Game setup generation watchdog from 300 to 500 seconds so large GM blueprints have enough time to finish without extending unrelated in-session generation limits (#3684).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 
 ### Fixed
 
+- Fixed generated and manually replaced Game Journal NPC portraits failing to update when a reputation label was appended to the NPC name. Portrait matching now treats the display label and the tracked NPC as the same character throughout the live session (#3681).
+- Increased the final Game setup generation watchdog from 300 to 500 seconds so large GM blueprints have enough time to finish without extending unrelated in-session generation limits (#3684).
 - Fixed merged Roleplay group prompts stripping every historical speaker-tag example. The latest assistant message now keeps its `<speaker>` wrappers while older tags are still trimmed, and the instruction remains inside `<output_format>` when available or otherwise appends to the last user message (#3673).
 - Preserved the **Enable Agents** master switch during the v2.3 capability migration, so upgrading cannot silently reactivate selected agents or their model calls. Hierarchical Maps now remains independently available when selected (#3669).
 - Made the v2.3 capability migration restart-safe by writing its completion marker only after per-chat selections are migrated and flushed to durable storage; interrupted migrations retry idempotently on the next startup (#3670).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 
 ### Added
 
+- Added Venice.ai as an Image Generation service, including authenticated live image-model discovery and native `/image/generate` support with model-aware sizing and validated base64 responses (#3682).
 - Added responsive Background library folders, desktop and touch drag-and-drop organization, A-Z/Z-A/Newest/Oldest sorting, and collapsible tag filters without limiting the Background agent's available choices (#3678).
 - Added Conversation, Roleplay, and Game compatibility badges to Download Agents, including catalog search by supported mode (#3676).
 

--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ Preset system with drag-and-drop prompt ordering, lorebooks with keyword trigger
 
 ### Connections & Providers
 
-OpenAI, OpenAI ChatGPT subscription login, Anthropic, Claude Subscription through the local Claude Agent SDK, Google Gemini, Google Vertex AI, OpenRouter, NanoGPT, Mistral, Cohere, xAI / Grok, the bundled downloadable Local Model sidecar, Pollinations, Stability AI, Together AI, NovelAI, ComfyUI, SD Web UI, Draw Things (Apple Silicon, Metal + Apple Neural Engine), Google AI Studio video models (Gemini Omni and Veo), xAI Imagine video, OpenRouter video, Seedance 2.0 video, and custom OpenAI-compatible endpoints. API keys are encrypted at rest with AES-256. Per-chat connection overrides.
+OpenAI, OpenAI ChatGPT subscription login, Anthropic, Claude Subscription through the local Claude Agent SDK, Google Gemini, Google Vertex AI, OpenRouter, NanoGPT, Mistral, Cohere, xAI / Grok, the bundled downloadable Local Model sidecar, Pollinations, Stability AI, Together AI, NovelAI, Venice.ai, ComfyUI, SD Web UI, Draw Things (Apple Silicon, Metal + Apple Neural Engine), Google AI Studio video models (Gemini Omni and Veo), xAI Imagine video, OpenRouter video, Seedance 2.0 video, and custom OpenAI-compatible endpoints. API keys are encrypted at rest with AES-256. Per-chat connection overrides.
 
 ### Export & Data
 

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -72,7 +72,7 @@ Marinara supports many providers. You pick one per connection.
 
 For chat and roleplay text, the choices are **OpenAI**, **OpenAI (ChatGPT)**, **Anthropic**, **Claude (Subscription)**, **Grok CLI (Subscription)**, **Google Gemini**, **Google Vertex AI**, **Mistral**, **Cohere**, **OpenRouter**, **NanoGPT**, **xAI / Grok**, and **Custom (OAI-Compatible)** for local or self-hosted models such as Ollama, LM Studio, and KoboldCpp.
 
-For image generation, the choices include **OpenAI (DALL-E)**, **Stability AI**, **Together AI**, **NovelAI**, **OpenRouter Images**, **xAI / Grok Imagine**, **Pollinations**, **Stable Horde**, **SD Web UI (AUTOMATIC1111 / Forge)**, **ComfyUI**, **RunPod Serverless (ComfyUI)**, **Draw Things**, **NanoGPT**, and **Block Entropy**.
+For image generation, the choices include **OpenAI (DALL-E)**, **Stability AI**, **Together AI**, **NovelAI**, **OpenRouter Images**, **xAI / Grok Imagine**, **Venice.ai**, **Pollinations**, **Stable Horde**, **SD Web UI (AUTOMATIC1111 / Forge)**, **ComfyUI**, **RunPod Serverless (ComfyUI)**, **Draw Things**, **NanoGPT**, and **Block Entropy**.
 
 For video generation, the choices are **Google AI Studio**, **xAI Imagine**, **OpenRouter Video**, and **Seedance 2.0**.
 

--- a/docs/media/image-providers.md
+++ b/docs/media/image-providers.md
@@ -1,6 +1,6 @@
 # Image Generation Providers and Setup
 
-This guide explains how to connect an image generation service to Marinara Engine. It also covers what each of the 14 services needs. Image generation powers scene illustrations, selfies, scene backgrounds, and generated avatars, portraits, and sprites.
+This guide explains how to connect an image generation service to Marinara Engine. It also covers what each of the 15 services needs. Image generation powers scene illustrations, selfies, scene backgrounds, and generated avatars, portraits, and sprites.
 
 You set up image generation as a special kind of connection. Once one image connection works, every image feature in the app can use it.
 
@@ -23,7 +23,7 @@ If **Test Image** returns a picture, your connection is ready. If it fails, chec
 
 ## Choosing a service
 
-The 14 services fall into three groups. Cloud services need an API key and an account. Free services need no key. Local services run image software on your own computer.
+The 15 services fall into three groups. Cloud services need an API key and an account. Free services need no key. Local services run image software on your own computer.
 
 The table below shows each service at a glance. Details and quirks follow in the per-service sections.
 
@@ -35,6 +35,7 @@ The table below shows each service at a glance. Details and quirks follow in the
 | NovelAI | Yes | Cloud |
 | OpenRouter Images | Yes | Cloud |
 | xAI / Grok Imagine | Yes | Cloud |
+| Venice.ai | Yes | Cloud |
 | NanoGPT | Yes | Cloud |
 | Block Entropy | Yes | Cloud |
 | RunPod Serverless (ComfyUI) | Yes | Cloud |
@@ -67,6 +68,10 @@ Cloud service with the default Base URL `https://openrouter.ai/api/v1`. It needs
 ## xAI / Grok Imagine
 
 Cloud service with the default Base URL `https://api.x.ai/v1`. It needs an xAI API key. It uses Grok Imagine for image generation.
+
+## Venice.ai
+
+Cloud service with the default Base URL `https://api.venice.ai/api/v1`. It needs a Venice API key. Use **Fetch Models from API** to load the image models available to your account. Marinara uses Venice's native image endpoint and automatically maps requested dimensions to each model's pixel, aspect-ratio, or resolution-tier sizing format.
 
 ## NanoGPT
 
@@ -155,6 +160,7 @@ A **reference image** is an existing picture you send along with your prompt. It
 | OpenAI (DALL-E) | Up to 16 |
 | NovelAI | Up to 16, V4.5 model only |
 | xAI / Grok Imagine | Up to 3 |
+| Venice.ai | Not supported for text-to-image generation |
 | NanoGPT | Up to 3 |
 | Stability AI | First image only, used as image to image |
 | OpenRouter Images | Supported, no fixed limit |

--- a/packages/client/src/components/connections/ConnectionEditor.tsx
+++ b/packages/client/src/components/connections/ConnectionEditor.tsx
@@ -498,13 +498,15 @@ export function ConnectionEditor() {
   const selectedVideoProvider = videoSourceToProviderOption(selectedVideoService);
   const selectedVideoDefaultsService = videoSelectionToDefaultsService(selectedVideoService, localModel, localBaseUrl);
   const apiKeyLink =
-    localProvider === "video_generation" && selectedVideoDefaultsService === "xai"
-      ? API_KEY_LINKS.xai
-      : localProvider === "video_generation" && selectedVideoDefaultsService === "openrouter"
-        ? API_KEY_LINKS.openrouter
-        : localProvider === "video_generation" && selectedVideoDefaultsService === "seedance"
-          ? { label: "Open Seedance API docs", url: "https://seedance2.ai/api-docs" }
-          : API_KEY_LINKS[localProvider];
+    localProvider === "image_generation" && selectedImageService === "venice"
+      ? { label: "Get your Venice API key", url: "https://venice.ai/settings/api" }
+      : localProvider === "video_generation" && selectedVideoDefaultsService === "xai"
+        ? API_KEY_LINKS.xai
+        : localProvider === "video_generation" && selectedVideoDefaultsService === "openrouter"
+          ? API_KEY_LINKS.openrouter
+          : localProvider === "video_generation" && selectedVideoDefaultsService === "seedance"
+            ? { label: "Open Seedance API docs", url: "https://seedance2.ai/api-docs" }
+            : API_KEY_LINKS[localProvider];
 
   useEffect(() => {
     if (localProvider !== "image_generation" || !selectedImageDefaultsService) {

--- a/packages/client/src/components/game/GameJournal.tsx
+++ b/packages/client/src/components/game/GameJournal.tsx
@@ -9,10 +9,11 @@ import { useState, useEffect, useRef, useCallback, useMemo } from "react";
 import { X, MapPin, Swords, ScrollText, Package, Users, PenLine, BookOpen, Trash2, Loader2, Wand2 } from "lucide-react";
 import { cn } from "../../lib/utils";
 import { api } from "../../lib/api-client";
+import { cleanNpcAvatarDisplayName, normalizeNpcAvatarName } from "../../lib/game-npc-avatar";
 import { applyInlineMarkdown, renderMarkdownBlocks } from "../../lib/markdown";
 import { AnimatedText } from "./AnimatedText";
 
-import { normalizeTextForMatch, type GameNpc } from "@marinara-engine/shared";
+import type { GameNpc } from "@marinara-engine/shared";
 
 interface JournalEntry {
   timestamp: string;
@@ -82,14 +83,12 @@ function isMobileGameViewport(): boolean {
   return typeof window !== "undefined" && window.matchMedia("(max-width: 767px)").matches;
 }
 
-const TRAILING_REPUTATION_LABEL = /(devoted|allied|friendly|neutral|unfriendly|hostile|enemy)$/i;
-
 function normalizeNpcName(value: string): string {
-  return normalizeTextForMatch(value).replace(/[_-]+/g, " ");
+  return normalizeNpcAvatarName(value);
 }
 
 function cleanNpcDisplayName(value: string): string {
-  return value.replace(TRAILING_REPUTATION_LABEL, "").trim() || value;
+  return cleanNpcAvatarDisplayName(value);
 }
 
 function normalizeNpcEntryTitle(value: string): string {

--- a/packages/client/src/components/game/GameSurface.tsx
+++ b/packages/client/src/components/game/GameSurface.tsx
@@ -21,7 +21,11 @@ import { toast } from "sonner";
 import { useGameModeStore } from "../../stores/game-mode.store";
 import { useGameAssetStore } from "../../stores/game-asset.store";
 import { gameAssetKeys, useGameAssetManifest, type GameAssetManifest } from "../../hooks/use-game-assets";
-import { isSameNpcAvatarResource } from "../../lib/game-npc-avatar";
+import {
+  cleanNpcAvatarDisplayName,
+  isSameNpcAvatarResource,
+  normalizeNpcAvatarName,
+} from "../../lib/game-npc-avatar";
 import { useChatStore } from "../../stores/chat.store";
 import { useUIStore } from "../../stores/ui.store";
 import { useGameStateStore } from "../../stores/game-state.store";
@@ -970,10 +974,8 @@ function generatedEnemyToCombatant(enemy: CombatEnemy, index: number, fallbackLe
   };
 }
 
-const TRAILING_NPC_REPUTATION_LABEL = /(devoted|allied|friendly|neutral|unfriendly|hostile|enemy)$/i;
-
 function cleanGameNpcDisplayName(value: string): string {
-  return value.replace(TRAILING_NPC_REPUTATION_LABEL, "").trim() || value;
+  return cleanNpcAvatarDisplayName(value);
 }
 
 function normalizeGameNpcJournalName(value: string): string {
@@ -6654,12 +6656,12 @@ function GameSurfaceComponent({
       if (!activeChatId) return;
 
       const displayName = cleanGameNpcDisplayName(npcName).trim();
-      const normalizedName = normalizeTextForMatch(displayName);
+      const normalizedName = normalizeNpcAvatarName(displayName);
       if (!normalizedName) return;
 
       const targetNpc = useGameModeStore
         .getState()
-        .npcs.find((npc) => normalizeTextForMatch(npc.name) === normalizedName);
+        .npcs.find((npc) => normalizeNpcAvatarName(npc.name) === normalizedName);
 
       setPendingNpcPortraitUploadName(targetNpc?.name ?? displayName);
       npcPortraitUploadInputRef.current?.click();
@@ -6672,11 +6674,11 @@ function GameSurfaceComponent({
       if (!activeChatId) return;
 
       const displayName = cleanGameNpcDisplayName(npcName).trim();
-      const normalizedName = normalizeTextForMatch(displayName);
+      const normalizedName = normalizeNpcAvatarName(displayName);
       if (!normalizedName) return;
 
       const currentNpcs = useGameModeStore.getState().npcs;
-      const existingNpcIndex = currentNpcs.findIndex((npc) => normalizeTextForMatch(npc.name) === normalizedName);
+      const existingNpcIndex = currentNpcs.findIndex((npc) => normalizeNpcAvatarName(npc.name) === normalizedName);
       const targetNpc =
         existingNpcIndex >= 0
           ? currentNpcs[existingNpcIndex]!
@@ -6726,7 +6728,7 @@ function GameSurfaceComponent({
       if (!activeChatId) return;
 
       const displayName = cleanGameNpcDisplayName(npcName).trim();
-      const normalizedName = normalizeTextForMatch(displayName);
+      const normalizedName = normalizeNpcAvatarName(displayName);
       if (!normalizedName) return;
 
       if (!chatMeta.enableSpriteGeneration || !chatMeta.gameImageConnectionId) {
@@ -6736,10 +6738,10 @@ function GameSurfaceComponent({
 
       const currentNpcs = useGameModeStore.getState().npcs;
       const metadataNpc = Array.isArray(chatMeta.gameNpcs)
-        ? (chatMeta.gameNpcs as GameNpc[]).find((npc) => normalizeTextForMatch(npc.name) === normalizedName)
+        ? (chatMeta.gameNpcs as GameNpc[]).find((npc) => normalizeNpcAvatarName(npc.name) === normalizedName)
         : null;
       const targetNpc =
-        currentNpcs.find((npc) => normalizeTextForMatch(npc.name) === normalizedName) ??
+        currentNpcs.find((npc) => normalizeNpcAvatarName(npc.name) === normalizedName) ??
         metadataNpc ??
         ({
           id: buildPartyNpcId(displayName),
@@ -6775,7 +6777,7 @@ function GameSurfaceComponent({
         if (!result) return;
         await applyGeneratedAssets(result);
         const generated = result.generatedNpcAvatars.find(
-          (avatar) => normalizeTextForMatch(avatar.name) === normalizeTextForMatch(targetNpc.name),
+          (avatar) => normalizeNpcAvatarName(avatar.name) === normalizeNpcAvatarName(targetNpc.name),
         );
         if (generated) {
           clearFailedNpcAvatars([targetNpc.name]);

--- a/packages/client/src/lib/game-npc-avatar.ts
+++ b/packages/client/src/lib/game-npc-avatar.ts
@@ -1,7 +1,7 @@
 import { normalizeTextForMatch } from "@marinara-engine/shared";
 
 const NPC_AVATAR_REVISION_PARAM = "mariAvatarRevision";
-const TRAILING_NPC_REPUTATION_LABEL = /(?:devoted|allied|friendly|neutral|unfriendly|hostile|enemy)$/i;
+const TRAILING_NPC_REPUTATION_LABEL = /(?:^|[\s_-])(?:devoted|allied|friendly|neutral|unfriendly|hostile|enemy)$/i;
 let npcAvatarRevision = 0;
 
 export function cleanNpcAvatarDisplayName(value: string): string {
@@ -9,7 +9,7 @@ export function cleanNpcAvatarDisplayName(value: string): string {
 }
 
 export function normalizeNpcAvatarName(value: string): string {
-  return normalizeTextForMatch(cleanNpcAvatarDisplayName(value)).replace(/[_-]+/g, " ");
+  return normalizeTextForMatch(cleanNpcAvatarDisplayName(value).replace(/[_-]+/g, " "));
 }
 
 function splitHash(value: string): { base: string; hash: string } {

--- a/packages/client/src/lib/game-npc-avatar.ts
+++ b/packages/client/src/lib/game-npc-avatar.ts
@@ -1,5 +1,16 @@
+import { normalizeTextForMatch } from "@marinara-engine/shared";
+
 const NPC_AVATAR_REVISION_PARAM = "mariAvatarRevision";
+const TRAILING_NPC_REPUTATION_LABEL = /(?:devoted|allied|friendly|neutral|unfriendly|hostile|enemy)$/i;
 let npcAvatarRevision = 0;
+
+export function cleanNpcAvatarDisplayName(value: string): string {
+  return value.replace(TRAILING_NPC_REPUTATION_LABEL, "").trim() || value;
+}
+
+export function normalizeNpcAvatarName(value: string): string {
+  return normalizeTextForMatch(cleanNpcAvatarDisplayName(value)).replace(/[_-]+/g, " ");
+}
 
 function splitHash(value: string): { base: string; hash: string } {
   const hashIndex = value.indexOf("#");

--- a/packages/client/src/stores/game-mode.store.ts
+++ b/packages/client/src/stores/game-mode.store.ts
@@ -2,7 +2,11 @@
 // Store: Game Mode
 // ──────────────────────────────────────────────
 import { create } from "zustand";
-import { isSameNpcAvatarResource, withFreshNpcAvatarRevision } from "../lib/game-npc-avatar";
+import {
+  isSameNpcAvatarResource,
+  normalizeNpcAvatarName,
+  withFreshNpcAvatarRevision,
+} from "../lib/game-npc-avatar";
 import { api } from "../lib/api-client";
 import type {
   GameActiveState,
@@ -297,11 +301,11 @@ export const useGameModeStore = create<GameModeStore>((set) => ({
       const existingByName = new Map<string, string>();
       for (const existing of s.npcs) {
         if (existing.avatarUrl && existing.name) {
-          existingByName.set(existing.name.toLowerCase(), existing.avatarUrl);
+          existingByName.set(normalizeNpcAvatarName(existing.name), existing.avatarUrl);
         }
       }
       const merged = npcs.map((npc) => {
-        const preserved = existingByName.get((npc.name ?? "").toLowerCase());
+        const preserved = existingByName.get(normalizeNpcAvatarName(npc.name ?? ""));
         if (!preserved) return npc;
         if (!npc.avatarUrl || isSameNpcAvatarResource(npc.avatarUrl, preserved)) {
           return { ...npc, avatarUrl: preserved };
@@ -314,7 +318,8 @@ export const useGameModeStore = create<GameModeStore>((set) => ({
     set((s) => {
       let modified = false;
       const nextNpcs = s.npcs.map((npc) => {
-        const match = avatars.find((a) => a.name.toLowerCase() === npc.name.toLowerCase());
+        const npcName = normalizeNpcAvatarName(npc.name);
+        const match = avatars.find((avatar) => normalizeNpcAvatarName(avatar.name) === npcName);
         if (match) {
           const avatarUrl = withFreshNpcAvatarRevision(match.avatarUrl);
           modified = true;
@@ -324,7 +329,8 @@ export const useGameModeStore = create<GameModeStore>((set) => ({
       });
 
       for (const avatar of avatars) {
-        const exists = nextNpcs.some((npc) => npc.name.toLowerCase() === avatar.name.toLowerCase());
+        const avatarName = normalizeNpcAvatarName(avatar.name);
+        const exists = nextNpcs.some((npc) => normalizeNpcAvatarName(npc.name) === avatarName);
         if (!exists) {
           nextNpcs.push(buildTrackedNpcStub(avatar.name, withFreshNpcAvatarRevision(avatar.avatarUrl)));
           modified = true;

--- a/packages/server/src/db/file-backed-store.ts
+++ b/packages/server/src/db/file-backed-store.ts
@@ -69,6 +69,12 @@ type TableSnapshotManifest = {
   tables: Record<string, number>;
 };
 
+type FileTransactionContext = {
+  snapshots: Map<string, Row[]>;
+  dirtyTables: Set<string>;
+  flushed: boolean;
+};
+
 export type QuarantinedStorageTable = {
   table: string;
   files: Array<{
@@ -855,11 +861,14 @@ class FileTableStore {
   private beforeExitHandler: (() => void) | null = null;
   private loadedManifest: TableSnapshotManifest | null = null;
   // Rollback state for the active transaction lives in this AsyncLocalStorage so
-  // it is bound to the transaction's own async call path. A concurrent
-  // non-transactional write that interleaves during an await runs OUTSIDE this
-  // context and is therefore never recorded — so it survives a rollback. See
-  // transaction() / recordTxMutation().
-  private readonly txContext = new AsyncLocalStorage<{ snapshots: Map<string, Row[]>; dirtyTables: Set<string> }>();
+  // it is bound to the transaction's own async call path. Writes from other
+  // async call paths wait for the transaction to finish and are therefore never
+  // captured by (or reverted with) its rollback snapshots.
+  private readonly txContext = new AsyncLocalStorage<FileTransactionContext>();
+  private transactionQueue: Promise<void> = Promise.resolve();
+  private activeTransactionCount = 0;
+  private transactionIdleWaiters = new Set<() => void>();
+  private pendingTransactionFlush = false;
   private quarantinedTables: QuarantinedStorageTable[] = [];
 
   constructor(
@@ -893,19 +902,31 @@ class FileTableStore {
   async transaction<T>(fn: (tx: FileNativeDB) => Promise<T> | T, tx: FileNativeDB): Promise<T> {
     // Copy-on-write rollback, isolated to this transaction's async context:
     // instead of cloning every table up front (O(total rows) per call, on the
-    // per-turn setMemories hot path) and restoring the whole map on throw (which
-    // also dropped concurrent writes), snapshot each table only on its first
-    // mutation by THIS transaction and restore only those. Mutations made on
-    // other async call paths (concurrent non-transactional writes) run outside
-    // the context, are never recorded, and so survive a rollback.
+    // per-turn setMemories hot path), snapshot each table only on its first
+    // mutation by THIS transaction and restore only those. Other writes wait for
+    // this transaction, then run against its committed or restored state.
     if (this.txContext.getStore()) {
       // Nested call: run inside the outer transaction's context so the whole
       // nest rolls back together; the outermost owns snapshot/restore.
       return await fn(tx);
     }
-    const ctx = { snapshots: new Map<string, Row[]>(), dirtyTables: new Set<string>() };
+
+    let releaseTransaction!: () => void;
+    const previousTransaction = this.transactionQueue;
+    this.transactionQueue = new Promise<void>((resolve) => {
+      releaseTransaction = resolve;
+    });
+    await previousTransaction;
+    if (this.activeFlush) await this.activeFlush;
+
+    const ctx: FileTransactionContext = {
+      snapshots: new Map<string, Row[]>(),
+      dirtyTables: new Set<string>(),
+      flushed: false,
+    };
     const dirtySnapshot = this.dirty;
     const dirtyTablesSnapshot = new Set(this.dirtyTables);
+    this.activeTransactionCount++;
 
     try {
       return await this.txContext.run(ctx, () => fn(tx));
@@ -916,7 +937,38 @@ class FileTableStore {
       }
       this.dirty = dirtySnapshot;
       this.dirtyTables = dirtyTablesSnapshot;
+      if (ctx.flushed) {
+        this.dirty = true;
+        for (const tableName of ctx.dirtyTables) this.dirtyTables.add(tableName);
+        try {
+          await this.txContext.run(ctx, () => this.flush(true, true));
+        } catch (rollbackError) {
+          throw new AggregateError([err, rollbackError], "File-storage transaction and durable rollback both failed");
+        }
+      }
       throw err;
+    } finally {
+      this.activeTransactionCount--;
+      if (this.activeTransactionCount === 0) {
+        for (const resolve of this.transactionIdleWaiters) resolve();
+        this.transactionIdleWaiters.clear();
+      }
+      releaseTransaction();
+      if (this.pendingTransactionFlush) {
+        this.pendingTransactionFlush = false;
+        void this.flush();
+      }
+    }
+  }
+
+  private async waitForTransactions(): Promise<void> {
+    if (this.activeTransactionCount === 0) return;
+    await new Promise<void>((resolve) => this.transactionIdleWaiters.add(resolve));
+  }
+
+  private async waitForWritableTurn(): Promise<void> {
+    if (this.activeTransactionCount > 0 && !this.txContext.getStore()) {
+      await this.waitForTransactions();
     }
   }
 
@@ -950,6 +1002,7 @@ class FileTableStore {
       values: (rows) => {
         const runInsert = (onConflict?: { target: unknown; set: Row }) =>
           executable(async () => {
+            await this.waitForWritableTurn();
             const conflictColumns = normalizeConflictTargets(onConflict?.target);
             const inputRows = Array.isArray(rows) ? rows : [rows];
             const target = this.rows(meta.name);
@@ -991,6 +1044,7 @@ class FileTableStore {
       set: (patch) => {
         const runUpdate = (condition?: Condition) =>
           executable(async () => {
+            await this.waitForWritableTurn();
             const target = this.rows(meta.name);
             const changedIndexes: number[] = [];
             const nextRows = target.map((row, index) => {
@@ -1024,6 +1078,7 @@ class FileTableStore {
     const meta = getMeta(table);
     const runDelete = (condition?: Condition) =>
       executable(async () => {
+        await this.waitForWritableTurn();
         this.deleteWhere(meta, condition);
       });
     const builder = runDelete() as DeleteBuilder;
@@ -1031,10 +1086,18 @@ class FileTableStore {
     return builder;
   }
 
-  async flush(force = false) {
+  async flush(force = false, throwOnError = false) {
+    const transactionContext = this.txContext.getStore();
+    if (this.activeTransactionCount > 0 && !(force && transactionContext)) {
+      this.pendingTransactionFlush = true;
+      if (transactionContext) return;
+      await this.waitForTransactions();
+    }
+    if (transactionContext && force) transactionContext.flushed = true;
     if (this.activeFlush) {
       await this.activeFlush;
-      if (this.dirty || this.dirtyTables.size > 0) await this.flush(force);
+      if (this.dirty || this.dirtyTables.size > 0) await this.flush(force, throwOnError);
+      else if (throwOnError && this.lastFlushError) throw this.lastFlushError;
       return;
     }
     if (!force && !this.dirty && this.dirtyTables.size === 0) return;
@@ -1064,6 +1127,7 @@ class FileTableStore {
     } finally {
       if (this.activeFlush === flush) this.activeFlush = null;
     }
+    if (throwOnError && this.lastFlushError) throw this.lastFlushError;
   }
 
   async close() {
@@ -1138,12 +1202,12 @@ class FileTableStore {
       let changed = false;
       for (const row of this.rows(childMeta.name)) {
         if (row[relation.childKey] != null && deletedValues.has(row[relation.childKey])) {
+          if (!changed) this.recordTxMutation(childMeta.name);
           row[relation.childKey] = null;
           changed = true;
         }
       }
       if (changed) {
-        this.recordTxMutation(childMeta.name);
         this.markDirty(childMeta.name);
       }
     }
@@ -1367,7 +1431,7 @@ export async function createFileNativeDB(testHooks?: FileNativeStoreTestHooks): 
 
   const controller: FileNativeStoreController = {
     rootDir,
-    flush: () => store.flush(true),
+    flush: () => store.flush(true, true),
     close: () => store.close(),
     getQuarantinedTables: () => store.getQuarantinedTables(),
   };

--- a/packages/server/src/routes/backup.routes.ts
+++ b/packages/server/src/routes/backup.routes.ts
@@ -71,6 +71,22 @@ const ZIP_LOCAL_FILE_HEADER_SIGNATURE = 0x04034b50;
 const ZIP_EOCD_MIN_SIZE = 22;
 const ZIP_EOCD_MAX_COMMENT_BYTES = 0xffff;
 const ZIP_ENCRYPTED_FLAG = 0x0001;
+let profileImportLifecycleTail = Promise.resolve();
+
+/** Serialize database replacement, asset promotion, and failure recovery as one import lifecycle. */
+async function withProfileImportLifecycleLock<T>(task: () => Promise<T>): Promise<T> {
+  const predecessor = profileImportLifecycleTail;
+  let release: () => void = () => undefined;
+  profileImportLifecycleTail = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+  await predecessor;
+  try {
+    return await task();
+  } finally {
+    release();
+  }
+}
 
 function normalizeLorebookScope(value: unknown): { mode: "all" | "disabled" | "specific"; chatIds: string[] } {
   if (!value || typeof value !== "object") return { mode: "all", chatIds: [] };
@@ -749,62 +765,76 @@ async function importProfileStorageSnapshot(
     });
   };
 
-  let files = 0;
-  let committed = false;
-  try {
-    await app.db.transaction(async (tx) => {
-      for (const tableName of FILE_BACKED_TABLES) {
-        const table = profileTableObjects.get(tableName);
-        const rows = snapshot.tables[tableName];
-        if (!table || !Array.isArray(rows) || rows.length === 0) {
-          tableCounts[tableName] = 0;
-          continue;
-        }
-
-        emit("tables", `Importing ${tableName.replace(/_/g, " ")}`);
-        for (const row of rows) {
-          const cleanRow = { ...row };
-          if (tableName === "api_connections") cleanRow.apiKeyEncrypted = "";
-          const insert = tx.insert(table as any).values(cleanRow as any) as any;
-          const conflictTarget = schemaPrimaryKeyColumn(table);
-          if (conflictTarget) {
-            // Preserve live secrets on rows that still exist: the export redacts secret
-            // columns, so upserting the blanks would wipe them unrecoverably. The fresh
-            // insert above still carries the blanks (no prior secret to keep).
-            await insert.onConflictDoUpdate({ target: conflictTarget, set: buildProfileUpdateSet(tableName, cleanRow) });
-          } else {
-            await insert;
+  return withProfileImportLifecycleLock(async () => {
+    let files = 0;
+    let committed = false;
+    let rollbackFailed = false;
+    try {
+      await app.db.transaction(async (tx) => {
+        for (const tableName of FILE_BACKED_TABLES) {
+          const table = profileTableObjects.get(tableName);
+          const rows = snapshot.tables[tableName];
+          if (!table || !Array.isArray(rows) || rows.length === 0) {
+            tableCounts[tableName] = 0;
+            continue;
           }
-          completedItems++;
-          tableCounts[tableName] = (tableCounts[tableName] ?? 0) + 1;
+
           emit("tables", `Importing ${tableName.replace(/_/g, " ")}`);
+          for (const row of rows) {
+            const cleanRow = { ...row };
+            if (tableName === "api_connections") cleanRow.apiKeyEncrypted = "";
+            const insert = tx.insert(table as any).values(cleanRow as any) as any;
+            const conflictTarget = schemaPrimaryKeyColumn(table);
+            if (conflictTarget) {
+              // Preserve live secrets on rows that still exist: the export redacts secret
+              // columns, so upserting the blanks would wipe them unrecoverably. The fresh
+              // insert above still carries the blanks (no prior secret to keep).
+              await insert.onConflictDoUpdate({
+                target: conflictTarget,
+                set: buildProfileUpdateSet(tableName, cleanRow),
+              });
+            } else {
+              await insert;
+            }
+            completedItems++;
+            tableCounts[tableName] = (tableCounts[tableName] ?? 0) + 1;
+            emit("tables", `Importing ${tableName.replace(/_/g, " ")}`);
+          }
+        }
+
+        await promoteStagedProfileAssets(stagedAssets);
+        for (const asset of stagedAssets.assets) {
+          files++;
+          completedItems++;
+          emit("files", `Restoring ${asset.path}`, files);
+        }
+        await flushDB();
+      });
+      committed = true;
+      return buildProfileImportStats(tableCounts, files);
+    } catch (error) {
+      try {
+        await rollbackPromotedProfileAssets(stagedAssets);
+      } catch (rollbackError) {
+        rollbackFailed = true;
+        logger.error(
+          rollbackError,
+          "[backup] Asset rollback failed; preserving recovery files at %s",
+          stagedAssets.rootDir,
+        );
+        throw new AggregateError([error, rollbackError], "Profile import and asset rollback both failed");
+      }
+      throw error;
+    } finally {
+      if (!rollbackFailed) {
+        try {
+          await cleanupStagedProfileAssets(stagedAssets);
+        } catch (cleanupError) {
+          if (committed) logger.warn(cleanupError, "[backup] Failed to remove profile import staging files");
         }
       }
-
-      await promoteStagedProfileAssets(stagedAssets);
-      for (const asset of stagedAssets.assets) {
-        files++;
-        completedItems++;
-        emit("files", `Restoring ${asset.path}`, files);
-      }
-      await flushDB();
-    });
-    committed = true;
-    return buildProfileImportStats(tableCounts, files);
-  } catch (error) {
-    try {
-      await rollbackPromotedProfileAssets(stagedAssets);
-    } catch (rollbackError) {
-      throw new AggregateError([error, rollbackError], "Profile import and asset rollback both failed");
     }
-    throw error;
-  } finally {
-    try {
-      await cleanupStagedProfileAssets(stagedAssets);
-    } catch (cleanupError) {
-      if (committed) logger.warn(cleanupError, "[backup] Failed to remove profile import staging files");
-    }
-  }
+  });
 }
 
 async function buildProfileExportEnvelope(

--- a/packages/server/src/routes/backup.routes.ts
+++ b/packages/server/src/routes/backup.routes.ts
@@ -28,6 +28,15 @@ import { flushDB } from "../db/connection.js";
 import { requirePrivilegedAccess } from "../middleware/privileged-gate.js";
 import { assertInsideDir } from "../utils/security.js";
 import { logger } from "../lib/logger.js";
+import {
+  ProfileImportAssetValidationError,
+  cleanupStagedProfileAssets,
+  promoteStagedProfileAssets,
+  rollbackPromotedProfileAssets,
+  stageProfileImportAssets,
+  type ProfileImportAssetInput,
+  type StagedProfileImportAssets,
+} from "../services/import/profile-import-assets.js";
 
 /** Directories inside DATA_DIR that should be included in every backup. */
 const BACKUP_DIRS = [
@@ -653,12 +662,79 @@ function countLegacyProfileImportItems(data: Record<string, any>) {
   }, 0);
 }
 
+function validateProfileStorageTableInputs(snapshot: ProfileStorageSnapshot) {
+  for (const tableName of FILE_BACKED_TABLES) {
+    const rows = snapshot.tables[tableName];
+    if (rows === undefined) continue;
+    if (!Array.isArray(rows)) {
+      throw new ProfileImportRequestError(`Profile table ${tableName} is not an array.`);
+    }
+
+    const table = profileTableObjects.get(tableName);
+    if (!table) throw new ProfileImportRequestError(`Profile table ${tableName} is not supported.`);
+    const primaryKey = schemaPrimaryKeyColumn(table);
+    for (const row of rows) {
+      if (!row || typeof row !== "object" || Array.isArray(row)) {
+        throw new ProfileImportRequestError(`Profile table ${tableName} contains an invalid row.`);
+      }
+      if (primaryKey) {
+        const primaryValue = row[primaryKey.key];
+        if (primaryValue === undefined || primaryValue === null || primaryValue === "") {
+          throw new ProfileImportRequestError(
+            `Profile table ${tableName} contains a row without ${primaryKey.key}.`,
+          );
+        }
+      }
+    }
+  }
+}
+
+function buildProfileImportAssetInputs(
+  snapshot: ProfileStorageSnapshot,
+  readAsset: ProfileAssetReader | undefined,
+): ProfileImportAssetInput[] {
+  if (!Array.isArray(snapshot.files)) return [];
+  return snapshot.files.flatMap((file) => {
+    const safePath = normalizeProfileAssetPath(file?.path);
+    if (!safePath) return [];
+    const expectedSize = getProfileAssetManifestSize(file, safePath);
+    assertProfileArchiveEntryLimit(safePath, expectedSize);
+    return [
+      {
+        path: safePath,
+        expectedSize,
+        read: () =>
+          typeof file.data === "string"
+            ? Buffer.from(file.data, "base64")
+            : readAsset
+              ? readAsset(safePath)
+              : null,
+      },
+    ];
+  });
+}
+
 async function importProfileStorageSnapshot(
   app: FastifyInstance,
   snapshot: ProfileStorageSnapshot,
   onProgress?: ProfileImportProgressReporter,
   readAsset?: ProfileAssetReader,
 ) {
+  validateProfileStorageTableInputs(snapshot);
+  let stagedAssets: StagedProfileImportAssets;
+  try {
+    stagedAssets = await stageProfileImportAssets(
+      getDataDir(),
+      buildProfileImportAssetInputs(snapshot, readAsset),
+      PROFILE_ARCHIVE_TOTAL_UNCOMPRESSED_LIMIT_BYTES,
+    );
+  } catch (error) {
+    if (error instanceof ProfileImportAssetValidationError) {
+      throw new ProfileImportRequestError(error.message);
+    }
+    throw error;
+  }
+
   const totalItems = Math.max(1, countProfileStorageSnapshotItems(snapshot));
   let completedItems = 0;
   const tableCounts: Record<string, number> = {};
@@ -673,61 +749,62 @@ async function importProfileStorageSnapshot(
     });
   };
 
-  for (const tableName of FILE_BACKED_TABLES) {
-    const table = profileTableObjects.get(tableName);
-    const rows = snapshot.tables[tableName];
-    if (!table || !Array.isArray(rows) || rows.length === 0) {
-      tableCounts[tableName] = 0;
-      continue;
-    }
-
-    emit("tables", `Importing ${tableName.replace(/_/g, " ")}`);
-    for (const row of rows) {
-      const cleanRow = { ...row };
-      if (tableName === "api_connections") cleanRow.apiKeyEncrypted = "";
-      const insert = app.db.insert(table as any).values(cleanRow as any) as any;
-      const conflictTarget = schemaPrimaryKeyColumn(table);
-      if (conflictTarget) {
-        // Preserve live secrets on rows that still exist: the export redacts secret
-        // columns, so upserting the blanks would wipe them unrecoverably. The fresh
-        // insert above still carries the blanks (no prior secret to keep).
-        await insert.onConflictDoUpdate({ target: conflictTarget, set: buildProfileUpdateSet(tableName, cleanRow) });
-      } else {
-        await insert;
-      }
-      completedItems++;
-      tableCounts[tableName] = (tableCounts[tableName] ?? 0) + 1;
-      emit("tables", `Importing ${tableName.replace(/_/g, " ")}`);
-    }
-  }
-
   let files = 0;
-  let restoredFileBytes = 0;
-  if (Array.isArray(snapshot.files)) {
-    for (const file of snapshot.files) {
-      const safePath = normalizeProfileAssetPath(file?.path);
-      if (!safePath) continue;
-      const expectedSize = getProfileAssetManifestSize(file, safePath);
-      assertProfileArchiveEntryLimit(safePath, expectedSize);
-      const buffer =
-        typeof file.data === "string" ? Buffer.from(file.data, "base64") : readAsset ? await readAsset(safePath) : null;
-      if (!buffer) continue;
-      restoredFileBytes += expectedSize;
-      assertProfileArchiveTotalLimit(restoredFileBytes);
-      if (buffer.length !== expectedSize) {
-        throw new ProfileImportRequestError(`Profile asset ${safePath} does not match its manifest size.`);
+  let committed = false;
+  try {
+    await app.db.transaction(async (tx) => {
+      for (const tableName of FILE_BACKED_TABLES) {
+        const table = profileTableObjects.get(tableName);
+        const rows = snapshot.tables[tableName];
+        if (!table || !Array.isArray(rows) || rows.length === 0) {
+          tableCounts[tableName] = 0;
+          continue;
+        }
+
+        emit("tables", `Importing ${tableName.replace(/_/g, " ")}`);
+        for (const row of rows) {
+          const cleanRow = { ...row };
+          if (tableName === "api_connections") cleanRow.apiKeyEncrypted = "";
+          const insert = tx.insert(table as any).values(cleanRow as any) as any;
+          const conflictTarget = schemaPrimaryKeyColumn(table);
+          if (conflictTarget) {
+            // Preserve live secrets on rows that still exist: the export redacts secret
+            // columns, so upserting the blanks would wipe them unrecoverably. The fresh
+            // insert above still carries the blanks (no prior secret to keep).
+            await insert.onConflictDoUpdate({ target: conflictTarget, set: buildProfileUpdateSet(tableName, cleanRow) });
+          } else {
+            await insert;
+          }
+          completedItems++;
+          tableCounts[tableName] = (tableCounts[tableName] ?? 0) + 1;
+          emit("tables", `Importing ${tableName.replace(/_/g, " ")}`);
+        }
       }
-      const outputPath = assertInsideDir(getDataDir(), join(getDataDir(), ...safePath.split("/")));
-      await mkdir(dirname(outputPath), { recursive: true });
-      await writeFile(outputPath, buffer);
-      files++;
-      completedItems++;
-      emit("files", `Restoring ${safePath}`, files);
+
+      await promoteStagedProfileAssets(stagedAssets);
+      for (const asset of stagedAssets.assets) {
+        files++;
+        completedItems++;
+        emit("files", `Restoring ${asset.path}`, files);
+      }
+      await flushDB();
+    });
+    committed = true;
+    return buildProfileImportStats(tableCounts, files);
+  } catch (error) {
+    try {
+      await rollbackPromotedProfileAssets(stagedAssets);
+    } catch (rollbackError) {
+      throw new AggregateError([error, rollbackError], "Profile import and asset rollback both failed");
+    }
+    throw error;
+  } finally {
+    try {
+      await cleanupStagedProfileAssets(stagedAssets);
+    } catch (cleanupError) {
+      if (committed) logger.warn(cleanupError, "[backup] Failed to remove profile import staging files");
     }
   }
-
-  await flushDB();
-  return buildProfileImportStats(tableCounts, files);
 }
 
 async function buildProfileExportEnvelope(

--- a/packages/server/src/routes/connections.routes.ts
+++ b/packages/server/src/routes/connections.routes.ts
@@ -25,6 +25,7 @@ import { fetchOpenAIChatGPTModels, getOpenAIChatGPTAuth } from "../services/llm/
 import { fetchGrokCliModels } from "../services/llm/providers/grok-subscription.provider.js";
 import { buildGoogleVertexModelUrl, googleAuthHeadersForVertex } from "../services/llm/providers/google.provider.js";
 import { resolveConnectionImageDefaults } from "../services/image/image-generation-defaults.js";
+import { buildVeniceApiUrl, normalizeVeniceImageModels } from "../services/image/venice-image.js";
 import { isImageLocalUrlsEnabled, isProviderLocalUrlsEnabled } from "../config/runtime-config.js";
 import { logDebugOverride } from "../lib/logger.js";
 import {
@@ -812,6 +813,31 @@ export async function connectionsRoutes(app: FastifyInstance) {
           });
         }
         return { models: normalizeModelsResponse("openrouter", json) };
+      }
+
+      if (conn.provider === "image_generation" && imageSource === "venice") {
+        const res = await safeFetch(buildVeniceApiUrl(baseUrl, "models"), {
+          headers,
+          policy: localUrlPolicyForProvider(conn.provider, imageSource),
+          maxResponseBytes: 5 * 1024 * 1024,
+          decodeCompressedResponse: true,
+        });
+        if (!res.ok) {
+          const body = await res.text();
+          return reply.status(502).send({
+            error: `Venice returned ${res.status}: ${sanitizeProviderBody(body)}`,
+          });
+        }
+        const text = await res.text();
+        let json: unknown;
+        try {
+          json = JSON.parse(text);
+        } catch {
+          return reply.status(502).send({
+            error: `Failed to fetch models: ${sanitizeProviderBody(text)}`,
+          });
+        }
+        return { models: normalizeVeniceImageModels(json) };
       }
 
       if (conn.provider === "image_generation" && imageSource === "horde") {

--- a/packages/server/src/routes/game.routes.ts
+++ b/packages/server/src/routes/game.routes.ts
@@ -32,7 +32,10 @@ import { extractLeadingThinkingBlocks } from "../services/llm/inline-thinking.js
 import { type ChatCompletionResult, type ChatMessage, type ChatOptions } from "../services/llm/base-provider.js";
 import { isDiceNotation, rollDice } from "../services/game/dice.service.js";
 import { jsonishLooksTruncated, parseGameJsonish } from "../services/game/jsonish.js";
-import { resolveInitialGameGmConnectionId } from "../services/game/initial-game-setup.js";
+import {
+  GAME_SETUP_GENERATION_TIMEOUT_MS,
+  resolveInitialGameGmConnectionId,
+} from "../services/game/initial-game-setup.js";
 import { validateTransition } from "../services/game/state-machine.service.js";
 import {
   buildSetupPrompt,
@@ -6384,7 +6387,7 @@ export async function gameRoutes(app: FastifyInstance) {
       maxTokens: Math.max(GAME_SETUP_MIN_OUTPUT_TOKENS, setupGenerationParameters?.maxTokens ?? 0),
       maxTokensOverride: conn.maxTokensOverride,
     });
-    const setupAbort = createResponseAbortTracker(reply, GAME_GENERATION_TIMEOUT_MS, "Game setup");
+    const setupAbort = createResponseAbortTracker(reply, GAME_SETUP_GENERATION_TIMEOUT_MS, "Game setup");
     const setupOverrides: Partial<ChatOptions> = {
       maxTokens: setupMaxTokens,
       stream: streaming,

--- a/packages/server/src/routes/generate.routes.ts
+++ b/packages/server/src/routes/generate.routes.ts
@@ -7226,6 +7226,7 @@ export async function generateRoutes(app: FastifyInstance) {
                               imageEndpointId: imgConnFull.imageEndpointId || undefined,
                               comfyWorkflow: imgConnFull.comfyuiWorkflow || undefined,
                               imageDefaults,
+                              debugMode: input.debugMode,
                               fallback: imageFallback,
                               onFallback,
                             });
@@ -7904,6 +7905,7 @@ export async function generateRoutes(app: FastifyInstance) {
                         comfyWorkflow: imgConnFull.comfyuiWorkflow || undefined,
                         imageDefaults,
                         referenceImages: illustratorRefImages,
+                        debugMode: input.debugMode,
                         fallback: imageFallback,
                         onFallback,
                       });

--- a/packages/server/src/routes/noodle.routes.ts
+++ b/packages/server/src/routes/noodle.routes.ts
@@ -1251,6 +1251,7 @@ async function generateNoodlePostImage(input: {
         comfyWorkflow: input.imageConnection.comfyuiWorkflow || undefined,
         imageDefaults,
         referenceImages,
+        debugMode: input.debugMode,
         fallback: imageFallback,
       }),
     (error, attempt, maxAttempts) => {

--- a/packages/server/src/services/game/initial-game-setup.ts
+++ b/packages/server/src/services/game/initial-game-setup.ts
@@ -1,3 +1,5 @@
+export const GAME_SETUP_GENERATION_TIMEOUT_MS = 500 * 1000;
+
 export function resolveInitialGameGmConnectionId(
   explicitConnectionId: string | null | undefined,
   chatConnectionId: string | null | undefined,

--- a/packages/server/src/services/image/image-generation.ts
+++ b/packages/server/src/services/image/image-generation.ts
@@ -25,7 +25,7 @@ import {
 } from "@marinara-engine/shared";
 import { isImageLocalUrlsEnabled } from "../../config/runtime-config.js";
 import { generateRunPodComfyUI } from "./runpod-comfyui.service.js";
-import { logger } from "../../lib/logger.js";
+import { logger, logDebugOverride } from "../../lib/logger.js";
 import { assertInsideDir, normalizeLoopbackUrl, safeFetch, validateOutboundUrl } from "../../utils/security.js";
 import { notifyGenerationFallback, type GenerationFallbackNotifier } from "../generation/fallback-notification.js";
 import {
@@ -106,6 +106,8 @@ export interface ImageGenRequest {
   transparentBackground?: boolean;
   /** Optional caller-owned abort signal for cancelling long image requests. */
   signal?: AbortSignal;
+  /** Emit the final provider request even when the global log level is above debug. */
+  debugMode?: boolean;
   /** Called immediately before a configured fallback connection is attempted. */
   onFallback?: GenerationFallbackNotifier;
   /** Optional one-shot backup connection used only when the primary image request fails. */
@@ -935,6 +937,12 @@ async function generateXAI(baseUrl: string, apiKey: string, request: ImageGenReq
 }
 
 async function generateVenice(baseUrl: string, apiKey: string, request: ImageGenRequest): Promise<ImageGenResult> {
+  const body = buildVeniceImageRequest(request);
+  logDebugOverride(
+    request.debugMode === true,
+    "[debug/image/venice] final request payload:\n%s",
+    JSON.stringify(body, null, 2),
+  );
   const resp = await imageFetch(
     buildVeniceApiUrl(baseUrl, "image/generate"),
     {
@@ -943,7 +951,7 @@ async function generateVenice(baseUrl: string, apiKey: string, request: ImageGen
         "Content-Type": "application/json",
         Authorization: `Bearer ${apiKey}`,
       },
-      body: JSON.stringify(buildVeniceImageRequest(request)),
+      body: JSON.stringify(body),
       signal: imageRequestSignal(request),
     },
     { allowLocal: request.allowLocalUrls },

--- a/packages/server/src/services/image/image-generation.ts
+++ b/packages/server/src/services/image/image-generation.ts
@@ -28,6 +28,11 @@ import { generateRunPodComfyUI } from "./runpod-comfyui.service.js";
 import { logger } from "../../lib/logger.js";
 import { assertInsideDir, normalizeLoopbackUrl, safeFetch, validateOutboundUrl } from "../../utils/security.js";
 import { notifyGenerationFallback, type GenerationFallbackNotifier } from "../generation/fallback-notification.js";
+import {
+  buildVeniceApiUrl,
+  buildVeniceImageRequest,
+  parseVeniceImageResponse,
+} from "./venice-image.js";
 
 // sharp is an optional native module (no prebuilds on some platforms like Termux).
 // Lazy-load so the server boots even when sharp is missing. The Draw Things img2img
@@ -145,6 +150,7 @@ const EXPLICIT_IMAGE_SOURCES = new Set([
   "novelai",
   "horde",
   "xai",
+  "venice",
   "comfyui",
   "automatic1111",
   "runpod_comfyui",
@@ -224,6 +230,8 @@ export async function generateImage(
           return generateHorde(normalizedBaseUrl, apiKey, scopedRequest);
         case "xai":
           return generateXAI(normalizedBaseUrl, apiKey, scopedRequest);
+        case "venice":
+          return generateVenice(normalizedBaseUrl, apiKey, scopedRequest);
         case "comfyui":
           return generateComfyUI(normalizedBaseUrl, scopedRequest);
         case "runpod_comfyui": {
@@ -924,6 +932,35 @@ async function generateXAI(baseUrl: string, apiKey: string, request: ImageGenReq
   if (result?.url) return downloadImageUrl(result.url, request.allowLocalUrls, request.signal);
 
   throw new Error("No image data in xAI response");
+}
+
+async function generateVenice(baseUrl: string, apiKey: string, request: ImageGenRequest): Promise<ImageGenResult> {
+  const resp = await imageFetch(
+    buildVeniceApiUrl(baseUrl, "image/generate"),
+    {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${apiKey}`,
+      },
+      body: JSON.stringify(buildVeniceImageRequest(request)),
+      signal: imageRequestSignal(request),
+    },
+    { allowLocal: request.allowLocalUrls },
+  );
+
+  const responseText = await resp.text();
+  if (!resp.ok) {
+    throw new Error(`Venice image generation failed (${resp.status}): ${sanitizeErrorText(responseText)}`);
+  }
+
+  let response: unknown;
+  try {
+    response = JSON.parse(responseText);
+  } catch {
+    throw new Error("Venice image generation returned invalid JSON");
+  }
+  return parseVeniceImageResponse(response);
 }
 
 async function generateNanoGPT(baseUrl: string, apiKey: string, request: ImageGenRequest): Promise<ImageGenResult> {

--- a/packages/server/src/services/image/venice-image.ts
+++ b/packages/server/src/services/image/venice-image.ts
@@ -142,7 +142,7 @@ export function normalizeVeniceImageModels(value: unknown): Array<{ id: string; 
   if (!isRecord(value) || !Array.isArray(value.data)) return [];
   return value.data
     .map((entry) => {
-      if (!isRecord(entry) || (typeof entry.type === "string" && entry.type !== "image")) return null;
+      if (!isRecord(entry) || entry.type !== "image") return null;
       const id = typeof entry.id === "string" ? entry.id.trim() : "";
       const spec = isRecord(entry.model_spec) ? entry.model_spec : null;
       const name = spec && typeof spec.name === "string" ? spec.name.trim() : "";

--- a/packages/server/src/services/image/venice-image.ts
+++ b/packages/server/src/services/image/venice-image.ts
@@ -1,0 +1,152 @@
+const VENICE_MAX_DIMENSION = 1280;
+const VENICE_MAX_IMAGE_BYTES = 30 * 1024 * 1024;
+
+const VENICE_ASPECT_RATIOS = [
+  ["1:1", 1],
+  ["16:9", 16 / 9],
+  ["9:16", 9 / 16],
+  ["4:3", 4 / 3],
+  ["3:4", 3 / 4],
+  ["3:2", 3 / 2],
+  ["2:3", 2 / 3],
+] as const;
+
+type VeniceImageRequestInput = {
+  model?: string;
+  prompt: string;
+  negativePrompt?: string;
+  width?: number;
+  height?: number;
+};
+
+export type VeniceImageResult = {
+  base64: string;
+  mimeType: string;
+  ext: string;
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === "object" && !Array.isArray(value);
+}
+
+function veniceAspectRatio(width: number, height: number): string {
+  const ratio = width / height;
+  return VENICE_ASPECT_RATIOS.reduce((best, candidate) =>
+    Math.abs(candidate[1] - ratio) < Math.abs(best[1] - ratio) ? candidate : best,
+  )[0];
+}
+
+function scaledVeniceDimensions(width: number, height: number): { width: number; height: number } {
+  const scale = Math.min(1, VENICE_MAX_DIMENSION / Math.max(width, height));
+  const roundDimension = (value: number) => Math.max(8, Math.round((value * scale) / 8) * 8);
+  return { width: roundDimension(width), height: roundDimension(height) };
+}
+
+function veniceResolution(width: number, height: number): "1K" | "2K" | "4K" {
+  const largestDimension = Math.max(width, height);
+  if (largestDimension >= 3072) return "4K";
+  if (largestDimension >= 1536) return "2K";
+  return "1K";
+}
+
+function isVeniceResolutionTierModel(model: string): boolean {
+  return /^(?:gpt-image-2|nano-banana-(?:2|pro))(?:$|-)/i.test(model);
+}
+
+function isVeniceAspectRatioModel(model: string): boolean {
+  return /^(?:qwen-image-2)(?:$|-)/i.test(model);
+}
+
+export function buildVeniceApiUrl(baseUrl: string, resource: "models" | "image/generate"): string {
+  const parsed = new URL(baseUrl.replace(/\/+$/, ""));
+  let path = parsed.pathname.replace(/\/+$/, "");
+  path = path.replace(/\/(?:models|image\/generate)$/i, "");
+
+  if (!path || path === "/") path = "/api/v1";
+  else if (path === "/api") path = "/api/v1";
+
+  parsed.pathname = `${path}/${resource}`.replace(/\/{2,}/g, "/");
+  parsed.search = "";
+  parsed.hash = "";
+  if (resource === "models") parsed.searchParams.set("type", "image");
+  return parsed.toString();
+}
+
+export function buildVeniceImageRequest(input: VeniceImageRequestInput): Record<string, unknown> {
+  const model = input.model?.trim();
+  if (!model) throw new Error("Venice image generation requires a model");
+
+  const width = Number.isFinite(input.width) && Number(input.width) > 0 ? Number(input.width) : 1024;
+  const height = Number.isFinite(input.height) && Number(input.height) > 0 ? Number(input.height) : 1024;
+  const body: Record<string, unknown> = {
+    model,
+    prompt: input.prompt.trim(),
+    format: "webp",
+    return_binary: false,
+    variants: 1,
+  };
+
+  if (input.negativePrompt?.trim()) body.negative_prompt = input.negativePrompt.trim();
+
+  if (isVeniceResolutionTierModel(model)) {
+    body.aspect_ratio = veniceAspectRatio(width, height);
+    body.resolution = veniceResolution(width, height);
+  } else if (isVeniceAspectRatioModel(model)) {
+    body.aspect_ratio = veniceAspectRatio(width, height);
+  } else {
+    Object.assign(body, scaledVeniceDimensions(width, height));
+  }
+
+  return body;
+}
+
+function normalizeBase64(value: string): string {
+  const compact = value.replace(/^data:image\/[a-z0-9.+-]+;base64,/i, "").replace(/\s+/g, "");
+  const unpadded = compact.replace(/=+$/, "");
+  if (!unpadded || /[^A-Za-z0-9+/]/.test(unpadded) || unpadded.length % 4 === 1) {
+    throw new Error("Venice returned invalid base64 image data");
+  }
+  return `${unpadded}${"=".repeat((4 - (unpadded.length % 4)) % 4)}`;
+}
+
+function detectImageType(buffer: Buffer): Pick<VeniceImageResult, "mimeType" | "ext"> | null {
+  if (buffer.subarray(0, 8).equals(Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]))) {
+    return { mimeType: "image/png", ext: "png" };
+  }
+  if (buffer[0] === 0xff && buffer[1] === 0xd8 && buffer[2] === 0xff) {
+    return { mimeType: "image/jpeg", ext: "jpg" };
+  }
+  if (buffer.subarray(0, 4).toString("ascii") === "RIFF" && buffer.subarray(8, 12).toString("ascii") === "WEBP") {
+    return { mimeType: "image/webp", ext: "webp" };
+  }
+  return null;
+}
+
+export function parseVeniceImageResponse(value: unknown): VeniceImageResult {
+  const encoded = isRecord(value) && Array.isArray(value.images) ? value.images[0] : null;
+  if (typeof encoded !== "string" || !encoded.trim()) {
+    throw new Error("Venice response did not contain image data");
+  }
+
+  const buffer = Buffer.from(normalizeBase64(encoded), "base64");
+  if (buffer.byteLength === 0 || buffer.byteLength > VENICE_MAX_IMAGE_BYTES) {
+    throw new Error("Venice returned an empty or oversized image");
+  }
+  const type = detectImageType(buffer);
+  if (!type) throw new Error("Venice returned data that was not a supported image");
+
+  return { base64: buffer.toString("base64"), ...type };
+}
+
+export function normalizeVeniceImageModels(value: unknown): Array<{ id: string; name: string }> {
+  if (!isRecord(value) || !Array.isArray(value.data)) return [];
+  return value.data
+    .map((entry) => {
+      if (!isRecord(entry) || (typeof entry.type === "string" && entry.type !== "image")) return null;
+      const id = typeof entry.id === "string" ? entry.id.trim() : "";
+      const spec = isRecord(entry.model_spec) ? entry.model_spec : null;
+      const name = spec && typeof spec.name === "string" ? spec.name.trim() : "";
+      return id ? { id, name: name || id } : null;
+    })
+    .filter((model): model is { id: string; name: string } => Boolean(model));
+}

--- a/packages/server/src/services/import/profile-import-assets.ts
+++ b/packages/server/src/services/import/profile-import-assets.ts
@@ -1,0 +1,136 @@
+import { existsSync } from "node:fs";
+import { copyFile, mkdir, mkdtemp, rename, rm, writeFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import { assertInsideDir } from "../../utils/security.js";
+
+export class ProfileImportAssetValidationError extends Error {}
+
+export type ProfileImportAssetInput = {
+  path: string;
+  expectedSize: number;
+  read: () => Buffer | null | Promise<Buffer | null>;
+};
+
+type StagedProfileImportAsset = {
+  path: string;
+  stagedPath: string;
+  outputPath: string;
+  backupPath: string;
+  hadExistingOutput: boolean;
+  promotionAttempted: boolean;
+};
+
+export type StagedProfileImportAssets = {
+  rootDir: string;
+  assets: StagedProfileImportAsset[];
+  totalBytes: number;
+};
+
+function safeRelativeAssetParts(path: string): string[] {
+  const parts = path.replace(/\\/g, "/").split("/").filter(Boolean);
+  if (parts.length < 2 || parts.some((part) => part === "." || part === ".." || part.includes(":"))) {
+    throw new ProfileImportAssetValidationError(`Profile asset path is invalid: ${path}`);
+  }
+  return parts;
+}
+
+export async function stageProfileImportAssets(
+  dataDir: string,
+  inputs: ProfileImportAssetInput[],
+  totalByteLimit: number,
+): Promise<StagedProfileImportAssets> {
+  await mkdir(dataDir, { recursive: true });
+  const rootDir = await mkdtemp(join(dataDir, ".profile-import-"));
+  const stagedDataDir = join(rootDir, "staged");
+  const rollbackDataDir = join(rootDir, "rollback");
+  const assets: StagedProfileImportAsset[] = [];
+  const seenPaths = new Set<string>();
+  let totalBytes = 0;
+
+  try {
+    for (const input of inputs) {
+      const parts = safeRelativeAssetParts(input.path);
+      if (seenPaths.has(input.path)) {
+        throw new ProfileImportAssetValidationError(`Profile contains duplicate asset path ${input.path}.`);
+      }
+      seenPaths.add(input.path);
+      const buffer = await input.read();
+      if (!buffer) continue;
+      if (buffer.byteLength !== input.expectedSize) {
+        throw new ProfileImportAssetValidationError(
+          `Profile asset ${input.path} does not match its manifest size.`,
+        );
+      }
+
+      totalBytes += buffer.byteLength;
+      if (totalBytes > totalByteLimit) {
+        throw new ProfileImportAssetValidationError(
+          `Profile archive restored assets are too large (${totalBytes} bytes, limit ${totalByteLimit} bytes).`,
+        );
+      }
+
+      const stagedPath = assertInsideDir(stagedDataDir, join(stagedDataDir, ...parts));
+      const outputPath = assertInsideDir(dataDir, join(dataDir, ...parts));
+      const backupPath = assertInsideDir(rollbackDataDir, join(rollbackDataDir, ...parts));
+      await mkdir(dirname(stagedPath), { recursive: true });
+      await writeFile(stagedPath, buffer);
+      assets.push({
+        path: input.path,
+        stagedPath,
+        outputPath,
+        backupPath,
+        hadExistingOutput: false,
+        promotionAttempted: false,
+      });
+    }
+
+    return { rootDir, assets, totalBytes };
+  } catch (error) {
+    await rm(rootDir, { recursive: true, force: true }).catch(() => undefined);
+    throw error;
+  }
+}
+
+export async function promoteStagedProfileAssets(stage: StagedProfileImportAssets): Promise<void> {
+  for (const asset of stage.assets) {
+    await mkdir(dirname(asset.outputPath), { recursive: true });
+    asset.hadExistingOutput = existsSync(asset.outputPath);
+    if (asset.hadExistingOutput) {
+      await mkdir(dirname(asset.backupPath), { recursive: true });
+      await copyFile(asset.outputPath, asset.backupPath);
+    }
+
+    asset.promotionAttempted = true;
+    try {
+      await rename(asset.stagedPath, asset.outputPath);
+    } catch (error) {
+      const code = (error as NodeJS.ErrnoException | null)?.code;
+      if (code !== "EEXIST" && code !== "EPERM") throw error;
+      await rm(asset.outputPath, { force: true });
+      await rename(asset.stagedPath, asset.outputPath);
+    }
+  }
+}
+
+export async function rollbackPromotedProfileAssets(stage: StagedProfileImportAssets): Promise<void> {
+  const errors: unknown[] = [];
+  for (const asset of [...stage.assets].reverse()) {
+    if (!asset.promotionAttempted) continue;
+    try {
+      if (asset.hadExistingOutput) {
+        await copyFile(asset.backupPath, asset.outputPath);
+      } else {
+        await rm(asset.outputPath, { force: true });
+      }
+    } catch (error) {
+      errors.push(error);
+    }
+  }
+  if (errors.length > 0) {
+    throw new AggregateError(errors, `Failed to roll back ${errors.length} profile asset(s)`);
+  }
+}
+
+export async function cleanupStagedProfileAssets(stage: StagedProfileImportAssets): Promise<void> {
+  await rm(stage.rootDir, { recursive: true, force: true });
+}

--- a/packages/shared/src/constants/model-lists.ts
+++ b/packages/shared/src/constants/model-lists.ts
@@ -651,6 +651,13 @@ export const IMAGE_GENERATION_SOURCES: ImageGenSource[] = [
     requiresApiKey: true,
   },
   {
+    id: "venice",
+    name: "Venice.ai",
+    description: "Private image generation through Venice's native image API.",
+    defaultBaseUrl: "https://api.venice.ai/api/v1",
+    requiresApiKey: true,
+  },
+  {
     id: "pollinations",
     name: "Pollinations",
     description: "Free, no-key-needed image generation via Pollinations AI.",
@@ -753,6 +760,10 @@ const IMAGE_GEN_MODELS: KnownModel[] = [
   { id: "grok-4.1-fast-image", name: "Grok 4.1 Fast Image", context: 0, maxOutput: 0 },
   { id: "grok-imagine-image", name: "Grok Imagine Image", context: 0, maxOutput: 0 },
   { id: "grok-2-image", name: "Grok 2 Image", context: 0, maxOutput: 0 },
+  // Venice.ai
+  { id: "chroma", name: "Chroma (Venice)", context: 0, maxOutput: 0 },
+  { id: "flux-2-pro", name: "FLUX 2 Pro (Venice)", context: 0, maxOutput: 0 },
+  { id: "venice-sd35", name: "Venice SD3.5", context: 0, maxOutput: 0 },
   // NovelAI
   { id: "nai-diffusion-4-curated-preview", name: "NAI Diffusion 4 Curated", context: 0, maxOutput: 0 },
   { id: "nai-diffusion-4-5-full", name: "NAI Diffusion 4.5 Full", context: 0, maxOutput: 0 },
@@ -805,6 +816,7 @@ export function inferImageSource(model: string, baseUrl: string): string {
     m === "blockentropy" ||
     m === "openrouter" ||
     m === "xai" ||
+    m === "venice" ||
     m === "comfyui" ||
     m === "automatic1111" ||
     m === "runpod_comfyui" ||
@@ -816,6 +828,7 @@ export function inferImageSource(model: string, baseUrl: string): string {
   if (u.includes("nano-gpt.com")) return "nanogpt";
   if (u.includes("openrouter.ai")) return "openrouter";
   if (u.includes("api.x.ai") || u.includes("x.ai")) return "xai";
+  if (u.includes("venice.ai")) return "venice";
   if (m.startsWith("grok-") && m.includes("image")) return "xai";
   if (m.includes("grok") && m.includes("imagine")) return "xai";
   if (m.startsWith("dall-e") || m.startsWith("gpt-image") || u.includes("openai.com")) return "openai";

--- a/scripts/regressions/file-backed-shutdown.regression.ts
+++ b/scripts/regressions/file-backed-shutdown.regression.ts
@@ -70,6 +70,95 @@ try {
   rmSync(failingStorageDir, { recursive: true, force: true });
 }
 
+const transactionStorageDir = mkdtempSync(join(tmpdir(), "marinara-file-transaction-"));
+process.env.FILE_STORAGE_DIR = transactionStorageDir;
+try {
+  const db = await createFileNativeDB();
+  await db.insert(appSettings).values({ key: "transaction-value", value: "live", updatedAt: "2026-07-16" });
+  await db._fileStore.flush();
+
+  let releaseTransaction!: () => void;
+  const transactionGate = new Promise<void>((resolve) => {
+    releaseTransaction = resolve;
+  });
+  let transactionStarted!: () => void;
+  const transactionReady = new Promise<void>((resolve) => {
+    transactionStarted = resolve;
+  });
+  const failedTransaction = db.transaction(async (tx) => {
+    await tx.update(appSettings).set({ value: "imported" }).where(eq(appSettings.key, "transaction-value"));
+    await db._fileStore.flush();
+    transactionStarted();
+    await transactionGate;
+    throw new Error("simulated profile asset promotion failure");
+  });
+  await transactionReady;
+
+  let outsideWriteFinished = false;
+  const outsideWrite = db
+    .insert(appSettings)
+    .values({ key: "outside-write", value: "preserved", updatedAt: "2026-07-16" })
+    .then(() => {
+      outsideWriteFinished = true;
+    });
+  await Promise.resolve();
+  assert.equal(outsideWriteFinished, false, "non-transaction writes must wait for the active transaction");
+
+  releaseTransaction();
+  await assert.rejects(failedTransaction, /simulated profile asset promotion failure/u);
+  await outsideWrite;
+  await db._fileStore.flush();
+
+  const rows = await db.select().from(appSettings);
+  assert.equal(rows.find((row) => row.key === "transaction-value")?.value, "live");
+  assert.equal(rows.find((row) => row.key === "outside-write")?.value, "preserved");
+  const persistedRows = JSON.parse(
+    readFileSync(join(transactionStorageDir, "tables", "app_settings.json"), "utf8"),
+  ) as Array<{ key: string; value: string }>;
+  assert.equal(persistedRows.find((row) => row.key === "transaction-value")?.value, "live");
+  assert.equal(persistedRows.find((row) => row.key === "outside-write")?.value, "preserved");
+  await db._fileStore.close();
+  console.info("File-backed serialized durable transaction regression passed.");
+} finally {
+  rmSync(transactionStorageDir, { recursive: true, force: true });
+}
+
+const transactionFlushFailureDir = mkdtempSync(join(tmpdir(), "marinara-file-transaction-flush-failure-"));
+process.env.FILE_STORAGE_DIR = transactionFlushFailureDir;
+let rejectNextTransactionWrite = false;
+try {
+  const expectedFailure = new Error("simulated transaction flush failure");
+  const db = await createFileNativeDB({
+    beforeTableWrite: (table) => {
+      if (table !== "app_settings" || !rejectNextTransactionWrite) return;
+      rejectNextTransactionWrite = false;
+      throw expectedFailure;
+    },
+  });
+  await db.insert(appSettings).values({ key: "flush-rollback", value: "live", updatedAt: "2026-07-16" });
+  await db._fileStore.flush();
+
+  await assert.rejects(
+    db.transaction(async (tx) => {
+      await tx.update(appSettings).set({ value: "imported" }).where(eq(appSettings.key, "flush-rollback"));
+      rejectNextTransactionWrite = true;
+      await db._fileStore.flush();
+    }),
+    expectedFailure,
+  );
+
+  const rows = await db.select().from(appSettings);
+  assert.equal(rows.find((row) => row.key === "flush-rollback")?.value, "live");
+  const persistedRows = JSON.parse(
+    readFileSync(join(transactionFlushFailureDir, "tables", "app_settings.json"), "utf8"),
+  ) as Array<{ key: string; value: string }>;
+  assert.equal(persistedRows.find((row) => row.key === "flush-rollback")?.value, "live");
+  await db._fileStore.close();
+  console.info("File-backed failed transaction flush rollback regression passed.");
+} finally {
+  rmSync(transactionFlushFailureDir, { recursive: true, force: true });
+}
+
 const packagedSchemaStorageDir = mkdtempSync(join(tmpdir(), "marinara-file-package-schema-"));
 process.env.FILE_STORAGE_DIR = packagedSchemaStorageDir;
 try {

--- a/scripts/regressions/open-issues.regression.ts
+++ b/scripts/regressions/open-issues.regression.ts
@@ -293,6 +293,7 @@ assert.deepEqual(
     data: [
       { id: "chroma", type: "image", model_spec: { name: "Chroma" } },
       { id: "llama", type: "text", model_spec: { name: "Llama" } },
+      { id: "untyped", model_spec: { name: "Untyped" } },
     ],
   }),
   [{ id: "chroma", name: "Chroma" }],
@@ -886,6 +887,8 @@ assert.match(refreshedNpcAvatar, /mariAvatarRevision=/u);
 assert.equal(withoutNpcAvatarRevision(refreshedNpcAvatar), "/avatars/npc/chat/albedo.png?size=small#portrait");
 assert.equal(isSameNpcAvatarResource(refreshedNpcAvatar, "/avatars/npc/chat/albedo.png?size=small#portrait"), true);
 assert.equal(normalizeNpcAvatarName("Director Althea Voss Friendly"), normalizeNpcAvatarName("Director Althea Voss"));
+assert.equal(normalizeNpcAvatarName("Benemy"), "benemy");
+assert.equal(normalizeNpcAvatarName("Director__Althea--Voss Friendly"), normalizeNpcAvatarName("Director Althea Voss"));
 
 const noodleAvatarCrop = parseNoodleAvatarCrop(
   JSON.stringify({ srcX: 0.25, srcY: 0.1, srcWidth: 0.5, srcHeight: 0.5 }),

--- a/scripts/regressions/open-issues.regression.ts
+++ b/scripts/regressions/open-issues.regression.ts
@@ -81,7 +81,7 @@ import {
 } from "../../packages/server/src/services/image/illustrator-prompt-review.js";
 import { resolveReviewedImagePromptSubmission } from "../../packages/server/src/services/image/image-prompt-review.js";
 import {
-  cleanupStagedProfileImportAssets,
+  cleanupStagedProfileAssets,
   promoteStagedProfileAssets,
   rollbackPromotedProfileAssets,
   stageProfileImportAssets,
@@ -331,7 +331,7 @@ try {
   assert.equal(readFileSync(liveAvatarPath, "utf8"), "imported-avatar");
   await rollbackPromotedProfileAssets(stagedProfileAssets);
   assert.equal(readFileSync(liveAvatarPath, "utf8"), "live-avatar");
-  await cleanupStagedProfileImportAssets(stagedProfileAssets);
+  await cleanupStagedProfileAssets(stagedProfileAssets);
 } finally {
   rmSync(profileImportAssetRoot, { recursive: true, force: true });
 }

--- a/scripts/regressions/open-issues.regression.ts
+++ b/scripts/regressions/open-issues.regression.ts
@@ -81,6 +81,12 @@ import {
 } from "../../packages/server/src/services/image/illustrator-prompt-review.js";
 import { resolveReviewedImagePromptSubmission } from "../../packages/server/src/services/image/image-prompt-review.js";
 import {
+  cleanupStagedProfileImportAssets,
+  promoteStagedProfileAssets,
+  rollbackPromotedProfileAssets,
+  stageProfileImportAssets,
+} from "../../packages/server/src/services/import/profile-import-assets.js";
+import {
   buildVeniceApiUrl,
   buildVeniceImageRequest,
   normalizeVeniceImageModels,
@@ -291,6 +297,44 @@ assert.deepEqual(
   }),
   [{ id: "chroma", name: "Chroma" }],
 );
+
+const profileImportAssetRoot = mkdtempSync(join(tmpdir(), "marinara-profile-import-atomic-"));
+try {
+  const liveAvatarPath = join(profileImportAssetRoot, "avatars", "character.png");
+  mkdirSync(join(profileImportAssetRoot, "avatars"), { recursive: true });
+  writeFileSync(liveAvatarPath, "live-avatar");
+  await assert.rejects(
+    stageProfileImportAssets(
+      profileImportAssetRoot,
+      [
+        { path: "avatars/character.png", expectedSize: 15, read: () => Buffer.from("imported-avatar") },
+        {
+          path: "gallery/corrupt.png",
+          expectedSize: 8,
+          read: () => {
+            throw new Error("simulated corrupt archive member");
+          },
+        },
+      ],
+      1024,
+    ),
+    /simulated corrupt archive member/u,
+  );
+  assert.equal(readFileSync(liveAvatarPath, "utf8"), "live-avatar");
+
+  const stagedProfileAssets = await stageProfileImportAssets(
+    profileImportAssetRoot,
+    [{ path: "avatars/character.png", expectedSize: 15, read: () => Buffer.from("imported-avatar") }],
+    1024,
+  );
+  await promoteStagedProfileAssets(stagedProfileAssets);
+  assert.equal(readFileSync(liveAvatarPath, "utf8"), "imported-avatar");
+  await rollbackPromotedProfileAssets(stagedProfileAssets);
+  assert.equal(readFileSync(liveAvatarPath, "utf8"), "live-avatar");
+  await cleanupStagedProfileImportAssets(stagedProfileAssets);
+} finally {
+  rmSync(profileImportAssetRoot, { recursive: true, force: true });
+}
 
 const mainPromptConnection: IllustratorPromptConnection = {
   id: "main-prompt-connection",

--- a/scripts/regressions/open-issues.regression.ts
+++ b/scripts/regressions/open-issues.regression.ts
@@ -27,6 +27,7 @@ import { getAvatarCropStyle } from "../../packages/client/src/lib/utils.js";
 import { getApiErrorMessage } from "../../packages/client/src/lib/api-client.js";
 import {
   isSameNpcAvatarResource,
+  normalizeNpcAvatarName,
   withFreshNpcAvatarRevision,
   withoutNpcAvatarRevision,
 } from "../../packages/client/src/lib/game-npc-avatar.js";
@@ -47,7 +48,10 @@ import {
   stripConversationPromptTimestamps,
   stripConversationResponseEnvelope,
 } from "../../packages/server/src/services/conversation/transcript-sanitize.js";
-import { resolveInitialGameGmConnectionId } from "../../packages/server/src/services/game/initial-game-setup.js";
+import {
+  GAME_SETUP_GENERATION_TIMEOUT_MS,
+  resolveInitialGameGmConnectionId,
+} from "../../packages/server/src/services/game/initial-game-setup.js";
 import {
   resolveIllustratorPromptRuntime,
   type IllustratorPromptConnection,
@@ -245,6 +249,7 @@ assert.deepEqual(completeProfessorMariPersona.convoBehavior, {
 assert.equal(resolveInitialGameGmConnectionId(undefined, "chat-connection"), "chat-connection");
 assert.equal(resolveInitialGameGmConnectionId("explicit-connection", "chat-connection"), "explicit-connection");
 assert.equal(resolveInitialGameGmConnectionId(undefined, null), null);
+assert.equal(GAME_SETUP_GENERATION_TIMEOUT_MS, 500_000);
 assert.equal(DEFAULT_GENERATION_PARAMS.reasoningEffort, "maximum");
 
 const mainPromptConnection: IllustratorPromptConnection = {
@@ -796,6 +801,7 @@ const refreshedNpcAvatar = withFreshNpcAvatarRevision("/avatars/npc/chat/albedo.
 assert.match(refreshedNpcAvatar, /mariAvatarRevision=/u);
 assert.equal(withoutNpcAvatarRevision(refreshedNpcAvatar), "/avatars/npc/chat/albedo.png?size=small#portrait");
 assert.equal(isSameNpcAvatarResource(refreshedNpcAvatar, "/avatars/npc/chat/albedo.png?size=small#portrait"), true);
+assert.equal(normalizeNpcAvatarName("Director Althea Voss Friendly"), normalizeNpcAvatarName("Director Althea Voss"));
 
 const noodleAvatarCrop = parseNoodleAvatarCrop(
   JSON.stringify({ srcX: 0.25, srcY: 0.1, srcWidth: 0.5, srcHeight: 0.5 }),

--- a/scripts/regressions/open-issues.regression.ts
+++ b/scripts/regressions/open-issues.regression.ts
@@ -80,6 +80,12 @@ import {
   resolveIllustratorPromptSubmission,
 } from "../../packages/server/src/services/image/illustrator-prompt-review.js";
 import { resolveReviewedImagePromptSubmission } from "../../packages/server/src/services/image/image-prompt-review.js";
+import {
+  buildVeniceApiUrl,
+  buildVeniceImageRequest,
+  normalizeVeniceImageModels,
+  parseVeniceImageResponse,
+} from "../../packages/server/src/services/image/venice-image.js";
 import { resolveSceneVideoPrompt } from "../../packages/server/src/services/video/scene-video-prompt-review.js";
 import {
   buildLorebookEntryCreateRow,
@@ -251,6 +257,40 @@ assert.equal(resolveInitialGameGmConnectionId("explicit-connection", "chat-conne
 assert.equal(resolveInitialGameGmConnectionId(undefined, null), null);
 assert.equal(GAME_SETUP_GENERATION_TIMEOUT_MS, 500_000);
 assert.equal(DEFAULT_GENERATION_PARAMS.reasoningEffort, "maximum");
+
+assert.equal(
+  buildVeniceApiUrl("https://api.venice.ai/api/v1", "models"),
+  "https://api.venice.ai/api/v1/models?type=image",
+);
+assert.deepEqual(buildVeniceImageRequest({ model: "venice-sd35", prompt: "canal", width: 1600, height: 900 }), {
+  model: "venice-sd35",
+  prompt: "canal",
+  format: "webp",
+  return_binary: false,
+  variants: 1,
+  width: 1280,
+  height: 720,
+});
+assert.deepEqual(buildVeniceImageRequest({ model: "gpt-image-2", prompt: "canal", width: 1536, height: 1024 }), {
+  model: "gpt-image-2",
+  prompt: "canal",
+  format: "webp",
+  return_binary: false,
+  variants: 1,
+  aspect_ratio: "3:2",
+  resolution: "2K",
+});
+const tinyVenicePng = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]).toString("base64");
+assert.equal(parseVeniceImageResponse({ images: [tinyVenicePng] }).mimeType, "image/png");
+assert.deepEqual(
+  normalizeVeniceImageModels({
+    data: [
+      { id: "chroma", type: "image", model_spec: { name: "Chroma" } },
+      { id: "llama", type: "text", model_spec: { name: "Llama" } },
+    ],
+  }),
+  [{ id: "chroma", name: "Chroma" }],
+);
 
 const mainPromptConnection: IllustratorPromptConnection = {
   id: "main-prompt-connection",


### PR DESCRIPTION
## Linked issue

Closes #3681
Closes #3682
Closes #3683
Closes #3684
Closes #3685

## Why this change

- This v3.2.2 batch resolves current user-facing Game portrait and setup failures, adds the requested Venice image provider, prevents partial profile restores, and coordinates the package-owned Calls typed-message fix.

## What changed

- Canonicalized Game NPC identity matching so portrait refreshes survive appended reputation labels.
- Extended only the final Game setup watchdog from 300 to 500 seconds.
- Added Venice image generation and live image-model discovery with model-aware request sizing and response validation.
- Staged and validated native-profile assets before mutation, serialized table writes, and added durable row/asset rollback on promotion or flush failure while preserving warning-only missing assets.
- Added v3.2.2 release notes for #3681–#3685; the downloadable Calls runtime fix is in Pasta-Devs/Marinara-Agents#47.

## Validation

- [ ] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed `CONTRIBUTING.md`

### Manual verification notes

- `pnpm check`, `pnpm regression:issues`, `pnpm regression:prompt`, `pnpm version:check`, `pnpm credits:check`, and `git diff --check` passed locally.
- Marinara-Agents Calls v1.0.4 built successfully; its catalog validation and whitespace checks passed.
- Full `pnpm smoke:ui`: 61 passed, 39 skipped. The unchanged Roleplay resize test failed its 70 ms transition sample once and passed on focused rerun. The unchanged Hierarchical Maps placement test still records a 404 from its unmocked `/api/chats/:id/spatial-context` request; that route/test is outside this diff.
- Human verification remains: refresh an NPC portrait with a reputation label, exercise the 500-second setup boundary, generate through Venice, import a deliberately corrupt profile archive, and install Calls v1.0.4 to send a typed message.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Version/release files updated (only if this PR includes a version bump)

Updated `CHANGELOG.md`, `README.md`, `docs/FAQ.md`, and `docs/media/image-providers.md` for v3.2.2 and Venice support. No version bump is included because the repository is already at 3.2.2.

## UI evidence (if applicable)

No new layout is introduced; the Game Journal change restores existing portrait behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Venice.ai as an image-generation provider, including model discovery, supported sizing, and validated image results.
  * Added Venice.ai setup guidance and API key information to documentation.

* **Bug Fixes**
  * Improved NPC portrait matching when names include reputation labels.
  * Profile imports now validate assets and roll back safely when failures occur.
  * Conversation Calls no longer save fallback replies after generation failures.
  * Increased the Game setup generation timeout to support larger blueprints.
  * Improved storage reliability during concurrent writes and failed transactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->