### PR TITLE
Raise routine summary output budget

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 
 ### Fixed
 
+- Raised Conversation routine-summary generations from a 512-token ceiling to an 8,192-token default, honored larger Connection overrides, and requested low reasoning effort so reasoning models still return visible summaries (#3696).
 - Applied saved Connection Custom Parameters to every API-backed text generation that uses that connection, including Noodle and custom endpoints hosted locally, while preserving per-chat and per-call overrides.
 - Routed bare Cohere API roots and versioned API URLs through Cohere's OpenAI-compatible endpoint.
 - Kept the Noodle Carryover mode buttons equal-width while scaling their labels to remain fully visible with consistent spacing before each checkbox.

--- a/packages/server/src/services/conversation/schedule.service.ts
+++ b/packages/server/src/services/conversation/schedule.service.ts
@@ -31,12 +31,7 @@ export type { CharacterSchedules, ConversationMessageIntent, CurrentConversation
 // ── Constants ──
 
 const DAYS = CONVERSATION_SCHEDULE_DAYS;
-
-export const ROUTINE_SUMMARY_DEFAULT_MAX_TOKENS = 8192;
-
-export function resolveRoutineSummaryMaxTokens(maxTokensOverride: number | null): number {
-  return maxTokensOverride ?? ROUTINE_SUMMARY_DEFAULT_MAX_TOKENS;
-}
+const ROUTINE_SUMMARY_DEFAULT_MAX_TOKENS = 8192;
 
 export type WeekScheduleDraftMode = "rewrite" | "adjust" | "vary" | "repair";
 
@@ -321,7 +316,7 @@ export async function generateScheduleRoutineSummary(
     {
       model,
       temperature: 0.55,
-      maxTokens: resolveRoutineSummaryMaxTokens(provider.maxTokensOverrideValue),
+      maxTokens: provider.maxTokensOverrideValue ?? ROUTINE_SUMMARY_DEFAULT_MAX_TOKENS,
       reasoningEffort: "low",
     },
   );

--- a/packages/server/src/services/conversation/schedule.service.ts
+++ b/packages/server/src/services/conversation/schedule.service.ts
@@ -32,6 +32,12 @@ export type { CharacterSchedules, ConversationMessageIntent, CurrentConversation
 
 const DAYS = CONVERSATION_SCHEDULE_DAYS;
 
+export const ROUTINE_SUMMARY_DEFAULT_MAX_TOKENS = 8192;
+
+export function resolveRoutineSummaryMaxTokens(maxTokensOverride: number | null): number {
+  return maxTokensOverride ?? ROUTINE_SUMMARY_DEFAULT_MAX_TOKENS;
+}
+
 export type WeekScheduleDraftMode = "rewrite" | "adjust" | "vary" | "repair";
 
 export type WeekScheduleDraftOptions = {
@@ -312,7 +318,12 @@ export async function generateScheduleRoutineSummary(
       { role: "system", content: systemPrompt },
       { role: "user", content: "Summarize the routine." },
     ],
-    { model, temperature: 0.55, maxTokens: Math.min(provider.maxTokensOverrideValue ?? 512, 512) },
+    {
+      model,
+      temperature: 0.55,
+      maxTokens: resolveRoutineSummaryMaxTokens(provider.maxTokensOverrideValue),
+      reasoningEffort: "low",
+    },
   );
   const summary = (result.content ?? "").replace(/^```(?:text)?/i, "").replace(/```$/i, "").trim();
   if (!summary) throw new Error("Routine summary was empty");

--- a/scripts/regressions/open-issues.regression.ts
+++ b/scripts/regressions/open-issues.regression.ts
@@ -105,7 +105,10 @@ import {
   initializeActivityFromMessages,
   isAutonomousDailyBudgetExhausted,
 } from "../../packages/server/src/services/conversation/autonomous.service.js";
-import type { WeekSchedule } from "../../packages/server/src/services/conversation/schedule.service.js";
+import {
+  resolveRoutineSummaryMaxTokens,
+  type WeekSchedule,
+} from "../../packages/server/src/services/conversation/schedule.service.js";
 import { resolveGroupGenerationMode } from "../../packages/server/src/routes/generate/generate-route-utils.js";
 import { parseDockerDefaultGatewayIp } from "../../packages/server/src/middleware/ip-allowlist.js";
 import {
@@ -395,6 +398,10 @@ await assert.rejects(
   }),
   /selected selfie Prompt Model connection could not be found/u,
 );
+
+assert.equal(resolveRoutineSummaryMaxTokens(null), 8192);
+assert.equal(resolveRoutineSummaryMaxTokens(16_384), 16_384);
+assert.equal(resolveRoutineSummaryMaxTokens(4096), 4096);
 
 const autonomousSchedule = (talkativeness: number, cap: number): WeekSchedule => ({
   weekStart: "2026-07-13",

--- a/scripts/regressions/open-issues.regression.ts
+++ b/scripts/regressions/open-issues.regression.ts
@@ -106,9 +106,15 @@ import {
   isAutonomousDailyBudgetExhausted,
 } from "../../packages/server/src/services/conversation/autonomous.service.js";
 import {
-  resolveRoutineSummaryMaxTokens,
+  generateScheduleRoutineSummary,
   type WeekSchedule,
 } from "../../packages/server/src/services/conversation/schedule.service.js";
+import type {
+  BaseLLMProvider,
+  ChatCompletionResult,
+  ChatMessage,
+  ChatOptions,
+} from "../../packages/server/src/services/llm/base-provider.js";
 import { resolveGroupGenerationMode } from "../../packages/server/src/routes/generate/generate-route-utils.js";
 import { parseDockerDefaultGatewayIp } from "../../packages/server/src/middleware/ip-allowlist.js";
 import {
@@ -399,9 +405,37 @@ await assert.rejects(
   /selected selfie Prompt Model connection could not be found/u,
 );
 
-assert.equal(resolveRoutineSummaryMaxTokens(null), 8192);
-assert.equal(resolveRoutineSummaryMaxTokens(16_384), 16_384);
-assert.equal(resolveRoutineSummaryMaxTokens(4096), 4096);
+async function captureRoutineSummaryOptions(maxTokensOverrideValue: number | null): Promise<ChatOptions> {
+  let capturedOptions: ChatOptions | null = null;
+  const provider = {
+    maxTokensOverrideValue,
+    async chatComplete(_messages: ChatMessage[], options: ChatOptions): Promise<ChatCompletionResult> {
+      capturedOptions = options;
+      return { content: "Usually available in the evenings.", toolCalls: [], finishReason: "stop" };
+    },
+  } as unknown as BaseLLMProvider;
+
+  await generateScheduleRoutineSummary(provider, "reasoning-model", "Routine Tester", {
+    weekStart: "2026-07-13",
+    days: {},
+    inactivityThresholdMinutes: 60,
+    autonomousDailyCapOverride: 3,
+    talkativeness: 50,
+  });
+
+  assert.ok(capturedOptions);
+  return capturedOptions;
+}
+
+for (const [override, expectedMaxTokens] of [
+  [null, 8192],
+  [16_384, 16_384],
+  [4096, 4096],
+] as const) {
+  const options = await captureRoutineSummaryOptions(override);
+  assert.equal(options.maxTokens, expectedMaxTokens);
+  assert.equal(options.reasoningEffort, "low");
+}
 
 const autonomousSchedule = (talkativeness: number, cap: number): WeekSchedule => ({
   weekStart: "2026-07-13",


### PR DESCRIPTION
## Linked issue

Closes #3696

## Why this change

- Conversation routine summaries were hard-capped at 512 output tokens even when a Connection requested a larger limit. Reasoning-capable models could spend that entire allowance on hidden reasoning and return no visible summary.

## What changed

- Use an 8,192-token default for routine-summary generations.
- Honor explicit Connection output-token overrides instead of clamping them back to 512.
- Request low reasoning effort for the short summary task.
- Add regression coverage for the default, higher override, and explicit lower-cap cases.
- Document the fix in the changelog.

## Validation

- [ ] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed `CONTRIBUTING.md`

### Automated checks run

- `pnpm regression:issues`
- `pnpm check`
- `pnpm version:check`

### Manual verification notes

- Manually verify routine-summary generation with a reasoning-capable OpenAI-compatible Connection and no output-token override.
- Manually verify that an 8,192-or-higher Connection override is forwarded unchanged and produces visible summary text.
- Manually verify that an intentionally lower Connection cap remains respected.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Version/release files updated (only if this PR includes a version bump)

## UI evidence (if applicable)

- Not applicable; this is a server-side generation-budget fix.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Conversation routine summaries now support up to 8,192 tokens by default.
  * Larger configured token limits are now honored.
  * Summaries generated by reasoning models are more likely to include visible results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->