### PR TITLE
Fix selector text shaking during Accent Pulse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 
 ### Fixed
 
+- Kept native selector labels visually stable while Accent Pulse is enabled, including Agent Connection Override, Lorebook Prompt Position, and Connection Defaults controls (#3733).
 - Added a clearly labeled avatar upload/replace field above Name in Character Metadata, reusing the same upload and crop flow as the editor portrait so the action is discoverable on desktop and touch devices.
 - Accepted dot or comma decimal input for Connection temperature, top-p, and other generation parameters without truncating fractional values (#3713).
 - Kept mobile Game CYOA choices visible between compact widget rails and exposed a direct host action from the world-map surface to the full hierarchical map editor (#3691).

--- a/packages/client/src/styles/globals.css
+++ b/packages/client/src/styles/globals.css
@@ -1690,15 +1690,22 @@
 }
 
 /* Pulse ticks update root accent variables every 500ms. Keep dense editor reading
-   surfaces on the selected base accent so Chromium does not rerasterize their text
-   on every tick; headers and explicitly animated chrome continue to pulse. */
-[data-marinara-accent-animation] .mari-editor-content {
+   surfaces and native selectors on the selected base accent so Chromium does not
+   rerasterize their text on every tick; explicit accent chrome continues to pulse. */
+[data-marinara-accent-animation] :where(.mari-editor-content, select) {
   --primary: var(--marinara-app-accent-static);
   --ring: var(--marinara-app-accent-static);
   --marinara-app-accent-solid: var(--marinara-app-accent-static);
   --marinara-app-accent-gradient: var(--marinara-app-accent-static-gradient);
   --marinara-chat-chrome-accent: var(--marinara-app-accent-static);
   --marinara-chat-chrome-accent-gradient: var(--marinara-app-accent-static-gradient);
+}
+
+/* Native select text is painted by the platform. Transitioning an inherited
+   accent border can invalidate that text layer and make the label appear to
+   flicker or shift even though its own color is unchanged. */
+[data-marinara-accent-animation] select {
+  transition: none;
 }
 
 .mari-editor-content-inner {

--- a/scripts/regressions/open-issues.regression.ts
+++ b/scripts/regressions/open-issues.regression.ts
@@ -701,8 +701,9 @@ assert.match(
 );
 assert.match(
   globalStyles,
-  /\[data-marinara-accent-animation\] \.mari-editor-content \{[\s\S]*--primary: var\(--marinara-app-accent-static\);[\s\S]*--marinara-chat-chrome-accent: var\(--marinara-app-accent-static\);[\s\S]*\}/u,
+  /\[data-marinara-accent-animation\] :where\(\.mari-editor-content, select\) \{[\s\S]*--primary: var\(--marinara-app-accent-static\);[\s\S]*--marinara-chat-chrome-accent: var\(--marinara-app-accent-static\);[\s\S]*\}/u,
 );
+assert.match(globalStyles, /\[data-marinara-accent-animation\] select \{\s*transition: none;\s*\}/u);
 
 assert.equal(stripLeadingMessageTimestamps("[11.07 15:53] Character: Hello!"), "Character: Hello!");
 assert.equal(stripLeadingMessageTimestamps("[11.07.2026 15:53] Character: Hello!"), "Character: Hello!");


### PR DESCRIPTION
## Linked issue

Closes #3733

## Why this change

Accent Pulse updates shared accent variables every 500 ms. Native select borders and focus tokens inherited those updates, causing Chromium to rerasterize the platform-painted selected text so labels appeared to flicker or shift in Agent Connection Override, Lorebook Prompt Position, and Connection Defaults.

## What changed

- Keep native selectors on the chosen static accent while explicit accent chrome continues to pulse.
- Disable tick-driven transitions on native selects so the platform text layer remains stable.
- Add a regression guard and an Unreleased changelog entry.

## Validation

Automated evidence completed:

- `pnpm --filter @marinara-engine/server exec tsx ../../scripts/regressions/open-issues.regression.ts` — passed
- `pnpm check` — passed
- `git diff --check` — passed

Human verification checklist (intentionally left unchecked):

- [ ] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed `CONTRIBUTING.md`

### Manual verification notes

- Manually enable Accent Pulse and watch Agent Connection Override, Lorebook Prompt Position, and every Connection Defaults selector across several pulse ticks.
- Repeat in light and dark themes and verify selector focus styling remains clear.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Version/release files updated (only if this PR includes a version bump)

`CHANGELOG.md` was updated under Unreleased; no version metadata changed.

## UI evidence (if applicable)

No recording attached; the regression is cadence-dependent and still needs the manual checks above.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented native selector labels from flickering or shifting while Accent Pulse is enabled.
  * Stabilized affected controls, including Agent Connection Override, Lorebook Prompt Position, and Connection Defaults.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->