### PR TITLE
Preserve the input caret after typographic quotes

### DIFF
--- a/e2e/core-flows.e2e.ts
+++ b/e2e/core-flows.e2e.ts
@@ -416,6 +416,58 @@ test("provider concurrency errors appear in generation toasts", async ({ page },
   }
 });
 
+test("typographic quotes do not pull the Roleplay caret behind later text", async ({ page }, testInfo) => {
+  test.skip(!testInfo.project.name.includes("desktop"), "Roleplay quote caret behavior is covered on desktop.");
+
+  const chatResponse = await page.request.post("/api/chats", {
+    data: { name: "Roleplay Quote Caret Smoke", mode: "roleplay", characterIds: [] },
+  });
+  expect(chatResponse.ok()).toBeTruthy();
+  const chat = (await chatResponse.json()) as { id: string };
+
+  try {
+    await page.addInitScript((chatId) => {
+      const persisted = JSON.parse(localStorage.getItem("marinara-engine-ui") ?? '{"state":{},"version":65}') as {
+        state: Record<string, unknown>;
+        version: number;
+      };
+      persisted.state.hasCompletedOnboarding = true;
+      persisted.state.quoteFormat = "typographic";
+      localStorage.setItem("marinara-engine-ui", JSON.stringify(persisted));
+      localStorage.setItem("marinara-active-chat-id", chatId);
+    }, chat.id);
+    await page.goto("/");
+
+    const input = page.locator("textarea.mari-chat-input-textarea");
+    const waitForDelayedSelectionRestores = () =>
+      input.evaluate(
+        () =>
+          new Promise<void>((resolve) => {
+            requestAnimationFrame(() => requestAnimationFrame(() => resolve()));
+          }),
+      );
+
+    await input.focus();
+    await page.keyboard.type("wasn't");
+    await waitForDelayedSelectionRestores();
+
+    await expect(input).toHaveValue("wasn’t");
+    await expect.poll(() => input.evaluate((element) => element.selectionStart)).toBe(6);
+    await expect.poll(() => input.evaluate((element) => element.selectionEnd)).toBe(6);
+
+    await input.fill("");
+    await input.focus();
+    await page.keyboard.type('"t');
+    await waitForDelayedSelectionRestores();
+
+    await expect(input).toHaveValue("“t");
+    await expect.poll(() => input.evaluate((element) => element.selectionStart)).toBe(2);
+    await expect.poll(() => input.evaluate((element) => element.selectionEnd)).toBe(2);
+  } finally {
+    await page.request.delete(`/api/chats/${chat.id}`);
+  }
+});
+
 test("generation fallbacks identify the replacement connection in a toast", async ({ page }, testInfo) => {
   test.skip(!testInfo.project.name.includes("desktop"), "Fallback toast regression is covered on desktop.");
 

--- a/packages/client/src/lib/text-selection.ts
+++ b/packages/client/src/lib/text-selection.ts
@@ -27,9 +27,10 @@ function applyTextSelection(snapshot: TextSelectionSnapshot) {
 export function restoreTextSelectionAfterRender(snapshot: TextSelectionSnapshot): () => void {
   let canceled = false;
   const frameIds: number[] = [];
+  const expectedValue = snapshot.element.value;
 
   const restore = () => {
-    if (!canceled) applyTextSelection(snapshot);
+    if (!canceled && snapshot.element.value === expectedValue) applyTextSelection(snapshot);
   };
 
   restore();


### PR DESCRIPTION
## What changed

- Stops delayed quote-selection restoration when the textarea has received newer text.
- Adds browser regression coverage for an apostrophe in `wasn't` and text following a double quote.

## Why

Typographic quote formatting restores the captured selection across a microtask and two animation frames so React renders do not move the caret. A later keystroke could arrive before those callbacks completed, allowing an older selection to overwrite the browser's newer caret position.

The restoration now proceeds only while the textarea still contains the exact value that scheduled it. Typing or otherwise changing the value makes the stale callback inert.

Fixes #3934

## Validation performed

- `pnpm check`
- `pnpm exec playwright test -c playwright.config.ts e2e/core-flows.e2e.ts --grep "typographic quotes do not pull"` (1 passed, 1 mobile skip by design)
- `git diff --check`

## Manual verification

- [ ] Enable typographic quotes and type `wasn't` quickly in the Roleplay input; verify the caret remains after `t`.
- [ ] Type a double quote followed immediately by a letter; verify the caret remains after the letter.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed text cursor positioning when typographic quotes are automatically applied, preventing the caret from jumping behind later text.
  - Improved selection restoration so it does not overwrite the cursor position after the text content changes.

- **Tests**
  - Added end-to-end coverage for typographic quote formatting and cursor placement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->