### PR TITLE
fix: contain cropped avatar upload targets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,7 +66,7 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 - Stopped HTML-escaping angle brackets in prompt leaf content so character card fields, persona, lorebook entries, memories, and scene text now reach the model verbatim — `<thinking>`, `<scenario>`, and inline HTML like `<div>` are passed through as written instead of arriving as `&lt;thinking&gt;`, which had been corrupting cards, breaking roleplay HTML, and showing raw `&lt;` in the editor. This finalizes prompt leaf content as verbatim and **supersedes** the `<`/`&` prompt-boundary escaping added in #3108 (line above) and the untrusted-card-text escaping in the "Hardened prompt assembly" entry below, for Marinara's local single-user threat model. The framework's own structural section wrappers are emitted around this content and are unaffected, and the agent value/attribute escapers are unchanged (they still escape values into machine-parsed XML).
 - Made image prompt review display the subject-count-resolved dimensions actually sent to native NovelAI, kept Prompt Prefix count tokens out of scene sizing, and filled new NovelAI settings for legacy partial profiles (#3758).
 - Made recalled memories, cross-chat awareness, connected Roleplay/Game context, and their command instructions honor the active Conversation preset's XML, Markdown, or unwrapped format instead of emitting hardcoded XML (#3753).
-- Kept existing cropped Character avatars contained inside the Metadata upload preview instead of allowing the image to cover the card editor (#3741).
+- Kept existing cropped Character and Persona avatars contained inside editor upload targets and prevented escaped image layers from hijacking page clicks (#3741, #3939).
 
 ## [2.3.3]
 

--- a/packages/client/src/components/characters/CharacterEditor.tsx
+++ b/packages/client/src/components/characters/CharacterEditor.tsx
@@ -944,7 +944,7 @@ export function CharacterEditor() {
               <img
                 src={avatarPreview}
                 alt={formData.name}
-                className="h-full w-full object-cover"
+                className="pointer-events-none h-full w-full object-cover"
                 style={getAvatarCropStyle(formData.extensions.avatarCrop as AvatarCrop | LegacyAvatarCrop | undefined)}
               />
             ) : (
@@ -1373,7 +1373,7 @@ function MetadataTab({
               <img
                 src={avatarPreview}
                 alt=""
-                className="h-full w-full object-cover"
+                className="pointer-events-none h-full w-full object-cover"
                 style={getAvatarCropStyle(savedCrop ?? undefined)}
               />
             ) : (

--- a/packages/client/src/components/personas/PersonaEditor.tsx
+++ b/packages/client/src/components/personas/PersonaEditor.tsx
@@ -1350,7 +1350,7 @@ export function PersonaEditor() {
               <img
                 src={avatarPreview}
                 alt={formData.name}
-                className="h-full w-full object-cover"
+                className="pointer-events-none h-full w-full object-cover"
                 style={getAvatarCropStyle(formData.avatarCrop)}
               />
             ) : (

--- a/packages/client/src/styles/globals.css
+++ b/packages/client/src/styles/globals.css
@@ -1566,6 +1566,7 @@
 }
 
 .mari-editor-avatar-tile {
+  position: relative;
   cursor: pointer;
 }
 

--- a/scripts/regressions/open-issues.regression.ts
+++ b/scripts/regressions/open-issues.regression.ts
@@ -1270,6 +1270,21 @@ assert.match(
   /"relative flex h-16 w-16 shrink-0 items-center justify-center overflow-hidden rounded-xl/u,
   "The Metadata avatar preview must contain absolutely positioned saved crops",
 );
+assert.match(
+  globalStyles,
+  /\.mari-editor-avatar-tile \{\s*position: relative;\s*cursor: pointer;/u,
+  "The shared editor avatar upload target must contain absolutely positioned crops",
+);
+assert.equal(
+  characterEditorSource.match(/className="pointer-events-none h-full w-full object-cover"/gu)?.length,
+  2,
+  "Character avatar images inside upload targets must not intercept page clicks",
+);
+assert.equal(
+  personaEditorSource.match(/className="pointer-events-none h-full w-full object-cover"/gu)?.length,
+  1,
+  "The Persona header avatar inside its upload target must not intercept page clicks",
+);
 assert.match(gameJournalSource, /data-game-journal-scroll/u);
 assert.match(gameSurfaceSource, /h-\[min\(42rem,calc\(100dvh-6rem\)\)\]/u);
 assert.match(gameAssetHooksSource, /export function useGameAssetManifest/u);


### PR DESCRIPTION
## Why

In v2.3.3, changing a current-format avatar crop could let an absolutely positioned preview image escape its upload thumbnail. The escaped image covered the editor and clicks bubbled to the upload target, repeatedly opening the file picker. Staging already contains the original Metadata containment fix from #3741; this follow-up hardens every editor upload thumbnail involved in the report.

Fixes #3939.

## What changed

- enforce the shared Character and Persona header avatar tile as a positioning context
- prevent cropped image layers inside upload targets from receiving pointer events
- extend the open-issue regression guard for containment and click interception
- update the Unreleased changelog entry to include #3939

## Impact

Character and Persona crop previews remain visually contained, while normal editor clicks cannot be redirected into the avatar file picker by an escaped image layer.

## Checks

- pnpm check
- pnpm regression:issues
- pnpm smoke:ui (82 passed, 52 viewport-specific skips)
- git diff --check

## Manual verification

- [ ] Manually open a Character with an existing crop and drag or resize the crop on desktop
- [ ] Manually click elsewhere in the editor after changing the crop and confirm no file picker opens
- [ ] Manually repeat the crop interaction at a mobile viewport
- [ ] Manually spot-check the Persona header avatar upload target

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Character and Persona avatar previews so they remain contained within editor upload areas.
  * Prevented avatar images from intercepting clicks intended for upload controls or surrounding page elements.

* **Tests**
  * Added regression coverage to verify avatar containment, positioning, and click behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->