### PR TITLE
feat: redesign tracker world state panel

### DIFF
--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -12,6 +12,7 @@
   },
   "dependencies": {
     "@dnd-kit/core": "6.3.1",
+    "@fontsource/share-tech-mono": "5.2.7",
     "@marinara-engine/shared": "workspace:*",
     "@tanstack/react-query": "^5.100.9",
     "class-variance-authority": "^0.7.1",

--- a/packages/client/src/components/chat/RoleplayHUD.tsx
+++ b/packages/client/src/components/chat/RoleplayHUD.tsx
@@ -1343,7 +1343,6 @@ function CombinedWorldWidget({
       ? "text-[var(--muted-foreground)]/70"
       : weatherStyle.color;
   const temperatureDisplay = getTemperatureGaugeDisplay(temperature, trackerTemperatureUnit);
-  const tempNumeric = temperatureDisplay.numericCelsius;
   const tempColor = temperatureDisplay.color;
   const sideLayout = layout === "left" || layout === "right";
 
@@ -1395,7 +1394,7 @@ function CombinedWorldWidget({
               variant="solid-bulb"
               className="h-4 w-[0.625rem] shrink-0"
             />
-            {tempNumeric !== null && (
+            {temperatureDisplay.isPure && (
               <span
                 className="shrink-0 text-[0.5rem] font-bold leading-none md:text-[0.5625rem]"
                 style={{ color: tempColor }}

--- a/packages/client/src/components/chat/RoleplayHUD.tsx
+++ b/packages/client/src/components/chat/RoleplayHUD.tsx
@@ -22,21 +22,21 @@ import { cn } from "../../lib/utils";
 import { api } from "../../lib/api-client";
 import type { AgentFailure } from "../../lib/agent-failures";
 import { TrackerPanelIcon } from "../ui/TrackerPanelIcon";
+import { WorldCalendarIcon } from "../ui/WorldCalendarIcon";
+import { WorldClockIcon, WorldThermometerIcon } from "../ui/WorldStateInstruments";
 import { useGameStateStore } from "../../stores/game-state.store";
 import { useAgentStore } from "../../stores/agent.store";
 import { useAgentConfigs, useCustomAgentRuns, type AgentConfigRow } from "../../hooks/use-agents";
 import { discardPendingGameStatePatch, useGameStatePatcher } from "../../hooks/use-game-state-patcher";
 import { useUIStore } from "../../stores/ui.store";
 import {
+  classifyWorldWeather,
   getLocationPinColor,
-  getTemperatureColor,
   getTemperatureGaugeDisplay,
-  getTemperatureKeywordHint,
-  getWeatherIconColor,
-  getWorldDateIconColor,
-  getWorldTimeIconColor,
-  parseTemperatureValue,
-} from "../../features/tracker-panel/lib/world-state-display";
+  getWorldDateDisplay,
+  getWorldTimeDisplay,
+  type WorldWeatherFamily,
+} from "../../lib/world-state-helpers";
 import { TrackerLockProvider } from "../../features/tracker-panel/components/TrackerLockContext";
 import { useTrackerFieldLockUpdater } from "../../features/tracker-panel/hooks/use-tracker-field-lock-updater";
 import { ROLEPLAY_POPOVER_SCROLL_AREA, ROLEPLAY_POPOVER_SHELL } from "./roleplay-popover-styles";
@@ -1328,28 +1328,23 @@ function CombinedWorldWidget({
 }) {
   const [open, setOpen] = useState(false);
   const buttonRef = useRef<HTMLButtonElement>(null);
-  const weatherEmoji = weather ? getWeatherEmoji(weather) : "🌤️";
+  const weatherFamily = classifyWorldWeather(weather);
+  const weatherStyle = HUD_WEATHER_STYLES[weatherFamily];
+  const weatherEmoji = weatherStyle.emoji;
   const pinColor = getLocationPinColor(location);
-  const dateColor = getWorldDateIconColor(date);
-  const timeColor = getWorldTimeIconColor(time);
-  const weatherColor = getWeatherIconColor(weather);
+  const dateDisplay = getWorldDateDisplay(date);
+  const timeDisplay = getWorldTimeDisplay(time);
+  const timeColor =
+    timeDisplay.kind === "empty"
+      ? "text-[var(--muted-foreground)]/70"
+      : HUD_TIME_COLORS[timeDisplay.timeOfDay];
+  const weatherColor =
+    weatherFamily === "atmosphere" && !weather
+      ? "text-[var(--muted-foreground)]/70"
+      : weatherStyle.color;
   const temperatureDisplay = getTemperatureGaugeDisplay(temperature, trackerTemperatureUnit);
-  const tempNumeric = temperature ? parseTemperatureValue(temperature) : null;
-  const temp = tempNumeric ?? (temperature ? getTemperatureKeywordHint(temperature) : null);
-  const tempColor = getTemperatureColor(temperature);
-
-  // Dynamic calendar: show day number
-  const dateParts = date ? parseDateLabel(date) : { day: null, month: null };
-
-  // Dynamic clock: compute hand angles
-  const hour = time ? extractHourFromTime(time) : -1;
-  const minute = time ? parseMinutes(time) : 0;
-  const hourAngle = hour >= 0 ? (hour % 12) * 30 + minute * 0.5 : 0;
-  const minuteAngle = minute * 6;
-
-  const tempFill =
-    temperatureDisplay.percent == null ? 0.3 : Math.max(0, Math.min(1, temperatureDisplay.percent / 100));
-  const tempFillColor = temperatureDisplay.color;
+  const tempNumeric = temperatureDisplay.numericCelsius;
+  const tempColor = temperatureDisplay.color;
   const sideLayout = layout === "left" || layout === "right";
 
   return (
@@ -1374,96 +1369,16 @@ function CombinedWorldWidget({
         {/* Mini calendar with day number */}
         {!sideLayout && (
           <>
-            <svg viewBox="0 0 20 20" fill="none" className={cn("shrink-0 h-4 w-4 drop-shadow-sm", dateColor)}>
-              <rect x="2" y="4" width="16" height="14" rx="2" stroke="currentColor" strokeWidth="1.5" opacity="0.7" />
-              <line x1="2" y1="8" x2="18" y2="8" stroke="currentColor" strokeWidth="1.2" opacity="0.5" />
-              <line
-                x1="6"
-                y1="2"
-                x2="6"
-                y2="5.5"
-                stroke="currentColor"
-                strokeWidth="1.5"
-                strokeLinecap="round"
-                opacity="0.7"
-              />
-              <line
-                x1="14"
-                y1="2"
-                x2="14"
-                y2="5.5"
-                stroke="currentColor"
-                strokeWidth="1.5"
-                strokeLinecap="round"
-                opacity="0.7"
-              />
-              {dateParts.day && (
-                <text
-                  x="10"
-                  y="15.5"
-                  textAnchor="middle"
-                  fill="currentColor"
-                  fontSize="7"
-                  fontWeight="700"
-                  opacity="0.95"
-                >
-                  {dateParts.day}
-                </text>
-              )}
-            </svg>
+            <WorldCalendarIcon
+              day={dateDisplay.day}
+              className={cn("h-4 w-4 shrink-0 drop-shadow-sm", dateDisplay.iconColor)}
+            />
 
-            {/* Mini clock with dynamic hands */}
-            <svg viewBox="0 0 20 20" fill="none" className={cn("shrink-0 h-4 w-4 drop-shadow-sm", timeColor)}>
-              <circle cx="10" cy="10" r="8" stroke="currentColor" strokeWidth="1.5" opacity="0.7" />
-              {hour >= 0 ? (
-                <>
-                  <line
-                    x1="10"
-                    y1="10"
-                    x2={10 + 4.2 * Math.sin((hourAngle * Math.PI) / 180)}
-                    y2={10 - 4.2 * Math.cos((hourAngle * Math.PI) / 180)}
-                    stroke="currentColor"
-                    strokeWidth="1.8"
-                    strokeLinecap="round"
-                    opacity="0.95"
-                  />
-                  <line
-                    x1="10"
-                    y1="10"
-                    x2={10 + 5.8 * Math.sin((minuteAngle * Math.PI) / 180)}
-                    y2={10 - 5.8 * Math.cos((minuteAngle * Math.PI) / 180)}
-                    stroke="currentColor"
-                    strokeWidth="1.2"
-                    strokeLinecap="round"
-                    opacity="0.8"
-                  />
-                </>
-              ) : (
-                <>
-                  <line
-                    x1="10"
-                    y1="10"
-                    x2="10"
-                    y2="5.5"
-                    stroke="currentColor"
-                    strokeWidth="1.8"
-                    strokeLinecap="round"
-                    opacity="0.95"
-                  />
-                  <line
-                    x1="10"
-                    y1="10"
-                    x2="14"
-                    y2="10"
-                    stroke="currentColor"
-                    strokeWidth="1.2"
-                    strokeLinecap="round"
-                    opacity="0.8"
-                  />
-                </>
-              )}
-              <circle cx="10" cy="10" r="1" fill="currentColor" opacity="0.95" />
-            </svg>
+            <WorldClockIcon
+              display={timeDisplay}
+              variant="monochrome"
+              className={cn("h-4 w-4 shrink-0 drop-shadow-sm", timeColor)}
+            />
 
             {/* Weather emoji */}
             <span
@@ -1475,32 +1390,16 @@ function CombinedWorldWidget({
               {weatherEmoji}
             </span>
 
-            {/* Mini thermometer with fill — vivid color & fill level changes dynamically */}
-            <svg viewBox="0 0 10 20" fill="none" className="shrink-0 h-4 w-[0.625rem]">
-              <rect
-                x="3"
-                y="1"
-                width="4"
-                height="13"
-                rx="2"
-                stroke={tempFillColor}
-                strokeWidth="1.2"
-                fill="none"
-                opacity={temp !== null ? 1 : 0.3}
-              />
-              <rect
-                x="3.8"
-                y={1 + 12 * (1 - tempFill)}
-                width="2.4"
-                height={12 * tempFill + 1}
-                rx="1"
-                fill={tempFillColor}
-                opacity={temp !== null ? 0.9 : 0.2}
-              />
-              <circle cx="5" cy="17" r="2.5" fill={tempFillColor} opacity={temp !== null ? 1 : 0.25} />
-            </svg>
+            <WorldThermometerIcon
+              display={temperatureDisplay}
+              variant="solid-bulb"
+              className="h-4 w-[0.625rem] shrink-0"
+            />
             {tempNumeric !== null && (
-              <span className={cn("text-[0.5rem] md:text-[0.5625rem] font-bold leading-none shrink-0", tempColor)}>
+              <span
+                className="shrink-0 text-[0.5rem] font-bold leading-none md:text-[0.5625rem]"
+                style={{ color: tempColor }}
+              >
                 {temperatureDisplay.label}
               </span>
             )}
@@ -1531,7 +1430,7 @@ function CombinedWorldWidget({
             onUpdateWorldCustomFields={onUpdateWorldCustomFields}
             weatherEmoji={weatherEmoji}
             pinColor={pinColor}
-            dateColor={dateColor}
+            dateColor={dateDisplay.iconColor}
             timeColor={timeColor}
             weatherColor={weatherColor}
             tempColor={tempColor}
@@ -1549,66 +1448,31 @@ function CombinedWorldWidget({
 // Helpers
 // ═══════════════════════════════════════════════
 
-function parseDateLabel(date: string): { day: string | null; month: string | null } {
-  const numMatch = date.match(/(\d+)/);
-  const day = numMatch ? numMatch[1] : null;
-  const words = date
-    .replace(/\d+(st|nd|rd|th)?/gi, "")
-    .split(/[\s,/.-]+/)
-    .filter((w) => w.length > 2);
-  const month = words[0]?.slice(0, 3) ?? null;
-  return { day, month };
-}
+const HUD_WEATHER_STYLES: Record<WorldWeatherFamily, { emoji: string; color: string }> = {
+  thunder: { emoji: "⛈️", color: "text-violet-300" },
+  blizzard: { emoji: "🌨️", color: "text-sky-300" },
+  "heavy-rain": { emoji: "🌧️", color: "text-blue-300" },
+  rain: { emoji: "🌦️", color: "text-cyan-300" },
+  hail: { emoji: "🧊", color: "text-sky-200" },
+  snow: { emoji: "❄️", color: "text-sky-300" },
+  fog: { emoji: "🌫️", color: "text-zinc-300" },
+  sand: { emoji: "🏜️", color: "text-amber-300" },
+  ash: { emoji: "🌋", color: "text-stone-300" },
+  fire: { emoji: "🔥", color: "text-red-400" },
+  wind: { emoji: "💨", color: "text-teal-300" },
+  blossom: { emoji: "🌸", color: "text-[var(--marinara-chat-chrome-panel-text)]" },
+  aurora: { emoji: "🌌", color: "text-[var(--marinara-chat-chrome-panel-text)]" },
+  cloud: { emoji: "☁️", color: "text-zinc-300" },
+  clear: { emoji: "☀️", color: "text-yellow-300" },
+  heat: { emoji: "🥵", color: "text-red-400" },
+  cold: { emoji: "🥶", color: "text-sky-300" },
+  atmosphere: { emoji: "🌤️", color: "text-sky-300" },
+};
 
-function extractHourFromTime(time: string): number {
-  const t = time.toLowerCase();
-  const m24 = t.match(/\b(\d{1,2})[:.h](\d{2})\b/);
-  if (m24) {
-    let h = parseInt(m24[1]!, 10);
-    if (t.includes("pm") && h < 12) h += 12;
-    if (t.includes("am") && h === 12) h = 0;
-    if (h >= 0 && h < 24) return h;
-  }
-  const mAP = t.match(/\b(\d{1,2})\s*(am|pm)\b/);
-  if (mAP) {
-    let h = parseInt(mAP[1]!, 10);
-    if (mAP[2] === "pm" && h < 12) h += 12;
-    if (mAP[2] === "am" && h === 12) h = 0;
-    if (h >= 0 && h < 24) return h;
-  }
-  if (t.includes("midnight")) return 0;
-  if (t.includes("dawn") || t.includes("sunrise")) return 6;
-  if (t.includes("morning")) return 9;
-  if (t.includes("noon") || t.includes("midday")) return 12;
-  if (t.includes("afternoon")) return 15;
-  if (t.includes("dusk") || t.includes("sunset") || t.includes("evening")) return 18;
-  if (t.includes("night")) return 22;
-  return -1;
-}
-
-function parseMinutes(time: string): number {
-  const m = time.match(/\b\d{1,2}[:.h](\d{2})\b/);
-  return m ? parseInt(m[1]!, 10) : 0;
-}
-
-function getWeatherEmoji(weather: string): string {
-  const w = weather.toLowerCase();
-  if (w.includes("thunder") || w.includes("lightning")) return "⛈️";
-  if (w.includes("blizzard")) return "🌨️";
-  if (w.includes("heavy rain") || w.includes("downpour") || w.includes("storm")) return "🌧️";
-  if (w.includes("rain") || w.includes("drizzle") || w.includes("shower")) return "🌦️";
-  if (w.includes("hail")) return "🧊";
-  if (w.includes("snow") || w.includes("sleet") || w.includes("frost")) return "❄️";
-  if (w.includes("fog") || w.includes("mist") || w.includes("haze")) return "🌫️";
-  if (w.includes("sand") || w.includes("dust")) return "🏜️";
-  if (w.includes("ash") || w.includes("volcanic") || w.includes("smoke")) return "🌋";
-  if (w.includes("ember") || w.includes("fire") || w.includes("inferno")) return "🔥";
-  if (w.includes("wind") || w.includes("breez") || w.includes("gust")) return "💨";
-  if (w.includes("cherry") || w.includes("blossom") || w.includes("petal")) return "🌸";
-  if (w.includes("aurora") || w.includes("northern light")) return "🌌";
-  if (w.includes("cloud") || w.includes("overcast") || w.includes("grey") || w.includes("gray")) return "☁️";
-  if (w.includes("clear") || w.includes("sunny") || w.includes("bright")) return "☀️";
-  if (w.includes("hot") || w.includes("swelter")) return "🥵";
-  if (w.includes("cold") || w.includes("freez")) return "🥶";
-  return "🌤️";
-}
+const HUD_TIME_COLORS: Record<ReturnType<typeof getWorldTimeDisplay>["timeOfDay"], string> = {
+  dawn: "text-amber-300",
+  day: "text-yellow-300",
+  dusk: "text-orange-400",
+  night: "text-indigo-300",
+  unknown: "text-amber-300",
+};

--- a/packages/client/src/components/chat/RoleplayHUDPanels.tsx
+++ b/packages/client/src/components/chat/RoleplayHUDPanels.tsx
@@ -1575,7 +1575,7 @@ export function CombinedWorldPanel({
           onToggleLock={weatherLock.onToggle}
         />
         <WorldFieldRow
-          icon={<Thermometer size="0.8125rem" className={tempColor} />}
+          icon={<Thermometer size="0.8125rem" style={{ color: tempColor }} />}
           label="Temperature"
           value={temperature}
           onSave={onSaveTemperature}

--- a/packages/client/src/components/layout/TrackerDataSidebar.tsx
+++ b/packages/client/src/components/layout/TrackerDataSidebar.tsx
@@ -1,1 +1,3 @@
+import "../../features/tracker-panel/tracker-font.css";
+
 export { TrackerDataSidebar } from "../../features/tracker-panel/components/TrackerDataSidebar";

--- a/packages/client/src/components/ui/WorldCalendarIcon.tsx
+++ b/packages/client/src/components/ui/WorldCalendarIcon.tsx
@@ -1,0 +1,33 @@
+export function WorldCalendarIcon({ day, className }: { day: string | null; className?: string }) {
+  return (
+    <svg aria-hidden="true" viewBox="0 0 20 20" fill="none" className={className}>
+      <rect x="2" y="4" width="16" height="14" rx="2" stroke="currentColor" strokeWidth="1.5" opacity="0.7" />
+      <line x1="2" y1="8" x2="18" y2="8" stroke="currentColor" strokeWidth="1.2" opacity="0.5" />
+      <line
+        x1="6"
+        y1="2"
+        x2="6"
+        y2="5.5"
+        stroke="currentColor"
+        strokeWidth="1.5"
+        strokeLinecap="round"
+        opacity="0.7"
+      />
+      <line
+        x1="14"
+        y1="2"
+        x2="14"
+        y2="5.5"
+        stroke="currentColor"
+        strokeWidth="1.5"
+        strokeLinecap="round"
+        opacity="0.7"
+      />
+      {day && (
+        <text x="10" y="15.5" textAnchor="middle" fill="currentColor" fontSize="7" fontWeight="700" opacity="0.95">
+          {day}
+        </text>
+      )}
+    </svg>
+  );
+}

--- a/packages/client/src/components/ui/WorldStateInstruments.tsx
+++ b/packages/client/src/components/ui/WorldStateInstruments.tsx
@@ -1,0 +1,100 @@
+export function WorldClockIcon({
+  display,
+  variant,
+  className,
+}: {
+  display: { hour: number | null; minute: number | null };
+  variant: "monochrome" | "accented";
+  className?: string;
+}) {
+  const hasTime = display.hour !== null && display.minute !== null;
+  const hour = display.hour ?? 0;
+  const minute = display.minute ?? 0;
+  const hourAngle = (hour % 12) * 30 + minute * 0.5;
+  const minuteAngle = minute * 6;
+  const rimColor = variant === "accented" ? "var(--muted-foreground)" : "currentColor";
+  const minuteColor = variant === "accented" ? "var(--primary)" : "currentColor";
+
+  return (
+    <svg aria-hidden="true" viewBox="0 0 20 20" fill="none" className={className}>
+      <circle cx="10" cy="10" r="8" stroke={rimColor} strokeWidth="1.5" opacity="0.7" />
+      <line
+        x1="10"
+        y1="10"
+        x2={hasTime ? 10 + 4.2 * Math.sin((hourAngle * Math.PI) / 180) : 10}
+        y2={hasTime ? 10 - 4.2 * Math.cos((hourAngle * Math.PI) / 180) : 5.5}
+        stroke="currentColor"
+        strokeWidth="1.8"
+        strokeLinecap="round"
+        opacity="0.95"
+      />
+      <line
+        x1="10"
+        y1="10"
+        x2={hasTime ? 10 + 5.8 * Math.sin((minuteAngle * Math.PI) / 180) : 14}
+        y2={hasTime ? 10 - 5.8 * Math.cos((minuteAngle * Math.PI) / 180) : 10}
+        stroke={minuteColor}
+        strokeWidth="1.2"
+        strokeLinecap="round"
+        opacity="0.8"
+      />
+      <circle cx="10" cy="10" r="1" fill="currentColor" opacity="0.95" />
+    </svg>
+  );
+}
+
+export function WorldThermometerIcon({
+  display,
+  variant,
+  className,
+}: {
+  display: { percent: number; color: string; value: number | null };
+  variant: "solid-bulb" | "outline-bulb";
+  className?: string;
+}) {
+  const hasValue = display.value !== null;
+  const fill = display.percent / 100;
+  const fillHeight = 12 * fill + 1;
+  const fillY = 1 + 12 * (1 - fill);
+  const solidBulb = variant === "solid-bulb";
+
+  return (
+    <svg
+      aria-hidden="true"
+      viewBox="0 0 10 20"
+      fill="none"
+      className={className}
+      opacity={!solidBulb && !hasValue ? 0.45 : undefined}
+    >
+      <rect
+        x="3"
+        y="1"
+        width="4"
+        height="13"
+        rx="2"
+        fill="none"
+        stroke={display.color}
+        strokeWidth="1.2"
+        opacity={solidBulb ? (hasValue ? 1 : 0.3) : undefined}
+      />
+      <rect
+        x="3.8"
+        y={fillY}
+        width="2.4"
+        height={fillHeight}
+        rx="1"
+        fill={display.color}
+        opacity={solidBulb ? (hasValue ? 0.9 : 0.2) : 0.9}
+      />
+      <circle
+        cx="5"
+        cy="17"
+        r="2.5"
+        fill={solidBulb ? display.color : "none"}
+        stroke={solidBulb ? undefined : display.color}
+        strokeWidth={solidBulb ? undefined : 1.2}
+        opacity={solidBulb ? (hasValue ? 1 : 0.25) : undefined}
+      />
+    </svg>
+  );
+}

--- a/packages/client/src/features/tracker-panel/components/TrackerDataSidebar.tsx
+++ b/packages/client/src/features/tracker-panel/components/TrackerDataSidebar.tsx
@@ -158,7 +158,7 @@ export function TrackerDataSidebar({ fillHeight = false }: { fillHeight?: boolea
       )}
       style={trackerPanelSurfaceStyle}
     >
-      <div className="pointer-events-none absolute inset-0 z-0 opacity-[0.08] [background-image:linear-gradient(color-mix(in_srgb,var(--foreground)_12%,transparent)_1px,transparent_1px),linear-gradient(90deg,color-mix(in_srgb,var(--foreground)_9%,transparent)_1px,transparent_1px)] [background-size:8px_8px]" />
+      <div className="pointer-events-none absolute inset-0 z-0 opacity-[0.11] [background-image:linear-gradient(color-mix(in_srgb,var(--foreground)_12%,transparent)_1px,transparent_1px),linear-gradient(90deg,color-mix(in_srgb,var(--foreground)_9%,transparent)_1px,transparent_1px)] [background-size:8px_8px]" />
       <TrackerLockProvider
         fieldLocks={fieldLocks}
         hiddenTrackerFields={hiddenTrackerFields}

--- a/packages/client/src/features/tracker-panel/components/sections/WorldDateTimeTiles.tsx
+++ b/packages/client/src/features/tracker-panel/components/sections/WorldDateTimeTiles.tsx
@@ -1,157 +1,157 @@
-import { Clock } from "lucide-react";
 import { cn } from "../../../../lib/utils";
-import { getWorldDateDisplay, getWorldTimeDisplay, type WorldDateDisplay } from "../../lib/world-state-display";
-import { FittedText } from "../controls/InlineControls";
+import { WorldCalendarIcon } from "../../../../components/ui/WorldCalendarIcon";
+import { WorldClockIcon } from "../../../../components/ui/WorldStateInstruments";
+import type { TrackerPanelSizeProfile } from "../../../../stores/ui.store";
+import type { WorldStatePresentation } from "../../lib/world-state-display";
 import { useTrackerFieldLock } from "../TrackerLockContext";
-import { WorldRenderedEdit, WorldTileShell } from "./WorldEditableTile";
+import {
+  WORLD_INSTRUMENT_TEXT_STYLE,
+  WorldRenderedEdit,
+  WorldValueText,
+} from "./WorldEditableTile";
 
-export function WorldDateTile({
-  value,
-  display = getWorldDateDisplay(value),
-  onSave,
-  lockKey,
+const WORLD_DATE_TIME_PROFILE_STYLES: Record<
+  TrackerPanelSizeProfile,
+  {
+    shell: string;
+    grid: string;
+    clock: string;
+    calendar: string;
+    edit: string;
+    time: string;
+    date: string;
+  }
+> = {
+  compact: {
+    shell: "px-0",
+    grid: "grid-cols-[1.25rem_minmax(0,1fr)]",
+    clock: "h-4 w-4 opacity-80",
+    calendar: "h-3.5 w-3.5 opacity-[0.58]",
+    edit: "px-0.5",
+    time: "text-sm leading-4",
+    date: "text-xs leading-4",
+  },
+  standard: {
+    shell: "pr-1",
+    grid: "grid-cols-[1.5rem_minmax(0,1fr)]",
+    clock: "h-5 w-5 opacity-85",
+    calendar: "h-4 w-4 opacity-[0.62]",
+    edit: "px-1",
+    time: "text-[1.0625rem] leading-5",
+    date: "text-[0.8125rem] leading-4",
+  },
+  expanded: {
+    shell: "pr-1",
+    grid: "grid-cols-[1.5rem_minmax(0,1fr)]",
+    clock: "h-6 w-6 opacity-85",
+    calendar: "h-5 w-5 opacity-[0.62]",
+    edit: "px-1",
+    time: "text-[1.1875rem] leading-6",
+    date: "text-sm leading-5",
+  },
+};
+
+export function WorldDateTimeTile({
+  dateText,
+  dateColor,
+  dateDay,
+  timeDisplay,
+  onSaveDate,
+  onSaveTime,
+  dateLockKey,
+  timeLockKey,
+  sizeProfile,
 }: {
-  value: string | null | undefined;
-  display?: WorldDateDisplay;
-  onSave?: (value: string) => void;
-  lockKey?: string;
+  dateText: string;
+  dateColor: string;
+  dateDay: string | null;
+  timeDisplay: WorldStatePresentation["time"];
+  onSaveDate: (value: string) => void;
+  onSaveTime: (value: string) => void;
+  dateLockKey?: string;
+  timeLockKey?: string;
+  sizeProfile: TrackerPanelSizeProfile;
 }) {
-  const lock = useTrackerFieldLock(lockKey);
-  const isFreeformDate = display.kind === "freeform";
-
+  const dateLock = useTrackerFieldLock(dateLockKey);
+  const timeLock = useTrackerFieldLock(timeLockKey);
+  const style = WORLD_DATE_TIME_PROFILE_STYLES[sizeProfile];
   return (
-    <WorldTileShell label="Date">
-      <WorldRenderedEdit
-        label="Date"
-        value={display.raw || value}
-        onSave={onSave}
-        placeholder="Set date"
-        className={cn(
-          "overflow-hidden text-center",
-          isFreeformDate
-            ? "flex flex-col items-center justify-center px-0.5 py-1"
-            : "grid grid-rows-[0.95rem_minmax(0,1fr)]",
-        )}
-        inputClassName="text-center"
-        showEditHint={false}
-        {...lock}
-      >
-        {isFreeformDate ? (
-          <>
-            <span className="mb-0.5 max-w-full truncate text-[0.4375rem] font-bold uppercase leading-none text-[var(--muted-foreground)]/75">
-              Date
-            </span>
-            <span className="line-clamp-2 max-w-full break-words text-[0.5625rem] font-black leading-[0.625rem] text-[var(--foreground)] [overflow-wrap:anywhere]">
-              {display.main}
-            </span>
-            {display.detail && (
-              <span className="mt-0.5 line-clamp-1 max-w-full break-words text-[0.5rem] font-semibold leading-[0.625rem] text-[var(--muted-foreground)]/82 [overflow-wrap:anywhere]">
-                {display.detail}
-              </span>
+    <div className={cn("relative z-[1] min-h-16 min-w-0 overflow-hidden rounded-sm py-1", style.shell)}>
+      <div className={cn("relative z-[1] grid min-h-14 min-w-0 grid-rows-[auto_auto] content-center", style.grid)}>
+        <WorldClockIcon
+          display={timeDisplay}
+          variant="accented"
+          className={cn(
+            "pointer-events-none col-start-1 row-start-1 self-center justify-self-center text-[var(--tracker-world-time-accent)] drop-shadow-sm",
+            style.clock,
+          )}
+        />
+        {dateDay && (
+          <WorldCalendarIcon
+            day={dateDay}
+            className={cn(
+              "pointer-events-none col-start-1 row-start-2 self-center justify-self-center drop-shadow-sm",
+              style.calendar,
+              dateColor,
             )}
-          </>
-        ) : (
-          <>
-            <div className="bg-[var(--foreground)]/10 text-[0.5rem] font-bold leading-[0.95rem] text-[var(--foreground)]/75">
-              {display.month}
-            </div>
-            <div className="flex min-h-0 flex-col items-center justify-center bg-[var(--background)]/22 text-[var(--foreground)]">
-              <span className="text-base font-black leading-none">{display.day}</span>
-              {display.year && (
-                <span className="mt-0.5 text-[0.5rem] font-semibold leading-none text-[var(--muted-foreground)]/70">
-                  {display.year}
-                </span>
-              )}
-            </div>
-          </>
+          />
         )}
-      </WorldRenderedEdit>
-    </WorldTileShell>
-  );
-}
-
-function WorldClockFace({ hour, minute }: { hour: number | null; minute: number | null }) {
-  const hasTime = hour !== null && minute !== null;
-  const minuteRotation = hasTime ? minute * 6 : 0;
-  const hourRotation = hasTime ? (hour % 12) * 30 + minute * 0.5 : -45;
-
-  return (
-    <div className="relative flex h-7 w-7 items-center justify-center rounded-full border border-[var(--border)]/45 bg-[radial-gradient(circle_at_50%_48%,color-mix(in_srgb,var(--background)_58%,transparent)_0%,color-mix(in_srgb,var(--background)_84%,transparent)_68%,color-mix(in_srgb,var(--foreground)_8%,transparent)_100%)] text-sky-300 shadow-[inset_0_-2px_5px_rgba(0,0,0,0.28),0_0_10px_rgba(56,189,248,0.10)]">
-      {hasTime ? (
-        <>
-          <span className="absolute h-1 w-1 rounded-full bg-sky-300 shadow-[0_0_5px_rgba(125,211,252,0.42)]" />
-          <span
-            className="absolute left-1/2 top-1/2 h-[0.5625rem] w-[2px] origin-bottom rounded-full bg-sky-300"
-            style={{ transform: `translate(-50%, -100%) rotate(${hourRotation}deg)` }}
+        <WorldRenderedEdit
+          label="Time"
+          value={timeDisplay.raw}
+          onSave={onSaveTime}
+          placeholder="Set time"
+          className={cn("col-start-2 row-start-1 w-full min-w-0 self-center rounded-sm py-0.5 text-left", style.edit)}
+          inputClassName={cn(
+            "text-left text-[var(--tracker-world-time-accent)]",
+            WORLD_INSTRUMENT_TEXT_STYLE,
+            style.time,
+          )}
+          {...timeLock}
+        >
+          <WorldValueText
+            value={timeDisplay.raw}
+            maxLines={timeDisplay.kind === "clock" ? 1 : 3}
+            className={cn(
+              "min-w-0 text-left text-[var(--tracker-world-time-accent)] drop-shadow-sm",
+              WORLD_INSTRUMENT_TEXT_STYLE,
+              style.time,
+              timeDisplay.kind === "clock"
+                ? "whitespace-nowrap [overflow-wrap:normal]"
+                : "whitespace-pre-wrap break-words [overflow-wrap:anywhere]",
+            )}
           />
-          <span
-            className="absolute left-1/2 top-1/2 h-[0.78rem] w-[1px] origin-bottom rounded-full bg-sky-200"
-            style={{ transform: `translate(-50%, -100%) rotate(${minuteRotation}deg)` }}
+        </WorldRenderedEdit>
+        <WorldRenderedEdit
+          label="Date"
+          value={dateText}
+          onSave={onSaveDate}
+          placeholder="Set date"
+          className={cn(
+            "col-start-2 row-start-2 w-full min-w-0 justify-self-start overflow-hidden rounded-sm py-0.5 text-left",
+            style.edit,
+            sizeProfile === "compact" ? "pr-1" : "pr-2",
+          )}
+          inputClassName={cn(
+            "text-left",
+            WORLD_INSTRUMENT_TEXT_STYLE,
+            style.date,
+            sizeProfile === "compact" ? "pr-1" : "pr-2",
+          )}
+          {...dateLock}
+        >
+          <WorldValueText
+            value={dateText}
+            maxLines={2}
+            className={cn(
+              "relative z-[1] min-w-0 text-left text-[color-mix(in_srgb,var(--foreground)_86%,var(--muted-foreground))] drop-shadow-[0_1px_1px_color-mix(in_srgb,var(--background)_90%,transparent)]",
+              WORLD_INSTRUMENT_TEXT_STYLE,
+              style.date,
+              "tracking-[0.015em]",
+            )}
           />
-        </>
-      ) : (
-        <Clock size="0.875rem" />
-      )}
+        </WorldRenderedEdit>
+      </div>
     </div>
-  );
-}
-
-export function WorldTimeTile({
-  value,
-  onSave,
-  lockKey,
-}: {
-  value: string | null | undefined;
-  onSave?: (value: string) => void;
-  lockKey?: string;
-}) {
-  const lock = useTrackerFieldLock(lockKey);
-  const display = getWorldTimeDisplay(value);
-  const isPhraseTime = display.kind === "phrase";
-  const clockLabel = `${display.main}${display.suffix ? ` ${display.suffix}` : ""}`;
-
-  return (
-    <WorldTileShell label="Time">
-      <WorldRenderedEdit
-        label="Time"
-        value={display.raw || value}
-        onSave={onSave}
-        placeholder="Set time"
-        className={cn(
-          "overflow-hidden text-center",
-          isPhraseTime
-            ? "flex flex-col items-center justify-center px-0.5 py-1"
-            : "grid grid-rows-[minmax(0,1fr)_0.6875rem] px-0.5 pb-0.5 pt-0.5",
-        )}
-        inputClassName="text-center"
-        showEditHint={false}
-        {...lock}
-      >
-        {isPhraseTime ? (
-          <>
-            <span className="mb-0.5 max-w-full truncate text-[0.4375rem] font-bold uppercase leading-none text-[var(--muted-foreground)]/75">
-              Time
-            </span>
-            <span className="line-clamp-3 max-w-full whitespace-normal break-words text-center text-[0.625rem] font-black leading-[0.7rem] text-[var(--foreground)]">
-              {display.main}
-            </span>
-          </>
-        ) : (
-          <>
-            <div className="flex min-h-0 items-center justify-center overflow-visible">
-              <WorldClockFace hour={display.hour} minute={display.minute} />
-            </div>
-            <FittedText
-              align="center"
-              minScale={0.62}
-              title={clockLabel}
-              className="w-full max-w-full translate-y-px text-[0.625rem] font-black leading-[0.6875rem] text-[var(--foreground)]"
-            >
-              {clockLabel}
-            </FittedText>
-          </>
-        )}
-      </WorldRenderedEdit>
-    </WorldTileShell>
   );
 }

--- a/packages/client/src/features/tracker-panel/components/sections/WorldEditableTile.tsx
+++ b/packages/client/src/features/tracker-panel/components/sections/WorldEditableTile.tsx
@@ -1,32 +1,10 @@
-import { useEffect, useRef, useState, type ReactNode } from "react";
+import { useEffect, useLayoutEffect, useRef, useState, type CSSProperties, type ReactNode } from "react";
 import { Lock, Pencil, Unlock } from "lucide-react";
 import { cn } from "../../../../lib/utils";
 import { visibleText } from "../../lib/tracker-display";
 
-export function WorldTileShell({
-  label,
-  children,
-  className,
-}: {
-  label: string;
-  children: ReactNode;
-  className?: string;
-}) {
-  return (
-    <div
-      className={cn(
-        "relative min-h-[3.125rem] min-w-0 overflow-hidden rounded-[5px] border border-[var(--border)]/36 bg-[var(--tracker-panel-card-background,color-mix(in_srgb,var(--background)_43%,transparent))] shadow-[inset_0_1px_0_color-mix(in_srgb,var(--foreground)_9%,transparent),inset_0_-10px_20px_color-mix(in_srgb,var(--background)_18%,transparent)] transition-[border-color,box-shadow] duration-200",
-        className,
-      )}
-      title={label}
-    >
-      <div className="pointer-events-none absolute inset-0 bg-[linear-gradient(135deg,color-mix(in_srgb,var(--foreground)_5%,transparent),transparent_42%,color-mix(in_srgb,var(--foreground)_7%,transparent))]" />
-      <div className="pointer-events-none absolute inset-x-1 bottom-1 h-px bg-[linear-gradient(90deg,transparent,color-mix(in_srgb,var(--foreground)_14%,transparent),transparent)] opacity-70" />
-      <span className="sr-only">{label}</span>
-      <div className="relative z-[1] h-full min-w-0">{children}</div>
-    </div>
-  );
-}
+export const WORLD_INSTRUMENT_TEXT_STYLE =
+  "font-[family-name:'Share_Tech_Mono',monospace] font-normal uppercase tabular-nums tracking-[0.035em]";
 
 export function WorldRenderedEdit({
   label,
@@ -36,7 +14,6 @@ export function WorldRenderedEdit({
   className,
   inputClassName,
   showEditHint = true,
-  editHintClassName,
   locked = false,
   lockMode = false,
   onToggleLock,
@@ -44,12 +21,11 @@ export function WorldRenderedEdit({
 }: {
   label: string;
   value: string | null | undefined;
-  onSave?: (value: string) => void;
-  placeholder?: string;
+  onSave: (value: string) => void;
+  placeholder: string;
   className?: string;
   inputClassName?: string;
   showEditHint?: boolean;
-  editHintClassName?: string;
   locked?: boolean;
   lockMode?: boolean;
   onToggleLock?: () => void;
@@ -58,8 +34,9 @@ export function WorldRenderedEdit({
   const currentValue = value === null || value === undefined ? "" : String(value);
   const [editing, setEditing] = useState(false);
   const [draft, setDraft] = useState(currentValue);
-  const inputRef = useRef<HTMLInputElement>(null);
+  const inputRef = useRef<HTMLTextAreaElement>(null);
   const committedRef = useRef(false);
+  const cancelledRef = useRef(false);
   const title = `${label}: ${visibleText(value)}`;
   const lockToggleActive = lockMode && !!onToggleLock;
 
@@ -70,45 +47,49 @@ export function WorldRenderedEdit({
   useEffect(() => {
     if (!editing) return;
     committedRef.current = false;
+    cancelledRef.current = false;
     inputRef.current?.focus();
     inputRef.current?.select();
   }, [editing]);
 
+  useLayoutEffect(() => {
+    if (!editing || !inputRef.current) return;
+    inputRef.current.style.height = "auto";
+    inputRef.current.style.height = `${inputRef.current.scrollHeight}px`;
+  }, [draft, editing]);
+
   const commit = () => {
-    if (committedRef.current) return;
+    if (committedRef.current || cancelledRef.current) return;
     committedRef.current = true;
     const trimmed = draft.trim();
-    if (trimmed !== currentValue) onSave?.(trimmed);
+    if (trimmed !== currentValue) onSave(trimmed);
     setEditing(false);
   };
 
-  if (!onSave) {
-    return (
-      <div className={cn("h-full min-w-0", className)} title={title}>
-        {children}
-      </div>
-    );
-  }
-
   if (editing) {
     return (
-      <input
+      <textarea
         ref={inputRef}
         value={draft}
         onChange={(event) => setDraft(event.target.value)}
         onKeyDown={(event) => {
-          if (event.key === "Enter") commit();
-          if (event.key === "Escape") {
+          if (event.key === "Enter" && !event.shiftKey) {
+            event.preventDefault();
+            commit();
+          } else if (event.key === "Escape") {
+            event.preventDefault();
+            cancelledRef.current = true;
             setDraft(currentValue);
             setEditing(false);
           }
         }}
         onBlur={commit}
         className={cn(
-          "h-full w-full min-w-0 rounded-sm border border-[var(--foreground)]/25 bg-[var(--background)]/68 px-1 text-[0.6875rem] font-semibold text-[var(--foreground)] outline-none focus:ring-1 focus:ring-[var(--border)]",
+          "h-auto max-h-24 min-h-full w-full min-w-0 resize-none overflow-y-auto rounded-sm border border-[var(--foreground)]/25 bg-[var(--background)]/68 px-1 py-1 text-[0.6875rem] font-semibold leading-4 text-[var(--foreground)] outline-none focus:ring-1 focus:ring-[var(--border)]",
+          className,
           inputClassName,
         )}
-        placeholder={placeholder ?? `Set ${label.toLowerCase()}`}
+        placeholder={placeholder}
         aria-label={label}
       />
     );
@@ -126,9 +107,7 @@ export function WorldRenderedEdit({
       }}
       title={lockToggleActive ? (locked ? `Unlock ${label.toLowerCase()}` : `Lock ${label.toLowerCase()}`) : title}
       aria-label={
-        lockToggleActive
-          ? `${locked ? "Unlock" : "Lock"} ${label.toLowerCase()}`
-          : `${title}. Click to edit.`
+        lockToggleActive ? `${locked ? "Unlock" : "Lock"} ${label.toLowerCase()}` : `${title}. Click to edit.`
       }
       aria-pressed={lockToggleActive ? locked : undefined}
       className={cn(
@@ -144,7 +123,6 @@ export function WorldRenderedEdit({
           className={cn(
             "pointer-events-none absolute right-0.5 top-0.5 z-[12] flex h-3.5 w-3.5 items-center justify-center rounded-[2px] bg-[var(--background)]/58 shadow-[0_0_6px_color-mix(in_srgb,var(--foreground)_10%,transparent)] ring-1 ring-[var(--border)] transition-opacity duration-150 [@media(pointer:coarse)]:h-4 [@media(pointer:coarse)]:w-4",
             locked ? "text-[var(--foreground)] opacity-90" : "text-[var(--muted-foreground)] opacity-50",
-            editHintClassName,
           )}
           aria-hidden="true"
         >
@@ -159,7 +137,6 @@ export function WorldRenderedEdit({
         <span
           className={cn(
             "pointer-events-none absolute right-0.5 top-0.5 z-[12] flex h-3 w-3 translate-y-0.5 items-center justify-center rounded-[2px] bg-[var(--background)]/58 text-[var(--muted-foreground)] opacity-0 shadow-[0_0_6px_color-mix(in_srgb,var(--foreground)_10%,transparent)] ring-1 ring-[var(--border)] transition-[opacity,transform] duration-150 group-hover/world-edit:translate-y-0 group-hover/world-edit:opacity-70 group-focus-visible/world-edit:translate-y-0 group-focus-visible/world-edit:opacity-80 max-md:translate-y-0 max-md:opacity-45",
-            editHintClassName,
           )}
           aria-hidden="true"
         >
@@ -167,5 +144,107 @@ export function WorldRenderedEdit({
         </span>
       )}
     </button>
+  );
+}
+
+/** Raw world text that shrinks to its field's line budget before clamping exceptional values. */
+export function WorldValueText({
+  value,
+  maxLines,
+  className,
+  minScale = 0.62,
+}: {
+  value: string | null | undefined;
+  maxLines: 1 | 2 | 3;
+  className?: string;
+  minScale?: number;
+}) {
+  const text = value === null || value === undefined ? "" : String(value);
+  const displayText = text || "Not recorded";
+  const containerRef = useRef<HTMLSpanElement>(null);
+  const measureRef = useRef<HTMLSpanElement>(null);
+  const [fit, setFit] = useState({ scale: 1, fontSize: 0, lineHeight: 0 });
+
+  useLayoutEffect(() => {
+    const container = containerRef.current;
+    const measure = measureRef.current;
+    if (!container || !measure) return;
+
+    const updateScale = () => {
+      measure.style.fontSize = "";
+      measure.style.lineHeight = "";
+      const computed = window.getComputedStyle(measure);
+      const baseFontSize = Number.parseFloat(computed.fontSize);
+      const baseLineHeight = Number.parseFloat(computed.lineHeight);
+      if (!container.clientWidth || !baseFontSize || !baseLineHeight) return;
+
+      const fits = (candidate: number) => {
+        measure.style.fontSize = `${baseFontSize * candidate}px`;
+        measure.style.lineHeight = `${baseLineHeight * candidate}px`;
+        return measure.scrollHeight <= baseLineHeight * candidate * maxLines + 1;
+      };
+
+      let nextScale = 1;
+      if (!fits(1)) {
+        let lower = minScale;
+        let upper = 1;
+        for (let step = 0; step < 7; step += 1) {
+          const candidate = (lower + upper) / 2;
+          if (fits(candidate)) lower = candidate;
+          else upper = candidate;
+        }
+        nextScale = fits(lower) ? lower : minScale;
+      }
+
+      setFit((previous) =>
+        Math.abs(previous.scale - nextScale) < 0.01 &&
+        Math.abs(previous.fontSize - baseFontSize * nextScale) < 0.1 &&
+        Math.abs(previous.lineHeight - baseLineHeight * nextScale) < 0.1
+          ? previous
+          : {
+              scale: nextScale,
+              fontSize: baseFontSize * nextScale,
+              lineHeight: baseLineHeight * nextScale,
+            },
+      );
+    };
+
+    updateScale();
+    const resizeObserver =
+      typeof ResizeObserver === "undefined" ? null : new ResizeObserver(() => updateScale());
+    resizeObserver?.observe(container);
+    void document.fonts?.ready.then(updateScale);
+    if (!resizeObserver) window.addEventListener("resize", updateScale);
+    return () => {
+      resizeObserver?.disconnect();
+      if (!resizeObserver) window.removeEventListener("resize", updateScale);
+    };
+  }, [displayText, maxLines, minScale]);
+
+  const fittedStyle: CSSProperties = {
+    display: "-webkit-box",
+    WebkitBoxOrient: "vertical",
+    WebkitLineClamp: maxLines,
+    fontSize: fit.scale < 0.999 ? `${fit.fontSize}px` : undefined,
+    lineHeight: fit.scale < 0.999 ? `${fit.lineHeight}px` : undefined,
+  };
+
+  return (
+    <span
+      ref={containerRef}
+      className={cn("relative block min-w-0 overflow-hidden whitespace-pre-wrap break-words [overflow-wrap:anywhere] leading-5", className)}
+      dir="auto"
+    >
+      <span
+        ref={measureRef}
+        aria-hidden="true"
+        className="pointer-events-none invisible absolute inset-x-0 top-0 block whitespace-pre-wrap break-words [overflow-wrap:anywhere]"
+      >
+        {displayText}
+      </span>
+      <span className="overflow-hidden" style={fittedStyle}>
+        {displayText}
+      </span>
+    </span>
   );
 }

--- a/packages/client/src/features/tracker-panel/components/sections/WorldEditableTile.tsx
+++ b/packages/client/src/features/tracker-panel/components/sections/WorldEditableTile.tsx
@@ -73,7 +73,7 @@ export function WorldRenderedEdit({
         value={draft}
         onChange={(event) => setDraft(event.target.value)}
         onKeyDown={(event) => {
-          if (event.key === "Enter" && !event.shiftKey) {
+          if (event.key === "Enter" && !event.shiftKey && !event.nativeEvent.isComposing) {
             event.preventDefault();
             commit();
           } else if (event.key === "Escape") {

--- a/packages/client/src/features/tracker-panel/components/sections/WorldForecastTile.tsx
+++ b/packages/client/src/features/tracker-panel/components/sections/WorldForecastTile.tsx
@@ -1,360 +1,121 @@
-import type { CSSProperties } from "react";
-import type { TrackerPanelSizeProfile, TrackerTemperatureUnit } from "../../../../stores/ui.store";
 import { cn } from "../../../../lib/utils";
-import {
-  getTemperatureColor,
-  getTemperatureGaugeDisplay,
-  getWeatherEmoji,
-  parsePureTemperatureValue,
-} from "../../lib/world-state-display";
-import { visibleText } from "../../lib/tracker-display";
-import { FittedText } from "../controls/InlineControls";
+import { WorldThermometerIcon } from "../../../../components/ui/WorldStateInstruments";
+import type { TrackerPanelSizeProfile } from "../../../../stores/ui.store";
+import type { WorldStatePresentation } from "../../lib/world-state-display";
 import { useTrackerFieldLock } from "../TrackerLockContext";
-import { WorldRenderedEdit, WorldTileShell } from "./WorldEditableTile";
+import {
+  WORLD_INSTRUMENT_TEXT_STYLE,
+  WorldRenderedEdit,
+  WorldValueText,
+} from "./WorldEditableTile";
+
+const WORLD_FORECAST_PROFILE_STYLES: Record<
+  TrackerPanelSizeProfile,
+  {
+    shell: string;
+    edit: string;
+    primary: string;
+    secondary: string;
+    thermometer: string;
+  }
+> = {
+  compact: {
+    shell: "px-0",
+    edit: "px-0.5",
+    primary: "text-sm leading-4",
+    secondary: "whitespace-pre-wrap break-words text-xs leading-4 [overflow-wrap:anywhere]",
+    thermometer: "h-5 w-[0.625rem]",
+  },
+  standard: {
+    shell: "px-0.5",
+    edit: "px-1",
+    primary: "text-[1.0625rem] leading-5",
+    secondary: "text-[0.8125rem] leading-4",
+    thermometer: "h-5 w-[0.625rem]",
+  },
+  expanded: {
+    shell: "px-1",
+    edit: "px-1",
+    primary: "text-[1.1875rem] leading-6",
+    secondary: "text-sm leading-5",
+    thermometer: "h-6 w-3",
+  },
+};
 
 export function WorldForecastTile({
-  weather,
-  temperature,
-  trackerPanelSizeProfile,
-  trackerTemperatureUnit,
+  weatherText,
+  temperatureValue,
+  temperatureDisplay,
   onSaveWeather,
   onSaveTemperature,
   weatherLockKey,
   temperatureLockKey,
+  sizeProfile,
 }: {
-  weather: string | null | undefined;
-  temperature: string | null | undefined;
-  trackerPanelSizeProfile: TrackerPanelSizeProfile;
-  trackerTemperatureUnit: TrackerTemperatureUnit;
-  onSaveWeather?: (value: string) => void;
-  onSaveTemperature?: (value: string) => void;
+  weatherText: string;
+  temperatureValue?: string | null;
+  temperatureDisplay: WorldStatePresentation["temperature"];
+  onSaveWeather: (value: string) => void;
+  onSaveTemperature: (value: string) => void;
   weatherLockKey?: string;
   temperatureLockKey?: string;
+  sizeProfile: TrackerPanelSizeProfile;
 }) {
   const weatherLock = useTrackerFieldLock(weatherLockKey);
   const temperatureLock = useTrackerFieldLock(temperatureLockKey);
-  const weatherText = visibleText(weather, "Set weather");
-  const temperatureDisplay = getTemperatureGaugeDisplay(temperature, trackerTemperatureUnit);
-  const temperatureText = temperature?.trim() ?? "";
-  const useDescriptiveTempRail = temperatureText.length > 0 && parsePureTemperatureValue(temperatureText) === null;
-  const useHorizontalTempRail = trackerPanelSizeProfile !== "compact";
-  const useHorizontalTempLayout = useHorizontalTempRail || useDescriptiveTempRail;
+  const style = WORLD_FORECAST_PROFILE_STYLES[sizeProfile];
+  const thermometerColor = temperatureDisplay.color;
   return (
-    <WorldTileShell label="Forecast" className="min-h-[3.125rem]">
-      <div className="@container relative h-full min-w-0 overflow-hidden">
-        <div
-          aria-hidden="true"
-          className={cn(
-            "pointer-events-none absolute top-1/2 z-0 -translate-y-1/2 select-none text-[2.75rem] leading-none opacity-[0.085] saturate-125 @min-[7rem]:text-[3.25rem] @min-[10rem]:text-[4rem] @min-[14rem]:text-[4.65rem]",
-            useDescriptiveTempRail
-              ? "right-[46%] @min-[10rem]:right-[44%] @min-[14rem]:right-[42%]"
-              : useHorizontalTempRail
-                ? "right-[4rem] @min-[7rem]:right-[4.15rem] @min-[10rem]:right-[4.25rem] @min-[14rem]:right-[4.35rem]"
-                : "right-[2rem] @min-[7rem]:right-[2.3rem] @min-[10rem]:right-[2.7rem] @min-[14rem]:right-[3.05rem]",
-          )}
-        >
-          {getWeatherEmoji(weather)}
-        </div>
-        <div className="pointer-events-none absolute inset-0 z-[1] bg-[linear-gradient(90deg,color-mix(in_srgb,var(--background)_28%,transparent)_0%,transparent_48%),radial-gradient(ellipse_at_82%_45%,color-mix(in_srgb,var(--foreground)_7%,transparent)_0%,transparent_58%)]" />
-        <div className="pointer-events-none absolute inset-1 z-[1] rounded-[3px] opacity-[0.14] [background-image:repeating-linear-gradient(135deg,color-mix(in_srgb,var(--foreground)_24%,transparent)_0_1px,transparent_1px_7px)]" />
+    <div className={cn("relative z-[1] min-h-16 min-w-0 overflow-hidden rounded-sm py-1", style.shell)}>
+      <div className="relative z-[1] grid min-h-14 min-w-0 grid-cols-1 grid-rows-[auto_auto] content-center">
         <WorldRenderedEdit
-          label="Weather"
-          value={weather}
-          onSave={onSaveWeather}
-          placeholder="Set weather"
-          className={cn(
-            "relative z-[2] flex h-full min-w-0 flex-col justify-center overflow-hidden px-1.5 py-1 text-left @min-[10rem]:px-2",
-            useDescriptiveTempRail
-              ? "pr-[48%] @min-[10rem]:pr-[46%] @min-[14rem]:pr-[44%]"
-              : useHorizontalTempRail
-                ? "pr-[4.75rem] @min-[7rem]:pr-[4.9rem] @min-[10rem]:pr-[5rem] @min-[14rem]:pr-[5.1rem]"
-                : "pr-[2.65rem] @min-[7rem]:pr-[2.95rem] @min-[10rem]:pr-[3.35rem] @min-[14rem]:pr-[3.85rem]",
-          )}
-          inputClassName={cn(
-            "text-left text-[0.75rem]",
-            useDescriptiveTempRail
-              ? "pr-[48%] @min-[10rem]:pr-[46%] @min-[14rem]:pr-[44%]"
-              : useHorizontalTempRail
-                ? "pr-[4.75rem] @min-[7rem]:pr-[4.9rem] @min-[10rem]:pr-[5rem] @min-[14rem]:pr-[5.1rem]"
-                : "pr-[2.65rem] @min-[7rem]:pr-[2.95rem] @min-[10rem]:pr-[3.35rem] @min-[14rem]:pr-[3.85rem]",
-          )}
-          editHintClassName={cn(
-            useDescriptiveTempRail
-              ? "right-[47%] @min-[10rem]:right-[45%] @min-[14rem]:right-[43%]"
-              : useHorizontalTempRail
-                ? "right-[4.45rem] @min-[7rem]:right-[4.6rem] @min-[10rem]:right-[4.7rem] @min-[14rem]:right-[4.8rem]"
-                : "right-[2.45rem] @min-[7rem]:right-[2.65rem] @min-[10rem]:right-[2.95rem] @min-[14rem]:right-[3.25rem]",
-          )}
-          {...weatherLock}
-        >
-          <WorldWeatherLabel text={weatherText} trackerPanelSizeProfile={trackerPanelSizeProfile} />
-        </WorldRenderedEdit>
-        <div
-          className={cn(
-            "absolute bottom-0.5 right-0.5 top-0.5 z-[3]",
-            useDescriptiveTempRail
-              ? "w-[46%] @min-[10rem]:w-[44%] @min-[14rem]:w-[42%]"
-              : useHorizontalTempRail
-                ? "w-[4.15rem] @min-[7rem]:w-[4.25rem] @min-[10rem]:w-[4.35rem] @min-[14rem]:w-[4.45rem]"
-                : "w-[2.3rem] @min-[7rem]:w-[2.45rem] @min-[10rem]:bottom-0.5 @min-[10rem]:top-auto @min-[10rem]:h-[2.95rem] @min-[10rem]:w-[2.7rem] @min-[14rem]:w-[3rem]",
-          )}
-        >
-          <WorldRenderedEdit
-            label="Temp"
-            value={temperature}
-            onSave={onSaveTemperature}
-            placeholder="Set temp"
-            className={cn(
-              "h-full w-full rounded-[3px] bg-[color-mix(in_srgb,var(--background)_38%,transparent)] text-center shadow-[inset_0_1px_0_color-mix(in_srgb,var(--foreground)_8%,transparent),0_0_8px_color-mix(in_srgb,var(--background)_30%,transparent)] ring-1 ring-[var(--border)]/24 hover:!bg-[color-mix(in_srgb,var(--background)_46%,transparent)]",
-              useHorizontalTempLayout
-                ? "grid grid-cols-[minmax(0,1fr)_1.4rem] items-center gap-0.5 py-0.5 pl-0.5 pr-1 @min-[10rem]:grid-cols-[minmax(0,1fr)_1.5rem] @min-[14rem]:gap-1 @min-[14rem]:pl-1 @min-[14rem]:pr-1.5"
-                : "flex flex-col items-center justify-center gap-[0.125rem] px-0 pb-0.5 pt-0.5 @min-[10rem]:gap-0.5 @min-[10rem]:pt-0.5",
-            )}
-            inputClassName={cn(
-              "text-center text-[0.625rem]",
-              useHorizontalTempRail && "text-[0.6875rem]",
-              useDescriptiveTempRail && "text-left",
-            )}
-            showEditHint={false}
-            {...temperatureLock}
-          >
-            <span
-              className={cn(
-                "min-w-0 font-black tracking-normal drop-shadow-sm",
-                useDescriptiveTempRail
-                  ? "line-clamp-3 w-full justify-self-stretch whitespace-normal break-words text-left text-[0.5625rem] leading-[1.05] @min-[10rem]:text-[0.625rem]"
-                  : useHorizontalTempLayout
-                    ? "truncate justify-self-end text-right text-[0.625rem] leading-none @min-[10rem]:text-[0.6875rem] @min-[14rem]:text-[0.75rem]"
-                    : "truncate text-[0.5625rem] leading-none @min-[10rem]:text-[0.625rem]",
-                getTemperatureColor(temperature),
-              )}
-            >
-              {temperatureDisplay.label}
-            </span>
-            <span
-              className={cn(
-                "flex min-w-0 items-center justify-center overflow-visible",
-                useHorizontalTempLayout ? "h-full w-full" : "order-first h-[1.55rem] w-full @min-[14rem]:h-[1.6rem]",
-              )}
-            >
-              <WorldThermometerGauge
-                display={temperatureDisplay}
-                variant={useHorizontalTempLayout ? "expanded" : "compact"}
-              />
-            </span>
-          </WorldRenderedEdit>
-        </div>
-      </div>
-    </WorldTileShell>
-  );
-}
-
-type WorldWeatherLabelPlan =
-  | {
-      kind: "headline";
-      minScale: number;
-    }
-  | {
-      kind: "phrase";
-      lines: string[];
-      density: "comfortable" | "dense";
-      minScale: number;
-    };
-
-function getBalancedWeatherLines(text: string, lineCount: 2 | 3) {
-  const words = text.split(/\s+/).filter(Boolean);
-  if (words.length <= 1) return [text];
-  if (words.length <= lineCount) return words;
-
-  const candidates: string[][] = [];
-  if (lineCount === 2) {
-    for (let firstBreak = 1; firstBreak < words.length; firstBreak += 1) {
-      candidates.push([words.slice(0, firstBreak).join(" "), words.slice(firstBreak).join(" ")]);
-    }
-  } else {
-    for (let firstBreak = 1; firstBreak < words.length - 1; firstBreak += 1) {
-      for (let secondBreak = firstBreak + 1; secondBreak < words.length; secondBreak += 1) {
-        candidates.push([
-          words.slice(0, firstBreak).join(" "),
-          words.slice(firstBreak, secondBreak).join(" "),
-          words.slice(secondBreak).join(" "),
-        ]);
-      }
-    }
-  }
-
-  return candidates.reduce(
-    (best, candidate) => {
-      const scoreLines = (lines: string[]) => {
-        const lengths = lines.map((line) => line.length);
-        const longest = Math.max(...lengths);
-        const shortest = Math.min(...lengths);
-        const isolatedTinyWordPenalty = lines.some((line) => line.length <= 3 && !line.includes(" ")) ? 8 : 0;
-        return longest * 2 + (longest - shortest) + isolatedTinyWordPenalty;
-      };
-
-      return scoreLines(candidate) < scoreLines(best) ? candidate : best;
-    },
-    candidates[0] ?? [text],
-  );
-}
-
-function getWorldWeatherLabelPlan(
-  text: string,
-  trackerPanelSizeProfile: TrackerPanelSizeProfile,
-): WorldWeatherLabelPlan {
-  const normalized = text.replace(/\s+/g, " ").trim();
-  const words = normalized ? normalized.split(" ") : [];
-  const wordCount = words.length;
-  const longestWord = words.reduce((longest, word) => Math.max(longest, word.length), 0);
-  const isExpanded = trackerPanelSizeProfile === "expanded";
-  const isCompact = trackerPanelSizeProfile === "compact";
-  const headlineLimit = isExpanded ? 13 : isCompact ? 16 : 18;
-  const longestHeadlineWordLimit = isExpanded ? 12 : 16;
-  const canUseHeadline =
-    wordCount <= 1 || (wordCount <= 2 && normalized.length <= headlineLimit && longestWord <= longestHeadlineWordLimit);
-
-  if (canUseHeadline) {
-    return {
-      kind: "headline",
-      minScale: longestWord > longestHeadlineWordLimit ? 0.44 : 0.56,
-    };
-  }
-
-  const useThreeLines =
-    !isExpanded && (wordCount > (isCompact ? 4 : 5) || normalized.length > (isCompact ? 34 : 42) || longestWord > 18);
-  const lines = getBalancedWeatherLines(normalized, useThreeLines ? 3 : 2);
-
-  return {
-    kind: "phrase",
-    lines,
-    density: lines.length >= 3 || normalized.length > 38 || longestWord > 16 ? "dense" : "comfortable",
-    minScale: lines.length >= 3 ? 0.5 : 0.56,
-  };
-}
-
-function getWorldWeatherPhraseTextClass(
-  trackerPanelSizeProfile: TrackerPanelSizeProfile,
-  density: "comfortable" | "dense",
-) {
-  if (density === "dense") {
-    return trackerPanelSizeProfile === "expanded"
-      ? "text-[0.5625rem] leading-[0.625rem] @min-[7rem]:text-[0.625rem] @min-[7rem]:leading-[0.7rem] @min-[10rem]:text-[0.6875rem] @min-[10rem]:leading-[0.75rem] @min-[14rem]:text-[0.75rem] @min-[14rem]:leading-[0.8125rem]"
-      : "text-[0.625rem] leading-[0.6875rem] @min-[7rem]:text-[0.6875rem] @min-[7rem]:leading-[0.75rem] @min-[10rem]:text-[0.75rem] @min-[10rem]:leading-[0.8125rem]";
-  }
-
-  return trackerPanelSizeProfile === "expanded"
-    ? "text-[0.6875rem] leading-[0.75rem] @min-[7rem]:text-[0.75rem] @min-[7rem]:leading-[0.8125rem] @min-[10rem]:text-[0.8125rem] @min-[10rem]:leading-[0.875rem] @min-[14rem]:text-[0.875rem] @min-[14rem]:leading-[0.95rem]"
-    : "text-[0.75rem] leading-[0.8125rem] @min-[7rem]:text-[0.8125rem] @min-[7rem]:leading-[0.875rem] @min-[10rem]:text-[0.875rem] @min-[10rem]:leading-[0.95rem]";
-}
-
-function WorldWeatherLabel({
-  text,
-  trackerPanelSizeProfile,
-}: {
-  text: string;
-  trackerPanelSizeProfile: TrackerPanelSizeProfile;
-}) {
-  const plan = getWorldWeatherLabelPlan(text, trackerPanelSizeProfile);
-
-  if (plan.kind === "headline") {
-    return (
-      <FittedText
-        className="w-full max-w-full font-black leading-[0.9rem] tracking-normal text-[0.8125rem] text-[var(--foreground)]/92 drop-shadow-sm @min-[7rem]:text-[0.9375rem] @min-[7rem]:leading-[1rem] @min-[10rem]:text-[1.0625rem] @min-[10rem]:leading-[1.1rem] @min-[14rem]:text-[1.1875rem] @min-[14rem]:leading-[1.2rem] @min-[18rem]:text-[1.25rem] @min-[18rem]:leading-[1.25rem]"
-        minScale={plan.minScale}
-      >
-        {text}
-      </FittedText>
-    );
-  }
-
-  return (
-    <span
-      className={cn(
-        "flex w-full max-w-full min-w-0 flex-col justify-center overflow-hidden",
-        plan.lines.length >= 3 ? "gap-0" : "gap-px",
-      )}
-    >
-      {plan.lines.map((line, index) => (
-        <FittedText
-          key={`${line}-${index}`}
-          className={cn(
-            "w-full max-w-full font-extrabold normal-case tracking-normal text-[var(--foreground)]/92 drop-shadow-sm",
-            getWorldWeatherPhraseTextClass(trackerPanelSizeProfile, plan.density),
-          )}
-          minScale={plan.minScale}
-        >
-          {line}
-        </FittedText>
-      ))}
-    </span>
-  );
-}
-
-function WorldThermometerGauge({
-  display,
-  variant = "compact",
-}: {
-  display: ReturnType<typeof getTemperatureGaugeDisplay>;
-  variant?: "compact" | "expanded";
-}) {
-  const fillStyle = { "--temperature-glow": display.color, backgroundColor: display.color } as CSSProperties &
-    Record<"--temperature-glow", string>;
-  const expanded = variant === "expanded";
-  return (
-    <div className={cn("relative", expanded ? "h-[2.55rem] w-[1.15rem]" : "h-[1.55rem] w-[0.95rem]")}>
-      <div
-        className={cn(
-          "absolute left-1/2 -translate-x-1/2 overflow-hidden rounded-full border border-[var(--border)]/42 bg-[var(--background)]/52 shadow-[inset_0_0_4px_rgba(0,0,0,0.32)]",
-          expanded ? "bottom-[0.58rem] h-[1.78rem] w-[0.5rem]" : "bottom-[0.42rem] h-[1rem] w-[0.42rem]",
-        )}
-      >
-        <div
-          className={cn(
-            "absolute inset-x-0 overflow-hidden rounded-full",
-            expanded ? "bottom-[0.15625rem] top-[0.15625rem]" : "bottom-[0.125rem] top-[0.125rem]",
-          )}
+          label="Temperature"
+          value={temperatureValue}
+          onSave={onSaveTemperature}
+          placeholder="Set temperature"
+          className={cn("row-start-1 w-full min-w-0 self-center rounded-sm py-0.5 text-right", style.edit)}
+          inputClassName={cn("text-right", WORLD_INSTRUMENT_TEXT_STYLE, style.primary)}
+          {...temperatureLock}
         >
           <span
+            className="flex w-full min-w-0 items-center justify-end gap-1"
+            style={{ color: thermometerColor }}
+          >
+            <WorldValueText
+              value={temperatureDisplay.label}
+              maxLines={2}
+              className={cn(
+                "min-w-0 text-right",
+                WORLD_INSTRUMENT_TEXT_STYLE,
+                style.primary,
+              )}
+            />
+            <WorldThermometerIcon
+              display={temperatureDisplay}
+              variant="outline-bulb"
+              className={cn("shrink-0", style.thermometer)}
+            />
+          </span>
+        </WorldRenderedEdit>
+        <WorldRenderedEdit
+          label="Weather"
+          value={weatherText}
+          onSave={onSaveWeather}
+          placeholder="Set weather"
+          className={cn("row-start-2 w-full min-w-0 rounded-sm py-0.5 text-right", style.edit)}
+          inputClassName={cn("text-right", WORLD_INSTRUMENT_TEXT_STYLE, style.secondary)}
+          {...weatherLock}
+        >
+          <WorldValueText
+            value={weatherText}
+            maxLines={3}
             className={cn(
-              "absolute bottom-0 left-1/2 -translate-x-1/2 rounded-full shadow-[0_0_6px_color-mix(in_srgb,var(--temperature-glow)_16%,transparent)] transition-[height] duration-200",
-              expanded ? "w-[0.25rem]" : "w-[0.2rem]",
+              "min-w-0 text-right text-[var(--foreground)] drop-shadow-sm",
+              WORLD_INSTRUMENT_TEXT_STYLE,
+              style.secondary,
             )}
-            style={{ ...fillStyle, height: `${display.percent}%` }}
           />
-        </div>
-        <span
-          className={cn(
-            "absolute left-1/2 w-px -translate-x-1/2 rounded-full bg-[var(--foreground)]/18",
-            expanded ? "top-[0.18rem] h-1" : "top-[0.125rem] h-0.5",
-          )}
-        />
-      </div>
-      <span
-        className={cn(
-          "absolute left-1/2 z-[1] -translate-x-1/2 shadow-[0_0_6px_color-mix(in_srgb,var(--temperature-glow)_14%,transparent)]",
-          expanded ? "bottom-[0.49rem] h-[0.42rem] w-[0.27rem]" : "bottom-[0.36rem] h-[0.3rem] w-[0.22rem]",
-        )}
-        style={fillStyle}
-      />
-      <div
-        className={cn(
-          "absolute bottom-0 left-1/2 -translate-x-1/2 rounded-full border border-[var(--border)]/42 bg-[var(--background)]/54 shadow-[inset_0_-2px_4px_rgba(0,0,0,0.26),0_0_6px_color-mix(in_srgb,var(--temperature-glow)_9%,transparent)]",
-          expanded ? "h-[0.92rem] w-[0.92rem]" : "h-[0.72rem] w-[0.72rem]",
-        )}
-      >
-        <span
-          className={cn("absolute rounded-full", expanded ? "inset-[0.19rem]" : "inset-[0.15rem]")}
-          style={fillStyle}
-        />
-        <span
-          className={cn(
-            "absolute rounded-full bg-[var(--foreground)]/24",
-            expanded
-              ? "left-[0.3rem] top-[0.26rem] h-[0.28rem] w-[0.2rem]"
-              : "left-[0.23rem] top-[0.2rem] h-[0.22rem] w-[0.16rem]",
-          )}
-        />
+        </WorldRenderedEdit>
       </div>
     </div>
   );

--- a/packages/client/src/features/tracker-panel/components/sections/WorldLocationPlate.tsx
+++ b/packages/client/src/features/tracker-panel/components/sections/WorldLocationPlate.tsx
@@ -1,53 +1,42 @@
-import { MapPin } from "lucide-react";
 import { cn } from "../../../../lib/utils";
-import { getLocationPinColor } from "../../lib/world-state-display";
-import { visibleText } from "../../lib/tracker-display";
+import type { TrackerPanelSizeProfile } from "../../../../stores/ui.store";
 import { useTrackerFieldLock } from "../TrackerLockContext";
-import { WorldRenderedEdit, WorldTileShell } from "./WorldEditableTile";
+import { WorldRenderedEdit, WorldValueText } from "./WorldEditableTile";
 
 export function WorldLocationPlate({
   value,
   onSave,
-  className,
   lockKey,
+  sizeProfile,
 }: {
   value: string | null | undefined;
-  onSave?: (value: string) => void;
-  className?: string;
+  onSave: (value: string) => void;
   lockKey?: string;
+  sizeProfile: TrackerPanelSizeProfile;
 }) {
   const lock = useTrackerFieldLock(lockKey);
-  const locationText = visibleText(value, "Set location");
-  const compactLocationText = locationText.length > 34;
-
+  const compact = sizeProfile === "compact";
   return (
-    <WorldTileShell label="Location" className={cn("min-h-[2.375rem]", className)}>
-      <WorldRenderedEdit
-        label="Location"
+    <WorldRenderedEdit
+      label="Location"
+      value={value}
+      onSave={onSave}
+      placeholder="Set location"
+      className={cn(
+        "flex min-w-0 items-center gap-1.5 rounded-sm px-1 pb-0.5 pt-0 text-left",
+        compact && "px-0.5",
+      )}
+      inputClassName={cn("text-left text-sm", compact && "text-[0.8125rem]")}
+      {...lock}
+    >
+      <WorldValueText
         value={value}
-        onSave={onSave}
-        placeholder="Set location"
-        className="relative z-[1] grid grid-cols-[1.7rem_minmax(0,1fr)] items-center gap-1 px-1 py-1 text-left @min-[380px]:grid-cols-[1.9rem_minmax(0,1fr)] @min-[380px]:px-1.5"
-        inputClassName="text-center text-[0.75rem]"
-        editHintClassName="right-1 top-1"
-        {...lock}
-      >
-        <div className="relative flex h-full min-h-[1.625rem] w-full items-center justify-center overflow-hidden rounded-[3px] bg-[color-mix(in_srgb,var(--background)_34%,transparent)] ring-1 ring-[var(--border)]/24 @min-[380px]:min-h-[1.8rem]">
-          <div className="pointer-events-none absolute inset-0 opacity-[0.17] [background-image:radial-gradient(circle,color-mix(in_srgb,var(--foreground)_44%,transparent)_0.75px,transparent_1px)] [background-size:4px_4px]" />
-          <MapPin
-            size="0.8125rem"
-            className={cn("relative z-[1] shrink-0 drop-shadow-sm", getLocationPinColor(value))}
-          />
-        </div>
-        <span
-          className={cn(
-            "line-clamp-2 min-w-0 max-w-full pr-3 whitespace-normal break-words text-left font-bold text-[var(--foreground)]/92 drop-shadow-sm",
-            compactLocationText ? "text-[0.625rem] leading-[0.75rem]" : "text-[0.75rem] leading-4",
-          )}
-        >
-          {locationText}
-        </span>
-      </WorldRenderedEdit>
-    </WorldTileShell>
+        maxLines={2}
+        className={cn(
+          "min-w-0 text-sm font-semibold leading-5 text-[var(--foreground)]",
+          compact && "text-[0.8125rem] leading-4",
+        )}
+      />
+    </WorldRenderedEdit>
   );
 }

--- a/packages/client/src/features/tracker-panel/components/sections/WorldStatePanel.tsx
+++ b/packages/client/src/features/tracker-panel/components/sections/WorldStatePanel.tsx
@@ -1,5 +1,18 @@
-import { type ReactNode } from "react";
-import { MapPin, X } from "lucide-react";
+import { useId, type ReactNode } from "react";
+import {
+  Cloud,
+  CloudFog,
+  CloudLightning,
+  CloudRain,
+  Flame,
+  MapPin,
+  Moon,
+  Snowflake,
+  Sun,
+  Wind,
+  X,
+  type LucideIcon,
+} from "lucide-react";
 import {
   DEFAULT_WORLD_CUSTOM_FIELD_ICON,
   removeTrackerFieldLockPrefix,
@@ -14,20 +27,17 @@ import type { GameStatePatchField } from "../../../../hooks/use-game-state-patch
 import type { TrackerPanelSizeProfile, TrackerTemperatureUnit } from "../../../../stores/ui.store";
 import { cn } from "../../../../lib/utils";
 import {
-  getWorldAmbienceStyle,
+  getLocationPinColor,
   getWorldDateDisplay,
-  getWorldTimeDisplay,
-  WORLD_FREEFORM_DATE_GRID_BASE_CLASS,
-  WORLD_FREEFORM_DATE_GRID_PHRASE_TIME_CLASS,
-  WORLD_GRID_BASE_CLASS,
-  WORLD_GRID_PHRASE_TIME_CLASS,
-} from "../../lib/world-state-display";
+} from "../../../../lib/world-state-helpers";
+import { getWorldStatePresentation, type WorldSceneGlyph } from "../../lib/world-state-display";
+import { visibleText } from "../../lib/tracker-display";
 import { WorldCustomFieldIcon } from "../../lib/world-custom-field-icons";
 import { InlineEdit } from "../controls/InlineControls";
 import { AddRowButton, SectionHeader } from "../controls/SectionControls";
 import { useTrackerFieldLock, useTrackerLockContext } from "../TrackerLockContext";
-import { WorldDateTile, WorldTimeTile } from "./WorldDateTimeTiles";
-import { WorldTileShell } from "./WorldEditableTile";
+import { WorldDateTimeTile } from "./WorldDateTimeTiles";
+import { WorldRenderedEdit, WorldValueText } from "./WorldEditableTile";
 import { WorldForecastTile } from "./WorldForecastTile";
 import { WorldLocationPlate } from "./WorldLocationPlate";
 
@@ -44,6 +54,187 @@ function makeUniqueWorldCustomFieldName(fields: WorldCustomField[]) {
 
 function normalizeCustomFieldName(value: string) {
   return value.normalize("NFKC").trim().toLocaleLowerCase("en-US").replace(/\s+/gu, " ");
+}
+
+const WORLD_SCENE_ICONS = {
+  sun: Sun,
+  moon: Moon,
+  cloud: Cloud,
+  rain: CloudRain,
+  snow: Snowflake,
+  storm: CloudLightning,
+  fog: CloudFog,
+  wind: Wind,
+  fire: Flame,
+} satisfies Record<WorldSceneGlyph, LucideIcon>;
+
+function WorldSceneAtmosphere({
+  glyph,
+  sizeProfile,
+}: {
+  glyph?: WorldSceneGlyph;
+  sizeProfile: TrackerPanelSizeProfile;
+}) {
+  if (!glyph) return null;
+  const Icon = WORLD_SCENE_ICONS[glyph];
+
+  return (
+    <div
+      aria-hidden="true"
+      className={cn(
+        "pointer-events-none absolute inset-y-0 left-1/2 z-0 flex w-[clamp(3rem,32%,8rem)] -translate-x-1/2 items-center justify-center py-0.5 text-[var(--tracker-world-scene-ink)]",
+        sizeProfile === "compact" ? "opacity-[0.18]" : "opacity-[0.22]",
+      )}
+    >
+      <Icon className="h-full w-auto max-w-full" strokeWidth={0.8} />
+    </div>
+  );
+}
+
+function WorldLocatorRail({ locationColor }: { locationColor: string }) {
+  return (
+    <div aria-hidden="true" className="pointer-events-none absolute inset-0">
+      <span
+        className={cn(
+          "absolute left-1 top-[calc(50%-0.1875rem)] z-[2] flex h-5 w-5 -translate-y-1/2 items-center justify-center opacity-65",
+          locationColor,
+        )}
+      >
+        <span className="absolute inset-0 rounded-full border border-current/20" />
+        <span className="absolute inset-1 rounded-full border border-current/15" />
+        <MapPin className="relative h-[0.95rem] w-[0.95rem]" strokeWidth={2.2} />
+      </span>
+      <span className="absolute inset-x-2 -bottom-3.5 h-8 overflow-hidden [mask-image:linear-gradient(90deg,transparent_0%,black_3%,black_94%,transparent_100%)]">
+        <span className="absolute inset-x-0 top-1/2 h-1 -translate-y-1/2 opacity-65 [background-image:radial-gradient(circle,color-mix(in_srgb,var(--muted-foreground)_58%,transparent)_1px,transparent_1.4px)] [background-position:center] [background-size:10px_4px]" />
+        <span className="absolute inset-x-[22%] top-1/2 h-1 -translate-y-1/2 opacity-75 [background-image:radial-gradient(circle,color-mix(in_srgb,var(--tracker-world-scene-stroke)_72%,transparent)_1px,transparent_1.4px)] [background-position:center] [background-size:10px_4px] [mask-image:linear-gradient(90deg,transparent,black_48%,black_52%,transparent)]" />
+        <svg viewBox="0 0 32 32" className="absolute left-1/2 top-1/2 h-4 w-4 -translate-x-1/2 -translate-y-1/2">
+          <path
+            d="M16 1.5 C17.5 8.5 23.5 14.5 30.5 16 C23.5 17.5 17.5 23.5 16 30.5 C14.5 23.5 8.5 17.5 1.5 16 C8.5 14.5 14.5 8.5 16 1.5Z"
+            fill="color-mix(in srgb, var(--background) 88%, transparent)"
+            stroke="var(--tracker-world-scene-stroke)"
+            strokeWidth="1.25"
+          />
+          <path
+            d="M16 5.5 C17 10.5 21.5 15 26.5 16 C21.5 17 17 21.5 16 26.5 C15 21.5 10.5 17 5.5 16 C10.5 15 15 10.5 16 5.5Z"
+            fill="none"
+            stroke="color-mix(in srgb, var(--tracker-world-scene-stroke) 70%, transparent)"
+            strokeWidth="0.75"
+          />
+          <circle
+            cx="16"
+            cy="16"
+            r="1.65"
+            fill="color-mix(in srgb, var(--tracker-world-scene-stroke) 92%, transparent)"
+          />
+        </svg>
+      </span>
+    </div>
+  );
+}
+
+function WorldInstrumentFrame({
+  sizeProfile,
+  locationColor,
+  dateColor,
+}: {
+  sizeProfile: TrackerPanelSizeProfile;
+  locationColor: string;
+  dateColor: string;
+}) {
+  const compact = sizeProfile === "compact";
+  const gradientId = useId().replace(/:/g, "");
+  const topHighlightId = `${gradientId}-world-frame-top`;
+  const bottomHighlightId = `${gradientId}-world-frame-bottom`;
+
+  return (
+    <div aria-hidden="true" className={cn("pointer-events-none absolute inset-0 z-0", locationColor)}>
+      <svg
+        viewBox="0 0 600 160"
+        preserveAspectRatio="none"
+        className={cn("h-full w-full opacity-55", compact && "opacity-40")}
+      >
+        <defs>
+          <linearGradient id={topHighlightId} x1="72" y1="0" x2="430" y2="0" gradientUnits="userSpaceOnUse">
+            <stop offset="0" stopColor="currentColor" stopOpacity="0" />
+            <stop offset="0.2" stopColor="currentColor" stopOpacity="0.72" />
+            <stop offset="0.56" stopColor="var(--tracker-world-scene-ink)" stopOpacity="1" />
+            <stop offset="0.82" stopColor="var(--tracker-world-scene-ink)" stopOpacity="0.46" />
+            <stop offset="1" stopColor="var(--tracker-world-scene-ink)" stopOpacity="0" />
+          </linearGradient>
+          <linearGradient
+            id={bottomHighlightId}
+            className={dateColor}
+            x1="72"
+            y1="0"
+            x2="528"
+            y2="0"
+            gradientUnits="userSpaceOnUse"
+          >
+            <stop offset="0" stopColor="currentColor" stopOpacity="0" />
+            <stop offset="0.14" stopColor="currentColor" stopOpacity="0.72" />
+            <stop offset="0.3" stopColor="var(--tracker-world-time-accent)" stopOpacity="0.82" />
+            <stop offset="0.48" stopColor="var(--tracker-world-scene-ink)" stopOpacity="1" />
+            <stop offset="0.72" stopColor="var(--tracker-world-weather-accent)" stopOpacity="0.88" />
+            <stop offset="0.88" stopColor="var(--tracker-world-temperature-accent)" stopOpacity="0.62" />
+            <stop offset="1" stopColor="var(--tracker-world-temperature-accent)" stopOpacity="0" />
+          </linearGradient>
+        </defs>
+        <path
+          d="M0.5 14 L5 9 H12 L16 1 H584 L588 9 H595 L599.5 14 V146 L595 151 H588 L584 159 H16 L12 151 H5 L0.5 146 Z"
+          fill="none"
+          stroke="color-mix(in srgb, var(--muted-foreground) 70%, transparent)"
+          strokeWidth="0.55"
+          vectorEffect="non-scaling-stroke"
+        />
+        <path
+          d="M3 16 L7 12 H14 L18 5 H582 L586 12 H593 L597 16 V144 L593 148 H586 L582 155 H18 L14 148 H7 L3 144 Z"
+          fill="none"
+          stroke="color-mix(in srgb, var(--foreground) 40%, transparent)"
+          strokeWidth="0.45"
+          vectorEffect="non-scaling-stroke"
+        />
+        <path
+          d="M72 1 H430"
+          fill="none"
+          stroke={`url(#${topHighlightId})`}
+          strokeLinecap="round"
+          strokeWidth="1.05"
+          vectorEffect="non-scaling-stroke"
+        />
+        <path
+          d="M72 159 H528"
+          fill="none"
+          stroke={`url(#${bottomHighlightId})`}
+          strokeLinecap="round"
+          strokeWidth="1.1"
+          vectorEffect="non-scaling-stroke"
+        />
+        {!compact && (
+          <>
+            <path
+              d="M3 35 V58 M597 101 V125"
+              fill="none"
+              stroke="color-mix(in srgb, var(--tracker-world-scene-stroke) 46%, transparent)"
+              strokeWidth="0.65"
+              vectorEffect="non-scaling-stroke"
+            />
+            <circle
+              cx="7"
+              cy="21"
+              r="1"
+              fill="color-mix(in srgb, var(--tracker-world-scene-stroke) 70%, transparent)"
+            />
+            <circle
+              cx="593"
+              cy="139"
+              r="1"
+              fill="color-mix(in srgb, var(--tracker-world-scene-stroke) 70%, transparent)"
+            />
+          </>
+        )}
+      </svg>
+    </div>
+  );
 }
 
 function WorldCustomFieldPlate({
@@ -69,8 +260,6 @@ function WorldCustomFieldPlate({
   const valueLockKey = worldCustomFieldTrackerLockKey(field, "value", fieldIndex);
   const valueLock = useTrackerFieldLock(valueLockKey);
   const name = field.name?.trim() || "Field";
-  const valueText = field.value?.trim() || "Set value";
-  const valueIsLong = valueText.length > 36 || valueText.includes(" ");
   const customPrefix = worldCustomFieldTrackerLockPrefix(field, fieldIndex);
 
   const updateName = (nextName: string) => {
@@ -85,55 +274,60 @@ function WorldCustomFieldPlate({
   };
 
   return (
-    <WorldTileShell label={name} className={cn("min-h-[2.75rem]", className)}>
+    <div
+      className={cn("@container relative min-h-[2.25rem] min-w-0 transition-colors duration-200", className)}
+      title={name}
+    >
       <div
         className={cn(
-          "relative z-[1] grid h-full items-center gap-1 px-1 py-1 text-left @min-[380px]:px-1.5",
-          "grid-cols-[1.7rem_minmax(2.6rem,0.42fr)_minmax(0,1fr)] @min-[380px]:grid-cols-[1.9rem_minmax(3rem,0.4fr)_minmax(0,1fr)]",
-          deleteMode && "pr-7",
+          "relative z-[1] grid h-full items-center gap-1 px-1 py-0.5 text-left @min-[380px]:px-1.5",
+          "grid-cols-[1.5rem_minmax(2.6rem,0.42fr)_minmax(0,1fr)] @min-[380px]:grid-cols-[1.7rem_minmax(3rem,0.4fr)_minmax(0,1fr)]",
+          deleteMode && "pr-7 [@media(pointer:coarse)]:pr-12",
         )}
       >
-        <div className="relative flex h-full min-h-[1.625rem] w-full items-center justify-center overflow-hidden rounded-[3px] bg-[color-mix(in_srgb,var(--background)_34%,transparent)] ring-1 ring-[var(--border)]/24 @min-[380px]:min-h-[1.8rem]">
+        <div className="relative flex h-full min-h-[2rem] w-full items-center justify-center overflow-hidden bg-[color-mix(in_srgb,var(--background)_18%,transparent)]">
           <div className="pointer-events-none absolute inset-0 opacity-[0.17] [background-image:radial-gradient(circle,color-mix(in_srgb,var(--foreground)_44%,transparent)_0.75px,transparent_1px)] [background-size:4px_4px]" />
           <WorldCustomFieldIcon icon={field.icon} className="relative z-[1]" />
         </div>
         {addMode && (
-          <InlineEdit
-            value={name}
-            onSave={updateName}
-            placeholder="Field"
-            ariaLabel={`${name} field name`}
-            className="min-w-0 px-0.5 py-0 text-[0.625rem] font-semibold uppercase text-[var(--muted-foreground)]/88"
-            previewClassName="truncate"
-            scrollOnHover
-            showEditHint={false}
-            locked={!!fieldLocks?.[worldCustomFieldTrackerLockKey(field, "name", fieldIndex)]}
-            lockMode={false}
-          />
+          <dt className="min-w-0">
+            <InlineEdit
+              value={name}
+              onSave={updateName}
+              placeholder="Field"
+              ariaLabel={`${name} field name`}
+              className="min-w-0 px-0.5 py-0 text-[0.625rem] font-semibold uppercase text-[var(--muted-foreground)]/88"
+              previewClassName="truncate"
+              scrollOnHover
+              showEditHint={false}
+              locked={!!fieldLocks?.[worldCustomFieldTrackerLockKey(field, "name", fieldIndex)]}
+              lockMode={false}
+            />
+          </dt>
         )}
         {!addMode && (
-          <span
-            className="min-w-0 truncate px-0.5 text-[0.625rem] font-semibold uppercase text-[var(--muted-foreground)]/88"
+          <dt
+            dir="auto"
+            className="line-clamp-2 min-w-0 whitespace-normal break-words px-0.5 text-[0.625rem] font-semibold uppercase text-[var(--muted-foreground)]/88"
             title={name}
           >
             {name}
-          </span>
+          </dt>
         )}
-        <InlineEdit
-          value={field.value}
-          onSave={(value) => onUpdate({ ...field, value })}
-          placeholder="Set value"
-          ariaLabel={`${name} value`}
-          className={cn(
-            "min-w-0 max-w-full pr-3 text-left font-bold text-[var(--foreground)]/92 drop-shadow-sm",
-            valueIsLong ? "min-h-5 text-[0.625rem] leading-[0.75rem]" : "text-[0.75rem] leading-4",
-          )}
-          previewLineCount={valueIsLong ? 2 : undefined}
-          scrollOnHover={!valueIsLong}
-          previewClassName={valueIsLong ? "whitespace-normal break-words" : undefined}
-          showEditHint={!deleteMode}
-          {...valueLock}
-        />
+        <dd className="min-w-0">
+          <WorldRenderedEdit
+            label={`${name} value`}
+            value={field.value}
+            onSave={(value) => onUpdate({ ...field, value })}
+            placeholder="Not recorded"
+            className="min-h-8 min-w-0 max-w-full pr-3 text-left font-bold text-[var(--foreground)]/92 drop-shadow-sm"
+            inputClassName="text-left text-[0.75rem]"
+            showEditHint={!deleteMode}
+            {...valueLock}
+          >
+            <WorldValueText value={field.value} maxLines={3} className="text-[0.75rem] leading-4" />
+          </WorldRenderedEdit>
+        </dd>
       </div>
       {deleteMode && (
         <button
@@ -144,12 +338,12 @@ function WorldCustomFieldPlate({
           }}
           title={`Remove ${name}`}
           aria-label={`Remove ${name}`}
-          className="absolute right-1 top-1/2 z-[4] flex h-5 w-5 -translate-y-1/2 items-center justify-center rounded-full bg-[var(--background)]/85 text-[var(--destructive)] shadow-sm ring-1 ring-[var(--border)]/70 backdrop-blur-sm transition-all hover:bg-[var(--accent)] focus-visible:outline-none focus-visible:ring-[var(--border)] active:scale-90 [@media(pointer:coarse)]:h-6 [@media(pointer:coarse)]:w-6"
+          className="absolute right-1 top-1/2 z-[4] flex h-5 w-5 -translate-y-1/2 items-center justify-center rounded-full bg-[var(--background)]/85 text-[var(--destructive)] shadow-sm ring-1 ring-[var(--border)]/70 backdrop-blur-sm transition-all hover:bg-[var(--accent)] focus-visible:outline-none focus-visible:ring-[var(--border)] active:scale-90 [@media(pointer:coarse)]:h-11 [@media(pointer:coarse)]:w-11"
         >
           <X size="0.625rem" />
         </button>
       )}
-    </WorldTileShell>
+    </div>
   );
 }
 
@@ -175,23 +369,24 @@ export function WorldStatePanel({
   onToggleCollapsed?: () => void;
 }) {
   const worldCustomFields = Array.isArray(state?.worldCustomFields) ? state.worldCustomFields : [];
+  const presentation = getWorldStatePresentation(
+    {
+      time: state?.time,
+      weather: state?.weather,
+      temperature: state?.temperature,
+    },
+    trackerTemperatureUnit,
+  );
+  const locationColor = getLocationPinColor(state?.location);
   const dateDisplay = getWorldDateDisplay(state?.date);
-  const hasFreeformDate = dateDisplay.kind === "freeform";
-  const hasPhraseTime = getWorldTimeDisplay(state?.time).kind === "phrase";
-  const gridColumnsClass = hasFreeformDate
-    ? hasPhraseTime
-      ? WORLD_FREEFORM_DATE_GRID_PHRASE_TIME_CLASS
-      : WORLD_FREEFORM_DATE_GRID_BASE_CLASS
-    : hasPhraseTime
-      ? WORLD_GRID_PHRASE_TIME_CLASS
-      : WORLD_GRID_BASE_CLASS;
-
+  const isCompact = trackerPanelSizeProfile === "compact";
   return (
     <div
-      className="relative z-10 overflow-hidden border-b border-[var(--border)] shadow-inner transition-colors duration-200"
-      style={getWorldAmbienceStyle()}
+      className="relative z-10 overflow-hidden border-b border-[var(--border)] shadow-inner transition-colors duration-200 @container"
+      style={presentation.ambienceStyle}
     >
-      <div className="pointer-events-none absolute inset-x-0 bottom-0 h-px bg-[var(--foreground)]/10" />
+      <div className="pointer-events-none absolute inset-0 opacity-[var(--tracker-world-atmosphere-opacity)] [background-image:radial-gradient(circle_at_68%_54%,var(--tracker-world-scene-wash),transparent_34%),radial-gradient(ellipse_at_18%_0%,var(--tracker-world-time-tone),transparent_48%),radial-gradient(ellipse_at_82%_12%,var(--tracker-world-weather-tone),transparent_44%),radial-gradient(ellipse_at_50%_100%,var(--tracker-world-temperature-tone),transparent_52%)] transition-[opacity,filter] duration-300 ease-[cubic-bezier(0.16,1,0.3,1)] motion-reduce:transition-none" />
+      <div className="pointer-events-none absolute inset-x-0 bottom-0 h-px bg-[var(--foreground)]/9" />
 
       <SectionHeader
         icon={<MapPin size="0.6875rem" />}
@@ -220,63 +415,96 @@ export function WorldStatePanel({
       />
 
       {!collapsed && (
-        <div className={cn("relative grid gap-0.5 p-1", gridColumnsClass)}>
-          <WorldDateTile
-            value={state?.date}
-            display={dateDisplay}
-            onSave={(value) => onSaveField("date", value || null)}
-            lockKey={worldTrackerLockKey("date")}
-          />
-          <WorldTimeTile
-            value={state?.time}
-            onSave={(value) => onSaveField("time", value || null)}
-            lockKey={worldTrackerLockKey("time")}
-          />
-          <WorldForecastTile
-            weather={state?.weather}
-            temperature={state?.temperature}
-            trackerPanelSizeProfile={trackerPanelSizeProfile}
-            trackerTemperatureUnit={trackerTemperatureUnit}
-            onSaveWeather={(value) => onSaveField("weather", value || null)}
-            onSaveTemperature={(value) => onSaveField("temperature", value || null)}
-            weatherLockKey={worldTrackerLockKey("weather")}
-            temperatureLockKey={worldTrackerLockKey("temperature")}
-          />
-          <WorldLocationPlate
-            value={state?.location}
-            onSave={(value) => onSaveField("location", value || null)}
-            className="col-span-full"
-            lockKey={worldTrackerLockKey("location")}
-          />
-          {worldCustomFields.map((field, index) => (
-            <WorldCustomFieldPlate
-              key={`${field.name}-${index}`}
-              field={field}
-              fieldIndex={index}
-              className="col-span-full"
-              addMode={addMode}
-              deleteMode={deleteMode}
-              onUpdate={(updated) => {
-                const next = [...worldCustomFields];
-                next[index] = updated;
-                onSaveField("worldCustomFields", next);
-              }}
-              onRemove={() =>
-                onSaveField(
-                  "worldCustomFields",
-                  worldCustomFields.filter((_, fieldIndex) => fieldIndex !== index),
-                )
-              }
-              isNameTaken={(candidate) =>
-                worldCustomFields.some(
-                  (otherField, otherIndex) =>
-                    otherIndex !== index &&
-                    normalizeCustomFieldName(otherField.name) === normalizeCustomFieldName(candidate),
-                )
-              }
+        <>
+          <div
+            className={cn(
+              "relative z-[1] mt-0.5 grid min-w-0 gap-0.5 px-2 py-1.5 @container",
+              isCompact && "px-1.5 py-1",
+            )}
+          >
+            <WorldInstrumentFrame
+              sizeProfile={trackerPanelSizeProfile}
+              locationColor={locationColor}
+              dateColor={dateDisplay.iconColor}
             />
-          ))}
-        </div>
+            <div className="relative min-w-0 pb-1.5">
+              <WorldLocatorRail locationColor={locationColor} />
+              <div className={cn("min-w-0 pl-7", isCompact && "pl-6")}>
+                <WorldLocationPlate
+                  value={state?.location}
+                  onSave={(value) => onSaveField("location", value || null)}
+                  lockKey={worldTrackerLockKey("location")}
+                  sizeProfile={trackerPanelSizeProfile}
+                />
+              </div>
+            </div>
+            <div
+              className={cn(
+                "relative isolate mx-auto grid w-full max-w-[30rem] min-w-0 grid-cols-2 gap-2 px-1",
+                isCompact && "grid-cols-[minmax(0,0.9fr)_minmax(0,1.1fr)] gap-1 px-0",
+                trackerPanelSizeProfile === "standard" &&
+                  "grid-cols-[minmax(0,1.05fr)_minmax(0,0.95fr)] gap-1.5 px-0.5",
+              )}
+            >
+              <WorldSceneAtmosphere glyph={presentation.sceneGlyph} sizeProfile={trackerPanelSizeProfile} />
+              <WorldDateTimeTile
+                dateText={visibleText(state?.date, "")}
+                dateColor={dateDisplay.iconColor}
+                dateDay={dateDisplay.day}
+                timeDisplay={presentation.time}
+                onSaveDate={(value) => onSaveField("date", value || null)}
+                onSaveTime={(value) => onSaveField("time", value || null)}
+                dateLockKey={worldTrackerLockKey("date")}
+                timeLockKey={worldTrackerLockKey("time")}
+                sizeProfile={trackerPanelSizeProfile}
+              />
+              <WorldForecastTile
+                weatherText={presentation.weatherText}
+                temperatureValue={state?.temperature}
+                temperatureDisplay={presentation.temperature}
+                onSaveWeather={(value) => onSaveField("weather", value || null)}
+                onSaveTemperature={(value) => onSaveField("temperature", value || null)}
+                weatherLockKey={worldTrackerLockKey("weather")}
+                temperatureLockKey={worldTrackerLockKey("temperature")}
+                sizeProfile={trackerPanelSizeProfile}
+              />
+            </div>
+          </div>
+          {worldCustomFields.length > 0 && (
+            <section className="relative grid min-w-0 gap-1 px-1 pb-1">
+              <dl className="grid min-w-0 gap-0.5">
+                {worldCustomFields.map((field, index) => (
+                  <WorldCustomFieldPlate
+                    key={`${field.name}-${index}`}
+                    field={field}
+                    fieldIndex={index}
+                    className="col-span-full"
+                    addMode={addMode}
+                    deleteMode={deleteMode}
+                    onUpdate={(updated) => {
+                      const next = [...worldCustomFields];
+                      next[index] = updated;
+                      onSaveField("worldCustomFields", next);
+                    }}
+                    onRemove={() =>
+                      onSaveField(
+                        "worldCustomFields",
+                        worldCustomFields.filter((_, fieldIndex) => fieldIndex !== index),
+                      )
+                    }
+                    isNameTaken={(candidate) =>
+                      worldCustomFields.some(
+                        (otherField, otherIndex) =>
+                          otherIndex !== index &&
+                          normalizeCustomFieldName(otherField.name) === normalizeCustomFieldName(candidate),
+                      )
+                    }
+                  />
+                ))}
+              </dl>
+            </section>
+          )}
+        </>
       )}
     </div>
   );

--- a/packages/client/src/features/tracker-panel/components/sections/WorldStatePanel.tsx
+++ b/packages/client/src/features/tracker-panel/components/sections/WorldStatePanel.tsx
@@ -275,7 +275,10 @@ function WorldCustomFieldPlate({
 
   return (
     <div
-      className={cn("@container relative min-h-[2.25rem] min-w-0 transition-colors duration-200", className)}
+      className={cn(
+        "@container relative min-h-[2.25rem] min-w-0 transition-colors duration-200 [@media(pointer:coarse)]:min-h-11",
+        className,
+      )}
       title={name}
     >
       <div

--- a/packages/client/src/features/tracker-panel/lib/world-state-display.ts
+++ b/packages/client/src/features/tracker-panel/lib/world-state-display.ts
@@ -1,409 +1,247 @@
 import type { CSSProperties } from "react";
 import type { TrackerTemperatureUnit } from "../../../stores/ui.store";
+import {
+  classifyWorldWeather,
+  getTemperatureGaugeDisplay,
+  getWorldTimeDisplay,
+  type WorldWeatherFamily,
+} from "../../../lib/world-state-helpers";
 import { visibleText } from "./tracker-display";
 
-// Row 1 holds Date / Time / Forecast; the forecast column flexes to fill the
-// remaining width so weather is never squeezed. Location renders on its own
-// full-width row below (see WorldStatePanel), so no per-tile width balancing is
-// needed. Word-based times ("Afternoon") get a wider Time column so the word
-// stays readable and wraps on spaces instead of shrinking; clock times keep the
-// compact 3.25rem column.
-export const WORLD_GRID_BASE_CLASS = "grid-cols-[2.5rem_3.25rem_minmax(0,1fr)]";
-export const WORLD_GRID_PHRASE_TIME_CLASS = "grid-cols-[2.5rem_4.5rem_minmax(0,1fr)]";
-export const WORLD_FREEFORM_DATE_GRID_BASE_CLASS = "grid-cols-[minmax(3.8rem,4.45rem)_3.25rem_minmax(0,1fr)]";
-export const WORLD_FREEFORM_DATE_GRID_PHRASE_TIME_CLASS = "grid-cols-[minmax(3.8rem,4.45rem)_4.5rem_minmax(0,1fr)]";
+export type WorldSceneGlyph = "sun" | "moon" | "cloud" | "rain" | "snow" | "storm" | "fog" | "wind" | "fire";
+type WorldSceneTone = "warm" | "cool" | "muted" | "neutral";
+type WorldTimeDisplay = ReturnType<typeof getWorldTimeDisplay>;
+type WorldTimeOfDay = WorldTimeDisplay["timeOfDay"];
 
-export const WORLD_MONTH_LABELS = ["JAN", "FEB", "MAR", "APR", "MAY", "JUN", "JUL", "AUG", "SEP", "OCT", "NOV", "DEC"];
-export const WORLD_MONTH_ALIASES: Record<string, number> = {
-  jan: 0,
-  january: 0,
-  feb: 1,
-  february: 1,
-  mar: 2,
-  march: 2,
-  apr: 3,
-  april: 3,
-  may: 4,
-  jun: 5,
-  june: 5,
-  jul: 6,
-  july: 6,
-  aug: 7,
-  august: 7,
-  sep: 8,
-  sept: 8,
-  september: 8,
-  oct: 9,
-  october: 9,
-  nov: 10,
-  november: 10,
-  dec: 11,
-  december: 11,
+interface WorldScenePresentation {
+  glyph?: WorldSceneGlyph;
+  tone: WorldSceneTone;
+}
+
+interface TrackerWeatherStyle {
+  tone: string;
+  accent: string;
+  scene?: WorldScenePresentation;
+}
+
+/**
+ * Select one conservative cue for the whole scene. Individual field
+ * presentations remain authoritative; this is only a compact, optional hint.
+ */
+function getWorldScenePresentation({
+  time,
+  weatherFamily,
+  weatherText,
+}: {
+  time: WorldTimeDisplay;
+  weatherFamily: WorldWeatherFamily;
+  weatherText: string;
+}): WorldScenePresentation {
+  const normalizedWeather = weatherText.toLowerCase();
+  const mentionsDay = /\b(day|daylight|morning|noon|afternoon|sunrise|sunny|sunlit)\b/.test(normalizedWeather);
+  const mentionsNight = /\b(night|nighttime|midnight|evening|dusk|moonlit|starlit)\b/.test(normalizedWeather);
+  const hasTimeConflict =
+    (time.timeOfDay === "night" && mentionsDay) ||
+    ((time.timeOfDay === "dawn" || time.timeOfDay === "day") && mentionsNight);
+
+  if (hasTimeConflict) return { tone: "neutral" };
+
+  if (weatherFamily === "clear") {
+    if (time.timeOfDay === "night") return { glyph: "moon", tone: "cool" };
+    if (time.timeOfDay === "dawn" || time.timeOfDay === "day") {
+      return { glyph: "sun", tone: "warm" };
+    }
+  }
+
+  const configuredScene = TRACKER_WEATHER_STYLES[weatherFamily].scene;
+  if (configuredScene) return configuredScene;
+  if (time.timeOfDay === "night") return { glyph: "moon", tone: "cool" };
+
+  return { tone: "neutral" };
+}
+
+interface WorldStateInputs {
+  time?: string | null;
+  weather?: string | null;
+  temperature?: string | null;
+}
+
+type WorldAmbienceStyle = CSSProperties & Record<`--${string}`, string | number>;
+
+const WORLD_TIME_TONE: Record<WorldTimeOfDay, string> = {
+  dawn: "color-mix(in srgb, var(--primary) 15%, transparent)",
+  day: "color-mix(in srgb, var(--foreground) 8%, transparent)",
+  dusk: "color-mix(in srgb, color-mix(in srgb, var(--primary) 70%, var(--destructive) 30%) 15%, transparent)",
+  night: "color-mix(in srgb, var(--accent) 18%, transparent)",
+  unknown: "transparent",
 };
 
-function getFreeformDateParts(text: string) {
-  const normalized = text.replace(/\s+/g, " ").trim();
-  const ofMatch = normalized.match(/^(.+?)\s+of\s+(.+)$/i);
-  if (ofMatch) {
-    return {
-      main: ofMatch[2]!.trim(),
-      detail: ofMatch[1]!.trim(),
-    };
-  }
+const WORLD_TIME_ACCENT: Record<WorldTimeOfDay, string> = {
+  dawn: "oklch(0.8 0.13 72)",
+  day: "oklch(0.82 0.055 225)",
+  dusk: "oklch(0.72 0.135 38)",
+  night: "oklch(0.7 0.12 255)",
+  unknown: "var(--muted-foreground)",
+};
 
-  const commaParts = normalized.split(/\s*,\s*/).filter(Boolean);
-  if (commaParts.length > 1) {
-    return {
-      main: commaParts[0]!,
-      detail: commaParts.slice(1).join(", "),
-    };
-  }
+const TRACKER_WEATHER_STYLES: Record<WorldWeatherFamily, TrackerWeatherStyle> = {
+  thunder: {
+    tone: "color-mix(in srgb, var(--muted-foreground) 16%, transparent)",
+    accent: "oklch(0.68 0.14 285)",
+    scene: { glyph: "storm", tone: "muted" },
+  },
+  blizzard: {
+    tone: "color-mix(in srgb, var(--foreground) 10%, transparent)",
+    accent: "oklch(0.86 0.07 220)",
+    scene: { glyph: "snow", tone: "cool" },
+  },
+  "heavy-rain": {
+    tone: "color-mix(in srgb, var(--muted-foreground) 16%, transparent)",
+    accent: "oklch(0.68 0.14 285)",
+    scene: { glyph: "storm", tone: "muted" },
+  },
+  rain: {
+    tone: "color-mix(in srgb, var(--primary) 10%, transparent)",
+    accent: "oklch(0.7 0.13 235)",
+    scene: { glyph: "rain", tone: "cool" },
+  },
+  hail: {
+    tone: "color-mix(in srgb, var(--foreground) 10%, transparent)",
+    accent: "oklch(0.86 0.07 220)",
+    scene: { glyph: "snow", tone: "cool" },
+  },
+  snow: {
+    tone: "color-mix(in srgb, var(--foreground) 10%, transparent)",
+    accent: "oklch(0.86 0.07 220)",
+    scene: { glyph: "snow", tone: "cool" },
+  },
+  fog: {
+    tone: "color-mix(in srgb, var(--muted-foreground) 12%, transparent)",
+    accent: "oklch(0.72 0.035 240)",
+    scene: { glyph: "fog", tone: "muted" },
+  },
+  sand: {
+    tone: "color-mix(in srgb, var(--destructive) 9%, transparent)",
+    accent: "oklch(0.76 0.12 72)",
+    scene: { glyph: "wind", tone: "warm" },
+  },
+  ash: {
+    tone: "color-mix(in srgb, var(--muted-foreground) 14%, transparent)",
+    accent: "oklch(0.62 0.025 250)",
+    scene: { glyph: "fog", tone: "muted" },
+  },
+  fire: {
+    tone: "color-mix(in srgb, var(--destructive) 12%, transparent)",
+    accent: "oklch(0.73 0.17 44)",
+    scene: { glyph: "fire", tone: "warm" },
+  },
+  wind: {
+    tone: "color-mix(in srgb, var(--foreground) 7%, transparent)",
+    accent: "oklch(0.76 0.09 210)",
+    scene: { glyph: "wind", tone: "cool" },
+  },
+  blossom: {
+    tone: "color-mix(in srgb, var(--primary) 10%, transparent)",
+    accent: "oklch(0.78 0.12 15)",
+    scene: { glyph: "sun", tone: "warm" },
+  },
+  aurora: {
+    tone: "color-mix(in srgb, var(--accent) 15%, transparent)",
+    accent: "oklch(0.76 0.13 190)",
+    scene: { glyph: "moon", tone: "cool" },
+  },
+  cloud: {
+    tone: "color-mix(in srgb, var(--muted-foreground) 10%, transparent)",
+    accent: "oklch(0.7 0.035 235)",
+    scene: { glyph: "cloud", tone: "muted" },
+  },
+  clear: {
+    tone: "color-mix(in srgb, var(--primary) 9%, transparent)",
+    accent: "oklch(0.81 0.12 85)",
+  },
+  heat: {
+    tone: "color-mix(in srgb, var(--destructive) 12%, transparent)",
+    accent: "oklch(0.7 0.17 38)",
+    scene: { glyph: "fire", tone: "warm" },
+  },
+  cold: {
+    tone: "color-mix(in srgb, var(--primary) 9%, transparent)",
+    accent: "oklch(0.74 0.11 235)",
+    scene: { glyph: "snow", tone: "cool" },
+  },
+  atmosphere: {
+    tone: "transparent",
+    accent: "var(--muted-foreground)",
+  },
+};
 
-  const words = normalized.split(" ");
-  if (words.length > 2) {
-    return {
-      main: words.slice(0, 2).join(" "),
-      detail: words.slice(2).join(" "),
-    };
-  }
+const WORLD_SCENE_INK: Record<WorldSceneTone, string> = {
+  cool: "oklch(0.76 0.105 232)",
+  warm: "oklch(0.79 0.125 76)",
+  muted: "color-mix(in oklch, var(--muted-foreground) 78%, var(--foreground) 22%)",
+  neutral: "color-mix(in oklch, var(--muted-foreground) 64%, var(--foreground) 36%)",
+};
 
-  return {
-    main: normalized,
-    detail: "",
-  };
-}
-
-function getCalendarDateDisplay({
-  month,
-  day,
-  year = "",
-  raw,
+function getWorldAmbienceStyle({
+  time,
+  weatherFamily,
+  hasWeatherText,
+  temperature,
+  scene,
 }: {
-  month: string;
-  day: string;
-  year?: string;
-  raw: string;
-}) {
-  return {
-    kind: "calendar" as const,
-    month,
-    day,
-    year,
-    raw,
-    main: "",
-    detail: "",
-  };
-}
+  time: WorldTimeDisplay;
+  weatherFamily: WorldWeatherFamily;
+  hasWeatherText: boolean;
+  temperature: ReturnType<typeof getTemperatureGaugeDisplay>;
+  scene: WorldScenePresentation;
+}): WorldAmbienceStyle {
+  const weatherStyle = TRACKER_WEATHER_STYLES[weatherFamily];
+  const sceneInk = WORLD_SCENE_INK[scene.tone];
+  const temperatureTone =
+    temperature.value === null ? "transparent" : `color-mix(in srgb, ${temperature.color} 8%, transparent)`;
+  const hasAtmosphere =
+    time.timeOfDay !== "unknown" ||
+    weatherFamily !== "atmosphere" ||
+    temperature.value !== null;
 
-export function getWorldDateDisplay(date: string | null | undefined) {
-  const text = (date ?? "").trim();
-  if (!text) return { kind: "empty" as const, month: "DATE", day: "--", year: "", raw: "", main: "", detail: "" };
-
-  const isoMatch = text.match(/\b(\d{4})[-/.](\d{1,2})[-/.](\d{1,2})\b/);
-  if (isoMatch) {
-    const monthIndex = Number(isoMatch[2]) - 1;
-    return getCalendarDateDisplay({
-      month: WORLD_MONTH_LABELS[monthIndex] ?? "DATE",
-      day: String(Number(isoMatch[3])).padStart(2, "0"),
-      year: isoMatch[1]!,
-      raw: text,
-    });
-  }
-
-  const numericDate = text.match(/\b(\d{1,2})[-/.](\d{1,2})[-/.](\d{2,4})\b/);
-  if (numericDate) {
-    const first = Number(numericDate[1]);
-    const second = Number(numericDate[2]);
-    const day = first > 12 ? first : second;
-    const monthIndex = (first > 12 ? second : first) - 1;
-    return getCalendarDateDisplay({
-      month: WORLD_MONTH_LABELS[monthIndex] ?? "DATE",
-      day: String(day).padStart(2, "0"),
-      year: numericDate[3]!,
-      raw: text,
-    });
-  }
-
-  const namedMonthFirst = text.match(
-    /\b(jan(?:uary)?|feb(?:ruary)?|mar(?:ch)?|apr(?:il)?|may|jun(?:e)?|jul(?:y)?|aug(?:ust)?|sep(?:t|tember)?|oct(?:ober)?|nov(?:ember)?|dec(?:ember)?)\.?\s+(\d{1,2})(?:st|nd|rd|th)?(?:,?\s+(\d{2,4}))?\b/i,
-  );
-  if (namedMonthFirst) {
-    const monthIndex = WORLD_MONTH_ALIASES[namedMonthFirst[1]!.toLowerCase()];
-    return getCalendarDateDisplay({
-      month: monthIndex === undefined ? "DATE" : (WORLD_MONTH_LABELS[monthIndex] ?? "DATE"),
-      day: String(Number(namedMonthFirst[2])).padStart(2, "0"),
-      year: namedMonthFirst[3] ?? "",
-      raw: text,
-    });
-  }
-
-  const dayFirst = text.match(
-    /\b(\d{1,2})(?:st|nd|rd|th)?\s+(jan(?:uary)?|feb(?:ruary)?|mar(?:ch)?|apr(?:il)?|may|jun(?:e)?|jul(?:y)?|aug(?:ust)?|sep(?:t|tember)?|oct(?:ober)?|nov(?:ember)?|dec(?:ember)?)(?:\.|,)?(?:\s+(\d{2,4}))?\b/i,
-  );
-  if (dayFirst) {
-    const monthIndex = WORLD_MONTH_ALIASES[dayFirst[2]!.toLowerCase()];
-    return getCalendarDateDisplay({
-      month: monthIndex === undefined ? "DATE" : (WORLD_MONTH_LABELS[monthIndex] ?? "DATE"),
-      day: String(Number(dayFirst[1])).padStart(2, "0"),
-      year: dayFirst[3] ?? "",
-      raw: text,
-    });
-  }
-
-  const freeform = getFreeformDateParts(text);
-  return {
-    kind: "freeform" as const,
-    month: "DATE",
-    day: "",
-    year: "",
-    raw: text,
-    main: freeform.main,
-    detail: freeform.detail,
-  };
-}
-
-export type WorldDateDisplay = ReturnType<typeof getWorldDateDisplay>;
-
-export function getWorldTimeDisplay(time: string | null | undefined) {
-  const text = (time ?? "").trim();
-  if (!text) return { kind: "empty" as const, main: "--:--", suffix: "", raw: "", hour: null, minute: null };
-
-  const meridiem = text.match(/\b(1[0-2]|0?\d)(?::([0-5]\d))?\s*([ap])\.?m?\.?\b/i);
-  if (meridiem) {
-    const displayHour = Number(meridiem[1]);
-    const minute = Number(meridiem[2] ?? "00");
-    const marker = meridiem[3]!.toLowerCase();
-    const hour = marker === "p" ? (displayHour % 12) + 12 : displayHour % 12;
-    return {
-      kind: "clock" as const,
-      main: `${meridiem[1]!.padStart(2, "0")}:${meridiem[2] ?? "00"}`,
-      suffix: `${meridiem[3]!.toUpperCase()}M`,
-      hour,
-      minute,
-      raw: text,
-    };
-  }
-
-  const twentyFourHour = text.match(/\b([01]?\d|2[0-3])[:.]([0-5]\d)\b/);
-  if (twentyFourHour) {
-    const hour = Number(twentyFourHour[1]);
-    const minute = Number(twentyFourHour[2]);
-    return {
-      kind: "clock" as const,
-      main: `${twentyFourHour[1]!.padStart(2, "0")}:${twentyFourHour[2]}`,
-      suffix: "",
-      hour,
-      minute,
-      raw: text,
-    };
-  }
-
-  // Word-based time ("Late", "Midnight", "Just before dawn") — no clock face,
-  // shown as a wrapped phrase so it is never truncated to "Late...".
-  return { kind: "phrase" as const, main: text, suffix: "", raw: text, hour: null, minute: null };
-}
-
-export function getWeatherEmoji(weather: string | null | undefined) {
-  const text = (weather ?? "").toLowerCase();
-  if (text.includes("thunder") || text.includes("lightning")) return "⛈️";
-  if (text.includes("blizzard")) return "🌨️";
-  if (text.includes("heavy rain") || text.includes("downpour") || text.includes("storm")) return "🌧️";
-  if (text.includes("rain") || text.includes("drizzle") || text.includes("shower")) return "🌦️";
-  if (text.includes("hail")) return "🧊";
-  if (text.includes("snow") || text.includes("sleet") || text.includes("frost")) return "❄️";
-  if (text.includes("fog") || text.includes("mist") || text.includes("haze")) return "🌫️";
-  if (text.includes("sand") || text.includes("dust")) return "🏜️";
-  if (text.includes("ash") || text.includes("volcanic") || text.includes("smoke")) return "🌋";
-  if (text.includes("ember") || text.includes("fire") || text.includes("inferno")) return "🔥";
-  if (text.includes("wind") || text.includes("breez") || text.includes("gust")) return "💨";
-  if (text.includes("cherry") || text.includes("blossom") || text.includes("petal")) return "🌸";
-  if (text.includes("aurora") || text.includes("northern light")) return "🌌";
-  if (text.includes("cloud") || text.includes("overcast") || text.includes("grey") || text.includes("gray"))
-    return "☁️";
-  if (text.includes("clear") || text.includes("sunny") || text.includes("bright")) return "☀️";
-  if (text.includes("hot") || text.includes("swelter")) return "🥵";
-  if (text.includes("cold") || text.includes("freez")) return "🥶";
-  return "🌤️";
-}
-
-export function parseTemperatureValue(temperature: string | null | undefined) {
-  const match = (temperature ?? "").match(/(-?\d+(?:\.\d+)?)(?:\s*°?\s*(f(?:ahrenheit)?|c(?:elsius)?)\b)?/i);
-  if (!match) return null;
-  const numeric = parseFloat(match[1]!);
-  const unit = match[2]?.toLowerCase();
-  if (unit?.startsWith("f")) return (numeric - 32) * (5 / 9);
-  return numeric;
-}
-
-/** Parse a temperature only when the entire value is numeric, with an optional unit. */
-export function parsePureTemperatureValue(temperature: string | null | undefined) {
-  const match = (temperature ?? "").match(/^\s*([+-]?\d+(?:\.\d+)?)\s*°?\s*(f(?:ahrenheit)?|c(?:elsius)?)?\s*$/i);
-  if (!match) return null;
-  const numeric = parseFloat(match[1]!);
-  return match[2]?.toLowerCase().startsWith("f") ? (numeric - 32) * (5 / 9) : numeric;
-}
-
-function formatTemperatureValue(celsius: number, unit: TrackerTemperatureUnit) {
-  if (unit === "fahrenheit") return `${Math.round(celsius * (9 / 5) + 32)}°F`;
-  return `${Math.round(celsius)}°C`;
-}
-
-export function getTemperatureKeywordHint(temperature: string | null | undefined) {
-  const text = (temperature ?? "").toLowerCase();
-  if (/\b(freez|frigid|arctic|glacial|sub-?zero|blizzard)/.test(text)) return -10;
-  if (/\b(cold|chill|frost|wintry|icy|bitter|nipp)/.test(text)) return 2;
-  if (/\b(cool|brisk|crisp|refresh)/.test(text)) return 12;
-  if (/\b(mild|pleasant|comfort|temperate|fair)/.test(text)) return 20;
-  if (/\b(warm|balmy|toasty|muggy|humid|stuffy|sultry)/.test(text)) return 28;
-  if (/\b(hot|swelter|blaz|scorch|burn|heat|boil|sear|bak)/.test(text)) return 38;
-  return null;
-}
-
-export function getTemperatureColor(temperature: string | null | undefined) {
-  const parsed = parseTemperatureValue(temperature);
-  const value = parsed ?? getTemperatureKeywordHint(temperature);
-  if (value === null) return "text-[var(--muted-foreground)]/70";
-  if (value < 0) return "text-blue-400";
-  if (value < 15) return "text-sky-400";
-  if (value < 30) return "text-lime-500";
-  return "text-red-400";
-}
-
-export function getTemperatureGaugeDisplay(
-  temperature: string | null | undefined,
-  unit: TrackerTemperatureUnit = "celsius",
-) {
-  const parsed = parseTemperatureValue(temperature);
-  const pureParsed = parsePureTemperatureValue(temperature);
-  const hinted = getTemperatureKeywordHint(temperature);
-  const value = parsed ?? hinted;
-  const percent =
-    value === null ? 42 : Math.max(8, Math.min(96, Math.round(((Math.max(-12, Math.min(42, value)) + 12) / 54) * 100)));
-  const color =
-    value === null
-      ? "color-mix(in srgb, var(--foreground) 42%, var(--muted-foreground) 28%)"
-      : value < 0
-        ? "rgb(96 165 250)"
-        : value < 15
-          ? "rgb(56 189 248)"
-          : value < 30
-            ? "rgb(132 204 22)"
-            : "rgb(248 113 113)";
-
-  return {
-    color,
-    label: pureParsed !== null ? formatTemperatureValue(pureParsed, unit) : visibleText(temperature, "--"),
-    percent,
-  };
-}
-
-export function getLocationPinColor(location: string | null | undefined) {
-  const text = (location ?? "").toLowerCase();
-  if (
-    /\b(sea|ocean|lake|river|pond|creek|bay|shore|beach|harbor|harbour|port|coast|marsh|swamp|waterfall|spring|well|dock|canal|dam|reef|lagoon|estuary|fjord|cove)\b/.test(
-      text,
-    )
-  ) {
-    return "text-blue-400";
-  }
-  if (
-    /\b(mountain|hill|cliff|peak|ridge|canyon|gorge|cave|cavern|mine|quarry|summit|bluff|crag|volcano|crater|mesa|plateau|ravine|boulder)\b/.test(
-      text,
-    )
-  ) {
-    return "text-amber-700";
-  }
-  if (
-    /\b(city|town|village|castle|palace|fortress|market|shop|inn|tavern|bar|pub|guild|district|quarter|bazaar|temple|church|cathedral|shrine|tower|gate|square|plaza|street|alley|arena|throne|court|capitol|capital|metro|subway)\b/.test(
-      text,
-    )
-  ) {
-    return "text-sky-400";
-  }
-  if (
-    /\b(room|hall|chamber|dungeon|cellar|basement|attic|library|study|bedroom|kitchen|office|lab|laboratory|vault|corridor|passage|cabin|hut|tent|interior|house|home|building|apartment|manor|lodge|dormitor|warehouse|prison|cell|jail)\b/.test(
-      text,
-    )
-  ) {
-    return "text-amber-300";
-  }
-  return "text-emerald-400";
-}
-
-export function getWorldDateIconColor(date: string | null | undefined) {
-  const text = (date ?? "").trim();
-  if (!text) return "text-[var(--muted-foreground)]/70";
-
-  const display = getWorldDateDisplay(text);
-  const normalized = `${text} ${display.main} ${display.detail}`.toLowerCase();
-  const monthIndex =
-    display.month !== "DATE" ? WORLD_MONTH_LABELS.indexOf(display.month) : inferMonthIndexFromText(normalized);
-
-  if (/\b(winter|snow|frost|yuletide|christmas|yule|solstice)\b/.test(normalized)) return "text-sky-300";
-  if (/\b(spring|blossom|bloom|equinox)\b/.test(normalized)) return "text-emerald-300";
-  if (/\b(summer|midsummer|sunny|heatwave)\b/.test(normalized)) return "text-yellow-300";
-  if (/\b(autumn|fall|harvest|leaf|leaves)\b/.test(normalized)) return "text-orange-400";
-
-  if (monthIndex === 11 || monthIndex === 0 || monthIndex === 1) return "text-sky-300";
-  if (monthIndex >= 2 && monthIndex <= 4) return "text-emerald-300";
-  if (monthIndex >= 5 && monthIndex <= 7) return "text-yellow-300";
-  if (monthIndex >= 8 && monthIndex <= 10) return "text-orange-400";
-  return "text-zinc-200";
-}
-
-export function getWorldTimeIconColor(time: string | null | undefined) {
-  const text = (time ?? "").trim();
-  if (!text) return "text-[var(--muted-foreground)]/70";
-  const normalized = text.toLowerCase();
-
-  if (/\b(dawn|sunrise|morning|daybreak)\b/.test(normalized)) return "text-amber-300";
-  if (/\b(noon|midday|afternoon|daylight)\b/.test(normalized)) return "text-yellow-300";
-  if (/\b(dusk|sunset|twilight|evening|golden hour)\b/.test(normalized)) return "text-orange-400";
-  if (/\b(night|midnight|moon|moonlit|late)\b/.test(normalized)) return "text-indigo-300";
-
-  const display = getWorldTimeDisplay(text);
-  const hour = display.hour;
-  if (hour === null) return "text-amber-300";
-  if (hour >= 5 && hour < 10) return "text-amber-300";
-  if (hour >= 10 && hour < 17) return "text-yellow-300";
-  if (hour >= 17 && hour < 20) return "text-orange-400";
-  return "text-indigo-300";
-}
-
-export function getWeatherIconColor(weather: string | null | undefined) {
-  const text = (weather ?? "").toLowerCase();
-  if (!text) return "text-[var(--muted-foreground)]/70";
-  if (text.includes("thunder") || text.includes("lightning")) return "text-violet-300";
-  if (text.includes("blizzard") || text.includes("snow") || text.includes("sleet") || text.includes("frost"))
-    return "text-sky-300";
-  if (text.includes("heavy rain") || text.includes("downpour") || text.includes("storm")) return "text-blue-300";
-  if (text.includes("rain") || text.includes("drizzle") || text.includes("shower")) return "text-cyan-300";
-  if (text.includes("hail")) return "text-sky-200";
-  if (text.includes("fog") || text.includes("mist") || text.includes("haze")) return "text-zinc-300";
-  if (text.includes("sand") || text.includes("dust")) return "text-amber-300";
-  if (text.includes("ash") || text.includes("volcanic") || text.includes("smoke")) return "text-stone-300";
-  if (text.includes("ember") || text.includes("fire") || text.includes("inferno")) return "text-red-400";
-  if (text.includes("wind") || text.includes("breez") || text.includes("gust")) return "text-teal-300";
-  if (text.includes("cherry") || text.includes("blossom") || text.includes("petal"))
-    return "text-[var(--marinara-chat-chrome-panel-text)]";
-  if (text.includes("aurora") || text.includes("northern light"))
-    return "text-[var(--marinara-chat-chrome-panel-text)]";
-  if (text.includes("cloud") || text.includes("overcast") || text.includes("grey") || text.includes("gray"))
-    return "text-zinc-300";
-  if (text.includes("clear") || text.includes("sunny") || text.includes("bright")) return "text-yellow-300";
-  if (text.includes("hot") || text.includes("swelter")) return "text-red-400";
-  return "text-sky-300";
-}
-
-function inferMonthIndexFromText(text: string) {
-  for (const [alias, index] of Object.entries(WORLD_MONTH_ALIASES)) {
-    if (new RegExp(`\\b${alias}\\.?\\b`, "i").test(text)) return index;
-  }
-  return -1;
-}
-
-export function getWorldAmbienceStyle(): CSSProperties {
   return {
     background: "var(--tracker-panel-section-background, color-mix(in srgb, var(--card) 6%, transparent))",
+    "--tracker-world-time-tone": WORLD_TIME_TONE[time.timeOfDay],
+    "--tracker-world-weather-tone": weatherStyle.tone,
+    "--tracker-world-temperature-tone": temperatureTone,
+    "--tracker-world-time-accent": time.timeOfDay === "unknown" ? sceneInk : WORLD_TIME_ACCENT[time.timeOfDay],
+    "--tracker-world-weather-accent": hasWeatherText ? weatherStyle.accent : sceneInk,
+    "--tracker-world-temperature-accent": temperature.value !== null ? temperature.color : sceneInk,
+    "--tracker-world-scene-ink": sceneInk,
+    "--tracker-world-scene-wash": `color-mix(in oklch, ${sceneInk} 16%, transparent)`,
+    "--tracker-world-scene-stroke": `color-mix(in oklch, ${sceneInk} 34%, transparent)`,
+    "--tracker-world-atmosphere-opacity": hasAtmosphere ? "0.78" : "0.36",
   };
 }
+
+export function getWorldStatePresentation(
+  inputs: WorldStateInputs = {},
+  temperatureUnit: TrackerTemperatureUnit = "celsius",
+) {
+  const time = getWorldTimeDisplay(inputs.time);
+  const weatherText = visibleText(inputs.weather, "");
+  const weatherFamily = classifyWorldWeather(weatherText);
+  const temperature = getTemperatureGaugeDisplay(inputs.temperature, temperatureUnit);
+  const scene = getWorldScenePresentation({ time, weatherFamily, weatherText });
+
+  return {
+    time,
+    weatherText,
+    temperature,
+    sceneGlyph: scene.glyph,
+    ambienceStyle: getWorldAmbienceStyle({
+      time,
+      weatherFamily,
+      hasWeatherText: Boolean(weatherText),
+      temperature,
+      scene,
+    }),
+  } as const;
+}
+
+export type WorldStatePresentation = ReturnType<typeof getWorldStatePresentation>;

--- a/packages/client/src/features/tracker-panel/tracker-font.css
+++ b/packages/client/src/features/tracker-panel/tracker-font.css
@@ -1,0 +1,1 @@
+@import "@fontsource/share-tech-mono/400.css";

--- a/packages/client/src/lib/world-state-helpers.ts
+++ b/packages/client/src/lib/world-state-helpers.ts
@@ -1,0 +1,300 @@
+import type { TrackerTemperatureUnit } from "../stores/ui.store";
+
+const WORLD_MONTH_ALIASES: Record<string, number> = {
+  jan: 0,
+  january: 0,
+  feb: 1,
+  february: 1,
+  mar: 2,
+  march: 2,
+  apr: 3,
+  april: 3,
+  may: 4,
+  jun: 5,
+  june: 5,
+  jul: 6,
+  july: 6,
+  aug: 7,
+  august: 7,
+  sep: 8,
+  sept: 8,
+  september: 8,
+  oct: 9,
+  october: 9,
+  nov: 10,
+  november: 10,
+  dec: 11,
+  december: 11,
+};
+
+type WorldTimeOfDay = "dawn" | "day" | "dusk" | "night" | "unknown";
+
+// Preserve the legacy HUD's approximate clock positions for familiar phrases.
+function getWorldTimePhrase(text: string): { timeOfDay: WorldTimeOfDay; hour: number | null } | null {
+  if (/\b(dawn|sunrise|daybreak|morning)\b/.test(text)) {
+    return { timeOfDay: "dawn", hour: /\bmorning\b/.test(text) ? 9 : /\b(dawn|sunrise)\b/.test(text) ? 6 : null };
+  }
+  if (/\b(noon|midday|afternoon|daylight)\b/.test(text)) {
+    return { timeOfDay: "day", hour: /\b(noon|midday)\b/.test(text) ? 12 : /\bafternoon\b/.test(text) ? 15 : null };
+  }
+  if (/\b(dusk|sunset|twilight|evening|golden hour)\b/.test(text)) {
+    return {
+      timeOfDay: "dusk",
+      hour: /\b(dusk|sunset|evening)\b/.test(text) ? 18 : null,
+    };
+  }
+  if (/\b(night|midnight|witching|moon|moonlit|moonlight|late)\b/.test(text)) {
+    return {
+      timeOfDay: "night",
+      hour: /\bmidnight\b/.test(text) ? 0 : /\bnight\b/.test(text) ? 22 : null,
+    };
+  }
+  return null;
+}
+
+function getWorldTimeOfDay(hour: number | null, text: string): WorldTimeOfDay {
+  const phrase = getWorldTimePhrase(text);
+  if (phrase) return phrase.timeOfDay;
+  if (hour === null) return "unknown";
+  // These bands match the legacy HUD icon colors.
+  if (hour >= 5 && hour < 10) return "dawn";
+  if (hour >= 10 && hour < 17) return "day";
+  if (hour >= 17 && hour < 20) return "dusk";
+  return "night";
+}
+
+export function getWorldTimeDisplay(time: string | null | undefined) {
+  const text = (time ?? "").trim();
+  if (!text) {
+    return {
+      kind: "empty" as const,
+      raw: "",
+      hour: null,
+      minute: null,
+      timeOfDay: "unknown" as const,
+    };
+  }
+
+  const normalized = text.toLowerCase();
+  const meridiem = text.match(/\b(1[0-2]|0?\d)(?:[:.h]([0-5]\d))?\s*([ap])\.?m?\.?\b/i);
+  if (meridiem) {
+    const displayHour = Number(meridiem[1]);
+    const minute = Number(meridiem[2] ?? "00");
+    const marker = meridiem[3]!.toLowerCase();
+    const hour = marker === "p" ? (displayHour % 12) + 12 : displayHour % 12;
+    return {
+      kind: "clock" as const,
+      hour,
+      minute,
+      timeOfDay: getWorldTimeOfDay(hour, normalized),
+      raw: text,
+    };
+  }
+
+  const twentyFourHour = text.match(/\b([01]?\d|2[0-3])[:.h]([0-5]\d)\b/i);
+  if (twentyFourHour) {
+    const hour = Number(twentyFourHour[1]);
+    const minute = Number(twentyFourHour[2]);
+    return {
+      kind: "clock" as const,
+      hour,
+      minute,
+      timeOfDay: getWorldTimeOfDay(hour, normalized),
+      raw: text,
+    };
+  }
+
+  const phrase = getWorldTimePhrase(normalized);
+  const phraseHour = phrase?.hour ?? null;
+  return {
+    kind: "phrase" as const,
+    raw: text,
+    hour: phraseHour,
+    minute: phraseHour === null ? null : 0,
+    timeOfDay: phrase?.timeOfDay ?? "unknown",
+  };
+}
+
+export type WorldWeatherFamily =
+  | "thunder"
+  | "blizzard"
+  | "heavy-rain"
+  | "rain"
+  | "hail"
+  | "snow"
+  | "fog"
+  | "sand"
+  | "ash"
+  | "fire"
+  | "wind"
+  | "blossom"
+  | "aurora"
+  | "cloud"
+  | "clear"
+  | "heat"
+  | "cold"
+  | "atmosphere";
+
+export function classifyWorldWeather(weather: string | null | undefined): WorldWeatherFamily {
+  const text = (weather ?? "").toLowerCase();
+  if (!text) return "atmosphere";
+  if (text.includes("thunder") || text.includes("lightning")) return "thunder";
+  if (text.includes("blizzard")) return "blizzard";
+  if (text.includes("heavy rain") || text.includes("downpour") || text.includes("storm")) return "heavy-rain";
+  if (text.includes("rain") || text.includes("drizzle") || text.includes("shower")) return "rain";
+  if (text.includes("hail")) return "hail";
+  if (text.includes("snow") || text.includes("sleet") || text.includes("frost")) return "snow";
+  if (text.includes("fog") || text.includes("mist") || text.includes("haze")) return "fog";
+  if (text.includes("sand") || text.includes("dust")) return "sand";
+  if (text.includes("ash") || text.includes("volcanic") || text.includes("smoke")) return "ash";
+  if (text.includes("ember") || text.includes("fire") || text.includes("inferno")) return "fire";
+  if (text.includes("wind") || text.includes("breez") || text.includes("gust")) return "wind";
+  if (text.includes("cherry") || text.includes("blossom") || text.includes("petal")) return "blossom";
+  if (text.includes("aurora") || text.includes("northern light")) return "aurora";
+  if (text.includes("cloud") || text.includes("overcast") || text.includes("grey") || text.includes("gray")) return "cloud";
+  if (text.includes("clear") || text.includes("sunny") || text.includes("bright")) return "clear";
+  if (text.includes("hot") || text.includes("swelter")) return "heat";
+  if (text.includes("cold") || text.includes("freez")) return "cold";
+  return "atmosphere";
+}
+
+function parseTemperatureValue(temperature: string | null | undefined) {
+  const match = (temperature ?? "").match(/(-?\d+(?:\.\d+)?)(?:\s*°?\s*(f(?:ahrenheit)?|c(?:elsius)?)\b)?/i);
+  if (!match) return null;
+  const numeric = parseFloat(match[1]!);
+  const unit = match[2]?.toLowerCase();
+  return unit?.startsWith("f") ? (numeric - 32) * (5 / 9) : numeric;
+}
+
+function parsePureTemperatureValue(temperature: string | null | undefined) {
+  const match = (temperature ?? "").match(/^\s*([+-]?\d+(?:\.\d+)?)\s*°?\s*(f(?:ahrenheit)?|c(?:elsius)?)?\s*$/i);
+  if (!match) return null;
+  const numeric = parseFloat(match[1]!);
+  return match[2]?.toLowerCase().startsWith("f") ? (numeric - 32) * (5 / 9) : numeric;
+}
+
+function getTemperatureKeywordHint(temperature: string | null | undefined) {
+  const text = (temperature ?? "").toLowerCase();
+  if (/\b(freez|frigid|arctic|glacial|sub-?zero|blizzard)/.test(text)) return -10;
+  if (/\b(cold|chill|frost|wintry|icy|bitter|nipp)/.test(text)) return 2;
+  if (/\b(cool|brisk|crisp|refresh)/.test(text)) return 12;
+  if (/\b(mild|pleasant|comfort|temperate|fair)/.test(text)) return 20;
+  if (/\b(warm|balmy|toasty|muggy|humid|stuffy|sultry)/.test(text)) return 28;
+  if (/\b(hot|swelter|blaz|scorch|burn|heat|boil|sear|bak)/.test(text)) return 38;
+  return null;
+}
+
+export function getTemperatureGaugeDisplay(
+  temperature: string | null | undefined,
+  unit: TrackerTemperatureUnit = "celsius",
+) {
+  const numericCelsius = parseTemperatureValue(temperature);
+  const pureParsed = parsePureTemperatureValue(temperature);
+  const value = numericCelsius ?? getTemperatureKeywordHint(temperature);
+  const percent =
+    value === null ? 42 : Math.max(8, Math.min(96, Math.round(((Math.max(-12, Math.min(42, value)) + 12) / 54) * 100)));
+  const color =
+    value === null
+      ? "color-mix(in srgb, var(--foreground) 42%, var(--muted-foreground) 28%)"
+      : value < 0
+        ? "rgb(96 165 250)"
+        : value < 15
+          ? "rgb(56 189 248)"
+          : value < 30
+            ? "rgb(132 204 22)"
+            : "rgb(248 113 113)";
+  return {
+    color,
+    label:
+      pureParsed !== null
+        ? unit === "fahrenheit"
+          ? `${Math.round(pureParsed * (9 / 5) + 32)}°F`
+          : `${Math.round(pureParsed)}°C`
+        : (temperature ?? "").trim() || "--",
+    numericCelsius,
+    percent,
+    value,
+  };
+}
+
+export function getLocationPinColor(location: string | null | undefined) {
+  const text = (location ?? "").toLowerCase();
+  if (
+    /\b(sea|ocean|lake|river|pond|creek|bay|shore|beach|harbor|harbour|port|coast|marsh|swamp|waterfall|spring|well|dock|canal|dam|reef|lagoon|estuary|fjord|cove)\b/.test(
+      text,
+    )
+  )
+    return "text-blue-400";
+  if (
+    /\b(mountain|hill|cliff|peak|ridge|canyon|gorge|cave|cavern|mine|quarry|summit|bluff|crag|volcano|crater|mesa|plateau|ravine|boulder)\b/.test(
+      text,
+    )
+  )
+    return "text-amber-700";
+  if (
+    /\b(city|town|village|castle|palace|fortress|market|shop|inn|tavern|bar|pub|guild|district|quarter|bazaar|temple|church|cathedral|shrine|tower|gate|square|plaza|street|alley|arena|throne|court|capitol|capital|metro|subway)\b/.test(
+      text,
+    )
+  )
+    return "text-sky-400";
+  if (
+    /\b(room|hall|chamber|dungeon|cellar|basement|attic|library|study|bedroom|kitchen|office|lab|laboratory|vault|corridor|passage|cabin|hut|tent|interior|house|home|building|apartment|manor|lodge|dormitor|warehouse|prison|cell|jail)\b/.test(
+      text,
+    )
+  )
+    return "text-amber-300";
+  return "text-emerald-400";
+}
+
+function parseWorldDate(date: string | null | undefined): { day: string | null; monthIndex: number | null } {
+  const text = (date ?? "").trim();
+  if (!text) return { day: null, monthIndex: null };
+
+  const isoMatch = text.match(/\b\d{4}[-/.](\d{1,2})[-/.](\d{1,2})\b/);
+  if (isoMatch) {
+    const month = Number(isoMatch[1]);
+    return { day: isoMatch[2] ?? null, monthIndex: month >= 1 && month <= 12 ? month - 1 : null };
+  }
+
+  const numericDate = text.match(/\b(\d{1,2})[-/.](\d{1,2})[-/.]\d{2,4}\b/);
+  if (numericDate) {
+    const first = Number(numericDate[1]);
+    const second = Number(numericDate[2]);
+    const monthFirst = first <= 12;
+    const month = monthFirst ? first : second;
+    return {
+      day: monthFirst ? numericDate[2] : numericDate[1],
+      monthIndex: month >= 1 && month <= 12 ? month - 1 : null,
+    };
+  }
+
+  for (const [alias, index] of Object.entries(WORLD_MONTH_ALIASES)) {
+    if (new RegExp(`\\b${alias}\\.?\\b`, "i").test(text)) {
+      return {
+        day: text.match(/\b(\d{1,2})(?:st|nd|rd|th)?\b/i)?.[1] ?? null,
+        monthIndex: index,
+      };
+    }
+  }
+  return {
+    day: text.match(/\b(\d{1,2})(?:st|nd|rd|th)?\b/i)?.[1] ?? null,
+    monthIndex: null,
+  };
+}
+
+export function getWorldDateDisplay(date: string | null | undefined) {
+  const text = (date ?? "").trim();
+  const normalized = text.toLowerCase();
+  const { day, monthIndex } = parseWorldDate(text);
+  let iconColor = "text-zinc-200";
+  if (!text) iconColor = "text-[var(--muted-foreground)]/70";
+  else if (/\b(winter|snow|frost|yuletide|christmas|yule|solstice)\b/.test(normalized)) iconColor = "text-sky-300";
+  else if (/\b(spring|blossom|bloom|equinox)\b/.test(normalized)) iconColor = "text-emerald-300";
+  else if (/\b(summer|midsummer|sunny|heatwave)\b/.test(normalized)) iconColor = "text-yellow-300";
+  else if (/\b(autumn|fall|harvest|leaf|leaves)\b/.test(normalized)) iconColor = "text-orange-400";
+  else if (monthIndex === 11 || monthIndex === 0 || monthIndex === 1) iconColor = "text-sky-300";
+  else if (monthIndex !== null && monthIndex >= 2 && monthIndex <= 4) iconColor = "text-emerald-300";
+  else if (monthIndex !== null && monthIndex >= 5 && monthIndex <= 7) iconColor = "text-yellow-300";
+  else if (monthIndex !== null && monthIndex >= 8 && monthIndex <= 10) iconColor = "text-orange-400";
+  return { day, iconColor };
+}

--- a/packages/client/src/lib/world-state-helpers.ts
+++ b/packages/client/src/lib/world-state-helpers.ts
@@ -140,7 +140,7 @@ export function classifyWorldWeather(weather: string | null | undefined): WorldW
   if (!text) return "atmosphere";
   if (text.includes("thunder") || text.includes("lightning")) return "thunder";
   if (text.includes("blizzard")) return "blizzard";
-  if (text.includes("heavy rain") || text.includes("downpour") || text.includes("storm")) return "heavy-rain";
+  if (text.includes("heavy rain") || text.includes("downpour") || /\bstorm\b/.test(text)) return "heavy-rain";
   if (text.includes("rain") || text.includes("drizzle") || text.includes("shower")) return "rain";
   if (text.includes("hail")) return "hail";
   if (text.includes("snow") || text.includes("sleet") || text.includes("frost")) return "snow";
@@ -205,13 +205,13 @@ export function getTemperatureGaugeDisplay(
             : "rgb(248 113 113)";
   return {
     color,
+    isPure: pureParsed !== null,
     label:
       pureParsed !== null
         ? unit === "fahrenheit"
           ? `${Math.round(pureParsed * (9 / 5) + 32)}°F`
           : `${Math.round(pureParsed)}°C`
         : (temperature ?? "").trim() || "--",
-    numericCelsius,
     percent,
     value,
   };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -34,6 +34,9 @@ importers:
       '@dnd-kit/core':
         specifier: 6.3.1
         version: 6.3.1(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@fontsource/share-tech-mono':
+        specifier: 5.2.7
+        version: 5.2.7
       '@marinara-engine/shared':
         specifier: workspace:*
         version: link:../shared
@@ -1162,6 +1165,9 @@ packages:
 
   '@fastify/websocket@11.2.0':
     resolution: {integrity: sha512-3HrDPbAG1CzUCqnslgJxppvzaAZffieOVbLp1DAy1huCSynUWPifSvfdEDUR8HlJLp3sp1A36uOM2tJogADS8w==}
+
+  '@fontsource/share-tech-mono@5.2.7':
+    resolution: {integrity: sha512-1JBJ6CU9u5av8aFEUOGOJkq60/IEVVOZDCmiU8X3i0skk0Pp69GngDwlBUHaTZa4G6pbF1UDrC+Fm7XSckW6TQ==}
 
   '@google/genai@1.52.0':
     resolution: {integrity: sha512-gwSvbpiN/17O9TbsqSsE/OzZcpv5Fo4RQjdngGgogtuB9RsyJ8ZHhX5KjHj1bp5N9snN2eK8LDGXSaWW2hof8Q==}
@@ -5235,6 +5241,8 @@ snapshots:
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
+
+  '@fontsource/share-tech-mono@5.2.7': {}
 
   '@google/genai@1.52.0(@modelcontextprotocol/sdk@1.29.0(zod@3.25.76))':
     dependencies:

--- a/scripts/regressions/open-issues.regression.ts
+++ b/scripts/regressions/open-issues.regression.ts
@@ -72,7 +72,10 @@ import {
   resolveGameSetupImport,
   type GameSetupShareSource,
 } from "../../packages/client/src/lib/game-setup-share.js";
-import { getTemperatureGaugeDisplay } from "../../packages/client/src/lib/world-state-helpers.js";
+import {
+  classifyWorldWeather,
+  getTemperatureGaugeDisplay,
+} from "../../packages/client/src/lib/world-state-helpers.js";
 import {
   resolveStandardEmojiShortcode,
   searchStandardEmojiShortcodes,
@@ -778,10 +781,17 @@ assert.equal(bulkUpdateLorebookEntriesSchema.safeParse({ entryIds: ["entry-1"], 
 
 assert.equal(getTemperatureGaugeDisplay("15°C", "celsius").label, "15°C");
 assert.equal(getTemperatureGaugeDisplay("59 Fahrenheit", "celsius").label, "15°C");
+assert.equal(getTemperatureGaugeDisplay("15°C", "celsius").isPure, true);
+assert.equal(getTemperatureGaugeDisplay("Around 15°C, windy skies ahead", "celsius").isPure, false);
 assert.equal(
   getTemperatureGaugeDisplay("Around 15°C, windy skies ahead", "celsius").label,
   "Around 15°C, windy skies ahead",
 );
+assert.equal(classifyWorldWeather("snowstorm"), "snow");
+assert.equal(classifyWorldWeather("sandstorm"), "sand");
+assert.equal(classifyWorldWeather("firestorm"), "fire");
+assert.equal(classifyWorldWeather("windstorm"), "wind");
+assert.equal(classifyWorldWeather("storm"), "heavy-rain");
 
 const replayMessages = [
   { id: "start", chatId: "session-1", role: "user", content: "[start game]" },

--- a/scripts/regressions/open-issues.regression.ts
+++ b/scripts/regressions/open-issues.regression.ts
@@ -72,10 +72,7 @@ import {
   resolveGameSetupImport,
   type GameSetupShareSource,
 } from "../../packages/client/src/lib/game-setup-share.js";
-import {
-  getTemperatureGaugeDisplay,
-  parsePureTemperatureValue,
-} from "../../packages/client/src/features/tracker-panel/lib/world-state-display.js";
+import { getTemperatureGaugeDisplay } from "../../packages/client/src/lib/world-state-helpers.js";
 import {
   resolveStandardEmojiShortcode,
   searchStandardEmojiShortcodes,
@@ -779,9 +776,8 @@ assert.equal(
 );
 assert.equal(bulkUpdateLorebookEntriesSchema.safeParse({ entryIds: ["entry-1"], changes: {} }).success, false);
 
-assert.equal(parsePureTemperatureValue("15°C"), 15);
-assert.equal(parsePureTemperatureValue("59 Fahrenheit"), 15);
-assert.equal(parsePureTemperatureValue("Around 15°C, windy skies ahead"), null);
+assert.equal(getTemperatureGaugeDisplay("15°C", "celsius").label, "15°C");
+assert.equal(getTemperatureGaugeDisplay("59 Fahrenheit", "celsius").label, "15°C");
 assert.equal(
   getTemperatureGaugeDisplay("Around 15°C, windy skies ahead", "celsius").label,
   "Around 15°C, windy skies ahead",


### PR DESCRIPTION
## Linked issue

Closes #3745

## Why this change

The Tracker's World State section was cramped, visually flat, and unreliable at communicating authored values that do not resemble conventional dashboard data. Fantasy dates, descriptive times, prose weather, and non-numeric temperatures need to remain legible without losing the immersive character of the sidebar.

The Tracker and RoleplayHUD had also accumulated overlapping interpretations of the same world-state values, making their behavior easier to drift apart.

## What changed

- Redesign the World State panel with an ornate responsive frame, expressive location plate, atmospheric scene glyphs, and clearer time/date and weather/temperature groupings.
- Preserve authored strings while fitting bounded field text across compact, standard, and expanded Tracker profiles.
- Add shared calendar, clock, and thermometer instruments used by both the Tracker and RoleplayHUD.
- Consolidate time, weather, temperature, location, and date interpretation into shared helpers while retaining surface-specific palettes.
- Lazy-load Share Tech Mono with the Tracker and use it for instrument readouts.
- Update the existing open-issues regression for the shared temperature helper boundary.

## Validation

- [x] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [x] Ran the app, clicked through the changes manually
- [x] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [x] Above manual verification completed (describe below)
- [x] Read and followed `CONTRIBUTING.md`

Automated validation completed during this change:

- `pnpm check` passed, including lint, TypeScript, and production builds.
- The changed `open-issues.regression.ts` lane passed inside `pnpm regression:issues`.
- `git diff --check` passed before commit.
- The aggregate `pnpm regression:issues` command later failed in the unrelated capability-package lifecycle regression because `spatial_context_snapshots.id` already existed.

### Manual verification notes

- Xel verified compact, standard, and expanded Tracker widths with both conventional and prose world-state values.
- verified light and dark themes, empty values, editing, and RoleplayHUD parity.

## Docs and release impact

- [x] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Version/release files updated (only if this PR includes a version bump)

No version or release metadata changes are included. No user documentation changes appear necessary for this presentation-only update.

## UI evidence (if applicable)

<img width="635" height="270" alt="Screenshot 2026-07-17 232913" src="https://github.com/user-attachments/assets/d793c5ac-edcc-4cd9-b5e8-dcfaccc3a7c6" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Refreshed the world-state HUD with clearer calendar, clock, thermometer, weather, and location visuals.
  * Added responsive world-state tiles that adapt to panel size and fit longer text cleanly.
  * Improved editing for world-state values with textarea support and more reliable save/cancel behavior.
  * Added consistent date, time, weather, temperature, and location display formatting.
  * Introduced a dedicated monospace font for tracker panels.

* **Bug Fixes**
  * Improved temperature gauge colors and Fahrenheit-to-Celsius display handling.
  * Enhanced readability through refined tracker panel styling and background contrast.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->