### PR TITLE
Fix NovelAI resolved-size reporting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 
 ### Fixed
 
+- Made image prompt review display the subject-count-resolved dimensions actually sent to native NovelAI, kept Prompt Prefix count tokens out of scene sizing, and filled new NovelAI settings for legacy partial profiles (#3758).
 - Kept existing cropped Character avatars contained inside the Metadata upload preview instead of allowing the image to cover the card editor (#3741).
 
 ## [2.3.3]

--- a/packages/server/src/routes/backgrounds.routes.ts
+++ b/packages/server/src/routes/backgrounds.routes.ts
@@ -26,6 +26,7 @@ import { createPromptOverridesStorage } from "../services/storage/prompt-overrid
 import { buildBackgroundProviderPrompt, generateChatBackground } from "../services/game/game-asset-generation.js";
 import { resolveConnectionImageDefaults } from "../services/image/image-generation-defaults.js";
 import { loadImageGenerationUserSettings } from "../services/image/image-generation-settings.js";
+import { resolveImagePromptReviewSize } from "../services/image/image-prompt-review.js";
 import { resolveImageConnectionFallback } from "../services/generation/media-connection-fallback.js";
 import { resolveGameSetupArtStylePrompt } from "@marinara-engine/shared";
 
@@ -472,6 +473,13 @@ export async function backgroundsRoutes(app: FastifyInstance) {
       promptOverride: context.promptOverride?.prompt,
       negativePromptOverride: context.promptOverride?.negativePrompt,
     });
+    const previewSize = resolveImagePromptReviewSize({
+      connection: context.imgConn,
+      prompt: compiled.prompt,
+      width: context.imageSettings.background.width,
+      height: context.imageSettings.background.height,
+      imageDefaults: resolveConnectionImageDefaults(context.imgConn),
+    });
 
     return {
       items: [
@@ -481,8 +489,8 @@ export async function backgroundsRoutes(app: FastifyInstance) {
           title: "Scene background",
           prompt: compiled.prompt,
           negativePrompt: compiled.negativePrompt,
-          width: context.imageSettings.background.width,
-          height: context.imageSettings.background.height,
+          width: previewSize.width,
+          height: previewSize.height,
         },
       ],
     };

--- a/packages/server/src/routes/characters.routes.ts
+++ b/packages/server/src/routes/characters.routes.ts
@@ -24,6 +24,7 @@ import { generateImage } from "../services/image/image-generation.js";
 import { resolveConnectionImageDefaults } from "../services/image/image-generation-defaults.js";
 import { loadImageGenerationUserSettings } from "../services/image/image-generation-settings.js";
 import { compileImagePrompt } from "../services/image/image-prompt-compiler.js";
+import { resolveImagePromptReviewSize } from "../services/image/image-prompt-review.js";
 import { resolveImageConnectionFallback } from "../services/generation/media-connection-fallback.js";
 import {
   ConversationCallVideoClipAvatarMismatchError,
@@ -602,6 +603,13 @@ export async function charactersRoutes(app: FastifyInstance) {
       styleProfileId: body.styleProfileId,
       imageDefaults,
     });
+    const previewSize = resolveImagePromptReviewSize({
+      connection: resolved.conn,
+      prompt: compiled.prompt,
+      width,
+      height,
+      imageDefaults,
+    });
 
     return {
       items: [
@@ -611,8 +619,8 @@ export async function charactersRoutes(app: FastifyInstance) {
           title: `Avatar: ${body.name?.trim() || "Character"}`,
           prompt: compiled.prompt,
           negativePrompt: compiled.negativePrompt,
-          width,
-          height,
+          width: previewSize.width,
+          height: previewSize.height,
         },
       ],
     };

--- a/packages/server/src/routes/gallery.routes.ts
+++ b/packages/server/src/routes/gallery.routes.ts
@@ -34,7 +34,10 @@ import { generateImage, saveImageToDisk } from "../services/image/image-generati
 import { resolveConnectionImageDefaults } from "../services/image/image-generation-defaults.js";
 import { loadImageGenerationUserSettings } from "../services/image/image-generation-settings.js";
 import { compileImagePrompt } from "../services/image/image-prompt-compiler.js";
-import { resolveReviewedImagePromptSubmission } from "../services/image/image-prompt-review.js";
+import {
+  resolveImagePromptReviewSize,
+  resolveReviewedImagePromptSubmission,
+} from "../services/image/image-prompt-review.js";
 import { runImageGenerationRequest } from "../services/image/image-generation-queue.js";
 import { persistGeneratedImageToEntityGalleries } from "../services/image/generated-image-entity-gallery.js";
 import {
@@ -1067,6 +1070,13 @@ export async function galleryRoutes(app: FastifyInstance) {
     const providerNegativePrompt = promptSubmission.negativePrompt;
 
     if (input.previewOnly) {
+      const previewSize = resolveImagePromptReviewSize({
+        connection: imageConn,
+        prompt: providerPrompt,
+        width,
+        height,
+        imageDefaults,
+      });
       return {
         items: [
           {
@@ -1075,8 +1085,8 @@ export async function galleryRoutes(app: FastifyInstance) {
             title: `${characterName} selfie`,
             prompt: providerPrompt,
             ...(providerNegativePrompt ? { negativePrompt: providerNegativePrompt } : {}),
-            width,
-            height,
+            width: previewSize.width,
+            height: previewSize.height,
           },
         ],
       };

--- a/packages/server/src/routes/game.routes.ts
+++ b/packages/server/src/routes/game.routes.ts
@@ -210,6 +210,7 @@ import {
 } from "../services/video/video-generation.js";
 import { resolveGameVideoRuntime, type GameVideoRuntime } from "../services/video/game-video-runtime.js";
 import { resolveConnectionImageDefaults } from "../services/image/image-generation-defaults.js";
+import { resolveImagePromptReviewSize } from "../services/image/image-prompt-review.js";
 import {
   resolveImageConnectionFallback,
   resolveVideoConnectionFallback,
@@ -10595,14 +10596,21 @@ export async function gameRoutes(app: FastifyInstance) {
                 compiled.negativePrompt,
               );
             }
+            const previewSize = resolveImagePromptReviewSize({
+              connection: imgConn,
+              prompt: compiled.prompt,
+              width: backgroundSize.width,
+              height: backgroundSize.height,
+              imageDefaults: imgDefaults,
+            });
             return {
               id: `storyboard:${frameIndex}`,
               kind: "illustration" as const,
               title: `Keyframe ${frameIndex + 1}: ${plannedFrame.title}`,
               prompt: compiled.prompt,
               negativePrompt: compiled.negativePrompt,
-              width: backgroundSize.width,
-              height: backgroundSize.height,
+              width: previewSize.width,
+              height: previewSize.height,
             };
           }),
         );
@@ -11243,6 +11251,14 @@ export async function gameRoutes(app: FastifyInstance) {
     const imgServiceHint = imgConn.imageService || imgSource;
     const imgEndpointId = imgConn.imageEndpointId || undefined;
     const imgDefaults = resolveConnectionImageDefaults(imgConn);
+    const previewSizeFor = (prompt: string, size: ImageGenerationSize) =>
+      resolveImagePromptReviewSize({
+        connection: imgConn,
+        prompt,
+        width: size.width,
+        height: size.height,
+        imageDefaults: imgDefaults,
+      });
     const promptOverridesStorage = createPromptOverridesStorage(app.db);
     const promptOverrideById = new Map(
       (input.promptOverrides ?? []).map((item) => [
@@ -11319,14 +11335,15 @@ export async function gameRoutes(app: FastifyInstance) {
         promptOverride: promptOverride?.prompt,
         negativePromptOverride: promptOverride?.negativePrompt,
       });
+      const previewSize = previewSizeFor(compiledReviewPrompt.prompt, backgroundSize);
       items.push({
         id: gameImagePromptReviewId("background", slug),
         kind: "background",
         title: `Background: ${slug}`,
         prompt: compiledReviewPrompt.prompt,
         negativePrompt: compiledReviewPrompt.negativePrompt,
-        width: backgroundSize.width,
-        height: backgroundSize.height,
+        width: previewSize.width,
+        height: previewSize.height,
       });
     }
 
@@ -11436,14 +11453,15 @@ export async function gameRoutes(app: FastifyInstance) {
           promptOverride: promptOverride?.prompt,
           negativePromptOverride: promptOverride?.negativePrompt,
         });
+        const previewSize = previewSizeFor(compiledReviewPrompt.prompt, backgroundSize);
         items.push({
           id: gameImagePromptReviewId("illustration", illustrationReviewKey),
           kind: "illustration",
           title: illustration.reason ? `Illustration: ${illustration.reason}` : "Scene illustration",
           prompt: compiledReviewPrompt.prompt,
           negativePrompt: compiledReviewPrompt.negativePrompt,
-          width: backgroundSize.width,
-          height: backgroundSize.height,
+          width: previewSize.width,
+          height: previewSize.height,
         });
       }
     }
@@ -11526,14 +11544,15 @@ export async function gameRoutes(app: FastifyInstance) {
             promptOverride: promptOverride?.prompt,
             negativePromptOverride: promptOverride?.negativePrompt,
           });
+          const previewSize = previewSizeFor(compiledReviewPrompt.prompt, portraitSize);
           portraitPreviewItems[index] = {
             id: gameImagePromptReviewId("portrait", npc.name),
             kind: "portrait",
             title: `Portrait: ${npc.name}`,
             prompt: compiledReviewPrompt.prompt,
             negativePrompt: compiledReviewPrompt.negativePrompt,
-            width: portraitSize.width,
-            height: portraitSize.height,
+            width: previewSize.width,
+            height: previewSize.height,
           };
         }
       };

--- a/packages/server/src/routes/generate/retry-agents-route.ts
+++ b/packages/server/src/routes/generate/retry-agents-route.ts
@@ -73,6 +73,7 @@ import { resolveImageConnectionFallback } from "../../services/generation/media-
 import type { GenerationFallbackNotifier } from "../../services/generation/fallback-notification.js";
 import { createReplyFallbackNotifier } from "./fallback-notification.js";
 import { runImageGenerationRequest } from "../../services/image/image-generation-queue.js";
+import { resolveImagePromptReviewSize } from "../../services/image/image-prompt-review.js";
 import {
   parseIllustratorPromptReviewOverride,
   resolveIllustratorPromptSubmission,
@@ -3128,6 +3129,13 @@ async function applyRetryResultEffects(args: {
             });
 
             if (reviewImagePromptsBeforeSend && !illustratorPromptReviewOverride) {
+              const previewSize = resolveImagePromptReviewSize({
+                connection: imgConnFull,
+                prompt: promptSubmission.prompt,
+                width: imgWidth,
+                height: imgHeight,
+                imageDefaults,
+              });
               sendSseEvent(reply, {
                 type: "image_prompt_review",
                 data: {
@@ -3138,8 +3146,8 @@ async function applyRetryResultEffects(args: {
                     title: "Scene illustration",
                     prompt: promptSubmission.prompt,
                     ...(promptSubmission.negativePrompt ? { negativePrompt: promptSubmission.negativePrompt } : {}),
-                    width: imgWidth,
-                    height: imgHeight,
+                    width: previewSize.width,
+                    height: previewSize.height,
                   },
                   resultData: illData,
                 },

--- a/packages/server/src/routes/noodle.routes.ts
+++ b/packages/server/src/routes/noodle.routes.ts
@@ -53,6 +53,7 @@ import { generateImage, saveImageToDisk } from "../services/image/image-generati
 import { resolveConnectionImageDefaults } from "../services/image/image-generation-defaults.js";
 import { loadImageGenerationUserSettings } from "../services/image/image-generation-settings.js";
 import { compileImagePrompt } from "../services/image/image-prompt-compiler.js";
+import { resolveImagePromptReviewSize } from "../services/image/image-prompt-review.js";
 import {
   loadPrompt,
   NOODLE_IMAGE_POST,
@@ -1247,6 +1248,13 @@ async function generateNoodlePostImage(input: {
   }
 
   if (input.previewOnly) {
+    const previewSize = resolveImagePromptReviewSize({
+      connection: input.imageConnection,
+      prompt: finalPrompt,
+      width: imageSettings.illustration.width,
+      height: imageSettings.illustration.height,
+      imageDefaults,
+    });
     return {
       imageUrl: null,
       metadata: {},
@@ -1255,8 +1263,8 @@ async function generateNoodlePostImage(input: {
         title: `${input.account.displayName} Noodle image`,
         prompt: finalPrompt,
         negativePrompt: finalNegativePrompt,
-        width: imageSettings.illustration.width,
-        height: imageSettings.illustration.height,
+        width: previewSize.width,
+        height: previewSize.height,
       },
     };
   }

--- a/packages/server/src/routes/sprites.routes.ts
+++ b/packages/server/src/routes/sprites.routes.ts
@@ -48,6 +48,7 @@ import { generateImage } from "../services/image/image-generation.js";
 import { resolveConnectionImageDefaults } from "../services/image/image-generation-defaults.js";
 import { loadImageGenerationUserSettings } from "../services/image/image-generation-settings.js";
 import { compileImagePrompt } from "../services/image/image-prompt-compiler.js";
+import { resolveImagePromptReviewSize } from "../services/image/image-prompt-review.js";
 import {
   resolveImageConnectionFallback,
   resolveVideoConnectionFallback,
@@ -1559,14 +1560,21 @@ export async function spritesRoutes(app: FastifyInstance) {
             compiledPrompt,
           );
           const finalPrompt = withSpriteBackgroundContract(reviewedPrompt.value, plan);
+          const previewSize = resolveImagePromptReviewSize({
+            connection: conn,
+            prompt: finalPrompt.prompt,
+            width: 1024,
+            height: 1024,
+            imageDefaults,
+          });
           return {
             id: spritePromptReviewId("expression", plan.spriteType, expression),
             kind: "sprite",
             title: `Expression: ${expression.replace(/_/g, " ")}`,
             prompt: finalPrompt.prompt,
             negativePrompt: finalPrompt.negativePrompt,
-            width: 1024,
-            height: 1024,
+            width: previewSize.width,
+            height: previewSize.height,
           };
         }),
       );
@@ -1590,6 +1598,13 @@ export async function spritesRoutes(app: FastifyInstance) {
       }),
       plan,
     );
+    const previewSize = resolveImagePromptReviewSize({
+      connection: conn,
+      prompt: finalPrompt.prompt,
+      width: plan.sheetWidth,
+      height: plan.sheetHeight,
+      imageDefaults,
+    });
     return {
       items: [
         {
@@ -1601,8 +1616,8 @@ export async function spritesRoutes(app: FastifyInstance) {
               : `Expression sprites: ${plan.cols}x${plan.rows}`,
           prompt: finalPrompt.prompt,
           negativePrompt: finalPrompt.negativePrompt,
-          width: plan.sheetWidth,
-          height: plan.sheetHeight,
+          width: previewSize.width,
+          height: previewSize.height,
         },
       ],
     };

--- a/packages/server/src/services/image/image-generation.ts
+++ b/packages/server/src/services/image/image-generation.ts
@@ -1460,6 +1460,16 @@ export function resolveNovelAiSize(
   return { width, height };
 }
 
+/** Resolve the native NovelAI request size from scene content only, excluding the connection Prompt Prefix. */
+export function resolveNovelAiRequestSize(
+  request: ImageGenRequest,
+  defaults: NovelAiDefaults = resolveNovelAiDefaults(request),
+): { width: number; height: number } {
+  const model = request.model || "nai-diffusion-4-5-full";
+  const scenePrompt = isNovelAiV4Model(model) ? sanitizeNovelAiV4Prompt(request.prompt) : request.prompt;
+  return resolveNovelAiSize(request, scenePrompt, defaults);
+}
+
 function isNovelAiV4Model(model: string): boolean {
   return /^nai-diffusion-(?:4(?:-(?:curated-preview|full))?|4-5(?:-(?:curated|full))?)$/i.test(model.trim());
 }
@@ -1717,7 +1727,7 @@ async function generateNovelAI(baseUrl: string, apiKey: string, request: ImageGe
   }
   const directorReferenceImages = await prepareNovelAiDirectorReferenceImages(referenceImages);
   const characterPromptPayload = buildNovelAiV4CharacterPromptPayload(request.characterPrompts, model);
-  const size = resolveNovelAiSize(request, mergedPrompt, defaults);
+  const size = resolveNovelAiRequestSize(request, defaults);
 
   const parameters: Record<string, unknown> = {
     width: size.width,
@@ -2329,9 +2339,9 @@ function resolveSeed(profile: ImageGenerationDefaultsProfile | null | undefined)
   return typeof profile?.seed === "number" && profile.seed >= 0 ? profile.seed : randomSeed();
 }
 
-function resolveNovelAiDefaults(request: ImageGenRequest): NovelAiDefaults {
+export function resolveNovelAiDefaults(request: ImageGenRequest): NovelAiDefaults {
   if (request.imageDefaults?.service === "novelai" && request.imageDefaults.novelai) {
-    return request.imageDefaults.novelai;
+    return { ...DEFAULT_NOVELAI_DEFAULTS, ...request.imageDefaults.novelai };
   }
   return DEFAULT_NOVELAI_DEFAULTS;
 }

--- a/packages/server/src/services/image/image-prompt-review.ts
+++ b/packages/server/src/services/image/image-prompt-review.ts
@@ -1,7 +1,40 @@
+import type { ImageGenerationDefaultsProfile } from "@marinara-engine/shared";
+
+import { resolveImageGenerationService, type ImageDefaultsConnection } from "./image-generation-defaults.js";
+import { resolveNovelAiRequestSize } from "./image-generation.js";
+
 export type ReviewedImagePromptSubmission = {
   prompt: string;
   negativePrompt: string;
 };
+
+type ImagePromptReviewConnection = Pick<
+  ImageDefaultsConnection,
+  "baseUrl" | "model" | "imageGenerationSource" | "imageService"
+>;
+
+/** Resolve the dimensions shown before an image request using the same native NovelAI sizing rule as generation. */
+export function resolveImagePromptReviewSize(args: {
+  connection: ImagePromptReviewConnection;
+  prompt: string;
+  width: number;
+  height: number;
+  imageDefaults?: ImageGenerationDefaultsProfile | null;
+}): { width: number; height: number } {
+  const requestedSize = { width: args.width, height: args.height };
+  const isNativeNovelAi =
+    resolveImageGenerationService(args.connection) === "novelai" &&
+    (args.connection.baseUrl ?? "").toLowerCase().includes("novelai.net");
+  if (!isNativeNovelAi) return requestedSize;
+
+  return resolveNovelAiRequestSize({
+    prompt: args.prompt,
+    width: args.width,
+    height: args.height,
+    model: args.connection.model ?? undefined,
+    imageDefaults: args.imageDefaults,
+  });
+}
 
 /**
  * Apply a reviewed positive prompt while retaining the compiled negative prompt

--- a/scripts/regressions/open-issues.regression.ts
+++ b/scripts/regressions/open-issues.regression.ts
@@ -90,6 +90,8 @@ import {
 import { runImageGenerationRequest } from "../../packages/server/src/services/image/image-generation-queue.js";
 import {
   detectNovelAiSubjectCount,
+  resolveNovelAiDefaults,
+  resolveNovelAiRequestSize,
   resolveNovelAiSize,
 } from "../../packages/server/src/services/image/image-generation.js";
 import { DEFAULT_NOVELAI_DEFAULTS } from "../../packages/shared/src/constants/image-generation-defaults.js";
@@ -98,7 +100,10 @@ import {
   parseIllustratorPromptReviewOverride,
   resolveIllustratorPromptSubmission,
 } from "../../packages/server/src/services/image/illustrator-prompt-review.js";
-import { resolveReviewedImagePromptSubmission } from "../../packages/server/src/services/image/image-prompt-review.js";
+import {
+  resolveImagePromptReviewSize,
+  resolveReviewedImagePromptSubmission,
+} from "../../packages/server/src/services/image/image-prompt-review.js";
 import {
   cleanupStagedProfileAssets,
   promoteStagedProfileAssets,
@@ -1609,9 +1614,87 @@ const legacyNovelAiProfile = {
   seed: -1,
   novelai: { promptPrefix: "2girls" },
 } as unknown as ImageGenerationDefaultsProfile;
+assert.deepEqual(resolveNovelAiDefaults({ prompt: "1boy", imageDefaults: legacyNovelAiProfile }), {
+  ...DEFAULT_NOVELAI_DEFAULTS,
+  promptPrefix: "2girls",
+});
 assert.deepEqual(
   resolveNovelAiSize({ prompt: "1boy", width: 1216, height: 832, imageDefaults: legacyNovelAiProfile }, "1boy"),
   { width: 832, height: 1216 },
+);
+const nativeNovelAiConnection = {
+  baseUrl: "https://image.novelai.net",
+  model: "nai-diffusion-4-5-full",
+  imageService: "novelai",
+};
+const prefixedNovelAiProfile = {
+  version: 1,
+  service: "novelai",
+  seed: -1,
+  novelai: { ...DEFAULT_NOVELAI_DEFAULTS, promptPrefix: "2girls" },
+} satisfies ImageGenerationDefaultsProfile;
+assert.deepEqual(
+  resolveNovelAiRequestSize({
+    prompt: "1boy",
+    width: 1216,
+    height: 832,
+    model: nativeNovelAiConnection.model,
+    imageDefaults: prefixedNovelAiProfile,
+  }),
+  { width: 832, height: 1216 },
+);
+assert.deepEqual(
+  resolveImagePromptReviewSize({
+    connection: nativeNovelAiConnection,
+    prompt: "1boy",
+    width: 1216,
+    height: 832,
+    imageDefaults: prefixedNovelAiProfile,
+  }),
+  { width: 832, height: 1216 },
+);
+assert.deepEqual(
+  resolveImagePromptReviewSize({
+    connection: nativeNovelAiConnection,
+    prompt: "1girl, 1boy, 1other",
+    width: 832,
+    height: 1216,
+    imageDefaults: prefixedNovelAiProfile,
+  }),
+  { width: 1216, height: 832 },
+);
+assert.deepEqual(
+  resolveImagePromptReviewSize({
+    connection: nativeNovelAiConnection,
+    prompt: "1boy",
+    width: 1216,
+    height: 832,
+    imageDefaults: {
+      ...prefixedNovelAiProfile,
+      novelai: { ...prefixedNovelAiProfile.novelai!, dynamicResolutionBySubjectCount: false },
+    },
+  }),
+  { width: 1216, height: 832 },
+);
+assert.deepEqual(
+  resolveImagePromptReviewSize({
+    connection: { ...nativeNovelAiConnection, baseUrl: "https://novelai-proxy.example.com" },
+    prompt: "1boy",
+    width: 1216,
+    height: 832,
+    imageDefaults: prefixedNovelAiProfile,
+  }),
+  { width: 1216, height: 832 },
+);
+assert.deepEqual(
+  resolveImagePromptReviewSize({
+    connection: { baseUrl: "https://api.openai.com", model: "gpt-image-1", imageService: "openai" },
+    prompt: "1boy",
+    width: 1024,
+    height: 1024,
+    imageDefaults: null,
+  }),
+  { width: 1024, height: 1024 },
 );
 
 const originalChatGenerationTimeout = process.env.CHAT_GENERATION_TIMEOUT_MS;

--- a/scripts/regressions/open-issues.regression.ts
+++ b/scripts/regressions/open-issues.regression.ts
@@ -93,6 +93,7 @@ import {
   resolveNovelAiSize,
 } from "../../packages/server/src/services/image/image-generation.js";
 import { DEFAULT_NOVELAI_DEFAULTS } from "../../packages/shared/src/constants/image-generation-defaults.js";
+import type { ImageGenerationDefaultsProfile } from "../../packages/shared/src/types/image-generation-defaults.js";
 import {
   parseIllustratorPromptReviewOverride,
   resolveIllustratorPromptSubmission,
@@ -1601,6 +1602,16 @@ assert.deepEqual(
     { ...DEFAULT_NOVELAI_DEFAULTS, dynamicResolutionBySubjectCount: false },
   ),
   { width: 1024, height: 1024 },
+);
+const legacyNovelAiProfile = {
+  version: 1,
+  service: "novelai",
+  seed: -1,
+  novelai: { promptPrefix: "2girls" },
+} as unknown as ImageGenerationDefaultsProfile;
+assert.deepEqual(
+  resolveNovelAiSize({ prompt: "1boy", width: 1216, height: 832, imageDefaults: legacyNovelAiProfile }, "1boy"),
+  { width: 832, height: 1216 },
 );
 
 const originalChatGenerationTimeout = process.env.CHAT_GENERATION_TIMEOUT_MS;

--- a/scripts/regressions/open-issues.regression.ts
+++ b/scripts/regressions/open-issues.regression.ts
@@ -1619,7 +1619,7 @@ assert.deepEqual(resolveNovelAiDefaults({ prompt: "1boy", imageDefaults: legacyN
   promptPrefix: "2girls",
 });
 assert.deepEqual(
-  resolveNovelAiSize({ prompt: "1boy", width: 1216, height: 832, imageDefaults: legacyNovelAiProfile }, "1boy"),
+  resolveNovelAiSize({ prompt: "1boy", width: 1216, height: 832, imageDefaults: legacyNovelAiProfile }),
   { width: 832, height: 1216 },
 );
 const nativeNovelAiConnection = {


### PR DESCRIPTION
## Why

NovelAI dynamic resolution correctly changed the generated image size, but image prompt review still displayed the configured dimensions. Subject-count tokens in a connection Prompt Prefix could also change scene orientation, and partial pre-v2.3.3 profiles could omit newer defaults.

Closes #3758.

## What changed

- report subject-count-resolved dimensions from the final scene prompt in every image prompt review surface
- exclude Prompt Prefix from subject-count detection while still sending the prefix to NovelAI
- merge legacy partial NovelAI profiles over current defaults
- preserve requested dimensions for non-native NovelAI proxies, other providers, and disabled dynamic sizing
- add positive and negative regression rows for native NovelAI, prefixes, proxies, other providers, and legacy profiles
- update the changelog

## Validation

Automated evidence:

- PASS: `pnpm regression:issues`
- PASS: `pnpm check`
- PASS after CodeRabbit cleanup: focused open-issues regression

Manual verification remaining:

- [ ] Review a one-subject NovelAI prompt and confirm the UI reports 832x1216
- [ ] Review a three-subject NovelAI prompt and confirm the UI reports 1216x832
- [ ] Confirm a Prompt Prefix count token does not change scene orientation


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Image prompt previews now display dimensions that match the actual image request, including NovelAI subject-based sizing.
  * Prompt prefixes no longer affect scene-based image dimensions.
  * Legacy and partial NovelAI settings now receive appropriate default values.
  * Preview sizing is corrected across backgrounds, characters, galleries, storyboards, sprites, illustrations, and retry flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->