### PR TITLE
fix: keep game hot-activation proof runnable

### DIFF
--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -75,7 +75,7 @@ Sometimes the server is running but the browser shows a blank page, or the app l
 
 If **Agents → Download Agents** says the catalog is unavailable, the machine running the Marinara server—not only the browser—must be able to reach the official [Pasta-Devs/Marinara-Agents](https://github.com/Pasta-Devs/Marinara-Agents) catalog over GitHub HTTPS. Installed agents continue to work offline at their current version. Restore the server connection and restart Marinara to retry automatic package updates, or click **Refresh** or **Try again** to browse the catalog immediately.
 
-If an installed map, call, or Conversation game does not appear, close Marinara Engine completely and start it again. Packages containing server or client runtime code deliberately remain in **Restart required** state until the next process start. Then enable the agent for the chat in Chat Settings; Game-compatible agents can also be selected during game creation.
+If an installed map or call does not appear, close Marinara Engine completely and start it again. Those route-bearing packages remain in **Restart required** state until the next process start. Conversation games are different: current Engine builds hot-activate them immediately. Refresh the catalog if installation failed, then confirm the game shows as ready; adding it under a chat's **Commands** settings is only necessary when you want characters to initiate it themselves, not for the game's manual slash command.
 
 If an older installation cannot complete its first package migration, do not delete the `data/capability-packages` folder or your chat data. Marinara leaves the migration incomplete and retries on the next startup. Existing chat selections and settings remain stored while the catalog is unreachable.
 

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "regression:providers": "pnpm build:shared && pnpm --filter @marinara-engine/server exec tsx ../../scripts/regressions/provider-compat.regression.ts",
     "regression:jsonish": "pnpm --filter @marinara-engine/server exec tsx ../../scripts/regressions/jsonish-output.regression.ts",
     "regression:tts": "pnpm build:shared && pnpm --filter @marinara-engine/server exec tsx ../../scripts/regressions/tts-source-persistence.regression.ts",
-    "regression:issues": "pnpm --filter @marinara-engine/server exec tsx ../../scripts/regressions/open-issues.regression.ts && pnpm --filter @marinara-engine/server exec tsx ../../scripts/regressions/file-backed-shutdown.regression.ts && pnpm --filter @marinara-engine/server exec tsx ../../scripts/regressions/capability-package-lifecycle.regression.ts && pnpm --filter @marinara-engine/client exec tsx ../../scripts/regressions/conversation-game-slash.regression.ts",
+    "regression:issues": "pnpm --filter @marinara-engine/server exec tsx ../../scripts/regressions/open-issues.regression.ts && pnpm --filter @marinara-engine/server exec tsx ../../scripts/regressions/file-backed-shutdown.regression.ts && pnpm --filter @marinara-engine/server exec tsx ../../scripts/regressions/capability-package-lifecycle.regression.ts && pnpm --filter @marinara-engine/server exec tsx ../../scripts/regressions/conversation-game-slash.regression.ts",
     "regression:roleplay": "pnpm build:shared && pnpm --filter @marinara-engine/server exec tsx ../../scripts/regressions/roleplay-streaming.regression.ts",
     "regression:sprites": "pnpm --filter @marinara-engine/server exec tsx ../../scripts/regressions/sprite-background.regression.ts",
     "smoke:ui": "playwright test -c playwright.config.ts",


### PR DESCRIPTION
## Linked work

Follow-up to #3699 and #3700.

## Why this change

The squash review for #3700 moved the new Conversation game slash regression to the client workspace, but that workspace does not provide the `tsx` executable. As a result, the merged `pnpm regression:issues` command stops with `Command "tsx" not found` before it can run the proof. The troubleshooting guide also retained the old instruction to restart Engine and activate a game per chat.

## What changed

- Run the Conversation game slash regression through the server workspace, which owns the repository's `tsx` runner and already executes the adjacent capability lifecycle regression.
- Clarify that Maps and Calls retain their restart path while Conversation games hot-activate; Commands selection controls only character initiation.

## Validation

- [ ] Review the troubleshooting wording against the merged runtime behavior
- [ ] Confirm the issue regression script runs from a clean checkout

### Automated evidence

- `pnpm check` — passed on the squash-merged staging head.
- `pnpm regression:issues` — passed end-to-end after the runner correction.
- `git diff --check` — passed.

Expected error logs from deliberately failing file-storage and capability fixtures appeared while their assertions passed.

## Risk

Low. This follow-up changes one package-script workspace selector and one troubleshooting paragraph; it does not alter production runtime code.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified troubleshooting steps for installed agent items that do not appear.
  * Explained when a restart is required, when conversation games activate immediately, and how to verify installation failures.
  * Clarified that adding a game to chat Commands is only needed for character-initiated games.

* **Tests**
  * Updated regression coverage for conversation-game slash commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->