### PR TITLE
fix: contain existing avatars in Character Metadata editor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 
 ## [Unreleased]
 
+### Fixed
+
+- Kept existing cropped Character avatars contained inside the Metadata upload preview instead of allowing the image to cover the card editor (#3741).
+
 ## [2.3.3]
 
 ### Added

--- a/packages/client/src/components/characters/CharacterEditor.tsx
+++ b/packages/client/src/components/characters/CharacterEditor.tsx
@@ -1357,7 +1357,7 @@ function MetadataTab({
         >
           <span
             className={cn(
-              "flex h-16 w-16 shrink-0 items-center justify-center overflow-hidden rounded-xl border border-[var(--border)] bg-[var(--background)]",
+              "relative flex h-16 w-16 shrink-0 items-center justify-center overflow-hidden rounded-xl border border-[var(--border)] bg-[var(--background)]",
               !avatarPreview && "mari-avatar-placeholder mari-avatar-placeholder--character",
             )}
           >

--- a/scripts/regressions/open-issues.regression.ts
+++ b/scripts/regressions/open-issues.regression.ts
@@ -682,6 +682,11 @@ assert.doesNotMatch(agentEditorSource, /fetch\(["']\/api\/game-assets\/pick-loca
 assert.match(agentEditorSource, /api\.post<[^>]+>\(["']\/game-assets\/pick-local-music-folder["']\)/u);
 assert.match(characterEditorSource, /avatar preview/u);
 assert.match(characterEditorSource, /getAvatarCropStyle/u);
+assert.match(
+  characterEditorSource,
+  /"relative flex h-16 w-16 shrink-0 items-center justify-center overflow-hidden rounded-xl/u,
+  "The Metadata avatar preview must contain absolutely positioned saved crops",
+);
 assert.match(gameJournalSource, /data-game-journal-scroll/u);
 assert.match(gameSurfaceSource, /h-\[min\(42rem,calc\(100dvh-6rem\)\)\]/u);
 assert.match(gameAssetHooksSource, /export function useGameAssetManifest/u);


### PR DESCRIPTION
## Why

The v2.3.3 Character Metadata avatar preview lacked a positioning context. Existing current-format cropped avatars are absolutely positioned by design, so the image could escape the preview and cover the entire editor.

Promotes the already validated staging fix from #3742. Closes #3741.

## What changed

- Keep saved cropped avatars inside the 64 by 64 pixel Metadata preview.
- Add a regression guard for the required positioning context.
- Record the patch under Unreleased without changing the 2.3.3 version.

## Test plan

- [ ] Manually open a Character Card with an existing current-format cropped avatar and verify the image stays inside the Metadata preview.
- [ ] Manually confirm the Character Card remains editable on desktop and mobile layouts.
- [ ] Run pnpm regression:issues.
- [ ] Run pnpm check.

## Validation

- pnpm regression:issues passed locally on #3742.
- pnpm check passed locally on #3742.
- GitHub pnpm-validate and container-build-test passed on #3742.
- CodeRabbit completed with no actionable review threads.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed cropped character avatars in the metadata upload preview so they remain contained within the card editor instead of covering it.
  * Improved the avatar preview layout when uploading or replacing an avatar.

* **Tests**
  * Added regression coverage to verify the corrected avatar preview behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->