### PR TITLE
Fix Conversation group compatibility defaults

### DIFF
--- a/packages/client/src/components/chat/ChatSettingsDrawer.tsx
+++ b/packages/client/src/components/chat/ChatSettingsDrawer.tsx
@@ -5164,7 +5164,7 @@ export function ChatSettingsDrawer({
             </Section>
           )}
 
-          {/* Group Chat Settings — only when 2+ characters, game mode handles it internally */}
+          {/* Every existing and new multi-character chat gets this section. Missing mode metadata means Grouped. */}
           {chatCharIds.length > 1 && modeCapabilities.supportsGroupChatControls && (
             <Section
               style={{ order: CHAT_SETTINGS_ORDER.groupChat }}

--- a/packages/server/src/routes/generate.routes.ts
+++ b/packages/server/src/routes/generate.routes.ts
@@ -4851,12 +4851,17 @@ export async function generateRoutes(app: FastifyInstance) {
             historyMacroProfilesById,
           );
           if (chatMode === "conversation" && conversationIsGroup && !input.impersonate) {
+            const turnCharacterName =
+              usesIndividualGroupGeneration && groupTurnPromptEnabled && speaksOnlyTargetCharacter && targetCharId
+                ? (charInfo.find((character) => character.id === targetCharId)?.name ?? null)
+                : null;
             preparedMessagesForGen.push({
               role: "user",
               content: formatConversationGroupOutputFormat({
                 wrapFormat,
                 characterNames: conversationCharacterNames,
                 userName: personaName,
+                turnCharacterName,
               }),
               contextKind: "injection",
             });
@@ -5732,6 +5737,7 @@ export async function generateRoutes(app: FastifyInstance) {
               : null;
             fullResponse = stripConversationResponseEnvelope(fullResponse, {
               speakerName: conversationSpeakerName,
+              speakerNames: charInfo.map((character) => character.name),
               preserveSpeakerPrefix: isGroupChat && !usesIndividualGroupGeneration,
             });
             if (fullResponse !== beforeStrip) {
@@ -6094,8 +6100,8 @@ export async function generateRoutes(app: FastifyInstance) {
         // are declared above the follow-up loop so they survive iterations.)
 
         const generationGuideInstruction = buildGenerationGuideInstruction(input.generationGuide, promptMacroContext);
-        const buildCharacterInstruction = (charName: string) =>
-          groupTurnPromptEnabled ? `Respond ONLY as ${charName}.` : null;
+        const buildRoleplayCharacterInstruction = (charName: string) =>
+          groupTurnPromptEnabled && chatMode !== "conversation" ? `Respond ONLY as ${charName}.` : null;
 
         if (useIndividualLoop) {
           // Individual group mode: generate one response per character
@@ -6116,8 +6122,9 @@ export async function generateRoutes(app: FastifyInstance) {
               `data: ${JSON.stringify({ type: "group_turn", data: { characterId: charId, characterName: charName, index: ci } })}\n\n`,
             );
 
-            // Append "Respond ONLY as [name]" instruction
-            const charInstruction = buildCharacterInstruction(charName);
+            // Conversation puts its short turn instruction in Output Format.
+            // Keep the established Roleplay instruction placement unchanged.
+            const charInstruction = buildRoleplayCharacterInstruction(charName);
             const messagesWithInstruction = [...runningMessages];
             // Add as a system message at the end (just before any trailing user message)
             if (charInstruction) {
@@ -6206,14 +6213,10 @@ export async function generateRoutes(app: FastifyInstance) {
               return;
             }
 
-            // Get character of regenerated message and append "Respond ONLY as [name]" instruction
+            // Conversation puts its short turn instruction in Output Format.
             targetCharId = regenMsg?.characterId ?? null;
             const targetCharName = charInfo.find((c) => c.id === targetCharId)?.name ?? "Character";
-            const charInstruction = targetCharId
-              ? buildCharacterInstruction(targetCharName)
-              : groupTurnPromptEnabled
-                ? `Respond ONLY as ${targetCharName}.`
-                : null;
+            const charInstruction = buildRoleplayCharacterInstruction(targetCharName);
             if (charInstruction) {
               sentMessages.push({ role: "system", content: charInstruction });
             }

--- a/packages/server/src/routes/generate.routes.ts
+++ b/packages/server/src/routes/generate.routes.ts
@@ -6101,7 +6101,7 @@ export async function generateRoutes(app: FastifyInstance) {
 
         const generationGuideInstruction = buildGenerationGuideInstruction(input.generationGuide, promptMacroContext);
         const buildRoleplayCharacterInstruction = (charName: string) =>
-          groupTurnPromptEnabled && chatMode !== "conversation" ? `Respond ONLY as ${charName}.` : null;
+          groupTurnPromptEnabled && chatMode === "roleplay" ? `Respond ONLY as ${charName}.` : null;
 
         if (useIndividualLoop) {
           // Individual group mode: generate one response per character

--- a/packages/server/src/routes/generate/conversation-prompt-formatting.ts
+++ b/packages/server/src/routes/generate/conversation-prompt-formatting.ts
@@ -11,12 +11,20 @@ export function formatConversationGroupOutputFormat(args: {
   wrapFormat: WrapFormat;
   characterNames: string[];
   userName: string;
+  turnCharacterName?: string | null;
 }): string {
   const characterList = Array.from(new Set(args.characterNames.map((name) => name.trim()).filter(Boolean))).join(", ");
   const userName = args.userName.trim() || "the user";
   const responseBoundary = `Only respond for these characters: ${characterList || "the listed characters"}. Never respond for ${userName} or write ${userName}'s messages.`;
+  const turnCharacterName = args.turnCharacterName?.trim();
   return wrapContent(
-    [CONVERSATION_GROUP_NAME_PREFIX_INSTRUCTION, responseBoundary].join("\n"),
+    [
+      CONVERSATION_GROUP_NAME_PREFIX_INSTRUCTION,
+      responseBoundary,
+      turnCharacterName ? `Respond as ${turnCharacterName} alone.` : null,
+    ]
+      .filter((line): line is string => line !== null)
+      .join("\n"),
     "Output Format",
     args.wrapFormat,
   );

--- a/packages/server/src/services/conversation/transcript-sanitize.ts
+++ b/packages/server/src/services/conversation/transcript-sanitize.ts
@@ -14,9 +14,8 @@ export function collapseDuplicateConversationSpeakerPrefixes(
   speakerNames: readonly string[],
 ): string {
   let cleaned = content;
-  for (const rawName of speakerNames) {
-    const speakerName = rawName.trim();
-    if (!speakerName) continue;
+  const uniqueSpeakerNames = new Set(speakerNames.map((speakerName) => speakerName.trim()).filter(Boolean));
+  for (const speakerName of uniqueSpeakerNames) {
     const escapedName = speakerName.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
     cleaned = cleaned.replace(
       new RegExp(`(^|\\n)(\\s*(?:[-*]\\s*)?)(${escapedName}\\s*:\\s*)(?:${escapedName}\\s*:\\s*)+`, "gi"),

--- a/packages/server/src/services/conversation/transcript-sanitize.ts
+++ b/packages/server/src/services/conversation/transcript-sanitize.ts
@@ -8,6 +8,24 @@ const TIMESTAMP_TOKEN = String.raw`\[(?:${DATE_TIME_TOKEN_SOURCE}|${CLOCK_TOKEN_
 const LEADING_TIMESTAMP_RE = new RegExp(`^(\\s*(?:[-*]\\s*)?)(?:${TIMESTAMP_TOKEN}\\s*)+`, "gim");
 const SPEAKER_TIMESTAMP_RE = new RegExp(`^(\\s*(?:[-*]\\s*)?[^:\\n]{1,80}:\\s*)(?:${TIMESTAMP_TOKEN}\\s*)+`, "gim");
 
+/** Collapse model-produced `Name: Name:` prefixes without touching later dialogue text. */
+export function collapseDuplicateConversationSpeakerPrefixes(
+  content: string,
+  speakerNames: readonly string[],
+): string {
+  let cleaned = content;
+  for (const rawName of speakerNames) {
+    const speakerName = rawName.trim();
+    if (!speakerName) continue;
+    const escapedName = speakerName.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+    cleaned = cleaned.replace(
+      new RegExp(`(^|\\n)(\\s*(?:[-*]\\s*)?)(${escapedName}\\s*:\\s*)(?:${escapedName}\\s*:\\s*)+`, "gi"),
+      "$1$2$3",
+    );
+  }
+  return cleaned;
+}
+
 /**
  * Conversation mode adds prompt-only timestamps like [12:01] for DM time awareness.
  * Strip those when conversation text crosses into roleplay/game context.
@@ -29,10 +47,18 @@ export function stripConversationPromptTimestamps(content: string): string {
  */
 export function stripConversationResponseEnvelope(
   content: string,
-  options: { speakerName?: string | null; preserveSpeakerPrefix?: boolean } = {},
+  options: {
+    speakerName?: string | null;
+    speakerNames?: readonly string[];
+    preserveSpeakerPrefix?: boolean;
+  } = {},
 ): string {
   let cleaned = stripConversationPromptTimestamps(content);
   const speakerName = options.speakerName?.trim();
+  cleaned = collapseDuplicateConversationSpeakerPrefixes(
+    cleaned,
+    options.speakerNames ?? (speakerName ? [speakerName] : []),
+  );
   if (!speakerName || options.preserveSpeakerPrefix) return cleaned;
 
   const escapedName = speakerName.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");

--- a/scripts/regressions/open-issues.regression.ts
+++ b/scripts/regressions/open-issues.regression.ts
@@ -1249,7 +1249,7 @@ assert.equal(
 assert.equal(
   collapseDuplicateConversationSpeakerPrefixes(
     "Dottore: Dottore: The procedure is complete.\nPantalone: Pantalone: At what cost?",
-    ["Dottore", "Pantalone"],
+    ["Dottore", " Pantalone ", "Dottore"],
   ),
   "Dottore: The procedure is complete.\nPantalone: At what cost?",
 );

--- a/scripts/regressions/open-issues.regression.ts
+++ b/scripts/regressions/open-issues.regression.ts
@@ -66,6 +66,7 @@ import { parseNoodleAvatarCrop } from "../../packages/server/src/services/storag
 import { sanitizeExampleDialoguePromptLeaf } from "../../packages/server/src/services/prompt/prompt-escaping.js";
 import { parseCharacterCommands } from "../../packages/server/src/services/conversation/character-commands.js";
 import {
+  collapseDuplicateConversationSpeakerPrefixes,
   stripConversationPromptTimestamps,
   stripConversationResponseEnvelope,
 } from "../../packages/server/src/services/conversation/transcript-sanitize.js";
@@ -323,6 +324,11 @@ assert.strictEqual(parseDockerDefaultGatewayIp("Iface\tDestination\tGateway\tFla
 
 assert.equal(resolveGroupGenerationMode("conversation", "individual"), "individual");
 assert.equal(resolveGroupGenerationMode("conversation", "merged"), "merged");
+assert.equal(
+  resolveGroupGenerationMode("conversation", undefined),
+  "merged",
+  "pre-existing Conversation groups without mode metadata must retain Grouped behavior",
+);
 assert.equal(getChatModeCapabilities("conversation").supportsGroupChatControls, true);
 assert.equal(getChatModeCapabilities("conversation").modeSections.includes("group-chat"), true);
 assert.equal(resolveGroupGenerationMode("roleplay", "individual"), "individual");
@@ -994,6 +1000,11 @@ assert.doesNotMatch(conversationGroupSettingsSource, /label="Cross-Chat Awarenes
 assert.match(conversationGroupSettingsSource, /Individual replies can use many tokens/u);
 assert.match(
   conversationGroupSettingsSource,
+  /chatCharIds\.length > 1 && modeCapabilities\.supportsGroupChatControls/u,
+  "pre-existing multi-character Conversation chats must show Group Chat settings without requiring mode metadata",
+);
+assert.match(
+  conversationGroupSettingsSource,
   /if \(!\(await flushProseGuardianDrafts\(\)\)\) return;[\s\S]{0,250}onClose\(\)/u,
   "Closing Chat Settings must persist changed Prose Guardian preferences before unmounting the drawer",
 );
@@ -1234,6 +1245,20 @@ assert.equal(
     preserveSpeakerPrefix: true,
   }),
   "Character: Hello!",
+);
+assert.equal(
+  collapseDuplicateConversationSpeakerPrefixes(
+    "Dottore: Dottore: The procedure is complete.\nPantalone: Pantalone: At what cost?",
+    ["Dottore", "Pantalone"],
+  ),
+  "Dottore: The procedure is complete.\nPantalone: At what cost?",
+);
+assert.equal(
+  stripConversationResponseEnvelope("Dottore: Dottore: The procedure is complete.", {
+    speakerName: "Dottore",
+    speakerNames: ["Dottore", "Pantalone"],
+  }),
+  "The procedure is complete.",
 );
 assert.equal(
   stripLeadingMessageTimestamps("We meet at [11.07 15:53] by the station."),

--- a/scripts/regressions/prompt.regression.ts
+++ b/scripts/regressions/prompt.regression.ts
@@ -508,6 +508,7 @@ import {
   type SimpleMessage,
 } from "../../packages/server/src/routes/generate/generate-route-utils.js";
 import { formatRoleplaySummaryChatLog } from "../../packages/server/src/services/generation/roleplay-summary-runtime.js";
+import { scopeIndividualGroupMessagesForTarget } from "../../packages/server/src/services/generation/prompt-message-scope.js";
 import { resolveGenerationPromptPresetChoices } from "../../packages/server/src/routes/generate/prompt-preset-selection.js";
 import {
   calibrateLorebookSimilarity,
@@ -4895,6 +4896,39 @@ Use HTML sparingly and diegetically. Do not replace normal prose/dialogue unless
         "utf8",
       );
       assert.equal(contextSource.includes(instruction), false);
+    },
+  },
+  {
+    name: "individual Conversation turns attach only the responding character card",
+    run() {
+      const scoped = scopeIndividualGroupMessagesForTarget(
+        [
+          {
+            role: "system",
+            content: [
+              "<Dottore>\n<description>Dottore card only.</description>\n</Dottore>",
+              "<Pantalone>\n<description>Pantalone card only.</description>\n</Pantalone>",
+            ].join("\n"),
+            contextKind: "prompt",
+          },
+          {
+            role: "assistant",
+            content: "Pantalone spoke earlier and remains visible as shared history.",
+            contextKind: "history",
+            characterId: "pantalone",
+          },
+        ],
+        "dottore",
+        [
+          { id: "dottore", name: "Dottore", description: "Dottore card only." },
+          { id: "pantalone", name: "Pantalone", description: "Pantalone card only." },
+        ],
+      );
+
+      assert.match(scoped[0]?.content ?? "", /Dottore card only\./u);
+      assert.doesNotMatch(scoped[0]?.content ?? "", /Pantalone card only\./u);
+      assert.equal(scoped[1]?.role, "user");
+      assert.match(scoped[1]?.content ?? "", /Pantalone spoke earlier/u);
     },
   },
   {

--- a/scripts/regressions/prompt.regression.ts
+++ b/scripts/regressions/prompt.regression.ts
@@ -4896,6 +4896,13 @@ Use HTML sparingly and diegetically. Do not replace normal prose/dialogue unless
         "utf8",
       );
       assert.equal(contextSource.includes(instruction), false);
+
+      const routeSource = readFileSync(
+        new URL("../../packages/server/src/routes/generate.routes.ts", import.meta.url),
+        "utf8",
+      );
+      assert.match(routeSource, /groupTurnPromptEnabled && chatMode === "roleplay"/u);
+      assert.doesNotMatch(routeSource, /groupTurnPromptEnabled && chatMode !== "conversation"/u);
     },
   },
   {

--- a/scripts/regressions/prompt.regression.ts
+++ b/scripts/regressions/prompt.regression.ts
@@ -4880,6 +4880,15 @@ Use HTML sparingly and diegetically. Do not replace normal prose/dialogue unless
       );
       assert.equal(formatOutput("markdown"), `## Output Format\n${instruction}\n${responseBoundary}`);
       assert.equal(formatOutput("none"), `${instruction}\n${responseBoundary}`);
+      assert.equal(
+        formatConversationGroupOutputFormat({
+          wrapFormat: "markdown",
+          characterNames: ["Dottore", "Pantalone"],
+          userName: "Mari",
+          turnCharacterName: "Dottore",
+        }),
+        `## Output Format\n${instruction}\n${responseBoundary}\nRespond as Dottore alone.`,
+      );
 
       const contextSource = readFileSync(
         new URL("../../packages/server/src/routes/generate/conversation-context-block.ts", import.meta.url),


### PR DESCRIPTION
## Linked issue

Follow-up to #3887

## Why this change

- Existing Conversation group chats must retain their previous grouped generation behavior unless the user explicitly opts into Individual mode.
- Individual turns were using a separate system instruction instead of the requested short instruction in Output Format, and repeated model speaker prefixes could leak into saved messages.

## What changed

- Kept missing `groupChatMode` metadata as Grouped and documented the metadata-independent drawer visibility for every multi-character chat.
- Added `Respond as <character> alone.` to the Conversation Output Format only for explicit Individual turns.
- Collapsed repeated known speaker prefixes such as `Dottore: Dottore:` before saving responses.
- Added regressions for legacy Grouped defaults, drawer visibility, Individual Output Format, and duplicate speaker cleanup.

## Validation

- [ ] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed `CONTRIBUTING.md`

### Manual verification notes

- Manually verify an existing Conversation chat with two or more characters shows Group Chat settings with Grouped selected.
- Manually verify Grouped generation remains one combined request and preserves existing message behavior.
- Manually verify opting into Individual adds the selected character instruction under Output Format and duplicate speaker names are not displayed.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Version/release files updated (only if this PR includes a version bump)

## UI evidence (if applicable)

- Existing settings controls are reused without visual changes; no screenshot attached yet.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced multi-character conversation outputs by requiring the assistant to respond as the correct character on each turn.
  * Added improved support for legacy multi-character chats missing mode metadata, defaulting them to Grouped behavior.

* **Bug Fixes**
  * Prevented duplicated speaker labels by collapsing repeated “Name: Name:” prefixes in model transcripts.
  * Improved conversation response post-processing so speaker/timestamp envelope stripping identifies speakers more reliably.
  * Refined roleplay per-character instruction generation to keep outputs consistent across conversation loops.

* **Documentation**
  * Clarified how “Group Chat” settings apply to multi-character chats without required mode metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->