### PR TITLE
feat: allow re-running a single custom agent from Chat Settings

### DIFF
--- a/packages/client/src/components/chat/ChatSettingsDrawer.tsx
+++ b/packages/client/src/components/chat/ChatSettingsDrawer.tsx
@@ -2944,6 +2944,13 @@ export function ChatSettingsDrawer({
     await retryAgents(chat.id, ["lorebook-keeper"], { lorebookKeeperBackfill: true });
   }, [chat.id, retryAgents]);
 
+  const handleRerunCustomAgent = useCallback(
+    async (agentId: string) => {
+      await retryAgents(chat.id, [agentId]);
+    },
+    [chat.id, retryAgents],
+  );
+
   const toggleTool = (toolId: string) => {
     const current = [...activeToolIds];
     const idx = current.indexOf(toolId);
@@ -3934,6 +3941,21 @@ export function ChatSettingsDrawer({
                       {agent.description}
                     </span>
                   </div>
+                  <button
+                    onClick={() => {
+                      void handleRerunCustomAgent(agent.id);
+                    }}
+                    disabled={agentProcessing}
+                    className={cn(
+                      "flex h-6 w-6 shrink-0 items-center justify-center rounded-md text-[var(--muted-foreground)] transition-colors",
+                      agentProcessing
+                        ? "cursor-not-allowed opacity-40"
+                        : "hover:bg-[var(--primary)]/15 hover:text-[var(--primary)]",
+                    )}
+                    title={`Re-run ${agent.name} on the last message`}
+                  >
+                    <RefreshCw size="0.6875rem" className={cn(agentProcessing && "animate-spin")} />
+                  </button>
                   <button
                     onClick={() => {
                       void toggleAgent(agent.id);


### PR DESCRIPTION
## Linked issue

Closes #3878

## Why this change

Custom agents attached to a chat had no way to be manually re-run on the last message. The retry-agents backend (`POST /retry-agents`, `retry-agents-route.ts`) and the client hook `useGenerate().retryAgents(chatId, agentTypes, options)` are both already fully generic — `resolveActiveRetryAgentTypes` permits retrying any agent type present in `chatMeta.activeAgentIds`, built-in or custom. But every existing UI call site hardcoded a specific agent type (`["illustrator"]` for the Illustrate button, `["lorebook-keeper"]` for the Lorebook Keeper's "Backfill Unprocessed" button) or restricted to built-in tracker agents via `isBuiltInTrackerAgentType` (the per-tracker refresh buttons in the Roleplay HUD panels). Custom agents had no equivalent.

## What changed

- Added `handleRerunCustomAgent(agentId)` in `ChatSettingsDrawer.tsx`, calling the existing `retryAgents(chat.id, [agentId])`.
- Added a re-run (refresh) icon button next to the existing "Remove from chat" button in the Custom Agents settings card (Chat Settings → Agents → Custom Agents), one per active custom agent. Disabled and spinning while `agentProcessing` is true, same convention as the Lorebook Keeper backfill button right above it in the same file.
- No server-side change needed — the backend already supports this.

## Validation

- [ ] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [x] Ran the app, clicked through the changes manually
- [x] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [x] Above manual verification completed (describe below)
- [x] Read and followed `CONTRIBUTING.md`

### Manual verification notes

Applied the equivalent change to a local install running an earlier commit on this branch, rebuilt the client, restarted the server, and opened a real chat with 3 active custom agents (an image-prompt agent and two prose/continuity agents). Confirmed the Custom Agents card in Chat Settings renders one re-run button per agent with the correct name in its title/tooltip, and clicking one fires `POST /retry-agents` with just that agent's type and returns 200, without affecting the other agents or the main assistant message. Disabled/spinner state was verified against the pre-existing `agentProcessing` flag used identically by the neighboring Lorebook Keeper button in the same file. Because `pnpm`/Docker aren't set up in this working copy, I did not additionally run `pnpm check` or a container build against this exact diff — the change is a self-contained 22-line addition reusing only symbols (`RefreshCw`, `cn`, `agentProcessing`, `retryAgents`, `useCallback`) already imported and used identically elsewhere in the same file, so no new type or lint surface is introduced.

## Docs and release impact

- [x] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Version/release files updated (only if this PR includes a version bump)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a **Re-run** control for active custom agents in chat settings.
  * Re-run controls are disabled and show a loading indicator while an agent is processing.
  * Existing controls for removing custom agents remain available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->