### PR TITLE
fix(convo): stop messages staying truncated when the staggered reveal is interrupted (#4039)

### DIFF
--- a/packages/client/src/components/chat/ConversationView.tsx
+++ b/packages/client/src/components/chat/ConversationView.tsx
@@ -1070,6 +1070,9 @@ export function ConversationView({
           if (!renderedMessageKeysRef.current.has(key)) {
             staggerTimersRef.current[key]?.forEach(clearTimeout);
             delete staggerTimersRef.current[key];
+            // Reveal fully so an interrupted stagger never leaves the message
+            // permanently truncated at a part boundary (#4039).
+            setVisiblePartCounts((prev) => ({ ...prev, [key]: count }));
             return;
           }
           setVisiblePartCounts((prev) => ({ ...prev, [key]: partIndex }));
@@ -1093,6 +1096,9 @@ export function ConversationView({
           if (!renderedMessageKeysRef.current.has(key)) {
             staggerTimersRef.current[key]?.forEach(clearTimeout);
             delete staggerTimersRef.current[key];
+            // Reveal fully so an interrupted stagger never leaves the message
+            // permanently truncated at a speaker-segment boundary (#4039).
+            setVisibleSegmentCounts((prev) => ({ ...prev, [key]: count }));
             return;
           }
           setVisibleSegmentCounts((prev) => ({ ...prev, [key]: segmentIndex }));


### PR DESCRIPTION
## Why

Reported in #4039: in Conversation mode (since the multi-character convo work), messages intermittently display only part of their content — cut off around a `word:` / `Speaker:` boundary — while editing the message reveals that the full content was generated and stored.

**Root cause (it's not the segmentation regex):** I reproduced the speaker/name segmentation directly and it handles `word:` correctly — nothing is dropped there. The truncation is in the **staggered reveal**. Multi-speaker (or classic multi-part) assistant messages reveal their segments/parts one at a time, 1.5s apart, by ratcheting `visibleSegmentCounts[key]` / `visiblePartCounts[key]` from 1 up to the full count. Each stagger timer bails early when the message is not currently rendered (scrolled out of view / virtualized) — but it bailed **without advancing the count**, leaving the stored value stuck at a partial number. The render then caps the message at that stale value (`visibleSegmentCounts[key] ?? fullCount`), so everything after the last-revealed `Speaker:` boundary stays hidden until the chat is switched. Editing bypasses the segmented render, which is why it shows the full text.

## What changed

`packages/client/src/components/chat/ConversationView.tsx` — in both stagger loops (parts and segments), when a reveal timer bails because the message isn't rendered, it now sets the visible count to the **full** count before clearing itself, instead of leaving it stuck partway. An interrupted reveal therefore shows the complete message when it re-renders, rather than staying truncated.

No change to the segmentation regexes or the normal (uninterrupted) reveal animation.

## Test plan

- [ ] In a multi-character Conversation, generate a long message with several `Speaker:` segments; while it is revealing, scroll it out of view and back, then confirm the whole message is shown (not cut off at a `Speaker:`/`word:` line).
- [ ] Repeat in classic message style with a multi-line assistant message (multi-part reveal).
- [ ] Confirm the normal staggered reveal still animates for a message that stays on screen.
- [ ] Confirm editing a message still shows full content, and that switching chats and back shows full content.
- [ ] `pnpm check` passes. (Passed in the authoring session; re-verify locally.)

Fixes #4039.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed interrupted assistant messages occasionally remaining partially hidden.
  * Messages now complete their reveal correctly when interrupted or unmounted during display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->