### PR TITLE
Read zTXt character-card chunks so Character Tavern imports work

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 
 ### Fixed
 
+- Fixed Character Tavern imports from the Card Browser: their cards store character data in compressed zTXt PNG chunks, which every Marinara card parser (Card Browser import, file/URL import, SillyTavern bulk import) now reads alongside tEXt and iTXt. Re-exporting such a character also strips the stale compressed data instead of shipping outdated card JSON (#4002).
 - Fixed the Windows launcher crash `ERR_INVALID_URL_SCHEME` in `protect-launcher-data.mjs` (and the same latent pattern in `read-launcher-env.mjs`): the run-directly guard now resolves `process.argv[1]` with `pathToFileURL`, so drive-letter paths no longer parse as URL schemes, update snapshots are created again, and auto-update is no longer skipped (#3997).
 - Listed ComfyUI models from the DiffusionModels folder (UNETLoader) alongside StableDiffusion checkpoints in the connection editor's "Fetch models from API", so models such as Anima and zImage are selectable without typing their names manually (#3993).
 - Let the Custom sound description use the full Settings card width and moved its actions below the copy so labels and buttons no longer collide on narrow screens.

--- a/packages/client/src/lib/png-parser.ts
+++ b/packages/client/src/lib/png-parser.ts
@@ -4,7 +4,11 @@
 // Supports V2 and V3 character card specs
 // ──────────────────────────────────────────────
 
+import { MAX_FILE_SIZES } from "@marinara-engine/shared";
+
 const CHARA_KEYWORDS = new Set(["ccv3", "chara"]);
+// zTXt card metadata may be raw JSON or base64 (up to 4/3 the JSON size).
+const MAX_CHARACTER_CARD_CHUNK_SIZE = Math.ceil(MAX_FILE_SIZES.CHARACTER_JSON / 3) * 4;
 
 /** Find the first null byte in a Uint8Array starting from `from`. */
 function findNull(data: Uint8Array, from: number): number {
@@ -29,8 +33,36 @@ function parseCharaChunkText(text: string): Record<string, unknown> {
 
 /** Inflate a zlib (RFC 1950) stream — the encoding zTXt chunks use. */
 async function inflateZlib(data: Uint8Array): Promise<Uint8Array> {
-  const stream = new Blob([data as BlobPart]).stream().pipeThrough(new DecompressionStream("deflate"));
-  return new Uint8Array(await new Response(stream).arrayBuffer());
+  const reader = new Blob([data as BlobPart])
+    .stream()
+    .pipeThrough(new DecompressionStream("deflate"))
+    .getReader();
+  const chunks: Uint8Array[] = [];
+  let totalLength = 0;
+
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+
+      totalLength += value.byteLength;
+      if (totalLength > MAX_CHARACTER_CARD_CHUNK_SIZE) {
+        await reader.cancel().catch(() => undefined);
+        throw new Error("Compressed character metadata exceeds the allowed size");
+      }
+      chunks.push(value);
+    }
+  } finally {
+    reader.releaseLock();
+  }
+
+  const inflated = new Uint8Array(totalLength);
+  let offset = 0;
+  for (const chunk of chunks) {
+    inflated.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  return inflated;
 }
 
 /**

--- a/packages/client/src/lib/png-parser.ts
+++ b/packages/client/src/lib/png-parser.ts
@@ -14,6 +14,25 @@ function findNull(data: Uint8Array, from: number): number {
   return -1;
 }
 
+/** Parse chunk text that may be raw JSON or base64-encoded JSON. */
+function parseCharaChunkText(text: string): Record<string, unknown> {
+  try {
+    return JSON.parse(text) as Record<string, unknown>;
+  } catch {
+    // Decode base64 → bytes → UTF-8 (atob alone produces Latin-1, breaking multi-byte chars)
+    const raw = atob(text);
+    const utf8Bytes = new Uint8Array(raw.length);
+    for (let i = 0; i < raw.length; i++) utf8Bytes[i] = raw.charCodeAt(i);
+    return JSON.parse(new TextDecoder().decode(utf8Bytes)) as Record<string, unknown>;
+  }
+}
+
+/** Inflate a zlib (RFC 1950) stream — the encoding zTXt chunks use. */
+async function inflateZlib(data: Uint8Array): Promise<Uint8Array> {
+  const stream = new Blob([data as BlobPart]).stream().pipeThrough(new DecompressionStream("deflate"));
+  return new Uint8Array(await new Response(stream).arrayBuffer());
+}
+
 /**
  * Reads a PNG file's text chunks and extracts character card JSON.
  * Checks for V3 "ccv3" keyword first, then falls back to V2 "chara".
@@ -70,6 +89,21 @@ export async function parsePngCharacterCard(
           found.set(keyword, JSON.parse(jsonStr) as Record<string, unknown>);
         }
       }
+    } else if (type === "zTXt") {
+      // zTXt chunk: keyword\0 compressionMethod(1 byte, 0 = zlib deflate) compressedText.
+      // Character Tavern cards store their chara/ccv3 payloads this way.
+      const nullIdx = findNull(chunkData, 0);
+      if (nullIdx > 0) {
+        const keyword = new TextDecoder().decode(chunkData.slice(0, nullIdx));
+        if (CHARA_KEYWORDS.has(keyword) && !found.has(keyword) && chunkData[nullIdx + 1] === 0) {
+          try {
+            const inflated = await inflateZlib(chunkData.slice(nullIdx + 2));
+            found.set(keyword, parseCharaChunkText(new TextDecoder().decode(inflated)));
+          } catch {
+            // Skip malformed compressed chunks; other chunks may still carry the card.
+          }
+        }
+      }
     } else if (type === "iTXt") {
       // iTXt chunk: keyword\0 compressionFlag compressionMethod languageTag\0 translatedKeyword\0 text
       const nullIdx = findNull(chunkData, 0);
@@ -119,15 +153,15 @@ export async function parsePngCharacterCard(
     throw new Error("No character data found in PNG — this doesn't appear to be a SillyTavern character card");
   }
 
-  const imageDataUrl = await fileToDataUrl(file);
-  return { json, imageDataUrl };
+  return { json, imageDataUrl: bytesToDataUrl(bytes, file.type || "image/png") };
 }
 
-function fileToDataUrl(file: File): Promise<string> {
-  return new Promise((resolve, reject) => {
-    const reader = new FileReader();
-    reader.onload = () => resolve(reader.result as string);
-    reader.onerror = reject;
-    reader.readAsDataURL(file);
-  });
+/** Build a data URL from bytes already in memory (no FileReader — also runs under Node regressions). */
+function bytesToDataUrl(bytes: Uint8Array, mimeType: string): string {
+  let binary = "";
+  const chunkSize = 0x8000;
+  for (let i = 0; i < bytes.length; i += chunkSize) {
+    binary += String.fromCharCode(...bytes.subarray(i, i + chunkSize));
+  }
+  return `data:${mimeType};base64,${btoa(binary)}`;
 }

--- a/packages/server/src/routes/characters.routes.ts
+++ b/packages/server/src/routes/characters.routes.ts
@@ -2573,7 +2573,10 @@ function buildChunk(type: string, data: Buffer): Buffer {
 }
 
 function readPngTextKeyword(chunkType: string, chunkData: Buffer): string | null {
-  if (chunkType !== "tEXt" && chunkType !== "iTXt") return null;
+  // zTXt keywords sit at the same null-terminated position; without it, a
+  // re-exported Character Tavern card would keep stale compressed chara data
+  // alongside the freshly injected tEXt chunk.
+  if (chunkType !== "tEXt" && chunkType !== "iTXt" && chunkType !== "zTXt") return null;
 
   const nullIdx = chunkData.indexOf(0);
   if (nullIdx <= 0) return null;

--- a/packages/server/src/routes/import.routes.ts
+++ b/packages/server/src/routes/import.routes.ts
@@ -3,6 +3,7 @@
 // ──────────────────────────────────────────────
 import type { FastifyInstance, FastifyRequest } from "fastify";
 import { execFile } from "child_process";
+import { inflateSync } from "node:zlib";
 import { platform, homedir } from "os";
 import { readdir, stat } from "fs/promises";
 import { resolve as pathResolve } from "path";
@@ -192,8 +193,21 @@ function pickFolder(): Promise<string | null> {
 /** Read PNG tEXt chunk with keyword "chara" → base64-encoded JSON character data */
 const CHARA_KEYWORDS = new Set(["ccv3", "chara"]);
 
-/** Extract character JSON from a PNG buffer, checking tEXt and iTXt chunks for "ccv3" (V3) or "chara" (V2) keywords. */
-function extractCharaFromPng(buf: Buffer): Record<string, unknown> | null {
+/** Parse chunk text that may be raw JSON or base64-encoded JSON. */
+function parseCharaChunkText(text: string): Record<string, unknown> | null {
+  try {
+    return JSON.parse(text) as Record<string, unknown>;
+  } catch {
+    try {
+      return JSON.parse(Buffer.from(text, "base64").toString("utf-8")) as Record<string, unknown>;
+    } catch {
+      return null;
+    }
+  }
+}
+
+/** Extract character JSON from a PNG buffer, checking tEXt, zTXt, and iTXt chunks for "ccv3" (V3) or "chara" (V2) keywords. */
+export function extractCharaFromPng(buf: Buffer): Record<string, unknown> | null {
   if (buf.length < 8) return null;
   const found = new Map<string, Record<string, unknown>>();
   let offset = 8; // skip PNG signature
@@ -212,6 +226,22 @@ function extractCharaFromPng(buf: Buffer): Record<string, unknown> | null {
           try {
             const json = Buffer.from(b64, "base64").toString("utf-8");
             found.set(keyword, JSON.parse(json));
+          } catch {
+            /* skip malformed */
+          }
+        }
+      }
+    } else if (type === "zTXt") {
+      // zTXt: keyword\0 compressionMethod(1 byte, 0 = zlib deflate) compressedText.
+      // Character Tavern cards store their chara/ccv3 payloads this way.
+      const nullIdx = payload.indexOf(0);
+      if (nullIdx >= 0) {
+        const keyword = payload.subarray(0, nullIdx).toString("ascii");
+        if (CHARA_KEYWORDS.has(keyword) && !found.has(keyword) && payload[nullIdx + 1] === 0) {
+          try {
+            const text = inflateSync(payload.subarray(nullIdx + 2)).toString("utf-8");
+            const parsed = parseCharaChunkText(text);
+            if (parsed) found.set(keyword, parsed);
           } catch {
             /* skip malformed */
           }

--- a/packages/server/src/routes/import.routes.ts
+++ b/packages/server/src/routes/import.routes.ts
@@ -7,7 +7,7 @@ import { inflateSync } from "node:zlib";
 import { platform, homedir } from "os";
 import { readdir, stat } from "fs/promises";
 import { resolve as pathResolve } from "path";
-import { normalizeTextForMatch, type ChatMode } from "@marinara-engine/shared";
+import { MAX_FILE_SIZES, normalizeTextForMatch, type ChatMode } from "@marinara-engine/shared";
 import { importSTChat } from "../services/import/st-chat.importer.js";
 import {
   importSTCharacter,
@@ -32,6 +32,7 @@ import { assertInsideDir, safeCompareString, tokenForPath } from "../utils/secur
 
 const PICK_FOLDER_TIMEOUT_MS = 60_000; // 60s — prevents infinite hang on headless servers
 const FOLDER_TOKEN_TTL_MS = 15 * 60_000;
+const MAX_CHARACTER_CARD_CHUNK_SIZE = Math.ceil(MAX_FILE_SIZES.CHARACTER_JSON / 3) * 4;
 
 const folderTokens = new Map<string, { path: string; expiresAt: number }>();
 
@@ -239,7 +240,9 @@ export function extractCharaFromPng(buf: Buffer): Record<string, unknown> | null
         const keyword = payload.subarray(0, nullIdx).toString("ascii");
         if (CHARA_KEYWORDS.has(keyword) && !found.has(keyword) && payload[nullIdx + 1] === 0) {
           try {
-            const text = inflateSync(payload.subarray(nullIdx + 2)).toString("utf-8");
+            const text = inflateSync(payload.subarray(nullIdx + 2), {
+              maxOutputLength: MAX_CHARACTER_CARD_CHUNK_SIZE,
+            }).toString("utf-8");
             const parsed = parseCharaChunkText(text);
             if (parsed) found.set(keyword, parsed);
           } catch {

--- a/packages/server/src/services/import/st-bulk.importer.ts
+++ b/packages/server/src/services/import/st-bulk.importer.ts
@@ -5,6 +5,7 @@ import { readdir, readFile, stat, copyFile, mkdir } from "fs/promises";
 import { join, extname, basename, relative } from "path";
 import { existsSync, readdirSync } from "fs";
 import { randomUUID } from "crypto";
+import { inflateSync } from "node:zlib";
 import type { DB } from "../../db/connection.js";
 import {
   getExistingCharacterTagKeys,
@@ -27,7 +28,7 @@ const BG_EXTS = new Set([".jpg", ".jpeg", ".png", ".gif", ".webp", ".avif"]);
 
 const CHARA_KEYWORDS = new Set(["ccv3", "chara"]);
 
-/** Read PNG tEXt/iTXt chunks with keyword "ccv3" or "chara" → base64 JSON. Prefers ccv3 (V3). */
+/** Read PNG tEXt/zTXt/iTXt chunks with keyword "ccv3" or "chara" → base64 JSON. Prefers ccv3 (V3). */
 function extractCharaFromPng(buf: Buffer): Record<string, unknown> | null {
   // PNG signature: 8 bytes
   if (buf.length < 8) return null;
@@ -48,6 +49,25 @@ function extractCharaFromPng(buf: Buffer): Record<string, unknown> | null {
           try {
             const json = Buffer.from(b64, "base64").toString("utf-8");
             found.set(keyword, JSON.parse(json));
+          } catch {
+            /* skip malformed */
+          }
+        }
+      }
+    } else if (type === "zTXt") {
+      // zTXt: keyword\0 compressionMethod(1 byte, 0 = zlib deflate) compressedText.
+      // Character Tavern cards store their chara/ccv3 payloads this way.
+      const nullIdx = payload.indexOf(0);
+      if (nullIdx >= 0) {
+        const keyword = payload.subarray(0, nullIdx).toString("ascii");
+        if (CHARA_KEYWORDS.has(keyword) && !found.has(keyword) && payload[nullIdx + 1] === 0) {
+          try {
+            const text = inflateSync(payload.subarray(nullIdx + 2)).toString("utf-8");
+            try {
+              found.set(keyword, JSON.parse(text));
+            } catch {
+              found.set(keyword, JSON.parse(Buffer.from(text, "base64").toString("utf-8")));
+            }
           } catch {
             /* skip malformed */
           }

--- a/packages/server/src/services/import/st-bulk.importer.ts
+++ b/packages/server/src/services/import/st-bulk.importer.ts
@@ -19,10 +19,11 @@ import { characters as charactersTable } from "../../db/schema/index.js";
 import { createCharactersStorage } from "../storage/characters.storage.js";
 import { DATA_DIR } from "../../utils/data-dir.js";
 import { getFileTimestampOverrides, parseTrustedTimestamp } from "./import-timestamps.js";
-import { normalizeTextForMatch } from "@marinara-engine/shared";
+import { MAX_FILE_SIZES, normalizeTextForMatch } from "@marinara-engine/shared";
 
 const BG_DIR = join(DATA_DIR, "backgrounds");
 const BG_EXTS = new Set([".jpg", ".jpeg", ".png", ".gif", ".webp", ".avif"]);
+const MAX_CHARACTER_CARD_CHUNK_SIZE = Math.ceil(MAX_FILE_SIZES.CHARACTER_JSON / 3) * 4;
 
 // ─── Helpers ───
 
@@ -62,7 +63,9 @@ function extractCharaFromPng(buf: Buffer): Record<string, unknown> | null {
         const keyword = payload.subarray(0, nullIdx).toString("ascii");
         if (CHARA_KEYWORDS.has(keyword) && !found.has(keyword) && payload[nullIdx + 1] === 0) {
           try {
-            const text = inflateSync(payload.subarray(nullIdx + 2)).toString("utf-8");
+            const text = inflateSync(payload.subarray(nullIdx + 2), {
+              maxOutputLength: MAX_CHARACTER_CARD_CHUNK_SIZE,
+            }).toString("utf-8");
             try {
               found.set(keyword, JSON.parse(text));
             } catch {

--- a/scripts/regressions/open-issues.regression.ts
+++ b/scripts/regressions/open-issues.regression.ts
@@ -62,6 +62,7 @@ import { characterMatchesSearch, parseCharacterDisplayData } from "../../package
 import {
   DEFAULT_GENERATION_PARAMS,
   DEFAULT_TRANSLATION_SYSTEM_PROMPT,
+  MAX_FILE_SIZES,
   resolveTranslationSystemPrompt,
 } from "../../packages/shared/src/constants/defaults.js";
 import { normalizeIllustratorImagesPerGeneration } from "../../packages/shared/src/utils/illustrator-generation-count.js";
@@ -2965,6 +2966,30 @@ try {
     (clientParsed.json as { data?: { name?: string } }).data?.name,
     "Tavern Import",
     "Client Card Browser import must extract character JSON from zTXt chunks",
+  );
+
+  const maxCharacterCardChunkSize = Math.ceil(MAX_FILE_SIZES.CHARACTER_JSON / 3) * 4;
+  const oversizedZtxtData = Buffer.concat([
+    Buffer.from("chara", "ascii"),
+    Buffer.from([0, 0]),
+    deflateSync(Buffer.alloc(maxCharacterCardChunkSize + 1, 0x41)),
+  ]);
+  const oversizedZtxtPng = Buffer.concat([
+    Buffer.from([137, 80, 78, 71, 13, 10, 26, 10]),
+    pngChunk("IHDR", ihdr),
+    pngChunk("zTXt", oversizedZtxtData),
+    pngChunk("IDAT", idat),
+    pngChunk("IEND", Buffer.alloc(0)),
+  ]);
+  assert.equal(
+    extractCharaFromPng(oversizedZtxtPng),
+    null,
+    "Server import must reject zTXt metadata that expands beyond the character-card limit",
+  );
+  await assert.rejects(
+    parsePngCharacterCard(new File([new Uint8Array(oversizedZtxtPng)], "oversized-card.png", { type: "image/png" })),
+    /No character data found/,
+    "Client import must reject zTXt metadata that expands beyond the character-card limit",
   );
 
   const { injectTextChunk } = await import("../../packages/server/src/routes/characters.routes.js");

--- a/scripts/regressions/open-issues.regression.ts
+++ b/scripts/regressions/open-issues.regression.ts
@@ -2914,4 +2914,66 @@ try {
   );
 }
 
+// Issue #4002 — Character Tavern stores card JSON in zTXt (zlib-compressed)
+// PNG chunks; every card-parsing path must read them, and export must strip
+// stale ones so re-exported cards cannot carry outdated compressed data.
+{
+  const { deflateSync, crc32: zlibCrc32 } = await import("node:zlib");
+  const { parsePngCharacterCard } = await import("../../packages/client/src/lib/png-parser.js");
+  const { extractCharaFromPng } = await import("../../packages/server/src/routes/import.routes.js");
+
+  const pngChunk = (type: string, data: Buffer) => {
+    const typeBytes = Buffer.from(type, "ascii");
+    const length = Buffer.alloc(4);
+    length.writeUInt32BE(data.length);
+    const crc = Buffer.alloc(4);
+    crc.writeUInt32BE(zlibCrc32(Buffer.concat([typeBytes, data])) >>> 0);
+    return Buffer.concat([length, typeBytes, data, crc]);
+  };
+  const card = { spec: "chara_card_v3", spec_version: "3.0", data: { name: "Tavern Import", description: "zTXt" } };
+  const base64Card = Buffer.from(JSON.stringify(card), "utf8").toString("base64");
+  const ztxtData = Buffer.concat([
+    Buffer.from("chara", "ascii"),
+    Buffer.from([0, 0]),
+    deflateSync(Buffer.from(base64Card, "ascii")),
+  ]);
+  const ihdr = Buffer.alloc(13);
+  ihdr.writeUInt32BE(1, 0);
+  ihdr.writeUInt32BE(1, 4);
+  ihdr[8] = 8;
+  ihdr[9] = 6;
+  const idat = Buffer.from([0x78, 0x01, 0x62, 0x60, 0x60, 0x60, 0x60, 0x00, 0x00, 0x00, 0x05, 0x00, 0x01]);
+  const ztxtPng = Buffer.concat([
+    Buffer.from([137, 80, 78, 71, 13, 10, 26, 10]),
+    pngChunk("IHDR", ihdr),
+    pngChunk("zTXt", ztxtData),
+    pngChunk("IDAT", idat),
+    pngChunk("IEND", Buffer.alloc(0)),
+  ]);
+
+  const serverParsed = extractCharaFromPng(ztxtPng);
+  assert.equal(
+    (serverParsed as { data?: { name?: string } } | null)?.data?.name,
+    "Tavern Import",
+    "Server import must extract character JSON from zTXt chunks",
+  );
+
+  const clientParsed = await parsePngCharacterCard(
+    new File([new Uint8Array(ztxtPng)], "card.png", { type: "image/png" }),
+  );
+  assert.equal(
+    (clientParsed.json as { data?: { name?: string } }).data?.name,
+    "Tavern Import",
+    "Client Card Browser import must extract character JSON from zTXt chunks",
+  );
+
+  const { injectTextChunk } = await import("../../packages/server/src/routes/characters.routes.js");
+  const reExported = injectTextChunk(ztxtPng, "chara", Buffer.from(JSON.stringify({ fresh: true })).toString("base64"));
+  assert.equal(
+    reExported.includes(deflateSync(Buffer.from(base64Card, "ascii"))),
+    false,
+    "Export must strip stale zTXt chara chunks instead of shipping outdated data",
+  );
+}
+
 console.info("Open-issue regressions passed.");


### PR DESCRIPTION
## Linked issue

Fixes #4002

## Why this change

Every card imported from Character Tavern through the Card Browser failed with "No character data found in PNG — this doesn't appear to be a SillyTavern character card". Reproduced against their live CDN: Character Tavern now embeds the `chara`/`ccv3` card JSON in **zTXt** (zlib-compressed) PNG chunks. Marinara's card parsers only read `tEXt` and `iTXt`, so the PNG parsed fine but no card data was ever found.

## What changed

All four chunk-reading paths now handle zTXt (compression method 0 / zlib), preferring `ccv3` over `chara` exactly as before:

- **Client Card Browser parser** (`png-parser.ts`) — inflates via `DecompressionStream("deflate")` (the Compression Streams zlib format; supported by all browsers Marinara targets). Its data-URL step now builds from the bytes already in memory instead of `FileReader`, which also lets the parser run under Node-based regressions.
- **Server single import** (`import.routes.ts`) and **SillyTavern bulk import** (`st-bulk.importer.ts`) — inflate via `node:zlib`.
- **Export chunk stripping** (`characters.routes.ts`) — recognizes zTXt keywords, so re-exporting a Character Tavern character strips its stale compressed card data instead of shipping outdated JSON alongside the fresh `tEXt` chunk.

Regression: the open-issues lane builds a synthetic zTXt card PNG and asserts client extraction, server extraction, and export stripping. Both parsers were additionally verified against a **real downloaded Character Tavern card** (extracted `chara_card_v3` with correct name from both).

## Validation

- [ ] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed `CONTRIBUTING.md`

### Manual verification notes

- Manually import a Character Tavern card end-to-end through the Card Browser UI and confirm the character is created with correct fields and avatar.
- Manually re-export that character as PNG and re-import it, confirming the exported card carries the current (not stale) data.
- Manually confirm ChubAI imports still work (tEXt path unchanged).

`pnpm check` and the open-issues regression lane were run by the preparing agent and passed; real-card extraction was verified programmatically. The browser UI flow needs the human check above. Checkboxes left unchecked per repository policy.

## Docs and release impact

- [ ] No docs changes needed
- [x] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Version/release files updated (only if this PR includes a version bump)

CHANGELOG.md updated; no version bump.

## UI evidence

No UI changes — the existing import flow simply succeeds where it previously errored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Character cards imported from the Card Browser now support compressed PNG metadata.
  * Re-exported cards remove outdated embedded character data, preventing stale card information.
  * Improved handling of malformed compressed metadata without interrupting imports.
* **Tests**
  * Added regression coverage for importing, exporting, and cleaning compressed character-card data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->