### PR TITLE
Release: finalize v2.3.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 
 ## [Unreleased]
 
+## [2.3.3]
+
 ### Added
 
 - Added `CHAT_GENERATION_TIMEOUT_MS` for slow Conversation, Roleplay, and Game providers and `AUTO_UPDATE_ENABLED=false` for persistent launcher update opt-out on Windows, macOS/Linux, and Termux, without disabling manual updates (#3730).
@@ -11,21 +13,17 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 - Added compatibility-aware official Agent catalog selection so each Engine major installs and updates only from its matching catalog lane (#3712).
 - Added configurable pauses between generated TTS dialogue lines, with the saved preference shared across playback sessions (#3718).
 
-### Fixed
-
-- Kept native selector labels visually stable while Accent Pulse is enabled, including Agent Connection Override, Lorebook Prompt Position, and Connection Defaults controls (#3733).
-- Added a clearly labeled avatar upload/replace field above Name in Character Metadata, reusing the same upload and crop flow as the editor portrait so the action is discoverable on desktop and touch devices.
-- Accepted dot or comma decimal input for Connection temperature, top-p, and other generation parameters without truncating fractional values (#3713).
-- Kept mobile Game CYOA choices visible between compact widget rails and exposed a direct host action from the world-map surface to the full hierarchical map editor (#3691).
-
-## [2.3.3]
-
 ### Changed
 
 - Synchronized the stable release identity as v2.3.3 across the Engine, PWA manifest, Windows installer, Android bootstrap APK, update checks, and Home release link. Android uses `versionName` `2.3.3` with `versionCode` `38` so it updates over every previously published APK.
 
 ### Fixed
 
+- Kept native selector labels and their shared Agent and Lorebook editor shells visually stable while Accent Pulse is enabled, including Hierarchical Maps, Agent Connection Override, Lorebook Prompt Position, and Connection Defaults controls (#3733).
+- Added a clearly labeled avatar upload/replace field above Name in Character Metadata, reusing the same upload and crop flow as the editor portrait so the action is discoverable on desktop and touch devices.
+- Accepted dot or comma decimal input for Connection temperature, top-p, and other generation parameters without truncating fractional values (#3713).
+- Kept mobile Game CYOA choices visible between compact widget rails and exposed a direct host action from the world-map surface to the full hierarchical map editor (#3691).
+- Prevented duplicate style and appearance instructions in image-generation prompts while preserving configured styles through compact-token and final prompt-length limits (#3728).
 - Stopped the v2.3.2 capability migration from selecting Hierarchical Maps in every Roleplay, Visual Novel, and Game chat. A one-time correction removes only the accidental selections from chats without existing map definitions or snapshots, preserving intentional Maps usage and all other agent selections (#3723).
 - Made Hierarchical Maps obey each chat's **Enable Agents** master toggle across Roleplay and Game UI, prompt generation, lorebook previews, retries, tracker state patches, session carryover, and checkpoints. Disabled chats no longer initialize or call Maps services.
 - Quarantined incompatible Hierarchical Maps 1.0.x runtimes before their database adapter can load, preventing the recurring `t.select is not a function` crash while leaving compatible package updates available.

--- a/e2e/core-flows.e2e.ts
+++ b/e2e/core-flows.e2e.ts
@@ -80,10 +80,11 @@ test("What's New opens once for each Marinara Engine version", async ({ page }) 
 
   const announcement = page.getByRole("dialog", { name: "What's New?" });
   await expect(announcement).toBeVisible();
-  await expect(announcement.getByText(`Version ${APP_VERSION}`)).toBeVisible();
-  await expect(announcement.getByRole("heading", { name: "A quick patch with bug fixes!" })).toBeVisible();
+  await expect(announcement.getByText(`Version ${APP_VERSION}`, { exact: true })).toBeVisible();
+  await expect(announcement.getByRole("heading", { name: "We fixed the most glaring issues." })).toBeVisible();
+  await expect(announcement.getByText(/We’re sorry for the inconvenience/)).toBeVisible();
   await expect(announcement.getByText("Marinara Engine has been updated.", { exact: true })).toHaveCount(0);
-  await expect(announcement.getByText("Hierarchical Maps")).toHaveCount(0);
+  await expect(announcement.getByText(/Hierarchical Maps/)).toBeVisible();
   await expect(announcement.getByText("Tactical Combat Mode in Games")).toHaveCount(0);
   await expect(announcement.getByRole("link", { name: "View release" })).toHaveAttribute(
     "href",

--- a/packages/client/src/components/modals/WhatsNewModal.tsx
+++ b/packages/client/src/components/modals/WhatsNewModal.tsx
@@ -27,9 +27,9 @@ type ReleaseAnnouncement = {
 // entry still get a one-time update notice and a link to their full release.
 const RELEASE_ANNOUNCEMENTS: Record<string, ReleaseAnnouncement> = {
   "2.3.3": {
-    headline: "A critical stability update.",
+    headline: "We fixed the most glaring issues.",
     intro:
-      "This update repairs Hierarchical Maps activation and upgrade crashes, restores reliable Game message sending, and clears stale Character panel filters so your full library is visible again.",
+      "We’re sorry for the inconvenience caused by the last update. Version 2.3.3 fixes the most disruptive Hierarchical Maps, Game message sending, Character library, and Accent Pulse problems, along with several smaller regressions.",
     highlights: [],
   },
   "2.3.2": {

--- a/packages/client/src/components/modals/WhatsNewModal.tsx
+++ b/packages/client/src/components/modals/WhatsNewModal.tsx
@@ -29,7 +29,7 @@ const RELEASE_ANNOUNCEMENTS: Record<string, ReleaseAnnouncement> = {
   "2.3.3": {
     headline: "We fixed the most glaring issues.",
     intro:
-      "We’re sorry for the inconvenience caused by the last update. Version 2.3.3 fixes the most disruptive Hierarchical Maps, Game message sending, Character library, and Accent Pulse problems, along with several smaller regressions.",
+      "We’re sorry for the inconvenience caused by the last update. This release fixes the most disruptive Hierarchical Maps, Game message sending, Character library, and Accent Pulse problems, along with several smaller regressions.",
     highlights: [],
   },
   "2.3.2": {


### PR DESCRIPTION
## Linked issue

Closes #3737

## Why

v2.3.3 needs complete, user-facing release notes before the validated staging tree is promoted to main and published. The announcement should acknowledge the disruption from v2.3.2, and every merged staging fix must appear in the release-notes source of truth.

## What changed

- Updated the v2.3.3 What's New message to name the most disruptive fixes and apologize for the inconvenience.
- Folded all staging release notes into the v2.3.3 section.
- Added the previously omitted image-prompt deduplication fix and the final Accent Pulse editor-shell coverage.
- Confirmed generated Credits are current at 51 contributors.

## Automated validation

- `pnpm credits:sync`
- `pnpm credits:check`
- `pnpm version:sync -- --android-version-code 38`
- `pnpm version:check`
- `git diff --check`

## Release validation still required

- [ ] Run the full repository check and focused regressions.
- [ ] Build and verify the production application and release packaging.
- [ ] Verify update/install paths for Windows, macOS, Linux, Android/Termux, and iPhone/iPad PWA clients.
- [ ] Verify staging and main container tags.
- [ ] Verify the release ZIP, Windows EXE, and Android bootstrap APK.

## Manual verification

- [ ] Manually open What's New on desktop and mobile and verify the v2.3.3 copy fits.
- [ ] Manually verify release downloads after publication.
