### PR TITLE
feat(chat): custom quick replies + translation display options (#4024)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 
 ### Added
 
+- Added user-defined **Custom Quick Replies**: create your own buttons in **Settings → General → Quick replies** that each send a fixed message, macro, or `/slash` command from the quick replies menu beside Send, in both Conversation and Roleplay/Game input (#4024).
+- Added a **Show Only Translation** toggle to **Chat Settings → Translation** that displays just the translated text in place of the original once a message is translated, and rendered translated text through the same markdown pipeline as messages so bold, italics, and quotes format correctly (#4024).
 - Added an `AGENT_CALL_TIMEOUT_MS` override for agent LLM calls (trackers, HTML reformatter, and other agents). The previous fixed 5-minute cap cancelled slow local models mid-stream and then burned a second 5 minutes on the automatic invalid-JSON retry; the cap is now configurable from 10 seconds to 1 hour and documented next to `CHAT_GENERATION_TIMEOUT_MS` (#3958).
 
 - Added safe host-rendered contribution slots to Browser Personal Extensions. `marinara.ui.registerContribution(...)` can add themed top-bar buttons, Extensions menu items, and right-side panels containing bounded text, actions, inputs, selects, toggles, sliders, and color controls. Marinara validates and renders every descriptor while activation and form events return only to the exact-hash-approved sandbox Worker; extensions never receive host DOM, markup, styling, React, network, or direct API authority. The existing constrained `marinara.ui.showWindow(...)` window supports the expanded controls as well.

--- a/packages/client/src/components/chat/ChatArea.tsx
+++ b/packages/client/src/components/chat/ChatArea.tsx
@@ -1460,7 +1460,13 @@ export function ChatArea() {
     }
     useTranslationStore
       .getState()
-      .seedFromMessages(messages as unknown as Array<{ id: string; extra?: string | Record<string, unknown> | null }>);
+      .seedFromMessages(
+        messages as unknown as Array<{
+          id: string;
+          content?: string;
+          extra?: string | Record<string, unknown> | null;
+        }>,
+      );
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [chat?.id, msgPageCount]);
 

--- a/packages/client/src/components/chat/ChatInput.tsx
+++ b/packages/client/src/components/chat/ChatInput.tsx
@@ -319,6 +319,7 @@ export const ChatInput = memo(function ChatInput({
   const showQuickReplyPostOnly = useUIStore((s) => s.showQuickReplyPostOnly);
   const showQuickReplyGuide = useUIStore((s) => s.showQuickReplyGuide);
   const showQuickReplyImpersonate = useUIStore((s) => s.showQuickReplyImpersonate);
+  const customQuickReplies = useUIStore((s) => s.customQuickReplies);
   const speechToTextEnabled = useUIStore((s) => s.speechToTextEnabled);
   const quoteFormat = useUIStore((s) => s.quoteFormat);
   const createMessage = useCreateMessage(activeChatId);
@@ -1327,6 +1328,19 @@ export const ChatInput = memo(function ChatInput({
     await runQuickSlashCommand(`/guided ${text}`, "Guided generation failed");
   }, [activeChatId, isInputBusy, requiresManualGuideTarget, hasPendingAttachments, runQuickSlashCommand]);
 
+  const sendCustomQuickReply = useCallback(
+    async (content: string) => {
+      const el = textareaRef.current;
+      if (!el || !activeChatId || isInputBusy || isReadingAttachments) return;
+      el.value = content;
+      resizeChatInputTextarea(el);
+      syncInputState(content);
+      setInputDraft(activeChatId, content);
+      await handleSend();
+    },
+    [activeChatId, isInputBusy, isReadingAttachments, syncInputState, setInputDraft, handleSend],
+  );
+
   const quickReplyActions = useMemo<QuickReplyAction[]>(() => {
     const actions: QuickReplyAction[] = [];
     const getPostOnlyDisabledReason = () => {
@@ -1384,6 +1398,25 @@ export const ChatInput = memo(function ChatInput({
         onSelect: handleImpersonateQuickButton,
       });
     }
+    for (const entry of customQuickReplies) {
+      const label = entry.label.trim() || entry.content.trim().slice(0, 24) || "Quick reply";
+      if (!entry.content.trim()) continue;
+      actions.push({
+        id: `custom-${entry.id}`,
+        label,
+        description: "Send a saved custom quick reply",
+        icon: <Sparkles size="0.875rem" />,
+        disabled: !activeChatId || isInputBusy || isReadingAttachments,
+        disabledReason: !activeChatId
+          ? "Select or create a chat first."
+          : isInputBusy
+            ? (inputBusyReason ?? undefined)
+            : isReadingAttachments
+              ? "Still reading attached files."
+              : undefined,
+        onSelect: () => sendCustomQuickReply(entry.content),
+      });
+    }
     return actions;
   }, [
     activeChatId,
@@ -1397,6 +1430,8 @@ export const ChatInput = memo(function ChatInput({
     showQuickReplyPostOnly,
     showQuickReplyGuide,
     showQuickReplyImpersonate,
+    customQuickReplies,
+    sendCustomQuickReply,
     handlePostOnlyButton,
     handleGuidedGenerationButton,
     handleImpersonateQuickButton,

--- a/packages/client/src/components/chat/ChatMessage.tsx
+++ b/packages/client/src/components/chat/ChatMessage.tsx
@@ -1323,8 +1323,9 @@ export const ChatMessage = memo(function ChatMessage({
   }, []);
 
   // Translation
-  const { translate, translations, translating } = useTranslate();
+  const { translate, translations, translationSources, translating } = useTranslate();
   const translatedText = translations[message.id];
+  const translationSource = translationSources[message.id];
   const isTranslating = !!translating[message.id];
 
   // TTS
@@ -2013,8 +2014,11 @@ export const ChatMessage = memo(function ChatMessage({
     [activeChatMetadata],
   );
   // When enabled, the translation replaces the original in place instead of
-  // appearing below it.
-  const showTranslationOnly = translationDisplayOnly && !!translatedText && !isTranslating;
+  // appearing below it — but only while it matches the currently visible
+  // content, so switching swipes or editing never shows a stale translation
+  // in place of the real text.
+  const showTranslationOnly =
+    translationDisplayOnly && !!translatedText && !isTranslating && translationSource === message.content;
 
   const handleCopy = () => {
     copyToClipboard(message.content);

--- a/packages/client/src/components/chat/ChatMessage.tsx
+++ b/packages/client/src/components/chat/ChatMessage.tsx
@@ -1999,6 +1999,23 @@ export const ChatMessage = memo(function ChatMessage({
     return renderContent(text, dialogueColor, speakerColorMap, boldDialogue, htmlScopeClass, quoteFormat);
   }, [text, dialogueColor, speakerColorMap, boldDialogue, htmlScopeClass, quoteFormat]);
 
+  // Translated text is rendered through the same markdown pipeline as the
+  // message so bold/italics/quotes format identically.
+  const renderedTranslation = useMemo(
+    () =>
+      translatedText
+        ? renderContent(translatedText, dialogueColor, speakerColorMap, boldDialogue, htmlScopeClass, quoteFormat)
+        : null,
+    [translatedText, dialogueColor, speakerColorMap, boldDialogue, htmlScopeClass, quoteFormat],
+  );
+  const translationDisplayOnly = useMemo(
+    () => parseChatMetadata(activeChatMetadata).translationDisplayOnly === true,
+    [activeChatMetadata],
+  );
+  // When enabled, the translation replaces the original in place instead of
+  // appearing below it.
+  const showTranslationOnly = translationDisplayOnly && !!translatedText && !isTranslating;
+
   const handleCopy = () => {
     copyToClipboard(message.content);
     setCopied(true);
@@ -2145,6 +2162,8 @@ export const ChatMessage = memo(function ChatMessage({
           <>
             {diceRollResult ? (
               <DiceMessageContent diceRollResult={diceRollResult} createdAt={message.createdAt} />
+            ) : showTranslationOnly ? (
+              renderedTranslation
             ) : (
               renderedContent
             )}
@@ -2154,14 +2173,12 @@ export const ChatMessage = memo(function ChatMessage({
           </>
         )}
       </div>
-      {(translatedText || isTranslating) && (
+      {(translatedText || isTranslating) && !showTranslationOnly && (
         <div className="mt-2 border-t border-white/10 pt-2">
           {isTranslating ? (
             <span className="text-[0.75rem] italic text-white/40">Translating…</span>
           ) : (
-            <div className="whitespace-pre-wrap text-[0.8125rem] leading-relaxed text-blue-200/70">
-              {translatedText}
-            </div>
+            <div className="text-[0.8125rem] leading-relaxed text-blue-200/70">{renderedTranslation}</div>
           )}
         </div>
       )}
@@ -2278,6 +2295,8 @@ export const ChatMessage = memo(function ChatMessage({
                 >
                   {diceRollResult ? (
                     <DiceMessageContent diceRollResult={diceRollResult} createdAt={message.createdAt} />
+                  ) : showTranslationOnly ? (
+                    renderedTranslation
                   ) : (
                     renderedContent
                   )}
@@ -3027,6 +3046,8 @@ export const ChatMessage = memo(function ChatMessage({
                     <>
                       {diceRollResult ? (
                         <DiceMessageContent diceRollResult={diceRollResult} createdAt={message.createdAt} />
+                      ) : showTranslationOnly ? (
+                        renderedTranslation
                       ) : (
                         renderedContent
                       )}
@@ -3037,13 +3058,13 @@ export const ChatMessage = memo(function ChatMessage({
                   )}
                 </div>
                 {/* Translation */}
-                {(translatedText || isTranslating) && (
+                {(translatedText || isTranslating) && !showTranslationOnly && (
                   <div className="mt-2 border-t border-[var(--border)] pt-2">
                     {isTranslating ? (
                       <span className="text-[0.75rem] italic text-[var(--muted-foreground)]">Translating…</span>
                     ) : (
-                      <div className="whitespace-pre-wrap text-[0.8125rem] leading-relaxed text-[var(--muted-foreground)]">
-                        {translatedText}
+                      <div className="text-[0.8125rem] leading-relaxed text-[var(--muted-foreground)]">
+                        {renderedTranslation}
                       </div>
                     )}
                   </div>

--- a/packages/client/src/components/chat/ConversationInput.tsx
+++ b/packages/client/src/components/chat/ConversationInput.tsx
@@ -2252,7 +2252,7 @@ export function ConversationInput({
             <div className="hidden sm:block">
               <QuickReplyMenu
                 actions={quickReplyActions}
-                disabled={!activeChatId || isReadingAttachments || (!hasInput && attachments.length === 0)}
+                disabled={!activeChatId || isReadingAttachments}
               />
             </div>
           )}

--- a/packages/client/src/components/chat/ConversationInput.tsx
+++ b/packages/client/src/components/chat/ConversationInput.tsx
@@ -414,6 +414,7 @@ export function ConversationInput({
   const showQuickRepliesMenu = useUIStore((s) => s.showQuickRepliesMenu);
   const showQuickReplyPostOnly = useUIStore((s) => s.showQuickReplyPostOnly);
   const showQuickReplyGuide = useUIStore((s) => s.showQuickReplyGuide);
+  const customQuickReplies = useUIStore((s) => s.customQuickReplies);
   const speechToTextEnabled = useUIStore((s) => s.speechToTextEnabled);
   const quoteFormat = useUIStore((s) => s.quoteFormat);
   const createMessage = useCreateMessage(activeChatId);
@@ -1353,6 +1354,20 @@ export function ConversationInput({
     await runQuickSlashCommand(`/guided ${text}`, "Guided generation failed");
   }, [activeChatId, isSendBlocked, hasPendingAttachments, runQuickSlashCommand]);
 
+  const sendCustomQuickReply = useCallback(
+    async (content: string) => {
+      const el = textareaRef.current;
+      if (!el || !activeChatId || isSendBlocked || isReadingAttachments) return;
+      el.value = content;
+      el.style.height = "auto";
+      el.style.height = `${Math.min(el.scrollHeight, 160)}px`;
+      syncInputState(content);
+      setInputDraft(activeChatId, content);
+      await handleSend();
+    },
+    [activeChatId, isSendBlocked, isReadingAttachments, syncInputState, setInputDraft, handleSend],
+  );
+
   const quickReplyActions = useMemo<QuickReplyAction[]>(() => {
     const actions: QuickReplyAction[] = [];
     const getPostOnlyDisabledReason = () => {
@@ -1391,6 +1406,25 @@ export function ConversationInput({
         onSelect: handleGuidedGenerationButton,
       });
     }
+    for (const entry of customQuickReplies) {
+      const label = entry.label.trim() || entry.content.trim().slice(0, 24) || "Quick reply";
+      if (!entry.content.trim()) continue;
+      actions.push({
+        id: `custom-${entry.id}`,
+        label,
+        description: "Send a saved custom quick reply",
+        icon: <Sparkles size="0.875rem" />,
+        disabled: !activeChatId || isSendBlocked || isReadingAttachments,
+        disabledReason: !activeChatId
+          ? "Select or create a chat first."
+          : isSendBlocked
+            ? "Wait for the current agents to finish."
+            : isReadingAttachments
+              ? "Still reading attached files."
+              : undefined,
+        onSelect: () => sendCustomQuickReply(entry.content),
+      });
+    }
     return actions;
   }, [
     activeChatId,
@@ -1401,6 +1435,8 @@ export function ConversationInput({
     hasPendingAttachments,
     showQuickReplyPostOnly,
     showQuickReplyGuide,
+    customQuickReplies,
+    sendCustomQuickReply,
     handlePostOnlyButton,
     handleGuidedGenerationButton,
   ]);

--- a/packages/client/src/components/panels/SettingsPanel.tsx
+++ b/packages/client/src/components/panels/SettingsPanel.tsx
@@ -2652,6 +2652,75 @@ function QuickRepliesSetting() {
               </button>
             );
           })}
+          <CustomQuickRepliesManager />
+        </div>
+      )}
+    </div>
+  );
+}
+
+function CustomQuickRepliesManager() {
+  const localize = useLocalizedUiText();
+  const customQuickReplies = useUIStore((s) => s.customQuickReplies);
+  const addCustomQuickReply = useUIStore((s) => s.addCustomQuickReply);
+  const updateCustomQuickReply = useUIStore((s) => s.updateCustomQuickReply);
+  const removeCustomQuickReply = useUIStore((s) => s.removeCustomQuickReply);
+
+  return (
+    <div className="mt-1 border-t border-[var(--border)]/60 pt-2">
+      <div className="mb-1 flex items-center justify-between gap-2 px-1">
+        <span className="text-[0.65rem] font-semibold uppercase tracking-wide text-[var(--muted-foreground)]">
+          {localize("Custom quick replies")}
+        </span>
+        <button
+          type="button"
+          onClick={() => addCustomQuickReply("", "")}
+          className="flex items-center gap-1 rounded-md bg-[var(--secondary)]/50 px-2 py-1 text-[0.65rem] font-medium text-[var(--muted-foreground)] transition-colors hover:bg-[var(--secondary)] hover:text-[var(--foreground)] active:scale-[0.98]"
+          title={localize("Add a custom quick reply")}
+        >
+          <Plus size="0.75rem" aria-hidden="true" />
+          {localize("Add")}
+        </button>
+      </div>
+      {customQuickReplies.length === 0 ? (
+        <p className="px-1 pb-1 text-[0.65rem] leading-tight text-[var(--muted-foreground)]">
+          {localize(
+            "Add buttons that send a fixed message, macro, or slash command from the quick replies menu beside Send.",
+          )}
+        </p>
+      ) : (
+        <div className="grid gap-1.5">
+          {customQuickReplies.map((entry) => (
+            <div
+              key={entry.id}
+              className="grid gap-1 rounded-md border border-[var(--border)]/60 bg-[var(--background)]/30 p-1.5"
+            >
+              <div className="flex items-center gap-1.5">
+                <input
+                  value={entry.label}
+                  onChange={(event) => updateCustomQuickReply(entry.id, { label: event.target.value })}
+                  placeholder={localize("Button label")}
+                  className="min-w-0 flex-1 rounded bg-[var(--secondary)]/60 px-2 py-1 text-xs outline-none ring-1 ring-transparent focus:ring-[var(--primary)]/40"
+                />
+                <button
+                  type="button"
+                  onClick={() => removeCustomQuickReply(entry.id)}
+                  className="flex h-6 w-6 shrink-0 items-center justify-center rounded text-[var(--destructive)] transition-colors hover:bg-[var(--destructive)]/10 active:scale-90"
+                  title={localize("Remove quick reply")}
+                  aria-label={localize("Remove quick reply")}
+                >
+                  <Trash2 size="0.75rem" aria-hidden="true" />
+                </button>
+              </div>
+              <textarea
+                value={entry.content}
+                onChange={(event) => updateCustomQuickReply(entry.id, { content: event.target.value })}
+                placeholder={localize("Message, macro, or /slash command to send")}
+                rows={2}
+                className="w-full resize-y rounded bg-[var(--secondary)]/60 px-2 py-1 text-xs outline-none ring-1 ring-transparent focus:ring-[var(--primary)]/40"
+              />
+            </div>
+          ))}
         </div>
       )}
     </div>

--- a/packages/client/src/features/chat-settings/sections/TranslationSection.tsx
+++ b/packages/client/src/features/chat-settings/sections/TranslationSection.tsx
@@ -155,6 +155,12 @@ export function TranslationSection({ metadata, textConnections, onMetadataChange
           description="Add a translate button beside Send so you can translate and edit your message before sending it."
           onToggle={() => onMetadataChange({ showInputTranslateButton: !metadata.showInputTranslateButton })}
         />
+        <TranslationToggle
+          enabled={metadata.translationDisplayOnly === true}
+          title="Show Only Translation"
+          description="Once a message is translated, show just the translation in its place instead of both the original and the translation."
+          onToggle={() => onMetadataChange({ translationDisplayOnly: !metadata.translationDisplayOnly })}
+        />
       </div>
     </ChatSettingsSection>
   );

--- a/packages/client/src/hooks/use-generate.ts
+++ b/packages/client/src/hooks/use-generate.ts
@@ -3046,7 +3046,7 @@ export function useGenerate() {
                       deeplxUrl: store.config.deeplxUrl,
                     })
                     .then((result) => {
-                      store.setTranslation(id, result.translatedText);
+                      store.setTranslation(id, result.translatedText, textToTranslate);
                       store.setTranslating(id, false);
                       // Persist to message extra
                       api

--- a/packages/client/src/hooks/use-translate.ts
+++ b/packages/client/src/hooks/use-translate.ts
@@ -9,6 +9,7 @@ import { useTranslationStore } from "../stores/translation.store";
 // ── Hook ──
 export function useTranslate() {
   const translations = useTranslationStore((s) => s.translations);
+  const translationSources = useTranslationStore((s) => s.translationSources);
   const translating = useTranslationStore((s) => s.translating);
   const config = useTranslationStore((s) => s.config);
 
@@ -38,7 +39,7 @@ export function useTranslate() {
         deeplApiKey: store.config.deeplApiKey,
         deeplxUrl: store.config.deeplxUrl,
       });
-      store.setTranslation(messageId, result.translatedText);
+      store.setTranslation(messageId, result.translatedText, text);
       // Persist to message extra so translation survives refresh/chat switch
       if (chatId) {
         api
@@ -59,6 +60,7 @@ export function useTranslate() {
   return {
     translate,
     translations,
+    translationSources,
     translating,
     config,
   };

--- a/packages/client/src/stores/translation.store.ts
+++ b/packages/client/src/stores/translation.store.ts
@@ -19,43 +19,56 @@ interface TranslationStore {
   setConfig: (config: TranslationConfig) => void;
   /** messageId -> translated text */
   translations: Record<string, string>;
+  /** messageId -> the source text that was translated (used to detect stale swipe/edit content) */
+  translationSources: Record<string, string>;
   /** messageId -> hidden translation display state */
   hiddenTranslationIds: Record<string, boolean>;
   /** messageId -> currently translating */
   translating: Record<string, boolean>;
-  setTranslation: (id: string, text: string) => void;
+  setTranslation: (id: string, text: string, source?: string) => void;
   removeTranslation: (id: string) => void;
   setTranslating: (id: string, val: boolean) => void;
   /** Clear all translations (e.g. on chat switch) */
   clearAll: () => void;
   /** Seed translations from message extras (e.g. on chat load) */
-  seedFromMessages: (messages: Array<{ id: string; extra?: string | Record<string, unknown> | null }>) => void;
+  seedFromMessages: (
+    messages: Array<{ id: string; content?: string; extra?: string | Record<string, unknown> | null }>,
+  ) => void;
 }
 
 export const useTranslationStore = create<TranslationStore>((set) => ({
   config: { provider: "google", inputTargetLanguage: "en", outputTargetLanguage: "en" },
   setConfig: (config) => set({ config }),
   translations: {},
+  translationSources: {},
   hiddenTranslationIds: {},
   translating: {},
-  setTranslation: (id, text) =>
+  setTranslation: (id, text, source) =>
     set((s) => {
       const { [id]: _, ...hiddenRest } = s.hiddenTranslationIds;
       return {
         translations: { ...s.translations, [id]: text },
+        translationSources:
+          source === undefined ? s.translationSources : { ...s.translationSources, [id]: source },
         hiddenTranslationIds: hiddenRest,
       };
     }),
   removeTranslation: (id) =>
     set((s) => {
       const { [id]: _, ...rest } = s.translations;
-      return { translations: rest, hiddenTranslationIds: { ...s.hiddenTranslationIds, [id]: true } };
+      const { [id]: __, ...sourceRest } = s.translationSources;
+      return {
+        translations: rest,
+        translationSources: sourceRest,
+        hiddenTranslationIds: { ...s.hiddenTranslationIds, [id]: true },
+      };
     }),
   setTranslating: (id, val) => set((s) => ({ translating: { ...s.translating, [id]: val } })),
-  clearAll: () => set({ translations: {}, translating: {}, hiddenTranslationIds: {} }),
+  clearAll: () => set({ translations: {}, translationSources: {}, translating: {}, hiddenTranslationIds: {} }),
   seedFromMessages: (messages) =>
     set((s) => {
       const seeded: Record<string, string> = {};
+      const seededSources: Record<string, string> = {};
       for (const msg of messages) {
         if (!msg.extra) continue;
         try {
@@ -67,12 +80,16 @@ export const useTranslationStore = create<TranslationStore>((set) => ({
             !s.hiddenTranslationIds[msg.id]
           ) {
             seeded[msg.id] = extra.translation;
+            if (typeof msg.content === "string") seededSources[msg.id] = msg.content;
           }
         } catch {
           // Skip messages with malformed extra JSON
         }
       }
       // Merge with existing (in-flight translations win over seeded)
-      return { translations: { ...seeded, ...s.translations } };
+      return {
+        translations: { ...seeded, ...s.translations },
+        translationSources: { ...seededSources, ...s.translationSources },
+      };
     }),
 }));

--- a/packages/client/src/stores/ui.store.ts
+++ b/packages/client/src/stores/ui.store.ts
@@ -3,6 +3,7 @@
 // ──────────────────────────────────────────────
 import { create } from "zustand";
 import { createJSONStorage, persist } from "zustand/middleware";
+import { generateClientId } from "../lib/utils";
 import {
   IMAGE_STYLE_PROFILES_STORAGE_KEY,
   normalizeImageStyleProfileSettings,
@@ -411,6 +412,13 @@ export interface CustomTheme {
   installedAt: string;
 }
 
+/** A user-defined quick reply that sends a fixed prompt, macro, or slash command. */
+export interface CustomQuickReply {
+  id: string;
+  label: string;
+  content: string;
+}
+
 interface UIState {
   sidebarOpen: boolean;
   sidebarWidth: number;
@@ -582,6 +590,8 @@ interface UIState {
   showQuickReplyPostOnly: boolean;
   showQuickReplyGuide: boolean;
   showQuickReplyImpersonate: boolean;
+  /** User-defined quick replies that send a fixed prompt, macro, or slash command. */
+  customQuickReplies: CustomQuickReply[];
   confirmBeforeDelete: boolean;
   /** When true, chat exports include saved thinking/reasoning metadata. */
   includeReasoningInExports: boolean;
@@ -882,6 +892,9 @@ interface UIState {
   setShowQuickReplyPostOnly: (v: boolean) => void;
   setShowQuickReplyGuide: (v: boolean) => void;
   setShowQuickReplyImpersonate: (v: boolean) => void;
+  addCustomQuickReply: (label: string, content: string) => void;
+  updateCustomQuickReply: (id: string, patch: Partial<Omit<CustomQuickReply, "id">>) => void;
+  removeCustomQuickReply: (id: string) => void;
   setConfirmBeforeDelete: (v: boolean) => void;
   setIncludeReasoningInExports: (v: boolean) => void;
   setMessagesPerPage: (n: number) => void;
@@ -1076,6 +1089,7 @@ export function pickSyncedSettings(state: UIState) {
     showQuickReplyPostOnly: state.showQuickReplyPostOnly,
     showQuickReplyGuide: state.showQuickReplyGuide,
     showQuickReplyImpersonate: state.showQuickReplyImpersonate,
+    customQuickReplies: state.customQuickReplies,
     confirmBeforeDelete: state.confirmBeforeDelete,
     includeReasoningInExports: state.includeReasoningInExports,
     messagesPerPage: state.messagesPerPage,
@@ -1261,6 +1275,7 @@ export const useUIStore = create<UIState>()(
       showQuickReplyPostOnly: true,
       showQuickReplyGuide: true,
       showQuickReplyImpersonate: true,
+      customQuickReplies: [],
       confirmBeforeDelete: true,
       includeReasoningInExports: false,
       messagesPerPage: 20,
@@ -1993,6 +2008,23 @@ export const useUIStore = create<UIState>()(
       setShowQuickReplyPostOnly: (v) => set({ showQuickReplyPostOnly: v }),
       setShowQuickReplyGuide: (v) => set({ showQuickReplyGuide: v }),
       setShowQuickReplyImpersonate: (v) => set({ showQuickReplyImpersonate: v }),
+      addCustomQuickReply: (label, content) =>
+        set((state) => ({
+          customQuickReplies: [
+            ...state.customQuickReplies,
+            { id: generateClientId(), label: label.trim(), content },
+          ],
+        })),
+      updateCustomQuickReply: (id, patch) =>
+        set((state) => ({
+          customQuickReplies: state.customQuickReplies.map((entry) =>
+            entry.id === id
+              ? { ...entry, ...(patch.label !== undefined ? { label: patch.label } : {}), ...(patch.content !== undefined ? { content: patch.content } : {}) }
+              : entry,
+          ),
+        })),
+      removeCustomQuickReply: (id) =>
+        set((state) => ({ customQuickReplies: state.customQuickReplies.filter((entry) => entry.id !== id) })),
       setConfirmBeforeDelete: (v) => set({ confirmBeforeDelete: v }),
       setIncludeReasoningInExports: (v) => set({ includeReasoningInExports: v }),
       setMessagesPerPage: (n) => set({ messagesPerPage: n }),
@@ -2869,6 +2901,7 @@ export const useUIStore = create<UIState>()(
         showQuickReplyPostOnly: state.showQuickReplyPostOnly,
         showQuickReplyGuide: state.showQuickReplyGuide,
         showQuickReplyImpersonate: state.showQuickReplyImpersonate,
+        customQuickReplies: state.customQuickReplies,
         confirmBeforeDelete: state.confirmBeforeDelete,
         includeReasoningInExports: state.includeReasoningInExports,
         messagesPerPage: state.messagesPerPage,

--- a/packages/shared/src/types/chat.ts
+++ b/packages/shared/src/types/chat.ts
@@ -413,6 +413,8 @@ export interface ChatMetadata {
   translationInputPrompt?: string | null;
   /** AI system prompt for incoming response translation. Supports {{targetLanguage}}. */
   translationOutputPrompt?: string | null;
+  /** Show only the translated text in place of the original message once a translation exists. */
+  translationDisplayOnly?: boolean;
   /** Allow roleplay characters to create direct-message conversation chats with hidden [dm] commands. */
   roleplayDmCommandsEnabled?: boolean;
   /** Chat-scoped Intiface Central WebSocket URL for haptic manual and auto-connect. */


### PR DESCRIPTION
## Why

Two QoL requests from #4024 (maintainer agreed to both in the Discord thread):

1. **Custom quick replies** — like SillyTavern's, users want to define their own quick-reply buttons that send a fixed prompt/macro/command, instead of only the three built-in actions (Post only / Guide reply / Impersonate).
2. **Translation display options** — translations currently render *below* the original, doubling message length (painful on mobile), and translated text isn't formatted (no markdown). Requested: an option to show only the translation, and markdown formatting for translated text.

## What changed

### Custom quick replies
- `ui.store.ts`: new persisted `customQuickReplies` list (`{ id, label, content }`) with `addCustomQuickReply` / `updateCustomQuickReply` / `removeCustomQuickReply`.
- `SettingsPanel.tsx`: a **Custom quick replies** manager inside **Settings → General → Quick replies** (add / edit label + content / remove).
- `ChatInput.tsx` (Roleplay/Game) and `ConversationInput.tsx` (Conversation): custom entries are appended to the quick replies menu; selecting one writes its content into the composer and sends it through the normal send path, so macros and `/slash` commands execute as if typed.

### Translation display options
- `packages/shared` `ChatMetadata`: new `translationDisplayOnly?: boolean`.
- `TranslationSection.tsx`: **Show Only Translation** toggle.
- `ChatMessage.tsx`: translated text now renders through the same `renderContent` markdown pipeline as messages (bold/italics/quotes) in both the Conversation and Roleplay surfaces; when *Show Only Translation* is on and a translation exists, the translation replaces the original in place instead of appearing below it.

## Notes / decisions
- Custom quick replies appear only when the **Quick replies** menu is enabled (they live in that menu); the manager is in that same settings block.
- Empty-content custom replies are skipped in the menu; an empty label falls back to a truncated preview of the content.
- User-visible strings use the existing `useLocalizedUiText()` pattern used by the surrounding quick-reply settings (English source, community locales fall back to English).

## Test plan

- [ ] In **Settings → General → Quick replies**, add a custom reply (label + a `/slash` command, e.g. `/sys ...`); confirm it appears in the quick replies menu beside Send in a Roleplay chat and a Conversation chat, and that selecting it runs the command.
- [ ] Add a custom reply whose content is plain text with a `{{macro}}`; confirm the macro resolves when sent.
- [ ] Confirm custom replies persist across reload and can be edited/removed.
- [ ] In **Chat Settings → Translation**, enable **Show Only Translation**; translate a message and confirm only the translation shows, with markdown (bold/italics) rendered; disable it and confirm both original and translation show.
- [ ] Verify translated markdown renders in both Conversation and Roleplay message surfaces.
- [ ] `pnpm check` passes. (It passed in the authoring session; re-verify locally.)

Fixes #4024.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Create and manage custom Quick Replies for fixed messages, macros, or slash commands.
  * Use custom Quick Replies directly from the chat Send menu.
  * Enable **Show Only Translation** in Chat Settings to replace original text with translated content.
* **Improvements**
  * Translations now retain consistent markdown formatting with regular messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->