### PR TITLE
refactor(client): centralize API transport policy

### DIFF
--- a/packages/client/src/components/chat/ChatBranchSelector.tsx
+++ b/packages/client/src/components/chat/ChatBranchSelector.tsx
@@ -26,6 +26,7 @@ import { showConfirmDialog, showPromptDialog } from "../../lib/app-dialogs";
 import { CHAT_FLOATING_UI_DISMISS_EVENT, isDesktopShellNavigationTarget } from "../../lib/chat-floating-ui-events";
 import { getChatDisplayName } from "../../lib/chat-display";
 import { compareChatsByActivityDesc } from "../../lib/chat-recency";
+import { api } from "../../lib/api-client";
 import { useChatStore } from "../../stores/chat.store";
 import { cn } from "../../lib/utils";
 import {
@@ -120,10 +121,15 @@ export function ChatBranchSelector({
       const formData = new FormData();
       formData.append("chatId", activeChatId);
       formData.append("file", file);
-      const res = await fetch("/api/import/st-chat-into-group", { method: "POST", body: formData });
-      const data = await res.json().catch(() => ({}));
-      if (!res.ok || data?.success === false || data?.error) {
-        toast.error(`Import failed: ${data?.error ?? res.statusText ?? "Unknown error"}`);
+      const data = await api.upload<{
+        success?: boolean;
+        error?: string;
+        messagesImported?: number;
+        groupId?: string;
+        chatId?: string;
+      }>("/import/st-chat-into-group", formData);
+      if (data.success === false || data.error) {
+        toast.error(`Import failed: ${data.error ?? "Unknown error"}`);
         return;
       }
       toast.success(`Imported ${data.messagesImported ?? 0} messages as a new branch`);

--- a/packages/client/src/components/layout/ChatSidebar.tsx
+++ b/packages/client/src/components/layout/ChatSidebar.tsx
@@ -61,6 +61,7 @@ import { Reorder, useDragControls } from "framer-motion";
 import { parseChatMetadata } from "../../lib/chat-display";
 import { compareChatsByActivityAsc, compareChatsByActivityDesc } from "../../lib/chat-recency";
 import { getCurrentGameGroupRepresentative } from "../../lib/game-session-resolution";
+import { api } from "../../lib/api-client";
 import { SelectionActionBar } from "../ui/SelectionActionBar";
 import { SmoothFolderContent } from "../ui/SmoothFolderContent";
 
@@ -658,15 +659,14 @@ export function ChatSidebar() {
         const formData = new FormData();
         formData.append("file", file);
         formData.append("mode", activeTab);
-        const res = await fetch("/api/import/st-chat", { method: "POST", body: formData });
-        const data = (await res.json().catch(() => ({}))) as {
+        const data = await api.upload<{
           success?: boolean;
           chatId?: string;
           error?: string;
           messagesImported?: number;
-        };
-        if (!res.ok || data.success === false || data.error) {
-          toast.error(`Import failed: ${data.error ?? res.statusText ?? "Unknown error"}`);
+        }>("/import/st-chat", formData);
+        if (data.success === false || data.error) {
+          toast.error(`Import failed: ${data.error ?? "Unknown error"}`);
           return;
         }
 

--- a/packages/client/src/components/modals/STBulkImportModal.tsx
+++ b/packages/client/src/components/modals/STBulkImportModal.tsx
@@ -24,7 +24,7 @@ import {
 } from "lucide-react";
 import { useQueryClient } from "@tanstack/react-query";
 import { cn } from "../../lib/utils";
-import { getAdminSecretHeader } from "../../lib/api-client";
+import { api } from "../../lib/api-client";
 
 interface Props {
   open: boolean;
@@ -189,12 +189,8 @@ export function STBulkImportModal({ open, onClose }: Props) {
     setError("");
 
     try {
-      const res = await fetch("/api/import/st-bulk/scan", {
+      const res = await api.raw("/import/st-bulk/scan", {
         method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-          ...getAdminSecretHeader(),
-        },
         body: JSON.stringify({ folderPath: folderPath.trim(), folderToken }),
       });
       const { data, raw } = await readJsonResponse<ScanResult>(res);
@@ -221,12 +217,8 @@ export function STBulkImportModal({ open, onClose }: Props) {
   const loadDirectory = useCallback(async (dirPath?: string) => {
     setBrowserLoading(true);
     try {
-      const res = await fetch("/api/import/list-directory", {
+      const res = await api.raw("/import/list-directory", {
         method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-          ...getAdminSecretHeader(),
-        },
         body: JSON.stringify({ path: dirPath || "" }),
       });
       const { data, raw } = await readJsonResponse<{
@@ -258,9 +250,8 @@ export function STBulkImportModal({ open, onClose }: Props) {
     setPicking(true);
     setError("");
     try {
-      const res = await fetch("/api/import/pick-folder", {
+      const res = await api.raw("/import/pick-folder", {
         method: "POST",
-        headers: getAdminSecretHeader(),
       });
       const { data, raw } = await readJsonResponse<{
         success: boolean;
@@ -307,12 +298,8 @@ export function STBulkImportModal({ open, onClose }: Props) {
     setError("");
 
     try {
-      const res = await fetch("/api/import/st-bulk/run", {
+      const res = await api.raw("/import/st-bulk/run", {
         method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-          ...getAdminSecretHeader(),
-        },
         body: JSON.stringify({
           folderPath: folderPath.trim(),
           folderToken,

--- a/packages/client/src/components/panels/SettingsPanel.tsx
+++ b/packages/client/src/components/panels/SettingsPanel.tsx
@@ -27,7 +27,6 @@ import {
   ADMIN_SECRET_STORAGE_KEY,
   ApiError,
   api,
-  getAdminSecretHeader,
   getPrivilegedActionErrorMessage,
 } from "../../lib/api-client";
 import { chatBackgroundUrlToMetadata } from "../../lib/backgrounds";
@@ -6773,9 +6772,8 @@ function AdvancedSettings() {
   const handleCreateBackup = async () => {
     setCreatingBackup(true);
     try {
-      const res = await fetch("/api/backup/download", {
+      const res = await api.raw("/backup/download", {
         method: "POST",
-        headers: getAdminSecretHeader(),
       });
       if (!res.ok) throw new Error(await readSettingsResponseError(res, "Backup failed"));
 

--- a/packages/client/src/hooks/use-knowledge-sources.ts
+++ b/packages/client/src/hooks/use-knowledge-sources.ts
@@ -31,15 +31,7 @@ export function useUploadKnowledgeSource() {
     mutationFn: async (file: File) => {
       const form = new FormData();
       form.append("file", file);
-      const res = await fetch("/api/knowledge-sources/upload", {
-        method: "POST",
-        body: form,
-      });
-      if (!res.ok) {
-        const err = await res.json().catch(() => ({ error: "Upload failed" }));
-        throw new Error(err.error || "Upload failed");
-      }
-      return res.json() as Promise<KnowledgeSource>;
+      return api.upload<KnowledgeSource>("/knowledge-sources/upload", form);
     },
     onSuccess: () => {
       qc.invalidateQueries({ queryKey: ksKeys.all });

--- a/packages/client/src/lib/api-client.ts
+++ b/packages/client/src/lib/api-client.ts
@@ -9,7 +9,7 @@ const BASE = "/api";
 const UNSAFE_METHODS = new Set(["POST", "PUT", "PATCH", "DELETE"]);
 export const ADMIN_SECRET_STORAGE_KEY = "marinara_admin_secret";
 
-export function getAdminSecretHeader(): Record<string, string> {
+function getAdminSecretHeader(): Record<string, string> {
   if (typeof window === "undefined") return {};
   const secret = window.localStorage.getItem(ADMIN_SECRET_STORAGE_KEY)?.trim();
   return secret ? { "X-Admin-Secret": secret } : {};
@@ -279,6 +279,7 @@ async function readDownloadFilename(res: Response, fallbackFilename: string) {
 }
 
 export const api = {
+  /** Return the raw response while still applying shared auth, CSRF, and cache policy. */
   raw: (path: string, init?: RequestInit) => apiFetch(path, init),
 
   get: <T>(path: string, init?: RequestInit) => request<T>(path, init),
@@ -319,11 +320,9 @@ export const api = {
 
   /** Download a POST endpoint as a file (useful for bulk exports). */
   downloadPost: async (path: string, body: unknown, fallbackFilename = "export.bin") => {
-    const res = await fetch(`${BASE}${path}`, {
+    const res = await apiFetch(path, {
       method: "POST",
-      headers: { ...getAdminSecretHeader(), [CSRF_HEADER]: CSRF_HEADER_VALUE, "Content-Type": "application/json" },
       body: JSON.stringify(body),
-      cache: "no-store",
     });
     showGenerationFallbackHeader(res);
     if (!res.ok) {
@@ -339,11 +338,9 @@ export const api = {
    * Stream an SSE endpoint. Returns an async iterable of parsed events.
    */
   stream: async function* (path: string, body?: unknown, signal?: AbortSignal): AsyncGenerator<string> {
-    const res = await fetch(`${BASE}${path}`, {
+    const res = await apiFetch(path, {
       method: "POST",
-      headers: { ...getAdminSecretHeader(), [CSRF_HEADER]: CSRF_HEADER_VALUE, "Content-Type": "application/json" },
       body: body !== undefined ? JSON.stringify(body) : undefined,
-      cache: "no-store",
       signal,
     });
     showGenerationFallbackHeader(res);
@@ -415,11 +412,9 @@ export const api = {
     body?: unknown,
     signal?: AbortSignal,
   ): AsyncGenerator<{ type: string; data: unknown } & Record<string, unknown>> {
-    const res = await fetch(`${BASE}${path}`, {
+    const res = await apiFetch(path, {
       method: "POST",
-      headers: { ...getAdminSecretHeader(), [CSRF_HEADER]: CSRF_HEADER_VALUE, "Content-Type": "application/json" },
       body: body !== undefined ? JSON.stringify(body) : undefined,
-      cache: "no-store",
       signal,
     });
     showGenerationFallbackHeader(res);
@@ -479,9 +474,8 @@ export const api = {
 
   /** Upload a file via multipart/form-data */
   upload: async <T>(path: string, formData: FormData): Promise<T> => {
-    const res = await fetch(`${BASE}${path}`, {
+    const res = await apiFetch(path, {
       method: "POST",
-      headers: { ...getAdminSecretHeader(), [CSRF_HEADER]: CSRF_HEADER_VALUE },
       body: formData,
     });
     showGenerationFallbackHeader(res);

--- a/packages/client/src/lib/api-client.ts
+++ b/packages/client/src/lib/api-client.ts
@@ -11,8 +11,12 @@ export const ADMIN_SECRET_STORAGE_KEY = "marinara_admin_secret";
 
 function getAdminSecretHeader(): Record<string, string> {
   if (typeof window === "undefined") return {};
-  const secret = window.localStorage.getItem(ADMIN_SECRET_STORAGE_KEY)?.trim();
-  return secret ? { "X-Admin-Secret": secret } : {};
+  try {
+    const secret = window.localStorage.getItem(ADMIN_SECRET_STORAGE_KEY)?.trim();
+    return secret ? { "X-Admin-Secret": secret } : {};
+  } catch {
+    return {};
+  }
 }
 
 export class ApiError extends Error {


### PR DESCRIPTION
## Linked issue

Follow-up to #3603.

## Why this change

- #3603 identified a wider inventory of direct internal `/api` fetches that bypass shared admin-secret, CSRF, cache, and error-handling policy. This applies the recommended incremental migration to the privileged and straightforward multipart paths reviewed here.

## What changed

- Route API-client POST downloads, SSE streams, and multipart uploads through the existing `apiFetch` transport boundary.
- Migrate SillyTavern bulk import and backup download raw-response calls to `api.raw` while preserving JSON, SSE, header, and binary response access.
- Migrate knowledge-source, standalone chat, and branch chat multipart imports to `api.upload`.
- Keep the global CSRF fetch shim as defense-in-depth and make the admin-header helper private now that no external callers remain.

## Validation

- [x] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [x] Ran the app, clicked through the changes manually
- [x] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [x] Read and followed `CONTRIBUTING.md`

### Manual verification notes

- `pnpm check` passed on the rebased commit, including project-context checks, workspace lint/type checks, and production builds.
- A disposable Chromium Playwright pass exercised the real browser API client with forced admin authentication: missing/correct secret behavior, bulk scan and SSE completion, accepted/rejected knowledge uploads, standalone and branch chat imports, and ZIP backup headers/signature all passed. The temporary test and isolated data were removed afterward.
- Actual UI controls, native save-dialog interaction, container builds, mobile, and theme-specific behavior were not manually verified.

## Docs and release impact

- [x] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Version/release files updated (only if this PR includes a version bump)

No documentation or release metadata changes are required for this internal transport refactor.

## UI evidence (if applicable)

Not applicable; there is no visual UI change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved chat and bulk chat imports with more consistent success and error handling.
  * Improved SillyTavern folder scanning, browsing, and bulk import requests.
  * Improved knowledge source upload reliability and error handling.
  * Improved backup downloads, including filename handling and download fallbacks.
* **Refactor**
  * Standardized several upload, download, and streaming operations for more consistent behavior across the app.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->