### PR TITLE
Fix Prose Guardian swipe saves and fenced code overflow

### DIFF
--- a/packages/client/src/components/chat/ChatMessage.tsx
+++ b/packages/client/src/components/chat/ChatMessage.tsx
@@ -2921,7 +2921,7 @@ export const ChatMessage = memo(function ChatMessage({
 
         <div
           className={cn(
-            "mari-message-body flex flex-col gap-0.5",
+            "mari-message-body flex min-w-0 max-w-full flex-col gap-0.5",
             isUser ? "items-end" : "items-start",
             editing && "w-full",
           )}

--- a/packages/client/src/components/chat/ChatSettingsDrawer.tsx
+++ b/packages/client/src/components/chat/ChatSettingsDrawer.tsx
@@ -118,6 +118,10 @@ import {
 import { useUpdateGameWidgets } from "../../hooks/use-game";
 import { useRegexScripts, useUpdateRegexScript, type RegexScriptRow } from "../../hooks/use-regex-scripts";
 import { api } from "../../lib/api-client";
+import {
+  trackChatMetadataSave,
+  waitForPendingChatMetadataSaves,
+} from "../../lib/chat-metadata-save-barrier";
 import { appendLocalSidecarConnectionOption, filterLanguageGenerationConnections } from "../../lib/connection-filters";
 import {
   deriveActiveLorebookViews,
@@ -2200,11 +2204,19 @@ export function ChatSettingsDrawer({
     setProseGuardianStyleDraft(proseGuardianStyleInstructions);
   }, [proseGuardianStyleInstructions]);
 
+  const updateMetaAsync = updateMeta.mutateAsync;
+  const saveProseGuardianSettings = useCallback(
+    (patch: Record<string, unknown>) =>
+      trackChatMetadataSave(chat.id, () => updateMetaAsync({ id: chat.id, ...patch })),
+    [chat.id, updateMetaAsync],
+  );
   const commitProseGuardianSettings = useCallback(
     (patch: Record<string, unknown>) => {
-      updateMeta.mutate({ id: chat.id, ...patch });
+      void saveProseGuardianSettings(patch).catch(() => {
+        toast.error("Failed to save Prose Guardian changes.");
+      });
     },
-    [chat.id, updateMeta],
+    [saveProseGuardianSettings],
   );
   const flushProseGuardianDrafts = useCallback(async () => {
     const patch: Record<string, unknown> = {};
@@ -2215,10 +2227,13 @@ export function ChatSettingsDrawer({
     if (banned !== proseGuardianBannedWords) patch.proseGuardianBannedWords = banned;
     if (avoid !== proseGuardianAvoidInstructions) patch.proseGuardianAvoidInstructions = avoid;
     if (prefer !== proseGuardianStyleInstructions) patch.proseGuardianStyleInstructions = prefer;
-    if (Object.keys(patch).length === 0) return true;
+    if (Object.keys(patch).length === 0) {
+      await waitForPendingChatMetadataSaves(chat.id);
+      return true;
+    }
 
     try {
-      await updateMeta.mutateAsync({ id: chat.id, ...patch });
+      await saveProseGuardianSettings(patch);
       return true;
     } catch {
       toast.error("Failed to save Prose Guardian changes.");
@@ -2232,7 +2247,7 @@ export function ChatSettingsDrawer({
     proseGuardianBannedWords,
     proseGuardianStyleDraft,
     proseGuardianStyleInstructions,
-    updateMeta,
+    saveProseGuardianSettings,
   ]);
   const getKnowledgeAgentSourceSettings = useCallback(
     (agentType: KnowledgeAgentType) => {

--- a/packages/client/src/hooks/use-generate.ts
+++ b/packages/client/src/hooks/use-generate.ts
@@ -16,6 +16,7 @@ import {
 } from "../lib/generation-stream-policy";
 import { requestChatScrollToBottom } from "../lib/chat-scroll-events";
 import { startSceneWithPromptPreferences } from "../lib/scene-generation";
+import { waitForPendingChatMetadataSaves } from "../lib/chat-metadata-save-barrier";
 import { agentKeys } from "./use-agents";
 import { discardPendingGameStatePatch } from "./use-game-state-patcher";
 import { spatialContextKeys } from "./use-spatial-context";
@@ -1485,6 +1486,8 @@ export function useGenerate() {
         // Flush any pending game-state widget edits so the server sees them before committing
         const flushPatch = useGameStateStore.getState().flushPatch;
         if (flushPatch) await flushPatch();
+
+        await waitForPendingChatMetadataSaves(params.chatId);
 
         for await (const event of api.streamEvents(
           "/generate",
@@ -2968,6 +2971,8 @@ export function useGenerate() {
             throw new Error(`Failed to flush pending game-state edits${detail}`, { cause: error });
           }
         }
+
+        await waitForPendingChatMetadataSaves(chatId);
 
         let agentResultCount = 0;
         let trackerPatchCount = 0;

--- a/packages/client/src/lib/chat-metadata-save-barrier.ts
+++ b/packages/client/src/lib/chat-metadata-save-barrier.ts
@@ -1,0 +1,29 @@
+const pendingSavesByChat = new Map<string, Promise<void>>();
+
+/** Register a metadata save immediately and keep saves ordered for one chat. */
+export function trackChatMetadataSave<T>(chatId: string, save: () => Promise<T>): Promise<T> {
+  const previous = pendingSavesByChat.get(chatId) ?? Promise.resolve();
+  const operation = previous.then(save);
+  const settled = operation.then(
+    () => undefined,
+    () => undefined,
+  );
+
+  pendingSavesByChat.set(chatId, settled);
+  void settled.then(() => {
+    if (pendingSavesByChat.get(chatId) === settled) pendingSavesByChat.delete(chatId);
+  });
+
+  return operation;
+}
+
+/** Wait until all metadata saves already registered for this chat have settled. */
+export async function waitForPendingChatMetadataSaves(chatId: string): Promise<void> {
+  let pending = pendingSavesByChat.get(chatId);
+  while (pending) {
+    await pending;
+    const next = pendingSavesByChat.get(chatId);
+    if (!next || next === pending) return;
+    pending = next;
+  }
+}

--- a/packages/client/src/styles/globals.css
+++ b/packages/client/src/styles/globals.css
@@ -2502,6 +2502,12 @@ strong {
 }
 
 /* Chat message narration text color */
+.mari-message-body,
+.mari-message-bubble {
+  min-width: 0;
+  max-width: 100%;
+}
+
 .mari-message-content {
   min-width: 0;
   max-width: 100%;
@@ -2582,6 +2588,9 @@ strong {
 /* Fenced code blocks */
 .mari-message-content .mari-md-codeblock {
   position: relative;
+  box-sizing: border-box;
+  display: block;
+  width: 100%;
   font-family: "Consolas", "Monaco", "Courier New", monospace;
   font-size: 0.85em;
   line-height: 1.45;

--- a/scripts/regressions/open-issues.regression.ts
+++ b/scripts/regressions/open-issues.regression.ts
@@ -31,6 +31,10 @@ import {
   shouldExecuteQuickPostAsCommand,
 } from "../../packages/client/src/lib/slash-commands.js";
 import { getAvatarCropStyle } from "../../packages/client/src/lib/utils.js";
+import {
+  trackChatMetadataSave,
+  waitForPendingChatMetadataSaves,
+} from "../../packages/client/src/lib/chat-metadata-save-barrier.js";
 import { resolveEchoChamberTopLayout } from "../../packages/client/src/lib/echo-chamber-layout.js";
 import {
   resolveConversationSelfieConnectionId,
@@ -973,6 +977,10 @@ const conversationGenerationSource = readFileSync(
   new URL("../../packages/server/src/routes/generate.routes.ts", import.meta.url),
   "utf8",
 );
+const clientGenerationSource = readFileSync(
+  new URL("../../packages/client/src/hooks/use-generate.ts", import.meta.url),
+  "utf8",
+);
 const conversationPresenceSource = readFileSync(
   new URL("../../packages/server/src/routes/generate/conversation-presence-runtime.ts", import.meta.url),
   "utf8",
@@ -989,6 +997,33 @@ assert.match(
   /if \(!\(await flushProseGuardianDrafts\(\)\)\) return;[\s\S]{0,250}onClose\(\)/u,
   "Closing Chat Settings must persist changed Prose Guardian preferences before unmounting the drawer",
 );
+assert.match(
+  clientGenerationSource,
+  /await waitForPendingChatMetadataSaves\(params\.chatId\);[\s\S]{0,250}api\.streamEvents\(\s*"\/generate"/u,
+  "swipe generation must wait for Prose Guardian settings blurred from the open drawer",
+);
+
+const metadataSaveOrder: string[] = [];
+let releaseFirstMetadataSave!: () => void;
+const firstMetadataSaveBlocker = new Promise<void>((resolve) => {
+  releaseFirstMetadataSave = resolve;
+});
+const firstMetadataSave = trackChatMetadataSave("chat-prose-swipe", async () => {
+  await firstMetadataSaveBlocker;
+  metadataSaveOrder.push("first");
+});
+const secondMetadataSave = trackChatMetadataSave("chat-prose-swipe", async () => {
+  metadataSaveOrder.push("second");
+});
+let metadataWaitFinished = false;
+const pendingMetadataWait = waitForPendingChatMetadataSaves("chat-prose-swipe").then(() => {
+  metadataWaitFinished = true;
+});
+await Promise.resolve();
+assert.equal(metadataWaitFinished, false, "swipe generation should remain blocked while preferences are saving");
+releaseFirstMetadataSave();
+await Promise.all([firstMetadataSave, secondMetadataSave, pendingMetadataWait]);
+assert.deepEqual(metadataSaveOrder, ["first", "second"]);
 assert.match(
   conversationGroupSettingsSource,
   /\{!isConversation && \(\s*<button[\s\S]{0,1500}Name Prefix History/u,
@@ -1172,11 +1207,17 @@ const markdownBlockquoteStyles =
 assert.match(markdownBlockquoteStyles, /color:\s*inherit;/u);
 assert.doesNotMatch(markdownBlockquoteStyles, /color:\s*var\(--muted-foreground\);/u);
 const markdownMessageStyles = globalStyles.match(/\.mari-message-content \{[\s\S]*?\}/u)?.[0] ?? "";
+const markdownMessageContainerStyles =
+  globalStyles.match(/\.mari-message-body,\s*\.mari-message-bubble \{[\s\S]*?\}/u)?.[0] ?? "";
 const markdownCodeBlockStyles =
   globalStyles.match(/\.mari-message-content \.mari-md-codeblock \{[\s\S]*?\}/u)?.[0] ?? "";
 assert.match(markdownMessageStyles, /min-width:\s*0;/u);
 assert.match(markdownMessageStyles, /max-width:\s*100%;/u);
 assert.match(markdownMessageStyles, /overflow-wrap:\s*anywhere;/u);
+assert.match(markdownMessageContainerStyles, /min-width:\s*0;/u);
+assert.match(markdownMessageContainerStyles, /max-width:\s*100%;/u);
+assert.match(markdownCodeBlockStyles, /box-sizing:\s*border-box;/u);
+assert.match(markdownCodeBlockStyles, /width:\s*100%;/u);
 assert.match(markdownCodeBlockStyles, /max-width:\s*100%;/u);
 assert.match(markdownCodeBlockStyles, /overflow-x:\s*auto;/u);
 


### PR DESCRIPTION
## Why

Prose Guardian preferences saved on field blur could race a swipe/regeneration request, so the new swipe used the previous server-side settings even though the UI soon showed the update as saved. Fenced Markdown code blocks could still force iOS message bubbles wider than the viewport because their flex ancestors retained min-content sizing.

Closes #3897
Closes #3898

## What changed

- register Prose Guardian metadata saves synchronously and serialize them per chat
- wait for those saves before normal generation and manual agent retry requests
- constrain message body and bubble flex sizing
- make fenced code blocks use a border-box, container-width scrolling surface
- add regression coverage for the save barrier and fenced-code containment

## Automated validation

- `pnpm regression:issues` — passed
- `pnpm check` — passed
- `git diff --check` — passed
- `pnpm smoke:ui` — 72 passed, 47 skipped, 3 unrelated failures in existing Roleplay setup/Noodle tests; the relevant Roleplay rewrite-streaming test passed

GitHub `pnpm-validate` did not reach validation because `onnxruntime-node` timed out downloading during `pnpm install`.

## Manual verification

- [ ] In an open Chat Settings drawer, edit a Prose Guardian preference and immediately create a new swipe; verify the agent prompt uses the edited value.
- [ ] Repeat with a manual Prose Guardian retry.
- [ ] On iOS Safari, render a fenced code block containing one very long unbroken line; verify the message stays inside the viewport and the code block scrolls horizontally.
- [ ] Verify inline code still wraps without widening the message.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved chat message and code block sizing in constrained layouts to prevent overflow.
  * Ensured Prose Guardian settings are saved in order before chat generation or retries begin.
  * Prevented generation from starting while pending chat metadata updates remain incomplete.

* **Tests**
  * Added regression coverage for metadata save ordering and markdown content sizing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->