### PR TITLE
Fix current issues and agent timeout completion

### DIFF
--- a/packages/client/src/components/chat/ConversationMediaPickerPanel.tsx
+++ b/packages/client/src/components/chat/ConversationMediaPickerPanel.tsx
@@ -66,6 +66,9 @@ export function ConversationMediaPickerPanel({
               icon: "⭐",
               label: "Custom emojis",
               render: (query) => <CustomEmojiTab onInsert={onEmojiSelect} query={query} />,
+              renderSearch: (query) => (
+                <CustomEmojiTab onInsert={onEmojiSelect} query={query} searchResultsOnly />
+              ),
             }}
           />
         )}

--- a/packages/client/src/components/chat/CustomEmojiTab.tsx
+++ b/packages/client/src/components/chat/CustomEmojiTab.tsx
@@ -15,13 +15,26 @@ import {
 } from "../../hooks/use-custom-emojis";
 import { useConversationCustomEmojis, type ConversationCustomEmoji } from "../../hooks/use-conversation-custom-emojis";
 import { CustomEmojiSelectionSettings } from "./CustomEmojiSelectionSettings";
-import { readImageDimensions, validateDimensionsForKind, slugifyCustomName } from "../../lib/custom-emoji";
+import {
+  filterCustomEmojisByName,
+  readImageDimensions,
+  validateDimensionsForKind,
+  slugifyCustomName,
+} from "../../lib/custom-emoji";
 import { showPromptDialog, showConfirmDialog } from "../../lib/app-dialogs";
 import { downloadJsonFile } from "../../lib/download-json";
 import { api } from "../../lib/api-client";
 import { cn } from "../../lib/utils";
 
-export function CustomEmojiTab({ onInsert, query }: { onInsert: (token: string) => void; query: string }) {
+export function CustomEmojiTab({
+  onInsert,
+  query,
+  searchResultsOnly = false,
+}: {
+  onInsert: (token: string) => void;
+  query: string;
+  searchResultsOnly?: boolean;
+}) {
   const { data: emojis } = useCustomEmojis();
   const upload = useUploadCustomEmoji();
   const rename = useRenameCustomEmoji();
@@ -52,12 +65,12 @@ export function CustomEmojiTab({ onInsert, query }: { onInsert: (token: string) 
     conversationEmojis.filter((emoji) => emoji.source === "Global").map((emoji) => emoji.name),
   );
   const visibleGlobal = editing ? list : list.filter((emoji) => insertableGlobalNames.has(emoji.name));
-  const filteredGlobal = q ? visibleGlobal.filter((emoji) => emoji.name.toLowerCase().includes(q)) : visibleGlobal;
+  const filteredGlobal = filterCustomEmojisByName(visibleGlobal, q);
   const filteredGroups: [string, ConversationCustomEmoji[]][] = q
     ? sourceGroups
         .map(
           ([source, emojis]) =>
-            [source, emojis.filter((emoji) => emoji.name.toLowerCase().includes(q))] as [
+            [source, filterCustomEmojisByName(emojis, q)] as [
               string,
               ConversationCustomEmoji[],
             ],
@@ -166,73 +179,83 @@ export function CustomEmojiTab({ onInsert, query }: { onInsert: (token: string) 
     [importEmojis],
   );
 
+  if (searchResultsOnly && filteredGlobal.length === 0 && filteredGroups.length === 0) return null;
+
   return (
     <div className="px-1">
-      <div className="mb-2 flex items-center justify-between gap-2">
-        <div className="flex items-center gap-1.5">
-          <button
-            type="button"
-            onClick={() => fileRef.current?.click()}
-            className="inline-flex items-center gap-1.5 rounded-md bg-foreground/5 px-2 py-1 text-xs text-foreground/70 ring-1 ring-foreground/10 transition-colors hover:bg-foreground/10 hover:text-foreground/90"
-          >
-            <ImagePlus size="0.875rem" /> Upload
-          </button>
-          {editing && (
-            <>
-              <button
-                type="button"
-                onClick={() => importFileRef.current?.click()}
-                className="rounded-md bg-foreground/5 px-2 py-1 text-xs text-foreground/70 ring-1 ring-foreground/10 transition-colors hover:bg-foreground/10 hover:text-foreground/90"
-              >
-                Import
-              </button>
-              {list.length > 0 && (
+      {!searchResultsOnly && (
+        <div className="mb-2 flex items-center justify-between gap-2">
+          <div className="flex items-center gap-1.5">
+            <button
+              type="button"
+              onClick={() => fileRef.current?.click()}
+              className="inline-flex items-center gap-1.5 rounded-md bg-foreground/5 px-2 py-1 text-xs text-foreground/70 ring-1 ring-foreground/10 transition-colors hover:bg-foreground/10 hover:text-foreground/90"
+            >
+              <ImagePlus size="0.875rem" /> Upload
+            </button>
+            {editing && (
+              <>
                 <button
                   type="button"
-                  onClick={() => void handleExport()}
+                  onClick={() => importFileRef.current?.click()}
                   className="rounded-md bg-foreground/5 px-2 py-1 text-xs text-foreground/70 ring-1 ring-foreground/10 transition-colors hover:bg-foreground/10 hover:text-foreground/90"
                 >
-                  Export
+                  Import
                 </button>
+                {list.length > 0 && (
+                  <button
+                    type="button"
+                    onClick={() => void handleExport()}
+                    className="rounded-md bg-foreground/5 px-2 py-1 text-xs text-foreground/70 ring-1 ring-foreground/10 transition-colors hover:bg-foreground/10 hover:text-foreground/90"
+                  >
+                    Export
+                  </button>
+                )}
+              </>
+            )}
+          </div>
+          <input ref={fileRef} type="file" accept="image/*" multiple className="hidden" onChange={handleFiles} />
+          <input
+            ref={importFileRef}
+            type="file"
+            accept=".json,application/json"
+            className="hidden"
+            onChange={handleImportFile}
+          />
+          <div className="flex items-center gap-1">
+            <button
+              type="button"
+              onClick={() => setShowSettings((v) => !v)}
+              title="Selection preferences"
+              aria-label="Selection preferences"
+              className={cn(
+                "flex items-center rounded-md px-1.5 py-1 text-xs transition-colors",
+                showSettings
+                  ? "bg-foreground/10 text-foreground/80 ring-1 ring-foreground/15"
+                  : "text-foreground/45 hover:bg-foreground/10 hover:text-foreground/70",
               )}
-            </>
-          )}
+            >
+              <Settings size="0.875rem" />
+            </button>
+            <button
+              type="button"
+              onClick={() => setEditing((v) => !v)}
+              className={cn(
+                "rounded-md px-2 py-1 text-xs transition-colors",
+                editing
+                  ? "bg-foreground/10 text-foreground/80 ring-1 ring-foreground/15"
+                  : "text-foreground/45 hover:bg-foreground/10 hover:text-foreground/70",
+              )}
+            >
+              {editing ? "Done" : "Edit"}
+            </button>
+          </div>
         </div>
-        <input ref={fileRef} type="file" accept="image/*" multiple className="hidden" onChange={handleFiles} />
-        <input ref={importFileRef} type="file" accept=".json,application/json" className="hidden" onChange={handleImportFile} />
-        <div className="flex items-center gap-1">
-          <button
-            type="button"
-            onClick={() => setShowSettings((v) => !v)}
-            title="Selection preferences"
-            aria-label="Selection preferences"
-            className={cn(
-              "flex items-center rounded-md px-1.5 py-1 text-xs transition-colors",
-              showSettings
-                ? "bg-foreground/10 text-foreground/80 ring-1 ring-foreground/15"
-                : "text-foreground/45 hover:bg-foreground/10 hover:text-foreground/70",
-            )}
-          >
-            <Settings size="0.875rem" />
-          </button>
-          <button
-            type="button"
-            onClick={() => setEditing((v) => !v)}
-            className={cn(
-              "rounded-md px-2 py-1 text-xs transition-colors",
-              editing
-                ? "bg-foreground/10 text-foreground/80 ring-1 ring-foreground/15"
-                : "text-foreground/45 hover:bg-foreground/10 hover:text-foreground/70",
-            )}
-          >
-            {editing ? "Done" : "Edit"}
-          </button>
-        </div>
-      </div>
+      )}
 
-      {showSettings && <CustomEmojiSelectionSettings />}
+      {!searchResultsOnly && showSettings && <CustomEmojiSelectionSettings />}
 
-      {error && <p className="mb-2 px-1 text-[0.6875rem] text-red-400">{error}</p>}
+      {!searchResultsOnly && error && <p className="mb-2 px-1 text-[0.6875rem] text-red-400">{error}</p>}
 
       {filteredGlobal.length === 0 && filteredGroups.length === 0 ? (
         <p className="px-1 py-6 text-center text-[0.6875rem] text-foreground/45">
@@ -248,9 +271,9 @@ export function CustomEmojiTab({ onInsert, query }: { onInsert: (token: string) 
         <>
           {filteredGlobal.length > 0 && (
             <>
-              {filteredGroups.length > 0 && (
+              {(searchResultsOnly || filteredGroups.length > 0) && (
                 <p className="mb-1 px-1 text-[0.625rem] font-semibold uppercase tracking-wide text-foreground/40">
-                  Global
+                  {searchResultsOnly ? "Custom" : "Global"}
                 </p>
               )}
               <div className="grid grid-cols-6 gap-1">

--- a/packages/client/src/components/chat/ReactionAddButton.tsx
+++ b/packages/client/src/components/chat/ReactionAddButton.tsx
@@ -7,6 +7,7 @@
 import { useRef, useState, type RefObject } from "react";
 import { SmilePlus } from "lucide-react";
 import { cn } from "../../lib/utils";
+import { filterCustomEmojisByName } from "../../lib/custom-emoji";
 import { EmojiPicker } from "../ui/EmojiPicker";
 import { useCustomEmojis } from "../../hooks/use-custom-emojis";
 
@@ -68,6 +69,35 @@ function ReactionPickerPanel({
   onPick: (emoji: string, imageUrl: string | null) => void;
 }) {
   const { data: customEmojis } = useCustomEmojis();
+  const renderCustomEmojis = (query: string, searchResultsOnly = false) => {
+    const filtered = filterCustomEmojisByName(customEmojis ?? [], query);
+    if (searchResultsOnly && filtered.length === 0) return null;
+    return (
+      <div>
+        {searchResultsOnly && (
+          <p className="mb-1 px-1 text-[0.625rem] font-semibold uppercase tracking-wide text-foreground/40">Custom</p>
+        )}
+        <div className="grid grid-cols-6 gap-1">
+          {filtered.map((emoji) => (
+            <button
+              key={emoji.id}
+              type="button"
+              onClick={() => onPick(`:${emoji.name}:`, emoji.url)}
+              title={`:${emoji.name}:`}
+              className="flex aspect-square w-full items-center justify-center rounded-md p-1 transition-transform hover:scale-110 hover:bg-foreground/10 active:scale-100"
+            >
+              <img src={emoji.url} alt={`:${emoji.name}:`} className="max-h-9 max-w-full object-contain" />
+            </button>
+          ))}
+          {filtered.length === 0 && (
+            <p className="col-span-6 px-1 py-6 text-center text-[0.6875rem] text-foreground/45">
+              No custom emojis to react with yet.
+            </p>
+          )}
+        </div>
+      </div>
+    );
+  };
 
   return (
     <EmojiPicker
@@ -78,26 +108,8 @@ function ReactionPickerPanel({
       customTab={{
         icon: "⭐",
         label: "Custom emojis",
-        render: () => (
-          <div className="grid grid-cols-6 gap-1">
-            {(customEmojis ?? []).map((emoji) => (
-              <button
-                key={emoji.id}
-                type="button"
-                onClick={() => onPick(`:${emoji.name}:`, emoji.url)}
-                title={`:${emoji.name}:`}
-                className="flex aspect-square w-full items-center justify-center rounded-md p-1 transition-transform hover:scale-110 hover:bg-foreground/10 active:scale-100"
-              >
-                <img src={emoji.url} alt={`:${emoji.name}:`} className="max-h-9 max-w-full object-contain" />
-              </button>
-            ))}
-            {(customEmojis ?? []).length === 0 && (
-              <p className="col-span-6 px-1 py-6 text-center text-[0.6875rem] text-foreground/45">
-                No custom emojis to react with yet.
-              </p>
-            )}
-          </div>
-        ),
+        render: (query) => renderCustomEmojis(query),
+        renderSearch: (query) => renderCustomEmojis(query, true),
       }}
     />
   );

--- a/packages/client/src/components/modals/AboutMeViewerModal.tsx
+++ b/packages/client/src/components/modals/AboutMeViewerModal.tsx
@@ -304,6 +304,7 @@ export function AboutMeViewerModal({
         icon: "⭐",
         label: "Custom emojis",
         render: (query) => <CustomEmojiTab onInsert={insertEmoji} query={query} />,
+        renderSearch: (query) => <CustomEmojiTab onInsert={insertEmoji} query={query} searchResultsOnly />,
       }}
     />
   );

--- a/packages/client/src/components/ui/EmojiPicker.tsx
+++ b/packages/client/src/components/ui/EmojiPicker.tsx
@@ -1149,7 +1149,12 @@ interface EmojiPickerProps {
   /** Container (e.g. input bar) whose top edge determines vertical placement */
   containerRef?: React.RefObject<HTMLElement | null>;
   /** Optional extra tab (e.g. custom emojis) shown after the standard categories. */
-  customTab?: { icon: React.ReactNode; label?: string; render: (query: string) => React.ReactNode };
+  customTab?: {
+    icon: React.ReactNode;
+    label?: string;
+    render: (query: string) => React.ReactNode;
+    renderSearch?: (query: string) => React.ReactNode;
+  };
   /** Render inline to fill a parent (no portal/positioning) — e.g. inside the mobile composer sheet. */
   embedded?: boolean;
 }
@@ -1289,8 +1294,8 @@ export function EmojiPicker({
 
   if (!open) return null;
 
-  // Filter emojis by search
-  const filteredCategories = search.trim()
+  const searching = search.trim().length > 0;
+  const filteredCategories = searching
     ? (() => {
         const q = search.trim().toLowerCase();
         return CATEGORIES.map((cat) => ({
@@ -1302,10 +1307,13 @@ export function EmojiPicker({
         })).filter((cat) => cat.emojis.length > 0);
       })()
     : CATEGORIES;
+  const visibleStandardCategories = searching
+    ? filteredCategories
+    : [CATEGORIES[typeof activeCategory === "number" ? activeCategory : 0]];
 
   const content = (
     <>
-      {/* Search — filters the active standard category, or the custom tab's emojis */}
+      {/* Search spans every standard category and custom emojis, regardless of the selected tab. */}
       <div className="border-b border-foreground/10 px-3 py-2">
         <input
           type="text"
@@ -1359,32 +1367,34 @@ export function EmojiPicker({
 
       {/* Emoji grid (or the custom-emoji tab content) */}
       <div className="flex-1 overflow-y-auto px-2 py-2">
-        {activeCategory === "custom" && customTab
+        {!searching && activeCategory === "custom" && customTab
           ? customTab.render(search)
-          : (search.trim()
-              ? filteredCategories
-              : [CATEGORIES[typeof activeCategory === "number" ? activeCategory : 0]]
-            ).map((cat) => (
-              <div key={cat.label}>
-                <p className="mb-1 px-1 text-[0.625rem] font-semibold uppercase tracking-wide text-foreground/45">
-                  {cat.label}
-                </p>
-                <div className="grid grid-cols-8 gap-0.5">
-                  {cat.emojis.map((emoji) => (
-                    <button
-                      key={emoji}
-                      type="button"
-                      onClick={() => handleSelect(emoji)}
-                      aria-label={EMOJI_SEARCH_NAMES[emoji] ?? EMOJI_ALIASES[emoji] ?? emoji}
-                      title={EMOJI_SEARCH_NAMES[emoji] ?? EMOJI_ALIASES[emoji] ?? emoji}
-                      className="rounded-md p-1 text-xl transition-transform hover:scale-125 hover:bg-foreground/10 active:scale-100"
-                    >
-                      {emoji}
-                    </button>
-                  ))}
-                </div>
-              </div>
-            ))}
+          : (
+              <>
+                {visibleStandardCategories.map((cat) => (
+                  <div key={cat.label}>
+                    <p className="mb-1 px-1 text-[0.625rem] font-semibold uppercase tracking-wide text-foreground/45">
+                      {cat.label}
+                    </p>
+                    <div className="grid grid-cols-8 gap-0.5">
+                      {cat.emojis.map((emoji) => (
+                        <button
+                          key={emoji}
+                          type="button"
+                          onClick={() => handleSelect(emoji)}
+                          aria-label={EMOJI_SEARCH_NAMES[emoji] ?? EMOJI_ALIASES[emoji] ?? emoji}
+                          title={EMOJI_SEARCH_NAMES[emoji] ?? EMOJI_ALIASES[emoji] ?? emoji}
+                          className="rounded-md p-1 text-xl transition-transform hover:scale-125 hover:bg-foreground/10 active:scale-100"
+                        >
+                          {emoji}
+                        </button>
+                      ))}
+                    </div>
+                  </div>
+                ))}
+                {searching && customTab && (customTab.renderSearch?.(search) ?? customTab.render(search))}
+              </>
+            )}
       </div>
     </>
   );

--- a/packages/client/src/lib/custom-emoji.ts
+++ b/packages/client/src/lib/custom-emoji.ts
@@ -32,6 +32,13 @@ export function slugifyCustomName(raw: string): string {
     .slice(0, CUSTOM_NAME_MAX_LENGTH);
 }
 
+/** Match custom emoji names consistently across composer and reaction searches. */
+export function filterCustomEmojisByName<T extends { name: string }>(emojis: T[], query: string): T[] {
+  const normalizedQuery = query.trim().toLowerCase();
+  if (!normalizedQuery) return emojis;
+  return emojis.filter((emoji) => emoji.name.toLowerCase().includes(normalizedQuery));
+}
+
 /** Reject an image whose width or height exceeds the kind's max dimension. */
 export function validateDimensionsForKind(width: number, height: number, kind: CustomKind): CustomKindValidation {
   const max = CUSTOM_KIND_MAX_DIMENSION[kind];

--- a/packages/client/src/stores/ui.store.ts
+++ b/packages/client/src/stores/ui.store.ts
@@ -1136,6 +1136,7 @@ export function pickSyncedSettings(state: UIState) {
     defaultDialogueColor: state.defaultDialogueColor,
     chatChromeTextColor: state.chatChromeTextColor,
     chatFontOpacity: state.chatFontOpacity,
+    gameTextEffectsEnabled: state.gameTextEffectsEnabled,
     roleplayAvatarStyle: state.roleplayAvatarStyle,
     roleplayAvatarScale: state.roleplayAvatarScale,
     roleplayAvatarsScrollable: state.roleplayAvatarsScrollable,

--- a/packages/server/src/routes/generate.routes.ts
+++ b/packages/server/src/routes/generate.routes.ts
@@ -240,6 +240,7 @@ import {
   customAgentCanEmitResult,
   findResultAgent,
   isAbortLikeError,
+  shouldAutomaticallyRetryAgentResult,
 } from "./generate/agent-result-capabilities.js";
 import { appendConversationCustomAssetAdvertisements } from "./generate/conversation-custom-assets.js";
 import { injectConnectedConversationPromptBlocks } from "./generate/connected-conversation-injections.js";
@@ -6864,8 +6865,16 @@ export async function generateRoutes(app: FastifyInstance) {
           // ── Auto-retry failed agents once ──
           const failedResults = postResults.filter((r) => !r.success);
           if (failedResults.length > 0 && !abortController.signal.aborted) {
+            const retryableFailures = failedResults.filter(shouldAutomaticallyRetryAgentResult);
+            const timedOutFailures = failedResults.filter((result) => !shouldAutomaticallyRetryAgentResult(result));
+            if (timedOutFailures.length > 0) {
+              logger.warn(
+                "[agents] Skipping automatic retry after timeout for: %s",
+                timedOutFailures.map((result) => result.agentType).join(", "),
+              );
+            }
             const retryResults: AgentResult[] = [];
-            for (const failed of failedResults) {
+            for (const failed of retryableFailures) {
               const agentCfg = resolvedAgents.find((a) => a.type === failed.agentType);
               if (!agentCfg) continue;
               try {

--- a/packages/server/src/routes/generate/agent-result-capabilities.ts
+++ b/packages/server/src/routes/generate/agent-result-capabilities.ts
@@ -10,6 +10,11 @@ export function isAbortLikeError(error: unknown): boolean {
   return error instanceof Error && error.name === "AbortError";
 }
 
+export function shouldAutomaticallyRetryAgentResult(result: Pick<AgentResult, "success" | "error">): boolean {
+  if (result.success) return false;
+  return !/\b(?:timed?\s*out|timeout|etimedout|deadline exceeded)\b/i.test(result.error ?? "");
+}
+
 export function customAgentCanApplyResult(
   result: AgentResult,
   agents: ResolvedAgent[],

--- a/packages/server/src/services/image/image-generation.ts
+++ b/packages/server/src/services/image/image-generation.ts
@@ -2105,9 +2105,14 @@ function openRouterAspectRatio(width?: number, height?: number): string | null {
   )[0];
 }
 
-function openRouterModalities(model?: string): string[] {
+export function openRouterModalities(model?: string): string[] {
   const lower = model?.trim().toLowerCase() ?? "";
-  if (lower.startsWith("black-forest-labs/") || lower.startsWith("sourceful/") || lower.startsWith("recraft/")) {
+  if (
+    lower.startsWith("black-forest-labs/") ||
+    lower.startsWith("sourceful/") ||
+    lower.startsWith("recraft/") ||
+    lower.startsWith("krea/")
+  ) {
     return ["image"];
   }
   return ["image", "text"];

--- a/packages/shared/src/utils/conversation-presence.ts
+++ b/packages/shared/src/utils/conversation-presence.ts
@@ -133,6 +133,7 @@ export function getCurrentStatus(
   const currentMinutes = now.getHours() * 60 + now.getMinutes();
 
   for (const block of daySchedule) {
+    if (!block || typeof block.time !== "string") continue;
     const [startStr, endStr] = block.time.split("-");
     if (!startStr || !endStr) continue;
 

--- a/scripts/regressions/open-issues.regression.ts
+++ b/scripts/regressions/open-issues.regression.ts
@@ -31,6 +31,7 @@ import {
   shouldExecuteQuickPostAsCommand,
 } from "../../packages/client/src/lib/slash-commands.js";
 import { getAvatarCropStyle } from "../../packages/client/src/lib/utils.js";
+import { filterCustomEmojisByName } from "../../packages/client/src/lib/custom-emoji.js";
 import {
   trackChatMetadataSave,
   waitForPendingChatMetadataSaves,
@@ -121,6 +122,7 @@ import { shouldAutomaticallyRetryAgentResult } from "../../packages/server/src/r
 import { runImageGenerationRequest } from "../../packages/server/src/services/image/image-generation-queue.js";
 import {
   detectNovelAiSubjectCount,
+  openRouterModalities,
   resolveNovelAiDefaults,
   resolveNovelAiRequestSize,
   resolveNovelAiSize,
@@ -1668,6 +1670,11 @@ const retryAgentsPromptReviewSource = readFileSync(
   new URL("../../packages/server/src/routes/generate/retry-agents-route.ts", import.meta.url),
   "utf8",
 );
+const uiStoreSource = readFileSync(new URL("../../packages/client/src/stores/ui.store.ts", import.meta.url), "utf8");
+const syncedSettingsSource = uiStoreSource.slice(
+  uiStoreSource.indexOf("export function pickSyncedSettings"),
+  uiStoreSource.indexOf("export const useUIStore"),
+);
 assert.equal(
   shouldAutomaticallyRetryAgentResult({ success: false, error: "The operation was aborted due to timeout" }),
   false,
@@ -1682,6 +1689,24 @@ assert.equal(
   shouldAutomaticallyRetryAgentResult({ success: true, error: null }),
   false,
   "successful agents should never enter the automatic retry queue",
+);
+assert.deepEqual(openRouterModalities("krea/krea-2-large"), ["image"]);
+assert.deepEqual(openRouterModalities(" KREA/krea-2-medium-turbo "), ["image"]);
+assert.deepEqual(openRouterModalities("google/gemini-3.1-flash-image-preview"), ["image", "text"]);
+assert.deepEqual(
+  filterCustomEmojisByName(
+    [
+      { name: "MariWave", id: "wave" },
+      { name: "dottore_stare", id: "stare" },
+    ],
+    "mari",
+  ),
+  [{ name: "MariWave", id: "wave" }],
+);
+assert.match(
+  syncedSettingsSource,
+  /gameTextEffectsEnabled: state\.gameTextEffectsEnabled/,
+  "Game text effects must remain off after synced settings are restored",
 );
 assert.match(chatAreaPromptReviewSource, /MEDIA_PROMPT_PREVIEW_TIMEOUT_MS/);
 assert.match(chatAreaPromptReviewSource, /confirmRoleplayVideoPromptReview/);

--- a/scripts/regressions/open-issues.regression.ts
+++ b/scripts/regressions/open-issues.regression.ts
@@ -117,6 +117,7 @@ import {
   normalizeCustomAgentRepositoryUrl,
   parseCustomAgentRepositoryArchive,
 } from "../../packages/server/src/services/agents/custom-agent-repositories.service.js";
+import { shouldAutomaticallyRetryAgentResult } from "../../packages/server/src/routes/generate/agent-result-capabilities.js";
 import { runImageGenerationRequest } from "../../packages/server/src/services/image/image-generation-queue.js";
 import {
   detectNovelAiSubjectCount,
@@ -1666,6 +1667,21 @@ const imagePromptReviewModalSource = readFileSync(
 const retryAgentsPromptReviewSource = readFileSync(
   new URL("../../packages/server/src/routes/generate/retry-agents-route.ts", import.meta.url),
   "utf8",
+);
+assert.equal(
+  shouldAutomaticallyRetryAgentResult({ success: false, error: "The operation was aborted due to timeout" }),
+  false,
+  "timed-out agents should settle as failures instead of starting another full timeout window",
+);
+assert.equal(
+  shouldAutomaticallyRetryAgentResult({ success: false, error: "Agent returned invalid JSON" }),
+  true,
+  "ordinary agent failures should retain the existing one-time automatic retry",
+);
+assert.equal(
+  shouldAutomaticallyRetryAgentResult({ success: true, error: null }),
+  false,
+  "successful agents should never enter the automatic retry queue",
 );
 assert.match(chatAreaPromptReviewSource, /MEDIA_PROMPT_PREVIEW_TIMEOUT_MS/);
 assert.match(chatAreaPromptReviewSource, /confirmRoleplayVideoPromptReview/);

--- a/scripts/regressions/timezone.regression.ts
+++ b/scripts/regressions/timezone.regression.ts
@@ -54,6 +54,14 @@ assert.equal(
   getEffectiveCurrentStatus(timeZoneSchedule, null, scheduleInstant, "free time", tokyoScheduleNow).status,
   "idle",
 );
+const malformedSchedule = {
+  ...timeZoneSchedule,
+  days: { Tuesday: [{ activity: "missing time", status: "dnd" }] },
+} as unknown as WeekSchedule;
+assert.deepEqual(
+  getEffectiveCurrentStatus(malformedSchedule, null, scheduleInstant, "free time", newYorkScheduleNow),
+  { status: "online", activity: "free time" },
+);
 assert.equal(
   getEffectiveCurrentStatus(
     timeZoneSchedule,


### PR DESCRIPTION
## Linked issues

Closes #3801
Closes #3944
Closes #3945
Closes #3946

## Why this change

- Timed-out post-generation agents entered another full automatic retry window, so the stream appeared to hang instead of settling with the existing failed-agent notification.
- The Game text-effects toggle was stored locally but omitted from cross-device settings sync, allowing the disabled state to revert.
- OpenRouter Krea image models were requested with `image, text` output instead of image-only output.
- Custom emoji search depended on the selected tab and did not work in the reaction picker.
- Malformed persisted schedule blocks without `time` could crash the UI while resolving conversation presence.

## What changed

- Treat agent timeout results as terminal for the current turn while retaining the existing one-time retry for ordinary failures.
- Include `gameTextEffectsEnabled` in the synced settings subset.
- Recognize the `krea/` OpenRouter model family as image-only.
- Search standard and custom emoji together regardless of the active tab, including reaction search.
- Ignore malformed schedule blocks that do not contain a time range.
- Add focused regressions for each failure mode.

## Validation evidence

- `pnpm check` passed. The existing `HomeProfessorMariChat.tsx` hook dependency warning remains unchanged.
- `pnpm regression:issues` passed.
- `pnpm regression:timezone` passed.
- `pnpm smoke:ui` completed with 81 passed and 52 expected project skips; one unrelated Tracker persistence flow failed once, then passed when rerun in isolation.
- `git diff --check` passed.

## Human verification checklist

- [ ] Manually verify a timed-out post-generation agent settles the stream and displays the failed-agent toast.
- [ ] Disable Game text effects, reload, and verify the setting remains disabled after settings sync.
- [ ] Generate an image with an OpenRouter `krea/` model.
- [ ] Search for a custom emoji from a standard emoji tab in both the chat and reaction pickers.
- [ ] Load a conversation containing malformed schedule metadata and verify the UI remains usable.
- [ ] Check relevant empty states and mobile behavior.

## Contributor checklist

- [ ] Read and followed `CONTRIBUTING.md`.
- [ ] Container build and runtime verified.
- [ ] Documentation impact reviewed.
- [ ] Release metadata impact reviewed.

## UI evidence

The full Playwright smoke suite exercised the desktop and mobile shell. No visual redesign is included; the emoji picker retains its existing categories and styling while search now spans all emoji sources.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Emoji picker searches now show matching custom emojis alongside standard results.
  - Added support for image-only responses from additional image models.
  - Game text-effects settings are now preserved when UI settings are synchronized.

- **Bug Fixes**
  - Automatic retries now skip failures that are not retryable timeouts.
  - Invalid schedule entries no longer disrupt presence status calculations.

- **Tests**
  - Expanded regression coverage for emoji search, retry behavior, image modalities, settings persistence, and malformed schedules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->