### PR TITLE
fix: batch same-connection agents reliably

### DIFF
--- a/packages/server/src/routes/generate/retry-agents-route.ts
+++ b/packages/server/src/routes/generate/retry-agents-route.ts
@@ -1188,6 +1188,7 @@ async function resolveRetryAgents(args: {
     return resolveStoredRetryConnection(null, fallbackConn);
   };
   const fallbackConnection = await resolveFallbackRetryConnection();
+  const retryAgentConnectionCache = new Map<string, RetryAgentConnectionResolution>();
   const resolvedAgents: ResolvedRetryAgent[] = [];
   const skippedLocalSidecarAgents: string[] = [];
   const defaultAgentConnectionAgents: string[] = [];
@@ -1219,9 +1220,13 @@ async function resolveRetryAgents(args: {
       return fallbackConnection;
     }
 
+    const cachedConnection = retryAgentConnectionCache.get(connectionId);
+    if (cachedConnection) return cachedConnection;
+
+    let resolution: RetryAgentConnectionResolution;
     if (isLocalSidecarConnectionId(connectionId) && localSidecarAvailableForTrackers) {
       const primaryProvider = getLocalSidecarProvider();
-      return {
+      resolution = {
         entry: {
           connectionId,
           provider: wrapRetryAgentProvider(primaryProvider, connectionId),
@@ -1234,14 +1239,15 @@ async function resolveRetryAgents(args: {
           cachingAtDepth: 5,
         },
       };
+    } else {
+      const agentConn = await conns.getWithKey(connectionId);
+      resolution = agentConn
+        ? resolveStoredRetryConnection(connectionId, agentConn)
+        : { entry: null, unavailableReason: "the configured connection was deleted" };
     }
 
-    const agentConn = await conns.getWithKey(connectionId);
-    if (!agentConn) {
-      return { entry: null, unavailableReason: "the configured connection was deleted" };
-    }
-
-    return resolveStoredRetryConnection(connectionId, agentConn);
+    retryAgentConnectionCache.set(connectionId, resolution);
+    return resolution;
   };
   const defaultAgentConnection = defaultAgentConn
     ? await resolveRetryAgentConnection(defaultAgentConn.id as string)

--- a/packages/server/src/services/agents/agent-executor.ts
+++ b/packages/server/src/services/agents/agent-executor.ts
@@ -1487,7 +1487,6 @@ function shouldRunAgentIndividually(config: Pick<AgentExecConfig, "type" | "sett
   // These agents either need compact prompts or carry large private extras that
   // must not be merged into unrelated batched agent requests.
   return (
-    config.type === "expression" ||
     config.type === "illustrator" ||
     config.type === "lorebook-keeper" ||
     resolveAgentResultType(config) === "text_rewrite" ||

--- a/packages/server/src/services/generation/agent-resolution.ts
+++ b/packages/server/src/services/generation/agent-resolution.ts
@@ -173,7 +173,7 @@ function resolveConnectionMaxOutputTokens(connection: { provider: string; model:
 
 async function resolveAgentConnectionProvider(args: {
   connections: ConnectionsStore;
-  agentProviderCache: Map<string, AgentProviderCacheEntry>;
+  agentProviderCache: Map<string | null, AgentProviderCacheEntry>;
   connectionId: string | null;
   fallbackProvider: BaseLLMProvider;
   fallbackModel: string;
@@ -188,6 +188,9 @@ async function resolveAgentConnectionProvider(args: {
   onFallback?: GenerationFallbackNotifier;
   resolveBaseUrl(connection: { baseUrl: string | null; provider: string }): string;
 }): Promise<AgentConnectionResolution> {
+  const cached = args.agentProviderCache.get(args.connectionId);
+  if (cached) return { entry: cached };
+
   if (!args.connectionId) {
     const provider = withConnectionFallbackProvider({
       primary: args.fallbackProvider,
@@ -197,22 +200,19 @@ async function resolveAgentConnectionProvider(args: {
       category: "agents",
       onFallback: args.onFallback,
     });
-    return {
-      entry: {
-        provider,
-        model: args.fallbackModel,
-        customParameters: args.fallbackCustomParameters,
-        maxOutputTokens: args.fallbackMaxOutputTokens,
-        maxParallelJobs: args.fallbackMaxParallelJobs,
-        enableCaching: args.fallbackEnableCaching,
-        anthropicExtendedCacheTtl: args.fallbackAnthropicExtendedCacheTtl,
-        cachingAtDepth: args.fallbackCachingAtDepth,
-      },
+    const resolved = {
+      provider,
+      model: args.fallbackModel,
+      customParameters: args.fallbackCustomParameters,
+      maxOutputTokens: args.fallbackMaxOutputTokens,
+      maxParallelJobs: args.fallbackMaxParallelJobs,
+      enableCaching: args.fallbackEnableCaching,
+      anthropicExtendedCacheTtl: args.fallbackAnthropicExtendedCacheTtl,
+      cachingAtDepth: args.fallbackCachingAtDepth,
     };
+    args.agentProviderCache.set(null, resolved);
+    return { entry: resolved };
   }
-
-  const cached = args.agentProviderCache.get(args.connectionId);
-  if (cached) return { entry: cached };
 
   const agentConn = await args.connections.getWithKey(args.connectionId);
   if (!agentConn) {
@@ -304,7 +304,7 @@ export async function resolveAgentPipelineAgents({
       !isRetiredBuiltInAgentId(agent.type as string),
   );
   const resolvedAgents: ResolvedAgent[] = [];
-  const agentProviderCache = new Map<string, AgentProviderCacheEntry>();
+  const agentProviderCache = new Map<string | null, AgentProviderCacheEntry>();
   const localSidecarAvailableForTrackers =
     sidecarModelService.getConfig().useForTrackers && sidecarModelService.getConfiguredModelRef() !== null;
 

--- a/packages/server/src/services/generation/agent-resolution.ts
+++ b/packages/server/src/services/generation/agent-resolution.ts
@@ -210,7 +210,7 @@ async function resolveAgentConnectionProvider(args: {
       anthropicExtendedCacheTtl: args.fallbackAnthropicExtendedCacheTtl,
       cachingAtDepth: args.fallbackCachingAtDepth,
     };
-    args.agentProviderCache.set(null, resolved);
+    args.agentProviderCache.set(args.connectionId, resolved);
     return { entry: resolved };
   }
 

--- a/scripts/regressions/open-issues.regression.ts
+++ b/scripts/regressions/open-issues.regression.ts
@@ -1048,6 +1048,13 @@ assert.match(
   /item\.negativePrompt !== undefined \|\| negativePrompt \? \{ negativePrompt \} : \{\}/,
 );
 assert.match(retryAgentsPromptReviewSource, /\[debug\/retry-agents\/illustrator\] final prompt/);
+assert.match(
+  retryAgentsPromptReviewSource,
+  /const retryAgentConnectionCache = new Map<string, RetryAgentConnectionResolution>\(\);/,
+  "retry agent resolution should reuse provider wrappers for the same stored connection",
+);
+assert.match(retryAgentsPromptReviewSource, /retryAgentConnectionCache\.get\(connectionId\)/);
+assert.match(retryAgentsPromptReviewSource, /retryAgentConnectionCache\.set\(connectionId, resolution\)/);
 
 const sharedGameSetupSource: GameSetupShareSource = {
   gameName: "Tower Run",

--- a/scripts/regressions/open-issues.regression.ts
+++ b/scripts/regressions/open-issues.regression.ts
@@ -1050,7 +1050,7 @@ assert.match(
 assert.match(retryAgentsPromptReviewSource, /\[debug\/retry-agents\/illustrator\] final prompt/);
 assert.match(
   retryAgentsPromptReviewSource,
-  /const retryAgentConnectionCache = new Map<string, RetryAgentConnectionResolution>\(\);/,
+  /const\s+retryAgentConnectionCache\s*=\s*new\s+Map<string,\s*RetryAgentConnectionResolution>\(\);/,
   "retry agent resolution should reuse provider wrappers for the same stored connection",
 );
 assert.match(retryAgentsPromptReviewSource, /retryAgentConnectionCache\.get\(connectionId\)/);

--- a/scripts/regressions/roleplay-streaming.regression.ts
+++ b/scripts/regressions/roleplay-streaming.regression.ts
@@ -23,6 +23,15 @@ import {
 import { useAgentStore } from "../../packages/client/src/stores/agent.store.js";
 import { advanceWeatherFrameClock } from "../../packages/client/src/lib/weather-frame-clock.js";
 import { trackerEditableText } from "../../packages/client/src/features/tracker-panel/lib/tracker-display.js";
+import { executeAgentBatch } from "../../packages/server/src/services/agents/agent-executor.js";
+import { resolveAgentPipelineAgents } from "../../packages/server/src/services/generation/agent-resolution.js";
+import {
+  BaseLLMProvider,
+  type ChatCompletionResult,
+  type ChatMessage,
+  type ChatOptions,
+} from "../../packages/server/src/services/llm/base-provider.js";
+import type { AgentCallDebugEvent, AgentContext } from "../../packages/shared/src/types/agent.js";
 
 assert.equal(
   trackerEditableText({ name: "HP", value: 75, max: 100, color: "#ef4444" }),
@@ -164,6 +173,120 @@ assert.equal(
   2,
   "rewrite editors should count as one call separate from the tracker call",
 );
+
+class CountingTrackerBatchProvider extends BaseLLMProvider {
+  calls = 0;
+
+  constructor() {
+    super("http://localhost", "");
+  }
+
+  async *chat(_messages: ChatMessage[], _options: ChatOptions): AsyncGenerator<string, void, unknown> {
+    return;
+  }
+
+  override async chatComplete(_messages: ChatMessage[], _options: ChatOptions): Promise<ChatCompletionResult> {
+    this.calls += 1;
+    return {
+      content: JSON.stringify({
+        expression: { expressions: [] },
+        "world-state": { date: "Unknown", time: "Night" },
+        background: { chosen: null, generate: null },
+      }),
+      toolCalls: [],
+      finishReason: "stop",
+      usage: { promptTokens: 100, completionTokens: 20, totalTokens: 120 },
+    };
+  }
+}
+
+const trackerBatchProvider = new CountingTrackerBatchProvider();
+const trackerBatchDebugEvents: AgentCallDebugEvent[] = [];
+const fallbackResolvedAgents = await resolveAgentPipelineAgents({
+  connections: {
+    getDefaultForAgents: async () => null,
+    getFallbackForAgents: async () => null,
+    getWithKey: async () => null,
+  } as unknown as Parameters<typeof resolveAgentPipelineAgents>[0]["connections"],
+  configuredAgents: [
+    { ...makeAgent("expression", "sprite_change"), connectionId: null },
+    { ...makeAgent("world-state", "game_state_update"), connectionId: null },
+    { ...makeAgent("background", "background_change"), connectionId: null },
+  ],
+  chatId: "tracker-batch-regression",
+  chatEnableAgents: true,
+  hasPerChatAgentList: false,
+  perChatAgentSet: new Set<string>(),
+  agentPromptTemplateSelections: {},
+  chatProvider: trackerBatchProvider,
+  chatConnectionId: "chat-connection",
+  chatModel: "agent-model",
+  chatCustomParameters: {},
+  chatMaxOutputTokens: null,
+  chatMaxParallelJobs: 1,
+  chatEnableCaching: false,
+  chatAnthropicExtendedCacheTtl: false,
+  chatCachingAtDepth: 5,
+  resolveBaseUrl: () => "",
+});
+
+assert.equal(fallbackResolvedAgents.resolvedAgents.length, 3);
+assert.ok(
+  fallbackResolvedAgents.resolvedAgents.every(
+    (agent) => agent.provider === fallbackResolvedAgents.resolvedAgents[0]!.provider,
+  ),
+  "ordinary generation should reuse one provider wrapper when agents share the chat fallback connection",
+);
+
+const trackerBatchResults = await executeAgentBatch(
+  [
+    makeAgent("expression", "sprite_change"),
+    makeAgent("world-state", "game_state_update"),
+    makeAgent("background", "background_change"),
+  ],
+  {
+    chatId: "tracker-batch-regression",
+    chatMode: "roleplay",
+    recentMessages: [],
+    mainResponse: "Night settles over the lake.",
+    gameState: null,
+    characters: [],
+    persona: null,
+    memory: {},
+    activatedLorebookEntries: null,
+    writableLorebookIds: null,
+    chatSummary: null,
+    streaming: false,
+    agentDebug: (event) => trackerBatchDebugEvents.push(event),
+  } satisfies AgentContext,
+  trackerBatchProvider,
+  "agent-model",
+);
+
+assert.equal(trackerBatchProvider.calls, 1, "compatible tracker agents should share one provider request");
+assert.equal(trackerBatchResults.length, 3);
+assert.ok(trackerBatchResults.every((result) => result.success));
+assert.deepEqual(
+  trackerBatchDebugEvents.map((event) => ({
+    stage: event.stage,
+    agentType: event.agentType,
+    batchedAgentTypes: event.batchedAgentTypes,
+  })),
+  [
+    {
+      stage: "request",
+      agentType: "__batch__",
+      batchedAgentTypes: ["expression", "world-state", "background"],
+    },
+    {
+      stage: "response",
+      agentType: "__batch__",
+      batchedAgentTypes: ["expression", "world-state", "background"],
+    },
+  ],
+  "tracker batch debug output should describe the real combined request",
+);
+
 const queuedEchoBatch = enqueueEchoChamberMessages(
   {
     messages: [{ characterName: "Watcher", reaction: "The old reaction.", timestamp: 1 }],


### PR DESCRIPTION
## Linked issue

Closes #3783

## Why this change

- Compatible agents could be split into separate paid-model requests even when they shared a connection and model. Retry resolution recreated provider wrappers per saved agent, ordinary generation did the same for direct chat-connection fallbacks, and Expression Engine was explicitly excluded from batching.

## What changed

- Reuse request-scoped provider resolutions for every saved retry agent sharing a connection, including default, explicit, and local-sidecar connections.
- Reuse the ordinary generation wrapper when multiple agents inherit the chat connection directly.
- Allow Expression Engine to participate in compatible agent batches.
- Add regression proof that Expression Engine, World State, and Background make one provider call with one `Agent Batch (3)` debug request/response pair.

## Validation

- [ ] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed `CONTRIBUTING.md`

### Manual verification notes

- `pnpm regression:roleplay` — passed. The controlled provider fixture asserts one provider call, three successful logical results, and one batch debug request/response pair.
- `pnpm regression:issues` — passed sequentially. Its expected simulated storage errors remain part of the passing fixtures.
- `pnpm check` — passed after the final implementation.
- No live paid-provider call was made; provider request-count behavior was verified with the deterministic regression fixture.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Version/release files updated (only if this PR includes a version bump)

No docs or release metadata changes are needed for this server-side orchestration fix.

## UI evidence (if applicable)

Not applicable; no UI files changed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reliability by reusing cached retry agent connection resolutions per connection ID.
  - Enhanced agent connection provider resolution by caching even fallback cases when no connection ID is present.
  - Broadened isolation rules so specialized and “JSON-only” music agents execute independently when needed.
  - Improved batching consistency for compatible tracker agents.

- **Tests**
  - Added regression coverage to verify retry-agent connection caching behavior.
  - Added regression coverage validating tracker-agent batching into a single combined provider request.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->