### PR TITLE
Add local ComfyUI video generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 
 ### Added
 
+- Added local ComfyUI video generation for API-format WAN and other workflows, including prompt, size, seed, frame-count, and uploaded first-frame placeholders (#3804).
 - Added an in-app and GitHub ComfyUI workflow guide covering API-format exports, Marinara placeholders, local and RunPod reference-image inputs, character-specific workflows, LAN setup, VRAM constraints, and troubleshooting (#3749).
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ Preset system with drag-and-drop prompt ordering, lorebooks with keyword trigger
 
 ### Connections & Providers
 
-OpenAI, OpenAI ChatGPT subscription login, Anthropic, Claude Subscription through the local Claude Agent SDK, Google Gemini, Google Vertex AI, OpenRouter, NanoGPT, Mistral, Cohere, xAI / Grok, the bundled downloadable Local Model sidecar, Pollinations, Stability AI, Together AI, NovelAI, Venice.ai, ComfyUI, SD Web UI, Draw Things (Apple Silicon, Metal + Apple Neural Engine), Google AI Studio video models (Gemini Omni and Veo), xAI Imagine video, OpenRouter video, Seedance 2.0 video, and custom OpenAI-compatible endpoints. API keys are encrypted at rest with AES-256. Per-chat connection overrides.
+OpenAI, OpenAI ChatGPT subscription login, Anthropic, Claude Subscription through the local Claude Agent SDK, Google Gemini, Google Vertex AI, OpenRouter, NanoGPT, Mistral, Cohere, xAI / Grok, the bundled downloadable Local Model sidecar, Pollinations, Stability AI, Together AI, NovelAI, Venice.ai, ComfyUI image and local video workflows, SD Web UI, Draw Things (Apple Silicon, Metal + Apple Neural Engine), Google AI Studio video models (Gemini Omni and Veo), xAI Imagine video, OpenRouter video, Seedance 2.0 video, and custom OpenAI-compatible endpoints. API keys are encrypted at rest with AES-256. Per-chat connection overrides.
 
 ### Export & Data
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -160,9 +160,9 @@ A timeout is the longest time the server waits for a slow job before giving up. 
 | `CHAT_GENERATION_TIMEOUT_MS` | `300000` (5 minutes) | Provider headers/time-to-first-token and inter-chunk timeout for ordinary Conversation, Roleplay, and Game generations. Valid range: `10000`-`3600000`. It does not change Agent, media, embedding, tool, or background-job timeouts. |
 | `EMBEDDING_TIMEOUT_MS` | `300000` (5 minutes) | Time allowed for one embedding request. Higher helps slow local embedding servers. |
 | `IMAGE_GEN_TIMEOUT_MS` | `1800000` (30 minutes) | Time allowed for one image generation request. |
-| `VIDEO_GEN_TIMEOUT_MS` | `1800000` (30 minutes) | Time allowed for one scene video generation request. |
+| `VIDEO_GEN_TIMEOUT_MS` | `1800000` (30 minutes) | Time allowed for one scene video generation request, including local ComfyUI video workflows. |
 | `VIDEO_GEN_MAX_RESPONSE_BYTES` | `167772160` (160 MiB) | Largest scene video download the server will accept. |
-| `COMFYUI_GEN_TIMEOUT` | `2400` (40 minutes, in seconds) | Time allowed for one ComfyUI workflow after it is queued. |
+| `COMFYUI_GEN_TIMEOUT` | `2400` (40 minutes, in seconds) | Time allowed for one ComfyUI image workflow after it is queued. |
 | `SPRITE_GENERATION_TIMEOUT_MS` | falls back to `IMAGE_GEN_TIMEOUT_MS` | Time allowed for one AI sprite generation job. |
 | `CUSTOM_TOOL_TIMEOUT_MS` | `60000` (1 minute) | Time allowed for one custom tool call. |
 | `MAX_TOOL_ROUNDS` | `100` | Most tool-call rounds before the model must give a final answer. |

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -74,7 +74,7 @@ For chat and roleplay text, the choices are **OpenAI**, **OpenAI (ChatGPT)**, **
 
 For image generation, the choices include **OpenAI (DALL-E)**, **Stability AI**, **Together AI**, **NovelAI**, **OpenRouter Images**, **xAI / Grok Imagine**, **Venice.ai**, **Pollinations**, **Stable Horde**, **SD Web UI (AUTOMATIC1111 / Forge)**, **ComfyUI**, **RunPod Serverless (ComfyUI)**, **Draw Things**, **NanoGPT**, and **Block Entropy**.
 
-For video generation, the choices are **Google AI Studio**, **xAI Imagine**, **OpenRouter Video**, and **Seedance 2.0**.
+For video generation, the choices are **Google AI Studio**, **xAI Imagine**, **OpenRouter Video**, **Seedance 2.0**, and local **ComfyUI** API-format workflows.
 
 You can save many connections at once and assign a different one to each chat. See [Connecting to an AI Provider](connections/connecting-to-a-provider.md).
 

--- a/docs/media/comfyui.md
+++ b/docs/media/comfyui.md
@@ -1,6 +1,6 @@
 # ComfyUI Workflow Setup
 
-Marinara Engine can send image-generation requests to a local ComfyUI server or a RunPod Serverless endpoint that runs ComfyUI. A local connection can use Marinara's built-in basic workflow, but a custom API-format workflow gives you control over checkpoints, LoRAs, VAEs, ControlNet, reference-image nodes, samplers, and other ComfyUI features.
+Marinara Engine can send image- and video-generation requests to a local ComfyUI server, and image requests to a RunPod Serverless endpoint that runs ComfyUI. A local image connection can use Marinara's built-in basic workflow, while video connections and advanced image setups use a custom API-format workflow.
 
 The workflow JSON pasted into Marinara is a snapshot. Marinara does not keep a live link to the workflow open in ComfyUI. Whenever you change the workflow in ComfyUI, test it again, export it again, and replace the JSON saved on the Marinara connection.
 
@@ -8,7 +8,7 @@ The workflow JSON pasted into Marinara is a snapshot. Marinara does not keep a l
 
 Install ComfyUI, add the checkpoints and custom nodes your workflow needs, and start its server. The usual local address is `http://127.0.0.1:8188`.
 
-If ComfyUI runs on a different computer on your home network, its server must listen on an address that Marinara can reach. You must also set `IMAGE_LOCAL_URLS_ENABLED=true` in Marinara's `.env`; see the [Server Configuration Reference](../CONFIGURATION.md). Check the other computer's firewall if the connection still fails.
+If ComfyUI runs on a different computer on your home network, its server must listen on an address that Marinara can reach. Image connections also require `IMAGE_LOCAL_URLS_ENABLED=true` in Marinara's `.env`; see the [Server Configuration Reference](../CONFIGURATION.md). Check the other computer's firewall if the connection still fails.
 
 A local language model and an image model may not fit in GPU memory at the same time, especially on an 8 GB card. Marinara's image queue prevents multiple image jobs from running together, but it cannot make two loaded models fit into the same VRAM. If you run out of memory, use a cloud or separately hosted language model, run ComfyUI on another device, or unload one model before using the other.
 
@@ -32,6 +32,25 @@ A local language model and an image model may not fit in GPU memory at the same 
 7. Open the exported `.json` file in a text editor.
 
 An API-format workflow is different from the normal visual-editor workflow. Its top-level keys are node IDs, and each node normally contains `class_type` and `inputs`. Export the API version; do not paste the regular workflow file containing the editor's visual layout.
+
+## ComfyUI video workflows
+
+Create a **Video Generation** connection, choose **ComfyUI**, and paste an API-format workflow into the required **ComfyUI Workflow** field. WAN 2.2 and other local video graphs are supported as long as the same workflow runs in ComfyUI and saves an MP4 through an output such as the core **SaveVideo** node.
+
+Video workflows can use these quoted placeholders:
+
+| Placeholder              | Value supplied by Marinara                                          |
+| ------------------------ | ------------------------------------------------------------------- |
+| `%prompt%`               | The compiled scene or animation prompt.                             |
+| `%width%`, `%height%`    | `832×480` for 480p or `1280×720` for 720p, swapped for 9:16.        |
+| `%seed%`                 | A new random 32-bit seed.                                           |
+| `%length%`               | Clip length as a frame count at 16 fps.                             |
+| `%model%`                | The connection's Model value, when one is set.                      |
+| `%reference_image_name%` | The uploaded first-frame filename for a ComfyUI **LoadImage** node. |
+
+Marinara queues the workflow through `/prompt`, polls `/history`, and downloads the MP4 named in a `gifs` or `images` output. Image-to-video actions provide `%reference_image_name%`; text-only connection tests do not, so keep that input optional when the same workflow must support both.
+
+Local WAN renders can exceed 30 minutes on mid-range GPUs. ComfyUI video jobs use `VIDEO_GEN_TIMEOUT_MS`, not the image-only `COMFYUI_GEN_TIMEOUT`; raise the video timeout and restart Marinara if a valid workflow is cut off early.
 
 ## Add Marinara placeholders
 
@@ -144,13 +163,15 @@ This can produce more consistent results than one generic workflow, but each con
 | ComfyUI reports a missing node or input          | Install the same custom-node packages used when the workflow was built and confirm their input names have not changed.                                                                                                        |
 | The job completes but Marinara receives no image | Add a connected **SaveImage** output and test the workflow directly in ComfyUI again.                                                                                                                                         |
 | A reference-image node fails                     | For a normal local **LoadImage** node, use a `%reference_image_name...%` placeholder. Use raw base64 only with a node designed for it, and confirm that the Marinara feature actually supplied a reference.                   |
-| A remote/LAN ComfyUI URL is blocked              | Enable `IMAGE_LOCAL_URLS_ENABLED`, make ComfyUI listen on the network interface, and check the host firewall. Do not expose an unauthenticated ComfyUI server to the public internet.                                         |
-| A long generation times out                      | Increase `COMFYUI_GEN_TIMEOUT` in Marinara's `.env`. The value is measured in seconds and defaults to `2400`.                                                                                                                 |
+| A remote/LAN ComfyUI URL is blocked              | For image connections, enable `IMAGE_LOCAL_URLS_ENABLED`. Make ComfyUI listen on the network interface and check the host firewall. Do not expose an unauthenticated ComfyUI server to the public internet.                   |
+| A long image generation times out                | Increase `COMFYUI_GEN_TIMEOUT` in Marinara's `.env`. The value is measured in seconds and defaults to `2400`.                                                                                                                 |
+| A long video generation times out                | Increase `VIDEO_GEN_TIMEOUT_MS` in Marinara's `.env`. The value is measured in milliseconds and defaults to `1800000` (30 minutes).                                                                                           |
 | Generation runs out of GPU memory                | Reduce image dimensions or model size, unload the local language model, use a remote language model, or move ComfyUI to another device.                                                                                       |
 
 ## Related guides
 
 - [Image Generation Providers and Setup](image-providers.md) covers all supported image services and shared image settings.
+- [Scene Video Generation](scene-video.md) covers video connections and every scene-video surface.
 - [Image Style Profiles](style-profiles.md) explains Marinara's reusable prompt styles.
 - [Illustrator Agent](illustrator-agent.md) covers automatic scene illustration.
 - [Server Configuration Reference](../CONFIGURATION.md) documents local-network access and ComfyUI timeouts.

--- a/docs/media/scene-video.md
+++ b/docs/media/scene-video.md
@@ -19,7 +19,7 @@ To make scene videos, you first add a connection that can generate video. This u
 3. Set the provider type to **Video Generation**.
 4. Under **Video Service**, pick one of the five services below.
 5. Enter the API key for a cloud service. Local ComfyUI does not need one.
-6. Pick a model, or keep the default model the service fills in.
+6. For cloud services, pick a model or keep the provider default. For ComfyUI, leave the model unset unless the workflow uses `%model%`.
 7. Save the connection.
 
 The **Video Service** picker offers five choices. Each one fills in a default web address and, where applicable, a default model:

--- a/docs/media/scene-video.md
+++ b/docs/media/scene-video.md
@@ -17,12 +17,12 @@ To make scene videos, you first add a connection that can generate video. This u
 1. Open **Settings**, then open **Connections**.
 2. Click **Add Connection**.
 3. Set the provider type to **Video Generation**.
-4. Under **Video Service**, pick one of the four services below.
-5. Enter the API key for that service. An API key is a secret token that proves your account to the provider.
+4. Under **Video Service**, pick one of the five services below.
+5. Enter the API key for a cloud service. Local ComfyUI does not need one.
 6. Pick a model, or keep the default model the service fills in.
 7. Save the connection.
 
-The **Video Service** picker offers four choices. Each one fills in a default web address and a default model:
+The **Video Service** picker offers five choices. Each one fills in a default web address and, where applicable, a default model:
 
 | Video Service        | Default model               | Notes                                                                        |
 | -------------------- | --------------------------- | ---------------------------------------------------------------------------- |
@@ -30,10 +30,11 @@ The **Video Service** picker offers four choices. Each one fills in a default we
 | **xAI Imagine**      | `grok-imagine-video-1.5`    | Grok Imagine video through the xAI Videos API.                               |
 | **OpenRouter Video** | `google/veo-3.1`            | Video models through OpenRouter. You can type any OpenRouter video model ID. |
 | **Seedance 2.0**     | `seedance-2-0`              | Text, first-frame, and first and last frame video modes.                     |
+| **ComfyUI**          | Workflow-defined            | Local WAN and other video workflows exported in API format.                  |
 
 **Google AI Studio** covers two model families. **Gemini Omni** uses `gemini-omni-flash-preview`. **Google Veo** uses `veo-3.1-generate-preview`. Which one runs depends on the model you pick in the connection.
 
-There is no local or self-hosted option for video. Every video service needs an online account and an API key.
+For **ComfyUI**, use the usual local address `http://127.0.0.1:8188` and paste an API-format video workflow into **ComfyUI Workflow**. The workflow is required. See [ComfyUI Workflow Setup](comfyui.md#comfyui-video-workflows) for placeholders and output-node requirements.
 
 ### Make it the default video connection
 
@@ -50,6 +51,7 @@ A Video Generation connection has its own **Video Generation Defaults** panel in
 | xAI Imagine      | 10s            | 1 to 15s     | 16:9         | 720p             |
 | OpenRouter Video | 10s            | 1 to 60s     | 16:9         | 720p             |
 | Seedance 2.0     | 5s             | 4 to 15s     | 16:9         | 720p             |
+| ComfyUI          | 5s             | 1 to 60s     | 16:9         | 720p             |
 
 Gemini Omni has no resolution field, and its length is written into the prompt text instead of a separate setting. Google Veo forces 8 seconds whenever it animates a reference image, because it needs 8 seconds to blend the first and last frames.
 
@@ -63,15 +65,16 @@ If your Marinara server already has a public web address, you can set an environ
 
 ## Choosing a provider
 
-All four services make short clips from your image. They differ in speed, clip length, and how they handle reference images.
+All five services make short clips from your image. They differ in speed, clip length, and how they handle reference images.
 
 - **Google AI Studio (Gemini Omni)**: flexible length up to 60 seconds. Length is baked into the prompt, not a separate control.
 - **Google AI Studio (Veo)**: strong quality, but fixed to 4, 6, or 8 seconds. It uses 8 seconds when it animates an image.
 - **xAI Imagine**: 1 to 15 second clips. It uses a shorter prompt limit than the other services.
 - **OpenRouter Video**: 1 to 60 seconds, and lets you type any video model your OpenRouter account supports.
 - **Seedance 2.0**: 4 to 15 second clips with first-frame and first and last frame modes. It needs a public link to your reference image.
+- **ComfyUI**: local generation through your own API-format workflow. Marinara uploads the reference image directly to ComfyUI when the workflow uses `%reference_image_name%`.
 
-Expect video jobs to take a while. The provider starts the job, then Marinara waits and checks until the clip is ready. This can take several minutes per clip, longer than a still image.
+Expect video jobs to take a while. The provider starts the job, then Marinara waits and checks until the clip is ready. This can take several minutes per clip, longer than a still image. Large local WAN models may need more than the 30-minute default; raise `VIDEO_GEN_TIMEOUT_MS` and restart Marinara when necessary.
 
 ## Generate a video from the Gallery
 

--- a/packages/client/src/components/connections/ConnectionEditor.tsx
+++ b/packages/client/src/components/connections/ConnectionEditor.tsx
@@ -131,6 +131,7 @@ const DEFAULT_VIDEO_MODELS: Record<VideoDefaultsService, string> = {
   xai: "grok-imagine-video-1.5",
   openrouter: "google/veo-3.1",
   seedance: "seedance-2-0",
+  comfyui: "",
 };
 const VIDEO_RESOLUTION_OPTIONS: Array<{ value: VideoResolution; label: string }> = [
   { value: "480p", label: "480p" },
@@ -145,7 +146,11 @@ const VIDEO_REFERENCE_UPLOAD_EXPIRY_OPTIONS: Array<{ value: VideoReferenceUpload
 ];
 
 function videoSourceToDefaultsService(value: string | null | undefined): VideoDefaultsService {
-  return value === "xai" || value === "openrouter" || value === "seedance" || value === "google_veo"
+  return value === "xai" ||
+    value === "openrouter" ||
+    value === "seedance" ||
+    value === "google_veo" ||
+    value === "comfyui"
     ? value
     : "gemini_omni";
 }
@@ -454,16 +459,26 @@ export function ConnectionEditor() {
       const label = labelMsg + ": " + msg.split("\n")[0];
       return { parseError: true as const, label, charPos };
     }
-    const KNOWN_SUBS = [
-      { token: "%prompt%", label: "%prompt%", critical: true },
-      { token: "%negative_prompt%", label: "%negative_prompt%", critical: false },
-      { token: "%width%", label: "%width%", critical: false },
-      { token: "%height%", label: "%height%", critical: false },
-      { token: "%seed%", label: "%seed%", critical: false },
-      { token: "%model%", label: "%model%", critical: false },
-      { token: "%reference_image%", label: "%reference_image%", critical: false },
-      { token: "%reference_image_name%", label: "%reference_image_name%", critical: false },
-    ];
+    const KNOWN_SUBS =
+      localProvider === "video_generation"
+        ? [
+            { token: "%prompt%", label: "%prompt%", critical: true },
+            { token: "%width%", label: "%width%", critical: false },
+            { token: "%height%", label: "%height%", critical: false },
+            { token: "%seed%", label: "%seed%", critical: false },
+            { token: "%length%", label: "%length%", critical: false },
+            { token: "%reference_image_name%", label: "%reference_image_name%", critical: false },
+          ]
+        : [
+            { token: "%prompt%", label: "%prompt%", critical: true },
+            { token: "%negative_prompt%", label: "%negative_prompt%", critical: false },
+            { token: "%width%", label: "%width%", critical: false },
+            { token: "%height%", label: "%height%", critical: false },
+            { token: "%seed%", label: "%seed%", critical: false },
+            { token: "%model%", label: "%model%", critical: false },
+            { token: "%reference_image%", label: "%reference_image%", critical: false },
+            { token: "%reference_image_name%", label: "%reference_image_name%", critical: false },
+          ];
     const hasReferenceImage = /%reference_image(?:_0[1-4])?%/.test(wf);
     const hasReferenceImageName = /%reference_image_name(?:_0[1-4])?%/.test(wf);
     const missing = KNOWN_SUBS.filter(({ token }) => {
@@ -472,7 +487,7 @@ export function ConnectionEditor() {
       return !wf.includes(token);
     });
     return { parseError: false as const, missing };
-  }, [localComfyuiWorkflow]);
+  }, [localComfyuiWorkflow, localProvider]);
 
   const effectiveImageGenerationSource = useMemo(() => {
     if (localProvider !== "image_generation") return "";
@@ -497,6 +512,10 @@ export function ConnectionEditor() {
       : "";
   const selectedVideoProvider = videoSourceToProviderOption(selectedVideoService);
   const selectedVideoDefaultsService = videoSelectionToDefaultsService(selectedVideoService, localModel, localBaseUrl);
+  const usesComfyUiWorkflow =
+    (localProvider === "image_generation" &&
+      (selectedImageService === "comfyui" || selectedImageService === "runpod_comfyui")) ||
+    (localProvider === "video_generation" && selectedVideoProvider === "comfyui");
   const apiKeyLink =
     localProvider === "image_generation" && selectedImageService === "venice"
       ? { label: "Get your Venice API key", url: "https://venice.ai/settings/api" }
@@ -506,7 +525,9 @@ export function ConnectionEditor() {
           ? API_KEY_LINKS.openrouter
           : localProvider === "video_generation" && selectedVideoDefaultsService === "seedance"
             ? { label: "Open Seedance API docs", url: "https://seedance2.ai/api-docs" }
-            : API_KEY_LINKS[localProvider];
+            : localProvider === "video_generation" && selectedVideoDefaultsService === "comfyui"
+              ? undefined
+              : API_KEY_LINKS[localProvider];
 
   useEffect(() => {
     if (localProvider !== "image_generation" || !selectedImageDefaultsService) {
@@ -638,7 +659,10 @@ export function ConnectionEditor() {
       promptPresetId: !isMediaProvider ? localPromptPresetId || null : null,
       openrouterProvider: localOpenrouterProvider || null,
       imageGenerationSource: isImageProvider ? localImageGenerationSource || localImageService || null : null,
-      comfyuiWorkflow: isImageProvider ? localComfyuiWorkflow || null : null,
+      comfyuiWorkflow:
+        isImageProvider || (isVideoProvider && selectedVideoProvider === "comfyui")
+          ? localComfyuiWorkflow || null
+          : null,
       imageService: isImageProvider ? localImageGenerationSource || localImageService || null : null,
       imageEndpointId:
         isImageProvider && selectedImageService === "runpod_comfyui" ? localImageEndpointId || null : null,
@@ -827,7 +851,8 @@ export function ConnectionEditor() {
       videoService,
       imageEndpointId:
         isImageProvider && selectedImageService === "runpod_comfyui" ? localImageEndpointId || null : null,
-      comfyuiWorkflow: isImageProvider ? localComfyuiWorkflow || null : null,
+      comfyuiWorkflow:
+        isImageProvider || (isVideoProvider && videoProvider === "comfyui") ? localComfyuiWorkflow || null : null,
       claudeFastMode: localClaudeFastMode,
     };
 
@@ -1862,13 +1887,18 @@ export function ConnectionEditor() {
           )}
 
           {/* ── ComfyUI Workflow ── */}
-          {localProvider === "image_generation" &&
-            (selectedImageService === "comfyui" || selectedImageService === "runpod_comfyui") && (
+          {usesComfyUiWorkflow && (
               <FieldGroup
-                label={`ComfyUI Workflow (${selectedImageService === "runpod_comfyui" ? "Required" : "Optional"})`}
+                label={`ComfyUI Workflow (${
+                  localProvider === "video_generation" || selectedImageService === "runpod_comfyui"
+                    ? "Required"
+                    : "Optional"
+                })`}
                 icon={<Zap size="0.875rem" className="text-sky-400" />}
                 help={
-                  selectedImageService === "runpod_comfyui"
+                  localProvider === "video_generation"
+                    ? "Paste a ComfyUI video workflow in API format. Use %prompt%, %width%, %height%, %seed%, and %length% for the 16 fps frame count. Use %reference_image_name% in image-to-video workflows so Marinara can upload the first frame to ComfyUI."
+                    : selectedImageService === "runpod_comfyui"
                     ? "Paste your ComfyUI workflow JSON (API format). RunPod needs the full workflow to execute; the endpoint sends this workflow to your serverless endpoint. Use placeholders like %prompt%, %seed%, %width%, %height%, %reference_image%, and %reference_image_01% through %reference_image_04% to let Marinara inject generation parameters."
                     : "Paste a custom ComfyUI workflow JSON (API format). Use placeholders like %prompt%, %negative_prompt%, %width%, %height%, %seed%, %model%, %steps%, %cfg%, %sampler%, %scheduler%, and %denoise%. For reference images, use %reference_image% / %reference_image_01% through %reference_image_04% to inject base64 strings, or %reference_image_name% / %reference_image_name_01% through %reference_image_name_04% to upload images to ComfyUI's input directory and inject filenames for LoadImage nodes. Leave empty to use the built-in default txt2img workflow."
                 }
@@ -1928,9 +1958,18 @@ export function ConnectionEditor() {
                     </p>
                   )}
                 <p className="text-[0.55rem] text-[var(--muted-foreground)] mt-1">
-                  Export your workflow from ComfyUI using <strong>Save (API Format)</strong> in the menu. Placeholders
-                  like <code>%prompt%</code>, <code>%steps%</code>, <code>%sampler%</code>, and reference-image
-                  placeholders will be replaced at generation time.
+                  Export your workflow from ComfyUI using <strong>Save (API Format)</strong> in the menu.{" "}
+                  {localProvider === "video_generation" ? (
+                    <>
+                      Use a video output node such as <strong>SaveVideo</strong>. Marinara downloads the MP4 reported in
+                      the workflow&apos;s <code>gifs</code> or <code>images</code> output.
+                    </>
+                  ) : (
+                    <>
+                      Placeholders like <code>%prompt%</code>, <code>%steps%</code>, <code>%sampler%</code>, and
+                      reference-image placeholders will be replaced at generation time.
+                    </>
+                  )}
                 </p>
               </FieldGroup>
             )}
@@ -3266,6 +3305,7 @@ function VideoGenerationDefaultsPanel({
     value.service === "xai" ||
     value.service === "openrouter" ||
     value.service === "seedance" ||
+    value.service === "comfyui" ||
     value.service === "google_veo"
       ? value.service
       : "gemini_omni";
@@ -3278,7 +3318,9 @@ function VideoGenerationDefaultsPanel({
           ? `${value.openrouter.durationSeconds}s, ${value.openrouter.aspectRatio}, ${value.openrouter.resolution}`
           : service === "seedance"
             ? `${value.seedance.durationSeconds}s, ${value.seedance.aspectRatio}, ${value.seedance.resolution}`
-            : `${value.geminiOmni.durationSeconds}s, ${value.geminiOmni.aspectRatio}`;
+            : service === "comfyui"
+              ? `${value.comfyui.durationSeconds}s, ${value.comfyui.aspectRatio}, ${value.comfyui.resolution}`
+              : `${value.geminiOmni.durationSeconds}s, ${value.geminiOmni.aspectRatio}`;
   const serviceLabel =
     service === "xai"
       ? "xAI Imagine"
@@ -3288,7 +3330,9 @@ function VideoGenerationDefaultsPanel({
           ? "OpenRouter Video"
           : service === "seedance"
             ? "Seedance 2.0"
-            : "Google AI Studio Gemini Omni";
+            : service === "comfyui"
+              ? "ComfyUI"
+              : "Google AI Studio Gemini Omni";
 
   const updateGeminiOmni = (patch: Partial<VideoGenerationDefaultsProfile["geminiOmni"]>) => {
     onChange({
@@ -3325,6 +3369,13 @@ function VideoGenerationDefaultsPanel({
       seedance: { ...value.seedance, ...patch },
     });
   };
+  const updateComfyUi = (patch: Partial<VideoGenerationDefaultsProfile["comfyui"]>) => {
+    onChange({
+      ...value,
+      service: "comfyui",
+      comfyui: { ...value.comfyui, ...patch },
+    });
+  };
 
   return (
     <FieldGroup
@@ -3339,7 +3390,9 @@ function VideoGenerationDefaultsPanel({
               ? "Connection-scoped defaults for OpenRouter asynchronous video generation."
               : service === "seedance"
                 ? "Connection-scoped defaults for Seedance 2.0 asynchronous video generation."
-                : "Connection-scoped defaults for scene video generation. Duration is rendered into the Omni prompt."
+                : service === "comfyui"
+                  ? "Connection-scoped dimensions and duration for local ComfyUI video workflows."
+                  : "Connection-scoped defaults for scene video generation. Duration is rendered into the Omni prompt."
       }
     >
       <div className="rounded-xl bg-[var(--secondary)]/40 ring-1 ring-[var(--border)]">
@@ -3371,7 +3424,11 @@ function VideoGenerationDefaultsPanel({
               </button>
             </div>
 
-            {service === "xai" || service === "google_veo" || service === "openrouter" || service === "seedance" ? (
+            {service === "xai" ||
+            service === "google_veo" ||
+            service === "openrouter" ||
+            service === "seedance" ||
+            service === "comfyui" ? (
               <>
                 <div className="grid gap-2 sm:grid-cols-3">
                   <NumberSetting
@@ -3383,7 +3440,9 @@ function VideoGenerationDefaultsPanel({
                           ? value.googleVeo.durationSeconds
                           : service === "seedance"
                             ? value.seedance.durationSeconds
-                            : value.openrouter.durationSeconds
+                            : service === "comfyui"
+                              ? value.comfyui.durationSeconds
+                              : value.openrouter.durationSeconds
                     }
                     min={service === "google_veo" || service === "seedance" ? 4 : 1}
                     max={service === "xai" || service === "seedance" ? 15 : service === "google_veo" ? 8 : 60}
@@ -3393,6 +3452,8 @@ function VideoGenerationDefaultsPanel({
                         updateGoogleVeo({ durationSeconds: durationSeconds <= 5 ? 4 : durationSeconds <= 7 ? 6 : 8 });
                       } else if (service === "seedance") {
                         updateSeedance({ durationSeconds });
+                      } else if (service === "comfyui") {
+                        updateComfyUi({ durationSeconds });
                       } else updateOpenRouter({ durationSeconds });
                     }}
                   />
@@ -3406,13 +3467,16 @@ function VideoGenerationDefaultsPanel({
                             ? value.googleVeo.aspectRatio
                             : service === "seedance"
                               ? value.seedance.aspectRatio
-                              : value.openrouter.aspectRatio
+                              : service === "comfyui"
+                                ? value.comfyui.aspectRatio
+                                : value.openrouter.aspectRatio
                       }
                       onChange={(event) => {
                         const aspectRatio = event.target.value === "9:16" ? "9:16" : "16:9";
                         if (service === "xai") updateXai({ aspectRatio });
                         else if (service === "google_veo") updateGoogleVeo({ aspectRatio });
                         else if (service === "seedance") updateSeedance({ aspectRatio });
+                        else if (service === "comfyui") updateComfyUi({ aspectRatio });
                         else updateOpenRouter({ aspectRatio });
                       }}
                       className="mt-1 w-full rounded-lg bg-[var(--card)] px-3 py-2 text-xs ring-1 ring-[var(--border)] focus:outline-none focus:ring-sky-400/50"
@@ -3431,19 +3495,24 @@ function VideoGenerationDefaultsPanel({
                             ? value.googleVeo.resolution
                             : service === "seedance"
                               ? value.seedance.resolution
-                              : value.openrouter.resolution
+                              : service === "comfyui"
+                                ? value.comfyui.resolution
+                                : value.openrouter.resolution
                       }
                       onChange={(event) => {
                         const resolution = event.target.value as VideoResolution;
                         if (service === "xai") updateXai({ resolution });
                         else if (service === "google_veo") updateGoogleVeo({ resolution });
                         else if (service === "seedance") updateSeedance({ resolution });
+                        else if (service === "comfyui") updateComfyUi({ resolution });
                         else updateOpenRouter({ resolution });
                       }}
                       className="mt-1 w-full rounded-lg bg-[var(--card)] px-3 py-2 text-xs ring-1 ring-[var(--border)] focus:outline-none focus:ring-sky-400/50"
                     >
                       {VIDEO_RESOLUTION_OPTIONS.filter(
-                        (option) => service !== "google_veo" || option.value !== "480p",
+                        (option) =>
+                          (service !== "google_veo" || option.value !== "480p") &&
+                          (service !== "comfyui" || option.value !== "1080p"),
                       ).map((option) => (
                         <option key={option.value} value={option.value}>
                           {option.label}
@@ -3459,7 +3528,9 @@ function VideoGenerationDefaultsPanel({
                       ? "Veo accepts 4, 6, or 8 seconds. Character loop references use the avatar as the first and last frame and run at 8 seconds."
                       : service === "seedance"
                         ? "Seedance accepts 4-15 seconds. Reference-image jobs send matching first and last frames when the provider can fetch the reference URL."
-                        : "These values are sent to OpenRouter's asynchronous Videos API. OpenRouter model support varies, so keep the model's own limits in mind."}
+                        : service === "comfyui"
+                          ? "ComfyUI receives width, height, and a 16 fps frame count through workflow placeholders."
+                          : "These values are sent to OpenRouter's asynchronous Videos API. OpenRouter model support varies, so keep the model's own limits in mind."}
                 </p>
               </>
             ) : (

--- a/packages/server/src/routes/connections.routes.ts
+++ b/packages/server/src/routes/connections.routes.ts
@@ -1003,6 +1003,7 @@ export async function connectionsRoutes(app: FastifyInstance) {
     const isGoogleVeoVideo = videoSource === "google_veo" || videoServiceHint === "google_veo";
     const isOpenRouterVideo = videoSource === "openrouter" || videoServiceHint === "openrouter";
     const isSeedanceVideo = videoSource === "seedance" || videoServiceHint === "seedance";
+    const isComfyUiVideo = videoSource === "comfyui" || videoServiceHint === "comfyui";
     const baseUrl = (
       conn.baseUrl ||
       (isXaiVideo
@@ -1013,7 +1014,9 @@ export async function connectionsRoutes(app: FastifyInstance) {
             ? DEFAULT_OPENROUTER_VIDEO_BASE_URL
             : isSeedanceVideo
               ? DEFAULT_SEEDANCE_VIDEO_BASE_URL
-              : providerDef?.defaultBaseUrl || DEFAULT_GEMINI_OMNI_VIDEO_BASE_URL)
+              : isComfyUiVideo
+                ? "http://127.0.0.1:8188"
+                : providerDef?.defaultBaseUrl || DEFAULT_GEMINI_OMNI_VIDEO_BASE_URL)
     ).replace(/\/+$/, "");
     const videoModel =
       conn.model ||
@@ -1025,7 +1028,9 @@ export async function connectionsRoutes(app: FastifyInstance) {
             ? DEFAULT_OPENROUTER_VIDEO_MODEL
             : isSeedanceVideo
               ? DEFAULT_SEEDANCE_VIDEO_MODEL
-              : DEFAULT_GEMINI_OMNI_VIDEO_MODEL);
+              : isComfyUiVideo
+                ? ""
+                : DEFAULT_GEMINI_OMNI_VIDEO_MODEL);
     const activeDefaults = isXaiVideo
       ? defaults.xai
       : isGoogleVeoVideo
@@ -1034,7 +1039,9 @@ export async function connectionsRoutes(app: FastifyInstance) {
           ? defaults.openrouter
           : isSeedanceVideo
             ? defaults.seedance
-            : defaults.geminiOmni;
+            : isComfyUiVideo
+              ? defaults.comfyui
+              : defaults.geminiOmni;
 
     const prompt =
       "Create a concise cinematic 16:9 game scene video: a plate of spaghetti with marinara sauce on a table, gentle steam rising, warm kitchen light, slow push-in camera, no text or logos.";
@@ -1055,7 +1062,10 @@ export async function connectionsRoutes(app: FastifyInstance) {
               ? defaults.openrouter.resolution
               : isSeedanceVideo
                 ? defaults.seedance.resolution
-                : undefined,
+                : isComfyUiVideo
+                  ? defaults.comfyui.resolution
+                  : undefined,
+        comfyWorkflow: conn.comfyuiWorkflow || undefined,
       });
       return {
         success: true,

--- a/packages/server/src/routes/connections.routes.ts
+++ b/packages/server/src/routes/connections.routes.ts
@@ -39,6 +39,7 @@ import { DATA_DIR } from "../utils/data-dir.js";
 
 const CONNECTION_TEST_ERROR_PREVIEW_CHARS = 2000;
 const CONNECTION_IMAGES_DIR = join(DATA_DIR, "connections", "images");
+const DEFAULT_COMFYUI_VIDEO_BASE_URL = "http://127.0.0.1:8188";
 const DEFAULT_GEMINI_OMNI_VIDEO_MODEL = "gemini-omni-flash-preview";
 const DEFAULT_GEMINI_OMNI_VIDEO_BASE_URL = "https://generativelanguage.googleapis.com/v1beta";
 const DEFAULT_GOOGLE_VEO_VIDEO_MODEL = "veo-3.1-generate-preview";
@@ -1015,7 +1016,7 @@ export async function connectionsRoutes(app: FastifyInstance) {
             : isSeedanceVideo
               ? DEFAULT_SEEDANCE_VIDEO_BASE_URL
               : isComfyUiVideo
-                ? "http://127.0.0.1:8188"
+                ? DEFAULT_COMFYUI_VIDEO_BASE_URL
                 : providerDef?.defaultBaseUrl || DEFAULT_GEMINI_OMNI_VIDEO_BASE_URL)
     ).replace(/\/+$/, "");
     const videoModel =

--- a/packages/server/src/routes/gallery.routes.ts
+++ b/packages/server/src/routes/gallery.routes.ts
@@ -795,7 +795,8 @@ export async function galleryRoutes(app: FastifyInstance) {
     const sceneVideos = createGameSceneVideosStorage(app.db);
     const { videoConnectionId, galleryImage, videoRuntime, durationSeconds, aspectRatio, prompt, videoFallback } =
       prepared;
-    const { source, serviceHint, baseUrl, apiKey, model, resolution, publicReferenceUpload } = videoRuntime;
+    const { source, serviceHint, baseUrl, apiKey, model, resolution, publicReferenceUpload, comfyWorkflow } =
+      videoRuntime;
 
     const galleryImagePath = resolveGalleryImagePath(galleryImage);
     if (!galleryImagePath) {
@@ -833,6 +834,7 @@ export async function galleryRoutes(app: FastifyInstance) {
         durationSeconds,
         aspectRatio,
         resolution,
+        comfyWorkflow,
         referenceImage,
         publicReferenceUpload,
         queue: input.queueMediaGenerationRequests,

--- a/packages/server/src/routes/game.routes.ts
+++ b/packages/server/src/routes/game.routes.ts
@@ -10777,6 +10777,7 @@ export async function gameRoutes(app: FastifyInstance) {
                   durationSeconds: Math.min(videoRuntime.maxDurationSeconds, plannedFrame.durationSeconds),
                   aspectRatio: plannedFrame.aspectRatio,
                   resolution: videoRuntime.resolution,
+                  comfyWorkflow: videoRuntime.comfyWorkflow,
                   referenceImage,
                   publicReferenceUpload: videoRuntime.publicReferenceUpload,
                   fallback: videoFallback,
@@ -11039,6 +11040,7 @@ export async function gameRoutes(app: FastifyInstance) {
       minDurationSeconds,
       maxDurationSeconds,
       publicReferenceUpload,
+      comfyWorkflow,
       activeDefaults: activeVideoDefaults,
       hasStoredDefaults,
     } = videoRuntime;
@@ -11143,6 +11145,7 @@ export async function gameRoutes(app: FastifyInstance) {
         durationSeconds,
         aspectRatio,
         resolution,
+        comfyWorkflow,
         referenceImage,
         publicReferenceUpload,
         queue: input.queueMediaGenerationRequests,

--- a/packages/server/src/routes/sprites.routes.ts
+++ b/packages/server/src/routes/sprites.routes.ts
@@ -161,6 +161,7 @@ type VideoGenerationConnection = {
   model?: string | null;
   videoGenerationSource?: string | null;
   videoService?: string | null;
+  comfyuiWorkflow?: string | null;
   defaultParameters?: string | null;
 };
 
@@ -348,6 +349,7 @@ function resolveVideoConnection(connection: VideoGenerationConnection) {
   const isGoogleVeoVideo = source === "google_veo" || serviceHint === "google_veo";
   const isOpenRouterVideo = source === "openrouter" || serviceHint === "openrouter";
   const isSeedanceVideo = source === "seedance" || serviceHint === "seedance";
+  const isComfyUiVideo = source === "comfyui" || serviceHint === "comfyui";
   return {
     source,
     serviceHint,
@@ -361,7 +363,9 @@ function resolveVideoConnection(connection: VideoGenerationConnection) {
             ? "https://openrouter.ai/api/v1"
             : isSeedanceVideo
               ? "https://api.seedance2.ai"
-              : "https://generativelanguage.googleapis.com/v1beta"),
+              : isComfyUiVideo
+                ? "http://127.0.0.1:8188"
+                : "https://generativelanguage.googleapis.com/v1beta"),
     model:
       connection.model ||
       (isXaiVideo
@@ -372,7 +376,9 @@ function resolveVideoConnection(connection: VideoGenerationConnection) {
             ? "google/veo-3.1"
             : isSeedanceVideo
               ? "seedance-2-0"
-              : "gemini-omni-flash-preview"),
+              : isComfyUiVideo
+                ? ""
+                : "gemini-omni-flash-preview"),
     resolution: isXaiVideo
       ? videoDefaults.xai.resolution
       : isGoogleVeoVideo
@@ -381,7 +387,10 @@ function resolveVideoConnection(connection: VideoGenerationConnection) {
           ? videoDefaults.openrouter.resolution
           : isSeedanceVideo
             ? videoDefaults.seedance.resolution
-            : undefined,
+            : isComfyUiVideo
+              ? videoDefaults.comfyui.resolution
+              : undefined,
+    comfyWorkflow: connection.comfyuiWorkflow || undefined,
     publicReferenceUpload: resolveVideoReferencePublicUploadOptions(isSeedanceVideo, videoDefaults.seedance),
   };
 }
@@ -1770,6 +1779,7 @@ export async function spritesRoutes(app: FastifyInstance) {
                   durationSeconds,
                   aspectRatio: ANIMATED_EXPRESSION_ASPECT_RATIO,
                   resolution: resolved.resolution,
+                  comfyWorkflow: resolved.comfyWorkflow,
                   referenceImage,
                   publicReferenceUpload: resolved.publicReferenceUpload,
                   fallback: videoFallback,

--- a/packages/server/src/services/generation/media-connection-fallback.ts
+++ b/packages/server/src/services/generation/media-connection-fallback.ts
@@ -57,5 +57,6 @@ export async function resolveVideoConnectionFallback(
     apiKey: connection.apiKey || "",
     serviceHint: String(connection.videoService ?? connection.videoGenerationSource ?? source),
     model,
+    comfyWorkflow: connection.comfyuiWorkflow || undefined,
   };
 }

--- a/packages/server/src/services/video/game-video-runtime.ts
+++ b/packages/server/src/services/video/game-video-runtime.ts
@@ -23,6 +23,7 @@ const DEFAULT_OPENROUTER_VIDEO_MODEL = "google/veo-3.1";
 const DEFAULT_OPENROUTER_VIDEO_BASE_URL = "https://openrouter.ai/api/v1";
 const DEFAULT_SEEDANCE_VIDEO_MODEL = "seedance-2-0";
 const DEFAULT_SEEDANCE_VIDEO_BASE_URL = "https://api.seedance2.ai";
+const DEFAULT_COMFYUI_VIDEO_BASE_URL = "http://127.0.0.1:8188";
 
 interface VideoRuntimeConnection {
   baseUrl?: string | null;
@@ -31,6 +32,7 @@ interface VideoRuntimeConnection {
   defaultParameters?: unknown;
   videoGenerationSource?: string | null;
   videoService?: string | null;
+  comfyuiWorkflow?: string | null;
 }
 
 interface ActiveVideoDefaults {
@@ -45,6 +47,7 @@ export interface GameVideoRuntime {
   baseUrl: string;
   apiKey: string;
   model: string;
+  comfyWorkflow?: string;
   resolution?: VideoResolution;
   promptLimits: SceneVideoPromptLimits;
   minDurationSeconds: number;
@@ -92,6 +95,7 @@ export function resolveGameVideoRuntime(connection: VideoRuntimeConnection): Gam
   const isGoogleVeo = source === "google_veo" || serviceHint === "google_veo";
   const isOpenRouter = source === "openrouter" || serviceHint === "openrouter";
   const isSeedance = source === "seedance" || serviceHint === "seedance";
+  const isComfyUi = source === "comfyui" || serviceHint === "comfyui";
   const activeDefaults = isXai
     ? videoDefaults.xai
     : isGoogleVeo
@@ -100,7 +104,9 @@ export function resolveGameVideoRuntime(connection: VideoRuntimeConnection): Gam
         ? videoDefaults.openrouter
         : isSeedance
           ? videoDefaults.seedance
-          : videoDefaults.geminiOmni;
+          : isComfyUi
+            ? videoDefaults.comfyui
+            : videoDefaults.geminiOmni;
   const resolution = isXai
     ? videoDefaults.xai.resolution
     : isGoogleVeo
@@ -109,7 +115,9 @@ export function resolveGameVideoRuntime(connection: VideoRuntimeConnection): Gam
         ? videoDefaults.openrouter.resolution
         : isSeedance
           ? videoDefaults.seedance.resolution
-          : undefined;
+          : isComfyUi
+            ? videoDefaults.comfyui.resolution
+            : undefined;
 
   return {
     source,
@@ -124,7 +132,9 @@ export function resolveGameVideoRuntime(connection: VideoRuntimeConnection): Gam
             ? DEFAULT_OPENROUTER_VIDEO_BASE_URL
             : isSeedance
               ? DEFAULT_SEEDANCE_VIDEO_BASE_URL
-              : DEFAULT_GEMINI_OMNI_BASE_URL),
+              : isComfyUi
+                ? DEFAULT_COMFYUI_VIDEO_BASE_URL
+                : DEFAULT_GEMINI_OMNI_BASE_URL),
     apiKey: connection.apiKey || "",
     model:
       connection.model ||
@@ -136,7 +146,10 @@ export function resolveGameVideoRuntime(connection: VideoRuntimeConnection): Gam
             ? DEFAULT_OPENROUTER_VIDEO_MODEL
             : isSeedance
               ? DEFAULT_SEEDANCE_VIDEO_MODEL
-              : DEFAULT_GEMINI_OMNI_MODEL),
+              : isComfyUi
+                ? ""
+                : DEFAULT_GEMINI_OMNI_MODEL),
+    comfyWorkflow: connection.comfyuiWorkflow || undefined,
     resolution,
     promptLimits: getSceneVideoPromptLimits(isXai, isGeminiOmni),
     minDurationSeconds: isGoogleVeo || isSeedance ? 4 : 1,

--- a/packages/server/src/services/video/video-generation.ts
+++ b/packages/server/src/services/video/video-generation.ts
@@ -28,6 +28,8 @@ export interface VideoGenerationRequest {
   aspectRatio: "16:9" | "9:16";
   resolution?: "480p" | "720p" | "1080p";
   referenceImage?: VideoReferenceImage | null;
+  /** API-format workflow JSON for local ComfyUI video generation. */
+  comfyWorkflow?: string;
   lastFrameImage?: VideoReferenceImage | null;
   publicReferenceUpload?: VideoReferencePublicUploadOptions | null;
   signal?: AbortSignal;
@@ -46,6 +48,7 @@ export interface VideoGenerationRequest {
     apiKey: string;
     serviceHint: string;
     model: string;
+    comfyWorkflow?: string;
   };
 }
 
@@ -144,6 +147,11 @@ async function generateVideoUnqueued(
         generateSeedanceVideo(baseUrl, apiKey, { ...primaryRequest, signal }),
       );
     }
+    if (resolvedService === "comfyui") {
+      return await withVideoGenerationDeadline(request.signal, VIDEO_GEN_TIMEOUT, (signal) =>
+        generateComfyUiVideo(baseUrl, { ...primaryRequest, signal }),
+      );
+    }
     throw new Error(`Unsupported video generation service: ${resolvedService || serviceHint || source}`);
   } catch (error) {
     const fallback = request.fallback;
@@ -168,6 +176,7 @@ async function generateVideoUnqueued(
       ...request,
       fallback: undefined,
       model: fallback.model,
+      comfyWorkflow: fallback.comfyWorkflow,
       connectionKey: fallback.connectionId,
     });
   }
@@ -262,7 +271,195 @@ function normalizeVideoService(value: string): string {
   if (normalized === "seedance" || normalized === "seedance2" || normalized === "seedance-2") {
     return "seedance";
   }
+  if (normalized === "comfyui" || normalized === "comfy-ui") {
+    return "comfyui";
+  }
   return normalized;
+}
+
+type ComfyUiOutputKey = "gifs" | "images";
+
+interface ComfyUiOutputFile {
+  filename: string;
+  subfolder?: string;
+  type?: string;
+}
+
+interface ComfyUiHistoryEntry {
+  outputs?: Record<string, Partial<Record<ComfyUiOutputKey, ComfyUiOutputFile[]>>>;
+  status?: Record<string, unknown>;
+}
+
+function replaceComfyUiVideoPlaceholders(value: unknown, replacements: Record<string, string | number>): unknown {
+  if (typeof value === "string") {
+    const exact = replacements[value];
+    if (exact !== undefined) return exact;
+    return Object.entries(replacements).reduce(
+      (resolved, [placeholder, replacement]) => resolved.replaceAll(placeholder, String(replacement)),
+      value,
+    );
+  }
+  if (Array.isArray(value)) return value.map((entry) => replaceComfyUiVideoPlaceholders(entry, replacements));
+  if (value && typeof value === "object") {
+    return Object.fromEntries(
+      Object.entries(value).map(([key, entry]) => [key, replaceComfyUiVideoPlaceholders(entry, replacements)]),
+    );
+  }
+  return value;
+}
+
+function comfyUiVideoFetch(url: string | URL, init?: RequestInit, maxResponseBytes = 2 * 1024 * 1024) {
+  return safeFetch(url, {
+    ...(init ?? {}),
+    policy: {
+      allowLocal: true,
+      allowLoopback: true,
+      allowedProtocols: ["https:", "http:"],
+    },
+    maxResponseBytes,
+    decodeCompressedResponse: true,
+  });
+}
+
+async function uploadComfyUiVideoReference(
+  baseUrl: string,
+  reference: VideoReferenceImage,
+  signal?: AbortSignal,
+): Promise<string> {
+  const imageBytes = Buffer.from(stripDataUrl(reference.base64), "base64");
+  const extension = reference.mimeType === "image/jpeg" ? "jpg" : "png";
+  const filename = `marinara-video-reference-${newId()}.${extension}`;
+  const formData = new FormData();
+  formData.append("image", new Blob([imageBytes], { type: reference.mimeType }), filename);
+  formData.append("overwrite", "true");
+  const response = await comfyUiVideoFetch(`${baseUrl}/upload/image`, {
+    method: "POST",
+    body: formData,
+    signal,
+  });
+  const text = await response.text();
+  if (!response.ok) {
+    throw new Error(`ComfyUI reference image upload failed (${response.status}): ${formatProviderError(text)}`);
+  }
+  let result: unknown;
+  try {
+    result = JSON.parse(text) as unknown;
+  } catch {
+    throw new Error("ComfyUI reference image upload returned invalid JSON");
+  }
+  const uploadedName = readString(asRecord(result).name);
+  if (!uploadedName) throw new Error("ComfyUI did not return a filename for the uploaded reference image");
+  return uploadedName;
+}
+
+function comfyUiWorkflowStatusError(status: unknown): string | null {
+  const record = asRecord(status);
+  if (readString(record.status_str)?.toLowerCase() !== "error") return null;
+  const details = record.messages ?? record;
+  try {
+    return formatProviderError(JSON.stringify(details));
+  } catch {
+    return "Unknown workflow error";
+  }
+}
+
+function isComfyUiWorkflowComplete(status: unknown): boolean {
+  const record = asRecord(status);
+  return record.completed === true || readString(record.status_str)?.toLowerCase() === "success";
+}
+
+function collectComfyUiVideoFiles(entry: ComfyUiHistoryEntry): ComfyUiOutputFile[] {
+  if (!entry.outputs) return [];
+  const files: ComfyUiOutputFile[] = [];
+  for (const output of Object.values(entry.outputs)) {
+    for (const key of ["gifs", "images"] as const) {
+      for (const file of output[key] ?? []) {
+        if (typeof file?.filename === "string" && file.filename.toLowerCase().endsWith(".mp4")) files.push(file);
+      }
+    }
+  }
+  return files;
+}
+
+async function generateComfyUiVideo(baseUrl: string, request: VideoGenerationRequest): Promise<VideoGenerationResult> {
+  const workflowText = request.comfyWorkflow?.trim();
+  if (!workflowText) throw new Error("ComfyUI video generation requires an API-format workflow");
+  let workflow: unknown;
+  try {
+    workflow = JSON.parse(workflowText) as unknown;
+  } catch {
+    throw new Error("Invalid ComfyUI video workflow JSON");
+  }
+
+  const base = baseUrl.replace(/\/+$/, "");
+  const landscape = request.resolution === "480p" ? { width: 832, height: 480 } : { width: 1280, height: 720 };
+  const dimensions = request.aspectRatio === "9:16" ? { width: landscape.height, height: landscape.width } : landscape;
+  const replacements: Record<string, string | number> = {
+    "%prompt%": request.prompt,
+    "%width%": dimensions.width,
+    "%height%": dimensions.height,
+    "%seed%": Math.floor(Math.random() * 2 ** 32),
+    "%length%": Math.max(1, Math.round(request.durationSeconds * 16)),
+  };
+  if (request.model?.trim()) replacements["%model%"] = request.model.trim();
+  if (request.referenceImage && workflowText.includes("%reference_image_name%")) {
+    replacements["%reference_image_name%"] = await uploadComfyUiVideoReference(
+      base,
+      request.referenceImage,
+      request.signal,
+    );
+  }
+
+  const queueResponse = await comfyUiVideoFetch(`${base}/prompt`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ prompt: replaceComfyUiVideoPlaceholders(workflow, replacements) }),
+    signal: request.signal,
+  });
+  const queueText = await queueResponse.text();
+  if (!queueResponse.ok) {
+    throw new Error(`ComfyUI video queue failed (${queueResponse.status}): ${formatProviderError(queueText)}`);
+  }
+  let queued: unknown;
+  try {
+    queued = JSON.parse(queueText) as unknown;
+  } catch {
+    throw new Error("ComfyUI video queue returned invalid JSON");
+  }
+  const promptId = readString(asRecord(queued).prompt_id);
+  if (!promptId) throw new Error(`ComfyUI video queue did not return a prompt_id: ${formatProviderError(queueText)}`);
+
+  while (true) {
+    await delayWithSignal(1000, request.signal);
+    const historyResponse = await comfyUiVideoFetch(`${base}/history/${encodeURIComponent(promptId)}`, {
+      signal: request.signal,
+    });
+    if (!historyResponse.ok) continue;
+    const history = (await historyResponse.json()) as Record<string, ComfyUiHistoryEntry>;
+    const entry = history[promptId];
+    const statusError = comfyUiWorkflowStatusError(entry?.status);
+    if (statusError) throw new Error(`ComfyUI video workflow failed: ${statusError}`);
+    const output = collectComfyUiVideoFiles(entry ?? ({} as ComfyUiHistoryEntry))[0];
+    if (output) {
+      const params = new URLSearchParams({
+        filename: output.filename,
+        subfolder: output.subfolder || "",
+        type: output.type || "output",
+      });
+      const videoResponse = await comfyUiVideoFetch(
+        `${base}/view?${params}`,
+        { signal: request.signal },
+        MAX_VIDEO_RESPONSE_BYTES,
+      );
+      if (!videoResponse.ok) throw new Error(`ComfyUI video fetch failed (${videoResponse.status})`);
+      const buffer = Buffer.from(await videoResponse.arrayBuffer());
+      if (!isMp4Buffer(buffer)) throw new Error("ComfyUI returned a non-MP4 video output");
+      return { base64: buffer.toString("base64"), mimeType: "video/mp4", ext: "mp4" };
+    }
+    if (isComfyUiWorkflowComplete(entry?.status)) {
+      throw new Error("ComfyUI video workflow completed without an MP4 output");
+    }
+  }
 }
 
 async function generateGeminiOmniVideo(

--- a/packages/server/src/services/video/video-generation.ts
+++ b/packages/server/src/services/video/video-generation.ts
@@ -392,7 +392,12 @@ async function generateComfyUiVideo(baseUrl: string, request: VideoGenerationReq
   }
 
   const base = baseUrl.replace(/\/+$/, "");
-  const landscape = request.resolution === "480p" ? { width: 832, height: 480 } : { width: 1280, height: 720 };
+  const landscape =
+    request.resolution === "480p"
+      ? { width: 832, height: 480 }
+      : request.resolution === "1080p"
+        ? { width: 1920, height: 1080 }
+        : { width: 1280, height: 720 };
   const dimensions = request.aspectRatio === "9:16" ? { width: landscape.height, height: landscape.width } : landscape;
   const replacements: Record<string, string | number> = {
     "%prompt%": request.prompt,

--- a/packages/shared/src/constants/model-lists.ts
+++ b/packages/shared/src/constants/model-lists.ts
@@ -605,6 +605,13 @@ export const VIDEO_GENERATION_SOURCES: VideoGenSource[] = [
     defaultBaseUrl: "https://api.seedance2.ai",
     requiresApiKey: true,
   },
+  {
+    id: "comfyui",
+    name: "ComfyUI",
+    description: "Local API-format workflows for WAN and other video models.",
+    defaultBaseUrl: "http://127.0.0.1:8188",
+    requiresApiKey: false,
+  },
 ];
 
 export const IMAGE_GENERATION_SOURCES: ImageGenSource[] = [
@@ -790,6 +797,7 @@ const VIDEO_GEN_MODELS: KnownModel[] = [
 export function inferVideoSource(model: string, baseUrl: string): string {
   const m = model.toLowerCase();
   const u = baseUrl.toLowerCase();
+  if (m === "comfyui" || u.includes(":8188") || u.includes("comfyui")) return "comfyui";
   if (m === "seedance" || m.startsWith("seedance-") || u.includes("seedance2.ai")) return "seedance";
   if (m === "openrouter" || u.includes("openrouter.ai")) return "openrouter";
   if (m.includes("/") && (m.includes("veo") || m.includes("wan"))) return "openrouter";

--- a/packages/shared/src/constants/video-generation-defaults.ts
+++ b/packages/shared/src/constants/video-generation-defaults.ts
@@ -2,6 +2,7 @@ import type {
   GeminiOmniVideoDefaults,
   GoogleVeoVideoDefaults,
   OpenRouterVideoDefaults,
+  ComfyUiVideoDefaults,
   SeedanceVideoDefaults,
   VideoAspectRatio,
   VideoDefaultsService,
@@ -20,6 +21,7 @@ export const VIDEO_DEFAULTS_SERVICES: VideoDefaultsService[] = [
   "xai",
   "openrouter",
   "seedance",
+  "comfyui",
 ];
 
 export const DEFAULT_GEMINI_OMNI_VIDEO_DEFAULTS: GeminiOmniVideoDefaults = {
@@ -53,6 +55,12 @@ export const DEFAULT_SEEDANCE_VIDEO_DEFAULTS: SeedanceVideoDefaults = {
   temporaryPublicReferenceUploadExpiry: "12h",
 };
 
+export const DEFAULT_COMFYUI_VIDEO_DEFAULTS: ComfyUiVideoDefaults = {
+  durationSeconds: 5,
+  aspectRatio: "16:9",
+  resolution: "720p",
+};
+
 export function createDefaultVideoGenerationProfile(
   service: VideoDefaultsService = "gemini_omni",
 ): VideoGenerationDefaultsProfile {
@@ -64,6 +72,7 @@ export function createDefaultVideoGenerationProfile(
     xai: { ...DEFAULT_XAI_VIDEO_DEFAULTS },
     openrouter: { ...DEFAULT_OPENROUTER_VIDEO_DEFAULTS },
     seedance: { ...DEFAULT_SEEDANCE_VIDEO_DEFAULTS },
+    comfyui: { ...DEFAULT_COMFYUI_VIDEO_DEFAULTS },
   };
 }
 
@@ -125,6 +134,12 @@ export function normalizeVideoGenerationProfile(rawProfile: unknown): {
       DEFAULT_SEEDANCE_VIDEO_DEFAULTS.temporaryPublicReferenceUploadExpiry,
     ),
   };
+  const rawComfyUi = isRecord(raw.comfyui) ? raw.comfyui : rawService === "comfyui" ? raw : {};
+  profile.comfyui = {
+    durationSeconds: readInteger(rawComfyUi.durationSeconds, DEFAULT_COMFYUI_VIDEO_DEFAULTS.durationSeconds, 1, 60),
+    aspectRatio: readAspectRatio(rawComfyUi.aspectRatio, DEFAULT_COMFYUI_VIDEO_DEFAULTS.aspectRatio),
+    resolution: readResolution(rawComfyUi.resolution, DEFAULT_COMFYUI_VIDEO_DEFAULTS.resolution),
+  };
   const changed = JSON.stringify(profile) !== JSON.stringify(rawProfile);
   return { profile, changed };
 }
@@ -166,6 +181,7 @@ function readService(value: unknown): VideoDefaultsService {
     value === "openrouter" ||
     value === "seedance" ||
     value === "google_veo" ||
+    value === "comfyui" ||
     value === "gemini_omni"
     ? value
     : "gemini_omni";

--- a/packages/shared/src/types/connection.ts
+++ b/packages/shared/src/types/connection.ts
@@ -59,7 +59,7 @@ export interface APIConnection {
   openrouterProvider: string | null;
   /** Explicit image backend selection for image-generation connections (e.g. ComfyUI on a remote host). */
   imageGenerationSource: string | null;
-  /** ComfyUI workflow JSON for image generation */
+  /** ComfyUI workflow JSON for image or video generation */
   comfyuiWorkflow: string | null;
   /** Explicitly selected image generation service ID (e.g. "comfyui", "automatic1111"). Overrides URL inference when set. */
   imageService: string | null;

--- a/packages/shared/src/types/video-generation-defaults.ts
+++ b/packages/shared/src/types/video-generation-defaults.ts
@@ -1,4 +1,4 @@
-export type VideoDefaultsService = "gemini_omni" | "google_veo" | "xai" | "openrouter" | "seedance";
+export type VideoDefaultsService = "gemini_omni" | "google_veo" | "xai" | "openrouter" | "seedance" | "comfyui";
 
 export type VideoAspectRatio = "16:9" | "9:16";
 export type VideoResolution = "480p" | "720p" | "1080p";
@@ -31,6 +31,13 @@ export interface OpenRouterVideoDefaults {
   resolution: VideoResolution;
 }
 
+export interface ComfyUiVideoDefaults {
+  /** ComfyUI workflows receive this duration as a 16 fps frame count through %length%. */
+  durationSeconds: number;
+  aspectRatio: VideoAspectRatio;
+  resolution: VideoResolution;
+}
+
 export interface SeedanceVideoDefaults {
   /** Seedance 2.0 accepts 4-15 seconds for video generations. */
   durationSeconds: number;
@@ -49,4 +56,5 @@ export interface VideoGenerationDefaultsProfile {
   xai: XaiVideoDefaults;
   openrouter: OpenRouterVideoDefaults;
   seedance: SeedanceVideoDefaults;
+  comfyui: ComfyUiVideoDefaults;
 }


### PR DESCRIPTION
## Linked issue

Closes #3804

## Why this change

- Video generation currently requires a cloud service even though Marinara already supports local ComfyUI image workflows.
- A ComfyUI video connection lets Game mode scene videos run locally and reuse users' API-format workflows.

## What changed

- Added ComfyUI as a local video source using the existing connection and workflow fields.
- Added API-workflow placeholder substitution, optional reference-image upload, queue/history polling, MP4 download validation, and existing video deadlines.
- Threaded ComfyUI workflows through Game, Gallery, Storyboard, Sprite, fallback, and connection-test paths.
- Added ComfyUI video defaults and connection-editor controls while leaving model selection workflow-defined.
- Updated the README, configuration, FAQ, troubleshooting, and media documentation.

## Automated validation completed

- `pnpm check`
- `git diff --check`
- Mock ComfyUI protocol integration covering reference upload, placeholder substitution, queueing, polling, MP4 retrieval, and missing-workflow rejection
- CodeRabbit review completed; all three findings were applied, and the incremental re-review reported no actionable comments

## Validation

- [ ] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed `CONTRIBUTING.md`

### Manual verification notes

- Configure a local ComfyUI video connection with an API-format workflow.
- Generate text-to-video and image-to-video outputs, then verify polling, download, timeout, and error behavior.
- Verify the source appears in connection selection and persists through export/import.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Version/release files updated (only if this PR includes a version bump)

## UI evidence (if applicable)

- Add connection/settings evidence after manual browser verification.
