### PR TITLE
fix: restore chroma styling for Roleplay transcript controls

### DIFF
--- a/packages/client/src/components/chat/TranscriptWindowControls.tsx
+++ b/packages/client/src/components/chat/TranscriptWindowControls.tsx
@@ -11,6 +11,8 @@ type TranscriptWindowControlsProps = {
   buttonClassName?: string;
 };
 
+const TRANSCRIPT_WINDOW_BUTTON_CLASS = "mari-chrome-control mari-chrome-control--small px-3 text-xs";
+
 export function TranscriptWindowControls({
   hiddenBeforeCount,
   hiddenAfterCount,
@@ -28,10 +30,7 @@ export function TranscriptWindowControls({
         <button
           type="button"
           onClick={onShowOlder}
-          className={cn(
-            "inline-flex items-center gap-1.5 rounded-lg border border-[var(--border)] bg-[var(--secondary)] px-3 py-1.5 text-xs font-medium text-[var(--muted-foreground)] transition-all hover:bg-[var(--accent)]",
-            buttonClassName,
-          )}
+          className={cn(TRANSCRIPT_WINDOW_BUTTON_CLASS, buttonClassName)}
         >
           <ChevronUp size="0.75rem" />
           Show older ({hiddenBeforeCount})
@@ -41,10 +40,7 @@ export function TranscriptWindowControls({
         <button
           type="button"
           onClick={onShowNewer}
-          className={cn(
-            "inline-flex items-center gap-1.5 rounded-lg border border-[var(--border)] bg-[var(--secondary)] px-3 py-1.5 text-xs font-medium text-[var(--muted-foreground)] transition-all hover:bg-[var(--accent)]",
-            buttonClassName,
-          )}
+          className={cn(TRANSCRIPT_WINDOW_BUTTON_CLASS, buttonClassName)}
         >
           <ChevronDown size="0.75rem" />
           Show newer ({hiddenAfterCount})
@@ -54,10 +50,7 @@ export function TranscriptWindowControls({
         <button
           type="button"
           onClick={onJumpToLatest}
-          className={cn(
-            "inline-flex items-center gap-1.5 rounded-lg border border-[var(--border)] bg-[var(--secondary)] px-3 py-1.5 text-xs font-medium text-[var(--muted-foreground)] transition-all hover:bg-[var(--accent)]",
-            buttonClassName,
-          )}
+          className={cn(TRANSCRIPT_WINDOW_BUTTON_CLASS, buttonClassName)}
         >
           Latest
         </button>

--- a/scripts/regressions/open-issues.regression.ts
+++ b/scripts/regressions/open-issues.regression.ts
@@ -738,6 +738,10 @@ const connectionsPanelSource = readFileSync(
   new URL("../../packages/client/src/components/panels/ConnectionsPanel.tsx", import.meta.url),
   "utf8",
 );
+const transcriptWindowControlsSource = readFileSync(
+  new URL("../../packages/client/src/components/chat/TranscriptWindowControls.tsx", import.meta.url),
+  "utf8",
+);
 const globalStyles = readFileSync(new URL("../../packages/client/src/styles/globals.css", import.meta.url), "utf8");
 const galleryRoutesSource = readFileSync(
   new URL("../../packages/server/src/routes/gallery.routes.ts", import.meta.url),
@@ -766,6 +770,15 @@ assert.doesNotMatch(gameAssetStoreSource, /api\.|fetchManifest|rescanAssets|\/ga
 assert.match(sidecarStoreSource, /consumeSidecarDownloadStream/u);
 assert.doesNotMatch(sidecarStoreSource, /readSseData|Best-effort delete|Best-effort unload/u);
 assert.match(connectionsPanelSource, /Failed to delete the Local Whisper model/u);
+assert.match(
+  transcriptWindowControlsSource,
+  /const TRANSCRIPT_WINDOW_BUTTON_CLASS = "mari-chrome-control mari-chrome-control--small px-3 text-xs";/u,
+);
+assert.equal(
+  transcriptWindowControlsSource.match(/className=\{cn\(TRANSCRIPT_WINDOW_BUTTON_CLASS, buttonClassName\)\}/gu)?.length,
+  3,
+);
+assert.doesNotMatch(transcriptWindowControlsSource, /text-\[var\(--muted-foreground\)\]/u);
 assert.match(galleryRoutesSource, /resolveIllustratorPromptRuntime\(\{[\s\S]*chatMetadata: meta/u);
 assert.match(
   conversationSelfieRuntimeSource,


### PR DESCRIPTION
## Linked issue

Closes #3797

## Why this change

- Roleplay's upper transcript-window control retained legacy muted text and secondary-button styling, so `Show older (number)` ignored the configured chroma accent and no longer matched the current controls.

## What changed

- Replace the shared transcript-window control's legacy button utilities with the existing small `mari-chrome-control` treatment.
- Apply the chroma-aware design consistently to `Show older`, `Show newer`, and `Latest` without changing their pagination behavior.
- Add a regression guard that rejects the legacy muted-foreground styling and verifies all three controls reuse the shared class.

## Validation

- [ ] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed `CONTRIBUTING.md`

### Manual verification notes

- Automated: `pnpm check` passed locally.
- Automated: `pnpm build:shared` followed by `pnpm regression:issues` passed on the final pushed staging lineage.
- Automated: the existing Roleplay surface smoke passed on desktop and mobile Chromium (2/2).
- Manual browser inspection was not completed because the in-app browser connection could not initialize. Verify a windowed Roleplay transcript with a non-default chroma accent before merge.
- A broader smoke invocation was stopped after encountering the unrelated existing desktop Roleplay panel timing failure; the correctly scoped Roleplay rerun passed.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Version/release files updated (only if this PR includes a version bump)

## UI evidence (if applicable)

- Not captured because the in-app browser connection was unavailable.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Standardized styling for transcript navigation buttons, including “Show older,” “Show newer,” and “Latest.”
  * Updated the button appearance to use the intended text color styling consistently.
* **Tests**
  * Added regression coverage to verify consistent transcript navigation button styling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->