### PR TITLE
fix: preserve Noodle context and custom generation parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 
 ### Fixed
 
+- Made `@handle` mentions in Noodle replies open the referenced profile, and resolved active Persona, Character, and linked lorebook macros before Noodle refresh prompts reach the model (#3687).
 - Fixed merged Roleplay group prompts stripping every historical speaker-tag example. The latest assistant message now keeps its `<speaker>` wrappers while older tags are still trimmed, and the instruction remains inside `<output_format>` when available or otherwise appends to the last user message (#3673).
 - Preserved the **Enable Agents** master switch during the v2.3 capability migration, so upgrading cannot silently reactivate selected agents or their model calls. Hierarchical Maps now remains independently available when selected (#3669).
 - Made the v2.3 capability migration restart-safe by writing its completion marker only after per-chat selections are migrated and flushed to durable storage; interrupted migrations retry idempotently on the next startup (#3670).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 ### Fixed
 
 - Made `@handle` mentions in Noodle replies open the referenced profile, and resolved active Persona, Character, and linked lorebook macros before Noodle refresh prompts reach the model (#3687).
+- Let Connection Custom Parameters preserve arbitrary JSON values and convenient bare string values instead of discarding invalid drafts, and restored unified reasoning-effort requests for dynamically discovered OpenRouter models (#3688).
 - Fixed merged Roleplay group prompts stripping every historical speaker-tag example. The latest assistant message now keeps its `<speaker>` wrappers while older tags are still trimmed, and the instruction remains inside `<output_format>` when available or otherwise appends to the last user message (#3673).
 - Preserved the **Enable Agents** master switch during the v2.3 capability migration, so upgrading cannot silently reactivate selected agents or their model calls. Hierarchical Maps now remains independently available when selected (#3669).
 - Made the v2.3 capability migration restart-safe by writing its completion marker only after per-chat selections are migrated and flushed to durable storage; interrupted migrations retry idempotently on the next startup (#3670).

--- a/e2e/core-flows.e2e.ts
+++ b/e2e/core-flows.e2e.ts
@@ -3180,6 +3180,26 @@ test("Noodle posts tag invited characters with @handle mentions", async ({ page 
 
     await mention.click();
     await expect(noodle.getByRole("heading", { name: "Professor Mari", exact: true })).toBeVisible();
+
+    const replyResponse = await page.request.post(`/api/noodle/posts/${post.id}/interactions`, {
+      data: {
+        actorKind: "persona",
+        actorEntityId: personaId,
+        type: "reply",
+        content: "Reply mention for @professor_mari.",
+      },
+    });
+    expect(replyResponse.ok()).toBe(true);
+    const reply = (await replyResponse.json()) as { id: string };
+
+    await page.reload();
+    await page.locator('[data-tour="noodle-tab"]').click();
+    const replyMention = page
+      .locator(`[data-noodle-interaction-id="${reply.id}"]`)
+      .getByRole("button", { name: "View @professor_mari profile" });
+    await expect(replyMention).toBeVisible();
+    await replyMention.click();
+    await expect(noodle.getByRole("heading", { name: "Professor Mari", exact: true })).toBeVisible();
     expect(errors).toEqual([]);
   } finally {
     if (createdPostId) {

--- a/packages/client/src/components/noodle/NoodleView.tsx
+++ b/packages/client/src/components/noodle/NoodleView.tsx
@@ -511,18 +511,20 @@ function NoodleMentionSuggestions({
   );
 }
 
-function NoodlePostContent({
+function NoodleTextContent({
   content,
   accountByHandle,
   onOpenProfile,
+  className,
 }: {
   content: string;
   accountByHandle: Map<string, NoodleAccount>;
   onOpenProfile: (account: NoodleAccount) => void;
+  className?: string;
 }) {
   const mentions = findNoodleTextMentions(content);
   if (mentions.length === 0) {
-    return <p className="mt-2 whitespace-pre-wrap text-sm leading-6">{content}</p>;
+    return <p className={cn("whitespace-pre-wrap text-sm", className)}>{content}</p>;
   }
 
   const parts: React.ReactNode[] = [];
@@ -549,7 +551,7 @@ function NoodlePostContent({
     cursor = mention.end;
   }
   if (cursor < content.length) parts.push(content.slice(cursor));
-  return <p className="mt-2 whitespace-pre-wrap text-sm leading-6">{parts}</p>;
+  return <p className={cn("whitespace-pre-wrap text-sm", className)}>{parts}</p>;
 }
 
 function NoodlePollCard({
@@ -3695,7 +3697,12 @@ export function NoodleView() {
                 </div>
               </div>
             ) : !poll || post.content.trim() !== poll.question ? (
-              <NoodlePostContent content={post.content} accountByHandle={accountByHandle} onOpenProfile={openProfile} />
+              <NoodleTextContent
+                content={post.content}
+                accountByHandle={accountByHandle}
+                onOpenProfile={openProfile}
+                className="mt-2 leading-6"
+              />
             ) : null}
             {poll && (
               <NoodlePollCard
@@ -3845,7 +3852,15 @@ export function NoodleView() {
                           </div>
                           {parentActor && (
                             <p className="mt-0.5 text-[var(--muted-foreground)]">
-                              Replying to <span className="text-[var(--noodle-blue)]">@{parentActor.handle}</span>
+                              Replying to{" "}
+                              <button
+                                type="button"
+                                onClick={() => openProfile(parentActor)}
+                                className="font-medium text-[var(--noodle-blue)] hover:underline focus-visible:rounded-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--noodle-blue)]/70"
+                                aria-label={`View @${parentActor.handle} profile`}
+                              >
+                                @{parentActor.handle}
+                              </button>
                             </p>
                           )}
                           {editingReplyId === reply.id ? (
@@ -3879,7 +3894,12 @@ export function NoodleView() {
                               </div>
                             </div>
                           ) : reply.content ? (
-                            <p className="mt-1 whitespace-pre-wrap text-sm leading-5">{reply.content}</p>
+                            <NoodleTextContent
+                              content={reply.content}
+                              accountByHandle={accountByHandle}
+                              onOpenProfile={openProfile}
+                              className="mt-1 leading-5"
+                            />
                           ) : null}
                           {reply.imageUrl && (
                             <button

--- a/packages/client/src/components/noodle/NoodleView.tsx
+++ b/packages/client/src/components/noodle/NoodleView.tsx
@@ -3798,9 +3798,8 @@ export function NoodleView() {
                   const parentReply = reply.parentInteractionId
                     ? (replyById.get(reply.parentInteractionId) ?? null)
                     : null;
-                  const parentActor = parentReply
-                    ? (accountById.get(parentReply.actorAccountId) ?? parentReply.actorSnapshot)
-                    : null;
+                  const parentActorAccount = parentReply ? (accountById.get(parentReply.actorAccountId) ?? null) : null;
+                  const parentActor = parentActorAccount ?? parentReply?.actorSnapshot ?? null;
                   const replyLikes = postInteractions.filter(
                     (interaction) => interaction.type === "like" && interaction.parentInteractionId === reply.id,
                   );
@@ -3853,14 +3852,18 @@ export function NoodleView() {
                           {parentActor && (
                             <p className="mt-0.5 text-[var(--muted-foreground)]">
                               Replying to{" "}
-                              <button
-                                type="button"
-                                onClick={() => openProfile(parentActor)}
-                                className="font-medium text-[var(--noodle-blue)] hover:underline focus-visible:rounded-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--noodle-blue)]/70"
-                                aria-label={`View @${parentActor.handle} profile`}
-                              >
-                                @{parentActor.handle}
-                              </button>
+                              {parentActorAccount ? (
+                                <button
+                                  type="button"
+                                  onClick={() => openProfile(parentActorAccount)}
+                                  className="font-medium text-[var(--noodle-blue)] hover:underline focus-visible:rounded-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--noodle-blue)]/70"
+                                  aria-label={`View @${parentActorAccount.handle} profile`}
+                                >
+                                  @{parentActorAccount.handle}
+                                </button>
+                              ) : (
+                                <span className="text-[var(--noodle-blue)]">@{parentActor.handle}</span>
+                              )}
                             </p>
                           )}
                           {editingReplyId === reply.id ? (

--- a/packages/client/src/components/ui/GenerationParametersEditor.tsx
+++ b/packages/client/src/components/ui/GenerationParametersEditor.tsx
@@ -11,6 +11,7 @@ import { cn } from "../../lib/utils";
 import { SettingsSwitch } from "../panels/settings/SettingControls";
 import { DraftTextarea } from "./DraftTextarea";
 import { HelpTooltip } from "./HelpTooltip";
+import { parseCustomParametersDraft } from "../../lib/generation-custom-parameters";
 
 export type EditableGenerationParameters = Pick<
   GenerationParameters,
@@ -499,11 +500,10 @@ function CustomParametersInput({
   const [focused, setFocused] = useState(false);
 
   useEffect(() => {
-    if (!focused) {
+    if (!focused && error === null) {
       setDraft(serialized);
-      setError(null);
     }
-  }, [focused, serialized]);
+  }, [error, focused, serialized]);
 
   const commit = () => {
     const parsed = parseCustomParametersDraft(draft);
@@ -543,14 +543,15 @@ function CustomParametersInput({
         }}
         rows={3}
         spellCheck={false}
+        aria-invalid={error ? true : undefined}
         className={PARAM_TEXTAREA_CLASS}
-        placeholder={focused ? "" : '{ "thinking": true }'}
+        placeholder={focused ? "" : '{ "reasoning_effort": "high" }'}
       />
       {error ? (
         <p className="mt-1 text-[0.5625rem] text-amber-500">{error}</p>
       ) : (
         <p className="mt-1 text-[0.5625rem] text-[var(--muted-foreground)]/70">
-          Must be a JSON object. Use lowercase true, false, and null.
+          Accepts strings, numbers, booleans, null, arrays, and nested objects. Bare string values are saved as strings.
         </p>
       )}
     </div>
@@ -560,34 +561,6 @@ function CustomParametersInput({
 function stringifyCustomParameters(value: Record<string, unknown> | null | undefined): string {
   if (!value || Object.keys(value).length === 0) return "";
   return JSON.stringify(value, null, 2);
-}
-
-function parseCustomParametersDraft(
-  draft: string,
-): { ok: true; value: Record<string, unknown> } | { ok: false; error: string } {
-  const trimmed = draft.trim();
-  if (!trimmed) return { ok: true, value: {} };
-
-  const attempts = [trimmed];
-  const normalized = trimmed
-    .replace(/\bTrue\b/g, "true")
-    .replace(/\bFalse\b/g, "false")
-    .replace(/\bNone\b/g, "null");
-  if (normalized !== trimmed) attempts.push(normalized);
-
-  for (const attempt of attempts) {
-    try {
-      const parsed = JSON.parse(attempt);
-      if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
-        return { ok: true, value: parsed as Record<string, unknown> };
-      }
-      return { ok: false, error: "Custom parameters must be a JSON object, not an array or scalar." };
-    } catch {
-      // Try the next normalized variant.
-    }
-  }
-
-  return { ok: false, error: "Invalid JSON. Check quotes, commas, and boolean casing." };
 }
 
 function ParamInput({

--- a/packages/client/src/lib/generation-custom-parameters.ts
+++ b/packages/client/src/lib/generation-custom-parameters.ts
@@ -48,19 +48,58 @@ function quoteBareObjectValues(source: string): string {
   return normalized;
 }
 
+function normalizePythonLiterals(source: string): string {
+  const literals = new Map([
+    ["True", "true"],
+    ["False", "false"],
+    ["None", "null"],
+  ]);
+  let normalized = "";
+  let inString = false;
+  let escaped = false;
+
+  for (let index = 0; index < source.length; index += 1) {
+    const character = source[index]!;
+    if (inString) {
+      normalized += character;
+      if (escaped) escaped = false;
+      else if (character === "\\") escaped = true;
+      else if (character === '"') inString = false;
+      continue;
+    }
+    if (character === '"') {
+      inString = true;
+      normalized += character;
+      continue;
+    }
+
+    const match = [...literals].find(
+      ([literal]) =>
+        source.startsWith(literal, index) &&
+        !/[A-Za-z0-9_$]/u.test(source[index - 1] ?? "") &&
+        !/[A-Za-z0-9_$]/u.test(source[index + literal.length] ?? ""),
+    );
+    if (!match) {
+      normalized += character;
+      continue;
+    }
+    normalized += match[1];
+    index += match[0].length - 1;
+  }
+
+  return normalized;
+}
+
 export function parseCustomParametersDraft(draft: string): CustomParametersParseResult {
   const trimmed = draft.trim();
   if (!trimmed) return { ok: true, value: {} };
 
-  const pythonLiteralNormalized = trimmed
-    .replace(/\bTrue\b/g, "true")
-    .replace(/\bFalse\b/g, "false")
-    .replace(/\bNone\b/g, "null");
+  const pythonLiteralNormalized = normalizePythonLiterals(trimmed);
   const attempts = Array.from(
     new Set([
       trimmed,
-      quoteBareObjectValues(trimmed),
       pythonLiteralNormalized,
+      quoteBareObjectValues(trimmed),
       quoteBareObjectValues(pythonLiteralNormalized),
     ]),
   );

--- a/packages/client/src/lib/generation-custom-parameters.ts
+++ b/packages/client/src/lib/generation-custom-parameters.ts
@@ -1,0 +1,81 @@
+export type CustomParametersParseResult =
+  | { ok: true; value: Record<string, unknown> }
+  | { ok: false; error: string };
+
+function quoteBareObjectValues(source: string): string {
+  const replacements: Array<{ start: number; end: number; value: string }> = [];
+  let inString = false;
+  let escaped = false;
+
+  for (let index = 0; index < source.length; index += 1) {
+    const character = source[index]!;
+    if (inString) {
+      if (escaped) escaped = false;
+      else if (character === "\\") escaped = true;
+      else if (character === '"') inString = false;
+      continue;
+    }
+    if (character === '"') {
+      inString = true;
+      continue;
+    }
+    if (character !== ":") continue;
+
+    let valueStart = index + 1;
+    while (/\s/u.test(source[valueStart] ?? "")) valueStart += 1;
+    const first = source[valueStart];
+    if (!first || first === '"' || first === "{" || first === "[") continue;
+
+    let valueEnd = valueStart;
+    while (valueEnd < source.length && source[valueEnd] !== "," && source[valueEnd] !== "}") valueEnd += 1;
+    let trimmedEnd = valueEnd;
+    while (trimmedEnd > valueStart && /\s/u.test(source[trimmedEnd - 1] ?? "")) trimmedEnd -= 1;
+    const rawValue = source.slice(valueStart, trimmedEnd);
+    if (!rawValue) continue;
+
+    try {
+      JSON.parse(rawValue);
+    } catch {
+      replacements.push({ start: valueStart, end: trimmedEnd, value: JSON.stringify(rawValue) });
+      index = valueEnd - 1;
+    }
+  }
+
+  let normalized = source;
+  for (const replacement of replacements.reverse()) {
+    normalized = `${normalized.slice(0, replacement.start)}${replacement.value}${normalized.slice(replacement.end)}`;
+  }
+  return normalized;
+}
+
+export function parseCustomParametersDraft(draft: string): CustomParametersParseResult {
+  const trimmed = draft.trim();
+  if (!trimmed) return { ok: true, value: {} };
+
+  const pythonLiteralNormalized = trimmed
+    .replace(/\bTrue\b/g, "true")
+    .replace(/\bFalse\b/g, "false")
+    .replace(/\bNone\b/g, "null");
+  const attempts = Array.from(
+    new Set([
+      trimmed,
+      quoteBareObjectValues(trimmed),
+      pythonLiteralNormalized,
+      quoteBareObjectValues(pythonLiteralNormalized),
+    ]),
+  );
+
+  for (const attempt of attempts) {
+    try {
+      const parsed = JSON.parse(attempt);
+      if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+        return { ok: true, value: parsed as Record<string, unknown> };
+      }
+      return { ok: false, error: "Custom parameters must be a JSON object, not an array or scalar." };
+    } catch {
+      // Try the next conservative normalization.
+    }
+  }
+
+  return { ok: false, error: "Invalid object. Check property quotes, commas, and nested JSON values." };
+}

--- a/packages/server/src/routes/noodle.routes.ts
+++ b/packages/server/src/routes/noodle.routes.ts
@@ -24,6 +24,7 @@ import {
   noodleSettingsUpdateSchema,
   PROFESSOR_MARI_ID,
   readNoodlePollFromMetadata,
+  resolveMacros,
   type APIProvider,
   type NoodleAccount,
   type NoodleBootstrap,
@@ -85,6 +86,7 @@ import {
   sampleNoodlePastMemoriesWeighted,
 } from "../services/noodle/noodle-prompt.js";
 import { processLorebooks } from "../services/lorebook/index.js";
+import { buildPromptMacroContext, resolveMacrosWithVariableSnapshot } from "../services/prompt/index.js";
 import type { DB } from "../db/connection.js";
 import {
   generateImageCaptionForDataUrl,
@@ -771,9 +773,25 @@ async function buildRefreshPrompt(input: {
     input.noodle.listInteractions(recalledPosts.map((post) => post.id)),
   ]);
 
+  const promptMacroContext = await buildPromptMacroContext({
+    db: input.db,
+    characterIds: selectedCharacterIds,
+    personaName: personaNameFromRow(personaRow),
+    personaPhoneticName: personaRow?.phoneticName ?? "",
+    personaDescription: personaRow?.description ?? "",
+    personaFields: {
+      phoneticName: personaRow?.phoneticName ?? "",
+      personality: personaRow?.personality ?? "",
+      scenario: personaRow?.scenario ?? "",
+      backstory: personaRow?.backstory ?? "",
+      appearance: personaRow?.appearance ?? "",
+    },
+    lastGenerationType: "noodle",
+  });
+  const resolveNoodleMacros = (value: string) => resolveMacros(value, promptMacroContext, { trimResult: false });
   const characterContext = characterRows
     .filter((row): row is NonNullable<typeof row> => !!row)
-    .map(characterContextFromRow)
+    .map((row) => resolveNoodleMacros(characterContextFromRow(row)))
     .join("\n\n");
   const randomUserContext = activeRandomUsers
     .map(
@@ -783,7 +801,9 @@ async function buildRefreshPrompt(input: {
         }\n</random_user>`,
     )
     .join("\n\n");
-  const personaContext = personaRow ? personaContextFromRow(personaRow) : "No user persona is active.";
+  const personaContext = personaRow
+    ? resolveNoodleMacros(personaContextFromRow(personaRow))
+    : "No user persona is active.";
   const activeAccountList = [...input.activeAccounts, ...(input.personaAccount ? [input.personaAccount] : [])]
     .map(
       (account) =>
@@ -818,6 +838,8 @@ async function buildRefreshPrompt(input: {
           tokenBudget: noodleLorebookTokenBudget(activeCharacters.length),
           generationTriggers: ["noodle"],
           previewOnly: true,
+          resolveContent: (value) =>
+            resolveMacrosWithVariableSnapshot(value, promptMacroContext, { trimResult: false }),
         },
       )
     : null;

--- a/packages/server/src/services/llm/providers/openai.provider.ts
+++ b/packages/server/src/services/llm/providers/openai.provider.ts
@@ -691,6 +691,15 @@ export class OpenAIProvider extends BaseLLMProvider {
     return !!reasoningEffort && reasoningEffort !== "none";
   }
 
+  private requestReasoningLogValue(body: Record<string, unknown>): string {
+    if (typeof body.reasoning_effort === "string") return body.reasoning_effort;
+    if (!body.reasoning || typeof body.reasoning !== "object" || Array.isArray(body.reasoning)) return "none";
+    const reasoning = body.reasoning as Record<string, unknown>;
+    if (typeof reasoning.effort === "string") return reasoning.effort;
+    if (reasoning.enabled === true) return "enabled";
+    return Object.keys(reasoning).length > 0 ? "configured" : "none";
+  }
+
   private isOpenRouterEndpoint(): boolean {
     return (
       this.providerKind === "openrouter" || (!this.isGenericCustomProvider() && this.baseUrl.includes("openrouter.ai"))
@@ -743,11 +752,12 @@ export class OpenAIProvider extends BaseLLMProvider {
     )
       return;
 
-    if (
-      this.supportsOpenRouterUnifiedReasoning(options.model) &&
-      this.hasActiveReasoningEffort(options.reasoningEffort)
-    ) {
-      body.reasoning = { effort: options.reasoningEffort };
+    if (this.isOpenRouterEndpoint() && this.hasActiveReasoningEffort(options.reasoningEffort)) {
+      const existingReasoning =
+        body.reasoning && typeof body.reasoning === "object" && !Array.isArray(body.reasoning)
+          ? (body.reasoning as Record<string, unknown>)
+          : {};
+      body.reasoning = { ...existingReasoning, effort: options.reasoningEffort };
       return;
     }
 
@@ -1052,10 +1062,6 @@ export class OpenAIProvider extends BaseLLMProvider {
         body.verbosity = options.verbosity;
       }
 
-      if (this.shouldSendParameter(options, "reasoningEffort")) {
-        this.applyChatCompletionsReasoning(body, options);
-      }
-
       // OpenRouter provider routing preference
       const openrouterProvider = this.resolveOpenrouterProvider(options.openrouterProvider);
       if (this.shouldApplyOpenRouterProviderOverride(openrouterProvider)) {
@@ -1071,15 +1077,22 @@ export class OpenAIProvider extends BaseLLMProvider {
       }
     }
 
+    if (
+      this.shouldSendParameter(options, "reasoningEffort") &&
+      (!suppressModelParameters || this.isOpenRouterEndpoint())
+    ) {
+      this.applyChatCompletionsReasoning(body, options);
+    }
+
     this.applyOpenRouterServiceTier(body, options);
     this.applyCustomParameters(body, options);
     this.stripUnsupportedSamplerParameters(body, options);
 
     logger.debug(
-      "[OpenAI chat()] stream=%s model=%s reasoning_effort=%s enableThinking=%s verbosity=%s max_completion_tokens=%s max_tokens=%s temperature=%s top_p=%s tools=%s",
+      "[OpenAI chat()] stream=%s model=%s reasoning=%s enableThinking=%s verbosity=%s max_completion_tokens=%s max_tokens=%s temperature=%s top_p=%s tools=%s",
       body.stream,
       body.model,
-      body.reasoning_effort ?? "none",
+      this.requestReasoningLogValue(body),
       !!options.enableThinking,
       body.verbosity ?? "default",
       body.max_completion_tokens ?? "n/a",
@@ -1331,10 +1344,6 @@ export class OpenAIProvider extends BaseLLMProvider {
         body.verbosity = options.verbosity;
       }
 
-      if (this.shouldSendParameter(options, "reasoningEffort")) {
-        this.applyChatCompletionsReasoning(body, options);
-      }
-
       // OpenRouter provider routing preference
       const openrouterProvider = this.resolveOpenrouterProvider(options.openrouterProvider);
       if (this.shouldApplyOpenRouterProviderOverride(openrouterProvider)) {
@@ -1350,11 +1359,26 @@ export class OpenAIProvider extends BaseLLMProvider {
       }
     }
 
+    if (
+      this.shouldSendParameter(options, "reasoningEffort") &&
+      (!suppressModelParameters || this.isOpenRouterEndpoint())
+    ) {
+      this.applyChatCompletionsReasoning(body, options);
+    }
+
     this.applyOpenRouterServiceTier(body, options);
     this.applyCustomParameters(body, options);
     this.stripUnsupportedSamplerParameters(body, options);
 
-    logger.debug("[OpenAI chatComplete()] stream=%s model=%s onToken=%s", useStream, body.model, !!options.onToken);
+    logger.debug(
+      "[OpenAI chatComplete()] stream=%s model=%s reasoning=%s enableThinking=%s verbosity=%s onToken=%s",
+      useStream,
+      body.model,
+      this.requestReasoningLogValue(body),
+      !!options.enableThinking,
+      body.verbosity ?? "default",
+      !!options.onToken,
+    );
 
     const response = await llmFetch(url, {
       method: "POST",

--- a/scripts/regressions/open-issues.regression.ts
+++ b/scripts/regressions/open-issues.regression.ts
@@ -1219,6 +1219,10 @@ assert.deepEqual(parseCustomParametersDraft('{ "reasoning_effort": high, "awesom
   ok: true,
   value: { reasoning_effort: "high", awesomesauce: "enabled" },
 });
+assert.deepEqual(parseCustomParametersDraft('{ "enabled": True, "empty": None, "label": "True story" }'), {
+  ok: true,
+  value: { enabled: true, empty: null, label: "True story" },
+});
 assert.deepEqual(
   parseCustomParametersDraft(
     '{ "string": "potatoes!", "count": 3, "enabled": true, "empty": null, "list": ["a", 2], "nested": { "mode": "deep" } }',

--- a/scripts/regressions/open-issues.regression.ts
+++ b/scripts/regressions/open-issues.regression.ts
@@ -25,6 +25,7 @@ import {
 } from "../../packages/client/src/lib/slash-commands.js";
 import { getAvatarCropStyle } from "../../packages/client/src/lib/utils.js";
 import { getApiErrorMessage } from "../../packages/client/src/lib/api-client.js";
+import { parseCustomParametersDraft } from "../../packages/client/src/lib/generation-custom-parameters.js";
 import {
   isSameNpcAvatarResource,
   withFreshNpcAvatarRevision,
@@ -1120,5 +1121,28 @@ queuedAbortController.abort(new Error("expected queued abort"));
 await assert.rejects(abortedQueuedImage, /expected queued abort/u);
 releaseBlockingQueuedImage();
 await blockingQueuedImage;
+
+assert.deepEqual(parseCustomParametersDraft('{ "reasoning_effort": high, "awesomesauce": enabled }'), {
+  ok: true,
+  value: { reasoning_effort: "high", awesomesauce: "enabled" },
+});
+assert.deepEqual(
+  parseCustomParametersDraft(
+    '{ "string": "potatoes!", "count": 3, "enabled": true, "empty": null, "list": ["a", 2], "nested": { "mode": "deep" } }',
+  ),
+  {
+    ok: true,
+    value: {
+      string: "potatoes!",
+      count: 3,
+      enabled: true,
+      empty: null,
+      list: ["a", 2],
+      nested: { mode: "deep" },
+    },
+  },
+);
+assert.equal(parseCustomParametersDraft("[1, 2]").ok, false);
+assert.equal(parseCustomParametersDraft('{ "broken": [1, }').ok, false);
 
 console.info("Open-issue regressions passed.");

--- a/scripts/regressions/provider-compat.regression.ts
+++ b/scripts/regressions/provider-compat.regression.ts
@@ -1,6 +1,9 @@
 import assert from "node:assert/strict";
 import { createServer } from "node:http";
-import { findKnownModel } from "../../packages/shared/src/constants/model-lists.js";
+import {
+  findKnownModel,
+  resolveProviderReasoningEffort,
+} from "../../packages/shared/src/constants/model-lists.js";
 import {
   applyGlmThinkingParameters,
   isNativeGlmEndpoint,
@@ -107,6 +110,53 @@ try {
 } finally {
   await new Promise<void>((resolve, reject) =>
     gatewayServer.close((error) => (error ? reject(error) : resolve())),
+  );
+}
+
+let openRouterRequestBody: Record<string, unknown> | null = null;
+const openRouterServer = createServer(async (request, response) => {
+  const chunks: Buffer[] = [];
+  for await (const chunk of request) chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+  openRouterRequestBody = JSON.parse(Buffer.concat(chunks).toString("utf8")) as Record<string, unknown>;
+  response.writeHead(200, { "content-type": "application/json" });
+  response.end(JSON.stringify({ choices: [{ message: { content: "reasoned response" }, finish_reason: "stop" }] }));
+});
+await new Promise<void>((resolve) => openRouterServer.listen(0, "127.0.0.1", resolve));
+try {
+  const address = openRouterServer.address();
+  assert.ok(address && typeof address === "object");
+  const provider = new OpenAIProvider(
+    `http://127.0.0.1:${address.port}/v1`,
+    "test",
+    undefined,
+    undefined,
+    undefined,
+    "openrouter",
+  );
+  const resolvedTencentEffort = resolveProviderReasoningEffort({
+    provider: "openrouter",
+    model: "tencent/hy3:free",
+    reasoningEffort: "xhigh",
+  });
+  assert.equal(resolvedTencentEffort, "high");
+  assert.equal(
+    await collectProviderOutput(provider, {
+      model: "tencent/hy3:free",
+      stream: false,
+      enableThinking: true,
+      reasoningEffort: resolvedTencentEffort,
+      customParameters: { awesomesauce: "enabled", nested: { level: 3 } },
+    }),
+    "reasoned response",
+  );
+  const capturedOpenRouterBody = openRouterRequestBody as Record<string, unknown> | null;
+  assert.ok(capturedOpenRouterBody);
+  assert.deepEqual(capturedOpenRouterBody.reasoning, { effort: "high" });
+  assert.equal(capturedOpenRouterBody.awesomesauce, "enabled");
+  assert.deepEqual(capturedOpenRouterBody.nested, { level: 3 });
+} finally {
+  await new Promise<void>((resolve, reject) =>
+    openRouterServer.close((error) => (error ? reject(error) : resolve())),
   );
 }
 


### PR DESCRIPTION
## Linked issue

Closes #3687
Closes #3688

## Why this change

- Noodle reply mentions were plain text, and active Persona, Character, and lorebook macros could reach refresh prompts unresolved.
- Connection Custom Parameters discarded invalid drafts and made bare string values appear unsupported.
- Dynamically discovered OpenRouter models could resolve a reasoning effort in Peek Prompt while unknown-model parameter suppression removed the actual provider reasoning request.

## What changed

- Reused the accessible Noodle mention renderer for posts and replies, with live-account profile links and safe snapshot fallbacks.
- Built the standard Noodle macro context from the active Persona and Characters, then resolved Persona, Character, and final linked-lorebook content before provider submission.
- Added a conservative Custom Parameters parser that preserves arbitrary JSON values, accepts convenient bare scalar strings, and keeps invalid drafts visible with an error.
- Sent OpenRouter unified `reasoning: { effort }` configuration for dynamically discovered models without weakening sampler suppression.
- Updated provider logs to report the effective nested or legacy reasoning request and added regressions for the captured OpenRouter body.
- Updated the v3.2.2 changelog.

## Validation

- [ ] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed `CONTRIBUTING.md`

### Manual verification notes

- `pnpm check`
- `pnpm regression:providers`
- `pnpm regression:issues`
- `pnpm regression:noodle`
- Focused desktop Playwright flow: `Noodle posts tag invited characters with @handle mentions`
- `pnpm version:check`
- `pnpm credits:check`
- `git diff --check`
- Manually verify a Noodle refresh with `{{user}}` in the active Persona, Character, and linked lorebook content.
- Manually verify Custom Parameters save quoted JSON, bare string values, nested objects, arrays, numbers, booleans, and null.
- Manually verify OpenRouter reasoning on a dynamically discovered reasoning model.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Version/release files updated (only if this PR includes a version bump)

## UI evidence (if applicable)

- Behavioral editor and inline-link changes are covered by the focused browser regression; no screenshot attached.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Noodle now makes tagged `@mentions` clickable in posts and replies, opening the referenced profile.
  - Persona, character, and lorebook macros are resolved before Noodle refresh prompts are generated.
  - Connection Custom Parameters now preserve flexible JSON, bare-string values, and common literal formats instead of rejecting valid drafts.
  - Reasoning-effort settings now work consistently with dynamically discovered OpenRouter models.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->