### PR TITLE
fix: preserve Hierarchical Maps chat selections on upgrade

### DIFF
--- a/packages/server/src/services/capability-packages/legacy-capability-chat-migration.ts
+++ b/packages/server/src/services/capability-packages/legacy-capability-chat-migration.ts
@@ -1,15 +1,11 @@
 import type { DB } from "../../db/connection.js";
+import { spatialContextSnapshots } from "../../db/schema/index.js";
 import { logger } from "../../lib/logger.js";
 import { createChatsStorage } from "../storage/chats.storage.js";
 
-const CONVERSATION_GAME_PACKAGES = [
-  "uno",
-  "chess",
-  "poker",
-  "eightball",
-  "tic-tac-toe",
-  "rock-paper-scissors",
-];
+const CONVERSATION_GAME_PACKAGES = ["uno", "chess", "poker", "eightball", "tic-tac-toe", "rock-paper-scissors"];
+const HIERARCHICAL_MAPS_ID = "hierarchical-maps";
+const HIERARCHICAL_MAPS_MIGRATED_MODES = new Set(["roleplay", "game", "visual_novel"]);
 
 function parseMetadata(value: unknown): Record<string, unknown> {
   if (value && typeof value === "object" && !Array.isArray(value)) return value as Record<string, unknown>;
@@ -33,13 +29,32 @@ export function buildLegacyChatCapabilityPatch(chat: { mode: string; metadata: u
   if (chat.mode === "conversation") {
     for (const id of CONVERSATION_GAME_PACKAGES) active.add(id);
     if (metadata.conversationCallsEnabled === true) active.add("conversation-calls");
-  } else if (chat.mode === "roleplay" || chat.mode === "game" || chat.mode === "visual_novel") {
-    active.add("hierarchical-maps");
   }
   return active.size === before ? null : { activeAgentIds: [...active] };
 }
 
-/** Preserve exactly the feature availability older Engine builds gave existing chats. */
+function hasPersistedSpatialDefinition(metadata: Record<string, unknown>): boolean {
+  const definition = metadata.spatialContext;
+  if (!definition || typeof definition !== "object" || Array.isArray(definition)) return false;
+  const locations = (definition as Record<string, unknown>).locations;
+  return Array.isArray(locations) && locations.length > 0;
+}
+
+export function buildHierarchicalMapsSelectionCorrectionPatch(
+  chat: { mode: string; metadata: unknown },
+  hasSpatialSnapshots: boolean,
+) {
+  if (!HIERARCHICAL_MAPS_MIGRATED_MODES.has(chat.mode)) return null;
+  const metadata = parseMetadata(chat.metadata);
+  const activeAgentIds = Array.isArray(metadata.activeAgentIds)
+    ? metadata.activeAgentIds.filter((id): id is string => typeof id === "string")
+    : [];
+  if (!activeAgentIds.includes(HIERARCHICAL_MAPS_ID)) return null;
+  if (hasSpatialSnapshots || hasPersistedSpatialDefinition(metadata)) return null;
+  return { activeAgentIds: activeAgentIds.filter((id) => id !== HIERARCHICAL_MAPS_ID) };
+}
+
+/** Preserve implicitly available legacy features without overwriting per-chat opt-ins. */
 export async function migrateLegacyChatCapabilitySelections(db: DB) {
   const chats = createChatsStorage(db);
   let updated = 0;
@@ -50,4 +65,20 @@ export async function migrateLegacyChatCapabilitySelections(db: DB) {
     updated += 1;
   }
   logger.info("Migrated optional feature selections for %d existing chats", updated);
+}
+
+/** Undo v2.3.2's implicit Maps selection only where no persisted map exists. */
+export async function correctLegacyHierarchicalMapsSelections(db: DB) {
+  const chats = createChatsStorage(db);
+  const snapshotRows = await db.select({ chatId: spatialContextSnapshots.chatId }).from(spatialContextSnapshots);
+  const chatsWithSnapshots = new Set(snapshotRows.map((row) => row.chatId));
+  let updated = 0;
+  for (const chat of await chats.list()) {
+    const patch = buildHierarchicalMapsSelectionCorrectionPatch(chat, chatsWithSnapshots.has(chat.id));
+    if (!patch) continue;
+    await chats.patchMetadata(chat.id, patch, { touchUpdatedAt: false });
+    updated += 1;
+  }
+  logger.info("Corrected Hierarchical Maps selections for %d existing chats without map data", updated);
+  return updated;
 }

--- a/packages/server/src/services/capability-packages/legacy-capability-migration.ts
+++ b/packages/server/src/services/capability-packages/legacy-capability-migration.ts
@@ -1,6 +1,9 @@
 import type { DB } from "../../db/connection.js";
 import { flushDB } from "../../db/connection.js";
-import { migrateLegacyChatCapabilitySelections } from "./legacy-capability-chat-migration.js";
+import {
+  correctLegacyHierarchicalMapsSelections,
+  migrateLegacyChatCapabilitySelections,
+} from "./legacy-capability-chat-migration.js";
 import { capabilityPackageManager } from "./package-manager.service.js";
 
 type AvailabilityMigrationResult = Awaited<ReturnType<typeof capabilityPackageManager.migrateLegacyAvailability>>;
@@ -8,14 +11,21 @@ type AvailabilityMigrationResult = Awaited<ReturnType<typeof capabilityPackageMa
 export type LegacyCapabilityMigrationDependencies = {
   migrateAvailability: (legacyInstall: boolean) => Promise<AvailabilityMigrationResult>;
   migrateChatSelections: (db: DB) => Promise<void>;
+  correctHierarchicalMapsSelections: (db: DB) => Promise<number>;
+  isHierarchicalMapsCorrectionComplete: () => Promise<boolean>;
   flush: () => Promise<void>;
+  completeHierarchicalMapsCorrection: () => Promise<void>;
   complete: () => Promise<void>;
 };
 
 const defaultDependencies: LegacyCapabilityMigrationDependencies = {
   migrateAvailability: (legacyInstall) => capabilityPackageManager.migrateLegacyAvailability(legacyInstall),
   migrateChatSelections: migrateLegacyChatCapabilitySelections,
+  correctHierarchicalMapsSelections: correctLegacyHierarchicalMapsSelections,
+  isHierarchicalMapsCorrectionComplete: async () =>
+    capabilityPackageManager.isHierarchicalMapsSelectionCorrectionComplete(),
   flush: flushDB,
+  completeHierarchicalMapsCorrection: () => capabilityPackageManager.completeHierarchicalMapsSelectionCorrection(),
   complete: () => capabilityPackageManager.completeLegacyAvailabilityMigration(),
 };
 
@@ -26,10 +36,21 @@ export async function migrateLegacyCapabilities(
   dependencies: LegacyCapabilityMigrationDependencies = defaultDependencies,
 ): Promise<AvailabilityMigrationResult> {
   const migration = await dependencies.migrateAvailability(legacyInstall);
-  if (!migration.migrated) return migration;
+  const correctionComplete = await dependencies.isHierarchicalMapsCorrectionComplete();
+  if (migration.migrated) {
+    await dependencies.migrateChatSelections(db);
+    await dependencies.flush();
+    if (!correctionComplete) await dependencies.completeHierarchicalMapsCorrection();
+    await dependencies.complete();
+    return { ...migration, complete: true };
+  }
 
-  await dependencies.migrateChatSelections(db);
-  await dependencies.flush();
-  await dependencies.complete();
-  return { ...migration, complete: true };
+  if (!correctionComplete) {
+    if (migration.legacy) {
+      await dependencies.correctHierarchicalMapsSelections(db);
+      await dependencies.flush();
+    }
+    await dependencies.completeHierarchicalMapsCorrection();
+  }
+  return migration;
 }

--- a/packages/server/src/services/capability-packages/package-manager.service.ts
+++ b/packages/server/src/services/capability-packages/package-manager.service.ts
@@ -24,6 +24,7 @@ const ROOT = join(DATA_DIR, "capability-packages");
 const VERSIONS = join(ROOT, "versions");
 const REGISTRY = join(ROOT, "installed.json");
 const AVAILABILITY_MIGRATION = join(ROOT, "availability-migration-v1.json");
+const HIERARCHICAL_MAPS_SELECTION_CORRECTION = join(ROOT, "hierarchical-maps-selection-correction-v1.json");
 const NON_DOWNLOADABLE_CORE_PACKAGE_IDS = new Set(["about-me-keeper"]);
 const CATALOG_URL = process.env.MARINARA_AGENT_CATALOG_URL?.trim() ||
   "https://raw.githubusercontent.com/Pasta-Devs/Marinara-Agents/main/catalog/catalog.json";
@@ -96,6 +97,24 @@ async function writeAvailabilityMigration(kind: "fresh" | "legacy") {
     mode: 0o600,
   });
   await rename(temporary, AVAILABILITY_MIGRATION);
+}
+
+async function readAvailabilityMigrationKind(): Promise<"fresh" | "legacy" | null> {
+  try {
+    const parsed = JSON.parse(await readFile(AVAILABILITY_MIGRATION, "utf8")) as Record<string, unknown>;
+    return parsed.schemaVersion === 1 && (parsed.kind === "fresh" || parsed.kind === "legacy") ? parsed.kind : null;
+  } catch {
+    return null;
+  }
+}
+
+async function writeHierarchicalMapsSelectionCorrection() {
+  await mkdir(ROOT, { recursive: true });
+  const temporary = `${HIERARCHICAL_MAPS_SELECTION_CORRECTION}.tmp-${process.pid}-${Date.now()}`;
+  await writeFile(temporary, JSON.stringify({ schemaVersion: 1, completedAt: new Date().toISOString() }, null, 2), {
+    mode: 0o600,
+  });
+  await rename(temporary, HIERARCHICAL_MAPS_SELECTION_CORRECTION);
 }
 
 async function fetchBytes(url: string, maximum: number): Promise<Buffer> {
@@ -403,7 +422,13 @@ export const capabilityPackageManager = {
   },
 
   async migrateLegacyAvailability(legacyInstall: boolean) {
-    if (existsSync(AVAILABILITY_MIGRATION)) return { migrated: false, legacy: legacyInstall, complete: true };
+    if (existsSync(AVAILABILITY_MIGRATION)) {
+      return {
+        migrated: false,
+        legacy: (await readAvailabilityMigrationKind()) === "legacy",
+        complete: true,
+      };
+    }
     if (!legacyInstall) {
       await writeAvailabilityMigration("fresh");
       return { migrated: false, legacy: false, complete: true };
@@ -422,6 +447,14 @@ export const capabilityPackageManager = {
 
   async completeLegacyAvailabilityMigration() {
     await writeAvailabilityMigration("legacy");
+  },
+
+  isHierarchicalMapsSelectionCorrectionComplete() {
+    return existsSync(HIERARCHICAL_MAPS_SELECTION_CORRECTION);
+  },
+
+  async completeHierarchicalMapsSelectionCorrection() {
+    await writeHierarchicalMapsSelectionCorrection();
   },
 
   async updateInstalledPackagesToLatest() {

--- a/scripts/regressions/capability-package-lifecycle.regression.ts
+++ b/scripts/regressions/capability-package-lifecycle.regression.ts
@@ -9,6 +9,7 @@ process.env.DATA_DIR = dataDir;
 const packagesRoot = join(dataDir, "capability-packages");
 const registryPath = join(packagesRoot, "installed.json");
 const migrationPath = join(packagesRoot, "availability-migration-v1.json");
+const mapsCorrectionPath = join(packagesRoot, "hierarchical-maps-selection-correction-v1.json");
 const modelsRoot = join(dataDir, "models");
 const speechConfigPath = join(modelsRoot, "sidecar-speech-config.json");
 let closeDatabase: (() => Promise<void>) | null = null;
@@ -170,9 +171,11 @@ try {
   const { capabilityPackageManager, findCompatibleCapabilityPackageUpdates } = await import(
     "../../packages/server/src/services/capability-packages/package-manager.service.js"
   );
-  const { buildLegacyChatCapabilityPatch } = await import(
-    "../../packages/server/src/services/capability-packages/legacy-capability-chat-migration.js"
-  );
+  const {
+    buildHierarchicalMapsSelectionCorrectionPatch,
+    buildLegacyChatCapabilityPatch,
+    correctLegacyHierarchicalMapsSelections,
+  } = await import("../../packages/server/src/services/capability-packages/legacy-capability-chat-migration.js");
   const { migrateLegacyCapabilities } = await import(
     "../../packages/server/src/services/capability-packages/legacy-capability-migration.js"
   );
@@ -185,6 +188,54 @@ try {
     null,
     "Legacy capability migration must preserve a chat that did not select Hierarchical Maps",
   );
+  assert.deepEqual(
+    buildLegacyChatCapabilityPatch({ mode: "conversation", metadata: { activeAgentIds: [] } }),
+    {
+      activeAgentIds: ["uno", "chess", "poker", "eightball", "tic-tac-toe", "rock-paper-scissors"],
+    },
+    "The Maps fix must preserve migration of conversation games that were previously implicit",
+  );
+  assert.deepEqual(
+    buildHierarchicalMapsSelectionCorrectionPatch(
+      {
+        mode: "roleplay",
+        metadata: { enableAgents: false, activeAgentIds: ["illustrator", "hierarchical-maps"] },
+      },
+      false,
+    ),
+    { activeAgentIds: ["illustrator"] },
+    "The correction must remove an auto-added Maps selection when the chat has no map data",
+  );
+  assert.equal(
+    buildHierarchicalMapsSelectionCorrectionPatch(
+      {
+        mode: "roleplay",
+        metadata: {
+          activeAgentIds: ["hierarchical-maps"],
+          spatialContext: { locations: [{ id: "existing-location" }] },
+        },
+      },
+      false,
+    ),
+    null,
+    "The correction must preserve Maps when a spatial definition exists",
+  );
+  assert.equal(
+    buildHierarchicalMapsSelectionCorrectionPatch(
+      { mode: "game", metadata: { activeAgentIds: ["hierarchical-maps"] } },
+      true,
+    ),
+    null,
+    "The correction must preserve Maps when spatial snapshots exist",
+  );
+  assert.equal(
+    buildHierarchicalMapsSelectionCorrectionPatch(
+      { mode: "conversation", metadata: { activeAgentIds: ["hierarchical-maps"] } },
+      false,
+    ),
+    null,
+    "The correction must not alter chat modes that the faulty migration did not touch",
+  );
 
   const migrationSteps: string[] = [];
   const completedMigration = await migrateLegacyCapabilities({} as never, true, {
@@ -195,14 +246,25 @@ try {
     async migrateChatSelections() {
       migrationSteps.push("chats");
     },
+    async correctHierarchicalMapsSelections() {
+      migrationSteps.push("correction");
+      return 0;
+    },
+    async isHierarchicalMapsCorrectionComplete() {
+      migrationSteps.push("correction-check");
+      return false;
+    },
     async flush() {
       migrationSteps.push("flush");
+    },
+    async completeHierarchicalMapsCorrection() {
+      migrationSteps.push("correction-marker");
     },
     async complete() {
       migrationSteps.push("marker");
     },
   });
-  assert.deepEqual(migrationSteps, ["packages", "chats", "flush", "marker"]);
+  assert.deepEqual(migrationSteps, ["packages", "correction-check", "chats", "flush", "correction-marker", "marker"]);
   assert.equal(completedMigration.complete, true);
 
   const interruptedSteps: string[] = [];
@@ -215,9 +277,20 @@ try {
       async migrateChatSelections() {
         interruptedSteps.push("chats");
       },
+      async correctHierarchicalMapsSelections() {
+        interruptedSteps.push("correction");
+        return 0;
+      },
+      async isHierarchicalMapsCorrectionComplete() {
+        interruptedSteps.push("correction-check");
+        return false;
+      },
       async flush() {
         interruptedSteps.push("flush");
         throw new Error("fixture flush failed");
+      },
+      async completeHierarchicalMapsCorrection() {
+        interruptedSteps.push("correction-marker");
       },
       async complete() {
         interruptedSteps.push("marker");
@@ -225,11 +298,53 @@ try {
     }),
     /fixture flush failed/,
   );
-  assert.deepEqual(interruptedSteps, ["packages", "chats", "flush"]);
+  assert.deepEqual(interruptedSteps, ["packages", "correction-check", "chats", "flush"]);
+
+  const correctionSteps: string[] = [];
+  await migrateLegacyCapabilities({} as never, true, {
+    async migrateAvailability() {
+      correctionSteps.push("packages");
+      return { migrated: false, legacy: true, complete: true };
+    },
+    async migrateChatSelections() {
+      correctionSteps.push("chats");
+    },
+    async correctHierarchicalMapsSelections() {
+      correctionSteps.push("correction");
+      return 1;
+    },
+    async isHierarchicalMapsCorrectionComplete() {
+      correctionSteps.push("correction-check");
+      return false;
+    },
+    async flush() {
+      correctionSteps.push("flush");
+    },
+    async completeHierarchicalMapsCorrection() {
+      correctionSteps.push("correction-marker");
+    },
+    async complete() {
+      correctionSteps.push("marker");
+    },
+  });
+  assert.deepEqual(correctionSteps, ["packages", "correction-check", "correction", "flush", "correction-marker"]);
 
   assert.equal(existsSync(migrationPath), false);
   await capabilityPackageManager.completeLegacyAvailabilityMigration();
   assert.equal(JSON.parse(readFileSync(migrationPath, "utf8")).kind, "legacy");
+  assert.equal((await capabilityPackageManager.migrateLegacyAvailability(false)).legacy, true);
+  assert.equal(existsSync(mapsCorrectionPath), false);
+  await capabilityPackageManager.completeHierarchicalMapsSelectionCorrection();
+  assert.equal(existsSync(mapsCorrectionPath), true);
+  rmSync(migrationPath);
+  const freshMigration = await capabilityPackageManager.migrateLegacyAvailability(false);
+  assert.deepEqual(freshMigration, { migrated: false, legacy: false, complete: true });
+  assert.equal(JSON.parse(readFileSync(migrationPath, "utf8")).kind, "fresh");
+  assert.equal(
+    (await capabilityPackageManager.migrateLegacyAvailability(true)).legacy,
+    false,
+    "A fresh-install marker must not later be mistaken for the faulty legacy migration",
+  );
   const catalogEntry = (manifest: typeof legacyManifest) => ({
     manifest,
     category: "misc",
@@ -407,7 +522,85 @@ try {
     "../../packages/server/src/services/storage/game-state.storage.js"
   );
   const { createLorebooksStorage } = await import("../../packages/server/src/services/storage/lorebooks.storage.js");
-  const rollbackChat = await createChatsStorage(db).create({
+  const chatsStore = createChatsStorage(db);
+  const autoAddedMapsChat = await chatsStore.create({
+    name: "Auto-added Maps selection fixture",
+    mode: "roleplay",
+    characterIds: [],
+  });
+  assert.ok(autoAddedMapsChat);
+  await chatsStore.patchMetadata(autoAddedMapsChat.id, {
+    enableAgents: false,
+    activeAgentIds: ["illustrator", "hierarchical-maps"],
+  });
+  const autoAddedBeforeCorrection = await chatsStore.getById(autoAddedMapsChat.id);
+  assert.ok(autoAddedBeforeCorrection);
+
+  const definitionMapsChat = await chatsStore.create({
+    name: "Persisted Maps definition fixture",
+    mode: "roleplay",
+    characterIds: [],
+  });
+  assert.ok(definitionMapsChat);
+  await chatsStore.patchMetadata(definitionMapsChat.id, {
+    activeAgentIds: ["hierarchical-maps"],
+    spatialContext: {
+      schemaVersion: 1,
+      ownerMode: "roleplay",
+      enabled: true,
+      locations: [
+        {
+          id: "existing-location",
+          parentId: null,
+          name: "Existing location",
+          kind: "region",
+          description: "A persisted map location.",
+          lorebookEntryIds: [],
+          childPresentation: "list",
+          links: [],
+          status: "active",
+          sortOrder: 0,
+        },
+      ],
+      startingLocationId: "existing-location",
+      revision: 1,
+    },
+  });
+
+  const snapshotMapsChat = await chatsStore.create({
+    name: "Persisted Maps snapshot fixture",
+    mode: "game",
+    characterIds: [],
+  });
+  assert.ok(snapshotMapsChat);
+  await chatsStore.patchMetadata(snapshotMapsChat.id, { activeAgentIds: ["hierarchical-maps"] });
+  await persistence.spatialSnapshots.create({
+    id: "maps-correction-snapshot",
+    chatId: snapshotMapsChat.id,
+    messageId: "",
+    swipeIndex: 0,
+    currentLocationId: "existing-location",
+    definitionRevision: 1,
+    source: "bootstrap",
+    transitionCommandId: null,
+    transitionPayloadHash: null,
+    createdAt: "2026-07-16T00:00:00.000Z",
+  });
+
+  assert.equal(await correctLegacyHierarchicalMapsSelections(db), 1);
+  const correctedMetadata = JSON.parse(String((await chatsStore.getById(autoAddedMapsChat.id))?.metadata));
+  assert.deepEqual(correctedMetadata.activeAgentIds, ["illustrator"]);
+  assert.equal(correctedMetadata.enableAgents, false);
+  assert.equal((await chatsStore.getById(autoAddedMapsChat.id))?.updatedAt, autoAddedBeforeCorrection.updatedAt);
+  assert.deepEqual(JSON.parse(String((await chatsStore.getById(definitionMapsChat.id))?.metadata)).activeAgentIds, [
+    "hierarchical-maps",
+  ]);
+  assert.deepEqual(JSON.parse(String((await chatsStore.getById(snapshotMapsChat.id))?.metadata)).activeAgentIds, [
+    "hierarchical-maps",
+  ]);
+  assert.equal(await correctLegacyHierarchicalMapsSelections(db), 0, "The chat correction must be idempotent");
+
+  const rollbackChat = await chatsStore.create({
     name: "Capability persistence rollback fixture",
     mode: "roleplay",
     characterIds: [],

--- a/scripts/regressions/capability-package-lifecycle.regression.ts
+++ b/scripts/regressions/capability-package-lifecycle.regression.ts
@@ -177,13 +177,13 @@ try {
     "../../packages/server/src/services/capability-packages/legacy-capability-migration.js"
   );
 
-  assert.deepEqual(
+  assert.equal(
     buildLegacyChatCapabilityPatch({
       mode: "roleplay",
       metadata: { enableAgents: false, activeAgentIds: ["illustrator", "custom-agent"] },
     }),
-    { activeAgentIds: ["illustrator", "custom-agent", "hierarchical-maps"] },
-    "Legacy capability selection must not alter the agent execution master switch",
+    null,
+    "Legacy capability migration must preserve a chat that did not select Hierarchical Maps",
   );
 
   const migrationSteps: string[] = [];


### PR DESCRIPTION
## Linked issue

Closes #3723

## Why this change

- Marinara Engine v2.3.2's one-time legacy capability migration unconditionally adds Hierarchical Maps to every existing roleplay, game, and legacy visual-novel chat. That overwrites per-chat opt-in state and can unexpectedly activate the tracker after an update.

## What changed

- Stopped the legacy capability migration from adding Hierarchical Maps to chats that never selected it.
- Added a durable one-time correction marker that distinguishes fresh installs, direct upgrades to the fixed release, and installations that already completed the faulty v2.3.2 migration.
- For affected installations only, remove the Maps selection when a chat has neither a persisted spatial definition with locations nor any spatial snapshot. Preserve `enableAgents`, timestamps, other selected agents, and every chat with actual map data.
- Added pure, orchestration-order, marker-classification, storage-backed, preservation, and idempotence regression coverage.

## Validation

- [ ] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed `CONTRIBUTING.md`

Automated validation performed:

- `pnpm regression:issues` passes after `pnpm build:shared` refreshed the previously stale shared build.
- Focused capability lifecycle regression passes independently.
- Shared/server lint passes.
- Client ESLint passes with the unrelated untracked `dist.before-game-setup-import-20260716/` backup explicitly ignored.
- `pnpm build` passes.
- `pnpm check` reaches client ESLint but cannot pass unchanged while that preserved backup directory is inside the client workspace; ESLint reports errors from its minified build assets.

### Manual verification notes

- Restarted the local `marinara.service` after the completed build.
- Verified `/api/health` reports `ok` and the exact hashed JavaScript bundle referenced by `packages/client/dist/index.html` returns HTTP 200.
- Audited aggregate live saved state without reading chat content: all five chats selecting Maps have persisted map data; the correction removed zero live selections.
- Browser click-through remains for a human contributor.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Version/release files updated (only if this PR includes a version bump)

## UI evidence (if applicable)

Not applicable; this is a server-side startup migration fix.
