### PR TITLE
Suppress the reference-image prompt line for local SD backends (ComfyUI/A1111/Draw Things)

### DIFF
--- a/packages/server/src/routes/gallery.routes.ts
+++ b/packages/server/src/routes/gallery.routes.ts
@@ -46,7 +46,7 @@ import {
 } from "../services/generation/media-connection-fallback.js";
 import { resolveIllustratorPromptRuntime } from "../services/generation/illustrator-prompt-runtime.js";
 import { resolveConversationSelfieSystemPrompt } from "../services/conversation/selfie-prompt.js";
-import { isNovelAiImageConnection, resolveIllustratorCharacterReferences } from "./generate/illustrator-references.js";
+import { suppressesReferencePromptLine, resolveIllustratorCharacterReferences } from "./generate/illustrator-references.js";
 import { resolveBaseUrl } from "./generate/generate-route-utils.js";
 import {
   compactVideoPromptText,
@@ -988,7 +988,7 @@ export async function galleryRoutes(app: FastifyInstance) {
       return reply.status(502).send({ error: "The conversation model returned an empty selfie prompt." });
     }
 
-    const suppressReferencePromptLine = isNovelAiImageConnection({
+    const suppressReferencePromptLine = suppressesReferencePromptLine({
       model: imageConn.model,
       baseUrl: imageConn.baseUrl,
       imageService: imageConn.imageService,

--- a/packages/server/src/routes/gallery.routes.ts
+++ b/packages/server/src/routes/gallery.routes.ts
@@ -990,12 +990,16 @@ export async function galleryRoutes(app: FastifyInstance) {
       return reply.status(502).send({ error: "The conversation model returned an empty selfie prompt." });
     }
 
-    const suppressReferencePromptLine = suppressesReferencePromptLine({
-      model: imageConn.model,
-      baseUrl: imageConn.baseUrl,
-      imageService: imageConn.imageService,
-      imageGenerationSource: imageConn.imageGenerationSource,
-    });
+    const imageFallback = await resolveImageConnectionFallback(connections, imageConn.id);
+    const suppressReferencePromptLine = suppressesReferencePromptLine(
+      {
+        model: imageConn.model,
+        baseUrl: imageConn.baseUrl,
+        imageService: imageConn.imageService,
+        imageGenerationSource: imageConn.imageGenerationSource,
+      },
+      imageFallback,
+    );
     let finalPrompt = selfiePositivePrompt ? `${imagePrompt}, ${selfiePositivePrompt}` : imagePrompt;
     let referenceImages: string[] | undefined;
     const selfieUseAvatarReferences = meta.selfieUseAvatarReferences === true;
@@ -1102,7 +1106,6 @@ export async function galleryRoutes(app: FastifyInstance) {
     }
 
     try {
-      const imageFallback = await resolveImageConnectionFallback(connections, imageConn.id);
       const imageConnectionQueueKey = imageConn.id?.trim() || `${imageServiceHint}:${imageBaseUrl}:${imageModel}`;
       const imageResult = await runImageGenerationRequest({
         connectionKey: imageConnectionQueueKey,

--- a/packages/server/src/routes/generate.routes.ts
+++ b/packages/server/src/routes/generate.routes.ts
@@ -137,7 +137,7 @@ import {
   type DirectMessageCommand,
 } from "../services/conversation/character-commands.js";
 import {
-  isNovelAiImageConnection,
+  suppressesReferencePromptLine,
   mergeIllustratorNegativePrompt,
   resolveIllustratorCharacterReferences,
 } from "./generate/illustrator-references.js";
@@ -7837,7 +7837,7 @@ export async function generateRoutes(app: FastifyInstance) {
                       const imgApiKey = imgConnFull.apiKey || "";
                       const imgSource = (imgConnFull as any).imageGenerationSource || imgModel;
                       const imgServiceHint = imgConnFull.imageService || imgSource;
-                      const suppressReferencePromptLine = isNovelAiImageConnection({
+                      const suppressReferencePromptLine = suppressesReferencePromptLine({
                         model: imgModel,
                         baseUrl: imgBaseUrl,
                         imageService: imgServiceHint,

--- a/packages/server/src/routes/generate.routes.ts
+++ b/packages/server/src/routes/generate.routes.ts
@@ -7837,14 +7837,17 @@ export async function generateRoutes(app: FastifyInstance) {
                       const imgApiKey = imgConnFull.apiKey || "";
                       const imgSource = (imgConnFull as any).imageGenerationSource || imgModel;
                       const imgServiceHint = imgConnFull.imageService || imgSource;
-                      const suppressReferencePromptLine = suppressesReferencePromptLine({
-                        model: imgModel,
-                        baseUrl: imgBaseUrl,
-                        imageService: imgServiceHint,
-                        imageGenerationSource: imgSource,
-                      });
-                      const imageDefaults = resolveConnectionImageDefaults(imgConnFull);
                       const imageFallback = await resolveImageConnectionFallback(connections, imgConnFull.id);
+                      const suppressReferencePromptLine = suppressesReferencePromptLine(
+                        {
+                          model: imgModel,
+                          baseUrl: imgBaseUrl,
+                          imageService: imgServiceHint,
+                          imageGenerationSource: imgSource,
+                        },
+                        imageFallback,
+                      );
+                      const imageDefaults = resolveConnectionImageDefaults(imgConnFull);
                       const imageSettings = await loadImageGenerationUserSettings(app.db);
                       const styleProfileId =
                         ((chatMeta.gameSetupConfig as Record<string, unknown> | undefined)?.imageStyleProfileId as

--- a/packages/server/src/routes/generate/retry-agents-route.ts
+++ b/packages/server/src/routes/generate/retry-agents-route.ts
@@ -139,7 +139,7 @@ import {
   validateSpriteExpressionEntries,
 } from "./expression-agent-utils.js";
 import {
-  isNovelAiImageConnection,
+  suppressesReferencePromptLine,
   mergeIllustratorNegativePrompt,
   resolveIllustratorCharacterReferences,
 } from "./illustrator-references.js";
@@ -3026,7 +3026,7 @@ async function applyRetryResultEffects(args: {
             const imgApiKey = imgConnFull.apiKey || "";
             const imgSource = (imgConnFull as any).imageGenerationSource || imgModel;
             const imgServiceHint = imgConnFull.imageService || imgSource;
-            const suppressReferencePromptLine = isNovelAiImageConnection({
+            const suppressReferencePromptLine = suppressesReferencePromptLine({
               model: imgModel,
               baseUrl: imgBaseUrl,
               imageService: imgServiceHint,

--- a/packages/server/src/routes/generate/retry-agents-route.ts
+++ b/packages/server/src/routes/generate/retry-agents-route.ts
@@ -3026,14 +3026,17 @@ async function applyRetryResultEffects(args: {
             const imgApiKey = imgConnFull.apiKey || "";
             const imgSource = (imgConnFull as any).imageGenerationSource || imgModel;
             const imgServiceHint = imgConnFull.imageService || imgSource;
-            const suppressReferencePromptLine = suppressesReferencePromptLine({
-              model: imgModel,
-              baseUrl: imgBaseUrl,
-              imageService: imgServiceHint,
-              imageGenerationSource: imgSource,
-            });
-            const imageDefaults = resolveConnectionImageDefaults(imgConnFull);
             const imageFallback = await resolveImageConnectionFallback(conns, imgConnFull.id);
+            const suppressReferencePromptLine = suppressesReferencePromptLine(
+              {
+                model: imgModel,
+                baseUrl: imgBaseUrl,
+                imageService: imgServiceHint,
+                imageGenerationSource: imgSource,
+              },
+              imageFallback,
+            );
+            const imageDefaults = resolveConnectionImageDefaults(imgConnFull);
             const imageSettings = await loadImageGenerationUserSettings(app.db);
 
             const chatMeta = typeof chat.metadata === "string" ? JSON.parse(chat.metadata) : (chat.metadata ?? {});

--- a/packages/server/src/services/generation/conversation-selfie-command-runtime.ts
+++ b/packages/server/src/services/generation/conversation-selfie-command-runtime.ts
@@ -191,12 +191,16 @@ async function generateSelfie(
   const imagePrompt = (promptResult.content ?? "").trim();
   if (!imagePrompt) return;
 
-  const suppressReferencePromptLine = suppressesReferencePromptLine({
-    model: imgConnFull.model,
-    baseUrl: imgConnFull.baseUrl,
-    imageService: imgConnFull.imageService,
-    imageGenerationSource: imgConnFull.imageGenerationSource,
-  });
+  const imageFallback = await resolveImageConnectionFallback(args.connections, imgConnFull.id);
+  const suppressReferencePromptLine = suppressesReferencePromptLine(
+    {
+      model: imgConnFull.model,
+      baseUrl: imgConnFull.baseUrl,
+      imageService: imgConnFull.imageService,
+      imageGenerationSource: imgConnFull.imageGenerationSource,
+    },
+    imageFallback,
+  );
   let finalSelfiePrompt = selfiePositivePrompt ? `${imagePrompt}, ${selfiePositivePrompt}` : imagePrompt;
   let selfieReferenceImages: string[] | undefined;
   const selfieUseAvatarReferences = args.chatMeta.selfieUseAvatarReferences === true;
@@ -247,7 +251,6 @@ async function generateSelfie(
   const selfieRes = typeof args.chatMeta.selfieResolution === "string" ? args.chatMeta.selfieResolution : "";
   const [selfieW, selfieH] = selfieRes.split("x").map(Number) as [number, number];
   const serviceHint = imgConnFull.imageService || "";
-  const imageFallback = await resolveImageConnectionFallback(args.connections, imgConnFull.id);
   const compiledSelfiePrompt = compileImagePrompt({
     kind: "selfie",
     prompt: finalSelfiePrompt,

--- a/packages/server/src/services/generation/conversation-selfie-command-runtime.ts
+++ b/packages/server/src/services/generation/conversation-selfie-command-runtime.ts
@@ -2,7 +2,7 @@ import type { DB } from "../../db/connection.js";
 import { isDebugAgentsEnabled } from "../../config/runtime-config.js";
 import { logger, logDebugOverride } from "../../lib/logger.js";
 import {
-  isNovelAiImageConnection,
+  suppressesReferencePromptLine,
   resolveIllustratorCharacterReferences,
 } from "../image/illustrator-references.js";
 import { compileImagePrompt } from "../image/image-prompt-compiler.js";
@@ -191,7 +191,7 @@ async function generateSelfie(
   const imagePrompt = (promptResult.content ?? "").trim();
   if (!imagePrompt) return;
 
-  const suppressReferencePromptLine = isNovelAiImageConnection({
+  const suppressReferencePromptLine = suppressesReferencePromptLine({
     model: imgConnFull.model,
     baseUrl: imgConnFull.baseUrl,
     imageService: imgConnFull.imageService,

--- a/packages/server/src/services/image/illustrator-references.ts
+++ b/packages/server/src/services/image/illustrator-references.ts
@@ -55,32 +55,69 @@ export function isNovelAiImageConnection(args: {
   });
 }
 
-/**
- * Providers for which the prose "Attached are reference images…" line should be
- * omitted from the image prompt. NovelAI receives references through its native
- * character-reference fields, and local Stable Diffusion backends
- * (ComfyUI / AUTOMATIC1111 / Draw Things on their default ports) receive
- * reference images out-of-band — in all cases the sentence is invisible to the
- * image model and only consumes prompt tokens.
- */
-export function suppressesReferencePromptLine(args: {
+type ReferencePromptImageProvider = {
   model?: unknown;
   baseUrl?: unknown;
   imageService?: unknown;
   imageGenerationSource?: unknown;
-}): boolean {
-  if (isNovelAiImageConnection(args)) return true;
-  return [args.baseUrl, args.imageService, args.imageGenerationSource].some((value) => {
-    if (typeof value !== "string") return false;
-    const normalized = value.trim().toLowerCase();
+  serviceHint?: unknown;
+  source?: unknown;
+};
+
+const LOCAL_STABLE_DIFFUSION_SERVICES = new Set(["comfyui", "automatic1111", "drawthings"]);
+const LOCAL_STABLE_DIFFUSION_PORTS = new Set(["8188", "7860"]);
+const LOOPBACK_IMAGE_HOSTS = new Set(["localhost", "localhost.localdomain", "127.0.0.1", "::1"]);
+
+function isLocalStableDiffusionUrl(value: unknown): boolean {
+  if (typeof value !== "string" || !value.trim()) return false;
+  try {
+    const url = new URL(value);
+    const hostname = url.hostname
+      .replace(/^\[|\]$/g, "")
+      .replace(/\.$/, "")
+      .toLowerCase();
     return (
-      normalized === "comfyui" ||
-      normalized === "automatic1111" ||
-      normalized === "drawthings" ||
-      normalized.includes(":8188") ||
-      normalized.includes(":7860")
+      (url.protocol === "http:" || url.protocol === "https:") &&
+      LOOPBACK_IMAGE_HOSTS.has(hostname) &&
+      LOCAL_STABLE_DIFFUSION_PORTS.has(url.port)
     );
-  });
+  } catch {
+    return false;
+  }
+}
+
+function providerSuppressesReferencePromptLine(args: ReferencePromptImageProvider): boolean {
+  if (
+    isNovelAiImageConnection({
+      model: args.model,
+      baseUrl: args.baseUrl,
+      imageService: args.imageService ?? args.serviceHint,
+      imageGenerationSource: args.imageGenerationSource ?? args.source,
+    })
+  ) {
+    return true;
+  }
+  const explicitServiceValues = [args.imageService, args.imageGenerationSource, args.serviceHint, args.source];
+  return (
+    explicitServiceValues.some(
+      (value) => typeof value === "string" && LOCAL_STABLE_DIFFUSION_SERVICES.has(value.trim().toLowerCase()),
+    ) || isLocalStableDiffusionUrl(args.baseUrl)
+  );
+}
+
+/**
+ * Providers for which the prose "Attached are reference images…" line should be
+ * omitted from the image prompt. NovelAI receives references through its native
+ * character-reference fields. Local Stable Diffusion backends receive reference
+ * images out-of-band, so this prose does not encode the image and only consumes
+ * prompt tokens. When a fallback is configured, every possible provider must
+ * support omission because the same compiled prompt is reused for the retry.
+ */
+export function suppressesReferencePromptLine(
+  args: ReferencePromptImageProvider,
+  fallback?: ReferencePromptImageProvider | null,
+): boolean {
+  return providerSuppressesReferencePromptLine(args) && (!fallback || providerSuppressesReferencePromptLine(fallback));
 }
 
 const MAX_ILLUSTRATOR_REFERENCE_IMAGES = 6;

--- a/packages/server/src/services/image/illustrator-references.ts
+++ b/packages/server/src/services/image/illustrator-references.ts
@@ -55,6 +55,34 @@ export function isNovelAiImageConnection(args: {
   });
 }
 
+/**
+ * Providers for which the prose "Attached are reference images…" line should be
+ * omitted from the image prompt. NovelAI receives references through its native
+ * character-reference fields, and local Stable Diffusion backends
+ * (ComfyUI / AUTOMATIC1111 / Draw Things on their default ports) receive
+ * reference images out-of-band — in all cases the sentence is invisible to the
+ * image model and only consumes prompt tokens.
+ */
+export function suppressesReferencePromptLine(args: {
+  model?: unknown;
+  baseUrl?: unknown;
+  imageService?: unknown;
+  imageGenerationSource?: unknown;
+}): boolean {
+  if (isNovelAiImageConnection(args)) return true;
+  return [args.baseUrl, args.imageService, args.imageGenerationSource].some((value) => {
+    if (typeof value !== "string") return false;
+    const normalized = value.trim().toLowerCase();
+    return (
+      normalized === "comfyui" ||
+      normalized === "automatic1111" ||
+      normalized === "drawthings" ||
+      normalized.includes(":8188") ||
+      normalized.includes(":7860")
+    );
+  });
+}
+
 const MAX_ILLUSTRATOR_REFERENCE_IMAGES = 6;
 const MAX_ILLUSTRATOR_APPEARANCE_CHARS = 1400;
 const NAME_STOPWORDS = new Set(["the", "a", "an", "il", "la", "le", "de", "van", "von", "dr", "mr", "ms"]);

--- a/scripts/regressions/prompt.regression.ts
+++ b/scripts/regressions/prompt.regression.ts
@@ -334,6 +334,7 @@ import {
   normalizeIllustratorAppearance,
   readIllustratorAppearance,
   resolveIllustratorCharacterReferences,
+  suppressesReferencePromptLine,
 } from "../../packages/server/src/routes/generate/illustrator-references.js";
 import {
   OFFICIAL_AGENT_KNOWLEDGE_ENTRIES,
@@ -1693,6 +1694,39 @@ const cases: RegressionCase[] = [
       assert.match(gameSurfaceSource, /setStoryboardViewerPlayingVideoId\(activeStoryboardKeyframe\.video\.id\)/);
       assert.match(backgroundViewerSource, /onEnded=\{\(\) =>/);
       assert.doesNotMatch(backgroundViewerSource, /\bloop\b/);
+    },
+  },
+  {
+    name: "reference prompt suppression requires explicit local providers and fallback-safe routing",
+    run() {
+      for (const service of ["comfyui", "automatic1111", "drawthings"]) {
+        assert.equal(suppressesReferencePromptLine({ imageService: service }), true);
+        assert.equal(suppressesReferencePromptLine({ imageGenerationSource: service }), true);
+      }
+
+      assert.equal(suppressesReferencePromptLine({ baseUrl: "http://127.0.0.1:8188" }), true);
+      assert.equal(suppressesReferencePromptLine({ baseUrl: "http://localhost:7860/sdapi/v1" }), true);
+      assert.equal(suppressesReferencePromptLine({ baseUrl: "http://[::1]:8188" }), true);
+      assert.equal(suppressesReferencePromptLine({ baseUrl: "https://images.example.com:8188" }), false);
+      assert.equal(suppressesReferencePromptLine({ baseUrl: "https://images.example.com/api/:7860" }), false);
+      assert.equal(suppressesReferencePromptLine({ imageService: "proxy:8188" }), false);
+      assert.equal(suppressesReferencePromptLine({ baseUrl: "http://localhost:81880" }), false);
+
+      const localPrimary = { imageService: "comfyui" };
+      assert.equal(
+        suppressesReferencePromptLine(localPrimary, {
+          serviceHint: "openai",
+          baseUrl: "https://api.openai.com/v1",
+        }),
+        false,
+      );
+      assert.equal(
+        suppressesReferencePromptLine(localPrimary, {
+          serviceHint: "automatic1111",
+          baseUrl: "http://localhost:7860",
+        }),
+        true,
+      );
     },
   },
   {


### PR DESCRIPTION
## Problem

When avatar references are attached, the engine appends a prose line to the image prompt:

> "Attached are reference images of X. Use them only to preserve character likeness and visual identity; the written scene prompt is authoritative for…"

For ComfyUI / AUTOMATIC1111 / Draw Things connections the reference images travel out-of-band (ComfyUI upload endpoint / img2img payload), and the CLIP text encoder cannot act on an instruction sentence — it just tokenizes it. On tag-trained SDXL checkpoints (Pony/Illustrious) this costs ~40 of the strongest prompt tokens and measurably dilutes tag adherence, especially with CLIP's 77-token chunking.

NovelAI connections already suppress this line (`isNovelAiImageConnection`) for the same underlying reason: the provider consumes references natively, so the sentence is invisible to the model.

## Change

- New `suppressesReferencePromptLine()` in `services/image/illustrator-references.ts` — returns true for NovelAI (delegating to the existing predicate) and for local SD backends, detected via explicit `imageService`/`imageGenerationSource` ids (`comfyui`, `automatic1111`, `drawthings`) plus the default local ports (`:8188`, `:7860`) in the base URL, mirroring the style of the NovelAI check.
- The four `suppressReferencePromptLine` call sites (generate route, retry-agents route, gallery route, selfie command runtime) use the new function instead of `isNovelAiImageConnection` directly.

`isNovelAiImageConnection` remains exported and unchanged.

## Notes

- No behavior change for cloud image providers (OpenAI, Stability, Together, …) — multimodal providers that can actually read the reference line keep receiving it.
- Reference *images* are still attached exactly as before; only the prose sentence is dropped for backends that can't use it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved character reference handling for selfie and illustration image generation.
  * Reference-image prompt details are now adjusted more consistently across supported image-generation services.
  * Updated retry-based image generation to apply the same reference prompt behavior as standard generation flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->