### PR TITLE
Center the Review and Run button label in extension editor

### DIFF
--- a/packages/client/src/components/panels/settings/PersonalExtensionsSettings.tsx
+++ b/packages/client/src/components/panels/settings/PersonalExtensionsSettings.tsx
@@ -432,14 +432,18 @@ function ExtensionSettings({ showIntro, mode }: { showIntro: boolean; mode: Exte
                 onClick={() => void (current.enabled ? disableExtension(current) : runExtension(current))}
                 disabled={busy}
                 className={cn(
-                  "flex min-h-9 items-center gap-1.5 rounded-md px-3 text-xs font-semibold transition-colors disabled:cursor-not-allowed disabled:opacity-50",
+                  "flex min-h-9 items-center justify-center gap-1.5 rounded-md px-3 text-xs font-semibold leading-none transition-colors disabled:cursor-not-allowed disabled:opacity-50",
                   current.enabled
                     ? "bg-[var(--secondary)] text-[var(--foreground)] hover:bg-[var(--accent)]"
                     : "bg-[var(--primary)] text-[var(--primary-foreground)] hover:opacity-90",
                 )}
               >
-                {current.enabled ? <PowerOff size="0.75rem" /> : <Power size="0.75rem" />}
-                {current.enabled ? "Disable" : "Review and Run"}
+                {current.enabled ? (
+                  <PowerOff size="0.75rem" className="shrink-0" />
+                ) : (
+                  <Power size="0.75rem" className="shrink-0" />
+                )}
+                <span>{current.enabled ? "Disable" : "Review and Run"}</span>
               </button>
             )}
             {isExternal && (


### PR DESCRIPTION
## Linked issue

None — maintainer UI report: the "Review and Run" button label in **Settings → Addons → Extensions** is not centered correctly, for both Personal and third-party extensions.

## What changed

The extension editor's run/disable button rendered its icon next to a bare text node with only `items-center`, so the label could sit slightly off relative to the icon. Added `justify-center` and `leading-none`, kept the icon from shrinking (`shrink-0`), and wrapped the label in a `<span>` so the icon and text center together. The editor is shared, so this covers both Personal and External (third-party) extensions.

## Validation

- [ ] `pnpm check` passes locally
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport)
- [ ] Read and followed `CONTRIBUTING.md`

Automated: `pnpm check` passes.

### Manual verification notes

- Open a Personal extension and a third-party extension in the editor; confirm the "Review and Run" (and "Disable") button label is centered with its icon, on desktop and mobile.

## Docs and release impact

- [x] No docs changes needed (styling only)

## UI evidence

Styling-only; screenshots to be added during manual verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)