### PR TITLE
fix: preserve Persona names in Name Prefix History

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 
 ### Fixed
 
+- Kept each historical user turn under the Persona that sent it when Name Prefix History is enabled, instead of relabeling every user message with the currently selected Persona.
 - Accepted the single-object array wrapper some local models return for generated Noodle profiles, preventing timeline refreshes from failing with HTTP 500 during first-time bio generation (#3871).
 - Gave current semantic lorebook matches the same context-budget priority as current keyword matches, so configured entry order—not activation method—decides which entries are attached when every match cannot fit.
 - Clarified in Peek Prompt when provider formatting has combined several chat turns into one request block, preventing a merged block from looking like missing Hide From AI context.

--- a/packages/server/src/routes/generate.routes.ts
+++ b/packages/server/src/routes/generate.routes.ts
@@ -212,6 +212,7 @@ import {
   isRoleplaySummaryMode,
   preserveTrackerCharacterUiFields,
   prefixGroupIndividualHistorySpeakers,
+  readPersonaSnapshotName,
   resolveActiveCharacterIds,
   resolveActivePersonaCandidate,
   resolveBaseUrl,
@@ -1218,6 +1219,7 @@ export async function generateRoutes(app: FastifyInstance) {
       };
       const mapChatHistoryMessageForPrompt = async (m: any): Promise<GenerationPromptMessage> => {
         const extra = parseExtra(m.extra);
+        const personaSnapshotName = m.role === "user" ? readPersonaSnapshotName(extra) : null;
         const attachments = normalizePromptAttachments(m.extra);
         const providerMetadata: Record<string, unknown> = {};
         // For Google connections, carry stored Gemini parts (thought signatures) on assistant messages
@@ -1263,6 +1265,7 @@ export async function generateRoutes(app: FastifyInstance) {
           content,
           contextKind: "history" as const,
           characterId: typeof m.characterId === "string" && m.characterId ? m.characterId : null,
+          ...(personaSnapshotName ? { personaSnapshotName } : {}),
           ...(hiddenFromAICharacterIds.length ? { hiddenFromAICharacterIds } : {}),
           ...(attachmentInputs.images.length ? { images: attachmentInputs.images } : {}),
           ...(attachmentInputs.files.length ? { files: attachmentInputs.files } : {}),

--- a/packages/server/src/routes/generate/dry-run-route.ts
+++ b/packages/server/src/routes/generate/dry-run-route.ts
@@ -71,6 +71,7 @@ import {
   parseExtra,
   parseStoredGenerationParameters,
   prefixGroupIndividualHistorySpeakers,
+  readPersonaSnapshotName,
   resolveActiveCharacterIds,
   resolveActivePersonaCandidate,
   resolvePromptCharacterIdsForTarget,
@@ -98,6 +99,7 @@ type DryRunPromptMessage = {
   files?: Array<{ type: string; data: string; filename?: string }>;
   contextKind?: "prompt" | "history" | "injection";
   characterId?: string | null;
+  personaSnapshotName?: string | null;
   providerMetadata?: Record<string, unknown>;
 };
 
@@ -672,6 +674,7 @@ export async function registerDryRunRoute(app: FastifyInstance) {
     const excludePastReasoning = chatMeta.excludePastReasoning !== false;
     let mappedMessages = chatMessages.map((m: any) => {
       const extra = parseExtra(m.extra);
+      const personaSnapshotName = m.role === "user" ? readPersonaSnapshotName(extra) : null;
       const attachments = extra.attachments as PromptAttachment[] | undefined;
       const images = extractImageAttachmentDataUrls(attachments);
       const files = extractFileAttachmentInputs(attachments);
@@ -686,6 +689,7 @@ export async function registerDryRunRoute(app: FastifyInstance) {
         content: appendReadableAttachmentsToContent((m.content as string) ?? "", attachments),
         contextKind: "history" as const,
         characterId: typeof m.characterId === "string" && m.characterId ? m.characterId : null,
+        ...(personaSnapshotName ? { personaSnapshotName } : {}),
         ...(hiddenFromAICharacterIds.length ? { hiddenFromAICharacterIds } : {}),
         ...(images?.length ? { images } : {}),
         ...(files.length ? { files } : {}),

--- a/packages/server/src/routes/generate/generate-route-utils.ts
+++ b/packages/server/src/routes/generate/generate-route-utils.ts
@@ -58,6 +58,7 @@ export type SimpleMessage = {
 export type SpeakerPrefixMessage = SimpleMessage & {
   characterId?: string | null;
   name?: string | null;
+  personaSnapshotName?: string | null;
   providerMetadata?: Record<string, unknown>;
 };
 export type StoredGenerationParameters = Partial<GenerationParameters>;
@@ -668,6 +669,13 @@ function prefixSpeakerName(content: string, speakerName: string): string {
   return trimmed ? `${speaker}: ${trimmed}` : `${speaker}:`;
 }
 
+export function readPersonaSnapshotName(extra: unknown): string | null {
+  const snapshot = parseExtra(extra).personaSnapshot;
+  if (!snapshot || typeof snapshot !== "object" || Array.isArray(snapshot)) return null;
+  const name = (snapshot as { name?: unknown }).name;
+  return typeof name === "string" && name.trim() ? name.trim() : null;
+}
+
 export function prefixGroupIndividualHistorySpeakers<T extends SpeakerPrefixMessage>(
   messages: T[],
   options: {
@@ -680,7 +688,7 @@ export function prefixGroupIndividualHistorySpeakers<T extends SpeakerPrefixMess
   return messages.map((message) => {
     let speakerName: string | null = null;
     if (message.role === "user") {
-      speakerName = personaName;
+      speakerName = message.personaSnapshotName?.trim() || personaName;
     } else if (message.role === "assistant") {
       speakerName =
         (message.characterId ? (options.characterNamesById.get(message.characterId) ?? null) : null) ??

--- a/packages/server/src/services/generation/prompt-message-scope.ts
+++ b/packages/server/src/services/generation/prompt-message-scope.ts
@@ -7,6 +7,7 @@ export type GenerationPromptMessage = {
   content: string;
   contextKind?: "prompt" | "history" | "injection";
   characterId?: string | null;
+  personaSnapshotName?: string | null;
   hiddenFromAICharacterIds?: string[];
   images?: string[];
   files?: Array<{ type: string; data: string; filename?: string }>;

--- a/scripts/regressions/prompt.regression.ts
+++ b/scripts/regressions/prompt.regression.ts
@@ -498,6 +498,8 @@ import {
   injectIntoOutputFormatOrLastUser,
   isMessageHiddenFromAIForCharacter,
   preserveTrackerCharacterUiFields,
+  prefixGroupIndividualHistorySpeakers,
+  readPersonaSnapshotName,
   resolveActivePersonaCandidate,
   resolveRoleplaySummaryTail,
   shouldEnableAgentsForGeneration,
@@ -838,6 +840,41 @@ const cases: RegressionCase[] = [
       assert.equal(messages[1]?.content, '"An older line."');
       assert.equal(messages[2]?.content, '"A user-authored tag."');
       assert.equal(messages[3]?.content, '<speaker="Pantalone">"The latest example."</speaker>');
+    },
+  },
+  {
+    name: "name-prefixed history preserves each user turn's Persona snapshot",
+    run() {
+      const historicalPersonaName = readPersonaSnapshotName({
+        personaSnapshot: { personaId: "powers-that-be", name: " Powers That Be " },
+      });
+      assert.equal(historicalPersonaName, "Powers That Be");
+      assert.equal(readPersonaSnapshotName({ personaSnapshot: { name: "  " } }), null);
+
+      const messages = prefixGroupIndividualHistorySpeakers(
+        [
+          {
+            role: "user" as const,
+            content: "A decree from the old Persona.",
+            personaSnapshotName: historicalPersonaName,
+          },
+          { role: "assistant" as const, content: "An answer.", characterId: "dottore" },
+          { role: "user" as const, content: "A question from the current Persona." },
+        ],
+        {
+          personaName: "Mari",
+          characterNamesById: new Map([["dottore", "Dottore"]]),
+        },
+      );
+
+      assert.deepEqual(
+        messages.map((message) => message.content),
+        [
+          "Powers That Be: A decree from the old Persona.",
+          "Dottore: An answer.",
+          "Mari: A question from the current Persona.",
+        ],
+      );
     },
   },
   {


### PR DESCRIPTION
## Linked issue

No GitHub issue has been filed yet. This draft tracks a regression reported directly by the maintainer; an issue should be opened and linked before the PR is marked ready.

## Why this change

When **Name Prefix History** is enabled, switching Personas relabels every historical user turn with the currently selected Persona. Messages originally sent as Powers That Be therefore reach the model as if Mari had sent them.

## What changed

- Read the Persona snapshot already stored on each historical user message.
- Carry that snapshot name through prompt shaping and prefer it when prefixing user history.
- Preserve the current-Persona fallback for unsnapshotted legacy messages and new dry-run input.
- Apply identical behavior to real generation and Peek Prompt.
- Add regression coverage for mixed historical/current Personas and update the changelog.

## Root cause

The history prefixer accepted one generation-wide `personaName` and applied it to every user message. Although messages already persisted their send-time `personaSnapshot`, prompt mapping discarded that name before Name Prefix History ran.

## Validation

Automated commands run successfully:

- `pnpm regression:prompt`
- `pnpm check`
- `pnpm version:check`
- `git diff --check`

- [ ] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed `CONTRIBUTING.md`

### Manual verification notes

- Manually send Roleplay group messages as Persona A with Name Prefix History enabled.
- Switch to Persona B, inspect Peek Prompt, and generate another response.
- Confirm Persona A remains the prefix on its historical turns while the current turn uses Persona B.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Version/release files updated (only if this PR includes a version bump)

## UI evidence (if applicable)

No UI changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Name Prefix History so historical user messages retain the persona name that originally sent them, rather than being relabeled under the currently selected persona.
  * Applied the corrected persona names consistently in chat generation and dry-run previews.
* **Tests**
  * Added regression coverage for persona-prefixed historical messages, including names with extra whitespace.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->