### PR TITLE
feat(noodle): isolate private accounts

### DIFF
--- a/docs/noodle/settings.md
+++ b/docs/noodle/settings.md
@@ -157,6 +157,7 @@ This table lists every Noodle setting with its default and range.
 
 | Setting | Default | Range or options |
 |---|---|---|
+| **Enable NoodleR** | off | on or off |
 | **Generation connection** | none | any text connection (required for refresh) |
 | **Professor Mari participates** | on | on or off |
 | **Refreshes/day** | 2 | 0 to 24 (0 turns automatic refreshes off) |

--- a/docs/noodle/settings.md
+++ b/docs/noodle/settings.md
@@ -12,6 +12,12 @@ Noodle is the in-app social media timeline in Marinara Engine. If you are new to
 
 All Noodle settings are global. They apply to every persona and every chat, not to one chat at a time. Changes save as soon as you make them.
 
+## NoodleR Access
+
+- **Enable NoodleR**: a toggle, default **off**. Turn it on to opt in to private creator accounts. While it is off, NoodleR account queries are unavailable and private account data remains isolated from the public Noodle timeline.
+
+This setting enables the private-account foundation only. Private navigation and creator tools arrive separately.
+
 ## Invites
 
 The **Invites** section chooses which characters can take part in a Noodle refresh. A refresh is when the AI writes a batch of posts, replies, reposts, and likes for the invited accounts.

--- a/packages/client/src/components/noodle/NoodleView.tsx
+++ b/packages/client/src/components/noodle/NoodleView.tsx
@@ -104,6 +104,7 @@ import {
   useInviteNoodleCharacter,
   useInviteNoodleCharacters,
   useNoodle,
+  useNoodlerAccounts,
   usePatchNoodleAccountSettings,
   useRefreshNoodle,
   useRemoveNoodleCharacter,
@@ -1067,6 +1068,9 @@ export function NoodleView() {
   const noodlePromptLoading = noodlePromptDetail.isLoading || noodlePromptDefault.isLoading;
   const noodlePromptDirty = noodlePromptDraft !== noodlePromptText;
   const settings = data?.settings;
+  const { data: privateAccounts = [], isLoading: privateAccountsLoading } = useNoodlerAccounts(
+    settings?.enableNoodler === true,
+  );
   const accounts = useMemo(
     () =>
       (data?.accounts ?? []).filter(
@@ -2666,6 +2670,28 @@ export function NoodleView() {
 
   const settingsContent = (
     <>
+      <Section
+        title="NoodleR Access"
+        help="Keeps private creator accounts isolated from the public Noodle timeline. Later NoodleR slices add private navigation and creator tools."
+      >
+        <div className="space-y-3">
+          <ToggleSetting
+            label="Enable NoodleR"
+            help="Opt in to private creator accounts. Turning this off hides private account data from NoodleR queries without changing the public timeline."
+            checked={settings?.enableNoodler ?? false}
+            disabled={!settings || updateSettings.isPending}
+            onChange={(checked) => saveSettings({ enableNoodler: checked })}
+          />
+          {settings?.enableNoodler && (
+            <div className="rounded-md border border-[var(--marinara-chat-chrome-panel-border)] bg-[var(--noodle-blue)]/5 px-3 py-2.5 text-xs text-[var(--muted-foreground)]">
+              {privateAccountsLoading
+                ? "Loading private accounts..."
+                : `${privateAccounts.length} private account${privateAccounts.length === 1 ? "" : "s"}. Private navigation arrives in the next NoodleR slice.`}
+            </div>
+          )}
+        </div>
+      </Section>
+
       <Section
         title="Noodle Prompt"
         help="Controls the editable base instructions used to write Noodle timeline refreshes. Timeline voice and tone instructions are appended after this prompt."

--- a/packages/client/src/components/noodle/NoodleView.tsx
+++ b/packages/client/src/components/noodle/NoodleView.tsx
@@ -1068,9 +1068,11 @@ export function NoodleView() {
   const noodlePromptLoading = noodlePromptDetail.isLoading || noodlePromptDefault.isLoading;
   const noodlePromptDirty = noodlePromptDraft !== noodlePromptText;
   const settings = data?.settings;
-  const { data: privateAccounts = [], isLoading: privateAccountsLoading } = useNoodlerAccounts(
-    settings?.enableNoodler === true,
-  );
+  const {
+    data: privateAccounts = [],
+    isLoading: privateAccountsLoading,
+    isError: privateAccountsError,
+  } = useNoodlerAccounts(settings?.enableNoodler === true);
   const accounts = useMemo(
     () =>
       (data?.accounts ?? []).filter(
@@ -2671,28 +2673,6 @@ export function NoodleView() {
   const settingsContent = (
     <>
       <Section
-        title="NoodleR Access"
-        help="Keeps private creator accounts isolated from the public Noodle timeline. Later NoodleR slices add private navigation and creator tools."
-      >
-        <div className="space-y-3">
-          <ToggleSetting
-            label="Enable NoodleR"
-            help="Opt in to private creator accounts. Turning this off hides private account data from NoodleR queries without changing the public timeline."
-            checked={settings?.enableNoodler ?? false}
-            disabled={!settings || updateSettings.isPending}
-            onChange={(checked) => saveSettings({ enableNoodler: checked })}
-          />
-          {settings?.enableNoodler && (
-            <div className="rounded-md border border-[var(--marinara-chat-chrome-panel-border)] bg-[var(--noodle-blue)]/5 px-3 py-2.5 text-xs text-[var(--muted-foreground)]">
-              {privateAccountsLoading
-                ? "Loading private accounts..."
-                : `${privateAccounts.length} private account${privateAccounts.length === 1 ? "" : "s"}. Private navigation arrives in the next NoodleR slice.`}
-            </div>
-          )}
-        </div>
-      </Section>
-
-      <Section
         title="Noodle Prompt"
         help="Controls the editable base instructions used to write Noodle timeline refreshes. Timeline voice and tone instructions are appended after this prompt."
       >
@@ -3390,6 +3370,30 @@ export function NoodleView() {
                   onCommit={(value) => saveSettings({ carryoverMaxItems: value })}
                 />
               </div>
+            </div>
+          </Section>
+
+          <Section
+            title="NoodleR Access"
+            help="Keeps private creator accounts isolated from the public Noodle timeline. Later NoodleR slices add private navigation and creator tools."
+          >
+            <div className="space-y-3">
+              <ToggleSetting
+                label="Enable NoodleR"
+                help="Opt in to private creator accounts. Turning this off hides private account data from NoodleR queries without changing the public timeline."
+                checked={settings.enableNoodler}
+                disabled={updateSettings.isPending}
+                onChange={(checked) => saveSettings({ enableNoodler: checked })}
+              />
+              {settings.enableNoodler && (
+                <div className="rounded-md border border-[var(--marinara-chat-chrome-panel-border)] bg-[var(--noodle-blue)]/5 px-3 py-2.5 text-xs text-[var(--muted-foreground)]">
+                  {privateAccountsError
+                    ? "Private accounts could not be loaded. Try again later."
+                    : privateAccountsLoading
+                      ? "Loading private accounts..."
+                      : `${privateAccounts.length} private account${privateAccounts.length === 1 ? "" : "s"}. Private navigation arrives in the next NoodleR slice.`}
+                </div>
+              )}
             </div>
           </Section>
 

--- a/packages/client/src/hooks/use-noodle.ts
+++ b/packages/client/src/hooks/use-noodle.ts
@@ -35,6 +35,7 @@ export type NoodleRefreshResult = {
 export const noodleKeys = {
   all: ["noodle"] as const,
   bootstrap: () => [...noodleKeys.all, "bootstrap"] as const,
+  privateAccounts: () => [...noodleKeys.all, "private-accounts"] as const,
 };
 
 function preservePollVotes(current: NoodleBootstrap | undefined, next: NoodleBootstrap): NoodleBootstrap {
@@ -53,6 +54,15 @@ export function useNoodle(enabled = true) {
     refetchIntervalInBackground: false,
     structuralSharing: (current, next) =>
       preservePollVotes(current as NoodleBootstrap | undefined, next as NoodleBootstrap),
+  });
+}
+
+export function useNoodlerAccounts(enabled = true) {
+  return useQuery({
+    queryKey: noodleKeys.privateAccounts(),
+    queryFn: () => api.get<NoodleAccount[]>("/noodle/noodler/accounts"),
+    enabled,
+    staleTime: 10_000,
   });
 }
 

--- a/packages/server/src/db/schema/noodle.ts
+++ b/packages/server/src/db/schema/noodle.ts
@@ -3,19 +3,27 @@
 // ──────────────────────────────────────────────
 import { fileTable, text } from "../file-schema.js";
 
-export const noodleAccounts = fileTable("noodle_accounts", {
-  id: text("id").primaryKey(),
-  kind: text("kind").notNull(),
-  entityId: text("entity_id").notNull(),
-  handle: text("handle").notNull(),
-  displayName: text("display_name").notNull(),
-  bio: text("bio").notNull().default(""),
-  avatarUrl: text("avatar_url"),
-  invited: text("invited").notNull().default("false"),
-  settings: text("settings").notNull().default("{}"),
-  createdAt: text("created_at").notNull(),
-  updatedAt: text("updated_at").notNull(),
-});
+export const noodleAccounts = fileTable(
+  "noodle_accounts",
+  {
+    id: text("id").primaryKey(),
+    kind: text("kind").notNull(),
+    entityId: text("entity_id").notNull(),
+    handle: text("handle").notNull(),
+    displayName: text("display_name").notNull(),
+    bio: text("bio").notNull().default(""),
+    avatarUrl: text("avatar_url"),
+    invited: text("invited").notNull().default("false"),
+    settings: text("settings").notNull().default("{}"),
+    visibility: text("visibility").notNull().default("public"),
+    publicAccountId: text("public_account_id"),
+    createdAt: text("created_at").notNull(),
+    updatedAt: text("updated_at").notNull(),
+  },
+  {
+    uniqueBy: [{ keys: ["publicAccountId"], when: (row) => row.publicAccountId != null }],
+  },
+);
 
 export const noodlePosts = fileTable("noodle_posts", {
   id: text("id").primaryKey(),

--- a/packages/server/src/routes/noodle.routes.ts
+++ b/packages/server/src/routes/noodle.routes.ts
@@ -21,6 +21,7 @@ import {
   noodleInteractionOwnerSchema,
   noodleInteractionUpdateSchema,
   noodlePostUpdateSchema,
+  noodlePrivateAccountCreateSchema,
   noodleRemoveInteractionSchema,
   noodleRescheduleRefreshSchema,
   noodleRefreshSchema,
@@ -92,6 +93,7 @@ import {
 import { processLorebooks } from "../services/lorebook/index.js";
 import { buildPromptMacroContext, resolveMacrosWithVariableSnapshot } from "../services/prompt/index.js";
 import type { DB } from "../db/connection.js";
+import { isFileUniqueConstraintError } from "../db/file-schema.js";
 import {
   generateImageCaptionForDataUrl,
   resolveImageCaptioningRuntime,
@@ -1353,6 +1355,30 @@ export async function noodleRoutes(app: FastifyInstance) {
     const parsed = noodleSettingsUpdateSchema.safeParse(req.body);
     if (!parsed.success) return reply.code(400).send({ error: parsed.error.flatten() });
     return noodle.updateSettings(parsed.data);
+  });
+
+  app.get("/noodler/accounts", async (_req, reply) => {
+    const settings = await noodle.getSettings();
+    if (!settings.enableNoodler) return reply.code(404).send({ error: "Not Found" });
+    return noodle.listPrivateAccounts();
+  });
+
+  app.post("/accounts/:id/private", async (req, reply) => {
+    const settings = await noodle.getSettings();
+    if (!settings.enableNoodler) return reply.code(404).send({ error: "Not Found" });
+    const parsed = noodlePrivateAccountCreateSchema.safeParse(req.body ?? {});
+    if (!parsed.success) return reply.code(400).send({ error: parsed.error.flatten() });
+    const { id } = req.params as { id: string };
+    try {
+      const created = await noodle.createPrivateAccount(id);
+      if (!created) return reply.code(404).send({ error: "Noodle account not found" });
+      return reply.code(201).send(created);
+    } catch (error) {
+      if (isFileUniqueConstraintError(error, "noodle_accounts", ["publicAccountId"])) {
+        return reply.code(409).send({ error: "A private account already exists for this Noodle account." });
+      }
+      throw error;
+    }
   });
 
   app.put("/refresh-schedule", async (req, reply) => {

--- a/packages/server/src/services/storage/noodle.storage.ts
+++ b/packages/server/src/services/storage/noodle.storage.ts
@@ -953,7 +953,16 @@ export function createNoodleStorage(db: DB) {
 
     async listRepliesByActorSince(actorAccountId: string, since: string, limit = 100): Promise<NoodleInteraction[]> {
       if (!(await this.getAccountById(actorAccountId))) return [];
-      const publicPostIds = new Set((await this.listPosts({ limit: 300 })).map((post) => post.id));
+      const publicAccountIds = (await this.listAccounts()).map((account) => account.id);
+      if (publicAccountIds.length === 0) return [];
+      const publicPostIds = new Set(
+        (
+          await db
+            .select({ id: noodlePosts.id })
+            .from(noodlePosts)
+            .where(inArray(noodlePosts.authorAccountId, publicAccountIds))
+        ).map((post) => post.id),
+      );
       const rows = await db
         .select()
         .from(noodleInteractions)

--- a/packages/server/src/services/storage/noodle.storage.ts
+++ b/packages/server/src/services/storage/noodle.storage.ts
@@ -326,6 +326,8 @@ function mapAccount(row: AccountRow): NoodleAccount {
     avatarCrop: settings.profile.avatarCrop ?? null,
     invited: normalizeBool(row.invited),
     settings,
+    visibility: row.visibility === "private" ? "private" : "public",
+    publicAccountId: row.publicAccountId ?? null,
     createdAt: row.createdAt,
     updatedAt: row.updatedAt,
   };
@@ -450,12 +452,19 @@ export function createNoodleStorage(db: DB) {
     },
 
     async listAccounts(): Promise<NoodleAccount[]> {
-      const rows = await db.select().from(noodleAccounts).orderBy(desc(noodleAccounts.updatedAt));
+      const rows = await db
+        .select()
+        .from(noodleAccounts)
+        .where(eq(noodleAccounts.visibility, "public"))
+        .orderBy(desc(noodleAccounts.updatedAt));
       return rows.map(mapAccount);
     },
 
     async getAccountById(id: string): Promise<NoodleAccount | null> {
-      const rows = await db.select().from(noodleAccounts).where(eq(noodleAccounts.id, id));
+      const rows = await db
+        .select()
+        .from(noodleAccounts)
+        .where(and(eq(noodleAccounts.id, id), eq(noodleAccounts.visibility, "public")));
       return rows[0] ? mapAccount(rows[0]) : null;
     },
 
@@ -463,7 +472,13 @@ export function createNoodleStorage(db: DB) {
       const rows = await db
         .select()
         .from(noodleAccounts)
-        .where(and(eq(noodleAccounts.kind, kind), eq(noodleAccounts.entityId, entityId)));
+        .where(
+          and(
+            eq(noodleAccounts.kind, kind),
+            eq(noodleAccounts.entityId, entityId),
+            eq(noodleAccounts.visibility, "public"),
+          ),
+        );
       return rows[0] ? mapAccount(rows[0]) : null;
     },
 
@@ -472,8 +487,62 @@ export function createNoodleStorage(db: DB) {
       const rows = await db
         .select()
         .from(noodleAccounts)
-        .where(and(eq(noodleAccounts.kind, kind), inArray(noodleAccounts.entityId, entityIds)));
+        .where(
+          and(
+            eq(noodleAccounts.kind, kind),
+            inArray(noodleAccounts.entityId, entityIds),
+            eq(noodleAccounts.visibility, "public"),
+          ),
+        );
       return rows.map(mapAccount);
+    },
+
+    async listPrivateAccounts(): Promise<NoodleAccount[]> {
+      const rows = await db
+        .select()
+        .from(noodleAccounts)
+        .where(eq(noodleAccounts.visibility, "private"))
+        .orderBy(desc(noodleAccounts.updatedAt));
+      return rows.map(mapAccount);
+    },
+
+    async getPrivateAccountById(id: string): Promise<NoodleAccount | null> {
+      const rows = await db
+        .select()
+        .from(noodleAccounts)
+        .where(and(eq(noodleAccounts.id, id), eq(noodleAccounts.visibility, "private")));
+      return rows[0] ? mapAccount(rows[0]) : null;
+    },
+
+    async getPrivateAccountForPublicAccount(publicAccountId: string): Promise<NoodleAccount | null> {
+      const rows = await db
+        .select()
+        .from(noodleAccounts)
+        .where(and(eq(noodleAccounts.visibility, "private"), eq(noodleAccounts.publicAccountId, publicAccountId)));
+      return rows[0] ? mapAccount(rows[0]) : null;
+    },
+
+    async createPrivateAccount(publicAccountId: string): Promise<NoodleAccount | null> {
+      const publicAccount = await this.getAccountById(publicAccountId);
+      if (!publicAccount || (publicAccount.kind !== "persona" && publicAccount.kind !== "character")) return null;
+      const timestamp = now();
+      const id = newId();
+      await db.insert(noodleAccounts).values({
+        id,
+        kind: publicAccount.kind,
+        entityId: publicAccount.entityId,
+        handle: `${publicAccount.handle}_private`,
+        displayName: publicAccount.displayName,
+        bio: "",
+        avatarUrl: null,
+        invited: "false",
+        settings: JSON.stringify(emptyNoodleAccountSettings()),
+        visibility: "private",
+        publicAccountId,
+        createdAt: timestamp,
+        updatedAt: timestamp,
+      });
+      return this.getPrivateAccountById(id);
     },
 
     async upsertAccountFromProfile(input: {
@@ -533,6 +602,8 @@ export function createNoodleStorage(db: DB) {
           ...emptyNoodleAccountSettings(),
           profile: input.avatarCrop !== undefined ? { avatarCrop: input.avatarCrop } : {},
         }),
+        visibility: "public",
+        publicAccountId: null,
         createdAt: timestamp,
         updatedAt: timestamp,
       });
@@ -541,7 +612,10 @@ export function createNoodleStorage(db: DB) {
 
     async updateAccount(id: string, input: NoodleAccountUpdateInput): Promise<NoodleAccount | null> {
       return db.transaction(async (tx) => {
-        const rows = await tx.select().from(noodleAccounts).where(eq(noodleAccounts.id, id));
+        const rows = await tx
+          .select()
+          .from(noodleAccounts)
+          .where(and(eq(noodleAccounts.id, id), eq(noodleAccounts.visibility, "public")));
         const row = rows[0];
         if (!row) return null;
         await tx
@@ -562,7 +636,10 @@ export function createNoodleStorage(db: DB) {
 
     async updateAccountProfile(id: string, input: NoodleAccountProfileUpdateInput): Promise<NoodleAccount | null> {
       return db.transaction(async (tx) => {
-        const rows = await tx.select().from(noodleAccounts).where(eq(noodleAccounts.id, id));
+        const rows = await tx
+          .select()
+          .from(noodleAccounts)
+          .where(and(eq(noodleAccounts.id, id), eq(noodleAccounts.visibility, "public")));
         const row = rows[0];
         if (!row) return null;
         const settings = normalizeNoodleAccountSettings(row.settings);
@@ -588,7 +665,10 @@ export function createNoodleStorage(db: DB) {
 
     async patchAccountSettings(id: string, input: NoodleAccountSettingsPatchInput): Promise<NoodleAccount | null> {
       return db.transaction(async (tx) => {
-        const rows = await tx.select().from(noodleAccounts).where(eq(noodleAccounts.id, id));
+        const rows = await tx
+          .select()
+          .from(noodleAccounts)
+          .where(and(eq(noodleAccounts.id, id), eq(noodleAccounts.visibility, "public")));
         const row = rows[0];
         if (!row) return null;
         const current = normalizeNoodleAccountSettings(row.settings);
@@ -616,7 +696,10 @@ export function createNoodleStorage(db: DB) {
       followedAt = new Date().toISOString(),
     ): Promise<{ account: NoodleAccount; changed: boolean } | null> {
       return db.transaction(async (tx) => {
-        const rows = await tx.select().from(noodleAccounts).where(eq(noodleAccounts.id, id));
+        const rows = await tx
+          .select()
+          .from(noodleAccounts)
+          .where(and(eq(noodleAccounts.id, id), eq(noodleAccounts.visibility, "public")));
         const row = rows[0];
         if (!row) return null;
         const current = normalizeNoodleAccountSettings(row.settings);
@@ -659,27 +742,47 @@ export function createNoodleStorage(db: DB) {
       await db
         .update(noodleAccounts)
         .set({ invited: "false", updatedAt: now() })
-        .where(and(eq(noodleAccounts.kind, "character"), eq(noodleAccounts.invited, "true")));
+        .where(
+          and(
+            eq(noodleAccounts.kind, "character"),
+            eq(noodleAccounts.invited, "true"),
+            eq(noodleAccounts.visibility, "public"),
+          ),
+        );
     },
 
     async listPosts(options: { limit?: number; since?: string } = {}): Promise<NoodlePost[]> {
       const limit = Math.max(1, Math.min(300, Math.floor(options.limit ?? 120)));
+      const publicAccountIds = (await this.listAccounts()).map((account) => account.id);
+      if (publicAccountIds.length === 0) return [];
       const rows = options.since
         ? await db
             .select()
             .from(noodlePosts)
-            .where(gt(noodlePosts.createdAt, options.since))
+            .where(
+              and(
+                gt(noodlePosts.createdAt, options.since),
+                inArray(noodlePosts.authorAccountId, publicAccountIds),
+              ),
+            )
             .orderBy(desc(noodlePosts.createdAt))
             .limit(limit)
-        : await db.select().from(noodlePosts).orderBy(desc(noodlePosts.createdAt)).limit(limit);
+        : await db
+            .select()
+            .from(noodlePosts)
+            .where(inArray(noodlePosts.authorAccountId, publicAccountIds))
+            .orderBy(desc(noodlePosts.createdAt))
+            .limit(limit);
       return rows.map(mapPost);
     },
 
     async listPostsBefore(before: string): Promise<NoodlePost[]> {
+      const publicAccountIds = (await this.listAccounts()).map((account) => account.id);
+      if (publicAccountIds.length === 0) return [];
       const rows = await db
         .select()
         .from(noodlePosts)
-        .where(lt(noodlePosts.createdAt, before))
+        .where(and(lt(noodlePosts.createdAt, before), inArray(noodlePosts.authorAccountId, publicAccountIds)))
         .orderBy(desc(noodlePosts.createdAt));
       return rows.map(mapPost);
     },
@@ -714,7 +817,9 @@ export function createNoodleStorage(db: DB) {
 
     async getPostById(id: string): Promise<NoodlePost | null> {
       const rows = await db.select().from(noodlePosts).where(eq(noodlePosts.id, id));
-      return rows[0] ? mapPost(rows[0]) : null;
+      const row = rows[0];
+      if (!row || !(await this.getAccountById(row.authorAccountId))) return null;
+      return mapPost(row);
     },
 
     async updatePostMedia(
@@ -755,6 +860,19 @@ export function createNoodleStorage(db: DB) {
     async deletePost(id: string): Promise<NoodlePost | null> {
       const existing = await this.getPostById(id);
       if (!existing) return null;
+      const interactions = await db.select().from(noodleInteractions).where(eq(noodleInteractions.postId, id));
+      const publicAccountIds = new Set((await this.listAccounts()).map((account) => account.id));
+      if (interactions.some((interaction) => !publicAccountIds.has(interaction.actorAccountId))) return null;
+      const interactionIds = interactions.map((interaction) => interaction.id);
+      const digests = await db.select().from(noodleActivityDigests);
+      const relatedDigests = digests.filter(
+        (digest) =>
+          digest.sourcePostId === id ||
+          (digest.sourceInteractionId !== null && interactionIds.includes(digest.sourceInteractionId)),
+      );
+      if (relatedDigests.some((digest) => !parseStringArray(digest.accountIds).every((accountId) => publicAccountIds.has(accountId)))) {
+        return null;
+      }
       await db.transaction(async (tx) => {
         await tx.delete(noodleInteractions).where(eq(noodleInteractions.postId, id));
         await tx.delete(noodleActivityDigests).where(eq(noodleActivityDigests.sourcePostId, id));
@@ -764,25 +882,78 @@ export function createNoodleStorage(db: DB) {
     },
 
     async resetTimeline(): Promise<void> {
+      const publicAccountIds = (await this.listAccounts()).map((account) => account.id);
+      const publicPosts =
+        publicAccountIds.length > 0
+          ? await db
+              .select()
+              .from(noodlePosts)
+              .where(inArray(noodlePosts.authorAccountId, publicAccountIds))
+          : [];
+      const publicPostIds = publicPosts.map((post) => post.id);
+      const publicInteractions = await db
+        .select()
+        .from(noodleInteractions)
+        .where(inArray(noodleInteractions.postId, publicPostIds));
+      const publicAccountIdSet = new Set(publicAccountIds);
+      const protectedPostIds = new Set(
+        publicInteractions
+          .filter((interaction) => !publicAccountIdSet.has(interaction.actorAccountId))
+          .map((interaction) => interaction.postId),
+      );
+      const interactionPostById = new Map(
+        publicInteractions.map((interaction) => [interaction.id, interaction.postId]),
+      );
+      const digests = await db.select().from(noodleActivityDigests);
+      for (const digest of digests) {
+        if (parseStringArray(digest.accountIds).every((accountId) => publicAccountIdSet.has(accountId))) continue;
+        if (digest.sourcePostId && publicPostIds.includes(digest.sourcePostId)) {
+          protectedPostIds.add(digest.sourcePostId);
+        }
+        if (digest.sourceInteractionId) {
+          const postId = interactionPostById.get(digest.sourceInteractionId);
+          if (postId) protectedPostIds.add(postId);
+        }
+      }
+      const deletablePostIds = publicPostIds.filter((postId) => !protectedPostIds.has(postId));
+      const deletableInteractionIds = publicInteractions
+        .filter((interaction) => deletablePostIds.includes(interaction.postId))
+        .map((interaction) => interaction.id);
       await db.transaction(async (tx) => {
-        await tx.delete(noodleInteractions);
-        await tx.delete(noodleActivityDigests);
+        if (deletableInteractionIds.length > 0) {
+          await tx
+            .delete(noodleActivityDigests)
+            .where(inArray(noodleActivityDigests.sourceInteractionId, deletableInteractionIds));
+        }
+        if (deletablePostIds.length > 0) {
+          await tx.delete(noodleActivityDigests).where(inArray(noodleActivityDigests.sourcePostId, deletablePostIds));
+          await tx.delete(noodleInteractions).where(inArray(noodleInteractions.postId, deletablePostIds));
+          await tx.delete(noodlePosts).where(inArray(noodlePosts.id, deletablePostIds));
+        }
         await tx.delete(noodleRefreshRuns);
-        await tx.delete(noodlePosts);
       });
     },
 
     async listInteractions(postIds: string[] = []): Promise<NoodleInteraction[]> {
       if (postIds.length === 0) return [];
+      const publicPostIds = new Set(
+        (await Promise.all(postIds.map((postId) => this.getPostById(postId))))
+          .filter((post): post is NoodlePost => post !== null)
+          .map((post) => post.id),
+      );
+      if (publicPostIds.size === 0) return [];
+      const publicAccountIds = new Set((await this.listAccounts()).map((account) => account.id));
       const rows = await db
         .select()
         .from(noodleInteractions)
-        .where(inArray(noodleInteractions.postId, postIds))
+        .where(inArray(noodleInteractions.postId, [...publicPostIds]))
         .orderBy(noodleInteractions.createdAt);
-      return rows.map(mapInteraction);
+      return rows.filter((row) => publicAccountIds.has(row.actorAccountId)).map(mapInteraction);
     },
 
     async listRepliesByActorSince(actorAccountId: string, since: string, limit = 100): Promise<NoodleInteraction[]> {
+      if (!(await this.getAccountById(actorAccountId))) return [];
+      const publicPostIds = new Set((await this.listPosts({ limit: 300 })).map((post) => post.id));
       const rows = await db
         .select()
         .from(noodleInteractions)
@@ -795,12 +966,15 @@ export function createNoodleStorage(db: DB) {
         )
         .orderBy(desc(noodleInteractions.createdAt))
         .limit(Math.max(1, Math.min(200, Math.floor(limit))));
-      return rows.map(mapInteraction);
+      return rows.filter((row) => publicPostIds.has(row.postId)).map(mapInteraction);
     },
 
     async getInteractionById(id: string): Promise<NoodleInteraction | null> {
       const rows = await db.select().from(noodleInteractions).where(eq(noodleInteractions.id, id));
-      return rows[0] ? mapInteraction(rows[0]) : null;
+      const row = rows[0];
+      if (!row) return null;
+      const [post, actor] = await Promise.all([this.getPostById(row.postId), this.getAccountById(row.actorAccountId)]);
+      return post && actor ? mapInteraction(row) : null;
     },
 
     async updateInteraction(
@@ -834,6 +1008,19 @@ export function createNoodleStorage(db: DB) {
         }
       }
       const deletedRows = rows.filter((row) => deletedIds.has(row.id));
+      const publicAccountIds = new Set((await this.listAccounts()).map((account) => account.id));
+      if (deletedRows.some((row) => !publicAccountIds.has(row.actorAccountId))) return [];
+      const relatedDigests = await db
+        .select()
+        .from(noodleActivityDigests)
+        .where(inArray(noodleActivityDigests.sourceInteractionId, [...deletedIds]));
+      if (
+        relatedDigests.some(
+          (digest) => !parseStringArray(digest.accountIds).every((accountId) => publicAccountIds.has(accountId)),
+        )
+      ) {
+        return [];
+      }
       await db.transaction(async (tx) => {
         await tx
           .delete(noodleActivityDigests)
@@ -852,11 +1039,7 @@ export function createNoodleStorage(db: DB) {
 
       const parentInteractionId = input.parentInteractionId ?? null;
       if (parentInteractionId) {
-        const parentRows = await db
-          .select()
-          .from(noodleInteractions)
-          .where(eq(noodleInteractions.id, parentInteractionId));
-        const parent = parentRows[0];
+        const parent = await this.getInteractionById(parentInteractionId);
         if (!parent || parent.postId !== postId || parent.type !== "reply") return null;
       }
 
@@ -943,6 +1126,8 @@ export function createNoodleStorage(db: DB) {
       postId: string,
       input: Omit<NoodleRemoveInteractionInput, "actorKind" | "actorEntityId"> & { actorAccountId: string },
     ): Promise<NoodleInteraction | null> {
+      const post = await this.getPostById(postId);
+      if (!post) return null;
       const rows = await db
         .select()
         .from(noodleInteractions)
@@ -958,6 +1143,18 @@ export function createNoodleStorage(db: DB) {
         );
       const existing = rows[0];
       if (!existing) return null;
+      const relatedDigests = await db
+        .select()
+        .from(noodleActivityDigests)
+        .where(eq(noodleActivityDigests.sourceInteractionId, existing.id));
+      const publicAccountIds = new Set((await this.listAccounts()).map((account) => account.id));
+      if (
+        relatedDigests.some(
+          (digest) => !parseStringArray(digest.accountIds).every((accountId) => publicAccountIds.has(accountId)),
+        )
+      ) {
+        return null;
+      }
       await db.transaction(async (tx) => {
         await tx.delete(noodleActivityDigests).where(eq(noodleActivityDigests.sourceInteractionId, existing.id));
         await tx.delete(noodleInteractions).where(eq(noodleInteractions.id, existing.id));
@@ -974,11 +1171,24 @@ export function createNoodleStorage(db: DB) {
     }): Promise<NoodleDigestEntry> {
       const id = newId();
       const uniqueAccountIds = Array.from(new Set(input.accountIds.filter(Boolean)));
+      const publicAccountIds = new Set((await this.listAccounts()).map((account) => account.id));
+      if (!uniqueAccountIds.every((accountId) => publicAccountIds.has(accountId))) {
+        throw new Error("Public Noodle digests cannot reference private accounts.");
+      }
       await db.transaction(async (tx) => {
         if (input.sourceInteractionId) {
-          await tx
-            .delete(noodleActivityDigests)
+          const existingDigests = await tx
+            .select()
+            .from(noodleActivityDigests)
             .where(eq(noodleActivityDigests.sourceInteractionId, input.sourceInteractionId));
+          const publicDigestIds = existingDigests
+            .filter((digest) =>
+              parseStringArray(digest.accountIds).every((accountId) => publicAccountIds.has(accountId)),
+            )
+            .map((digest) => digest.id);
+          if (publicDigestIds.length > 0) {
+            await tx.delete(noodleActivityDigests).where(inArray(noodleActivityDigests.id, publicDigestIds));
+          }
         }
         await tx.insert(noodleActivityDigests).values({
           id,
@@ -999,6 +1209,16 @@ export function createNoodleStorage(db: DB) {
       input: { accountIds: string[]; content: string },
     ): Promise<NoodleDigestEntry | null> {
       const uniqueAccountIds = Array.from(new Set(input.accountIds.filter(Boolean)));
+      const existingRows = await db.select().from(noodleActivityDigests).where(eq(noodleActivityDigests.id, id));
+      const existing = existingRows[0];
+      if (!existing) return null;
+      const publicAccountIds = new Set((await this.listAccounts()).map((account) => account.id));
+      if (
+        !parseStringArray(existing.accountIds).every((accountId) => publicAccountIds.has(accountId)) ||
+        !uniqueAccountIds.every((accountId) => publicAccountIds.has(accountId))
+      ) {
+        return null;
+      }
       await db
         .update(noodleActivityDigests)
         .set({
@@ -1039,18 +1259,26 @@ export function createNoodleStorage(db: DB) {
           : Promise.resolve([]),
       ]);
       const sourcePostById = new Map(sourcePosts.map((post) => [post.id, post]));
-      const liveInteractionIds = new Set(sourceInteractions.map((interaction) => interaction.id));
+      const sourceInteractionById = new Map(sourceInteractions.map((interaction) => [interaction.id, interaction]));
+      const publicAccountIds = new Set((await this.listAccounts()).map((account) => account.id));
 
       return rows
         .filter((row) => {
-          if (row.sourceInteractionId) return liveInteractionIds.has(row.sourceInteractionId);
+          const digest = mapDigest(row);
+          if (!digest.accountIds.every((accountId) => publicAccountIds.has(accountId))) return false;
+          if (row.sourceInteractionId) {
+            const interaction = sourceInteractionById.get(row.sourceInteractionId);
+            if (!interaction || !publicAccountIds.has(interaction.actorAccountId)) return false;
+            const sourcePost = sourcePostById.get(interaction.postId);
+            return Boolean(sourcePost && publicAccountIds.has(sourcePost.authorAccountId));
+          }
           // Older model-authored summaries had only a refresh-run reference,
           // so there is no way to invalidate them when their source post or
           // comment is deleted. Deterministic event digests supersede them.
           if (row.sourceRunId && !row.sourcePostId) return false;
           if (!row.sourcePostId) return true;
           const sourcePost = sourcePostById.get(row.sourcePostId);
-          if (!sourcePost) return false;
+          if (!sourcePost || !publicAccountIds.has(sourcePost.authorAccountId)) return false;
           // Digests created before source_interaction_id existed cannot be tied
           // safely to a still-live comment. Keep only the post's canonical digest;
           // stale legacy comment digests must never re-enter generation context.

--- a/packages/shared/src/schemas/noodle.schema.ts
+++ b/packages/shared/src/schemas/noodle.schema.ts
@@ -40,6 +40,7 @@ export const DEFAULT_NOODLE_SETTINGS = {
   carryoverMaxItems: 8,
   theme: "system",
   generationConnectionId: null,
+  enableNoodler: false,
 } as const;
 
 export const noodleSettingsSchema = z.object({
@@ -88,6 +89,7 @@ export const noodleSettingsSchema = z.object({
   carryoverMaxItems: z.number().int().min(1).max(50).default(DEFAULT_NOODLE_SETTINGS.carryoverMaxItems),
   theme: noodleThemeSchema.default(DEFAULT_NOODLE_SETTINGS.theme),
   generationConnectionId: z.string().min(1).nullable().default(DEFAULT_NOODLE_SETTINGS.generationConnectionId),
+  enableNoodler: z.boolean().default(DEFAULT_NOODLE_SETTINGS.enableNoodler),
 });
 
 export const noodleSettingsUpdateSchema = noodleSettingsSchema.partial();
@@ -161,6 +163,8 @@ export const noodleAccountProfileUpdateSchema = z
   .strict();
 
 export const noodleAccountFollowUpdateSchema = z.object({ followed: z.boolean() }).strict();
+
+export const noodlePrivateAccountCreateSchema = z.object({}).strict();
 
 export const noodleInviteSchema = z.object({
   characterId: z.string().min(1),
@@ -399,6 +403,7 @@ export type NoodleAccountUpdateInput = z.infer<typeof noodleAccountUpdateSchema>
 export type NoodleAccountProfileUpdateInput = z.infer<typeof noodleAccountProfileUpdateSchema>;
 export type NoodleAccountSettingsPatchInput = z.infer<typeof noodleAccountSettingsPatchSchema>;
 export type NoodleAccountFollowUpdateInput = z.infer<typeof noodleAccountFollowUpdateSchema>;
+export type NoodlePrivateAccountCreateInput = z.infer<typeof noodlePrivateAccountCreateSchema>;
 export type NoodleInviteInput = z.infer<typeof noodleInviteSchema>;
 export type NoodleBulkInviteInput = z.infer<typeof noodleBulkInviteSchema>;
 export type NoodlePollInput = z.infer<typeof noodlePollInputSchema>;

--- a/packages/shared/src/types/noodle.ts
+++ b/packages/shared/src/types/noodle.ts
@@ -4,6 +4,7 @@
 import type { LegacyPersonaAvatarCrop, PersonaAvatarCrop } from "./persona.js";
 
 export type NoodleAccountKind = "persona" | "character" | "random_user";
+export type NoodleAccountVisibility = "public" | "private";
 export type NoodleInteractionType = "like" | "repost" | "reply" | "vote";
 export type NoodlePostSource = "manual" | "generated";
 export type NoodleTheme = "system" | "light" | "dark";
@@ -75,6 +76,7 @@ export interface NoodleSettings {
   carryoverMaxItems: number;
   theme: NoodleTheme;
   generationConnectionId: string | null;
+  enableNoodler: boolean;
 }
 
 export interface NoodleAccount {
@@ -88,6 +90,8 @@ export interface NoodleAccount {
   avatarCrop: NoodleAvatarCrop | null;
   invited: boolean;
   settings: NoodleAccountSettings;
+  visibility: NoodleAccountVisibility;
+  publicAccountId: string | null;
   createdAt: string;
   updatedAt: string;
 }


### PR DESCRIPTION
## Linked issue

Closes #3754

## Why this change

NoodleR private-account creation previously required inserting a private row and separately writing a reverse link onto the public account. A failure between those writes could leave an orphan, while concurrent requests could create duplicate private accounts.

Private records also need a hard boundary from existing public Noodle queries and mutations before later NoodleR features build on them.

## What changed

- Added `visibility` and nullable `publicAccountId` fields to Noodle account rows.
- Added a conditional unique constraint so one public account can own at most one private account.
- Made private-account creation a single insert; the reverse relationship is derived from `publicAccountId`.
- Added a default-off NoodleR access gate and gated private-account list/create endpoints.
- Return a clean `409` when concurrent creation loses the unique-constraint race.
- Scoped public account, post, interaction, digest, invite-reset, and timeline-reset operations so private data cannot be read, mutated, or deleted through public-mode paths.
- Added the minimal NoodleR access setting stub and documented its default-off behavior.

## Storage impact

This changes the persisted `noodle_accounts` row shape. No standalone migration script is required for the file-native backend: existing rows are normalized on load to `visibility: "public"` and `publicAccountId: null`.

## Validation

- [ ] Run `pnpm check`.
- [ ] Run `pnpm guard:installer-artifacts`.
- [ ] Run `pnpm version:check`.
- [ ] Run `pnpm regression`.
- [ ] Manually verify NoodleR access gating in a browser.
- [ ] Manually verify public Noodle behavior with NoodleR enabled and disabled.

Automated evidence gathered while preparing this PR:

- `pnpm check` passed, including TypeScript, ESLint, and production builds.
- `pnpm guard:installer-artifacts` passed.
- `pnpm version:check` passed.
- Every deterministic non-browser lane reached by `pnpm regression` passed, including all Noodle regressions.
- A final focused `pnpm regression:noodle` passed after isolation hardening.
- `smoke:ui` could not run because the Playwright Chromium host is missing `libnspr4.so`; no browser automation host was connected for a substitute browser check.

## Controlled concurrency and isolation proof

A temporary proof script was run against isolated file-native storage and removed before handoff. It used `Promise.all` for two HTTP creation requests against the same public account and verified:

- Exactly one request returned `201` and the other returned `409`.
- Exactly one private row existed in live storage.
- The row contained the expected `publicAccountId`; no reverse-link write or orphan was created.
- The disabled feature gate returned `404`.
- Private accounts, posts, and interactions were inaccessible through public queries.
- Public timeline reset preserved private data.
- Reopened persisted storage still contained exactly one private account and preserved public-query isolation.

## Manual verification needed

- Manually verify the NoodleR access toggle in the Noodle settings UI.
- Manually verify the gated private-account endpoint before and after enabling access.
- Manually verify the public timeline, profile editing, interactions, and reset behavior with private fixture data present.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an optional **NoodleR Access** setting, disabled by default.
  * Enabled users can view available private creator accounts and see their loading status and count.
  * Added support for creating private creator accounts.
  * Public Noodle timelines, posts, interactions, and digests now exclude private-account data.

* **Documentation**
  * Updated the Noodle settings guide with details about NoodleR access and private account visibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
