### PR TITLE
Log full agent responses in server debug output

### DIFF
--- a/packages/server/src/services/agents/agent-executor.ts
+++ b/packages/server/src/services/agents/agent-executor.ts
@@ -28,7 +28,7 @@ import {
   resolveMacros,
 } from "@marinara-engine/shared";
 import { getMaxToolRounds, isDebugAgentsEnabled } from "../../config/runtime-config.js";
-import { logger } from "../../lib/logger.js";
+import { logger, logDebugOverride } from "../../lib/logger.js";
 import { wrapContent } from "../prompt/format-engine.js";
 import { sanitizePromptLeaf } from "../prompt/prompt-escaping.js";
 import { settleAgentJobsWithConcurrencyLimit } from "./agent-concurrency.js";
@@ -563,6 +563,17 @@ function debugUsage(usage?: LLMUsage): Partial<AgentCallDebugEvent> {
 }
 
 function emitAgentDebug(context: AgentContext, event: AgentCallDebugEvent): void {
+  if ((event.stage === "response" || event.stage === "retry_response") && typeof event.response === "string") {
+    logDebugOverride(
+      Boolean(context.agentDebug) || isDebugAgentsEnabled(),
+      "[agent-debug] %s %s response (%d chars):\n%s",
+      event.agentType,
+      event.stage === "retry_response" ? "retry" : "raw",
+      event.response.length,
+      event.response,
+    );
+  }
+
   try {
     context.agentDebug?.(event);
   } catch (err) {


### PR DESCRIPTION
## What changed

- Mirrors complete raw agent responses to the server terminal when UI debug mode or `DEBUG_AGENTS` is enabled.
- Covers initial and retry responses through the shared debug-event boundary, including malformed JSON payloads.
- Preserves normal logging behavior when debug output is disabled.

## Why

The agent executor already sent the full response through the browser debug event, but its server-side logger only emitted a short preview at debug level. With the default log level, a malformed JSON response therefore produced a retry warning without showing the payload that caused it.

This gives users diagnosing local-model formatting failures the same response detail in the server terminal that they already receive in the browser console.

Fixes #3931

## Validation performed

- `pnpm check`
- `pnpm regression:prompt`
- `pnpm --filter @marinara-engine/server exec tsc --noEmit`
- `git diff --check`

## Manual verification

- [ ] Enable UI debug mode and confirm a malformed agent response is printed in full in the server terminal before the JSON retry warning.
- [ ] Confirm successful initial and retry responses remain visible in the browser debug console.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved debug logging for agent responses and retries.
  * Debug output now includes response length and full response text when agent debugging is enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->