### PR TITLE
Rebrand: Marinara Engine → Guksu Motor (user-facing only)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
-# Contributing to Marinara Engine
+# Contributing to Guksu Motor
 
-This is the canonical contributor guide for Marinara Engine. Use it with `README.md` for the product overview, `CHANGELOG.md` for release notes, and `CLAUDE.md` only as a thin companion for maintainers using AI agent. All participants are expected to follow the [Code of Conduct](CODE_OF_CONDUCT.md).
+This is the canonical contributor guide for Guksu Motor. Use it with `README.md` for the product overview, `CHANGELOG.md` for release notes, and `CLAUDE.md` only as a thin companion for maintainers using AI agent. All participants are expected to follow the [Code of Conduct](CODE_OF_CONDUCT.md).
 
 ## Tech Stack
 
@@ -44,7 +44,7 @@ Copy `.env.example` to `.env` when you need to change ports, HTTPS settings, or 
 
 ## Branches
 
-Marinara Engine uses two long-lived branches:
+Guksu Motor uses two long-lived branches:
 
 | Branch    | Role                                                                                           |
 | --------- | ---------------------------------------------------------------------------------------------- |
@@ -70,13 +70,13 @@ Guidelines:
 
 Official downloadable agent and capability-package sources live in the separate [Pasta-Devs/Marinara-Agents](https://github.com/Pasta-Devs/Marinara-Agents) repository. Fixes to agents such as Illustrator, Music DJ, and Lorebook Keeper—including their definitions, default prompts, package-owned runtime code, metadata, artwork/assets, manifests, artifacts, and catalog validation—must use that repository's issues and target its `staging` branch.
 
-Marinara Engine owns the host integration: package loading, capability APIs and shared contracts, Engine UI/settings, storage, provider/model routing, orchestration, and compatibility handling. A fix can therefore mention or affect a downloadable agent while still belonging in Engine when it changes only how the host loads, configures, or executes the package. Determine the owning repository before opening an issue, branch, or PR, and split cross-repository changes when both package content and host integration need updates.
+Guksu Motor owns the host integration: package loading, capability APIs and shared contracts, Engine UI/settings, storage, provider/model routing, orchestration, and compatibility handling. A fix can therefore mention or affect a downloadable agent while still belonging in Engine when it changes only how the host loads, configures, or executes the package. Determine the owning repository before opening an issue, branch, or PR, and split cross-repository changes when both package content and host integration need updates.
 
 ## Prompt Leaf Content Is Verbatim (Decision + Threat Model)
 
 **Invariant:** what the model receives inside a prompt section equals what the user typed. Prompt *leaf* content — character card fields, persona, lorebook entries, memories, scene text, example dialogue — is passed to the model **verbatim**. Do not HTML-escape `<`, `>`, or `&` in this content. Users legitimately organize cards and lorebooks with angle-bracket / HTML-style tags (`<thinking>`, `<scenario>`, `<div>`), and those must reach the model as written.
 
-**Why this is safe.** Marinara is a local, single-user tool. The person who authors or imports a card is the same person any "injection" in that card would target — so the worst realistic outcome of an unescaped tag is the model role-playing something odd, which the user sees in their own chat and fixes by editing their own card. That is a rare, self-inflicted, self-correcting annoyance, not a security boundary. An LLM also does not parse the prompt as an XML document, so a stray `<` cannot "break out" of a section the way it would in a real parser — escaping it only corrupts text. Escaping traded that non-threat for a constant, real harm (mangled cards, broken roleplay HTML, wasted tokens).
+**Why this is safe.** Guksu is a local, single-user tool. The person who authors or imports a card is the same person any "injection" in that card would target — so the worst realistic outcome of an unescaped tag is the model role-playing something odd, which the user sees in their own chat and fixes by editing their own card. That is a rare, self-inflicted, self-correcting annoyance, not a security boundary. An LLM also does not parse the prompt as an XML document, so a stray `<` cannot "break out" of a section the way it would in a real parser — escaping it only corrupts text. Escaping traded that non-threat for a constant, real harm (mangled cards, broken roleplay HTML, wasted tokens).
 
 **Structure is separate from content.** The framework's own section wrappers (`<description>…</description>`, `<last_message>…`, etc.) are emitted by `wrapContent` *around* leaf content, from fixed section names. Verbatim content therefore cannot alter structural tags; it only changes what sits inside them.
 
@@ -172,7 +172,7 @@ All server-side logging goes through a shared [Pino](https://getpino.io/) logger
 
 ## AI Agent Workflow
 
-AI coding agents should use `.github/agents/chai-workflow.md` as an additive workflow overlay. It adapts the Chai Agent Workflow Pack for Marinara's branch, issue, PR, validation, and risky-work expectations.
+AI coding agents should use `.github/agents/chai-workflow.md` as an additive workflow overlay. It adapts the Chai Agent Workflow Pack for Guksu's branch, issue, PR, validation, and risky-work expectations.
 
 The overlay is not a substitute for this guide. When instructions conflict, follow this file, `AGENTS.md`, package-specific instructions, and maintainer requests first. The overlay is mainly a proof and coordination layer: reproduce before fixing when practical, verify the user-facing claim before saying done, keep PR/issue text exact, leave PR checkboxes unchecked for humans, and call out risky-work proof gaps honestly.
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # ──────────────────────────────────────────────
-# Marinara Engine — Multi-stage Docker Build
+# Guksu Motor — Multi-stage Docker Build
 # ──────────────────────────────────────────────
 
 # ── Stage 1: Build ──

--- a/Dockerfile.lite
+++ b/Dockerfile.lite
@@ -1,5 +1,5 @@
 # ──────────────────────────────────────────────
-# Marinara Engine — Wolfi Lite Docker Build
+# Guksu Motor — Wolfi Lite Docker Build
 # ──────────────────────────────────────────────
 # Three-stage build using Chainguard Wolfi images:
 #   1. Builder  — full dev toolchain, compiles TS and bundles client

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# 🍝 Marinara Engine
+# 🍜 Guksu Motor
 
 <h3 align="center"><b>Fun. Intuitive. Plug-And-Play.</b></h3>
 
@@ -15,7 +15,7 @@
 
 ## Table of Contents
 
-- [🍝 Marinara Engine](#-marinara-engine)
+- [🍜 Guksu Motor](#-guksu-motor)
   - [Table of Contents](#table-of-contents)
   - [Latest Release](#latest-release)
   - [Roadmap](#roadmap)
@@ -103,7 +103,7 @@
 
 Current stable release: **[v2.3.3](https://github.com/Pasta-Devs/Marinara-Engine/releases/tag/v2.3.3)**.
 
-See [CHANGELOG.md](CHANGELOG.md) for detailed release notes. Tagged releases use the `vX.Y.Z` format and are published on the [Releases](https://github.com/Pasta-Devs/Marinara-Engine/releases) page with a Windows installer, Android bootstrap APK, and named versioned source ZIP. Android APKs are Termux bootstrap + WebView shells: they can download Termux from F-Droid, launch Android's installer, start the Termux setup flow after required permission prompts, then open the local Marinara server on the same device.
+See [CHANGELOG.md](CHANGELOG.md) for detailed release notes. Tagged releases use the `vX.Y.Z` format and are published on the [Releases](https://github.com/Pasta-Devs/Marinara-Engine/releases) page with a Windows installer, Android bootstrap APK, and named versioned source ZIP. Android APKs are Termux bootstrap + WebView shells: they can download Termux from F-Droid, launch Android's installer, start the Termux setup flow after required permission prompts, then open the local Guksu server on the same device.
 
 ---
 
@@ -129,11 +129,11 @@ More detailed public [roadmap](https://github.com/orgs/Pasta-Devs/projects/1).
 | 🤖 Android Manual Termux | [Android (Termux) Installation Guide](docs/installation/android-termux.md) — manual fallback |
 | 📱 iOS / iPadOS          | [iOS / iPadOS PWA Guide](docs/installation/ios-pwa.md)                                       |
 
-> **Recommended Android path:** download the Android APK from the latest GitHub Release, open it, then tap **Install / Start Marinara**. The APK can download Termux from F-Droid, hand it to Android's installer, request Termux command permission, start the setup command, and open the local Marinara server when it is ready. If Android blocks that handoff, the APK copies a fresh-Termux setup command that can be pasted into Termux manually. Android still shows its required install/permission prompts.
+> **Recommended Android path:** download the Android APK from the latest GitHub Release, open it, then tap **Install / Start Guksu**. The APK can download Termux from F-Droid, hand it to Android's installer, request Termux command permission, start the setup command, and open the local Guksu server when it is ready. If Android blocks that handoff, the APK copies a fresh-Termux setup command that can be pasted into Termux manually. Android still shows its required install/permission prompts.
 
 Each guide covers installation, updating, and LAN access for that platform. See [Configuration Reference](docs/CONFIGURATION.md) for environment variables setup. Having trouble? See [FAQ](docs/FAQ.md) and [Troubleshooting](docs/TROUBLESHOOTING.md).
 
-Upgrading from an older release? See [Upgrading Marinara Engine](docs/UPGRADING.md) for the platform-by-platform upgrade path.
+Upgrading from an older release? See [Upgrading Guksu Motor](docs/UPGRADING.md) for the platform-by-platform upgrade path.
 
 Security defaults are intentionally local-first: loopback access works out of the box, ordinary LAN and public clients require Basic Auth unless you explicitly opt back in, and Tailscale (`100.64.0.0/10`) plus same-host Docker bridge/gateway traffic are trusted by default for easier private installs. Set `BYPASS_AUTH_TAILSCALE=false` or `BYPASS_AUTH_DOCKER=false` if you want those clients to authenticate too. `ALLOW_UNAUTHENTICATED_PRIVATE_NETWORK=true` restores unauthenticated access for other trusted private networks; public clients still require `ALLOW_UNAUTHENTICATED_REMOTE=true`. Powerful actions such as backups, bulk import, update apply, sidecar install/download/delete, haptics, and custom tool mutation also require `ADMIN_SECRET`; see [Access Control](docs/CONFIGURATION.md#access-control).
 
@@ -147,11 +147,11 @@ Three chat modes — **Conversation** (Discord-style DMs), **Roleplay** (immersi
 
 ### Visual & Immersive
 
-Character expression sprites with automatic emotion switching, custom scene backgrounds, dynamic weather overlays, gallery illustrations, short scene videos from generated illustrations, Game Mode storyboards with selectable keyframe and video prompt styles, two visual themes (Y2K Marinara and SillyTavern classic), and light/dark mode.
+Character expression sprites with automatic emotion switching, custom scene backgrounds, dynamic weather overlays, gallery illustrations, short scene videos from generated illustrations, Game Mode storyboards with selectable keyframe and video prompt styles, two visual themes (Y2K Guksu and SillyTavern classic), and light/dark mode.
 
 ### AI Agent System
 
-An optional one-click catalog of 29 first-party agents and feature packages. Fresh installs stay lightweight with no bundled agents. Open **Agents → Download Agents** to install only what you want or uninstall packages you no longer need. Installed official packages automatically update to the newest compatible catalog version when the Marinara server starts, while remaining available at their current version when the server is offline. Existing installations retain their agents during Engine upgrades. Package sources, artifacts, and the complete catalog are published in [Pasta-Devs/Marinara-Agents](https://github.com/Pasta-Devs/Marinara-Agents). You can also create or import custom agents.
+An optional one-click catalog of 29 first-party agents and feature packages. Fresh installs stay lightweight with no bundled agents. Open **Agents → Download Agents** to install only what you want or uninstall packages you no longer need. Installed official packages automatically update to the newest compatible catalog version when the Guksu server starts, while remaining available at their current version when the server is offline. Existing installations retain their agents during Engine upgrades. Package sources, artifacts, and the complete catalog are published in [Pasta-Devs/Marinara-Agents](https://github.com/Pasta-Devs/Marinara-Agents). You can also create or import custom agents.
 
 - **Writer Agents:** Prose Guardian, Continuity Checker, Narrative Director, Knowledge Retrieval, Knowledge Router, and Card Evolution Auditor.
 - **Tracker Agents:** World State, Expression Engine, Quest Tracker, Background, Character Tracker, Persona Stats, Custom Tracker, and Hierarchical Maps.
@@ -228,7 +228,7 @@ The full guide library is browsable inside the app: open **Documentation** from 
 
 <p align="left">
   <a href="https://github.com/Pasta-Devs/Marinara-Engine/graphs/contributors">
-    <img src="https://contrib.rocks/image?repo=Pasta-Devs/Marinara-Engine" alt="Marinara Engine contributors" />
+    <img src="https://contrib.rocks/image?repo=Pasta-Devs/Marinara-Engine" alt="Guksu Motor contributors" />
   </a>
 </p>
 

--- a/android/README.md
+++ b/android/README.md
@@ -1,23 +1,23 @@
-# Marinara Engine - Android APK
+# Guksu Motor - Android APK
 
-The Android app is a Termux bootstrap + WebView shell for Marinara Engine. It is not a native Android server build, but it can help launch the Termux setup flow and then opens the local Marinara server in a fullscreen WebView.
+The Android app is a Termux bootstrap + WebView shell for Guksu Motor. It is not a native Android server build, but it can help launch the Termux setup flow and then opens the local Guksu server in a fullscreen WebView.
 
 > **Android permission reality:** Android does not allow an ordinary APK to silently install another app or run commands inside Termux without user approval. First launch may still ask the user to install Termux, grant **Run commands in Termux environment** permission, and enable Termux external commands.
 
 ## How It Works
 
-- If Marinara Engine is already running in Termux, the APK opens `http://127.0.0.1:<PORT>` inside a fullscreen WebView. The default build-time port is `7860`.
-- If the server is not running, the APK shows bootstrap actions: **Install / Start Marinara**, **Get Termux manually**, and **Retry connection**.
-- **Install / Start Marinara** downloads the current suggested Termux APK from F-Droid when Termux is missing, hands it to Android's package installer, then continues setup after the user approves the install.
-- After Termux is installed, **Install / Start Marinara** uses Termux's `RUN_COMMAND` integration to run the Marinara Termux installer command. This requires the Android **Run commands in Termux environment** permission to be granted to Marinara Engine, and `allow-external-apps=true` to be enabled in Termux.
+- If Guksu Motor is already running in Termux, the APK opens `http://127.0.0.1:<PORT>` inside a fullscreen WebView. The default build-time port is `7860`.
+- If the server is not running, the APK shows bootstrap actions: **Install / Start Guksu**, **Get Termux manually**, and **Retry connection**.
+- **Install / Start Guksu** downloads the current suggested Termux APK from F-Droid when Termux is missing, hands it to Android's package installer, then continues setup after the user approves the install.
+- After Termux is installed, **Install / Start Guksu** uses Termux's `RUN_COMMAND` integration to run the Guksu Termux installer command. This requires the Android **Run commands in Termux environment** permission to be granted to Guksu Motor, and `allow-external-apps=true` to be enabled in Termux.
 - If Termux blocks external commands, the APK copies the required `allow-external-apps` command to the clipboard and opens Termux so the user can paste it once.
 - The server, launcher updates, and `AUTO_OPEN_BROWSER` behavior are still owned by the Termux launcher, not by this APK.
 - Release and versioning policy follows the main repo docs in [../CONTRIBUTING.md](../CONTRIBUTING.md): root `package.json` is canonical, Android `versionName` should match the app version, and `versionCode` must increase for every shipped APK.
 - If you build the APK with a non-default port, Termux must use the same `PORT` value in `.env`.
 
-**Fast path:** install the APK, open it, tap **Install / Start Marinara**, approve Android/Termux prompts, wait for the Termux launcher to finish, then return to the Marinara Engine app.
+**Fast path:** install the APK, open it, tap **Install / Start Guksu**, approve Android/Termux prompts, wait for the Termux launcher to finish, then return to the Guksu Motor app.
 
-**Manual fallback:** install Termux from F-Droid, paste the fresh-Termux command below so it creates/updates the Marinara folder, then open the Marinara Engine Android app.
+**Manual fallback:** install Termux from F-Droid, paste the fresh-Termux command below so it creates/updates the Guksu folder, then open the Guksu Motor Android app.
 
 ## Features
 
@@ -89,13 +89,13 @@ cd android
 ### Bootstrap Path
 
 1. Install the APK from the GitHub Release.
-2. Open **Marinara Engine**.
-3. If the server is not running, tap **Install / Start Marinara**.
-4. If Termux is missing, approve Android's install prompts so Marinara can install the F-Droid Termux APK.
+2. Open **Guksu Motor**.
+3. If the server is not running, tap **Install / Start Guksu**.
+4. If Termux is missing, approve Android's install prompts so Guksu can install the F-Droid Termux APK.
 5. If Android asks for **Run commands in Termux environment**, grant it.
-6. If Termux blocks external commands, paste the copied `allow-external-apps` command in Termux once, then tap **Install / Start Marinara** again.
-7. Wait for Termux to finish installing dependencies, building Marinara Engine, and starting the local server.
-8. Return to **Marinara Engine**. The WebView shell connects automatically once the server is ready.
+6. If Termux blocks external commands, paste the copied `allow-external-apps` command in Termux once, then tap **Install / Start Guksu** again.
+7. Wait for Termux to finish installing dependencies, building Guksu Motor, and starting the local server.
+8. Return to **Guksu Motor**. The WebView shell connects automatically once the server is ready.
 
 ### Manual Path
 
@@ -105,7 +105,7 @@ On a fresh Termux install, paste this command first:
 pkg update -y && pkg install -y git nodejs-lts && ([ -d "$HOME/Marinara-Engine/.git" ] || git clone https://github.com/Pasta-Devs/Marinara-Engine.git "$HOME/Marinara-Engine") && cd "$HOME/Marinara-Engine" && chmod +x start-termux.sh && ./start-termux.sh
 ```
 
-After Marinara has been installed once, start it again in Termux:
+After Guksu has been installed once, start it again in Termux:
 
 ```bash
 cd "$HOME/Marinara-Engine"
@@ -115,14 +115,14 @@ cd "$HOME/Marinara-Engine"
 To skip the update check and start the already-installed local copy, run `./start-termux.sh --skip-update`.
 To skip automatic Engine updates on every launch, add `AUTO_UPDATE_ENABLED=false` to the project `.env`; manual update controls remain available.
 
-Then open the **Marinara Engine** app from your home screen. The app shows "Connecting..." until the local server is ready, then loads automatically.
+Then open the **Guksu Motor** app from your home screen. The app shows "Connecting..." until the local server is ready, then loads automatically.
 
-Because the APK points at `http://127.0.0.1:<PORT>`, it only works while the Marinara Engine server is running on the same Android device and using the same port value.
+Because the APK points at `http://127.0.0.1:<PORT>`, it only works while the Guksu Motor server is running on the same Android device and using the same port value.
 
-On Android 13 and newer, enabling **Mobile app** under **Background Notifications** opens Android's notification permission prompt. Browser notifications remain a separate setting. Notifications conceal reply content and ask the user to open Marinara to read the message.
+On Android 13 and newer, enabling **Mobile app** under **Background Notifications** opens Android's notification permission prompt. Browser notifications remain a separate setting. Notifications conceal reply content and ask the user to open Guksu to read the message.
 
 ## Pre-built APKs
 
 When maintainers attach them to a tagged release, pre-built APKs are available on the main [Releases](https://github.com/Pasta-Devs/Marinara-Engine/releases) page.
 
-Release APKs include the bootstrap controls above. They still rely on Termux for the local Linux/Node runtime, and Android still requires the user-visible permission handoff before the APK can ask Termux to install or start Marinara Engine.
+Release APKs include the bootstrap controls above. They still rely on Termux for the local Linux/Node runtime, and Android still requires the user-visible permission handoff before the APK can ask Termux to install or start Guksu Motor.

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name">Marinara Engine</string>
+    <string name="app_name">Guksu Motor</string>
 </resources>

--- a/custom_components/marinara_engine/button.py
+++ b/custom_components/marinara_engine/button.py
@@ -38,14 +38,14 @@ class MarinaraAbortButton(CoordinatorEntity[MarinaraCoordinator], ButtonEntity):
         super().__init__(coordinator)
         self._entry = entry
         self._attr_unique_id = f"{entry.entry_id}_abort_generation"
-        self._attr_name = "Marinara Abort Generation"
+        self._attr_name = "Guksu Abort Generation"
 
     @property
     def device_info(self) -> dict:
         return {
             "identifiers": {(DOMAIN, self._entry.entry_id)},
-            "name": "Marinara Engine",
-            "manufacturer": "Marinara Engine",
+            "name": "Guksu Motor",
+            "manufacturer": "Guksu Motor",
             "model": "Local AI Engine",
         }
 
@@ -66,14 +66,14 @@ class MarinaraSyncToolsButton(CoordinatorEntity[MarinaraCoordinator], ButtonEnti
         super().__init__(coordinator)
         self._entry = entry
         self._attr_unique_id = f"{entry.entry_id}_sync_tools"
-        self._attr_name = "Marinara Sync HA Tools"
+        self._attr_name = "Guksu Sync HA Tools"
 
     @property
     def device_info(self) -> dict:
         return {
             "identifiers": {(DOMAIN, self._entry.entry_id)},
-            "name": "Marinara Engine",
-            "manufacturer": "Marinara Engine",
+            "name": "Guksu Motor",
+            "manufacturer": "Guksu Motor",
             "model": "Local AI Engine",
         }
 

--- a/custom_components/marinara_engine/config_flow.py
+++ b/custom_components/marinara_engine/config_flow.py
@@ -102,7 +102,7 @@ class MarinaraConfigFlow(ConfigFlow, domain=DOMAIN):
                 self._abort_if_unique_id_configured()
 
                 return self.async_create_entry(
-                    title=f"Marinara Engine ({host}:{port})",
+                    title=f"Guksu Motor ({host}:{port})",
                     data={
                         CONF_HOST: host,
                         CONF_PORT: port,

--- a/custom_components/marinara_engine/manifest.json
+++ b/custom_components/marinara_engine/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "marinara_engine",
-  "name": "Marinara Engine",
+  "name": "Guksu Motor",
   "version": "1.0.0",
   "config_flow": true,
   "documentation": "https://github.com/Pasta-Devs/Marinara-Engine/blob/main/docs/integrations/home-assistant.md",

--- a/custom_components/marinara_engine/select.py
+++ b/custom_components/marinara_engine/select.py
@@ -30,14 +30,14 @@ class MarinaraActiveChatSelect(CoordinatorEntity[MarinaraCoordinator], SelectEnt
         super().__init__(coordinator)
         self._entry = entry
         self._attr_unique_id = f"{entry.entry_id}_active_chat"
-        self._attr_name = "Marinara Active Chat"
+        self._attr_name = "Guksu Active Chat"
 
     @property
     def device_info(self) -> dict:
         return {
             "identifiers": {(DOMAIN, self._entry.entry_id)},
-            "name": "Marinara Engine",
-            "manufacturer": "Marinara Engine",
+            "name": "Guksu Motor",
+            "manufacturer": "Guksu Motor",
             "model": "Local AI Engine",
         }
 

--- a/custom_components/marinara_engine/sensor.py
+++ b/custom_components/marinara_engine/sensor.py
@@ -35,8 +35,8 @@ class _MarinaraEntity(CoordinatorEntity[MarinaraCoordinator]):
     def device_info(self) -> dict:
         return {
             "identifiers": {(DOMAIN, self._entry.entry_id)},
-            "name": "Marinara Engine",
-            "manufacturer": "Marinara Engine",
+            "name": "Guksu Motor",
+            "manufacturer": "Guksu Motor",
             "model": "Local AI Engine",
             "configuration_url": self.coordinator.base_url,
         }
@@ -52,7 +52,7 @@ class MarinaraChatCountSensor(_MarinaraEntity, SensorEntity):
     def __init__(self, coordinator: MarinaraCoordinator, entry: ConfigEntry) -> None:
         super().__init__(coordinator, entry)
         self._attr_unique_id = f"{entry.entry_id}_chat_count"
-        self._attr_name = "Marinara Chat Count"
+        self._attr_name = "Guksu Chat Count"
 
     @property
     def native_value(self) -> int:
@@ -78,7 +78,7 @@ class MarinaraActiveAgentCountSensor(_MarinaraEntity, SensorEntity):
     def __init__(self, coordinator: MarinaraCoordinator, entry: ConfigEntry) -> None:
         super().__init__(coordinator, entry)
         self._attr_unique_id = f"{entry.entry_id}_active_agent_count"
-        self._attr_name = "Marinara Active Agent Count"
+        self._attr_name = "Guksu Active Agent Count"
 
     @property
     def native_value(self) -> int:

--- a/custom_components/marinara_engine/strings.json
+++ b/custom_components/marinara_engine/strings.json
@@ -2,8 +2,8 @@
   "config": {
     "step": {
       "user": {
-        "title": "Connect to Marinara Engine",
-        "description": "Enter the host and port where Marinara Engine is running (default: localhost:7860).",
+        "title": "Connect to Guksu Motor",
+        "description": "Enter the host and port where Guksu Motor is running (default: localhost:7860).",
         "data": {
           "host": "Host",
           "port": "Port"
@@ -11,24 +11,24 @@
       }
     },
     "error": {
-      "cannot_connect": "Cannot connect to Marinara Engine. Check the host, port, and that the server is running.",
+      "cannot_connect": "Cannot connect to Guksu Motor. Check the host, port, and that the server is running.",
       "unknown": "An unexpected error occurred."
     },
     "abort": {
-      "already_configured": "Marinara Engine at this address is already configured."
+      "already_configured": "Guksu Motor at this address is already configured."
     }
   },
   "options": {
     "step": {
       "init": {
-        "title": "Marinara Engine Options",
-        "description": "Choose the primary chat and which tool categories Marinara is allowed to use.",
+        "title": "Guksu Motor Options",
+        "description": "Choose the primary chat and which tool categories Guksu is allowed to use.",
         "data": {
           "primary_chat_id": "Primary Chat",
           "enabled_categories": "Exposed Tool Categories"
         },
         "data_description": {
-          "enabled_categories": "Only the selected categories will be synced as tools into Marinara Engine. Changes take effect after pressing the Sync HA Tools button or restarting Home Assistant."
+          "enabled_categories": "Only the selected categories will be synced as tools into Guksu Motor. Changes take effect after pressing the Sync HA Tools button or restarting Home Assistant."
         }
       }
     }

--- a/custom_components/marinara_engine/switch.py
+++ b/custom_components/marinara_engine/switch.py
@@ -40,14 +40,14 @@ class MarinaraAgentSwitch(CoordinatorEntity[MarinaraCoordinator], SwitchEntity):
         self._entry = entry
         self._agent_id: str = agent["id"]
         self._attr_unique_id = f"{entry.entry_id}_agent_{agent['id']}"
-        self._attr_name = f"Marinara Agent: {agent.get('name', agent['id'])}"
+        self._attr_name = f"Guksu Agent: {agent.get('name', agent['id'])}"
 
     @property
     def device_info(self) -> dict:
         return {
             "identifiers": {(DOMAIN, self._entry.entry_id)},
-            "name": "Marinara Engine",
-            "manufacturer": "Marinara Engine",
+            "name": "Guksu Motor",
+            "manufacturer": "Guksu Motor",
             "model": "Local AI Engine",
         }
 

--- a/custom_components/marinara_engine/translations/en.json
+++ b/custom_components/marinara_engine/translations/en.json
@@ -2,8 +2,8 @@
   "config": {
     "step": {
       "user": {
-        "title": "Connect to Marinara Engine",
-        "description": "Enter the host and port where Marinara Engine is running (default: localhost:7860).",
+        "title": "Connect to Guksu Motor",
+        "description": "Enter the host and port where Guksu Motor is running (default: localhost:7860).",
         "data": {
           "host": "Host",
           "port": "Port"
@@ -11,24 +11,24 @@
       }
     },
     "error": {
-      "cannot_connect": "Cannot connect to Marinara Engine. Verify the host and port and that the server is running.",
+      "cannot_connect": "Cannot connect to Guksu Motor. Verify the host and port and that the server is running.",
       "unknown": "An unexpected error occurred."
     },
     "abort": {
-      "already_configured": "Marinara Engine at this address is already configured."
+      "already_configured": "Guksu Motor at this address is already configured."
     }
   },
   "options": {
     "step": {
       "init": {
-        "title": "Marinara Engine Options",
-        "description": "Choose the primary chat and which tool categories Marinara is allowed to use.",
+        "title": "Guksu Motor Options",
+        "description": "Choose the primary chat and which tool categories Guksu is allowed to use.",
         "data": {
           "primary_chat_id": "Primary Chat",
           "enabled_categories": "Exposed Tool Categories"
         },
         "data_description": {
-          "enabled_categories": "Only the selected categories will be synced as tools into Marinara Engine. Changes take effect after pressing the Sync HA Tools button or restarting Home Assistant."
+          "enabled_categories": "Only the selected categories will be synced as tools into Guksu Motor. Changes take effect after pressing the Sync HA Tools button or restarting Home Assistant."
         }
       }
     }

--- a/custom_components/marinara_engine/webhook.py
+++ b/custom_components/marinara_engine/webhook.py
@@ -34,7 +34,7 @@ def async_register_webhook(hass: HomeAssistant, webhook_id: str) -> None:
     async_register(
         hass,
         DOMAIN,
-        "Marinara Engine",
+        "Guksu Motor",
         webhook_id,
         _handle_webhook,
         allowed_methods=["POST"],

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,5 @@
 # ──────────────────────────────────────────────
-# Marinara Engine — Docker Compose
+# Guksu Motor — Docker Compose
 # ──────────────────────────────────────────────
 services:
   marinara:

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -1,10 +1,10 @@
 # Server Configuration Reference
 
-This guide explains how to change server-level settings for Marinara Engine using environment variables. An environment variable is a setting you write in a plain text file that the server reads. Most users never need this page. The full variable list is near the bottom.
+This guide explains how to change server-level settings for Guksu Motor using environment variables. An environment variable is a setting you write in a plain text file that the server reads. Most users never need this page. The full variable list is near the bottom.
 
-## When would you configure Marinara?
+## When would you configure Guksu?
 
-Marinara Engine works out of the box with no configuration. You only need this page for a small number of tasks. Most of them involve running the server for more than one device.
+Guksu Motor works out of the box with no configuration. You only need this page for a small number of tasks. Most of them involve running the server for more than one device.
 
 You might edit configuration when you want to:
 
@@ -17,12 +17,12 @@ You might edit configuration when you want to:
 
 Almost everything else, like your AI provider keys, characters, and chat options, is set inside the app, not here. To add an AI provider, see [Connecting to an AI Provider](connections/connecting-to-a-provider.md).
 
-Optional first-party agents are also managed inside the app. Open **Agents → Download Agents** to install or uninstall them. Marinara automatically selects the [Pasta-Devs/Marinara-Agents](https://github.com/Pasta-Devs/Marinara-Agents) catalog lane matching its Engine major version.
+Optional first-party agents are also managed inside the app. Open **Agents → Download Agents** to install or uninstall them. Guksu automatically selects the [Pasta-Devs/Marinara-Agents](https://github.com/Pasta-Devs/Marinara-Agents) catalog lane matching its Engine major version.
 
 Package lifecycle and storage:
 
 - **Updates:** On every server startup, already-installed official packages automatically upgrade to the newest compatible version before their runtimes activate and self-check. A fresh install remains empty until you choose packages.
-- **Platforms:** The same behavior applies to desktop, Docker, and Termux-hosted Android installations. iOS and other browser clients use the packages installed on their Marinara host server.
+- **Platforms:** The same behavior applies to desktop, Docker, and Termux-hosted Android installations. iOS and other browser clients use the packages installed on their Guksu host server.
 - **Persistence:** Packages live under `DATA_DIR/capability-packages`. Docker volumes, custom data directories, backups, and normal upgrades preserve them.
 - **Offline resilience:** Existing packages continue working at their installed version when outbound GitHub HTTPS is unavailable or an update fails verification.
 
@@ -30,7 +30,7 @@ Package lifecycle and storage:
 
 Configuration lives in a file named `.env`. This is a plain text file with one setting per line, in the form `KEY=value`. Lines that start with `#` are comments and the server ignores them.
 
-Marinara creates an empty `.env` for you the first time it starts, so you do not have to make one by hand.
+Guksu creates an empty `.env` for you the first time it starts, so you do not have to make one by hand.
 
 - On normal installs, the `.env` file sits in the project root folder.
 - On official Docker or Podman images, it sits at `/app/data/.env`, inside the same storage volume as your data.
@@ -49,7 +49,7 @@ The server reads `.env` by itself, no matter how you start it. This includes run
 
 ## Restart or hot reload
 
-Marinara watches the `.env` file while it runs. When you save a change, most settings take effect within about 2 seconds, with no restart. The server writes a log line starting with `[env-watcher]` each time it applies a change.
+Guksu watches the `.env` file while it runs. When you save a change, most settings take effect within about 2 seconds, with no restart. The server writes a log line starting with `[env-watcher]` each time it applies a change.
 
 A small group of low-level settings are locked in when the server starts. Changing them needs a full restart. These settings are:
 
@@ -83,7 +83,7 @@ The main access-control settings are:
 | --- | --- | --- |
 | `BASIC_AUTH_USER` | empty | Username for a password prompt. Set with `BASIC_AUTH_PASS` to require a login. |
 | `BASIC_AUTH_PASS` | empty | Password for the login prompt. Leave either field empty to turn login off. |
-| `BASIC_AUTH_REALM` | `Marinara Engine` | Text shown in the browser's password box. |
+| `BASIC_AUTH_REALM` | `Guksu Motor` | Text shown in the browser's password box. |
 | `IP_ALLOWLIST` | empty | Comma-separated IPs or CIDR ranges that are always allowed. Loopback is always allowed. |
 | `IP_ALLOWLIST_ENABLED` | `true` | Set to `false` to keep the list but pause enforcement. |
 | `ALLOW_UNAUTHENTICATED_PRIVATE_NETWORK` | `false` | Restores passwordless access from private networks when no login is set. |
@@ -96,7 +96,7 @@ The main access-control settings are:
 | `SSL_KEY` | empty | Path to the TLS private key file. |
 | `CSRF_TRUSTED_ORIGINS` | empty | Extra browser origins allowed to save changes. Use for a public domain or an unusual port. |
 
-Basic Auth is short for HTTP Basic Authentication, a simple username and password prompt. Its credentials are only encoded, not encrypted, so always pair it with HTTPS when your server faces the public internet. HTTPS is the secure, encrypted version of HTTP. To turn it on directly, set both `SSL_CERT` and `SSL_KEY`, or put a reverse proxy in front of Marinara.
+Basic Auth is short for HTTP Basic Authentication, a simple username and password prompt. Its credentials are only encoded, not encrypted, so always pair it with HTTPS when your server faces the public internet. HTTPS is the secure, encrypted version of HTTP. To turn it on directly, set both `SSL_CERT` and `SSL_KEY`, or put a reverse proxy in front of Guksu.
 
 To let other devices reach the server at all, the server must bind to a reachable interface. Set `HOST=0.0.0.0`. The shell launchers do this for you, but `pnpm start` binds to loopback only.
 
@@ -110,7 +110,7 @@ Storage settings control where your local data lives. Your data includes chats, 
 | `FILE_STORAGE_DIR` | the `storage` folder inside `DATA_DIR` | Overrides the file-storage folder. |
 | `ENCRYPTION_KEY` | empty | Key used to encrypt saved API keys. Generate one with the command below. |
 
-Marinara keeps your data as plain JSON files. This makes backups easy to copy and inspect.
+Guksu keeps your data as plain JSON files. This makes backups easy to copy and inspect.
 
 To generate an encryption key, run this command and paste the result into `ENCRYPTION_KEY`:
 
@@ -231,7 +231,7 @@ This section lists the remaining settings, grouped by purpose. The tables above 
 
 `AUTO_CREATE_DEFAULT_CONNECTION` is kept only for older installs. New builds no longer ship a bundled starter connection, so leaving it on does nothing. To start chatting, add a connection under [Connecting to an AI Provider](connections/connecting-to-a-provider.md).
 
-Conversation schedule controls default to the timezone reported by the browser or app device. **Schedule timezone** can be changed during Conversation setup, in Conversation Chat Settings, or in the character schedule editor. The selected IANA timezone is one global preference shared by every Conversation chat and synced to other Marinara clients connected to the same server.
+Conversation schedule controls default to the timezone reported by the browser or app device. **Schedule timezone** can be changed during Conversation setup, in Conversation Chat Settings, or in the character schedule editor. The selected IANA timezone is one global preference shared by every Conversation chat and synced to other Guksu clients connected to the same server.
 
 ### Media and sprite tools
 
@@ -279,4 +279,4 @@ For a Giphy key, note that GIF search stays unavailable until you set `GIPHY_API
 - [Where Your Data Is Stored](data/where-data-is-stored.md)
 - [Connecting to an AI Provider](connections/connecting-to-a-provider.md)
 - [Scene Video](media/scene-video.md)
-- [Troubleshooting Marinara Engine](TROUBLESHOOTING.md)
+- [Troubleshooting Guksu Motor](TROUBLESHOOTING.md)

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -1,16 +1,16 @@
 # Frequently Asked Questions
 
-This guide answers the questions people ask most about Marinara Engine. Answers are grouped by topic. Each one links to a full guide when you want more detail.
+This guide answers the questions people ask most about Guksu Motor. Answers are grouped by topic. Each one links to a full guide when you want more detail.
 
-## How do I access Marinara Engine from my phone or another device?
+## How do I access Guksu Motor from my phone or another device?
 
-Marinara Engine runs as a local server on one computer. You open it in a web browser. This answer covers access from phone, tablet, or another computer on the same network.
+Guksu Motor runs as a local server on one computer. You open it in a web browser. This answer covers access from phone, tablet, or another computer on the same network.
 
 The start scripts (`start.sh`, `start.bat`, and `start-termux.sh`) already bind the server to all network interfaces (`0.0.0.0`). Other devices can reach the server over the network, but access control blocks them by default. Until you set up access on the host computer, a remote device only sees an **Access blocked** page with setup instructions.
 
 Follow these steps:
 
-1. Keep Marinara running on the host computer.
+1. Keep Guksu running on the host computer.
 2. On the host computer, set up access control: Basic Auth (a username and password) or an IP allowlist (a list of trusted device addresses). [Remote Access](REMOTE_ACCESS.md) walks through each option, including a bypass for fully trusted private networks.
 3. Find the host computer's local IP address. On Windows, run this command and read the **IPv4 Address**:
 
@@ -36,17 +36,17 @@ Replace `192.168.1.42` with your own host IP address.
 
 On the same computer (`127.0.0.1`), you never need a password. Other devices are blocked until you set up access control (Basic Auth or an IP allowlist). Each option is explained in [Remote Access](REMOTE_ACCESS.md).
 
-If the two devices are not on the same network, a tool like Tailscale can help. Tailscale gives each device a stable private address. You can then connect from anywhere without exposing Marinara to the public internet. If you cannot connect, see [Troubleshooting](TROUBLESHOOTING.md).
+If the two devices are not on the same network, a tool like Tailscale can help. Tailscale gives each device a stable private address. You can then connect from anywhere without exposing Guksu to the public internet. If you cannot connect, see [Troubleshooting](TROUBLESHOOTING.md).
 
-## Is there a mobile app for Marinara?
+## Is there a mobile app for Guksu?
 
 There is no separate native mobile app. On a phone or tablet, you use the same web app in a browser. Most mobile browsers offer an **Add to Home Screen** or **Install App** option that makes it feel like a real app, with no browser bar. This is called a PWA (Progressive Web App, a website you can install like an app).
 
-On Android, you can also install an APK, the installable app file for Android. It runs Marinara locally on the phone. See [Android Installation](installation/android-termux.md). On iPhone and iPad, see the [iOS PWA Guide](installation/ios-pwa.md).
+On Android, you can also install an APK, the installable app file for Android. It runs Guksu locally on the phone. See [Android Installation](installation/android-termux.md). On iPhone and iPad, see the [iOS PWA Guide](installation/ios-pwa.md).
 
 ## What are the three chat modes?
 
-Marinara has three chat modes, shown as tabs when you open the chat list:
+Guksu has three chat modes, shown as tabs when you open the chat list:
 
 - **Conversation**: a texting or direct-message style chat, like messaging a character in a chat app.
 - **Roleplay**: an immersive story scene with narration, character avatars, and optional character art.
@@ -56,11 +56,11 @@ Each mode has its own getting-started guide. Start with the mode you want, then 
 
 ## How do I change the timezone used by Conversation schedules?
 
-Open a Conversation and choose **Schedule timezone** in Chat Settings, or choose it while creating schedules in the Conversation setup flow. Marinara starts with the timezone reported by your device, but you can select any supported IANA timezone or choose **Use device** to reset it. This is one global preference for all Conversation chats, including server-side autonomous messages, and it syncs to other devices connected to the same Marinara server.
+Open a Conversation and choose **Schedule timezone** in Chat Settings, or choose it while creating schedules in the Conversation setup flow. Guksu starts with the timezone reported by your device, but you can select any supported IANA timezone or choose **Use device** to reset it. This is one global preference for all Conversation chats, including server-side autonomous messages, and it syncs to other devices connected to the same Guksu server.
 
-## Do I need an API key to use Marinara?
+## Do I need an API key to use Guksu?
 
-Almost always, yes. A **connection** is a saved link that tells Marinara how to reach one AI service: which provider, which model, and your login for it. An **API key** is a secret code, a bit like a password. You get it from an AI provider so Marinara can talk to that provider for you.
+Almost always, yes. A **connection** is a saved link that tells Guksu how to reach one AI service: which provider, which model, and your login for it. An **API key** is a secret code, a bit like a password. You get it from an AI provider so Guksu can talk to that provider for you.
 
 You need at least one connection before you can start any chat. To make one, open the **Connections** panel, click **New**, pick a provider, paste your **API Key**, and pick a model. For the full walkthrough, see [Connecting to an AI Provider](connections/connecting-to-a-provider.md).
 
@@ -68,7 +68,7 @@ A few providers do not use an API key at all. The subscription options (Claude, 
 
 ## Which AI providers are supported?
 
-Marinara supports many providers. You pick one per connection.
+Guksu supports many providers. You pick one per connection.
 
 For chat and roleplay text, the choices are **OpenAI**, **OpenAI (ChatGPT)**, **Anthropic**, **Claude (Subscription)**, **Grok CLI (Subscription)**, **Google Gemini**, **Google Vertex AI**, **Mistral**, **Cohere**, **OpenRouter**, **NanoGPT**, **xAI / Grok**, and **Custom (OAI-Compatible)** for local or self-hosted models such as Ollama, LM Studio, and KoboldCpp.
 
@@ -78,9 +78,9 @@ For video generation, the choices are **Google AI Studio**, **xAI Imagine**, **O
 
 You can save many connections at once and assign a different one to each chat. See [Connecting to an AI Provider](connections/connecting-to-a-provider.md).
 
-## Do I have to pay to use Marinara?
+## Do I have to pay to use Guksu?
 
-Marinara itself is free and runs on your own computer. You pay whatever your chosen AI provider charges, which varies by provider and model.
+Guksu itself is free and runs on your own computer. You pay whatever your chosen AI provider charges, which varies by provider and model.
 
 Some options cost nothing to try. **Pollinations** image generation needs no key. **Stable Horde** is free, and a key is optional for faster priority. The built-in **Local Model** runs on your machine with no key. The subscription options (Claude, ChatGPT, and Grok) use a paid plan you may already have, instead of a pay-per-use API key.
 
@@ -106,17 +106,17 @@ For the full feature, see [Lorebooks](lorebooks/overview.md).
 
 ## What is an agent?
 
-An **agent** is an optional AI helper that runs during a chat to do a focused job. Examples include tracking the current scene, watching writing quality, adding maps or calls, or running a Conversation table game. Fresh installations have no optional agents. Open the **Agents** panel, click **Download Agents**, read an item's details, and install it. Then enable compatible agents per chat in **Chat Settings**. Installed official packages automatically update to the newest compatible catalog version whenever the Marinara server starts; if the host is offline or verification fails, the installed version keeps working. The catalog also handles complete package removal. See [Agents](agents/agents-overview.md) and the public [Marinara-Agents repository](https://github.com/Pasta-Devs/Marinara-Agents).
+An **agent** is an optional AI helper that runs during a chat to do a focused job. Examples include tracking the current scene, watching writing quality, adding maps or calls, or running a Conversation table game. Fresh installations have no optional agents. Open the **Agents** panel, click **Download Agents**, read an item's details, and install it. Then enable compatible agents per chat in **Chat Settings**. Installed official packages automatically update to the newest compatible catalog version whenever the Guksu server starts; if the host is offline or verification fails, the installed version keeps working. The catalog also handles complete package removal. See [Agents](agents/agents-overview.md) and the public [Marinara-Agents repository](https://github.com/Pasta-Devs/Marinara-Agents).
 
 ## How do I set up Noodle?
 
-Noodle is Marinara's local, fictional social network for your characters. Open the **Noodle** tab and open its **Settings**. Invite characters or character folders, choose a generation connection under **Refresh**, then select **Refresh now** to generate the first activity. You can also set automatic refresh times, image generation, random users, and carryover into your chats.
+Noodle is Guksu's local, fictional social network for your characters. Open the **Noodle** tab and open its **Settings**. Invite characters or character folders, choose a generation connection under **Refresh**, then select **Refresh now** to generate the first activity. You can also set automatic refresh times, image generation, random users, and carryover into your chats.
 
 See [Noodle: The In-App Social Timeline](noodle/overview.md) and [Noodle Settings and Chat Carryover](noodle/settings.md) for the full guides.
 
 ## Why doesn't my character remember earlier messages?
 
-AI models can only hold so much text at once, so old messages fall out of view in long chats. Marinara has two memory systems that help:
+AI models can only hold so much text at once, so old messages fall out of view in long chats. Guksu has two memory systems that help:
 
 - **Memory Recall** searches earlier messages and quietly adds the most relevant bits back into the prompt. Turn it on in **Chat Settings** under **Memory Recall**.
 - Summaries compress old messages into short recaps. Roleplay chats use **Chat Summary**, and Conversation chats use **Automatic Summarization**.
@@ -131,11 +131,11 @@ Remember that a backup does not include your API keys, so re-enter them after yo
 
 ## Where is my data stored?
 
-Everything lives on the computer running Marinara, inside the `data` folder in your install. Your characters, chats, personas, lorebooks, presets, and settings are all saved there. Nothing is stored in the cloud. See [Where Your Data Is Stored](data/where-data-is-stored.md).
+Everything lives on the computer running Guksu, inside the `data` folder in your install. Your characters, chats, personas, lorebooks, presets, and settings are all saved there. Nothing is stored in the cloud. See [Where Your Data Is Stored](data/where-data-is-stored.md).
 
 ## Will I lose my data when I update?
 
-No. Updating Marinara keeps your characters, chats, and settings in place. It is still smart to make a backup before a big update, just in case. For update steps on each platform, see [Upgrading](UPGRADING.md).
+No. Updating Guksu keeps your characters, chats, and settings in place. It is still smart to make a backup before a big update, just in case. For update steps on each platform, see [Upgrading](UPGRADING.md).
 
 ## What can Professor Mari do?
 
@@ -161,9 +161,9 @@ Yes, in **Conversation** mode. Audio and video calls are a Conversation-only fea
 
 If you want to talk back with your microphone and the browser's own speech recognition is unreliable, first install **Calls** from **Agents > Download Agents**. Then open the **Connections** panel, expand the **Local Model** card, find **Local Speech Model**, pick **Whisper Tiny (Multilingual)** or **Whisper Base (Multilingual)**, and click **Download Whisper**. Uninstalling Calls also removes its Whisper downloads to reclaim disk space. For the full call setup, see [Calls](conversation/calls.md).
 
-## Can Marinara generate images?
+## Can Guksu generate images?
 
-Yes. Add an image generation connection, for example **Pollinations** (needs no key) or a paid provider. Marinara can then create character avatars, scene art, selfies, and Game Mode storyboards. See [Connecting to an AI Provider](connections/connecting-to-a-provider.md) to add one.
+Yes. Add an image generation connection, for example **Pollinations** (needs no key) or a paid provider. Guksu can then create character avatars, scene art, selfies, and Game Mode storyboards. See [Connecting to an AI Provider](connections/connecting-to-a-provider.md) to add one.
 
 ## How do I read the documentation inside the app?
 
@@ -172,7 +172,7 @@ Every install ships with the full set of guides. You can read them without leavi
 - On the Home screen, click the **Documentation** button in the footer, next to **Replay Tutorial**.
 - In the Home FAQ, open the documentation question and click **Open Documentation**.
 
-Both buttons open the same in-app viewer. It lists every guide and renders it inside Marinara.
+Both buttons open the same in-app viewer. It lists every guide and renders it inside Guksu.
 
 ## Where do I get help or report a bug?
 

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -1,10 +1,10 @@
-# Marinara Engine Installation
+# Guksu Motor Installation
 
-This guide helps you pick the right way to install Marinara Engine for your device. Marinara runs on your own machine, so your chats and data stay local. Each platform below has its own step by step guide, linked from the table.
+This guide helps you pick the right way to install Guksu Motor for your device. Guksu runs on your own machine, so your chats and data stay local. Each platform below has its own step by step guide, linked from the table.
 
 ## Choose your platform
 
-Pick the guide that matches the device you want to run Marinara on.
+Pick the guide that matches the device you want to run Guksu on.
 
 | Platform | Installation guide |
 |---|---|
@@ -16,8 +16,8 @@ Pick the guide that matches the device you want to run Marinara on.
 
 A few things to know before you pick:
 
-- On **iPhone or iPad**, Marinara does not run the server itself. You run the server on a computer, a home server, or an Android device. Then you open it in Safari on your iPhone or iPad. The iOS guide explains this.
-- On **Android**, Marinara runs inside **Termux**. Termux is a free app that gives Android a small Linux environment. The release APK just helps you set Termux up.
+- On **iPhone or iPad**, Guksu does not run the server itself. You run the server on a computer, a home server, or an Android device. Then you open it in Safari on your iPhone or iPad. The iOS guide explains this.
+- On **Android**, Guksu runs inside **Termux**. Termux is a free app that gives Android a small Linux environment. The release APK just helps you set Termux up.
 
 ## Which should I pick
 
@@ -39,13 +39,13 @@ If you are comfortable with a terminal and may want to edit the code, run from s
 http://127.0.0.1:7860
 ```
 
-- The address `127.0.0.1` means your own computer, and `7860` is the default port. To reach Marinara from your phone or another device on your network, see the [FAQ](FAQ.md) for LAN access.
+- The address `127.0.0.1` means your own computer, and `7860` is the default port. To reach Guksu from your phone or another device on your network, see the [FAQ](FAQ.md) for LAN access.
 
 ## Where to go after install
 
-Once Marinara is running and open in your browser, read [Getting Started with Marinara Engine](home/welcome.md). It walks you through your first steps: adding a connection, making or importing a character, and starting a chat.
+Once Guksu is running and open in your browser, read [Getting Started with Guksu Motor](home/welcome.md). It walks you through your first steps: adding a connection, making or importing a character, and starting a chat.
 
-To keep your install up to date later, see [Upgrading Marinara Engine](UPGRADING.md).
+To keep your install up to date later, see [Upgrading Guksu Motor](UPGRADING.md).
 
 ## Related guides
 
@@ -54,5 +54,5 @@ To keep your install up to date later, see [Upgrading Marinara Engine](UPGRADING
 - [Container installation](installation/containers.md)
 - [Android (Termux) installation](installation/android-termux.md)
 - [iOS and iPadOS](installation/ios-pwa.md)
-- [Upgrading Marinara Engine](UPGRADING.md)
-- [Getting Started with Marinara Engine](home/welcome.md)
+- [Upgrading Guksu Motor](UPGRADING.md)
+- [Getting Started with Guksu Motor](home/welcome.md)

--- a/docs/REMOTE_ACCESS.md
+++ b/docs/REMOTE_ACCESS.md
@@ -1,24 +1,24 @@
 # Remote Access: Basic Auth and IP Allowlist
 
-This guide explains how to reach Marinara Engine from another device, such as your phone, a laptop, or a Docker container. It covers the two main options: Basic Auth and the IP allowlist. It also covers the private-network bypass, HTTPS, Admin Access, and the "save blocked" CSRF message. Almost every setting here lives in the server `.env` file, not in the app.
+This guide explains how to reach Guksu Motor from another device, such as your phone, a laptop, or a Docker container. It covers the two main options: Basic Auth and the IP allowlist. It also covers the private-network bypass, HTTPS, Admin Access, and the "save blocked" CSRF message. Almost every setting here lives in the server `.env` file, not in the app.
 
 A quick word list used throughout this guide:
 
-- `.env` file: a plain text settings file in the Marinara Engine folder, next to `package.json`.
+- `.env` file: a plain text settings file in the Guksu Motor folder, next to `package.json`.
 - Loopback: the machine that is actually running the server. Its address is `127.0.0.1` or `localhost`.
-- Remote access: opening Marinara from any device that is NOT the machine running the server.
+- Remote access: opening Guksu from any device that is NOT the machine running the server.
 
-## What Marinara blocks by default
+## What Guksu blocks by default
 
-To protect your data, a fresh Marinara install refuses connections from other devices until you set up access control. By default, only three kinds of client are trusted:
+To protect your data, a fresh Guksu install refuses connections from other devices until you set up access control. By default, only three kinds of client are trusted:
 
 1. Loopback (`127.0.0.1` or `::1`), the machine running the server itself.
 2. Tailscale devices in your tailnet. Tailscale is a private network tool, and its addresses use the `100.64.0.0/10` range.
-3. Docker clients on the same host. Marinara recognizes the usual `172.16.0.0/12` bridge range and the container's exact default gateway, which also covers Docker Desktop and custom address pools.
+3. Docker clients on the same host. Guksu recognizes the usual `172.16.0.0/12` bridge range and the container's exact default gateway, which also covers Docker Desktop and custom address pools.
 
-Everything else, such as your phone on the same Wi-Fi or a public-internet client, is blocked until you pick an option below. A blocked device that opens Marinara in a browser sees a dark setup page. Its title reads **This Marinara Engine install needs access control before remote devices can connect.** The page shows your device's own IP and two copy-paste `.env` snippets.
+Everything else, such as your phone on the same Wi-Fi or a public-internet client, is blocked until you pick an option below. A blocked device that opens Guksu in a browser sees a dark setup page. Its title reads **This Guksu Motor install needs access control before remote devices can connect.** The page shows your device's own IP and two copy-paste `.env` snippets.
 
-If you do nothing and never set a password, Marinara stays locked to those three trusted sources. That is the safe default.
+If you do nothing and never set a password, Guksu stays locked to those three trusted sources. That is the safe default.
 
 ## Where the .env file lives
 
@@ -43,8 +43,8 @@ The shell launchers (`start.bat`, `start.sh`) set `HOST=0.0.0.0` for you. Runnin
 Read these in order and stop at the first one that matches you.
 
 1. You only connect over Tailscale, or only from Docker containers on the same host. You do not need to do anything. It already works.
-2. You want to reach Marinara from a phone, tablet, or laptop on your home Wi-Fi. Use Basic Auth (Option 1 below).
-3. You are exposing Marinara to the public internet. Use Basic Auth plus HTTPS.
+2. You want to reach Guksu from a phone, tablet, or laptop on your home Wi-Fi. Use Basic Auth (Option 1 below).
+3. You are exposing Guksu to the public internet. Use Basic Auth plus HTTPS.
 4. Your client devices have fixed IP addresses and you would rather not type a password. Use the IP allowlist (Option 2 below).
 5. Your whole network is trusted and you never want a password. Use the private-network bypass (Option 3 below). Read the warning there first.
 
@@ -67,11 +67,11 @@ openssl rand -base64 24
 
 Save `.env`. The change applies within a couple of seconds, with no restart. Then follow these steps from the remote device.
 
-1. Open Marinara in your browser using the server's address, for example `http://192.168.1.50:7860`.
+1. Open Guksu in your browser using the server's address, for example `http://192.168.1.50:7860`.
 2. Enter the username and password you set when the browser prompts you.
 3. You should see the app load. The browser remembers the login for the rest of the session.
 
-By default, the browser prompt says **Marinara Engine**. You can change that text with `BASIC_AUTH_REALM`.
+By default, the browser prompt says **Guksu Motor**. You can change that text with `BASIC_AUTH_REALM`.
 
 Some clients skip the password even when Basic Auth is on:
 
@@ -80,7 +80,7 @@ Some clients skip the password even when Basic Auth is on:
 - Tailscale (`100.64.0.0/10`) and same-host Docker bridge/gateway traffic, unless you turn their bypass off.
 - The `/api/health` address, so uptime monitors keep working.
 
-Important: Basic Auth only encodes the password. It does not encrypt it. Anyone watching an unencrypted connection can read it. If you expose Marinara to the public internet, pair Basic Auth with HTTPS (see below).
+Important: Basic Auth only encodes the password. It does not encrypt it. Anyone watching an unencrypted connection can read it. If you expose Guksu to the public internet, pair Basic Auth with HTTPS (see below).
 
 ## Option 2: IP allowlist
 
@@ -118,7 +118,7 @@ ALLOW_UNAUTHENTICATED_PRIVATE_NETWORK=true
 
 This restores the older "open on the LAN, blocked from the public internet" behavior. It applies only to standard private-network ranges, for example `10.0.0.0/8`, `172.16.0.0/12`, and `192.168.0.0/16`. The CGNAT range `100.64.0.0/10` also counts. CGNAT is a shared address system used by some internet providers, and Tailscale uses the same range. Public-internet addresses are still blocked with a 403.
 
-Warning: anyone on the same network can then reach Marinara with no password. That is fine on a network you control. It is not fine on shared Wi-Fi at a coffee shop, airport, or dorm. When in doubt, use Basic Auth instead.
+Warning: anyone on the same network can then reach Guksu with no password. That is fine on a network you control. It is not fine on shared Wi-Fi at a coffee shop, airport, or dorm. When in doubt, use Basic Auth instead.
 
 There is also a broader flag, `ALLOW_UNAUTHENTICATED_REMOTE=true`, which allows passwordless access from ANY address, including the public internet. Do not turn this on. If you truly need public access, use Basic Auth plus HTTPS, or put a reverse proxy in front that handles the login.
 
@@ -147,7 +147,7 @@ Your regular LAN may use `172.16.x.x` addresses. In that case, turn the Docker b
 BYPASS_AUTH_DOCKER=false
 ```
 
-Marinara may also sit behind a reverse proxy container on the Docker bridge or detected gateway. To make Marinara's own access checks apply to the clients the proxy forwards, set:
+Guksu may also sit behind a reverse proxy container on the Docker bridge or detected gateway. To make Guksu's own access checks apply to the clients the proxy forwards, set:
 
 ```env
 REQUIRE_AUTH_FOR_DOCKER_PROXY=true
@@ -168,7 +168,7 @@ SSL_CERT=/path/to/cert.pem
 SSL_KEY=/path/to/key.pem
 ```
 
-2. Reverse proxy. Put Marinara behind nginx, Caddy, Traefik, or a Cloudflare Tunnel. The proxy handles the HTTPS part and forwards to Marinara over plain HTTP on the same machine.
+2. Reverse proxy. Put Guksu behind nginx, Caddy, Traefik, or a Cloudflare Tunnel. The proxy handles the HTTPS part and forwards to Guksu over plain HTTP on the same machine.
 
 You need a certificate and key before setting `SSL_CERT` and `SSL_KEY`. You can create one with a tool like `mkcert` for local use, or `certbot` for a public domain. If the files are missing or unreadable, the server stops on startup and names the exact paths it tried.
 
@@ -184,7 +184,7 @@ On the loopback machine, these actions usually work with no admin secret. From a
 ADMIN_SECRET=some-long-random-string
 ```
 
-2. On the remote device, open Marinara and go to **Settings**, then the **Advanced** tab, then the **Admin Access** section.
+2. On the remote device, open Guksu and go to **Settings**, then the **Advanced** tab, then the **Admin Access** section.
 3. Paste the same value into the box (its placeholder reads **ADMIN_SECRET**), then click **Save**.
 4. You should see the message **Admin secret saved for this browser**.
 
@@ -195,13 +195,13 @@ A few things to know about the admin secret:
 - If the server operator sets `MARINARA_REQUIRE_ADMIN_SECRET_ON_LOOPBACK=true`, even the loopback machine needs the secret.
 - This is separate from Basic Auth. You can use both. Basic Auth gates the whole app, and the admin secret gates the dangerous actions.
 
-If a privileged action fails on a remote device, Marinara shows an error message with two fixes. One fix is to open the app through localhost. The other is to set `ADMIN_SECRET` in the server `.env`, then paste the same value in **Settings** > **Advanced** > **Admin Access**.
+If a privileged action fails on a remote device, Guksu shows an error message with two fixes. One fix is to open the app through localhost. The other is to set `ADMIN_SECRET` in the server `.env`, then paste the same value in **Settings** > **Advanced** > **Admin Access**.
 
 ## Why is my save blocked (CSRF)
 
-CSRF stands for cross-site request forgery. It is a protection that stops another website you have open from quietly making changes in Marinara without your permission. It runs automatically. There is no setting to turn it on.
+CSRF stands for cross-site request forgery. It is a protection that stops another website you have open from quietly making changes in Guksu without your permission. It runs automatically. There is no setting to turn it on.
 
-Sometimes CSRF blocks your own saves. This usually happens when you reach Marinara through a public domain name or an unusual port that the server does not yet trust. Two things tell you when this happens.
+Sometimes CSRF blocks your own saves. This usually happens when you reach Guksu through a public domain name or an unusual port that the server does not yet trust. Two things tell you when this happens.
 
 - A red banner at the top of the app warns that **Saves will silently fail** because this origin is not trusted. The banner shows the exact `.env` line to add and has a **Copy** button.
 - If a save is actually rejected, a small pop-up message appears. Its title is **Save blocked: missing CSRF header**, **Save blocked: cross-site request rejected**, or **Save blocked: origin not trusted**.
@@ -216,11 +216,11 @@ Loopback, normal LAN addresses, Tailscale (`100.64.0.0/10`), and Docker bridge (
 
 ## A note on blocked local providers
 
-Say you connect Marinara to a local AI provider, for example one running on your own machine. The request may be refused with a message about a "private, loopback, metadata, or reserved IP range". That is a different safety check called SSRF protection. SSRF stands for server-side request forgery. It stops the server from calling private addresses unless you allow it. The error names the exact `.env` variable to set, such as `PROVIDER_LOCAL_URLS_ENABLED`. See [Server Configuration Reference](CONFIGURATION.md) for the full list.
+Say you connect Guksu to a local AI provider, for example one running on your own machine. The request may be refused with a message about a "private, loopback, metadata, or reserved IP range". That is a different safety check called SSRF protection. SSRF stands for server-side request forgery. It stops the server from calling private addresses unless you allow it. The error names the exact `.env` variable to set, such as `PROVIDER_LOCAL_URLS_ENABLED`. See [Server Configuration Reference](CONFIGURATION.md) for the full list.
 
 ## Access from a phone or tablet
 
-To open Marinara from a phone or tablet on the same network:
+To open Guksu from a phone or tablet on the same network:
 
 1. Make sure the server listens on all interfaces with `HOST=0.0.0.0` in `.env`.
 2. Pick an access option above. Basic Auth is the simplest for a phone on your home Wi-Fi.
@@ -233,5 +233,5 @@ If the page does not load at all, the server may not be reachable. Check `HOST=0
 ## Related guides
 
 - [Server Configuration Reference](CONFIGURATION.md) for the full list of `.env` settings and edge cases.
-- [Troubleshooting Marinara Engine](TROUBLESHOOTING.md) for connection errors, mobile access, and more.
-- [Frequently Asked Questions](FAQ.md) for a quick walkthrough of reaching Marinara from another device.
+- [Troubleshooting Guksu Motor](TROUBLESHOOTING.md) for connection errors, mobile access, and more.
+- [Frequently Asked Questions](FAQ.md) for a quick walkthrough of reaching Guksu from another device.

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -1,13 +1,13 @@
-# Troubleshooting Marinara Engine
+# Troubleshooting Guksu Motor
 
-This guide lists common problems in Marinara Engine and how to fix them. Find the section that matches your symptom, then follow the steps. If nothing here helps, see the last section, Getting more help.
+This guide lists common problems in Guksu Motor and how to fix them. Find the section that matches your symptom, then follow the steps. If nothing here helps, see the last section, Getting more help.
 
 ## First things to try
 
 Many problems clear up with two quick steps.
 
 1. Do a hard refresh of the page. Press **Ctrl+Shift+R** on Windows or Linux, or **Cmd+Shift+R** on a Mac.
-2. Look at the server console (the terminal window that runs Marinara) for red error lines. Those lines usually name the real problem.
+2. Look at the server console (the terminal window that runs Guksu) for red error lines. Those lines usually name the real problem.
 
 If you are asking the team for help, turn on **Debug mode** first so the server logs the prompt and response. See Getting more help at the end of this guide.
 
@@ -15,7 +15,7 @@ If you are asking the team for help, turn on **Debug mode** first so the server 
 
 ### Windows: EPERM or corepack signature error when installing pnpm
 
-pnpm is the package manager Marinara uses to install its code. If you see `EPERM: operation not permitted` or a corepack signature verification failure, corepack could not write into the Node install folder.
+pnpm is the package manager Guksu uses to install its code. If you see `EPERM: operation not permitted` or a corepack signature verification failure, corepack could not write into the Node install folder.
 
 Pick one fix:
 
@@ -34,9 +34,9 @@ npm install -g corepack
 
 ### Windows: `'pnpm' is not recognized` while building the shared package
 
-Marinara v2.3.0 could start pnpm through Corepack successfully and then fail during the shared-package build because that build tried to launch a second, global `pnpm` executable. v2.3.1 removes that nested requirement. Close the failed launcher and run `start.bat` again so it can pull the corrected build script before rebuilding. Your data does not need to be removed.
+Guksu v2.3.0 could start pnpm through Corepack successfully and then fail during the shared-package build because that build tried to launch a second, global `pnpm` executable. v2.3.1 removes that nested requirement. Close the failed launcher and run `start.bat` again so it can pull the corrected build script before rebuilding. Your data does not need to be removed.
 
-If the checkout itself cannot update, run `git pull` in the Marinara folder and start it again. As a temporary v2.3.0 workaround, install the pinned package manager globally, rerun the launcher, and then update normally:
+If the checkout itself cannot update, run `git pull` in the Guksu folder and start it again. As a temporary v2.3.0 workaround, install the pinned package manager globally, rerun the launcher, and then update normally:
 
 ```bash
 npm install -g pnpm@10.33.2
@@ -44,17 +44,17 @@ npm install -g pnpm@10.33.2
 
 ### Linux: ERR_PNPM_ENAMETOOLONG during install
 
-This means an older install left behind long folder paths. From the Marinara folder, clear the partial install and run the launcher again:
+This means an older install left behind long folder paths. From the Guksu folder, clear the partial install and run the launcher again:
 
 ```bash
 rm -rf node_modules .pnpm .pnpm-store
 ```
 
-Then start Marinara again with `./start.sh`. If you install by hand, run `pnpm install` after removing those folders.
+Then start Guksu again with `./start.sh`. If you install by hand, run `pnpm install` after removing those folders.
 
 ### ERR_PNPM_TRUST_DOWNGRADE or a missing chess.js during build
 
-This is almost always a half-finished install. First rerun the launcher so it can repair the workspace. If you install by hand, run this single command from the Marinara folder:
+This is almost always a half-finished install. First rerun the launcher so it can repair the workspace. If you install by hand, run this single command from the Guksu folder:
 
 ```bash
 pnpm --config.trustPolicy=off --config.confirmModulesPurge=false install --frozen-lockfile
@@ -69,23 +69,23 @@ Sometimes the server is running but the browser shows a blank page, or the app l
 1. Do a hard refresh (**Ctrl+Shift+R** or **Cmd+Shift+R**).
 2. If that does not help, open **Settings**, go to the **Advanced** tab, then the **Updates** section, and click **Refresh App**.
 
-**Refresh App** clears the browser service worker (a background script that caches the web app) and the browser cache, then reloads. It does not change your data. Your chats, settings, and other local data stay intact. It also does not update the server code, so it is not a substitute for a real update. See [Upgrading Marinara Engine](UPGRADING.md) to update the app itself.
+**Refresh App** clears the browser service worker (a background script that caches the web app) and the browser cache, then reloads. It does not change your data. Your chats, settings, and other local data stay intact. It also does not update the server code, so it is not a substitute for a real update. See [Upgrading Guksu Motor](UPGRADING.md) to update the app itself.
 
 ## Downloadable agent problems
 
-If **Agents → Download Agents** says the catalog is unavailable, the machine running the Marinara server—not only the browser—must be able to reach the official [Pasta-Devs/Marinara-Agents](https://github.com/Pasta-Devs/Marinara-Agents) catalog over GitHub HTTPS. Installed agents continue to work offline at their current version. Restore the server connection and restart Marinara to retry automatic package updates, or click **Refresh** or **Try again** to browse the catalog immediately.
+If **Agents → Download Agents** says the catalog is unavailable, the machine running the Guksu server—not only the browser—must be able to reach the official [Pasta-Devs/Marinara-Agents](https://github.com/Pasta-Devs/Marinara-Agents) catalog over GitHub HTTPS. Installed agents continue to work offline at their current version. Restore the server connection and restart Guksu to retry automatic package updates, or click **Refresh** or **Try again** to browse the catalog immediately.
 
-If an installed map or call does not appear, close Marinara Engine completely and start it again. Those route-bearing packages remain in **Restart required** state until the next process start. Conversation games are different: current Engine builds hot-activate them immediately. Refresh the catalog if installation failed, then confirm the game shows as ready; adding it under a chat's **Commands** settings is only necessary when you want characters to initiate it themselves, not for the game's manual slash command.
+If an installed map or call does not appear, close Guksu Motor completely and start it again. Those route-bearing packages remain in **Restart required** state until the next process start. Conversation games are different: current Engine builds hot-activate them immediately. Refresh the catalog if installation failed, then confirm the game shows as ready; adding it under a chat's **Commands** settings is only necessary when you want characters to initiate it themselves, not for the game's manual slash command.
 
-If an older installation cannot complete its first package migration, do not delete the `data/capability-packages` folder or your chat data. Marinara leaves the migration incomplete and retries on the next startup. Existing chat selections and settings remain stored while the catalog is unreachable.
+If an older installation cannot complete its first package migration, do not delete the `data/capability-packages` folder or your chat data. Guksu leaves the migration incomplete and retries on the next startup. Existing chat selections and settings remain stored while the catalog is unreachable.
 
-Package downloads are rejected when their checksum, declared file list, Engine version range, or archive paths do not match the official catalog. Update Marinara Engine first, refresh the catalog, and retry. Do not manually extract an artifact into the data directory.
+Package downloads are rejected when their checksum, declared file list, Engine version range, or archive paths do not match the official catalog. Update Guksu Motor first, refresh the catalog, and retry. Do not manually extract an artifact into the data directory.
 
-Automatic updates never install packages the user did not choose. They only replace an already-installed official package with a newer compatible, verified catalog build. A failed update leaves the installed version registered; if a newly updated server runtime fails its startup self-check, Marinara rolls it back to the previous version.
+Automatic updates never install packages the user did not choose. They only replace an already-installed official package with a newer compatible, verified catalog build. A failed update leaves the installed version registered; if a newly updated server runtime fails its startup self-check, Guksu rolls it back to the previous version.
 
-## Accessing Marinara from another device
+## Accessing Guksu from another device
 
-If you cannot access Marinara from a phone, tablet, or another computer on your network, work through these checks.
+If you cannot access Guksu from a phone, tablet, or another computer on your network, work through these checks.
 
 - Bind the server to a reachable address. The server listens on `127.0.0.1` (loopback, your own machine only) by default. The shell launchers set `HOST=0.0.0.0` for you. If you started with `pnpm start` by hand, set `HOST=0.0.0.0` in your `.env` file first.
 - Confirm both devices are on the same Wi-Fi network.
@@ -97,14 +97,14 @@ For the full walkthrough, see [Remote Access](REMOTE_ACCESS.md) and the [Frequen
 
 ## Save blocked, or settings that do not persist
 
-If a save seems to work but reverts when you reload, Marinara's cross-site protection is blocking it. CSRF (cross-site request forgery) protection guards actions that change data. It only trusts certain browser origins.
+If a save seems to work but reverts when you reload, Guksu's cross-site protection is blocking it. CSRF (cross-site request forgery) protection guards actions that change data. It only trusts certain browser origins.
 
 You will see one or both of these signs:
 
 - A red banner at the top of the screen warning that saves will silently fail because this origin is not trusted.
 - A toast titled **Save blocked: missing CSRF header**, **Save blocked: cross-site request rejected**, or **Save blocked: origin not trusted**.
 
-Loopback, private network addresses, Tailscale, and the Docker bridge are trusted automatically. This usually only happens when you reach Marinara through a public IP address or a domain name. Add that address to `CSRF_TRUSTED_ORIGINS` in `.env`. Use a comma-separated list for more than one, for example:
+Loopback, private network addresses, Tailscale, and the Docker bridge are trusted automatically. This usually only happens when you reach Guksu through a public IP address or a domain name. Add that address to `CSRF_TRUSTED_ORIGINS` in `.env`. Use a comma-separated list for more than one, for example:
 
 ```bash
 CSRF_TRUSTED_ORIGINS=http://203.0.113.10:7831,https://chat.example.com
@@ -116,7 +116,7 @@ No restart is needed. The banner has a Copy button that fills in the exact line 
 
 Generation errors appear as a toast at the bottom of the screen. If a connection failed, the toast names the reason. The toast stays up long enough to read and copy.
 
-- **No API connection configured for this chat**: the chat has no connection selected. Open the **Connections** panel, create one, then pick it for the chat. See [Connecting to an AI Provider](connections/connecting-to-a-provider.md). An API key is a secret code from a provider that lets Marinara use their models.
+- **No API connection configured for this chat**: the chat has no connection selected. Open the **Connections** panel, create one, then pick it for the chat. See [Connecting to an AI Provider](connections/connecting-to-a-provider.md). An API key is a secret code from a provider that lets Guksu use their models.
 - The model does not accept a parameter: the toast tells you which one. Open **Chat Settings** > **Advanced Parameters** and find that parameter. Turn off the switch next to its name (the tooltip reads "This parameter is sent to the model").
 - The model says a parameter is required: do the same, but turn the switch next to that parameter on.
 - **The AI returned an empty response. Try sending your message again.**: send your message again. If it keeps happening, try a different model or connection.
@@ -158,7 +158,7 @@ Chat summaries need a working text connection to write them.
 
 The **Card Browser** lets you search public character sites and import characters. Open it from the **Card Browser** icon in the top bar, then click **Download Cards**.
 
-- If JannyAI search or a character page fails with a Cloudflare block, Marinara shows a message. It asks you to visit the JannyAI site once in the same browser to clear the challenge, then retry.
+- If JannyAI search or a character page fails with a Cloudflare block, Guksu shows a message. It asks you to visit the JannyAI site once in the same browser to clear the challenge, then retry.
 - If your CharacterTavern or Pygmalion login stops working after you restart the server, that is expected. Those logins live only in server memory and clear on restart. Open the login window and paste your cookie or token again.
 
 ## Media generation problems
@@ -171,7 +171,7 @@ Generated still sprites normally use native transparency or an adaptive flat chr
 pnpm backgroundremover:install
 ```
 
-Then restart Marinara and click **Reapply Cleanup** in the sprite generation window. Marinara will still try the built-in matte path first and use the AI model only when the border does not look uniform. If the install fails:
+Then restart Guksu and click **Reapply Cleanup** in the sprite generation window. Guksu will still try the built-in matte path first and use the AI model only when the border does not look uniform. If the install fails:
 
 - Confirm Python 3.9 to 3.11 is installed. Newer Python versions can force slow native builds.
 - Rebuild the tool with `pnpm backgroundremover:reinstall`.
@@ -185,13 +185,13 @@ Storyboards are a Game Mode feature. They turn a completed narration turn into k
 - For automatic storyboards, open **Chat Settings** > **Agents** > **Storyboards** and confirm **Automatic Storyboard Illustrations** is on. Turn on **Automatic Storyboard Animations** too if you also want clips.
 - Keyframe images need a Game image connection. Clips also need a video connection.
 - If a custom prompt works better with all characters combined, turn off **Use NovelAI Character Prompts**.
-- Slow providers can hit a timeout. Raise `IMAGE_GEN_TIMEOUT_MS` or `VIDEO_GEN_TIMEOUT_MS` in `.env`, then restart Marinara. The server only reads these values at startup.
+- Slow providers can hit a timeout. Raise `IMAGE_GEN_TIMEOUT_MS` or `VIDEO_GEN_TIMEOUT_MS` in `.env`, then restart Guksu. The server only reads these values at startup.
 
 See [Game Mode: Getting Started](game/getting-started.md) for the full setup.
 
 ### Game Mode world generation shows a JSON error
 
-If starting a game fails because the model returned broken JSON, Marinara opens the **Repair JSON** window instead of throwing the whole turn away. JSON is the structured text format the model must return.
+If starting a game fails because the model returned broken JSON, Guksu opens the **Repair JSON** window instead of throwing the whole turn away. JSON is the structured text format the model must return.
 
 1. Fix the brackets, commas, or fields in the editor. The banner reads **JSON is valid.** once the text parses.
 2. Click **Format** to tidy the layout.
@@ -201,24 +201,24 @@ If starting a game fails because the model returned broken JSON, Marinara opens 
 
 - If characters do not speak during a call, Text to Speech is not set up. Open **Connections** > **Text to Speech**, enable it, choose a source, enter your key, pick a voice, and save. A character with no voice appears as text only.
 - If the microphone is not working, you may need the local speech model. Install **Calls** from **Agents > Download Agents**, then open **Connections** > **Local Model**, expand the card, find **Local Speech Model**, choose a Whisper model, and click **Download Whisper**. Firefox in particular needs this because it lacks browser speech recognition. Uninstalling Calls deletes its Whisper models to reclaim disk space.
-- On a Lite build, the message **Local Whisper is disabled in Lite mode** means that small build cannot run the local speech model. Use a full Marinara install instead.
+- On a Lite build, the message **Local Whisper is disabled in Lite mode** means that small build cannot run the local speech model. Use a full Guksu install instead.
 
 ### Music DJ Spotify login fails on a remote or network install
 
 The Music DJ agent's Spotify mode uses OAuth. OAuth is a login handoff where Spotify sends you back to a callback address. A redirect URI is that callback address, and Spotify only accepts `https://` addresses or the loopback address `http://127.0.0.1`. It rejects plain network IP addresses.
 
-- If you reach Marinara at localhost, the editor shows a `127.0.0.1` callback. Register that with Spotify and the login completes.
-- If you reach Marinara over HTTPS, the editor shows your HTTPS callback. Register that.
+- If you reach Guksu at localhost, the editor shows a `127.0.0.1` callback. Register that with Spotify and the login completes.
+- If you reach Guksu over HTTPS, the editor shows your HTTPS callback. Register that.
 - If HTTPS is terminated upstream and the host does not match, set `SPOTIFY_REDIRECT_URI` in `.env` to your public callback address.
 - On a plain-HTTP network install, the popup cannot load, but the address bar still holds a valid code. Copy the full URL from the popup. Then expand **Browser couldn't reach the callback?** under the Connect button and paste it. The pasted URL is valid for 10 minutes.
 
-The cleanest long-term fix is to put the server behind HTTPS. Last checked against Marinara Engine 2.2.0. Spotify tightened these rules in February 2025.
+The cleanest long-term fix is to put the server behind HTTPS. Last checked against Guksu Motor 2.2.0. Spotify tightened these rules in February 2025.
 
 ## Storage and data
 
 ### Data seems missing after an update
 
-If your chats or presets look missing after an update, do not delete any data folders yet. Marinara keeps your live data in a `storage` folder inside its data directory.
+If your chats or presets look missing after an update, do not delete any data folders yet. Guksu keeps your live data in a `storage` folder inside its data directory.
 
 Check both of these local locations for a `storage` folder:
 
@@ -235,9 +235,9 @@ Loopback sessions can make backups without an admin secret. From another device,
 
 ### Android app stuck on Connecting or Waiting for Server
 
-The Android app is a small shell around Termux. Termux is a Linux terminal app for Android, and it runs the real Marinara server.
+The Android app is a small shell around Termux. Termux is a Linux terminal app for Android, and it runs the real Guksu server.
 
-1. Tap **Install / Start Marinara**.
+1. Tap **Install / Start Guksu**.
 2. If Android asks to install Termux, approve the prompts.
 3. If Android asks to run commands in Termux, grant it.
 4. Wait for the launcher to finish and start the server, then return to the app.
@@ -256,7 +256,7 @@ If it still stops, close other Android apps, reopen Termux, and run the command 
 
 ### Android update runs out of storage while installing dependencies
 
-The built Marinara app is not several gigabytes, and Noodle does not download its own AI models. A large temporary footprint during an update usually comes from pnpm's dependency store and virtual store, especially after several releases or an interrupted forced reinstall.
+The built Guksu app is not several gigabytes, and Noodle does not download its own AI models. A large temporary footprint during an update usually comes from pnpm's dependency store and virtual store, especially after several releases or an interrupted forced reinstall.
 
 The current launcher prunes packages left over from older releases and avoids rebuilding the dependency store more than once for the same update. If an older launcher already filled the device, update the launcher and reclaim its unreferenced cache before trying again:
 
@@ -273,7 +273,7 @@ Do not delete `data`, `storage`, or `marinara-engine.db`; those locations may co
 
 For Conversation schedules, open Conversation Chat Settings or a character schedule editor and choose **Schedule timezone**. This global selection applies to every Conversation chat, including background autonomous messages, and can be reset with **Use device**.
 
-For Noodle or server jobs without a Conversation override, remove any blank `TZ=` line from `.env` and restart Marinara so the server inherits the host timezone. To choose a host fallback explicitly, set a valid IANA name such as `TZ=Europe/Warsaw` or `TZ=America/New_York`. Current releases treat a blank value as unset, but a restart is still required for Node's timezone state and scheduled jobs to be rebuilt consistently.
+For Noodle or server jobs without a Conversation override, remove any blank `TZ=` line from `.env` and restart Guksu so the server inherits the host timezone. To choose a host fallback explicitly, set a valid IANA name such as `TZ=Europe/Warsaw` or `TZ=America/New_York`. Current releases treat a blank value as unset, but a restart is still required for Node's timezone state and scheduled jobs to be rebuilt consistently.
 
 ### Container permission denied on a volume mount
 
@@ -287,7 +287,7 @@ If a Docker or Podman container fails with permission errors on the data volume:
 
 If the lite container restarts whenever it sends an AI request on a Raspberry Pi 4 or similar ARM device, check the exit code. Exit 132 or SIGILL points to a known upstream problem in the lite image's Node build on some ARM chips. SIGILL means the program hit an instruction the CPU cannot run.
 
-The regular (non-lite) image is not affected. Until the upstream fix ships, use the regular image on that device. Known affected lite images include `1.5.7-lite` and `1.5.8-lite`. Last checked against Marinara Engine 2.2.0.
+The regular (non-lite) image is not affected. Until the upstream fix ships, use the regular image on that device. Known affected lite images include `1.5.7-lite` and `1.5.8-lite`. Last checked against Guksu Motor 2.2.0.
 
 ## Getting more help
 
@@ -309,7 +309,7 @@ Then reach the community:
 - [Frequently Asked Questions](FAQ.md)
 - [Server Configuration Reference](CONFIGURATION.md)
 - [Remote Access](REMOTE_ACCESS.md)
-- [Upgrading Marinara Engine](UPGRADING.md)
+- [Upgrading Guksu Motor](UPGRADING.md)
 - [Connecting to an AI Provider](connections/connecting-to-a-provider.md)
 - [Local Model Setup](connections/local-model.md)
 - [Game Mode: Getting Started](game/getting-started.md)

--- a/docs/UPGRADING.md
+++ b/docs/UPGRADING.md
@@ -1,16 +1,16 @@
-# Upgrading Marinara Engine
+# Upgrading Guksu Motor
 
-This guide shows you how to update Marinara Engine to a newer version. It covers every install type, the in-app update tools, and what to do if an upgrade fails. Your chats and settings are kept when you upgrade.
+This guide shows you how to update Guksu Motor to a newer version. It covers every install type, the in-app update tools, and what to do if an upgrade fails. Your chats and settings are kept when you upgrade.
 
 ## Your data is preserved
 
-Upgrading Marinara Engine does not delete your data. Your chats, characters, personas, lorebooks, presets, connections, and settings all stay in place.
+Upgrading Guksu Motor does not delete your data. Your chats, characters, personas, lorebooks, presets, connections, and settings all stay in place.
 
-Marinara keeps your data in a local data folder on the machine that runs the server. Docker and Podman keep it in the `marinara-data` volume. Updating only replaces the app code, not this data folder or volume.
+Guksu keeps your data in a local data folder on the machine that runs the server. Docker and Podman keep it in the `marinara-data` volume. Updating only replaces the app code, not this data folder or volume.
 
-When upgrading from a version that bundled first-party agents, maps, calls, or Conversation games, the first start downloads their matching optional packages from the official catalog. Existing chat selections, agent settings, stored runtime data, and history are preserved. Keep the server online for that first start. If the catalog cannot be reached, Marinara retries the migration the next time it starts instead of deleting or disabling your stored configuration.
+When upgrading from a version that bundled first-party agents, maps, calls, or Conversation games, the first start downloads their matching optional packages from the official catalog. Existing chat selections, agent settings, stored runtime data, and history are preserved. Keep the server online for that first start. If the catalog cannot be reached, Guksu retries the migration the next time it starts instead of deleting or disabling your stored configuration.
 
-To learn where your data lives and how to save a copy, see [Backing Up and Restoring Marinara](data/backup-and-restore.md).
+To learn where your data lives and how to save a copy, see [Backing Up and Restoring Guksu](data/backup-and-restore.md).
 
 ## Back up first
 
@@ -24,30 +24,30 @@ Upgrades are safe, but a backup is cheap insurance. Make one before any large ju
 
 You should see the button change to **Creating backup...** while it works. When it finishes, your browser saves a `.zip` archive of your data.
 
-Full steps for backups and restoring are in [Backing Up and Restoring Marinara](data/backup-and-restore.md).
+Full steps for backups and restoring are in [Backing Up and Restoring Guksu](data/backup-and-restore.md).
 
 ## Upgrade by platform
 
-Pick the section that matches how you installed Marinara. A "git checkout" below means a copy installed with the Git tool. A "clone" is a downloaded copy made with Git.
+Pick the section that matches how you installed Guksu. A "git checkout" below means a copy installed with the Git tool. A "clone" is a downloaded copy made with Git.
 
 ### Windows
 
 If you used the Windows installer or a git checkout, the launcher updates you automatically.
 
-1. Close Marinara Engine.
+1. Close Guksu Motor.
 2. Open it again from the Start Menu shortcut, or run `start.bat`.
 
 The launcher fetches the latest code, reinstalls what changed, rebuilds the app, and starts the new version. This works for both the installer and a manual clone.
 
 For one launch, run `start.bat --skip-update`. To keep the installed Engine version across launches, set `AUTO_UPDATE_ENABLED=false` in the project `.env`. This only disables automatic Engine updates; manual commands and **Settings → Advanced → Check for Updates** remain available.
 
-If the launcher says Node.js is too old, install Node.js 24 LTS, then start Marinara again. LTS means Long Term Support, the recommended stable release of Node.js.
+If the launcher says Node.js is too old, install Node.js 24 LTS, then start Guksu again. LTS means Long Term Support, the recommended stable release of Node.js.
 
 You can also download the newest installer from the GitHub Releases page and run it. It uses the same git-based path, so future updates still run through the launcher.
 
 ### macOS and Linux
 
-Close Marinara Engine, then run the launcher from your Marinara folder.
+Close Guksu Motor, then run the launcher from your Guksu folder.
 
 ```bash
 ./start.sh
@@ -77,7 +77,7 @@ Release images are published as `ghcr.io/pasta-devs/marinara-engine:X.Y.Z` and `
 
 ### Android (Termux)
 
-Termux is a terminal and Linux environment for Android. Its launcher updates Marinara each time you run it.
+Termux is a terminal and Linux environment for Android. Its launcher updates Guksu each time you run it.
 
 1. Open Termux.
 2. Run the launcher.
@@ -98,24 +98,24 @@ cd Marinara-Engine
 
 For a persistent opt-out, set `AUTO_UPDATE_ENABLED=false` in the project `.env`. This affects only launcher-managed Engine updates; manual updates and the in-app update controls remain available.
 
-If you use the Android app icon (the APK), open it and tap **Install / Start Marinara**. The APK is a sideloaded app, which means you installed it outside the official app store. It is a shell over Termux, so it updates the same Termux copy behind it.
+If you use the Android app icon (the APK), open it and tap **Install / Start Guksu**. The APK is a sideloaded app, which means you installed it outside the official app store. It is a shell over Termux, so it updates the same Termux copy behind it.
 
 ### iPhone and iPad
 
-iPhone and iPad do not run the Marinara server. They open a server that runs on another device through Safari. The copy on your Home Screen is a PWA, short for Progressive Web App. A PWA is a website you add to your Home Screen so it opens like an app.
+iPhone and iPad do not run the Guksu server. They open a server that runs on another device through Safari. The copy on your Home Screen is a PWA, short for Progressive Web App. A PWA is a website you add to your Home Screen so it opens like an app.
 
-1. Update the computer, Docker host, or Android device that actually runs your Marinara server. Use that device's section above.
+1. Update the computer, Docker host, or Android device that actually runs your Guksu server. Use that device's section above.
 2. Reload the Home Screen PWA or the Safari tab on your iPhone or iPad.
 
 If Safari keeps showing an older build after the host is updated, reset the cached copy.
 
 1. Remove the Home Screen icon.
-2. Clear Safari website data for the Marinara host.
+2. Clear Safari website data for the Guksu host.
 3. Add it to the Home Screen again.
 
 ## Checking for and applying updates in the app
 
-Marinara can check GitHub for a newer version from inside the app. Some installs can also apply the update from the browser.
+Guksu can check GitHub for a newer version from inside the app. Some installs can also apply the update from the browser.
 
 1. Open **Settings**.
 2. Go to the **Advanced** tab.
@@ -159,9 +159,9 @@ Applying from a different device is off by default. It needs all three of the fo
 - The server owner set `ADMIN_SECRET` (a password for protected actions) in `.env`.
 - You saved that same secret in **Settings -> Advanced -> Admin Access** on your device.
 
-When you click **Apply Update**, the button shows **Updating...**. The server fetches the new code, reinstalls dependencies, rebuilds, and then shuts down. You then see: "Update applied successfully. Please relaunch the app to use the new version." Start Marinara again to finish.
+When you click **Apply Update**, the button shows **Updating...**. The server fetches the new code, reinstalls dependencies, rebuilds, and then shuts down. You then see: "Update applied successfully. Please relaunch the app to use the new version." Start Guksu again to finish.
 
-If **Apply Update** is not available, Marinara shows why and what to do instead.
+If **Apply Update** is not available, Guksu shows why and what to do instead.
 
 - Container installs show the image tag and the `docker compose pull && docker compose up -d` command to run on the host.
 - Git installs with apply turned off show a manual update command you can copy.
@@ -187,12 +187,12 @@ Most upgrade problems come from an old Node.js version, a partial download, or a
 - If the app looks broken after the server updated, try the **Refresh App** button above.
 - If a git install cannot update cleanly, run your platform's manual update commands shown in that install guide.
 
-For error messages and step-by-step fixes, see [Troubleshooting Marinara Engine](TROUBLESHOOTING.md).
+For error messages and step-by-step fixes, see [Troubleshooting Guksu Motor](TROUBLESHOOTING.md).
 
 ## Related guides
 
-- [Backing Up and Restoring Marinara](data/backup-and-restore.md)
-- [Troubleshooting Marinara Engine](TROUBLESHOOTING.md)
+- [Backing Up and Restoring Guksu](data/backup-and-restore.md)
+- [Troubleshooting Guksu Motor](TROUBLESHOOTING.md)
 - [Windows Installation Guide](installation/windows.md)
 - [macOS / Linux Installation Guide](installation/macos-linux.md)
 - [Run via Container (Docker / Podman)](installation/containers.md)

--- a/docs/agents/agents-overview.md
+++ b/docs/agents/agents-overview.md
@@ -1,6 +1,6 @@
 # Agents: AI Helpers for Your Chats
 
-This guide explains what agents are in Marinara Engine, how to download them, when they run, and how to turn them on for a chat. It covers the **Agents** panel, the official catalog, per-chat settings, and how to tell when an agent has run. For the full first-party catalog, see the Related guides at the end.
+This guide explains what agents are in Guksu Motor, how to download them, when they run, and how to turn them on for a chat. It covers the **Agents** panel, the official catalog, per-chat settings, and how to tell when an agent has run. For the full first-party catalog, see the Related guides at the end.
 
 ## What agents are
 
@@ -8,7 +8,7 @@ Agents are small AI helpers that run automatically around your main chat reply. 
 
 Agents are turned on per chat, not per character. There is no agent toggle on a character card. Two chats with the same character can run completely different agents. You choose which agents run in each chat's settings.
 
-Fresh Marinara Engine installations start without optional agents. This keeps the base app and Termux installation smaller. The official v2.3.0+ catalog contains 29 one-click packages: 6 Writer Agents, 8 Tracker Agents, and 15 Misc Agents, including Maps, Calls, and all six Conversation games. Their source, manifests, downloadable artifacts, and repository-level catalog are public in [Pasta-Devs/Marinara-Agents](https://github.com/Pasta-Devs/Marinara-Agents). For the complete per-agent guide, see [Downloadable Agents Reference](built-in-agents.md). To make your own, see [Creating Custom Agents](custom-agents.md).
+Fresh Guksu Motor installations start without optional agents. This keeps the base app and Termux installation smaller. The official v2.3.0+ catalog contains 29 one-click packages: 6 Writer Agents, 8 Tracker Agents, and 15 Misc Agents, including Maps, Calls, and all six Conversation games. Their source, manifests, downloadable artifacts, and repository-level catalog are public in [Pasta-Devs/Marinara-Agents](https://github.com/Pasta-Devs/Marinara-Agents). For the complete per-agent guide, see [Downloadable Agents Reference](built-in-agents.md). To make your own, see [Creating Custom Agents](custom-agents.md).
 
 ## The three phases
 
@@ -22,15 +22,15 @@ Every agent runs at one of three points around your reply. This point is called 
 
 Open the **Agents** panel from the right-side panel tabs (the Sparkles icon). Here you browse, create, and organize agents. This is your library. It is not the on or off switch for a single chat.
 
-Click **Download Agents** at the top to open the full-screen official catalog. It works on desktop and mobile. Select an item to read its description, supported feature type, download size, permissions, version compatibility, and documentation. Click **Install** to add it; the same screen offers immediate manual updates and **Uninstall** for packages you already have. Marinara also checks every installed official package at server startup and upgrades it to the newest compatible catalog version before its runtime activates. Packages continue working at their current version when the host server is offline or an update cannot be verified.
+Click **Download Agents** at the top to open the full-screen official catalog. It works on desktop and mobile. Select an item to read its description, supported feature type, download size, permissions, version compatibility, and documentation. Click **Install** to add it; the same screen offers immediate manual updates and **Uninstall** for packages you already have. Guksu also checks every installed official package at server startup and upgrades it to the newest compatible catalog version before its runtime activates. Packages continue working at their current version when the host server is offline or an update cannot be verified.
 
-The in-app catalog is backed by the public [Marinara-Agents repository](https://github.com/Pasta-Devs/Marinara-Agents). You can inspect every package and artifact there, but normal users should install through **Download Agents** so Marinara can validate compatibility, permissions, hashes, archive contents, and restart requirements.
+The in-app catalog is backed by the public [Marinara-Agents repository](https://github.com/Pasta-Devs/Marinara-Agents). You can inspect every package and artifact there, but normal users should install through **Download Agents** so Guksu can validate compatibility, permissions, hashes, archive contents, and restart requirements.
 
 The catalog includes first-party chat agents, Hierarchical Maps, Conversation audio/video calls, and every optional Conversation game. Installed agents are grouped into **Writer Agents**, **Tracker Agents**, and **Misc Agents**, plus a **Custom Agents** section for ones you make. Uninstalling a catalog package removes its code and settings from the Engine while preserving chat messages and history. Deleting a custom agent removes it for good.
 
-When upgrading from an Engine version that bundled these features, Marinara downloads the matching packages once and preserves existing chat selections, agent settings, stored runtime data, and history. If that migration cannot reach the catalog, it retries at the next startup instead of discarding anything.
+When upgrading from an Engine version that bundled these features, Guksu downloads the matching packages once and preserves existing chat selections, agent settings, stored runtime data, and history. If that migration cannot reach the catalog, it retries at the next startup instead of discarding anything.
 
-Automatic startup updates never install an unselected package. Desktop, Docker, and Android/Termux installations update the packages stored by their local server. iOS, iPadOS, and other browser clients use the packages installed and updated by the Marinara server they connect to.
+Automatic startup updates never install an unselected package. Desktop, Docker, and Android/Termux installations update the packages stored by their local server. iOS, iPadOS, and other browser clients use the packages installed and updated by the Guksu server they connect to.
 
 ## Enabling agents for a chat
 
@@ -52,7 +52,7 @@ The **Agents** section has a few more controls:
 
 ### The cost warning
 
-Agents cost extra tokens and extra model calls. Each agent adds its own instructions, and often its own model call. Marinara groups agents that share the same connection into one call when it can. Above the agent list, a readout estimates the load for your current setup. It shows about how many tokens of agent instructions you added and about how many extra calls happen per turn.
+Agents cost extra tokens and extra model calls. Each agent adds its own instructions, and often its own model call. Guksu groups agents that share the same connection into one call when it can. Above the agent list, a readout estimates the load for your current setup. It shows about how many tokens of agent instructions you added and about how many extra calls happen per turn.
 
 This readout turns amber with a warning icon when the load gets heavy. The real cost per turn is higher than the number shown. Your chat history and character details are sent with each call. If you see the warning, remove agents you do not need, or move some to a cheaper or local connection.
 

--- a/docs/agents/built-in-agents.md
+++ b/docs/agents/built-in-agents.md
@@ -1,6 +1,6 @@
 # Downloadable Agents Reference
 
-This guide lists all 29 official first-party packages available through **Agents → Download Agents**, grouped by category. Agents do not ship inside a fresh Marinara Engine installation. Their package sources, manifests, artifacts, and machine-readable catalog are published in [Pasta-Devs/Marinara-Agents](https://github.com/Pasta-Devs/Marinara-Agents). For each one, this guide explains what the agent does, when it runs or integrates, which chat modes allow it, and the main settings. For installation and activation, read the [Agents overview](agents-overview.md) first.
+This guide lists all 29 official first-party packages available through **Agents → Download Agents**, grouped by category. Agents do not ship inside a fresh Guksu Motor installation. Their package sources, manifests, artifacts, and machine-readable catalog are published in [Pasta-Devs/Marinara-Agents](https://github.com/Pasta-Devs/Marinara-Agents). For each one, this guide explains what the agent does, when it runs or integrates, which chat modes allow it, and the main settings. For installation and activation, read the [Agents overview](agents-overview.md) first.
 
 ## How to read this reference
 
@@ -12,7 +12,7 @@ Each agent below shows three quick facts.
 - **Where it works**: the chat modes that let you add the agent. Most agents work in **Roleplay** chats. A few work in other modes, and each entry says which.
 - **Key settings**: the settings you are most likely to change. You set these when you add the agent, or later in the agent's setup card in **Chat Settings**.
 
-Marinara groups its agents into three categories in the **Agents** panel: **Writer Agents**, **Tracker Agents**, and **Misc Agents**. This reference uses the same grouping.
+Guksu groups its agents into three categories in the **Agents** panel: **Writer Agents**, **Tracker Agents**, and **Misc Agents**. This reference uses the same grouping.
 
 A run interval means the agent runs once every few assistant messages instead of after every message. You can change a run interval in the agent's setup, up to 100.
 
@@ -136,7 +136,7 @@ Adds persistent nested locations and spatial relationships to a story. You can a
 
 - **Integration**: Feature package; it contributes map UI and chat runtime context instead of running as a normal generation-phase agent.
 - **Where it works**: Roleplay and Game.
-- **Key settings**: enable it for the Roleplay chat from **Chat Settings → Agents**, or select it during Game creation and manage it later from that game's settings. Installing or removing it requires a Marinara restart.
+- **Key settings**: enable it for the Roleplay chat from **Chat Settings → Agents**, or select it during Game creation and manage it later from that game's settings. Installing or removing it requires a Guksu restart.
 - **Full guide**: [Hierarchical Maps: Setup, Authoring, and Travel](hierarchical-maps.md).
 
 ## Misc agents
@@ -213,7 +213,7 @@ Adds live audio and video calls with Conversation characters, including user-sta
 
 - **Integration**: Conversation feature package; it adds toolbar, chat-surface, and Chat Settings controls instead of running as a normal generation-phase agent.
 - **Where it works**: Conversation.
-- **Key settings**: open **Chat Settings → Agents → Calls** to enable calls and choose speech, microphone, ringing, and video behavior. See [Conversation Audio and Video Calls](../conversation/calls.md). Installing or removing it requires a Marinara restart.
+- **Key settings**: open **Chat Settings → Agents → Calls** to enable calls and choose speech, microphone, ringing, and video behavior. See [Conversation Audio and Video Calls](../conversation/calls.md). Installing or removing it requires a Guksu restart.
 
 ### UNO
 
@@ -221,7 +221,7 @@ Adds a rules-enforced UNO table for you and Conversation characters, with config
 
 - **Integration**: Conversation game package.
 - **Where it works**: Conversation.
-- **Key settings**: start it from the games picker or with `/uno`; the setup chooses players and house rules. Installing or removing it requires a Marinara restart.
+- **Key settings**: start it from the games picker or with `/uno`; the setup chooses players and house rules. Installing or removing it requires a Guksu restart.
 
 ### Chess
 
@@ -229,7 +229,7 @@ Adds a one-on-one Chess board with legal move enforcement, check and checkmate d
 
 - **Integration**: Conversation game package.
 - **Where it works**: Conversation.
-- **Key settings**: start it from the games picker or with `/chess`, then choose the opponent and which side you play. Installing or removing it requires a Marinara restart.
+- **Key settings**: start it from the games picker or with `/chess`, then choose the opponent and which side you play. Installing or removing it requires a Guksu restart.
 
 ### Poker
 
@@ -237,7 +237,7 @@ Adds a Texas Hold'em table for two to eight total players, with blinds, betting 
 
 - **Integration**: Conversation game package.
 - **Where it works**: Conversation.
-- **Key settings**: start it from the games picker or with `/poker`, then choose the players, starting chips, and blind values. Installing or removing it requires a Marinara restart.
+- **Key settings**: start it from the games picker or with `/poker`, then choose the players, starting chips, and blind values. Installing or removing it requires a Guksu restart.
 
 ### 8-Ball Pool
 
@@ -245,7 +245,7 @@ Adds a one-on-one pool table with solids and stripes, aiming and shot strength, 
 
 - **Integration**: Conversation game package.
 - **Where it works**: Conversation.
-- **Key settings**: start it from the games picker or with `/8ball`, then choose the opponent. Installing or removing it requires a Marinara restart.
+- **Key settings**: start it from the games picker or with `/8ball`, then choose the opponent. Installing or removing it requires a Guksu restart.
 
 ### Tic-Tac-Toe
 
@@ -253,7 +253,7 @@ Adds a one-on-one Tic-Tac-Toe board with selectable or random marks, legal turn 
 
 - **Integration**: Conversation game package.
 - **Where it works**: Conversation.
-- **Key settings**: start it from the games picker or with `/tictactoe` (alias `/ttt`), then choose the opponent and mark. Installing or removing it requires a Marinara restart.
+- **Key settings**: start it from the games picker or with `/tictactoe` (alias `/ttt`), then choose the opponent and mark. Installing or removing it requires a Guksu restart.
 
 ### Rock-Paper-Scissors
 
@@ -261,7 +261,7 @@ Adds a one-on-one Rock-Paper-Scissors match where both choices stay hidden until
 
 - **Integration**: Conversation game package.
 - **Where it works**: Conversation.
-- **Key settings**: start it from the games picker or with `/rps`, then choose the opponent and a best-of-three, five, or seven match. Installing or removing it requires a Marinara restart.
+- **Key settings**: start it from the games picker or with `/rps`, then choose the opponent and a best-of-three, five, or seven match. Installing or removing it requires a Guksu restart.
 
 ## Related guides
 

--- a/docs/agents/custom-agents.md
+++ b/docs/agents/custom-agents.md
@@ -1,12 +1,12 @@
 # Creating Custom Agents
 
-This guide shows you how to build your own agent in Marinara Engine. An agent is a small AI helper that runs automatically alongside your chat. You will learn how to set its phase, powers, output type, activation keywords, tools, and prompt, with one full worked example.
+This guide shows you how to build your own agent in Guksu Motor. An agent is a small AI helper that runs automatically alongside your chat. You will learn how to set its phase, powers, output type, activation keywords, tools, and prompt, with one full worked example.
 
 New to agents? Read [Agents: AI Helpers for Your Chats](agents-overview.md) first for the basics, then come back here.
 
 ## When to build a custom agent
 
-Marinara Engine offers many official downloadable agents. See the [Downloadable Agents Reference](built-in-agents.md) and the public [Pasta-Devs/Marinara-Agents](https://github.com/Pasta-Devs/Marinara-Agents) package repository before you build your own. A catalog agent may already do what you want, and the official manifests provide working package examples.
+Guksu Motor offers many official downloadable agents. See the [Downloadable Agents Reference](built-in-agents.md) and the public [Pasta-Devs/Marinara-Agents](https://github.com/Pasta-Devs/Marinara-Agents) package repository before you build your own. A catalog agent may already do what you want, and the official manifests provide working package examples.
 
 Build a custom agent when you need something the built-ins do not cover. Good reasons include:
 
@@ -74,7 +74,7 @@ If you turn on **Edit lorebooks**, a **Lorebook Writer** section appears. Turn o
 
 ## Result Type
 
-The **Result Type** tells Marinara how to read your agent's output. Most result types expect the agent to return JSON. JSON is a simple text format written with braces and quotation marks. Each result type needs the matching ability from the table above.
+The **Result Type** tells Guksu how to read your agent's output. Most result types expect the agent to return JSON. JSON is a simple text format written with braces and quotation marks. Each result type needs the matching ability from the table above.
 
 | Result Type | What it does | Ability needed |
 |---|---|---|
@@ -170,7 +170,7 @@ The agent returns JSON like this after each reply:
 {"editedText":"The colour of the harbour caught her eye.","changes":[{"description":"color to colour, harbor to harbour"}]}
 ```
 
-Marinara reads `editedText` and swaps it into the reply. You see the message in British English. The `changes` notes appear as a short summary of what the agent adjusted.
+Guksu reads `editedText` and swaps it into the reply. You see the message in British English. The `changes` notes appear as a short summary of what the agent adjusted.
 
 ## Importing and exporting agents
 

--- a/docs/agents/hierarchical-maps.md
+++ b/docs/agents/hierarchical-maps.md
@@ -1,7 +1,7 @@
 # Hierarchical Maps: Setup, Authoring, and Travel
 
 > **Current compatibility:** This guide matches Hierarchical Maps **1.1.5** on
-> Marinara Engine **2.3.3**. Maps 1.1.5 supports Engine 2.3.2 through the current
+> Guksu Motor **2.3.3**. Maps 1.1.5 supports Engine 2.3.2 through the current
 > 2.x releases. The package supports Roleplay and Game chats.
 
 Hierarchical Maps adds a persistent story map to Roleplay and Game chats. Instead of keeping one free-text location, it can represent a world as nested places:
@@ -15,7 +15,7 @@ The Shattered Coast
     └── Old Sewers
 ```
 
-Marinara keeps an authoritative current location in this hierarchy. The current path, exact location details, nearby destinations, and eligible lore linked to the exact current location can be included in the next reply's context. The AI cannot move the story merely by narrating that the party went somewhere; you choose a destination and commit the move with your next turn.
+Guksu keeps an authoritative current location in this hierarchy. The current path, exact location details, nearby destinations, and eligible lore linked to the exact current location can be included in the next reply's context. The AI cannot move the story merely by narrating that the party went somewhere; you choose a destination and commit the move with your next turn.
 
 Hierarchical Maps works in **Roleplay** and **Game**. Each chat has its own map and current location.
 
@@ -45,7 +45,7 @@ A 25-floor tower should normally model the floors as 25 siblings under one tower
 ## Quick start
 
 1. Open the **Agents** panel, click **Download Agents**, and install **Hierarchical Maps**. If the catalog then offers **Update**, install that too.
-2. Restart Marinara when the catalog asks.
+2. Restart Guksu when the catalog asks.
 3. Open the Roleplay or Game chat where the map should live.
 4. Open **Agents → Hierarchical Maps**, turn on **Use in this chat**, and click **Create map**. You can also activate it through **Chat Settings → Agents → Tracker Agents** and open **Hierarchical map** there.
 5. Choose **Draft with AI**, describe what you want, and click **Generate draft**.
@@ -75,7 +75,7 @@ The installed feature also appears as **Hierarchical Maps** in the main **Agents
 
 ### Game
 
-You can select Hierarchical Maps while creating a game, or add it later from that game's **Chat Settings → Agents** section. When selected during setup, Marinara can prepare a hierarchy from the accepted game world for you to review before play.
+You can select Hierarchical Maps while creating a game, or add it later from that game's **Chat Settings → Agents** section. When selected during setup, Guksu can prepare a hierarchy from the accepted game world for you to review before play.
 
 If you skip the generated map during setup, you can still build one later from Chat Settings.
 
@@ -122,11 +122,11 @@ If you do not like the generated result, use **Edit prompt**, **Regenerate**, or
 
 If a map exists but the story has no committed map history yet, the AI builder can also **Replace draft**. After the campaign has used the map, replacement is protected: expand the existing hierarchy instead so saved turns keep referring to the same location IDs.
 
-For a saved map that has not been used in a turn, open **Expand with AI**, choose **Replace draft**, and generate a replacement. Once committed history exists, Marinara allows expansion but not wholesale replacement. Export the map before major restructuring.
+For a saved map that has not been used in a turn, open **Expand with AI**, choose **Replace draft**, and generate a replacement. Once committed history exists, Guksu allows expansion but not wholesale replacement. Export the map before major restructuring.
 
 ## Build or edit a map manually
 
-From an empty map, click **Build manually**. Marinara creates one broad starting location. Select it in the hierarchy, then use:
+From an empty map, click **Build manually**. Guksu creates one broad starting location. Select it in the hierarchy, then use:
 
 - **Add child** for a place inside the selected location.
 - **Add sibling** for a place beside it under the same parent.
@@ -275,7 +275,7 @@ Archived locations can be restored from the Details pane.
 
 ### Hierarchical Maps is missing from Chat Settings
 
-Check that the package is installed, that Marinara was restarted after installation, and that the chat is Roleplay or Game. In the chat, turn on the **Enable Agents** master switch, open **Tracker Agents**, and enable **Hierarchical Maps**. Then scroll back to the **Hierarchical map** setting that appears.
+Check that the package is installed, that Guksu was restarted after installation, and that the chat is Roleplay or Game. In the chat, turn on the **Enable Agents** master switch, open **Tracker Agents**, and enable **Hierarchical Maps**. Then scroll back to the **Hierarchical map** setting that appears.
 
 ### The map cannot be enabled
 

--- a/docs/agents/knowledge-sources.md
+++ b/docs/agents/knowledge-sources.md
@@ -1,6 +1,6 @@
 # Knowledge Sources: Retrieval and Router Agents
 
-This guide explains the two Knowledge agents in Marinara Engine: **Knowledge Retrieval** and **Knowledge Router**. Both pull facts from your lorebooks into a chat only when a scene needs them. This way you do not have to put every detail into every prompt.
+This guide explains the two Knowledge agents in Guksu Motor: **Knowledge Retrieval** and **Knowledge Router**. Both pull facts from your lorebooks into a chat only when a scene needs them. This way you do not have to put every detail into every prompt.
 
 ## What these agents do
 
@@ -8,7 +8,7 @@ A lorebook is a set of world or character notes you write ahead of time. Each no
 
 Knowledge agents solve this with RAG. RAG stands for retrieval-augmented generation. It means the app finds the entries that fit the current scene, then adds only those to the prompt for that one turn.
 
-Marinara does this with two optional agents:
+Guksu does this with two optional agents:
 
 - **Knowledge Retrieval** reads your chosen sources, summarizes the facts that matter, and adds the summary to the prompt.
 - **Knowledge Router** reads a short list of your entries, picks the ones that fit the scene, and adds those entries word for word.
@@ -28,7 +28,7 @@ Use this table to choose. Read the notes below it before you decide.
 
 **Knowledge Retrieval** reads every enabled entry in your chosen lorebooks, plus the text of any files you upload. It then asks the AI to write a short summary of the facts that fit the recent messages. This costs more per turn because the AI reads the full source material.
 
-**Knowledge Router** is the cheaper option. It builds a small catalog of your entries. Each catalog line holds an ID, a name, a few keywords, and a short summary. The AI reads that catalog, picks the entries that fit the scene, and Marinara adds those entries in full. The AI never reads every entry in full, so the router stays cheap even with a big lorebook.
+**Knowledge Router** is the cheaper option. It builds a small catalog of your entries. Each catalog line holds an ID, a name, a few keywords, and a short summary. The AI reads that catalog, picks the entries that fit the scene, and Guksu adds those entries in full. The AI never reads every entry in full, so the router stays cheap even with a big lorebook.
 
 You can add both agents to one chat, but they may add overlapping content and raise your token cost. The agent editor warns you when both are set up. For cleaner prompts, pick one.
 

--- a/docs/agents/memory.md
+++ b/docs/agents/memory.md
@@ -1,10 +1,10 @@
 # Memory Recall and Chat Summaries
 
-This guide explains how Marinara Engine helps a long chat stay coherent after it grows past what the AI model can read at once. It covers **Memory Recall** (semantic search over past messages), **Chat Summary** for Roleplay chats, and **Automatic Summarization** for Conversation chats.
+This guide explains how Guksu Motor helps a long chat stay coherent after it grows past what the AI model can read at once. It covers **Memory Recall** (semantic search over past messages), **Chat Summary** for Roleplay chats, and **Automatic Summarization** for Conversation chats.
 
 ## The two memory systems
 
-Every AI model can only read a limited amount of text at one time. That limit is called the context window. When a chat gets long, the oldest messages fall out of that window and the AI forgets them. Marinara Engine (called Marinara after this) has two separate systems that fix this.
+Every AI model can only read a limited amount of text at one time. That limit is called the context window. When a chat gets long, the oldest messages fall out of that window and the AI forgets them. Guksu Motor (called Guksu after this) has two separate systems that fix this.
 
 - **Memory Recall** searches your older messages for the parts most related to what you just said, then quietly adds those parts back into the prompt. It works in every chat mode.
 - **Summaries** compress old messages into short recaps that replace the raw messages in the prompt. Roleplay chats use **Chat Summary**. Conversation chats use **Automatic Summarization**.
@@ -15,7 +15,7 @@ You can use both systems at the same time. They do different jobs and do not con
 
 ## Memory Recall setup
 
-**Memory Recall** finds relevant fragments from earlier in a chat and injects them into the prompt as memories. It uses an embedding: a numeric fingerprint of a message's meaning. Marinara compares the fingerprint of your new message against stored fingerprints of past messages, then adds the closest matches.
+**Memory Recall** finds relevant fragments from earlier in a chat and injects them into the prompt as memories. It uses an embedding: a numeric fingerprint of a message's meaning. Guksu compares the fingerprint of your new message against stored fingerprints of past messages, then adds the closest matches.
 
 ### Turning Memory Recall on
 
@@ -41,9 +41,9 @@ Memory Recall needs an embedding source to build those meaning fingerprints. You
 4. Optionally set an **Embedding Endpoint URL** to override the address.
 5. Optionally use the **Embedding Connection** dropdown to borrow another connection's key and address. Options include **Same as this connection** and **Local Model (sidecar)**.
 
-Some providers do not offer embeddings. In that case Marinara shows a note asking you to pick a dedicated embedding connection, such as an OpenAI-compatible one, Google, or the Local Model.
+Some providers do not offer embeddings. In that case Guksu shows a note asking you to pick a dedicated embedding connection, such as an OpenAI-compatible one, Google, or the Local Model.
 
-If you set no embedding connection at all, Marinara falls back to a built-in local embedding model. It downloads this model one time and runs it on your own machine, with no API key needed. For more on the built-in model, see [Local Model Setup](../connections/local-model.md).
+If you set no embedding connection at all, Guksu falls back to a built-in local embedding model. It downloads this model one time and runs it on your own machine, with no API key needed. For more on the built-in model, see [Local Model Setup](../connections/local-model.md).
 
 This same **Semantic Search (Embeddings)** setting also powers Lorebook semantic search, so setting it up once helps both features.
 
@@ -68,14 +68,14 @@ The toolbar has icons to export memories, import memories, rebuild memories, and
 
 Keep these points in mind:
 
-- Marinara stores memory chunks in the background whenever an embedding source is available, even if **Enable Memory Recall** is off. The toggle only controls whether stored memories get injected. To stop storing memories, remove the embedding source or clear the memories from time to time.
+- Guksu stores memory chunks in the background whenever an embedding source is available, even if **Enable Memory Recall** is off. The toggle only controls whether stored memories get injected. To stop storing memories, remove the embedding source or clear the memories from time to time.
 - A chunk needs at least 5 new messages before it is created. Smaller batches wait for the next reply.
 - Recalled fragments must be closely related enough to pass a similarity check. Weak matches are skipped, so recall can return nothing even when memories exist.
 - Only a small budget of the prompt is used for recalled memories, so only the most relevant few are ever added.
 - If you change the embedding model after memories already exist, the old chunks no longer match. Use the rebuild icon to remake them.
 - Deleting a chat's messages also deletes its memory chunks.
 
-Some container builds of Marinara, known as Marinara Lite, turn Memory Recall off completely. On those builds the **Memory Recall** section does not appear at all.
+Some container builds of Guksu, known as Guksu Lite, turn Memory Recall off completely. On those builds the **Memory Recall** section does not appear at all.
 
 ## Chat Summary (Roleplay)
 
@@ -142,7 +142,7 @@ Two settings in the **Automatic Summarization** section shape how days are split
 - **Day Rollover Hour**: the hour when a new day begins for summaries. The default is 4 AM, and you can pick any hour from 12 AM (midnight) through 11 AM. Messages sent before this hour count as part of the previous day. Pick a time when you are never chatting so a late-night session is not cut in half.
 - **Recent Message Tail**: how many of today's newest messages stay word-for-word even after they are summarized. The default is 10, and the range is 0 to 50.
 
-If you change **Day Rollover Hour** after summaries already exist, Marinara warns you that older summaries used the previous setting.
+If you change **Day Rollover Hour** after summaries already exist, Guksu warns you that older summaries used the previous setting.
 
 ### Filling in missing days
 
@@ -171,4 +171,4 @@ Changing the connection or model used for summaries does not rewrite day or week
 - [Connecting to an AI Provider](../connections/connecting-to-a-provider.md)
 - [Conversation Mode: Getting Started](../conversation/getting-started.md)
 - [Roleplay Mode: Getting Started](../roleplay/getting-started.md)
-- [Troubleshooting Marinara Engine](../TROUBLESHOOTING.md)
+- [Troubleshooting Guksu Motor](../TROUBLESHOOTING.md)

--- a/docs/appearance/appearance-settings.md
+++ b/docs/appearance/appearance-settings.md
@@ -1,6 +1,6 @@
 # Appearance Settings
 
-This guide walks through the **Settings -> Appearance** tab in Marinara Engine section by section. It covers colors, text size, chat layout, message styling for each mode, and how to reset everything to the defaults.
+This guide walks through the **Settings -> Appearance** tab in Guksu Motor section by section. It covers colors, text size, chat layout, message styling for each mode, and how to reset everything to the defaults.
 
 Fonts, backgrounds, and custom CSS themes each have their own guide. This page links to them where they belong.
 
@@ -24,7 +24,7 @@ Several colors below have separate dark and light defaults. They follow the acti
 
 **Visual Style** picks the overall look of the whole app. You choose between two cards:
 
-- **Default (Marinara)** (the default). A retro Y2K look with glow effects.
+- **Default (Guksu)** (the default). A retro Y2K look with glow effects.
 - **SillyTavern**. A clean, minimal look inspired by the original SillyTavern.
 
 This is only a skin. It has nothing to do with importing data from SillyTavern, which is a separate tool.
@@ -47,7 +47,7 @@ You can only use one of these at a time. Turning on **RGB Mode** turns off **Acc
 
 ## Custom Mouse Pointer
 
-**Custom Mouse Pointer** (default on) uses Marinara's accent-colored cursor across the app. Turn it off to use your normal system cursor, or to let a custom CSS theme control the cursor.
+**Custom Mouse Pointer** (default on) uses Guksu's accent-colored cursor across the app. Turn it off to use your normal system cursor, or to let a custom CSS theme control the cursor.
 
 ## Display Size and Chat Font Size
 
@@ -117,7 +117,7 @@ The **Backgrounds** section lets you import and choose chat background images an
 
 ## Reset Appearance
 
-The **Reset Appearance** button sits at the top of the **App Style** section. It resets the entire **Appearance** tab back to Marinara defaults. This includes colors, text sizes, layout, avatar and sprite scales, and gradients.
+The **Reset Appearance** button sits at the top of the **App Style** section. It resets the entire **Appearance** tab back to Guksu defaults. This includes colors, text sizes, layout, avatar and sprite scales, and gradients.
 
 Reset also clears the current chat's background and turns off any active custom theme from the Theme Library. Use it when your styling gets messy and you want a clean start.
 

--- a/docs/appearance/card-css-theming.md
+++ b/docs/appearance/card-css-theming.md
@@ -1,6 +1,6 @@
 # Card CSS Theming Guide
 
-This guide shows character and persona creators how to give a card its own look in chat. You embed CSS in the card's Creator Notes, and Marinara Engine applies it safely to that character's messages. It can only ever style the chat, never the rest of the app.
+This guide shows character and persona creators how to give a card its own look in chat. You embed CSS in the card's Creator Notes, and Guksu Motor applies it safely to that character's messages. It can only ever style the chat, never the rest of the app.
 
 ## Before you start
 
@@ -12,7 +12,7 @@ A few plain definitions used throughout this guide:
 - A **selector** is the part of a CSS rule that picks which elements to style.
 - A **descendant selector** uses a space to mean "inside". `.a .b` matches a `.b` that sits inside an `.a`.
 - The **cascade** is the CSS system that decides which rule wins when several rules apply to the same element.
-- A **layout** is how messages are arranged on screen. Marinara has a **Linear** row layout and a **Bubbles** layout.
+- A **layout** is how messages are arranged on screen. Guksu has a **Linear** row layout and a **Bubbles** layout.
 
 ## Quick Start
 
@@ -59,7 +59,7 @@ The character's name glows pink and their text goes soft pink in every layout. T
 
 ## How Card Theming works
 
-When a character with CSS in their **Creator Notes** is active, Marinara does four things:
+When a character with CSS in their **Creator Notes** is active, Guksu does four things:
 
 1. It reads every `<style>` block from the **Creator Notes**.
 2. It sanitizes the CSS and strips anything dangerous. See the "What you cannot style" section below.
@@ -78,7 +78,7 @@ Use **Exclusive** for group chats where each character has its own look. Use **C
 
 ## The one scoping rule that matters
 
-Marinara rewrites your CSS so it can only reach the chat. How it rewrites it depends on the mode.
+Guksu rewrites your CSS so it can only reach the chat. How it rewrites it depends on the mode.
 
 - **Chat** mode scopes everything under the chat area. `.mari-message-bubble` matches normally, because it sits inside the area.
 - **Exclusive** mode scopes everything under each of your character's own message elements. Those carry `data-card-css`. A class on that same element cannot match it as a descendant. Only things inside it can.
@@ -506,7 +506,7 @@ Swap the colors, the `content` glyph, and the fonts to make it your own.
 If you would rather not hand-write CSS, give an AI assistant this prompt. Fill in your character concept where marked.
 
 ```text
-I'm creating a character card for Marinara Engine (an AI chat app). The card has a
+I'm creating a character card for Guksu Motor (an AI chat app). The card has a
 "Creator Notes" field where I can embed <style> blocks. Write CSS that themes the
 character's messages.
 

--- a/docs/appearance/chat-backgrounds.md
+++ b/docs/appearance/chat-backgrounds.md
@@ -1,6 +1,6 @@
 # Chat Backgrounds
 
-This guide covers the background library in Marinara Engine. These are images you upload and pick from by hand to sit behind your chat. For the **Background** agent that picks a scene backdrop for you each turn, see [Roleplay Backgrounds](../roleplay/backgrounds.md). For AI-generated scene backgrounds you make from the Gallery, see [Scene Backgrounds and the Gallery](../media/scene-backgrounds.md).
+This guide covers the background library in Guksu Motor. These are images you upload and pick from by hand to sit behind your chat. For the **Background** agent that picks a scene backdrop for you each turn, see [Roleplay Backgrounds](../roleplay/backgrounds.md). For AI-generated scene backgrounds you make from the Gallery, see [Scene Backgrounds and the Gallery](../media/scene-backgrounds.md).
 
 ## Where to find backgrounds
 
@@ -16,10 +16,10 @@ A chat background only shows in Roleplay and Game mode chats. Conversation mode 
 
 ## The background library
 
-The library holds every image you can pick from. It mixes images you uploaded with the built-in art bundled with Marinara. Each image shows a small label so you can tell them apart:
+The library holds every image you can pick from. It mixes images you uploaded with the built-in art bundled with Guksu. Each image shows a small label so you can tell them apart:
 
 - **Library**: an image you uploaded yourself. You can rename, tag, and delete these.
-- **Game asset**: a built-in image bundled with Marinara. These are read-only. You cannot rename, tag, or delete them.
+- **Game asset**: a built-in image bundled with Guksu. These are read-only. You cannot rename, tag, or delete them.
 
 ### Import a background
 
@@ -30,7 +30,7 @@ The library holds every image you can pick from. It mixes images you uploaded wi
 
 You can import several files at once. Each file must be an image in one of these formats: JPG, PNG, GIF, WebP, or AVIF. Each file can be up to 20 MB.
 
-Marinara checks the real contents of every file, not just its name. If you rename a non-image file to end in `.png`, the upload is rejected.
+Guksu checks the real contents of every file, not just its name. If you rename a non-image file to end in `.png`, the upload is rejected.
 
 ### Pick a background for the current chat
 
@@ -49,7 +49,7 @@ Use the selector beside search to sort backgrounds **A-Z**, **Z-A**, **Newest**,
 
 Folders organize the library without moving or hiding the underlying image files.
 
-1. Click **New Folder**. Marinara creates a uniquely named folder.
+1. Click **New Folder**. Guksu creates a uniquely named folder.
 2. Double-click or double-tap the folder name to rename it. You can also focus it and press F2.
 3. On desktop, drag a background row into a folder. On a phone or tablet, drag it by the visible grip handle.
 4. Drag a background back into the unfiled area to remove it from its folder.
@@ -71,13 +71,13 @@ You can only rename images with the **Library** label.
 Tags help you group and search your uploads. You can only tag images with the **Library** label.
 
 1. Click the tag icon (**Edit tags**) on the image row.
-2. Type a tag in the **Add tag...** field. As you type, Marinara suggests tags you used before.
+2. Type a tag in the **Add tag...** field. As you type, Guksu suggests tags you used before.
 3. Press Enter or click **Add**.
 4. To remove a tag, click the small X on that tag chip.
 
 ### Delete a background
 
-You can only delete images with the **Library** label. Hover over the image row and click the trash icon, then confirm the deletion. If the image was the current chat background or the default Roleplay background, Marinara switches back to the built-in default for you.
+You can only delete images with the **Library** label. Hover over the image row and click the trash icon, then confirm the deletion. If the image was the current chat background or the default Roleplay background, Guksu switches back to the built-in default for you.
 
 ## Setting a default Roleplay background
 

--- a/docs/appearance/custom-css-themes.md
+++ b/docs/appearance/custom-css-themes.md
@@ -1,19 +1,19 @@
 # Custom CSS Themes (Theme Library)
 
-This guide explains how to change the whole look of Marinara Engine with a custom CSS theme. You will learn how to create, import, export, and activate themes. You will also see which CSS variables you can change and how themes work with extensions and Card CSS.
+This guide explains how to change the whole look of Guksu Motor with a custom CSS theme. You will learn how to create, import, export, and activate themes. You will also see which CSS variables you can change and how themes work with extensions and Card CSS.
 
 ## What a custom theme is
 
-A custom theme is a block of CSS that repaints Marinara. CSS, short for Cascading Style Sheets, is the code that sets colors, borders, and spacing across the app. A theme can change the page background, the accent color, cards, borders, text, and more.
+A custom theme is a block of CSS that repaints Guksu. CSS, short for Cascading Style Sheets, is the code that sets colors, borders, and spacing across the app. A theme can change the page background, the accent color, cards, borders, text, and more.
 
-Custom themes live in the **Theme Library**. They are stored on your Marinara server, so they sync to every device and browser that connects to the same server. This is different from most other appearance settings, which stay on one device. For the per-device settings, see the [Appearance Settings](appearance-settings.md) guide.
+Custom themes live in the **Theme Library**. They are stored on your Guksu server, so they sync to every device and browser that connects to the same server. This is different from most other appearance settings, which stay on one device. For the per-device settings, see the [Appearance Settings](appearance-settings.md) guide.
 
 Only one custom theme can be active at a time. You can keep as many themes in your library as you like and switch between them.
 
 ## Where to find the Theme Library
 
 1. Open **Settings**.
-2. Open the **Addons** tab. The tab opens with the line "Extensions add trusted browser or server behavior; custom themes change Marinara's look."
+2. Open the **Addons** tab. The tab opens with the line "Extensions add trusted browser or server behavior; custom themes change Guksu's look."
 3. Scroll past the **Extension Library** section. The **Theme Library** section sits below it.
 
 The section is titled **Theme Library** and reads "Create, import, activate, edit, export, or remove custom CSS themes."
@@ -26,7 +26,7 @@ The section is titled **Theme Library** and reads "Create, import, activate, edi
 4. Leave **Preview** on to see your changes live in the app as you type. Turn **Preview** off to stop the live preview.
 5. Click **Save**.
 
-A new theme starts from a template. The template lists common variables as commented-out examples, so you can remove the comment marks and set your own values. When you save a brand new theme, Marinara activates it right away. It also shows a confirmation with the theme name, like: Theme "My Theme" saved and activated.
+A new theme starts from a template. The template lists common variables as commented-out examples, so you can remove the comment marks and set your own values. When you save a brand new theme, Guksu activates it right away. It also shows a confirmation with the theme name, like: Theme "My Theme" saved and activated.
 
 To change a theme later, find it in the **Installed Themes** list. Click the code icon (its tooltip reads **Edit theme CSS**), make your edits, and click **Save**. Editing a saved theme updates it but does not change which theme is active.
 
@@ -42,7 +42,7 @@ To import a theme:
 
 A `.css` file becomes one theme, named after the file. A `.json` file can hold one or more themes, and it comes in two kinds.
 
-The first kind is a file exported from Marinara. It wraps each theme in extra fields that Marinara adds on export. You do not need to read or edit it. Import the file as-is.
+The first kind is a file exported from Guksu. It wraps each theme in extra fields that Guksu adds on export. You do not need to read or edit it. Import the file as-is.
 
 The second kind is a small file you write yourself. For a single theme, this is enough:
 
@@ -52,14 +52,14 @@ The second kind is a small file you write yourself. For a single theme, this is 
 
 Imported themes sync to your server, but they do not activate on their own. A theme that already exists on the server, with the same name and the same CSS, is skipped instead of added twice.
 
-To export a theme, find it in the **Installed Themes** list and click the upload icon (its tooltip reads **Export theme**). Marinara downloads a `.json` file that you can import somewhere else.
+To export a theme, find it in the **Installed Themes** list and click the upload icon (its tooltip reads **Export theme**). Guksu downloads a `.json` file that you can import somewhere else.
 
 ## Activating a theme
 
 The **Installed Themes** list shows every theme, plus a **Default Theme** entry at the top.
 
 1. Click a theme's name to make it active. A check mark shows the active theme.
-2. Click **Default Theme** to turn off custom theming and return to Marinara's built-in look.
+2. Click **Default Theme** to turn off custom theming and return to Guksu's built-in look.
 
 The **Reset Appearance** button sits at the top of the **App Style** section in **Settings -> Appearance**. It also turns off the active custom theme when you use it.
 
@@ -86,7 +86,7 @@ The theme editor has a collapsible **CSS Variable Reference**. Click it to see t
 | `--popover` | Dropdown background |
 | `--accent` | Hover highlights |
 
-You are not limited to this list. A theme can set any CSS variable Marinara uses, and it can add other custom styles too.
+You are not limited to this list. A theme can set any CSS variable Guksu uses, and it can add other custom styles too.
 
 Some visual effects have their own variables. For example, a theme can request the accent pulse animation by setting `--marinara-theme-accent-pulse: enabled`.
 
@@ -98,9 +98,9 @@ A theme name can be up to 200 characters. The CSS payload can be up to 256 KiB, 
 
 ## Admin Access for remote installs
 
-Creating, editing, importing, activating, and removing a theme are protected actions. This matters only when you open Marinara over a network.
+Creating, editing, importing, activating, and removing a theme are protected actions. This matters only when you open Guksu over a network.
 
-If you open Marinara on the same computer that runs the server, using loopback (also called localhost), these actions just work. If you open Marinara from another device, such as a phone or a computer on your network, the server needs an admin secret first.
+If you open Guksu on the same computer that runs the server, using loopback (also called localhost), these actions just work. If you open Guksu from another device, such as a phone or a computer on your network, the server needs an admin secret first.
 
 To manage themes over a network:
 
@@ -111,9 +111,9 @@ Without this, theme changes over a network fail. For the full setup, see the [Se
 
 ## How themes, extensions, and Card CSS work together
 
-Marinara has three ways to add custom CSS. They are separate features and can all be active at once.
+Guksu has three ways to add custom CSS. They are separate features and can all be active at once.
 
-A custom theme repaints the whole app. It is allowed to override Marinara's core variables, use `!important`, and use `position: fixed`. That is the point of a theme.
+A custom theme repaints the whole app. It is allowed to override Guksu's core variables, use `!important`, and use `position: fixed`. That is the point of a theme.
 
 Extensions can also inject CSS into the page. You manage them in **Settings -> Addons -> Extension Library**, right above the Theme Library. Extension CSS follows the same rules as theme CSS, so an enabled extension can also change how the app looks. See the [Extensions guide](../extending/extensions.md).
 

--- a/docs/appearance/fonts.md
+++ b/docs/appearance/fonts.md
@@ -1,6 +1,6 @@
 # Custom Fonts and Google Fonts
 
-This guide shows how to change the font Marinara Engine uses across the app. You can pick the built-in font, add your own font files, or download a font from Google Fonts by name.
+This guide shows how to change the font Guksu Motor uses across the app. You can pick the built-in font, add your own font files, or download a font from Google Fonts by name.
 
 ## Choosing an app font
 
@@ -13,27 +13,27 @@ The font setting lives in **Settings**, under the **Appearance** tab, in the **T
 
 The default choice is **Default (Inter)**. Inter is a clean font chosen for on-screen reading. Any custom fonts you add appear in the same **Font** dropdown, below the default option.
 
-Your font choice syncs across devices. When you pick a font, every browser and device connected to the same Marinara server switches to it. To learn how this sync works, see the [Settings Overview](../settings/settings-overview.md) guide.
+Your font choice syncs across devices. When you pick a font, every browser and device connected to the same Guksu server switches to it. To learn how this sync works, see the [Settings Overview](../settings/settings-overview.md) guide.
 
 ## Adding your own fonts
 
-You can add a custom font by dropping a font file into a folder on the server. This is the machine that runs Marinara.
+You can add a custom font by dropping a font file into a folder on the server. This is the machine that runs Guksu.
 
-1. Find the `data/fonts/` folder inside Marinara's data folder on the server machine.
+1. Find the `data/fonts/` folder inside Guksu's data folder on the server machine.
 2. Copy your font file into that folder.
 3. Go back to **Settings**, then **Appearance**, then **Text & Scale**.
 4. Open the **Font** dropdown. Your font now appears in the list.
 5. Select it.
 
-Marinara reads these font file types: `.ttf`, `.otf`, `.woff`, and `.woff2`. Files with any other extension are ignored.
+Guksu reads these font file types: `.ttf`, `.otf`, `.woff`, and `.woff2`. Files with any other extension are ignored.
 
-Marinara builds a display name from the file name. For example, a file named `OpenSans-Bold.ttf` shows up as "Open Sans". So name your files in a clear way if you want a tidy list.
+Guksu builds a display name from the file name. For example, a file named `OpenSans-Bold.ttf` shows up as "Open Sans". So name your files in a clear way if you want a tidy list.
 
-Font files in the `data/fonts/` folder live on the server. Every device that connects to the same Marinara server can use them. Your font choice syncs across those devices too, so they all show the same font.
+Font files in the `data/fonts/` folder live on the server. Every device that connects to the same Guksu server can use them. Your font choice syncs across those devices too, so they all show the same font.
 
 ## Downloading from Google Fonts
 
-Marinara can fetch a font straight from Google Fonts for you. The server needs internet access for this to work.
+Guksu can fetch a font straight from Google Fonts for you. The server needs internet access for this to work.
 
 1. Open **Settings**, then **Appearance**, then **Text & Scale**.
 2. Find the **Google Fonts** field.
@@ -43,15 +43,15 @@ Marinara can fetch a font straight from Google Fonts for you. The server needs i
 
 Type the name exactly as Google Fonts spells it. The **Browse fonts at fonts.google.com** link sits next to the field. It opens the Google Fonts site in a new tab so you can look up names.
 
-The name may use letters, numbers, and spaces only. If you download the same font again later, Marinara replaces the old copy instead of making a duplicate.
+The name may use letters, numbers, and spaces only. If you download the same font again later, Guksu replaces the old copy instead of making a duplicate.
 
-If the download fails, read the error message. When Marinara cannot reach Google Fonts, it tells you to check your internet connection. When it says the font was not found, there are two possible causes. The name may not match a font on Google Fonts. Or the font may have no regular (400) weight, which is the normal non-bold style. Check the spelling, and check on the Google Fonts site that the font offers a Regular style.
+If the download fails, read the error message. When Guksu cannot reach Google Fonts, it tells you to check your internet connection. When it says the font was not found, there are two possible causes. The name may not match a font on Google Fonts. Or the font may have no regular (400) weight, which is the normal non-bold style. Check the spelling, and check on the Google Fonts site that the font offers a Regular style.
 
 ## Open Fonts Folder is local only
 
 Next to the **Font** dropdown there is an **Open Fonts Folder** button. It opens the `data/fonts/` folder in the file explorer on the server machine.
 
-This button acts on the server, not on the device where you are viewing Marinara. If you run Marinara on your own computer, it opens the folder for you. If you connect from a phone or a second computer, the button does nothing useful for you. In that case, copy your font files into the server's `data/fonts/` folder yourself.
+This button acts on the server, not on the device where you are viewing Guksu. If you run Guksu on your own computer, it opens the folder for you. If you connect from a phone or a second computer, the button does nothing useful for you. In that case, copy your font files into the server's `data/fonts/` folder yourself.
 
 ## Related guides
 

--- a/docs/characters/bot-browser.md
+++ b/docs/characters/bot-browser.md
@@ -1,12 +1,12 @@
 # Card Browser: Finding and Importing Characters
 
-This guide explains the **Card Browser** in Marinara Engine, the built-in tool for finding character cards on public sites and importing them into your library. It covers the six sources, how to search and filter, and how adult content works on each source. It also covers how to import a character or save it as a file. Older versions called this tab **Bot Browser** or **Browser**.
+This guide explains the **Card Browser** in Guksu Motor, the built-in tool for finding character cards on public sites and importing them into your library. It covers the six sources, how to search and filter, and how adult content works on each source. It also covers how to import a character or save it as a file. Older versions called this tab **Bot Browser** or **Browser**.
 
-A character card is a file that holds one character's name, personality, greeting, and other details. Normally you would download a card from a website and then upload it into Marinara. The **Card Browser** does both steps for you in one place.
+A character card is a file that holds one character's name, personality, greeting, and other details. Normally you would download a card from a website and then upload it into Guksu. The **Card Browser** does both steps for you in one place.
 
 ## What the Card Browser is
 
-The **Card Browser** searches several public character-card sites from inside Marinara. It supports six sources: **ChubAI**, **JannyAI**, **CharacterTavern**, **Pygmalion**, **Wyvern**, and **DataCat**. You can search a source, filter the results, and preview a character's full details. Then you can import that character into your library or save it as a PNG file. You do not need an account or an API key to browse and import character cards at the default settings.
+The **Card Browser** searches several public character-card sites from inside Guksu. It supports six sources: **ChubAI**, **JannyAI**, **CharacterTavern**, **Pygmalion**, **Wyvern**, and **DataCat**. You can search a source, filter the results, and preview a character's full details. Then you can import that character into your library or save it as a PNG file. You do not need an account or an API key to browse and import character cards at the default settings.
 
 ## Opening the Card Browser
 
@@ -31,7 +31,7 @@ One naming note: the menu lists **ChubAI**, but on a character's detail page the
 
 ## Searching, sorting, and pages
 
-Type in the **Search characters...** box to search. You do not need to press Enter. Marinara waits a moment (about half a second) after you stop typing, then searches automatically. Clearing the box or changing a filter also searches again.
+Type in the **Search characters...** box to search. You do not need to press Enter. Guksu waits a moment (about half a second) after you stop typing, then searches automatically. Clearing the box or changing a filter also searches again.
 
 Next to the search box is a sort dropdown. The options are different on each source, and each source starts on its own default sort:
 
@@ -91,7 +91,7 @@ Adult characters show a small red **NSFW** badge in the corner of their thumbnai
 
 **CharacterTavern** and **Pygmalion** hide their adult content behind a login. You do not need to log in for normal, public characters. Logging in only unlocks adult content.
 
-To log in, click the **Log In** button in the toolbar. A login window opens. You paste a value copied from your own account on that outside site. Marinara does not ask for your password.
+To log in, click the **Log In** button in the toolbar. A login window opens. You paste a value copied from your own account on that outside site. Guksu does not ask for your password.
 
 For **Pygmalion**, the window is titled **Pygmalion Authentication** and asks for an **Auth Token**:
 
@@ -99,7 +99,7 @@ For **Pygmalion**, the window is titled **Pygmalion Authentication** and asks fo
 2. Open your browser's developer tools. On most browsers you press the F12 key. Developer tools are a built-in browser panel for advanced users.
 3. Open the **Application** tab, then **Local Storage**.
 4. Find the entry named `authn` and copy its value.
-5. Paste the value into the **Auth Token** box in Marinara.
+5. Paste the value into the **Auth Token** box in Guksu.
 6. Click **Save & Connect**. You should see a message that NSFW content is enabled.
 
 For **CharacterTavern**, the window is titled **CharacterTavern Session** and asks for a **Cookie String**:
@@ -108,12 +108,12 @@ For **CharacterTavern**, the window is titled **CharacterTavern Session** and as
 2. Open developer tools with the F12 key.
 3. Open the **Application** tab, then **Cookies**.
 4. Find the cookie named `session` and copy its value.
-5. Paste the value into the **Cookie String** box in Marinara.
+5. Paste the value into the **Cookie String** box in Guksu.
 6. Click **Save & Connect**. You should see a message that NSFW content is enabled.
 
 Each window has a help section that repeats these steps. Each window also has a link that opens the source's own website. In the **Pygmalion** window this link reads **Website**. In the **CharacterTavern** window it reads **CharacterTavern**. To sign out, open the login window again and click **Log Out**.
 
-Important: these logins are held in the server's memory only. They are never saved to a file. If you restart the Marinara server, you are logged out of both sources and must paste the value again. Marinara shows a message telling you to log in again when this happens.
+Important: these logins are held in the server's memory only. They are never saved to a file. If you restart the Guksu server, you are logged out of both sources and must paste the value again. Guksu shows a message telling you to log in again when this happens.
 
 ## Reviewing a character before import
 
@@ -127,7 +127,7 @@ Some sources do not always return full details. If nothing loads, the view says 
 
 ## Importing or downloading a character
 
-The detail view gives you two buttons. **Import** adds the character to your Marinara library. **Download as PNG** saves the character as a file on your device without adding it to your library.
+The detail view gives you two buttons. **Import** adds the character to your Guksu library. **Download as PNG** saves the character as a file on your device without adding it to your library.
 
 To import character cards into your library:
 
@@ -147,11 +147,11 @@ The **Imported tags** panel next to the avatar controls which tags come along wi
 | ------------- | -------------------------------------------- |
 | All tags      | Keeps the source's tags.                     |
 | No tags       | Skips the source's tags.                     |
-| Existing only | Keeps only tags you already use in Marinara. |
+| Existing only | Keeps only tags you already use in Guksu. |
 
 ### Embedded lorebook prompt
 
-If the character carries an embedded lorebook, importing shows a small confirm box from your web browser. It asks if you also want to save the lorebook as a separate, standalone Marinara lorebook. Click **OK** to create the separate lorebook plus the copy attached to the character. Click **Cancel** to keep the lorebook attached to the character only.
+If the character carries an embedded lorebook, importing shows a small confirm box from your web browser. It asks if you also want to save the lorebook as a separate, standalone Guksu lorebook. Click **OK** to create the separate lorebook plus the copy attached to the character. Click **Cancel** to keep the lorebook attached to the character only.
 
 ### Download as PNG
 
@@ -170,9 +170,9 @@ The **Card Browser** panel in the right sidebar keeps a separate list of charact
 
 ## Troubleshooting
 
-**JannyAI search or details fail with a Cloudflare error.** Some sites block automated requests. Visit jannyai.com once in the same web browser, pass any challenge it shows, then return to Marinara and search again.
+**JannyAI search or details fail with a Cloudflare error.** Some sites block automated requests. Visit jannyai.com once in the same web browser, pass any challenge it shows, then return to Guksu and search again.
 
-**My CharacterTavern or Pygmalion login stopped working.** Restarting the Marinara server clears these logins. Open the **Log In** window again and paste your token or cookie value once more.
+**My CharacterTavern or Pygmalion login stopped working.** Restarting the Guksu server clears these logins. Open the **Log In** window again and paste your token or cookie value once more.
 
 **A search fails or a source stops working.** Public sites can change their pages or block access at any time. Try again later. If a source keeps failing, open the character on the site directly and download the card yourself. Then bring it in through the normal import flow. See [Importing and Exporting Character Cards](import-export.md).
 

--- a/docs/characters/choosing-your-persona.md
+++ b/docs/characters/choosing-your-persona.md
@@ -4,11 +4,11 @@ This guide explains how to pick which persona represents you in a chat. It cover
 
 ## Your active persona and per-chat personas
 
-A persona is your own character card, the identity Marinara Engine uses to represent you. It gives the AI your name and details so the AI knows who it is talking to. To learn how to build one, see [User Personas](personas.md).
+A persona is your own character card, the identity Guksu Motor uses to represent you. It gives the AI your name and details so the AI knows who it is talking to. To learn how to build one, see [User Personas](personas.md).
 
-Marinara chooses your persona in two layers:
+Guksu chooses your persona in two layers:
 
-- Your **active persona** is your global default. Marinara uses it in any chat that has no persona of its own.
+- Your **active persona** is your global default. Guksu uses it in any chat that has no persona of its own.
 - A per-chat persona overrides the active persona for one chat only.
 
 You can have exactly one active persona at a time. You can also have none.
@@ -61,7 +61,7 @@ On mobile, persona switching shares a menu with connection switching. Tap the **
 
 ## Which persona wins
 
-Marinara picks your chat persona in this order:
+Guksu picks your chat persona in this order:
 
 1. The chat's own per-chat persona, if you set one.
 2. Otherwise, your global active persona.

--- a/docs/characters/colors-and-stats.md
+++ b/docs/characters/colors-and-stats.md
@@ -1,6 +1,6 @@
 # Character Colors and RPG Stats
 
-This guide covers the **Colors** tab and the **Stats** tab in Marinara Engine. Both tabs appear in the Character editor and the Persona editor. Colors change how a character or your persona looks in chat. Stats set up trackable values like health or hunger.
+This guide covers the **Colors** tab and the **Stats** tab in Guksu Motor. Both tabs appear in the Character editor and the Persona editor. Colors change how a character or your persona looks in chat. Stats set up trackable values like health or hunger.
 
 ## The Colors tab
 

--- a/docs/characters/creating-and-editing-characters.md
+++ b/docs/characters/creating-and-editing-characters.md
@@ -1,6 +1,6 @@
 # Creating and Editing Characters
 
-This guide shows you how to make a character in Marinara Engine. It also shows how to use the Character Editor to write, save, and manage card versions. It covers the Metadata, Card, and Advanced tabs, avatars, and saved version history.
+This guide shows you how to make a character in Guksu Motor. It also shows how to use the Character Editor to write, save, and manage card versions. It covers the Metadata, Card, and Advanced tabs, avatars, and saved version history.
 
 ## What a character card is
 
@@ -67,7 +67,7 @@ The **Card** tab is the main writing workspace. It holds the fields the AI reads
 - **Description**. The character's general identity and role. This is sent in every prompt.
 - **Personality**. A short summary of temperament, speech habits, and behavior patterns.
 - **Backstory**. History, origin, and important relationships.
-- **Appearance**. Physical description, clothing, and visual details. Marinara also uses this text to seed an AI avatar prompt.
+- **Appearance**. Physical description, clothing, and visual details. Guksu also uses this text to seed an AI avatar prompt.
 - **Scenario**. The default setting for new chats with this character.
 
 The **Dialogue & Greetings** section sets how a chat opens and how the character sounds:
@@ -154,7 +154,7 @@ If the underlying text changed since the proposal was made, the app warns you be
 
 ## A note on Professor Mari
 
-**Professor Mari** is a built-in assistant character that ships with Marinara. You cannot delete her. If you try, the app blocks it and tells you she is a built-in character. To learn what she does, see [Professor Mari, Your In-App Assistant](../home/professor-mari.md).
+**Professor Mari** is a built-in assistant character that ships with Guksu. You cannot delete her. If you try, the app blocks it and tells you she is a built-in character. To learn what she does, see [Professor Mari, Your In-App Assistant](../home/professor-mari.md).
 
 ## Related guides
 

--- a/docs/characters/import-export.md
+++ b/docs/characters/import-export.md
@@ -1,8 +1,8 @@
 # Importing and Exporting Character Cards
 
-This guide shows how to import character cards into Marinara Engine and export your own characters back out. It covers the file types Marinara accepts, the choices in the import dialog, and the three export formats.
+This guide shows how to import character cards into Guksu Motor and export your own characters back out. It covers the file types Guksu accepts, the choices in the import dialog, and the three export formats.
 
-A character card is a single file that holds one character: its name, description, personality, greetings, and often an avatar image. Cards let you move a character between Marinara and other roleplay apps.
+A character card is a single file that holds one character: its name, description, personality, greetings, and often an avatar image. Cards let you move a character between Guksu and other roleplay apps.
 
 ## Import formats
 
@@ -13,9 +13,9 @@ The **Import Character** window accepts four file types. You can drop several fi
 | **.json** | A plain character card in text form (Chara Card V2). |
 | **.png** | A character card image with the card data hidden inside the picture. |
 | **.charx** | A Character Card V3 package (CharX), the zip-based format used by RisuAI. |
-| **.marinara** | A Marinara native export (also seen as `.marinara.json`). |
+| **.marinara** | A Guksu native export (also seen as `.marinara.json`). |
 
-A **.marinara** file keeps the most detail, because it is Marinara's own format. The other three come from SillyTavern, Chub, Risu, and similar tools.
+A **.marinara** file keeps the most detail, because it is Guksu's own format. The other three come from SillyTavern, Chub, Risu, and similar tools.
 
 ## Importing a character
 
@@ -48,12 +48,12 @@ Pick **Character only** unless you know you want the rules everywhere.
 
 A lorebook is a set of background facts the AI can look up during a chat. If a card you are importing has a lorebook baked in, the import pauses and shows an **Embedded lorebook found** panel. It lists each file and how many entries it holds. Choose one option for the whole batch:
 
-- **Import Lorebook**: also create a standalone Marinara lorebook linked to the character.
+- **Import Lorebook**: also create a standalone Guksu lorebook linked to the character.
 - **No Import**: keep the lorebook only inside the card.
 
 ### Importing many cards at once
 
-The same **Import Character** window handles batch imports. Select several files, and Marinara imports them one after another. The result list has one row per file, so you can see which cards worked and which failed.
+The same **Import Character** window handles batch imports. Select several files, and Guksu imports them one after another. The result list has one row per file, so you can see which cards worked and which failed.
 
 ## Exporting a character
 
@@ -61,11 +61,11 @@ Open a character in the editor, then click **Export character** in the top toolb
 
 | Format | What you get | Best for |
 | --- | --- | --- |
-| **Marinara Native** | A `.marinara.json` file that keeps Marinara metadata, sprites, gallery images, and attached lorebooks. | Moving a character between Marinara installs with full detail. |
-| **Compatible JSON** | Plain Chara Card V2 JSON with no Marinara wrapper. | Sharing to other apps that read JSON cards. |
+| **Guksu Native** | A `.marinara.json` file that keeps Guksu metadata, sprites, gallery images, and attached lorebooks. | Moving a character between Guksu installs with full detail. |
+| **Compatible JSON** | Plain Chara Card V2 JSON with no Guksu wrapper. | Sharing to other apps that read JSON cards. |
 | **Compatible PNG Card** | A Chara Card V2 image with the card data baked into the picture. | Apps and sites that expect a PNG card, such as SillyTavern, Chub, and Risu. |
 
-Choose **Marinara Native** when you want to keep everything. Choose one of the **Compatible** formats when the file is going to another tool. The two compatible formats drop Marinara-only extras like sprites and gallery images.
+Choose **Guksu Native** when you want to keep everything. Choose one of the **Compatible** formats when the file is going to another tool. The two compatible formats drop Guksu-only extras like sprites and gallery images.
 
 ## Exporting many characters at once
 
@@ -74,9 +74,9 @@ You can export a batch of characters as a single zip file.
 1. Open the **Characters** panel.
 2. Click the **Select** button in the toolbar to enter select mode. It is an icon button with a checkmark.
 3. Tick the characters you want.
-4. Click **Export** in the action bar at the bottom. Marinara downloads a zip named `marinara-characters.zip`.
+4. Click **Export** in the action bar at the bottom. Guksu downloads a zip named `marinara-characters.zip`.
 
-The zip holds one **Marinara Native** file per character. There is no PNG or compatible-JSON option for bulk export, so use single-character export when you need those formats.
+The zip holds one **Guksu Native** file per character. There is no PNG or compatible-JSON option for bulk export, so use single-character export when you need those formats.
 
 ## Importing a whole SillyTavern folder
 

--- a/docs/characters/library-organization.md
+++ b/docs/characters/library-organization.md
@@ -106,7 +106,7 @@ When you want to act on several characters at once, use selection mode.
 
 The action bar has two buttons:
 
-- **Export** downloads all selected characters together as a single zip file named `marinara-characters.zip`. This is a bulk export in Marinara Engine's own native format.
+- **Export** downloads all selected characters together as a single zip file named `marinara-characters.zip`. This is a bulk export in Guksu Motor's own native format.
 - **Delete** removes all selected characters. You will be asked to confirm first: **Delete N characters?**
 
 While in selection mode you can also drag your selected characters into a folder all at once, instead of moving them one by one.

--- a/docs/characters/personas.md
+++ b/docs/characters/personas.md
@@ -1,10 +1,10 @@
 # User Personas: Creating and Editing
 
-This guide explains what a persona is, how to create and edit one, and how to import, export, duplicate, and delete personas. A persona is your own character card: the identity Marinara Engine uses to represent you in a chat.
+This guide explains what a persona is, how to create and edit one, and how to import, export, duplicate, and delete personas. A persona is your own character card: the identity Guksu Motor uses to represent you in a chat.
 
 ## What a persona is
 
-A persona is who you are in a chat. It has a name, a description, and other optional details. Marinara sends these details into every prompt so the AI knows who it is talking to.
+A persona is who you are in a chat. It has a name, a description, and other optional details. Guksu sends these details into every prompt so the AI knows who it is talking to.
 
 You can make many personas. You keep them in the **Personas** panel. You pick one persona as your global default, called the **active persona**. You can also override the persona for a single chat. This guide covers making and editing personas. To learn how to choose which persona a chat uses, see [Choosing Your Persona in a Chat](choosing-your-persona.md).
 
@@ -130,7 +130,7 @@ The values you set here are the starting defaults for new chats. They do not upd
 
 ## Version history
 
-Every time you save a change to a persona's card fields, Marinara saves a snapshot automatically. The **Version history** panel on the **Metadata** tab lists these saved versions with a timestamp.
+Every time you save a change to a persona's card fields, Guksu saves a snapshot automatically. The **Version history** panel on the **Metadata** tab lists these saved versions with a timestamp.
 
 For each saved version you can:
 
@@ -157,7 +157,7 @@ To delete many at once, click **Select** in the **Personas** panel and check the
 Click **Import** in the **Personas** panel to open the **Import Persona** window. You can drag files in or click to browse. You can import many files at once. It accepts two file types:
 
 - **.marinara** native package files. These restore full persona details, sprites, and gallery structure.
-- **.json** files. A Marinara JSON export imports fully. A generic JSON file from another tool is mapped field by field into a new persona. The name is required. Other recognized fields are pulled in when present.
+- **.json** files. A Guksu JSON export imports fully. A generic JSON file from another tool is mapped field by field into a new persona. The name is required. Other recognized fields are pulled in when present.
 
 Each file shows a success or failure icon and a message. A summary line shows how many succeeded and how many failed.
 
@@ -165,8 +165,8 @@ Each file shows a success or failure icon and a message. A summary line shows ho
 
 You can export from the **Export persona** icon in the **Persona Editor**, or with the bulk **Export** action in the panel's selection mode. The **Export Persona** window offers two formats:
 
-- **Native**: keeps all Marinara persona details, sprites, and attached lorebooks. Use this to move a persona between Marinara installs.
-- **Compatible**: exports plain persona fields only. Use this for other tools that do not understand Marinara's format.
+- **Native**: keeps all Guksu persona details, sprites, and attached lorebooks. Use this to move a persona between Guksu installs.
+- **Compatible**: exports plain persona fields only. Use this for other tools that do not understand Guksu's format.
 
 A bulk export downloads a single zip file with one file per selected persona.
 

--- a/docs/characters/sprites.md
+++ b/docs/characters/sprites.md
@@ -4,7 +4,7 @@ This guide shows you how to add character art called sprites and generate it wit
 
 ## What sprites are
 
-A sprite is standing character art: a picture of a character that Marinara Engine shows floating over the chat scene. Marinara uses two kinds of sprite:
+A sprite is standing character art: a picture of a character that Guksu Motor shows floating over the chat scene. Guksu uses two kinds of sprite:
 
 - **Facial Expressions**: portrait images for different moods, like happy, sad, or angry.
 - **Full-body**: whole-body images for different poses, like idle, walk, or battle stance.
@@ -25,7 +25,7 @@ This guide covers the **Facial Expressions** and **Full-body** categories. The *
 
 ## Uploading your own sprites
 
-You can upload art you already have. Marinara accepts common image files. Transparent PNG files give the best result, because the empty area around the character stays see-through over the scene.
+You can upload art you already have. Guksu accepts common image files. Transparent PNG files give the best result, because the empty area around the character stays see-through over the scene.
 
 ### Upload one sprite
 
@@ -64,7 +64,7 @@ Deleting asks you to confirm with the message "Delete sprite for" and the name. 
 
 ## Generating sprites with AI
 
-If you have an image connection set up, Marinara can draw sprites for you. A connection is the link between Marinara and an AI service. To generate sprites you need an image connection, and for animated sprites you need a video connection. See [Connecting to an AI Provider](../connections/connecting-to-a-provider.md) to set one up.
+If you have an image connection set up, Guksu can draw sprites for you. A connection is the link between Guksu and an AI service. To generate sprites you need an image connection, and for animated sprites you need a video connection. See [Connecting to an AI Provider](../connections/connecting-to-a-provider.md) to set one up.
 
 To start, click **Generate Sprite** in the **Add Sprite** box. This opens the **Generate Sprites** window. At the top you choose a source: **Expressions (Portrait)** or **Full-body**.
 
@@ -73,7 +73,7 @@ Fill in the window:
 1. Pick an **Image Generation Connection** from the dropdown.
 2. Add up to four **Reference Images** if you want the art to match a look. You can also tick the box to use the current avatar as a reference.
 3. Write an **Appearance Description** of how the character looks. This is required.
-4. Optionally turn on **Transparent sprite background**. Marinara requests native PNG transparency first. If the provider cannot return alpha, it chooses a saturated green, magenta, or cyan matte that least overlaps the colors in your **Appearance Description**, then removes that matte automatically.
+4. Optionally turn on **Transparent sprite background**. Guksu requests native PNG transparency first. If the provider cannot return alpha, it chooses a saturated green, magenta, or cyan matte that least overlaps the colors in your **Appearance Description**, then removes that matte automatically.
 5. Choose how many images to make with **Expression Count** (or **Pose Count** for full-body), then pick which expressions or poses to fill.
 6. Click the **Generate** button.
 
@@ -84,7 +84,7 @@ On the **Full-body** source, if the character already has portrait expressions, 
 Two notes about AI generation:
 
 - Generation can take a few minutes, even though the in-app text may suggest less. Slow AI services take longer. Please wait rather than starting over.
-- On some devices, such as certain Android installs, AI sprite generation and background cleanup are not available. When that happens, the button is disabled and Marinara shows the reason on screen.
+- On some devices, such as certain Android installs, AI sprite generation and background cleanup are not available. When that happens, the button is disabled and Guksu shows the reason on screen.
 
 ### Animated portrait sprites
 
@@ -92,7 +92,7 @@ On the **Expressions (Portrait)** source there is a checkbox called **Generate a
 
 ## Cleaning up sprite backgrounds
 
-A sprite looks best when only the character shows and the background is see-through. Generated still sprites use native transparency when the provider supports it. Otherwise, Marinara removes a flat adaptive chroma matte with a soft edge and cleans its color out of hair, fabric, and other partially transparent pixels. Older white-background sprites remain supported.
+A sprite looks best when only the character shows and the background is see-through. Generated still sprites use native transparency when the provider supports it. Otherwise, Guksu removes a flat adaptive chroma matte with a soft edge and cleans its color out of hair, fabric, and other partially transparent pixels. Older white-background sprites remain supported.
 
 ### Clean one sprite by hand
 
@@ -105,11 +105,11 @@ The **Clean Backgrounds** button removes the background from every sprite curren
 1. Set the **Cleanup strength** slider. It runs from Soft to Aggressive, from 0 to 100, and starts at 35. A higher value removes more of the background but can bite into the character.
 2. Click **Clean Backgrounds** and confirm.
 
-After a batch cleanup, Marinara keeps a safety copy. A line reads "Last cleanup has a restore point" with an **Undo Cleanup** button. Click it to put every affected sprite back the way it was.
+After a batch cleanup, Guksu keeps a safety copy. A line reads "Last cleanup has a restore point" with an **Undo Cleanup** button. Click it to put every affected sprite back the way it was.
 
 Background cleanup works on PNG, JPG, JPEG, WEBP, and AVIF images. It does not work on GIF or SVG files.
 
-Automatic cleanup examines the image before choosing an engine. The fast built-in matte cleanup handles flat chroma and legacy white backgrounds first. If the border is not actually uniform, Marinara can use the optional AI background remover as a fallback when it is installed. The manual cleanup editor remains the safest option for a busy scene or a subject whose colors are nearly identical to the background.
+Automatic cleanup examines the image before choosing an engine. The fast built-in matte cleanup handles flat chroma and legacy white backgrounds first. If the border is not actually uniform, Guksu can use the optional AI background remover as a fallback when it is installed. The manual cleanup editor remains the safest option for a busy scene or a subject whose colors are nearly identical to the background.
 
 ## Exporting sprites
 

--- a/docs/chats/branches.md
+++ b/docs/chats/branches.md
@@ -1,6 +1,6 @@
 # Chat Branches
 
-This guide explains chat branches in Marinara Engine: what a branch is and how to make one. It also covers switching, renaming, deleting, exporting, and importing branches. A branch lets you try a different path in a chat without losing the original.
+This guide explains chat branches in Guksu Motor: what a branch is and how to make one. It also covers switching, renaming, deleting, exporting, and importing branches. A branch lets you try a different path in a chat without losing the original.
 
 ## What a branch is
 
@@ -17,7 +17,7 @@ You create a branch from any message in the chat.
 1. Hover over a message (or tap it on mobile) to show the message action bar.
 2. Click the **Branch from here** button. It uses a small branching icon.
 
-Marinara copies the chat up to and including that message into a new branch. The new branch:
+Guksu copies the chat up to and including that message into a new branch. The new branch:
 
 - Keeps the same mode, characters, persona, prompt preset, and connection as the source chat.
 - Copies every message, including all swipes (alternate replies) and which swipe was active. See the [Message Actions guide](messages.md) for how swipes work.
@@ -78,9 +78,9 @@ You can bring a saved chat log in as a new branch of the chat you have open.
 
 1. Open the **Chat Branches** popover.
 2. Click the **Import** button.
-3. Pick a JSONL file (`.jsonl`) exported from SillyTavern or from Marinara.
+3. Pick a JSONL file (`.jsonl`) exported from SillyTavern or from Guksu.
 
-Marinara adds the file as a new branch in the current chat's group. You should see a message like "Imported N messages as a new branch". The app then switches to the new branch.
+Guksu adds the file as a new branch in the current chat's group. You should see a message like "Imported N messages as a new branch". The app then switches to the new branch.
 
 ## Related guides
 

--- a/docs/chats/chat-settings.md
+++ b/docs/chats/chat-settings.md
@@ -25,7 +25,7 @@ The **Chat Name** section holds the name shown in your chat list. This name is o
 
 ## Connection
 
-The **Connection** section picks which AI provider and model answers in this chat. A connection is a saved link to an AI provider, including its API key and chosen model. An API key is a secret code that lets Marinara Engine use your account with that provider.
+The **Connection** section picks which AI provider and model answers in this chat. A connection is a saved link to an AI provider, including its API key and chosen model. An API key is a secret code that lets Guksu Motor use your account with that provider.
 
 Pick a saved connection from the dropdown. You can also pick **Random**. It chooses a different connection each time from the connections you marked for your random pool.
 
@@ -46,7 +46,7 @@ The bar has a row of small icon buttons with no text labels. Each button shows i
 - The up-arrow icon (**Export preset (.json)**) saves the selected preset to a `.json` file.
 - The trash icon (**Delete preset**) removes the selected preset.
 
-Next to the dropdown is a star button. Click it to mark a preset as the default for new chats in this mode. When you create a new chat in that mode, Marinara applies the starred preset for you. Only one preset per mode can be the starred default at a time.
+Next to the dropdown is a star button. Click it to mark a preset as the default for new chats in this mode. When you create a new chat in that mode, Guksu applies the starred preset for you. Only one preset per mode can be the starred default at a time.
 
 Each mode that supports this feature has a built-in **Default** preset. You cannot rename, save into, or delete the **Default** preset. Applying it resets the chat's preset-controlled settings back to the app defaults.
 

--- a/docs/chats/connected-chats.md
+++ b/docs/chats/connected-chats.md
@@ -2,7 +2,7 @@
 
 This guide explains how to link a Conversation chat to a Roleplay or Game chat so the two share context. It also covers **Cross-Chat Awareness**, the special tags that pass information across a link, and how to jump between linked chats.
 
-Marinara Engine (called Marinara after this) has two separate features that let chats know about each other. One is automatic. The other is an explicit one-to-one link you set up yourself. This guide keeps them apart, because they work in different ways.
+Guksu Motor (called Guksu after this) has two separate features that let chats know about each other. One is automatic. The other is an explicit one-to-one link you set up yourself. This guide keeps them apart, because they work in different ways.
 
 ## What Connected Chats do
 
@@ -20,7 +20,7 @@ Two features are easy to confuse. Read this section before you set anything up.
 
 **Cross-Chat Awareness** is automatic. It is a Conversation-mode setting. When a character is present in more than one Conversation chat, it can remember and reference what happened in those other chats. You do not link anything by hand. The setting is on by default.
 
-You find it in the **Cross-Chat Awareness** section of **Chat Settings**. Its help text reads: "Characters remember and reference conversations from other chats they're in. Pulls recent messages from sibling chats and injects them as context." Marinara matches these sibling chats by shared character, not by shared user.
+You find it in the **Cross-Chat Awareness** section of **Chat Settings**. Its help text reads: "Characters remember and reference conversations from other chats they're in. Pulls recent messages from sibling chats and injects them as context." Guksu matches these sibling chats by shared character, not by shared user.
 
 A **Connected Chats** link is different. It is something you create on purpose. It joins exactly one Conversation to one Roleplay or Game chat. It carries story context and the special tags described below.
 
@@ -58,7 +58,7 @@ Write these tags as literal text if you ever need to reference them. Each is sho
 
 - `<influence>` sends a one-time steer from the Conversation into the linked story chat. It affects the very next linked turn, then it is used up.
 - `<note>` saves a durable fact from the Conversation into the linked story chat. It stays in the story chat's prompt on every turn until you clear it.
-- `<ooc>` lets a Roleplay character step out of the story and reply directly to the linked Conversation. Marinara posts that text to the linked direct-message chat.
+- `<ooc>` lets a Roleplay character step out of the story and reply directly to the linked Conversation. Guksu posts that text to the linked direct-message chat.
 
 So a Conversation character can quietly shape or inform the story with `<influence>` and `<note>`. A Roleplay character can talk back to the Conversation with `<ooc>`.
 
@@ -66,7 +66,7 @@ So a Conversation character can quietly shape or inform the story with `<influen
 
 When a Conversation character saves a durable `<note>`, it shows up on the story side. The Roleplay or Game chat gets a **Conversation Notes** section in its **Chat Settings**.
 
-This section lists every saved note. Each note has a delete button. To remove all of them at once, use the **Clear all notes** button. Marinara asks you to confirm before it clears them, and this cannot be undone.
+This section lists every saved note. Each note has a delete button. To remove all of them at once, use the **Clear all notes** button. Guksu asks you to confirm before it clears them, and this cannot be undone.
 
 If no character has saved a note yet, the section explains that notes wrapped in a `<note>` tag will appear here once saved.
 

--- a/docs/chats/export-import.md
+++ b/docs/chats/export-import.md
@@ -1,13 +1,13 @@
 # Exporting and Importing Chats
 
-This guide shows how to save a chat to a file and load a chat back into Marinara Engine. You can export one chat or many chats at once. You can also import a chat file that came from Marinara or from SillyTavern (another roleplay chat app).
+This guide shows how to save a chat to a file and load a chat back into Guksu Motor. You can export one chat or many chats at once. You can also import a chat file that came from Guksu or from SillyTavern (another roleplay chat app).
 
 ## File formats you will see
 
-Marinara uses two chat file formats.
+Guksu uses two chat file formats.
 
-- **JSONL**: JSONL means JSON Lines. It is a plain text file that saves one message per line. This is the default export format. You can import a JSONL file back into Marinara later.
-- **Text**: A plain, readable `.txt` transcript. It is easy to read and share, but Marinara cannot import it back in. Use **Text** only when you want a human to read the chat.
+- **JSONL**: JSONL means JSON Lines. It is a plain text file that saves one message per line. This is the default export format. You can import a JSONL file back into Guksu later.
+- **Text**: A plain, readable `.txt` transcript. It is easy to read and share, but Guksu cannot import it back in. Use **Text** only when you want a human to read the chat.
 
 The chat import feature accepts a `.jsonl` file only. If you want to re-import a chat later, export it as **JSONL**, not **Text**.
 
@@ -39,13 +39,13 @@ The bulk export always uses the **JSONL** format. Click **Delete** in the same b
 
 ## Import a chat as a new chat
 
-This creates a brand new chat from a `.jsonl` file. Use it to import chat files saved by Marinara or exported from SillyTavern.
+This creates a brand new chat from a `.jsonl` file. Use it to import chat files saved by Guksu or exported from SillyTavern.
 
 1. Open the chat list in the left sidebar.
-2. Pick the mode tab you want: **CONVO**, **RP**, or **GM**. Marinara creates the imported chat in the tab you have open right now.
-3. Click the import button next to the **New** button at the top of the list. Its tooltip reads **Import SillyTavern or Marinara chat JSONL**.
+2. Pick the mode tab you want: **CONVO**, **RP**, or **GM**. Guksu creates the imported chat in the tab you have open right now.
+3. Click the import button next to the **New** button at the top of the list. Its tooltip reads **Import SillyTavern or Guksu chat JSONL**.
 4. Choose your `.jsonl` file in the file picker.
-5. You should see a message that says "Imported N messages", and Marinara switches you into the new chat.
+5. You should see a message that says "Imported N messages", and Guksu switches you into the new chat.
 
 If you want the new chat in Roleplay mode, open the **RP** tab before you import. The tab you have open sets the mode, not the file.
 
@@ -67,8 +67,8 @@ Some models save hidden thinking or reasoning text with a reply. A setting decid
 
 The setting is **Include reasoning in exports**. You find it in **Settings**, on the **Advanced** tab, in the **Message Tools** section. It is a toggle, and it is **off** by default.
 
-- When it is **off**, Marinara leaves saved thinking and reasoning text out of both **JSONL** and **Text** chat exports.
-- When it is **on**, Marinara adds that hidden thinking and reasoning text to both formats.
+- When it is **off**, Guksu leaves saved thinking and reasoning text out of both **JSONL** and **Text** chat exports.
+- When it is **on**, Guksu adds that hidden thinking and reasoning text to both formats.
 
 This setting affects both single-chat exports and bulk `.zip` exports.
 

--- a/docs/chats/group-chats.md
+++ b/docs/chats/group-chats.md
@@ -1,6 +1,6 @@
 # Group Chats and Group Conversations
 
-This guide covers group chats in Marinara Engine, which are chats that hold two or more characters at once. It explains how to create a group chat and how to add or remove members. It also shows how to control who speaks in Conversation mode and in Roleplay mode.
+This guide covers group chats in Guksu Motor, which are chats that hold two or more characters at once. It explains how to create a group chat and how to add or remove members. It also shows how to control who speaks in Conversation mode and in Roleplay mode.
 
 ## What a group chat is
 
@@ -8,7 +8,7 @@ A group chat is any chat that has two or more characters in it. There is no sepa
 
 Group chats work in two modes: **Conversation** and **Roleplay**. Game Mode has its own separate party system and is not covered here.
 
-The word "group" is used for a few different things in Marinara. A group chat means many characters in one chat. That is different from **Folders**, which are saved lists of characters you can reuse. It is also different from **Chat Branches**, which are alternate versions of the same chat. This guide is only about group chats.
+The word "group" is used for a few different things in Guksu. A group chat means many characters in one chat. That is different from **Folders**, which are saved lists of characters you can reuse. It is also different from **Chat Branches**, which are alternate versions of the same chat. This guide is only about group chats.
 
 ## Creating a group chat
 
@@ -24,7 +24,7 @@ Once you add a second character, the label above the picker updates. In Conversa
 
 There is no fixed limit on the number of characters. In practice, more characters means a longer prompt and a higher cost per reply. Add only the characters the scene needs.
 
-If you do not rename the chat, Marinara names it after the characters, joined with commas. An example is "Alice, Bob, Carol".
+If you do not rename the chat, Guksu names it after the characters, joined with commas. An example is "Alice, Bob, Carol".
 
 ### Adding many characters at once with Folders
 
@@ -62,7 +62,7 @@ Sometimes you want a character to sit out for a while but stay in the roster. Us
 
 A disabled character stays in the member list but is left out of every reply. Their character card is not sent to the model, and they cannot be picked to speak.
 
-There is one safety fallback. If you disable every character in the chat, Marinara treats all of them as active again. This prevents a reply with zero characters.
+There is one safety fallback. If you disable every character in the chat, Guksu treats all of them as active again. This prevents a reply with zero characters.
 
 This on and off state is saved per chat. It does not change the character anywhere else in the app.
 
@@ -140,7 +140,7 @@ The button tooltip reads "Trigger character response".
 
 Turn on **Character Exchanges** to let characters talk to each other on their own. It is off by default. The description reads "Characters chat with each other in group chats."
 
-When it is on, the characters can reply to each other while you are away, not only to you. This runs only while Marinara is open in your browser. If you close the app, the exchanges stop. It also shares the same daily message limit that autonomous messages use.
+When it is on, the characters can reply to each other while you are away, not only to you. This runs only while Guksu is open in your browser. If you close the app, the exchanges stop. It also shares the same daily message limit that autonomous messages use.
 
 ## Turn handling at a glance
 

--- a/docs/chats/guided-and-impersonate.md
+++ b/docs/chats/guided-and-impersonate.md
@@ -1,6 +1,6 @@
 # Guided Generation and Impersonate
 
-This guide covers two ways to steer a chat in Marinara Engine. Guided generation points the AI in a direction without posting a visible message. Impersonate has the AI write your own reply for you. It also covers the Quick replies menu that puts both actions next to the Send button.
+This guide covers two ways to steer a chat in Guksu Motor. Guided generation points the AI in a direction without posting a visible message. Impersonate has the AI write your own reply for you. It also covers the Quick replies menu that puts both actions next to the Send button.
 
 ## Guided generation
 
@@ -41,7 +41,7 @@ When the setting is on and you have text in the box, the **Regenerate** button c
 
 ### Reading Stored guidance
 
-When a reply was made with a direction, Marinara saves that direction so you can see it later. A **Stored guidance** action (a scroll icon) appears on the message.
+When a reply was made with a direction, Guksu saves that direction so you can see it later. A **Stored guidance** action (a scroll icon) appears on the message.
 
 1. Click the **Stored guidance** icon on the AI message.
 2. A window titled **Stored guidance** opens and shows the direction that produced the reply.
@@ -85,10 +85,10 @@ Impersonate has a settings section that applies to every `/impersonate` you run,
 
 The section has these controls:
 
-- **Prompt Template**: an optional instruction sent to the model every time you impersonate. Leave it empty to use the chat's own prompt, or the built-in default when the chat has none. It supports the macros `{{user}}`, `{{persona_description}}`, and `{{impersonate_direction}}`. A macro is a placeholder that Marinara replaces with real text before sending. Click **Built-in default** to read the default text. A **Reset** button clears a custom template back to empty.
+- **Prompt Template**: an optional instruction sent to the model every time you impersonate. Leave it empty to use the chat's own prompt, or the built-in default when the chat has none. It supports the macros `{{user}}`, `{{persona_description}}`, and `{{impersonate_direction}}`. A macro is a placeholder that Guksu replaces with real text before sending. Click **Built-in default** to read the default text. A **Reset** button clears a custom template back to empty.
 - **Preset**: use a specific prompt preset for impersonate replies only. A preset is a saved bundle of prompt settings. See [Presets](../prompts/presets.md). The default is **Use chat default**. Presets apply in Roleplay only.
 - **Connection**: route impersonate replies to a specific connection, such as a cheaper or faster model. A connection is a saved link to an AI provider. See [Connecting to an AI Provider](../connections/connecting-to-a-provider.md). The default is **Use chat default**. You can also choose **Random**.
-- **Skip agents**: when on, Marinara skips the agent pipeline (trackers, lorebook routers, and similar helpers) during impersonate. This keeps impersonate fast and stops it from changing world state. It is off by default. See [Agents](../agents/agents-overview.md).
+- **Skip agents**: when on, Guksu skips the agent pipeline (trackers, lorebook routers, and similar helpers) during impersonate. This keeps impersonate fast and stops it from changing world state. It is off by default. See [Agents](../agents/agents-overview.md).
 - **Use CYOA as direction**: when on, clicking a CYOA option uses it as the impersonate direction instead of posting it as a normal message. CYOA means choose your own adventure, a set of clickable choices some chats show after a reply. This setting is off by default.
 
 ### Setting a custom impersonate prompt

--- a/docs/chats/managing-chats.md
+++ b/docs/chats/managing-chats.md
@@ -1,6 +1,6 @@
 # Managing Your Chat List
 
-This guide covers the chat list in Marinara Engine. It explains the three mode tabs and how to create, import, rename, delete, organize, search, and bulk-manage your chats. It also covers the recent chats row on the Home screen.
+This guide covers the chat list in Guksu Motor. It explains the three mode tabs and how to create, import, rename, delete, organize, search, and bulk-manage your chats. It also covers the recent chats row on the Home screen.
 
 ## The chat list and mode tabs
 
@@ -24,19 +24,19 @@ Some rows show a small branch icon with a number. This means the chat has more t
 
 The new chat is named **New Conversation**, **New Roleplay**, or **New Game**. You can rename it later (see Renaming a chat below).
 
-You need at least one connection before a chat will open. A connection links Marinara to an AI provider. If you have no connection yet, a **Set Up** window appears instead of the chat. It asks you to choose a connection first. If you have none at all, it shows **No connections found** with an **Open Connections** button. To set one up, see [Connecting to an AI Provider](../connections/connecting-to-a-provider.md).
+You need at least one connection before a chat will open. A connection links Guksu to an AI provider. If you have no connection yet, a **Set Up** window appears instead of the chat. It asks you to choose a connection first. If you have none at all, it shows **No connections found** with an **Open Connections** button. To set one up, see [Connecting to an AI Provider](../connections/connecting-to-a-provider.md).
 
-If you saved a starred default Chat Settings Preset for that mode, Marinara applies it to the new chat automatically. See [Chat Settings Overview](chat-settings.md).
+If you saved a starred default Chat Settings Preset for that mode, Guksu applies it to the new chat automatically. See [Chat Settings Overview](chat-settings.md).
 
 ## Importing a chat
 
-You can import a chat log saved as a `.jsonl` file, from SillyTavern or from Marinara.
+You can import a chat log saved as a `.jsonl` file, from SillyTavern or from Guksu.
 
 1. Pick the mode tab you want the imported chat to land in.
-2. Click the **Import** button near the top of the panel. Its tooltip reads **Import SillyTavern or Marinara chat JSONL**.
+2. Click the **Import** button near the top of the panel. Its tooltip reads **Import SillyTavern or Guksu chat JSONL**.
 3. Choose your `.jsonl` file.
 
-Marinara creates a new chat in the current tab's mode and opens it. You should see a message that reads **Imported N messages**, where N is the message count.
+Guksu creates a new chat in the current tab's mode and opens it. You should see a message that reads **Imported N messages**, where N is the message count.
 
 For all the ways to import and export chats, including bulk import and export formats, see [Exporting and Importing Chats](export-import.md).
 

--- a/docs/chats/messages.md
+++ b/docs/chats/messages.md
@@ -2,7 +2,7 @@
 
 This guide covers what you can do with a single message in a chat. It explains the message toolbar, how to edit and delete a message, and how swipes and regeneration work. It also covers the display toggles that show token counts and message numbers.
 
-Every message in Marinara Engine, whether you wrote it or the AI did, has a small toolbar. The toolbar appears when you hover over the message on a computer, or when you tap the message on a phone or tablet.
+Every message in Guksu Motor, whether you wrote it or the AI did, has a small toolbar. The toolbar appears when you hover over the message on a computer, or when you tap the message on a phone or tablet.
 
 ## The message toolbar
 
@@ -101,4 +101,4 @@ A related toggle in the same **Message Tools** section, **Show model name on mes
 - [Text to Speech (TTS) Setup](../media/tts-setup.md)
 - [Message Translation](../integrations/message-translation.md)
 - [Settings Overview](../settings/settings-overview.md)
-- [Troubleshooting Marinara Engine](../TROUBLESHOOTING.md)
+- [Troubleshooting Guksu Motor](../TROUBLESHOOTING.md)

--- a/docs/chats/peek-prompt.md
+++ b/docs/chats/peek-prompt.md
@@ -1,8 +1,8 @@
 # Peek Prompt: See What the AI Received
 
-Peek Prompt shows you the exact text that Marinara Engine sent to the AI model for a reply. It can also show a live preview of the prompt before anything is sent. This guide explains what the viewer shows, how to open it, how to read Stored guidance, and how to use it to debug replies.
+Peek Prompt shows you the exact text that Guksu Motor sent to the AI model for a reply. It can also show a live preview of the prompt before anything is sent. This guide explains what the viewer shows, how to open it, how to read Stored guidance, and how to use it to debug replies.
 
-A prompt is the full block of instructions and chat history that Marinara builds and sends to the model. The model reads that prompt and writes a reply. Peek Prompt lets you see that block after it is put together, so nothing about your reply is a mystery.
+A prompt is the full block of instructions and chat history that Guksu builds and sends to the model. The model reads that prompt and writes a reply. Peek Prompt lets you see that block after it is put together, so nothing about your reply is a mystery.
 
 ## What Peek Prompt shows
 
@@ -42,7 +42,7 @@ The second way is a typed shortcut. It works even before you have any AI reply, 
 
 3. Press Enter or click Send.
 
-Instead of sending a message, Marinara clears the box and opens the Peek Prompt viewer. The shortcuts `{{prompt_preview}}` and `{{preview_prompt}}` do the same thing.
+Instead of sending a message, Guksu clears the box and opens the Peek Prompt viewer. The shortcuts `{{prompt_preview}}` and `{{preview_prompt}}` do the same thing.
 
 ## Reading Stored guidance
 

--- a/docs/chats/sending-and-streaming.md
+++ b/docs/chats/sending-and-streaming.md
@@ -1,6 +1,6 @@
 # Sending and Streaming Messages
 
-This guide covers the basics of every chat in Marinara Engine. It explains how you send a message, how the AI reply streams onto the screen, and how to stop or retry a reply. It also covers attachments, the "thinking" indicators, and what to do when a generation error appears.
+This guide covers the basics of every chat in Guksu Motor. It explains how you send a message, how the AI reply streams onto the screen, and how to stop or retry a reply. It also covers attachments, the "thinking" indicators, and what to do when a generation error appears.
 
 ## Send a message
 
@@ -31,7 +31,7 @@ When a mode's toggle is off, pressing Enter adds a new line instead. You then cl
 
 You can attach images or files so the AI can see or read them. Click the paperclip control in the input bar and pick a file. Attached files show as small chips above the input before you send.
 
-Marinara accepts these file types:
+Guksu accepts these file types:
 
 - Images.
 - PDF files.
@@ -39,7 +39,7 @@ Marinara accepts these file types:
 
 Each file must be 20 MB or smaller. A larger file is rejected with a note that says the file is too large. An unsupported file type is rejected with a note that lists the allowed types.
 
-The AI can only "see" an image if the connected model supports vision. If your model is text only, turn on **Image Captioning**. This setting lives in the per chat **Chat Settings**, in the **Advanced Parameters** section, and is off by default. When on, Marinara describes each attached image in text using a connection you pick, then sends that description instead of the raw image.
+The AI can only "see" an image if the connected model supports vision. If your model is text only, turn on **Image Captioning**. This setting lives in the per chat **Chat Settings**, in the **Advanced Parameters** section, and is off by default. When on, Guksu describes each attached image in text using a connection you pick, then sends that description instead of the raw image.
 
 ## Streaming the reply
 
@@ -55,11 +55,11 @@ Streaming shows the reply appearing word by word as it generates, instead of wai
 
 When **Enable streaming** is off, the full reply appears all at once after the model finishes.
 
-**Trim incomplete model endings** only affects the saved message. When on, Marinara removes a trailing unfinished sentence from the reply. It leaves complete replies and command style endings alone.
+**Trim incomplete model endings** only affects the saved message. When on, Guksu removes a trailing unfinished sentence from the reply. It leaves complete replies and command style endings alone.
 
 ## Typing and progress indicators
 
-Before the first word of a reply arrives, Marinara shows that the character is working. You see the character's name with three animated dots. In a group chat the names of every replying character appear together.
+Before the first word of a reply arrives, Guksu shows that the character is working. You see the character's name with three animated dots. In a group chat the names of every replying character appear together.
 
 While the server prepares the prompt, a short progress line cycles through these labels:
 
@@ -71,17 +71,17 @@ While the server prepares the prompt, a short progress line cycles through these
 - **Retrieving knowledge...**
 - **Generating...**
 
-Each label matches a step Marinara runs before or during the reply. The line clears once the first word of the reply streams in. Some steps only run when a chat uses that feature, so you may not see every label.
+Each label matches a step Guksu runs before or during the reply. The line clears once the first word of the reply streams in. Some steps only run when a chat uses that feature, so you may not see every label.
 
 If a character's presence is set to a busy or away status, a waiting indicator appears instead of the typing dots. The reply starts once the character is available again.
 
 ## See the model's thinking
 
-Some models expose a hidden reasoning trace, often called "thinking". Marinara keeps this separate from the visible reply.
+Some models expose a hidden reasoning trace, often called "thinking". Guksu keeps this separate from the visible reply.
 
 When a reply has thinking attached, a **View thoughts** action (a brain icon) appears on that message. Click it to open a panel that shows the captured reasoning text.
 
-For the reasoning to show, the model must actually return it. Some models wrap their reasoning in plain text tags. For those, set custom **Thinking Tags** on the connection so Marinara can split the hidden reasoning from the visible reply. Several common tag pairs are already recognized. See the generation parameters guide below for how to set **Thinking Tags**.
+For the reasoning to show, the model must actually return it. Some models wrap their reasoning in plain text tags. For those, set custom **Thinking Tags** on the connection so Guksu can split the hidden reasoning from the visible reply. Several common tag pairs are already recognized. See the generation parameters guide below for how to set **Thinking Tags**.
 
 ## Stop a reply
 
@@ -99,9 +99,9 @@ In Roleplay mode there is a related shortcut. Press **Send** with an empty box t
 
 ## When a generation error appears
 
-If a reply fails, Marinara shows a toast notification at the bottom of the screen. The toast stays up for about 15 seconds, and you can copy its text. A stopped reply is not treated as an error.
+If a reply fails, Guksu shows a toast notification at the bottom of the screen. The toast stays up for about 15 seconds, and you can copy its text. A stopped reply is not treated as an error.
 
-For some common problems, Marinara rewrites the raw error into a clear next step:
+For some common problems, Guksu rewrites the raw error into a clear next step:
 
 - If the model rejects a parameter it does not support, the toast tells you how to fix it. Go to **Chat Settings**, open **Advanced Parameters**, and turn off **Send** for that parameter.
 - If the model requires a parameter that is off, the toast tells you to turn it back on. Go to the same place and turn on **Send** for that parameter.
@@ -118,11 +118,11 @@ If an error keeps happening, the troubleshooting guide below has more fixes for 
 
 A long reply can take a while, and that is normal. You can stop the reply at any time with the stop button.
 
-On mobile, the browser may pause a chat tab when you switch away from it. If the reply was still streaming, Marinara shows a **Finishing in background...** state. It then checks whether the reply finished on the server. If it is taking longer, you see a note that says the reply is still finishing in the background. Refresh the chat in a moment if it has not appeared.
+On mobile, the browser may pause a chat tab when you switch away from it. If the reply was still streaming, Guksu shows a **Finishing in background...** state. It then checks whether the reply finished on the server. If it is taking longer, you see a note that says the reply is still finishing in the background. Refresh the chat in a moment if it has not appeared.
 
 ## Related guides
 
 - [Message Actions: Edit, Delete, Swipe, Regenerate](messages.md)
 - [Connecting to an AI Provider](../connections/connecting-to-a-provider.md)
 - [Generation Parameters](../prompts/generation-parameters.md)
-- [Troubleshooting Marinara Engine](../TROUBLESHOOTING.md)
+- [Troubleshooting Guksu Motor](../TROUBLESHOOTING.md)

--- a/docs/chats/slash-commands.md
+++ b/docs/chats/slash-commands.md
@@ -1,6 +1,6 @@
 # Slash Commands Reference
 
-This guide lists the slash commands you can type in a Marinara Engine chat. A slash command is a shortcut you type in the message box, starting with a forward slash, to do something quickly. Some commands act on your screen right away, and some ask the AI to write something.
+This guide lists the slash commands you can type in a Guksu Motor chat. A slash command is a shortcut you type in the message box, starting with a forward slash, to do something quickly. Some commands act on your screen right away, and some ask the AI to write something.
 
 ## How slash commands work
 
@@ -18,7 +18,7 @@ Some commands run in your browser and change the chat right away, with no cost. 
 
 Slash commands work in the **Conversation** and **Roleplay** message boxes. In **Game** mode, only `/illustrate` works as a slash command. Anything else you type starting with a slash is sent as normal text.
 
-Several commands use message numbers. Marinara counts messages from the first message in the chat as number 1, then 2, then 3, and so on. Commands like `/goto`, `/hide`, and `/unhide` use these numbers.
+Several commands use message numbers. Guksu counts messages from the first message in the chat as number 1, then 2, then 3, and so on. Commands like `/goto`, `/hide`, and `/unhide` use these numbers.
 
 ## Chat and message commands
 
@@ -85,7 +85,7 @@ The `/roll` command reads dice notation. This rolls two six-sided dice:
 /roll 2d6
 ```
 
-You can add a modifier, like `/roll 1d20+5`. If you type `/roll` with nothing after it, Marinara rolls `1d20`.
+You can add a modifier, like `/roll 1d20+5`. If you type `/roll` with nothing after it, Guksu rolls `1d20`.
 
 A sprite is a piece of character art that shows an expression. The `/emote` command switches which one is shown. Type `/emote` alone to see the available expressions, or name one to switch to it:
 

--- a/docs/connections/connecting-to-a-provider.md
+++ b/docs/connections/connecting-to-a-provider.md
@@ -1,20 +1,20 @@
 # Connecting to an AI Provider
 
-This guide shows you how to connect Marinara Engine to an AI provider so your characters can reply. You will create a connection, paste an API key, pick a model, and test that it works.
+This guide shows you how to connect Guksu Motor to an AI provider so your characters can reply. You will create a connection, paste an API key, pick a model, and test that it works.
 
 ## What a connection is
 
-A connection is a saved setup that tells Marinara Engine how to reach one AI service. Each connection stores four things: the provider, the API key or login, the base URL (the web address of the service), and the model.
+A connection is a saved setup that tells Guksu Motor how to reach one AI service. Each connection stores four things: the provider, the API key or login, the base URL (the web address of the service), and the model.
 
-An API key is a secret code from your AI provider. It works like a password. It lets Marinara talk to the AI service and use your account there. Marinara stores your key encrypted, and it is never included when you export a connection.
+An API key is a secret code from your AI provider. It works like a password. It lets Guksu talk to the AI service and use your account there. Guksu stores your key encrypted, and it is never included when you export a connection.
 
-Marinara Engine does not come with a ready-made connection or a free starter key. A fresh install has zero connections. You must create at least one connection before you can start a chat.
+Guksu Motor does not come with a ready-made connection or a free starter key. A fresh install has zero connections. You must create at least one connection before you can start a chat.
 
 ## Opening the Connections panel
 
 You manage connections in the **Connections** panel on the right side of the app.
 
-If you have no connections yet and you try to start a chat, Marinara shows a **Set Up** dialog. That dialog has an **Open Connections** button. Click it to jump straight to the **Connections** panel.
+If you have no connections yet and you try to start a chat, Guksu shows a **Set Up** dialog. That dialog has an **Open Connections** button. Click it to jump straight to the **Connections** panel.
 
 At the top of the panel you will see three buttons. They show icons only, with no text labels.
 
@@ -29,12 +29,12 @@ Follow these steps to add your first provider.
 1. In the **Connections** panel, click the **New** button (the plus icon).
 2. In the **Create Connection** window, type a **Name** for the connection. Pick something you will recognize later, for example `GPT-4o Main`.
 3. Under **Provider**, click the button for the service you want, for example **OpenAI**, **Anthropic**, or **OpenRouter**.
-4. Click **Create**. Marinara creates the connection and opens the full **Connection Editor** for it.
+4. Click **Create**. Guksu creates the connection and opens the full **Connection Editor** for it.
 5. Find the **API Key** field. Paste your key from the provider here. If you do not have a key yet, click the **Get your {Provider} API key** link under the field. That link opens the provider's key page in your browser.
 6. Open the **Model** dropdown and pick a model. You can type in the **Search models...** box to filter the list. If the list is empty, click **Fetch Models from API** to load the models your account can use.
 7. Click **Save**. The status text near the top changes to **Saved**.
 
-You usually do not need to touch the **Base URL** field. Marinara fills it in for known providers. Only change it if you use a proxy or a local server.
+You usually do not need to touch the **Base URL** field. Guksu fills it in for known providers. Only change it if you use a proxy or a local server.
 
 For the list of every supported provider, its default settings, and where to get each key, see [Supported AI Providers](providers-reference.md).
 
@@ -72,11 +72,11 @@ If a test or a message fails, check these first:
 - A key from the wrong provider. Each provider needs its own key. Switching the **Provider** clears the **API Key** field on purpose.
 - A blocked or unreachable **Base URL**. Leave it blank to use the provider default, unless you run a local or proxy server.
 
-For more fixes to connection and generation errors, see [Troubleshooting Marinara Engine](../TROUBLESHOOTING.md).
+For more fixes to connection and generation errors, see [Troubleshooting Guksu Motor](../TROUBLESHOOTING.md).
 
 ## Related guides
 
 - [Supported AI Providers](providers-reference.md)
 - [Claude, ChatGPT, and Grok Subscription Connections](subscription-clis.md)
 - [Connecting a Local or Self-Hosted Model](local-self-hosted.md)
-- [Troubleshooting Marinara Engine](../TROUBLESHOOTING.md)
+- [Troubleshooting Guksu Motor](../TROUBLESHOOTING.md)

--- a/docs/connections/local-model.md
+++ b/docs/connections/local-model.md
@@ -1,12 +1,12 @@
 # Local Model Setup
 
-This guide explains the built-in **Local Model**, a small AI model that Marinara Engine downloads and runs on your own machine. It needs no API key and no online account. This guide covers setup, the **Runtime Settings**, and how the Local Model powers helpers like tracker agents, Game Mode scene effects, and offline call transcription.
+This guide explains the built-in **Local Model**, a small AI model that Guksu Motor downloads and runs on your own machine. It needs no API key and no online account. This guide covers setup, the **Runtime Settings**, and how the Local Model powers helpers like tracker agents, Game Mode scene effects, and offline call transcription.
 
 ## What the Local Model is
 
-The **Local Model** is a compact language model (Gemma) that runs entirely on your computer. An API key is a secret code that lets Marinara talk to an online AI service. The Local Model needs no API key, because nothing leaves your machine.
+The **Local Model** is a compact language model (Gemma) that runs entirely on your computer. An API key is a secret code that lets Guksu talk to an online AI service. The Local Model needs no API key, because nothing leaves your machine.
 
-The Local Model is deliberately small. It is meant for background helper work, not for your main chat or roleplay. Marinara uses it for these jobs:
+The Local Model is deliberately small. It is meant for background helper work, not for your main chat or roleplay. Guksu uses it for these jobs:
 
 - Tracker agents in Roleplay mode.
 - Scene effects in Game Mode, such as backgrounds, music, and weather.
@@ -37,7 +37,7 @@ Support depends on your operating system:
 
 - **Windows (64-bit) and Linux (64-bit)**: You get a full **Runtime Target** picker, so you can choose your graphics card (GPU) family or run on the processor (CPU) only.
 - **Windows on ARM and Linux on ARM**: A reduced set of options, mostly CPU based.
-- **macOS on Apple Silicon**: Marinara uses the MLX runtime, tuned for Apple chips. Custom models are HuggingFace repositories instead of single files.
+- **macOS on Apple Silicon**: Guksu uses the MLX runtime, tuned for Apple chips. Custom models are HuggingFace repositories instead of single files.
 - **macOS on Intel and Android**: Effectively CPU only.
 
 The Local Model is not available in "Lite" installs. A Lite install is a slimmed-down build that leaves out the local runtime to save space. On a Lite install, the Local Model card does not appear.
@@ -88,7 +88,7 @@ Under **Use Your Own Model From HuggingFace** you can supply your own model from
 3. On non-Apple hardware, pick a specific file from the dropdown, then click **Download Selected GGUF**.
 4. On Apple Silicon, once the repository is validated, click **Use Validated MLX Repo**.
 
-Marinara keeps only one Local Model file on disk at a time. Downloading a new model deletes the old one first. There is no separate delete button for the main Local Model. To remove it, download a different model over it.
+Guksu keeps only one Local Model file on disk at a time. Downloading a new model deletes the old one first. There is no separate delete button for the main Local Model. To remove it, download a different model over it.
 
 ## Runtime Settings reference
 
@@ -100,7 +100,7 @@ Open the **Runtime Settings** section inside the setup window to tune how the mo
 
 | Setting | Default | What it controls |
 | --- | --- | --- |
-| Runtime Target | Auto detect | Which GPU family Marinara installs for |
+| Runtime Target | Auto detect | Which GPU family Guksu installs for |
 | GPU Offload | Auto offload | How much work goes to the GPU |
 | Native Tool Calls | On | Lets the model use tools and function calls |
 | Pooling Type | None | Embedding math for lorebook search |
@@ -138,7 +138,7 @@ Once a model is downloaded, the Local Model card shows two switches:
 - **Use for tracker agents (roleplay)**. This is off by default.
 - **Use for game scene analysis**. This is on by default.
 
-These two switches decide whether Marinara keeps the Local Model running in the background. If both are off, the runtime does not start on its own. Turning either one on makes Marinara start the local server automatically. The first start after you turn one on can take a moment.
+These two switches decide whether Guksu keeps the Local Model running in the background. If both are off, the runtime does not start on its own. Turning either one on makes Guksu start the local server automatically. The first start after you turn one on can take a moment.
 
 The card also has a **Use local model for all tracker agents** button. It points every built-in tracker agent at the Local Model in one click. A line below shows how many tracker agents point at the local model, for example "3/7 built-in tracker agents currently point at the local model." This only changes which model the agents use. It does not turn the agents on. See [Memory Recall and Chat Summaries](../agents/memory.md) and your mode guide for enabling agents.
 
@@ -188,13 +188,13 @@ SIDECAR_RUNTIME_INSTALL_ENABLED=true
 
 Or enter your Admin Access secret once in **Settings -> Advanced -> Admin Access**, then try again. See [Server Configuration Reference](../CONFIGURATION.md).
 
-**The runtime failed to start.** The setup window shows a box titled **Local runtime failed to start** with the error and a log file path. Click **Retry Startup**. If that fails, click **Reinstall Runtime**, or try a different **Runtime Target**. You can click **Continue Without Local AI** to keep using Marinara without the Local Model. The Connections card shows the same problem as **Local runtime unavailable**.
+**The runtime failed to start.** The setup window shows a box titled **Local runtime failed to start** with the error and a log file path. Click **Retry Startup**. If that fails, click **Reinstall Runtime**, or try a different **Runtime Target**. You can click **Continue Without Local AI** to keep using Guksu without the Local Model. The Connections card shows the same problem as **Local runtime unavailable**.
 
 **Lorebook search says the local model is not enabled.** Turn on **Use for tracker agents (roleplay)** or **Use for game scene analysis** in the Local Model card, then try the vectorization again.
 
 **A Game Mode banner reads "Local scene helper failed to start."** Click **Open Local AI Model** in the banner to retry, switch models, or turn off local scene analysis.
 
-For more help, see [Troubleshooting Marinara Engine](../TROUBLESHOOTING.md).
+For more help, see [Troubleshooting Guksu Motor](../TROUBLESHOOTING.md).
 
 ## Related guides
 

--- a/docs/connections/local-self-hosted.md
+++ b/docs/connections/local-self-hosted.md
@@ -1,20 +1,20 @@
 # Connecting a Local or Self-Hosted Model
 
-This guide shows you how to connect Marinara Engine to an AI model that runs on your own computer or your own server. It covers popular local model servers like Ollama, LM Studio, and KoboldCpp, plus the settings that make them work.
+This guide shows you how to connect Guksu Motor to an AI model that runs on your own computer or your own server. It covers popular local model servers like Ollama, LM Studio, and KoboldCpp, plus the settings that make them work.
 
 ## What self-hosted means
 
-A self-hosted model is an AI model that runs on hardware you control. You install a local model server, that server loads a model, and the server answers requests at a web address on your machine. Marinara Engine then talks to that address instead of a paid cloud service.
+A self-hosted model is an AI model that runs on hardware you control. You install a local model server, that server loads a model, and the server answers requests at a web address on your machine. Guksu Motor then talks to that address instead of a paid cloud service.
 
 Common local model servers include Ollama, LM Studio, and KoboldCpp. Each one runs on your computer and gives you a private endpoint. An endpoint is the web address where the server listens for requests.
 
-This guide is about external local servers that you install and run yourself. Marinara also ships its own small built-in model that needs no separate server. If you want that instead, see the [Local Model Setup](local-model.md) guide.
+This guide is about external local servers that you install and run yourself. Guksu also ships its own small built-in model that needs no separate server. If you want that instead, see the [Local Model Setup](local-model.md) guide.
 
-Before you start, make sure your local model server is already installed, running, and has a model loaded. Marinara does not start that server for you. It only connects to it.
+Before you start, make sure your local model server is already installed, running, and has a model loaded. Guksu does not start that server for you. It only connects to it.
 
 ## Set up a Custom connection
 
-Marinara connects to local servers through the **Custom (OAI-Compatible)** provider. OAI-compatible means the server speaks the same request format as the OpenAI Chat Completions API. Ollama, LM Studio, and KoboldCpp all offer this format.
+Guksu connects to local servers through the **Custom (OAI-Compatible)** provider. OAI-compatible means the server speaks the same request format as the OpenAI Chat Completions API. Ollama, LM Studio, and KoboldCpp all offer this format.
 
 Follow these steps to create the connection.
 
@@ -34,7 +34,7 @@ The **API Key** field is optional for local servers. For the **Custom (OAI-Compa
 
 ## Base URLs for common local servers
 
-The **Base URL** tells Marinara where your local server listens. Each server has a default address and port. A port is the numbered channel a server uses on your machine. Use the address for the server you run.
+The **Base URL** tells Guksu where your local server listens. Each server has a default address and port. A port is the numbered channel a server uses on your machine. Use the address for the server you run.
 
 | Local server | Base URL |
 |---|---|
@@ -42,7 +42,7 @@ The **Base URL** tells Marinara where your local server listens. Each server has
 | LM Studio | `http://localhost:1234/v1` |
 | KoboldCpp | `http://localhost:5001/v1` |
 
-Here `localhost` means "this same computer." If Marinara runs on the same computer as your model server, these addresses work as written.
+Here `localhost` means "this same computer." If Guksu runs on the same computer as your model server, these addresses work as written.
 
 The **Base URL** field shows a safety warning: "Only use URLs from providers you trust. A malicious endpoint could intercept your messages and API keys." Only enter an address you set up yourself or fully trust.
 
@@ -54,15 +54,15 @@ On Windows, a local server can be blocked even when it is running. The editor sh
 
 The connection editor has a **Local / Custom Endpoint** section with a toggle labeled **Treat as local/custom endpoint**. It is off by default. Turn it on for self-hosted or proxied endpoints, especially a custom web address that points at a model server on your local network.
 
-When this toggle is off, Marinara plays it safe with tool calls for models it does not recognize. Turning the toggle on tells Marinara to always attempt tool calls. It also tells Professor Mari to use a backup tool method (a JSON tool protocol) instead of native tool calls only. Professor Mari is the in-app assistant.
+When this toggle is off, Guksu plays it safe with tool calls for models it does not recognize. Turning the toggle on tells Guksu to always attempt tool calls. It also tells Professor Mari to use a backup tool method (a JSON tool protocol) instead of native tool calls only. Professor Mari is the in-app assistant.
 
 Turn this toggle on if Professor Mari stops after using a tool. Turn it on too if your endpoint claims OpenAI compatibility but does not reliably support tool calls. If your local model works fine without it, you can leave it off.
 
 ## Reaching a server on another computer
 
-Marinara always allows connections to your own computer. Addresses like `localhost` and `127.0.0.1` are called loopback addresses, meaning "this same machine." These always work for a connection, with no extra setup.
+Guksu always allows connections to your own computer. Addresses like `localhost` and `127.0.0.1` are called loopback addresses, meaning "this same machine." These always work for a connection, with no extra setup.
 
-If your model server runs on a different computer on your home or office network, that is a private network address. Marinara blocks private network addresses by default for safety. To allow them, the person who runs the Marinara server must set an environment variable. An environment variable is a setting the server reads when it starts.
+If your model server runs on a different computer on your home or office network, that is a private network address. Guksu blocks private network addresses by default for safety. To allow them, the person who runs the Guksu server must set an environment variable. An environment variable is a setting the server reads when it starts.
 
 Add this line to the server `.env` file:
 
@@ -70,7 +70,7 @@ Add this line to the server `.env` file:
 PROVIDER_LOCAL_URLS_ENABLED=true
 ```
 
-Save the file and restart the Marinara server for the change to take effect. After that, you can use a Base URL that points at another machine on your network, such as `http://192.168.1.50:11434/v1`.
+Save the file and restart the Guksu server for the change to take effect. After that, you can use a Base URL that points at another machine on your network, such as `http://192.168.1.50:11434/v1`.
 
 On Android, this setting is turned on by default when you do not set it. For more about the `.env` file and server settings, see the [Server Configuration Reference](../CONFIGURATION.md).
 
@@ -85,7 +85,7 @@ The connection editor has a **Connection Tests** card at the bottom. Use it befo
 
 If both tests succeed, your local model is ready to use in a chat. Open a chat, open its settings, and pick this connection.
 
-If a test fails, first check that your local server is still running and that the model is loaded. Then check that the **Base URL** matches the server's address and port exactly. For a server on another computer, confirm that `PROVIDER_LOCAL_URLS_ENABLED` is set and that you restarted the Marinara server.
+If a test fails, first check that your local server is still running and that the model is loaded. Then check that the **Base URL** matches the server's address and port exactly. For a server on another computer, confirm that `PROVIDER_LOCAL_URLS_ENABLED` is set and that you restarted the Guksu server.
 
 ## Related guides
 

--- a/docs/connections/organizing-connections.md
+++ b/docs/connections/organizing-connections.md
@@ -1,6 +1,6 @@
 # Organizing Connections
 
-This guide covers how to keep your saved connections tidy in Marinara Engine. It explains connection folders, search and sort, duplicating and deleting, the random pool, the Quick Connection Switcher, and exporting or importing connections. A connection is a saved setup that tells Marinara how to reach one AI service.
+This guide covers how to keep your saved connections tidy in Guksu Motor. It explains connection folders, search and sort, duplicating and deleting, the random pool, the Quick Connection Switcher, and exporting or importing connections. A connection is a saved setup that tells Guksu how to reach one AI service.
 
 You do all of this in the **Connections** panel. Open it, and your saved connections appear as a list of rows. Each row shows the connection name and its provider and model below the name.
 
@@ -20,7 +20,7 @@ To file a connection into a folder, drag the connection row and drop it onto the
 
 To collapse or expand a folder, click the folder row once. A small number on the folder row shows how many connections are inside.
 
-To delete a folder, click the trash icon on the folder row. If the folder still has connections inside, Marinara asks you to confirm with a **Delete Folder** dialog. An empty folder is deleted right away, with no confirmation prompt. Deleting a folder does not delete the connections inside it. Those connections move back to the unfiled area instead.
+To delete a folder, click the trash icon on the folder row. If the folder still has connections inside, Guksu asks you to confirm with a **Delete Folder** dialog. An empty folder is deleted right away, with no confirmation prompt. Deleting a folder does not delete the connections inside it. Those connections move back to the unfiled area instead.
 
 ## Search and sort
 
@@ -44,7 +44,7 @@ Hover over a connection row (or look at the row on a touch screen) to see its ac
 
 To duplicate a connection, click the **Duplicate** button (the copy icon). This makes a full copy, including the stored API key. The copy opens in the editor so you can rename it. There is no confirmation step.
 
-To delete a single connection, click its **Delete** button (the trash icon). Marinara shows a **Delete Connection** dialog that reads Delete "your connection name"? This cannot be undone. Click **Delete** to confirm.
+To delete a single connection, click its **Delete** button (the trash icon). Guksu shows a **Delete Connection** dialog that reads Delete "your connection name"? This cannot be undone. Click **Delete** to confirm.
 
 To delete or export several connections at once, click the **Select** button at the top of the panel. This turns on selection mode. Tap the connections you want, then use the **Export** or **Delete** button in the action bar at the bottom. Bulk delete shows a **Delete Connections** dialog before it removes them.
 
@@ -68,7 +68,7 @@ You can export connections to a file to back them up or move them to another ins
 
 **Your API keys are never included in an export.** After you import connections, you must open each one and enter its API key again.
 
-To export a single connection, open it in the editor and click its **Export** button (the upload icon). To export several at once, use **Select** mode in the panel and click **Export** in the action bar. Before the download starts, Marinara shows an **Export Connection Data** dialog with this warning: This will export your connection data, WITHOUT your provided API Key. Remember to never share those with others! Click **Export** to continue.
+To export a single connection, open it in the editor and click its **Export** button (the upload icon). To export several at once, use **Select** mode in the panel and click **Export** in the action bar. Before the download starts, Guksu shows an **Export Connection Data** dialog with this warning: This will export your connection data, WITHOUT your provided API Key. Remember to never share those with others! Click **Export** to continue.
 
 A single connection downloads as a `.connection.json` file. Several connections download together as a `marinara-connections.zip` file.
 

--- a/docs/connections/providers-reference.md
+++ b/docs/connections/providers-reference.md
@@ -1,6 +1,6 @@
 # Supported AI Providers
 
-This guide lists every AI provider Marinara Engine can connect to. For each one it tells you where to get an API key, the default base URL, and any quirks to know. An API key is a secret password from a provider that lets Marinara talk to their AI service.
+This guide lists every AI provider Guksu Motor can connect to. For each one it tells you where to get an API key, the default base URL, and any quirks to know. An API key is a secret password from a provider that lets Guksu talk to their AI service.
 
 To learn the general steps for adding a connection, read [Connecting to an AI Provider](connecting-to-a-provider.md) first. This page is a reference you can search when you want details on one specific provider.
 
@@ -12,7 +12,7 @@ Most providers on this page are cloud services that host the AI for you. You mak
 
 You will see two terms often:
 
-- Base URL: the web address Marinara sends requests to. Most providers fill this in for you. You only change it for local or custom servers.
+- Base URL: the web address Guksu sends requests to. Most providers fill this in for you. You only change it for local or custom servers.
 - Model: the specific AI model you pick after choosing a provider. Available models change often, so this page does not list them. Use the **Model** dropdown or the **Fetch Models from API** button in the connection editor to see the current list.
 
 ## OpenAI
@@ -29,7 +29,7 @@ You will see two terms often:
 
 **Anthropic** runs the Claude models. It supports prompt caching, which can lower the cost of long chats. You can turn this on with the **Enable prompt caching** toggle in the connection editor.
 
-**Anthropic** does not offer embeddings. Embeddings turn text into number lists so Marinara can search lorebooks and memory. For those features, use a separate embedding connection (see the Embeddings section below).
+**Anthropic** does not offer embeddings. Embeddings turn text into number lists so Guksu can search lorebooks and memory. For those features, use a separate embedding connection (see the Embeddings section below).
 
 ## Google Gemini
 
@@ -45,7 +45,7 @@ You will see two terms often:
 
 **Google Vertex AI** runs Gemini models through a Google Cloud project. It needs more setup than **Google Gemini**. You must edit the **Base URL** and replace `YOUR_PROJECT_ID` with your real project ID. Also change the region if it is not `us-central1`.
 
-The **API Key** field accepts any one of these three credential types, and Marinara detects which one you pasted:
+The **API Key** field accepts any one of these three credential types, and Guksu detects which one you pasted:
 
 1. A service-account JSON key.
 2. An OAuth access token, for example from `gcloud auth print-access-token`.
@@ -63,7 +63,7 @@ The **API Key** field accepts any one of these three credential types, and Marin
 - Where to get a key: `https://dashboard.cohere.com/api-keys`
 - Default base URL: `https://api.cohere.ai/compatibility/v1`
 
-**Cohere** uses its OpenAI-compatible endpoint by default. If you paste an older Cohere v2 URL, Marinara switches it to the compatibility endpoint for you. Requests still work.
+**Cohere** uses its OpenAI-compatible endpoint by default. If you paste an older Cohere v2 URL, Guksu switches it to the compatibility endpoint for you. Requests still work.
 
 ## OpenRouter
 
@@ -87,13 +87,13 @@ The **API Key** field accepts any one of these three credential types, and Marin
 - Where to get a key: `https://console.x.ai`
 - Default base URL: `https://api.x.ai/v1`
 
-**xAI / Grok** runs the Grok models. When you pick this provider in the **Create Connection** modal, Marinara prefills the model with Grok 4.5. You can change the model afterward.
+**xAI / Grok** runs the Grok models. When you pick this provider in the **Create Connection** modal, Guksu prefills the model with Grok 4.5. You can change the model afterward.
 
 ## Claude (Subscription)
 
 - API key: none. You sign in to a local tool instead.
 
-**Claude (Subscription)** uses your Anthropic Pro or Max plan through the Claude Code tool. The tool runs on the computer that hosts the Marinara server, and you sign in once. The **API Key** and **Base URL** fields are hidden for this provider. It does not offer embeddings (see the Embeddings section below).
+**Claude (Subscription)** uses your Anthropic Pro or Max plan through the Claude Code tool. The tool runs on the computer that hosts the Guksu server, and you sign in once. The **API Key** and **Base URL** fields are hidden for this provider. It does not offer embeddings (see the Embeddings section below).
 
 Install and login steps are in [Claude, ChatGPT, and Grok Subscription Connections](subscription-clis.md).
 
@@ -101,7 +101,7 @@ Install and login steps are in [Claude, ChatGPT, and Grok Subscription Connectio
 
 - API key: none. You sign in to a local tool instead.
 
-**OpenAI (ChatGPT)** uses your ChatGPT account through the Codex tool. The tool runs on the computer that hosts the Marinara server, and you sign in once. The **API Key** and **Base URL** fields are hidden for this provider. It does not offer embeddings (see the Embeddings section below).
+**OpenAI (ChatGPT)** uses your ChatGPT account through the Codex tool. The tool runs on the computer that hosts the Guksu server, and you sign in once. The **API Key** and **Base URL** fields are hidden for this provider. It does not offer embeddings (see the Embeddings section below).
 
 Install and login steps are in [Claude, ChatGPT, and Grok Subscription Connections](subscription-clis.md).
 
@@ -109,7 +109,7 @@ Install and login steps are in [Claude, ChatGPT, and Grok Subscription Connectio
 
 - API key: none. You sign in to a local tool instead.
 
-**Grok CLI (Subscription)** uses your SuperGrok or X Premium+ account through the Grok CLI tool. The tool runs on the computer that hosts the Marinara server, and you sign in once. The **API Key** and **Base URL** fields are hidden for this provider. It does not offer embeddings (see the Embeddings section below).
+**Grok CLI (Subscription)** uses your SuperGrok or X Premium+ account through the Grok CLI tool. The tool runs on the computer that hosts the Guksu server, and you sign in once. The **API Key** and **Base URL** fields are hidden for this provider. It does not offer embeddings (see the Embeddings section below).
 
 Install and login steps are in [Claude, ChatGPT, and Grok Subscription Connections](subscription-clis.md).
 
@@ -119,7 +119,7 @@ Install and login steps are in [Claude, ChatGPT, and Grok Subscription Connectio
 
 Pick **Custom (OAI-Compatible)** to connect a local or self-hosted model server, such as Ollama, LM Studio, or KoboldCpp. It also works for any hosted proxy that speaks the OpenAI chat format. The **API Key** can be left empty for most local servers. You set the **Base URL** to your server address.
 
-For step-by-step setup and the **Treat as local/custom endpoint** toggle, read [Connecting a Local or Self-Hosted Model](local-self-hosted.md). For the small model that ships inside Marinara, read [Local Model Setup](local-model.md).
+For step-by-step setup and the **Treat as local/custom endpoint** toggle, read [Connecting a Local or Self-Hosted Model](local-self-hosted.md). For the small model that ships inside Guksu, read [Local Model Setup](local-model.md).
 
 ## Image Generation
 
@@ -135,7 +135,7 @@ The full setup and limits for each video service live in [Scene Video Generation
 
 ## Embeddings
 
-Embeddings power lorebook semantic search and Memory Recall. They turn text into number lists so Marinara can find related entries. Most chat providers let you set an **Embedding Model** and an optional **Embedding Endpoint URL** in the connection editor.
+Embeddings power lorebook semantic search and Memory Recall. They turn text into number lists so Guksu can find related entries. Most chat providers let you set an **Embedding Model** and an optional **Embedding Endpoint URL** in the connection editor.
 
 Some providers cannot make embeddings. **Anthropic**, **Claude (Subscription)**, **OpenAI (ChatGPT)**, and **Grok CLI (Subscription)** do not offer them. For those, use the **Embedding Connection** dropdown to borrow another connection, such as an OpenAI-compatible one, **Google Gemini**, or the built-in **Local Model**.
 

--- a/docs/connections/subscription-clis.md
+++ b/docs/connections/subscription-clis.md
@@ -1,12 +1,12 @@
 # Claude, ChatGPT, and Grok Subscription Connections
 
-This guide covers the three connections that sign in through an account instead of an API key: **Claude (Subscription)**, **OpenAI (ChatGPT)**, and **Grok CLI (Subscription)**. You install a small command line tool, log in once, and Marinara Engine uses that account to chat. A command line tool (CLI) is a program you run by typing a command in a terminal window.
+This guide covers the three connections that sign in through an account instead of an API key: **Claude (Subscription)**, **OpenAI (ChatGPT)**, and **Grok CLI (Subscription)**. You install a small command line tool, log in once, and Guksu Motor uses that account to chat. A command line tool (CLI) is a program you run by typing a command in a terminal window.
 
 ## What subscription connections are
 
-Most connections in Marinara Engine use an API key. An API key is a secret string, like a password, that you paste into the connection so the AI service can bill your account.
+Most connections in Guksu Motor use an API key. An API key is a secret string, like a password, that you paste into the connection so the AI service can bill your account.
 
-These three connections work differently. They use a local login instead of an API key. You sign in to a CLI on your own machine, and Marinara reuses that login. Nothing is pasted into Marinara.
+These three connections work differently. They use a local login instead of an API key. You sign in to a CLI on your own machine, and Guksu reuses that login. Nothing is pasted into Guksu.
 
 Use a subscription connection when your account includes access through one of these CLIs:
 
@@ -22,15 +22,15 @@ The account requirement depends on the provider.
 - **OpenAI (ChatGPT)** supports eligible Free and paid ChatGPT plans. Usage limits vary by plan.
 - **Grok CLI (Subscription)** needs SuperGrok or X Premium+.
 
-For all three providers, the CLI must be installed and logged in on the same machine that runs the Marinara server. This is not the browser or phone you view Marinara on. Marinara runs the CLI locally, so the login has to live next to the server.
+For all three providers, the CLI must be installed and logged in on the same machine that runs the Guksu server. This is not the browser or phone you view Guksu on. Guksu runs the CLI locally, so the login has to live next to the server.
 
-If you run Marinara on your own computer, that computer is the server. If you run it on another machine or in Docker, install and log in the CLI there.
+If you run Guksu on your own computer, that computer is the server. If you run it on another machine or in Docker, install and log in the CLI there.
 
 ## Claude (Subscription)
 
 You need an Anthropic Pro or Max subscription. This is the same sign-in that Visual Studio Code and other Anthropic tools use.
 
-1. On the machine running Marinara, install the Claude Code CLI:
+1. On the machine running Guksu, install the Claude Code CLI:
 
 ```
 npm i -g @anthropic-ai/claude-code
@@ -42,7 +42,7 @@ npm i -g @anthropic-ai/claude-code
 claude auth login
 ```
 
-3. In Marinara, open the **Connections** panel and click **New**.
+3. In Guksu, open the **Connections** panel and click **New**.
 4. In the **Create Connection** modal, type a name and pick the **Claude (Subscription)** provider, then click **Create**.
 5. In the editor, notice there is no **API Key** or **Base URL** field. An info panel confirms they are not required.
 6. Choose a Claude model, such as an Opus or Sonnet model, from the **Model** dropdown.
@@ -52,9 +52,9 @@ Claude subscription connections support text chat only. This connection has two 
 
 ## OpenAI (ChatGPT)
 
-You need a ChatGPT account. Marinara routes chat through the Codex CLI login.
+You need a ChatGPT account. Guksu routes chat through the Codex CLI login.
 
-1. On the machine running Marinara, install the Codex CLI:
+1. On the machine running Guksu, install the Codex CLI:
 
 ```
 npm i -g @openai/codex
@@ -66,18 +66,18 @@ npm i -g @openai/codex
 codex login
 ```
 
-3. In Marinara, open the **Connections** panel and click **New**.
+3. In Guksu, open the **Connections** panel and click **New**.
 4. In the **Create Connection** modal, type a name and pick the **OpenAI (ChatGPT)** provider, then click **Create**.
 5. Choose a model from the **Model** dropdown. The list comes from your ChatGPT session when available, otherwise a built-in list.
 6. Click **Save**, then click **Send Test Message** to confirm a reply.
 
-Marinara reads your local Codex login file and refreshes the session when it can.
+Guksu reads your local Codex login file and refreshes the session when it can.
 
 ## Grok CLI (Subscription)
 
 You need a SuperGrok or X Premium+ account.
 
-1. On the machine running Marinara, install the Grok CLI:
+1. On the machine running Guksu, install the Grok CLI:
 
 ```
 curl -fsSL https://x.ai/cli/install.sh | bash
@@ -89,7 +89,7 @@ curl -fsSL https://x.ai/cli/install.sh | bash
 grok login
 ```
 
-3. In Marinara, open the **Connections** panel and click **New**.
+3. In Guksu, open the **Connections** panel and click **New**.
 4. In the **Create Connection** modal, type a name and pick the **Grok CLI (Subscription)** provider, then click **Create**.
 5. Pick a model, or leave the **Model** field blank to use the CLI default. The safest model for roleplay is usually `grok-composer-2.5-fast`.
 6. Click **Save**, then click **Send Test Message**. This connection can run a test even with no model set.
@@ -100,7 +100,7 @@ To load Grok models, use the **Fetch Models from Grok CLI** button in the **Mode
 
 ## Why there is no API key field
 
-For all three subscription providers, the **API Key** and **Base URL** fields are hidden. That is on purpose. Your login lives inside the CLI on the server machine, so there is nothing for you to type into Marinara.
+For all three subscription providers, the **API Key** and **Base URL** fields are hidden. That is on purpose. Your login lives inside the CLI on the server machine, so there is nothing for you to type into Guksu.
 
 If you selected the wrong provider by mistake and see no key field, switch back to the provider you meant in the provider grid. The key field returns for API-based providers.
 
@@ -118,7 +118,7 @@ The **Claude (Subscription)** editor has a **Diagnose Model Routing** button in 
 
 1. Pick a model and click **Save**. The button is disabled until a model is selected.
 2. Click **Diagnose Model Routing**.
-3. Read the result. Marinara sends a real prompt through your Claude Code login. It then reports which model your account was actually billed for.
+3. Read the result. Guksu sends a real prompt through your Claude Code login. It then reports which model your account was actually billed for.
 
 This catches a silent downgrade, where you request a larger model like Opus and quietly receive Sonnet or Haiku.
 

--- a/docs/conversation/calls.md
+++ b/docs/conversation/calls.md
@@ -1,10 +1,10 @@
 # Conversation Audio and Video Calls
 
-This guide explains Conversation calls in Marinara Engine. You will learn how a call works, how to set one up, how to talk during a call, and how to fix common problems.
+This guide explains Conversation calls in Guksu Motor. You will learn how a call works, how to set one up, how to talk during a call, and how to fix common problems.
 
 Calls exist only in Conversation Mode. Roleplay and Game chats do not have a call screen.
 
-Calls is an optional agent package. Install **Calls** from **Agents → Download Agents** before following the setup below, then restart Marinara when the catalog asks.
+Calls is an optional agent package. Install **Calls** from **Agents → Download Agents** before following the setup below, then restart Guksu when the catalog asks.
 
 ## What a call is
 
@@ -17,9 +17,9 @@ During a call:
 - You answer by microphone or by typing.
 - You can optionally see looping AI-generated video clips of a character instead of a still avatar.
 
-A call is not a peer-to-peer phone call. Marinara records your local browser microphone or camera. It sends that input to the model you picked for that Conversation. It speaks replies through your TTS provider and stores the call data on your own machine.
+A call is not a peer-to-peer phone call. Guksu records your local browser microphone or camera. It sends that input to the model you picked for that Conversation. It speaks replies through your TTS provider and stores the call data on your own machine.
 
-When the call ends, Marinara writes a short summary of the audio call back into the normal Conversation. The full call transcript stays in separate call storage and is not copied message by message into the main chat.
+When the call ends, Guksu writes a short summary of the audio call back into the normal Conversation. The full call transcript stays in separate call storage and is not copied message by message into the main chat.
 
 ## Before you start
 
@@ -47,22 +47,22 @@ For the full walkthrough, read [Text to Speech (TTS) Setup](../media/tts-setup.m
 5. Set **Voice Option** to **One voice for all characters** or **Selected per character**.
 6. Save, then use the preview button to confirm you hear audio.
 
-For a group call, per-character voices make it much easier to tell who is talking. If a character has no voice that Marinara can resolve, that character becomes text only for the call.
+For a group call, per-character voices make it much easier to tell who is talking. If a character has no voice that Guksu can resolve, that character becomes text only for the call.
 
 ### Choose a microphone input mode
 
 When **Call Audio Pipeline** is on, an **Audio input mode** dropdown appears with four choices. Pick the one that fits your browser and provider.
 
 - **Mic recording + Local Whisper**: records while you are unmuted, ignores silence, and turns your speech into text on your own machine. This is the default and the best choice for Firefox.
-- **Browser speech recognition**: uses your browser Web Speech feature. The Web Speech API is a built-in browser tool for turning speech into text. Support varies by browser, and Marinara falls back to Local Whisper when it is missing.
-- **Manual system dictation**: only puts the cursor in the call text box so your operating system dictation can type there. Marinara does not record your microphone by itself in this mode.
+- **Browser speech recognition**: uses your browser Web Speech feature. The Web Speech API is a built-in browser tool for turning speech into text. Support varies by browser, and Guksu falls back to Local Whisper when it is missing.
+- **Manual system dictation**: only puts the cursor in the call text box so your operating system dictation can type there. Guksu does not record your microphone by itself in this mode.
 - **Provider-native audio/video**: sends your recorded audio or video straight to the Conversation model, when that model can accept media directly. If the model cannot, use Local Whisper or browser speech recognition instead.
 
 The camera and screen buttons appear only when **Camera and screen input** is on. They work only in **Provider-native audio/video** mode. In every other mode the buttons are visible but stay disabled.
 
 ### Download Local Whisper
 
-Local Whisper turns your speech into text on the machine running Marinara. Your microphone audio never leaves that machine for transcription. The resulting text is still sent to your Conversation model as part of the call.
+Local Whisper turns your speech into text on the machine running Guksu. Your microphone audio never leaves that machine for transcription. The resulting text is still sent to your Conversation model as part of the call.
 
 Local Whisper is owned by the Calls package and is the most reliable microphone path for browsers with weak speech support, including Firefox. After installing Calls, open **Connections**, open **Local Model**, expand the card, and find **Local Speech Model**. The section is hidden when Calls is not installed. For the general Local Model card, see [Local Model Setup](../connections/local-model.md).
 
@@ -121,13 +121,13 @@ When calls are on for a chat, a phone button appears next to the conversation na
 
 Click **Start call**. The full call screen opens right away.
 
-Only one call can be active or ringing per chat. If you start a call while one is already going, Marinara reopens that call instead of making a new one.
+Only one call can be active or ringing per chat. If you start a call while one is already going, Guksu reopens that call instead of making a new one.
 
 ### Incoming character calls
 
 A character can ring you if the **Calls** command is on. When that happens and you are inside that chat, an **Incoming call** banner appears above the message box. The banner has a **Decline call** button and an **Answer call** button.
 
-If you are somewhere else in Marinara, an incoming-call notification appears, similar to the notification for an autonomous character message. A short ringing tone plays. Marinara never answers for you, so you must click **Answer call**.
+If you are somewhere else in Guksu, an incoming-call notification appears, similar to the notification for an autonomous character message. A short ringing tone plays. Guksu never answers for you, so you must click **Answer call**.
 
 Only characters that are currently available join a call. If a schedule or status marks a character as offline, that character does not join the call, even though they belong to the chat.
 
@@ -135,7 +135,7 @@ Only characters that are currently available join a call. If a schedule or statu
 
 You can end a call at any time with the red **End call** button. It sits on the call screen and on the minimized popout. A character can also leave or end the call through an in-call command.
 
-When the call ends, Marinara stops recording, closes the media safely, and adds a card to the normal Conversation.
+When the call ends, Guksu stops recording, closes the media safely, and adds a card to the normal Conversation.
 
 ## The call screen and controls
 
@@ -156,7 +156,7 @@ The control bar at the bottom of the stage has icon buttons:
 
 If you stay muted for a while, a reminder appears: "You are muted! Remember to unmute yourself first if you want to talk."
 
-If you leave the Conversation while a call is active, the call shrinks into a small floating popout. The popout shows the chat name, the elapsed time, and a red **End call** button. Click the popout body to return to the full call screen. Marinara keeps the call running while you browse other panels.
+If you leave the Conversation while a call is active, the call shrinks into a small floating popout. The popout shows the chat name, the elapsed time, and a red **End call** button. Click the popout body to return to the full call screen. Guksu keeps the call running while you browse other panels.
 
 ### Soundboard
 
@@ -180,11 +180,11 @@ For more on sprites and the editor, see [Character Sprites (Expressions and Full
 
 The **Generate Clips** button opens the **Generate Call Clips** window. There you choose a **Video Generation Connection** and choose **Use avatar as reference**. Then you pick which standard clips to make. You can also define one custom clip with a **Clip name** and an action description.
 
-The six standard clip types are **Idle**, **Talking**, **Laughing**, **Angry**, **Crying**, and **Sighing**. During a spoken turn, Marinara reads the voice cues in a line, such as `[sighs]` or `[laughs]`. It picks a matching reaction clip, then returns the character to Idle.
+The six standard clip types are **Idle**, **Talking**, **Laughing**, **Angry**, **Crying**, and **Sighing**. During a spoken turn, Guksu reads the voice cues in a line, such as `[sighs]` or `[laughs]`. It picks a matching reaction clip, then returns the character to Idle.
 
 Two extra toggles appear under **Character video presence** when it is on:
 
-- **Automatic video clips generation**: off by default. When on, Marinara auto-generates only the two basic clips, **Idle** and **Talking**, for a call participant that needs them. Reaction clips and custom clips are never auto-generated. You make those by hand from the **Clips** sub-tab.
+- **Automatic video clips generation**: off by default. When on, Guksu auto-generates only the two basic clips, **Idle** and **Talking**, for a call participant that needs them. Reaction clips and custom clips are never auto-generated. You make those by hand from the **Clips** sub-tab.
 - **Custom clips**: off by default. When on, a character can rarely request a one-off clip during a live call, and can replay a ready custom clip afterward. This is meant for special visual requests, not for every mood or line.
 
 Missing clips never block a call. The character just shows a still avatar until a clip is ready. If you trim a clip, it loops inside the trim range you set.
@@ -212,7 +212,7 @@ Some commands add a small system entry to the call chat. For example, a selfie s
 
 ## The call-ended summary
 
-When a call ends, Marinara adds a card to the normal Conversation transcript. The card shows the call status. You may see these titles:
+When a call ends, Guksu adds a card to the normal Conversation transcript. The card shows the call status. You may see these titles:
 
 - **Call Started**
 - **Incoming Call**
@@ -220,7 +220,7 @@ When a call ends, Marinara adds a card to the normal Conversation transcript. Th
 - **Call Declined**
 - **Missed Call**
 
-After a **Call Ended** card, Marinara generates a short audio call summary in the background if anything meaningful happened. It then adds that summary to the Conversation as hidden context that the model can read. This keeps the model aware of what was said without copying the whole call into the visible chat.
+After a **Call Ended** card, Guksu generates a short audio call summary in the background if anything meaningful happened. It then adds that summary to the Conversation as hidden context that the model can read. This keeps the model aware of what was said without copying the whole call into the visible chat.
 
 The detailed call transcript stays in separate call storage. Only the short summary flows back into the normal chat.
 
@@ -232,15 +232,15 @@ If you click **Start call** and see "Conversation call audio is not enabled in C
 
 ### I can hear characters, but they cannot hear me
 
-Open **Chat Settings**, then **Agents**, then **Calls**, and confirm **Call Audio Pipeline** is on. Then confirm your browser has given the Marinara page permission to use the microphone.
+Open **Chat Settings**, then **Agents**, then **Calls**, and confirm **Call Audio Pipeline** is on. Then confirm your browser has given the Guksu page permission to use the microphone.
 
 If you are on Firefox, or browser speech recognition does not work, install Calls and download Local Whisper. Open **Connections**, then **Local Model**, then **Local Speech Model**. Then choose **Mic recording + Local Whisper**.
 
 ### Local Whisper says it is unavailable
 
-Local Whisper needs the native ONNX runtime for your platform. ONNX is the engine that runs the local speech model. If the model was set up for a different Node build, reinstall dependencies with the same Node build you use to run Marinara, then restart.
+Local Whisper needs the native ONNX runtime for your platform. ONNX is the engine that runs the local speech model. If the model was set up for a different Node build, reinstall dependencies with the same Node build you use to run Guksu, then restart.
 
-If you run a "Lite" build of Marinara, Local Whisper is turned off in that build. The app shows: "Local Whisper is disabled in Lite mode. Use a full Marinara install to download and run the local speech model." Use a full install to get Local Whisper.
+If you run a "Lite" build of Guksu, Local Whisper is turned off in that build. The app shows: "Local Whisper is disabled in Lite mode. Use a full Guksu install to download and run the local speech model." Use a full install to get Local Whisper.
 
 ### The browser speech option does nothing
 

--- a/docs/conversation/emoji-stickers-gifs.md
+++ b/docs/conversation/emoji-stickers-gifs.md
@@ -76,13 +76,13 @@ The **GIFs** tab searches Giphy, a large online GIF library. Type in the search 
 
 ### GIF search needs a key
 
-GIF search needs a free Giphy API key. An API key is a secret code that lets Marinara Engine talk to the Giphy service on your behalf. Without a key, the **GIFs** tab shows a setup card instead of results.
+GIF search needs a free Giphy API key. An API key is a secret code that lets Guksu Motor talk to the Giphy service on your behalf. Without a key, the **GIFs** tab shows a setup card instead of results.
 
 To set up GIF search:
 
 1. Open the Giphy Developer Dashboard at `https://developers.giphy.com/dashboard/`.
 2. Create a free API key for a web app.
-3. Add the key to your `.env` file. This is the server settings file for Marinara.
+3. Add the key to your `.env` file. This is the server settings file for Guksu.
 
 Add a line like this to `.env`:
 
@@ -90,7 +90,7 @@ Add a line like this to `.env`:
 GIPHY_API_KEY=your_key_here
 ```
 
-After you add the key, restart Marinara. For a full explanation of the `.env` file, see the server configuration guide linked below.
+After you add the key, restart Guksu. For a full explanation of the `.env` file, see the server configuration guide linked below.
 
 ### GIF content rating
 
@@ -116,7 +116,7 @@ To change a tagged image later, click its tag button again. The menu offers **Re
 
 ## Selection preferences
 
-Marinara can tell the responding character which of your custom emojis and stickers it may use in its reply. You control this with **Selection preferences**.
+Guksu can tell the responding character which of your custom emojis and stickers it may use in its reply. You control this with **Selection preferences**.
 
 To open the panel, click the gear icon labeled **Selection preferences**. It sits at the top of the **Custom emojis** tab and the **Stickers** tab. Both open the same setting. This setting is saved per chat, so each chat can differ.
 

--- a/docs/conversation/getting-started.md
+++ b/docs/conversation/getting-started.md
@@ -1,10 +1,10 @@
 # Conversation Mode: Getting Started
 
-This guide covers Conversation Mode in Marinara Engine, the messenger-style chat mode. It explains what the mode is and how the four-step setup wizard works. It also covers the Conversation-only features you get, such as autonomous messages, presence status, reactions, selfies, and table games.
+This guide covers Conversation Mode in Guksu Motor, the messenger-style chat mode. It explains what the mode is and how the four-step setup wizard works. It also covers the Conversation-only features you get, such as autonomous messages, presence status, reactions, selfies, and table games.
 
 ## What Conversation Mode is
 
-Conversation Mode is one of Marinara Engine's chat modes. It works like a messaging app. You get one or more characters, an input bar, and a scrolling message history.
+Conversation Mode is one of Guksu Motor's chat modes. It works like a messaging app. You get one or more characters, an input bar, and a scrolling message history.
 
 Think of it as sending direct messages, or DMs, the way you would text a friend. There is no game master, no scene art, and no required mechanics. It is the lightest chat mode, and many users spend most of their time here.
 
@@ -93,7 +93,7 @@ Next to the pill is a **What are you doing?** field. Type a short custom activit
 
 ## Reactions and notifications
 
-Any Conversation message can get an emoji reaction. Use the reaction button on a message to add your own. Marinara saves your reaction as a note like `[User reacted with ...]`, and future replies can see it. This lets a character notice that you reacted.
+Any Conversation message can get an emoji reaction. Use the reaction button on a message to add your own. Guksu saves your reaction as a note like `[User reacted with ...]`, and future replies can see it. This lets a character notice that you reacted.
 
 When the **Reactions** command family is on, characters can react too. They can react to your messages or to each other's messages. Reactions are handy in group chats, since a character can respond lightly without a full message.
 
@@ -163,7 +163,7 @@ Group chats have controls for turn-taking, like **Reply When Mentioned**. Open [
 
 ### A character forgets things from earlier
 
-Long chats fill the model's memory. Try a model with a larger context window, or add key facts to a lorebook entry so they stay in context. You can also start a fresh chat with the same character and persona. For more help, see [Troubleshooting Marinara Engine](../TROUBLESHOOTING.md).
+Long chats fill the model's memory. Try a model with a larger context window, or add key facts to a lorebook entry so they stay in context. You can also start a fresh chat with the same character and persona. For more help, see [Troubleshooting Guksu Motor](../TROUBLESHOOTING.md).
 
 ### A selfie does not look like the character
 

--- a/docs/conversation/profiles.md
+++ b/docs/conversation/profiles.md
@@ -17,7 +17,7 @@ The **Convo** tab holds three fields: **Convo Display Name**, **About Me**, and 
 
 **Convo Display Name** is the name shown for this character or persona in Conversation Mode chats. Leave it blank to use the card name instead. Changing it updates the name on existing messages right away. It only affects Conversation Mode.
 
-Characters (not personas) also have a checkbox: **Declare this name on the card in the prompt**. When you turn it on, Marinara adds a short line to the character's card text. That line tells the model which card is shown under which display name. This checkbox needs a display name to be set first.
+Characters (not personas) also have a checkbox: **Declare this name on the card in the prompt**. When you turn it on, Guksu adds a short line to the character's card text. That line tells the model which card is shown under which display name. This checkbox needs a display name to be set first.
 
 The `{{convo_display}}` macro puts the responding character's display name into a custom prompt. A macro is a placeholder like `{{convo_display}}` that gets replaced with real text. It resolves to nothing outside Conversation Mode. See [Macros](../prompts/macros.md).
 
@@ -25,7 +25,7 @@ The `{{convo_display}}` macro puts the responding character's display name into 
 
 **About Me** is a short self-written bio for the character or persona, shown in Conversation Mode. It can be a line or two, a single emoji, a joke, or nothing at all. An emoji button sits in the text box toolbar so you can drop an emoji into the bio.
 
-The bio is not just decoration. By default, Marinara adds the **About Me** of every present character and persona to the prompt on each turn. The bios go in as a short list of participant profiles. This way, the model always knows how each person presents themselves. You do not need to do anything for this to work.
+The bio is not just decoration. By default, Guksu adds the **About Me** of every present character and persona to the prompt on each turn. The bios go in as a short list of participant profiles. This way, the model always knows how each person presents themselves. You do not need to do anything for this to work.
 
 ### Writing an About Me with Professor Mari
 

--- a/docs/conversation/schedules.md
+++ b/docs/conversation/schedules.md
@@ -4,7 +4,7 @@ This guide explains how characters in Conversation Mode message you first, and h
 
 ## What autonomous messages and schedules do
 
-An autonomous message is a message a character sends you first, without you writing anything. Marinara Engine (Marinara for short) sends these when you have been quiet for a while, so a chat feels like a real messaging relationship.
+An autonomous message is a message a character sends you first, without you writing anything. Guksu Motor (Guksu for short) sends these when you have been quiet for a while, so a chat feels like a real messaging relationship.
 
 Two settings control this behavior:
 
@@ -48,7 +48,7 @@ The talkativeness-based default works like this:
 The **Schedules** toggle sits in the same **Autonomous Messaging** section and is off by default.
 
 1. Turn on the **Schedules** toggle.
-2. The first time you turn it on with characters in the chat, Marinara starts writing a weekly routine for each character.
+2. The first time you turn it on with characters in the chat, Guksu starts writing a weekly routine for each character.
 3. When routines exist, an **Edit schedules** list appears with one row per character.
 
 Each row shows how many days are filled, for example **3 days scheduled**, or **Create schedule** if that character has none yet. A **Generate** button (labeled **Regenerate** once routines exist) rebuilds the routines whenever you want.
@@ -142,7 +142,7 @@ If the chat has only one character, you can leave the name out. Run **/status** 
 
 ## How autonomous messages are paced
 
-Marinara paces autonomous messages so a character never spams you. The rules below use each character's own schedule.
+Guksu paces autonomous messages so a character never spams you. The rules below use each character's own schedule.
 
 - A character waits until you have been silent for its **Wait before checking in** time. The default is 120 minutes.
 - A character whose current status is **Offline** does not message first.
@@ -164,7 +164,7 @@ Click the status pill to open four choices:
 - **Do Not Disturb**: stops all autonomous messages.
 - **Invisible**: hides your status from characters.
 
-**Idle** is mostly automatic. If your status is **Active** and you do nothing for 10 minutes, Marinara sets you to **Idle**. It sets you back to **Active** when you return. You can also pick **Idle** yourself from the popup. Picking any status by hand turns off the automatic switch until you choose **Active** again.
+**Idle** is mostly automatic. If your status is **Active** and you do nothing for 10 minutes, Guksu sets you to **Idle**. It sets you back to **Active** when you return. You can also pick **Idle** yourself from the popup. Picking any status by hand turns off the automatic switch until you choose **Active** again.
 
 Set **Do Not Disturb** when you want quiet. No character will message you first while it is on. **Idle** does not block autonomous messages. Characters can still check in while you are away.
 

--- a/docs/conversation/selfies.md
+++ b/docs/conversation/selfies.md
@@ -49,11 +49,11 @@ To learn more about styles, see [Image Style Profiles](../media/style-profiles.m
 
 ### Send Avatar References
 
-**Send Avatar References** is a toggle that is off by default. When it is on, Marinara sends the character's avatar or sprite to the image service as a reference picture. This helps the selfie look like the character. It only works when the image provider supports reference images.
+**Send Avatar References** is a toggle that is off by default. When it is on, Guksu sends the character's avatar or sprite to the image service as a reference picture. This helps the selfie look like the character. It only works when the image provider supports reference images.
 
 ### Attach Card Appearance
 
-**Attach Card Appearance** is a toggle that is off by default. When it is on, Marinara adds the character card's appearance text to the selfie description. This gives the model more detail about how the character looks.
+**Attach Card Appearance** is a toggle that is off by default. When it is on, Guksu adds the character card's appearance text to the selfie description. This gives the model more detail about how the character looks.
 
 ### Resolution
 
@@ -72,7 +72,7 @@ The size options are:
 
 ## How a character sends a selfie
 
-Once selfies are set up, a character can decide to send one during the chat on their own. You do not type a command. The character chooses the moment, and Marinara generates the picture and posts it in the chat.
+Once selfies are set up, a character can decide to send one during the chat on their own. You do not type a command. The character chooses the moment, and Guksu generates the picture and posts it in the chat.
 
 ## Asking for a selfie by hand
 

--- a/docs/conversation/table-games.md
+++ b/docs/conversation/table-games.md
@@ -4,16 +4,16 @@ This guide covers the six optional table-game packages you can play against a ch
 
 ## What table games are
 
-Table games are small tabletop games that run right inside a Conversation Mode chat. Marinara Engine deals the cards or sets up the board, and it enforces every rule for you. Each seated character narrates its own moves in character. A live board appears above the message box while you play.
+Table games are small tabletop games that run right inside a Conversation Mode chat. Guksu Motor deals the cards or sets up the board, and it enforces every rule for you. Each seated character narrates its own moves in character. A live board appears above the message box while you play.
 
-Install each game you want from **Agents → Download Agents**. It becomes available immediately without restarting Marinara. An uninstalled game does not appear in the games picker, its slash command is unavailable, and its character command setting stays hidden.
+Install each game you want from **Agents → Download Agents**. It becomes available immediately without restarting Guksu. An uninstalled game does not appear in the games picker, its slash command is unavailable, and its character command setting stays hidden.
 
 Two facts to keep in mind:
 
 - Table games work in Conversation Mode only. You cannot start one in a Roleplay or Game Mode chat. If you type a game command in a Roleplay chat, you see a message such as "UNO can only be played in conversation chats."
 - Only one game can be active per chat at a time. Starting a new game replaces any game already running in that chat, even a finished one still showing its end banner.
 
-You also need at least one character in the chat. You must seat at least one of them as a bot before you can deal or start. Bot moves and in-character lines use the same connection as your normal chat replies. No extra account or API key is needed. An **API key** is the secret code that lets Marinara talk to an AI provider.
+You also need at least one character in the chat. You must seat at least one of them as a bot before you can deal or start. Bot moves and in-character lines use the same connection as your normal chat replies. No extra account or API key is needed. An **API key** is the secret code that lets Guksu talk to an AI provider.
 
 ## Starting a game
 
@@ -144,11 +144,11 @@ The board shows a top-down pool table with the real position of every ball. On y
 
 ## Tic-Tac-Toe
 
-Tic-Tac-Toe is one-on-one. The setup chooses the opponent and whether you play **X**, **O**, or a random mark. X moves first. During your turn, click an empty square. Marinara blocks illegal moves, asks the character for its move in character, and detects wins and draws automatically.
+Tic-Tac-Toe is one-on-one. The setup chooses the opponent and whether you play **X**, **O**, or a random mark. X moves first. During your turn, click an empty square. Guksu blocks illegal moves, asks the character for its move in character, and detects wins and draws automatically.
 
 ## Rock-Paper-Scissors
 
-Rock-Paper-Scissors is one-on-one. The setup chooses the opponent and a best-of-three, best-of-five, or best-of-seven match. Pick **Rock**, **Paper**, or **Scissors** each round. Your opponent's choice stays hidden until both choices are ready, then Marinara reveals the result and updates the match score.
+Rock-Paper-Scissors is one-on-one. The setup chooses the opponent and a best-of-three, best-of-five, or best-of-seven match. Pick **Rock**, **Paper**, or **Scissors** each round. Your opponent's choice stays hidden until both choices are ready, then Guksu reveals the result and updates the match score.
 
 ## Ending a game
 

--- a/docs/data/backup-and-restore.md
+++ b/docs/data/backup-and-restore.md
@@ -1,13 +1,13 @@
-# Backing Up and Restoring Marinara
+# Backing Up and Restoring Guksu
 
-This guide shows the two ways to save a copy of everything in Marinara Engine, and how to put that copy back later. Use it before you upgrade, move to a new device, or reset your data.
+This guide shows the two ways to save a copy of everything in Guksu Motor, and how to put that copy back later. Use it before you upgrade, move to a new device, or reset your data.
 
 ## Two ways to save your data
 
-Marinara gives you two save options. They live in different places and do different jobs.
+Guksu gives you two save options. They live in different places and do different jobs.
 
 - **Download Backup** makes a full **.zip** archive of everything on disk. A **.zip** is a single compressed file that holds many files inside it. This is the most complete copy, and the best guard against data loss.
-- **Export Profile** makes a lighter file that holds your account data (characters, personas, chats, lorebooks, presets, agents, and themes). A profile is Marinara's portable copy of your account. You can restore it later inside Marinara.
+- **Export Profile** makes a lighter file that holds your account data (characters, personas, chats, lorebooks, presets, agents, and themes). A profile is Guksu's portable copy of your account. You can restore it later inside Guksu.
 
 If you just want one safe copy of everything, use **Download Backup**. Use **Export Profile** when you want a smaller file or a version other roleplay tools can read.
 
@@ -15,7 +15,7 @@ Both save options live in **Settings** on the **Advanced** tab, in the **Backup 
 
 ## Access on the same device or another device
 
-On the computer that runs Marinara, these tools work right away. This is the loopback case, meaning you opened the app at `localhost` or `127.0.0.1` on the same machine.
+On the computer that runs Guksu, these tools work right away. This is the loopback case, meaning you opened the app at `localhost` or `127.0.0.1` on the same machine.
 
 From a phone, tablet, or any other device, backup and restore need the **Admin Access** secret. Set the secret on the server, then paste the same value into **Settings** on the **Advanced** tab under **Admin Access**. See the remote access guide linked at the end.
 
@@ -51,16 +51,16 @@ The **.zip** also contains a plain text file named `RESTORE.txt`. It explains ho
 
 The dialog offers two formats:
 
-| Format | What it is | Restorable in Marinara? |
+| Format | What it is | Restorable in Guksu? |
 | --- | --- | --- |
-| **Marinara Native** | Keeps Marinara fields, lorebook folders, character and persona data, presets, agents, themes, and inline media. | Yes |
+| **Guksu Native** | Keeps Guksu fields, lorebook folders, character and persona data, presets, agents, themes, and inline media. | Yes |
 | **Compatible JSON** | Plain character, persona, and lorebook files for other roleplay tools. | No |
 
-Choose **Marinara Native** to keep a copy you can restore in Marinara later. It downloads a file named `marinara-profile.json`.
+Choose **Guksu Native** to keep a copy you can restore in Guksu later. It downloads a file named `marinara-profile.json`.
 
-Choose **Compatible JSON** only when you want to move characters or lorebooks to another tool. It downloads a **.zip** of plain files. You cannot restore this file back into Marinara with **Import Profile**.
+Choose **Compatible JSON** only when you want to move characters or lorebooks to another tool. It downloads a **.zip** of plain files. You cannot restore this file back into Guksu with **Import Profile**.
 
-If a **Marinara Native** file would be very large, Marinara cannot fit it into one JSON file. It then asks **Export profile as ZIP?**. Click to accept, and it downloads `marinara-profile.zip` with the same data instead.
+If a **Guksu Native** file would be very large, Guksu cannot fit it into one JSON file. It then asks **Export profile as ZIP?**. Click to accept, and it downloads `marinara-profile.zip` with the same data instead.
 
 ## Restoring with Import Profile
 
@@ -68,15 +68,15 @@ To put a saved profile or a **Download Backup** archive back, use **Import Profi
 
 1. Open **Settings**.
 2. Go to the **Imports** tab.
-3. Find the **Profile & Marinara** section.
+3. Find the **Profile & Guksu** section.
 4. Click **Import Profile (JSON/ZIP)**.
 5. Pick your file. It can be a `marinara-profile.json`, a `marinara-profile.zip`, or a full **Download Backup** **.zip**.
-6. Marinara scans the file first. The button shows **Scanning Profile...**.
+6. Guksu scans the file first. The button shows **Scanning Profile...**.
 7. A dialog titled **Import Profile** appears. It lists what it found, for example the number of characters and personas.
 8. The dialog warns that importing cannot be undone. Read it, then click **Import** to go on, or **Cancel** to stop.
 9. The import runs and shows **Importing Profile...** with a progress bar.
 
-A recent Marinara profile restores by matching each item's own identity, not its name. So if you import the same profile twice, it updates your existing items in place instead of making duplicates.
+A recent Guksu profile restores by matching each item's own identity, not its name. So if you import the same profile twice, it updates your existing items in place instead of making duplicates.
 
 Very old profile files (from much older versions) do not carry this behavior. Re-importing one of those can create duplicate characters, personas, and lorebooks. If you only ever restore recent exports, you will not hit this.
 
@@ -86,9 +86,9 @@ If a **.zip** is missing some media files, the import still finishes. It shows a
 
 ## After you restore: re-enter your keys
 
-**Export Profile** removes secret values from the profile file. Your saved API keys and webhook links are blank inside it. That makes the profile file safe to store and share. An API key is the password that connects Marinara to an AI provider.
+**Export Profile** removes secret values from the profile file. Your saved API keys and webhook links are blank inside it. That makes the profile file safe to store and share. An API key is the password that connects Guksu to an AI provider.
 
-A **Download Backup** archive is different. Marinara does not remove secrets from it. The backup **.zip** is a raw copy of your data. It holds your saved keys and the secret file that can unlock them. Never share a backup **.zip**. Store it somewhere private.
+A **Download Backup** archive is different. Guksu does not remove secrets from it. The backup **.zip** is a raw copy of your data. It holds your saved keys and the secret file that can unlock them. Never share a backup **.zip**. Store it somewhere private.
 
 **Import Profile** restores from the profile file, even when you pick a backup **.zip**. The archive holds a copy of the profile file inside, and the import reads that copy. So items created by the import come in with blank keys and webhook links.
 
@@ -100,7 +100,7 @@ After you import a profile, do this:
 
 If you use custom tools that call a webhook link, re-enter that link on each tool too.
 
-Importing does not erase keys you have already set. If you re-import an old profile, Marinara keeps the live keys and webhook links on items that still exist. A re-import will not blank them.
+Importing does not erase keys you have already set. If you re-import an old profile, Guksu keeps the live keys and webhook links on items that still exist. A re-import will not blank them.
 
 ## The Existing backups list
 
@@ -108,8 +108,8 @@ The **Backup & Export** section can show an **Existing backups** list with a del
 
 ## Related guides
 
-- [Where Marinara Stores Your Data](where-data-is-stored.md)
+- [Where Guksu Stores Your Data](where-data-is-stored.md)
 - [Clearing or Resetting Your Data](clearing-data.md)
-- [Upgrading Marinara Engine](../UPGRADING.md)
+- [Upgrading Guksu Motor](../UPGRADING.md)
 - [Connecting to an AI Provider](../connections/connecting-to-a-provider.md)
 - [Remote Access: Basic Auth and IP Allowlist](../REMOTE_ACCESS.md)

--- a/docs/data/clearing-data.md
+++ b/docs/data/clearing-data.md
@@ -1,6 +1,6 @@
 # Clearing or Resetting Your Data
 
-This guide shows you how to permanently delete your data in Marinara Engine using the **Danger Zone**. You can clear a few categories or wipe everything. There is no undo, so read the warnings first.
+This guide shows you how to permanently delete your data in Guksu Motor using the **Danger Zone**. You can clear a few categories or wipe everything. There is no undo, so read the warnings first.
 
 ## Where the Danger Zone is
 
@@ -12,13 +12,13 @@ The clear data tools live in one place.
 
 The **Danger Zone** description reads: "Permanently clear selected categories of local data. Professor Mari is always preserved."
 
-If you use Marinara from another device (not the computer running the app), clearing data needs admin access. See [Remote Access](../REMOTE_ACCESS.md) for how to set that up.
+If you use Guksu from another device (not the computer running the app), clearing data needs admin access. See [Remote Access](../REMOTE_ACCESS.md) for how to set that up.
 
 ## Back up before you clear
 
 Clearing data cannot be undone. There is no trash and no recycle bin. Once you confirm, the data is gone.
 
-Make a backup first so you can restore later if you change your mind. See [Backing Up and Restoring Marinara](backup-and-restore.md).
+Make a backup first so you can restore later if you change your mind. See [Backing Up and Restoring Guksu](backup-and-restore.md).
 
 ## The eight data categories
 
@@ -65,5 +65,5 @@ Professor Mari is the built-in helper character. This feature never deletes her.
 
 ## Related guides
 
-- [Backing Up and Restoring Marinara](backup-and-restore.md)
+- [Backing Up and Restoring Guksu](backup-and-restore.md)
 - [Remote Access](../REMOTE_ACCESS.md)

--- a/docs/data/importing-from-sillytavern.md
+++ b/docs/data/importing-from-sillytavern.md
@@ -1,10 +1,10 @@
 # Importing from SillyTavern
 
-This guide shows how to bring your SillyTavern data into Marinara Engine. You can import one file at a time, or scan a whole SillyTavern folder and import everything at once.
+This guide shows how to bring your SillyTavern data into Guksu Motor. You can import one file at a time, or scan a whole SillyTavern folder and import everything at once.
 
 ## What you can bring over
 
-Marinara Engine can import these kinds of SillyTavern data:
+Guksu Motor can import these kinds of SillyTavern data:
 
 - Characters (character cards)
 - Chats (message logs)
@@ -31,13 +31,13 @@ This section has four one-file buttons. Each one opens a normal file picker with
 
 JSONL means one JSON record per line. It is the format SillyTavern uses to save a chat log.
 
-When you import a character whose card has an embedded lorebook, a browser prompt asks if you also want to import it as a standalone Marinara lorebook. Click **OK** to keep the World Info as its own lorebook you can reuse. Click **Cancel** to skip that step and import only the character.
+When you import a character whose card has an embedded lorebook, a browser prompt asks if you also want to import it as a standalone Guksu lorebook. Click **OK** to keep the World Info as its own lorebook you can reuse. Click **Cancel** to skip that step and import only the character.
 
 These quick buttons use fixed defaults you cannot change here. They keep all source tags and they scope any regex scripts to the character only. A regex script is a find-and-replace rule that changes text before or after the AI sees it. To choose those options yourself, use the **Import** button in the Characters panel instead. See [Importing and Exporting Character Cards](../characters/import-export.md).
 
 ### Importing a chat into a chosen mode
 
-The single-file **Import Chat (JSONL)** button above always makes a **Roleplay** chat. If you want the chat to land in a different mode, use the small import button at the top of the chat list instead. Its tooltip reads **Import SillyTavern or Marinara chat JSONL**. That button imports the file into whichever mode tab you have open, such as Conversation, Roleplay, or Game. For more on chat import and export, see [Exporting and Importing Chats](../chats/export-import.md).
+The single-file **Import Chat (JSONL)** button above always makes a **Roleplay** chat. If you want the chat to land in a different mode, use the small import button at the top of the chat list instead. Its tooltip reads **Import SillyTavern or Guksu chat JSONL**. That button imports the file into whichever mode tab you have open, such as Conversation, Roleplay, or Game. For more on chat import and export, see [Exporting and Importing Chats](../chats/export-import.md).
 
 ## Import from SillyTavern Folder
 
@@ -52,7 +52,7 @@ To open it, go to **Settings**, then **Imports**, then the **SillyTavern Import*
 3. Point at the main SillyTavern folder. The tip in the window says this is usually the folder that holds a `data/` or `public/` folder inside it.
 4. Click **Scan Folder**. The button shows **Scanning...** while it works.
 
-After the scan, Marinara reports how many items it found in each category. If it cannot read the folder, it shows an error such as "Could not find SillyTavern data directory."
+After the scan, Guksu reports how many items it found in each category. If it cannot read the folder, it shows an error such as "Could not find SillyTavern data directory."
 
 ### Step 2: choose what to import
 
@@ -60,18 +60,18 @@ The next screen is titled **Choose exactly what to import**. It shows a checklis
 
 Each category has **All** and **None** buttons and a **Show** or **Hide** toggle so you can see the individual items and their dates.
 
-Almost everything starts pre-selected. SillyTavern's built-in presets are the exception. Marinara detects them and leaves them unchecked, and a banner explains why. These are the stock presets such as `default`, `deterministic`, `neutral`, and the `universal-*` presets. Leave them unchecked unless you really want copies.
+Almost everything starts pre-selected. SillyTavern's built-in presets are the exception. Guksu detects them and leaves them unchecked, and a banner explains why. These are the stock presets such as `default`, `deterministic`, `neutral`, and the `universal-*` presets. Leave them unchecked unless you really want copies.
 
 If the scan found any characters, two extra controls appear:
 
-- **Imported character tags** sets the tag import mode. Choose **All tags** to keep the source tags, **No tags** to skip them, or **Existing only** to keep only tags you already have in Marinara. The default is **All tags**.
+- **Imported character tags** sets the tag import mode. Choose **All tags** to keep the source tags, **No tags** to skip them, or **Existing only** to keep only tags you already have in Guksu. The default is **All tags**.
 - **Imported regex scripts** sets where regex scripts go. Choose **Character only** so the scripts apply to each bot, or **Global** to add them to **Presets -> Regexes** for every chat. The default is **Character only**.
 
 When your selection looks right, click **Import Selected**. Click **Back** to return to the folder step.
 
 ### Step 3: watch the progress
 
-Marinara imports the items one at a time. You see a spinner, the current category and item name, a progress bar, and running counts per category.
+Guksu imports the items one at a time. You see a spinner, the current category and item name, a progress bar, and running counts per category.
 
 ### Step 4: read the results
 
@@ -79,10 +79,10 @@ The last step shows an **Import complete!** banner when the import succeeds, or 
 
 ### How the wizard handles your data
 
-- The import is best-effort per item. If one character, chat, preset, lorebook, background, or persona fails, Marinara skips it, records a warning, and keeps going with the rest.
+- The import is best-effort per item. If one character, chat, preset, lorebook, background, or persona fails, Guksu skips it, records a warning, and keeps going with the rest.
 - Several chat files that belong to one character import as branches of a single chat, not as separate chats.
 - Group chats always import as **Roleplay** chats.
-- Imported items keep the source file's last-changed date as their date in Marinara. They do not use the moment you ran the import.
+- Imported items keep the source file's last-changed date as their date in Guksu. They do not use the moment you ran the import.
 
 ## Access and folder rules
 
@@ -90,7 +90,7 @@ The single-file import buttons work for everyone with no extra setup.
 
 The **Import from SillyTavern Folder** wizard reads files from disk, so it needs privileged access. On the same machine as the server (loopback), it works with no extra setup. From another device or browser, you must set an admin secret on the server. Then save the same value in **Settings -> Advanced -> Admin Access**. See [Server Configuration Reference](../CONFIGURATION.md) for how to set the admin secret.
 
-If your server sets `IMPORT_ALLOWED_ROOTS`, Marinara rejects typed paths outside those folders. Paths you pick with **Browse** or the in-app folder browser always work, even with that setting on.
+If your server sets `IMPORT_ALLOWED_ROOTS`, Guksu rejects typed paths outside those folders. Paths you pick with **Browse** or the in-app folder browser always work, even with that setting on.
 
 ## What does not transfer
 
@@ -98,7 +98,7 @@ The folder wizard only scans the seven categories listed above. Other SillyTaver
 
 SillyTavern's built-in presets are left unchecked by default, so they do not come over unless you check them yourself.
 
-Marinara skips any single item that fails to convert. Check the warnings list on the last step of the wizard to see exactly what was left out.
+Guksu skips any single item that fails to convert. Check the warnings list on the last step of the wizard to see exactly what was left out.
 
 ## Related guides
 

--- a/docs/data/where-data-is-stored.md
+++ b/docs/data/where-data-is-stored.md
@@ -1,24 +1,24 @@
-# Where Marinara Stores Your Data
+# Where Guksu Stores Your Data
 
-This guide explains where Marinara Engine keeps your data on your own computer. It covers the main data folder, the `storage` and asset folders inside it, and the encryption key file that protects your saved API keys.
+This guide explains where Guksu Motor keeps your data on your own computer. It covers the main data folder, the `storage` and asset folders inside it, and the encryption key file that protects your saved API keys.
 
-Marinara Engine (called "Marinara" below) runs on your own machine. Marinara stores your saved characters, chats, and settings only on your own computer. Keep in mind that when you generate a reply, Marinara still sends your chat content to the AI provider you connected to.
+Guksu Motor (called "Guksu" below) runs on your own machine. Guksu stores your saved characters, chats, and settings only on your own computer. Keep in mind that when you generate a reply, Guksu still sends your chat content to the AI provider you connected to.
 
 ## The data folder (DATA_DIR)
 
-Everything you create in Marinara lives inside one folder on the machine that runs the server. That folder is called the data folder. The environment variable that points to it is named `DATA_DIR`. An environment variable is a value you set on the server outside the app. You will not find it inside the app's **Settings** panel.
+Everything you create in Guksu lives inside one folder on the machine that runs the server. That folder is called the data folder. The environment variable that points to it is named `DATA_DIR`. An environment variable is a value you set on the server outside the app. You will not find it inside the app's **Settings** panel.
 
-By default the data folder is a folder named `data` that Marinara creates next to its server files. If you run Marinara in an official Docker container, the data folder is `/app/data` inside the container.
+By default the data folder is a folder named `data` that Guksu creates next to its server files. If you run Guksu in an official Docker container, the data folder is `/app/data` inside the container.
 
-If you are not sure where the data folder is, check the server startup log. When Marinara starts, it prints a line that begins with `[storage] DATA_DIR=` followed by the full path to your data folder.
+If you are not sure where the data folder is, check the server startup log. When Guksu starts, it prints a line that begins with `[storage] DATA_DIR=` followed by the full path to your data folder.
 
-You can move the data folder to another location by setting `DATA_DIR` yourself. To learn how to set it, see the [Server Configuration Reference](../CONFIGURATION.md). Marinara must restart for a new `DATA_DIR` value to take effect.
+You can move the data folder to another location by setting `DATA_DIR` yourself. To learn how to set it, see the [Server Configuration Reference](../CONFIGURATION.md). Guksu must restart for a new `DATA_DIR` value to take effect.
 
 ## The storage folder and asset folders
 
 Inside the data folder, your data is split into a `storage` folder and several asset folders.
 
-The `storage` folder holds your text data: characters, chats, messages, lorebooks, presets, and connections. Marinara saves these as files here, so this is the folder that holds most of your work.
+The `storage` folder holds your text data: characters, chats, messages, lorebooks, presets, and connections. Guksu saves these as files here, so this is the folder that holds most of your work.
 
 Your images, audio, and other media files live in their own folders, each named for what it holds. The main asset folders are:
 
@@ -38,9 +38,9 @@ For a deeper technical explanation of how the `storage` folder works, developers
 
 ## The encryption key file
 
-Marinara encrypts your saved API keys so they are not stored as plain text. The key used for this encryption is saved in a file named `.encryption-key` inside your data folder.
+Guksu encrypts your saved API keys so they are not stored as plain text. The key used for this encryption is saved in a file named `.encryption-key` inside your data folder.
 
-This file matters when you move or restore your data. Say you copy your data folder to a new machine but leave the `.encryption-key` file behind. Marinara can no longer decrypt your saved API keys, so you have to enter them again. Always keep this file together with the rest of your data.
+This file matters when you move or restore your data. Say you copy your data folder to a new machine but leave the `.encryption-key` file behind. Guksu can no longer decrypt your saved API keys, so you have to enter them again. Always keep this file together with the rest of your data.
 
 Some advanced setups provide the key through an `ENCRYPTION_KEY` environment variable instead of the file. If you use that variable, keep the value safe on its own. In that case there is no `.encryption-key` file to copy. See the [Server Configuration Reference](../CONFIGURATION.md) for details.
 
@@ -50,10 +50,10 @@ On Android, the server's data folder usually sits in app storage that you cannot
 
 To get a copy of your data on Android, use the **Download Backup** button. You can find it in **Settings**, on the **Advanced** tab, in the **Backup & Export** section. This creates a single zip file with your data. The zip includes the `.encryption-key` file when one exists. This is the most reliable way to save your data from a phone.
 
-For the full backup and restore steps on every platform, see [Backing Up and Restoring Marinara](backup-and-restore.md).
+For the full backup and restore steps on every platform, see [Backing Up and Restoring Guksu](backup-and-restore.md).
 
 ## Related guides
 
-- [Backing Up and Restoring Marinara](backup-and-restore.md)
+- [Backing Up and Restoring Guksu](backup-and-restore.md)
 - [Server Configuration Reference](../CONFIGURATION.md)
 - [File-Native Storage](../development/file-storage.md)

--- a/docs/development/architecture-map.md
+++ b/docs/development/architecture-map.md
@@ -1,6 +1,6 @@
 # Architecture Map (Developers)
 
-This guide is developer material for contributors. It describes the code organization of Marinara Engine: shared foundations, feature systems, mode ownership, and where each piece of code belongs. It also lists the current large files and the direction for future refactor work.
+This guide is developer material for contributors. It describes the code organization of Guksu Motor: shared foundations, feature systems, mode ownership, and where each piece of code belongs. It also lists the current large files and the direction for future refactor work.
 
 Scope: `packages/client/src`, `packages/server/src`, and `packages/shared/src`. The repo keeps no conventional `.test.ts` suite. Tracked regression scripts and Playwright smoke coverage provide automated validation; temporary `.test.ts` proof files are gitignored and removed after use.
 
@@ -24,7 +24,7 @@ Use these codes when planning moves, labeling issues, or adding a short file hea
 | `FEATURE-ASSETS` | Backgrounds, avatars, gallery, generated images, sprites, game assets | asset routes, gallery storage, image services |
 | `FEATURE-SIDECAR` | Local model runtime, scene analysis, downloads, process control | sidecar store, `/api/sidecar`, sidecar services |
 | `FEATURE-TTS` | TTS config, voice routing, cache keys, audio playback | TTS settings/hooks/routes/services |
-| `FEATURE-IMPORT` | SillyTavern and Marinara importers and migration helpers | import routes/services |
+| `FEATURE-IMPORT` | SillyTavern and Guksu importers and migration helpers | import routes/services |
 | `TEST` | Tracked regression and browser smoke coverage, plus temporary proof tests when needed | `scripts/regressions`, `e2e`, and temporary `packages/server/src/**/__tests__/` files removed after use |
 
 Prefer making the path communicate the section. A comment like `// Section: MODE-GAME` is only useful while a file still sits in a mixed directory.

--- a/docs/development/file-storage.md
+++ b/docs/development/file-storage.md
@@ -1,10 +1,10 @@
 # File-Native Storage
 
-This guide describes Marinara Engine's local persistence architecture. For the user-facing folder layout, see [Where Your Data Is Stored](../data/where-data-is-stored.md).
+This guide describes Guksu Motor's local persistence architecture. For the user-facing folder layout, see [Where Your Data Is Stored](../data/where-data-is-stored.md).
 
 ## Source of truth
 
-Marinara stores application rows as JSON snapshots under `DATA_DIR/storage`:
+Guksu stores application rows as JSON snapshots under `DATA_DIR/storage`:
 
 ```text
 storage/
@@ -32,7 +32,7 @@ Downloaded capability packages may carry their own file-table instances. The sto
 
 Writes mark affected tables dirty. A short debounce coalesces nearby changes, while a safety timer periodically flushes pending work. Graceful shutdown waits for active writes and then persists any rows changed during that write.
 
-Each snapshot is written to a temporary file, flushed, and atomically renamed. Before replacement, the previous healthy snapshot is refreshed as a `.bak` file. On startup, an unreadable primary is recovered from its backup when possible. If neither copy is usable, Marinara quarantines the corrupt files with a timestamped suffix and starts only that table empty so the UI remains reachable for recovery.
+Each snapshot is written to a temporary file, flushed, and atomically renamed. Before replacement, the previous healthy snapshot is refreshed as a `.bak` file. On startup, an unreadable primary is recovered from its backup when possible. If neither copy is usable, Guksu quarantines the corrupt files with a timestamped suffix and starts only that table empty so the UI remains reachable for recovery.
 
 ## Transactions
 

--- a/docs/development/frontend.md
+++ b/docs/development/frontend.md
@@ -1,10 +1,10 @@
 # Frontend Architecture (Developers)
 
-This is developer material, not an end-user guide. It explains how the Marinara Engine client is built. It covers the React app structure, the Zustand stores, the React Query hooks, the main components, and the server API map. If you just want to use the app, start with the user guides instead.
+This is developer material, not an end-user guide. It explains how the Guksu Motor client is built. It covers the React app structure, the Zustand stores, the React Query hooks, the main components, and the server API map. If you just want to use the app, start with the user guides instead.
 
 ## Overview
 
-Marinara Engine is an AI chat application with Conversation, Roleplay, and Game modes. The client is a React 19 single-page app served by Vite, styled with Tailwind CSS v4, and packaged as a Progressive Web App (PWA).
+Guksu Motor is an AI chat application with Conversation, Roleplay, and Game modes. The client is a React 19 single-page app served by Vite, styled with Tailwind CSS v4, and packaged as a Progressive Web App (PWA).
 
 The client lives in `packages/client`. It talks to a Fastify API server (`packages/server`) over REST and Server-Sent Events (SSE). Shared data contracts (types, Zod schemas, constants) live in `packages/shared` and are imported by both sides.
 
@@ -77,7 +77,7 @@ The only persisted store (localStorage via the Zustand `persist` middleware). It
 - Behavior: `confirmBeforeDelete`, `enterToSendRP`, `enterToSendConvo`, `weatherEffects`, and `guideGenerations`.
 - Navigation: `rightPanel`, `rightPanelOpen`, `sidebarOpen`, `settingsTab`, all `*DetailId` fields, and `modal`.
 
-Synced custom themes are not stored in `ui.store.ts`. They are fetched from the server through React Query and mirrored across devices connected to the same Marinara instance.
+Synced custom themes are not stored in `ui.store.ts`. They are fetched from the server through React Query and mirrored across devices connected to the same Guksu instance.
 
 #### `chat.store.ts`: chat runtime
 
@@ -386,7 +386,7 @@ The project uses Tailwind CSS v4 with the `@tailwindcss/vite` plugin (no PostCSS
 
 ### Custom themes
 
-Users can create custom themes. Theme definitions are stored on the Marinara server and sync across connected devices. The active custom theme is shared too. The CSS is injected as a `style` tag by `CustomThemeInjector.tsx`.
+Users can create custom themes. Theme definitions are stored on the Guksu server and sync across connected devices. The active custom theme is shared too. The CSS is injected as a `style` tag by `CustomThemeInjector.tsx`.
 
 Synced theme CSS can request the built-in Accent Pulse engine with `--marinara-theme-accent-pulse: enabled`. Add `--marinara-theme-accent-pulse-source: #a78bfa` (or a gradient) when the pulse should use a specific theme accent instead of the current Appearance accent.
 
@@ -524,7 +524,7 @@ Agent memory tools use `/api/agents/memory/:agentType/:chatId`, where `agentType
 | `/api/updates/latest`           | Latest release metadata                 |
 | `/api/updates/commits-behind`   | Git install update distance             |
 | `/api/backup`                   | Full backup, export, import             |
-| `/api/import/*`                 | SillyTavern and Marinara profile import |
+| `/api/import/*`                 | SillyTavern and Guksu profile import |
 | `/api/admin/clear-all`          | Full data clear                         |
 | `/api/themes`                   | Synced custom themes                    |
 | `/api/extensions`               | Installed extensions                    |
@@ -541,7 +541,7 @@ Agent memory tools use `/api/agents/memory/:agentType/:chatId`, where `agentType
 
 The app is a Progressive Web App configured with VitePWA:
 
-- Manifest: `public/manifest.json` with the "Marinara Engine" app name, standalone display mode, and dark theme.
+- Manifest: `public/manifest.json` with the "Guksu Motor" app name, standalone display mode, and dark theme.
 - Icons: a 64px favicon, 192px and 512px maskable icons, and a splash logo.
 - Service worker: Workbox with an auto-update strategy.
 - Caching: static assets are cached; `/api/*` routes use NetworkOnly.

--- a/docs/development/hierarchical-locations-prd-v3.md
+++ b/docs/development/hierarchical-locations-prd-v3.md
@@ -2,7 +2,7 @@
 
 Status: Proposed, implementation-ready after maintainer approval
 
-Audience: Product, design, and Marinara Engine contributors
+Audience: Product, design, and Guksu Motor contributors
 
 Supersedes: `hierarchical-locations-prd-v2.md`
 
@@ -157,7 +157,7 @@ Storyboard should consume the reviewed visual identities from the completed GM t
 - Creating a storyboard resolves the exact spatial snapshot for its source message and swipe. The chat's latest location is never substituted for an earlier turn.
 - The storyboard freezes the resolved location, ordered candidate image IDs, per-keyframe selections, omissions, and provider capacity in a visual-reference manifest. Regeneration reuses that manifest until the creator explicitly chooses `Refresh references`.
 - The same primary location candidate is available to every keyframe. Character and persona candidates vary by the frame's visible-character list, so off-screen cast members do not consume reference slots.
-- The first version automatically selects one primary image per depicted entity and at most one supporting location image. Richer banks remain useful for manual selection and future shot-aware angle, outfit, expression, or detail matching, but Marinara does not send every stored image on every frame.
+- The first version automatically selects one primary image per depicted entity and at most one supporting location image. Richer banks remain useful for manual selection and future shot-aware angle, outfit, expression, or detail matching, but Guksu does not send every stored image on every frame.
 - If only one automatic slot remains, a keyframe with visible characters selects the lead visible character; an establishing keyframe with no visible characters selects the primary location. With two or more slots, the primary location is selected before additional visible-character references.
 - A higher-capacity provider does not silently add references to an existing storyboard. A lower-capacity provider produces an inline `Review references` conflict instead of silently changing the frozen payload.
 - Each keyframe preview has one progressive `Visual sources` disclosure listing the resolved location, selected characters, image roles, ordering, and omission reasons. `Refresh references` is available there without adding a separate Storyboard asset manager or blocking modal.
@@ -895,7 +895,7 @@ The editor and runtime controls use existing semantic theme tokens, support dark
 
 ### Portability and lifecycle coverage
 
-Native Marinara chat export must carry:
+Native Guksu chat export must carry:
 
 - The current definition in `marinara_metadata`.
 - Spatial snapshots keyed by exported message ordinal and swipe index, not by display names.

--- a/docs/development/ios-pwa-safe-area.md
+++ b/docs/development/ios-pwa-safe-area.md
@@ -1,6 +1,6 @@
 # iOS PWA Bottom Safe Area (Developers)
 
-This developer guide explains a colored stripe that can appear at the bottom of the screen. It shows up when Marinara Engine runs as an iPhone home screen app. It covers the fix Marinara ships, the trade-off that fix forces, and how to diagnose the stripe if a future change brings it back.
+This developer guide explains a colored stripe that can appear at the bottom of the screen. It shows up when Guksu Motor runs as an iPhone home screen app. It covers the fix Guksu ships, the trade-off that fix forces, and how to diagnose the stripe if a future change brings it back.
 
 A PWA (Progressive Web App) is a website a user installs to the home screen and opens like a native app. This is code-level material for contributors, not an end-user guide.
 
@@ -14,7 +14,7 @@ The result is a visible strip below the chat input box. This strip, often called
 
 ## The fix we ship
 
-Marinara sets the status bar style to `black` instead of `black-translucent`. The meta tag lives in `packages/client/index.html`.
+Guksu sets the status bar style to `black` instead of `black-translucent`. The meta tag lives in `packages/client/index.html`.
 
 ```html
 <meta name="apple-mobile-web-app-status-bar-style" content="black" />

--- a/docs/development/optional-agent-packages.md
+++ b/docs/development/optional-agent-packages.md
@@ -4,9 +4,9 @@ Status: implemented for the v2.3.0 development cycle in issue #3612.
 
 ## Objective
 
-Marinara Engine's base distribution must not compile or ship optional agent and capability implementations. Fresh installations start with no optional packages. Upgrades preserve capabilities that were available before this package system was introduced.
+Guksu Motor's base distribution must not compile or ship optional agent and capability implementations. Fresh installations start with no optional packages. Upgrades preserve capabilities that were available before this package system was introduced.
 
-The official catalog, package sources, reproducible artifacts, validation scripts, and contribution workflow live in [Pasta-Devs/Marinara-Agents](https://github.com/Pasta-Devs/Marinara-Agents). Installed artifacts live beneath the configured Marinara data directory so application updates cannot overwrite them.
+The official catalog, package sources, reproducible artifacts, validation scripts, and contribution workflow live in [Pasta-Devs/Marinara-Agents](https://github.com/Pasta-Devs/Marinara-Agents). Installed artifacts live beneath the configured Guksu data directory so application updates cannot overwrite them.
 
 ## Package model
 
@@ -17,7 +17,7 @@ An agent package may contribute one or more declarative agents and optional trus
 - shared JSON schemas and stable wire contracts;
 - package-owned assets, documentation, and Professor Mari knowledge fragments.
 
-Packages target a versioned Marinara capability API. They must not import private source paths from the engine.
+Packages target a versioned Guksu capability API. They must not import private source paths from the engine.
 
 Capability API 1.1 adds a generic runtime facade to the server activation context.
 Packages can read the effective agent-debug state and write through the Engine's
@@ -75,7 +75,7 @@ Only first-party trusted executable packages are enabled by the official catalog
 
 The server owns the installed-package registry and exposes installed capabilities to clients. Declarative and reloadable modules activate immediately. The UI invalidates catalog, agent, mode-capability, and active-chat queries after activation.
 
-The manifest may declare `restartRequired` only when the host cannot safely reload that entry point. Successful hot activation says `Agent installed. It is ready to use.` Restart-required activation says `Agent installed. Restart Marinara Engine to finish setup.`
+The manifest may declare `restartRequired` only when the host cannot safely reload that entry point. Successful hot activation says `Agent installed. It is ready to use.` Restart-required activation says `Agent installed. Restart Guksu Motor to finish setup.`
 
 Turn-game packages are hot-reloadable: installation registers their server engine and manual slash launcher immediately, and uninstallation detaches the runtime without an Engine restart. Per-chat Conversation Commands settings control only whether characters may emit the package's hidden command; they do not gate the user's slash launcher. Current official turn-game manifests retain their conservative legacy restart marker for Engine 2.x compatibility; Engine 3.x recognizes the `turn-game` kind, performs the safe hot activation, and returns the package as active and ready.
 

--- a/docs/development/writing-extensions.md
+++ b/docs/development/writing-extensions.md
@@ -1,10 +1,10 @@
 # Writing Extensions (Developers)
 
-This is developer material for people who want to author their own Marinara Engine extensions. It covers the extension manifest format and the browser marinara API. It also covers the CSS sanitization rules, the server extension marinara API and its sandbox, and the bundled example package. If you only want to install an extension someone else made, read the user guide instead: [Extensions](../extending/extensions.md).
+This is developer material for people who want to author their own Guksu Motor extensions. It covers the extension manifest format and the browser marinara API. It also covers the CSS sanitization rules, the server extension marinara API and its sandbox, and the bundled example package. If you only want to install an extension someone else made, read the user guide instead: [Extensions](../extending/extensions.md).
 
 ## Before you start
 
-An extension is a small add-on that changes how Marinara Engine looks or behaves. You author it as a small set of files, then import it from **Settings**, then **Addons**, then the **Extension Library** section. For the import, enable, export, and delete steps, see [Extensions](../extending/extensions.md).
+An extension is a small add-on that changes how Guksu Motor looks or behaves. You author it as a small set of files, then import it from **Settings**, then **Addons**, then the **Extension Library** section. For the import, enable, export, and delete steps, see [Extensions](../extending/extensions.md).
 
 Installing or updating an extension is a privileged action. It works from localhost with no extra setup. Any other browser (a phone, a LAN address, a remote tunnel) needs two more steps. Set `ADMIN_SECRET` on the server, then save the same value under **Settings**, then **Advanced**, then **Admin Access**. See [Server Configuration Reference](../CONFIGURATION.md) for how to set `ADMIN_SECRET`.
 
@@ -12,10 +12,10 @@ Installing or updating an extension is a privileged action. It works from localh
 
 There are two runtimes, and you choose one per extension.
 
-1. A browser extension (also called a client extension) injects CSS and JavaScript into the Marinara page in your browser. It can style the UI, add controls, watch the DOM, register timers, and call a limited set of app routes.
-2. A server extension runs trusted JavaScript inside the Marinara Node.js server process. It has no DOM. It can log, run timers, and make safe outbound web requests.
+1. A browser extension (also called a client extension) injects CSS and JavaScript into the Guksu page in your browser. It can style the UI, add controls, watch the DOM, register timers, and call a limited set of app routes.
+2. A server extension runs trusted JavaScript inside the Guksu Node.js server process. It has no DOM. It can log, run timers, and make safe outbound web requests.
 
-Neither kind edits Marinara source code on disk. A browser extension has the same browser privileges as the app UI. A server extension runs with the same privileges as the server process, so only run server code you trust.
+Neither kind edits Guksu source code on disk. A browser extension has the same browser privileges as the app UI. A server extension runs with the same privileges as the server process, so only run server code you trust.
 
 ## The extension manifest
 
@@ -44,7 +44,7 @@ A minimal browser manifest that points at those two files:
 }
 ```
 
-Marinara resolves `cssPath` and `jsPath` relative to the folder that holds `manifest.json` first. If nothing matches there, it tries the package root. Each one can be a single path or an array of paths. When you list several files, Marinara joins them in order.
+Guksu resolves `cssPath` and `jsPath` relative to the folder that holds `manifest.json` first. If nothing matches there, it tries the package root. Each one can be a single path or an array of paths. When you list several files, Guksu joins them in order.
 
 You can also put the code inline instead of in separate files:
 
@@ -62,18 +62,18 @@ You can also put the code inline instead of in separate files:
 }
 ```
 
-A manifest can supply both a file path and inline content for the same slot (for example both `cssPath` and `css`). In that case, the file content wins. Marinara uses the inline value only when the path resolves to nothing.
+A manifest can supply both a file path and inline content for the same slot (for example both `cssPath` and `css`). In that case, the file content wins. Guksu uses the inline value only when the path resolves to nothing.
 
 ### Manifest fields
 
 | Field | Required | Notes |
 | --- | --- | --- |
-| `kind` | Recommended | Use `marinara.extension` for a browser extension or `marinara.server-extension` for a server extension. The importer does not require this field. When both `kind` and `config.runtime` are missing, Marinara imports the extension as a browser extension. |
-| `version` | Recommended | Use `1`. The importer does not read or validate this field. Marinara writes it when it exports an extension, so include it to match the standard format. |
+| `kind` | Recommended | Use `marinara.extension` for a browser extension or `marinara.server-extension` for a server extension. The importer does not require this field. When both `kind` and `config.runtime` are missing, Guksu imports the extension as a browser extension. |
+| `version` | Recommended | Use `1`. The importer does not read or validate this field. Guksu writes it when it exports an extension, so include it to match the standard format. |
 | `config.name` | Yes | Display name. 1 to 200 characters. |
 | `config.description` | No | Up to 2000 characters. Defaults to an empty string. |
 | `config.runtime` | No | Use `client` for a browser extension or `server` for a server extension. Defaults to `client`. If `runtime` is `server`, the extension is treated as a server extension even when `kind` says otherwise. |
-| `config.enabled` | No | For a browser extension, whether it runs right after import. If you omit it, Marinara imports the extension disabled so you can review it first. A server extension is always imported disabled no matter what you set here. |
+| `config.enabled` | No | For a browser extension, whether it runs right after import. If you omit it, Guksu imports the extension disabled so you can review it first. A server extension is always imported disabled no matter what you set here. |
 | `config.cssPath` | No | Path or array of paths to CSS files, relative to the manifest folder. |
 | `config.jsPath` | No | Path or array of paths to browser JS files, relative to the manifest folder. |
 | `config.serverJsPath` | No | Path or array of paths to server JS files, relative to the manifest folder. |
@@ -81,7 +81,7 @@ A manifest can supply both a file path and inline content for the same slot (for
 | `config.js` | No | Inline browser JavaScript. Up to 1 MiB, measured as UTF-8 bytes. |
 | `config.serverJs` | No | Inline server JavaScript. Up to 1 MiB. Required for a server extension unless `serverJsPath` supplies the code. |
 
-Point `jsPath` and `serverJsPath` at plain JavaScript. Marinara does not compile TypeScript for extension code. A `.ts` file will not run, even though folder import can read it as package text.
+Point `jsPath` and `serverJsPath` at plain JavaScript. Guksu does not compile TypeScript for extension code. A `.ts` file will not run, even though folder import can read it as package text.
 
 ### Packaging several extensions
 
@@ -114,7 +114,7 @@ If there is no root package file, folder import scans for every `manifest.json` 
 
 ## Writing a browser extension
 
-Your browser JavaScript runs as a real page module. Marinara passes a frozen helper object named `marinara` into your code. Here is a small example that adds a styled button and cleans up after itself:
+Your browser JavaScript runs as a real page module. Guksu passes a frozen helper object named `marinara` into your code. Here is a small example that adds a styled button and cleans up after itself:
 
 ```js
 marinara.addStyle(`
@@ -152,7 +152,7 @@ The `marinara` helpers below all clean up automatically when the extension is di
 | `marinara.observe(target, callback, options)` | Creates a MutationObserver (default options watch child list and subtree) that disconnects on unload. |
 | `marinara.onCleanup(fn)` | Registers your own cleanup callback. If the extension already unloaded, `fn` runs right away. |
 
-Plain browser globals like `document`, `window`, and `fetch` are also reachable. The code runs as a real page module, not in a sandbox. Marinara catches any error while your module loads or runs. It writes the error to the browser devtools console, tagged with the extension name. It does not crash the app.
+Plain browser globals like `document`, `window`, and `fetch` are also reachable. The code runs as a real page module, not in a sandbox. Guksu catches any error while your module loads or runs. It writes the error to the browser devtools console, tagged with the extension name. It does not crash the app.
 
 ## CSS sanitization rules
 
@@ -228,8 +228,8 @@ A server extension reloads (it stops, then starts again) whenever you create, up
 | `marinara.version` | The server extension API version. Currently `1`. |
 | `marinara.extensionId` | The installed extension's ID. |
 | `marinara.extensionName` | The installed extension's name. |
-| `marinara.log.debug/info/warn/error(...)` | Writes to the Marinara server log, tagged with the extension name and ID. |
-| `marinara.fetch(url, options)` | Fetches an `http:` or `https:` URL through Marinara's outbound safety checks. The response is capped at 25 MiB. |
+| `marinara.log.debug/info/warn/error(...)` | Writes to the Guksu server log, tagged with the extension name and ID. |
+| `marinara.fetch(url, options)` | Fetches an `http:` or `https:` URL through Guksu's outbound safety checks. The response is capped at 25 MiB. |
 | `marinara.setInterval(fn, ms)` | Starts an interval that clears itself on unload. |
 | `marinara.setTimeout(fn, ms)` | Starts a timeout that clears itself on unload. |
 | `marinara.clearInterval(id)` | Clears an interval. |
@@ -242,7 +242,7 @@ While an enabled server extension is loaded, its row in the **Extension Library*
 
 ## The bundled example
 
-Marinara ships a minimal browser extension you can import to see the format in action. It lives in the install and repository at `docs/examples/extensions/minimal/`, and it is not visible inside the app. The docs browser does not serve the `examples/` folder, so there is no in-app link. Open the folder from the file system to find these three files.
+Guksu ships a minimal browser extension you can import to see the format in action. It lives in the install and repository at `docs/examples/extensions/minimal/`, and it is not visible inside the app. The docs browser does not serve the `examples/` folder, so there is no in-app link. Open the folder from the file system to find these three files.
 
 The `manifest.json`:
 

--- a/docs/extending/custom-tools.md
+++ b/docs/extending/custom-tools.md
@@ -1,6 +1,6 @@
 # Custom Tools and Function Calling
 
-This guide explains custom tools, also called Functions, in Marinara Engine. A custom tool teaches the AI to run a small action during a chat. It can return a fixed piece of text, call an outside web address, or run a short script on the server. You will learn how to build one, turn tool use on for a chat, and keep script tools safe.
+This guide explains custom tools, also called Functions, in Guksu Motor. A custom tool teaches the AI to run a small action during a chat. It can return a fixed piece of text, call an outside web address, or run a short script on the server. You will learn how to build one, turn tool use on for a chat, and keep script tools safe.
 
 ## What function calling is
 

--- a/docs/extending/extensions.md
+++ b/docs/extending/extensions.md
@@ -1,19 +1,19 @@
 # Extensions
 
-This guide explains what extensions are in Marinara Engine, and how to install, enable, export, and remove them. It covers the two kinds of extensions and the trust warnings each one shows. If you want to write your own extension, see the developer guide linked at the end.
+This guide explains what extensions are in Guksu Motor, and how to install, enable, export, and remove them. It covers the two kinds of extensions and the trust warnings each one shows. If you want to write your own extension, see the developer guide linked at the end.
 
 ## What an extension is
 
-An extension is an add-on that changes how Marinara looks or behaves. You install extensions that other people made, or that you wrote yourself.
+An extension is an add-on that changes how Guksu looks or behaves. You install extensions that other people made, or that you wrote yourself.
 
 There are two kinds of extension:
 
-- A **browser extension** runs inside the Marinara page in your web browser. It can change styling or add small features to the screen you are looking at. Some browser extensions also run JavaScript, a small program that acts on the page.
-- A **server extension** runs trusted JavaScript inside the Marinara server program on the host computer. It is more powerful, so only install a **server extension** from a source you trust.
+- A **browser extension** runs inside the Guksu page in your web browser. It can change styling or add small features to the screen you are looking at. Some browser extensions also run JavaScript, a small program that acts on the page.
+- A **server extension** runs trusted JavaScript inside the Guksu server program on the host computer. It is more powerful, so only install a **server extension** from a source you trust.
 
-Neither kind edits Marinara's own program files. An extension you disable or delete stops running and cleans up after itself.
+Neither kind edits Guksu's own program files. An extension you disable or delete stops running and cleans up after itself.
 
-You can get ready-made extensions from the official Marinara Engine Discord server. The **Extension Library** shows this same reminder below the list.
+You can get ready-made extensions from the official Guksu Motor Discord server. The **Extension Library** shows this same reminder below the list.
 
 ## Opening the Extension Library
 
@@ -23,7 +23,7 @@ You manage every extension in one place.
 2. Open the **Addons** tab. Its description reads "Themes, extensions, and custom behavior."
 3. Find the **Extension Library** section. Its description reads "Import, enable, disable, export, or remove installed extensions."
 
-The **Theme Library** sits in the same **Addons** tab, right below **Extension Library**. Themes are a separate feature for changing Marinara's look. See [Custom CSS Themes](../appearance/custom-css-themes.md).
+The **Theme Library** sits in the same **Addons** tab, right below **Extension Library**. Themes are a separate feature for changing Guksu's look. See [Custom CSS Themes](../appearance/custom-css-themes.md).
 
 ## Installing an extension
 
@@ -39,7 +39,7 @@ To install a whole folder:
 
 1. Click **Import Extension Folder**.
 2. Choose the folder that holds the extension files.
-3. Marinara imports every extension it finds inside.
+3. Guksu imports every extension it finds inside.
 
 Any other file type is rejected. You will see a message that lists the supported types.
 
@@ -61,8 +61,8 @@ Each row in the **Installed Extensions** list has a power icon on the left. Clic
 
 Turning an extension off never asks you to confirm. Turning one on may show a trust warning, because turning it on runs its code.
 
-- Turning on a **server extension** shows a dialog titled **Enable Server Extension**. It warns that the code runs inside the Marinara server program and can affect that server until you disable it. The confirm button is labeled **Enable Server Extension**. Only enable code you trust.
-- Turning on a **browser extension** that includes JavaScript shows a dialog titled **Enable Extension**. It warns that the code runs inside Marinara. The confirm button is labeled **Enable**.
+- Turning on a **server extension** shows a dialog titled **Enable Server Extension**. It warns that the code runs inside the Guksu server program and can affect that server until you disable it. The confirm button is labeled **Enable Server Extension**. Only enable code you trust.
+- Turning on a **browser extension** that includes JavaScript shows a dialog titled **Enable Extension**. It warns that the code runs inside Guksu. The confirm button is labeled **Enable**.
 - Turning on a **browser extension** that has styling only, with no JavaScript, runs right away with no dialog.
 
 ### Reading a server extension's status
@@ -83,7 +83,7 @@ You can save any installed extension as a file to back it up or share it.
 
 1. Find the extension in the **Installed Extensions** list.
 2. Click the export icon on the right of the row. Its title reads **Export extension**.
-3. Marinara downloads the extension as a `.zip` file.
+3. Guksu downloads the extension as a `.zip` file.
 
 The other person can install that `.zip` with **Import Extension File**.
 
@@ -97,15 +97,15 @@ Deleting is permanent. It removes the saved extension code from the server. Dele
 
 ## Changing an extension
 
-There is no way to edit an installed extension's code inside Marinara. To change one, delete it and import the new version. Importing a changed file creates a new entry rather than updating the old one, so delete the old entry to avoid duplicates.
+There is no way to edit an installed extension's code inside Guksu. To change one, delete it and import the new version. Importing a changed file creates a new entry rather than updating the old one, so delete the old entry to avoid duplicates.
 
 ## Why some actions need Admin Access
 
 Installing, enabling, disabling, exporting, and deleting an extension are protected actions. This protects the server from unwanted code.
 
-These actions work automatically when you open Marinara on the same computer that runs it, through `localhost` or `127.0.0.1`. The term `localhost` means "this computer".
+These actions work automatically when you open Guksu on the same computer that runs it, through `localhost` or `127.0.0.1`. The term `localhost` means "this computer".
 
-When you open Marinara from another device, such as your phone or a computer across your network, the server needs proof that you are allowed. You provide this with an admin secret:
+When you open Guksu from another device, such as your phone or a computer across your network, the server needs proof that you are allowed. You provide this with an admin secret:
 
 1. Set `ADMIN_SECRET` to a value of your choice in the server's `.env` file. The `.env` file holds server settings.
 2. Open **Settings**, then the **Advanced** tab, then **Admin Access**.
@@ -116,13 +116,13 @@ Without one of these two conditions, the action is denied. You will see an error
 ## What can go wrong
 
 - An extension does nothing after you enable it. Check that it is actually on, that a **server extension** shows **Running**, and that it is the kind you expected.
-- A browser extension that loads a font or image from the internet may show nothing. Marinara removes remote resources from extension styling for safety. Extensions must bundle fonts and images inside themselves.
+- A browser extension that loads a font or image from the internet may show nothing. Guksu removes remote resources from extension styling for safety. Extensions must bundle fonts and images inside themselves.
 - Two extensions can clash if they change the same part of the page. Disable one to test which one causes the problem.
-- A broken extension does not crash Marinara. Its errors are caught and logged, and you can disable or delete it at any time.
+- A broken extension does not crash Guksu. Its errors are caught and logged, and you can disable or delete it at any time.
 - An install fails with an access-denied error from another device. Set up **Admin Access** as described above.
 
 ## Related guides
 
 - [Writing Extensions (Developers)](../development/writing-extensions.md) for building your own extension.
-- [Custom CSS Themes](../appearance/custom-css-themes.md) for changing Marinara's look without an extension.
+- [Custom CSS Themes](../appearance/custom-css-themes.md) for changing Guksu's look without an extension.
 - [Remote Access](../REMOTE_ACCESS.md) for setting up access and the admin secret from other devices.

--- a/docs/extending/regex-scripts.md
+++ b/docs/extending/regex-scripts.md
@@ -1,6 +1,6 @@
 # Regex Scripts
 
-This guide explains regex scripts in Marinara Engine. A regex script is a find and replace rule that rewrites chat text automatically. This guide covers what regex scripts do, how to create one, where they run, and how to scope them to a single character.
+This guide explains regex scripts in Guksu Motor. A regex script is a find and replace rule that rewrites chat text automatically. This guide covers what regex scripts do, how to create one, where they run, and how to scope them to a single character.
 
 ## What a regex script is
 
@@ -149,7 +149,7 @@ Below the mode buttons, the panel lists each character with scoped scripts and l
 
 ## Importing regex scripts from SillyTavern
 
-Marinara can read regex scripts that come bundled inside a SillyTavern character card. When you import a card, a section titled **Imported regex scripts** appears with two choices:
+Guksu can read regex scripts that come bundled inside a SillyTavern character card. When you import a card, a section titled **Imported regex scripts** appears with two choices:
 
 - **Character only** (the default): the scripts stay scoped to that one character.
 - **Global**: the scripts are added to **Presets** and run in every chat.
@@ -158,7 +158,7 @@ This choice appears both in the single-character import dialog and in the bulk *
 
 ## Safety and performance
 
-Every pattern is checked before it can be saved or run. Marinara blocks patterns that are very likely to run slowly and hang the app. A blocked pattern shows this message: "Regex pattern is unsafe: avoid nested quantifiers, ambiguous quantified alternatives, and oversized patterns." Saving is blocked until you fix it.
+Every pattern is checked before it can be saved or run. Guksu blocks patterns that are very likely to run slowly and hang the app. A blocked pattern shows this message: "Regex pattern is unsafe: avoid nested quantifiers, ambiguous quantified alternatives, and oversized patterns." Saving is blocked until you fix it.
 
 In plain terms, avoid these shapes:
 

--- a/docs/game/combat.md
+++ b/docs/game/combat.md
@@ -1,6 +1,6 @@
 # Game Mode: Combat
 
-This guide explains combat in Marinara Engine Game Mode. It covers how a fight starts, the action menu, and the dice math behind every hit. It also explains status effects, elemental reactions, boss mechanics, loot, the Interrupt control, and Quick-Time Events. Combat is run by the AI Game Master (GM), the character who narrates your adventure.
+This guide explains combat in Guksu Motor Game Mode. It covers how a fight starts, the action menu, and the dice math behind every hit. It also explains status effects, elemental reactions, boss mechanics, loot, the Interrupt control, and Quick-Time Events. Combat is run by the AI Game Master (GM), the character who narrates your adventure.
 
 ## Starting an encounter
 

--- a/docs/game/dice-and-skill-checks.md
+++ b/docs/game/dice-and-skill-checks.md
@@ -1,6 +1,6 @@
 # Game Mode: Dice and Skill Checks
 
-This guide covers dice rolling in Marinara Engine Game Mode. It explains the quick-dice menu, custom dice notation, and the limits on custom rolls. It also covers how the Game Master runs a skill check against a Difficulty Class (DC).
+This guide covers dice rolling in Guksu Motor Game Mode. It explains the quick-dice menu, custom dice notation, and the limits on custom rolls. It also covers how the Game Master runs a skill check against a Difficulty Class (DC).
 
 ## Rolling dice
 

--- a/docs/game/game-assets.md
+++ b/docs/game/game-assets.md
@@ -4,7 +4,7 @@ This guide explains the game asset library that Game Mode uses for music, sound,
 
 ## What game assets are
 
-Game assets are the media files Game Mode plays and shows while a session runs. Marinara Engine sorts them into five categories:
+Game assets are the media files Game Mode plays and shows while a session runs. Guksu Motor sorts them into five categories:
 
 - **Music**: background music tracks that change with the scene.
 - **Ambient**: looping environmental sound, such as nature, urban, or interior audio.
@@ -16,7 +16,7 @@ Game Mode reads this library on its own. It picks music, ambient sound, and back
 
 ## The bundled starter set
 
-Marinara installs a free starter library the first time the server starts. It refreshes these files on later starts if the bundled set changes. The starter set includes:
+Guksu installs a free starter library the first time the server starts. It refreshes these files on later starts if the bundled set changes. The starter set includes:
 
 - Five **Music** tracks, one for each of several scene moods.
 - A set of **Ambient** loops under nature, urban, and interior folders.
@@ -129,7 +129,7 @@ Remember that bundled starter files are protected. You can rename or copy them, 
 
 ## Rescanning after outside changes
 
-Marinara keeps an internal list of your assets so Game Mode can find them fast. When you upload through the app, this list updates on its own.
+Guksu keeps an internal list of your assets so Game Mode can find them fast. When you upload through the app, this list updates on its own.
 
 If you copy files into the game asset folder directly on your computer, outside the app, the app does not notice right away. Click the **Rescan** button to make it re-read the folder and pick up the new files. **Rescan** sits in both the **Asset Browser** toolbar and the **Game Assets** section under **Settings**.
 
@@ -158,7 +158,7 @@ Picking a folder outside the app needs privileged access. On the same computer a
 
 ## Opening the folder on your computer
 
-The **Open in system folder** button opens the selected asset folder in your computer's normal file manager. This only works when you use the app on the same computer that runs the server. On a phone, tablet, or another computer, the app tells you that system folders can only be opened from the device hosting Marinara.
+The **Open in system folder** button opens the selected asset folder in your computer's normal file manager. This only works when you use the app on the same computer that runs the server. On a phone, tablet, or another computer, the app tells you that system folders can only be opened from the device hosting Guksu.
 
 ## Related guides
 

--- a/docs/game/getting-started.md
+++ b/docs/game/getting-started.md
@@ -1,10 +1,10 @@
 # Game Mode: Getting Started
 
-Game Mode turns Marinara Engine into a single-player role-playing game run by an AI Game Master. This guide covers what Game Mode is and what you need before you start. It then walks through the setup wizard and shows where to find each gameplay feature. Read it once, start a game, then follow the links at the end for deeper topics.
+Game Mode turns Guksu Motor into a single-player role-playing game run by an AI Game Master. This guide covers what Game Mode is and what you need before you start. It then walks through the setup wizard and shows where to find each gameplay feature. Read it once, start a game, then follow the links at the end for deeper topics.
 
 ## What Game Mode is
 
-Game Mode is one of Marinara's chat modes. The others are Conversation and Roleplay.
+Game Mode is one of Guksu's chat modes. The others are Conversation and Roleplay.
 
 In Game Mode, an AI Game Master (GM) runs a story for you. A Game Master is the AI that narrates the world, plays every character you meet, and decides what happens next. It works like the Dungeon Master in a tabletop game.
 
@@ -14,18 +14,18 @@ You do not have to use every mechanic. Some players skip combat and dice and use
 
 ## Before you start
 
-You need only one thing to start a game: an AI provider connection for the GM. A connection links Marinara to an AI provider so it can generate text. See [Connecting to an AI Provider](../connections/connecting-to-a-provider.md) if you have not set one up yet.
+You need only one thing to start a game: an AI provider connection for the GM. A connection links Guksu to an AI provider so it can generate text. See [Connecting to an AI Provider](../connections/connecting-to-a-provider.md) if you have not set one up yet.
 
 Everything else is optional and off by default. You can add these later:
 
 - **Image generation.** Game Mode has a visual layout with backgrounds and character art. To fill it, you need an image generation connection. The **Visual Generation** setting in the wizard is off by default, so you must turn it on yourself. Without it, you still get the story, state tracking, and combat, but the visual areas stay empty.
-- **A Local Model for scene effects.** Marinara can run a small model on your own machine, labeled **Local Model (Gemma)**. It powers background and music suggestions without extra cost. It is the default choice in the wizard. See [Local Model Setup](../connections/local-model.md).
+- **A Local Model for scene effects.** Guksu can run a small model on your own machine, labeled **Local Model (Gemma)**. It powers background and music suggestions without extra cost. It is the default choice in the wizard. See [Local Model Setup](../connections/local-model.md).
 - **A video generation connection.** This is only needed for scene videos or animated storyboards.
 - **Music.** The **Music DJ** agent can play game music. It needs Spotify or a local music folder, and it is off by default.
 
 ## The setup wizard
 
-When you create a Game Mode chat, a **setup wizard** opens. It has seven steps. The only required field is the GM connection on the first step. Every other field has a sensible default. You can move through the wizard quickly and let Marinara fill in the rest.
+When you create a Game Mode chat, a **setup wizard** opens. It has seven steps. The only required field is the GM connection on the first step. Every other field has a sensible default. You can move through the wizard quickly and let Guksu fill in the rest.
 
 The seven steps are:
 
@@ -60,7 +60,7 @@ These are the starting values in the **World**, **Party**, and **Features** step
 | Custom HUD Widgets | On | Uses AI-made status widgets from the new world |
 | Start Muted | Off | Begins the game with audio muted |
 
-New to Game Mode? Leave **Game Master Mode** on **Standalone GM**. Marinara builds a fair, slightly snarky GM for you, and you can feel out the mode before writing a custom GM card.
+New to Game Mode? Leave **Game Master Mode** on **Standalone GM**. Guksu builds a fair, slightly snarky GM for you, and you can feel out the mode before writing a custom GM card.
 
 Choose **Storyboard Optimized** on the final step when you want GM turns written as filmable visual beats. It selects the built-in **Storyboard Game Prompt**, **Comic Page Animation** planner, **Storyboard Illustration**, and **Comic Page Video** presets. Comic Page Animation uses the clip duration to limit the number of chronological panels, Storyboard Illustration formats each planned keyframe for the image model, and Comic Page Video treats those panels as ordered animation references. It does not turn image or video generation on and does not change your selected connections. The GM uses the wizard's **Keyframes per Turn** value as a target for strong visual anchor moments, but it can write fewer for a short exchange and can use more narration paragraphs when the story needs them.
 
@@ -134,9 +134,9 @@ The most common cause is that the model could not produce the full structured JS
 2. Try again. Some failures are one-off, and the same setup works on a second try.
 3. Shorten a very long setting or preferences field. Long inputs leave the model less room for the JSON output.
 
-If a call almost worked but the JSON was slightly broken, Marinara offers a **Repair JSON** modal. It opens a line-numbered editor with the model's raw output. A status line tells you whether the JSON is valid or shows the parse error. Click **Format** to tidy valid JSON. Then click **Apply Repaired JSON** to use your fixed version without paying for a full retry. The **Repair JSON** option also appears for session summaries and other structured calls.
+If a call almost worked but the JSON was slightly broken, Guksu offers a **Repair JSON** modal. It opens a line-numbered editor with the model's raw output. A status line tells you whether the JSON is valid or shows the parse error. Click **Format** to tidy valid JSON. Then click **Apply Repaired JSON** to use your fixed version without paying for a full retry. The **Repair JSON** option also appears for session summaries and other structured calls.
 
-For more symptoms and fixes, see [Troubleshooting Marinara Engine](../TROUBLESHOOTING.md).
+For more symptoms and fixes, see [Troubleshooting Guksu Motor](../TROUBLESHOOTING.md).
 
 ### The GM narrates cheerfully even though you chose a dark tone
 
@@ -156,4 +156,4 @@ Some models stay upbeat no matter the tone. You have two options. Add a clear in
 - [Connecting to an AI Provider](../connections/connecting-to-a-provider.md)
 - [Agents: AI Helpers for Your Chats](../agents/agents-overview.md)
 - [Generation Parameters](../prompts/generation-parameters.md)
-- [Troubleshooting Marinara Engine](../TROUBLESHOOTING.md)
+- [Troubleshooting Guksu Motor](../TROUBLESHOOTING.md)

--- a/docs/game/hud-widgets.md
+++ b/docs/game/hud-widgets.md
@@ -1,6 +1,6 @@
 # Game Mode: HUD Widgets
 
-This guide explains HUD widgets in Marinara Engine Game Mode. HUD stands for heads-up display: small info panels that sit at the left and right edges of the game screen. This guide covers the widget types, the review step before a game starts, moving and locking panels, and sharing widget layouts.
+This guide explains HUD widgets in Guksu Motor Game Mode. HUD stands for heads-up display: small info panels that sit at the left and right edges of the game screen. This guide covers the widget types, the review step before a game starts, moving and locking panels, and sharing widget layouts.
 
 ## What HUD widgets are
 

--- a/docs/game/map-time-weather.md
+++ b/docs/game/map-time-weather.md
@@ -12,7 +12,7 @@ You can drag the panel and lock it in place. For how draggable panels work, see 
 
 ## Grid view and node view
 
-The map has two views. Marinara Engine picks the view for you based on the kind of place the map represents. You do not switch views by hand.
+The map has two views. Guksu Motor picks the view for you based on the kind of place the map represents. You do not switch views by hand.
 
 - The **grid** view is for open areas like an overworld, a region, or a city. It shows terrain-colored squares, such as grass, forest, water, mountain, desert, snow, town, road, and cave.
 - The **node** view is for enclosed areas like dungeons and interiors. It shows locations as circles joined by lines. A location you have not discovered yet shows a question mark icon. A dashed line means a path you have not traveled. A solid line means a path you have used.
@@ -23,7 +23,7 @@ To travel, pick a place on the map. You can only pick certain places. On a grid 
 
 1. Click a grid square, or click a node on a node map.
 2. A **Destination:** chip appears above the message box with the place name.
-3. Type your message and send it. Marinara adds a short line like `*moves to <place>*` to the front of your message.
+3. Type your message and send it. Guksu adds a short line like `*moves to <place>*` to the front of your message.
 
 To cancel, click the small clear button (the X) on the **Destination:** chip.
 

--- a/docs/game/party-and-npcs.md
+++ b/docs/game/party-and-npcs.md
@@ -2,7 +2,7 @@
 
 This guide covers the people in your Game Mode campaign: your party members and the NPCs (non-player characters) the Game Master introduces. You will learn how to open party character sheets, edit or regenerate them, and read the Adventure Journal, including NPC reputation labels. It also explains the two Game Master modes.
 
-Game Mode is one of Marinara Engine's chat modes. It runs a single-player RPG (role-playing game) with an AI Game Master, often shortened to GM. For setup and the basics, see [Game Mode: Getting Started](getting-started.md).
+Game Mode is one of Guksu Motor's chat modes. It runs a single-player RPG (role-playing game) with an AI Game Master, often shortened to GM. For setup and the basics, see [Game Mode: Getting Started](getting-started.md).
 
 ## The party bar
 
@@ -102,7 +102,7 @@ An NPC appears in this tab once the Game Master has described it, given it a rep
 
 You pick who runs the game in the setup wizard, on the **Party** step, under **Game Master Mode**. There are two choices:
 
-- **Standalone GM**: the default. Marinara builds a game master for you. The wizard describes it as "A snarky narrator running the show". You do not need a character card.
+- **Standalone GM**: the default. Guksu builds a game master for you. The wizard describes it as "A snarky narrator running the show". You do not need a character card.
 - **Character GM**: use one of your own character cards as the Game Master. The engine tells the model to act as that character while still running the game. Pick this when you want a specific narrator voice.
 
 If this is your first game, use **Standalone GM**. You can set the mode when you create the game. For the full setup walkthrough, see [Game Mode: Getting Started](getting-started.md).

--- a/docs/game/sessions-and-saves.md
+++ b/docs/game/sessions-and-saves.md
@@ -1,6 +1,6 @@
 # Game Mode: Sessions and Saves
 
-This guide explains how Marinara Engine tracks your Game Mode progress across play sessions. It covers ending and starting a session and reading past sessions in the **Session History** panel. It also covers the **Show Spoilers** view and how the game saves your data.
+This guide explains how Guksu Motor tracks your Game Mode progress across play sessions. It covers ending and starting a session and reading past sessions in the **Session History** panel. It also covers the **Show Spoilers** view and how the game saves your data.
 
 ## What a session is
 

--- a/docs/game/storyboard.md
+++ b/docs/game/storyboard.md
@@ -1,16 +1,16 @@
 # Storyboard Engine Guide
 
-This guide explains storyboards in Marinara Engine. A storyboard turns one finished Game Mode turn into a short run of keyframe images. It can also add short animated clips, including continuous anime-style shots. The turn then reads like a mini cutscene. Storyboards are a Game Mode feature only. They do not exist in Roleplay or Conversation chats.
+This guide explains storyboards in Guksu Motor. A storyboard turns one finished Game Mode turn into a short run of keyframe images. It can also add short animated clips, including continuous anime-style shots. The turn then reads like a mini cutscene. Storyboards are a Game Mode feature only. They do not exist in Roleplay or Conversation chats.
 
 ## What storyboards are
 
 Game Mode is the chat mode where an AI Game Master (GM) narrates a turn-based adventure. When the GM finishes a narration turn, the Storyboard Engine can illustrate that single turn.
 
-Marinara reads the GM narration and splits it into a short run of ordered keyframes. Each keyframe is one picture of a moment in the turn. A storyboard holds 1 to 6 keyframes. The default is 3.
+Guksu reads the GM narration and splits it into a short run of ordered keyframes. Each keyframe is one picture of a moment in the turn. A storyboard holds 1 to 6 keyframes. The default is 3.
 
 Each keyframe is tied to a range of the turn's text. These text ranges are called reader sections. As you read down the turn, a small viewer shows the keyframe that matches your current spot in the text.
 
-Before it plans the images, Marinara strips the turn's GM command tags. GM command tags are hidden instruction tags in a GM message, such as dice rolls or game-state updates. They are removed so they do not show up in the picture.
+Before it plans the images, Guksu strips the turn's GM command tags. GM command tags are hidden instruction tags in a GM message, such as dice rolls or game-state updates. They are removed so they do not show up in the picture.
 
 Keyframe still images are saved in the **Gallery**, under the **Images** tab. Keyframe clips are saved as scene videos, under the **Videos** tab. Because they are normal Gallery items, you can preview, download, pin, or copy the prompt of any keyframe on its own.
 
@@ -46,7 +46,7 @@ While a storyboard is generating, the **Gallery** shows this banner: "Storyboard
 
 ## Automatic and manual storyboards
 
-You can make storyboards by hand, or have Marinara make them for you.
+You can make storyboards by hand, or have Guksu make them for you.
 
 Manual is the **Create storyboard** button in the **Gallery**. It builds a storyboard for the latest finished GM narration turn, only when you ask. You can also use it to refresh or re-illustrate the current turn, even when automatic storyboards are off.
 
@@ -137,7 +137,7 @@ The **NovelAI Keyframes** preset writes compact Danbooru tags. Danbooru tags are
 
 Game setup generates a campaign-level art style for visual consistency. For an existing game, open **Chat Settings > Agents > Illustrator** to see it under **Campaign art style**. You can edit it, clear it, restore the original setup-generated wording, or turn off **Use Campaign Art Style**.
 
-The campaign art style and **Image Style** profile are separate prompt layers. When both are enabled, Marinara includes both. Turning off or clearing the campaign style leaves the selected Image Style profile in place. This setting applies to storyboard keyframes and the game's other generated visual assets.
+The campaign art style and **Image Style** profile are separate prompt layers. When both are enabled, Guksu includes both. Turning off or clearing the campaign style leaves the selected Image Style profile in place. This setting applies to storyboard keyframes and the game's other generated visual assets.
 
 With **Expose image prompts before sending** enabled in **Settings > Generation**, manual **Create storyboard** requests first show the exact compiled positive and negative prompts for all planned keyframes. Changes in that review are one-off overrides for that storyboard only; they do not replace the campaign style or Image Style profile settings.
 
@@ -166,7 +166,7 @@ The floating viewer has these controls:
 
 **Background** fills the whole game surface with the active keyframe instead of a floating card. The image or clip sits behind the game controls. It uses the same reading-position logic as the floating viewer.
 
-Background mode has a trade-off. It turns off Marinara's normal generated scene location background. While it is on, the **Generate background** button in the illustrator popover is disabled. The button shows this note: "Storyboard background display is active, so scene background generation is disabled."
+Background mode has a trade-off. It turns off Guksu's normal generated scene location background. While it is on, the **Generate background** button in the illustrator popover is disabled. The button shows this note: "Storyboard background display is active, so scene background generation is disabled."
 
 ## Getting better results
 
@@ -184,7 +184,7 @@ For steadier results:
 
 For a compact NovelAI request, choose **NovelAI Keyframes** and turn off **Use Storyboard Template** in the **Storyboards** card. This sends the planned scene prompt directly while keeping the separate appearance, reference-image, image-instruction, and style settings available.
 
-**Use NovelAI Character Prompts** sends each visible character through native NovelAI Add Character captions and positions. This is on by default. Important: it only takes effect for an official NovelAI connection using a V4 or V4.5 model on novelai.net. For any other provider or model, the toggle does nothing, and Marinara uses the shared legacy prompt instead.
+**Use NovelAI Character Prompts** sends each visible character through native NovelAI Add Character captions and positions. This is on by default. Important: it only takes effect for an official NovelAI connection using a V4 or V4.5 model on novelai.net. For any other provider or model, the toggle does nothing, and Guksu uses the shared legacy prompt instead.
 
 ## Troubleshooting
 
@@ -196,9 +196,9 @@ For a compact NovelAI request, choose **NovelAI Keyframes** and turn off **Use S
 
 **Images appear, but no videos.** Videos need both **Automatic Storyboard Animations** on and a **Video Generation** connection selected. With animations off, storyboards make still keyframes only.
 
-**Automatic storyboards do not run.** Check that **Automatic Storyboard Illustrations** or **Automatic Storyboard Animations** is on. Check that the image connection is set and the GM turn has finished streaming. Marinara will not make a second storyboard for a turn that already has one. You can still remake it by hand with **Create storyboard** in the **Gallery**.
+**Automatic storyboards do not run.** Check that **Automatic Storyboard Illustrations** or **Automatic Storyboard Animations** is on. Check that the image connection is set and the GM turn has finished streaming. Guksu will not make a second storyboard for a turn that already has one. You can still remake it by hand with **Create storyboard** in the **Gallery**.
 
-**The storyboard is partial or stuck.** This usually means one or more image or video jobs failed, timed out, or hit a provider rate limit. Prohibited content can also block a job. If a provider is slow, raise the image and video generation timeouts in your `.env` file, then restart Marinara. See the [configuration guide](../CONFIGURATION.md) for the exact variable names.
+**The storyboard is partial or stuck.** This usually means one or more image or video jobs failed, timed out, or hit a provider rate limit. Prohibited content can also block a job. If a provider is slow, raise the image and video generation timeouts in your `.env` file, then restart Guksu. See the [configuration guide](../CONFIGURATION.md) for the exact variable names.
 
 For deeper diagnosis, set your log level to debug and watch the server log. The storyboard log lines are tagged `[debug/game/storyboard-illustrator]`, `[debug/game/storyboard-image-preview]`, `[debug/game/storyboard-image-assets]`, and `[debug/game/storyboard-video]`.
 

--- a/docs/home/achievements.md
+++ b/docs/home/achievements.md
@@ -1,10 +1,10 @@
 # Achievements
 
-This guide explains the Achievements feature in Marinara Engine. Achievements are cosmetic badges that unlock as you use the app. This guide covers where to find them, the full list, the on/off setting, and how unlocking works.
+This guide explains the Achievements feature in Guksu Motor. Achievements are cosmetic badges that unlock as you use the app. This guide covers where to find them, the full list, the on/off setting, and how unlocking works.
 
 ## What achievements are
 
-Achievements are small collectible badges. Marinara Engine unlocks them in the background as you do normal things, like creating chats, characters, or personas, or visiting community links.
+Achievements are small collectible badges. Guksu Motor unlocks them in the background as you do normal things, like creating chats, characters, or personas, or visiting community links.
 
 Achievements are purely cosmetic. They do not unlock features and they do not change how the app behaves. They are just a fun way to track what you have done.
 
@@ -69,7 +69,7 @@ Because tracking continues while the setting is off, your progress is not lost. 
 
 ## How unlocking works
 
-Marinara checks the ranked achievements against your current live counts. This check runs when a tracked action happens, such as creating a chat or clicking a footer link. It also runs when you open the Achievements panel.
+Guksu checks the ranked achievements against your current live counts. This check runs when a tracked action happens, such as creating a chat or clicking a footer link. It also runs when you open the Achievements panel.
 
 When an action triggers an unlock and the setting is on, a small pop-up notice appears. Its title is **Achievement unlocked**, and it names the badge, for example **Hoarder II** or **One Of Us**.
 
@@ -83,7 +83,7 @@ There is no button anywhere in the app to reset or clear your achievements.
 
 ## Related guides
 
-- [Getting Started with Marinara Engine](welcome.md)
+- [Getting Started with Guksu Motor](welcome.md)
 - [The First-Time Tutorial](tutorial.md)
 - [Professor Mari, Your In-App Assistant](professor-mari.md)
 - [Connecting to an AI Provider](../connections/connecting-to-a-provider.md)

--- a/docs/home/professor-mari.md
+++ b/docs/home/professor-mari.md
@@ -1,6 +1,6 @@
 # Professor Mari, Your In-App Assistant
 
-Professor Mari is Marinara Engine's built-in assistant on the Home screen. This guide shows where to find her, what she can do, how she keeps her changes reversible, and how to fix common problems.
+Professor Mari is Guksu Motor's built-in assistant on the Home screen. This guide shows where to find her, what she can do, how she keeps her changes reversible, and how to fix common problems.
 
 ## Where to find her
 
@@ -38,11 +38,11 @@ Guided flows ask one focused question at a time instead of presenting a long for
 
 ## She can also read and edit the app's own files
 
-Professor Mari can look inside Marinara's own program files, change them, and run commands on your computer. This is a real and powerful ability, so it is worth understanding clearly.
+Professor Mari can look inside Guksu's own program files, change them, and run commands on your computer. This is a real and powerful ability, so it is worth understanding clearly.
 
 Here is the trust boundary in plain terms:
 
-- She works only inside the folder where Marinara is installed. She cannot reach the rest of your computer.
+- She works only inside the folder where Guksu is installed. She cannot reach the rest of your computer.
 - She cannot write straight into your saved data folder, where your characters and chats live. Instead she uses the reviewable change flow described below.
 - Commands she runs stop on their own after a short time, so a stuck command cannot run forever.
 
@@ -50,7 +50,7 @@ Most people never need this. It exists so she can inspect or repair the app itse
 
 ## Picking a connection
 
-Professor Mari needs a connection to think. A connection links Marinara to an AI provider using an API key. An API key is a secret code from that provider.
+Professor Mari needs a connection to think. A connection links Guksu to an AI provider using an API key. An API key is a secret code from that provider.
 
 Click the link icon next to the paperclip to open the **Connections** dropdown. Pick any text generation connection you have set up. If you have downloaded the built in local model, it appears here too as **Local Model (sidecar)**. If the app knows the model's name, that name shows in the parentheses instead. Your choice is remembered in your browser.
 
@@ -129,7 +129,7 @@ Professor Mari is a helper, not the full documentation. Keep these limits in min
 - For edits, name the exact item and the exact field you want changed. A request like "rewrite this whole character" is riskier than "make Luna's greeting shorter, keep her personality the same."
 - For multi-step creation, use the suggestion chips to answer one focused question at a time instead of trying to provide every field at once.
 - If she says she finished a task but the app does not show it, trust the app. Finish the task yourself from the matching panel.
-- If you reach Marinara from another device instead of the same computer, her editing actions need remote access set up. See the remote access guide.
+- If you reach Guksu from another device instead of the same computer, her editing actions need remote access set up. See the remote access guide.
 
 ## Troubleshooting
 
@@ -137,11 +137,11 @@ Professor Mari is a helper, not the full documentation. Keep these limits in min
 - "You haven't set up a connection yet" pop-up message: pick a connection from the link icon dropdown, or add one first.
 - She cannot read your attached image: your model must support image input. Switch to a connection whose model can see images.
 - Fandom lookups fail: these need an internet connection, since Fandom is an outside website.
-- Her actions are blocked with a permission error: you are reaching Marinara over a network, not from the same computer. Set up remote access first.
+- Her actions are blocked with a permission error: you are reaching Guksu over a network, not from the same computer. Set up remote access first.
 
 ## Related guides
 
-- [Getting Started with Marinara Engine](welcome.md)
+- [Getting Started with Guksu Motor](welcome.md)
 - [The First-Time Tutorial](tutorial.md)
 - [Connecting to an AI Provider](../connections/connecting-to-a-provider.md)
 - [Creating and Editing Characters](../characters/creating-and-editing-characters.md)

--- a/docs/home/tutorial.md
+++ b/docs/home/tutorial.md
@@ -1,10 +1,10 @@
 # The First-Time Tutorial
 
-This guide explains the guided tour that appears the first time you open Marinara Engine. It covers every tour step in order, how to skip the tour, how to replay it later, and what changes on a phone.
+This guide explains the guided tour that appears the first time you open Guksu Motor. It covers every tour step in order, how to skip the tour, how to replay it later, and what changes on a phone.
 
 ## What the tutorial is
 
-The first time you open Marinara Engine, a guided tour starts on its own. People also call it the onboarding tour or the onboarding tutorial. Professor Mari, the built-in assistant, walks you around the main parts of the app.
+The first time you open Guksu Motor, a guided tour starts on its own. People also call it the onboarding tour or the onboarding tutorial. Professor Mari, the built-in assistant, walks you around the main parts of the app.
 
 The tour shows one card at a time. On a normal desktop screen, a pulsing ring highlights the button the card is talking about. Each card has a short title, a short explanation, and a row of small progress dots that show how far along you are.
 
@@ -14,7 +14,7 @@ The tour also does more than talk. As you move forward, some steps open the matc
 
 The tour has 15 steps. Here they are in order, with the exact title of each card and what it points at.
 
-1. **Welcome to Marinara Engine!** A centered welcome card. Professor Mari waves and offers to show you around.
+1. **Welcome to Guksu Motor!** A centered welcome card. Professor Mari waves and offers to show you around.
 2. **Card Browser** Highlights the **Card Browser** panel button, where you can click **Download Cards** to find and import ready-made characters.
 3. **Characters** Highlights the **Characters** panel button, where your characters live.
 4. **Lorebooks** Highlights the **Lorebooks** panel button, which holds extra world and character details.
@@ -48,5 +48,5 @@ The steps still work the same way underneath. Moving forward still opens the mat
 
 ## Related guides
 
-- [Getting Started with Marinara Engine](welcome.md)
+- [Getting Started with Guksu Motor](welcome.md)
 - [Professor Mari, Your In-App Assistant](professor-mari.md)

--- a/docs/home/welcome.md
+++ b/docs/home/welcome.md
@@ -1,28 +1,28 @@
-# Getting Started with Marinara Engine
+# Getting Started with Guksu Motor
 
-Welcome to Marinara Engine. This guide covers what the app is, what you see on the Home screen, and the first steps to start your first chat. It is written for a new user, so no prior setup knowledge is needed.
+Welcome to Guksu Motor. This guide covers what the app is, what you see on the Home screen, and the first steps to start your first chat. It is written for a new user, so no prior setup knowledge is needed.
 
-## What Marinara Engine is
+## What Guksu Motor is
 
-Marinara Engine is a local app for chatting and roleplaying with AI characters. It runs on your own machine, and you connect it to an AI service of your choice. You create or import characters, pick how you want to chat, and talk to them. Marinara does not run an AI by itself, so your first job is to add a connection. Most people connect to an online AI provider. There is also a small built-in **Local Model** you can download. It is best for light helper tasks, not for your main chat; see [Local Model Setup](../connections/local-model.md). After that first setup, everything works from the app.
+Guksu Motor is a local app for chatting and roleplaying with AI characters. It runs on your own machine, and you connect it to an AI service of your choice. You create or import characters, pick how you want to chat, and talk to them. Guksu does not run an AI by itself, so your first job is to add a connection. Most people connect to an online AI provider. There is also a small built-in **Local Model** you can download. It is best for light helper tasks, not for your main chat; see [Local Model Setup](../connections/local-model.md). After that first setup, everything works from the app.
 
 ## The Home screen at a glance
 
 The Home screen is what you see when no chat is open. From top to bottom, it shows these parts:
 
-- The app logo, the words **Marinara Engine**, and the version number below them.
+- The app logo, the words **Guksu Motor**, and the version number below them.
 - A row of your most recent chats: up to three, shown as chips you can click to reopen. If you have none yet, this row shows "No chats yet".
 - The **Ask Professor Mari** card: a chat box for the built-in assistant who can explain the app and help you set things up. A short **FAQ** sits next to it with common questions and answers.
 - An **Achievements** button, shown only when the Achievements setting is on.
 - A footer with these buttons: **Discord**, **Support**, **Credits**, **Documentation**, and **Replay Tutorial**.
 
-The first time you open Marinara, a short guided tour points out the main buttons and chat modes. For the full walkthrough, see [The First-Time Tutorial](tutorial.md).
+The first time you open Guksu, a short guided tour points out the main buttons and chat modes. For the full walkthrough, see [The First-Time Tutorial](tutorial.md).
 
 ## Your first steps
 
 Follow these steps in order to get to your first chat.
 
-1. Install Marinara Engine and open it in your browser. Pick your platform in [Marinara Engine Installation](../INSTALLATION.md).
+1. Install Guksu Motor and open it in your browser. Pick your platform in [Guksu Motor Installation](../INSTALLATION.md).
 2. Add a connection so the app can reach an AI service. A connection stores your provider, your API key, and your model. An API key is a secret code, a bit like a password, that you get from the AI provider. See [Connecting to an AI Provider](../connections/connecting-to-a-provider.md).
 3. Make or import a character to chat with. Open the **Characters** panel, then click **New** to open the **Create Character** window, or click **Import** to bring in a card from a file. See [Creating and Editing Characters](../characters/creating-and-editing-characters.md).
 4. Start a chat. In the chat sidebar, pick a mode tab, then click the **+** button. The button is named **New Conversation**, **New Roleplay**, or **New Game**, to match the tab. The new chat opens with a setup window that walks you through the rest. If you have no connection saved yet, a **Set Up Conversation**, **Set Up Roleplay**, or **Set Up Game** window appears first. Choose your connection there, then click **Create Chat**.
@@ -31,7 +31,7 @@ If you get stuck on any step, ask the built-in assistant. Read [Professor Mari, 
 
 ## The three chat modes
 
-Marinara has three chat modes. You pick one when you start a new chat.
+Guksu has three chat modes. You pick one when you start a new chat.
 
 - **Conversation**: a plain, direct AI chat with no roleplay, styled like a messaging app. See [Conversation Mode: Getting Started](../conversation/getting-started.md).
 - **Roleplay**: immersive roleplay with characters, scene tracking, and world state. See [Roleplay Mode: Getting Started](../roleplay/getting-started.md).
@@ -46,11 +46,11 @@ You have several ways to get help without leaving the app:
 - Open the in-app guides with the **Documentation** button in the Home screen footer.
 - Click **Discord** in the footer to reach the community, or **Support** to back the project.
 
-If something is broken or does not work, see [Troubleshooting Marinara Engine](../TROUBLESHOOTING.md).
+If something is broken or does not work, see [Troubleshooting Guksu Motor](../TROUBLESHOOTING.md).
 
 ## Related guides
 
-- [Marinara Engine Installation](../INSTALLATION.md)
+- [Guksu Motor Installation](../INSTALLATION.md)
 - [Connecting to an AI Provider](../connections/connecting-to-a-provider.md)
 - [Creating and Editing Characters](../characters/creating-and-editing-characters.md)
 - [The First-Time Tutorial](tutorial.md)

--- a/docs/installation/android-termux.md
+++ b/docs/installation/android-termux.md
@@ -1,33 +1,33 @@
 # Android (Termux) Installation Guide
 
-This guide shows you how to run Marinara Engine on an Android phone or tablet. Marinara runs inside Termux, a free Linux environment for Android. You can set it up the easy way with the Android app, or by hand in the Termux terminal.
+This guide shows you how to run Guksu Motor on an Android phone or tablet. Guksu runs inside Termux, a free Linux environment for Android. You can set it up the easy way with the Android app, or by hand in the Termux terminal.
 
 ## What Termux and F-Droid are
 
-Termux is a free app that gives your phone a small Linux system and a command line. Marinara Engine needs it because Marinara is a Linux server, not a native Android app.
+Termux is a free app that gives your phone a small Linux system and a command line. Guksu Motor needs it because Guksu is a Linux server, not a native Android app.
 
 F-Droid is a free, open-source app store for Android. You install Termux from F-Droid.
 
-Install Termux from F-Droid here: [Termux on F-Droid](https://f-droid.org/en/packages/com.termux/). Do not use the Play Store version of Termux. It is outdated and does not work with Marinara.
+Install Termux from F-Droid here: [Termux on F-Droid](https://f-droid.org/en/packages/com.termux/). Do not use the Play Store version of Termux. It is outdated and does not work with Guksu.
 
 ## Install with the Android app (APK)
 
-The easiest path uses the Marinara Engine Android app. An APK is an Android app install file. This app is a small helper: it sets up Termux for you, then opens Marinara once the local server is running. It still needs Termux to do the real work, so Android will ask you to approve a few prompts.
+The easiest path uses the Guksu Motor Android app. An APK is an Android app install file. This app is a small helper: it sets up Termux for you, then opens Guksu once the local server is running. It still needs Termux to do the real work, so Android will ask you to approve a few prompts.
 
 1. Download the Android APK from the [latest GitHub Release](https://github.com/Pasta-Devs/Marinara-Engine/releases).
 2. Install the APK, then open the app.
-3. Tap **Install / Start Marinara**.
+3. Tap **Install / Start Guksu**.
 4. If Termux is not installed yet, approve Android's install prompts so the app can download and install Termux from F-Droid.
 5. When Android asks, grant the **Run commands in Termux environment** permission.
-6. If Termux blocks the setup, the app copies an `allow-external-apps` command for you. Paste that command into Termux once, then tap **Install / Start Marinara** again.
-7. Wait while Termux installs the dependencies and builds Marinara. The first build takes a few minutes.
-8. The app opens Marinara for you once the local server is ready.
+6. If Termux blocks the setup, the app copies an `allow-external-apps` command for you. Paste that command into Termux once, then tap **Install / Start Guksu** again.
+7. Wait while Termux installs the dependencies and builds Guksu. The first build takes a few minutes.
+8. The app opens Guksu for you once the local server is ready.
 
-If you prefer a home-screen icon that opens Marinara like a normal app, this same Android app provides it. It is a wrapper around the Termux server, so the server must be set up first. It cannot skip Android's install and permission prompts.
+If you prefer a home-screen icon that opens Guksu like a normal app, this same Android app provides it. It is a wrapper around the Termux server, so the server must be set up first. It cannot skip Android's install and permission prompts.
 
 ## Install manually in Termux
 
-If you would rather not use the app, you can install Marinara by hand. Open Termux and paste this one command:
+If you would rather not use the app, you can install Guksu by hand. Open Termux and paste this one command:
 
 ```
 pkg update -y && pkg install -y git nodejs-lts && ([ -d "$HOME/Marinara-Engine/.git" ] || git clone https://github.com/Pasta-Devs/Marinara-Engine.git "$HOME/Marinara-Engine") && cd "$HOME/Marinara-Engine" && chmod +x start-termux.sh && ./start-termux.sh
@@ -36,12 +36,12 @@ pkg update -y && pkg install -y git nodejs-lts && ([ -d "$HOME/Marinara-Engine/.
 This one command does five things:
 
 1. Updates the Termux packages.
-2. Installs Git and Node.js. Marinara supports Node.js versions 24, 25, and 26.
-3. Downloads Marinara Engine, unless it is already installed.
+2. Installs Git and Node.js. Guksu supports Node.js versions 24, 25, and 26.
+3. Downloads Guksu Motor, unless it is already installed.
 4. Makes the launcher (the `start-termux.sh` script) runnable.
 5. Runs the launcher for the first time.
 
-The launcher installs the app's dependencies, builds Marinara on your device, and starts the local server. It also upgrades Node.js for you if your version is too old. The first run is slow because it builds the app. Later runs are much faster.
+The launcher installs the app's dependencies, builds Guksu on your device, and starts the local server. It also upgrades Node.js for you if your version is too old. The first run is slow because it builds the app. Later runs are much faster.
 
 When it finishes, open this address in your Android browser:
 
@@ -49,11 +49,11 @@ When it finishes, open this address in your Android browser:
 http://127.0.0.1:7860
 ```
 
-Marinara listens on the port set by `PORT` (the network port the app uses). The default is 7860. If you set a different `PORT`, use that number instead.
+Guksu listens on the port set by `PORT` (the network port the app uses). The default is 7860. If you set a different `PORT`, use that number instead.
 
-Tip: to get an app-like icon, open your browser menu and choose the option that adds Marinara to your home screen. The exact menu name differs between browsers.
+Tip: to get an app-like icon, open your browser menu and choose the option that adds Guksu to your home screen. The exact menu name differs between browsers.
 
-## Start Marinara again
+## Start Guksu again
 
 After the first setup, you do not repeat the install. Open Termux and run:
 
@@ -62,22 +62,22 @@ cd Marinara-Engine
 ./start-termux.sh
 ```
 
-The launcher checks for updates, then starts Marinara. To start your current copy without checking GitHub, add `--skip-update`:
+The launcher checks for updates, then starts Guksu. To start your current copy without checking GitHub, add `--skip-update`:
 
 ```
 cd Marinara-Engine
 ./start-termux.sh --skip-update
 ```
 
-The launcher also removes unreferenced packages from its local pnpm cache during dependency updates. This keeps old releases from accumulating several gigabytes on the phone; it does not touch Marinara chats, settings, or other user data.
+The launcher also removes unreferenced packages from its local pnpm cache during dependency updates. This keeps old releases from accumulating several gigabytes on the phone; it does not touch Guksu chats, settings, or other user data.
 
 ## Access from another device
 
-By default, the launcher makes Marinara reachable on your local network. This means a laptop or another phone on the same Wi-Fi can open it. For step-by-step instructions on finding the right address, see the [Frequently Asked Questions](../FAQ.md).
+By default, the launcher makes Guksu reachable on your local network. This means a laptop or another phone on the same Wi-Fi can open it. For step-by-step instructions on finding the right address, see the [Frequently Asked Questions](../FAQ.md).
 
 ## Updating
 
-Each time you run the launcher (`./start-termux.sh`), it checks GitHub for a newer version and updates before it starts. So the simple way to stay current is to just start Marinara normally.
+Each time you run the launcher (`./start-termux.sh`), it checks GitHub for a newer version and updates before it starts. So the simple way to stay current is to just start Guksu normally.
 
 To start your installed copy without updating, use the skip flag:
 
@@ -87,11 +87,11 @@ To start your installed copy without updating, use the skip flag:
 
 To keep the installed Engine version across launches, add `AUTO_UPDATE_ENABLED=false` to the project `.env`. This does not disable manual update commands or **Settings → Advanced → Updates**.
 
-You can also check for updates inside the app. Open **Settings**, go to the **Advanced** tab, and open the **Updates** section. Click **Check for Updates** to see if a newer release exists. The in-app **Apply Update** button is off by default and needs setup. For how to enable and use it, see [Upgrading Marinara Engine](../UPGRADING.md).
+You can also check for updates inside the app. Open **Settings**, go to the **Advanced** tab, and open the **Updates** section. Click **Check for Updates** to see if a newer release exists. The in-app **Apply Update** button is off by default and needs setup. For how to enable and use it, see [Upgrading Guksu Motor](../UPGRADING.md).
 
 ## Related guides
 
-- [Marinara Engine Installation](../INSTALLATION.md)
+- [Guksu Motor Installation](../INSTALLATION.md)
 - [iOS / iPadOS PWA Guide](ios-pwa.md)
-- [Upgrading Marinara Engine](../UPGRADING.md)
+- [Upgrading Guksu Motor](../UPGRADING.md)
 - [Frequently Asked Questions](../FAQ.md)

--- a/docs/installation/containers.md
+++ b/docs/installation/containers.md
@@ -1,27 +1,27 @@
 # Run via Container (Docker / Podman)
 
-This guide shows you how to run Marinara Engine inside a container using Docker or Podman. A container is a self-contained package that bundles the app and everything it needs to run. You do not have to install Node.js or other tools on your computer. If you are new and just want Marinara running, this is the easiest path.
+This guide shows you how to run Guksu Motor inside a container using Docker or Podman. A container is a self-contained package that bundles the app and everything it needs to run. You do not have to install Node.js or other tools on your computer. If you are new and just want Guksu running, this is the easiest path.
 
 ## Prerequisites
 
-Before you start, install one of these on the machine that will run Marinara:
+Before you start, install one of these on the machine that will run Guksu:
 
 - Docker Desktop (Windows or macOS) or Docker Engine (Linux). Docker is the most common container tool.
 - Or Podman. Podman is a drop-in replacement for Docker. It runs without a background service and works well without root access.
 
 A few terms used below:
 
-- **Image**: a downloadable, read-only template that contains Marinara Engine. You run an image to create a running container.
+- **Image**: a downloadable, read-only template that contains Guksu Motor. You run an image to create a running container.
 - **Volume**: a storage area the container tool manages for you. A volume keeps your data even when you delete and recreate the container.
 - **LAN**: your local network (the Wi-Fi or wired network at your home or office).
 
-The official Marinara images are published at `ghcr.io/pasta-devs/marinara-engine`.
+The official Guksu images are published at `ghcr.io/pasta-devs/marinara-engine`.
 
 ## Pull and run
 
-The repository includes a ready-to-use `docker-compose.yml` file in the project root. Compose reads this file and starts the container for you. This is the recommended way to run Marinara.
+The repository includes a ready-to-use `docker-compose.yml` file in the project root. Compose reads this file and starts the container for you. This is the recommended way to run Guksu.
 
-1. Get a copy of the repository. If you already have a Marinara Engine checkout, open a terminal in that folder. If not, clone it first:
+1. Get a copy of the repository. If you already have a Guksu Motor checkout, open a terminal in that folder. If not, clone it first:
 
 ```bash
 git clone https://github.com/Pasta-Devs/Marinara-Engine.git
@@ -50,13 +50,13 @@ The `docker-compose.yml` file uses the `ghcr.io/pasta-devs/marinara-engine:lates
 http://127.0.0.1:7860
 ```
 
-You should see the Marinara Engine home screen. If you do, the container is running. The address `127.0.0.1` means "this same computer", and `7860` is the default port Marinara listens on.
+You should see the Guksu Motor home screen. If you do, the container is running. The address `127.0.0.1` means "this same computer", and `7860` is the default port Guksu listens on.
 
 If the page does not load, see the Troubleshooting section below.
 
 ## Where your data is stored
 
-Your data (your chats, characters, uploads, fonts, and default backgrounds) is saved as plain files. Marinara uses file-backed storage, which means your data lives as normal files rather than inside a single database file. Compose keeps these files in a named volume called `marinara-data`.
+Your data (your chats, characters, uploads, fonts, and default backgrounds) is saved as plain files. Guksu uses file-backed storage, which means your data lives as normal files rather than inside a single database file. Compose keeps these files in a named volume called `marinara-data`.
 
 Compose adds the project folder name in front of volume names, so the real volume name follows a `PROJECT_marinara-data` pattern. To find the exact name on your machine, list the volumes:
 
@@ -74,13 +74,13 @@ Replace `PROJECT_marinara-data` with the name the previous command printed.
 
 Each time the container starts, it prepares the data folder. By default the container starts as root. It fixes the folder ownership so the app can write to it, then switches to a non-root user for safety. This repair works for the named volume and also for a folder you mount from your host. It means older setups can move to file-backed storage without you running any manual ownership commands.
 
-Marinara also creates an empty settings file at `/app/data/.env` inside the volume on first start. This is where you can add server settings later. Because it lives in the volume, your settings survive container restarts and image updates. See [Server Configuration Reference](../CONFIGURATION.md) for the full list of settings.
+Guksu also creates an empty settings file at `/app/data/.env` inside the volume on first start. This is where you can add server settings later. Because it lives in the volume, your settings survive container restarts and image updates. See [Server Configuration Reference](../CONFIGURATION.md) for the full list of settings.
 
-## Exposing Marinara to your LAN
+## Exposing Guksu to your LAN
 
-By default, Compose only lets you reach Marinara from the same computer. This is the safe default. If you want to open Marinara on your phone or another computer on your network, you must do two things. Change the port mapping, and turn on a login so strangers cannot reach it.
+By default, Compose only lets you reach Guksu from the same computer. This is the safe default. If you want to open Guksu on your phone or another computer on your network, you must do two things. Change the port mapping, and turn on a login so strangers cannot reach it.
 
-Basic Auth is a simple username and password prompt that protects the app. Never expose Marinara to your network without it.
+Basic Auth is a simple username and password prompt that protects the app. Never expose Guksu to your network without it.
 
 1. Open `docker-compose.yml` in a text editor.
 
@@ -113,11 +113,11 @@ environment:
 docker compose up -d
 ```
 
-Now other devices on your network can reach Marinara at `http://YOUR_COMPUTER_IP:7860` when `PORT` is unset. If you set `PORT`, replace `7860` with that host port. They must enter the username and password you set. To find good ways to allow only certain devices, and to learn what the admin secret does, read [Remote Access: Basic Auth and IP Allowlist](../REMOTE_ACCESS.md).
+Now other devices on your network can reach Guksu at `http://YOUR_COMPUTER_IP:7860` when `PORT` is unset. If you set `PORT`, replace `7860` with that host port. They must enter the username and password you set. To find good ways to allow only certain devices, and to learn what the admin secret does, read [Remote Access: Basic Auth and IP Allowlist](../REMOTE_ACCESS.md).
 
 ## Choosing an image: latest, staging, or lite
 
-Marinara publishes several image tags. Pick the one that fits your needs.
+Guksu publishes several image tags. Pick the one that fits your needs.
 
 - `latest` is the recommended stable release. The `docker-compose.yml` file uses it by default.
 - `X.Y.Z` is a fixed version, such as `ghcr.io/pasta-devs/marinara-engine:2.0.6`. Use this when you want to pin one exact release.
@@ -151,7 +151,7 @@ The lite tag is `ghcr.io/pasta-devs/marinara-engine:lite`, and each release also
 docker run -d --name marinara-lite -p 127.0.0.1:7860:7860 -v marinara-data:/app/data ghcr.io/pasta-devs/marinara-engine:lite
 ```
 
-Some older lite images can crash on Raspberry Pi 4 and similar ARM computers. The crash shows a `SIGILL` error (an illegal-instruction error from the processor) during outgoing AI provider calls. If you use one of these devices, run the regular `latest` image instead. See [Troubleshooting Marinara Engine](../TROUBLESHOOTING.md) for the current details.
+Some older lite images can crash on Raspberry Pi 4 and similar ARM computers. The crash shows a `SIGILL` error (an illegal-instruction error from the processor) during outgoing AI provider calls. If you use one of these devices, run the regular `latest` image instead. See [Troubleshooting Guksu Motor](../TROUBLESHOOTING.md) for the current details.
 
 ## Updating
 
@@ -169,7 +169,7 @@ For Podman Compose, run this one command:
 podman compose pull && podman compose up -d
 ```
 
-You can also check your version inside the app. Open **Settings**, go to the **Advanced** tab, and find the **Updates** section. Click **Check for Updates**. For container installs, Marinara detects that it is running in Docker and shows you the release image tag plus the host command to run. It cannot apply the update from inside the browser, so you still run the command above on the host.
+You can also check your version inside the app. Open **Settings**, go to the **Advanced** tab, and find the **Updates** section. Click **Check for Updates**. For container installs, Guksu detects that it is running in Docker and shows you the release image tag plus the host command to run. It cannot apply the update from inside the browser, so you still run the command above on the host.
 
 ## Podman
 
@@ -231,14 +231,14 @@ docker build -f Dockerfile.lite -t marinara-engine:lite .
 
 **The page will not load, or the port is already in use.** Another program may already use port `7860`. Change the port mapping to a free port, such as `8080:7860` in the `ports:` list. Then restart with `docker compose up -d` and open `http://127.0.0.1:8080`.
 
-**Marinara cannot write files, or you see permission errors.** The container repairs the ownership of the data folder each time it starts. This works for named volumes and for folders you mount from your host. The repair can fail on some host file systems, and it is skipped if you set `MARINARA_SKIP_DATA_CHOWN=true`. If the errors continue, use the default `marinara-data` named volume. It is the most reliable choice.
+**Guksu cannot write files, or you see permission errors.** The container repairs the ownership of the data folder each time it starts. This works for named volumes and for folders you mount from your host. The repair can fail on some host file systems, and it is skipped if you set `MARINARA_SKIP_DATA_CHOWN=true`. If the errors continue, use the default `marinara-data` named volume. It is the most reliable choice.
 
 **The lite image crashes on a Raspberry Pi 4.** See the lite image note above. Use the regular `latest` image on that hardware.
 
-For more help, read [Troubleshooting Marinara Engine](../TROUBLESHOOTING.md).
+For more help, read [Troubleshooting Guksu Motor](../TROUBLESHOOTING.md).
 
 ## Related guides
 
 - [Server Configuration Reference](../CONFIGURATION.md)
 - [Remote Access: Basic Auth and IP Allowlist](../REMOTE_ACCESS.md)
-- [Troubleshooting Marinara Engine](../TROUBLESHOOTING.md)
+- [Troubleshooting Guksu Motor](../TROUBLESHOOTING.md)

--- a/docs/installation/ios-pwa.md
+++ b/docs/installation/ios-pwa.md
@@ -1,10 +1,10 @@
 # iOS / iPadOS PWA Guide
 
-This guide shows how to use Marinara Engine on an iPhone or iPad. iOS and iPadOS cannot run the Marinara server themselves. Instead, you connect to a server on another device and save it to your Home Screen as a web app.
+This guide shows how to use Guksu Motor on an iPhone or iPad. iOS and iPadOS cannot run the Guksu server themselves. Instead, you connect to a server on another device and save it to your Home Screen as a web app.
 
 ## iOS runs the server on another device
 
-Marinara Engine has two parts: a server that does the real work, and a web app that you view in a browser. On iPhone and iPad, Apple does not let the server run on the device. So you run the server somewhere else, then open it from Safari on your iPhone or iPad.
+Guksu Motor has two parts: a server that does the real work, and a web app that you view in a browser. On iPhone and iPad, Apple does not let the server run on the device. So you run the server somewhere else, then open it from Safari on your iPhone or iPad.
 
 The server can run on any of these:
 
@@ -13,7 +13,7 @@ The server can run on any of these:
 - An Android phone with Termux (see [Android (Termux) Installation Guide](android-termux.md)).
 - A Docker or Podman container (see [Run via Container](containers.md)).
 
-Your iPhone or iPad reaches that server over the network. This is the same idea as opening any website, except the website is your own Marinara server.
+Your iPhone or iPad reaches that server over the network. This is the same idea as opening any website, except the website is your own Guksu server.
 
 ## Connect from Safari
 
@@ -28,29 +28,29 @@ http://<host-ip>:7860
 
 3. Open **Safari** on your iPhone or iPad.
 4. Type that address into the Safari address bar and go to it.
-5. You should see the Marinara home screen load in the browser.
+5. You should see the Guksu home screen load in the browser.
 
 If the page does not load, or you get a password prompt, see the Troubleshooting section below. The server owner controls network access and passwords. Those server settings live in the [Remote Access guide](../REMOTE_ACCESS.md), not on your iPhone or iPad.
 
 ## Add to Home Screen
 
-You can save Marinara as a PWA so it opens like a normal app. PWA means Progressive Web App, a website that runs in its own window with its own Home Screen icon.
+You can save Guksu as a PWA so it opens like a normal app. PWA means Progressive Web App, a website that runs in its own window with its own Home Screen icon.
 
-1. Open your Marinara server in **Safari** (see the steps above).
+1. Open your Guksu server in **Safari** (see the steps above).
 2. Tap the Share button. It is the square icon with an arrow pointing up.
 3. Scroll down the share sheet and tap **Add to Home Screen**.
 4. Change the name if you want, then tap **Add**.
-5. You should now see a Marinara icon on your Home Screen.
+5. You should now see a Guksu icon on your Home Screen.
 
-Tap that icon to open Marinara in its own window, without the Safari address bar.
+Tap that icon to open Guksu in its own window, without the Safari address bar.
 
 ## HTTPS note
 
 PWAs behave most reliably over HTTPS. HTTPS means a secure, encrypted web connection, shown by `https://` at the start of the address.
 
-Plain HTTP over your LAN still works in Safari for normal use. But some iOS or iPadOS versions limit standalone PWA behavior for a plain `http://` address. If that happens, serve Marinara over HTTPS.
+Plain HTTP over your LAN still works in Safari for normal use. But some iOS or iPadOS versions limit standalone PWA behavior for a plain `http://` address. If that happens, serve Guksu over HTTPS.
 
-Tailscale gives each device a stable private address and improves reachability, but Tailscale alone does not change an `http://` address into HTTPS. Use a Tailscale setup that explicitly serves HTTPS, or ask the server owner to put Marinara behind HTTPS.
+Tailscale gives each device a stable private address and improves reachability, but Tailscale alone does not change an `http://` address into HTTPS. Use a Tailscale setup that explicitly serves HTTPS, or ask the server owner to put Guksu behind HTTPS.
 
 These options are explained in the [Remote Access guide](../REMOTE_ACCESS.md). If a plain HTTP address gives you trouble as a Home Screen app, keep it as a Safari bookmark instead.
 
@@ -58,27 +58,27 @@ These options are explained in the [Remote Access guide](../REMOTE_ACCESS.md). I
 
 Sometimes Safari keeps showing an older version of the app, or the saved web app gets stuck. Reinstalling the Home Screen app usually fixes this.
 
-1. Press and hold the Marinara icon on your Home Screen.
+1. Press and hold the Guksu icon on your Home Screen.
 2. Tap the option to remove or delete the app, then confirm.
 3. Open the **Settings** app on your iPhone or iPad.
 4. Tap **Safari**. On newer iOS and iPadOS versions, it may be under **Apps**, then **Safari**.
 5. Tap **Advanced**, then tap **Website Data**.
-6. Find the entry for your Marinara host address. If you do not see it, tap **Show All Sites**.
+6. Find the entry for your Guksu host address. If you do not see it, tap **Show All Sites**.
 7. Swipe left on that entry, then tap **Delete**. This removes the old saved files for that server.
-8. Open Marinara again in **Safari** using the steps in Connect from Safari.
+8. Open Guksu again in **Safari** using the steps in Connect from Safari.
 9. Add it to your Home Screen again using the steps in Add to Home Screen.
 
 Your chats, characters, and settings are stored on the server, not on your iPhone or iPad. Reinstalling the Home Screen app does not delete them.
 
 ## Troubleshooting
 
-**The page will not load in Safari.** Check that the server is still running on the host device. Check that both devices are on the same network or Tailscale. Confirm the IP address and the port `7860` are correct. For deeper network help, see the [Remote Access guide](../REMOTE_ACCESS.md) and [Troubleshooting Marinara Engine](../TROUBLESHOOTING.md).
+**The page will not load in Safari.** Check that the server is still running on the host device. Check that both devices are on the same network or Tailscale. Confirm the IP address and the port `7860` are correct. For deeper network help, see the [Remote Access guide](../REMOTE_ACCESS.md) and [Troubleshooting Guksu Motor](../TROUBLESHOOTING.md).
 
 **Safari asks for a username and password.** The server owner turned on password protection for remote devices. Get the username and password from whoever runs the server. The setup is covered in the [Remote Access guide](../REMOTE_ACCESS.md).
 
 **Safari keeps showing an old build.** Reload the page first. If it still looks old, follow the Clearing and reinstalling the PWA steps above.
 
-**A red banner says saves will silently fail.** This is a network trust warning from the server, not an iPhone or iPad problem. The server owner needs to trust your address. See the [Remote Access guide](../REMOTE_ACCESS.md) and [Troubleshooting Marinara Engine](../TROUBLESHOOTING.md).
+**A red banner says saves will silently fail.** This is a network trust warning from the server, not an iPhone or iPad problem. The server owner needs to trust your address. See the [Remote Access guide](../REMOTE_ACCESS.md) and [Troubleshooting Guksu Motor](../TROUBLESHOOTING.md).
 
 **Privileged actions are blocked.** Some maintenance actions need an admin secret from the server owner. On your iPhone or iPad, you save that value in **Settings**, then **Advanced**, then **Admin Access**. The [Remote Access guide](../REMOTE_ACCESS.md) explains what the admin secret is and how to get one.
 
@@ -86,5 +86,5 @@ Your chats, characters, and settings are stored on the server, not on your iPhon
 
 - [Remote Access: Basic Auth and IP Allowlist](../REMOTE_ACCESS.md)
 - [Frequently Asked Questions](../FAQ.md)
-- [Troubleshooting Marinara Engine](../TROUBLESHOOTING.md)
+- [Troubleshooting Guksu Motor](../TROUBLESHOOTING.md)
 - [Android (Termux) Installation Guide](android-termux.md)

--- a/docs/installation/macos-linux.md
+++ b/docs/installation/macos-linux.md
@@ -1,15 +1,15 @@
 # macOS / Linux Installation Guide
 
-This guide shows you how to install and run Marinara Engine on macOS or Linux. You will install two required tools, start the app with the shell launcher, and learn how to update it later. Marinara Engine (called Marinara after this) runs entirely on your own computer.
+This guide shows you how to install and run Guksu Motor on macOS or Linux. You will install two required tools, start the app with the shell launcher, and learn how to update it later. Guksu Motor (called Guksu after this) runs entirely on your own computer.
 
 ## Prerequisites
 
 You need two free tools installed before you start:
 
-- **Node.js**: the program that runs Marinara. Install version 24, 25, or 26 (version 24 is the recommended LTS release).
-- **Git**: the tool that downloads Marinara and fetches updates.
+- **Node.js**: the program that runs Guksu. Install version 24, 25, or 26 (version 24 is the recommended LTS release).
+- **Git**: the tool that downloads Guksu and fetches updates.
 
-You do not need to install pnpm yourself. pnpm is the package manager Marinara uses to fetch its parts. The shell launcher installs the correct pnpm version for you.
+You do not need to install pnpm yourself. pnpm is the package manager Guksu uses to fetch its parts. The shell launcher installs the correct pnpm version for you.
 
 ### Install on macOS
 
@@ -69,9 +69,9 @@ You should see a version like `git version 2.40` or higher. If either command re
 
 ## Quick start with the launcher
 
-The launcher script `start.sh` is the recommended way to run Marinara. It installs everything, builds the app, and opens it in your browser.
+The launcher script `start.sh` is the recommended way to run Guksu. It installs everything, builds the app, and opens it in your browser.
 
-1. Download Marinara. Run this command:
+1. Download Guksu. Run this command:
 
 ```bash
 git clone https://github.com/Pasta-Devs/Marinara-Engine.git
@@ -89,13 +89,13 @@ cd Marinara-Engine
 chmod +x start.sh
 ```
 
-4. Start Marinara. Run this command:
+4. Start Guksu. Run this command:
 
 ```bash
 ./start.sh
 ```
 
-The first run takes a few minutes because it downloads and builds everything. When it finishes, Marinara opens in your browser at http://127.0.0.1:7860. The number 7860 is the default port, which is the doorway the app uses on your computer.
+The first run takes a few minutes because it downloads and builds everything. When it finishes, Guksu opens in your browser at http://127.0.0.1:7860. The number 7860 is the default port, which is the doorway the app uses on your computer.
 
 If your browser does not open on its own, open it yourself and go to that same address.
 
@@ -112,7 +112,7 @@ Every time you run `./start.sh` from a Git download, the launcher will:
 
 ### Turning off the automatic browser open
 
-By default the launcher opens your browser for you. To stop this, create a file named `.env` in the Marinara folder and add this line:
+By default the launcher opens your browser for you. To stop this, create a file named `.env` in the Guksu folder and add this line:
 
 ```bash
 AUTO_OPEN_BROWSER=false
@@ -125,7 +125,7 @@ PORT=7860
 AUTO_OPEN_BROWSER=true
 ```
 
-`PORT` sets the address port (7860 by default). By default the launcher also lets other devices on your LAN reach the server. LAN means local area network, the network in your home or office. Marinara still blocks those devices until you set up a password or another access option. The [Remote Access: Basic Auth and IP Allowlist](../REMOTE_ACCESS.md) guide shows you how.
+`PORT` sets the address port (7860 by default). By default the launcher also lets other devices on your LAN reach the server. LAN means local area network, the network in your home or office. Guksu still blocks those devices until you set up a password or another access option. The [Remote Access: Basic Auth and IP Allowlist](../REMOTE_ACCESS.md) guide shows you how.
 
 ## Manual setup
 
@@ -144,7 +144,7 @@ npm install --global corepack
 corepack enable pnpm
 ```
 
-2. Download Marinara. Run this command:
+2. Download Guksu. Run this command:
 
 ```bash
 git clone https://github.com/Pasta-Devs/Marinara-Engine.git
@@ -192,11 +192,11 @@ Then run this command:
 
 ## Optional background remover
 
-Marinara can remove the background from character sprite images. A sprite is a character picture used in Roleplay and Game modes. Native transparency and built-in adaptive matte cleanup work without this download. Install the extra AI remover only if you also need a fallback for sprites made against detailed scenery, shadows, or other non-flat backgrounds; it downloads large files.
+Guksu can remove the background from character sprite images. A sprite is a character picture used in Roleplay and Game modes. Native transparency and built-in adaptive matte cleanup work without this download. Install the extra AI remover only if you also need a fallback for sprites made against detailed scenery, shadows, or other non-flat backgrounds; it downloads large files.
 
 The extra tool is a Python program. Installing it creates a Python venv (a virtual environment, a private folder that holds Python packages). It also downloads PyTorch, a machine learning library. Finally it downloads the U2Net models, the files that find the subject in an image.
 
-To install it once, run this command from the Marinara folder:
+To install it once, run this command from the Guksu folder:
 
 ```bash
 pnpm backgroundremover:install
@@ -222,7 +222,7 @@ BACKGROUNDREMOVER_AUTO_INSTALL=true
 
 ## Updating
 
-When you start Marinara with `./start.sh` from a Git download, the launcher checks for a newer version. It updates itself automatically before it starts. Your chats, characters, and settings are kept.
+When you start Guksu with `./start.sh` from a Git download, the launcher checks for a newer version. It updates itself automatically before it starts. Your chats, characters, and settings are kept.
 
 Run `./start.sh --skip-update` to skip one check. To keep the installed Engine version across launches, add `AUTO_UPDATE_ENABLED=false` to `.env`. You can still check or update manually from **Settings → Advanced → Updates** or with Git commands.
 
@@ -232,17 +232,17 @@ For the full update steps, including how to back up first and how to switch rele
 
 ## Key terms
 
-- **pnpm**: the package manager Marinara uses to download and organize its parts.
+- **pnpm**: the package manager Guksu uses to download and organize its parts.
 - **Corepack**: a helper included with Node.js that turns on pnpm.
 - **LAN**: local area network, the private network in your home or office.
-- **.env**: a plain text settings file in the Marinara folder, one setting per line.
+- **.env**: a plain text settings file in the Guksu folder, one setting per line.
 - **venv**: a Python virtual environment, a private folder that holds Python packages.
 - **PyTorch**: a machine learning library used by the optional background remover.
 - **U2Net**: the model files the background remover uses to find the subject in an image.
 
 ## Related guides
 
-- [Marinara Engine Installation](../INSTALLATION.md): pick the right install method for your device.
-- [Upgrading Marinara Engine](../UPGRADING.md): full update and backup steps for every platform.
-- [Remote Access: Basic Auth and IP Allowlist](../REMOTE_ACCESS.md): set up a password so other devices can reach Marinara.
-- [Troubleshooting Marinara Engine](../TROUBLESHOOTING.md): fixes for install and startup problems.
+- [Guksu Motor Installation](../INSTALLATION.md): pick the right install method for your device.
+- [Upgrading Guksu Motor](../UPGRADING.md): full update and backup steps for every platform.
+- [Remote Access: Basic Auth and IP Allowlist](../REMOTE_ACCESS.md): set up a password so other devices can reach Guksu.
+- [Troubleshooting Guksu Motor](../TROUBLESHOOTING.md): fixes for install and startup problems.

--- a/docs/installation/windows.md
+++ b/docs/installation/windows.md
@@ -1,10 +1,10 @@
 # Windows Installation Guide
 
-This guide shows you how to install Marinara Engine on Windows. You can use the one click installer (the easy path) or set it up from source. It also covers system requirements, optional features, and how to update later.
+This guide shows you how to install Guksu Motor on Windows. You can use the one click installer (the easy path) or set it up from source. It also covers system requirements, optional features, and how to update later.
 
 ## System requirements
 
-Marinara Engine runs on your own Windows PC. You need the following:
+Guksu Motor runs on your own Windows PC. You need the following:
 
 - Windows 10 or Windows 11 (64 bit).
 - A few gigabytes of free disk space for the app and its dependencies.
@@ -23,7 +23,7 @@ The installer is the easiest way to start. It checks for Node.js and Git, helps 
 
 Follow these steps:
 
-1. Open the Marinara Engine releases page in your browser.
+1. Open the Guksu Motor releases page in your browser.
 
 ```text
 https://github.com/Pasta-Devs/Marinara-Engine/releases
@@ -33,7 +33,7 @@ https://github.com/Pasta-Devs/Marinara-Engine/releases
 3. Run the installer and follow the on screen prompts. If Node.js or Git are missing, let the installer install them.
 4. Choose the install folder when asked, or accept the default.
 5. Wait for the installer to download the app and build it. This can take a few minutes.
-6. When it finishes, double click the new desktop shortcut to launch Marinara Engine.
+6. When it finishes, double click the new desktop shortcut to launch Guksu Motor.
 
 Your browser should open to the app after a short delay. If it does not open on its own, open your browser and go to this address:
 
@@ -153,7 +153,7 @@ HOST=0.0.0.0
 
 ## Optional: AI sprite background removal
 
-Marinara Engine requests native transparency for generated still sprites and has built-in adaptive matte cleanup for flat chroma and older white backgrounds. You can also install an optional tool called `backgroundremover` as a fallback for detailed scenery and other non-flat backgrounds. It is optional because it downloads large machine learning files.
+Guksu Motor requests native transparency for generated still sprites and has built-in adaptive matte cleanup for flat chroma and older white backgrounds. You can also install an optional tool called `backgroundremover` as a fallback for detailed scenery and other non-flat backgrounds. It is optional because it downloads large machine learning files.
 
 To use it you first need Python. Install Python 3.11 from the official site, then run the install command from the `Marinara-Engine` folder:
 
@@ -167,7 +167,7 @@ Run the installer step:
 pnpm backgroundremover:install
 ```
 
-This creates a private Python folder (a venv) under your data folder. Marinara Engine then uses it automatically for sprite cleanup. A venv is a self contained Python setup that does not affect the rest of your system.
+This creates a private Python folder (a venv) under your data folder. Guksu Motor then uses it automatically for sprite cleanup. A venv is a self contained Python setup that does not affect the rest of your system.
 
 You can also let **start.bat** install the tool for you on the next launch. Add this line to your `.env` file:
 
@@ -177,11 +177,11 @@ BACKGROUNDREMOVER_AUTO_INSTALL=true
 
 ## Accessing from another device
 
-You can open Marinara Engine from your phone, tablet, or another computer on the same network. For the setup steps and the security options, see the [Frequently Asked Questions](../FAQ.md) guide.
+You can open Guksu Motor from your phone, tablet, or another computer on the same network. For the setup steps and the security options, see the [Frequently Asked Questions](../FAQ.md) guide.
 
-## Updating Marinara Engine
+## Updating Guksu Motor
 
-Your chats, characters, and settings stay in place when you update. Marinara Engine offers three ways to update on Windows.
+Your chats, characters, and settings stay in place when you update. Guksu Motor offers three ways to update on Windows.
 
 ### Automatic updates with the launcher
 
@@ -266,11 +266,11 @@ git checkout -B staging origin/staging
 
 If the install or launch fails, first make sure Node.js is version 24, 25, or 26 and that Git is installed. If your antivirus blocks the installer or the download, that is a known false alarm as noted above.
 
-For more fixes, see the [Troubleshooting Marinara Engine](../TROUBLESHOOTING.md) guide.
+For more fixes, see the [Troubleshooting Guksu Motor](../TROUBLESHOOTING.md) guide.
 
 ## Related guides
 
-- [Marinara Engine Installation](../INSTALLATION.md): pick the right install method for your device.
-- [Upgrading Marinara Engine](../UPGRADING.md): more detail on keeping the app up to date.
-- [Troubleshooting Marinara Engine](../TROUBLESHOOTING.md): fixes for common problems.
+- [Guksu Motor Installation](../INSTALLATION.md): pick the right install method for your device.
+- [Upgrading Guksu Motor](../UPGRADING.md): more detail on keeping the app up to date.
+- [Troubleshooting Guksu Motor](../TROUBLESHOOTING.md): fixes for common problems.
 - [Frequently Asked Questions](../FAQ.md): quick answers, including network access.

--- a/docs/integrations/discord-mirror.md
+++ b/docs/integrations/discord-mirror.md
@@ -1,10 +1,10 @@
 # Discord Message Mirror
 
-This guide explains the Discord Message Mirror in Marinara Engine. The mirror copies your chat messages into a Discord channel, one way, as you chat. It works in Conversation, Roleplay, and Game modes.
+This guide explains the Discord Message Mirror in Guksu Motor. The mirror copies your chat messages into a Discord channel, one way, as you chat. It works in Conversation, Roleplay, and Game modes.
 
 ## What the mirror does
 
-The Discord Message Mirror is a one-way relay. Marinara sends messages out to a Discord channel. Discord cannot send messages back into Marinara. This is not a two-way Discord bot.
+The Discord Message Mirror is a one-way relay. Guksu sends messages out to a Discord channel. Discord cannot send messages back into Guksu. This is not a two-way Discord bot.
 
 The mirror uses a Discord webhook. A webhook is a special URL that lets one app post messages into a Discord channel.
 
@@ -12,7 +12,7 @@ The mirror is set per chat. Each chat has its own webhook URL. You turn the mirr
 
 ## Create a Discord webhook URL
 
-You create the webhook inside Discord, not inside Marinara. You need permission to manage the Discord channel you want to use.
+You create the webhook inside Discord, not inside Guksu. You need permission to manage the Discord channel you want to use.
 
 1. Open your Discord server and pick the channel where messages should appear.
 2. Open that channel's settings, then open **Integrations**, then **Webhooks**.
@@ -37,11 +37,11 @@ The webhook setting lives in each chat's settings. It sits inside the **Connecte
 
 The mirror is now on for that chat. To turn it off, clear the input box so it is empty.
 
-If the URL is not a valid Discord webhook, you see the red text "Invalid webhook URL format" below the box. Fix the URL, and the mirror will save. Marinara also checks the URL again on the server when you save.
+If the URL is not a valid Discord webhook, you see the red text "Invalid webhook URL format" below the box. Fix the URL, and the mirror will save. Guksu also checks the URL again on the server when you save.
 
 ## What gets sent
 
-Marinara mirrors your messages and the AI replies as they are generated.
+Guksu mirrors your messages and the AI replies as they are generated.
 
 - Sender name: your messages use your active persona name. AI messages use the character name.
 - In Game Mode, story narration is sent under the name "Narrator". Turns by party members or NPCs (non-player characters) are sent under the name "Party". If your game uses the **Character GM** option, the game master's replies use that character's name instead.
@@ -53,11 +53,11 @@ Marinara mirrors your messages and the AI replies as they are generated.
 
 - Regenerated replies and swipes are not mirrored again. Only the first reply for each turn is sent to Discord.
 - Impersonated messages are not mirrored. Impersonate is the feature where the AI writes a message in your place.
-- If a send to Discord fails, Marinara does not show an error and does not retry. The failure is recorded on the server only.
+- If a send to Discord fails, Guksu does not show an error and does not retry. The failure is recorded on the server only.
 
 ## Rate limiting
 
-Discord limits how fast an app can post. Marinara sends at most one message about every 1.2 seconds per webhook. That is around 50 messages per minute. Extra messages wait in a queue and go out in order. If Discord asks Marinara to slow down, Marinara waits, then continues sending.
+Discord limits how fast an app can post. Guksu sends at most one message about every 1.2 seconds per webhook. That is around 50 messages per minute. Extra messages wait in a queue and go out in order. If Discord asks Guksu to slow down, Guksu waits, then continues sending.
 
 ## Related guides
 

--- a/docs/integrations/haptic-feedback.md
+++ b/docs/integrations/haptic-feedback.md
@@ -1,12 +1,12 @@
 # Haptic Feedback Setup
 
-This guide shows you how to let an AI character control connected haptic devices in Marinara Engine. It covers installing the helper app, adding the **Haptic Feedback** agent to a chat, connecting to your device, and the touch settings you can adjust.
+This guide shows you how to let an AI character control connected haptic devices in Guksu Motor. It covers installing the helper app, adding the **Haptic Feedback** agent to a chat, connecting to your device, and the touch settings you can adjust.
 
 ## What haptic feedback is
 
-Haptic feedback lets an AI character send touch cues to a connected haptic device (an intimate toy) during a chat. Marinara Engine does not talk to the device directly. Instead, it sends commands to a free companion app called **Intiface Central**, and that app talks to your device.
+Haptic feedback lets an AI character send touch cues to a connected haptic device (an intimate toy) during a chat. Guksu Motor does not talk to the device directly. Instead, it sends commands to a free companion app called **Intiface Central**, and that app talks to your device.
 
-**Intiface Central** speaks a device protocol called **Buttplug.io**. This is the same open standard that many toys and other apps support. You install **Intiface Central** once, pair your device with it, and Marinara connects to it over a local network address.
+**Intiface Central** speaks a device protocol called **Buttplug.io**. This is the same open standard that many toys and other apps support. You install **Intiface Central** once, pair your device with it, and Guksu connects to it over a local network address.
 
 Haptic feedback is built as one of the chat **Agents**, the AI helpers you can add to a chat. It works in Conversation mode and Roleplay mode. It is not available in Game Mode.
 
@@ -23,7 +23,7 @@ https://intiface.com/central/
 2. Open **Intiface Central** and start its server. Look for the server start button inside the app.
 3. Pair or connect your device inside **Intiface Central** so the app can see it.
 
-If **Intiface Central** is not running with its server started, Marinara cannot send any touch cues.
+If **Intiface Central** is not running with its server started, Guksu cannot send any touch cues.
 
 ## Add the Haptic Feedback agent
 
@@ -41,7 +41,7 @@ Once the toggle is on, the AI can send hidden touch cues while it writes. These 
 
 ## Connect, scan, and find your device
 
-When you open the **Haptic Feedback** card, Marinara tries to connect to **Intiface Central** automatically using the saved address. You can also connect by hand.
+When you open the **Haptic Feedback** card, Guksu tries to connect to **Intiface Central** automatically using the saved address. You can also connect by hand.
 
 The card shows a status row with a colored dot. A green dot means connected. A red dot means not connected. Next to it is a button that reads **Connect** when you are offline and **Disconnect** when you are connected.
 
@@ -59,9 +59,9 @@ The **Intiface URL** field holds the network address of your **Intiface Central*
 ws://127.0.0.1:12345
 ```
 
-The address `127.0.0.1` means "this same computer". If you leave the field blank, Marinara uses the server default. Marinara also remembers your address in the browser, so it is reused across chats and devices.
+The address `127.0.0.1` means "this same computer". If you leave the field blank, Guksu uses the server default. Guksu also remembers your address in the browser, so it is reused across chats and devices.
 
-If you run Marinara in Docker, or you open Marinara in a browser on a different device, `127.0.0.1` will not reach your **Intiface Central**. In that case, enter the address of the computer running **Intiface Central**. It looks like the example below, where you replace the numbers with that computer's real address.
+If you run Guksu in Docker, or you open Guksu in a browser on a different device, `127.0.0.1` will not reach your **Intiface Central**. In that case, enter the address of the computer running **Intiface Central**. It looks like the example below, where you replace the numbers with that computer's real address.
 
 ```
 ws://192.168.1.50:12345
@@ -79,7 +79,7 @@ The three choices set how strong and how long each cue can be.
 | **Standard** | Balanced feedback for most scenes | The default |
 | **Intense** | Stronger feedback with a higher cap | Strongest option |
 
-**Standard** is selected by default. Pick the one that feels right for your scene. In Roleplay chats, Marinara limits every cue to the range set by your choice. The AI cannot go past it.
+**Standard** is selected by default. Pick the one that feels right for your scene. In Roleplay chats, Guksu limits every cue to the range set by your choice. The AI cannot go past it.
 
 ## Incidental contact
 
@@ -89,9 +89,9 @@ When it is off, the AI ignores small accidental touches in the story. It only se
 
 ## Using it from another device
 
-By default, Marinara only accepts haptic commands from the same computer that runs the Marinara server. This keeps device control local and private.
+By default, Guksu only accepts haptic commands from the same computer that runs the Guksu server. This keeps device control local and private.
 
-Because of this, haptic feedback will not work if you open Marinara from a phone or another device. This applies when that device reaches a Marinara server running elsewhere. The connect, scan, and command actions are refused unless you change the server settings.
+Because of this, haptic feedback will not work if you open Guksu from a phone or another device. This applies when that device reaches a Guksu server running elsewhere. The connect, scan, and command actions are refused unless you change the server settings.
 
 To allow haptic control from another device, turn on a server setting called `HAPTICS_ALLOW_REMOTE`. You must also set up access protection, such as Basic Auth or an admin secret. See the [Server Configuration Reference](../CONFIGURATION.md) for the setting. See the [Remote Access guide](../REMOTE_ACCESS.md) for the access protection. You enter admin access under **Settings** in the **Advanced** area, in the **Admin Access** section.
 
@@ -104,7 +104,7 @@ If the AI never triggers your device, check these in order.
 3. Make sure the status dot is green and the **Haptic Feedback** toggle is on.
 4. If you are on a phone or a remote device, review the remote access notes above.
 
-When **Intiface Central** is not connected, or no device is attached, Marinara skips the AI touch cue quietly. You will not see an error in the chat.
+When **Intiface Central** is not connected, or no device is attached, Guksu skips the AI touch cue quietly. You will not see an error in the chat.
 
 ## Related guides
 

--- a/docs/integrations/home-assistant.md
+++ b/docs/integrations/home-assistant.md
@@ -1,16 +1,16 @@
 # Home Assistant Integration
 
-This guide shows you how to connect Marinara Engine to Home Assistant. Once connected, your AI characters can control real smart home devices right from a chat. They can work lights, climate, covers, and media players. The connection also lets Home Assistant automations send messages into Marinara.
+This guide shows you how to connect Guksu Motor to Home Assistant. Once connected, your AI characters can control real smart home devices right from a chat. They can work lights, climate, covers, and media players. The connection also lets Home Assistant automations send messages into Guksu.
 
 Home Assistant is a free, open source platform for controlling smart home devices. If you do not run Home Assistant, you do not need this integration.
 
 ## What this integration does
 
-The integration is a small piece of software that installs inside Home Assistant. It links a running Home Assistant to a running Marinara Engine server. Once installed, it does three things for you automatically:
+The integration is a small piece of software that installs inside Home Assistant. It links a running Home Assistant to a running Guksu Motor server. Once installed, it does three things for you automatically:
 
-- It creates smart home tools inside Marinara. These appear in the **Functions** section of the Presets panel. Marinara calls these "custom tools" or "Functions". See [Custom Tools](../extending/custom-tools.md) for how Functions work in general.
-- It creates one AI agent inside Marinara named **Home Assistant**. An agent is an AI helper that runs alongside your chat. See [Agents Overview](../agents/agents-overview.md).
-- It creates several Home Assistant entities so you can watch and control Marinara from the Home Assistant side. An entity is a device, sensor, or control in Home Assistant.
+- It creates smart home tools inside Guksu. These appear in the **Functions** section of the Presets panel. Guksu calls these "custom tools" or "Functions". See [Custom Tools](../extending/custom-tools.md) for how Functions work in general.
+- It creates one AI agent inside Guksu named **Home Assistant**. An agent is an AI helper that runs alongside your chat. See [Agents Overview](../agents/agents-overview.md).
+- It creates several Home Assistant entities so you can watch and control Guksu from the Home Assistant side. An entity is a device, sensor, or control in Home Assistant.
 
 You never copy tool addresses or set up tools by hand. The integration wires everything together on first setup.
 
@@ -20,12 +20,12 @@ Before you start, make sure you have all of the following.
 
 - A running Home Assistant, version 2024.1.0 or newer.
 - HACS installed in Home Assistant. HACS is the Home Assistant Community Store, a tool for installing custom integrations that are not built in.
-- Marinara Engine installed and running, and reachable from your Home Assistant machine. The default address is `localhost:7860`. If Home Assistant runs on a different device, read the note below about passwords.
-- The setting `WEBHOOK_LOCAL_URLS_ENABLED=true` added to Marinara's `.env` file.
+- Guksu Motor installed and running, and reachable from your Home Assistant machine. The default address is `localhost:7860`. If Home Assistant runs on a different device, read the note below about passwords.
+- The setting `WEBHOOK_LOCAL_URLS_ENABLED=true` added to Guksu's `.env` file.
 
-The `.env` file is the plain text settings file for the Marinara server. See [Server Configuration](../CONFIGURATION.md) to learn where it is and how to edit it.
+The `.env` file is the plain text settings file for the Guksu server. See [Server Configuration](../CONFIGURATION.md) to learn where it is and how to edit it.
 
-You need that last setting because the integration uses a webhook. A webhook is a web address that lets one app send data to another automatically. Home Assistant's webhook address is a local, plain `http` address. Marinara blocks calls to local `http` addresses by default for safety. Setting `WEBHOOK_LOCAL_URLS_ENABLED=true` allows them.
+You need that last setting because the integration uses a webhook. A webhook is a web address that lets one app send data to another automatically. Home Assistant's webhook address is a local, plain `http` address. Guksu blocks calls to local `http` addresses by default for safety. Setting `WEBHOOK_LOCAL_URLS_ENABLED=true` allows them.
 
 Add this line to your `.env` file:
 
@@ -33,15 +33,15 @@ Add this line to your `.env` file:
 WEBHOOK_LOCAL_URLS_ENABLED=true
 ```
 
-This setting takes effect within a couple of seconds. You do not need to restart the Marinara server.
+This setting takes effect within a couple of seconds. You do not need to restart the Guksu server.
 
 ### If Home Assistant runs on a different device
 
-The integration connects to Marinara without a username or password. There is no place to enter one in the setup form. Because of this, where Home Assistant runs matters:
+The integration connects to Guksu without a username or password. There is no place to enter one in the setup form. Because of this, where Home Assistant runs matters:
 
-- If Home Assistant and Marinara run on the same machine, the connection works out of the box.
-- If Home Assistant runs on a different device, Marinara blocks the connection by default. You must allow the Home Assistant device to connect without a password. One way is to add that device's IP address to `IP_ALLOWLIST` in Marinara's `.env` file. An IP address is the number address of a device on your network. On a fully trusted home network, you can set `ALLOW_UNAUTHENTICATED_PRIVATE_NETWORK=true` instead.
-- If Marinara is protected with `BASIC_AUTH_USER` and `BASIC_AUTH_PASS`, the integration cannot log in. It then only works from the same machine, or from a device listed in `IP_ALLOWLIST`.
+- If Home Assistant and Guksu run on the same machine, the connection works out of the box.
+- If Home Assistant runs on a different device, Guksu blocks the connection by default. You must allow the Home Assistant device to connect without a password. One way is to add that device's IP address to `IP_ALLOWLIST` in Guksu's `.env` file. An IP address is the number address of a device on your network. On a fully trusted home network, you can set `ALLOW_UNAUTHENTICATED_PRIVATE_NETWORK=true` instead.
+- If Guksu is protected with `BASIC_AUTH_USER` and `BASIC_AUTH_PASS`, the integration cannot log in. It then only works from the same machine, or from a device listed in `IP_ALLOWLIST`.
 
 See [Remote Access](../REMOTE_ACCESS.md) for how these settings work and which one to pick.
 
@@ -60,25 +60,25 @@ https://github.com/Pasta-Devs/Marinara-Engine
 ```
 
 4. Set the category to **Integration**, then click **Add**.
-5. Search for **Marinara Engine**, then install it.
+5. Search for **Guksu Motor**, then install it.
 6. Restart Home Assistant.
 
 ### Set it up
 
 1. Go to **Settings**, then **Devices & Services**, then click **Add Integration**.
-2. Search for **Marinara Engine**.
-3. Enter the **Host** and **Port** where Marinara is running. The defaults are `localhost` and `7860`.
+2. Search for **Guksu Motor**.
+3. Enter the **Host** and **Port** where Guksu is running. The defaults are `localhost` and `7860`.
 4. Click **Submit**.
 
-If Marinara cannot be reached at that address, Home Assistant shows an error and does not finish. See Troubleshooting below.
+If Guksu cannot be reached at that address, Home Assistant shows an error and does not finish. See Troubleshooting below.
 
-## What Marinara Engine creates automatically
+## What Guksu Motor creates automatically
 
 When setup succeeds, the integration builds everything for you.
 
 - It registers a private webhook inside Home Assistant.
-- It creates the smart home tools in Marinara's **Functions** section, each already pointed at that webhook.
-- It creates the **Home Assistant** agent in Marinara, listing every enabled tool.
+- It creates the smart home tools in Guksu's **Functions** section, each already pointed at that webhook.
+- It creates the **Home Assistant** agent in Guksu, listing every enabled tool.
 - It creates the Home Assistant entities described later in this guide.
 
 ## Add the Home Assistant agent to a chat
@@ -103,12 +103,12 @@ The AI should call a smart home tool, such as `ha_turn_on`, and the matching lig
 
 ## Exposed tool categories
 
-The integration groups its smart home tools into eight categories. You choose which categories Marinara may use.
+The integration groups its smart home tools into eight categories. You choose which categories Guksu may use.
 
-To change the categories, open **Settings**, then **Devices & Services**, click **Marinara Engine**, then click **Configure**. You will see two options:
+To change the categories, open **Settings**, then **Devices & Services**, click **Guksu Motor**, then click **Configure**. You will see two options:
 
 - **Primary Chat**: the default chat that the Home Assistant services target. Those services are described later in this guide.
-- **Exposed Tool Categories**: the list of tool categories Marinara is allowed to use.
+- **Exposed Tool Categories**: the list of tool categories Guksu is allowed to use.
 
 This table lists each category, its default state, and the tools it contains.
 
@@ -127,30 +127,30 @@ Both **Locks** and **Generic Service Calls (Advanced)** are off by default. Turn
 
 Most tools accept either one specific device or a room name. If you give a room name, the tool acts on every matching device in that room at once.
 
-Changes to the categories only take effect after you press **Marinara Sync HA Tools** or restart Home Assistant. That button is described in the next section.
+Changes to the categories only take effect after you press **Guksu Sync HA Tools** or restart Home Assistant. That button is described in the next section.
 
 ## Home Assistant entities
 
-The integration creates these entities under a Home Assistant device named **Marinara Engine**.
+The integration creates these entities under a Home Assistant device named **Guksu Motor**.
 
 | Entity | Type | What it does |
 |---|---|---|
-| Marinara Chat Count | Sensor | Shows the total number of Marinara chats |
-| Marinara Active Agent Count | Sensor | Shows how many Marinara agents are enabled |
-| Marinara Active Chat | Select | Picks which chat the Home Assistant services target |
-| Marinara Agent: (name) | Switch | Turns one Marinara agent on or off. There is one switch per agent |
-| Marinara Abort Generation | Button | Cancels any AI response that is being generated |
-| Marinara Sync HA Tools | Button | Re-sends all tools and rebuilds the Home Assistant agent |
+| Guksu Chat Count | Sensor | Shows the total number of Guksu chats |
+| Guksu Active Agent Count | Sensor | Shows how many Guksu agents are enabled |
+| Guksu Active Chat | Select | Picks which chat the Home Assistant services target |
+| Guksu Agent: (name) | Switch | Turns one Guksu agent on or off. There is one switch per agent |
+| Guksu Abort Generation | Button | Cancels any AI response that is being generated |
+| Guksu Sync HA Tools | Button | Re-sends all tools and rebuilds the Home Assistant agent |
 
-The integration checks Marinara for new chats and agents every 30 seconds. A chat or agent you just made in Marinara may take up to 30 seconds to show up here.
+The integration checks Guksu for new chats and agents every 30 seconds. A chat or agent you just made in Guksu may take up to 30 seconds to show up here.
 
-## Control Marinara from Home Assistant automations
+## Control Guksu from Home Assistant automations
 
-The integration adds two Home Assistant services. You use these inside Home Assistant automations, not inside Marinara. Both can target your **Primary Chat** by default.
+The integration adds two Home Assistant services. You use these inside Home Assistant automations, not inside Guksu. Both can target your **Primary Chat** by default.
 
 ### Send Message (marinara_engine.send_message)
 
-This sends a message into a Marinara chat.
+This sends a message into a Guksu chat.
 
 - `message`: the message text. This field is required.
 - `chat_id`: which chat to send to. If you leave it blank, the Primary Chat is used.
@@ -181,43 +181,43 @@ This starts an AI reply in a chat without you sending a visible message.
 
 ## Re-syncing after you change settings
 
-When you change the enabled categories, press **Marinara Sync HA Tools** to apply the change. You can find this button on the **Marinara Engine** device page in Home Assistant.
+When you change the enabled categories, press **Guksu Sync HA Tools** to apply the change. You can find this button on the **Guksu Motor** device page in Home Assistant.
 
-Pressing **Marinara Sync HA Tools** does the following:
+Pressing **Guksu Sync HA Tools** does the following:
 
-- It updates the existing tools in place, so any changes reach Marinara.
-- It rebuilds the **Home Assistant** agent if you deleted it in Marinara.
+- It updates the existing tools in place, so any changes reach Guksu.
+- It rebuilds the **Home Assistant** agent if you deleted it in Guksu.
 - It disables any tool whose category you turned off. It does not delete those tools.
 
-Do not hand-edit the Home Assistant tools inside Marinara. The next sync overwrites your edits and turns the tools back on.
+Do not hand-edit the Home Assistant tools inside Guksu. The next sync overwrites your edits and turns the tools back on.
 
 ## Troubleshooting
 
 ### The setup form says it cannot connect
 
-Make sure Marinara Engine is running. Check that the **Host** and **Port** you entered match where it is listening. The default is `localhost` and `7860`.
+Make sure Guksu Motor is running. Check that the **Host** and **Port** you entered match where it is listening. The default is `localhost` and `7860`.
 
-If Home Assistant runs on a different device than Marinara, Marinara blocks it by default. The integration cannot send a password, so Marinara must accept that device without one. Add the Home Assistant device's IP address to `IP_ALLOWLIST` in Marinara's `.env` file. See [Remote Access](../REMOTE_ACCESS.md) for this and other options. A Marinara protected with `BASIC_AUTH_USER` and `BASIC_AUTH_PASS` also rejects the integration, unless the device is listed in `IP_ALLOWLIST`.
+If Home Assistant runs on a different device than Guksu, Guksu blocks it by default. The integration cannot send a password, so Guksu must accept that device without one. Add the Home Assistant device's IP address to `IP_ALLOWLIST` in Guksu's `.env` file. See [Remote Access](../REMOTE_ACCESS.md) for this and other options. A Guksu protected with `BASIC_AUTH_USER` and `BASIC_AUTH_PASS` also rejects the integration, unless the device is listed in `IP_ALLOWLIST`.
 
-These rules still apply after setup. If Marinara later blocks the Home Assistant device, the sensors and the chat list quietly stop updating.
+These rules still apply after setup. If Guksu later blocks the Home Assistant device, the sensors and the chat list quietly stop updating.
 
 ### The AI tries a device tool but nothing happens
 
-The webhook call is most likely blocked. Add `WEBHOOK_LOCAL_URLS_ENABLED=true` to Marinara's `.env` file and save it. This takes effect within a couple of seconds. Without it, tool calls can fail with a message about `http` not being allowed, or about a private address being refused.
+The webhook call is most likely blocked. Add `WEBHOOK_LOCAL_URLS_ENABLED=true` to Guksu's `.env` file and save it. This takes effect within a couple of seconds. Without it, tool calls can fail with a message about `http` not being allowed, or about a private address being refused.
 
-If Marinara and Home Assistant run on the same machine, the integration uses the internal address for the webhook automatically. If Marinara runs on a different device, make sure Home Assistant's local network address is reachable from that device.
+If Guksu and Home Assistant run on the same machine, the integration uses the internal address for the webhook automatically. If Guksu runs on a different device, make sure Home Assistant's local network address is reachable from that device.
 
 ### The tools do not appear in the Functions list
 
-Press **Marinara Sync HA Tools**, or restart Home Assistant. Then check the **Functions** section of the Presets panel in Marinara.
+Press **Guksu Sync HA Tools**, or restart Home Assistant. Then check the **Functions** section of the Presets panel in Guksu.
 
 ### The Home Assistant agent is not in my chat
 
-First confirm the **Home Assistant** agent exists in Marinara under Agents. If it is missing, press **Marinara Sync HA Tools** to rebuild it. Then open **Chat Settings**, open the **Agents** section, and add the **Home Assistant** agent to that chat.
+First confirm the **Home Assistant** agent exists in Guksu under Agents. If it is missing, press **Guksu Sync HA Tools** to rebuild it. Then open **Chat Settings**, open the **Agents** section, and add the **Home Assistant** agent to that chat.
 
 ### Finding the webhook address by hand
 
-You rarely need this, since each tool already has the address set. To find it, open **Settings**, then **Devices & Services**, then **Marinara Engine** in Home Assistant. The webhook uses this pattern, where 8123 is the default Home Assistant port:
+You rarely need this, since each tool already has the address set. To find it, open **Settings**, then **Devices & Services**, then **Guksu Motor** in Home Assistant. The webhook uses this pattern, where 8123 is the default Home Assistant port:
 
 ```
 http://<homeassistant-ip>:8123/api/webhook/<webhook-id>
@@ -225,7 +225,7 @@ http://<homeassistant-ip>:8123/api/webhook/<webhook-id>
 
 ## Uninstalling
 
-To remove the integration, delete it from **Settings**, then **Devices & Services**, then **Marinara Engine** in Home Assistant. This removes the Home Assistant entities. The tools it created in Marinara's **Functions** section stay in Marinara. So does the **Home Assistant** agent. Delete both by hand in Marinara if you no longer want them.
+To remove the integration, delete it from **Settings**, then **Devices & Services**, then **Guksu Motor** in Home Assistant. This removes the Home Assistant entities. The tools it created in Guksu's **Functions** section stay in Guksu. So does the **Home Assistant** agent. Delete both by hand in Guksu if you no longer want them.
 
 ## Related guides
 

--- a/docs/integrations/message-translation.md
+++ b/docs/integrations/message-translation.md
@@ -1,6 +1,6 @@
 # Message Translation
 
-Marinara Engine can translate chat messages between languages. This guide covers the four translation providers, the automatic translation toggles, the per-message Translate button, and the limits of each provider.
+Guksu Motor can translate chat messages between languages. This guide covers the four translation providers, the automatic translation toggles, the per-message Translate button, and the limits of each provider.
 
 Translation is set up per chat. Each chat keeps its own provider, target language, and keys. A setting you enter in one chat does not carry over to another.
 
@@ -42,7 +42,7 @@ When you pick **DeepL API**, a **DeepL API Key** field appears. Paste your DeepL
 xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx:fx
 ```
 
-A key that ends in `:fx` is a free-tier key. Marinara sends it to DeepL's free service. Any other key is treated as a paid key.
+A key that ends in `:fx` is a free-tier key. Guksu sends it to DeepL's free service. Any other key is treated as a paid key.
 
 ### DeepLX setup
 
@@ -52,7 +52,7 @@ DeepLX is a free, self-hosted translation server that you run yourself. When you
 http://localhost:1188
 ```
 
-If your DeepLX server runs on your own machine or your local network, the address is a local address. Marinara blocks requests to local addresses by default for safety. To allow them, set this line in your `.env` file and save the file:
+If your DeepLX server runs on your own machine or your local network, the address is a local address. Guksu blocks requests to local addresses by default for safety. To allow them, set this line in your `.env` file and save the file:
 
 ```
 DEEPLX_LOCAL_URLS_ENABLED=true
@@ -64,7 +64,7 @@ A DeepLX server at a public internet address does not need this setting. Only lo
 
 ### AI translation setup
 
-When you pick **AI (via connection)**, Marinara uses one of your AI providers to translate. Two extra fields appear.
+When you pick **AI (via connection)**, Guksu uses one of your AI providers to translate. Two extra fields appear.
 
 The **Connection** dropdown lets you choose which AI connection does the translating. This field is required. If you leave it unset, translation fails with the message "Connection ID is required for AI translation". A connection is a saved link to an AI provider. See the connections guide below to set one up.
 
@@ -78,9 +78,9 @@ You are a translator. Translate the given text accurately, preserving formatting
 
 Below the provider settings are three toggles. All three are off by default.
 
-**Auto-Translate Responses** translates every AI response automatically, right after it is generated. In Game mode, Marinara removes game-master-only tags from the narration before translating it.
+**Auto-Translate Responses** translates every AI response automatically, right after it is generated. In Game mode, Guksu removes game-master-only tags from the narration before translating it.
 
-**Translate My Messages** translates your own message into the target language just before it is sent to the AI. The translation replaces your typed text. If the translation fails, Marinara sends your original text instead and shows an error message.
+**Translate My Messages** translates your own message into the target language just before it is sent to the AI. The translation replaces your typed text. If the translation fails, Guksu sends your original text instead and shows an error message.
 
 **Show Draft Translate Button** adds a **Translate draft** button next to the **Send** button. This lets you translate your message and review or edit the result before you send it. This is the manual alternative to **Translate My Messages**, which translates on send with no chance to review.
 

--- a/docs/lorebooks/entries.md
+++ b/docs/lorebooks/entries.md
@@ -2,7 +2,7 @@
 
 This guide explains how to build the entries inside a lorebook. It covers the **Entries** tab, trigger keywords, and the three entry types. It also covers where each entry goes in the prompt and the timing controls that decide when an entry fires. If you are new to lorebooks, read the [Lorebooks Overview](overview.md) first.
 
-An entry is one block of text plus the rules that decide when Marinara Engine adds that text to the AI's prompt. When an entry activates, its content is injected so the AI "remembers" a fact you never typed into the chat.
+An entry is one block of text plus the rules that decide when Guksu Motor adds that text to the AI's prompt. When an entry activates, its content is injected so the AI "remembers" a fact you never typed into the chat.
 
 ## The Entries tab
 
@@ -28,11 +28,11 @@ To create an entry, follow these steps.
 4. Click the row (or its chevron arrow) to expand the full editor drawer.
 5. Fill in the keywords and content, described in the sections below.
 
-Your edits save automatically. While you type, the drawer shows **Autosaving…**, then **Saving…**, then **Saved automatically**. If a save fails, your text stays in place and Marinara retries it on your next edit. You do not need a separate save button for entries.
+Your edits save automatically. While you type, the drawer shows **Autosaving…**, then **Saving…**, then **Saved automatically**. If a save fails, your text stays in place and Guksu retries it on your next edit. You do not need a separate save button for entries.
 
 Each entry appears as a compact one-line row. The row holds the most-used controls. Expand the row to reach the rest.
 
-To duplicate an entry, hover the row and click the **Duplicate** button. To remove one, click the **Delete** button. Marinara asks you to confirm with the prompt "Delete this lorebook entry?".
+To duplicate an entry, hover the row and click the **Duplicate** button. To remove one, click the **Delete** button. Guksu asks you to confirm with the prompt "Delete this lorebook entry?".
 
 ## Entry content and keys
 
@@ -61,7 +61,7 @@ By default, a primary key matches if the word appears anywhere in the recent cha
 | **Case Sensitive** | Entry drawer | Off | Uppercase and lowercase must match exactly. |
 | **Regex** | Compact row | Off | Treats each key as a regular expression pattern instead of plain text. |
 
-A regular expression (regex) is a pattern-matching language for text. Use it only if you know regex. Marinara runs each regex key with a short safety timeout. A pattern that runs too long does not match on that scan, so keep patterns simple.
+A regular expression (regex) is a pattern-matching language for text. Use it only if you know regex. Guksu runs each regex key with a short safety timeout. A pattern that runs too long does not match on that scan, so keep patterns simple.
 
 ## Entry types: Normal, Constant, Selective
 

--- a/docs/lorebooks/import-export.md
+++ b/docs/lorebooks/import-export.md
@@ -1,13 +1,13 @@
 # Importing and Exporting Lorebooks
 
-This guide shows you how to bring lorebooks into Marinara Engine and how to save them out as files. It covers single files, many files at once, and the two export formats. A lorebook is a set of keyword-triggered notes that Marinara adds to the AI's prompt when a matching word appears. Some other roleplay tools call this feature **World Info**.
+This guide shows you how to bring lorebooks into Guksu Motor and how to save them out as files. It covers single files, many files at once, and the two export formats. A lorebook is a set of keyword-triggered notes that Guksu adds to the AI's prompt when a matching word appears. Some other roleplay tools call this feature **World Info**.
 
 ## What you can import
 
-Marinara can read two kinds of lorebook file, and it detects which one you gave it automatically:
+Guksu can read two kinds of lorebook file, and it detects which one you gave it automatically:
 
-- A lorebook exported from Marinara itself. This keeps every field and every folder.
-- A **World Info** file from another tool. This includes SillyTavern World Info files and the V2 character card "character-book" format. Marinara maps the other tool's fields onto its own.
+- A lorebook exported from Guksu itself. This keeps every field and every folder.
+- A **World Info** file from another tool. This includes SillyTavern World Info files and the V2 character card "character-book" format. Guksu maps the other tool's fields onto its own.
 
 Both kinds are plain `.json` files. You do not need an account or an API key to import a lorebook.
 
@@ -22,7 +22,7 @@ Follow these steps to import one lorebook file.
 5. Wait for the result. Each file shows a green check with **Imported lorebook**, or a red mark with an error message.
 6. Click **Close**. Your new lorebook now appears in the **Lorebooks** panel list.
 
-Marinara keeps the imported file's own date as the lorebook's created date, not the moment you imported it.
+Guksu keeps the imported file's own date as the lorebook's created date, not the moment you imported it.
 
 ## Import many lorebooks at once (bulk import)
 
@@ -30,9 +30,9 @@ The **Import Lorebook** window accepts more than one file in a single go.
 
 1. Open the **Lorebooks** panel and click the download-arrow icon. Its tooltip reads **Import**.
 2. Drag several `.json` files onto the drop box at the same time, or click the box and select multiple files.
-3. Marinara imports each file in turn and lists a result row for every one. A summary line shows how many succeeded and how many failed.
+3. Guksu imports each file in turn and lists a result row for every one. A summary line shows how many succeeded and how many failed.
 
-You can mix Marinara files and **World Info** files in the same batch. Marinara checks each file on its own.
+You can mix Guksu files and **World Info** files in the same batch. Guksu checks each file on its own.
 
 ## Export a lorebook
 
@@ -41,11 +41,11 @@ Exporting saves one lorebook to a file on your device. This is how you share a l
 1. In the **Lorebooks** panel, click a lorebook to open its editor.
 2. Click the export icon in the editor header. Its tooltip reads **Export lorebook**.
 3. The **Export Lorebook** window opens with two choices. Pick one:
-   - **Marinara Native** keeps Marinara folders and every entry field. Use this to move a lorebook to another Marinara install with nothing lost. The file name ends in `.marinara.json`.
-   - **Compatible JSON** saves a folderless **World Info** file for other roleplay tools. Some Marinara-only details are dropped. The file name ends in `.json`.
+   - **Guksu Native** keeps Guksu folders and every entry field. Use this to move a lorebook to another Guksu install with nothing lost. The file name ends in `.marinara.json`.
+   - **Compatible JSON** saves a folderless **World Info** file for other roleplay tools. Some Guksu-only details are dropped. The file name ends in `.json`.
 4. Your browser downloads the file.
 
-Choose **Marinara Native** when the file is for Marinara. Choose **Compatible JSON** when the file is for a different tool.
+Choose **Guksu Native** when the file is for Guksu. Choose **Compatible JSON** when the file is for a different tool.
 
 ## Export many lorebooks at once (bulk export)
 
@@ -56,7 +56,7 @@ You can save several lorebooks into one zip file.
 3. Click **Export** in the selection bar at the bottom.
 4. Your browser downloads a single zip named `marinara-lorebooks.zip`.
 
-Bulk export always uses the **Marinara Native** format, so it round-trips back into Marinara with nothing lost.
+Bulk export always uses the **Guksu Native** format, so it round-trips back into Guksu with nothing lost.
 
 ## Importing a whole SillyTavern folder
 

--- a/docs/lorebooks/linking-to-characters.md
+++ b/docs/lorebooks/linking-to-characters.md
@@ -39,7 +39,7 @@ A lorebook that is set to Global is active in every chat. It cannot also be link
 
 ## Scope: which chats can use the linked lorebook
 
-**Scope** controls where a linked lorebook is allowed to turn on. It does not mean every chat in Marinara. It means chats that include this character, or that use this persona. There are three scope modes.
+**Scope** controls where a linked lorebook is allowed to turn on. It does not mean every chat in Guksu. It means chats that include this character, or that use this persona. There are three scope modes.
 
 - **All chats with [name]**: the default. The lorebook turns on in every chat that includes this character or uses this persona.
 - **Disabled for all chats**: the link stays, but the lorebook never turns on. Use this to pause a lorebook without unlinking it.
@@ -72,7 +72,7 @@ When a character card already has an embedded lorebook, extra controls appear be
 - **Edit Embedded Lorebook**: opens that linked lorebook in the full editor. Your edits there sync back into the card's embedded copy automatically.
 - **Remove from card**: deletes the embedded copy from the card. Any separately linked lorebook in your library is left alone.
 
-This is useful for cards you imported from other tools. Many imported cards arrive with an embedded lorebook. Click **Import Embedded Lorebook** to get a fully editable version in Marinara.
+This is useful for cards you imported from other tools. Many imported cards arrive with an embedded lorebook. Click **Import Embedded Lorebook** to get a fully editable version in Guksu.
 
 ## The Chat Settings Lorebooks section
 

--- a/docs/lorebooks/overview.md
+++ b/docs/lorebooks/overview.md
@@ -1,12 +1,12 @@
 # Lorebooks Overview
 
-This guide explains what a lorebook is in Marinara Engine, how the **Lorebooks** panel works, and how a lorebook becomes active in a chat. It also walks you through creating your first lorebook and its first entry. Deeper topics like keywords, timing, and semantic search live in their own guides, linked at the end.
+This guide explains what a lorebook is in Guksu Motor, how the **Lorebooks** panel works, and how a lorebook becomes active in a chat. It also walks you through creating your first lorebook and its first entry. Deeper topics like keywords, timing, and semantic search live in their own guides, linked at the end.
 
 ## What a lorebook is
 
 A lorebook is a small knowledge base that the AI can pull from during a chat. It is also called **World Info**, and the two names mean the same thing. Each lorebook holds a list of entries. An entry has two parts: some trigger keywords and a block of text.
 
-When a keyword shows up in the recent chat, Marinara Engine adds that entry's text into the prompt. The prompt is the hidden instructions and history sent to the AI for each reply. This lets the AI use facts it was never told directly in the conversation.
+When a keyword shows up in the recent chat, Guksu Motor adds that entry's text into the prompt. The prompt is the hidden instructions and history sent to the AI for each reply. This lets the AI use facts it was never told directly in the conversation.
 
 Here is a simple example. You write a lorebook entry with the keyword `Eldoria` and this text:
 
@@ -18,7 +18,7 @@ Now, whenever you or a character mentions Eldoria, the AI receives that fact. It
 
 Lorebooks are useful for world lore, character backstories, place names, factions, rules, and any facts you want the AI to remember. You do not need to repeat these facts in every message. The lorebook supplies them only when they are relevant, which saves space in the prompt.
 
-Keyword matching works with any AI connection and needs no extra setup. Marinara can also match entries by meaning instead of exact words, using optional semantic search. That is a separate, opt-in feature covered in its own guide.
+Keyword matching works with any AI connection and needs no extra setup. Guksu can also match entries by meaning instead of exact words, using optional semantic search. That is a separate, opt-in feature covered in its own guide.
 
 ## The Lorebooks panel
 
@@ -56,7 +56,7 @@ A lorebook only feeds the AI when it is active in the current chat. There are th
 2. **Linked to a character or persona.** A linked lorebook auto-activates in any chat that includes that character or uses that persona. You set links in the **Overview** tab or from the character or persona editor. This is the most common choice for a character's own backstory.
 3. **Pinned to a single chat.** You can add a lorebook to just one chat from that chat's settings. It stays active in that chat only. This is handy for lore that fits one story and not your whole library.
 
-A global lorebook and a linked lorebook cannot be the same lorebook. Turning on **Global** clears any character or persona links when you save. Marinara treats these two options as mutually exclusive.
+A global lorebook and a linked lorebook cannot be the same lorebook. Turning on **Global** clears any character or persona links when you save. Guksu treats these two options as mutually exclusive.
 
 Every active lorebook still respects its **Enabled** switch. If a lorebook is turned off, none of its entries activate, even when it is global or linked. To see which lorebooks are active in the open chat, open the chat's settings and find its **Lorebooks** section. You can also edit the active list there. A separate guide covers that section.
 
@@ -86,7 +86,7 @@ Open a lorebook and click the **Overview** tab to set how the whole lorebook beh
 
 | Setting | What it does | Default |
 |---|---|---|
-| **Scan Depth** | How many recent messages Marinara checks for keyword matches. Set 0 to scan the whole chat. | 2 |
+| **Scan Depth** | How many recent messages Guksu checks for keyword matches. Set 0 to scan the whole chat. | 2 |
 | **Token Budget** | The most tokens this lorebook can add to one prompt. Set 0 for no limit. | 2048 |
 | **Entry Limit** | The most entries this lorebook can add to one prompt. The range is 1 to 1000. | 100 |
 | **Max Depth** | How many extra recursive passes to run. This field appears only when **Recursive** is on. The range is 1 to 10. | 3 |

--- a/docs/lorebooks/semantic-search.md
+++ b/docs/lorebooks/semantic-search.md
@@ -1,6 +1,6 @@
 # Semantic Search for Lorebooks
 
-This guide explains semantic search for lorebooks in Marinara Engine. Semantic search lets a lorebook entry activate by meaning, not just by exact keywords. You will learn how to set up an embedding source, vectorize your entries, and tune the matching.
+This guide explains semantic search for lorebooks in Guksu Motor. Semantic search lets a lorebook entry activate by meaning, not just by exact keywords. You will learn how to set up an embedding source, vectorize your entries, and tune the matching.
 
 ## What semantic search adds
 
@@ -8,7 +8,7 @@ A lorebook is a set of entries. Each entry has trigger keywords and a block of t
 
 Semantic search fixes that. It compares the meaning of the recent chat with the meaning of your entries. An entry can then activate even when no exact keyword matches. For example, an entry keyed to "sword" can still match a message that only says "blade".
 
-This works using embeddings. An embedding is a list of numbers that captures the meaning of a piece of text. Marinara stores one embedding, also called a vector, for each entry. This step is called vectorization. At chat time, Marinara embeds your recent messages and finds the entries whose meaning is closest.
+This works using embeddings. An embedding is a list of numbers that captures the meaning of a piece of text. Guksu stores one embedding, also called a vector, for each entry. This step is called vectorization. At chat time, Guksu embeds your recent messages and finds the entries whose meaning is closest.
 
 Keyword matching still works when semantic search is on. Semantic search adds extra matches. It does not replace your keywords.
 
@@ -28,9 +28,9 @@ Not every provider offers embeddings. If the provider cannot do embeddings, the 
 
 Option 2: the built-in local model.
 
-Marinara can run a small embedding model on your own machine with no API key. In the lorebook picker this option is named **Local Model (sidecar)**. It appears only after you download the local model. See [Local Model Setup](../connections/local-model.md) for how to install it.
+Guksu can run a small embedding model on your own machine with no API key. In the lorebook picker this option is named **Local Model (sidecar)**. It appears only after you download the local model. See [Local Model Setup](../connections/local-model.md) for how to install it.
 
-If you are on a Marinara Lite build, the **Local Model (sidecar)** option is hidden. On Lite, semantic search needs a connection with an embedding model.
+If you are on a Guksu Lite build, the **Local Model (sidecar)** option is hidden. On Lite, semantic search needs a connection with an embedding model.
 
 ## Turn on Vectors for a lorebook
 
@@ -60,7 +60,7 @@ Set **Query Messages** to 0 to search against the full chat history instead of a
 
 **Score Threshold** controls how close the meaning must be. A low value like 0.2 lets more entries in but risks off-topic matches. A high value like 0.5 is stricter and matches only close meanings. Start at the default and adjust if you get too many or too few matches.
 
-Marinara calibrates this score against several unrelated neutral passages from the same embedding model. This removes the unusually high common cosine floor produced by some local and OpenAI-compatible embedding backends, where unrelated texts can otherwise all score around 0.95 or higher. The setting therefore remains useful across embedding models instead of requiring a model-specific cutoff near 1.0.
+Guksu calibrates this score against several unrelated neutral passages from the same embedding model. This removes the unusually high common cosine floor produced by some local and OpenAI-compatible embedding backends, where unrelated texts can otherwise all score around 0.95 or higher. The setting therefore remains useful across embedding models instead of requiring a model-specific cutoff near 1.0.
 
 **Vector Limit** caps semantic matches only. Your normal token budgets still apply on top of it.
 
@@ -93,7 +93,7 @@ Rebuild every vector after you change the embedding model. Use **Re-vectorize N 
 
 Do not run only a partial vectorize after a model change. If a "missing only" run returns a different vector size than the stored vectors, the server refuses it with this message: "Embedding dimensions changed. Use Re-vectorize all entries instead of only missing entries before switching embedding models."
 
-There is one quiet failure mode to know about. At chat time, Marinara embeds your recent messages with a query model. The query model is the active connection's own embedding model. If the connection has none set, Marinara uses the built-in local model. The query model may produce a different vector size than the model that vectorized your entries. Marinara then skips those entries in semantic matching. You do not see an error. To avoid this, vectorize your entries with the same embedding source you use during chat. Re-vectorize after any model change.
+There is one quiet failure mode to know about. At chat time, Guksu embeds your recent messages with a query model. The query model is the active connection's own embedding model. If the connection has none set, Guksu uses the built-in local model. The query model may produce a different vector size than the model that vectorized your entries. Guksu then skips those entries in semantic matching. You do not see an error. To avoid this, vectorize your entries with the same embedding source you use during chat. Re-vectorize after any model change.
 
 ## How it feeds the Knowledge Router agent
 

--- a/docs/lorebooks/token-budgets.md
+++ b/docs/lorebooks/token-budgets.md
@@ -1,12 +1,12 @@
 # Lorebook Token Budgets and Recursion
 
-This guide explains how Marinara Engine limits how much lorebook text reaches the AI. It covers each lorebook's own **Token Budget** and **Entry Limit**, plus the chat-wide **Lorebook Token Budget**. It also explains how Marinara trims entries when a budget is full, and what **Recursive** scanning does.
+This guide explains how Guksu Motor limits how much lorebook text reaches the AI. It covers each lorebook's own **Token Budget** and **Entry Limit**, plus the chat-wide **Lorebook Token Budget**. It also explains how Guksu trims entries when a budget is full, and what **Recursive** scanning does.
 
 A token is a small chunk of text, roughly a few characters. Every model has a limited context window, which is the total amount of text it can read at once. Budgets keep your lorebooks from filling that window and crowding out the actual conversation.
 
 ## Two token budgets
 
-Marinara applies two separate token budgets every time it builds a prompt. Marinara skips an entry if it would push either budget over its cap.
+Guksu applies two separate token budgets every time it builds a prompt. Guksu skips an entry if it would push either budget over its cap.
 
 1. Each lorebook has its own **Token Budget**. This caps how much text that one lorebook can add per reply.
 2. The chat has a single **Lorebook Token Budget**. This caps the total text from all active lorebooks combined in that chat.
@@ -37,13 +37,13 @@ The default is **8192**. Set it to **0** for unlimited. This budget is the total
 
 ## How entries get trimmed
 
-When more entries match than a budget allows, Marinara keeps the most important ones and drops the rest. It sorts entries before trimming so the ones you most likely need survive.
+When more entries match than a budget allows, Guksu keeps the most important ones and drops the rest. It sorts entries before trimming so the ones you most likely need survive.
 
 - **Constant** entries come first. These are entries set to inject every time the lorebook is active.
 - Entries that matched your latest message come next.
 - Remaining entries follow in their normal injection order.
 
-Marinara goes down that list and adds each entry that still fits. If an entry would push a budget over its cap, Marinara skips that entry and moves on. It still checks every entry below the skipped one. This means a smaller entry can get in even after Marinara skips a larger one.
+Guksu goes down that list and adds each entry that still fits. If an entry would push a budget over its cap, Guksu skips that entry and moves on. It still checks every entry below the skipped one. This means a smaller entry can get in even after Guksu skips a larger one.
 
 ## Seeing skipped entries in Active Context
 
@@ -61,7 +61,7 @@ Expand a skipped entry to see more detail. It shows the matched keywords, the es
 
 ## Recursive scanning
 
-Normally Marinara scans only your recent messages for keyword matches. With **Recursive** scanning on, it also scans the text of entries that just activated. This lets an activated entry pull in related entries whose keywords appear in its text.
+Normally Guksu scans only your recent messages for keyword matches. With **Recursive** scanning on, it also scans the text of entries that just activated. This lets an activated entry pull in related entries whose keywords appear in its text.
 
 Turn it on in the lorebook **Overview** tab.
 

--- a/docs/media/animated-expressions.md
+++ b/docs/media/animated-expressions.md
@@ -1,12 +1,12 @@
 # Animated Expressions
 
-This guide explains animated expressions in Marinara Engine: short looping animations used as a character's portrait sprites. A sprite is the standing character art Marinara shows for a character during a chat. Animated expressions make those portraits move instead of sitting still.
+This guide explains animated expressions in Guksu Motor: short looping animations used as a character's portrait sprites. A sprite is the standing character art Guksu shows for a character during a chat. Animated expressions make those portraits move instead of sitting still.
 
 ## What animated expressions are
 
-A normal expression sprite is a still image, such as a happy face or an angry face. An animated expression is a short looping animation that plays in place of that still image. Marinara saves each one as a GIF sprite. A GIF is an image file that loops a short animation on its own.
+A normal expression sprite is a still image, such as a happy face or an angry face. An animated expression is a short looping animation that plays in place of that still image. Guksu saves each one as a GIF sprite. A GIF is an image file that loops a short animation on its own.
 
-Marinara makes an animated expression in two steps. First it asks a **Video Generation** connection to create a short video clip of the expression. Then it converts that clip into a looping GIF sprite on your machine.
+Guksu makes an animated expression in two steps. First it asks a **Video Generation** connection to create a short video clip of the expression. Then it converts that clip into a looping GIF sprite on your machine.
 
 Once saved, an animated expression works like any other sprite. The downloadable **Expression Engine** agent picks it and shows it when the scene calls for that emotion. See [Character Sprites](../characters/sprites.md) for how sprites are shown, and [Downloadable Agents Reference](../agents/built-in-agents.md) for the Expression Engine.
 
@@ -15,7 +15,7 @@ Once saved, an animated expression works like any other sprite. The downloadable
 You need two things set up before you can generate animated expressions.
 
 1. A **Video Generation** connection. This is a saved link to a provider that can make video. See [Scene Video Generation](scene-video.md) to add one.
-2. ffmpeg installed on the machine running Marinara. ffmpeg is a free media tool that converts the video clip into a GIF sprite.
+2. ffmpeg installed on the machine running Guksu. ffmpeg is a free media tool that converts the video clip into a GIF sprite.
 
 If ffmpeg is not found, generation fails right away with this message:
 
@@ -35,15 +35,15 @@ You generate animated expressions from the same modal you use for still sprites.
 4. Check the box labeled **Generate animated portraits**. The window switches to animated mode:
    - The connection picker changes from **Image Generation Connection** to **Video Generation Connection**.
    - The grid controls for still sprite sheets disappear.
-   - Marinara now generates one expression at a time instead of a full sheet.
+   - Guksu now generates one expression at a time instead of a full sheet.
 5. Pick your **Video Generation Connection** from the dropdown.
 6. Fill in the **Appearance Description** so the provider knows how the character looks.
 7. Pick which expressions to generate.
 8. Click **Generate Animated Portrait** for one expression, or **Generate Animated Portraits** for several.
 
-While it runs, you should see the message "Generating animated portrait GIFs...". Each expression becomes a short video first, then Marinara converts it into a GIF sprite.
+While it runs, you should see the message "Generating animated portrait GIFs...". Each expression becomes a short video first, then Guksu converts it into a GIF sprite.
 
-When generation finishes, review the results and click the save button to add them to the character or persona. If one expression fails, Marinara keeps the finished ones. It lists the failed names so you can retry them.
+When generation finishes, review the results and click the save button to add them to the character or persona. If one expression fails, Guksu keeps the finished ones. It lists the failed names so you can retry them.
 
 ## Duration and shape
 
@@ -51,11 +51,11 @@ Every animated expression is a tall portrait clip. The shape is fixed at 9:16 (p
 
 You can change how long each clip runs. Open **Settings** and find the **Video Generation** section. The setting is called **Animated expression length**. It defaults to 3 seconds. You can set it from 1 to 8 seconds.
 
-Marinara saves the final result as a small looping GIF, 512 pixels wide. A shorter clip gives a smaller file and a quicker, tighter loop.
+Guksu saves the final result as a small looping GIF, 512 pixels wide. A shorter clip gives a smaller file and a quicker, tighter loop.
 
 ## Transparency caveat
 
-Still sprites can have their background cleaned away so the character floats over the scene. Animated expressions are different. Marinara does not run background cleanup on them.
+Still sprites can have their background cleaned away so the character floats over the scene. Animated expressions are different. Guksu does not run background cleanup on them.
 
 In animated mode the transparent-background checkbox is labeled **Prefer clean transparent-style background**. This checkbox only adds a hint to the video prompt. Its help text says clearly: "Adds a flat transparent-friendly background instruction to the video prompt. GIF transparency is not guaranteed."
 
@@ -63,9 +63,9 @@ The review step confirms the same thing. It shows this note: "Animated portrait 
 
 ## What to expect
 
-Animated expressions take longer than still sprites. Marinara generates them one expression at a time, not in a batch. Picking many expressions at once can take a while, so start with a few.
+Animated expressions take longer than still sprites. Guksu generates them one expression at a time, not in a batch. Picking many expressions at once can take a while, so start with a few.
 
-If you turned on **Expose media prompts before sending** (in **Settings**, in the **Image Generation** section), Marinara pauses at a prompt review step. You can read and edit each prompt before Marinara sends it to the provider. Leave this setting off to skip the review.
+If you turned on **Expose media prompts before sending** (in **Settings**, in the **Image Generation** section), Guksu pauses at a prompt review step. You can read and edit each prompt before Guksu sends it to the provider. Leave this setting off to skip the review.
 
 ## Troubleshooting
 
@@ -73,7 +73,7 @@ Generation fails with a message about ffmpeg. Install ffmpeg and make sure the s
 
 The dropdown says no video generation connections were found. Add a **Video Generation** connection first. See [Scene Video Generation](scene-video.md).
 
-The **Generate Sprite** button is disabled. On some devices Marinara cannot load its image library, which turns off all sprite generation, including animated expressions. This happens on some Android and Termux installs.
+The **Generate Sprite** button is disabled. On some devices Guksu cannot load its image library, which turns off all sprite generation, including animated expressions. This happens on some Android and Termux installs.
 
 The saved GIF still shows a background. This is expected. Animated expressions skip background cleanup. See "Transparency caveat" above.
 

--- a/docs/media/comfyui.md
+++ b/docs/media/comfyui.md
@@ -1,45 +1,45 @@
 # ComfyUI Workflow Setup
 
-Marinara Engine can send image-generation requests to a local ComfyUI server or a RunPod Serverless endpoint that runs ComfyUI. A local connection can use Marinara's built-in basic workflow, but a custom API-format workflow gives you control over checkpoints, LoRAs, VAEs, ControlNet, reference-image nodes, samplers, and other ComfyUI features.
+Guksu Motor can send image-generation requests to a local ComfyUI server or a RunPod Serverless endpoint that runs ComfyUI. A local connection can use Guksu's built-in basic workflow, but a custom API-format workflow gives you control over checkpoints, LoRAs, VAEs, ControlNet, reference-image nodes, samplers, and other ComfyUI features.
 
-The workflow JSON pasted into Marinara is a snapshot. Marinara does not keep a live link to the workflow open in ComfyUI. Whenever you change the workflow in ComfyUI, test it again, export it again, and replace the JSON saved on the Marinara connection.
+The workflow JSON pasted into Guksu is a snapshot. Guksu does not keep a live link to the workflow open in ComfyUI. Whenever you change the workflow in ComfyUI, test it again, export it again, and replace the JSON saved on the Guksu connection.
 
 ## Before you begin
 
 Install ComfyUI, add the checkpoints and custom nodes your workflow needs, and start its server. The usual local address is `http://127.0.0.1:8188`.
 
-If ComfyUI runs on a different computer on your home network, its server must listen on an address that Marinara can reach. You must also set `IMAGE_LOCAL_URLS_ENABLED=true` in Marinara's `.env`; see the [Server Configuration Reference](../CONFIGURATION.md). Check the other computer's firewall if the connection still fails.
+If ComfyUI runs on a different computer on your home network, its server must listen on an address that Guksu can reach. You must also set `IMAGE_LOCAL_URLS_ENABLED=true` in Guksu's `.env`; see the [Server Configuration Reference](../CONFIGURATION.md). Check the other computer's firewall if the connection still fails.
 
-A local language model and an image model may not fit in GPU memory at the same time, especially on an 8 GB card. Marinara's image queue prevents multiple image jobs from running together, but it cannot make two loaded models fit into the same VRAM. If you run out of memory, use a cloud or separately hosted language model, run ComfyUI on another device, or unload one model before using the other.
+A local language model and an image model may not fit in GPU memory at the same time, especially on an 8 GB card. Guksu's image queue prevents multiple image jobs from running together, but it cannot make two loaded models fit into the same VRAM. If you run out of memory, use a cloud or separately hosted language model, run ComfyUI on another device, or unload one model before using the other.
 
-## Create the Marinara connection
+## Create the Guksu connection
 
 1. Open **Connections** and create a new **Image Generation** connection.
 2. Choose **ComfyUI** for a local server or **RunPod Serverless (ComfyUI)** for a RunPod endpoint.
-3. For local ComfyUI, enter its Base URL. No API key is required. If the **ComfyUI Workflow** field is empty, Marinara uses a built-in basic text-to-image workflow.
+3. For local ComfyUI, enter its Base URL. No API key is required. If the **ComfyUI Workflow** field is empty, Guksu uses a built-in basic text-to-image workflow.
 4. For RunPod, enter your API key and Endpoint ID. A custom workflow is required.
 5. Configure **Local Image Defaults**. These values replace the matching placeholders in your workflow.
 6. Save the connection and use **Test Image** after adding the workflow.
 
 ## Build and export a workflow
 
-1. Create a separate workflow in ComfyUI for Marinara.
+1. Create a separate workflow in ComfyUI for Guksu.
 2. Configure and connect your checkpoint, LoRAs, VAE, prompt encoders, latent-image or image-input nodes, sampler, and output nodes as usual.
 3. Queue the workflow in ComfyUI and confirm that it produces the expected image.
-4. Include an output node. **SaveImage** is the safest choice because Marinara reads completed images or animations from ComfyUI's workflow history.
+4. Include an output node. **SaveImage** is the safest choice because Guksu reads completed images or animations from ComfyUI's workflow history.
 5. Save the editable workflow under a recognizable name, such as `Marinara_Workflow`.
 6. Export the workflow in API format. Depending on the ComfyUI frontend version, this action may be named **Save (API Format)**, **Export (API)**, or **Export to API**. If it is hidden, enable ComfyUI's developer or dev-mode options.
 7. Open the exported `.json` file in a text editor.
 
 An API-format workflow is different from the normal visual-editor workflow. Its top-level keys are node IDs, and each node normally contains `class_type` and `inputs`. Export the API version; do not paste the regular workflow file containing the editor's visual layout.
 
-## Add Marinara placeholders
+## Add Guksu placeholders
 
-Replace the values that Marinara should control with the placeholders below.
+Replace the values that Guksu should control with the placeholders below.
 
-For a **local ComfyUI** connection, keep every placeholder inside JSON quotes. Marinara parses the workflow first, then converts an exact numeric placeholder such as `"%width%"` to a real number. It therefore remains valid for nodes that require numeric input.
+For a **local ComfyUI** connection, keep every placeholder inside JSON quotes. Guksu parses the workflow first, then converts an exact numeric placeholder such as `"%width%"` to a real number. It therefore remains valid for nodes that require numeric input.
 
-For a **RunPod Serverless (ComfyUI)** connection, keep text placeholders such as `"%prompt%"`, `"%model%"`, and `"%sampler%"` quoted, but leave numeric placeholders such as `%width%`, `%height%`, `%seed%`, `%steps%`, `%cfg%`, `%denoise%`, and `%clip_skip%` unquoted. RunPod substitution happens before Marinara parses the workflow, so the inserted number makes the submitted JSON valid. The connection editor may temporarily mark this template as invalid JSON because the unquoted token is not replaced until generation time; this warning does not prevent it from being saved.
+For a **RunPod Serverless (ComfyUI)** connection, keep text placeholders such as `"%prompt%"`, `"%model%"`, and `"%sampler%"` quoted, but leave numeric placeholders such as `%width%`, `%height%`, `%seed%`, `%steps%`, `%cfg%`, `%denoise%`, and `%clip_skip%` unquoted. RunPod substitution happens before Guksu parses the workflow, so the inserted number makes the submitted JSON valid. The connection editor may temporarily mark this template as invalid JSON because the unquoted token is not replaced until generation time; this warning does not prevent it from being saved.
 
 The relevant parts of a basic **local** API workflow may look like this:
 
@@ -79,9 +79,9 @@ The relevant parts of a basic **local** API workflow may look like this:
 }
 ```
 
-This is only a fragment: keep the node links and other inputs from your exported workflow. You may embed prompt placeholders inside a longer string to prepend or append fixed tags. A numeric placeholder should normally be the entire value. In a RunPod copy of the workflow, remove the quotes around those numeric tokens. You can also leave any setting hard-coded when you do not want Marinara's connection defaults to change it.
+This is only a fragment: keep the node links and other inputs from your exported workflow. You may embed prompt placeholders inside a longer string to prepend or append fixed tags. A numeric placeholder should normally be the entire value. In a RunPod copy of the workflow, remove the quotes around those numeric tokens. You can also leave any setting hard-coded when you do not want Guksu's connection defaults to change it.
 
-| Placeholder           | Value supplied by Marinara                                                                  |
+| Placeholder           | Value supplied by Guksu                                                                  |
 | --------------------- | ------------------------------------------------------------------------------------------- |
 | `%prompt%`            | Positive image prompt. The connection editor warns if this is missing.                      |
 | `%negative_prompt%`   | Negative image prompt.                                                                      |
@@ -99,7 +99,7 @@ After editing, save the JSON, copy the entire file, paste it into **ComfyUI Work
 
 ## Use reference images
 
-Marinara can provide up to four reference images when the feature starting the generation has images to send. A custom workflow must contain compatible input nodes and placeholders; adding a placeholder does not create or connect those nodes automatically.
+Guksu can provide up to four reference images when the feature starting the generation has images to send. A custom workflow must contain compatible input nodes and placeholders; adding a placeholder does not create or connect those nodes automatically.
 
 ### Local ComfyUI: upload filenames for LoadImage
 
@@ -117,9 +117,9 @@ For a standard ComfyUI **LoadImage** node, use a filename placeholder:
 }
 ```
 
-Marinara uploads the reference to ComfyUI's input directory and replaces the placeholder with the filename returned by ComfyUI. `%reference_image_name%` means the first image. Workflows with several reference inputs can use `%reference_image_name_01%` through `%reference_image_name_04%`.
+Guksu uploads the reference to ComfyUI's input directory and replaces the placeholder with the filename returned by ComfyUI. `%reference_image_name%` means the first image. Workflows with several reference inputs can use `%reference_image_name_01%` through `%reference_image_name_04%`.
 
-If the workflow always requires an image input, enable **Upload a 1x1 placeholder when no reference image is provided** in **Local Image Defaults**. Marinara then supplies a tiny placeholder image when the request has no real reference.
+If the workflow always requires an image input, enable **Upload a 1x1 placeholder when no reference image is provided** in **Local Image Defaults**. Guksu then supplies a tiny placeholder image when the request has no real reference.
 
 ### Raw base64 image data
 
@@ -129,7 +129,7 @@ RunPod workflows support the raw base64 placeholders. The filename-upload placeh
 
 ## Keep character-specific workflows
 
-You can create a separate exported workflow and Marinara image connection for each character that needs a particular checkpoint, LoRA stack, ControlNet setup, or reference-image layout. Select the appropriate image connection wherever that character or image feature lets you choose one.
+You can create a separate exported workflow and Guksu image connection for each character that needs a particular checkpoint, LoRA stack, ControlNet setup, or reference-image layout. Select the appropriate image connection wherever that character or image feature lets you choose one.
 
 This can produce more consistent results than one generic workflow, but each connection still holds its own copied JSON. After changing a character's workflow in ComfyUI, repeat the export, edit, copy, and paste steps for that connection.
 
@@ -137,21 +137,21 @@ This can produce more consistent results than one generic workflow, but each con
 
 | Problem                                          | What to check                                                                                                                                                                                                                 |
 | ------------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Marinara reports invalid workflow JSON           | For local ComfyUI, check quotes, commas, and brackets after adding placeholders. For RunPod, only numeric placeholders should be unquoted; all text placeholders and the rest of the template still need correct JSON syntax. |
+| Guksu reports invalid workflow JSON           | For local ComfyUI, check quotes, commas, and brackets after adding placeholders. For RunPod, only numeric placeholders should be unquoted; all text placeholders and the rest of the template still need correct JSON syntax. |
 | The literal prompt or placeholder reaches a node | Confirm that the token is spelled exactly as listed and that the pasted workflow is the newly exported API version.                                                                                                           |
 | The image ignores the requested dimensions       | Put `%width%` and `%height%` in the latent-image or equivalent size node that actually feeds the sampler.                                                                                                                     |
 | ComfyUI cannot find the model                    | Use the exact checkpoint name expected by the loader, or keep the checkpoint hard-coded in the workflow instead of using `%model%`.                                                                                           |
 | ComfyUI reports a missing node or input          | Install the same custom-node packages used when the workflow was built and confirm their input names have not changed.                                                                                                        |
-| The job completes but Marinara receives no image | Add a connected **SaveImage** output and test the workflow directly in ComfyUI again.                                                                                                                                         |
-| A reference-image node fails                     | For a normal local **LoadImage** node, use a `%reference_image_name...%` placeholder. Use raw base64 only with a node designed for it, and confirm that the Marinara feature actually supplied a reference.                   |
+| The job completes but Guksu receives no image | Add a connected **SaveImage** output and test the workflow directly in ComfyUI again.                                                                                                                                         |
+| A reference-image node fails                     | For a normal local **LoadImage** node, use a `%reference_image_name...%` placeholder. Use raw base64 only with a node designed for it, and confirm that the Guksu feature actually supplied a reference.                   |
 | A remote/LAN ComfyUI URL is blocked              | Enable `IMAGE_LOCAL_URLS_ENABLED`, make ComfyUI listen on the network interface, and check the host firewall. Do not expose an unauthenticated ComfyUI server to the public internet.                                         |
-| A long generation times out                      | Increase `COMFYUI_GEN_TIMEOUT` in Marinara's `.env`. The value is measured in seconds and defaults to `2400`.                                                                                                                 |
+| A long generation times out                      | Increase `COMFYUI_GEN_TIMEOUT` in Guksu's `.env`. The value is measured in seconds and defaults to `2400`.                                                                                                                 |
 | Generation runs out of GPU memory                | Reduce image dimensions or model size, unload the local language model, use a remote language model, or move ComfyUI to another device.                                                                                       |
 
 ## Related guides
 
 - [Image Generation Providers and Setup](image-providers.md) covers all supported image services and shared image settings.
-- [Image Style Profiles](style-profiles.md) explains Marinara's reusable prompt styles.
+- [Image Style Profiles](style-profiles.md) explains Guksu's reusable prompt styles.
 - [Illustrator Agent](illustrator-agent.md) covers automatic scene illustration.
 - [Server Configuration Reference](../CONFIGURATION.md) documents local-network access and ComfyUI timeouts.
 - [ComfyUI workflow concepts](https://docs.comfy.org/development/core-concepts/workflow) explains workflows in the official ComfyUI documentation.

--- a/docs/media/image-providers.md
+++ b/docs/media/image-providers.md
@@ -1,12 +1,12 @@
 # Image Generation Providers and Setup
 
-This guide explains how to connect an image generation service to Marinara Engine. It also covers what each of the 15 services needs. Image generation powers scene illustrations, selfies, scene backgrounds, and generated avatars, portraits, and sprites.
+This guide explains how to connect an image generation service to Guksu Motor. It also covers what each of the 15 services needs. Image generation powers scene illustrations, selfies, scene backgrounds, and generated avatars, portraits, and sprites.
 
 You set up image generation as a special kind of connection. Once one image connection works, every image feature in the app can use it.
 
 ## How to add an image generation connection
 
-An **API key** is a secret password from a provider that lets Marinara use your account. A **Base URL** is the web address of the service's application interface. Marinara fills in the correct Base URL for you when you pick a service.
+An **API key** is a secret password from a provider that lets Guksu use your account. A **Base URL** is the web address of the service's application interface. Guksu fills in the correct Base URL for you when you pick a service.
 
 Follow these steps to add an image connection.
 
@@ -17,7 +17,7 @@ Follow these steps to add an image connection.
 5. Paste your **API Key** if that service needs one. Free and local services do not.
 6. Pick a **Model** from the list, or type a model ID. Some services offer **Fetch Models from API** to load the current list.
 7. Click **Save**.
-8. Click **Test Image** to confirm it works. Marinara generates a small test image.
+8. Click **Test Image** to confirm it works. Guksu generates a small test image.
 
 If **Test Image** returns a picture, your connection is ready. If it fails, check the API key and Base URL.
 
@@ -71,7 +71,7 @@ Cloud service with the default Base URL `https://api.x.ai/v1`. It needs an xAI A
 
 ## Venice.ai
 
-Cloud service with the default Base URL `https://api.venice.ai/api/v1`. It needs a Venice API key. Use **Fetch Models from API** to load the image models available to your account. Marinara uses Venice's native image endpoint and automatically maps requested dimensions to each model's pixel, aspect-ratio, or resolution-tier sizing format.
+Cloud service with the default Base URL `https://api.venice.ai/api/v1`. It needs a Venice API key. Use **Fetch Models from API** to load the image models available to your account. Guksu uses Venice's native image endpoint and automatically maps requested dimensions to each model's pixel, aspect-ratio, or resolution-tier sizing format.
 
 ## NanoGPT
 
@@ -79,7 +79,7 @@ Cloud service with the default Base URL `https://nano-gpt.com/api/v1`. It needs 
 
 ## Block Entropy
 
-Cloud service with the default Base URL `https://api.blockentropy.ai`. It needs an API key. Marinara has no dedicated handler for Block Entropy, so it sends requests in the OpenAI compatible format. Its real compatibility is not confirmed, so test it with **Test Image** before you rely on it.
+Cloud service with the default Base URL `https://api.blockentropy.ai`. It needs an API key. Guksu has no dedicated handler for Block Entropy, so it sends requests in the OpenAI compatible format. Its real compatibility is not confirmed, so test it with **Test Image** before you rely on it.
 
 ## RunPod Serverless (ComfyUI)
 
@@ -103,11 +103,11 @@ Local service with the default Base URL `http://127.0.0.1:8188`. It talks to a C
 
 ## Draw Things
 
-Local service with the default Base URL `http://localhost:7860`. It talks to the Draw Things app on macOS or iOS. Marinara treats it like an AUTOMATIC1111 server. No API key is needed.
+Local service with the default Base URL `http://localhost:7860`. It talks to the Draw Things app on macOS or iOS. Guksu treats it like an AUTOMATIC1111 server. No API key is needed.
 
 ## Local services on your network
 
-The word `localhost` (also called loopback) means the same computer that runs Marinara. Local image servers on that same computer work with no extra setup.
+The word `localhost` (also called loopback) means the same computer that runs Guksu. Local image servers on that same computer work with no extra setup.
 
 If your image server runs on a different computer on your home network, you must allow local network addresses in the server configuration. See the [Server Configuration Reference](../CONFIGURATION.md) for how to do that.
 
@@ -115,7 +115,7 @@ If your image server runs on a different computer on your home network, you must
 
 For **ComfyUI** and **RunPod Serverless (ComfyUI)**, a **ComfyUI Workflow** field appears. Paste a workflow JSON that you exported from ComfyUI with **Save (API Format)**, **Export (API)**, or **Export to API**, depending on the frontend version. The field is labeled Optional for **ComfyUI** and Required for **RunPod Serverless (ComfyUI)**.
 
-Marinara fills your workflow using placeholders. Put these text markers in your workflow where the value should go.
+Guksu fills your workflow using placeholders. Put these text markers in your workflow where the value should go.
 
 - `%prompt%` and `%negative_prompt%` for the prompts.
 - `%width%`, `%height%`, and `%seed%` for the image size and seed.
@@ -175,7 +175,7 @@ NovelAI precise reference images only work on a V4.5 model, such as `nai-diffusi
 
 The **Queue image generation requests** toggle lives in **Settings**, then **Generations**, then **Image Generation**. It is on by default.
 
-When it is on, Marinara sends image jobs one at a time. Keep it on for services that reject two requests at once. Turn it off only if your service handles many requests at the same time and you want them faster.
+When it is on, Guksu sends image jobs one at a time. Keep it on for services that reject two requests at once. Turn it off only if your service handles many requests at the same time and you want them faster.
 
 ## Related guides
 

--- a/docs/media/music.md
+++ b/docs/media/music.md
@@ -1,6 +1,6 @@
 # Music DJ: Spotify, YouTube, and Local Music
 
-This guide explains how to play background music in Marinara Engine using the **Music DJ**. You will learn how to connect Spotify, YouTube, or your own local music files. You will also learn how the music player, the **DJ Mari** playlist maker, and Game Mode music work.
+This guide explains how to play background music in Guksu Motor using the **Music DJ**. You will learn how to connect Spotify, YouTube, or your own local music files. You will also learn how the music player, the **DJ Mari** playlist maker, and Game Mode music work.
 
 ## What Music DJ is
 
@@ -10,7 +10,7 @@ This guide explains how to play background music in Marinara Engine using the **
 
 - **Spotify**: controls playback on your own real Spotify account and devices.
 - **YouTube**: searches YouTube and plays the result in a small in-app player. No login is needed.
-- **Custom**: plays your own audio files from a folder on the machine that runs Marinara.
+- **Custom**: plays your own audio files from a folder on the machine that runs Guksu.
 
 Whichever source is active shows up as a small **Music Player** pinned in the top bar of the app. On phones and narrow windows it becomes a small floating round widget you can drag.
 
@@ -40,11 +40,11 @@ Open the **Music DJ** editor and find the **Spotify Connection** field. Then fol
 
 1. Open the **Spotify Developer Dashboard** at the link shown in the app.
 2. Create a new app and select "Web API".
-3. In the app's Redirect URIs, add the exact redirect address that Marinara shows you in step 3 of the in-app setup box. A redirect address is the web address Spotify sends you back to after you log in.
+3. In the app's Redirect URIs, add the exact redirect address that Guksu shows you in step 3 of the in-app setup box. A redirect address is the web address Spotify sends you back to after you log in.
 4. Copy the **Client ID** from your Spotify app and paste it into the **Spotify Client ID** field.
 5. Save the agent, then click **Connect Spotify Account**.
 
-A Spotify login and permission window opens. After you approve, the window shows a short "Spotify Connected!" page and closes. Back in Marinara you should see a green **Connected to Spotify** pill. A **Disconnect** button removes the saved connection.
+A Spotify login and permission window opens. After you approve, the window shows a short "Spotify Connected!" page and closes. Back in Guksu you should see a green **Connected to Spotify** pill. A **Disconnect** button removes the saved connection.
 
 The app shows this note: "Requires Spotify Premium. Tokens refresh automatically, no need to reconnect." A free Spotify account can connect, but play, pause, skip, and volume control need Spotify Premium. Premium is the paid Spotify plan.
 
@@ -52,7 +52,7 @@ The app shows this note: "Requires Spotify Premium. Tokens refresh automatically
 
 Spotify plays through a device, such as your phone, your desktop Spotify app, or an in-app player.
 
-On desktop you can turn the browser tab itself into a Spotify device. Click the laptop icon on the mini player. Its tooltip reads **Enable Marinara player** or **Use Marinara player**. This registers a Spotify device named "Marinara Engine" so music streams into the tab. In-app streaming also needs Spotify Premium.
+On desktop you can turn the browser tab itself into a Spotify device. Click the laptop icon on the mini player. Its tooltip reads **Enable Guksu player** or **Use Guksu player**. This registers a Spotify device named "Guksu Motor" so music streams into the tab. In-app streaming also needs Spotify Premium.
 
 On mobile, the player prefers your phone's own Spotify device. So tapping play plays music on your phone, not in the background browser tab.
 
@@ -60,7 +60,7 @@ If a Spotify device does not allow remote volume, the volume slider is replaced 
 
 ### Spotify on another machine
 
-Spotify only accepts secure `https://` redirect addresses or the loopback address `http://127.0.0.1`. Loopback means the same computer. If Marinara runs on another machine over plain `http`, the login window may fail to load.
+Spotify only accepts secure `https://` redirect addresses or the loopback address `http://127.0.0.1`. Loopback means the same computer. If Guksu runs on another machine over plain `http`, the login window may fail to load.
 
 Two options help here:
 
@@ -75,7 +75,7 @@ See the [Server Configuration Reference](../CONFIGURATION.md) for how to set env
 
 ## YouTube setup
 
-YouTube mode needs a free YouTube Data API key. An API key is a secret code that lets Marinara use a service on your behalf. No YouTube account login and no Premium are needed.
+YouTube mode needs a free YouTube Data API key. An API key is a secret code that lets Guksu use a service on your behalf. No YouTube account login and no Premium are needed.
 
 Open the **Music DJ** editor and find the **YouTube Connection** field. Then follow these steps.
 
@@ -91,14 +91,14 @@ The app shows this note: "The free quota (~100 searches/day) is plenty for a per
 
 ## Custom (local) music
 
-Custom mode plays your own audio files from the machine that runs Marinara's server. Supported file types are `.mp3`, `.ogg`, `.wav`, `.flac`, `.m4a`, `.aac`, and `.webm`.
+Custom mode plays your own audio files from the machine that runs Guksu's server. Supported file types are `.mp3`, `.ogg`, `.wav`, `.flac`, `.m4a`, `.aac`, and `.webm`.
 
 Open the **Music DJ** editor and find the **Custom Music Library** field. It has one switch: **Use Game Assets music folder**.
 
-- Switch on: Custom mode reads audio you uploaded to Game Assets. Game Assets is Marinara's built-in asset library for Game Mode. Use the **Game Assets music folder** field to pick a folder. Type `music` for the whole music library, or a subfolder like `music/combat`. The **Open Folder** button opens that folder on the server machine.
+- Switch on: Custom mode reads audio you uploaded to Game Assets. Game Assets is Guksu's built-in asset library for Game Mode. Use the **Game Assets music folder** field to pick a folder. Type `music` for the whole music library, or a subfolder like `music/combat`. The **Open Folder** button opens that folder on the server machine.
 - Switch off: Custom mode reads a folder on the server device. Use **Select Folder** to open a folder picker on the server machine, or paste the path into the **Music folder on this device** field.
 
-Playing from a folder outside Game Assets needs local access on the server. If you use Marinara from another device without a password or admin secret, this one feature can be blocked. See [Remote Access: Basic Auth and IP Allowlist](../REMOTE_ACCESS.md).
+Playing from a folder outside Game Assets needs local access on the server. If you use Guksu from another device without a password or admin secret, this one feature can be blocked. See [Remote Access: Basic Auth and IP Allowlist](../REMOTE_ACCESS.md).
 
 ## Using the music player
 
@@ -114,7 +114,7 @@ On a fresh profile the visible source starts as **YouTube**. You can change the 
 
 The player shows the current track's cover art or thumbnail, title, and artist or channel. Controls depend on the source.
 
-- Spotify: shuffle, **Previous**, play or pause, **Next**, repeat, a volume slider with mute, the **DJ** button, the laptop **Marinara player** button, and the **Music DJ setup** gear.
+- Spotify: shuffle, **Previous**, play or pause, **Next**, repeat, a volume slider with mute, the **DJ** button, the laptop **Guksu player** button, and the **Music DJ setup** gear.
 - YouTube: play or pause, an expand arrow that opens a small 16:9 video panel, a **Stop** button, and a volume slider with mute.
 - Custom: play or pause and volume, using your local files.
 
@@ -158,14 +158,14 @@ In **Conversation** mode you cannot add **Music DJ** as an agent. Instead, chara
 
 Open the chat's **Commands** section. Turn on the master **Commands** toggle first. Then turn on the **Music** toggle. Its description reads "Let characters play songs through the active Music Player."
 
-Now a character can name a song for Spotify, or describe a track for YouTube, and Marinara plays it through the active source. This works even when **Music DJ** is not enabled anywhere. It only needs Spotify connected or a YouTube key saved.
+Now a character can name a song for Spotify, or describe a track for YouTube, and Guksu plays it through the active source. This works even when **Music DJ** is not enabled anywhere. It only needs Spotify connected or a YouTube key saved.
 
 If Spotify is not connected or lacks playback permission, a Spotify song command does nothing and shows no error. So set up your source first if songs are not playing.
 
 ## Troubleshooting
 
 - The mini player is missing. Turn on **Music Player** in **Settings**, **General** tab, **App Behavior** section.
-- Spotify plays nothing. Playback control needs Spotify Premium and an active Spotify device. Open the desktop app on a device, or click **Enable Marinara player** on desktop.
+- Spotify plays nothing. Playback control needs Spotify Premium and an active Spotify device. Open the desktop app on a device, or click **Enable Guksu player** on desktop.
 - The Spotify login window fails on another machine. Use the "Browser couldn't reach the callback?" paste box, or set `SPOTIFY_REDIRECT_URI` on the server.
 - YouTube search fails. Confirm the **YouTube Data API v3** is enabled for your project and the key is not restricted by HTTP referrer. If you hit the daily quota, try again the next day or use another key.
 - Custom music will not play from a device folder over remote access. That folder needs local access on the server. See [Remote Access: Basic Auth and IP Allowlist](../REMOTE_ACCESS.md).

--- a/docs/media/scene-backgrounds.md
+++ b/docs/media/scene-backgrounds.md
@@ -1,6 +1,6 @@
 # Scene Backgrounds and the Gallery
 
-This guide covers AI-generated scene backgrounds, the backdrop images Marinara Engine creates for you from the **Gallery**, and the Gallery panel itself. Two related guides exist: [Chat Backgrounds](../appearance/chat-backgrounds.md) covers the hand-picked upload library, and [Roleplay Backgrounds](../roleplay/backgrounds.md) covers the agent that auto-picks a backdrop each turn.
+This guide covers AI-generated scene backgrounds, the backdrop images Guksu Motor creates for you from the **Gallery**, and the Gallery panel itself. Two related guides exist: [Chat Backgrounds](../appearance/chat-backgrounds.md) covers the hand-picked upload library, and [Roleplay Backgrounds](../roleplay/backgrounds.md) covers the agent that auto-picks a backdrop each turn.
 
 ## Where scene backgrounds work
 
@@ -28,7 +28,7 @@ The background is built from your current scene. In a game, this includes the ge
 
 ### If no image connection is set
 
-If Marinara cannot find an image connection to use, the generate step fails with this message:
+If Guksu cannot find an image connection to use, the generate step fails with this message:
 
 ```
 Choose an image generation connection for the Background/Illustrator agent, or mark an image generation connection as the default for agents.
@@ -65,12 +65,12 @@ Move your pointer over any image in the **Images** tab, or tap it on mobile, to 
 
 ## Reviewing a prompt before it is sent
 
-You can check and edit the prompt before Marinara sends a background request to your image provider.
+You can check and edit the prompt before Guksu sends a background request to your image provider.
 
 1. Open **Settings**, then **Generations**, then **Image Generation**.
 2. Turn on **Expose media prompts before sending**.
 
-With this setting on, a **Review Image Prompt** window opens before each request is sent. Its help text reads: "Edit the prompt below before Marinara sends the image request to your provider."
+With this setting on, a **Review Image Prompt** window opens before each request is sent. Its help text reads: "Edit the prompt below before Guksu sends the image request to your provider."
 
 In the window, you can:
 

--- a/docs/media/scene-video.md
+++ b/docs/media/scene-video.md
@@ -1,6 +1,6 @@
 # Scene Video Generation
 
-This guide explains how Marinara Engine turns a scene illustration into a short MP4 video clip. It covers the video providers, how to generate a clip from the Gallery, the Game Mode controls, and the video settings. A scene video is a brief animated clip made from one still image.
+This guide explains how Guksu Motor turns a scene illustration into a short MP4 video clip. It covers the video providers, how to generate a clip from the Gallery, the Game Mode controls, and the video settings. A scene video is a brief animated clip made from one still image.
 
 ## What scene video does
 
@@ -37,7 +37,7 @@ There is no local or self-hosted option for video. Every video service needs an 
 
 ### Make it the default video connection
 
-The connection editor for a Video Generation connection shows a **Default for Videos** group. Turn on **Use as default video connection** so Marinara can use this connection when a chat has no video connection of its own. Only mark one connection as the default video connection.
+The connection editor for a Video Generation connection shows a **Default for Videos** group. Turn on **Use as default video connection** so Guksu can use this connection when a chat has no video connection of its own. Only mark one connection as the default video connection.
 
 ### Connection video defaults
 
@@ -55,11 +55,11 @@ Gemini Omni has no resolution field, and its length is written into the prompt t
 
 ### Seedance reference frames
 
-Seedance must fetch your reference image over a public web link before it can animate it. A local Marinara server has no public link, so plain local setups need one extra step.
+Seedance must fetch your reference image over a public web link before it can animate it. A local Guksu server has no public link, so plain local setups need one extra step.
 
 Open the Seedance connection and turn on **Upload Seedance reference frames temporarily**. This uploads the reference frame to a temporary public link so Seedance can read it. You can pick how long that link lasts under **Temporary link lifetime**, which defaults to 12 hours.
 
-If your Marinara server already has a public web address, you can set an environment variable instead of using temporary uploads. See the [Server Configuration Reference](../CONFIGURATION.md) for the video reference setting.
+If your Guksu server already has a public web address, you can set an environment variable instead of using temporary uploads. See the [Server Configuration Reference](../CONFIGURATION.md) for the video reference setting.
 
 ## Choosing a provider
 
@@ -71,7 +71,7 @@ All four services make short clips from your image. They differ in speed, clip l
 - **OpenRouter Video**: 1 to 60 seconds, and lets you type any video model your OpenRouter account supports.
 - **Seedance 2.0**: 4 to 15 second clips with first-frame and first and last frame modes. It needs a public link to your reference image.
 
-Expect video jobs to take a while. The provider starts the job, then Marinara waits and checks until the clip is ready. This can take several minutes per clip, longer than a still image.
+Expect video jobs to take a while. The provider starts the job, then Guksu waits and checks until the clip is ready. This can take several minutes per clip, longer than a still image.
 
 ## Generate a video from the Gallery
 
@@ -97,7 +97,7 @@ The same **Review Video Prompt** window appears for **Animate illustration** whe
 
 Under the **Videos** tab, each clip plays inline and shows its length and model name. You can pin a clip with **Pin video to chat**, or save it with **Download scene video**. If there are no clips yet, the tab reads **No videos yet**.
 
-If you try to make a video with no picture in the chat, Marinara shows this message: "Add or generate a gallery image before generating a scene video." Generate or upload a picture first, then try again.
+If you try to make a video with no picture in the chat, Guksu shows this message: "Add or generate a gallery image before generating a scene video." Generate or upload a picture first, then try again.
 
 ## Game Mode scene video
 
@@ -130,7 +130,7 @@ The **Game Video Prompt** continues to control manual Gallery and Game Assets vi
 
 When you first create a Game Mode chat, the setup wizard also has a **Video Generation Connection** picker. It is on the **Features** step, and it appears after you turn on **Visual Generation**.
 
-If a chat has no video connection of its own, Marinara falls back to the connection you marked **Use as default video connection**. If there is no chat connection and no default, video actions show a warning telling you to pick one.
+If a chat has no video connection of its own, Guksu falls back to the connection you marked **Use as default video connection**. If there is no chat connection and no default, video actions show a warning telling you to pick one.
 
 ## Video generation settings
 
@@ -144,7 +144,7 @@ The same section has an **Animated expression length** setting. That belongs to 
 
 ## Storyboards
 
-Game Mode can also build a storyboard, which is an ordered set of keyframe pictures for one game turn. When storyboard animations are turned on, Marinara animates each keyframe into a clip using your video connection and the **Storyboard Video Prompt**. It inherits the **Game Video Prompt** unless you choose a separate template. A keyframe is one still frame in that ordered set.
+Game Mode can also build a storyboard, which is an ordered set of keyframe pictures for one game turn. When storyboard animations are turned on, Guksu animates each keyframe into a clip using your video connection and the **Storyboard Video Prompt**. It inherits the **Game Video Prompt** unless you choose a separate template. A keyframe is one still frame in that ordered set.
 
 Storyboards have their own controls and their own guide. See [Game Mode Storyboards](../game/storyboard.md) for the full setup and workflow.
 
@@ -160,7 +160,7 @@ Scene video always animates an existing picture. Use **Illustrate**, upload a pi
 
 ### The video takes a long time
 
-This is normal. The provider starts the job, and Marinara waits and checks until the clip is ready. Veo, xAI, OpenRouter, and Seedance all work this way, and a clip can take several minutes.
+This is normal. The provider starts the job, and Guksu waits and checks until the clip is ready. Veo, xAI, OpenRouter, and Seedance all work this way, and a clip can take several minutes.
 
 ### Seedance fails to read the reference image
 

--- a/docs/media/style-profiles.md
+++ b/docs/media/style-profiles.md
@@ -1,12 +1,12 @@
 # Image Style Profiles
 
-This guide explains image style profiles in Marinara Engine. A style profile is a reusable "house style" that shapes every image prompt before Marinara sends it to your image provider. Use it to make avatars, portraits, selfies, backgrounds, illustrations, and sprites look consistent.
+This guide explains image style profiles in Guksu Motor. A style profile is a reusable "house style" that shapes every image prompt before Guksu sends it to your image provider. Use it to make avatars, portraits, selfies, backgrounds, illustrations, and sprites look consistent.
 
 ## What a style profile is
 
-Marinara Engine can generate many kinds of images: character and persona avatars, portraits, Conversation-mode selfies, scene backgrounds, in-scene illustrations, and character sprites. Every one of those images starts as a text prompt.
+Guksu Motor can generate many kinds of images: character and persona avatars, portraits, Conversation-mode selfies, scene backgrounds, in-scene illustrations, and character sprites. Every one of those images starts as a text prompt.
 
-A style profile is a saved set of rules that Marinara adds to that text prompt. It can add positive words (what you want), negative words (what you want to avoid), and a preferred prompt style. This keeps a single look across every image, so you do not have to retype the same style words each time.
+A style profile is a saved set of rules that Guksu adds to that text prompt. It can add positive words (what you want), negative words (what you want to avoid), and a preferred prompt style. This keeps a single look across every image, so you do not have to retype the same style words each time.
 
 You pick one profile as the app-wide default. You can override it for a single chat or a single image connection. All of that is explained below.
 
@@ -19,7 +19,7 @@ To find the editor, follow these steps.
 
 ## The built-in profiles
 
-Marinara ships with 10 built-in style profiles. **Auto** is the default. You can edit any of them, and you can reset a built-in profile back to its original values at any time.
+Guksu ships with 10 built-in style profiles. **Auto** is the default. You can edit any of them, and you can reset a built-in profile back to its original values at any time.
 
 Some terms used below:
 
@@ -55,7 +55,7 @@ Your choice saves right away. New images use the profile you picked.
 You can edit a built-in profile in place, but the **Clone** button lets you keep the original and build your own version. To create and customize a profile, follow these steps.
 
 1. Open the **Editing** dropdown and pick the profile closest to what you want.
-2. Click **Clone**. Marinara makes a copy, selects it for editing, and immediately makes the copy your app-wide default style.
+2. Click **Clone**. Guksu makes a copy, selects it for editing, and immediately makes the copy your app-wide default style.
 3. Change the **Name** field to something you will recognize.
 4. Pick a **Prompt grammar** (explained in the next section).
 5. Fill in **Style text** with a plain description of the look you want.
@@ -70,7 +70,7 @@ Two buttons help you manage profiles:
 
 ## Prompt grammar modes
 
-The **Prompt grammar** dropdown tells Marinara how the image model prefers to read a prompt. Pick the mode that matches your image model. There are four modes.
+The **Prompt grammar** dropdown tells Guksu how the image model prefers to read a prompt. Pick the mode that matches your image model. There are four modes.
 
 - **Hybrid**: a mix of sentences and tags. A safe general choice.
 - **Danbooru tags**: short comma-separated Danbooru-style tags. Best for anime SDXL checkpoints like Illustrious, Pony, and NovelAI.
@@ -79,7 +79,7 @@ The **Prompt grammar** dropdown tells Marinara how the image model prefers to re
 
 ## The Test bench
 
-The **Test bench** section lets you preview exactly what Marinara would send, without generating a real image. Open it inside the Style Profiles editor. To use it, follow these steps.
+The **Test bench** section lets you preview exactly what Guksu would send, without generating a real image. Open it inside the Style Profiles editor. To use it, follow these steps.
 
 1. Pick an **Image kind** (for example, portrait or background).
 2. Type a rough prompt into **Sample input**.
@@ -87,9 +87,9 @@ The **Test bench** section lets you preview exactly what Marinara would send, wi
 
 The Test bench also shows a short note about cleanup. When it changes nothing, it says "No cleanup needed for this sample." When it edits your prompt, it says how many duplicate or misplaced fragments it cleaned.
 
-## How Marinara cleans the prompt
+## How Guksu cleans the prompt
 
-Before any image request leaves Marinara, it compiles your prompt with the active profile. The compiler does a few things:
+Before any image request leaves Guksu, it compiles your prompt with the active profile. The compiler does a few things:
 
 - It removes near-duplicate tags, such as a repeated quality tag.
 - It moves simple negative phrases (like "avoid text" or "no watermark") into the negative prompt.
@@ -120,13 +120,13 @@ If your subject words disappear for a portrait, avatar, or sprite, try the **ill
 
 ## Setting precedence: chat, connection, then global
 
-Marinara can pick a style profile from three places. The most specific choice wins. The order is:
+Guksu can pick a style profile from three places. The most specific choice wins. The order is:
 
 1. An explicit profile chosen for the current chat or game.
 2. The **Style Profile** set on the image connection (under **Local Image Defaults** in the connection editor).
 3. The global **Default style** you set in **Settings**.
 
-The **Local Image Defaults** section appears only for local Stable Diffusion connections (AUTOMATIC1111 / SD Web UI, ComfyUI, and NovelAI). For every other provider, the choice falls straight through to the global **Default style**. To set a per-connection profile, open the connection, expand **Local Image Defaults**, and pick a profile in the **Style Profile** dropdown. Leave it on **Use global default** to follow the global choice. When Marinara can guess a good profile from the connection's model name, it shows a "Use ..." button that applies that profile in one click.
+The **Local Image Defaults** section appears only for local Stable Diffusion connections (AUTOMATIC1111 / SD Web UI, ComfyUI, and NovelAI). For every other provider, the choice falls straight through to the global **Default style**. To set a per-connection profile, open the connection, expand **Local Image Defaults**, and pick a profile in the **Style Profile** dropdown. Leave it on **Use global default** to follow the global choice. When Guksu can guess a good profile from the connection's model name, it shows a "Use ..." button that applies that profile in one click.
 
 ## Related guides
 

--- a/docs/media/tts-setup.md
+++ b/docs/media/tts-setup.md
@@ -1,6 +1,6 @@
 # Text to Speech (TTS) Setup
 
-This guide shows you how to set up Text to Speech in Marinara Engine so the app can read messages and game narration out loud. Text to Speech (TTS) turns written chat text into spoken audio. This guide covers picking a voice provider, choosing voices, auto-play, and the per-message playback controls.
+This guide shows you how to set up Text to Speech in Guksu Motor so the app can read messages and game narration out loud. Text to Speech (TTS) turns written chat text into spoken audio. This guide covers picking a voice provider, choosing voices, auto-play, and the per-message playback controls.
 
 ## Where TTS settings live
 
@@ -23,7 +23,7 @@ A **Source** is the service that makes the audio. The four choices are:
 - **PocketTTS**: a free voice server you run on your own computer.
 - **xAI Voice**: xAI's voice service.
 
-The default Source is **OpenAI-compatible**. Marinara keeps a separate saved profile for each Source, including its encrypted API key, endpoint, model, voices, and provider parameters. Switching Sources restores that Source's previous setup; a Source you have not configured yet starts with its defaults.
+The default Source is **OpenAI-compatible**. Guksu keeps a separate saved profile for each Source, including its encrypted API key, endpoint, model, voices, and provider parameters. Switching Sources restores that Source's previous setup; a Source you have not configured yet starts with its defaults.
 
 ## Step 2: Enter the Base URL, API Key, and Model
 
@@ -46,7 +46,7 @@ For **ElevenLabs**, the **Model** field offers a dropdown of speech models. Pick
 
 ### PocketTTS is a separate program
 
-PocketTTS is not built into Marinara Engine. You install and run it yourself, following the PocketTTS project's own instructions. Marinara does not download or manage it for you.
+PocketTTS is not built into Guksu Motor. You install and run it yourself, following the PocketTTS project's own instructions. Guksu does not download or manage it for you.
 
 Once you have installed PocketTTS, start its server. The app's help text refers to this command:
 

--- a/docs/noodle/overview.md
+++ b/docs/noodle/overview.md
@@ -1,6 +1,6 @@
 # Noodle: The In-App Social Timeline
 
-Noodle is a pretend social media feed built into Marinara Engine. It looks like a Twitter or X style timeline. But every account and post belongs to your own world: your persona, your characters, and Professor Mari. This guide covers what Noodle is, how to open it, and how to post, follow, and refresh the timeline.
+Noodle is a pretend social media feed built into Guksu Motor. It looks like a Twitter or X style timeline. But every account and post belongs to your own world: your persona, your characters, and Professor Mari. This guide covers what Noodle is, how to open it, and how to post, follow, and refresh the timeline.
 
 ## What Noodle is
 
@@ -104,7 +104,7 @@ Your persona can follow any invited character, but only after that character has
 
 Each persona you create gets its own Noodle account. At the bottom of the left sidebar, your persona's name and avatar are a button. Click it to open **Switch account** and pick a different persona.
 
-Switching accounts here changes which persona you post, like, reply, and follow as inside Noodle. It does not change the app's active persona anywhere else in Marinara.
+Switching accounts here changes which persona you post, like, reply, and follow as inside Noodle. It does not change the app's active persona anywhere else in Guksu.
 
 ## Refresh timeline
 
@@ -120,7 +120,7 @@ Before a refresh works, you need three things:
 
 If something is missing, Noodle blocks the refresh and shows a message telling you what to fix. For example, "Choose a generation connection for Noodle first." On success you see "Noodle timeline refreshed."
 
-You can refresh by hand at any time with **Refresh timeline**. Noodle can also refresh itself on a schedule. Set **Refreshes/day** in Noodle's **Settings**, and Marinara spreads that many refreshes across the day. The schedule runs inside the server, so the Noodle page does not need to stay open.
+You can refresh by hand at any time with **Refresh timeline**. Noodle can also refresh itself on a schedule. Set **Refreshes/day** in Noodle's **Settings**, and Guksu spreads that many refreshes across the day. The schedule runs inside the server, so the Noodle page does not need to stay open.
 
 Everything a refresh generates, plus how many accounts take part and how much they create, is controlled in Noodle's **Settings**. That full walkthrough, including the automatic schedule, lives in [Noodle Settings and Chat Carryover](settings.md).
 

--- a/docs/noodle/settings.md
+++ b/docs/noodle/settings.md
@@ -2,7 +2,7 @@
 
 This guide covers the **Noodle settings** panel section by section, with every default and limit. It also explains how to connect Noodle to your chats. Two features do this: **Carryover to chats** and the per-chat **Allow Noodle references** toggle. They work in opposite directions.
 
-Noodle is the in-app social media timeline in Marinara Engine. If you are new to it, read [Noodle: The In-App Social Timeline](overview.md) first. A persona is the character you play as in a chat. A connection is a saved link to an AI provider that generates text or images. See [Connecting to an AI Provider](../connections/connecting-to-a-provider.md).
+Noodle is the in-app social media timeline in Guksu Motor. If you are new to it, read [Noodle: The In-App Social Timeline](overview.md) first. A persona is the character you play as in a chat. A connection is a saved link to an AI provider that generates text or images. See [Connecting to an AI Provider](../connections/connecting-to-a-provider.md).
 
 ## Opening the Noodle settings panel
 
@@ -37,13 +37,13 @@ Inviting from a folder is a one-time bulk action. It is not a live sync. Charact
 The **Refresh** section controls the AI connection Noodle writes with, and how often Noodle refreshes on its own.
 
 - **Generation connection**: a dropdown. Pick the connection Noodle uses to write posts, replies, reposts, likes, and profile text. It starts unset with the placeholder **Choose connection**. You must pick one before any refresh will run. Vision-capable models also receive up to eight recent relevant images from Noodle posts and comments. Text-only models that reject those image inputs are retried automatically without the pictures.
-- **Refreshes/day**: a number, from 0 to 24, default **2**. This is how many automatic refreshes Marinara runs per day. Set it to 0 to turn automatic refreshes off. It does not limit how often you refresh by hand.
+- **Refreshes/day**: a number, from 0 to 24, default **2**. This is how many automatic refreshes Guksu runs per day. Set it to 0 to turn automatic refreshes off. It does not limit how often you refresh by hand.
 
 ### Automatic schedule
 
-When **Refreshes/day** is above 0, Marinara splits the day into equal windows and picks one random time inside each window. The planned times, with their timezone, show under **Automatic schedule**. Click the pencil next to a future time to move it to a different hour. Past times, completed times, and duplicate times cannot be picked.
+When **Refreshes/day** is above 0, Guksu splits the day into equal windows and picks one random time inside each window. The planned times, with their timezone, show under **Automatic schedule**. Click the pencil next to a future time to move it to a different hour. Past times, completed times, and duplicate times cannot be picked.
 
-Automatic refreshes run inside the Marinara server. The Noodle page does not need to stay open, but Marinara itself must be running. If a refresh fails, the schedule shows the error and retries later, waiting longer after repeated failures. If several planned times are missed, one successful catch-up refresh covers them instead of flooding the timeline.
+Automatic refreshes run inside the Guksu server. The Noodle page does not need to stay open, but Guksu itself must be running. If a refresh fails, the schedule shows the error and retries later, waiting longer after repeated failures. If several planned times are missed, one successful catch-up refresh covers them instead of flooding the timeline.
 
 ## Active Accounts
 
@@ -115,7 +115,7 @@ The **Carryover** section pushes recent Noodle activity into your chats. When on
 - **Carry items**: a number, 1 to 50, default **8**. This is the most activity summaries added to one chat turn.
 
 Carryover only pulls activity for characters who are invited on Noodle, plus the chat's active persona. Folder-only inclusion is not enough here.
-The complete wrapped carryover block has a separate hard 8,192-token budget per chat generation. If the item limit would exceed it, Marinara keeps the newest summaries that fit and renders them in chronological order.
+The complete wrapped carryover block has a separate hard 8,192-token budget per chat generation. If the item limit would exceed it, Guksu keeps the newest summaries that fit and renders them in chronological order.
 
 ## Reset Noodle
 
@@ -146,7 +146,7 @@ To make Noodle activity appear in a chat, turn on the matching **Carryover to ch
 ## Troubleshooting
 
 - **Refresh now generates nothing**: pick a **Generation connection**, invite at least one character (or turn on random users), and check the error shown in the **Refresh** section.
-- **Automatic refreshes are not happening**: set **Refreshes/day** above 0, keep the Marinara server running, and check the planned times and timezone under **Automatic schedule**. If the schedule shows an error, fix the connection or rate limit problem and let the retry run.
+- **Automatic refreshes are not happening**: set **Refreshes/day** above 0, keep the Guksu server running, and check the planned times and timezone under **Automatic schedule**. If the schedule shows an error, fix the connection or rate limit problem and let the retry run.
 - **Posts do not mention a recent chat**: turn on **Allow Noodle references** in that chat's settings, and make sure the character is invited. Chat context is guidance for the AI, not a guarantee.
 - **Noodle activity does not show in chats**: turn on the matching **Carryover to chats** mode, and raise **Carry hours** if the activity is too old.
 - **Posts have no images**: turn on **Image generation**, pick a working image connection, and check the **Images/refresh** limit.

--- a/docs/prompts/chat-settings-presets.md
+++ b/docs/prompts/chat-settings-presets.md
@@ -1,6 +1,6 @@
 # Chat Settings Presets
 
-This guide explains Chat Settings Presets in Marinara Engine. A preset is a named bundle of a chat's connection, prompt preset, and other per-chat settings. You can reuse the bundle across chats. This guide shows how to save, apply, star a default, rename, import, and export presets.
+This guide explains Chat Settings Presets in Guksu Motor. A preset is a named bundle of a chat's connection, prompt preset, and other per-chat settings. You can reuse the bundle across chats. This guide shows how to save, apply, star a default, rename, import, and export presets.
 
 ## What a Chat Settings Preset is
 
@@ -12,7 +12,7 @@ Chat Settings Presets work in Conversation Mode and Roleplay Mode. Game Mode doe
 
 ## Chat Settings Presets are not prompt presets
 
-Marinara has two different "preset" systems. Do not mix them up.
+Guksu has two different "preset" systems. Do not mix them up.
 
 - A **prompt preset** is the system prompt template that builds the text sent to the AI. You edit it in the Presets panel. See [Preset Editor and Prompt Manager](presets.md).
 - A **Chat Settings Preset** is a wider bundle. It includes which prompt preset the chat uses, plus the connection, agents, and more.
@@ -67,7 +67,7 @@ When a preset is already the default, the star tooltip reads **This preset is th
 
 Use **Export preset (.json)** to save a preset as a file you can share or back up. The file downloads with a `.marinara-chat-preset.json` name.
 
-Use **Import preset (.json)** to load a preset file back in. Marinara adds the imported preset as a new, non-default preset. It does not overwrite anything and it does not become the default until you star it.
+Use **Import preset (.json)** to load a preset file back in. Guksu adds the imported preset as a new, non-default preset. It does not overwrite anything and it does not become the default until you star it.
 
 Presets store settings, not secrets. Sharing a preset file is a safe way to pass your setup to another person.
 

--- a/docs/prompts/conditional-prompts.md
+++ b/docs/prompts/conditional-prompts.md
@@ -1,12 +1,12 @@
 # Conditional Prompts ({{#if}})
 
-This guide explains how to use `{{#if}}` blocks in Marinara Engine. A conditional block lets you include some prompt text only when a value matches a rule you set. Conditionals are part of the macro system, so they work everywhere macros work, including character cards, personas, lorebook entries, and prompt presets.
+This guide explains how to use `{{#if}}` blocks in Guksu Motor. A conditional block lets you include some prompt text only when a value matches a rule you set. Conditionals are part of the macro system, so they work everywhere macros work, including character cards, personas, lorebook entries, and prompt presets.
 
 ## What conditional prompts do
 
-A macro is a `{{double-brace}}` placeholder that Marinara Engine replaces with a live value while it builds your prompt. A conditional block goes one step further. It checks a value, then keeps one piece of text and throws the rest away.
+A macro is a `{{double-brace}}` placeholder that Guksu Motor replaces with a live value while it builds your prompt. A conditional block goes one step further. It checks a value, then keeps one piece of text and throws the rest away.
 
-You write a condition, some text to use when the condition is true, and (optionally) text to use when it is false. Marinara reads the condition each time it builds a prompt. This means the same card or preset can behave differently for different characters, personas, or chats.
+You write a condition, some text to use when the condition is true, and (optionally) text to use when it is false. Guksu reads the condition each time it builds a prompt. This means the same card or preset can behave differently for different characters, personas, or chats.
 
 A common use is character-specific instructions inside one shared preset. Another common use is including a field only when it has content, so you do not send an empty label to the model.
 
@@ -30,7 +30,7 @@ Text used when false.
 {{/if}}
 ```
 
-You can also chain extra conditions with `{{else if}}`. Marinara checks each branch in order from top to bottom. It keeps the first branch whose condition is true, resolves the macros inside that branch, and discards every other branch. If no condition is true and there is no `{{else}}`, the whole block resolves to nothing.
+You can also chain extra conditions with `{{else if}}`. Guksu checks each branch in order from top to bottom. It keeps the first branch whose condition is true, resolves the macros inside that branch, and discards every other branch. If no condition is true and there is no `{{else}}`, the whole block resolves to nothing.
 
 ```
 {{#if length == "short"}}
@@ -61,13 +61,13 @@ The condition is usually a left value, an operator, and a right value, like `cha
 
 A few rules control how the comparison works:
 
-1. For `==`, `=`, `is`, `!=`, and `is not`, if both sides look like numbers, Marinara compares them as numbers. So `5` equals `5.0`. Otherwise it compares them as text, ignoring uppercase and lowercase. So `Mari` equals `mari`.
+1. For `==`, `=`, `is`, `!=`, and `is not`, if both sides look like numbers, Guksu compares them as numbers. So `5` equals `5.0`. Otherwise it compares them as text, ignoring uppercase and lowercase. So `Mari` equals `mari`.
 2. For `>`, `<`, `>=`, and `<=`, both sides must be numbers. If either side is not a number, the condition is false.
 3. For `contains`, `includes`, `not contains`, and `not includes`, the match is case-insensitive. So `contains "dr"` matches the text `Dr Smith`.
 
 ### Truthy checks (no operator)
 
-If you write a condition with no operator, Marinara does a truthy check. This asks a simple question: does this value have real content in it?
+If you write a condition with no operator, Guksu does a truthy check. This asks a simple question: does this value have real content in it?
 
 ```
 {{#if scenario}}
@@ -89,11 +89,11 @@ The left or right side of a condition can be any of these:
 4. An explicit variable lookup written as `var:name` or `var.name`.
 5. Another macro, whose value is resolved first and then compared.
 
-If you write a bare word that is not a keyword, Marinara treats it as a variable name. If no variable by that name exists, it uses the word as its own plain text. Quoting your literal values avoids this confusion, so quote them when in doubt.
+If you write a bare word that is not a keyword, Guksu treats it as a variable name. If no variable by that name exists, it uses the word as its own plain text. Quoting your literal values avoids this confusion, so quote them when in doubt.
 
 ## Quoting rules
 
-When you compare against a fixed piece of text, put it in quotes. This tells Marinara to treat it as an exact literal and not as a keyword or a variable.
+When you compare against a fixed piece of text, put it in quotes. This tells Guksu to treat it as an exact literal and not as a keyword or a variable.
 
 ```
 {{#if char == "Dottore"}}
@@ -101,7 +101,7 @@ Speak in a cold, clinical tone.
 {{/if}}
 ```
 
-You can use straight double quotes or straight single quotes. Marinara also accepts curly (typographic) quotes, but straight quotes are safest and match every in-app example. Inside a quoted value you can escape a quote with a backslash, and you can write `\n` for a newline.
+You can use straight double quotes or straight single quotes. Guksu also accepts curly (typographic) quotes, but straight quotes are safest and match every in-app example. Inside a quoted value you can escape a quote with a backslash, and you can write `\n` for a newline.
 
 Always quote a literal that has a space in it, such as `"Dr Smith"`. An unquoted multi-word value is read as one variable name, which is almost never what you want.
 
@@ -109,7 +109,7 @@ Always quote a literal that has a space in it, such as `"Dr Smith"`. An unquoted
 
 In a group chat with two or more characters, a group block repeats the same text once for each character. This lets you write one block that describes every character in the scene.
 
-To make a group block, put a single `[` on its own line, then your text, then a single `]` on its own line. The block must contain a character macro, such as `{{char}}` or `{{description}}`, or a character-based condition like `{{#if char == "Alice"}}`. Marinara then repeats the block once per character and resolves the character macros against each one in turn.
+To make a group block, put a single `[` on its own line, then your text, then a single `]` on its own line. The block must contain a character macro, such as `{{char}}` or `{{description}}`, or a character-based condition like `{{#if char == "Alice"}}`. Guksu then repeats the block once per character and resolves the character macros against each one in turn.
 
 ```
 [

--- a/docs/prompts/generation-parameters.md
+++ b/docs/prompts/generation-parameters.md
@@ -1,6 +1,6 @@
 # Generation Parameters
 
-This guide explains the generation parameters in Marinara Engine. These are the settings that control how the AI writes each reply, such as **Temperature** and **Max Output Tokens**. You change them per chat in the **Advanced Parameters** panel.
+This guide explains the generation parameters in Guksu Motor. These are the settings that control how the AI writes each reply, such as **Temperature** and **Max Output Tokens**. You change them per chat in the **Advanced Parameters** panel.
 
 ## What generation parameters do
 
@@ -40,7 +40,7 @@ Each numeric parameter has an input box and its own on and off switch. That swit
 
 Together, **Frequency** and **Presence** are the repetition penalties.
 
-**Reasoning Effort** tells a thinking-capable model how much to reason before it answers. A thinking-capable model is one that works through a problem in hidden steps first. The choices are **None**, **Low**, **Medium**, **High**, **Xhigh**, and **Maximum**. If the model does not support the tier you pick, Marinara lowers it to the strongest tier that model allows.
+**Reasoning Effort** tells a thinking-capable model how much to reason before it answers. A thinking-capable model is one that works through a problem in hidden steps first. The choices are **None**, **Low**, **Medium**, **High**, **Xhigh**, and **Maximum**. If the model does not support the tier you pick, Guksu lowers it to the strongest tier that model allows.
 
 **Verbosity** controls how long and detailed replies should be. The choices are **None**, **Low**, **Medium**, and **High**. **Low** keeps replies short. **High** encourages longer, more descriptive replies. Only some models use this setting.
 
@@ -48,7 +48,7 @@ Together, **Frequency** and **Presence** are the repetition penalties.
 
 Every numeric parameter, plus **Reasoning Effort** and **Verbosity**, has a small on and off switch next to its name. The switch has no text label in the app; this guide calls it the Send switch. Hover it to see "This parameter is sent to the model" or "This parameter is not sent to the model."
 
-When a parameter's Send switch is on, Marinara includes that parameter in the request to the provider. When it is off, Marinara leaves that parameter out completely. The provider then uses its own default for that setting.
+When a parameter's Send switch is on, Guksu includes that parameter in the request to the provider. When it is off, Guksu leaves that parameter out completely. The provider then uses its own default for that setting.
 
 Turning the Send switch off is different from setting a value like 1 or 0. A value of 1 still tells the provider what to use. Turning the switch off tells the provider nothing, so the model decides.
 
@@ -81,13 +81,13 @@ Use it only for models that support a prefill or a set opening tag. For example,
 
 ## Thinking Tags
 
-**Thinking Tags** tell Marinara how a model marks its hidden reasoning inside plain text. Some models wrap their reasoning in tags. If Marinara knows those tags, it can hide that reasoning behind the **View thoughts** action instead of showing it in the reply.
+**Thinking Tags** tell Guksu how a model marks its hidden reasoning inside plain text. Some models wrap their reasoning in tags. If Guksu knows those tags, it can hide that reasoning behind the **View thoughts** action instead of showing it in the reply.
 
 You write one wrapper per line, with a slot in the middle for the hidden text. Common wrappers such as think, thinking, thought, pipe, channel, and bracket pairs are already recognized. You only need this field for models that use an unusual wrapper.
 
 ## Custom Parameters
 
-**Custom Parameters** lets you add raw settings that Marinara does not show as its own field. You type a JSON object, and Marinara merges it into the request sent to the provider.
+**Custom Parameters** lets you add raw settings that Guksu does not show as its own field. You type a JSON object, and Guksu merges it into the request sent to the provider.
 
 Custom Parameters saved as connection defaults are sent for every API-backed text generation that uses that connection, including Conversation, Roleplay, Game, Noodle, summaries, and agents. This also applies to custom endpoints running on your own machine. Per-chat Custom Parameters are added for that chat and override matching connection-level keys.
 
@@ -111,7 +111,7 @@ Leave it on unless you have a clear reason to feed old reasoning back into the m
 
 ## Image Captioning
 
-**Image Captioning** changes how the AI handles image attachments. When it is on, Marinara describes each attached image in text using a connection you choose, instead of sending the image itself.
+**Image Captioning** changes how the AI handles image attachments. When it is on, Guksu describes each attached image in text using a connection you choose, instead of sending the image itself.
 
 Use this for models that cannot see images. When you turn it on, pick a connection in the **Captioning Connection** dropdown. A text-only endpoint may fail if you point it at the wrong connection. This setting is off by default.
 
@@ -137,7 +137,7 @@ Game Mode is a special case. Game Mode sets some parameters on its own to keep i
 
 ## Some models ignore some parameters
 
-Not every model accepts every parameter. When Marinara knows a model rejects a setting, it leaves that setting out of the request. The slider or box still shows in the app, but changing it has no effect for that model.
+Not every model accepts every parameter. When Guksu knows a model rejects a setting, it leaves that setting out of the request. The slider or box still shows in the app, but changing it has no effect for that model.
 
 This is common with certain reasoning and thinking models, which refuse sampling settings like temperature. If a setting seems to do nothing, the model may not accept it. Model behavior also depends heavily on which model you picked, so the same value can feel different across models.
 

--- a/docs/prompts/macros.md
+++ b/docs/prompts/macros.md
@@ -1,10 +1,10 @@
 # Prompt Macros
 
-This guide explains prompt macros in Marinara Engine. A macro is a short `{{tag}}` that Marinara replaces with a live value. The value is filled in when a prompt is built, such as your name or the current date. You will learn every built-in macro, where you can type them, and the mistakes to avoid.
+This guide explains prompt macros in Guksu Motor. A macro is a short `{{tag}}` that Guksu replaces with a live value. The value is filled in when a prompt is built, such as your name or the current date. You will learn every built-in macro, where you can type them, and the mistakes to avoid.
 
 ## What macros are and where they work
 
-A macro is literal text wrapped in double braces, like `{{user}}` or `{{char}}`. When Marinara builds the text it sends to the AI, it scans for these tags and swaps each one for its current value. There is no switch to turn macros on. Any field that supports them always resolves them.
+A macro is literal text wrapped in double braces, like `{{user}}` or `{{char}}`. When Guksu builds the text it sends to the AI, it scans for these tags and swaps each one for its current value. There is no switch to turn macros on. Any field that supports them always resolves them.
 
 Macro names are not case sensitive for built-in tags. So `{{user}}` and `{{USER}}` both work.
 
@@ -18,11 +18,11 @@ You can type macros in many places across the app:
 - Agent prompt templates.
 - The chat message box. Type `{{roll:1d20}}` in a message and it resolves before the message is sent.
 
-A macro value can contain another macro, and Marinara resolves that one too.
+A macro value can contain another macro, and Guksu resolves that one too.
 
 ## Before you start
 
-You do not need to set anything up. The built-in macros work right away, with no API key and no extra connection. An API key is the secret code that lets Marinara talk to an AI provider, but macros run inside Marinara on their own.
+You do not need to set anything up. The built-in macros work right away, with no API key and no extra connection. An API key is the secret code that lets Guksu talk to an AI provider, but macros run inside Guksu on their own.
 
 Two macro features do depend on other parts of the app:
 
@@ -79,7 +79,7 @@ You edit these fields on the **Convo** tab of the **Character Editor** and the *
 
 ## Conversation placement macros
 
-Conversation Mode automatically inserts several blocks into the prompt for you. These macros let a preset **move** a block to wherever you place the macro. When you use one, Marinara renders that block at the macro and **skips** its automatic insertion, so the content is never duplicated. Each macro has one or more aliases; every alias behaves the same.
+Conversation Mode automatically inserts several blocks into the prompt for you. These macros let a preset **move** a block to wherever you place the macro. When you use one, Guksu renders that block at the macro and **skips** its automatic insertion, so the content is never duplicated. Each macro has one or more aliases; every alias behaves the same.
 
 | Macro (and aliases) | Places |
 | --- | --- |
@@ -90,7 +90,7 @@ Conversation Mode automatically inserts several blocks into the prompt for you. 
 | `{{memories}}`, `{{memoryRecall}}` | The memory-recall block. |
 | `{{lorebook}}`, `{{lore}}` | Lorebook injections. |
 
-These only apply in Conversation Mode. In a one-character conversation, placing the participant bios yourself with `{{char_about}}` / `{{persona_about}}` (see above) works the same way: Marinara then skips its automatic participant "about me" block so the bios are not inserted twice. Group conversations keep the automatic participant block because either singular macro covers only one participant and must not hide everyone else's bio.
+These only apply in Conversation Mode. In a one-character conversation, placing the participant bios yourself with `{{char_about}}` / `{{persona_about}}` (see above) works the same way: Guksu then skips its automatic participant "about me" block so the bios are not inserted twice. Group conversations keep the automatic participant block because either singular macro covers only one participant and must not hide everyone else's bio.
 
 ## Context macros
 
@@ -110,7 +110,7 @@ The value of `{{lastGenerationType}}` is a plain label. Example values seen in t
 
 `{{gameStoryboardKeyframeCount}}` is supplied to Game Mode GM prompts, including the built-in **Storyboard Game Prompt**. It is a narrative target, not a demand for exactly that many paragraphs. The storyboard planner still returns fewer shots when a turn does not contain enough distinct visual moments.
 
-The `{{agent::TYPE}}` macro inserts the saved output of an agent (a background helper that fills in things like a scene tracker). The easiest way to add it is inside the **Preset Editor**: click **Add Section**, open the **Agent Sections** group, and pick an agent. Marinara creates a section that already contains the right `{{agent::TYPE}}` tag. This macro is resolved last, so agent text cannot inject more macros into your prompt.
+The `{{agent::TYPE}}` macro inserts the saved output of an agent (a background helper that fills in things like a scene tracker). The easiest way to add it is inside the **Preset Editor**: click **Add Section**, open the **Agent Sections** group, and pick an agent. Guksu creates a section that already contains the right `{{agent::TYPE}}` tag. This macro is resolved last, so agent text cannot inject more macros into your prompt.
 
 ## Time macros
 
@@ -179,7 +179,7 @@ Variables let one part of your prompt store a value and let a later part read it
 
 Variables resolve from left to right in one prompt build. A value set early, for example in a lorebook entry that comes first, can be read later in the same prompt.
 
-Important scope limit: these variables only live for a single reply. Marinara does not save them anywhere. When the next reply is generated, every variable starts empty again. Do not expect `{{setvar}}` to remember a value across turns.
+Important scope limit: these variables only live for a single reply. Guksu does not save them anywhere. When the next reply is generated, every variable starts empty again. Do not expect `{{setvar}}` to remember a value across turns.
 
 Any `{{NAME}}` that is not a built-in macro is treated as a preset variable and looked up by name. If no variable with that name exists, the tag is left in the text exactly as you typed it. See [Preset Variables](preset-variables.md) for how to define these.
 
@@ -201,7 +201,7 @@ These macros shape the text around them.
 
 ## Showing literal double braces
 
-There is no escape character for macros. If you want double braces to stay in the text, use a name that Marinara does not know. Any unknown `{{name}}` is left exactly as typed, as long as no preset variable shares that name. If you need a private note that never reaches the AI, use `{{// like this}}` instead.
+There is no escape character for macros. If you want double braces to stay in the text, use a name that Guksu does not know. Any unknown `{{name}}` is left exactly as typed, as long as no preset variable shares that name. If you need a private note that never reaches the AI, use `{{// like this}}` instead.
 
 ## The Macro reference and /macros
 
@@ -216,7 +216,7 @@ You can also type `/macros` in the chat box (the short form `/macro` works too).
 
 - Do not write variables inside a `{{random::...}}` block. A `{{setvar}}` inside a random option runs for every option before the choice is made, not just the chosen one.
 - Do not expect variables to persist. Values set with `{{setvar}}` reset on the next reply.
-- `{{prompt}}` is not a macro. If your whole message is `{{prompt}}`, Marinara opens the **Peek Prompt** viewer instead of sending it. See [Peek Prompt](../chats/peek-prompt.md).
+- `{{prompt}}` is not a macro. If your whole message is `{{prompt}}`, Guksu opens the **Peek Prompt** viewer instead of sending it. See [Peek Prompt](../chats/peek-prompt.md).
 - Custom Tools do not use `{{macro}}` text. Do not paste `{{roll:1d20}}` into a tool field expecting it to resolve.
 - The **Impersonate** prompt template accepts only a few placeholders, not the full macro list. Its names differ too, so a macro that works in a card may not work there.
 - Very large or deeply nested macro output is cut off silently. There is no error, so keep macro expansions reasonable.

--- a/docs/prompts/preset-variables.md
+++ b/docs/prompts/preset-variables.md
@@ -6,7 +6,7 @@ This guide explains **Preset Variables**, the small form-like choices you can bu
 
 A prompt preset is a reusable blueprint for the text sent to the AI. A preset variable adds a labeled choice to that blueprint. You give the choice a name, write a question, and list some options.
 
-Inside any prompt section you type the variable's name in double braces, like `{{tone}}`. When the AI generates a reply, Marinara Engine replaces `{{tone}}` with the option value the user picked. This lets one preset produce different behavior without editing the prompt text.
+Inside any prompt section you type the variable's name in double braces, like `{{tone}}`. When the AI generates a reply, Guksu Motor replaces `{{tone}}` with the option value the user picked. This lets one preset produce different behavior without editing the prompt text.
 
 Preset variables live inside a prompt preset, so they work in the chat modes that use prompt presets. They do not apply in Conversation mode. That mode uses a single prompt-text override instead of the section-based preset, so there is nothing for the variables to fill in. To learn about presets themselves, see [Preset Editor and Prompt Manager](presets.md).
 
@@ -35,7 +35,7 @@ You add variables while editing a preset. Follow these steps.
 
 To use the variable, type its name in braces inside any prompt section's content. For example, put `{{tone}}` in a section, then create a variable named `tone` with a **Gentle** option and a **Harsh** option. When the user picks Harsh, the section receives the harsh value.
 
-A variable must always keep at least one option. If you try to delete the last option, Marinara keeps it.
+A variable must always keep at least one option. If you try to delete the last option, Guksu keeps it.
 
 ## The Configure Preset Variables modal
 
@@ -55,7 +55,7 @@ You do not have to reopen a preset from scratch to change your answers. In the c
 
 ## The {{NAME}} catch-all
 
-Marinara resolves many built-in macros, such as `{{user}}` and `{{char}}`. After those, any leftover placeholder in the form `{{NAME}}` (letters, numbers, and underscores only) is matched against your preset variables.
+Guksu resolves many built-in macros, such as `{{user}}` and `{{char}}`. After those, any leftover placeholder in the form `{{NAME}}` (letters, numbers, and underscores only) is matched against your preset variables.
 
 If a variable with that exact name exists, the placeholder becomes the chosen value. If no variable matches, the `{{NAME}}` text is left exactly as typed. This is why an unknown placeholder shows up unchanged in the output instead of raising an error. For the full macro list, see [Prompt Macros](macros.md).
 

--- a/docs/prompts/presets.md
+++ b/docs/prompts/presets.md
@@ -1,10 +1,10 @@
 # Preset Editor and Prompt Manager
 
-This guide explains prompt presets in Marinara Engine. You will learn what they are, how to build one in the **Preset Editor**, and how to assign one to a chat. A preset controls the structure of the text that Marinara sends to the AI.
+This guide explains prompt presets in Guksu Motor. You will learn what they are, how to build one in the **Preset Editor**, and how to assign one to a chat. A preset controls the structure of the text that Guksu sends to the AI.
 
 ## What a preset is
 
-A preset is a reusable blueprint. It decides what information Marinara sends to the AI and in what order. That includes system instructions you write, the character card, your persona, the chat history, lorebook entries, and more.
+A preset is a reusable blueprint. It decides what information Guksu sends to the AI and in what order. That includes system instructions you write, the character card, your persona, the chat history, lorebook entries, and more.
 
 Presets shape the prompt for **Roleplay** and **Game** chats. **Conversation** mode works differently and uses a single prompt field. See "How Conversation and Game modes differ" below.
 
@@ -38,7 +38,7 @@ Follow these steps to make a new preset.
 
 The editor does not save on its own. Your changes are only kept after you click **Save**. If you try to leave with unsaved edits, a warning appears with **Keep editing**, **Discard**, and **Save & close** buttons.
 
-To export a preset, open it and click the export button (up-arrow icon) in the top bar. Marinara asks to save first if you have unsaved edits. To delete a preset, use the trash icon in the top bar.
+To export a preset, open it and click the export button (up-arrow icon) in the top bar. Guksu asks to save first if you have unsaved edits. To delete a preset, use the trash icon in the top bar.
 
 ## The Overview, Sections, and Prompts tabs
 
@@ -56,9 +56,9 @@ The **Overview** tab holds four fields. **Name** is the display name shown in th
 
 The **Prompts** tab holds the mode prompts.
 
-- **Conversation Mode**: a text box used as this preset's Conversation prompt. Leave it empty to use Marinara's built-in conversation prompt.
+- **Conversation Mode**: a text box used as this preset's Conversation prompt. Leave it empty to use Guksu's built-in conversation prompt.
 - **Roleplay Mode**: not editable here. Roleplay uses the assembled prompt from your **Sections**.
-- **Game Mode**: a text box used as this preset's Game prompt. Leave it empty to use Marinara's built-in game prompt.
+- **Game Mode**: a text box used as this preset's Game prompt. Leave it empty to use Guksu's built-in game prompt.
 
 ## Sections and markers
 
@@ -68,7 +68,7 @@ Click **Add Section** to open the add menu. It offers two kinds of section.
 
 A **Prompt Block** is a free-text section that you write yourself. Use it for system instructions, tone rules, or any wording you want in every prompt.
 
-A **marker** is an auto-filled section. It has no text of its own. Instead, Marinara fills it at send time with live content from your chat. The table below lists the markers.
+A **marker** is an auto-filled section. It has no text of its own. Instead, Guksu fills it at send time with live content from your chat. The table below lists the markers.
 
 | Marker | What it inserts |
 |---|---|
@@ -81,7 +81,7 @@ A **marker** is an auto-filled section. It has no text of its own. Instead, Mari
 | **Lorebook Marker (Before)** | Lorebook entries set to insert before. |
 | **Lorebook Marker (After)** | Lorebook entries set to insert after. |
 
-A section that is a marker shows a **MARKER** badge in its row. Expand it to see a note that names the marker type. You cannot type content into most markers, because Marinara generates them for you.
+A section that is a marker shows a **MARKER** badge in its row. Expand it to see a note that names the marker type. You cannot type content into most markers, because Guksu generates them for you.
 
 If your chat has active lorebooks but your preset has no lorebook marker, a warning appears. It reads: "Add a lorebook marker when this preset should receive active lorebook entries." Add a lorebook marker so those entries reach the AI. See [Lorebooks Overview](../lorebooks/overview.md).
 
@@ -156,7 +156,7 @@ Below the dropdown is a status row. It shows one of three states:
 - **Preset**: the prompt comes from the chosen preset.
 - **Custom**: you have typed a chat-local edit for this chat only.
 
-Click **Edit Prompt** to type a prompt just for this chat. The editor opens as **Edit Conversation Prompt** or **Edit Game Prompt**. If your edit matches the preset or default exactly, Marinara treats it as not customized. Once a custom edit exists, a **Reset to default prompt** button appears to clear it.
+Click **Edit Prompt** to type a prompt just for this chat. The editor opens as **Edit Conversation Prompt** or **Edit Game Prompt**. If your edit matches the preset or default exactly, Guksu treats it as not customized. Once a custom edit exists, a **Reset to default prompt** button appears to clear it.
 
 Game chats also have an **Extra instructions** box. Text there is added to the Game prompt. It has a limit of 2000 characters. A sample instruction is "Write in the style of Terry Pratchett."
 

--- a/docs/prompts/prompt-overrides.md
+++ b/docs/prompts/prompt-overrides.md
@@ -1,10 +1,10 @@
 # Prompt Overrides for Image and Video
 
-This guide covers **Prompt Overrides**, the editors that change the templates Marinara Engine uses to write prompts for image and video generation. It shows where they live, what you can edit, and how to save a custom template safely.
+This guide covers **Prompt Overrides**, the editors that change the templates Guksu Motor uses to write prompts for image and video generation. It shows where they live, what you can edit, and how to save a custom template safely.
 
 ## What Prompt Overrides are
 
-A **Prompt Override** is a reusable template for a media prompt. When Marinara generates an image or a video, it first builds a text prompt for the image or video model. Prompt Overrides let you edit those templates.
+A **Prompt Override** is a reusable template for a media prompt. When Guksu generates an image or a video, it first builds a text prompt for the image or video model. Prompt Overrides let you edit those templates.
 
 This feature is only about picture and video prompts. It does not change the text prompt sent to your chat model during a conversation or roleplay. That is a common mix-up. To change the prompt that goes to a chat model, use a Prompt Preset and Generation Parameters instead. See [Preset Editor and Prompt Manager](presets.md) and [Generation Parameters](generation-parameters.md).
 

--- a/docs/roleplay/backgrounds.md
+++ b/docs/roleplay/backgrounds.md
@@ -4,7 +4,7 @@ This guide covers the scene backdrop in Roleplay Mode: the **Background** agent 
 
 ## The scene background
 
-Roleplay Mode shows a full scene backdrop behind your messages. When the backdrop changes, Marinara cross-fades smoothly from the old image to the new one, so scene changes feel gentle instead of jumpy.
+Roleplay Mode shows a full scene backdrop behind your messages. When the backdrop changes, Guksu cross-fades smoothly from the old image to the new one, so scene changes feel gentle instead of jumpy.
 
 You do not need image generation for this to work. If you have not set up an image generation connection, the backdrop shows as a solid color. Your chat still works as normal text chat.
 
@@ -23,7 +23,7 @@ After that, the scene backdrop updates on its own as your story moves between pl
 
 ## Generate a background by hand
 
-You can also make a new backdrop yourself, without the agent. Marinara builds an image prompt from the scene (its genre, setting, current location, weather, and time) and creates a fresh backdrop.
+You can also make a new backdrop yourself, without the agent. Guksu builds an image prompt from the scene (its genre, setting, current location, weather, and time) and creates a fresh backdrop.
 
 1. Open the **Gallery** (the image icon in the chat toolbar).
 2. Click the **Background** button.
@@ -31,7 +31,7 @@ You can also make a new backdrop yourself, without the agent. Marinara builds an
 
 While it runs, you see this note: "AI background generation is running. The new background will be applied when it finishes." The new image is added to your background library and applied to the scene.
 
-Manual generation and the **Background** agent both need an image generation connection. Marinara uses the connection set for the **Background** agent first. If none is set, it falls back to the **Illustrator** agent's connection, then to your default image generation connection. If it cannot find one, generation fails with this message: "Choose an image generation connection for the Background/Illustrator agent, or mark an image generation connection as the default for agents."
+Manual generation and the **Background** agent both need an image generation connection. Guksu uses the connection set for the **Background** agent first. If none is set, it falls back to the **Illustrator** agent's connection, then to your default image generation connection. If it cannot find one, generation fails with this message: "Choose an image generation connection for the Background/Illustrator agent, or mark an image generation connection as the default for agents."
 
 Scene background generation works only in Roleplay and Game modes. It is not available in Conversation mode.
 

--- a/docs/roleplay/getting-started.md
+++ b/docs/roleplay/getting-started.md
@@ -4,7 +4,7 @@ This guide covers what Roleplay Mode is, how to start a roleplay, and what you s
 
 ## What Roleplay Mode is
 
-Roleplay Mode is one of Marinara Engine's chat modes. The others are Conversation and Game. Roleplay gives you an immersive scene view built around a story.
+Roleplay Mode is one of Guksu Motor's chat modes. The others are Conversation and Game. Roleplay gives you an immersive scene view built around a story.
 
 A roleplay scene can show a background image, character sprites, and a heads-up display of world state. A sprite is a character picture that changes with emotion. A heads-up display, or HUD, is the small strip of info widgets at the top of the chat.
 
@@ -119,11 +119,11 @@ You can set a cheaper model for agents than for chat. Many users run chat on a s
 
 **HUD widgets show the wrong value.** A tracker agent fills each widget. Open the widget panel and edit the value by hand. If values keep drifting, switch the agent connection to a stronger model. You can also lock a field so the next automatic run does not overwrite it.
 
-**Sprite expressions do not change.** Check that the character has an uploaded sprite library. Image generation is needed only when you want Marinara to create new sprites. Without sprites to show, the expression agent runs but has nothing to display. You can also set an expression by hand with the **/emote** command.
+**Sprite expressions do not change.** Check that the character has an uploaded sprite library. Image generation is needed only when you want Guksu to create new sprites. Without sprites to show, the expression agent runs but has nothing to display. You can also set an expression by hand with the **/emote** command.
 
 **The background never changes.** The **Background** agent picks from your background library. With only one or two backgrounds, it keeps picking those. Add more backgrounds so the agent has more choices. See [Roleplay Backgrounds](backgrounds.md).
 
-**A regenerated reply keeps the wrong direction.** Turn on **Debug mode** in **Settings**, under **Advanced**. Open the **Agents & Actions** menu, find the **Injections** tab, then edit or re-run the saved snippet before you regenerate. For more help, see [Troubleshooting Marinara Engine](../TROUBLESHOOTING.md).
+**A regenerated reply keeps the wrong direction.** Turn on **Debug mode** in **Settings**, under **Advanced**. Open the **Agents & Actions** menu, find the **Injections** tab, then edit or re-run the saved snippet before you regenerate. For more help, see [Troubleshooting Guksu Motor](../TROUBLESHOOTING.md).
 
 ## Related guides
 

--- a/docs/roleplay/hud-and-trackers.md
+++ b/docs/roleplay/hud-and-trackers.md
@@ -1,10 +1,10 @@
 # Roleplay HUD and Trackers
 
-This guide explains the Roleplay HUD and the small tracker widgets it shows. You will learn how to edit and lock their values, and how the larger Tracker Panel works. It applies to Roleplay Mode in Marinara Engine.
+This guide explains the Roleplay HUD and the small tracker widgets it shows. You will learn how to edit and lock their values, and how the larger Tracker Panel works. It applies to Roleplay Mode in Guksu Motor.
 
 ## What the HUD is
 
-The HUD (heads-up display) is a row of small icon widgets at the top of the chat area. Each widget shows a piece of live story state, such as the time, your stats, or who is present. Marinara keeps these values up to date for you as the story moves.
+The HUD (heads-up display) is a row of small icon widgets at the top of the chat area. Each widget shows a piece of live story state, such as the time, your stats, or who is present. Guksu keeps these values up to date for you as the story moves.
 
 The values come from tracker agents. An agent is a small AI helper that runs in the background. Each tracker agent watches the story and updates one part of the HUD after each message. You do not have to ask for it.
 

--- a/docs/roleplay/narrative-director.md
+++ b/docs/roleplay/narrative-director.md
@@ -1,6 +1,6 @@
 # Narrative Director and Secret Plot
 
-This guide explains the Narrative Director agent in Marinara Engine. It covers the Push Story button, the Natural and Random Event modes, and the hidden Secret Plot arc. These features are for Roleplay Mode.
+This guide explains the Narrative Director agent in Guksu Motor. It covers the Push Story button, the Natural and Random Event modes, and the hidden Secret Plot arc. These features are for Roleplay Mode.
 
 ## What the Narrative Director is
 

--- a/docs/roleplay/scenes.md
+++ b/docs/roleplay/scenes.md
@@ -1,6 +1,6 @@
 # Scenes: Branching a Roleplay
 
-This guide explains scenes in Marinara Engine. A scene is a short, self-contained roleplay that branches off from a Conversation chat. This guide covers how to start one, play it, and how to end, discard, fork, or convert it.
+This guide explains scenes in Guksu Motor. A scene is a short, self-contained roleplay that branches off from a Conversation chat. This guide covers how to start one, play it, and how to end, discard, fork, or convert it.
 
 ## What a scene is
 
@@ -31,7 +31,7 @@ Follow these steps:
 6. Optionally, type notes in the **Extra instructions** box to steer the scene.
 7. Click **Plan Scene**.
 
-Marinara plans the scene and opens it as a new roleplay chat. You should see the new scene appear in your chat list and open automatically, with an opening message that sets the situation. If you change your mind at the setup window, click **Cancel** and no scene is created.
+Guksu plans the scene and opens it as a new roleplay chat. You should see the new scene appear in your chat list and open automatically, with an opening message that sets the situation. If you change your mind at the setup window, click **Cancel** and no scene is created.
 
 You can also start a scene without a description. Type just the command on its own if the conversation already has enough history to build from.
 
@@ -39,7 +39,7 @@ You can also start a scene without a description. Type just the command on its o
 /scene
 ```
 
-If the conversation has no messages yet, Marinara asks you to add a description or chat first before it can plan a scene.
+If the conversation has no messages yet, Guksu asks you to add a description or chat first before it can plan a scene.
 
 A character can also ask to start a scene. When that happens, the same **Scene Prompt Setup** window opens, with a line like "[Character] wants to start a scene." Pick **POV** and **Tense** and click **Plan Scene** the same way, or click **Cancel** to decline.
 
@@ -48,7 +48,7 @@ A character can also ask to start a scene. When that happens, the same **Scene P
 While you are inside an active scene, a bar sits just above the message box. It holds the controls that decide what happens to the scene. The exact buttons you see depend on whether the scene has a linked conversation.
 
 - **Back to conversation** returns you to the Conversation chat that started the scene. It leaves the scene open and running, so you can come back to it later. This button appears only when the scene has an origin conversation.
-- **End Scene** finishes the scene and saves a summary. When you click it, the bar asks **End and save summary?** with a **Yes** and a **No** button. Click **Yes** to confirm. The button shows a **Saving...** state while it works. Marinara writes a short summary of the scene back to the origin conversation as a memory, then returns you to where that conversation left off.
+- **End Scene** finishes the scene and saves a summary. When you click it, the bar asks **End and save summary?** with a **Yes** and a **No** button. Click **Yes** to confirm. The button shows a **Saving...** state while it works. Guksu writes a short summary of the scene back to the origin conversation as a memory, then returns you to where that conversation left off.
 - **Discard** throws the scene away without saving anything. When you click it, the bar asks **Discard scene?** with **Yes** and **No** buttons. Click **Yes** to delete the scene and go back to the conversation. Nothing is written back.
 - **Convert** turns the scene into a standalone roleplay chat of its own. It is explained in its own section below, because it changes the scene permanently.
 
@@ -63,7 +63,7 @@ To use it:
 1. Hover over the message you want to branch from.
 2. Click the **Clone from here** action.
 
-Marinara creates a fresh standalone roleplay from the scene, copying the messages up to that point. Your original scene stays open and active, so this is a safe way to explore a different path. You should see a confirmation that the scene was cloned as a roleplay, and the new chat opens.
+Guksu creates a fresh standalone roleplay from the scene, copying the messages up to that point. Your original scene stays open and active, so this is a safe way to explore a different path. You should see a confirmation that the scene was cloned as a roleplay, and the new chat opens.
 
 Cloning keeps the original scene. Converting, described next, does not.
 

--- a/docs/settings/settings-overview.md
+++ b/docs/settings/settings-overview.md
@@ -1,10 +1,10 @@
 # Settings Overview
 
-This guide maps the Marinara Engine **Settings** panel: its six tabs and what each one controls. It covers the **General** tab in depth, the **Text Rules** that format your chat text, and how settings sync across your devices.
+This guide maps the Guksu Motor **Settings** panel: its six tabs and what each one controls. It covers the **General** tab in depth, the **Text Rules** that format your chat text, and how settings sync across your devices.
 
 ## The Settings panel and its six tabs
 
-Open **Settings** using the gear icon in the top bar. At the top of the panel is a **Search settings** box. Type any word (like `delete`, `streaming`, or `quotes`) and Marinara jumps you to the matching section.
+Open **Settings** using the gear icon in the top bar. At the top of the panel is a **Search settings** box. Type any word (like `delete`, `streaming`, or `quotes`) and Guksu jumps you to the matching section.
 
 The panel has six tabs. The table below shows what each tab controls.
 
@@ -24,14 +24,14 @@ Here is where to read more about each tab:
 - **Generations**: see [Style Profiles](../media/style-profiles.md) and [Scene Video](../media/scene-video.md).
 - **Addons**: see [Custom CSS Themes](../appearance/custom-css-themes.md) and [Extensions](../extending/extensions.md).
 - **Imports**: see [Importing from SillyTavern](../data/importing-from-sillytavern.md) and [Backup and Restore](../data/backup-and-restore.md).
-- **Advanced**: see the **Message Tools** section below, plus [Upgrading Marinara Engine](../UPGRADING.md), [Remote Access](../REMOTE_ACCESS.md), and [Clearing Your Data](../data/clearing-data.md).
+- **Advanced**: see the **Message Tools** section below, plus [Upgrading Guksu Motor](../UPGRADING.md), [Remote Access](../REMOTE_ACCESS.md), and [Clearing Your Data](../data/clearing-data.md).
 
 ## Settings, General tab
 
 The **General** tab holds six sections. This page owns two of them in full: **App Behavior** and **Text Rules**. The others are summarized here and covered in detail in their own guides.
 
 - **App Behavior**: language, delete safety, and show/hide toggles. Covered below.
-- **Notifications**: notification sounds plus separate browser and Android app controls. **Background Notifications** cover autonomous Conversation messages, while **Generation Completion Notifications** cover replies you start manually in Conversation, Roleplay, Visual Novel, and Game modes. Both work while Marinara remains open but unfocused, and message contents stay hidden.
+- **Notifications**: notification sounds plus separate browser and Android app controls. **Background Notifications** cover autonomous Conversation messages, while **Generation Completion Notifications** cover replies you start manually in Conversation, Roleplay, Visual Novel, and Game modes. Both work while Guksu remains open but unfocused, and message contents stay hidden.
 - **Responses**: how replies stream, save, and paginate. See [Sending and Streaming Messages](../chats/sending-and-streaming.md).
 - **Input & Editing**: message input and fast edit controls. See [Message Actions](../chats/messages.md).
 - **Text Rules**: formatting applied to chat text. Covered below.
@@ -42,7 +42,7 @@ The **General** tab holds six sections. This page owns two of them in full: **Ap
 This section is at **Settings** > **General** > **App Behavior**. It controls daily app behavior and a few show/hide toggles.
 
 - **Language**: choose the app language. Only English is available right now. The setting is saved so future translations can add more.
-- **Confirm before deleting**: on by default. When on, Marinara asks before it permanently deletes a chat, a character, or another item. Keep it on to avoid accidental deletes.
+- **Confirm before deleting**: on by default. When on, Guksu asks before it permanently deletes a chat, a character, or another item. Keep it on to avoid accidental deletes.
 - **Achievements**: on by default. When on, the Home screen shows the achievements button and unlock notices. When off, tracking stays silent. See [Achievements](../home/achievements.md).
 - **Music Player**: on by default. When on, the compact Music Player is shown. See [Music](../media/music.md).
 - **Mini Mari surprise visits**: on by default. When on, a rare Chibi Professor Mari message can appear while you scroll. Turn it off if it gets in the way.
@@ -111,19 +111,19 @@ The **Message Tools** section is at **Settings** > **Advanced** > **Message Tool
 | **Include reasoning in exports** | Adds hidden thinking to chat exports. | [Exporting and Importing Chats](../chats/export-import.md) |
 | **Debug mode** | Logs model payloads in the server console for support. | [Troubleshooting](../TROUBLESHOOTING.md) |
 
-The rest of the **Advanced** tab is covered elsewhere. See [Upgrading Marinara Engine](../UPGRADING.md) for **Updates**, [Remote Access](../REMOTE_ACCESS.md) for **Admin Access**, [Backup and Restore](../data/backup-and-restore.md) for **Backup & Export**, and [Clearing Your Data](../data/clearing-data.md) for **Danger Zone**.
+The rest of the **Advanced** tab is covered elsewhere. See [Upgrading Guksu Motor](../UPGRADING.md) for **Updates**, [Remote Access](../REMOTE_ACCESS.md) for **Admin Access**, [Backup and Restore](../data/backup-and-restore.md) for **Backup & Export**, and [Clearing Your Data](../data/clearing-data.md) for **Danger Zone**.
 
 ## How settings sync across devices
 
-Marinara stores most of your settings on the server, so they follow you between browsers and devices. This is the settings sync behavior.
+Guksu stores most of your settings on the server, so they follow you between browsers and devices. This is the settings sync behavior.
 
 Here is how it works:
 
 1. You change a setting anywhere in **Settings**.
-2. About one second later, Marinara saves the change to the server with a timestamp.
-3. When another browser opens the same Marinara server, it loads those saved settings.
+2. About one second later, Guksu saves the change to the server with a timestamp.
+3. When another browser opens the same Guksu server, it loads those saved settings.
 
-Each device keeps the newer copy. This is last-write-wins by timestamp. Watch out for one result of this rule. If you open Marinara on a second device, its copy can quietly overwrite a setting you just changed on the first device. Give the app a moment to sync before you switch devices.
+Each device keeps the newer copy. This is last-write-wins by timestamp. Watch out for one result of this rule. If you open Guksu on a second device, its copy can quietly overwrite a setting you just changed on the first device. Give the app a moment to sync before you switch devices.
 
 Two settings never sync. They stay per-browser on the device where you set them:
 
@@ -141,6 +141,6 @@ If the server is unreachable, the app keeps working from your local settings and
 - [Sending and Streaming Messages](../chats/sending-and-streaming.md)
 - [Exporting and Importing Chats](../chats/export-import.md)
 - [Where Your Data Is Stored](../data/where-data-is-stored.md)
-- [Upgrading Marinara Engine](../UPGRADING.md)
+- [Upgrading Guksu Motor](../UPGRADING.md)
 - [Troubleshooting](../TROUBLESHOOTING.md)
 - [Achievements](../home/achievements.md)

--- a/packages/client/index.html
+++ b/packages/client/index.html
@@ -6,13 +6,13 @@
       name="viewport"
       content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no, viewport-fit=cover"
     />
-    <meta name="description" content="Marinara Engine — RPG chat and roleplay engine" />
+    <meta name="description" content="Guksu Motor — RPG chat and roleplay engine" />
     <meta name="theme-color" content="#0a0a0f" />
     <meta name="color-scheme" content="dark light" />
     <meta name="apple-mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-status-bar-style" content="black" />
     <meta name="mobile-web-app-capable" content="yes" />
-    <title>Marinara Engine</title>
+    <title>Guksu Motor</title>
     <style>
       /* Sets WKWebView native backing color for iOS safe-area zones.
          Literal opaque value required — CSS vars not resolved for backing.

--- a/packages/client/public/manifest.json
+++ b/packages/client/public/manifest.json
@@ -1,6 +1,6 @@
 {
-  "name": "Marinara Engine",
-  "short_name": "Marinara",
+  "name": "Guksu Motor",
+  "short_name": "Guksu",
   "description": "AI Chat & Roleplay Frontend — Conversation, Roleplay, Game",
   "version": "2.3.3",
   "start_url": "/",

--- a/packages/client/src/App.tsx
+++ b/packages/client/src/App.tsx
@@ -159,7 +159,7 @@ export class AppRecoveryBoundary extends Component<{ children: ReactNode }, { er
       >
         <div className="w-full max-w-lg rounded-xl border border-[var(--marinara-chat-chrome-accent)] bg-[var(--marinara-chat-chrome-panel-bg)] p-5 shadow-2xl ring-1 ring-[var(--marinara-chat-chrome-focus-ring)]">
           <h1 className="text-lg font-semibold text-[var(--marinara-chat-chrome-panel-title)]">
-            Marinara hit a recoverable UI error.
+            Guksu hit a recoverable UI error.
           </h1>
           <p className="mt-2 text-sm text-[var(--marinara-chat-chrome-panel-muted)]">
             The app shell crashed while rendering. Reload first; reset local UI state only if the same screen keeps

--- a/packages/client/src/components/agents/AgentCatalogView.tsx
+++ b/packages/client/src/components/agents/AgentCatalogView.tsx
@@ -102,10 +102,10 @@ function formatBytes(bytes: number) {
 function catalogErrorDescription(error: unknown) {
   const offlineSuffix = "Installed agents remain available offline.";
   if (error instanceof ApiError) {
-    return `Marinara Engine returned HTTP ${error.status}: ${error.message}. ${offlineSuffix}`;
+    return `Guksu Motor returned HTTP ${error.status}: ${error.message}. ${offlineSuffix}`;
   }
   if (error instanceof Error && error.message) return `${error.message}. ${offlineSuffix}`;
-  return `Marinara Engine could not load the official catalog. ${offlineSuffix}`;
+  return `Guksu Motor could not load the official catalog. ${offlineSuffix}`;
 }
 
 function kindLabel(kind: CapabilityCatalogPackage["manifest"]["kind"][number]) {
@@ -196,7 +196,7 @@ export function AgentCatalogView() {
       const result = await install.mutateAsync(entry.manifest.id);
       toast.success(
         result.status === "restart-required"
-          ? "Agent installed. Restart Marinara Engine to finish setup."
+          ? "Agent installed. Restart Guksu Motor to finish setup."
           : "Agent installed. It is ready to use.",
       );
     } catch (error) {
@@ -217,7 +217,7 @@ export function AgentCatalogView() {
       const result = await uninstall.mutateAsync(entry.manifest.id);
       toast.success(
         result.restartRequired
-          ? `${entry.manifest.name} uninstalled. Restart Marinara Engine to finish removal.`
+          ? `${entry.manifest.name} uninstalled. Restart Guksu Motor to finish removal.`
           : `${entry.manifest.name} uninstalled.`,
       );
     } catch (error) {
@@ -237,7 +237,7 @@ export function AgentCatalogView() {
       if (result.failures.length === 0) {
         toast.success(
           result.restartRequired
-            ? `${result.succeeded.length} agents installed. Restart Marinara Engine to finish setup.`
+            ? `${result.succeeded.length} agents installed. Restart Guksu Motor to finish setup.`
             : `${result.succeeded.length} agents installed and ready to use.`,
         );
       } else {
@@ -277,7 +277,7 @@ export function AgentCatalogView() {
       if (result.failures.length === 0) {
         toast.success(
           result.restartRequired
-            ? `${result.succeeded.length} agents uninstalled. Restart Marinara Engine to finish removal.`
+            ? `${result.succeeded.length} agents uninstalled. Restart Guksu Motor to finish removal.`
             : `${result.succeeded.length} agents uninstalled.`,
         );
       } else {
@@ -401,7 +401,7 @@ export function AgentCatalogView() {
                 aria-live="polite"
               >
                 {bulkProgress.action === "install" ? "Installing" : "Uninstalling"} agent {bulkProgress.completed} of{" "}
-                {bulkProgress.total}. Keep Marinara Engine open until this finishes.
+                {bulkProgress.total}. Keep Guksu Motor open until this finishes.
               </p>
             )}
           </div>
@@ -583,7 +583,7 @@ export function AgentCatalogView() {
                 ) : (
                   <span>Agent v{selected.manifest.version}</span>
                 )}
-                <span>Marinara Engine v{selected.manifest.engine.min}+</span>
+                <span>Guksu Motor v{selected.manifest.engine.min}+</span>
               </div>
 
               <section>

--- a/packages/client/src/components/agents/AgentEditor.tsx
+++ b/packages/client/src/components/agents/AgentEditor.tsx
@@ -1694,7 +1694,7 @@ export function AgentEditor() {
             <FieldGroup
               label="Result Type"
               icon={<FileText size="0.875rem" className="text-[var(--primary)]" />}
-              help="Controls how Marinara interprets this custom agent's output. Some result types require the matching ability toggle above."
+              help="Controls how Guksu interprets this custom agent's output. Some result types require the matching ability toggle above."
             >
               <div className="grid grid-cols-1 gap-2 sm:grid-cols-2 lg:grid-cols-3">
                 {CUSTOM_AGENT_RESULT_TYPE_OPTIONS.map((option) => {
@@ -2759,7 +2759,7 @@ export function AgentEditor() {
                     {spotifyPasteOpen && (
                       <div className="space-y-2 pt-1">
                         <p className="text-white/40 leading-relaxed">
-                          If you&apos;re running Marinara on a different machine, the popup probably failed to load
+                          If you&apos;re running Guksu on a different machine, the popup probably failed to load
                           (Spotify only allows <code className="text-white/50">127.0.0.1</code> or HTTPS callbacks).
                           Copy the full URL from the popup&apos;s address bar and paste it here:
                         </p>
@@ -2869,7 +2869,7 @@ export function AgentEditor() {
                   </p>
                   <p className="text-[0.625rem] text-white/30 leading-relaxed">
                     Spotify only accepts <code className="text-white/40">https://</code> redirect URIs or loopback (
-                    <code className="text-white/40">http://127.0.0.1</code>). If you&apos;re running Marinara on another
+                    <code className="text-white/40">http://127.0.0.1</code>). If you&apos;re running Guksu on another
                     machine over plain HTTP, register the loopback URI anyway and use the paste-back fallback that
                     appears under the Connect button — or set{" "}
                     <code className="text-white/40">SPOTIFY_REDIRECT_URI</code> to your HTTPS URL.
@@ -3083,7 +3083,7 @@ export function AgentEditor() {
                       </button>
                     </div>
                     <p className="mt-2 text-[0.625rem] leading-relaxed text-white/40">
-                      The folder picker opens on the device running Marinara&apos;s server. Custom mode will list and
+                      The folder picker opens on the device running Guksu&apos;s server. Custom mode will list and
                       play supported audio files from that folder. On devices without a folder picker, paste the path
                       here.
                     </p>

--- a/packages/client/src/components/agents/ToolEditor.tsx
+++ b/packages/client/src/components/agents/ToolEditor.tsx
@@ -42,7 +42,7 @@ const EXEC_TYPES = [
 ] as const;
 
 const SCRIPT_TOOLS_DISABLED_MESSAGE =
-  "Script tools are disabled. Set CUSTOM_TOOL_SCRIPT_ENABLED=true in your .env and restart Marinara only for trusted in-process script tools.";
+  "Script tools are disabled. Set CUSTOM_TOOL_SCRIPT_ENABLED=true in your .env and restart Guksu only for trusted in-process script tools.";
 
 // ═══════════════════════════════════════════════
 //  Main Editor
@@ -576,7 +576,7 @@ export function ToolEditor() {
                   <div className="font-medium">Script tools are disabled on this server.</div>
                   <div className="mt-1 text-amber-100/80">
                     Set <code className="rounded bg-black/20 px-1">CUSTOM_TOOL_SCRIPT_ENABLED=true</code> in{" "}
-                    <code className="rounded bg-black/20 px-1">.env</code> and restart Marinara only for trusted
+                    <code className="rounded bg-black/20 px-1">.env</code> and restart Guksu only for trusted
                     in-process Script tools.
                   </div>
                 </div>
@@ -586,7 +586,7 @@ export function ToolEditor() {
           </FieldGroup>
 
           <FieldGroup
-            label="Hidden Marinara context"
+            label="Hidden Guksu context"
             icon={<KeyRound size="0.875rem" className="text-[var(--primary)]" />}
             help="Adds a separate server-provided context object to webhook and script executions. The AI does not see these fields as tool parameters."
           >

--- a/packages/client/src/components/bot-browser/BotBrowserView.tsx
+++ b/packages/client/src/components/bot-browser/BotBrowserView.tsx
@@ -46,7 +46,7 @@ type TagImportMode = "all" | "none" | "existing";
 const TAG_IMPORT_OPTIONS: Array<{ value: TagImportMode; label: string; description: string }> = [
   { value: "all", label: "All tags", description: "Keep source tags." },
   { value: "none", label: "No tags", description: "Skip source tags." },
-  { value: "existing", label: "Existing only", description: "Keep tags already in Marinara." },
+  { value: "existing", label: "Existing only", description: "Keep tags already in Guksu." },
 ];
 
 const SOURCE_MENU_MIN_WIDTH = 180;

--- a/packages/client/src/components/characters/CharacterEditor.tsx
+++ b/packages/client/src/components/characters/CharacterEditor.tsx
@@ -145,7 +145,7 @@ const CHARACTER_CARD_SECTIONS = [
 ] as const;
 
 const CHARACTER_METADATA_HELP =
-  "Use metadata for identity, sharing, and library organization. The avatar identifies the character throughout Marinara, name is used as {{char}}, creator/version help track authorship and revisions, tags make the card searchable, talkativeness affects group chat response frequency, and creator notes stay private.";
+  "Use metadata for identity, sharing, and library organization. The avatar identifies the character throughout Guksu, name is used as {{char}}, creator/version help track authorship and revisions, tags make the card searchable, talkativeness affects group chat response frequency, and creator notes stay private.";
 
 const CHARACTER_CARD_HELP =
   "Write the fields that define how the model sees and plays the character. Description, personality, backstory, appearance, scenario, and dialogue are kept together here so you can treat the card as one writing document.";
@@ -184,7 +184,7 @@ const CHARACTER_COLORS_HELP =
   "Name color is applied to the character's display name in chat. Gradients use CSS linear-gradient. Dialogue color applies to text inside dialogue quotation marks and can optionally be bolded from Settings. Box color sets the background color of the character's message bubble in roleplay mode. Leave any field empty to use the default theme colors.";
 
 const CHARACTER_LOREBOOK_HELP =
-  "Attach lorebook/world-info entries to this character. Entries trigger from keywords during conversation; embedded card lorebooks can be imported into Marinara as linked lorebooks for deeper editing.";
+  "Attach lorebook/world-info entries to this character. Entries trigger from keywords during conversation; embedded card lorebooks can be imported into Guksu as linked lorebooks for deeper editing.";
 
 interface ParsedCharacter {
   id: string;
@@ -891,8 +891,8 @@ export function CharacterEditor() {
       <ExportFormatDialog
         open={exportDialogOpen}
         title="Export Character"
-        description="Native keeps Marinara metadata, sprites, gallery images, and attached lorebooks. Compatible exports direct Chara Card V2 JSON for other platforms."
-        compatibleDescription="Exports direct Chara Card V2 JSON without the Marinara wrapper."
+        description="Native keeps Guksu metadata, sprites, gallery images, and attached lorebooks. Compatible exports direct Chara Card V2 JSON for other platforms."
+        compatibleDescription="Exports direct Chara Card V2 JSON without the Guksu wrapper."
         showPngOption
         onClose={() => setExportDialogOpen(false)}
         onSelect={(format: ExportFormatChoice) => {
@@ -2128,7 +2128,7 @@ function characterGalleryClipDeleteMessage(clip: CharacterGalleryClip) {
   if (clip.source === "conversation-call") {
     return "Delete this call clip? The standard slot will stay available for regeneration or upload.";
   }
-  return "Delete this clip everywhere it appears in Marinara? This cannot be undone.";
+  return "Delete this clip everywhere it appears in Guksu? This cannot be undone.";
 }
 
 function isCharacterCallVideoClip(clip: CharacterGalleryClip) {
@@ -3391,7 +3391,7 @@ function SpritesTab({
     if (
       !(await showConfirmDialog({
         title: "Clean Sprite Backgrounds",
-        message: `Clean backgrounds on ${visibleSprites.length} saved ${modeLabel} sprite${visibleSprites.length === 1 ? "" : "s"} at strength ${savedCleanupStrength}? Marinara will keep a restore point in case the cleanup looks wrong.`,
+        message: `Clean backgrounds on ${visibleSprites.length} saved ${modeLabel} sprite${visibleSprites.length === 1 ? "" : "s"} at strength ${savedCleanupStrength}? Guksu will keep a restore point in case the cleanup looks wrong.`,
         confirmLabel: "Clean",
       }))
     ) {
@@ -4402,7 +4402,7 @@ function LorebookTab({
           <span className="text-[0.6875rem] text-[var(--muted-foreground)]">
             {linkedLorebookId
               ? "Edit opens the lorebook editor; changes sync back into the card's embedded copy."
-              : "Import bakes this embedded lorebook into Marinara as an editable linked lorebook."}
+              : "Import bakes this embedded lorebook into Guksu as an editable linked lorebook."}
           </span>
         </div>
       )}

--- a/packages/client/src/components/chat/ChatArea.tsx
+++ b/packages/client/src/components/chat/ChatArea.tsx
@@ -2896,7 +2896,7 @@ export function ChatArea() {
                   >
                     <img
                       src={showEmptyStateEffects ? "/logo-splash.gif" : "/logo.png"}
-                      alt="Marinara Engine"
+                      alt="Guksu Motor"
                       width={80}
                       height={80}
                       decoding="async"
@@ -2915,7 +2915,7 @@ export function ChatArea() {
                       isPageActive && "mari-logo-gradient-text--active",
                     )}
                   >
-                    Marinara Engine
+                    Guksu Motor
                   </h3>
                   <p className="mari-chrome-text-muted mt-0.5 text-[0.625rem] tracking-wide opacity-65">
                     v{APP_VERSION}
@@ -2966,6 +2966,7 @@ export function ChatArea() {
                       >
                         Marinara
                       </a>
+                      , Fork by The Bird Internet Company
                     </span>
                     <span>
                       Partnered with{" "}

--- a/packages/client/src/components/chat/ChatSettingsDrawer.tsx
+++ b/packages/client/src/components/chat/ChatSettingsDrawer.tsx
@@ -7419,7 +7419,7 @@ export function ChatSettingsDrawer({
                               ? "Roleplay DJ queues several fitting tracks when it changes music."
                               : musicPlayerSource === "youtube"
                                 ? "YouTube mode uses the Music DJ agent's YouTube connection and embedded player."
-                                : "Custom mode picks from local Game Assets music and plays it in Marinara Engine."}
+                                : "Custom mode picks from local Game Assets music and plays it in Guksu Motor."}
                           </p>
                         </AgentSettingsCard>
                       )}
@@ -9175,7 +9175,7 @@ function MemoryRecallMemoriesModal({
 
         {!memoriesQuery.isLoading && !memoriesQuery.error && memories.length === 0 && (
           <div className="rounded-xl bg-[var(--secondary)]/60 px-4 py-8 text-center text-xs text-[var(--muted-foreground)]">
-            No recall memories have been created for this chat yet. Marinara creates them after generation in groups of
+            No recall memories have been created for this chat yet. Guksu creates them after generation in groups of
             5 messages.
           </div>
         )}

--- a/packages/client/src/components/chat/HomeFaq.tsx
+++ b/packages/client/src/components/chat/HomeFaq.tsx
@@ -34,7 +34,7 @@ interface HomeFaqProps {
 const QUICK_FIXES = [
   "Raise max output tokens if agents, trackers, or Lorebook Keeper keep failing or returning broken JSON.",
   "Update before digging too deep. If you installed from Git, use the updater or the Advanced settings update check.",
-  "If the installer or startup scripts vanished, check antivirus quarantine first and whitelist the Marinara folder.",
+  "If the installer or startup scripts vanished, check antivirus quarantine first and whitelist the Guksu folder.",
   "If Game Mode setup keeps failing, switch to a stronger model before changing prompts or presets.",
 ];
 
@@ -42,13 +42,13 @@ const HOME_FAQ_ITEMS: HomeFaqItem[] = [
   {
     id: "connect-model",
     category: "Top Issue",
-    question: "How do I connect Marinara to a model?",
+    question: "How do I connect Guksu to a model?",
     answer: "Create a connection first, test it, then select it for the chat before you send a message.",
     bullets: [
       "Open Connections from the top bar, create a new connection, choose your provider, then fill in the API key, base URL if needed, and model name.",
       "Use Test Connection before saving. If the test fails, check the key, provider route, base URL, and model spelling before changing chat settings.",
       "After saving, pick that connection from the chains icon on the left side of the chat input, or set it in Chat Settings for that chat.",
-      "For local models, make sure the local server or Marinara Local Model sidecar is running first. The bundled Local Model is best for helpers and trackers, not main roleplay generation.",
+      "For local models, make sure the local server or Guksu Local Model sidecar is running first. The bundled Local Model is best for helpers and trackers, not main roleplay generation.",
     ],
   },
   {
@@ -80,7 +80,7 @@ const HOME_FAQ_ITEMS: HomeFaqItem[] = [
     category: "Top Issue",
     question: "I saw '[sidecar] Startup with max GPU offload failed, retrying with CPU fallback'. Is that normal?",
     answer:
-      "Usually yes. Marinara's local sidecar is meant to live on CPU and RAM so your main RP model can keep the GPU and VRAM.",
+      "Usually yes. Guksu's local sidecar is meant to live on CPU and RAM so your main RP model can keep the GPU and VRAM.",
     bullets: [
       "A fallback message does not automatically mean anything is broken.",
       "The sidecar is there for helpers and utility tasks, not to compete with your main model for VRAM.",
@@ -92,7 +92,7 @@ const HOME_FAQ_ITEMS: HomeFaqItem[] = [
     category: "Setup",
     question: "Where can I find documentation?",
     answer:
-      "Marinara ships full guides with every install: installation, configuration, troubleshooting, macros, extensions, Game Mode, and more. You can read them without leaving the app.",
+      "Guksu ships full guides with every install: installation, configuration, troubleshooting, macros, extensions, Game Mode, and more. You can read them without leaving the app.",
     bullets: [
       "Use the Open Documentation button below, or the Documentation button at the bottom of the home page, to browse every guide in-app.",
       "The same guides live on disk as regular markdown files, at the folder path shown below.",
@@ -102,10 +102,10 @@ const HOME_FAQ_ITEMS: HomeFaqItem[] = [
   {
     id: "antivirus-installer",
     category: "Setup",
-    question: "My antivirus flagged the installer or deleted files. Is Marinara safe?",
+    question: "My antivirus flagged the installer or deleted files. Is Guksu safe?",
     answer: "This is a very common false-positive path for installers and batch files that spawn local services.",
     bullets: [
-      "Add the Marinara folder to your antivirus exclusions before reinstalling or restoring files.",
+      "Add the Guksu folder to your antivirus exclusions before reinstalling or restoring files.",
       "Bitdefender and Windows Defender are the most common sources of quarantines here.",
       "Restoring the quarantined files and rerunning usually fixes the issue.",
       "If you want a second opinion, compare the release files against a VirusTotal report rather than trusting a single AV popup.",
@@ -138,9 +138,9 @@ const HOME_FAQ_ITEMS: HomeFaqItem[] = [
     id: "android-apk-termux",
     category: "Setup",
     question: "Is the Android APK standalone?",
-    answer: "No. The APK is only a WebView shell for Marinara Engine running locally in Termux.",
+    answer: "No. The APK is only a WebView shell for Guksu Motor running locally in Termux.",
     bullets: [
-      "Use Install / Start Marinara in the APK, or follow the Android Termux guide so Termux creates the Marinara-Engine folder before running ./start-termux.sh.",
+      "Use Install / Start Guksu in the APK, or follow the Android Termux guide so Termux creates the Marinara-Engine folder before running ./start-termux.sh.",
       "The APK opens the same-device local server at 127.0.0.1, so it cannot work if Termux is closed.",
       "If it stays on the connection screen, go back to Termux and start the server.",
     ],
@@ -152,14 +152,14 @@ const HOME_FAQ_ITEMS: HomeFaqItem[] = [
     answer: "Your system usually just does not have pnpm available yet.",
     bullets: [
       "Install pnpm globally with npm install -g pnpm, or use the EXE installer if you want the guided path.",
-      "On Android or Termux, a long pause at Corepack alignment is a recurring pain point rather than a special Marinara-only error.",
+      "On Android or Termux, a long pause at Corepack alignment is a recurring pain point rather than a special Guksu-only error.",
       "If Termux hangs specifically on 'Aligning pnpm via Corepack', let it finish before assuming it is dead.",
     ],
   },
   {
     id: "google-cloud-credit",
     category: "Connections",
-    question: "Can I use Google Cloud's free credit with Marinara?",
+    question: "Can I use Google Cloud's free credit with Guksu?",
     answer: "Usually yes, but not every Google route behaves the same.",
     bullets: [
       "Newer AI Studio API accounts have tighter limitations, so Vertex is the safer route.",
@@ -180,9 +180,9 @@ const HOME_FAQ_ITEMS: HomeFaqItem[] = [
   {
     id: "unknown-model-parameters",
     category: "Connections",
-    question: "My custom or self-hosted model is not listed. Which parameters will Marinara send?",
+    question: "My custom or self-hosted model is not listed. Which parameters will Guksu send?",
     answer:
-      "For unknown models, Marinara avoids guessing provider-specific parameters and only sends the custom parameters you define.",
+      "For unknown models, Guksu avoids guessing provider-specific parameters and only sends the custom parameters you define.",
     bullets: [
       "Use Custom Parameters on the connection when your runtime expects special flags.",
       "Known model profiles still get their supported defaults, but unknown model IDs stay conservative to avoid rejected requests.",
@@ -195,7 +195,7 @@ const HOME_FAQ_ITEMS: HomeFaqItem[] = [
     answer: "Yes. Set the context and output overrides to match what your runtime actually supports.",
     bullets: [
       "Use the connection overrides or Chat Settings Advanced Parameters instead of relying on a hard built-in ceiling.",
-      "If the backend or model loader only exposes a smaller window, Marinara cannot make that runtime accept more context.",
+      "If the backend or model loader only exposes a smaller window, Guksu cannot make that runtime accept more context.",
     ],
   },
   {
@@ -366,7 +366,7 @@ const HOME_FAQ_ITEMS: HomeFaqItem[] = [
     id: "comfyui-illustrator-setup",
     category: "Images",
     question: "How do I get ComfyUI or Illustrator working?",
-    answer: "The workflow template has to expose the placeholders Marinara expects.",
+    answer: "The workflow template has to expose the placeholders Guksu expects.",
     bullets: [
       "Use %prompt%, %width%, %height%, %negative_prompt%, and %seed% in the workflow or request template.",
       "Use %reference_image_01% through %reference_image_04% or %reference_image_name_01% through %reference_image_name_04% for multiple ComfyUI reference slots.",
@@ -432,7 +432,7 @@ const HOME_FAQ_ITEMS: HomeFaqItem[] = [
     id: "game-party-members",
     category: "Game Mode",
     question: "Can I add new party members mid-game?",
-    answer: "Yes. Marinara can recruit party members during an active game now.",
+    answer: "Yes. Guksu can recruit party members during an active game now.",
     bullets: [
       "If some portraits or tracker details lag behind after recruiting someone new, refresh or regenerate the related asset rather than assuming the recruit failed.",
     ],
@@ -468,7 +468,7 @@ const HOME_FAQ_ITEMS: HomeFaqItem[] = [
     category: "Misc",
     question: "Is there built-in content filtering?",
     answer:
-      "Not as a separate Marinara safety layer. Filtering behavior mostly depends on the model or provider you connect.",
+      "Not as a separate Guksu safety layer. Filtering behavior mostly depends on the model or provider you connect.",
   },
   {
     id: "shared-gpu",
@@ -484,12 +484,12 @@ const HOME_FAQ_ITEMS: HomeFaqItem[] = [
     category: "Misc",
     question: "Is there a mobile app?",
     answer:
-      "Not as a standalone app yet. You can install Marinara as a PWA from the browser on phones and tablets while the server runs on your computer, Docker host, or Termux device.",
+      "Not as a standalone app yet. You can install Guksu as a PWA from the browser on phones and tablets while the server runs on your computer, Docker host, or Termux device.",
   },
   {
     id: "tts-support",
     category: "Misc",
-    question: "Does Marinara support TTS?",
+    question: "Does Guksu support TTS?",
     answer: "Yes. There is built-in support for OpenAI-compatible TTS providers now.",
     bullets: [
       "Set it up from the Connections area and the TTS settings card.",
@@ -560,7 +560,7 @@ function FaqDocsAccess({ compact }: { compact?: boolean }) {
       >
         <p className="text-[var(--muted-foreground)]/70">On disk at:</p>
         <code className="block break-all text-[var(--foreground)]/85">
-          {index ? index.root : "the docs folder inside your Marinara install folder"}
+          {index ? index.root : "the docs folder inside your Guksu install folder"}
         </code>
       </div>
       <button

--- a/packages/client/src/components/chat/HomeProfessorMariChat.tsx
+++ b/packages/client/src/components/chat/HomeProfessorMariChat.tsx
@@ -91,7 +91,7 @@ const PROFESSOR_MARI_ERROR_TOAST_DURATION_MS = 120_000;
 const PROFESSOR_MARI_NO_CONNECTION_TOAST =
   "You haven't set up a connection yet! Click the link icon beside the paperclip to select one.";
 const MARI_WELCOME =
-  "Howdy, welcome to Marinara Engine!\n\nFeeling a little lost? It is not a skill issue yet, I am here to help! Ask me about the app, your setup, or what to do next.\n\nNeed something made or changed? I can create character cards, personas, lorebooks, chats, and presets, and I can make reversible local workspace changes with a Keep/Restore review. Select a connection via the link icon beside the paperclip first and then ask away!";
+  "Howdy, welcome to Guksu Motor!\n\nFeeling a little lost? It is not a skill issue yet, I am here to help! Ask me about the app, your setup, or what to do next.\n\nNeed something made or changed? I can create character cards, personas, lorebooks, chats, and presets, and I can make reversible local workspace changes with a Keep/Restore review. Select a connection via the link icon beside the paperclip first and then ask away!";
 const NEW_SKILL_CONTENT = `# Custom Professor Mari Skill
 
 Use this skill when the request matches a workflow you want Professor Mari to follow.

--- a/packages/client/src/components/connections/ConnectionEditor.tsx
+++ b/packages/client/src/components/connections/ConnectionEditor.tsx
@@ -1291,7 +1291,7 @@ export function ConnectionEditor() {
                 <AlertCircle size="0.75rem" className="mt-px shrink-0" />
                 <span>
                   Routes chat through your local <strong>Claude Code</strong> install so it bills against your Anthropic{" "}
-                  <strong>Pro / Max</strong> subscription instead of an API key. Prerequisites on the Marinara host:
+                  <strong>Pro / Max</strong> subscription instead of an API key. Prerequisites on the Guksu host:
                 </span>
               </p>
               <ol className="mt-1.5 ml-4 list-decimal space-y-0.5 text-[0.625rem] text-[var(--muted-foreground)]">
@@ -1318,7 +1318,7 @@ export function ConnectionEditor() {
                 <AlertCircle size="0.75rem" className="mt-px shrink-0" />
                 <span>
                   Routes chat through your local <strong>Codex ChatGPT</strong> login so it uses your ChatGPT account
-                  instead of an OpenAI API key. Prerequisites on the Marinara host:
+                  instead of an OpenAI API key. Prerequisites on the Guksu host:
                 </span>
               </p>
               <ol className="mt-1.5 ml-4 list-decimal space-y-0.5 text-[0.625rem] text-[var(--muted-foreground)]">
@@ -1331,7 +1331,7 @@ export function ConnectionEditor() {
                 <li>API Key and Base URL are not required for this provider.</li>
               </ol>
               <p className="mt-1.5 text-[0.625rem] text-[var(--muted-foreground)]">
-                Marinara reads the local Codex auth file and refreshes the ChatGPT session when possible. Embeddings are
+                Guksu reads the local Codex auth file and refreshes the ChatGPT session when possible. Embeddings are
                 not available on this provider; configure a separate connection for embedding work.
               </p>
             </div>
@@ -1345,7 +1345,7 @@ export function ConnectionEditor() {
                 <span>
                   Routes chat through your local <strong>Grok CLI</strong> install so it uses your signed-in{" "}
                   <strong>SuperGrok / X Premium+</strong> account instead of an xAI API key. Prerequisites on the
-                  Marinara host:
+                  Guksu host:
                 </span>
               </p>
               <ol className="mt-1.5 ml-4 list-decimal space-y-0.5 text-[0.625rem] text-[var(--muted-foreground)]">
@@ -1361,7 +1361,7 @@ export function ConnectionEditor() {
                 <li>API Key and Base URL are not required for this provider.</li>
               </ol>
               <p className="mt-1.5 text-[0.625rem] text-[var(--muted-foreground)]">
-                Marinara runs <code className="rounded bg-[var(--secondary)] px-1">grok</code> headlessly with Grok-side
+                Guksu runs <code className="rounded bg-[var(--secondary)] px-1">grok</code> headlessly with Grok-side
                 tools, memory, web search, plans, and subagents disabled. Embeddings are not available on this provider;
                 configure a separate connection for embedding work. The safest roleplay model is usually{" "}
                 <code className="rounded bg-[var(--secondary)] px-1">grok-composer-2.5-fast</code>; leave the model
@@ -1426,7 +1426,7 @@ export function ConnectionEditor() {
               <FieldGroup
                 label="API Key"
                 icon={<Key size="0.875rem" className="text-sky-400" />}
-                help="Your authentication key from the AI provider. You can get one from their website. It's like a password that lets Marinara talk to the AI service."
+                help="Your authentication key from the AI provider. You can get one from their website. It's like a password that lets Guksu talk to the AI service."
               >
                 <input
                   value={localApiKey}
@@ -1869,7 +1869,7 @@ export function ConnectionEditor() {
                 icon={<Zap size="0.875rem" className="text-sky-400" />}
                 help={
                   selectedImageService === "runpod_comfyui"
-                    ? "Paste your ComfyUI workflow JSON (API format). RunPod needs the full workflow to execute; the endpoint sends this workflow to your serverless endpoint. Use placeholders like %prompt%, %seed%, %width%, %height%, %reference_image%, and %reference_image_01% through %reference_image_04% to let Marinara inject generation parameters."
+                    ? "Paste your ComfyUI workflow JSON (API format). RunPod needs the full workflow to execute; the endpoint sends this workflow to your serverless endpoint. Use placeholders like %prompt%, %seed%, %width%, %height%, %reference_image%, and %reference_image_01% through %reference_image_04% to let Guksu inject generation parameters."
                     : "Paste a custom ComfyUI workflow JSON (API format). Use placeholders like %prompt%, %negative_prompt%, %width%, %height%, %seed%, %model%, %steps%, %cfg%, %sampler%, %scheduler%, and %denoise%. For reference images, use %reference_image% / %reference_image_01% through %reference_image_04% to inject base64 strings, or %reference_image_name% / %reference_image_name_01% through %reference_image_name_04% to upload images to ComfyUI's input directory and inject filenames for LoadImage nodes. Leave empty to use the built-in default txt2img workflow."
                 }
               >
@@ -2035,7 +2035,7 @@ export function ConnectionEditor() {
               icon={
                 <SlidersHorizontal size="0.875rem" className="text-[var(--marinara-chat-chrome-button-text-active)]" />
               }
-              help="How many agent LLM requests Marinara may run at once for this connection. Higher values can speed up agent-heavy chats on providers that tolerate parallel calls."
+              help="How many agent LLM requests Guksu may run at once for this connection. Higher values can speed up agent-heavy chats on providers that tolerate parallel calls."
             >
               <div className="flex items-center gap-3">
                 <DraftNumberInput
@@ -2086,7 +2086,7 @@ export function ConnectionEditor() {
             <FieldGroup
               label="Prompt Preset Override"
               icon={<FileText size="0.875rem" className="mari-chrome-accent-icon mari-accent-animated" />}
-              help="Optional. When roleplay chats use this connection, Marinara assembles this prompt preset instead of the chat's selected prompt preset. Conversation and game mode keep their built-in prompt flows."
+              help="Optional. When roleplay chats use this connection, Guksu assembles this prompt preset instead of the chat's selected prompt preset. Conversation and game mode keep their built-in prompt flows."
             >
               <select
                 value={localPromptPresetId}
@@ -2104,7 +2104,7 @@ export function ConnectionEditor() {
                 ))}
               </select>
               <p className="mt-1 text-[0.625rem] text-[var(--muted-foreground)]">
-                Use this for models that need a different prompt structure. If this preset has variables, Marinara uses
+                Use this for models that need a different prompt structure. If this preset has variables, Guksu uses
                 the preset&apos;s saved defaults unless the chat already uses the same preset.
               </p>
             </FieldGroup>
@@ -2232,7 +2232,7 @@ export function ConnectionEditor() {
                     );
                     markDirty();
                   }}
-                  description="Uses temporary public links when Seedance needs first/last-frame references and cannot fetch local Marinara URLs."
+                  description="Uses temporary public links when Seedance needs first/last-frame references and cannot fetch local Guksu URLs."
                   className="p-1"
                 />
                 {localVideoDefaults.seedance.temporaryPublicReferenceUploadEnabled && (
@@ -2268,7 +2268,7 @@ export function ConnectionEditor() {
                 )}
                 <p className="px-1 text-[0.55rem] leading-relaxed text-[var(--muted-foreground)]">
                   Keep this off if you do not want local avatar or gallery reference frames uploaded outside this
-                  Marinara install.
+                  Guksu install.
                 </p>
               </div>
             </FieldGroup>
@@ -2385,7 +2385,7 @@ export function ConnectionEditor() {
                 </>
               ) : (
                 <p className="mt-1 text-[0.625rem] text-[var(--muted-foreground)]">
-                  This provider does not expose embeddings through Marinara. Choose a dedicated embedding connection
+                  This provider does not expose embeddings through Guksu. Choose a dedicated embedding connection
                   below, such as OpenAI-compatible, Google, or the Local Model sidecar.
                 </p>
               )}

--- a/packages/client/src/components/diagnostics/CsrfOriginWarningBanner.tsx
+++ b/packages/client/src/components/diagnostics/CsrfOriginWarningBanner.tsx
@@ -120,7 +120,7 @@ export function CsrfOriginWarningBanner() {
             ⚠ Saves will silently fail — this origin is not trusted
           </div>
           <div style={{ fontSize: "0.85rem", opacity: 0.95, lineHeight: 1.4 }}>
-            Marinara&apos;s CSRF protection rejects unsafe API requests from{" "}
+            Guksu&apos;s CSRF protection rejects unsafe API requests from{" "}
             <code
               style={{
                 background: "rgba(0,0,0,0.25)",

--- a/packages/client/src/components/game/GameJsonRepairModal.tsx
+++ b/packages/client/src/components/game/GameJsonRepairModal.tsx
@@ -91,7 +91,7 @@ export function GameJsonRepairModal({ request, onClose, onApplied }: GameJsonRep
             <Braces size="1rem" />
           </div>
           <div className="min-w-0 text-sm text-[var(--muted-foreground)]">
-            The model returned JSON that Marinara could not apply. Fix the brackets, commas, or fields here, then apply
+            The model returned JSON that Guksu could not apply. Fix the brackets, commas, or fields here, then apply
             it without regenerating the whole response.
           </div>
         </div>

--- a/packages/client/src/components/game/GameSetupWizard.tsx
+++ b/packages/client/src/components/game/GameSetupWizard.tsx
@@ -2655,7 +2655,7 @@ export function GameSetupWizard({
                         className="mt-2 w-full resize-y rounded-lg bg-[var(--secondary)] px-3 py-2 text-xs leading-relaxed text-[var(--foreground)] outline-none ring-1 ring-[var(--border)] transition-all placeholder:text-[var(--muted-foreground)] focus:ring-[var(--primary)]/40"
                       />
                       <p className="mt-1 text-[0.5625rem] leading-relaxed text-[var(--muted-foreground)]">
-                        Optional. If left blank, Marinara builds from the existing game setup.
+                        Optional. If left blank, Guksu builds from the existing game setup.
                       </p>
                     </div>
 

--- a/packages/client/src/components/game/GameSurface.tsx
+++ b/packages/client/src/components/game/GameSurface.tsx
@@ -463,7 +463,7 @@ function isMobileGameViewport(): boolean {
 }
 
 function isBrowserSpotifyDeviceName(name: string | null | undefined): boolean {
-  return name === "Marinara Engine";
+  return name === "Guksu Motor";
 }
 
 function isPersonalMobileSpotifyDeviceType(type: string | null | undefined): boolean {
@@ -11274,7 +11274,7 @@ function GameSurfaceComponent({
                         <div className="min-w-0 flex-1">
                           <div className="text-xs font-medium text-amber-200">Local scene helper failed to start</div>
                           <div className="mt-1 text-[0.6875rem] leading-relaxed text-white/70">
-                            Marinara will keep the game running without the local sidecar for now.
+                            Guksu will keep the game running without the local sidecar for now.
                             {sidecarFailedRuntimeVariant &&
                               ` Runtime: ${sidecarFailedRuntimeVariant.replace(/-/g, " ")}.`}
                             {sidecarStartupError ? ` ${sidecarStartupError}.` : ""}

--- a/packages/client/src/components/layout/ChatSidebar.tsx
+++ b/packages/client/src/components/layout/ChatSidebar.tsx
@@ -1194,8 +1194,8 @@ export function ChatSidebar() {
           onClick={() => chatImportInputRef.current?.click()}
           disabled={isImportingChat}
           className="mari-chrome-control mari-chrome-control--primary flex-1 text-xs"
-          title={isImportingChat ? "Importing chat" : "Import SillyTavern or Marinara chat JSONL"}
-          aria-label={isImportingChat ? "Importing chat" : "Import SillyTavern or Marinara chat JSONL"}
+          title={isImportingChat ? "Importing chat" : "Import SillyTavern or Guksu chat JSONL"}
+          aria-label={isImportingChat ? "Importing chat" : "Import SillyTavern or Guksu chat JSONL"}
         >
           <Download size="0.8125rem" />
         </button>
@@ -1359,7 +1359,7 @@ export function ChatSidebar() {
               <AlertTriangle size="1.25rem" className="text-[var(--destructive)]" />
             </div>
             <p className="text-xs text-[var(--muted-foreground)]">
-              Marinara is still waking up. Chats should appear in a moment.
+              Guksu is still waking up. Chats should appear in a moment.
             </p>
             <button
               onClick={() => void refetchChats()}

--- a/packages/client/src/components/lorebooks/LorebookAssignmentSection.tsx
+++ b/packages/client/src/components/lorebooks/LorebookAssignmentSection.tsx
@@ -387,7 +387,7 @@ export function LorebookAssignmentSection({
                   <p className="text-xs font-semibold">Scope</p>
                   <p className="mt-0.5 text-[0.625rem] text-[var(--muted-foreground)]">
                     Controls where this assignment is active. All chats means chats that include {ownerLabel}, not every
-                    chat in Marinara.
+                    chat in Guksu.
                   </p>
                 </div>
 

--- a/packages/client/src/components/lorebooks/LorebookEditor.tsx
+++ b/packages/client/src/components/lorebooks/LorebookEditor.tsx
@@ -1659,7 +1659,7 @@ export function LorebookEditor() {
       <ExportFormatDialog
         open={exportDialogOpen}
         title="Export Lorebook"
-        description="Native keeps Marinara folders and entry fields. Compatible exports a folderless World Info JSON for other roleplay tools."
+        description="Native keeps Guksu folders and entry fields. Compatible exports a folderless World Info JSON for other roleplay tools."
         onClose={() => setExportDialogOpen(false)}
         onSelect={(format: ExportFormatChoice) => {
           if (!lorebookId) return;

--- a/packages/client/src/components/modals/ImportCharacterModal.tsx
+++ b/packages/client/src/components/modals/ImportCharacterModal.tsx
@@ -29,7 +29,7 @@ type TagImportMode = "all" | "none" | "existing";
 const TAG_IMPORT_OPTIONS: Array<{ value: TagImportMode; label: string; description: string }> = [
   { value: "all", label: "All tags", description: "Keep source tags." },
   { value: "none", label: "No tags", description: "Skip source tags." },
-  { value: "existing", label: "Existing only", description: "Keep tags already in Marinara." },
+  { value: "existing", label: "Existing only", description: "Keep tags already in Guksu." },
 ];
 
 type RegexScriptScope = "character" | "global";
@@ -261,7 +261,7 @@ export function ImportCharacterModal({ open, onClose }: Props) {
               <div className="min-w-0 flex-1">
                 <p className="text-sm font-semibold text-[var(--foreground)]">Embedded lorebook found</p>
                 <p className="mt-1 text-xs leading-relaxed text-[var(--muted-foreground)]">
-                  Import the embedded lorebook as a standalone Marinara lorebook, or keep it only inside the character
+                  Import the embedded lorebook as a standalone Guksu lorebook, or keep it only inside the character
                   card.
                 </p>
                 <div className="mt-3 max-h-32 overflow-y-auto rounded-lg border border-[var(--border)]/70 bg-[var(--background)]/40">
@@ -390,7 +390,7 @@ export function ImportCharacterModal({ open, onClose }: Props) {
           <div className="text-center">
             <p className="text-sm font-medium">Drop one or more files here or click to browse</p>
             <p className="mt-1 text-xs text-[var(--muted-foreground)]">
-              Supports JSON, PNG character cards, CharX, and Marinara exports
+              Supports JSON, PNG character cards, CharX, and Guksu exports
             </p>
           </div>
           <div className="flex gap-2">

--- a/packages/client/src/components/modals/ImportPersonaModal.tsx
+++ b/packages/client/src/components/modals/ImportPersonaModal.tsx
@@ -184,7 +184,7 @@ export function ImportPersonaModal({ open, onClose }: Props) {
           />
           <div className="text-center">
             <p className="text-sm font-medium">Drop one or more files here or click to browse</p>
-            <p className="mt-1 text-xs text-[var(--muted-foreground)]">Supports JSON and Marinara persona exports</p>
+            <p className="mt-1 text-xs text-[var(--muted-foreground)]">Supports JSON and Guksu persona exports</p>
           </div>
           <div className="flex gap-2">
             <span className="flex items-center gap-1 rounded-full bg-[var(--secondary)] px-2.5 py-1 text-xs text-[var(--muted-foreground)]">

--- a/packages/client/src/components/modals/ModelDownloadModal.tsx
+++ b/packages/client/src/components/modals/ModelDownloadModal.tsx
@@ -311,11 +311,11 @@ export function ModelDownloadModal({ open, onClose }: Props) {
         : "Downloading your selected GGUF and preparing it for local use."
       : progress?.phase === "runtime"
         ? activeBackend === "mlx"
-          ? "Downloading a private uv bootstrap and creating an isolated MLX environment inside Marinara's sidecar runtime folder."
+          ? "Downloading a private uv bootstrap and creating an isolated MLX environment inside Guksu's sidecar runtime folder."
           : "Downloading the official local runtime for this device."
         : activeBackend === "mlx"
-          ? "Starting the MLX server in the background. You can close this window while Marinara finishes booting it."
-          : "Starting the local sidecar server in the background. You can close this window while Marinara finishes booting it.";
+          ? "Starting the MLX server in the background. You can close this window while Guksu finishes booting it."
+          : "Starting the local sidecar server in the background. You can close this window while Guksu finishes booting it.";
   const runtimeStatusLabel = canFinish
     ? "Ready"
     : isBlockingSetup
@@ -492,12 +492,12 @@ export function ModelDownloadModal({ open, onClose }: Props) {
           </div>
           <div className="text-sm text-[var(--muted-foreground)]">
             <p>
-              Marinara Engine can run a local sidecar for trackers, scene analysis, and game-state helpers without
+              Guksu Motor can run a local sidecar for trackers, scene analysis, and game-state helpers without
               spending main-model tokens.
             </p>
             <p className="mt-1.5 text-xs text-[var(--muted-foreground)]/70">
               {isAppleSilicon
-                ? "Set up the MLX runtime first if you want Marinara to keep it private and isolated, then choose either a curated Gemma preset or an MLX-native HuggingFace repo."
+                ? "Set up the MLX runtime first if you want Guksu to keep it private and isolated, then choose either a curated Gemma preset or an MLX-native HuggingFace repo."
                 : "Set up the runtime first, then choose either a curated Gemma preset or any GGUF from HuggingFace. Runtime device selection lives inside Runtime Settings."}
             </p>
           </div>
@@ -662,11 +662,11 @@ export function ModelDownloadModal({ open, onClose }: Props) {
                         />
                       </div>
                       <div className="text-xs text-[var(--muted-foreground)]/70">
-                        Pick the GPU family you actually want Marinara to target so it does not guess the wrong adapter.
+                        Pick the GPU family you actually want Guksu to target so it does not guess the wrong adapter.
                       </div>
                       {platform === "linux" && config.runtimePreference === "nvidia" && (
                         <div className="rounded-lg border border-amber-500/20 bg-amber-500/10 px-3 py-2 text-xs leading-relaxed text-amber-100">
-                          Linux CUDA binaries are not currently published by llama.cpp, so Marinara tries Vulkan first
+                          Linux CUDA binaries are not currently published by llama.cpp, so Guksu tries Vulkan first
                           and falls back to CPU. Use System llama-server for a custom CUDA build.
                         </div>
                       )}
@@ -914,7 +914,7 @@ export function ModelDownloadModal({ open, onClose }: Props) {
                 <div className="mt-3 flex items-center justify-between gap-3 max-sm:flex-col max-sm:items-stretch">
                   <div className="text-xs text-[var(--muted-foreground)]/70">
                     Max response tokens caps how much the local runtime can generate. If it is too large relative to the
-                    context window, Marinara has to trim more of the prompt to make room. Marinara does not impose an
+                    context window, Guksu has to trim more of the prompt to make room. Guksu does not impose an
                     upper limit here; the selected model and your hardware still decide what can actually run.
                   </div>
                   <button
@@ -945,7 +945,7 @@ export function ModelDownloadModal({ open, onClose }: Props) {
                 <div className="rounded-xl border border-amber-500/25 bg-amber-500/5 p-4">
                   <div className="text-sm font-medium text-amber-200">Local runtime failed to start</div>
                   <div className="mt-1 text-xs text-[var(--muted-foreground)]/85">
-                    Marinara will keep working without the local model until you retry or change these settings.
+                    Guksu will keep working without the local model until you retry or change these settings.
                   </div>
                   <div className="mt-3 flex flex-col gap-1 text-xs text-[var(--muted-foreground)]/75">
                     {failedRuntimeVariant && <span>Runtime: {formatRuntimeVariantLabel(failedRuntimeVariant)}</span>}
@@ -1189,7 +1189,7 @@ export function ModelDownloadModal({ open, onClose }: Props) {
               </div>
               <div className="mt-2 text-xs text-[var(--muted-foreground)]/70">
                 {isAppleSilicon
-                  ? "Enter an MLX-native HuggingFace repo. Marinara will validate it, then let the MLX runtime pull and cache it locally on first startup."
+                  ? "Enter an MLX-native HuggingFace repo. Guksu will validate it, then let the MLX runtime pull and cache it locally on first startup."
                   : "Enter a GGUF repo on HuggingFace, list the available files, and choose the one you want to download."}
               </div>
               <div className="mt-3 flex flex-col gap-2">

--- a/packages/client/src/components/modals/STBulkImportModal.tsx
+++ b/packages/client/src/components/modals/STBulkImportModal.tsx
@@ -82,7 +82,7 @@ type TagImportMode = "all" | "none" | "existing";
 const TAG_IMPORT_OPTIONS: Array<{ value: TagImportMode; label: string; description: string }> = [
   { value: "all", label: "All tags", description: "Keep source tags." },
   { value: "none", label: "No tags", description: "Skip source tags." },
-  { value: "existing", label: "Existing only", description: "Keep tags already in Marinara." },
+  { value: "existing", label: "Existing only", description: "Keep tags already in Guksu." },
 ];
 
 const REGEX_SCOPE_OPTIONS: Array<{ value: "character" | "global"; label: string; description: string }> = [

--- a/packages/client/src/components/modals/ScenePromptPreferencesModal.tsx
+++ b/packages/client/src/components/modals/ScenePromptPreferencesModal.tsx
@@ -67,7 +67,7 @@ export function ScenePromptPreferencesModal({
             {sourceLabel ? `${sourceLabel} wants to start a scene.` : "Start a scene."}
           </p>
           <p className="text-xs leading-relaxed text-[var(--muted-foreground)]">
-            Pick the writing shape before Marinara plans the scene.
+            Pick the writing shape before Guksu plans the scene.
           </p>
         </div>
 

--- a/packages/client/src/components/modals/WhatsNewModal.tsx
+++ b/packages/client/src/components/modals/WhatsNewModal.tsx
@@ -66,8 +66,8 @@ const RELEASE_ANNOUNCEMENTS: Record<string, ReleaseAnnouncement> = {
 };
 
 const FALLBACK_ANNOUNCEMENT: ReleaseAnnouncement = {
-  headline: "Marinara Engine has been updated.",
-  intro: "Marinara Engine has been updated! Read the release notes for everything included in this version.",
+  headline: "Guksu Motor has been updated.",
+  intro: "Guksu Motor has been updated! Read the release notes for everything included in this version.",
   highlights: [],
 };
 

--- a/packages/client/src/components/noodle/NoodleHome.tsx
+++ b/packages/client/src/components/noodle/NoodleHome.tsx
@@ -780,7 +780,7 @@ function BrowserChrome() {
       <div className="flex h-8 min-w-0 flex-1 items-center gap-2 rounded-full border border-[var(--marinara-chat-chrome-panel-border)] bg-[var(--card)] px-3 text-xs shadow-sm">
         <Lock size={13} className="hidden shrink-0 text-[var(--noodle-blue)] sm:block" />
         <Search size={14} className="shrink-0 text-[var(--noodle-blue)] sm:hidden" />
-        <span className="truncate text-[var(--foreground)] sm:hidden">noodle.marinara.local/home</span>
+        <span className="truncate text-[var(--foreground)] sm:hidden">noodle.guksu.local/home</span>
         <span className="hidden truncate text-[var(--foreground)] sm:inline">https://noodle.local</span>
         <span className="hidden rounded-full bg-[var(--noodle-blue)]/15 px-2 py-0.5 font-semibold text-[var(--noodle-blue)] sm:inline-flex">
           Noodle
@@ -3085,7 +3085,7 @@ export function NoodleHome({ navigation, onNavigate }: NoodleHomeProps) {
                       <p>
                         The server timezone could not be detected. Remove a blank <code>TZ=</code> from your{" "}
                         <code>.env</code>, or set an IANA timezone such as <code>TZ=Europe/Warsaw</code>, then restart
-                        Marinara.
+                        Guksu.
                       </p>
                     </div>
                   )}

--- a/packages/client/src/components/onboarding/OnboardingTutorial.tsx
+++ b/packages/client/src/components/onboarding/OnboardingTutorial.tsx
@@ -43,7 +43,7 @@ interface TourStep {
 const STEPS: TourStep[] = [
   {
     target: null,
-    title: "Welcome to Marinara Engine!",
+    title: "Welcome to Guksu Motor!",
     body: "Hi! I'm Professor Mari, your assistant and guide! First time around? Allow me to show you around. This is a quick orientation tour, so you can skip it if you already know your way around, but skipping will make me sad a little.",
     sprite: { src: "/sprites/mari/Mari_wave.png" },
   },
@@ -164,7 +164,7 @@ const STEPS: TourStep[] = [
   {
     target: "panel-connections",
     title: "You're All Set!",
-    body: "I'm available from the Home page whenever you need help, and my starter chips can guide you through common first steps without making you type everything. For your first real step, set up a Connection. After that, try creating a new chat. Don't worry, I will be there to guide you. Thank you for trying Marinara Engine. Have fun, and please report bugs or rough edges through our Discord or GitHub so we can keep improving it.",
+    body: "I'm available from the Home page whenever you need help, and my starter chips can guide you through common first steps without making you type everything. For your first real step, set up a Connection. After that, try creating a new chat. Don't worry, I will be there to guide you. Thank you for trying Guksu Motor. Have fun, and please report bugs or rough edges through our Discord or GitHub so we can keep improving it.",
     side: "bottom",
     openPanel: "connections",
     sprite: { src: "/sprites/mari/Mari_greet.png" },

--- a/packages/client/src/components/panels/ConnectionsPanel.tsx
+++ b/packages/client/src/components/panels/ConnectionsPanel.tsx
@@ -129,7 +129,7 @@ function formatBytes(bytes: number): string {
 
 function describeSpeechRuntimeUnavailable(runtime: SidecarSpeechRuntimeDiagnostics | null): string {
   if (!runtime) {
-    return "Local Whisper needs the native ONNX runtime for this platform. Reinstall dependencies with the same Node architecture used to run Marinara.";
+    return "Local Whisper needs the native ONNX runtime for this platform. Reinstall dependencies with the same Node architecture used to run Guksu.";
   }
 
   const runtimeTuple = `${runtime.platform}/${runtime.arch}`;
@@ -139,18 +139,18 @@ function describeSpeechRuntimeUnavailable(runtime: SidecarSpeechRuntimeDiagnosti
       : "";
 
   if (runtime.liteMode) {
-    return "Local Whisper is disabled in Lite mode. Use a full Marinara install to download and run the local speech model.";
+    return "Local Whisper is disabled in Lite mode. Use a full Guksu install to download and run the local speech model.";
   }
 
   if (!runtime.packageFound) {
-    return `Local Whisper needs onnxruntime-node. Run pnpm install with Node ${runtime.nodeVersion} (${runtimeTuple}), then restart Marinara.`;
+    return `Local Whisper needs onnxruntime-node. Run pnpm install with Node ${runtime.nodeVersion} (${runtimeTuple}), then restart Guksu.`;
   }
 
   if (installed && !runtime.installedBindingArchs.includes(runtime.arch)) {
-    return `Marinara is running with ${runtimeTuple} Node, but this install has ONNX runtime for ${installed}. Restart Marinara with the matching Node architecture, or reinstall dependencies using the same Node architecture you use to run Marinara.`;
+    return `Guksu is running with ${runtimeTuple} Node, but this install has ONNX runtime for ${installed}. Restart Guksu with the matching Node architecture, or reinstall dependencies using the same Node architecture you use to run Guksu.`;
   }
 
-  return `Local Whisper cannot find the ONNX runtime for ${runtimeTuple}. Run pnpm install --force --frozen-lockfile with the same Node architecture used to run Marinara, then restart.`;
+  return `Local Whisper cannot find the ONNX runtime for ${runtimeTuple}. Run pnpm install --force --frozen-lockfile with the same Node architecture used to run Guksu, then restart.`;
 }
 
 function formatRuntimeVariantLabel(variant: string | null): string | null {
@@ -589,7 +589,7 @@ function SidecarCard() {
             <div className="mt-2.5 rounded-lg border border-amber-500/20 bg-amber-500/5 p-2.5">
               <div className="text-[0.6875rem] font-medium text-amber-200">Local runtime unavailable</div>
               <div className="mt-1 text-[0.6875rem] text-[var(--muted-foreground)]/75">
-                {startupError ?? "Marinara will keep running without the local model until you retry."}
+                {startupError ?? "Guksu will keep running without the local model until you retry."}
               </div>
               {failedRuntimeVariant && (
                 <div className="mt-1 text-[0.6875rem] text-[var(--muted-foreground)]/60">

--- a/packages/client/src/components/panels/SettingsPanel.tsx
+++ b/packages/client/src/components/panels/SettingsPanel.tsx
@@ -418,9 +418,9 @@ const SETTINGS_SECTIONS: readonly SettingsSectionMeta[] = [
   {
     id: "profile-marinara",
     tab: "import",
-    label: "Profile & Marinara",
-    description: "Restore full profiles or import individual Marinara files.",
-    aliases: ["profile", "import", "restore", "marinara", "json", "zip"],
+    label: "Profile & Guksu",
+    description: "Restore full profiles or import individual Guksu files.",
+    aliases: ["profile", "import", "restore", "guksu", "json", "zip"],
   },
   {
     id: "sillytavern-import",
@@ -536,8 +536,8 @@ const SETTINGS_SEARCHABLE_CONTROLS: readonly SettingsSearchableControlMeta[] = [
   {
     id: "notification-unfocused-only",
     sectionId: "notifications",
-    label: "Only when Marinara is unfocused",
-    description: "Play notification sounds only while Marinara is not focused.",
+    label: "Only when Guksu is unfocused",
+    description: "Play notification sounds only while Guksu is not focused.",
     aliases: ["sound", "background", "unfocused"],
     kind: "Toggle",
   },
@@ -773,8 +773,8 @@ const SETTINGS_SEARCHABLE_CONTROLS: readonly SettingsSearchableControlMeta[] = [
     id: "visual-theme",
     sectionId: "app-style",
     label: "Visual Style",
-    description: "Switch between Marinara and SillyTavern visual themes.",
-    aliases: ["theme", "style", "sillytavern", "marinara"],
+    description: "Switch between Guksu and SillyTavern visual themes.",
+    aliases: ["theme", "style", "sillytavern", "guksu"],
     kind: "Button group",
   },
   {
@@ -789,7 +789,7 @@ const SETTINGS_SEARCHABLE_CONTROLS: readonly SettingsSearchableControlMeta[] = [
     id: "custom-cursor",
     sectionId: "app-style",
     label: "Custom Mouse Pointer",
-    description: "Use Marinara's accent-colored cursor.",
+    description: "Use Guksu's accent-colored cursor.",
     aliases: ["cursor", "mouse", "pointer"],
     kind: "Toggle",
   },
@@ -821,7 +821,7 @@ const SETTINGS_SEARCHABLE_CONTROLS: readonly SettingsSearchableControlMeta[] = [
     id: "rgb-mode",
     sectionId: "app-style",
     label: "RGB Mode",
-    description: "Cycle the app accent through Marinara's rainbow palette.",
+    description: "Cycle the app accent through Guksu's rainbow palette.",
     aliases: ["rainbow", "accent", "color"],
     kind: "Toggle",
   },
@@ -1120,10 +1120,10 @@ function isStandaloneIosInstall(): boolean {
 function getNativeConsoleShortcutHelp(): string {
   const bridge = getMarinaraAndroidBridge();
   if (typeof bridge?.openConsole === "function") {
-    return "Opens Termux from the Android APK so you can view Marinara server logs while Debug mode is enabled.";
+    return "Opens Termux from the Android APK so you can view Guksu server logs while Debug mode is enabled.";
   }
   if (isMarinaraAndroidShell()) {
-    return "This Android APK build cannot expose the Termux console shortcut yet. Update Marinara, or open Termux manually.";
+    return "This Android APK build cannot expose the Termux console shortcut yet. Update Guksu, or open Termux manually.";
   }
   if (isStandaloneIosInstall()) {
     return "iPhone installations do not expose a native console shortcut yet. Use the host server logs or Safari Web Inspector.";
@@ -2728,7 +2728,7 @@ function GeneralSettings() {
             label="Trim incomplete model endings"
             checked={trimIncompleteModelOutput}
             onChange={setTrimIncompleteModelOutput}
-            help="When on, Marinara trims a trailing unfinished sentence from AI responses before saving the message. It leaves complete responses and command-only endings alone."
+            help="When on, Guksu trims a trailing unfinished sentence from AI responses before saving the message. It leaves complete responses and command-only endings alone."
           />
 
           <label
@@ -3069,7 +3069,7 @@ function ImageGenerationSettings() {
         <div id={getSettingsControlAnchorId("image-style-profiles")} className="mt-1 scroll-mt-3">
           <div className="mb-2 flex items-center gap-1 text-xs font-medium text-[var(--foreground)]">
             Style Profiles
-            <HelpTooltip text="Defines what Anime, Danbooru, Realistic, and custom styles mean when Marinara compiles image prompts. Profiles merge with per-chat and connection settings, then clean duplicate tags before sending." />
+            <HelpTooltip text="Defines what Anime, Danbooru, Realistic, and custom styles mean when Guksu compiles image prompts. Profiles merge with per-chat and connection settings, then clean duplicate tags before sending." />
           </div>
           <ImageStyleProfilesEditor value={imageStyleProfiles} onChange={setImageStyleProfiles} />
         </div>
@@ -3636,7 +3636,7 @@ function AppearanceSettings() {
     void setActiveSyncedTheme
       .mutateAsync(null)
       .then(() => {
-        toast.success("Appearance reset to Marinara defaults.");
+        toast.success("Appearance reset to Guksu defaults.");
       })
       .catch((err) => {
         console.error("[AppearanceSettings] Failed to clear active synced theme:", err);
@@ -3781,7 +3781,7 @@ function AppearanceSettings() {
               onClick={handleResetAppearance}
               disabled={setActiveSyncedTheme.isPending}
               className={SETTINGS_BUTTON_CLASS}
-              title="Reset all Appearance settings to Marinara defaults"
+              title="Reset all Appearance settings to Guksu defaults"
             >
               {setActiveSyncedTheme.isPending ? (
                 <Loader2 size="0.75rem" className="animate-spin" />
@@ -3796,14 +3796,14 @@ function AppearanceSettings() {
             <div className="flex items-center gap-1.5">
               <Paintbrush size="0.75rem" className="text-[var(--marinara-chat-chrome-button-text-active)]" />
               <span className="text-xs font-medium">Visual Style</span>
-              <HelpTooltip text="Choose how the entire app looks. 'Marinara' uses a retro Y2K aesthetic with glow effects. 'SillyTavern' uses a clean, minimal look inspired by the original SillyTavern." />
+              <HelpTooltip text="Choose how the entire app looks. 'Guksu' uses a retro Y2K aesthetic with glow effects. 'SillyTavern' uses a clean, minimal look inspired by the original SillyTavern." />
             </div>
             <div className="grid grid-cols-2 gap-2">
               {(
                 [
                   {
                     id: "default" as VisualTheme,
-                    label: "Default (Marinara)",
+                    label: "Default (Guksu)",
                     desc: "Y2K / retro aesthetic with glow effects",
                   },
                   {
@@ -3850,7 +3850,7 @@ function AppearanceSettings() {
             label="Custom Mouse Pointer"
             checked={customCursorEnabled}
             onChange={setCustomCursorEnabled}
-            help="Uses Marinara's accent-colored cursor across the app. Turn this off to use the system cursor or let a custom CSS theme control cursor styles."
+            help="Uses Guksu's accent-colored cursor across the app. Turn this off to use the system cursor or let a custom CSS theme control cursor styles."
           />
 
           <SearchableSettingTarget controlId="app-background-color">
@@ -3899,7 +3899,7 @@ function AppearanceSettings() {
             checked={appAccentRgbMode}
             onChange={handleAppAccentRgbModeChange}
             switchClassName={appAccentRgbMode ? "mari-rgb-toggle-track" : undefined}
-            help="Cycles the app accent through Marinara's rainbow palette while enabled. Your saved Accent Color stays unchanged. Reduced-motion preferences are respected."
+            help="Cycles the app accent through Guksu's rainbow palette while enabled. Your saved Accent Color stays unchanged. Reduced-motion preferences are respected."
           />
         </div>
       </SettingsSection>
@@ -4776,7 +4776,7 @@ function AddonsSettings() {
   return (
     <div className="flex flex-col gap-3">
       <SettingsIntro>
-        Extensions add trusted browser or server behavior; custom themes change Marinara's look.
+        Extensions add trusted browser or server behavior; custom themes change Guksu's look.
       </SettingsIntro>
       <ExtensionsSettings showIntro={false} />
       <ThemesSettings showIntro={false} />
@@ -5059,7 +5059,7 @@ function ThemesSettings({ showIntro = true }: { showIntro?: boolean } = {}) {
     <div className="flex flex-col gap-3">
       {showIntro && (
         <SettingsIntro>
-          Create or import custom CSS themes. Themes sync across devices connected to this Marinara server.
+          Create or import custom CSS themes. Themes sync across devices connected to this Guksu server.
         </SettingsIntro>
       )}
 
@@ -5227,7 +5227,7 @@ function ThemesSettings({ showIntro = true }: { showIntro?: boolean } = {}) {
             <code className="rounded bg-[var(--secondary)] px-1">--marinara-chat-chrome-surface-bg</code>) or add custom
             styles. JSON themes should have{" "}
             <code className="rounded bg-[var(--secondary)] px-1">{`{ "name": "...", "css": "..." }`}</code> format.
-            Imported theme files sync to this Marinara server but do not auto-activate.
+            Imported theme files sync to this Guksu server but do not auto-activate.
           </div>
         </div>
       </SettingsSection>
@@ -5447,7 +5447,7 @@ function describeExtensionImportError(error: unknown, name?: string) {
         : "Failed to import extension.";
   const subject = name ? `Failed to install "${name}": ${rawMessage}` : rawMessage;
   if (error instanceof ApiError && error.status === 403) {
-    return `${subject} Installing extensions requires loopback access or admin access. Open Marinara Engine through localhost, or set ADMIN_SECRET=<secret> in the server .env and paste the same value in Settings → Advanced → Admin Access. Marinara sends it as the X-Admin-Secret header.`;
+    return `${subject} Installing extensions requires loopback access or admin access. Open Guksu Motor through localhost, or set ADMIN_SECRET=<secret> in the server .env and paste the same value in Settings → Advanced → Admin Access. Guksu sends it as the X-Admin-Secret header.`;
   }
   return subject;
 }
@@ -5670,7 +5670,7 @@ function ExtensionsSettings({ showIntro = true }: { showIntro?: boolean } = {}) 
     if (nextEnabled && ext.runtime === "server") {
       const confirmed = await showConfirmDialog({
         title: "Enable Server Extension",
-        message: `Enable "${ext.name}"? This runs trusted JavaScript inside the Marinara Node.js server process and can affect this server until disabled. Only enable code you trust.`,
+        message: `Enable "${ext.name}"? This runs trusted JavaScript inside the Guksu Node.js server process and can affect this server until disabled. Only enable code you trust.`,
         confirmLabel: "Enable Server Extension",
         tone: "destructive",
       });
@@ -5678,7 +5678,7 @@ function ExtensionsSettings({ showIntro = true }: { showIntro?: boolean } = {}) 
     } else if (nextEnabled && ext.js?.trim()) {
       const confirmed = await showConfirmDialog({
         title: "Enable Extension",
-        message: `Enable "${ext.name}"? This runs the extension's JavaScript inside Marinara Engine.`,
+        message: `Enable "${ext.name}"? This runs the extension's JavaScript inside Guksu Motor.`,
         confirmLabel: "Enable",
         tone: "destructive",
       });
@@ -5869,7 +5869,7 @@ function ExtensionsSettings({ showIntro = true }: { showIntro?: boolean } = {}) 
             process and should only come from trusted sources.
           </div>
           <div className="rounded-lg bg-[var(--secondary)]/35 p-2.5 text-[0.625rem] leading-relaxed text-[var(--muted-foreground)] ring-1 ring-[var(--border)]">
-            Extensions can be downloaded from the official Marinara Engine Discord server.
+            Extensions can be downloaded from the official Guksu Motor Discord server.
           </div>
         </div>
       </SettingsSection>
@@ -6363,13 +6363,13 @@ function ImportSettings() {
   return (
     <div className="flex flex-col gap-3">
       <SettingsIntro>
-        Import data from Marinara exports, SillyTavern, or asset folders. Full profile imports also restore synced
+        Import data from Guksu exports, SillyTavern, or asset folders. Full profile imports also restore synced
         custom themes and profile archive assets.
       </SettingsIntro>
 
       <SettingsSection
-        title="Profile & Marinara"
-        description="Restore full profiles or import individual Marinara files."
+        title="Profile & Guksu"
+        description="Restore full profiles or import individual Guksu files."
         icon={<Download size="0.875rem" />}
         {...getSettingsSectionAnchorProps("profile-marinara")}
       >
@@ -6556,7 +6556,7 @@ function ImportButton({
           importEmbeddedLorebook = window.confirm(
             `${preview.name ?? file.name} includes an embedded lorebook with ${preview.embeddedLorebookEntries} entr${
               preview.embeddedLorebookEntries === 1 ? "y" : "ies"
-            }.\n\nImport it as a standalone Marinara lorebook too?`,
+            }.\n\nImport it as a standalone Guksu lorebook too?`,
           );
         }
       }
@@ -6800,7 +6800,7 @@ function AdvancedSettings() {
             suggestedName,
             types: [
               {
-                description: "Marinara backup archive",
+                description: "Guksu backup archive",
                 accept: { "application/zip": [".zip"] },
               },
             ],
@@ -7009,8 +7009,8 @@ function AdvancedSettings() {
       <ExportFormatDialog
         open={exportProfileDialogOpen}
         title="Export Profile"
-        description="Native creates a Marinara profile JSON for restoring your data in Marinara. If the JSON would be too large, Marinara will offer a profile ZIP instead."
-        nativeDescription="Keeps Marinara fields, lorebook folders, character/persona metadata, presets, agents, themes, and inline assets for re-import."
+        description="Native creates a Guksu profile JSON for restoring your data in Guksu. If the JSON would be too large, Guksu will offer a profile ZIP instead."
+        nativeDescription="Keeps Guksu fields, lorebook folders, character/persona metadata, presets, agents, themes, and inline assets for re-import."
         compatibleDescription="Exports direct character JSON, simple persona JSON, and folderless lorebooks for other roleplay tools."
         onClose={() => setExportProfileDialogOpen(false)}
         onSelect={handleExportProfileChoice}
@@ -7145,7 +7145,7 @@ function AdvancedSettings() {
               )}
               {isIosClient && (
                 <p className="text-[0.625rem] text-[var(--muted-foreground)]">
-                  On iPhone or iPad, this updates the Marinara server you are connected to. Reload the Home Screen app
+                  On iPhone or iPad, this updates the Guksu server you are connected to. Reload the Home Screen app
                   after the host finishes updating.
                 </p>
               )}
@@ -7186,7 +7186,7 @@ function AdvancedSettings() {
                   )}
                   {updateCheck.data.versionUpdate && (
                     <span className="text-[0.625rem] text-[var(--muted-foreground)]">
-                      Android APK assets are WebView shells, not standalone apps. Start Marinara in Termux first.
+                      Android APK assets are WebView shells, not standalone apps. Start Guksu in Termux first.
                     </span>
                   )}
                   {manualUpdateHint && (
@@ -7242,7 +7242,7 @@ function AdvancedSettings() {
             </button>
             <HelpTooltip
               side="bottom"
-              text="Manual refresh unregisters the active service worker and clears browser caches before reloading. Marinara's stored chats, settings, and other local app data stay intact."
+              text="Manual refresh unregisters the active service worker and clears browser caches before reloading. Guksu's stored chats, settings, and other local app data stay intact."
             />
           </div>
         </div>

--- a/packages/client/src/components/panels/settings/SettingControls.tsx
+++ b/packages/client/src/components/panels/settings/SettingControls.tsx
@@ -177,7 +177,7 @@ export function ConversationSoundSetting() {
         setPreference(false);
         toast.error(
           permission === "unsupported"
-            ? "Mobile notifications require the Marinara Android app."
+            ? "Mobile notifications require the Guksu Android app."
             : "Android notification permission was not granted.",
         );
       })
@@ -223,14 +223,14 @@ export function ConversationSoundSetting() {
       />
       <ToggleSetting
         anchorId="settings-control-notification-unfocused-only"
-        label="Only when Marinara is unfocused"
+        label="Only when Guksu is unfocused"
         checked={notificationSoundsOnlyWhenUnfocused}
         onChange={setNotificationSoundsOnlyWhenUnfocused}
       />
       <div className="mt-1 flex items-center gap-1.5">
         <Bell size="0.75rem" className="text-[var(--muted-foreground)]" />
         <span className="text-xs font-medium">Background Notifications</span>
-        <HelpTooltip text="Show a private operating-system notification when an autonomous Conversation message arrives while Marinara is not focused. Message content is hidden." />
+        <HelpTooltip text="Show a private operating-system notification when an autonomous Conversation message arrives while Guksu is not focused. Message content is hidden." />
       </div>
       <ToggleSetting
         anchorId="settings-control-browser-background-notifications"
@@ -259,14 +259,14 @@ export function ConversationSoundSetting() {
         disabled={!nativeNotificationsAvailable}
         help={
           nativeNotificationsAvailable
-            ? "Uses native Android notifications from the installed Marinara app."
-            : "Available in the updated Marinara Android APK. Browser and PWA installations use the Browser toggle above."
+            ? "Uses native Android notifications from the installed Guksu app."
+            : "Available in the updated Guksu Android APK. Browser and PWA installations use the Browser toggle above."
         }
       />
       <div className="mt-1 flex items-center gap-1.5">
         <BellRing size="0.75rem" className="text-[var(--muted-foreground)]" />
         <span className="text-xs font-medium">Generation Completion Notifications</span>
-        <HelpTooltip text="Show a private operating-system notification when a reply you started manually finishes in Conversation, Roleplay, Visual Novel, or Game mode while Marinara is not focused. Message content is hidden." />
+        <HelpTooltip text="Show a private operating-system notification when a reply you started manually finishes in Conversation, Roleplay, Visual Novel, or Game mode while Guksu is not focused. Message content is hidden." />
       </div>
       <ToggleSetting
         anchorId="settings-control-browser-generation-notifications"
@@ -295,8 +295,8 @@ export function ConversationSoundSetting() {
         disabled={!nativeNotificationsAvailable}
         help={
           nativeNotificationsAvailable
-            ? "Uses native Android notifications from the installed Marinara app."
-            : "Available in the updated Marinara Android APK. Browser and PWA installations use the Browser toggle above."
+            ? "Uses native Android notifications from the installed Guksu app."
+            : "Available in the updated Guksu Android APK. Browser and PWA installations use the Browser toggle above."
         }
       />
     </div>

--- a/packages/client/src/components/panels/settings/TTSConfigCard.tsx
+++ b/packages/client/src/components/panels/settings/TTSConfigCard.tsx
@@ -1339,7 +1339,7 @@ export function TTSConfigCard() {
 
           <FieldRow
             label="Random NPC Voices"
-            help="When enabled, tracked game NPCs without a character-specific voice use a stable random provider voice. If voice metadata is available, Marinara prefers matching male/female pools."
+            help="When enabled, tracked game NPCs without a character-specific voice use a stable random provider voice. If voice metadata is available, Guksu prefers matching male/female pools."
           >
             <div className="space-y-2 rounded-xl border border-sky-400/15 bg-sky-400/5 p-2">
               <ToggleRow

--- a/packages/client/src/components/personas/PersonaEditor.tsx
+++ b/packages/client/src/components/personas/PersonaEditor.tsx
@@ -509,7 +509,7 @@ function PersonaVideosGallery({ personaId, personaName }: { personaId: string; p
       if (
         !(await showConfirmDialog({
           title: "Delete Clip",
-          message: "Delete this clip everywhere it appears in Marinara? This cannot be undone.",
+          message: "Delete this clip everywhere it appears in Guksu? This cannot be undone.",
           confirmLabel: "Delete",
           tone: "destructive",
         }))
@@ -1311,8 +1311,8 @@ export function PersonaEditor() {
       <ExportFormatDialog
         open={exportDialogOpen}
         title="Export Persona"
-        description="Native keeps Marinara persona metadata, sprites, and attached lorebooks. Compatible exports simple persona JSON for other tools."
-        compatibleDescription="Exports persona fields directly without the Marinara wrapper."
+        description="Native keeps Guksu persona metadata, sprites, and attached lorebooks. Compatible exports simple persona JSON for other tools."
+        compatibleDescription="Exports persona fields directly without the Guksu wrapper."
         onClose={() => setExportDialogOpen(false)}
         onSelect={(format: ExportFormatChoice) => {
           if (!personaId) return;
@@ -1741,7 +1741,7 @@ function PersonaSpritesTab({
     if (
       !(await showConfirmDialog({
         title: "Clean Sprite Backgrounds",
-        message: `Clean backgrounds on ${visibleSprites.length} saved ${modeLabel} sprite${visibleSprites.length === 1 ? "" : "s"} at strength ${savedCleanupStrength}? Marinara will keep a restore point in case the cleanup looks wrong.`,
+        message: `Clean backgrounds on ${visibleSprites.length} saved ${modeLabel} sprite${visibleSprites.length === 1 ? "" : "s"} at strength ${savedCleanupStrength}? Guksu will keep a restore point in case the cleanup looks wrong.`,
         confirmLabel: "Clean",
       }))
     ) {

--- a/packages/client/src/components/presets/PresetEditor.tsx
+++ b/packages/client/src/components/presets/PresetEditor.tsx
@@ -749,7 +749,7 @@ function PromptsTab({
           value={conversationPrompt}
           onChange={onConversationPromptChange}
           title="Edit Conversation Mode Prompt"
-          placeholder="Leave empty to use Marinara's built-in conversation prompt."
+          placeholder="Leave empty to use Guksu's built-in conversation prompt."
           className="mari-editor-field min-h-[12rem] w-full p-3 font-mono text-xs"
           formatOnChange={formatPrompt}
           spellCheck={false}
@@ -770,7 +770,7 @@ function PromptsTab({
           value={gamePrompt}
           onChange={onGamePromptChange}
           title="Edit Game Mode Prompt"
-          placeholder="Leave empty to use Marinara's built-in game prompt."
+          placeholder="Leave empty to use Guksu's built-in game prompt."
           className="mari-editor-field min-h-[12rem] w-full p-3 font-mono text-xs"
           formatOnChange={formatPrompt}
           spellCheck={false}

--- a/packages/client/src/components/spotify/SpotifyMiniPlayer.tsx
+++ b/packages/client/src/components/spotify/SpotifyMiniPlayer.tsx
@@ -214,7 +214,7 @@ function getShuffleTitle(shuffle: boolean) {
 }
 
 function isBrowserSpotifyDeviceName(name: string | null | undefined): boolean {
-  return name === "Marinara Engine";
+  return name === "Guksu Motor";
 }
 
 function isPersonalMobileSpotifyDeviceType(type: string | null | undefined): boolean {
@@ -454,7 +454,7 @@ export function SpotifyMiniPlayer({
       .then(() => {
         if (disposed || !window.Spotify?.Player) return;
         sdkPlayer = new window.Spotify.Player({
-          name: "Marinara Engine",
+          name: "Guksu Motor",
           volume: 0.5,
           getOAuthToken: (callback) => {
             void api
@@ -697,7 +697,7 @@ export function SpotifyMiniPlayer({
     }
     if (!spotifyStreamingAvailable) {
       setSdkError("Reconnect Spotify to enable in-app playback.");
-      toast.info("Reconnect Spotify with the streaming scope to use Marinara as a Spotify player.");
+      toast.info("Reconnect Spotify with the streaming scope to use Guksu as a Spotify player.");
       return;
     }
     setSdkError(null);
@@ -1071,7 +1071,7 @@ export function SpotifyMiniPlayer({
                 MUSIC_PLAYER_ICON_CLASS,
                 MUSIC_PLAYER_ICON_HOVER_CLASS,
               )}
-              title={sdkDeviceId ? "Use Marinara player" : "Enable Marinara player"}
+              title={sdkDeviceId ? "Use Guksu player" : "Enable Guksu player"}
             >
               {browserPlaybackLoading ? (
                 <Loader2 size="0.8125rem" className="animate-spin" />

--- a/packages/client/src/components/ui/CallClipGenerationModal.tsx
+++ b/packages/client/src/components/ui/CallClipGenerationModal.tsx
@@ -91,7 +91,7 @@ export function CallClipGenerationModal({
     <Modal open={open} onClose={onClose} title="Generate Call Clips" width="max-w-lg">
       <div className="space-y-4">
         <p className="text-sm leading-relaxed text-[var(--muted-foreground)]">
-          Generate video-call loop clips for {entityName}. Marinara will use the selected video generation connection.
+          Generate video-call loop clips for {entityName}. Guksu will use the selected video generation connection.
         </p>
 
         <label className="grid gap-1.5 text-xs font-semibold text-[var(--foreground)]">

--- a/packages/client/src/components/ui/ChibiProfessorMariEasterEgg.tsx
+++ b/packages/client/src/components/ui/ChibiProfessorMariEasterEgg.tsx
@@ -48,7 +48,7 @@ function showChibiProfessorMariToast() {
         />
         <div className="space-y-2 text-sm leading-relaxed">
           <p>
-            If you see this image while scrolling through Marinara Engine, you've been visited by the rare Chibi
+            If you see this image while scrolling through Guksu Motor, you've been visited by the rare Chibi
             Professor Mari!
           </p>
           <p>Good luck and fortune will come to you very soon. Make sure to say "thank you, Professor!"</p>

--- a/packages/client/src/components/ui/ExportFormatDialog.tsx
+++ b/packages/client/src/components/ui/ExportFormatDialog.tsx
@@ -19,8 +19,8 @@ interface ExportFormatDialogProps {
 export function ExportFormatDialog({
   open,
   title,
-  description = "Choose how Marinara should package this export.",
-  nativeDescription = "Keeps Marinara-specific fields, folders, metadata, and import fidelity.",
+  description = "Choose how Guksu should package this export.",
+  nativeDescription = "Keeps Guksu-specific fields, folders, metadata, and import fidelity.",
   compatibleDescription = "Uses folderless, platform-friendly JSON where possible for tools like SillyTavern and Chub.",
   pngDescription = "Chara Card V2 PNG with the avatar baked in — works in SillyTavern, Chub, and Risu.",
   showPngOption = false,
@@ -33,7 +33,7 @@ export function ExportFormatDialog({
     icon: typeof Layers;
     description: string;
   }> = [
-    { id: "native", label: "Marinara Native", icon: Layers, description: nativeDescription },
+    { id: "native", label: "Guksu Native", icon: Layers, description: nativeDescription },
     { id: "compatible", label: "Compatible JSON", icon: FileJson, description: compatibleDescription },
     ...(showPngOption
       ? [{ id: "compatible-png" as const, label: "Compatible PNG Card", icon: ImageDown, description: pngDescription }]

--- a/packages/client/src/components/ui/GifPicker.tsx
+++ b/packages/client/src/components/ui/GifPicker.tsx
@@ -226,7 +226,7 @@ export function GifPicker({ open, onClose, onSelect, anchorRef, containerRef, em
                 <p className="text-xs font-semibold text-foreground/85">GIF search needs a GIPHY API key.</p>
                 <p className="mt-1 text-[0.6875rem] leading-relaxed text-foreground/55">
                   Create a free key, paste it into <code className={setupCodeClass}>GIPHY_API_KEY</code> in your{" "}
-                  <code className={setupCodeClass}>.env</code> file, then restart Marinara.
+                  <code className={setupCodeClass}>.env</code> file, then restart Guksu.
                 </p>
               </div>
               <ol className="space-y-1 text-left text-[0.6875rem] leading-relaxed text-foreground/55">

--- a/packages/client/src/components/ui/ImagePromptReviewModal.tsx
+++ b/packages/client/src/components/ui/ImagePromptReviewModal.tsx
@@ -75,7 +75,7 @@ export function ImagePromptReviewModal({
     >
       <div className="flex max-h-[72vh] flex-col gap-4">
         <div className="text-xs leading-relaxed text-[var(--muted-foreground)]">
-          Edit the prompt{items.length === 1 ? "" : "s"} below before Marinara sends the {mediaLabel} request
+          Edit the prompt{items.length === 1 ? "" : "s"} below before Guksu sends the {mediaLabel} request
           {items.length === 1 ? "" : "s"} to your provider.
         </div>
 

--- a/packages/client/src/components/ui/SpriteGenerationModal.tsx
+++ b/packages/client/src/components/ui/SpriteGenerationModal.tsx
@@ -1898,11 +1898,11 @@ export function SpriteGenerationModal({
                 <span className="mt-0.5 block text-[0.625rem] leading-relaxed text-[var(--muted-foreground)]">
                   {animatedExpressionMode
                     ? "Adds a flat transparent-friendly background instruction to the video prompt. GIF transparency is not guaranteed."
-                    : "Uses native transparency when available. Otherwise, Marinara chooses a flat chroma matte that avoids the character's colors, removes it, and cleans color spill around soft edges."}
+                    : "Uses native transparency when available. Otherwise, Guksu chooses a flat chroma matte that avoids the character's colors, removes it, and cleans color spill around soft edges."}
                 </span>
                 {!animatedExpressionMode && selectedModelIsGptImage2 && nativeTransparentPng && (
                   <span className="mt-1 block text-[0.625rem] leading-relaxed text-[var(--muted-foreground)]">
-                    GPT-Image-2 does not support native transparency right now, so Marinara will use the adaptive matte
+                    GPT-Image-2 does not support native transparency right now, so Guksu will use the adaptive matte
                     fallback.
                   </span>
                 )}
@@ -2129,7 +2129,7 @@ export function SpriteGenerationModal({
               {generationProgress && <p className="mt-1 text-xs text-[var(--primary)]">{generationProgress}</p>}
               <p className="mt-1 text-xs text-[var(--muted-foreground)]">
                 {animatedExpressionMode
-                  ? "Each expression becomes a short video first, then Marinara converts it to a GIF sprite."
+                  ? "Each expression becomes a short video first, then Guksu converts it to a GIF sprite."
                   : fullBodyExpressionMode
                     ? "Each 2×2 batch gets one automatic retry before pausing for your decision."
                     : spriteType === "full-body"

--- a/packages/client/src/features/chat-settings/sections/TranslationSection.tsx
+++ b/packages/client/src/features/chat-settings/sections/TranslationSection.tsx
@@ -91,7 +91,7 @@ export function TranslationSection({ metadata, textConnections, onMetadataChange
                 <label className="text-[0.6875rem] font-medium text-[var(--muted-foreground)]">
                   AI Prompt
                   <HelpTooltip
-                    text="System prompt used by AI translation. Restoring uses Marinara's built-in default."
+                    text="System prompt used by AI translation. Restoring uses Guksu's built-in default."
                     size="0.625rem"
                   />
                 </label>

--- a/packages/client/src/hooks/use-themes.ts
+++ b/packages/client/src/hooks/use-themes.ts
@@ -177,7 +177,7 @@ export function useLegacyThemeMigration() {
         await qc.invalidateQueries({ queryKey: themeKeys.all });
       } catch (err) {
         console.warn("[Themes] Legacy custom theme migration failed; will retry on the next app start.", err);
-        toast.warning("Legacy theme migration paused. It will retry the next time Marinara starts.");
+        toast.warning("Legacy theme migration paused. It will retry the next time Guksu starts.");
       } finally {
         inFlightRef.current = false;
       }

--- a/packages/client/src/lib/api-client.ts
+++ b/packages/client/src/lib/api-client.ts
@@ -31,7 +31,7 @@ export class ApiError extends Error {
 }
 
 export const PRIVILEGED_ACCESS_HINT =
-  "This action needs loopback access or admin access. Open the app through localhost, or set ADMIN_SECRET=<secret> in the server .env and paste the same value in Settings → Advanced → Admin Access. Marinara sends it as the X-Admin-Secret header.";
+  "This action needs loopback access or admin access. Open the app through localhost, or set ADMIN_SECRET=<secret> in the server .env and paste the same value in Settings → Advanced → Admin Access. Guksu sends it as the X-Admin-Secret header.";
 
 /**
  * Build a user-facing message for a privileged-gated action (extension install,

--- a/packages/client/src/lib/character-import.ts
+++ b/packages/client/src/lib/character-import.ts
@@ -38,7 +38,7 @@ export function confirmEmbeddedLorebookImport(characterName: string, embeddedLor
   if (entryCount === 0) return true;
 
   return window.confirm(
-    `${characterName} includes an embedded lorebook with ${entryCount} entr${entryCount === 1 ? "y" : "ies"}.\n\nImport it as a standalone Marinara lorebook too?`,
+    `${characterName} includes an embedded lorebook with ${entryCount} entr${entryCount === 1 ? "y" : "ies"}.\n\nImport it as a standalone Guksu lorebook too?`,
   );
 }
 

--- a/packages/client/src/lib/csrf-fetch.ts
+++ b/packages/client/src/lib/csrf-fetch.ts
@@ -54,7 +54,7 @@ function notifyCsrf(body: CsrfErrorBody): void {
       ? body.hint
       : typeof body.error === "string" && body.error
         ? body.error
-        : "Marinara rejected this request as untrusted. Add this origin to CSRF_TRUSTED_ORIGINS in your .env, then try again.";
+        : "Guksu rejected this request as untrusted. Add this origin to CSRF_TRUSTED_ORIGINS in your .env, then try again.";
 
   toast.error(title, {
     description,

--- a/packages/client/src/lib/game-setup-share.ts
+++ b/packages/client/src/lib/game-setup-share.ts
@@ -301,7 +301,7 @@ export function parseGameSetupShareFileJson(text: string): GameSetupShareFile {
     throw new Error("Choose a reusable Game Mode setup JSON file, not the readable text summary.");
   }
   if (!isRecord(value) || value.format !== GAME_SETUP_SHARE_FORMAT) {
-    throw new Error("This is not a Marinara Game Mode setup file.");
+    throw new Error("This is not a Guksu Game Mode setup file.");
   }
   if (value.version !== GAME_SETUP_SHARE_VERSION) {
     throw new Error(`This Game Mode setup file uses unsupported version ${String(value.version ?? "unknown")}.`);
@@ -711,7 +711,7 @@ export function buildGameSetupSummarySections(source: GameSetupShareSource): Gam
 export function formatGameSetupShareText(source: GameSetupShareSource): string {
   const sections = buildGameSetupSummarySections(source);
   return [
-    `${source.gameName} - Marinara Game Mode Setup`,
+    `${source.gameName} - Guksu Game Mode Setup`,
     "Recreate this from Game > New Game. Local characters, personas, lorebooks, and connections are named but not included.",
     "",
     ...sections.flatMap((section) => [section.title, ...section.rows.map((row) => `${row.label}: ${row.value}`), ""]),

--- a/packages/client/src/lib/generation-fallback-notice.ts
+++ b/packages/client/src/lib/generation-fallback-notice.ts
@@ -31,7 +31,7 @@ export function showGenerationFallbackToast(raw: unknown): void {
   const connection = readNoticeText(notice.connectionName) ?? readNoticeText(notice.connectionId) ?? "fallback";
   const model = readNoticeText(notice.model);
   toast.info(`${categoryLabel(notice.category)} switched to ${connection}${model ? ` (${model})` : ""}.`, {
-    description: "The primary generation failed, so Marinara retried with your configured fallback.",
+    description: "The primary generation failed, so Guksu retried with your configured fallback.",
     duration: 10_000,
   });
 }

--- a/packages/client/src/lib/generation-parameter-errors.ts
+++ b/packages/client/src/lib/generation-parameter-errors.ts
@@ -78,7 +78,7 @@ export function formatGenerationParameterError(message: string): string {
   ]);
   if (missing) {
     if (missing.toLowerCase() === "model") {
-      return "The provider says the model field is missing. Marinara now sends the configured connection model automatically; if this keeps happening, remove any custom request parameter named model or re-save the connection's model.";
+      return "The provider says the model field is missing. Guksu now sends the configured connection model automatically; if this keeps happening, remove any custom request parameter named model or re-save the connection's model.";
     }
     return `The model says the ${missing} parameter is required. Go to Chat Settings > Advanced Parameters and turn on Send for ${missing}.`;
   }

--- a/packages/client/src/lib/host-device.ts
+++ b/packages/client/src/lib/host-device.ts
@@ -15,4 +15,4 @@ export function isHostDeviceBrowser(): boolean {
 }
 
 export const HOST_DEVICE_FILE_MANAGER_MESSAGE =
-  "System folders can only be opened from the device hosting Marinara Engine.";
+  "System folders can only be opened from the device hosting Guksu Motor.";

--- a/packages/client/src/lib/local-notifications.ts
+++ b/packages/client/src/lib/local-notifications.ts
@@ -103,7 +103,7 @@ export async function showLocalMessageNotification({
   if (typeof window === "undefined" || !("Notification" in window)) return false;
 
   const notification = new window.Notification(resolveMessageNotificationTitle(title, characterName), {
-    body: "Open Marinara to read it.",
+    body: "Open Guksu to read it.",
     icon: "/icon-192.png",
     tag,
   });
@@ -129,7 +129,7 @@ export function showNativeMessageNotification({
   }
   bridge.showNotification(
     resolveMessageNotificationTitle(title, characterName),
-    "Open Marinara to read it.",
+    "Open Guksu to read it.",
     tag ?? "message",
   );
   return true;

--- a/win/installer/install.bat
+++ b/win/installer/install.bat
@@ -1,7 +1,7 @@
 @echo off
 setlocal enabledelayedexpansion
 cd /d "%~dp0\.."
-title Marinara Engine - Installer
+title Guksu Motor - Installer
 color 0A
 
 :: -- Safety net: if anything goes catastrophically wrong, the window stays open --
@@ -17,7 +17,7 @@ set "RELEASE_COMMIT=%MARINARA_RELEASE_COMMIT%"
 
 echo.
 echo  +==========================================+
-echo  ^|   Marinara Engine - Windows Installer     ^|
+echo  ^|   Guksu Motor - Windows Installer         ^|
 echo  ^|   v2.3.3                                  ^|
 
 echo  +==========================================+
@@ -51,10 +51,10 @@ goto :after_same_install_dir_warning
 
 :warn_same_install_dir
 echo.
-echo  [WARN] You are reinstalling Marinara Engine into:
+echo  [WARN] You are reinstalling Guksu Motor into:
 echo         %INSTALL_DIR%
 echo.
-echo         Before continuing, copy the Marinara data folder(s) below to
+echo         Before continuing, copy the Guksu data folder(s) below to
 echo         a backup location outside this install folder if you want to
 echo         keep chats, characters, images, and settings:
 if exist "%INSTALL_DIR%\packages\server\data\" echo           %INSTALL_DIR%\packages\server\data
@@ -219,7 +219,7 @@ echo  [OK] pnpm !CURRENT_PNPM_VERSION! ready
 :: -- Clone repository --
 echo.
 if exist "%INSTALL_DIR%\.git" goto :update_repo
-echo  [..] Cloning Marinara Engine to %INSTALL_DIR%...
+echo  [..] Cloning Guksu Motor to %INSTALL_DIR%...
 git clone --branch "%RELEASE_TAG%" --depth 1 https://github.com/Pasta-Devs/Marinara-Engine.git "%INSTALL_DIR%"
 if errorlevel 1 (
     set "INSTALL_ERROR=Failed to clone release %RELEASE_TAG%. Check your internet connection and try again."
@@ -320,7 +320,7 @@ echo  [OK] Dependencies installed
 
 :: -- Build --
 echo.
-echo  [..] Building Marinara Engine...
+echo  [..] Building Guksu Motor...
 call :run_pnpm --filter @marinara-engine/shared build
 if %errorlevel% neq 0 (
     set "INSTALL_ERROR=Shared package build failed."
@@ -335,7 +335,7 @@ echo  [OK] Build complete
 
 :: -- Create desktop shortcut --
 echo  [..] Creating desktop shortcut...
-set "SHORTCUT=%USERPROFILE%\Desktop\Marinara Engine.lnk"
+set "SHORTCUT=%USERPROFILE%\Desktop\Guksu Motor.lnk"
 set "VBS=%TEMP%\create_shortcut.vbs"
 
 (
@@ -345,7 +345,7 @@ set "VBS=%TEMP%\create_shortcut.vbs"
     echo oLink.TargetPath = "%INSTALL_DIR%\start.bat"
     echo oLink.WorkingDirectory = "%INSTALL_DIR%"
     echo oLink.IconLocation = "%INSTALL_DIR%\win\installer\app-icon.ico,0"
-    echo oLink.Description = "Marinara Engine - AI Chat ^& Roleplay"
+    echo oLink.Description = "Guksu Motor - AI Chat ^& Roleplay"
     echo oLink.Save
 ) > "%VBS%"
 cscript //nologo "%VBS%"
@@ -357,7 +357,7 @@ echo.
 echo  ==========================================
 echo    Installation complete!
 echo.
-echo    To start: double-click "Marinara Engine"
+echo    To start: double-click "Guksu Motor"
 echo    on your Desktop, or run start.bat in:
 echo    %INSTALL_DIR%
 echo.

--- a/win/installer/installer.nsi
+++ b/win/installer/installer.nsi
@@ -12,7 +12,7 @@
 !insertmacro GetParent
 
 ; ── App metadata ──
-!define APP_NAME "Marinara Engine"
+!define APP_NAME "Guksu Motor"
 !define APP_VERSION "2.3.3"
 !define APP_PUBLISHER "Pasta-Devs"
 !define APP_URL "https://github.com/Pasta-Devs/Marinara-Engine"
@@ -33,7 +33,7 @@
 !endif
 
 Name "${APP_NAME}"
-OutFile "Marinara-Engine-Installer-${APP_VERSION}.exe"
+OutFile "Guksu-Motor-Installer-${APP_VERSION}.exe"
 InstallDir "${DEFAULT_DIR}"
 InstallDirRegKey HKCU "Software\${APP_NAME}" "InstallDir"
 RequestExecutionLevel user
@@ -70,7 +70,7 @@ Click Next to continue."
 ; ── Directory page ──
 !define MUI_DIRECTORYPAGE_TEXT_TOP "\
 Choose where to install ${APP_NAME}. About 2.5 GB of free space is recommended.$\r$\n$\r$\n\
-Upgrading? Choose the Marinara Engine folder that already has your data. Before reinstalling, back up packages\server\data, or the root data folder for older installs.$\r$\n$\r$\n\
+Upgrading? Choose the Guksu Motor folder that already has your data. Before reinstalling, back up packages\server\data, or the root data folder for older installs.$\r$\n$\r$\n\
 The installer will download app files and install dependencies."
 
 ; ── Finish page ──
@@ -184,7 +184,7 @@ Function WarnSameDirectoryReinstall
   MessageBox MB_YESNO|MB_ICONEXCLAMATION "\
 You are reinstalling ${APP_NAME} into the same folder:$\r$\n\
 $INSTDIR$\r$\n$\r$\n\
-Before continuing, copy the Marinara data folder(s) below to a backup location outside this install folder if you want to keep chats, characters, images, and settings:$\r$\n\
+Before continuing, copy the Guksu data folder(s) below to a backup location outside this install folder if you want to keep chats, characters, images, and settings:$\r$\n\
 $USER_DATA_PATHS$\r$\n$\r$\n\
 If a data folder contains marinara-engine.db, copy it together with marinara-engine.db-wal and marinara-engine.db-shm if present.$\r$\n$\r$\n\
 Continue anyway?" IDYES continueReinstallWarning


### PR DESCRIPTION
## Summary

Renames the product's *display name* from "Marinara Engine" to "Guksu Motor" (short form "Marinara" → "Guksu"). This is a user-facing-only rebrand — internal identifiers are deliberately left unchanged so existing installs, imports, and publishes keep working.

**Why:** requested rebrand of the product name across everything a user actually sees, without breaking the technical surface area that other things depend on.

**Changed (183 files):**
- README, CONTRIBUTING, android/README, and all of `docs/**` — prose only, code blocks/technical identifiers untouched. `CHANGELOG.md` is left as a historical record.
- Client UI copy (`packages/client/src/**`, `index.html`, `manifest.json`) — every literal string shown to users: titles, toasts, tooltips, error messages, PWA name.
- Windows installer (`win/installer/*`) — wizard title, downloaded filename, desktop shortcut, wizard/warning text.
- Android app label (`strings.xml` `app_name`) only.
- Home Assistant integration (`custom_components/marinara_engine/`) — config-flow strings and entity/device display names that render in HA's UI.
- Docker header comments only.
- Home screen footer attribution updated to "Created by Marinara, Fork by The Bird Internet Company".

**Deliberately unchanged (internal identifiers, kept stable):**
- npm package scope (`@marinara-engine/*`)
- Docker image/volume names
- Android `applicationId`/namespace (`com.marinara.engine`) — changing it would orphan existing installs
- CSS custom properties, event-bus keys, export/serialization "kind" identifiers
- Home Assistant integration `domain` slug (`marinara_engine`) — changing it would break existing HA config entries
- GitHub repo/org names (`Pasta-Devs/Marinara-Engine`, `EdenVapor/Marinara-Engine`) — out of scope for this change
- `ChatSettingsDrawer.tsx`'s `MARINARA_UNIVERSAL_PRESET_NAME` ("Marinara's Universal Preset") — tied to real seeded server data (`packages/server/src/db/seed.ts`, `default-preset.json`); renaming the *display* name needs a coordinated server-side change, out of scope here.

## Validation

- `pnpm check` (lint + typecheck + build across all workspaces) passes.
- `python3 -m py_compile` on the touched Home Assistant integration files passes.
- Grepped the full diff for accidental internal-identifier renames (`@guksu-*`, `--guksu-*` CSS vars, `guksu:` event keys, Android applicationId, npm package names) — none found.
- Caught and fixed one real bug during review: an early pass had renamed the external repo link `Pasta-Devs/Marinara-Agents` to `Guksu-Agents` in 11 doc files, which would have 404'd since that repo wasn't renamed (repo renames are out of scope). Reverted.

## Manual verification needed

- [ ] Visually check the client app in a browser — home screen, settings panel, onboarding tutorial, FAQ, import/export dialogs — for any leftover "Marinara" text or awkward phrasing from the rename.
- [ ] Build and run the Windows installer to confirm the wizard title, filename, and desktop shortcut look right end-to-end.
- [ ] Build the Android APK and confirm the launcher label reads "Guksu Motor".
- [ ] Install the Home Assistant integration fresh and confirm the config flow, device name, and entity names read correctly, and that upgrading an existing HA install (same `domain` slug) doesn't break existing entities.
- [ ] Spot-check a handful of `docs/**` pages for readability post-rename (large mechanical pass across 114 files).
- [ ] Confirm the new footer attribution text and formatting look right in the UI.

No linked issue/feature request exists for this change — consider opening one before merging, per `CONTRIBUTING.md § Before You Open a Pull Request`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WW8SWEhiubGxc7MPYXwXF6