### PR TITLE
Add reusable Game Mode setup imports

### DIFF
--- a/e2e/core-flows.e2e.ts
+++ b/e2e/core-flows.e2e.ts
@@ -1969,7 +1969,30 @@ test("Game setup only shows features owned by installed agents", async ({ page, 
       ),
     ).toBeVisible();
 
-    let dialog = await openLorebooksStep();
+    const temperatureField = initialDialog.locator('input[inputmode="decimal"]').first();
+    await expect(temperatureField).toHaveValue("0.65");
+    await initialDialog.getByRole("button", { name: "Next", exact: true }).click();
+    await expect(initialDialog.getByRole("heading", { name: "World", exact: true })).toBeVisible();
+    await expect(initialDialog.locator('input[placeholder="Describe your world…"]')).toHaveValue(
+      "A city built around a shifting dungeon tower",
+    );
+    await expect(initialDialog.getByRole("button", { name: "Hard", exact: true })).toHaveClass(
+      /bg-\[var\(--primary\)\]\/20/,
+    );
+    await initialDialog.getByRole("button", { name: "Next", exact: true }).click();
+    await expect(initialDialog.getByRole("heading", { name: "Party", exact: true })).toBeVisible();
+    await initialDialog.getByRole("button", { name: "Next", exact: true }).click();
+    await expect(initialDialog.getByRole("heading", { name: "Goals", exact: true })).toBeVisible();
+    await expect(initialDialog.locator('textarea[placeholder="What do you want to achieve?"]')).toHaveValue(
+      "Reach the final floor",
+    );
+    await expect(initialDialog.locator('textarea[placeholder="Any extra details for the GM?"]')).toHaveValue(
+      "Use clear progression and frequent loot rewards.",
+    );
+    await initialDialog.getByRole("button", { name: "Next", exact: true }).click();
+    await expect(initialDialog.getByRole("heading", { name: "Lorebooks", exact: true })).toBeVisible();
+
+    let dialog = initialDialog;
     await expect(dialog.getByText("Hierarchical world map", { exact: true })).toHaveCount(0);
     await dialog.getByRole("button", { name: "Next", exact: true }).click();
     await expect(dialog.getByRole("heading", { name: "Features", exact: true })).toBeVisible();

--- a/e2e/core-flows.e2e.ts
+++ b/e2e/core-flows.e2e.ts
@@ -1872,6 +1872,47 @@ test("Game setup only shows features owned by installed agents", async ({ page, 
 
   try {
     await page.goto("/");
+    const initialDialog = page.getByRole("dialog", { name: "New Game" });
+    const importButton = initialDialog.getByRole("button", { name: "Import setup", exact: true });
+    await expect(importButton).toBeEnabled();
+    await initialDialog.getByLabel("Import Game Mode setup file").setInputFiles({
+      name: "tower-run.marinara-game-setup.json",
+      mimeType: "application/json",
+      buffer: Buffer.from(
+        JSON.stringify({
+          format: "marinara-game-setup",
+          version: 1,
+          exportedAt: "2026-07-16T12:00:00.000Z",
+          gameName: "Imported Tower Run",
+          setup: {
+            config: {
+              genre: "Fantasy",
+              setting: "A city built around a shifting dungeon tower",
+              tone: "Heroic",
+              difficulty: "Hard",
+              playerGoals: "Reach the final floor",
+              gmMode: "standalone",
+              rating: "sfw",
+              partyCharacterIds: [],
+              generationParameters: { temperature: 0.65 },
+            },
+            effectiveGenerationParameters: { temperature: 0.65, maxTokens: 8192 },
+            preferences: "Use clear progression and frequent loot rewards.",
+            createdAt: "2026-07-16T11:00:00.000Z",
+          },
+        }),
+      ),
+    });
+    await expect(initialDialog.locator('input[placeholder="Name your adventure..."]')).toHaveValue(
+      "Imported Tower Run",
+    );
+    await expect(
+      initialDialog.getByText(
+        "tower-run.marinara-game-setup.json loaded. Review the steps, then start the new game.",
+        { exact: true },
+      ),
+    ).toBeVisible();
+
     let dialog = await openLorebooksStep();
     await expect(dialog.getByText("Hierarchical world map", { exact: true })).toHaveCount(0);
     await dialog.getByRole("button", { name: "Next", exact: true }).click();

--- a/packages/client/src/components/game/GameSetupSummary.tsx
+++ b/packages/client/src/components/game/GameSetupSummary.tsx
@@ -1,9 +1,10 @@
 import { Copy, Download, Info } from "lucide-react";
 import { toast } from "sonner";
 import type { GameInitialSetupSnapshot, GameSetupConfig, GenerationParameters } from "@marinara-engine/shared";
-import { sanitizeExportFilenamePart } from "../../lib/download-json";
+import { downloadJsonFile, sanitizeExportFilenamePart } from "../../lib/download-json";
 import { copyToClipboard } from "../../lib/utils";
 import {
+  buildGameSetupShareFile,
   buildGameSetupSummarySections,
   formatGameSetupShareText,
   type GameSetupShareLabels,
@@ -98,6 +99,7 @@ export function GameSetupSummary({
     connections: snapshot?.connections,
     fallbackGmConnectionId,
     labels,
+    createdAt: snapshot?.createdAt,
   };
   const sections = buildGameSetupSummarySections(source);
   const shareText = formatGameSetupShareText(source);
@@ -110,16 +112,11 @@ export function GameSetupSummary({
   };
 
   const handleDownload = () => {
-    const blob = new Blob([shareText], { type: "text/plain;charset=utf-8" });
-    const url = URL.createObjectURL(blob);
-    const anchor = document.createElement("a");
-    anchor.href = url;
-    anchor.download = `${sanitizeExportFilenamePart(gameName, "game")}-marinara-setup.txt`;
-    document.body.appendChild(anchor);
-    anchor.click();
-    anchor.remove();
-    URL.revokeObjectURL(url);
-    toast.success("Initial Game Mode setup downloaded.");
+    downloadJsonFile(
+      buildGameSetupShareFile(source),
+      `${sanitizeExportFilenamePart(gameName, "game")}.marinara-game-setup.json`,
+    );
+    toast.success("Reusable Game Mode setup downloaded.");
   };
 
   return (
@@ -132,8 +129,8 @@ export function GameSetupSummary({
           <p className="mt-0.5 max-w-md text-[0.6875rem] leading-relaxed text-[var(--marinara-chat-chrome-panel-muted)]">
             {snapshot
               ? createdAt
-                ? `Saved ${createdAt}. Copy or download it whenever this combination produces a game worth sharing.`
-                : "Saved when this campaign was created."
+                ? `Saved ${createdAt}. Copy a readable summary or download a reusable setup file.`
+                : "Saved when this campaign was created. Download it to reuse these settings in a new game."
               : "Reconstructed from the campaign's earliest saved setup."}
           </p>
         </div>
@@ -152,7 +149,7 @@ export function GameSetupSummary({
             className="flex min-h-11 flex-1 items-center justify-center gap-1.5 rounded-lg bg-[var(--primary)] px-3 text-xs font-semibold text-[var(--primary-foreground)] transition-[filter,transform] hover:brightness-105 active:scale-[0.98] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--marinara-chat-chrome-focus-ring)] sm:flex-none"
           >
             <Download size={13} />
-            Download .txt
+            Download setup
           </button>
         </div>
       </div>

--- a/packages/client/src/components/game/GameSetupWizard.tsx
+++ b/packages/client/src/components/game/GameSetupWizard.tsx
@@ -492,6 +492,12 @@ export function GameSetupWizard({
   const setupImportInputRef = useRef<HTMLInputElement>(null);
   const pendingImportedGenerationParametersRef = useRef<Partial<EditableGenerationParameters> | null>(null);
   const importedGenerationParametersRef = useRef<Partial<GenerationParameters> | null>(null);
+  const importedArtStyleSettingsRef = useRef<
+    Pick<
+      GameSetupConfig,
+      "artStylePrompt" | "generatedArtStylePrompt" | "useCampaignArtStyle" | "imageStyleProfileId"
+    > | null
+  >(null);
 
   const sidecarStatus = useSidecarStore((s) => s.status);
   const sidecarConfig = useSidecarStore((s) => s.config);
@@ -763,12 +769,13 @@ export function GameSetupWizard({
   useEffect(() => {
     const importedParameters = pendingImportedGenerationParametersRef.current;
     if (importedParameters) {
+      if (!gmConnectionId) return;
       pendingImportedGenerationParametersRef.current = null;
       setGenerationParameters(getEditableGenerationParameters(gmParameterDefaults, importedParameters));
       return;
     }
     setGenerationParameters(gmParameterDefaults);
-  }, [gmParameterDefaults]);
+  }, [gmConnectionId, gmParameterDefaults]);
 
   useEffect(() => {
     if (enableSpriteGeneration && !imageConnectionId && preferredImageConnectionId) {
@@ -949,7 +956,16 @@ export function GameSetupWizard({
       setGenerationParameters(getEditableGenerationParameters(importedGmDefaults, importedParameterOverrides));
       importedGenerationParametersRef.current = importedGenerationParameters;
       pendingImportedGenerationParametersRef.current =
-        imported.gmConnectionId !== gmConnectionId ? importedParameterOverrides : null;
+        importedParameterOverrides &&
+        (imported.gmConnectionId === null || imported.gmConnectionId !== gmConnectionId)
+          ? importedParameterOverrides
+          : null;
+      importedArtStyleSettingsRef.current = {
+        artStylePrompt: config.artStylePrompt,
+        generatedArtStylePrompt: config.generatedArtStylePrompt,
+        useCampaignArtStyle: config.useCampaignArtStyle,
+        imageStyleProfileId: config.imageStyleProfileId,
+      };
       setUseLocalScene(
         sidecarAvailable &&
           !config.sceneConnectionId &&
@@ -1071,6 +1087,7 @@ export function GameSetupWizard({
         enableSpriteGeneration: illustratorEnabled || undefined,
         imageConnectionId: illustratorEnabled && imageConnectionId ? imageConnectionId : undefined,
         videoConnectionId: illustratorEnabled && videoConnectionId ? videoConnectionId : undefined,
+        ...(importedArtStyleSettingsRef.current ?? {}),
         gameStoryboardAutoIllustrationsEnabled: illustratorEnabled
           ? enableStoryboardIllustrations
           : undefined,

--- a/packages/client/src/components/game/GameSetupWizard.tsx
+++ b/packages/client/src/components/game/GameSetupWizard.tsx
@@ -1,9 +1,10 @@
 // ──────────────────────────────────────────────
 // Game: Setup Wizard (initial game setup modal)
 // ──────────────────────────────────────────────
-import { useState, useMemo, useCallback, useEffect } from "react";
+import { useState, useMemo, useCallback, useEffect, useRef, type ChangeEvent } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { motion, AnimatePresence, useReducedMotion } from "framer-motion";
+import { toast } from "sonner";
 import {
   Wand2,
   ArrowRight,
@@ -26,6 +27,8 @@ import {
   Map as MapIcon,
   RotateCcw,
   FolderOpen,
+  FileUp,
+  CheckCircle2,
 } from "lucide-react";
 import {
   ANIME_GAME_PROMPT_TEMPLATE_ID,
@@ -41,6 +44,7 @@ import {
   type GameInitialSetupLabels,
   type GameSetupConfig,
   type GameGmMode,
+  type GenerationParameters,
   type SpatialMapGroundingMode,
   type SpatialMapDraftSize,
   type GameCombatStyle,
@@ -51,6 +55,7 @@ import { cn, getAvatarCropStyle, parseAvatarCropJson, type AvatarCropValue } fro
 import {
   GenerationParametersFields,
   getEditableGenerationParameters,
+  parseEditableGenerationParameters,
   ROLEPLAY_PARAMETER_DEFAULTS,
   type EditableGenerationParameters,
 } from "../ui/GenerationParametersEditor";
@@ -75,6 +80,7 @@ import { useLorebooks } from "../../hooks/use-lorebooks";
 import { useCapabilityAgentRegistry } from "../../hooks/use-capability-packages";
 import { useGameAssetStore } from "../../stores/game-asset.store";
 import { useUIStore } from "../../stores/ui.store";
+import { parseGameSetupShareFileJson, resolveGameSetupImport } from "../../lib/game-setup-share";
 
 interface GameSetupWizardProps {
   onComplete: (
@@ -154,6 +160,7 @@ const GENRES = ["Fantasy", "Sci-Fi", "Horror", "Modern", "Post-Apocalyptic", "Cy
 const TONES = ["Heroic", "Dark", "Comedic", "Gritty", "Whimsical", "Serious", "Campy"];
 const DIFFICULTIES = ["Casual", "Normal", "Hard", "Brutal"];
 const LEARNED_OPTION_PREVIEW_LIMIT = 8;
+const GAME_SETUP_IMPORT_MAX_BYTES = 1_000_000;
 
 const SETTING_SUGGESTIONS = [
   "Surprise me!",
@@ -479,6 +486,10 @@ export function GameSetupWizard({
     goals: false,
     preferences: false,
   });
+  const [importedSetupNotice, setImportedSetupNotice] = useState<string | null>(null);
+  const setupImportInputRef = useRef<HTMLInputElement>(null);
+  const pendingImportedGenerationParametersRef = useRef<Partial<EditableGenerationParameters> | null>(null);
+  const importedGenerationParametersRef = useRef<Partial<GenerationParameters> | null>(null);
 
   const sidecarStatus = useSidecarStore((s) => s.status);
   const sidecarConfig = useSidecarStore((s) => s.config);
@@ -516,12 +527,12 @@ export function GameSetupWizard({
   // "local" = sidecar, a connection id = API connection, null = skip
   const sceneModelValue = useLocalScene && sidecarAvailable ? "local" : sceneConnectionId;
 
-  const { data: connectionsList } = useConnections();
-  const { data: promptPresetsList } = usePresets();
+  const { data: connectionsList, isLoading: connectionsLoading } = useConnections();
+  const { data: promptPresetsList, isLoading: promptPresetsLoading } = usePresets();
   const { data: defaultPreset } = useDefaultPreset();
-  const { data: personasList } = usePersonas();
+  const { data: personasList, isLoading: personasLoading } = usePersonas();
   const { data: characterGroupsList } = useCharacterGroups();
-  const { data: lorebooksList } = useLorebooks();
+  const { data: lorebooksList, isLoading: lorebooksLoading } = useLorebooks();
   const { data: installedAgentManifests = [], isLoading: installedAgentsLoading } = useCapabilityAgentRegistry();
   const installedAgentIds = useMemo(
     () => new Set(installedAgentManifests.map((agent) => agent.id)),
@@ -616,6 +627,8 @@ export function GameSetupWizard({
     () => (lorebooksList as Array<{ id: string; name: string; enabled?: boolean }>) ?? [],
     [lorebooksList],
   );
+  const setupImportResourcesReady =
+    !connectionsLoading && !promptPresetsLoading && !personasLoading && !lorebooksLoading;
 
   const availableLorebooks = useMemo(
     () =>
@@ -746,6 +759,12 @@ export function GameSetupWizard({
   }, []);
 
   useEffect(() => {
+    const importedParameters = pendingImportedGenerationParametersRef.current;
+    if (importedParameters) {
+      pendingImportedGenerationParametersRef.current = null;
+      setGenerationParameters(getEditableGenerationParameters(gmParameterDefaults, importedParameters));
+      return;
+    }
     setGenerationParameters(gmParameterDefaults);
   }, [gmParameterDefaults]);
 
@@ -852,6 +871,157 @@ export function GameSetupWizard({
     }
   };
 
+  const handleImportSetupFile = async (event: ChangeEvent<HTMLInputElement>) => {
+    const input = event.currentTarget;
+    const file = input.files?.[0];
+    input.value = "";
+    if (!file || isLoading) return;
+
+    try {
+      if (!setupImportResourcesReady) {
+        throw new Error("Setup resources are still loading. Try the import again in a moment.");
+      }
+      if (file.size > GAME_SETUP_IMPORT_MAX_BYTES) {
+        throw new Error("This setup file is too large. Choose a Game Mode setup file smaller than 1 MB.");
+      }
+
+      const shareFile = parseGameSetupShareFileJson(await file.text());
+      const imported = resolveGameSetupImport(shareFile, {
+        characters,
+        connections,
+        lorebooks,
+        personas,
+        promptPresets,
+      });
+      const config = imported.config;
+      const importedGenres = config.genre
+        .split(",")
+        .map((value) => value.trim())
+        .filter(Boolean);
+      const importedTones = config.tone
+        .split(",")
+        .map((value) => value.trim())
+        .filter(Boolean);
+      const importedPresentation =
+        config.gameGmPromptTemplateId === ANIME_GAME_PROMPT_TEMPLATE_ID ? "anime" : "standard";
+      const importedPromptPreset = promptPresets.find((preset) => preset.id === config.promptPresetId) ?? null;
+      const importedCustomPrompt = config.gameSystemPrompt?.trim() ?? "";
+      const importedBasePrompt =
+        importedPresentation === "anime"
+          ? ANIME_GAME_SYSTEM_PROMPT
+          : importedPromptPreset?.gamePrompt?.trim() || DEFAULT_GAME_SYSTEM_PROMPT;
+      const importedWidgets = normalizeGameHudWidgets(config.customHudWidgets ?? []);
+      const importedGenerationParameters = imported.effectiveGenerationParameters ?? config.generationParameters ?? null;
+      const importedParameterOverrides = parseEditableGenerationParameters(importedGenerationParameters);
+      const hasImportedGenerationParameters =
+        importedGenerationParameters !== null && Object.keys(importedGenerationParameters).length > 0;
+      const importedGmConnection = connections.find((connection) => connection.id === imported.gmConnectionId) ?? null;
+      const importedGmDefaults = getEditableGenerationParameters(
+        ROLEPLAY_PARAMETER_DEFAULTS,
+        importedGmConnection?.defaultParameters,
+      );
+
+      setStep(0);
+      setGameName(imported.gameName);
+      setGenres(importedGenres.length > 0 ? importedGenres : ["Fantasy"]);
+      setCustomGenre("");
+      setSetting(config.setting);
+      setTones(importedTones.length > 0 ? importedTones : ["Heroic"]);
+      setCustomTone("");
+      setDifficulty(config.difficulty);
+      setCombatStyle(config.combatStyle === "tactical" ? "tactical" : "classic");
+      setRating(config.rating);
+      setLanguage(config.language?.trim() || "English");
+      setGmMode(config.gmMode);
+      setGmCharacterId(config.gmCharacterId ?? null);
+      setPartyCharacterIds(config.partyCharacterIds);
+      setPersonaId(config.personaId ?? null);
+      setPlayerGoals(config.playerGoals);
+      setPreferences(imported.preferences);
+      setGmSearch("");
+      setPartySearch("");
+      setPartyFolderId("");
+      setPersonaSearch("");
+      setGmConnectionId(imported.gmConnectionId);
+      setCustomizeParameters(hasImportedGenerationParameters);
+      setGenerationParameters(getEditableGenerationParameters(importedGmDefaults, importedParameterOverrides));
+      importedGenerationParametersRef.current = importedGenerationParameters;
+      pendingImportedGenerationParametersRef.current =
+        imported.gmConnectionId !== gmConnectionId ? importedParameterOverrides : null;
+      setUseLocalScene(
+        sidecarAvailable &&
+          !config.sceneConnectionId &&
+          shareFile.setup.connections?.scene?.provider === "local",
+      );
+      setSceneConnectionId(config.sceneConnectionId ?? null);
+
+      const visualGenerationEnabled =
+        config.enableSpriteGeneration === true ||
+        config.gameStoryboardAutoIllustrationsEnabled === true ||
+        config.gameStoryboardAutoGenerationEnabled === true;
+      setEnableSpriteGeneration(visualGenerationEnabled);
+      setImageConnectionId(config.imageConnectionId ?? null);
+      setVideoConnectionId(config.videoConnectionId ?? null);
+      setEnableStoryboardIllustrations(
+        config.gameStoryboardAutoIllustrationsEnabled === true ||
+          config.gameStoryboardAutoGenerationEnabled === true,
+      );
+      setEnableStoryboardAnimations(config.gameStoryboardAutoGenerationEnabled === true);
+      setStoryboardKeyframeCount(
+        Math.min(
+          GAME_STORYBOARD_KEYFRAME_COUNT_MAX,
+          Math.max(
+            GAME_STORYBOARD_KEYFRAME_COUNT_MIN,
+            Number.isFinite(config.gameStoryboardKeyframeCount)
+              ? Math.round(config.gameStoryboardKeyframeCount!)
+              : GAME_STORYBOARD_KEYFRAME_COUNT_DEFAULT,
+          ),
+        ),
+      );
+      setGamePresentation(importedPresentation);
+      setActiveLorebookIds(config.activeLorebookIds ?? []);
+      setLbSearch("");
+      setEnableCustomWidgets(config.enableCustomWidgets !== false);
+      setManualWidgetSetupEnabled(importedWidgets.length > 0);
+      setCustomHudWidgets(
+        importedWidgets.length > 0
+          ? importedWidgets
+          : normalizeGameHudWidgets([createDefaultGameHudWidget("progress_bar", [])]),
+      );
+      setEnableSpotifyDj(config.enableSpotifyDj === true);
+      setGameSpotifySourceType(normalizeGameSpotifySourceType(config.spotifySourceType));
+      setGameSpotifyPlaylistId(config.spotifyPlaylistId?.trim() || "");
+      setGameSpotifyPlaylistName(config.spotifyPlaylistName?.trim() || "");
+      setGameSpotifyArtist(config.spotifyArtist?.trim() || "");
+      setEnableLorebookKeeper(config.enableLorebookKeeper === true);
+      setPromptPresetTouched(true);
+      setPromptPresetId(config.promptPresetId ?? null);
+      setCustomGamePromptEnabled(Boolean(importedCustomPrompt));
+      setGameSystemPromptDraft(importedCustomPrompt || importedBasePrompt);
+      setGameSystemPromptEdited(Boolean(importedCustomPrompt));
+      setGameSpecialInstructions(config.gameSpecialInstructions?.trim() || "");
+      setDraftSpatialMap(false);
+      setSpatialMapDraftSize("medium");
+      setSpatialMapGroundingMode("setup");
+
+      const warningCount = imported.warnings.length;
+      setImportedSetupNotice(
+        warningCount > 0
+          ? `${file.name} loaded. ${warningCount} local ${warningCount === 1 ? "selection needs" : "selections need"} review.`
+          : `${file.name} loaded. Review the steps, then start the new game.`,
+      );
+      toast.success("Game Mode setup imported.");
+      if (warningCount > 0) {
+        toast.warning("Some local selections could not be restored.", {
+          description: imported.warnings.join(" "),
+        });
+      }
+    } catch (error) {
+      setImportedSetupNotice(null);
+      toast.error(error instanceof Error ? error.message : "Could not import this Game Mode setup file.");
+    }
+  };
+
   const handleComplete = () => {
     if (isLoading || !canStart) return;
     const trimmedGameSystemPrompt = gameSystemPromptDraft.trim();
@@ -929,7 +1099,9 @@ export function GameSetupWizard({
           musicDjEnabled && gameSpotifySourceType === "artist" ? gameSpotifyArtist.trim() || undefined : undefined,
         enableLorebookKeeper: lorebookKeeperEnabled || undefined,
         language: normalizedLanguage || undefined,
-        generationParameters: customizeParameters ? generationParameters : undefined,
+        generationParameters: customizeParameters
+          ? { ...(importedGenerationParametersRef.current ?? {}), ...generationParameters }
+          : undefined,
         promptPresetId,
         gameSystemPrompt: customGameSystemPrompt,
         gameSpecialInstructions: trimmedGameSpecialInstructions || null,
@@ -1007,6 +1179,47 @@ export function GameSetupWizard({
               <div className="space-y-4">
         {step === 0 && (
           <>
+            <div className="rounded-lg border border-[var(--border)] bg-[var(--card)] px-3 py-3">
+              <input
+                ref={setupImportInputRef}
+                type="file"
+                accept=".json,application/json"
+                onChange={(event) => void handleImportSetupFile(event)}
+                className="sr-only"
+                aria-label="Import Game Mode setup file"
+              />
+              <div className="flex flex-col gap-3 sm:flex-row sm:items-center">
+                <div className="flex min-w-0 flex-1 items-start gap-2.5">
+                  <FileUp size={16} className="mt-0.5 shrink-0 text-[var(--primary)]" />
+                  <div className="min-w-0">
+                    <p className="text-xs font-semibold text-[var(--foreground)]">Reuse a game setup</p>
+                    <p className="mt-0.5 text-[0.625rem] leading-relaxed text-[var(--muted-foreground)]">
+                      Import a setup downloaded from another campaign. You can review every step before starting.
+                    </p>
+                  </div>
+                </div>
+                <button
+                  type="button"
+                  onClick={() => setupImportInputRef.current?.click()}
+                  disabled={isLoading || !setupImportResourcesReady}
+                  className="flex min-h-11 shrink-0 items-center justify-center gap-1.5 rounded-lg border border-[var(--border)] bg-[var(--secondary)] px-3 text-xs font-medium text-[var(--foreground)] transition-colors hover:bg-[var(--accent)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--primary)]/40 disabled:cursor-wait disabled:opacity-50"
+                >
+                  <FileUp size={13} />
+                  {setupImportResourcesReady ? "Import setup" : "Loading…"}
+                </button>
+              </div>
+              {importedSetupNotice && (
+                <p
+                  className="mt-3 flex items-start gap-2 border-t border-[var(--border)] pt-3 text-[0.6875rem] leading-relaxed text-[var(--foreground)]"
+                  role="status"
+                  aria-live="polite"
+                >
+                  <CheckCircle2 size={13} className="mt-0.5 shrink-0 text-[var(--primary)]" />
+                  <span>{importedSetupNotice}</span>
+                </p>
+              )}
+            </div>
+
             <div>
               <label className={GAME_SETUP_FIELD_LABEL}>Game Name</label>
               <input

--- a/packages/client/src/lib/game-setup-share.ts
+++ b/packages/client/src/lib/game-setup-share.ts
@@ -3,6 +3,7 @@ import {
   COMIC_PAGE_GAME_VIDEO_PROMPT_TEMPLATE_ID,
   GAME_STORYBOARD_COMIC_ANIMATION_PROMPT_TEMPLATE_ID,
   STORYBOARD_OPTIMIZED_IMAGE_PROMPT_TEMPLATE_ID,
+  generationParametersSchema,
   type GameInitialSetupConnectionSnapshot,
   type GameInitialSetupLabels,
   type GameInitialSetupSnapshot,
@@ -84,6 +85,15 @@ export interface GameSetupSummarySection {
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return !!value && typeof value === "object" && !Array.isArray(value);
+}
+
+const importedGenerationParametersSchema = generationParametersSchema.partial().strict();
+
+function parseGenerationParameters(value: unknown): Partial<GenerationParameters> | undefined {
+  if (value === undefined) return undefined;
+  const parsed = importedGenerationParametersSchema.safeParse(value);
+  if (!parsed.success) throw new Error("This file has invalid generation parameters.");
+  return parsed.data;
 }
 
 function requireString(
@@ -229,9 +239,7 @@ function parseShareConfig(value: unknown): GameSetupConfig {
   if (value.customHudWidgets !== undefined && !Array.isArray(value.customHudWidgets)) {
     throw new Error("This file has invalid HUD widgets.");
   }
-  if (value.generationParameters !== undefined && !isRecord(value.generationParameters)) {
-    throw new Error("This file has invalid generation parameters.");
-  }
+  const generationParameters = parseGenerationParameters(value.generationParameters);
 
   return {
     ...(value as unknown as GameSetupConfig),
@@ -243,6 +251,7 @@ function parseShareConfig(value: unknown): GameSetupConfig {
     gmMode,
     rating,
     partyCharacterIds: [...value.partyCharacterIds],
+    generationParameters,
   };
 }
 
@@ -305,15 +314,10 @@ export function parseGameSetupShareFileJson(text: string): GameSetupShareFile {
   if (typeof setup.preferences === "string" && setup.preferences.length > 5_000) {
     throw new Error("This file's additional preferences are too long.");
   }
-  if (
-    setup.effectiveGenerationParameters != null &&
-    !isRecord(setup.effectiveGenerationParameters)
-  ) {
-    throw new Error("This file has invalid effective generation parameters.");
-  }
-  const effectiveGenerationParameters = isRecord(setup.effectiveGenerationParameters)
-    ? (setup.effectiveGenerationParameters as Partial<GenerationParameters>)
-    : null;
+  const effectiveGenerationParameters =
+    setup.effectiveGenerationParameters == null
+      ? null
+      : (parseGenerationParameters(setup.effectiveGenerationParameters) ?? null);
 
   return {
     format: GAME_SETUP_SHARE_FORMAT,
@@ -361,7 +365,8 @@ function resolveConnectionId(
   const model = normalizeLookupValue(snapshot.model);
   const service = normalizeLookupValue(snapshot.service);
   const candidates = connections.filter((connection) => normalizeLookupValue(connection.name) === name);
-  const pool = candidates.length > 0 ? candidates : connections;
+  if (candidates.length === 0) return null;
+  const pool = candidates;
 
   const scored = pool
     .map((connection) => {

--- a/packages/client/src/lib/game-setup-share.ts
+++ b/packages/client/src/lib/game-setup-share.ts
@@ -4,9 +4,14 @@ import {
   GAME_STORYBOARD_COMIC_ANIMATION_PROMPT_TEMPLATE_ID,
   STORYBOARD_OPTIMIZED_IMAGE_PROMPT_TEMPLATE_ID,
   type GameInitialSetupConnectionSnapshot,
+  type GameInitialSetupLabels,
+  type GameInitialSetupSnapshot,
   type GameSetupConfig,
   type GenerationParameters,
 } from "@marinara-engine/shared";
+
+export const GAME_SETUP_SHARE_FORMAT = "marinara-game-setup";
+export const GAME_SETUP_SHARE_VERSION = 1;
 
 export interface GameSetupShareLabels {
   characterNames?: Readonly<Record<string, string>>;
@@ -29,6 +34,42 @@ export interface GameSetupShareSource {
   };
   fallbackGmConnectionId?: string | null;
   labels?: GameSetupShareLabels;
+  createdAt?: string | null;
+}
+
+export interface GameSetupShareFile {
+  format: typeof GAME_SETUP_SHARE_FORMAT;
+  version: typeof GAME_SETUP_SHARE_VERSION;
+  exportedAt: string;
+  gameName: string;
+  gmConnectionId?: string | null;
+  setup: GameInitialSetupSnapshot;
+}
+
+export interface GameSetupImportConnection {
+  id: string;
+  name: string;
+  provider?: string | null;
+  model?: string | null;
+  imageService?: string | null;
+  videoService?: string | null;
+}
+
+export interface GameSetupImportContext {
+  characters: ReadonlyArray<{ id: string; name: string }>;
+  connections: ReadonlyArray<GameSetupImportConnection>;
+  lorebooks: ReadonlyArray<{ id: string; name: string }>;
+  personas: ReadonlyArray<{ id: string; name: string }>;
+  promptPresets: ReadonlyArray<{ id: string; name: string }>;
+}
+
+export interface ResolvedGameSetupImport {
+  gameName: string;
+  config: GameSetupConfig;
+  preferences: string;
+  effectiveGenerationParameters: Partial<GenerationParameters> | null;
+  gmConnectionId: string | null;
+  warnings: string[];
 }
 
 export interface GameSetupSummaryRow {
@@ -39,6 +80,401 @@ export interface GameSetupSummaryRow {
 export interface GameSetupSummarySection {
   title: string;
   rows: GameSetupSummaryRow[];
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === "object" && !Array.isArray(value);
+}
+
+function requireString(
+  record: Record<string, unknown>,
+  key: string,
+  label: string,
+  maxLength = 50_000,
+): string {
+  const value = record[key];
+  if (typeof value !== "string" || !value.trim()) {
+    throw new Error(`This file is missing a valid ${label}.`);
+  }
+  if (value.length > maxLength) {
+    throw new Error(`This file's ${label} is too long.`);
+  }
+  return value;
+}
+
+function optionalStringRecord(value: unknown): Record<string, string> | undefined {
+  if (!isRecord(value)) return undefined;
+  const entries = Object.entries(value).filter(
+    (entry): entry is [string, string] => typeof entry[1] === "string" && entry[1].trim().length > 0,
+  );
+  return entries.length > 0 ? Object.fromEntries(entries) : undefined;
+}
+
+function parseShareLabels(value: unknown): GameInitialSetupLabels | undefined {
+  if (!isRecord(value)) return undefined;
+  const labels: GameInitialSetupLabels = {
+    characterNames: optionalStringRecord(value.characterNames),
+    lorebookNames: optionalStringRecord(value.lorebookNames),
+    promptPresetNames: optionalStringRecord(value.promptPresetNames),
+    personaName: typeof value.personaName === "string" ? value.personaName : null,
+  };
+  return Object.values(labels).some((entry) => entry != null) ? labels : undefined;
+}
+
+function parseConnectionSnapshot(value: unknown): GameInitialSetupConnectionSnapshot | null {
+  if (!isRecord(value) || typeof value.name !== "string" || !value.name.trim()) return null;
+  return {
+    name: value.name.trim(),
+    provider: typeof value.provider === "string" ? value.provider : null,
+    model: typeof value.model === "string" ? value.model : null,
+    service: typeof value.service === "string" ? value.service : null,
+  };
+}
+
+function parseShareConnections(value: unknown): GameInitialSetupSnapshot["connections"] {
+  if (!isRecord(value)) return undefined;
+  return {
+    gm: parseConnectionSnapshot(value.gm),
+    scene: parseConnectionSnapshot(value.scene),
+    image: parseConnectionSnapshot(value.image),
+    video: parseConnectionSnapshot(value.video),
+  };
+}
+
+function parseShareConfig(value: unknown): GameSetupConfig {
+  if (!isRecord(value)) throw new Error("This file does not contain Game Mode setup settings.");
+
+  const gmMode = value.gmMode;
+  if (gmMode !== "standalone" && gmMode !== "character") {
+    throw new Error("This file has an invalid Game Master mode.");
+  }
+  const rating = value.rating;
+  if (rating !== "sfw" && rating !== "nsfw") {
+    throw new Error("This file has an invalid content rating.");
+  }
+  if (!Array.isArray(value.partyCharacterIds) || value.partyCharacterIds.some((id) => typeof id !== "string")) {
+    throw new Error("This file has an invalid starting party.");
+  }
+  if (typeof value.playerGoals !== "string" || value.playerGoals.length > 2_000) {
+    throw new Error("This file has invalid player goals.");
+  }
+
+  const optionalStrings: Record<string, number> = {
+    gmCharacterId: 1_000,
+    personaId: 1_000,
+    sceneConnectionId: 1_000,
+    imageConnectionId: 1_000,
+    videoConnectionId: 1_000,
+    gameGmPromptTemplateId: 200,
+    gameStoryboardAnimationPromptTemplateId: 200,
+    gameStoryboardImagePromptTemplateId: 200,
+    gameStoryboardVideoPromptTemplateId: 200,
+    artStylePrompt: 500,
+    generatedArtStylePrompt: 500,
+    imageStyleProfileId: 1_000,
+    spotifyPlaylistId: 1_000,
+    spotifyPlaylistName: 1_000,
+    spotifyArtist: 1_000,
+    language: 100,
+    promptPresetId: 1_000,
+    gameSystemPrompt: 50_000,
+    gameSpecialInstructions: 2_000,
+  };
+  for (const [key, maxLength] of Object.entries(optionalStrings)) {
+    const entry = value[key];
+    if (entry != null && (typeof entry !== "string" || entry.length > maxLength)) {
+      throw new Error(`This file has an invalid ${titleCaseToken(key)} value.`);
+    }
+  }
+
+  const optionalBooleans = [
+    "enableSpriteGeneration",
+    "gameStoryboardAutoIllustrationsEnabled",
+    "gameStoryboardAutoGenerationEnabled",
+    "useCampaignArtStyle",
+    "enableCustomWidgets",
+    "enableSpotifyDj",
+    "enableLorebookKeeper",
+  ];
+  for (const key of optionalBooleans) {
+    if (value[key] !== undefined && typeof value[key] !== "boolean") {
+      throw new Error(`This file has an invalid ${titleCaseToken(key)} value.`);
+    }
+  }
+
+  if (value.combatStyle !== undefined && value.combatStyle !== "classic" && value.combatStyle !== "tactical") {
+    throw new Error("This file has an invalid combat style.");
+  }
+  if (
+    value.spotifySourceType !== undefined &&
+    value.spotifySourceType !== "liked" &&
+    value.spotifySourceType !== "playlist" &&
+    value.spotifySourceType !== "artist" &&
+    value.spotifySourceType !== "any"
+  ) {
+    throw new Error("This file has an invalid Spotify source type.");
+  }
+  if (
+    value.gameStoryboardKeyframeCount !== undefined &&
+    (typeof value.gameStoryboardKeyframeCount !== "number" || !Number.isFinite(value.gameStoryboardKeyframeCount))
+  ) {
+    throw new Error("This file has an invalid storyboard keyframe count.");
+  }
+  if (
+    value.activeLorebookIds !== undefined &&
+    (!Array.isArray(value.activeLorebookIds) || value.activeLorebookIds.some((id) => typeof id !== "string"))
+  ) {
+    throw new Error("This file has invalid active lorebooks.");
+  }
+  if (value.customHudWidgets !== undefined && !Array.isArray(value.customHudWidgets)) {
+    throw new Error("This file has invalid HUD widgets.");
+  }
+  if (value.generationParameters !== undefined && !isRecord(value.generationParameters)) {
+    throw new Error("This file has invalid generation parameters.");
+  }
+
+  return {
+    ...(value as unknown as GameSetupConfig),
+    genre: requireString(value, "genre", "genre", 200),
+    setting: requireString(value, "setting", "setting"),
+    tone: requireString(value, "tone", "tone", 200),
+    difficulty: requireString(value, "difficulty", "difficulty", 100),
+    playerGoals: value.playerGoals,
+    gmMode,
+    rating,
+    partyCharacterIds: [...value.partyCharacterIds],
+  };
+}
+
+export function buildGameSetupShareFile(
+  source: GameSetupShareSource,
+  exportedAt = new Date().toISOString(),
+): GameSetupShareFile {
+  const labels: GameInitialSetupLabels | undefined = source.labels
+    ? {
+        characterNames: source.labels.characterNames ? { ...source.labels.characterNames } : undefined,
+        lorebookNames: source.labels.lorebookNames ? { ...source.labels.lorebookNames } : undefined,
+        promptPresetNames: source.labels.promptPresetNames ? { ...source.labels.promptPresetNames } : undefined,
+        personaName: source.labels.personaName ?? null,
+      }
+    : undefined;
+
+  return {
+    format: GAME_SETUP_SHARE_FORMAT,
+    version: GAME_SETUP_SHARE_VERSION,
+    exportedAt,
+    gameName: source.gameName,
+    gmConnectionId: source.fallbackGmConnectionId ?? null,
+    setup: {
+      config: source.config,
+      effectiveGenerationParameters: source.effectiveGenerationParameters ?? source.config.generationParameters ?? null,
+      preferences: source.preferences?.trim() || null,
+      connections: source.connections
+        ? {
+            gm: source.connections.gm ?? null,
+            scene: source.connections.scene ?? null,
+            image: source.connections.image ?? null,
+            video: source.connections.video ?? null,
+          }
+        : undefined,
+      labels,
+      createdAt: source.createdAt?.trim() || exportedAt,
+    },
+  };
+}
+
+export function parseGameSetupShareFileJson(text: string): GameSetupShareFile {
+  let value: unknown;
+  try {
+    value = JSON.parse(text);
+  } catch {
+    throw new Error("Choose a reusable Game Mode setup JSON file, not the readable text summary.");
+  }
+  if (!isRecord(value) || value.format !== GAME_SETUP_SHARE_FORMAT) {
+    throw new Error("This is not a Marinara Game Mode setup file.");
+  }
+  if (value.version !== GAME_SETUP_SHARE_VERSION) {
+    throw new Error(`This Game Mode setup file uses unsupported version ${String(value.version ?? "unknown")}.`);
+  }
+  if (!isRecord(value.setup)) throw new Error("This file does not contain a saved setup snapshot.");
+
+  const setup = value.setup;
+  if (setup.preferences != null && typeof setup.preferences !== "string") {
+    throw new Error("This file has invalid additional preferences.");
+  }
+  if (typeof setup.preferences === "string" && setup.preferences.length > 5_000) {
+    throw new Error("This file's additional preferences are too long.");
+  }
+  if (
+    setup.effectiveGenerationParameters != null &&
+    !isRecord(setup.effectiveGenerationParameters)
+  ) {
+    throw new Error("This file has invalid effective generation parameters.");
+  }
+  const effectiveGenerationParameters = isRecord(setup.effectiveGenerationParameters)
+    ? (setup.effectiveGenerationParameters as Partial<GenerationParameters>)
+    : null;
+
+  return {
+    format: GAME_SETUP_SHARE_FORMAT,
+    version: GAME_SETUP_SHARE_VERSION,
+    exportedAt: typeof value.exportedAt === "string" ? value.exportedAt : new Date(0).toISOString(),
+    gameName: requireString(value, "gameName", "game name", 200),
+    gmConnectionId: typeof value.gmConnectionId === "string" ? value.gmConnectionId : null,
+    setup: {
+      config: parseShareConfig(setup.config),
+      effectiveGenerationParameters,
+      preferences: typeof setup.preferences === "string" ? setup.preferences : null,
+      connections: parseShareConnections(setup.connections),
+      labels: parseShareLabels(setup.labels),
+      createdAt: typeof setup.createdAt === "string" ? setup.createdAt : new Date(0).toISOString(),
+    },
+  };
+}
+
+function normalizeLookupValue(value: string | null | undefined): string {
+  return value?.trim().toLocaleLowerCase() ?? "";
+}
+
+function resolveNamedResourceId(
+  sourceId: string | null | undefined,
+  sourceName: string | null | undefined,
+  resources: ReadonlyArray<{ id: string; name: string }>,
+): string | null {
+  if (sourceId && resources.some((resource) => resource.id === sourceId)) return sourceId;
+  const normalizedName = normalizeLookupValue(sourceName);
+  if (!normalizedName) return null;
+  const matches = resources.filter((resource) => normalizeLookupValue(resource.name) === normalizedName);
+  return matches.length === 1 ? matches[0]!.id : null;
+}
+
+function resolveConnectionId(
+  sourceId: string | null | undefined,
+  snapshot: GameInitialSetupConnectionSnapshot | null | undefined,
+  connections: ReadonlyArray<GameSetupImportConnection>,
+): string | null {
+  if (sourceId && connections.some((connection) => connection.id === sourceId)) return sourceId;
+  if (!snapshot) return null;
+
+  const name = normalizeLookupValue(snapshot.name);
+  const provider = normalizeLookupValue(snapshot.provider);
+  const model = normalizeLookupValue(snapshot.model);
+  const service = normalizeLookupValue(snapshot.service);
+  const candidates = connections.filter((connection) => normalizeLookupValue(connection.name) === name);
+  const pool = candidates.length > 0 ? candidates : connections;
+
+  const scored = pool
+    .map((connection) => {
+      let score = candidates.includes(connection) ? 8 : 0;
+      if (provider && normalizeLookupValue(connection.provider) === provider) score += 4;
+      if (model && normalizeLookupValue(connection.model) === model) score += 3;
+      if (
+        service &&
+        [connection.imageService, connection.videoService].some(
+          (candidate) => normalizeLookupValue(candidate) === service,
+        )
+      ) {
+        score += 2;
+      }
+      return { connection, score };
+    })
+    .filter((entry) => entry.score > 0)
+    .sort((a, b) => b.score - a.score);
+
+  if (scored.length === 0 || (scored[1] && scored[0]!.score === scored[1].score && candidates.length !== 1)) {
+    return null;
+  }
+  return scored[0]!.connection.id;
+}
+
+function describeSavedResource(sourceName: string | null | undefined, fallback: string): string {
+  return sourceName?.trim() ? `“${sourceName.trim()}”` : fallback;
+}
+
+export function resolveGameSetupImport(
+  file: GameSetupShareFile,
+  context: GameSetupImportContext,
+): ResolvedGameSetupImport {
+  const { config: sourceConfig, labels, connections: snapshots } = file.setup;
+  const warnings: string[] = [];
+
+  const gmCharacterName = sourceConfig.gmCharacterId ? labels?.characterNames?.[sourceConfig.gmCharacterId] : null;
+  const gmCharacterId = resolveNamedResourceId(sourceConfig.gmCharacterId, gmCharacterName, context.characters);
+  let gmMode = sourceConfig.gmMode;
+  if (gmMode === "character" && !gmCharacterId) {
+    warnings.push(
+      `${describeSavedResource(gmCharacterName, "The saved GM character")} is unavailable; using a standalone narrator.`,
+    );
+    gmMode = "standalone";
+  }
+
+  const partyCharacterIds = sourceConfig.partyCharacterIds.flatMap((sourceId) => {
+    const sourceName = labels?.characterNames?.[sourceId];
+    const resolvedId = resolveNamedResourceId(sourceId, sourceName, context.characters);
+    if (resolvedId) return [resolvedId];
+    warnings.push(`${describeSavedResource(sourceName, "A saved party member")} is unavailable and was skipped.`);
+    return [];
+  });
+
+  const personaId = resolveNamedResourceId(sourceConfig.personaId, labels?.personaName, context.personas);
+  if (sourceConfig.personaId && !personaId) {
+    warnings.push(`${describeSavedResource(labels?.personaName, "The saved player persona")} is unavailable.`);
+  }
+
+  const activeLorebookIds = (sourceConfig.activeLorebookIds ?? []).flatMap((sourceId) => {
+    const sourceName = labels?.lorebookNames?.[sourceId];
+    const resolvedId = resolveNamedResourceId(sourceId, sourceName, context.lorebooks);
+    if (resolvedId) return [resolvedId];
+    warnings.push(`${describeSavedResource(sourceName, "A saved lorebook")} is unavailable and was skipped.`);
+    return [];
+  });
+
+  const promptPresetName = sourceConfig.promptPresetId
+    ? labels?.promptPresetNames?.[sourceConfig.promptPresetId]
+    : null;
+  const promptPresetId = resolveNamedResourceId(sourceConfig.promptPresetId, promptPresetName, context.promptPresets);
+  if (sourceConfig.promptPresetId && !promptPresetId) {
+    warnings.push(`${describeSavedResource(promptPresetName, "The saved prompt preset")} is unavailable.`);
+  }
+
+  const gmConnectionId = resolveConnectionId(file.gmConnectionId, snapshots?.gm, context.connections);
+  if ((file.gmConnectionId || snapshots?.gm) && !gmConnectionId) {
+    warnings.push(
+      `${describeSavedResource(snapshots?.gm?.name, "The saved GM connection")} is unavailable; select one before starting.`,
+    );
+  }
+  const sceneConnectionId = resolveConnectionId(sourceConfig.sceneConnectionId, snapshots?.scene, context.connections);
+  const imageConnectionId = resolveConnectionId(sourceConfig.imageConnectionId, snapshots?.image, context.connections);
+  const videoConnectionId = resolveConnectionId(sourceConfig.videoConnectionId, snapshots?.video, context.connections);
+  if ((sourceConfig.sceneConnectionId || snapshots?.scene) && !sceneConnectionId) {
+    warnings.push(`${describeSavedResource(snapshots?.scene?.name, "The saved scene connection")} is unavailable.`);
+  }
+  if ((sourceConfig.imageConnectionId || snapshots?.image) && !imageConnectionId) {
+    warnings.push(`${describeSavedResource(snapshots?.image?.name, "The saved image connection")} is unavailable.`);
+  }
+  if ((sourceConfig.videoConnectionId || snapshots?.video) && !videoConnectionId) {
+    warnings.push(`${describeSavedResource(snapshots?.video?.name, "The saved video connection")} is unavailable.`);
+  }
+
+  return {
+    gameName: file.gameName,
+    config: {
+      ...sourceConfig,
+      gmMode,
+      gmCharacterId,
+      partyCharacterIds: [...new Set(partyCharacterIds)],
+      personaId,
+      sceneConnectionId: sceneConnectionId ?? undefined,
+      imageConnectionId: imageConnectionId ?? undefined,
+      videoConnectionId: videoConnectionId ?? undefined,
+      activeLorebookIds: [...new Set(activeLorebookIds)],
+      promptPresetId,
+    },
+    preferences: file.setup.preferences ?? "",
+    effectiveGenerationParameters: file.setup.effectiveGenerationParameters ?? null,
+    gmConnectionId,
+    warnings: [...new Set(warnings)],
+  };
 }
 
 function titleCaseToken(value: string): string {

--- a/scripts/regressions/open-issues.regression.ts
+++ b/scripts/regressions/open-issues.regression.ts
@@ -63,7 +63,13 @@ import {
   findReplayStoryboardKeyframe,
 } from "../../packages/client/src/lib/game-session-replay.js";
 import { findReplayableGameSessionChat } from "../../packages/client/src/lib/game-session-resolution.js";
-import { formatGameSetupShareText } from "../../packages/client/src/lib/game-setup-share.js";
+import {
+  buildGameSetupShareFile,
+  formatGameSetupShareText,
+  parseGameSetupShareFileJson,
+  resolveGameSetupImport,
+  type GameSetupShareSource,
+} from "../../packages/client/src/lib/game-setup-share.js";
 import {
   getTemperatureGaugeDisplay,
   parsePureTemperatureValue,
@@ -804,7 +810,7 @@ assert.match(
 );
 assert.match(retryAgentsPromptReviewSource, /\[debug\/retry-agents\/illustrator\] final prompt/);
 
-const sharedGameSetup = formatGameSetupShareText({
+const sharedGameSetupSource: GameSetupShareSource = {
   gameName: "Tower Run",
   config: {
     genre: "Fantasy, anime JRPG dungeon crawler",
@@ -843,8 +849,10 @@ const sharedGameSetup = formatGameSetupShareText({
   effectiveGenerationParameters: {
     temperature: 1.1,
     maxTokens: 16384,
+    maxContext: 128000,
     reasoningEffort: "high",
     customParameters: { example_flag: true },
+    stopSequences: ["[END]"],
   },
   preferences: "Use clear progression and frequent loot rewards.",
   connections: {
@@ -857,7 +865,8 @@ const sharedGameSetup = formatGameSetupShareText({
     lorebookNames: { "lorebook-local-id": "Dungeon Lore" },
     personaName: "Player Persona",
   },
-});
+};
+const sharedGameSetup = formatGameSetupShareText(sharedGameSetupSource);
 assert.match(sharedGameSetup, /Presentation: Storyboard Optimized/u);
 assert.match(sharedGameSetup, /Temperature: 1\.1/u);
 assert.match(sharedGameSetup, /Max Tokens: 16384/u);
@@ -868,6 +877,88 @@ assert.match(sharedGameSetup, /"startingValue": 3/u);
 assert.doesNotMatch(
   sharedGameSetup,
   /character-local-id|persona-local-id|connection-local-id|lorebook-local-id|profile-local-id|widget-local-id/u,
+);
+
+const exportedGameSetup = buildGameSetupShareFile(sharedGameSetupSource, "2026-07-16T12:00:00.000Z");
+const parsedGameSetup = parseGameSetupShareFileJson(JSON.stringify(exportedGameSetup));
+const resolvedGameSetup = resolveGameSetupImport(parsedGameSetup, {
+  characters: [{ id: "character-new-id", name: "Party Member" }],
+  personas: [{ id: "persona-new-id", name: "Player Persona" }],
+  lorebooks: [{ id: "lorebook-new-id", name: "Dungeon Lore" }],
+  promptPresets: [],
+  connections: [
+    {
+      id: "gm-connection-new-id",
+      name: "ChatGPT Subscription",
+      provider: "openai_chatgpt",
+      model: "gpt-5.6-sol",
+    },
+    {
+      id: "image-connection-new-id",
+      name: "Image Generator",
+      provider: "image_generation",
+      model: "banana-2-lite",
+    },
+    {
+      id: "video-connection-new-id",
+      name: "Video Generator",
+      provider: "video_generation",
+      videoService: "gemini-omni",
+    },
+  ],
+});
+assert.equal(exportedGameSetup.format, "marinara-game-setup");
+assert.equal(exportedGameSetup.version, 1);
+assert.equal(exportedGameSetup.exportedAt, "2026-07-16T12:00:00.000Z");
+assert.equal(parsedGameSetup.setup.effectiveGenerationParameters?.temperature, 1.1);
+assert.equal(parsedGameSetup.setup.effectiveGenerationParameters?.maxContext, 128000);
+assert.deepEqual(parsedGameSetup.setup.effectiveGenerationParameters?.stopSequences, ["[END]"]);
+assert.equal(resolvedGameSetup.gmConnectionId, "gm-connection-new-id");
+assert.equal(resolvedGameSetup.config.imageConnectionId, "image-connection-new-id");
+assert.equal(resolvedGameSetup.config.videoConnectionId, "video-connection-new-id");
+assert.deepEqual(resolvedGameSetup.config.partyCharacterIds, ["character-new-id"]);
+assert.equal(resolvedGameSetup.config.personaId, "persona-new-id");
+assert.deepEqual(resolvedGameSetup.config.activeLorebookIds, ["lorebook-new-id"]);
+assert.equal(resolvedGameSetup.preferences, "Use clear progression and frequent loot rewards.");
+assert.deepEqual(resolvedGameSetup.warnings, []);
+assert.doesNotMatch(JSON.stringify(exportedGameSetup), /apiKey|baseUrl/u);
+
+const unresolvedGameSetup = resolveGameSetupImport(parsedGameSetup, {
+  characters: [],
+  personas: [],
+  lorebooks: [],
+  promptPresets: [],
+  connections: [],
+});
+assert.equal(unresolvedGameSetup.gmConnectionId, null);
+assert.deepEqual(unresolvedGameSetup.config.partyCharacterIds, []);
+assert.equal(unresolvedGameSetup.config.personaId, null);
+assert.deepEqual(unresolvedGameSetup.config.activeLorebookIds, []);
+assert.ok(unresolvedGameSetup.warnings.length >= 5);
+assert.throws(
+  () => parseGameSetupShareFileJson(sharedGameSetup),
+  /Choose a reusable Game Mode setup JSON file/u,
+);
+assert.throws(
+  () => parseGameSetupShareFileJson(JSON.stringify({ ...exportedGameSetup, version: 99 })),
+  /unsupported version 99/u,
+);
+assert.throws(
+  () => parseGameSetupShareFileJson(JSON.stringify({ format: "other", version: 1 })),
+  /not a Marinara Game Mode setup file/u,
+);
+assert.throws(
+  () =>
+    parseGameSetupShareFileJson(
+      JSON.stringify({
+        ...exportedGameSetup,
+        setup: {
+          ...exportedGameSetup.setup,
+          config: { ...exportedGameSetup.setup.config, generationParameters: [] },
+        },
+      }),
+    ),
+  /invalid generation parameters/u,
 );
 
 const sanitizedExampleDialogue = sanitizeExampleDialoguePromptLeaf(

--- a/scripts/regressions/open-issues.regression.ts
+++ b/scripts/regressions/open-issues.regression.ts
@@ -864,6 +864,9 @@ const sharedGameSetupSource: GameSetupShareSource = {
     partyCharacterIds: ["character-local-id"],
     personaId: "persona-local-id",
     activeLorebookIds: ["lorebook-local-id"],
+    artStylePrompt: "Painterly cel-shaded fantasy",
+    generatedArtStylePrompt: "Original painterly cel-shaded fantasy",
+    useCampaignArtStyle: false,
     imageStyleProfileId: "image-style-profile-local-id",
     enableSpriteGeneration: true,
     imageConnectionId: "image-connection-local-id",
@@ -960,6 +963,10 @@ assert.equal(resolvedGameSetup.config.videoConnectionId, "video-connection-new-i
 assert.deepEqual(resolvedGameSetup.config.partyCharacterIds, ["character-new-id"]);
 assert.equal(resolvedGameSetup.config.personaId, "persona-new-id");
 assert.deepEqual(resolvedGameSetup.config.activeLorebookIds, ["lorebook-new-id"]);
+assert.equal(resolvedGameSetup.config.artStylePrompt, "Painterly cel-shaded fantasy");
+assert.equal(resolvedGameSetup.config.generatedArtStylePrompt, "Original painterly cel-shaded fantasy");
+assert.equal(resolvedGameSetup.config.useCampaignArtStyle, false);
+assert.equal(resolvedGameSetup.config.imageStyleProfileId, "image-style-profile-local-id");
 assert.equal(resolvedGameSetup.preferences, "Use clear progression and frequent loot rewards.");
 assert.deepEqual(resolvedGameSetup.warnings, []);
 assert.doesNotMatch(JSON.stringify(exportedGameSetup), /apiKey|baseUrl/u);
@@ -976,6 +983,21 @@ assert.deepEqual(unresolvedGameSetup.config.partyCharacterIds, []);
 assert.equal(unresolvedGameSetup.config.personaId, null);
 assert.deepEqual(unresolvedGameSetup.config.activeLorebookIds, []);
 assert.ok(unresolvedGameSetup.warnings.length >= 5);
+const providerOnlyGameSetup = resolveGameSetupImport(parsedGameSetup, {
+  characters: [],
+  personas: [],
+  lorebooks: [],
+  promptPresets: [],
+  connections: [
+    {
+      id: "wrong-name-same-provider",
+      name: "Different OpenAI Connection",
+      provider: "openai_chatgpt",
+      model: "gpt-5.6-sol",
+    },
+  ],
+});
+assert.equal(providerOnlyGameSetup.gmConnectionId, null);
 assert.throws(
   () => parseGameSetupShareFileJson(sharedGameSetup),
   /Choose a reusable Game Mode setup JSON file/u,
@@ -996,6 +1018,45 @@ assert.throws(
         setup: {
           ...exportedGameSetup.setup,
           config: { ...exportedGameSetup.setup.config, generationParameters: [] },
+        },
+      }),
+    ),
+  /invalid generation parameters/u,
+);
+assert.throws(
+  () =>
+    parseGameSetupShareFileJson(
+      JSON.stringify({
+        ...exportedGameSetup,
+        setup: {
+          ...exportedGameSetup.setup,
+          config: { ...exportedGameSetup.setup.config, generationParameters: { maxContext: "invalid" } },
+        },
+      }),
+    ),
+  /invalid generation parameters/u,
+);
+assert.throws(
+  () =>
+    parseGameSetupShareFileJson(
+      JSON.stringify({
+        ...exportedGameSetup,
+        setup: {
+          ...exportedGameSetup.setup,
+          effectiveGenerationParameters: { stopSequences: "invalid" },
+        },
+      }),
+    ),
+  /invalid generation parameters/u,
+);
+assert.throws(
+  () =>
+    parseGameSetupShareFileJson(
+      JSON.stringify({
+        ...exportedGameSetup,
+        setup: {
+          ...exportedGameSetup.setup,
+          effectiveGenerationParameters: { unsupportedParameter: true },
         },
       }),
     ),


### PR DESCRIPTION
## Linked issue

Closes #3701

## Why this change

- Initial Game Setup downloads were readable summaries, so users could not reuse a successful Game Mode configuration or share one that degrades gracefully when local resources differ.

## What changed

- Export a versioned `.marinara-game-setup.json` bundle containing the initial setup snapshot and full effective generation parameters, without credentials or connection endpoints.
- Add a mobile-friendly import action to Game > New Game that fills the wizard without auto-starting.
- Remap local characters, personas, lorebooks, presets, and connections by exact ID or unique name; skip missing resources with review warnings and require a replacement GM connection before starting.
- Add malformed-file, version, missing-resource, round-trip, and browser-flow coverage.

## Validation

- [x] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [x] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed `CONTRIBUTING.md`

### Manual verification notes

- `pnpm check`
- `pnpm regression:issues`
- Focused desktop Playwright import flow passed: `Game setup only shows features owned by installed agents`.
- Live preview restarted successfully; `/api/health` returned `ok`, and the served Game Setup bundle contained the import UI.
- Full `pnpm smoke:ui` completed with 63 passing, 40 skipped, and one unrelated persistent Hierarchical Maps test failure caused by a 404; the failing test reproduced in isolation.
- Manual light-theme and mobile visual review remain for a human contributor.

## Docs and release impact

- [x] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Version/release files updated (only if this PR includes a version bump)

## UI evidence

No screenshots committed. The focused Playwright flow verifies the setup import control and imported game-name state.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added reusable JSON export and import for game setups.
  * Added an “Import setup” option to the game setup wizard.
  * Restores game settings, selected resources, generation parameters, and other configuration from imported files.
  * Shows success messages and warnings when setups are imported.
  * Downloaded setup files now use descriptive names and reusable `.marinara-game-setup.json` formatting.
* **Bug Fixes**
  * Improved handling of unavailable or renamed resources during setup import.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->