### PR TITLE
Append Example Dialogue when its preset marker is absent

### DIFF
--- a/docs/prompts/presets.md
+++ b/docs/prompts/presets.md
@@ -83,6 +83,8 @@ A **marker** is an auto-filled section. It has no text of its own. Instead, Mari
 
 A section that is a marker shows a **MARKER** badge in its row. Expand it to see a note that names the marker type. You cannot type content into most markers, because Marinara generates them for you.
 
+When a preset has no enabled **Dialogue Examples** marker, non-empty Example Dialogue is appended to **Character Info** after Scenario. It uses the preset's XML, Markdown, or unwrapped formatting. Add a Dialogue Examples marker when you want to control its placement explicitly; Marinara will not include it twice.
+
 If your chat has active lorebooks but your preset has no lorebook marker, a warning appears. It reads: "Add a lorebook marker when this preset should receive active lorebook entries." Add a lorebook marker so those entries reach the AI. See [Lorebooks Overview](../lorebooks/overview.md).
 
 If you have set up custom agents with the "inject as section" option turned on, the add menu shows an **Agent Sections** group. Each agent section inserts that agent's latest output into the prompt. You can add your own instructions around it.

--- a/packages/server/src/services/prompt/assembler.ts
+++ b/packages/server/src/services/prompt/assembler.ts
@@ -272,6 +272,19 @@ export async function assemblePrompt(input: AssemblerInput): Promise<AssemblerOu
   // Build lookup maps
   const sectionMap = new Map(input.sections.map((s) => [s.id, s]));
   const groupMap = new Map(input.groups.map((g) => [g.id, g]));
+  const hasDialogueExamplesMarker = sectionOrder.some((sectionId) => {
+    const section = sectionMap.get(sectionId);
+    if (!section || section.enabled !== "true" || section.isMarker !== "true" || !section.markerConfig) return false;
+    if (section.groupId) {
+      const group = groupMap.get(section.groupId);
+      if (group && group.enabled !== "true") return false;
+    }
+    try {
+      return (JSON.parse(section.markerConfig) as MarkerConfig).type === "dialogue_examples";
+    } catch {
+      return false;
+    }
+  });
 
   // Inject choice variable values into variableValues
   // chatChoices is { variableName: value | value[] } — resolve and merge into variables so {{varName}} resolves
@@ -359,6 +372,7 @@ export async function assemblePrompt(input: AssemblerInput): Promise<AssemblerOu
     previewOnly: input.previewOnly === true,
     resolveLorebookContent: (value) => resolveMacrosWithVariableSnapshot(value, macroCtx, deferNameMacroOptions),
     groupScenarioOverrideText: input.groupScenarioOverrideText ?? null,
+    hasDialogueExamplesMarker,
     macroCtx,
   };
 

--- a/packages/server/src/services/prompt/marker-expander.ts
+++ b/packages/server/src/services/prompt/marker-expander.ts
@@ -92,6 +92,8 @@ export interface MarkerContext {
   lorebookScanResultApplied?: boolean;
   /** When set, replaces all individual character scenario fields with this shared group scenario. */
   groupScenarioOverrideText?: string | null;
+  /** Whether the preset has an enabled marker that owns Example Dialogue placement. */
+  hasDialogueExamplesMarker?: boolean;
 }
 
 /** Expanded marker result. */
@@ -137,6 +139,18 @@ export function orderCharacterMarkerFields(fields: readonly string[]): string[] 
     .map(({ field }) => field);
 }
 
+/** Append Example Dialogue to Character Info when no dedicated marker owns it. */
+export function resolveCharacterMarkerFields(
+  configuredFields: readonly string[] | undefined,
+  hasDialogueExamplesMarker: boolean,
+): string[] {
+  const fields = [...(configuredFields ?? DEFAULT_CHARACTER_MARKER_FIELDS)];
+  if (!hasDialogueExamplesMarker && !fields.includes("mes_example") && !fields.includes("example_dialogue")) {
+    fields.push("mes_example");
+  }
+  return orderCharacterMarkerFields(fields);
+}
+
 /**
  * Expand a marker section into actual content based on its type and config.
  */
@@ -175,7 +189,7 @@ async function expandCharacter(config: MarkerConfig, ctx: MarkerContext): Promis
     const profile = characterMacroProfileFromData(data);
     const characterMacroContext = macroContextForCharacterProfile(ctx.macroCtx, profile);
 
-    const fields = orderCharacterMarkerFields(config.characterFields ?? DEFAULT_CHARACTER_MARKER_FIELDS);
+    const fields = resolveCharacterMarkerFields(config.characterFields, ctx.hasDialogueExamplesMarker === true);
 
     const charParts: string[] = [];
     for (const field of fields) {

--- a/scripts/regressions/prompt.regression.ts
+++ b/scripts/regressions/prompt.regression.ts
@@ -309,6 +309,7 @@ import { resolveConversationConnectedChatContext } from "../../packages/server/s
 import {
   expandMarker,
   orderCharacterMarkerFields,
+  resolveCharacterMarkerFields,
   type MarkerContext,
 } from "../../packages/server/src/services/prompt/marker-expander.js";
 import {
@@ -3606,6 +3607,121 @@ Use HTML sparingly and diegetically. Do not replace normal prose/dialogue unless
         ]),
         ["description", "personality", "backstory", "appearance", "scenario", "mes_example", "system_prompt", "stats"],
       );
+      assert.deepEqual(resolveCharacterMarkerFields(undefined, false), [
+        "description",
+        "personality",
+        "backstory",
+        "appearance",
+        "scenario",
+        "mes_example",
+        "system_prompt",
+      ]);
+      assert.deepEqual(resolveCharacterMarkerFields(undefined, true), [
+        "description",
+        "personality",
+        "backstory",
+        "appearance",
+        "scenario",
+        "system_prompt",
+      ]);
+    },
+  },
+  {
+    name: "character markers append Example Dialogue only when no enabled dialogue marker owns it",
+    async run() {
+      const characterRow = {
+        id: "char-example-fallback",
+        data: JSON.stringify({
+          name: "Dottore",
+          description: "",
+          personality: "",
+          scenario: "CHARACTER_SCENARIO",
+          first_mes: "",
+          mes_example: "CHARACTER_EXAMPLE_DIALOGUE",
+          creator_notes: "",
+          system_prompt: "CHARACTER_SYSTEM_PROMPT",
+          post_history_instructions: "",
+          tags: [],
+          creator: "",
+          character_version: "1.0",
+          alternate_greetings: [],
+          extensions: {
+            talkativeness: 0.5,
+            fav: false,
+            world: "",
+            depth_prompt: { prompt: "", depth: 4, role: "system" },
+            backstory: "",
+            appearance: "",
+          },
+          character_book: null,
+        }),
+      };
+      const db = {
+        select: () => ({
+          from: () => ({ where: async () => [characterRow] }),
+        }),
+      } as unknown as DB;
+
+      const assemble = (wrapFormat: "xml" | "markdown" | "none", withDialogueMarker: boolean) =>
+        assemblePrompt({
+          db,
+          preset: {
+            id: `preset-example-fallback-${wrapFormat}`,
+            name: "Example Dialogue Fallback Fixture",
+            sectionOrder: JSON.stringify(withDialogueMarker ? ["character", "examples"] : ["character"]),
+            groupOrder: JSON.stringify([]),
+            wrapFormat,
+            parameters: JSON.stringify({}),
+            variableGroups: JSON.stringify([]),
+            variableValues: JSON.stringify({}),
+          },
+          sections: [
+            promptSection({
+              id: "character",
+              identifier: "characterInfo",
+              name: "Character Info",
+              isMarker: "true",
+              markerConfig: JSON.stringify({ type: "character" }),
+            }),
+            ...(withDialogueMarker
+              ? [
+                  promptSection({
+                    id: "examples",
+                    identifier: "dialogueExamples",
+                    name: "Dialogue Examples",
+                    isMarker: "true",
+                    markerConfig: JSON.stringify({ type: "dialogue_examples" }),
+                    injectionOrder: 1,
+                  }),
+                ]
+              : []),
+          ],
+          groups: [],
+          choiceBlocks: [],
+          chatChoices: {},
+          chatId: "chat-example-fallback",
+          characterIds: [characterRow.id],
+          personaName: "Mari",
+          personaDescription: "",
+          chatMessages: [],
+        });
+
+      for (const wrapFormat of ["xml", "markdown", "none"] as const) {
+        const result = await assemble(wrapFormat, false);
+        const promptText = result.messages.map((message) => message.content).join("\n");
+        assert.equal(promptText.match(/CHARACTER_EXAMPLE_DIALOGUE/g)?.length, 1);
+        assert.ok(promptText.indexOf("CHARACTER_SCENARIO") < promptText.indexOf("CHARACTER_EXAMPLE_DIALOGUE"));
+        assert.ok(promptText.indexOf("CHARACTER_EXAMPLE_DIALOGUE") < promptText.indexOf("CHARACTER_SYSTEM_PROMPT"));
+        if (wrapFormat === "xml") assert.match(promptText, /<mes_example>/);
+        if (wrapFormat === "markdown") assert.match(promptText, /#### mes_example/);
+        if (wrapFormat === "none") assert.equal(promptText.includes("mes_example"), false);
+      }
+
+      const explicitMarker = await assemble("xml", true);
+      const explicitPromptText = explicitMarker.messages.map((message) => message.content).join("\n");
+      assert.equal(explicitPromptText.match(/CHARACTER_EXAMPLE_DIALOGUE/g)?.length, 1);
+      assert.match(explicitPromptText, /<dialogue_examples>/);
+      assert.equal(explicitPromptText.includes("<mes_example>"), false);
     },
   },
   {


### PR DESCRIPTION
## Linked issue

Closes #3833

## Why this change

Roleplay character cards can contain Example Dialogue, but presets that use a Character marker without a separate Dialogue Examples marker silently omit it. The expanded named character block then suppresses the general identity fallback, so valid card content never reaches the model.

## What changed

- Detect whether the assembled preset has an enabled Dialogue Examples marker, including group enablement.
- When it does not, append non-empty Example Dialogue inside Character Info after Scenario and before advanced character instructions.
- Reuse the existing character-field sanitization and wrap engine, preserving XML, Markdown, and None formatting.
- Preserve explicit Dialogue Examples marker placement without duplicating the content.
- Document the fallback behavior and add prompt regression coverage.

## Automated validation performed

- `pnpm regression:prompt` — passed, including XML, Markdown, None, field order, and explicit-marker negative controls.
- `pnpm check` — passed (workspace type checks, lint, and production builds).
- `git diff --check` — passed.

## Validation checklist

- [ ] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (XML / Markdown / None, empty dialogue, explicit marker)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed `CONTRIBUTING.md`

## Manual verification notes

Manual Roleplay verification remains for a human contributor: generate once with Character Info and no Dialogue Examples marker, then once with an enabled Dialogue Examples marker, and inspect Peek Prompt for exactly one copy in the expected location.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated docs as needed
- [ ] Version/release files updated (only if this PR includes a version bump)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Example Dialogue is now automatically included after Scenario when no enabled Dialogue Examples marker is configured.
  * Automatic placement respects the preset’s XML, Markdown, or unwrapped formatting.
  * Adding a Dialogue Examples marker provides explicit control over placement and prevents duplicate dialogue.

* **Documentation**
  * Updated preset documentation to explain Example Dialogue placement and formatting behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->