### PR TITLE
Fix editor history and preserve partial character updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 
 ### Fixed
 
+- Preserved greetings, example dialogue, creator notes, system prompts, post-history instructions, character versions, and alternate greetings when Professor Mari or another app-data caller updates an unrelated Character Card field (#3708).
 - Restored native undo and redo in shared text editors, including lorebook Content and Description fields, and made `Tab` / `Shift+Tab` indent or unindent every selected line without replacing the selection.
 - Resolved `{{user}}`, `{{char}}`, and other prompt macros in opening greetings and `/guided` instructions at the final provider boundary, including lorebook routing and embedding scans, so late prompt injections cannot send raw identity placeholders to models (#3704).
 - Raised Conversation routine-summary generations from a 512-token ceiling to an 8,192-token default, honored larger Connection overrides, and requested low reasoning effort so reasoning models still return visible summaries (#3696).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 
 ### Fixed
 
+- Restored native undo and redo in shared text editors, including lorebook Content and Description fields, and made `Tab` / `Shift+Tab` indent or unindent every selected line without replacing the selection.
 - Resolved `{{user}}`, `{{char}}`, and other prompt macros in opening greetings and `/guided` instructions at the final provider boundary, including lorebook routing and embedding scans, so late prompt injections cannot send raw identity placeholders to models (#3704).
 - Raised Conversation routine-summary generations from a 512-token ceiling to an 8,192-token default, honored larger Connection overrides, and requested low reasoning effort so reasoning models still return visible summaries (#3696).
 - Allowed selected custom agents to run in Conversation, Roleplay, and Game chats whenever **Enable Agents** is on, while preserving per-mode availability rules for official packages (#3692).

--- a/e2e/core-flows.e2e.ts
+++ b/e2e/core-flows.e2e.ts
@@ -135,7 +135,7 @@ test("turning off the custom mouse pointer persists immediately and after reload
     .toBeNull();
 });
 
-test("Convo About Me keeps manual editing without legacy AI Write controls", async ({ page }, testInfo) => {
+test("Convo About Me keeps manual editing and native expanded-editor keyboard behavior", async ({ page }, testInfo) => {
   test.skip(!testInfo.project.name.includes("desktop"), "The shared Convo profile fields are covered on desktop.");
 
   const characterName = "About Me Controls Smoke";
@@ -144,7 +144,7 @@ test("Convo About Me keeps manual editing without legacy AI Write controls", asy
       data: {
         name: characterName,
         personality: "Dryly funny and observant.",
-        extensions: { aboutMe: "quietly judging your playlist" },
+        extensions: { aboutMe: "alpha\nbeta" },
       },
     },
   });
@@ -154,17 +154,57 @@ test("Convo About Me keeps manual editing without legacy AI Write controls", asy
   try {
     await page.goto("/");
     await page.locator('[data-tour="panel-characters"]').click();
-    await page.getByText(characterName, { exact: true }).click();
+    await page.getByText(characterName, { exact: true }).first().click();
 
     const editorSections = page.getByRole("navigation", { name: "Editor sections" });
     await editorSections.getByRole("button", { name: "Convo", exact: true }).click();
 
     const fields = page.locator('[data-component="ConvoProfileFields"]');
     await expect(fields.getByText("About Me", { exact: true })).toBeVisible();
-    await expect(fields.locator("textarea").first()).toHaveValue("quietly judging your playlist");
+    const aboutMe = fields.locator("textarea").first();
+    await expect(aboutMe).toHaveValue("alpha\nbeta");
     await expect(fields.getByRole("button", { name: "AI Write", exact: true })).toHaveCount(0);
     await expect(fields.getByRole("button", { name: "AI Write sources", exact: true })).toHaveCount(0);
     await expect(fields.locator("select")).toHaveCount(1);
+
+    await aboutMe.evaluate((textarea) => {
+      textarea.focus();
+      textarea.setSelectionRange(0, textarea.value.length);
+    });
+    await page.keyboard.press("Tab");
+    await expect(aboutMe).toHaveValue("  alpha\n  beta");
+    await page.keyboard.press(`${process.platform === "darwin" ? "Meta" : "Control"}+z`);
+    await expect(aboutMe).toHaveValue("alpha\nbeta");
+
+    await fields.getByRole("button", { name: "Expand editor", exact: true }).first().click();
+    const expandedEditor = page.locator('[data-component="ExpandedMacroEditor"] textarea');
+    await expect(expandedEditor).toHaveValue("alpha\nbeta");
+
+    await expandedEditor.evaluate((textarea) => {
+      textarea.focus();
+      textarea.setSelectionRange(textarea.value.length, textarea.value.length);
+    });
+    await page.keyboard.type("!");
+    await expect(expandedEditor).toHaveValue("alpha\nbeta!");
+    await page.keyboard.press(`${process.platform === "darwin" ? "Meta" : "Control"}+z`);
+    await expect(expandedEditor).toHaveValue("alpha\nbeta");
+
+    await expandedEditor.evaluate((textarea) => {
+      textarea.focus();
+      textarea.setSelectionRange(0, textarea.value.length);
+    });
+    await page.keyboard.press("Tab");
+    await expect(expandedEditor).toHaveValue("  alpha\n  beta");
+    await page.keyboard.press(`${process.platform === "darwin" ? "Meta" : "Control"}+z`);
+    await expect(expandedEditor).toHaveValue("alpha\nbeta");
+
+    await expandedEditor.evaluate((textarea) => {
+      textarea.focus();
+      textarea.setSelectionRange(0, textarea.value.length);
+    });
+    await page.keyboard.press("Tab");
+    await page.keyboard.press("Shift+Tab");
+    await expect(expandedEditor).toHaveValue("alpha\nbeta");
   } finally {
     await page.request.delete(`/api/characters/${character.id}`);
   }

--- a/packages/client/src/components/game-assets/FileEditorModal.tsx
+++ b/packages/client/src/components/game-assets/FileEditorModal.tsx
@@ -6,6 +6,7 @@ import { FileText, X } from "lucide-react";
 import type { TreeNode } from "../../hooks/use-game-assets";
 import { useGameAssetFileContent, useSaveGameAssetFile } from "../../hooks/use-game-assets";
 import { cn } from "../../lib/utils";
+import { handleTextareaTab } from "../../lib/textarea-editing";
 import { toast } from "sonner";
 import { renderMarkdownBlocks, applyInlineMarkdown } from "../../lib/markdown";
 
@@ -81,18 +82,7 @@ export function FileEditorModal({ node, onClose, initialMode = "edit" }: FileEdi
 
   const handleKeyDown = useCallback(
     (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
-      if (e.key === "Tab") {
-        e.preventDefault();
-        const ta = e.currentTarget;
-        const start = ta.selectionStart;
-        const end = ta.selectionEnd;
-        const newValue = content.substring(0, start) + "  " + content.substring(end);
-        setContent(newValue);
-        requestAnimationFrame(() => {
-          ta.selectionStart = ta.selectionEnd = start + 2;
-        });
-        return;
-      }
+      if (handleTextareaTab(e)) return;
 
       if (e.key === "s" && (e.metaKey || e.ctrlKey)) {
         e.preventDefault();
@@ -108,7 +98,7 @@ export function FileEditorModal({ node, onClose, initialMode = "edit" }: FileEdi
         return;
       }
     },
-    [content, isDirty, handleSave, handleRequestClose],
+    [isDirty, handleSave, handleRequestClose],
   );
 
   const isMd = node.ext === ".md";

--- a/packages/client/src/components/presets/PresetEditor.tsx
+++ b/packages/client/src/components/presets/PresetEditor.tsx
@@ -67,27 +67,8 @@ import { useQuoteFormatter } from "../../hooks/use-quote-formatter";
 import { EditorTabRail } from "../ui/EditorTabRail";
 import { useTouchFolderDrag } from "../../hooks/use-touch-folder-drag";
 import { getTouchReorderDropIndex } from "../../lib/touch-reorder";
+import { handleTextareaTab } from "../../lib/textarea-editing";
 import { SettingsSwitch } from "../panels/settings/SettingControls";
-
-/** Intercept Tab in a textarea to insert 2 spaces instead of changing focus. */
-function handleTextareaTab(
-  e: React.KeyboardEvent<HTMLTextAreaElement>,
-  value: string,
-  setValue: (v: string) => void,
-  formatValue: (v: string) => string = (v) => v,
-) {
-  if (e.key !== "Tab") return;
-  e.preventDefault();
-  const ta = e.currentTarget;
-  const start = ta.selectionStart;
-  const end = ta.selectionEnd;
-  const newValue = formatValue(value.substring(0, start) + "  " + value.substring(end));
-  setValue(newValue);
-  // Restore cursor position after React re-renders
-  requestAnimationFrame(() => {
-    ta.selectionStart = ta.selectionEnd = start + 2;
-  });
-}
 
 // ── Input caret helpers ──
 type TextSelection = { start: number; end: number };
@@ -2692,21 +2673,7 @@ function ExpandedEditorModal({
               ref={textareaRef}
               value={local}
               onChange={handleChange}
-              onKeyDown={(e) =>
-                handleTextareaTab(
-                  e,
-                  local,
-                  (v) => {
-                    const nextValue = formatQuotes(v);
-                    setLocal(nextValue);
-                    if (timeoutRef.current) clearTimeout(timeoutRef.current);
-                    timeoutRef.current = setTimeout(() => {
-                      onChange(nextValue);
-                    }, 600);
-                  },
-                  formatQuotes,
-                )
-              }
+              onKeyDown={handleTextareaTab}
               className="mari-editor-field h-full w-full resize-none p-4 font-mono text-sm"
               placeholder="Prompt content… (supports macros like {{user}}, {{char}}, etc.)"
             />

--- a/packages/client/src/components/ui/ExpandedTextarea.tsx
+++ b/packages/client/src/components/ui/ExpandedTextarea.tsx
@@ -1,11 +1,12 @@
 // ──────────────────────────────────────────────
 // Expanded Textarea — Fullscreen editing overlay
 // ──────────────────────────────────────────────
-import { useEffect, useRef, type CSSProperties, type ReactNode } from "react";
+import { useEffect, useRef, type CSSProperties, type KeyboardEvent as ReactKeyboardEvent, type ReactNode } from "react";
 import { createPortal } from "react-dom";
 import { motion, AnimatePresence } from "framer-motion";
 import { Minimize2 } from "lucide-react";
 import { cn } from "../../lib/utils";
+import { handleTextareaTab } from "../../lib/textarea-editing";
 import {
   NEUTRAL_PANEL_HEADER,
   NEUTRAL_PANEL_SCROLL_AREA,
@@ -111,6 +112,7 @@ export function ExpandedTextarea({
               ref={textareaRef}
               value={value}
               onChange={(e) => onChange(e.target.value)}
+              onKeyDown={(event: ReactKeyboardEvent<HTMLTextAreaElement>) => handleTextareaTab(event)}
               placeholder={placeholder}
               className={cn(
                 "h-full w-full resize-none rounded-xl p-5 text-sm leading-relaxed outline-none transition-colors",

--- a/packages/client/src/components/ui/ExpandedTextarea.tsx
+++ b/packages/client/src/components/ui/ExpandedTextarea.tsx
@@ -1,7 +1,7 @@
 // ──────────────────────────────────────────────
 // Expanded Textarea — Fullscreen editing overlay
 // ──────────────────────────────────────────────
-import { useEffect, useRef, type CSSProperties, type KeyboardEvent as ReactKeyboardEvent, type ReactNode } from "react";
+import { useEffect, useRef, type CSSProperties, type ReactNode } from "react";
 import { createPortal } from "react-dom";
 import { motion, AnimatePresence } from "framer-motion";
 import { Minimize2 } from "lucide-react";
@@ -112,7 +112,7 @@ export function ExpandedTextarea({
               ref={textareaRef}
               value={value}
               onChange={(e) => onChange(e.target.value)}
-              onKeyDown={(event: ReactKeyboardEvent<HTMLTextAreaElement>) => handleTextareaTab(event)}
+              onKeyDown={handleTextareaTab}
               placeholder={placeholder}
               className={cn(
                 "h-full w-full resize-none rounded-xl p-5 text-sm leading-relaxed outline-none transition-colors",

--- a/packages/client/src/components/ui/MacroTextarea.tsx
+++ b/packages/client/src/components/ui/MacroTextarea.tsx
@@ -1,4 +1,13 @@
-import { useCallback, useEffect, useRef, useState, type ChangeEvent, type KeyboardEvent as ReactKeyboardEvent, type ReactNode, type Ref } from "react";
+import {
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+  type ChangeEvent,
+  type KeyboardEvent as ReactKeyboardEvent,
+  type ReactNode,
+  type Ref,
+} from "react";
 import { createPortal } from "react-dom";
 import { BookOpen, Maximize2, X } from "lucide-react";
 import { SUPPORTED_MACROS } from "@marinara-engine/shared";
@@ -103,13 +112,6 @@ function ExpandedMacroEditor({
     [formatOnChange, onChange],
   );
 
-  const handleKeyDown = useCallback(
-    (event: ReactKeyboardEvent<HTMLTextAreaElement>) => {
-      handleTextareaTab(event);
-    },
-    [],
-  );
-
   if (!open) {
     return null;
   }
@@ -146,7 +148,7 @@ function ExpandedMacroEditor({
             ref={textareaRef}
             value={localValue}
             onChange={handleChange}
-            onKeyDown={handleKeyDown}
+            onKeyDown={handleTextareaTab}
             placeholder={placeholder}
             className="min-h-0 flex-1 resize-none bg-[var(--secondary)] p-4 font-mono text-sm leading-6 text-[var(--foreground)] outline-none placeholder:text-[var(--muted-foreground)]"
             spellCheck={false}

--- a/packages/client/src/components/ui/MacroTextarea.tsx
+++ b/packages/client/src/components/ui/MacroTextarea.tsx
@@ -4,6 +4,7 @@ import { BookOpen, Maximize2, X } from "lucide-react";
 import { SUPPORTED_MACROS } from "@marinara-engine/shared";
 
 import { cn } from "../../lib/utils";
+import { handleTextareaTab } from "../../lib/textarea-editing";
 
 type MacroDefinition = (typeof SUPPORTED_MACROS)[number];
 
@@ -56,14 +57,6 @@ interface ExpandedMacroEditorProps {
   formatOnChange?: (textarea: HTMLTextAreaElement) => string;
 }
 
-function insertTextAtSelection(target: HTMLTextAreaElement, insertText: string): { value: string; cursor: number } {
-  const { selectionStart, selectionEnd, value } = target;
-  return {
-    value: `${value.slice(0, selectionStart)}${insertText}${value.slice(selectionEnd)}`,
-    cursor: selectionStart + insertText.length,
-  };
-}
-
 function ExpandedMacroEditor({
   open,
   title,
@@ -112,21 +105,9 @@ function ExpandedMacroEditor({
 
   const handleKeyDown = useCallback(
     (event: ReactKeyboardEvent<HTMLTextAreaElement>) => {
-      if (event.key !== "Tab") {
-        return;
-      }
-
-      event.preventDefault();
-      const target = event.currentTarget;
-      const next = insertTextAtSelection(target, "  ");
-      setLocalValue(next.value);
-      onChange(next.value);
-      requestAnimationFrame(() => {
-        target.selectionStart = next.cursor;
-        target.selectionEnd = next.cursor;
-      });
+      handleTextareaTab(event);
     },
-    [onChange],
+    [],
   );
 
   if (!open) {
@@ -136,6 +117,7 @@ function ExpandedMacroEditor({
   return (
     <MacroModalPortal>
       <div
+        data-component="ExpandedMacroEditor"
         className={cn(
           "fixed inset-0 z-[140] flex items-center justify-center bg-black/70 p-3 pb-[max(env(safe-area-inset-bottom),0.75rem)] pt-[max(env(safe-area-inset-top),0.75rem)] backdrop-blur-sm sm:p-4",
           EDITOR_MODAL_SURFACE_VARIABLES,
@@ -328,16 +310,9 @@ export function MacroTextarea({
         return;
       }
 
-      event.preventDefault();
-      const target = event.currentTarget;
-      const next = insertTextAtSelection(target, "  ");
-      onChange(next.value);
-      requestAnimationFrame(() => {
-        target.selectionStart = next.cursor;
-        target.selectionEnd = next.cursor;
-      });
+      handleTextareaTab(event);
     },
-    [onChange, onKeyDown],
+    [onKeyDown],
   );
 
   const affordanceButtonClassName = cn(

--- a/packages/client/src/lib/textarea-editing.ts
+++ b/packages/client/src/lib/textarea-editing.ts
@@ -1,0 +1,154 @@
+const INDENT = "  ";
+
+interface TextareaEdit {
+  start: number;
+  end: number;
+  replacement: string;
+  selectionStart: number;
+  selectionEnd: number;
+  selectionDirection: "forward" | "backward" | "none";
+}
+
+interface TextareaTabEvent {
+  key: string;
+  shiftKey: boolean;
+  altKey: boolean;
+  ctrlKey: boolean;
+  metaKey: boolean;
+  defaultPrevented: boolean;
+  currentTarget: HTMLTextAreaElement;
+  preventDefault: () => void;
+}
+
+function selectedLineRange(value: string, selectionStart: number, selectionEnd: number) {
+  const start = value.lastIndexOf("\n", selectionStart - 1) + 1;
+  const endsAtNextLineStart = selectionEnd > selectionStart && value[selectionEnd - 1] === "\n";
+  const effectiveEnd = endsAtNextLineStart ? selectionEnd - 1 : selectionEnd;
+  const nextLineBreak = value.indexOf("\n", effectiveEnd);
+  const end = nextLineBreak === -1 ? value.length : nextLineBreak;
+  return { start, end };
+}
+
+function unindentPrefixLength(value: string): number {
+  if (value.startsWith("\t")) return 1;
+  if (value.startsWith(INDENT)) return INDENT.length;
+  return value.startsWith(" ") ? 1 : 0;
+}
+
+function createTabEdit(textarea: HTMLTextAreaElement, unindent: boolean): TextareaEdit | null {
+  const value = textarea.value;
+  const selectionStart = textarea.selectionStart;
+  const selectionEnd = textarea.selectionEnd;
+  const selectionDirection = textarea.selectionDirection ?? "none";
+
+  if (selectionStart === selectionEnd) {
+    if (!unindent) {
+      return {
+        start: selectionStart,
+        end: selectionEnd,
+        replacement: INDENT,
+        selectionStart: selectionStart + INDENT.length,
+        selectionEnd: selectionStart + INDENT.length,
+        selectionDirection: "none",
+      };
+    }
+
+    const lineStart = value.lastIndexOf("\n", selectionStart - 1) + 1;
+    const removeLength = unindentPrefixLength(value.slice(lineStart));
+    if (removeLength === 0) return null;
+    const nextCaret = Math.max(lineStart, selectionStart - removeLength);
+    return {
+      start: lineStart,
+      end: lineStart + removeLength,
+      replacement: "",
+      selectionStart: nextCaret,
+      selectionEnd: nextCaret,
+      selectionDirection: "none",
+    };
+  }
+
+  const range = selectedLineRange(value, selectionStart, selectionEnd);
+  const lines = value.slice(range.start, range.end).split("\n");
+  const replacement = lines
+    .map((line) => {
+      if (!unindent) return `${INDENT}${line}`;
+      return line.slice(unindentPrefixLength(line));
+    })
+    .join("\n");
+
+  if (replacement === value.slice(range.start, range.end)) return null;
+  return {
+    start: range.start,
+    end: range.end,
+    replacement,
+    selectionStart: range.start,
+    selectionEnd: range.start + replacement.length,
+    selectionDirection,
+  };
+}
+
+function dispatchInput(textarea: HTMLTextAreaElement, replacement: string) {
+  const InputEventConstructor = textarea.ownerDocument.defaultView?.InputEvent;
+  const event = InputEventConstructor
+    ? new InputEventConstructor("input", { bubbles: true, data: replacement, inputType: "insertText" })
+    : new Event("input", { bubbles: true });
+  textarea.dispatchEvent(event);
+}
+
+function applyTextareaEdit(textarea: HTMLTextAreaElement, edit: TextareaEdit) {
+  const before = textarea.value;
+  const expected = `${before.slice(0, edit.start)}${edit.replacement}${before.slice(edit.end)}`;
+  let inputDispatched = false;
+  const markInputDispatched = () => {
+    inputDispatched = true;
+  };
+
+  textarea.addEventListener("input", markInputDispatched, { once: true });
+  textarea.setSelectionRange(edit.start, edit.end);
+
+  let appliedWithNativeHistory = false;
+  try {
+    // execCommand is intentionally used here: unlike assigning `value` or
+    // calling setRangeText, it records scripted textarea edits in the native
+    // undo stack across Chromium, Firefox, and Safari.
+    appliedWithNativeHistory = textarea.ownerDocument.execCommand("insertText", false, edit.replacement);
+  } catch {
+    // Older embedded browsers can reject execCommand. The fallback still
+    // performs the edit, though those browsers cannot preserve native undo.
+  }
+  textarea.removeEventListener("input", markInputDispatched);
+
+  if (!appliedWithNativeHistory || textarea.value !== expected) {
+    if (textarea.value !== before) textarea.value = before;
+    textarea.setRangeText(edit.replacement, edit.start, edit.end, "end");
+  }
+  if (!inputDispatched) dispatchInput(textarea, edit.replacement);
+
+  const restoreSelection = () => {
+    if (textarea.ownerDocument.activeElement !== textarea || textarea.value !== expected) return;
+    textarea.setSelectionRange(edit.selectionStart, edit.selectionEnd, edit.selectionDirection);
+  };
+  restoreSelection();
+  textarea.ownerDocument.defaultView?.requestAnimationFrame(restoreSelection);
+}
+
+/**
+ * Applies editor-style Tab and Shift+Tab behavior without discarding the
+ * browser's native undo transaction.
+ */
+export function handleTextareaTab(event: TextareaTabEvent): boolean {
+  if (
+    event.defaultPrevented ||
+    event.key !== "Tab" ||
+    event.altKey ||
+    event.ctrlKey ||
+    event.metaKey
+  ) {
+    return false;
+  }
+
+  event.preventDefault();
+  const edit = createTabEdit(event.currentTarget, event.shiftKey);
+  if (edit) applyTextareaEdit(event.currentTarget, edit);
+  return true;
+}

--- a/packages/server/src/services/mari-db/mari-db.service.ts
+++ b/packages/server/src/services/mari-db/mari-db.service.ts
@@ -753,6 +753,17 @@ export function normalizeCharacterActionData(input: Row): Row {
   out.post_history_instructions = out.post_history_instructions ?? out.postHistoryInstructions;
   out.character_version = out.character_version ?? out.characterVersion;
   out.alternate_greetings = out.alternate_greetings ?? out.alternateGreetings;
+  for (const key of [
+    "first_mes",
+    "mes_example",
+    "creator_notes",
+    "system_prompt",
+    "post_history_instructions",
+    "character_version",
+    "alternate_greetings",
+  ]) {
+    if (out[key] === undefined) delete out[key];
+  }
   delete out.firstMes;
   delete out.firstMessage;
   delete out.greeting;

--- a/scripts/regressions/open-issues.regression.ts
+++ b/scripts/regressions/open-issues.regression.ts
@@ -229,15 +229,19 @@ assert.equal(minimalProfessorMariPersona.convoBehavior, "");
 const generatedCharacterData = normalizeCharacterActionData({
   firstMessage: "Welcome to the laboratory.",
   mesExample: "{{char}}: Observe carefully.",
+  creatorNotes: "Created for regression coverage.",
   systemPrompt: "Stay in character.",
   postHistoryInstructions: "Remain concise.",
+  characterVersion: "1.2.3",
   alternateGreetings: ["You made it."],
   aboutMe: "lab gremlin. ethically flexible. coffee required.",
 });
 assert.equal(generatedCharacterData.first_mes, "Welcome to the laboratory.");
 assert.equal(generatedCharacterData.mes_example, "{{char}}: Observe carefully.");
+assert.equal(generatedCharacterData.creator_notes, "Created for regression coverage.");
 assert.equal(generatedCharacterData.system_prompt, "Stay in character.");
 assert.equal(generatedCharacterData.post_history_instructions, "Remain concise.");
+assert.equal(generatedCharacterData.character_version, "1.2.3");
 assert.deepEqual(generatedCharacterData.alternate_greetings, ["You made it."]);
 assert.equal(
   (generatedCharacterData.extensions as Record<string, unknown>).aboutMe,
@@ -245,6 +249,13 @@ assert.equal(
 );
 assert.equal(Object.hasOwn(generatedCharacterData, "aboutMe"), false);
 assert.equal(Object.hasOwn(generatedCharacterData, "firstMessage"), false);
+
+const partialCharacterUpdateData = normalizeCharacterActionData({ personality: "Quietly analytical." });
+assert.deepEqual(
+  partialCharacterUpdateData,
+  { personality: "Quietly analytical." },
+  "Partial character updates must not synthesize undefined fields that deepMerge treats as deletions",
+);
 
 const professorMariAboutMeCommands = parseCharacterCommands(
   '[update_character: name="Luna", about_me="fate dealer. tea hoarder. 🔮"]\n' +

--- a/scripts/regressions/open-issues.regression.ts
+++ b/scripts/regressions/open-issues.regression.ts
@@ -104,6 +104,7 @@ import { resolveSceneVideoPrompt } from "../../packages/server/src/services/vide
 import {
   buildLorebookEntryCreateRow,
   buildPersonaCreateRow,
+  MariDbService,
   normalizeCharacterActionData,
 } from "../../packages/server/src/services/mari-db/mari-db.service.js";
 import {
@@ -256,6 +257,77 @@ assert.deepEqual(
   { personality: "Quietly analytical." },
   "Partial character updates must not synthesize undefined fields that deepMerge treats as deletions",
 );
+
+const characterUpdateStorageRoot = mkdtempSync(join(tmpdir(), "marinara-character-update-preservation-"));
+const previousFileStorageDir = process.env.FILE_STORAGE_DIR;
+process.env.FILE_STORAGE_DIR = characterUpdateStorageRoot;
+let closeCharacterUpdateDb: (() => Promise<void>) | null = null;
+try {
+  const { closeDB, getDB } = await import("../../packages/server/src/db/connection.js");
+  closeCharacterUpdateDb = closeDB;
+  const mariDb = new MariDbService(await getDB());
+  const characterId = "partial-update-preservation";
+  const createResult = await mariDb.executeAction({
+    action: "character.create",
+    id: characterId,
+    data: {
+      name: "Preserved Character",
+      personality: "Before the update.",
+      firstMes: "Welcome to the laboratory.",
+      mesExample: "{{char}}: Observe carefully.",
+      creatorNotes: "Created for integration coverage.",
+      systemPrompt: "Stay in character.",
+      postHistoryInstructions: "Remain concise.",
+      characterVersion: "1.2.3",
+      alternateGreetings: ["You made it."],
+    },
+  });
+  assert.equal(createResult.ok, true, "The character update regression fixture must be created");
+
+  const updateResult = await mariDb.executeAction({
+    action: "character.update",
+    id: characterId,
+    patch: { personality: "After the update." },
+    apply: true,
+  });
+  assert.equal(updateResult.ok, true, "A personality-only character.update must apply");
+
+  const readResult = await mariDb.executeAction({ action: "character.get", id: characterId });
+  assert.equal(readResult.ok, true);
+  const updatedCard = (readResult.output as { data: Record<string, unknown> }).data;
+  assert.deepEqual(
+    {
+      personality: updatedCard.personality,
+      first_mes: updatedCard.first_mes,
+      mes_example: updatedCard.mes_example,
+      creator_notes: updatedCard.creator_notes,
+      system_prompt: updatedCard.system_prompt,
+      post_history_instructions: updatedCard.post_history_instructions,
+      character_version: updatedCard.character_version,
+      alternate_greetings: updatedCard.alternate_greetings,
+    },
+    {
+      personality: "After the update.",
+      first_mes: "Welcome to the laboratory.",
+      mes_example: "{{char}}: Observe carefully.",
+      creator_notes: "Created for integration coverage.",
+      system_prompt: "Stay in character.",
+      post_history_instructions: "Remain concise.",
+      character_version: "1.2.3",
+      alternate_greetings: ["You made it."],
+    },
+    "character.update must preserve every omitted Character Card field through the real merge and persistence path",
+  );
+
+  for (const approval of mariDb.getPendingApprovals()) {
+    await mariDb.keepAppliedReview(approval.id);
+  }
+} finally {
+  await closeCharacterUpdateDb?.();
+  if (previousFileStorageDir === undefined) delete process.env.FILE_STORAGE_DIR;
+  else process.env.FILE_STORAGE_DIR = previousFileStorageDir;
+  rmSync(characterUpdateStorageRoot, { recursive: true, force: true });
+}
 
 const professorMariAboutMeCommands = parseCharacterCommands(
   '[update_character: name="Luna", about_me="fate dealer. tea hoarder. 🔮"]\n' +


### PR DESCRIPTION
## Why

Expanded text editors lost native undo history and replaced multiline selections when indenting. Separately, partial `character.update` app-data actions can erase omitted Character Card fields such as greetings and example dialogue.

Fixes #3708.

## What

- restore native undo/redo-friendly edits across shared expanded text editors
- indent and unindent every selected line with Tab and Shift+Tab
- preserve omitted Character Card fields during partial `character.update` actions
- add focused regression coverage and release notes

## Test plan

- [ ] Manually verify Cmd/Ctrl+Z restores typed and indented lorebook text.
- [ ] Manually verify Tab and Shift+Tab indent and unindent multiline selections.
- [ ] Manually verify a partial `character.update` leaves greetings and example dialogue unchanged.
- [ ] Run the focused editor Playwright regression.
- [ ] Run the open-issues regression.
- [ ] Run `pnpm check`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved greetings, example dialogue, creator notes, system prompts, and post-history instructions when updating unrelated character fields.
  * Restored native undo/redo behavior in shared text editors.
  * Added consistent `Tab` indentation and `Shift+Tab` unindentation for selected lines.
  * Ensured manual About Me edits persist in the expanded editor.
* **Tests**
  * Expanded regression and end-to-end coverage for character updates and editor keyboard behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->