### PR TITLE
feat(noodle): add private generation operation

### DIFF
--- a/packages/client/src/hooks/use-noodle.ts
+++ b/packages/client/src/hooks/use-noodle.ts
@@ -382,6 +382,7 @@ export function useRefreshNoodle() {
   return useMutation({
     mutationFn: (input: { personaId?: string; connectionId?: string }) =>
       api.post<NoodleRefreshResult>("/noodle/refresh", {
+        mode: "public",
         ...input,
         debugMode: useUIStore.getState().debugMode,
         reviewImagePromptsBeforeSend: useUIStore.getState().reviewImagePromptsBeforeSend,

--- a/packages/server/src/routes/noodle.routes.ts
+++ b/packages/server/src/routes/noodle.routes.ts
@@ -21,7 +21,7 @@ import {
   noodlePrivateAccountCreateSchema,
   noodleRemoveInteractionSchema,
   noodleRescheduleRefreshSchema,
-  noodleRefreshSchema,
+  noodleGenerationRequestSchema,
   noodleSettingsUpdateSchema,
   readNoodlePollFromMetadata,
   type NoodleAccount,
@@ -41,6 +41,7 @@ import { resolveNoodleAvatarCropAfterProfileUpdate } from "../services/noodle/no
 
 import { createPublicNoodleGenerationService } from "../services/noodle/noodle-public-generation.service.js";
 import { createPublicNoodleImagesService } from "../services/noodle/noodle-public-images.service.js";
+import { generatePrivatePost } from "../services/noodle/noodle-private-generation.service.js";
 import {
   bootstrapVisibleNoodle,
   characterAvatarCrop,
@@ -75,6 +76,7 @@ export async function noodleRoutes(app: FastifyInstance) {
   const publicGeneration = createPublicNoodleGenerationService(app.db);
   const publicImages = createPublicNoodleImagesService(app.db);
   let refreshInFlight = false;
+  const privateGenerationInFlight = new Set<string>();
 
   app.get("/", async () => {
     return bootstrapVisibleNoodle(noodle, characters);
@@ -474,10 +476,37 @@ export async function noodleRoutes(app: FastifyInstance) {
   });
 
   app.post("/refresh", async (req, reply) => {
-    const parsed = noodleRefreshSchema.safeParse(req.body);
+    const parsed = noodleGenerationRequestSchema.safeParse(req.body);
     if (!parsed.success) return reply.code(400).send({ error: parsed.error.flatten() });
     const settings = await noodle.getSettings();
+    if (parsed.data.mode === "private" && !settings.enableNoodler) {
+      return reply.code(404).send({ error: "Not Found" });
+    }
+    if (parsed.data.mode === "private" && privateGenerationInFlight.has(parsed.data.targetAccountId)) {
+      return reply.code(409).send({ error: "A generation for this NoodleR account is already running." });
+    }
+    if (parsed.data.mode === "private") privateGenerationInFlight.add(parsed.data.targetAccountId);
     const connectionId = parsed.data.connectionId ?? settings.generationConnectionId;
+    if (parsed.data.mode === "private") {
+      try {
+        if (!connectionId) {
+          return reply.code(400).send({ error: "Select a Noodle generation connection first." });
+        }
+        const conn = await connections.getWithKey(connectionId);
+        if (!conn) return reply.code(404).send({ error: "Noodle generation connection not found" });
+        const generated = await generatePrivatePost(app.db, {
+          request: parsed.data,
+          connection: conn,
+        });
+        if (!generated.ok) return reply.code(404).send({ error: generated.message });
+        return generated.post;
+      } catch (error) {
+        logger.error(error, "[noodler] Private post generation failed");
+        return reply.code(500).send({ error: getErrorMessage(error) });
+      } finally {
+        privateGenerationInFlight.delete(parsed.data.targetAccountId);
+      }
+    }
     if (!connectionId) return reply.code(400).send({ error: "Select a Noodle generation connection first." });
     const conn = await connections.getWithKey(connectionId);
     if (!conn) return reply.code(404).send({ error: "Noodle generation connection not found" });

--- a/packages/server/src/services/noodle/noodle-generation-log.ts
+++ b/packages/server/src/services/noodle/noodle-generation-log.ts
@@ -1,0 +1,5 @@
+import type { ChatMessage } from "../llm/base-provider.js";
+
+export function formatNoodleMessagesForLog(messages: readonly ChatMessage[]) {
+  return messages.map((message) => `${message.role.toUpperCase()}:\n${message.content}`).join("\n\n");
+}

--- a/packages/server/src/services/noodle/noodle-private-generation.service.ts
+++ b/packages/server/src/services/noodle/noodle-private-generation.service.ts
@@ -6,6 +6,7 @@ import {
   type NoodlePost,
   type NoodlePrivateGenerationRequest,
 } from "@marinara-engine/shared";
+import { isDebugAgentsEnabled } from "../../config/runtime-config.js";
 import type { DB } from "../../db/connection.js";
 import { logDebugOverride } from "../../lib/logger.js";
 import { resolveBaseUrl } from "../generation/connection-base-url.js";
@@ -116,7 +117,7 @@ export async function generatePrivatePost(
     recentPosts,
     request: input.request,
   });
-  const debugMode = input.request.debugMode === true;
+  const debugMode = input.request.debugMode === true || isDebugAgentsEnabled();
   logDebugOverride(debugMode, "[debug/noodler] Prompt sent to model:\n%s", formatNoodleMessagesForLog(messages));
   const completionOptions = {
     model: input.connection.model,

--- a/packages/server/src/services/noodle/noodle-private-generation.service.ts
+++ b/packages/server/src/services/noodle/noodle-private-generation.service.ts
@@ -1,0 +1,174 @@
+import {
+  createNoodlePoll,
+  noodleGeneratedPrivatePostSchema,
+  type APIProvider,
+  type NoodleAccount,
+  type NoodlePost,
+  type NoodlePrivateGenerationRequest,
+} from "@marinara-engine/shared";
+import type { DB } from "../../db/connection.js";
+import { logDebugOverride } from "../../lib/logger.js";
+import { resolveBaseUrl } from "../generation/connection-base-url.js";
+import { resolveStoredMaxTokens } from "../generation/generation-parameters.js";
+import { clampGenerationMaxOutputTokens } from "../generation/output-token-limits.js";
+import { parseGameJsonish } from "../game/jsonish.js";
+import { withConnectionFallbackProvider } from "../llm/connection-fallback-provider.js";
+import type { ChatMessage } from "../llm/base-provider.js";
+import { createLLMProvider } from "../llm/provider-registry.js";
+import { createConnectionsStorage } from "../storage/connections.storage.js";
+import { createNoodleStorage } from "../storage/noodle.storage.js";
+import { normalizeNoodleImagePrompt } from "./noodle-image-prompt.js";
+import { formatNoodleMessagesForLog } from "./noodle-generation-log.js";
+import { noodleResponseFormat } from "./noodle-response-format.js";
+
+type GenerationConnection = NonNullable<Awaited<ReturnType<ReturnType<typeof createConnectionsStorage>["getWithKey"]>>>;
+
+export type PrivatePostGenerationInput = {
+  request: NoodlePrivateGenerationRequest;
+  connection: GenerationConnection;
+};
+
+export type PrivatePostGenerationResult =
+  | { ok: true; post: NoodlePost }
+  | { ok: false; error: "private_account_not_found"; message: string };
+
+const PRIVATE_POST_MAX_TOKENS = 2048;
+
+function formatPrivatePostHistory(posts: NoodlePost[]): string {
+  if (posts.length === 0) return "No previous posts on this private page.";
+  return posts
+    .slice()
+    .reverse()
+    .map((post) => `- ${post.createdAt}: ${post.content}`)
+    .join("\n");
+}
+
+export function buildPrivatePostMessages(input: {
+  account: Pick<NoodleAccount, "displayName" | "handle" | "bio">;
+  recentPosts: NoodlePost[];
+  request: Pick<NoodlePrivateGenerationRequest, "privatePostGuide" | "privateProjectWork">;
+}): ChatMessage[] {
+  const system = [
+    "You write exactly one post for one private NoodleR creator page in Marinara Engine.",
+    "Write only as the supplied private account. Do not create other accounts, interactions, follows, or public timeline activity.",
+    "Use the private profile as supplied. Do not infer or reveal a linked public identity.",
+    "An optional imagePrompt must be a concrete visual description for this post, or null when no image fits.",
+    "Return one JSON object with content, imagePrompt, and poll. Set poll to null unless a two-to-four-option poll naturally fits.",
+    "Return JSON only. No prose outside the JSON object.",
+  ].join("\n");
+  const user = [
+    "# Private account",
+    `Display name: ${input.account.displayName}`,
+    `Handle: @${input.account.handle}`,
+    `Bio: ${input.account.bio || "No bio provided."}`,
+    "",
+    "# Recent private posts",
+    formatPrivatePostHistory(input.recentPosts),
+    ...(input.request.privatePostGuide ? ["", "# Post direction", input.request.privatePostGuide] : []),
+    ...(input.request.privateProjectWork ? ["", "# Project work direction", input.request.privateProjectWork] : []),
+  ].join("\n");
+  return [
+    { role: "system", content: system },
+    { role: "user", content: user },
+  ];
+}
+
+function parsePrivatePost(content: string) {
+  return noodleGeneratedPrivatePostSchema.parse(parseGameJsonish(content));
+}
+
+export async function generatePrivatePost(
+  db: DB,
+  input: PrivatePostGenerationInput,
+): Promise<PrivatePostGenerationResult> {
+  const noodle = createNoodleStorage(db);
+  const account = await noodle.getPrivateAccountById(input.request.targetAccountId);
+  if (!account) {
+    return {
+      ok: false,
+      error: "private_account_not_found",
+      message: "NoodleR account not found.",
+    };
+  }
+
+  const connections = createConnectionsStorage(db);
+  const fallbackConnection = await connections.getFallbackForMain();
+  const provider = withConnectionFallbackProvider({
+    primary: createLLMProvider(
+      input.connection.provider,
+      resolveBaseUrl(input.connection),
+      input.connection.apiKey,
+      input.connection.maxContext,
+      input.connection.openrouterProvider,
+      input.connection.maxTokensOverride,
+      input.connection.claudeFastMode === "true",
+      input.connection.treatAsLocalEndpoint === "true",
+      input.connection.defaultParameters,
+    ),
+    primaryConnectionId: input.connection.id,
+    fallbackConnection,
+    fallbackBaseUrl: fallbackConnection ? resolveBaseUrl(fallbackConnection) : "",
+    category: "main",
+  });
+  const recentPosts = await noodle.listPrivatePostsByAccount(account.id, 8);
+  const messages = buildPrivatePostMessages({
+    account,
+    recentPosts,
+    request: input.request,
+  });
+  const debugMode = input.request.debugMode === true;
+  logDebugOverride(debugMode, "[debug/noodler] Prompt sent to model:\n%s", formatNoodleMessagesForLog(messages));
+  const completionOptions = {
+    model: input.connection.model,
+    maxTokens: clampGenerationMaxOutputTokens({
+      provider: input.connection.provider as APIProvider,
+      model: input.connection.model,
+      maxTokens: resolveStoredMaxTokens(input.connection.defaultParameters, PRIVATE_POST_MAX_TOKENS),
+      maxTokensOverride: input.connection.maxTokensOverride,
+    }),
+    temperature: 0.9,
+    topP: 0.95,
+    stream: false,
+    debugMode,
+    responseFormat: noodleResponseFormat(input.connection.model, "private_post"),
+  } as const;
+
+  let response = await provider.chatComplete(messages, completionOptions);
+  let content = response.content ?? "";
+  logDebugOverride(debugMode, "[debug/noodler] Raw model response (attempt 1):\n%s", content);
+  let generated;
+  try {
+    generated = parsePrivatePost(content);
+  } catch (error) {
+    const correctionMessages: ChatMessage[] = [
+      ...messages,
+      { role: "assistant", content },
+      {
+        role: "user",
+        content:
+          "The response was not one valid private-post JSON object. Return exactly one object with content, imagePrompt, and poll. Return JSON only.",
+      },
+    ];
+    logDebugOverride(
+      debugMode,
+      "[debug/noodler] Correction prompt sent to model:\n%s",
+      formatNoodleMessagesForLog(correctionMessages),
+    );
+    response = await provider.chatComplete(correctionMessages, completionOptions);
+    content = response.content ?? "";
+    logDebugOverride(debugMode, "[debug/noodler] Raw model response (attempt 2):\n%s", content);
+    generated = parsePrivatePost(content);
+  }
+
+  const poll = generated.poll ? createNoodlePoll(generated.poll) : null;
+  const post = await noodle.createPrivatePost({
+    authorAccountId: account.id,
+    content: generated.content,
+    imageUrl: null,
+    imagePrompt: normalizeNoodleImagePrompt(generated.imagePrompt),
+    source: "generated",
+    metadata: { ...(poll ? { poll } : {}) },
+  });
+  if (!post) throw new Error("Failed to persist the generated private NoodleR post.");
+  return { ok: true, post };
+}

--- a/packages/server/src/services/noodle/noodle-public-generation.service.ts
+++ b/packages/server/src/services/noodle/noodle-public-generation.service.ts
@@ -40,6 +40,7 @@ import {
 } from "./noodle-public-support.js";
 import { noodleResponseFormat } from "./noodle-response-format.js";
 import { isUnsupportedNoodleVisionInputError } from "./noodle-vision.js";
+import { formatNoodleMessagesForLog } from "./noodle-generation-log.js";
 
 type PublicGenerationConnection = NonNullable<
   Awaited<ReturnType<ReturnType<typeof createConnectionsStorage>["getWithKey"]>>
@@ -107,10 +108,6 @@ function sinceHoursIso(hours: number) {
 
 function timelineRefreshMaxTokens(characterCount: number) {
   return 4096 + Math.max(0, characterCount) * 1024;
-}
-
-export function formatNoodleMessagesForLog(messages: readonly ChatMessage[]) {
-  return messages.map((message) => `${message.role.toUpperCase()}:\n${message.content}`).join("\n\n");
 }
 
 async function ensureRandomUserAccounts(noodle: ReturnType<typeof createNoodleStorage>) {

--- a/packages/server/src/services/noodle/noodle-refresh-scheduler.service.ts
+++ b/packages/server/src/services/noodle/noodle-refresh-scheduler.service.ts
@@ -128,7 +128,7 @@ export function startNoodleRefreshScheduler(app: FastifyInstance) {
       const response = await app.inject({
         method: "POST",
         url: "/api/noodle/refresh",
-        payload: {},
+        payload: { mode: "public" },
       });
       const completedAt = new Date();
       const latest = await noodle.ensureRefreshSchedule(completedAt);

--- a/packages/server/src/services/noodle/noodle-response-format.ts
+++ b/packages/server/src/services/noodle/noodle-response-format.ts
@@ -104,15 +104,27 @@ const profilesSchema = {
   additionalProperties: false,
 } as const;
 
+const privatePostSchema = {
+  type: "object",
+  properties: {
+    content: { type: "string" },
+    imagePrompt: nullableString,
+    poll: pollSchema,
+  },
+  required: ["content", "imagePrompt", "poll"],
+  additionalProperties: false,
+} as const;
+
 export function noodleResponseFormat(
   model: string,
-  kind: "timeline" | "profiles",
+  kind: "timeline" | "profiles" | "private_post",
 ): { type: string; [key: string]: unknown } {
   if (!isOpenAIGpt56Model(model)) return { type: "json_object" };
+  const schema = kind === "timeline" ? timelineSchema : kind === "profiles" ? profilesSchema : privatePostSchema;
   return {
     type: "json_schema",
-    name: kind === "timeline" ? "noodle_timeline" : "noodle_profiles",
-    schema: kind === "timeline" ? timelineSchema : profilesSchema,
+    name: kind === "timeline" ? "noodle_timeline" : kind === "profiles" ? "noodle_profiles" : "noodler_private_post",
+    schema,
     strict: true,
   };
 }

--- a/packages/server/src/services/storage/noodle.storage.ts
+++ b/packages/server/src/services/storage/noodle.storage.ts
@@ -795,6 +795,56 @@ export function createNoodleStorage(db: DB) {
       return rows.map(mapPost);
     },
 
+    async listPrivatePostsByAccount(accountId: string, limit = 8): Promise<NoodlePost[]> {
+      const account = await this.getPrivateAccountById(accountId);
+      if (!account) return [];
+      const rows = await db
+        .select()
+        .from(noodlePosts)
+        .where(eq(noodlePosts.authorAccountId, accountId))
+        .orderBy(desc(noodlePosts.createdAt))
+        .limit(Math.max(1, Math.min(50, Math.floor(limit))));
+      return rows.map(mapPost);
+    },
+
+    async getPrivatePostById(id: string): Promise<NoodlePost | null> {
+      const rows = await db.select().from(noodlePosts).where(eq(noodlePosts.id, id));
+      const row = rows[0];
+      if (!row || !(await this.getPrivateAccountById(row.authorAccountId))) return null;
+      return mapPost(row);
+    },
+
+    async createPrivatePost(
+      input: Omit<NoodleCreatePostInput, "authorKind" | "authorEntityId"> & {
+        authorAccountId: string;
+        source?: NoodlePostSource;
+        metadata?: Record<string, unknown>;
+      },
+    ): Promise<NoodlePost | null> {
+      const account = await this.getPrivateAccountById(input.authorAccountId);
+      if (!account) return null;
+      const timestamp = now();
+      const id = newId();
+      return db.transaction(async (tx) => {
+        await tx.insert(noodlePosts).values({
+          id,
+          authorAccountId: input.authorAccountId,
+          content: input.content,
+          imageUrl: input.imageUrl ?? null,
+          imagePrompt: input.imagePrompt ?? null,
+          parentPostId: input.parentPostId ?? null,
+          quotePostId: input.quotePostId ?? null,
+          source: input.source ?? "manual",
+          metadata: JSON.stringify(input.metadata ?? {}),
+          authorSnapshot: JSON.stringify(snapshotForAccount(account)),
+          createdAt: timestamp,
+          updatedAt: timestamp,
+        });
+        const rows = await tx.select().from(noodlePosts).where(eq(noodlePosts.id, id));
+        return rows[0] ? mapPost(rows[0]) : null;
+      });
+    },
+
     async createPost(
       input: Omit<NoodleCreatePostInput, "authorKind" | "authorEntityId"> & {
         authorAccountId: string;

--- a/packages/shared/src/schemas/noodle.schema.ts
+++ b/packages/shared/src/schemas/noodle.schema.ts
@@ -290,12 +290,38 @@ export const noodleInteractionUpdateSchema = noodleInteractionOwnerSchema
     message: "Provide comment text or an image update.",
   });
 
-export const noodleRefreshSchema = z.object({
-  personaId: z.string().min(1).optional(),
+const noodleGenerationConnectionShape = {
   connectionId: z.string().min(1).optional(),
   debugMode: z.boolean().optional(),
-  reviewImagePromptsBeforeSend: z.boolean().optional(),
-});
+};
+
+export const noodlePublicGenerationRequestSchema = z
+  .object({
+    mode: z.literal("public"),
+    ...noodleGenerationConnectionShape,
+    personaId: z.string().min(1).optional(),
+    reviewImagePromptsBeforeSend: z.boolean().optional(),
+  })
+  .strict();
+
+export const noodlePrivatePostGuideSchema = z.string().trim().min(1).max(2000);
+
+export const noodlePrivateProjectWorkSchema = z.string().trim().min(1).max(4000);
+
+export const noodlePrivateGenerationRequestSchema = z
+  .object({
+    mode: z.literal("private"),
+    ...noodleGenerationConnectionShape,
+    targetAccountId: z.string().min(1),
+    privatePostGuide: noodlePrivatePostGuideSchema.optional(),
+    privateProjectWork: noodlePrivateProjectWorkSchema.optional(),
+  })
+  .strict();
+
+export const noodleGenerationRequestSchema = z.discriminatedUnion("mode", [
+  noodlePublicGenerationRequestSchema,
+  noodlePrivateGenerationRequestSchema,
+]);
 
 export const noodleRescheduleRefreshSchema = z.object({
   scheduledTime: z.string().datetime(),
@@ -310,6 +336,14 @@ export const noodleGeneratedPostSchema = z.object({
   attachGalleryImage: z.boolean().optional().default(false),
   poll: noodlePollInputSchema.nullable().optional(),
 });
+
+export const noodleGeneratedPrivatePostSchema = z
+  .object({
+    content: z.string().trim().min(1).max(4000),
+    imagePrompt: z.string().max(2000).nullable().optional(),
+    poll: noodlePollInputSchema.nullable().optional(),
+  })
+  .strict();
 
 export const noodleGeneratedInteractionSchema = z
   .object({
@@ -414,8 +448,24 @@ export type NoodleCreateInteractionInput = z.infer<typeof noodleCreateInteractio
 export type NoodleRemoveInteractionInput = z.infer<typeof noodleRemoveInteractionSchema>;
 export type NoodleInteractionOwnerInput = z.infer<typeof noodleInteractionOwnerSchema>;
 export type NoodleInteractionUpdateInput = z.infer<typeof noodleInteractionUpdateSchema>;
-export type NoodleRefreshInput = z.infer<typeof noodleRefreshSchema>;
+type InferredNoodlePublicGenerationRequest = z.infer<typeof noodlePublicGenerationRequestSchema>;
+type AssertNoKeys<T extends never> = T;
+export type NoodlePublicGenerationRequest = InferredNoodlePublicGenerationRequest &
+  Record<
+    AssertNoKeys<
+      Extract<
+        keyof InferredNoodlePublicGenerationRequest,
+        "targetAccountId" | "privatePostGuide" | "privateProjectWork"
+      >
+    >,
+    never
+  >;
+export type NoodlePrivatePostGuide = z.infer<typeof noodlePrivatePostGuideSchema>;
+export type NoodlePrivateProjectWork = z.infer<typeof noodlePrivateProjectWorkSchema>;
+export type NoodlePrivateGenerationRequest = z.infer<typeof noodlePrivateGenerationRequestSchema>;
+export type NoodleGenerationRequest = z.infer<typeof noodleGenerationRequestSchema>;
 export type NoodleRescheduleRefreshInput = z.infer<typeof noodleRescheduleRefreshSchema>;
 export type NoodleGeneratedRefresh = z.infer<typeof noodleGeneratedRefreshSchema>;
+export type NoodleGeneratedPrivatePost = z.infer<typeof noodleGeneratedPrivatePostSchema>;
 export type NoodleGeneratedProfiles = z.infer<typeof noodleGeneratedProfilesSchema>;
 export type NoodleGeneratedProfile = z.infer<typeof noodleGeneratedProfileSchema>;

--- a/scripts/regressions/noodle-prompt.regression.ts
+++ b/scripts/regressions/noodle-prompt.regression.ts
@@ -1,5 +1,8 @@
 import assert from "node:assert/strict";
-import { DEFAULT_NOODLE_SETTINGS, noodleRefreshSchema } from "../../packages/shared/src/schemas/noodle.schema.js";
+import {
+  DEFAULT_NOODLE_SETTINGS,
+  noodleGenerationRequestSchema,
+} from "../../packages/shared/src/schemas/noodle.schema.js";
 import { canManageNoodleReply } from "../../packages/shared/src/utils/noodle-interactions.js";
 import type { NoodleAccount, NoodleInteraction, NoodlePost } from "../../packages/shared/src/types/noodle.js";
 import { LIMITS, PROFESSOR_MARI_ID } from "../../packages/shared/src/constants/defaults.js";
@@ -48,7 +51,8 @@ import { normalizeNoodleImagePrompt } from "../../packages/server/src/services/n
 import { characterAppearanceFromRow } from "../../packages/server/src/services/noodle/noodle-public-images.service.js";
 import { buildNoodleProfileTargetBlock } from "../../packages/server/src/services/noodle/noodle-public-profiles.service.js";
 import { buildOptedInChatContext } from "../../packages/server/src/services/noodle/noodle-public-prompt.service.js";
-import { formatNoodleMessagesForLog } from "../../packages/server/src/services/noodle/noodle-public-generation.service.js";
+import { formatNoodleMessagesForLog } from "../../packages/server/src/services/noodle/noodle-generation-log.js";
+import { buildPrivatePostMessages } from "../../packages/server/src/services/noodle/noodle-private-generation.service.js";
 import { resolveStoredMaxTokens } from "../../packages/server/src/services/generation/generation-parameters.js";
 import { clampGenerationMaxOutputTokens } from "../../packages/server/src/services/generation/output-token-limits.js";
 import {
@@ -321,7 +325,68 @@ assert.equal(
 assert.equal(canGenerateNoodleActivityForAccountKind("persona"), false);
 assert.equal(canGenerateNoodleActivityForAccountKind("character"), true);
 assert.equal(canGenerateNoodleActivityForAccountKind("random_user"), true);
-assert.equal(noodleRefreshSchema.parse({ reviewImagePromptsBeforeSend: true }).reviewImagePromptsBeforeSend, true);
+assert.equal(
+  noodleGenerationRequestSchema.parse({ mode: "public", reviewImagePromptsBeforeSend: true })
+    .reviewImagePromptsBeforeSend,
+  true,
+);
+assert.equal(noodleGenerationRequestSchema.safeParse({ mode: "public", personaId: "persona-1" }).success, true);
+assert.equal(
+  noodleGenerationRequestSchema.safeParse({
+    mode: "private",
+    targetAccountId: "private-1",
+    privatePostGuide: "Write about tonight.",
+    privateProjectWork: "Advance the current beat.",
+  }).success,
+  true,
+);
+assert.equal(noodleGenerationRequestSchema.safeParse({}).success, false);
+assert.equal(noodleGenerationRequestSchema.safeParse({ mode: "private" }).success, false);
+assert.equal(noodleGenerationRequestSchema.safeParse({ mode: "public", targetAccountId: "private-1" }).success, false);
+assert.equal(
+  noodleGenerationRequestSchema.safeParse({
+    mode: "public",
+    privatePostGuide: "Write about tonight.",
+  }).success,
+  false,
+);
+assert.equal(
+  noodleGenerationRequestSchema.safeParse({
+    mode: "public",
+    privateProjectWork: "Advance the current beat.",
+  }).success,
+  false,
+);
+assert.equal(
+  noodleGenerationRequestSchema.safeParse({
+    mode: "private",
+    targetAccountId: "private-1",
+    personaId: "persona-1",
+  }).success,
+  false,
+);
+assert.equal(
+  noodleGenerationRequestSchema.safeParse({
+    mode: "private",
+    targetAccountId: "private-1",
+    reviewImagePromptsBeforeSend: true,
+  }).success,
+  false,
+);
+const privatePostMessages = buildPrivatePostMessages({
+  account: { displayName: "Private Name", handle: "private_handle", bio: "Private bio" },
+  recentPosts: [],
+  request: {
+    privatePostGuide: "Write about tonight.",
+    privateProjectWork: "Advance the current beat.",
+  },
+});
+assert.match(privatePostMessages[0]?.content ?? "", /exactly one post for one private NoodleR creator page/u);
+assert.match(privatePostMessages[0]?.content ?? "", /Do not infer or reveal a linked public identity/u);
+assert.match(privatePostMessages[1]?.content ?? "", /Private Name/u);
+assert.match(privatePostMessages[1]?.content ?? "", /Write about tonight\./u);
+assert.match(privatePostMessages[1]?.content ?? "", /Advance the current beat\./u);
+assert.doesNotMatch(privatePostMessages.map((message) => message.content).join("\n"), /subscriber|PPV|disclosure/u);
 assert.match(NOODLE_PERSONA_AUTHORSHIP_INSTRUCTION, /controlled exclusively by the user/u);
 assert.match(
   NOODLE_PERSONA_AUTHORSHIP_INSTRUCTION,


### PR DESCRIPTION
> **IMPORTANT: NOODLER IMPLEMENTATION PLAN - SLICE 4.** This PR is Slice 4, the private generation operation. It builds on Slice 1A (#3744), Slice 1B (#3751), Slice 2 (#3759), and Slice 3 (#3782). Later NoodleR capabilities, including stage identity and guided-generation UI, subscriptions and access, fan activity, automatic posting, cross-mode integration, and creator-project orchestration, remain intentionally out of scope.

## Linked issue

Closes #3793

## Summary

- Add `generatePrivatePost()` as a typed, single-account operation beside the public generation service established in Slice 3.
- Replace the flattened refresh request with strict `mode: "public"` and `mode: "private"` schema variants.
- Restrict `targetAccountId`, `privatePostGuide`, and `privateProjectWork` to the private variant at both the Zod-schema and inferred-TypeScript levels.
- Add private-only post list/get/create storage operations without widening existing public account or post reads.
- Keep private generation out of public participant selection, interactions, follows, digests, bootstrap data, and refresh-run history.
- Preserve generated private image prompts for a later private-media workflow without serving private generated image files in this slice.

## Why

The original oversized NoodleR implementation added private targeted generation as optional branches throughout the public timeline pipeline. That allowed public-mode requests to carry private-only fields and coupled one private creator post to public participant selection, timeline activity, refresh runs, and later NoodleR policies.

This slice resolves P2 Finding 4 by making public and private generation different typed operations. The route validates and dispatches the discriminated request, but the private service never calls or branches inside the public generation service.

## Known limitations

- This PR adds the server operation only; Slice 5 owns stage identity, disclosure rules, and guided-generation UI.
- `privatePostGuide` and `privateProjectWork` are bounded instruction strings only. They do not define modal controls, project IDs, milestone lifecycle, access tiers, or scheduling behavior.
- Private image prompts are persisted, but private image generation/review/serving is intentionally deferred until a private media path can enforce isolation.
- No public client path invokes private generation yet; current public refresh callers now send `mode: "public"` explicitly.
- The full `pnpm regression` command passed every deterministic/non-browser lane, then Playwright failed before executing browser assertions because Chromium could not load the host library `libnspr4.so`.

## Test plan

- [ ] Run `pnpm check`.
- [ ] Run `pnpm guard:installer-artifacts`.
- [ ] Run `pnpm regression:noodle`.
- [ ] Run `pnpm regression` on a host with Playwright Chromium dependencies installed.
- [ ] Verify a public request containing `targetAccountId` returns HTTP 400 before generation starts.
- [ ] Verify a public request containing `privatePostGuide` returns HTTP 400 before generation starts.
- [ ] Verify a public request containing `privateProjectWork` returns HTTP 400 before generation starts.
- [ ] Verify a private request targeting a public account returns 404 and creates no post.
- [ ] Verify a private request targeting a private account creates exactly one private post.
- [ ] Verify the private post is absent from public account, post, bootstrap, digest, and refresh-run reads.
- [ ] Verify two concurrent requests for the same private account return one generation and one conflict response.
- [ ] Verify separate private accounts can generate independently.
- [ ] Verify malformed model output receives one correction attempt and valid corrected output persists.
- [ ] Verify NoodleR-disabled private requests return 404 without revealing connection configuration.

## Validation notes

A temporary deterministic service fixture used isolated file storage and a local OpenAI-compatible provider. It returned malformed output first and valid corrected output second. The proof confirmed one private post was persisted, its image prompt remained private with no served image URL, and the private account/post did not appear in public account, post, bootstrap, digest, or refresh-run reads. The temporary fixture was removed before commit.

`pnpm check`, `pnpm guard:installer-artifacts`, and `pnpm regression:noodle` passed locally. Every deterministic/non-browser lane in `pnpm regression` also passed. Playwright could not launch Chromium because `libnspr4.so` is missing from the host, so no browser assertions were personally verified.

## Docs touched

None. This slice adds an internal generation operation and request contract but no user-facing NoodleR generation workflow. User-facing documentation belongs with the later slice that exposes the operation in the UI.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for generating private posts for private accounts.
  * Added private post content, image prompts, polls, and optional guidance to generation requests.
  * Added storage and retrieval for private posts.
  * Added validation for public and private generation request formats.

* **Bug Fixes**
  * Refresh requests now explicitly identify public generation mode.
  * Added safeguards to prevent duplicate private generations for the same account.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->