### PR TITLE
Fix Accent Pulse flicker inside Agent and Lorebook editors

### DIFF
--- a/packages/client/src/styles/globals.css
+++ b/packages/client/src/styles/globals.css
@@ -1689,10 +1689,10 @@
   padding: 1.5rem;
 }
 
-/* Pulse ticks update root accent variables every 500ms. Keep dense editor reading
-   surfaces and native selectors on the selected base accent so Chromium does not
-   rerasterize their text on every tick; explicit accent chrome continues to pulse. */
-[data-marinara-accent-animation] :where(.mari-editor-content, select) {
+/* Pulse ticks update root accent variables every 500ms. Keep task-focused editor
+   shells and native selectors on the selected base accent so animated header or
+   panel chrome cannot make Chromium rerasterize nearby form-control text. */
+[data-marinara-accent-animation] :where(.mari-editor-shell, select) {
   --primary: var(--marinara-app-accent-static);
   --ring: var(--marinara-app-accent-static);
   --marinara-app-accent-solid: var(--marinara-app-accent-static);

--- a/scripts/regressions/open-issues.regression.ts
+++ b/scripts/regressions/open-issues.regression.ts
@@ -701,7 +701,7 @@ assert.match(
 );
 assert.match(
   globalStyles,
-  /\[data-marinara-accent-animation\] :where\(\.mari-editor-content, select\) \{[\s\S]*--primary: var\(--marinara-app-accent-static\);[\s\S]*--marinara-chat-chrome-accent: var\(--marinara-app-accent-static\);[\s\S]*\}/u,
+  /\[data-marinara-accent-animation\] :where\(\.mari-editor-shell, select\) \{[\s\S]*--primary: var\(--marinara-app-accent-static\);[\s\S]*--marinara-chat-chrome-accent: var\(--marinara-app-accent-static\);[\s\S]*\}/u,
 );
 assert.match(globalStyles, /\[data-marinara-accent-animation\] select \{\s*transition: none;\s*\}/u);
 


### PR DESCRIPTION
## Linked issue

Closes #3733

Follow-up to #3734.

## Why this change

#3734 stopped Accent Pulse from transitioning native selectors and fixed Connection Defaults, but Agent Connection Override and Lorebook Prompt Position still shared a Chromium paint layer with animated full-page editor chrome. Accent ticks in the editor header or panels could therefore rerasterize nearby platform-painted selector text even though the selectors themselves used static accent tokens.

The Agent Editor is shared by built-in, downloaded, and custom agents, so the remaining bug also affected Hierarchical Maps.

## What changed

- Move the static Accent Pulse boundary from only the editor body to the entire shared editor shell.
- Keep the existing global native-selector stabilization that already fixed Connection Defaults.
- Update the regression guard to require editor-shell containment.

## Validation

Automated evidence completed:

- `pnpm --filter @marinara-engine/server exec tsx ../../scripts/regressions/open-issues.regression.ts` — passed
- `pnpm check` — passed
- `git diff --check` — passed

Human verification checklist (intentionally left unchecked):

- [ ] Enable Accent Pulse and watch Agent Connection Override for several pulse ticks.
- [ ] Repeat with the Hierarchical Maps agent.
- [ ] Watch Lorebook Prompt Position on desktop and mobile entry controls for several pulse ticks.
- [ ] Confirm Connection Defaults remains stable.
- [ ] Confirm editor focus rings and selected states remain clear in light and dark themes.

## Docs and release impact

The Unreleased changelog entry was added by #3734 and already describes these affected controls. No version metadata changed.

## UI evidence

User verification confirmed the first patch fixed Connection Defaults but not the two shared editor paths. The checks above remain for final manual confirmation of this follow-up.
