### PR TITLE
fix: address July 19 issue sweep

### DIFF
--- a/e2e/core-flows.e2e.ts
+++ b/e2e/core-flows.e2e.ts
@@ -1,5 +1,6 @@
 import { expect, test, type Page } from "@playwright/test";
 import { readFileSync } from "node:fs";
+import { createServer } from "node:http";
 
 const TRANSPARENT_GIF_BASE64 = "R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw==";
 const WHATS_NEW_SEEN_VERSION_KEY = "marinara:whats-new:seen-version";
@@ -834,6 +835,65 @@ test("NPC avatar uploads accept Cyrillic character names", async ({ request }, t
     expect(imageResponse.headers()["content-type"]).toBe("image/gif");
   } finally {
     await request.delete(`/api/chats/${chat.id}`);
+  }
+});
+
+test("PocketTTS uses its OpenAI-compatible speech endpoint", async ({ request }, testInfo) => {
+  test.skip(!testInfo.project.name.includes("desktop"), "PocketTTS routing is covered on desktop.");
+
+  let receivedPath = "";
+  let receivedContentType = "";
+  let receivedBody = "";
+  const pocketTts = createServer((incoming, response) => {
+    const chunks: Buffer[] = [];
+    incoming.on("data", (chunk) => chunks.push(Buffer.from(chunk)));
+    incoming.on("end", () => {
+      receivedPath = incoming.url ?? "";
+      receivedContentType = String(incoming.headers["content-type"] ?? "");
+      receivedBody = Buffer.concat(chunks).toString("utf8");
+      response.writeHead(200, { "Content-Type": "audio/mpeg" });
+      response.end(Buffer.from([0x49, 0x44, 0x33]));
+    });
+  });
+  await new Promise<void>((resolve) => pocketTts.listen(0, "127.0.0.1", resolve));
+  const address = pocketTts.address();
+  if (!address || typeof address === "string") throw new Error("PocketTTS mock did not bind to a TCP port");
+
+  const originalConfigResponse = await request.get("/api/tts/config");
+  expect(originalConfigResponse.ok()).toBeTruthy();
+  const originalConfig = await originalConfigResponse.json();
+
+  try {
+    const configResponse = await request.put("/api/tts/config", {
+      data: {
+        enabled: true,
+        source: "pockettts",
+        baseUrl: `http://127.0.0.1:${address.port}`,
+        model: "pocket-tts",
+        voice: "alba",
+        audioFormat: "mp3",
+      },
+    });
+    expect(configResponse.ok()).toBeTruthy();
+
+    const speechResponse = await request.post("/api/tts/speak", {
+      data: { text: "Hello from Marinara." },
+    });
+    expect(speechResponse.ok()).toBeTruthy();
+    expect(receivedPath).toBe("/v1/audio/speech");
+    expect(receivedContentType).toContain("application/json");
+    expect(JSON.parse(receivedBody)).toMatchObject({
+      model: "pocket-tts",
+      input: "Hello from Marinara.",
+      voice: "alba",
+      response_format: "mp3",
+      speed: 1,
+    });
+  } finally {
+    await request.put("/api/tts/config", { data: originalConfig });
+    await new Promise<void>((resolve, reject) => {
+      pocketTts.close((error) => (error ? reject(error) : resolve()));
+    });
   }
 });
 

--- a/e2e/core-flows.e2e.ts
+++ b/e2e/core-flows.e2e.ts
@@ -809,6 +809,34 @@ test("game widget edits preserve their live numeric values", async ({ request },
   }
 });
 
+test("NPC avatar uploads accept Cyrillic character names", async ({ request }, testInfo) => {
+  test.skip(!testInfo.project.name.includes("desktop"), "NPC avatar upload compatibility is covered on desktop.");
+
+  const chatResponse = await request.post("/api/chats", {
+    data: { name: "Unicode NPC Avatar Smoke", mode: "roleplay", characterIds: [] },
+  });
+  expect(chatResponse.ok()).toBeTruthy();
+  const chat = (await chatResponse.json()) as { id: string };
+
+  try {
+    const uploadResponse = await request.post(`/api/avatars/npc/${chat.id}`, {
+      data: {
+        name: "Корвин",
+        avatar: `data:image/gif;base64,${TRANSPARENT_GIF_BASE64}`,
+      },
+    });
+    expect(uploadResponse.ok()).toBeTruthy();
+    const upload = (await uploadResponse.json()) as { avatarPath: string };
+    expect(decodeURIComponent(upload.avatarPath)).toContain("/корвин.gif?");
+
+    const imageResponse = await request.get(upload.avatarPath);
+    expect(imageResponse.ok()).toBeTruthy();
+    expect(imageResponse.headers()["content-type"]).toBe("image/gif");
+  } finally {
+    await request.delete(`/api/chats/${chat.id}`);
+  }
+});
+
 test("failed Game Lorebook Keeper run exposes a retry action", async ({ page }, testInfo) => {
   test.skip(!testInfo.project.name.includes("desktop"), "Game session recovery regression is covered on desktop.");
 

--- a/e2e/core-flows.e2e.ts
+++ b/e2e/core-flows.e2e.ts
@@ -4562,6 +4562,97 @@ test("chat mode tabs and new-chat actions stay reachable", async ({ page }) => {
   expect(errors).toEqual([]);
 });
 
+test("Roleplay reduced paint effects preserve semantic and custom styling", async ({ page }, testInfo) => {
+  test.skip(testInfo.project.name.includes("mobile"), "Reduced Roleplay paint styling is covered on desktop.");
+
+  const chatResponse = await page.request.post("/api/chats", {
+    data: { name: "Reduced Roleplay Paint Smoke", mode: "roleplay", characterIds: [] },
+  });
+  expect(chatResponse.ok()).toBeTruthy();
+  const chat = (await chatResponse.json()) as { id: string };
+
+  try {
+    const messageResponse = await page.request.post(`/api/chats/${chat.id}/messages`, {
+      data: {
+        role: "assistant",
+        content: "A semantic ring must survive the lighter paint profile.",
+        extra: { isConversationStart: true },
+      },
+    });
+    expect(messageResponse.ok()).toBeTruthy();
+
+    await page.addInitScript((chatId) => localStorage.setItem("marinara-active-chat-id", chatId), chat.id);
+    await page.goto("/");
+
+    const surface = page.locator('[data-chat-mode="roleplay"]');
+    const bubble = page.locator('[data-message-role="assistant"] .mari-rp-bubble').first();
+    await expect(surface).not.toHaveClass(/mari-rp-reduced-paint/);
+    await expect(bubble).toBeVisible();
+    await expect(page.locator(".rpg-vignette")).not.toHaveCSS("display", "none");
+
+    await page.locator('[data-tour="panel-settings"]').click();
+    await page.getByRole("tab", { name: "Appearance" }).click();
+    const reducedPaintToggle = page.getByLabel("Reduced paint effects");
+    await reducedPaintToggle.scrollIntoViewIfNeeded();
+    await page.getByText("Reduced paint effects", { exact: true }).click();
+    await expect(reducedPaintToggle).toBeChecked();
+
+    await expect(surface).toHaveClass(/mari-rp-reduced-paint/);
+    const reducedStyles = await bubble.evaluate((element) => {
+      const bubbleStyle = getComputedStyle(element);
+      const overlayStyle = getComputedStyle(document.querySelector(".rpg-overlay")!);
+      const vignetteStyle = getComputedStyle(document.querySelector(".rpg-vignette")!);
+      return {
+        backgroundImage: bubbleStyle.backgroundImage,
+        boxShadow: bubbleStyle.boxShadow,
+        dropShadow: bubbleStyle.getPropertyValue("--tw-shadow").trim(),
+        overlayBackgroundImage: overlayStyle.backgroundImage,
+        overlayBackgroundColor: overlayStyle.backgroundColor,
+        vignetteDisplay: vignetteStyle.display,
+      };
+    });
+    expect(reducedStyles.backgroundImage).toContain("linear-gradient");
+    expect(reducedStyles.dropShadow).toBe("0 0 #0000");
+    expect(reducedStyles.boxShadow).not.toBe("none");
+    expect(reducedStyles.overlayBackgroundImage).toBe("none");
+    expect(reducedStyles.overlayBackgroundColor).toBe("rgba(8, 8, 18, 0.5)");
+    expect(reducedStyles.vignetteDisplay).toBe("none");
+
+    await page.evaluate(() => {
+      const style = document.createElement("style");
+      style.id = "reduced-paint-card-css-smoke";
+      style.textContent = ".mari-card-css .mari-message-bubble { background: rgb(1, 2, 3); }";
+      document.head.append(style);
+    });
+    await expect(bubble).toHaveCSS("background-color", "rgb(1, 2, 3)");
+    await expect(bubble).toHaveCSS("background-image", "none");
+    await page.evaluate(() => document.getElementById("reduced-paint-card-css-smoke")?.remove());
+
+    await expect
+      .poll(() =>
+        page.evaluate(() => {
+          const persisted = JSON.parse(localStorage.getItem("marinara-engine-ui") ?? '{"state":{}}') as {
+            state?: { roleplayReducedPaintEffects?: unknown };
+          };
+          return persisted.state?.roleplayReducedPaintEffects;
+        }),
+      )
+      .toBe(true);
+
+    await page.reload();
+    await expect(surface).toHaveClass(/mari-rp-reduced-paint/);
+
+    // Exercise the transparent-bubble branch directly after proving the setting
+    // persisted. The production attribute is driven by the existing opacity state.
+    await bubble.evaluate((element) => element.setAttribute("data-roleplay-bubble-transparent", "true"));
+    await expect(bubble).toHaveCSS("background-image", "none");
+    await expect(bubble).toHaveCSS("background-color", "rgba(0, 0, 0, 0)");
+    await expect(bubble).not.toHaveCSS("box-shadow", "none");
+  } finally {
+    await page.request.delete(`/api/chats/${chat.id}`);
+  }
+});
+
 test("memory recall modal accepts clicks from chat settings", async ({ page }, testInfo) => {
   test.skip(!testInfo.project.name.includes("desktop"), "Memory recall modal regression is covered on desktop.");
 

--- a/e2e/core-flows.e2e.ts
+++ b/e2e/core-flows.e2e.ts
@@ -4476,7 +4476,7 @@ test("Noodle mobile shell keeps navigation usable across every view", async ({ p
   await expect(drawer).toHaveCount(0);
   const composer = page.getByRole("heading", { name: "New post" });
   await expect(composer).toBeVisible();
-  await page.getByRole("button", { name: "Close post composer" }).click();
+  await page.getByRole("button", { name: "Close New post" }).click();
 
   await noodle.getByRole("button", { name: "Open Noodle account menu" }).click();
   await accountMenu.getByRole("button", { name: "Settings", exact: true }).click();

--- a/e2e/core-flows.e2e.ts
+++ b/e2e/core-flows.e2e.ts
@@ -773,6 +773,42 @@ test("historical Game Peek Prompt returns the exact selected turn request", asyn
   }
 });
 
+test("game widget edits preserve their live numeric values", async ({ request }, testInfo) => {
+  test.skip(!testInfo.project.name.includes("desktop"), "Game widget persistence is covered on desktop.");
+
+  const chatResponse = await request.post("/api/chats", {
+    data: { name: "Game Widget Value Smoke", mode: "game", characterIds: [] },
+  });
+  expect(chatResponse.ok()).toBeTruthy();
+  const chat = (await chatResponse.json()) as { id: string };
+
+  try {
+    const widgets = [
+      {
+        id: "party-health",
+        type: "gauge",
+        label: "Party health",
+        position: "hud_left",
+        config: { startingValue: 20, value: 55, max: 100 },
+      },
+    ];
+    const updateResponse = await request.put(`/api/game/${chat.id}/widgets`, { data: { widgets } });
+    expect(updateResponse.ok()).toBeTruthy();
+
+    const storedResponse = await request.get(`/api/chats/${chat.id}`);
+    expect(storedResponse.ok()).toBeTruthy();
+    const storedChat = (await storedResponse.json()) as { metadata: string | Record<string, unknown> };
+    const metadata =
+      typeof storedChat.metadata === "string"
+        ? (JSON.parse(storedChat.metadata) as Record<string, unknown>)
+        : storedChat.metadata;
+    const storedWidgets = metadata.gameWidgetState as typeof widgets;
+    expect(storedWidgets[0]?.config).toMatchObject({ startingValue: 20, value: 55, max: 100 });
+  } finally {
+    await request.delete(`/api/chats/${chat.id}`);
+  }
+});
+
 test("failed Game Lorebook Keeper run exposes a retry action", async ({ page }, testInfo) => {
   test.skip(!testInfo.project.name.includes("desktop"), "Game session recovery regression is covered on desktop.");
 

--- a/e2e/core-flows.e2e.ts
+++ b/e2e/core-flows.e2e.ts
@@ -856,14 +856,16 @@ test("PocketTTS uses its OpenAI-compatible speech endpoint", async ({ request },
     });
   });
   await new Promise<void>((resolve) => pocketTts.listen(0, "127.0.0.1", resolve));
-  const address = pocketTts.address();
-  if (!address || typeof address === "string") throw new Error("PocketTTS mock did not bind to a TCP port");
-
-  const originalConfigResponse = await request.get("/api/tts/config");
-  expect(originalConfigResponse.ok()).toBeTruthy();
-  const originalConfig = await originalConfigResponse.json();
+  let originalConfig: unknown;
 
   try {
+    const address = pocketTts.address();
+    if (!address || typeof address === "string") throw new Error("PocketTTS mock did not bind to a TCP port");
+
+    const originalConfigResponse = await request.get("/api/tts/config");
+    expect(originalConfigResponse.ok()).toBeTruthy();
+    originalConfig = await originalConfigResponse.json();
+
     const configResponse = await request.put("/api/tts/config", {
       data: {
         enabled: true,
@@ -889,11 +891,35 @@ test("PocketTTS uses its OpenAI-compatible speech endpoint", async ({ request },
       response_format: "mp3",
       speed: 1,
     });
-  } finally {
-    await request.put("/api/tts/config", { data: originalConfig });
-    await new Promise<void>((resolve, reject) => {
-      pocketTts.close((error) => (error ? reject(error) : resolve()));
+
+    const fallbackConfigResponse = await request.put("/api/tts/config", {
+      data: {
+        enabled: true,
+        source: "pockettts",
+        baseUrl: `http://127.0.0.1:${address.port}`,
+        model: "pocket-tts",
+        voice: "",
+        audioFormat: "mp3",
+      },
     });
+    expect(fallbackConfigResponse.ok()).toBeTruthy();
+
+    const fallbackSpeechResponse = await request.post("/api/tts/speak", {
+      data: { text: "Use the default PocketTTS voice." },
+    });
+    expect(fallbackSpeechResponse.ok()).toBeTruthy();
+    expect(JSON.parse(receivedBody)).toMatchObject({
+      input: "Use the default PocketTTS voice.",
+      voice: "alba",
+    });
+  } finally {
+    try {
+      if (originalConfig !== undefined) await request.put("/api/tts/config", { data: originalConfig });
+    } finally {
+      await new Promise<void>((resolve, reject) => {
+        pocketTts.close((error) => (error ? reject(error) : resolve()));
+      });
+    }
   }
 });
 
@@ -4565,16 +4591,34 @@ test("chat mode tabs and new-chat actions stay reachable", async ({ page }) => {
 test("Roleplay reduced paint effects preserve semantic and custom styling", async ({ page }, testInfo) => {
   test.skip(testInfo.project.name.includes("mobile"), "Reduced Roleplay paint styling is covered on desktop.");
 
+  const characterResponse = await page.request.post("/api/characters", {
+    data: {
+      data: {
+        name: "Reduced Paint Tint",
+        extensions: { boxColor: "#123456" },
+      },
+    },
+  });
+  expect(characterResponse.ok()).toBeTruthy();
+  const character = (await characterResponse.json()) as { id: string };
   const chatResponse = await page.request.post("/api/chats", {
-    data: { name: "Reduced Roleplay Paint Smoke", mode: "roleplay", characterIds: [] },
+    data: { name: "Reduced Roleplay Paint Smoke", mode: "roleplay", characterIds: [character.id] },
   });
   expect(chatResponse.ok()).toBeTruthy();
   const chat = (await chatResponse.json()) as { id: string };
 
   try {
+    const userMessageResponse = await page.request.post(`/api/chats/${chat.id}/messages`, {
+      data: {
+        role: "user",
+        content: "The default bubble should become transparent.",
+      },
+    });
+    expect(userMessageResponse.ok()).toBeTruthy();
     const messageResponse = await page.request.post(`/api/chats/${chat.id}/messages`, {
       data: {
         role: "assistant",
+        characterId: character.id,
         content: "A semantic ring must survive the lighter paint profile.",
         extra: { isConversationStart: true },
       },
@@ -4586,6 +4630,7 @@ test("Roleplay reduced paint effects preserve semantic and custom styling", asyn
 
     const surface = page.locator('[data-chat-mode="roleplay"]');
     const bubble = page.locator('[data-message-role="assistant"] .mari-rp-bubble').first();
+    const defaultBubble = page.locator('[data-message-role="user"] .mari-rp-bubble').first();
     await expect(surface).not.toHaveClass(/mari-rp-reduced-paint/);
     await expect(bubble).toBeVisible();
     await expect(page.locator(".rpg-vignette")).not.toHaveCSS("display", "none");
@@ -4628,28 +4673,37 @@ test("Roleplay reduced paint effects preserve semantic and custom styling", asyn
     await expect(bubble).toHaveCSS("background-image", "none");
     await page.evaluate(() => document.getElementById("reduced-paint-card-css-smoke")?.remove());
 
+    const opacitySlider = page.getByLabel("Roleplay Messages Background Opacity");
+    await opacitySlider.focus();
+    for (let step = 0; step < 18; step += 1) await opacitySlider.press("ArrowLeft");
+    await expect(opacitySlider).toHaveValue("0");
+    await expect(defaultBubble).toHaveAttribute("data-roleplay-bubble-transparent", "true");
+    await expect(defaultBubble).toHaveCSS("background-image", "none");
+    await expect(defaultBubble).toHaveCSS("background-color", "rgba(0, 0, 0, 0)");
+    await expect(bubble).not.toHaveAttribute("data-roleplay-bubble-transparent", "true");
+    expect(await bubble.evaluate((element) => getComputedStyle(element).backgroundImage)).toContain("rgb(18, 52, 86)");
+
     await expect
       .poll(() =>
         page.evaluate(() => {
           const persisted = JSON.parse(localStorage.getItem("marinara-engine-ui") ?? '{"state":{}}') as {
-            state?: { roleplayReducedPaintEffects?: unknown };
+            state?: { roleplayReducedPaintEffects?: unknown; chatFontOpacity?: unknown };
           };
-          return persisted.state?.roleplayReducedPaintEffects;
+          return [persisted.state?.roleplayReducedPaintEffects, persisted.state?.chatFontOpacity];
         }),
       )
-      .toBe(true);
+      .toEqual([true, 0]);
 
     await page.reload();
     await expect(surface).toHaveClass(/mari-rp-reduced-paint/);
-
-    // Exercise the transparent-bubble branch directly after proving the setting
-    // persisted. The production attribute is driven by the existing opacity state.
-    await bubble.evaluate((element) => element.setAttribute("data-roleplay-bubble-transparent", "true"));
-    await expect(bubble).toHaveCSS("background-image", "none");
-    await expect(bubble).toHaveCSS("background-color", "rgba(0, 0, 0, 0)");
+    await expect(defaultBubble).toHaveAttribute("data-roleplay-bubble-transparent", "true");
+    await expect(bubble).not.toHaveAttribute("data-roleplay-bubble-transparent", "true");
     await expect(bubble).not.toHaveCSS("box-shadow", "none");
   } finally {
-    await page.request.delete(`/api/chats/${chat.id}`);
+    await Promise.all([
+      page.request.delete(`/api/chats/${chat.id}`).catch(() => undefined),
+      page.request.delete(`/api/characters/${character.id}`).catch(() => undefined),
+    ]);
   }
 });
 

--- a/packages/client/src/components/chat/ChatMessage.tsx
+++ b/packages/client/src/components/chat/ChatMessage.tsx
@@ -2130,9 +2130,7 @@ export const ChatMessage = memo(function ChatMessage({
 
             {/* Message bubble */}
             <div
-              data-roleplay-bubble-transparent={
-                chatFontOpacity <= 0 || roleplayBubbleBg === "transparent" ? "true" : undefined
-              }
+              data-roleplay-bubble-transparent={roleplayBubbleBg === "transparent" ? "true" : undefined}
               className={cn(
                 "mari-message-bubble mari-rp-bubble relative overflow-hidden rounded-2xl shadow-lg shadow-black/20",
                 roleplayAvatarsScrollable && showRoleplayAvatarPanel && "mari-rp-bubble--scrollable-avatar-panel",

--- a/packages/client/src/components/chat/ChatMessage.tsx
+++ b/packages/client/src/components/chat/ChatMessage.tsx
@@ -2130,6 +2130,9 @@ export const ChatMessage = memo(function ChatMessage({
 
             {/* Message bubble */}
             <div
+              data-roleplay-bubble-transparent={
+                chatFontOpacity <= 0 || roleplayBubbleBg === "transparent" ? "true" : undefined
+              }
               className={cn(
                 "mari-message-bubble mari-rp-bubble relative overflow-hidden rounded-2xl shadow-lg shadow-black/20",
                 roleplayAvatarsScrollable && showRoleplayAvatarPanel && "mari-rp-bubble--scrollable-avatar-panel",

--- a/packages/client/src/components/chat/ChatRoleplaySurface.tsx
+++ b/packages/client/src/components/chat/ChatRoleplaySurface.tsx
@@ -1284,6 +1284,7 @@ export function ChatRoleplaySurface({
   const sidebarOpen = useUIStore((s) => s.sidebarOpen);
   const rightPanelOpen = useUIStore((s) => s.rightPanelOpen);
   const chatBackgroundBlur = useUIStore((s) => s.chatBackgroundBlur);
+  const roleplayReducedPaintEffects = useUIStore((s) => s.roleplayReducedPaintEffects);
   const initialLoadSettledRef = useRef(false);
   const prevMessageKeysRef = useRef<Set<string>>(new Set());
   const seenMessageKeysRef = useRef(roleplayNotificationSeenKeys);
@@ -1507,7 +1508,10 @@ export function ChatRoleplaySurface({
   return (
     <div data-component="ChatArea.Roleplay" className="flex flex-1 overflow-hidden">
       <div
-        className="rpg-chat-area mari-chat-area mari-card-css relative flex flex-1 flex-col overflow-hidden"
+        className={cn(
+          "rpg-chat-area mari-chat-area mari-card-css relative flex flex-1 flex-col overflow-hidden",
+          roleplayReducedPaintEffects && "mari-rp-reduced-paint",
+        )}
         data-chat-mode="roleplay"
         style={{ isolation: "isolate" }}
       >

--- a/packages/client/src/components/panels/SettingsPanel.tsx
+++ b/packages/client/src/components/panels/SettingsPanel.tsx
@@ -954,6 +954,14 @@ const SETTINGS_SEARCHABLE_CONTROLS: readonly SettingsSearchableControlMeta[] = [
     kind: "Slider",
   },
   {
+    id: "roleplay-reduced-paint-effects",
+    sectionId: "roleplay-messages",
+    label: "Reduced paint effects",
+    description: "Flatten costly Roleplay transparency, shadows, and scene overlays.",
+    aliases: ["roleplay", "performance", "firefox", "slow", "paint", "effects"],
+    kind: "Toggle",
+  },
+  {
     id: "scrollable-avatars",
     sectionId: "roleplay-messages",
     label: "Scrollable Avatars",
@@ -3675,6 +3683,8 @@ function AppearanceSettings() {
   const setChatChromeTextColor = useUIStore((s) => s.setChatChromeTextColor);
   const chatFontOpacity = useUIStore((s) => s.chatFontOpacity);
   const setChatFontOpacity = useUIStore((s) => s.setChatFontOpacity);
+  const roleplayReducedPaintEffects = useUIStore((s) => s.roleplayReducedPaintEffects);
+  const setRoleplayReducedPaintEffects = useUIStore((s) => s.setRoleplayReducedPaintEffects);
   const roleplayAvatarStyle = useUIStore((s) => s.roleplayAvatarStyle);
   const setRoleplayAvatarStyle = useUIStore((s) => s.setRoleplayAvatarStyle);
   const roleplayAvatarScale = useUIStore((s) => s.roleplayAvatarScale);
@@ -4226,6 +4236,14 @@ function AppearanceSettings() {
               Reset opacity to default
             </button>
           </label>
+
+          <ToggleSetting
+            anchorId={getSettingsControlAnchorId("roleplay-reduced-paint-effects")}
+            label="Reduced paint effects"
+            checked={roleplayReducedPaintEffects}
+            onChange={setRoleplayReducedPaintEffects}
+            help="Flattens costly Roleplay transparency, shadows, and scene overlays to keep navigation responsive, especially in Firefox. Applies immediately in every browser."
+          />
 
           <div className="flex flex-col gap-2">
             <div className="flex items-center gap-1.5">

--- a/packages/client/src/stores/ui.store.ts
+++ b/packages/client/src/stores/ui.store.ts
@@ -668,6 +668,8 @@ interface UIState {
   chatChromeTextColor: string;
   /** Opacity for roleplay message backgrounds (0–100) */
   chatFontOpacity: number;
+  /** When true, flatten expensive Roleplay paint effects for smoother navigation. */
+  roleplayReducedPaintEffects: boolean;
   /** Layout style for roleplay message avatars */
   roleplayAvatarStyle: RoleplayAvatarStyle;
   /** Scale multiplier for Roleplay message avatars. */
@@ -946,6 +948,7 @@ interface UIState {
   setChatFontColor: (v: string) => void;
   setChatChromeTextColor: (v: string) => void;
   setChatFontOpacity: (v: number) => void;
+  setRoleplayReducedPaintEffects: (v: boolean) => void;
   setRoleplayAvatarStyle: (v: RoleplayAvatarStyle) => void;
   setRoleplayAvatarScale: (v: number) => void;
   setRoleplayAvatarsScrollable: (v: boolean) => void;
@@ -1344,6 +1347,7 @@ export const useUIStore = create<UIState>()(
       chatFontColor: "",
       chatChromeTextColor: "",
       chatFontOpacity: 90,
+      roleplayReducedPaintEffects: false,
       roleplayAvatarStyle: "circles" as RoleplayAvatarStyle,
       roleplayAvatarScale: 1,
       roleplayAvatarsScrollable: false,
@@ -2092,6 +2096,7 @@ export const useUIStore = create<UIState>()(
       setChatFontColor: (v) => set({ chatFontColor: v }),
       setChatChromeTextColor: (v) => set({ chatChromeTextColor: normalizeChatChromeTextColor(v) }),
       setChatFontOpacity: (v) => set({ chatFontOpacity: Math.max(0, Math.min(100, v)) }),
+      setRoleplayReducedPaintEffects: (v) => set({ roleplayReducedPaintEffects: v }),
       setRoleplayAvatarStyle: (v) => set({ roleplayAvatarStyle: v }),
       setRoleplayAvatarScale: (v) =>
         set({ roleplayAvatarScale: Math.max(ROLEPLAY_AVATAR_SCALE_MIN, Math.min(ROLEPLAY_AVATAR_SCALE_MAX, v)) }),
@@ -2142,6 +2147,7 @@ export const useUIStore = create<UIState>()(
           chatFontColor: "",
           chatChromeTextColor: "",
           chatFontOpacity: 90,
+          roleplayReducedPaintEffects: false,
           roleplayAvatarStyle: "circles" as RoleplayAvatarStyle,
           roleplayAvatarScale: 1,
           roleplayAvatarsScrollable: false,
@@ -2255,7 +2261,7 @@ export const useUIStore = create<UIState>()(
     }),
     {
       name: "marinara-engine-ui",
-      version: 76,
+      version: 77,
       // Debounce localStorage writes to avoid sync I/O on every state change
       storage: createJSONStorage(() => {
         let timer: ReturnType<typeof setTimeout> | null = null;
@@ -2809,10 +2815,14 @@ export const useUIStore = create<UIState>()(
           delete persisted.characterPanelFavoriteFilter;
           delete persisted.characterPanelScrollTop;
         }
+        if (version <= 76 && persisted.roleplayReducedPaintEffects === undefined) {
+          persisted.roleplayReducedPaintEffects = false;
+        }
         persisted.appAccentRgbMode = persisted.appAccentRgbMode === true;
         persisted.customCursorEnabled = persisted.customCursorEnabled !== false;
         persisted.professorMariSuggestionsEnabled = persisted.professorMariSuggestionsEnabled !== false;
         persisted.includeReasoningInExports = persisted.includeReasoningInExports === true;
+        persisted.roleplayReducedPaintEffects = persisted.roleplayReducedPaintEffects === true;
         persisted.chatChromeTextColor = normalizeChatChromeTextColor(persisted.chatChromeTextColor);
         persisted.defaultRoleplayBackground = normalizeDefaultRoleplayBackground(persisted.defaultRoleplayBackground);
         delete persisted.trackerPanelWidth;
@@ -2946,6 +2956,7 @@ export const useUIStore = create<UIState>()(
         chatFontColor: state.chatFontColor,
         chatChromeTextColor: state.chatChromeTextColor,
         chatFontOpacity: state.chatFontOpacity,
+        roleplayReducedPaintEffects: state.roleplayReducedPaintEffects,
         roleplayAvatarStyle: state.roleplayAvatarStyle,
         roleplayAvatarScale: state.roleplayAvatarScale,
         roleplayAvatarsScrollable: state.roleplayAvatarsScrollable,

--- a/packages/client/src/styles/globals.css
+++ b/packages/client/src/styles/globals.css
@@ -4035,6 +4035,22 @@ strong {
   background-color: var(--mari-rp-bubble-bg);
 }
 
+/* Optional low-paint Roleplay profile. Keep these selectors deliberately low
+   specificity so custom Card CSS can still replace message backgrounds. */
+.mari-rp-reduced-paint :where(.mari-rp-bubble) {
+  --tw-shadow: 0 0 #0000;
+  --tw-shadow-colored: 0 0 #0000;
+}
+
+.mari-rp-reduced-paint :where(.mari-rp-bubble:not([data-roleplay-bubble-transparent="true"])) {
+  background: linear-gradient(var(--mari-rp-bubble-bg), var(--mari-rp-bubble-bg)), var(--background);
+}
+
+.mari-rp-reduced-paint :where(.mari-rp-bubble[data-roleplay-bubble-transparent="true"]) {
+  background-color: transparent;
+  background-image: none;
+}
+
 /* ─────────────────────────────────────────────
    15. CHAT: ROLEPLAY MODE
    ───────────────────────────────────────────── */
@@ -4177,12 +4193,24 @@ strong {
   );
 }
 
+.mari-rp-reduced-paint > .rpg-overlay {
+  background: rgba(8, 8, 18, 0.5);
+}
+
+[data-theme="light"] .mari-rp-reduced-paint > .rpg-overlay {
+  background: rgba(250, 248, 255, 0.35);
+}
+
 .rpg-vignette {
   background: radial-gradient(ellipse at center, transparent 50%, rgba(0, 0, 0, 0.3) 100%);
 }
 
 [data-theme="light"] .rpg-vignette {
   background: radial-gradient(ellipse at center, transparent 60%, rgba(120, 100, 160, 0.12) 100%);
+}
+
+.mari-rp-reduced-paint > .rpg-vignette {
+  display: none;
 }
 
 .rpg-avatar-glow {

--- a/packages/server/src/routes/avatars.routes.ts
+++ b/packages/server/src/routes/avatars.routes.ts
@@ -6,6 +6,7 @@ import { existsSync, mkdirSync, writeFileSync } from "fs";
 import { join, extname } from "path";
 import { DATA_DIR } from "../utils/data-dir.js";
 import { assertInsideDir, isAllowedImageBuffer } from "../utils/security.js";
+import { npcAvatarSlug } from "../services/game/npc-avatar-utils.js";
 
 const AVATAR_DIR = join(DATA_DIR, "avatars");
 const NPC_AVATAR_DIR = join(AVATAR_DIR, "npc");
@@ -93,10 +94,7 @@ export async function avatarsRoutes(app: FastifyInstance) {
       return reply.status(400).send({ error: "Invalid avatar format — expected base64 data URL" });
     }
 
-    const safeName = name
-      .toLowerCase()
-      .replace(/[^a-z0-9]+/g, "-")
-      .replace(/(^-|-$)/g, "");
+    const safeName = npcAvatarSlug(name);
     if (!safeName) {
       return reply.status(400).send({ error: "Invalid character name" });
     }

--- a/packages/server/src/routes/chats.routes.ts
+++ b/packages/server/src/routes/chats.routes.ts
@@ -106,7 +106,7 @@ import {
   resolveMemoryRecallEmbeddingSource,
 } from "../services/memory-recall-embedding.js";
 import { applyRegexScriptsToPromptMessages } from "../services/regex/regex-application.js";
-import { sanitizeGameNpcAvatarUrls } from "../services/game/npc-avatar-utils.js";
+import { npcAvatarSlug, sanitizeGameNpcAvatarUrls } from "../services/game/npc-avatar-utils.js";
 import { buildCommittedTrackerContextBlock } from "../services/generation/committed-tracker-context.js";
 import { parseLorebookWriteApprovalText } from "./generate/agent-write-approval.js";
 import { persistLorebookKeeperUpdates } from "./generate/lorebook-keeper-utils.js";
@@ -1875,10 +1875,7 @@ export async function chatsRoutes(app: FastifyInstance) {
           continue;
         }
         // 2. Try loading a stored NPC avatar from disk
-        const safeName = name
-          .toLowerCase()
-          .replace(/[^a-z0-9]+/g, "-")
-          .replace(/(^-|-$)/g, "");
+        const safeName = npcAvatarSlug(name);
         if (safeName) {
           const npcPath = join(NPC_AVATAR_DIR, req.params.id, `${safeName}.png`);
           if (existsSync(npcPath)) char.avatarPath = `/api/avatars/npc/${req.params.id}/${safeName}.png`;

--- a/packages/server/src/routes/game.routes.ts
+++ b/packages/server/src/routes/game.routes.ts
@@ -78,7 +78,7 @@ import {
 import { generateWeather, inferBiome, shouldWeatherChange } from "../services/game/weather.service.js";
 import { rollEncounter, rollEnemyCount } from "../services/game/encounter.service.js";
 import { processReputationActions } from "../services/game/reputation.service.js";
-import { sanitizeGameNpcAvatarUrls } from "../services/game/npc-avatar-utils.js";
+import { npcAvatarSlug, sanitizeGameNpcAvatarUrls } from "../services/game/npc-avatar-utils.js";
 import { createCheckpointService, type CheckpointTrigger } from "../services/game/checkpoint.service.js";
 import {
   resolveSkillCheck,
@@ -4138,10 +4138,7 @@ function buildGameNpcId(name: string): string {
 }
 
 function buildNpcAvatarUrl(chatId: string, name: string): string | null {
-  const slug = name
-    .toLowerCase()
-    .replace(/[^a-z0-9]+/g, "-")
-    .replace(/(^-|-$)/g, "");
+  const slug = npcAvatarSlug(name);
   return slug ? `/api/avatars/npc/${chatId}/${slug}.png` : null;
 }
 

--- a/packages/server/src/routes/game.routes.ts
+++ b/packages/server/src/routes/game.routes.ts
@@ -2375,7 +2375,10 @@ function clampWidgetValue(value: number, max: number): number {
   return Math.max(0, Math.min(max, value));
 }
 
-function normalizeSetupHudWidgetStartingValues(widgets: Array<{ type: string; config: Record<string, unknown> }>) {
+function normalizeHudWidgetValues(
+  widgets: Array<{ type: string; config: Record<string, unknown> }>,
+  preserveCurrentValues = false,
+) {
   for (const widget of widgets) {
     if (!isNumericHudWidgetType(widget.type)) continue;
 
@@ -2386,11 +2389,11 @@ function normalizeSetupHudWidgetStartingValues(widgets: Array<{ type: string; co
 
     widget.config.max = max;
     widget.config.startingValue = initialValue;
-    widget.config.value = initialValue;
+    widget.config.value = preserveCurrentValues ? clampWidgetValue(currentValue ?? initialValue, max) : initialValue;
   }
 }
 
-function sanitizeGameHudWidgets(value: unknown): HudWidget[] {
+function sanitizeGameHudWidgets(value: unknown, preserveCurrentValues = false): HudWidget[] {
   const parsed = z.array(hudWidgetSchema).max(MAX_GAME_HUD_WIDGETS).safeParse(value);
   if (!parsed.success) return [];
 
@@ -2402,7 +2405,7 @@ function sanitizeGameHudWidgets(value: unknown): HudWidget[] {
     accent: widget.accent?.trim() || undefined,
     config: { ...(widget.config as Record<string, unknown>) },
   }));
-  normalizeSetupHudWidgetStartingValues(widgets);
+  normalizeHudWidgetValues(widgets, preserveCurrentValues);
   return widgets as HudWidget[];
 }
 
@@ -5937,7 +5940,7 @@ export async function gameRoutes(app: FastifyInstance) {
       const parsed = blueprintSchema.safeParse(setupData.blueprint);
       if (parsed.success) {
         normalizeStatBlocks(parsed.data.hudWidgets);
-        normalizeSetupHudWidgetStartingValues(parsed.data.hudWidgets);
+        normalizeHudWidgetValues(parsed.data.hudWidgets);
         updates.gameBlueprint = parsed.data;
       } else {
         // Last-ditch recovery: keep the user's HUD widgets even if campaignPlan
@@ -5953,7 +5956,7 @@ export async function gameRoutes(app: FastifyInstance) {
         });
         if (hudOnly.success && hudOnly.data.hudWidgets.length > 0) {
           normalizeStatBlocks(hudOnly.data.hudWidgets);
-          normalizeSetupHudWidgetStartingValues(hudOnly.data.hudWidgets);
+          normalizeHudWidgetValues(hudOnly.data.hudWidgets);
           updates.gameBlueprint = { hudWidgets: hudOnly.data.hudWidgets };
         }
       }
@@ -9339,7 +9342,7 @@ export async function gameRoutes(app: FastifyInstance) {
     const { widgets: rawWidgets } = z
       .object({ widgets: z.array(hudWidgetSchema).max(MAX_GAME_HUD_WIDGETS) })
       .parse(req.body);
-    const widgets = sanitizeGameHudWidgets(rawWidgets);
+    const widgets = sanitizeGameHudWidgets(rawWidgets, true);
     const chats = createChatsStorage(app.db);
     const chat = await chats.getById(req.params.chatId);
     if (!chat) throw new Error("Chat not found");

--- a/packages/server/src/routes/generate.routes.ts
+++ b/packages/server/src/routes/generate.routes.ts
@@ -128,7 +128,7 @@ import { executeAgent, normalizeAgentContextSize, resolveAgentResultType } from 
 import { matchCustomAgentActivation } from "./generate/agent-activation.js";
 import { listCharacterSprites } from "../services/game/sprite.service.js";
 import { generateChatBackground } from "../services/game/game-asset-generation.js";
-import { sanitizeGameNpcAvatarUrls } from "../services/game/npc-avatar-utils.js";
+import { npcAvatarSlug, sanitizeGameNpcAvatarUrls } from "../services/game/npc-avatar-utils.js";
 import {
   parseCharacterCommands,
   parseCharacterCommandsBySpeaker,
@@ -7190,10 +7190,7 @@ export async function generateRoutes(app: FastifyInstance) {
                     continue;
                   }
                   // Try loading a stored NPC avatar from disk
-                  const safeName = name
-                    .toLowerCase()
-                    .replace(/[^a-z0-9]+/g, "-")
-                    .replace(/(^-|-$)/g, "");
+                  const safeName = npcAvatarSlug(name);
                   if (safeName) {
                     const npcAvatarPath = join(NPC_AVATAR_DIR, input.chatId, `${safeName}.png`);
                     if (existsSync(npcAvatarPath)) {
@@ -7278,10 +7275,7 @@ export async function generateRoutes(app: FastifyInstance) {
                             });
 
                             // Save to NPC avatars directory
-                            const safeName = npcName
-                              .toLowerCase()
-                              .replace(/[^a-z0-9]+/g, "-")
-                              .replace(/(^-|-$)/g, "");
+                            const safeName = npcAvatarSlug(npcName);
                             const npcDir = join(NPC_AVATAR_DIR, input.chatId);
                             if (!existsSync(npcDir)) mkdirSync(npcDir, { recursive: true });
                             writeFileSync(join(npcDir, `${safeName}.png`), Buffer.from(imageResult.base64, "base64"));

--- a/packages/server/src/routes/tts.routes.ts
+++ b/packages/server/src/routes/tts.routes.ts
@@ -739,7 +739,7 @@ export async function ttsRoutes(app: FastifyInstance) {
     const url = useNanoGptSpeech
       ? `${nanoGptV1BaseUrl(base)}/audio/speech`
       : usePocketTtsSpeech
-        ? `${base}/tts`
+        ? `${pocketTtsV1BaseUrl(base)}/audio/speech`
         : useXaiSpeech
           ? `${base}/tts`
           : cfg.source === "elevenlabs"
@@ -758,65 +758,54 @@ export async function ttsRoutes(app: FastifyInstance) {
 
     let providerRes: Response;
     try {
-      const pocketTtsForm = usePocketTtsSpeech ? new FormData() : null;
-      if (pocketTtsForm) {
-        pocketTtsForm.set("text", providerText);
-        if (requestVoice.trim()) pocketTtsForm.set("voice_url", requestVoice.trim());
-        if (audioFormat !== "mp3") pocketTtsForm.set("output_format", audioFormat);
-      }
-
       providerRes = await safeFetch(url, {
         method: "POST",
         headers: useNanoGptSpeech
           ? nanoGptHeaders(cfg.apiKey)
-          : usePocketTtsSpeech
-            ? optionalBearerHeaders(cfg.apiKey)
-            : useXaiSpeech
-              ? openAiHeaders(cfg.apiKey)
-              : cfg.source === "elevenlabs"
-                ? elevenLabsHeaders(cfg.apiKey)
-                : openAiHeaders(cfg.apiKey),
-        body: pocketTtsForm
-          ? pocketTtsForm
-          : useNanoGptSpeech
+          : useXaiSpeech
+            ? openAiHeaders(cfg.apiKey)
+            : cfg.source === "elevenlabs"
+              ? elevenLabsHeaders(cfg.apiKey)
+              : openAiHeaders(cfg.apiKey),
+        body: useNanoGptSpeech
+          ? JSON.stringify({
+              model,
+              input: providerText,
+              voice: requestVoice || "alloy",
+              ...(includeSpeed ? { speed: cfg.speed } : {}),
+              response_format: audioFormat,
+              ...(speechInstructions ? { instructions: speechInstructions } : {}),
+            })
+          : useXaiSpeech
             ? JSON.stringify({
-                model,
-                input: providerText,
-                voice: requestVoice || "alloy",
-                ...(includeSpeed ? { speed: cfg.speed } : {}),
-                response_format: audioFormat,
-                ...(speechInstructions ? { instructions: speechInstructions } : {}),
+                text: providerText,
+                voice_id: requestVoice || "eve",
+                language: "auto",
+                output_format: {
+                  codec: audioFormat,
+                  sample_rate: audioFormat === "mp3" ? 44_100 : 24_000,
+                  ...(audioFormat === "mp3" ? { bit_rate: 128_000 } : {}),
+                },
+                ...(includeSpeed ? { speed: xaiSpeed } : {}),
               })
-            : useXaiSpeech
+            : cfg.source === "elevenlabs"
               ? JSON.stringify({
                   text: providerText,
-                  voice_id: requestVoice || "eve",
-                  language: "auto",
-                  output_format: {
-                    codec: audioFormat,
-                    sample_rate: audioFormat === "mp3" ? 44_100 : 24_000,
-                    ...(audioFormat === "mp3" ? { bit_rate: 128_000 } : {}),
+                  model_id: model,
+                  ...(elevenLabsLanguageCode ? { language_code: elevenLabsLanguageCode } : {}),
+                  voice_settings: {
+                    stability: cfg.elevenLabsStability,
+                    ...(includeSpeed ? { speed: elevenLabsSpeed } : {}),
                   },
-                  ...(includeSpeed ? { speed: xaiSpeed } : {}),
                 })
-              : cfg.source === "elevenlabs"
-                ? JSON.stringify({
-                    text: providerText,
-                    model_id: model,
-                    ...(elevenLabsLanguageCode ? { language_code: elevenLabsLanguageCode } : {}),
-                    voice_settings: {
-                      stability: cfg.elevenLabsStability,
-                      ...(includeSpeed ? { speed: elevenLabsSpeed } : {}),
-                    },
-                  })
-                : JSON.stringify({
-                    model,
-                    input: providerText,
-                    voice: requestVoice,
-                    ...(includeSpeed ? { speed: cfg.speed } : {}),
-                    response_format: audioFormat,
-                    ...(speechInstructions ? { instructions: speechInstructions } : {}),
-                  }),
+              : JSON.stringify({
+                  model,
+                  input: providerText,
+                  voice: requestVoice || (usePocketTtsSpeech ? "alba" : ""),
+                  ...(includeSpeed ? { speed: cfg.speed } : {}),
+                  response_format: audioFormat,
+                  ...(speechInstructions ? { instructions: speechInstructions } : {}),
+                }),
         signal: AbortSignal.timeout(60_000),
         policy: {
           allowLocal: allowLocalTtsUrl(cfg),

--- a/packages/server/src/services/game/npc-avatar-utils.ts
+++ b/packages/server/src/services/game/npc-avatar-utils.ts
@@ -2,6 +2,13 @@ import type { GameNpc } from "@marinara-engine/shared";
 
 export const BUILT_IN_MARI_AVATAR = "/sprites/mari/Mari_profile.png";
 
+export function npcAvatarSlug(name: string): string {
+  return name
+    .toLowerCase()
+    .replace(/[^\p{L}\p{N}]+/gu, "-")
+    .replace(/(^-|-$)/g, "");
+}
+
 function normalizeNpcName(name: string): string {
   return name
     .normalize("NFKD")


### PR DESCRIPTION
## Linked issues

Closes #3799
Closes #3796
Closes #3791
Closes #3786

## Why this change

The current issue queue exposed four focused regressions: editing a Game HUD widget reset its live gauge value, Cyrillic NPC names could not round-trip through avatar filenames, Firefox could stall while painting the layered Roleplay surface, and PocketTTS requests still used an obsolete multipart `/tts` contract.

## What changed

- Preserve current numeric HUD values during runtime widget edits while retaining setup-time default normalization.
- Reuse one Unicode-aware NPC avatar slug helper for uploads, lookup, generation, and Game avatar URLs.
- Add a persisted, opt-in **Reduced paint effects** Roleplay setting that flattens costly bubble shadows, scene overlays, and the vignette without overriding semantic rings or custom card CSS.
- Send PocketTTS JSON requests to its OpenAI-compatible `/v1/audio/speech` endpoint and use its `alba` default voice.
- Correct one stale Noodle smoke assertion to match the reusable Modal's existing accessible close label.

## Validation

- [ ] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed `CONTRIBUTING.md`

### Automated verification notes

- `pnpm check` — passed (TypeScript, ESLint, production builds).
- `pnpm smoke:ui` — 72 passed, 46 intentional viewport skips.
- Focused Chromium run — all four issue regressions passed together.
- Focused Firefox run — Reduced Roleplay paint regression passed.
- The Roleplay regression verifies immediate application, persistence after reload, flattened computed paint styles, preserved semantic rings, transparent bubbles, and custom card CSS precedence.

### Manual verification requested from reviewer

- Manually edit a live Game gauge and confirm its current value survives.
- Manually upload/select a Cyrillic-named NPC avatar.
- Manually speak through a running PocketTTS server.
- Manually compare Roleplay navigation in Firefox with Reduced paint effects off and on.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Version/release files updated (only if this PR includes a version bump)

No release metadata changed. The new setting is self-described in Appearance settings.

## UI evidence

Reduced paint effects enabled in Appearance → Roleplay Messages:

![Reduced paint effects enabled](https://gist.githubusercontent.com/SpicyMarinara/d03aadaf4de5f62a64ef953e35b2254b/raw/roleplay-reduced-paint.png)

[Open the full-size proof image](https://gist.github.com/SpicyMarinara/d03aadaf4de5f62a64ef953e35b2254b)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a “Reduced paint effects” option for Roleplay messages to simplify visual effects and improve navigation smoothness.
  * Improved support for PocketTTS speech requests.
  * NPC avatar filenames now support names with international characters more reliably.

* **Bug Fixes**
  * Preserved game widget values when widgets are updated.
  * Improved transparent message bubble styling in reduced-effects mode.

* **Tests**
  * Expanded coverage for widget persistence, avatar uploads, PocketTTS routing, mobile composer controls, and Roleplay appearance settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->