### PR TITLE
Fix scoped lore, Professor Mari commands, and dialogue defaults

### DIFF
--- a/e2e/core-flows.e2e.ts
+++ b/e2e/core-flows.e2e.ts
@@ -137,6 +137,105 @@ test("turning off the custom mouse pointer persists immediately and after reload
     .toBeNull();
 });
 
+test("default dialogue color fills only cards without their own dialogue color", async ({ page }, testInfo) => {
+  test.skip(!testInfo.project.name.includes("desktop"), "Dialogue color precedence is covered on desktop.");
+
+  const uncoloredCharacterResponse = await page.request.post("/api/characters", {
+    data: { data: { name: "Global Dialogue Color" } },
+  });
+  expect(uncoloredCharacterResponse.ok()).toBeTruthy();
+  const uncoloredCharacter = (await uncoloredCharacterResponse.json()) as { id: string };
+
+  const coloredCharacterResponse = await page.request.post("/api/characters", {
+    data: {
+      data: {
+        name: "Card Dialogue Color",
+        extensions: { dialogueColor: "#22c55e" },
+      },
+    },
+  });
+  expect(coloredCharacterResponse.ok()).toBeTruthy();
+  const coloredCharacter = (await coloredCharacterResponse.json()) as { id: string };
+
+  const chatResponse = await page.request.post("/api/chats", {
+    data: {
+      name: "Default Dialogue Color Smoke",
+      mode: "roleplay",
+      characterIds: [uncoloredCharacter.id, coloredCharacter.id],
+    },
+  });
+  expect(chatResponse.ok()).toBeTruthy();
+  const chat = (await chatResponse.json()) as { id: string };
+
+  try {
+    const uncoloredMessageResponse = await page.request.post(`/api/chats/${chat.id}/messages`, {
+      data: {
+        role: "assistant",
+        characterId: uncoloredCharacter.id,
+        content: '"Use the global fallback."',
+      },
+    });
+    expect(uncoloredMessageResponse.ok()).toBeTruthy();
+    const uncoloredMessage = (await uncoloredMessageResponse.json()) as { id: string };
+
+    const coloredMessageResponse = await page.request.post(`/api/chats/${chat.id}/messages`, {
+      data: {
+        role: "assistant",
+        characterId: coloredCharacter.id,
+        content: '"Keep the card override."',
+      },
+    });
+    expect(coloredMessageResponse.ok()).toBeTruthy();
+    const coloredMessage = (await coloredMessageResponse.json()) as { id: string };
+
+    await page.addInitScript((chatId) => localStorage.setItem("marinara-active-chat-id", chatId), chat.id);
+    await page.goto("/");
+
+    const uncoloredDialogue = page
+      .locator(`[data-message-id="${uncoloredMessage.id}"] .mari-message-content strong`)
+      .first();
+    const coloredDialogue = page
+      .locator(`[data-message-id="${coloredMessage.id}"] .mari-message-content strong`)
+      .first();
+    await expect(uncoloredDialogue).toBeVisible();
+    await expect(coloredDialogue).toHaveCSS("color", "rgb(34, 197, 94)");
+
+    await page.locator('[data-tour="panel-settings"]').click();
+    await page.getByRole("tab", { name: "Appearance" }).click();
+    const dialogueColorControl = page.locator("#settings-control-default-dialogue-color");
+    await dialogueColorControl.scrollIntoViewIfNeeded();
+    const dialogueColorToggle = dialogueColorControl.locator('input[type="checkbox"]');
+    await dialogueColorControl.locator("label[for]").first().click();
+    await expect(dialogueColorToggle).toBeChecked();
+    await dialogueColorControl.getByRole("button", { name: /Scheme default/ }).click();
+    await dialogueColorControl.getByLabel("Default Dialogue Color hex or CSS color").fill("#d946ef");
+
+    await expect(uncoloredDialogue).toHaveCSS("color", "rgb(217, 70, 239)");
+    await expect(coloredDialogue).toHaveCSS("color", "rgb(34, 197, 94)");
+    await expect
+      .poll(() =>
+        page.evaluate(() => {
+          const persisted = JSON.parse(localStorage.getItem("marinara-engine-ui") ?? '{"state":{}}') as {
+            state?: { defaultDialogueColorEnabled?: unknown; defaultDialogueColor?: unknown };
+          };
+          return [persisted.state?.defaultDialogueColorEnabled, persisted.state?.defaultDialogueColor];
+        }),
+      )
+      .toEqual([true, "#d946ef"]);
+
+    await dialogueColorControl.locator("label[for]").first().click();
+    await expect(dialogueColorToggle).not.toBeChecked();
+    await expect(uncoloredDialogue).not.toHaveCSS("color", "rgb(217, 70, 239)");
+    await expect(coloredDialogue).toHaveCSS("color", "rgb(34, 197, 94)");
+  } finally {
+    await page.request.delete(`/api/chats/${chat.id}`).catch(() => undefined);
+    await Promise.all([
+      page.request.delete(`/api/characters/${uncoloredCharacter.id}`).catch(() => undefined),
+      page.request.delete(`/api/characters/${coloredCharacter.id}`).catch(() => undefined),
+    ]);
+  }
+});
+
 test("Convo About Me keeps manual editing and native expanded-editor keyboard behavior", async ({ page }, testInfo) => {
   test.skip(!testInfo.project.name.includes("desktop"), "The shared Convo profile fields are covered on desktop.");
 

--- a/packages/client/src/components/characters/CharacterEditor.tsx
+++ b/packages/client/src/components/characters/CharacterEditor.tsx
@@ -189,7 +189,7 @@ const CHARACTER_STATS_HELP =
   "HP is injected into the prompt so the AI knows the character's current health. Attributes are custom stats, like STR or DEX, that define the character's capabilities. The Character Tracker agent can adjust values based on combat, healing, and narrative events. Values set here serve as the initial/default state for new conversations.";
 
 const CHARACTER_COLORS_HELP =
-  "Name color is applied to the character's display name in chat. Gradients use CSS linear-gradient. Dialogue color applies to text inside dialogue quotation marks and can optionally be bolded from Settings. Box color sets the background color of the character's message bubble in roleplay mode. Leave any field empty to use the default theme colors.";
+  "Name color is applied to the character's display name in chat. Gradients use CSS linear-gradient. Dialogue color applies to text inside dialogue quotation marks and can optionally be bolded from Settings. Box color sets the background color of the character's message bubble in roleplay mode. An empty dialogue color uses the default from Settings > Appearance when enabled; other empty fields use theme colors.";
 
 const CHARACTER_LOREBOOK_HELP =
   "Attach lorebook/world-info entries to this character. Entries trigger from keywords during conversation; embedded card lorebooks can be imported into Marinara as linked lorebooks for deeper editing.";

--- a/packages/client/src/components/chat/ChatMessage.tsx
+++ b/packages/client/src/components/chat/ChatMessage.tsx
@@ -49,7 +49,7 @@ import { chatKeys, rememberRecentMessageContentEdit } from "../../hooks/use-chat
 import { useShallow } from "zustand/react/shallow";
 import { createMessageMacroResolver } from "../../lib/chat-macros";
 import { useApplyRegex } from "../../hooks/use-apply-regex";
-import { useUIStore } from "../../stores/ui.store";
+import { getDefaultChatTextColor, useUIStore } from "../../stores/ui.store";
 import { useChatStore } from "../../stores/chat.store";
 import { parseChatMetadata } from "../../lib/chat-display";
 import { useTranslate } from "../../hooks/use-translate";
@@ -1203,6 +1203,9 @@ export const ChatMessage = memo(function ChatMessage({
   const {
     chatFontSize,
     chatFontColor,
+    defaultDialogueColorEnabled,
+    defaultDialogueColor,
+    theme,
     chatFontOpacity,
     roleplayAvatarStyle,
     roleplayAvatarScale,
@@ -1222,6 +1225,9 @@ export const ChatMessage = memo(function ChatMessage({
     useShallow((s) => ({
       chatFontSize: s.chatFontSize,
       chatFontColor: s.chatFontColor,
+      defaultDialogueColorEnabled: s.defaultDialogueColorEnabled,
+      defaultDialogueColor: s.defaultDialogueColor,
+      theme: s.theme,
       chatFontOpacity: s.chatFontOpacity,
       roleplayAvatarStyle: s.roleplayAvatarStyle,
       roleplayAvatarScale: s.roleplayAvatarScale,
@@ -1881,7 +1887,10 @@ export const ChatMessage = memo(function ChatMessage({
         }
       : personaInfo
     : resolvedCharacterInfo;
-  const dialogueColor = msgColors?.dialogueColor;
+  const fallbackDialogueColor = defaultDialogueColorEnabled
+    ? defaultDialogueColor || getDefaultChatTextColor(theme)
+    : undefined;
+  const dialogueColor = msgColors?.dialogueColor || fallbackDialogueColor;
   const boxBgColor = msgColors?.boxColor;
   const msgNameColor = msgColors?.nameColor;
   const roleplayBubbleBg = boxBgColor ? boxBgColor : isUser ? userBubbleBg : assistantBubbleBg;

--- a/packages/client/src/components/game/GameNarration.tsx
+++ b/packages/client/src/components/game/GameNarration.tsx
@@ -62,7 +62,7 @@ import { useTTSConfig } from "../../hooks/use-tts";
 import { useApplyRegex } from "../../hooks/use-apply-regex";
 import { useGameAssetManifest } from "../../hooks/use-game-assets";
 import { useGameModeStore } from "../../stores/game-mode.store";
-import { useUIStore } from "../../stores/ui.store";
+import { getDefaultChatTextColor, useUIStore } from "../../stores/ui.store";
 import { useChatStore } from "../../stores/chat.store";
 import { parseChatMetadata } from "../../lib/chat-display";
 import { parseMessageExtraRecord } from "../../lib/chat-message-extra";
@@ -1012,6 +1012,14 @@ export function GameNarration({
   const gameDialogueDisplayMode = useUIStore((s) => s.gameDialogueDisplayMode);
   const gameTextEffectsEnabled = useUIStore((s) => s.gameTextEffectsEnabled);
   const quoteFormat = useUIStore((s) => s.quoteFormat);
+  const defaultDialogueColorEnabled = useUIStore((s) => s.defaultDialogueColorEnabled);
+  const defaultDialogueColor = useUIStore((s) => s.defaultDialogueColor);
+  const theme = useUIStore((s) => s.theme);
+  const fallbackDialogueColor = defaultDialogueColorEnabled
+    ? defaultDialogueColor || getDefaultChatTextColor(theme)
+    : undefined;
+  const personaDialogueColor =
+    personaInfo?.dialogueColor || fallbackDialogueColor || personaInfo?.nameColor || "#a5b4fc";
   const useStackedLogDisplay = gameDialogueDisplayMode === "stacked";
   const showLogsButton = !useStackedLogDisplay;
   const [editingContent, setEditingContent] = useState<string | null>(null);
@@ -1105,20 +1113,20 @@ export function GameNarration({
   const speakerColors = useMemo(() => {
     const byName = new Map<string, string>();
     for (const [, c] of activeCharacterEntries) {
-      const color = c.dialogueColor || c.nameColor;
+      const color = c.dialogueColor || fallbackDialogueColor || c.nameColor;
       if (color) byName.set(normalizeTextForMatch(c.name), color);
     }
     if (speakerAvatarMap) {
       for (const [name, info] of speakerAvatarMap) {
-        const color = info.dialogueColor || info.nameColor;
+        const color = info.dialogueColor || fallbackDialogueColor || info.nameColor;
         if (color) byName.set(normalizeTextForMatch(name), color);
       }
     }
-    if (personaInfo?.name && (personaInfo.dialogueColor || personaInfo.nameColor)) {
-      byName.set(normalizeTextForMatch(personaInfo.name), personaInfo.dialogueColor || personaInfo.nameColor || "");
+    if (personaInfo?.name) {
+      byName.set(normalizeTextForMatch(personaInfo.name), personaDialogueColor);
     }
     return byName;
-  }, [activeCharacterEntries, personaInfo, speakerAvatarMap]);
+  }, [activeCharacterEntries, fallbackDialogueColor, personaDialogueColor, personaInfo?.name, speakerAvatarMap]);
 
   /** Name-display colors (prefers nameColor which may be a gradient). */
   const speakerNameColors = useMemo(() => {
@@ -1310,7 +1318,7 @@ export function GameNarration({
         if (!msg.content?.trim()) continue;
         if (isSyntheticGameStartMessage(msg)) continue;
         const playerName = personaInfo?.name || "You";
-        const color = personaInfo?.dialogueColor || personaInfo?.nameColor || "#a5b4fc";
+        const color = personaDialogueColor;
         out.push({
           kind: "user",
           messageId: msg.id,
@@ -1337,7 +1345,7 @@ export function GameNarration({
       }
     }
     return out;
-  }, [messages, personaInfo, speakerColors, segmentDeletes]);
+  }, [messages, personaDialogueColor, personaInfo, speakerColors, segmentDeletes]);
 
   // Past-review entry the player is currently looking at. Each wheel-up bumps
   // `messageOffset`; we step back that many entries from the most recent log entry.
@@ -1530,7 +1538,7 @@ export function GameNarration({
     // Prepend the user's action as a player dialogue segment when we're streaming or just got a response
     if (latestUserMessage?.content && latestAssistant) {
       const playerName = personaInfo?.name || "You";
-      const color = personaInfo?.dialogueColor || personaInfo?.nameColor || "#a5b4fc";
+      const color = personaDialogueColor;
       result.push({
         id: `${latestUserMessage.id}-player`,
         type: "dialogue",
@@ -1570,7 +1578,7 @@ export function GameNarration({
       // Prepend the player's party-chat input as a dialogue segment
       if (partyChatInput) {
         const playerName = personaInfo?.name || "You";
-        const color = personaInfo?.dialogueColor || personaInfo?.nameColor || "#a5b4fc";
+        const color = personaDialogueColor;
         result.push({
           id: `party-chat-input-${result.length}`,
           type: "dialogue",
@@ -1715,6 +1723,7 @@ export function GameNarration({
     speakerColors,
     latestUserMessage,
     personaInfo,
+    personaDialogueColor,
     partyDialogue,
     partyChatInput,
     partyChatInputMessageId,
@@ -2375,7 +2384,7 @@ export function GameNarration({
       if (showUserMessages && msg.role === "user" && msg.content.trim()) {
         if (isSyntheticGameStartMessage(msg)) continue;
         const playerName = personaInfo?.name || "You";
-        const color = personaInfo?.dialogueColor || personaInfo?.nameColor || "#a5b4fc";
+        const color = personaDialogueColor;
         entries.push({
           messageId: msg.id,
           segments: [
@@ -2481,7 +2490,7 @@ export function GameNarration({
       // Prepend the player's party-chat input
       if (partyChatInput) {
         const playerName = personaInfo?.name || "You";
-        const color = personaInfo?.dialogueColor || personaInfo?.nameColor || "#a5b4fc";
+        const color = personaDialogueColor;
         partySegs.push({
           id: "party-log-player-input",
           type: "dialogue" as const,
@@ -2585,6 +2594,7 @@ export function GameNarration({
     segments,
     showUserMessages,
     personaInfo,
+    personaDialogueColor,
     partyChatInput,
     partyChatInputMessageId,
     partyChatMessageId,

--- a/packages/client/src/components/panels/SettingsPanel.tsx
+++ b/packages/client/src/components/panels/SettingsPanel.tsx
@@ -859,6 +859,14 @@ const SETTINGS_SEARCHABLE_CONTROLS: readonly SettingsSearchableControlMeta[] = [
     kind: "Picker",
   },
   {
+    id: "default-dialogue-color",
+    sectionId: "text-scale",
+    label: "Default Dialogue Color",
+    description: "Choose the dialogue highlight used by cards without their own dialogue color.",
+    aliases: ["quote color", "character dialogue", "persona dialogue"],
+    kind: "Toggle",
+  },
+  {
     id: "chat-chrome-text-color",
     sectionId: "text-scale",
     label: "Chat Chrome Text Color",
@@ -3697,6 +3705,10 @@ function AppearanceSettings() {
   // Text appearance
   const chatFontColor = useUIStore((s) => s.chatFontColor);
   const setChatFontColor = useUIStore((s) => s.setChatFontColor);
+  const defaultDialogueColorEnabled = useUIStore((s) => s.defaultDialogueColorEnabled);
+  const setDefaultDialogueColorEnabled = useUIStore((s) => s.setDefaultDialogueColorEnabled);
+  const defaultDialogueColor = useUIStore((s) => s.defaultDialogueColor);
+  const setDefaultDialogueColor = useUIStore((s) => s.setDefaultDialogueColor);
   const chatChromeTextColor = useUIStore((s) => s.chatChromeTextColor);
   const setChatChromeTextColor = useUIStore((s) => s.setChatChromeTextColor);
   const chatFontOpacity = useUIStore((s) => s.chatFontOpacity);
@@ -4065,6 +4077,32 @@ function AppearanceSettings() {
               emptyText={`Scheme default ${getDefaultChatTextColor(theme)}`}
               emptyPreviewValue={getDefaultChatTextColor(theme)}
               clearLabel="Reset to default"
+            />
+          </SearchableSettingTarget>
+
+          <SearchableSettingTarget controlId="default-dialogue-color">
+            <ColorPicker
+              value={defaultDialogueColor}
+              onChange={setDefaultDialogueColor}
+              compact
+              label="Default Dialogue Color"
+              helpText="When enabled, this colors dialogue for character and persona cards that do not have their own Dialogue Highlight Color. A card's own dialogue color always overrides it."
+              emptyText={`Scheme default ${getDefaultChatTextColor(theme)}`}
+              emptyPreviewValue={getDefaultChatTextColor(theme)}
+              clearLabel="Reset to scheme default"
+              disabled={!defaultDialogueColorEnabled}
+              headerAction={
+                <SettingsSwitch
+                  checked={defaultDialogueColorEnabled}
+                  onChange={setDefaultDialogueColorEnabled}
+                  ariaLabel={
+                    defaultDialogueColorEnabled
+                      ? "Disable the default dialogue color"
+                      : "Enable the default dialogue color"
+                  }
+                  className="p-0 hover:bg-transparent"
+                />
+              }
             />
           </SearchableSettingTarget>
 

--- a/packages/client/src/components/personas/PersonaEditor.tsx
+++ b/packages/client/src/components/personas/PersonaEditor.tsx
@@ -167,7 +167,7 @@ const PERSONA_SPRITES_HELP =
   "Upload sprites one by one, or use Upload Folder to bulk-import a folder of PNGs. Each filename becomes the expression name, for example admiration.png becomes admiration. To rotate variants, share a prefix before an underscore, for example happy_01.png and happy_blush.png. Persona sprites can be used in Game Mode and roleplay with the Expression Engine. Use transparent PNGs for best results.";
 
 const PERSONA_COLORS_HELP =
-  "Name color is applied to your persona's display name in chat. Gradients use CSS linear-gradient. Dialogue color applies to text inside dialogue quotation marks and can optionally be bolded from Settings. Box color sets the background color of your persona's message bubble. Leave any field empty to use the default theme colors.";
+  "Name color is applied to your persona's display name in chat. Gradients use CSS linear-gradient. Dialogue color applies to text inside dialogue quotation marks and can optionally be bolded from Settings. Box color sets the background color of your persona's message bubble. An empty dialogue color uses the default from Settings > Appearance when enabled; other empty fields use theme colors.";
 
 const PERSONA_STATS_HELP =
   "Status bars represent your persona's physical and mental state, such as hunger, energy, or mood. The Persona Stats agent adjusts values realistically based on what happens in the narrative. Bars are displayed in the HUD widget during chat with color-coded gradients. Values set here serve as the initial defaults for new conversations.";

--- a/packages/client/src/stores/ui.store.ts
+++ b/packages/client/src/stores/ui.store.ts
@@ -653,6 +653,10 @@ interface UIState {
   // ── Text Appearance ──
   /** Color for chat message text (empty = theme default) */
   chatFontColor: string;
+  /** Whether cards without their own dialogue color use the global dialogue color */
+  defaultDialogueColorEnabled: boolean;
+  /** Default dialogue highlight color for cards without one (empty = theme default) */
+  defaultDialogueColor: string;
   /** Color for non-action chrome copy in tracker widgets, folder labels, settings descriptors, and popovers (empty = scheme default) */
   chatChromeTextColor: string;
   /** Opacity for roleplay message backgrounds (0–100) */
@@ -925,6 +929,8 @@ interface UIState {
   setSummaryPopoverSettings: (settings: Partial<SummaryPopoverSettings>) => void;
   setScenePromptPreferences: (preferences: ScenePromptPreferences) => void;
   setChatFontColor: (v: string) => void;
+  setDefaultDialogueColorEnabled: (v: boolean) => void;
+  setDefaultDialogueColor: (v: string) => void;
   setChatChromeTextColor: (v: string) => void;
   setChatFontOpacity: (v: number) => void;
   setRoleplayReducedPaintEffects: (v: boolean) => void;
@@ -1122,6 +1128,8 @@ export function pickSyncedSettings(state: UIState) {
     summaryPopoverSettings: state.summaryPopoverSettings,
     scenePromptPreferences: state.scenePromptPreferences,
     chatFontColor: state.chatFontColor,
+    defaultDialogueColorEnabled: state.defaultDialogueColorEnabled,
+    defaultDialogueColor: state.defaultDialogueColor,
     chatChromeTextColor: state.chatChromeTextColor,
     chatFontOpacity: state.chatFontOpacity,
     roleplayAvatarStyle: state.roleplayAvatarStyle,
@@ -1305,6 +1313,8 @@ export const useUIStore = create<UIState>()(
       summaryPopoverSettings: DEFAULT_SUMMARY_POPOVER_SETTINGS,
       scenePromptPreferences: DEFAULT_SCENE_PROMPT_PREFERENCES,
       chatFontColor: "",
+      defaultDialogueColorEnabled: false,
+      defaultDialogueColor: "",
       chatChromeTextColor: "",
       chatFontOpacity: 90,
       roleplayReducedPaintEffects: false,
@@ -2029,6 +2039,8 @@ export const useUIStore = create<UIState>()(
       setScenePromptPreferences: (preferences) =>
         set({ scenePromptPreferences: normalizeScenePromptPreferences(preferences) }),
       setChatFontColor: (v) => set({ chatFontColor: v }),
+      setDefaultDialogueColorEnabled: (v) => set({ defaultDialogueColorEnabled: v }),
+      setDefaultDialogueColor: (v) => set({ defaultDialogueColor: v }),
       setChatChromeTextColor: (v) => set({ chatChromeTextColor: normalizeChatChromeTextColor(v) }),
       setChatFontOpacity: (v) => set({ chatFontOpacity: Math.max(0, Math.min(100, v)) }),
       setRoleplayReducedPaintEffects: (v) => set({ roleplayReducedPaintEffects: v }),
@@ -2079,6 +2091,8 @@ export const useUIStore = create<UIState>()(
           fontFamily: "",
           conversationMessageStyle: "classic" as ConversationMessageStyle,
           chatFontColor: "",
+          defaultDialogueColorEnabled: false,
+          defaultDialogueColor: "",
           chatChromeTextColor: "",
           chatFontOpacity: 90,
           roleplayReducedPaintEffects: false,
@@ -2182,7 +2196,7 @@ export const useUIStore = create<UIState>()(
     }),
     {
       name: "marinara-engine-ui",
-      version: 78,
+      version: 79,
       // Debounce localStorage writes to avoid sync I/O on every state change
       storage: createJSONStorage(() => {
         let timer: ReturnType<typeof setTimeout> | null = null;
@@ -2727,12 +2741,23 @@ export const useUIStore = create<UIState>()(
         if (version <= 77 && persisted.gameTextEffectsEnabled === undefined) {
           persisted.gameTextEffectsEnabled = true;
         }
+        if (version <= 78) {
+          if (persisted.defaultDialogueColorEnabled === undefined) {
+            persisted.defaultDialogueColorEnabled = false;
+          }
+          if (persisted.defaultDialogueColor === undefined) {
+            persisted.defaultDialogueColor = "";
+          }
+        }
         persisted.appAccentRgbMode = persisted.appAccentRgbMode === true;
         persisted.customCursorEnabled = persisted.customCursorEnabled !== false;
         persisted.professorMariSuggestionsEnabled = persisted.professorMariSuggestionsEnabled !== false;
         persisted.includeReasoningInExports = persisted.includeReasoningInExports === true;
         persisted.roleplayReducedPaintEffects = persisted.roleplayReducedPaintEffects === true;
         persisted.gameTextEffectsEnabled = persisted.gameTextEffectsEnabled !== false;
+        persisted.defaultDialogueColorEnabled = persisted.defaultDialogueColorEnabled === true;
+        persisted.defaultDialogueColor =
+          typeof persisted.defaultDialogueColor === "string" ? persisted.defaultDialogueColor : "";
         persisted.chatChromeTextColor = normalizeChatChromeTextColor(persisted.chatChromeTextColor);
         persisted.defaultRoleplayBackground = normalizeDefaultRoleplayBackground(persisted.defaultRoleplayBackground);
         delete persisted.trackerPanelWidth;
@@ -2858,6 +2883,8 @@ export const useUIStore = create<UIState>()(
         summaryPopoverSettings: state.summaryPopoverSettings,
         scenePromptPreferences: state.scenePromptPreferences,
         chatFontColor: state.chatFontColor,
+        defaultDialogueColorEnabled: state.defaultDialogueColorEnabled,
+        defaultDialogueColor: state.defaultDialogueColor,
         chatChromeTextColor: state.chatChromeTextColor,
         chatFontOpacity: state.chatFontOpacity,
         roleplayReducedPaintEffects: state.roleplayReducedPaintEffects,

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -28,6 +28,7 @@
     "buttplug": "4.0.1",
     "dotenv": "^16.6.1",
     "fastify": "^5.8.5",
+    "jsonrepair": "^3.15.0",
     "nanoid": "^5.1.11",
     "pdf-parse": "^2.4.5",
     "pino": "^9.14.0",

--- a/packages/server/src/routes/generate.routes.ts
+++ b/packages/server/src/routes/generate.routes.ts
@@ -84,7 +84,12 @@ import { createAppSettingsStorage } from "../services/storage/app-settings.stora
 import { buildLorebookSemanticEmbeddingsById, warmLorebookEntryEmbeddings } from "../services/lorebook/embeddings.js";
 import { applyRegexScriptsToPromptMessages } from "../services/regex/regex-application.js";
 import { createPromptOverridesStorage } from "../services/storage/prompt-overrides.storage.js";
-import { filterRelevantLorebooks, processLorebooks } from "../services/lorebook/index.js";
+import {
+  filterRelevantLorebooks,
+  processLorebooks,
+  scopeLorebookScanResultToCharacter,
+  type LorebookScanResult,
+} from "../services/lorebook/index.js";
 import {
   filterGameInternalAgentIds,
   resolveLorebookScopeExclusions,
@@ -482,6 +487,37 @@ import {
   buildSummaryWriteApprovalProposal,
   isAgentWriteApprovalEnvelope,
 } from "./generate/agent-write-approval.js";
+
+function scopeLorebookPromptMessagesForCharacter(
+  messages: GenerationPromptMessage[],
+  source: LorebookScanResult,
+  scoped: LorebookScanResult,
+): GenerationPromptMessage[] {
+  const worldInfoReplacements = [
+    [source.worldInfoBefore, scoped.worldInfoBefore],
+    [source.worldInfoAfter, scoped.worldInfoAfter],
+  ] as const;
+  const scopedDepthContents = new Set(scoped.depthEntries.map((entry) => entry.content));
+  const removedDepthContents = source.depthEntries
+    .map((entry) => entry.content)
+    .filter((content) => !scopedDepthContents.has(content));
+
+  return messages
+    .map((message) => {
+      if (message.contextKind === "history") return message;
+      let content = message.content;
+      for (const [currentValue, scopedValue] of worldInfoReplacements) {
+        if (currentValue && currentValue !== scopedValue) {
+          content = content.split(currentValue).join(scopedValue);
+        }
+      }
+      for (const removedContent of removedDepthContents) {
+        content = content.split(removedContent).join("");
+      }
+      return content === message.content ? message : { ...message, content };
+    })
+    .filter((message) => message.content.trim().length > 0);
+}
 
 const PROFESSOR_MARI_INTERNAL_CHAT_MARKER = "professor-mari";
 type ConversationContextMacroKey =
@@ -1566,6 +1602,8 @@ export async function generateRoutes(app: FastifyInstance) {
           : [];
         const lorebookScopeExclusions = resolveLorebookScopeExclusions(chatMode, chatMeta);
         let lorebookScanSnapshot: LorebookScanSnapshot = emptyLorebookScanSnapshot();
+        let lorebookPromptScanResult: LorebookScanResult | null = null;
+        const scopedLorebookScansByCharacterId = new Map<string, Promise<LorebookScanResult>>();
         let presetHandledLorebooks = false;
         let characterAdvancedPromptsInjected = false;
         const presetHasLorebookMarker = (sections: Array<{ isMarker: string; markerConfig: string | null }>) =>
@@ -1899,6 +1937,7 @@ export async function generateRoutes(app: FastifyInstance) {
           };
 
           const assembled = await assemblePrompt(assemblerInput);
+          lorebookPromptScanResult = assembled.lorebookScanResult ?? null;
           if (assembled.lorebookActivatedEntries || assembled.lorebookBudgetSkippedEntries) {
             lorebookScanSnapshot = {
               activatedEntries: assembled.lorebookActivatedEntries ?? [],
@@ -2344,6 +2383,7 @@ export async function generateRoutes(app: FastifyInstance) {
               generationTriggers: lorebookGenerationTriggers,
               resolveContent: resolvePromptMacrosForLorebook,
             });
+            lorebookPromptScanResult = lorebookResult;
             lorebookScanSnapshot = toLorebookScanSnapshot(lorebookResult);
             rememberKnowledgeRouterActivatedLorebookIds(
               knowledgeRouterActivatedLorebookEntryIds,
@@ -2412,6 +2452,7 @@ export async function generateRoutes(app: FastifyInstance) {
             generationTriggers: lorebookGenerationTriggers,
             resolveContent: resolvePromptMacrosForLorebook,
           });
+          lorebookPromptScanResult = lorebookResult;
           lorebookScanSnapshot = toLorebookScanSnapshot(lorebookResult);
           rememberKnowledgeRouterActivatedLorebookIds(
             knowledgeRouterActivatedLorebookEntryIds,
@@ -2781,6 +2822,7 @@ export async function generateRoutes(app: FastifyInstance) {
                 resolveContent: resolvePromptMacrosForLorebook,
               },
             );
+            lorebookPromptScanResult = lorebookResult;
             lorebookScanSnapshot = toLorebookScanSnapshot(lorebookResult);
             rememberKnowledgeRouterActivatedLorebookIds(
               knowledgeRouterActivatedLorebookEntryIds,
@@ -4845,6 +4887,30 @@ export async function generateRoutes(app: FastifyInstance) {
             gameAwareMessagesForGen,
             audienceCharacterIds,
           );
+          if (
+            usesIndividualGroupGeneration &&
+            deferCharacterMacros &&
+            promptCharacterIds.length > 1 &&
+            targetCharId &&
+            lorebookPromptScanResult
+          ) {
+            let scopedScanPromise = scopedLorebookScansByCharacterId.get(targetCharId);
+            if (!scopedScanPromise) {
+              scopedScanPromise = scopeLorebookScanResultToCharacter(
+                app.db,
+                lorebookPromptScanResult,
+                targetCharId,
+                lorebookGenerationTriggers,
+              );
+              scopedLorebookScansByCharacterId.set(targetCharId, scopedScanPromise);
+            }
+            const scopedLorebookScan = await scopedScanPromise;
+            gameAwareMessagesForGen = scopeLorebookPromptMessagesForCharacter(
+              gameAwareMessagesForGen,
+              lorebookPromptScanResult,
+              scopedLorebookScan,
+            );
+          }
           const targetContextBlock = targetCharId
             ? conversationContextBlocksByCharacterId.get(targetCharId)
             : undefined;

--- a/packages/server/src/services/lorebook/index.ts
+++ b/packages/server/src/services/lorebook/index.ts
@@ -18,6 +18,7 @@ import { createLorebooksStorage } from "../storage/lorebooks.storage.js";
 import { GAME_LOREBOOK_KEEPER_SOURCE_ID } from "./game-lorebook-scope.js";
 import {
   scanForActivatedEntries,
+  lorebookEntryPassesContextFilters,
   passesForcedEntryActivationGates,
   type ScanMessage,
   type ScanOptions,
@@ -48,6 +49,91 @@ export interface LorebookScanResult {
   updatedEntryStateOverrides?: Record<string, { ephemeral?: number | null; enabled?: boolean }>;
   /** Updated per-chat timing states for sticky/cooldown/delay. Caller should persist to chat metadata. */
   updatedEntryTimingStates?: Record<string, LorebookEntryTimingState>;
+}
+
+export function scopeLorebookScanResultToCharacterContext(
+  result: LorebookScanResult,
+  entries: LorebookEntry[],
+  options: {
+    characterId: string;
+    characterTags?: string[];
+    generationTriggers?: string[];
+  },
+): LorebookScanResult {
+  const entriesById = new Map(entries.map((entry) => [entry.id, entry]));
+  const activatedById = new Map(result.activatedEntries.map((entry) => [entry.id, entry]));
+  const scopedActivatedEntries: ActivatedEntry[] = [];
+
+  for (const entryId of result.activatedEntryIds) {
+    const storedEntry = entriesById.get(entryId);
+    const activation = activatedById.get(entryId);
+    if (!storedEntry || !activation) continue;
+    if (
+      !lorebookEntryPassesContextFilters(storedEntry, {
+        activeCharacterIds: [options.characterId],
+        activeCharacterTags: options.characterTags ?? [],
+        generationTriggers: options.generationTriggers ?? ["chat"],
+      })
+    ) {
+      continue;
+    }
+
+    scopedActivatedEntries.push({
+      entry: { ...storedEntry, content: activation.content },
+      rawContent: storedEntry.content,
+      matchedKeys: activation.matchedKeys,
+      activationSources: activation.activationSources,
+      injectionOrder: storedEntry.order,
+      sticky: activation.matchType === "sticky",
+    });
+  }
+
+  const processed = processActivatedEntries(scopedActivatedEntries, 0);
+  const scopedIds = new Set(scopedActivatedEntries.map((entry) => entry.entry.id));
+  const scopedSkippedEntries = result.budgetSkippedEntries.filter((entry) => {
+    const storedEntry = entriesById.get(entry.id);
+    return (
+      !!storedEntry &&
+      lorebookEntryPassesContextFilters(storedEntry, {
+        activeCharacterIds: [options.characterId],
+        activeCharacterTags: options.characterTags ?? [],
+        generationTriggers: options.generationTriggers ?? ["chat"],
+      })
+    );
+  });
+
+  return {
+    ...result,
+    ...processed,
+    activatedEntryIds: scopedActivatedEntries.map((entry) => entry.entry.id),
+    activatedEntries: result.activatedEntries.filter((entry) => scopedIds.has(entry.id)),
+    budgetSkippedEntries: scopedSkippedEntries,
+  };
+}
+
+export async function scopeLorebookScanResultToCharacter(
+  db: DB,
+  result: LorebookScanResult,
+  characterId: string,
+  generationTriggers: string[] = ["chat"],
+): Promise<LorebookScanResult> {
+  const lorebooks = createLorebooksStorage(db);
+  const characters = createCharactersStorage(db);
+  const entryIds = uniqueStrings([
+    ...result.activatedEntryIds,
+    ...result.budgetSkippedEntries.map((entry) => entry.id),
+  ]);
+  const entries = (await Promise.all(entryIds.map((entryId) => lorebooks.getEntry(entryId)))).filter(
+    (entry): entry is NonNullable<typeof entry> => !!entry,
+  ) as unknown as LorebookEntry[];
+  const character = await characters.getById(characterId);
+  const data = character ? safeJsonParse<CharacterData | null>((character as { data?: unknown }).data, null) : null;
+
+  return scopeLorebookScanResultToCharacterContext(result, entries, {
+    characterId,
+    characterTags: data ? readStringArray(data.tags) : [],
+    generationTriggers,
+  });
 }
 
 export type LorebookBudgetSkipReason = "lorebook" | "chat" | "both" | "location";

--- a/packages/server/src/services/lorebook/index.ts
+++ b/packages/server/src/services/lorebook/index.ts
@@ -123,9 +123,7 @@ export async function scopeLorebookScanResultToCharacter(
     ...result.activatedEntryIds,
     ...result.budgetSkippedEntries.map((entry) => entry.id),
   ]);
-  const entries = (await Promise.all(entryIds.map((entryId) => lorebooks.getEntry(entryId)))).filter(
-    (entry): entry is NonNullable<typeof entry> => !!entry,
-  ) as unknown as LorebookEntry[];
+  const entries = await lorebooks.listEligibleEntriesByIds(entryIds);
   const character = await characters.getById(characterId);
   const data = character ? safeJsonParse<CharacterData | null>((character as { data?: unknown }).data, null) : null;
 

--- a/packages/server/src/services/professor-mari/workspace-agent.service.ts
+++ b/packages/server/src/services/professor-mari/workspace-agent.service.ts
@@ -12,8 +12,10 @@ import type {
   ChatCompletionResult,
   ChatMessage,
   ChatOptions,
+  LLMToolDefinition,
   LLMUsage,
 } from "../llm/base-provider.js";
+import { parseTextualToolCalls } from "../llm/textual-tool-call-parser.js";
 import { createLLMProvider } from "../llm/provider-registry.js";
 import { getLocalSidecarProvider, LOCAL_SIDECAR_MODEL } from "../llm/local-sidecar.js";
 import { createChatsStorage } from "../storage/chats.storage.js";
@@ -309,6 +311,15 @@ const WORKSPACE_TOOL_DEFINITIONS: WorkspaceToolDefinition[] = [
     },
   },
 ];
+
+const WORKSPACE_TEXTUAL_TOOL_DEFINITIONS: LLMToolDefinition[] = WORKSPACE_TOOL_DEFINITIONS.map((tool) => ({
+  type: "function",
+  function: {
+    name: tool.name,
+    description: tool.description,
+    parameters: tool.parameters,
+  },
+}));
 
 function getPathEnvKey(env: NodeJS.ProcessEnv) {
   return Object.keys(env).find((key) => key.toLowerCase() === "path") ?? "PATH";
@@ -779,7 +790,7 @@ function createProviderForConnection(connection: WorkspaceConnection): BaseLLMPr
 
 function parseToolArgumentsValue(value: unknown): Record<string, unknown> {
   if (isRecord(value)) return value;
-  if (typeof value === "string") return parseJsonObject(value) ?? {};
+  if (typeof value === "string") return tryParseJsonPayload(value) ?? {};
   return {};
 }
 
@@ -798,25 +809,61 @@ function hasActionPayload(payload: Record<string, unknown>): boolean {
   );
 }
 
+function closeOpenJsonContainers(raw: string): string | null {
+  const stack: string[] = [];
+  let inString = false;
+  let escaped = false;
+  for (const char of raw) {
+    if (inString) {
+      if (escaped) escaped = false;
+      else if (char === "\\") escaped = true;
+      else if (char === '"') inString = false;
+      continue;
+    }
+    if (char === '"') {
+      inString = true;
+      continue;
+    }
+    if (char === "{" || char === "[") {
+      stack.push(char);
+      continue;
+    }
+    if (char !== "}" && char !== "]") continue;
+    const expected = char === "}" ? "{" : "[";
+    if (stack.pop() !== expected) return null;
+  }
+  if (inString) return null;
+  return (
+    raw +
+    stack
+      .reverse()
+      .map((opening) => (opening === "{" ? "}" : "]"))
+      .join("")
+  );
+}
+
+function repairJsonSyntax(raw: string): string {
+  return raw
+    .replace(/[‘’]/g, "'")
+    .replace(/[“”]/g, '"')
+    .replace(/([{,]\s*)([A-Za-z_][\w.-]*)\s*:/g, '$1"$2":')
+    .replace(/:\s*'([^']*)'/g, (_match, value: string) => `: ${JSON.stringify(value)}`)
+    .replace(/,\s*([\]}])/g, "$1");
+}
+
 function tryParseJsonPayload(raw: string): Record<string, unknown> | null {
-  try {
-    const parsed = JSON.parse(raw) as unknown;
-    return isRecord(parsed) ? parsed : null;
-  } catch {
-    // A single stray comma or smart-quote anywhere in the envelope (most often inside the
-    // optional `suggestions` array) would otherwise fail the entire { say, commands, stop }
-    // object, not just the chips - repair the common near-miss cases before giving up.
+  const repaired = repairJsonSyntax(raw);
+  const candidates = [raw, repaired, closeOpenJsonContainers(raw), closeOpenJsonContainers(repaired)];
+  for (const candidate of candidates) {
+    if (!candidate) continue;
     try {
-      const repaired = raw
-        .replace(/[‘’]/g, "'")
-        .replace(/[“”]/g, '"')
-        .replace(/,\s*([\]}])/g, "$1");
-      const parsed = JSON.parse(repaired) as unknown;
+      const parsed = JSON.parse(candidate) as unknown;
       return isRecord(parsed) ? parsed : null;
     } catch {
-      return null;
+      // Try the next conservative repair candidate.
     }
   }
+  return null;
 }
 
 function findJsonPayloadMatch(content: string): JsonPayloadMatch | null {
@@ -857,8 +904,20 @@ function findJsonPayloadMatch(content: string): JsonPayloadMatch | null {
         break;
       }
     }
+    const incompleteRaw = content.slice(start).trim();
+    const incompletePayload = tryParseJsonPayload(incompleteRaw);
+    if (incompletePayload && hasActionPayload(incompletePayload)) {
+      return { payload: incompletePayload, raw: incompleteRaw, start, end: content.length };
+    }
   }
   return null;
+}
+
+function isAppDataActionName(value: unknown): value is string {
+  return (
+    typeof value === "string" &&
+    /^(?:characters?|personas?|lorebooks?|themes?|agents?|presets?|promptpresets?)\./i.test(value.trim())
+  );
 }
 
 function rawJsonToolCalls(payload: Record<string, unknown>): unknown[] {
@@ -866,19 +925,52 @@ function rawJsonToolCalls(payload: Record<string, unknown>): unknown[] {
   if (Array.isArray(plural)) return plural;
   const single = payload.tool_call ?? payload.toolCall ?? payload.command;
   if (single !== undefined) return [single];
-  if (typeof payload.name === "string") return [payload];
+  if (typeof payload.name === "string" || isAppDataActionName(payload.action)) return [payload];
   return [];
 }
 
 function parseJsonCommandCallsFromPayload(payload: Record<string, unknown>): WorkspaceCommandCall[] {
   const calls: WorkspaceCommandCall[] = [];
   rawJsonToolCalls(payload).forEach((raw, index) => {
-    if (!isRecord(raw) || typeof raw.name !== "string" || !isWorkspaceToolName(raw.name)) return;
-    const args = parseToolArgumentsValue(raw.arguments ?? raw.args ?? raw.input ?? {});
-    const id = typeof raw.id === "string" && raw.id.trim() ? raw.id.trim() : newToolCallId(raw.name, index);
-    calls.push({ id, name: raw.name, arguments: args });
+    if (!isRecord(raw)) return;
+    const requestedName = typeof raw.name === "string" ? raw.name.trim() : "";
+    const directAction = isAppDataActionName(raw.action) ? raw.action.trim() : null;
+    const nameAsAction = isAppDataActionName(requestedName) ? requestedName : null;
+    const workspaceName = isWorkspaceToolName(requestedName)
+      ? requestedName
+      : directAction || nameAsAction
+        ? "app_data"
+        : null;
+    if (!workspaceName) return;
+
+    const parsedArguments = parseToolArgumentsValue(raw.arguments ?? raw.args ?? raw.input ?? {});
+    const argumentsWithRecoveredAction =
+      workspaceName === "app_data" && (directAction || nameAsAction)
+        ? {
+            ...(directAction ? raw : parsedArguments),
+            ...parsedArguments,
+            action: directAction ?? nameAsAction,
+          }
+        : parsedArguments;
+    const id = typeof raw.id === "string" && raw.id.trim() ? raw.id.trim() : newToolCallId(workspaceName, index);
+    calls.push({ id, name: workspaceName, arguments: argumentsWithRecoveredAction });
   });
   return calls;
+}
+
+function parseTextualWorkspaceCommandCalls(content: string): WorkspaceCommandCall[] {
+  return parseTextualToolCalls(content, WORKSPACE_TEXTUAL_TOOL_DEFINITIONS).flatMap((call) => {
+    const name = call.function.name;
+    if (!isWorkspaceToolName(name)) return [];
+    return [
+      {
+        id: call.id,
+        name,
+        arguments: parseToolArgumentsValue(call.function.arguments),
+        raw: content,
+      },
+    ];
+  });
 }
 
 function jsonPayloadVisibleText(payload: Record<string, unknown>): string {
@@ -908,7 +1000,7 @@ function parseXmlCommandCalls(content: string): WorkspaceCommandCall[] {
     const name = match[1];
     if (!name || !isWorkspaceToolName(name)) continue;
     const rawBody = match[2]?.trim() ?? "{}";
-    let args = parseJsonObject(rawBody) ?? {};
+    let args = tryParseJsonPayload(rawBody) ?? {};
     if (name === "bash" && !args.command && rawBody && !rawBody.startsWith("{")) args = { command: rawBody };
     calls.push({ id: newToolCallId(name, index), name, arguments: args, raw: match[0] });
   }
@@ -1003,12 +1095,14 @@ function stripWorkspaceCommands(content: string): string {
     .trim();
 }
 
-function parseAssistantWorkspaceAction(content: string): AssistantWorkspaceAction {
+export function parseAssistantWorkspaceAction(content: string): AssistantWorkspaceAction {
   const { content: contentWithoutJson, matches } = removeJsonActionFrames(content);
   const jsonCommands = matches.flatMap((match) => parseJsonCommandCallsFromPayload(match.payload));
+  const textualCommands = parseTextualWorkspaceCommandCalls(contentWithoutJson);
   // If JSON frames are present, treat all prose outside them as protocol leakage.
   // Visible text must come from the frame's say/message/final field only.
-  const inlineVisibleText = matches.length > 0 ? "" : stripWorkspaceCommands(contentWithoutJson);
+  const inlineVisibleText =
+    matches.length > 0 || textualCommands.length > 0 ? "" : stripWorkspaceCommands(contentWithoutJson);
   const frameVisibleText = matches
     .map((match) => jsonPayloadVisibleText(match.payload))
     .filter(Boolean)
@@ -1019,6 +1113,7 @@ function parseAssistantWorkspaceAction(content: string): AssistantWorkspaceActio
   const commands = dedupeWorkspaceCommandCalls([
     ...parseXmlCommandCalls(contentWithoutJson),
     ...jsonCommands,
+    ...textualCommands,
     ...parseBracketCommandCalls(contentWithoutJson),
   ]);
   const protocolValid = matches.length > 0;

--- a/packages/server/src/services/professor-mari/workspace-agent.service.ts
+++ b/packages/server/src/services/professor-mari/workspace-agent.service.ts
@@ -7,6 +7,7 @@ import { mkdir, readdir, readFile, stat, writeFile } from "node:fs/promises";
 import { delimiter, dirname, join, relative, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import type { FastifyInstance } from "fastify";
+import { jsonrepair } from "jsonrepair";
 import type {
   BaseLLMProvider,
   ChatCompletionResult,
@@ -842,18 +843,19 @@ function closeOpenJsonContainers(raw: string): string | null {
   );
 }
 
-function repairJsonSyntax(raw: string): string {
-  return raw
-    .replace(/[‘’]/g, "'")
-    .replace(/[“”]/g, '"')
-    .replace(/([{,]\s*)([A-Za-z_][\w.-]*)\s*:/g, '$1"$2":')
-    .replace(/:\s*'([^']*)'/g, (_match, value: string) => `: ${JSON.stringify(value)}`)
-    .replace(/,\s*([\]}])/g, "$1");
-}
-
 function tryParseJsonPayload(raw: string): Record<string, unknown> | null {
-  const repaired = repairJsonSyntax(raw);
-  const candidates = [raw, repaired, closeOpenJsonContainers(raw), closeOpenJsonContainers(repaired)];
+  let repaired: string | null = null;
+  try {
+    repaired = jsonrepair(raw);
+  } catch {
+    // Fall through to the conservative container-closing recovery.
+  }
+  const candidates = [
+    raw,
+    repaired,
+    closeOpenJsonContainers(raw),
+    repaired && closeOpenJsonContainers(repaired),
+  ];
   for (const candidate of candidates) {
     if (!candidate) continue;
     try {
@@ -882,6 +884,7 @@ function findJsonPayloadMatch(content: string): JsonPayloadMatch | null {
     let depth = 0;
     let inString = false;
     let escaped = false;
+    let closedWithoutAction = false;
     for (let index = start; index < content.length; index += 1) {
       const char = content[index];
       if (inString) {
@@ -901,9 +904,11 @@ function findJsonPayloadMatch(content: string): JsonPayloadMatch | null {
         const raw = content.slice(start, index + 1);
         const payload = tryParseJsonPayload(raw);
         if (payload && hasActionPayload(payload)) return { payload, raw, start, end: index + 1 };
+        closedWithoutAction = true;
         break;
       }
     }
+    if (closedWithoutAction) continue;
     const incompleteRaw = content.slice(start).trim();
     const incompletePayload = tryParseJsonPayload(incompleteRaw);
     if (incompletePayload && hasActionPayload(incompletePayload)) {
@@ -1100,9 +1105,8 @@ export function parseAssistantWorkspaceAction(content: string): AssistantWorkspa
   const jsonCommands = matches.flatMap((match) => parseJsonCommandCallsFromPayload(match.payload));
   const textualCommands = parseTextualWorkspaceCommandCalls(contentWithoutJson);
   // If JSON frames are present, treat all prose outside them as protocol leakage.
-  // Visible text must come from the frame's say/message/final field only.
-  const inlineVisibleText =
-    matches.length > 0 || textualCommands.length > 0 ? "" : stripWorkspaceCommands(contentWithoutJson);
+  // Textual calls have no visible-text field, so retain their surrounding prose.
+  const inlineVisibleText = matches.length > 0 ? "" : stripWorkspaceCommands(contentWithoutJson);
   const frameVisibleText = matches
     .map((match) => jsonPayloadVisibleText(match.payload))
     .filter(Boolean)

--- a/packages/server/src/services/prompt/assembler.ts
+++ b/packages/server/src/services/prompt/assembler.ts
@@ -220,6 +220,8 @@ export interface AssemblerOutput {
   lorebookActivatedEntries?: LorebookScanResult["activatedEntries"];
   /** Lorebook entries matched but excluded by token budgets while expanding lorebook markers. */
   lorebookBudgetSkippedEntries?: LorebookScanResult["budgetSkippedEntries"];
+  /** Full lorebook scan used to replace shared group lore with responder-scoped lore. */
+  lorebookScanResult?: LorebookScanResult;
   /** Agent types whose runtime data was consumed by enabled agent_data sections. */
   runtimeAgentTypesUsed?: string[];
 }
@@ -569,6 +571,7 @@ export async function assemblePrompt(input: AssemblerInput): Promise<AssemblerOu
       : {}),
     ...(markerCtx.lorebookScanResult
       ? {
+          lorebookScanResult: markerCtx.lorebookScanResult,
           lorebookActivatedEntries: markerCtx.lorebookScanResult.activatedEntries,
           lorebookBudgetSkippedEntries: markerCtx.lorebookScanResult.budgetSkippedEntries,
         }

--- a/packages/server/src/services/storage/lorebooks.storage.ts
+++ b/packages/server/src/services/storage/lorebooks.storage.ts
@@ -22,6 +22,7 @@ import {
   type UpdateLorebookEntryInput,
   type BulkUpdateLorebookEntriesInput,
   type CreateLorebookFolderInput,
+  type LorebookEntry,
   type UpdateLorebookFolderInput,
 } from "@marinara-engine/shared";
 import { collectEffectivelyDisabledFolderIds, collectFolderSubtreeIds } from "@marinara-engine/shared";
@@ -612,7 +613,7 @@ export function createLorebooksStorage(db: DB) {
     async listEligibleEntriesByIds(
       entryIds: string[],
       filters?: { excludedLorebookIds?: string[]; excludedSourceAgentIds?: string[] },
-    ) {
+    ): Promise<LorebookEntry[]> {
       const requestedIds = uniqueStrings(entryIds).slice(0, LIMITS.MAX_LOREBOOK_ENTRIES);
       if (requestedIds.length === 0) return [];
 
@@ -669,7 +670,9 @@ export function createLorebooksStorage(db: DB) {
             allowedBookIds.has(entry.lorebookId) &&
             (!entry.folderId || !disabledFolderIds.has(entry.folderId as string)),
         )
-        .sort((left, right) => (requestedOrder.get(left.id) ?? 0) - (requestedOrder.get(right.id) ?? 0));
+        .sort(
+          (left, right) => (requestedOrder.get(left.id) ?? 0) - (requestedOrder.get(right.id) ?? 0),
+        ) as unknown as LorebookEntry[];
     },
 
     /**

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -164,6 +164,9 @@ importers:
       fastify:
         specifier: ^5.8.5
         version: 5.8.5
+      jsonrepair:
+        specifier: ^3.15.0
+        version: 3.15.0
       nanoid:
         specifier: ^5.1.11
         version: 5.1.11
@@ -2943,6 +2946,10 @@ packages:
   jsonpointer@5.0.1:
     resolution: {integrity: sha512-p/nXbhSEcu3pZRdkW1OfJhpsVtW1gd4Wa1fnQc9YLiTfAjn0312eMKimbdIQzuZl9aa9xUGaRlP9T/CJE/ditQ==}
     engines: {node: '>=0.10.0'}
+
+  jsonrepair@3.15.0:
+    resolution: {integrity: sha512-wy8OTjwsJwQRnQJkKnMJJ9vcytRdBPAgIF/Hy6+s1dAj42BHMKiyL8JzEieIl3JY7idt8eyHwBWTO8mh/+mtwA==}
+    hasBin: true
 
   jwa@2.0.1:
     resolution: {integrity: sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==}
@@ -7057,6 +7064,8 @@ snapshots:
       graceful-fs: 4.2.11
 
   jsonpointer@5.0.1: {}
+
+  jsonrepair@3.15.0: {}
 
   jwa@2.0.1:
     dependencies:

--- a/scripts/regressions/prompt.regression.ts
+++ b/scripts/regressions/prompt.regression.ts
@@ -5567,6 +5567,17 @@ Use HTML sparingly and diegetically. Do not replace normal prose/dialogue unless
       );
       assert.equal(actionUsedAsToolName.commands[0]?.name, "app_data");
       assert.equal(actionUsedAsToolName.commands[0]?.arguments.action, "persona.create");
+
+      const textualCallWithProse = parseAssistantWorkspaceAction(
+        "Let me check that for you.\n<tool_call>mari status</tool_call>",
+      );
+      assert.equal(textualCallWithProse.commands.length, 1);
+      assert.match(textualCallWithProse.visibleText, /^Let me check that for you\./u);
+
+      const repairedProse = parseAssistantWorkspaceAction(
+        '{say: "I noticed, name: value in prose", commands: [], stop: true}',
+      );
+      assert.equal(repairedProse.visibleText, "I noticed, name: value in prose");
     },
   },
   {

--- a/scripts/regressions/prompt.regression.ts
+++ b/scripts/regressions/prompt.regression.ts
@@ -518,8 +518,12 @@ import {
   calibrateLorebookSimilarity,
   lorebookSimilarityBaseline,
 } from "../../packages/server/src/services/lorebook/embeddings.js";
-import { resolveAndBudgetActivatedLorebookEntries } from "../../packages/server/src/services/lorebook/index.js";
+import {
+  resolveAndBudgetActivatedLorebookEntries,
+  scopeLorebookScanResultToCharacterContext,
+} from "../../packages/server/src/services/lorebook/index.js";
 import { scanForActivatedEntries } from "../../packages/server/src/services/lorebook/keyword-scanner.js";
+import { parseAssistantWorkspaceAction } from "../../packages/server/src/services/professor-mari/workspace-agent.service.js";
 import { fitMessagesForModelAccess } from "../../packages/server/src/services/generation/model-access-policy.js";
 import {
   assemblePrompt,
@@ -5457,6 +5461,112 @@ Use HTML sparingly and diegetically. Do not replace normal prose/dialogue unless
       assert.match(system, /<character_tracker_history>/u);
       assert.match(system, /this list does not mean everyone is present now/u);
       assert.match(system, /"value":72/u);
+    },
+  },
+  {
+    name: "individual group lorebook filters are scoped to the responding character",
+    run() {
+      const makeEntry = (id: string, content: string, tag: string | null, order: number) =>
+        ({
+          id,
+          lorebookId: "book-pasta",
+          enabled: true,
+          constant: false,
+          selective: false,
+          keys: ["pasta"],
+          secondaryKeys: [],
+          selectiveLogic: "and",
+          useRegex: false,
+          matchWholeWords: false,
+          caseSensitive: false,
+          locked: false,
+          preventRecursion: false,
+          excludeRecursion: false,
+          delayUntilRecursion: false,
+          excludeFromVectorization: false,
+          embedding: null,
+          position: 0,
+          depth: 4,
+          role: "system",
+          order,
+          group: null,
+          groupWeight: 100,
+          probability: 100,
+          sticky: null,
+          cooldown: null,
+          delay: null,
+          activationConditions: [],
+          schedule: null,
+          characterFilterMode: "any",
+          characterFilterIds: [],
+          characterTagFilterMode: tag ? "include" : "any",
+          characterTagFilters: tag ? [tag] : [],
+          generationTriggerFilterMode: "any",
+          generationTriggerFilters: [],
+          additionalMatchingSources: [],
+          scanDepth: null,
+          content,
+          name: id,
+        }) as any;
+      const entries = [
+        makeEntry("generic-pasta", "Pasta is a food.", null, 0),
+        makeEntry("loves-pasta", "{{char}} loves pasta.", "loves_pasta", 1),
+        makeEntry("hates-pasta", "{{char}} hates pasta.", "hates_pasta", 2),
+      ];
+      const scanResult = {
+        worldInfoBefore: "Pasta is a food.\n\n{{char}} loves pasta.\n\n{{char}} hates pasta.",
+        worldInfoAfter: "",
+        depthEntries: [],
+        totalEntries: 3,
+        totalTokensEstimate: 16,
+        activatedEntryIds: entries.map((entry) => entry.id),
+        activatedEntries: entries.map((entry) => ({
+          id: entry.id,
+          content: entry.content,
+          matchedKeys: ["pasta"],
+          activationSources: ["keyword"],
+          matchType: "keyword",
+        })),
+        budgetSkippedEntries: [],
+      } as any;
+
+      const loverLore = scopeLorebookScanResultToCharacterContext(scanResult, entries, {
+        characterId: "lover",
+        characterTags: ["loves_pasta"],
+      });
+      assert.equal(loverLore.worldInfoBefore, "Pasta is a food.\n\n{{char}} loves pasta.");
+      assert.deepEqual(loverLore.activatedEntryIds, ["generic-pasta", "loves-pasta"]);
+
+      const haterLore = scopeLorebookScanResultToCharacterContext(scanResult, entries, {
+        characterId: "hater",
+        characterTags: ["hates_pasta"],
+      });
+      assert.equal(haterLore.worldInfoBefore, "Pasta is a food.\n\n{{char}} hates pasta.");
+      assert.deepEqual(haterLore.activatedEntryIds, ["generic-pasta", "hates-pasta"]);
+    },
+  },
+  {
+    name: "Professor Mari recovers malformed small-model app-data calls",
+    run() {
+      const missingEnvelopeClosers = parseAssistantWorkspaceAction(
+        '{"say":"","commands":[{"name":"app_data","arguments":{"action":"character.create","data":{"name":"Stheno Test"},"apply":true}}',
+      );
+      assert.equal(missingEnvelopeClosers.commands.length, 1);
+      assert.equal(missingEnvelopeClosers.commands[0]?.name, "app_data");
+      assert.equal(missingEnvelopeClosers.commands[0]?.arguments.action, "character.create");
+      assert.equal((missingEnvelopeClosers.commands[0]?.arguments.data as { name?: string })?.name, "Stheno Test");
+
+      const actionWithoutToolName = parseAssistantWorkspaceAction(
+        '{"say":"","commands":[{"action":"lorebook.create","data":{"name":"Recovered Lore"},"apply":true}],"stop":false}',
+      );
+      assert.equal(actionWithoutToolName.commands[0]?.name, "app_data");
+      assert.equal(actionWithoutToolName.commands[0]?.arguments.action, "lorebook.create");
+
+      const actionUsedAsToolName = parseAssistantWorkspaceAction(
+        '<|tool_call|>{"name":"app_data","arguments":{"action":"persona.create","data":{"name":"Recovered Persona"},"apply":true}}',
+      );
+      assert.equal(actionUsedAsToolName.commands[0]?.name, "app_data");
+      assert.equal(actionUsedAsToolName.commands[0]?.arguments.action, "persona.create");
     },
   },
   {


### PR DESCRIPTION
## Linked issue

Closes #3913
Closes #3909

The default dialogue color is a maintainer-requested follow-up added to this PR; it does not have a separate issue.

## Why this change

- Individual group generations build one shared prompt before the responding character is known. Character-tag lorebook filters were evaluated against the union of the whole roster, so responder-specific entries leaked into every character prompt.
- Small local models can return a recognizable but malformed Professor Mari app-data call. The runtime repaired the protocol by asking the model again instead of executing the recoverable command, which could lead to repeated generations. The unsafe Unix launcher `.env` sourcing reported in #3909 is already fixed on staging by #3814; this PR addresses the remaining Professor Mari failure path.
- Cards without their own dialogue highlight color had no user-selectable global fallback. Users should be able to choose one default while retaining per-character and per-persona overrides.

## What changed

- Preserve the shared lorebook activation, probability, and budget decision, then scope its selected entries to the actual responder before each Individual group generation.
- Keep unfiltered lore shared while enforcing character ID and character-tag include/exclude filters for Conversation and Roleplay Individual prompts.
- Expose the assembler lorebook scan so custom-preset prompt placement can be scoped without rebuilding or relocating user sections.
- Recover conservatively malformed JSON envelopes, direct app-data action shapes, action names used as tool names, and common textual tool-call wrappers.
- Keep the existing repeated-failure and maximum-round loop brakes in place.
- Add a persisted **Default Dialogue Color** switch and color picker under Appearance → Chat Text Color.
- Apply that fallback in Roleplay and Game dialogue only when the responding character/persona card has no dialogue color; card-level colors remain authoritative.
- Update character/persona color help text and add a browser regression for precedence, persistence, and disabling the fallback.
- Add deterministic regressions for the reported pasta-tag split and malformed Stheno-style command shapes.

## Validation

- [ ] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed `CONTRIBUTING.md`

Additional automated validation already run:

- `pnpm check`
- `pnpm --filter @marinara-engine/server lint`
- `pnpm regression:prompt`
- `node scripts/regressions/launcher-env.regression.mjs`
- Focused Playwright regression: default dialogue fallback and card override precedence
- Full Playwright suite: 74 passed and 48 skipped; two unrelated existing smoke failures reproduced independently (Noodle's duplicate account-menu accessible name and the Roleplay side-panel 70 ms animation timing assertion)
- `git diff --check`

### Manual verification notes

- Manual provider testing with L3-8B-Stheno-v3.2-IQ4_XS was not available. The parser recovery and prompt-scoping paths are covered by deterministic regressions.
- The dialogue color control and precedence behavior are covered in a real browser against an isolated temporary app data directory.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Version/release files updated (only if this PR includes a version bump)

The new Appearance control includes inline help and updates the character/persona Colors help copy. No release metadata changed.

## UI evidence (if applicable)

Automated browser coverage verifies the enabled fallback, card-level override, persisted preference value, and disabled state. No screenshot is attached.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Lorebook content is now more accurately tailored to the responding character in individual group conversations.
  * Improved support for recognizing workspace commands expressed in text, JSON, XML, and bracket-based formats.
  * Workspace actions can now be recovered from incomplete or imperfectly formatted command payloads.

* **Bug Fixes**
  * Reduced unrelated lorebook content being included in character-specific responses.
  * Improved reliability when processing malformed workspace command data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
