### PR TITLE
List ComfyUI DiffusionModels folder models in Fetch models from API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 
 ### Fixed
 
+- Listed ComfyUI models from the DiffusionModels folder (UNETLoader) alongside StableDiffusion checkpoints in the connection editor's "Fetch models from API", so models such as Anima and zImage are selectable without typing their names manually (#3993).
 - Disabled Venice.ai's optional `safe_mode` blur in native image requests so supported generations are returned without the provider's default censoring overlay (#3990).
 - Protected launcher-driven Engine updates with a private snapshot of the configured user-data directory outside the checkout and automatic restoration if an update attempt leaves that directory missing or empty. Launcher dependency refreshes now use the pinned lockfile instead of destructive forced reinstalls, preventing the Windows Fastify plugin type failures reported after v2.3.4 updates (#3961, #3976).
 - Installed and verified Sharp's WebAssembly runtime on Termux while suppressing unsupported Android native source builds, restoring NovelAI Precise Reference preprocessing without requiring an Android NDK (#3975).

--- a/packages/server/src/routes/connections.routes.ts
+++ b/packages/server/src/routes/connections.routes.ts
@@ -156,6 +156,21 @@ function resolveVideoGenerationSource(conn: Record<string, unknown>, baseUrl: st
   return inferVideoSource(explicitSource || serviceHint || model, baseUrl);
 }
 
+// Returns the model-name options a ComfyUI loader node exposes through
+// object_info, or null when the response does not carry that node's schema —
+// a valid empty list and missing metadata must stay distinguishable so the
+// route can keep its 502 contract for malformed checkpoint responses.
+export function parseComfyLoaderModelNames(info: unknown, nodeName: string, inputName: string): string[] | null {
+  if (!isRecord(info)) return null;
+  const node = info[nodeName];
+  if (!isRecord(node) || !isRecord(node.input) || !isRecord(node.input.required)) return null;
+  const input = node.input.required[inputName];
+  if (!Array.isArray(input)) return null;
+  const options = input[0];
+  if (!Array.isArray(options)) return null;
+  return options.filter((option): option is string => typeof option === "string");
+}
+
 function localUrlPolicyForProvider(provider: string, imageSource: string) {
   const isLocalImageBackend =
     provider === "image_generation" && (imageSource === "comfyui" || imageSource === "automatic1111");
@@ -751,21 +766,21 @@ export async function connectionsRoutes(app: FastifyInstance) {
             maxResponseBytes: 5 * 1024 * 1024,
             decodeCompressedResponse: true,
           });
-          if (!res.ok) return { status: res.status, names: null };
-          const info = (await res.json()) as Record<
-            string,
-            { input?: { required?: Record<string, [unknown] | undefined> } } | undefined
-          >;
-          const options = info[nodeName]?.input?.required?.[inputName]?.[0];
-          const names = Array.isArray(options)
-            ? options.filter((option): option is string => typeof option === "string")
-            : [];
-          return { status: res.status, names };
+          if (!res.ok) return { ok: false, status: res.status, names: null };
+          return {
+            ok: true,
+            status: res.status,
+            names: parseComfyLoaderModelNames(await res.json(), nodeName, inputName),
+          };
         };
 
         const checkpoints = await fetchComfyLoaderModelNames("CheckpointLoaderSimple", "ckpt_name");
         if (!checkpoints.names) {
-          return reply.status(502).send({ error: `ComfyUI returned ${checkpoints.status}` });
+          return reply.status(502).send({
+            error: checkpoints.ok
+              ? "ComfyUI did not return checkpoint model metadata"
+              : `ComfyUI returned ${checkpoints.status}`,
+          });
         }
         // Models in ComfyUI's diffusion_models folder (e.g. Anima, zImage) load
         // through UNETLoader, not CheckpointLoaderSimple. Listing failures here

--- a/packages/server/src/routes/connections.routes.ts
+++ b/packages/server/src/routes/connections.routes.ts
@@ -743,21 +743,39 @@ export async function connectionsRoutes(app: FastifyInstance) {
         return { models: knownStabilityImageModels() };
       }
 
-      // ComfyUI: fetch checkpoints from object_info
+      // ComfyUI: fetch checkpoints and diffusion models from object_info
       if (conn.provider === "image_generation" && imageSource === "comfyui") {
-        const res = await safeFetch(`${baseUrl}/object_info/CheckpointLoaderSimple`, {
-          policy: localUrlPolicyForProvider(conn.provider, imageSource),
-          maxResponseBytes: 5 * 1024 * 1024,
-          decodeCompressedResponse: true,
-        });
-        if (!res.ok) {
-          return reply.status(502).send({ error: `ComfyUI returned ${res.status}` });
-        }
-        const info = (await res.json()) as {
-          CheckpointLoaderSimple?: { input?: { required?: { ckpt_name?: [string[]] } } };
+        const fetchComfyLoaderModelNames = async (nodeName: string, inputName: string) => {
+          const res = await safeFetch(`${baseUrl}/object_info/${nodeName}`, {
+            policy: localUrlPolicyForProvider(conn.provider, imageSource),
+            maxResponseBytes: 5 * 1024 * 1024,
+            decodeCompressedResponse: true,
+          });
+          if (!res.ok) return { status: res.status, names: null };
+          const info = (await res.json()) as Record<
+            string,
+            { input?: { required?: Record<string, [unknown] | undefined> } } | undefined
+          >;
+          const options = info[nodeName]?.input?.required?.[inputName]?.[0];
+          const names = Array.isArray(options)
+            ? options.filter((option): option is string => typeof option === "string")
+            : [];
+          return { status: res.status, names };
         };
-        const ckpts = info.CheckpointLoaderSimple?.input?.required?.ckpt_name?.[0] ?? [];
-        return { models: ckpts.map((name: string) => ({ id: name, name })) };
+
+        const checkpoints = await fetchComfyLoaderModelNames("CheckpointLoaderSimple", "ckpt_name");
+        if (!checkpoints.names) {
+          return reply.status(502).send({ error: `ComfyUI returned ${checkpoints.status}` });
+        }
+        // Models in ComfyUI's diffusion_models folder (e.g. Anima, zImage) load
+        // through UNETLoader, not CheckpointLoaderSimple. Listing failures here
+        // must not hide the checkpoints on ComfyUI builds without that node.
+        const diffusionModels = await fetchComfyLoaderModelNames("UNETLoader", "unet_name").catch(() => ({
+          status: 0,
+          names: null,
+        }));
+        const names = [...new Set([...checkpoints.names, ...(diffusionModels.names ?? [])])];
+        return { models: names.map((name: string) => ({ id: name, name })) };
       }
 
       // AUTOMATIC1111 / SD Web UI: fetch models from /sdapi/v1/sd-models

--- a/scripts/regressions/open-issues.regression.ts
+++ b/scripts/regressions/open-issues.regression.ts
@@ -2857,4 +2857,61 @@ try {
   rmSync(backgroundSeedRoot, { recursive: true, force: true });
 }
 
+// Issue #3993 — ComfyUI model fetch must list the DiffusionModels (UNETLoader)
+// folder and keep missing loader metadata distinguishable from an empty list.
+{
+  const { parseComfyLoaderModelNames } = await import("../../packages/server/src/routes/connections.routes.js");
+  const checkpointInfo = {
+    CheckpointLoaderSimple: { input: { required: { ckpt_name: [["sd15.safetensors", "shared.safetensors"]] } } },
+  };
+  const unetInfo = {
+    UNETLoader: {
+      input: { required: { unet_name: [["anima.safetensors", "zimage.safetensors", "shared.safetensors"]] } },
+    },
+  };
+  assert.deepEqual(parseComfyLoaderModelNames(checkpointInfo, "CheckpointLoaderSimple", "ckpt_name"), [
+    "sd15.safetensors",
+    "shared.safetensors",
+  ]);
+  assert.deepEqual(parseComfyLoaderModelNames(unetInfo, "UNETLoader", "unet_name"), [
+    "anima.safetensors",
+    "zimage.safetensors",
+    "shared.safetensors",
+  ]);
+  assert.deepEqual(
+    parseComfyLoaderModelNames({ CheckpointLoaderSimple: { input: { required: { ckpt_name: [[]] } } } },
+      "CheckpointLoaderSimple",
+      "ckpt_name",
+    ),
+    [],
+    "A genuinely empty checkpoint list must stay a list, not a missing-schema signal",
+  );
+  assert.equal(
+    parseComfyLoaderModelNames({}, "CheckpointLoaderSimple", "ckpt_name"),
+    null,
+    "Missing checkpoint schema must be reported as null so the route can 502",
+  );
+  assert.equal(
+    parseComfyLoaderModelNames({}, "UNETLoader", "unet_name"),
+    null,
+    "A ComfyUI build without UNETLoader must be detectable so the route can degrade to checkpoints",
+  );
+  assert.equal(
+    parseComfyLoaderModelNames(
+      { CheckpointLoaderSimple: { input: { required: { ckpt_name: ["not-an-array"] } } } },
+      "CheckpointLoaderSimple",
+      "ckpt_name",
+    ),
+    null,
+    "Malformed options must not be mistaken for an empty model list",
+  );
+  const checkpointNames = parseComfyLoaderModelNames(checkpointInfo, "CheckpointLoaderSimple", "ckpt_name") ?? [];
+  const unetNames = parseComfyLoaderModelNames(unetInfo, "UNETLoader", "unet_name") ?? [];
+  assert.deepEqual(
+    [...new Set([...checkpointNames, ...unetNames])],
+    ["sd15.safetensors", "shared.safetensors", "anima.safetensors", "zimage.safetensors"],
+    "Overlapping names across the two folders must be listed once",
+  );
+}
+
 console.info("Open-issue regressions passed.");


### PR DESCRIPTION
## Linked issue

Fixes #3993

## Why this change

ComfyUI stores models in two folders: checkpoints (StableDiffusion) and diffusion_models (DiffusionModels). The connection editor's "Fetch models from API" only queried `object_info/CheckpointLoaderSimple`, so models in the DiffusionModels folder — Anima, zImage, and similar — never appeared in the selector even though they generate correctly when their names are typed manually.

## What changed

- The ComfyUI model fetch in `connections.routes.ts` now also queries `object_info/UNETLoader` and merges its `unet_name` options with the existing `ckpt_name` list, deduplicated, checkpoints first.
- A failed or missing UNETLoader lookup degrades to the checkpoint list alone, so older ComfyUI builds without that node keep today's behavior; a failed checkpoint lookup still returns 502 as before.
- CHANGELOG entry under Unreleased → Fixed.

This is the fix alone — no changes to generation, workflows, or other providers.

## Validation

- [ ] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed `CONTRIBUTING.md`

### Manual verification notes

- Manually verify against a real ComfyUI instance with models in both folders: "Fetch models from API" should list both sets, deduplicated.
- Manually verify against a ComfyUI instance with an empty diffusion_models folder: the checkpoint list should be unchanged.
- Manually verify that selecting a DiffusionModels entry from the fetched list generates successfully (the issue reports manual entry already works).

`pnpm check` was run by the preparing agent and passed; the boxes above are left for the human contributor per repository policy.

## Docs and release impact

- [ ] No docs changes needed
- [x] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Version/release files updated (only if this PR includes a version bump)

CHANGELOG.md updated; no version bump.

## UI evidence

No UI changes — the existing model selector simply receives more entries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * ComfyUI model discovery now includes models from the `DiffusionModels` folder alongside Stable Diffusion checkpoints.
  * Models such as Anima and zImage can be selected in the connection editor without manually entering their names.

* **Bug Fixes**
  * Improved model listing reliability when one model source is unavailable.
  * Removed duplicate model entries from fetched results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->