### PR TITLE
fix: honor connection max output tokens in Noodle

### DIFF
--- a/packages/server/src/routes/noodle.routes.ts
+++ b/packages/server/src/routes/noodle.routes.ts
@@ -62,7 +62,7 @@ import {
 } from "../services/prompt-overrides/index.js";
 import { parseGameJsonish } from "../services/game/jsonish.js";
 import { resolveIllustratorCharacterReferences } from "./generate/illustrator-references.js";
-import { resolveBaseUrl } from "./generate/generate-route-utils.js";
+import { parseStoredGenerationParameters, resolveBaseUrl } from "./generate/generate-route-utils.js";
 import { logger, logDebugOverride } from "../lib/logger.js";
 import { clampGenerationMaxOutputTokens } from "../services/generation/output-token-limits.js";
 import { resolveImageConnectionFallback } from "../services/generation/media-connection-fallback.js";
@@ -303,6 +303,12 @@ function profileSetupMaxTokens(characterCount: number) {
 
 function timelineRefreshMaxTokens(characterCount: number) {
   return 4096 + Math.max(0, characterCount) * 1024;
+}
+
+export function resolveNoodleMaxOutputTokens(defaultParameters: unknown, calculatedMaxTokens: number): number {
+  const connectionParameters = parseStoredGenerationParameters(defaultParameters);
+  if (connectionParameters?.enabledParameters?.maxTokens === false) return calculatedMaxTokens;
+  return connectionParameters?.maxTokens ?? calculatedMaxTokens;
 }
 
 function shuffle<T>(items: T[]): T[] {
@@ -1035,6 +1041,7 @@ async function generateMissingNoodleProfiles(input: {
     provider: string;
     model: string;
     maxTokensOverride?: number | null;
+    defaultParameters?: unknown;
   };
   debugMode: boolean;
 }) {
@@ -1099,7 +1106,7 @@ async function generateMissingNoodleProfiles(input: {
   const maxTokens = clampGenerationMaxOutputTokens({
     provider: input.connection.provider as APIProvider,
     model: input.connection.model,
-    maxTokens: profileSetupMaxTokens(targets.length),
+    maxTokens: resolveNoodleMaxOutputTokens(input.connection.defaultParameters, profileSetupMaxTokens(targets.length)),
     maxTokensOverride: input.connection.maxTokensOverride,
   });
   const result = await input.provider.chatComplete(messages, {
@@ -1956,8 +1963,9 @@ export async function noodleRoutes(app: FastifyInstance) {
       const timelineMaxTokens = clampGenerationMaxOutputTokens({
         provider: conn.provider as APIProvider,
         model: conn.model,
-        maxTokens: timelineRefreshMaxTokens(
-          selectedParticipants.filter((account) => account.kind === "character").length,
+        maxTokens: resolveNoodleMaxOutputTokens(
+          conn.defaultParameters,
+          timelineRefreshMaxTokens(selectedParticipants.filter((account) => account.kind === "character").length),
         ),
         maxTokensOverride: conn.maxTokensOverride,
       });

--- a/scripts/regressions/noodle-prompt.regression.ts
+++ b/scripts/regressions/noodle-prompt.regression.ts
@@ -46,7 +46,11 @@ import {
   NOODLE_IMAGE_POST,
   NOODLE_TIMELINE_BASE,
 } from "../../packages/server/src/services/prompt-overrides/registry/noodle.js";
-import { collectNoodlePriorityAccountIds } from "../../packages/server/src/routes/noodle.routes.js";
+import {
+  collectNoodlePriorityAccountIds,
+  resolveNoodleMaxOutputTokens,
+} from "../../packages/server/src/routes/noodle.routes.js";
+import { clampGenerationMaxOutputTokens } from "../../packages/server/src/services/generation/output-token-limits.js";
 import { NOODLE_TIMELINE_VOICE } from "../../packages/server/src/services/prompt-overrides/registry/noodle.js";
 
 const makeAccount = (id: string): NoodleAccount => ({
@@ -63,6 +67,22 @@ const makeAccount = (id: string): NoodleAccount => ({
   createdAt: "2026-07-10T10:00:00.000Z",
   updatedAt: "2026-07-10T10:00:00.000Z",
 });
+
+assert.equal(resolveNoodleMaxOutputTokens(null, 6144), 6144);
+assert.equal(
+  resolveNoodleMaxOutputTokens(JSON.stringify({ maxTokens: 16_000, enabledParameters: { maxTokens: true } }), 6144),
+  16_000,
+);
+assert.equal(resolveNoodleMaxOutputTokens({ maxTokens: 16_000, enabledParameters: { maxTokens: false } }, 6144), 6144);
+assert.equal(
+  clampGenerationMaxOutputTokens({
+    provider: "custom",
+    model: "kimi-k2.7",
+    maxTokens: resolveNoodleMaxOutputTokens({ maxTokens: 16_000 }, 6144),
+    maxTokensOverride: 8192,
+  }),
+  8192,
+);
 
 const participantSettings = {
   ...DEFAULT_NOODLE_SETTINGS,

--- a/scripts/regressions/noodle-prompt.regression.ts
+++ b/scripts/regressions/noodle-prompt.regression.ts
@@ -68,13 +68,13 @@ const makeAccount = (id: string): NoodleAccount => ({
   updatedAt: "2026-07-10T10:00:00.000Z",
 });
 
-assert.equal(resolveNoodleMaxOutputTokens(null, 6144), 6144);
-assert.equal(
+assert.strictEqual(resolveNoodleMaxOutputTokens(null, 6144), 6144);
+assert.strictEqual(
   resolveNoodleMaxOutputTokens(JSON.stringify({ maxTokens: 16_000, enabledParameters: { maxTokens: true } }), 6144),
   16_000,
 );
-assert.equal(resolveNoodleMaxOutputTokens({ maxTokens: 16_000, enabledParameters: { maxTokens: false } }, 6144), 6144);
-assert.equal(
+assert.strictEqual(resolveNoodleMaxOutputTokens({ maxTokens: 16_000, enabledParameters: { maxTokens: false } }, 6144), 6144);
+assert.strictEqual(
   clampGenerationMaxOutputTokens({
     provider: "custom",
     model: "kimi-k2.7",


### PR DESCRIPTION
## Linked issue

Closes #3764

## Why this change

- Noodle ignored the enabled Max Output Tokens value saved in a connection's Default Chat Parameters. It instead sent its internal character-count budget, causing models that need a larger output allowance to truncate or fail.

## What changed

- Resolve Noodle's profile-setup and timeline-refresh output budgets from the saved connection Max Output Tokens value when that parameter is enabled.
- Fall back to Noodle's existing character-count calculation when the value is absent or its send toggle is disabled.
- Preserve the existing model-known maximum and connection-level hard cap.
- Add regression coverage for enabled, disabled, absent, legacy, and capped values.

## Validation

- [ ] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed `CONTRIBUTING.md`

### Manual verification notes

- Automated: `pnpm regression:noodle` passed locally.
- Automated: `pnpm check` passed locally.
- Manually verify a Noodle refresh sends the enabled connection Max Output Tokens value for both missing-profile generation and timeline generation.
- Manually verify disabling Max Output Tokens restores Noodle's calculated character-count budget.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Version/release files updated (only if this PR includes a version bump)

## UI evidence (if applicable)

- Not applicable; no UI change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved generated profile and timeline responses by honoring configured output-token limits from connection defaults.
  * Added support for explicitly disabling maximum token settings and applying overrides.
  * Ensured resolved token limits are consistently clamped to safe values.
* **Tests**
  * Expanded regression coverage to validate defaulting, disabled behavior, override precedence, and clamping.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->