### PR TITLE
Prevent duplicate generated posts and replies

### DIFF
--- a/packages/client/src/hooks/use-background-autonomous.ts
+++ b/packages/client/src/hooks/use-background-autonomous.ts
@@ -182,7 +182,9 @@ export function useBackgroundAutonomousPolling() {
                     },
                     abortController.signal,
                   )) {
-                    if ((_event as { type: string }).type === "token") receivedTokens = true;
+                    const eventType = (_event as { type: string }).type;
+                    if (eventType === "token") receivedTokens = true;
+                    else if (eventType === "generation_discarded") receivedTokens = false;
                   }
                 } finally {
                   if (useChatStore.getState().abortControllers.get(chat.id) === abortController) {

--- a/packages/client/src/hooks/use-generate.ts
+++ b/packages/client/src/hooks/use-generate.ts
@@ -255,15 +255,18 @@ function resolveCachedCharacterIdentity(
   };
 }
 
-function latestAssistantMessage(messages: Iterable<Message>): Message | null {
+function latestMessage(messages: Iterable<Message>): Message | null {
   let latest: Message | null = null;
   for (const message of messages) {
-    if (message.role !== "assistant") continue;
     if (!latest || new Date(message.createdAt).getTime() >= new Date(latest.createdAt).getTime()) {
       latest = message;
     }
   }
   return latest;
+}
+
+function latestAssistantMessage(messages: Iterable<Message>): Message | null {
+  return latestMessage([...messages].filter((message) => message.role === "assistant"));
 }
 
 function resolveNotifiedCharacterId(
@@ -288,27 +291,39 @@ function assistantMessageFingerprint(message: Message): string {
   ]);
 }
 
-type AssistantMessageSnapshot = {
+type MessageSnapshot = {
   cacheWasLoaded: boolean;
   fingerprints: ReadonlyMap<string, string>;
 };
 
-function snapshotAssistantMessages(qc: QueryClient, chatId: string): AssistantMessageSnapshot {
+function snapshotMessagesByRole(qc: QueryClient, chatId: string, role: Message["role"]): MessageSnapshot {
   const cached = qc.getQueryData<InfiniteData<Message[]>>(chatKeys.messages(chatId));
   return {
     cacheWasLoaded: cached !== undefined,
     fingerprints: new Map(
       (cached?.pages.flat() ?? [])
-        .filter((message) => message.role === "assistant")
+        .filter((message) => message.role === role)
         .map((message) => [message.id, assistantMessageFingerprint(message)]),
     ),
   };
 }
 
+function latestNewMessageByRole(
+  qc: QueryClient,
+  chatId: string,
+  role: Message["role"],
+  snapshot: MessageSnapshot,
+): Message | null {
+  if (!snapshot.cacheWasLoaded) return null;
+  return latestMessage(
+    getCachedMessages(qc, chatId).filter((message) => message.role === role && !snapshot.fingerprints.has(message.id)),
+  );
+}
+
 function latestChangedAssistantMessage(
   qc: QueryClient,
   chatId: string,
-  snapshot: AssistantMessageSnapshot,
+  snapshot: MessageSnapshot,
 ): Message | null {
   if (!snapshot.cacheWasLoaded) return null;
   return latestAssistantMessage(
@@ -317,6 +332,30 @@ function latestChangedAssistantMessage(
         message.role === "assistant" && snapshot.fingerprints.get(message.id) !== assistantMessageFingerprint(message),
     ),
   );
+}
+
+function createCacheOnlyPartialMessage(params: {
+  chatId: string;
+  role: Message["role"];
+  characterId: string | null;
+  content: string;
+  createdAt: string;
+}): Message {
+  return {
+    id: `__partial_${params.chatId}_${Date.now()}`,
+    chatId: params.chatId,
+    role: params.role,
+    characterId: params.characterId,
+    content: params.content,
+    activeSwipeIndex: 0,
+    extra: {
+      displayText: null,
+      isGenerated: params.role === "assistant",
+      tokenCount: null,
+      generationInfo: null,
+    },
+    createdAt: params.createdAt,
+  };
 }
 
 function replyNotificationTitle(mode: Chat["mode"] | undefined, characterName: string | null): string | undefined {
@@ -626,12 +665,12 @@ async function refreshMessagesAuthoritatively(
   await qc.cancelQueries({ queryKey: msgKey, exact: true });
 
   try {
-    await qc.refetchQueries({ queryKey: msgKey, exact: true, type: "all" });
+    await qc.refetchQueries({ queryKey: msgKey, exact: true, type: "all" }, { throwOnError: true });
     refetchSucceeded = true;
   } catch {
     try {
       await new Promise((resolve) => setTimeout(resolve, 250));
-      await qc.refetchQueries({ queryKey: msgKey, exact: true, type: "all" });
+      await qc.refetchQueries({ queryKey: msgKey, exact: true, type: "all" }, { throwOnError: true });
       refetchSucceeded = true;
     } catch {
       /* best-effort — keep any persisted messages we already have */
@@ -1130,7 +1169,12 @@ export function useGenerate() {
       // message after it is upserted into the cache. Cancel early so the
       // post-save refresh owns the query lifecycle for this generation.
       await qc.cancelQueries({ queryKey: chatKeys.messages(params.chatId), exact: true });
-      const assistantMessagesBeforeGeneration = snapshotAssistantMessages(qc, params.chatId);
+      const assistantMessagesBeforeGeneration = snapshotMessagesByRole(qc, params.chatId, "assistant");
+      const expectedPersistedRole: Message["role"] = params.impersonate ? "user" : "assistant";
+      const expectedMessagesBeforeGeneration =
+        expectedPersistedRole === "assistant"
+          ? assistantMessagesBeforeGeneration
+          : snapshotMessagesByRole(qc, params.chatId, expectedPersistedRole);
       if (params.regenerateMessageId) {
         forgetRecentMessageContentEdit(params.chatId, params.regenerateMessageId);
       }
@@ -1242,11 +1286,13 @@ export function useGenerate() {
       let passiveStreamRecovered = false;
       let spatialTransitionCommitted = false;
       let passiveStreamSettled = false;
-      let passiveRecoveryRefetchSucceeded = false;
+      let passiveRecoveryDurableMessage: Message | null = null;
       let typingActive = false;
       let typewriterDone: (() => void) | null = null;
       let rafId = 0;
       const persistedMessages = new Map<string, Message>();
+      let sawGroupTurn = false;
+      let currentGroupTurnSavedMessage: Message | null = null;
       let heldTextRewriteMessage: Message | null = null;
       let holdingTextRewrite = false;
       let gameStatePatchAnchor: { messageId: string; swipeIndex: number } | null = null;
@@ -1840,6 +1886,7 @@ export function useGenerate() {
 
             case "group_turn": {
               const turn = event.data as { characterId: string; characterName: string; index: number };
+              sawGroupTurn = true;
               leadingSpeakerPrefixFilter.addLabels([turn.characterName]);
 
               // If this isn't the first character, flush the previous one's content
@@ -1847,13 +1894,13 @@ export function useGenerate() {
                 flushLeadingSpeakerPrefix();
                 // Drain typewriter for the previous character (only if streaming)
                 await waitForTypewriterDrain();
-                const previousGroupMessage = latestAssistantMessage(persistedMessages.values());
+                const previousGroupMessage = currentGroupTurnSavedMessage;
 
                 // Pick up the just-saved message from the previous character
                 await refreshMessagesAuthoritatively(qc, params.chatId, persistedMessages.values());
                 // Increment unread if user navigated away during group generation
                 const activeNow = useChatStore.getState().activeChatId;
-                if (activeNow !== params.chatId) {
+                if (previousGroupMessage && activeNow !== params.chatId) {
                   useChatStore.getState().incrementUnread(params.chatId);
                   const identity = resolveCachedCharacterIdentity(
                     qc,
@@ -1893,6 +1940,7 @@ export function useGenerate() {
               } else {
                 setStreamedMessageId(params.chatId, null);
               }
+              currentGroupTurnSavedMessage = null;
 
               if (streamingEnabled) setStreamCommitted(params.chatId, false);
               if (isActiveChat()) setStreamingCharacterId(turn.characterId);
@@ -2071,7 +2119,14 @@ export function useGenerate() {
             }
 
             case "generation_discarded": {
-              receivedContent = false;
+              const discarded = event.data as { characterId?: unknown } | null;
+              const discardedCharacterId =
+                discarded && typeof discarded.characterId === "string" ? discarded.characterId : null;
+              if (discardedCharacterId) {
+                completeQueuedResponse(params.chatId, discardedCharacterId);
+              }
+              currentGroupTurnSavedMessage = null;
+              receivedContent = latestAssistantMessage(persistedMessages.values()) !== null;
               replaceGeneratedContentWithTypewriter("");
               if (!params.autonomous) {
                 toast.info("The model repeated its previous message, so it was not posted.");
@@ -2084,6 +2139,7 @@ export function useGenerate() {
               const savedMessage = event.data as Message;
               if (savedMessage.role === "assistant") {
                 completeQueuedResponse(params.chatId, savedMessage.characterId);
+                currentGroupTurnSavedMessage = savedMessage;
               }
               await qc.cancelQueries({ queryKey: chatKeys.messages(params.chatId), exact: true });
               persistedMessages.set(savedMessage.id, savedMessage);
@@ -2573,11 +2629,22 @@ export function useGenerate() {
           const settled = await waitForServerGenerationToSettle(params.chatId, abortController.signal);
           passiveStreamSettled = settled;
           if (!abortController.signal.aborted) {
-            passiveRecoveryRefetchSucceeded = await refreshMessagesAuthoritatively(
+            const recoveryRefetchSucceeded = await refreshMessagesAuthoritatively(
               qc,
               params.chatId,
               persistedMessages.values(),
             );
+            if (recoveryRefetchSucceeded) {
+              passiveRecoveryDurableMessage = latestNewMessageByRole(
+                qc,
+                params.chatId,
+                expectedPersistedRole,
+                expectedMessagesBeforeGeneration,
+              );
+              if (passiveRecoveryDurableMessage) {
+                persistedMessages.set(passiveRecoveryDurableMessage.id, passiveRecoveryDurableMessage);
+              }
+            }
             if (!settled) {
               toast.info(
                 "Generation is still finishing in the background. Refresh the chat in a moment if it has not appeared.",
@@ -2660,7 +2727,12 @@ export function useGenerate() {
         // increment unread badge + play notification sound so they know.
         // Only notify if actual content was produced (skip offline/error cases).
         const currentActive = useChatStore.getState().activeChatId;
-        if (receivedContent && currentActive !== params.chatId) {
+        const hasDurableAssistantReply = latestAssistantMessage(persistedMessages.values()) !== null;
+        const notificationEligibleContent =
+          receivedContent &&
+          (!passiveStreamRecovered || hasDurableAssistantReply) &&
+          (!sawGroupTurn || currentGroupTurnSavedMessage !== null);
+        if (notificationEligibleContent && currentActive !== params.chatId) {
           useChatStore.getState().incrementUnread(params.chatId);
           // Show floating avatar notification bubble — look up character from cache
           const chatList = qc.getQueryData<Chat[]>(chatKeys.list());
@@ -2721,22 +2793,14 @@ export function useGenerate() {
             ? null
             : (params.forCharacterId ?? useChatStore.getState().streamingCharacterId ?? null);
           if (passiveStreamRecovered) {
-            if (!passiveRecoveryRefetchSucceeded) {
-              unpersistedPartialMessage = {
-                id: `__partial_${params.chatId}_${Date.now()}`,
+            if (!passiveRecoveryDurableMessage) {
+              unpersistedPartialMessage = createCacheOnlyPartialMessage({
                 chatId: params.chatId,
                 role: partialRole,
                 characterId: partialCharacterId,
                 content: partialContent,
-                activeSwipeIndex: 0,
-                extra: {
-                  displayText: null,
-                  isGenerated: !params.impersonate,
-                  tokenCount: null,
-                  generationInfo: null,
-                },
                 createdAt,
-              };
+              });
             }
           } else {
             try {
@@ -2754,21 +2818,13 @@ export function useGenerate() {
                 "[use-generate] Failed to persist stopped partial message; keeping cache-only fallback",
                 error,
               );
-              unpersistedPartialMessage = {
-                id: `__partial_${params.chatId}_${Date.now()}`,
+              unpersistedPartialMessage = createCacheOnlyPartialMessage({
                 chatId: params.chatId,
                 role: partialRole,
                 characterId: partialCharacterId,
                 content: partialContent,
-                activeSwipeIndex: 0,
-                extra: {
-                  displayText: null,
-                  isGenerated: !params.impersonate,
-                  tokenCount: null,
-                  generationInfo: null,
-                },
                 createdAt,
-              };
+              });
             }
           }
         }
@@ -2839,7 +2895,8 @@ export function useGenerate() {
           !abortController.signal.aborted &&
           !params.impersonate &&
           !params.turnGameBots &&
-          ((sawDoneEvent && receivedContent) || passiveStreamSettled);
+          ((sawDoneEvent && receivedContent) ||
+            (passiveStreamSettled && passiveRecoveryDurableMessage?.role === "assistant"));
         if (completedReply) {
           const notifiedMessage =
             latestAssistantMessage(persistedForRefresh) ??

--- a/packages/client/src/hooks/use-generate.ts
+++ b/packages/client/src/hooks/use-generate.ts
@@ -2071,6 +2071,9 @@ export function useGenerate() {
                   };
                   rememberContinuedMessageContent(updatedMessage);
                   persistedMessages.set(updatedMessage.id, updatedMessage);
+                  if (currentGroupTurnSavedMessage?.id === updatedMessage.id) {
+                    currentGroupTurnSavedMessage = updatedMessage;
+                  }
                   // Keep the final rewritten text as the live stream until the
                   // full generation lifecycle finishes. The durable row is
                   // primed during final cleanup so there is no full-text flash.
@@ -2102,6 +2105,9 @@ export function useGenerate() {
                     };
                     rememberContinuedMessageContent(updatedMessage);
                     persistedMessages.set(updatedMessage.id, updatedMessage);
+                    if (currentGroupTurnSavedMessage?.id === updatedMessage.id) {
+                      currentGroupTurnSavedMessage = updatedMessage;
+                    }
                     upsertPersistedMessages(qc, params.chatId, [updatedMessage]);
                   }
                 }

--- a/packages/client/src/hooks/use-generate.ts
+++ b/packages/client/src/hooks/use-generate.ts
@@ -649,6 +649,7 @@ async function refreshMessagesAuthoritatively(
     }
   }
   preserveRecentMessageContentEditsInCache(qc, chatId);
+  return refetchSucceeded;
 }
 
 function parseChatMetadata(metadata: Chat["metadata"] | string | null | undefined): Record<string, unknown> {
@@ -1241,6 +1242,7 @@ export function useGenerate() {
       let passiveStreamRecovered = false;
       let spatialTransitionCommitted = false;
       let passiveStreamSettled = false;
+      let passiveRecoveryRefetchSucceeded = false;
       let typingActive = false;
       let typewriterDone: (() => void) | null = null;
       let rafId = 0;
@@ -2068,6 +2070,15 @@ export function useGenerate() {
               break;
             }
 
+            case "generation_discarded": {
+              receivedContent = false;
+              replaceGeneratedContentWithTypewriter("");
+              if (!params.autonomous) {
+                toast.info("The model repeated its previous message, so it was not posted.");
+              }
+              break;
+            }
+
             case "message_saved": {
               flushLeadingSpeakerPrefix();
               const savedMessage = event.data as Message;
@@ -2562,7 +2573,11 @@ export function useGenerate() {
           const settled = await waitForServerGenerationToSettle(params.chatId, abortController.signal);
           passiveStreamSettled = settled;
           if (!abortController.signal.aborted) {
-            await refreshMessagesAuthoritatively(qc, params.chatId, persistedMessages.values());
+            passiveRecoveryRefetchSucceeded = await refreshMessagesAuthoritatively(
+              qc,
+              params.chatId,
+              persistedMessages.values(),
+            );
             if (!settled) {
               toast.info(
                 "Generation is still finishing in the background. Refresh the chat in a moment if it has not appeared.",
@@ -2705,36 +2720,56 @@ export function useGenerate() {
           const partialCharacterId = params.impersonate
             ? null
             : (params.forCharacterId ?? useChatStore.getState().streamingCharacterId ?? null);
-          try {
-            const created = await api.post<Message>(`/chats/${params.chatId}/messages`, {
-              role: partialRole,
-              characterId: partialCharacterId,
-              content: partialContent,
-              createdAt,
-              updatedAt: createdAt,
-            });
-            unpersistedPartialMessage = created;
-            persistedMessages.set(created.id, created);
-          } catch (error) {
-            console.warn(
-              "[use-generate] Failed to persist stopped partial message; keeping cache-only fallback",
-              error,
-            );
-            unpersistedPartialMessage = {
-              id: `__partial_${params.chatId}_${Date.now()}`,
-              chatId: params.chatId,
-              role: partialRole,
-              characterId: partialCharacterId,
-              content: partialContent,
-              activeSwipeIndex: 0,
-              extra: {
-                displayText: null,
-                isGenerated: !params.impersonate,
-                tokenCount: null,
-                generationInfo: null,
-              },
-              createdAt,
-            };
+          if (passiveStreamRecovered) {
+            if (!passiveRecoveryRefetchSucceeded) {
+              unpersistedPartialMessage = {
+                id: `__partial_${params.chatId}_${Date.now()}`,
+                chatId: params.chatId,
+                role: partialRole,
+                characterId: partialCharacterId,
+                content: partialContent,
+                activeSwipeIndex: 0,
+                extra: {
+                  displayText: null,
+                  isGenerated: !params.impersonate,
+                  tokenCount: null,
+                  generationInfo: null,
+                },
+                createdAt,
+              };
+            }
+          } else {
+            try {
+              const created = await api.post<Message>(`/chats/${params.chatId}/messages`, {
+                role: partialRole,
+                characterId: partialCharacterId,
+                content: partialContent,
+                createdAt,
+                updatedAt: createdAt,
+              });
+              unpersistedPartialMessage = created;
+              persistedMessages.set(created.id, created);
+            } catch (error) {
+              console.warn(
+                "[use-generate] Failed to persist stopped partial message; keeping cache-only fallback",
+                error,
+              );
+              unpersistedPartialMessage = {
+                id: `__partial_${params.chatId}_${Date.now()}`,
+                chatId: params.chatId,
+                role: partialRole,
+                characterId: partialCharacterId,
+                content: partialContent,
+                activeSwipeIndex: 0,
+                extra: {
+                  displayText: null,
+                  isGenerated: !params.impersonate,
+                  tokenCount: null,
+                  generationInfo: null,
+                },
+                createdAt,
+              };
+            }
           }
         }
         const persistedForRefresh = [

--- a/packages/server/src/routes/generate.routes.ts
+++ b/packages/server/src/routes/generate.routes.ts
@@ -5918,11 +5918,10 @@ export async function generateRoutes(app: FastifyInstance) {
             );
             fullResponse = "";
             if (!holdForTextRewrite) sendSseEvent(reply, { type: "content_replace", data: "" });
-            sendSseEvent(reply, { type: "generation_discarded", data: { reason: "duplicate_response" } });
-            if (input.autonomous) {
-              recordAssistantActivity(input.chatId, targetCharId ?? undefined);
-              await recordSavedAutonomousGeneration(targetCharId);
-            }
+            sendSseEvent(reply, {
+              type: "generation_discarded",
+              data: { reason: "duplicate_response", characterId: targetCharId },
+            });
             return null;
           }
 
@@ -8301,9 +8300,34 @@ export async function generateRoutes(app: FastifyInstance) {
                       messageId,
                     );
                   }
+                  const rewriteCharacterId =
+                    typeof (lastSavedMsg as { characterId?: unknown } | null)?.characterId === "string"
+                      ? (lastSavedMsg as { characterId: string }).characterId
+                      : null;
+                  const repeatsPriorConversationResponse =
+                    rewriteAllowed &&
+                    !strictEditNeeded &&
+                    chatMode === "conversation" &&
+                    !input.impersonate &&
+                    !input.regenerateMessageId &&
+                    !input.continueMessageId &&
+                    editedText.trim().length > 0 &&
+                    isRepeatedConversationResponse(
+                      await chats.listMessages(input.chatId),
+                      rewriteCharacterId,
+                      editedText,
+                      { excludeMessageId: messageId },
+                    );
+                  if (repeatsPriorConversationResponse) {
+                    logger.warn(
+                      { chatId: input.chatId, characterId: rewriteCharacterId, messageId },
+                      "[text-rewrite] Skipping custom rewrite because it repeated a prior Conversation response",
+                    );
+                  }
                   const changedMessage =
                     rewriteAllowed &&
                     !droppedProtectedMarkup &&
+                    !repeatsPriorConversationResponse &&
                     editedText.trim().length > 0 &&
                     editedText !== currentResponseForRewrite;
                   if (changedMessage) {

--- a/packages/server/src/routes/generate.routes.ts
+++ b/packages/server/src/routes/generate.routes.ts
@@ -154,6 +154,7 @@ import {
 import { buildIntentCooldownPatch, isMessageIntent } from "../services/conversation/intent.service.js";
 import { buildImpersonateInstruction } from "../services/conversation/impersonate-prompt.js";
 import {
+  isRepeatedConversationResponse,
   stripConversationPromptTimestamps,
   stripConversationResponseEnvelope,
 } from "../services/conversation/transcript-sanitize.js";
@@ -256,6 +257,7 @@ import { resolveConversationPresenceRuntime } from "./generate/conversation-pres
 import { resolveProfessorMariPromptContext } from "./generate/professor-mari-prompt-context.js";
 import {
   appendToFirstSystemMessage,
+  CONVERSATION_NO_REPEAT_INSTRUCTION,
   conversationPromptHistoryContent,
   formatConversationGroupOutputFormat,
   latestHistoryUserContent,
@@ -2167,6 +2169,7 @@ export async function generateRoutes(app: FastifyInstance) {
               ].join("\n"),
             );
           }
+          conversationInstructionParts.push(CONVERSATION_NO_REPEAT_INSTRUCTION);
 
           let conversationSystemPrompt = formatConversationInstructionsForWrap(
             conversationInstructionParts.filter((part) => part.trim().length > 0).join("\n"),
@@ -5899,6 +5902,27 @@ export async function generateRoutes(app: FastifyInstance) {
             reply.raw.write(
               `data: ${JSON.stringify({ type: "error", data: "The AI returned an empty response. Try sending your message again." })}\n\n`,
             );
+            return null;
+          }
+
+          if (
+            chatMode === "conversation" &&
+            !input.impersonate &&
+            !input.regenerateMessageId &&
+            !input.continueMessageId &&
+            isRepeatedConversationResponse(await chats.listMessages(input.chatId), targetCharId, fullResponse)
+          ) {
+            logger.warn(
+              { chatId: input.chatId, characterId: targetCharId, responseLength: fullResponse.length },
+              "[generate] Discarding repeated Conversation response",
+            );
+            fullResponse = "";
+            if (!holdForTextRewrite) sendSseEvent(reply, { type: "content_replace", data: "" });
+            sendSseEvent(reply, { type: "generation_discarded", data: { reason: "duplicate_response" } });
+            if (input.autonomous) {
+              recordAssistantActivity(input.chatId, targetCharId ?? undefined);
+              await recordSavedAutonomousGeneration(targetCharId);
+            }
             return null;
           }
 

--- a/packages/server/src/routes/generate/conversation-prompt-formatting.ts
+++ b/packages/server/src/routes/generate/conversation-prompt-formatting.ts
@@ -5,6 +5,8 @@ import { wrapContent } from "../../services/prompt/format-engine.js";
 import { parseExtra } from "./generate-route-utils.js";
 
 export const CONVERSATION_GROUP_NAME_PREFIX_INSTRUCTION = "Remember to prefix messages with `Name: message`!";
+export const CONVERSATION_NO_REPEAT_INSTRUCTION =
+  "Do not repeat a message you already sent in the recent conversation. If your first draft repeats one, write a genuinely different response.";
 
 export function formatConversationGroupOutputFormat(args: {
   wrapFormat: WrapFormat;

--- a/packages/server/src/routes/generate/dry-run-route.ts
+++ b/packages/server/src/routes/generate/dry-run-route.ts
@@ -86,6 +86,7 @@ import {
   type PromptAttachment,
 } from "../generate/generate-route-utils.js";
 import { buildGenerationPromptPresetCandidates, type PromptPresetCandidateSource } from "./prompt-preset-selection.js";
+import { CONVERSATION_NO_REPEAT_INSTRUCTION } from "./conversation-prompt-formatting.js";
 import { createGameStateStorage, type GameStateVisibleAnchor } from "../../services/storage/game-state.storage.js";
 import { buildCommittedTrackerContextBlock } from "../../services/generation/committed-tracker-context.js";
 import { logger } from "../../lib/logger.js";
@@ -1360,7 +1361,13 @@ export async function registerDryRunRoute(app: FastifyInstance) {
         conversationPromptTemplate.replace(/\{\{charName\}\}/g, charNameList).replace(/\{\{userName\}\}/g, personaName),
       );
       finalMessages = [
-        { role: "system", content: formatConversationInstructionsForWrap(renderedConversationPrompt, wrapFormat) },
+        {
+          role: "system",
+          content: formatConversationInstructionsForWrap(
+            `${renderedConversationPrompt}\n${CONVERSATION_NO_REPEAT_INSTRUCTION}`,
+            wrapFormat,
+          ),
+        },
         ...finalMessages,
       ];
     }

--- a/packages/server/src/services/conversation/server-autonomous-scheduler.service.ts
+++ b/packages/server/src/services/conversation/server-autonomous-scheduler.service.ts
@@ -85,8 +85,9 @@ function shouldConsiderChat(chat: RawChat): boolean {
   return meta.autonomousMessages === true && meta.sceneStatus !== "active";
 }
 
-function parseSsePayload(payload: string): { done: boolean; error: string | null } {
+function parseSsePayload(payload: string): { done: boolean; discarded: boolean; error: string | null } {
   let done = false;
+  let discarded = false;
   let error: string | null = null;
 
   for (const block of payload.split(/\n\n/u)) {
@@ -99,6 +100,7 @@ function parseSsePayload(payload: string): { done: boolean; error: string | null
     try {
       const event = JSON.parse(line) as { type?: string; data?: unknown };
       if (event.type === "done") done = true;
+      if (event.type === "generation_discarded") discarded = true;
       if (event.type === "error") {
         error = typeof event.data === "string" ? event.data : "Generation failed";
       }
@@ -107,7 +109,7 @@ function parseSsePayload(payload: string): { done: boolean; error: string | null
     }
   }
 
-  return { done, error };
+  return { done, discarded, error };
 }
 
 function isHardGenerationFailure(error: string, statusCode?: number): boolean {
@@ -231,6 +233,11 @@ export function startServerAutonomousScheduler(app: FastifyInstance) {
     if (!result.done) {
       clearGenerationInProgress(chatId, claimedAt);
       logger.warn("[autonomous-scheduler] Generate ended without a done event for chat %s", chatId);
+      return false;
+    }
+
+    if (result.discarded) {
+      clearFailureBackoff(chatId);
       return false;
     }
 

--- a/packages/server/src/services/conversation/transcript-sanitize.ts
+++ b/packages/server/src/services/conversation/transcript-sanitize.ts
@@ -39,7 +39,7 @@ export function isRepeatedConversationResponse(
     const message = messages[index]!;
     if (options.excludeMessageId && message.id === options.excludeMessageId) continue;
     if (message.role !== "assistant" || (message.characterId ?? null) !== characterId) continue;
-    return normalizeTextForMatch(message.content) === normalizedContent;
+    if (normalizeTextForMatch(message.content) === normalizedContent) return true;
   }
   return false;
 }

--- a/packages/server/src/services/conversation/transcript-sanitize.ts
+++ b/packages/server/src/services/conversation/transcript-sanitize.ts
@@ -15,6 +15,7 @@ const SPEAKER_TIMESTAMP_RE = new RegExp(`^(\\s*(?:[-*]\\s*)?[^:\\n]{1,80}:\\s*)(
 const CONVERSATION_REPEAT_MIN_LENGTH = 40;
 
 type ConversationResponseHistoryMessage = {
+  id?: unknown;
   role?: unknown;
   characterId?: unknown;
   content?: unknown;
@@ -29,12 +30,14 @@ export function isRepeatedConversationResponse(
   messages: readonly ConversationResponseHistoryMessage[],
   characterId: string | null,
   content: string,
+  options: { excludeMessageId?: string | null } = {},
 ): boolean {
   const normalizedContent = normalizeTextForMatch(content);
   if (normalizedContent.length < CONVERSATION_REPEAT_MIN_LENGTH) return false;
 
   for (let index = messages.length - 1; index >= 0; index--) {
     const message = messages[index]!;
+    if (options.excludeMessageId && message.id === options.excludeMessageId) continue;
     if (message.role !== "assistant" || (message.characterId ?? null) !== characterId) continue;
     return normalizeTextForMatch(message.content) === normalizedContent;
   }

--- a/packages/server/src/services/conversation/transcript-sanitize.ts
+++ b/packages/server/src/services/conversation/transcript-sanitize.ts
@@ -1,12 +1,45 @@
 // ──────────────────────────────────────────────
 // Conversation: Transcript Sanitizers
 // ──────────────────────────────────────────────
-import { CLOCK_TOKEN_SOURCE, DATE_TIME_TOKEN_SOURCE, FULL_DATE_TOKEN_SOURCE } from "@marinara-engine/shared";
+import {
+  CLOCK_TOKEN_SOURCE,
+  DATE_TIME_TOKEN_SOURCE,
+  FULL_DATE_TOKEN_SOURCE,
+  normalizeTextForMatch,
+} from "@marinara-engine/shared";
 
 const DATE_TAG_RE = /<\/?date(?:="[^"]*")?>/gi;
 const TIMESTAMP_TOKEN = String.raw`\[(?:${DATE_TIME_TOKEN_SOURCE}|${CLOCK_TOKEN_SOURCE}|${FULL_DATE_TOKEN_SOURCE})\]`;
 const LEADING_TIMESTAMP_RE = new RegExp(`^(\\s*(?:[-*]\\s*)?)(?:${TIMESTAMP_TOKEN}\\s*)+`, "gim");
 const SPEAKER_TIMESTAMP_RE = new RegExp(`^(\\s*(?:[-*]\\s*)?[^:\\n]{1,80}:\\s*)(?:${TIMESTAMP_TOKEN}\\s*)+`, "gim");
+const CONVERSATION_REPEAT_MIN_LENGTH = 40;
+
+type ConversationResponseHistoryMessage = {
+  role?: unknown;
+  characterId?: unknown;
+  content?: unknown;
+};
+
+/**
+ * Detect a substantial exact repeat of the same character's latest message.
+ * Short conversational responses remain repeatable because phrases such as
+ * "lol" or "good morning" can be natural on consecutive turns.
+ */
+export function isRepeatedConversationResponse(
+  messages: readonly ConversationResponseHistoryMessage[],
+  characterId: string | null,
+  content: string,
+): boolean {
+  const normalizedContent = normalizeTextForMatch(content);
+  if (normalizedContent.length < CONVERSATION_REPEAT_MIN_LENGTH) return false;
+
+  for (let index = messages.length - 1; index >= 0; index--) {
+    const message = messages[index]!;
+    if (message.role !== "assistant" || (message.characterId ?? null) !== characterId) continue;
+    return normalizeTextForMatch(message.content) === normalizedContent;
+  }
+  return false;
+}
 
 /** Collapse model-produced `Name: Name:` prefixes without touching later dialogue text. */
 export function collapseDuplicateConversationSpeakerPrefixes(

--- a/packages/server/src/services/noodle/noodle-generated-refresh.ts
+++ b/packages/server/src/services/noodle/noodle-generated-refresh.ts
@@ -58,28 +58,48 @@ export function deduplicateGeneratedNoodleContent(generated: NoodleGeneratedRefr
   removedCount: number;
 } {
   const seenContent = new Set<string>();
+  const retainedPosts = new Map<string, { index: number; tempId: string | undefined }>();
+  const tempIdAliases = new Map<string, string>();
   let removedCount = 0;
+  const keepFirst = (key: string): boolean => {
+    if (seenContent.has(key)) {
+      removedCount += 1;
+      return false;
+    }
+    seenContent.add(key);
+    return true;
+  };
 
-  const posts = generated.posts.filter((post) => {
+  const posts: NoodleGeneratedRefresh["posts"] = [];
+  for (const post of generated.posts) {
     const key = normalizedGeneratedContentKey(post.authorHandle, post.content);
-    if (seenContent.has(key)) {
-      removedCount += 1;
-      return false;
+    if (keepFirst(key)) {
+      retainedPosts.set(key, { index: posts.length, tempId: post.tempId });
+      posts.push(post);
+      continue;
     }
-    seenContent.add(key);
-    return true;
-  });
+    if (!post.tempId) continue;
 
-  const interactions = generated.interactions.filter((interaction) => {
-    if (interaction.type !== "reply" || !interaction.content?.trim()) return true;
-    const key = normalizedGeneratedContentKey(interaction.actorHandle, interaction.content);
-    if (seenContent.has(key)) {
-      removedCount += 1;
-      return false;
+    const retained = retainedPosts.get(key);
+    if (!retained) continue;
+    if (!retained.tempId) {
+      const retainedPost = posts[retained.index];
+      if (!retainedPost) continue;
+      retained.tempId = post.tempId;
+      posts[retained.index] = { ...retainedPost, tempId: retained.tempId };
     }
-    seenContent.add(key);
-    return true;
-  });
+    tempIdAliases.set(post.tempId, retained.tempId);
+  }
+
+  const interactions = generated.interactions
+    .filter((interaction) => {
+      if (interaction.type !== "reply" || !interaction.content?.trim()) return true;
+      return keepFirst(normalizedGeneratedContentKey(interaction.actorHandle, interaction.content));
+    })
+    .map((interaction) => {
+      const targetTempId = interaction.targetTempId && tempIdAliases.get(interaction.targetTempId);
+      return targetTempId ? { ...interaction, targetTempId } : interaction;
+    });
 
   return {
     generated: { ...generated, posts, interactions },

--- a/packages/server/src/services/noodle/noodle-generated-refresh.ts
+++ b/packages/server/src/services/noodle/noodle-generated-refresh.ts
@@ -42,6 +42,51 @@ export function validateNoodleGeneratedRefresh(
   return hasUsableAttribution ? null : "the response used no selected participant handle";
 }
 
+function normalizedGeneratedContentKey(handle: string, content: string): string {
+  const normalizedContent = content.normalize("NFKC").trim().replace(/\s+/gu, " ").toLowerCase();
+  return `${normalizeNoodleHandle(handle)}\u0000${normalizedContent}`;
+}
+
+/**
+ * Keep the first generated post or reply for each account and discard later
+ * copies. Posts take precedence because the response groups posts before
+ * interactions. Filtering before media preparation ensures a copy never
+ * reaches image generation or persistence.
+ */
+export function deduplicateGeneratedNoodleContent(generated: NoodleGeneratedRefresh): {
+  generated: NoodleGeneratedRefresh;
+  removedCount: number;
+} {
+  const seenContent = new Set<string>();
+  let removedCount = 0;
+
+  const posts = generated.posts.filter((post) => {
+    const key = normalizedGeneratedContentKey(post.authorHandle, post.content);
+    if (seenContent.has(key)) {
+      removedCount += 1;
+      return false;
+    }
+    seenContent.add(key);
+    return true;
+  });
+
+  const interactions = generated.interactions.filter((interaction) => {
+    if (interaction.type !== "reply" || !interaction.content?.trim()) return true;
+    const key = normalizedGeneratedContentKey(interaction.actorHandle, interaction.content);
+    if (seenContent.has(key)) {
+      removedCount += 1;
+      return false;
+    }
+    seenContent.add(key);
+    return true;
+  });
+
+  return {
+    generated: { ...generated, posts, interactions },
+    removedCount,
+  };
+}
+
 const collectionSchemas = {
   posts: noodleGeneratedPostSchema,
   interactions: noodleGeneratedInteractionSchema,

--- a/packages/server/src/services/noodle/noodle-prompt.ts
+++ b/packages/server/src/services/noodle/noodle-prompt.ts
@@ -23,6 +23,8 @@ export const NOODLE_PERSONA_AUTHORSHIP_INSTRUCTION =
   "- The user persona is controlled exclusively by the user. Never generate posts, replies, likes, reposts, poll votes, or follows as a persona. Personas may only be mentioned or targeted by other accounts.";
 export const NOODLE_PERSONA_IDENTITY_INSTRUCTION =
   "- Every persona account is a separate user identity. Preserve the accountKey on historical posts and replies: changing the currently selected persona never changes, merges, or reattributes activity created by another persona.";
+export const NOODLE_UNIQUE_CONTENT_INSTRUCTION =
+  "- Never reuse the same message text for more than one post or reply by the same account. In particular, do not copy a new post's content into a reply or duplicate a reply as a new post.";
 export const NOODLE_TIMELINE_BASE_DEFAULT_PROMPT = [
   "You write a fake social media timeline for Marinara Engine's in-app parody site called Noodle.",
   NOODLE_ADULT_PLATFORM_POLICY,
@@ -31,6 +33,7 @@ export const NOODLE_TIMELINE_BASE_DEFAULT_PROMPT = [
   "- To respond directly to an existing comment, create a reply interaction for its post and set parentInteractionId to that comment's exact replyId.",
   "- Do not make an account interact with the same existing post again when it has already liked, reposted, voted, or replied there, unless that account was tagged or is answering a direct response to its own comment. Never make an account reply to its own comment.",
   "- Avoid repeating an account's recent post topic or phrasing. Continue an existing thread only when new activity gives the account a reason to return.",
+  NOODLE_UNIQUE_CONTENT_INSTRUCTION,
   NOODLE_PERSONA_AUTHORSHIP_INSTRUCTION,
   NOODLE_PERSONA_IDENTITY_INSTRUCTION,
   "- For each interaction, set either targetTempId or targetPostId and set the unused target field to null.",

--- a/packages/server/src/services/noodle/noodle-public-generation.service.ts
+++ b/packages/server/src/services/noodle/noodle-public-generation.service.ts
@@ -22,7 +22,11 @@ import { createGalleryStorage } from "../storage/gallery.storage.js";
 import { createNoodleStorage } from "../storage/noodle.storage.js";
 import { createPromptOverridesStorage } from "../storage/prompt-overrides.storage.js";
 import { commitGeneratedNoodleActivity, prepareGeneratedNoodleMedia } from "./noodle-generated-activity.service.js";
-import { parseNoodleGeneratedRefreshResponse, validateNoodleGeneratedRefresh } from "./noodle-generated-refresh.js";
+import {
+  deduplicateGeneratedNoodleContent,
+  parseNoodleGeneratedRefreshResponse,
+  validateNoodleGeneratedRefresh,
+} from "./noodle-generated-refresh.js";
 import { normalizeNoodleHandle } from "./noodle-handle.js";
 import { chooseNoodleParticipantAccounts, collectNoodlePriorityAccountIds } from "./noodle-participant-selection.js";
 import { buildRefreshPrompt } from "./noodle-public-prompt.service.js";
@@ -416,6 +420,14 @@ export function createPublicNoodleGenerationService(db: DB) {
             rejected.issueCount === 1 ? "" : "s",
           );
         }
+        const deduplicated = deduplicateGeneratedNoodleContent(parsedGenerated.refresh);
+        if (deduplicated.removedCount > 0) {
+          logger.warn(
+            "[noodle] Removed %d duplicate generated post/reply item%s",
+            deduplicated.removedCount,
+            deduplicated.removedCount === 1 ? "" : "s",
+          );
+        }
         const preparedMedia = await prepareGeneratedNoodleMedia({
           db,
           characters,
@@ -423,7 +435,7 @@ export function createPublicNoodleGenerationService(db: DB) {
           gallery,
           characterGallery,
           promptOverrides,
-          generated: parsedGenerated.refresh,
+          generated: deduplicated.generated,
           selectedParticipants,
           personaAccount,
           settings,
@@ -433,7 +445,7 @@ export function createPublicNoodleGenerationService(db: DB) {
         });
         const activity = await commitGeneratedNoodleActivity({
           db,
-          generated: parsedGenerated.refresh,
+          generated: deduplicated.generated,
           selectedParticipants,
           personaAccount,
           settings,

--- a/packages/server/src/services/noodle/noodle-public-prompt.service.ts
+++ b/packages/server/src/services/noodle/noodle-public-prompt.service.ts
@@ -26,6 +26,7 @@ import {
   NOODLE_LEGACY_RECALLED_MEMORY_INSTRUCTION,
   NOODLE_PERSONA_IDENTITY_INSTRUCTION,
   NOODLE_RECALLED_MEMORY_INSTRUCTION,
+  NOODLE_UNIQUE_CONTENT_INSTRUCTION,
   noodleTimelineFeatureInstructions,
   sampleNoodlePastMemories,
   sampleNoodlePastMemoriesWeighted,
@@ -578,6 +579,9 @@ export async function buildRefreshPrompt(input: {
   const textOnlyContext = buildContext(new Set(), "", captionedImages);
 
   const outputFormat = [
+    "# Content Uniqueness",
+    NOODLE_UNIQUE_CONTENT_INSTRUCTION,
+    "",
     NOODLE_JSON_OUTPUT_HEADING,
     JSON.stringify(
       {

--- a/scripts/regressions/open-issues.regression.ts
+++ b/scripts/regressions/open-issues.regression.ts
@@ -72,6 +72,7 @@ import { sanitizeExampleDialoguePromptLeaf } from "../../packages/server/src/ser
 import { parseCharacterCommands } from "../../packages/server/src/services/conversation/character-commands.js";
 import {
   collapseDuplicateConversationSpeakerPrefixes,
+  isRepeatedConversationResponse,
   stripConversationPromptTimestamps,
   stripConversationResponseEnvelope,
 } from "../../packages/server/src/services/conversation/transcript-sanitize.js";
@@ -1322,6 +1323,25 @@ assert.match(markdownCodeBlockStyles, /overflow-x:\s*auto;/u);
 assert.equal(stripLeadingMessageTimestamps("[11.07 15:53] Character: Hello!"), "Character: Hello!");
 assert.equal(stripLeadingMessageTimestamps("[11.07.2026 15:53] Character: Hello!"), "Character: Hello!");
 assert.equal(stripConversationPromptTimestamps("[11.07 15:53] Character: Hello!"), "Character: Hello!");
+assert.equal(
+  isRepeatedConversationResponse(
+    [
+      {
+        role: "assistant",
+        characterId: "dottore",
+        content: "The experiment remains stable after every measured interval.",
+      },
+      {
+        role: "assistant",
+        characterId: "dottore",
+        content: "A different observation separates the two matching responses.",
+      },
+    ],
+    "dottore",
+    "The experiment remains stable after every measured interval.",
+  ),
+  true,
+);
 assert.equal(
   stripConversationResponseEnvelope("[11.07 15:53] Character: Hello!", { speakerName: "Character" }),
   "Hello!",


### PR DESCRIPTION
## Linked issue

Closes #3918

## Why this change

Model output could be persisted more than once in two user-visible paths. Noodle could copy a new post verbatim into a reply from the same account, while Conversation mode could repeat a prior substantial message during either a normal reply or an Autonomous check-in.

Conversation also had a separate interrupted-stream recovery race: after an authoritative refetch found the server-saved response, the client could still POST its streamed partial as a second message.

## What changed

- Added explicit no-repeat instructions to Noodle and Conversation prompts, including Conversation prompt previews.
- Removed normalized duplicate Noodle posts/replies before media preparation or persistence.
- Rejected substantial exact repeats of the same character's latest Conversation response before saving, while preserving short natural repeats and regeneration/continuation behavior.
- Added an SSE discard signal so active, background, and server Autonomous flows do not display or notify for rejected copies.
- Prevented passive stream recovery from performing a second durable partial-message write after its authoritative refetch.

## Validation

- [x] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [x] Read and followed `CONTRIBUTING.md`

Command results:

- `pnpm check` — passed, including workspace lint/type checks and production builds.
- `pnpm regression:roleplay` — passed.
- `pnpm regression:noodle` — passed.
- Disposable duplicate-boundary regression — passed, then removed per repository policy.
- `pnpm regression:prompt` — relevant Conversation assertions passed before the suite stopped on an unrelated existing assertion that the public agent reference is missing Prose Guardian.

### Manual verification notes

- Not performed. This change has no visual layout impact; the reported duplicate-generation scenarios require model/runtime reproduction.

## Docs and release impact

- [x] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Version/release files updated (only if this PR includes a version bump)

No installation, configuration, or release behavior changed. No documentation or version files were modified.

## UI evidence (if applicable)

Not applicable; no visual UI changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented duplicate Conversation responses from being saved or displayed.
  * Improved recovery after interrupted background generation.
  * Correctly handles discarded generations without leaving stale streamed text.
  * Prevented duplicate generated posts and replies in Noodle timelines.

* **Improvements**
  * Enhanced generation completion, notifications, and retry handling after stream interruptions.
  * Added safeguards to encourage unique Conversation and Noodle content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->