### PR TITLE
fix(game): keep NPC avoid rules in negative prompt

### DIFF
--- a/packages/server/src/services/prompt-overrides/registry/game-assets.ts
+++ b/packages/server/src/services/prompt-overrides/registry/game-assets.ts
@@ -65,7 +65,6 @@ export const GAME_NPC_PORTRAIT: PromptOverrideKeyDef<GameNpcPortraitCtx> = {
       ctx.compositionRule,
       `SD/Illustrious tags: solo, single character, portrait, upper body, centered composition, clean readable avatar.`,
       `Single subject only, one portrait, one face, one frame. High quality game avatar, clear readable design.`,
-      `Avoid text, letters, captions, UI, watermarks, logos, signatures, speech bubbles, split panels, collage, contact sheet, multiple portraits, duplicated faces, and four-image grids.`,
     ]
       .filter(Boolean)
       .join(" "),

--- a/packages/server/src/services/prompt-overrides/registry/game-assets.ts
+++ b/packages/server/src/services/prompt-overrides/registry/game-assets.ts
@@ -65,6 +65,7 @@ export const GAME_NPC_PORTRAIT: PromptOverrideKeyDef<GameNpcPortraitCtx> = {
       ctx.compositionRule,
       `SD/Illustrious tags: solo, single character, portrait, upper body, centered composition, clean readable avatar.`,
       `Single subject only, one portrait, one face, one frame. High quality game avatar, clear readable design.`,
+      `Avoid text, letters, captions, UI, watermarks, logos, signatures, speech bubbles, split panels, collage, contact sheet, multiple portraits, duplicated faces, and four-image grids.`,
     ]
       .filter(Boolean)
       .join(" "),

--- a/packages/shared/src/utils/image-prompt-compiler.ts
+++ b/packages/shared/src/utils/image-prompt-compiler.ts
@@ -325,9 +325,15 @@ function splitPromptListItems(value: string): string[] {
   return parts;
 }
 
-function splitNaturalPromptClauses(value: string): string[] {
-  const parts: string[] = [];
+type NaturalPromptClause = {
+  value: string;
+  startsAtBoundary: boolean;
+};
+
+function splitNaturalPromptClauses(value: string): NaturalPromptClause[] {
+  const parts: NaturalPromptClause[] = [];
   let current = "";
+  let startsAtBoundary = true;
   let parenDepth = 0;
   let bracketDepth = 0;
   let braceDepth = 0;
@@ -336,7 +342,7 @@ function splitNaturalPromptClauses(value: string): string[] {
 
   const pushCurrent = () => {
     const clean = current.trim();
-    if (clean) parts.push(clean);
+    if (clean) parts.push({ value: clean, startsAtBoundary });
     current = "";
   };
 
@@ -376,8 +382,14 @@ function splitNaturalPromptClauses(value: string): string[] {
 
     const insideGroup = parenDepth > 0 || bracketDepth > 0 || braceDepth > 0;
     const startsNegativeClause = /^\s*(?:avoid|no|without)\b/i.test(value.slice(index + 1));
-    if (!insideGroup && (char === "\n" || (char === "," && startsNegativeClause))) {
+    if (!insideGroup && char === "\n") {
       pushCurrent();
+      startsAtBoundary = true;
+      continue;
+    }
+    if (!insideGroup && char === "," && startsNegativeClause) {
+      pushCurrent();
+      startsAtBoundary = false;
       continue;
     }
 
@@ -386,6 +398,71 @@ function splitNaturalPromptClauses(value: string): string[] {
 
   pushCurrent();
   return parts;
+}
+
+function isStandaloneNegativeListInstruction(value: string): boolean {
+  return /^(?:avoid|exclude|do not include|don't include)\b/i.test(value.trim());
+}
+
+function splitStandaloneNegativeInstruction(value: string): string[] {
+  const clean = value.trim();
+  const match = clean.match(/^(?:avoid|exclude|do not include|don't include)\s+(.+)$/i);
+  if (!match?.[1]) return [clean];
+
+  const body = match[1].trim();
+  const sentenceBoundary = findTopLevelSentenceBoundary(body);
+  const listText = (sentenceBoundary >= 0 ? body.slice(0, sentenceBoundary) : body)
+    .replace(/[.!?]+$/g, "")
+    .trim();
+  const trailingText = sentenceBoundary >= 0 ? body.slice(sentenceBoundary + 1).trim() : "";
+  const negativeItems = splitPromptListItems(listText)
+    .map((item) => item.replace(/^(?:and|or)\s+/i, "").trim())
+    .filter(Boolean)
+    .map((item) => `avoid ${item}`);
+
+  return [...negativeItems, ...(trailingText ? [trailingText] : [])];
+}
+
+function findTopLevelSentenceBoundary(value: string): number {
+  let parenDepth = 0;
+  let bracketDepth = 0;
+  let braceDepth = 0;
+  let quote: '"' | null = null;
+  let escaped = false;
+
+  for (let index = 0; index < value.length; index += 1) {
+    const char = value[index]!;
+    if (escaped) {
+      escaped = false;
+      continue;
+    }
+    if (char === "\\") {
+      escaped = true;
+      continue;
+    }
+    if (quote) {
+      if (char === quote) quote = null;
+      continue;
+    }
+    if (char === '"') {
+      quote = char;
+      continue;
+    }
+
+    if (char === "(") parenDepth += 1;
+    else if (char === ")" && parenDepth > 0) parenDepth -= 1;
+    else if (char === "[") bracketDepth += 1;
+    else if (char === "]" && bracketDepth > 0) bracketDepth -= 1;
+    else if (char === "{") braceDepth += 1;
+    else if (char === "}" && braceDepth > 0) braceDepth -= 1;
+
+    const insideGroup = parenDepth > 0 || bracketDepth > 0 || braceDepth > 0;
+    if (!insideGroup && /[.!?]/.test(char) && (!value[index + 1] || /\s/.test(value[index + 1]!))) {
+      return index;
+    }
+  }
+
+  return -1;
 }
 
 export function mergeCompiledPromptMeta(
@@ -430,10 +507,16 @@ function splitPromptFragments(
   if (promptMode === "natural") {
     const fragments: string[] = [];
     for (const part of splitNaturalPromptClauses(normalized)) {
-      const clean = part.trim();
+      const clean = part.value.trim();
       if (!clean) continue;
       if (hasAvoidInstructionPrefix(clean)) {
-        fragments.push(...splitPromptListItems(clean));
+        // Generated prompts use sentence-level avoid lists; inline clauses must retain the
+        // one-item negation behavior that keeps following positive descriptors intact.
+        const listItems =
+          part.startsAtBoundary && isStandaloneNegativeListInstruction(clean)
+            ? splitStandaloneNegativeInstruction(clean)
+            : splitPromptListItems(clean);
+        fragments.push(...listItems);
       } else {
         fragments.push(clean);
       }

--- a/packages/shared/src/utils/image-prompt-compiler.ts
+++ b/packages/shared/src/utils/image-prompt-compiler.ts
@@ -325,15 +325,9 @@ function splitPromptListItems(value: string): string[] {
   return parts;
 }
 
-type NaturalPromptClause = {
-  value: string;
-  startsAtBoundary: boolean;
-};
-
-function splitNaturalPromptClauses(value: string): NaturalPromptClause[] {
-  const parts: NaturalPromptClause[] = [];
+function splitNaturalPromptClauses(value: string): string[] {
+  const parts: string[] = [];
   let current = "";
-  let startsAtBoundary = true;
   let parenDepth = 0;
   let bracketDepth = 0;
   let braceDepth = 0;
@@ -342,7 +336,7 @@ function splitNaturalPromptClauses(value: string): NaturalPromptClause[] {
 
   const pushCurrent = () => {
     const clean = current.trim();
-    if (clean) parts.push({ value: clean, startsAtBoundary });
+    if (clean) parts.push(clean);
     current = "";
   };
 
@@ -382,14 +376,8 @@ function splitNaturalPromptClauses(value: string): NaturalPromptClause[] {
 
     const insideGroup = parenDepth > 0 || bracketDepth > 0 || braceDepth > 0;
     const startsNegativeClause = /^\s*(?:avoid|no|without)\b/i.test(value.slice(index + 1));
-    if (!insideGroup && char === "\n") {
+    if (!insideGroup && (char === "\n" || (char === "," && startsNegativeClause))) {
       pushCurrent();
-      startsAtBoundary = true;
-      continue;
-    }
-    if (!insideGroup && char === "," && startsNegativeClause) {
-      pushCurrent();
-      startsAtBoundary = false;
       continue;
     }
 
@@ -398,71 +386,6 @@ function splitNaturalPromptClauses(value: string): NaturalPromptClause[] {
 
   pushCurrent();
   return parts;
-}
-
-function isStandaloneNegativeListInstruction(value: string): boolean {
-  return /^(?:avoid|exclude|do not include|don't include)\b/i.test(value.trim());
-}
-
-function splitStandaloneNegativeInstruction(value: string): string[] {
-  const clean = value.trim();
-  const match = clean.match(/^(?:avoid|exclude|do not include|don't include)\s+(.+)$/i);
-  if (!match?.[1]) return [clean];
-
-  const body = match[1].trim();
-  const sentenceBoundary = findTopLevelSentenceBoundary(body);
-  const listText = (sentenceBoundary >= 0 ? body.slice(0, sentenceBoundary) : body)
-    .replace(/[.!?]+$/g, "")
-    .trim();
-  const trailingText = sentenceBoundary >= 0 ? body.slice(sentenceBoundary + 1).trim() : "";
-  const negativeItems = splitPromptListItems(listText)
-    .map((item) => item.replace(/^(?:and|or)\s+/i, "").trim())
-    .filter(Boolean)
-    .map((item) => `avoid ${item}`);
-
-  return [...negativeItems, ...(trailingText ? [trailingText] : [])];
-}
-
-function findTopLevelSentenceBoundary(value: string): number {
-  let parenDepth = 0;
-  let bracketDepth = 0;
-  let braceDepth = 0;
-  let quote: '"' | null = null;
-  let escaped = false;
-
-  for (let index = 0; index < value.length; index += 1) {
-    const char = value[index]!;
-    if (escaped) {
-      escaped = false;
-      continue;
-    }
-    if (char === "\\") {
-      escaped = true;
-      continue;
-    }
-    if (quote) {
-      if (char === quote) quote = null;
-      continue;
-    }
-    if (char === '"') {
-      quote = char;
-      continue;
-    }
-
-    if (char === "(") parenDepth += 1;
-    else if (char === ")" && parenDepth > 0) parenDepth -= 1;
-    else if (char === "[") bracketDepth += 1;
-    else if (char === "]" && bracketDepth > 0) bracketDepth -= 1;
-    else if (char === "{") braceDepth += 1;
-    else if (char === "}" && braceDepth > 0) braceDepth -= 1;
-
-    const insideGroup = parenDepth > 0 || bracketDepth > 0 || braceDepth > 0;
-    if (!insideGroup && /[.!?]/.test(char) && (!value[index + 1] || /\s/.test(value[index + 1]!))) {
-      return index;
-    }
-  }
-
-  return -1;
 }
 
 export function mergeCompiledPromptMeta(
@@ -507,16 +430,10 @@ function splitPromptFragments(
   if (promptMode === "natural") {
     const fragments: string[] = [];
     for (const part of splitNaturalPromptClauses(normalized)) {
-      const clean = part.value.trim();
+      const clean = part.trim();
       if (!clean) continue;
       if (hasAvoidInstructionPrefix(clean)) {
-        // Generated prompts use sentence-level avoid lists; inline clauses must retain the
-        // one-item negation behavior that keeps following positive descriptors intact.
-        const listItems =
-          part.startsAtBoundary && isStandaloneNegativeListInstruction(clean)
-            ? splitStandaloneNegativeInstruction(clean)
-            : splitPromptListItems(clean);
-        fragments.push(...listItems);
+        fragments.push(...splitPromptListItems(clean));
       } else {
         fragments.push(clean);
       }

--- a/packages/shared/src/utils/image-prompt-compiler.ts
+++ b/packages/shared/src/utils/image-prompt-compiler.ts
@@ -381,16 +381,20 @@ function splitNaturalPromptClauses(value: string): NaturalPromptClause[] {
     else if (char === "}" && braceDepth > 0) braceDepth -= 1;
 
     const insideGroup = parenDepth > 0 || bracketDepth > 0 || braceDepth > 0;
-    const startsNegativeClause = /^\s*(?:avoid|no|without)\b/i.test(value.slice(index + 1));
     if (!insideGroup && char === "\n") {
       pushCurrent();
       startsAtBoundary = true;
       continue;
     }
-    if (!insideGroup && char === "," && startsNegativeClause) {
-      pushCurrent();
-      startsAtBoundary = false;
-      continue;
+    if (!insideGroup && char === ",") {
+      const startsNegativeClause = /^\s*(?:avoid|no|without|exclude|do not include|don't include)\b/i.test(
+        value.slice(index + 1),
+      );
+      if (startsNegativeClause) {
+        pushCurrent();
+        startsAtBoundary = false;
+        continue;
+      }
     }
 
     current += char;

--- a/scripts/regressions/prompt.regression.ts
+++ b/scripts/regressions/prompt.regression.ts
@@ -3656,6 +3656,62 @@ Use HTML sparingly and diegetically. Do not replace normal prose/dialogue unless
       assert.match(natural.prompt, /holding flowers/);
       assert.match(natural.prompt, /smiling/);
 
+      const inlineAvoid = compileImagePrompt({
+        kind: "selfie",
+        prompt: "A woman, avoid makeup, holding flowers, smiling",
+        styleProfiles,
+        styleProfileId: "realistic",
+      });
+
+      assert.match(inlineAvoid.negativePrompt, /\bmakeup\b/);
+      assert.doesNotMatch(inlineAvoid.negativePrompt, /holding flowers|smiling/);
+      assert.match(inlineAvoid.prompt, /holding flowers/);
+      assert.match(inlineAvoid.prompt, /smiling/);
+
+      const standaloneAvoid = compileImagePrompt({
+        kind: "portrait",
+        prompt:
+          "Avoid text, letters, captions, UI, watermarks, logos, speech bubbles, split panels, collage, contact sheet, multiple portraits, duplicated faces, and four-image grids.",
+        styleProfiles,
+        styleProfileId: "z-image-turbo",
+      });
+
+      for (const artifact of [
+        "text",
+        "letters",
+        "captions",
+        "UI",
+        "watermarks",
+        "logos",
+        "speech bubbles",
+        "split panels",
+        "collage",
+        "contact sheet",
+        "multiple portraits",
+        "duplicated faces",
+        "four-image grids",
+      ]) {
+        assert.doesNotMatch(standaloneAvoid.prompt, new RegExp(`\\b${artifact}\\b`, "i"));
+        assert.ok(
+          standaloneAvoid.diagnostics.movedNegativeFragments.some((fragment) =>
+            new RegExp(`^avoid ${artifact}$`, "i").test(fragment),
+          ),
+          `${artifact} was not routed to the negative path`,
+        );
+      }
+      assert.match(standaloneAvoid.negativePrompt, /text|UI|watermarks|logos|collage/i);
+
+      const standaloneAvoidWithFollowingSentence = compileImagePrompt({
+        kind: "portrait",
+        prompt: "Avoid text, captions, watermarks. A woman with auburn hair and green eyes.",
+        styleProfiles,
+        styleProfileId: "z-image-turbo",
+      });
+
+      assert.match(standaloneAvoidWithFollowingSentence.negativePrompt, /text|captions|watermarks/i);
+      assert.match(standaloneAvoidWithFollowingSentence.prompt, /auburn hair|green eyes/i);
+      assert.doesNotMatch(standaloneAvoidWithFollowingSentence.prompt, /avoid text|captions|watermarks/i);
+
       const groupedNatural = compileImagePrompt({
         kind: "selfie",
         prompt: 'A cafe sign says "no shoes, no service", no (bad hands, extra fingers:1.2), holding flowers',

--- a/scripts/regressions/prompt.regression.ts
+++ b/scripts/regressions/prompt.regression.ts
@@ -3198,6 +3198,8 @@ Use HTML sparingly and diegetically. Do not replace normal prose/dialogue unless
         styleProfileId: "z-image-turbo",
       });
       assert.equal(countAppearance(zImage.prompt), 1);
+      assert.doesNotMatch(zImage.prompt, /\b(?:letters|captions|UI|watermarks|logos|speech bubbles|split panels|collage)\b/i);
+      assert.match(zImage.negativePrompt, /letters|captions|UI|watermark|logo|collage/i);
 
       const tagged = await buildNpcPortraitProviderPrompt({
         ...request,
@@ -3653,6 +3655,62 @@ Use HTML sparingly and diegetically. Do not replace normal prose/dialogue unless
       assert.doesNotMatch(natural.negativePrompt, /holding flowers|smiling/);
       assert.match(natural.prompt, /holding flowers/);
       assert.match(natural.prompt, /smiling/);
+
+      const inlineAvoid = compileImagePrompt({
+        kind: "selfie",
+        prompt: "A woman, avoid makeup, holding flowers, smiling",
+        styleProfiles,
+        styleProfileId: "realistic",
+      });
+
+      assert.match(inlineAvoid.negativePrompt, /\bmakeup\b/);
+      assert.doesNotMatch(inlineAvoid.negativePrompt, /holding flowers|smiling/);
+      assert.match(inlineAvoid.prompt, /holding flowers/);
+      assert.match(inlineAvoid.prompt, /smiling/);
+
+      const standaloneAvoid = compileImagePrompt({
+        kind: "portrait",
+        prompt:
+          "Avoid text, letters, captions, UI, watermarks, logos, speech bubbles, split panels, collage, contact sheet, multiple portraits, duplicated faces, and four-image grids.",
+        styleProfiles,
+        styleProfileId: "z-image-turbo",
+      });
+
+      for (const artifact of [
+        "text",
+        "letters",
+        "captions",
+        "UI",
+        "watermarks",
+        "logos",
+        "speech bubbles",
+        "split panels",
+        "collage",
+        "contact sheet",
+        "multiple portraits",
+        "duplicated faces",
+        "four-image grids",
+      ]) {
+        assert.doesNotMatch(standaloneAvoid.prompt, new RegExp(`\\b${artifact}\\b`, "i"));
+        assert.ok(
+          standaloneAvoid.diagnostics.movedNegativeFragments.some((fragment) =>
+            new RegExp(`^avoid ${artifact}$`, "i").test(fragment),
+          ),
+          `${artifact} was not routed to the negative path`,
+        );
+      }
+      assert.match(standaloneAvoid.negativePrompt, /text|UI|watermarks|logos|collage/i);
+
+      const standaloneAvoidWithFollowingSentence = compileImagePrompt({
+        kind: "portrait",
+        prompt: "Avoid text, captions, watermarks. A woman with auburn hair and green eyes.",
+        styleProfiles,
+        styleProfileId: "z-image-turbo",
+      });
+
+      assert.match(standaloneAvoidWithFollowingSentence.negativePrompt, /text|captions|watermarks/i);
+      assert.match(standaloneAvoidWithFollowingSentence.prompt, /auburn hair|green eyes/i);
+      assert.doesNotMatch(standaloneAvoidWithFollowingSentence.prompt, /avoid text|captions|watermarks/i);
 
       const groupedNatural = compileImagePrompt({
         kind: "selfie",

--- a/scripts/regressions/prompt.regression.ts
+++ b/scripts/regressions/prompt.regression.ts
@@ -3656,62 +3656,6 @@ Use HTML sparingly and diegetically. Do not replace normal prose/dialogue unless
       assert.match(natural.prompt, /holding flowers/);
       assert.match(natural.prompt, /smiling/);
 
-      const inlineAvoid = compileImagePrompt({
-        kind: "selfie",
-        prompt: "A woman, avoid makeup, holding flowers, smiling",
-        styleProfiles,
-        styleProfileId: "realistic",
-      });
-
-      assert.match(inlineAvoid.negativePrompt, /\bmakeup\b/);
-      assert.doesNotMatch(inlineAvoid.negativePrompt, /holding flowers|smiling/);
-      assert.match(inlineAvoid.prompt, /holding flowers/);
-      assert.match(inlineAvoid.prompt, /smiling/);
-
-      const standaloneAvoid = compileImagePrompt({
-        kind: "portrait",
-        prompt:
-          "Avoid text, letters, captions, UI, watermarks, logos, speech bubbles, split panels, collage, contact sheet, multiple portraits, duplicated faces, and four-image grids.",
-        styleProfiles,
-        styleProfileId: "z-image-turbo",
-      });
-
-      for (const artifact of [
-        "text",
-        "letters",
-        "captions",
-        "UI",
-        "watermarks",
-        "logos",
-        "speech bubbles",
-        "split panels",
-        "collage",
-        "contact sheet",
-        "multiple portraits",
-        "duplicated faces",
-        "four-image grids",
-      ]) {
-        assert.doesNotMatch(standaloneAvoid.prompt, new RegExp(`\\b${artifact}\\b`, "i"));
-        assert.ok(
-          standaloneAvoid.diagnostics.movedNegativeFragments.some((fragment) =>
-            new RegExp(`^avoid ${artifact}$`, "i").test(fragment),
-          ),
-          `${artifact} was not routed to the negative path`,
-        );
-      }
-      assert.match(standaloneAvoid.negativePrompt, /text|UI|watermarks|logos|collage/i);
-
-      const standaloneAvoidWithFollowingSentence = compileImagePrompt({
-        kind: "portrait",
-        prompt: "Avoid text, captions, watermarks. A woman with auburn hair and green eyes.",
-        styleProfiles,
-        styleProfileId: "z-image-turbo",
-      });
-
-      assert.match(standaloneAvoidWithFollowingSentence.negativePrompt, /text|captions|watermarks/i);
-      assert.match(standaloneAvoidWithFollowingSentence.prompt, /auburn hair|green eyes/i);
-      assert.doesNotMatch(standaloneAvoidWithFollowingSentence.prompt, /avoid text|captions|watermarks/i);
-
       const groupedNatural = compileImagePrompt({
         kind: "selfie",
         prompt: 'A cafe sign says "no shoes, no service", no (bad hands, extra fingers:1.2), holding flowers',

--- a/scripts/regressions/prompt.regression.ts
+++ b/scripts/regressions/prompt.regression.ts
@@ -3668,6 +3668,20 @@ Use HTML sparingly and diegetically. Do not replace normal prose/dialogue unless
       assert.match(inlineAvoid.prompt, /holding flowers/);
       assert.match(inlineAvoid.prompt, /smiling/);
 
+      for (const instruction of ["exclude makeup", "do not include makeup", "don't include makeup"]) {
+        const inlineNegativeInstruction = compileImagePrompt({
+          kind: "selfie",
+          prompt: `A woman, ${instruction}, holding flowers, smiling`,
+          styleProfiles,
+          styleProfileId: "realistic",
+        });
+
+        assert.match(inlineNegativeInstruction.negativePrompt, /\bmakeup\b/);
+        assert.doesNotMatch(inlineNegativeInstruction.negativePrompt, /holding flowers|smiling/);
+        assert.match(inlineNegativeInstruction.prompt, /holding flowers/);
+        assert.match(inlineNegativeInstruction.prompt, /smiling/);
+      }
+
       const standaloneAvoid = compileImagePrompt({
         kind: "portrait",
         prompt:


### PR DESCRIPTION
## Linked issue

Closes #3867

## Why this change

Z-Image Turbo NPC portrait prompts leaked artifact-avoidance terms into the positive prompt because the deterministic template placed the avoid-list in the positive source text. Natural-language scope heuristics cannot safely distinguish every standalone list from affirmative or inline clauses.

## What changed

- Removed the generated NPC avoid sentence from the positive prompt template.
- Kept the existing `GAME_PORTRAIT_NEGATIVE_PROMPT` as the single provider-visible artifact exclusion channel.
- Removed the broad heuristic parser change so inline negation behavior from issue #3054 remains unchanged.
- Retained regression coverage for the final NPC positive and negative provider prompts.

## Validation

Commands run locally:

- `pnpm regression:prompt`
- `pnpm check` (running after this commit)

Manual browser verification was not performed because this is a shared/server prompt compiler change.

- [ ] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed `CONTRIBUTING.md`

### Manual verification notes

-

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Version/release files updated (only if this PR includes a version bump)

## UI evidence (if applicable)

Not applicable.