### PR TITLE
fix: hot-activate conversation games

### DIFF
--- a/docs/conversation/table-games.md
+++ b/docs/conversation/table-games.md
@@ -6,7 +6,7 @@ This guide covers the six optional table-game packages you can play against a ch
 
 Table games are small tabletop games that run right inside a Conversation Mode chat. Marinara Engine deals the cards or sets up the board, and it enforces every rule for you. Each seated character narrates its own moves in character. A live board appears above the message box while you play.
 
-Install each game you want from **Agents → Download Agents**, then restart Marinara when the catalog asks. An uninstalled game does not appear in the games picker, its slash command is unavailable, and its character command setting stays hidden.
+Install each game you want from **Agents → Download Agents**. It becomes available immediately without restarting Marinara. An uninstalled game does not appear in the games picker, its slash command is unavailable, and its character command setting stays hidden.
 
 Two facts to keep in mind:
 

--- a/docs/development/optional-agent-packages.md
+++ b/docs/development/optional-agent-packages.md
@@ -60,6 +60,8 @@ The server owns the installed-package registry and exposes installed capabilitie
 
 The manifest may declare `restartRequired` only when the host cannot safely reload that entry point. Successful hot activation says `Agent installed. It is ready to use.` Restart-required activation says `Agent installed. Restart Marinara Engine to finish setup.`
 
+Turn-game packages are hot-reloadable: installation registers their server engine and manual slash launcher immediately, and uninstallation detaches the runtime without an Engine restart. Per-chat Conversation Commands settings control only whether characters may emit the package's hidden command; they do not gate the user's slash launcher.
+
 ## Compatibility migration
 
 On the first upgraded launch:

--- a/docs/development/optional-agent-packages.md
+++ b/docs/development/optional-agent-packages.md
@@ -60,7 +60,7 @@ The server owns the installed-package registry and exposes installed capabilitie
 
 The manifest may declare `restartRequired` only when the host cannot safely reload that entry point. Successful hot activation says `Agent installed. It is ready to use.` Restart-required activation says `Agent installed. Restart Marinara Engine to finish setup.`
 
-Turn-game packages are hot-reloadable: installation registers their server engine and manual slash launcher immediately, and uninstallation detaches the runtime without an Engine restart. Per-chat Conversation Commands settings control only whether characters may emit the package's hidden command; they do not gate the user's slash launcher.
+Turn-game packages are hot-reloadable: installation registers their server engine and manual slash launcher immediately, and uninstallation detaches the runtime without an Engine restart. Per-chat Conversation Commands settings control only whether characters may emit the package's hidden command; they do not gate the user's slash launcher. Current official turn-game manifests retain their conservative legacy restart marker for Engine 2.x compatibility; Engine 3.x recognizes the `turn-game` kind, performs the safe hot activation, and returns the package as active and ready.
 
 ## Compatibility migration
 

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "regression:providers": "pnpm build:shared && pnpm --filter @marinara-engine/server exec tsx ../../scripts/regressions/provider-compat.regression.ts",
     "regression:jsonish": "pnpm --filter @marinara-engine/server exec tsx ../../scripts/regressions/jsonish-output.regression.ts",
     "regression:tts": "pnpm build:shared && pnpm --filter @marinara-engine/server exec tsx ../../scripts/regressions/tts-source-persistence.regression.ts",
-    "regression:issues": "pnpm --filter @marinara-engine/server exec tsx ../../scripts/regressions/open-issues.regression.ts && pnpm --filter @marinara-engine/server exec tsx ../../scripts/regressions/file-backed-shutdown.regression.ts && pnpm --filter @marinara-engine/server exec tsx ../../scripts/regressions/capability-package-lifecycle.regression.ts",
+    "regression:issues": "pnpm --filter @marinara-engine/server exec tsx ../../scripts/regressions/open-issues.regression.ts && pnpm --filter @marinara-engine/server exec tsx ../../scripts/regressions/file-backed-shutdown.regression.ts && pnpm --filter @marinara-engine/server exec tsx ../../scripts/regressions/capability-package-lifecycle.regression.ts && pnpm --filter @marinara-engine/server exec tsx ../../scripts/regressions/conversation-game-slash.regression.ts",
     "regression:roleplay": "pnpm build:shared && pnpm --filter @marinara-engine/server exec tsx ../../scripts/regressions/roleplay-streaming.regression.ts",
     "regression:sprites": "pnpm --filter @marinara-engine/server exec tsx ../../scripts/regressions/sprite-background.regression.ts",
     "smoke:ui": "playwright test -c playwright.config.ts",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "regression:providers": "pnpm build:shared && pnpm --filter @marinara-engine/server exec tsx ../../scripts/regressions/provider-compat.regression.ts",
     "regression:jsonish": "pnpm --filter @marinara-engine/server exec tsx ../../scripts/regressions/jsonish-output.regression.ts",
     "regression:tts": "pnpm build:shared && pnpm --filter @marinara-engine/server exec tsx ../../scripts/regressions/tts-source-persistence.regression.ts",
-    "regression:issues": "pnpm --filter @marinara-engine/server exec tsx ../../scripts/regressions/open-issues.regression.ts && pnpm --filter @marinara-engine/server exec tsx ../../scripts/regressions/file-backed-shutdown.regression.ts && pnpm --filter @marinara-engine/server exec tsx ../../scripts/regressions/capability-package-lifecycle.regression.ts && pnpm --filter @marinara-engine/server exec tsx ../../scripts/regressions/conversation-game-slash.regression.ts",
+    "regression:issues": "pnpm --filter @marinara-engine/server exec tsx ../../scripts/regressions/open-issues.regression.ts && pnpm --filter @marinara-engine/server exec tsx ../../scripts/regressions/file-backed-shutdown.regression.ts && pnpm --filter @marinara-engine/server exec tsx ../../scripts/regressions/capability-package-lifecycle.regression.ts && pnpm --filter @marinara-engine/client exec tsx ../../scripts/regressions/conversation-game-slash.regression.ts",
     "regression:roleplay": "pnpm build:shared && pnpm --filter @marinara-engine/server exec tsx ../../scripts/regressions/roleplay-streaming.regression.ts",
     "regression:sprites": "pnpm --filter @marinara-engine/server exec tsx ../../scripts/regressions/sprite-background.regression.ts",
     "smoke:ui": "playwright test -c playwright.config.ts",

--- a/packages/client/src/components/chat/ChatSettingsDrawer.tsx
+++ b/packages/client/src/components/chat/ChatSettingsDrawer.tsx
@@ -8647,8 +8647,8 @@ export function ChatSettingsDrawer({
 
             {agentAddIsFeature ? (
               <div className="rounded-xl bg-[var(--secondary)]/70 px-3 py-2.5 text-[0.6875rem] leading-5 text-[var(--muted-foreground)] ring-1 ring-[var(--border)]">
-                This activates the downloaded feature for this chat. Its package owns the UI and runtime, so it does not
-                make a separate agent model call or use an agent connection.
+                This lets characters initiate the downloaded feature in this chat. Manual controls supplied by the
+                installed package remain available independently, and no separate agent model call or connection is used.
               </div>
             ) : agentAddIsRuntimeDisabled ? (
               <div className="rounded-xl bg-[var(--secondary)]/70 px-3 py-2.5 text-[0.6875rem] leading-5 text-[var(--muted-foreground)] ring-1 ring-[var(--border)]">

--- a/packages/client/src/components/chat/ChatSetupWizard.tsx
+++ b/packages/client/src/components/chat/ChatSetupWizard.tsx
@@ -2710,7 +2710,8 @@ function RoleplaySetupWizard({ chat, onFinish }: ChatSetupWizardProps) {
 
                 {agentAddPreview.agent.execution === "feature" ? (
                   <p className="rounded-lg bg-[var(--accent)] px-3 py-2 text-[0.6875rem] text-[var(--muted-foreground)] ring-1 ring-[var(--border)]">
-                    This activates the downloaded feature for this chat. It does not make a separate agent model call.
+                    This lets characters initiate the downloaded feature in this chat. Manual controls supplied by the
+                    installed package remain available independently, and no separate agent model call is used.
                   </p>
                 ) : (
                   <div className="grid gap-3 sm:grid-cols-2">

--- a/packages/client/src/components/chat/ConversationInput.tsx
+++ b/packages/client/src/components/chat/ConversationInput.tsx
@@ -31,6 +31,7 @@ import {
   matchSlashCommand,
   shouldExecuteQuickPostAsCommand,
   getSlashCompletions,
+  type ConversationGameSlashContribution,
   type SlashCommand,
   type SlashCommandContext,
 } from "../../lib/slash-commands";
@@ -68,6 +69,7 @@ import {
   startsWithTextForMatch,
   type MariSuggestionChip,
   type Message,
+  isInstalledCapabilityReady,
 } from "@marinara-engine/shared";
 
 interface Attachment {
@@ -160,6 +162,7 @@ function buildConversationSlashCompletions(
   input: string,
   characters: Array<{ id: string; name: string }> | undefined,
   availableCapabilityIds: ReadonlySet<string>,
+  conversationGames: readonly ConversationGameSlashContribution[],
 ): ConversationSlashCompletion[] {
   if (!input.startsWith("/")) return [];
 
@@ -216,7 +219,7 @@ function buildConversationSlashCompletions(
       });
   }
 
-  return getSlashCompletions(input, { mode: "conversation", availableCapabilityIds })
+  return getSlashCompletions(input, { mode: "conversation", availableCapabilityIds, conversationGames })
     .filter((command) => !isConversationHiddenSlashCommand(command))
     .map((command) => {
       const { value, cursor } = buildSlashCommandPrefill(command, characters);
@@ -361,12 +364,24 @@ export function ConversationInput({
     () => new Set(installedCapabilities.filter((item) => item.status === "active").map((item) => item.id)),
     [installedCapabilities],
   );
-  const availableConversationGames = installedCapabilities.filter(
-    (item) =>
-      item.status === "active" &&
-      item.manifest.kind.includes("turn-game") &&
-      item.manifest.entrypoints.client &&
-      item.manifest.contributions?.conversationGame,
+  const availableConversationGames = useMemo(
+    () => installedCapabilities.filter(
+      (item) =>
+        isInstalledCapabilityReady(item) &&
+        item.manifest.kind.includes("turn-game") &&
+        item.manifest.entrypoints.client &&
+        item.manifest.contributions?.conversationGame,
+    ),
+    [installedCapabilities],
+  );
+  const conversationGameSlashContributions = useMemo<ConversationGameSlashContribution[]>(
+    () => availableConversationGames.map((game) => ({
+      packageId: game.id,
+      packageName: game.manifest.name,
+      command: game.manifest.contributions!.conversationGame!.command,
+      aliases: game.manifest.contributions!.conversationGame!.aliases,
+    })),
+    [availableConversationGames],
   );
   const chatName = activeChat?.name;
   const streamingChatId = useChatStore((s) => s.streamingChatId);
@@ -933,7 +948,11 @@ export function ConversationInput({
     }
 
     // Slash command check
-    const matched = matchSlashCommand(raw, { mode: "conversation", availableCapabilityIds });
+    const matched = matchSlashCommand(raw, {
+      mode: "conversation",
+      availableCapabilityIds,
+      conversationGames: conversationGameSlashContributions,
+    });
     if (matched) {
       if (isConversationHiddenSlashCommand(matched.command)) {
         setFeedback("Impersonate is not available in Conversation mode.");
@@ -955,6 +974,7 @@ export function ConversationInput({
         illustrate: onIllustrate,
         selfie: onGenerateSelfie,
         availableCapabilityIds,
+        conversationGames: conversationGameSlashContributions,
       };
       const submittedDraft = textareaRef.current?.value ?? "";
       const submittedHeight = textareaRef.current?.style.height ?? "auto";
@@ -1098,13 +1118,18 @@ export function ConversationInput({
     onIllustrate,
     onGenerateSelfie,
     availableCapabilityIds,
+    conversationGameSlashContributions,
   ]);
 
   const runQuickSlashCommand = useCallback(
     async (commandLine: string, fallbackError: string) => {
       if (!activeChatId) return;
       const submittingChatId = activeChatId;
-      const matched = matchSlashCommand(commandLine, { mode: "conversation", availableCapabilityIds });
+      const matched = matchSlashCommand(commandLine, {
+        mode: "conversation",
+        availableCapabilityIds,
+        conversationGames: conversationGameSlashContributions,
+      });
       if (!matched) return;
       if (isConversationHiddenSlashCommand(matched.command)) {
         toast.info("Impersonate is not available in Conversation mode.");
@@ -1131,6 +1156,7 @@ export function ConversationInput({
         illustrate: onIllustrate,
         selfie: onGenerateSelfie,
         availableCapabilityIds,
+        conversationGames: conversationGameSlashContributions,
       };
 
       const previousDraft = textareaRef.current?.value ?? "";
@@ -1197,6 +1223,7 @@ export function ConversationInput({
       onIllustrate,
       onGenerateSelfie,
       availableCapabilityIds,
+      conversationGameSlashContributions,
       qc,
       setInputDraft,
       syncInputState,
@@ -1215,7 +1242,11 @@ export function ConversationInput({
     const hasFiles = attachments.length > 0;
     if (!hasText && !hasFiles) return;
 
-    if (shouldExecuteQuickPostAsCommand(raw, { mode: "conversation", availableCapabilityIds })) {
+    if (shouldExecuteQuickPostAsCommand(raw, {
+      mode: "conversation",
+      availableCapabilityIds,
+      conversationGames: conversationGameSlashContributions,
+    })) {
       await handleSend();
       return;
     }
@@ -1337,6 +1368,7 @@ export function ConversationInput({
     updateMessageExtra,
     handleSend,
     availableCapabilityIds,
+    conversationGameSlashContributions,
   ]);
 
   const handleGuidedGenerationButton = useCallback(async () => {
@@ -1535,7 +1567,12 @@ export function ConversationInput({
 
       // Slash completions
       if (formatted.startsWith("/")) {
-        const results = buildConversationSlashCompletions(formatted, activeChatCharacters, availableCapabilityIds);
+        const results = buildConversationSlashCompletions(
+          formatted,
+          activeChatCharacters,
+          availableCapabilityIds,
+          conversationGameSlashContributions,
+        );
         setCompletions(results);
         setSelectedCompletion(0);
       } else {
@@ -1600,6 +1637,7 @@ export function ConversationInput({
       setInputDraft,
       syncInputState,
       availableCapabilityIds,
+      conversationGameSlashContributions,
     ],
   );
 

--- a/packages/client/src/hooks/use-capability-packages.ts
+++ b/packages/client/src/hooks/use-capability-packages.ts
@@ -121,7 +121,7 @@ export function useInstallCapabilityPackage() {
   const invalidate = useInvalidateCapabilityState();
   return useMutation({
     mutationFn: (id: string) => api.post<InstalledCapabilityPackage>(`/capability-packages/${id}/install`),
-    onSuccess: invalidate,
+    onSettled: invalidate,
   });
 }
 

--- a/packages/client/src/lib/slash-commands.ts
+++ b/packages/client/src/lib/slash-commands.ts
@@ -80,11 +80,21 @@ export interface SlashCommandContext {
   selfie?: (characterId?: string) => void | Promise<void>;
   /** Active downloadable capability packages available to this composer. */
   availableCapabilityIds?: ReadonlySet<string>;
+  /** Installed Conversation games that contribute manual slash launchers. */
+  conversationGames?: readonly ConversationGameSlashContribution[];
+}
+
+export interface ConversationGameSlashContribution {
+  packageId: string;
+  packageName: string;
+  command: string;
+  aliases: readonly string[];
 }
 
 export interface SlashCommandAvailability {
   mode?: "conversation" | "roleplay";
   availableCapabilityIds?: ReadonlySet<string>;
+  conversationGames?: readonly ConversationGameSlashContribution[];
 }
 
 function isSlashCommandAvailable(command: SlashCommand, availability: SlashCommandAvailability = {}): boolean {
@@ -270,7 +280,7 @@ function withSlashCommandTimeout<T>(promise: Promise<T>, timeoutMs: number, mess
 }
 
 function buildSlashHelpText(availability: SlashCommandAvailability): string {
-  const availableCommands = COMMANDS.filter((command) => isSlashCommandAvailable(command, availability));
+  const availableCommands = getAvailableSlashCommands(availability);
   return [
     "Available Commands:",
     "",
@@ -559,7 +569,11 @@ const COMMANDS: SlashCommand[] = [
     async execute(_args, ctx) {
       return {
         handled: true,
-        feedback: buildSlashHelpText({ mode: ctx.mode, availableCapabilityIds: ctx.availableCapabilityIds }),
+        feedback: buildSlashHelpText({
+          mode: ctx.mode,
+          availableCapabilityIds: ctx.availableCapabilityIds,
+          conversationGames: ctx.conversationGames,
+        }),
       };
     },
   },
@@ -1300,6 +1314,48 @@ const COMMANDS: SlashCommand[] = [
   },
 ];
 
+function buildConversationGameSlashCommands(
+  games: readonly ConversationGameSlashContribution[] = [],
+): SlashCommand[] {
+  const reserved = new Set(
+    COMMANDS.flatMap((command) => [command.name, ...(command.aliases ?? [])]).map((name) => name.toLocaleLowerCase()),
+  );
+  const commands: SlashCommand[] = [];
+  for (const game of games) {
+    const name = game.command.startsWith("/") ? game.command.slice(1).toLocaleLowerCase() : "";
+    if (!/^[a-z0-9-]+$/u.test(name) || reserved.has(name)) continue;
+    reserved.add(name);
+    const aliases = game.aliases
+      .map((alias) => alias.trim().toLocaleLowerCase())
+      .filter((alias) => {
+        if (!/^[a-z0-9-]+$/u.test(alias) || reserved.has(alias)) return false;
+        reserved.add(alias);
+        return true;
+      });
+    commands.push({
+      name,
+      aliases,
+      description: `Start ${game.packageName}`,
+      usage: game.command,
+      requiredCapabilityId: game.packageId,
+      modes: ["conversation"],
+      local: true,
+      async execute(args, ctx) {
+        if (args.trim()) return { handled: true, feedback: `Usage: ${game.command}` };
+        useConversationGamesStore.getState().openSetup(game.packageId, ctx.chatId);
+        return { handled: true };
+      },
+    });
+  }
+  return commands;
+}
+
+function getAvailableSlashCommands(availability: SlashCommandAvailability = {}): SlashCommand[] {
+  return [...COMMANDS, ...buildConversationGameSlashCommands(availability.conversationGames)].filter((command) =>
+    isSlashCommandAvailable(command, availability),
+  );
+}
+
 /** Find a matching command for the given input. */
 export function matchSlashCommand(
   input: string,
@@ -1310,7 +1366,7 @@ export function matchSlashCommand(
   const cmdName = (spaceIdx === -1 ? input.slice(1) : input.slice(1, spaceIdx)).toLowerCase();
   const args = spaceIdx === -1 ? "" : input.slice(spaceIdx + 1);
 
-  for (const cmd of COMMANDS) {
+  for (const cmd of getAvailableSlashCommands(availability)) {
     if ((cmd.name === cmdName || cmd.aliases?.includes(cmdName)) && isSlashCommandAvailable(cmd, availability)) {
       return { command: cmd, args };
     }
@@ -1329,7 +1385,7 @@ export function getSlashCompletions(partial: string, availability: SlashCommandA
   const rawPrefix = partial.slice(1);
   if (rawPrefix.includes(" ")) return [];
   const prefix = rawPrefix.trim().toLowerCase();
-  const availableCommands = COMMANDS.filter((command) => isSlashCommandAvailable(command, availability));
+  const availableCommands = getAvailableSlashCommands(availability);
   if (!prefix) return availableCommands;
   return availableCommands.filter(
     (command) => command.name.startsWith(prefix) || command.aliases?.some((alias) => alias.startsWith(prefix)),

--- a/packages/client/src/lib/slash-commands.ts
+++ b/packages/client/src/lib/slash-commands.ts
@@ -1318,15 +1318,15 @@ function buildConversationGameSlashCommands(
   games: readonly ConversationGameSlashContribution[] = [],
 ): SlashCommand[] {
   const reserved = new Set(
-    COMMANDS.flatMap((command) => [command.name, ...(command.aliases ?? [])]).map((name) => name.toLocaleLowerCase()),
+    COMMANDS.flatMap((command) => [command.name, ...(command.aliases ?? [])]).map((name) => name.toLowerCase()),
   );
   const commands: SlashCommand[] = [];
   for (const game of games) {
-    const name = game.command.startsWith("/") ? game.command.slice(1).toLocaleLowerCase() : "";
+    const name = game.command.startsWith("/") ? game.command.slice(1).toLowerCase() : "";
     if (!/^[a-z0-9-]+$/u.test(name) || reserved.has(name)) continue;
     reserved.add(name);
     const aliases = game.aliases
-      .map((alias) => alias.trim().toLocaleLowerCase())
+      .map((alias) => alias.trim().toLowerCase())
       .filter((alias) => {
         if (!/^[a-z0-9-]+$/u.test(alias) || reserved.has(alias)) return false;
         reserved.add(alias);

--- a/packages/server/src/routes/capability-packages.routes.ts
+++ b/packages/server/src/routes/capability-packages.routes.ts
@@ -4,6 +4,7 @@ import { z } from "zod";
 import { BUILT_IN_AGENT_MANIFESTS } from "@marinara-engine/shared";
 import { requirePrivilegedAccess } from "../middleware/privileged-gate.js";
 import { capabilityPackageManager } from "../services/capability-packages/package-manager.service.js";
+import { capabilityModuleRuntime } from "../services/capability-packages/capability-module-runtime.service.js";
 import { refreshCapabilityAgentRegistry } from "../services/capability-packages/capability-agent-registry.service.js";
 import { createChatsStorage } from "../services/storage/chats.storage.js";
 import { createAgentsStorage } from "../services/storage/agents.storage.js";
@@ -27,12 +28,19 @@ export async function capabilityPackagesRoutes(app: FastifyInstance) {
     if (!requirePrivilegedAccess(request, reply, { feature: "Agent package installation" })) return;
     const { id } = packageParams.parse(request.params);
     const installed = await capabilityPackageManager.install(id);
-    await refreshCapabilityAgentRegistry();
-    return installed;
+    try {
+      return installed.manifest.kind.includes("turn-game")
+        ? await capabilityModuleRuntime.activatePackage(app, id)
+        : installed;
+    } finally {
+      await refreshCapabilityAgentRegistry();
+    }
   });
   app.delete<{ Params: { id: string } }>("/:id", async (request, reply) => {
     if (!requirePrivilegedAccess(request, reply, { feature: "Agent package removal" })) return;
     const { id } = packageParams.parse(request.params);
+    const existing = (await capabilityPackageManager.installed()).find((item) => item.id === id);
+    if (existing?.manifest.kind.includes("turn-game")) await capabilityModuleRuntime.deactivatePackage(id);
     const removed = await capabilityPackageManager.uninstall(id);
     if (!removed) return reply.status(404).send({ error: "Package not found" });
     const chats = createChatsStorage(app.db);
@@ -55,6 +63,10 @@ export async function capabilityPackagesRoutes(app: FastifyInstance) {
     const agentConfig = await createAgentsStorage(app.db).getByType(id);
     if (agentConfig) await createAgentsStorage(app.db).remove(agentConfig.id);
     await refreshCapabilityAgentRegistry();
-    return { restartRequired: Boolean(removed.manifest.entrypoints.server || removed.manifest.entrypoints.client) };
+    return {
+      restartRequired:
+        !removed.manifest.kind.includes("turn-game") &&
+        Boolean(removed.manifest.entrypoints.server || removed.manifest.entrypoints.client),
+    };
   });
 }

--- a/packages/server/src/services/capability-packages/capability-module-runtime.service.ts
+++ b/packages/server/src/services/capability-packages/capability-module-runtime.service.ts
@@ -47,7 +47,7 @@ async function runCleanups(cleanups: Cleanup[]): Promise<void> {
 }
 
 class CapabilityModuleRuntime {
-  private cleanup: Cleanup[] = [];
+  private cleanups = new Map<string, Cleanup>();
 
   async start(app: FastifyInstance): Promise<void> {
     // Bundled package modules execute before activate(context), so give their
@@ -57,7 +57,7 @@ class CapabilityModuleRuntime {
     prepareCapabilityRuntimeEnvironment();
     await this.ensureModuleResolution();
     for (const runtimePackage of await capabilityPackageManager.runtimePackages()) {
-      await this.activateOne(app, runtimePackage, true);
+      await this.activateOne(app, runtimePackage, true, false);
     }
   }
 
@@ -79,6 +79,7 @@ class CapabilityModuleRuntime {
     app: FastifyInstance,
     runtimePackage: Awaited<ReturnType<typeof capabilityPackageManager.runtimePackages>>[number],
     allowRollback: boolean,
+    throwOnFailure: boolean,
   ): Promise<void> {
     const { installed, serverEntrypoint } = runtimePackage;
     const registeredCleanups: Cleanup[] = [];
@@ -88,7 +89,9 @@ class CapabilityModuleRuntime {
       const blockReason = capabilityPackageManager.runtimeBlockReason(installed);
       if (blockReason) throw new Error(blockReason);
 
-      const module = (await import(pathToFileURL(serverEntrypoint).href)) as CapabilityModule;
+      const moduleUrl = new URL(pathToFileURL(serverEntrypoint).href);
+      moduleUrl.searchParams.set("activation", `${installed.version}-${Date.now()}`);
+      const module = (await import(moduleUrl.href)) as CapabilityModule;
       if (typeof module.activate !== "function") throw new Error("Server entrypoint must export activate(context)");
       const trackCleanup = (cleanup: Cleanup) => {
         let called = false;
@@ -117,7 +120,7 @@ class CapabilityModuleRuntime {
       await module.selfCheck?.(context);
       await capabilityPackageManager.markRuntimeStatus(installed.id, "active");
       await capabilityPackageManager.markRuntimeReadiness(installed.id, "ready");
-      this.cleanup.push(async () => {
+      this.cleanups.set(installed.id, async () => {
         if (moduleCleanup) await moduleCleanup();
         await runCleanups(registeredCleanups);
       });
@@ -133,7 +136,13 @@ class CapabilityModuleRuntime {
       const previous = allowRollback ? await capabilityPackageManager.rollbackRuntime(installed.id) : null;
       if (previous) {
         logger.warn("Rolling capability package %s back to %s", installed.id, previous.installed.version);
-        await this.activateOne(app, previous, false);
+        await this.activateOne(app, previous, false, false);
+        if (throwOnFailure) {
+          throw new Error(
+            `Could not activate ${installed.id}@${installed.version}; restored ${previous.installed.version}`,
+            { cause: error },
+          );
+        }
         return;
       }
       await capabilityPackageManager.markRuntimeStatus(
@@ -146,11 +155,35 @@ class CapabilityModuleRuntime {
         "error",
         error instanceof Error ? error.message : String(error),
       );
+      if (throwOnFailure) throw error;
     }
   }
 
+  async activatePackage(app: FastifyInstance, packageId: string): Promise<InstalledCapabilityPackage> {
+    prepareCapabilityRuntimeEnvironment();
+    await this.ensureModuleResolution();
+    const runtimePackage = (await capabilityPackageManager.runtimePackages()).find(
+      ({ installed }) => installed.id === packageId,
+    );
+    if (!runtimePackage) throw new Error(`Installed capability package ${packageId} has no server runtime`);
+    await this.deactivatePackage(packageId);
+    await this.activateOne(app, runtimePackage, true, true);
+    const installed = (await capabilityPackageManager.installed()).find((item) => item.id === packageId);
+    if (!installed) throw new Error(`Capability package ${packageId} disappeared during activation`);
+    return installed;
+  }
+
+  async deactivatePackage(packageId: string): Promise<void> {
+    const cleanup = this.cleanups.get(packageId);
+    if (!cleanup) return;
+    this.cleanups.delete(packageId);
+    await cleanup();
+    logger.info("Deactivated capability package %s", packageId);
+  }
+
   async stop(): Promise<void> {
-    for (const cleanup of this.cleanup.splice(0).reverse()) {
+    for (const [packageId, cleanup] of [...this.cleanups.entries()].reverse()) {
+      this.cleanups.delete(packageId);
       try {
         await cleanup();
       } catch (error) {

--- a/packages/server/src/services/capability-packages/capability-module-runtime.service.ts
+++ b/packages/server/src/services/capability-packages/capability-module-runtime.service.ts
@@ -212,7 +212,11 @@ class CapabilityModuleRuntime {
     const cleanup = this.cleanups.get(packageId);
     if (!cleanup) return;
     this.cleanups.delete(packageId);
-    await cleanup();
+    try {
+      await cleanup();
+    } catch (error) {
+      logger.warn(error, "Capability package %s cleanup failed during deactivation", packageId);
+    }
     logger.info("Deactivated capability package %s", packageId);
   }
 

--- a/scripts/regressions/capability-package-lifecycle.regression.ts
+++ b/scripts/regressions/capability-package-lifecycle.regression.ts
@@ -12,7 +12,7 @@ const migrationPath = join(packagesRoot, "availability-migration-v1.json");
 const modelsRoot = join(dataDir, "models");
 const speechConfigPath = join(modelsRoot, "sidecar-speech-config.json");
 
-function installedPackage(id: string, kind: string[], version = "1.0.0") {
+function installedPackage(id: string, kind: string[], version = "1.0.0", restartRequired = true) {
   return {
     id,
     version,
@@ -30,7 +30,7 @@ function installedPackage(id: string, kind: string[], version = "1.0.0") {
         { path: "client.js", sha256: "0".repeat(64), bytes: 1 },
       ],
       permissions: ["ui"],
-      restartRequired: true,
+      restartRequired,
     },
     installedAt: "2026-07-14T00:00:00.000Z",
     status: "active",
@@ -337,6 +337,26 @@ try {
   );
   assert.equal(JSON.stringify(diagnostics).includes("snapshot read failed"), false, "Health diagnostics must omit errors");
 
+  await capabilityModuleRuntime.stop();
+  assert.equal(getCapabilityService("readiness:success"), null, "Runtime stop must remove ready contributions");
+  const hotGame = installedPackage("hot-game", ["agent", "turn-game"], "1.0.0", false);
+  writeRegistry([hotGame]);
+  writeFileSync(
+    join(packagesRoot, "versions", hotGame.id, hotGame.version, "server.mjs"),
+    `export async function activate({ api }) {
+      return api.registerService("hot-game:runtime", { active: true });
+    }`,
+  );
+  const activatedHotGame = await capabilityModuleRuntime.activatePackage(
+    {} as Parameters<typeof capabilityModuleRuntime.activatePackage>[0],
+    hotGame.id,
+  );
+  assert.equal(activatedHotGame.status, "active");
+  assert.equal(activatedHotGame.readiness, "ready");
+  assert.deepEqual(getCapabilityService("hot-game:runtime"), { active: true });
+  await capabilityModuleRuntime.deactivatePackage(hotGame.id);
+  assert.equal(getCapabilityService("hot-game:runtime"), null, "Hot uninstall must remove game contributions");
+
   const { getFileTableConfig, isFileTable } = await import("../../packages/server/src/db/file-schema.js");
   const packageTable = {};
   Object.defineProperty(packageTable, Symbol.for("marinara:file-table"), {
@@ -346,7 +366,6 @@ try {
   assert.equal(getFileTableConfig(packageTable as never).name, "package_fixture");
 
   await capabilityModuleRuntime.stop();
-  assert.equal(getCapabilityService("readiness:success"), null, "Runtime stop must remove ready contributions");
 
   console.info("Capability package lifecycle and readiness regressions passed.");
 } finally {

--- a/scripts/regressions/capability-package-lifecycle.regression.ts
+++ b/scripts/regressions/capability-package-lifecycle.regression.ts
@@ -339,7 +339,7 @@ try {
 
   await capabilityModuleRuntime.stop();
   assert.equal(getCapabilityService("readiness:success"), null, "Runtime stop must remove ready contributions");
-  const hotGame = installedPackage("hot-game", ["agent", "turn-game"], "1.0.0", false);
+  const hotGame = installedPackage("hot-game", ["agent", "turn-game"], "1.0.0", true);
   writeRegistry([hotGame]);
   writeFileSync(
     join(packagesRoot, "versions", hotGame.id, hotGame.version, "server.mjs"),

--- a/scripts/regressions/capability-package-lifecycle.regression.ts
+++ b/scripts/regressions/capability-package-lifecycle.regression.ts
@@ -607,6 +607,7 @@ try {
   assert.equal(getCapabilityService("readiness:success"), null, "Runtime stop must remove ready contributions");
   const hotGame = installedPackage("hot-game", ["agent", "turn-game"], "1.0.0", false);
   writeRegistry([hotGame]);
+  mkdirSync(join(packagesRoot, "versions", hotGame.id, hotGame.version), { recursive: true });
   writeFileSync(
     join(packagesRoot, "versions", hotGame.id, hotGame.version, "server.mjs"),
     `export async function activate({ api }) {

--- a/scripts/regressions/conversation-game-slash.regression.ts
+++ b/scripts/regressions/conversation-game-slash.regression.ts
@@ -11,7 +11,7 @@ const availability = {
       packageId: "eightball",
       packageName: "8-Ball Pool",
       command: "/8ball",
-      aliases: ["8-ball", "8 ball", "eightball", "pool", "billiards"],
+      aliases: ["8-ball", "eightball", "pool", "billiards"],
     },
   ],
 };

--- a/scripts/regressions/conversation-game-slash.regression.ts
+++ b/scripts/regressions/conversation-game-slash.regression.ts
@@ -1,0 +1,45 @@
+import assert from "node:assert/strict";
+import { getSlashCompletions, matchSlashCommand } from "../../packages/client/src/lib/slash-commands.js";
+import { useConversationGamesStore } from "../../packages/client/src/stores/conversation-games.store.js";
+
+const availability = {
+  mode: "conversation" as const,
+  availableCapabilityIds: new Set(["uno", "eightball"]),
+  conversationGames: [
+    { packageId: "uno", packageName: "UNO", command: "/uno", aliases: ["uno"] },
+    {
+      packageId: "eightball",
+      packageName: "8-Ball Pool",
+      command: "/8ball",
+      aliases: ["8-ball", "8 ball", "eightball", "pool", "billiards"],
+    },
+  ],
+};
+
+const uno = matchSlashCommand("/uno", availability);
+assert.equal(uno?.command.name, "uno", "An installed game's primary slash command must be registered");
+await uno?.command.execute("", { chatId: "conversation-chat", mode: "conversation" } as never);
+assert.deepEqual(useConversationGamesStore.getState().setup, {
+  packageId: "uno",
+  chatId: "conversation-chat",
+});
+
+const pool = matchSlashCommand("/pool", availability);
+assert.equal(pool?.command.name, "8ball", "Single-token package aliases must become slash aliases");
+assert.equal(
+  getSlashCompletions("/un", availability).some((command) => command.name === "uno"),
+  true,
+  "Installed game commands must appear in slash autocomplete",
+);
+assert.equal(
+  matchSlashCommand("/uno", { ...availability, mode: "roleplay" }),
+  null,
+  "Conversation game commands must remain unavailable in Roleplay chats",
+);
+assert.equal(
+  matchSlashCommand("/uno", { mode: "conversation", availableCapabilityIds: new Set(), conversationGames: [] }),
+  null,
+  "Uninstalled games must not contribute slash commands",
+);
+
+console.info("Dynamic conversation game slash regressions passed.");

--- a/scripts/regressions/conversation-game-slash.regression.ts
+++ b/scripts/regressions/conversation-game-slash.regression.ts
@@ -4,17 +4,42 @@ import { useConversationGamesStore } from "../../packages/client/src/stores/conv
 
 const availability = {
   mode: "conversation" as const,
-  availableCapabilityIds: new Set(["uno", "eightball"]),
+  availableCapabilityIds: new Set([
+    "uno",
+    "chess",
+    "poker",
+    "eightball",
+    "tic-tac-toe",
+    "rock-paper-scissors",
+  ]),
   conversationGames: [
     { packageId: "uno", packageName: "UNO", command: "/uno", aliases: ["uno"] },
+    { packageId: "chess", packageName: "Chess", command: "/chess", aliases: ["chess"] },
+    { packageId: "poker", packageName: "Poker", command: "/poker", aliases: ["poker", "hold'em"] },
     {
       packageId: "eightball",
       packageName: "8-Ball Pool",
       command: "/8ball",
       aliases: ["8-ball", "8 ball", "eightball", "pool", "billiards"],
     },
+    {
+      packageId: "tic-tac-toe",
+      packageName: "Tic-Tac-Toe",
+      command: "/tictactoe",
+      aliases: ["tic-tac-toe", "tic tac toe", "ttt"],
+    },
+    {
+      packageId: "rock-paper-scissors",
+      packageName: "Rock-Paper-Scissors",
+      command: "/rps",
+      aliases: ["rock paper scissors", "rock-paper-scissors", "rps"],
+    },
   ],
 };
+
+for (const command of ["/uno", "/chess", "/poker", "/8ball", "/tictactoe", "/rps"]) {
+  assert.ok(matchSlashCommand(command, availability), `${command} must be registered after its package is installed`);
+}
 
 const uno = matchSlashCommand("/uno", availability);
 assert.equal(uno?.command.name, "uno", "An installed game's primary slash command must be registered");
@@ -26,6 +51,8 @@ assert.deepEqual(useConversationGamesStore.getState().setup, {
 
 const pool = matchSlashCommand("/pool", availability);
 assert.equal(pool?.command.name, "8ball", "Single-token package aliases must become slash aliases");
+const ttt = matchSlashCommand("/ttt", availability);
+assert.equal(ttt?.command.name, "tictactoe", "Tic-Tac-Toe's short alias must open the installed game");
 assert.equal(
   getSlashCompletions("/un", availability).some((command) => command.name === "uno"),
   true,


### PR DESCRIPTION
## Linked issue

Closes #3699

Paired package publication: Pasta-Devs/Marinara-Agents#55.

## Why this change

Installed Conversation game manifests declare manual launchers such as `/uno`, but the client slash matcher only considered static Engine commands. Game commands therefore fell through as ordinary chat text. The same packages were marked restart-required even though turn-game runtimes register reloadable engines, commands, and services rather than Fastify routes.

## What changed

- Synthesize slash commands and single-token aliases from ready installed `conversationGame` manifest contributions.
- Make those commands available in autocomplete, `/help`, normal Send, and Quick Replies Post Only without consulting per-chat character-command toggles.
- Add focused hot activation/deactivation for `turn-game` server runtimes while preserving restart behavior for route-bearing packages.
- Refresh the installed package and agent registries after activation and hot-detach game runtimes before uninstall.
- Document install-only manual launch behavior and add regressions for slash discovery plus runtime activation cleanup.

## Validation

- [ ] `pnpm check`
- [ ] Capability package lifecycle regression
- [ ] Conversation game slash regression
- [ ] Install a game in a running Engine and launch it immediately with its slash command
- [ ] Confirm the slash command works with the chat's Commands toggle off
- [ ] Uninstall the game and confirm its slash command and surface disappear without restart
- [ ] Confirm Maps and Calls retain their existing restart-required path

### Automated evidence

- `pnpm check` — passed.
- `pnpm --filter @marinara-engine/server exec tsx ../../scripts/regressions/capability-package-lifecycle.regression.ts` — passed.
- `pnpm --filter @marinara-engine/server exec tsx ../../scripts/regressions/conversation-game-slash.regression.ts` — passed.

### Manual proof gap

A live install/uninstall browser smoke test remains before this draft is ready. The paired 1.0.2 package artifacts are being prepared separately.

## Risk

This changes executable capability-package lifecycle behavior. Hot activation is intentionally restricted to packages whose manifest includes `turn-game`; route-bearing Maps and Calls packages are not dynamically registered into an already-ready Fastify instance.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Installed conversation games now appear immediately in slash-command autocomplete and can be launched without restarting.
  * Game commands and aliases are available only when the corresponding game is installed and ready.
  * Uninstalling a game removes its commands and runtime contributions immediately.

* **Documentation**
  * Clarified installation, availability, and restart behavior for table games and optional agent packages.

* **Bug Fixes**
  * Improved command matching and availability across conversation modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->