### PR TITLE
fix: recover Noodle profiles and align lorebook match priority

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 
 ### Fixed
 
+- Accepted the single-object array wrapper some local models return for generated Noodle profiles, preventing timeline refreshes from failing with HTTP 500 during first-time bio generation (#3871).
+- Gave current semantic lorebook matches the same context-budget priority as current keyword matches, so configured entry order—not activation method—decides which entries are attached when every match cannot fit.
 - Clarified in Peek Prompt when provider formatting has combined several chat turns into one request block, preventing a merged block from looking like missing Hide From AI context.
 - Returned parsed chat metadata and character IDs from public chat reads so fresh sidebar tag filters match the shared API contract (#3857).
 - Deep-merged partial nested Character PATCH fields without materializing destructive defaults, preserving omitted extensions and embedded-lorebook data (#3858).

--- a/docs/lorebooks/semantic-search.md
+++ b/docs/lorebooks/semantic-search.md
@@ -12,6 +12,8 @@ This works using embeddings. An embedding is a list of numbers that captures the
 
 Keyword matching still works when semantic search is on. Semantic search adds extra matches. It does not replace your keywords.
 
+Keyword and semantic matches have equal priority when Marinara applies lorebook entry and token budgets. If every matching entry cannot fit, the entry order you configured decides between current keyword and semantic matches; the activation method itself does not win.
+
 ## Before you start: pick an embedding source
 
 Semantic search needs a model that can create embeddings. You have two options.

--- a/packages/server/src/services/lorebook/index.ts
+++ b/packages/server/src/services/lorebook/index.ts
@@ -401,8 +401,8 @@ function resolveFinalLorebookContent(
 function lorebookSelectionOrder(a: ActivatedEntry, b: ActivatedEntry): number {
   if (a.entry.constant && !b.entry.constant) return -1;
   if (!a.entry.constant && b.entry.constant) return 1;
-  if (a.matchedLatestUserMessage && !b.matchedLatestUserMessage) return -1;
-  if (!a.matchedLatestUserMessage && b.matchedLatestUserMessage) return 1;
+  if (a.matchedCurrentContext && !b.matchedCurrentContext) return -1;
+  if (!a.matchedCurrentContext && b.matchedCurrentContext) return 1;
   return a.injectionOrder - b.injectionOrder;
 }
 
@@ -565,7 +565,7 @@ function mergeActivatedEntries(...groups: ActivatedEntry[][]): ActivatedEntry[] 
         ...existing.activationSources,
         ...candidate.activationSources,
       ]) as LorebookActivationSource[],
-      matchedLatestUserMessage: existing.matchedLatestUserMessage || candidate.matchedLatestUserMessage,
+      matchedCurrentContext: existing.matchedCurrentContext || candidate.matchedCurrentContext,
       sticky: existing.sticky || candidate.sticky,
     });
   }

--- a/packages/server/src/services/lorebook/keyword-scanner.ts
+++ b/packages/server/src/services/lorebook/keyword-scanner.ts
@@ -46,8 +46,8 @@ export interface ActivatedEntry {
   matchedKeys: string[];
   /** Every mechanism that activated this entry in this generation. */
   activationSources: LorebookActivationSource[];
-  /** True when a primary key matched the latest user message directly. */
-  matchedLatestUserMessage?: boolean;
+  /** True when keyword or semantic activation reflects the current user context. */
+  matchedCurrentContext?: boolean;
   /** Priority order for injection */
   injectionOrder: number;
   /** True when sticky state kept this entry active without a fresh keyword match */
@@ -569,7 +569,7 @@ export function scanForActivatedEntries(
     // Test primary keys
     const { matched, matchedKeys } = testPrimaryKeys(entry.keys, entryScanText, matchOptions);
     if (!matched) continue;
-    const matchedLatestUserMessage =
+    const matchedCurrentContext =
       latestUserText.length > 0 ? testPrimaryKeys(entry.keys, latestUserText, matchOptions).matched : false;
 
     // Test secondary keys (selective mode)
@@ -584,14 +584,14 @@ export function scanForActivatedEntries(
     activated.push({
       entry,
       matchedKeys,
-      matchedLatestUserMessage,
+      matchedCurrentContext,
       activationSources: [recursionPass ? "recursive" : "keyword"],
       injectionOrder: entry.order,
     });
     activatedIds.add(entry.id);
   }
 
-  // ── Semantic fallback: check entries with embeddings that weren't keyword-matched ──
+  // ── Semantic matching: add vector matches that weren't already activated ──
   if (
     (chatEmbedding && chatEmbedding.length > 0) ||
     Array.from(semanticEmbeddingsByLorebookId.values()).some((embedding) => embedding && embedding.length > 0)
@@ -643,6 +643,10 @@ export function scanForActivatedEntries(
       activated.push({
         entry: candidate.entry,
         matchedKeys: [`[semantic:${candidate.similarity.toFixed(3)}]`],
+        // Semantic candidates describe the same current scan context as a key
+        // matched in the latest user turn. Giving both this marker keeps the
+        // budget selector neutral between keyword and vector activation.
+        matchedCurrentContext: latestUserText.length > 0,
         injectionOrder: candidate.entry.order,
         activationSources: [recursionPass ? "recursive" : "semantic"],
       });

--- a/packages/server/src/services/noodle/noodle-generated-profiles.ts
+++ b/packages/server/src/services/noodle/noodle-generated-profiles.ts
@@ -17,12 +17,20 @@ export function parseNoodleGeneratedProfiles(value: unknown): {
   profiles: NoodleGeneratedProfile[];
   rejected: RejectedNoodleGeneratedProfile[];
 } {
-  const record = value && typeof value === "object" && !Array.isArray(value) ? value as Record<string, unknown> : null;
+  const normalizedValue =
+    Array.isArray(value) && value.length === 1 && value[0] && typeof value[0] === "object" && !Array.isArray(value[0])
+      ? value[0]
+      : value;
+  const record =
+    normalizedValue && typeof normalizedValue === "object" && !Array.isArray(normalizedValue)
+      ? (normalizedValue as Record<string, unknown>)
+      : null;
   const rawProfiles = record?.profiles;
   if (!Array.isArray(rawProfiles)) {
     // Preserve the useful top-level validation error for a wholly malformed
-    // response. Only individual profile failures are recoverable.
-    noodleGeneratedProfilesSchema.parse(value);
+    // response. Only a single object wrapper and individual profile failures
+    // are recoverable.
+    noodleGeneratedProfilesSchema.parse(normalizedValue);
     return { profiles: [], rejected: [] };
   }
 

--- a/scripts/regressions/noodle-prompt.regression.ts
+++ b/scripts/regressions/noodle-prompt.regression.ts
@@ -943,6 +943,25 @@ assert.deepEqual(
 );
 assert.deepEqual(partiallyInvalidGeneratedProfiles.rejected, [{ index: 0, issueCount: 1 }]);
 
+const singlyWrappedGeneratedProfiles = parseNoodleGeneratedProfiles([
+  {
+    profiles: [
+      {
+        entityId: "wrapped-character",
+        name: "Wrapped Character",
+        handle: "wrapped_character",
+        bio: "Recovered from a one-item array wrapper.",
+        location: "Noodle",
+      },
+    ],
+  },
+]);
+assert.deepEqual(
+  singlyWrappedGeneratedProfiles.profiles.map((profile) => profile.entityId),
+  ["wrapped-character"],
+);
+assert.throws(() => parseNoodleGeneratedProfiles([{ profiles: [] }, { profiles: [] }]));
+
 // sampleNoodlePastMemoriesWeighted should reliably favor a much higher-weighted item over
 // several trials, while still keeping baseline-weighted items reachable (not filtered out).
 let highWeightPicks = 0;

--- a/scripts/regressions/prompt.regression.ts
+++ b/scripts/regressions/prompt.regression.ts
@@ -511,6 +511,7 @@ import {
   calibrateLorebookSimilarity,
   lorebookSimilarityBaseline,
 } from "../../packages/server/src/services/lorebook/embeddings.js";
+import { resolveAndBudgetActivatedLorebookEntries } from "../../packages/server/src/services/lorebook/index.js";
 import { scanForActivatedEntries } from "../../packages/server/src/services/lorebook/keyword-scanner.js";
 import { fitMessagesForModelAccess } from "../../packages/server/src/services/generation/model-access-policy.js";
 import {
@@ -5295,7 +5296,7 @@ Use HTML sparingly and diegetically. Do not replace normal prose/dialogue unless
     },
   },
   {
-    name: "semantic lorebook scan activates vector matches even when entries have primary keys",
+    name: "semantic lorebook matches share current-context priority with keyword matches",
     run() {
       const entry = {
         id: "entry-semantic",
@@ -5388,6 +5389,45 @@ Use HTML sparingly and diegetically. Do not replace normal prose/dialogue unless
       );
       assert.equal(clusteredRelevant.length, 1);
       assert.match(clusteredRelevant[0]?.matchedKeys[0] ?? "", /^\[semantic:0\.66/u);
+
+      const mixedMatches = scanForActivatedEntries(
+        [{ role: "user", content: "exact trigger near the semantic topic" }],
+        [
+          {
+            ...entry,
+            id: "entry-keyword-current",
+            keys: ["exact trigger"],
+            embedding: [0, 1],
+            order: 20,
+            content: "keyword current context",
+          } as any,
+          {
+            ...entry,
+            id: "entry-semantic-current",
+            keys: ["keyword that is absent"],
+            embedding: [1, 0],
+            order: 10,
+            content: "semantic current context",
+          } as any,
+        ],
+        {
+          chatEmbedding: [1, 0],
+          semanticThresholdByLorebookId: new Map([["book-semantic", 0.9]]),
+        },
+      );
+      const semanticCurrent = mixedMatches.find((match) => match.entry.id === "entry-semantic-current");
+      assert.equal(semanticCurrent?.matchedCurrentContext, true);
+
+      const budgetedMixedMatches = resolveAndBudgetActivatedLorebookEntries(
+        mixedMatches,
+        new Map([["book-semantic", { name: "Semantic Book", tokenBudget: 0, entryLimit: 100 }]]),
+        6,
+        0,
+      );
+      assert.deepEqual(
+        budgetedMixedMatches.map((match) => match.entry.id),
+        ["entry-semantic-current"],
+      );
     },
   },
 ];


### PR DESCRIPTION
## Linked issue

Closes #3871

## Why this change

- Noodle timeline refreshes can fail with HTTP 500 during first-time bio generation when a local model wraps the expected profile object in a one-element array.
- Lorebook keyword matches could displace semantic matches under a tight context budget even when the semantic entry had the higher configured priority.

## What changed

- Unwrap only an unambiguous one-object array around generated Noodle profile payloads while continuing to reject multi-object arrays.
- Give semantic matches from the current scan context the same budget-selection tier as current keyword matches, leaving configured lorebook entry order to decide which entry fits.
- Add regression coverage for both fixes, document lorebook budget behavior, and update the changelog.

## Validation

Automated commands run successfully:

- `pnpm regression:noodle`
- `pnpm regression:prompt`
- `pnpm check`
- `pnpm version:check`
- `git diff --check`

- [ ] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed `CONTRIBUTING.md`

### Manual verification notes

- Manually verify a first-time Noodle refresh with the affected local Kobold setup when profile generation returns `[{ "profiles": [...] }]`.
- Manually verify a lorebook with semantic search enabled where current keyword and semantic matches compete for a budget that fits only one entry.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Version/release files updated (only if this PR includes a version bump)

## UI evidence (if applicable)

No UI changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed HTTP 500 errors during first-time Noodle profile generation for supported single-object wrapper responses.
  * Improved lorebook entry prioritization when matching entries exceed the available context budget.
  * Keyword and semantic matches now receive equal current-context priority, with configured entry order determining selection when needed.

* **Documentation**
  * Clarified lorebook activation and prioritization behavior.

* **Tests**
  * Added regression coverage for profile response parsing and mixed keyword/semantic lorebook matching.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->