### PR TITLE
fix: address TTS, agent settings, and mobile code regressions

### DIFF
--- a/packages/client/src/components/chat/ChatSettingsDrawer.tsx
+++ b/packages/client/src/components/chat/ChatSettingsDrawer.tsx
@@ -2206,6 +2206,34 @@ export function ChatSettingsDrawer({
     },
     [chat.id, updateMeta],
   );
+  const flushProseGuardianDrafts = useCallback(async () => {
+    const patch: Record<string, unknown> = {};
+    const banned = proseGuardianBannedDraft.trim();
+    const avoid = proseGuardianAvoidDraft.trim();
+    const prefer = proseGuardianStyleDraft.trim();
+
+    if (banned !== proseGuardianBannedWords) patch.proseGuardianBannedWords = banned;
+    if (avoid !== proseGuardianAvoidInstructions) patch.proseGuardianAvoidInstructions = avoid;
+    if (prefer !== proseGuardianStyleInstructions) patch.proseGuardianStyleInstructions = prefer;
+    if (Object.keys(patch).length === 0) return true;
+
+    try {
+      await updateMeta.mutateAsync({ id: chat.id, ...patch });
+      return true;
+    } catch {
+      toast.error("Failed to save Prose Guardian changes.");
+      return false;
+    }
+  }, [
+    chat.id,
+    proseGuardianAvoidDraft,
+    proseGuardianAvoidInstructions,
+    proseGuardianBannedDraft,
+    proseGuardianBannedWords,
+    proseGuardianStyleDraft,
+    proseGuardianStyleInstructions,
+    updateMeta,
+  ]);
   const getKnowledgeAgentSourceSettings = useCallback(
     (agentType: KnowledgeAgentType) => {
       const config = agentConfigsByType.get(agentType);
@@ -3075,13 +3103,14 @@ export function ChatSettingsDrawer({
         const canCloseAgentSuite =
           !showAgentSuiteModal || (await (agentSuiteCloseGuardRef.current?.() ?? Promise.resolve(true)));
         if (!canCloseAgentSuite) return;
+        if (!(await flushProseGuardianDrafts())) return;
         setShowAgentSuiteModal(false);
         onClose();
       } finally {
         drawerClosingRef.current = false;
       }
     })();
-  }, [onClose, showAgentSuiteModal]);
+  }, [flushProseGuardianDrafts, onClose, showAgentSuiteModal]);
   // Session-ephemeral: did the user change Day Rollover Hour in this drawer mount?
   // Used to gate the "transitional duplication" warning so it only appears
   // immediately after a change (when the warning is operationally useful) and

--- a/packages/client/src/lib/tts-service.ts
+++ b/packages/client/src/lib/tts-service.ts
@@ -1,6 +1,7 @@
 // ──────────────────────────────────────────────
 // TTS Service — Server-proxied audio playback
 // ──────────────────────────────────────────────
+import { TTS_DIALOGUE_PAUSE_MAX_SECONDS } from "@marinara-engine/shared";
 import { getOrCreateCachedTTSAudioBlob } from "./tts-audio-cache";
 
 export type TTSState = "idle" | "loading" | "playing" | "paused" | "error";
@@ -68,8 +69,15 @@ function playbackAbortError(): DOMException {
   return new DOMException("TTS playback aborted", "AbortError");
 }
 
+export function normalizeTTSPlaybackDelayMs(delayMs: number | undefined): number {
+  const maximumDelayMs = TTS_DIALOGUE_PAUSE_MAX_SECONDS * 1000;
+  return typeof delayMs === "number" && Number.isFinite(delayMs)
+    ? Math.max(0, Math.min(maximumDelayMs, delayMs))
+    : 0;
+}
+
 function waitForPlaybackDelay(delayMs: number | undefined, signal: AbortSignal): Promise<void> {
-  const ms = typeof delayMs === "number" && Number.isFinite(delayMs) ? Math.max(0, Math.min(1500, delayMs)) : 0;
+  const ms = normalizeTTSPlaybackDelayMs(delayMs);
 
   if (ms <= 0) return Promise.resolve();
   if (signal.aborted) return Promise.reject(playbackAbortError());

--- a/packages/client/src/styles/globals.css
+++ b/packages/client/src/styles/globals.css
@@ -2503,6 +2503,9 @@ strong {
 
 /* Chat message narration text color */
 .mari-message-content {
+  min-width: 0;
+  max-width: 100%;
+  overflow-wrap: anywhere;
   color: var(--foreground);
 }
 
@@ -2566,6 +2569,7 @@ strong {
   border-radius: 4px;
   padding: 0.1em 0.35em;
   color: #e8e6e3;
+  overflow-wrap: anywhere;
   word-break: break-word;
 }
 
@@ -2586,7 +2590,10 @@ strong {
   border-radius: 8px;
   padding: 0.75em 1em;
   margin: 0.5em 0;
+  min-width: 0;
+  max-width: 100%;
   overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
   white-space: pre;
   color: #d4d4d4;
 }

--- a/scripts/regressions/open-issues.regression.ts
+++ b/scripts/regressions/open-issues.regression.ts
@@ -986,6 +986,11 @@ assert.doesNotMatch(conversationGroupSettingsSource, /label="Cross-Chat Awarenes
 assert.match(conversationGroupSettingsSource, /Individual replies can use many tokens/u);
 assert.match(
   conversationGroupSettingsSource,
+  /if \(!\(await flushProseGuardianDrafts\(\)\)\) return;[\s\S]{0,250}onClose\(\)/u,
+  "Closing Chat Settings must persist changed Prose Guardian preferences before unmounting the drawer",
+);
+assert.match(
+  conversationGroupSettingsSource,
   /\{!isConversation && \(\s*<button[\s\S]{0,1500}Name Prefix History/u,
   "Conversation group settings should not show the roleplay-only Name Prefix History toggle",
 );
@@ -1166,6 +1171,14 @@ const markdownBlockquoteStyles =
   globalStyles.match(/\.mari-message-content \.mari-md-blockquote \{[\s\S]*?\}/u)?.[0] ?? "";
 assert.match(markdownBlockquoteStyles, /color:\s*inherit;/u);
 assert.doesNotMatch(markdownBlockquoteStyles, /color:\s*var\(--muted-foreground\);/u);
+const markdownMessageStyles = globalStyles.match(/\.mari-message-content \{[\s\S]*?\}/u)?.[0] ?? "";
+const markdownCodeBlockStyles =
+  globalStyles.match(/\.mari-message-content \.mari-md-codeblock \{[\s\S]*?\}/u)?.[0] ?? "";
+assert.match(markdownMessageStyles, /min-width:\s*0;/u);
+assert.match(markdownMessageStyles, /max-width:\s*100%;/u);
+assert.match(markdownMessageStyles, /overflow-wrap:\s*anywhere;/u);
+assert.match(markdownCodeBlockStyles, /max-width:\s*100%;/u);
+assert.match(markdownCodeBlockStyles, /overflow-x:\s*auto;/u);
 
 assert.equal(stripLeadingMessageTimestamps("[11.07 15:53] Character: Hello!"), "Character: Hello!");
 assert.equal(stripLeadingMessageTimestamps("[11.07.2026 15:53] Character: Hello!"), "Character: Hello!");

--- a/scripts/regressions/tts-source-persistence.regression.ts
+++ b/scripts/regressions/tts-source-persistence.regression.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import { TTS_API_KEY_MASK, ttsConfigSchema } from "../../packages/shared/src/types/tts.js";
 import { buildTTSVoiceRequests } from "../../packages/client/src/lib/tts-dialogue.ts";
+import { normalizeTTSPlaybackDelayMs } from "../../packages/client/src/lib/tts-service.ts";
 import { maskTTSConfigForResponse, prepareTTSConfigForStorage } from "../../packages/server/src/routes/tts.routes.ts";
 
 const encryptForTest = (value: string) => (value ? `encrypted:${value}` : "");
@@ -48,6 +49,10 @@ assert.deepEqual(
   maximumPauseRequests.map((request) => request.pauseAfterMs),
   [60_000, undefined],
 );
+assert.equal(normalizeTTSPlaybackDelayMs(60_000), 60_000);
+assert.equal(normalizeTTSPlaybackDelayMs(60_001), 60_000);
+assert.equal(normalizeTTSPlaybackDelayMs(-1), 0);
+assert.equal(normalizeTTSPlaybackDelayMs(Number.NaN), 0);
 assert.throws(() => ttsConfigSchema.parse({ dialoguePauseMs: 60_001 }));
 
 const legacyOpenAiConfig = ttsConfigSchema.parse({


### PR DESCRIPTION
## Linked issues

Closes #3718
Closes #3897
Closes #3898

## Why this change

Three user-visible regressions interrupted normal chat use: configured TTS pauses were silently shortened, code-formatted messages could expand beyond an iOS viewport, and Prose Guardian edits could be discarded when Chat Settings closed before the textarea blur save ran.

## What changed

- Normalize TTS playback delays against the shared 60-second ceiling instead of the obsolete 1,500 ms limit.
- Keep chat markdown within its message container, allow long inline code to break, and preserve horizontal scrolling for fenced code blocks.
- Flush changed Prose Guardian per-chat preferences before closing Chat Settings, keep the drawer open on save failure, and surface an error toast.
- Extend regression coverage for the TTS ceiling, mobile markdown containment, and the Prose Guardian close/save ordering.

## Validation

- [ ] pnpm check passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed CONTRIBUTING.md

Automated validation performed by Codex:

- pnpm regression:tts completed successfully.
- pnpm regression:issues completed successfully.
- pnpm regression:prompt completed successfully.
- pnpm check completed successfully.
- git diff --check completed successfully.

### Manual verification notes

- [ ] Enable Only read dialogues, choose a pause greater than 1.5 seconds, and verify the next utterance waits for the selected duration.
- [ ] On iOS, verify long inline and fenced code stay inside the message viewport; fenced code should scroll horizontally.
- [ ] Edit each Prose Guardian preference, close Chat Settings by outside click and by the close button, then verify the next rewrite uses the saved values.
- [ ] Force a metadata save failure and verify Chat Settings remains open with an error toast.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Version/release files updated (only if this PR includes a version bump)

## UI evidence (if applicable)

No screenshots attached. Manual iOS viewport verification remains pending because the local in-app browser surface was unavailable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prose Guardian drafts now save automatically before the Agent Suite closes, with an error notification if saving fails.
  * Text-to-speech playback delays now handle invalid values safely and respect the configured maximum.
  * Chat messages and code blocks now wrap long content more reliably and support horizontal scrolling on touch devices.

* **Tests**
  * Added regression coverage for draft persistence, playback delay handling, and markdown layout behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->