### PR TITLE
fix: resolve assigned generation and sprite bugs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 
 ### Fixed
 
+- Made Conversation setup connect enabled Illustrator selfies to the default image-generation connection instead of leaving Generated Selfies inactive (#3880).
+- Recovered every Noodle timeline collection when local models return adjacent JSON objects, preserving posts and interactions alongside follows instead of parsing only the final object (#3881).
+- Routed Character and Persona sprite downloads through the Android shell's native file saver and stacked the sprite Upload action beneath its expression field on mobile so it stays inside the card (#3884).
 - Kept the desktop Tracker Panel out of the centered Roleplay chat column, shrinking it, responsively reflowing its controls, and proportionally scaling its typography to the available side gutter on narrower screens instead of shifting messages and the composer sideways or clipping its contents.
 - Stacked a top-corner Echo Chamber below the open Tracker Panel on the same desktop side and constrained its message area to the remaining visible height instead of letting the two panels overlap or spill below the screen.
 - Kept each historical user turn under the Persona that sent it when Name Prefix History is enabled, instead of relabeling every user message with the currently selected Persona.

--- a/android/app/src/main/java/com/marinara/engine/MainActivity.java
+++ b/android/app/src/main/java/com/marinara/engine/MainActivity.java
@@ -709,6 +709,7 @@ public class MainActivity extends Activity {
             runOnUiThread(() -> showNativeMessageNotification(title, body, tag));
         }
 
+        /** Saves a base64-encoded web download through Android's native storage APIs. */
         @JavascriptInterface
         public void saveFile(String base64Data, String mimeType, String filename) {
             new Thread(() -> {
@@ -754,12 +755,14 @@ public class MainActivity extends Activity {
         }
     }
 
+    /** Removes path separators and reserved characters from a browser-provided filename. */
     private String sanitizeDownloadFilename(String filename) {
         String safe = filename == null ? "" : filename.trim().replaceAll("[\\\\/:*?\"<>|]", "_");
         if (safe.isEmpty()) safe = "marinara-download";
         return safe.length() > 120 ? safe.substring(0, 120) : safe;
     }
 
+    /** Returns a safe MIME type when the browser does not provide a valid media type. */
     private String normalizeDownloadMimeType(String mimeType) {
         if (mimeType == null || !mimeType.matches("^[A-Za-z0-9.+-]+/[A-Za-z0-9.+-]+$")) {
             return "application/octet-stream";
@@ -767,11 +770,13 @@ public class MainActivity extends Activity {
         return mimeType;
     }
 
+    /** Produces a user-facing fallback when an exception has no message. */
     private String safeErrorMessage(Exception error) {
         String message = error.getMessage();
         return message == null || message.trim().isEmpty() ? error.getClass().getSimpleName() : message;
     }
 
+    /** Writes a download into the app's Pictures or Downloads collection on Android 10 and newer. */
     private void saveFileToMediaStore(byte[] data, String mimeType, String filename) throws Exception {
         ContentResolver resolver = getContentResolver();
         boolean isImage = mimeType.startsWith("image/");
@@ -808,6 +813,7 @@ public class MainActivity extends Activity {
         ).show());
     }
 
+    /** Opens Android's document picker to save a download on Android 7 through 9. */
     private void beginLegacyFileSave(byte[] data, String mimeType, String filename) {
         if (pendingFileSaveData != null) {
             Toast.makeText(this, "Finish saving the current file first.", Toast.LENGTH_SHORT).show();

--- a/android/app/src/main/java/com/marinara/engine/MainActivity.java
+++ b/android/app/src/main/java/com/marinara/engine/MainActivity.java
@@ -10,6 +10,8 @@ import android.app.PendingIntent;
 import android.content.ActivityNotFoundException;
 import android.content.ClipData;
 import android.content.ClipboardManager;
+import android.content.ContentResolver;
+import android.content.ContentValues;
 import android.content.Context;
 import android.content.Intent;
 import android.content.pm.PackageManager;
@@ -17,9 +19,12 @@ import android.content.pm.PackageInstaller;
 import android.net.Uri;
 import android.os.Build;
 import android.os.Bundle;
+import android.os.Environment;
 import android.os.Handler;
 import android.os.Looper;
+import android.provider.MediaStore;
 import android.provider.Settings;
+import android.util.Base64;
 import android.view.View;
 import android.view.Window;
 import android.view.WindowManager;
@@ -56,6 +61,7 @@ public class MainActivity extends Activity {
     private static final int UNKNOWN_APP_SOURCES_REQUEST = 1003;
     private static final int TERMUX_INSTALL_STATUS_REQUEST = 1004;
     private static final int NOTIFICATION_PERMISSION_REQUEST = 1005;
+    private static final int FILE_SAVE_REQUEST = 1006;
     private static final String NOTIFICATION_PERMISSION_PREFS = "marinara_notification_permission";
     private static final String NOTIFICATION_PERMISSION_REQUESTED = "requested";
     private static final String MESSAGE_NOTIFICATION_CHANNEL_ID = "marinara_messages";
@@ -76,6 +82,8 @@ public class MainActivity extends Activity {
     private ProgressBar spinner;
     private TextView statusText;
     private ValueCallback<Uri[]> fileUploadCallback;
+    private byte[] pendingFileSaveData;
+    private String pendingFileSaveName;
     private boolean isDownloadingTermux;
     private boolean pendingStartAfterTermuxInstall;
     private boolean isCheckingServer;
@@ -702,6 +710,28 @@ public class MainActivity extends Activity {
         }
 
         @JavascriptInterface
+        public void saveFile(String base64Data, String mimeType, String filename) {
+            new Thread(() -> {
+                try {
+                    byte[] data = Base64.decode(base64Data, Base64.DEFAULT);
+                    String safeFilename = sanitizeDownloadFilename(filename);
+                    String safeMimeType = normalizeDownloadMimeType(mimeType);
+                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+                        saveFileToMediaStore(data, safeMimeType, safeFilename);
+                    } else {
+                        runOnUiThread(() -> beginLegacyFileSave(data, safeMimeType, safeFilename));
+                    }
+                } catch (Exception error) {
+                    runOnUiThread(() -> Toast.makeText(
+                            MainActivity.this,
+                            "Could not save the file: " + safeErrorMessage(error),
+                            Toast.LENGTH_LONG
+                    ).show());
+                }
+            }).start();
+        }
+
+        @JavascriptInterface
         public void openConsole() {
             runOnUiThread(() -> {
                 if (!isTermuxInstalled()) {
@@ -722,6 +752,78 @@ public class MainActivity extends Activity {
                 }
             });
         }
+    }
+
+    private String sanitizeDownloadFilename(String filename) {
+        String safe = filename == null ? "" : filename.trim().replaceAll("[\\\\/:*?\"<>|]", "_");
+        if (safe.isEmpty()) safe = "marinara-download";
+        return safe.length() > 120 ? safe.substring(0, 120) : safe;
+    }
+
+    private String normalizeDownloadMimeType(String mimeType) {
+        if (mimeType == null || !mimeType.matches("^[A-Za-z0-9.+-]+/[A-Za-z0-9.+-]+$")) {
+            return "application/octet-stream";
+        }
+        return mimeType;
+    }
+
+    private String safeErrorMessage(Exception error) {
+        String message = error.getMessage();
+        return message == null || message.trim().isEmpty() ? error.getClass().getSimpleName() : message;
+    }
+
+    private void saveFileToMediaStore(byte[] data, String mimeType, String filename) throws Exception {
+        ContentResolver resolver = getContentResolver();
+        boolean isImage = mimeType.startsWith("image/");
+        Uri collection = isImage
+                ? MediaStore.Images.Media.getContentUri(MediaStore.VOLUME_EXTERNAL_PRIMARY)
+                : MediaStore.Downloads.getContentUri(MediaStore.VOLUME_EXTERNAL_PRIMARY);
+        String directory = (isImage ? Environment.DIRECTORY_PICTURES : Environment.DIRECTORY_DOWNLOADS)
+                + "/Marinara";
+        ContentValues values = new ContentValues();
+        values.put(MediaStore.MediaColumns.DISPLAY_NAME, filename);
+        values.put(MediaStore.MediaColumns.MIME_TYPE, mimeType);
+        values.put(MediaStore.MediaColumns.RELATIVE_PATH, directory);
+        values.put(MediaStore.MediaColumns.IS_PENDING, 1);
+        Uri target = resolver.insert(collection, values);
+        if (target == null) throw new IllegalStateException("Android did not create a destination file");
+
+        try {
+            try (OutputStream output = resolver.openOutputStream(target)) {
+                if (output == null) throw new IllegalStateException("Android did not open the destination file");
+                output.write(data);
+            }
+            ContentValues complete = new ContentValues();
+            complete.put(MediaStore.MediaColumns.IS_PENDING, 0);
+            resolver.update(target, complete, null, null);
+        } catch (Exception error) {
+            resolver.delete(target, null, null);
+            throw error;
+        }
+
+        runOnUiThread(() -> Toast.makeText(
+                MainActivity.this,
+                "Saved " + filename + " to " + directory,
+                Toast.LENGTH_LONG
+        ).show());
+    }
+
+    private void beginLegacyFileSave(byte[] data, String mimeType, String filename) {
+        if (pendingFileSaveData != null) {
+            Toast.makeText(this, "Finish saving the current file first.", Toast.LENGTH_SHORT).show();
+            return;
+        }
+        Intent intent = new Intent(Intent.ACTION_CREATE_DOCUMENT);
+        intent.addCategory(Intent.CATEGORY_OPENABLE);
+        intent.setType(mimeType);
+        intent.putExtra(Intent.EXTRA_TITLE, filename);
+        if (intent.resolveActivity(getPackageManager()) == null) {
+            Toast.makeText(this, "No Android file picker is available.", Toast.LENGTH_LONG).show();
+            return;
+        }
+        pendingFileSaveData = data;
+        pendingFileSaveName = filename;
+        startActivityForResult(intent, FILE_SAVE_REQUEST);
     }
 
     private void createMessageNotificationChannel() {
@@ -880,6 +982,31 @@ public class MainActivity extends Activity {
                 Uri[] result = WebChromeClient.FileChooserParams.parseResult(resultCode, data);
                 fileUploadCallback.onReceiveValue(result);
                 fileUploadCallback = null;
+            }
+        } else if (requestCode == FILE_SAVE_REQUEST) {
+            byte[] fileData = pendingFileSaveData;
+            String fileName = pendingFileSaveName;
+            pendingFileSaveData = null;
+            pendingFileSaveName = null;
+            Uri destination = resultCode == RESULT_OK && data != null ? data.getData() : null;
+            if (fileData != null && destination != null) {
+                new Thread(() -> {
+                    try (OutputStream output = getContentResolver().openOutputStream(destination)) {
+                        if (output == null) throw new IllegalStateException("Android did not open the destination file");
+                        output.write(fileData);
+                        runOnUiThread(() -> Toast.makeText(
+                                MainActivity.this,
+                                "Saved " + fileName,
+                                Toast.LENGTH_LONG
+                        ).show());
+                    } catch (Exception error) {
+                        runOnUiThread(() -> Toast.makeText(
+                                MainActivity.this,
+                                "Could not save the file: " + safeErrorMessage(error),
+                                Toast.LENGTH_LONG
+                        ).show());
+                    }
+                }).start();
             }
         } else if (requestCode == UNKNOWN_APP_SOURCES_REQUEST) {
             if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O || getPackageManager().canRequestPackageInstalls()) {

--- a/packages/client/src/components/characters/CharacterEditor.tsx
+++ b/packages/client/src/components/characters/CharacterEditor.tsx
@@ -3281,8 +3281,9 @@ function SpritesTab({
     e.target.value = "";
   };
 
+  /** Open the sprite picker unless another single-file upload is already running. */
   const startUpload = (expression: string) => {
-    if (!expression) return;
+    if (uploading || !expression) return;
     pendingExpressionRef.current = expression;
     fileInputRef.current?.click();
   };

--- a/packages/client/src/components/characters/CharacterEditor.tsx
+++ b/packages/client/src/components/characters/CharacterEditor.tsx
@@ -102,6 +102,7 @@ import {
 import { extractColorsFromImage } from "../../lib/avatar-color-extraction";
 import { HelpTooltip } from "../ui/HelpTooltip";
 import { api } from "../../lib/api-client";
+import { saveBlobToDevice } from "../../lib/file-download";
 import { ColorPicker } from "../ui/ColorPicker";
 import { MacroTextarea } from "../ui/MacroTextarea";
 import { Modal } from "../ui/Modal";
@@ -3347,20 +3348,16 @@ function SpritesTab({
   }, [characterId, deleteSprite, visibleSprites]);
 
   const downloadSpriteFile = useCallback(async (sprite: SpriteInfo) => {
-    const response = await fetch(sprite.url);
-    if (!response.ok) {
-      throw new Error(`Failed to download ${sprite.expression}`);
-    }
+    try {
+      const response = await fetch(sprite.url);
+      if (!response.ok) {
+        throw new Error(`Failed to download ${sprite.expression}`);
+      }
 
-    const blob = await response.blob();
-    const objectUrl = URL.createObjectURL(blob);
-    const anchor = document.createElement("a");
-    anchor.href = objectUrl;
-    anchor.download = sprite.filename || `${sprite.expression}.png`;
-    document.body.appendChild(anchor);
-    anchor.click();
-    anchor.remove();
-    URL.revokeObjectURL(objectUrl);
+      await saveBlobToDevice(await response.blob(), sprite.filename || `${sprite.expression}.png`);
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : "Failed to download sprite.");
+    }
   }, []);
 
   const handleExportSprites = useCallback(
@@ -3679,7 +3676,7 @@ function SpritesTab({
             {backgroundCleanupReason}
           </div>
         )}
-        <div className="flex gap-2">
+        <div className="flex flex-col gap-2 sm:flex-row">
           <input
             value={newExpression}
             onChange={(e) => setNewExpression(e.target.value)}
@@ -3688,7 +3685,7 @@ function SpritesTab({
                 ? "Pose name (e.g. idle, walk, battle_stance)…"
                 : "Expression name (e.g. happy, sad, angry)…"
             }
-            className="flex-1 rounded-xl border border-[var(--border)] bg-[var(--secondary)] px-3 py-2 text-sm outline-none focus:border-[var(--primary)]/40 focus:ring-1 focus:ring-[var(--primary)]/20"
+            className="min-w-0 flex-1 rounded-xl border border-[var(--border)] bg-[var(--secondary)] px-3 py-2 text-sm outline-none focus:border-[var(--primary)]/40 focus:ring-1 focus:ring-[var(--primary)]/20"
             onKeyDown={(e) => {
               if (e.key === "Enter" && newExpression.trim()) {
                 startUpload(normalizeExpressionForCategory(newExpression));
@@ -3699,7 +3696,7 @@ function SpritesTab({
             type="button"
             onClick={() => newExpression.trim() && startUpload(normalizeExpressionForCategory(newExpression))}
             disabled={!newExpression.trim() || uploading}
-            className="flex items-center gap-1.5 rounded-xl bg-[var(--primary)] px-4 py-2 text-xs font-medium text-[var(--primary-foreground)] shadow-sm transition-all hover:shadow-md disabled:opacity-40"
+            className="flex w-full items-center justify-center gap-1.5 rounded-xl bg-[var(--primary)] px-4 py-2 text-xs font-medium text-[var(--primary-foreground)] shadow-sm transition-all hover:shadow-md disabled:opacity-40 sm:w-auto"
           >
             <Plus size="0.8125rem" />
             Upload

--- a/packages/client/src/components/characters/CharacterEditor.tsx
+++ b/packages/client/src/components/characters/CharacterEditor.tsx
@@ -102,7 +102,7 @@ import {
 import { extractColorsFromImage } from "../../lib/avatar-color-extraction";
 import { HelpTooltip } from "../ui/HelpTooltip";
 import { api } from "../../lib/api-client";
-import { saveBlobToDevice } from "../../lib/file-download";
+import { downloadSpriteFile } from "../../lib/sprite-download";
 import { ColorPicker } from "../ui/ColorPicker";
 import { MacroTextarea } from "../ui/MacroTextarea";
 import { Modal } from "../ui/Modal";
@@ -3346,19 +3346,6 @@ function SpritesTab({
       setDeletingSprites(null);
     }
   }, [characterId, deleteSprite, visibleSprites]);
-
-  const downloadSpriteFile = useCallback(async (sprite: SpriteInfo) => {
-    try {
-      const response = await fetch(sprite.url);
-      if (!response.ok) {
-        throw new Error(`Failed to download ${sprite.expression}`);
-      }
-
-      await saveBlobToDevice(await response.blob(), sprite.filename || `${sprite.expression}.png`);
-    } catch (error) {
-      toast.error(error instanceof Error ? error.message : "Failed to download sprite.");
-    }
-  }, []);
 
   const handleExportSprites = useCallback(
     async (spritesToExport: SpriteInfo[], modeLabel: "visible" | "all") => {

--- a/packages/client/src/components/chat/ChatSetupWizard.tsx
+++ b/packages/client/src/components/chat/ChatSetupWizard.tsx
@@ -704,6 +704,10 @@ function ConversationQuickSetup({ chat, onFinish }: ChatSetupWizardProps) {
       return !agentId || installedAgentIds.has(agentId);
     });
   }, [installedAgentIds]);
+  const availableConversationCommandIds = useMemo(
+    () => new Set(availableConversationCommandOptions.map((command) => command.id)),
+    [availableConversationCommandOptions],
+  );
   const hasConversationCommands = availableConversationCommandOptions.length > 0;
   const hasInstalledAgents = installedAgentIds.size > 0;
   const openDownloadAgents = useCallback(() => {
@@ -1038,7 +1042,7 @@ function ConversationQuickSetup({ chat, onFinish }: ChatSetupWizardProps) {
         : null;
     const selfieCommandEnabled =
       commandsEnabled &&
-      availableConversationCommandOptions.some((command) => command.id === "selfie") &&
+      availableConversationCommandIds.has("selfie") &&
       isConversationCommandToggleEnabled(conversationCommandToggles, "selfie");
     const selfieConnectionId = resolveConversationSelfieConnectionId({
       currentConnectionId: metadata.imageGenConnectionId,
@@ -1095,7 +1099,7 @@ function ConversationQuickSetup({ chat, onFinish }: ChatSetupWizardProps) {
     customConversationPromptEnabled,
     conversationSystemPromptDraft,
     baseConversationPrompt,
-    availableConversationCommandOptions,
+    availableConversationCommandIds,
     connectionOptions,
     metadata.imageGenConnectionId,
   ]);

--- a/packages/client/src/components/chat/ChatSetupWizard.tsx
+++ b/packages/client/src/components/chat/ChatSetupWizard.tsx
@@ -38,6 +38,7 @@ import { useChatStore } from "../../stores/chat.store";
 import { useSidecarStore } from "../../stores/sidecar.store";
 import { api } from "../../lib/api-client";
 import { appendLocalSidecarConnectionOption } from "../../lib/connection-filters";
+import { resolveConversationSelfieConnectionId } from "../../lib/conversation-selfie-setup";
 import { getAgentRunIntervalMeta } from "../../lib/agent-cadence";
 import { characterMatchesSearch, getCharacterTitle, parseCharacterDisplayData } from "../../lib/character-display";
 import { addSilentGreetingSwipes } from "../../lib/message-swipes";
@@ -215,6 +216,7 @@ type ConnectionSetupOption = {
   name: string;
   provider?: string;
   defaultParameters?: unknown;
+  defaultForAgents?: boolean | string;
 };
 
 function parseCharacterFolderIds(value: unknown): string[] {
@@ -1034,6 +1036,15 @@ function ConversationQuickSetup({ chat, onFinish }: ChatSetupWizardProps) {
       trimmedConversationSystemPrompt !== baseConversationPromptText
         ? trimmedConversationSystemPrompt
         : null;
+    const selfieCommandEnabled =
+      commandsEnabled &&
+      availableConversationCommandOptions.some((command) => command.id === "selfie") &&
+      isConversationCommandToggleEnabled(conversationCommandToggles, "selfie");
+    const selfieConnectionId = resolveConversationSelfieConnectionId({
+      currentConnectionId: metadata.imageGenConnectionId,
+      selfieCommandEnabled,
+      connections: connectionOptions,
+    });
     await updateMeta.mutateAsync({
       id: chat.id,
       autonomousMessages: autonomousEnabled,
@@ -1043,6 +1054,7 @@ function ConversationQuickSetup({ chat, onFinish }: ChatSetupWizardProps) {
       conversationSetupComplete: true,
       chatParameters: customizeParameters ? generationParameters : null,
       customSystemPrompt,
+      ...(selfieConnectionId ? { imageGenConnectionId: selfieConnectionId } : {}),
     });
     if (autonomousEnabled && generateSchedule) {
       setScheduleState("generating");
@@ -1083,6 +1095,9 @@ function ConversationQuickSetup({ chat, onFinish }: ChatSetupWizardProps) {
     customConversationPromptEnabled,
     conversationSystemPromptDraft,
     baseConversationPrompt,
+    availableConversationCommandOptions,
+    connectionOptions,
+    metadata.imageGenConnectionId,
   ]);
 
   const renderConnectionStep = () => (

--- a/packages/client/src/components/personas/PersonaEditor.tsx
+++ b/packages/client/src/components/personas/PersonaEditor.tsx
@@ -1631,8 +1631,9 @@ function PersonaSpritesTab({
     e.target.value = "";
   };
 
+  /** Open the sprite picker unless another single-file upload is already running. */
   const startUpload = (expression: string) => {
-    if (!expression) return;
+    if (uploading || !expression) return;
     pendingExpressionRef.current = expression;
     fileInputRef.current?.click();
   };

--- a/packages/client/src/components/personas/PersonaEditor.tsx
+++ b/packages/client/src/components/personas/PersonaEditor.tsx
@@ -72,6 +72,7 @@ import { ImageUploadDropzone } from "../ui/ImageUploadDropzone";
 import { CustomEmojiTagButton } from "../ui/CustomEmojiTagButton";
 import { CallClipGenerationModal } from "../ui/CallClipGenerationModal";
 import { api } from "../../lib/api-client";
+import { saveBlobToDevice } from "../../lib/file-download";
 import { parseTrackerCardColorConfig, serializeTrackerCardColorConfig } from "../../lib/tracker-card-colors";
 import { estimateTextTokens, formatEstimatedTokens } from "../../lib/character-token-count";
 import {
@@ -1689,20 +1690,16 @@ function PersonaSpritesTab({
   }, [deleteSprite, personaId, visibleSprites]);
 
   const downloadSpriteFile = useCallback(async (sprite: SpriteInfo) => {
-    const response = await fetch(sprite.url);
-    if (!response.ok) {
-      throw new Error(`Failed to download ${sprite.expression}`);
-    }
+    try {
+      const response = await fetch(sprite.url);
+      if (!response.ok) {
+        throw new Error(`Failed to download ${sprite.expression}`);
+      }
 
-    const blob = await response.blob();
-    const objectUrl = URL.createObjectURL(blob);
-    const anchor = document.createElement("a");
-    anchor.href = objectUrl;
-    anchor.download = sprite.filename || `${sprite.expression}.png`;
-    document.body.appendChild(anchor);
-    anchor.click();
-    anchor.remove();
-    URL.revokeObjectURL(objectUrl);
+      await saveBlobToDevice(await response.blob(), sprite.filename || `${sprite.expression}.png`);
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : "Failed to download sprite.");
+    }
   }, []);
 
   const handleExportSprites = useCallback(
@@ -2020,7 +2017,7 @@ function PersonaSpritesTab({
             {backgroundCleanupReason}
           </div>
         )}
-        <div className="flex gap-2">
+        <div className="flex flex-col gap-2 sm:flex-row">
           <input
             value={newExpression}
             onChange={(e) => setNewExpression(e.target.value)}
@@ -2029,7 +2026,7 @@ function PersonaSpritesTab({
                 ? "Pose name (e.g. idle, walk, battle_stance)…"
                 : "Expression name (e.g. happy, sad, angry)…"
             }
-            className="flex-1 rounded-xl border border-[var(--border)] bg-[var(--secondary)] px-3 py-2 text-sm outline-none focus:border-[var(--primary)]/40 focus:ring-1 focus:ring-[var(--primary)]/20"
+            className="min-w-0 flex-1 rounded-xl border border-[var(--border)] bg-[var(--secondary)] px-3 py-2 text-sm outline-none focus:border-[var(--primary)]/40 focus:ring-1 focus:ring-[var(--primary)]/20"
             onKeyDown={(e) => {
               if (e.key === "Enter" && newExpression.trim()) {
                 startUpload(normalizeExpressionForCategory(newExpression));
@@ -2040,7 +2037,7 @@ function PersonaSpritesTab({
             type="button"
             onClick={() => newExpression.trim() && startUpload(normalizeExpressionForCategory(newExpression))}
             disabled={!newExpression.trim() || uploading}
-            className="flex items-center gap-1.5 rounded-xl bg-[var(--primary)] px-4 py-2 text-xs font-medium text-[var(--primary-foreground)] shadow-sm transition-all hover:shadow-md disabled:opacity-40"
+            className="flex w-full items-center justify-center gap-1.5 rounded-xl bg-[var(--primary)] px-4 py-2 text-xs font-medium text-[var(--primary-foreground)] shadow-sm transition-all hover:shadow-md disabled:opacity-40 sm:w-auto"
           >
             <Plus size="0.8125rem" />
             Upload

--- a/packages/client/src/components/personas/PersonaEditor.tsx
+++ b/packages/client/src/components/personas/PersonaEditor.tsx
@@ -72,7 +72,7 @@ import { ImageUploadDropzone } from "../ui/ImageUploadDropzone";
 import { CustomEmojiTagButton } from "../ui/CustomEmojiTagButton";
 import { CallClipGenerationModal } from "../ui/CallClipGenerationModal";
 import { api } from "../../lib/api-client";
-import { saveBlobToDevice } from "../../lib/file-download";
+import { downloadSpriteFile } from "../../lib/sprite-download";
 import { parseTrackerCardColorConfig, serializeTrackerCardColorConfig } from "../../lib/tracker-card-colors";
 import { estimateTextTokens, formatEstimatedTokens } from "../../lib/character-token-count";
 import {
@@ -1688,19 +1688,6 @@ function PersonaSpritesTab({
       setDeletingSprites(null);
     }
   }, [deleteSprite, personaId, visibleSprites]);
-
-  const downloadSpriteFile = useCallback(async (sprite: SpriteInfo) => {
-    try {
-      const response = await fetch(sprite.url);
-      if (!response.ok) {
-        throw new Error(`Failed to download ${sprite.expression}`);
-      }
-
-      await saveBlobToDevice(await response.blob(), sprite.filename || `${sprite.expression}.png`);
-    } catch (error) {
-      toast.error(error instanceof Error ? error.message : "Failed to download sprite.");
-    }
-  }, []);
 
   const handleExportSprites = useCallback(
     async (spritesToExport: SpriteInfo[], modeLabel: "visible" | "all") => {

--- a/packages/client/src/lib/conversation-selfie-setup.ts
+++ b/packages/client/src/lib/conversation-selfie-setup.ts
@@ -4,6 +4,7 @@ export type ConversationSelfieConnectionOption = {
   defaultForAgents?: boolean | string;
 };
 
+/** Resolve the image connection that Conversation setup should persist for enabled selfies. */
 export function resolveConversationSelfieConnectionId(input: {
   currentConnectionId: unknown;
   selfieCommandEnabled: boolean;
@@ -18,7 +19,7 @@ export function resolveConversationSelfieConnectionId(input: {
     input.connections.find(
       (connection) =>
         connection.provider === "image_generation" &&
-        (connection.defaultForAgents === true || connection.defaultForAgents === "true"),
+        String(connection.defaultForAgents) === "true",
     )?.id ?? null
   );
 }

--- a/packages/client/src/lib/conversation-selfie-setup.ts
+++ b/packages/client/src/lib/conversation-selfie-setup.ts
@@ -1,0 +1,24 @@
+export type ConversationSelfieConnectionOption = {
+  id: string;
+  provider?: string;
+  defaultForAgents?: boolean | string;
+};
+
+export function resolveConversationSelfieConnectionId(input: {
+  currentConnectionId: unknown;
+  selfieCommandEnabled: boolean;
+  connections: readonly ConversationSelfieConnectionOption[];
+}): string | null {
+  const currentConnectionId =
+    typeof input.currentConnectionId === "string" ? input.currentConnectionId.trim() : "";
+  if (currentConnectionId) return currentConnectionId;
+  if (!input.selfieCommandEnabled) return null;
+
+  return (
+    input.connections.find(
+      (connection) =>
+        connection.provider === "image_generation" &&
+        (connection.defaultForAgents === true || connection.defaultForAgents === "true"),
+    )?.id ?? null
+  );
+}

--- a/packages/client/src/lib/file-download.ts
+++ b/packages/client/src/lib/file-download.ts
@@ -2,11 +2,13 @@ type MarinaraAndroidFileBridge = {
   saveFile?: (base64Data: string, mimeType: string, filename: string) => void;
 };
 
+/** Read the optional Android shell file bridge from the current browser window. */
 function getAndroidFileBridge(): MarinaraAndroidFileBridge | null {
   if (typeof window === "undefined") return null;
   return (window as Window & { MarinaraAndroid?: MarinaraAndroidFileBridge }).MarinaraAndroid ?? null;
 }
 
+/** Encode binary file data for the Android JavaScript bridge without overflowing the call stack. */
 function arrayBufferToBase64(buffer: ArrayBuffer): string {
   const bytes = new Uint8Array(buffer);
   const chunkSize = 0x8000;
@@ -17,6 +19,7 @@ function arrayBufferToBase64(buffer: ArrayBuffer): string {
   return window.btoa(binary);
 }
 
+/** Trigger the standard browser download path and retain the object URL long enough for mobile browsers. */
 function triggerBrowserDownload(blob: Blob, filename: string) {
   const objectUrl = URL.createObjectURL(blob);
   const anchor = document.createElement("a");

--- a/packages/client/src/lib/file-download.ts
+++ b/packages/client/src/lib/file-download.ts
@@ -1,0 +1,42 @@
+type MarinaraAndroidFileBridge = {
+  saveFile?: (base64Data: string, mimeType: string, filename: string) => void;
+};
+
+function getAndroidFileBridge(): MarinaraAndroidFileBridge | null {
+  if (typeof window === "undefined") return null;
+  return (window as Window & { MarinaraAndroid?: MarinaraAndroidFileBridge }).MarinaraAndroid ?? null;
+}
+
+function arrayBufferToBase64(buffer: ArrayBuffer): string {
+  const bytes = new Uint8Array(buffer);
+  const chunkSize = 0x8000;
+  let binary = "";
+  for (let offset = 0; offset < bytes.length; offset += chunkSize) {
+    binary += String.fromCharCode(...bytes.subarray(offset, offset + chunkSize));
+  }
+  return window.btoa(binary);
+}
+
+function triggerBrowserDownload(blob: Blob, filename: string) {
+  const objectUrl = URL.createObjectURL(blob);
+  const anchor = document.createElement("a");
+  anchor.href = objectUrl;
+  anchor.download = filename;
+  anchor.rel = "noopener";
+  document.body.appendChild(anchor);
+  anchor.click();
+  anchor.remove();
+  window.setTimeout(() => URL.revokeObjectURL(objectUrl), 60_000);
+}
+
+/** Save a fetched file through the Android shell when available, or through the browser otherwise. */
+export async function saveBlobToDevice(blob: Blob, filename: string): Promise<void> {
+  const bridge = getAndroidFileBridge();
+  if (typeof bridge?.saveFile === "function") {
+    const base64Data = arrayBufferToBase64(await blob.arrayBuffer());
+    bridge.saveFile(base64Data, blob.type || "application/octet-stream", filename);
+    return;
+  }
+
+  triggerBrowserDownload(blob, filename);
+}

--- a/packages/client/src/lib/sprite-download.ts
+++ b/packages/client/src/lib/sprite-download.ts
@@ -1,0 +1,22 @@
+import { toast } from "sonner";
+import { saveBlobToDevice } from "./file-download";
+
+export type DownloadableSprite = {
+  url: string;
+  filename?: string | null;
+  expression: string;
+};
+
+/** Fetch and save one sprite while reporting any failure through the shared app toast. */
+export async function downloadSpriteFile(sprite: DownloadableSprite): Promise<void> {
+  try {
+    const response = await fetch(sprite.url);
+    if (!response.ok) {
+      throw new Error(`Failed to download ${sprite.expression}`);
+    }
+
+    await saveBlobToDevice(await response.blob(), sprite.filename || `${sprite.expression}.png`);
+  } catch (error) {
+    toast.error(error instanceof Error ? error.message : "Failed to download sprite.");
+  }
+}

--- a/packages/server/src/services/game/jsonish.ts
+++ b/packages/server/src/services/game/jsonish.ts
@@ -102,7 +102,7 @@ function collectBalancedJsonRegions(raw: string): Array<{ start: number; end: nu
   return regions;
 }
 
-function parseEmbeddedJson(raw: string): unknown | undefined {
+function collectIndependentJsonRegions(raw: string): Array<{ start: number; end: number }> {
   const regions = collectBalancedJsonRegions(raw).sort(
     (left, right) => left.start - right.start || right.end - left.end,
   );
@@ -113,6 +113,11 @@ function parseEmbeddedJson(raw: string): unknown | undefined {
     independentRegions.push(region);
     enclosingEnd = region.end;
   }
+  return independentRegions;
+}
+
+function parseEmbeddedJson(raw: string): unknown | undefined {
+  const independentRegions = collectIndependentJsonRegions(raw);
   independentRegions.sort((left, right) => right.start - left.start);
   for (const region of independentRegions) {
     try {
@@ -330,6 +335,29 @@ export function parseGameJsonish(raw: string): unknown {
   } catch {
     return unwrapJsonString(JSON.parse(candidate));
   }
+}
+
+/**
+ * Parse every independent JSON-ish value emitted in one model response. Some
+ * local models serialize a requested object as adjacent collection fragments
+ * instead of one enclosing object. Callers that support fragment merging can
+ * use this without changing the single-value behavior of parseGameJsonish.
+ */
+export function parseGameJsonishSequence(raw: string): unknown[] {
+  const unfenced = stripFences(raw.trim());
+  const regions = collectIndependentJsonRegions(unfenced).sort((left, right) => left.start - right.start);
+  if (regions.length <= 1) return [parseGameJsonish(raw)];
+
+  const parsed: unknown[] = [];
+  for (const region of regions) {
+    try {
+      parsed.push(parseGameJsonish(unfenced.slice(region.start, region.end)));
+    } catch {
+      // Keep other complete fragments usable. If every fragment fails, the
+      // normal parser below retains its existing error and repair behavior.
+    }
+  }
+  return parsed.length > 0 ? parsed : [parseGameJsonish(raw)];
 }
 
 export function jsonishLooksTruncated(raw: string): boolean {

--- a/packages/server/src/services/game/jsonish.ts
+++ b/packages/server/src/services/game/jsonish.ts
@@ -102,6 +102,7 @@ function collectBalancedJsonRegions(raw: string): Array<{ start: number; end: nu
   return regions;
 }
 
+/** Return top-level balanced JSON regions in source order, excluding nested regions. */
 function collectIndependentJsonRegions(raw: string): Array<{ start: number; end: number }> {
   const regions = collectBalancedJsonRegions(raw).sort(
     (left, right) => left.start - right.start || right.end - left.end,
@@ -345,7 +346,7 @@ export function parseGameJsonish(raw: string): unknown {
  */
 export function parseGameJsonishSequence(raw: string): unknown[] {
   const unfenced = stripFences(raw.trim());
-  const regions = collectIndependentJsonRegions(unfenced).sort((left, right) => left.start - right.start);
+  const regions = collectIndependentJsonRegions(unfenced);
   if (regions.length <= 1) return [parseGameJsonish(raw)];
 
   const parsed: unknown[] = [];

--- a/packages/server/src/services/noodle/noodle-generated-refresh.ts
+++ b/packages/server/src/services/noodle/noodle-generated-refresh.ts
@@ -6,6 +6,7 @@ import {
   noodleGeneratedRefreshSchema,
   type NoodleGeneratedRefresh,
 } from "@marinara-engine/shared";
+import { parseGameJsonishSequence } from "../game/jsonish.js";
 import { normalizeNoodleHandle } from "./noodle-handle.js";
 
 type RefreshCollection = keyof NoodleGeneratedRefresh;
@@ -82,6 +83,41 @@ export function parseNoodleGeneratedRefresh(value: unknown): {
         rejected.push({ collection, index, issueCount: parsed.error.issues.length });
       }
     });
+  }
+
+  return { refresh, rejected };
+}
+
+/**
+ * Recover a complete refresh from adjacent JSON objects. Local models
+ * sometimes emit one object per collection (posts, interactions, follows,
+ * digests) even though the prompt requests a single enclosing object.
+ */
+export function parseNoodleGeneratedRefreshResponse(raw: string): {
+  refresh: NoodleGeneratedRefresh;
+  rejected: RejectedNoodleGeneratedRefreshItem[];
+} {
+  const parsedValues = parseGameJsonishSequence(raw).flatMap((value) => (Array.isArray(value) ? value : [value]));
+  if (parsedValues.length === 1) return parseNoodleGeneratedRefresh(parsedValues[0]);
+
+  const refresh: NoodleGeneratedRefresh = { posts: [], interactions: [], follows: [], digests: [] };
+  const rejected: RejectedNoodleGeneratedRefreshItem[] = [];
+  const sourceOffsets: Record<RefreshCollection, number> = { posts: 0, interactions: 0, follows: 0, digests: 0 };
+
+  for (const value of parsedValues) {
+    const parsed = parseNoodleGeneratedRefresh(value);
+    for (const collection of Object.keys(collectionSchemas) as RefreshCollection[]) {
+      (refresh[collection] as unknown[]).push(...parsed.refresh[collection]);
+      const collectionRejected = parsed.rejected.filter((item) => item.collection === collection);
+      rejected.push(
+        ...collectionRejected.map((item) => ({
+          ...item,
+          index: item.index < 0 ? item.index : item.index + sourceOffsets[collection],
+        })),
+      );
+      sourceOffsets[collection] +=
+        parsed.refresh[collection].length + collectionRejected.filter((item) => item.index >= 0).length;
+    }
   }
 
   return { refresh, rejected };

--- a/packages/server/src/services/noodle/noodle-public-generation.service.ts
+++ b/packages/server/src/services/noodle/noodle-public-generation.service.ts
@@ -11,7 +11,6 @@ import { resolveBaseUrl } from "../generation/connection-base-url.js";
 import { resolveStoredChatOptions, resolveStoredMaxTokens } from "../generation/generation-parameters.js";
 import type { ImageCaptioningRuntime } from "../generation/image-captioning-runtime.js";
 import { clampGenerationMaxOutputTokens } from "../generation/output-token-limits.js";
-import { parseGameJsonish } from "../game/jsonish.js";
 import { withConnectionFallbackProvider } from "../llm/connection-fallback-provider.js";
 import type { ChatMessage } from "../llm/base-provider.js";
 import { createLLMProvider } from "../llm/provider-registry.js";
@@ -23,7 +22,7 @@ import { createGalleryStorage } from "../storage/gallery.storage.js";
 import { createNoodleStorage } from "../storage/noodle.storage.js";
 import { createPromptOverridesStorage } from "../storage/prompt-overrides.storage.js";
 import { commitGeneratedNoodleActivity, prepareGeneratedNoodleMedia } from "./noodle-generated-activity.service.js";
-import { parseNoodleGeneratedRefresh, validateNoodleGeneratedRefresh } from "./noodle-generated-refresh.js";
+import { parseNoodleGeneratedRefreshResponse, validateNoodleGeneratedRefresh } from "./noodle-generated-refresh.js";
 import { normalizeNoodleHandle } from "./noodle-handle.js";
 import { chooseNoodleParticipantAccounts, collectNoodlePriorityAccountIds } from "./noodle-participant-selection.js";
 import { buildRefreshPrompt } from "./noodle-public-prompt.service.js";
@@ -338,14 +337,14 @@ export function createPublicNoodleGenerationService(db: DB) {
           1,
           content,
         );
-        let parsedGenerated: ReturnType<typeof parseNoodleGeneratedRefresh> | null = null;
+        let parsedGenerated: ReturnType<typeof parseNoodleGeneratedRefreshResponse> | null = null;
         let retryReason: string | null = null;
         const allowedActorHandles = new Set(
           selectedParticipants.map((account) => normalizeNoodleHandle(account.handle)),
         );
         const knownHandles = new Set(activeAccounts.map((account) => normalizeNoodleHandle(account.handle)));
         try {
-          parsedGenerated = parseNoodleGeneratedRefresh(parseGameJsonish(content));
+          parsedGenerated = parseNoodleGeneratedRefreshResponse(content);
           retryReason = validateNoodleGeneratedRefresh(parsedGenerated.refresh, allowedActorHandles, knownHandles);
         } catch (error) {
           retryReason = `the response was not valid timeline JSON (${getErrorMessage(error)})`;
@@ -386,7 +385,7 @@ export function createPublicNoodleGenerationService(db: DB) {
           parsedGenerated = null;
           let correctedRetryReason: string | null = null;
           try {
-            parsedGenerated = parseNoodleGeneratedRefresh(parseGameJsonish(content));
+            parsedGenerated = parseNoodleGeneratedRefreshResponse(content);
             correctedRetryReason = validateNoodleGeneratedRefresh(
               parsedGenerated.refresh,
               allowedActorHandles,

--- a/scripts/regressions/noodle-prompt.regression.ts
+++ b/scripts/regressions/noodle-prompt.regression.ts
@@ -46,6 +46,7 @@ import { canCreateGeneratedNoodleInteraction } from "../../packages/server/src/s
 import { parseNoodleGeneratedProfiles } from "../../packages/server/src/services/noodle/noodle-generated-profiles.js";
 import {
   parseNoodleGeneratedRefresh,
+  parseNoodleGeneratedRefreshResponse,
   validateNoodleGeneratedRefresh,
 } from "../../packages/server/src/services/noodle/noodle-generated-refresh.js";
 import { normalizeNoodleImagePrompt } from "../../packages/server/src/services/noodle/noodle-image-prompt.js";
@@ -747,6 +748,15 @@ const resilientRefresh = parseNoodleGeneratedRefresh({
 assert.equal(resilientRefresh.refresh.posts.length, 1);
 assert.equal(resilientRefresh.refresh.interactions.length, 0);
 assert.deepEqual(resilientRefresh.rejected, [{ collection: "interactions", index: 0, issueCount: 1 }]);
+const adjacentRefresh = parseNoodleGeneratedRefreshResponse(`
+{"posts":[{"authorHandle":"alpha","content":"A recovered post."}]}
+{"interactions":[{"actorHandle":"beta","targetTempId":"post-alpha","type":"like"}]}
+{"follows":[{"actorHandle":"alpha","targetHandle":"beta"}]}
+`);
+assert.equal(adjacentRefresh.refresh.posts.length, 1);
+assert.equal(adjacentRefresh.refresh.interactions.length, 1);
+assert.equal(adjacentRefresh.refresh.follows.length, 1);
+assert.deepEqual(adjacentRefresh.rejected, []);
 assert.equal(
   validateNoodleGeneratedRefresh(
     { posts: [], interactions: [], follows: [], digests: [] },

--- a/scripts/regressions/open-issues.regression.ts
+++ b/scripts/regressions/open-issues.regression.ts
@@ -1024,6 +1024,8 @@ assert.match(characterEditorSource, /avatar preview/u);
 assert.match(characterEditorSource, /getAvatarCropStyle/u);
 assert.match(characterEditorSource, /downloadSpriteFile/u);
 assert.match(personaEditorSource, /downloadSpriteFile/u);
+assert.match(characterEditorSource, /if \(uploading \|\| !expression\) return;/u);
+assert.match(personaEditorSource, /if \(uploading \|\| !expression\) return;/u);
 assert.match(characterEditorSource, /className="flex flex-col gap-2 sm:flex-row"/u);
 assert.match(personaEditorSource, /className="flex flex-col gap-2 sm:flex-row"/u);
 assert.match(fileDownloadSource, /MarinaraAndroid/u);

--- a/scripts/regressions/open-issues.regression.ts
+++ b/scripts/regressions/open-issues.regression.ts
@@ -952,6 +952,10 @@ const fileDownloadSource = readFileSync(
   new URL("../../packages/client/src/lib/file-download.ts", import.meta.url),
   "utf8",
 );
+const spriteDownloadSource = readFileSync(
+  new URL("../../packages/client/src/lib/sprite-download.ts", import.meta.url),
+  "utf8",
+);
 const androidMainActivitySource = readFileSync(
   new URL("../../android/app/src/main/java/com/marinara/engine/MainActivity.java", import.meta.url),
   "utf8",
@@ -1018,11 +1022,12 @@ assert.match(gameAssetsRoutesSource, /const \{ path: encoded \} = \(req\.query a
 assert.doesNotMatch(gameAssetsRoutesSource, /app\.get\("\/local-music-file\/:encoded"/u);
 assert.match(characterEditorSource, /avatar preview/u);
 assert.match(characterEditorSource, /getAvatarCropStyle/u);
-assert.match(characterEditorSource, /saveBlobToDevice/u);
-assert.match(personaEditorSource, /saveBlobToDevice/u);
+assert.match(characterEditorSource, /downloadSpriteFile/u);
+assert.match(personaEditorSource, /downloadSpriteFile/u);
 assert.match(characterEditorSource, /className="flex flex-col gap-2 sm:flex-row"/u);
 assert.match(personaEditorSource, /className="flex flex-col gap-2 sm:flex-row"/u);
 assert.match(fileDownloadSource, /MarinaraAndroid/u);
+assert.match(spriteDownloadSource, /saveBlobToDevice/u);
 assert.match(androidMainActivitySource, /public void saveFile\(String base64Data, String mimeType, String filename\)/u);
 assert.match(androidMainActivitySource, /MediaStore\.Images\.Media\.getContentUri/u);
 assert.match(

--- a/scripts/regressions/open-issues.regression.ts
+++ b/scripts/regressions/open-issues.regression.ts
@@ -32,6 +32,7 @@ import {
 } from "../../packages/client/src/lib/slash-commands.js";
 import { getAvatarCropStyle } from "../../packages/client/src/lib/utils.js";
 import { resolveEchoChamberTopLayout } from "../../packages/client/src/lib/echo-chamber-layout.js";
+import { resolveConversationSelfieConnectionId } from "../../packages/client/src/lib/conversation-selfie-setup.js";
 import {
   resolveTrackerPanelContentScale,
   resolveTrackerPanelDesktopWidth,
@@ -900,6 +901,35 @@ const serverPackageJson = JSON.parse(
 assert.match(serverPackageJson.scripts?.dev ?? "", /--ignore \.\.\/shared\/dist/u);
 assert.equal(resolveDevSharedBuildScript({ DEV_PRESERVE_SHARED_DIST: "true" }), "build:preserve");
 assert.equal(resolveDevSharedBuildScript({}), "build");
+const conversationImageConnections = [
+  { id: "text", provider: "openai", defaultForAgents: true },
+  { id: "image-secondary", provider: "image_generation", defaultForAgents: false },
+  { id: "image-default", provider: "image_generation", defaultForAgents: "true" },
+];
+assert.equal(
+  resolveConversationSelfieConnectionId({
+    currentConnectionId: null,
+    selfieCommandEnabled: true,
+    connections: conversationImageConnections,
+  }),
+  "image-default",
+);
+assert.equal(
+  resolveConversationSelfieConnectionId({
+    currentConnectionId: "image-explicit",
+    selfieCommandEnabled: true,
+    connections: conversationImageConnections,
+  }),
+  "image-explicit",
+);
+assert.equal(
+  resolveConversationSelfieConnectionId({
+    currentConnectionId: null,
+    selfieCommandEnabled: false,
+    connections: conversationImageConnections,
+  }),
+  null,
+);
 const playwrightWebServer = Array.isArray(playwrightConfig.webServer)
   ? playwrightConfig.webServer[0]
   : playwrightConfig.webServer;
@@ -912,6 +942,18 @@ const agentEditorSource = readFileSync(
 );
 const characterEditorSource = readFileSync(
   new URL("../../packages/client/src/components/characters/CharacterEditor.tsx", import.meta.url),
+  "utf8",
+);
+const personaEditorSource = readFileSync(
+  new URL("../../packages/client/src/components/personas/PersonaEditor.tsx", import.meta.url),
+  "utf8",
+);
+const fileDownloadSource = readFileSync(
+  new URL("../../packages/client/src/lib/file-download.ts", import.meta.url),
+  "utf8",
+);
+const androidMainActivitySource = readFileSync(
+  new URL("../../android/app/src/main/java/com/marinara/engine/MainActivity.java", import.meta.url),
   "utf8",
 );
 const gameJournalSource = readFileSync(
@@ -976,6 +1018,13 @@ assert.match(gameAssetsRoutesSource, /const \{ path: encoded \} = \(req\.query a
 assert.doesNotMatch(gameAssetsRoutesSource, /app\.get\("\/local-music-file\/:encoded"/u);
 assert.match(characterEditorSource, /avatar preview/u);
 assert.match(characterEditorSource, /getAvatarCropStyle/u);
+assert.match(characterEditorSource, /saveBlobToDevice/u);
+assert.match(personaEditorSource, /saveBlobToDevice/u);
+assert.match(characterEditorSource, /className="flex flex-col gap-2 sm:flex-row"/u);
+assert.match(personaEditorSource, /className="flex flex-col gap-2 sm:flex-row"/u);
+assert.match(fileDownloadSource, /MarinaraAndroid/u);
+assert.match(androidMainActivitySource, /public void saveFile\(String base64Data, String mimeType, String filename\)/u);
+assert.match(androidMainActivitySource, /MediaStore\.Images\.Media\.getContentUri/u);
 assert.match(
   characterEditorSource,
   /"relative flex h-16 w-16 shrink-0 items-center justify-center overflow-hidden rounded-xl/u,


### PR DESCRIPTION
## Linked issues

Closes #3880
Closes #3881
Closes #3884

Issue #3877 was reviewed during this assigned-only sweep and intentionally remains open because it requires an explicit security and permission-model decision before implementation.

## Why this change

Three issues assigned to SpicyMarinara affect common generation and media workflows:

- Conversation setup can show Selfies as enabled without assigning Illustrator's Generated Selfies connection.
- Noodle can discard posts and interactions when a local model emits adjacent JSON collection objects.
- Character and Persona sprite downloads do not complete in the Android shell, while the mobile Upload action can escape its expression row.

## What changed

- Conversation setup now preserves an explicit selfie connection or assigns the default image-generation connection when the installed Selfies command is enabled.
- Noodle now parses every independent JSON-ish value in a response and merges collection fragments before row validation, on both initial and correction attempts.
- Sprite downloads now use an Android JavaScript bridge that saves images through MediaStore on Android 10+ and the system file picker on Android 7-9, while retaining browser downloads outside the shell.
- Character and Persona mobile sprite forms now place Upload below the expression field at phone widths and restore the horizontal row at the existing `sm` breakpoint.
- Added regression coverage and Unreleased changelog entries for all three fixes.

## Automated evidence

- `pnpm check` passed.
- `pnpm regression:noodle` passed, including adjacent posts, interactions, and follows.
- `pnpm regression:issues` passed, including selfie connection selection and Android/mobile wiring assertions.
- `gradle :app:compileDebugJavaWithJavac` passed.
- `pnpm smoke:ui` completed with 74 passing and 47 skipped tests; one unrelated Noodle mobile-navigation test failed because its strict selector matches both the header and bottom account-menu buttons.

## Validation

- [ ] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed `CONTRIBUTING.md`

### Manual verification requested

- Manually create a Conversation with Illustrator installed, Selfies enabled, and a default image connection; verify Generated Selfies opens with that connection selected.
- Manually refresh Noodle with a local model that emits adjacent JSON objects and verify posts, interactions, and follows all appear.
- Manually download a saved Character and Persona sprite from the Android bootstrap and verify the image appears under Pictures/Marinara on Android 10+; verify the save picker on Android 7-9 if those devices are supported in the test matrix.
- Manually inspect both Character and Persona sprite forms at a phone viewport and verify Upload sits below the expression field without horizontal overflow.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Version/release files updated (only if this PR includes a version bump)

`CHANGELOG.md` is updated. No install instructions, release version, or version-bearing files changed.

## UI evidence

Automated mobile shell coverage ran as part of `pnpm smoke:ui`. Interactive Android device verification remains requested above.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a shared device download utility so character/persona sprite downloads reliably save on Android (with browser fallback).
  * Improved chat setup for selfie-enabled flows by auto-selecting the default image-generation connection when none is chosen.
  * Prevented starting a new sprite upload while an upload is already in progress.
* **Bug Fixes**
  * Restored Noodle timeline refresh recovery for responses containing multiple adjacent JSON objects (posts, interactions, follows).
  * Improved Android sprite download delivery and adjusted the “Add Sprite” control positioning for mobile card layout.
* **Tests**
  * Expanded regression coverage for selfie connection selection and multi-object refresh parsing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->