### PR TITLE
Refactor shared agent, prompt, and lorebook contracts

### DIFF
--- a/packages/client/src/components/chat/ChatSettingsDrawer.tsx
+++ b/packages/client/src/components/chat/ChatSettingsDrawer.tsx
@@ -1634,7 +1634,6 @@ export function ChatSettingsDrawer({
       const cfg = agentConfigsByType.get(id);
       const settings = mergeBuiltInAgentSettings(id, cfg?.settings);
       const promptTemplate = resolveAgentPromptTemplate({
-        agentType: id,
         promptTemplate: cfg?.promptTemplate || "",
         fallbackPromptTemplate: getDefaultAgentPrompt(id),
         settings,

--- a/packages/server/src/routes/generate.routes.ts
+++ b/packages/server/src/routes/generate.routes.ts
@@ -3188,7 +3188,6 @@ export async function generateRoutes(app: FastifyInstance) {
                 }
               : null,
           memory: {},
-          activatedLorebookEntries: null,
           writableLorebookIds: null,
           chatSummary: activeChatSummary,
           streaming: input.streaming,

--- a/packages/server/src/routes/generate/retry-agents-route.ts
+++ b/packages/server/src/routes/generate/retry-agents-route.ts
@@ -5,7 +5,6 @@ import {
   BUILT_IN_TOOLS,
   DEFAULT_AGENT_TOOLS,
   getDefaultAgentPrompt,
-  getBuiltInAgentDefaultPrompt,
   applyQuestUpdatesToPlayerStats,
   applyTrackerFieldLocksToGameStatePatch,
   getDefaultBuiltInAgentSettings,
@@ -434,10 +433,6 @@ function applyRetryMusicPlayerSource(
   };
 }
 
-function resolveRetryAgentRuntimePhase(_agentType: string, configuredPhase: string): string {
-  return normalizeAgentPhaseValue(configuredPhase);
-}
-
 function getRetryAgentFallbackPrompt(agentType: string, settings: Record<string, unknown>): string {
   if (agentType === "spotify" && musicAgentUsesYoutube(settings)) {
     return getDefaultAgentPrompt("youtube");
@@ -445,7 +440,7 @@ function getRetryAgentFallbackPrompt(agentType: string, settings: Record<string,
   if (agentType === "spotify" && musicAgentUsesCustom(settings)) {
     return getDefaultAgentPrompt("local-music");
   }
-  return getBuiltInAgentDefaultPrompt(agentType) || getDefaultAgentPrompt(agentType);
+  return getDefaultAgentPrompt(agentType);
 }
 
 function getGameImageStylePrompt(chat: any, chatMeta: Record<string, unknown>): string {
@@ -740,7 +735,6 @@ async function buildRetryAgentContext(args: {
             ...(personaContext.rpgStats ? { rpgStats: personaContext.rpgStats } : {}),
           }
         : null,
-    activatedLorebookEntries: null,
     writableLorebookIds: null,
     chatSummary: resolveRoleplayChatSummary(chatMode, chatMeta),
     streaming,
@@ -1280,7 +1274,6 @@ async function resolveRetryAgents(args: {
     settings = applyTextRewriteAgentChatSettings(cfg.type as string, settings, chatMeta);
     settings = applyKnowledgeAgentChatSettings(cfg.type as string, settings, chatMeta);
     const selectedPromptTemplate = resolveAgentPromptTemplate({
-      agentType: cfg.type as string,
       promptTemplate: normalizeProseGuardianPromptTemplate(cfg.type as string, cfg.promptTemplate),
       fallbackPromptTemplate: getRetryAgentFallbackPrompt(cfg.type as string, settings),
       settings,
@@ -1293,7 +1286,7 @@ async function resolveRetryAgents(args: {
         id: cfg.id,
         type: cfg.type,
         name: cfg.name,
-        phase: resolveRetryAgentRuntimePhase(cfg.type as string, cfg.phase as string),
+        phase: normalizeAgentPhaseValue(cfg.phase),
         promptTemplate: selectedPromptTemplate,
         connectionId: effectiveConnectionId,
         settings,
@@ -1354,7 +1347,6 @@ async function resolveRetryAgents(args: {
     settings = applyTextRewriteAgentChatSettings(builtIn.id, settings, chatMeta);
     settings = applyKnowledgeAgentChatSettings(builtIn.id, settings, chatMeta);
     const selectedPromptTemplate = resolveAgentPromptTemplate({
-      agentType: builtIn.id,
       promptTemplate: "",
       fallbackPromptTemplate: getRetryAgentFallbackPrompt(builtIn.id, settings),
       settings,
@@ -1367,7 +1359,7 @@ async function resolveRetryAgents(args: {
         id: `builtin:${builtIn.id}`,
         type: builtIn.id,
         name: builtIn.name,
-        phase: resolveRetryAgentRuntimePhase(builtIn.id, builtIn.phase),
+        phase: normalizeAgentPhaseValue(builtIn.phase),
         promptTemplate: selectedPromptTemplate,
         connectionId: builtInConnection.entry.connectionId,
         settings,

--- a/packages/server/src/services/agents/agent-executor.ts
+++ b/packages/server/src/services/agents/agent-executor.ts
@@ -24,7 +24,6 @@ import {
   normalizeTrackerHiddenFields,
   normalizeCustomAgentCapabilities,
   getDefaultAgentPrompt,
-  getBuiltInAgentDefaultPrompt,
   normalizeRpgStatPools,
   resolveMacros,
 } from "@marinara-engine/shared";
@@ -125,7 +124,7 @@ function musicDjUsesJsonOnlyProvider(config: Pick<AgentExecConfig, "type" | "set
 function getDefaultPromptForAgent(config: Pick<AgentExecConfig, "type" | "settings">): string {
   if (musicDjUsesYoutube(config)) return getDefaultAgentPrompt("youtube");
   if (musicDjUsesCustom(config)) return getDefaultAgentPrompt("local-music");
-  return getBuiltInAgentDefaultPrompt(config.type) || getDefaultAgentPrompt(config.type);
+  return getDefaultAgentPrompt(config.type);
 }
 
 function stringifyAgentSettingMacroValue(value: unknown): string {

--- a/packages/server/src/services/generation/agent-resolution.ts
+++ b/packages/server/src/services/generation/agent-resolution.ts
@@ -147,11 +147,15 @@ function applyMusicPlayerSourceToMusicDjSettings(
   };
 }
 
+function musicAgentUsesSource(settings: Record<string, unknown>, source: "youtube" | "custom"): boolean {
+  return settings.musicProvider === source || settings.musicPlayerSource === source;
+}
+
 function getAgentFallbackPrompt(agentType: string, settings: Record<string, unknown>): string {
-  if (agentType === "spotify" && (settings.musicProvider === "youtube" || settings.musicPlayerSource === "youtube")) {
+  if (agentType === "spotify" && musicAgentUsesSource(settings, "youtube")) {
     return getDefaultAgentPrompt("youtube");
   }
-  if (agentType === "spotify" && (settings.musicProvider === "custom" || settings.musicPlayerSource === "custom")) {
+  if (agentType === "spotify" && musicAgentUsesSource(settings, "custom")) {
     return getDefaultAgentPrompt("local-music");
   }
   return getDefaultAgentPrompt(agentType);

--- a/packages/server/src/services/generation/agent-resolution.ts
+++ b/packages/server/src/services/generation/agent-resolution.ts
@@ -2,7 +2,6 @@ import {
   BUILT_IN_AGENTS,
   DEFAULT_AGENT_TOOLS,
   getDefaultAgentPrompt,
-  getBuiltInAgentDefaultPrompt,
   getDefaultBuiltInAgentSettings,
   isBuiltInAgentRuntimeDisabled,
   isAgentConfigDeleted,
@@ -115,10 +114,6 @@ export type ResolvedAgentPipelineAgents = {
   agentConnectionWarnings: AgentConnectionWarning[];
 };
 
-function resolveAgentRuntimePhase(_agentType: string, configuredPhase: string): string {
-  return normalizeAgentPhaseValue(configuredPhase);
-}
-
 function parseAgentSettings(settings: unknown): Record<string, unknown> {
   if (!settings) return {};
   if (typeof settings === "string") {
@@ -159,7 +154,7 @@ function getAgentFallbackPrompt(agentType: string, settings: Record<string, unkn
   if (agentType === "spotify" && (settings.musicProvider === "custom" || settings.musicPlayerSource === "custom")) {
     return getDefaultAgentPrompt("local-music");
   }
-  return getBuiltInAgentDefaultPrompt(agentType) || getDefaultAgentPrompt(agentType);
+  return getDefaultAgentPrompt(agentType);
 }
 
 function resolveConnectionCustomParameters(connection: { defaultParameters?: unknown }): Record<string, unknown> {
@@ -375,7 +370,6 @@ export async function resolveAgentPipelineAgents({
       settings.enabledTools = [...DEFAULT_AGENT_TOOLS[cfg.type as string]!];
     }
     let selectedPromptTemplate = resolveAgentPromptTemplate({
-      agentType: cfg.type as string,
       promptTemplate: normalizeProseGuardianPromptTemplate(cfg.type as string, cfg.promptTemplate),
       fallbackPromptTemplate: getAgentFallbackPrompt(cfg.type as string, settings),
       settings,
@@ -435,7 +429,7 @@ export async function resolveAgentPipelineAgents({
       id: cfg.id,
       type: cfg.type,
       name: cfg.name,
-      phase: resolveAgentRuntimePhase(cfg.type as string, cfg.phase as string),
+      phase: normalizeAgentPhaseValue(cfg.phase),
       promptTemplate: selectedPromptTemplate,
       connectionId: effectiveConnectionId,
       settings,
@@ -533,7 +527,6 @@ export async function resolveAgentPipelineAgents({
       builtInSettings.enabledTools = [...DEFAULT_AGENT_TOOLS[builtIn.id]!];
     }
     let selectedPromptTemplate = resolveAgentPromptTemplate({
-      agentType: builtIn.id,
       promptTemplate: "",
       fallbackPromptTemplate: getAgentFallbackPrompt(builtIn.id, builtInSettings),
       settings: builtInSettings,
@@ -543,7 +536,7 @@ export async function resolveAgentPipelineAgents({
       id: `builtin:${builtIn.id}`,
       type: builtIn.id,
       name: builtIn.name,
-      phase: resolveAgentRuntimePhase(builtIn.id, builtIn.phase),
+      phase: normalizeAgentPhaseValue(builtIn.phase),
       promptTemplate: selectedPromptTemplate,
       connectionId: builtInConnectionId,
       settings: builtInSettings,

--- a/packages/shared/src/features/agents/agent-registry.ts
+++ b/packages/shared/src/features/agents/agent-registry.ts
@@ -11,10 +11,6 @@ export function getBuiltInAgentManifest(agentId: string): BuiltInAgentManifest |
   return BUILT_IN_AGENT_MANIFESTS.find((agent) => agent.id === agentId) ?? null;
 }
 
-export function getBuiltInAgentDefaultPrompt(agentId: string): string {
-  return getBuiltInAgentManifest(agentId)?.defaultPromptTemplate ?? "";
-}
-
 export function isBuiltInAgentRuntimeDisabled(agentId: string): boolean {
   return getBuiltInAgentManifest(agentId)?.runtimeDisabled === true;
 }

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -82,7 +82,6 @@ export * from "./constants/tracker-custom-field-icons.js";
 export * from "./features/agents/agent-manifest.types.js";
 export {
   BUILT_IN_AGENT_MANIFESTS,
-  getBuiltInAgentDefaultPrompt,
   isBuiltInAgentRuntimeDisabled,
 } from "./features/agents/agent-registry.js";
 export * from "./features/function-calls/tool-definitions.js";

--- a/packages/shared/src/schemas/lorebook.schema.ts
+++ b/packages/shared/src/schemas/lorebook.schema.ts
@@ -105,90 +105,53 @@ export const createLorebookFolderSchema = z.object({
   order: z.number().int().default(0),
 });
 
-export const updateLorebookFolderSchema = z.object({
-  name: z.string().min(1).max(200).optional(),
-  enabled: z.boolean().optional(),
-  parentFolderId: z.string().nullable().optional(),
-  order: z.number().int().optional(),
+export const updateLorebookFolderSchema = createLorebookFolderSchema.partial();
+
+const lorebookBaseSchema = z.object({
+  name: z.string().min(1).max(200),
+  description: z.string().default(""),
+  category: lorebookCategorySchema.default("uncategorized"),
+  imagePath: z.string().nullable().default(null),
+  scanDepth: z.number().int().min(0).default(2),
+  tokenBudget: z.number().int().min(0).default(2048),
+  entryLimit: z
+    .number()
+    .int()
+    .min(LIMITS.LOREBOOK_ENTRY_LIMIT_MIN)
+    .max(LIMITS.LOREBOOK_ENTRY_LIMIT_MAX)
+    .default(LIMITS.LOREBOOK_ENTRY_LIMIT_DEFAULT),
+  recursiveScanning: z.boolean().default(false),
+  maxRecursionDepth: z.number().int().min(1).max(10).default(3),
+  excludeFromVectorization: z.boolean().default(true),
+  vectorQueryDepth: z
+    .number()
+    .int()
+    .min(0)
+    .max(LIMITS.LOREBOOK_VECTOR_QUERY_DEPTH_MAX)
+    .default(LIMITS.LOREBOOK_VECTOR_QUERY_DEPTH_DEFAULT),
+  vectorScoreThreshold: z.number().min(0).max(1).default(LIMITS.LOREBOOK_VECTOR_SCORE_THRESHOLD_DEFAULT),
+  vectorMaxResults: z
+    .number()
+    .int()
+    .min(LIMITS.LOREBOOK_VECTOR_MAX_RESULTS_MIN)
+    .max(LIMITS.LOREBOOK_VECTOR_MAX_RESULTS_MAX)
+    .default(LIMITS.LOREBOOK_VECTOR_MAX_RESULTS_DEFAULT),
+  characterId: z.string().nullable().default(null),
+  characterIds: z.array(z.string()).default([]),
+  personaId: z.string().nullable().default(null),
+  personaIds: z.array(z.string()).default([]),
+  chatId: z.string().nullable().default(null),
+  isGlobal: z.boolean().default(false),
+  enabled: z.boolean().default(true),
+  scope: lorebookScopeSchema.default({ mode: "all", chatIds: [] }),
+  tags: z.array(z.string()).default([]),
+  generatedBy: lorebookGeneratedBySchema.default(null),
+  sourceAgentId: z.string().nullable().default(null),
 });
 
-export const createLorebookSchema = z
-  .object({
-    name: z.string().min(1).max(200),
-    description: z.string().default(""),
-    category: lorebookCategorySchema.default("uncategorized"),
-    imagePath: z.string().nullable().default(null),
-    scanDepth: z.number().int().min(0).default(2),
-    tokenBudget: z.number().int().min(0).default(2048),
-    entryLimit: z
-      .number()
-      .int()
-      .min(LIMITS.LOREBOOK_ENTRY_LIMIT_MIN)
-      .max(LIMITS.LOREBOOK_ENTRY_LIMIT_MAX)
-      .default(LIMITS.LOREBOOK_ENTRY_LIMIT_DEFAULT),
-    recursiveScanning: z.boolean().default(false),
-    maxRecursionDepth: z.number().int().min(1).max(10).default(3),
-    excludeFromVectorization: z.boolean().default(true),
-    vectorQueryDepth: z
-      .number()
-      .int()
-      .min(0)
-      .max(LIMITS.LOREBOOK_VECTOR_QUERY_DEPTH_MAX)
-      .default(LIMITS.LOREBOOK_VECTOR_QUERY_DEPTH_DEFAULT),
-    vectorScoreThreshold: z.number().min(0).max(1).default(LIMITS.LOREBOOK_VECTOR_SCORE_THRESHOLD_DEFAULT),
-    vectorMaxResults: z
-      .number()
-      .int()
-      .min(LIMITS.LOREBOOK_VECTOR_MAX_RESULTS_MIN)
-      .max(LIMITS.LOREBOOK_VECTOR_MAX_RESULTS_MAX)
-      .default(LIMITS.LOREBOOK_VECTOR_MAX_RESULTS_DEFAULT),
-    characterId: z.string().nullable().default(null),
-    characterIds: z.array(z.string()).default([]),
-    personaId: z.string().nullable().default(null),
-    personaIds: z.array(z.string()).default([]),
-    chatId: z.string().nullable().default(null),
-    isGlobal: z.boolean().default(false),
-    enabled: z.boolean().default(true),
-    scope: lorebookScopeSchema.default({ mode: "all", chatIds: [] }),
-    tags: z.array(z.string()).default([]),
-    generatedBy: lorebookGeneratedBySchema.default(null),
-    sourceAgentId: z.string().nullable().default(null),
-  })
-  .superRefine(addLorebookScopeConflictIssues);
+export const createLorebookSchema = lorebookBaseSchema.superRefine(addLorebookScopeConflictIssues);
 
-export const updateLorebookSchema = z
-  .object({
-    name: z.string().min(1).max(200).optional(),
-    description: z.string().optional(),
-    category: lorebookCategorySchema.optional(),
-    imagePath: z.string().nullable().optional(),
-    scanDepth: z.number().int().min(0).optional(),
-    tokenBudget: z.number().int().min(0).optional(),
-    entryLimit: z.number().int().min(LIMITS.LOREBOOK_ENTRY_LIMIT_MIN).max(LIMITS.LOREBOOK_ENTRY_LIMIT_MAX).optional(),
-    recursiveScanning: z.boolean().optional(),
-    maxRecursionDepth: z.number().int().min(1).max(10).optional(),
-    excludeFromVectorization: z.boolean().optional(),
-    vectorQueryDepth: z.number().int().min(0).max(LIMITS.LOREBOOK_VECTOR_QUERY_DEPTH_MAX).optional(),
-    vectorScoreThreshold: z.number().min(0).max(1).optional(),
-    vectorMaxResults: z
-      .number()
-      .int()
-      .min(LIMITS.LOREBOOK_VECTOR_MAX_RESULTS_MIN)
-      .max(LIMITS.LOREBOOK_VECTOR_MAX_RESULTS_MAX)
-      .optional(),
-    characterId: z.string().nullable().optional(),
-    characterIds: z.array(z.string()).optional(),
-    personaId: z.string().nullable().optional(),
-    personaIds: z.array(z.string()).optional(),
-    chatId: z.string().nullable().optional(),
-    isGlobal: z.boolean().optional(),
-    enabled: z.boolean().optional(),
-    scope: lorebookScopeSchema.optional(),
-    tags: z.array(z.string()).optional(),
-    generatedBy: lorebookGeneratedBySchema.optional(),
-    sourceAgentId: z.string().nullable().optional(),
-  })
-  .superRefine(addLorebookScopeConflictIssues);
+export const updateLorebookSchema = lorebookBaseSchema.partial().superRefine(addLorebookScopeConflictIssues);
 
 export const createLorebookEntrySchema = z.object({
   lorebookId: z.string(),
@@ -237,50 +200,7 @@ export const createLorebookEntrySchema = z.object({
   excludeFromVectorization: z.boolean().default(false),
 });
 
-export const updateLorebookEntrySchema = z.object({
-  name: z.string().min(1).max(200).optional(),
-  content: z.string().optional(),
-  description: z.string().optional(),
-  keys: z.array(z.string()).optional(),
-  secondaryKeys: z.array(z.string()).optional(),
-  enabled: z.boolean().optional(),
-  constant: z.boolean().optional(),
-  selective: z.boolean().optional(),
-  selectiveLogic: selectiveLogicSchema.optional(),
-  probability: z.number().nullable().optional(),
-  scanDepth: z.number().nullable().optional(),
-  matchWholeWords: z.boolean().optional(),
-  caseSensitive: z.boolean().optional(),
-  useRegex: z.boolean().optional(),
-  characterFilterMode: lorebookFilterModeSchema.optional(),
-  characterFilterIds: z.array(z.string()).optional(),
-  characterTagFilterMode: lorebookFilterModeSchema.optional(),
-  characterTagFilters: z.array(z.string()).optional(),
-  generationTriggerFilterMode: lorebookFilterModeSchema.optional(),
-  generationTriggerFilters: z.array(z.string()).optional(),
-  additionalMatchingSources: z.array(lorebookMatchingSourceSchema).optional(),
-  position: z.number().int().min(0).max(2).optional(),
-  depth: z.number().int().min(0).optional(),
-  order: z.number().int().optional(),
-  role: z.enum(["system", "user", "assistant"]).optional(),
-  sticky: z.number().nullable().optional(),
-  cooldown: z.number().nullable().optional(),
-  delay: z.number().nullable().optional(),
-  ephemeral: z.number().int().min(0).nullable().optional(),
-  group: z.string().optional(),
-  groupWeight: z.number().nullable().optional(),
-  folderId: z.string().nullable().optional(),
-  preventRecursion: z.boolean().optional(),
-  excludeRecursion: z.boolean().optional(),
-  delayUntilRecursion: z.boolean().optional(),
-  locked: z.boolean().optional(),
-  tag: z.string().optional(),
-  relationships: z.record(z.string()).optional(),
-  dynamicState: z.record(z.unknown()).optional(),
-  activationConditions: z.array(activationConditionSchema).optional(),
-  schedule: lorebookScheduleSchema.nullable().optional(),
-  excludeFromVectorization: z.boolean().optional(),
-});
+export const updateLorebookEntrySchema = createLorebookEntrySchema.omit({ lorebookId: true }).partial();
 
 const bulkUpdateLorebookEntryChangesSchema = updateLorebookEntrySchema
   .pick({

--- a/packages/shared/src/schemas/prompt.schema.ts
+++ b/packages/shared/src/schemas/prompt.schema.ts
@@ -111,21 +111,7 @@ export const createChoiceBlockSchema = z.object({
   optionSort: choiceOptionSortSchema.default("manual"),
 });
 
-export const updateChoiceBlockSchema = z.object({
-  variableName: z
-    .string()
-    .min(1)
-    .max(100)
-    .regex(/^\w+$/, "Variable name must be alphanumeric/underscores only")
-    .optional(),
-  question: z.string().min(1).max(500).optional(),
-  options: z.array(choiceOptionSchema).min(1).optional(),
-  multiSelect: z.boolean().optional(),
-  separator: z.string().max(20).optional(),
-  randomPick: z.boolean().optional(),
-  displayMode: choiceDisplayModeSchema.optional(),
-  optionSort: choiceOptionSortSchema.optional(),
-});
+export const updateChoiceBlockSchema = createChoiceBlockSchema.omit({ presetId: true }).partial();
 
 // ── Groups ──
 
@@ -137,12 +123,7 @@ export const createPromptGroupSchema = z.object({
   enabled: z.boolean().default(true),
 });
 
-export const updatePromptGroupSchema = z.object({
-  name: z.string().min(1).max(200).optional(),
-  parentGroupId: z.string().nullable().optional(),
-  order: z.number().int().optional(),
-  enabled: z.boolean().optional(),
-});
+export const updatePromptGroupSchema = createPromptGroupSchema.omit({ presetId: true }).partial();
 
 // ── Presets ──
 
@@ -192,18 +173,9 @@ export const createPromptSectionSchema = z.object({
   forbidOverrides: z.boolean().default(false),
 });
 
-export const updatePromptSectionSchema = z.object({
-  name: z.string().min(1).max(200).optional(),
-  content: z.string().optional(),
-  role: promptRoleSchema.optional(),
-  enabled: z.boolean().optional(),
-  groupId: z.string().nullable().optional(),
-  markerConfig: markerConfigSchema.nullable().optional(),
-  injectionPosition: injectionPositionSchema.optional(),
-  injectionDepth: z.number().int().min(0).optional(),
-  injectionOrder: z.number().int().optional(),
-  forbidOverrides: z.boolean().optional(),
-});
+export const updatePromptSectionSchema = createPromptSectionSchema
+  .omit({ presetId: true, identifier: true, isMarker: true })
+  .partial();
 
 // ── Exported input types ──
 

--- a/packages/shared/src/types/agent.ts
+++ b/packages/shared/src/types/agent.ts
@@ -241,7 +241,6 @@ export function normalizeAgentPromptTemplateSelectionMap(value: unknown): Record
 }
 
 export function resolveAgentPromptTemplate(input: {
-  agentType: string;
   promptTemplate?: string | null;
   fallbackPromptTemplate?: string | null;
   settings?: unknown;
@@ -387,8 +386,6 @@ export interface AgentContext {
   } | null;
   /** The agent's own persistent memory (key-value) */
   memory: Record<string, unknown>;
-  /** Lorebook entries activated for this generation (read context) */
-  activatedLorebookEntries: Array<{ id: string; name: string; content: string; tag: string }> | null;
   /** All lorebook IDs the agent can write to */
   writableLorebookIds: string[] | null;
   /** Chat summary text (if any) — helps agents avoid duplicating summarized info */
@@ -488,8 +485,6 @@ function toBuiltInAgentMeta(agent: BuiltInAgentManifest): BuiltInAgentMeta {
 }
 
 export const BUILT_IN_AGENTS: BuiltInAgentMeta[] = [];
-
-export const BUILT_IN_AGENT_RUN_INTERVAL_DEFAULTS: Record<string, number> = {};
 
 export const DEFAULT_AGENT_CONTEXT_SIZE = 5;
 export const DEFAULT_AGENT_MAX_TOKENS = 4096;
@@ -641,10 +636,8 @@ export const DEFAULT_AGENT_TOOLS: Record<string, string[]> = {};
 export function replaceBuiltInAgentDefinitions(manifests: readonly BuiltInAgentManifest[]): void {
   replaceBuiltInAgentManifestRegistry(manifests);
   BUILT_IN_AGENTS.splice(0, BUILT_IN_AGENTS.length, ...manifests.map(toBuiltInAgentMeta));
-  for (const key of Object.keys(BUILT_IN_AGENT_RUN_INTERVAL_DEFAULTS)) delete BUILT_IN_AGENT_RUN_INTERVAL_DEFAULTS[key];
   for (const key of Object.keys(DEFAULT_AGENT_TOOLS)) delete DEFAULT_AGENT_TOOLS[key];
   for (const agent of manifests) {
-    if (agent.runInterval !== undefined) BUILT_IN_AGENT_RUN_INTERVAL_DEFAULTS[agent.id] = agent.runInterval;
     DEFAULT_AGENT_TOOLS[agent.id] = [...(agent.defaultTools ?? [])];
   }
 }

--- a/scripts/regressions/prompt.regression.ts
+++ b/scripts/regressions/prompt.regression.ts
@@ -601,7 +601,6 @@ function makeRegressionAgentContext(overrides: Partial<AgentContext> = {}): Agen
     characters: [{ id: "char-dottore", name: "Dottore", description: "A precise researcher." }],
     persona: { name: "Mari", description: "The active user persona." },
     memory: {},
-    activatedLorebookEntries: null,
     writableLorebookIds: null,
     chatSummary: null,
     wrapFormat: "markdown",
@@ -2490,12 +2489,10 @@ const cases: RegressionCase[] = [
       );
       const settings = getDefaultBuiltInAgentSettings("illustrator");
       const illustrationPrompt = resolveAgentPromptTemplate({
-        agentType: "illustrator",
         promptTemplate: "BASE ILLUSTRATION PROMPT",
         settings,
       });
       const explicitBackgroundPrompt = resolveAgentPromptTemplate({
-        agentType: "illustrator",
         promptTemplate: "BASE ILLUSTRATION PROMPT",
         settings,
         selectedPromptTemplateId: "background",
@@ -3012,7 +3009,6 @@ Use HTML sparingly and diegetically. Do not replace normal prose/dialogue unless
           appearance: "Red dress.",
         },
         memory: {},
-        activatedLorebookEntries: null,
         writableLorebookIds: null,
         chatSummary: null,
       };

--- a/scripts/regressions/roleplay-streaming.regression.ts
+++ b/scripts/regressions/roleplay-streaming.regression.ts
@@ -309,7 +309,6 @@ const trackerBatchResults = await executeAgentBatch(
     characters: [],
     persona: null,
     memory: {},
-    activatedLorebookEntries: null,
     writableLorebookIds: null,
     chatSummary: null,
     streaming: false,


### PR DESCRIPTION
## Linked issue

Closes #3915

## Why this change

- Reduce duplicated validation rules and unused shared API surface in the Engine's agent, prompt, and lorebook host contracts.
- Keep create/update validation aligned while preserving existing runtime behavior.

## What changed

- Derive lorebook folder, lorebook, lorebook-entry, prompt-group, prompt-section, and choice-block update schemas from their create schemas.
- Remove the unused `AgentContext.activatedLorebookEntries` field, `resolveAgentPromptTemplate.agentType` argument, and write-only built-in run-interval mirror.
- Use the canonical built-in prompt resolver and call the canonical agent-phase normalizer directly.
- Update affected callers and regression fixtures for the reduced contracts.

## Validation

- [x] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [x] Above manual verification completed (describe below)
- [x] Read and followed `CONTRIBUTING.md`

### Manual verification notes

- `pnpm check` passed, including workspace lint/type checks and the production build.
- `pnpm regression:prompt` passed the affected prompt, lorebook, and agent cases, then exited non-zero on an unchanged Windows CRLF-sensitive assertion for the Prose Guardian documentation heading. The heading exists in both this branch and `origin/staging`.
- In Chromium at `localhost:5173`, verified default/non-default agent prompt selection and persistence; disposable prompt preset/group/section/choice CRUD; disposable lorebook/folder/entry CRUD and partial updates; cleanup of all disposable records; and an empty browser warning/error log.
- Provider-backed agent generation, container execution, mobile viewport, and light/dark visual checks were not run because this refactor does not change generated UI or provider behavior.

## Docs and release impact

- [x] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Version/release files updated (only if this PR includes a version bump)

No documentation, release metadata, or user-facing UI changes are required.

## UI evidence (if applicable)

Not applicable: this is a behavior-preserving contract and schema simplification with no visual changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved fallback prompt selection for agents, including music-focused agents.
  * Standardized agent phase handling for more consistent execution behavior.
  * Removed obsolete context data that could cause inconsistent agent processing.

* **Validation**
  * Updated lorebook and prompt update validation to stay aligned with their creation rules.
  * Preserved lorebook scope conflict checks while simplifying supported update payloads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->