### PR TITLE
Fix character and persona prompt field order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 
 ### Fixed
 
+- Kept Character and Persona prompt sections in editor order across preset markers, fallbacks, agent lore, and Game/scene card contexts: Description, Personality, Backstory, Appearance, Scenario, then Example Dialogue when present (#3817).
 - Streamed Roleplay and Game scene-video files with standard byte-range and HEAD handling instead of synchronously buffering complete MP4 files for every playback request (#3811).
 - Stopped the macOS/Linux and Termux launchers from sourcing `.env` as Bash code; launcher-owned settings now use Node's non-evaluating dotenv parser while preserving ambient-environment precedence (#3810).
 - Routed the Roleplay Gallery's **Background** action through Illustrator's background prompt mode instead of bypassing the agent with a raw scene-generation prompt (#3809).

--- a/packages/server/src/routes/chats.routes.ts
+++ b/packages/server/src/routes/chats.routes.ts
@@ -2603,15 +2603,6 @@ export async function chatsRoutes(app: FastifyInstance) {
                     2,
                   ),
                 );
-              if (characterMacroContext.characterFields.scenario && !hasGroupOverride)
-                parts.push(
-                  wrapContent(
-                    resolveCharacterMacros(characterMacroContext.characterFields.scenario),
-                    "scenario",
-                    wrapFormat,
-                    2,
-                  ),
-                );
               if (characterMacroContext.characterFields.backstory)
                 parts.push(
                   wrapContent(
@@ -2626,6 +2617,15 @@ export async function chatsRoutes(app: FastifyInstance) {
                   wrapContent(
                     resolveCharacterMacros(characterMacroContext.characterFields.appearance),
                     "appearance",
+                    wrapFormat,
+                    2,
+                  ),
+                );
+              if (characterMacroContext.characterFields.scenario && !hasGroupOverride)
+                parts.push(
+                  wrapContent(
+                    resolveCharacterMacros(characterMacroContext.characterFields.scenario),
+                    "scenario",
                     wrapFormat,
                     2,
                   ),

--- a/packages/server/src/routes/game.routes.ts
+++ b/packages/server/src/routes/game.routes.ts
@@ -2134,11 +2134,11 @@ function buildNpcPartyCard(npc: Pick<GameNpc, "name" | "description" | "location
 
 function buildRecruitCharacterSourceCard(characterData: Record<string, any>): string {
   const lines = [`Name: ${String(characterData.name || "Unknown")}`];
-  if (typeof characterData.personality === "string" && characterData.personality.trim()) {
-    lines.push(`Personality: ${characterData.personality.trim()}`);
-  }
   if (typeof characterData.description === "string" && characterData.description.trim()) {
     lines.push(`Description: ${characterData.description.trim()}`);
+  }
+  if (typeof characterData.personality === "string" && characterData.personality.trim()) {
+    lines.push(`Personality: ${characterData.personality.trim()}`);
   }
   const backstory =
     typeof characterData.extensions?.backstory === "string" && characterData.extensions.backstory.trim()
@@ -6220,9 +6220,9 @@ export async function gameRoutes(app: FastifyInstance) {
       if (gmChar) {
         const data = typeof gmChar.data === "string" ? JSON.parse(gmChar.data) : gmChar.data;
         const parts = [`Name: ${data.name}`];
-        if (data.personality) parts.push(`Personality: ${data.personality}`);
         const description = typeof data.description === "string" ? data.description : "";
         if (description) parts.push(`Description: ${description}`);
+        if (data.personality) parts.push(`Personality: ${data.personality}`);
         const gmBackstory = data.extensions?.backstory || data.backstory;
         const gmAppearance = data.extensions?.appearance || data.appearance;
         if (gmBackstory) parts.push(`Backstory: ${gmBackstory}`);
@@ -6264,9 +6264,9 @@ export async function gameRoutes(app: FastifyInstance) {
         if (typeof data.name === "string" && data.name.trim()) {
           partyNames.push(data.name.trim());
         }
-        if (data.personality) parts.push(`Personality: ${data.personality}`);
         const description = typeof data.description === "string" ? data.description : "";
         if (description) parts.push(`Description: ${description}`);
+        if (data.personality) parts.push(`Personality: ${data.personality}`);
         const pcBackstory = data.extensions?.backstory || data.backstory;
         const pcAppearance = data.extensions?.appearance || data.appearance;
         if (pcBackstory) parts.push(`Backstory: ${pcBackstory}`);
@@ -9432,8 +9432,8 @@ export async function gameRoutes(app: FastifyInstance) {
         const description = typeof charData.description === "string" ? charData.description : "";
         const card = [
           `Name: ${charData.name}`,
-          charData.personality ? `Personality: ${charData.personality}` : null,
           description ? `Description: ${description}` : null,
+          charData.personality ? `Personality: ${charData.personality}` : null,
           charData.extensions?.backstory || charData.backstory
             ? `Backstory: ${charData.extensions?.backstory || charData.backstory}`
             : null,

--- a/packages/server/src/routes/generate/dry-run-route.ts
+++ b/packages/server/src/routes/generate/dry-run-route.ts
@@ -950,14 +950,14 @@ export async function registerDryRunRoute(app: FastifyInstance) {
         personaLines.push(`Name: ${personaName}`);
         const resolvedPersonaDescription = resolvePromptMacros(personaDescription);
         const resolvedPersonaPersonality = resolvePromptMacros(personaFields.personality ?? "");
-        const resolvedPersonaScenario = resolvePromptMacros(personaFields.scenario ?? "");
         const resolvedPersonaBackstory = resolvePromptMacros(personaFields.backstory ?? "");
         const resolvedPersonaAppearance = resolvePromptMacros(personaFields.appearance ?? "");
+        const resolvedPersonaScenario = resolvePromptMacros(personaFields.scenario ?? "");
         if (resolvedPersonaDescription.trim()) personaLines.push(`Description: ${resolvedPersonaDescription.trim()}`);
         if (resolvedPersonaPersonality.trim()) personaLines.push(`Personality: ${resolvedPersonaPersonality.trim()}`);
-        if (resolvedPersonaScenario.trim()) personaLines.push(`Scenario: ${resolvedPersonaScenario.trim()}`);
         if (resolvedPersonaBackstory.trim()) personaLines.push(`Backstory: ${resolvedPersonaBackstory.trim()}`);
         if (resolvedPersonaAppearance.trim()) personaLines.push(`Appearance: ${resolvedPersonaAppearance.trim()}`);
+        if (resolvedPersonaScenario.trim()) personaLines.push(`Scenario: ${resolvedPersonaScenario.trim()}`);
         return wrapContent(personaLines.join("\n"), "Persona", wrapFormat).trim();
       })();
 
@@ -998,10 +998,14 @@ export async function registerDryRunRoute(app: FastifyInstance) {
             const lines: string[] = [];
             const resolvedDesc = resolveCharacterMacros(desc);
             const resolvedPersonality = resolveCharacterMacros(personality);
+            const resolvedBackstory = resolveCharacterMacros(cardPromptText(extensions.backstory));
+            const resolvedAppearance = resolveCharacterMacros(cardPromptText(extensions.appearance));
             const resolvedScenario = resolveCharacterMacros(scenario);
             const resolvedMesExample = resolveCharacterMacros(mesExample);
             if (resolvedDesc.trim()) lines.push(resolvedDesc.trim());
             if (resolvedPersonality.trim()) lines.push(`Personality: ${resolvedPersonality.trim()}`);
+            if (resolvedBackstory.trim()) lines.push(`Backstory: ${resolvedBackstory.trim()}`);
+            if (resolvedAppearance.trim()) lines.push(`Appearance: ${resolvedAppearance.trim()}`);
             if (resolvedScenario.trim()) lines.push(`Scenario: ${resolvedScenario.trim()}`);
             if (resolvedMesExample.trim()) lines.push(`Example messages:\n${resolvedMesExample.trim()}`);
 

--- a/packages/server/src/routes/scene.routes.ts
+++ b/packages/server/src/routes/scene.routes.ts
@@ -131,8 +131,8 @@ async function buildCharacterContext(chars: ReturnType<typeof createCharactersSt
     ctx += `<character="${data.name}" id="${cid}">\n`;
     if (description) ctx += `${description}\n`;
     if (data.personality) ctx += `${data.personality}\n`;
-    if (data.extensions?.appearance) ctx += `Appearance: ${data.extensions.appearance}\n`;
     if (data.extensions?.backstory) ctx += `Backstory: ${data.extensions.backstory}\n`;
+    if (data.extensions?.appearance) ctx += `Appearance: ${data.extensions.appearance}\n`;
     ctx += `</character>\n\n`;
   }
   return ctx;

--- a/packages/server/src/services/agents/agent-executor.ts
+++ b/packages/server/src/services/agents/agent-executor.ts
@@ -2149,9 +2149,9 @@ function buildLoreBlock(context: AgentContext): string {
     for (const char of context.characters) {
       parts.push(`<character id="${char.id}" name="${char.name}">`);
       pushLoreField(parts, "Description", char.description, CHARACTER_LORE_DESCRIPTION_LIMIT);
-      pushLoreField(parts, "Appearance", char.appearance, CHARACTER_LORE_FIELD_LIMIT);
       pushLoreField(parts, "Personality", char.personality, CHARACTER_LORE_FIELD_LIMIT);
       pushLoreField(parts, "Backstory", char.backstory, CHARACTER_LORE_FIELD_LIMIT);
+      pushLoreField(parts, "Appearance", char.appearance, CHARACTER_LORE_FIELD_LIMIT);
       pushLoreField(parts, "Scenario", char.scenario, CHARACTER_LORE_FIELD_LIMIT);
       if (char.rpgStats?.enabled) {
         const pools = normalizeRpgStatPools(char.rpgStats);

--- a/packages/server/src/services/generation/character-prompt-context.ts
+++ b/packages/server/src/services/generation/character-prompt-context.ts
@@ -90,9 +90,9 @@ const CHARACTER_FALLBACK_FIELDS: Array<{
 }> = [
   { key: "description", label: "description", macroAliases: ["description"] },
   { key: "personality", label: "personality", macroAliases: ["personality"] },
-  { key: "scenario", label: "scenario", macroAliases: ["scenario"] },
   { key: "backstory", label: "backstory", macroAliases: ["backstory"] },
   { key: "appearance", label: "appearance", macroAliases: ["appearance"] },
+  { key: "scenario", label: "scenario", macroAliases: ["scenario"] },
   { key: "systemPrompt", label: "system_prompt", macroAliases: ["charSysInfo"] },
   { key: "mesExample", label: "example_dialogue", macroAliases: ["example"] },
 ];

--- a/packages/server/src/services/generation/game-gm-prompt-runtime.ts
+++ b/packages/server/src/services/generation/game-gm-prompt-runtime.ts
@@ -110,8 +110,8 @@ function buildLibraryCardParts(data: any, fallbackName = "Unknown"): { name: str
   const backstory = cardPromptText(data.extensions?.backstory || data.backstory);
   const appearance = cardPromptText(data.extensions?.appearance || data.appearance);
   const systemPrompt = cardPromptText(data.system_prompt);
-  if (personality) parts.push(`Personality: ${personality}`);
   if (description) parts.push(`Description: ${description}`);
+  if (personality) parts.push(`Personality: ${personality}`);
   if (backstory) parts.push(`Backstory: ${backstory}`);
   if (appearance) parts.push(`Appearance: ${appearance}`);
   if (systemPrompt) parts.push(`Character System Instructions: ${systemPrompt}`);

--- a/packages/server/src/services/generation/professor-mari-command-runtime.ts
+++ b/packages/server/src/services/generation/professor-mari-command-runtime.ts
@@ -634,14 +634,14 @@ async function fetchCharacterContent(command: FetchCommand, args: Parameters<typ
   const parts = [`Name: ${data.name}`];
   if (data.description) parts.push(`Description: ${data.description}`);
   if (data.personality) parts.push(`Personality: ${data.personality}`);
+  if (data.extensions?.backstory) parts.push(`Backstory: ${data.extensions.backstory}`);
+  if (data.extensions?.appearance) parts.push(`Appearance: ${data.extensions.appearance}`);
   if (data.scenario) parts.push(`Scenario: ${data.scenario}`);
   if (data.mes_example) parts.push(`Example Messages: ${data.mes_example}`);
   if (data.system_prompt) parts.push(`System Prompt: ${data.system_prompt}`);
   if (data.post_history_instructions) parts.push(`Post-History Instructions: ${data.post_history_instructions}`);
   if (data.first_mes) parts.push(`First Message: ${data.first_mes}`);
   if (data.creator_notes) parts.push(`Creator Notes: ${data.creator_notes}`);
-  if (data.extensions?.appearance) parts.push(`Appearance: ${data.extensions.appearance}`);
-  if (data.extensions?.backstory) parts.push(`Backstory: ${data.extensions.backstory}`);
   return parts.join("\n");
 }
 
@@ -655,9 +655,9 @@ async function fetchPersonaContent(command: FetchCommand, args: Parameters<typeo
   const parts = [`Name: ${found.name}`];
   if (found.description) parts.push(`Description: ${found.description}`);
   if (found.personality) parts.push(`Personality: ${found.personality}`);
-  if (found.scenario) parts.push(`Scenario: ${found.scenario}`);
-  if (found.appearance) parts.push(`Appearance: ${found.appearance}`);
   if (found.backstory) parts.push(`Backstory: ${found.backstory}`);
+  if (found.appearance) parts.push(`Appearance: ${found.appearance}`);
+  if (found.scenario) parts.push(`Scenario: ${found.scenario}`);
   return parts.join("\n");
 }
 

--- a/packages/server/src/services/prompt/marker-expander.ts
+++ b/packages/server/src/services/prompt/marker-expander.ts
@@ -110,6 +110,33 @@ function resolveSanitizedPromptLeaf(value: string, ctx: MarkerContext, macroCtx:
   return sanitizePromptLeaf(resolveMacros(value, macroCtx), ctx.wrapFormat);
 }
 
+const DEFAULT_CHARACTER_MARKER_FIELDS = [
+  "description",
+  "personality",
+  "backstory",
+  "appearance",
+  "scenario",
+  "system_prompt",
+];
+
+const CHARACTER_CARD_FIELD_ORDER = new Map(
+  ["description", "personality", "backstory", "appearance", "scenario", "mes_example", "example_dialogue"].map(
+    (field, index) => [field, index],
+  ),
+);
+
+/** Keep selected card sections in the same order as the Character editor. */
+export function orderCharacterMarkerFields(fields: readonly string[]): string[] {
+  return fields
+    .map((field, index) => ({ field, index }))
+    .sort((left, right) => {
+      const leftOrder = CHARACTER_CARD_FIELD_ORDER.get(left.field) ?? Number.POSITIVE_INFINITY;
+      const rightOrder = CHARACTER_CARD_FIELD_ORDER.get(right.field) ?? Number.POSITIVE_INFINITY;
+      return leftOrder - rightOrder || left.index - right.index;
+    })
+    .map(({ field }) => field);
+}
+
 /**
  * Expand a marker section into actual content based on its type and config.
  */
@@ -148,14 +175,7 @@ async function expandCharacter(config: MarkerConfig, ctx: MarkerContext): Promis
     const profile = characterMacroProfileFromData(data);
     const characterMacroContext = macroContextForCharacterProfile(ctx.macroCtx, profile);
 
-    const fields = config.characterFields ?? [
-      "description",
-      "personality",
-      "scenario",
-      "backstory",
-      "appearance",
-      "system_prompt",
-    ];
+    const fields = orderCharacterMarkerFields(config.characterFields ?? DEFAULT_CHARACTER_MARKER_FIELDS);
 
     const charParts: string[] = [];
     for (const field of fields) {

--- a/scripts/regressions/prompt.regression.ts
+++ b/scripts/regressions/prompt.regression.ts
@@ -260,7 +260,11 @@ import {
 import { injectIdentityFallbackMessages } from "../../packages/server/src/services/generation/character-prompt-context.js";
 import { injectSceneContextMessages } from "../../packages/server/src/services/generation/scene-context-runtime.js";
 import { resolveConversationConnectedChatContext } from "../../packages/server/src/routes/generate/conversation-connected-context.js";
-import { expandMarker, type MarkerContext } from "../../packages/server/src/services/prompt/marker-expander.js";
+import {
+  expandMarker,
+  orderCharacterMarkerFields,
+  type MarkerContext,
+} from "../../packages/server/src/services/prompt/marker-expander.js";
 import {
   buildRuntimeAgentSectionEligibleTypesForTest,
   clearUnusedRuntimeAgentSectionsForTest,
@@ -2841,6 +2845,17 @@ Use HTML sparingly and diegetically. Do not replace normal prose/dialogue unless
       const context = makeRegressionAgentContext({
         wrapFormat: "markdown",
         mainResponse: "Dottore studies the rain-slick street and chooses a darker alley backdrop.",
+        characters: [
+          {
+            id: "char-dottore",
+            name: "Dottore",
+            description: "AGENT_CHAR_DESCRIPTION",
+            personality: "AGENT_CHAR_PERSONALITY",
+            backstory: "AGENT_CHAR_BACKSTORY",
+            appearance: "AGENT_CHAR_APPEARANCE",
+            scenario: "AGENT_CHAR_SCENARIO",
+          },
+        ],
       });
 
       const result = await executeAgent(config as any, context, provider as any, "regression-model");
@@ -2855,6 +2870,19 @@ Use HTML sparingly and diegetically. Do not replace normal prose/dialogue unless
       assert.match(last.content, /Agent "background" \(Background\):/);
       assert.doesNotMatch(last.content, /Agent "quest"/);
       assert.equal(last.content.trim().endsWith('Return JSON: {"chosen": null}'), true);
+      const system = messages[0]?.content ?? "";
+      const cardFieldPositions = [
+        "AGENT_CHAR_DESCRIPTION",
+        "AGENT_CHAR_PERSONALITY",
+        "AGENT_CHAR_BACKSTORY",
+        "AGENT_CHAR_APPEARANCE",
+        "AGENT_CHAR_SCENARIO",
+      ].map((fragment) => system.indexOf(fragment));
+      assert.ok(cardFieldPositions.every((position) => position >= 0));
+      assert.deepEqual(
+        cardFieldPositions,
+        [...cardFieldPositions].sort((left, right) => left - right),
+      );
     },
   },
   {
@@ -3437,6 +3465,142 @@ Use HTML sparingly and diegetically. Do not replace normal prose/dialogue unless
       assert.match(promptText, /<START>/);
       assert.equal(promptText.includes("&lt;START>"), false);
       assert.match(promptText, /<system>bad example<\/system>/);
+    },
+  },
+  {
+    name: "character and persona card sections follow editor order in identity fallbacks",
+    run() {
+      const messages: ChatMLMessage[] = [
+        { role: "system", content: "Stable system prompt." },
+        { role: "user", content: "Hello." },
+      ];
+
+      injectIdentityFallbackMessages({
+        messages,
+        charInfo: [
+          {
+            id: "char-ordered",
+            name: "Ordered Character",
+            description: "CHAR_DESCRIPTION",
+            personality: "CHAR_PERSONALITY",
+            backstory: "CHAR_BACKSTORY",
+            appearance: "CHAR_APPEARANCE",
+            scenario: "CHAR_SCENARIO",
+            mesExample: "CHAR_EXAMPLE_DIALOGUE",
+            creatorNotes: "",
+            systemPrompt: "",
+            firstMes: "",
+            postHistoryInstructions: "",
+            tags: [],
+            talkativeness: 0.5,
+            avatarPath: null,
+            avatarCrop: null,
+          },
+        ],
+        promptTargetCharacterId: null,
+        promptMacroContext: {
+          user: "Mari",
+          char: "Ordered Character",
+          characters: ["Ordered Character"],
+          variables: {},
+        },
+        wrapFormat: "xml",
+        personaName: "Mari",
+        personaDescription: "PERSONA_DESCRIPTION",
+        personaFields: {
+          personality: "PERSONA_PERSONALITY",
+          backstory: "PERSONA_BACKSTORY",
+          appearance: "PERSONA_APPEARANCE",
+          scenario: "PERSONA_SCENARIO",
+        },
+        persona: null,
+        resolvePromptMacros: (value) => value,
+      });
+
+      const promptText = messages.map((message) => message.content).join("\n");
+      const assertInOrder = (fragments: string[]) => {
+        const positions = fragments.map((fragment) => promptText.indexOf(fragment));
+        assert.ok(positions.every((position) => position >= 0));
+        assert.deepEqual(
+          positions,
+          [...positions].sort((left, right) => left - right),
+        );
+      };
+
+      assertInOrder([
+        "CHAR_DESCRIPTION",
+        "CHAR_PERSONALITY",
+        "CHAR_BACKSTORY",
+        "CHAR_APPEARANCE",
+        "CHAR_SCENARIO",
+        "CHAR_EXAMPLE_DIALOGUE",
+      ]);
+      assertInOrder([
+        "PERSONA_DESCRIPTION",
+        "PERSONA_PERSONALITY",
+        "PERSONA_BACKSTORY",
+        "PERSONA_APPEARANCE",
+        "PERSONA_SCENARIO",
+      ]);
+    },
+  },
+  {
+    name: "character marker selections follow editor order without disturbing advanced fields",
+    run() {
+      assert.deepEqual(
+        orderCharacterMarkerFields([
+          "scenario",
+          "system_prompt",
+          "appearance",
+          "mes_example",
+          "description",
+          "backstory",
+          "personality",
+          "stats",
+        ]),
+        ["description", "personality", "backstory", "appearance", "scenario", "mes_example", "system_prompt", "stats"],
+      );
+    },
+  },
+  {
+    name: "persona markers preserve editor order and omit empty sections",
+    async run() {
+      const expanded = await expandMarker(
+        { type: "persona" },
+        {
+          db: undefined as unknown as DB,
+          chatId: "chat-persona-order",
+          characterIds: [],
+          personaName: "Mari",
+          personaDescription: "PERSONA_MARKER_DESCRIPTION",
+          personaFields: {
+            personality: "PERSONA_MARKER_PERSONALITY",
+            backstory: "PERSONA_MARKER_BACKSTORY",
+            appearance: "   ",
+            scenario: "PERSONA_MARKER_SCENARIO",
+          },
+          chatMessages: [],
+          chatSummary: null,
+          wrapFormat: "xml",
+          enableAgents: true,
+          activeAgentIds: [],
+          activeLorebookIds: [],
+          macroCtx: { user: "Mari", char: "Dottore", characters: ["Dottore"], variables: {} },
+        },
+      );
+
+      const positions = [
+        "PERSONA_MARKER_DESCRIPTION",
+        "PERSONA_MARKER_PERSONALITY",
+        "PERSONA_MARKER_BACKSTORY",
+        "PERSONA_MARKER_SCENARIO",
+      ].map((fragment) => expanded.content.indexOf(fragment));
+      assert.ok(positions.every((position) => position >= 0));
+      assert.deepEqual(
+        positions,
+        [...positions].sort((left, right) => left - right),
+      );
+      assert.equal(expanded.content.includes("<appearance>"), false);
     },
   },
   {


### PR DESCRIPTION
## Linked issue

Closes #3817

## Why this change

Character and Persona sections should reach models in the same top-to-bottom order users see in their editors. Several serializers placed Scenario before Backstory and Appearance, while agent and Game card contexts had their own ordering drift.

## Root cause

The canonical order was repeated manually across marker expansion, fallback injection, prompt preview, agents, and Game helpers. The Characters marker default itself encoded the old order, and saved custom marker selections were emitted in their stored order.

## What changed

- Canonicalize selected Characters marker fields as Description, Personality, Backstory, Appearance, Scenario, then Example Dialogue when selected.
- Apply the same relative order to no-marker identity fallbacks, Peek Prompt, and legacy dry-run assembly while continuing to omit blank fields.
- Align Persona prompt previews with the existing canonical Persona marker, fallback, and macro order.
- Correct ordering in agent lore, Game setup/runtime cards, scene context, and Professor Mari card fetches.
- Add regressions for Character and Persona field order, blank-section omission, custom marker selections, and agent lore.

## Automated evidence

- pnpm regression:prompt
- pnpm check

## Manual verification

- [ ] Inspect Peek Prompt in Roleplay with a Characters marker and every Character card section populated.
- [ ] Inspect Conversation and Game prompts with partially populated Character and Persona cards.
- [ ] Confirm custom marker field selections still include only the selected fields.

## Risk

This is a provider-facing prompt-order change. Field content, labels, wrappers, preset section placement, advanced instructions, and macro behavior are unchanged. Existing custom marker selections are preserved but their standard card fields now follow the editor order.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Standardized Character and Persona prompt sections to follow the editor’s field order across previews, generated prompts, fallback contexts, agent lore, and game/scene cards.
  * Ensured Example Dialogue appears last when present.
  * Added missing Backstory and Appearance details to character prompt previews.
  * Corrected formatting and ordering inconsistencies in generated character and persona content.
* **Tests**
  * Added regression coverage verifying consistent field ordering and omission of empty sections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->