### PR TITLE
fix: hide empty Roleplay background layers

### DIFF
--- a/e2e/core-flows.e2e.ts
+++ b/e2e/core-flows.e2e.ts
@@ -5367,6 +5367,17 @@ test("Roleplay displays a selected background when its file route is GET-only", 
     await page.locator('[data-tour="panel-settings"]').click();
     await page.getByPlaceholder("Search settings").fill("Backgrounds");
     await page.getByRole("button", { name: /Backgrounds Section/ }).click();
+    await page.getByRole("button", { name: "Remove" }).click();
+    await expect
+      .poll(async () =>
+        page
+          .locator("img.mari-background:not([src])")
+          .evaluateAll(
+            (layers) =>
+              layers.length > 0 && layers.every((layer) => (layer as HTMLElement).style.opacity === "0"),
+          ),
+      )
+      .toBe(true);
     await page.locator(`img[src="${backgroundUrl}"]`).locator("..").click();
 
     await expect

--- a/packages/client/src/components/chat/ChatRoleplaySurface.tsx
+++ b/packages/client/src/components/chat/ChatRoleplaySurface.tsx
@@ -257,7 +257,7 @@ function CrossfadeBackground({
           className,
         )}
         style={{
-          opacity: aActive ? 1 : 0,
+          opacity: aActive && bgA ? 1 : 0,
           transition: "opacity 700ms ease-in-out, filter 180ms ease-out, transform 180ms ease-out",
           ...backgroundBlurStyle,
         }}
@@ -271,7 +271,7 @@ function CrossfadeBackground({
           className,
         )}
         style={{
-          opacity: aActive ? 0 : 1,
+          opacity: !aActive && bgB ? 1 : 0,
           transition: "opacity 700ms ease-in-out, filter 180ms ease-out, transform 180ms ease-out",
           ...backgroundBlurStyle,
         }}


### PR DESCRIPTION
## Linked issue

Closes #3894

## Why this change

Roleplay chats without a selected background still mount both image layers used for crossfading. When the active layer has no source, Chromium can paint its native broken-image placeholder beneath the Roleplay HUD.

## What changed

- Keep each crossfade layer transparent unless it has a background URL.
- Preserve the mounted dual-layer crossfade behavior for real background changes.
- Extend the existing Roleplay background smoke test to remove the background first and assert that every source-less layer remains transparent.

## Validation

- [ ] pnpm check passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed CONTRIBUTING.md

Automated verification performed by Codex:

- pnpm check completed successfully.
- Focused Roleplay background smoke test passed in desktop and mobile Chromium: 2 passed.
- The full pnpm smoke:ui run passed both existing selected-background cases and 71 other cases. The command finished with 73 passed, 47 skipped, and 2 failures unrelated to this patch: the Roleplay setup empty-agent-library flow and the Noodle mobile account-menu locator.

### Manual verification notes

- [ ] Open a Roleplay chat with no background in Chromium and verify no broken-image marker appears.
- [ ] Select or switch a background and verify the 700 ms crossfade still works.
- [ ] Clear the background and verify the image fades away without a placeholder.

The automated in-app browser connection failed before Marinara could be opened, so those manual checks remain explicitly pending.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Version/release files updated (only if this PR includes a version bump)

## UI evidence (if applicable)

The linked issue contains the before screenshot. A browser-verified after screenshot remains pending.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed roleplay background removal so cleared background layers become fully transparent.
  - Improved background crossfades to prevent empty image layers from appearing.
  - Preserved smooth background switching and fitting behavior after selecting a new image.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->