### PR TITLE
fix: make connection reference cleanup atomic

### DIFF
--- a/packages/server/src/services/storage/connection-reference-cleanup.ts
+++ b/packages/server/src/services/storage/connection-reference-cleanup.ts
@@ -55,7 +55,7 @@ function serializeNullifiedConnectionIdReferences(
   let changed = false;
   try {
     const parsed = JSON.parse(serialized, (key, value: unknown) => {
-      if (/ConnectionId$/.test(key) && value === deletedConnectionId) {
+      if (/[Cc]onnectionId$/.test(key) && value === deletedConnectionId) {
         changed = true;
         return null;
       }

--- a/packages/server/src/services/storage/connection-reference-cleanup.ts
+++ b/packages/server/src/services/storage/connection-reference-cleanup.ts
@@ -31,60 +31,41 @@ import { now } from "../../utils/id-generator.js";
 
 const CLEANUP_BATCH_SIZE = 250;
 
-export type ConnectionReferenceCleanupResult = {
+type ConnectionReferenceCleanupResult = {
   chatsUpdated: number;
   agentsUpdated: number;
   connectionsUpdated: number;
 };
 
-function parseJsonObject(raw: unknown): Record<string, unknown> {
-  if (typeof raw !== "string") {
-    return raw && typeof raw === "object" && !Array.isArray(raw) ? (raw as Record<string, unknown>) : {};
-  }
-  try {
-    const parsed = JSON.parse(raw) as unknown;
-    return parsed && typeof parsed === "object" && !Array.isArray(parsed) ? (parsed as Record<string, unknown>) : {};
-  } catch {
-    return {};
-  }
-}
-
 /**
- * Recursively replaces any `"...ConnectionId": "<deletedId>"` entry, at any
- * nesting depth, with `null`. Returns the (possibly new) value plus whether
- * anything changed, so callers can skip writing back unchanged rows.
+ * Returns rewritten serialized JSON only when an object contains a matching
+ * `*ConnectionId` reference. Malformed and non-object roots are left alone.
  */
-export function nullifyConnectionIdReferences(
-  value: unknown,
+function serializeNullifiedConnectionIdReferences(
+  raw: unknown,
   deletedConnectionId: string,
-): { value: unknown; changed: boolean } {
-  if (Array.isArray(value)) {
-    let changed = false;
-    const next = value.map((item) => {
-      const result = nullifyConnectionIdReferences(item, deletedConnectionId);
-      if (result.changed) changed = true;
-      return result.value;
-    });
-    return changed ? { value: next, changed: true } : { value, changed: false };
+): string | undefined {
+  if (typeof raw !== "string" && (!raw || typeof raw !== "object" || Array.isArray(raw))) {
+    return undefined;
   }
 
-  if (value && typeof value === "object") {
-    let changed = false;
-    const next: Record<string, unknown> = {};
-    for (const [key, entry] of Object.entries(value as Record<string, unknown>)) {
-      if (/ConnectionId$/.test(key) && entry === deletedConnectionId) {
-        next[key] = null;
+  const serialized = typeof raw === "string" ? raw : JSON.stringify(raw);
+  if (serialized === undefined || !serialized.trimStart().startsWith("{")) return undefined;
+
+  let changed = false;
+  try {
+    const parsed = JSON.parse(serialized, (key, value: unknown) => {
+      if (/ConnectionId$/.test(key) && value === deletedConnectionId) {
         changed = true;
-        continue;
+        return null;
       }
-      const result = nullifyConnectionIdReferences(entry, deletedConnectionId);
-      if (result.changed) changed = true;
-      next[key] = result.value;
-    }
-    return changed ? { value: next, changed: true } : { value, changed: false };
+      return value;
+    }) as unknown;
+    return changed ? JSON.stringify(parsed) : undefined;
+  } catch (error) {
+    if (error instanceof SyntaxError) return undefined;
+    throw error;
   }
-
-  return { value, changed: false };
 }
 
 /**
@@ -122,16 +103,15 @@ export async function sweepDanglingConnectionReferences(
       .limit(CLEANUP_BATCH_SIZE)
       .offset(offset);
     for (const chat of chatRows) {
-      const metadata = parseJsonObject(chat.metadata);
-      const swept = nullifyConnectionIdReferences(metadata, deletedConnectionId);
+      const metadata = serializeNullifiedConnectionIdReferences(chat.metadata, deletedConnectionId);
       const directMatch = chat.connectionId === deletedConnectionId;
-      if (!swept.changed && !directMatch) continue;
+      if (metadata === undefined && !directMatch) continue;
 
       await db
         .update(chats)
         .set({
           connectionId: directMatch ? null : chat.connectionId,
-          metadata: swept.changed ? JSON.stringify(swept.value) : chat.metadata,
+          metadata: metadata ?? chat.metadata,
           updatedAt: now(),
         })
         .where(eq(chats.id, chat.id));
@@ -148,16 +128,15 @@ export async function sweepDanglingConnectionReferences(
       .limit(CLEANUP_BATCH_SIZE)
       .offset(offset);
     for (const agent of agentRows) {
-      const settings = parseJsonObject(agent.settings);
-      const swept = nullifyConnectionIdReferences(settings, deletedConnectionId);
+      const settings = serializeNullifiedConnectionIdReferences(agent.settings, deletedConnectionId);
       const directMatch = agent.connectionId === deletedConnectionId;
-      if (!swept.changed && !directMatch) continue;
+      if (settings === undefined && !directMatch) continue;
 
       await db
         .update(agentConfigs)
         .set({
           connectionId: directMatch ? null : agent.connectionId,
-          settings: swept.changed ? JSON.stringify(swept.value) : agent.settings,
+          settings: settings ?? agent.settings,
           updatedAt: now(),
         })
         .where(eq(agentConfigs.id, agent.id));

--- a/packages/server/src/services/storage/connections.storage.ts
+++ b/packages/server/src/services/storage/connections.storage.ts
@@ -434,9 +434,10 @@ export function createConnectionsStorage(db: DB) {
     },
 
     async remove(id: string) {
-      await db.delete(apiConnections).where(eq(apiConnections.id, id));
-
-      const cleanup = await sweepDanglingConnectionReferences(db, id);
+      const cleanup = await db.transaction(async (tx) => {
+        await tx.delete(apiConnections).where(eq(apiConnections.id, id));
+        return sweepDanglingConnectionReferences(tx, id);
+      });
       const totalCleaned = cleanup.chatsUpdated + cleanup.agentsUpdated + cleanup.connectionsUpdated;
       if (totalCleaned > 0) {
         logger.info(


### PR DESCRIPTION
## Linked issue

Closes #3900

## Why this change

- Bulk connection deletion sends requests concurrently. Each deletion previously removed its connection and then rewrote stale whole-JSON cleanup snapshots outside a transaction, allowing one sweep to restore another deleted connection ID.
- A cleanup failure could also leave the connection deleted with only part of its references cleared.

## What changed

- Run connection deletion and the complete dangling-reference sweep inside one file-store transaction.
- Replace bespoke parse-and-copy recursion with a private JSON reviver helper while preserving malformed JSON, non-object roots, legacy object-shaped values, nested arrays, and `__proto__` properties.
- Propagate genuine serialization and reviver failures so the transaction rolls back; suppress only malformed-input `SyntaxError`.
- Narrow internal cleanup symbols that have no external consumers while retaining cleanup counts and logging.

## Validation

- [x] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [x] Read and followed `CONTRIBUTING.md`

### Manual verification notes

- `pnpm check` passed on the final rebased commit.
- An isolated actual file-store probe confirmed concurrent deletion of connections A and B clears both references.
- Focused probes confirmed transaction rollback after injected cleanup failure and deep valid-JSON processing failure.
- Focused compatibility controls covered direct and nested references, malformed JSON, root arrays, nonmatching IDs, legacy raw objects, and nested `__proto__`.
- No browser or container verification was performed; this is an internal server storage change.
- Atomicity is scoped to in-process writer serialization and error rollback. Crash durability and general read isolation are unchanged.

## Docs and release impact

- [x] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Version/release files updated (only if this PR includes a version bump)

No documentation or release metadata changes are expected for this internal storage correction.

## UI evidence (if applicable)

Not applicable; no UI changed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cleanup of references when a connection is deleted.
  * Connection deletions and related reference cleanup now occur together, reducing the risk of inconsistent data.
  * Invalid or unsupported stored JSON is preserved instead of being unintentionally modified.
  * Direct connection references in chats, agent configurations, and embedding settings are cleared reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->