### PR TITLE
Background Illustrator generation without locking chat input

### DIFF
--- a/packages/client/src/components/chat/ChatInput.tsx
+++ b/packages/client/src/components/chat/ChatInput.tsx
@@ -51,6 +51,7 @@ import { applyTextareaQuoteFormat } from "../../lib/textarea-quotes";
 import { translateDraftText } from "../../lib/draft-translation";
 import { prepareImageAttachment } from "../../lib/chat-attachment-images";
 import { CARD_ASSET_INSERT_EVENT, type CardAssetInsertDetail } from "../../lib/card-asset-links";
+import { isGenerationSendBlocked } from "../../lib/generation-stream-policy";
 import { requestChatScrollToBottom } from "../../lib/chat-scroll-events";
 import { EmojiPicker } from "../ui/EmojiPicker";
 import { SpeechToTextButton } from "../ui/SpeechToTextButton";
@@ -228,9 +229,6 @@ export const ChatInput = memo(function ChatInput({
   const emojiButtonRef = useRef<HTMLButtonElement>(null);
   const inputBarRef = useRef<HTMLDivElement>(null);
   const focusAfterMobileRestoreRef = useRef(false);
-  const textareaFocusedRef = useRef(false);
-  const restoreFocusAfterBusyRef = useRef(false);
-  const wasInputBusyRef = useRef(false);
   const draftTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const currentInputFrameRef = useRef<number | null>(null);
   const pendingCurrentInputRef = useRef("");
@@ -247,8 +245,16 @@ export const ChatInput = memo(function ChatInput({
   const professorMariSuggestionsEnabled = useUIStore((s) => s.professorMariSuggestionsEnabled);
   const streamingChatId = useChatStore((s) => s.streamingChatId);
   const isStreamingGlobal = useChatStore((s) => s.isStreaming);
-  const isStreaming = isStreamingGlobal && streamingChatId === activeChatId;
-  const isInputBusy = isStreaming || interactionsLocked;
+  const isBackgroundIllustration = useChatStore((s) =>
+    activeChatId ? s.backgroundIllustrationChatIds.has(activeChatId) : false,
+  );
+  const hasActiveStream = isStreamingGlobal && streamingChatId === activeChatId;
+  const isStreaming = hasActiveStream && !isBackgroundIllustration;
+  const isInputBusy = isGenerationSendBlocked({
+    streamActive: hasActiveStream,
+    agentsProcessing: interactionsLocked,
+    backgroundIllustration: isBackgroundIllustration,
+  });
   const responseQueue = useChatStore((s) =>
     activeChatId ? (s.responseQueues.get(activeChatId) ?? EMPTY_RESPONSE_QUEUE) : EMPTY_RESPONSE_QUEUE,
   );
@@ -1589,32 +1595,6 @@ export const ChatInput = memo(function ChatInput({
   }, []);
 
   useEffect(() => {
-    const wasInputBusy = wasInputBusyRef.current;
-    wasInputBusyRef.current = isInputBusy;
-
-    if (isInputBusy) {
-      if (textareaFocusedRef.current) restoreFocusAfterBusyRef.current = true;
-      return;
-    }
-
-    if (!wasInputBusy || !restoreFocusAfterBusyRef.current) return;
-    restoreFocusAfterBusyRef.current = false;
-    if (!activeChatId || shouldShowMobileCollapsedComposer) return;
-
-    const focus = () => {
-      const textarea = textareaRef.current;
-      if (!textarea || textarea.disabled) return;
-      const activeElement = document.activeElement;
-      if (activeElement && activeElement !== document.body && activeElement !== textarea) return;
-      textarea.focus({ preventScroll: true });
-      textareaFocusedRef.current = true;
-      ensureInputVisible();
-    };
-
-    requestAnimationFrame(focus);
-  }, [activeChatId, ensureInputVisible, isInputBusy, shouldShowMobileCollapsedComposer]);
-
-  useEffect(() => {
     if (mobileHistoryCollapsed || !focusAfterMobileRestoreRef.current) return;
     focusAfterMobileRestoreRef.current = false;
     const focus = () => {
@@ -1839,14 +1819,10 @@ export const ChatInput = memo(function ChatInput({
           onKeyDown={handleKeyDown}
           onPaste={handlePaste}
           onFocus={() => {
-            textareaFocusedRef.current = true;
             ensureInputVisible();
           }}
-          onBlur={() => {
-            if (!isInputBusy) textareaFocusedRef.current = false;
-          }}
           placeholder={inputPlaceholder}
-          disabled={!activeChatId || isInputBusy}
+          disabled={!activeChatId}
           rows={1}
           spellCheck
           autoCorrect="on"

--- a/packages/client/src/components/chat/ChatInput.tsx
+++ b/packages/client/src/components/chat/ChatInput.tsx
@@ -627,11 +627,11 @@ export const ChatInput = memo(function ChatInput({
   const isReadingAttachments = pendingAttachmentReads > 0;
   const hasPendingAttachments = isReadingAttachments || attachments.length > 0;
   const requiresManualGuideTarget = groupResponseOrder === "manual" && activeCharacterNames.length > 1;
-  const inputBusyReason = isStreaming
-    ? "Wait for the current stream to finish."
-    : interactionsLocked
-      ? "Wait for agents to finish."
-      : null;
+  const inputBusyReason = isInputBusy
+    ? isStreaming
+      ? "Wait for the current stream to finish."
+      : "Wait for agents to finish."
+    : null;
 
   const removeAttachment = (idx: number) => {
     updateAttachments((prev) => prev.filter((_, i) => i !== idx));

--- a/packages/client/src/components/chat/ConversationInput.tsx
+++ b/packages/client/src/components/chat/ConversationInput.tsx
@@ -42,6 +42,7 @@ import { applyTextareaQuoteFormat } from "../../lib/textarea-quotes";
 import { translateDraftText } from "../../lib/draft-translation";
 import { prepareImageAttachment } from "../../lib/chat-attachment-images";
 import { CARD_ASSET_INSERT_EVENT, type CardAssetInsertDetail } from "../../lib/card-asset-links";
+import { isGenerationSendBlocked } from "../../lib/generation-stream-policy";
 import { requestChatScrollToBottom } from "../../lib/chat-scroll-events";
 import { searchStandardEmojiShortcodes, type StandardEmojiShortcode } from "../../lib/emoji-shortcodes";
 import { QuickConnectionSwitcher } from "./QuickConnectionSwitcher";
@@ -386,7 +387,19 @@ export function ConversationInput({
   const chatName = activeChat?.name;
   const streamingChatId = useChatStore((s) => s.streamingChatId);
   const isStreamingGlobal = useChatStore((s) => s.isStreaming);
-  const isStreaming = isStreamingGlobal && streamingChatId === activeChatId;
+  const isBackgroundIllustration = useChatStore((s) =>
+    activeChatId ? s.backgroundIllustrationChatIds.has(activeChatId) : false,
+  );
+  const agentsProcessing = useAgentStore((s) =>
+    activeChatId ? s.processingChatIds.includes(activeChatId) : s.isProcessing,
+  );
+  const hasActiveStream = isStreamingGlobal && streamingChatId === activeChatId;
+  const isStreaming = hasActiveStream && !isBackgroundIllustration;
+  const isSendBlocked = isGenerationSendBlocked({
+    streamActive: hasActiveStream,
+    agentsProcessing,
+    backgroundIllustration: isBackgroundIllustration,
+  });
   const delayedCharacterInfo = useChatStore((s) => s.delayedCharacterInfo);
   // Show stop button only during actual generation, not during busy delay
   const isActuallyGenerating = isStreaming && !delayedCharacterInfo;
@@ -415,7 +428,7 @@ export function ConversationInput({
     !hasInput &&
     attachments.length === 0 &&
     !isReadingAttachments &&
-    !isStreaming &&
+    !isSendBlocked &&
     !mobilePickerOpen;
   const chatMetadata = useMemo(() => parseChatMetadata(activeChat?.metadata), [activeChat?.metadata]);
   const inactiveCharacterIds = useMemo(
@@ -479,10 +492,16 @@ export function ConversationInput({
     return null;
   }, [messagesData]);
   const lastMessageRole = lastMessage?.role ?? null;
-  const canRetry = !isStreaming && lastMessageRole === "user";
+  const canRetry = !isSendBlocked && lastMessageRole === "user";
   const canSubmit = hasInput || attachments.length > 0 || canRetry;
   const showRetrySendState = canRetry && !hasInput && attachments.length === 0;
-  const sendButtonTitle = isActuallyGenerating ? "Stop generating" : showRetrySendState ? "Retry generation" : "Send";
+  const sendButtonTitle = isActuallyGenerating
+    ? "Stop generating"
+    : isSendBlocked
+      ? "Wait for agents to finish"
+      : showRetrySendState
+        ? "Retry generation"
+        : "Send";
 
   const syncInputState = useCallback(
     (value: string) => {
@@ -864,7 +883,7 @@ export function ConversationInput({
   );
 
   const handleSend = useCallback(async () => {
-    if (!activeChatId) return;
+    if (!activeChatId || isSendBlocked) return;
     if (isReadingAttachments) {
       toast.info("Still reading attached files. Send will be ready in a moment.");
       return;
@@ -891,59 +910,6 @@ export function ConversationInput({
       syncInputState("");
       replaceAttachments([]);
       onPeekPrompt?.();
-      return;
-    }
-
-    // If already generating for this chat, just save the message without
-    // triggering another generation — the in-progress generation will see
-    // it (server re-reads messages after any busy delay).
-    if (isStreaming) {
-      const activeChatData = useChatStore.getState().activeChat;
-      const cachedCharacters = qc.getQueryData<Array<{ id: string; data: unknown }>>(characterKeys.list());
-      const cachedPersonas = qc.getQueryData<Array<Record<string, unknown>>>(characterKeys.personas);
-      const resolveInputMacros = createInputMacroResolverForChat(activeChatData, cachedCharacters, cachedPersonas, raw);
-      const streamMeta = parseChatMetadata(activeChatData?.metadata);
-      // First pass: resolve macros against raw input, so {{input}} uses the pre-translation text.
-      let message = applyToUserInput(raw, {
-        resolveMacros: resolveInputMacros,
-        scopedMode: streamMeta.scopedRegexMode,
-      });
-      // Input translation for streaming path too
-      if (streamMeta.translateInput && message.trim()) {
-        try {
-          const { translateText } = await import("../../lib/translate-text");
-          const translated = await translateText(message);
-          if (translated.trim()) message = translated;
-        } catch {
-          toast.error("Failed to translate message — sending original");
-        }
-      }
-      // Final pass: resolve macros introduced by translation while {{input}} still points to raw.
-      message = resolveInputMacros(message);
-      if (textareaRef.current) {
-        textareaRef.current.value = "";
-        textareaRef.current.style.height = "auto";
-      }
-      clearInputDraft(activeChatId);
-      syncInputState("");
-      const currentAttachments = attachments.map((a) => ({
-        type: a.type,
-        data: a.data,
-        filename: a.name,
-        name: a.name,
-      }));
-      replaceAttachments([]);
-      const created = await createMessage.mutateAsync({
-        role: "user",
-        content: message,
-        characterId: null,
-      });
-      if (currentAttachments.length) {
-        await updateMessageExtra.mutateAsync({
-          messageId: created.id,
-          extra: { attachments: currentAttachments },
-        });
-      }
       return;
     }
 
@@ -1097,13 +1063,12 @@ export function ConversationInput({
     attachments,
     canRetry,
     isReadingAttachments,
-    isStreaming,
+    isSendBlocked,
     generate,
     applyToUserInput,
     extractMentions,
     clearInputDraft,
     createMessage,
-    updateMessageExtra,
     activeCharacterNames,
     completions,
     _mentionQuery,
@@ -1231,7 +1196,7 @@ export function ConversationInput({
   );
 
   const handlePostOnlyButton = useCallback(async () => {
-    if (!activeChatId || isStreaming) return;
+    if (!activeChatId || isSendBlocked) return;
     const submittingChatId = activeChatId;
     if (isReadingAttachments) {
       toast.info("Still reading attached files. Post will be ready in a moment.");
@@ -1350,7 +1315,7 @@ export function ConversationInput({
     }
   }, [
     activeChatId,
-    isStreaming,
+    isSendBlocked,
     isReadingAttachments,
     attachments,
     completions,
@@ -1372,7 +1337,7 @@ export function ConversationInput({
   ]);
 
   const handleGuidedGenerationButton = useCallback(async () => {
-    if (!activeChatId || isStreaming) return;
+    if (!activeChatId || isSendBlocked) return;
     if (hasPendingAttachments) {
       toast.info("Clear or send attachments before using guided generation.");
       return;
@@ -1380,20 +1345,20 @@ export function ConversationInput({
     const text = textareaRef.current?.value?.trim() ?? "";
     if (!text) return;
     await runQuickSlashCommand(`/guided ${text}`, "Guided generation failed");
-  }, [activeChatId, isStreaming, hasPendingAttachments, runQuickSlashCommand]);
+  }, [activeChatId, isSendBlocked, hasPendingAttachments, runQuickSlashCommand]);
 
   const quickReplyActions = useMemo<QuickReplyAction[]>(() => {
     const actions: QuickReplyAction[] = [];
     const getPostOnlyDisabledReason = () => {
       if (!activeChatId) return "Select or create a chat first.";
-      if (isStreaming) return "Wait for the current stream to finish.";
+      if (isSendBlocked) return "Wait for the current agents to finish.";
       if (isReadingAttachments) return "Still reading attached files.";
       if (!hasInput && attachments.length === 0) return "Type a draft first.";
       return undefined;
     };
     const getGuideDisabledReason = () => {
       if (!activeChatId) return "Select or create a chat first.";
-      if (isStreaming) return "Wait for the current stream to finish.";
+      if (isSendBlocked) return "Wait for the current agents to finish.";
       if (hasPendingAttachments) return "Clear or post attachments first.";
       if (!hasInput) return "Type a direction first.";
       return undefined;
@@ -1404,7 +1369,7 @@ export function ConversationInput({
         label: "Post only",
         description: "Add your message without a reply",
         icon: <FileText size="0.875rem" />,
-        disabled: !activeChatId || isStreaming || isReadingAttachments || (!hasInput && attachments.length === 0),
+        disabled: !activeChatId || isSendBlocked || isReadingAttachments || (!hasInput && attachments.length === 0),
         disabledReason: getPostOnlyDisabledReason(),
         onSelect: handlePostOnlyButton,
       });
@@ -1415,7 +1380,7 @@ export function ConversationInput({
         label: "Guide reply",
         description: "Send as /guided direction",
         icon: <WandSparkles size="0.875rem" />,
-        disabled: !activeChatId || isStreaming || !hasInput || hasPendingAttachments,
+        disabled: !activeChatId || isSendBlocked || !hasInput || hasPendingAttachments,
         disabledReason: getGuideDisabledReason(),
         onSelect: handleGuidedGenerationButton,
       });
@@ -1423,7 +1388,7 @@ export function ConversationInput({
     return actions;
   }, [
     activeChatId,
-    isStreaming,
+    isSendBlocked,
     isReadingAttachments,
     hasInput,
     attachments.length,
@@ -1705,11 +1670,7 @@ export function ConversationInput({
         // If fetch fails (CORS etc.), send without attachment — still shows as image in chat
       }
 
-      // If already streaming for this chat, just save the message
-      if (isStreaming) {
-        createMessage.mutate({ role: "user", content: gifUrl, characterId: null });
-        return;
-      }
+      if (isSendBlocked) return;
 
       await generate({
         chatId: activeChatId,
@@ -1718,7 +1679,7 @@ export function ConversationInput({
         ...(gifAttachments ? { attachments: gifAttachments } : {}),
       });
     },
-    [activeChatId, isStreaming, generate, createMessage],
+    [activeChatId, isSendBlocked, generate],
   );
 
   const handleStickerSelect = useCallback(
@@ -1740,14 +1701,10 @@ export function ConversationInput({
       }
       if (choice !== "send") return; // dismissed
 
-      // "Send & reply" — post the sticker as its own message (mirror the GIF send guards).
-      if (isStreaming) {
-        createMessage.mutate({ role: "user", content: token, characterId: null });
-        return;
-      }
+      if (isSendBlocked) return;
       await generate({ chatId: activeChatId, connectionId: null, userMessage: token });
     },
-    [activeChatId, isStreaming, generate, createMessage, insertStickerToken],
+    [activeChatId, isSendBlocked, generate, insertStickerToken],
   );
   const showDraftTranslateButton = chatMetadata.showInputTranslateButton === true;
   const showMobileToolsTab =
@@ -2091,7 +2048,7 @@ export function ConversationInput({
           <span>{chipRowHint}</span>
         </p>
       )}
-      <MariSuggestionChips chips={chipRowChips} onSelect={handleMariChipSelect} disabled={isStreaming} />
+      <MariSuggestionChips chips={chipRowChips} onSelect={handleMariChipSelect} disabled={isSendBlocked} />
 
       {/* Input bar */}
       <div
@@ -2264,13 +2221,15 @@ export function ConversationInput({
                 ? () => useChatStore.getState().stopGeneration(activeChatId ?? undefined)
                 : handleSend
             }
-            disabled={!isActuallyGenerating && (isReadingAttachments || !activeChatId || !canSubmit)}
+            disabled={
+              !isActuallyGenerating && (isSendBlocked || isReadingAttachments || !activeChatId || !canSubmit)
+            }
             aria-label={sendButtonTitle}
             className={cn(
               "flex h-9 w-9 items-center justify-center rounded-xl transition-all duration-200 sm:h-8 sm:w-8",
               isActuallyGenerating
                 ? "text-foreground/75 hover:bg-foreground/10 hover:text-foreground/90"
-                : canSubmit && !isReadingAttachments
+                : canSubmit && !isSendBlocked && !isReadingAttachments
                   ? "text-foreground/75 hover:bg-foreground/10 hover:text-foreground/90 active:scale-90"
                   : "text-foreground/20",
             )}

--- a/packages/client/src/components/game/GameInput.tsx
+++ b/packages/client/src/components/game/GameInput.tsx
@@ -35,7 +35,10 @@ interface GameInputProps {
   pendingMoveLabel?: string | null;
   /** Clear the staged destination without sending it. */
   onClearPendingMove?: () => void;
+  /** Blocks turn submission and turn-mutating controls while generation is active. */
   disabled: boolean;
+  /** Blocks drafting only when the current game view itself is not interactive. */
+  draftDisabled: boolean;
   isStreaming: boolean;
   /** When true, renders without the bottom-bar chrome (for embedding inside narration box) */
   inline?: boolean;
@@ -112,6 +115,7 @@ export function GameInput({
   pendingMoveLabel,
   onClearPendingMove,
   disabled,
+  draftDisabled,
   isStreaming,
   inline,
   draftKey,
@@ -171,17 +175,15 @@ export function GameInput({
     setAddressMode("scene");
   }, [addressMode, hasPartyMembers]);
 
-  // Honors focus requests even if the input was disabled at the time the
-  // token bumped (e.g. Interrupt clicked while `isStreaming` is still true) —
-  // we re-attempt the focus once `disabled` flips to false.
+  // A reviewed/history game state can still disable drafting entirely.
   const lastFocusedTokenRef = useRef(0);
   useEffect(() => {
     if (!focusToken) return;
     if (lastFocusedTokenRef.current === focusToken) return;
-    if (disabled) return;
+    if (draftDisabled) return;
     inputRef.current?.focus();
     lastFocusedTokenRef.current = focusToken;
-  }, [focusToken, disabled]);
+  }, [focusToken, draftDisabled]);
 
   useEffect(() => {
     if (!addressMenuOpen) return;
@@ -615,7 +617,7 @@ export function GameInput({
           onKeyDown={handleKeyDown}
           placeholder={
             isStreaming
-              ? "Waiting for the Game Master..."
+              ? "Prepare your next move..."
               : addressMode === "party"
                 ? "Say to party..."
                 : addressMode === "gm"
@@ -624,7 +626,7 @@ export function GameInput({
                     ? "What do you do when you arrive?"
                     : "What do you do?"
           }
-          disabled={disabled}
+          disabled={draftDisabled}
           rows={1}
           className="min-w-0 flex-1 resize-none bg-transparent px-2 py-1.5 text-sm leading-normal text-foreground outline-none placeholder:text-foreground/30 disabled:opacity-50"
           style={{ minHeight: 36, maxHeight: 120 }}

--- a/packages/client/src/components/game/GameSurface.tsx
+++ b/packages/client/src/components/game/GameSurface.tsx
@@ -26,6 +26,7 @@ import { useChatStore } from "../../stores/chat.store";
 import { useUIStore } from "../../stores/ui.store";
 import { useGameStateStore } from "../../stores/game-state.store";
 import { useGalleryStore } from "../../stores/gallery.store";
+import { useAgentStore } from "../../stores/agent.store";
 import {
   useSyncGameState,
   useCreateGame,
@@ -74,6 +75,7 @@ import { spriteKeys, type SpriteInfo } from "../../hooks/use-characters";
 import { lorebookKeys } from "../../hooks/use-lorebooks";
 import { api, getJsonRepairRequest, type JsonRepairRequest } from "../../lib/api-client";
 import { useRenderTimer } from "../../lib/perf-diagnostics";
+import { isGenerationSendBlocked } from "../../lib/generation-stream-policy";
 import { showConfirmDialog } from "../../lib/app-dialogs";
 import { CHAT_FLOATING_UI_DISMISS_EVENT } from "../../lib/chat-floating-ui-events";
 import {
@@ -2361,6 +2363,15 @@ function GameSurfaceComponent({
   isMessagesLoading,
 }: GameSurfaceProps) {
   useRenderTimer("game-surface"); // [#3104 diagnostic]
+  const backgroundIllustration = useChatStore((state) =>
+    state.backgroundIllustrationChatIds.has(activeChatId),
+  );
+  const agentsProcessing = useAgentStore((state) => state.processingChatIds.includes(activeChatId));
+  const gameInputGenerationBlocked = isGenerationSendBlocked({
+    streamActive: isStreaming,
+    agentsProcessing,
+    backgroundIllustration,
+  });
   // Sync game metadata → store
   useSyncGameState(activeChatId, chatMeta);
   const hierarchicalMapsActive =
@@ -11623,8 +11634,9 @@ function GameSurfaceComponent({
                               hasPartyMembers={partyMembers.length > 0}
                               pendingMoveLabel={pendingMapMove?.label ?? null}
                               onClearPendingMove={() => setPendingMapMove(null)}
-                              disabled={isStreaming || !sessionInteractive}
-                              isStreaming={isStreaming}
+                              disabled={gameInputGenerationBlocked || !sessionInteractive}
+                              draftDisabled={!sessionInteractive}
+                              isStreaming={gameInputGenerationBlocked}
                               inline
                               draftKey={activeChatId}
                               focusToken={gameInputFocusToken}
@@ -11711,8 +11723,9 @@ function GameSurfaceComponent({
                           hasPartyMembers={partyMembers.length > 0}
                           pendingMoveLabel={pendingMapMove?.label ?? null}
                           onClearPendingMove={() => setPendingMapMove(null)}
-                          disabled={isStreaming || !sessionInteractive}
-                          isStreaming={isStreaming}
+                          disabled={gameInputGenerationBlocked || !sessionInteractive}
+                          draftDisabled={!sessionInteractive}
+                          isStreaming={gameInputGenerationBlocked}
                           inline
                           draftKey={activeChatId}
                           focusToken={gameInputFocusToken}

--- a/packages/client/src/hooks/use-generate.ts
+++ b/packages/client/src/hooks/use-generate.ts
@@ -11,6 +11,7 @@ import { chatBackgroundMetadataToUrl } from "../lib/backgrounds";
 import { formatGenerationParameterError } from "../lib/generation-parameter-errors";
 import {
   getTypewriterRevealCharsPerSecond,
+  isGenerationStartBlocked,
   reconcileTypewriterReplacement,
   shouldKeepStreamLiveThroughPostProcessing,
 } from "../lib/generation-stream-policy";
@@ -1085,7 +1086,15 @@ export function useGenerate() {
       // keep generating in the background while the user navigates elsewhere.
       // Uses the shared abortControllers map as the source of truth so ALL callers
       // of useGenerate() coordinate (the old per-instance useRef could diverge).
-      if (activeGenerateLocks.has(params.chatId) || useChatStore.getState().abortControllers.has(params.chatId)) {
+      const generationState = useChatStore.getState();
+      const existingGenerationIsIllustrationOnly = generationState.backgroundIllustrationChatIds.has(params.chatId);
+      if (
+        isGenerationStartBlocked({
+          setupLocked: activeGenerateLocks.has(params.chatId),
+          activeController: generationState.abortControllers.has(params.chatId),
+          backgroundIllustration: existingGenerationIsIllustrationOnly,
+        })
+      ) {
         console.warn("[Generate] Skipped — generation already in progress for this chat");
         return false;
       }
@@ -1095,6 +1104,7 @@ export function useGenerate() {
       const abortController = new AbortController();
       try {
         useChatStore.getState().setAbortController(params.chatId, abortController);
+        useChatStore.getState().setBackgroundIllustration(params.chatId, false);
       } finally {
         activeGenerateLocks.delete(params.chatId);
       }
@@ -1238,6 +1248,8 @@ export function useGenerate() {
       let receivedThinking = false; // Whether provider-native thinking chunks were received
       let gameTurnLoadedSoundPlayed = false;
       let sawDoneEvent = false;
+      let illustrationQueued = false;
+      let illustrationSettled = false;
       let passiveStreamRecovered = false;
       let spatialTransitionCommitted = false;
       let passiveStreamSettled = false;
@@ -2269,6 +2281,7 @@ export function useGenerate() {
             }
 
             case "illustration": {
+              illustrationSettled = true;
               const illData = event.data as {
                 messageId: string;
                 imageUrl: string;
@@ -2282,11 +2295,18 @@ export function useGenerate() {
               if (!streamingEnabled) {
                 await refreshMessagesAuthoritatively(qc, params.chatId, persistedMessages.values());
               }
+              void qc.invalidateQueries({ queryKey: ["gallery", params.chatId] });
+              break;
+            }
+
+            case "illustration_queued": {
+              illustrationQueued = true;
               break;
             }
 
             case "agent_error": {
               const errData = event.data as { agentType: string; agentName?: string | null; error: string };
+              if (errData.agentType === "illustrator") illustrationSettled = true;
               const failure = toAgentFailure(errData);
               setFailedAgentFailures([failure], params.chatId);
               showAgentFailuresError([failure], () => {
@@ -2442,6 +2462,9 @@ export function useGenerate() {
 
             case "done": {
               sawDoneEvent = true;
+              if (illustrationQueued && !illustrationSettled) {
+                useChatStore.getState().setBackgroundIllustration(params.chatId, true);
+              }
               if (spriteChangeReceived) {
                 qc.invalidateQueries({ queryKey: chatKeys.messages(params.chatId) });
               }
@@ -2627,6 +2650,7 @@ export function useGenerate() {
         if (stillOwnerAtCleanupStart) {
           useChatStore.getState().clearPerChatState(params.chatId);
           useChatStore.getState().setAbortController(params.chatId, null);
+          useChatStore.getState().setBackgroundIllustration(params.chatId, false);
         }
 
         if (shouldRefreshGameState) {
@@ -2951,6 +2975,8 @@ export function useGenerate() {
         return false;
       }
       useChatStore.getState().setAbortController(chatId, abortController);
+      useChatStore.getState().setBackgroundIllustration(chatId, false);
+      const isIllustratorOnlyRetry = agentTypes.length === 1 && agentTypes[0] === "illustrator";
       const isTrackerRetry = agentTypes.some(
         (agentType) => isBuiltInTrackerAgentType(agentType) || !isBuiltInAgentType(agentType),
       );
@@ -3231,6 +3257,12 @@ export function useGenerate() {
               }
               break;
             }
+            case "illustration_queued": {
+              if (isIllustratorOnlyRetry) {
+                useChatStore.getState().setBackgroundIllustration(chatId, true);
+              }
+              break;
+            }
             case "image_prompt_review": {
               imagePromptReviewRequested = true;
               window.dispatchEvent(
@@ -3285,9 +3317,11 @@ export function useGenerate() {
             : "Agent retry failed";
         showError(msg);
       } finally {
-        setProcessing(false, chatId);
-        if (useChatStore.getState().abortControllers.get(chatId) === abortController) {
+        const stillOwner = useChatStore.getState().abortControllers.get(chatId) === abortController;
+        if (stillOwner) {
+          setProcessing(false, chatId);
           useChatStore.getState().setAbortController(chatId, null);
+          useChatStore.getState().setBackgroundIllustration(chatId, false);
         }
         if (isTrackerRetry) useGameStateStore.getState().clearRefreshingChat(chatId);
         if (hasError && isActiveChat()) {

--- a/packages/client/src/lib/generation-stream-policy.ts
+++ b/packages/client/src/lib/generation-stream-policy.ts
@@ -18,6 +18,28 @@ interface TypewriterRevealRateInput {
   streamComplete: boolean;
 }
 
+interface GenerationSendBlockInput {
+  streamActive: boolean;
+  agentsProcessing: boolean;
+  backgroundIllustration: boolean;
+}
+
+interface GenerationStartBlockInput {
+  setupLocked: boolean;
+  activeController: boolean;
+  backgroundIllustration: boolean;
+}
+
+/** Keep send actions guarded while leaving the draft field itself editable. */
+export function isGenerationSendBlocked(input: GenerationSendBlockInput): boolean {
+  return !input.backgroundIllustration && (input.streamActive || input.agentsProcessing);
+}
+
+/** An Illustrator-only SSE tail may coexist with the chat's next text generation. */
+export function isGenerationStartBlocked(input: GenerationStartBlockInput): boolean {
+  return input.setupLocked || (input.activeController && !input.backgroundIllustration);
+}
+
 /**
  * Keep the reveal slightly behind an open transport so provider-sized bursts
  * remain a continuous typewriter queue instead of draining into visible gaps.

--- a/packages/client/src/stores/chat.store.ts
+++ b/packages/client/src/stores/chat.store.ts
@@ -178,6 +178,8 @@ interface ChatState {
   thinkingBuffers: Map<string, string>;
   /** Per-chat AbortControllers for active generations — keyed by chatId. */
   abortControllers: Map<string, AbortController>;
+  /** Chats whose reply is complete while an Illustrator image finishes on the existing SSE tail. */
+  backgroundIllustrationChatIds: Set<string>;
   /** When regenerating, the ID of the message being regenerated (so streaming shows in-place). */
   regenerateMessageId: string | null;
   /** During group chat individual mode, the character currently streaming. */
@@ -245,6 +247,7 @@ interface ChatState {
   setStreamedMessageId: (chatId: string, messageId: string | null) => void;
   setMariPhase: (chatId: string, phase: "thinking" | "updating" | "idle") => void;
   setAbortController: (chatId: string, controller: AbortController | null) => void;
+  setBackgroundIllustration: (chatId: string, pending: boolean) => void;
   stopGeneration: (chatId?: string) => void;
   appendStreamBuffer: (text: string, chatId?: string) => void;
   setStreamBuffer: (text: string, chatId?: string) => void;
@@ -334,6 +337,7 @@ export const useChatStore = create<ChatState>()(
     thinkingBuffer: "",
     thinkingBuffers: new Map(),
     abortControllers: new Map(),
+    backgroundIllustrationChatIds: new Set(),
     regenerateMessageId: null,
     streamingCharacterId: null,
     responseQueues: new Map(),
@@ -491,6 +495,13 @@ export const useChatStore = create<ChatState>()(
         if (controller) m.set(chatId, controller);
         else m.delete(chatId);
         return { abortControllers: m };
+      }),
+    setBackgroundIllustration: (chatId, pending) =>
+      set((state) => {
+        const next = new Set(state.backgroundIllustrationChatIds);
+        if (pending) next.add(chatId);
+        else next.delete(chatId);
+        return { backgroundIllustrationChatIds: next };
       }),
     stopGeneration: (chatId) => {
       const { activeChatId, streamingChatId, abortControllers } = useChatStore.getState();
@@ -918,6 +929,7 @@ export const useChatStore = create<ChatState>()(
         thinkingBuffer: "",
         thinkingBuffers: new Map(),
         abortControllers: new Map(),
+        backgroundIllustrationChatIds: new Set(),
         regenerateMessageId: null,
         streamingCharacterId: null,
         responseQueues: new Map(),

--- a/packages/server/src/routes/generate.routes.ts
+++ b/packages/server/src/routes/generate.routes.ts
@@ -7963,6 +7963,10 @@ export async function generateRoutes(app: FastifyInstance) {
                 imgConnFull ??= await connections.getDefaultForImageGeneration();
                 if (imgConnFull) {
                   const resolvedImageConnection = imgConnFull;
+                  trySendSseEvent(reply, {
+                    type: "illustration_queued",
+                    data: { messageId },
+                  });
                   // Queue image generation to run after the result loop so it doesn't
                   // block other agents (game state, trackers, rewrite agents).
                   pendingIllustration = (async () => {

--- a/packages/server/src/routes/generate/retry-agents-route.ts
+++ b/packages/server/src/routes/generate/retry-agents-route.ts
@@ -3190,6 +3190,10 @@ async function applyRetryResultEffects(args: {
               queueImageGenerationRequests ? "enabled" : "disabled",
               imageConnectionQueueKey,
             );
+            sendSseEvent(reply, {
+              type: "illustration_queued",
+              data: { messageId: retryMessageId },
+            });
             const imageResult = await runImageGenerationRequest({
               connectionKey: imageConnectionQueueKey,
               queue: queueImageGenerationRequests,

--- a/scripts/regressions/roleplay-streaming.regression.ts
+++ b/scripts/regressions/roleplay-streaming.regression.ts
@@ -2,6 +2,8 @@ import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 import {
   getTypewriterRevealCharsPerSecond,
+  isGenerationSendBlocked,
+  isGenerationStartBlocked,
   isMessageShadowedByLiveStream,
   reconcileTypewriterReplacement,
   shouldKeepStreamLiveThroughPostProcessing,
@@ -38,6 +40,67 @@ import type { AgentCallDebugEvent, AgentContext } from "../../packages/shared/sr
 const retryAgentRouteSource = readFileSync(
   new URL("../../packages/server/src/routes/generate/retry-agents-route.ts", import.meta.url),
   "utf8",
+);
+const generateRouteSource = readFileSync(
+  new URL("../../packages/server/src/routes/generate.routes.ts", import.meta.url),
+  "utf8",
+);
+const chatInputSource = readFileSync(
+  new URL("../../packages/client/src/components/chat/ChatInput.tsx", import.meta.url),
+  "utf8",
+);
+const gameInputSource = readFileSync(
+  new URL("../../packages/client/src/components/game/GameInput.tsx", import.meta.url),
+  "utf8",
+);
+assert.match(
+  generateRouteSource,
+  /type: "illustration_queued"/u,
+  "automatic Illustrator runs should announce their background-only tail before generation completes",
+);
+assert.match(
+  retryAgentRouteSource,
+  /type: "illustration_queued"/u,
+  "an Illustrator-only retry should expose the same background handoff",
+);
+const chatTextareaSource = chatInputSource.match(/<textarea[\s\S]*?\/>/u)?.[0] ?? "";
+assert.match(chatTextareaSource, /disabled=\{!activeChatId\}/u);
+assert.doesNotMatch(
+  chatTextareaSource,
+  /disabled=\{[^}]*isInputBusy/u,
+  "agent work should guard sending without disabling preparation of the next draft",
+);
+const gameTextareaSource = gameInputSource.match(/<textarea[\s\S]*?\/>/u)?.[0] ?? "";
+assert.match(
+  gameTextareaSource,
+  /disabled=\{draftDisabled\}/u,
+  "Game mode should keep its draft field separate from the generation send lock",
+);
+
+assert.equal(
+  isGenerationSendBlocked({ streamActive: true, agentsProcessing: true, backgroundIllustration: false }),
+  true,
+  "ordinary streaming and agent work should keep send actions guarded",
+);
+assert.equal(
+  isGenerationSendBlocked({ streamActive: false, agentsProcessing: true, backgroundIllustration: false }),
+  true,
+  "agent-only retries should guard sending without locking the draft field",
+);
+assert.equal(
+  isGenerationSendBlocked({ streamActive: true, agentsProcessing: true, backgroundIllustration: true }),
+  false,
+  "an Illustrator-only tail should permit the next message to be sent",
+);
+assert.equal(
+  isGenerationStartBlocked({ setupLocked: false, activeController: true, backgroundIllustration: false }),
+  true,
+  "ordinary same-chat generations must remain exclusive",
+);
+assert.equal(
+  isGenerationStartBlocked({ setupLocked: false, activeController: true, backgroundIllustration: true }),
+  false,
+  "the next same-chat generation should be allowed while Illustrator finishes",
 );
 assert.match(
   retryAgentRouteSource,

--- a/scripts/regressions/roleplay-streaming.regression.ts
+++ b/scripts/regressions/roleplay-streaming.regression.ts
@@ -49,6 +49,10 @@ const chatInputSource = readFileSync(
   new URL("../../packages/client/src/components/chat/ChatInput.tsx", import.meta.url),
   "utf8",
 );
+const conversationInputSource = readFileSync(
+  new URL("../../packages/client/src/components/chat/ConversationInput.tsx", import.meta.url),
+  "utf8",
+);
 const gameInputSource = readFileSync(
   new URL("../../packages/client/src/components/game/GameInput.tsx", import.meta.url),
   "utf8",
@@ -69,6 +73,12 @@ assert.doesNotMatch(
   chatTextareaSource,
   /disabled=\{[^}]*isInputBusy/u,
   "agent work should guard sending without disabling preparation of the next draft",
+);
+const conversationTextareaSource = conversationInputSource.match(/<textarea[\s\S]*?\/>/u)?.[0] ?? "";
+assert.doesNotMatch(
+  conversationTextareaSource,
+  /disabled=/u,
+  "Conversation drafts should remain editable regardless of send-blocking state",
 );
 const gameTextareaSource = gameInputSource.match(/<textarea[\s\S]*?\/>/u)?.[0] ?? "";
 assert.match(


### PR DESCRIPTION
## Linked issue

Closes #3911

## Why this change

Chat composers should let users prepare their next response while agents work. Illustrator image generation is also independent after the assistant reply is complete, so it should not keep the composer or same-chat generation lock occupied while the image provider finishes.

## What changed

- Keep Conversation, Roleplay, and Game draft fields editable during ordinary generation and agent processing while Send and Enter-to-send remain guarded.
- Mark automatic and Illustrator-only retry image work as a background tail once other reply work is complete.
- Allow a new same-chat text generation to take ownership while the older Illustrator stream continues listening for completion.
- Preserve the existing exact message/swipe attachment path and invalidate both messages and the chat Gallery when the image arrives.
- Guard overlapping cleanup by AbortController identity so an older Illustrator task cannot clear a newer generation.
- Add regression coverage for normal exclusivity, agent-only send blocking, editable draft fields, and Illustrator-tail overlap.

## Validation

Automated evidence:

- `pnpm check` — passed
- `pnpm regression:roleplay` — passed
- `pnpm --filter @marinara-engine/server lint` — passed serially

Human checklist (intentionally left unchecked):

- [ ] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed `CONTRIBUTING.md`

### Manual verification notes

Not performed in a live provider session. Please manually verify:

- Start an Illustrator-enabled reply, type while other agents are processing, and confirm Enter/Send does not submit yet.
- Once only the image generation remains, send the prepared draft and confirm the next reply begins.
- Confirm the completed image appears under the original assistant message and in Gallery, including after switching swipes.
- Repeat with an Illustrator-only retry and in Conversation, Roleplay, and Game composers.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Version/release files updated (only if this PR includes a version bump)

No install, update, release, or configuration behavior changed.

## UI evidence

No screenshots attached. This changes composer interaction state without introducing new visual UI.

## Risk boundary

- Risk type: generation ownership and agent-result delivery.
- Entrypoints: main `/generate` stream and Illustrator-only retry stream.
- Positive proof: policy regressions cover background-tail send/start allowance and editable Roleplay/Game draft fields.
- Negative controls: normal active generations and agent-only retries remain send-blocking and same-chat exclusive.
- Proof gap: no live image provider, network disconnect, or browser interaction was exercised in this worktree.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved generation status handling across chat and game inputs.
  - Added support for continuing to draft messages while background illustrations finish.
  - Added clearer input states and messaging, including “Prepare your next move...”.
  - Illustration progress is now reflected immediately in the interface.

- **Bug Fixes**
  - Prevented conflicting submissions while agents or illustration generation are still processing.
  - Improved cleanup of illustration-processing states after completion or retry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->