### PR TITLE
Fix Illustrator background history and mode tags

### DIFF
--- a/packages/server/src/services/game/game-asset-generation.ts
+++ b/packages/server/src/services/game/game-asset-generation.ts
@@ -280,8 +280,8 @@ function writeChatBackgroundMeta(meta: ChatBackgroundMeta): void {
   atomicWriteText(CHAT_BACKGROUND_META_PATH, JSON.stringify(meta, null, 2));
 }
 
-function chatBackgroundTags(req: ChatBackgroundGenRequest, slug: string): string[] {
-  const tags = new Set<string>(["generated", req.sourceMode === "game" ? "game" : "roleplay", slug.replace(/-/g, " ")]);
+export function chatBackgroundTags(req: ChatBackgroundGenRequest, slug: string): string[] {
+  const tags = new Set<string>(["generated", req.sourceMode ?? "roleplay", slug.replace(/-/g, " ")]);
   for (const value of [req.locationSlug, req.reason, ...(req.tags ?? [])]) {
     if (!value) continue;
     const clean = value.trim().replace(/\s+/g, " ");

--- a/packages/server/src/services/generation/illustrator-background-generation.ts
+++ b/packages/server/src/services/generation/illustrator-background-generation.ts
@@ -132,9 +132,12 @@ export function buildIllustratorBackgroundPlanUserPrompt(args: {
   gameState: GameState | null;
   recentMessages: Array<{ role: string; content: string; gameState?: GameState | null }>;
 }): string {
-  const previousTrackedLocations = Array.from(
-    new Set(args.recentMessages.map((message) => readTrimmedString(message.gameState?.location)).filter(Boolean)),
-  ).slice(-3);
+  const trackedLocations = args.recentMessages
+    .map((message) => readTrimmedString(message.gameState?.location))
+    .filter(Boolean);
+  const previousTrackedLocations = trackedLocations
+    .filter((location, index) => trackedLocations.lastIndexOf(location) === index)
+    .slice(-3);
   const recentContext = args.recentMessages
     .slice(-6)
     .map((message) => `${message.role}: ${message.content.replace(/\s+/gu, " ").trim().slice(0, 1_500)}`)

--- a/scripts/regressions/prompt.regression.ts
+++ b/scripts/regressions/prompt.regression.ts
@@ -439,6 +439,7 @@ import {
 import {
   buildNpcPortraitProviderPrompt,
   buildSceneIllustrationProviderPrompt,
+  chatBackgroundTags,
   safeGeneratedAssetSlug,
 } from "../../packages/server/src/services/game/game-asset-generation.js";
 import {
@@ -2636,11 +2637,32 @@ const cases: RegressionCase[] = [
             content: "The group leaves the archive.",
             gameState: { location: "Royal Archive" } as any,
           },
+          {
+            role: "assistant",
+            content: "They follow the moonlit road.",
+            gameState: { location: "Moonlit Road" } as any,
+          },
+          {
+            role: "assistant",
+            content: "They briefly return through the archive gate.",
+            gameState: { location: "Royal Archive" } as any,
+          },
         ],
       });
       assert.match(prompt, /Current tracker state:.*Enchanted Forest Clearing/u);
-      assert.match(prompt, /Recent committed tracker locations: Royal Archive/u);
+      assert.match(prompt, /Recent committed tracker locations: Moonlit Road -> Royal Archive/u);
       assert.match(prompt, /Currently active background: old-library\.png/u);
+
+      const visualNovelTags = chatBackgroundTags(
+        {
+          sourceMode: "visual_novel",
+          locationSlug: "moonlit-garden",
+          tags: ["garden"],
+        } as any,
+        "moonlit-garden",
+      );
+      assert.ok(visualNovelTags.includes("visual_novel"));
+      assert.ok(!visualNovelTags.includes("roleplay"));
 
       const drawerSource = readFileSync(
         new URL("../../packages/client/src/components/chat/ChatSettingsDrawer.tsx", import.meta.url),


### PR DESCRIPTION
Follow-up to #3925. Refs #3924.

Why

Two valid Copilot findings arrived after the final feature push while CI was already running. Repeated tracker locations could preserve their first occurrence instead of the latest one, and Visual Novel background assets were tagged as Roleplay.

Changes

- Keep the three most recent distinct tracker locations in chronological order for background planning.
- Preserve `visual_novel` as the generated background mode tag, with Roleplay as the fallback only when no source mode exists.
- Add regression coverage for repeated location history and Visual Novel tags.

Validation

- `pnpm regression:prompt`
- `pnpm --filter @marinara-engine/server lint`
- `git diff --check`