### PR TITLE
Fix agent cadence and custom music folder integration

### DIFF
--- a/docs/game/game-assets.md
+++ b/docs/game/game-assets.md
@@ -147,7 +147,7 @@ A bar shows "All folders included" or how many folders are excluded, with a **Re
 
 **Music DJ** is a helper agent that can play music during a game. When it runs in its Custom mode, it plays tracks from a folder you choose. You can set that folder in two places.
 
-When you enable **Music DJ** for a chat, the setup form shows a **Custom Music Folder** field. It points at a folder inside your game assets, such as `music` or `music/combat`.
+When you enable **Music DJ** for a chat, the setup form follows the source saved on the Music DJ agent. **Game Assets** shows a path inside your game assets, such as `music` or `music/combat`. **Folder on this device** shows the saved server-device path and a **Choose Folder** button.
 
 The full **Music DJ** editor has a **Custom Music Library** section. Its **Use Game Assets music folder** switch picks between two modes:
 

--- a/docs/media/illustrator-agent.md
+++ b/docs/media/illustrator-agent.md
@@ -6,7 +6,7 @@ This guide covers the **Illustrator**, a built-in helper that draws pictures of 
 
 An agent is a small AI helper that runs automatically for one chat. The **Illustrator** is a post-processing agent, which means it runs after the AI finishes each reply. It reads the latest reply and decides if the moment is worth a picture. When it is, the Illustrator writes an image prompt and sends it to your image provider. A prompt is the text description that tells an image model what to draw.
 
-The Illustrator does not draw every message. By default, after it makes an image it waits about 5 assistant replies before it can make another one. If it decides a moment is not worth illustrating, it skips it and makes no image. Every image it creates is saved to the chat **Gallery**.
+The Illustrator does not draw every message. By default, after it makes an image it waits about 5 accepted assistant replies before it can make another one. Swiping or regenerating the same reply does not advance that interval. If it decides a moment is not worth illustrating, it skips it and makes no image. Every image it creates is saved to the chat **Gallery**.
 
 You can use the Illustrator in **Roleplay** and **Game Mode** chats, and installing it also unlocks Conversation selfies. Its short description in the app reads: "Responsible for image and video generations." The setup steps and settings in this guide are for Roleplay chats. Game Mode uses one simple switch instead, covered in the Game Mode section below.
 

--- a/docs/media/music.md
+++ b/docs/media/music.md
@@ -98,6 +98,8 @@ Open the **Music DJ** editor and find the **Custom Music Library** field. It has
 - Switch on: Custom mode reads audio you uploaded to Game Assets. Game Assets is Marinara's built-in asset library for Game Mode. Use the **Game Assets music folder** field to pick a folder. Type `music` for the whole music library, or a subfolder like `music/combat`. The **Open Folder** button opens that folder on the server machine.
 - Switch off: Custom mode reads a folder on the server device. Use **Select Folder** to open a folder picker on the server machine, or paste the path into the **Music folder on this device** field.
 
+Roleplay and Game chat setup show the same selected source. If you chose a folder on the server device, the chat's Music DJ settings show that saved path and a **Choose Folder** button instead of asking for a Game Assets path.
+
 Playing from a folder outside Game Assets needs local access on the server. If you use Marinara from another device without a password or admin secret, this one feature can be blocked. See [Remote Access: Basic Auth and IP Allowlist](../REMOTE_ACCESS.md).
 
 ## Using the music player

--- a/packages/client/src/components/agents/AgentEditor.tsx
+++ b/packages/client/src/components/agents/AgentEditor.tsx
@@ -155,7 +155,8 @@ function normalizeMusicProvider(settings: Record<string, unknown>): MusicProvide
 }
 
 function normalizeCustomMusicSource(settings: Record<string, unknown>): CustomMusicSource {
-  return settings.customMusicSource === "folder" || settings.localMusicSource === "folder" ? "folder" : "game-assets";
+  const source = settings.customMusicSource ?? settings.localMusicSource;
+  return source === "folder" ? "folder" : "game-assets";
 }
 
 function normalizeExternalMusicFolderInput(value: unknown): string {

--- a/packages/client/src/components/chat/AgentAddSetupFields.tsx
+++ b/packages/client/src/components/chat/AgentAddSetupFields.tsx
@@ -1,5 +1,5 @@
 import { useRef, type ReactNode } from "react";
-import { Check, Loader2, Upload } from "lucide-react";
+import { Check, FolderOpen, Loader2, Upload } from "lucide-react";
 import { useQueries, useQuery } from "@tanstack/react-query";
 import {
   DEFAULT_AGENT_PROMPT_TEMPLATE_ID,
@@ -33,6 +33,7 @@ import {
 
 export type KnowledgeAgentType = "knowledge-retrieval" | "knowledge-router";
 export type MusicProvider = "spotify" | "youtube" | "custom";
+export type CustomMusicSource = "game-assets" | "folder";
 
 export type AgentAddSetupState = {
   directorMode: "natural" | "random";
@@ -63,7 +64,9 @@ export type AgentAddSetupState = {
   spotifyPlaylistName: string | null;
   spotifyArtist: string;
   musicProvider: MusicProvider;
+  customMusicSource: CustomMusicSource;
   customMusicFolder: string;
+  customMusicExternalFolder: string;
   hapticFeedbackEnabled: boolean;
   hapticSensitivity: HapticFeedbackSensitivity;
   hapticIncidentalContact: boolean;
@@ -137,6 +140,14 @@ function normalizeCustomMusicFolder(value: unknown): string {
   const normalized = raw.replace(/^\/+/, "").replace(/\/+$/g, "");
   if (!normalized || normalized.includes("..")) return "music";
   return normalized.startsWith("music") ? normalized : `music/${normalized}`;
+}
+
+export function normalizeCustomMusicSource(settings: Record<string, unknown>): CustomMusicSource {
+  return settings.customMusicSource === "folder" || settings.localMusicSource === "folder" ? "folder" : "game-assets";
+}
+
+export function normalizeCustomMusicExternalFolder(value: unknown): string {
+  return typeof value === "string" ? value.trim() : "";
 }
 
 function normalizeHapticSensitivity(value: unknown): HapticFeedbackSensitivity {
@@ -321,7 +332,11 @@ export function buildInitialAgentAddSetupState({
     spotifyPlaylistName: readString(metadata.spotifyPlaylistName) || null,
     spotifyArtist: readString(metadata.spotifyArtist),
     musicProvider,
+    customMusicSource: normalizeCustomMusicSource(settings),
     customMusicFolder: normalizeCustomMusicFolder(settings.customMusicFolder ?? metadata.customMusicFolder),
+    customMusicExternalFolder: normalizeCustomMusicExternalFolder(
+      settings.customMusicExternalFolder ?? settings.localMusicExternalFolder,
+    ),
     hapticFeedbackEnabled: metadata.enableHapticFeedback === true,
     hapticSensitivity: normalizeHapticSensitivity(metadata.hapticSensitivity),
     hapticIncidentalContact: metadata.hapticIncidentalContact === true,
@@ -362,9 +377,10 @@ export function applyAgentAddSetupToAgentSettings(
   }
   if (agentId === "spotify") {
     next.musicProvider = setup.musicProvider;
+    next.customMusicSource = setup.customMusicSource;
     next.customMusicFolder = normalizeCustomMusicFolder(setup.customMusicFolder);
-    next.enabledTools =
-      setup.musicProvider === "spotify" ? next.enabledTools : [];
+    next.customMusicExternalFolder = normalizeCustomMusicExternalFolder(setup.customMusicExternalFolder);
+    next.enabledTools = setup.musicProvider === "spotify" ? next.enabledTools : [];
   }
   if (agentId === "illustrator") {
     next.includeCharacterAppearance = setup.includeCharacterAppearance;
@@ -1103,6 +1119,19 @@ function MusicDjSetupFields({
     retry: false,
   });
 
+  const selectCustomMusicFolder = async () => {
+    try {
+      const data = await api.post<{ success: boolean; path: string }>("/game-assets/pick-local-music-folder");
+      if (data.success !== true || !data.path) throw new Error("No folder selected.");
+      onChange({ customMusicSource: "folder", customMusicExternalFolder: data.path });
+    } catch (error) {
+      await showAlertDialog({
+        title: "Couldn't Select Music Folder",
+        message: error instanceof Error ? error.message : "The music folder could not be selected.",
+      });
+    }
+  };
+
   return (
     <div className="space-y-2.5 rounded-lg bg-[var(--background)]/65 px-3 py-2.5 ring-1 ring-[var(--border)]">
       <p className="text-[0.625rem] text-[var(--muted-foreground)]">
@@ -1207,20 +1236,67 @@ function MusicDjSetupFields({
           YouTube mode uses the Music DJ agent's saved YouTube connection and embedded player.
         </p>
       ) : (
-        <label className="flex flex-col gap-1 rounded-lg bg-[var(--background)]/75 px-3 py-2 ring-1 ring-[var(--border)]">
-          <SetupLabel>Custom Music Folder</SetupLabel>
-          <input
-            value={value.customMusicFolder}
-            disabled={disabled}
-            onChange={(event) => onChange({ customMusicFolder: event.target.value })}
-            onBlur={() => onChange({ customMusicFolder: normalizeCustomMusicFolder(value.customMusicFolder) })}
-            placeholder="music"
-            className="w-full rounded-lg border border-[var(--border)] bg-[var(--background)] px-2.5 py-2 font-mono text-xs text-[var(--foreground)] placeholder:text-[var(--muted-foreground)]/50 disabled:cursor-not-allowed disabled:opacity-60"
-          />
-          <span className="text-[0.5625rem] text-[var(--muted-foreground)]">
-            Reads local audio from Game Assets, for example <code>music</code> or <code>music/combat</code>.
-          </span>
-        </label>
+        <div className="space-y-2 rounded-lg bg-[var(--background)]/75 px-3 py-2 ring-1 ring-[var(--border)]">
+          <label className="flex flex-col gap-1">
+            <SetupLabel>Custom Music Source</SetupLabel>
+            <select
+              value={value.customMusicSource}
+              disabled={disabled}
+              onChange={(event) => onChange({ customMusicSource: event.target.value as CustomMusicSource })}
+              className="w-full rounded-lg border border-[var(--border)] bg-[var(--background)] px-2.5 py-2 text-xs text-[var(--foreground)] disabled:cursor-not-allowed disabled:opacity-60"
+            >
+              <option value="game-assets">Game Assets</option>
+              <option value="folder">Folder on this device</option>
+            </select>
+          </label>
+
+          {value.customMusicSource === "folder" ? (
+            <div className="flex flex-col gap-1">
+              <SetupLabel>Music Folder on This Device</SetupLabel>
+              <div className="flex flex-col gap-2 sm:flex-row">
+                <input
+                  value={value.customMusicExternalFolder}
+                  disabled={disabled}
+                  onChange={(event) => onChange({ customMusicExternalFolder: event.target.value })}
+                  onBlur={() =>
+                    onChange({
+                      customMusicExternalFolder: normalizeCustomMusicExternalFolder(value.customMusicExternalFolder),
+                    })
+                  }
+                  placeholder="No folder selected"
+                  className="min-w-0 flex-1 rounded-lg border border-[var(--border)] bg-[var(--background)] px-2.5 py-2 font-mono text-xs text-[var(--foreground)] placeholder:text-[var(--muted-foreground)]/50 disabled:cursor-not-allowed disabled:opacity-60"
+                />
+                <button
+                  type="button"
+                  disabled={disabled}
+                  onClick={() => void selectCustomMusicFolder()}
+                  className="inline-flex min-h-9 items-center justify-center gap-1.5 rounded-lg border border-[var(--border)] bg-[var(--muted)] px-3 text-xs font-medium text-[var(--foreground)] transition-colors hover:bg-[var(--accent)] disabled:cursor-not-allowed disabled:opacity-60"
+                >
+                  <FolderOpen size="0.75rem" />
+                  Choose Folder
+                </button>
+              </div>
+              <span className="text-[0.5625rem] text-[var(--muted-foreground)]">
+                Music DJ will choose from audio files in this folder and its subfolders.
+              </span>
+            </div>
+          ) : (
+            <label className="flex flex-col gap-1">
+              <SetupLabel>Game Assets Music Folder</SetupLabel>
+              <input
+                value={value.customMusicFolder}
+                disabled={disabled}
+                onChange={(event) => onChange({ customMusicFolder: event.target.value })}
+                onBlur={() => onChange({ customMusicFolder: normalizeCustomMusicFolder(value.customMusicFolder) })}
+                placeholder="music"
+                className="w-full rounded-lg border border-[var(--border)] bg-[var(--background)] px-2.5 py-2 font-mono text-xs text-[var(--foreground)] placeholder:text-[var(--muted-foreground)]/50 disabled:cursor-not-allowed disabled:opacity-60"
+              />
+              <span className="text-[0.5625rem] text-[var(--muted-foreground)]">
+                Reads local audio from Game Assets, for example <code>music</code> or <code>music/combat</code>.
+              </span>
+            </label>
+          )}
+        </div>
       )}
     </div>
   );

--- a/packages/client/src/components/chat/AgentAddSetupFields.tsx
+++ b/packages/client/src/components/chat/AgentAddSetupFields.tsx
@@ -143,7 +143,8 @@ function normalizeCustomMusicFolder(value: unknown): string {
 }
 
 export function normalizeCustomMusicSource(settings: Record<string, unknown>): CustomMusicSource {
-  return settings.customMusicSource === "folder" || settings.localMusicSource === "folder" ? "folder" : "game-assets";
+  const source = settings.customMusicSource ?? settings.localMusicSource;
+  return source === "folder" ? "folder" : "game-assets";
 }
 
 export function normalizeCustomMusicExternalFolder(value: unknown): string {

--- a/packages/client/src/components/chat/ChatSettingsDrawer.tsx
+++ b/packages/client/src/components/chat/ChatSettingsDrawer.tsx
@@ -42,6 +42,7 @@ import {
   Save,
   FileText,
   FilePlus2,
+  FolderOpen,
   Upload,
   Download,
   Star,
@@ -259,8 +260,11 @@ import {
   applyAgentAddSetupToAgentSettings,
   buildAgentAddMetadataPatch,
   buildInitialAgentAddSetupState,
+  normalizeCustomMusicExternalFolder,
+  normalizeCustomMusicSource,
   type AgentAddSetupState,
   type AgentAddSpriteSubject,
+  type CustomMusicSource,
   type MusicProvider,
 } from "./AgentAddSetupFields";
 import { GameWidgetFileControls, GameWidgetSetupEditor, normalizeGameHudWidgets } from "../game/GameWidgetSetupEditor";
@@ -1331,7 +1335,11 @@ export function ChatSettingsDrawer({
     typeof metadata.gameSpotifyPlaylistId === "string" ? metadata.gameSpotifyPlaylistId : "";
   const gameSpotifyArtist = typeof metadata.gameSpotifyArtist === "string" ? metadata.gameSpotifyArtist : "";
   const musicDjSettings = mergeBuiltInAgentSettings("spotify", agentConfigsByType.get("spotify")?.settings);
+  const customMusicSource = normalizeCustomMusicSource(musicDjSettings);
   const customMusicFolder = normalizeCustomMusicFolder(metadata.customMusicFolder ?? musicDjSettings.customMusicFolder);
+  const customMusicExternalFolder = normalizeCustomMusicExternalFolder(
+    musicDjSettings.customMusicExternalFolder ?? musicDjSettings.localMusicExternalFolder,
+  );
   const gameMusicDjEnabled =
     metadata.gameUseMusicDj === true || gameUseSpotifyMusic || activeAgentIds.includes("youtube");
   const spriteCharacterIds: string[] = Array.isArray(metadata.spriteCharacterIds) ? metadata.spriteCharacterIds : [];
@@ -3387,7 +3395,9 @@ export function ChatSettingsDrawer({
         ...mergeBuiltInAgentSettings("spotify", config?.settings),
         musicProvider: provider,
         musicPlayerSource: provider,
+        customMusicSource,
         customMusicFolder,
+        customMusicExternalFolder,
         enabledTools: provider === "spotify" ? (DEFAULT_AGENT_TOOLS.spotify ?? []) : [],
       };
 
@@ -3406,7 +3416,15 @@ export function ChatSettingsDrawer({
         settings: nextSettings,
       });
     },
-    [agentConfigsByType, createAgent, customMusicFolder, installedAgentManifests, updateAgentConfig],
+    [
+      agentConfigsByType,
+      createAgent,
+      customMusicExternalFolder,
+      customMusicFolder,
+      customMusicSource,
+      installedAgentManifests,
+      updateAgentConfig,
+    ],
   );
 
   const changeMusicDjProvider = useCallback(
@@ -3445,6 +3463,107 @@ export function ChatSettingsDrawer({
       await updateAgentConfig.mutateAsync({ id: config.id, settings: nextSettings });
     },
     [agentConfigsByType, chat.id, updateAgentConfig, updateMeta],
+  );
+
+  const updateCustomMusicLibrary = useCallback(
+    async (patch: { customMusicSource?: CustomMusicSource; customMusicExternalFolder?: string }) => {
+      try {
+        const config = agentConfigsByType.get("spotify") ?? null;
+        if (!config) throw new Error("Music DJ agent settings are missing.");
+        const nextSettings = {
+          ...mergeBuiltInAgentSettings("spotify", config.settings),
+          ...patch,
+        };
+        await updateAgentConfig.mutateAsync({ id: config.id, settings: nextSettings });
+      } catch (error) {
+        await showAlertDialog({
+          title: "Couldn't Update Music Folder",
+          message: error instanceof Error ? error.message : "The custom music folder could not be updated.",
+        });
+      }
+    },
+    [agentConfigsByType, updateAgentConfig],
+  );
+
+  const selectCustomMusicExternalFolder = useCallback(async () => {
+    try {
+      const data = await api.post<{ success: boolean; path: string }>("/game-assets/pick-local-music-folder");
+      if (data.success !== true || !data.path) throw new Error("No folder selected.");
+      await updateCustomMusicLibrary({
+        customMusicSource: "folder",
+        customMusicExternalFolder: data.path,
+      });
+    } catch (error) {
+      await showAlertDialog({
+        title: "Couldn't Select Music Folder",
+        message: error instanceof Error ? error.message : "The music folder could not be selected.",
+      });
+    }
+  }, [updateCustomMusicLibrary]);
+
+  const renderCustomMusicLibrarySettings = (surface: "game" | "roleplay") => (
+    <div className="space-y-2">
+      <label className="flex flex-col gap-1">
+        <span className="text-[0.625rem] font-medium text-[var(--muted-foreground)]">Custom music source</span>
+        <select
+          value={customMusicSource}
+          onChange={(event) =>
+            void updateCustomMusicLibrary({ customMusicSource: event.target.value as CustomMusicSource })
+          }
+          className="w-full rounded-lg border border-[var(--border)] bg-[var(--background)] px-2.5 py-2 text-xs text-[var(--foreground)]"
+        >
+          <option value="game-assets">Game Assets</option>
+          <option value="folder">Folder on this device</option>
+        </select>
+      </label>
+
+      {customMusicSource === "folder" ? (
+        <div className="flex flex-col gap-1">
+          <span className="text-[0.625rem] font-medium text-[var(--muted-foreground)]">
+            Music folder on this device
+          </span>
+          <div className="flex flex-col gap-2 sm:flex-row">
+            <input
+              key={`${chat.id}-${surface}-custom-music-folder-${customMusicExternalFolder}`}
+              defaultValue={customMusicExternalFolder}
+              onBlur={(event) =>
+                void updateCustomMusicLibrary({
+                  customMusicSource: "folder",
+                  customMusicExternalFolder: normalizeCustomMusicExternalFolder(event.target.value),
+                })
+              }
+              placeholder="No folder selected"
+              className="min-w-0 flex-1 rounded-lg border border-[var(--border)] bg-[var(--background)] px-2.5 py-2 font-mono text-xs text-[var(--foreground)] placeholder:text-[var(--muted-foreground)]/50"
+            />
+            <button
+              type="button"
+              onClick={() => void selectCustomMusicExternalFolder()}
+              className="inline-flex min-h-9 items-center justify-center gap-1.5 rounded-lg border border-[var(--border)] bg-[var(--muted)] px-3 text-xs font-medium text-[var(--foreground)] transition-colors hover:bg-[var(--accent)]"
+            >
+              <FolderOpen size="0.75rem" />
+              Choose Folder
+            </button>
+          </div>
+          <span className="text-[0.5625rem] text-[var(--muted-foreground)]">
+            Music DJ will choose from audio files in this folder and its subfolders.
+          </span>
+        </div>
+      ) : (
+        <label className="flex flex-col gap-1">
+          <span className="text-[0.625rem] font-medium text-[var(--muted-foreground)]">Game Assets music folder</span>
+          <input
+            key={`${chat.id}-${surface}-custom-music-${customMusicFolder}`}
+            defaultValue={customMusicFolder}
+            onBlur={(event) => void saveCustomMusicFolder(event.target.value)}
+            placeholder="music"
+            className="w-full rounded-lg border border-[var(--border)] bg-[var(--background)] px-2.5 py-2 font-mono text-xs text-[var(--foreground)] placeholder:text-[var(--muted-foreground)]/50"
+          />
+          <span className="text-[0.5625rem] text-[var(--muted-foreground)]">
+            Reads local audio from Game Assets, for example <code>music</code> or <code>music/combat</code>.
+          </span>
+        </label>
+      )}
+    </div>
   );
 
   const toggleGameMusicDj = useCallback(async () => {
@@ -6521,24 +6640,7 @@ export function ChatSettingsDrawer({
                         </div>
                       )}
 
-                      {gameMusicDjEnabled && musicPlayerSource === "custom" && (
-                        <label className="flex flex-col gap-1">
-                          <span className="text-[0.625rem] font-medium text-[var(--muted-foreground)]">
-                            Custom music folder
-                          </span>
-                          <input
-                            key={`${chat.id}-game-custom-music-${customMusicFolder}`}
-                            defaultValue={customMusicFolder}
-                            onBlur={(event) => void saveCustomMusicFolder(event.target.value)}
-                            placeholder="music"
-                            className="w-full rounded-lg border border-[var(--border)] bg-[var(--background)] px-2.5 py-2 font-mono text-xs text-[var(--foreground)] placeholder:text-[var(--muted-foreground)]/50"
-                          />
-                          <span className="text-[0.5625rem] text-[var(--muted-foreground)]">
-                            Reads local audio from Game Assets, for example <code>music</code> or{" "}
-                            <code>music/combat</code>.
-                          </span>
-                        </label>
-                      )}
+                      {gameMusicDjEnabled && musicPlayerSource === "custom" && renderCustomMusicLibrarySettings("game")}
                     </AgentSettingsCard>
                   )}
 
@@ -7395,31 +7497,16 @@ export function ChatSettingsDrawer({
                             </>
                           )}
 
-                          {musicPlayerSource === "custom" && (
-                            <label className="flex flex-col gap-1">
-                              <span className="text-[0.625rem] font-medium text-[var(--muted-foreground)]">
-                                Custom music folder
-                              </span>
-                              <input
-                                key={`${chat.id}-roleplay-custom-music-${customMusicFolder}`}
-                                defaultValue={customMusicFolder}
-                                onBlur={(event) => void saveCustomMusicFolder(event.target.value)}
-                                placeholder="music"
-                                className="w-full rounded-lg border border-[var(--border)] bg-[var(--background)] px-2.5 py-2 font-mono text-xs text-[var(--foreground)] placeholder:text-[var(--muted-foreground)]/50"
-                              />
-                              <span className="text-[0.5625rem] text-[var(--muted-foreground)]">
-                                Reads local audio from Game Assets, for example <code>music</code> or{" "}
-                                <code>music/combat</code>.
-                              </span>
-                            </label>
-                          )}
+                          {musicPlayerSource === "custom" && renderCustomMusicLibrarySettings("roleplay")}
 
                           <p className="text-[0.625rem] text-[var(--muted-foreground)]">
                             {musicPlayerSource === "spotify"
                               ? "Roleplay DJ queues several fitting tracks when it changes music."
                               : musicPlayerSource === "youtube"
                                 ? "YouTube mode uses the Music DJ agent's YouTube connection and embedded player."
-                                : "Custom mode picks from local Game Assets music and plays it in Marinara Engine."}
+                                : customMusicSource === "folder"
+                                  ? "Custom mode picks from the selected device folder and plays it in Marinara Engine."
+                                  : "Custom mode picks from local Game Assets music and plays it in Marinara Engine."}
                           </p>
                         </AgentSettingsCard>
                       )}

--- a/packages/client/src/components/chat/LocalMusicPlayer.tsx
+++ b/packages/client/src/components/chat/LocalMusicPlayer.tsx
@@ -10,6 +10,7 @@ import {
 } from "react";
 import { encodeAssetPath } from "../game-assets/encode-asset-path";
 import { MusicSourceButton, MusicSourceGlyph } from "../music/MusicSourceButton";
+import { api } from "../../lib/api-client";
 import { cn } from "../../lib/utils";
 import { useAgentStore } from "../../stores/agent.store";
 import { useUIStore } from "../../stores/ui.store";
@@ -90,11 +91,25 @@ function getMobileExpandedPanelStyle(position: { x: number; y: number }): CSSPro
   };
 }
 
-function getTrackUrl(path: string) {
-  if (path.startsWith("local-music:")) {
-    return `/api/game-assets/local-music-file/${encodeURIComponent(path.slice("local-music:".length))}`;
+async function loadTrackSource(path: string): Promise<{ url: string; objectUrl: boolean }> {
+  if (!path.startsWith("local-music:")) {
+    return { url: `/api/game-assets/file/${encodeAssetPath(path)}`, objectUrl: false };
   }
-  return `/api/game-assets/file/${encodeAssetPath(path)}`;
+
+  const encodedPath = encodeURIComponent(path.slice("local-music:".length));
+  const response = await api.raw(`/game-assets/local-music-file?path=${encodedPath}`);
+  if (!response.ok) {
+    const payload = (await response.json().catch(() => null)) as { error?: unknown; message?: unknown } | null;
+    const detail =
+      typeof payload?.message === "string"
+        ? payload.message
+        : typeof payload?.error === "string"
+          ? payload.error
+          : response.statusText;
+    throw new Error(detail || `Custom music could not be loaded (${response.status}).`);
+  }
+
+  return { url: URL.createObjectURL(await response.blob()), objectUrl: true };
 }
 
 function LocalPlayerIcon({ icon: Icon }: { icon: LucideIcon }) {
@@ -117,6 +132,8 @@ export function LocalMusicPlayer({ mobile = false }: { mobile?: boolean } = {}) 
   const desktopViewport = useMediaQuery("(min-width: 768px)");
 
   const audioRef = useRef<HTMLAudioElement | null>(null);
+  const objectUrlRef = useRef<string | null>(null);
+  const sourceLoadIdRef = useRef(0);
   const lastNonceRef = useRef(0);
   const prevVolumeRef = useRef(70);
   const dragRef = useRef<{
@@ -133,6 +150,12 @@ export function LocalMusicPlayer({ mobile = false }: { mobile?: boolean } = {}) 
 
   const active = musicPlayerActive && (mobile || desktopViewport);
 
+  const releaseObjectUrl = useCallback(() => {
+    if (!objectUrlRef.current) return;
+    URL.revokeObjectURL(objectUrlRef.current);
+    objectUrlRef.current = null;
+  }, []);
+
   useEffect(() => {
     if (!active) return;
     if (!localMusicPlay) return;
@@ -142,21 +165,36 @@ export function LocalMusicPlayer({ mobile = false }: { mobile?: boolean } = {}) 
     const audio = audioRef.current;
     if (!audio) return;
 
-    const src = getTrackUrl(localMusicPlay.path);
+    const sourceLoadId = ++sourceLoadIdRef.current;
+    audio.pause();
+    audio.removeAttribute("src");
+    audio.load();
+    releaseObjectUrl();
     setError(null);
     setNowPlaying({ path: localMusicPlay.path, title: localMusicPlay.title, mood: localMusicPlay.mood });
-    setPaused(false);
-    audio.src = src;
-    audio.loop = true;
-    audio.volume = Math.max(0, Math.min(1, playerVolume / 100));
-    audio
-      .play()
-      .then(() => setPaused(false))
+    setPaused(true);
+
+    void loadTrackSource(localMusicPlay.path)
+      .then(async (source) => {
+        if (sourceLoadId !== sourceLoadIdRef.current) {
+          if (source.objectUrl) URL.revokeObjectURL(source.url);
+          return;
+        }
+
+        releaseObjectUrl();
+        if (source.objectUrl) objectUrlRef.current = source.url;
+        audio.src = source.url;
+        audio.loop = true;
+        audio.volume = Math.max(0, Math.min(1, playerVolume / 100));
+        await audio.play();
+        if (sourceLoadId === sourceLoadIdRef.current) setPaused(false);
+      })
       .catch((err) => {
+        if (sourceLoadId !== sourceLoadIdRef.current) return;
         setPaused(true);
         setError(err instanceof Error ? err.message : "Local playback failed");
       });
-  }, [active, localMusicPlay, playerVolume]);
+  }, [active, localMusicPlay, playerVolume, releaseObjectUrl]);
 
   useEffect(() => {
     if (localMusicVolume != null) setPlayerVolume(localMusicVolume);
@@ -172,10 +210,20 @@ export function LocalMusicPlayer({ mobile = false }: { mobile?: boolean } = {}) 
 
   useEffect(() => {
     if (active) return;
+    sourceLoadIdRef.current += 1;
     audioRef.current?.pause();
+    releaseObjectUrl();
     setNowPlaying(null);
     setPaused(true);
-  }, [active]);
+  }, [active, releaseObjectUrl]);
+
+  useEffect(
+    () => () => {
+      sourceLoadIdRef.current += 1;
+      releaseObjectUrl();
+    },
+    [releaseObjectUrl],
+  );
 
   const togglePlay = () => {
     const audio = audioRef.current;
@@ -192,8 +240,13 @@ export function LocalMusicPlayer({ mobile = false }: { mobile?: boolean } = {}) 
   };
 
   const close = () => {
-    audioRef.current?.pause();
-    if (audioRef.current) audioRef.current.currentTime = 0;
+    sourceLoadIdRef.current += 1;
+    if (audioRef.current) {
+      audioRef.current.pause();
+      audioRef.current.removeAttribute("src");
+      audioRef.current.load();
+    }
+    releaseObjectUrl();
     setNowPlaying(null);
     setPaused(true);
     setError(null);

--- a/packages/server/src/routes/game-assets.routes.ts
+++ b/packages/server/src/routes/game-assets.routes.ts
@@ -524,12 +524,12 @@ export async function gameAssetsRoutes(app: FastifyInstance) {
     return reply.header("Content-Type", mime).header("Cache-Control", "public, max-age=604800").send(stream);
   });
 
-  // ── GET /game-assets/local-music-file/:encoded ──
+  // ── GET /game-assets/local-music-file?path=:encoded ──
   // Serves an audio file selected through the local music folder picker.
-  app.get("/local-music-file/:encoded", async (req, reply) => {
+  app.get("/local-music-file", async (req, reply) => {
     if (!requirePrivilegedAccess(req, reply, { feature: "Custom music folder picker" })) return;
 
-    const { encoded } = (req.params as { encoded?: string }) ?? {};
+    const { path: encoded } = (req.query as { path?: string }) ?? {};
     if (!encoded) {
       return reply.status(400).send({ error: "Missing music file" });
     }

--- a/packages/server/src/routes/generate.routes.ts
+++ b/packages/server/src/routes/generate.routes.ts
@@ -3184,6 +3184,7 @@ export async function generateRoutes(app: FastifyInstance) {
         }
 
         const illustratorAgentForInterval = resolvedAgents.find((a) => a.type === "illustrator");
+        const createsAssistantMessage = !input.impersonate && !input.regenerateMessageId && !input.continueMessageId;
         if (
           illustratorAgentForInterval &&
           (await shouldSkipAgentByAssistantInterval({
@@ -3193,6 +3194,7 @@ export async function generateRoutes(app: FastifyInstance) {
             settings: illustratorAgentForInterval.settings,
             fallbackInterval: (getDefaultBuiltInAgentSettings("illustrator").runInterval as number) ?? 5,
             messages: allChatMessages,
+            countUpcomingAssistantMessage: createsAssistantMessage,
           }))
         ) {
           resolvedAgents.splice(resolvedAgents.indexOf(illustratorAgentForInterval), 1);
@@ -3586,6 +3588,7 @@ export async function generateRoutes(app: FastifyInstance) {
               settings: ceaAgent.settings,
               fallbackInterval: (getDefaultBuiltInAgentSettings("card-evolution-auditor").runInterval as number) ?? 8,
               messages: allChatMessages,
+              countUpcomingAssistantMessage: createsAssistantMessage,
             })
           ) {
             resolvedAgents.splice(resolvedAgents.indexOf(ceaAgent), 1);
@@ -3603,6 +3606,7 @@ export async function generateRoutes(app: FastifyInstance) {
               settings: amkAgent.settings,
               fallbackInterval: (getDefaultBuiltInAgentSettings("about-me-keeper").runInterval as number) ?? 8,
               messages: allChatMessages,
+              countUpcomingAssistantMessage: createsAssistantMessage,
             })
           ) {
             resolvedAgents.splice(resolvedAgents.indexOf(amkAgent), 1);

--- a/packages/server/src/services/agents/agent-executor.ts
+++ b/packages/server/src/services/agents/agent-executor.ts
@@ -97,7 +97,8 @@ function getMusicProvider(settings: Record<string, unknown> | null | undefined):
 }
 
 function getCustomMusicSource(settings: Record<string, unknown> | null | undefined): CustomMusicSource {
-  return settings?.customMusicSource === "folder" || settings?.localMusicSource === "folder" ? "folder" : "game-assets";
+  const source = settings?.customMusicSource ?? settings?.localMusicSource;
+  return source === "folder" ? "folder" : "game-assets";
 }
 
 function normalizeAgentContextWrapFormat(value: unknown): WrapFormat {

--- a/packages/server/src/services/generation/agent-cadence.ts
+++ b/packages/server/src/services/generation/agent-cadence.ts
@@ -23,6 +23,7 @@ export async function shouldSkipAgentByAssistantInterval({
   settings,
   fallbackInterval,
   messages,
+  countUpcomingAssistantMessage = true,
 }: {
   agentsStore: AgentsStore;
   chatId: string;
@@ -30,6 +31,7 @@ export async function shouldSkipAgentByAssistantInterval({
   settings: unknown;
   fallbackInterval: number;
   messages: ChatMessageLike[];
+  countUpcomingAssistantMessage?: boolean;
 }): Promise<boolean> {
   const runInterval = resolveAgentRunInterval(settings, fallbackInterval);
   if (runInterval <= 1) return false;
@@ -40,5 +42,6 @@ export async function shouldSkipAgentByAssistantInterval({
   const lastRunIdx = messages.findIndex((message) => message.id === lastRun.messageId);
   if (lastRunIdx < 0) return false;
   const assistantMessagesSince = messages.slice(lastRunIdx + 1).filter((message) => message.role === "assistant");
-  return assistantMessagesSince.length + 1 < runInterval;
+  const upcomingAssistantMessages = countUpcomingAssistantMessage ? 1 : 0;
+  return assistantMessagesSince.length + upcomingAssistantMessages < runInterval;
 }

--- a/scripts/regressions/open-issues.regression.ts
+++ b/scripts/regressions/open-issues.regression.ts
@@ -746,9 +746,17 @@ const transcriptWindowControlsSource = readFileSync(
   new URL("../../packages/client/src/components/chat/TranscriptWindowControls.tsx", import.meta.url),
   "utf8",
 );
+const localMusicPlayerSource = readFileSync(
+  new URL("../../packages/client/src/components/chat/LocalMusicPlayer.tsx", import.meta.url),
+  "utf8",
+);
 const globalStyles = readFileSync(new URL("../../packages/client/src/styles/globals.css", import.meta.url), "utf8");
 const galleryRoutesSource = readFileSync(
   new URL("../../packages/server/src/routes/gallery.routes.ts", import.meta.url),
+  "utf8",
+);
+const gameAssetsRoutesSource = readFileSync(
+  new URL("../../packages/server/src/routes/game-assets.routes.ts", import.meta.url),
   "utf8",
 );
 const conversationSelfieRuntimeSource = readFileSync(
@@ -759,6 +767,13 @@ assert.match(appSource, /--marinara-app-accent-static-gradient/u);
 assert.match(appSource, /swipeDirections=\{\["left", "right", "top"\]\}/u);
 assert.doesNotMatch(agentEditorSource, /fetch\(["']\/api\/game-assets\/pick-local-music-folder/u);
 assert.match(agentEditorSource, /api\.post<[^>]+>\(["']\/game-assets\/pick-local-music-folder["']\)/u);
+assert.match(localMusicPlayerSource, /api\.raw\(`\/game-assets\/local-music-file\?path=\$\{encodedPath\}`\)/u);
+assert.match(localMusicPlayerSource, /URL\.createObjectURL\(await response\.blob\(\)\)/u);
+assert.match(localMusicPlayerSource, /URL\.revokeObjectURL/u);
+assert.doesNotMatch(localMusicPlayerSource, /return `\/api\/game-assets\/local-music-file/u);
+assert.match(gameAssetsRoutesSource, /app\.get\("\/local-music-file"/u);
+assert.match(gameAssetsRoutesSource, /const \{ path: encoded \} = \(req\.query as \{ path\?: string \}\)/u);
+assert.doesNotMatch(gameAssetsRoutesSource, /app\.get\("\/local-music-file\/:encoded"/u);
 assert.match(characterEditorSource, /avatar preview/u);
 assert.match(characterEditorSource, /getAvatarCropStyle/u);
 assert.match(

--- a/scripts/regressions/prompt.regression.ts
+++ b/scripts/regressions/prompt.regression.ts
@@ -213,11 +213,46 @@ import {
   executeAgentBatch,
   renderAgentPromptTemplate,
 } from "../../packages/server/src/services/agents/agent-executor.js";
+import { shouldSkipAgentByAssistantInterval } from "../../packages/server/src/services/generation/agent-cadence.js";
 import type { ResolvedAgent } from "../../packages/server/src/services/agents/agent-pipeline.js";
 import { loadGameVideoPrompt } from "../../packages/server/src/services/video/game-video-prompt.js";
 import { loadGameStoryboardImagePrompt } from "../../packages/server/src/services/image/game-storyboard-image-prompt.js";
 import { formatAgentFailuresToast, toAgentFailure } from "../../packages/client/src/lib/agent-failures.js";
 import { formatGenerationParameterError } from "../../packages/client/src/lib/generation-parameter-errors.js";
+
+const assistantCadenceMessages = [
+  { id: "illustrator-anchor", role: "assistant" },
+  { id: "accepted-user-turn", role: "user" },
+  { id: "accepted-assistant-turn", role: "assistant" },
+];
+const illustratorCadenceStore = {
+  getLastSuccessfulRunByType: async () => ({ messageId: "illustrator-anchor" }),
+};
+assert.equal(
+  await shouldSkipAgentByAssistantInterval({
+    agentsStore: illustratorCadenceStore,
+    chatId: "roleplay-cadence",
+    agentType: "illustrator",
+    settings: { runInterval: 2 },
+    fallbackInterval: 5,
+    messages: assistantCadenceMessages,
+  }),
+  false,
+  "a fresh assistant message should satisfy the next Illustrator interval",
+);
+assert.equal(
+  await shouldSkipAgentByAssistantInterval({
+    agentsStore: illustratorCadenceStore,
+    chatId: "roleplay-cadence",
+    agentType: "illustrator",
+    settings: { runInterval: 2 },
+    fallbackInterval: 5,
+    messages: assistantCadenceMessages,
+    countUpcomingAssistantMessage: false,
+  }),
+  true,
+  "a swipe or continuation should not count as a new accepted assistant message",
+);
 import {
   compactVideoPromptText,
   getSceneVideoPromptLimits,

--- a/scripts/regressions/prompt.regression.ts
+++ b/scripts/regressions/prompt.regression.ts
@@ -219,6 +219,7 @@ import { loadGameVideoPrompt } from "../../packages/server/src/services/video/ga
 import { loadGameStoryboardImagePrompt } from "../../packages/server/src/services/image/game-storyboard-image-prompt.js";
 import { formatAgentFailuresToast, toAgentFailure } from "../../packages/client/src/lib/agent-failures.js";
 import { formatGenerationParameterError } from "../../packages/client/src/lib/generation-parameter-errors.js";
+import { normalizeCustomMusicSource } from "../../packages/client/src/components/chat/AgentAddSetupFields.js";
 
 const assistantCadenceMessages = [
   { id: "illustrator-anchor", role: "assistant" },
@@ -228,6 +229,16 @@ const assistantCadenceMessages = [
 const illustratorCadenceStore = {
   getLastSuccessfulRunByType: async () => ({ messageId: "illustrator-anchor" }),
 };
+assert.strictEqual(
+  normalizeCustomMusicSource({ customMusicSource: "game-assets", localMusicSource: "folder" }),
+  "game-assets",
+  "the current custom music source should override stale legacy settings",
+);
+assert.strictEqual(
+  normalizeCustomMusicSource({ localMusicSource: "folder" }),
+  "folder",
+  "legacy custom music source settings should remain supported as a fallback",
+);
 assert.equal(
   await shouldSkipAgentByAssistantInterval({
     agentsStore: illustratorCadenceStore,


### PR DESCRIPTION
## Linked issue

Closes #3820
Closes #3821
Closes #3827

## Why this change

- Roleplay swipes and continuations reuse an existing assistant message, but Illustrator cadence treated each generation as a new accepted reply. This could make Illustrator eligible and reset its interval too early.
- Music DJ already saves and reads a device-folder source, but Roleplay and Game chat surfaces only showed the Game Assets path. Users could not see the folder they had configured.
- Custom-folder songs were encoded into a route parameter that commonly exceeded Fastify's 100-character limit. The audio element also bypassed Marinara's authenticated API client, so the route could return 404 or 403 JSON that browsers reported as an unsupported media source.

## What changed

- Count an upcoming assistant message for interval agents only when generation will create a new assistant message. Swipes, continuations, and impersonation no longer advance the interval.
- Preserve Music DJ's `customMusicSource` and `customMusicExternalFolder` through chat agent setup.
- Show the active Game Assets or device-folder source in Roleplay and Game settings, including the saved path and existing privileged folder picker.
- Send long encoded device paths as a query parameter and fetch selected songs through the authenticated API client before playback, without weakening the privileged file route.
- Revoke temporary browser media URLs when a track is replaced, stopped, or the player unmounts.
- Document accepted-turn Illustrator cadence and the mirrored Music DJ source behavior.
- Add regression coverage for new-message versus swipe/continuation cadence and authenticated custom-folder playback wiring.

## Validation

- [ ] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed `CONTRIBUTING.md`

### Manual verification notes

- Automated: `pnpm check` passed on the final diff.
- Automated: `pnpm regression:issues` passed, including the custom-folder playback wiring regression.
- Automated: `pnpm regression:prompt` passed, including the new cadence regression.
- Automated: client `tsc --noEmit`, server lint, and `git diff --check` passed.
- Direct route proof: a >100-character encoded song path returns 403 without the required admin header and returns the MP3 with `audio/mpeg` when authenticated.
- The isolated client preview built and started against the local server. Browser click-through was not completed because the in-app browser controller failed to connect; manually verify Roleplay and Game Music DJ settings and one device-folder song before merge.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Version/release files updated (only if this PR includes a version bump)

Updated `docs/media/illustrator-agent.md`, `docs/media/music.md`, and `docs/game/game-assets.md`.

## UI evidence (if applicable)

Not captured. Manually verify the Custom source selector, saved device path, Choose Folder action, and device-folder playback in Roleplay and Game on desktop and mobile.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Music DJ now supports selecting music from Game Assets or a folder on the device.
  - Saved music sources are displayed in chat settings, with a **Choose Folder** option for local folders.
  - Local music playback is more reliable when loading selected tracks.

- **Bug Fixes**
  - Improved timing for agents that act after a set number of accepted assistant replies.
  - Clarified that Illustrator skips unworthy moments and saves generated images to the Gallery.

- **Documentation**
  - Updated setup guidance for Music DJ and Illustrator behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->