### PR TITLE
fix: enforce dynamic NPC portrait rewrites

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 ### Fixed
 
 - Applied enabled Connection generation defaults across every Noodle text-generation path and allowed custom OpenAI-compatible endpoints to receive explicitly enabled top-k, reasoning-effort, and verbosity parameters (#3845).
-- Kept dynamic NPC portrait prompt rewrites authoritative, removed host instructions that forced custom directors to echo raw canonical prose labels, and excluded non-visual NPC history notes from portrait appearance context (#3846).
+- Kept dynamic NPC portrait prompt rewrites authoritative, resolved a usable text connection instead of silently bypassing enabled rewrites, allowed custom non-JSON output, removed legacy reputation-note leakage, and preserved explicit non-human species cues (#3846).
 - Removed unused agent/turn-game contract members, obsolete generated registries, duplicate tool arrays, Visual Novel types, chat-mode definitions, and redundant public aliases while preserving legacy downloadable-agent package parsing (#3847, #3848).
 - Regenerated merged Roleplay group replies with the full active character roster instead of narrowing the prompt to the previously saved speaker (#3850).
 - Made the Character editor's **Copy ID** action work on mobile and non-secure browser contexts and report only confirmed clipboard success (#3851).

--- a/packages/server/src/routes/game.routes.ts
+++ b/packages/server/src/routes/game.routes.ts
@@ -1186,7 +1186,57 @@ export async function buildDynamicGameImagePromptMessages(args: {
   ];
 }
 
-async function createDynamicGameImagePromptGenerator(args: {
+type DynamicGamePromptConnections = Pick<
+  ReturnType<typeof createConnectionsStorage>,
+  "getWithKey" | "listRandomPool" | "getDefaultForAgents"
+>;
+
+export async function resolveDynamicGameImagePromptConnection(args: {
+  connections: DynamicGamePromptConnections;
+  meta: Record<string, unknown>;
+  setupConfig: Record<string, unknown> | null;
+  chatConnectionId: string | null;
+}) {
+  const explicitConnectionId = readTrimmedString(args.meta.illustratorPromptConnectionId);
+  if (explicitConnectionId) {
+    return resolveConnection(args.connections, explicitConnectionId, null);
+  }
+
+  let lastError: unknown;
+  const candidateIds = Array.from(
+    new Set(
+      [
+        readTrimmedString(args.meta.gameSceneConnectionId),
+        readTrimmedString(args.setupConfig?.sceneConnectionId),
+        readTrimmedString(args.chatConnectionId),
+      ].filter((id): id is string => Boolean(id)),
+    ),
+  );
+  for (const candidateId of candidateIds) {
+    try {
+      return await resolveConnection(args.connections, candidateId, null);
+    } catch (err) {
+      lastError = err;
+    }
+  }
+
+  const defaultAgentConnection = await args.connections.getDefaultForAgents();
+  if (defaultAgentConnection) {
+    return resolveConnection(args.connections, defaultAgentConnection.id, null);
+  }
+
+  throw lastError instanceof Error ? lastError : new Error("No text connection configured for dynamic image prompts");
+}
+
+export function dynamicGameImagePromptRequestOptions(kind: GameDynamicImagePromptKind, signal?: AbortSignal) {
+  return {
+    stream: false,
+    maxTokens: kind === "illustration" ? 3000 : 1400,
+    signal,
+  };
+}
+
+export async function createDynamicGameImagePromptGenerator(args: {
   connections: ReturnType<typeof createConnectionsStorage>;
   promptOverridesStorage?: PromptOverridesStorage;
   chat: NonNullable<StoredChatRecord>;
@@ -1199,15 +1249,12 @@ async function createDynamicGameImagePromptGenerator(args: {
   if (args.meta.gameImageDynamicPromptEnabled !== true) return undefined;
 
   try {
-    const promptConnectionId =
-      readTrimmedString(args.meta.illustratorPromptConnectionId) ??
-      readTrimmedString(args.meta.gameSceneConnectionId) ??
-      readTrimmedString(args.setupConfig?.sceneConnectionId);
-    const { conn, baseUrl, defaultGenerationParameters } = await resolveConnection(
-      args.connections,
-      promptConnectionId,
-      args.chat.connectionId,
-    );
+    const { conn, baseUrl, defaultGenerationParameters } = await resolveDynamicGameImagePromptConnection({
+      connections: args.connections,
+      meta: args.meta,
+      setupConfig: args.setupConfig,
+      chatConnectionId: args.chat.connectionId,
+    });
     const parameters = resolveStoredGameGenerationParameters(args.meta, defaultGenerationParameters);
     const provider = await createGameMainProvider(args.connections, conn, baseUrl);
 
@@ -1233,12 +1280,7 @@ async function createDynamicGameImagePromptGenerator(args: {
         messages,
         gameGenOptions(
           conn.model ?? "",
-          {
-            stream: false,
-            maxTokens: request.kind === "illustration" ? 3000 : 1400,
-            responseFormat: { type: "json_object" },
-            signal: args.signal,
-          },
+          dynamicGameImagePromptRequestOptions(request.kind, args.signal),
           parameters,
           conn.provider,
         ),
@@ -1261,7 +1303,7 @@ async function createDynamicGameImagePromptGenerator(args: {
     };
   } catch (err) {
     logger.warn(err, "[game/dynamic-image-prompt] Failed to initialise dynamic prompt generation");
-    return undefined;
+    throw err;
   }
 }
 
@@ -2657,7 +2699,7 @@ function mergeGameInventoryItems(...sources: ChatInventoryItem[][]): ChatInvento
 }
 
 async function resolveConnection(
-  connections: ReturnType<typeof createConnectionsStorage>,
+  connections: Pick<ReturnType<typeof createConnectionsStorage>, "getWithKey" | "listRandomPool">,
   connId: string | null | undefined,
   chatConnectionId: string | null,
 ) {
@@ -4143,8 +4185,22 @@ function normalizePortraitAppearancePart(value: string): string {
   return value.toLowerCase().replace(/\s+/g, " ").trim();
 }
 
+export function sanitizeNpcPortraitAppearanceText(value: string): string {
+  return value
+    .replace(/\s+Notable details:\s*[\s\S]*$/i, "")
+    .replace(
+      /\[[^\]\r\n]{1,500}\]\s*reputation\s*[+-]?\d+(?:\s*(?:→|->)\s*-?\d+)?(?:\s*\([^)]*\))?/gi,
+      " ",
+    )
+    .replace(/\breputation\s*[+-]?\d+\s*(?:→|->)\s*-?\d+(?:\s*\([^)]*\))?/gi, " ")
+    .replace(/\s+([,.;])/g, "$1")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
 function addPortraitAppearancePart(parts: string[], seenValues: Set<string>, value: unknown, label?: string): void {
-  const trimmed = optionalTrimmedString(value);
+  const raw = optionalTrimmedString(value);
+  const trimmed = raw ? sanitizeNpcPortraitAppearanceText(raw) : null;
   if (!trimmed) return;
 
   const normalizedValue = normalizePortraitAppearancePart(trimmed);

--- a/packages/server/src/routes/game.routes.ts
+++ b/packages/server/src/routes/game.routes.ts
@@ -1191,6 +1191,7 @@ type DynamicGamePromptConnections = Pick<
   "getWithKey" | "listRandomPool" | "getDefaultForAgents"
 >;
 
+/** Resolve the configured dynamic-prompt text connection without silently accepting stale fallbacks. */
 export async function resolveDynamicGameImagePromptConnection(args: {
   connections: DynamicGamePromptConnections;
   meta: Record<string, unknown>;
@@ -1228,6 +1229,7 @@ export async function resolveDynamicGameImagePromptConnection(args: {
   throw lastError instanceof Error ? lastError : new Error("No text connection configured for dynamic image prompts");
 }
 
+/** Build provider options that preserve a custom Prompt Director's output format. */
 export function dynamicGameImagePromptRequestOptions(kind: GameDynamicImagePromptKind, signal?: AbortSignal) {
   return {
     stream: false,
@@ -1236,7 +1238,7 @@ export function dynamicGameImagePromptRequestOptions(kind: GameDynamicImagePromp
   };
 }
 
-export async function createDynamicGameImagePromptGenerator(args: {
+async function createDynamicGameImagePromptGenerator(args: {
   connections: ReturnType<typeof createConnectionsStorage>;
   promptOverridesStorage?: PromptOverridesStorage;
   chat: NonNullable<StoredChatRecord>;
@@ -4185,9 +4187,11 @@ function normalizePortraitAppearancePart(value: string): string {
   return value.toLowerCase().replace(/\s+/g, " ").trim();
 }
 
+/** Remove legacy journal and reputation metadata before portrait prompt assembly. */
 export function sanitizeNpcPortraitAppearanceText(value: string): string {
   return value
-    .replace(/\s+Notable details:\s*[\s\S]*$/i, "")
+    .replace(/(?:^|\s+)Notable details:\s*[\s\S]*$/i, "")
+    .replace(/\s*\breputation\s*:\s*[^,.;\r\n]*\s*[,;]?/gi, " ")
     .replace(
       /\[[^\]\r\n]{1,500}\]\s*reputation\s*[+-]?\d+(?:\s*(?:→|->)\s*-?\d+)?(?:\s*\([^)]*\))?/gi,
       " ",

--- a/packages/server/src/services/game/game-asset-generation.ts
+++ b/packages/server/src/services/game/game-asset-generation.ts
@@ -363,10 +363,13 @@ function npcPortraitSlug(req: NpcPortraitRequest): string {
   });
 }
 
-function hasExplicitNonHumanCue(value: string): boolean {
-  return /\b(?:animal|cat|kitten|dog|puppy|wolf|fox|bird|raven|crow|owl|horse|deer|rabbit|rat|mouse|snake|lizard|dragon|beast|creature|monster|spirit|ghost|construct|golem|doll|object|statue|mascot|non[-\s]?human|anthropomorphic|feral|quadruped)\b/i.test(
-    value,
+function deriveExplicitNonHumanCue(value: string): string | null {
+  const match = value.match(
+    /\b(?:xenomorph|extraterrestrial|alien|biomechanical|insectoid|reptilian|avian|amphibian|android|robot|synth(?:etic)?|animal|cat|kitten|dog|puppy|wolf|fox|bird|raven|crow|owl|horse|deer|rabbit|rat|mouse|snake|lizard|dragon|beast|creature|monster|spirit|ghost|construct|golem|doll|object|statue|mascot|non[-\s]?human|anthropomorphic|feral|quadruped)\b/i,
   );
+  if (!match?.[0]) return null;
+  const cue = match[0].toLowerCase().replace(/\s+/g, "-");
+  return cue === "non-human" || cue === "nonhuman" ? "non-human creature" : cue;
 }
 
 function normalizeNpcGenderCue(gender: string | null | undefined, pronouns: string | null | undefined, text: string) {
@@ -443,12 +446,14 @@ function collectNpcVisualAttributeTags(text: string): string[] {
   return tags.slice(0, 4);
 }
 
-function buildNpcAppearanceLine(req: NpcPortraitRequest, explicitNonHuman: boolean): string {
+function buildNpcAppearanceLine(req: NpcPortraitRequest, nonHumanCue: string | null): string {
   const context = req.appearance.trim();
-  if (explicitNonHuman && !context) return "Appearance: non-human creature.";
+  if (nonHumanCue && !context) return `Appearance: ${nonHumanCue}.`;
 
   const identityTags: string[] = [];
-  if (!explicitNonHuman) {
+  if (nonHumanCue) {
+    identityTags.push(nonHumanCue);
+  } else {
     identityTags.push(deriveNpcAgeCue(context) ?? "adult");
     identityTags.push(normalizeNpcGenderCue(req.gender, req.pronouns, context) ?? "androgynous");
     identityTags.push("human or humanoid person");
@@ -462,15 +467,15 @@ function buildNpcAppearanceLine(req: NpcPortraitRequest, explicitNonHuman: boole
 
 function npcPortraitVariables(req: NpcPortraitRequest) {
   const context = req.appearance.trim();
-  const explicitNonHuman = hasExplicitNonHumanCue(`${req.npcName} ${context}`);
+  const nonHumanCue = deriveExplicitNonHumanCue(`${req.npcName} ${context}`);
   return {
     npcName: req.npcName,
-    appearanceLine: buildNpcAppearanceLine(req, explicitNonHuman),
-    nonHumanRule: explicitNonHuman
+    appearanceLine: buildNpcAppearanceLine(req, nonHumanCue),
+    nonHumanRule: nonHumanCue
       ? "The description explicitly indicates a non-human subject. Preserve that exact species, body plan, age category, and silhouette; do not turn it into a human or kemonomimi character unless the description says humanoid."
       : "Unless the description explicitly says otherwise, depict this NPC as a human or humanoid person. Do not infer an animal species from the name, mood, speech verbs, or setting.",
     artStyleLine: req.artStyle ? `Art style: ${req.artStyle}.` : "",
-    compositionRule: explicitNonHuman
+    compositionRule: nonHumanCue
       ? "Use a centered avatar composition appropriate to the subject, including a creature portrait or full head-and-body crop only when that best preserves the described non-human form."
       : "Use a centered human/humanoid avatar composition: face and shoulders, readable expression, clear outfit cues.",
   };
@@ -694,10 +699,11 @@ async function maybeGenerateDynamicGameImagePrompt(
   if (!generator) return request.sourcePrompt;
   try {
     const generated = cleanDynamicGameImagePrompt(await generator(request), request.maxCharacters);
-    return generated || request.sourcePrompt;
+    if (!generated) throw new Error("Dynamic image prompt generation returned no usable prompt");
+    return generated;
   } catch (err) {
-    logger.warn(err, "[game-asset-gen] Dynamic image prompt generation failed; using deterministic prompt");
-    return request.sourcePrompt;
+    logger.warn(err, "[game-asset-gen] Dynamic image prompt generation failed");
+    throw err;
   }
 }
 

--- a/scripts/regressions/prompt.regression.ts
+++ b/scripts/regressions/prompt.regression.ts
@@ -3168,6 +3168,11 @@ Use HTML sparingly and diegetically. Do not replace normal prose/dialogue unless
       assert.match(legacyPollutedAppearance, /nine-foot Xenomorph with a biomechanical black carapace/i);
       assert.doesNotMatch(legacyPollutedAppearance, /Notable details|reputation|\[helped\]/i);
       assert.equal(sanitizeNpcPortraitAppearanceText("[helped] reputation +15 → 15 (neutral)"), "");
+      assert.equal(sanitizeNpcPortraitAppearanceText("Notable details: reputation: trusted"), "");
+      assert.equal(
+        sanitizeNpcPortraitAppearanceText("Black carapace. Reputation: trusted, elongated skull"),
+        "Black carapace. elongated skull",
+      );
     },
   },
   {

--- a/scripts/regressions/prompt.regression.ts
+++ b/scripts/regressions/prompt.regression.ts
@@ -414,8 +414,11 @@ import {
   buildDynamicGameImagePromptMessages,
   buildIllustrationNarrationSummaryMessages,
   buildStoryboardIllustratorMessages,
+  dynamicGameImagePromptRequestOptions,
   extractCharacterAppearanceText,
+  resolveDynamicGameImagePromptConnection,
   resolveNpcPortraitAppearance,
+  sanitizeNpcPortraitAppearanceText,
   selectStoryboardAppearanceCharacterNames,
 } from "../../packages/server/src/routes/game.routes.js";
 import { buildLegacyDefaultAgentConfigUpdate } from "../../packages/server/src/services/agents/default-prompt-migration.js";
@@ -3151,6 +3154,20 @@ Use HTML sparingly and diegetically. Do not replace normal prose/dialogue unless
       assert.match(appearance, /Current outfit: Persimmon kimono/);
       assert.match(appearance, /Current expression or mood: Warm smile/);
       assert.doesNotMatch(appearance, /debt-scroll|Notable details/);
+
+      const legacyPollutedAppearance = resolveNpcPortraitAppearance(
+        { description: null },
+        {
+          description:
+            "A nine-foot Xenomorph with a biomechanical black carapace. Notable details: [helped] reputation +15 → 15 (neutral)",
+          descriptionSource: "model",
+          notes: [],
+        } as any,
+        null,
+      );
+      assert.match(legacyPollutedAppearance, /nine-foot Xenomorph with a biomechanical black carapace/i);
+      assert.doesNotMatch(legacyPollutedAppearance, /Notable details|reputation|\[helped\]/i);
+      assert.equal(sanitizeNpcPortraitAppearanceText("[helped] reputation +15 → 15 (neutral)"), "");
     },
   },
   {
@@ -3222,6 +3239,30 @@ Use HTML sparingly and diegetically. Do not replace normal prose/dialogue unless
       });
       assert.equal(narrationPrompt.prompt.toLowerCase().split(narrationDescription.toLowerCase()).length - 1, 1);
       assert.doesNotMatch(narrationPrompt.prompt, /Canonical NPC profile:/);
+
+      let xenomorphSourcePrompt = "";
+      await buildNpcPortraitProviderPrompt({
+        ...request,
+        npcName: "Xenomorph Drone",
+        appearance: "A nine-foot biomechanical hunter with an elongated skull and black carapace.",
+        dynamicPromptGenerator: async (dynamicRequest) => {
+          xenomorphSourcePrompt = dynamicRequest.sourcePrompt;
+          return "xenomorph, biomechanical black carapace, elongated skull, solo portrait";
+        },
+      });
+      assert.match(xenomorphSourcePrompt, /Appearance: xenomorph/i);
+      assert.doesNotMatch(xenomorphSourcePrompt, /human or humanoid person/i);
+
+      await assert.rejects(
+        () =>
+          buildNpcPortraitProviderPrompt({
+            ...request,
+            dynamicPromptGenerator: async () => {
+              throw new Error("prompt director unavailable");
+            },
+          }),
+        /prompt director unavailable/,
+      );
     },
   },
   {
@@ -3265,6 +3306,40 @@ Use HTML sparingly and diegetically. Do not replace normal prose/dialogue unless
       assert.match(messages[1]?.content ?? "", /Appearance traits: towering alien/);
       assert.doesNotMatch(messages[1]?.content ?? "", /copy the Required canonical NPC visual profile/i);
       assert.doesNotMatch(messages[1]?.content ?? "", /Return only JSON/i);
+
+      const requestOptions = dynamicGameImagePromptRequestOptions("portrait");
+      assert.equal("responseFormat" in requestOptions, false);
+    },
+  },
+  {
+    name: "dynamic image prompts fall back to the default agent text connection",
+    async run() {
+      const defaultAgentConnection = {
+        id: "agent-default",
+        provider: "openai",
+        model: "prompt-model",
+        baseUrl: "https://example.invalid/v1",
+        apiKey: "test-key",
+      };
+      const connections = {
+        async listRandomPool() {
+          return [];
+        },
+        async getWithKey(id: string) {
+          return id === defaultAgentConnection.id ? defaultAgentConnection : null;
+        },
+        async getDefaultForAgents() {
+          return defaultAgentConnection;
+        },
+      } as unknown as Parameters<typeof resolveDynamicGameImagePromptConnection>[0]["connections"];
+      const resolved = await resolveDynamicGameImagePromptConnection({
+        connections,
+        meta: { gameSceneConnectionId: "deleted-scene-connection" },
+        setupConfig: null,
+        chatConnectionId: null,
+      });
+
+      assert.equal(resolved.conn.id, defaultAgentConnection.id);
     },
   },
   {


### PR DESCRIPTION
## Why

The staging retest for #3846 showed that enabled dynamic portrait rewriting could still fall back to the deterministic compiler without telling the user. That fallback reintroduced legacy reputation notes and the canonical-profile header, while the compact tag compiler did not recognize Xenomorph and similar non-human identities.

## What changed

- Resolve available Game prompt connections in order and fall back to the configured default agent text connection.
- Fail an enabled dynamic rewrite instead of silently sending the deterministic prompt when initialization or generation fails.
- Stop forcing provider-level JSON mode so custom Prompt Directors can return their requested plain tag format.
- Strip legacy `Notable details` and reputation-event text at the shared portrait appearance boundary.
- Preserve explicit Xenomorph, alien, biomechanical, synth, and related non-human cues before tagged prompt compilation.
- Add regression coverage for the exact staging payload shape, connection fallback, custom output format, failure behavior, and species preservation.

Closes #3846

## Automated evidence

- `pnpm regression:prompt` passed.
- `pnpm check` passed.

## Validation checklist

- [ ] Run `pnpm regression:prompt`.
- [ ] Run `pnpm check`.
- [ ] Manually verify a custom Game Image Prompt Director returns clean tags for an NPC with reputation history.
- [ ] Manually verify a Xenomorph portrait retains its species and biomechanical traits.

## Docs and release impact

- Updated the existing #3846 changelog entry.
- No version-bearing files changed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved dynamic image prompt connection selection, including fallback behavior when scene connections are unavailable.
  - Dynamic prompt failures now surface clearly instead of silently falling back or disabling prompting.
  - Added support for custom non-JSON prompt output.
  - Cleaned NPC portrait details by removing reputation and legacy metadata leakage.
  - Preserved explicit non-human species cues in generated portraits.
- **Tests**
  - Added regression coverage for prompt sanitization, connection fallback, output handling, and failure scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->