### PR TITLE
Harden host folder and Giphy failure paths

### DIFF
--- a/packages/client/src/components/agents/AgentEditor.tsx
+++ b/packages/client/src/components/agents/AgentEditor.tsx
@@ -8,6 +8,7 @@ import { toast } from "sonner";
 import { useUIStore } from "../../stores/ui.store";
 import { showConfirmDialog } from "../../lib/app-dialogs";
 import { api } from "../../lib/api-client";
+import { HostDeviceFileManagerError } from "../../lib/host-device";
 import {
   agentKeys,
   useAgentConfigs,
@@ -16,6 +17,7 @@ import {
   type AgentConfigRow,
 } from "../../hooks/use-agents";
 import { useConnections } from "../../hooks/use-connections";
+import { useOpenGameAssetsFolder } from "../../hooks/use-game-assets";
 import {
   isCustomToolSelectable,
   useCustomToolCapabilities,
@@ -429,6 +431,7 @@ export function AgentEditor() {
   const { data: customToolCapabilities } = useCustomToolCapabilities();
   const updateAgent = useUpdateAgent();
   const createAgent = useCreateAgent();
+  const openGameAssetsFolder = useOpenGameAssetsFolder();
   const qc = useQueryClient();
   const deleteAgent = useDeleteAgent();
   const connectionIndexRef = useRef<{
@@ -1328,19 +1331,16 @@ export function AgentEditor() {
     [localEnabledTools.length, setMusicPlayerSource],
   );
 
-  const handleOpenCustomMusicFolder = useCallback(async () => {
+  const handleOpenCustomMusicFolder = async () => {
     const subfolder = normalizeCustomMusicFolderInput(localCustomMusicFolder);
     try {
-      await fetch("/api/game-assets/open-folder", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ subfolder }),
-      });
+      await openGameAssetsFolder.mutateAsync(subfolder);
       toast.success(`Opened Game Assets/${subfolder}`);
-    } catch {
-      toast.error("Could not open the Custom music folder.");
+    } catch (error) {
+      if (error instanceof HostDeviceFileManagerError) return;
+      toast.error(error instanceof Error ? error.message : "Could not open the Custom music folder.");
     }
-  }, [localCustomMusicFolder]);
+  };
 
   const handleSelectCustomMusicFolder = useCallback(async () => {
     try {

--- a/packages/client/src/components/agents/AgentEditor.tsx
+++ b/packages/client/src/components/agents/AgentEditor.tsx
@@ -7,7 +7,7 @@ import { useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
 import { useUIStore } from "../../stores/ui.store";
 import { showConfirmDialog } from "../../lib/app-dialogs";
-import { api } from "../../lib/api-client";
+import { api, getPrivilegedActionErrorMessage } from "../../lib/api-client";
 import { HostDeviceFileManagerError } from "../../lib/host-device";
 import {
   agentKeys,
@@ -1338,7 +1338,7 @@ export function AgentEditor() {
       toast.success(`Opened Game Assets/${subfolder}`);
     } catch (error) {
       if (error instanceof HostDeviceFileManagerError) return;
-      toast.error(error instanceof Error ? error.message : "Could not open the Custom music folder.");
+      toast.error(getPrivilegedActionErrorMessage(error, "Could not open the Custom music folder."));
     }
   };
 

--- a/packages/client/src/components/panels/SettingsPanel.tsx
+++ b/packages/client/src/components/panels/SettingsPanel.tsx
@@ -146,7 +146,7 @@ import {
   type FolderPackageImportEntry,
   type PackageTextFile,
 } from "../../lib/folder-package-transfer";
-import { HOST_DEVICE_FILE_MANAGER_MESSAGE } from "../../lib/host-device";
+import { HOST_DEVICE_FILE_MANAGER_MESSAGE, HostDeviceFileManagerError, isHostDeviceBrowser } from "../../lib/host-device";
 import { isZipFile as isZipArchiveFile, readTextFilesFromZip } from "../../lib/read-zip-text";
 
 type CustomFontFace = {
@@ -3317,7 +3317,7 @@ function GameAssetsSettings() {
   const handleOpenGameAssetFolder = (subfolder: string) => {
     openGameAssetsFolder.mutate(subfolder, {
       onError: (error) => {
-        if (error instanceof Error && error.message === HOST_DEVICE_FILE_MANAGER_MESSAGE) return;
+        if (error instanceof HostDeviceFileManagerError) return;
         toast.error("Failed to open game assets folder.");
       },
     });
@@ -3515,6 +3515,17 @@ function AppearanceSettings() {
   const activeChatId = useChatStore((s) => s.activeChatId);
   const updateMeta = useUpdateChatMetadata();
   const setActiveSyncedTheme = useSetActiveTheme();
+  const handleOpenFontsFolder = async () => {
+    if (!isHostDeviceBrowser()) {
+      toast.info(HOST_DEVICE_FILE_MANAGER_MESSAGE);
+      return;
+    }
+    try {
+      await api.post("/fonts/open-folder");
+    } catch (error) {
+      toast.error(getPrivilegedActionErrorMessage(error, "Could not open fonts folder."));
+    }
+  };
   const handleAppBackgroundColorChange = useCallback(
     (color: string) => {
       const normalized = color.trim();
@@ -3955,7 +3966,7 @@ function AppearanceSettings() {
               </p>
             )}
             <button
-              onClick={() => api.post("/fonts/open-folder").catch(() => {})}
+              onClick={handleOpenFontsFolder}
               className={cn(SETTINGS_BUTTON_CLASS, "mt-1 self-start")}
             >
               <FolderOpen size="0.75rem" />

--- a/packages/client/src/components/panels/SettingsPanel.tsx
+++ b/packages/client/src/components/panels/SettingsPanel.tsx
@@ -3318,7 +3318,7 @@ function GameAssetsSettings() {
     openGameAssetsFolder.mutate(subfolder, {
       onError: (error) => {
         if (error instanceof HostDeviceFileManagerError) return;
-        toast.error("Failed to open game assets folder.");
+        toast.error(getPrivilegedActionErrorMessage(error, "Failed to open game assets folder."));
       },
     });
   };

--- a/packages/client/src/hooks/use-game-assets.ts
+++ b/packages/client/src/hooks/use-game-assets.ts
@@ -4,7 +4,7 @@
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { api } from "../lib/api-client";
 import { encodeAssetPath } from "../components/game-assets/encode-asset-path";
-import { HOST_DEVICE_FILE_MANAGER_MESSAGE, isHostDeviceBrowser } from "../lib/host-device";
+import { HOST_DEVICE_FILE_MANAGER_MESSAGE, HostDeviceFileManagerError, isHostDeviceBrowser } from "../lib/host-device";
 import { toast } from "sonner";
 
 /**
@@ -161,7 +161,7 @@ export function useOpenGameAssetsFolder() {
     mutationFn: (subfolder?: string) => {
       if (!isHostDeviceBrowser()) {
         toast.info(HOST_DEVICE_FILE_MANAGER_MESSAGE);
-        throw new Error(HOST_DEVICE_FILE_MANAGER_MESSAGE);
+        throw new HostDeviceFileManagerError();
       }
       return api.post("/game-assets/open-folder", { subfolder });
     },

--- a/packages/client/src/hooks/use-scene-analysis.ts
+++ b/packages/client/src/hooks/use-scene-analysis.ts
@@ -16,11 +16,10 @@ import type {
 } from "@marinara-engine/shared";
 import { useUIStore } from "../stores/ui.store";
 
-type AnalyzeSceneInput = SceneAnalysisRequest & {
+type AnalyzeSceneInput = Omit<SceneAnalysisRequest, "debugMode"> & {
   /** When provided, uses a regular connection instead of sidecar. */
   chatId?: string;
   connectionId?: string;
-  streaming?: boolean;
 };
 
 async function analyzeScene(input: AnalyzeSceneInput): Promise<SceneAnalysis> {

--- a/packages/client/src/lib/host-device.ts
+++ b/packages/client/src/lib/host-device.ts
@@ -16,3 +16,10 @@ export function isHostDeviceBrowser(): boolean {
 
 export const HOST_DEVICE_FILE_MANAGER_MESSAGE =
   "System folders can only be opened from the device hosting Marinara Engine.";
+
+export class HostDeviceFileManagerError extends Error {
+  constructor() {
+    super(HOST_DEVICE_FILE_MANAGER_MESSAGE);
+    this.name = "HostDeviceFileManagerError";
+  }
+}

--- a/packages/server/src/lib/open-folder-in-file-manager.ts
+++ b/packages/server/src/lib/open-folder-in-file-manager.ts
@@ -1,0 +1,22 @@
+import { spawn } from "child_process";
+import { platform } from "os";
+
+/** Open a folder using the host platform's native file manager. */
+export function openFolderInFileManager(path: string): Promise<void> {
+  const os = platform();
+  const cmd = os === "darwin" ? "open" : os === "win32" ? "explorer" : "xdg-open";
+
+  return new Promise((resolve, reject) => {
+    const child = spawn(cmd, [path], {
+      detached: true,
+      stdio: "ignore",
+      windowsHide: true,
+    });
+
+    child.once("error", reject);
+    child.once("spawn", () => {
+      child.unref();
+      resolve();
+    });
+  });
+}

--- a/packages/server/src/routes/fonts.routes.ts
+++ b/packages/server/src/routes/fonts.routes.ts
@@ -6,9 +6,9 @@ import { logger } from "../lib/logger.js";
 import { existsSync, mkdirSync, createReadStream } from "fs";
 import { readdir, readFile, rename, unlink, writeFile } from "fs/promises";
 import { join, extname, basename } from "path";
-import { execFile } from "child_process";
-import { platform } from "os";
 import { DATA_DIR } from "../utils/data-dir.js";
+import { requirePrivilegedAccess } from "../middleware/privileged-gate.js";
+import { openFolderInFileManager } from "../lib/open-folder-in-file-manager.js";
 
 const FONTS_DIR = join(DATA_DIR, "fonts");
 const FONT_METADATA_FILE = join(FONTS_DIR, "font-metadata.json");
@@ -371,13 +371,15 @@ export async function fontsRoutes(app: FastifyInstance) {
   });
 
   /** Open the data/fonts folder in the native file explorer */
-  app.post("/open-folder", async (_req, reply) => {
+  app.post("/open-folder", async (req, reply) => {
+    if (!requirePrivilegedAccess(req, reply, { loopbackOnly: true, feature: "Fonts folder opening" })) return;
     ensureDir();
-    const os = platform();
-    const cmd = os === "darwin" ? "open" : os === "win32" ? "explorer" : "xdg-open";
-    execFile(cmd, [FONTS_DIR], (err) => {
-      if (err) logger.warn(err, "Could not open fonts folder");
-    });
+    try {
+      await openFolderInFileManager(FONTS_DIR);
+    } catch (err) {
+      logger.warn(err, "Could not open fonts folder");
+      return reply.status(500).send({ error: "Could not open fonts folder" });
+    }
     return reply.send({ ok: true, path: FONTS_DIR });
   });
 

--- a/packages/server/src/routes/game-assets.routes.ts
+++ b/packages/server/src/routes/game-assets.routes.ts
@@ -28,6 +28,7 @@ import { GAME_ASSETS_DIR, buildAssetManifest, getAssetManifest } from "../servic
 import { folderContainsBundledGameAssets, isBundledGameAsset } from "../services/game/native-game-assets.js";
 import { requirePrivilegedAccess } from "../middleware/privileged-gate.js";
 import { assertInsideDir } from "../utils/security.js";
+import { openFolderInFileManager } from "../lib/open-folder-in-file-manager.js";
 
 const META_PATH = join(GAME_ASSETS_DIR, "meta.json");
 
@@ -700,17 +701,19 @@ export async function gameAssetsRoutes(app: FastifyInstance) {
 
   // ── POST /game-assets/open-folder ──
   app.post("/open-folder", async (req, reply) => {
+    if (!requirePrivilegedAccess(req, reply, { loopbackOnly: true, feature: "Game assets folder opening" })) return;
     const { subfolder } = (req.body as { subfolder?: string }) ?? {};
     let target = GAME_ASSETS_DIR;
     if (subfolder && isSafePath(subfolder)) {
       target = join(GAME_ASSETS_DIR, subfolder);
     }
     if (!existsSync(target)) mkdirSync(target, { recursive: true });
-    const os = platform();
-    const cmd = os === "darwin" ? "open" : os === "win32" ? "explorer" : "xdg-open";
-    execFile(cmd, [target], (err) => {
-      if (err) logger.warn(err, "Could not open game assets folder");
-    });
+    try {
+      await openFolderInFileManager(target);
+    } catch (err) {
+      logger.warn(err, "Could not open game assets folder");
+      return reply.status(500).send({ error: "Could not open game assets folder" });
+    }
     return reply.send({ ok: true, path: target });
   });
 

--- a/packages/server/src/routes/gifs.routes.ts
+++ b/packages/server/src/routes/gifs.routes.ts
@@ -27,11 +27,12 @@ const giphyItemSchema = z
       original: giphyImageAssetSchema.optional(),
     }),
   })
-  .transform(({ id, title, images }) => {
+  .transform(({ id, title, images }, ctx) => {
     const preview = images.fixed_height_small?.url ?? images.fixed_height?.url;
     const url = images.original?.url ?? images.fixed_height?.url;
     if (!preview || !url) {
-      throw new Error("Invalid Giphy response body");
+      ctx.addIssue({ code: "custom", message: "Giphy item has no usable image URL" });
+      return z.NEVER;
     }
 
     const width = Number(images.fixed_height?.width);
@@ -47,7 +48,12 @@ const giphyItemSchema = z
   });
 
 const giphyResponseSchema = z.object({
-  data: z.array(giphyItemSchema),
+  data: z.array(z.unknown()).transform((items) =>
+    items.flatMap((item) => {
+      const result = giphyItemSchema.safeParse(item);
+      return result.success ? [result.data] : [];
+    }),
+  ),
   pagination: z.object({
     offset: z.number().finite(),
     count: z.number().finite(),
@@ -98,7 +104,7 @@ export async function gifsRoutes(app: FastifyInstance) {
       return { results, next: hasMore ? String(nextOffset) : "" };
     } catch (error) {
       const timedOut = error instanceof DOMException && error.name === "TimeoutError";
-      req.log.error({ kind: timedOut ? "timeout" : "failure" }, timedOut ? "Giphy API request timed out" : "Giphy API request failed");
+      req.log.error(error, timedOut ? "Giphy API request timed out" : "Giphy API request failed");
       return reply.status(timedOut ? 504 : 502).send({
         error: timedOut ? "Giphy API request timed out" : "Giphy API request failed",
       });

--- a/packages/server/src/routes/gifs.routes.ts
+++ b/packages/server/src/routes/gifs.routes.ts
@@ -2,9 +2,58 @@
 // Routes: Giphy GIF proxy (keeps API key server-side)
 // ──────────────────────────────────────────────
 import type { FastifyInstance } from "fastify";
+import { z } from "zod";
 import { getGifApiKey } from "../config/runtime-config.js";
 
 const GIPHY_BASE = "https://api.giphy.com/v1/gifs";
+const GIPHY_REQUEST_TIMEOUT_MS = 12_000;
+
+const giphyImageAssetSchema = z.preprocess(
+  (value) => (value && typeof value === "object" && !Array.isArray(value) ? value : {}),
+  z.object({
+    url: z.string().url().regex(/^https?:\/\//i).optional(),
+    width: z.unknown().optional(),
+    height: z.unknown().optional(),
+  }),
+);
+
+const giphyItemSchema = z
+  .object({
+    id: z.string().min(1),
+    title: z.string(),
+    images: z.object({
+      fixed_height_small: giphyImageAssetSchema.optional(),
+      fixed_height: giphyImageAssetSchema.optional(),
+      original: giphyImageAssetSchema.optional(),
+    }),
+  })
+  .transform(({ id, title, images }) => {
+    const preview = images.fixed_height_small?.url ?? images.fixed_height?.url;
+    const url = images.original?.url ?? images.fixed_height?.url;
+    if (!preview || !url) {
+      throw new Error("Invalid Giphy response body");
+    }
+
+    const width = Number(images.fixed_height?.width);
+    const height = Number(images.fixed_height?.height);
+    return {
+      id,
+      title,
+      preview,
+      url,
+      width: Number.isFinite(width) ? width || 200 : 200,
+      height: Number.isFinite(height) ? height || 200 : 200,
+    };
+  });
+
+const giphyResponseSchema = z.object({
+  data: z.array(giphyItemSchema),
+  pagination: z.object({
+    offset: z.number().finite(),
+    count: z.number().finite(),
+    total_count: z.number().finite(),
+  }),
+});
 
 export async function gifsRoutes(app: FastifyInstance) {
   // GET /api/gifs/search?q=hello&limit=20&pos=
@@ -31,33 +80,28 @@ export async function gifsRoutes(app: FastifyInstance) {
     });
 
     const url = `${GIPHY_BASE}/${endpoint}?${params}`;
-    const res = await fetch(url);
 
-    if (!res.ok) {
-      const body = await res.text();
-      req.log.error({ status: res.status, body }, "Giphy API error");
-      return reply.status(502).send({ error: "Giphy API request failed" });
+    try {
+      const res = await fetch(url, { signal: AbortSignal.timeout(GIPHY_REQUEST_TIMEOUT_MS) });
+
+      if (!res.ok) {
+        req.log.error({ status: res.status }, "Giphy API error");
+        return reply.status(502).send({ error: "Giphy API request failed" });
+      }
+
+      const { data: results, pagination } = giphyResponseSchema.parse(await res.json());
+      const { offset, count, total_count: totalCount } = pagination;
+
+      const nextOffset = offset + count;
+      const hasMore = nextOffset < totalCount;
+
+      return { results, next: hasMore ? String(nextOffset) : "" };
+    } catch (error) {
+      const timedOut = error instanceof DOMException && error.name === "TimeoutError";
+      req.log.error({ kind: timedOut ? "timeout" : "failure" }, timedOut ? "Giphy API request timed out" : "Giphy API request failed");
+      return reply.status(timedOut ? 504 : 502).send({
+        error: timedOut ? "Giphy API request timed out" : "Giphy API request failed",
+      });
     }
-
-    const data = (await res.json()) as {
-      data?: any[];
-      pagination?: { offset?: number; count?: number; total_count?: number };
-    };
-    const items = data.data ?? [];
-    const pagination = data.pagination;
-    const nextOffset = (pagination?.offset ?? 0) + (pagination?.count ?? 0);
-    const hasMore = nextOffset < (pagination?.total_count ?? 0);
-
-    // Map to a simplified format for the client
-    const results = items.map((g: any) => ({
-      id: g.id,
-      title: g.title ?? "",
-      preview: g.images?.fixed_height_small?.url ?? g.images?.fixed_height?.url ?? "",
-      url: g.images?.original?.url ?? g.images?.fixed_height?.url ?? "",
-      width: Number(g.images?.fixed_height?.width) || 200,
-      height: Number(g.images?.fixed_height?.height) || 200,
-    }));
-
-    return { results, next: hasMore ? String(nextOffset) : "" };
   });
 }


### PR DESCRIPTION
## Linked issue

Closes #3824
Closes #3825

## Why this change

- Native folder routes could launch Explorer, Finder, or `xdg-open` for authenticated or trusted non-loopback clients and return absolute host paths.
- The Giphy proxy relied on ambient Undici timeouts and loosely trusted upstream response shapes.

## What changed

- Gate Fonts and Game Assets folder routes with loopback-only privileged access and share a detached native file-manager launcher.
- Route client folder actions through host-device-aware helpers with a typed cancellation error, avoiding duplicate or misleading toasts.
- Add a 12-second Giphy timeout, stable 504/502 error mapping, and response validation.
- Remove ignored `debugMode` and `streaming` inputs from the scene-analysis hook API.

## Validation

- [x] `pnpm check` passes locally
- [ ] Container behavior checked, if applicable
- [x] Ran the app and clicked through the changes manually
- [x] Checked relevant edge cases and error paths
- [x] Read and followed `CONTRIBUTING.md`

### Validation notes

- `pnpm check` passed on the final branch based directly on the latest `origin/staging`.
- In Chrome, a trusted non-loopback `localtest.me` client received the host-only message for Fonts and Game Assets; Game Assets did not also show the generic failure toast.
- A seeded conversation exercised the GIF picker missing-key state with no browser console errors; the seeded chats were removed afterward.
- On Windows, the detached file-manager helper resolved after launch and both local folder endpoints returned 200 instead of treating Explorer exit code 1 as failure.
- Configured-key timeout and malformed-response behavior were exercised with focused route mocks, not live Giphy traffic.

## Docs and release impact

No documentation or release metadata changes are needed. Existing user-facing behavior remains the same except for safer access boundaries and clearer upstream failure responses.

## UI evidence (if applicable)

No screenshots attached. The affected UI behavior consists of guard and error states exercised manually.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for opening Game Assets and Fonts folders using the system file manager.
  * Added clear feedback when folder-opening actions succeed or fail.

* **Bug Fixes**
  * Improved handling when folder access is unavailable or restricted.
  * Strengthened GIF search response validation and added timeout handling for more reliable results.
  * Folder-opening failures now return clear errors instead of failing silently.

* **Security**
  * Restricted folder-opening actions to authorized local access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->