### PR TITLE
fix: honor dynamic portrait prompt overrides

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 ### Fixed
 
 - Applied enabled Connection generation defaults across every Noodle text-generation path and allowed custom OpenAI-compatible endpoints to receive explicitly enabled top-k, reasoning-effort, and verbosity parameters (#3845).
-- Kept dynamic NPC portrait prompt rewrites authoritative and excluded non-visual NPC history notes from portrait appearance context (#3846).
+- Kept dynamic NPC portrait prompt rewrites authoritative, removed host instructions that forced custom directors to echo raw canonical prose labels, and excluded non-visual NPC history notes from portrait appearance context (#3846).
 - Removed unused agent/turn-game contract members, obsolete generated registries, duplicate tool arrays, Visual Novel types, chat-mode definitions, and redundant public aliases while preserving legacy downloadable-agent package parsing (#3847, #3848).
 - Regenerated merged Roleplay group replies with the full active character roster instead of narrowing the prompt to the previously saved speaker (#3850).
 - Made the Character editor's **Copy ID** action work on mobile and non-secure browser contexts and report only confirmed clipboard success (#3851).

--- a/packages/server/src/routes/game.routes.ts
+++ b/packages/server/src/routes/game.routes.ts
@@ -1176,7 +1176,6 @@ export async function buildDynamicGameImagePromptMessages(args: {
         [
           `Rewrite this into one positive prompt for a ${gameDynamicImagePromptKindLabel(args.request.kind)}.`,
           `Maximum length: ${args.request.maxCharacters} characters.`,
-          'Return only JSON: {"prompt":"..."}.',
         ]
           .filter(Boolean)
           .join("\n"),

--- a/packages/server/src/routes/game.routes.ts
+++ b/packages/server/src/routes/game.routes.ts
@@ -1119,7 +1119,7 @@ function sanitizeDynamicGameImagePromptResponse(raw: string, maxCharacters: numb
   return candidate.slice(0, maxCharacters).trim() || null;
 }
 
-async function buildDynamicGameImagePromptMessages(args: {
+export async function buildDynamicGameImagePromptMessages(args: {
   promptOverridesStorage?: PromptOverridesStorage;
   request: GameDynamicImagePromptRequest;
   meta: Record<string, unknown>;
@@ -1165,11 +1165,6 @@ async function buildDynamicGameImagePromptMessages(args: {
   const systemPrompt = args.promptOverridesStorage
     ? await loadPrompt(args.promptOverridesStorage, GAME_IMAGE_PROMPT_DIRECTOR, vars)
     : GAME_IMAGE_PROMPT_DIRECTOR.defaultBuilder(vars);
-  const portraitIdentityInstruction =
-    args.request.kind === "portrait"
-      ? "For NPC portraits, copy the Required canonical NPC visual profile / Appearance traits from <asset_context> and <draft_prompt> into the returned prompt. Do not replace them with a generic character design."
-      : "";
-
   return [
     { role: "system", content: systemPrompt },
     {
@@ -1180,7 +1175,6 @@ async function buildDynamicGameImagePromptMessages(args: {
         `<draft_prompt>\n${sourcePrompt}\n</draft_prompt>`,
         [
           `Rewrite this into one positive prompt for a ${gameDynamicImagePromptKindLabel(args.request.kind)}.`,
-          portraitIdentityInstruction,
           `Maximum length: ${args.request.maxCharacters} characters.`,
           'Return only JSON: {"prompt":"..."}.',
         ]

--- a/packages/server/src/services/game/game-asset-generation.ts
+++ b/packages/server/src/services/game/game-asset-generation.ts
@@ -560,7 +560,7 @@ export async function buildNpcPortraitProviderPrompt(req: NpcPortraitRequest): P
     maxCharacters: 1400,
     assetContext: [
       `NPC name: ${req.npcName}`,
-      req.appearance ? `Required canonical NPC visual profile: ${req.appearance}` : "",
+      req.appearance ? `Appearance traits: ${req.appearance}` : "",
       req.gender ? `Gender: ${req.gender}` : "",
       req.pronouns ? `Pronouns: ${req.pronouns}` : "",
       req.artStyle ? `Art style: ${req.artStyle}` : "",

--- a/scripts/regressions/prompt.regression.ts
+++ b/scripts/regressions/prompt.regression.ts
@@ -411,6 +411,7 @@ import {
 } from "../../packages/server/src/services/generation/lorebook-generation-runtime.js";
 import {
   buildGameIllustratorAppearanceContextBlock,
+  buildDynamicGameImagePromptMessages,
   buildIllustrationNarrationSummaryMessages,
   buildStoryboardIllustratorMessages,
   extractCharacterAppearanceText,
@@ -3221,6 +3222,34 @@ Use HTML sparingly and diegetically. Do not replace normal prose/dialogue unless
       });
       assert.equal(narrationPrompt.prompt.toLowerCase().split(narrationDescription.toLowerCase()).length - 1, 1);
       assert.doesNotMatch(narrationPrompt.prompt, /Canonical NPC profile:/);
+    },
+  },
+  {
+    name: "custom dynamic portrait instructions remain authoritative",
+    async run() {
+      const override = "Return only a clean comma-separated visual tag list. Never copy prose labels.";
+      const messages = await buildDynamicGameImagePromptMessages({
+        promptOverridesStorage: {
+          get: async (key: string) =>
+            key === "game.imagePromptDirector"
+              ? { key, template: override, enabled: true, updatedAt: "2026-07-20T00:00:00.000Z" }
+              : null,
+        } as any,
+        request: {
+          kind: "portrait",
+          title: "Sentinel",
+          sourcePrompt: "One alien sentinel in a bioluminescent hive interior.",
+          assetContext: ["NPC name: Sentinel", "Appearance traits: towering alien, long tail, glowing eyes"],
+          maxCharacters: 1400,
+        },
+        meta: {},
+        setupConfig: null,
+        latestState: null,
+      });
+
+      assert.equal(messages[0]?.content, override);
+      assert.match(messages[1]?.content ?? "", /Appearance traits: towering alien/);
+      assert.doesNotMatch(messages[1]?.content ?? "", /copy the Required canonical NPC visual profile/i);
     },
   },
   {

--- a/scripts/regressions/prompt.regression.ts
+++ b/scripts/regressions/prompt.regression.ts
@@ -3228,13 +3228,27 @@ Use HTML sparingly and diegetically. Do not replace normal prose/dialogue unless
     name: "custom dynamic portrait instructions remain authoritative",
     async run() {
       const override = "Return only a clean comma-separated visual tag list. Never copy prose labels.";
+      const promptOverridesStorage = {
+        async get(key: string) {
+          return key === "game.imagePromptDirector"
+            ? { key, template: override, enabled: true, updatedAt: "2026-07-20T00:00:00.000Z" }
+            : null;
+        },
+        async list() {
+          return [];
+        },
+        async upsert(input) {
+          return {
+            key: input.key,
+            template: input.template,
+            enabled: input.enabled,
+            updatedAt: "2026-07-20T00:00:00.000Z",
+          };
+        },
+        async remove() {},
+      } satisfies PromptOverridesStorage;
       const messages = await buildDynamicGameImagePromptMessages({
-        promptOverridesStorage: {
-          get: async (key: string) =>
-            key === "game.imagePromptDirector"
-              ? { key, template: override, enabled: true, updatedAt: "2026-07-20T00:00:00.000Z" }
-              : null,
-        } as any,
+        promptOverridesStorage,
         request: {
           kind: "portrait",
           title: "Sentinel",
@@ -3250,6 +3264,7 @@ Use HTML sparingly and diegetically. Do not replace normal prose/dialogue unless
       assert.equal(messages[0]?.content, override);
       assert.match(messages[1]?.content ?? "", /Appearance traits: towering alien/);
       assert.doesNotMatch(messages[1]?.content ?? "", /copy the Required canonical NPC visual profile/i);
+      assert.doesNotMatch(messages[1]?.content ?? "", /Return only JSON/i);
     },
   },
   {


### PR DESCRIPTION
## Why

The staging fix for #3846 removed narrative tracker notes, but a host-added portrait instruction still told the dynamic prompt model to copy the raw `Required canonical NPC visual profile` line. That instruction competed with user-authored Prompt Director overrides such as requests for a clean tag list, making the override appear bypassed.

## What changed

- Present canonical appearance as neutral `Appearance traits` input to the dynamic director.
- Remove the host-added portrait-only command that forced raw prose-label copying.
- Keep canonical-preservation guidance in the built-in default director, where it does not override a user-authored template.
- Add regression coverage proving a custom director remains the system authority.

Closes #3846

## Automated evidence

- `pnpm regression:prompt` passed.
- `pnpm check` passed.

## Validation checklist

- [ ] Run `pnpm regression:prompt`.
- [ ] Run `pnpm check`.
- [ ] Manually verify a custom Game Mode Image Prompt Director can return a tag list without the raw canonical-profile label.

## Docs and release impact

- Updated the existing #3846 changelog entry.
- No version-bearing files changed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved dynamic NPC portrait prompt handling.
  * Custom image-direction instructions are now preserved without being overridden by additional canonical profile wording.
  * Non-visual NPC history details are excluded from portrait appearance context.
* **Tests**
  * Added regression coverage to verify custom portrait instructions remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->