### PR TITLE
Fix Windows launcher ERR_INVALID_URL_SCHEME in run-directly guards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 
 ### Fixed
 
+- Fixed the Windows launcher crash `ERR_INVALID_URL_SCHEME` in `protect-launcher-data.mjs` (and the same latent pattern in `read-launcher-env.mjs`): the run-directly guard now resolves `process.argv[1]` with `pathToFileURL`, so drive-letter paths no longer parse as URL schemes, update snapshots are created again, and auto-update is no longer skipped (#3997).
 - Listed ComfyUI models from the DiffusionModels folder (UNETLoader) alongside StableDiffusion checkpoints in the connection editor's "Fetch models from API", so models such as Anima and zImage are selectable without typing their names manually (#3993).
 - Disabled Venice.ai's optional `safe_mode` blur in native image requests so supported generations are returned without the provider's default censoring overlay (#3990).
 - Protected launcher-driven Engine updates with a private snapshot of the configured user-data directory outside the checkout and automatic restoration if an update attempt leaves that directory missing or empty. Launcher dependency refreshes now use the pinned lockfile instead of destructive forced reinstalls, preventing the Windows Fastify plugin type failures reported after v2.3.4 updates (#3961, #3976).

--- a/scripts/protect-launcher-data.mjs
+++ b/scripts/protect-launcher-data.mjs
@@ -3,7 +3,7 @@
 import { chmod, cp, mkdir, readFile, readdir, rename, rm, stat, writeFile } from "node:fs/promises";
 import { dirname, isAbsolute, resolve } from "node:path";
 import { parseEnv } from "node:util";
-import { fileURLToPath } from "node:url";
+import { fileURLToPath, pathToFileURL } from "node:url";
 
 const repositoryRoot = fileURLToPath(new URL("..", import.meta.url));
 const serverRoot = resolve(repositoryRoot, "packages/server");
@@ -158,7 +158,9 @@ async function main() {
   throw new Error("Usage: node scripts/protect-launcher-data.mjs <snapshot|restore-if-missing>");
 }
 
-if (process.argv[1] && fileURLToPath(import.meta.url) === fileURLToPath(new URL(process.argv[1], "file:"))) {
+// pathToFileURL handles Windows drive letters; new URL(path, "file:") parses
+// "D:" as a URL scheme and crashes fileURLToPath with ERR_INVALID_URL_SCHEME.
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
   main().catch((error) => {
     console.error(`  [ERROR] Could not protect launcher data: ${error instanceof Error ? error.message : error}`);
     process.exitCode = 1;

--- a/scripts/read-launcher-env.mjs
+++ b/scripts/read-launcher-env.mjs
@@ -1,6 +1,6 @@
 import { readFileSync } from "node:fs";
 import { parseEnv } from "node:util";
-import { fileURLToPath } from "node:url";
+import { pathToFileURL } from "node:url";
 
 export const LAUNCHER_ENV_KEYS = [
   "AUTO_UPDATE_ENABLED",
@@ -39,6 +39,8 @@ function main() {
   }
 }
 
-if (process.argv[1] && fileURLToPath(import.meta.url) === fileURLToPath(new URL(process.argv[1], "file:"))) {
+// pathToFileURL handles Windows drive letters; new URL(path, "file:") parses
+// "D:" as a URL scheme and crashes fileURLToPath with ERR_INVALID_URL_SCHEME.
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
   main();
 }

--- a/scripts/regressions/launcher-update.regression.mjs
+++ b/scripts/regressions/launcher-update.regression.mjs
@@ -124,4 +124,34 @@ try {
   rmSync(fixtureBackupRoot, { recursive: true, force: true });
 }
 
+// Issue #3997 — the run-directly guard must build its comparison URL with
+// pathToFileURL. new URL(process.argv[1], "file:") parses a Windows drive
+// prefix such as "D:" as the URL scheme, so fileURLToPath threw
+// ERR_INVALID_URL_SCHEME at module load and the launcher skipped the update
+// snapshot on Windows.
+for (const script of ["scripts/protect-launcher-data.mjs", "scripts/read-launcher-env.mjs"]) {
+  const source = readFileSync(resolve(repositoryRoot, script), "utf8");
+  assert.doesNotMatch(
+    source,
+    /new URL\(process\.argv/u,
+    `${script} must not parse process.argv[1] with new URL(..., "file:")`,
+  );
+  assert.match(
+    source,
+    /import\.meta\.url === pathToFileURL\(process\.argv\[1\]\)\.href/u,
+    `${script} must compare import.meta.url against pathToFileURL(process.argv[1])`,
+  );
+}
+{
+  const { spawnSync } = await import("node:child_process");
+  // Running the script directly must evaluate the guard without throwing and
+  // reach main(), which rejects missing arguments with its usage error.
+  const direct = spawnSync(process.execPath, [resolve(repositoryRoot, "scripts/protect-launcher-data.mjs")], {
+    encoding: "utf8",
+  });
+  assert.equal(direct.status, 1, "Direct execution must reach main() and fail with the usage error");
+  assert.match(direct.stderr + direct.stdout, /Usage: node scripts\/protect-launcher-data\.mjs/u);
+  assert.doesNotMatch(direct.stderr, /ERR_INVALID_URL_SCHEME/u);
+}
+
 console.log("Launcher update reminder regressions passed.");


### PR DESCRIPTION
## Linked issue

Fixes #3997

## Why this change

On Windows, restarting Marinara from a fresh staging checkout crashed the launcher's update-snapshot step with `ERR_INVALID_URL_SCHEME` from `protect-launcher-data.mjs:161`, and the launcher then skipped auto-update to protect user data. The run-directly guard built its comparison URL with `new URL(process.argv[1], "file:")` — a Windows path like `D:\Users\...` has its drive prefix parsed as the URL *scheme*, so the `file:` base is ignored and `fileURLToPath` throws on the resulting `d:` URL at module load. `read-launcher-env.mjs` carried the same latent pattern.

## What changed

- Both run-directly guards now compare `import.meta.url === pathToFileURL(process.argv[1]).href` — `pathToFileURL` is the drive-letter-safe conversion.
- The launcher-update regression lane now asserts the `pathToFileURL` guard shape in both scripts, fails if the `new URL(process.argv...)` pattern is reintroduced, and executes `protect-launcher-data.mjs` directly to prove the guard reaches `main()` without a URL-scheme crash.
- CHANGELOG entry under Unreleased → Fixed.

This is the fix alone; no behavior changes beyond the guard evaluation.

## Validation

- [ ] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed `CONTRIBUTING.md`

### Manual verification notes

- Manually verify on Windows: restart the launcher on staging and confirm "Checking for updates..." proceeds to a created/skipped snapshot message with no `ERR_INVALID_URL_SCHEME`, and auto-update is no longer skipped.
- Manually verify `Get-Content .env`-driven launcher settings still resolve (read-launcher-env.mjs path) on Windows.

`pnpm check`, `regression:issues`-adjacent launcher lanes (`launcher-env`, `launcher-update`) were run by the preparing agent and passed on macOS; the Windows behavior itself needs the manual check above. The boxes are left for the human contributor per repository policy.

## Docs and release impact

- [ ] No docs changes needed
- [x] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Version/release files updated (only if this PR includes a version bump)

CHANGELOG.md updated; no version bump.

## UI evidence

No UI changes — launcher console output only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a Windows launcher crash caused by drive-letter paths being misinterpreted as URL schemes.
  * Restored launcher snapshot creation and prevented affected auto-update checks from being skipped.

* **Tests**
  * Added regression coverage to verify direct launcher execution works correctly on Windows-style paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->