### PR TITLE
Extension settings: accent colors for enabled/delete + wrap dialog hashes

### DIFF
--- a/packages/client/src/components/panels/settings/PersonalExtensionsSettings.tsx
+++ b/packages/client/src/components/panels/settings/PersonalExtensionsSettings.tsx
@@ -269,7 +269,6 @@ function ExtensionSettings({ showIntro, mode }: { showIntro: boolean; mode: Exte
         title: "Delete Personal Extension?",
         message: `Delete "${extension.name}" and its private extension storage? This cannot be undone.`,
         confirmLabel: "Delete",
-        tone: "destructive",
       });
       if (!confirmed) return;
       try {
@@ -729,7 +728,7 @@ function ExtensionSettings({ showIntro, mode }: { showIntro: boolean; mode: Exte
                     className={cn(
                       "group relative rounded-lg border px-3 py-2.5 pr-32 transition-colors max-md:pr-28",
                       extension.enabled
-                        ? "border-emerald-500/25 bg-emerald-500/6"
+                        ? "border-[var(--primary)]/30 bg-[var(--primary)]/[0.07]"
                         : "border-[var(--border)] bg-[var(--secondary)]/45 hover:bg-[var(--secondary)]/70",
                     )}
                   >
@@ -742,7 +741,7 @@ function ExtensionSettings({ showIntro, mode }: { showIntro: boolean; mode: Exte
                         className={cn(
                           "mt-0.5 flex h-7 w-7 shrink-0 items-center justify-center rounded-md border",
                           extension.enabled
-                            ? "border-emerald-500/25 bg-emerald-500/10 text-emerald-300"
+                            ? "border-[var(--primary)]/30 bg-[var(--primary)]/10 text-[var(--primary)]"
                             : "border-[var(--border)] bg-[var(--background)]/60 text-[var(--muted-foreground)]",
                         )}
                       >
@@ -761,10 +760,10 @@ function ExtensionSettings({ showIntro, mode }: { showIntro: boolean; mode: Exte
                             className={cn(
                               "rounded px-1.5 py-0.5 text-[0.5625rem] font-semibold ring-1",
                               extension.enabled
-                                ? "bg-emerald-500/10 text-emerald-300 ring-emerald-500/20"
+                                ? "bg-[var(--primary)]/10 text-[var(--primary)] ring-[var(--primary)]/25"
                                 : approved
                                   ? "bg-[var(--background)]/60 text-[var(--muted-foreground)] ring-[var(--border)]"
-                                  : "bg-amber-500/10 text-amber-300 ring-amber-500/20",
+                                  : "bg-[var(--primary)]/[0.06] text-[var(--foreground)] ring-[var(--primary)]/20",
                             )}
                           >
                             {status}

--- a/packages/client/src/components/ui/AppDialogRenderer.tsx
+++ b/packages/client/src/components/ui/AppDialogRenderer.tsx
@@ -54,7 +54,9 @@ export function AppDialogRenderer() {
       chatFloatingPanel
     >
       <div className="space-y-4">
-        <p className="whitespace-pre-wrap text-sm leading-relaxed text-[var(--foreground)]">{dialog.message}</p>
+        <p className="whitespace-pre-wrap break-words text-sm leading-relaxed text-[var(--foreground)]">
+          {dialog.message}
+        </p>
 
         {dialog.kind === "prompt" && (
           <form


### PR DESCRIPTION
## Linked issue

Follow-up to #4006/#4007, addressing further maintainer UI feedback after testing Personal Extensions.

## Why this change

1. Enabled extensions in the list were highlighted with a hardcoded emerald green (row, icon badge, and the "Enabled"/"Running" status pill) instead of the accent color.
2. The delete confirmation button used the destructive (red) tone instead of the accent styling.
3. The run/delete confirmation dialog did not wrap a long unbroken SHA-256 hash, so it overflowed off the side of the box.

## What changed

- **Enabled list styling → accent:** the enabled row background/border, the enabled icon badge, and the "Enabled"/"Running" status pill now use `var(--primary)` tokens instead of emerald. The needs-approval pill drops amber for a neutral accent tint.
- **Delete confirm → accent:** `removeExtension` drops `tone: "destructive"`, so the confirm button uses the standard accent styling. The confirmation copy is unchanged. Genuine error banners (load/permission errors, server errors) keep the destructive red, since those are errors, not actions.
- **Dialog wrapping:** `AppDialogRenderer` adds `break-words` so long unbroken tokens (a full `sha256:` hash) wrap inside the dialog instead of overflowing. This is an app-wide dialog improvement and only affects tokens that would otherwise overflow.

### Third-party parity (requested)

Both the Personal and External extension tabs render through the same list rows and the same confirmation dialog, so all three fixes apply identically to imported third-party extensions.

## Validation

- [ ] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed `CONTRIBUTING.md`

Automated: `pnpm check` passes.

### Manual verification notes

- Enable a browser extension and confirm the row, icon, and status pill use the accent color (light + dark), for both a Professor Mari draft and an imported third-party extension.
- Click delete and confirm the dialog's Delete button uses the accent color and the long hash in the message wraps inside the box.
- Confirm error states (e.g. no Admin Access) still show the red error banner.

## Docs and release impact

- [x] No docs changes needed (styling only)
- [ ] Version/release files updated (only if this PR includes a version bump)

## UI evidence

Styling-only change; screenshots to be added during manual verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated personal extension status indicators and cards with refreshed primary color styling.
  * Improved confirmation dialog message formatting for better text wrapping and preserved whitespace.

* **Bug Fixes**
  * Removed the destructive visual treatment from the personal extension deletion confirmation dialog.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->