### PR TITLE
Add configurable pauses between TTS dialogue lines

### DIFF
--- a/packages/client/src/components/panels/settings/TTSConfigCard.tsx
+++ b/packages/client/src/components/panels/settings/TTSConfigCard.tsx
@@ -421,6 +421,7 @@ export function TTSConfigCard() {
   const [autoplayGame, setAutoplayGame] = useState(false);
   const [progressivePlayback, setProgressivePlayback] = useState(false);
   const [dialogueOnly, setDialogueOnly] = useState(false);
+  const [dialoguePauseMs, setDialoguePauseMs] = useState(300);
   const [audioFormat, setAudioFormat] = useState<TTSAudioFormat>("mp3");
   const [callAudioEnabled, setCallAudioEnabled] = useState(false);
   const [callAudioInputMode, setCallAudioInputMode] = useState<TTSConversationCallAudioInputMode>("local_whisper");
@@ -476,6 +477,7 @@ export function TTSConfigCard() {
     setAutoplayGame(savedConfig.autoplayGame);
     setProgressivePlayback(savedConfig.progressivePlayback ?? false);
     setDialogueOnly(savedConfig.dialogueOnly ?? false);
+    setDialoguePauseMs(savedConfig.dialoguePauseMs ?? 300);
     setAudioFormat(savedConfig.audioFormat ?? "mp3");
     setCallAudioEnabled(savedConfig.callAudioEnabled ?? false);
     setCallAudioInputMode(savedConfig.callAudioInputMode ?? "local_whisper");
@@ -545,6 +547,7 @@ export function TTSConfigCard() {
     autoplayGame,
     progressivePlayback,
     dialogueOnly,
+    dialoguePauseMs,
     audioFormat,
     callAudioEnabled,
     callSttConnectionId: "",
@@ -1491,6 +1494,30 @@ export function TTSConfigCard() {
                 mark({ dialogueOnly: v });
               }}
             />
+            {dialogueOnly && (
+              <FieldRow
+                label={`Pause between dialogues — ${dialoguePauseMs} ms`}
+                help="Adds silence between separate dialogue lines in the same message. It does not pause between chunks of the same long dialogue."
+              >
+                <input
+                  type="range"
+                  min={0}
+                  max={1500}
+                  step={50}
+                  value={dialoguePauseMs}
+                  onChange={(event) => {
+                    const next = Number(event.target.value);
+                    setDialoguePauseMs(next);
+                    mark({ dialoguePauseMs: next });
+                  }}
+                  className="w-full accent-rose-400"
+                />
+                <div className="flex justify-between text-[0.6rem] text-[var(--muted-foreground)]">
+                  <span>No pause</span>
+                  <span>1500 ms</span>
+                </div>
+              </FieldRow>
+            )}
           </div>
 
           <div className="flex items-center gap-2 rounded-xl border border-sky-400/15 bg-sky-400/5 px-2.5 py-2">

--- a/packages/client/src/lib/tts-dialogue.ts
+++ b/packages/client/src/lib/tts-dialogue.ts
@@ -12,6 +12,7 @@ export interface TTSVoiceRequest {
   speaker?: string;
   tone?: string;
   voice?: string;
+  pauseAfterMs?: number;
 }
 
 export interface CachedTTSVoiceRequest extends TTSVoiceRequest {
@@ -378,7 +379,7 @@ export function buildTTSVoiceRequests(
         : [{ text: cleanTTSInputText(normalized), speaker: fallbackSpeaker || undefined } satisfies TTSUtterance];
 
   const fallbackSpeakerKey = normalizeTTSCharacterName(fallbackSpeaker);
-  return utterances.flatMap((utterance) => {
+  return utterances.flatMap((utterance, utteranceIndex) => {
     const speaker = utterance.speaker || fallbackSpeaker || undefined;
     const speakerKey = normalizeTTSCharacterName(speaker);
     const resolvedCharacterId = speaker
@@ -388,11 +389,18 @@ export function buildTTSVoiceRequests(
     const voice = resolveTTSVoiceForSpeaker(config, speaker, resolvedCharacterId);
     if (config.source === "elevenlabs" && !voice) return [];
 
-    return splitTTSChunks(utterance.text).map((chunk) => ({
+    const chunks = splitTTSChunks(utterance.text);
+    return chunks.map((chunk, chunkIndex) => ({
       text: chunk,
       speaker,
       tone: utterance.tone,
       voice,
+      ...(config.dialogueOnly &&
+      utteranceIndex < utterances.length - 1 &&
+      chunkIndex === chunks.length - 1 &&
+      config.dialoguePauseMs > 0
+        ? { pauseAfterMs: config.dialoguePauseMs }
+        : {}),
     }));
   });
 }
@@ -409,10 +417,7 @@ function isLikelyTTSVNSpeaker(value: string): boolean {
   return /^[\p{L}\p{N}][\p{L}\p{N}' ._-]{0,47}$/u.test(speaker);
 }
 
-export function extractDialogueUtterances(
-  text: string,
-  fallbackSpeaker?: string | null,
-): TTSUtterance[] {
+export function extractDialogueUtterances(text: string, fallbackSpeaker?: string | null): TTSUtterance[] {
   // Remove ordinary HTML before looking for quoted dialogue. Otherwise quote
   // marks inside style/class attributes are mistaken for spoken lines.
   const speechText = stripTTSMarkup(text, true);

--- a/packages/client/src/lib/tts-service.ts
+++ b/packages/client/src/lib/tts-service.ts
@@ -24,6 +24,7 @@ export interface TTSSpeakRequest {
   speaker?: string;
   tone?: string;
   voice?: string;
+  pauseAfterMs?: number;
   cacheKey?: string;
   cacheAliases?: string[];
   activeId?: string | null;
@@ -65,6 +66,30 @@ function waitForBlobWithAbort(promise: Promise<Blob>, signal?: AbortSignal): Pro
 
 function playbackAbortError(): DOMException {
   return new DOMException("TTS playback aborted", "AbortError");
+}
+
+function waitForPlaybackDelay(delayMs: number | undefined, signal: AbortSignal): Promise<void> {
+  const ms = typeof delayMs === "number" && Number.isFinite(delayMs) ? Math.max(0, Math.min(1500, delayMs)) : 0;
+
+  if (ms <= 0) return Promise.resolve();
+  if (signal.aborted) return Promise.reject(playbackAbortError());
+
+  return new Promise((resolve, reject) => {
+    const cleanup = () => {
+      signal.removeEventListener("abort", onAbort);
+    };
+    const onAbort = () => {
+      clearTimeout(timer);
+      cleanup();
+      reject(playbackAbortError());
+    };
+
+    const timer = setTimeout(() => {
+      cleanup();
+      resolve();
+    }, ms);
+    signal.addEventListener("abort", onAbort, { once: true });
+  });
 }
 
 function shouldWaitForPlaybackReturn(error: unknown): boolean {
@@ -472,12 +497,17 @@ class TTSService {
 
         try {
           await playBlob(result.blob, result.request, result.index);
+          await waitForPlaybackDelay(result.request.pauseAfterMs, abortController.signal);
           played += 1;
           if (nextFetch && this.isCurrentSequence(sequence)) {
             this.setState("loading", id ?? null);
           }
         } catch (err) {
           detachAbortSignal();
+          if (err instanceof Error && err.name === "AbortError") {
+            this.setState("idle");
+            return;
+          }
           if (options.throwOnError) throw err;
           return;
         }
@@ -499,13 +529,13 @@ class TTSService {
     }
 
     const results = await Promise.all(playableRequests.map((request, index) => fetchChunk(request, index)));
-    detachAbortSignal();
     if (!this.isCurrentSequence(sequence)) return;
-    if (this.abortController === abortController) {
-      this.abortController = null;
-    }
 
     if (results.some((result) => !result.ok && isAbortError(result.error))) {
+      detachAbortSignal();
+      if (this.abortController === abortController) {
+        this.abortController = null;
+      }
       this.setState("idle");
       return;
     }
@@ -514,6 +544,10 @@ class TTSService {
     const fetchErrors = results.flatMap((result) => (result.ok ? [] : [result.error]));
     handleFetchFailures(fetchErrors);
     if (playableChunks.length === 0) {
+      detachAbortSignal();
+      if (this.abortController === abortController) {
+        this.abortController = null;
+      }
       const error = fetchErrors[0] ?? new Error("TTS request failed");
       this.lastError = error.message;
       this.setState("error");
@@ -524,11 +558,24 @@ class TTSService {
     for (const chunk of playableChunks) {
       try {
         await playBlob(chunk.blob, chunk.request, chunk.index);
+        await waitForPlaybackDelay(chunk.request.pauseAfterMs, abortController.signal);
       } catch (err) {
+        detachAbortSignal();
+        if (this.abortController === abortController) {
+          this.abortController = null;
+        }
+        if (err instanceof Error && err.name === "AbortError") {
+          this.setState("idle");
+          return;
+        }
         if (options.throwOnError) throw err;
         return;
       }
       if (!this.isCurrentSequence(sequence)) return;
+    }
+    detachAbortSignal();
+    if (this.abortController === abortController) {
+      this.abortController = null;
     }
     this.setState("idle");
   }

--- a/packages/shared/src/types/tts.ts
+++ b/packages/shared/src/types/tts.ts
@@ -126,6 +126,7 @@ const ttsConfigBaseSchema = z.object({
   autoplayGame: z.boolean().default(false),
   progressivePlayback: z.boolean().default(false),
   dialogueOnly: z.boolean().default(false),
+  dialoguePauseMs: z.number().min(0).max(1500).default(300),
   audioFormat: ttsAudioFormatSchema.default("mp3"),
   /** Global gate for Conversation-mode calls. Individual chats opt in separately. */
   callAudioEnabled: z.boolean().default(false),

--- a/scripts/regressions/tts-source-persistence.regression.ts
+++ b/scripts/regressions/tts-source-persistence.regression.ts
@@ -1,8 +1,40 @@
 import assert from "node:assert/strict";
 import { TTS_API_KEY_MASK, ttsConfigSchema } from "../../packages/shared/src/types/tts.js";
+import { buildTTSVoiceRequests } from "../../packages/client/src/lib/tts-dialogue.ts";
 import { maskTTSConfigForResponse, prepareTTSConfigForStorage } from "../../packages/server/src/routes/tts.routes.ts";
 
 const encryptForTest = (value: string) => (value ? `encrypted:${value}` : "");
+
+const legacyConfigWithoutDialoguePause = ttsConfigSchema.parse({});
+assert.equal(legacyConfigWithoutDialoguePause.dialoguePauseMs, 300);
+
+const dialogueConfig = ttsConfigSchema.parse({ dialogueOnly: true, dialoguePauseMs: 300 });
+const twoUtterances = buildTTSVoiceRequests('"First line." "Second line."', dialogueConfig);
+assert.deepEqual(
+  twoUtterances.map((request) => request.pauseAfterMs),
+  [300, undefined],
+);
+
+const threeUtterances = buildTTSVoiceRequests('"First." "Second." "Third."', dialogueConfig);
+assert.deepEqual(
+  threeUtterances.map((request) => request.pauseAfterMs),
+  [300, 300, undefined],
+);
+
+const longDialogue = `${"A".repeat(950)}. Short ending.`;
+const splitUtteranceRequests = buildTTSVoiceRequests(`"${longDialogue}" "Next line."`, dialogueConfig);
+assert.ok(splitUtteranceRequests.length > 2);
+assert.ok(splitUtteranceRequests.slice(0, -2).every((request) => request.pauseAfterMs === undefined));
+assert.equal(splitUtteranceRequests.at(-2)?.pauseAfterMs, 300);
+assert.equal(splitUtteranceRequests.at(-1)?.pauseAfterMs, undefined);
+
+const fullMessageConfig = ttsConfigSchema.parse({ dialogueOnly: false, dialoguePauseMs: 300 });
+const fullMessageRequests = buildTTSVoiceRequests('"First." "Second."', fullMessageConfig);
+assert.ok(fullMessageRequests.every((request) => request.pauseAfterMs === undefined));
+
+const zeroPauseConfig = ttsConfigSchema.parse({ dialogueOnly: true, dialoguePauseMs: 0 });
+const zeroPauseRequests = buildTTSVoiceRequests('"First." "Second."', zeroPauseConfig);
+assert.ok(zeroPauseRequests.every((request) => request.pauseAfterMs === undefined));
 
 const legacyOpenAiConfig = ttsConfigSchema.parse({
   enabled: true,


### PR DESCRIPTION
## Linked issue

Closes #3718.

## Why this change

When **Only read dialogues** is enabled, separate dialogue lines from the same message are played immediately one after another.

Because the TTS sequence currently starts the next generated clip as soon as the previous clip ends, conversations with multiple dialogue lines can sound unnaturally continuous.

## What changed

- Added a persisted `dialoguePauseMs` TTS setting.
- Added a configurable delay from `0` to `1500` milliseconds.
- Set the default delay to `300` milliseconds.
- Added a delay slider below **Only read dialogues** in the TTS settings panel.
- Preserved dialogue utterance boundaries during TTS request construction.
- Applied the delay only after the final chunk of each utterance.
- Avoided pauses between chunks belonging to the same long utterance.
- Added abort support so stopping TTS during a delay prevents the next clip from starting.
- Applied the behavior to both progressive and non-progressive sequence playback.

## User impact

Users can control the pacing between separate dialogue lines without affecting normal full-message TTS playback.

The selected delay is saved with the existing TTS configuration and applies to newly started playback.

## Technical notes

The delay is playback metadata and is not included in generated-audio cache keys.

Audio generation may continue progressively during the delay, but playback waits for the configured interval before starting the next clip.

Manual playback and autoplay already use `buildTTSVoiceRequests()` with `speakSequence()`, so no call-site changes were required.

## Validation

- TTS regression script: passed.
- Client TypeScript and production build: passed.
- Shared and server TypeScript checks: passed.
- Client ESLint: passed.
- `git diff --check`: passed.

The exact `pnpm regression:tts` and `pnpm lint` wrappers were attempted, but the Codex pnpm runtime stopped during its automatic install step because third-party dependency build scripts are not approved. The same underlying build, regression, TypeScript, and ESLint commands were run directly with the installed workspace binaries and passed.

## Manual verification

- [ ] Verify the slider is shown only while **Only read dialogues** is enabled.
- [ ] Verify the slider range is `0–1500 ms` with `50 ms` steps.
- [ ] Verify pauses in progressive and non-progressive playback.
- [ ] Verify stopping playback during a pause prevents the next clip from starting.
- [ ] Verify the settings panel in light and dark themes.

## UI evidence

A screenshot of the TTS settings panel still needs to be added before marking this PR ready for review.