### PR TITLE
Fix Roleplay persona selection and remove summary caps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 
 ### Fixed
 
+- Kept new Roleplay chats Persona-less when the user selects no Persona, including the first optimistic message snapshot, provider prompt, scene generation, and combat context; only Conversation mode may fall back to the globally active Persona.
+- Removed Roleplay Summary's 2,000-character truncation for each source message and the 64 KiB compiled-summary ceiling in `chats.json`, so chapter-length messages and accumulated summaries remain complete unless the selected model rejects the request.
 - Preserved greetings, example dialogue, creator notes, system prompts, post-history instructions, character versions, and alternate greetings when Professor Mari or another app-data caller updates an unrelated Character Card field (#3708).
 - Restored native undo and redo in shared text editors, including lorebook Content and Description fields, and made `Tab` / `Shift+Tab` indent or unindent every selected line without replacing the selection.
 - Resolved `{{user}}`, `{{char}}`, and other prompt macros in opening greetings and `/guided` instructions at the final provider boundary, including lorebook routing and embedding scans, so late prompt injections cannot send raw identity placeholders to models (#3704).

--- a/packages/client/src/components/chat/ChatArea.tsx
+++ b/packages/client/src/components/chat/ChatArea.tsx
@@ -879,7 +879,9 @@ export function ChatArea() {
   const chatCharIds = useMemo(() => getChatCharacterIds({ characterIds: chatCharacterIdsRaw }), [chatCharacterIdsRaw]);
   const chatPersonaId = useMemo(() => resolveChatPersonaId(chat), [chat]);
   const { data: chatPersona } = usePersona(chatPersonaId);
-  const { data: activePersonaFallback } = useActivePersona(!!chat?.id && !chatPersonaId && !isGameChat);
+  const { data: activePersonaFallback } = useActivePersona(
+    !!chat?.id && !chatPersonaId && chatMode === "conversation",
+  );
 
   const activeCharacterQueries = useQueries({
     queries: chatCharIds.map((id) => ({
@@ -1043,8 +1045,9 @@ export function ChatArea() {
 
   // Active persona info (for user message styling: name, avatar, colors)
   const personaInfo = useMemo(() => {
-    // Prefer per-chat personaId, fall back to the globally active persona outside Game mode.
-    const persona = chatPersona ?? (!isGameChat ? activePersonaFallback : null);
+    // Roleplay and Game may intentionally have no Persona; only Conversation
+    // falls back to the globally active account Persona.
+    const persona = chatPersona ?? (chatMode === "conversation" ? activePersonaFallback : null);
     if (!persona) return undefined;
     const avatarCrop =
       typeof persona.avatarCrop === "string" ? parseAvatarCropJson(persona.avatarCrop) : (persona.avatarCrop ?? null);
@@ -1064,7 +1067,7 @@ export function ChatArea() {
       dialogueColor: persona.dialogueColor || undefined,
       boxColor: persona.boxColor || undefined,
     };
-  }, [activePersonaFallback, chatPersona, isGameChat]);
+  }, [activePersonaFallback, chatMode, chatPersona]);
 
   const { startEncounter } = useEncounter();
   const { concludeScene, abandonScene, forkScene, isForking } = useScene();
@@ -1513,14 +1516,14 @@ export function ChatArea() {
   // (personas have no other data-card-css hook), so only feed it in Convo mode.
   const cardCssPersonas = useMemo<PersonaCssRow[] | undefined>(() => {
     if (chatMode !== "conversation") return undefined;
-    const persona = (chatPersona ?? (!isGameChat ? activePersonaFallback : null)) as
+    const persona = (chatPersona ?? (chatMode === "conversation" ? activePersonaFallback : null)) as
       | { id?: string; creatorNotes?: string | null }
       | null
       | undefined;
     return persona?.id
       ? [{ id: persona.id, creatorNotes: typeof persona.creatorNotes === "string" ? persona.creatorNotes : null }]
       : undefined;
-  }, [chatMode, chatPersona, activePersonaFallback, isGameChat]);
+  }, [chatMode, chatPersona, activePersonaFallback]);
   const cardCssInjector = (
     <CreatorNotesCssInjector
       characterIds={chatCharIds}

--- a/packages/client/src/hooks/use-generate.ts
+++ b/packages/client/src/hooks/use-generate.ts
@@ -27,6 +27,7 @@ import {
   createInlineThinkingStreamFilter,
   EDITABLE_CHARACTER_CARD_FIELDS,
   normalizeThinkingTagPairs,
+  resolveChatPersonaCandidate,
   type AgentWriteApprovalProposal,
   type AgentCallDebugEvent,
   type CharacterCardFieldUpdate,
@@ -1156,12 +1157,10 @@ export function useGenerate() {
           qc.getQueryData<any>(chatKeys.detail(params.chatId)) ??
           (qc.getQueryData<any[]>(chatKeys.list()) ?? []).find((c: any) => c.id === params.chatId);
         const chatPersonaId = activeChat?.personaId as string | null | undefined;
-        // Game mode skips the active-persona fallback, matching the server's snapshot stamping
+        // Roleplay may intentionally have no Persona. Keep optimistic snapshot
+        // stamping identical to the server's Conversation-only fallback policy.
         const snapshotPersona = cachedPersonas
-          ? ((chatPersonaId ? cachedPersonas.find((p) => p.id === chatPersonaId) : null) ??
-            (activeChat?.mode !== "game"
-              ? cachedPersonas.find((p) => p.isActive === "true" || p.isActive === true)
-              : null))
+          ? resolveChatPersonaCandidate(cachedPersonas, chatPersonaId, activeChat?.mode)
           : null;
         const personaSnapshot = snapshotPersona
           ? {

--- a/packages/server/src/routes/chats.routes.ts
+++ b/packages/server/src/routes/chats.routes.ts
@@ -112,6 +112,7 @@ import { parseLorebookWriteApprovalText } from "./generate/agent-write-approval.
 import { persistLorebookKeeperUpdates } from "./generate/lorebook-keeper-utils.js";
 import {
   clampRoleplaySummaryMaxTokens,
+  formatRoleplaySummaryChatLog,
   resolveChatSummaryPrompt,
 } from "../services/generation/roleplay-summary-runtime.js";
 import { resolveLorebookTokenBudget } from "../services/generation/lorebook-generation-runtime.js";
@@ -354,8 +355,8 @@ async function buildPersonaSnapshotForChat(
   const charactersStore = createCharactersStorage(app.db);
   const personas = await charactersStore.listPersonas();
   const chatPersonaId = chat?.personaId ?? null;
-  // Game mode skips the active-persona fallback — persona must be explicitly
-  // selected in the setup wizard (mirrors generate.routes.ts persona resolution).
+  // Only Conversation falls back to the active Persona. Roleplay and Game may
+  // intentionally remain Persona-less (mirrors generate.routes.ts resolution).
   const persona = resolveActivePersonaCandidate(personas, chatPersonaId, chat?.mode);
 
   if (!persona) return null;
@@ -3689,9 +3690,7 @@ export async function chatsRoutes(app: FastifyInstance) {
     if (selectedMessages.length === 0) {
       return reply.status(400).send({ error: "No non-hidden messages available for the requested summary range" });
     }
-    const chatLog = selectedMessages
-      .map((m: any) => `[${m.role}]: ${(m.content as string).slice(0, 2000)}`)
-      .join("\n\n");
+    const chatLog = formatRoleplaySummaryChatLog(selectedMessages);
 
     const previousSummary = chatMeta.summary ?? null;
     const requestedPromptTemplateId =

--- a/packages/server/src/routes/encounter.routes.ts
+++ b/packages/server/src/routes/encounter.routes.ts
@@ -154,15 +154,14 @@ async function buildCharacterContext(chars: ReturnType<typeof createCharactersSt
 
 /**
  * Build persona context. Prefers the chat-scoped persona (`chat.personaId`)
- * before falling back to the globally active persona — mirrors the same
- * resolution order used elsewhere (see `chats.routes.ts`). Without this, a
+ * before Conversation-only fallback to the globally active Persona — mirrors
+ * the resolution order used elsewhere (see `chats.routes.ts`). Without this, a
  * user who picks a per-chat persona but doesn't have a matching global active
  * persona ends up named "User" in combat because the encounter prompt's
  * `${personaName}` placeholder defaulted to that string.
  *
- * Game mode skips the active-persona fallback — persona must be explicitly
- * selected in the setup wizard (see generate.routes.ts persona resolution),
- * so a persona-less game stays persona-less in combat too.
+ * Roleplay and Game skip active-Persona fallback, so both can intentionally
+ * remain Persona-less in combat prompts.
  */
 async function buildPersonaContext(
   chars: ReturnType<typeof createCharactersStorage>,

--- a/packages/server/src/routes/generate.routes.ts
+++ b/packages/server/src/routes/generate.routes.ts
@@ -345,6 +345,7 @@ import {
   clampRoleplaySummaryContextSize,
   clampRoleplaySummaryInterval,
   clampRoleplaySummaryMaxTokens,
+  formatRoleplaySummaryChatLog,
   isAutomaticRoleplaySummaryEnabled,
   parseChatSummaryText,
   resolveChatSummaryPrompt,
@@ -829,8 +830,8 @@ export async function generateRoutes(app: FastifyInstance) {
           .catch(releaseActiveGenerationAndRethrow);
       }
 
-      // Snapshot persona info for per-message persona tracking
-      // (game mode skips the active-persona fallback, matching the prompt's persona resolution below)
+      // Snapshot Persona info for per-message tracking. Only Conversation may
+      // fall back to the active Persona; Roleplay and Game can stay Persona-less.
       if (userMsg?.id) {
         const snapshotPersonas = await chars.listPersonas().catch(releaseActiveGenerationAndRethrow);
         const snapshotPersona = resolveActivePersonaCandidate(snapshotPersonas, chat.personaId, requestChatMode);
@@ -1285,8 +1286,8 @@ export async function generateRoutes(app: FastifyInstance) {
         throw new Error("All characters in this chat are disabled. Enable at least one character before generating.");
       }
 
-      // Resolve persona — prefer per-chat personaId, fall back to globally active persona
-      // (Game mode skips the fallback — persona must be explicitly selected in the setup wizard)
+      // Resolve Persona — explicit selection always wins, while only
+      // Conversation may fall back to the globally active Persona.
       let personaId: string | null = null;
       let personaName = "User";
       let personaPhoneticName = "";
@@ -6245,9 +6246,7 @@ export async function generateRoutes(app: FastifyInstance) {
           const summaryProvider = resolvedSummaryConnection.provider;
           const summaryModel = resolvedSummaryConnection.model;
 
-          const chatLog = selectedMessages
-            .map((message: any) => `[${message.role}]: ${(message.content as string).slice(0, 2000)}`)
-            .join("\n\n");
+          const chatLog = formatRoleplaySummaryChatLog(selectedMessages);
           const previousSummary = typeof chatMeta.summary === "string" ? chatMeta.summary.trim() : "";
           const globalSummaryPromptSettings = await appSettings.get(CHAT_SUMMARY_PROMPT_SETTINGS_KEY);
           const result = await summaryProvider.chatComplete(

--- a/packages/server/src/routes/generate/generate-route-utils.ts
+++ b/packages/server/src/routes/generate/generate-route-utils.ts
@@ -13,6 +13,7 @@ import {
   parseTrackerFieldLocks,
   parseTrackerHiddenFields,
   resolveMacros,
+  resolveChatPersonaCandidate,
   unwrapConversationInstructions,
   wrapConversationInstructions,
   type CharacterStat,
@@ -43,20 +44,15 @@ export type SpeakerPrefixMessage = SimpleMessage & {
 export type StoredGenerationParameters = Partial<GenerationParameters>;
 
 /**
- * Resolve the persona visible to a chat. An explicit chat persona always wins;
- * non-game chats may fall back to the globally active persona, while Game Mode
- * deliberately remains persona-less unless setup selected one.
+ * Preserve the route-layer export while sharing the same Persona policy with
+ * the client: only Conversation falls back to the globally active Persona.
  */
 export function resolveActivePersonaCandidate<T extends { id: string; isActive?: unknown }>(
   personas: readonly T[],
   chatPersonaId: string | null | undefined,
   chatMode: string | null | undefined,
 ): T | null {
-  return (
-    (chatPersonaId ? personas.find((persona) => persona.id === chatPersonaId) : null) ??
-    (chatMode !== "game" ? personas.find((persona) => persona.isActive === "true") : null) ??
-    null
-  );
+  return resolveChatPersonaCandidate(personas, chatPersonaId, chatMode);
 }
 
 export type LocalSidecarGenerationConnection = {

--- a/packages/server/src/routes/scene.routes.ts
+++ b/packages/server/src/routes/scene.routes.ts
@@ -140,10 +140,9 @@ async function buildCharacterContext(chars: ReturnType<typeof createCharactersSt
 
 /**
  * Build persona context. Prefers the chat-scoped persona (`chat.personaId`)
- * before falling back to the globally active persona — the same resolution
- * order used elsewhere (see `chats.routes.ts`). Game mode skips the fallback:
- * persona must be explicitly selected in the setup wizard, so a persona-less
- * game stays persona-less in scene prompts too.
+ * before Conversation-only fallback to the globally active Persona — the same
+ * resolution order used elsewhere (see `chats.routes.ts`). Roleplay and Game
+ * may intentionally remain Persona-less in scene prompts.
  */
 async function buildPersonaContext(
   chars: ReturnType<typeof createCharactersStorage>,

--- a/packages/server/src/services/generation/roleplay-summary-runtime.ts
+++ b/packages/server/src/services/generation/roleplay-summary-runtime.ts
@@ -14,6 +14,12 @@ const MAX_SUMMARY_CONTEXT_SIZE = 500;
 
 export const CONTINUE_ASSISTANT_MESSAGE_PROMPT = "Your last message got cut off! Please, continue!";
 
+export function formatRoleplaySummaryChatLog(
+  messages: readonly { role: string; content: string }[],
+): string {
+  return messages.map((message) => `[${message.role}]: ${message.content}`).join("\n\n");
+}
+
 export function clampRoleplaySummaryInterval(value: unknown): number {
   const parsed = Number(value);
   if (!Number.isFinite(parsed) || parsed <= 0) return DEFAULT_AUTOMATIC_SUMMARY_INTERVAL;

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -105,6 +105,7 @@ export * from "./utils/game-state-text.js";
 export * from "./utils/custom-tracker-fields.js";
 export * from "./utils/tracker-field-locks.js";
 export * from "./utils/chat-summary-entries.js";
+export * from "./utils/chat-persona.js";
 export * from "./utils/quest-state.js";
 export * from "./utils/quote-format.js";
 export * from "./utils/image-prompt-compiler.js";

--- a/packages/shared/src/utils/chat-persona.ts
+++ b/packages/shared/src/utils/chat-persona.ts
@@ -1,0 +1,18 @@
+/**
+ * Resolve the Persona visible to a chat. Explicit chat selection always wins.
+ * Conversation may use the globally active Persona for its account-style UX;
+ * Roleplay, legacy Visual Novel, and Game remain Persona-less unless selected.
+ */
+export function resolveChatPersonaCandidate<T extends { id: string; isActive?: unknown }>(
+  personas: readonly T[],
+  chatPersonaId: string | null | undefined,
+  chatMode: string | null | undefined,
+): T | null {
+  return (
+    (chatPersonaId ? personas.find((persona) => persona.id === chatPersonaId) : null) ??
+    (chatMode === "conversation"
+      ? personas.find((persona) => persona.isActive === "true" || persona.isActive === true)
+      : null) ??
+    null
+  );
+}

--- a/packages/shared/src/utils/chat-summary-entries.ts
+++ b/packages/shared/src/utils/chat-summary-entries.ts
@@ -9,7 +9,6 @@ const VALID_KINDS = new Set<ChatSummaryEntryKind>(["rolling"]);
 const VALID_ORIGINS = new Set<ChatSummaryEntryOrigin>(["manual", "automated", "legacy"]);
 const VALID_SOURCES = new Set<ChatSummaryEntrySource>(["last", "range", "agent"]);
 
-export const COMPILED_CHAT_SUMMARY_MAX_BYTES = 64 * 1024;
 export const MAX_AUTOMATED_CHAT_SUMMARY_ENTRIES = 200;
 
 export type ChatSummaryEntryInput = Partial<ChatSummaryEntry> & {
@@ -37,49 +36,6 @@ function fallbackId(prefix: string, seed: string) {
 
 function trimString(value: unknown) {
   return typeof value === "string" ? value.trim() : "";
-}
-
-function utf8ByteLength(text: string): number {
-  let bytes = 0;
-  for (let i = 0; i < text.length; i += 1) {
-    const code = text.charCodeAt(i);
-    if (code < 0x80) {
-      bytes += 1;
-    } else if (code < 0x800) {
-      bytes += 2;
-    } else if (code >= 0xd800 && code <= 0xdbff && i + 1 < text.length) {
-      const next = text.charCodeAt(i + 1);
-      if (next >= 0xdc00 && next <= 0xdfff) {
-        bytes += 4;
-        i += 1;
-      } else {
-        bytes += 3;
-      }
-    } else {
-      bytes += 3;
-    }
-  }
-  return bytes;
-}
-
-function trimToUtf8Bytes(text: string, maxBytes: number, fromStart = true): string {
-  if (maxBytes <= 0) return "";
-  if (utf8ByteLength(text) <= maxBytes) return text;
-
-  let low = 0;
-  let high = text.length;
-  while (low < high) {
-    const mid = Math.ceil((low + high) / 2);
-    const candidate = fromStart ? text.slice(text.length - mid) : text.slice(0, mid);
-    if (utf8ByteLength(candidate) <= maxBytes) {
-      low = mid;
-    } else {
-      high = mid - 1;
-    }
-  }
-
-  const trimmed = fromStart ? text.slice(text.length - low) : text.slice(0, low);
-  return fromStart ? trimmed.replace(/^[\uDC00-\uDFFF]/, "") : trimmed.replace(/[\uD800-\uDBFF]$/, "");
 }
 
 function normalizeIsoTimestamp(value: unknown, fallback: string) {
@@ -292,7 +248,7 @@ export function compileChatSummaryEntries(entries: ChatSummaryEntry[]): string |
     .join("\n\n")
     .trim();
   if (!compiled) return null;
-  return trimToUtf8Bytes(compiled, COMPILED_CHAT_SUMMARY_MAX_BYTES, true).trim() || null;
+  return compiled;
 }
 
 export function appendChatSummaryEntryToMetadata(

--- a/scripts/regressions/prompt.regression.ts
+++ b/scripts/regressions/prompt.regression.ts
@@ -22,6 +22,7 @@ import {
   LIMITS,
   resolveRegexPatternLiteralMacros,
   resolveGameSetupArtStylePrompt,
+  resolveChatPersonaCandidate,
   resolveMacros,
   resolveAgentPromptTemplate,
   resolveDefaultAgentPromptTemplateId,
@@ -246,11 +247,13 @@ import {
   collectLatestTrackerCharacterHistory,
   injectIntoOutputFormatOrLastUser,
   preserveTrackerCharacterUiFields,
+  resolveActivePersonaCandidate,
   shouldEnableAgentsForGeneration,
   shouldInjectIdentityFallback,
   stripSpeakerTagsExceptLastAssistant,
   type SimpleMessage,
 } from "../../packages/server/src/routes/generate/generate-route-utils.js";
+import { formatRoleplaySummaryChatLog } from "../../packages/server/src/services/generation/roleplay-summary-runtime.js";
 import { resolveGenerationPromptPresetChoices } from "../../packages/server/src/routes/generate/prompt-preset-selection.js";
 import {
   calibrateLorebookSimilarity,
@@ -2715,6 +2718,22 @@ Use HTML sparingly and diegetically. Do not replace normal prose/dialogue unless
     },
   },
   {
+    name: "Roleplay preserves an explicit no-Persona selection",
+    run() {
+      const personas = [
+        { id: "active-persona", isActive: "true" },
+        { id: "selected-persona", isActive: "false" },
+      ];
+
+      assert.equal(resolveChatPersonaCandidate(personas, null, "roleplay"), null);
+      assert.equal(resolveActivePersonaCandidate(personas, null, "roleplay"), null);
+      assert.equal(resolveActivePersonaCandidate(personas, null, "visual_novel"), null);
+      assert.equal(resolveActivePersonaCandidate(personas, null, "game"), null);
+      assert.equal(resolveActivePersonaCandidate(personas, null, "conversation")?.id, "active-persona");
+      assert.equal(resolveActivePersonaCandidate(personas, "selected-persona", "roleplay")?.id, "selected-persona");
+    },
+  },
+  {
     name: "chat summaries normalize legacy data and compile enabled entries only",
     run() {
       const legacyEntries = normalizeChatSummaryEntries([], {
@@ -2737,6 +2756,27 @@ Use HTML sparingly and diegetically. Do not replace normal prose/dialogue unless
       ]);
 
       assert.equal(compiled, "The previous scene was summarized.");
+
+      const chapterMessage = "A".repeat(8_500);
+      assert.equal(
+        formatRoleplaySummaryChatLog([{ role: "assistant", content: chapterMessage }]),
+        `[assistant]: ${chapterMessage}`,
+        "Roleplay Summary must send a chapter-length source message without per-message truncation",
+      );
+
+      const largeSummary = "Summary detail. ".repeat(5_000);
+      const compiledLargeSummary = compileChatSummaryEntries([
+        {
+          ...legacyEntries[0]!,
+          id: "large-summary",
+          content: largeSummary,
+        },
+      ]);
+      assert.equal(
+        compiledLargeSummary,
+        largeSummary.trim(),
+        "Compiled chat metadata must preserve summaries larger than the former 64 KiB ceiling",
+      );
     },
   },
   {


### PR DESCRIPTION
## Why

Three maintainer-reported limits can silently change Roleplay behavior or discard legitimate long-form data before the v3.2.2 release:

- a newly created Roleplay chat can attach the active Persona even when the user explicitly selected no Persona
- Roleplay summary generation truncates every source message to 2,000 characters, which breaks chapter-length generations
- compiled chat summary metadata in `chats.json` is silently truncated to 64 KiB

No linked issue was supplied; this is a maintainer-requested release-blocking fix batch.

## What

- preserve an explicit no-Persona Roleplay selection through optimistic message snapshots, provider prompts, scenes, and encounters
- retain Conversation mode active-Persona fallback for its account-style behavior
- pass complete Roleplay messages into manual and automatic summary generation
- persist complete compiled summaries without the former 64 KiB metadata ceiling
- retain structural validation and surface provider context failures normally
- add focused regressions and v3.2.2 release notes

## Test plan

- [ ] Manually create a Roleplay chat with a Character and no Persona, then verify the first generation keeps `personaId` null.
- [ ] Manually summarize a Roleplay chat containing a message longer than 8,000 characters.
- [ ] Manually persist accumulated chat summaries larger than 64 KiB.
- [ ] Run `pnpm regression:prompt`.
- [ ] Run `pnpm check`.
- [ ] Run `pnpm version:check`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Roleplay chats now preserve an explicitly selected “no Persona” setting throughout generation, prompts, scenes, and combat.
  * Conversation mode continues to support fallback to the globally active Persona.
  * Longer roleplay summaries and chapter-length inputs are no longer truncated automatically.
* **Tests**
  * Added regression coverage for Persona selection behavior and expanded summary size handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->