### PR TITLE
Remove hidden chat ceilings and clarify prompt blocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 
 ### Added
 
+- Added explicit numeric overrides for Conversation chat check-in ceilings and removed the 50-message ceiling from Conversation and Roleplay recent-summary tails, while retaining conservative defaults and cost guidance (#3864).
 - Added **Noodle** to Lorebook entry Generation filters so entries can target Noodle context without being injected into other generation paths (#3842).
 - Added per-character **Hide From AI** controls to Roleplay group chats, with avatar-based multi-selection, recipient markers, and character-scoped prompt history while preserving the existing global hide option.
 - Added `||` (OR), `&&` (AND), parentheses, and equality-list shorthand to conditional prompt macros, with matching in-app and documentation examples.
@@ -16,6 +17,7 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 
 ### Fixed
 
+- Clarified in Peek Prompt when provider formatting has combined several chat turns into one request block, preventing a merged block from looking like missing Hide From AI context.
 - Returned parsed chat metadata and character IDs from public chat reads so fresh sidebar tag filters match the shared API contract (#3857).
 - Deep-merged partial nested Character PATCH fields without materializing destructive defaults, preserving omitted extensions and embedded-lorebook data (#3858).
 - Validated and normalized native Marinara character cards before persistence while preserving unknown embedded-lorebook properties (#3859).

--- a/docs/agents/memory.md
+++ b/docs/agents/memory.md
@@ -116,7 +116,7 @@ The **Maximum output size** field sets how long a generated summary can be. The 
 The **Display** controls in the popover decide how summarized messages appear on screen:
 
 - **Hide summarised messages**: hides the raw messages once a summary covers them. Off by default.
-- **Recent message tail**: keeps this many of the newest messages fully visible even when hiding is on. The default is 10, and the range is 0 to 50. Setting 0 hides the whole summarized batch.
+- **Recent message tail**: keeps this many of the newest messages fully visible even when hiding is on. The default is 10, and any non-negative whole number is accepted. Setting 0 hides the whole summarized batch. Higher values increase prompt size and model cost.
 - **Collapse hidden messages**: controls how hidden messages look in the transcript.
 
 If your chat requires agent write approval (a separate Agents setting), AI-generated summaries wait for your review before they take effect.
@@ -140,7 +140,7 @@ The modal lists week entries first, then any days not yet folded into a week. Ex
 Two settings in the **Automatic Summarization** section shape how days are split:
 
 - **Day Rollover Hour**: the hour when a new day begins for summaries. The default is 4 AM, and you can pick any hour from 12 AM (midnight) through 11 AM. Messages sent before this hour count as part of the previous day. Pick a time when you are never chatting so a late-night session is not cut in half.
-- **Recent Message Tail**: how many of today's newest messages stay word-for-word even after they are summarized. The default is 10, and the range is 0 to 50.
+- **Recent Message Tail**: how many of today's newest messages stay word-for-word even after they are summarized. The default is 10, and any non-negative whole number is accepted. Higher values increase prompt size and model cost.
 
 If you change **Day Rollover Hour** after summaries already exist, Marinara warns you that older summaries used the previous setting.
 

--- a/docs/chats/peek-prompt.md
+++ b/docs/chats/peek-prompt.md
@@ -17,7 +17,7 @@ A source badge sits at the top next to the title. It tells you which version of 
 
 Below the badge is a generation info panel. It can show the provider and model name, an estimated token count, and the real prompt token count once a reply has finished. A token is a small chunk of text that models count instead of words. This panel also shows small tags for the values used, such as **Temperature**, **Max Output Tokens**, **Thinking**, **Reasoning**, **Verbosity**, **Service Tier**, and **Assistant Prefill**. Sampling values like **Top P**, **Top K**, and **Min P** can also appear here.
 
-The rest of the window is the prompt itself, split into collapsible sections. Each section has a label and its own rough token estimate. The chat messages are grouped under one **Chat History** section that you can expand to read each message. Click any section header to open or close it.
+The rest of the window is the prompt itself, split into collapsible sections. Each section has a label and its own rough token estimate. The chat messages are grouped under one **Chat History** section. For an exact saved request, the provider may have combined several chat turns into one provider block. Expand each block to inspect all model-visible text inside it. Click any section header to open or close it.
 
 ## Opening Peek Prompt
 

--- a/docs/conversation/schedules.md
+++ b/docs/conversation/schedules.md
@@ -26,10 +26,10 @@ In the new-chat setup wizard, **Autonomous Messages** is on by default. You can 
 
 ### Chat Check-In Cap
 
-Below the toggle, the **Chat Check-In Cap** dropdown limits how many times per day characters may reach out in this chat.
+Below the toggle, **Chat Check-In Cap** limits how many times per day characters may reach out in this chat.
 
 - The default option is **Default chat ceiling (talkativeness-based)**. The limit comes from each character's talkativeness.
-- You can instead pick a fixed number from **1 check-in / day** up to **8 check-ins / day**.
+- Choose **Numeric value** to show a number field and enter any positive whole-number ceiling. Higher ceilings can create many model requests and notifications.
 
 This cap is a ceiling for the whole chat. A character's own limit, set in its schedule, can only lower this number, never raise it.
 

--- a/packages/client/src/components/chat/ChatSettingsDrawer.tsx
+++ b/packages/client/src/components/chat/ChatSettingsDrawer.tsx
@@ -5416,7 +5416,7 @@ export function ChatSettingsDrawer({
                               onCommit={(value) =>
                                 updateMeta.mutate({
                                   id: chat.id,
-                                  autonomousDailyCapOverride: Math.max(1, Math.floor(value)),
+                                  autonomousDailyCapOverride: value,
                                 })
                               }
                               ariaLabel="Numeric chat check-in ceiling"
@@ -8659,7 +8659,7 @@ export function ChatSettingsDrawer({
                     onCommit={(value) =>
                       updateMeta.mutate({
                         id: chat.id,
-                        summaryTailMessages: Math.max(SUMMARY_TAIL_MESSAGES.MIN, Math.floor(value)),
+                        summaryTailMessages: value,
                       })
                     }
                     ariaLabel="Recent message tail"

--- a/packages/client/src/components/chat/ChatSettingsDrawer.tsx
+++ b/packages/client/src/components/chat/ChatSettingsDrawer.tsx
@@ -204,6 +204,7 @@ import {
   LIMITS,
   MIN_AGENT_MAX_TOKENS,
   PROFESSOR_MARI_ID,
+  SUMMARY_TAIL_MESSAGES,
   estimateAgentLoadCost,
   getAgentPromptTemplateOptions,
   includesTextForMatch,
@@ -303,8 +304,6 @@ function normalizeCustomMusicFolder(value: unknown): string {
   if (!normalized || normalized.includes("..")) return "music";
   return normalized.startsWith("music") ? normalized : `music/${normalized}`;
 }
-
-const AUTONOMOUS_DAILY_CAP_OPTIONS = [1, 2, 3, 4, 5, 6, 7, 8] as const;
 
 const DEFAULT_PROSE_GUARDIAN_BANNED_WORDS = "ozone";
 const DEFAULT_PROSE_GUARDIAN_AVOID =
@@ -5389,31 +5388,47 @@ export function ChatSettingsDrawer({
 
                   {metadata.autonomousMessages && (
                     <div className="border-t border-[var(--border)]/50 px-3 pb-2.5 pt-2">
-                      <label className="space-y-1.5">
+                      <div className="space-y-1.5">
                         <span className="block text-[0.625rem] font-medium text-[var(--muted-foreground)]">
                           Chat Check-In Cap
                         </span>
                         <select
-                          value={autonomousDailyCapOverride ?? ""}
+                          aria-label="Chat check-in cap mode"
+                          value={autonomousDailyCapOverride === null ? "default" : "numeric"}
                           onChange={(e) =>
                             updateMeta.mutate({
                               id: chat.id,
-                              autonomousDailyCapOverride: e.target.value ? Number(e.target.value) : null,
+                              autonomousDailyCapOverride:
+                                e.target.value === "numeric" ? (autonomousDailyCapOverride ?? 8) : null,
                             })
                           }
                           className="w-full rounded-lg bg-[var(--secondary)] px-3 py-2 text-xs outline-none ring-1 ring-transparent transition-shadow focus:ring-[var(--primary)]/40"
                         >
-                          <option value="">Default chat ceiling (talkativeness-based)</option>
-                          {AUTONOMOUS_DAILY_CAP_OPTIONS.map((cap) => (
-                            <option key={cap} value={cap}>
-                              {cap} check-in{cap === 1 ? "" : "s"} / day
-                            </option>
-                          ))}
+                          <option value="default">Default chat ceiling (talkativeness-based)</option>
+                          <option value="numeric">Numeric value</option>
                         </select>
+                        {autonomousDailyCapOverride !== null && (
+                          <label className="flex items-center justify-between gap-3 rounded-md bg-[var(--background)]/35 px-2.5 py-2">
+                            <span className="text-[0.625rem] text-[var(--muted-foreground)]">Check-ins per day</span>
+                            <DraftNumberInput
+                              value={autonomousDailyCapOverride}
+                              min={1}
+                              onCommit={(value) =>
+                                updateMeta.mutate({
+                                  id: chat.id,
+                                  autonomousDailyCapOverride: Math.max(1, Math.floor(value)),
+                                })
+                              }
+                              ariaLabel="Numeric chat check-in ceiling"
+                              className="w-24 rounded-md bg-[var(--secondary)] px-2 py-1.5 text-right text-xs outline-none ring-1 ring-transparent transition-shadow focus:ring-[var(--primary)]/40"
+                            />
+                          </label>
+                        )}
                         <p className="text-[0.55rem] text-[var(--muted-foreground)]">
-                          Sets the chat-wide ceiling; character caps can only lower it.
+                          Sets the chat-wide ceiling; character caps can only lower it. Higher ceilings may create many
+                          model requests and notifications.
                         </p>
-                      </label>
+                      </div>
                     </div>
                   )}
                 </div>
@@ -8638,23 +8653,23 @@ export function ChatSettingsDrawer({
                 {/* Recent message tail */}
                 <div className="space-y-1.5">
                   <span className="text-xs font-medium">Recent Message Tail</span>
-                  <input
-                    type="number"
-                    min={0}
-                    max={50}
-                    step={1}
-                    value={(metadata.summaryTailMessages as number | undefined) ?? 10}
-                    onChange={(e) => {
-                      const raw = Number(e.target.value);
-                      const clamped = Number.isFinite(raw) ? Math.max(0, Math.min(50, Math.floor(raw))) : 10;
-                      updateMeta.mutate({ id: chat.id, summaryTailMessages: clamped });
-                    }}
+                  <DraftNumberInput
+                    value={(metadata.summaryTailMessages as number | undefined) ?? SUMMARY_TAIL_MESSAGES.DEFAULT}
+                    min={SUMMARY_TAIL_MESSAGES.MIN}
+                    onCommit={(value) =>
+                      updateMeta.mutate({
+                        id: chat.id,
+                        summaryTailMessages: Math.max(SUMMARY_TAIL_MESSAGES.MIN, Math.floor(value)),
+                      })
+                    }
+                    ariaLabel="Recent message tail"
                     className="w-full rounded-lg bg-[var(--secondary)] px-3 py-2 text-xs outline-none ring-1 ring-transparent transition-shadow focus:ring-[var(--primary)]/40"
                   />
                   <p className="text-[0.625rem] text-[var(--muted-foreground)]">
                     How many recent messages to keep word-for-word, even once they&apos;re summarized. Helps characters
                     pick up the actual flow of last night&apos;s conversation instead of just the gist. Set to{" "}
-                    <span className="font-medium">0</span> to disable.
+                    <span className="font-medium">0</span> to disable. Higher values increase prompt size and model
+                    cost.
                   </p>
                 </div>
               </div>

--- a/packages/client/src/components/chat/PeekPromptModal.tsx
+++ b/packages/client/src/components/chat/PeekPromptModal.tsx
@@ -432,8 +432,7 @@ function ChatHistorySection({
           Chat History
         </span>
         <span className="text-[0.625rem] text-[var(--muted-foreground)]">
-          {entries.length} {providerBlocks ? "provider block" : "message"}
-          {entries.length !== 1 ? "s" : ""}
+          {`${entries.length} ${providerBlocks ? "provider block" : "message"}${entries.length !== 1 ? "s" : ""}`}
         </span>
         <span className="ml-auto text-[0.625rem] text-[var(--muted-foreground)]">
           ~{fmtTokens(tokens)} token{tokens !== 1 ? "s" : ""}
@@ -610,8 +609,8 @@ export function PeekPromptModal({ data, onClose }: PeekPromptModalProps) {
             </div>
           )}
           {data.exact && (
-            <div className="flex items-start gap-2 rounded-lg border border-[var(--border)] bg-[var(--secondary)]/25 px-3 py-2 text-[0.6875rem] leading-snug text-[var(--muted-foreground)]">
-              <Info size="0.75rem" className="mt-0.5 shrink-0 text-[var(--primary)]" />
+            <div className="flex items-start gap-2 rounded-lg border border-(--border) bg-(--secondary)/25 px-3 py-2 text-[0.6875rem] leading-snug text-(--muted-foreground)">
+              <Info size="0.75rem" className="mt-0.5 shrink-0 text-(--primary)" />
               <span>
                 Providers may combine several chat turns into one request block. Expand Chat History to inspect all
                 model-visible text inside each block.

--- a/packages/client/src/components/chat/PeekPromptModal.tsx
+++ b/packages/client/src/components/chat/PeekPromptModal.tsx
@@ -2,7 +2,7 @@
 // Peek Prompt Modal — collapsible section viewer
 // ──────────────────────────────────────────────
 import { useState, useMemo } from "react";
-import { X, ChevronRight, ChevronDown } from "lucide-react";
+import { X, ChevronRight, ChevronDown, Info } from "lucide-react";
 import { cn } from "../../lib/utils";
 import {
   NEUTRAL_PANEL_HEADER,
@@ -395,7 +395,15 @@ function CollapsibleBlock({
   );
 }
 
-function ChatHistorySection({ entries, rawContent }: { entries: ChatHistoryEntry[]; rawContent: string }) {
+function ChatHistorySection({
+  entries,
+  rawContent,
+  providerBlocks = false,
+}: {
+  entries: ChatHistoryEntry[];
+  rawContent: string;
+  providerBlocks?: boolean;
+}) {
   const [open, setOpen] = useState(false);
   const tokens = estimateTokens(rawContent);
 
@@ -424,7 +432,8 @@ function ChatHistorySection({ entries, rawContent }: { entries: ChatHistoryEntry
           Chat History
         </span>
         <span className="text-[0.625rem] text-[var(--muted-foreground)]">
-          {entries.length} message{entries.length !== 1 ? "s" : ""}
+          {entries.length} {providerBlocks ? "provider block" : "message"}
+          {entries.length !== 1 ? "s" : ""}
         </span>
         <span className="ml-auto text-[0.625rem] text-[var(--muted-foreground)]">
           ~{fmtTokens(tokens)} token{tokens !== 1 ? "s" : ""}
@@ -600,9 +609,18 @@ export function PeekPromptModal({ data, onClose }: PeekPromptModalProps) {
               Note: {data.agentNote}
             </div>
           )}
+          {data.exact && (
+            <div className="flex items-start gap-2 rounded-lg border border-[var(--border)] bg-[var(--secondary)]/25 px-3 py-2 text-[0.6875rem] leading-snug text-[var(--muted-foreground)]">
+              <Info size="0.75rem" className="mt-0.5 shrink-0 text-[var(--primary)]" />
+              <span>
+                Providers may combine several chat turns into one request block. Expand Chat History to inspect all
+                model-visible text inside each block.
+              </span>
+            </div>
+          )}
           {sections.map((s, i) =>
             s.kind === "chat-history" ? (
-              <ChatHistorySection key={i} entries={s.entries} rawContent={s.rawContent} />
+              <ChatHistorySection key={i} entries={s.entries} rawContent={s.rawContent} providerBlocks={data.exact} />
             ) : (
               <CollapsibleBlock
                 key={i}

--- a/packages/client/src/components/chat/SummaryPopover.tsx
+++ b/packages/client/src/components/chat/SummaryPopover.tsx
@@ -64,6 +64,7 @@ import {
   type ChatSummaryPromptTemplate,
 } from "@marinara-engine/shared";
 import { showConfirmDialog } from "../../lib/app-dialogs";
+import { DraftNumberInput } from "../ui/DraftNumberInput";
 
 interface SummaryPopoverProps {
   chatId: string;
@@ -1018,25 +1019,23 @@ export function SummaryPopover({
                   <div className="space-y-1 px-1 pb-0.5">
                     <label className="flex items-center justify-between gap-2 text-[0.6875rem] font-medium text-[var(--popover-foreground)]">
                       <span>Recent message tail</span>
-                      <input
-                        type="number"
+                      <DraftNumberInput
+                        ariaLabel="Recent message tail"
                         min={SUMMARY_TAIL_MESSAGES.MIN}
-                        max={SUMMARY_TAIL_MESSAGES.MAX}
-                        step={1}
                         value={summaryTailMessages ?? SUMMARY_TAIL_MESSAGES.DEFAULT}
-                        onChange={(event) => {
-                          const raw = Number(event.target.value);
-                          const clamped = Number.isFinite(raw)
-                            ? Math.max(SUMMARY_TAIL_MESSAGES.MIN, Math.min(SUMMARY_TAIL_MESSAGES.MAX, Math.floor(raw)))
-                            : SUMMARY_TAIL_MESSAGES.DEFAULT;
-                          updateMeta.mutate({ id: chatId, summaryTailMessages: clamped });
-                        }}
+                        onCommit={(value) =>
+                          updateMeta.mutate({
+                            id: chatId,
+                            summaryTailMessages: Math.max(SUMMARY_TAIL_MESSAGES.MIN, Math.floor(value)),
+                          })
+                        }
                         className="w-16 rounded-md bg-[var(--secondary)] px-2 py-1 text-right text-xs outline-none ring-1 ring-transparent transition-shadow focus:ring-[var(--primary)]/40"
                       />
                     </label>
                     <p className="text-[0.625rem] text-[var(--muted-foreground)]">
                       Most recent messages kept word-for-word when auto-hiding summarised ones. Set to{" "}
-                      <span className="font-medium">0</span> to hide the whole batch.
+                      <span className="font-medium">0</span> to hide the whole batch. Higher values increase prompt size
+                      and model cost.
                     </p>
                   </div>
                 )}

--- a/packages/client/src/components/chat/SummaryPopover.tsx
+++ b/packages/client/src/components/chat/SummaryPopover.tsx
@@ -1026,7 +1026,7 @@ export function SummaryPopover({
                         onCommit={(value) =>
                           updateMeta.mutate({
                             id: chatId,
-                            summaryTailMessages: Math.max(SUMMARY_TAIL_MESSAGES.MIN, Math.floor(value)),
+                            summaryTailMessages: value,
                           })
                         }
                         className="w-16 rounded-md bg-[var(--secondary)] px-2 py-1 text-right text-xs outline-none ring-1 ring-transparent transition-shadow focus:ring-[var(--primary)]/40"

--- a/packages/server/src/routes/generate/conversation-history-runtime.ts
+++ b/packages/server/src/routes/generate/conversation-history-runtime.ts
@@ -1,5 +1,9 @@
 import type { WrapFormat } from "@marinara-engine/shared";
-import { normalizeTextForMatch, stripLeadingMessageTimestamps } from "@marinara-engine/shared";
+import {
+  normalizeSummaryTailMessages,
+  normalizeTextForMatch,
+  stripLeadingMessageTimestamps,
+} from "@marinara-engine/shared";
 
 import { logger } from "../../lib/logger.js";
 import {
@@ -249,10 +253,7 @@ export async function prepareConversationPromptHistory(args: {
     fmtDateKey,
   });
 
-  const tailCount = Math.max(
-    0,
-    Math.min(50, Math.floor((args.chatMeta.summaryTailMessages as number | undefined) ?? 10)),
-  );
+  const tailCount = normalizeSummaryTailMessages(args.chatMeta.summaryTailMessages);
   const tailEntries = collectConversationSummaryTail({
     buckets,
     tailCount,

--- a/packages/server/src/routes/generate/generate-route-utils.ts
+++ b/packages/server/src/routes/generate/generate-route-utils.ts
@@ -5,6 +5,7 @@ import {
   applyTrackerFieldLocksToGameStatePatch,
   generationParametersSchema,
   normalizeTextForMatch,
+  normalizeSummaryTailMessages,
   normalizeWorldCustomFields,
   normalizeThinkingTagPairs,
   parseTrackerFieldLocks,
@@ -535,14 +536,10 @@ export function isRoleplaySummaryMode(chatMode: string): boolean {
  * `DEFAULT` only when the value is genuinely unset; an explicit `MIN` (0) means
  * "hide the whole batch". A present-but-invalid value (NaN, negative) fails
  * closed to `MIN` so corrupt metadata hides more rather than silently leaking
- * extra context. Clamped to [MIN, MAX].
+ * extra context. There is intentionally no upper cap.
  */
 export function resolveRoleplaySummaryTail(value: unknown): number {
-  const { MIN, MAX, DEFAULT } = SUMMARY_TAIL_MESSAGES;
-  if (value === undefined || value === null) return DEFAULT;
-  const n = Math.floor(Number(value));
-  if (!Number.isFinite(n) || n < MIN) return MIN;
-  return Math.min(MAX, n);
+  return normalizeSummaryTailMessages(value);
 }
 
 /**
@@ -558,8 +555,8 @@ export function computeSummaryHideIds(args: {
 }): string[] {
   const { messages, entryMessageIds, tail } = args;
   if (entryMessageIds.length === 0) return [];
-  const { MIN, MAX } = SUMMARY_TAIL_MESSAGES;
-  const clampedTail = Number.isFinite(tail) ? Math.max(MIN, Math.min(MAX, Math.floor(tail))) : MIN;
+  const { MIN } = SUMMARY_TAIL_MESSAGES;
+  const clampedTail = Number.isFinite(tail) ? Math.max(MIN, Math.floor(tail)) : MIN;
   const visible = messages.filter((message) => !isMessageHiddenFromAI(message));
   const tailIdSet = new Set(clampedTail > 0 ? visible.slice(-clampedTail).map((message) => message.id) : []);
   const entryIdSet = new Set(entryMessageIds);

--- a/packages/server/src/services/conversation/autonomous.service.ts
+++ b/packages/server/src/services/conversation/autonomous.service.ts
@@ -103,14 +103,15 @@ export function getAutonomousDailyBudget(
   return budget?.date === today ? budget : { date: today, counts: {} };
 }
 
-function readAutonomousDailyCapOverride(value: unknown): number | null {
+function readAutonomousDailyCapOverride(value: unknown, maximum?: number): number | null {
   if (typeof value !== "number" || !Number.isFinite(value)) return null;
-  return Math.max(1, Math.min(8, Math.floor(value)));
+  const normalized = Math.max(1, Math.floor(value));
+  return maximum === undefined ? normalized : Math.min(maximum, normalized);
 }
 
 export function dailyCapForCharacter(schedule: WeekSchedule | undefined, chatMeta?: Record<string, unknown>): number {
   const chatCap = chatMeta ? readAutonomousDailyCapOverride(chatMeta.autonomousDailyCapOverride) : null;
-  const characterCap = readAutonomousDailyCapOverride(schedule?.autonomousDailyCapOverride);
+  const characterCap = readAutonomousDailyCapOverride(schedule?.autonomousDailyCapOverride, 8);
   if (chatCap != null && characterCap != null) return Math.min(chatCap, characterCap);
   if (characterCap != null) return characterCap;
   if (chatCap != null) return chatCap;

--- a/packages/shared/src/types/chat.ts
+++ b/packages/shared/src/types/chat.ts
@@ -209,12 +209,20 @@ export interface ChatMemoryChunk {
 }
 
 /**
- * Bounds for `ChatMetadata.summaryTailMessages` — the single source of truth for
- * the tail limits, shared by the server resolver (read) and the popover slider
- * (write) so display and persistence can't drift. `DEFAULT` applies only when the
- * value is unset; an explicit `MIN` (0) means "hide the whole batch".
+ * Defaults for `ChatMetadata.summaryTailMessages`. `DEFAULT` applies only when
+ * the value is unset; an explicit `MIN` (0) means "hide the whole batch".
+ * There is intentionally no upper limit because the user controls the context
+ * and model budget for this local app.
  */
-export const SUMMARY_TAIL_MESSAGES = { MIN: 0, MAX: 50, DEFAULT: 10 } as const;
+export const SUMMARY_TAIL_MESSAGES = { MIN: 0, DEFAULT: 10 } as const;
+
+export function normalizeSummaryTailMessages(value: unknown): number {
+  const { MIN, DEFAULT } = SUMMARY_TAIL_MESSAGES;
+  if (value === undefined || value === null) return DEFAULT;
+  const parsed = Math.floor(Number(value));
+  if (!Number.isFinite(parsed) || parsed < MIN) return MIN;
+  return parsed;
+}
 export const CHAT_SUMMARY_OUTPUT_TOKENS = { MIN: 1, MAX: 32768, DEFAULT: 4096 } as const;
 
 export type GameStoryboardViewerDisplayMode = "floating" | "background";
@@ -614,7 +622,7 @@ export interface ChatMetadata {
    * gist. In roleplay/visual-novel mode it is the protected tail for
    * `hideSummarisedMessages`: the last N messages stay visible (never hidden)
    * when the auto-summary hides the rest. 0 disables (hide the whole batch).
-   * Valid range: 0-50. Default: 10.
+   * Any non-negative whole number is accepted. Default: 10.
    */
   summaryTailMessages?: number;
   /** When true or omitted, prior provider reasoning metadata is not replayed into future prompts. */

--- a/scripts/regressions/open-issues.regression.ts
+++ b/scripts/regressions/open-issues.regression.ts
@@ -155,6 +155,7 @@ import {
 import {
   checkAutonomousMessaging,
   clearChatActivity,
+  dailyCapForCharacter,
   initializeActivityFromMessages,
   isAutonomousDailyBudgetExhausted,
 } from "../../packages/server/src/services/conversation/autonomous.service.js";
@@ -796,6 +797,16 @@ const autonomousSchedule = (talkativeness: number, cap: number): WeekSchedule =>
   autonomousDailyCapOverride: cap,
   talkativeness,
 });
+assert.equal(
+  dailyCapForCharacter(undefined, { autonomousDailyCapOverride: 75 }),
+  75,
+  "chat-level autonomous ceilings should accept numeric overrides above the former limit",
+);
+assert.equal(
+  dailyCapForCharacter(autonomousSchedule(90, 8), { autonomousDailyCapOverride: 75 }),
+  8,
+  "per-character safety limits should still be able to lower a numeric chat ceiling",
+);
 const autonomousChatId = "regression-autonomous-candidates";
 initializeActivityFromMessages(autonomousChatId, [
   { role: "user", createdAt: new Date(Date.now() - 5 * 60_000).toISOString() },

--- a/scripts/regressions/prompt.regression.ts
+++ b/scripts/regressions/prompt.regression.ts
@@ -386,6 +386,36 @@ assert.deepEqual(
   ["pantalone", "dottore"],
   "squashed system runs should retain their character audience",
 );
+const maukieRestrictedRun: ChatMLMessage[] = [
+  { role: "user", content: "Visible before private run", contextKind: "history" },
+  ...Array.from({ length: 16 }, (_, index) => ({
+    role: index % 2 === 0 ? ("user" as const) : ("assistant" as const),
+    content: `Private run message ${index + 1}`,
+    contextKind: "history" as const,
+    hiddenFromAICharacterIds: ["maukie"],
+  })),
+  { role: "user", content: "Visible after private run", contextKind: "history" },
+];
+assert.deepEqual(
+  filterPromptMessagesForCharacterAudience(maukieRestrictedRun, ["powers-that-be"]).map((message) => message.content),
+  maukieRestrictedRun.map((message) => message.content),
+  "every message in a character-scoped run should remain visible to other responding characters",
+);
+assert.deepEqual(
+  filterPromptMessagesForCharacterAudience(maukieRestrictedRun, ["maukie"]).map((message) => message.content),
+  ["Visible before private run", "Visible after private run"],
+  "every message in a character-scoped run should be removed for the restricted character",
+);
+assert.equal(resolveRoleplaySummaryTail(75), 75, "summary tails should not retain the former 50-message ceiling");
+assert.deepEqual(
+  computeSummaryHideIds({
+    messages: Array.from({ length: 75 }, (_, index) => ({ id: `tail-${index}` })),
+    entryMessageIds: Array.from({ length: 75 }, (_, index) => `tail-${index}`),
+    tail: 75,
+  }),
+  [],
+  "an uncapped roleplay summary tail should protect every requested recent message",
+);
 import {
   compactVideoPromptText,
   getSceneVideoPromptLimits,
@@ -462,11 +492,13 @@ import {
   buildGenerationGuideInstruction,
   appendSeparateAgentInjectionMessage,
   collectLatestTrackerCharacterHistory,
+  computeSummaryHideIds,
   getMessageHiddenFromAICharacterIds,
   injectIntoOutputFormatOrLastUser,
   isMessageHiddenFromAIForCharacter,
   preserveTrackerCharacterUiFields,
   resolveActivePersonaCandidate,
+  resolveRoleplaySummaryTail,
   shouldEnableAgentsForGeneration,
   shouldInjectIdentityFallback,
   stripSpeakerTagsExceptLastAssistant,
@@ -4863,6 +4895,68 @@ Use HTML sparingly and diegetically. Do not replace normal prose/dialogue unless
       assert.match(promptText, new RegExp(authoredSystemInstruction, "u"));
       assert.equal(promptText.includes(legacySetupMembership), false, promptText);
       assert.match(promptText, new RegExp(currentMembership, "u"));
+    },
+  },
+  {
+    name: "Conversation recent-message tails accept values above the former ceiling",
+    async run() {
+      const olderMessages = Array.from({ length: 55 }, (_, index) => ({
+        id: `uncapped-tail-${index}`,
+        role: "user" as const,
+        content: `UNCAPPED_TAIL_MESSAGE_${index}`,
+        createdAt: new Date(Date.UTC(2026, 6, 14, 10, index)).toISOString(),
+      }));
+      const currentMessage = {
+        id: "uncapped-tail-current",
+        role: "user" as const,
+        content: "CURRENT_CONVERSATION_MESSAGE",
+        createdAt: "2026-07-15T12:00:00.000Z",
+      };
+      const chatMessages = [...olderMessages, currentMessage];
+      const prepared = await prepareConversationPromptHistory({
+        finalMessages: chatMessages.map((message) => ({
+          id: message.id,
+          role: message.role,
+          content: message.content,
+          contextKind: "history" as const,
+        })),
+        chatMessages,
+        scopedMessages: chatMessages,
+        chatMeta: {
+          summaryTailMessages: olderMessages.length,
+          daySummaries: {
+            "14.07.2026": { summary: "Compact prior-day summary.", keyDetails: [] },
+          },
+          weekSummaries: {},
+        },
+        chatId: "conversation-uncapped-tail-regression",
+        chats: {
+          async patchMetadata() {
+            throw new Error("An existing prior-day summary should not require a metadata patch");
+          },
+        },
+        chars: {
+          async getById() {
+            return null;
+          },
+        },
+        characterIds: ["char-echo"],
+        allCharacterIds: ["char-echo"],
+        convoCharInfo: [{ name: "Echo" }],
+        convoCharNames: ["Echo"],
+        personaName: "User",
+        nowInstant: new Date("2026-07-15T18:00:00.000Z"),
+        promptTimeZone: "UTC",
+        wrapFormat: "xml",
+        connection: { provider: "openai", apiKey: "", model: "regression-model" },
+        connectionId: "regression-connection",
+        baseUrl: "https://example.invalid/v1",
+      });
+      const promptText = prepared.finalMessages.map((message) => message.content).join("\n");
+
+      assert.match(promptText, /UNCAPPED_TAIL_MESSAGE_0/u);
+      assert.match(promptText, /UNCAPPED_TAIL_MESSAGE_54/u);
+      assert.match(promptText, /CURRENT_CONVERSATION_MESSAGE/u);
     },
   },
   {


### PR DESCRIPTION
## Summary

- replace the fixed Conversation chat check-in choices with a Default/Numeric selector and an uncapped positive whole-number override
- remove the former 50-message ceiling from Conversation and Roleplay recent-summary tails
- clarify that exact Peek Prompt history counts provider request blocks, which may contain several chat turns
- add regressions for long per-character Hide From AI runs, uncapped summary tails, and chat-level autonomous ceilings
- update the user documentation and changelog

## Why

Issue #3864 identified hidden hard ceilings that prevented users from explicitly choosing the context and autonomous-request budgets appropriate for their chats.

The Hide From AI report also exposed a presentation problem rather than an audience-filtering failure: providers may merge many chat turns into a small number of request blocks, while Peek Prompt labeled those blocks as individual messages. In the reproduced 16-message run, every restricted message remained visible to the non-restricted character and every one was excluded for the restricted character. The revised wording makes the exact saved request easier to interpret.

Related to #3864.

## User impact

Conversation users can choose the talkativeness-based default or enter their own chat-wide check-in ceiling. Character-specific caps can still lower that ceiling. Automatic summarization accepts any non-negative whole-number recent-message tail in both Conversation and Roleplay, with prompt-size and request-cost guidance shown beside the controls.

## Validation

- `pnpm check`
- `pnpm regression:prompt`
- `pnpm regression:issues`
- `pnpm smoke:ui` (74 passed, 46 viewport-inapplicable tests skipped)
- `git diff --check`
- isolated dry-run against the reproduced chat: 16/16 restricted messages included for the other character and 16/16 excluded for the restricted character

## Manual verification

- [ ] Manually verify the Conversation Chat Check-In Cap switches between Default and Numeric modes and persists a value above 8.
- [ ] Manually verify a character-specific cap still lowers a larger chat-wide numeric ceiling.
- [ ] Manually verify Recent Message Tail accepts and persists a value above 50 in Conversation and Roleplay.
- [ ] Manually verify exact Peek Prompt labels provider blocks and exposes all model-visible text when Chat History is expanded.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added numeric controls for autonomous chat check-in limits, alongside the default behavior.
  * Expanded recent-message tail settings to accept any non-negative whole number, including values above the previous limit.
  * Added clearer guidance about prompt size and model costs for larger tails.

* **Bug Fixes**
  * Improved Peek Prompt messaging when providers combine multiple chat turns into one request block.

* **Documentation**
  * Updated chat settings and prompt inspection documentation to reflect the new controls and behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->