### PR TITLE
Add a Game mode text effects toggle

### DIFF
--- a/packages/client/src/components/game/AnimatedText.tsx
+++ b/packages/client/src/components/game/AnimatedText.tsx
@@ -26,6 +26,7 @@
 // ──────────────────────────────────────────────
 import { useMemo } from "react";
 import DOMPurify from "dompurify";
+import { useUIStore } from "../../stores/ui.store";
 
 // ── Effect types & rules ──
 
@@ -122,17 +123,20 @@ const EFFECT_CLASS: Record<TextEffect, string> = {
  * Parse explicit {effect:text} tags, ALL CAPS, and (parenthetical) text.
  * All other effects require the GM to use explicit {effect:text} markup.
  */
-function applyTextEffects(html: string): string {
+function applyTextEffects(html: string, enabled: boolean): string {
   let result = html;
 
   // 1) Explicit tags: {shake:angry words here}
   result = result.replace(
     /\{(shake|shout|whisper|glow|pulse|wave|flicker|drip|bounce|tremble|glitch|expand):([^}]+)\}/gi,
     (_match, effect: string, text: string) => {
+      if (!enabled) return text;
       const cls = EFFECT_CLASS[effect.toLowerCase() as TextEffect];
       return cls ? `<span class="${cls}">${text}</span>` : text;
     },
   );
+
+  if (!enabled) return result;
 
   // 2) ALL CAPS words → shout (skip inside HTML tags)
   result = wrapOutsideTags(result, /\b[A-Z]{3,}\b/g, EFFECT_CLASS.shout);
@@ -220,22 +224,23 @@ interface AnimatedTextProps {
 }
 
 export function AnimatedText({ html, className, style }: AnimatedTextProps) {
+  const textEffectsEnabled = useUIStore((state) => state.gameTextEffectsEnabled);
   const processedHtml = useMemo(() => {
-    let result = applyTextEffects(html);
+    let result = applyTextEffects(html, textEffectsEnabled);
     result = wrapCharactersForWave(result);
     // Re-sanitize after our additions
     return DOMPurify.sanitize(result, {
       ALLOWED_TAGS: ["strong", "em", "br", "span"],
       ALLOWED_ATTR: ["class", "style"],
     });
-  }, [html]);
+  }, [html, textEffectsEnabled]);
 
   return <span className={className} style={style} dangerouslySetInnerHTML={{ __html: processedHtml }} />;
 }
 
 /** Convenience: apply effects to plain text (not pre-formatted HTML). */
-export function animateTextHtml(html: string): string {
-  let result = applyTextEffects(html);
+export function animateTextHtml(html: string, enabled = true): string {
+  let result = applyTextEffects(html, enabled);
   result = wrapCharactersForWave(result);
   return DOMPurify.sanitize(result, {
     ALLOWED_TAGS: ["strong", "em", "br", "span"],

--- a/packages/client/src/components/game/GameNarration.tsx
+++ b/packages/client/src/components/game/GameNarration.tsx
@@ -580,12 +580,12 @@ function slicePreservingEffects(content: string, maxVisible: number): string {
   return result;
 }
 
-function getGameTranslationHtml(message: NarrationMessage, translatedText: string): string {
+function getGameTranslationHtml(message: NarrationMessage, translatedText: string, textEffectsEnabled: boolean): string {
   const content =
     message.role === "assistant" || message.role === "narrator" || message.role === "system"
       ? stripGmTagsKeepReadables(translatedText)
       : translatedText.replace(/^\[(?:To the party|To the GM)]\s*/i, "");
-  return animateTextHtml(formatNarration(content.trim(), false));
+  return animateTextHtml(formatNarration(content.trim(), false), textEffectsEnabled);
 }
 
 function hashVoiceKey(value: string): string {
@@ -1010,6 +1010,7 @@ export function GameNarration({
   const [logsOpen, setLogsOpen] = useState(false);
   const messagesPerPage = useUIStore((s) => s.messagesPerPage);
   const gameDialogueDisplayMode = useUIStore((s) => s.gameDialogueDisplayMode);
+  const gameTextEffectsEnabled = useUIStore((s) => s.gameTextEffectsEnabled);
   const quoteFormat = useUIStore((s) => s.quoteFormat);
   const useStackedLogDisplay = gameDialogueDisplayMode === "stacked";
   const showLogsButton = !useStackedLogDisplay;
@@ -3256,7 +3257,9 @@ export function GameNarration({
           {translatedText ? (
             <div
               className="game-narration-prose text-sm leading-relaxed text-sky-50/85"
-              dangerouslySetInnerHTML={{ __html: getGameTranslationHtml(message, translatedText) }}
+              dangerouslySetInnerHTML={{
+                __html: getGameTranslationHtml(message, translatedText, gameTextEffectsEnabled),
+              }}
             />
           ) : (
             <div className="text-xs text-sky-200/60">Translating...</div>
@@ -3264,7 +3267,7 @@ export function GameNarration({
         </div>
       );
     },
-    [],
+    [gameTextEffectsEnabled],
   );
 
   const playClickSfx = useCallback(() => {
@@ -4183,7 +4186,9 @@ export function GameNarration({
                   seg.partyType === "thought" ? "italic opacity-80" : "font-semibold",
                 )}
                 style={seg.color ? { ...narrationFontStyle, color: seg.color } : narrationFontStyle}
-                dangerouslySetInnerHTML={{ __html: animateTextHtml(formatNarration(seg.content, false)) }}
+                dangerouslySetInnerHTML={{
+                  __html: animateTextHtml(formatNarration(seg.content, false), gameTextEffectsEnabled),
+                }}
               />
             )}
           </div>
@@ -4205,7 +4210,9 @@ export function GameNarration({
             <div
               className="whitespace-pre-wrap break-words text-xs leading-relaxed"
               style={narrationFontStyle}
-              dangerouslySetInnerHTML={{ __html: animateTextHtml(formatNarration(seg.content, false)) }}
+              dangerouslySetInnerHTML={{
+                __html: animateTextHtml(formatNarration(seg.content, false), gameTextEffectsEnabled),
+              }}
             />
           )}
         </div>
@@ -4229,7 +4236,10 @@ export function GameNarration({
               className="text-xs italic leading-relaxed text-amber-200/70"
               style={narrationFontStyle}
               dangerouslySetInnerHTML={{
-                __html: animateTextHtml(formatNarration(seg.readableContent ?? seg.content, false)),
+                __html: animateTextHtml(
+                  formatNarration(seg.readableContent ?? seg.content, false),
+                  gameTextEffectsEnabled,
+                ),
               }}
             />
           )}
@@ -4255,7 +4265,9 @@ export function GameNarration({
           <div
             className="text-xs leading-relaxed text-[var(--foreground)]/80 dark:text-white/80"
             style={narrationStyle}
-            dangerouslySetInnerHTML={{ __html: animateTextHtml(formatNarration(seg.content, false)) }}
+            dangerouslySetInnerHTML={{
+              __html: animateTextHtml(formatNarration(seg.content, false), gameTextEffectsEnabled),
+            }}
           />
         )}
       </div>
@@ -4618,6 +4630,7 @@ export function GameNarration({
                               dangerouslySetInnerHTML={{
                                 __html: animateTextHtml(
                                   formatNarration(slicePreservingEffects(active.content, visibleChars), false),
+                                  gameTextEffectsEnabled,
                                 ),
                               }}
                             />
@@ -4707,6 +4720,7 @@ export function GameNarration({
                     dangerouslySetInnerHTML={{
                       __html: animateTextHtml(
                         formatNarration(slicePreservingEffects(active.content, visibleChars), false),
+                        gameTextEffectsEnabled,
                       ),
                     }}
                   />
@@ -4770,6 +4784,7 @@ export function GameNarration({
                   dangerouslySetInnerHTML={{
                     __html: animateTextHtml(
                       formatNarration(slicePreservingEffects(active.content, visibleChars), false),
+                      gameTextEffectsEnabled,
                     ),
                   }}
                 />
@@ -5418,7 +5433,10 @@ export function GameNarration({
                                   )}
                                   style={seg.color ? { ...narrationFontStyle, color: seg.color } : narrationFontStyle}
                                   dangerouslySetInnerHTML={{
-                                    __html: animateTextHtml(formatNarration(seg.content, false)),
+                                    __html: animateTextHtml(
+                                      formatNarration(seg.content, false),
+                                      gameTextEffectsEnabled,
+                                    ),
                                   }}
                                 />
                               )}
@@ -5448,7 +5466,9 @@ export function GameNarration({
                             <div
                               className="whitespace-pre-wrap break-words pr-6 text-xs leading-relaxed text-cyan-50/80"
                               style={narrationFontStyle}
-                              dangerouslySetInnerHTML={{ __html: animateTextHtml(formatNarration(seg.content, false)) }}
+                              dangerouslySetInnerHTML={{
+                                __html: animateTextHtml(formatNarration(seg.content, false), gameTextEffectsEnabled),
+                              }}
                             />
                           </div>
                         );
@@ -5479,7 +5499,10 @@ export function GameNarration({
                                 className="text-xs italic leading-relaxed text-amber-200/70"
                                 style={narrationFontStyle}
                                 dangerouslySetInnerHTML={{
-                                  __html: animateTextHtml(formatNarration(seg.readableContent ?? seg.content, false)),
+                                  __html: animateTextHtml(
+                                    formatNarration(seg.readableContent ?? seg.content, false),
+                                    gameTextEffectsEnabled,
+                                  ),
                                 }}
                               />
                             )}
@@ -5511,7 +5534,9 @@ export function GameNarration({
                             <div
                               className="text-xs leading-relaxed text-white/80"
                               style={narrationStyle}
-                              dangerouslySetInnerHTML={{ __html: animateTextHtml(formatNarration(seg.content, false)) }}
+                              dangerouslySetInnerHTML={{
+                                __html: animateTextHtml(formatNarration(seg.content, false), gameTextEffectsEnabled),
+                              }}
                             />
                           )}
                         </div>

--- a/packages/client/src/components/panels/SettingsPanel.tsx
+++ b/packages/client/src/components/panels/SettingsPanel.tsx
@@ -1018,6 +1018,14 @@ const SETTINGS_SEARCHABLE_CONTROLS: readonly SettingsSearchableControlMeta[] = [
     kind: "Button group",
   },
   {
+    id: "game-text-effects",
+    sectionId: "game-presentation",
+    label: "Game text effects",
+    description: "Animate dramatic words and explicit text-effect tags in Game mode.",
+    aliases: ["game", "text", "animation", "effects", "accessibility", "motion"],
+    kind: "Toggle",
+  },
+  {
     id: "weather-effects",
     sectionId: "motion-backgrounds",
     label: "Dynamic weather effects",
@@ -3695,6 +3703,8 @@ function AppearanceSettings() {
   const setRoleplaySpriteScale = useUIStore((s) => s.setRoleplaySpriteScale);
   const gameDialogueDisplayMode = useUIStore((s) => s.gameDialogueDisplayMode);
   const setGameDialogueDisplayMode = useUIStore((s) => s.setGameDialogueDisplayMode);
+  const gameTextEffectsEnabled = useUIStore((s) => s.gameTextEffectsEnabled);
+  const setGameTextEffectsEnabled = useUIStore((s) => s.setGameTextEffectsEnabled);
   const gameAvatarScale = useUIStore((s) => s.gameAvatarScale);
   const setGameAvatarScale = useUIStore((s) => s.setGameAvatarScale);
   const gameFullBodySpriteScale = useUIStore((s) => s.gameFullBodySpriteScale);
@@ -4518,6 +4528,14 @@ function AppearanceSettings() {
               ))}
             </div>
           </div>
+
+          <ToggleSetting
+            anchorId={getSettingsControlAnchorId("game-text-effects")}
+            label="Game text effects"
+            checked={gameTextEffectsEnabled}
+            onChange={setGameTextEffectsEnabled}
+            help="Animates dramatic words, ALL CAPS emphasis, parenthetical asides, and explicit text-effect tags in Game mode. Turn this off for plain, stable text."
+          />
         </div>
       </SettingsSection>
 

--- a/packages/client/src/stores/ui.store.ts
+++ b/packages/client/src/stores/ui.store.ts
@@ -670,6 +670,8 @@ interface UIState {
   chatFontOpacity: number;
   /** When true, flatten expensive Roleplay paint effects for smoother navigation. */
   roleplayReducedPaintEffects: boolean;
+  /** Whether Game mode applies animated emphasis to narration and dialogue text. */
+  gameTextEffectsEnabled: boolean;
   /** Layout style for roleplay message avatars */
   roleplayAvatarStyle: RoleplayAvatarStyle;
   /** Scale multiplier for Roleplay message avatars. */
@@ -949,6 +951,7 @@ interface UIState {
   setChatChromeTextColor: (v: string) => void;
   setChatFontOpacity: (v: number) => void;
   setRoleplayReducedPaintEffects: (v: boolean) => void;
+  setGameTextEffectsEnabled: (v: boolean) => void;
   setRoleplayAvatarStyle: (v: RoleplayAvatarStyle) => void;
   setRoleplayAvatarScale: (v: number) => void;
   setRoleplayAvatarsScrollable: (v: boolean) => void;
@@ -1348,6 +1351,7 @@ export const useUIStore = create<UIState>()(
       chatChromeTextColor: "",
       chatFontOpacity: 90,
       roleplayReducedPaintEffects: false,
+      gameTextEffectsEnabled: true,
       roleplayAvatarStyle: "circles" as RoleplayAvatarStyle,
       roleplayAvatarScale: 1,
       roleplayAvatarsScrollable: false,
@@ -2097,6 +2101,7 @@ export const useUIStore = create<UIState>()(
       setChatChromeTextColor: (v) => set({ chatChromeTextColor: normalizeChatChromeTextColor(v) }),
       setChatFontOpacity: (v) => set({ chatFontOpacity: Math.max(0, Math.min(100, v)) }),
       setRoleplayReducedPaintEffects: (v) => set({ roleplayReducedPaintEffects: v }),
+      setGameTextEffectsEnabled: (v) => set({ gameTextEffectsEnabled: v }),
       setRoleplayAvatarStyle: (v) => set({ roleplayAvatarStyle: v }),
       setRoleplayAvatarScale: (v) =>
         set({ roleplayAvatarScale: Math.max(ROLEPLAY_AVATAR_SCALE_MIN, Math.min(ROLEPLAY_AVATAR_SCALE_MAX, v)) }),
@@ -2148,6 +2153,7 @@ export const useUIStore = create<UIState>()(
           chatChromeTextColor: "",
           chatFontOpacity: 90,
           roleplayReducedPaintEffects: false,
+          gameTextEffectsEnabled: true,
           roleplayAvatarStyle: "circles" as RoleplayAvatarStyle,
           roleplayAvatarScale: 1,
           roleplayAvatarsScrollable: false,
@@ -2261,7 +2267,7 @@ export const useUIStore = create<UIState>()(
     }),
     {
       name: "marinara-engine-ui",
-      version: 77,
+      version: 78,
       // Debounce localStorage writes to avoid sync I/O on every state change
       storage: createJSONStorage(() => {
         let timer: ReturnType<typeof setTimeout> | null = null;
@@ -2818,11 +2824,15 @@ export const useUIStore = create<UIState>()(
         if (version <= 76 && persisted.roleplayReducedPaintEffects === undefined) {
           persisted.roleplayReducedPaintEffects = false;
         }
+        if (version <= 77 && persisted.gameTextEffectsEnabled === undefined) {
+          persisted.gameTextEffectsEnabled = true;
+        }
         persisted.appAccentRgbMode = persisted.appAccentRgbMode === true;
         persisted.customCursorEnabled = persisted.customCursorEnabled !== false;
         persisted.professorMariSuggestionsEnabled = persisted.professorMariSuggestionsEnabled !== false;
         persisted.includeReasoningInExports = persisted.includeReasoningInExports === true;
         persisted.roleplayReducedPaintEffects = persisted.roleplayReducedPaintEffects === true;
+        persisted.gameTextEffectsEnabled = persisted.gameTextEffectsEnabled !== false;
         persisted.chatChromeTextColor = normalizeChatChromeTextColor(persisted.chatChromeTextColor);
         persisted.defaultRoleplayBackground = normalizeDefaultRoleplayBackground(persisted.defaultRoleplayBackground);
         delete persisted.trackerPanelWidth;
@@ -2957,6 +2967,7 @@ export const useUIStore = create<UIState>()(
         chatChromeTextColor: state.chatChromeTextColor,
         chatFontOpacity: state.chatFontOpacity,
         roleplayReducedPaintEffects: state.roleplayReducedPaintEffects,
+        gameTextEffectsEnabled: state.gameTextEffectsEnabled,
         roleplayAvatarStyle: state.roleplayAvatarStyle,
         roleplayAvatarScale: state.roleplayAvatarScale,
         roleplayAvatarsScrollable: state.roleplayAvatarsScrollable,


### PR DESCRIPTION
## Linked issue

Closes #3801

## Why this change

- Game mode automatically animates context-matched words, ALL CAPS text, parenthetical asides, and explicit effect tags. Misclassification can distract users or make dialogue harder to read, so this presentation layer needs an opt-out.

## What changed

- Added a persisted, default-on Game text effects preference under Settings > Appearance > Game Presentation.
- Applied the preference across live narration, dialogue history, translations, choices, title cards, and other Game text surfaces that use the shared effect renderer.
- Preserved the readable content of explicit effect tags when effects are disabled instead of exposing tag syntax.

## Validation

- [ ] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed `CONTRIBUTING.md`

### Manual verification notes

- Manually verify the toggle in Settings > Appearance > Game Presentation.
- In Game mode, compare context-matched text, ALL CAPS text, parenthetical text, and an explicit effect tag with the toggle on and off.
- Verify the preference persists after reload and resets with Reset Appearance.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Version/release files updated (only if this PR includes a version bump)

## UI evidence (if applicable)

- Screenshot or recording to be attached after browser verification.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Game Presentation setting to enable or disable animated game text effects.
  * The preference is saved automatically and restored across sessions.
  * Text effects now apply consistently across narration, dialogue, readable content, and game logs.

* **Bug Fixes**
  * Disabling game text effects now reliably displays the original text without animation or special effects.
  * Resetting appearance settings restores game text effects to enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->