### PR TITLE
fix: enforce character and chat data boundaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 
 ### Fixed
 
+- Returned parsed chat metadata and character IDs from public chat reads so fresh sidebar tag filters match the shared API contract (#3857).
+- Deep-merged partial nested Character PATCH fields without materializing destructive defaults, preserving omitted extensions and embedded-lorebook data (#3858).
+- Validated and normalized native Marinara character cards before persistence while preserving unknown embedded-lorebook properties (#3859).
 - Applied enabled Connection generation defaults across every Noodle text-generation path and allowed custom OpenAI-compatible endpoints to receive explicitly enabled top-k, reasoning-effort, and verbosity parameters (#3845).
 - Kept dynamic NPC portrait prompt rewrites authoritative, resolved a usable text connection instead of silently bypassing enabled rewrites, allowed custom non-JSON output, removed legacy reputation-note leakage, and preserved explicit non-human species cues (#3846).
 - Removed unused agent/turn-game contract members, obsolete generated registries, duplicate tool arrays, Visual Novel types, chat-mode definitions, and redundant public aliases while preserving legacy downloadable-agent package parsing (#3847, #3848).

--- a/packages/server/src/routes/characters.routes.ts
+++ b/packages/server/src/routes/characters.routes.ts
@@ -786,7 +786,6 @@ export async function charactersRoutes(app: FastifyInstance) {
         versionSource,
         versionReason,
         skipVersionSnapshot,
-        mergeExtensions: false,
       }),
     );
   });

--- a/packages/server/src/routes/chats.routes.ts
+++ b/packages/server/src/routes/chats.routes.ts
@@ -495,9 +495,9 @@ export async function chatsRoutes(app: FastifyInstance) {
     return Promise.all(
       allChats.map(async (chat) => {
         const metadata = parseChatMetadata(chat.metadata);
-        return sanitizeChatGameNpcAvatars({
+        return normalizeChatForResponse({
           ...chat,
-          metadata: JSON.stringify(metadata),
+          metadata,
           messageCount: await storage.countMessages(chat.id),
         });
       }),
@@ -531,7 +531,7 @@ export async function chatsRoutes(app: FastifyInstance) {
         characterExchanges: false,
         tags: ["internal"],
       });
-      return sanitizeChatGameNpcAvatars(updated ?? existing);
+      return normalizeChatForResponse(updated ?? existing);
     }
 
     const created = await storage.create({
@@ -553,7 +553,7 @@ export async function chatsRoutes(app: FastifyInstance) {
       characterExchanges: false,
       tags: ["internal"],
     });
-    return sanitizeChatGameNpcAvatars(updated ?? created);
+    return normalizeChatForResponse(updated ?? created);
   });
 
   app.post<{ Querystring: { connectionId?: string; personaId?: string } }>(
@@ -618,7 +618,7 @@ export async function chatsRoutes(app: FastifyInstance) {
         characterExchanges: false,
         tags: ["internal"],
       });
-      return sanitizeChatGameNpcAvatars(updated ?? created);
+      return normalizeChatForResponse(updated ?? created);
     },
   );
 
@@ -642,7 +642,7 @@ export async function chatsRoutes(app: FastifyInstance) {
       characterIds: [PROFESSOR_MARI_ID],
       promptPresetId: null,
     });
-    return sanitizeChatGameNpcAvatars(updated ?? target);
+    return normalizeChatForResponse(updated ?? target);
   });
 
   app.patch<{ Params: { id: string }; Body: { name?: unknown } }>(
@@ -653,7 +653,7 @@ export async function chatsRoutes(app: FastifyInstance) {
       const name = typeof req.body?.name === "string" ? req.body.name.trim() : "";
       if (!name) return reply.status(400).send({ error: "Name is required" });
       const updated = await storage.update(target.id, { name });
-      return sanitizeChatGameNpcAvatars(updated ?? target);
+      return normalizeChatForResponse(updated ?? target);
     },
   );
 
@@ -847,7 +847,7 @@ export async function chatsRoutes(app: FastifyInstance) {
       Object.prototype.hasOwnProperty.call(incoming, "hideSummarisedMessages") &&
       typeof incoming.hideSummarisedMessages === "boolean"
     ) {
-      return storage.patchMetadata(req.params.id, async (freshMeta) => {
+      const updated = await storage.patchMetadata(req.params.id, async (freshMeta) => {
         const previousHideEnabled = freshMeta.hideSummarisedMessages === true;
         if (previousHideEnabled === incoming.hideSummarisedMessages) {
           return incoming;
@@ -903,8 +903,10 @@ export async function chatsRoutes(app: FastifyInstance) {
           summary: compileChatSummaryEntries(nextEntries),
         };
       });
+      return updated ? normalizeChatForResponse(updated) : updated;
     }
-    return storage.patchMetadata(req.params.id, incoming);
+    const updated = await storage.patchMetadata(req.params.id, incoming);
+    return updated ? normalizeChatForResponse(updated) : updated;
   });
 
   // Mark a chat as having autonomous messages the user has not viewed yet.
@@ -912,14 +914,16 @@ export async function chatsRoutes(app: FastifyInstance) {
     const chat = await storage.getById(req.params.id);
     if (!chat) return reply.status(404).send({ error: "Chat not found" });
     const input = markAutonomousUnreadSchema.parse(req.body ?? {});
-    return storage.markAutonomousUnread(req.params.id, input);
+    const updated = await storage.markAutonomousUnread(req.params.id, input);
+    return updated ? normalizeChatForResponse(updated) : updated;
   });
 
   // Clear autonomous unread state when the user views the relevant chat.
   app.delete<{ Params: { id: string } }>("/:id/autonomous-unread", async (req, reply) => {
     const chat = await storage.getById(req.params.id);
     if (!chat) return reply.status(404).send({ error: "Chat not found" });
-    return storage.clearAutonomousUnread(req.params.id);
+    const updated = await storage.clearAutonomousUnread(req.params.id);
+    return updated ? normalizeChatForResponse(updated) : updated;
   });
 
   // Update chat summaries (entry-level merge for day/week summaries).
@@ -944,7 +948,7 @@ export async function chatsRoutes(app: FastifyInstance) {
       },
     }));
     if (!updated) return reply.status(404).send({ error: "Chat not found" });
-    return updated;
+    return normalizeChatForResponse(updated);
   });
 
   // Update rolling summary entries without replacing unrelated chat metadata.
@@ -1046,7 +1050,7 @@ export async function chatsRoutes(app: FastifyInstance) {
     });
 
     if (!updated) return reply.status(404).send({ error: "Chat not found" });
-    return updated;
+    return normalizeChatForResponse(updated);
   });
 
   app.post<{
@@ -3613,7 +3617,8 @@ export async function chatsRoutes(app: FastifyInstance) {
     }
 
     // Return the fully-updated chat (including copied metadata)
-    return storage.getById(newChat.id);
+    const branchedChat = await storage.getById(newChat.id);
+    return branchedChat ? normalizeChatForResponse(branchedChat) : branchedChat;
   });
 
   // ── Generate Summary ──

--- a/packages/server/src/routes/chats.routes.ts
+++ b/packages/server/src/routes/chats.routes.ts
@@ -286,6 +286,15 @@ function sanitizeChatGameNpcAvatars<T extends { metadata?: unknown }>(chat: T): 
     metadata: typeof chat.metadata === "string" ? JSON.stringify(sanitizedMetadata) : sanitizedMetadata,
   };
 }
+
+/** Convert storage-encoded chat JSON columns to the shared public Chat shape. */
+export function normalizeChatForResponse<T extends { metadata?: unknown; characterIds?: unknown }>(chat: T) {
+  return sanitizeChatGameNpcAvatars({
+    ...chat,
+    characterIds: resolveChatCharacterIds(chat.characterIds),
+    metadata: parseChatMetadata(chat.metadata),
+  });
+}
 type SummaryEntriesPatchBody =
   | { operation: "replace"; entry: Partial<ChatSummaryEntry> & { id: string; content: string } }
   | { operation: "delete"; entryId: string }
@@ -478,7 +487,7 @@ export async function chatsRoutes(app: FastifyInstance) {
   app.get("/", async () => {
     await cleanupEmptyRoleplayDmChats();
     const chats = await storage.list();
-    return chats.filter((chat) => !shouldHideProfessorMariChat(chat)).map(sanitizeChatGameNpcAvatars);
+    return chats.filter((chat) => !shouldHideProfessorMariChat(chat)).map(normalizeChatForResponse);
   });
 
   app.get("/internal/professor-mari/chats", async () => {
@@ -671,7 +680,7 @@ export async function chatsRoutes(app: FastifyInstance) {
   // List chats by group
   app.get<{ Params: { groupId: string } }>("/group/:groupId", async (req) => {
     const chats = await storage.listByGroup(req.params.groupId);
-    return chats.filter((chat) => !shouldHideProfessorMariChat(chat)).map(sanitizeChatGameNpcAvatars);
+    return chats.filter((chat) => !shouldHideProfessorMariChat(chat)).map(normalizeChatForResponse);
   });
 
   // Get single chat
@@ -680,7 +689,7 @@ export async function chatsRoutes(app: FastifyInstance) {
     if (!chat || isHomeProfessorMariChat(chat)) {
       return reply.status(404).send({ error: "Chat not found" });
     }
-    return sanitizeChatGameNpcAvatars(chat);
+    return normalizeChatForResponse(chat);
   });
 
   // Create chat
@@ -699,7 +708,7 @@ export async function chatsRoutes(app: FastifyInstance) {
     );
     if (!chat) return chat;
 
-    return chat;
+    return normalizeChatForResponse(chat);
   });
 
   // Update chat
@@ -767,7 +776,8 @@ export async function chatsRoutes(app: FastifyInstance) {
         }
       }
     }
-    return storage.update(req.params.id, data);
+    const updated = await storage.update(req.params.id, data);
+    return updated ? normalizeChatForResponse(updated) : updated;
   });
 
   app.post<{ Params: { id: string } }>("/:id/touch", async (req, reply) => {
@@ -775,7 +785,8 @@ export async function chatsRoutes(app: FastifyInstance) {
     if (!chat || isHomeProfessorMariChat(chat)) {
       return reply.status(404).send({ error: "Chat not found" });
     }
-    return storage.touch(req.params.id);
+    const updated = await storage.touch(req.params.id);
+    return updated ? normalizeChatForResponse(updated) : updated;
   });
 
   // Update chat metadata (partial merge)

--- a/packages/server/src/services/import/marinara.importer.ts
+++ b/packages/server/src/services/import/marinara.importer.ts
@@ -7,9 +7,16 @@ import {
   getFolderImportEntries,
   getFolderManifestConfig,
   isJsonRecord,
+  characterDataSchema,
   lorebookFilterModeSchema,
 } from "@marinara-engine/shared";
-import type { ExportEnvelope, ExportType, LorebookFilterMode, LorebookMatchingSource } from "@marinara-engine/shared";
+import type {
+  CharacterData,
+  ExportEnvelope,
+  ExportType,
+  LorebookFilterMode,
+  LorebookMatchingSource,
+} from "@marinara-engine/shared";
 import { createCharactersStorage } from "../storage/characters.storage.js";
 import { createCharacterGalleryStorage } from "../storage/character-gallery.storage.js";
 import { createLorebooksStorage } from "../storage/lorebooks.storage.js";
@@ -270,6 +277,12 @@ function unwrapFolderManifestEnvelope(value: unknown): ExportEnvelope | null {
 
 // ── Character ────────────────────────────────
 
+/** Validate and default a native character payload before it reaches storage. */
+export function normalizeNativeCharacterData(data: unknown): CharacterData | null {
+  const parsed = characterDataSchema.safeParse(data);
+  return parsed.success ? parsed.data : null;
+}
+
 async function importCharacter(data: unknown, db: DB) {
   const storage = createCharactersStorage(db);
   const galleryStorage = createCharacterGalleryStorage(db);
@@ -282,7 +295,7 @@ async function importCharacter(data: unknown, db: DB) {
     sprites?: unknown;
     gallery?: unknown;
   };
-  const charData = d?.data ? { ...(d.data as Record<string, unknown>) } : undefined;
+  const charData = isJsonRecord(d?.data) ? { ...d.data } : undefined;
   const metadata = d?.metadata && typeof d.metadata === "object" ? (d.metadata as Record<string, unknown>) : null;
   const comment = typeof metadata?.comment === "string" ? metadata.comment : undefined;
   if (!charData || typeof charData !== "object") {
@@ -334,7 +347,12 @@ async function importCharacter(data: unknown, db: DB) {
     charData.extensions = extensions;
   }
 
-  const result = await storage.create(charData as any, undefined, readTimestampOverrides(d), comment);
+  const normalizedCharacterData = normalizeNativeCharacterData(charData);
+  if (!normalizedCharacterData) {
+    return { success: false, type: "marinara_character" as const, error: "Invalid character data" };
+  }
+
+  const result = await storage.create(normalizedCharacterData, undefined, readTimestampOverrides(d), comment);
   if (result?.id) {
     const avatarPath = await saveAvatarFromDataUrl(d.avatar, "character", result.id);
     if (avatarPath) {
@@ -347,7 +365,7 @@ async function importCharacter(data: unknown, db: DB) {
     success: true,
     type: "marinara_character" as const,
     id: result?.id,
-    name: (charData as any).name ?? "Imported character",
+    name: normalizedCharacterData.name,
   };
 }
 

--- a/packages/server/src/services/storage/characters.storage.ts
+++ b/packages/server/src/services/storage/characters.storage.ts
@@ -12,7 +12,14 @@ import {
   personaGroups,
 } from "../../db/schema/index.js";
 import { newId, now } from "../../utils/id-generator.js";
-import { PROFESSOR_MARI_ID, type CharacterData, type PersonaCardSnapshot } from "@marinara-engine/shared";
+import {
+  PROFESSOR_MARI_ID,
+  characterBookSchema,
+  characterExtensionsSchema,
+  type CharacterData,
+  type PersonaCardSnapshot,
+  type UpdateCharacterInput,
+} from "@marinara-engine/shared";
 import { normalizeTimestampOverrides, type TimestampOverrides } from "../import/import-timestamps.js";
 import { toPaginatedList } from "../../utils/list-pagination.js";
 
@@ -45,26 +52,44 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return !!value && typeof value === "object" && !Array.isArray(value);
 }
 
+function mergeNestedRecord(current: Record<string, unknown>, patch: Record<string, unknown>): Record<string, unknown> {
+  const merged = { ...current };
+  for (const [key, value] of Object.entries(patch)) {
+    if (value === undefined) {
+      delete merged[key];
+    } else if (isRecord(value) && isRecord(merged[key])) {
+      merged[key] = mergeNestedRecord(merged[key], value);
+    } else {
+      merged[key] = value;
+    }
+  }
+  return merged;
+}
+
+type CharacterDataUpdate = Partial<CharacterData> | UpdateCharacterInput["data"];
+const defaultCharacterExtensions = characterExtensionsSchema.parse({});
+const defaultCharacterBook = characterBookSchema.parse({});
+
 function mergeCharacterData(
   current: CharacterData,
-  data: Partial<CharacterData>,
+  data: CharacterDataUpdate,
   options?: { mergeExtensions?: boolean },
 ): CharacterData {
-  const merged = { ...current, ...data };
-  if ((options?.mergeExtensions ?? true) === false || !isRecord(data.extensions)) return merged;
-
-  const extensions = {
-    ...(isRecord(current.extensions) ? current.extensions : {}),
-    ...data.extensions,
-  };
-  for (const [key, value] of Object.entries(data.extensions)) {
-    if (value === undefined) delete extensions[key];
+  const merged = { ...current, ...data } as CharacterData;
+  if ((options?.mergeExtensions ?? true) !== false && isRecord(data.extensions)) {
+    merged.extensions = mergeNestedRecord(
+      isRecord(current.extensions) ? current.extensions : defaultCharacterExtensions,
+      data.extensions,
+    ) as CharacterData["extensions"];
+  }
+  if (isRecord(data.character_book)) {
+    merged.character_book = mergeNestedRecord(
+      isRecord(current.character_book) ? current.character_book : defaultCharacterBook,
+      data.character_book,
+    ) as unknown as CharacterData["character_book"];
   }
 
-  return {
-    ...merged,
-    extensions: extensions as CharacterData["extensions"],
-  };
+  return merged;
 }
 
 type CharacterRow = typeof characters.$inferSelect;
@@ -378,7 +403,7 @@ export function createCharactersStorage(db: DB) {
 
     async update(
       id: string,
-      data: Partial<CharacterData>,
+      data: CharacterDataUpdate,
       avatarPath?: string,
       options?: {
         updatedAt?: string | null;

--- a/packages/shared/src/schemas/character.schema.ts
+++ b/packages/shared/src/schemas/character.schema.ts
@@ -80,15 +80,17 @@ export const characterBookEntrySchema = z
   })
   .passthrough();
 
-export const characterBookSchema = z.object({
-  name: z.string().default(""),
-  description: z.string().default(""),
-  scan_depth: z.number().default(2),
-  token_budget: z.number().default(512),
-  recursive_scanning: z.boolean().default(false),
-  extensions: z.record(z.unknown()).default({}),
-  entries: z.array(characterBookEntrySchema).default([]),
-});
+export const characterBookSchema = z
+  .object({
+    name: z.string().default(""),
+    description: z.string().default(""),
+    scan_depth: z.number().default(2),
+    token_budget: z.number().default(512),
+    recursive_scanning: z.boolean().default(false),
+    extensions: z.record(z.unknown()).default({}),
+    entries: z.array(characterBookEntrySchema).default([]),
+  })
+  .passthrough();
 
 export const characterDataSchema = z
   .object({
@@ -120,8 +122,16 @@ export const createCharacterSchema = z.object({
   data: characterDataSchema,
 });
 
+const updateCharacterExtensionsSchema = characterExtensionsSchema.partial().extend({
+  depth_prompt: depthPromptSchema.partial().optional(),
+  convoBehavior: convoBehaviorConfigSchema.partial().optional(),
+});
+
 export const updateCharacterSchema = z.object({
-  data: characterDataSchema.partial(),
+  data: characterDataSchema.partial().extend({
+    extensions: updateCharacterExtensionsSchema.optional(),
+    character_book: characterBookSchema.partial().nullable().optional(),
+  }),
 });
 
 export const createGroupSchema = z.object({

--- a/packages/shared/src/schemas/character.schema.ts
+++ b/packages/shared/src/schemas/character.schema.ts
@@ -123,6 +123,8 @@ export const createCharacterSchema = z.object({
 });
 
 const updateCharacterExtensionsSchema = characterExtensionsSchema.partial().extend({
+  // Zod 3 short-circuits these optional wrappers before applying the nested
+  // schema defaults. Revalidate this omission behavior before upgrading to Zod 4.
   depth_prompt: depthPromptSchema.partial().optional(),
   convoBehavior: convoBehaviorConfigSchema.partial().optional(),
 });

--- a/scripts/regressions/open-issues.regression.ts
+++ b/scripts/regressions/open-issues.regression.ts
@@ -20,6 +20,7 @@ import {
   normalizeLorebookCategory,
   updateLorebookSchema,
 } from "../../packages/shared/src/schemas/lorebook.schema.js";
+import { characterDataSchema, updateCharacterSchema } from "../../packages/shared/src/schemas/character.schema.js";
 import { buildLorebookDuplicateInput } from "../../packages/client/src/lib/lorebook-duplicate.js";
 import { appendLorebookActivationKeys } from "../../packages/client/src/lib/lorebook-keys.js";
 import { arePresetChoiceSelectionsComplete } from "../../packages/client/src/lib/preset-choice-selection.js";
@@ -114,6 +115,7 @@ import {
 } from "../../packages/server/src/services/sidecar/scene-analyzer.js";
 import { createAgentsStorage } from "../../packages/server/src/services/storage/agents.storage.js";
 import { createCustomToolsStorage } from "../../packages/server/src/services/storage/custom-tools.storage.js";
+import { createCharactersStorage } from "../../packages/server/src/services/storage/characters.storage.js";
 import { resolveRunPodComfyUiTimeoutSeconds } from "../../packages/server/src/services/image/runpod-comfyui.service.js";
 import {
   findMissingComfyReferenceSlots,
@@ -170,6 +172,8 @@ import {
   resolveGroupGenerationMode,
   shouldRestoreRegenerationCharacterTarget,
 } from "../../packages/server/src/routes/generate/generate-route-utils.js";
+import { normalizeChatForResponse } from "../../packages/server/src/routes/chats.routes.js";
+import { normalizeNativeCharacterData } from "../../packages/server/src/services/import/marinara.importer.js";
 import { parseDockerDefaultGatewayIp } from "../../packages/server/src/middleware/ip-allowlist.js";
 import {
   moveBackgroundAssignment,
@@ -350,6 +354,55 @@ assert.deepEqual(
   "Partial character updates must not synthesize undefined fields that deepMerge treats as deletions",
 );
 
+assert.deepEqual(
+  normalizeChatForResponse({
+    id: "fresh-chat",
+    characterIds: '["character-a","character-b"]',
+    metadata: '{"tags":["saved-tag"],"gameNpcs":[]}',
+  }),
+  {
+    id: "fresh-chat",
+    characterIds: ["character-a", "character-b"],
+    metadata: { tags: ["saved-tag"], gameNpcs: [] },
+  },
+  "Fresh chat responses must expose parsed tags and character IDs",
+);
+
+assert.deepEqual(
+  updateCharacterSchema.parse({
+    data: {
+      extensions: { fav: true, depth_prompt: { prompt: "Updated only" } },
+      character_book: { name: "Renamed" },
+    },
+  }).data,
+  {
+    extensions: { fav: true, depth_prompt: { prompt: "Updated only" } },
+    character_book: { name: "Renamed" },
+  },
+  "Character PATCH parsing must not materialize omitted nested defaults",
+);
+
+assert.equal(
+  normalizeNativeCharacterData({}),
+  null,
+  "A native character import without the required name must fail before persistence",
+);
+const normalizedNativeCharacter = normalizeNativeCharacterData({
+  name: "Legacy",
+  character_book: {
+    name: "Archive",
+    custom_top_level_property: "preserved",
+  },
+});
+assert.ok(normalizedNativeCharacter);
+assert.equal(normalizedNativeCharacter.description, "");
+assert.equal(normalizedNativeCharacter.character_book?.entries.length, 0);
+assert.equal(
+  (normalizedNativeCharacter.character_book as Record<string, unknown>).custom_top_level_property,
+  "preserved",
+  "Native import normalization must preserve unknown embedded-lorebook properties",
+);
+
 const characterUpdateStorageRoot = mkdtempSync(join(tmpdir(), "marinara-character-update-preservation-"));
 const previousFileStorageDir = process.env.FILE_STORAGE_DIR;
 process.env.FILE_STORAGE_DIR = characterUpdateStorageRoot;
@@ -358,6 +411,73 @@ try {
   const { closeDB, getDB } = await import("../../packages/server/src/db/connection.js");
   closeCharacterUpdateDb = closeDB;
   const db = await getDB();
+  const characterStorage = createCharactersStorage(db);
+  const patchFixture = characterDataSchema.parse({
+    name: "Nested patch fixture",
+    extensions: {
+      fav: false,
+      depth_prompt: { prompt: "Original", depth: 7, role: "assistant" },
+      thirdParty: { retained: true },
+    },
+    character_book: {
+      name: "Original book",
+      description: "Keep this description",
+      entries: [{ id: 9, content: "Keep this entry" }],
+      custom_top_level_property: "preserved",
+    },
+  });
+  const createdPatchFixture = await characterStorage.create(patchFixture);
+  assert.ok(createdPatchFixture);
+  const nestedPatch = updateCharacterSchema.parse({
+    data: {
+      extensions: { fav: true, depth_prompt: { prompt: "Updated only" } },
+      character_book: { name: "Renamed" },
+    },
+  });
+  const patchedFixture = await characterStorage.update(createdPatchFixture.id, nestedPatch.data);
+  assert.ok(patchedFixture);
+  const patchedFixtureData = JSON.parse(patchedFixture.data) as {
+    extensions: Record<string, unknown> & {
+      fav: boolean;
+      depth_prompt: { prompt: string; depth: number; role: string };
+      thirdParty: { retained: boolean };
+    };
+    character_book: Record<string, unknown> & {
+      name: string;
+      description: string;
+      entries: Array<{ content: string }>;
+    };
+  };
+  assert.equal(patchedFixtureData.extensions.fav, true);
+  assert.deepEqual(patchedFixtureData.extensions.depth_prompt, {
+    prompt: "Updated only",
+    depth: 7,
+    role: "assistant",
+  });
+  assert.deepEqual(patchedFixtureData.extensions.thirdParty, { retained: true });
+  assert.equal(patchedFixtureData.character_book.name, "Renamed");
+  assert.equal(patchedFixtureData.character_book.description, "Keep this description");
+  assert.equal(patchedFixtureData.character_book.entries[0]!.content, "Keep this entry");
+  assert.equal(patchedFixtureData.character_book.custom_top_level_property, "preserved");
+
+  const emptyBookFixture = await characterStorage.create(characterDataSchema.parse({ name: "Empty book fixture" }));
+  assert.ok(emptyBookFixture);
+  const createdBookFixture = await characterStorage.update(
+    emptyBookFixture.id,
+    updateCharacterSchema.parse({ data: { character_book: { name: "New book" } } }).data,
+  );
+  assert.ok(createdBookFixture);
+  const createdBookData = JSON.parse(createdBookFixture.data) as { character_book: Record<string, unknown> };
+  assert.deepEqual(createdBookData.character_book, {
+    name: "New book",
+    description: "",
+    scan_depth: 2,
+    token_budget: 512,
+    recursive_scanning: false,
+    extensions: {},
+    entries: [],
+  });
+
   const mariDb = new MariDbService(db);
   const customToolsStore = createCustomToolsStorage(db);
   const agentsStore = createAgentsStorage(db);


### PR DESCRIPTION
## Why

Fresh chat loads exposed storage-encoded JSON to consumers, partial nested character PATCH bodies materialized schema defaults before a shallow replacement, and native character imports persisted unchecked payloads. Those boundary failures caused inconsistent sidebar tags and risked durable character-card data loss.

Closes #3857
Closes #3858
Closes #3859

## What changed

- Normalize public chat metadata and character IDs at the response boundary.
- Parse Character PATCH nested objects as true partials and recursively merge objects while replacing arrays/scalars.
- Default a newly created embedded lorebook without overwriting omitted fields on an existing one.
- Validate and normalize native character payloads before persistence, preserving unknown embedded-lorebook properties.
- Add exact regressions and changelog entries.

## Validation

- `pnpm build:shared && pnpm regression:issues`
- `pnpm check`

## Manual verification

- [ ] Manually verify tags appear immediately after a fresh chat-list load.
- [ ] Manually verify a partial Character PATCH preserves omitted extension and embedded-lorebook data.
- [ ] Manually verify malformed native character imports fail without creating a row.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Public chat APIs now return a consistent response with structured metadata and resolved character IDs, fixing sidebar tag filtering.
  - Character PATCH updates now deep-merge nested data, correctly preserve omitted fields, and avoid destructive defaults.
  - Imported/valid native Marinara character cards are now validated/normalized while preserving unknown embedded lorebook properties.
- **Improvements**
  - Character and chat metadata updates are returned in a unified, sanitized format.
- **Tests**
  - Added regression coverage for chat normalization, nested PATCH semantics, and Marinara import normalization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->