### PR TITLE
fix: isolate Playwright startup from an active dev server

### DIFF
--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -8,7 +8,7 @@
     "mari": "./dist/bin/mari.js"
   },
   "scripts": {
-    "dev": "tsx watch --ignore ./data --ignore ./node_modules --ignore ../../node_modules src/index.ts",
+    "dev": "tsx watch --ignore ./data --ignore ../shared/dist --ignore ./node_modules --ignore ../../node_modules src/index.ts",
     "build": "node ./scripts/build.mjs",
     "start": "node dist/index.js",
     "test": "node ./scripts/run-tests.mjs",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -13,6 +13,7 @@
   },
   "scripts": {
     "build": "node -e \"const fs=require('fs');['dist','tsconfig.tsbuildinfo'].forEach(p=>{try{fs.rmSync(p,{recursive:true,force:true})}catch{}})\" && node scripts/generate-feature-registries.mjs && tsc",
+    "build:preserve": "node -e \"const fs=require('fs');try{fs.rmSync('tsconfig.tsbuildinfo',{force:true})}catch{}\" && node scripts/generate-feature-registries.mjs && tsc",
     "dev": "node scripts/generate-feature-registries.mjs && tsc --watch --preserveWatchOutput",
     "clean": "node -e \"const fs=require('fs');['dist','tsconfig.tsbuildinfo'].forEach(p=>{try{fs.rmSync(p,{recursive:true,force:true})}catch{}})\"",
     "lint": "node scripts/generate-feature-registries.mjs && tsc --noEmit"

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -39,6 +39,7 @@ export default defineConfig({
             AUTO_CREATE_DEFAULT_CONNECTION: "false",
             AUTO_OPEN_BROWSER: "false",
             DATA_DIR: "../../.tmp/playwright-data",
+            DEV_PRESERVE_SHARED_DIST: "true",
             DEV_SERVER_READY_TIMEOUT_MS: "180000",
             LOG_DISABLE_REQUEST_LOGGING: "true",
             LOG_LEVEL: "silent",

--- a/scripts/dev-shared-build.mjs
+++ b/scripts/dev-shared-build.mjs
@@ -1,0 +1,4 @@
+/** Select the shared-package build used before a development stack starts. */
+export function resolveDevSharedBuildScript(environment = process.env) {
+  return environment.DEV_PRESERVE_SHARED_DIST === "true" ? "build:preserve" : "build";
+}

--- a/scripts/dev.mjs
+++ b/scripts/dev.mjs
@@ -1,5 +1,6 @@
 import { spawn, spawnSync } from "node:child_process";
 import { basename } from "node:path";
+import { resolveDevSharedBuildScript } from "./dev-shared-build.mjs";
 
 function parseIntegerEnv(name, fallback) {
   const raw = process.env[name];
@@ -11,7 +12,7 @@ function parseIntegerEnv(name, fallback) {
 const SERVER_PORT = parseIntegerEnv("PORT", 7860);
 const SERVER_HEALTH_URL = `http://127.0.0.1:${SERVER_PORT}/api/health`;
 const HEALTH_TIMEOUT_MS = parseIntegerEnv("DEV_SERVER_READY_TIMEOUT_MS", 120_000);
-const SHARED_BUILD_SCRIPT = process.env.DEV_PRESERVE_SHARED_DIST === "true" ? "build:preserve" : "build";
+const SHARED_BUILD_SCRIPT = resolveDevSharedBuildScript();
 
 const pnpmCliPath = process.env.npm_execpath;
 const npmUserAgent = process.env.npm_config_user_agent ?? "";

--- a/scripts/dev.mjs
+++ b/scripts/dev.mjs
@@ -11,6 +11,7 @@ function parseIntegerEnv(name, fallback) {
 const SERVER_PORT = parseIntegerEnv("PORT", 7860);
 const SERVER_HEALTH_URL = `http://127.0.0.1:${SERVER_PORT}/api/health`;
 const HEALTH_TIMEOUT_MS = parseIntegerEnv("DEV_SERVER_READY_TIMEOUT_MS", 120_000);
+const SHARED_BUILD_SCRIPT = process.env.DEV_PRESERVE_SHARED_DIST === "true" ? "build:preserve" : "build";
 
 const pnpmCliPath = process.env.npm_execpath;
 const npmUserAgent = process.env.npm_config_user_agent ?? "";
@@ -86,7 +87,7 @@ process.on("SIGINT", () => stopChildren("SIGINT"));
 process.on("SIGTERM", () => stopChildren("SIGTERM"));
 
 try {
-  await runPnpm(["build:shared"]);
+  await runPnpm(["--filter", "@marinara-engine/shared", SHARED_BUILD_SCRIPT]);
 
   const server = spawnPnpm(["--filter", "@marinara-engine/server", "dev"]);
   server.once("exit", (code, signal) => {

--- a/scripts/regressions/open-issues.regression.ts
+++ b/scripts/regressions/open-issues.regression.ts
@@ -692,6 +692,10 @@ const sharedPackageJson = JSON.parse(
 const preserveSharedBuild = sharedPackageJson.scripts?.["build:preserve"] ?? "";
 assert.match(preserveSharedBuild, /tsconfig\.tsbuildinfo/u);
 assert.doesNotMatch(preserveSharedBuild, /\[['"]dist['"]/u);
+const serverPackageJson = JSON.parse(
+  readFileSync(new URL("../../packages/server/package.json", import.meta.url), "utf8"),
+) as { scripts?: Record<string, string> };
+assert.match(serverPackageJson.scripts?.dev ?? "", /--ignore \.\.\/shared\/dist/u);
 const devLauncher = readFileSync(new URL("../../scripts/dev.mjs", import.meta.url), "utf8");
 assert.match(devLauncher, /DEV_PRESERVE_SHARED_DIST/u);
 assert.match(devLauncher, /SHARED_BUILD_SCRIPT/u);

--- a/scripts/regressions/open-issues.regression.ts
+++ b/scripts/regressions/open-issues.regression.ts
@@ -4,6 +4,8 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
 import type { Chat, Message } from "../../packages/shared/src/types/chat.js";
+import playwrightConfig from "../../playwright.config.js";
+import { resolveDevSharedBuildScript } from "../dev-shared-build.mjs";
 
 const REPOSITORY_ROOT = fileURLToPath(new URL("../../", import.meta.url));
 import {
@@ -691,16 +693,17 @@ const sharedPackageJson = JSON.parse(
 ) as { scripts?: Record<string, string> };
 const preserveSharedBuild = sharedPackageJson.scripts?.["build:preserve"] ?? "";
 assert.match(preserveSharedBuild, /tsconfig\.tsbuildinfo/u);
-assert.doesNotMatch(preserveSharedBuild, /\[['"]dist['"]/u);
+assert.doesNotMatch(preserveSharedBuild, /\bdist\b/u);
 const serverPackageJson = JSON.parse(
   readFileSync(new URL("../../packages/server/package.json", import.meta.url), "utf8"),
 ) as { scripts?: Record<string, string> };
 assert.match(serverPackageJson.scripts?.dev ?? "", /--ignore \.\.\/shared\/dist/u);
-const devLauncher = readFileSync(new URL("../../scripts/dev.mjs", import.meta.url), "utf8");
-assert.match(devLauncher, /DEV_PRESERVE_SHARED_DIST/u);
-assert.match(devLauncher, /SHARED_BUILD_SCRIPT/u);
-const playwrightConfig = readFileSync(new URL("../../playwright.config.ts", import.meta.url), "utf8");
-assert.match(playwrightConfig, /DEV_PRESERVE_SHARED_DIST:\s*["']true["']/u);
+assert.equal(resolveDevSharedBuildScript({ DEV_PRESERVE_SHARED_DIST: "true" }), "build:preserve");
+assert.equal(resolveDevSharedBuildScript({}), "build");
+const playwrightWebServer = Array.isArray(playwrightConfig.webServer)
+  ? playwrightConfig.webServer[0]
+  : playwrightConfig.webServer;
+assert.equal(playwrightWebServer?.env?.DEV_PRESERVE_SHARED_DIST, "true");
 
 const appSource = readFileSync(new URL("../../packages/client/src/App.tsx", import.meta.url), "utf8");
 const agentEditorSource = readFileSync(

--- a/scripts/regressions/open-issues.regression.ts
+++ b/scripts/regressions/open-issues.regression.ts
@@ -686,6 +686,18 @@ assert.doesNotMatch(termuxLauncher, /run_pnpm install --force/u);
 assert.match(termuxLauncher, /run_pnpm store prune/u);
 assert.match(termuxLauncher, /TERMUX_REBUILD_REQUIRED/u);
 
+const sharedPackageJson = JSON.parse(
+  readFileSync(new URL("../../packages/shared/package.json", import.meta.url), "utf8"),
+) as { scripts?: Record<string, string> };
+const preserveSharedBuild = sharedPackageJson.scripts?.["build:preserve"] ?? "";
+assert.match(preserveSharedBuild, /tsconfig\.tsbuildinfo/u);
+assert.doesNotMatch(preserveSharedBuild, /\[['"]dist['"]/u);
+const devLauncher = readFileSync(new URL("../../scripts/dev.mjs", import.meta.url), "utf8");
+assert.match(devLauncher, /DEV_PRESERVE_SHARED_DIST/u);
+assert.match(devLauncher, /SHARED_BUILD_SCRIPT/u);
+const playwrightConfig = readFileSync(new URL("../../playwright.config.ts", import.meta.url), "utf8");
+assert.match(playwrightConfig, /DEV_PRESERVE_SHARED_DIST:\s*["']true["']/u);
+
 const appSource = readFileSync(new URL("../../packages/client/src/App.tsx", import.meta.url), "utf8");
 const agentEditorSource = readFileSync(
   new URL("../../packages/client/src/components/agents/AgentEditor.tsx", import.meta.url),


### PR DESCRIPTION
## Why

Playwright starts a second development stack on isolated test ports. That stack previously ran the normal clean shared-package build, which removed packages/shared/dist while an existing API server could still be importing from it. The live server then restarted into a missing module and exited.

Closes #3778.

## Summary

- Add a shared build mode that refreshes TypeScript output without deleting dist.
- Select that preserved build only for Playwright-started development stacks.
- Keep the normal API watcher from reacting to shared artifacts written by the test stack.
- Keep normal clean development and production builds unchanged.
- Add regression guards for the Playwright-to-dev wiring.

## Validation

Automated validation completed locally:

- pnpm --filter @marinara-engine/shared build
- pnpm --filter @marinara-engine/shared build:preserve
- pnpm regression:issues
- pnpm check
- Focused desktop Chromium smoke test: 1 passed
- Two-stack reproduction: the original API stayed healthy and did not restart while Playwright rebuilt shared and completed the browser test

Manual verification for the human contributor:

- [ ] Manually start pnpm dev on the normal development ports.
- [ ] Manually start a Playwright smoke test on its isolated ports.
- [ ] Manually verify the original API remains continuously healthy while Playwright runs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved development stability by preserving shared build output when running the development server.
  * Prevented unnecessary server restarts when shared package files change.

* **Tests**
  * Added regression coverage for shared build preservation and development environment configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->