### PR TITLE
fix(image): prevent duplicate prompt inputs

### DIFF
--- a/packages/server/src/services/game/game-asset-generation.ts
+++ b/packages/server/src/services/game/game-asset-generation.ts
@@ -602,17 +602,28 @@ function compileGameImagePrompt(
     };
   }
   if (kind === "illustration" && req.preserveFullScenePrompt) {
-    const compiledPrefix = compileImagePrompt({
-      kind,
-      prompt: "",
-      negativePrompt,
-      hardNegative,
-      styleProfiles: req.styleProfiles,
-      styleProfileId: req.styleProfileId,
-      imageDefaults: req.imgDefaults,
-      generatedStyle: req.artStyle,
-      applyPromptModeToSourcePrompt: false,
-    });
+    const compilePrefix = (dedupeAgainstPrompt: string) =>
+      compileImagePrompt({
+        kind,
+        prompt: "",
+        dedupeAgainstPrompt,
+        negativePrompt,
+        hardNegative,
+        styleProfiles: req.styleProfiles!,
+        styleProfileId: req.styleProfileId,
+        imageDefaults: req.imgDefaults,
+        generatedStyle: req.artStyle,
+        applyPromptModeToSourcePrompt: false,
+      });
+    // The preliminary prefix determines how much preserved source text can actually fit.
+    // Compare against only that guaranteed slice so truncation cannot remove the sole style copy.
+    const preliminaryPrefix = compilePrefix(prompt);
+    const preliminaryHeader = [canonicalPrefix, preliminaryPrefix.prompt].filter(Boolean).join(", ");
+    const guaranteedSourceLength = Math.max(
+      0,
+      maxLength - preliminaryHeader.length - (preliminaryHeader && prompt.trim() ? 2 : 0),
+    );
+    const compiledPrefix = compilePrefix(prompt.trim().slice(0, guaranteedSourceLength));
     const protectedPrompt = [canonicalPrefix, compiledPrefix.prompt, prompt.trim()].filter(Boolean).join(", ");
     return {
       prompt: protectedPrompt.slice(0, maxLength),

--- a/packages/shared/src/utils/image-prompt-compiler.ts
+++ b/packages/shared/src/utils/image-prompt-compiler.ts
@@ -31,22 +31,30 @@ export interface CompileImagePromptInput {
 }
 
 export function compileImagePrompt(input: CompileImagePromptInput): CompiledImagePrompt {
-  const initial = compileImagePromptPass(input, false);
+  const initial = compileImagePromptPass(input, false, false);
   const generatedStyle = input.generatedStyle?.trim() ?? "";
-  if (!generatedStyle) return initial;
+  const userPositive = input.userPositive?.trim() ?? "";
+  if (!generatedStyle && !userPositive) return initial;
 
   // Only trust deduplication after transformation and compaction. If they removed the
-  // source copy, rebuild with the explicit style protected from the compacting budget.
+  // source copy, rebuild with explicit inputs protected from the compacting budget.
   const { fragmentMode } = resolveImagePromptCompilationMode(input, initial.profile);
   const providerVisiblePrompt = [initial.prompt, input.dedupeAgainstPrompt].filter(Boolean).join("\n");
-  if (promptContainsPositiveNormalizedValue(providerVisiblePrompt, generatedStyle, fragmentMode)) return initial;
+  const protectGeneratedStyle =
+    Boolean(generatedStyle) &&
+    !promptContainsPositiveNormalizedValue(providerVisiblePrompt, generatedStyle, fragmentMode);
+  const protectUserPositive =
+    Boolean(userPositive) &&
+    !promptContainsPositiveNormalizedValue(providerVisiblePrompt, userPositive, fragmentMode);
+  if (!protectGeneratedStyle && !protectUserPositive) return initial;
 
-  return compileImagePromptPass(input, true);
+  return compileImagePromptPass(input, protectGeneratedStyle, protectUserPositive);
 }
 
 function compileImagePromptPass(
   input: CompileImagePromptInput,
   protectGeneratedStyle: boolean,
+  protectUserPositive: boolean,
 ): CompiledImagePrompt {
   const profile = findImageStyleProfile(
     input.styleProfiles,
@@ -68,12 +76,9 @@ function compileImagePromptPass(
   const generatedStylePart = protectGeneratedStyle
     ? generatedStyle
     : omitPromptValueAlreadyPresent(generatedStyle, duplicateComparisonPrompt, fragmentMode, positiveDiagnostics);
-  const userPositivePart = omitPromptValueAlreadyPresent(
-    userPositive,
-    duplicateComparisonPrompt,
-    fragmentMode,
-    positiveDiagnostics,
-  );
+  const userPositivePart = protectUserPositive
+    ? userPositive
+    : omitPromptValueAlreadyPresent(userPositive, duplicateComparisonPrompt, fragmentMode, positiveDiagnostics);
   const promptPrefix = imagePromptPrefixFromDefaults(input.imageDefaults);
   const negativePromptPrefix = imageNegativePromptPrefixFromDefaults(input.imageDefaults);
   const sourceCueText = [input.prompt, input.userPositive].filter(Boolean).join("\n");
@@ -98,7 +103,11 @@ function compileImagePromptPass(
           hardPrefix: protectGeneratedStyle,
         },
         { value: input.prompt, sourcePrompt: true },
-        { value: userPositivePart, sourcePrompt: true },
+        {
+          value: userPositivePart,
+          sourcePrompt: !protectUserPositive,
+          hardPrefix: protectUserPositive,
+        },
         { value: profileSubjectTags, sourcePrompt: false },
         { value: profile.positiveTags, sourcePrompt: false },
       ]
@@ -109,7 +118,7 @@ function compileImagePromptPass(
         { value: profileStyleText, sourcePrompt: false },
         { value: generatedStylePart, sourcePrompt: false },
         { value: input.prompt, sourcePrompt: true },
-        { value: userPositivePart, sourcePrompt: true },
+        { value: userPositivePart, sourcePrompt: !protectUserPositive },
       ];
   const negativeParts = [
     negativePromptPrefix,

--- a/packages/shared/src/utils/image-prompt-compiler.ts
+++ b/packages/shared/src/utils/image-prompt-compiler.ts
@@ -16,6 +16,8 @@ export interface CompiledImagePrompt {
 export interface CompileImagePromptInput {
   kind: ImagePromptKind;
   prompt: string;
+  /** Additional provider-visible prompt text used only to suppress exact repeated inputs. */
+  dedupeAgainstPrompt?: string | null;
   negativePrompt?: string | null;
   styleProfiles: ImageStyleProfileSettings;
   styleProfileId?: string | null;
@@ -29,6 +31,23 @@ export interface CompileImagePromptInput {
 }
 
 export function compileImagePrompt(input: CompileImagePromptInput): CompiledImagePrompt {
+  const initial = compileImagePromptPass(input, false);
+  const generatedStyle = input.generatedStyle?.trim() ?? "";
+  if (!generatedStyle) return initial;
+
+  // Only trust deduplication after transformation and compaction. If they removed the
+  // source copy, rebuild with the explicit style protected from the compacting budget.
+  const { fragmentMode } = resolveImagePromptCompilationMode(input, initial.profile);
+  const providerVisiblePrompt = [initial.prompt, input.dedupeAgainstPrompt].filter(Boolean).join("\n");
+  if (promptContainsPositiveNormalizedValue(providerVisiblePrompt, generatedStyle, fragmentMode)) return initial;
+
+  return compileImagePromptPass(input, true);
+}
+
+function compileImagePromptPass(
+  input: CompileImagePromptInput,
+  protectGeneratedStyle: boolean,
+): CompiledImagePrompt {
   const profile = findImageStyleProfile(
     input.styleProfiles,
     input.styleProfileId || input.imageDefaults?.styleProfileId || input.styleProfiles.defaultProfileId,
@@ -39,21 +58,27 @@ export function compileImagePrompt(input: CompileImagePromptInput): CompiledImag
   const movedNegativeFragments: string[] = [];
 
   const generatedStyle = input.generatedStyle?.trim() ?? "";
+  const userPositive = input.userPositive?.trim() ?? "";
+  const {
+    preserveGeneratedPrompt,
+    compactPrompt,
+    fragmentMode,
+  } = resolveImagePromptCompilationMode(input, profile);
+  const duplicateComparisonPrompt = [input.prompt, input.dedupeAgainstPrompt].filter(Boolean).join("\n");
+  const generatedStylePart = protectGeneratedStyle
+    ? generatedStyle
+    : omitPromptValueAlreadyPresent(generatedStyle, duplicateComparisonPrompt, fragmentMode, positiveDiagnostics);
+  const userPositivePart = omitPromptValueAlreadyPresent(
+    userPositive,
+    duplicateComparisonPrompt,
+    fragmentMode,
+    positiveDiagnostics,
+  );
   const promptPrefix = imagePromptPrefixFromDefaults(input.imageDefaults);
   const negativePromptPrefix = imageNegativePromptPrefixFromDefaults(input.imageDefaults);
-  const taggedPromptMode = promptMode === "tagged" || promptMode === "danbooru";
-  const applyPromptModeToSourcePrompt = input.applyPromptModeToSourcePrompt === true;
-  const preserveGeneratedPrompt =
-    !applyPromptModeToSourcePrompt &&
-    (input.kind === "illustration" || input.kind === "background" || input.kind === "selfie");
-  const compactTags = !applyPromptModeToSourcePrompt && !preserveGeneratedPrompt && taggedPromptMode;
-  const compactVisualPrompt =
-    profile.baseStyle !== "z_image_turbo" && ["avatar", "portrait", "sprite"].includes(input.kind);
-  const compactPrompt = compactTags || compactVisualPrompt;
   const sourceCueText = [input.prompt, input.userPositive].filter(Boolean).join("\n");
   const sourceCues = compactPrompt ? deriveTaggedSourceCues(sourceCueText) : [];
   const profileSubjectTags = reconcileProfileSubjectTags(profile.subjectTags[input.kind] ?? "", sourceCues);
-  const fragmentMode = compactPrompt ? "tagged" : promptMode;
   const profileStyleText =
     compactPrompt || (profile.styleText && generatedStyle)
       ? ""
@@ -67,9 +92,13 @@ export function compileImagePrompt(input: CompileImagePromptInput): CompiledImag
     ? [
         { value: promptPrefix, sourcePrompt: false, hardPrefix: true },
         { value: sourceCues.join(", "), sourcePrompt: false },
-        { value: generatedStyle, sourcePrompt: true },
+        {
+          value: generatedStylePart,
+          sourcePrompt: !protectGeneratedStyle,
+          hardPrefix: protectGeneratedStyle,
+        },
         { value: input.prompt, sourcePrompt: true },
-        { value: input.userPositive, sourcePrompt: true },
+        { value: userPositivePart, sourcePrompt: true },
         { value: profileSubjectTags, sourcePrompt: false },
         { value: profile.positiveTags, sourcePrompt: false },
       ]
@@ -78,9 +107,9 @@ export function compileImagePrompt(input: CompileImagePromptInput): CompiledImag
         { value: profile.positiveTags, sourcePrompt: false },
         { value: profileSubjectTags, sourcePrompt: false },
         { value: profileStyleText, sourcePrompt: false },
-        { value: generatedStyle, sourcePrompt: false },
+        { value: generatedStylePart, sourcePrompt: false },
         { value: input.prompt, sourcePrompt: true },
-        { value: input.userPositive, sourcePrompt: true },
+        { value: userPositivePart, sourcePrompt: true },
       ];
   const negativeParts = [
     negativePromptPrefix,
@@ -128,7 +157,11 @@ export function compileImagePrompt(input: CompileImagePromptInput): CompiledImag
     hardPrefix.length,
   );
   if (positive.length === 0) {
-    positive = fallbackPositiveFragments(input, promptMode, compactPrompt);
+    positive = fallbackPositiveFragments(
+      [generatedStylePart, input.prompt, userPositivePart],
+      promptMode,
+      compactPrompt,
+    );
   }
   const negative = dedupeFragments(negativeFragments, profile.rules.dedupeStrength, negativeDiagnostics);
 
@@ -144,12 +177,62 @@ export function compileImagePrompt(input: CompileImagePromptInput): CompiledImag
   };
 }
 
+function resolveImagePromptCompilationMode(input: CompileImagePromptInput, profile: ImageStyleProfile) {
+  const promptMode = profile.promptMode;
+  const taggedPromptMode = promptMode === "tagged" || promptMode === "danbooru";
+  const applyPromptModeToSourcePrompt = input.applyPromptModeToSourcePrompt === true;
+  const preserveGeneratedPrompt =
+    !applyPromptModeToSourcePrompt &&
+    (input.kind === "illustration" || input.kind === "background" || input.kind === "selfie");
+  const compactTags = !applyPromptModeToSourcePrompt && !preserveGeneratedPrompt && taggedPromptMode;
+  const compactVisualPrompt =
+    profile.baseStyle !== "z_image_turbo" && ["avatar", "portrait", "sprite"].includes(input.kind);
+  const compactPrompt = compactTags || compactVisualPrompt;
+  return {
+    preserveGeneratedPrompt,
+    compactPrompt,
+    fragmentMode: compactPrompt ? ("tagged" as const) : promptMode,
+  };
+}
+
+function omitPromptValueAlreadyPresent(
+  value: string,
+  prompt: string,
+  promptMode: ImageStyleProfile["promptMode"],
+  diagnostics: string[],
+): string {
+  if (!value || !promptContainsPositiveNormalizedValue(prompt, value, promptMode)) return value;
+  diagnostics.push(value);
+  return "";
+}
+
+function promptContainsPositiveNormalizedValue(
+  prompt: string,
+  value: string,
+  promptMode: ImageStyleProfile["promptMode"],
+): boolean {
+  const normalizedValue = normalizePromptContainmentText(value);
+  if (!normalizedValue) return false;
+  const positivePrompt = splitPromptFragments(prompt, promptMode)
+    .filter((fragment) => !extractNegativeFragment(fragment) && !hasAvoidInstructionPrefix(fragment))
+    .join(" ");
+  return ` ${normalizePromptContainmentText(positivePrompt)} `.includes(` ${normalizedValue} `);
+}
+
+function normalizePromptContainmentText(value: string): string {
+  return value
+    .toLowerCase()
+    .replace(/[^\p{L}\p{N}]+/gu, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
 function fallbackPositiveFragments(
-  input: CompileImagePromptInput,
+  values: Array<string | null | undefined>,
   promptMode: ImageStyleProfile["promptMode"],
   compactPrompt: boolean,
 ): string[] {
-  const fallbackFragments = [input.generatedStyle, input.prompt, input.userPositive]
+  const fallbackFragments = values
     .flatMap((value) => splitPromptFragments(value, "natural"))
     .filter((fragment) => !extractNegativeFragment(fragment) && !hasAvoidInstructionPrefix(fragment))
     .map((fragment) => cleanPromptFragment(fragment, promptMode))

--- a/scripts/regressions/prompt.regression.ts
+++ b/scripts/regressions/prompt.regression.ts
@@ -2648,14 +2648,33 @@ Use HTML sparingly and diegetically. Do not replace normal prose/dialogue unless
           styleProfiles,
           styleProfileId: profile.id,
         });
-        assert.ok(
-          countValue(sprite.prompt, appearance) <= 1,
+        assert.equal(
+          countValue(sprite.prompt, appearance),
+          1,
           `${profile.id}/sprite repeated the supplied appearance: ${sprite.prompt}`,
         );
         assert.match(sprite.prompt, /silver-furred/i);
         assert.match(sprite.prompt, /persimmon kimono/i);
         assert.match(sprite.prompt, /debt-scroll/i);
-        assert.ok(sprite.diagnostics.removedPositiveDuplicates.includes(appearance));
+        if (profile.id === "anime") {
+          const compactAppearance = "natural expression";
+          const compactBudgetPrompt = [
+            ...Array.from({ length: 40 }, (_, index) => `forest detail ${index}`),
+            compactAppearance,
+          ].join(", ");
+          const compactSprite = compileImagePrompt({
+            kind: "sprite",
+            prompt: compactBudgetPrompt,
+            userPositive: compactAppearance,
+            styleProfiles,
+            styleProfileId: profile.id,
+          });
+          assert.equal(
+            countValue(compactSprite.prompt, compactAppearance),
+            1,
+            `compact sprite lost the supplied appearance: ${compactSprite.prompt}`,
+          );
+        }
 
         const preservedPrompt = `Art direction: ${generatedStyle}. Lyra raises a lantern in the graveyard.`;
         const preservedPrefix = compileImagePrompt({

--- a/scripts/regressions/prompt.regression.ts
+++ b/scripts/regressions/prompt.regression.ts
@@ -2615,6 +2615,182 @@ Use HTML sparingly and diegetically. Do not replace normal prose/dialogue unless
     },
   },
   {
+    name: "image prompt compilation suppresses exact provider-visible duplicate inputs",
+    run() {
+      const styleProfiles = createDefaultImageStyleProfileSettings();
+      const generatedStyle = "Watercolor fantasy illustration, soft edges, warm palette";
+      const appearance = "silver-furred fox-woman, persimmon kimono, debt-scroll tucked in her sleeve";
+      const countValue = (prompt: string, value: string) =>
+        prompt.toLowerCase().split(value.toLowerCase()).length - 1;
+
+      for (const profile of styleProfiles.profiles) {
+        for (const kind of ["portrait", "background", "illustration"] as const) {
+          const compiled = compileImagePrompt({
+            kind,
+            prompt: `Art style: ${generatedStyle}. A moonlit graveyard scene with one clear subject.`,
+            styleProfiles,
+            styleProfileId: profile.id,
+            generatedStyle,
+            applyPromptModeToSourcePrompt: kind !== "portrait",
+          });
+
+          assert.equal(
+            countValue(compiled.prompt, generatedStyle),
+            1,
+            `${profile.id}/${kind} repeated the generated style: ${compiled.prompt}`,
+          );
+        }
+
+        const sprite = compileImagePrompt({
+          kind: "sprite",
+          prompt: `Single full-body character sprite, ${appearance}, idle pose.`,
+          userPositive: appearance,
+          styleProfiles,
+          styleProfileId: profile.id,
+        });
+        assert.ok(
+          countValue(sprite.prompt, appearance) <= 1,
+          `${profile.id}/sprite repeated the supplied appearance: ${sprite.prompt}`,
+        );
+        assert.match(sprite.prompt, /silver-furred/i);
+        assert.match(sprite.prompt, /persimmon kimono/i);
+        assert.match(sprite.prompt, /debt-scroll/i);
+        assert.ok(sprite.diagnostics.removedPositiveDuplicates.includes(appearance));
+
+        const preservedPrompt = `Art direction: ${generatedStyle}. Lyra raises a lantern in the graveyard.`;
+        const preservedPrefix = compileImagePrompt({
+          kind: "illustration",
+          prompt: "",
+          dedupeAgainstPrompt: preservedPrompt,
+          styleProfiles,
+          styleProfileId: profile.id,
+          generatedStyle,
+        });
+        const preservedProviderPrompt = [preservedPrefix.prompt, preservedPrompt].filter(Boolean).join(", ");
+        assert.equal(
+          countValue(preservedProviderPrompt, generatedStyle),
+          1,
+          `${profile.id}/preserved illustration repeated the generated style: ${preservedProviderPrompt}`,
+        );
+        assert.ok(preservedPrefix.diagnostics.removedPositiveDuplicates.includes(generatedStyle));
+      }
+
+      const zImageStyleAlreadyPresent = compileImagePrompt({
+        kind: "portrait",
+        prompt: `Art style: ${generatedStyle}. Centered portrait of Lyra.`,
+        styleProfiles,
+        styleProfileId: "z-image-turbo",
+        generatedStyle,
+      });
+      assert.equal(countValue(zImageStyleAlreadyPresent.prompt, generatedStyle), 1);
+      assert.doesNotMatch(zImageStyleAlreadyPresent.prompt, /Z-Image Turbo prompt that keeps compact narrative/);
+
+      const zImageStyleMissing = compileImagePrompt({
+        kind: "portrait",
+        prompt: "Centered portrait of Lyra.",
+        styleProfiles,
+        styleProfileId: "z-image-turbo",
+        generatedStyle,
+      });
+      assert.equal(countValue(zImageStyleMissing.prompt, generatedStyle), 1);
+
+      const zImageStyleOnlyNegated = compileImagePrompt({
+        kind: "portrait",
+        prompt: `Avoid ${generatedStyle}. Centered portrait of Lyra.`,
+        styleProfiles,
+        styleProfileId: "z-image-turbo",
+        generatedStyle,
+      });
+      assert.equal(countValue(zImageStyleOnlyNegated.prompt, generatedStyle), 1);
+      assert.equal(zImageStyleOnlyNegated.diagnostics.removedPositiveDuplicates.includes(generatedStyle), false);
+
+      const zImageAppearanceMissing = compileImagePrompt({
+        kind: "sprite",
+        prompt: "Single full-body character sprite in an idle pose.",
+        userPositive: appearance,
+        styleProfiles,
+        styleProfileId: "z-image-turbo",
+      });
+      assert.equal(countValue(zImageAppearanceMissing.prompt, appearance), 1);
+
+      const compactBudgetPrompt = [
+        ...Array.from({ length: 40 }, (_, index) => `blue eyes detail ${index}`),
+        `Art style: ornate rococo oil painting`,
+      ].join(", ");
+      for (const profileId of ["anime", "danbooru", "realistic", "painterly"] as const) {
+        const compact = compileImagePrompt({
+          kind: "portrait",
+          prompt: compactBudgetPrompt,
+          styleProfiles,
+          styleProfileId: profileId,
+          generatedStyle: "ornate rococo oil painting",
+        });
+        assert.equal(
+          countValue(compact.prompt, "ornate rococo oil painting"),
+          1,
+          `${profileId} compact prompt lost the configured style: ${compact.prompt}`,
+        );
+      }
+
+      const semicolonNegation = compileImagePrompt({
+        kind: "portrait",
+        prompt: "Centered portrait; avoid ornate rococo oil painting",
+        styleProfiles,
+        styleProfileId: "danbooru",
+        generatedStyle: "ornate rococo oil painting",
+      });
+      assert.equal(countValue(semicolonNegation.prompt, "ornate rococo oil painting"), 1);
+      assert.match(semicolonNegation.negativePrompt, /ornate rococo oil painting/i);
+
+      const embeddedNegation = compileImagePrompt({
+        kind: "portrait",
+        prompt: "Centered portrait, avoid ornate rococo oil painting, blue eyes",
+        styleProfiles,
+        styleProfileId: "anime",
+        generatedStyle: "ornate rococo oil painting",
+      });
+      assert.equal(countValue(embeddedNegation.prompt, "ornate rococo oil painting"), 1);
+      assert.match(embeddedNegation.negativePrompt, /ornate rococo oil painting/i);
+    },
+  },
+  {
+    name: "preserved storyboard prompts retain one configured style through final truncation",
+    async run() {
+      const generatedStyle = "ornate rococo oil painting";
+      const longScene = `${"moonlit forest atmosphere ".repeat(280).slice(0, 6900)} Art direction: ${generatedStyle}.`;
+      const compiled = await buildSceneIllustrationProviderPrompt({
+        chatId: "style-truncation-regression",
+        prompt: "A moonlit forest scene.",
+        artStyle: generatedStyle,
+        preserveFullScenePrompt: true,
+        dynamicPromptGenerator: async () => longScene,
+        styleProfiles: createDefaultImageStyleProfileSettings(),
+        styleProfileId: "z-image-turbo",
+        imgModel: "unused",
+        imgBaseUrl: "",
+        imgApiKey: "",
+      });
+
+      assert.equal(compiled.prompt.length, 7000);
+      assert.equal(compiled.prompt.toLowerCase().split(generatedStyle).length - 1, 1);
+
+      const styleLeadingScene = `Art direction: ${generatedStyle}. ${"moonlit forest atmosphere ".repeat(280)}`;
+      const styleLeading = await buildSceneIllustrationProviderPrompt({
+        chatId: "style-deduplication-regression",
+        prompt: "A moonlit forest scene.",
+        artStyle: generatedStyle,
+        preserveFullScenePrompt: true,
+        dynamicPromptGenerator: async () => styleLeadingScene,
+        styleProfiles: createDefaultImageStyleProfileSettings(),
+        styleProfileId: "z-image-turbo",
+        imgModel: "unused",
+        imgBaseUrl: "",
+        imgApiKey: "",
+      });
+      assert.equal(styleLeading.prompt.toLowerCase().split(generatedStyle).length - 1, 1);
+    },
+  },
+  {
     name: "danbooru illustration prompts preserve generated tags",
     run() {
       const compiled = compileImagePrompt({


### PR DESCRIPTION
## Linked issue

Closes #3728

## Why this change

- Image builders can embed an explicit art style or appearance in the source prompt while also passing the same value separately to the shared compiler, causing duplicated provider-visible prompt content.
- Deduplicating too early can also remove the dedicated style before compact-token or storyboard-character limits discard the source copy, silently losing the configured style.

## What changed

- Detect complete normalized duplicates using the effective prompt grammar so negative clauses are not mistaken for positive style copies.
- Recheck the transformed provider-visible prompt and protect the explicit style when compaction would otherwise remove its only positive copy.
- Limit preserved-storyboard deduplication to source text guaranteed to survive final 7,000-character assembly.
- Add regressions across built-in profiles, image kinds, compact-token limits, semicolon and embedded negative clauses, appearance cues, and storyboard truncation.

## Validation

- [x] `pnpm check` passes locally
- [x] Container (Docker / Podman) built and ran without issue
- [x] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [x] Read and followed `CONTRIBUTING.md`

Automated validation performed:

- `pnpm regression:prompt`
- `pnpm check`

### Manual verification notes

- The reporter manually confirmed that the original Z-Image portrait duplication was removed before the compact/truncation hardening.
- The reporter manually confirmed a Z-Image portrait with an explicit art style shows the style exactly once in the provider prompt.
- The reporter manually confirmed other styles retain their art styles.
- The reporter manually confirmed a long preserved storyboard prompt retains the configured art style after final truncation.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Version/release files updated (only if this PR includes a version bump)

No documentation or release metadata changes are expected because this is an internal prompt-assembly correction.

## UI evidence (if applicable)

Not applicable; no UI changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Improved image prompt compilation to preserve important style and scene details when prompts approach length limits.
  * Reduced repeated style and appearance instructions in generated image prompts for cleaner, more consistent results.
  * Improved handling of preserved scenes, portraits, backgrounds, illustrations, and storyboard prompts during truncation.
  * Ensured configured styles remain represented once, including compact prompts and prompts containing negated or embedded variations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->