### PR TITLE
Add character-scoped Roleplay message visibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 
 ### Added
 
+- Added per-character **Hide From AI** controls to Roleplay group chats, with avatar-based multi-selection, recipient markers, and character-scoped prompt history while preserving the existing global hide option.
 - Added `||` (OR), `&&` (AND), parentheses, and equality-list shorthand to conditional prompt macros, with matching in-app and documentation examples.
 - Added the `{{group}}` prompt macro for listing every other active chat character, including during targeted Roleplay group generation.
 - Added a chibi Professor Mari artwork icon to Marinara's Universal Preset for existing and new users.
@@ -14,6 +15,7 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 
 ### Fixed
 
+- Kept the Roleplay **Hide From AI** action on the selected chroma/accent color and suppressed the browser's transient tap-highlight color.
 - Kept Character and Persona prompt sections in editor order across preset markers, fallbacks, agent lore, and Game/scene card contexts: Description, Personality, Backstory, Appearance, Scenario, then Example Dialogue when present (#3817).
 - Made PocketTTS server voices directly selectable for global, character, and narrator assignments while retaining custom voice IDs, URLs, and paths, and aligned new PocketTTS setups with the compatible server's default endpoint (#3786).
 - Streamed Roleplay and Game scene-video files with standard byte-range and HEAD handling instead of synchronously buffering complete MP4 files for every playback request (#3811).

--- a/docs/chats/messages.md
+++ b/docs/chats/messages.md
@@ -16,7 +16,7 @@ The buttons below appear on messages. Some only show up in certain situations, w
 | **Edit** | Opens the message for editing. See below. | Always |
 | **Regenerate** | Creates a new alternate reply (a swipe). See below. | AI messages. In Roleplay mode, also on your messages. In Conversation mode, also on your messages made by Impersonate |
 | **Show original before rewrite** / **Show rewritten version** | Switches between the original and rewritten text. Both versions remain available so you can compare them or keep the one you prefer. | Only after an agent rewrote the message |
-| **Hide from AI** / **Unhide from AI** | Stops or resumes sending this message to the AI on later turns. | Always |
+| **Hide from AI** / **Unhide from AI** | Stops or resumes sending this message to the AI on later turns. In a Roleplay group chat, opens a character chooser. | Always |
 | **Peek prompt** | Shows the exact prompt the AI received for this reply. | Only on the latest AI message |
 | **Stored guidance** | Shows the direction that steered this reply. | Only if the reply used a guided direction or was made by Impersonate |
 | **Branch from here** | Copies the chat up to this message into a new branch. | Always |
@@ -80,6 +80,8 @@ Empty-Send retry starts a fresh reply. If the last message in the chat is yours 
 ## Hiding a message from the AI
 
 The AI context is the set of messages the app sends to the AI on each turn. Click **Hide from AI** to keep a message out of that context on future turns. The message stays visible to you and shows a **Hidden from AI** label. Click **Unhide from AI** to send it again.
+
+In a Roleplay group chat with more than one character, **Hide from AI** opens a compact avatar chooser. Select the group avatar to hide the message from everyone, or select one or more character avatars to hide it only from those characters. Selecting everyone clears individual selections, while selecting an individual character turns off the everyone option. The crossed-eye marker on the message shows the avatars of the characters who cannot see it. In a one-character chat, the button continues to hide or unhide the message directly.
 
 You can also hide or unhide messages by number with the `/hide` and `/unhide` slash commands. Message numbers start at 1, counting from the first message in the chat.
 

--- a/packages/client/src/components/chat/ChatArea.tsx
+++ b/packages/client/src/components/chat/ChatArea.tsx
@@ -2019,8 +2019,14 @@ export function ChatArea() {
   );
 
   const handleToggleHiddenFromAI = useCallback(
-    (messageId: string, current: boolean) => {
-      updateMessageExtra.mutate({ messageId, extra: { hiddenFromAI: !current } });
+    (messageId: string, hiddenFromAll: boolean, hiddenFromAICharacterIds?: string[]) => {
+      updateMessageExtra.mutate({
+        messageId,
+        extra:
+          hiddenFromAICharacterIds === undefined
+            ? { hiddenFromAI: !hiddenFromAll, hiddenFromAICharacterIds: [] }
+            : { hiddenFromAI: false, hiddenFromAICharacterIds },
+      });
     },
     [updateMessageExtra],
   );

--- a/packages/client/src/components/chat/ChatMessage.tsx
+++ b/packages/client/src/components/chat/ChatMessage.tsx
@@ -2261,7 +2261,12 @@ export const ChatMessage = memo(function ChatMessage({
                 <span className="h-px flex-1 bg-amber-400/20" />
               </div>
               {isHiddenCollapsed ? (
-                <HiddenFromAIMessageSummary roleplay onExpand={() => setManuallyExpandedHidden(true)} />
+                <HiddenFromAIMessageSummary
+                  roleplay
+                  onExpand={() => setManuallyExpandedHidden(true)}
+                  recipientAvatars={hiddenFromAIRecipientAvatars}
+                  statusLabel={hiddenFromAIStatusLabel}
+                />
               ) : (
                 <div
                   className={cn("mari-message-content break-words italic", !isHtmlContent && "whitespace-pre-wrap")}
@@ -2965,7 +2970,11 @@ export const ChatMessage = memo(function ChatMessage({
             style={{ ...messageTextStyle, ...(boxBgColor ? { backgroundColor: boxBgColor } : {}) }}
           >
             {isHiddenCollapsed ? (
-              <HiddenFromAIMessageSummary onExpand={() => setManuallyExpandedHidden(true)} />
+              <HiddenFromAIMessageSummary
+                onExpand={() => setManuallyExpandedHidden(true)}
+                recipientAvatars={hiddenFromAIRecipientAvatars}
+                statusLabel={hiddenFromAIStatusLabel}
+              />
             ) : editing ? (
               <EditTextarea
                 initialContent={message.content}

--- a/packages/client/src/components/chat/ChatMessage.tsx
+++ b/packages/client/src/components/chat/ChatMessage.tsx
@@ -202,16 +202,274 @@ function isMessageQuickEditIgnoredTarget(target: EventTarget | null): boolean {
   );
 }
 
+type AIVisibilityCharacter = {
+  id: string;
+  name: string;
+  avatarUrl: string | null;
+  avatarCrop: AvatarCropValue | null | undefined;
+};
+
+type ToggleHiddenFromAI = (
+  messageId: string,
+  hiddenFromAll: boolean,
+  hiddenFromAICharacterIds?: string[],
+) => void;
+
+function AIVisibilityAvatar({
+  character,
+  className,
+}: {
+  character: AIVisibilityCharacter;
+  className: string;
+}) {
+  return character.avatarUrl ? (
+    <span className={cn("block overflow-hidden rounded-full bg-[var(--marinara-chat-chrome-panel-bg)]", className)}>
+      <img
+        src={character.avatarUrl}
+        alt=""
+        aria-hidden="true"
+        className="h-full w-full object-cover"
+        style={getAvatarCropStyle(character.avatarCrop)}
+      />
+    </span>
+  ) : (
+    <span
+      aria-hidden="true"
+      className={cn(
+        "flex items-center justify-center rounded-full bg-[var(--marinara-chat-chrome-highlight-bg)] font-semibold text-[var(--marinara-chat-chrome-highlight-text)]",
+        className,
+      )}
+    >
+      {character.name.trim().charAt(0).toUpperCase() || "?"}
+    </span>
+  );
+}
+
+function AIVisibilityGroupAvatar({
+  characters,
+  className = "h-7 w-7",
+}: {
+  characters: AIVisibilityCharacter[];
+  className?: string;
+}) {
+  const visible = characters.slice(0, 2);
+  if (visible.length <= 1) {
+    const character = visible[0];
+    return character ? (
+      <AIVisibilityAvatar character={character} className={className} />
+    ) : (
+      <span
+        aria-hidden="true"
+        className={cn(
+          "flex items-center justify-center rounded-full bg-[var(--marinara-chat-chrome-highlight-bg)] text-[var(--marinara-chat-chrome-highlight-text)]",
+          className,
+        )}
+      >
+        <User size="55%" />
+      </span>
+    );
+  }
+
+  return (
+    <span aria-hidden="true" className={cn("relative block", className)}>
+      {visible.map((character, index) => (
+        <span
+          key={character.id}
+          className={cn(
+            "absolute h-[72%] w-[72%] rounded-full ring-1 ring-[var(--marinara-chat-chrome-panel-bg)]",
+            index === 0 ? "left-0 top-0 z-10" : "bottom-0 right-0",
+          )}
+        >
+          <AIVisibilityAvatar character={character} className="h-full w-full" />
+        </span>
+      ))}
+    </span>
+  );
+}
+
+function AIVisibilityRecipientAvatars({
+  characters,
+  hiddenFromAll,
+  hiddenCharacterIds,
+}: {
+  characters: AIVisibilityCharacter[];
+  hiddenFromAll: boolean;
+  hiddenCharacterIds: string[];
+}) {
+  if (hiddenFromAll) {
+    return (
+      <span className="ml-0.5 inline-flex" title="Hidden from all characters">
+        <AIVisibilityGroupAvatar characters={characters} className="h-4 w-4" />
+      </span>
+    );
+  }
+
+  const recipients = hiddenCharacterIds
+    .map((id) => characters.find((character) => character.id === id))
+    .filter((character): character is AIVisibilityCharacter => Boolean(character));
+  if (recipients.length === 0) return null;
+
+  return (
+    <span className="ml-0.5 inline-flex -space-x-1" title={`Hidden from ${recipients.map((item) => item.name).join(", ")}`}>
+      {recipients.map((character) => (
+        <span key={character.id} className="rounded-full ring-1 ring-[var(--marinara-chat-chrome-panel-bg)]">
+          <AIVisibilityAvatar character={character} className="h-4 w-4 text-[0.45rem]" />
+        </span>
+      ))}
+    </span>
+  );
+}
+
+function HideFromAIAction({
+  messageId,
+  hiddenFromAll,
+  hiddenCharacterIds,
+  characters,
+  onToggle,
+  dark,
+  align = "left",
+}: {
+  messageId: string;
+  hiddenFromAll: boolean;
+  hiddenCharacterIds: string[];
+  characters: AIVisibilityCharacter[];
+  onToggle: ToggleHiddenFromAI;
+  dark?: boolean;
+  align?: "left" | "right";
+}) {
+  const [open, setOpen] = useState(false);
+  const rootRef = useRef<HTMLDivElement>(null);
+  const isGroupChat = characters.length > 1;
+  const hasRestriction = hiddenFromAll || hiddenCharacterIds.length > 0;
+
+  useEffect(() => {
+    if (!open) return;
+    const handlePointerDown = (event: PointerEvent) => {
+      if (!rootRef.current?.contains(event.target as Node)) setOpen(false);
+    };
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") setOpen(false);
+    };
+    document.addEventListener("pointerdown", handlePointerDown);
+    document.addEventListener("keydown", handleKeyDown);
+    return () => {
+      document.removeEventListener("pointerdown", handlePointerDown);
+      document.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [open]);
+
+  const toggleCharacter = (characterId: string) => {
+    const next = hiddenFromAll
+      ? [characterId]
+      : hiddenCharacterIds.includes(characterId)
+        ? hiddenCharacterIds.filter((id) => id !== characterId)
+        : [...hiddenCharacterIds, characterId];
+    onToggle(messageId, false, next);
+  };
+
+  return (
+    <div ref={rootRef} className="relative">
+      <ActionBtn
+        icon={hasRestriction ? <Eye size={MESSAGE_ACTION_ICON_SIZE} /> : <EyeOff size={MESSAGE_ACTION_ICON_SIZE} />}
+        onClick={() => {
+          if (isGroupChat) {
+            setOpen((value) => !value);
+          } else if (hiddenCharacterIds.length > 0 && !hiddenFromAll) {
+            onToggle(messageId, false, []);
+          } else {
+            onToggle(messageId, hiddenFromAll);
+          }
+        }}
+        title={
+          isGroupChat
+            ? hasRestriction
+              ? "Change who this is hidden from"
+              : "Choose who to hide this from"
+            : hasRestriction
+              ? "Unhide from AI"
+              : "Hide from AI"
+        }
+        className={cn(
+          "[-webkit-tap-highlight-color:transparent]",
+          hasRestriction && MESSAGE_CHROME_ACTIVE_ICON_CLASS,
+          hasRestriction && "mari-accent-animated",
+        )}
+        ariaPressed={hasRestriction}
+        dark={dark}
+      />
+
+      {open && isGroupChat && (
+        <div
+          role="menu"
+          aria-label="Choose which characters cannot see this message"
+          className={cn(
+            "marinara-chat-popover absolute bottom-[calc(100%+0.45rem)] z-[80] flex max-h-36 w-max max-w-[min(22rem,calc(100vw-1rem))] flex-wrap items-center gap-1.5 overflow-x-hidden overflow-y-auto rounded-xl border border-[var(--marinara-chat-chrome-panel-border)] bg-[var(--marinara-chat-chrome-panel-bg)] p-2 shadow-xl",
+            align === "right" ? "right-0" : "left-0",
+          )}
+        >
+          <button
+            type="button"
+            role="menuitemcheckbox"
+            aria-checked={hiddenFromAll}
+            aria-label="Hide from all characters"
+            title="All characters"
+            onClick={() => onToggle(messageId, hiddenFromAll)}
+            className={cn(
+              "flex aspect-square w-[clamp(1.5rem,8vw,2.25rem)] shrink-0 items-center justify-center rounded-full transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--marinara-chat-chrome-focus-ring)]",
+              hiddenFromAll
+                ? "bg-[var(--marinara-chat-chrome-highlight-bg)] opacity-100 ring-2 ring-[var(--marinara-chat-chrome-button-border-active)]"
+                : "opacity-55 hover:bg-[var(--marinara-chat-chrome-highlight-bg-hover)] hover:opacity-100",
+            )}
+          >
+            <AIVisibilityGroupAvatar characters={characters} className="h-[72%] w-[72%]" />
+          </button>
+
+          <span aria-hidden="true" className="h-7 w-px bg-[var(--marinara-chat-chrome-panel-divider)]" />
+
+          {characters.map((character) => {
+            const selected = !hiddenFromAll && hiddenCharacterIds.includes(character.id);
+            return (
+              <button
+                key={character.id}
+                type="button"
+                role="menuitemcheckbox"
+                aria-checked={selected}
+                aria-label={`Hide from ${character.name}`}
+                title={character.name}
+                onClick={() => toggleCharacter(character.id)}
+                className={cn(
+                  "flex aspect-square w-[clamp(1.5rem,8vw,2.25rem)] shrink-0 items-center justify-center rounded-full transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--marinara-chat-chrome-focus-ring)]",
+                  selected
+                    ? "bg-[var(--marinara-chat-chrome-highlight-bg)] opacity-100 ring-2 ring-[var(--marinara-chat-chrome-button-border-active)] brightness-110"
+                    : hiddenFromAll
+                      ? "opacity-35 hover:opacity-80"
+                      : "opacity-55 hover:bg-[var(--marinara-chat-chrome-highlight-bg-hover)] hover:opacity-100",
+                )}
+              >
+                <AIVisibilityAvatar character={character} className="h-[72%] w-[72%] text-[0.625rem]" />
+              </button>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}
+
 function HiddenFromAIMessageButton({
   roleplay,
   canCollapse,
   onExpand,
   isHiddenExpanded,
+  recipientAvatars,
+  statusLabel = "Hidden from AI",
 }: {
   roleplay?: boolean;
   canCollapse: boolean;
   onExpand: () => void;
   isHiddenExpanded: boolean;
+  recipientAvatars?: ReactNode;
+  statusLabel?: string;
 }) {
   const statusClassName = cn(
     "inline-flex items-center gap-1 rounded px-1 py-0.5 text-[0.625rem] font-medium text-[var(--marinara-chat-chrome-highlight-text)]",
@@ -220,8 +478,9 @@ function HiddenFromAIMessageButton({
 
   if (!canCollapse) {
     return (
-      <span className={cn(statusClassName, "align-middle")} title="Hidden from AI">
+      <span className={cn(statusClassName, "align-middle")} title={statusLabel}>
         <EyeOff size="0.7rem" className="shrink-0" />
+        {recipientAvatars}
       </span>
     );
   }
@@ -236,17 +495,28 @@ function HiddenFromAIMessageButton({
           "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--marinara-chat-chrome-focus-ring)]",
           roleplay && "opacity-80 hover:opacity-100",
         )}
-        aria-label={isHiddenExpanded ? "Collapse hidden from AI message" : "Expand hidden from AI message"}
-        title={isHiddenExpanded ? "Collapse hidden from AI message" : "Expand hidden from AI message"}
+        aria-label={`${isHiddenExpanded ? "Collapse" : "Expand"} message. ${statusLabel}`}
+        title={`${statusLabel}. ${isHiddenExpanded ? "Collapse message" : "Expand message"}`}
       >
         <ChevronRight size="0.7rem" className={cn("shrink-0 transition-transform", isHiddenExpanded && "rotate-90")} />
         <EyeOff size="0.7rem" className="shrink-0" />
+        {recipientAvatars}
       </button>
     </span>
   );
 }
 
-function HiddenFromAIMessageSummary({ roleplay, onExpand }: { roleplay?: boolean; onExpand: () => void }) {
+function HiddenFromAIMessageSummary({
+  roleplay,
+  onExpand,
+  recipientAvatars,
+  statusLabel = "Hidden from AI",
+}: {
+  roleplay?: boolean;
+  onExpand: () => void;
+  recipientAvatars?: ReactNode;
+  statusLabel?: string;
+}) {
   return (
     <button
       type="button"
@@ -262,7 +532,8 @@ function HiddenFromAIMessageSummary({ roleplay, onExpand }: { roleplay?: boolean
       aria-label="Expand hidden from AI message"
     >
       <EyeOff size="0.8rem" className="shrink-0" />
-      <span className="min-w-0 flex-1 truncate">Hidden from AI</span>
+      {recipientAvatars}
+      <span className="min-w-0 flex-1 truncate">{statusLabel}</span>
       <span className="shrink-0 text-[0.625rem] opacity-70">Show</span>
     </button>
   );
@@ -357,7 +628,7 @@ interface ChatMessageProps {
   onEdit?: (messageId: string, content: string) => void;
   onSetActiveSwipe?: (messageId: string, index: number) => void;
   onToggleConversationStart?: (messageId: string, current: boolean) => void;
-  onToggleHiddenFromAI?: (messageId: string, current: boolean) => void;
+  onToggleHiddenFromAI?: ToggleHiddenFromAI;
   onPeekPrompt?: () => void;
   onBranch?: (messageId: string) => void;
   onCloneSceneFromHere?: (messageId: string) => void;
@@ -1243,7 +1514,17 @@ export const ChatMessage = memo(function ChatMessage({
     return typeof message.extra === "string" ? JSON.parse(message.extra) : message.extra;
   }, [message.extra]);
   const isConversationStart = !!extra.isConversationStart;
-  const isHiddenFromAI = extra.hiddenFromAI === true;
+  const isHiddenFromAllAI = extra.hiddenFromAI === true;
+  const hiddenFromAICharacterIds: string[] = Array.isArray(extra.hiddenFromAICharacterIds)
+    ? Array.from(
+        new Set<string>(
+          (extra.hiddenFromAICharacterIds as unknown[])
+            .filter((characterId): characterId is string => typeof characterId === "string" && !!characterId.trim())
+            .map((characterId) => characterId.trim()),
+        ),
+      )
+    : [];
+  const isHiddenFromAI = isHiddenFromAllAI || hiddenFromAICharacterIds.length > 0;
   const thinking = extra.thinking as string | undefined;
   const generationReplay = hasGenerationReplayDetails(extra.generationReplay) ? extra.generationReplay : null;
   const diceRollResult = isDiceRollResult(extra.diceRollResult) ? extra.diceRollResult : null;
@@ -1455,6 +1736,20 @@ export const ChatMessage = memo(function ChatMessage({
     if (message.characterId) allowedIds.add(message.characterId);
     return new Map(Array.from(characterMap).filter(([id]) => allowedIds.has(id)));
   }, [characterMap, chatCharacterIds, message.characterId]);
+  const aiVisibilityCharacters = useMemo<AIVisibilityCharacter[]>(() => {
+    const result: AIVisibilityCharacter[] = [];
+    for (const id of chatCharacterIds ?? []) {
+      const character = characterMap?.get(id);
+      if (!character) continue;
+      result.push({
+        id,
+        name: character.name,
+        avatarUrl: character.avatarUrl,
+        avatarCrop: character.avatarCrop,
+      });
+    }
+    return result;
+  }, [characterMap, chatCharacterIds]);
 
   // Resolve character info from characters that actually belong to this chat.
   const charInfo = message.characterId && scopedCharacterMap ? scopedCharacterMap.get(message.characterId) : null;
@@ -1794,16 +2089,38 @@ export const ChatMessage = memo(function ChatMessage({
   const isHiddenExpanded =
     isHiddenFromAI && (!collapseHiddenMessages || manuallyExpandedHidden || editing || !!isStreaming);
   const isHiddenCollapsed = isHiddenFromAI && collapseHiddenMessages && !isHiddenExpanded;
+  const hiddenFromAIRecipientNames = aiVisibilityCharacters
+    .filter((character) => hiddenFromAICharacterIds.includes(character.id))
+    .map((character) => character.name);
+  const hiddenFromAIStatusLabel = isHiddenFromAllAI
+    ? "Hidden from all characters"
+    : hiddenFromAIRecipientNames.length > 0
+      ? `Hidden from ${hiddenFromAIRecipientNames.join(", ")}`
+      : "Hidden from selected characters";
+  const hiddenFromAIRecipientAvatars = (
+    <AIVisibilityRecipientAvatars
+      characters={aiVisibilityCharacters}
+      hiddenFromAll={isHiddenFromAllAI}
+      hiddenCharacterIds={hiddenFromAICharacterIds}
+    />
+  );
   const hiddenFromAIHeader = isHiddenFromAI ? (
     <HiddenFromAIMessageButton
       roleplay={isRoleplay}
       canCollapse={collapseHiddenMessages}
       isHiddenExpanded={isHiddenExpanded}
       onExpand={() => setManuallyExpandedHidden((value) => !value)}
+      recipientAvatars={hiddenFromAIRecipientAvatars}
+      statusLabel={hiddenFromAIStatusLabel}
     />
   ) : null;
   const roleplayBubbleContent = isHiddenCollapsed ? (
-    <HiddenFromAIMessageSummary roleplay={isRoleplay} onExpand={() => setManuallyExpandedHidden(true)} />
+    <HiddenFromAIMessageSummary
+      roleplay={isRoleplay}
+      onExpand={() => setManuallyExpandedHidden(true)}
+      recipientAvatars={hiddenFromAIRecipientAvatars}
+      statusLabel={hiddenFromAIStatusLabel}
+    />
   ) : editing ? (
     <EditTextarea
       initialContent={message.content}
@@ -2377,18 +2694,14 @@ export const ChatMessage = memo(function ChatMessage({
                 dark
               />
               {onToggleHiddenFromAI && (
-                <ActionBtn
-                  icon={
-                    isHiddenFromAI ? (
-                      <Eye size={MESSAGE_ACTION_ICON_SIZE} />
-                    ) : (
-                      <EyeOff size={MESSAGE_ACTION_ICON_SIZE} />
-                    )
-                  }
-                  onClick={() => onToggleHiddenFromAI(message.id, isHiddenFromAI)}
-                  title={isHiddenFromAI ? "Unhide from AI" : "Hide from AI"}
-                  className={isHiddenFromAI ? MESSAGE_CHROME_ACTIVE_ICON_CLASS : undefined}
+                <HideFromAIAction
+                  messageId={message.id}
+                  hiddenFromAll={isHiddenFromAllAI}
+                  hiddenCharacterIds={hiddenFromAICharacterIds}
+                  characters={isRoleplay ? aiVisibilityCharacters : []}
+                  onToggle={onToggleHiddenFromAI}
                   dark
+                  align={isUser ? "right" : "left"}
                 />
               )}
               {isLastAssistantMessage && !isUser && (
@@ -2859,14 +3172,14 @@ export const ChatMessage = memo(function ChatMessage({
               />
             )}
             {onToggleHiddenFromAI && (
-              <ActionBtn
-                icon={
-                  isHiddenFromAI ? <Eye size={MESSAGE_ACTION_ICON_SIZE} /> : <EyeOff size={MESSAGE_ACTION_ICON_SIZE} />
-                }
-                onClick={() => onToggleHiddenFromAI(message.id, isHiddenFromAI)}
-                title={isHiddenFromAI ? "Unhide from AI" : "Hide from AI"}
-                className={isHiddenFromAI ? MESSAGE_CHROME_ACTIVE_ICON_CLASS : undefined}
+              <HideFromAIAction
+                messageId={message.id}
+                hiddenFromAll={isHiddenFromAllAI}
+                hiddenCharacterIds={hiddenFromAICharacterIds}
+                characters={isRoleplay ? aiVisibilityCharacters : []}
+                onToggle={onToggleHiddenFromAI}
                 dark
+                align={isUser ? "right" : "left"}
               />
             )}
             <ActionBtn

--- a/packages/client/src/components/chat/ChatMessage.tsx
+++ b/packages/client/src/components/chat/ChatMessage.tsx
@@ -223,7 +223,12 @@ function AIVisibilityAvatar({
   className: string;
 }) {
   return character.avatarUrl ? (
-    <span className={cn("block overflow-hidden rounded-full bg-[var(--marinara-chat-chrome-panel-bg)]", className)}>
+    <span
+      className={cn(
+        "relative isolate block overflow-hidden rounded-full bg-[var(--marinara-chat-chrome-panel-bg)]",
+        className,
+      )}
+    >
       <img
         src={character.avatarUrl}
         alt=""

--- a/packages/client/src/components/chat/ChatRoleplaySurface.tsx
+++ b/packages/client/src/components/chat/ChatRoleplaySurface.tsx
@@ -1116,7 +1116,11 @@ type RoleplaySurfaceProps = {
   onEdit: (messageId: string, content: string) => void;
   onSetActiveSwipe: (messageId: string, index: number) => void;
   onToggleConversationStart: (messageId: string, current: boolean) => void;
-  onToggleHiddenFromAI: (messageId: string, current: boolean) => void;
+  onToggleHiddenFromAI: (
+    messageId: string,
+    hiddenFromAll: boolean,
+    hiddenFromAICharacterIds?: string[],
+  ) => void;
   onPeekPrompt: () => void;
   onBranch?: (messageId: string) => void;
   onCloneSceneFromHere?: (messageId: string) => void;

--- a/packages/server/src/routes/chats.routes.ts
+++ b/packages/server/src/routes/chats.routes.ts
@@ -1701,12 +1701,15 @@ export async function chatsRoutes(app: FastifyInstance) {
       if (Object.prototype.hasOwnProperty.call(partial, "hiddenFromAI")) {
         syncAllSwipeExtra.hiddenFromAI = partial.hiddenFromAI;
       }
+      if (Object.prototype.hasOwnProperty.call(partial, "hiddenFromAICharacterIds")) {
+        syncAllSwipeExtra.hiddenFromAICharacterIds = partial.hiddenFromAICharacterIds;
+      }
       if (Object.prototype.hasOwnProperty.call(partial, "reactions")) {
         syncAllSwipeExtra.reactions = partial.reactions;
       }
 
       if (Object.keys(syncAllSwipeExtra).length > 0) {
-        // hiddenFromAI and reactions are message-level fields, so keep them
+        // AI visibility and reactions are message-level fields, so keep them
         // stable across swipe changes instead of binding them to one swipe.
         const swipes = await storage.getSwipes(req.params.messageId);
         for (const swipe of swipes) {

--- a/packages/server/src/routes/generate.routes.ts
+++ b/packages/server/src/routes/generate.routes.ts
@@ -200,6 +200,7 @@ import {
   computeSummaryHideIds,
   selectRollingSummaryMessages,
   injectIntoOutputFormatOrLastUser,
+  getMessageHiddenFromAICharacterIds,
   isManualTrackerCharacterId,
   isMessageHiddenFromAI,
   mergeCustomParameters,
@@ -421,6 +422,7 @@ import {
   type ConversationProfileParticipant,
 } from "../services/conversation/conversation-profiles.js";
 import {
+  filterPromptMessagesForCharacterAudience,
   scopeIndividualGroupMessagesForTarget,
   type GenerationPromptMessage,
 } from "../services/generation/prompt-message-scope.js";
@@ -1243,6 +1245,7 @@ export async function generateRoutes(app: FastifyInstance) {
           const photoName = userUploadedImages[0]?.filename ?? userUploadedImages[0]?.name;
           content += `\n[Sent a photo${photoName ? `: ${photoName}` : ""}]`;
         }
+        const hiddenFromAICharacterIds = getMessageHiddenFromAICharacterIds(m);
 
         return {
           id: typeof m.id === "string" ? m.id : null,
@@ -1250,6 +1253,7 @@ export async function generateRoutes(app: FastifyInstance) {
           content,
           contextKind: "history" as const,
           characterId: typeof m.characterId === "string" && m.characterId ? m.characterId : null,
+          ...(hiddenFromAICharacterIds.length ? { hiddenFromAICharacterIds } : {}),
           ...(attachmentInputs.images.length ? { images: attachmentInputs.images } : {}),
           ...(attachmentInputs.files.length ? { files: attachmentInputs.files } : {}),
           ...(Object.keys(providerMetadata).length ? { providerMetadata } : {}),
@@ -4729,6 +4733,17 @@ export async function generateRoutes(app: FastifyInstance) {
               ]);
             }
           }
+          const audienceCharacterIds = input.impersonate
+            ? []
+            : speaksOnlyTargetCharacter
+              ? targetCharId
+                ? [targetCharId]
+                : []
+              : characterIds;
+          gameAwareMessagesForGen = filterPromptMessagesForCharacterAudience(
+            gameAwareMessagesForGen,
+            audienceCharacterIds,
+          );
           const scopedMessagesForGen =
             isGroupChat && usesIndividualGroupGeneration && targetCharId
               ? scopeIndividualGroupMessagesForTarget(gameAwareMessagesForGen, targetCharId, charInfo)

--- a/packages/server/src/routes/generate/dry-run-route.ts
+++ b/packages/server/src/routes/generate/dry-run-route.ts
@@ -64,6 +64,7 @@ import {
   extractImageAttachmentDataUrls,
   findTrackerContextInsertIndex,
   formatConversationInstructionsForWrap,
+  getMessageHiddenFromAICharacterIds,
   isMessageHiddenFromAI,
   mergeCustomParameters,
   normalizePromptWrapFormat,
@@ -674,6 +675,7 @@ export async function registerDryRunRoute(app: FastifyInstance) {
       const attachments = extra.attachments as PromptAttachment[] | undefined;
       const images = extractImageAttachmentDataUrls(attachments);
       const files = extractFileAttachmentInputs(attachments);
+      const hiddenFromAICharacterIds = getMessageHiddenFromAICharacterIds(m);
       const geminiParts =
         !excludePastReasoning && isGoogleProvider && m.role === "assistant" && extra.geminiParts
           ? { providerMetadata: { geminiParts: extra.geminiParts } }
@@ -684,6 +686,7 @@ export async function registerDryRunRoute(app: FastifyInstance) {
         content: appendReadableAttachmentsToContent((m.content as string) ?? "", attachments),
         contextKind: "history" as const,
         characterId: typeof m.characterId === "string" && m.characterId ? m.characterId : null,
+        ...(hiddenFromAICharacterIds.length ? { hiddenFromAICharacterIds } : {}),
         ...(images?.length ? { images } : {}),
         ...(files.length ? { files } : {}),
         ...geminiParts,
@@ -721,6 +724,11 @@ export async function registerDryRunRoute(app: FastifyInstance) {
         ? body.forCharacterId
         : null;
     const promptCharacterIds = resolvePromptCharacterIdsForTarget(characterIds, promptTargetCharacterId);
+    if (promptTargetCharacterId && !impersonate) {
+      mappedMessages = mappedMessages.filter(
+        (message) => !message.hiddenFromAICharacterIds?.includes(promptTargetCharacterId),
+      );
+    }
 
     // Persona resolution (same strategy as generation; read-only)
     let personaId: string | null = null;

--- a/packages/server/src/routes/generate/dry-run-route.ts
+++ b/packages/server/src/routes/generate/dry-run-route.ts
@@ -724,9 +724,15 @@ export async function registerDryRunRoute(app: FastifyInstance) {
         ? body.forCharacterId
         : null;
     const promptCharacterIds = resolvePromptCharacterIdsForTarget(characterIds, promptTargetCharacterId);
-    if (promptTargetCharacterId && !impersonate) {
+    const audienceCharacterIds = impersonate
+      ? []
+      : promptTargetCharacterId
+        ? [promptTargetCharacterId]
+        : characterIds;
+    if (audienceCharacterIds.length > 0) {
+      const audience = new Set(audienceCharacterIds);
       mappedMessages = mappedMessages.filter(
-        (message) => !message.hiddenFromAICharacterIds?.includes(promptTargetCharacterId),
+        (message) => !message.hiddenFromAICharacterIds?.some((characterId) => audience.has(characterId)),
       );
     }
 

--- a/packages/server/src/routes/generate/generate-route-utils.ts
+++ b/packages/server/src/routes/generate/generate-route-utils.ts
@@ -509,6 +509,22 @@ export function isMessageHiddenFromAI(message: { extra?: unknown }): boolean {
   return parseExtra(message.extra).hiddenFromAI === true;
 }
 
+export function getMessageHiddenFromAICharacterIds(message: { extra?: unknown }): string[] {
+  const value = parseExtra(message.extra).hiddenFromAICharacterIds;
+  if (!Array.isArray(value)) return [];
+  return Array.from(
+    new Set(value.filter((item): item is string => typeof item === "string").map((item) => item.trim()).filter(Boolean)),
+  );
+}
+
+export function isMessageHiddenFromAIForCharacter(
+  message: { extra?: unknown },
+  characterId: string | null | undefined,
+): boolean {
+  if (isMessageHiddenFromAI(message)) return true;
+  return typeof characterId === "string" && getMessageHiddenFromAICharacterIds(message).includes(characterId);
+}
+
 export function isRoleplaySummaryMode(chatMode: string): boolean {
   return chatMode === "roleplay" || chatMode === "visual_novel";
 }

--- a/packages/server/src/services/generation/prompt-message-scope.ts
+++ b/packages/server/src/services/generation/prompt-message-scope.ts
@@ -7,6 +7,7 @@ export type GenerationPromptMessage = {
   content: string;
   contextKind?: "prompt" | "history" | "injection";
   characterId?: string | null;
+  hiddenFromAICharacterIds?: string[];
   images?: string[];
   files?: Array<{ type: string; data: string; filename?: string }>;
   providerMetadata?: Record<string, unknown>;
@@ -227,6 +228,21 @@ function reassignHistoryLastMessageWrapper(messages: GenerationPromptMessage[]):
     ...messages[lastHistoryIndex]!,
     content: `## Last Message\n${messages[lastHistoryIndex]!.content}`,
   };
+}
+
+export function filterPromptMessagesForCharacterAudience(
+  messages: GenerationPromptMessage[],
+  audienceCharacterIds: string[],
+): GenerationPromptMessage[] {
+  if (audienceCharacterIds.length === 0) return messages;
+  const audience = new Set(audienceCharacterIds);
+  const filtered = messages.filter(
+    (message) => !message.hiddenFromAICharacterIds?.some((characterId) => audience.has(characterId)),
+  );
+  if (filtered.length === messages.length) return messages;
+  reassignHistoryLastMessageWrapper(filtered);
+  pruneEmptyPromptWrappers(filtered);
+  return filtered;
 }
 
 export function scopeIndividualGroupMessagesForTarget(

--- a/packages/server/src/services/prompt/assembler.ts
+++ b/packages/server/src/services/prompt/assembler.ts
@@ -826,6 +826,10 @@ function appendFallbackChatSummaryToSystemPrompt(
 function enforceStrictRoles(messages: ChatMLMessage[]): ChatMLMessage[] {
   if (messages.length === 0) return messages;
 
+  const hasSameAudience = (first: ChatMLMessage | undefined, second: ChatMLMessage) =>
+    JSON.stringify(first?.hiddenFromAICharacterIds ?? []) ===
+    JSON.stringify(second.hiddenFromAICharacterIds ?? []);
+
   const mergeInto = (target: ChatMLMessage, source: ChatMLMessage) => {
     target.content += "\n\n" + source.content;
     if (target.contextKind !== source.contextKind) {
@@ -847,8 +851,8 @@ function enforceStrictRoles(messages: ChatMLMessage[]): ChatMLMessage[] {
   let idx = 0;
   while (idx < messages.length && messages[idx]!.role === "system") {
     const msg = messages[idx]!;
-    const leadingSystem = result[0];
-    if (leadingSystem?.role === "system") {
+    const leadingSystem = result[result.length - 1];
+    if (leadingSystem?.role === "system" && hasSameAudience(leadingSystem, msg)) {
       mergeInto(leadingSystem, msg);
     } else {
       result.push({ ...msg });
@@ -861,14 +865,14 @@ function enforceStrictRoles(messages: ChatMLMessage[]): ChatMLMessage[] {
 
     if (msg.role === "system") {
       const prev = result[result.length - 1];
-      if (prev?.role === "system") mergeInto(prev, msg);
+      if (prev?.role === "system" && hasSameAudience(prev, msg)) mergeInto(prev, msg);
       else result.push({ ...msg });
       continue;
     }
 
     const prev = result[result.length - 1];
     const sameCharacter = (prev?.characterId ?? null) === (msg.characterId ?? null);
-    if (prev && prev.role === msg.role && sameCharacter) {
+    if (prev && prev.role === msg.role && sameCharacter && hasSameAudience(prev, msg)) {
       mergeInto(prev, msg);
     } else {
       result.push({ ...msg });

--- a/packages/server/src/services/prompt/assembler.ts
+++ b/packages/server/src/services/prompt/assembler.ts
@@ -826,9 +826,14 @@ function appendFallbackChatSummaryToSystemPrompt(
 function enforceStrictRoles(messages: ChatMLMessage[]): ChatMLMessage[] {
   if (messages.length === 0) return messages;
 
-  const hasSameAudience = (first: ChatMLMessage | undefined, second: ChatMLMessage) =>
-    JSON.stringify(first?.hiddenFromAICharacterIds ?? []) ===
-    JSON.stringify(second.hiddenFromAICharacterIds ?? []);
+  const hasSameAudience = (first: ChatMLMessage | undefined, second: ChatMLMessage) => {
+    const firstAudience = first?.hiddenFromAICharacterIds ?? [];
+    const secondAudience = second.hiddenFromAICharacterIds ?? [];
+    return (
+      firstAudience.length === secondAudience.length &&
+      firstAudience.every((characterId) => secondAudience.includes(characterId))
+    );
+  };
 
   const mergeInto = (target: ChatMLMessage, source: ChatMLMessage) => {
     target.content += "\n\n" + source.content;

--- a/packages/server/src/services/prompt/merger.ts
+++ b/packages/server/src/services/prompt/merger.ts
@@ -3,6 +3,15 @@
 // ──────────────────────────────────────────────
 import type { ChatMLMessage } from "@marinara-engine/shared";
 
+function hasSameAudience(first: ChatMLMessage | undefined, second: ChatMLMessage): boolean {
+  const firstAudience = first?.hiddenFromAICharacterIds ?? [];
+  const secondAudience = second.hiddenFromAICharacterIds ?? [];
+  return (
+    firstAudience.length === secondAudience.length &&
+    firstAudience.every((characterId) => secondAudience.includes(characterId))
+  );
+}
+
 /**
  * Merge consecutive messages that share the same role, with a double-newline separator.
  *
@@ -31,11 +40,7 @@ export function mergeAdjacentMessages(messages: ChatMLMessage[]): ChatMLMessage[
   const canMerge = (a: ChatMLMessage, b: ChatMLMessage) => {
     if (a.role !== b.role) return false;
     if ((a.characterId ?? null) !== (b.characterId ?? null)) return false;
-    if (
-      JSON.stringify(a.hiddenFromAICharacterIds ?? []) !== JSON.stringify(b.hiddenFromAICharacterIds ?? [])
-    ) {
-      return false;
-    }
+    if (!hasSameAudience(a, b)) return false;
     if (!a.contextKind || !b.contextKind) return true;
     return a.contextKind === b.contextKind;
   };
@@ -79,8 +84,8 @@ export function mergeAdjacentMessages(messages: ChatMLMessage[]): ChatMLMessage[
 }
 
 /**
- * Squash all system messages into one (used when `squashSystemMessages` is enabled).
- * Groups all consecutive system messages at the start, then keeps the rest.
+ * Squash contiguous leading system messages with the same character audience
+ * (used when `squashSystemMessages` is enabled), then keep the rest.
  */
 export function squashLeadingSystemMessages(messages: ChatMLMessage[]): ChatMLMessage[] {
   if (messages.length === 0) return [];
@@ -93,32 +98,32 @@ export function squashLeadingSystemMessages(messages: ChatMLMessage[]): ChatMLMe
 
   if (systemEnd <= 1) return messages; // Nothing to squash
 
-  // Character-scoped visibility must survive until the per-character prompt is
-  // prepared. Combining different audiences here would make that impossible.
   const leadingSystemMessages = messages.slice(0, systemEnd);
-  const firstAudience = JSON.stringify(leadingSystemMessages[0]?.hiddenFromAICharacterIds ?? []);
-  if (
-    leadingSystemMessages.some(
-      (message) => JSON.stringify(message.hiddenFromAICharacterIds ?? []) !== firstAudience,
-    )
-  ) {
-    return messages;
+  const squashRun = (run: ChatMLMessage[]): ChatMLMessage => {
+    if (run.length === 1) return run[0]!;
+    const contextKinds = new Set(run.map((message) => message.contextKind).filter(Boolean));
+    return {
+      role: "system",
+      content: run.map((message) => message.content).join("\n\n"),
+      ...(contextKinds.size === 1 ? { contextKind: [...contextKinds][0] } : {}),
+      ...(run[0]?.hiddenFromAICharacterIds?.length
+        ? { hiddenFromAICharacterIds: run[0].hiddenFromAICharacterIds }
+        : {}),
+    };
+  };
+
+  const squashedSystemMessages: ChatMLMessage[] = [];
+  let runStart = 0;
+  for (let index = 1; index <= leadingSystemMessages.length; index += 1) {
+    if (
+      index < leadingSystemMessages.length &&
+      hasSameAudience(leadingSystemMessages[runStart], leadingSystemMessages[index]!)
+    ) {
+      continue;
+    }
+    squashedSystemMessages.push(squashRun(leadingSystemMessages.slice(runStart, index)));
+    runStart = index;
   }
 
-  const combinedContent = leadingSystemMessages.map((m) => m.content).join("\n\n");
-  const contextKinds = new Set(
-    leadingSystemMessages.map((m) => m.contextKind).filter(Boolean),
-  );
-
-  return [
-    {
-      role: "system",
-      content: combinedContent,
-      ...(contextKinds.size === 1 ? { contextKind: [...contextKinds][0] } : {}),
-      ...(leadingSystemMessages[0]?.hiddenFromAICharacterIds?.length
-        ? { hiddenFromAICharacterIds: leadingSystemMessages[0].hiddenFromAICharacterIds }
-        : {}),
-    },
-    ...messages.slice(systemEnd),
-  ];
+  return [...squashedSystemMessages, ...messages.slice(systemEnd)];
 }

--- a/packages/server/src/services/prompt/merger.ts
+++ b/packages/server/src/services/prompt/merger.ts
@@ -31,6 +31,11 @@ export function mergeAdjacentMessages(messages: ChatMLMessage[]): ChatMLMessage[
   const canMerge = (a: ChatMLMessage, b: ChatMLMessage) => {
     if (a.role !== b.role) return false;
     if ((a.characterId ?? null) !== (b.characterId ?? null)) return false;
+    if (
+      JSON.stringify(a.hiddenFromAICharacterIds ?? []) !== JSON.stringify(b.hiddenFromAICharacterIds ?? [])
+    ) {
+      return false;
+    }
     if (!a.contextKind || !b.contextKind) return true;
     return a.contextKind === b.contextKind;
   };
@@ -54,6 +59,9 @@ export function mergeAdjacentMessages(messages: ChatMLMessage[]): ChatMLMessage[
         ...(mergedContextKind ? { contextKind: mergedContextKind } : {}),
         name: current.name,
         ...(current.characterId ? { characterId: current.characterId } : {}),
+        ...(current.hiddenFromAICharacterIds?.length
+          ? { hiddenFromAICharacterIds: current.hiddenFromAICharacterIds }
+          : {}),
         ...(mergedImages ? { images: mergedImages } : {}),
         ...(mergedFiles ? { files: mergedFiles } : {}),
         ...(mergedMeta ? { providerMetadata: mergedMeta } : {}),
@@ -85,15 +93,21 @@ export function squashLeadingSystemMessages(messages: ChatMLMessage[]): ChatMLMe
 
   if (systemEnd <= 1) return messages; // Nothing to squash
 
-  const combinedContent = messages
-    .slice(0, systemEnd)
-    .map((m) => m.content)
-    .join("\n\n");
+  // Character-scoped visibility must survive until the per-character prompt is
+  // prepared. Combining different audiences here would make that impossible.
+  const leadingSystemMessages = messages.slice(0, systemEnd);
+  const firstAudience = JSON.stringify(leadingSystemMessages[0]?.hiddenFromAICharacterIds ?? []);
+  if (
+    leadingSystemMessages.some(
+      (message) => JSON.stringify(message.hiddenFromAICharacterIds ?? []) !== firstAudience,
+    )
+  ) {
+    return messages;
+  }
+
+  const combinedContent = leadingSystemMessages.map((m) => m.content).join("\n\n");
   const contextKinds = new Set(
-    messages
-      .slice(0, systemEnd)
-      .map((m) => m.contextKind)
-      .filter(Boolean),
+    leadingSystemMessages.map((m) => m.contextKind).filter(Boolean),
   );
 
   return [
@@ -101,6 +115,9 @@ export function squashLeadingSystemMessages(messages: ChatMLMessage[]): ChatMLMe
       role: "system",
       content: combinedContent,
       ...(contextKinds.size === 1 ? { contextKind: [...contextKinds][0] } : {}),
+      ...(leadingSystemMessages[0]?.hiddenFromAICharacterIds?.length
+        ? { hiddenFromAICharacterIds: leadingSystemMessages[0].hiddenFromAICharacterIds }
+        : {}),
     },
     ...messages.slice(systemEnd),
   ];

--- a/packages/server/src/services/storage/chats.storage.ts
+++ b/packages/server/src/services/storage/chats.storage.ts
@@ -189,7 +189,14 @@ function freshSwipeMessageExtra(value: unknown): Record<string, unknown> {
     generationInfo: null,
   };
 
-  for (const key of ["hiddenFromAI", "hiddenFromUser", "isConversationStart", "reactions", "personaSnapshot"]) {
+  for (const key of [
+    "hiddenFromAI",
+    "hiddenFromAICharacterIds",
+    "hiddenFromUser",
+    "isConversationStart",
+    "reactions",
+    "personaSnapshot",
+  ]) {
     if (Object.prototype.hasOwnProperty.call(current, key)) {
       next[key] = current[key];
     }

--- a/packages/shared/src/types/chat.ts
+++ b/packages/shared/src/types/chat.ts
@@ -743,6 +743,8 @@ export interface MessageExtra {
   hiddenFromUser?: boolean;
   /** When true, the visible message is excluded from future AI prompt context */
   hiddenFromAI?: boolean;
+  /** Character IDs whose generation context excludes this message. Global hiddenFromAI takes precedence. */
+  hiddenFromAICharacterIds?: string[];
   /** When true, Roleplay renders this generated assistant turn as a fresh bubble instead of grouping with the previous assistant turn. */
   startsNewAssistantBubble?: boolean;
   /** Structured dice roll payload rendered by the chat UI. */

--- a/packages/shared/src/types/prompt.ts
+++ b/packages/shared/src/types/prompt.ts
@@ -251,6 +251,8 @@ export interface ChatMLMessage {
   name?: string;
   /** Internal speaker identity for group chat history role scoping. */
   characterId?: string | null;
+  /** Internal Roleplay audience filter. Removed before messages reach a provider. */
+  hiddenFromAICharacterIds?: string[];
   /** Base64 data URLs for multimodal image inputs */
   images?: string[];
   /** Base64 data URLs for provider-native file/document inputs */

--- a/scripts/regressions/prompt.regression.ts
+++ b/scripts/regressions/prompt.regression.ts
@@ -354,12 +354,37 @@ assert.deepEqual(
   "merged messages should retain their restricted audience",
 );
 assert.equal(
+  mergeAdjacentMessages([
+    { role: "user", content: "First shared secret", hiddenFromAICharacterIds: ["pantalone", "dottore"] },
+    { role: "user", content: "Second shared secret", hiddenFromAICharacterIds: ["dottore", "pantalone"] },
+  ]).length,
+  1,
+  "equivalent character audiences should merge regardless of selection order",
+);
+assert.equal(
   squashLeadingSystemMessages([
     { role: "system", content: "Visible system context" },
     { role: "system", content: "Private event", hiddenFromAICharacterIds: ["pantalone"] },
   ]).length,
   2,
   "system-message squashing should not combine different character audiences",
+);
+const audienceScopedSystemMessages = squashLeadingSystemMessages([
+  { role: "system", content: "Public setup A" },
+  { role: "system", content: "Public setup B" },
+  { role: "system", content: "Private setup A", hiddenFromAICharacterIds: ["pantalone", "dottore"] },
+  { role: "system", content: "Private setup B", hiddenFromAICharacterIds: ["dottore", "pantalone"] },
+  { role: "user", content: "Continue" },
+]);
+assert.deepEqual(
+  audienceScopedSystemMessages.map((message) => message.content),
+  ["Public setup A\n\nPublic setup B", "Private setup A\n\nPrivate setup B", "Continue"],
+  "leading system messages should squash within contiguous equivalent audience runs",
+);
+assert.deepEqual(
+  audienceScopedSystemMessages[1]!.hiddenFromAICharacterIds,
+  ["pantalone", "dottore"],
+  "squashed system runs should retain their character audience",
 );
 import {
   compactVideoPromptText,

--- a/scripts/regressions/prompt.regression.ts
+++ b/scripts/regressions/prompt.regression.ts
@@ -214,6 +214,11 @@ import {
   renderAgentPromptTemplate,
 } from "../../packages/server/src/services/agents/agent-executor.js";
 import { shouldSkipAgentByAssistantInterval } from "../../packages/server/src/services/generation/agent-cadence.js";
+import { filterPromptMessagesForCharacterAudience } from "../../packages/server/src/services/generation/prompt-message-scope.js";
+import {
+  mergeAdjacentMessages,
+  squashLeadingSystemMessages,
+} from "../../packages/server/src/services/prompt/merger.js";
 import type { ResolvedAgent } from "../../packages/server/src/services/agents/agent-pipeline.js";
 import { loadGameVideoPrompt } from "../../packages/server/src/services/video/game-video-prompt.js";
 import { loadGameStoryboardImagePrompt } from "../../packages/server/src/services/image/game-storyboard-image-prompt.js";
@@ -263,6 +268,98 @@ assert.equal(
   }),
   true,
   "a swipe or continuation should not count as a new accepted assistant message",
+);
+
+const selectivelyHiddenMessage = {
+  extra: JSON.stringify({ hiddenFromAICharacterIds: ["pantalone", "pantalone", " dottore ", 42] }),
+};
+assert.deepEqual(
+  getMessageHiddenFromAICharacterIds(selectivelyHiddenMessage),
+  ["pantalone", "dottore"],
+  "per-character AI visibility should normalize valid unique character IDs",
+);
+assert.equal(
+  isMessageHiddenFromAIForCharacter(selectivelyHiddenMessage, "pantalone"),
+  true,
+  "a selectively hidden message should be excluded from the selected character's context",
+);
+assert.equal(
+  isMessageHiddenFromAIForCharacter(selectivelyHiddenMessage, "maukie"),
+  false,
+  "a selectively hidden message should remain visible to non-selected characters",
+);
+assert.equal(
+  isMessageHiddenFromAIForCharacter({ extra: { hiddenFromAI: true } }, "maukie"),
+  true,
+  "legacy global AI visibility should continue to hide messages from every character",
+);
+
+const audienceScopedHistory: ChatMLMessage[] = [
+  {
+    role: "user",
+    content: "<chat_history>\nVisible setup\n</chat_history>",
+    contextKind: "history",
+  },
+  {
+    role: "assistant",
+    content: "<last_message>\nPantalone's private clue\n</last_message>",
+    contextKind: "history",
+    characterId: "dottore",
+    hiddenFromAICharacterIds: ["pantalone"],
+  },
+];
+const pantaloneHistory = filterPromptMessagesForCharacterAudience(audienceScopedHistory, ["pantalone"]);
+assert.equal(pantaloneHistory.length, 1, "the selected character should not receive the restricted history message");
+assert.match(
+  pantaloneHistory[0]!.content,
+  /^<last_message>[\s\S]*Visible setup[\s\S]*<\/last_message>$/,
+  "history wrappers should be repaired after a restricted message is removed",
+);
+assert.equal(
+  filterPromptMessagesForCharacterAudience(audienceScopedHistory, ["dottore"]).length,
+  2,
+  "other group characters should keep the restricted message in context",
+);
+assert.equal(
+  mergeAdjacentMessages([
+    { role: "user", content: "Visible", contextKind: "history" },
+    {
+      role: "user",
+      content: "Private",
+      contextKind: "history",
+      hiddenFromAICharacterIds: ["pantalone"],
+    },
+  ]).length,
+  2,
+  "prompt assembly must not merge messages with different character audiences",
+);
+const mergedRestrictedHistory = mergeAdjacentMessages([
+  {
+    role: "user",
+    content: "First private detail",
+    contextKind: "history",
+    hiddenFromAICharacterIds: ["pantalone"],
+  },
+  {
+    role: "user",
+    content: "Second private detail",
+    contextKind: "history",
+    hiddenFromAICharacterIds: ["pantalone"],
+  },
+]);
+assert.equal(mergedRestrictedHistory.length, 1, "messages with the same restricted audience may still merge");
+assert.deepEqual(
+  mergedRestrictedHistory[0]!.hiddenFromAICharacterIds,
+  ["pantalone"],
+  "merged messages should retain their restricted audience",
+);
+assert.equal(
+  squashLeadingSystemMessages([
+    { role: "system", content: "Visible system context" },
+    { role: "system", content: "Private event", hiddenFromAICharacterIds: ["pantalone"] },
+  ]).length,
+  2,
+  "system-message squashing should not combine different character audiences",
 );
 import {
   compactVideoPromptText,
@@ -336,7 +433,9 @@ import {
   buildGenerationGuideInstruction,
   appendSeparateAgentInjectionMessage,
   collectLatestTrackerCharacterHistory,
+  getMessageHiddenFromAICharacterIds,
   injectIntoOutputFormatOrLastUser,
+  isMessageHiddenFromAIForCharacter,
   preserveTrackerCharacterUiFields,
   resolveActivePersonaCandidate,
   shouldEnableAgentsForGeneration,


### PR DESCRIPTION
## Why

Roleplay group chats need message visibility scoped to selected characters so private information can remain available to the rest of the cast. The existing control also briefly used a browser tap-highlight color instead of the configured chat chroma.

The accompanying Illustrator cadence report was investigated on the same branch. Persisted state for the reported chat shows three swipes and one accepted assistant reply since an interval-2 run; the cadence endpoint reports that the next accepted assistant reply is eligible. No cadence behavior was changed without a reproducible failing state, and #3820 remains open for manual confirmation.

Fixes #3838
Refs #3820

## Changes

- preserve the existing direct global toggle outside multi-character Roleplay chats
- add a compact avatar chooser for **All** or one or more current chat characters
- scale and wrap avatar options on narrow screens, with vertical overflow for large casts
- clip current-format avatar crops inside their circular menu and marker frames
- show restricted-character avatars beside the crossed-eye message marker
- persist restrictions across swipes and filter prompt history per responding character
- preserve audience metadata through prompt merging, strict-role formatting, and system-message squashing
- use configured chat chroma/accent tokens and suppress the browser tap highlight
- document the group-chat behavior

## Automated evidence

- `pnpm check`
- `pnpm regression:prompt`
- `pnpm --filter @marinara-engine/client build`
- focused mobile Chromium smoke test for the previously flaky Noodle flow

## Test plan

- [ ] Manually verify Illustrator runs on the next accepted Roleplay reply at the configured interval
- [ ] Manually verify swipes and continuations do not count toward Illustrator cadence
- [ ] Manually verify single-character Hide From AI remains a direct toggle
- [ ] Manually verify **All** and multi-character selections in a Roleplay group chat
- [ ] Manually verify circular avatars stay clipped in the chooser and message marker
- [ ] Manually verify the compact chooser wraps and scrolls vertically on mobile
- [ ] Manually inspect prompts for selected and non-selected responding characters
- [ ] Run `pnpm regression:prompt`
- [ ] Run `pnpm check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added per-character “Hide from AI” controls for Roleplay group chats.
  * Select all characters or specific recipients using an avatar picker.
  * Hidden-message indicators now show selected recipients, while global hiding remains available.
  * Character-specific visibility is respected when generating responses.

* **Bug Fixes**
  * Preserved selected accent colors and removed unwanted tap-highlight effects.

* **Documentation**
  * Updated message-action guidance for group and single-character chats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->