### PR TITLE
Fix scoped Illustrator retries and empty-response fallback

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "regression:jsonish": "pnpm --filter @marinara-engine/server exec tsx ../../scripts/regressions/jsonish-output.regression.ts",
     "regression:tts": "pnpm build:shared && pnpm --filter @marinara-engine/server exec tsx ../../scripts/regressions/tts-source-persistence.regression.ts",
     "regression:issues": "pnpm --filter @marinara-engine/server exec tsx ../../scripts/regressions/open-issues.regression.ts && pnpm --filter @marinara-engine/server exec tsx ../../scripts/regressions/agent-catalog-kind-badges.regression.ts && pnpm --filter @marinara-engine/server exec tsx ../../scripts/regressions/file-backed-shutdown.regression.ts && pnpm --filter @marinara-engine/server exec tsx ../../scripts/regressions/capability-package-lifecycle.regression.ts && pnpm --filter @marinara-engine/server exec tsx ../../scripts/regressions/conversation-game-slash.regression.ts && node ./scripts/regressions/launcher-env.regression.mjs && pnpm --filter @marinara-engine/server exec tsx ../../scripts/regressions/scene-video-range.regression.ts",
-    "regression:roleplay": "pnpm build:shared && pnpm --filter @marinara-engine/server exec tsx ../../scripts/regressions/roleplay-streaming.regression.ts",
+    "regression:roleplay": "pnpm build:shared && pnpm --filter @marinara-engine/server exec tsx ../../scripts/regressions/roleplay-streaming.regression.ts && pnpm --filter @marinara-engine/server exec tsx ../../scripts/regressions/illustrator-visual-retry.regression.ts",
     "regression:sprites": "pnpm --filter @marinara-engine/server exec tsx ../../scripts/regressions/sprite-background.regression.ts",
     "smoke:ui": "playwright test -c playwright.config.ts",
     "test": "node ./scripts/check-windows-installer-layout.mjs && pnpm -r run test",

--- a/packages/client/src/components/chat/ChatArea.tsx
+++ b/packages/client/src/components/chat/ChatArea.tsx
@@ -72,6 +72,7 @@ import {
 import { resolveLiveConversationStatus } from "../../lib/conversation-presence-status";
 import { useUIStore } from "../../stores/ui.store";
 import { useAgentStore } from "../../stores/agent.store";
+import { illustratorRetryTargetsForFailures } from "../../lib/agent-failures";
 import { cn, parseAvatarCropJson } from "../../lib/utils";
 import { Modal } from "../ui/Modal";
 import { useEncounter } from "../../hooks/use-encounter";
@@ -1922,7 +1923,17 @@ export function ChatArea() {
 
   const handleRetryAgents = useCallback(async () => {
     if (!activeChatId || isStreaming || agentProcessing || failedAgentTypes.length === 0) return;
-    await retryAgents(activeChatId, failedAgentTypes);
+    const failureState = useAgentStore.getState();
+    const failures =
+      failureState.failedAgentChatId && failureState.failedAgentChatId !== activeChatId
+        ? []
+        : failureState.failedAgentFailures;
+    const illustratorRetryTargets = illustratorRetryTargetsForFailures(failures);
+    await retryAgents(
+      activeChatId,
+      failedAgentTypes,
+      illustratorRetryTargets ? { illustratorRetryTargets } : undefined,
+    );
   }, [activeChatId, isStreaming, agentProcessing, failedAgentTypes, retryAgents]);
 
   const handleRerunTrackers = useCallback(async () => {

--- a/packages/client/src/components/chat/RoleplayHUDActionsMenu.tsx
+++ b/packages/client/src/components/chat/RoleplayHUDActionsMenu.tsx
@@ -260,7 +260,7 @@ export function RoleplayHUDActionsMenu({
               <div className="space-y-1">
                 {displayedFailures.map((failure) => (
                   <div
-                    key={failure.agentType}
+                    key={`${failure.agentType}:${failure.retryTarget ?? "agent"}`}
                     className="rounded-md border border-amber-400/15 bg-amber-500/10 px-2 py-1.5 text-[0.625rem]"
                     title={failure.error ?? undefined}
                   >

--- a/packages/client/src/hooks/use-generate.ts
+++ b/packages/client/src/hooks/use-generate.ts
@@ -68,8 +68,11 @@ function withIllustratorFailureTargets(
   options: RetryAgentsOptions | undefined,
   failures: AgentFailure[],
 ): RetryAgentsOptions | undefined {
+  const baseOptions: RetryAgentsOptions = { ...options };
+  delete baseOptions.illustratorRetryTargets;
   const illustratorRetryTargets = illustratorRetryTargetsForFailures(failures);
-  return illustratorRetryTargets ? { ...options, illustratorRetryTargets } : options;
+  if (illustratorRetryTargets) return { ...baseOptions, illustratorRetryTargets };
+  return Object.keys(baseOptions).length > 0 ? baseOptions : undefined;
 }
 
 /** Show a persistent, copyable error toast and log to console */

--- a/packages/client/src/hooks/use-generate.ts
+++ b/packages/client/src/hooks/use-generate.ts
@@ -6,7 +6,14 @@ import type { AvatarCropValue } from "../lib/utils";
 import { useQueryClient, type InfiniteData, type QueryClient } from "@tanstack/react-query";
 import { toast, type ExternalToast } from "sonner";
 import { api, ApiError } from "../lib/api-client";
-import { formatAgentFailuresToast, toAgentFailure, type AgentFailure } from "../lib/agent-failures";
+import {
+  formatAgentFailuresToast,
+  illustratorRetryTargetsForFailures,
+  mergeAgentFailures,
+  toAgentFailure,
+  type AgentFailure,
+  type IllustratorRetryTarget,
+} from "../lib/agent-failures";
 import { chatBackgroundMetadataToUrl } from "../lib/backgrounds";
 import { formatGenerationParameterError } from "../lib/generation-parameter-errors";
 import {
@@ -52,9 +59,18 @@ type RetryAgentsOptions = {
     prompt: string;
     negativePrompt?: string;
   };
+  illustratorRetryTargets?: IllustratorRetryTarget[];
 };
 
 type RetryAgentsFn = (chatId: string, agentTypes: string[], options?: RetryAgentsOptions) => Promise<boolean>;
+
+function withIllustratorFailureTargets(
+  options: RetryAgentsOptions | undefined,
+  failures: AgentFailure[],
+): RetryAgentsOptions | undefined {
+  const illustratorRetryTargets = illustratorRetryTargetsForFailures(failures);
+  return illustratorRetryTargets ? { ...options, illustratorRetryTargets } : options;
+}
 
 /** Show a persistent, copyable error toast and log to console */
 function showError(msg: string, options?: Pick<ExternalToast, "action">) {
@@ -2381,12 +2397,28 @@ export function useGenerate() {
             }
 
             case "agent_error": {
-              const errData = event.data as { agentType: string; agentName?: string | null; error: string };
-              if (errData.agentType === "illustrator") illustrationSettled = true;
+              const errData = event.data as {
+                agentType: string;
+                agentName?: string | null;
+                error: string;
+                retryTarget?: unknown;
+              };
+              if (errData.agentType === "illustrator" && errData.retryTarget !== "background") {
+                illustrationSettled = true;
+              }
               const failure = toAgentFailure(errData);
-              setFailedAgentFailures([failure], params.chatId);
+              const failureState = useAgentStore.getState();
+              const existingFailures =
+                failureState.failedAgentChatId && failureState.failedAgentChatId !== params.chatId
+                  ? []
+                  : failureState.failedAgentFailures;
+              setFailedAgentFailures(mergeAgentFailures(existingFailures, [failure]), params.chatId);
               showAgentFailuresError([failure], () => {
-                void retryAgentsRef.current?.(params.chatId, [failure.agentType]);
+                void retryAgentsRef.current?.(
+                  params.chatId,
+                  [failure.agentType],
+                  withIllustratorFailureTargets(undefined, [failure]),
+                );
               });
               break;
             }
@@ -3119,6 +3151,7 @@ export function useGenerate() {
             ...(options?.illustratorPromptReviewOverride
               ? { illustratorPromptReviewOverride: options.illustratorPromptReviewOverride }
               : {}),
+            ...(options?.illustratorRetryTargets ? { illustratorRetryTargets: options.illustratorRetryTargets } : {}),
             musicPlayerEnabled: useUIStore.getState().musicPlayerEnabled,
             musicPlayerSource: useUIStore.getState().musicPlayerSource,
             lorebookKeeperBackfill: options?.lorebookKeeperBackfill === true,
@@ -3290,7 +3323,11 @@ export function useGenerate() {
                 failedRetryFailures.push(failure);
                 setFailedAgentFailures(failedRetryFailures, chatId);
                 showAgentFailuresError([failure], () => {
-                  void retryAgentsRef.current?.(chatId, [failure.agentType], options);
+                  void retryAgentsRef.current?.(
+                    chatId,
+                    [failure.agentType],
+                    withIllustratorFailureTargets(options, [failure]),
+                  );
                 });
               }
               break;
@@ -3316,7 +3353,7 @@ export function useGenerate() {
                 void retryAgentsRef.current?.(
                   chatId,
                   failures.map((failure) => failure.agentType),
-                  options,
+                  withIllustratorFailureTargets(options, failures),
                 );
               });
               break;
@@ -3377,12 +3414,23 @@ export function useGenerate() {
               break;
             }
             case "agent_error": {
-              const errData = event.data as { agentType: string; agentName?: string | null; error: string };
+              const errData = event.data as {
+                agentType: string;
+                agentName?: string | null;
+                error: string;
+                retryTarget?: unknown;
+              };
               hasError = true;
               const failure = toAgentFailure(errData);
-              setFailedAgentFailures([failure], chatId);
+              const mergedFailures = mergeAgentFailures(failedRetryFailures, [failure]);
+              failedRetryFailures.splice(0, failedRetryFailures.length, ...mergedFailures);
+              setFailedAgentFailures(failedRetryFailures, chatId);
               showAgentFailuresError([failure], () => {
-                void retryAgentsRef.current?.(chatId, [failure.agentType], options);
+                void retryAgentsRef.current?.(
+                  chatId,
+                  [failure.agentType],
+                  withIllustratorFailureTargets(options, [failure]),
+                );
               });
               break;
             }

--- a/packages/client/src/lib/agent-failures.ts
+++ b/packages/client/src/lib/agent-failures.ts
@@ -1,16 +1,24 @@
 import { isConcurrencyLimitError } from "./generation-parameter-errors";
 
+export type IllustratorRetryTarget = "illustration" | "background";
+
 export interface AgentFailure {
   agentType: string;
   agentName: string;
   error: string | null;
   reasonLabel: string | null;
+  retryTarget: IllustratorRetryTarget | null;
 }
 
 interface RawAgentFailure {
   agentType: string;
   agentName?: string | null;
   error?: string | null;
+  retryTarget?: unknown;
+}
+
+function parseIllustratorRetryTarget(value: unknown): IllustratorRetryTarget | null {
+  return value === "illustration" || value === "background" ? value : null;
 }
 
 function classifyAgentFailureReason(error: string | null | undefined): string | null {
@@ -62,7 +70,31 @@ export function toAgentFailure(raw: RawAgentFailure): AgentFailure {
     agentName,
     error,
     reasonLabel: classifyAgentFailureReason(error),
+    retryTarget: raw.agentType === "illustrator" ? parseIllustratorRetryTarget(raw.retryTarget) : null,
   };
+}
+
+export function mergeAgentFailures(existing: AgentFailure[], incoming: AgentFailure[]): AgentFailure[] {
+  const merged = [...existing];
+  for (const failure of incoming) {
+    for (let index = merged.length - 1; index >= 0; index--) {
+      const current = merged[index]!;
+      if (current.agentType !== failure.agentType) continue;
+      if (current.retryTarget === null || failure.retryTarget === null || current.retryTarget === failure.retryTarget) {
+        merged.splice(index, 1);
+      }
+    }
+    merged.push(failure);
+  }
+  return merged;
+}
+
+export function illustratorRetryTargetsForFailures(failures: AgentFailure[]): IllustratorRetryTarget[] | undefined {
+  const illustratorFailures = failures.filter((failure) => failure.agentType === "illustrator");
+  if (illustratorFailures.length === 0 || illustratorFailures.some((failure) => failure.retryTarget === null)) {
+    return undefined;
+  }
+  return Array.from(new Set(illustratorFailures.map((failure) => failure.retryTarget as IllustratorRetryTarget)));
 }
 
 export function formatAgentFailureTitle(failure: AgentFailure): string {

--- a/packages/client/src/stores/agent.store.ts
+++ b/packages/client/src/stores/agent.store.ts
@@ -310,11 +310,12 @@ export const useAgentStore = create<AgentState>((set, get) => ({
         agentName: agentType,
         error: null,
         reasonLabel: null,
+        retryTarget: null,
       })),
     }),
   setFailedAgentFailures: (failures, chatId = null) =>
     set({
-      failedAgentTypes: failures.map((failure) => failure.agentType),
+      failedAgentTypes: Array.from(new Set(failures.map((failure) => failure.agentType))),
       failedAgentChatId: chatId,
       failedAgentFailures: failures,
     }),

--- a/packages/server/src/routes/generate.routes.ts
+++ b/packages/server/src/routes/generate.routes.ts
@@ -8260,6 +8260,7 @@ export async function generateRoutes(app: FastifyInstance) {
                       data: {
                         agentType: "illustrator",
                         agentName: illustratorBackgroundAgent.name ?? "Illustrator",
+                        retryTarget: "background",
                         error: `Background generation failed: ${
                           backgroundError instanceof Error ? backgroundError.message : String(backgroundError)
                         }`,
@@ -8513,6 +8514,7 @@ export async function generateRoutes(app: FastifyInstance) {
                           data: {
                             agentType: "illustrator",
                             agentName: illustratorAgent?.name ?? "Illustrator",
+                            retryTarget: "illustration",
                             error: `Image generation failed: ${illErr instanceof Error ? illErr.message : String(illErr)}`,
                           },
                         })}\n\n`,
@@ -8527,6 +8529,7 @@ export async function generateRoutes(app: FastifyInstance) {
                       data: {
                         agentType: "illustrator",
                         agentName: illustratorAgent?.name ?? "Illustrator",
+                        retryTarget: "illustration",
                         error:
                           "No image generation connection is set on the Illustrator agent or under Settings → Connections → Defaults → Images. Choose one there, or assign one directly in Settings → Agents → Illustrator.",
                       },

--- a/packages/server/src/routes/generate/retry-agents-route.ts
+++ b/packages/server/src/routes/generate/retry-agents-route.ts
@@ -158,6 +158,11 @@ import {
   illustratorRequestedBackground,
   illustratorTrackerLocationChanged,
 } from "../../services/generation/illustrator-background-generation.js";
+import {
+  parseIllustratorRetryTargets,
+  shouldRetryIllustratorTarget,
+  type IllustratorRetryTarget,
+} from "../../services/generation/illustrator-retry-targets.js";
 import { normalizeContextInjections } from "./agent-normalizers.js";
 import { executeToolCalls, type MetadataPatchInput } from "../../services/tools/tool-executor.js";
 
@@ -2474,6 +2479,7 @@ async function applyRetryResultEffects(args: {
   queueImageGenerationRequests: boolean;
   reviewImagePromptsBeforeSend: boolean;
   illustratorPromptReviewOverride: IllustratorPromptReviewOverride | null;
+  illustratorRetryTargets: IllustratorRetryTarget[] | undefined;
   debugMode: boolean;
   secretPlotRerollMode?: "full" | "turn_only";
 }) {
@@ -2495,6 +2501,7 @@ async function applyRetryResultEffects(args: {
     queueImageGenerationRequests,
     reviewImagePromptsBeforeSend,
     illustratorPromptReviewOverride,
+    illustratorRetryTargets,
     debugMode,
     secretPlotRerollMode,
   } = args;
@@ -2996,7 +3003,13 @@ async function applyRetryResultEffects(args: {
     }
 
     // ── ILLUSTRATOR: generate image from agent prompt ──
-    if (result.success && result.type === "image_prompt" && result.data && typeof result.data === "object") {
+    if (
+      shouldRetryIllustratorTarget(illustratorRetryTargets, "illustration") &&
+      result.success &&
+      result.type === "image_prompt" &&
+      result.data &&
+      typeof result.data === "object"
+    ) {
       const illustratorFailureName =
         resolvedAgents.find((a) => a.resolved.id === result.agentId || a.resolved.type === "illustrator")?.cfg.name ??
         "Illustrator";
@@ -3296,6 +3309,7 @@ async function applyRetryResultEffects(args: {
               data: {
                 agentType: "illustrator",
                 agentName: illustratorFailureName,
+                retryTarget: "illustration",
                 error:
                   "No image generation connection is set on the Illustrator agent or under Settings -> Connections -> Defaults -> Images. Choose one there, or assign one directly in Settings -> Agents -> Illustrator.",
               },
@@ -3309,6 +3323,7 @@ async function applyRetryResultEffects(args: {
           data: {
             agentType: "illustrator",
             agentName: illustratorFailureName,
+            retryTarget: "illustration",
             error: illErr instanceof Error ? illErr.message : "Image generation failed",
           },
         });
@@ -3375,6 +3390,7 @@ async function applyRetryResultEffects(args: {
     illustratorResult &&
     illustratorEntry &&
     !illustratorPromptReviewOverride &&
+    shouldRetryIllustratorTarget(illustratorRetryTargets, "background") &&
     illustratorBackgroundGenerationEnabled((chat as { mode?: unknown }).mode, chatMeta)
   ) {
     const backgroundAtDecision =
@@ -3474,6 +3490,7 @@ async function applyRetryResultEffects(args: {
         data: {
           agentType: "illustrator",
           agentName: illustratorEntry.cfg?.name ?? illustratorEntry.resolved.name ?? "Illustrator",
+          retryTarget: "background",
           error: `Background generation failed: ${
             backgroundError instanceof Error ? backgroundError.message : String(backgroundError)
           }`,
@@ -3506,6 +3523,8 @@ export async function registerRetryAgentsRoute(app: FastifyInstance) {
       agentPromptTemplateIds?: unknown;
       /** Resume a reviewed Illustrator retry without running the Illustrator LLM a second time. */
       illustratorPromptReviewOverride?: unknown;
+      /** Limit an Illustrator retry to visual jobs that failed in the original run. */
+      illustratorRetryTargets?: unknown;
       lorebookKeeperBackfill?: boolean;
       /** When set, scope history and game state to this assistant message (as at original generation), not the latest turn. */
       forMessageId?: string;
@@ -3524,6 +3543,7 @@ export async function registerRetryAgentsRoute(app: FastifyInstance) {
       reviewImagePromptsBeforeSend = false,
       agentPromptTemplateIds,
       illustratorPromptReviewOverride: rawIllustratorPromptReviewOverride,
+      illustratorRetryTargets: rawIllustratorRetryTargets,
       lorebookKeeperBackfill = false,
       forMessageId,
       musicPlayerSource = "spotify",
@@ -3533,11 +3553,18 @@ export async function registerRetryAgentsRoute(app: FastifyInstance) {
     const illustratorPromptReviewOverride = rawIllustratorPromptReviewOverride
       ? parseIllustratorPromptReviewOverride(rawIllustratorPromptReviewOverride)
       : null;
+    const illustratorRetryTargets = parseIllustratorRetryTargets(rawIllustratorRetryTargets);
     if (!chatId || !agentTypes?.length) {
       return reply.status(400).send({ error: "chatId and agentTypes are required" });
     }
     if (rawIllustratorPromptReviewOverride && !illustratorPromptReviewOverride) {
       return reply.status(400).send({ error: "Invalid Illustrator prompt review override" });
+    }
+    if (illustratorRetryTargets === null) {
+      return reply.status(400).send({ error: "Invalid Illustrator retry targets" });
+    }
+    if (illustratorRetryTargets && !agentTypes.includes("illustrator")) {
+      return reply.status(400).send({ error: "Illustrator retry targets require an Illustrator retry" });
     }
 
     startSseReply(reply, { "X-Accel-Buffering": "no" });
@@ -3949,6 +3976,7 @@ export async function registerRetryAgentsRoute(app: FastifyInstance) {
         queueImageGenerationRequests,
         reviewImagePromptsBeforeSend,
         illustratorPromptReviewOverride,
+        illustratorRetryTargets,
         debugMode,
         secretPlotRerollMode,
       });

--- a/packages/server/src/services/generation/illustrator-retry-targets.ts
+++ b/packages/server/src/services/generation/illustrator-retry-targets.ts
@@ -1,0 +1,22 @@
+export type IllustratorRetryTarget = "illustration" | "background";
+
+const ILLUSTRATOR_RETRY_TARGETS = new Set<IllustratorRetryTarget>(["illustration", "background"]);
+
+export function parseIllustratorRetryTargets(value: unknown): IllustratorRetryTarget[] | null | undefined {
+  if (value === undefined) return undefined;
+  if (!Array.isArray(value) || value.length === 0) return null;
+
+  const targets: IllustratorRetryTarget[] = [];
+  for (const target of value) {
+    if (typeof target !== "string" || !ILLUSTRATOR_RETRY_TARGETS.has(target as IllustratorRetryTarget)) return null;
+    if (!targets.includes(target as IllustratorRetryTarget)) targets.push(target as IllustratorRetryTarget);
+  }
+  return targets;
+}
+
+export function shouldRetryIllustratorTarget(
+  targets: IllustratorRetryTarget[] | undefined,
+  target: IllustratorRetryTarget,
+): boolean {
+  return targets === undefined || targets.includes(target);
+}

--- a/packages/server/src/services/llm/connection-fallback-provider.ts
+++ b/packages/server/src/services/llm/connection-fallback-provider.ts
@@ -126,13 +126,13 @@ export class ConnectionFallbackProvider extends BaseLLMProvider {
   }
 
   async *chat(messages: ChatMessage[], options: ChatOptions): AsyncGenerator<string, LLMUsage | void, unknown> {
-    let emittedOutput = false;
+    let emittedUsableOutput = false;
     try {
       const primaryOptions = options.onToken
         ? {
             ...options,
             onToken: async (chunk: string) => {
-              emittedOutput ||= chunk.length > 0;
+              emittedUsableOutput ||= chunk.trim().length > 0;
               await options.onToken?.(chunk);
             },
           }
@@ -140,24 +140,25 @@ export class ConnectionFallbackProvider extends BaseLLMProvider {
       const generation = this.primary.chat(messages, primaryOptions);
       let result = await generation.next();
       while (!result.done) {
-        emittedOutput ||= result.value.length > 0;
+        emittedUsableOutput ||= result.value.trim().length > 0;
         yield result.value;
         result = await generation.next();
       }
-      return result.value;
+      if (emittedUsableOutput || options.signal?.aborted) return result.value;
+      await this.logFallback(new Error("Primary provider returned an empty completion"));
     } catch (error) {
-      if (emittedOutput || isAbortFailure(error, options.signal)) throw error;
+      if (emittedUsableOutput || isAbortFailure(error, options.signal)) throw error;
       await this.logFallback(error);
-      return yield* this.fallback.chat(messages, fallbackOptions(options, this.connection));
     }
+    return yield* this.fallback.chat(messages, fallbackOptions(options, this.connection));
   }
 
   async chatComplete(messages: ChatMessage[], options: ChatOptions): Promise<ChatCompletionResult> {
     try {
       const result = await this.primary.chatComplete(messages, options);
-      const hasUsableOutput = Boolean(result.content) || result.toolCalls.length > 0;
-      if (result.finishReason !== "error" || hasUsableOutput || options.signal?.aborted) return result;
-      await this.logFallback(new Error("Primary provider returned an empty error completion"));
+      const hasUsableOutput = Boolean(result.content?.trim()) || result.toolCalls.length > 0;
+      if (hasUsableOutput || options.signal?.aborted) return result;
+      await this.logFallback(new Error("Primary provider returned an empty completion"));
     } catch (error) {
       if (isAbortFailure(error, options.signal)) throw error;
       await this.logFallback(error);

--- a/packages/server/src/services/llm/connection-fallback-provider.ts
+++ b/packages/server/src/services/llm/connection-fallback-provider.ts
@@ -150,6 +150,7 @@ export class ConnectionFallbackProvider extends BaseLLMProvider {
       if (emittedUsableOutput || isAbortFailure(error, options.signal)) throw error;
       await this.logFallback(error);
     }
+    options.signal?.throwIfAborted();
     return yield* this.fallback.chat(messages, fallbackOptions(options, this.connection));
   }
 
@@ -163,6 +164,7 @@ export class ConnectionFallbackProvider extends BaseLLMProvider {
       if (isAbortFailure(error, options.signal)) throw error;
       await this.logFallback(error);
     }
+    options.signal?.throwIfAborted();
     return this.fallback.chatComplete(messages, fallbackOptions(options, this.connection));
   }
 

--- a/scripts/regressions/illustrator-visual-retry.regression.ts
+++ b/scripts/regressions/illustrator-visual-retry.regression.ts
@@ -33,6 +33,16 @@ assert.equal(
   undefined,
   "legacy unscoped Illustrator failures must retain the full retry path",
 );
+assert.equal(
+  illustratorRetryTargetsForFailures(
+    mergeAgentFailures(
+      [illustrationFailure],
+      [toAgentFailure({ agentType: "illustrator", error: "Legacy failure" })],
+    ),
+  ),
+  undefined,
+  "mixed scoped and legacy failures must retain the full retry path",
+);
 
 const backgroundOnly = parseIllustratorRetryTargets(["background"]);
 assert.deepEqual(backgroundOnly, ["background"]);

--- a/scripts/regressions/illustrator-visual-retry.regression.ts
+++ b/scripts/regressions/illustrator-visual-retry.regression.ts
@@ -1,0 +1,52 @@
+import assert from "node:assert/strict";
+import {
+  illustratorRetryTargetsForFailures,
+  mergeAgentFailures,
+  toAgentFailure,
+} from "../../packages/client/src/lib/agent-failures.js";
+import {
+  parseIllustratorRetryTargets,
+  shouldRetryIllustratorTarget,
+} from "../../packages/server/src/services/generation/illustrator-retry-targets.js";
+
+const illustrationFailure = toAgentFailure({
+  agentType: "illustrator",
+  agentName: "Illustrator",
+  retryTarget: "illustration",
+  error: "Image generation failed",
+});
+const backgroundFailure = toAgentFailure({
+  agentType: "illustrator",
+  agentName: "Illustrator",
+  retryTarget: "background",
+  error: "Background generation failed",
+});
+
+assert.deepEqual(illustratorRetryTargetsForFailures([illustrationFailure]), ["illustration"]);
+assert.deepEqual(illustratorRetryTargetsForFailures([backgroundFailure]), ["background"]);
+assert.deepEqual(illustratorRetryTargetsForFailures(mergeAgentFailures([illustrationFailure], [backgroundFailure])), [
+  "illustration",
+  "background",
+]);
+assert.equal(
+  illustratorRetryTargetsForFailures([toAgentFailure({ agentType: "illustrator", error: "Prompt failed" })]),
+  undefined,
+  "legacy unscoped Illustrator failures must retain the full retry path",
+);
+
+const backgroundOnly = parseIllustratorRetryTargets(["background"]);
+assert.deepEqual(backgroundOnly, ["background"]);
+assert.equal(shouldRetryIllustratorTarget(backgroundOnly ?? undefined, "background"), true);
+assert.equal(shouldRetryIllustratorTarget(backgroundOnly ?? undefined, "illustration"), false);
+
+const illustrationOnly = parseIllustratorRetryTargets(["illustration"]);
+assert.deepEqual(illustrationOnly, ["illustration"]);
+assert.equal(shouldRetryIllustratorTarget(illustrationOnly ?? undefined, "illustration"), true);
+assert.equal(shouldRetryIllustratorTarget(illustrationOnly ?? undefined, "background"), false);
+
+assert.equal(shouldRetryIllustratorTarget(undefined, "illustration"), true);
+assert.equal(shouldRetryIllustratorTarget(undefined, "background"), true);
+assert.equal(parseIllustratorRetryTargets([]), null);
+assert.equal(parseIllustratorRetryTargets(["sprite"]), null);
+
+console.info("Illustrator visual retry regression passed.");

--- a/scripts/regressions/provider-compat.regression.ts
+++ b/scripts/regressions/provider-compat.regression.ts
@@ -485,6 +485,26 @@ assert.deepEqual(fallbackNotice, {
   model: "fallback-model",
 });
 
+const emptyStreamFallback = new RegressionProvider(["fallback after empty stream"]);
+assert.equal(
+  await collectProviderOutput(
+    new ConnectionFallbackProvider(new RegressionProvider(["  "]), emptyStreamFallback, fallbackConnection, "main"),
+    { model: "primary-model" },
+  ),
+  "  fallback after empty stream",
+);
+assert.equal(emptyStreamFallback.calls, 1, "an empty successful stream must activate the fallback");
+
+const emptyCompletionFallback = new RegressionProvider(["fallback after empty completion"]);
+const emptyCompletionResult = await new ConnectionFallbackProvider(
+  new RegressionProvider([]),
+  emptyCompletionFallback,
+  fallbackConnection,
+  "main",
+).chatComplete([{ role: "user", content: "test" }], { model: "primary-model", stream: false });
+assert.equal(emptyCompletionResult.content, "fallback after empty completion");
+assert.equal(emptyCompletionFallback.calls, 1, "an empty successful completion must activate the fallback");
+
 const partialPrimary = new RegressionProvider(["partial"], new Error("stream interrupted"));
 const unusedFallback = new RegressionProvider(["must not be appended"]);
 await assert.rejects(

--- a/scripts/regressions/provider-compat.regression.ts
+++ b/scripts/regressions/provider-compat.regression.ts
@@ -51,6 +51,7 @@ class RegressionProvider extends BaseLLMProvider {
   constructor(
     private readonly chunks: string[],
     private readonly failure?: Error,
+    private readonly usage?: LLMUsage,
   ) {
     super("", "");
   }
@@ -60,6 +61,7 @@ class RegressionProvider extends BaseLLMProvider {
     this.lastOptions = options;
     for (const chunk of this.chunks) yield chunk;
     if (this.failure) throw this.failure;
+    return this.usage;
   }
 }
 
@@ -504,6 +506,21 @@ const emptyCompletionResult = await new ConnectionFallbackProvider(
 ).chatComplete([{ role: "user", content: "test" }], { model: "primary-model", stream: false });
 assert.equal(emptyCompletionResult.content, "fallback after empty completion");
 assert.equal(emptyCompletionFallback.calls, 1, "an empty successful completion must activate the fallback");
+
+const whitespaceCompletionFallback = new RegressionProvider(["fallback after whitespace completion"]);
+const whitespaceCompletionResult = await new ConnectionFallbackProvider(
+  new RegressionProvider([" \n "], undefined, {
+    promptTokens: 1,
+    completionTokens: 1,
+    totalTokens: 2,
+    finishReason: "length",
+  }),
+  whitespaceCompletionFallback,
+  fallbackConnection,
+  "main",
+).chatComplete([{ role: "user", content: "test" }], { model: "primary-model", stream: false });
+assert.equal(whitespaceCompletionResult.content, "fallback after whitespace completion");
+assert.equal(whitespaceCompletionFallback.calls, 1, "a whitespace-only completion must activate the fallback");
 
 const partialPrimary = new RegressionProvider(["partial"], new Error("stream interrupted"));
 const unusedFallback = new RegressionProvider(["must not be appended"]);


### PR DESCRIPTION
## Why

Two generation failure paths currently do more work than users expect:

- Retrying one failed Illustrator visual reruns both the roleplay illustration and automatic background.
- A primary model can return an empty response after filtering without activating its configured fallback model.

The first behavior wastes an already successful image generation. The second can leave a turn without usable output despite a configured fallback.

Fixes #3929.

## What changed

- Preserve whether the Illustrator illustration or background generation failed and retry only the failed visual job.
- Keep legacy unscoped Illustrator failures on the full retry path.
- Activate the configured fallback for empty or whitespace-only successful streaming and non-streaming responses.
- Preserve existing behavior for visible partial output, tool-call output, and user cancellation.
- Add regressions for scoped Illustrator retries and empty-response fallback activation.

## Validation performed

- `pnpm check`
- `pnpm regression:providers`
- `pnpm regression:roleplay`

## Test plan

- [ ] Manually verify a failed Roleplay background retry does not create a second scene illustration.
- [ ] Manually verify a failed Roleplay illustration retry does not regenerate the background.
- [ ] Manually verify an empty primary response invokes the configured fallback model.
- [ ] Manually verify a visible partial primary response is not replaced by fallback output.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Retry Illustrator failures for specific targets, including illustrations and scene backgrounds.
  * Added validation and clearer reporting for targeted retry requests.
  * Providers now fall back when responses are empty or contain only whitespace.

* **Bug Fixes**
  * Improved preservation and deduplication of failure details across retries.
  * Corrected failure-item handling when multiple retry targets share an agent type.

* **Tests**
  * Added regression coverage for targeted Illustrator retries and empty provider responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->