### PR TITLE
fix: smooth Roleplay interactions and TTS pauses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 ### Fixed
 
 - Smoothed Roleplay typing and streamed replies by batching draft-state publication, pacing the Typewriter effect against bursty provider delivery, and replacing the repaint-heavy streaming glow with an opacity pulse (#3836).
+- Prevented Firefox from flashing Roleplay backgrounds while desktop sidebars open and close by using an instant shell-panel fallback and keeping the background bitmap viewport-sized during relayout (#3836).
+- Changed the TTS dialogue pause control to whole seconds from 1 through 60, migrating legacy sub-second and no-pause values to the new 1-second minimum.
 - Kept Character and Persona prompt sections in editor order across preset markers, fallbacks, agent lore, and Game/scene card contexts: Description, Personality, Backstory, Appearance, Scenario, then Example Dialogue when present (#3817).
 - Made PocketTTS server voices directly selectable for global, character, and narrator assignments while retaining custom voice IDs, URLs, and paths, and aligned new PocketTTS setups with the compatible server's default endpoint (#3786).
 - Streamed Roleplay and Game scene-video files with standard byte-range and HEAD handling instead of synchronously buffering complete MP4 files for every playback request (#3811).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 ### Fixed
 
 - Smoothed Roleplay typing and streamed replies by batching draft-state publication, pacing the Typewriter effect against bursty provider delivery, and replacing the repaint-heavy streaming glow with an opacity pulse (#3836).
-- Prevented Firefox from flashing Roleplay backgrounds while desktop sidebars open and close by using an instant shell-panel fallback and keeping the background bitmap viewport-sized during relayout (#3836).
+- Kept selected Roleplay backgrounds fitted to the resized chat area and repainted weather effects immediately after relayout, preventing Firefox flashes as desktop sidebars open and close (#3836).
 - Changed the TTS dialogue pause control to whole seconds from 1 through 60, migrating legacy sub-second and no-pause values to the new 1-second minimum.
 - Kept Character and Persona prompt sections in editor order across preset markers, fallbacks, agent lore, and Game/scene card contexts: Description, Personality, Backstory, Appearance, Scenario, then Example Dialogue when present (#3817).
 - Made PocketTTS server voices directly selectable for global, character, and narrator assignments while retaining custom voice IDs, URLs, and paths, and aligned new PocketTTS setups with the compatible server's default endpoint (#3786).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,6 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 ### Fixed
 
 - Smoothed Roleplay typing and streamed replies by batching draft-state publication, pacing the Typewriter effect against bursty provider delivery, and replacing the repaint-heavy streaming glow with an opacity pulse (#3836).
-- Kept Roleplay background images composited while chat and tool sidebars resize the desktop chat, preventing the temporary background flicker in Firefox (#3836).
 - Kept Character and Persona prompt sections in editor order across preset markers, fallbacks, agent lore, and Game/scene card contexts: Description, Personality, Backstory, Appearance, Scenario, then Example Dialogue when present (#3817).
 - Made PocketTTS server voices directly selectable for global, character, and narrator assignments while retaining custom voice IDs, URLs, and paths, and aligned new PocketTTS setups with the compatible server's default endpoint (#3786).
 - Streamed Roleplay and Game scene-video files with standard byte-range and HEAD handling instead of synchronously buffering complete MP4 files for every playback request (#3811).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 ### Fixed
 
 - Smoothed Roleplay typing and streamed replies by batching draft-state publication, pacing the Typewriter effect against bursty provider delivery, and replacing the repaint-heavy streaming glow with an opacity pulse (#3836).
+- Kept Roleplay background images composited while chat and tool sidebars resize the desktop chat, preventing the temporary background flicker in Firefox (#3836).
 - Kept Character and Persona prompt sections in editor order across preset markers, fallbacks, agent lore, and Game/scene card contexts: Description, Personality, Backstory, Appearance, Scenario, then Example Dialogue when present (#3817).
 - Made PocketTTS server voices directly selectable for global, character, and narrator assignments while retaining custom voice IDs, URLs, and paths, and aligned new PocketTTS setups with the compatible server's default endpoint (#3786).
 - Streamed Roleplay and Game scene-video files with standard byte-range and HEAD handling instead of synchronously buffering complete MP4 files for every playback request (#3811).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 
 ### Fixed
 
+- Smoothed Roleplay typing and streamed replies by batching draft-state publication, pacing the Typewriter effect against bursty provider delivery, and replacing the repaint-heavy streaming glow with an opacity pulse (#3836).
 - Kept Character and Persona prompt sections in editor order across preset markers, fallbacks, agent lore, and Game/scene card contexts: Description, Personality, Backstory, Appearance, Scenario, then Example Dialogue when present (#3817).
 - Made PocketTTS server voices directly selectable for global, character, and narrator assignments while retaining custom voice IDs, URLs, and paths, and aligned new PocketTTS setups with the compatible server's default endpoint (#3786).
 - Streamed Roleplay and Game scene-video files with standard byte-range and HEAD handling instead of synchronously buffering complete MP4 files for every playback request (#3811).

--- a/docs/chats/sending-and-streaming.md
+++ b/docs/chats/sending-and-streaming.md
@@ -51,7 +51,7 @@ Streaming shows the reply appearing word by word as it generates, instead of wai
 | **Streaming speed** | 50 | Sets how fast streamed text renders on screen |
 | **Trim incomplete model endings** | Off | Trims a trailing unfinished sentence before saving |
 
-**Streaming speed** is a slider from 1 to 100. A lower value gives a slower typewriter effect so you can read along. A higher value shows text almost instantly. This speed only changes how fast text renders on your screen. It does not change how fast the model itself writes.
+**Streaming speed** is a slider from 1 to 100. A lower value gives a slower typewriter effect so you can read along. A higher value shows text almost instantly. Marinara smooths bursty token delivery while the model is writing, then uses your selected speed to finish the reply. This setting does not change how fast the model itself writes.
 
 When **Enable streaming** is off, the full reply appears all at once after the model finishes.
 

--- a/e2e/core-flows.e2e.ts
+++ b/e2e/core-flows.e2e.ts
@@ -5007,7 +5007,9 @@ test("mobile Game keeps CYOA usable above four HUD widgets", async ({ page, requ
   }
 });
 
-test("Roleplay displays a selected background when its file route is GET-only", async ({ page }) => {
+test("Roleplay keeps a selected background stable while side panels resize the chat", async ({
+  page,
+}, testInfo) => {
   const chatResponse = await page.request.post("/api/chats", {
     data: { name: "Roleplay Background Smoke", mode: "roleplay", characterIds: [] },
   });
@@ -5074,6 +5076,34 @@ test("Roleplay displays a selected background when its file route is GET-only", 
       .toBe(true);
     expect(requestedMethods).toContain("GET");
     expect(requestedMethods).not.toContain("HEAD");
+
+    const activeBackground = page.locator('.mari-background[style*="opacity: 1"]');
+    await expect(activeBackground).toHaveCount(1);
+    await expect(activeBackground).toHaveCSS("backface-visibility", "hidden");
+    await expect(activeBackground).toHaveCSS("contain", "paint");
+    expect(await activeBackground.evaluate((element) => getComputedStyle(element).willChange)).toContain("transform");
+    await expect(activeBackground).not.toHaveCSS("transform", "none");
+
+    if (testInfo.project.name.includes("desktop")) {
+      await page.getByRole("button", { name: "Close panel" }).click();
+      await expect(page.locator('[data-component="RightPanelDesktopSlot"]')).toHaveCSS("width", "0px");
+      const originalBackground = await activeBackground.elementHandle();
+
+      await page.getByTitle("Characters").click();
+      await expect(page.locator('[data-component="RightPanel"]')).toBeVisible();
+      expect(await activeBackground.evaluate((element, original) => element === original, originalBackground)).toBe(
+        true,
+      );
+      await expect(activeBackground).toHaveCSS("opacity", "1");
+
+      await page.getByRole("button", { name: "Close panel" }).click();
+      await page.locator('[data-tour="sidebar-toggle"]').click();
+      await expect(page.locator('[data-component="ChatSidebarSlot"]')).not.toHaveCSS("width", "0px");
+      expect(await activeBackground.evaluate((element, original) => element === original, originalBackground)).toBe(
+        true,
+      );
+      await expect(activeBackground).toHaveCSS("opacity", "1");
+    }
   } finally {
     await page.request.delete(`/api/chats/${chat.id}`);
   }

--- a/e2e/core-flows.e2e.ts
+++ b/e2e/core-flows.e2e.ts
@@ -5062,7 +5062,7 @@ test("Roleplay displays a selected background when its file route is GET-only", 
       await route.fulfill({
         status: 200,
         contentType: "image/svg+xml",
-        body: '<svg xmlns="http://www.w3.org/2000/svg" width="2" height="2"><path fill="#47234f" d="M0 0h2v2H0z"/></svg>',
+        body: '<svg xmlns="http://www.w3.org/2000/svg" width="1600" height="900" viewBox="0 0 1600 900" preserveAspectRatio="none"><path fill="#8f365f" d="M0 0h800v900H0z"/><path fill="#36548f" d="M800 0h800v900H800z"/></svg>',
       });
     });
     await page.addInitScript((chatId) => {
@@ -5083,13 +5083,42 @@ test("Roleplay displays a selected background when its file route is GET-only", 
             (layers, expectedUrl) =>
               layers.some(
                 (layer) =>
-                  (layer as HTMLElement).style.backgroundImage.includes(expectedUrl) &&
+                  (layer as HTMLImageElement).getAttribute("src")?.includes(expectedUrl) &&
                   (layer as HTMLElement).style.opacity === "1",
               ),
             backgroundUrl,
           ),
       )
       .toBe(true);
+
+    const roleplaySurface = page.locator('[data-chat-mode="roleplay"]');
+    const activeBackground = page.locator(`img.mari-background[src="${backgroundUrl}"]`);
+    await expect(activeBackground).toHaveCSS("object-fit", "fill");
+    const expectBackgroundToFitRoleplaySurface = async () => {
+      await expect
+        .poll(async () => {
+          const [surfaceBox, backgroundBox] = await Promise.all([
+            roleplaySurface.boundingBox(),
+            activeBackground.boundingBox(),
+          ]);
+          if (!surfaceBox || !backgroundBox) return null;
+          return {
+            width: Math.round(backgroundBox.width - surfaceBox.width),
+            height: Math.round(backgroundBox.height - surfaceBox.height),
+          };
+        })
+        .toEqual({ width: 0, height: 0 });
+    };
+
+    await expectBackgroundToFitRoleplaySurface();
+    await page.locator('[data-tour="panel-settings"]').click();
+    await expectBackgroundToFitRoleplaySurface();
+    await page.locator('[data-tour="panel-settings"]').click();
+    await expectBackgroundToFitRoleplaySurface();
+    await page.locator('[data-tour="sidebar-toggle"]').click();
+    await expectBackgroundToFitRoleplaySurface();
+    await page.locator('[data-tour="sidebar-toggle"]').click();
+    await expectBackgroundToFitRoleplaySurface();
     expect(requestedMethods).toContain("GET");
     expect(requestedMethods).not.toContain("HEAD");
   } finally {

--- a/e2e/core-flows.e2e.ts
+++ b/e2e/core-flows.e2e.ts
@@ -965,6 +965,24 @@ test("PocketTTS discovers server voices and uses its speech endpoint", async ({ 
       "Agent Cobra (AgentCobra.wav)",
     );
     await expect(ttsCard.getByText("Loaded 2 voices from PocketTTS server.", { exact: true })).toBeVisible();
+
+    await ttsCard.getByText("Only read dialogues", { exact: true }).click();
+    const dialoguePause = ttsCard.getByLabel("Pause between dialogues in seconds");
+    await expect(dialoguePause).toHaveAttribute("min", "1");
+    await expect(dialoguePause).toHaveAttribute("max", "60");
+    await expect(dialoguePause).toHaveAttribute("step", "1");
+    await expect(dialoguePause).toHaveValue("1");
+    await expect(ttsCard.getByText("Pause between dialogues: 1 second", { exact: true })).toBeVisible();
+
+    await dialoguePause.fill("60");
+    await expect(ttsCard.getByText("Pause between dialogues: 60 seconds", { exact: true })).toBeVisible();
+    await expect
+      .poll(async () => {
+        const response = await request.get("/api/tts/config");
+        const config = (await response.json()) as { dialoguePauseMs?: number };
+        return config.dialoguePauseMs;
+      })
+      .toBe(60_000);
   } finally {
     try {
       if (originalConfig !== undefined) await request.put("/api/tts/config", { data: originalConfig });

--- a/e2e/core-flows.e2e.ts
+++ b/e2e/core-flows.e2e.ts
@@ -5007,9 +5007,7 @@ test("mobile Game keeps CYOA usable above four HUD widgets", async ({ page, requ
   }
 });
 
-test("Roleplay keeps a selected background stable while side panels resize the chat", async ({
-  page,
-}, testInfo) => {
+test("Roleplay displays a selected background when its file route is GET-only", async ({ page }) => {
   const chatResponse = await page.request.post("/api/chats", {
     data: { name: "Roleplay Background Smoke", mode: "roleplay", characterIds: [] },
   });
@@ -5076,34 +5074,6 @@ test("Roleplay keeps a selected background stable while side panels resize the c
       .toBe(true);
     expect(requestedMethods).toContain("GET");
     expect(requestedMethods).not.toContain("HEAD");
-
-    const activeBackground = page.locator('.mari-background[style*="opacity: 1"]');
-    await expect(activeBackground).toHaveCount(1);
-    await expect(activeBackground).toHaveCSS("backface-visibility", "hidden");
-    await expect(activeBackground).toHaveCSS("contain", "paint");
-    expect(await activeBackground.evaluate((element) => getComputedStyle(element).willChange)).toContain("transform");
-    await expect(activeBackground).not.toHaveCSS("transform", "none");
-
-    if (testInfo.project.name.includes("desktop")) {
-      await page.getByRole("button", { name: "Close panel" }).click();
-      await expect(page.locator('[data-component="RightPanelDesktopSlot"]')).toHaveCSS("width", "0px");
-      const originalBackground = await activeBackground.elementHandle();
-
-      await page.getByTitle("Characters").click();
-      await expect(page.locator('[data-component="RightPanel"]')).toBeVisible();
-      expect(await activeBackground.evaluate((element, original) => element === original, originalBackground)).toBe(
-        true,
-      );
-      await expect(activeBackground).toHaveCSS("opacity", "1");
-
-      await page.getByRole("button", { name: "Close panel" }).click();
-      await page.locator('[data-tour="sidebar-toggle"]').click();
-      await expect(page.locator('[data-component="ChatSidebarSlot"]')).not.toHaveCSS("width", "0px");
-      expect(await activeBackground.evaluate((element, original) => element === original, originalBackground)).toBe(
-        true,
-      );
-      await expect(activeBackground).toHaveCSS("opacity", "1");
-    }
   } finally {
     await page.request.delete(`/api/chats/${chat.id}`);
   }

--- a/packages/client/src/components/chat/ChatInput.tsx
+++ b/packages/client/src/components/chat/ChatInput.tsx
@@ -1,7 +1,7 @@
 // ──────────────────────────────────────────────
 // Chat: Input — mode-aware styling
 // ──────────────────────────────────────────────
-import { useState, useRef, useCallback, useEffect, useMemo, memo } from "react";
+import { useState, useRef, useCallback, useEffect, useMemo, memo, type FormEvent } from "react";
 import {
   Send,
   Paperclip,
@@ -90,6 +90,14 @@ const TEXT_ATTACHMENT_EXTENSIONS = new Set([
   "yml",
 ]);
 const PDF_ATTACHMENT_MIME_TYPE = "application/pdf";
+const QUOTE_INPUT_TRIGGER_RE = /["'\u2018\u2019\u201a\u201b\u201c\u201d\u201e\u201f]/;
+
+function shouldFormatQuoteInput(event: FormEvent<HTMLTextAreaElement> | undefined, value: string): boolean {
+  const inputEvent = event?.nativeEvent as InputEvent | undefined;
+  const inputType = typeof inputEvent?.inputType === "string" ? inputEvent.inputType : "";
+  if (inputType.startsWith("delete")) return false;
+  return QUOTE_INPUT_TRIGGER_RE.test(inputEvent?.data ?? value);
+}
 
 function getFileExtension(fileName: string): string {
   const match = fileName.toLowerCase().match(/\.([a-z0-9]+)$/);
@@ -224,6 +232,8 @@ export const ChatInput = memo(function ChatInput({
   const restoreFocusAfterBusyRef = useRef(false);
   const wasInputBusyRef = useRef(false);
   const draftTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const currentInputFrameRef = useRef<number | null>(null);
+  const pendingCurrentInputRef = useRef("");
   const attachmentsRef = useRef<Attachment[]>([]);
   const pendingAttachmentDraftsRef = useRef<Map<string, Attachment[]>>(new Map());
   const activeChatId = useChatStore((s) => s.activeChatId);
@@ -340,8 +350,18 @@ export const ChatInput = memo(function ChatInput({
 
   const syncInputState = useCallback(
     (value: string) => {
-      setHasInput(value.trim().length > 0);
-      setCurrentInput(value);
+      const nextHasInput = value.trim().length > 0;
+      setHasInput((current) => (current === nextHasInput ? current : nextHasInput));
+      pendingCurrentInputRef.current = value;
+      if (typeof window === "undefined" || typeof window.requestAnimationFrame !== "function") {
+        setCurrentInput(value);
+        return;
+      }
+      if (currentInputFrameRef.current !== null) return;
+      currentInputFrameRef.current = window.requestAnimationFrame(() => {
+        currentInputFrameRef.current = null;
+        setCurrentInput(pendingCurrentInputRef.current);
+      });
     },
     [setCurrentInput],
   );
@@ -463,6 +483,11 @@ export const ChatInput = memo(function ChatInput({
       if (draftTimerRef.current) clearTimeout(draftTimerRef.current);
       // Cancel pending resize rAF
       if (resizeRafRef.current) cancelAnimationFrame(resizeRafRef.current);
+      if (currentInputFrameRef.current !== null) {
+        cancelAnimationFrame(currentInputFrameRef.current);
+        currentInputFrameRef.current = null;
+        useChatStore.getState().setCurrentInput(pendingCurrentInputRef.current);
+      }
       // Flush draft synchronously
       if (chatId && textarea) {
         const text = textarea.value;
@@ -1369,19 +1394,17 @@ export const ChatInput = memo(function ChatInput({
     }
   };
 
-  const handleInput = () => {
+  const handleInput = (event?: FormEvent<HTMLTextAreaElement>) => {
     const el = textareaRef.current;
     if (!el) return;
-    const fixed = applyTextareaQuoteFormat(el, quoteFormat);
-    const nowHasInput = fixed.trim().length > 0;
-    setHasInput((prev) => (prev === nowHasInput ? prev : nowHasInput));
+    const fixed = shouldFormatQuoteInput(event, el.value) ? applyTextareaQuoteFormat(el, quoteFormat) : el.value;
+    syncInputState(fixed);
 
     // Keep draft in sync so it survives remounts (debounced to avoid store churn)
     if (activeChatId) {
       if (draftTimerRef.current) clearTimeout(draftTimerRef.current);
       const chatId = activeChatId;
       const text = fixed;
-      setCurrentInput(text);
       draftTimerRef.current = setTimeout(() => {
         if (text.trim()) {
           setInputDraft(chatId, text);

--- a/packages/client/src/components/chat/ChatRoleplaySurface.tsx
+++ b/packages/client/src/components/chat/ChatRoleplaySurface.tsx
@@ -282,7 +282,7 @@ function CrossfadeBackground({
         alt=""
         draggable={false}
         className={cn(
-          "mari-background pointer-events-none absolute inset-0 h-full w-full select-none object-fill object-center transition-opacity duration-700 ease-in-out",
+          "mari-background pointer-events-none absolute inset-0 h-full w-full select-none object-fill object-center",
           className,
         )}
         style={{
@@ -296,7 +296,7 @@ function CrossfadeBackground({
         alt=""
         draggable={false}
         className={cn(
-          "mari-background pointer-events-none absolute inset-0 h-full w-full select-none object-fill object-center transition-opacity duration-700 ease-in-out",
+          "mari-background pointer-events-none absolute inset-0 h-full w-full select-none object-fill object-center",
           className,
         )}
         style={{

--- a/packages/client/src/components/chat/ChatRoleplaySurface.tsx
+++ b/packages/client/src/components/chat/ChatRoleplaySurface.tsx
@@ -214,12 +214,10 @@ function WeatherEffectsConnected() {
 }
 
 function getBackgroundBlurStyle(blurPx: number): Pick<CSSProperties, "filter" | "transform"> {
-  if (blurPx <= 0) {
-    return { transform: "translate3d(0, 0, 0)" };
-  }
+  if (blurPx <= 0) return {};
   return {
     filter: `blur(${blurPx}px)`,
-    transform: `translate3d(0, 0, 0) scale(${Math.min(1.08, 1 + blurPx * 0.0025)})`,
+    transform: `scale(${Math.min(1.08, 1 + blurPx * 0.0025)})`,
   };
 }
 

--- a/packages/client/src/components/chat/ChatRoleplaySurface.tsx
+++ b/packages/client/src/components/chat/ChatRoleplaySurface.tsx
@@ -214,10 +214,12 @@ function WeatherEffectsConnected() {
 }
 
 function getBackgroundBlurStyle(blurPx: number): Pick<CSSProperties, "filter" | "transform"> {
-  if (blurPx <= 0) return {};
+  if (blurPx <= 0) {
+    return { transform: "translate3d(0, 0, 0)" };
+  }
   return {
     filter: `blur(${blurPx}px)`,
-    transform: `scale(${Math.min(1.08, 1 + blurPx * 0.0025)})`,
+    transform: `translate3d(0, 0, 0) scale(${Math.min(1.08, 1 + blurPx * 0.0025)})`,
   };
 }
 

--- a/packages/client/src/components/chat/ChatRoleplaySurface.tsx
+++ b/packages/client/src/components/chat/ChatRoleplaySurface.tsx
@@ -277,30 +277,34 @@ function CrossfadeBackground({
 
   return (
     <>
-      <div
-        className={cn(
-          "mari-background absolute inset-0 bg-cover bg-center bg-no-repeat transition-opacity duration-700 ease-in-out",
-          className,
-        )}
-        style={{
-          backgroundImage: bgA ? `url(${bgA})` : "none",
-          opacity: aActive ? 1 : 0,
-          transition: "opacity 700ms ease-in-out, filter 180ms ease-out, transform 180ms ease-out",
-          ...backgroundBlurStyle,
-        }}
-      />
-      <div
-        className={cn(
-          "mari-background absolute inset-0 bg-cover bg-center bg-no-repeat transition-opacity duration-700 ease-in-out",
-          className,
-        )}
-        style={{
-          backgroundImage: bgB ? `url(${bgB})` : "none",
-          opacity: aActive ? 0 : 1,
-          transition: "opacity 700ms ease-in-out, filter 180ms ease-out, transform 180ms ease-out",
-          ...backgroundBlurStyle,
-        }}
-      />
+      <div className="mari-background-viewport pointer-events-none absolute inset-0">
+        <div
+          className={cn(
+            "mari-background absolute inset-0 bg-cover bg-center bg-no-repeat transition-opacity duration-700 ease-in-out",
+            className,
+          )}
+          style={{
+            backgroundImage: bgA ? `url(${bgA})` : "none",
+            opacity: aActive ? 1 : 0,
+            transition: "opacity 700ms ease-in-out, filter 180ms ease-out, transform 180ms ease-out",
+            ...backgroundBlurStyle,
+          }}
+        />
+      </div>
+      <div className="mari-background-viewport pointer-events-none absolute inset-0">
+        <div
+          className={cn(
+            "mari-background absolute inset-0 bg-cover bg-center bg-no-repeat transition-opacity duration-700 ease-in-out",
+            className,
+          )}
+          style={{
+            backgroundImage: bgB ? `url(${bgB})` : "none",
+            opacity: aActive ? 0 : 1,
+            transition: "opacity 700ms ease-in-out, filter 180ms ease-out, transform 180ms ease-out",
+            ...backgroundBlurStyle,
+          }}
+        />
+      </div>
     </>
   );
 }

--- a/packages/client/src/components/chat/ChatRoleplaySurface.tsx
+++ b/packages/client/src/components/chat/ChatRoleplaySurface.tsx
@@ -277,34 +277,34 @@ function CrossfadeBackground({
 
   return (
     <>
-      <div className="mari-background-viewport pointer-events-none absolute inset-0">
-        <div
-          className={cn(
-            "mari-background absolute inset-0 bg-cover bg-center bg-no-repeat transition-opacity duration-700 ease-in-out",
-            className,
-          )}
-          style={{
-            backgroundImage: bgA ? `url(${bgA})` : "none",
-            opacity: aActive ? 1 : 0,
-            transition: "opacity 700ms ease-in-out, filter 180ms ease-out, transform 180ms ease-out",
-            ...backgroundBlurStyle,
-          }}
-        />
-      </div>
-      <div className="mari-background-viewport pointer-events-none absolute inset-0">
-        <div
-          className={cn(
-            "mari-background absolute inset-0 bg-cover bg-center bg-no-repeat transition-opacity duration-700 ease-in-out",
-            className,
-          )}
-          style={{
-            backgroundImage: bgB ? `url(${bgB})` : "none",
-            opacity: aActive ? 0 : 1,
-            transition: "opacity 700ms ease-in-out, filter 180ms ease-out, transform 180ms ease-out",
-            ...backgroundBlurStyle,
-          }}
-        />
-      </div>
+      <img
+        src={bgA ?? undefined}
+        alt=""
+        draggable={false}
+        className={cn(
+          "mari-background pointer-events-none absolute inset-0 h-full w-full select-none object-fill object-center transition-opacity duration-700 ease-in-out",
+          className,
+        )}
+        style={{
+          opacity: aActive ? 1 : 0,
+          transition: "opacity 700ms ease-in-out, filter 180ms ease-out, transform 180ms ease-out",
+          ...backgroundBlurStyle,
+        }}
+      />
+      <img
+        src={bgB ?? undefined}
+        alt=""
+        draggable={false}
+        className={cn(
+          "mari-background pointer-events-none absolute inset-0 h-full w-full select-none object-fill object-center transition-opacity duration-700 ease-in-out",
+          className,
+        )}
+        style={{
+          opacity: aActive ? 0 : 1,
+          transition: "opacity 700ms ease-in-out, filter 180ms ease-out, transform 180ms ease-out",
+          ...backgroundBlurStyle,
+        }}
+      />
     </>
   );
 }

--- a/packages/client/src/components/panels/settings/TTSConfigCard.tsx
+++ b/packages/client/src/components/panels/settings/TTSConfigCard.tsx
@@ -38,7 +38,14 @@ import type {
   TTSAudioFormat,
   TTSConversationCallAudioInputMode,
 } from "@marinara-engine/shared";
-import { ELEVENLABS_TTS_LANGUAGE_OPTIONS, TTS_API_KEY_MASK, ttsSourceProfileFromConfig } from "@marinara-engine/shared";
+import {
+  ELEVENLABS_TTS_LANGUAGE_OPTIONS,
+  TTS_API_KEY_MASK,
+  TTS_DIALOGUE_PAUSE_DEFAULT_SECONDS,
+  TTS_DIALOGUE_PAUSE_MAX_SECONDS,
+  TTS_DIALOGUE_PAUSE_MIN_SECONDS,
+  ttsSourceProfileFromConfig,
+} from "@marinara-engine/shared";
 import { HelpTooltip } from "../../ui/HelpTooltip";
 import { SettingsCheckbox, SettingsSwitch } from "./SettingControls";
 
@@ -470,7 +477,7 @@ export function TTSConfigCard() {
   const [autoplayGame, setAutoplayGame] = useState(false);
   const [progressivePlayback, setProgressivePlayback] = useState(false);
   const [dialogueOnly, setDialogueOnly] = useState(false);
-  const [dialoguePauseMs, setDialoguePauseMs] = useState(300);
+  const [dialoguePauseSeconds, setDialoguePauseSeconds] = useState(TTS_DIALOGUE_PAUSE_DEFAULT_SECONDS);
   const [audioFormat, setAudioFormat] = useState<TTSAudioFormat>("mp3");
   const [callAudioEnabled, setCallAudioEnabled] = useState(false);
   const [callAudioInputMode, setCallAudioInputMode] = useState<TTSConversationCallAudioInputMode>("local_whisper");
@@ -526,7 +533,15 @@ export function TTSConfigCard() {
     setAutoplayGame(savedConfig.autoplayGame);
     setProgressivePlayback(savedConfig.progressivePlayback ?? false);
     setDialogueOnly(savedConfig.dialogueOnly ?? false);
-    setDialoguePauseMs(savedConfig.dialoguePauseMs ?? 300);
+    setDialoguePauseSeconds(
+      Math.min(
+        TTS_DIALOGUE_PAUSE_MAX_SECONDS,
+        Math.max(
+          TTS_DIALOGUE_PAUSE_MIN_SECONDS,
+          Math.round((savedConfig.dialoguePauseMs ?? TTS_DIALOGUE_PAUSE_DEFAULT_SECONDS * 1000) / 1000),
+        ),
+      ),
+    );
     setAudioFormat(savedConfig.audioFormat ?? "mp3");
     setCallAudioEnabled(savedConfig.callAudioEnabled ?? false);
     setCallAudioInputMode(savedConfig.callAudioInputMode ?? "local_whisper");
@@ -596,7 +611,7 @@ export function TTSConfigCard() {
     autoplayGame,
     progressivePlayback,
     dialogueOnly,
-    dialoguePauseMs,
+    dialoguePauseMs: dialoguePauseSeconds * 1000,
     audioFormat,
     callAudioEnabled,
     callSttConnectionId: "",
@@ -1538,25 +1553,26 @@ export function TTSConfigCard() {
             />
             {dialogueOnly && (
               <FieldRow
-                label={`Pause between dialogues — ${dialoguePauseMs} ms`}
+                label={`Pause between dialogues: ${dialoguePauseSeconds} ${dialoguePauseSeconds === 1 ? "second" : "seconds"}`}
                 help="Adds silence between separate dialogue lines in the same message. It does not pause between chunks of the same long dialogue."
               >
                 <input
                   type="range"
-                  min={0}
-                  max={1500}
-                  step={50}
-                  value={dialoguePauseMs}
+                  aria-label="Pause between dialogues in seconds"
+                  min={TTS_DIALOGUE_PAUSE_MIN_SECONDS}
+                  max={TTS_DIALOGUE_PAUSE_MAX_SECONDS}
+                  step={1}
+                  value={dialoguePauseSeconds}
                   onChange={(event) => {
                     const next = Number(event.target.value);
-                    setDialoguePauseMs(next);
-                    mark({ dialoguePauseMs: next });
+                    setDialoguePauseSeconds(next);
+                    mark({ dialoguePauseMs: next * 1000 });
                   }}
-                  className="w-full accent-rose-400"
+                  className="w-full accent-[var(--primary)]"
                 />
                 <div className="flex justify-between text-[0.6rem] text-[var(--muted-foreground)]">
-                  <span>No pause</span>
-                  <span>1500 ms</span>
+                  <span>{TTS_DIALOGUE_PAUSE_MIN_SECONDS} s</span>
+                  <span>{TTS_DIALOGUE_PAUSE_MAX_SECONDS} s</span>
                 </div>
               </FieldRow>
             )}

--- a/packages/client/src/components/panels/settings/TTSConfigCard.tsx
+++ b/packages/client/src/components/panels/settings/TTSConfigCard.tsx
@@ -534,13 +534,7 @@ export function TTSConfigCard() {
     setProgressivePlayback(savedConfig.progressivePlayback ?? false);
     setDialogueOnly(savedConfig.dialogueOnly ?? false);
     setDialoguePauseSeconds(
-      Math.min(
-        TTS_DIALOGUE_PAUSE_MAX_SECONDS,
-        Math.max(
-          TTS_DIALOGUE_PAUSE_MIN_SECONDS,
-          Math.round((savedConfig.dialoguePauseMs ?? TTS_DIALOGUE_PAUSE_DEFAULT_SECONDS * 1000) / 1000),
-        ),
-      ),
+      (savedConfig.dialoguePauseMs ?? TTS_DIALOGUE_PAUSE_DEFAULT_SECONDS * 1000) / 1000,
     );
     setAudioFormat(savedConfig.audioFormat ?? "mp3");
     setCallAudioEnabled(savedConfig.callAudioEnabled ?? false);

--- a/packages/client/src/hooks/use-generate.ts
+++ b/packages/client/src/hooks/use-generate.ts
@@ -10,6 +10,7 @@ import { formatAgentFailuresToast, toAgentFailure, type AgentFailure } from "../
 import { chatBackgroundMetadataToUrl } from "../lib/backgrounds";
 import { formatGenerationParameterError } from "../lib/generation-parameter-errors";
 import {
+  getTypewriterRevealCharsPerSecond,
   reconcileTypewriterReplacement,
   shouldKeepStreamLiveThroughPostProcessing,
 } from "../lib/generation-stream-policy";
@@ -1230,6 +1231,8 @@ export function useGenerate() {
       ]);
       let fullBuffer = ""; // What the user sees (or accumulates silently when streaming is off)
       let pendingText = ""; // Tokens waiting to be typed out
+      let lastVisibleChunkAt = 0;
+      let observedArrivalCharsPerSecond: number | null = null;
       let receivedContent = false; // Whether any actual message content was received
       let receivedThinking = false; // Whether provider-native thinking chunks were received
       let gameTurnLoadedSoundPlayed = false;
@@ -1262,6 +1265,18 @@ export function useGenerate() {
         }
         if (!normalizedChunk) return;
         if (streamingEnabled && shouldDisplayRawStream) {
+          const now = performance.now();
+          if (lastVisibleChunkAt > 0) {
+            const elapsedMs = now - lastVisibleChunkAt;
+            if (elapsedMs >= 16 && elapsedMs <= 5000) {
+              const sampleRate = (normalizedChunk.length * 1000) / elapsedMs;
+              observedArrivalCharsPerSecond =
+                observedArrivalCharsPerSecond === null
+                  ? sampleRate
+                  : observedArrivalCharsPerSecond * 0.5 + sampleRate * 0.5;
+            }
+          }
+          lastVisibleChunkAt = now;
           pendingText += normalizedChunk;
           startTypewriter();
         } else {
@@ -1372,7 +1387,12 @@ export function useGenerate() {
           const elapsedMs = Math.min(TYPEWRITER_MAX_FRAME_MS, Math.max(0, now - lastTypewriterPaintAt));
           lastTypewriterPaintAt = now;
 
-          const charsPerSecond = getCharsPerSecond();
+          const charsPerSecond = getTypewriterRevealCharsPerSecond({
+            selectedCharsPerSecond: getCharsPerSecond(),
+            pendingCharacters: pendingText.length,
+            observedArrivalCharsPerSecond,
+            streamComplete: sawDoneEvent,
+          });
           if (charsPerSecond === Infinity) {
             fullBuffer += pendingText;
             pendingText = "";

--- a/packages/client/src/lib/generation-stream-policy.ts
+++ b/packages/client/src/lib/generation-stream-policy.ts
@@ -11,6 +11,30 @@ interface TypewriterReplacement {
   pendingText: string;
 }
 
+interface TypewriterRevealRateInput {
+  selectedCharsPerSecond: number;
+  pendingCharacters: number;
+  observedArrivalCharsPerSecond: number | null;
+  streamComplete: boolean;
+}
+
+/**
+ * Keep the reveal slightly behind an open transport so provider-sized bursts
+ * remain a continuous typewriter queue instead of draining into visible gaps.
+ * Once transport completes, return to the user's selected speed so completion
+ * is never artificially delayed.
+ */
+export function getTypewriterRevealCharsPerSecond(input: TypewriterRevealRateInput): number {
+  if (!Number.isFinite(input.selectedCharsPerSecond) || input.streamComplete) {
+    return input.selectedCharsPerSecond;
+  }
+
+  const arrivalRate = input.observedArrivalCharsPerSecond ?? input.pendingCharacters;
+  const initialRateFloor =
+    input.observedArrivalCharsPerSecond === null ? Math.min(12, input.selectedCharsPerSecond) : 1;
+  return Math.max(initialRateFloor, Math.min(input.selectedCharsPerSecond, arrivalRate * 0.95));
+}
+
 /**
  * Reconcile an authoritative replacement with text that the typewriter has
  * already painted. Server cleanup can trim a leading newline, speaker label,

--- a/packages/client/src/styles/globals.css
+++ b/packages/client/src/styles/globals.css
@@ -4058,14 +4058,6 @@ strong {
   background: var(--background);
 }
 
-/* Keep the crossfade layers composited while desktop side panels resize the
-   Roleplay surface. Firefox can otherwise briefly drop a repainted layer. */
-.mari-background {
-  backface-visibility: hidden;
-  contain: paint;
-  will-change: opacity, filter, transform;
-}
-
 [data-chat-mode="roleplay"] {
   --mari-roleplay-message-column-width: 58rem;
 }

--- a/packages/client/src/styles/globals.css
+++ b/packages/client/src/styles/globals.css
@@ -4058,6 +4058,14 @@ strong {
   background: var(--background);
 }
 
+/* Keep the crossfade layers composited while desktop side panels resize the
+   Roleplay surface. Firefox can otherwise briefly drop a repainted layer. */
+.mari-background {
+  backface-visibility: hidden;
+  contain: paint;
+  will-change: opacity, filter, transform;
+}
+
 [data-chat-mode="roleplay"] {
   --mari-roleplay-message-column-width: 58rem;
 }

--- a/packages/client/src/styles/globals.css
+++ b/packages/client/src/styles/globals.css
@@ -2949,6 +2949,20 @@ strong {
 /* Firefox on Windows can rasterize text inside large blurred/translucent layout layers,
    which shows up most clearly on high-DPI displays. Fall back to opaque shell chrome there. */
 @supports (-moz-appearance: none) {
+  @media (min-width: 768px) {
+    .mari-background-viewport {
+      right: auto;
+      left: 50%;
+      width: 100vw;
+      transform: translateX(-50%);
+    }
+
+    .mari-shell-panel-slot,
+    .mari-shell-panel-motion {
+      transition: none;
+    }
+  }
+
   :root {
     --marinara-topbar-surface: var(--card);
   }

--- a/packages/client/src/styles/globals.css
+++ b/packages/client/src/styles/globals.css
@@ -4328,20 +4328,31 @@ strong {
   box-shadow:
     0 0 0 2px rgba(96, 165, 250, 0.25),
     0 0 16px rgba(96, 165, 250, 0.1);
-  animation: rpg-stream-pulse 2s ease-in-out infinite;
+}
+
+.rpg-streaming::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  border: 1px solid rgba(96, 165, 250, 0.5);
+  border-radius: inherit;
+  box-shadow: inset 0 0 16px rgba(96, 165, 250, 0.18);
+  opacity: 0.25;
+  animation: rpg-stream-pulse 1.6s cubic-bezier(0.16, 1, 0.3, 1) infinite alternate;
+  will-change: opacity;
 }
 
 @keyframes rpg-stream-pulse {
-  0%,
-  100% {
-    box-shadow:
-      0 0 0 2px rgba(96, 165, 250, 0.25),
-      0 0 16px rgba(96, 165, 250, 0.1);
+  to {
+    opacity: 0.8;
   }
-  50% {
-    box-shadow:
-      0 0 0 3px rgba(96, 165, 250, 0.4),
-      0 0 24px rgba(96, 165, 250, 0.2);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .rpg-streaming::after {
+    animation: none;
+    opacity: 0.45;
   }
 }
 

--- a/packages/client/src/styles/globals.css
+++ b/packages/client/src/styles/globals.css
@@ -2950,13 +2950,6 @@ strong {
    which shows up most clearly on high-DPI displays. Fall back to opaque shell chrome there. */
 @supports (-moz-appearance: none) {
   @media (min-width: 768px) {
-    .mari-background-viewport {
-      right: auto;
-      left: 50%;
-      width: 100vw;
-      transform: translateX(-50%);
-    }
-
     .mari-shell-panel-slot,
     .mari-shell-panel-motion {
       transition: none;

--- a/packages/client/src/styles/themes/sillytavern.css
+++ b/packages/client/src/styles/themes/sillytavern.css
@@ -513,8 +513,9 @@
   background-clip: unset;
 }
 
-[data-visual-theme="sillytavern"] .rpg-streaming {
-  animation-name: st-stream-pulse;
+[data-visual-theme="sillytavern"] .rpg-streaming::after {
+  border-color: rgba(74, 114, 176, 0.55);
+  box-shadow: inset 0 0 14px rgba(74, 114, 176, 0.2);
 }
 
 /* ─── Function call card → cleaner look ─── */

--- a/packages/client/src/workers/weather-effects.worker.ts
+++ b/packages/client/src/workers/weather-effects.worker.ts
@@ -71,7 +71,7 @@ function resizeSurface(nextWidth: number, nextHeight: number, nextScale: number)
   context.setTransform(scale, 0, 0, scale, 0, 0);
 }
 
-function drawFrame(now: number) {
+function drawFrame(now: number, advanceSimulation = true) {
   if (!context || !config || hidden) {
     previousTime = now;
     return;
@@ -79,7 +79,7 @@ function drawFrame(now: number) {
 
   const elapsed = previousTime === 0 ? FRAME_MS : Math.min(100, now - previousTime);
   previousTime = now;
-  const frameScale = Math.min(3, Math.max(0.5, elapsed / BASE_FRAME_MS));
+  const frameScale = advanceSimulation ? Math.min(3, Math.max(0.5, elapsed / BASE_FRAME_MS)) : 0;
   frameCount += frameScale;
   context.clearRect(0, 0, width, height);
 
@@ -179,7 +179,7 @@ self.onmessage = (event: MessageEvent<WeatherWorkerMessage>) => {
     resizeSurface(message.width, message.height, message.scale);
     // Resizing a canvas clears it. Repaint in the same worker task so the
     // browser never presents a blank weather layer between sidebar layouts.
-    drawFrame(performance.now());
+    drawFrame(performance.now(), false);
   } else {
     hidden = message.hidden;
     previousTime = performance.now();

--- a/packages/client/src/workers/weather-effects.worker.ts
+++ b/packages/client/src/workers/weather-effects.worker.ts
@@ -173,9 +173,13 @@ self.onmessage = (event: MessageEvent<WeatherWorkerMessage>) => {
     nextLightning = config.lightning ? 200 + Math.random() * 400 : Infinity;
     resizeSurface(message.width, message.height, message.scale);
     populateParticles();
+    drawFrame(performance.now());
     if (timer === null) scheduleFrame();
   } else if (message.type === "resize") {
     resizeSurface(message.width, message.height, message.scale);
+    // Resizing a canvas clears it. Repaint in the same worker task so the
+    // browser never presents a blank weather layer between sidebar layouts.
+    drawFrame(performance.now());
   } else {
     hidden = message.hidden;
     previousTime = performance.now();

--- a/packages/shared/src/types/tts.ts
+++ b/packages/shared/src/types/tts.ts
@@ -12,6 +12,17 @@ export type TTSAudioFormat = z.infer<typeof ttsAudioFormatSchema>;
 export const ttsVoiceModeSchema = z.enum(["single", "per-character"]);
 export type TTSVoiceMode = z.infer<typeof ttsVoiceModeSchema>;
 
+export const TTS_DIALOGUE_PAUSE_MIN_SECONDS = 1;
+export const TTS_DIALOGUE_PAUSE_MAX_SECONDS = 60;
+export const TTS_DIALOGUE_PAUSE_DEFAULT_SECONDS = 1;
+
+function normalizeDialoguePauseMs(value: number): number {
+  const wholeSeconds = Math.round(value / 1000);
+  return (
+    Math.min(TTS_DIALOGUE_PAUSE_MAX_SECONDS, Math.max(TTS_DIALOGUE_PAUSE_MIN_SECONDS, wholeSeconds)) * 1000
+  );
+}
+
 export const ttsConversationCallAudioInputModeSchema = z.enum(["system", "auto", "transcribe", "local_whisper"]);
 export type TTSConversationCallAudioInputMode = z.infer<typeof ttsConversationCallAudioInputModeSchema>;
 
@@ -126,7 +137,13 @@ const ttsConfigBaseSchema = z.object({
   autoplayGame: z.boolean().default(false),
   progressivePlayback: z.boolean().default(false),
   dialogueOnly: z.boolean().default(false),
-  dialoguePauseMs: z.number().min(0).max(1500).default(300),
+  /** Stored in milliseconds for backward compatibility; the setting is configured in whole seconds. */
+  dialoguePauseMs: z
+    .number()
+    .min(0)
+    .max(TTS_DIALOGUE_PAUSE_MAX_SECONDS * 1000)
+    .default(TTS_DIALOGUE_PAUSE_DEFAULT_SECONDS * 1000)
+    .transform(normalizeDialoguePauseMs),
   audioFormat: ttsAudioFormatSchema.default("mp3"),
   /** Global gate for Conversation-mode calls. Individual chats opt in separately. */
   callAudioEnabled: z.boolean().default(false),

--- a/scripts/regressions/roleplay-streaming.regression.ts
+++ b/scripts/regressions/roleplay-streaming.regression.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 import {
+  getTypewriterRevealCharsPerSecond,
   isMessageShadowedByLiveStream,
   reconcileTypewriterReplacement,
   shouldKeepStreamLiveThroughPostProcessing,
@@ -63,6 +64,37 @@ assert.equal(
   "object-shaped tracker values must become editable text instead of invalid React children",
 );
 assert.equal(trackerEditableText({ nested: true }), '{"nested":true}');
+
+assert.equal(
+  getTypewriterRevealCharsPerSecond({
+    selectedCharsPerSecond: 90,
+    pendingCharacters: 45,
+    observedArrivalCharsPerSecond: null,
+    streamComplete: false,
+  }),
+  42.75,
+  "the first provider burst should be spread across roughly one second instead of draining immediately",
+);
+assert.equal(
+  getTypewriterRevealCharsPerSecond({
+    selectedCharsPerSecond: 90,
+    pendingCharacters: 20,
+    observedArrivalCharsPerSecond: 40,
+    streamComplete: false,
+  }),
+  38,
+  "an open stream should reveal slightly behind its observed arrival rate to absorb chunk gaps",
+);
+assert.equal(
+  getTypewriterRevealCharsPerSecond({
+    selectedCharsPerSecond: 90,
+    pendingCharacters: 200,
+    observedArrivalCharsPerSecond: 40,
+    streamComplete: true,
+  }),
+  90,
+  "a completed stream should drain at the user's selected speed",
+);
 
 assert.equal(
   shouldKeepStreamLiveThroughPostProcessing({

--- a/scripts/regressions/tts-source-persistence.regression.ts
+++ b/scripts/regressions/tts-source-persistence.regression.ts
@@ -6,35 +6,49 @@ import { maskTTSConfigForResponse, prepareTTSConfigForStorage } from "../../pack
 const encryptForTest = (value: string) => (value ? `encrypted:${value}` : "");
 
 const legacyConfigWithoutDialoguePause = ttsConfigSchema.parse({});
-assert.equal(legacyConfigWithoutDialoguePause.dialoguePauseMs, 300);
+assert.equal(legacyConfigWithoutDialoguePause.dialoguePauseMs, 1000);
 
-const dialogueConfig = ttsConfigSchema.parse({ dialogueOnly: true, dialoguePauseMs: 300 });
+const legacySubSecondPause = ttsConfigSchema.parse({ dialoguePauseMs: 300 });
+assert.equal(legacySubSecondPause.dialoguePauseMs, 1000);
+
+const dialogueConfig = ttsConfigSchema.parse({ dialogueOnly: true, dialoguePauseMs: 3000 });
 const twoUtterances = buildTTSVoiceRequests('"First line." "Second line."', dialogueConfig);
 assert.deepEqual(
   twoUtterances.map((request) => request.pauseAfterMs),
-  [300, undefined],
+  [3000, undefined],
 );
 
 const threeUtterances = buildTTSVoiceRequests('"First." "Second." "Third."', dialogueConfig);
 assert.deepEqual(
   threeUtterances.map((request) => request.pauseAfterMs),
-  [300, 300, undefined],
+  [3000, 3000, undefined],
 );
 
 const longDialogue = `${"A".repeat(950)}. Short ending.`;
 const splitUtteranceRequests = buildTTSVoiceRequests(`"${longDialogue}" "Next line."`, dialogueConfig);
 assert.ok(splitUtteranceRequests.length > 2);
 assert.ok(splitUtteranceRequests.slice(0, -2).every((request) => request.pauseAfterMs === undefined));
-assert.equal(splitUtteranceRequests.at(-2)?.pauseAfterMs, 300);
+assert.equal(splitUtteranceRequests.at(-2)?.pauseAfterMs, 3000);
 assert.equal(splitUtteranceRequests.at(-1)?.pauseAfterMs, undefined);
 
-const fullMessageConfig = ttsConfigSchema.parse({ dialogueOnly: false, dialoguePauseMs: 300 });
+const fullMessageConfig = ttsConfigSchema.parse({ dialogueOnly: false, dialoguePauseMs: 3000 });
 const fullMessageRequests = buildTTSVoiceRequests('"First." "Second."', fullMessageConfig);
 assert.ok(fullMessageRequests.every((request) => request.pauseAfterMs === undefined));
 
-const zeroPauseConfig = ttsConfigSchema.parse({ dialogueOnly: true, dialoguePauseMs: 0 });
-const zeroPauseRequests = buildTTSVoiceRequests('"First." "Second."', zeroPauseConfig);
-assert.ok(zeroPauseRequests.every((request) => request.pauseAfterMs === undefined));
+const legacyZeroPauseConfig = ttsConfigSchema.parse({ dialogueOnly: true, dialoguePauseMs: 0 });
+const legacyZeroPauseRequests = buildTTSVoiceRequests('"First." "Second."', legacyZeroPauseConfig);
+assert.deepEqual(
+  legacyZeroPauseRequests.map((request) => request.pauseAfterMs),
+  [1000, undefined],
+);
+
+const maximumPauseConfig = ttsConfigSchema.parse({ dialogueOnly: true, dialoguePauseMs: 60_000 });
+const maximumPauseRequests = buildTTSVoiceRequests('"First." "Second."', maximumPauseConfig);
+assert.deepEqual(
+  maximumPauseRequests.map((request) => request.pauseAfterMs),
+  [60_000, undefined],
+);
+assert.throws(() => ttsConfigSchema.parse({ dialoguePauseMs: 60_001 }));
 
 const legacyOpenAiConfig = ttsConfigSchema.parse({
   enabled: true,


### PR DESCRIPTION
Closes #3836

## Why

Roleplay typing published the full draft to shared state synchronously for every key. Streamed replies also drained each provider burst faster than the next chunk arrived, and the Roleplay streaming glow continuously repainted a box shadow. Together these made both composing and reading feel less fluid.

Firefox could also briefly flash Roleplay's visual layers while the desktop shell changed width around opening or closing sidebars. The first workaround kept the background viewport-sized, but that caused sidebars to crop it instead of resizing the whole composition into the remaining chat area. The weather OffscreenCanvas also cleared itself on resize and waited until its next 30 FPS tick to repaint. Separately, the TTS dialogue-pause control exposed milliseconds, allowed no pause, and topped out at only 1.5 seconds instead of presenting a useful human-scale range.

## Changes

- Batch Roleplay draft publication to one update per animation frame and avoid rescanning quote formatting for unrelated input events.
- Measure visible token delivery and keep the open Typewriter queue slightly behind that cadence, then return to the selected speed as soon as transport completes.
- Replace the animated box shadow with a compositor-friendly opacity pulse and disable the loop for reduced-motion users.
- Render Roleplay crossfade backgrounds as persistent image layers that resize with the chat pane and preserve the whole composition as sidebars change the available width.
- Repaint the weather OffscreenCanvas immediately after initialization and resize so the browser never presents its cleared intermediate state.
- Keep the instant desktop sidebar fallback in Firefox; other browsers retain the existing panel animation.
- Present the TTS dialogue pause as whole seconds from 1 through 60 while retaining millisecond storage compatibility and migrating legacy sub-second or no-pause values to one second.
- Document the changes and extend Roleplay, TTS persistence, and Connections UI regression coverage.

## Automated validation

- `pnpm check`
- `pnpm --filter @marinara-engine/client lint`
- `pnpm --filter @marinara-engine/client build`
- `pnpm regression:roleplay`
- `pnpm regression:tts`
- `pnpm smoke:ui` (72 passed, 46 viewport-specific skips)
- Targeted PocketTTS Connections UI test in desktop Chromium
- Repeated selected-background open/close cycles for both sidebars in desktop Chromium and Firefox
- `git diff --check`

## Manual verification

- [ ] Manually verify fast typing in a long Roleplay draft on desktop.
- [ ] Manually verify the composer on a mobile viewport.
- [ ] Manually verify a bursty streamed Roleplay response at low, default, and high Streaming Speed settings.
- [ ] Manually verify stream completion, regeneration, rewrite, and group-turn transitions.
- [ ] Manually verify the complete selected Roleplay background resizes with the chat area when opening and closing both desktop sidebars.
- [ ] Manually verify weather effects remain visually stable while opening and closing both desktop sidebars in Firefox.
- [ ] Manually verify reduced-motion behavior.
- [ ] Manually verify the TTS dialogue pause shows and persists whole seconds from 1 through 60 in Settings → Connections → TTS.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved streaming text pacing for smoother, more responsive generation.
  - Reduced Roleplay background flashes during layout changes, especially in Firefox.
  - Refined Roleplay streaming visuals with a smoother opacity-based pulse.

- **Improvements**
  - TTS dialogue pauses now use whole seconds from 1–60, with older values automatically adjusted.
  - Updated streaming-speed guidance to clarify how bursty generation is smoothed and rendered.

- **Documentation**
  - Clarified the behavior of the streaming speed setting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->