### PR TITLE
fix: contain existing avatars in Character Metadata editor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 
 ## [Unreleased]
 
+### Fixed
+
+- Kept existing cropped Character avatars contained inside the Metadata upload preview instead of allowing the image to cover the card editor (#3741).
+
 ## [2.3.3]
 
 ### Added

--- a/packages/client/src/components/characters/CharacterEditor.tsx
+++ b/packages/client/src/components/characters/CharacterEditor.tsx
@@ -1357,7 +1357,7 @@ function MetadataTab({
         >
           <span
             className={cn(
-              "flex h-16 w-16 shrink-0 items-center justify-center overflow-hidden rounded-xl border border-[var(--border)] bg-[var(--background)]",
+              "relative flex h-16 w-16 shrink-0 items-center justify-center overflow-hidden rounded-xl border border-[var(--border)] bg-[var(--background)]",
               !avatarPreview && "mari-avatar-placeholder mari-avatar-placeholder--character",
             )}
           >

--- a/scripts/regressions/open-issues.regression.ts
+++ b/scripts/regressions/open-issues.regression.ts
@@ -682,6 +682,11 @@ assert.doesNotMatch(agentEditorSource, /fetch\(["']\/api\/game-assets\/pick-loca
 assert.match(agentEditorSource, /api\.post<[^>]+>\(["']\/game-assets\/pick-local-music-folder["']\)/u);
 assert.match(characterEditorSource, /avatar preview/u);
 assert.match(characterEditorSource, /getAvatarCropStyle/u);
+assert.match(
+  characterEditorSource,
+  /"relative flex h-16 w-16 shrink-0 items-center justify-center overflow-hidden rounded-xl/u,
+  "The Metadata avatar preview must contain absolutely positioned saved crops",
+);
 assert.match(gameJournalSource, /data-game-journal-scroll/u);
 assert.match(gameSurfaceSource, /h-\[min\(42rem,calc\(100dvh-6rem\)\)\]/u);
 assert.match(gameAssetHooksSource, /export function useGameAssetManifest/u);


### PR DESCRIPTION
## Why

In v2.3.3, opening a Character Card with a current-format cropped avatar can make the avatar escape the new Metadata preview and cover the entire editor. The shared crop renderer uses absolute positioning, but this newly added preview did not establish a positioning context.

Fixes #3741.

## What changed

- Anchor the Metadata avatar preview with relative positioning.
- Add a regression guard for the required crop container.
- Record the fix under Unreleased.

## Test plan

- [ ] Manually open a Character Card with an existing current-format cropped avatar and verify the image stays inside the Metadata preview.
- [ ] Manually confirm the Character Card remains editable on desktop and mobile layouts.
- [ ] Run pnpm regression:issues.
- [ ] Run pnpm check.

## Proof so far

- pnpm regression:issues passed locally.
- pnpm check passed locally, including TypeScript, ESLint, production build, and PWA generation.
- Browser click-through was attempted, but the available browser connection failed before attaching. Manual desktop and mobile confirmation remains required.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed cropped Character avatars in the Metadata upload preview so they remain contained within the preview card instead of covering the editor.
  * Added regression coverage to help prevent this display issue from recurring.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->