### PR TITLE
fix: separate Conversation smart candidates

### DIFF
--- a/packages/server/src/routes/generate.routes.ts
+++ b/packages/server/src/routes/generate.routes.ts
@@ -395,6 +395,7 @@ import {
 } from "../services/generation/generation-text-utils.js";
 import {
   areConversationSchedulesEnabled,
+  formatSmartGroupCandidates,
   parsePromptPresetChoices,
 } from "../services/generation/conversation-context-utils.js";
 import { recoverImplicitSelfieCommand } from "../services/generation/selfie-command-recovery.js";
@@ -4597,22 +4598,21 @@ export async function generateRoutes(app: FastifyInstance) {
             .filter(Boolean)
             .join("\n");
 
-          const candidates = availableGroupCharacters
-            .map((character) => {
+          const candidates = formatSmartGroupCandidates(
+            availableGroupCharacters.map((character) => {
               const presence = conversationCharacterPresenceById.get(character.id);
-              return [
-                `- id: ${character.id}`,
-                `  name: ${presence?.displayName ?? character.name}`,
-                `  talkativeness: ${presence?.talkativeness ?? Math.round(character.talkativeness * 100)}%`,
-                presence ? `  current status: ${presence.status}` : null,
-                presence?.activity ? `  current activity: ${presence.activity}` : null,
-                character.personality ? `  personality: ${character.personality.slice(0, 500)}` : null,
-                character.description ? `  description: ${character.description.slice(0, 500)}` : null,
-              ]
-                .filter(Boolean)
-                .join("\n");
-            })
-            .join("\n\n");
+              return {
+                id: character.id,
+                name: presence?.displayName ?? character.name,
+                talkativeness: presence?.talkativeness ?? Math.round(character.talkativeness * 100),
+                status: presence?.status,
+                activity: presence?.activity,
+                personality: character.personality?.slice(0, 500),
+                description: character.description?.slice(0, 500),
+              };
+            }),
+            chatMode === "conversation",
+          );
 
           const selectorInstructions =
             chatMode === "conversation"

--- a/packages/server/src/services/generation/conversation-context-utils.ts
+++ b/packages/server/src/services/generation/conversation-context-utils.ts
@@ -1,5 +1,37 @@
 import type { ConversationStatusOverride } from "@marinara-engine/shared";
 
+export interface SmartGroupCandidatePromptData {
+  id: string;
+  name: string;
+  talkativeness: number;
+  status?: string;
+  activity?: string;
+  personality?: string;
+  description?: string;
+}
+
+export function formatSmartGroupCandidates(
+  candidates: SmartGroupCandidatePromptData[],
+  useCandidateBlocks: boolean,
+): string {
+  return candidates
+    .map((candidate) => {
+      const fields = [
+        `id: ${candidate.id}`,
+        `name: ${candidate.name}`,
+        `talkativeness: ${candidate.talkativeness}%`,
+        candidate.status !== undefined ? `current status: ${candidate.status}` : null,
+        candidate.activity ? `current activity: ${candidate.activity}` : null,
+        candidate.personality ? `personality: ${candidate.personality}` : null,
+        candidate.description ? `description: ${candidate.description}` : null,
+      ].filter((field): field is string => field !== null);
+
+      if (useCandidateBlocks) return ["<candidate>", ...fields, "</candidate>"].join("\n");
+      return fields.map((field, index) => `${index === 0 ? "- " : "  "}${field}`).join("\n");
+    })
+    .join("\n\n");
+}
+
 export function hasConversationSchedules(value: unknown): value is Record<string, any> {
   return !!value && typeof value === "object" && Object.keys(value as Record<string, unknown>).length > 0;
 }

--- a/scripts/regressions/prompt.regression.ts
+++ b/scripts/regressions/prompt.regression.ts
@@ -460,6 +460,7 @@ import { buildLegacyDefaultAgentConfigUpdate } from "../../packages/server/src/s
 import { buildMemoryRecallBlock } from "../../packages/server/src/services/generation/memory-recall-context.js";
 import { truncateRecalledMemory } from "../../packages/server/src/services/generation/memory-recall-pack.js";
 import { mergeConversationCharacterMemories } from "../../packages/server/src/services/generation/conversation-memory-context.js";
+import { formatSmartGroupCandidates } from "../../packages/server/src/services/generation/conversation-context-utils.js";
 import {
   formatAwarenessContextBlock,
   formatAwarenessConversationBlock,
@@ -660,6 +661,65 @@ const keywordOptions = {
 };
 
 const cases: RegressionCase[] = [
+  {
+    name: "Conversation smart sorting separates each character candidate without changing Roleplay formatting",
+    run() {
+      const candidates = [
+        {
+          id: "dottore",
+          name: "Dottore",
+          talkativeness: 70,
+          status: "online",
+          personality: "Core Traits:\n- precise\n- merciless",
+        },
+        {
+          id: "pantalone",
+          name: "Pantalone",
+          talkativeness: 45,
+          activity: "Reviewing the ledgers",
+        },
+      ];
+
+      assert.equal(
+        formatSmartGroupCandidates(candidates, true),
+        [
+          "<candidate>",
+          "id: dottore",
+          "name: Dottore",
+          "talkativeness: 70%",
+          "current status: online",
+          "personality: Core Traits:",
+          "- precise",
+          "- merciless",
+          "</candidate>",
+          "",
+          "<candidate>",
+          "id: pantalone",
+          "name: Pantalone",
+          "talkativeness: 45%",
+          "current activity: Reviewing the ledgers",
+          "</candidate>",
+        ].join("\n"),
+      );
+      assert.equal(
+        formatSmartGroupCandidates(candidates, false),
+        [
+          "- id: dottore",
+          "  name: Dottore",
+          "  talkativeness: 70%",
+          "  current status: online",
+          "  personality: Core Traits:",
+          "- precise",
+          "- merciless",
+          "",
+          "- id: pantalone",
+          "  name: Pantalone",
+          "  talkativeness: 45%",
+          "  current activity: Reviewing the ledgers",
+        ].join("\n"),
+      );
+    },
+  },
   {
     name: "installed Conversation feature commands do not require per-chat agent attachment",
     run() {


### PR DESCRIPTION
## Linked issue

No linked issue. This is a maintainer-requested follow-up to Conversation Individual-mode smart response ordering.

## Why this change

Conversation smart sorting placed every character inside one `<candidates>` block using YAML-like `- id:` separators. Character personality and description text can contain their own headings, indentation, and bullet lists, making candidate boundaries ambiguous to the selector model.

## What changed

- Wrap each Conversation smart-sort character in its own `<candidate>...</candidate>` block.
- Preserve character card content verbatim inside each block.
- Keep the existing Roleplay smart-sort candidate format unchanged.
- Add a prompt regression covering card-owned `Core Traits` bullets and the Roleplay negative control.

## Validation

- [ ] `pnpm check` passes locally
- [ ] `pnpm regression:prompt` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed `CONTRIBUTING.md`

### Manual verification notes

- Automated prompt regression verifies that each Conversation candidate receives a distinct XML block even when personality content contains its own bullet list.
- Automated negative control verifies that Roleplay retains the legacy list format.
- No live provider request was performed.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Version/release files updated (only if this PR includes a version bump)

## UI evidence

Not applicable; this changes an internal selector prompt.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Improved consistency in smart group responder selection by standardizing how candidate details are presented.
  * Candidate information such as names, availability, activity, personality, descriptions, and talkativeness is now formatted more reliably.
  * Added safeguards to verify formatting across supported responder selection modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->