### PR TITLE
Move Roleplay background generation to Illustrator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 
 ### Fixed
 
+- Removed the Background agent's obsolete image-generation toggle and runtime path. The agent now only selects existing library backgrounds, while Illustrator owns automatic and Gallery background generation. Gallery-generated backgrounds are applied to the active Roleplay chat instead of being attached as ordinary illustrations.
 - Stopped Roleplay generation immediately when **Stop** is pressed by sending the explicit server cancellation through the authenticated API client instead of allowing CSRF protection to discard it.
 - Made renamed Chat Summary preset markers use their authored wrapper name and resolved character-dependent summary macros against each individual group responder, allowing conditional summary knowledge to remain scoped to its intended character.
 - Kept Chat Summary entry editing responsive by isolating the live title and content draft from the rest of the summary popover until **Save** is pressed.

--- a/docs/agents/built-in-agents.md
+++ b/docs/agents/built-in-agents.md
@@ -98,11 +98,11 @@ Manages quest objectives, completion, and rewards. Use it for adventure style pl
 
 ### Background
 
-Picks the best matching background image for the current scene from your uploaded backgrounds. It can also generate a new background when nothing fits, if you turn that on.
+Picks the best matching background image for the current scene from your uploaded backgrounds. It does not generate images; use Illustrator when you want automatic scene background generation.
 
 - **Phase**: Post-Processing.
 - **Where it works**: Roleplay.
-- **Key settings**: a **Background Image Generation** toggle. Generated backgrounds are saved into your normal background library for reuse.
+- **Key settings**: standard Agent connection and context controls. Background selection uses only images already available in your background library.
 
 ### Character Tracker
 

--- a/docs/media/scene-backgrounds.md
+++ b/docs/media/scene-backgrounds.md
@@ -31,10 +31,10 @@ The background is built from your current scene. In a game, this includes the ge
 If Marinara cannot find an image connection to use, the generate step fails with this message:
 
 ```
-Choose an image generation connection for the Background/Illustrator agent, or mark an image generation connection as the default for agents.
+Choose an image generation connection for the Illustrator agent, or mark one as the default image connection.
 ```
 
-To fix this, open the **Connections** panel, expand **Defaults**, and choose an image connection under **Images**, or set a connection for the **Background** agent.
+To fix this, open the **Connections** panel, expand **Defaults**, and choose an image connection under **Images**, or set an image connection override on the **Illustrator** agent.
 
 ## The Gallery panel
 

--- a/docs/roleplay/backgrounds.md
+++ b/docs/roleplay/backgrounds.md
@@ -10,7 +10,7 @@ You do not need image generation for this to work. If you have not set up an ima
 
 ## The Background agent
 
-The **Background** agent is an optional helper that chooses a scene backdrop for you. It runs after each reply. It reads the current scene, then picks the most fitting image from every available background. Library folders are only an organization aid in Settings and never hide choices from the agent. If a location has no matching image, it can generate a new one for you.
+The **Background** agent is an optional helper that chooses a scene backdrop for you. It runs after each reply. It reads the current scene, then picks the most fitting image from every available background. Library folders are only an organization aid in Settings and never hide choices from the agent. It selects existing images only; automatic background generation belongs to the **Illustrator** agent.
 
 The **Background** agent is off by default. To turn it on:
 
@@ -31,7 +31,7 @@ You can also make a new backdrop yourself, without the agent. Marinara builds an
 
 While it runs, you see this note: "AI background generation is running. The new background will be applied when it finishes." The new image is added to your background library and applied to the scene.
 
-Manual generation and the **Background** agent both need an image generation connection. Marinara uses the connection set for the **Background** agent first. If none is set, it falls back to the **Illustrator** agent's connection, then to your default image generation connection. If it cannot find one, generation fails with this message: "Choose an image generation connection for the Background/Illustrator agent, or mark an image generation connection as the default for agents."
+Manual generation uses the **Illustrator** agent's image connection, then falls back to your default image generation connection. The **Background** agent does not need an image connection because it only selects images already in your library. If Marinara cannot find a connection, generation fails with this message: "Choose an image generation connection for the Illustrator agent, or mark one as the default image connection."
 
 Scene background generation works only in Roleplay and Game modes. It is not available in Conversation mode.
 

--- a/packages/client/src/components/agents/AgentEditor.tsx
+++ b/packages/client/src/components/agents/AgentEditor.tsx
@@ -531,7 +531,6 @@ export function AgentEditor() {
   const [localUseChatActiveLorebooks, setLocalUseChatActiveLorebooks] = useState(false);
   const [localSourceFileIds, setLocalSourceFileIds] = useState<string[]>([]);
   const [localAutoGenerateAvatars, setLocalAutoGenerateAvatars] = useState(false);
-  const [localAutoGenerateBackgrounds, setLocalAutoGenerateBackgrounds] = useState(false);
   const [localUseAvatarReferences, setLocalUseAvatarReferences] = useState(false);
   const [localIncludeCharacterAppearance, setLocalIncludeCharacterAppearance] = useState(false);
   const [localImagePositivePrompt, setLocalImagePositivePrompt] = useState("");
@@ -589,7 +588,9 @@ export function AgentEditor() {
       setLocalPromptTemplates(normalizeAgentPromptTemplateOptions(promptTemplateSource));
       setLocalContextSize(normalizeOptionalNumber(settings.contextSize));
       setLocalMaxTokens(normalizeOptionalNumber(settings.maxTokens) || (defaultSettings.maxTokens as number) || "");
-      setLocalImageConnectionId(normalizeImageConnectionOverride(settings.imageConnectionId));
+      setLocalImageConnectionId(
+        agentType === "background" ? "" : normalizeImageConnectionOverride(settings.imageConnectionId),
+      );
       setLocalRunInterval(
         (settings.runInterval as number | undefined) ?? (defaultSettings.runInterval as number) ?? "",
       );
@@ -641,7 +642,6 @@ export function AgentEditor() {
       );
       setLocalSourceFileIds(normalizeStringArray(settings.sourceFileIds));
       setLocalAutoGenerateAvatars(settings.autoGenerateAvatars === true);
-      setLocalAutoGenerateBackgrounds(settings.autoGenerateBackgrounds === true);
       setLocalUseAvatarReferences(
         (settings.useAvatarReferences as boolean | undefined) ?? defaultSettings.useAvatarReferences === true,
       );
@@ -707,7 +707,6 @@ export function AgentEditor() {
       setLocalUseChatActiveLorebooks(defaultSettings.useChatActiveLorebooks === true);
       setLocalSourceFileIds([]);
       setLocalAutoGenerateAvatars(false);
-      setLocalAutoGenerateBackgrounds(false);
       setLocalUseAvatarReferences(defaultSettings.useAvatarReferences === true);
       setLocalIncludeCharacterAppearance(defaultSettings.includeCharacterAppearance === true);
       setLocalImagePositivePrompt("");
@@ -763,7 +762,6 @@ export function AgentEditor() {
       setLocalUseChatActiveLorebooks(false);
       setLocalSourceFileIds([]);
       setLocalAutoGenerateAvatars(false);
-      setLocalAutoGenerateBackgrounds(false);
       setLocalUseAvatarReferences(false);
       setLocalIncludeCharacterAppearance(false);
       setLocalImagePositivePrompt("");
@@ -837,8 +835,6 @@ export function AgentEditor() {
   const isKnowledgeRetrievalAgent = agentDetailId === "knowledge-retrieval" || dbConfig?.type === "knowledge-retrieval";
   // Knowledge Router agent — also uses the lorebook source selector (file picker stays Retrieval-only)
   const isKnowledgeRouterAgent = agentDetailId === "knowledge-router" || dbConfig?.type === "knowledge-router";
-  // Background agent — can optionally generate missing roleplay backgrounds.
-  const isBackgroundAgent = agentDetailId === "background" || dbConfig?.type === "background";
   // Prose Guardian agent — exposes macro defaults used by its rewrite prompt.
   const isProseGuardianAgent = agentDetailId === "prose-guardian" || dbConfig?.type === "prose-guardian";
   // Continuity Checker agent — shares the rewrite reveal timing control.
@@ -1020,7 +1016,8 @@ export function AgentEditor() {
       if (currentSettings[key] !== undefined) preservedSpotifyFields[key] = currentSettings[key];
     }
     const savedConnectionId = normalizeTextConnectionOverride(localConnectionId);
-    const savedImageConnectionId = normalizeImageConnectionOverride(localImageConnectionId);
+    const savedImageConnectionId =
+      agentType === "background" ? "" : normalizeImageConnectionOverride(localImageConnectionId);
 
     const payload = {
       name: localName,
@@ -1073,7 +1070,6 @@ export function AgentEditor() {
         ...(isKnowledgeRetrievalAgent && localSourceFileIds.length > 0 ? { sourceFileIds: localSourceFileIds } : {}),
         ...(savedImageConnectionId ? { imageConnectionId: savedImageConnectionId } : {}),
         ...(localAutoGenerateAvatars ? { autoGenerateAvatars: true } : {}),
-        ...(localAutoGenerateBackgrounds ? { autoGenerateBackgrounds: true } : {}),
         ...(isIllustratorAgent
           ? {
               useAvatarReferences: localUseAvatarReferences,
@@ -1155,7 +1151,6 @@ export function AgentEditor() {
     localSourceLorebookIds,
     localSourceFileIds,
     localAutoGenerateAvatars,
-    localAutoGenerateBackgrounds,
     localUseAvatarReferences,
     localIncludeCharacterAppearance,
     localProseGuardianBanned,
@@ -1251,9 +1246,8 @@ export function AgentEditor() {
         : {}),
       ...(localSourceLorebookIds.length > 0 ? { sourceLorebookIds: localSourceLorebookIds } : {}),
       ...(isKnowledgeRetrievalAgent && localSourceFileIds.length > 0 ? { sourceFileIds: localSourceFileIds } : {}),
-      ...(localImageConnectionId ? { imageConnectionId: localImageConnectionId } : {}),
+      ...(agentType !== "background" && localImageConnectionId ? { imageConnectionId: localImageConnectionId } : {}),
       ...(localAutoGenerateAvatars ? { autoGenerateAvatars: true } : {}),
-      ...(localAutoGenerateBackgrounds ? { autoGenerateBackgrounds: true } : {}),
       ...(isIllustratorAgent
         ? {
             useAvatarReferences: localUseAvatarReferences,
@@ -1980,68 +1974,6 @@ export function AgentEditor() {
                       </option>
                     ))}
                   </select>
-                </div>
-              )}
-            </FieldGroup>
-          )}
-
-          {/* ── Missing Background Generation (Background agent only) ── */}
-          {isBackgroundAgent && (
-            <FieldGroup
-              label="Background Image Generation"
-              icon={<ImageIcon size="0.875rem" className="text-[var(--primary)]" />}
-              help="When enabled, the Background agent can generate a new reusable roleplay background when none of your existing backgrounds fit the scene."
-            >
-              <EditorSwitchRow
-                label={localAutoGenerateBackgrounds ? "Generate missing backgrounds" : "Only pick existing backgrounds"}
-                checked={localAutoGenerateBackgrounds}
-                onChange={() => {
-                  setLocalAutoGenerateBackgrounds(!localAutoGenerateBackgrounds);
-                  markDirty();
-                }}
-                description={
-                  localAutoGenerateBackgrounds
-                    ? "If nothing fits a changed location, the agent can request a new background image."
-                    : "The agent will choose the closest uploaded background and never create a new one."
-                }
-                labelClassName="text-sm"
-              />
-
-              {localAutoGenerateBackgrounds && (
-                <div className="mt-3 space-y-2">
-                  <div>
-                    <label className="mb-1 block text-xs text-[var(--muted-foreground)]">
-                      Image Generation Connection
-                    </label>
-                    <select
-                      value={localImageConnectionId}
-                      onChange={(e) => {
-                        setLocalImageConnectionId(e.target.value);
-                        markDirty();
-                      }}
-                      className="w-full rounded-xl bg-[var(--secondary)] px-3 py-2.5 text-sm ring-1 ring-[var(--border)] focus:outline-none focus:ring-2 focus:ring-[var(--ring)]"
-                    >
-                      <option value="">
-                        {defaultAgentImageConn
-                          ? `Agent image default (${defaultAgentImageConn.name})`
-                          : "None (select a connection)"}
-                      </option>
-                      {imageConnections.map((conn) => (
-                        <option key={conn.id} value={conn.id}>
-                          {conn.name} ({conn.provider})
-                        </option>
-                      ))}
-                    </select>
-                  </div>
-                  <p className="text-[0.625rem] text-[var(--muted-foreground)]">
-                    Generated images are saved into your normal Backgrounds library, so later runs can reuse them
-                    instead of regenerating the same place.
-                  </p>
-                  {!localImageConnectionId && !defaultAgentImageConn && (
-                    <p className="rounded-lg border border-amber-400/20 bg-amber-400/10 px-3 py-2 text-[0.625rem] text-amber-300">
-                      Add an image generation connection here or choose one under Defaults → Images in Connections.
-                    </p>
-                  )}
                 </div>
               )}
             </FieldGroup>

--- a/packages/client/src/components/chat/ChatArea.tsx
+++ b/packages/client/src/components/chat/ChatArea.tsx
@@ -1235,6 +1235,7 @@ export function ChatArea() {
     if (!activeChatId) return;
     await retryAgents(activeChatId, ["illustrator"], {
       agentPromptTemplateIds: { illustrator: "background" },
+      illustratorRetryTargets: ["background"],
     });
   }, [activeChatId, retryAgents]);
 

--- a/packages/server/src/routes/backgrounds.routes.ts
+++ b/packages/server/src/routes/backgrounds.routes.ts
@@ -164,11 +164,10 @@ function readTrimmedString(value: unknown): string | null {
   return typeof value === "string" && value.trim().length > 0 ? value.trim() : null;
 }
 
-async function readAgentImageConnectionId(
+async function readIllustratorImageConnectionId(
   agents: ReturnType<typeof createAgentsStorage>,
-  type: "background" | "illustrator",
 ): Promise<string | null> {
-  const agent = await agents.getByType(type);
+  const agent = await agents.getByType("illustrator");
   return readTrimmedString(parseRecord(agent?.settings).imageConnectionId);
 }
 
@@ -185,11 +184,8 @@ async function resolveSceneBackgroundImageConnection(
 
   if (mode === "game") {
     pushCandidate(readTrimmedString(metadata.gameImageConnectionId));
-    pushCandidate(await readAgentImageConnectionId(agents, "illustrator"));
-  } else {
-    pushCandidate(await readAgentImageConnectionId(agents, "background"));
-    pushCandidate(await readAgentImageConnectionId(agents, "illustrator"));
   }
+  pushCandidate(await readIllustratorImageConnectionId(agents));
 
   for (const id of candidates) {
     const conn = await connections.getWithKey(id);
@@ -402,8 +398,7 @@ export async function backgroundsRoutes(app: FastifyInstance) {
     if (!imgConn) {
       return {
         response: reply.status(400).send({
-          error:
-            "Choose an image generation connection for the Background/Illustrator agent, or mark an image generation connection as the default for agents.",
+          error: "Choose an image generation connection for the Illustrator agent, or mark one as the default image connection.",
         }),
       };
     }

--- a/packages/server/src/routes/generate.routes.ts
+++ b/packages/server/src/routes/generate.routes.ts
@@ -38,7 +38,6 @@ import {
   LOCAL_SIDECAR_CONNECTION_ID,
   normalizeTextForMatch,
   normalizeGameStoryboardKeyframeCount,
-  resolveGameSetupArtStylePrompt,
   type APIProvider,
   type MacroContext,
 } from "@marinara-engine/shared";
@@ -79,7 +78,6 @@ import { createPersonaGalleryStorage } from "../services/storage/persona-gallery
 import { createAppSettingsStorage } from "../services/storage/app-settings.storage.js";
 import { buildLorebookSemanticEmbeddingsById, warmLorebookEntryEmbeddings } from "../services/lorebook/embeddings.js";
 import { applyRegexScriptsToPromptMessages } from "../services/regex/regex-application.js";
-import { createPromptOverridesStorage } from "../services/storage/prompt-overrides.storage.js";
 import {
   filterRelevantLorebooks,
   processLorebooks,
@@ -130,7 +128,6 @@ import { DATA_DIR } from "../utils/data-dir.js";
 import { executeAgent, normalizeAgentContextSize, resolveAgentResultType } from "../services/agents/agent-executor.js";
 import { matchCustomAgentActivation } from "./generate/agent-activation.js";
 import { listCharacterSprites } from "../services/game/sprite.service.js";
-import { generateChatBackground } from "../services/game/game-asset-generation.js";
 import {
   generateIllustratorSceneBackground,
   illustratorBackgroundGenerationEnabled,
@@ -3488,30 +3485,8 @@ export async function generateRoutes(app: FastifyInstance) {
         // If the background agent is enabled, load available backgrounds + tags into context
         const backgroundAgent = resolvedAgents.find((a) => a.type === "background");
         if (backgroundAgent) {
-          const backgroundGenerationEnabled =
-            backgroundAgent.settings?.autoGenerateBackgrounds === true &&
-            chatMeta.gameStoryboardViewerDisplayMode !== "background";
           agentContext.memory._availableBackgrounds = [];
           agentContext.memory._currentBackground = currentBackground;
-          if (backgroundGenerationEnabled) {
-            agentContext.memory._backgroundGenerationEnabled = true;
-          }
-          if (backgroundGenerationEnabled) {
-            const setupConfigForBackground =
-              chatMeta.gameSetupConfig &&
-              typeof chatMeta.gameSetupConfig === "object" &&
-              !Array.isArray(chatMeta.gameSetupConfig)
-                ? (chatMeta.gameSetupConfig as Record<string, unknown>)
-                : null;
-            agentContext.memory._backgroundWorldContext = {
-              genre: (setupConfigForBackground?.genre as string | undefined) ?? null,
-              setting: (setupConfigForBackground?.setting as string | undefined) ?? null,
-              location: gameState?.location ?? null,
-              weather: gameState?.weather ?? null,
-              timeOfDay: gameState?.time ?? null,
-              worldOverview: (chatMeta.gameWorldOverview as string | undefined) ?? null,
-            };
-          }
           try {
             const { readdirSync, readFileSync, existsSync } = await import("fs");
             const { join, extname } = await import("path");
@@ -6991,18 +6966,6 @@ export async function generateRoutes(app: FastifyInstance) {
             return trackerFieldLocksAreEmpty(locks) ? null : JSON.stringify(locks);
           };
 
-          const resolveAgentImageConnectionId = async (agent: ResolvedAgent | undefined): Promise<string | null> => {
-            let imgConnId = (agent?.settings?.imageConnectionId as string) ?? null;
-            if (!imgConnId) {
-              const defaultImageConn = (await connections.list()).find(
-                (c) =>
-                  c.provider === "image_generation" && (c.defaultForAgents === true || c.defaultForAgents === "true"),
-              );
-              imgConnId = defaultImageConn?.id ?? null;
-            }
-            return imgConnId;
-          };
-
           for (const result of sortedResults) {
             const resultMessageId =
               result.agentType === "lorebook-keeper" && lorebookKeeperProcessedMessageId
@@ -7018,16 +6981,6 @@ export async function generateRoutes(app: FastifyInstance) {
             ) {
               const bgData = result.data as {
                 chosen?: string | null;
-                generate?: {
-                  location?: unknown;
-                  locationSlug?: unknown;
-                  slug?: unknown;
-                  prompt?: unknown;
-                  description?: unknown;
-                  reason?: unknown;
-                } | null;
-                generated?: boolean;
-                error?: string;
               };
               if (typeof bgData.chosen === "string") {
                 bgData.chosen = bgData.chosen.trim() || null;
@@ -7043,143 +6996,6 @@ export async function generateRoutes(app: FastifyInstance) {
                   if (!valid) {
                     logger.warn(`[generate] Background agent chose "${bgData.chosen}" which doesn't exist — rejecting`);
                     bgData.chosen = null;
-                  }
-                }
-              }
-
-              const generationRequest =
-                bgData.generate && typeof bgData.generate === "object" && !Array.isArray(bgData.generate)
-                  ? bgData.generate
-                  : null;
-              const currentBackgroundAgent = resolvedAgents.find(
-                (a) => a.id === result.agentId || a.type === "background",
-              );
-              const canGenerateBackground =
-                currentBackgroundAgent?.settings?.autoGenerateBackgrounds === true &&
-                chatMeta.gameStoryboardViewerDisplayMode !== "background";
-              if (!bgData.chosen && canGenerateBackground && generationRequest) {
-                const promptText =
-                  typeof generationRequest.prompt === "string" && generationRequest.prompt.trim()
-                    ? generationRequest.prompt.trim()
-                    : typeof generationRequest.description === "string"
-                      ? generationRequest.description.trim()
-                      : "";
-                const locationSource =
-                  typeof generationRequest.location === "string" && generationRequest.location.trim()
-                    ? generationRequest.location
-                    : typeof generationRequest.locationSlug === "string" && generationRequest.locationSlug.trim()
-                      ? generationRequest.locationSlug
-                      : typeof generationRequest.slug === "string" && generationRequest.slug.trim()
-                        ? generationRequest.slug
-                        : typeof generationRequest.reason === "string" && generationRequest.reason.trim()
-                          ? generationRequest.reason
-                          : promptText;
-                const locationText = locationSource.trim();
-                if (promptText && locationText) {
-                  try {
-                    const imgConnId = await resolveAgentImageConnectionId(currentBackgroundAgent);
-                    if (!imgConnId) {
-                      bgData.error =
-                        "No image generation connection set on the Background agent, and no default agent image connection is configured.";
-                      trySendSseEvent(reply, {
-                        type: "agent_error",
-                        data: {
-                          agentType: "background",
-                          agentName: currentBackgroundAgent?.name ?? "Background",
-                          error:
-                            "No image generation connection set on the Background agent, and no default agent image connection is configured. Assign one in Settings → Agents → Background.",
-                        },
-                      });
-                    } else {
-                      const imgConnFull = await connections.getWithKey(imgConnId);
-                      if (!imgConnFull) throw new Error("Cannot resolve Background agent image connection");
-
-                      const imageDefaults = resolveConnectionImageDefaults(imgConnFull);
-                      const imageFallback = await resolveImageConnectionFallback(connections, imgConnFull.id);
-                      const imageSettings = await loadImageGenerationUserSettings(app.db);
-                      const promptOverridesStorage = createPromptOverridesStorage(app.db);
-                      const setupConfigForImage =
-                        chatMeta.gameSetupConfig &&
-                        typeof chatMeta.gameSetupConfig === "object" &&
-                        !Array.isArray(chatMeta.gameSetupConfig)
-                          ? (chatMeta.gameSetupConfig as Record<string, unknown>)
-                          : null;
-                      const styleProfileId =
-                        (setupConfigForImage?.imageStyleProfileId as string | undefined) ??
-                        (chatMeta.imageStyleProfileId as string | undefined) ??
-                        null;
-                      const generatedFilename = await generateChatBackground({
-                        chatId: input.chatId,
-                        locationSlug: locationText.slice(0, 120),
-                        sceneDescription: promptText.slice(0, 1000),
-                        genre: (setupConfigForImage?.genre as string | undefined) ?? undefined,
-                        setting: (setupConfigForImage?.setting as string | undefined) ?? undefined,
-                        currentLocation: gameState?.location ?? null,
-                        currentWeather: gameState?.weather ?? null,
-                        currentTimeOfDay: gameState?.time ?? null,
-                        worldOverview: (chatMeta.gameWorldOverview as string | undefined) ?? null,
-                        artStyle: resolveGameSetupArtStylePrompt(setupConfigForImage) || undefined,
-                        reason:
-                          typeof generationRequest.reason === "string"
-                            ? generationRequest.reason.trim().slice(0, 300)
-                            : undefined,
-                        imgModel: imgConnFull.model || "",
-                        imgBaseUrl: imgConnFull.baseUrl || "https://image.pollinations.ai",
-                        imgApiKey: imgConnFull.apiKey || "",
-                        imgSource: (imgConnFull as any).imageGenerationSource || imgConnFull.model || "",
-                        imgService: imgConnFull.imageService || (imgConnFull as any).imageGenerationSource || "",
-                        imgEndpointId: imgConnFull.imageEndpointId || undefined,
-                        imgComfyWorkflow: imgConnFull.comfyuiWorkflow || undefined,
-                        imgDefaults: imageDefaults,
-                        imgFallback: imageFallback,
-                        styleProfiles: imageSettings.styleProfiles,
-                        styleProfileId,
-                        promptOverridesStorage,
-                        size: {
-                          width: imageSettings.background.width,
-                          height: imageSettings.background.height,
-                        },
-                        debugLog,
-                      });
-                      if (generatedFilename) {
-                        bgData.chosen = generatedFilename;
-                        bgData.generated = true;
-                        trySendSseEvent(reply, {
-                          type: "agent_result",
-                          data: {
-                            agentType: result.agentType,
-                            agentName: currentBackgroundAgent?.name ?? "Background",
-                            resultType: result.type,
-                            data: bgData,
-                            tokensUsed: result.tokensUsed,
-                            success: result.success,
-                            error: result.error,
-                            durationMs: result.durationMs,
-                          },
-                        });
-                      } else {
-                        bgData.error = "Background image generation failed";
-                        trySendSseEvent(reply, {
-                          type: "agent_error",
-                          data: {
-                            agentType: "background",
-                            agentName: currentBackgroundAgent?.name ?? "Background",
-                            error: "Background image generation failed. Check the image connection and server logs.",
-                          },
-                        });
-                      }
-                    }
-                  } catch (bgErr) {
-                    logger.error(bgErr, "[background-agent] Image generation failed");
-                    bgData.error = bgErr instanceof Error ? bgErr.message : "Background image generation failed";
-                    trySendSseEvent(reply, {
-                      type: "agent_error",
-                      data: {
-                        agentType: "background",
-                        agentName: currentBackgroundAgent?.name ?? "Background",
-                        error: `Background image generation failed: ${bgData.error}`,
-                      },
-                    });
                   }
                 }
               }

--- a/packages/server/src/routes/generate/retry-agents-route.ts
+++ b/packages/server/src/routes/generate/retry-agents-route.ts
@@ -544,6 +544,7 @@ async function buildRetryAgentContext(args: {
   lorebooksStore: ReturnType<typeof createLorebooksStorage>;
   streaming: boolean;
   wrapFormat: WrapFormat;
+  forceIllustratorBackgroundGeneration: boolean;
   /**
    * When retrying agents for a specific assistant message (e.g. refreshing cached prompt injections),
    * use the game-state snapshot committed for that message+swipe — not the latest chat snapshot.
@@ -568,6 +569,7 @@ async function buildRetryAgentContext(args: {
     lorebooksStore,
     streaming,
     wrapFormat,
+    forceIllustratorBackgroundGeneration,
     historicalGameStateAnchor,
     useLatestGameStateFallback = true,
   } = args;
@@ -945,7 +947,8 @@ async function buildRetryAgentContext(args: {
 
   if (
     resolvedAgentTypes.has("illustrator") &&
-    illustratorBackgroundGenerationEnabled((chat as { mode?: unknown }).mode, chatMeta)
+    (forceIllustratorBackgroundGeneration ||
+      illustratorBackgroundGenerationEnabled((chat as { mode?: unknown }).mode, chatMeta))
   ) {
     agentContext.memory._illustratorBackgroundGenerationEnabled = true;
     agentContext.memory._currentBackground = currentBackground;
@@ -2513,6 +2516,8 @@ async function applyRetryResultEffects(args: {
   const chats = createChatsStorage(app.db);
   const agentsStore = createAgentsStorage(app.db);
   const chatMeta = parseExtra(chat.metadata) as Record<string, unknown>;
+  const isManualIllustratorBackgroundRequest =
+    illustratorRetryTargets?.length === 1 && illustratorRetryTargets[0] === "background";
   let currentResponseForRewrite = agentContext.mainResponse;
   const retryOwnerSpatialProjection =
     (retryMessageId
@@ -3393,7 +3398,8 @@ async function applyRetryResultEffects(args: {
     illustratorEntry &&
     !illustratorPromptReviewOverride &&
     shouldRetryIllustratorTarget(illustratorRetryTargets, "background") &&
-    illustratorBackgroundGenerationEnabled((chat as { mode?: unknown }).mode, chatMeta)
+    (isManualIllustratorBackgroundRequest ||
+      illustratorBackgroundGenerationEnabled((chat as { mode?: unknown }).mode, chatMeta))
   ) {
     const backgroundAtDecision =
       typeof chatMeta.background === "string" && chatMeta.background.trim() ? chatMeta.background.trim() : null;
@@ -3414,13 +3420,16 @@ async function applyRetryResultEffects(args: {
         ? parseGameStateRow(latestSnapshot as Record<string, unknown>)
         : agentContext.gameState;
       const illData = illustratorResult.data as Record<string, unknown>;
-      const requestedBackground = illustratorRequestedBackground(illData.generateBackground);
+      const requestedBackground =
+        isManualIllustratorBackgroundRequest || illustratorRequestedBackground(illData.generateBackground);
       const trackerLocationChanged = illustratorTrackerLocationChanged(
         agentContext.gameState?.location,
         latestGameState?.location,
       );
       if (!requestedBackground && !trackerLocationChanged) return;
-      const backgroundDecisionReason = requestedBackground
+      const backgroundDecisionReason = isManualIllustratorBackgroundRequest
+        ? "Manual Gallery background request"
+        : requestedBackground
         ? typeof illData.reason === "string"
           ? illData.reason
           : undefined
@@ -3576,6 +3585,8 @@ export async function registerRetryAgentsRoute(app: FastifyInstance) {
     if (illustratorRetryTargets && !agentTypes.includes("illustrator")) {
       return reply.status(400).send({ error: "Illustrator retry targets require an Illustrator retry" });
     }
+    const isManualIllustratorBackgroundRequest =
+      illustratorRetryTargets?.length === 1 && illustratorRetryTargets[0] === "background";
 
     startSseReply(reply, { "X-Accel-Buffering": "no" });
     const onFallback = createReplyFallbackNotifier(reply);
@@ -3732,6 +3743,7 @@ export async function registerRetryAgentsRoute(app: FastifyInstance) {
         lorebooksStore,
         streaming,
         wrapFormat: retryWrapFormat,
+        forceIllustratorBackgroundGeneration: isManualIllustratorBackgroundRequest,
         historicalGameStateAnchor,
       });
       agentContext.signal = abortController.signal;
@@ -3754,6 +3766,7 @@ export async function registerRetryAgentsRoute(app: FastifyInstance) {
               lorebooksStore,
               streaming,
               wrapFormat: retryWrapFormat,
+              forceIllustratorBackgroundGeneration: isManualIllustratorBackgroundRequest,
               historicalGameStateAnchor: preGenerationGameStateAnchor,
               useLatestGameStateFallback: false,
             })

--- a/packages/server/src/services/agents/agent-executor.ts
+++ b/packages/server/src/services/agents/agent-executor.ts
@@ -2378,41 +2378,6 @@ function buildAgentExtras(context: AgentContext, agentTypes: string[] = []): str
     }
   }
 
-  if (agentTypes.includes("background") && context.memory._backgroundGenerationEnabled === true) {
-    parts.push(`<background_generation enabled="true">`);
-    parts.push(
-      `If no listed background fits a changed or new location, request a generated reusable location background instead of forcing a weak match.`,
-    );
-    const worldContext =
-      context.memory._backgroundWorldContext &&
-      typeof context.memory._backgroundWorldContext === "object" &&
-      !Array.isArray(context.memory._backgroundWorldContext)
-        ? (context.memory._backgroundWorldContext as Record<string, unknown>)
-        : null;
-    if (worldContext) {
-      const fields = [
-        ["genre", worldContext.genre],
-        ["setting", worldContext.setting],
-        ["location", worldContext.location],
-        ["weather", worldContext.weather],
-        ["timeOfDay", worldContext.timeOfDay],
-        ["world", worldContext.worldOverview],
-      ]
-        .map(([label, value]) => {
-          const text = typeof value === "string" ? value.replace(/\s+/g, " ").trim().slice(0, 180) : "";
-          return text ? `${label}: ${escapeXml(text)}` : "";
-        })
-        .filter(Boolean);
-      if (fields.length > 0) {
-        parts.push(`World context for generated backgrounds: ${fields.join("; ")}.`);
-        parts.push(
-          `Generated background prompts must include the setting era/genre and concrete location details. Do not request modern scenery, technology, signage, UI, or objects unless this world context supports them.`,
-        );
-      }
-    }
-    parts.push(`</background_generation>`);
-  }
-
   if (agentTypes.includes("spotify") && context.memory._spotifyDjConstraints) {
     parts.push(`<spotify_dj_constraints>`);
     parts.push(JSON.stringify(context.memory._spotifyDjConstraints));

--- a/packages/server/src/services/professor-mari/official-agent-knowledge.ts
+++ b/packages/server/src/services/professor-mari/official-agent-knowledge.ts
@@ -82,7 +82,7 @@ export const OFFICIAL_AGENT_KNOWLEDGE_ENTRIES: readonly OfficialAgentKnowledgeEn
     name: "Background",
     category: "tracker",
     modes: "Roleplay",
-    summary: "selects a fitting scene background and can generate missing locations when configured",
+    summary: "selects a fitting scene background from the existing background library",
   },
   {
     id: "character-tracker",

--- a/scripts/regressions/prompt.regression.ts
+++ b/scripts/regressions/prompt.regression.ts
@@ -2673,10 +2673,43 @@ const cases: RegressionCase[] = [
         new URL("../../packages/server/src/services/agents/agent-executor.ts", import.meta.url),
         "utf8",
       );
+      const agentEditorSource = readFileSync(
+        new URL("../../packages/client/src/components/agents/AgentEditor.tsx", import.meta.url),
+        "utf8",
+      );
+      const generationRoutesSource = readFileSync(
+        new URL("../../packages/server/src/routes/generate.routes.ts", import.meta.url),
+        "utf8",
+      );
+      const retryAgentsRouteSource = readFileSync(
+        new URL("../../packages/server/src/routes/generate/retry-agents-route.ts", import.meta.url),
+        "utf8",
+      );
+      const chatAreaSource = readFileSync(
+        new URL("../../packages/client/src/components/chat/ChatArea.tsx", import.meta.url),
+        "utf8",
+      );
+      const backgroundsRoutesSource = readFileSync(
+        new URL("../../packages/server/src/routes/backgrounds.routes.ts", import.meta.url),
+        "utf8",
+      );
       assert.match(drawerSource, /label="Generate Scene Backgrounds"/u);
       assert.match(drawerSource, /renderIllustratorImageStyleSelect\(\)/u);
       assert.match(executorSource, /<illustrator_background_generation enabled="true">/u);
       assert.match(executorSource, /"generateBackground"/u);
+      assert.doesNotMatch(executorSource, /<background_generation enabled=/u);
+      assert.doesNotMatch(agentEditorSource, /Background Image Generation|autoGenerateBackgrounds/u);
+      assert.doesNotMatch(generationRoutesSource, /autoGenerateBackgrounds|bgData\.generate/u);
+      assert.match(chatAreaSource, /illustratorRetryTargets: \["background"\]/u);
+      assert.match(
+        retryAgentsRouteSource,
+        /isManualIllustratorBackgroundRequest\s+\|\|\s+illustratorRequestedBackground/u,
+      );
+      assert.doesNotMatch(backgroundsRoutesSource, /getByType\("background"\)/u);
+      assert.match(
+        backgroundsRoutesSource,
+        /Choose an image generation connection for the Illustrator agent, or mark one as the default image connection\./u,
+      );
     },
   },
   {


### PR DESCRIPTION
## Why

The Background agent still exposed an older image-generation path that overlaps with Illustrator's newer scene-background generation. The two paths had different prompts, connections, and behavior, making ownership unclear.

Gallery → Background also invoked Illustrator as a normal illustration retry, so the result could be attached to the chat instead of becoming the active Roleplay background.

## What changed

- Remove the Background agent's obsolete generation toggle, image connection, prompt context, and runtime generation branch.
- Keep Background selection compatible with existing library images while ignoring legacy package generation requests.
- Route manual scene-background connection resolution through Illustrator, then the default image connection.
- Make Gallery → Background an explicit background-only Illustrator run.
- Save the generated image to the background library and immediately apply it to the active Roleplay chat without attaching an ordinary illustration.
- Update user documentation, Professor Mari's built-in agent knowledge, changelog, and regression coverage.

## Impact

Background now has one responsibility: selecting an existing backdrop. Illustrator owns both automatic and manual background creation. Older installed Background packages can still select images safely; their obsolete generation payload is ignored by the Engine.

## Companion change

- Pasta-Devs/Marinara-Agents#96 publishes the selection-only Background `1.0.2` package.

## Validation

- `pnpm check`
- `pnpm regression:prompt`
- Relevant Playwright Roleplay-background coverage passed on desktop and mobile.
- Three unrelated failures from the first full smoke run passed on an isolated rerun.

## Manual verification

- [ ] Manually verify Gallery → Background creates a reusable background and immediately applies it to the active Roleplay chat.
- [ ] Manually verify the generated background is not attached as a normal chat illustration.
- [ ] Manually verify Background still selects existing library images after updating the downloadable package.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Background selection now uses images from your existing background library.
  * Illustrator handles automatic and manual background generation.
  * Generated backgrounds are applied directly to the active Roleplay chat.

* **Bug Fixes**
  * Removed obsolete Background agent image-generation controls.
  * Improved image-connection guidance and error messages for background generation.

* **Documentation**
  * Updated agent, roleplay background, and troubleshooting documentation to reflect the revised workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->