### PR TITLE
Fix Individual Conversation group generation

### DIFF
--- a/packages/server/src/routes/generate.routes.ts
+++ b/packages/server/src/routes/generate.routes.ts
@@ -1477,6 +1477,16 @@ export async function generateRoutes(app: FastifyInstance) {
         let conversationLorebookBlockValue = "";
         let conversationMemoriesBlockValue = "";
         let conversationReplyRulesBlockValue = "";
+        const buildConversationRelocationValues = (
+          lorebook: string,
+        ): Record<ConversationRelocationMacroKey, string> => ({
+          context: conversationContextBlockValue,
+          commands: !input.impersonate ? (conversationCommandsReminder ?? "") : "",
+          reactRules: "",
+          replyRules: conversationReplyRulesBlockValue,
+          memories: conversationMemoriesBlockValue,
+          lorebook,
+        });
         const identityFallbackPromptTemplateSources: string[] = [];
         const conversationCommandsEnabled = chatMode === "conversation" && chatMeta.characterCommands !== false;
         let temperature: number | undefined = 1;
@@ -3009,14 +3019,7 @@ export async function generateRoutes(app: FastifyInstance) {
         if (chatMode === "conversation") {
           decodeDeferredRelocationConditionals(
             finalMessages,
-            {
-              context: conversationContextBlockValue,
-              commands: !input.impersonate ? (conversationCommandsReminder ?? "") : "",
-              reactRules: "",
-              replyRules: conversationReplyRulesBlockValue,
-              memories: conversationMemoriesBlockValue,
-              lorebook: conversationLorebookBlockValue,
-            },
+            buildConversationRelocationValues(conversationLorebookBlockValue),
             promptMacroContext,
             deferConversationLorebookScanToResponder ? { preserveKeys: new Set(["lorebook"]) } : undefined,
           );
@@ -4884,14 +4887,7 @@ export async function generateRoutes(app: FastifyInstance) {
 
           decodeDeferredRelocationConditionals(
             prepared,
-            {
-              context: conversationContextBlockValue,
-              commands: !input.impersonate ? (conversationCommandsReminder ?? "") : "",
-              reactRules: "",
-              replyRules: conversationReplyRulesBlockValue,
-              memories: conversationMemoriesBlockValue,
-              lorebook: loreBlock,
-            },
+            buildConversationRelocationValues(loreBlock),
             promptMacroContext,
           );
           return prepared;

--- a/packages/server/src/routes/generate.routes.ts
+++ b/packages/server/src/routes/generate.routes.ts
@@ -484,6 +484,7 @@ import {
 } from "./generate/agent-write-approval.js";
 
 const PROFESSOR_MARI_INTERNAL_CHAT_MARKER = "professor-mari";
+const INDIVIDUAL_CONVERSATION_LOREBOOK_TOKEN = "__MARINARA_INDIVIDUAL_CONVERSATION_LOREBOOK__";
 type ConversationContextMacroKey =
   | "context"
   | "commands"
@@ -586,6 +587,7 @@ function decodeDeferredRelocationConditionals(
   messages: GenerationPromptMessage[],
   relocationValues: Record<ConversationRelocationMacroKey, string>,
   baseContext: MacroContext,
+  options: { preserveKeys?: ReadonlySet<ConversationRelocationMacroKey> } = {},
 ): void {
   if (!messages.some((message) => hasDeferredRelocationConditionals(message.content))) return;
 
@@ -607,12 +609,17 @@ function decodeDeferredRelocationConditionals(
     if (!hasDeferredRelocationConditionals(message.content)) continue;
     messages[index] = {
       ...message,
-      content: message.content.replace(DEFERRED_RELOCATION_CONDITIONAL_TOKEN_RE, (_match, encoded: string) => {
+      content: message.content.replace(DEFERRED_RELOCATION_CONDITIONAL_TOKEN_RE, (match, encoded: string) => {
         const payload = parseDeferredConditionalPayload(encoded);
         if (!payload) {
           logger.error("[generate/conversation] Malformed deferred relocation conditional token; dropping block");
           return "";
         }
+        const preserved = collectDeferredRelocationConditionOperands(match).some((operand) => {
+          const key = relocationKeyForOperand(operand);
+          return key ? options.preserveKeys?.has(key) === true : false;
+        });
+        if (preserved) return match;
         const selected = selectConditionalPayloadBranch(payload, evalContext, { trimResult: false });
         return resolveMacros(selected, evalContext, { trimResult: false });
       }),
@@ -1587,6 +1594,12 @@ export async function generateRoutes(app: FastifyInstance) {
             ? input.forCharacterId
             : null;
         const promptCharacterIds = resolvePromptCharacterIdsForTarget(characterIds, promptTargetCharacterId);
+        const deferConversationLorebookScanToResponder =
+          chatMode === "conversation" &&
+          characterIds.length > 1 &&
+          promptGroupChatMode === "individual" &&
+          !promptTargetCharacterId &&
+          input.impersonate !== true;
         const characterAdvancedPromptIds = resolveCharacterAdvancedPromptIds(promptCharacterIds, chatMode, chatMeta);
         const deferCharacterMacros =
           characterIds.length > 1 &&
@@ -1722,6 +1735,67 @@ export async function generateRoutes(app: FastifyInstance) {
             input,
             resolvePromptMacrosWithoutVariableWrites,
           );
+        const deferredLorebookEntryStateBaseline = deferConversationLorebookScanToResponder
+          ? ((chatMeta.entryStateOverrides as Record<
+              string,
+              { ephemeral?: number | null; enabled?: boolean }
+            >) ?? undefined)
+          : undefined;
+        const deferredLorebookTimingStateBaseline = deferConversationLorebookScanToResponder
+          ? ((chatMeta.entryTimingStates as Record<string, LorebookEntryTimingState>) ?? undefined)
+          : undefined;
+        const scanConversationLorebooks = async (
+          targetCharacterIds: string[],
+          options: { previewOnly?: boolean; recordSnapshot?: boolean } = {},
+        ) => {
+          sendProgress("lorebooks");
+          const lorebookResult = await processLorebooks(app.db, toLorebookScanMessages(), null, {
+            chatId: input.chatId,
+            characterIds: targetCharacterIds,
+            personaId,
+            activeLorebookIds: chatActiveLorebookIds,
+            excludedLorebookIds: lorebookScopeExclusions.excludedLorebookIds,
+            excludedSourceAgentIds: lorebookScopeExclusions.excludedSourceAgentIds,
+            tokenBudget: resolveLorebookTokenBudget(chatMeta),
+            chatEmbedding: chatContextEmbedding,
+            semanticEmbeddingsByLorebookId: lorebookSemanticEmbeddingsById,
+            semanticSimilarityBaseline: lorebookSemanticSimilarityBaseline,
+            entryStateOverrides: options.previewOnly
+              ? deferredLorebookEntryStateBaseline
+              : ((chatMeta.entryStateOverrides as Record<
+                  string,
+                  { ephemeral?: number | null; enabled?: boolean }
+                >) ?? undefined),
+            entryTimingStates: options.previewOnly
+              ? deferredLorebookTimingStateBaseline
+              : ((chatMeta.entryTimingStates as Record<string, LorebookEntryTimingState>) ?? undefined),
+            previewOnly: options.previewOnly,
+            generationTriggers: lorebookGenerationTriggers,
+            resolveContent: resolvePromptMacrosForLorebook,
+          });
+          if (options.recordSnapshot !== false) lorebookScanSnapshot = toLorebookScanSnapshot(lorebookResult);
+          rememberKnowledgeRouterActivatedLorebookIds(
+            knowledgeRouterActivatedLorebookEntryIds,
+            knowledgeRouterExcludedLorebookEntryIds,
+            lorebookResult,
+          );
+          knowledgeRouterActivationPassCompleted = true;
+
+          if (!options.previewOnly) {
+            if (lorebookResult.updatedEntryStateOverrides)
+              chatMeta.entryStateOverrides = lorebookResult.updatedEntryStateOverrides;
+            if (lorebookResult.updatedEntryTimingStates)
+              chatMeta.entryTimingStates = lorebookResult.updatedEntryTimingStates;
+            await persistLorebookRuntimeState({
+              chats,
+              chatId: input.chatId,
+              fallbackMeta: chatMeta,
+              entryStateOverrides: lorebookResult.updatedEntryStateOverrides,
+              entryTimingStates: lorebookResult.updatedEntryTimingStates,
+            });
+          }
+          return lorebookResult;
+        };
         const injectCharacterAdvancedPrompts = async () => {
           if (characterAdvancedPromptsInjected) return;
           const entries = await collectCharacterAdvancedPromptEntries(
@@ -2325,64 +2399,36 @@ export async function generateRoutes(app: FastifyInstance) {
 
           // ── Lorebook injection for conversation mode ──
           {
-            sendProgress("lorebooks");
-            const lorebookResult = await processLorebooks(app.db, toLorebookScanMessages(), null, {
-              chatId: input.chatId,
-              characterIds: promptCharacterIds,
-              personaId,
-              activeLorebookIds: chatActiveLorebookIds,
-              excludedLorebookIds: lorebookScopeExclusions.excludedLorebookIds,
-              excludedSourceAgentIds: lorebookScopeExclusions.excludedSourceAgentIds,
-              tokenBudget: resolveLorebookTokenBudget(chatMeta),
-              chatEmbedding: chatContextEmbedding,
-              semanticEmbeddingsByLorebookId: lorebookSemanticEmbeddingsById,
-              semanticSimilarityBaseline: lorebookSemanticSimilarityBaseline,
-              entryStateOverrides:
-                (chatMeta.entryStateOverrides as Record<string, { ephemeral?: number | null; enabled?: boolean }>) ??
-                undefined,
-              entryTimingStates: (chatMeta.entryTimingStates as Record<string, LorebookEntryTimingState>) ?? undefined,
-              generationTriggers: lorebookGenerationTriggers,
-              resolveContent: resolvePromptMacrosForLorebook,
-            });
-            lorebookScanSnapshot = toLorebookScanSnapshot(lorebookResult);
-            rememberKnowledgeRouterActivatedLorebookIds(
-              knowledgeRouterActivatedLorebookEntryIds,
-              knowledgeRouterExcludedLorebookEntryIds,
-              lorebookResult,
-            );
-            knowledgeRouterActivationPassCompleted = true;
-
-            if (lorebookResult.updatedEntryStateOverrides)
-              chatMeta.entryStateOverrides = lorebookResult.updatedEntryStateOverrides;
-            if (lorebookResult.updatedEntryTimingStates)
-              chatMeta.entryTimingStates = lorebookResult.updatedEntryTimingStates;
-            await persistLorebookRuntimeState({
-              chats,
-              chatId: input.chatId,
-              fallbackMeta: chatMeta,
-              entryStateOverrides: lorebookResult.updatedEntryStateOverrides,
-              entryTimingStates: lorebookResult.updatedEntryTimingStates,
-            });
-            const loreContent = [lorebookResult.worldInfoBefore, lorebookResult.worldInfoAfter]
-              .filter(Boolean)
-              .join("\n");
-            if (loreContent) {
-              const loreBlock = wrapContent(loreContent, "Lore", wrapFormat);
-              conversationLorebookBlockValue = loreBlock;
+            if (deferConversationLorebookScanToResponder) {
+              // Smart and Sequential Individual generations do not know the responder yet.
+              // Preserve the requested prompt location and scan with only the target
+              // character once each separate provider generation begins.
               if (conversationContextMacroSlots.lorebook) {
-                replaceConversationContextMacro(finalMessages, "lorebook", loreBlock);
-              } else {
-                // Inject before the awareness block (or before first user/assistant message)
-                const firstUserIdx = finalMessages.findIndex((m) => m.role === "user" || m.role === "assistant");
-                const insertAt = firstUserIdx >= 0 ? firstUserIdx : finalMessages.length;
-                finalMessages.splice(insertAt, 0, { role: "system" as const, content: loreBlock });
+                replaceConversationContextMacro(finalMessages, "lorebook", INDIVIDUAL_CONVERSATION_LOREBOOK_TOKEN);
               }
-            } else if (conversationContextMacroSlots.lorebook) {
-              replaceConversationContextMacro(finalMessages, "lorebook", "");
-            }
-            // Inject depth-based lorebook entries into the message array
-            if (lorebookResult.depthEntries.length > 0) {
-              finalMessages = injectAtDepth(finalMessages, lorebookResult.depthEntries);
+            } else {
+              const lorebookResult = await scanConversationLorebooks(promptCharacterIds);
+              const loreContent = [lorebookResult.worldInfoBefore, lorebookResult.worldInfoAfter]
+                .filter(Boolean)
+                .join("\n");
+              if (loreContent) {
+                const loreBlock = wrapContent(loreContent, "Lore", wrapFormat);
+                conversationLorebookBlockValue = loreBlock;
+                if (conversationContextMacroSlots.lorebook) {
+                  replaceConversationContextMacro(finalMessages, "lorebook", loreBlock);
+                } else {
+                  // Inject before the awareness block (or before first user/assistant message)
+                  const firstUserIdx = finalMessages.findIndex((m) => m.role === "user" || m.role === "assistant");
+                  const insertAt = firstUserIdx >= 0 ? firstUserIdx : finalMessages.length;
+                  finalMessages.splice(insertAt, 0, { role: "system" as const, content: loreBlock });
+                }
+              } else if (conversationContextMacroSlots.lorebook) {
+                replaceConversationContextMacro(finalMessages, "lorebook", "");
+              }
+              // Inject depth-based lorebook entries into the message array
+              if (lorebookResult.depthEntries.length > 0) {
+                finalMessages = injectAtDepth(finalMessages, lorebookResult.depthEntries);
+              }
             }
           }
         }
@@ -2972,6 +3018,7 @@ export async function generateRoutes(app: FastifyInstance) {
               lorebook: conversationLorebookBlockValue,
             },
             promptMacroContext,
+            deferConversationLorebookScanToResponder ? { preserveKeys: new Set(["lorebook"]) } : undefined,
           );
         }
 
@@ -4619,7 +4666,8 @@ export async function generateRoutes(app: FastifyInstance) {
               ? [
                   `You are a hidden response orchestrator for a Conversation-mode group chat.`,
                   `Choose one or more available characters to respond next, based on the latest message, recent conversation, relevance, personality, current schedule status, activity, talkativeness, and who has spoken recently.`,
-                  `Usually choose exactly one character. Choose multiple only when multiple characters have a strong immediate reason to answer.`,
+                  `Select every character who has a natural immediate reason to respond. One or several responders are equally valid.`,
+                  `In a larger group, do not default to one responder merely because the group is large; include multiple characters when several are directly involved or independently motivated, without forcing uninvolved characters to speak.`,
                   `Prefer an online character over an idle or do-not-disturb character unless the conversation clearly calls for someone else.`,
                   `Do not always choose the first character. Avoid making the same character speak twice in a row unless the context clearly calls for it.`,
                 ]
@@ -4797,6 +4845,58 @@ export async function generateRoutes(app: FastifyInstance) {
                     : []
           : [characterIds[0] ?? null];
 
+        if (deferConversationLorebookScanToResponder && respondingCharIds.length > 0) {
+          await scanConversationLorebooks(
+            respondingCharIds.filter((characterId): characterId is string => typeof characterId === "string"),
+            { recordSnapshot: false },
+          );
+        }
+
+        const prepareConversationLorebookForResponder = async (
+          targetCharId: string | null,
+          messages: GenerationPromptMessage[],
+        ): Promise<GenerationPromptMessage[]> => {
+          if (!deferConversationLorebookScanToResponder || !targetCharId) return messages;
+
+          const lorebookResult = await scanConversationLorebooks([targetCharId], { previewOnly: true });
+
+          const loreContent = [lorebookResult.worldInfoBefore, lorebookResult.worldInfoAfter]
+            .filter(Boolean)
+            .join("\n");
+          const loreBlock = loreContent ? wrapContent(loreContent, "Lore", wrapFormat) : "";
+          let prepared = messages.map((message) => ({
+            ...message,
+            content: message.content.split(INDIVIDUAL_CONVERSATION_LOREBOOK_TOKEN).join(loreBlock),
+          }));
+
+          if (loreBlock && !conversationContextMacroSlots.lorebook) {
+            const firstUserIdx = prepared.findIndex(
+              (message) => message.role === "user" || message.role === "assistant",
+            );
+            prepared.splice(firstUserIdx >= 0 ? firstUserIdx : prepared.length, 0, {
+              role: "system" as const,
+              content: loreBlock,
+            });
+          }
+          if (lorebookResult.depthEntries.length > 0) {
+            prepared = injectAtDepth(prepared, lorebookResult.depthEntries);
+          }
+
+          decodeDeferredRelocationConditionals(
+            prepared,
+            {
+              context: conversationContextBlockValue,
+              commands: !input.impersonate ? (conversationCommandsReminder ?? "") : "",
+              reactRules: "",
+              replyRules: conversationReplyRulesBlockValue,
+              memories: conversationMemoriesBlockValue,
+              lorebook: loreBlock,
+            },
+            promptMacroContext,
+          );
+          return prepared;
+        };
+
         /** Generate a single response for a given character and save it. */
         const generateForCharacter = async (
           targetCharId: string | null,
@@ -4820,7 +4920,7 @@ export async function generateRoutes(app: FastifyInstance) {
           // into another responder's prompt; impersonation gets the human seat,
           // and a merged generation that may voice several characters at once
           // stays on the hand-free spectator view.
-          let gameAwareMessagesForGen = messagesForGen;
+          let gameAwareMessagesForGen = await prepareConversationLorebookForResponder(targetCharId, messagesForGen);
           if (turnGameContextForSeat) {
             const viewerSeatId = input.impersonate
               ? chat.personaId || "human"
@@ -5767,6 +5867,13 @@ export async function generateRoutes(app: FastifyInstance) {
                 }
                 fullResponse = fullResponse.slice(paragraphBreak).trimStart();
                 stripTargetPrefix();
+              }
+              if (chatMode === "conversation" && otherNames.length > 0) {
+                const nextSpeakerPrefix = new RegExp(`\\n\\s*(?:${otherNames.join("|")})\\s*:\\s*`, "i");
+                const nextSpeakerMatch = fullResponse.match(nextSpeakerPrefix);
+                if (nextSpeakerMatch?.index != null) {
+                  fullResponse = fullResponse.slice(0, nextSpeakerMatch.index).trimEnd();
+                }
               }
               if (fullResponse !== beforeNamePrefixStrip) {
                 contentReplaced = true;

--- a/scripts/regressions/open-issues.regression.ts
+++ b/scripts/regressions/open-issues.regression.ts
@@ -983,6 +983,18 @@ const conversationGenerationSource = readFileSync(
   new URL("../../packages/server/src/routes/generate.routes.ts", import.meta.url),
   "utf8",
 );
+const foregroundAutonomousSource = readFileSync(
+  new URL("../../packages/client/src/hooks/use-autonomous-messaging.ts", import.meta.url),
+  "utf8",
+);
+const backgroundAutonomousSource = readFileSync(
+  new URL("../../packages/client/src/hooks/use-background-autonomous.ts", import.meta.url),
+  "utf8",
+);
+const serverAutonomousSchedulerSource = readFileSync(
+  new URL("../../packages/server/src/services/conversation/server-autonomous-scheduler.service.ts", import.meta.url),
+  "utf8",
+);
 const clientGenerationSource = readFileSync(
   new URL("../../packages/client/src/hooks/use-generate.ts", import.meta.url),
   "utf8",
@@ -1062,6 +1074,47 @@ assert.match(
   conversationGenerationSource,
   /smartResponseQueue\?\.length\s*\? \[\.\.\.smartResponseQueue\]/u,
   "Smart ordering should generate every character selected by the responder queue",
+);
+assert.match(
+  conversationGenerationSource,
+  /In a larger group, do not default to one responder merely because the group is large/u,
+  "Conversation Smart ordering should not bias larger groups toward one responder",
+);
+assert.match(
+  conversationGenerationSource,
+  /scanConversationLorebooks[\s\S]{0,1000}characterIds: targetCharacterIds/u,
+  "Individual Conversation lorebook scans should use only the current responder's character tags",
+);
+assert.match(
+  conversationGenerationSource,
+  /prepareConversationLorebookForResponder[\s\S]{0,1000}scanConversationLorebooks\(\[targetCharId\], \{ previewOnly: true \}\)/u,
+  "Individual Conversation lorebook scans should receive only the current responder ID",
+);
+assert.match(
+  conversationGenerationSource,
+  /let gameAwareMessagesForGen = await prepareConversationLorebookForResponder\(targetCharId, messagesForGen\)/u,
+  "Individual Conversation lorebook injection should happen separately for each provider generation",
+);
+assert.match(
+  conversationGenerationSource,
+  /chatMode === "conversation" && otherNames\.length > 0[\s\S]{0,500}fullResponse = fullResponse\.slice\(0, nextSpeakerMatch\.index\)/u,
+  "Individual Conversation generations should discard an extra character turn returned in the same completion",
+);
+for (const [source, lane] of [
+  [foregroundAutonomousSource, "foreground"],
+  [backgroundAutonomousSource, "background"],
+  [serverAutonomousSchedulerSource, "server scheduler"],
+] as const) {
+  assert.match(
+    source,
+    /forCharacterId: characterId/u,
+    `Conversation ${lane} autonomous generation must target one character`,
+  );
+}
+assert.match(
+  foregroundAutonomousSource,
+  /triggerAutonomousGeneration\(exchange\.characterIds\[0\]!\)/u,
+  "Character Exchanges should start a separate targeted Individual generation",
 );
 assert.match(
   conversationGenerationSource,


### PR DESCRIPTION
## Why

Individual Conversation group chats could behave inconsistently across larger Smart groups, autonomous replies, Character Exchanges, and character-tagged lorebooks:

- Smart selection was biased toward exactly one responder.
- A model could append another character's dialogue to a targeted Individual completion.
- Lorebook matching happened before Smart or Sequential responders were known, so every group member's character tags could activate entries for each responder.

## What changed

- Let Smart selection choose every naturally involved participant without biasing large groups toward one responder.
- Keep autonomous messages and Character Exchanges as separate, single-character generations, and discard an extra named character turn if a model returns one in the same completion.
- Defer lorebook injection for untargeted Individual generations until each responder is known.
- Scan character-tagged lorebooks with only the current responder while advancing shared lorebook runtime state once for the overall chat turn.
- Preserve existing lorebook relocation macros, depth injection, and conditional placement.
- Leave Grouped Conversation behavior unchanged.
- Add regression guards for Smart selection, targeted autonomous lanes, Character Exchanges, responder-scoped lorebooks, and extra-speaker pruning.

## Validation

- `pnpm check`
- `pnpm regression:prompt`
- `pnpm --filter @marinara-engine/server exec tsx ../../scripts/regressions/open-issues.regression.ts`
- `git diff --check`

## Manual verification

- [ ] Manually verify Smart Response Order can select several appropriate responders in a six-character Individual Conversation.
- [ ] Manually verify an autonomous message saves only the selected character's reply and a Character Exchange arrives as a separate generation.
- [ ] Manually verify character-tagged lorebook entries only appear for the current Individual responder.
- [ ] Manually verify Grouped Conversation prompts and responses remain unchanged.

## Risk boundary

This changes prompt assembly and responder routing in `/api/generate`. Automated prompt and source regressions passed; no live external model generation was performed.

No linked issue was supplied; please add one before merge if project policy requires it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved Conversation-mode group responses with responder-specific lorebook context.
  * Smart group ordering now supports multiple responders in larger conversations.
  * Individual responses better preserve turn boundaries by removing unintended extra speaker turns.
  * Autonomous messaging more reliably targets a single character and starts separate individual exchanges.

* **Tests**
  * Expanded regression coverage for group responder selection, lorebook scoping, turn handling, and autonomous messaging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->