### PR TITLE
fix: fit mobile CYOA between HUD widget rails

### DIFF
--- a/e2e/core-flows.e2e.ts
+++ b/e2e/core-flows.e2e.ts
@@ -4434,6 +4434,175 @@ test("mobile topbar remains reachable while sidebars switch", async ({ page }, t
   expect(errors).toEqual([]);
 });
 
+test("mobile Game keeps CYOA usable above four HUD widgets", async ({ page, request }, testInfo) => {
+  test.skip(!testInfo.project.name.includes("mobile"), "The Game viewport-pressure regression is mobile-only.");
+
+  const errors = collectUnexpectedErrors(page);
+  await expect.poll(async () => (await request.get("/api/health")).ok()).toBe(true);
+  const chatResponse = await request.post("/api/chats", {
+    data: { name: "Mobile Game CYOA Viewport Smoke", mode: "game", characterIds: [] },
+  });
+  expect(chatResponse.ok()).toBeTruthy();
+  const chat = (await chatResponse.json()) as { id: string };
+
+  const hudWidgets = [
+    {
+      id: "widget-floor",
+      type: "counter",
+      label: "Dungeon Floor",
+      icon: "🗼",
+      position: "hud_left",
+      accent: "#9B6CFF",
+      config: { count: 1 },
+    },
+    {
+      id: "widget-exp",
+      type: "progress_bar",
+      label: "EXP to Next Level",
+      icon: "✨",
+      position: "hud_left",
+      accent: "#4FD6FF",
+      config: { value: 20, max: 100 },
+    },
+    {
+      id: "widget-bonds",
+      type: "stat_block",
+      label: "Party Bonds",
+      icon: "💞",
+      position: "hud_right",
+      accent: "#FF69B4",
+      config: { stats: [{ name: "Ally", value: 40 }] },
+    },
+    {
+      id: "widget-pressure",
+      type: "gauge",
+      label: "Curse Pressure",
+      icon: "💜",
+      position: "hud_right",
+      accent: "#C43DFF",
+      config: { value: 10, max: 100 },
+    },
+  ];
+
+  try {
+    const metadataResponse = await request.patch(`/api/chats/${chat.id}/metadata`, {
+      data: {
+        gameId: "mobile-cyoa-viewport-smoke",
+        gameSessionStatus: "active",
+        gameSessionNumber: 1,
+        gameIntroPresented: true,
+        gameActiveState: "dialogue",
+        enableAgents: false,
+        activeAgentIds: [],
+        enableCustomWidgets: true,
+        gameBlueprint: {
+          campaignPlan: {},
+          hudWidgets,
+          introSequence: [],
+          visualTheme: {},
+        },
+      },
+    });
+    expect(metadataResponse.ok()).toBeTruthy();
+
+    const messageResponse = await request.post(`/api/chats/${chat.id}/messages`, {
+      data: {
+        role: "assistant",
+        content:
+          'The party reaches a fork in the flooded vault.\n\n[choices: "Take the surveyed stairs through the glowing nests"|"Risk the faster waterway before the chamber floods"|"Follow the unstable violet route into the unknown"]',
+      },
+    });
+    expect(messageResponse.ok()).toBeTruthy();
+
+    await page.route("**/api/game-assets/manifest", async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ scannedAt: "2026-07-16T00:00:00.000Z", count: 0, assets: {}, byCategory: {} }),
+      });
+    });
+    await page.route("**/api/backgrounds/file/Black.jpg", async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: "image/gif",
+        body: Buffer.from(TRANSPARENT_GIF_BASE64, "base64"),
+      });
+    });
+    await page.addInitScript((chatId) => {
+      localStorage.setItem("marinara-active-chat-id", chatId);
+      localStorage.setItem(
+        "marinara-engine-ui",
+        JSON.stringify({
+          state: {
+            hasCompletedOnboarding: true,
+            rightPanelOpen: false,
+            sidebarOpen: false,
+            gameNarrationTextSpeed: 100,
+          },
+          version: 65,
+        }),
+      );
+    }, chat.id);
+
+    await page.goto("/");
+    const choiceStack = page.locator('[data-component="GameSurface.MobileChoiceStack"]');
+    const widgetTray = page.locator('[data-component="GameSurface.MobileWidgetTray"]');
+    const narrationPanel = page.locator('[data-component="GameNarration.ActivePanel"]');
+    const options = page.locator('[data-component="GameChoiceCards.Options"] > button');
+    await expect(choiceStack).toBeVisible();
+    await expect(widgetTray).toBeVisible();
+    await expect(options).toHaveCount(3);
+
+    for (const viewport of [
+      { width: 390, height: 844 },
+      { width: 844, height: 390 },
+    ]) {
+      await page.setViewportSize(viewport);
+      await expect(page.getByTitle("Game actions")).toBeVisible();
+      await expect(page.locator('[data-tour="game-map"]').getByRole("button", { name: "Open map" })).toBeVisible();
+      await expect
+        .poll(async () => {
+          const choiceRect = await choiceStack.boundingBox();
+          const widgetRect = await widgetTray.boundingBox();
+          const narrationRect = await narrationPanel.boundingBox();
+          if (!choiceRect || !widgetRect || !narrationRect) return null;
+          return {
+            choiceHeightReserved: choiceRect.height >= 112,
+            choicesBeforeNarration: choiceRect.y + choiceRect.height <= narrationRect.y + 1,
+            widgetsInsideNarration:
+              widgetRect.y >= narrationRect.y - 1 &&
+              widgetRect.y + widgetRect.height <= narrationRect.y + narrationRect.height + 1,
+            widgetsUseOneCompactRow: widgetRect.height <= 40,
+          };
+        })
+        .toEqual({
+          choiceHeightReserved: true,
+          choicesBeforeNarration: true,
+          widgetsInsideNarration: true,
+          widgetsUseOneCompactRow: true,
+        });
+
+      const choiceHeight = await choiceStack.evaluate((element) => element.getBoundingClientRect().height);
+      expect(choiceHeight).toBeGreaterThanOrEqual(112);
+      await page
+        .locator('[data-component="GameChoiceCards.Options"]')
+        .evaluate((element) => element.scrollTo({ top: element.scrollHeight }));
+      await expect(page.getByText("Choose your action", { exact: true })).toBeVisible();
+      await expect(options.last()).toBeVisible();
+
+      if (viewport.height < 600) {
+        expect(await narrationPanel.evaluate((element) => element.scrollHeight > element.clientHeight)).toBe(true);
+        await narrationPanel.evaluate((element) => element.scrollTo({ top: element.scrollHeight }));
+        await expect(page.getByText("The party reaches a fork in the flooded vault.", { exact: true })).toBeVisible();
+      }
+    }
+
+    expect(errors).toEqual([]);
+  } finally {
+    await request.delete(`/api/chats/${chat.id}`);
+  }
+});
+
 test("Roleplay displays a selected background when its file route is GET-only", async ({ page }) => {
   const chatResponse = await page.request.post("/api/chats", {
     data: { name: "Roleplay Background Smoke", mode: "roleplay", characterIds: [] },

--- a/e2e/core-flows.e2e.ts
+++ b/e2e/core-flows.e2e.ts
@@ -4545,56 +4545,73 @@ test("mobile Game keeps CYOA usable above four HUD widgets", async ({ page, requ
     }, chat.id);
 
     await page.goto("/");
+    const choiceStage = page.locator('[data-component="GameSurface.MobileChoiceStage"]');
     const choiceStack = page.locator('[data-component="GameSurface.MobileChoiceStack"]');
-    const widgetTray = page.locator('[data-component="GameSurface.MobileWidgetTray"]');
+    const leftWidgetRail = page.locator('[data-component="GameSurface.MobileWidgetRailLeft"]');
+    const rightWidgetRail = page.locator('[data-component="GameSurface.MobileWidgetRailRight"]');
     const narrationPanel = page.locator('[data-component="GameNarration.ActivePanel"]');
+    const composer = page.getByPlaceholder("What do you do?");
+    const optionList = page.locator('[data-component="GameChoiceCards.Options"]');
     const options = page.locator('[data-component="GameChoiceCards.Options"] > button');
+    await expect(choiceStage).toBeVisible();
     await expect(choiceStack).toBeVisible();
-    await expect(widgetTray).toBeVisible();
+    await expect(leftWidgetRail).toBeVisible();
+    await expect(rightWidgetRail).toBeVisible();
+    await expect(composer).toBeVisible();
     await expect(options).toHaveCount(3);
 
-    for (const viewport of [
-      { width: 390, height: 844 },
-      { width: 844, height: 390 },
-    ]) {
+    for (const viewport of [{ width: 390, height: 700 }]) {
       await page.setViewportSize(viewport);
       await expect(page.getByTitle("Game actions")).toBeVisible();
       await expect(page.locator('[data-tour="game-map"]').getByRole("button", { name: "Open map" })).toBeVisible();
+
       await expect
         .poll(async () => {
+          const stageRect = await choiceStage.boundingBox();
           const choiceRect = await choiceStack.boundingBox();
-          const widgetRect = await widgetTray.boundingBox();
+          const leftWidgetRect = await leftWidgetRail.boundingBox();
+          const rightWidgetRect = await rightWidgetRail.boundingBox();
           const narrationRect = await narrationPanel.boundingBox();
-          if (!choiceRect || !widgetRect || !narrationRect) return null;
+          const composerRect = await composer.boundingBox();
+          if (!stageRect || !choiceRect || !leftWidgetRect || !rightWidgetRect || !narrationRect || !composerRect) {
+            return null;
+          }
           return {
-            choiceHeightReserved: choiceRect.height >= 112,
-            choicesBeforeNarration: choiceRect.y + choiceRect.height <= narrationRect.y + 1,
-            widgetsInsideNarration:
-              widgetRect.y >= narrationRect.y - 1 &&
-              widgetRect.y + widgetRect.height <= narrationRect.y + narrationRect.height + 1,
-            widgetsUseOneCompactRow: widgetRect.height <= 40,
+            choiceFillsCenter: choiceRect.height >= stageRect.height - 1,
+            choiceBetweenWidgets:
+              leftWidgetRect.x + leftWidgetRect.width <= choiceRect.x + 1 &&
+              choiceRect.x + choiceRect.width <= rightWidgetRect.x + 1,
+            widgetsShareChoiceBand:
+              leftWidgetRect.y >= stageRect.y - 1 &&
+              leftWidgetRect.y + leftWidgetRect.height <= stageRect.y + stageRect.height + 1 &&
+              rightWidgetRect.y >= stageRect.y - 1 &&
+              rightWidgetRect.y + rightWidgetRect.height <= stageRect.y + stageRect.height + 1,
+            choiceStageBeforeNarration: stageRect.y + stageRect.height <= narrationRect.y + 1,
+            narrationStartsInViewport: narrationRect.y >= 0 && narrationRect.y < viewport.height,
+            composerFullyInViewport: composerRect.y >= 0 && composerRect.y + composerRect.height <= viewport.height + 1,
           };
         })
         .toEqual({
-          choiceHeightReserved: true,
-          choicesBeforeNarration: true,
-          widgetsInsideNarration: true,
-          widgetsUseOneCompactRow: true,
+          choiceFillsCenter: true,
+          choiceBetweenWidgets: true,
+          widgetsShareChoiceBand: true,
+          choiceStageBeforeNarration: true,
+          narrationStartsInViewport: true,
+          composerFullyInViewport: true,
         });
 
-      const choiceHeight = await choiceStack.evaluate((element) => element.getBoundingClientRect().height);
-      expect(choiceHeight).toBeGreaterThanOrEqual(112);
-      await page
-        .locator('[data-component="GameChoiceCards.Options"]')
-        .evaluate((element) => element.scrollTo({ top: element.scrollHeight }));
+      await optionList.evaluate((element) => element.scrollTo({ top: element.scrollHeight }));
       await expect(page.getByText("Choose your action", { exact: true })).toBeVisible();
       await expect(options.last()).toBeVisible();
-
-      if (viewport.height < 600) {
-        expect(await narrationPanel.evaluate((element) => element.scrollHeight > element.clientHeight)).toBe(true);
-        await narrationPanel.evaluate((element) => element.scrollTo({ top: element.scrollHeight }));
-        await expect(page.getByText("The party reaches a fork in the flooded vault.", { exact: true })).toBeVisible();
-      }
+      const optionListRect = await optionList.boundingBox();
+      const lastOptionRect = await options.last().boundingBox();
+      expect(optionListRect).not.toBeNull();
+      expect(lastOptionRect).not.toBeNull();
+      expect(lastOptionRect!.y).toBeGreaterThanOrEqual(optionListRect!.y - 1);
+      expect(lastOptionRect!.y + lastOptionRect!.height).toBeLessThanOrEqual(
+        optionListRect!.y + optionListRect!.height + 1,
+      );
+      await expect(page.getByText("The party reaches a fork in the flooded vault.", { exact: true })).toBeVisible();
     }
 
     expect(errors).toEqual([]);

--- a/packages/client/src/components/game/GameChoiceCards.tsx
+++ b/packages/client/src/components/game/GameChoiceCards.tsx
@@ -73,7 +73,10 @@ export function GameChoiceCards({ choices, onSelect, onDismiss, disabled, replay
           )}
         </div>
 
-        <div className="flex min-h-0 flex-1 touch-pan-y flex-col gap-2 overflow-y-auto overscroll-contain pr-1 [-webkit-overflow-scrolling:touch]">
+        <div
+          data-component="GameChoiceCards.Options"
+          className="flex min-h-0 flex-1 touch-pan-y flex-col gap-2 overflow-y-auto overscroll-contain pr-1 [-webkit-overflow-scrolling:touch]"
+        >
           {choices.map((choice, i) => {
             const isRecordedChoice = !replayMode || normalizeChoiceText(choice) === normalizedReplayChoice;
             const choiceDisabled = disabled || selected !== null || !isRecordedChoice;

--- a/packages/client/src/components/game/GameNarration.tsx
+++ b/packages/client/src/components/game/GameNarration.tsx
@@ -3513,7 +3513,6 @@ export function GameNarration({
         )}
       </div>
     ) : null;
-  const choicesVisible = choicesSlot != null;
 
   const handleCopyMessage = useCallback(async (key: string, text: string) => {
     const didCopy = await copyToClipboard(text);
@@ -4264,27 +4263,14 @@ export function GameNarration({
   };
 
   return (
-    <div
-      className={cn(
-        "relative flex min-h-0 flex-1 items-end px-3 pb-[max(0.75rem,env(safe-area-inset-bottom))] sm:px-6 md:pb-4",
-        choicesVisible ? "pt-[clamp(3rem,10svh,5rem)] md:pt-[clamp(3rem,10svh,6rem)]" : "pt-20 md:pt-24",
-      )}
-    >
+    <div className="relative flex min-h-0 flex-1 items-end px-3 pb-[max(0.75rem,env(safe-area-inset-bottom))] pt-20 md:pt-24 sm:px-6 md:pb-4">
       <div className="pointer-events-none absolute inset-0 bg-gradient-to-t from-black/45 via-black/15 to-transparent" />
 
       <div
         data-tour="game-dialogue"
-        className={cn(
-          "relative z-10 mx-auto flex h-full min-h-0 w-full max-w-4xl flex-col justify-end",
-          choicesVisible ? "max-h-full" : "max-h-[calc(100svh-7rem)] md:max-h-[calc(100svh-8rem)]",
-        )}
+        className="relative z-10 mx-auto flex h-full max-h-[calc(100svh-7rem)] min-h-0 w-full max-w-4xl flex-col justify-end md:max-h-[calc(100svh-8rem)]"
       >
-        <div
-          className={cn(
-            "min-h-0 flex flex-1 flex-col",
-            choicesVisible ? "justify-start overflow-hidden" : "justify-end overflow-hidden",
-          )}
-        >
+        <div className="min-h-0 flex flex-1 flex-col justify-end overflow-hidden">
           {useStackedLogDisplay && (stackedLogEntries.length > 0 || stackedLogHeldHeight !== null) && (
             <div
               ref={stackedLogShellRef}
@@ -4407,7 +4393,7 @@ export function GameNarration({
           {choicesSlot}
 
           {/* Widget slot — mobile widget icons sit above the narration box */}
-          {!choicesVisible && widgetSlot}
+          {widgetSlot}
 
           {/* Skill check result — shown above the narration box until dismissed */}
           {skillCheckSlot}
@@ -4419,16 +4405,8 @@ export function GameNarration({
         <div
           data-game-skip-bg-nav="true"
           data-component="GameNarration.ActivePanel"
-          className={cn(
-            "rounded-2xl border border-[var(--border)] bg-[var(--card)]/90 p-3 shadow-[0_16px_38px_rgba(0,0,0,0.45)] backdrop-blur-md dark:border-white/15 dark:bg-black/50",
-            choicesVisible
-              ? "min-h-[4.5rem] max-h-[clamp(4.5rem,calc(28svh-2.5rem),18rem)] shrink overflow-y-auto overscroll-contain"
-              : "shrink-0",
-          )}
+          className="shrink-0 rounded-2xl border border-[var(--border)] bg-[var(--card)]/90 p-3 shadow-[0_16px_38px_rgba(0,0,0,0.45)] backdrop-blur-md dark:border-white/15 dark:bg-black/50"
         >
-          {/* CYOA owns the space above the box; secondary HUD widgets join the scrollable narration panel. */}
-          {choicesVisible && widgetSlot}
-
           {/* Scene preparation gate: wait for effects before showing narration */}
           {scenePreparing && (
             <div className="flex items-center gap-2 py-3">

--- a/packages/client/src/components/game/GameNarration.tsx
+++ b/packages/client/src/components/game/GameNarration.tsx
@@ -3513,6 +3513,7 @@ export function GameNarration({
         )}
       </div>
     ) : null;
+  const choicesVisible = choicesSlot != null;
 
   const handleCopyMessage = useCallback(async (key: string, text: string) => {
     const didCopy = await copyToClipboard(text);
@@ -4263,14 +4264,27 @@ export function GameNarration({
   };
 
   return (
-    <div className="relative flex min-h-0 flex-1 items-end px-3 pb-[max(0.75rem,env(safe-area-inset-bottom))] pt-20 md:pt-24 sm:px-6 md:pb-4">
+    <div
+      className={cn(
+        "relative flex min-h-0 flex-1 items-end px-3 pb-[max(0.75rem,env(safe-area-inset-bottom))] sm:px-6 md:pb-4",
+        choicesVisible ? "pt-[clamp(3rem,10svh,5rem)] md:pt-[clamp(3rem,10svh,6rem)]" : "pt-20 md:pt-24",
+      )}
+    >
       <div className="pointer-events-none absolute inset-0 bg-gradient-to-t from-black/45 via-black/15 to-transparent" />
 
       <div
         data-tour="game-dialogue"
-        className="relative z-10 mx-auto flex h-full max-h-[calc(100svh-7rem)] min-h-0 w-full max-w-4xl flex-col justify-end md:max-h-[calc(100svh-8rem)]"
+        className={cn(
+          "relative z-10 mx-auto flex h-full min-h-0 w-full max-w-4xl flex-col justify-end",
+          choicesVisible ? "max-h-full" : "max-h-[calc(100svh-7rem)] md:max-h-[calc(100svh-8rem)]",
+        )}
       >
-        <div className="min-h-0 flex flex-1 flex-col justify-end overflow-hidden">
+        <div
+          className={cn(
+            "min-h-0 flex flex-1 flex-col",
+            choicesVisible ? "justify-start overflow-hidden" : "justify-end overflow-hidden",
+          )}
+        >
           {useStackedLogDisplay && (stackedLogEntries.length > 0 || stackedLogHeldHeight !== null) && (
             <div
               ref={stackedLogShellRef}
@@ -4393,7 +4407,7 @@ export function GameNarration({
           {choicesSlot}
 
           {/* Widget slot — mobile widget icons sit above the narration box */}
-          {widgetSlot}
+          {!choicesVisible && widgetSlot}
 
           {/* Skill check result — shown above the narration box until dismissed */}
           {skillCheckSlot}
@@ -4404,8 +4418,17 @@ export function GameNarration({
 
         <div
           data-game-skip-bg-nav="true"
-          className="shrink-0 rounded-2xl border border-[var(--border)] bg-[var(--card)]/90 p-3 shadow-[0_16px_38px_rgba(0,0,0,0.45)] backdrop-blur-md dark:border-white/15 dark:bg-black/50"
+          data-component="GameNarration.ActivePanel"
+          className={cn(
+            "rounded-2xl border border-[var(--border)] bg-[var(--card)]/90 p-3 shadow-[0_16px_38px_rgba(0,0,0,0.45)] backdrop-blur-md dark:border-white/15 dark:bg-black/50",
+            choicesVisible
+              ? "min-h-[4.5rem] max-h-[clamp(4.5rem,calc(28svh-2.5rem),18rem)] shrink overflow-y-auto overscroll-contain"
+              : "shrink-0",
+          )}
         >
+          {/* CYOA owns the space above the box; secondary HUD widgets join the scrollable narration panel. */}
+          {choicesVisible && widgetSlot}
+
           {/* Scene preparation gate: wait for effects before showing narration */}
           {scenePreparing && (
             <div className="flex items-center gap-2 py-3">

--- a/packages/client/src/components/game/GameSurface.tsx
+++ b/packages/client/src/components/game/GameSurface.tsx
@@ -464,11 +464,6 @@ function isMobileGameViewport(): boolean {
   return typeof window !== "undefined" && window.matchMedia("(max-width: 767px)").matches;
 }
 
-function isCompactGameViewport(): boolean {
-  if (typeof window === "undefined") return false;
-  return window.innerWidth < 768 || (window.innerHeight < 600 && window.matchMedia("(pointer: coarse)").matches);
-}
-
 function isBrowserSpotifyDeviceName(name: string | null | undefined): boolean {
   return name === "Marinara Engine";
 }
@@ -2941,7 +2936,9 @@ function GameSurfaceComponent({
   const [ambientVolume, setAmbientVolume] = useState(persistedGameAudioSettings.ambientVolume);
   const [audioSettingsHydrated, setAudioSettingsHydrated] = useState(false);
   const [tutorialOpen, setTutorialOpen] = useState(false);
-  const [compactHudWidgets, setCompactHudWidgets] = useState(isCompactGameViewport);
+  const [compactHudWidgets, setCompactHudWidgets] = useState(() =>
+    typeof window !== "undefined" ? window.innerWidth < 768 : false,
+  );
   const tutorialAutoTriggeredRef = useRef(false);
   const volumePopoverRef = useRef<HTMLDivElement>(null);
   const mobileVolumePopoverRef = useRef<HTMLDivElement>(null);
@@ -9618,6 +9615,13 @@ function GameSurfaceComponent({
   }, [handleStartGameNow, normalizedWidgets.length, startGame.isPending, startGameRequested]);
 
   useEffect(() => {
+    if (combatUiActive || normalizedWidgets.length === 0) {
+      compactHudWidgetsRef.current = false;
+      compactHudReleaseWidthRef.current = null;
+      setCompactHudWidgets(false);
+      return;
+    }
+
     const setCompactLayout = (nextCompact: boolean) => {
       if (compactHudWidgetsRef.current === nextCompact) return;
       compactHudWidgetsRef.current = nextCompact;
@@ -9625,18 +9629,8 @@ function GameSurfaceComponent({
     };
 
     const updateWidgetLayout = () => {
-      const viewportCompact = isCompactGameViewport();
-      if (combatUiActive || normalizedWidgets.length === 0) {
-        compactHudReleaseWidthRef.current = null;
-        setCompactLayout(viewportCompact);
-        return;
-      }
-
       const surface = hudSurfaceRef.current;
-      if (!surface) {
-        setCompactLayout(viewportCompact);
-        return;
-      }
+      if (!surface) return;
 
       const surfaceRect = surface.getBoundingClientRect();
       const dialogue = surface.querySelector<HTMLElement>('[data-tour="game-dialogue"]');
@@ -9668,7 +9662,7 @@ function GameSurfaceComponent({
         compactHudReleaseWidthRef.current = null;
       }
 
-      const nextCompact = viewportCompact || estimatedOverlap || measuredOverlap || heldByPreviousOverlap;
+      const nextCompact = surfaceRect.width < 768 || estimatedOverlap || measuredOverlap || heldByPreviousOverlap;
 
       setCompactLayout(nextCompact);
     };
@@ -10710,13 +10704,7 @@ function GameSurfaceComponent({
                 )}
               >
                 {/* Desktop controls */}
-                <div
-                  className={cn(
-                    "pointer-events-auto items-center",
-                    compactHudWidgets ? "hidden" : "hidden md:flex",
-                    CHAT_TOOLBAR_ICON_GAP_CLASS,
-                  )}
-                >
+                <div className={cn("pointer-events-auto hidden items-center md:flex", CHAT_TOOLBAR_ICON_GAP_CLASS)}>
                   {renderStoryboardBackgroundControls()}
                   <ChatBranchSelector
                     activeChatId={activeChatId}
@@ -10906,7 +10894,7 @@ function GameSurfaceComponent({
                 </div>
 
                 {/* Mobile controls */}
-                <div className={cn("pointer-events-auto", !compactHudWidgets && "md:hidden")}>
+                <div className="pointer-events-auto md:hidden">
                   <div className="relative">
                     <button
                       onClick={() => {
@@ -11205,7 +11193,7 @@ function GameSurfaceComponent({
                   )}
                 >
                   {/* Mobile: map icon button that opens modal */}
-                  <div data-tour="game-map" className={cn(!compactHudWidgets && "md:hidden")}>
+                  <div data-tour="game-map" className="md:hidden">
                     <MobileMapButton
                       chatId={activeChatId}
                       map={viewedMap}
@@ -11228,7 +11216,7 @@ function GameSurfaceComponent({
                     />
                   </div>
                   {/* Desktop: inline minimap */}
-                  <div className={cn("hidden", !compactHudWidgets && "md:block")}>
+                  <div className="hidden md:block">
                     <GameMapPanel
                       map={viewedMap}
                       maps={availableMaps}
@@ -11362,13 +11350,15 @@ function GameSurfaceComponent({
 
                 {/* Game content — Combat UI / TravelView / Narration */}
                 {(() => {
+                  const choicesVisible = Boolean(activeChoices && narrationDone);
+
                   // Mobile widget slot — rendered inside GameNarration to sit above the narration box
                   const mobileWidgetSlot =
-                    !combatUiActive && hudWidgets.length > 0 ? (
+                    !combatUiActive && hudWidgets.length > 0 && !(compactHudWidgets && choicesVisible) ? (
                       <div
                         data-component="GameSurface.MobileWidgetTray"
                         className={cn(
-                          "pointer-events-auto mb-[clamp(0.25rem,1svh,0.5rem)] flex items-center justify-between gap-3",
+                          "pointer-events-auto mb-2 flex items-end justify-between",
                           !compactHudWidgets && "md:hidden",
                         )}
                       >
@@ -11379,24 +11369,60 @@ function GameSurfaceComponent({
 
                   // Choice cards slot — rendered inside GameNarration above the narration box
                   const choicesSlot =
-                    activeChoices && narrationDone ? (
-                      <div
-                        data-component="GameSurface.MobileChoiceStack"
-                        className={cn(
-                          "pointer-events-auto mb-[clamp(0.25rem,1svh,0.5rem)] flex min-h-28 w-full shrink-0 justify-center overflow-hidden",
-                          compactHudWidgets
-                            ? "max-h-[clamp(7rem,30svh,14rem)]"
-                            : "max-h-[clamp(7rem,30svh,14rem)] sm:max-h-[clamp(7rem,36svh,20rem)] md:max-h-[min(52dvh,32rem)]",
-                        )}
-                      >
-                        <GameChoiceCards
-                          choices={activeChoices}
-                          onSelect={handleChoiceSelect}
-                          onDismiss={handleDismissChoices}
-                          disabled={isStreaming || !sessionInteractive}
-                        />
-                      </div>
-                    ) : undefined;
+                    activeChoices && narrationDone
+                      ? compactHudWidgets && !combatUiActive && hudWidgets.length > 0
+                        ? (
+                            <div
+                              data-component="GameSurface.MobileChoiceStage"
+                              className="pointer-events-auto mb-2 flex max-h-[clamp(8rem,30svh,14rem)] min-h-0 w-full shrink items-stretch gap-1.5 overflow-hidden sm:max-h-[clamp(9rem,36svh,20rem)]"
+                            >
+                              <div
+                                data-component="GameSurface.MobileWidgetRailLeft"
+                                className="relative z-10 flex shrink-0 items-center"
+                              >
+                                <MobileWidgetPanel
+                                  widgets={normalizedWidgets}
+                                  position="hud_left"
+                                  chatId={activeChatId}
+                                />
+                              </div>
+                              <div
+                                data-component="GameSurface.MobileChoiceStack"
+                                className="flex min-h-0 min-w-0 flex-1 overflow-hidden"
+                              >
+                                <GameChoiceCards
+                                  choices={activeChoices}
+                                  onSelect={handleChoiceSelect}
+                                  onDismiss={handleDismissChoices}
+                                  disabled={isStreaming || !sessionInteractive}
+                                />
+                              </div>
+                              <div
+                                data-component="GameSurface.MobileWidgetRailRight"
+                                className="relative z-10 flex shrink-0 items-center"
+                              >
+                                <MobileWidgetPanel
+                                  widgets={normalizedWidgets}
+                                  position="hud_right"
+                                  chatId={activeChatId}
+                                />
+                              </div>
+                            </div>
+                          )
+                        : (
+                            <div
+                              data-component="GameSurface.MobileChoiceStack"
+                              className="pointer-events-auto mb-2 flex max-h-[clamp(8rem,30svh,14rem)] min-h-0 w-full shrink justify-center overflow-hidden sm:max-h-[clamp(9rem,36svh,20rem)] md:max-h-[min(52dvh,32rem)]"
+                            >
+                              <GameChoiceCards
+                                choices={activeChoices}
+                                onSelect={handleChoiceSelect}
+                                onDismiss={handleDismissChoices}
+                                disabled={isStreaming || !sessionInteractive}
+                              />
+                            </div>
+                          )
+                      : undefined;
 
                   const skillCheckSlot = pendingSkillCheck ? (
                     <GameSkillCheckResult result={pendingSkillCheck} onDismiss={() => setPendingSkillCheck(null)} />

--- a/packages/client/src/components/game/GameSurface.tsx
+++ b/packages/client/src/components/game/GameSurface.tsx
@@ -464,6 +464,11 @@ function isMobileGameViewport(): boolean {
   return typeof window !== "undefined" && window.matchMedia("(max-width: 767px)").matches;
 }
 
+function isCompactGameViewport(): boolean {
+  if (typeof window === "undefined") return false;
+  return window.innerWidth < 768 || (window.innerHeight < 600 && window.matchMedia("(pointer: coarse)").matches);
+}
+
 function isBrowserSpotifyDeviceName(name: string | null | undefined): boolean {
   return name === "Marinara Engine";
 }
@@ -2936,9 +2941,7 @@ function GameSurfaceComponent({
   const [ambientVolume, setAmbientVolume] = useState(persistedGameAudioSettings.ambientVolume);
   const [audioSettingsHydrated, setAudioSettingsHydrated] = useState(false);
   const [tutorialOpen, setTutorialOpen] = useState(false);
-  const [compactHudWidgets, setCompactHudWidgets] = useState(() =>
-    typeof window !== "undefined" ? window.innerWidth < 768 : false,
-  );
+  const [compactHudWidgets, setCompactHudWidgets] = useState(isCompactGameViewport);
   const tutorialAutoTriggeredRef = useRef(false);
   const volumePopoverRef = useRef<HTMLDivElement>(null);
   const mobileVolumePopoverRef = useRef<HTMLDivElement>(null);
@@ -9615,13 +9618,6 @@ function GameSurfaceComponent({
   }, [handleStartGameNow, normalizedWidgets.length, startGame.isPending, startGameRequested]);
 
   useEffect(() => {
-    if (combatUiActive || normalizedWidgets.length === 0) {
-      compactHudWidgetsRef.current = false;
-      compactHudReleaseWidthRef.current = null;
-      setCompactHudWidgets(false);
-      return;
-    }
-
     const setCompactLayout = (nextCompact: boolean) => {
       if (compactHudWidgetsRef.current === nextCompact) return;
       compactHudWidgetsRef.current = nextCompact;
@@ -9629,8 +9625,18 @@ function GameSurfaceComponent({
     };
 
     const updateWidgetLayout = () => {
+      const viewportCompact = isCompactGameViewport();
+      if (combatUiActive || normalizedWidgets.length === 0) {
+        compactHudReleaseWidthRef.current = null;
+        setCompactLayout(viewportCompact);
+        return;
+      }
+
       const surface = hudSurfaceRef.current;
-      if (!surface) return;
+      if (!surface) {
+        setCompactLayout(viewportCompact);
+        return;
+      }
 
       const surfaceRect = surface.getBoundingClientRect();
       const dialogue = surface.querySelector<HTMLElement>('[data-tour="game-dialogue"]');
@@ -9662,7 +9668,7 @@ function GameSurfaceComponent({
         compactHudReleaseWidthRef.current = null;
       }
 
-      const nextCompact = surfaceRect.width < 768 || estimatedOverlap || measuredOverlap || heldByPreviousOverlap;
+      const nextCompact = viewportCompact || estimatedOverlap || measuredOverlap || heldByPreviousOverlap;
 
       setCompactLayout(nextCompact);
     };
@@ -10704,7 +10710,13 @@ function GameSurfaceComponent({
                 )}
               >
                 {/* Desktop controls */}
-                <div className={cn("pointer-events-auto hidden items-center md:flex", CHAT_TOOLBAR_ICON_GAP_CLASS)}>
+                <div
+                  className={cn(
+                    "pointer-events-auto items-center",
+                    compactHudWidgets ? "hidden" : "hidden md:flex",
+                    CHAT_TOOLBAR_ICON_GAP_CLASS,
+                  )}
+                >
                   {renderStoryboardBackgroundControls()}
                   <ChatBranchSelector
                     activeChatId={activeChatId}
@@ -10894,7 +10906,7 @@ function GameSurfaceComponent({
                 </div>
 
                 {/* Mobile controls */}
-                <div className="pointer-events-auto md:hidden">
+                <div className={cn("pointer-events-auto", !compactHudWidgets && "md:hidden")}>
                   <div className="relative">
                     <button
                       onClick={() => {
@@ -11193,7 +11205,7 @@ function GameSurfaceComponent({
                   )}
                 >
                   {/* Mobile: map icon button that opens modal */}
-                  <div data-tour="game-map" className="md:hidden">
+                  <div data-tour="game-map" className={cn(!compactHudWidgets && "md:hidden")}>
                     <MobileMapButton
                       chatId={activeChatId}
                       map={viewedMap}
@@ -11216,7 +11228,7 @@ function GameSurfaceComponent({
                     />
                   </div>
                   {/* Desktop: inline minimap */}
-                  <div className="hidden md:block">
+                  <div className={cn("hidden", !compactHudWidgets && "md:block")}>
                     <GameMapPanel
                       map={viewedMap}
                       maps={availableMaps}
@@ -11354,8 +11366,9 @@ function GameSurfaceComponent({
                   const mobileWidgetSlot =
                     !combatUiActive && hudWidgets.length > 0 ? (
                       <div
+                        data-component="GameSurface.MobileWidgetTray"
                         className={cn(
-                          "pointer-events-auto mb-2 flex items-end justify-between",
+                          "pointer-events-auto mb-[clamp(0.25rem,1svh,0.5rem)] flex items-center justify-between gap-3",
                           !compactHudWidgets && "md:hidden",
                         )}
                       >
@@ -11367,7 +11380,15 @@ function GameSurfaceComponent({
                   // Choice cards slot — rendered inside GameNarration above the narration box
                   const choicesSlot =
                     activeChoices && narrationDone ? (
-                      <div className="pointer-events-auto mb-2 flex max-h-[clamp(8rem,30svh,14rem)] min-h-0 w-full shrink justify-center overflow-hidden sm:max-h-[clamp(9rem,36svh,20rem)] md:max-h-[min(52dvh,32rem)]">
+                      <div
+                        data-component="GameSurface.MobileChoiceStack"
+                        className={cn(
+                          "pointer-events-auto mb-[clamp(0.25rem,1svh,0.5rem)] flex min-h-28 w-full shrink-0 justify-center overflow-hidden",
+                          compactHudWidgets
+                            ? "max-h-[clamp(7rem,30svh,14rem)]"
+                            : "max-h-[clamp(7rem,30svh,14rem)] sm:max-h-[clamp(7rem,36svh,20rem)] md:max-h-[min(52dvh,32rem)]",
+                        )}
+                      >
                         <GameChoiceCards
                           choices={activeChoices}
                           onSelect={handleChoiceSelect}

--- a/packages/client/src/components/game/GameWidgetPanel.tsx
+++ b/packages/client/src/components/game/GameWidgetPanel.tsx
@@ -322,7 +322,12 @@ export function MobileWidgetPanel({ widgets, position, chatId }: MobileWidgetPan
 
   return (
     <>
-      <div className={cn("pointer-events-auto flex flex-col gap-1.5", position === "hud_right" && "items-end")}>
+      <div
+        className={cn(
+          "pointer-events-auto flex flex-wrap items-end gap-1.5",
+          position === "hud_right" && "justify-end",
+        )}
+      >
         {filtered.map((w) => {
           const isExpanded = expandedId === w.id;
 

--- a/packages/client/src/components/game/GameWidgetPanel.tsx
+++ b/packages/client/src/components/game/GameWidgetPanel.tsx
@@ -322,12 +322,7 @@ export function MobileWidgetPanel({ widgets, position, chatId }: MobileWidgetPan
 
   return (
     <>
-      <div
-        className={cn(
-          "pointer-events-auto flex flex-wrap items-end gap-1.5",
-          position === "hud_right" && "justify-end",
-        )}
-      >
+      <div className={cn("pointer-events-auto flex flex-col gap-1.5", position === "hud_right" && "items-end")}>
         {filtered.map((w) => {
           const isExpanded = expandedId === w.id;
 


### PR DESCRIPTION
## Linked issue

Part of #3691

## Why this change

- On mobile, CYOA and the left/right HUD widget rails were rendered as consecutive vertical regions. The choice card therefore ignored the horizontal space already reserved between the widget columns and consumed scarce vertical viewport space instead.
- The resulting stack could crowd the narration and composer even though the center of the widget band was unused.

## What changed

- Place active mobile CYOA choices in the center gap between the existing left and right widget columns.
- Preserve the original widget rail, narration, composer, map, character, and Game-toolbar behavior.
- Keep the choice list independently scrollable when labels exceed the available center panel height.
- Add a focused 390x700 mobile regression that verifies the CYOA is between both widget rails, narration remains below it, the composer remains fully inside the viewport, and the final choice is reachable.

## Validation

- [x] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [x] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed `CONTRIBUTING.md`

Automated evidence collected while preparing this draft:

- `pnpm check`
- `pnpm exec playwright test -c playwright.config.ts --project=mobile-chromium --grep "mobile Game keeps CYOA"`
- Production client build, live service restart, `/api/health`, and exact entry/GameSurface bundle responses

### Manual verification notes

- The reporter reviewed the branch build on a real mobile browser and confirmed the centered CYOA layout is usable.
- The reporter confirmed the existing character/minimap controls should remain unchanged rather than expanding this patch into a broader mobile-toolbar redesign.
- Manually verify light and dark themes before marking this draft ready.
- Manually verify expanding each HUD widget does not obscure choice selection before marking this draft ready.

## Docs and release impact

- [x] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Version/release files updated (only if this PR includes a version bump)

## UI evidence (if applicable)

No media committed. The reporter reviewed the deployed branch on a real mobile browser; the focused regression records the responsive geometry and scrolling contract.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved mobile game layouts when multiple HUD widgets and choice cards are displayed.
  * Prevented HUD widgets from overlapping interactive choices in compact mode.
  * Added side rails around choice cards to improve spacing and visibility on mobile.
  * Verified that narration, choices, and the composer remain usable across supported mobile screen sizes.

* **Tests**
  * Added end-to-end coverage for mobile choice-based game flows with four HUD widgets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->