### PR TITLE
fix: keep Tracker and Echo panels within desktop gutters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 
 ### Fixed
 
+- Kept the desktop Tracker Panel out of the centered Roleplay chat column, shrinking it, responsively reflowing its controls, and proportionally scaling its typography to the available side gutter on narrower screens instead of shifting messages and the composer sideways or clipping its contents.
+- Stacked a top-corner Echo Chamber below the open Tracker Panel on the same desktop side and constrained its message area to the remaining visible height instead of letting the two panels overlap or spill below the screen.
 - Kept each historical user turn under the Persona that sent it when Name Prefix History is enabled, instead of relabeling every user message with the currently selected Persona.
 - Accepted the single-object array wrapper some local models return for generated Noodle profiles, preventing timeline refreshes from failing with HTTP 500 during first-time bio generation (#3871).
 - Gave current semantic lorebook matches the same context-budget priority as current keyword matches, so configured entry order—not activation method—decides which entries are attached when every match cannot fit.

--- a/e2e/core-flows.e2e.ts
+++ b/e2e/core-flows.e2e.ts
@@ -703,7 +703,9 @@ test("desktop Tracker stays in the Roleplay gutter without shifting the chat col
     const tracker = page.locator('[data-component="TrackerDataSidebarDesktop.left"]');
     await expect(tracker).toBeVisible();
     await tracker.evaluate(async (element) => {
-      await Promise.all(element.getAnimations().map((animation) => animation.finished.catch(() => undefined)));
+      await Promise.all(
+        element.getAnimations({ subtree: true }).map((animation) => animation.finished.catch(() => undefined)),
+      );
     });
 
     const [mainBox, chatColumnAfter, trackerBox] = await Promise.all([
@@ -742,10 +744,36 @@ test("desktop Tracker stays in the Roleplay gutter without shifting the chat col
 
     await tracker.getByRole("button", { name: "Open tracker settings" }).click();
     await expect(tracker.getByRole("toolbar", { name: "Tracker panel settings" })).toBeVisible();
-    const hasHorizontalOverflow = await trackerContent.evaluate(
-      (element) => element.scrollWidth > element.clientWidth + 1,
-    );
-    expect(hasHorizontalOverflow).toBe(false);
+    await tracker.evaluate(async (element) => {
+      await Promise.all(
+        element.getAnimations({ subtree: true }).map((animation) => animation.finished.catch(() => undefined)),
+      );
+    });
+    const horizontalOverflow = await trackerContent.evaluate((root) => {
+      let overflow: { className: string; clientWidth: number; depth: number; scrollWidth: number; tagName: string } | null =
+        null;
+      const scan = (node: Element, depth: number) => {
+        if (overflow || depth > 6) return;
+        const rect = node.getBoundingClientRect();
+        if (rect.width <= 0 || rect.height <= 0) return;
+        if (node.scrollWidth > node.clientWidth + 1) {
+          overflow = {
+            className: node.className,
+            clientWidth: node.clientWidth,
+            depth,
+            scrollWidth: node.scrollWidth,
+            tagName: node.tagName,
+          };
+          return;
+        }
+        for (let i = 0; i < node.children.length; i++) {
+          scan(node.children[i]!, depth + 1);
+        }
+      };
+      scan(root, 0);
+      return overflow;
+    });
+    expect(horizontalOverflow).toBeNull();
   } finally {
     await page.request.delete(`/api/chats/${chat.id}`);
   }

--- a/e2e/core-flows.e2e.ts
+++ b/e2e/core-flows.e2e.ts
@@ -661,6 +661,96 @@ test("Roleplay side panels synchronize their slide with the desktop shell resize
   }
 });
 
+test("desktop Tracker stays in the Roleplay gutter without shifting the chat column", async ({ page }, testInfo) => {
+  test.skip(!testInfo.project.name.includes("desktop"), "Desktop Tracker gutter behavior is covered on desktop.");
+
+  const chatResponse = await page.request.post("/api/chats", {
+    data: { name: "Tracker Gutter Layout Smoke", mode: "roleplay", characterIds: [] },
+  });
+  expect(chatResponse.ok()).toBeTruthy();
+  const chat = (await chatResponse.json()) as { id: string };
+
+  try {
+    await page.setViewportSize({ width: 1200, height: 900 });
+    const metadataResponse = await page.request.patch(`/api/chats/${chat.id}/metadata`, {
+      data: { enableAgents: true, activeAgentIds: [] },
+    });
+    expect(metadataResponse.ok()).toBeTruthy();
+    await page.addInitScript((chatId) => {
+      const persisted = JSON.parse(localStorage.getItem("marinara-engine-ui") ?? '{"state":{},"version":65}') as {
+        state: Record<string, unknown>;
+        version: number;
+      };
+      persisted.state.trackerPanelEnabled = true;
+      persisted.state.trackerPanelOpen = false;
+      persisted.state.trackerPanelSide = "left";
+      persisted.state.trackerPanelSizeProfile = "expanded";
+      persisted.state.trackerPanelHideHudWidgets = false;
+      localStorage.setItem("marinara-engine-ui", JSON.stringify(persisted));
+      localStorage.setItem("marinara-active-chat-id", chatId);
+    }, chat.id);
+    await page.goto("/");
+
+    const main = page.locator('[data-component="CenterContent"]');
+    const chatColumn = page.locator('[data-roleplay-chat-column="true"]');
+    const trackerToggle = page.locator('[data-tracker-panel-toggle="roleplay-hud"]:visible').first();
+    await expect(chatColumn).toBeVisible();
+    await expect(trackerToggle).toBeVisible();
+    const chatColumnBefore = await chatColumn.boundingBox();
+    expect(chatColumnBefore).not.toBeNull();
+
+    await trackerToggle.click();
+    const tracker = page.locator('[data-component="TrackerDataSidebarDesktop.left"]');
+    await expect(tracker).toBeVisible();
+    await tracker.evaluate(async (element) => {
+      await Promise.all(element.getAnimations().map((animation) => animation.finished.catch(() => undefined)));
+    });
+
+    const [mainBox, chatColumnAfter, trackerBox] = await Promise.all([
+      main.boundingBox(),
+      chatColumn.boundingBox(),
+      tracker.boundingBox(),
+    ]);
+    expect(mainBox).not.toBeNull();
+    expect(chatColumnAfter).not.toBeNull();
+    expect(trackerBox).not.toBeNull();
+    expect(Math.abs(chatColumnAfter!.x - chatColumnBefore!.x)).toBeLessThanOrEqual(1);
+    expect(Math.abs(chatColumnAfter!.width - chatColumnBefore!.width)).toBeLessThanOrEqual(1);
+
+    const expectedWidth = Math.min(420, Math.floor(chatColumnAfter!.x - mainBox!.x - 8));
+    expect(Math.abs(trackerBox!.width - expectedWidth)).toBeLessThanOrEqual(1);
+    expect(trackerBox!.x + trackerBox!.width).toBeLessThanOrEqual(chatColumnAfter!.x - 7);
+
+    const trackerContent = tracker.locator(".mari-tracker-panel-scroll");
+    const expectedScale = Math.max(0.65, expectedWidth / 420);
+    const appliedScale = Number(await trackerContent.getAttribute("data-tracker-content-scale"));
+    expect(Math.abs(appliedScale - expectedScale)).toBeLessThanOrEqual(0.001);
+    const emptyTrackerText = tracker.getByText("No tracker data yet.", { exact: true });
+    await expect(emptyTrackerText).toBeVisible();
+    const [emptyTextFontSize, rootFontSize] = await emptyTrackerText.evaluate((element) => [
+      parseFloat(getComputedStyle(element).fontSize),
+      parseFloat(getComputedStyle(document.documentElement).fontSize),
+    ]);
+    expect(Math.abs(emptyTextFontSize - rootFontSize * 0.6875 * expectedScale)).toBeLessThanOrEqual(0.1);
+
+    const trackerContentBox = await trackerContent.boundingBox();
+    expect(trackerContentBox).not.toBeNull();
+    expect(trackerContentBox!.x).toBeGreaterThanOrEqual(trackerBox!.x - 1);
+    expect(trackerContentBox!.x + trackerContentBox!.width).toBeLessThanOrEqual(
+      trackerBox!.x + trackerBox!.width + 1,
+    );
+
+    await tracker.getByRole("button", { name: "Open tracker settings" }).click();
+    await expect(tracker.getByRole("toolbar", { name: "Tracker panel settings" })).toBeVisible();
+    const hasHorizontalOverflow = await trackerContent.evaluate(
+      (element) => element.scrollWidth > element.clientWidth + 1,
+    );
+    expect(hasHorizontalOverflow).toBe(false);
+  } finally {
+    await page.request.delete(`/api/chats/${chat.id}`);
+  }
+});
+
 test("Roleplay Active Context shows rich lorebook activation provenance", async ({ page, request }, testInfo) => {
   const lorebookId = "roleplay-active-context-smoke-lorebook";
   const chatResponse = await request.post("/api/chats", {

--- a/packages/client/src/components/chat/ChatRoleplaySurface.tsx
+++ b/packages/client/src/components/chat/ChatRoleplaySurface.tsx
@@ -126,8 +126,6 @@ const ActiveLorebookEntriesContent = lazy(async () => {
   return { default: module.ActiveLorebookEntriesContent };
 });
 
-const TRACKER_FOREGROUND_AVOIDANCE_CLASS =
-  "md:pl-[var(--tracker-chat-avoid-left)] md:pr-[var(--tracker-chat-avoid-right)] md:transition-[padding] md:duration-200 md:ease-[cubic-bezier(0.16,1,0.3,1)]";
 const roleplayNotificationSeenKeys = new Set<string>();
 const MOBILE_FLOATING_PANEL_PADDING = 8;
 
@@ -1767,7 +1765,7 @@ export function ChatRoleplaySurface({
               </Suspense>
             )}
 
-            <div className={cn("absolute inset-0 z-10 overflow-hidden", TRACKER_FOREGROUND_AVOIDANCE_CLASS)}>
+            <div className="absolute inset-0 z-10 overflow-hidden">
               <div
                 ref={scrollRef}
                 data-chat-scroll
@@ -1929,11 +1927,11 @@ export function ChatRoleplaySurface({
             </div>
             <PinnedImageOverlay activeChatId={activeChatId} includeSceneVideos />
 
-            <div
-              ref={inputChromeRef}
-              className={cn("pointer-events-none absolute inset-x-0 bottom-0 z-30", TRACKER_FOREGROUND_AVOIDANCE_CLASS)}
-            >
-              <div className={cn("mari-roleplay-input-column pointer-events-auto relative mx-auto px-3 md:px-0")}>
+            <div ref={inputChromeRef} className="pointer-events-none absolute inset-x-0 bottom-0 z-30">
+              <div
+                data-roleplay-chat-column="true"
+                className="mari-roleplay-input-column pointer-events-auto relative mx-auto px-3 md:px-0"
+              >
                 {chatMeta.sceneStatus === "active" && (
                   <EndSceneBar
                     sceneChatId={activeChatId}

--- a/packages/client/src/components/chat/EchoChamberPanel.tsx
+++ b/packages/client/src/components/chat/EchoChamberPanel.tsx
@@ -28,6 +28,7 @@ import {
   getEchoChamberMessageInterval,
   resolveEchoChamberPersistedBaseline,
 } from "../../lib/echo-chamber-queue";
+import { resolveEchoChamberTopLayout } from "../../lib/echo-chamber-layout";
 
 const NAME_COLORS = [
   "text-red-400",
@@ -51,14 +52,17 @@ const WIDGET_BAR_H = 76; // top HUD toolbar: py-2 (16px) + widget buttons h-[3.7
 const INPUT_BOX_H = 72; // bottom chat input area height
 const HUD_EDGE_GAP = 16; // Aligns with the roleplay HUD edge padding.
 const FLOATING_EDGE_GAP = 16;
+const FLOATING_PANEL_STACK_GAP = 8;
 const TOP_BUTTON_GAP = 6; // Matches the tracker panel gap below the top controls.
 const DESKTOP_PANEL_WIDTH = 236;
+const DEFAULT_DESKTOP_PANEL_MAX_HEIGHT = 352;
 const MIN_PANEL_WIDTH = 176;
 const MIN_PANEL_HEIGHT = 96;
 const RESIZE_KEYBOARD_STEP = 24;
 const ROLEPLAY_AREA_SELECTOR = ".rpg-chat-area";
 const ROLEPLAY_TOP_ANCHOR_SELECTOR = '[data-tracker-panel-anchor="roleplay-hud"]';
 const ROLEPLAY_TOP_RIGHT_CONTROLS_SELECTOR = '[data-roleplay-top-controls="right"]';
+const TRACKER_PANEL_SELECTOR_PREFIX = '[data-component="TrackerDataSidebarDesktop.';
 
 interface EchoChamberPanelProps {
   hiddenOnMobile?: boolean;
@@ -96,6 +100,10 @@ function getDesktopAlignmentElement(isLeft: boolean) {
     : findVisibleElement(ROLEPLAY_TOP_RIGHT_CONTROLS_SELECTOR);
 }
 
+function getDesktopTrackerPanel(isLeft: boolean) {
+  return document.querySelector<HTMLElement>(`${TRACKER_PANEL_SELECTOR_PREFIX}${isLeft ? "left" : "right"}"]`);
+}
+
 function getTopChromeBottomOffset(containerRect: DOMRect, alignmentRect: DOMRect | null) {
   const candidates: number[] = [];
   const anchors = Array.from(document.querySelectorAll<HTMLElement>(ROLEPLAY_TOP_ANCHOR_SELECTOR));
@@ -108,17 +116,39 @@ function getTopChromeBottomOffset(containerRect: DOMRect, alignmentRect: DOMRect
   return candidates.length > 0 ? Math.max(TOP_BUTTON_GAP, ...candidates) : WIDGET_BAR_H + TOP_BUTTON_GAP;
 }
 
-function getDesktopPanelPosition(isTop: boolean, isLeft: boolean): CSSProperties {
+function getDesktopPanelPosition(isTop: boolean, isLeft: boolean, stackBelowTracker: boolean): CSSProperties {
   const containerRect = getRoleplayAreaRect();
   const alignmentElement = getDesktopAlignmentElement(isLeft);
   const alignmentRect = alignmentElement ? readVisibleRect(alignmentElement) : null;
-  const edgeOffset = alignmentRect && containerRect ? Math.max(0, Math.round(alignmentRect.left - containerRect.left)) : null;
+  const trackerPanel = isTop && stackBelowTracker ? getDesktopTrackerPanel(isLeft) : null;
+  const edgeOffset =
+    trackerPanel && containerRect
+      ? Math.max(0, Math.round(trackerPanel.offsetLeft - containerRect.left))
+      : alignmentRect && containerRect
+        ? Math.max(0, Math.round(alignmentRect.left - containerRect.left))
+        : null;
   const rightEdgeOffset =
-    alignmentRect && containerRect ? Math.max(0, Math.round(containerRect.right - alignmentRect.right)) : null;
-  const topOffset = isTop && containerRect ? getTopChromeBottomOffset(containerRect, alignmentRect) : undefined;
+    trackerPanel && containerRect
+      ? Math.max(0, Math.round(containerRect.right - trackerPanel.offsetLeft - trackerPanel.offsetWidth))
+      : alignmentRect && containerRect
+        ? Math.max(0, Math.round(containerRect.right - alignmentRect.right))
+        : null;
+  const baseTop = isTop && containerRect ? getTopChromeBottomOffset(containerRect, alignmentRect) : undefined;
+  const topLayout =
+    baseTop !== undefined && containerRect
+      ? resolveEchoChamberTopLayout({
+          baseTop,
+          containerTop: containerRect.top,
+          containerBottom: containerRect.bottom,
+          viewportBottom: window.innerHeight,
+          bottomClearance: INPUT_BOX_H + FLOATING_EDGE_GAP,
+          trackerBottom: trackerPanel ? trackerPanel.offsetTop + trackerPanel.offsetHeight : null,
+          stackGap: FLOATING_PANEL_STACK_GAP,
+        })
+      : null;
 
   return {
-    ...(topOffset !== undefined && { top: topOffset }),
+    ...(topLayout && { top: topLayout.top, maxHeight: topLayout.maxHeight }),
     ...(!isTop && { bottom: INPUT_BOX_H + FLOATING_EDGE_GAP }),
     ...(isLeft && {
       left: edgeOffset !== null ? `${edgeOffset}px` : `calc(${HUD_EDGE_GAP}px + var(--tracker-panel-hud-clear-left, 0px))`,
@@ -160,6 +190,9 @@ export function EchoChamberPanel({ hiddenOnMobile = false }: EchoChamberPanelPro
   const setEchoChamberSide = useUIStore((s) => s.setEchoChamberSide);
   const echoChamberOpen = useUIStore((s) => s.echoChamberOpen);
   const toggleEchoChamber = useUIStore((s) => s.toggleEchoChamber);
+  const trackerPanelEnabled = useUIStore((s) => s.trackerPanelEnabled);
+  const trackerPanelOpen = useUIStore((s) => s.trackerPanelOpen);
+  const trackerPanelSide = useUIStore((s) => s.trackerPanelSide);
   const echoMessages = useAgentStore((s) => s.echoMessages);
   const scrollRef = useRef<HTMLDivElement>(null);
   const panelRef = useRef<HTMLDivElement>(null);
@@ -380,8 +413,10 @@ export function EchoChamberPanel({ hiddenOnMobile = false }: EchoChamberPanelPro
     // Desktop: position within the chat area container (absolute, not fixed)
     const isTop = echoChamberSide.startsWith("top");
     const isLeft = echoChamberSide.endsWith("left");
+    const stackBelowTracker =
+      isTop && trackerPanelEnabled && trackerPanelOpen && trackerPanelSide === (isLeft ? "left" : "right");
     const update = () => {
-      setPosStyle(getDesktopPanelPosition(isTop, isLeft));
+      setPosStyle(getDesktopPanelPosition(isTop, isLeft, stackBelowTracker));
     };
 
     update();
@@ -397,13 +432,22 @@ export function EchoChamberPanel({ hiddenOnMobile = false }: EchoChamberPanelPro
         document.querySelectorAll<HTMLElement>(ROLEPLAY_TOP_RIGHT_CONTROLS_SELECTOR),
       );
       const huds = Array.from(document.querySelectorAll<HTMLElement>(".rpg-hud"));
-      const targets = [...roleplayAreas, ...topAnchors, ...topRightControls, ...huds];
+      const trackerPanels = stackBelowTracker
+        ? Array.from(
+            document.querySelectorAll<HTMLElement>(`${TRACKER_PANEL_SELECTOR_PREFIX}${isLeft ? "left" : "right"}"]`),
+          )
+        : [];
+      const targets = [...roleplayAreas, ...topAnchors, ...topRightControls, ...huds, ...trackerPanels];
       targets.forEach((target) => {
         if (observedTargets.has(target)) return;
         observer.observe(target);
         observedTargets.add(target);
       });
-      return roleplayAreas.length > 0 && (isLeft ? huds.length > 0 : topRightControls.length > 0);
+      return (
+        roleplayAreas.length > 0 &&
+        (isLeft ? huds.length > 0 : topRightControls.length > 0) &&
+        (!stackBelowTracker || trackerPanels.length > 0)
+      );
     };
     function scheduleUpdate() {
       if (frame) window.cancelAnimationFrame(frame);
@@ -428,7 +472,7 @@ export function EchoChamberPanel({ hiddenOnMobile = false }: EchoChamberPanelPro
       discoveryObserver?.disconnect();
       window.removeEventListener("resize", scheduleUpdate);
     };
-  }, [echoEnabled, echoChamberSide]);
+  }, [echoEnabled, echoChamberSide, trackerPanelEnabled, trackerPanelOpen, trackerPanelSide]);
 
   useEffect(() => {
     if (!echoEnabled || (isMobile && hiddenOnMobile)) return;
@@ -449,6 +493,7 @@ export function EchoChamberPanel({ hiddenOnMobile = false }: EchoChamberPanelPro
   if (!echoChamberOpen) {
     const collapsedStyle = { ...posStyle };
     delete collapsedStyle.width;
+    delete collapsedStyle.maxHeight;
     return (
       <button
         type="button"
@@ -476,6 +521,15 @@ export function EchoChamberPanel({ hiddenOnMobile = false }: EchoChamberPanelPro
     );
   }
 
+  const availableHeight = typeof posStyle.maxHeight === "number" ? posStyle.maxHeight : null;
+  const expandedPanelStyle: CSSProperties = {
+    ...posStyle,
+    ...(availableHeight !== null && {
+      maxHeight: Math.min(availableHeight, panelSize?.height ?? DEFAULT_DESKTOP_PANEL_MAX_HEIGHT),
+    }),
+    ...(panelSize && { width: panelSize.width, height: panelSize.height }),
+  };
+
   return (
     <div
       ref={panelRef}
@@ -485,7 +539,7 @@ export function EchoChamberPanel({ hiddenOnMobile = false }: EchoChamberPanelPro
         "pointer-events-auto max-md:w-auto md:w-[14.75rem]",
         !panelSize && "max-md:max-h-28 md:max-h-[22rem]",
       )}
-      style={{ ...posStyle, ...(panelSize && { width: panelSize.width, height: panelSize.height }) }}
+      style={expandedPanelStyle}
     >
       {/* Header — live dot, corner picker, close */}
       <div className="flex items-center justify-between px-2 py-1">

--- a/packages/client/src/components/layout/AppShell.tsx
+++ b/packages/client/src/components/layout/AppShell.tsx
@@ -30,6 +30,10 @@ import { getCssBackgroundStyle } from "../../lib/css-colors";
 import { showConfirmDialog } from "../../lib/app-dialogs";
 import { cn } from "../../lib/utils";
 import { parseChatMetadata } from "../../lib/chat-display";
+import {
+  resolveTrackerPanelContentScale,
+  resolveTrackerPanelDesktopWidth,
+} from "../../lib/tracker-panel-layout";
 import { motion, AnimatePresence } from "framer-motion";
 import {
   lazy,
@@ -98,12 +102,14 @@ const SHARED_SIDEBAR_WIDTH_MIN = Math.max(SIDEBAR_WIDTH_MIN, RIGHT_PANEL_WIDTH_M
 const SHARED_SIDEBAR_WIDTH_MAX = Math.min(SIDEBAR_WIDTH_MAX, RIGHT_PANEL_WIDTH_MAX);
 const TRACKER_PANEL_EDGE_OFFSET = 8;
 const TRACKER_PANEL_HUD_GAP = 6;
+const TRACKER_PANEL_CHAT_GAP = 8;
 const TRACKER_PANEL_DESKTOP_MOTION_MS = 260;
 const TRACKER_PANEL_DESKTOP_EXIT_MS = 240;
 const TRACKER_PANEL_DESKTOP_EASE = [0.16, 1, 0.3, 1] as const;
 const TRACKER_PANEL_DESKTOP_EXIT_EASE = [0.4, 0, 1, 1] as const;
 const TRACKER_PANEL_TOGGLE_SELECTOR = '[data-tracker-panel-toggle="roleplay-hud"]';
 const TRACKER_PANEL_ANCHOR_SELECTOR = '[data-tracker-panel-anchor="roleplay-hud"]';
+const ROLEPLAY_CHAT_COLUMN_SELECTOR = '[data-roleplay-chat-column="true"]';
 const TOP_BAR_SELECTOR = '[data-component="TopBar"]';
 const MOBILE_SHELL_PANEL_TOP_CLASS = "top-[calc(env(safe-area-inset-top)_+_3rem)]";
 const CENTER_COMPACT_WIDTH = 768;
@@ -265,6 +271,7 @@ export function AppShell() {
   const liveSidebarWidth = sidebarDragWidth ?? rightPanelDragWidth ?? sharedSidebarWidth;
   const liveRightPanelWidth = rightPanelDragWidth ?? sidebarDragWidth ?? sharedSidebarWidth;
   const trackerPanelWidth = getTrackerPanelWidthForProfile(trackerPanelSizeProfile);
+  const [trackerPanelResolvedWidth, setTrackerPanelResolvedWidth] = useState(trackerPanelWidth);
   const trackerPanelHasCustomBackground =
     trackerPanelBackgroundColor.trim().toLowerCase() !== TRACKER_PANEL_DEFAULT_BACKGROUND_COLOR;
   const trackerPanelBackgroundStyle = trackerPanelHasCustomBackground
@@ -844,14 +851,77 @@ export function AppShell() {
     updateTrackerPanelTop,
   ]);
 
-  const trackerPanelChatAvoidance =
-    !shellOverlayMode && trackerPanelAnchoredForMotion && trackerPanelSurfaceAvailable
-      ? Math.round(trackerPanelWidth * 0.62)
-      : 0;
+  useLayoutEffect(() => {
+    if (shellOverlayMode || !trackerPanelSurfaceAvailable) {
+      setTrackerPanelResolvedWidth(trackerPanelWidth);
+      return;
+    }
+
+    let frame = 0;
+    let discoveryObserver: MutationObserver | null = null;
+    let observedChatColumn: HTMLElement | null = null;
+    const observer = new ResizeObserver(() => scheduleUpdate());
+    const update = () => {
+      const main = mainRef.current;
+      const chatColumn = main?.querySelector<HTMLElement>(ROLEPLAY_CHAT_COLUMN_SELECTOR) ?? null;
+      const mainRect = main ? readVisibleElementRect(main) : null;
+      const chatColumnRect = chatColumn ? readVisibleElementRect(chatColumn) : null;
+
+      if (!mainRect || !chatColumn || !chatColumnRect) {
+        setTrackerPanelResolvedWidth(trackerPanelWidth);
+        return false;
+      }
+
+      const nextWidth = resolveTrackerPanelDesktopWidth({
+        preferredWidth: trackerPanelWidth,
+        mainLeft: mainRect.left,
+        mainRight: mainRect.right,
+        chatColumnLeft: chatColumnRect.left,
+        chatColumnRight: chatColumnRect.right,
+        side: trackerPanelSide,
+        gap: TRACKER_PANEL_CHAT_GAP,
+      });
+      setTrackerPanelResolvedWidth((current) => (current === nextWidth ? current : nextWidth));
+
+      if (observedChatColumn !== chatColumn) {
+        if (observedChatColumn) observer.unobserve(observedChatColumn);
+        observer.observe(chatColumn);
+        observedChatColumn = chatColumn;
+      }
+      return true;
+    };
+    function scheduleUpdate() {
+      if (frame) window.cancelAnimationFrame(frame);
+      frame = window.requestAnimationFrame(() => {
+        frame = 0;
+        const foundChatColumn = update();
+        if (foundChatColumn) {
+          discoveryObserver?.disconnect();
+          discoveryObserver = null;
+        }
+      });
+    }
+
+    if (mainRef.current) observer.observe(mainRef.current);
+    scheduleUpdate();
+    if (mainRef.current) {
+      discoveryObserver = new MutationObserver(() => scheduleUpdate());
+      discoveryObserver.observe(mainRef.current, { childList: true, subtree: true });
+    }
+    window.addEventListener("resize", scheduleUpdate);
+    return () => {
+      if (frame) window.cancelAnimationFrame(frame);
+      observer.disconnect();
+      discoveryObserver?.disconnect();
+      window.removeEventListener("resize", scheduleUpdate);
+    };
+  }, [shellOverlayMode, trackerPanelSide, trackerPanelSurfaceAvailable, trackerPanelWidth]);
+
   const trackerPanelHudClearance =
     !shellOverlayMode && trackerPanelAnchoredForMotion && trackerPanelHideHudWidgets && trackerPanelSurfaceAvailable
-      ? trackerPanelWidth + TRACKER_PANEL_HUD_GAP
+      ? trackerPanelResolvedWidth + TRACKER_PANEL_HUD_GAP
       : 0;
+  const trackerPanelContentScale = resolveTrackerPanelContentScale(trackerPanelWidth, trackerPanelResolvedWidth);
 
   const trackerPanelDesktop = (side: "left" | "right") =>
     trackerPanelVisible && trackerPanelSide === side ? (
@@ -894,7 +964,7 @@ export function AppShell() {
         style={{
           top: trackerPanelTop,
           maxHeight: `calc(100vh - ${trackerPanelTop + TRACKER_PANEL_EDGE_OFFSET}px)`,
-          width: trackerPanelWidth,
+          width: trackerPanelResolvedWidth,
           transformOrigin: `${side === "left" ? "left" : "right"} ${Math.max(
             -56,
             Math.min(56, (trackerPanelToggleAnchorY ?? trackerPanelTop) - trackerPanelTop),
@@ -905,7 +975,12 @@ export function AppShell() {
           ...(trackerPanelBackgroundStyle ?? {}),
         }}
       >
-        <div className="mari-tracker-panel-scroll max-h-[inherit] overflow-x-hidden overflow-y-auto">
+        <div
+          data-tracker-content-scale={trackerPanelContentScale.toFixed(4)}
+          data-tracker-content-constrained={trackerPanelContentScale < 1 ? "true" : undefined}
+          className="mari-tracker-panel-scroll max-h-[inherit] overflow-x-hidden overflow-y-auto"
+          style={{ "--tracker-panel-font-scale": trackerPanelContentScale } as CSSProperties}
+        >
           <Suspense fallback={<SidePanelFallback />}>
             <TrackerDataSidebar />
           </Suspense>
@@ -1025,8 +1100,6 @@ export function AppShell() {
             )}
             style={
               {
-                "--tracker-chat-avoid-left": `${trackerPanelSide === "left" ? trackerPanelChatAvoidance : 0}px`,
-                "--tracker-chat-avoid-right": `${trackerPanelSide === "right" ? trackerPanelChatAvoidance : 0}px`,
                 "--tracker-panel-hud-clear-left": `${trackerPanelSide === "left" ? trackerPanelHudClearance : 0}px`,
                 "--tracker-panel-hud-clear-right": `${trackerPanelSide === "right" ? trackerPanelHudClearance : 0}px`,
               } as CSSProperties

--- a/packages/client/src/components/layout/AppShell.tsx
+++ b/packages/client/src/components/layout/AppShell.tsx
@@ -852,7 +852,7 @@ export function AppShell() {
   ]);
 
   useLayoutEffect(() => {
-    if (shellOverlayMode || !trackerPanelSurfaceAvailable) {
+    if (shellOverlayMode || !trackerPanelSurfaceAvailable || !trackerPanelAnchoredForMotion) {
       setTrackerPanelResolvedWidth(trackerPanelWidth);
       return;
     }
@@ -915,7 +915,13 @@ export function AppShell() {
       discoveryObserver?.disconnect();
       window.removeEventListener("resize", scheduleUpdate);
     };
-  }, [shellOverlayMode, trackerPanelSide, trackerPanelSurfaceAvailable, trackerPanelWidth]);
+  }, [
+    shellOverlayMode,
+    trackerPanelAnchoredForMotion,
+    trackerPanelSide,
+    trackerPanelSurfaceAvailable,
+    trackerPanelWidth,
+  ]);
 
   const trackerPanelHudClearance =
     !shellOverlayMode && trackerPanelAnchoredForMotion && trackerPanelHideHudWidgets && trackerPanelSurfaceAvailable

--- a/packages/client/src/features/tracker-panel/components/TrackerSidebarHeader.tsx
+++ b/packages/client/src/features/tracker-panel/components/TrackerSidebarHeader.tsx
@@ -184,7 +184,7 @@ export function TrackerSidebarHeader({
       <div
         role="group"
         aria-label="Tracker editing modes"
-        className="flex items-center gap-0.5 rounded-md bg-[var(--background)]/30 p-0.5 ring-1 ring-[var(--border)]/45 shadow-[inset_0_1px_0_color-mix(in_srgb,var(--foreground)_4%,transparent)]"
+        className="flex max-w-full flex-wrap items-center justify-center gap-0.5 rounded-md bg-[var(--background)]/30 p-0.5 ring-1 ring-[var(--border)]/45 shadow-[inset_0_1px_0_color-mix(in_srgb,var(--foreground)_4%,transparent)]"
       >
         <button
           {...getToolbarItemProps("hide")}

--- a/packages/client/src/features/tracker-panel/components/TrackerSidebarHeader.tsx
+++ b/packages/client/src/features/tracker-panel/components/TrackerSidebarHeader.tsx
@@ -139,7 +139,7 @@ export function TrackerSidebarHeader({
   );
 
   const outerHeaderControls = (
-    <div className="flex w-full items-center justify-between gap-2">
+    <div className="flex w-full flex-wrap items-center justify-center gap-1 @min-[220px]:justify-between @min-[220px]:gap-2">
       <div
         role="group"
         aria-label="Tracker display settings"

--- a/packages/client/src/lib/echo-chamber-layout.ts
+++ b/packages/client/src/lib/echo-chamber-layout.ts
@@ -1,0 +1,32 @@
+interface EchoChamberTopLayoutInput {
+  baseTop: number;
+  containerTop: number;
+  containerBottom: number;
+  viewportBottom: number;
+  bottomClearance: number;
+  trackerBottom?: number | null;
+  stackGap?: number;
+}
+
+interface EchoChamberTopLayout {
+  top: number;
+  maxHeight: number;
+}
+
+/** Resolve a top-corner Echo Chamber position without letting it leave the visible chat area. */
+export function resolveEchoChamberTopLayout({
+  baseTop,
+  containerTop,
+  containerBottom,
+  viewportBottom,
+  bottomClearance,
+  trackerBottom,
+  stackGap = 0,
+}: EchoChamberTopLayoutInput): EchoChamberTopLayout {
+  const trackerTop = trackerBottom == null ? baseTop : Math.ceil(trackerBottom - containerTop + stackGap);
+  const top = Math.max(baseTop, trackerTop);
+  const visibleBottom = Math.min(containerBottom, viewportBottom);
+  const maxHeight = Math.max(0, Math.floor(visibleBottom - containerTop - top - bottomClearance));
+
+  return { top, maxHeight };
+}

--- a/packages/client/src/lib/tracker-panel-layout.ts
+++ b/packages/client/src/lib/tracker-panel-layout.ts
@@ -1,0 +1,29 @@
+interface TrackerPanelDesktopWidthInput {
+  preferredWidth: number;
+  mainLeft: number;
+  mainRight: number;
+  chatColumnLeft: number;
+  chatColumnRight: number;
+  side: "left" | "right";
+  gap?: number;
+}
+
+/** Keep the desktop Tracker inside the free gutter beside the centered Roleplay chat column. */
+export function resolveTrackerPanelDesktopWidth({
+  preferredWidth,
+  mainLeft,
+  mainRight,
+  chatColumnLeft,
+  chatColumnRight,
+  side,
+  gap = 0,
+}: TrackerPanelDesktopWidthInput) {
+  const gutterWidth = side === "left" ? chatColumnLeft - mainLeft : mainRight - chatColumnRight;
+  return Math.max(0, Math.min(preferredWidth, Math.floor(gutterWidth - gap)));
+}
+
+/** Scale constrained Tracker contents while retaining a readable lower bound and responsive reflow. */
+export function resolveTrackerPanelContentScale(preferredWidth: number, resolvedWidth: number, minimumScale = 0.65) {
+  if (preferredWidth <= 0 || resolvedWidth <= 0 || resolvedWidth >= preferredWidth) return 1;
+  return Math.max(minimumScale, resolvedWidth / preferredWidth);
+}

--- a/packages/client/src/styles/globals.css
+++ b/packages/client/src/styles/globals.css
@@ -2851,6 +2851,100 @@ strong {
   scrollbar-color: color-mix(in srgb, var(--primary) 42%, transparent) transparent;
 }
 
+/* Keep constrained desktop Tracker typography in normal layout flow. Scaling the
+   panel's whole rendering canvas causes its far edge to be clipped by the shell. */
+.mari-tracker-panel-scroll[data-tracker-content-constrained="true"] {
+  font-size: calc(1rem * var(--tracker-panel-font-scale));
+}
+
+.mari-tracker-panel-scroll[data-tracker-content-constrained="true"] [class~="text-[0.5625rem]"] {
+  font-size: calc(0.5625rem * var(--tracker-panel-font-scale));
+}
+
+.mari-tracker-panel-scroll[data-tracker-content-constrained="true"] [class~="text-[0.59375rem]"] {
+  font-size: calc(0.59375rem * var(--tracker-panel-font-scale));
+}
+
+.mari-tracker-panel-scroll[data-tracker-content-constrained="true"] [class~="text-[0.625rem]"] {
+  font-size: calc(0.625rem * var(--tracker-panel-font-scale));
+}
+
+.mari-tracker-panel-scroll[data-tracker-content-constrained="true"] [class~="text-[0.6875rem]"] {
+  font-size: calc(0.6875rem * var(--tracker-panel-font-scale));
+}
+
+.mari-tracker-panel-scroll[data-tracker-content-constrained="true"] [class~="text-[0.75rem]"] {
+  font-size: calc(0.75rem * var(--tracker-panel-font-scale));
+}
+
+.mari-tracker-panel-scroll[data-tracker-content-constrained="true"] [class~="text-[0.8125rem]"] {
+  font-size: calc(0.8125rem * var(--tracker-panel-font-scale));
+}
+
+.mari-tracker-panel-scroll[data-tracker-content-constrained="true"] [class~="text-[1.0625rem]"] {
+  font-size: calc(1.0625rem * var(--tracker-panel-font-scale));
+}
+
+.mari-tracker-panel-scroll[data-tracker-content-constrained="true"] [class~="text-[1.1875rem]"] {
+  font-size: calc(1.1875rem * var(--tracker-panel-font-scale));
+}
+
+.mari-tracker-panel-scroll[data-tracker-content-constrained="true"] :is(.text-xs, .text-sm, .text-lg, .text-2xl) {
+  font-size: calc(var(--tracker-panel-base-font-size) * var(--tracker-panel-font-scale));
+}
+
+.mari-tracker-panel-scroll[data-tracker-content-constrained="true"] .text-xs {
+  --tracker-panel-base-font-size: 0.75rem;
+}
+
+.mari-tracker-panel-scroll[data-tracker-content-constrained="true"] .text-sm {
+  --tracker-panel-base-font-size: 0.875rem;
+}
+
+.mari-tracker-panel-scroll[data-tracker-content-constrained="true"] .text-lg {
+  --tracker-panel-base-font-size: 1.125rem;
+}
+
+.mari-tracker-panel-scroll[data-tracker-content-constrained="true"] .text-2xl {
+  --tracker-panel-base-font-size: 1.5rem;
+}
+
+.mari-tracker-panel-scroll[data-tracker-content-constrained="true"] [class~="leading-[0.6875rem]"] {
+  line-height: calc(0.6875rem * var(--tracker-panel-font-scale));
+}
+
+.mari-tracker-panel-scroll[data-tracker-content-constrained="true"] [class~="leading-[0.875rem]"] {
+  line-height: calc(0.875rem * var(--tracker-panel-font-scale));
+}
+
+.mari-tracker-panel-scroll[data-tracker-content-constrained="true"] [class~="leading-[0.95rem]"] {
+  line-height: calc(0.95rem * var(--tracker-panel-font-scale));
+}
+
+.mari-tracker-panel-scroll[data-tracker-content-constrained="true"] [class~="leading-[1.35rem]"] {
+  line-height: calc(1.35rem * var(--tracker-panel-font-scale));
+}
+
+.mari-tracker-panel-scroll[data-tracker-content-constrained="true"] :is(.leading-3, .leading-4, .leading-5, .leading-6) {
+  line-height: calc(var(--tracker-panel-base-line-height) * var(--tracker-panel-font-scale));
+}
+
+.mari-tracker-panel-scroll[data-tracker-content-constrained="true"] .leading-3 {
+  --tracker-panel-base-line-height: 0.75rem;
+}
+
+.mari-tracker-panel-scroll[data-tracker-content-constrained="true"] .leading-4 {
+  --tracker-panel-base-line-height: 1rem;
+}
+
+.mari-tracker-panel-scroll[data-tracker-content-constrained="true"] .leading-5 {
+  --tracker-panel-base-line-height: 1.25rem;
+}
+
+.mari-tracker-panel-scroll[data-tracker-content-constrained="true"] .leading-6 {
+  --tracker-panel-base-line-height: 1.5rem;
+}
+
 .mari-tracker-panel-scroll::-webkit-scrollbar {
   width: 0.25rem;
 }

--- a/scripts/regressions/open-issues.regression.ts
+++ b/scripts/regressions/open-issues.regression.ts
@@ -31,6 +31,11 @@ import {
   shouldExecuteQuickPostAsCommand,
 } from "../../packages/client/src/lib/slash-commands.js";
 import { getAvatarCropStyle } from "../../packages/client/src/lib/utils.js";
+import { resolveEchoChamberTopLayout } from "../../packages/client/src/lib/echo-chamber-layout.js";
+import {
+  resolveTrackerPanelContentScale,
+  resolveTrackerPanelDesktopWidth,
+} from "../../packages/client/src/lib/tracker-panel-layout.js";
 import { getApiErrorMessage } from "../../packages/client/src/lib/api-client.js";
 import { parseCustomParametersDraft } from "../../packages/client/src/lib/generation-custom-parameters.js";
 import { parseGenerationParameterDraft } from "../../packages/client/src/lib/generation-parameter-draft.js";
@@ -2191,5 +2196,88 @@ try {
   if (originalCustomRepositoryFlag === undefined) delete process.env.ENABLE_CUSTOM_AGENT_REPOS;
   else process.env.ENABLE_CUSTOM_AGENT_REPOS = originalCustomRepositoryFlag;
 }
+
+const unstackedEchoLayout = resolveEchoChamberTopLayout({
+  baseTop: 96,
+  containerTop: 40,
+  containerBottom: 840,
+  viewportBottom: 800,
+  bottomClearance: 88,
+});
+assert.deepEqual(unstackedEchoLayout, { top: 96, maxHeight: 576 });
+const stackedEchoLayout = resolveEchoChamberTopLayout({
+  baseTop: 96,
+  containerTop: 40,
+  containerBottom: 840,
+  viewportBottom: 800,
+  bottomClearance: 88,
+  trackerBottom: 420,
+  stackGap: 8,
+});
+assert.deepEqual(stackedEchoLayout, { top: 388, maxHeight: 284 });
+assert.equal(
+  40 + stackedEchoLayout.top + stackedEchoLayout.maxHeight + 88,
+  800,
+  "A stacked Echo Chamber must remain inside the visible roleplay area",
+);
+assert.equal(
+  resolveEchoChamberTopLayout({
+    baseTop: 96,
+    containerTop: 40,
+    containerBottom: 840,
+    viewportBottom: 800,
+    bottomClearance: 88,
+    trackerBottom: 760,
+    stackGap: 8,
+  }).maxHeight,
+  0,
+  "Echo Chamber height must not become negative when the Tracker consumes the available corner",
+);
+assert.equal(
+  resolveTrackerPanelDesktopWidth({
+    preferredWidth: 340,
+    mainLeft: 280,
+    mainRight: 1920,
+    chatColumnLeft: 636,
+    chatColumnRight: 1564,
+    side: "left",
+    gap: 8,
+  }),
+  340,
+  "The Tracker should retain its selected width when it fits beside the chat column",
+);
+assert.equal(
+  resolveTrackerPanelDesktopWidth({
+    preferredWidth: 420,
+    mainLeft: 280,
+    mainRight: 1480,
+    chatColumnLeft: 416,
+    chatColumnRight: 1344,
+    side: "left",
+    gap: 8,
+  }),
+  128,
+  "The Tracker should shrink to the narrower left chat gutter",
+);
+assert.equal(
+  resolveTrackerPanelDesktopWidth({
+    preferredWidth: 340,
+    mainLeft: 0,
+    mainRight: 1200,
+    chatColumnLeft: 136,
+    chatColumnRight: 1064,
+    side: "right",
+    gap: 8,
+  }),
+  128,
+  "The Tracker should use the matching right chat gutter",
+);
+assert.equal(resolveTrackerPanelContentScale(340, 340), 1);
+assert.equal(resolveTrackerPanelContentScale(340, 255), 0.75);
+assert.equal(
+  resolveTrackerPanelContentScale(420, 128),
+  0.65,
+  "Severely constrained Tracker contents should reflow before their text becomes unreadably small",
+);
 
 console.info("Open-issue regressions passed.");


### PR DESCRIPTION
## Linked issue

No linked issue. This layout regression was reported directly during maintainer testing. A tracking issue should be opened before this draft is promoted if project policy requires one.

## Why this change

On desktop, opening the Tracker Panel could shift the centered Roleplay transcript and composer sideways. When the available side gutter became narrower than the selected Tracker width, the panel could also be clipped after its contents were scaled as a larger rendering canvas.

When Tracker and Echo Chamber occupied the same top corner, Echo Chamber independently used that corner and overlapped Tracker instead of stacking beneath it. It could then extend below the visible chat area.

## What changed

- Resolve the desktop Tracker width from the actual free gutter beside the centered Roleplay chat column.
- Keep the transcript and composer stationary when Tracker opens.
- Scale constrained Tracker typography in normal document flow and wrap its settings controls, avoiding clipped scaled canvases.
- Stack a same-side top Echo Chamber below the open Tracker and constrain Echo to the remaining visible height.
- Add deterministic layout regressions and a Chromium smoke test for narrow desktop gutter behavior.
- Document the fixes in the changelog.

## Validation

- [ ] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed `CONTRIBUTING.md`

Automated validation completed:

- `pnpm check`
- `pnpm regression:issues`
- `pnpm exec playwright test e2e/core-flows.e2e.ts --project=desktop-chromium --grep "desktop Tracker stays"`

### Manual verification notes

- The reporter confirmed the final desktop behavior looks correct.
- Before promotion from draft, manually verify both left and right top corners with Tracker and Echo Chamber open together.
- Manually verify compact, standard, and expanded Tracker widths across light and dark themes.
- Manually verify that bottom-corner Echo placement and mobile layouts remain unchanged.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Version/release files updated (only if this PR includes a version bump)

The changelog is updated. No version-bearing files changed.

## UI evidence

The focused Chromium regression exercises a 1200 × 900 desktop viewport and verifies that:

- the chat column does not move when Tracker opens;
- Tracker remains inside the available gutter;
- constrained typography uses the expected scale;
- the Tracker settings toolbar introduces no horizontal overflow.

No screenshot is attached to this draft.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented the desktop Tracker Panel from shifting or clipping the centered Roleplay chat column.
  * Improved Tracker Panel responsiveness, including control wrapping and proportional text scaling.
  * Positioned the Echo Chamber below an open Tracker Panel and constrained its height to prevent overlap or off-screen content.

* **Tests**
  * Added automated coverage for Tracker Panel sizing, positioning, scaling, settings visibility, and Echo Chamber layout behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->