### PR TITLE
fix: issue sweep — Push Story mode selector, Gemini model fetch, Termux channel-switch updates (#4020, #4021, #4022)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,9 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 
 ### Fixed
 
+- Moved the Natural/Random progression choice onto the **Push Story** button: clicking it now opens a Naturally/Randomly selector that arms the chosen mode for the next response, replacing the mode control previously buried in **Chat Settings → Agents → Narrative Director** (#4022).
+- Fetched the full Google Gemini model catalog in the connection editor by following the ListModels pagination, and refreshed the built-in Gemini/Gemma fallback list with the latest entries (#4021).
+- Gave in-app updates realistic install budgets on slow devices — update steps get four times as long on Android/Termux, where switching between stable and staging forces a near-full dependency reinstall — and update failures now report the failing pnpm step, timeouts, and the tail of the process output instead of an opaque `Command failed` (#4020).
 - Refreshed single- and multi-message deletion with the shared modal and control styling, including chroma-driven buttons, selection bars, checkboxes, and selected-message highlights instead of fixed destructive pink or red treatments.
 - Restored the immediate **Thinking…** placeholder in Roleplay and made Conversation and Roleplay expose one reasoning control as soon as the first reasoning chunk arrives. The existing Model Thoughts viewer now stays open and updates with the live reasoning stream, while completed messages retain their saved reasoning control (#3963).
 - Fixed Web Search (and other tools) returning empty or malformed parameters with GPT-5.6/5.5/5.4 and Codex models on the OpenAI Responses API. Streamed function-call arguments are keyed by the response item id rather than the call id, so the tool query is no longer dropped mid-stream (#4010).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,7 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 
 ### Fixed
 
-- Moved the Natural/Random progression choice onto the **Push Story** button: clicking it now opens a Naturally/Randomly selector that arms the chosen mode for the next response, replacing the mode control previously buried in **Chat Settings → Agents → Narrative Director** (#4022).
+- Moved the Natural/Random progression choice onto the **Push Story** button: clicking it now opens a Naturally/Randomly selector that arms the chosen mode for the next response, replacing the mode controls previously buried in **Chat Settings → Agents → Narrative Director**, the add-agent setup, and the Narrative Director editor's Story Push Mode default (#4022).
 - Fetched the full Google Gemini model catalog in the connection editor by following the ListModels pagination, and refreshed the built-in Gemini/Gemma fallback list with the latest entries (#4021).
 - Gave in-app updates realistic install budgets on slow devices — update steps get four times as long on Android/Termux, where switching between stable and staging forces a near-full dependency reinstall — and update failures now report the failing pnpm step, timeouts, and the tail of the process output instead of an opaque `Command failed` (#4020).
 - Refreshed single- and multi-message deletion with the shared modal and control styling, including chroma-driven buttons, selection bars, checkboxes, and selected-message highlights instead of fixed destructive pink or red treatments.

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -268,6 +268,18 @@ pnpm store prune
 
 Do not delete `data`, `storage`, or `marinara-engine.db`; those locations may contain your chats and settings. If the command still stops, capture the lines beginning at `Installing dependencies` and include the phone's free-space and memory figures in the report.
 
+### In-app update fails when switching between Stable and Staging on Android
+
+Switching channels (Stable ↔ Staging) forces a near-full dependency reinstall, which on Termux's slower storage can take much longer than an ordinary update. The in-app updater now allows extra time for each step on Android, so a channel switch that used to stop with a bare `Update failed: Command failed: corepack pnpm ... install` should complete.
+
+If an update still fails, the error now names the step that failed and includes the tail of its output. Read that message: a genuine dependency or lockfile error is reported there. You can also run the update by hand from Termux with the manual command shown in the error's hint, or reclaim space first:
+
+```bash
+cd Marinara-Engine
+pnpm store prune
+./start-termux.sh
+```
+
 ### Noodle shows `Etc/Unknown` or schedules use the wrong timezone
 
 For Conversation schedules, open Conversation Chat Settings or a character schedule editor and choose **Schedule timezone**. This global selection applies to every Conversation chat, including background autonomous messages, and can be reset with **Use device**.

--- a/packages/client/src/components/agents/AgentEditor.tsx
+++ b/packages/client/src/components/agents/AgentEditor.tsx
@@ -53,7 +53,6 @@ import {
   ImageIcon,
   Shield,
   ShieldCheck,
-  Shuffle,
 } from "lucide-react";
 import { useDeleteAgent } from "../../hooks/use-agents";
 import { useLorebooks, useEntriesAcrossLorebooks } from "../../hooks/use-lorebooks";
@@ -196,12 +195,6 @@ const PHASE_META: Record<AgentPhase, { label: string; color: string; icon: typeo
     description: "Runs after the main AI response. Can analyze and extract data from it.",
   },
 };
-
-type NarrativeDirectorMode = "natural" | "random";
-
-function normalizeNarrativeDirectorMode(value: unknown): NarrativeDirectorMode {
-  return value === "random" ? "random" : "natural";
-}
 
 function normalizeAgentMaxTokensInput(value: string): number | "" {
   if (value === "") return "";
@@ -532,7 +525,6 @@ export function AgentEditor() {
   const [localProseGuardianAvoid, setLocalProseGuardianAvoid] = useState(DEFAULT_PROSE_GUARDIAN_AVOID);
   const [localProseGuardianPrefer, setLocalProseGuardianPrefer] = useState("");
   const [localProseGuardianHoldForRewrite, setLocalProseGuardianHoldForRewrite] = useState(true);
-  const [localDirectorMode, setLocalDirectorMode] = useState<NarrativeDirectorMode>("natural");
   const [localSecretPlotEnabled, setLocalSecretPlotEnabled] = useState(false);
   const [localSecretPlotRunInterval, setLocalSecretPlotRunInterval] = useState(8);
   const [spotifyStatus, setSpotifyStatus] = useState<{
@@ -668,7 +660,6 @@ export function AgentEditor() {
       setLocalProseGuardianHoldForRewrite(
         (settings.holdForRewrite as boolean | undefined) ?? defaultSettings.holdForRewrite !== false,
       );
-      setLocalDirectorMode(normalizeNarrativeDirectorMode(settings.directorMode ?? defaultSettings.directorMode));
       setLocalSecretPlotEnabled(
         (settings.secretPlotEnabled as boolean | undefined) ?? defaultSettings.secretPlotEnabled === true,
       );
@@ -712,7 +703,6 @@ export function AgentEditor() {
       );
       setLocalProseGuardianPrefer(typeof defaultSettings.prefer === "string" ? defaultSettings.prefer : "");
       setLocalProseGuardianHoldForRewrite(defaultSettings.holdForRewrite !== false);
-      setLocalDirectorMode(normalizeNarrativeDirectorMode(defaultSettings.directorMode));
       setLocalSecretPlotEnabled(defaultSettings.secretPlotEnabled === true);
       setLocalSecretPlotRunInterval(normalizePositiveInteger(defaultSettings.secretPlotRunInterval, 8, 100));
       setLocalCustomCapabilities({});
@@ -763,7 +753,6 @@ export function AgentEditor() {
       setLocalProseGuardianAvoid(DEFAULT_PROSE_GUARDIAN_AVOID);
       setLocalProseGuardianPrefer("");
       setLocalProseGuardianHoldForRewrite(true);
-      setLocalDirectorMode("natural");
       setLocalSecretPlotEnabled(false);
       setLocalSecretPlotRunInterval(8);
       setLocalCustomCapabilities({});
@@ -1080,7 +1069,6 @@ export function AgentEditor() {
         ...(isContinuityAgent || isHtmlAgent ? { holdForRewrite: localProseGuardianHoldForRewrite } : {}),
         ...(isDirectorAgent
           ? {
-              directorMode: localDirectorMode,
               secretPlotEnabled: localSecretPlotEnabled,
               secretPlotRunInterval: localSecretPlotRunInterval,
             }
@@ -1150,7 +1138,6 @@ export function AgentEditor() {
     localProseGuardianAvoid,
     localProseGuardianPrefer,
     localProseGuardianHoldForRewrite,
-    localDirectorMode,
     localSecretPlotEnabled,
     localSecretPlotRunInterval,
     localImagePositivePrompt,
@@ -1258,7 +1245,6 @@ export function AgentEditor() {
       ...(isContinuityAgent || isHtmlAgent ? { holdForRewrite: localProseGuardianHoldForRewrite } : {}),
       ...(isDirectorAgent
         ? {
-            directorMode: localDirectorMode,
             secretPlotEnabled: localSecretPlotEnabled,
             secretPlotRunInterval: localSecretPlotRunInterval,
           }
@@ -2314,47 +2300,6 @@ export function AgentEditor() {
               <p className="mt-1 text-[0.625rem] text-[var(--muted-foreground)]">
                 The auditor proposes character card changes for manual approval only. It never applies edits by itself.
               </p>
-            </FieldGroup>
-          )}
-
-          {isDirectorAgent && (
-            <FieldGroup
-              label="Story Push Mode"
-              icon={<Shuffle size="0.875rem" className="text-[var(--primary)]" />}
-              help="Choose what Push Story should ask the Narrative Director to create when you arm it in chat."
-            >
-              <div className="grid grid-cols-2 gap-2 rounded-xl border border-[var(--border)] bg-[var(--secondary)]/60 p-1">
-                {[
-                  {
-                    id: "natural" as const,
-                    label: "Natural",
-                    description: "Advance existing tension, goals, or scenario threads.",
-                  },
-                  {
-                    id: "random" as const,
-                    label: "Random Event",
-                    description: "Introduce a plausible surprise, complication, or opportunity.",
-                  },
-                ].map((option) => (
-                  <button
-                    key={option.id}
-                    type="button"
-                    onClick={() => {
-                      setLocalDirectorMode(option.id);
-                      markDirty();
-                    }}
-                    className={cn(
-                      "rounded-lg px-3 py-2 text-left transition-all",
-                      localDirectorMode === option.id
-                        ? "bg-[var(--primary)]/15 text-[var(--foreground)] ring-1 ring-[var(--primary)]/40"
-                        : "text-[var(--muted-foreground)] hover:bg-[var(--accent)] hover:text-[var(--foreground)]",
-                    )}
-                  >
-                    <span className="block text-xs font-semibold">{option.label}</span>
-                    <span className="mt-0.5 block text-[0.625rem] leading-snug">{option.description}</span>
-                  </button>
-                ))}
-              </div>
             </FieldGroup>
           )}
 

--- a/packages/client/src/components/chat/AgentAddSetupFields.tsx
+++ b/packages/client/src/components/chat/AgentAddSetupFields.tsx
@@ -37,7 +37,6 @@ export type MusicProvider = "spotify" | "youtube" | "custom";
 export type CustomMusicSource = "game-assets" | "folder";
 
 export type AgentAddSetupState = {
-  directorMode: "natural" | "random";
   secretPlotEnabled: boolean;
   secretPlotRunInterval: number;
   proseGuardianBanned: string;
@@ -257,7 +256,6 @@ export function buildInitialAgentAddSetupState({
   );
 
   return {
-    directorMode: settings.directorMode === "random" ? "random" : "natural",
     secretPlotEnabled:
       allowSecretPlot &&
       (typeof metadata.narrativeDirectorSecretPlotEnabled === "boolean"
@@ -350,7 +348,6 @@ export function applyAgentAddSetupToAgentSettings(
 ): Record<string, unknown> {
   const next = { ...settings };
   if (agentId === "director") {
-    next.directorMode = setup.directorMode;
     next.secretPlotEnabled = options?.allowSecretPlot === false ? false : setup.secretPlotEnabled;
     next.secretPlotRunInterval = setup.secretPlotRunInterval;
     delete next.runInterval;
@@ -416,7 +413,6 @@ export function buildAgentAddMetadataPatch(
   }
 
   if (agentId === "director") {
-    patch.narrativeDirectorMode = setup.directorMode;
     patch.narrativeDirectorSecretPlotEnabled = options?.allowSecretPlot === false ? false : setup.secretPlotEnabled;
     patch.narrativeDirectorSecretPlotRunInterval = setup.secretPlotRunInterval;
   }

--- a/packages/client/src/components/chat/AgentAddSetupFields.tsx
+++ b/packages/client/src/components/chat/AgentAddSetupFields.tsx
@@ -571,41 +571,6 @@ function SetupToggle({
   );
 }
 
-function SetupSegmentedControl<T extends string>({
-  value,
-  options,
-  disabled,
-  onChange,
-}: {
-  value: T;
-  options: Array<{ id: T; label: string; description?: string }>;
-  disabled?: boolean;
-  onChange: (value: T) => void;
-}) {
-  return (
-    <div className="grid grid-cols-2 gap-1 rounded-lg border border-[var(--border)] bg-[var(--background)]/75 p-1">
-      {options.map((option) => (
-        <button
-          key={option.id}
-          type="button"
-          disabled={disabled}
-          onClick={() => onChange(option.id)}
-          aria-pressed={value === option.id}
-          className={cn(
-            "rounded-md px-2.5 py-2 text-left transition-all disabled:cursor-not-allowed disabled:opacity-60",
-            value === option.id
-              ? "bg-[var(--primary)]/12 text-[var(--foreground)] ring-1 ring-[var(--primary)]/35"
-              : "text-[var(--muted-foreground)] hover:bg-[var(--accent)] hover:text-[var(--foreground)]",
-          )}
-        >
-          <span className="block text-[0.6875rem] font-semibold">{option.label}</span>
-          {option.description ? <span className="mt-0.5 block text-[0.625rem]">{option.description}</span> : null}
-        </button>
-      ))}
-    </div>
-  );
-}
-
 function PromptTemplateSelect({
   options,
   value,
@@ -1459,15 +1424,9 @@ export function AgentAddSetupFields({
 
       {agentId === "director" && (
         <div className="space-y-2">
-          <SetupSegmentedControl
-            value={value.directorMode}
-            disabled={disabled}
-            options={[
-              { id: "natural", label: "Natural", description: "Advance existing story threads." },
-              { id: "random", label: "Random Event", description: "Introduce a plausible surprise." },
-            ]}
-            onChange={(directorMode) => onChange({ directorMode })}
-          />
+          <p className="rounded-lg bg-[var(--background)]/65 px-3 py-2 text-[0.625rem] text-[var(--muted-foreground)] ring-1 ring-[var(--border)]">
+            Choose between a natural or random push each time from the Push Story button above the chat input.
+          </p>
           {allowSecretPlotControls && (
             <SetupToggle
               label="Secret Plot"

--- a/packages/client/src/components/chat/ChatInput.tsx
+++ b/packages/client/src/components/chat/ChatInput.tsx
@@ -222,7 +222,11 @@ export const ChatInput = memo(function ChatInput({
   const [isTranslatingDraft, setIsTranslatingDraft] = useState(false);
   const [emojiOpen, setEmojiOpen] = useState(false);
   const isMobileComposerViewport = useIsMobileComposerViewport();
-  const [pushStoryArmed, setPushStoryArmed] = useState(false);
+  // Push Story arms for the next response with an explicit mode picked from
+  // the selector that opens on click; null means disarmed.
+  const [pushStoryMode, setPushStoryMode] = useState<NarrativeDirectorMode | null>(null);
+  const [pushStoryMenuOpen, setPushStoryMenuOpen] = useState(false);
+  const pushStoryMenuRef = useRef<HTMLDivElement>(null);
   const [isDragging, setIsDragging] = useState(false);
   const [charPickerOpen, setCharPickerOpen] = useState(false);
   const charPickerBtnRef = useRef<HTMLButtonElement>(null);
@@ -347,13 +351,11 @@ export const ChatInput = memo(function ChatInput({
   const combatActionActive =
     mode === "roleplay" && combatAgentEnabled === true && typeof onStartEncounter === "function";
   const showRoleplayAgentActions = narrativeDirectorActive || combatActionActive;
-  const narrativeDirectorMode: NarrativeDirectorMode =
-    chatMetadata.narrativeDirectorMode === "random" ? "random" : "natural";
   const consumeNarrativeDirectorMode = useCallback((): NarrativeDirectorMode | undefined => {
-    if (!pushStoryArmed || !narrativeDirectorActive) return undefined;
-    setPushStoryArmed(false);
-    return narrativeDirectorMode;
-  }, [narrativeDirectorActive, narrativeDirectorMode, pushStoryArmed]);
+    if (!pushStoryMode || !narrativeDirectorActive) return undefined;
+    setPushStoryMode(null);
+    return pushStoryMode;
+  }, [narrativeDirectorActive, pushStoryMode]);
   const generateWithNarrativeDirector = useCallback(
     (params: Parameters<typeof generate>[0]) => {
       const directorMode = consumeNarrativeDirectorMode();
@@ -785,22 +787,45 @@ export const ChatInput = memo(function ChatInput({
     qc,
   ]);
 
-  const handleTogglePushStory = useCallback(() => {
+  const handlePushStoryClick = useCallback(() => {
     if (!narrativeDirectorActive || isInputBusy) return;
-    setPushStoryArmed((current) => {
-      const next = !current;
-      if (next) {
-        toast.success(
-          `The next time a character responds, they will push the story forward ${
-            narrativeDirectorMode === "random" ? "randomly" : "naturally"
-          }!`,
-        );
-      } else {
-        toast.info("Push Story disarmed.");
-      }
-      return next;
-    });
-  }, [isInputBusy, narrativeDirectorActive, narrativeDirectorMode]);
+    if (pushStoryMode) {
+      setPushStoryMode(null);
+      setPushStoryMenuOpen(false);
+      toast.info("Push Story disarmed.");
+      return;
+    }
+    setPushStoryMenuOpen((open) => !open);
+  }, [isInputBusy, narrativeDirectorActive, pushStoryMode]);
+
+  const handleArmPushStory = useCallback((mode: NarrativeDirectorMode) => {
+    setPushStoryMode(mode);
+    setPushStoryMenuOpen(false);
+    toast.success(
+      `The next time a character responds, they will push the story forward ${
+        mode === "random" ? "randomly" : "naturally"
+      }!`,
+    );
+  }, []);
+
+  // Dismiss the Push Story mode selector on outside click or Escape.
+  useEffect(() => {
+    if (!pushStoryMenuOpen) return;
+    const handlePointerDown = (event: PointerEvent) => {
+      const target = event.target as Node | null;
+      if (target && pushStoryMenuRef.current?.contains(target)) return;
+      setPushStoryMenuOpen(false);
+    };
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") setPushStoryMenuOpen(false);
+    };
+    window.addEventListener("pointerdown", handlePointerDown, true);
+    window.addEventListener("keydown", handleKeyDown);
+    return () => {
+      window.removeEventListener("pointerdown", handlePointerDown, true);
+      window.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [pushStoryMenuOpen]);
 
   const handleSend = useCallback(async () => {
     const raw = getValue();
@@ -1696,26 +1721,57 @@ export const ChatInput = memo(function ChatInput({
       {showRoleplayAgentActions && (
         <div className="flex flex-wrap justify-center gap-2 py-1">
           {narrativeDirectorActive && (
-            <button
-              type="button"
-              onClick={handleTogglePushStory}
-              disabled={isInputBusy}
-              aria-pressed={pushStoryArmed}
-              className={cn(
-                ROLEPLAY_AGENT_ACTION_BUTTON_CLASS,
-                pushStoryArmed
-                  ? "bg-foreground/10 text-foreground ring-1 ring-foreground/25"
-                  : "text-foreground/50 hover:bg-foreground/10 hover:text-foreground/80",
+            <div ref={pushStoryMenuRef} className="relative">
+              <button
+                type="button"
+                onClick={handlePushStoryClick}
+                disabled={isInputBusy}
+                aria-pressed={pushStoryMode !== null}
+                aria-expanded={pushStoryMenuOpen}
+                aria-haspopup="menu"
+                className={cn(
+                  ROLEPLAY_AGENT_ACTION_BUTTON_CLASS,
+                  pushStoryMode
+                    ? "bg-foreground/10 text-foreground ring-1 ring-foreground/25"
+                    : "text-foreground/50 hover:bg-foreground/10 hover:text-foreground/80",
+                )}
+                title={
+                  pushStoryMode
+                    ? "Disarm the Narrative Director push"
+                    : "Choose how the Narrative Director pushes the story in the next response"
+                }
+              >
+                <WandSparkles size="0.875rem" />
+                <span>
+                  {pushStoryMode ? `Push Story: ${pushStoryMode === "random" ? "Randomly" : "Naturally"}` : "Push Story"}
+                </span>
+              </button>
+              {pushStoryMenuOpen && (
+                <div
+                  role="menu"
+                  className="absolute bottom-full left-1/2 z-50 mb-2 w-64 -translate-x-1/2 rounded-xl border border-[var(--border)] bg-[var(--card)] p-1 shadow-2xl"
+                >
+                  <button
+                    type="button"
+                    role="menuitem"
+                    onClick={() => handleArmPushStory("natural")}
+                    className="flex w-full flex-col items-start gap-0.5 rounded-lg px-3 py-2 text-left transition-colors hover:bg-foreground/10"
+                  >
+                    <span className="text-sm font-medium text-foreground">Naturally</span>
+                    <span className="text-xs text-foreground/60">Push the existing plot forward.</span>
+                  </button>
+                  <button
+                    type="button"
+                    role="menuitem"
+                    onClick={() => handleArmPushStory("random")}
+                    className="flex w-full flex-col items-start gap-0.5 rounded-lg px-3 py-2 text-left transition-colors hover:bg-foreground/10"
+                  >
+                    <span className="text-sm font-medium text-foreground">Randomly</span>
+                    <span className="text-xs text-foreground/60">Add a plausible surprise to the scene.</span>
+                  </button>
+                </div>
               )}
-              title={
-                narrativeDirectorMode === "random"
-                  ? "Arm a random Narrative Director event for the next response"
-                  : "Arm a natural Narrative Director push for the next response"
-              }
-            >
-              <WandSparkles size="0.875rem" />
-              <span>Push Story</span>
-            </button>
+            </div>
           )}
           {combatActionActive && (
             <button

--- a/packages/client/src/components/chat/ChatInput.tsx
+++ b/packages/client/src/components/chat/ChatInput.tsx
@@ -359,7 +359,13 @@ export const ChatInput = memo(function ChatInput({
   const generateWithNarrativeDirector = useCallback(
     (params: Parameters<typeof generate>[0]) => {
       const directorMode = consumeNarrativeDirectorMode();
-      return generate(directorMode ? { ...params, narrativeDirectorMode: directorMode } : params);
+      if (!directorMode) return generate(params);
+      // Re-arm the chosen mode if the push never reaches a response, so a
+      // failed generation does not silently swallow the user's selection.
+      return generate({ ...params, narrativeDirectorMode: directorMode }).catch((error) => {
+        setPushStoryMode((current) => current ?? directorMode);
+        throw error;
+      });
     },
     [consumeNarrativeDirectorMode, generate],
   );

--- a/packages/client/src/components/chat/ChatSettingsDrawer.tsx
+++ b/packages/client/src/components/chat/ChatSettingsDrawer.tsx
@@ -789,10 +789,6 @@ type AgentAddPreview = {
 
 type KnowledgeAgentType = "knowledge-retrieval" | "knowledge-router";
 
-function normalizeNarrativeDirectorMode(value: unknown): "natural" | "random" {
-  return value === "random" ? "random" : "natural";
-}
-
 function isRecord(value: unknown): value is Record<string, unknown> {
   return !!value && typeof value === "object" && !Array.isArray(value);
 }
@@ -1698,9 +1694,6 @@ export function ChatSettingsDrawer({
   const directorDefaults = useMemo(
     () => mergeBuiltInAgentSettings("director", directorConfig?.settings),
     [directorConfig?.settings],
-  );
-  const narrativeDirectorMode = normalizeNarrativeDirectorMode(
-    metadata.narrativeDirectorMode ?? directorDefaults.directorMode,
   );
   const narrativeDirectorSecretPlotEnabled =
     typeof metadata.narrativeDirectorSecretPlotEnabled === "boolean"
@@ -6963,22 +6956,10 @@ export function ChatSettingsDrawer({
                           order={getRoleplayAgentSettingsOrder("director")}
                           onRemove={getRoleplayAgentMenuRemoveHandler("director", directorAgentMeta.name)}
                         >
-                          <AgentSettingsSegmentedControl
-                            value={narrativeDirectorMode}
-                            options={[
-                              {
-                                id: "natural",
-                                label: "Natural",
-                                description: "Push the existing plot forward.",
-                              },
-                              {
-                                id: "random",
-                                label: "Random Event",
-                                description: "Add a plausible surprise.",
-                              },
-                            ]}
-                            onChange={(mode) => updateMeta.mutate({ id: chat.id, narrativeDirectorMode: mode })}
-                          />
+                          <p className="rounded-lg bg-[var(--background)]/45 px-2.5 py-2 text-[0.625rem] text-[var(--muted-foreground)] ring-1 ring-[var(--border)]">
+                            Choose between a natural or random push each time from the Push Story button above the chat
+                            input.
+                          </p>
                           {supportsNarrativeDirectorSecretPlot && (
                             <div className="mt-2 space-y-2">
                               <AgentSettingsToggle

--- a/packages/server/src/routes/connections.routes.ts
+++ b/packages/server/src/routes/connections.routes.ts
@@ -927,13 +927,54 @@ export async function connectionsRoutes(app: FastifyInstance) {
         return { models };
       }
 
-      let modelsUrl =
+      // Google's ListModels endpoint is paginated (small default page size),
+      // so a single request silently drops most of the catalog. Follow
+      // nextPageToken until the list is complete.
+      if (conn.provider === "google") {
+        const collected: unknown[] = [];
+        let pageToken = "";
+        for (let page = 0; page < 20; page++) {
+          const pageUrl =
+            `${baseUrl}${provider?.modelsEndpoint ?? "/models"}?key=${encodeURIComponent(conn.apiKey)}&pageSize=1000` +
+            (pageToken ? `&pageToken=${encodeURIComponent(pageToken)}` : "");
+          const pageRes = await safeFetch(pageUrl, {
+            headers,
+            policy: {
+              allowLocal: isProviderLocalUrlsEnabled(),
+              allowLoopback: true,
+              allowMdns: true,
+              allowedProtocols: ["https:", "http:"],
+              flagName: "PROVIDER_LOCAL_URLS_ENABLED",
+            },
+            maxResponseBytes: 5 * 1024 * 1024,
+            decodeCompressedResponse: true,
+          });
+          if (!pageRes.ok) {
+            const body = await pageRes.text();
+            return reply.status(502).send({
+              error: `Provider returned ${pageRes.status}: ${sanitizeProviderBody(body)}`,
+            });
+          }
+          const pageText = await pageRes.text();
+          let pageJson: { models?: unknown[]; nextPageToken?: string };
+          try {
+            pageJson = JSON.parse(pageText) as { models?: unknown[]; nextPageToken?: string };
+          } catch {
+            return reply.status(502).send({
+              error: `Failed to fetch models: ${sanitizeProviderBody(pageText)}`,
+            });
+          }
+          if (Array.isArray(pageJson.models)) collected.push(...pageJson.models);
+          pageToken = typeof pageJson.nextPageToken === "string" ? pageJson.nextPageToken : "";
+          if (!pageToken) break;
+        }
+        return { models: normalizeModelsResponse("google", { models: collected }) };
+      }
+
+      const modelsUrl =
         conn.provider === "google_vertex"
           ? buildGoogleVertexModelUrl(baseUrl, conn.model, "models")
           : `${baseUrl}${provider?.modelsEndpoint ?? "/models"}`;
-      if (conn.provider === "google") {
-        modelsUrl += `?key=${conn.apiKey}`;
-      }
 
       const res = await safeFetch(modelsUrl, {
         headers,
@@ -1377,7 +1418,14 @@ function normalizeModelsResponse(provider: string, json: Record<string, unknown>
         outputTokenLimit?: number;
       }>;
       return models
-        .filter((m) => m.supportedGenerationMethods?.includes("generateContent"))
+        .filter(
+          // Keep chat-capable models. Some catalog entries only advertise the
+          // streaming method, and a missing field should not hide a model.
+          (m) =>
+            !m.supportedGenerationMethods ||
+            m.supportedGenerationMethods.includes("generateContent") ||
+            m.supportedGenerationMethods.includes("streamGenerateContent"),
+        )
         .map((m) => ({
           id: (m.name ?? "").replace(/^models\//, ""),
           name: m.displayName ?? (m.name ?? "").replace(/^models\//, ""),

--- a/packages/server/src/routes/connections.routes.ts
+++ b/packages/server/src/routes/connections.routes.ts
@@ -968,6 +968,12 @@ export async function connectionsRoutes(app: FastifyInstance) {
           pageToken = typeof pageJson.nextPageToken === "string" ? pageJson.nextPageToken : "";
           if (!pageToken) break;
         }
+        if (pageToken) {
+          // Never report a silently truncated catalog as success.
+          return reply.status(502).send({
+            error: "Google returned more model pages than expected; refusing to show a truncated list.",
+          });
+        }
         return { models: normalizeModelsResponse("google", { models: collected }) };
       }
 

--- a/packages/server/src/routes/updates.routes.ts
+++ b/packages/server/src/routes/updates.routes.ts
@@ -470,7 +470,7 @@ async function resolvePinnedPnpmRunner(root: string): Promise<PnpmRunner> {
   try {
     const { stdout } = await execFileAsync("pnpm", ["--version"], {
       cwd: root,
-      timeout: 10_000,
+      timeout: updateStepTimeout(10_000),
       shell,
     });
     if (stdout.trim() === pnpmVersion) {
@@ -513,11 +513,16 @@ function describePnpmFailure(err: unknown, args: string[], timeout: number): Err
       `"${step}" was stopped after ${Math.round(timeout / 1000)}s (signal ${execError.signal ?? "unknown"}). Slow devices can need this long for a full reinstall; try again or run the update manually.`,
     );
   } else {
-    parts.push(`"${step}" failed${typeof execError?.code === "number" ? ` with exit code ${execError.code}` : ""}.`);
+    parts.push(`"${step}" failed${execError?.code != null ? ` with code ${String(execError.code)}` : ""}.`);
   }
-  const outputTail = (execError?.stderr || execError?.stdout || "").trim().split("\n").slice(-8).join("\n").trim();
+  const outputTail = [execError?.stderr, execError?.stdout]
+    .filter((value): value is string => Boolean(value))
+    .flatMap((value) => value.trim().split(/\r?\n/).slice(-8))
+    .join("\n")
+    .slice(-600)
+    .trim();
   if (outputTail) {
-    parts.push(`Output: ${outputTail.slice(-600)}`);
+    parts.push(`Output: ${outputTail}`);
   }
   return new Error(parts.join(" "));
 }

--- a/packages/server/src/routes/updates.routes.ts
+++ b/packages/server/src/routes/updates.routes.ts
@@ -57,6 +57,16 @@ const UPDATE_CHANNELS: Record<UpdateChannel, UpdateChannelInfo> = {
 const DEFAULT_PNPM_VERSION = "10.33.2";
 const PNPM_NONINTERACTIVE_ARGS = ["--config.trustPolicy=off", "--config.confirmModulesPurge=false"];
 const PNPM_UPDATE_INSTALL_ARGS = ["install", "--force", "--frozen-lockfile"];
+// A forced reinstall is verbose; the execFile default (1 MiB) can abort an
+// otherwise healthy install with a maxBuffer error.
+const PNPM_OUTPUT_MAX_BUFFER = 32 * 1024 * 1024;
+// Termux on Android runs on slow flash storage without prebuilt-binary
+// caches, so channel switches (full dependency purge + reinstall) routinely
+// need far longer than desktop installs.
+const UPDATE_STEP_TIMEOUT_MULTIPLIER = process.platform === "android" ? 4 : 1;
+function updateStepTimeout(baseMs: number): number {
+  return baseMs * UPDATE_STEP_TIMEOUT_MULTIPLIER;
+}
 const MANUAL_PNPM_COMMAND = `corepack pnpm@${DEFAULT_PNPM_VERSION}`;
 const DOCKER_IMAGE = "ghcr.io/pasta-devs/marinara-engine";
 const MANUAL_GIT_UPDATE_COMMAND =
@@ -444,7 +454,8 @@ async function resolvePinnedPnpmRunner(root: string): Promise<PnpmRunner> {
   try {
     const { stdout } = await execFileAsync("corepack", [`pnpm@${pnpmVersion}`, "--version"], {
       cwd: root,
-      timeout: 20_000,
+      // First run downloads the pinned pnpm; slow devices need extra headroom.
+      timeout: updateStepTimeout(20_000),
       shell,
     });
     if (stdout.trim() === pnpmVersion) {
@@ -472,7 +483,7 @@ async function resolvePinnedPnpmRunner(root: string): Promise<PnpmRunner> {
   try {
     const { stdout } = await execFileAsync("npx", ["--yes", `pnpm@${pnpmVersion}`, "--version"], {
       cwd: root,
-      timeout: 60_000,
+      timeout: updateStepTimeout(60_000),
       shell,
     });
     if (stdout.trim() === pnpmVersion) {
@@ -487,13 +498,43 @@ async function resolvePinnedPnpmRunner(root: string): Promise<PnpmRunner> {
   );
 }
 
-async function runPinnedPnpm(root: string, args: string[], timeout: number) {
+function describePnpmFailure(err: unknown, args: string[], timeout: number): Error {
+  const execError = err as NodeJS.ErrnoException & {
+    killed?: boolean;
+    signal?: string | null;
+    code?: number | string | null;
+    stderr?: string;
+    stdout?: string;
+  };
+  const step = `pnpm ${args.join(" ")}`;
+  const parts: string[] = [];
+  if (execError?.killed || execError?.signal) {
+    parts.push(
+      `"${step}" was stopped after ${Math.round(timeout / 1000)}s (signal ${execError.signal ?? "unknown"}). Slow devices can need this long for a full reinstall; try again or run the update manually.`,
+    );
+  } else {
+    parts.push(`"${step}" failed${typeof execError?.code === "number" ? ` with exit code ${execError.code}` : ""}.`);
+  }
+  const outputTail = (execError?.stderr || execError?.stdout || "").trim().split("\n").slice(-8).join("\n").trim();
+  if (outputTail) {
+    parts.push(`Output: ${outputTail.slice(-600)}`);
+  }
+  return new Error(parts.join(" "));
+}
+
+async function runPinnedPnpm(root: string, args: string[], baseTimeout: number) {
   const runner = await resolvePinnedPnpmRunner(root);
-  await execFileAsync(runner.command, [...runner.prefixArgs, ...PNPM_NONINTERACTIVE_ARGS, ...args], {
-    cwd: root,
-    timeout,
-    shell: process.platform === "win32",
-  });
+  const timeout = updateStepTimeout(baseTimeout);
+  try {
+    await execFileAsync(runner.command, [...runner.prefixArgs, ...PNPM_NONINTERACTIVE_ARGS, ...args], {
+      cwd: root,
+      timeout,
+      maxBuffer: PNPM_OUTPUT_MAX_BUFFER,
+      shell: process.platform === "win32",
+    });
+  } catch (err) {
+    throw describePnpmFailure(err, args, timeout);
+  }
   return { runner, pnpmVersion: getPinnedPnpmVersion(root) };
 }
 
@@ -941,8 +982,9 @@ export async function updatesRoutes(app: FastifyInstance) {
         // Otherwise, source differs from running build — need to rebuild
       }
 
-      // Step 2: pnpm install
-      await runPinnedPnpm(root, PNPM_UPDATE_INSTALL_ARGS, 180_000);
+      // Step 2: pnpm install. Channel switches (stable <-> staging) force a
+      // near-full dependency reinstall, so this step gets a generous budget.
+      await runPinnedPnpm(root, PNPM_UPDATE_INSTALL_ARGS, 300_000);
 
       // Step 3: Rebuild all packages
       await runPinnedBuild(root);

--- a/packages/shared/src/constants/model-lists.ts
+++ b/packages/shared/src/constants/model-lists.ts
@@ -270,6 +270,8 @@ export const OPENAI_CHATGPT_MODELS: KnownModel[] = [
 // ── Google AI Studio (from #model_google_select) ──
 
 export const GOOGLE_MODELS: KnownModel[] = [
+  // Gemini 3.6
+  { id: "gemini-3.6-flash", name: "gemini-3.6-flash", context: 1000000, maxOutput: 65536 },
   // Gemini 3.5
   { id: "gemini-3.5-flash", name: "gemini-3.5-flash", context: 1000000, maxOutput: 65536 },
   // Gemini 3.1
@@ -377,6 +379,9 @@ export const GOOGLE_MODELS: KnownModel[] = [
   { id: "gemini-2.0-flash-lite-preview", name: "gemini-2.0-flash-lite-preview", context: 1000000, maxOutput: 8192 },
   { id: "gemini-2.0-flash-lite", name: "gemini-2.0-flash-lite", context: 1000000, maxOutput: 8192 },
   // Gemma
+  { id: "gemma-4-27b-it", name: "gemma-4-27b-it", context: 131072, maxOutput: 8192 },
+  { id: "gemma-4-12b-it", name: "gemma-4-12b-it", context: 131072, maxOutput: 8192 },
+  { id: "gemma-4-4b-it", name: "gemma-4-4b-it", context: 131072, maxOutput: 8192 },
   { id: "gemma-3n-e4b-it", name: "gemma-3n-e4b-it", context: 32768, maxOutput: 8192 },
   { id: "gemma-3n-e2b-it", name: "gemma-3n-e2b-it", context: 32768, maxOutput: 8192 },
   { id: "gemma-3-27b-it", name: "gemma-3-27b-it", context: 32768, maxOutput: 8192 },

--- a/packages/shared/src/constants/model-lists.ts
+++ b/packages/shared/src/constants/model-lists.ts
@@ -379,8 +379,9 @@ export const GOOGLE_MODELS: KnownModel[] = [
   { id: "gemini-2.0-flash-lite-preview", name: "gemini-2.0-flash-lite-preview", context: 1000000, maxOutput: 8192 },
   { id: "gemini-2.0-flash-lite", name: "gemini-2.0-flash-lite", context: 1000000, maxOutput: 8192 },
   // Gemma
-  { id: "gemma-4-27b-it", name: "gemma-4-27b-it", context: 131072, maxOutput: 8192 },
-  { id: "gemma-4-12b-it", name: "gemma-4-12b-it", context: 131072, maxOutput: 8192 },
+  { id: "gemma-4-31b-it", name: "gemma-4-31b-it", context: 256000, maxOutput: 8192 },
+  { id: "gemma-4-26b-a4b-it", name: "gemma-4-26b-a4b-it", context: 256000, maxOutput: 8192 },
+  { id: "gemma-4-12b-it", name: "gemma-4-12b-it", context: 256000, maxOutput: 8192 },
   { id: "gemma-4-4b-it", name: "gemma-4-4b-it", context: 131072, maxOutput: 8192 },
   { id: "gemma-3n-e4b-it", name: "gemma-3n-e4b-it", context: 32768, maxOutput: 8192 },
   { id: "gemma-3n-e2b-it", name: "gemma-3n-e2b-it", context: 32768, maxOutput: 8192 },


### PR DESCRIPTION
## Why

Sweep of the three unclaimed open issues, all reported by users on v2.3.4:

- **#4020** — Switching stable → staging on Termux dies with an opaque `Update failed: Command failed: corepack pnpm ... install --force --frozen-lockfile`. The install step had a fixed 180s timeout; a channel switch forces a near-full dependency reinstall, which a phone cannot finish in 3 minutes. The killed process surfaced no stderr, so users had nothing to act on.
- **#4021** — Google Gemini model fetching returns a truncated list: the ListModels endpoint is paginated (small default page size) and we issued a single request without following `nextPageToken`, so most of the catalog — including every newer model — was silently dropped. The static fallback dropdown was also missing the newest Gemini/Gemma entries.
- **#4022** — Push Story always used the mode buried in Chat Settings → Agents → Narrative Director, forcing a settings round-trip to switch between Natural and Random progression. Requested UX (from the Discord thread): choose Naturally/Randomly right on the Push Story control.

## What changed

- **#4020, `updates.routes.ts`**: update-step timeouts scale 4× on Android; install base raised 180s → 300s; exec `maxBuffer` raised to 32 MiB so verbose `--force` installs aren't aborted; pnpm failures now report the failing step, whether it hit the timeout, and the tail of the process output. Corepack/npx probe timeouts get the same Android scaling (first run downloads the pinned pnpm).
- **#4021, `connections.routes.ts`**: the Google branch of `/:id/models` now follows `nextPageToken` (`pageSize=1000`, capped at 20 pages) and no longer hides models that only advertise `streamGenerateContent` or omit `supportedGenerationMethods`. `model-lists.ts`: added `gemini-3.6-flash` and the `gemma-4` family to the static fallback — **please sanity-check these IDs against a live fetch before release**, the live fetch is the source of truth.
- **#4022, `ChatInput.tsx`**: clicking Push Story now opens a two-option selector (Naturally — "Push the existing plot forward." / Randomly — "Add a plausible surprise to the scene."); picking one arms that mode for the next response and shows it on the button label; a second click disarms. `ChatSettingsDrawer.tsx` / `AgentAddSetupFields.tsx`: the segmented mode control is removed (nothing reads `metadata.narrativeDirectorMode` at generation time anymore — the server only runs the director with the explicit per-request mode) and replaced with a hint pointing at the Push Story button.
- `CHANGELOG.md`: Unreleased → Fixed entries for all three.

## Test plan

- [ ] Manually verify a stable → staging switch completes on Termux (or that a genuine failure now shows the pnpm output tail in the error toast).
- [ ] Manually verify "Fetch Models from API" on a Google Gemini connection lists the full current model catalog (more than 50 entries, including the newest releases).
- [ ] Verify the new static `GOOGLE_MODELS` IDs (`gemini-3.6-flash`, `gemma-4-*`) against a live ListModels response.
- [ ] Manually verify clicking Push Story in a roleplay chat offers Naturally/Randomly with descriptions, arms the chosen mode (label shows it), and a second click disarms — desktop and mobile viewport.
- [ ] Manually verify the Narrative Director card in Chat Settings → Agents and the add-agent setup no longer show the Natural/Random selector, and Secret Plot controls still work.
- [ ] `pnpm check` passes. (It passed in the authoring session; re-verify locally.)

Fixes #4020. Fixes #4021. Fixes #4022.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Choose Natural or Random Story pushes directly from the **Push Story** button.
  - Added newly available Gemini and Gemma models to connection setup.

- **Bug Fixes**
  - Improved Google model discovery across paginated results.
  - Increased update reliability on slower devices and provided more specific installation error details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->