### PR TITLE
Fix Illustrator current background context

### DIFF
--- a/packages/client/src/hooks/use-generate.ts
+++ b/packages/client/src/hooks/use-generate.ts
@@ -14,7 +14,7 @@ import {
   type AgentFailure,
   type IllustratorRetryTarget,
 } from "../lib/agent-failures";
-import { chatBackgroundMetadataToUrl } from "../lib/backgrounds";
+import { chatBackgroundMetadataToUrl, chatBackgroundUrlToMetadata } from "../lib/backgrounds";
 import { formatGenerationParameterError } from "../lib/generation-parameter-errors";
 import {
   getTypewriterRevealCharsPerSecond,
@@ -783,6 +783,11 @@ function getCachedChatForGeneration(qc: QueryClient, chatId: string): Chat | und
   if (detail) return detail;
   const list = qc.getQueryData<Chat[]>(chatKeys.list());
   return list?.find((chat) => chat.id === chatId);
+}
+
+function getActiveChatBackgroundForGeneration(chatId: string): string | null | undefined {
+  if (useChatStore.getState().activeChatId !== chatId) return undefined;
+  return chatBackgroundUrlToMetadata(useUIStore.getState().chatBackground);
 }
 
 function parseChatCharacterIds(rawIds: unknown): string[] {
@@ -1567,11 +1572,13 @@ export function useGenerate() {
         if (flushPatch) await flushPatch();
 
         await waitForPendingChatMetadataSaves(params.chatId);
+        const currentBackground = getActiveChatBackgroundForGeneration(params.chatId);
 
         for await (const event of api.streamEvents(
           "/generate",
           {
             ...params,
+            ...(currentBackground !== undefined ? { currentBackground } : {}),
             userStatus,
             userActivity,
             userTimeZone,
@@ -3135,6 +3142,7 @@ export function useGenerate() {
         }
 
         await waitForPendingChatMetadataSaves(chatId);
+        const currentBackground = getActiveChatBackgroundForGeneration(chatId);
 
         let agentResultCount = 0;
         let trackerPatchCount = 0;
@@ -3146,6 +3154,7 @@ export function useGenerate() {
           {
             chatId,
             agentTypes,
+            ...(currentBackground !== undefined ? { currentBackground } : {}),
             streaming: useUIStore.getState().enableStreaming,
             debugMode: retryDebugMode,
             queueImageGenerationRequests: useUIStore.getState().queueImageGenerationRequests,

--- a/packages/server/src/routes/generate.routes.ts
+++ b/packages/server/src/routes/generate.routes.ts
@@ -988,6 +988,12 @@ export async function generateRoutes(app: FastifyInstance) {
         logger.warn(err, "[generate] Failed to remember timezone for chat %s", input.chatId);
       }
     }
+    const currentBackgroundSource =
+      input.currentBackground !== undefined ? input.currentBackground : chatMeta.background;
+    const currentBackground =
+      typeof currentBackgroundSource === "string" && currentBackgroundSource.trim()
+        ? currentBackgroundSource.trim()
+        : null;
     const promptNow = toZonedWallClockDate(new Date(), promptTimeZone);
     const excludePastReasoning = chatMeta.excludePastReasoning !== false;
     const imageCaptioningRuntime: ImageCaptioningRuntime = await resolveImageCaptioningRuntime({
@@ -3485,7 +3491,7 @@ export async function generateRoutes(app: FastifyInstance) {
             backgroundAgent.settings?.autoGenerateBackgrounds === true &&
             chatMeta.gameStoryboardViewerDisplayMode !== "background";
           agentContext.memory._availableBackgrounds = [];
-          agentContext.memory._currentBackground = chatMeta.background ?? null;
+          agentContext.memory._currentBackground = currentBackground;
           if (backgroundGenerationEnabled) {
             agentContext.memory._backgroundGenerationEnabled = true;
           }
@@ -3540,7 +3546,7 @@ export async function generateRoutes(app: FastifyInstance) {
           illustratorBackgroundGenerationEnabled(chatMode, chatMeta)
         ) {
           agentContext.memory._illustratorBackgroundGenerationEnabled = true;
-          agentContext.memory._currentBackground = chatMeta.background ?? null;
+          agentContext.memory._currentBackground = currentBackground;
         }
 
         const spotifyMusicAgents = resolvedAgents.filter(
@@ -8179,6 +8185,7 @@ export async function generateRoutes(app: FastifyInstance) {
                       chatName: chat.name,
                       chatMode: chatMode === "visual_novel" ? "visual_novel" : "roleplay",
                       chatMetadata: freshMeta,
+                      currentBackground: backgroundBeforeGeneration ?? currentBackground,
                       illustratorAgent: illustratorBackgroundAgent,
                       assistantResponse: combinedResponse,
                       decisionReason: backgroundDecisionReason,

--- a/packages/server/src/routes/generate/retry-agents-route.ts
+++ b/packages/server/src/routes/generate/retry-agents-route.ts
@@ -534,6 +534,7 @@ async function buildRetryAgentContext(args: {
   db: Parameters<typeof buildPromptMacroContext>[0]["db"];
   chat: any;
   chatMeta: Record<string, unknown>;
+  currentBackground: string | null;
   recentMessages: any[];
   enabledConfigs: any[];
   resolvedAgentTypes: Set<string>;
@@ -557,6 +558,7 @@ async function buildRetryAgentContext(args: {
     db,
     chat,
     chatMeta,
+    currentBackground,
     recentMessages,
     enabledConfigs,
     resolvedAgentTypes,
@@ -935,7 +937,7 @@ async function buildRetryAgentContext(args: {
           })),
       );
       agentContext.memory._availableBackgrounds = availableBackgrounds;
-      agentContext.memory._currentBackground = chatMeta.background ?? null;
+      agentContext.memory._currentBackground = currentBackground;
     } catch (err) {
       logger.warn(err, "[retry-agents] Failed to load available backgrounds for retry");
     }
@@ -946,7 +948,7 @@ async function buildRetryAgentContext(args: {
     illustratorBackgroundGenerationEnabled((chat as { mode?: unknown }).mode, chatMeta)
   ) {
     agentContext.memory._illustratorBackgroundGenerationEnabled = true;
-    agentContext.memory._currentBackground = chatMeta.background ?? null;
+    agentContext.memory._currentBackground = currentBackground;
   }
 
   const spotifyRetryConfig = enabledConfigs.find((config) => config.type === "spotify");
@@ -3436,6 +3438,11 @@ async function applyRetryResultEffects(args: {
         chatName: chat.name,
         chatMode: (chat as { mode?: unknown }).mode === "visual_novel" ? "visual_novel" : "roleplay",
         chatMetadata: freshMeta,
+        currentBackground:
+          backgroundBeforeGeneration ??
+          (typeof agentContext.memory._currentBackground === "string"
+            ? agentContext.memory._currentBackground
+            : null),
         illustratorAgent: illustratorEntry.resolved,
         assistantResponse: agentContext.mainResponse ?? "",
         decisionReason: backgroundDecisionReason,
@@ -3515,6 +3522,8 @@ export async function registerRetryAgentsRoute(app: FastifyInstance) {
       agentTypes: string[];
       streaming?: boolean;
       debugMode?: boolean;
+      /** Background currently displayed on the active chat surface. */
+      currentBackground?: string | null;
       /** Serialize Roleplay Illustrator provider calls when enabled. */
       queueImageGenerationRequests?: boolean;
       /** Pause a manual Illustrator retry after prompt compilation so the client can review it. */
@@ -3539,6 +3548,7 @@ export async function registerRetryAgentsRoute(app: FastifyInstance) {
       agentTypes,
       streaming = true,
       debugMode = false,
+      currentBackground: requestedCurrentBackground,
       queueImageGenerationRequests = true,
       reviewImagePromptsBeforeSend = false,
       agentPromptTemplateIds,
@@ -3600,6 +3610,12 @@ export async function registerRetryAgentsRoute(app: FastifyInstance) {
       }
 
       const chatMeta = parseExtra(chat.metadata);
+      const currentBackgroundSource =
+        requestedCurrentBackground !== undefined ? requestedCurrentBackground : chatMeta.background;
+      const currentBackground =
+        typeof currentBackgroundSource === "string" && currentBackgroundSource.trim()
+          ? currentBackgroundSource.trim()
+          : null;
       const requireAgentWriteApproval = agentWriteApprovalRequired(chatMeta);
       const allMessages = await chats.listMessages(chatId);
       let startIdx = 0;
@@ -3706,6 +3722,7 @@ export async function registerRetryAgentsRoute(app: FastifyInstance) {
         db: app.db,
         chat,
         chatMeta,
+        currentBackground,
         recentMessages,
         enabledConfigs,
         resolvedAgentTypes: new Set(resolvedAgents.map((a) => a.resolved.type)),
@@ -3727,6 +3744,7 @@ export async function registerRetryAgentsRoute(app: FastifyInstance) {
               db: app.db,
               chat,
               chatMeta,
+              currentBackground,
               recentMessages: preGenerationRecentMessages,
               enabledConfigs,
               resolvedAgentTypes: new Set(resolvedAgents.map((a) => a.resolved.type)),

--- a/packages/server/src/services/generation/illustrator-background-generation.ts
+++ b/packages/server/src/services/generation/illustrator-background-generation.ts
@@ -249,6 +249,7 @@ export async function generateIllustratorSceneBackground(args: {
   chatName?: string | null;
   chatMode: "roleplay" | "visual_novel";
   chatMetadata: Record<string, unknown>;
+  currentBackground: string | null;
   illustratorAgent: ResolvedAgent;
   assistantResponse: string;
   decisionReason?: string;

--- a/packages/shared/src/schemas/chat.schema.ts
+++ b/packages/shared/src/schemas/chat.schema.ts
@@ -43,6 +43,7 @@ export const generateRequestSchema = z.object({
   autonomous: z.boolean().optional().default(false),
   autonomousIntentKey: z.string().max(100).optional().default(""),
   userTimeZone: z.string().max(100).optional().default(""),
+  currentBackground: z.string().nullable().optional(),
   mentionedCharacterNames: z.array(z.string()).optional().default([]),
   forCharacterId: z.string().nullable().optional().default(null),
   skipPresenceDelay: z.boolean().optional().default(false),

--- a/packages/shared/src/types/chat.ts
+++ b/packages/shared/src/types/chat.ts
@@ -812,6 +812,8 @@ export interface GenerateRequest {
   continueMessageId?: string | null;
   /** Override connection for this generation */
   connectionId: string | null;
+  /** Background currently displayed on the active chat surface. */
+  currentBackground?: string | null;
   /** Validated owner-mode movement committed with the user turn. */
   pendingSpatialTransition?: import("./spatial-context.js").PendingSpatialTransition | null;
   /** One-shot attachments sent with the user message. */


### PR DESCRIPTION
## Linked issue

No linked issue was supplied for this report. A tracking issue should be opened and linked before merge.

## Why this change

- Illustrator could report `Currently active background: none` even while a Roleplay or Visual Novel background was visibly active.
- The runtime relied only on saved chat metadata, which did not always represent the currently displayed default or a pending background update.
- The dedicated second-stage background planner accepted a current background but its callers did not supply one.

## What changed

- Send the active chat surface background with normal generation and agent retry requests.
- Preserve metadata fallback behavior for inactive chats and legacy callers.
- Use the resolved background in Illustrator and Background agent context.
- Require and forward the current background when building an Illustrator scene background prompt.

## Validation

- [ ] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed `CONTRIBUTING.md`

Automated checks run while preparing this PR:

- `pnpm check`
- `pnpm regression:prompt`
- `git diff --check`

### Manual verification notes

- Live Illustrator generation was not run to avoid consuming provider credits.
- Manually verify a normal Illustrator run and a failed-job retry with both a saved background and the default Roleplay background. Confirm the debug prompt names the active background instead of reporting `none`.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Version/release files updated (only if this PR includes a version bump)

No documentation or release metadata changes are expected for this internal context fix.

## UI evidence (if applicable)

Not applicable; no rendered UI was changed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Generation requests now preserve the chat’s currently displayed background.
  - Background context is retained when retrying agent responses.
  - Automatic scene background generation now respects the active or newly selected background.
  - Background state is normalized consistently when unavailable or cleared.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->