### PR TITLE
fix: keep stable catalog compatible with agent metadata

### DIFF
--- a/e2e/core-flows.e2e.ts
+++ b/e2e/core-flows.e2e.ts
@@ -1021,6 +1021,34 @@ test("downloadable agent catalog is usable on desktop and mobile", async ({ page
   expect(errors).toEqual([]);
 });
 
+test("agent catalog reports API failures without diagnosing an internet outage", async ({ page }) => {
+  await page.route("**/api/capability-packages/catalog", async (route) => {
+    await route.fulfill({
+      status: 400,
+      contentType: "application/json",
+      body: JSON.stringify({ error: "Validation Error" }),
+    });
+  });
+  await page.route("**/api/capability-packages/installed", async (route) => {
+    await route.fulfill({ status: 200, contentType: "application/json", body: "[]" });
+  });
+  await page.route("**/api/capability-packages/agents", async (route) => {
+    await route.fulfill({ status: 200, contentType: "application/json", body: "[]" });
+  });
+  await page.route("**/api/agents", async (route) => {
+    await route.fulfill({ status: 200, contentType: "application/json", body: "[]" });
+  });
+
+  await page.goto("/");
+  await page.locator('[data-tour="panel-agents"]').click();
+  await page.getByLabel("Agents").getByRole("button", { name: "Download Agents", exact: true }).click();
+
+  const catalogView = page.locator('[data-component="AgentCatalogView"]');
+  await expect(catalogView.getByText("The agent catalog is unavailable.")).toBeVisible();
+  await expect(catalogView.getByText(/Marinara Engine returned HTTP 400: Validation Error\./)).toBeVisible();
+  await expect(catalogView.getByText(/Check the server internet connection/)).toHaveCount(0);
+});
+
 test("Music Player links to Music DJ while its package is unavailable", async ({ page }) => {
   const errors = collectUnexpectedErrors(page);
   let musicDjInstalled = false;

--- a/packages/client/src/components/agents/AgentCatalogView.tsx
+++ b/packages/client/src/components/agents/AgentCatalogView.tsx
@@ -11,7 +11,7 @@ import {
   ShieldCheck,
   Sparkles,
   Trash2,
-  WifiOff,
+  TriangleAlert,
 } from "lucide-react";
 import { compareCapabilityPackageVersions, type CapabilityCatalogPackage } from "@marinara-engine/shared";
 import { toast } from "sonner";
@@ -23,7 +23,7 @@ import {
   useUninstallAllCapabilityPackages,
   useUninstallCapabilityPackage,
 } from "../../hooks/use-capability-packages";
-import { getPrivilegedActionErrorMessage } from "../../lib/api-client";
+import { ApiError, getPrivilegedActionErrorMessage } from "../../lib/api-client";
 import { showConfirmDialog } from "../../lib/app-dialogs";
 import { cn } from "../../lib/utils";
 import { useUIStore } from "../../stores/ui.store";
@@ -44,6 +44,15 @@ type BulkActionProgress = {
 function formatBytes(bytes: number) {
   if (bytes < 1024 * 1024) return `${Math.max(1, Math.round(bytes / 1024))} KB`;
   return `${(bytes / (1024 * 1024)).toFixed(bytes < 10 * 1024 * 1024 ? 1 : 0)} MB`;
+}
+
+function catalogErrorDescription(error: unknown) {
+  const offlineSuffix = "Installed agents remain available offline.";
+  if (error instanceof ApiError) {
+    return `Marinara Engine returned HTTP ${error.status}: ${error.message}. ${offlineSuffix}`;
+  }
+  if (error instanceof Error && error.message) return `${error.message}. ${offlineSuffix}`;
+  return `Marinara Engine could not load the official catalog. ${offlineSuffix}`;
 }
 
 function kindLabel(kind: CapabilityCatalogPackage["manifest"]["kind"][number]) {
@@ -340,11 +349,11 @@ export function AgentCatalogView() {
               </div>
             ) : catalog.isError ? (
               <div className="flex min-h-56 flex-col items-center justify-center gap-3 px-4 text-center">
-                <WifiOff size="2rem" className="text-[var(--muted-foreground)]" />
+                <TriangleAlert size="2rem" className="text-[var(--muted-foreground)]" />
                 <div>
                   <p className="font-semibold">The agent catalog is unavailable.</p>
                   <p className="mt-1 text-sm text-[var(--muted-foreground)]">
-                    Check the server internet connection. Installed agents remain available offline.
+                    {catalogErrorDescription(catalog.error)}
                   </p>
                 </div>
                 <button

--- a/packages/shared/src/schemas/capability-package.schema.ts
+++ b/packages/shared/src/schemas/capability-package.schema.ts
@@ -50,6 +50,12 @@ const capabilityPackageManifestBaseSchema = z.object({
         })
         .strict()
         .optional(),
+      agentDetail: z
+        .object({
+          agentIds: z.array(z.string().regex(/^[a-z0-9]+(?:-[a-z0-9]+)*$/).max(80)).min(1).max(32),
+        })
+        .strict()
+        .optional(),
     })
     .strict()
     .optional(),

--- a/scripts/regressions/capability-package-lifecycle.regression.ts
+++ b/scripts/regressions/capability-package-lifecycle.regression.ts
@@ -118,6 +118,38 @@ try {
     /requires capability API 1\.1; this Engine supports 1\.0/,
   );
 
+  const forwardCompatibleCatalog = capabilityCatalogSchema.parse({
+    schemaVersion: 1,
+    generatedAt: "2026-07-16T00:00:00.000Z",
+    packages: [
+      {
+        manifest: {
+          ...manifestV2,
+          id: "hierarchical-maps",
+          name: "Hierarchical Maps",
+          version: "1.1.1",
+          engine: { min: "3.2.0", maxExclusive: "3.3.0" },
+          capabilityApi: { major: 1, minor: 3 },
+          contributions: {
+            slots: ["chat-settings", "spatial-workspace", "chat-runtime", "game-world-map"],
+            agentDetail: { agentIds: ["hierarchical-maps"] },
+          },
+        },
+        category: "tracker",
+        artifact: {
+          url: "https://example.com/hierarchical-maps-1.1.1.zip",
+          sha256: "1".repeat(64),
+          bytes: 1,
+        },
+      },
+    ],
+  });
+  assert.deepEqual(
+    forwardCompatibleCatalog.packages[0]?.manifest.contributions?.agentDetail,
+    { agentIds: ["hierarchical-maps"] },
+    "Stable Engines must parse newer agent-detail metadata before applying compatibility gates",
+  );
+
   writeRegistry([installedPackage("conversation-calls", ["agent", "conversation-calls"])]);
   seedWhisperModels();
 

--- a/scripts/regressions/capability-package-lifecycle.regression.ts
+++ b/scripts/regressions/capability-package-lifecycle.regression.ts
@@ -149,6 +149,11 @@ try {
     { agentIds: ["hierarchical-maps"] },
     "Stable Engines must parse newer agent-detail metadata before applying compatibility gates",
   );
+  assert.match(
+    getCapabilityApiCompatibilityIssue(forwardCompatibleCatalog.packages[0]!.manifest) ?? "",
+    /requires capability API 1\.3; this Engine supports 1\.0/,
+    "Parsing newer contribution metadata must not bypass capability API compatibility gates",
+  );
 
   writeRegistry([installedPackage("conversation-calls", ["agent", "conversation-calls"])]);
   seedWhisperModels();
@@ -196,6 +201,7 @@ try {
     generatedAt: "2026-07-16T00:00:00.000Z",
     packages: [
       catalogEntry(callsUpdateManifest),
+      forwardCompatibleCatalog.packages[0]!,
       catalogEntry(futureEngineManifest),
       catalogEntry(futureCapabilityManifest),
       catalogEntry(coreUpdateManifest),


### PR DESCRIPTION
## Linked issue

Closes #3706

Related: Pasta-Devs/Marinara-Agents#60

## Why this change

- Stable Marinara Engine v2.3.1 successfully downloads the official Agent catalog but rejects the entire response when a newer, Engine-gated package declares `contributions.agentDetail`.
- The failed whole-catalog parse also aborts automatic package update discovery before existing Engine-version and capability-API compatibility gates can filter Hierarchical Maps out.
- The Agent Library then misdiagnoses the HTTP 400 validation response as a lost internet connection.

## What changed

- Backported the declarative `agentDetail.agentIds` contribution contract to the stable v2.3 schema without raising the Engine's supported capability API above 1.0.
- Added a regression using the live Hierarchical Maps v1.1.1 manifest shape and placed it in the automatic-update candidate catalog.
- Verified Maps still reports “requires capability API 1.3; this Engine supports 1.0” while compatible installed packages continue receiving update candidates.
- Replaced the offline-only Agent Library error with the actual HTTP status and server message, preserving the installed-agents-offline reassurance.
- Added desktop and mobile browser coverage for both the normal catalog and the HTTP 400 error state.

## Validation

- [ ] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed `CONTRIBUTING.md`

Automated evidence:

- `pnpm check` — passed.
- `pnpm --filter @marinara-engine/server exec tsx ../../scripts/regressions/capability-package-lifecycle.regression.ts` — passed.
- `pnpm exec playwright test e2e/core-flows.e2e.ts --grep "downloadable agent catalog is usable|agent catalog reports API failures"` — 4 passed across desktop and mobile Chromium.
- Built v2.3 server `capabilityPackageManager.catalog()` against the live official catalog — the fetch and strict parse succeeded for 29 packages, including Hierarchical Maps v1.1.1 with `agentDetail`.
- `git diff --check` — passed.

### Manual verification notes

- No human manual browser verification was performed. Automated Playwright covered desktop and mobile normal/error catalog paths.
- Container execution was not performed; issue #60 reports Docker, but the root failure is the shared Engine schema used by every install type.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Version/release files updated (only if this PR includes a version bump)

No docs or version files are changed. Docker/installer distribution still requires the maintainer's normal stable release process after merge.

## UI evidence (if applicable)

- Automated browser assertions verify the API error appears as `Marinara Engine returned HTTP 400: Validation Error.` and that the old internet-connection diagnosis is absent. No screenshot is attached yet.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Capability package manifests can now include optional agent detail metadata for more targeted agent information.

* **Bug Fixes**
  * Improved agent catalog error messages by distinguishing API failures from connectivity issues.
  * Catalog errors now display clearer unavailable status and relevant HTTP or validation details without incorrectly suggesting an internet outage.

* **Tests**
  * Added coverage for catalog API failures and forward-compatible agent metadata parsing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->