### PR TITLE
fix(agents): configurable AGENT_CALL_TIMEOUT_MS so slow local models aren't cancelled mid-stream (#3958)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -48,6 +48,11 @@ EMBEDDING_TIMEOUT_MS=300000
 # Ordinary Conversation, Roleplay, and Game provider timeout in milliseconds.
 # Valid range: 10000-3600000. Changes apply to the next generation without a restart.
 CHAT_GENERATION_TIMEOUT_MS=300000
+# Total-duration cap for one agent LLM call (trackers, HTML reformatter, ...),
+# applied even while the response is streaming. Raise this for slow local
+# models (e.g. llama.cpp on modest hardware). Valid range: 10000-3600000.
+# Changes apply to the next agent run without a restart.
+AGENT_CALL_TIMEOUT_MS=300000
 # Tool-calling loops and custom tool execution.
 MAX_TOOL_ROUNDS=100
 CUSTOM_TOOL_TIMEOUT_MS=60000

--- a/.env.example
+++ b/.env.example
@@ -43,16 +43,16 @@ LOG_PRESET=default
 LOG_LEVEL=warn
 LOG_DISABLE_REQUEST_LOGGING=false
 
-# Slow local embedding servers may need longer lorebook vectorization requests.
-EMBEDDING_TIMEOUT_MS=300000
-# Ordinary Conversation, Roleplay, and Game provider timeout in milliseconds.
-# Valid range: 10000-3600000. Changes apply to the next generation without a restart.
-CHAT_GENERATION_TIMEOUT_MS=300000
 # Total-duration cap for one agent LLM call (trackers, HTML reformatter, ...),
 # applied even while the response is streaming. Raise this for slow local
 # models (e.g. llama.cpp on modest hardware). Valid range: 10000-3600000.
 # Changes apply to the next agent run without a restart.
 AGENT_CALL_TIMEOUT_MS=300000
+# Slow local embedding servers may need longer lorebook vectorization requests.
+EMBEDDING_TIMEOUT_MS=300000
+# Ordinary Conversation, Roleplay, and Game provider timeout in milliseconds.
+# Valid range: 10000-3600000. Changes apply to the next generation without a restart.
+CHAT_GENERATION_TIMEOUT_MS=300000
 # Tool-calling loops and custom tool execution.
 MAX_TOOL_ROUNDS=100
 CUSTOM_TOOL_TIMEOUT_MS=60000

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 
 ### Added
 
+- Added an `AGENT_CALL_TIMEOUT_MS` override for agent LLM calls (trackers, HTML reformatter, and other agents). The previous fixed 5-minute cap cancelled slow local models mid-stream and then burned a second 5 minutes on the automatic invalid-JSON retry; the cap is now configurable from 10 seconds to 1 hour and documented next to `CHAT_GENERATION_TIMEOUT_MS` (#3958).
+
 - Added safe host-rendered contribution slots to Browser Personal Extensions. `marinara.ui.registerContribution(...)` can add themed top-bar buttons, Extensions menu items, and right-side panels containing bounded text, actions, inputs, selects, toggles, sliders, and color controls. Marinara validates and renders every descriptor while activation and form events return only to the exact-hash-approved sandbox Worker; extensions never receive host DOM, markup, styling, React, network, or direct API authority. The existing constrained `marinara.ui.showWindow(...)` window supports the expanded controls as well.
 - Added Atlas Cloud as an image and video generation service, including curated starter models, text/reference image requests, asynchronous job polling, connection tests, and Game/scene-video routing (#3989).
 - Added an Android-only **Show Android status bar** control under **Settings > General > App Behavior**, preserving fullscreen as the default while allowing the Android app to remember and restore the time, battery level, and notification icons across restarts (#3985).

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -203,7 +203,7 @@ A timeout is the longest time the server waits for a slow job before giving up. 
 | `CUSTOM_TOOL_TIMEOUT_MS` | `60000` (1 minute) | Time allowed for one custom tool call. |
 | `MAX_TOOL_ROUNDS` | `100` | Most tool-call rounds before the model must give a final answer. |
 
-The image, video, sprite, and ComfyUI timeouts are locked in at startup, so a change to them needs a restart. Chat-generation, embedding, and custom-tool timeouts take effect on the next request, with no restart. Invalid, zero, negative, or out-of-range chat timeout values log a warning and safely use the five-minute default. Raise a media timeout when large or high-quality jobs fail partway through. To learn more about video jobs, see [Scene Video](media/scene-video.md).
+The image, video, sprite, and ComfyUI timeouts are locked in at startup, so a change to them needs a restart. Chat-generation, agent, embedding, and custom-tool timeouts take effect on the next request or agent run, with no restart. Invalid, zero, negative, or out-of-range chat or agent timeout values log a warning and safely use the five-minute default. Raise a media timeout when large or high-quality jobs fail partway through. To learn more about video jobs, see [Scene Video](media/scene-video.md).
 
 ## Privileged APIs (ADMIN_SECRET)
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -193,6 +193,7 @@ A timeout is the longest time the server waits for a slow job before giving up. 
 | Variable | Default | What it does |
 | --- | --- | --- |
 | `CHAT_GENERATION_TIMEOUT_MS` | `300000` (5 minutes) | Provider headers/time-to-first-token and inter-chunk timeout for ordinary Conversation, Roleplay, and Game generations. Valid range: `10000`-`3600000`. It does not change Agent, media, embedding, tool, or background-job timeouts. |
+| `AGENT_CALL_TIMEOUT_MS` | `300000` (5 minutes) | Total-duration cap for one agent LLM call (trackers, HTML reformatter, and other agents), applied even while the response is still streaming. Raise it for slow local models that need longer than 5 minutes per agent pass. Valid range: `10000`-`3600000`. The Illustrator keeps at least its built-in 30-minute budget. |
 | `EMBEDDING_TIMEOUT_MS` | `300000` (5 minutes) | Time allowed for one embedding request. Higher helps slow local embedding servers. |
 | `IMAGE_GEN_TIMEOUT_MS` | `1800000` (30 minutes) | Time allowed for one image generation request. |
 | `VIDEO_GEN_TIMEOUT_MS` | `1800000` (30 minutes) | Time allowed for one scene video generation request, including local ComfyUI video workflows. |

--- a/packages/server/src/config/runtime-config.ts
+++ b/packages/server/src/config/runtime-config.ts
@@ -20,8 +20,10 @@ const DEFAULT_CUSTOM_TOOL_TIMEOUT_MS = 60_000;
 export const DEFAULT_CHAT_GENERATION_TIMEOUT_MS = 300_000;
 const MIN_CHAT_GENERATION_TIMEOUT_MS = 10_000;
 const MAX_CHAT_GENERATION_TIMEOUT_MS = 3_600_000;
+export const DEFAULT_AGENT_CALL_TIMEOUT_MS = 300_000;
 const MAX_TIMEOUT_MS = 2_147_483_647;
 let lastInvalidChatGenerationTimeout: string | null = null;
+let lastInvalidAgentCallTimeout: string | null = null;
 
 let envLoaded = false;
 // Keys that the .env file currently contributes to process.env. Tracked so a
@@ -453,6 +455,39 @@ export function getChatGenerationTimeoutMs() {
     );
   }
   return DEFAULT_CHAT_GENERATION_TIMEOUT_MS;
+}
+
+/**
+ * Per-call timeout for agent LLM requests (trackers, HTML reformatter, …).
+ * Unlike the main chat path, these are total-duration caps, so slow local
+ * models need a higher value here even when streaming (#3958). Read per
+ * request so .env hot reloads apply without a restart.
+ */
+export function getAgentCallTimeoutMs() {
+  const raw = normalizeEnvValue(process.env.AGENT_CALL_TIMEOUT_MS);
+  if (raw === null) return DEFAULT_AGENT_CALL_TIMEOUT_MS;
+
+  const parsed = /^\d+$/.test(raw) ? Number(raw) : Number.NaN;
+  if (
+    Number.isSafeInteger(parsed) &&
+    parsed >= MIN_CHAT_GENERATION_TIMEOUT_MS &&
+    parsed <= MAX_CHAT_GENERATION_TIMEOUT_MS
+  ) {
+    lastInvalidAgentCallTimeout = null;
+    return parsed;
+  }
+
+  if (lastInvalidAgentCallTimeout !== raw) {
+    lastInvalidAgentCallTimeout = raw;
+    sharedLogger.warn(
+      "[runtime-config] Ignoring invalid AGENT_CALL_TIMEOUT_MS=%s; expected %d-%d milliseconds, using %d",
+      raw,
+      MIN_CHAT_GENERATION_TIMEOUT_MS,
+      MAX_CHAT_GENERATION_TIMEOUT_MS,
+      DEFAULT_AGENT_CALL_TIMEOUT_MS,
+    );
+  }
+  return DEFAULT_AGENT_CALL_TIMEOUT_MS;
 }
 
 export function getMaxToolRounds() {

--- a/packages/server/src/services/agents/agent-executor.ts
+++ b/packages/server/src/services/agents/agent-executor.ts
@@ -27,7 +27,7 @@ import {
   normalizeRpgStatPools,
   resolveMacros,
 } from "@marinara-engine/shared";
-import { getMaxToolRounds, isDebugAgentsEnabled } from "../../config/runtime-config.js";
+import { getAgentCallTimeoutMs, getMaxToolRounds, isDebugAgentsEnabled } from "../../config/runtime-config.js";
 import { logger, logDebugOverride } from "../../lib/logger.js";
 import { wrapContent } from "../prompt/format-engine.js";
 import { sanitizePromptLeaf } from "../prompt/prompt-escaping.js";
@@ -41,7 +41,6 @@ const EXPRESSION_AGENT_RESPONSE_CHAR_LIMIT = 6000;
 const CHARACTER_LORE_DESCRIPTION_LIMIT = 2000;
 const CHARACTER_LORE_FIELD_LIMIT = 1200;
 const DEFAULT_AGENT_TEMPERATURE = 0.3;
-const DEFAULT_AGENT_CALL_TIMEOUT_MS = 5 * 60_000;
 const ILLUSTRATOR_AGENT_CALL_TIMEOUT_MS = 30 * 60_000;
 const AGENT_BATCH_FALLBACK_MAX_CONCURRENT = 4;
 
@@ -515,7 +514,11 @@ function combineAbortSignals(signals: AbortSignal[]): AbortSignal {
 }
 
 function agentCallSignal(parentSignal?: AbortSignal, agentType?: "illustrator"): AbortSignal {
-  const timeoutMs = agentType === "illustrator" ? ILLUSTRATOR_AGENT_CALL_TIMEOUT_MS : DEFAULT_AGENT_CALL_TIMEOUT_MS;
+  // AGENT_CALL_TIMEOUT_MS caps the TOTAL duration of one agent LLM call, even
+  // while streaming; slow local models need a raised value (#3958). The
+  // illustrator keeps at least its generous image-generation budget.
+  const configuredMs = getAgentCallTimeoutMs();
+  const timeoutMs = agentType === "illustrator" ? Math.max(ILLUSTRATOR_AGENT_CALL_TIMEOUT_MS, configuredMs) : configuredMs;
   const timeoutSignal = AbortSignal.timeout(timeoutMs);
   return parentSignal ? combineAbortSignals([parentSignal, timeoutSignal]) : timeoutSignal;
 }

--- a/packages/server/src/services/agents/agent-executor.ts
+++ b/packages/server/src/services/agents/agent-executor.ts
@@ -818,7 +818,10 @@ async function executeAgentWithTools(
   let totalTokens = 0;
   const debugAgentsEnabled = isDebugAgentsEnabled() && logger.isLevelEnabled("debug");
   const customParameters = agentCustomParameters(config);
-  const toolLoopSignal = agentCallSignal(context.signal, config.type === "illustrator" ? "illustrator" : undefined);
+  // Fresh per-call so AGENT_CALL_TIMEOUT_MS caps each LLM call, not the whole
+  // tool loop; earlier rounds must not eat a later round's budget.
+  const nextCallSignal = () =>
+    agentCallSignal(context.signal, config.type === "illustrator" ? "illustrator" : undefined);
 
   for (let round = 0; round < maxToolRounds; round++) {
     emitAgentDebug(context, {
@@ -839,7 +842,7 @@ async function executeAgentWithTools(
       customParameters,
       stream: streamResponses,
       tools: toolContext.tools,
-      signal: toolLoopSignal,
+      signal: nextCallSignal(),
     });
 
     totalTokens += result.usage?.totalTokens ?? 0;
@@ -922,7 +925,7 @@ async function executeAgentWithTools(
     cachingAtDepth: config.cachingAtDepth,
     customParameters,
     stream: streamResponses,
-    signal: toolLoopSignal,
+    signal: nextCallSignal(),
   });
   totalTokens += finalResult.usage?.totalTokens ?? 0;
   const responseText = finalResult.content?.trim() ?? "";


### PR DESCRIPTION
## Why

Fixes the root cause reported in #3958 (and its follow-up comment): local LLMs running as agents are cancelled mid-generation and then fail JSON validation on truncated output, even when actively streaming.

The reporter set `CHAT_GENERATION_TIMEOUT_MS=3600000` and still saw failures. That's because **agent LLM calls never consulted that setting.** Every agent call (trackers, HTML reformatter, etc.) was bounded by a hardcoded constant:

```ts
const DEFAULT_AGENT_CALL_TIMEOUT_MS = 5 * 60_000; // 300s, hardcoded
```

turned into `AbortSignal.timeout(300_000)` in `agentCallSignal()`. Two consequences:

1. It's a **total-duration** cap, not an idle cap — a healthy model streaming at 10–15 tk/s is still killed at exactly 300s. That's the "even when streaming" symptom and matches the llama.cpp `cancel task` log in the issue.
2. It ignores every configured timeout. Only the illustrator got a special 30-minute constant.

This also explains the reporter's "mysterious 600s second pass": when the first agent pass is cut at 300s, the truncated output fails JSON validation and the executor automatically retries once with a **fresh** 300s signal — so from the wall clock the second cancel lands at ~600s. It was 300 + 300, not a different timeout.

## What changed

- **`runtime-config.ts`**: new `getAgentCallTimeoutMs()` reading `AGENT_CALL_TIMEOUT_MS` (valid range 10000–3600000, default 300000), hot-reloaded per run and validated/warned exactly like `CHAT_GENERATION_TIMEOUT_MS`.
- **`agent-executor.ts`**: `agentCallSignal()` now uses the configured value; the illustrator keeps at least its built-in 30-minute budget via `Math.max`. The hardcoded `DEFAULT_AGENT_CALL_TIMEOUT_MS` constant is removed (the default now lives in runtime-config).
- **`.env.example`** and **`docs/CONFIGURATION.md`**: document the new knob next to `CHAT_GENERATION_TIMEOUT_MS`, noting it is a total-duration cap applied even while streaming.
- **`CHANGELOG.md`**: Unreleased → Added.

The automatic invalid-JSON retry behavior is unchanged — but with a correctly-sized budget the first pass should now complete, so the double-timeout stops happening.

## Test plan

- [ ] With a slow local endpoint (e.g. llama.cpp), enable an agent (HTML reformatter) and a task needing >5 min of generation; confirm it is cancelled at 300s with the default, and completes after setting `AGENT_CALL_TIMEOUT_MS=1800000`.
- [ ] Confirm an invalid `AGENT_CALL_TIMEOUT_MS` (e.g. `abc`, `5`, `99999999`) logs the range warning once and falls back to 300000.
- [ ] Confirm the value hot-reloads from `.env` without a server restart (like `CHAT_GENERATION_TIMEOUT_MS`).
- [ ] Confirm the Illustrator agent still gets at least its 30-minute budget.
- [ ] `pnpm check` passes. (It passed in the authoring session; re-verify locally.)

Closes #3958.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the configurable `AGENT_CALL_TIMEOUT_MS` setting for controlling the maximum duration of individual agent calls, including streaming.
  * Supports values from 10 seconds to 1 hour and applies to the next agent run without restarting.

* **Documentation**
  * Documented the new timeout setting in the example environment configuration, configuration reference, and changelog.

* **Bug Fixes**
  * Improved support for slow local models by replacing the previous fixed timeout with a configurable limit.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->