### PR TITLE
Add logical group macros and fix tracker retry persistence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,12 +6,17 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 
 ### Added
 
+- Added `||` (OR), `&&` (AND), parentheses, and equality-list shorthand to conditional prompt macros, with matching in-app and documentation examples.
+- Added the `{{group}}` prompt macro for listing every other active chat character, including during targeted Roleplay group generation.
 - Added a chibi Professor Mari artwork icon to Marinara's Universal Preset for existing and new users.
 - Added local ComfyUI video generation for API-format WAN and other workflows, including prompt, size, seed, frame-count, and uploaded first-frame placeholders (#3804).
 - Added an in-app and GitHub ComfyUI workflow guide covering API-format exports, Marinara placeholders, local and RunPod reference-image inputs, character-specific workflows, LAN setup, VRAM constraints, and troubleshooting (#3749).
 
 ### Fixed
 
+- Kept the full active Roleplay roster available while assembling a targeted character prompt so `{{group}}` lists the other character cards instead of resolving empty in manual group generation.
+- Applied the selected chroma text color to installed theme and extension names in Settings > Addons instead of inheriting the hard-coded pink accent.
+- Persisted successful Roleplay tracker re-runs against the visible tracker state when a refreshed scene has no assistant reply yet, instead of spending the agent call and then reporting that no tracker changes were returned.
 - Vertically centered the Character editor's Regex Script edit and delete actions against each script's enable toggle.
 - Restored Character and Persona tracker-card color settings so appearance changes update the card preview immediately and persist when saved.
 - Stopped HTML-escaping angle brackets in prompt leaf content so character card fields, persona, lorebook entries, memories, and scene text now reach the model verbatim — `<thinking>`, `<scenario>`, and inline HTML like `<div>` are passed through as written instead of arriving as `&lt;thinking&gt;`, which had been corrupting cards, breaking roleplay HTML, and showing raw `&lt;` in the editor. This finalizes prompt leaf content as verbatim and **supersedes** the `<`/`&` prompt-boundary escaping added in #3108 (line above) and the untrusted-card-text escaping in the "Hardened prompt assembly" entry below, for Marinara's local single-user threat model. The framework's own structural section wrappers are emitted around this content and are unaffected, and the agent value/attribute escapers are unchanged (they still escape values into machine-parsed XML).

--- a/docs/prompts/conditional-prompts.md
+++ b/docs/prompts/conditional-prompts.md
@@ -65,6 +65,38 @@ A few rules control how the comparison works:
 2. For `>`, `<`, `>=`, and `<=`, both sides must be numbers. If either side is not a number, the condition is false.
 3. For `contains`, `includes`, `not contains`, and `not includes`, the match is case-insensitive. So `contains "dr"` matches the text `Dr Smith`.
 
+## Combining conditions with OR and AND
+
+Use `||` when either condition may match. Use `&&` when every condition must match.
+
+```
+{{#if character == "Maukie" || character == "Pantalone"}}
+Use the shared Maukie and Pantalone instructions.
+{{/if}}
+
+{{#if characters contains "Maukie" && characters contains "Pantalone"}}
+Both characters are present in this chat.
+{{/if}}
+```
+
+`&&` is evaluated before `||`. Add parentheses when you want to control the order explicitly:
+
+```
+{{#if (character == "Maukie" || character == "Pantalone") && scenario contains "lake"}}
+Use the lakeside instructions for either character.
+{{/if}}
+```
+
+For several equality choices on the same value, you may omit the repeated left side after `||`:
+
+```
+{{#if character == "Maukie" || "Pantalone"}}
+Use the shared instructions.
+{{/if}}
+```
+
+This shorthand means `character == "Maukie" || character == "Pantalone"`. It applies to the equality operators `==`, `=`, and `is`. Write complete conditions on both sides of `&&`, since one value usually cannot equal two different choices at once.
+
 ### Truthy checks (no operator)
 
 If you write a condition with no operator, Marinara does a truthy check. This asks a simple question: does this value have real content in it?
@@ -83,7 +115,7 @@ A truthy check is true when the value is not empty and is not one of these words
 
 The left or right side of a condition can be any of these:
 
-1. A field or identity keyword, such as `char`, `user`, `persona`, `description`, `personality`, `scenario`, `input`, or `model`. These read the same values as the matching macros.
+1. A field or identity keyword, such as `char`, `user`, `group`, `persona`, `description`, `personality`, `scenario`, `input`, or `model`. These read the same values as the matching macros. `group` lists the other active chat characters after excluding the current responder.
 2. A quoted literal, such as `"Alice"`.
 3. A preset variable name, such as `length`. A preset variable is a named value you define in a Prompt Preset. See [Preset Variables](preset-variables.md).
 4. An explicit variable lookup written as `var:name` or `var.name`.

--- a/docs/prompts/macros.md
+++ b/docs/prompts/macros.md
@@ -40,6 +40,7 @@ These macros pull in the names and card fields of the person speaking and the ch
 | `{{char}}` / `{{charName}}` | The current character's name. Defaults to `Character`. |
 | `{{charNamePhonetic}}` | The character's Phonetic name, or `{{char}}` when it is empty. |
 | `{{characters}}` | Every character in the chat, joined by commas. |
+| `{{group}}` | Every other active character in the group chat, excluding the current responder. The persona is not part of this character roster. |
 | `{{persona}}` | Your persona's Description, Personality, Backstory, Appearance, and Scenario, joined by new lines. |
 | `{{personaDescription}}` | Your persona's Description field. |
 | `{{personaPersonality}}` | Your persona's Personality field. |
@@ -61,6 +62,8 @@ The character field macros read the current character's card:
 | `{{charPostHistory}}` | Post-History Instructions |
 
 In a chat with one character, these resolve against that character. In a group chat, they resolve against the first character by default. To repeat text for each character, put it inside a bracketed group block. See [Conditional Prompts](conditional-prompts.md) for group blocks.
+
+`{{group}}` follows the character currently responding, including during individual group generations. For example, if Pantalone is responding in a Roleplay group containing Powers That Be, Maukie, and Pantalone, `{{group}}` resolves to `Powers That Be, Maukie`. A character card remains in this roster even if its name happens to match `{{user}}`.
 
 The Phonetic name field has two jobs. It sets how the name is pronounced by text-to-speech. It also feeds `{{charNamePhonetic}}` and `{{userNamePhonetic}}`. You will find it in both the **Character Editor** and the **Persona Editor**.
 
@@ -211,6 +214,8 @@ Every macro-enabled field has two small buttons in its corner:
 - **Macro reference** opens a window titled **Macro reference** that lists every built-in macro by category, each with its exact syntax. This list is generated from the same source the engine uses, so it is always accurate.
 
 You can also type `/macros` in the chat box (the short form `/macro` works too). It prints the full macro list right in the chat as a quick reminder.
+
+Conditional blocks can combine comparisons with `||` (OR), `&&` (AND), and parentheses. Equality lists may use the compact form `{{#if character == "Maukie" || "Pantalone"}}`. See [Conditional Prompts](conditional-prompts.md) for precedence, group-chat examples, and the full operator list.
 
 ## Common mistakes
 

--- a/packages/client/src/components/panels/SettingsPanel.tsx
+++ b/packages/client/src/components/panels/SettingsPanel.tsx
@@ -5177,7 +5177,7 @@ function ThemesSettings({ showIntro = true }: { showIntro?: boolean } = {}) {
                   className="flex flex-1 items-center gap-2 min-w-0"
                 >
                   <FileCode2 size="0.75rem" className="shrink-0" />
-                  <span className="truncate">{t.name}</span>
+                  <span className="mari-chrome-text truncate">{t.name}</span>
                   {activeCustomTheme?.id === t.id && <Check size="0.75rem" className="shrink-0" />}
                 </button>
                 <button
@@ -5815,7 +5815,7 @@ function ExtensionsSettings({ showIntro = true }: { showIntro?: boolean } = {}) 
                 </button>
                 <div className="flex min-w-0 flex-1 flex-col gap-0.5">
                   <div className="flex min-w-0 items-center gap-1.5">
-                    <span className="truncate font-medium">{ext.name}</span>
+                    <span className="mari-chrome-text truncate font-medium">{ext.name}</span>
                     <span
                       className={cn(
                         "shrink-0 rounded px-1 py-px text-[0.5625rem] font-semibold",

--- a/packages/client/src/components/ui/MacroTextarea.tsx
+++ b/packages/client/src/components/ui/MacroTextarea.tsx
@@ -211,7 +211,7 @@ function MacrosReferenceModal({ open, onClose }: MacrosReferenceModalProps) {
           <div className="max-h-[calc(88vh-4rem)] space-y-4 overflow-y-auto p-4 supports-[height:100dvh]:max-h-[calc(88dvh-4rem)]">
             <section className="rounded-xl border border-[var(--border)] bg-[var(--secondary)] p-3 text-xs text-[var(--muted-foreground)]">
               <p>
-                Use <code className="text-[var(--foreground)]">{"{{macro}}"}</code> anywhere in prompt fields. Conditional blocks let you include content only when a value exists.
+                Use <code className="text-[var(--foreground)]">{"{{macro}}"}</code> anywhere in prompt fields. Conditional blocks can combine checks with <code className="text-[var(--foreground)]">||</code> (OR) and <code className="text-[var(--foreground)]">&&</code> (AND).
               </p>
               <div className="mt-3 grid gap-2 md:grid-cols-2">
                 <div className="rounded-lg border border-[var(--border)] bg-[var(--background)] p-2">
@@ -219,8 +219,8 @@ function MacrosReferenceModal({ open, onClose }: MacrosReferenceModalProps) {
                   <code className="mt-1 block whitespace-pre-wrap text-[var(--primary)]">{"{{#if character == \"Dottore\"}}\nWrite this for Dottore.\n{{else}}\nWrite this for anyone else.\n{{/if}}"}</code>
                 </div>
                 <div className="rounded-lg border border-[var(--border)] bg-[var(--background)] p-2">
-                  <p className="font-semibold text-[var(--foreground)]">Supported comparisons</p>
-                  <code className="mt-1 block whitespace-pre-wrap text-[var(--primary)]">{"{{#if character != \"Dottore\"}}\n...\n{{/if}}\n{{#if user contains \"Mari\"}}\n...\n{{/if}}"}</code>
+                  <p className="font-semibold text-[var(--foreground)]">Comparisons and logic</p>
+                  <code className="mt-1 block whitespace-pre-wrap text-[var(--primary)]">{"{{#if character == \"Maukie\" || \"Pantalone\"}}\n...\n{{/if}}\n{{#if scenario && user contains \"Mari\"}}\n...\n{{/if}}"}</code>
                 </div>
               </div>
             </section>

--- a/packages/client/src/lib/slash-commands.ts
+++ b/packages/client/src/lib/slash-commands.ts
@@ -256,7 +256,7 @@ function buildMacroHelpText(): string {
     "Supported Macros:",
     "Tip: In group chats, a bracketed block containing character macros like {{char}} and {{description}} repeats once per character.",
     'Conditional blocks: {{#if character == "Dottore"}}Dottore prompt{{else}}Fallback prompt{{/if}}',
-    "Conditionals support char, character, speaker, user, preset variables, comparisons, || (OR), && (AND), parentheses, and straight or typographic quotes.",
+    "Conditionals support char, character, speaker, group, user, preset variables, comparisons, || (OR), && (AND), parentheses, equality-list shorthand, and straight or typographic quotes.",
     ...Array.from(sections.entries()).flatMap(([category, lines], index) =>
       index === 0 ? ["", `${category}:`, ...lines] : ["", `${category}:`, ...lines],
     ),

--- a/packages/client/src/lib/slash-commands.ts
+++ b/packages/client/src/lib/slash-commands.ts
@@ -256,7 +256,7 @@ function buildMacroHelpText(): string {
     "Supported Macros:",
     "Tip: In group chats, a bracketed block containing character macros like {{char}} and {{description}} repeats once per character.",
     'Conditional blocks: {{#if character == "Dottore"}}Dottore prompt{{else}}Fallback prompt{{/if}}',
-    "Conditionals support char, character, speaker, user, preset variables, ==, !=, contains, and straight or typographic quotes.",
+    "Conditionals support char, character, speaker, user, preset variables, comparisons, || (OR), && (AND), parentheses, and straight or typographic quotes.",
     ...Array.from(sections.entries()).flatMap(([category, lines], index) =>
       index === 0 ? ["", `${category}:`, ...lines] : ["", `${category}:`, ...lines],
     ),

--- a/packages/server/src/routes/generate.routes.ts
+++ b/packages/server/src/routes/generate.routes.ts
@@ -1573,6 +1573,7 @@ export async function generateRoutes(app: FastifyInstance) {
         const promptMacroContext = await buildPromptMacroContext({
           db: app.db,
           characterIds: promptCharacterIds,
+          groupCharacterIds: promptTargetCharacterId ? characterIds : undefined,
           personaName,
           personaPhoneticName,
           personaDescription,
@@ -1821,6 +1822,7 @@ export async function generateRoutes(app: FastifyInstance) {
             chatChoices,
             chatId: input.chatId,
             characterIds: promptCharacterIds,
+            groupCharacterIds: characterIds,
             personaId,
             personaName,
             personaPhoneticName,

--- a/packages/server/src/routes/generate/dry-run-route.ts
+++ b/packages/server/src/routes/generate/dry-run-route.ts
@@ -801,6 +801,7 @@ export async function registerDryRunRoute(app: FastifyInstance) {
     const promptMacroContext = await buildPromptMacroContext({
       db: app.db,
       characterIds: promptCharacterIds,
+      groupCharacterIds: promptTargetCharacterId ? characterIds : undefined,
       personaName,
       personaDescription,
       personaFields,
@@ -1217,6 +1218,7 @@ export async function registerDryRunRoute(app: FastifyInstance) {
         chatChoices,
         chatId,
         characterIds: promptCharacterIds,
+        groupCharacterIds: characterIds,
         personaId,
         personaName,
         personaDescription,

--- a/packages/server/src/routes/generate/retry-agents-route.ts
+++ b/packages/server/src/routes/generate/retry-agents-route.ts
@@ -2546,6 +2546,10 @@ async function applyRetryResultEffects(args: {
       .then((snapshot) => projectGameSnapshotLocation(snapshot, retryOwnerSpatialProjection));
     return retryBaseGameStateSnapshotPromise;
   };
+  const buildSnapshotUpdateOptions = async () => ({
+    baseSnapshot: await loadRetryBaseGameStateSnapshot(),
+    ...(retryCompatibilityLocation !== null ? { compatibilityLocation: retryCompatibilityLocation } : {}),
+  });
   const loadRetryTargetGameStateSnapshot = async () => {
     if (!retryMessageId) {
       const latest = await gameStateStore.getLatest(chatId);
@@ -2572,10 +2576,14 @@ async function applyRetryResultEffects(args: {
     }
     const existing = await gameStateStore.getByMessage(retryMessageId, retrySwipeIndex);
     if (existing) return projectGameSnapshotLocation(existing, retryOwnerSpatialProjection);
-    return gameStateStore.updateByMessage(retryMessageId, retrySwipeIndex, chatId, {}, undefined, {
-      baseSnapshot: await loadRetryBaseGameStateSnapshot(),
-      ...(retryCompatibilityLocation !== null ? { compatibilityLocation: retryCompatibilityLocation } : {}),
-    });
+    return gameStateStore.updateByMessage(
+      retryMessageId,
+      retrySwipeIndex,
+      chatId,
+      {},
+      undefined,
+      await buildSnapshotUpdateOptions(),
+    );
   };
   const updateRetryTargetGameStateSnapshot = async (fields: Record<string, unknown>) => {
     if (retryMessageId) {
@@ -2585,10 +2593,7 @@ async function applyRetryResultEffects(args: {
         chatId,
         fields as any,
         undefined,
-        {
-          baseSnapshot: await loadRetryBaseGameStateSnapshot(),
-          ...(retryCompatibilityLocation !== null ? { compatibilityLocation: retryCompatibilityLocation } : {}),
-        },
+        await buildSnapshotUpdateOptions(),
       );
     }
     await loadRetryTargetGameStateSnapshot();

--- a/packages/server/src/routes/generate/retry-agents-route.ts
+++ b/packages/server/src/routes/generate/retry-agents-route.ts
@@ -2547,13 +2547,52 @@ async function applyRetryResultEffects(args: {
     return retryBaseGameStateSnapshotPromise;
   };
   const loadRetryTargetGameStateSnapshot = async () => {
-    if (!retryMessageId) return null;
+    if (!retryMessageId) {
+      const latest = await gameStateStore.getLatest(chatId);
+      if (latest) return projectGameSnapshotLocation(latest, retryOwnerSpatialProjection);
+
+      await gameStateStore.create({
+        chatId,
+        messageId: "",
+        swipeIndex: 0,
+        date: null,
+        time: null,
+        location: retryCompatibilityLocation,
+        weather: null,
+        temperature: null,
+        worldCustomFields: [],
+        presentCharacters: [],
+        recentEvents: [],
+        playerStats: null,
+        personaStats: null,
+        fieldLocks: null,
+        hiddenTrackerFields: null,
+      });
+      return projectGameSnapshotLocation(await gameStateStore.getLatest(chatId), retryOwnerSpatialProjection);
+    }
     const existing = await gameStateStore.getByMessage(retryMessageId, retrySwipeIndex);
     if (existing) return projectGameSnapshotLocation(existing, retryOwnerSpatialProjection);
     return gameStateStore.updateByMessage(retryMessageId, retrySwipeIndex, chatId, {}, undefined, {
       baseSnapshot: await loadRetryBaseGameStateSnapshot(),
       ...(retryCompatibilityLocation !== null ? { compatibilityLocation: retryCompatibilityLocation } : {}),
     });
+  };
+  const updateRetryTargetGameStateSnapshot = async (fields: Record<string, unknown>) => {
+    if (retryMessageId) {
+      return gameStateStore.updateByMessage(
+        retryMessageId,
+        retrySwipeIndex,
+        chatId,
+        fields as any,
+        undefined,
+        {
+          baseSnapshot: await loadRetryBaseGameStateSnapshot(),
+          ...(retryCompatibilityLocation !== null ? { compatibilityLocation: retryCompatibilityLocation } : {}),
+        },
+      );
+    }
+    await loadRetryTargetGameStateSnapshot();
+    return gameStateStore.updateLatest(chatId, fields as any);
   };
 
   for (const result of sortedResults) {
@@ -2620,7 +2659,6 @@ async function applyRetryResultEffects(args: {
     }
 
     if (
-      retryMessageId &&
       result.success &&
       result.type === "game_state_update" &&
       result.agentType !== "combat" &&
@@ -2651,17 +2689,7 @@ async function applyRetryResultEffects(args: {
           lockedWorldStatePatch.location = retryCompatibilityLocation;
         }
         if (Object.keys(worldStatePatch).length > 0 || retryCompatibilityLocation !== null) {
-          await gameStateStore.updateByMessage(
-            retryMessageId,
-            retrySwipeIndex,
-            chatId,
-            lockedWorldStatePatch as any,
-            undefined,
-            {
-              baseSnapshot: await loadRetryBaseGameStateSnapshot(),
-              ...(retryCompatibilityLocation !== null ? { compatibilityLocation: retryCompatibilityLocation } : {}),
-            },
-          );
+          await updateRetryTargetGameStateSnapshot(lockedWorldStatePatch);
         }
 
         const nextLocation = typeof lockedWorldStatePatch.location === "string" ? lockedWorldStatePatch.location : null;
@@ -2720,7 +2748,6 @@ async function applyRetryResultEffects(args: {
     }
 
     if (
-      retryMessageId &&
       result.success &&
       result.type === "character_tracker_update" &&
       result.data &&
@@ -2760,16 +2787,7 @@ async function applyRetryResultEffects(args: {
         presentCharacters = Array.isArray(lockedCharacterPatch.presentCharacters)
           ? lockedCharacterPatch.presentCharacters
           : presentCharacters;
-        await gameStateStore.updateByMessage(
-          retryMessageId,
-          retrySwipeIndex,
-          chatId,
-          {
-            presentCharacters,
-          },
-          undefined,
-          { baseSnapshot: await loadRetryBaseGameStateSnapshot() },
-        );
+        await updateRetryTargetGameStateSnapshot({ presentCharacters });
         sendSseEvent(reply, { type: "game_state_patch", data: { presentCharacters } });
       } catch (err) {
         logger.error(err, "[retry-agents] Failed to apply character-tracker update");
@@ -2777,7 +2795,6 @@ async function applyRetryResultEffects(args: {
     }
 
     if (
-      retryMessageId &&
       result.success &&
       result.type === "persona_stats_update" &&
       result.data &&
@@ -2878,7 +2895,6 @@ async function applyRetryResultEffects(args: {
     }
 
     if (
-      retryMessageId &&
       result.success &&
       result.type === "quest_update" &&
       result.data &&
@@ -2948,7 +2964,6 @@ async function applyRetryResultEffects(args: {
     }
 
     if (
-      retryMessageId &&
       result.success &&
       result.type === "custom_tracker_update" &&
       result.data &&

--- a/packages/server/src/services/prompt/assembler.ts
+++ b/packages/server/src/services/prompt/assembler.ts
@@ -133,6 +133,8 @@ export interface AssemblerInput {
   /** Chat context */
   chatId: string;
   characterIds: string[];
+  /** Full active roster when characterIds is narrowed to one generation target. */
+  groupCharacterIds?: string[];
   personaId?: string | null;
   personaName: string;
   personaPhoneticName?: string;
@@ -306,6 +308,7 @@ export async function assemblePrompt(input: AssemblerInput): Promise<AssemblerOu
   const macroCtx = await buildPromptMacroContext({
     db: input.db,
     characterIds: input.characterIds,
+    groupCharacterIds: input.groupCharacterIds,
     personaName: input.personaName,
     personaPhoneticName: input.personaPhoneticName,
     personaDescription: input.personaDescription,

--- a/packages/server/src/services/prompt/macro-context.ts
+++ b/packages/server/src/services/prompt/macro-context.ts
@@ -24,6 +24,8 @@ type PersonaFields = NonNullable<MacroContext["personaFields"]>;
 export interface BuildPromptMacroContextInput {
   db: DB;
   characterIds: string[];
+  /** Full active roster when characterIds is narrowed to one generation target. */
+  groupCharacterIds?: string[];
   personaName: string;
   personaPhoneticName?: string;
   personaDescription?: string;
@@ -249,6 +251,9 @@ export async function resolveCharacterMacroData(db: DB, characterIds: string[]):
 
 export async function buildPromptMacroContext(input: BuildPromptMacroContextInput): Promise<MacroContext> {
   const characterMacroData = await resolveCharacterMacroData(input.db, input.characterIds);
+  const groupCharacterMacroData = input.groupCharacterIds
+    ? await resolveCharacterMacroData(input.db, input.groupCharacterIds)
+    : characterMacroData;
   const variables = input.variables ?? {};
 
   return {
@@ -257,6 +262,7 @@ export async function buildPromptMacroContext(input: BuildPromptMacroContextInpu
     char: characterMacroData.names[0] || "Character",
     charPhonetic: characterMacroData.phoneticNames[0] || characterMacroData.names[0] || "Character",
     characters: characterMacroData.names,
+    groupCharacters: groupCharacterMacroData.names,
     characterProfiles: characterMacroData.profiles,
     variables,
     lastInput: input.lastInput,

--- a/packages/shared/src/utils/macro-engine.ts
+++ b/packages/shared/src/utils/macro-engine.ts
@@ -7,8 +7,10 @@ export interface MacroContext {
   userPhonetic?: string;
   char: string;
   charPhonetic?: string;
-  /** All characters in the chat */
+  /** Character names in the current prompt scope (used by {{characters}}) */
   characters: string[];
+  /** Full active chat character roster (used by {{group}} when the prompt is scoped to one responder) */
+  groupCharacters?: string[];
   /** Full per-character card fields for grouped macro expansion */
   characterProfiles?: Array<{
     name: string;
@@ -74,7 +76,7 @@ export interface ResolveMacroOptions {
   trimResult?: boolean;
   /**
    * Preserve character macros as internal tokens for a later known-speaker pass.
-   * "names" delays only {{char}}/{{charName}}; "all" also delays character field macros.
+   * "names" delays {{char}}/{{charName}} and {{group}}; "all" also delays character field macros.
    */
   deferCharacterMacros?: "names" | "all";
   /**
@@ -138,6 +140,7 @@ const MACRO_COMMENT_PATTERN = /\{\{\/\/[^}]*\}\}/g;
 const DEFERRED_CHARACTER_MACRO_TOKENS = {
   char: `${DEFERRED_CHARACTER_MACRO_TOKEN_PREFIX}CHAR\x1f`,
   charPhonetic: `${DEFERRED_CHARACTER_MACRO_TOKEN_PREFIX}CHAR_PHONETIC\x1f`,
+  group: `${DEFERRED_CHARACTER_MACRO_TOKEN_PREFIX}GROUP\x1f`,
   description: `${DEFERRED_CHARACTER_MACRO_TOKEN_PREFIX}DESCRIPTION\x1f`,
   personality: `${DEFERRED_CHARACTER_MACRO_TOKEN_PREFIX}PERSONALITY\x1f`,
   backstory: `${DEFERRED_CHARACTER_MACRO_TOKEN_PREFIX}BACKSTORY\x1f`,
@@ -149,7 +152,7 @@ const DEFERRED_CHARACTER_MACRO_TOKENS = {
 } as const;
 
 export type CharacterMacroProfile = NonNullable<MacroContext["characterProfiles"]>[number];
-type CharacterFieldMacroName = Exclude<keyof typeof DEFERRED_CHARACTER_MACRO_TOKENS, "char" | "charPhonetic">;
+type CharacterFieldMacroName = Exclude<keyof typeof DEFERRED_CHARACTER_MACRO_TOKENS, "char" | "charPhonetic" | "group">;
 type ConditionalBlockPayload = {
   condition: string;
   truthy: string;
@@ -273,9 +276,10 @@ export function collectDeferredRelocationConditionOperands(text: string): string
       : [{ condition: (payload as ConditionalBlockPayload).condition, content: "" }];
     for (const branch of branches) {
       if (branch.condition === null) continue;
-      const parsed = parseConditionExpression(branch.condition);
-      operands.push(parsed.left);
-      if (parsed.right !== undefined) operands.push(parsed.right);
+      for (const parsed of parseConditionComparisons(branch.condition)) {
+        operands.push(parsed.left);
+        if (parsed.right !== undefined) operands.push(parsed.right);
+      }
     }
   }
   return operands;
@@ -307,6 +311,11 @@ export const SUPPORTED_MACROS: readonly SupportedMacroDefinition[] = [
     description: "Current character phonetic name, or {{char}} when none is configured",
   },
   { category: "Identity", syntax: "{{characters}}", description: "All character names, comma-separated" },
+  {
+    category: "Identity",
+    syntax: "{{group}}",
+    description: "Other active chat characters, excluding the current responder",
+  },
   { category: "Character", syntax: "{{description}}", description: "Current character description" },
   { category: "Character", syntax: "{{personality}}", description: "Current character personality" },
   { category: "Character", syntax: "{{backstory}}", description: "Current character backstory" },
@@ -414,8 +423,8 @@ export const SUPPORTED_MACROS: readonly SupportedMacroDefinition[] = [
   },
   {
     category: "Formatting",
-    syntax: '{{#if char == "Name"}}...{{else}}...{{/if}}',
-    description: "Conditional block; supports straight or typographic quotes",
+    syntax: '{{#if char == "Name" || "Other"}}...{{else}}...{{/if}}',
+    description: "Conditional block with ||, &&, parentheses, else branches, and straight or typographic quotes",
   },
   { category: "Formatting", syntax: "{{noop}}", description: "No-op placeholder removed from output" },
   { category: "Formatting", syntax: "{{// comment}}", description: "Inline author comment removed from output" },
@@ -425,6 +434,18 @@ export const SUPPORTED_MACROS: readonly SupportedMacroDefinition[] = [
     description: "Accepted with straight or typographic quotes, but currently stripped from output",
   },
 ];
+
+function normalizeMacroIdentity(value: string): string {
+  return value.trim().replace(/\s+/g, " ").toLowerCase();
+}
+
+function resolveGroupCharacters(ctx: Pick<MacroContext, "characters" | "groupCharacters" | "char">): string {
+  const responderName = normalizeMacroIdentity(ctx.char);
+  return (ctx.groupCharacters ?? ctx.characters)
+    .map((name) => name.trim())
+    .filter((name) => name.length > 0 && normalizeMacroIdentity(name) !== responderName)
+    .join(", ");
+}
 
 function getCharacterFieldValue(profile: CharacterMacroProfile, field: CharacterFieldMacroName): string {
   return stripMacroComments(profile[field] ?? "");
@@ -449,6 +470,7 @@ function macroContextForCharacterProfile(profile: CharacterMacroProfile, base?: 
     char: profile.name,
     charPhonetic: profile.phoneticName ?? profile.name,
     characters: base?.characters ?? [profile.name],
+    groupCharacters: base?.groupCharacters,
     characterProfiles: base?.characterProfiles ?? [profile],
     variables: base?.variables ?? {},
     lastInput: base?.lastInput,
@@ -479,14 +501,12 @@ export function resolveCharacterScopedMacros(
   depth = 0,
   baseContext?: MacroContext,
 ): string {
-  const scoped = resolveConditionalBlocks(
-    stripMacroComments(template),
-    macroContextForCharacterProfile(profile, baseContext),
-    {},
-  );
+  const scopedContext = macroContextForCharacterProfile(profile, baseContext);
+  const scoped = resolveConditionalBlocks(stripMacroComments(template), scopedContext, {});
   return scoped
     .replace(/\{\{char(?:Name)?\}\}/gi, profile.name)
     .replace(/\{\{char(?:Name)?Phonetic\}\}/gi, profile.phoneticName ?? profile.name)
+    .replace(/\{\{group\}\}/gi, resolveGroupCharacters(scopedContext))
     .replace(/\{\{description\}\}/gi, () => resolveCharacterFieldValue(profile, "description", depth, baseContext))
     .replace(/\{\{personality\}\}/gi, () => resolveCharacterFieldValue(profile, "personality", depth, baseContext))
     .replace(/\{\{backstory\}\}/gi, () => resolveCharacterFieldValue(profile, "backstory", depth, baseContext))
@@ -509,6 +529,7 @@ export function resolveDeferredCharacterMacros(
   let result = resolveDeferredCharacterConditionals(template, scopedContext);
   result = result.split(DEFERRED_CHARACTER_MACRO_TOKENS.char).join(profile.name);
   result = result.split(DEFERRED_CHARACTER_MACRO_TOKENS.charPhonetic).join(profile.phoneticName ?? profile.name);
+  result = result.split(DEFERRED_CHARACTER_MACRO_TOKENS.group).join(resolveGroupCharacters(scopedContext));
   result = result
     .split(DEFERRED_CHARACTER_MACRO_TOKENS.description)
     .join(resolveCharacterFieldValue(profile, "description", 0, baseContext));
@@ -756,6 +777,8 @@ function resolveConditionalOperand(raw: string, ctx: MacroContext, options: Reso
       return ctx.personaFields?.scenario ?? "";
     case "characters":
       return ctx.characters.join(", ");
+    case "group":
+      return resolveGroupCharacters(ctx);
     case "input":
       return ctx.lastInput ?? "";
     case "model":
@@ -808,27 +831,197 @@ function resolveConditionalOperand(raw: string, ctx: MacroContext, options: Reso
 
 function isCharacterConditionalOperand(raw: string): boolean {
   const normalized = normalizeConditionKey(raw);
-  return /^(char|charname|charphonetic|charnamephonetic|character|characterphonetic|speaker|speakerphonetic|description|personality|backstory|appearance|scenario|example|charsysinfo|charposthistory)$/.test(
+  return /^(char|charname|charphonetic|charnamephonetic|character|characterphonetic|speaker|speakerphonetic|group|description|personality|backstory|appearance|scenario|example|charsysinfo|charposthistory)$/.test(
     normalized,
   );
 }
 
-function parseConditionExpression(condition: string): { left: string; operator: string; right?: string } {
-  const match = condition.match(
-    /^(.+?)\s*(>=|<=|>|<|==|!=|=|is\s+not|is|not\s+contains|not\s+includes|contains|includes)\s*(.+)$/i,
-  );
-  if (!match) return { left: condition.trim(), operator: "truthy" };
-  return {
-    left: match[1]?.trim() ?? "",
-    operator: (match[2] ?? "").toLowerCase().replace(/\s+/g, " "),
-    right: match[3]?.trim() ?? "",
-  };
+type ParsedConditionExpression = { left: string; operator: string; right?: string };
+
+function splitTopLevelCondition(input: string, delimiter: "||" | "&&"): string[] {
+  const parts: string[] = [];
+  let partStart = 0;
+  let quote: "single" | "double" | null = null;
+  let escaped = false;
+  let macroDepth = 0;
+  let parenthesisDepth = 0;
+
+  for (let index = 0; index < input.length; index += 1) {
+    const character = input[index]!;
+
+    if (quote) {
+      if (escaped) {
+        escaped = false;
+      } else if (character === "\\") {
+        escaped = true;
+      } else if (quoteKind(character) === quote) {
+        quote = null;
+      }
+      continue;
+    }
+
+    if (macroDepth > 0) {
+      if (character === "{" && input[index + 1] === "{") {
+        macroDepth += 1;
+        index += 1;
+      } else if (character === "}" && input[index + 1] === "}") {
+        macroDepth -= 1;
+        index += 1;
+      }
+      continue;
+    }
+
+    const nextQuote = quoteKind(character);
+    if (nextQuote) {
+      quote = nextQuote;
+      continue;
+    }
+    if (character === "{" && input[index + 1] === "{") {
+      macroDepth = 1;
+      index += 1;
+      continue;
+    }
+    if (character === "(") {
+      parenthesisDepth += 1;
+      continue;
+    }
+    if (character === ")" && parenthesisDepth > 0) {
+      parenthesisDepth -= 1;
+      continue;
+    }
+    if (parenthesisDepth === 0 && input.startsWith(delimiter, index)) {
+      parts.push(input.slice(partStart, index).trim());
+      partStart = index + delimiter.length;
+      index += delimiter.length - 1;
+    }
+  }
+
+  parts.push(input.slice(partStart).trim());
+  return parts;
+}
+
+function isWrappedCondition(input: string): boolean {
+  if (!input.startsWith("(") || !input.endsWith(")")) return false;
+  let quote: "single" | "double" | null = null;
+  let escaped = false;
+  let macroDepth = 0;
+  let parenthesisDepth = 0;
+
+  for (let index = 0; index < input.length; index += 1) {
+    const character = input[index]!;
+    if (quote) {
+      if (escaped) escaped = false;
+      else if (character === "\\") escaped = true;
+      else if (quoteKind(character) === quote) quote = null;
+      continue;
+    }
+    if (macroDepth > 0) {
+      if (character === "{" && input[index + 1] === "{") {
+        macroDepth += 1;
+        index += 1;
+      } else if (character === "}" && input[index + 1] === "}") {
+        macroDepth -= 1;
+        index += 1;
+      }
+      continue;
+    }
+    const nextQuote = quoteKind(character);
+    if (nextQuote) {
+      quote = nextQuote;
+      continue;
+    }
+    if (character === "{" && input[index + 1] === "{") {
+      macroDepth = 1;
+      index += 1;
+      continue;
+    }
+    if (character === "(") parenthesisDepth += 1;
+    else if (character === ")") parenthesisDepth -= 1;
+    if (parenthesisDepth === 0 && index < input.length - 1) return false;
+  }
+
+  return parenthesisDepth === 0;
+}
+
+function unwrapCondition(input: string): string {
+  let unwrapped = input.trim();
+  while (isWrappedCondition(unwrapped)) unwrapped = unwrapped.slice(1, -1).trim();
+  return unwrapped;
+}
+
+function parseConditionExpression(condition: string): ParsedConditionExpression {
+  const symbolicOperators = [">=", "<=", "==", "!=", ">", "<", "="] as const;
+  let quote: "single" | "double" | null = null;
+  let escaped = false;
+  let macroDepth = 0;
+
+  for (let index = 0; index < condition.length; index += 1) {
+    const character = condition[index]!;
+    if (quote) {
+      if (escaped) escaped = false;
+      else if (character === "\\") escaped = true;
+      else if (quoteKind(character) === quote) quote = null;
+      continue;
+    }
+    if (macroDepth > 0) {
+      if (character === "{" && condition[index + 1] === "{") {
+        macroDepth += 1;
+        index += 1;
+      } else if (character === "}" && condition[index + 1] === "}") {
+        macroDepth -= 1;
+        index += 1;
+      }
+      continue;
+    }
+    const nextQuote = quoteKind(character);
+    if (nextQuote) {
+      quote = nextQuote;
+      continue;
+    }
+    if (character === "{" && condition[index + 1] === "{") {
+      macroDepth = 1;
+      index += 1;
+      continue;
+    }
+
+    const symbolicOperator = symbolicOperators.find((operator) => condition.startsWith(operator, index));
+    if (symbolicOperator) {
+      const left = condition.slice(0, index).trim();
+      const right = condition.slice(index + symbolicOperator.length).trim();
+      if (left && right) return { left, operator: symbolicOperator, right };
+    }
+
+    if (index === 0 || /\s/u.test(condition[index - 1]!)) {
+      const wordMatch = condition
+        .slice(index)
+        .match(/^(is\s+not|not\s+contains|not\s+includes|contains|includes|is)(?=\s|$)/iu);
+      if (wordMatch?.[0]) {
+        const left = condition.slice(0, index).trim();
+        const right = condition.slice(index + wordMatch[0].length).trim();
+        if (left && right) {
+          return { left, operator: wordMatch[0].toLowerCase().replace(/\s+/g, " "), right };
+        }
+      }
+    }
+  }
+
+  return { left: condition.trim(), operator: "truthy" };
+}
+
+function parseConditionComparisons(condition: string): ParsedConditionExpression[] {
+  const expression = unwrapCondition(condition);
+  const orParts = splitTopLevelCondition(expression, "||");
+  if (orParts.length > 1) return orParts.flatMap(parseConditionComparisons);
+  const andParts = splitTopLevelCondition(expression, "&&");
+  if (andParts.length > 1) return andParts.flatMap(parseConditionComparisons);
+  return [parseConditionExpression(expression)];
 }
 
 function conditionDependsOnCharacter(condition: string): boolean {
-  const parsed = parseConditionExpression(condition);
-  return (
-    isCharacterConditionalOperand(parsed.left) || (parsed.right ? isCharacterConditionalOperand(parsed.right) : false)
+  return parseConditionComparisons(condition).some(
+    (parsed) =>
+      isCharacterConditionalOperand(parsed.left) ||
+      (parsed.right ? isCharacterConditionalOperand(parsed.right) : false),
   );
 }
 
@@ -882,12 +1075,65 @@ function resolveConditionMacros(condition: string, ctx: MacroContext, options: R
   });
 }
 
-function evaluateCondition(condition: string, ctx: MacroContext, options: ResolveMacroOptions = {}): boolean {
-  const parsed = parseConditionExpression(resolveConditionMacros(condition, ctx, options));
+function evaluateParsedCondition(
+  parsed: ParsedConditionExpression,
+  ctx: MacroContext,
+  options: ResolveMacroOptions,
+): boolean {
   const left = resolveConditionalOperand(parsed.left, ctx, options);
   if (parsed.operator === "truthy") return left.trim().length > 0 && !/^(false|0|no|off|null|undefined)$/i.test(left);
   const right = resolveConditionalOperand(parsed.right ?? "", ctx, options);
   return compareConditionValues(left, parsed.operator, right);
+}
+
+function parseSimpleCondition(
+  condition: string,
+  ctx: MacroContext,
+  options: ResolveMacroOptions,
+): ParsedConditionExpression | null {
+  const expression = unwrapCondition(condition);
+  if (
+    splitTopLevelCondition(expression, "||").length > 1 ||
+    splitTopLevelCondition(expression, "&&").length > 1
+  ) {
+    return null;
+  }
+  return parseConditionExpression(resolveConditionMacros(expression, ctx, options));
+}
+
+function evaluateConditionExpression(condition: string, ctx: MacroContext, options: ResolveMacroOptions): boolean {
+  const expression = unwrapCondition(condition);
+  const orParts = splitTopLevelCondition(expression, "||");
+  if (orParts.length > 1) {
+    let equalityShorthand: Pick<ParsedConditionExpression, "left" | "operator"> | null = null;
+    for (const part of orParts) {
+      const parsed = parseSimpleCondition(part, ctx, options);
+      if (parsed) {
+        let effective = parsed;
+        if (["=", "==", "is"].includes(parsed.operator) && parsed.right !== undefined) {
+          equalityShorthand = { left: parsed.left, operator: parsed.operator };
+        } else if (equalityShorthand && parsed.operator === "truthy" && stripOuterQuotes(parsed.left) !== null) {
+          effective = { ...equalityShorthand, right: parsed.left };
+        }
+        if (evaluateParsedCondition(effective, ctx, options)) return true;
+      } else if (evaluateConditionExpression(part, ctx, options)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  const andParts = splitTopLevelCondition(expression, "&&");
+  if (andParts.length > 1) {
+    return andParts.every((part) => evaluateConditionExpression(part, ctx, options));
+  }
+
+  const parsed = parseSimpleCondition(expression, ctx, options);
+  return parsed ? evaluateParsedCondition(parsed, ctx, options) : false;
+}
+
+function evaluateCondition(condition: string, ctx: MacroContext, options: ResolveMacroOptions = {}): boolean {
+  return evaluateConditionExpression(condition, ctx, options);
 }
 
 type MacroTag = {
@@ -999,8 +1245,9 @@ function branchDependsOnCharacter(branches: ConditionalBranchPayload[]): boolean
 }
 
 function conditionDependsOnDeferredOperand(condition: string, predicate: (operand: string) => boolean): boolean {
-  const parsed = parseConditionExpression(condition);
-  return predicate(parsed.left) || (parsed.right ? predicate(parsed.right) : false);
+  return parseConditionComparisons(condition).some(
+    (parsed) => predicate(parsed.left) || (parsed.right ? predicate(parsed.right) : false),
+  );
 }
 
 function branchDependsOnDeferredOperand(
@@ -1342,6 +1589,7 @@ function formatMacroDateTime(now: Date, requestedTimeZone?: string): MacroDateTi
  *  - {{persona}} — active persona description, personality, backstory, appearance, and scenario joined by new lines
  *  - {{char}} — current character name
  *  - {{characters}} — comma-separated list of all character names
+ *  - {{group}} — comma-separated list of other active chat characters
  *  - {{description}} / {{personality}} / {{backstory}} / {{appearance}} / {{scenario}} / {{example}} — current character card fields
  *  - {{charSysInfo}} / {{charPostHistory}} — current character instruction fields
  *  - {{date}} — current real date in the user's timezone (YYYY-MM-DD)
@@ -1374,7 +1622,7 @@ function formatMacroDateTime(now: Date, requestedTimeZone?: string): MacroDateTi
  *  - {{banned "text"}} — content filter (removed for now)
  *  - {{uppercase}}...{{/uppercase}} — convert to uppercase
  *  - {{lowercase}}...{{/lowercase}} — convert to lowercase
- *  - {{#if char == "Name"}}...{{else}}...{{/if}} — conditional block
+ *  - {{#if char == "Name" || "Other"}}...{{else}}...{{/if}} — conditional block with OR/AND logic
  */
 export function resolveMacros(template: string, ctx: MacroContext, options: ResolveMacroOptions = {}): string {
   const macroDepth = options.macroDepth ?? 0;
@@ -1407,12 +1655,13 @@ export function resolveMacros(template: string, ctx: MacroContext, options: Reso
   };
   const deferCharacterMacros = options.deferCharacterMacros;
   const characterReplacement = (field: keyof typeof DEFERRED_CHARACTER_MACRO_TOKENS): string => {
-    const isNameField = field === "char" || field === "charPhonetic";
+    const isNameField = field === "char" || field === "charPhonetic" || field === "group";
     if (deferCharacterMacros === "all" || (deferCharacterMacros === "names" && isNameField)) {
       return DEFERRED_CHARACTER_MACRO_TOKENS[field];
     }
     if (field === "char") return ctx.char;
     if (field === "charPhonetic") return ctx.charPhonetic || ctx.characterFields?.phoneticName || ctx.char;
+    if (field === "group") return resolveGroupCharacters(ctx);
     return resolveNestedFieldMacros(ctx.characterFields?.[field] ?? "");
   };
 
@@ -1479,6 +1728,7 @@ export function resolveMacros(template: string, ctx: MacroContext, options: Reso
   result = result.replace(/\{\{char(?:Name)?\}\}/gi, characterReplacement("char"));
   result = result.replace(/\{\{char(?:Name)?Phonetic\}\}/gi, characterReplacement("charPhonetic"));
   result = result.replace(/\{\{characters\}\}/gi, ctx.characters.join(", "));
+  result = result.replace(/\{\{group\}\}/gi, characterReplacement("group"));
   result = result.replace(/\{\{description\}\}/gi, characterReplacement("description"));
   result = result.replace(/\{\{personality\}\}/gi, characterReplacement("personality"));
   result = result.replace(/\{\{backstory\}\}/gi, characterReplacement("backstory"));

--- a/scripts/regressions/prompt.regression.ts
+++ b/scripts/regressions/prompt.regression.ts
@@ -59,10 +59,12 @@ import {
   GAME_STORYBOARD_STILL_ANIMATION_PROMPT_TEMPLATE,
   GAME_STORYBOARD_STILL_ANIMATION_PROMPT_TEMPLATE_ID,
   DEFERRED_RELOCATION_CONDITIONAL_TOKEN_RE,
+  hasDeferredCharacterMacros,
   hasDeferredRelocationConditionals,
   getGameStoryboardPromptTemplateKind,
   normalizeGameStoryboardKeyframeCount,
   parseDeferredConditionalPayload,
+  resolveDeferredCharacterMacros,
   selectConditionalPayloadBranch,
 } from "../../packages/shared/src/index.js";
 import { replaceBuiltInAgentDefinitions as replaceBuiltInAgentDefinitionsDist } from "../../packages/shared/dist/index.js";
@@ -1045,6 +1047,125 @@ const cases: RegressionCase[] = [
         "Hi Bob",
       );
       assert.equal(resolveMacros("{{#if 1==1}}It is one{{else if 2==2}}It is two{{/if}}", context), "It is one");
+    },
+  },
+  {
+    name: "macro conditionals support OR, AND, grouping, and equality shorthand",
+    run() {
+      const baseContext = {
+        user: "Mari",
+        char: "Pantalone",
+        characters: ["Maukie", "Pantalone", "Dottore"],
+        variables: {},
+        characterFields: { scenario: "Moonlit lake" },
+      };
+
+      assert.equal(
+        resolveMacros('{{#if character == "Maukie" || "Pantalone"}}selected{{else}}other{{/if}}', baseContext),
+        "selected",
+      );
+      assert.equal(
+        resolveMacros("{{#if character == “Maukie” || “Pantalone”}}selected{{else}}other{{/if}}", baseContext),
+        "selected",
+      );
+      assert.equal(
+        resolveMacros(
+          '{{#if characters contains "Maukie" && characters contains "Pantalone"}}together{{/if}}',
+          baseContext,
+        ),
+        "together",
+      );
+      assert.equal(
+        resolveMacros(
+          '{{#if (character == "Maukie" || character == "Pantalone") && scenario contains "lake"}}lake party{{/if}}',
+          baseContext,
+        ),
+        "lake party",
+      );
+      assert.equal(
+        resolveMacros(
+          '{{#if character == "Maukie" || character == "Pantalone" && scenario contains "palace"}}selected{{else}}other{{/if}}',
+          { ...baseContext, characterFields: { scenario: "Empty road" } },
+        ),
+        "other",
+      );
+      assert.equal(
+        resolveMacros('{{#if scenario == "A || B && C"}}literal{{/if}}', {
+          ...baseContext,
+          characterFields: { scenario: "A || B && C" },
+        }),
+        "literal",
+      );
+
+      const deferred = resolveMacros(
+        '{{#if character == "Maukie" || "Pantalone"}}selected{{else}}other{{/if}}',
+        { ...baseContext, char: "Dottore" },
+        { deferCharacterMacros: "names" },
+      );
+      assert.equal(hasDeferredCharacterMacros(deferred), true);
+      assert.equal(resolveDeferredCharacterMacros(deferred, { name: "Pantalone" }, baseContext), "selected");
+      assert.equal(resolveDeferredCharacterMacros(deferred, { name: "Dottore" }, baseContext), "other");
+    },
+  },
+  {
+    name: "group macro uses the full active roster without changing existing identity macros",
+    run() {
+      const context = {
+        user: "Powers That Be",
+        char: "Pantalone",
+        characters: ["Pantalone"],
+        groupCharacters: ["Powers That Be", "Maukie", "Pantalone"],
+        variables: {},
+      };
+
+      assert.equal(resolveMacros("{{group}}", context), "Powers That Be, Maukie");
+      assert.equal(
+        resolveMacros("The other players are {{group}}, and {{user}}.", context),
+        "The other players are Powers That Be, Maukie, and Powers That Be.",
+      );
+      assert.equal(resolveMacros("{{characters}}", context), "Pantalone");
+      assert.equal(resolveMacros("{{user}} / {{char}}", context), "Powers That Be / Pantalone");
+      assert.equal(
+        resolveMacros("{{group}}", {
+          ...context,
+          groupCharacters: ["Powers That Be", "Maukie", "  pantalone  "],
+        }),
+        "Powers That Be, Maukie",
+      );
+      assert.equal(
+        resolveMacros("{{group}}", { user: "Mari", char: "Dottore", characters: ["Dottore"], variables: {} }),
+        "",
+      );
+
+      const deferred = resolveMacros("{{char}} sees {{group}}", context, { deferCharacterMacros: "names" });
+      assert.equal(hasDeferredCharacterMacros(deferred), true);
+      assert.equal(
+        resolveDeferredCharacterMacros(deferred, { name: "Pantalone" }, context),
+        "Pantalone sees Powers That Be, Maukie",
+      );
+
+      const conditional = resolveMacros('{{#if group contains "Maukie"}}together{{else}}apart{{/if}}', context, {
+        deferCharacterMacros: "names",
+      });
+      assert.equal(hasDeferredCharacterMacros(conditional), true);
+      assert.equal(resolveDeferredCharacterMacros(conditional, { name: "Pantalone" }, context), "together");
+      assert.equal(resolveDeferredCharacterMacros(conditional, { name: "Maukie" }, context), "apart");
+
+      const assemblerSource = readFileSync(
+        new URL("../../packages/server/src/services/prompt/assembler.ts", import.meta.url),
+        "utf8",
+      );
+      const generateRouteSource = readFileSync(
+        new URL("../../packages/server/src/routes/generate.routes.ts", import.meta.url),
+        "utf8",
+      );
+      const dryRunRouteSource = readFileSync(
+        new URL("../../packages/server/src/routes/generate/dry-run-route.ts", import.meta.url),
+        "utf8",
+      );
+      assert.match(assemblerSource, /groupCharacterIds: input\.groupCharacterIds/);
+      assert.match(generateRouteSource, /characterIds: promptCharacterIds,\s*groupCharacterIds: characterIds,/);
+      assert.match(dryRunRouteSource, /characterIds: promptCharacterIds,\s*groupCharacterIds: characterIds,/);
     },
   },
   {

--- a/scripts/regressions/roleplay-streaming.regression.ts
+++ b/scripts/regressions/roleplay-streaming.regression.ts
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
 import {
   isMessageShadowedByLiveStream,
   reconcileTypewriterReplacement,
@@ -32,6 +33,29 @@ import {
   type ChatOptions,
 } from "../../packages/server/src/services/llm/base-provider.js";
 import type { AgentCallDebugEvent, AgentContext } from "../../packages/shared/src/types/agent.js";
+
+const retryAgentRouteSource = readFileSync(
+  new URL("../../packages/server/src/routes/generate/retry-agents-route.ts", import.meta.url),
+  "utf8",
+);
+assert.match(
+  retryAgentRouteSource,
+  /const updateRetryTargetGameStateSnapshot = async/,
+  "tracker retries should have an unanchored snapshot persistence path",
+);
+for (const resultType of [
+  "game_state_update",
+  "character_tracker_update",
+  "persona_stats_update",
+  "quest_update",
+  "custom_tracker_update",
+]) {
+  assert.doesNotMatch(
+    retryAgentRouteSource,
+    new RegExp(`retryMessageId\\s*&&\\s*result\\.success\\s*&&\\s*result\\.type === ["']${resultType}["']`),
+    `${resultType} retries must not require an assistant-message anchor`,
+  );
+}
 
 assert.equal(
   trackerEditableText({ name: "HP", value: 75, max: 100, color: "#ef4444" }),


### PR DESCRIPTION
## Linked issue

Closes #3812

## Why this change

- Prompt authors need reusable character conditions that can combine OR/AND checks and refer to every other active character in a group.
- Successful Roleplay tracker re-runs were discarded when a refreshed scene had no assistant-message anchor, despite the provider returning valid tracker data.
- Installed Theme and Extension names in Settings > Addons inherited the pink primary accent instead of the user's selected chroma text color.

## What changed

- Added `||`, `&&`, parentheses, and equality-list shorthand to conditional prompt macros.
- Added `{{group}}`, preserving the full active character roster through targeted Roleplay generation and Peek Prompt assembly while excluding only the current responder.
- Updated the in-app macro guidance, slash-command help, and prompt documentation.
- Persisted World State, Character, Persona, Quest, and Custom tracker re-runs against the visible/latest tracker state when no assistant reply exists, creating a baseline snapshot only when necessary.
- Applied the existing chroma text helper to installed Theme and Extension names.
- Added prompt and Roleplay regression coverage for the affected integration boundaries.

## Validation

- [ ] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed `CONTRIBUTING.md`

### Manual verification notes

- The maintainer tested the combined branch in Roleplay and confirmed the requested changes work.
- The saved three-character manual Roleplay preset was assembled read-only with Pantalone targeted; `{{group}}` resolved to `Powers That Be, Maukie`, while the same-named active persona remained available separately through `{{user}}`.
- Automated checks run: `pnpm check`, `pnpm regression:prompt`, `pnpm regression:roleplay`, `pnpm smoke:ui` (72 passed, 46 intentionally skipped), `pnpm version:check`, and `git diff --check`.
- Docker/Podman validation was not run.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Version/release files updated (only if this PR includes a version bump)

Prompt macro documentation and `CHANGELOG.md` are updated. This PR does not bump the application version.

## UI evidence (if applicable)

No screenshot is attached. The Settings change reuses the existing `mari-chrome-text` token on two installed-item name labels and was manually confirmed on the combined branch.

## Risk notes

Prompt assembly is the highest-risk path touched. Current and targeted/manual Roleplay paths are covered by regression checks and the saved-preset probe; Peek Prompt receives the same full-roster input. Existing identity macros remain unchanged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added `{{group}}` for listing other active chat characters.
  - Conditional prompt blocks now support `||`, `&&`, parentheses, and equality-list shorthand.
  - Group-aware prompt generation is supported for targeted roleplay responses.

- **Bug Fixes**
  - Fixed empty group values in targeted roleplay prompts.
  - Fixed theme colors for addon names in Settings.
  - Improved tracker persistence after roleplay retries without a new assistant reply.

- **Documentation**
  - Updated macro and conditional prompt guides with syntax details and examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->