### PR TITLE
Fix Individual Conversation prompt scoping

### DIFF
--- a/packages/server/src/routes/generate.routes.ts
+++ b/packages/server/src/routes/generate.routes.ts
@@ -247,7 +247,10 @@ import {
 import { appendConversationCustomAssetAdvertisements } from "./generate/conversation-custom-assets.js";
 import { injectConnectedConversationPromptBlocks } from "./generate/connected-conversation-injections.js";
 import { resolveConversationConnectedChatContext } from "./generate/conversation-connected-context.js";
-import { buildConversationCurrentContextBlock } from "./generate/conversation-context-block.js";
+import {
+  buildConversationCurrentContextBlock,
+  replaceConversationContextBlockForTarget,
+} from "./generate/conversation-context-block.js";
 import { prepareConversationPromptHistory } from "./generate/conversation-history-runtime.js";
 import { resolveConversationPresenceRuntime } from "./generate/conversation-presence-runtime.js";
 import { resolveProfessorMariPromptContext } from "./generate/professor-mari-prompt-context.js";
@@ -1463,6 +1466,7 @@ export async function generateRoutes(app: FastifyInstance) {
         // Relocation-macro content captured for the deferred-{{#if}} decode pass
         // (#3448) — set where each is computed, read after all are known.
         let conversationContextBlockValue = "";
+        let conversationContextBlocksByCharacterId = new Map<string, string>();
         let conversationLorebookBlockValue = "";
         let conversationMemoriesBlockValue = "";
         let conversationReplyRulesBlockValue = "";
@@ -1587,7 +1591,7 @@ export async function generateRoutes(app: FastifyInstance) {
         const deferCharacterMacros =
           characterIds.length > 1 &&
           promptGroupChatMode === "individual" &&
-          promptGroupResponseOrder !== "manual" &&
+          (promptGroupResponseOrder !== "manual" || chatMode === "conversation") &&
           input.impersonate !== true;
         const shouldPrefixGroupHistorySpeakers =
           chatMeta.groupSpeakerNamesInHistory === true &&
@@ -2121,14 +2125,21 @@ export async function generateRoutes(app: FastifyInstance) {
             customPrompt ?? (selectedConversationPrompt || DEFAULT_CONVERSATION_PROMPT);
           identityFallbackPromptTemplateSources.push(conversationPromptTemplate);
           conversationContextMacroSlots = resolveConversationContextMacroSlots(conversationPromptTemplate);
+          const individualConversationGroup = isGroup && promptGroupChatMode === "individual";
+          const aliasedConversationPrompt = (
+            individualConversationGroup
+              ? conversationPromptTemplate
+              : conversationPromptTemplate.replace(/\{\{charName\}\}/g, charNameList)
+          ).replace(/\{\{userName\}\}/g, personaName);
           const renderedConversationPrompt = resolveMacros(
-            conversationPromptTemplate
-              .replace(/\{\{charName\}\}/g, charNameList)
-              .replace(/\{\{userName\}\}/g, personaName),
+            aliasedConversationPrompt,
             promptMacroContext,
             // Defer {{#if}} blocks that test a relocation macro — their value is
             // filled in later; the decode pass below evaluates them (#3448).
-            { deferConditionalOperand: isRelocationConditionOperand },
+            {
+              deferConditionalOperand: isRelocationConditionOperand,
+              ...(deferCharacterMacros ? { deferCharacterMacros: "names" as const } : {}),
+            },
           );
           // Mark each relocation macro a deferred conditional actually references
           // as "used" so its retrieval runs and its value is captured for the
@@ -2140,14 +2151,15 @@ export async function generateRoutes(app: FastifyInstance) {
           }
           const conversationInstructionParts = [unwrapConversationInstructions(renderedConversationPrompt)];
 
-          if (isGroup) {
+          if (individualConversationGroup) {
+            conversationInstructionParts.push("This is a group DM with other participants.");
+          } else if (isGroup) {
             conversationInstructionParts.push(
               [
                 `This is a group DM. Each character responds in their own voice and personality. Not every character needs to respond every time; only those who would naturally react.`,
                 `IMPORTANT: Prefix each character's line with their name. Example:`,
                 `${convoCharNames[0] ?? "Alice"}: hey whats up`,
                 `${convoCharNames[1] ?? "Bob"}: not much lol`,
-                ``,
                 `If a character sends multiple lines in a row, only prefix the first line:`,
                 `${convoCharNames[0] ?? "Alice"}: so anyway`,
                 `i was thinking about that`,
@@ -2157,7 +2169,7 @@ export async function generateRoutes(app: FastifyInstance) {
           }
 
           let conversationSystemPrompt = formatConversationInstructionsForWrap(
-            conversationInstructionParts.filter((part) => part.trim().length > 0).join("\n\n"),
+            conversationInstructionParts.filter((part) => part.trim().length > 0).join("\n"),
             wrapFormat,
           );
 
@@ -2199,6 +2211,27 @@ export async function generateRoutes(app: FastifyInstance) {
             wrapFormat,
           });
           conversationContextBlockValue = contextBlock ?? "";
+          if (individualConversationGroup) {
+            conversationContextBlocksByCharacterId = new Map(
+              convoCharInfo.map((character) => [
+                character.charId,
+                buildConversationCurrentContextBlock({
+                  nowInstant,
+                  promptTimeZone,
+                  convoCharInfo,
+                  finalMessages,
+                  personaName,
+                  userMessage: input.userMessage,
+                  userStatus: input.userStatus,
+                  userActivity: input.userActivity,
+                  mentionedCharacterNames: input.mentionedCharacterNames,
+                  autonomousIntentKey: input.autonomousIntentKey,
+                  primaryCharacterId: character.charId,
+                  wrapFormat,
+                }),
+              ]),
+            );
+          }
 
           // ── Cross-chat awareness: show messages from other chats this character is in ──
           // (awarenessBlock is injected later, after persona info)
@@ -4812,6 +4845,19 @@ export async function generateRoutes(app: FastifyInstance) {
             gameAwareMessagesForGen,
             audienceCharacterIds,
           );
+          const targetContextBlock = targetCharId
+            ? conversationContextBlocksByCharacterId.get(targetCharId)
+            : undefined;
+          if (isGroupChat && usesIndividualGroupGeneration && targetContextBlock && conversationContextBlockValue) {
+            gameAwareMessagesForGen = gameAwareMessagesForGen.map((message) => ({
+              ...message,
+              content: replaceConversationContextBlockForTarget(
+                message.content,
+                conversationContextBlockValue,
+                targetContextBlock,
+              ),
+            }));
+          }
           const scopedMessagesForGen =
             isGroupChat && usesIndividualGroupGeneration && targetCharId
               ? scopeIndividualGroupMessagesForTarget(gameAwareMessagesForGen, targetCharId, charInfo)
@@ -4855,16 +4901,18 @@ export async function generateRoutes(app: FastifyInstance) {
               usesIndividualGroupGeneration && groupTurnPromptEnabled && speaksOnlyTargetCharacter && targetCharId
                 ? (charInfo.find((character) => character.id === targetCharId)?.name ?? null)
                 : null;
-            preparedMessagesForGen.push({
-              role: "user",
-              content: formatConversationGroupOutputFormat({
-                wrapFormat,
-                characterNames: conversationCharacterNames,
-                userName: personaName,
-                turnCharacterName,
-              }),
-              contextKind: "injection",
-            });
+            if (!usesIndividualGroupGeneration || turnCharacterName) {
+              preparedMessagesForGen.push({
+                role: "user",
+                content: formatConversationGroupOutputFormat({
+                  wrapFormat,
+                  characterNames: conversationCharacterNames,
+                  userName: personaName,
+                  turnCharacterName,
+                }),
+                contextKind: "injection",
+              });
+            }
           }
           // Defense in depth: the relocation decode pass should have consumed
           // every token already; strip any that slipped through so no control

--- a/packages/server/src/routes/generate/conversation-context-block.ts
+++ b/packages/server/src/routes/generate/conversation-context-block.ts
@@ -9,7 +9,9 @@ import {
 import { wrapContent } from "../../services/prompt/format-engine.js";
 
 type ConversationContextCharacter = {
+  charId?: string;
   name: string;
+  displayName?: string;
   status: string;
   activity: string;
   todaySchedule?: string | null;
@@ -30,6 +32,8 @@ export function buildConversationCurrentContextBlock(args: {
   userActivity?: string | null;
   mentionedCharacterNames?: string[] | null;
   autonomousIntentKey?: unknown;
+  /** Character receiving this prompt in Individual group mode. */
+  primaryCharacterId?: string | null;
   /** @deprecated Group behavior is derived from convoCharInfo. Kept for caller compatibility. */
   isGroup?: boolean;
   /** @deprecated Conversation mode no longer has a separate early-group mode. */
@@ -51,7 +55,7 @@ export function buildConversationCurrentContextBlock(args: {
     }
   }
 
-  const statusLine = buildConversationStatusLine(args.convoCharInfo);
+  const statusLines = buildConversationStatusLines(args.convoCharInfo, args.primaryCharacterId);
 
   const userStatusLabels: Record<string, string> = {
     active: "online",
@@ -80,7 +84,7 @@ export function buildConversationCurrentContextBlock(args: {
   const intentHint = isMessageIntent(autonomousIntentKey) ? getIntentHint(autonomousIntentKey) : "";
 
   const contextLines = [
-    `Your current status: ${statusLine}.`,
+    ...statusLines,
     ...(shouldIncludeUserStatus ? [`${args.personaName}'s status: ${userStatusLine}.`] : []),
     ...(proactiveTurnLine ? [proactiveTurnLine] : []),
     ...(mentionLine ? [mentionLine] : []),
@@ -92,7 +96,10 @@ export function buildConversationCurrentContextBlock(args: {
   return wrapContent(contextLines.join("\n"), "Context", args.wrapFormat);
 }
 
-function buildConversationStatusLine(convoCharInfo: ConversationContextCharacter[]): string {
+function buildConversationStatusLines(
+  convoCharInfo: ConversationContextCharacter[],
+  primaryCharacterId?: string | null,
+): string[] {
   const statusLabels: Record<string, string> = {
     online: "online",
     idle: "idle / away",
@@ -103,9 +110,36 @@ function buildConversationStatusLine(convoCharInfo: ConversationContextCharacter
     const label = statusLabels[character.status] ?? "online";
     return character.activity ? `${label} (${character.activity})` : label;
   };
-  return convoCharInfo.length === 1
-    ? buildCharStatus(convoCharInfo[0]!)
-    : convoCharInfo.map((character) => `${character.name}: ${buildCharStatus(character)}`).join("; ");
+  const promptName = (character: ConversationContextCharacter) => character.displayName?.trim() || character.name;
+  const primaryCharacter = primaryCharacterId
+    ? convoCharInfo.find((character) => character.charId === primaryCharacterId)
+    : null;
+
+  if (!primaryCharacter || convoCharInfo.length === 1) {
+    const statusLine =
+      convoCharInfo.length === 1
+        ? buildCharStatus(convoCharInfo[0]!)
+        : convoCharInfo.map((character) => `${character.name}: ${buildCharStatus(character)}`).join("; ");
+    return [`Your current status: ${statusLine}.`];
+  }
+
+  return [
+    `Your current status: ${promptName(primaryCharacter)}: ${buildCharStatus(primaryCharacter)}.`,
+    ...convoCharInfo
+      .filter((character) => character !== primaryCharacter)
+      .map((character) => `${promptName(character)}'s status: ${buildCharStatus(character)}.`),
+  ];
+}
+
+export function replaceConversationContextBlockForTarget(
+  content: string,
+  sharedContextBlock: string,
+  targetContextBlock: string,
+): string {
+  if (!sharedContextBlock || sharedContextBlock === targetContextBlock || !content.includes(sharedContextBlock)) {
+    return content;
+  }
+  return content.split(sharedContextBlock).join(targetContextBlock);
 }
 
 function buildMentionLine(args: {

--- a/packages/server/src/routes/generate/conversation-prompt-formatting.ts
+++ b/packages/server/src/routes/generate/conversation-prompt-formatting.ts
@@ -4,8 +4,7 @@ import type { GenerationPromptMessage } from "../../services/generation/prompt-m
 import { wrapContent } from "../../services/prompt/format-engine.js";
 import { parseExtra } from "./generate-route-utils.js";
 
-export const CONVERSATION_GROUP_NAME_PREFIX_INSTRUCTION =
-  "Remember to prefix messages with `Name: message`!";
+export const CONVERSATION_GROUP_NAME_PREFIX_INSTRUCTION = "Remember to prefix messages with `Name: message`!";
 
 export function formatConversationGroupOutputFormat(args: {
   wrapFormat: WrapFormat;
@@ -18,13 +17,9 @@ export function formatConversationGroupOutputFormat(args: {
   const responseBoundary = `Only respond for these characters: ${characterList || "the listed characters"}. Never respond for ${userName} or write ${userName}'s messages.`;
   const turnCharacterName = args.turnCharacterName?.trim();
   return wrapContent(
-    [
-      CONVERSATION_GROUP_NAME_PREFIX_INSTRUCTION,
-      responseBoundary,
-      turnCharacterName ? `Respond as ${turnCharacterName} alone.` : null,
-    ]
-      .filter((line): line is string => line !== null)
-      .join("\n"),
+    turnCharacterName
+      ? `Respond only as ${turnCharacterName}.`
+      : [CONVERSATION_GROUP_NAME_PREFIX_INSTRUCTION, responseBoundary].join("\n"),
     "Output Format",
     args.wrapFormat,
   );

--- a/scripts/regressions/prompt.regression.ts
+++ b/scripts/regressions/prompt.regression.ts
@@ -429,6 +429,10 @@ import {
 } from "../../packages/server/src/routes/generate/conversation-history-runtime.js";
 import { formatConversationGroupOutputFormat } from "../../packages/server/src/routes/generate/conversation-prompt-formatting.js";
 import {
+  buildConversationCurrentContextBlock,
+  replaceConversationContextBlockForTarget,
+} from "../../packages/server/src/routes/generate/conversation-context-block.js";
+import {
   LEGACY_DEFAULT_CONVERSATION_PROMPT_LEAD,
   migrateLegacyDefaultConversationPromptLead,
 } from "../../packages/server/src/db/default-conversation-prompt-migration.js";
@@ -4888,8 +4892,76 @@ Use HTML sparingly and diegetically. Do not replace normal prose/dialogue unless
           userName: "Mari",
           turnCharacterName: "Dottore",
         }),
-        `## Output Format\n${instruction}\n${responseBoundary}\nRespond as Dottore alone.`,
+        `## Output Format\nRespond only as Dottore.`,
       );
+
+      const individualOutput = formatConversationGroupOutputFormat({
+        wrapFormat: "xml",
+        characterNames: ["Dottore", "Pantalone"],
+        userName: "Mari",
+        turnCharacterName: "Dottore",
+      });
+      assert.match(individualOutput, /Respond only as Dottore\./u);
+      assert.doesNotMatch(individualOutput, /prefix messages|Pantalone|Never respond for Mari/u);
+
+      const contextCharacters = [
+        {
+          charId: "dottore",
+          name: "Dottore",
+          displayName: "Dottore",
+          status: "online",
+          activity: "",
+        },
+        {
+          charId: "pantalone",
+          name: "Pantalone",
+          displayName: "Pantalone",
+          status: "online",
+          activity: "",
+        },
+      ];
+      const sharedContext = buildConversationCurrentContextBlock({
+        nowInstant: new Date("2026-07-21T13:58:00.000Z"),
+        promptTimeZone: "Europe/Warsaw",
+        convoCharInfo: contextCharacters,
+        finalMessages: [{ role: "user" }],
+        personaName: "Mari",
+        userStatus: "active",
+        mentionedCharacterNames: ["Dottore"],
+        wrapFormat: "none",
+      });
+      const dottoreContext = buildConversationCurrentContextBlock({
+        nowInstant: new Date("2026-07-21T13:58:00.000Z"),
+        promptTimeZone: "Europe/Warsaw",
+        convoCharInfo: contextCharacters,
+        finalMessages: [{ role: "user" }],
+        personaName: "Mari",
+        userStatus: "active",
+        mentionedCharacterNames: ["Dottore"],
+        primaryCharacterId: "dottore",
+        wrapFormat: "none",
+      });
+      assert.match(sharedContext, /Your current status: Dottore: online; Pantalone: online\./u);
+      assert.match(dottoreContext, /^Your current status: Dottore: online\.\nPantalone's status: online\./u);
+      assert.doesNotMatch(dottoreContext, /Your current status:.*Pantalone/u);
+      assert.match(dottoreContext, /Mari @mentioned: Dottore/u);
+      assert.equal(
+        replaceConversationContextBlockForTarget(`Before\n${sharedContext}\nAfter`, sharedContext, dottoreContext),
+        `Before\n${dottoreContext}\nAfter`,
+      );
+
+      const deferredIdentity = resolveMacros(
+        "You are {{charName}}.",
+        {
+          user: "Mari",
+          char: "Dottore",
+          characters: ["Dottore", "Pantalone"],
+          groupCharacters: ["Dottore", "Pantalone"],
+          variables: {},
+        },
+        { deferCharacterMacros: "names" },
+      );
+      assert.equal(resolveDeferredCharacterMacros(deferredIdentity, { name: "Pantalone" }), "You are Pantalone.");
 
       const contextSource = readFileSync(
         new URL("../../packages/server/src/routes/generate/conversation-context-block.ts", import.meta.url),
@@ -4903,6 +4975,11 @@ Use HTML sparingly and diegetically. Do not replace normal prose/dialogue unless
       );
       assert.match(routeSource, /groupTurnPromptEnabled && chatMode === "roleplay"/u);
       assert.doesNotMatch(routeSource, /groupTurnPromptEnabled && chatMode !== "conversation"/u);
+      assert.match(
+        routeSource,
+        /if \(individualConversationGroup\) \{\s+conversationInstructionParts\.push\("This is a group DM with other participants\."\);\s+\} else if \(isGroup\)/u,
+      );
+      assert.doesNotMatch(routeSource, /conversationInstructionParts[^;]+\.join\("\\n\\n"\)/su);
     },
   },
   {


### PR DESCRIPTION
Closes #3887

## Why

Individual Conversation group generations were receiving a mixture of Grouped-mode and target-character instructions. Character identity could resolve to the full group before the responder was selected, the status block described every character as "your" status, and Output Format contained both group-wide and single-character rules.

## What changed

- defer Conversation identity macros until the actual Individual responder is selected, including Manual mode mentions
- keep a short `This is a group DM with other participants.` context line in Individual mode without the multi-speaker/prefix rules
- scope `Your current status` to the responder and list other participants' statuses separately
- emit only `Respond only as <character>.` in Individual Output Format
- preserve the established Grouped prompt contract while removing its extra blank separator
- avoid falling back to Grouped Output Format when the Individual turn-prompt option is disabled
- add positive and negative prompt regressions for identity, status, output rules, and context replacement

## Root cause

The Conversation system prompt and current-context block were assembled before the per-character generation target was known. The final provider-bound macro pass could scope unresolved character macros, but the prompt had already replaced `{{charName}}` with the group list and the shared status block had no target-specific variant. The Output Format helper also appended Individual guidance on top of the Grouped contract instead of choosing one contract.

## Validation

- `pnpm regression:prompt`
- `pnpm check`

## Manual verification

- [ ] Manually verify a Sequential Individual Conversation group turn sends only the selected character identity/status/output contract.
- [ ] Manually verify a Smart or @mentioned Manual Individual turn scopes the prompt to the selected responder.
- [ ] Manually verify Grouped Conversation mode retains its prior multi-speaker behavior with single-newline instruction spacing.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved conversation-mode group chats when generating individual responses for each character.
  - Each character now receives relevant, personalized conversation context and status information.
  - Primary and participating characters are identified more clearly in current-status details.

- **Bug Fixes**
  - Prevented duplicated or unnecessary formatting instructions in individual character responses.
  - Improved character-name resolution and response instructions across different output formats.
  - Ensured manual response ordering works correctly in conversation mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->