### PR TITLE
fix: report Agent catalog API errors accurately

### DIFF
--- a/e2e/core-flows.e2e.ts
+++ b/e2e/core-flows.e2e.ts
@@ -1056,6 +1056,34 @@ test("downloadable agent catalog is usable on desktop and mobile", async ({ page
   expect(errors).toEqual([]);
 });
 
+test("agent catalog reports API failures without diagnosing an internet outage", async ({ page }) => {
+  await page.route("**/api/capability-packages/catalog", async (route) => {
+    await route.fulfill({
+      status: 400,
+      contentType: "application/json",
+      body: JSON.stringify({ error: "Validation Error" }),
+    });
+  });
+  await page.route("**/api/capability-packages/installed", async (route) => {
+    await route.fulfill({ status: 200, contentType: "application/json", body: "[]" });
+  });
+  await page.route("**/api/capability-packages/agents", async (route) => {
+    await route.fulfill({ status: 200, contentType: "application/json", body: "[]" });
+  });
+  await page.route("**/api/agents", async (route) => {
+    await route.fulfill({ status: 200, contentType: "application/json", body: "[]" });
+  });
+
+  await page.goto("/");
+  await page.locator('[data-tour="panel-agents"]').click();
+  await page.getByLabel("Agents").getByRole("button", { name: "Download Agents", exact: true }).click();
+
+  const catalogView = page.locator('[data-component="AgentCatalogView"]');
+  await expect(catalogView.getByText("The agent catalog is unavailable.")).toBeVisible();
+  await expect(catalogView.getByText(/Marinara Engine returned HTTP 400: Validation Error\./)).toBeVisible();
+  await expect(catalogView.getByText(/Check the server internet connection/)).toHaveCount(0);
+});
+
 test("Music Player links to Music DJ while its package is unavailable", async ({ page }) => {
   const errors = collectUnexpectedErrors(page);
   let musicDjInstalled = false;

--- a/packages/client/src/components/agents/AgentCatalogView.tsx
+++ b/packages/client/src/components/agents/AgentCatalogView.tsx
@@ -11,7 +11,7 @@ import {
   ShieldCheck,
   Sparkles,
   Trash2,
-  WifiOff,
+  TriangleAlert,
 } from "lucide-react";
 import { compareCapabilityPackageVersions, type CapabilityCatalogPackage } from "@marinara-engine/shared";
 import { toast } from "sonner";
@@ -23,7 +23,7 @@ import {
   useUninstallAllCapabilityPackages,
   useUninstallCapabilityPackage,
 } from "../../hooks/use-capability-packages";
-import { getPrivilegedActionErrorMessage } from "../../lib/api-client";
+import { ApiError, getPrivilegedActionErrorMessage } from "../../lib/api-client";
 import { showConfirmDialog } from "../../lib/app-dialogs";
 import { cn } from "../../lib/utils";
 import { useUIStore } from "../../stores/ui.store";
@@ -96,6 +96,15 @@ type BulkActionProgress = {
 function formatBytes(bytes: number) {
   if (bytes < 1024 * 1024) return `${Math.max(1, Math.round(bytes / 1024))} KB`;
   return `${(bytes / (1024 * 1024)).toFixed(bytes < 10 * 1024 * 1024 ? 1 : 0)} MB`;
+}
+
+function catalogErrorDescription(error: unknown) {
+  const offlineSuffix = "Installed agents remain available offline.";
+  if (error instanceof ApiError) {
+    return `Marinara Engine returned HTTP ${error.status}: ${error.message}. ${offlineSuffix}`;
+  }
+  if (error instanceof Error && error.message) return `${error.message}. ${offlineSuffix}`;
+  return `Marinara Engine could not load the official catalog. ${offlineSuffix}`;
 }
 
 function kindLabel(kind: CapabilityCatalogPackage["manifest"]["kind"][number]) {
@@ -403,11 +412,11 @@ export function AgentCatalogView() {
               </div>
             ) : catalog.isError ? (
               <div className="flex min-h-56 flex-col items-center justify-center gap-3 px-4 text-center">
-                <WifiOff size="2rem" className="text-[var(--muted-foreground)]" />
+                <TriangleAlert size="2rem" className="text-[var(--muted-foreground)]" />
                 <div>
                   <p className="font-semibold">The agent catalog is unavailable.</p>
                   <p className="mt-1 text-sm text-[var(--muted-foreground)]">
-                    Check the server internet connection. Installed agents remain available offline.
+                    {catalogErrorDescription(catalog.error)}
                   </p>
                 </div>
                 <button


### PR DESCRIPTION
## Linked issue

Related to #3706 and #3707.

Also reported in Pasta-Devs/Marinara-Agents#60.

## Why this change

- Staging already supports the `agentDetail` contribution contract, so it does not need the v2.3 schema backport.
- Its Agent Library still diagnoses every catalog API failure as a lost server internet connection, even when Marinara Engine returned a concrete HTTP validation or server error.

## What changed

- Show the catalog API's actual HTTP status and error message.
- Replace the offline-specific icon with a general warning icon.
- Preserve the reassurance that installed agents remain usable offline.
- Add desktop and mobile browser coverage for normal and HTTP 400 catalog states.

## Validation

- [ ] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed `CONTRIBUTING.md`

Automated evidence:

- `pnpm check` — passed.
- `pnpm exec playwright test e2e/core-flows.e2e.ts --grep "downloadable agent catalog is usable|agent catalog reports API failures"` — 4 passed across desktop and mobile Chromium.
- `git diff --check` — passed.

### Manual verification notes

- No human manual browser verification was performed. Automated Playwright covered desktop and mobile normal/error catalog paths.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Version/release files updated (only if this PR includes a version bump)

No docs or release metadata changes are expected.

## UI evidence (if applicable)

- Automated assertions verify `Marinara Engine returned HTTP 400: Validation Error.` is shown and the old internet-connection diagnosis is absent.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved agent catalog error messages to show relevant HTTP status and error details.
  * Added an offline-availability notice without incorrectly suggesting that users check their server’s internet connection.
  * Updated the error display with clearer messaging and visual warning indicators.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->