### PR TITLE
Fix per-chat Tracker persistence and extension reinstalls

### DIFF
--- a/docs/development/writing-extensions.md
+++ b/docs/development/writing-extensions.md
@@ -36,6 +36,7 @@ A minimal browser manifest that points at those two files:
   "version": 1,
   "config": {
     "name": "My Extension",
+    "version": "1.0.0",
     "description": "Adds custom UI behavior and styling.",
     "enabled": true,
     "cssPath": "extension.css",
@@ -54,6 +55,7 @@ You can also put the code inline instead of in separate files:
   "version": 1,
   "config": {
     "name": "Inline Example",
+    "version": "1.0.0",
     "description": "Small inline extension.",
     "enabled": true,
     "css": ".my-class { color: var(--primary); }",
@@ -71,6 +73,7 @@ A manifest can supply both a file path and inline content for the same slot (for
 | `kind` | Recommended | Use `marinara.extension` for a browser extension or `marinara.server-extension` for a server extension. The importer does not require this field. When both `kind` and `config.runtime` are missing, Marinara imports the extension as a browser extension. |
 | `version` | Recommended | Use `1`. The importer does not read or validate this field. Marinara writes it when it exports an extension, so include it to match the standard format. |
 | `config.name` | Yes | Display name. 1 to 200 characters. |
+| `config.version` | No | Extension release version, such as `1.2.0`. Marinara uses numeric dotted versions to warn before replacing a newer installed release with an older one. |
 | `config.description` | No | Up to 2000 characters. Defaults to an empty string. |
 | `config.runtime` | No | Use `client` for a browser extension or `server` for a server extension. Defaults to `client`. If `runtime` is `server`, the extension is treated as a server extension even when `kind` says otherwise. |
 | `config.enabled` | No | For a browser extension, whether it runs right after import. If you omit it, Marinara imports the extension disabled so you can review it first. A server extension is always imported disabled no matter what you set here. |
@@ -100,6 +103,7 @@ To ship more than one extension in a single folder, add a root file named `marin
         "version": 1,
         "config": {
           "name": "Accent Glow",
+          "version": "1.0.0",
           "description": "Adds a small accent glow.",
           "enabled": true,
           "cssPath": "extension.css"

--- a/docs/examples/extensions/minimal/manifest.json
+++ b/docs/examples/extensions/minimal/manifest.json
@@ -3,6 +3,7 @@
   "version": 1,
   "config": {
     "name": "Example Accent Glow",
+    "version": "1.0.0",
     "description": "Example extension package for Marinara Engine.",
     "enabled": true,
     "cssPath": "extension.css",

--- a/docs/extending/extensions.md
+++ b/docs/extending/extensions.md
@@ -97,7 +97,7 @@ Deleting is permanent. It removes the saved extension code from the server. Dele
 
 ## Changing an extension
 
-There is no way to edit an installed extension's code inside Marinara. To change one, delete it and import the new version. Importing a changed file creates a new entry rather than updating the old one, so delete the old entry to avoid duplicates.
+There is no way to edit an installed extension's code inside Marinara. Import the new version using the same extension name, and Marinara updates the existing entry while preserving whether you enabled or disabled it. If the extension declares a numeric release version and the imported release is older than the installed one, Marinara asks before replacing it.
 
 ## Why some actions need Admin Access
 

--- a/e2e/core-flows.e2e.ts
+++ b/e2e/core-flows.e2e.ts
@@ -774,6 +774,14 @@ test("desktop Tracker stays in the Roleplay gutter without shifting the chat col
       return overflow;
     });
     expect(horizontalOverflow).toBeNull();
+
+    await page.reload();
+    await expect(tracker).toBeVisible();
+
+    await tracker.getByRole("button", { name: "Close tracker panel" }).click();
+    await expect(tracker).toBeHidden();
+    await page.reload();
+    await expect(tracker).toBeHidden();
   } finally {
     await page.request.delete(`/api/chats/${chat.id}`);
   }

--- a/e2e/core-flows.e2e.ts
+++ b/e2e/core-flows.e2e.ts
@@ -787,6 +787,122 @@ test("desktop Tracker stays in the Roleplay gutter without shifting the chat col
   }
 });
 
+test("reinstalling an extension updates the existing record instead of creating a duplicate", async ({ page }) => {
+  const name = "Extension Reinstall Smoke";
+  let extensionId: string | null = null;
+
+  try {
+    const firstResponse = await page.request.post("/api/extensions", {
+      data: {
+        name,
+        version: "2.0.0",
+        description: "First install",
+        runtime: "client",
+        css: ".extension-reinstall-smoke { color: red; }",
+        enabled: false,
+      },
+    });
+    expect(firstResponse.ok()).toBeTruthy();
+    const first = (await firstResponse.json()) as { id: string; version?: string | null };
+    extensionId = first.id;
+
+    const replacementResponse = await page.request.post("/api/extensions", {
+      data: {
+        name: name.toLowerCase(),
+        version: "3.0.0",
+        description: "Replacement install",
+        runtime: "client",
+        css: ".extension-reinstall-smoke { color: blue; }",
+        enabled: false,
+      },
+    });
+    expect(replacementResponse.ok()).toBeTruthy();
+    const replacement = (await replacementResponse.json()) as { id: string; version?: string | null };
+    expect(replacement.id).toBe(first.id);
+    expect(replacement.version).toBe("3.0.0");
+
+    const listResponse = await page.request.get("/api/extensions");
+    expect(listResponse.ok()).toBeTruthy();
+    const extensions = (await listResponse.json()) as Array<{ id: string; name: string }>;
+    expect(extensions.filter((extension) => extension.name.trim().toLowerCase() === name.toLowerCase())).toEqual([
+      expect.objectContaining({ id: first.id }),
+    ]);
+  } finally {
+    if (extensionId) await page.request.delete(`/api/extensions/${extensionId}`);
+  }
+});
+
+test("extension import warns before replacing a newer installed version", async ({ page }, testInfo) => {
+  test.skip(!testInfo.project.name.includes("desktop"), "The Add-ons downgrade confirmation is covered on desktop.");
+
+  const name = "Extension Downgrade Warning Smoke";
+  let extensionId: string | null = null;
+  const importFile = {
+    name: "extension-downgrade-warning.json",
+    mimeType: "application/json",
+    buffer: Buffer.from(
+      JSON.stringify({
+        kind: "marinara.extension",
+        version: 1,
+        config: {
+          name,
+          version: "1.0.0",
+          description: "Older release",
+          enabled: false,
+          css: ".extension-downgrade-warning { color: blue; }",
+        },
+      }),
+    ),
+  };
+
+  try {
+    const installResponse = await page.request.post("/api/extensions", {
+      data: {
+        name,
+        version: "2.0.0",
+        description: "Newer release",
+        runtime: "client",
+        css: ".extension-downgrade-warning { color: red; }",
+        enabled: false,
+      },
+    });
+    expect(installResponse.ok()).toBeTruthy();
+    extensionId = ((await installResponse.json()) as { id: string }).id;
+
+    await page.goto("/");
+    await page.locator('[data-tour="panel-settings"]').click();
+    await page.getByRole("tab", { name: "Addons" }).click();
+    const importButton = page.getByRole("button", { name: /Import Extension File/ });
+
+    let fileChooserPromise = page.waitForEvent("filechooser");
+    await importButton.click();
+    await (await fileChooserPromise).setFiles(importFile);
+    let downgradeDialog = page.getByRole("dialog", { name: "Install Older Extension Version?" });
+    await expect(downgradeDialog).toBeVisible();
+    await downgradeDialog.getByRole("button", { name: "Cancel" }).click();
+
+    let extensionResponse = await page.request.get("/api/extensions");
+    let extensions = (await extensionResponse.json()) as Array<{ name: string; version?: string | null }>;
+    expect(extensions.find((extension) => extension.name === name)?.version).toBe("2.0.0");
+
+    fileChooserPromise = page.waitForEvent("filechooser");
+    await importButton.click();
+    await (await fileChooserPromise).setFiles(importFile);
+    downgradeDialog = page.getByRole("dialog", { name: "Install Older Extension Version?" });
+    await downgradeDialog.getByRole("button", { name: "Install Older Version" }).click();
+
+    await expect
+      .poll(async () => {
+        extensionResponse = await page.request.get("/api/extensions");
+        extensions = (await extensionResponse.json()) as Array<{ name: string; version?: string | null }>;
+        return extensions.find((extension) => extension.name === name)?.version;
+      })
+      .toBe("1.0.0");
+  } finally {
+    if (extensionId) await page.request.delete(`/api/extensions/${extensionId}`);
+  }
+});
+
 test("Roleplay Active Context shows rich lorebook activation provenance", async ({ page, request }, testInfo) => {
   const lorebookId = "roleplay-active-context-smoke-lorebook";
   const chatResponse = await request.post("/api/chats", {

--- a/packages/client/src/components/chat/RoleplayHUD.tsx
+++ b/packages/client/src/components/chat/RoleplayHUD.tsx
@@ -283,7 +283,9 @@ export function RoleplayHUD({
           mobileCompact && "min-w-0",
         )}
       >
-        {trackerPanelEnabled && !trackerPanelOpen && <TrackerPanelToggleButton onToggle={toggleTrackerPanel} />}
+        {trackerPanelEnabled && !trackerPanelOpen && (
+          <TrackerPanelToggleButton onToggle={() => toggleTrackerPanel(chatId)} />
+        )}
 
         {/* Actions (Agents + Clear) */}
         <ActionsGroup

--- a/packages/client/src/components/layout/AppShell.tsx
+++ b/packages/client/src/components/layout/AppShell.tsx
@@ -259,6 +259,7 @@ export function AppShell() {
   const closeAgentDetail = useUIStore((s) => s.closeAgentDetail);
   const openAgentCatalog = useUIStore((s) => s.openAgentCatalog);
   const setTrackerPanelOpen = useUIStore((s) => s.setTrackerPanelOpen);
+  const restoreTrackerPanelOpenForChat = useUIStore((s) => s.restoreTrackerPanelOpenForChat);
   const [sidebarDragWidth, setSidebarDragWidth] = useState<number | null>(null);
   const [rightPanelDragWidth, setRightPanelDragWidth] = useState<number | null>(null);
   const sidebarDragWidthRef = useRef<number | null>(null);
@@ -679,9 +680,12 @@ export function AppShell() {
   const professorMariFloatingActive = hasDetailView && hasProfessorMariFloatingFollowup();
 
   useEffect(() => {
+    restoreTrackerPanelOpenForChat(activeChatId);
+  }, [activeChatId, restoreTrackerPanelOpenForChat, trackerPanelEnabled]);
+  useEffect(() => {
     if (!trackerPanelOpen || !activeChat?.mode || trackerPanelModeAvailable) return;
-    setTrackerPanelOpen(false);
-  }, [activeChat?.mode, setTrackerPanelOpen, trackerPanelModeAvailable, trackerPanelOpen]);
+    setTrackerPanelOpen(false, activeChatId);
+  }, [activeChat?.mode, activeChatId, setTrackerPanelOpen, trackerPanelModeAvailable, trackerPanelOpen]);
   useEffect(() => {
     if (trackerPanelVisible) {
       trackerPanelWasActiveRef.current = true;
@@ -1140,7 +1144,7 @@ export function AppShell() {
       {trackerPanelVisible && shellOverlayMode && (
         <div
           className={cn("fixed inset-x-0 bottom-0 z-30 bg-black/50 backdrop-blur-sm", MOBILE_SHELL_PANEL_TOP_CLASS)}
-          onClick={() => setTrackerPanelOpen(false)}
+          onClick={() => setTrackerPanelOpen(false, activeChatId)}
         />
       )}
 

--- a/packages/client/src/components/panels/SettingsPanel.tsx
+++ b/packages/client/src/components/panels/SettingsPanel.tsx
@@ -138,6 +138,11 @@ import { inspectCharacterFilesForEmbeddedLorebooks } from "../../lib/character-i
 import { showConfirmDialog } from "../../lib/app-dialogs";
 import { downloadJsonFile, sanitizeExportFilenamePart } from "../../lib/download-json";
 import { downloadZipFile } from "../../lib/download-zip";
+import {
+  compareExtensionVersions,
+  findExtensionsByName,
+  normalizeExtensionVersion,
+} from "../../lib/extension-install";
 import { createExtensionFolderPackageFilename, createExtensionFolderPackageFiles } from "../../lib/extension-transfer";
 import {
   collectFolderPackageEntries,
@@ -5395,6 +5400,7 @@ function normalizeExtensionImportEntry(entry: FolderPackageImportEntry, fallback
   const name = typeof record.name === "string" && record.name.trim() ? record.name.trim() : folderName;
   if (!name) return null;
   const runtime = getExtensionImportRuntime(entry.raw, record);
+  const version = normalizeExtensionVersion(record.version);
 
   if (runtime === "server") {
     const serverJsFromFiles = resolvePackageTextPaths(
@@ -5403,6 +5409,7 @@ function normalizeExtensionImportEntry(entry: FolderPackageImportEntry, fallback
     );
     return {
       name,
+      version,
       description: typeof record.description === "string" ? record.description : "",
       runtime,
       css: null,
@@ -5416,6 +5423,7 @@ function normalizeExtensionImportEntry(entry: FolderPackageImportEntry, fallback
 
   return {
     name,
+    version,
     description: typeof record.description === "string" ? record.description : "",
     runtime,
     css:
@@ -5547,15 +5555,52 @@ function ExtensionsSettings({ showIntro = true }: { showIntro?: boolean } = {}) 
   const updateExtension = useUpdateExtension();
   const deleteExtension = useDeleteExtension();
 
+  const installOrUpdateExtension = async (
+    normalized: NonNullable<ReturnType<typeof normalizeExtensionImportEntry>>,
+    installedAt: string,
+    candidates = extensionList,
+  ) => {
+    const matches = findExtensionsByName(candidates, normalized.name);
+    const existing = matches[0];
+    if (!existing) {
+      return {
+        extension: await createExtension.mutateAsync({ ...normalized, installedAt }),
+        status: "installed" as const,
+      };
+    }
+
+    if (compareExtensionVersions(normalized.version, existing.version) === -1) {
+      const confirmed = await showConfirmDialog({
+        title: "Install Older Extension Version?",
+        message: `Version ${normalized.version} of "${normalized.name}" is older than the installed version ${existing.version}. Replace it anyway?`,
+        confirmLabel: "Install Older Version",
+        tone: "destructive",
+      });
+      if (!confirmed) return { extension: existing, status: "cancelled" as const };
+    }
+
+    const updated = await updateExtension.mutateAsync({
+      id: existing.id,
+      ...normalized,
+      enabled: existing.runtime === normalized.runtime ? existing.enabled : false,
+    });
+    for (const duplicate of matches.slice(1)) {
+      await deleteExtension.mutateAsync(duplicate.id);
+    }
+    return { extension: updated, status: "updated" as const };
+  };
+
   const importExtensionEntries = async (
     entries: FolderPackageImportEntry[],
     installedAt: string,
     fallbackName: string,
   ) => {
-    let imported = 0;
+    let installed = 0;
+    let updated = 0;
     let importedEnabled = 0;
     let failed = 0;
     let skipped = 0;
+    let workingExtensions = extensionList;
     const failureMessages: string[] = [];
     for (const entry of entries) {
       const normalized = normalizeExtensionImportEntry(entry, fallbackName);
@@ -5565,38 +5610,54 @@ function ExtensionsSettings({ showIntro = true }: { showIntro?: boolean } = {}) 
         continue;
       }
       try {
-        await createExtension.mutateAsync({
-          ...normalized,
-          installedAt,
-        });
-        imported++;
-        if (normalized.enabled) importedEnabled++;
+        const result = await installOrUpdateExtension(normalized, installedAt, workingExtensions);
+        if (result.status === "cancelled") {
+          skipped++;
+          failureMessages.push(`Kept the installed version of "${normalized.name}".`);
+          continue;
+        }
+        if (result.status === "updated") updated++;
+        else installed++;
+        if (result.extension.enabled) importedEnabled++;
+        workingExtensions = [
+          result.extension,
+          ...workingExtensions.filter(
+            (extension) => extension.name.trim().toLowerCase() !== normalized.name.trim().toLowerCase(),
+          ),
+        ];
       } catch (err) {
         failed++;
         failureMessages.push(describeExtensionImportError(err, normalized.name));
         console.warn("[ExtensionsSettings] Failed to import extension entry:", normalized.name, err);
       }
     }
-    if (imported === 0 && failed === 0 && skipped === 0) throw new Error("No valid extensions found in file");
-    const skipNote = skipped > 0 ? ` (${skipped} skipped — no importable entry)` : "";
+    const completed = installed + updated;
+    if (completed === 0 && failed === 0 && skipped === 0) throw new Error("No valid extensions found in file");
+    const skipNote = skipped > 0 ? ` (${skipped} skipped)` : "";
+    const successSummary = [
+      installed > 0 ? `Installed ${installed} extension${installed === 1 ? "" : "s"}` : "",
+      updated > 0 ? `updated ${updated} extension${updated === 1 ? "" : "s"}` : "",
+    ]
+      .filter(Boolean)
+      .join(" and ");
     // "Review before enabling" would be misleading when a manifest imported
     // with enabled:true — those extensions are already running.
     const reviewNote =
       importedEnabled > 0
-        ? ` ${importedEnabled === imported ? "They are" : `${importedEnabled} of them are`} already enabled — review in the Extension Library.`
+        ? ` ${importedEnabled === completed ? "They are" : `${importedEnabled} of them are`} already enabled — review in the Extension Library.`
         : " Review before enabling.";
     if (failed > 0) {
       const more = failureMessages.length > 1 ? ` (+${failureMessages.length - 1} more)` : "";
       toast.error(
-        imported > 0
-          ? `Imported ${imported} extension${imported === 1 ? "" : "s"}${skipNote}; ${failed} failed — ${failureMessages[0]}${more}`
+        completed > 0
+          ? `${successSummary}${skipNote}; ${failed} failed — ${failureMessages[0]}${more}`
           : `Failed to import ${failed} extension${failed === 1 ? "" : "s"}${skipNote} — ${failureMessages[0]}${more}`,
         { duration: 12_000 },
       );
     } else if (skipped > 0) {
       toast.warning(
-        imported > 0
-          ? `Imported ${imported} extension${imported === 1 ? "" : "s"}${skipNote}.${reviewNote}`
+        completed > 0
+          ? `${successSummary}${skipNote}.${reviewNote}`
           : `Skipped ${skipped} extension entr${skipped === 1 ? "y" : "ies"}.`,
         {
           description: failureMessages[0],
@@ -5604,7 +5665,7 @@ function ExtensionsSettings({ showIntro = true }: { showIntro?: boolean } = {}) 
         },
       );
     } else {
-      toast.success(`Imported ${imported} extension${imported === 1 ? "" : "s"}${skipNote}.${reviewNote}`);
+      toast.success(`${successSummary}${skipNote}.${reviewNote}`);
     }
   };
 
@@ -5637,51 +5698,60 @@ function ExtensionsSettings({ showIntro = true }: { showIntro?: boolean } = {}) 
       } else if (/\.server\.(js|mjs|cjs)$/i.test(lowerName)) {
         const text = await file.text();
         const name = file.name.replace(/\.server\.(js|mjs|cjs)$/i, "");
-        try {
-          await createExtension.mutateAsync({
-            name,
-            description: "Server extension imported from file",
-            runtime: "server",
-            serverJs: text,
-            enabled: false,
-            installedAt,
-          });
-        } catch (err) {
-          throw new Error(describeExtensionImportError(err, name));
-        }
-        toast.success(`Server extension "${name}" imported and left disabled for review`);
+        await importExtensionEntries(
+          [
+            createInlineFolderPackageImportEntry(
+              {
+                name,
+                description: "Server extension imported from file",
+                runtime: "server",
+                serverJs: text,
+                enabled: false,
+              },
+              file.name,
+            ),
+          ],
+          installedAt,
+          name,
+        );
       } else if (/\.(js|mjs|cjs)$/i.test(lowerName)) {
         const text = await file.text();
         const name = file.name.replace(/\.(js|mjs|cjs)$/i, "");
-        try {
-          await createExtension.mutateAsync({
-            name,
-            description: "JS extension imported from file",
-            runtime: "client",
-            js: text,
-            enabled: false,
-            installedAt,
-          });
-        } catch (err) {
-          throw new Error(describeExtensionImportError(err, name));
-        }
-        toast.success(`Extension "${name}" imported and left disabled for review`);
+        await importExtensionEntries(
+          [
+            createInlineFolderPackageImportEntry(
+              {
+                name,
+                description: "JS extension imported from file",
+                runtime: "client",
+                js: text,
+                enabled: false,
+              },
+              file.name,
+            ),
+          ],
+          installedAt,
+          name,
+        );
       } else if (lowerName.endsWith(".css")) {
         const text = await file.text();
         const name = file.name.replace(/\.css$/i, "");
-        try {
-          await createExtension.mutateAsync({
-            name,
-            description: "CSS extension imported from file",
-            runtime: "client",
-            css: text,
-            enabled: false,
-            installedAt,
-          });
-        } catch (err) {
-          throw new Error(describeExtensionImportError(err, name));
-        }
-        toast.success(`Extension "${name}" imported and left disabled for review`);
+        await importExtensionEntries(
+          [
+            createInlineFolderPackageImportEntry(
+              {
+                name,
+                description: "CSS extension imported from file",
+                runtime: "client",
+                css: text,
+                enabled: false,
+              },
+              file.name,
+            ),
+          ],
+          installedAt,
+          name,
+        );
       } else {
         toast.error(
           "Only .zip, .json, .css, .js, .mjs, .cjs, .server.js, .server.mjs, and .server.cjs files are supported.",
@@ -5826,6 +5896,11 @@ function ExtensionsSettings({ showIntro = true }: { showIntro?: boolean } = {}) 
                 <div className="flex min-w-0 flex-1 flex-col gap-0.5">
                   <div className="flex min-w-0 items-center gap-1.5">
                     <span className="mari-chrome-text truncate font-medium">{ext.name}</span>
+                    {ext.version && (
+                      <span className="shrink-0 text-[0.5625rem] text-[var(--muted-foreground)]">
+                        v{ext.version}
+                      </span>
+                    )}
                     <span
                       className={cn(
                         "shrink-0 rounded px-1 py-px text-[0.5625rem] font-semibold",
@@ -5868,6 +5943,7 @@ function ExtensionsSettings({ showIntro = true }: { showIntro?: boolean } = {}) 
                       createExtensionFolderPackageFiles([
                         {
                           name: ext.name,
+                          version: ext.version ?? null,
                           description: ext.description ?? "",
                           runtime: ext.runtime,
                           css: ext.css ?? null,

--- a/packages/client/src/components/panels/SettingsPanel.tsx
+++ b/packages/client/src/components/panels/SettingsPanel.tsx
@@ -5582,6 +5582,7 @@ function ExtensionsSettings({ showIntro = true }: { showIntro?: boolean } = {}) 
     const updated = await updateExtension.mutateAsync({
       id: existing.id,
       ...normalized,
+      version: normalized.version ?? existing.version ?? null,
       enabled: existing.runtime === normalized.runtime ? existing.enabled : false,
     });
     for (const duplicate of matches.slice(1)) {

--- a/packages/client/src/features/tracker-panel/components/TrackerDataSidebar.tsx
+++ b/packages/client/src/features/tracker-panel/components/TrackerDataSidebar.tsx
@@ -172,7 +172,7 @@ export function TrackerDataSidebar({ fillHeight = false }: { fillHeight?: boolea
           onSetEditMode={setActiveEditMode}
           onSetSide={setTrackerPanelSide}
           onSetSizeProfile={setTrackerPanelSizeProfile}
-          onClose={() => setTrackerPanelOpen(false)}
+          onClose={() => setTrackerPanelOpen(false, activeChatId)}
         />
 
         <div className={cn("relative z-10", fillHeight && "min-h-0 flex-1 overflow-y-auto")}>

--- a/packages/client/src/hooks/use-settings-sync.ts
+++ b/packages/client/src/hooks/use-settings-sync.ts
@@ -40,11 +40,11 @@ type SyncedSettingsObject = ReturnType<typeof pickSyncedSettings>;
 type ServerSettingsPayload = SyncedSettingsObject & { __updatedAt?: number };
 type ParsedSettings = Partial<SyncedSettingsObject> & Record<string, unknown>;
 
-const DEVICE_LOCAL_SETTING_KEYS = ["fontSize", "chatFontSize"] as const;
+const LOCAL_ONLY_SETTING_KEYS = ["fontSize", "chatFontSize", "trackerPanelOpen"] as const;
 
-export function omitDeviceLocalSettings(settings: ParsedSettings): ParsedSettings {
+export function omitLocalOnlySettings(settings: ParsedSettings): ParsedSettings {
   const sanitized = { ...settings };
-  for (const key of DEVICE_LOCAL_SETTING_KEYS) {
+  for (const key of LOCAL_ONLY_SETTING_KEYS) {
     delete sanitized[key];
   }
   return sanitized;
@@ -166,8 +166,8 @@ export function useSettingsSync() {
           try {
             const parsed = parseServerSettingsValue(data.value);
             if (parsed.settings && typeof parsed.settings === "object") {
-              const hadDeviceLocalSettings = DEVICE_LOCAL_SETTING_KEYS.some((key) => key in parsed.settings);
-              parsed.settings = omitDeviceLocalSettings(parsed.settings);
+              const hadLocalOnlySettings = LOCAL_ONLY_SETTING_KEYS.some((key) => key in parsed.settings);
+              parsed.settings = omitLocalOnlySettings(parsed.settings);
 
               // Migrate old flat gradient fields → per-scheme nested (v10 → v11).
               if ("convoGradientFrom" in parsed.settings || "convoGradientTo" in parsed.settings) {
@@ -221,7 +221,7 @@ export function useSettingsSync() {
                 useUIStore.setState(parsed.settings);
                 lastPushed = serialize();
                 if (serverUpdatedAt !== null) writeLocalUpdatedAt(serverUpdatedAt);
-                if (hadDeviceLocalSettings) {
+                if (hadLocalOnlySettings) {
                   try {
                     await api.put(SETTINGS_PATH, {
                       value: buildServerSettingsValue(
@@ -231,7 +231,7 @@ export function useSettingsSync() {
                     });
                   } catch {
                     // Cleanup is best-effort; this browser still ignores
-                    // legacy size values from the server blob.
+                    // legacy local-only values from the server blob.
                   }
                 }
               }

--- a/packages/client/src/lib/extension-install.ts
+++ b/packages/client/src/lib/extension-install.ts
@@ -1,0 +1,32 @@
+import type { InstalledExtension } from "@marinara-engine/shared";
+
+export function normalizeExtensionVersion(value: unknown): string | null {
+  if (typeof value === "number" && Number.isFinite(value) && value >= 0) return String(value);
+  if (typeof value !== "string") return null;
+  const normalized = value.trim();
+  return normalized && normalized.length <= 64 ? normalized : null;
+}
+
+function parseNumericVersion(value: string | null | undefined): number[] | null {
+  if (!value) return null;
+  const normalized = value.trim().replace(/^v/i, "");
+  if (!/^\d+(?:\.\d+)*$/.test(normalized)) return null;
+  return normalized.split(".").map((part) => Number.parseInt(part, 10));
+}
+
+export function compareExtensionVersions(left: string | null | undefined, right: string | null | undefined) {
+  const leftParts = parseNumericVersion(left);
+  const rightParts = parseNumericVersion(right);
+  if (!leftParts || !rightParts) return null;
+  for (let index = 0; index < Math.max(leftParts.length, rightParts.length); index += 1) {
+    const delta = (leftParts[index] ?? 0) - (rightParts[index] ?? 0);
+    if (delta !== 0) return Math.sign(delta);
+  }
+  return 0;
+}
+
+export function findExtensionsByName<T extends Pick<InstalledExtension, "name">>(extensions: T[], name: string) {
+  const normalizedName = name.trim().toLowerCase();
+  if (!normalizedName) return [];
+  return extensions.filter((extension) => extension.name.trim().toLowerCase() === normalizedName);
+}

--- a/packages/client/src/lib/extension-transfer.ts
+++ b/packages/client/src/lib/extension-transfer.ts
@@ -4,6 +4,7 @@ import { reservePackageFolderSegment } from "./folder-package-transfer";
 
 export type ExtensionTransferConfig = {
   name: string;
+  version?: string | null;
   description?: string | null;
   runtime?: "client" | "server";
   css?: string | null;
@@ -25,6 +26,7 @@ export function createExtensionFolderPackageFiles(extensions: ExtensionTransferC
       runtime === "server"
         ? {
             name: extension.name,
+            ...(extension.version ? { version: extension.version } : {}),
             description: extension.description ?? "",
             runtime,
             serverJs,
@@ -33,6 +35,7 @@ export function createExtensionFolderPackageFiles(extensions: ExtensionTransferC
           }
         : {
             name: extension.name,
+            ...(extension.version ? { version: extension.version } : {}),
             description: extension.description ?? "",
             runtime,
             css,

--- a/packages/client/src/stores/ui.store.ts
+++ b/packages/client/src/stores/ui.store.ts
@@ -438,6 +438,7 @@ interface UIState {
   rightPanel: Panel;
   trackerPanelEnabled: boolean;
   trackerPanelOpen: boolean;
+  trackerPanelOpenByChatId: Record<string, boolean>;
   trackerPanelSide: TrackerPanelSide;
   trackerPanelHideHudWidgets: boolean;
   trackerPanelUseExpressionSprites: boolean;
@@ -775,9 +776,10 @@ interface UIState {
   setSidebarOpen: (open: boolean) => void;
   setSidebarWidth: (width: number) => void;
   setRightPanelWidth: (width: number) => void;
-  toggleTrackerPanel: () => void;
+  toggleTrackerPanel: (chatId?: string | null) => void;
   setTrackerPanelEnabled: (enabled: boolean) => void;
-  setTrackerPanelOpen: (open: boolean) => void;
+  setTrackerPanelOpen: (open: boolean, chatId?: string | null) => void;
+  restoreTrackerPanelOpenForChat: (chatId: string | null) => void;
   setTrackerPanelSide: (side: TrackerPanelSide) => void;
   setTrackerPanelHideHudWidgets: (hidden: boolean) => void;
   setTrackerPanelUseExpressionSprites: (enabled: boolean) => void;
@@ -1047,7 +1049,6 @@ export function pickSyncedSettings(state: UIState) {
     sidebarOpen: state.sidebarOpen,
     sidebarWidth: state.sidebarWidth,
     trackerPanelEnabled: state.trackerPanelEnabled,
-    trackerPanelOpen: state.trackerPanelOpen,
     trackerPanelSide: state.trackerPanelSide,
     trackerPanelHideHudWidgets: state.trackerPanelHideHudWidgets,
     trackerPanelUseExpressionSprites: state.trackerPanelUseExpressionSprites,
@@ -1178,6 +1179,7 @@ export const useUIStore = create<UIState>()(
       rightPanel: "chat" as Panel,
       trackerPanelEnabled: true,
       trackerPanelOpen: false,
+      trackerPanelOpenByChatId: {},
       trackerPanelSide: "right" as TrackerPanelSide,
       trackerPanelHideHudWidgets: false,
       trackerPanelUseExpressionSprites: false,
@@ -1381,19 +1383,45 @@ export const useUIStore = create<UIState>()(
         set({ sidebarWidth: Math.max(SIDEBAR_WIDTH_MIN, Math.min(SIDEBAR_WIDTH_MAX, width)) }),
       setRightPanelWidth: (width) =>
         set({ rightPanelWidth: Math.max(RIGHT_PANEL_WIDTH_MIN, Math.min(RIGHT_PANEL_WIDTH_MAX, width)) }),
-      toggleTrackerPanel: () =>
-        set((s) => ({
-          trackerPanelOpen: s.trackerPanelEnabled ? !s.trackerPanelOpen : false,
-        })),
+      toggleTrackerPanel: (chatId) =>
+        set((s) => {
+          const trackerPanelOpen = s.trackerPanelEnabled ? !s.trackerPanelOpen : false;
+          return {
+            trackerPanelOpen,
+            ...(chatId
+              ? { trackerPanelOpenByChatId: { ...s.trackerPanelOpenByChatId, [chatId]: trackerPanelOpen } }
+              : {}),
+          };
+        }),
       setTrackerPanelEnabled: (enabled) =>
         set({
           trackerPanelEnabled: enabled,
           trackerPanelOpen: enabled ? get().trackerPanelOpen : false,
         }),
-      setTrackerPanelOpen: (open) =>
-        set((s) => ({
-          trackerPanelOpen: s.trackerPanelEnabled ? open : false,
-        })),
+      setTrackerPanelOpen: (open, chatId) =>
+        set((s) => {
+          const trackerPanelOpen = s.trackerPanelEnabled ? open : false;
+          return {
+            trackerPanelOpen,
+            ...(chatId
+              ? { trackerPanelOpenByChatId: { ...s.trackerPanelOpenByChatId, [chatId]: trackerPanelOpen } }
+              : {}),
+          };
+        }),
+      restoreTrackerPanelOpenForChat: (chatId) => {
+        if (!chatId) return;
+        set((s) => {
+          const hasRememberedState = Object.prototype.hasOwnProperty.call(s.trackerPanelOpenByChatId, chatId);
+          const legacyOpen = Object.keys(s.trackerPanelOpenByChatId).length === 0 && s.trackerPanelOpen;
+          const rememberedOpen = hasRememberedState ? s.trackerPanelOpenByChatId[chatId] === true : legacyOpen;
+          return {
+            trackerPanelOpen: s.trackerPanelEnabled && rememberedOpen,
+            ...(hasRememberedState
+              ? {}
+              : { trackerPanelOpenByChatId: { ...s.trackerPanelOpenByChatId, [chatId]: rememberedOpen } }),
+          };
+        });
+      },
       setTrackerPanelSide: (side) => set({ trackerPanelSide: side }),
       setTrackerPanelHideHudWidgets: (hidden) => set({ trackerPanelHideHudWidgets: hidden }),
       setTrackerPanelUseExpressionSprites: (enabled) => set({ trackerPanelUseExpressionSprites: enabled }),
@@ -2056,6 +2084,7 @@ export const useUIStore = create<UIState>()(
         set({
           trackerPanelEnabled: true,
           trackerPanelOpen: false,
+          trackerPanelOpenByChatId: {},
           trackerPanelSide: "right" as TrackerPanelSide,
           trackerPanelHideHudWidgets: false,
           trackerPanelUseExpressionSprites: false,
@@ -2182,7 +2211,7 @@ export const useUIStore = create<UIState>()(
     }),
     {
       name: "marinara-engine-ui",
-      version: 78,
+      version: 79,
       // Debounce localStorage writes to avoid sync I/O on every state change
       storage: createJSONStorage(() => {
         let timer: ReturnType<typeof setTimeout> | null = null;
@@ -2727,6 +2756,22 @@ export const useUIStore = create<UIState>()(
         if (version <= 77 && persisted.gameTextEffectsEnabled === undefined) {
           persisted.gameTextEffectsEnabled = true;
         }
+        if (version <= 78) {
+          persisted.trackerPanelOpenByChatId = {};
+        }
+        if (
+          !persisted.trackerPanelOpenByChatId ||
+          typeof persisted.trackerPanelOpenByChatId !== "object" ||
+          Array.isArray(persisted.trackerPanelOpenByChatId)
+        ) {
+          persisted.trackerPanelOpenByChatId = {};
+        } else {
+          persisted.trackerPanelOpenByChatId = Object.fromEntries(
+            Object.entries(persisted.trackerPanelOpenByChatId).filter(
+              ([chatId, open]) => chatId.trim().length > 0 && typeof open === "boolean",
+            ),
+          );
+        }
         persisted.appAccentRgbMode = persisted.appAccentRgbMode === true;
         persisted.customCursorEnabled = persisted.customCursorEnabled !== false;
         persisted.professorMariSuggestionsEnabled = persisted.professorMariSuggestionsEnabled !== false;
@@ -2778,6 +2823,7 @@ export const useUIStore = create<UIState>()(
         agentPanelSort: state.agentPanelSort,
         trackerPanelEnabled: state.trackerPanelEnabled,
         trackerPanelOpen: state.trackerPanelOpen,
+        trackerPanelOpenByChatId: state.trackerPanelOpenByChatId,
         trackerPanelSide: state.trackerPanelSide,
         trackerPanelHideHudWidgets: state.trackerPanelHideHudWidgets,
         trackerPanelUseExpressionSprites: state.trackerPanelUseExpressionSprites,

--- a/packages/server/src/db/schema/extensions.ts
+++ b/packages/server/src/db/schema/extensions.ts
@@ -6,6 +6,7 @@ import { fileTable, text } from "../file-schema.js";
 export const installedExtensions = fileTable("installed_extensions", {
   id: text("id").primaryKey(),
   name: text("name").notNull(),
+  version: text("version"),
   description: text("description").notNull().default(""),
   runtime: text("runtime").notNull().default("client"),
   css: text("css"),

--- a/packages/server/src/routes/extensions.routes.ts
+++ b/packages/server/src/routes/extensions.routes.ts
@@ -48,9 +48,13 @@ export async function extensionsRoutes(app: FastifyInstance) {
   app.post("/", async (req, reply) => {
     if (!requirePrivilegedAccess(req, reply, { feature: "Extension install/update/delete" })) return;
     const input = createExtensionSchema.parse(req.body);
-    const created = await storage.create(input);
-    if (created?.runtime === "server") await serverExtensionRuntime.reloadExtension(created.id);
-    return withStatus(created);
+    const existing = await storage.getByName(input.name);
+    const installed = existing ? await storage.update(existing.id, input) : await storage.create(input);
+    if (!installed) throw new Error(`Failed to install extension ${input.name}`);
+    if (existing?.runtime === "server" || installed?.runtime === "server") {
+      await serverExtensionRuntime.reloadExtension(installed.id);
+    }
+    return withStatus(installed);
   });
 
   app.get<{ Params: { extensionRef: string } }>("/:extensionRef/storage", async (req, reply) => {

--- a/packages/server/src/services/storage/extensions.storage.ts
+++ b/packages/server/src/services/storage/extensions.storage.ts
@@ -13,6 +13,7 @@ function mapExtension(row: ExtensionRow): InstalledExtension {
   return {
     id: row.id,
     name: row.name,
+    version: row.version ?? null,
     description: row.description,
     runtime: row.runtime === "server" ? "server" : "client",
     css: row.css ?? null,
@@ -34,6 +35,14 @@ export function createExtensionsStorage(db: DB) {
     return row ? mapExtension(row) : null;
   };
 
+  const getByName = async (name: string) => {
+    const normalizedName = name.trim().toLowerCase();
+    if (!normalizedName) return null;
+    const extensions = await db.select().from(installedExtensions).orderBy(desc(installedExtensions.installedAt));
+    const row = extensions.find((extension) => extension.name.trim().toLowerCase() === normalizedName);
+    return row ? mapExtension(row) : null;
+  };
+
   return {
     async list() {
       const rows = await db.select().from(installedExtensions).orderBy(desc(installedExtensions.installedAt));
@@ -41,6 +50,7 @@ export function createExtensionsStorage(db: DB) {
     },
 
     getById,
+    getByName,
 
     async create(input: CreateExtensionInput) {
       const id = newId();
@@ -48,6 +58,7 @@ export function createExtensionsStorage(db: DB) {
       await db.insert(installedExtensions).values({
         id,
         name: input.name,
+        version: input.version == null ? null : String(input.version),
         description: input.description ?? "",
         runtime: input.runtime === "server" ? "server" : "client",
         css: input.runtime === "server" ? null : (input.css ?? null),
@@ -66,6 +77,7 @@ export function createExtensionsStorage(db: DB) {
         updatedAt: now(),
       };
       if (data.name !== undefined) updateFields.name = data.name;
+      if (data.version !== undefined) updateFields.version = data.version;
       if (data.description !== undefined) updateFields.description = data.description;
       if (data.runtime !== undefined) updateFields.runtime = data.runtime === "server" ? "server" : "client";
       if (data.css !== undefined) updateFields.css = data.css;

--- a/packages/server/src/services/storage/extensions.storage.ts
+++ b/packages/server/src/services/storage/extensions.storage.ts
@@ -1,7 +1,7 @@
 // ──────────────────────────────────────────────
 // Storage: Installed Extensions
 // ──────────────────────────────────────────────
-import { desc, eq } from "../../db/file-query.js";
+import { desc, eq, like } from "../../db/file-query.js";
 import type { DB } from "../../db/connection.js";
 import { installedExtensions } from "../../db/schema/index.js";
 import { newId, now } from "../../utils/id-generator.js";
@@ -38,7 +38,11 @@ export function createExtensionsStorage(db: DB) {
   const getByName = async (name: string) => {
     const normalizedName = name.trim().toLowerCase();
     if (!normalizedName) return null;
-    const extensions = await db.select().from(installedExtensions).orderBy(desc(installedExtensions.installedAt));
+    const extensions = await db
+      .select()
+      .from(installedExtensions)
+      .where(like(installedExtensions.name, `%${normalizedName}%`))
+      .orderBy(desc(installedExtensions.installedAt));
     const row = extensions.find((extension) => extension.name.trim().toLowerCase() === normalizedName);
     return row ? mapExtension(row) : null;
   };

--- a/packages/shared/src/schemas/extension.schema.ts
+++ b/packages/shared/src/schemas/extension.schema.ts
@@ -40,6 +40,9 @@ const jsByteLimit = (value: string | null | undefined) =>
 
 const jsByteMessage = `JS must be at most ${MAX_EXTENSION_JS_BYTES} bytes`;
 const extensionRuntimeSchema = z.enum(["client", "server"]);
+const extensionVersionSchema = z
+  .union([z.string().trim().min(1).max(64), z.number().finite().nonnegative().transform(String)])
+  .nullable();
 const MAX_EXTENSION_STORAGE_BYTES = 1_000_000;
 const extensionStorageByteMessage = `Extension storage must be at most ${MAX_EXTENSION_STORAGE_BYTES} bytes`;
 
@@ -60,7 +63,8 @@ export const extensionStorageResponseSchema = z.object({
 });
 
 export const createExtensionSchema = z.object({
-  name: z.string().min(1).max(200),
+  name: z.string().trim().min(1).max(200),
+  version: extensionVersionSchema.optional(),
   description: z.string().max(2000).default(""),
   runtime: extensionRuntimeSchema.optional().default("client"),
   css: z.string().nullable().optional().refine(cssByteLimit, { message: cssByteMessage }),
@@ -80,7 +84,8 @@ export const createExtensionSchema = z.object({
 
 export const updateExtensionSchema = z
   .object({
-    name: z.string().min(1).max(200).optional(),
+    name: z.string().trim().min(1).max(200).optional(),
+    version: extensionVersionSchema.optional(),
     description: z.string().max(2000).optional(),
     runtime: extensionRuntimeSchema.optional(),
     css: z.string().nullable().optional().refine(cssByteLimit, { message: cssByteMessage }),

--- a/packages/shared/src/types/extension.ts
+++ b/packages/shared/src/types/extension.ts
@@ -13,6 +13,8 @@
 export interface InstalledExtension {
   id: string;
   name: string;
+  /** Optional author-declared release version used for update and downgrade notices. */
+  version?: string | null;
   description: string;
   /** Where the extension executes. Existing/legacy extensions default to "client". */
   runtime: "client" | "server";

--- a/scripts/regressions/open-issues.regression.ts
+++ b/scripts/regressions/open-issues.regression.ts
@@ -44,6 +44,11 @@ import {
   resolveTrackerPanelContentScale,
   resolveTrackerPanelDesktopWidth,
 } from "../../packages/client/src/lib/tracker-panel-layout.js";
+import {
+  compareExtensionVersions,
+  findExtensionsByName,
+  normalizeExtensionVersion,
+} from "../../packages/client/src/lib/extension-install.js";
 import { getApiErrorMessage } from "../../packages/client/src/lib/api-client.js";
 import { parseCustomParametersDraft } from "../../packages/client/src/lib/generation-custom-parameters.js";
 import { parseGenerationParameterDraft } from "../../packages/client/src/lib/generation-parameter-draft.js";
@@ -2528,6 +2533,24 @@ assert.equal(
   resolveTrackerPanelContentScale(420, 128),
   0.65,
   "Severely constrained Tracker contents should reflow before their text becomes unreadably small",
+);
+assert.equal(normalizeExtensionVersion(" 1.2.0 "), "1.2.0");
+assert.equal(normalizeExtensionVersion(3), "3");
+assert.equal(normalizeExtensionVersion(""), null);
+assert.equal(compareExtensionVersions("1.9", "2.0"), -1);
+assert.equal(compareExtensionVersions("2.0.0", "2"), 0);
+assert.equal(compareExtensionVersions("3.1", "3.0.9"), 1);
+assert.equal(compareExtensionVersions("nightly", "3.0"), null);
+assert.deepEqual(
+  findExtensionsByName(
+    [
+      { id: "first", name: "Example Extension" },
+      { id: "second", name: "example extension" },
+      { id: "other", name: "Other" },
+    ],
+    " example EXTENSION ",
+  ).map((extension) => extension.id),
+  ["first", "second"],
 );
 
 console.info("Open-issue regressions passed.");


### PR DESCRIPTION
## Why

Tracker Panel visibility was stored globally, so chats could not reliably restore their own open or closed state after switching chats or restarting Marinara Engine.

Issue #3906 reports that reinstalling the same extension creates duplicate entries instead of updating the installed copy. The Add-ons flow should replace matching extensions and warn before a downgrade.

## What changed

- remember Tracker Panel visibility per chat in local persisted UI state
- restore both open and closed Tracker states after reloads
- keep per-chat visibility out of cross-device settings sync
- preserve the legacy open Tracker state during migration
- update extensions with the same case-insensitive name instead of creating duplicates
- preserve the existing extension ID and enabled state during UI-driven updates
- clean up older same-name duplicate records encountered during reimport
- retain optional extension release versions in storage and exported packages
- warn before replacing a newer numeric dotted version with an older one
- document the update behavior and extension version field

Closes #3906

## Validation

- `pnpm check`
- `pnpm regression:issues`
- focused desktop Playwright coverage: 3 passed
  - Tracker open and closed state survives reload
  - repeated extension install reuses the existing record
  - extension downgrade can be cancelled or explicitly confirmed

## Manual test plan

- [ ] Manually verify an open Tracker Panel restores after restarting Marinara Engine.
- [ ] Manually verify a closed Tracker Panel remains closed after restarting Marinara Engine.
- [ ] Manually verify different chats remember different Tracker Panel states.
- [ ] Manually reinstall the same extension and verify only one entry remains.
- [ ] Manually confirm an older extension version shows a downgrade warning before replacement.
- [ ] Manually confirm upgrading or reinstalling the same version replaces the existing extension.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Extensions now support release versions, version badges, and older-version replacement warnings.
  * Reinstalling an extension updates the existing installation instead of creating duplicates.
  * Tracker panel state is preserved separately for each chat.
  * Extension packages and documentation now include version information.

* **Bug Fixes**
  * Improved extension import handling for individual script and stylesheet files.
  * Tracker panel visibility and open/close behavior remain consistent across chats and reloads.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->