### PR TITLE
Fix assigned image, agent, and package lifecycle issues

### DIFF
--- a/packages/client/src/components/chat/AgentAddSetupFields.tsx
+++ b/packages/client/src/components/chat/AgentAddSetupFields.tsx
@@ -464,16 +464,24 @@ export function buildAgentAddMetadataPatch(
   }
   if (agentId === "illustrator") {
     const defaults = options?.illustratorDefaults;
-    if (!defaults || setup.includeCharacterAppearance !== defaults.includeCharacterAppearance) {
-      patch.illustratorIncludeCharacterAppearance = setup.includeCharacterAppearance;
-    } else if (hasOwn(metadata, "illustratorIncludeCharacterAppearance")) {
-      patch.illustratorIncludeCharacterAppearance = null;
-    }
-    if (!defaults || setup.useAvatarReferences !== defaults.useAvatarReferences) {
-      patch.illustratorUseAvatarReferences = setup.useAvatarReferences;
-    } else if (hasOwn(metadata, "illustratorUseAvatarReferences")) {
-      patch.illustratorUseAvatarReferences = null;
-    }
+    const applyIllustratorDefault = (
+      key: "illustratorIncludeCharacterAppearance" | "illustratorUseAvatarReferences",
+      value: boolean,
+      defaultValue: boolean | undefined,
+    ) => {
+      if (defaultValue === undefined || value !== defaultValue) patch[key] = value;
+      else if (hasOwn(metadata, key)) patch[key] = null;
+    };
+    applyIllustratorDefault(
+      "illustratorIncludeCharacterAppearance",
+      setup.includeCharacterAppearance,
+      defaults?.includeCharacterAppearance,
+    );
+    applyIllustratorDefault(
+      "illustratorUseAvatarReferences",
+      setup.useAvatarReferences,
+      defaults?.useAvatarReferences,
+    );
   }
   if (agentId === "haptic") {
     patch.enableHapticFeedback = setup.hapticFeedbackEnabled;

--- a/packages/client/src/components/chat/AgentAddSetupFields.tsx
+++ b/packages/client/src/components/chat/AgentAddSetupFields.tsx
@@ -394,7 +394,11 @@ export function buildAgentAddMetadataPatch(
   agentId: string,
   setup: AgentAddSetupState,
   metadata: Record<string, unknown>,
-  options?: { allowSecretPlot?: boolean; defaultPromptTemplateId?: string },
+  options?: {
+    allowSecretPlot?: boolean;
+    defaultPromptTemplateId?: string;
+    illustratorDefaults?: { includeCharacterAppearance: boolean; useAvatarReferences: boolean };
+  },
 ): Record<string, unknown> {
   const patch: Record<string, unknown> = {};
 
@@ -459,8 +463,17 @@ export function buildAgentAddMetadataPatch(
     patch.spotifyArtist = setup.spotifySourceType === "artist" ? setup.spotifyArtist.trim() || null : null;
   }
   if (agentId === "illustrator") {
-    patch.illustratorIncludeCharacterAppearance = setup.includeCharacterAppearance;
-    patch.illustratorUseAvatarReferences = setup.useAvatarReferences;
+    const defaults = options?.illustratorDefaults;
+    if (!defaults || setup.includeCharacterAppearance !== defaults.includeCharacterAppearance) {
+      patch.illustratorIncludeCharacterAppearance = setup.includeCharacterAppearance;
+    } else if (hasOwn(metadata, "illustratorIncludeCharacterAppearance")) {
+      patch.illustratorIncludeCharacterAppearance = null;
+    }
+    if (!defaults || setup.useAvatarReferences !== defaults.useAvatarReferences) {
+      patch.illustratorUseAvatarReferences = setup.useAvatarReferences;
+    } else if (hasOwn(metadata, "illustratorUseAvatarReferences")) {
+      patch.illustratorUseAvatarReferences = null;
+    }
   }
   if (agentId === "haptic") {
     patch.enableHapticFeedback = setup.hapticFeedbackEnabled;

--- a/packages/client/src/components/chat/ChatSettingsDrawer.tsx
+++ b/packages/client/src/components/chat/ChatSettingsDrawer.tsx
@@ -2121,14 +2121,14 @@ export function ChatSettingsDrawer({
     [chat.id, updateMeta],
   );
   const renderIllustratorPromptConnectionSelect = () => (
-    <label className="flex flex-col gap-1">
+    <div className="flex flex-col gap-1">
       <span className="text-[0.625rem] font-medium text-[var(--foreground)]">Prompt Model</span>
       <select
         value={illustratorPromptConnectionId}
         onChange={(event) => updateIllustratorPromptConnection(event.target.value)}
         className="w-full rounded-lg border border-[var(--border)] bg-[var(--background)] px-2.5 py-2 text-xs text-[var(--foreground)] outline-none transition-colors focus:border-[var(--primary)]/50"
       >
-        <option value="">Main chat model</option>
+        <option value="">Agent default</option>
         {selectedIllustratorPromptConnectionMissing && (
           <option value={illustratorPromptConnectionId}>Missing connection</option>
         )}
@@ -2143,7 +2143,11 @@ export function ChatSettingsDrawer({
         Chooses the text model that writes Illustrator/selfie prompts. Image rendering still uses the selected image
         connection for this feature or the agent setup.
       </span>
-    </label>
+      <AgentDefaultStatus
+        overridden={illustratorPromptConnectionId.length > 0}
+        onReset={() => updateIllustratorPromptConnection("")}
+      />
+    </div>
   );
   const toggleIllustratorCharacterAppearance = useCallback(() => {
     updateMeta.mutate({
@@ -2157,6 +2161,12 @@ export function ChatSettingsDrawer({
       illustratorUseAvatarReferences: !illustratorUseAvatarReferences,
     });
   }, [chat.id, illustratorUseAvatarReferences, updateMeta]);
+  const resetIllustratorCharacterAppearance = useCallback(() => {
+    updateMeta.mutate({ id: chat.id, illustratorIncludeCharacterAppearance: null });
+  }, [chat.id, updateMeta]);
+  const resetIllustratorAvatarReferences = useCallback(() => {
+    updateMeta.mutate({ id: chat.id, illustratorUseAvatarReferences: null });
+  }, [chat.id, updateMeta]);
   const proseGuardianBannedWords =
     typeof metadata.proseGuardianBannedWords === "string"
       ? metadata.proseGuardianBannedWords
@@ -3372,6 +3382,10 @@ export function ChatSettingsDrawer({
         ...buildAgentAddMetadataPatch(agent.id, setup, metadata, {
           allowSecretPlot: supportsNarrativeDirectorSecretPlot,
           defaultPromptTemplateId: resolveDefaultAgentPromptTemplateId(nextSettings),
+          illustratorDefaults: {
+            includeCharacterAppearance: nextSettings.includeCharacterAppearance === true,
+            useAvatarReferences: nextSettings.useAvatarReferences === true,
+          },
         }),
       });
       toast.success(`Added ${agent.name}! You can access its settings in Agents section in Chat Settings!`);
@@ -3938,6 +3952,7 @@ export function ChatSettingsDrawer({
                 <AgentPromptTemplateSelect
                   options={promptOptions}
                   selectedId={agentPromptTemplateSelections[agent.id] ?? getDefaultPromptTemplateIdForAgent(agent.id)}
+                  overridden={typeof agentPromptTemplateSelections[agent.id] === "string"}
                   onChange={(promptTemplateId) => updateAgentPromptTemplateSelection(agent.id, promptTemplateId)}
                 />
               </div>
@@ -7273,6 +7288,7 @@ export function ChatSettingsDrawer({
                               agentPromptTemplateSelections["echo-chamber"] ??
                               getDefaultPromptTemplateIdForAgent("echo-chamber")
                             }
+                            overridden={typeof agentPromptTemplateSelections["echo-chamber"] === "string"}
                             onChange={(promptTemplateId) =>
                               updateAgentPromptTemplateSelection("echo-chamber", promptTemplateId)
                             }
@@ -7311,6 +7327,7 @@ export function ChatSettingsDrawer({
                               agentPromptTemplateSelections["illustrator"] ??
                               getDefaultPromptTemplateIdForAgent("illustrator")
                             }
+                            overridden={typeof agentPromptTemplateSelections["illustrator"] === "string"}
                             onChange={(promptTemplateId) =>
                               updateAgentPromptTemplateSelection("illustrator", promptTemplateId)
                             }
@@ -7321,12 +7338,16 @@ export function ChatSettingsDrawer({
                             description="Append matched character appearance lines to image prompts, using only visible/generated names."
                             enabled={illustratorIncludeCharacterAppearance}
                             onToggle={toggleIllustratorCharacterAppearance}
+                            overridden={typeof metadata.illustratorIncludeCharacterAppearance === "boolean"}
+                            onReset={resetIllustratorCharacterAppearance}
                           />
                           <AgentSettingsToggle
                             label="Send Avatar References"
                             description="Send matching character and persona avatars or sprites as reference images when the provider supports them."
                             enabled={illustratorUseAvatarReferences}
                             onToggle={toggleIllustratorAvatarReferences}
+                            overridden={typeof metadata.illustratorUseAvatarReferences === "boolean"}
+                            onReset={resetIllustratorAvatarReferences}
                           />
                           <div className="flex flex-wrap items-center justify-between gap-2 rounded-lg bg-[var(--background)]/75 px-3 py-2 ring-1 ring-[var(--border)]">
                             <p className="min-w-0 flex-1 text-[0.625rem] leading-snug text-[var(--muted-foreground)]">
@@ -8254,6 +8275,7 @@ export function ChatSettingsDrawer({
                                             agentPromptTemplateSelections[agent.id] ??
                                             getDefaultPromptTemplateIdForAgent(agent.id)
                                           }
+                                          overridden={typeof agentPromptTemplateSelections[agent.id] === "string"}
                                           onChange={(promptTemplateId) =>
                                             updateAgentPromptTemplateSelection(agent.id, promptTemplateId)
                                           }
@@ -8264,12 +8286,18 @@ export function ChatSettingsDrawer({
                                           description="Append matched character appearance lines to image prompts, using only visible/generated names."
                                           enabled={illustratorIncludeCharacterAppearance}
                                           onToggle={toggleIllustratorCharacterAppearance}
+                                          overridden={
+                                            typeof metadata.illustratorIncludeCharacterAppearance === "boolean"
+                                          }
+                                          onReset={resetIllustratorCharacterAppearance}
                                         />
                                         <AgentSettingsToggle
                                           label="Send Avatar References"
                                           description="Send matching character and persona avatars or sprites as reference images when the provider supports them."
                                           enabled={illustratorUseAvatarReferences}
                                           onToggle={toggleIllustratorAvatarReferences}
+                                          overridden={typeof metadata.illustratorUseAvatarReferences === "boolean"}
+                                          onReset={resetIllustratorAvatarReferences}
                                         />
                                       </AgentSettingsCard>
                                     )}
@@ -9444,31 +9472,38 @@ function AgentSettingsToggle({
   description,
   enabled,
   onToggle,
+  overridden = false,
+  onReset,
   surface = "card",
 }: {
   label: string;
   description: string;
   enabled: boolean;
   onToggle: () => void;
+  overridden?: boolean;
+  onReset?: () => void;
   surface?: "card" | "secondary";
 }) {
   return (
-    <SettingsSwitch
-      label={label}
-      description={description}
-      checked={enabled}
-      onChange={() => onToggle()}
-      labelPosition="start"
-      className={cn(
-        "justify-between rounded-lg px-3 py-2.5 text-left",
-        enabled
-          ? "bg-[var(--primary)]/10 ring-1 ring-[var(--primary)]/30"
-          : surface === "secondary"
-            ? "bg-[var(--secondary)] hover:bg-[var(--accent)]"
-            : "bg-[var(--background)]/75 ring-1 ring-[var(--border)] hover:bg-[var(--accent)]",
-      )}
-      labelClassName="text-[0.6875rem] font-medium"
-    />
+    <div className="space-y-1">
+      <SettingsSwitch
+        label={label}
+        description={description}
+        checked={enabled}
+        onChange={() => onToggle()}
+        labelPosition="start"
+        className={cn(
+          "justify-between rounded-lg px-3 py-2.5 text-left",
+          enabled
+            ? "bg-[var(--primary)]/10 ring-1 ring-[var(--primary)]/30"
+            : surface === "secondary"
+              ? "bg-[var(--secondary)] hover:bg-[var(--accent)]"
+              : "bg-[var(--background)]/75 ring-1 ring-[var(--border)] hover:bg-[var(--accent)]",
+        )}
+        labelClassName="text-[0.6875rem] font-medium"
+      />
+      {onReset ? <AgentDefaultStatus overridden={overridden} onReset={onReset} /> : null}
+    </div>
   );
 }
 
@@ -10311,13 +10346,17 @@ function HapticConnectionPanel({
 function AgentPromptTemplateSelect({
   options,
   selectedId,
+  overridden = false,
   onChange,
 }: {
   options: AgentPromptTemplateOption[];
   selectedId: string;
+  overridden?: boolean;
   onChange: (promptTemplateId: string) => void;
 }) {
-  if (options.length <= 1) return null;
+  if (options.length <= 1) {
+    return overridden ? <AgentDefaultStatus overridden onReset={() => onChange("")} /> : null;
+  }
   const activeOption = options.find((option) => option.id === selectedId) ?? options[0];
 
   return (
@@ -10340,6 +10379,24 @@ function AgentPromptTemplateSelect({
         <p className="mt-1.5 text-[0.5625rem] leading-snug text-[var(--muted-foreground)]">
           {activeOption.description}
         </p>
+      ) : null}
+      <AgentDefaultStatus overridden={overridden} onReset={() => onChange("")} />
+    </div>
+  );
+}
+
+function AgentDefaultStatus({ overridden, onReset }: { overridden: boolean; onReset: () => void }) {
+  return (
+    <div className="flex items-center justify-between gap-2 px-1 text-[0.625rem] text-[var(--muted-foreground)]">
+      <span>{overridden ? "Chat override" : "Using agent default"}</span>
+      {overridden ? (
+        <button
+          type="button"
+          onClick={onReset}
+          className="font-medium text-[var(--primary)] transition-opacity hover:opacity-80"
+        >
+          Use agent default
+        </button>
       ) : null}
     </div>
   );

--- a/packages/client/src/components/chat/ChatSetupWizard.tsx
+++ b/packages/client/src/components/chat/ChatSetupWizard.tsx
@@ -2208,6 +2208,10 @@ function RoleplaySetupWizard({ chat, onFinish }: ChatSetupWizardProps) {
         ...buildAgentAddMetadataPatch(agent.id, setup, metadata, {
           allowSecretPlot: supportsNarrativeDirectorSecretPlot,
           defaultPromptTemplateId: resolveDefaultAgentPromptTemplateId(nextSettings),
+          illustratorDefaults: {
+            includeCharacterAppearance: nextSettings.includeCharacterAppearance === true,
+            useAvatarReferences: nextSettings.useAvatarReferences === true,
+          },
         }),
       });
       toast.success(`Added ${agent.name}! You can access its settings in Agents section in Chat Settings!`);

--- a/packages/server/src/routes/capability-packages.routes.ts
+++ b/packages/server/src/routes/capability-packages.routes.ts
@@ -11,6 +11,32 @@ import { createAgentsStorage } from "../services/storage/agents.storage.js";
 
 const packageParams = z.object({ id: z.string().regex(/^[a-z0-9]+(?:-[a-z0-9]+)*$/).max(80) });
 
+function removeAgentMapEntries(value: unknown, agentIds: ReadonlySet<string>): Record<string, unknown> | null {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return null;
+  const entries = Object.entries(value as Record<string, unknown>);
+  const filtered = entries.filter(([agentId]) => !agentIds.has(agentId));
+  return filtered.length === entries.length ? null : Object.fromEntries(filtered);
+}
+
+export function buildCapabilityAgentCleanupPatch(
+  metadata: Record<string, unknown>,
+  packageAgentIds: readonly string[],
+): Record<string, unknown> | null {
+  const agentIds = new Set(packageAgentIds);
+  const patch: Record<string, unknown> = {};
+  const activeAgentIds = Array.isArray(metadata.activeAgentIds)
+    ? metadata.activeAgentIds.filter((candidate: unknown): candidate is string => typeof candidate === "string")
+    : [];
+  const filteredActiveAgentIds = activeAgentIds.filter((agentId) => !agentIds.has(agentId));
+  if (filteredActiveAgentIds.length !== activeAgentIds.length) patch.activeAgentIds = filteredActiveAgentIds;
+
+  for (const key of ["agentOverrides", "agentPromptTemplateIds", "knowledgeAgentSources"] as const) {
+    const filtered = removeAgentMapEntries(metadata[key], agentIds);
+    if (filtered) patch[key] = filtered;
+  }
+  return Object.keys(patch).length > 0 ? patch : null;
+}
+
 export async function capabilityPackagesRoutes(app: FastifyInstance) {
   app.get("/catalog", async () => capabilityPackageManager.catalog());
   app.get("/installed", async () => capabilityPackageManager.installed());
@@ -40,6 +66,7 @@ export async function capabilityPackagesRoutes(app: FastifyInstance) {
     if (!requirePrivilegedAccess(request, reply, { feature: "Agent package removal" })) return;
     const { id } = packageParams.parse(request.params);
     const existing = (await capabilityPackageManager.installed()).find((item) => item.id === id);
+    const packageAgentIds = await capabilityPackageManager.packageAgentIds(id);
     if (existing?.manifest.kind.includes("turn-game")) await capabilityModuleRuntime.deactivatePackage(id);
     const removed = await capabilityPackageManager.uninstall(id);
     if (!removed) return reply.status(404).send({ error: "Package not found" });
@@ -52,16 +79,14 @@ export async function capabilityPackagesRoutes(app: FastifyInstance) {
       } catch {
         continue;
       }
-      const activeAgentIds = Array.isArray(metadata.activeAgentIds)
-        ? metadata.activeAgentIds.filter((candidate: unknown): candidate is string => typeof candidate === "string")
-        : [];
-      if (!activeAgentIds.includes(id)) continue;
-      await chats.patchMetadata(chat.id, { activeAgentIds: activeAgentIds.filter((candidate) => candidate !== id) }, {
-        touchUpdatedAt: false,
-      });
+      const patch = buildCapabilityAgentCleanupPatch(metadata, packageAgentIds);
+      if (patch) await chats.patchMetadata(chat.id, patch, { touchUpdatedAt: false });
     }
-    const agentConfig = await createAgentsStorage(app.db).getByType(id);
-    if (agentConfig) await createAgentsStorage(app.db).remove(agentConfig.id);
+    const agents = createAgentsStorage(app.db);
+    for (const agentId of packageAgentIds) {
+      const agentConfig = await agents.getByType(agentId);
+      if (agentConfig) await agents.remove(agentConfig.id);
+    }
     await refreshCapabilityAgentRegistry();
     return {
       restartRequired:

--- a/packages/server/src/routes/capability-packages.routes.ts
+++ b/packages/server/src/routes/capability-packages.routes.ts
@@ -65,9 +65,7 @@ export async function capabilityPackagesRoutes(app: FastifyInstance) {
   app.delete<{ Params: { id: string } }>("/:id", async (request, reply) => {
     if (!requirePrivilegedAccess(request, reply, { feature: "Agent package removal" })) return;
     const { id } = packageParams.parse(request.params);
-    const existing = (await capabilityPackageManager.installed()).find((item) => item.id === id);
-    const packageAgentIds = await capabilityPackageManager.packageAgentIds(id);
-    if (existing?.manifest.kind.includes("turn-game")) await capabilityModuleRuntime.deactivatePackage(id);
+    await capabilityModuleRuntime.deactivatePackage(id);
     const removed = await capabilityPackageManager.uninstall(id);
     if (!removed) return reply.status(404).send({ error: "Package not found" });
     const chats = createChatsStorage(app.db);
@@ -79,11 +77,11 @@ export async function capabilityPackagesRoutes(app: FastifyInstance) {
       } catch {
         continue;
       }
-      const patch = buildCapabilityAgentCleanupPatch(metadata, packageAgentIds);
+      const patch = buildCapabilityAgentCleanupPatch(metadata, removed.agentIds);
       if (patch) await chats.patchMetadata(chat.id, patch, { touchUpdatedAt: false });
     }
     const agents = createAgentsStorage(app.db);
-    for (const agentId of packageAgentIds) {
+    for (const agentId of removed.agentIds) {
       const agentConfig = await agents.getByType(agentId);
       if (agentConfig) await agents.remove(agentConfig.id);
     }

--- a/packages/server/src/services/capability-packages/package-manager.service.ts
+++ b/packages/server/src/services/capability-packages/package-manager.service.ts
@@ -191,6 +191,16 @@ async function readInstalledAgentDefinitions(installed: InstalledCapabilityPacka
   return packagedAgentDefinitionsSchema.parse(JSON.parse(await readFile(file, "utf8")));
 }
 
+async function readInstalledAgentIds(installed: InstalledCapabilityPackage): Promise<string[]> {
+  const ids = new Set([installed.id]);
+  try {
+    for (const definition of await readInstalledAgentDefinitions(installed)) ids.add(definition.id);
+  } catch (error) {
+    logger.warn(error, "Could not read agent definitions for package %s during cleanup", installed.id);
+  }
+  return [...ids];
+}
+
 export function findCompatibleCapabilityPackageUpdates(
   installedPackages: InstalledCapabilityPackage[],
   catalog: CapabilityCatalog,
@@ -394,14 +404,7 @@ export const capabilityPackageManager = {
 
   async packageAgentIds(packageId: string) {
     const installed = (await readRegistry()).packages.find((item) => item.id === packageId);
-    const ids = new Set([packageId]);
-    if (!installed) return [...ids];
-    try {
-      for (const definition of await readInstalledAgentDefinitions(installed)) ids.add(definition.id);
-    } catch (error) {
-      logger.warn(error, "Could not read agent definitions for package %s during cleanup", packageId);
-    }
-    return [...ids];
+    return installed ? readInstalledAgentIds(installed) : [packageId];
   },
 
   async runtimePackages() {
@@ -556,11 +559,12 @@ export const capabilityPackageManager = {
     const registry = await readRegistry();
     const existing = registry.packages.find((item) => item.id === packageId);
     if (!existing) return false;
+    const agentIds = await readInstalledAgentIds(existing);
     if (existing.manifest.kind.includes("conversation-calls")) {
       await sidecarSpeechService.deleteAllModels();
     }
     await writeRegistry(registry.packages.filter((item) => item.id !== packageId));
     await rm(join(VERSIONS, packageId), { recursive: true, force: true });
-    return existing;
+    return { ...existing, agentIds };
   },
 };

--- a/packages/server/src/services/capability-packages/package-manager.service.ts
+++ b/packages/server/src/services/capability-packages/package-manager.service.ts
@@ -18,6 +18,7 @@ import {
 } from "@marinara-engine/shared";
 import { DATA_DIR } from "../../utils/data-dir.js";
 import { safeFetch } from "../../utils/security.js";
+import { logger } from "../../lib/logger.js";
 import { sidecarSpeechService } from "../sidecar/sidecar-speech.service.js";
 
 const ROOT = join(DATA_DIR, "capability-packages");
@@ -176,6 +177,20 @@ function supportsEngineVersion(entry: CapabilityCatalogPackage, engineVersion: s
   );
 }
 
+export function getCapabilityPackageInstallIssue(manifest: CapabilityCatalogPackage["manifest"]): string | null {
+  if (manifest.kind.includes("turn-game") && !manifest.entrypoints.server) {
+    return "Turn-game packages require a server entrypoint";
+  }
+  return null;
+}
+
+async function readInstalledAgentDefinitions(installed: InstalledCapabilityPackage) {
+  const entrypoint = installed.manifest.entrypoints.agents;
+  if (!entrypoint) return [];
+  const file = inside(VERSIONS, join(VERSIONS, installed.id, installed.version, normalizeArchivePath(entrypoint)));
+  return packagedAgentDefinitionsSchema.parse(JSON.parse(await readFile(file, "utf8")));
+}
+
 export function findCompatibleCapabilityPackageUpdates(
   installedPackages: InstalledCapabilityPackage[],
   catalog: CapabilityCatalog,
@@ -194,6 +209,8 @@ export function findCompatibleCapabilityPackageUpdates(
 
 async function installCatalogPackage(entry: CapabilityCatalogPackage, activateDuringStartup = false) {
   const { manifest, artifact } = entry;
+  const installIssue = getCapabilityPackageInstallIssue(manifest);
+  if (installIssue) throw new Error(installIssue);
   const initiallyInstalled = (await readRegistry()).packages.find((item) => item.id === manifest.id);
   assertNotDowngrade(initiallyInstalled, manifest.version);
   const capabilityApiIssue = getCapabilityApiCompatibilityIssue(manifest);
@@ -365,10 +382,7 @@ export const capabilityPackageManager = {
     const ids = new Set<string>();
     for (const installed of registry.packages) {
       if (!isInstalledCapabilityReady(installed)) continue;
-      const entrypoint = installed.manifest.entrypoints.agents;
-      if (!entrypoint) continue;
-      const file = inside(VERSIONS, join(VERSIONS, installed.id, installed.version, normalizeArchivePath(entrypoint)));
-      const parsed = packagedAgentDefinitionsSchema.parse(JSON.parse(await readFile(file, "utf8")));
+      const parsed = await readInstalledAgentDefinitions(installed);
       for (const definition of parsed) {
         if (ids.has(definition.id)) throw new Error(`Agent ${definition.id} is provided by more than one package`);
         ids.add(definition.id);
@@ -376,6 +390,18 @@ export const capabilityPackageManager = {
       }
     }
     return definitions;
+  },
+
+  async packageAgentIds(packageId: string) {
+    const installed = (await readRegistry()).packages.find((item) => item.id === packageId);
+    const ids = new Set([packageId]);
+    if (!installed) return [...ids];
+    try {
+      for (const definition of await readInstalledAgentDefinitions(installed)) ids.add(definition.id);
+    } catch (error) {
+      logger.warn(error, "Could not read agent definitions for package %s during cleanup", packageId);
+    }
+    return [...ids];
   },
 
   async runtimePackages() {

--- a/packages/server/src/services/image/comfyui-reference-placeholders.ts
+++ b/packages/server/src/services/image/comfyui-reference-placeholders.ts
@@ -13,7 +13,7 @@ export function findMissingComfyReferenceSlots(
   referenceCount: number,
 ): number[] {
   const slots: number[] = [];
-  for (let index = Math.max(0, referenceCount); index < COMFYUI_MAX_REFERENCE_IMAGES; index += 1) {
+  for (let index = Math.max(0, referenceCount); index < COMFYUI_MAX_REFERENCE_IMAGES; index++) {
     if (workflowText.includes(numberedComfyReferencePlaceholder(baseName, index))) slots.push(index);
   }
   return slots;

--- a/packages/server/src/services/image/comfyui-reference-placeholders.ts
+++ b/packages/server/src/services/image/comfyui-reference-placeholders.ts
@@ -1,0 +1,20 @@
+export const COMFYUI_MAX_REFERENCE_IMAGES = 4;
+
+export type ComfyReferencePlaceholderBase = "reference_image" | "reference_image_name";
+
+export function numberedComfyReferencePlaceholder(baseName: ComfyReferencePlaceholderBase, index: number): string {
+  return `%${baseName}_${String(index + 1).padStart(2, "0")}%`;
+}
+
+/** Return only missing reference slots that the workflow actually declares. */
+export function findMissingComfyReferenceSlots(
+  workflowText: string,
+  baseName: ComfyReferencePlaceholderBase,
+  referenceCount: number,
+): number[] {
+  const slots: number[] = [];
+  for (let index = Math.max(0, referenceCount); index < COMFYUI_MAX_REFERENCE_IMAGES; index += 1) {
+    if (workflowText.includes(numberedComfyReferencePlaceholder(baseName, index))) slots.push(index);
+  }
+  return slots;
+}

--- a/packages/server/src/services/image/image-generation.ts
+++ b/packages/server/src/services/image/image-generation.ts
@@ -2537,15 +2537,19 @@ async function generateComfyUI(baseUrl: string, request: ImageGenRequest): Promi
   }
   if (defaults.uploadPlaceholderOnMissingReference) {
     for (const index of findMissingComfyReferenceSlots(workflowJson, "reference_image", references.length)) {
-      replacements[numberedComfyReferencePlaceholder("reference_image", index)] = COMFYUI_PLACEHOLDER_REFERENCE_BASE64;
+      const placeholder = numberedComfyReferencePlaceholder("reference_image", index);
+      logger.debug("Backfilled ComfyUI reference slot %s with the placeholder image", placeholder);
+      replacements[placeholder] = COMFYUI_PLACEHOLDER_REFERENCE_BASE64;
     }
     for (const index of findMissingComfyReferenceSlots(workflowJson, "reference_image_name", references.length)) {
+      const placeholder = numberedComfyReferencePlaceholder("reference_image_name", index);
       placeholderUploadedName ??= await uploadComfyReferenceImage(
         base,
         COMFYUI_PLACEHOLDER_REFERENCE_BASE64,
         request.signal,
       );
-      replacements[numberedComfyReferencePlaceholder("reference_image_name", index)] = placeholderUploadedName;
+      logger.debug("Backfilled ComfyUI reference slot %s with the uploaded placeholder", placeholder);
+      replacements[placeholder] = placeholderUploadedName;
     }
   }
   const resolvedWorkflow = replaceComfyUiPlaceholders(workflow, replacements);

--- a/packages/server/src/services/image/image-generation.ts
+++ b/packages/server/src/services/image/image-generation.ts
@@ -30,6 +30,11 @@ import { logger, logDebugOverride } from "../../lib/logger.js";
 import { assertInsideDir, normalizeLoopbackUrl, safeFetch, validateOutboundUrl } from "../../utils/security.js";
 import { notifyGenerationFallback, type GenerationFallbackNotifier } from "../generation/fallback-notification.js";
 import {
+  COMFYUI_MAX_REFERENCE_IMAGES,
+  findMissingComfyReferenceSlots,
+  numberedComfyReferencePlaceholder,
+} from "./comfyui-reference-placeholders.js";
+import {
   buildVeniceApiUrl,
   buildVeniceImageRequest,
   parseVeniceImageResponse,
@@ -2303,7 +2308,6 @@ const DEFAULT_COMFYUI_WORKFLOW: Record<string, unknown> = {
   },
 };
 
-const COMFYUI_MAX_REFERENCE_IMAGES = 4;
 const COMFYUI_OUTPUT_FILE_KEYS = ["gifs", "images"] as const;
 
 interface ComfyUiOutputFile {
@@ -2474,13 +2478,6 @@ function collectComfyReferenceImages(request: ImageGenRequest, defaults: ComfyUi
   return defaults.uploadPlaceholderOnMissingReference ? [COMFYUI_PLACEHOLDER_REFERENCE_BASE64] : [];
 }
 
-function numberedComfyReferencePlaceholder(
-  baseName: "reference_image" | "reference_image_name",
-  index: number,
-): string {
-  return `%${baseName}_${String(index + 1).padStart(2, "0")}%`;
-}
-
 async function generateComfyUI(baseUrl: string, request: ImageGenRequest): Promise<ImageGenResult> {
   const base = baseUrl.replace(/\/+$/, "");
   const defaults = resolveComfyUiDefaults(request);
@@ -2521,6 +2518,7 @@ async function generateComfyUI(baseUrl: string, request: ImageGenRequest): Promi
   }
   const workflowJson = JSON.stringify(workflow);
   const references = collectComfyReferenceImages(request, defaults);
+  let placeholderUploadedName: string | undefined;
   for (let i = 0; i < references.length; i++) {
     const reference = references[i]!;
     const referenceBase64 = decodeReferenceImage(reference).base64;
@@ -2532,8 +2530,22 @@ async function generateComfyUI(baseUrl: string, request: ImageGenRequest): Promi
 
     if (workflowJson.includes(namePlaceholder) || (i === 0 && workflowJson.includes("%reference_image_name%"))) {
       const uploadedName = await uploadComfyReferenceImage(base, reference, request.signal);
+      if (reference === COMFYUI_PLACEHOLDER_REFERENCE_BASE64) placeholderUploadedName = uploadedName;
       replacements[namePlaceholder] = uploadedName;
       if (i === 0) replacements["%reference_image_name%"] = uploadedName;
+    }
+  }
+  if (defaults.uploadPlaceholderOnMissingReference) {
+    for (const index of findMissingComfyReferenceSlots(workflowJson, "reference_image", references.length)) {
+      replacements[numberedComfyReferencePlaceholder("reference_image", index)] = COMFYUI_PLACEHOLDER_REFERENCE_BASE64;
+    }
+    for (const index of findMissingComfyReferenceSlots(workflowJson, "reference_image_name", references.length)) {
+      placeholderUploadedName ??= await uploadComfyReferenceImage(
+        base,
+        COMFYUI_PLACEHOLDER_REFERENCE_BASE64,
+        request.signal,
+      );
+      replacements[numberedComfyReferencePlaceholder("reference_image_name", index)] = placeholderUploadedName;
     }
   }
   const resolvedWorkflow = replaceComfyUiPlaceholders(workflow, replacements);

--- a/packages/server/src/services/image/runpod-comfyui.service.ts
+++ b/packages/server/src/services/image/runpod-comfyui.service.ts
@@ -23,6 +23,7 @@ import {
   type ComfyUiDefaults,
   type ImageGenerationDefaultsProfile,
 } from "@marinara-engine/shared";
+import { logger } from "../../lib/logger.js";
 import { safeFetch } from "../../utils/security.js";
 import {
   COMFYUI_MAX_REFERENCE_IMAGES,
@@ -129,8 +130,10 @@ export async function generateRunPodComfyUI(
   }
   if (defaults.uploadPlaceholderOnMissingReference) {
     for (const index of findMissingComfyReferenceSlots(wfStr, "reference_image", referenceImages.length)) {
+      const placeholder = numberedComfyReferencePlaceholder("reference_image", index);
+      logger.debug("Backfilled RunPod ComfyUI reference slot %s with the placeholder image", placeholder);
       wfStr = wfStr.replaceAll(
-        numberedComfyReferencePlaceholder("reference_image", index),
+        placeholder,
         escapeJsonStr(COMFYUI_PLACEHOLDER_REFERENCE_BASE64),
       );
     }

--- a/packages/server/src/services/image/runpod-comfyui.service.ts
+++ b/packages/server/src/services/image/runpod-comfyui.service.ts
@@ -24,6 +24,11 @@ import {
   type ImageGenerationDefaultsProfile,
 } from "@marinara-engine/shared";
 import { safeFetch } from "../../utils/security.js";
+import {
+  COMFYUI_MAX_REFERENCE_IMAGES,
+  findMissingComfyReferenceSlots,
+  numberedComfyReferencePlaceholder,
+} from "./comfyui-reference-placeholders.js";
 
 const DEFAULT_RUNPOD_POLL_INTERVAL_MS = 2_000;
 const DEFAULT_COMFYUI_GEN_TIMEOUT_SECONDS = 2_400;
@@ -40,7 +45,6 @@ const RUNPOD_MAX_POLLS = Math.max(
   Math.ceil((COMFYUI_GEN_TIMEOUT_SECONDS * 1000) / DEFAULT_RUNPOD_POLL_INTERVAL_MS),
 );
 const RUNPOD_MAX_RESPONSE_BYTES = 30 * 1024 * 1024;
-const RUNPOD_COMFYUI_MAX_REFERENCE_IMAGES = 4;
 interface RunPodRunResponse {
   id: string;
 }
@@ -117,10 +121,18 @@ export async function generateRunPodComfyUI(
   for (let i = 0; i < referenceImages.length; i++) {
     const referenceImage = referenceImages[i]!;
     const referenceImageBase64 = normalizeRunPodReferenceImageBase64(referenceImage);
-    const numbered = `%reference_image_${String(i + 1).padStart(2, "0")}%`;
+    const numbered = numberedComfyReferencePlaceholder("reference_image", i);
     wfStr = wfStr.replaceAll(numbered, escapeJsonStr(referenceImageBase64));
     if (i === 0) {
       wfStr = wfStr.replace(/%reference_image%/g, escapeJsonStr(referenceImageBase64));
+    }
+  }
+  if (defaults.uploadPlaceholderOnMissingReference) {
+    for (const index of findMissingComfyReferenceSlots(wfStr, "reference_image", referenceImages.length)) {
+      wfStr = wfStr.replaceAll(
+        numberedComfyReferencePlaceholder("reference_image", index),
+        escapeJsonStr(COMFYUI_PLACEHOLDER_REFERENCE_BASE64),
+      );
     }
   }
 
@@ -184,7 +196,7 @@ function collectRunPodReferenceImages(request: ImageGenRequest, defaults: ComfyU
   const references = [request.referenceImage, ...(request.referenceImages ?? [])]
     .filter((reference): reference is string => typeof reference === "string" && reference.trim().length > 0)
     .filter((reference, index, all) => all.indexOf(reference) === index)
-    .slice(0, RUNPOD_COMFYUI_MAX_REFERENCE_IMAGES);
+    .slice(0, COMFYUI_MAX_REFERENCE_IMAGES);
   if (references.length > 0) return references;
   return defaults.uploadPlaceholderOnMissingReference ? [COMFYUI_PLACEHOLDER_REFERENCE_BASE64] : [];
 }

--- a/scripts/regressions/capability-package-lifecycle.regression.ts
+++ b/scripts/regressions/capability-package-lifecycle.regression.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, unlinkSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -528,6 +528,12 @@ try {
     ]),
   );
   assert.deepEqual(await capabilityPackageManager.packageAgentIds(agentSuite.id), ["agent-suite", "suite-helper"]);
+  const removedAgentSuite = await capabilityPackageManager.uninstall(agentSuite.id);
+  assert.deepEqual(
+    removedAgentSuite && removedAgentSuite.agentIds,
+    ["agent-suite", "suite-helper"],
+    "Uninstall must retain every package-owned agent ID before deleting its definition file",
+  );
   const { buildCapabilityAgentCleanupPatch } =
     await import("../../packages/server/src/routes/capability-packages.routes.js");
   assert.deepEqual(
@@ -547,7 +553,7 @@ try {
       knowledgeAgentSources: { illustrator: {} },
     },
   );
-  unlinkSync(join(packagesRoot, "versions", agentSuite.id, agentSuite.version, "agents.json"));
+  writeRegistry([agentSuite]);
   assert.deepEqual(
     await capabilityPackageManager.packageAgentIds(agentSuite.id),
     ["agent-suite"],

--- a/scripts/regressions/capability-package-lifecycle.regression.ts
+++ b/scripts/regressions/capability-package-lifecycle.regression.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, unlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -169,6 +169,7 @@ try {
   const {
     capabilityPackageManager,
     findCompatibleCapabilityPackageUpdates,
+    getCapabilityPackageInstallIssue,
     resolveCapabilityCatalogUrl,
   } = await import(
     "../../packages/server/src/services/capability-packages/package-manager.service.js"
@@ -185,6 +186,20 @@ try {
     resolveCapabilityCatalogUrl("development", ""),
     "https://raw.githubusercontent.com/Pasta-Devs/Marinara-Agents/main/catalog/catalog.json",
     "Non-release builds must fall back to the legacy catalog instead of requesting a nonexistent lane",
+  );
+  assert.equal(getCapabilityPackageInstallIssue(legacyManifest), null);
+  const serverlessTurnGameManifest = capabilityPackageManifestSchema.parse({
+    ...legacyManifest,
+    id: "serverless-turn-game",
+    name: "Serverless Turn Game",
+    kind: ["agent", "turn-game"],
+    entrypoints: { client: "client.js" },
+    files: [{ path: "client.js", sha256: "0".repeat(64), bytes: 1 }],
+  });
+  assert.match(
+    getCapabilityPackageInstallIssue(serverlessTurnGameManifest) ?? "",
+    /require a server entrypoint/,
+    "Turn-game packages must fail validation before installation mutates package state",
   );
   assert.equal(
     resolveCapabilityCatalogUrl("3.2.2", " https://catalog.example.test/custom.json "),
@@ -477,6 +492,69 @@ try {
       `Hierarchical Maps ${version} must be blocked before its database adapter can crash the Engine`,
     );
   }
+  const agentSuite = {
+    ...installedPackage("agent-suite", ["agent"]),
+    manifest: {
+      ...installedPackage("agent-suite", ["agent"]).manifest,
+      entrypoints: { server: "server.mjs", client: "client.js", agents: "agents.json" },
+      files: [
+        ...installedPackage("agent-suite", ["agent"]).manifest.files,
+        { path: "agents.json", sha256: "0".repeat(64), bytes: 1 },
+      ],
+    },
+  };
+  writeRegistry([agentSuite]);
+  writeFileSync(
+    join(packagesRoot, "versions", agentSuite.id, agentSuite.version, "agents.json"),
+    JSON.stringify([
+      {
+        id: "agent-suite",
+        name: "Agent Suite",
+        description: "Primary agent.",
+        phase: "parallel",
+        enabledByDefault: true,
+        category: "misc",
+        defaultPromptTemplate: "Primary prompt.",
+      },
+      {
+        id: "suite-helper",
+        name: "Suite Helper",
+        description: "Secondary agent.",
+        phase: "parallel",
+        enabledByDefault: true,
+        category: "misc",
+        defaultPromptTemplate: "Helper prompt.",
+      },
+    ]),
+  );
+  assert.deepEqual(await capabilityPackageManager.packageAgentIds(agentSuite.id), ["agent-suite", "suite-helper"]);
+  const { buildCapabilityAgentCleanupPatch } =
+    await import("../../packages/server/src/routes/capability-packages.routes.js");
+  assert.deepEqual(
+    buildCapabilityAgentCleanupPatch(
+      {
+        activeAgentIds: ["agent-suite", "suite-helper", "illustrator"],
+        agentOverrides: { "suite-helper": true, illustrator: false },
+        agentPromptTemplateIds: { "agent-suite": "default", "suite-helper": "helper", illustrator: "portrait" },
+        knowledgeAgentSources: { "suite-helper": { sourceLorebookIds: ["book"] }, illustrator: {} },
+      },
+      ["agent-suite", "suite-helper"],
+    ),
+    {
+      activeAgentIds: ["illustrator"],
+      agentOverrides: { illustrator: false },
+      agentPromptTemplateIds: { illustrator: "portrait" },
+      knowledgeAgentSources: { illustrator: {} },
+    },
+  );
+  unlinkSync(join(packagesRoot, "versions", agentSuite.id, agentSuite.version, "agents.json"));
+  assert.deepEqual(
+    await capabilityPackageManager.packageAgentIds(agentSuite.id),
+    ["agent-suite"],
+    "Uninstall cleanup must retain a safe package-ID fallback when agent definitions are unavailable",
+  );
+
+  writeRegistry([installedPackage("conversation-calls", ["agent", "conversation-calls"])]);
   const removedCalls = await capabilityPackageManager.uninstall("conversation-calls");
   assert.ok(removedCalls, "Conversation Calls should be removed");
   assert.equal(existsSync(join(modelsRoot, "Xenova", "whisper-tiny")), false);

--- a/scripts/regressions/open-issues.regression.ts
+++ b/scripts/regressions/open-issues.regression.ts
@@ -116,6 +116,14 @@ import { createAgentsStorage } from "../../packages/server/src/services/storage/
 import { createCustomToolsStorage } from "../../packages/server/src/services/storage/custom-tools.storage.js";
 import { resolveRunPodComfyUiTimeoutSeconds } from "../../packages/server/src/services/image/runpod-comfyui.service.js";
 import {
+  findMissingComfyReferenceSlots,
+  numberedComfyReferencePlaceholder,
+} from "../../packages/server/src/services/image/comfyui-reference-placeholders.js";
+import {
+  buildAgentAddMetadataPatch,
+  buildInitialAgentAddSetupState,
+} from "../../packages/client/src/components/chat/AgentAddSetupFields.js";
+import {
   parseIllustratorPromptReviewOverride,
   resolveIllustratorPromptSubmission,
 } from "../../packages/server/src/services/image/illustrator-prompt-review.js";
@@ -185,6 +193,48 @@ const backgroundOrganization = normalizeBackgroundLibraryOrganization({
     "game:backgrounds:fantasy:castle": "missing-folder",
   },
 });
+
+const comfyReferenceWorkflow = JSON.stringify({
+  first: "%reference_image_01%",
+  second: "%reference_image_02%",
+  thirdName: "%reference_image_name_03%",
+  outsideSupportedRange: "%reference_image_05%",
+});
+assert.deepEqual(findMissingComfyReferenceSlots(comfyReferenceWorkflow, "reference_image", 1), [1]);
+assert.deepEqual(findMissingComfyReferenceSlots(comfyReferenceWorkflow, "reference_image_name", 1), [2]);
+assert.equal(numberedComfyReferencePlaceholder("reference_image_name", 2), "%reference_image_name_03%");
+
+const inheritedIllustratorSetup = buildInitialAgentAddSetupState({
+  agentId: "illustrator",
+  settings: { includeCharacterAppearance: true, useAvatarReferences: false },
+  metadata: {},
+  musicPlayerSource: "off",
+  roleplaySpriteScale: 1,
+});
+const inheritedIllustratorPatch = buildAgentAddMetadataPatch(
+  "illustrator",
+  inheritedIllustratorSetup,
+  {},
+  {
+    illustratorDefaults: { includeCharacterAppearance: true, useAvatarReferences: false },
+  },
+);
+assert.equal(Object.hasOwn(inheritedIllustratorPatch, "illustratorIncludeCharacterAppearance"), false);
+assert.equal(Object.hasOwn(inheritedIllustratorPatch, "illustratorUseAvatarReferences"), false);
+
+const staleIllustratorMetadata = {
+  illustratorIncludeCharacterAppearance: true,
+  illustratorUseAvatarReferences: false,
+};
+assert.deepEqual(
+  buildAgentAddMetadataPatch("illustrator", inheritedIllustratorSetup, staleIllustratorMetadata, {
+    illustratorDefaults: { includeCharacterAppearance: true, useAvatarReferences: false },
+  }),
+  {
+    illustratorIncludeCharacterAppearance: null,
+    illustratorUseAvatarReferences: null,
+  },
+);
 assert.equal(backgroundOrganization.folders.length, 1);
 assert.equal(backgroundOrganization.assignments["user:moonlit-garden.jpg"], "folder-night");
 assert.equal(backgroundOrganization.assignments["game:backgrounds:fantasy:castle"], undefined);


### PR DESCRIPTION
## Linked issues

Closes #3828
Closes #3829
Closes #3831
Closes #3832

## Why this change

The assigned sweep exposed four host-integration gaps: indexed ComfyUI reference slots could leak into workflows, invalid turn-game packages could mutate install state before activation failed, existing chats had no clear way back to changing agent defaults, and multi-agent package removal cleaned only the primary package ID.

## What changed

- Pad only workflow-declared missing ComfyUI reference slots with the existing placeholder image, for local and RunPod workflows, while preserving the opt-out setting.
- Reject turn-game packages without a server entrypoint before registry or artifact mutation.
- Keep newly attached Illustrator settings inherited when they match the agent defaults, and show compact inherited/override status plus a reset action for prompt templates, the Illustrator prompt model, and Illustrator reference toggles.
- Resolve all agent definitions owned by a package before uninstall, then remove their chat selections, agent-keyed metadata, configurations, runs, and memory using the existing storage cleanup path.
- Add focused regression coverage for each lifecycle edge case.

## Validation performed

- `pnpm check`
- `pnpm regression:issues`
- `pnpm smoke:ui` — 72 passed, 46 intentional viewport skips
- `git diff --check`

## Validation checklist

- [ ] `pnpm check` passes locally
- [ ] Relevant regression suites pass locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran affected UI paths manually
- [ ] Checked relevant error and compatibility paths
- [ ] Read and followed `CONTRIBUTING.md`

## Manual verification requested

- Manually verify a local ComfyUI workflow with one supplied reference and multiple indexed filename slots.
- Manually verify an existing Illustrator chat can reset its prompt template, prompt model, and reference toggles to the current agent defaults.
- Manually verify uninstalling a fixture package with two agent definitions removes both from chat settings and stored agent state.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Chat settings now show when Illustrator options and prompt templates override agent defaults.
  - Added “Use agent default” reset controls for Illustrator character appearance and avatar reference toggles.
  - Improved ComfyUI reference-image handling, automatically filling missing reference slots (including names).

- **Bug Fixes**
  - Capability package uninstall/removal now cleans up all associated agents and updates affected chat metadata accordingly.
  - Invalid “turn-game” packages missing a server entrypoint are rejected before installation proceeds.
  - Illustrator default vs override settings are preserved correctly; ComfyUI placeholder backfill now reuses uploaded placeholder filenames and uses safer timeout parsing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->