### PR TITLE
Extension UI polish: accent theming and floating-panel windows

### DIFF
--- a/docs/extending/personal-extensions.md
+++ b/docs/extending/personal-extensions.md
@@ -18,6 +18,10 @@ Sandboxing reduces authority; it does not make arbitrary code trustworthy. A mal
 
 A Browser Extension runs in a dedicated Worker inside an opaque-origin sandboxed iframe. It cannot access Marinara's page, DOM, cookies, browser storage, origin APIs, or network. Its capabilities are private extension storage, logging, managed timers, cleanup registration, and a constrained window UI. The extension never touches Marinara's DOM or writes HTML: it describes a window as a small set of elements (headings, text, preformatted blocks, buttons, and inputs), and the trusted sandbox renders them as text. Buttons report clicks — with the current input values — back to the extension, so it can show output, drive small tools, or add controls. This is enough for a closable info window, an extra button that does something, or a simple input-and-result tool.
 
+The window appears as a floating panel docked to the corner of the app, styled with the current accent color; the rest of Marinara stays visible and usable. It is not a full-screen takeover. Closing it (the panel's ✕) returns the app to normal.
+
+These UI capabilities and rules are identical for every Browser Extension regardless of source. An imported third-party (External) Extension gets the same window API and the same accent styling once it clears the same gates — the `.env` and Danger Zone opt-ins plus exact-hash approval. A third-party extension can add or change UI only through this same sandboxed window; it still cannot reach Marinara's own DOM.
+
 A Server Extension runs in a separate permission-restricted Node process inside macOS Seatbelt or Linux Bubblewrap. It cannot access Marinara files, user files, inherited server secrets, the network, child processes, workers, or native addons. If Marinara cannot establish a supported OS sandbox, Server Extensions remain disabled.
 
 ### Platform support

--- a/packages/client/src/components/layout/PersonalExtensionInjector.tsx
+++ b/packages/client/src/components/layout/PersonalExtensionInjector.tsx
@@ -10,7 +10,7 @@ type ActiveClientExtension = {
 
 type SandboxMessage = {
   channel?: string;
-  type?: "ready" | "error" | "log" | "storage" | "ui-window-open" | "ui-window-close";
+  type?: "ready" | "error" | "log" | "storage" | "ui-window-open" | "ui-window-close" | "ui-resize";
   contentHash?: string;
   requestId?: string;
   action?: "get" | "patch" | "delete";
@@ -18,30 +18,68 @@ type SandboxMessage = {
   level?: "debug" | "info" | "warn" | "error";
   args?: unknown[];
   message?: string;
+  width?: number;
+  height?: number;
 };
 
-// A hidden sandbox iframe becomes a centered, full-viewport overlay only while
-// the extension has an open window; the iframe draws its own backdrop and card.
-function setSandboxIframeVisible(iframe: HTMLIFrameElement, visible: boolean) {
-  if (visible) {
-    iframe.hidden = false;
-    iframe.removeAttribute("aria-hidden");
-    iframe.tabIndex = 0;
-    Object.assign(iframe.style, {
-      position: "fixed",
-      inset: "0",
-      width: "100%",
-      height: "100%",
-      border: "0",
-      zIndex: "2147483000",
-      colorScheme: "normal",
-    });
-  } else {
-    iframe.hidden = true;
-    iframe.setAttribute("aria-hidden", "true");
-    iframe.tabIndex = -1;
-    iframe.removeAttribute("style");
-  }
+// The sandbox iframe is a hidden 0×0 element until the extension opens a
+// window; then it becomes a small floating panel docked bottom-right. It never
+// covers Marinara's page — the rest of the app stays visible and interactive.
+function setSandboxIframeHidden(iframe: HTMLIFrameElement) {
+  iframe.hidden = true;
+  iframe.setAttribute("aria-hidden", "true");
+  iframe.tabIndex = -1;
+  iframe.removeAttribute("style");
+}
+
+function sizeSandboxPanel(iframe: HTMLIFrameElement, width?: number, height?: number) {
+  const maxW = Math.max(240, Math.min(window.innerWidth - 32, 420));
+  const maxH = Math.round(window.innerHeight * 0.7);
+  const w = Math.max(240, Math.min(typeof width === "number" ? width : 340, maxW));
+  const h = Math.max(80, Math.min(typeof height === "number" ? height : 240, maxH));
+  iframe.hidden = false;
+  iframe.removeAttribute("aria-hidden");
+  iframe.tabIndex = 0;
+  Object.assign(iframe.style, {
+    position: "fixed",
+    right: "1rem",
+    bottom: "1rem",
+    top: "auto",
+    left: "auto",
+    width: `${w}px`,
+    height: `${h}px`,
+    maxWidth: "calc(100vw - 2rem)",
+    maxHeight: "80vh",
+    border: "1px solid var(--border)",
+    borderRadius: "12px",
+    boxShadow: "0 16px 48px rgba(0,0,0,0.4)",
+    background: "transparent",
+    overflow: "hidden",
+    zIndex: "2147483000",
+    colorScheme: "normal",
+  });
+}
+
+// Forward Marinara's resolved accent/surface colors so the in-iframe window
+// matches the current theme. Only color strings cross the boundary.
+function postSandboxTheme(iframe: HTMLIFrameElement) {
+  const styles = getComputedStyle(document.documentElement);
+  const read = (name: string, fallback: string) => styles.getPropertyValue(name).trim() || fallback;
+  iframe.contentWindow?.postMessage(
+    {
+      channel: "marinara-personal-extension",
+      type: "ui-theme",
+      theme: {
+        accent: read("--primary", "#a855f7"),
+        accentText: read("--primary-foreground", "#ffffff"),
+        surface: read("--card", "#18181b"),
+        text: read("--foreground", "#f4f4f5"),
+        border: read("--border", "rgba(127,127,127,0.35)"),
+        muted: read("--secondary", "rgba(127,127,127,0.15)"),
+      },
+    },
+    "*",
+  );
 }
 
 const activeExtensions = new Map<string, ActiveClientExtension>();
@@ -142,11 +180,16 @@ export function PersonalExtensionInjector() {
         return;
       }
       if (message.type === "ui-window-open") {
-        setSandboxIframeVisible(active.iframe, true);
+        sizeSandboxPanel(active.iframe, message.width, message.height);
+        postSandboxTheme(active.iframe);
+        return;
+      }
+      if (message.type === "ui-resize") {
+        if (!active.iframe.hidden) sizeSandboxPanel(active.iframe, message.width, message.height);
         return;
       }
       if (message.type === "ui-window-close") {
-        setSandboxIframeVisible(active.iframe, false);
+        setSandboxIframeHidden(active.iframe);
         return;
       }
       if (message.type === "log" && LOG_LEVELS.has(message.level as NonNullable<SandboxMessage["level"]>)) {

--- a/packages/client/src/components/layout/PersonalExtensionInjector.tsx
+++ b/packages/client/src/components/layout/PersonalExtensionInjector.tsx
@@ -49,7 +49,7 @@ function sizeSandboxPanel(iframe: HTMLIFrameElement, width?: number, height?: nu
     width: `${w}px`,
     height: `${h}px`,
     maxWidth: "calc(100vw - 2rem)",
-    maxHeight: "80vh",
+    maxHeight: "70vh",
     border: "1px solid var(--border)",
     borderRadius: "12px",
     boxShadow: "0 16px 48px rgba(0,0,0,0.4)",

--- a/packages/client/src/components/panels/settings/PersonalExtensionsSettings.tsx
+++ b/packages/client/src/components/panels/settings/PersonalExtensionsSettings.tsx
@@ -239,7 +239,6 @@ function ExtensionSettings({ showIntro, mode }: { showIntro: boolean; mode: Exte
         message: riskMessage(extension, t),
         confirmLabel: t("settings.personalExtensions.approval.confirmLabel"),
         cancelLabel: t("settings.personalExtensions.approval.cancelLabel"),
-        tone: "destructive",
       });
       if (!confirmed) return;
       try {
@@ -463,9 +462,9 @@ function ExtensionSettings({ showIntro, mode }: { showIntro: boolean; mode: Exte
             className={cn(
               "flex items-start gap-2 rounded-lg border px-3 py-2.5 text-xs",
               current.enabled
-                ? "border-emerald-500/30 bg-emerald-500/8 text-emerald-300"
+                ? "border-[var(--primary)]/40 bg-[var(--primary)]/10 text-[var(--primary)]"
                 : approvalChanged
-                  ? "border-amber-500/30 bg-amber-500/8 text-amber-300"
+                  ? "border-[var(--primary)]/25 bg-[var(--primary)]/[0.06] text-[var(--foreground)]"
                   : "border-[var(--border)] bg-[var(--secondary)]/50 text-[var(--muted-foreground)]",
             )}
           >
@@ -538,8 +537,8 @@ function ExtensionSettings({ showIntro, mode }: { showIntro: boolean; mode: Exte
           />
         </label>
 
-        <div className="flex items-start gap-2 rounded-lg border border-amber-500/25 bg-amber-500/8 px-3 py-2.5 text-[0.6875rem] leading-relaxed text-amber-200">
-          <AlertTriangle size="0.875rem" className="mt-0.5 shrink-0" />
+        <div className="flex items-start gap-2 rounded-lg border border-[var(--primary)]/30 bg-[var(--primary)]/[0.08] px-3 py-2.5 text-[0.6875rem] leading-relaxed text-[var(--foreground)]">
+          <AlertTriangle size="0.875rem" className="mt-0.5 shrink-0 text-[var(--primary)]" />
           {draft.runtime === "server"
             ? t("settings.personalExtensions.sandbox.server")
             : t("settings.personalExtensions.sandbox.browser")}

--- a/packages/server/src/routes/personal-extensions.routes.ts
+++ b/packages/server/src/routes/personal-extensions.routes.ts
@@ -238,34 +238,47 @@ export function sandboxDocument(extension: PersonalExtension, nonce: string) {
   // Host-rendered window layer. The worker only sends element descriptors;
   // everything below builds DOM with textContent (never parsed markup) inside
   // this opaque-origin iframe, so the extension can present interactive UI
-  // without touching Marinara's page or being able to inject markup.
+  // without touching Marinara's page or being able to inject markup. The iframe
+  // is sized by the host to just this floating panel — it does not cover or
+  // take over Marinara's page.
+  const theme = { accent: "#a855f7", accentText: "#ffffff", surface: "rgba(24,24,27,0.98)", text: "#f4f4f5", border: "rgba(127,127,127,0.35)", muted: "rgba(127,127,127,0.15)" };
   const root = document.createElement("div");
   root.setAttribute("data-ext-root", "");
-  Object.assign(root.style, { position: "fixed", inset: "0", display: "none", padding: "1rem", boxSizing: "border-box", overflow: "auto", fontFamily: "system-ui, sans-serif" });
+  Object.assign(root.style, { display: "none", fontFamily: "system-ui, sans-serif", boxSizing: "border-box" });
+  document.documentElement.style.background = "transparent";
+  document.body.style.margin = "0";
+  document.body.style.background = "transparent";
   document.body.appendChild(root);
   const uiWindows = new Map();
-  const syncVisibility = () => {
-    const open = uiWindows.size > 0;
-    root.style.display = open ? "flex" : "none";
-    root.style.flexDirection = "column";
-    root.style.gap = "0.75rem";
-    root.style.alignItems = "center";
-    root.style.justifyContent = "center";
-    root.style.background = open ? "rgba(0,0,0,0.45)" : "transparent";
-    post({ type: open ? "ui-window-open" : "ui-window-close", contentHash: extension.contentHash });
+  const applyThemeVars = () => {
+    root.style.setProperty("--ext-accent", theme.accent);
+    root.style.setProperty("--ext-accent-text", theme.accentText);
+    root.style.setProperty("--ext-surface", theme.surface);
+    root.style.setProperty("--ext-text", theme.text);
+    root.style.setProperty("--ext-border", theme.border);
+    root.style.setProperty("--ext-muted", theme.muted);
   };
-  // Clicking the backdrop (outside any card) dismisses, matching host modals.
-  root.addEventListener("click", (event) => {
-    if (event.target !== root) return;
-    for (const windowId of [...uiWindows.keys()]) closeWindowLocally(windowId, true);
-  });
+  applyThemeVars();
+  const reportSize = () => {
+    if (uiWindows.size === 0) return;
+    const width = Math.min(420, Math.max(240, Math.ceil(root.scrollWidth)));
+    const height = Math.max(80, Math.ceil(root.scrollHeight));
+    post({ type: "ui-resize", contentHash: extension.contentHash, width, height });
+  };
+  const syncVisibility = (justOpened) => {
+    const open = uiWindows.size > 0;
+    root.style.display = open ? "block" : "none";
+    if (!open) { post({ type: "ui-window-close", contentHash: extension.contentHash }); return; }
+    if (justOpened) post({ type: "ui-window-open", contentHash: extension.contentHash });
+    reportSize();
+  };
   const closeWindowLocally = (windowId, notifyWorker) => {
     const entry = uiWindows.get(windowId);
     if (!entry) return;
     entry.card.remove();
     uiWindows.delete(windowId);
     if (notifyWorker) worker.postMessage({ type: "ui-closed", windowId });
-    syncVisibility();
+    syncVisibility(false);
   };
   const collectValues = (windowId) => {
     const values = {};
@@ -289,7 +302,7 @@ export function sandboxDocument(extension: PersonalExtension, nonce: string) {
     if (descriptor.kind === "pre") {
       const el = document.createElement("pre");
       el.textContent = descriptor.text || "";
-      Object.assign(el.style, { margin: "0", padding: "0.5rem", borderRadius: "6px", background: "rgba(127,127,127,0.15)", overflow: "auto", fontFamily: "ui-monospace, monospace", fontSize: "0.8125rem", lineHeight: "1.4" });
+      Object.assign(el.style, { margin: "0", padding: "0.5rem", borderRadius: "6px", background: "var(--ext-muted)", overflow: "auto", fontFamily: "ui-monospace, monospace", fontSize: "0.8125rem", lineHeight: "1.4" });
       return el;
     }
     if (descriptor.kind === "spacer") {
@@ -306,7 +319,7 @@ export function sandboxDocument(extension: PersonalExtension, nonce: string) {
       if (descriptor.placeholder) field.placeholder = descriptor.placeholder;
       field.value = descriptor.value || "";
       field.setAttribute("data-ext-input", descriptor.id);
-      Object.assign(field.style, { padding: "0.4rem 0.5rem", borderRadius: "6px", border: "1px solid rgba(127,127,127,0.4)", background: "rgba(127,127,127,0.08)", color: "inherit", font: "inherit" });
+      Object.assign(field.style, { padding: "0.4rem 0.5rem", borderRadius: "6px", border: "1px solid var(--ext-border)", background: "var(--ext-muted)", color: "inherit", font: "inherit" });
       if (descriptor.multiline) field.rows = 4;
       inputs.set(descriptor.id, field);
       wrap.appendChild(field);
@@ -316,7 +329,7 @@ export function sandboxDocument(extension: PersonalExtension, nonce: string) {
       const el = document.createElement("button");
       el.type = "button";
       el.textContent = descriptor.label || descriptor.text || "Button";
-      Object.assign(el.style, { alignSelf: "flex-start", padding: "0.4rem 0.85rem", borderRadius: "6px", border: "1px solid rgba(127,127,127,0.4)", background: "rgba(127,127,127,0.15)", color: "inherit", font: "inherit", cursor: "pointer" });
+      Object.assign(el.style, { alignSelf: "flex-start", padding: "0.4rem 0.85rem", borderRadius: "6px", border: "1px solid var(--ext-accent)", background: "var(--ext-accent)", color: "var(--ext-accent-text)", font: "inherit", fontWeight: "600", cursor: "pointer" });
       el.addEventListener("click", () => {
         worker.postMessage({ type: "ui-event", windowId, elementId: descriptor.id, values: collectValues(windowId) });
       });
@@ -332,9 +345,9 @@ export function sandboxDocument(extension: PersonalExtension, nonce: string) {
   const showWindow = (windowId, title, elements) => {
     closeWindowLocally(windowId, false);
     const card = document.createElement("section");
-    Object.assign(card.style, { width: "100%", maxWidth: "26rem", borderRadius: "10px", border: "1px solid rgba(127,127,127,0.35)", background: "rgba(24,24,27,0.98)", color: "#f4f4f5", boxShadow: "0 12px 40px rgba(0,0,0,0.45)", overflow: "hidden" });
+    Object.assign(card.style, { display: "block", width: "100%", boxSizing: "border-box", border: "1px solid var(--ext-border)", background: "var(--ext-surface)", color: "var(--ext-text)", overflow: "hidden" });
     const header = document.createElement("div");
-    Object.assign(header.style, { display: "flex", alignItems: "center", justifyContent: "space-between", gap: "0.5rem", padding: "0.5rem 0.5rem 0.5rem 0.85rem", borderBottom: "1px solid rgba(127,127,127,0.3)" });
+    Object.assign(header.style, { display: "flex", alignItems: "center", justifyContent: "space-between", gap: "0.5rem", padding: "0.5rem 0.5rem 0.5rem 0.85rem", borderBottom: "1px solid var(--ext-border)" });
     const titleEl = document.createElement("strong");
     titleEl.textContent = title || extension.name;
     titleEl.style.fontSize = "0.875rem";
@@ -354,13 +367,14 @@ export function sandboxDocument(extension: PersonalExtension, nonce: string) {
     const entry = { id: windowId, card, body, titleEl, inputs: new Map() };
     uiWindows.set(windowId, entry);
     renderBody(entry, elements);
-    syncVisibility();
+    syncVisibility(true);
   };
   const updateWindow = (windowId, title, elements) => {
     const entry = uiWindows.get(windowId);
     if (!entry) return;
     if (typeof title === "string") entry.titleEl.textContent = title;
     if (Array.isArray(elements)) renderBody(entry, elements);
+    reportSize();
   };
 
   let lastHeartbeat = Date.now();
@@ -428,6 +442,14 @@ export function sandboxDocument(extension: PersonalExtension, nonce: string) {
     if (event.source !== window.parent || event.data?.channel !== "marinara-personal-extension") return;
     const message = event.data;
     if (message.type === "storage-result") worker.postMessage(message);
+    if (message.type === "ui-theme" && message.theme && typeof message.theme === "object") {
+      // The host forwards Marinara's resolved accent/surface colors so the
+      // in-iframe window matches the app; values are only ever used as CSS.
+      for (const key of ["accent", "accentText", "surface", "text", "border", "muted"]) {
+        if (typeof message.theme[key] === "string" && message.theme[key]) theme[key] = message.theme[key];
+      }
+      applyThemeVars();
+    }
     if (message.type === "ui-dismiss") {
       for (const windowId of [...uiWindows.keys()]) closeWindowLocally(windowId, true);
     }

--- a/scripts/regressions/extension-security.regression.ts
+++ b/scripts/regressions/extension-security.regression.ts
@@ -346,6 +346,12 @@ try {
   assert.match(doc, /textContent/u, "Sandbox bootstrap must render window text via textContent");
   assert.doesNotMatch(doc, /innerHTML/u, "Sandbox bootstrap must never assign innerHTML");
   assert.match(doc, /ui-window-open/u, "Sandbox reveals the iframe only through the ui-window-open signal");
+  assert.match(doc, /ui-resize/u, "Sandbox reports its content size so the host can fit the floating panel");
+  assert.doesNotMatch(
+    doc,
+    /rgba\(0,\s*0,\s*0,\s*0\.45\)/u,
+    "The extension window is a floating panel, not a full-screen backdrop takeover",
+  );
   assert.ok(
     doc.includes("new Worker(") && doc.includes("marinara.ui.showWindow"),
     "Extension JS must run in the worker embedded by the bootstrap, not in the document",


### PR DESCRIPTION
## Linked issue

Follow-up to #4006 (merged), addressing maintainer UI feedback after testing the browser-extension window capability with Professor Mari.

## Why this change

Testing surfaced four issues:

1. The enabled "Running approved code" status used a hardcoded green instead of the accent color.
2. The browser/server sandbox warning used a hardcoded amber (yellow) instead of the accent color.
3. The run-approval confirmation button used the destructive (red) tone instead of the standard accent button styling.
4. The extension window opened as a **full-screen grey backdrop takeover** rather than over Marinara's page. That grey takeover was a presentation choice in the trusted renderer, not a security requirement.

## What changed

**Settings UI**
- Enabled status and the sandbox warning now use `var(--primary)` accent tokens instead of emerald/amber.
- The approval dialog drops `tone: "destructive"`, so the confirm button uses the standard accent styling. The confirmation step and full risk copy are unchanged.

**Extension window presentation**
- Replaced the full-viewport backdrop with a **floating panel** docked bottom-right, sized to its content (capped to 70vh). Marinara's page stays fully visible and interactive — the window is no longer modal.
- The host forwards Marinara's resolved accent/surface/border colors into the sandbox; the bootstrap applies them as CSS variables so the window (and its buttons) match the current theme.
- The bootstrap reports content size (`ui-resize`) so the host fits the panel; it no longer paints any page-covering backdrop.

**Third-party parity (requested)**
- These capabilities and styling are served by the shared sandbox document, so imported External Extensions get the identical window API and accent styling once they clear the same gates (`ENABLE_EXTERNAL_EXTENSIONS` + Danger Zone opt-in + exact-hash approval). A third-party extension can add or change UI only through this same sandboxed window — it still cannot reach Marinara's own DOM. Docs updated to state this explicitly.

### Security posture (unchanged)

Making the window a smaller floating panel instead of a full-viewport overlay is strictly less surface. The iframe is still opaque-origin, `allow-scripts` only, `connect-src 'none'`; the extension still has no DOM/network/host access and only *describes* a window the trusted host renders as text.

## Validation

- [ ] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed `CONTRIBUTING.md`

Automated: `pnpm check` and `pnpm regression:extensions-security` (including the real macOS Seatbelt server-sandbox proof) pass. The regression now also asserts the window is a floating panel — it reports `ui-resize` and never paints a full-screen backdrop.

### Manual verification notes

- Approve a Mari-authored ASCII-bunny browser extension and confirm the window opens as a bottom-right floating panel over the app (page still usable), styled with the accent, and closes via ✕.
- Confirm the Settings enabled-status pill, sandbox warning, and approval dialog button all use the accent in light and dark themes.
- Import a third-party browser extension that opens a window and confirm it gets the same panel + accent styling after the gates + approval.

## Docs and release impact

- [x] Updated docs (CHANGELOG covered by #4006; `docs/extending/personal-extensions.md` updated here)
- [ ] Version/release files updated (only if this PR includes a version bump)

## UI evidence

Floating panel renders inside the sandbox iframe; screenshots to be added during manual verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Personal extension interfaces now open in compact, corner-docked floating panels instead of full-screen overlays.
  - Panels automatically resize to fit their content and match the app’s current accent theme.
  - Closing an extension panel returns the app to its normal state.

- **Bug Fixes**
  - Updated extension settings alerts and status indicators to use consistent theme colors.
  - Improved sandbox security checks to prevent full-screen backdrop behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->