### PR TITLE
Add HumanOS persona builder skill

### DIFF
--- a/.agents/skills/build-humanos-personas/SKILL.md
+++ b/.agents/skills/build-humanos-personas/SKILL.md
@@ -1,0 +1,43 @@
+---
+name: build-humanos-personas
+description: Build or revise portable AI roleplay personas using the HumanOS layered workflow. Use when creating a character or user persona, separating character, world, story, and runtime truth, adapting a persona for JanitorAI/SillyTavern/other chat platforms, compressing a persona card to a token budget, or auditing an existing character card that has become overbloated or mixed its truth layers.
+---
+
+# Build HumanOS Personas
+
+Create durable, reusable roleplay architecture. Treat the persona as portable and keep campaign-specific material outside it unless the user explicitly wants a non-portable card.
+
+## Workflow
+
+1. Identify the requested deliverables and platform. Infer sensible defaults from supplied material; ask one focused question at a time, only when a missing choice would materially change the build.
+2. Establish the character kernel first: identity, personality, internal model, psychology, relationships, intimacy approach when relevant, and speech. Do not include plot events, setting facts, or current-scene facts here.
+3. Create the supporting truth layers separately:
+   - **World truth:** durable setting logic, institutions, norms, locations, NPC routines, and rules that are true regardless of this character's current scene.
+   - **Story binding:** the premise, inciting situation, fixed relationship history, and narrative pressures specific to this pairing or campaign.
+   - **Runtime truth:** the current moment only--location, immediate situation, recent changes, active objectives, mindset, known facts, and near-term open threads.
+4. Apply the layer audit in `references/humanos-layer-rules.md`. Move facts to the narrowest layer that can truthfully own them.
+5. Compress only after the full logic works. Preserve behavioural causality, boundaries, contradictions, and high-yield speech cues; remove duplicated description and decorative detail first.
+6. Produce requested platform adaptations without silently merging the layers. For platforms with one large description field, use clearly labelled sections and retain user agency instructions.
+7. Finish with a concise consistency check: no story/world leakage into the persona; no stale runtime facts presented as permanent; no instructions that write dialogue, decisions, or internal states for `{{user}}`.
+
+## Output Rules
+
+- Keep modules 1-7 (the persona card) story-free unless the user explicitly changes that architecture.
+- Do not "discard" Story Truth - this gets moved to a lorebook layer, or, if the user does not wish to create a lorebook, can be added as optional author notes.
+- Write observable patterns from inner rules: trait -> internal logic -> outward behaviour. Avoid adjective piles.
+- Preserve ambiguity where it supports play. Provide motivations and pressures, not predetermined outcomes.
+- Use third-person past narrative and present-tense dialogue only when the user asks for roleplay operating instructions.
+- Include consent, player agency, and no-forcing-user rules where relevant to the target platform.
+- Treat a runtime update as a patch to the runtime layer, not a reason to rewrite character, world, or story truth.
+
+## Common Deliverables
+
+- **Portable user persona / character kernel:** character truth only, usually Modules 1-7.
+- **Campaign pack:** character kernel + world truth + story binding + current runtime.
+- **Card-lite version:** compressed character kernel within the stated token ceiling; put optional depth into lorebook-ready material.
+- **Platform card:** reorganise the same truths to fit the platform without changing their ownership.
+- **Runtime update:** replace only current location, situation, objectives, mindset, current knowledge, and open threads.
+
+## Reference
+
+Read `references/humanos-layer-rules.md` before drafting or auditing a layered build. Use it as the decision standard whenever a fact could belong to more than one layer.

--- a/.agents/skills/build-humanos-personas/agents/openai.yaml
+++ b/.agents/skills/build-humanos-personas/agents/openai.yaml
@@ -1,0 +1,12 @@
+interface:
+  display_name: Build HumanOS Personas
+  short_description: Create portable, layered AI roleplay personas
+  default_prompt: Use $build-humanos-personas to build a portable HumanOS persona
+    for my new roleplay character.
+policy:
+  products:
+    - chatgpt
+    - codex
+    - api
+    - atlas
+  allow_implicit_invocation: true

--- a/.agents/skills/build-humanos-personas/references/humanos-layer-rules.md
+++ b/.agents/skills/build-humanos-personas/references/humanos-layer-rules.md
@@ -1,0 +1,65 @@
+# HumanOS Layer Rules
+
+## Ownership Test
+
+Ask: **Would this remain true if the character were moved into another story, setting, or scene?**
+
+| If the answer is... | Put it in... | Examples |
+|---|---|---|
+| Yes, it is true of the person | Character truth | attachment pattern, family history, values, appearance, fears, speech habits |
+| Yes, it is true of the setting | World truth | university culture, corporate rules, social norms, established NPC roles, city geography |
+| Only true of this campaign or pairing | Story binding | arranged marriage premise, shared secret, inciting betrayal, fixed relationship history |
+| Only true now | Runtime truth | current room, latest argument, immediate objectives, current suspicion, unresolved scene beat |
+
+## Character Truth: Portable Kernel
+
+Keep the kernel story-free. A compact seven-module structure is:
+
+1. Identity and presentation
+2. Personality and values
+3. Internal model and decision rules
+4. Psychology: wounds, fears, defences, contradictions
+5. Relationships and attachment behaviour
+6. Intimacy, boundaries, and vulnerability (only when relevant)
+7. Speech and interaction style
+
+State causal rules rather than plot facts. For example, write "withdraws when care feels like obligation" rather than "withdrew after the lake-house argument."
+
+## World Truth: Durable External Logic
+
+Include only stable external facts: era, place, culture, power structures, institutions, recurring locations, and supporting-cast routines. Define NPCs by role, personality snapshot, relationship/knowledge gap, and activation trigger. Do not put the protagonist's current emotional reading of an NPC here.
+
+## Story Binding: This Campaign's Fixed Premise
+
+Capture the premise and pressures that make this pairing or arc distinct: relationship status, known history, inciting event, agreements, secrets, public stakes, and current narrative direction. It may bind otherwise-portable characters to a specific story, but it does not describe the live scene.
+
+## Runtime Truth: Current And Replaceable State
+
+Use this structure:
+
+- Current situation
+- Current objectives
+- Current mindset
+- Known facts
+- Immediate constraints
+- Open threads / next pressure
+
+Write it from the active character's perspective when that helps the model drive the scene, while preserving `{{user}}`'s freedom to respond, decide, and change direction.
+
+## Audit Checklist
+
+- Does the persona card work in a new setting without contradicting itself?
+- Does the world section avoid personal plot history?
+- Does the story section avoid minute-by-minute scene status?
+- Can the runtime section be replaced without altering the other sections?
+- Do roleplay instructions prohibit speaking, choosing, feeling, or acting for `{{user}}`?
+- Does each recurring NPC have a reason to appear beyond filler?
+- Does the build offer pressure and choice rather than a fixed ending?
+
+## Compression Order
+
+1. Remove repeated traits and duplicate facts.
+2. Replace long descriptions with behavioural rules.
+3. Retain conflicts, boundaries, attachment logic, and speech anchors.
+4. Move optional history, setting detail, and side-character depth into lorebook-ready entries.
+5. Verify the token cap after each major cut; never cut the layer labels that prevent contamination.


### PR DESCRIPTION
## Linked issue

Closes #4015

## Why this change

HumanOS persona-building work needs a reusable path that preserves layer boundaries. Without a dedicated workflow, durable character/persona material can get blended with world truth, campaign-specific story binding, or current runtime state.

This skill gives users and agents a focused way to build, compress, adapt, and audit HumanOS persona cards while preserving `{{user}}` agency.

## What changed

- Added `.agents/skills/build-humanos-personas/SKILL.md` with the persona-building workflow, output rules, common deliverables, and consistency checks.
- Added OpenAI app metadata for the new skill.
- Added a compact HumanOS layer-rules reference covering character truth, world truth, story binding, runtime truth, audit checks, and compression order.
- Rebuilt the branch on current `staging` so it does not inherit the older `pr-3536` stack or merge commit.

## Validation

- [x] Agent-run automated validation completed: `pnpm check` passes locally under Node `v25.9.0` / pnpm `10.33.2`.
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [x] Read and followed `CONTRIBUTING.md` for branch target and PR structure

Additional checks:

- `git fetch --all --prune`
- `rg -n "^(<{7}|={7}|>{7})( |$)" .`
- `git log --merges --oneline upstream/staging..HEAD`
- `git merge-tree upstream/staging HEAD`
- Ruby YAML parse for `.agents/skills/build-humanos-personas/agents/openai.yaml`
- `git diff --cached --check`

### Manual verification notes

- No runtime UI or server behavior changed; this PR adds a skill/documentation bundle only.
- Manual app click-through remains unchecked because there is no app surface changed by this PR.
- `pnpm check` passed with one existing lint warning in `HomeProfessorMariChat.tsx`.

## Docs and release impact

- [ ] No docs changes needed
- [x] Updated docs/skill guidance as needed
- [ ] Version/release files updated (only if this PR includes a version bump)

## UI evidence (if applicable)

No UI changes.
