### PR TITLE
Sweep dangling connection references when a connection is deleted

### DIFF
--- a/packages/server/src/services/storage/connection-reference-cleanup.ts
+++ b/packages/server/src/services/storage/connection-reference-cleanup.ts
@@ -29,6 +29,8 @@ import type { DB } from "../../db/connection.js";
 import { apiConnections, chats, agentConfigs } from "../../db/schema/index.js";
 import { now } from "../../utils/id-generator.js";
 
+const CLEANUP_BATCH_SIZE = 250;
+
 export type ConnectionReferenceCleanupResult = {
   chatsUpdated: number;
   agentsUpdated: number;
@@ -107,44 +109,61 @@ export async function sweepDanglingConnectionReferences(
   if (danglingEmbeddingRefs.length > 0) {
     await db
       .update(apiConnections)
-      .set({ embeddingConnectionId: null })
+      .set({ embeddingConnectionId: null, updatedAt: now() })
       .where(eq(apiConnections.embeddingConnectionId, deletedConnectionId));
     result.connectionsUpdated = danglingEmbeddingRefs.length;
   }
 
-  const chatRows = await db.select().from(chats);
-  for (const chat of chatRows) {
-    const metadata = parseJsonObject(chat.metadata);
-    const swept = nullifyConnectionIdReferences(metadata, deletedConnectionId);
-    const directMatch = chat.connectionId === deletedConnectionId;
-    if (!swept.changed && !directMatch) continue;
+  for (let offset = 0; ; offset += CLEANUP_BATCH_SIZE) {
+    const chatRows = await db
+      .select()
+      .from(chats)
+      .orderBy(chats.id)
+      .limit(CLEANUP_BATCH_SIZE)
+      .offset(offset);
+    for (const chat of chatRows) {
+      const metadata = parseJsonObject(chat.metadata);
+      const swept = nullifyConnectionIdReferences(metadata, deletedConnectionId);
+      const directMatch = chat.connectionId === deletedConnectionId;
+      if (!swept.changed && !directMatch) continue;
 
-    await db
-      .update(chats)
-      .set({
-        connectionId: directMatch ? null : chat.connectionId,
-        metadata: swept.changed ? JSON.stringify(swept.value) : chat.metadata,
-        updatedAt: now(),
-      })
-      .where(eq(chats.id, chat.id));
-    result.chatsUpdated += 1;
+      await db
+        .update(chats)
+        .set({
+          connectionId: directMatch ? null : chat.connectionId,
+          metadata: swept.changed ? JSON.stringify(swept.value) : chat.metadata,
+          updatedAt: now(),
+        })
+        .where(eq(chats.id, chat.id));
+      result.chatsUpdated += 1;
+    }
+    if (chatRows.length < CLEANUP_BATCH_SIZE) break;
   }
 
-  const agentRows = await db.select().from(agentConfigs);
-  for (const agent of agentRows) {
-    const settings = parseJsonObject(agent.settings);
-    const swept = nullifyConnectionIdReferences(settings, deletedConnectionId);
-    const directMatch = agent.connectionId === deletedConnectionId;
-    if (!swept.changed && !directMatch) continue;
+  for (let offset = 0; ; offset += CLEANUP_BATCH_SIZE) {
+    const agentRows = await db
+      .select()
+      .from(agentConfigs)
+      .orderBy(agentConfigs.id)
+      .limit(CLEANUP_BATCH_SIZE)
+      .offset(offset);
+    for (const agent of agentRows) {
+      const settings = parseJsonObject(agent.settings);
+      const swept = nullifyConnectionIdReferences(settings, deletedConnectionId);
+      const directMatch = agent.connectionId === deletedConnectionId;
+      if (!swept.changed && !directMatch) continue;
 
-    await db
-      .update(agentConfigs)
-      .set({
-        connectionId: directMatch ? null : agent.connectionId,
-        settings: swept.changed ? JSON.stringify(swept.value) : agent.settings,
-      })
-      .where(eq(agentConfigs.id, agent.id));
-    result.agentsUpdated += 1;
+      await db
+        .update(agentConfigs)
+        .set({
+          connectionId: directMatch ? null : agent.connectionId,
+          settings: swept.changed ? JSON.stringify(swept.value) : agent.settings,
+          updatedAt: now(),
+        })
+        .where(eq(agentConfigs.id, agent.id));
+      result.agentsUpdated += 1;
+    }
+    if (agentRows.length < CLEANUP_BATCH_SIZE) break;
   }
 
   return result;

--- a/packages/server/src/services/storage/connection-reference-cleanup.ts
+++ b/packages/server/src/services/storage/connection-reference-cleanup.ts
@@ -1,0 +1,151 @@
+// ──────────────────────────────────────────────
+// Storage: dangling connection reference cleanup
+// ──────────────────────────────────────────────
+//
+// Deleting a connection currently leaves every stored reference to its id
+// untouched: chat.connectionId, agentConfig.connectionId,
+// connection.embeddingConnectionId, and the large family of *ConnectionId
+// keys stored inside chat.metadata (illustratorPromptConnectionId,
+// gameImageConnectionId, gameSceneConnectionId, sceneVideoConnectionId,
+// imageGenConnectionId, agentOverrides.<type>.imageConnectionId, …).
+//
+// Some resolution paths handle a dangling id gracefully (skip the affected
+// feature with a warning); others do not, and a dangling id can silently
+// misroute a request to an unrelated connection or hang far longer than a
+// normal request. Rather than hardening every individual resolution path
+// (and every future one that stores a new *ConnectionId field), this module
+// removes the dangling reference at the source, the moment the connection
+// is deleted.
+//
+// The sweep over chat.metadata and agentConfig.settings is generic rather
+// than a hardcoded field list: any JSON key ending in "ConnectionId" is
+// treated as a connection reference, at any nesting depth. This matches the
+// naming convention already used consistently for every such field in this
+// codebase, and stays correct as new *ConnectionId settings are added
+// without requiring this file to be updated in lockstep.
+
+import { eq } from "../../db/file-query.js";
+import type { DB } from "../../db/connection.js";
+import { apiConnections, chats, agentConfigs } from "../../db/schema/index.js";
+import { now } from "../../utils/id-generator.js";
+
+export type ConnectionReferenceCleanupResult = {
+  chatsUpdated: number;
+  agentsUpdated: number;
+  connectionsUpdated: number;
+};
+
+function parseJsonObject(raw: unknown): Record<string, unknown> {
+  if (typeof raw !== "string") {
+    return raw && typeof raw === "object" && !Array.isArray(raw) ? (raw as Record<string, unknown>) : {};
+  }
+  try {
+    const parsed = JSON.parse(raw) as unknown;
+    return parsed && typeof parsed === "object" && !Array.isArray(parsed) ? (parsed as Record<string, unknown>) : {};
+  } catch {
+    return {};
+  }
+}
+
+/**
+ * Recursively replaces any `"...ConnectionId": "<deletedId>"` entry, at any
+ * nesting depth, with `null`. Returns the (possibly new) value plus whether
+ * anything changed, so callers can skip writing back unchanged rows.
+ */
+export function nullifyConnectionIdReferences(
+  value: unknown,
+  deletedConnectionId: string,
+): { value: unknown; changed: boolean } {
+  if (Array.isArray(value)) {
+    let changed = false;
+    const next = value.map((item) => {
+      const result = nullifyConnectionIdReferences(item, deletedConnectionId);
+      if (result.changed) changed = true;
+      return result.value;
+    });
+    return changed ? { value: next, changed: true } : { value, changed: false };
+  }
+
+  if (value && typeof value === "object") {
+    let changed = false;
+    const next: Record<string, unknown> = {};
+    for (const [key, entry] of Object.entries(value as Record<string, unknown>)) {
+      if (/ConnectionId$/.test(key) && entry === deletedConnectionId) {
+        next[key] = null;
+        changed = true;
+        continue;
+      }
+      const result = nullifyConnectionIdReferences(entry, deletedConnectionId);
+      if (result.changed) changed = true;
+      next[key] = result.value;
+    }
+    return changed ? { value: next, changed: true } : { value, changed: false };
+  }
+
+  return { value, changed: false };
+}
+
+/**
+ * Clears every stored reference to `deletedConnectionId`: the direct
+ * `connectionId` columns on chats and agent configs, `embeddingConnectionId`
+ * on other connections, and any `*ConnectionId` key inside chat metadata or
+ * agent settings (however deeply nested). Call this once the connection
+ * itself has been removed (or is about to be); it is a no-op if nothing
+ * references the id.
+ */
+export async function sweepDanglingConnectionReferences(
+  db: DB,
+  deletedConnectionId: string,
+): Promise<ConnectionReferenceCleanupResult> {
+  const result: ConnectionReferenceCleanupResult = { chatsUpdated: 0, agentsUpdated: 0, connectionsUpdated: 0 };
+  if (!deletedConnectionId) return result;
+
+  const danglingEmbeddingRefs = await db
+    .select()
+    .from(apiConnections)
+    .where(eq(apiConnections.embeddingConnectionId, deletedConnectionId));
+  if (danglingEmbeddingRefs.length > 0) {
+    await db
+      .update(apiConnections)
+      .set({ embeddingConnectionId: null })
+      .where(eq(apiConnections.embeddingConnectionId, deletedConnectionId));
+    result.connectionsUpdated = danglingEmbeddingRefs.length;
+  }
+
+  const chatRows = await db.select().from(chats);
+  for (const chat of chatRows) {
+    const metadata = parseJsonObject(chat.metadata);
+    const swept = nullifyConnectionIdReferences(metadata, deletedConnectionId);
+    const directMatch = chat.connectionId === deletedConnectionId;
+    if (!swept.changed && !directMatch) continue;
+
+    await db
+      .update(chats)
+      .set({
+        connectionId: directMatch ? null : chat.connectionId,
+        metadata: swept.changed ? JSON.stringify(swept.value) : chat.metadata,
+        updatedAt: now(),
+      })
+      .where(eq(chats.id, chat.id));
+    result.chatsUpdated += 1;
+  }
+
+  const agentRows = await db.select().from(agentConfigs);
+  for (const agent of agentRows) {
+    const settings = parseJsonObject(agent.settings);
+    const swept = nullifyConnectionIdReferences(settings, deletedConnectionId);
+    const directMatch = agent.connectionId === deletedConnectionId;
+    if (!swept.changed && !directMatch) continue;
+
+    await db
+      .update(agentConfigs)
+      .set({
+        connectionId: directMatch ? null : agent.connectionId,
+        settings: swept.changed ? JSON.stringify(swept.value) : agent.settings,
+      })
+      .where(eq(agentConfigs.id, agent.id));
+    result.agentsUpdated += 1;
+  }
+
+  return result;
+}

--- a/packages/server/src/services/storage/connections.storage.ts
+++ b/packages/server/src/services/storage/connections.storage.ts
@@ -7,6 +7,8 @@ import { apiConnections } from "../../db/schema/index.js";
 import { newId, now } from "../../utils/id-generator.js";
 import { encryptApiKey, decryptApiKey } from "../../utils/crypto.js";
 import type { CreateConnectionInput } from "@marinara-engine/shared";
+import { sweepDanglingConnectionReferences } from "./connection-reference-cleanup.js";
+import { logger } from "../../lib/logger.js";
 
 type ConnectionDefaultCategory = "image_generation" | "video_generation" | "language";
 
@@ -433,6 +435,18 @@ export function createConnectionsStorage(db: DB) {
 
     async remove(id: string) {
       await db.delete(apiConnections).where(eq(apiConnections.id, id));
+
+      const cleanup = await sweepDanglingConnectionReferences(db, id);
+      const totalCleaned = cleanup.chatsUpdated + cleanup.agentsUpdated + cleanup.connectionsUpdated;
+      if (totalCleaned > 0) {
+        logger.info(
+          "[connections] Cleared dangling references to deleted connection %s: %d chat(s), %d agent(s), %d connection(s)",
+          id,
+          cleanup.chatsUpdated,
+          cleanup.agentsUpdated,
+          cleanup.connectionsUpdated,
+        );
+      }
     },
 
     async updateDefaultParameters(id: string, params: Record<string, unknown> | null) {


### PR DESCRIPTION
## Linked issue

Closes #3865

## Why this change

Deleting a connection leaves every stored reference to its id untouched — `chats.connectionId`, `agentConfigs.connectionId`, `connections.embeddingConnectionId`, and 15+ distinct `*ConnectionId` fields inside `chats.metadata` (`illustratorPromptConnectionId`, `gameImageConnectionId`, `gameSceneConnectionId`, `sceneVideoConnectionId`, `imageGenConnectionId`, `agentOverrides.<type>.imageConnectionId`, and more). #2683 / PR #2730 fixed the general per-agent connection resolution path to fail gracefully on a dangling id, but that fix didn't (and structurally couldn't, being a resolution-time guard) prevent the dangling reference from existing in the first place, and at least one other path (`illustratorPromptConnectionId` read directly in `agent-resolution.ts`'s illustrator special case and its near-duplicate in `retry-agents-route.ts`) doesn't fail gracefully at all — reproduced firsthand, a stale reference there silently misrouted a post-processing agent turn onto an unrelated, much larger model and turned a normal ~3 minute turn into over an hour.

Rather than adding another one-off guard to that specific path (and every future path that reads one of these fields), this removes the dangling reference at the source: the moment a connection is deleted.

## What changed

- Added `sweepDanglingConnectionReferences()` (`services/storage/connection-reference-cleanup.ts`), called from `connections.storage.ts`'s `remove()`.
- Clears `chats.connectionId` and `agentConfigs.connectionId` directly, and `connections.embeddingConnectionId` on any other connection.
- Sweeps `chats.metadata` and `agentConfigs.settings` recursively: any JSON key matching `/ConnectionId$/`, at any nesting depth, is treated as a connection reference and nulled if it matches the deleted id.
- Deliberately generic rather than a hardcoded field list — matches the naming convention already used consistently for every such field in this codebase, so it stays correct as new `*ConnectionId` settings get added without this file needing to track them.
- Logs a one-line summary (`chatsUpdated` / `agentsUpdated` / `connectionsUpdated`) when the sweep actually clears something, silent no-op otherwise.

## Validation

- [x] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [x] Above manual verification completed (describe below)
- [x] Read and followed `CONTRIBUTING.md`

### Manual verification notes

This is a backend-only, non-UI change, so the container/UI-mode checklist items above don't apply (left unticked rather than claimed). What I did verify directly:

- `tsc --noEmit` and a full `tsc` build against a real, dependency-installed checkout — both pass with zero errors.
- End-to-end against a running instance: created a throwaway connection, referenced it four different ways on a chat (`chat.connectionId`, `metadata.illustratorPromptConnectionId`, `metadata.gameImageConnectionId`, and the nested `metadata.agentOverrides.custom-akistar-forge.imageConnectionId`), deleted the connection via the API, then re-fetched the chat and confirmed all four references were nulled. Repeated with a fresh connection/chat pair to rule out a fluke.
- Confirmed the pre-existing #2683/#2730 general-path fix is present and working on current staging before scoping this PR to the gap it left.

## Docs and release impact

- [x] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Version/release files updated (only if this PR includes a version bump)

## UI evidence (if applicable)

N/A — backend-only change, no UI surface.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Deleting a connection now automatically clears references to it across chats, agent configurations, and related connection settings.
  * Nested connection references in metadata and settings are safely removed, preventing stale or invalid configuration links.
  * Cleanup activity is tracked to improve visibility into affected records.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->