### PR TITLE
Fix empty tool-call parameters with GPT-5.6 on the Responses API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 
 ### Fixed
 
+- Fixed Web Search (and other tools) returning empty or malformed parameters with GPT-5.6/5.5/5.4 and Codex models on the OpenAI Responses API. Streamed function-call arguments are keyed by the response item id rather than the call id, so the tool query is no longer dropped mid-stream (#4010).
 - Kept gradient **Accent Pulse** animating while the Appearance tab is open, so color changes can be previewed where the setting is configured.
 - Reworked Character and Persona avatar editing with a non-overlapping miniature AI wand, equal Upload/Generate actions in Metadata, a downward upload arrow, and accent-colored removal controls. Game Assets selection, menu, and removal states now follow the configured chroma instead of fixed pink or red treatments.
 - Fixed Character Tavern imports from the Card Browser: their cards store character data in compressed zTXt PNG chunks, which every Marinara card parser (Card Browser import, file/URL import, SillyTavern bulk import) now reads alongside tEXt and iTXt. Re-exporting such a character also strips the stale compressed data instead of shipping outdated card JSON (#4002).

--- a/packages/server/src/services/llm/providers/openai.provider.ts
+++ b/packages/server/src/services/llm/providers/openai.provider.ts
@@ -2285,12 +2285,16 @@ export class OpenAIProvider extends BaseLLMProvider {
             }
 
             case "response.output_item.added": {
-              // A new output item appeared — could be a function_call
+              // A new output item appeared — could be a function_call. Key the
+              // accumulator by the output item id: the argument delta/done
+              // events below reference the item via item_id, not call_id.
               const item = parsed.item as Record<string, unknown> | undefined;
               if (item?.type === "function_call") {
-                const callId = (item.call_id ?? item.id) as string;
-                fnCallArgs.set(callId, {
-                  id: callId,
+                const itemId = (item.id ?? item.call_id) as string;
+                fnCallArgs.set(itemId, {
+                  // Preserve call_id as the tool-call id downstream needs to
+                  // reference in function_call_output.
+                  id: ((item.call_id ?? item.id) as string) ?? "",
                   name: (item.name as string) ?? "",
                   arguments: (item.arguments as string) ?? "",
                 });
@@ -2299,23 +2303,23 @@ export class OpenAIProvider extends BaseLLMProvider {
             }
 
             case "response.function_call_arguments.delta": {
-              const callId = parsed.call_id as string | undefined;
+              const itemId = (parsed.item_id ?? parsed.call_id) as string | undefined;
               const delta = parsed.delta as string | undefined;
-              if (callId && delta) {
-                const entry = fnCallArgs.get(callId);
+              if (itemId && delta) {
+                const entry = fnCallArgs.get(itemId);
                 if (entry) entry.arguments += delta;
               }
               break;
             }
 
             case "response.function_call_arguments.done": {
-              const callId = parsed.call_id as string | undefined;
-              if (callId) {
-                const entry = fnCallArgs.get(callId);
+              const itemId = (parsed.item_id ?? parsed.call_id) as string | undefined;
+              if (itemId) {
+                const entry = fnCallArgs.get(itemId);
                 if (entry) {
                   // Overwrite with the final arguments if provided
                   const args = parsed.arguments as string | undefined;
-                  if (args) entry.arguments = args;
+                  if (typeof args === "string" && args) entry.arguments = args;
                 }
               }
               break;
@@ -2325,10 +2329,10 @@ export class OpenAIProvider extends BaseLLMProvider {
               // Finalize function_call items
               const item = parsed.item as Record<string, unknown> | undefined;
               if (item?.type === "function_call") {
-                const callId = ((item.call_id ?? item.id) as string) ?? "";
-                const entry = fnCallArgs.get(callId);
+                const itemId = ((item.id ?? item.call_id) as string) ?? "";
+                const entry = fnCallArgs.get(itemId);
                 functionCalls.push({
-                  id: callId,
+                  id: entry?.id ?? ((item.call_id ?? item.id) as string) ?? "",
                   type: "function",
                   function: {
                     name: entry?.name ?? (item.name as string) ?? "",

--- a/scripts/regressions/provider-compat.regression.ts
+++ b/scripts/regressions/provider-compat.regression.ts
@@ -581,4 +581,72 @@ await assert.rejects(
 );
 assert.equal(abortedFallback.calls, 0, "user cancellation must not trigger a fallback request");
 
+// Issue #4010 — GPT-5.6 (Responses API) streams function-call arguments in
+// `response.function_call_arguments.delta` events keyed by `item_id`, not
+// `call_id`. Accumulating by call_id left tool arguments empty, so Web Search
+// received blank/malformed JSON. Verify the streamed query is reassembled.
+{
+  const responsesToolSse = [
+    'event: response.output_item.added',
+    'data: {"type":"response.output_item.added","item":{"id":"fc_1","type":"function_call","call_id":"call_1","name":"web_search","arguments":""}}',
+    '',
+    'event: response.function_call_arguments.delta',
+    'data: {"type":"response.function_call_arguments.delta","item_id":"fc_1","output_index":0,"delta":"{\\"query\\":\\"latest "}',
+    '',
+    'event: response.function_call_arguments.delta',
+    'data: {"type":"response.function_call_arguments.delta","item_id":"fc_1","output_index":0,"delta":"marinara news\\"}"}',
+    '',
+    'event: response.function_call_arguments.done',
+    'data: {"type":"response.function_call_arguments.done","item_id":"fc_1","output_index":0,"arguments":"{\\"query\\":\\"latest marinara news\\"}"}',
+    '',
+    'event: response.output_item.done',
+    'data: {"type":"response.output_item.done","item":{"id":"fc_1","type":"function_call","call_id":"call_1","name":"web_search"}}',
+    '',
+    'event: response.completed',
+    'data: {"type":"response.completed","response":{"status":"completed"}}',
+    '',
+    'data: [DONE]',
+    '',
+  ].join("\n");
+  const responsesServer = createServer((_request, response) => {
+    response.writeHead(200, { "content-type": "text/event-stream" });
+    response.end(responsesToolSse);
+  });
+  await new Promise<void>((resolve) => responsesServer.listen(0, "127.0.0.1", resolve));
+  try {
+    const address = responsesServer.address();
+    assert.ok(address && typeof address === "object");
+    const provider = new OpenAIProvider(
+      `http://127.0.0.1:${address.port}/v1`,
+      "test",
+      undefined,
+      undefined,
+      undefined,
+      "openai",
+      undefined,
+      true,
+    );
+    const result = await provider.chatComplete([{ role: "user", content: "search please" }], {
+      model: "gpt-5.6",
+      stream: true,
+      tools: [
+        {
+          type: "function",
+          function: { name: "web_search", description: "Search the web", parameters: { type: "object", properties: { query: { type: "string" } } } },
+        },
+      ],
+    });
+    assert.equal(result.toolCalls.length, 1, "GPT-5.6 Responses stream must surface the function call");
+    assert.equal(result.toolCalls[0].function.name, "web_search");
+    assert.equal(
+      result.toolCalls[0].function.arguments,
+      '{"query":"latest marinara news"}',
+      "streamed function-call arguments must be accumulated by item_id, not dropped",
+    );
+    assert.equal(result.toolCalls[0].id, "call_1", "the tool call must keep its call_id for function_call_output");
+  } finally {
+    await new Promise<void>((resolve, reject) => responsesServer.close((error) => (error ? reject(error) : resolve())));
+  }
+}
+
 process.stdout.write("Provider compatibility regression passed.\n");


### PR DESCRIPTION
## Linked issue

Fixes #4010

## Why this change

Web Search (and any tool) fails with GPT-5.6 (Sol) in Roleplay mode: the model reports the tool-call JSON parameters are empty/blank/malformed, then loops indefinitely without answering. Reproduced by reasoning through the Responses-API streaming path.

**Root cause:** GPT-5.6/5.5/5.4 and Codex models use the OpenAI **Responses API**, which streams function-call arguments in `response.function_call_arguments.delta` / `.done` events that reference the output item by **`item_id`** (the `fc_…` item id) — not `call_id`. The streaming parser accumulated arguments in a map keyed by `call_id` (the `call_…` id) and read `parsed.call_id` from the delta events, a field those events don't carry. So the `if (callId && delta)` guard was always false, arguments never accumulated, and the tool call surfaced with empty arguments. This affected both OpenAI and OpenRouter because gpt-5.6 routes through the Responses API by model name (streaming only — Roleplay streams).

## What changed

- Key the argument accumulator by the **output item id** (`item.id`), and read the `delta`/`done` events by `item_id` (with `call_id` as a fallback for robustness).
- Preserve `call_id` as the surfaced tool-call `id`, so the follow-up `function_call_output` still references the call correctly.
- Regression: `provider-compat` now streams a Responses-API function call (`output_item.added` → two `function_call_arguments.delta` → `.done` → `output_item.done`) and asserts the query is reassembled (`{"query":"latest marinara news"}`) and the `call_id` is preserved. Pre-fix this asserts empty arguments and fails.

## Validation

- [ ] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed `CONTRIBUTING.md`

Automated: `pnpm check` and `pnpm regression:providers` (with the new Responses-API function-call test) pass.

### Manual verification notes

- Manually run Web Search in Roleplay with GPT-5.6 on a real OpenAI key and confirm the query fires and the model answers.
- Manually repeat via OpenRouter with a gpt-5.6 route.
- Manually confirm non-Responses models (e.g. GPT-4o, Claude) still call tools correctly (Chat Completions path unchanged).

## Docs and release impact

- [x] Updated CHANGELOG.md
- [ ] Version/release files updated (only if this PR includes a version bump)

## UI evidence

No UI changes — tool-call streaming fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)