### PR TITLE
fix: resolve assigned Conversation, Noodle, and Illustrator issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 
 ### Added
 
+- Added Grouped and Individual response modes to multi-character Conversations, including sequential, smart, manual, mention-directed, and autonomous character selection with a shared daily check-in budget and a token-use warning (#3887).
+- Added the user's current local time to every Noodle timeline refresh and an optional setting for attaching participating characters' existing generated schedules for the current day (#3886).
 - Added disabled-by-default custom GitHub agent repositories to Agents Manager, with manual preview/apply, explicit trust confirmation, stable sync identity, and bounded SSRF-safe archive validation (#3861).
 - Added explicit numeric overrides for Conversation chat check-in ceilings and removed the 50-message ceiling from Conversation and Roleplay recent-summary tails, while retaining conservative defaults and cost guidance (#3864).
 - Added **Noodle** to Lorebook entry Generation filters so entries can target Noodle context without being injected into other generation paths (#3842).
@@ -18,6 +20,11 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 
 ### Fixed
 
+- Kept automatic Roleplay Illustrator images on the same configured illustration canvas and requested orientation as manual Gallery generation, instead of leaving unattended images in a portrait/selfie-shaped layout (#3893).
+- Expanded Professor Mari's chat composer through approximately six lines before it scrolls internally (#3885).
+- Consolidated Cross-Chat Awareness under Connected Chats and restored normal spacing between Noodle references and Discord webhook controls (#3889).
+- Persisted enabled Conversation Selfie setup with its command toggle and default image-generation connection, keeping Generated Selfies active after chat creation (#3890).
+- Made Conversation character mentions always select the mentioned responder or responders, including legacy manual-response chats, and removed the redundant Reply When Mentioned toggle (#3891).
 - Made Conversation setup connect enabled Illustrator selfies to the default image-generation connection instead of leaving Generated Selfies inactive (#3880).
 - Recovered every Noodle timeline collection when local models return adjacent JSON objects, preserving posts and interactions alongside follows instead of parsing only the final object (#3881).
 - Routed Character and Persona sprite downloads through the Android shell's native file saver and stacked the sprite Upload action beneath its expression field on mobile so it stays inside the card (#3884).
@@ -26,7 +33,7 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 - Kept each historical user turn under the Persona that sent it when Name Prefix History is enabled, instead of relabeling every user message with the currently selected Persona.
 - Accepted the single-object array wrapper some local models return for generated Noodle profiles, preventing timeline refreshes from failing with HTTP 500 during first-time bio generation (#3871).
 - Gave current semantic lorebook matches the same context-budget priority as current keyword matches, so configured entry order—not activation method—decides which entries are attached when every match cannot fit.
-- Clarified in Peek Prompt when provider formatting has combined several chat turns into one request block, preventing a merged block from looking like missing Hide From AI context.
+- Simplified Peek Prompt's exact-request view by removing redundant provider-formatting guidance.
 - Returned parsed chat metadata and character IDs from public chat reads so fresh sidebar tag filters match the shared API contract (#3857).
 - Deep-merged partial nested Character PATCH fields without materializing destructive defaults, preserving omitted extensions and embedded-lorebook data (#3858).
 - Validated and normalized native Marinara character cards before persistence while preserving unknown embedded-lorebook properties (#3859).

--- a/docs/noodle/settings.md
+++ b/docs/noodle/settings.md
@@ -123,6 +123,7 @@ The template Noodle uses to write these image prompts is called **Noodle Post Im
 The **Timeline Writing** section tunes the refresh writer's tone and long-term memory behavior.
 
 - **Enhanced tone & continuity**: a toggle, default **off**. When on, each account's voice is grounded more strongly in its own Personality/Description/Backstory instead of a default upbeat tone, accounts are encouraged to react to, quote, or argue with each other's posts within the same refresh, older-post recall happens more often (and favors posts relevant to currently active accounts instead of picking purely at random), and the recall instruction allows rather than discourages references. Off reproduces Noodle's original tone and recall behavior exactly, so turning this on is the only way your timelines change.
+- **Use generated character schedules**: a toggle, default **off**. When on, Noodle includes today's existing generated Conversation schedule for each participating character when available. Noodle does not generate or refresh schedules itself. The user's current local date and time are included in every timeline refresh whether this toggle is on or off.
 
 ## Customizing the timeline writer's voice
 

--- a/packages/client/src/components/chat/ChatSettingsDrawer.tsx
+++ b/packages/client/src/components/chat/ChatSettingsDrawer.tsx
@@ -28,7 +28,6 @@ import {
   CalendarClock,
   RefreshCw,
   Settings2,
-  Link,
   ArrowRightLeft,
   Unlink,
   Brain,
@@ -5129,40 +5128,54 @@ export function ChatSettingsDrawer({
               icon={<Users size="0.875rem" />}
               help={
                 isConversation
-                  ? "Configure whether group conversations reply automatically or wait for a manually triggered character response."
+                  ? "Choose one grouped response or separate character turns. Individual replies use a separate model request for every responding character."
                   : "Configure how multiple characters interact. Merged mode combines all characters into one narrator; Individual mode has each character respond separately."
               }
             >
               {/* Mode selector */}
-              {!isConversation && (
-                <div className="space-y-2">
-                  <label className="text-[0.6875rem] font-medium text-[var(--muted-foreground)]">Mode</label>
-                  <div className="flex rounded-lg ring-1 ring-[var(--border)]">
-                    <button
-                      onClick={() => updateMeta.mutate({ id: chat.id, groupChatMode: "merged" })}
-                      className={cn(
-                        "flex-1 px-3 py-2 text-[0.6875rem] font-medium transition-colors rounded-l-lg",
-                        (metadata.groupChatMode ?? "merged") === "merged"
-                          ? "bg-[var(--primary)] text-white"
-                          : "text-[var(--muted-foreground)] hover:bg-[var(--accent)]",
-                      )}
-                    >
-                      Merged (Narrator)
-                    </button>
-                    <button
-                      onClick={() => updateMeta.mutate({ id: chat.id, groupChatMode: "individual" })}
-                      className={cn(
-                        "flex-1 px-3 py-2 text-[0.6875rem] font-medium transition-colors rounded-r-lg",
-                        metadata.groupChatMode === "individual"
-                          ? "bg-[var(--primary)] text-white"
-                          : "text-[var(--muted-foreground)] hover:bg-[var(--accent)]",
-                      )}
-                    >
-                      Individual
-                    </button>
-                  </div>
+              <div className="space-y-2">
+                <label className="text-[0.6875rem] font-medium text-[var(--muted-foreground)]">Mode</label>
+                <div className="flex rounded-lg ring-1 ring-[var(--border)]">
+                  <button
+                    onClick={() => updateMeta.mutate({ id: chat.id, groupChatMode: "merged" })}
+                    className={cn(
+                      "flex-1 px-3 py-2 text-[0.6875rem] font-medium transition-colors rounded-l-lg",
+                      (metadata.groupChatMode ?? "merged") === "merged"
+                        ? "bg-[var(--primary)] text-white"
+                        : "text-[var(--muted-foreground)] hover:bg-[var(--accent)]",
+                    )}
+                  >
+                    {isConversation ? "Grouped" : "Merged (Narrator)"}
+                  </button>
+                  <button
+                    onClick={() => {
+                      if (metadata.groupChatMode === "individual") return;
+                      updateMeta.mutate({
+                        id: chat.id,
+                        groupChatMode: "individual",
+                        ...(isConversation && metadata.groupResponseOrder === "manual"
+                          ? { groupResponseOrder: "sequential" as const }
+                          : {}),
+                      });
+                      if (isConversation) {
+                        toast.warning("Individual replies can use many tokens", {
+                          description:
+                            "Each responding character uses a separate model request. Large groups with Autonomous Messaging can increase token use quickly.",
+                          duration: 12_000,
+                        });
+                      }
+                    }}
+                    className={cn(
+                      "flex-1 px-3 py-2 text-[0.6875rem] font-medium transition-colors rounded-r-lg",
+                      metadata.groupChatMode === "individual"
+                        ? "bg-[var(--primary)] text-white"
+                        : "text-[var(--muted-foreground)] hover:bg-[var(--accent)]",
+                    )}
+                  >
+                    Individual
+                  </button>
                 </div>
-              )}
+              </div>
 
               {/* Merged mode: speaker color option */}
               {!isConversation && (metadata.groupChatMode ?? "merged") === "merged" && (
@@ -5199,7 +5212,7 @@ export function ChatSettingsDrawer({
               )}
 
               {/* Individual mode: response order */}
-              {!isConversation && metadata.groupChatMode === "individual" && (
+              {metadata.groupChatMode === "individual" && (
                 <div className="mt-2 space-y-2">
                   <label className="text-[0.6875rem] font-medium text-[var(--muted-foreground)]">Response Order</label>
                   <div className="flex rounded-lg ring-1 ring-[var(--border)]">
@@ -5239,7 +5252,9 @@ export function ChatSettingsDrawer({
                   </div>
                   <p className="text-[0.625rem] text-[var(--muted-foreground)]">
                     {metadata.groupResponseOrder === "manual"
-                      ? "No automatic responses — use the character picker in the input bar to trigger responses one at a time."
+                      ? isConversation
+                        ? "No automatic responses — @mention one or more characters to call them into the conversation."
+                        : "No automatic responses — use the character picker in the input bar to trigger responses one at a time."
                       : metadata.groupResponseOrder === "smart"
                         ? "An AI agent decides which characters should respond based on the scene context."
                         : "Characters respond one by one in their listed order."}
@@ -5450,40 +5465,6 @@ export function ChatSettingsDrawer({
                     </div>
                   )}
                 </div>
-
-                <button
-                  onClick={() => {
-                    const onlyWhenMentioned = metadata.groupResponseOrder === "manual";
-                    updateMeta.mutate({
-                      id: chat.id,
-                      groupResponseOrder: onlyWhenMentioned ? "sequential" : "manual",
-                    });
-                  }}
-                  className={cn(
-                    "mari-chat-option-field flex w-full items-center justify-between rounded-lg px-3 py-2.5 text-left transition-all",
-                    metadata.groupResponseOrder === "manual" && "mari-chat-option-field--active",
-                  )}
-                >
-                  <div className="flex-1 min-w-0">
-                    <span className="text-xs font-medium">Reply When Mentioned</span>
-                    <p className="text-[0.625rem] text-[var(--muted-foreground)]">
-                      Characters wait for direct mentions or manual response triggers
-                    </p>
-                  </div>
-                  <div
-                    className={cn(
-                      "mari-chat-option-switch h-5 w-9 shrink-0 rounded-full p-0.5 transition-colors",
-                      metadata.groupResponseOrder === "manual" && "mari-chat-option-switch--active",
-                    )}
-                  >
-                    <div
-                      className={cn(
-                        "h-4 w-4 rounded-full bg-white shadow-sm transition-transform",
-                        metadata.groupResponseOrder === "manual" && "translate-x-3.5",
-                      )}
-                    />
-                  </div>
-                </button>
 
                 {/* Character exchanges toggle (group chats only) */}
                 {chatCharIds.length > 1 && (
@@ -5920,59 +5901,51 @@ export function ChatSettingsDrawer({
             </Section>
           )}
 
-          {/* Cross-Chat Awareness — conversation mode only */}
-          {isConversation && (
-            <Section
-              label="Cross-Chat Awareness"
-              icon={<Link size="0.875rem" />}
-              help="Characters remember and reference conversations from other chats they're in. Pulls recent messages from sibling chats and injects them as context."
-            >
-              <button
-                onClick={() => {
-                  updateMeta.mutate({
-                    id: chat.id,
-                    crossChatAwareness: metadata.crossChatAwareness === false ? true : false,
-                  });
-                }}
-                className={cn(
-                  "flex w-full items-center justify-between rounded-lg px-3 py-2.5 text-left transition-all",
-                  metadata.crossChatAwareness !== false
-                    ? "bg-[var(--primary)]/10 ring-1 ring-[var(--primary)]/30"
-                    : "bg-[var(--secondary)] hover:bg-[var(--accent)]",
-                )}
-              >
-                <div className="flex-1 min-w-0">
-                  <span className="text-xs font-medium">Cross-Chat Awareness</span>
-                  <p className="text-[0.625rem] text-[var(--muted-foreground)]">
-                    Characters know what happens in their other chats
-                  </p>
-                </div>
-                <div
-                  className={cn(
-                    "h-5 w-9 shrink-0 rounded-full p-0.5 transition-colors",
-                    metadata.crossChatAwareness !== false ? "bg-[var(--primary)]" : "bg-[var(--muted-foreground)]/50",
-                  )}
-                >
-                  <div
-                    className={cn(
-                      "h-4 w-4 rounded-full bg-white shadow-sm transition-transform",
-                      metadata.crossChatAwareness !== false && "translate-x-3.5",
-                    )}
-                  />
-                </div>
-              </button>
-            </Section>
-          )}
-
           {/* Connected Roleplay — conversation mode: link to a roleplay or game chat */}
           {isConversation && (
             <Section
               style={{ order: CHAT_SETTINGS_ORDER.connectedChat }}
               label="Connected Chats"
               icon={<ArrowRightLeft size="0.875rem" />}
-              help="Link this conversation to a roleplay or game. Recent messages from the linked chat are pulled into context here automatically. To send something the other direction, the character uses `<influence>` (steers the next linked turn, one-shot) or `<note>` (persists on every future linked turn until cleared)."
+              help="Control awareness of sibling chats or link this conversation to a roleplay or game. Linked messages are pulled into context automatically; `<influence>` steers one linked turn and `<note>` persists until cleared."
             >
               <div className="space-y-2">
+                <button
+                  onClick={() => {
+                    updateMeta.mutate({
+                      id: chat.id,
+                      crossChatAwareness: metadata.crossChatAwareness === false ? true : false,
+                    });
+                  }}
+                  className={cn(
+                    "flex w-full items-center justify-between rounded-lg px-3 py-2.5 text-left transition-all",
+                    metadata.crossChatAwareness !== false
+                      ? "bg-[var(--primary)]/10 ring-1 ring-[var(--primary)]/30"
+                      : "bg-[var(--secondary)] hover:bg-[var(--accent)]",
+                  )}
+                >
+                  <div className="flex-1 min-w-0">
+                    <span className="text-xs font-medium">Cross-Chat Awareness</span>
+                    <p className="text-[0.625rem] text-[var(--muted-foreground)]">
+                      Characters know what happens in their other chats
+                    </p>
+                  </div>
+                  <div
+                    className={cn(
+                      "h-5 w-9 shrink-0 rounded-full p-0.5 transition-colors",
+                      metadata.crossChatAwareness !== false
+                        ? "bg-[var(--primary)]"
+                        : "bg-[var(--muted-foreground)]/50",
+                    )}
+                  >
+                    <div
+                      className={cn(
+                        "h-4 w-4 rounded-full bg-white shadow-sm transition-transform",
+                        metadata.crossChatAwareness !== false && "translate-x-3.5",
+                      )}
+                    />
+                  </div>
+                </button>
                 {chat.connectedChatId ? (
                   (() => {
                     const linked = (allChats ?? []).find((c: Chat) => c.id === chat.connectedChatId);

--- a/packages/client/src/components/chat/ChatSettingsDrawer.tsx
+++ b/packages/client/src/components/chat/ChatSettingsDrawer.tsx
@@ -5256,8 +5256,12 @@ export function ChatSettingsDrawer({
                         ? "No automatic responses — @mention one or more characters to call them into the conversation."
                         : "No automatic responses — use the character picker in the input bar to trigger responses one at a time."
                       : metadata.groupResponseOrder === "smart"
-                        ? "An AI agent decides which characters should respond based on the scene context."
-                        : "Characters respond one by one in their listed order."}
+                        ? isConversation
+                          ? "Smart chooses one or more available characters using the conversation, schedule status, and talkativeness."
+                          : "An AI agent decides which characters should respond based on the scene context."
+                        : isConversation
+                          ? "Available characters respond one by one in their listed order; offline characters are skipped."
+                          : "Characters respond one by one in their listed order."}
                   </p>
                   <button
                     onClick={() =>
@@ -5293,40 +5297,42 @@ export function ChatSettingsDrawer({
                       />
                     </div>
                   </button>
-                  <button
-                    onClick={() =>
-                      updateMeta.mutate({
-                        id: chat.id,
-                        groupSpeakerNamesInHistory: metadata.groupSpeakerNamesInHistory !== true,
-                      })
-                    }
-                    className={cn(
-                      "mari-chat-option-field flex w-full items-center justify-between rounded-lg px-3 py-2.5 text-left transition-all",
-                      metadata.groupSpeakerNamesInHistory === true && "mari-chat-option-field--active",
-                    )}
-                  >
-                    <div className="min-w-0 flex-1">
-                      <span className="text-[0.6875rem] font-medium">Name Prefix History</span>
-                      <p className="mt-0.5 text-[0.625rem] leading-relaxed text-[var(--muted-foreground)]">
-                        {metadata.groupSpeakerNamesInHistory === true
-                          ? "History turns are sent as Name: message before merged role blocks."
-                          : "History turns keep their stored text before role merging."}
-                      </p>
-                    </div>
-                    <div
+                  {!isConversation && (
+                    <button
+                      onClick={() =>
+                        updateMeta.mutate({
+                          id: chat.id,
+                          groupSpeakerNamesInHistory: metadata.groupSpeakerNamesInHistory !== true,
+                        })
+                      }
                       className={cn(
-                        "mari-chat-option-switch ml-3 h-5 w-9 shrink-0 rounded-full p-0.5 transition-colors",
-                        metadata.groupSpeakerNamesInHistory === true && "mari-chat-option-switch--active",
+                        "mari-chat-option-field flex w-full items-center justify-between rounded-lg px-3 py-2.5 text-left transition-all",
+                        metadata.groupSpeakerNamesInHistory === true && "mari-chat-option-field--active",
                       )}
                     >
+                      <div className="min-w-0 flex-1">
+                        <span className="text-[0.6875rem] font-medium">Name Prefix History</span>
+                        <p className="mt-0.5 text-[0.625rem] leading-relaxed text-[var(--muted-foreground)]">
+                          {metadata.groupSpeakerNamesInHistory === true
+                            ? "History turns are sent as Name: message before merged role blocks."
+                            : "History turns keep their stored text before role merging."}
+                        </p>
+                      </div>
                       <div
                         className={cn(
-                          "h-4 w-4 rounded-full bg-white shadow-sm transition-transform",
-                          metadata.groupSpeakerNamesInHistory === true && "translate-x-3.5",
+                          "mari-chat-option-switch ml-3 h-5 w-9 shrink-0 rounded-full p-0.5 transition-colors",
+                          metadata.groupSpeakerNamesInHistory === true && "mari-chat-option-switch--active",
                         )}
-                      />
-                    </div>
-                  </button>
+                      >
+                        <div
+                          className={cn(
+                            "h-4 w-4 rounded-full bg-white shadow-sm transition-transform",
+                            metadata.groupSpeakerNamesInHistory === true && "translate-x-3.5",
+                          )}
+                        />
+                      </div>
+                    </button>
+                  )}
                 </div>
               )}
 

--- a/packages/client/src/components/chat/ChatSetupWizard.tsx
+++ b/packages/client/src/components/chat/ChatSetupWizard.tsx
@@ -38,7 +38,7 @@ import { useChatStore } from "../../stores/chat.store";
 import { useSidecarStore } from "../../stores/sidecar.store";
 import { api } from "../../lib/api-client";
 import { appendLocalSidecarConnectionOption } from "../../lib/connection-filters";
-import { resolveConversationSelfieConnectionId } from "../../lib/conversation-selfie-setup";
+import { resolveConversationSelfieSetup } from "../../lib/conversation-selfie-setup";
 import { getAgentRunIntervalMeta } from "../../lib/agent-cadence";
 import { characterMatchesSearch, getCharacterTitle, parseCharacterDisplayData } from "../../lib/character-display";
 import { addSilentGreetingSwipes } from "../../lib/message-swipes";
@@ -1044,7 +1044,9 @@ function ConversationQuickSetup({ chat, onFinish }: ChatSetupWizardProps) {
       commandsEnabled &&
       availableConversationCommandIds.has("selfie") &&
       isConversationCommandToggleEnabled(conversationCommandToggles, "selfie");
-    const selfieConnectionId = resolveConversationSelfieConnectionId({
+    const selfieSetup = resolveConversationSelfieSetup({
+      commandToggles: conversationCommandToggles,
+      selfieCommandAvailable: availableConversationCommandIds.has("selfie"),
       currentConnectionId: metadata.imageGenConnectionId,
       selfieCommandEnabled,
       connections: connectionOptions,
@@ -1054,11 +1056,11 @@ function ConversationQuickSetup({ chat, onFinish }: ChatSetupWizardProps) {
       autonomousMessages: autonomousEnabled,
       conversationSchedulesEnabled: autonomousEnabled && generateSchedule,
       characterCommands: hasConversationCommands && commandsEnabled,
-      conversationCommandToggles,
+      conversationCommandToggles: selfieSetup.conversationCommandToggles,
       conversationSetupComplete: true,
       chatParameters: customizeParameters ? generationParameters : null,
       customSystemPrompt,
-      ...(selfieConnectionId ? { imageGenConnectionId: selfieConnectionId } : {}),
+      ...(selfieSetup.imageGenConnectionId ? { imageGenConnectionId: selfieSetup.imageGenConnectionId } : {}),
     });
     if (autonomousEnabled && generateSchedule) {
       setScheduleState("generating");

--- a/packages/client/src/components/chat/HomeProfessorMariChat.tsx
+++ b/packages/client/src/components/chat/HomeProfessorMariChat.tsx
@@ -1915,6 +1915,17 @@ export function HomeProfessorMariChat({
   const pendingConnectionPersistRef = useRef<string | null>(null);
   const connectionPersistInFlightRef = useRef(false);
 
+  const resizeComposer = useCallback((textarea: HTMLTextAreaElement | null) => {
+    if (!textarea) return;
+    textarea.style.height = "auto";
+    textarea.style.height = `${Math.min(textarea.scrollHeight, 128)}px`;
+  }, []);
+
+  useLayoutEffect(() => {
+    resizeComposer(embeddedTextareaRef.current);
+    resizeComposer(floatingTextareaRef.current);
+  }, [draft, resizeComposer]);
+
   const hasActiveGeneration = useChatStore((state) => (chatId ? state.abortControllers.has(chatId) : false));
   const mariPhase = useChatStore((state) => (chatId ? (state.mariPhaseByChatId.get(chatId) ?? null) : null));
   const mariChips = useAgentStore((state) => state.mariChips);
@@ -3089,6 +3100,7 @@ export function HomeProfessorMariChat({
             value={draft}
             onChange={(event) => {
               setDraft(event.target.value);
+              resizeComposer(event.currentTarget);
               if (mobileFocusMode) event.currentTarget.scrollIntoView({ block: "end" });
             }}
             onKeyDown={(event) => {
@@ -3099,7 +3111,7 @@ export function HomeProfessorMariChat({
             }}
             rows={1}
             placeholder="Ask Professor Mari..."
-            className="mari-chat-input-textarea h-8 min-h-8 flex-1 resize-none overflow-y-auto bg-transparent px-1 py-1.5 text-sm leading-normal text-foreground/90 outline-none placeholder:text-foreground/30 disabled:cursor-not-allowed disabled:opacity-40"
+            className="mari-chat-input-textarea min-h-8 max-h-32 flex-1 resize-none overflow-y-auto bg-transparent px-1 py-1.5 text-sm leading-normal text-foreground/90 outline-none placeholder:text-foreground/30 disabled:cursor-not-allowed disabled:opacity-40"
             disabled={isBusy}
           />
           <button
@@ -3711,6 +3723,7 @@ export function HomeProfessorMariChat({
                             value={draft}
                             onChange={(event) => {
                               setDraft(event.target.value);
+                              resizeComposer(event.currentTarget);
                               if (mobileFocusMode) event.currentTarget.scrollIntoView({ block: "end" });
                             }}
                             onKeyDown={(event) => {
@@ -3721,7 +3734,7 @@ export function HomeProfessorMariChat({
                             }}
                             rows={1}
                             placeholder="Ask Professor Mari..."
-                            className="mari-chat-input-textarea h-8 min-h-8 flex-1 resize-none overflow-y-auto bg-transparent px-1 py-1.5 text-sm leading-normal text-foreground/90 outline-none placeholder:text-foreground/30 disabled:cursor-not-allowed disabled:opacity-40"
+                            className="mari-chat-input-textarea min-h-8 max-h-32 flex-1 resize-none overflow-y-auto bg-transparent px-1 py-1.5 text-sm leading-normal text-foreground/90 outline-none placeholder:text-foreground/30 disabled:cursor-not-allowed disabled:opacity-40"
                             disabled={isBusy}
                           />
                           <button

--- a/packages/client/src/components/chat/HomeProfessorMariChat.tsx
+++ b/packages/client/src/components/chat/HomeProfessorMariChat.tsx
@@ -3100,7 +3100,6 @@ export function HomeProfessorMariChat({
             value={draft}
             onChange={(event) => {
               setDraft(event.target.value);
-              resizeComposer(event.currentTarget);
               if (mobileFocusMode) event.currentTarget.scrollIntoView({ block: "end" });
             }}
             onKeyDown={(event) => {
@@ -3111,7 +3110,7 @@ export function HomeProfessorMariChat({
             }}
             rows={1}
             placeholder="Ask Professor Mari..."
-            className="mari-chat-input-textarea min-h-8 max-h-32 flex-1 resize-none overflow-y-auto bg-transparent px-1 py-1.5 text-sm leading-normal text-foreground/90 outline-none placeholder:text-foreground/30 disabled:cursor-not-allowed disabled:opacity-40"
+            className="mari-chat-input-textarea min-h-8 max-h-32 flex-1 resize-none overflow-y-auto bg-transparent px-1 py-1.5 text-sm leading-normal text-foreground/90 outline-hidden placeholder:text-foreground/30 disabled:cursor-not-allowed disabled:opacity-40"
             disabled={isBusy}
           />
           <button
@@ -3723,7 +3722,6 @@ export function HomeProfessorMariChat({
                             value={draft}
                             onChange={(event) => {
                               setDraft(event.target.value);
-                              resizeComposer(event.currentTarget);
                               if (mobileFocusMode) event.currentTarget.scrollIntoView({ block: "end" });
                             }}
                             onKeyDown={(event) => {
@@ -3734,7 +3732,7 @@ export function HomeProfessorMariChat({
                             }}
                             rows={1}
                             placeholder="Ask Professor Mari..."
-                            className="mari-chat-input-textarea min-h-8 max-h-32 flex-1 resize-none overflow-y-auto bg-transparent px-1 py-1.5 text-sm leading-normal text-foreground/90 outline-none placeholder:text-foreground/30 disabled:cursor-not-allowed disabled:opacity-40"
+                            className="mari-chat-input-textarea min-h-8 max-h-32 flex-1 resize-none overflow-y-auto bg-transparent px-1 py-1.5 text-sm leading-normal text-foreground/90 outline-hidden placeholder:text-foreground/30 disabled:cursor-not-allowed disabled:opacity-40"
                             disabled={isBusy}
                           />
                           <button

--- a/packages/client/src/components/chat/PeekPromptModal.tsx
+++ b/packages/client/src/components/chat/PeekPromptModal.tsx
@@ -2,7 +2,7 @@
 // Peek Prompt Modal — collapsible section viewer
 // ──────────────────────────────────────────────
 import { useState, useMemo } from "react";
-import { X, ChevronRight, ChevronDown, Info } from "lucide-react";
+import { X, ChevronRight, ChevronDown } from "lucide-react";
 import { cn } from "../../lib/utils";
 import {
   NEUTRAL_PANEL_HEADER,
@@ -606,15 +606,6 @@ export function PeekPromptModal({ data, onClose }: PeekPromptModalProps) {
           {data.agentNote && (
             <div className="rounded-lg border border-[var(--marinara-chat-chrome-button-border)] bg-[var(--marinara-chat-chrome-highlight-bg)] px-3 py-2 text-[0.6875rem] text-[var(--marinara-chat-chrome-panel-text)]">
               Note: {data.agentNote}
-            </div>
-          )}
-          {data.exact && (
-            <div className="flex items-start gap-2 rounded-lg border border-(--border) bg-(--secondary)/25 px-3 py-2 text-[0.6875rem] leading-snug text-(--muted-foreground)">
-              <Info size="0.75rem" className="mt-0.5 shrink-0 text-(--primary)" />
-              <span>
-                Providers may combine several chat turns into one request block. Expand Chat History to inspect all
-                model-visible text inside each block.
-              </span>
             </div>
           )}
           {sections.map((s, i) =>

--- a/packages/client/src/components/noodle/NoodleHome.tsx
+++ b/packages/client/src/components/noodle/NoodleHome.tsx
@@ -3339,6 +3339,13 @@ export function NoodleHome({ navigation, onNavigate }: NoodleHomeProps) {
                 disabled={updateSettings.isPending}
                 onChange={(checked) => saveSettings({ enableEnhancedTimelineWriting: checked })}
               />
+              <ToggleSetting
+                label="Use generated character schedules"
+                help="Includes each participating character's already-generated Conversation schedule for today when one is available. Current time is always included even when this is off."
+                checked={settings.includeCharacterSchedules}
+                disabled={updateSettings.isPending}
+                onChange={(checked) => saveSettings({ includeCharacterSchedules: checked })}
+              />
             </div>
           </Section>
 

--- a/packages/client/src/features/chat-settings/sections/DiscordMirrorSection.tsx
+++ b/packages/client/src/features/chat-settings/sections/DiscordMirrorSection.tsx
@@ -9,7 +9,7 @@ interface DiscordMirrorControlsProps {
 export function DiscordMirrorControls({
   webhookUrl,
   onWebhookUrlChange,
-  className = "space-y-2 pt-2.5",
+  className = "space-y-2",
 }: DiscordMirrorControlsProps) {
   const webhookInputId = useId();
   const webhookErrorId = useId();

--- a/packages/client/src/hooks/use-noodle.ts
+++ b/packages/client/src/hooks/use-noodle.ts
@@ -539,6 +539,7 @@ export function useRefreshNoodle() {
       api.post<NoodleRefreshResult>("/noodle/refresh", {
         mode: "public",
         ...input,
+        timeZone: useUIStore.getState().conversationTimeZone,
         debugMode: useUIStore.getState().debugMode,
         reviewImagePromptsBeforeSend: useUIStore.getState().reviewImagePromptsBeforeSend,
       }),

--- a/packages/client/src/lib/conversation-selfie-setup.ts
+++ b/packages/client/src/lib/conversation-selfie-setup.ts
@@ -1,3 +1,5 @@
+import type { ConversationCommandToggles } from "@marinara-engine/shared";
+
 export type ConversationSelfieConnectionOption = {
   id: string;
   provider?: string;
@@ -22,4 +24,27 @@ export function resolveConversationSelfieConnectionId(input: {
         String(connection.defaultForAgents) === "true",
     )?.id ?? null
   );
+}
+
+/** Build the chat metadata that setup must persist for the Selfie command. */
+export function resolveConversationSelfieSetup(input: {
+  commandToggles: ConversationCommandToggles;
+  selfieCommandAvailable: boolean;
+  selfieCommandEnabled: boolean;
+  currentConnectionId: unknown;
+  connections: readonly ConversationSelfieConnectionOption[];
+}): {
+  conversationCommandToggles: ConversationCommandToggles;
+  imageGenConnectionId: string | null;
+} {
+  return {
+    conversationCommandToggles: input.selfieCommandAvailable
+      ? { ...input.commandToggles, selfie: input.selfieCommandEnabled }
+      : { ...input.commandToggles },
+    imageGenConnectionId: resolveConversationSelfieConnectionId({
+      currentConnectionId: input.currentConnectionId,
+      selfieCommandEnabled: input.selfieCommandEnabled,
+      connections: input.connections,
+    }),
+  };
 }

--- a/packages/client/src/lib/conversation-selfie-setup.ts
+++ b/packages/client/src/lib/conversation-selfie-setup.ts
@@ -38,9 +38,10 @@ export function resolveConversationSelfieSetup(input: {
   imageGenConnectionId: string | null;
 } {
   return {
-    conversationCommandToggles: input.selfieCommandAvailable
-      ? { ...input.commandToggles, selfie: input.selfieCommandEnabled }
-      : { ...input.commandToggles },
+    conversationCommandToggles: {
+      ...input.commandToggles,
+      ...(input.selfieCommandAvailable ? { selfie: input.selfieCommandEnabled } : {}),
+    },
     imageGenConnectionId: resolveConversationSelfieConnectionId({
       currentConnectionId: input.currentConnectionId,
       selfieCommandEnabled: input.selfieCommandEnabled,

--- a/packages/server/src/routes/generate.routes.ts
+++ b/packages/server/src/routes/generate.routes.ts
@@ -1454,6 +1454,11 @@ export async function generateRoutes(app: FastifyInstance) {
         };
         let conversationIsGroup = false;
         let conversationCharacterNames: string[] = [];
+        let conversationRespondingCharacterIds: Set<string> | null = null;
+        let conversationCharacterPresenceById = new Map<
+          string,
+          { displayName: string; status: string; activity: string; talkativeness: number }
+        >();
         let conversationImportantMemoryBlock: string | null = null;
         // Relocation-macro content captured for the deferred-{{#if}} decode pass
         // (#3448) — set where each is computed, read after all are known.
@@ -1999,6 +2004,18 @@ export async function generateRoutes(app: FastifyInstance) {
           const { convoCharInfo, convoCharNames, charNameList, isGroup } = presenceRuntime;
           conversationIsGroup = isGroup;
           conversationCharacterNames = convoCharNames;
+          conversationRespondingCharacterIds = new Set(presenceRuntime.respondingCharacterIds);
+          conversationCharacterPresenceById = new Map(
+            convoCharInfo.map((character) => [
+              character.charId,
+              {
+                displayName: character.displayName,
+                status: character.status,
+                activity: character.activity,
+                talkativeness: character.talkativeness,
+              },
+            ]),
+          );
 
           const nowInstant = new Date();
           const conversationSummaryFallback = await connections.getFallbackForAgents();
@@ -2583,6 +2600,13 @@ export async function generateRoutes(app: FastifyInstance) {
           character.postHistoryInstructions = resolveCharacterPromptText(character.postHistoryInstructions);
         }
         const characterMacroProfilesById = buildCharacterMacroProfilesById(charInfo);
+        const isAvailableGroupResponder = (characterId: string): boolean =>
+          chatMode !== "conversation" || conversationRespondingCharacterIds?.has(characterId) === true;
+        const availableGroupCharacters = charInfo.filter((character) => isAvailableGroupResponder(character.id));
+        const groupResponderName = (characterId: string): string =>
+          conversationCharacterPresenceById.get(characterId)?.displayName ??
+          charInfo.find((character) => character.id === characterId)?.name ??
+          "Character";
 
         await appendConversationCustomAssetAdvertisements({
           chatMode,
@@ -4463,11 +4487,17 @@ export async function generateRoutes(app: FastifyInstance) {
             (input.mentionedCharacterNames ?? []).map((name: string) => normalizeTextForMatch(name)),
           );
 
-          return charInfo
+          return availableGroupCharacters
             .filter((character) => {
-              if (requestedNames.has(normalizeTextForMatch(character.name))) return true;
-              const escaped = character.name.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-              return new RegExp(`@${escaped}(?=$|[\\s\\p{P}\\p{S}])`, "iu").test(latestUserText);
+              const names = [
+                character.name,
+                conversationCharacterPresenceById.get(character.id)?.displayName,
+              ].filter((name): name is string => typeof name === "string" && name.trim().length > 0);
+              if (names.some((name) => requestedNames.has(normalizeTextForMatch(name)))) return true;
+              return names.some((name) => {
+                const escaped = name.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+                return new RegExp(`@${escaped}(?=$|[\\s\\p{P}\\p{S}])`, "iu").test(latestUserText);
+              });
             })
             .map((character) => character.id);
         };
@@ -4496,9 +4526,14 @@ export async function generateRoutes(app: FastifyInstance) {
               : Array.isArray(parsedRecord.characters)
                 ? parsedRecord.characters
                 : [];
-          const validIds = new Set(characterIds);
+          const validIds = new Set(availableGroupCharacters.map((character) => character.id));
           const namesByLower = new Map(
-            charInfo.map((character) => [normalizeTextForMatch(character.name), character.id]),
+            availableGroupCharacters.flatMap((character) => {
+              const displayName = conversationCharacterPresenceById.get(character.id)?.displayName;
+              return [character.name, displayName]
+                .filter((name): name is string => typeof name === "string" && name.trim().length > 0)
+                .map((name) => [normalizeTextForMatch(name), character.id] as const);
+            }),
           );
           const selected: string[] = [];
 
@@ -4529,28 +4564,44 @@ export async function generateRoutes(app: FastifyInstance) {
             .filter(Boolean)
             .join("\n");
 
-          const candidates = charInfo
-            .map((character) =>
-              [
+          const candidates = availableGroupCharacters
+            .map((character) => {
+              const presence = conversationCharacterPresenceById.get(character.id);
+              return [
                 `- id: ${character.id}`,
-                `  name: ${character.name}`,
-                `  talkativeness: ${Math.round(character.talkativeness * 100)}%`,
+                `  name: ${presence?.displayName ?? character.name}`,
+                `  talkativeness: ${presence?.talkativeness ?? Math.round(character.talkativeness * 100)}%`,
+                presence ? `  current status: ${presence.status}` : null,
+                presence?.activity ? `  current activity: ${presence.activity}` : null,
                 character.personality ? `  personality: ${character.personality.slice(0, 500)}` : null,
                 character.description ? `  description: ${character.description.slice(0, 500)}` : null,
               ]
                 .filter(Boolean)
-                .join("\n"),
-            )
+                .join("\n");
+            })
             .join("\n\n");
+
+          const selectorInstructions =
+            chatMode === "conversation"
+              ? [
+                  `You are a hidden response orchestrator for a Conversation-mode group chat.`,
+                  `Choose one or more available characters to respond next, based on the latest message, recent conversation, relevance, personality, current schedule status, activity, talkativeness, and who has spoken recently.`,
+                  `Usually choose exactly one character. Choose multiple only when multiple characters have a strong immediate reason to answer.`,
+                  `Prefer an online character over an idle or do-not-disturb character unless the conversation clearly calls for someone else.`,
+                  `Do not always choose the first character. Avoid making the same character speak twice in a row unless the context clearly calls for it.`,
+                ]
+              : [
+                  `You are a hidden response orchestrator for a roleplay group chat.`,
+                  `Choose which character or characters should respond next, based on the latest user message, recent scene context, relevance, personality, and who has spoken recently.`,
+                  `Usually choose exactly one character. Choose multiple only when multiple characters have a strong immediate reason to answer.`,
+                  `Do not always choose the first character. Avoid making the same character speak twice in a row unless the context clearly calls for it.`,
+                ];
 
           const selectionPrompt: ChatMessage[] = [
             {
               role: "system",
               content: [
-                `You are a hidden response orchestrator for a roleplay group chat.`,
-                `Choose which character or characters should respond next, based on the latest user message, recent scene context, relevance, personality, and who has spoken recently.`,
-                `Usually choose exactly one character. Choose multiple only when multiple characters have a strong immediate reason to answer.`,
-                `Do not always choose the first character. Avoid making the same character speak twice in a row unless the context clearly calls for it.`,
+                ...selectorInstructions,
                 `Return ONLY a valid JSON array of character IDs, such as ["character-id"]. No prose, no object wrapper, no markdown.`,
               ].join("\n"),
             },
@@ -4617,7 +4668,9 @@ export async function generateRoutes(app: FastifyInstance) {
             .find((message: any) => message.role === "assistant" && typeof message.characterId === "string")
             ?.characterId as string | undefined;
           const fallback =
-            charInfo.find((character) => character.id !== lastAssistantCharacterId)?.id ?? charInfo[0]?.id ?? null;
+            availableGroupCharacters.find((character) => character.id !== lastAssistantCharacterId)?.id ??
+            availableGroupCharacters[0]?.id ??
+            null;
           return fallback ? [fallback] : [];
         };
 
@@ -4669,7 +4722,7 @@ export async function generateRoutes(app: FastifyInstance) {
               characterIds: smartResponseQueue,
               characters: smartResponseQueue.map((id, index) => ({
                 id,
-                name: charInfo.find((character) => character.id === id)?.name ?? "Character",
+                name: groupResponderName(id),
                 order: index + 1,
               })),
             },
@@ -4695,8 +4748,8 @@ export async function generateRoutes(app: FastifyInstance) {
         const turnGameContextForSeat =
           chatMode === "conversation" ? await getTurnGameContextBuilder(app.db, input.chatId) : null;
 
-        // Manual mode with forCharacterId: only generate for the specified character
-        // Sequential: all characters respond. Smart: generate the first queued character only.
+        // Manual mode with forCharacterId: only generate for the specified character.
+        // Sequential: all available characters respond. Smart: generate the selected queue in order.
         const respondingCharIds = useIndividualLoop
           ? input.forCharacterId && characterIds.includes(input.forCharacterId)
             ? [input.forCharacterId]
@@ -4705,9 +4758,9 @@ export async function generateRoutes(app: FastifyInstance) {
               : groupResponseOrder === "manual"
                 ? [] // manual mode without forCharacterId or a mention: no auto-generation
                 : groupResponseOrder === "sequential"
-                  ? [...characterIds]
-                  : smartResponseQueue?.[0]
-                    ? [smartResponseQueue[0]]
+                  ? availableGroupCharacters.map((character) => character.id)
+                  : smartResponseQueue?.length
+                    ? [...smartResponseQueue]
                     : []
           : [characterIds[0] ?? null];
 

--- a/packages/server/src/routes/generate.routes.ts
+++ b/packages/server/src/routes/generate.routes.ts
@@ -94,7 +94,10 @@ import { injectAtDepth } from "../services/lorebook/prompt-injector.js";
 import { createLLMProvider } from "../services/llm/provider-registry.js";
 import { resolveChatSummaryConnection } from "../services/chat-summary/connection-resolution.js";
 import { resolveConnectionImageDefaults } from "../services/image/image-generation-defaults.js";
-import { loadImageGenerationUserSettings } from "../services/image/image-generation-settings.js";
+import {
+  loadImageGenerationUserSettings,
+  resolveIllustratorImageSize,
+} from "../services/image/image-generation-settings.js";
 import { textRewriteDropsProtectedMarkup } from "../services/generation/text-rewrite-safety.js";
 import { compileImagePrompt } from "../services/image/image-prompt-compiler.js";
 import { persistGeneratedImageToEntityGalleries } from "../services/image/generated-image-entity-gallery.js";
@@ -4625,14 +4628,11 @@ export async function generateRoutes(app: FastifyInstance) {
         const useIndividualLoop =
           isGroupChat && usesIndividualGroupGeneration && !input.regenerateMessageId && !input.impersonate;
         const regenGroupChatIndividual = isGroupChat && usesIndividualGroupGeneration && input.regenerateMessageId;
-        const mentionedConversationCharacters =
-          chatMode === "conversation" && isGroupChat && !input.impersonate
-            ? charInfo.filter((character) =>
-                (input.mentionedCharacterNames ?? []).some(
-                  (name: string) => normalizeTextForMatch(name) === normalizeTextForMatch(character.name),
-                ),
-              )
-            : [];
+        const explicitlyMentionedConversationCharacterIds =
+          chatMode === "conversation" && isGroupChat && !input.impersonate ? getExplicitlyMentionedCharacterIds() : [];
+        const mentionedConversationCharacters = charInfo.filter((character) =>
+          explicitlyMentionedConversationCharacterIds.includes(character.id),
+        );
 
         const hasExplicitGenerationDirective = input.impersonate === true || Boolean(input.generationGuide?.trim());
         const selectExplicitOrFallbackSmartGroupResponder = (): string[] => {
@@ -4700,13 +4700,15 @@ export async function generateRoutes(app: FastifyInstance) {
         const respondingCharIds = useIndividualLoop
           ? input.forCharacterId && characterIds.includes(input.forCharacterId)
             ? [input.forCharacterId]
-            : groupResponseOrder === "manual"
-              ? [] // manual mode without forCharacterId: no auto-generation
-              : groupResponseOrder === "sequential"
-                ? [...characterIds]
-                : smartResponseQueue?.[0]
-                  ? [smartResponseQueue[0]]
-                  : []
+            : explicitlyMentionedConversationCharacterIds.length > 0
+              ? explicitlyMentionedConversationCharacterIds
+              : groupResponseOrder === "manual"
+                ? [] // manual mode without forCharacterId or a mention: no auto-generation
+                : groupResponseOrder === "sequential"
+                  ? [...characterIds]
+                  : smartResponseQueue?.[0]
+                    ? [smartResponseQueue[0]]
+                    : []
           : [characterIds[0] ?? null];
 
         /** Generate a single response for a given character and save it. */
@@ -7890,8 +7892,12 @@ export async function generateRoutes(app: FastifyInstance) {
                         (chatMeta.imageStyleProfileId as string | undefined) ??
                         null;
 
-                      const imgWidth = imageSettings.illustration.width;
-                      const imgHeight = imageSettings.illustration.height;
+                      const illustrationSize = resolveIllustratorImageSize(
+                        imageSettings.illustration,
+                        illData.aspectRatio,
+                      );
+                      const imgWidth = illustrationSize.width;
+                      const imgHeight = illustrationSize.height;
 
                       // Prepend style to the prompt for better results
                       let fullPrompt = style ? `${style}, ${imagePrompt}` : imagePrompt;

--- a/packages/server/src/routes/generate/conversation-presence-runtime.ts
+++ b/packages/server/src/routes/generate/conversation-presence-runtime.ts
@@ -29,6 +29,8 @@ export type ConversationPromptCharacterInfo = {
   status: string;
   activity: string;
   todaySchedule: string;
+  /** Conversation schedule talkativeness (0–100), used by Smart group response selection. */
+  talkativeness: number;
 };
 
 type ConversationPresenceChatsStore = {
@@ -75,6 +77,7 @@ export async function resolveConversationPresenceRuntime(args: {
   convoCharNames: string[];
   charNameList: string;
   isGroup: boolean;
+  respondingCharacterIds: string[];
   chatMessages: any[];
   finalMessages: GenerationPromptMessage[];
 }> {
@@ -122,24 +125,42 @@ export async function resolveConversationPresenceRuntime(args: {
     if (respondingConvoCharInfo.length === 0) {
       args.writeSse({ type: "done" });
       args.endSse();
-      return buildPresenceResult({ ended: true, convoCharInfo, convoCharNames, charNameList, args });
+      return buildPresenceResult({
+        ended: true,
+        convoCharInfo,
+        convoCharNames,
+        charNameList,
+        respondingCharacterIds: [],
+        args,
+      });
     }
   }
 
-  const respondingConvoCharNames = respondingConvoCharInfo.map((character) => character.displayName);
+  const requestedResponderNames = respondingConvoCharInfo.map((character) => character.displayName);
   const seatedGameCharIds = await resolveSeatedTurnGameCharacterIds(args.db, args.chatId);
   const effectiveStatus = (character: { charId: string; status: string }): string =>
     seatedGameCharIds.has(character.charId) ? "online" : character.status;
 
-  const allOffline =
-    respondingConvoCharInfo.length > 0 &&
-    respondingConvoCharInfo.every((character) => effectiveStatus(character) === "offline");
-  if (allOffline && !args.regenerateMessageId && !args.impersonate) {
-    args.writeSse({ type: "offline", characters: respondingConvoCharNames });
+  if (!args.regenerateMessageId && !args.impersonate) {
+    respondingConvoCharInfo = respondingConvoCharInfo.filter(
+      (character) => effectiveStatus(character) !== "offline",
+    );
+  }
+  if (respondingConvoCharInfo.length === 0 && !args.regenerateMessageId && !args.impersonate) {
+    args.writeSse({ type: "offline", characters: requestedResponderNames });
     args.writeSse({ type: "done" });
     args.endSse();
-    return buildPresenceResult({ ended: true, convoCharInfo, convoCharNames, charNameList, args });
+    return buildPresenceResult({
+      ended: true,
+      convoCharInfo,
+      convoCharNames,
+      charNameList,
+      respondingCharacterIds: [],
+      args,
+    });
   }
+  const respondingConvoCharNames = respondingConvoCharInfo.map((character) => character.displayName);
+  const respondingCharacterIds = respondingConvoCharInfo.map((character) => character.charId);
 
   let chatMessages = args.chatMessages;
   let finalMessages = args.finalMessages;
@@ -179,6 +200,7 @@ export async function resolveConversationPresenceRuntime(args: {
           convoCharInfo,
           convoCharNames,
           charNameList,
+          respondingCharacterIds,
           args,
           chatMessages,
           finalMessages,
@@ -205,7 +227,16 @@ export async function resolveConversationPresenceRuntime(args: {
     args.writeSse({ type: "typing", characters: convoCharNames });
   }
 
-  return buildPresenceResult({ ended: false, convoCharInfo, convoCharNames, charNameList, args, chatMessages, finalMessages });
+  return buildPresenceResult({
+    ended: false,
+    convoCharInfo,
+    convoCharNames,
+    charNameList,
+    respondingCharacterIds,
+    args,
+    chatMessages,
+    finalMessages,
+  });
 }
 
 async function resolveConversationPromptCharacters(args: {
@@ -234,12 +265,14 @@ async function resolveConversationPromptCharacters(args: {
     let status = fallback.status;
     let activity = fallback.activity;
     let todaySchedule = "";
+    let talkativeness = 50;
     const schedule = args.schedules[cid];
     if (schedule) {
       const derived = getEffectiveCurrentStatus(schedule, override, args.actualNow, "free time", args.promptNow);
       status = derived.status;
       activity = derived.activity;
       todaySchedule = getTodaySchedule(schedule, args.promptNow);
+      talkativeness = schedule.talkativeness;
     }
     const characterData = data as { name?: string; extensions?: Record<string, unknown> } | null;
     const name = characterData?.name?.trim() || "Unknown";
@@ -254,6 +287,7 @@ async function resolveConversationPromptCharacters(args: {
       status,
       activity,
       todaySchedule,
+      talkativeness,
     });
   }
   return convoCharInfo;
@@ -324,6 +358,7 @@ function buildPresenceResult(args: {
   convoCharInfo: ConversationPromptCharacterInfo[];
   convoCharNames: string[];
   charNameList: string;
+  respondingCharacterIds: string[];
   args: { chatMessages: any[]; finalMessages: GenerationPromptMessage[] };
   chatMessages?: any[];
   finalMessages?: GenerationPromptMessage[];
@@ -335,6 +370,7 @@ function buildPresenceResult(args: {
     convoCharNames: args.convoCharNames,
     charNameList: args.charNameList,
     isGroup: args.convoCharNames.length > 1,
+    respondingCharacterIds: args.respondingCharacterIds,
     chatMessages: args.chatMessages ?? args.args.chatMessages,
     finalMessages: args.finalMessages ?? args.args.finalMessages,
   };

--- a/packages/server/src/routes/generate/generate-route-utils.ts
+++ b/packages/server/src/routes/generate/generate-route-utils.ts
@@ -846,16 +846,11 @@ export function resolveActiveCharacterIds(
 
 export type GroupGenerationMode = "merged" | "individual";
 
-/**
- * Conversation groups are always generated as one merged provider response so
- * the model can decide which present characters speak in the turn. Only
- * roleplay-style chats honor an explicit merged/individual mode.
- */
+/** Resolve the stored generation mode for every group-capable chat mode. */
 export function resolveGroupGenerationMode(
-  chatMode: string | null | undefined,
+  _chatMode: string | null | undefined,
   configuredMode: unknown,
 ): GroupGenerationMode {
-  if (chatMode === "conversation") return "merged";
   return configuredMode === "individual" ? "individual" : "merged";
 }
 

--- a/packages/server/src/routes/generate/retry-agents-route.ts
+++ b/packages/server/src/routes/generate/retry-agents-route.ts
@@ -66,7 +66,10 @@ import { createPromptsStorage } from "../../services/storage/prompts.storage.js"
 import { findLastUserMessageIdBefore } from "../../services/generation/message-history.js";
 import { textRewriteDropsProtectedMarkup } from "../../services/generation/text-rewrite-safety.js";
 import { resolveConnectionImageDefaults } from "../../services/image/image-generation-defaults.js";
-import { loadImageGenerationUserSettings } from "../../services/image/image-generation-settings.js";
+import {
+  loadImageGenerationUserSettings,
+  resolveIllustratorImageSize,
+} from "../../services/image/image-generation-settings.js";
 import { compileImagePrompt } from "../../services/image/image-prompt-compiler.js";
 import { persistGeneratedImageToEntityGalleries } from "../../services/image/generated-image-entity-gallery.js";
 import { resolveImageConnectionFallback } from "../../services/generation/media-connection-fallback.js";
@@ -162,26 +165,6 @@ type PersonaContext = {
   personaStats: any;
   rpgStats: any;
 };
-
-function resolveIllustratorImageSize(
-  size: { width: number; height: number },
-  aspectRatio: unknown,
-): { width: number; height: number } {
-  const width = Math.max(1, Math.round(size.width));
-  const height = Math.max(1, Math.round(size.height));
-  const aspect = typeof aspectRatio === "string" ? aspectRatio.trim().toLowerCase() : "";
-  if (aspect === "portrait") {
-    return width <= height ? { width, height } : { width: height, height: width };
-  }
-  if (aspect === "landscape") {
-    return width >= height ? { width, height } : { width: height, height: width };
-  }
-  if (aspect === "square") {
-    const side = Math.min(width, height);
-    return { width: side, height: side };
-  }
-  return { width, height };
-}
 
 function cardPromptText(value: unknown): string {
   return typeof value === "string" ? stripMacroComments(value).trim() : "";

--- a/packages/server/src/routes/noodle.routes.ts
+++ b/packages/server/src/routes/noodle.routes.ts
@@ -43,6 +43,7 @@ import {
 } from "../services/noodle/noodle-refresh-schedule.js";
 import { isFileUniqueConstraintError } from "../db/file-schema.js";
 import { resolveImageCaptioningRuntime } from "./generate/image-captioning-runtime.js";
+import { normalizePromptTimeZone } from "../services/conversation/timezone.js";
 import { resolveNoodleAvatarCropAfterProfileUpdate } from "../services/noodle/noodle-profile-avatar.js";
 
 import { createPublicNoodleGenerationService } from "../services/noodle/noodle-public-generation.service.js";
@@ -789,6 +790,7 @@ export async function noodleRoutes(app: FastifyInstance) {
         imageCaptioning,
         settings,
         personaId: parsed.data.personaId,
+        timeZone: normalizePromptTimeZone(parsed.data.timeZone),
         debugMode: parsed.data.debugMode === true,
         reviewImagePromptsBeforeSend: parsed.data.reviewImagePromptsBeforeSend === true,
       });

--- a/packages/server/src/services/conversation/autonomous.service.ts
+++ b/packages/server/src/services/conversation/autonomous.service.ts
@@ -131,7 +131,11 @@ export function isAutonomousDailyBudgetExhausted(
   now: Date = new Date(),
 ): boolean {
   const budget = getAutonomousDailyBudget(chatMeta, now);
-  return (budget.counts[characterId] ?? 0) >= dailyCapForCharacter(schedule, chatMeta);
+  const checkInCount =
+    chatMeta.groupChatMode === "individual"
+      ? Object.values(budget.counts).reduce((total, count) => total + count, 0)
+      : (budget.counts[characterId] ?? 0);
+  return checkInCount >= dailyCapForCharacter(schedule, chatMeta);
 }
 
 export function buildAutonomousDailyBudgetPatch(

--- a/packages/server/src/services/image/image-generation-settings.ts
+++ b/packages/server/src/services/image/image-generation-settings.ts
@@ -40,6 +40,23 @@ export function clampImageDimension(value: unknown, fallback: number) {
   return Math.max(IMAGE_DIMENSION_MIN, Math.min(IMAGE_DIMENSION_MAX, Math.round(numeric)));
 }
 
+export function resolveIllustratorImageSize(size: ImageGenerationSize, aspectRatio: unknown): ImageGenerationSize {
+  const width = Math.max(1, Math.round(size.width));
+  const height = Math.max(1, Math.round(size.height));
+  const aspect = typeof aspectRatio === "string" ? aspectRatio.trim().toLowerCase() : "";
+  if (aspect === "portrait") {
+    return width <= height ? { width, height } : { width: height, height: width };
+  }
+  if (aspect === "landscape") {
+    return width >= height ? { width, height } : { width: height, height: width };
+  }
+  if (aspect === "square") {
+    const side = Math.min(width, height);
+    return { width: side, height: side };
+  }
+  return { width, height };
+}
+
 function readSize(raw: Record<string, unknown>, widthKey: string, heightKey: string, fallback: ImageGenerationSize) {
   return {
     width: clampImageDimension(raw[widthKey], fallback.width),

--- a/packages/server/src/services/noodle/noodle-public-generation.service.ts
+++ b/packages/server/src/services/noodle/noodle-public-generation.service.ts
@@ -51,6 +51,7 @@ type PublicGenerationInput = {
   imageCaptioning: ImageCaptioningRuntime;
   settings: NoodleSettings;
   personaId?: string;
+  timeZone?: string;
   debugMode: boolean;
   reviewImagePromptsBeforeSend: boolean;
 };
@@ -257,6 +258,7 @@ export function createPublicNoodleGenerationService(db: DB) {
           activeAccounts: selectedParticipants,
           personaAccount,
           settings,
+          timeZone: input.timeZone,
           imageCaptioning,
           debugMode,
         });

--- a/packages/server/src/services/noodle/noodle-public-prompt.service.ts
+++ b/packages/server/src/services/noodle/noodle-public-prompt.service.ts
@@ -4,6 +4,7 @@ import {
   type NoodleAccount,
   type NoodlePost,
   type NoodleSettings,
+  type WeekSchedule,
 } from "@marinara-engine/shared";
 import type { ChatMessage } from "../llm/base-provider.js";
 import { createCharactersStorage } from "../storage/characters.storage.js";
@@ -42,6 +43,13 @@ import {
   type NoodleVisionAttachment,
 } from "./noodle-vision.js";
 import { characterNameFromRow, parseRecord } from "./noodle-public-support.js";
+import { areConversationSchedulesEnabled } from "../generation/conversation-context-utils.js";
+import { getTodaySchedule, scheduleNeedsRefresh } from "../conversation/schedule.service.js";
+import {
+  normalizePromptTimeZone,
+  resolveConversationTimeZone,
+  toZonedWallClockDate,
+} from "../conversation/timezone.js";
 
 function parseStringArray(value: unknown): string[] {
   if (Array.isArray(value)) return value.filter((item): item is string => typeof item === "string" && item.length > 0);
@@ -58,6 +66,58 @@ function parseStringArray(value: unknown): string[] {
 
 function escapePromptAttribute(value: string) {
   return value.replace(/&/g, "&amp;").replace(/"/g, "&quot;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+}
+
+function parseWeekSchedule(value: unknown): WeekSchedule | null {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return null;
+  const schedule = value as Record<string, unknown>;
+  if (typeof schedule.weekStart !== "string" || !schedule.days || typeof schedule.days !== "object") return null;
+  return value as WeekSchedule;
+}
+
+export function formatNoodleCurrentTime(now: Date = new Date(), timeZone?: string): string {
+  const normalizedTimeZone = normalizePromptTimeZone(timeZone);
+  return new Intl.DateTimeFormat("en-US", {
+    ...(normalizedTimeZone ? { timeZone: normalizedTimeZone } : {}),
+    weekday: "long",
+    year: "numeric",
+    month: "long",
+    day: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+    timeZoneName: "short",
+  }).format(now);
+}
+
+export async function buildGeneratedCharacterScheduleContext(
+  chats: ReturnType<typeof createChatsStorage>,
+  characterNamesById: ReadonlyMap<string, string>,
+  fallbackTimeZone?: string,
+  now: Date = new Date(),
+): Promise<string> {
+  const missingCharacterIds = new Set(characterNamesById.keys());
+  if (missingCharacterIds.size === 0) return "No active character schedules are available.";
+
+  const scheduleLines: string[] = [];
+  for (const chat of await chats.list()) {
+    if (chat.mode !== "conversation" || missingCharacterIds.size === 0) continue;
+    const metadata = parseRecord(chat.metadata);
+    if (!areConversationSchedulesEnabled(metadata)) continue;
+    const schedules = parseRecord(metadata.characterSchedules);
+    const timeZone = resolveConversationTimeZone(metadata) ?? normalizePromptTimeZone(fallbackTimeZone);
+    const scheduleNow = toZonedWallClockDate(now, timeZone);
+
+    for (const characterId of missingCharacterIds) {
+      const schedule = parseWeekSchedule(schedules[characterId]);
+      if (!schedule || scheduleNeedsRefresh(schedule, scheduleNow)) continue;
+      const today = getTodaySchedule(schedule, scheduleNow);
+      if (!today) continue;
+      scheduleLines.push(`- ${characterNamesById.get(characterId) ?? "Character"}: ${today}`);
+      missingCharacterIds.delete(characterId);
+    }
+  }
+
+  return scheduleLines.length > 0 ? scheduleLines.join("\n") : "No generated schedules are available for today.";
 }
 
 /**
@@ -259,6 +319,7 @@ export async function buildRefreshPrompt(input: {
   activeAccounts: NoodleAccount[];
   personaAccount: NoodleAccount | null;
   settings: NoodleSettings;
+  timeZone?: string;
   imageCaptioning: ImageCaptioningRuntime;
   debugMode: boolean;
 }) {
@@ -266,6 +327,9 @@ export async function buildRefreshPrompt(input: {
   const activeRandomUsers = input.activeAccounts.filter((account) => account.kind === "random_user");
   const selectedCharacterIds = activeCharacters.map((account) => account.entityId);
   const characterRows = await Promise.all(selectedCharacterIds.map((id) => input.characters.getById(id)));
+  const characterNamesById = new Map(
+    activeCharacters.map((account) => [account.entityId, account.displayName] as const),
+  );
   const personaRow = input.personaAccount ? await input.characters.getPersona(input.personaAccount.entityId) : null;
   const recentCutoff = sinceHoursIso(48);
   const [recentCreatedPosts, recentPersonaComments] = await Promise.all([
@@ -316,8 +380,11 @@ export async function buildRefreshPrompt(input: {
   } else {
     recalledPosts = sampleNoodlePastMemories(olderPosts, pastMemorySampleSize);
   }
-  const [chatContext, recentInteractions, recalledInteractions] = await Promise.all([
+  const [chatContext, characterScheduleContext, recentInteractions, recalledInteractions] = await Promise.all([
     buildOptedInChatContext(input.chats, input.characters, selectedCharacterIds),
+    input.settings.includeCharacterSchedules
+      ? buildGeneratedCharacterScheduleContext(input.chats, characterNamesById, input.timeZone)
+      : Promise.resolve(""),
     input.noodle.listInteractions(recentPosts.map((post) => post.id)),
     input.noodle.listInteractions(recalledPosts.map((post) => post.id)),
   ]);
@@ -448,6 +515,7 @@ export async function buildRefreshPrompt(input: {
     [
       "# Active Noodle Accounts",
       activeAccountList || "No active accounts.",
+      `Current user time: ${formatNoodleCurrentTime(new Date(), input.timeZone)}`,
       "",
       "# User Persona",
       personaContext,
@@ -459,6 +527,7 @@ export async function buildRefreshPrompt(input: {
       "# Character Profiles",
       characterContext || "No character profiles.",
       "",
+      ...(characterScheduleContext ? ["# Today's Generated Character Schedules", characterScheduleContext, ""] : []),
       ...(loreContext ? ["# World / Lore", loreContext, ""] : []),
       ...(randomUserContext ? ["# Random User Profiles", randomUserContext, ""] : []),
       "# Opted-In Chat Context",

--- a/packages/shared/src/constants/chat-mode-capabilities.ts
+++ b/packages/shared/src/constants/chat-mode-capabilities.ts
@@ -116,6 +116,7 @@ export const CHAT_MODE_CAPABILITIES: Record<ChatMode, ChatModeCapabilities> = {
     modeSections: [
       "prompt-preset",
       "manual-replies",
+      "group-chat",
       "autonomous-messaging",
       "conversation-commands",
       "cross-chat-awareness",
@@ -123,7 +124,7 @@ export const CHAT_MODE_CAPABILITIES: Record<ChatMode, ChatModeCapabilities> = {
     ],
     supportsChatSettingsPresets: true,
     supportsPromptPresets: true,
-    supportsGroupChatControls: false,
+    supportsGroupChatControls: true,
     supportsSceneInstructions: false,
     supportsConnectedChat: true,
   },

--- a/packages/shared/src/schemas/noodle.schema.ts
+++ b/packages/shared/src/schemas/noodle.schema.ts
@@ -32,6 +32,7 @@ export const DEFAULT_NOODLE_SETTINGS = {
   imageCaptioningEnabled: false,
   imageCaptioningConnectionId: null,
   enableLorebookContext: false,
+  includeCharacterSchedules: false,
   enableEnhancedTimelineWriting: false,
   allowProfessorMari: true,
   allowRandomUsers: false,
@@ -79,6 +80,7 @@ export const noodleSettingsSchema = z.object({
     .nullable()
     .default(DEFAULT_NOODLE_SETTINGS.imageCaptioningConnectionId),
   enableLorebookContext: z.boolean().default(DEFAULT_NOODLE_SETTINGS.enableLorebookContext),
+  includeCharacterSchedules: z.boolean().default(DEFAULT_NOODLE_SETTINGS.includeCharacterSchedules),
   enableEnhancedTimelineWriting: z.boolean().default(DEFAULT_NOODLE_SETTINGS.enableEnhancedTimelineWriting),
   allowProfessorMari: z.boolean().default(DEFAULT_NOODLE_SETTINGS.allowProfessorMari),
   allowRandomUsers: z.boolean().default(DEFAULT_NOODLE_SETTINGS.allowRandomUsers),
@@ -353,6 +355,7 @@ export const noodlePublicGenerationRequestSchema = z
     mode: z.literal("public"),
     ...noodleGenerationConnectionShape,
     personaId: z.string().min(1).optional(),
+    timeZone: z.string().min(1).max(100).optional(),
     reviewImagePromptsBeforeSend: z.boolean().optional(),
   })
   .strict();

--- a/packages/shared/src/types/noodle.ts
+++ b/packages/shared/src/types/noodle.ts
@@ -77,6 +77,7 @@ export interface NoodleSettings {
   imageCaptioningEnabled: boolean;
   imageCaptioningConnectionId: string | null;
   enableLorebookContext: boolean;
+  includeCharacterSchedules: boolean;
   enableEnhancedTimelineWriting: boolean;
   allowProfessorMari: boolean;
   allowRandomUsers: boolean;

--- a/scripts/regressions/noodle-prompt.regression.ts
+++ b/scripts/regressions/noodle-prompt.regression.ts
@@ -52,7 +52,11 @@ import {
 import { normalizeNoodleImagePrompt } from "../../packages/server/src/services/noodle/noodle-image-prompt.js";
 import { characterAppearanceFromRow } from "../../packages/server/src/services/noodle/noodle-public-images.service.js";
 import { buildNoodleProfileTargetBlock } from "../../packages/server/src/services/noodle/noodle-public-profiles.service.js";
-import { buildOptedInChatContext } from "../../packages/server/src/services/noodle/noodle-public-prompt.service.js";
+import {
+  buildGeneratedCharacterScheduleContext,
+  buildOptedInChatContext,
+  formatNoodleCurrentTime,
+} from "../../packages/server/src/services/noodle/noodle-public-prompt.service.js";
 import { formatNoodleMessagesForLog } from "../../packages/server/src/services/noodle/noodle-generation-log.js";
 import {
   buildPrivatePostMessages,
@@ -350,6 +354,7 @@ assert.equal(
   true,
 );
 assert.equal(noodleGenerationRequestSchema.safeParse({ mode: "public", personaId: "persona-1" }).success, true);
+assert.equal(noodleGenerationRequestSchema.safeParse({ mode: "public", timeZone: "Europe/Warsaw" }).success, true);
 assert.equal(
   noodleGenerationRequestSchema.safeParse({
     mode: "private",
@@ -859,6 +864,40 @@ const optedInChatContext = await buildOptedInChatContext(
 assert.doesNotMatch(optedInChatContext, /chat-0/u);
 assert.match(optedInChatContext, /chat-8/u);
 assert.equal((optedInChatContext.match(/<chat_context /gu) ?? []).length, 8);
+
+const noodleScheduleNow = new Date("2026-07-21T10:30:00.000Z");
+const generatedScheduleContext = await buildGeneratedCharacterScheduleContext(
+  {
+    list: async () => [
+      {
+        id: "schedule-chat",
+        mode: "conversation",
+        metadata: {
+          conversationSchedulesEnabled: true,
+          conversationTimeZone: "Europe/Warsaw",
+          characterSchedules: {
+            "character-alpha": {
+              weekStart: "2026-07-20T00:00:00.000Z",
+              days: {
+                Tuesday: [
+                  { time: "08:00-12:00", status: "dnd", activity: "laboratory work" },
+                  { time: "12:00-13:00", status: "idle", activity: "lunch" },
+                ],
+              },
+              inactivityThresholdMinutes: 60,
+              talkativeness: 50,
+            },
+          },
+        },
+      },
+    ],
+  } as never,
+  new Map([["character-alpha", "Alpha"]]),
+  "UTC",
+  noodleScheduleNow,
+);
+assert.match(generatedScheduleContext, /Alpha: 08:00-12:00: laboratory work, 12:00-13:00: lunch/u);
+assert.match(formatNoodleCurrentTime(noodleScheduleNow, "Europe/Warsaw"), /12:30/u);
 
 const correctionMessages = [
   { role: "system" as const, content: "system prompt" },

--- a/scripts/regressions/noodle-settings.regression.ts
+++ b/scripts/regressions/noodle-settings.regression.ts
@@ -68,10 +68,12 @@ try {
   const updated = await firstNoodle.updateSettings({
     maxImagesPerRefresh: 9,
     allowRandomUsers: true,
+    includeCharacterSchedules: true,
     maxGeneratedPostsPerRefresh: 11,
   });
   assert.equal(updated.maxImagesPerRefresh, 9);
   assert.equal(updated.allowRandomUsers, true);
+  assert.equal(updated.includeCharacterSchedules, true);
   assert.equal(updated.maxGeneratedPostsPerRefresh, 11);
   const concurrentAccount = await firstNoodle.upsertAccountFromProfile({
     kind: "persona",
@@ -361,6 +363,7 @@ try {
   const reopenedSettings = await reopenedNoodle.getSettings();
   assert.equal(reopenedSettings.maxImagesPerRefresh, 9);
   assert.equal(reopenedSettings.allowRandomUsers, true);
+  assert.equal(reopenedSettings.includeCharacterSchedules, true);
   assert.equal(reopenedSettings.maxGeneratedPostsPerRefresh, 11);
   assert.equal((await reopenedNoodle.listSubscriptionsForViewer(viewer.id)).length, 0);
   assert.equal((await reopenedNoodle.listPostUnlocksForViewer(viewer.id)).length, 0);

--- a/scripts/regressions/open-issues.regression.ts
+++ b/scripts/regressions/open-issues.regression.ts
@@ -973,6 +973,10 @@ const conversationGenerationSource = readFileSync(
   new URL("../../packages/server/src/routes/generate.routes.ts", import.meta.url),
   "utf8",
 );
+const conversationPresenceSource = readFileSync(
+  new URL("../../packages/server/src/routes/generate/conversation-presence-runtime.ts", import.meta.url),
+  "utf8",
+);
 const professorMariHomeSource = readFileSync(
   new URL("../../packages/client/src/components/chat/HomeProfessorMariChat.tsx", import.meta.url),
   "utf8",
@@ -980,6 +984,26 @@ const professorMariHomeSource = readFileSync(
 assert.doesNotMatch(conversationGroupSettingsSource, /Reply When Mentioned/u);
 assert.doesNotMatch(conversationGroupSettingsSource, /label="Cross-Chat Awareness"/u);
 assert.match(conversationGroupSettingsSource, /Individual replies can use many tokens/u);
+assert.match(
+  conversationGroupSettingsSource,
+  /\{!isConversation && \(\s*<button[\s\S]{0,1500}Name Prefix History/u,
+  "Conversation group settings should not show the roleplay-only Name Prefix History toggle",
+);
+assert.match(
+  conversationPresenceSource,
+  /respondingConvoCharInfo = respondingConvoCharInfo\.filter\(\s*\(character\) => effectiveStatus\(character\) !== "offline"/u,
+  "Conversation response selection should remove offline characters before Sequential or Smart ordering",
+);
+assert.match(
+  conversationGenerationSource,
+  /Choose one or more available characters[\s\S]{0,500}current schedule status[\s\S]{0,500}talkativeness/u,
+  "Conversation Smart ordering should use a schedule-aware selector prompt",
+);
+assert.match(
+  conversationGenerationSource,
+  /smartResponseQueue\?\.length\s*\? \[\.\.\.smartResponseQueue\]/u,
+  "Smart ordering should generate every character selected by the responder queue",
+);
 assert.match(
   conversationGenerationSource,
   /explicitlyMentionedConversationCharacterIds\.length > 0\s*\? explicitlyMentionedConversationCharacterIds/u,

--- a/scripts/regressions/open-issues.regression.ts
+++ b/scripts/regressions/open-issues.regression.ts
@@ -51,6 +51,7 @@ import {
 } from "../../packages/client/src/lib/game-npc-avatar.js";
 import { characterMatchesSearch, parseCharacterDisplayData } from "../../packages/client/src/lib/character-display.js";
 import { DEFAULT_GENERATION_PARAMS } from "../../packages/shared/src/constants/defaults.js";
+import { getChatModeCapabilities } from "../../packages/shared/src/constants/chat-mode-capabilities.js";
 import { mergeNoodleCustomEmojiMap } from "../../packages/client/src/hooks/use-noodle-custom-emojis.js";
 import {
   isBundledGameAssetFolderPath,
@@ -318,6 +319,8 @@ assert.strictEqual(parseDockerDefaultGatewayIp("Iface\tDestination\tGateway\tFla
 
 assert.equal(resolveGroupGenerationMode("conversation", "individual"), "individual");
 assert.equal(resolveGroupGenerationMode("conversation", "merged"), "merged");
+assert.equal(getChatModeCapabilities("conversation").supportsGroupChatControls, true);
+assert.equal(getChatModeCapabilities("conversation").modeSections.includes("group-chat"), true);
 assert.equal(resolveGroupGenerationMode("roleplay", "individual"), "individual");
 assert.equal(resolveGroupGenerationMode("roleplay", "merged"), "merged");
 assert.equal(shouldRestoreRegenerationCharacterTarget("roleplay", "merged", ["a", "b"]), false);

--- a/scripts/regressions/open-issues.regression.ts
+++ b/scripts/regressions/open-issues.regression.ts
@@ -32,7 +32,10 @@ import {
 } from "../../packages/client/src/lib/slash-commands.js";
 import { getAvatarCropStyle } from "../../packages/client/src/lib/utils.js";
 import { resolveEchoChamberTopLayout } from "../../packages/client/src/lib/echo-chamber-layout.js";
-import { resolveConversationSelfieConnectionId } from "../../packages/client/src/lib/conversation-selfie-setup.js";
+import {
+  resolveConversationSelfieConnectionId,
+  resolveConversationSelfieSetup,
+} from "../../packages/client/src/lib/conversation-selfie-setup.js";
 import {
   resolveTrackerPanelContentScale,
   resolveTrackerPanelDesktopWidth,
@@ -46,10 +49,7 @@ import {
   withFreshNpcAvatarRevision,
   withoutNpcAvatarRevision,
 } from "../../packages/client/src/lib/game-npc-avatar.js";
-import {
-  characterMatchesSearch,
-  parseCharacterDisplayData,
-} from "../../packages/client/src/lib/character-display.js";
+import { characterMatchesSearch, parseCharacterDisplayData } from "../../packages/client/src/lib/character-display.js";
 import { DEFAULT_GENERATION_PARAMS } from "../../packages/shared/src/constants/defaults.js";
 import { mergeNoodleCustomEmojiMap } from "../../packages/client/src/hooks/use-noodle-custom-emojis.js";
 import {
@@ -85,15 +85,13 @@ import {
   resolveGameSetupImport,
   type GameSetupShareSource,
 } from "../../packages/client/src/lib/game-setup-share.js";
-import {
-  classifyWorldWeather,
-  getTemperatureGaugeDisplay,
-} from "../../packages/client/src/lib/world-state-helpers.js";
+import { classifyWorldWeather, getTemperatureGaugeDisplay } from "../../packages/client/src/lib/world-state-helpers.js";
 import {
   resolveStandardEmojiShortcode,
   searchStandardEmojiShortcodes,
 } from "../../packages/client/src/lib/emoji-shortcodes.js";
 import { persistGeneratedImageToEntityGalleries } from "../../packages/server/src/services/image/generated-image-entity-gallery.js";
+import { resolveIllustratorImageSize } from "../../packages/server/src/services/image/image-generation-settings.js";
 import { fetchBotBrowserJson } from "../../packages/server/src/services/bot-browser/fetch-json.js";
 import { isAllowedResponseContentType, validateOutboundUrl } from "../../packages/server/src/utils/security.js";
 import {
@@ -318,7 +316,7 @@ assert.strictEqual(
 );
 assert.strictEqual(parseDockerDefaultGatewayIp("Iface\tDestination\tGateway\tFlags\tMetric\n"), null);
 
-assert.equal(resolveGroupGenerationMode("conversation", "individual"), "merged");
+assert.equal(resolveGroupGenerationMode("conversation", "individual"), "individual");
 assert.equal(resolveGroupGenerationMode("conversation", "merged"), "merged");
 assert.equal(resolveGroupGenerationMode("roleplay", "individual"), "individual");
 assert.equal(resolveGroupGenerationMode("roleplay", "merged"), "merged");
@@ -326,6 +324,18 @@ assert.equal(shouldRestoreRegenerationCharacterTarget("roleplay", "merged", ["a"
 assert.equal(shouldRestoreRegenerationCharacterTarget("visual_novel", undefined, ["a", "b"]), false);
 assert.equal(shouldRestoreRegenerationCharacterTarget("roleplay", "individual", ["a", "b"]), true);
 assert.equal(shouldRestoreRegenerationCharacterTarget("roleplay", "merged", ["a"]), true);
+assert.deepEqual(resolveIllustratorImageSize({ width: 960, height: 540 }, "landscape"), {
+  width: 960,
+  height: 540,
+});
+assert.deepEqual(resolveIllustratorImageSize({ width: 540, height: 960 }, "landscape"), {
+  width: 960,
+  height: 540,
+});
+assert.deepEqual(resolveIllustratorImageSize({ width: 960, height: 540 }, "portrait"), {
+  width: 540,
+  height: 960,
+});
 
 const minimalProfessorMariPersona = buildPersonaCreateRow(
   { name: "Minimal helper persona" },
@@ -847,6 +857,14 @@ assert.equal(
   }),
   false,
 );
+assert.equal(
+  isAutonomousDailyBudgetExhausted("third-character", autonomousSchedule(70, 2), {
+    groupChatMode: "individual",
+    autonomousDailyBudget: { date: dateKey, counts: { tartaglia: 1, dottore: 1 } },
+  }),
+  true,
+  "individual Conversation groups should share one daily check-in count across their characters",
+);
 clearChatActivity(autonomousChatId);
 assert.equal(
   getApiErrorMessage(
@@ -930,6 +948,46 @@ assert.equal(
   }),
   null,
 );
+assert.deepEqual(
+  resolveConversationSelfieSetup({
+    commandToggles: {},
+    selfieCommandAvailable: true,
+    selfieCommandEnabled: true,
+    currentConnectionId: null,
+    connections: conversationImageConnections,
+  }),
+  {
+    conversationCommandToggles: { selfie: true },
+    imageGenConnectionId: "image-default",
+  },
+  "Conversation setup should persist both the enabled Selfie command and its default image connection",
+);
+const conversationGroupSettingsSource = readFileSync(
+  new URL("../../packages/client/src/components/chat/ChatSettingsDrawer.tsx", import.meta.url),
+  "utf8",
+);
+const conversationGenerationSource = readFileSync(
+  new URL("../../packages/server/src/routes/generate.routes.ts", import.meta.url),
+  "utf8",
+);
+const professorMariHomeSource = readFileSync(
+  new URL("../../packages/client/src/components/chat/HomeProfessorMariChat.tsx", import.meta.url),
+  "utf8",
+);
+assert.doesNotMatch(conversationGroupSettingsSource, /Reply When Mentioned/u);
+assert.doesNotMatch(conversationGroupSettingsSource, /label="Cross-Chat Awareness"/u);
+assert.match(conversationGroupSettingsSource, /Individual replies can use many tokens/u);
+assert.match(
+  conversationGenerationSource,
+  /explicitlyMentionedConversationCharacterIds\.length > 0\s*\? explicitlyMentionedConversationCharacterIds/u,
+  "explicit Conversation mentions should select the mentioned responders before the stored response order",
+);
+assert.match(
+  conversationGenerationSource,
+  /resolveIllustratorImageSize\(\s*imageSettings\.illustration,\s*illData\.aspectRatio/u,
+  "automatic Illustrator generation should use the same orientation resolver as manual Gallery generation",
+);
+assert.match(professorMariHomeSource, /Math\.min\(textarea\.scrollHeight, 128\)/u);
 const playwrightWebServer = Array.isArray(playwrightConfig.webServer)
   ? playwrightConfig.webServer[0]
   : playwrightConfig.webServer;
@@ -1077,7 +1135,8 @@ assert.match(
   /\[data-marinara-accent-animation\] :where\(\.mari-editor-shell, select\) \{[\s\S]*--primary: var\(--marinara-app-accent-static\);[\s\S]*--marinara-chat-chrome-accent: var\(--marinara-app-accent-static\);[\s\S]*\}/u,
 );
 assert.match(globalStyles, /\[data-marinara-accent-animation\] select \{\s*transition: none;\s*\}/u);
-const markdownBlockquoteStyles = globalStyles.match(/\.mari-message-content \.mari-md-blockquote \{[\s\S]*?\}/u)?.[0] ?? "";
+const markdownBlockquoteStyles =
+  globalStyles.match(/\.mari-message-content \.mari-md-blockquote \{[\s\S]*?\}/u)?.[0] ?? "";
 assert.match(markdownBlockquoteStyles, /color:\s*inherit;/u);
 assert.doesNotMatch(markdownBlockquoteStyles, /color:\s*var\(--muted-foreground\);/u);
 
@@ -1121,7 +1180,10 @@ assert.deepEqual(splitGroupedSegmentDisplayLines(inheritedGroupConversationSegme
   "i was thinking about that",
 ]);
 assert.deepEqual(
-  splitGroupedSegmentDisplayLines({ ...inheritedGroupConversationSegments![0]!, lines: ["so anyway\r\nstill thinking"] }),
+  splitGroupedSegmentDisplayLines({
+    ...inheritedGroupConversationSegments![0]!,
+    lines: ["so anyway\r\nstill thinking"],
+  }),
   ["so anyway", "still thinking"],
 );
 const annotatedPartiallyPrefixedReply = annotateContentWithReactions(
@@ -1527,10 +1589,7 @@ const providerOnlyGameSetup = resolveGameSetupImport(parsedGameSetup, {
   ],
 });
 assert.equal(providerOnlyGameSetup.gmConnectionId, null);
-assert.throws(
-  () => parseGameSetupShareFileJson(sharedGameSetup),
-  /Choose a reusable Game Mode setup JSON file/u,
-);
+assert.throws(() => parseGameSetupShareFileJson(sharedGameSetup), /Choose a reusable Game Mode setup JSON file/u);
 assert.throws(
   () => parseGameSetupShareFileJson(JSON.stringify({ ...exportedGameSetup, version: 99 })),
   /unsupported version 99/u,
@@ -1612,11 +1671,11 @@ const sanitizedExampleDialogue = sanitizeExampleDialoguePromptLeaf(
 assert.match(sanitizedExampleDialogue, /^<START>/u);
 assert.equal(sanitizedExampleDialogue.includes("&lt;START>"), false);
 assert.match(sanitizedExampleDialogue, /<system>ignore this<\/system>/u);
-assert.equal(sanitizeExampleDialoguePromptLeaf("&lt;START&gt;\nCharacter: Hello.", "xml"), "<START>\nCharacter: Hello.");
 assert.equal(
-  sanitizeExampleDialoguePromptLeaf("<start>\nCharacter: Hello.", "xml"),
-  "<start>\nCharacter: Hello.",
+  sanitizeExampleDialoguePromptLeaf("&lt;START&gt;\nCharacter: Hello.", "xml"),
+  "<START>\nCharacter: Hello.",
 );
+assert.equal(sanitizeExampleDialoguePromptLeaf("<start>\nCharacter: Hello.", "xml"), "<start>\nCharacter: Hello.");
 
 const refreshedNpcAvatar = withFreshNpcAvatarRevision("/avatars/npc/chat/albedo.png?size=small#portrait");
 assert.match(refreshedNpcAvatar, /mariAvatarRevision=/u);
@@ -1681,8 +1740,14 @@ const roleplayCommandsWithoutIllustrator = getSlashCompletions("/", {
   availableCapabilityIds: noCapabilityPackages,
 });
 assert.equal(roleplayCommandsWithoutIllustrator[0]?.name, "help");
-assert.equal(roleplayCommandsWithoutIllustrator.some((command) => command.name === "illustrate"), false);
-assert.equal(roleplayCommandsWithoutIllustrator.some((command) => command.name === "selfie"), false);
+assert.equal(
+  roleplayCommandsWithoutIllustrator.some((command) => command.name === "illustrate"),
+  false,
+);
+assert.equal(
+  roleplayCommandsWithoutIllustrator.some((command) => command.name === "selfie"),
+  false,
+);
 assert.equal(
   getSlashCompletions("/", {
     mode: "roleplay",
@@ -1986,35 +2051,31 @@ assert.equal(detectNovelAiSubjectCount("2girls, 1boy, outdoors | first | second 
 assert.equal(detectNovelAiSubjectCount("cinematic scene | first character | second character"), 2);
 assert.equal(detectNovelAiSubjectCount("empty landscape"), null);
 assert.deepEqual(
-  resolveNovelAiSize(
-    { prompt: "1girl", width: 1216, height: 832 },
-    "1girl",
-    { ...DEFAULT_NOVELAI_DEFAULTS, dynamicResolutionBySubjectCount: true },
-  ),
+  resolveNovelAiSize({ prompt: "1girl", width: 1216, height: 832 }, "1girl", {
+    ...DEFAULT_NOVELAI_DEFAULTS,
+    dynamicResolutionBySubjectCount: true,
+  }),
   { width: 832, height: 1216 },
 );
 assert.deepEqual(
-  resolveNovelAiSize(
-    { prompt: "2girls", width: 832, height: 1216 },
-    "2girls",
-    { ...DEFAULT_NOVELAI_DEFAULTS, dynamicResolutionBySubjectCount: true },
-  ),
+  resolveNovelAiSize({ prompt: "2girls", width: 832, height: 1216 }, "2girls", {
+    ...DEFAULT_NOVELAI_DEFAULTS,
+    dynamicResolutionBySubjectCount: true,
+  }),
   { width: 1024, height: 1024 },
 );
 assert.deepEqual(
-  resolveNovelAiSize(
-    { prompt: "1girl, 1boy, 1other", width: 832, height: 1216 },
-    "1girl, 1boy, 1other",
-    { ...DEFAULT_NOVELAI_DEFAULTS, dynamicResolutionBySubjectCount: true },
-  ),
+  resolveNovelAiSize({ prompt: "1girl, 1boy, 1other", width: 832, height: 1216 }, "1girl, 1boy, 1other", {
+    ...DEFAULT_NOVELAI_DEFAULTS,
+    dynamicResolutionBySubjectCount: true,
+  }),
   { width: 1216, height: 832 },
 );
 assert.deepEqual(
-  resolveNovelAiSize(
-    { prompt: "1girl", width: 1024, height: 1024 },
-    "1girl",
-    { ...DEFAULT_NOVELAI_DEFAULTS, dynamicResolutionBySubjectCount: false },
-  ),
+  resolveNovelAiSize({ prompt: "1girl", width: 1024, height: 1024 }, "1girl", {
+    ...DEFAULT_NOVELAI_DEFAULTS,
+    dynamicResolutionBySubjectCount: false,
+  }),
   { width: 1024, height: 1024 },
 );
 const legacyNovelAiProfile = {
@@ -2111,10 +2172,7 @@ assert.equal(comfyPlaceholderPng.toString("ascii", 1, 4), "PNG");
 assert.equal(comfyPlaceholderPng.readUInt32BE(16), 16);
 assert.equal(comfyPlaceholderPng.readUInt32BE(20), 16);
 
-const chatRoutesSource = readFileSync(
-  join(REPOSITORY_ROOT, "packages/server/src/routes/chats.routes.ts"),
-  "utf8",
-);
+const chatRoutesSource = readFileSync(join(REPOSITORY_ROOT, "packages/server/src/routes/chats.routes.ts"), "utf8");
 assert.match(
   chatRoutesSource,
   /if \(existing\.mode === "conversation" && hasStartedChat\) \{/u,
@@ -2162,10 +2220,8 @@ assert.equal(fittedSceneNarration.truncated, true);
 assert.equal(fittedSceneNarration.beats.at(-1)?.index, 99);
 assert.ok((fittedSceneNarration.beats[0]?.index ?? 0) > 0);
 assert.ok(
-  fittedSceneNarration.beats.reduce(
-    (total, beat) => total + beat.text.length + String(beat.index).length + 3,
-    0,
-  ) <= SIDECAR_SCENE_ANALYSIS_NARRATION_BUDGET_CHARS,
+  fittedSceneNarration.beats.reduce((total, beat) => total + beat.text.length + String(beat.index).length + 3, 0) <=
+    SIDECAR_SCENE_ANALYSIS_NARRATION_BUDGET_CHARS,
 );
 const fittedScenePrompt = buildSceneAnalyzerUserPrompt(
   longSceneNarration,
@@ -2241,7 +2297,10 @@ featureRepositoryArchive.addFile(
   "example-agents-main/agents.json",
   Buffer.from(JSON.stringify([{ ...repositoryDefinition, execution: "feature" }])),
 );
-assert.throws(() => parseCustomAgentRepositoryArchive(featureRepositoryArchive.toBuffer()), /requires a package runtime/u);
+assert.throws(
+  () => parseCustomAgentRepositoryArchive(featureRepositoryArchive.toBuffer()),
+  /requires a package runtime/u,
+);
 const originalCustomRepositoryFlag = process.env.ENABLE_CUSTOM_AGENT_REPOS;
 try {
   delete process.env.ENABLE_CUSTOM_AGENT_REPOS;


### PR DESCRIPTION
## Linked issues

Closes #3885
Closes #3886
Closes #3887
Closes #3889
Closes #3890
Closes #3891
Closes #3893

Issue #3877 was reviewed during this assigned-only sweep and intentionally remains open because full capability-package support for arbitrary custom repositories needs an explicit security and permission-model decision rather than a small issue-sweep patch.

## Why this change

This sweep addresses focused problems in Conversation groups, autonomous messaging, Noodle context, chat setup, and Roleplay illustrations:

- Professor Mari's input starts scrolling before users can see a useful multi-line draft.
- Noodle lacks the user's current time and cannot opt into existing character schedules.
- Multi-character Conversations need the same separate-request Individual mode available in Roleplay, with clear cost guidance and one shared autonomous check-in ceiling.
- Cross-chat settings are split across redundant sections, and the Discord controls have an oversized gap.
- Conversation setup can lose an enabled Selfie command and its default image connection.
- Character mentions can be disabled even though mentions should always call characters into group chats.
- Automatic Roleplay Illustrator generation does not use the orientation resolver already used by manual Gallery generation.
- Peek Prompt contains explanatory copy the maintainer removed as unnecessary.

## What changed

- Added Grouped and Individual response modes to Conversation group chats, reusing the existing Roleplay individual generation loop and response-order controls.
- Added a token-cost warning when Conversation Individual mode is selected.
- Preserved autonomous character selection by schedule and talkativeness while aggregating all Individual-mode character check-ins against one daily chat budget.
- Made explicit Conversation mentions take responder priority and removed the Reply When Mentioned toggle.
- Added the current local time to Noodle refresh prompts and an opt-in setting for today's already-generated Conversation schedules.
- Moved Cross-Chat Awareness into Connected Chats and normalized Discord webhook spacing.
- Persisted the enabled Selfie command together with its resolved default image connection during Conversation setup.
- Let Professor Mari's composer grow to approximately six lines before scrolling.
- Reused the manual Illustrator canvas-orientation resolver for unattended Roleplay illustrations.
- Included the maintainer's PeekPromptModal cleanup and updated release notes/docs.

## Automated validation

- `pnpm check` — passed (impeccable context, TypeScript/ESLint, shared/server/client builds)
- `pnpm regression:noodle` — passed
- `pnpm regression:prompt` — passed
- `pnpm regression:issues` — passed
- `pnpm version:check` — passed
- `pnpm smoke:ui` — 74 passed, 47 skipped, 1 pre-existing unrelated failure: the Noodle mobile shell test uses a strict `Open Noodle account menu` locator that currently matches both the header and mobile-nav buttons.
- `git diff --check` — passed

## Manual verification requested

- [ ] Manually verify Grouped and Individual Conversation generation with sequential, smart, manual, and explicit-mention responders.
- [ ] Manually verify a large autonomous Conversation group shows the Individual-mode warning and shares its daily check-in ceiling.
- [ ] Manually verify Noodle shows current-time-aware output with schedules both disabled and enabled.
- [ ] Manually verify Professor Mari's embedded and floating composers grow before scrolling.
- [ ] Manually verify Connected Chats, Discord spacing, and Selfie-enabled Conversation setup in desktop and mobile layouts.
- [ ] Manually verify an automatic Roleplay Illustrator image uses the same requested orientation as a manual Gallery illustration.
- [ ] Manually verify light and dark themes, narrow viewports, and error/empty states for the changed controls.

## Docs and release impact

Updated `CHANGELOG.md` and `docs/noodle/settings.md`. No version bump or release metadata change is included.

## UI evidence

No screenshots are attached. The automated UI smoke suite was run; the remaining manual visual checks are listed above.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added multi-character conversation response modes (grouped/individual) with daily budget + token warnings.
  * Added a Noodle “Use generated character schedules” option for timeline refreshes, including local time context.
  * Automatically resizes the Professor Mari chat composer.
* **Bug Fixes**
  * Improved roleplay image generation consistency and illustrator sizing.
  * Corrected conversation mention responder behavior and removed the redundant “Reply When Mentioned” toggle.
  * Fixed Selfie setup persistence, connected-chat settings organization, and Peek Prompt note rendering.
  * Improved timezone handling for Noodle refresh prompts and public timeline generation.
* **Documentation**
  * Updated Noodle settings docs to describe the new schedule toggle.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->