### PR TITLE
fix(selfie): feed Generation Style Text to the prompt model instead of the image prompt (#4028)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 
 ### Fixed
 
+- Stopped Conversation **Selfie** mode from pasting the image style profile's Generation Style Text verbatim into the final image prompt. The style now guides the prompt-building model (matching Roleplay illustration), so it still shapes the image without the redundant, CLIP-diluting copy (#4028).
 - Moved the Natural/Random progression choice onto the **Push Story** button: clicking it now opens a Naturally/Randomly selector that arms the chosen mode for the next response, replacing the mode controls previously buried in **Chat Settings → Agents → Narrative Director**, the add-agent setup, and the Narrative Director editor's Story Push Mode default (#4022).
 - Fetched the full Google Gemini model catalog in the connection editor by following the ListModels pagination, and refreshed the built-in Gemini/Gemma fallback list with the latest entries (#4021).
 - Gave in-app updates realistic install budgets on slow devices — update steps get four times as long on Android/Termux, where switching between stable and staging forces a near-full dependency reinstall — and update failures now report the failing pnpm step, timeouts, and the tail of the process output instead of an opaque `Command failed` (#4020).

--- a/packages/server/src/routes/gallery.routes.ts
+++ b/packages/server/src/routes/gallery.routes.ts
@@ -927,15 +927,18 @@ export async function galleryRoutes(app: FastifyInstance) {
     const selfiePositivePrompt = readTrimmedString(meta.selfiePositivePrompt) ?? selfieTags.join(", ").trim();
     const selfieNegativePrompt = readTrimmedString(meta.selfieNegativePrompt) ?? "";
     const promptOverridesStorage = createPromptOverridesStorage(app.db);
+    const imageDefaults = resolveConnectionImageDefaults(imageConn);
     const imageSettings = await loadImageGenerationUserSettings(app.db);
     const configuredStyleProfileId =
       ((meta.gameSetupConfig as Record<string, unknown> | undefined)?.imageStyleProfileId as string | undefined) ??
       (meta.imageStyleProfileId as string | undefined) ??
       null;
     const styleProfileId =
-      typeof configuredStyleProfileId === "string" && configuredStyleProfileId.trim()
+      (typeof configuredStyleProfileId === "string" && configuredStyleProfileId.trim()
         ? configuredStyleProfileId.trim()
-        : imageSettings.styleProfiles.defaultProfileId;
+        : undefined) ??
+      imageDefaults?.styleProfileId ??
+      imageSettings.styleProfiles.defaultProfileId;
     // Style feeds the prompt-building model as guidance rather than being pasted
     // verbatim into the final image prompt (#4028).
     const styleGuidance = resolveImageStyleGuidanceText(imageSettings.styleProfiles, styleProfileId);
@@ -1052,7 +1055,6 @@ export async function galleryRoutes(app: FastifyInstance) {
       }
     }
 
-    const imageDefaults = resolveConnectionImageDefaults(imageConn);
     const selfieResolution = readTrimmedString(meta.selfieResolution) ?? "";
     const [selfieWidth, selfieHeight] = selfieResolution.split("x").map(Number) as [number, number];
     const width = Number.isSafeInteger(selfieWidth) && selfieWidth > 0 ? selfieWidth : imageSettings.selfie.width;

--- a/packages/server/src/routes/gallery.routes.ts
+++ b/packages/server/src/routes/gallery.routes.ts
@@ -33,7 +33,11 @@ import { resolveGameVideoRuntime } from "../services/video/game-video-runtime.js
 import { generateImage, saveImageToDisk } from "../services/image/image-generation.js";
 import { resolveConnectionImageDefaults } from "../services/image/image-generation-defaults.js";
 import { loadImageGenerationUserSettings } from "../services/image/image-generation-settings.js";
-import { compileImagePrompt } from "../services/image/image-prompt-compiler.js";
+import {
+  compileImagePrompt,
+  formatImageStylePromptGuidance,
+  resolveImageStyleGuidanceText,
+} from "../services/image/image-prompt-compiler.js";
 import {
   resolveImagePromptReviewSize,
   resolveReviewedImagePromptSubmission,
@@ -923,12 +927,27 @@ export async function galleryRoutes(app: FastifyInstance) {
     const selfiePositivePrompt = readTrimmedString(meta.selfiePositivePrompt) ?? selfieTags.join(", ").trim();
     const selfieNegativePrompt = readTrimmedString(meta.selfieNegativePrompt) ?? "";
     const promptOverridesStorage = createPromptOverridesStorage(app.db);
-    const selfieSystemPrompt = await resolveConversationSelfieSystemPrompt({
+    const imageSettings = await loadImageGenerationUserSettings(app.db);
+    const configuredStyleProfileId =
+      ((meta.gameSetupConfig as Record<string, unknown> | undefined)?.imageStyleProfileId as string | undefined) ??
+      (meta.imageStyleProfileId as string | undefined) ??
+      null;
+    const styleProfileId =
+      typeof configuredStyleProfileId === "string" && configuredStyleProfileId.trim()
+        ? configuredStyleProfileId.trim()
+        : imageSettings.styleProfiles.defaultProfileId;
+    // Style feeds the prompt-building model as guidance rather than being pasted
+    // verbatim into the final image prompt (#4028).
+    const styleGuidance = resolveImageStyleGuidanceText(imageSettings.styleProfiles, styleProfileId);
+    const baseSelfieSystemPrompt = await resolveConversationSelfieSystemPrompt({
       promptOverridesStorage,
       chatPromptTemplate: selfiePromptTemplate,
       appearance,
       charName: characterName,
     });
+    const selfieSystemPrompt = styleGuidance
+      ? `${baseSelfieSystemPrompt}${formatImageStylePromptGuidance(styleGuidance)}`
+      : baseSelfieSystemPrompt;
 
     const selfieAbortSignal = createResponseAbortSignal(reply, SCENE_VIDEO_GENERATION_TIMEOUT_MS, "Selfie generation");
     let promptRuntime;
@@ -1034,15 +1053,6 @@ export async function galleryRoutes(app: FastifyInstance) {
     }
 
     const imageDefaults = resolveConnectionImageDefaults(imageConn);
-    const imageSettings = await loadImageGenerationUserSettings(app.db);
-    const configuredStyleProfileId =
-      ((meta.gameSetupConfig as Record<string, unknown> | undefined)?.imageStyleProfileId as string | undefined) ??
-      (meta.imageStyleProfileId as string | undefined) ??
-      null;
-    const styleProfileId =
-      typeof configuredStyleProfileId === "string" && configuredStyleProfileId.trim()
-        ? configuredStyleProfileId.trim()
-        : imageSettings.styleProfiles.defaultProfileId;
     const selfieResolution = readTrimmedString(meta.selfieResolution) ?? "";
     const [selfieWidth, selfieHeight] = selfieResolution.split("x").map(Number) as [number, number];
     const width = Number.isSafeInteger(selfieWidth) && selfieWidth > 0 ? selfieWidth : imageSettings.selfie.width;
@@ -1054,6 +1064,7 @@ export async function galleryRoutes(app: FastifyInstance) {
       styleProfiles: imageSettings.styleProfiles,
       styleProfileId,
       imageDefaults,
+      omitProfileStyleText: true,
     });
     const imageModel = imageConn.model || "";
     const imageBaseUrl = imageConn.baseUrl || "https://image.pollinations.ai";

--- a/packages/server/src/services/generation/conversation-selfie-command-runtime.ts
+++ b/packages/server/src/services/generation/conversation-selfie-command-runtime.ts
@@ -5,7 +5,11 @@ import {
   suppressesReferencePromptLine,
   resolveIllustratorCharacterReferences,
 } from "../image/illustrator-references.js";
-import { compileImagePrompt } from "../image/image-prompt-compiler.js";
+import {
+  compileImagePrompt,
+  formatImageStylePromptGuidance,
+  resolveImageStyleGuidanceText,
+} from "../image/image-prompt-compiler.js";
 import { persistGeneratedImageToEntityGalleries } from "../image/generated-image-entity-gallery.js";
 import { resolveConnectionImageDefaults } from "../image/image-generation-defaults.js";
 import { generateImage, saveImageToDisk } from "../image/image-generation.js";
@@ -149,12 +153,27 @@ async function generateSelfie(
     resolveBaseUrl,
     onFallback: reportFallback,
   });
-  const selfieSystemPrompt = await resolveConversationSelfieSystemPrompt({
+  const imageDefaults = resolveConnectionImageDefaults(imgConnFull);
+  const imageSettings = await loadImageGenerationUserSettings(args.db);
+  const configuredStyleProfileId =
+    readNestedString(args.chatMeta.gameSetupConfig, "imageStyleProfileId") ??
+    (typeof args.chatMeta.imageStyleProfileId === "string" ? args.chatMeta.imageStyleProfileId : null);
+  const styleProfileId =
+    typeof configuredStyleProfileId === "string" && configuredStyleProfileId.trim()
+      ? configuredStyleProfileId.trim()
+      : imageSettings.styleProfiles.defaultProfileId;
+  // Style is fed to the prompt-building model as guidance so it shapes the
+  // generated prompt, instead of being pasted verbatim into the image prompt.
+  const styleGuidance = resolveImageStyleGuidanceText(imageSettings.styleProfiles, styleProfileId);
+  const baseSelfieSystemPrompt = await resolveConversationSelfieSystemPrompt({
     promptOverridesStorage: createPromptOverridesStorage(args.db),
     chatPromptTemplate: selfiePromptTemplate,
     appearance,
     charName: args.charName,
   });
+  const selfieSystemPrompt = styleGuidance
+    ? `${baseSelfieSystemPrompt}${formatImageStylePromptGuidance(styleGuidance)}`
+    : baseSelfieSystemPrompt;
   const userPrompt = args.command.context
     ? `Context for the selfie: ${args.command.context}`
     : `Generate a casual selfie of ${args.charName} based on the current conversation context.`;
@@ -239,15 +258,6 @@ async function generateSelfie(
   const imgBaseUrl = imgConnFull.baseUrl || "https://image.pollinations.ai";
   const imgApiKey = imgConnFull.apiKey || "";
   const imgSource = imgConnFull.imageGenerationSource || imgModel;
-  const imageDefaults = resolveConnectionImageDefaults(imgConnFull);
-  const imageSettings = await loadImageGenerationUserSettings(args.db);
-  const configuredStyleProfileId =
-    readNestedString(args.chatMeta.gameSetupConfig, "imageStyleProfileId") ??
-    (typeof args.chatMeta.imageStyleProfileId === "string" ? args.chatMeta.imageStyleProfileId : null);
-  const styleProfileId =
-    typeof configuredStyleProfileId === "string" && configuredStyleProfileId.trim()
-      ? configuredStyleProfileId.trim()
-      : imageSettings.styleProfiles.defaultProfileId;
 
   const selfieRes = typeof args.chatMeta.selfieResolution === "string" ? args.chatMeta.selfieResolution : "";
   const [selfieW, selfieH] = selfieRes.split("x").map(Number) as [number, number];
@@ -259,6 +269,7 @@ async function generateSelfie(
     styleProfiles: imageSettings.styleProfiles,
     styleProfileId,
     imageDefaults,
+    omitProfileStyleText: true,
   });
   const imageResults = await generateIllustratorImageVariants({
     count: args.chatMeta.illustratorImagesPerGeneration,

--- a/packages/server/src/services/generation/conversation-selfie-command-runtime.ts
+++ b/packages/server/src/services/generation/conversation-selfie-command-runtime.ts
@@ -159,9 +159,11 @@ async function generateSelfie(
     readNestedString(args.chatMeta.gameSetupConfig, "imageStyleProfileId") ??
     (typeof args.chatMeta.imageStyleProfileId === "string" ? args.chatMeta.imageStyleProfileId : null);
   const styleProfileId =
-    typeof configuredStyleProfileId === "string" && configuredStyleProfileId.trim()
+    (typeof configuredStyleProfileId === "string" && configuredStyleProfileId.trim()
       ? configuredStyleProfileId.trim()
-      : imageSettings.styleProfiles.defaultProfileId;
+      : undefined) ??
+    imageDefaults?.styleProfileId ??
+    imageSettings.styleProfiles.defaultProfileId;
   // Style is fed to the prompt-building model as guidance so it shapes the
   // generated prompt, instead of being pasted verbatim into the image prompt.
   const styleGuidance = resolveImageStyleGuidanceText(imageSettings.styleProfiles, styleProfileId);

--- a/packages/server/src/services/image/image-prompt-compiler.ts
+++ b/packages/server/src/services/image/image-prompt-compiler.ts
@@ -1,2 +1,7 @@
-export { compileImagePrompt, mergeCompiledPromptMeta } from "@marinara-engine/shared";
+export {
+  compileImagePrompt,
+  mergeCompiledPromptMeta,
+  formatImageStylePromptGuidance,
+  resolveImageStyleGuidanceText,
+} from "@marinara-engine/shared";
 export type { CompiledImagePrompt, CompileImagePromptInput } from "@marinara-engine/shared";

--- a/packages/shared/src/utils/image-prompt-compiler.ts
+++ b/packages/shared/src/utils/image-prompt-compiler.ts
@@ -28,6 +28,36 @@ export interface CompileImagePromptInput {
   hardNegative?: string | null;
   /** Apply the selected grammar to generated prose that is normally preserved for review/readability. */
   applyPromptModeToSourcePrompt?: boolean;
+  /**
+   * Suppress appending the profile's raw styleText to the prompt. Used when the
+   * style is already conveyed another way (e.g. fed to the prompt-building LLM
+   * as guidance), so it is not duplicated verbatim into the final image prompt.
+   */
+  omitProfileStyleText?: boolean;
+}
+
+/**
+ * The active profile's style text when it should steer generation (a real base
+ * style, not "auto"). Empty when there is no explicit style to apply.
+ */
+export function resolveImageStyleGuidanceText(
+  styleProfiles: ImageStyleProfileSettings,
+  styleProfileId?: string | null,
+): string {
+  const profile = findImageStyleProfile(styleProfiles, styleProfileId || styleProfiles.defaultProfileId);
+  const styleText = profile.styleText?.trim() ?? "";
+  return styleText && profile.baseStyle !== "auto" ? styleText : "";
+}
+
+/**
+ * Guidance block appended to an image prompt-builder's system prompt so the
+ * generated prompt reflects the configured style instead of having the raw
+ * style text pasted verbatim into the final prompt.
+ */
+export function formatImageStylePromptGuidance(styleText: string): string {
+  const trimmed = styleText.trim();
+  if (!trimmed) return "";
+  return `\n\nVisual style guidance: compose the image prompt so it naturally reflects this style: ${trimmed}. Weave the style into the description; do not copy this guidance verbatim into your output.`;
 }
 
 export function compileImagePrompt(input: CompileImagePromptInput): CompiledImagePrompt {
@@ -85,7 +115,7 @@ function compileImagePromptPass(
   const sourceCues = compactPrompt ? deriveTaggedSourceCues(sourceCueText) : [];
   const profileSubjectTags = reconcileProfileSubjectTags(profile.subjectTags[input.kind] ?? "", sourceCues);
   const profileStyleText =
-    compactPrompt || (profile.styleText && generatedStyle)
+    input.omitProfileStyleText || compactPrompt || (profile.styleText && generatedStyle)
       ? ""
       : profile.styleText && profile.baseStyle !== "auto"
         ? profile.styleText


### PR DESCRIPTION
## Why

In Conversation **Selfie** mode, the image style profile's *Generation Style Text* was being pasted verbatim into the final image prompt submitted to the generator (#4028). Users saw their style guide duplicated in every selfie prompt — redundant, wordy, and diluting CLIP attention. The reporter confirmed this happens in Selfie mode but **not** Roleplay illustration.

**Root cause:** Roleplay illustration passes `generatedStyle` into `compileImagePrompt`, which suppresses the profile's raw `styleText` (the style is already reflected in the generated prompt). The two selfie paths omit `generatedStyle`, so the compiler falls through to appending `profile.styleText` verbatim.

The maintainer's design intent (from the Discord thread): the style should *guide the prompt-building LLM*, not be copied into the output — while still reaching image providers that lack a native style field.

## What changed

- **`packages/shared/.../image-prompt-compiler.ts`**: new `omitProfileStyleText` input flag that suppresses the verbatim `profile.styleText` append; two small exported helpers — `resolveImageStyleGuidanceText()` (the active profile's style text when a real base style is set) and `formatImageStylePromptGuidance()` (the guidance block appended to the prompt-builder's system prompt).
- **Both selfie paths** — the `[selfie]` Conversation command (`conversation-selfie-command-runtime.ts`) and the gallery selfie route (`gallery.routes.ts`) — now inject the active style as guidance into the prompt-builder's system prompt and pass `omitProfileStyleText: true`. The style still shapes the image (and still reaches providers without a style field, via the generated prompt), just not pasted verbatim.

Roleplay illustration, backgrounds, portraits, avatars, sprites, and game assets are untouched.

## Test plan

- [ ] With a style profile that has a non-empty Generation Style Text and a real base style, trigger a `[selfie]` in a Conversation and confirm the submitted image prompt (gallery → prompt) no longer contains the style text verbatim, while the image still reflects the style.
- [ ] Repeat via the Gallery "selfie" button (the `/:chatId/selfie` route), including preview-only.
- [ ] With a style profile set to base style "auto" (or empty style text), confirm behavior is unchanged (no guidance injected, nothing suppressed).
- [ ] Confirm Roleplay illustration prompts are unchanged.
- [ ] `pnpm check` passes. (It passed in the authoring session; re-verify locally.)

Fixes #4028.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Conversation Gallery Selfie mode prompt generation.
  * Image style guidance now influences prompt construction without being repeated verbatim in the final image prompt.
  * Reduced redundant style text, resulting in clearer and more consistent generated selfies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->