### PR TITLE
feat(chat-settings): inline prompt-preset editing + remembered section state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 
 ### Changed
 
+- Reworked the Chat Settings **Prompt Preset** area. Roleplay now shows the preset-section editor directly once a preset is selected instead of hiding it behind a collapsible toggle. Conversation and Game show the effective Conversation/Game prompt (from the selected preset, or the built-in default when the preset has none) in an inline editor you can type in directly, expand to a full window, and browse macros from — and the redundant "open selected preset" shortcut button was removed. Chat Settings now also remembers which sections you left expanded and restores them the next time you open the drawer.
 - Confined Professor Mari's raw shell commands to macOS Seatbelt or Linux Bubblewrap with outbound network denied, inherited server secrets removed, environment-secret and Git-internal files unreadable, and filesystem writes limited to ordinary workspace files and a private temporary directory. Dependency manifests, lockfiles, launchers, installers, and CI workflows are read-only in the shell and use an explicit in-chat review; raw package-manager mutations are blocked even when a package is cached. Raw shell now fails closed when no supported sandbox is available, while structured workspace and app-data tools remain available (#3973).
 - Made **Default Dialogue Color** permanently active for cards without their own dialogue color and removed its redundant Appearance toggle; Character and Persona card colors still take priority.
 

--- a/packages/client/src/components/chat/ChatSettingsDrawer.tsx
+++ b/packages/client/src/components/chat/ChatSettingsDrawer.tsx
@@ -4397,7 +4397,6 @@ export function ChatSettingsDrawer({
                 customPrompt={(metadata.customSystemPrompt as string) ?? ""}
                 promptPresetId={effectiveModePromptPresetId}
                 promptPresets={promptPresetOptions}
-                selectedPresetName={selectedModePromptPreset?.name ?? null}
                 selectedPresetPrompt={selectedModePromptPreset?.conversationPrompt ?? ""}
                 onCustomPromptChange={(id, customSystemPrompt) => updateMeta.mutate({ id, customSystemPrompt })}
                 onPromptPresetChange={handleModePromptPresetChange}

--- a/packages/client/src/components/chat/ChatSettingsDrawer.tsx
+++ b/packages/client/src/components/chat/ChatSettingsDrawer.tsx
@@ -956,7 +956,6 @@ export function ChatSettingsDrawer({
   const musicPlayerSource = useUIStore((s) => s.musicPlayerSource);
   const setMusicPlayerSource = useUIStore((s) => s.setMusicPlayerSource);
   const openToolDetail = useUIStore((s) => s.openToolDetail);
-  const openPresetDetail = useUIStore((s) => s.openPresetDetail);
   const debugMode = useUIStore((s) => s.debugMode);
   const setEditorDirty = useUIStore((s) => s.setEditorDirty);
   const openLorebookDetail = useUIStore((s) => s.openLorebookDetail);
@@ -3197,7 +3196,6 @@ export function ChatSettingsDrawer({
   const [showSummariesModal, setShowSummariesModal] = useState(false);
   const [showAgentSuiteModal, setShowAgentSuiteModal] = useState(false);
   const [showMemoriesModal, setShowMemoriesModal] = useState(false);
-  const [quickPresetEditorOpen, setQuickPresetEditorOpen] = useState(false);
   const [inlineResourceEditor, setInlineResourceEditor] = useState<{
     kind: "character" | "persona" | "lorebook";
     id: string;
@@ -3207,7 +3205,6 @@ export function ChatSettingsDrawer({
   }, []);
   useEffect(() => {
     setInlineResourceEditor(null);
-    setQuickPresetEditorOpen(false);
   }, [chat.id]);
   const handleAgentSuiteCloseGuardChange = useCallback((guard: (() => Promise<boolean>) | null) => {
     agentSuiteCloseGuardRef.current = guard;
@@ -3342,8 +3339,6 @@ export function ChatSettingsDrawer({
       ),
     [availableAgents],
   );
-  const [gamePromptDraft, setGamePromptDraft] = useState((metadata.gameSystemPrompt as string) ?? "");
-  const [gamePromptExpanded, setGamePromptExpanded] = useState(false);
   const [gameSpecialInstructionsDraft, setGameSpecialInstructionsDraft] = useState(
     (metadata.gameSpecialInstructions as string) ?? "",
   );
@@ -3404,10 +3399,6 @@ export function ChatSettingsDrawer({
   }, [campaignArtStyle, chat.id]);
 
   useEffect(() => {
-    setGamePromptDraft((metadata.gameSystemPrompt as string) ?? "");
-  }, [chat.id, metadata.gameSystemPrompt]);
-
-  useEffect(() => {
     modePromptDefaultAppliedRef.current = null;
   }, [chat.id]);
 
@@ -3441,18 +3432,11 @@ export function ChatSettingsDrawer({
         updateMeta.mutate({ id: chat.id, customSystemPrompt: null });
       }
       if (isGame) {
-        setGamePromptDraft("");
         updateMeta.mutate({ id: chat.id, gameSystemPrompt: null });
       }
     },
     [chat.id, fallbackPromptPreset?.id, isConversation, isGame, setPreset, updateMeta],
   );
-
-  const openSelectedModePromptPreset = useCallback(() => {
-    if (!effectiveModePromptPresetId) return;
-    onClose();
-    openPresetDetail(effectiveModePromptPresetId);
-  }, [effectiveModePromptPresetId, onClose, openPresetDetail]);
 
   const openAgentAddModal = (agent: AvailableAgent) => {
     setAgentAddCadenceInputFocused(false);
@@ -4396,12 +4380,10 @@ export function ChatSettingsDrawer({
                     </Suspense>
                   ) : null
                 }
-                quickEditorOpen={quickPresetEditorOpen}
                 showLorebookMarkerWarning={showLorebookMarkerWarning}
                 onEditVariables={() => {
                   if (chat.promptPresetId) setChoiceModalPresetId(chat.promptPresetId);
                 }}
-                onQuickEditorToggle={() => setQuickPresetEditorOpen((current) => !current)}
                 onPromptPresetChange={setPreset}
               />
             </div>
@@ -4419,7 +4401,6 @@ export function ChatSettingsDrawer({
                 selectedPresetPrompt={selectedModePromptPreset?.conversationPrompt ?? ""}
                 onCustomPromptChange={(id, customSystemPrompt) => updateMeta.mutate({ id, customSystemPrompt })}
                 onPromptPresetChange={handleModePromptPresetChange}
-                onOpenPromptPreset={openSelectedModePromptPreset}
               />
             </div>
           )}
@@ -4427,13 +4408,10 @@ export function ChatSettingsDrawer({
           {isGame && (
             <div style={{ order: CHAT_SETTINGS_ORDER.promptPreset }}>
               <GameExtraPromptSection
-                expanded={gamePromptExpanded}
                 storedValue={(metadata.gameSystemPrompt as string) ?? ""}
-                value={gamePromptDraft}
                 specialInstructionsValue={gameSpecialInstructionsDraft}
                 promptPresetId={effectiveModePromptPresetId}
                 promptPresets={promptPresetOptions}
-                selectedPresetName={selectedModePromptPreset?.name ?? null}
                 selectedPresetPrompt={selectedModePromptPreset?.gamePrompt ?? ""}
                 gmPromptTemplateId={selectedGameGmPromptTemplateId}
                 gmPromptTemplates={GAME_GM_BUILT_IN_PROMPT_TEMPLATES}
@@ -4441,12 +4419,9 @@ export function ChatSettingsDrawer({
                 onSpecialInstructionsCommit={(gameSpecialInstructions) =>
                   updateMeta.mutate({ id: chat.id, gameSpecialInstructions })
                 }
-                onExpandedChange={setGamePromptExpanded}
-                onValueChange={setGamePromptDraft}
                 onSpecialInstructionsChange={setGameSpecialInstructionsDraft}
                 onPromptPresetChange={handleModePromptPresetChange}
                 onGmPromptTemplateChange={updateGameGmPromptTemplateSelection}
-                onOpenPromptPreset={openSelectedModePromptPreset}
               />
             </div>
           )}

--- a/packages/client/src/features/chat-settings/ChatSettingsSection.tsx
+++ b/packages/client/src/features/chat-settings/ChatSettingsSection.tsx
@@ -2,8 +2,11 @@ import { useEffect, useState, type CSSProperties, type ReactNode, type KeyboardE
 import { ChevronDown } from "lucide-react";
 import { cn } from "../../lib/utils";
 import { HelpTooltip } from "../../components/ui/HelpTooltip";
+import { useUIStore } from "../../stores/ui.store";
 
 interface ChatSettingsSectionProps {
+  /** Stable id used to remember this section's expand/collapse state across reopens. */
+  id?: string;
   label: string;
   icon?: ReactNode;
   count?: number;
@@ -14,6 +17,7 @@ interface ChatSettingsSectionProps {
 }
 
 export function ChatSettingsSection({
+  id,
   label,
   icon,
   count,
@@ -22,11 +26,19 @@ export function ChatSettingsSection({
   initialOpen = false,
   children,
 }: ChatSettingsSectionProps) {
-  const [open, setOpen] = useState(initialOpen);
+  const rememberedOpen = useUIStore((s) => (id ? s.chatSettingsExpandedSections[id] : undefined));
+  const setSectionExpanded = useUIStore((s) => s.setChatSettingsSectionExpanded);
+  // Remembered state wins once it exists; otherwise fall back to initialOpen.
+  const [open, setOpen] = useState(rememberedOpen ?? initialOpen);
   useEffect(() => {
-    if (initialOpen) setOpen(true);
-  }, [initialOpen]);
-  const toggleOpen = () => setOpen((o) => !o);
+    if (rememberedOpen === undefined && initialOpen) setOpen(true);
+  }, [initialOpen, rememberedOpen]);
+  const toggleOpen = () =>
+    setOpen((current) => {
+      const next = !current;
+      if (id) setSectionExpanded(id, next);
+      return next;
+    });
   const handleHeaderKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
     if (event.target !== event.currentTarget) return;
     if (event.key !== "Enter" && event.key !== " ") return;

--- a/packages/client/src/features/chat-settings/sections/ChatNameSection.tsx
+++ b/packages/client/src/features/chat-settings/sections/ChatNameSection.tsx
@@ -20,6 +20,7 @@ export function ChatNameSection({
 }: ChatNameSectionProps) {
   return (
     <ChatSettingsSection
+      id="chat-name"
       label="Chat Name"
       icon={<LetterText size="0.875rem" />}
       help="This name is only visible to you — it won't be sent to the AI or affect the conversation in any way."

--- a/packages/client/src/features/chat-settings/sections/CombatStyleSection.tsx
+++ b/packages/client/src/features/chat-settings/sections/CombatStyleSection.tsx
@@ -12,6 +12,7 @@ interface CombatStyleSectionProps {
 export function CombatStyleSection({ style, combatStyle, onCombatStyleChange }: CombatStyleSectionProps) {
   return (
     <ChatSettingsSection
+      id="combat-style"
       style={style}
       label="Combat Style"
       icon={<Swords size="0.875rem" />}

--- a/packages/client/src/features/chat-settings/sections/ConnectionSection.tsx
+++ b/packages/client/src/features/chat-settings/sections/ConnectionSection.tsx
@@ -20,6 +20,7 @@ export function ConnectionSection({ connectionId, connections, isGame, onConnect
 
   return (
     <ChatSettingsSection
+      id="connection"
       label="Connection"
       icon={<Plug size="0.875rem" />}
       help={

--- a/packages/client/src/features/chat-settings/sections/ConversationPromptSection.tsx
+++ b/packages/client/src/features/chat-settings/sections/ConversationPromptSection.tsx
@@ -3,7 +3,6 @@ import { RotateCcw, Sliders } from "lucide-react";
 import { DEFAULT_CONVERSATION_PROMPT } from "@marinara-engine/shared";
 import { MacroTextarea } from "../../../components/ui/MacroTextarea";
 import { ChatSettingsSection } from "../ChatSettingsSection";
-import { useTranslation as useUiTranslation } from "react-i18next";
 
 interface PromptPresetOption {
   id: string;
@@ -16,7 +15,6 @@ interface ConversationPromptSectionProps {
   customPrompt: string;
   promptPresetId: string | null;
   promptPresets: PromptPresetOption[];
-  selectedPresetName: string | null;
   selectedPresetPrompt: string;
   onCustomPromptChange: (chatId: string, customPrompt: string | null) => void;
   onPromptPresetChange: (presetId: string | null) => void;
@@ -31,7 +29,6 @@ export function ConversationPromptSection({
   onCustomPromptChange,
   onPromptPresetChange,
 }: ConversationPromptSectionProps) {
-  const { t: localizeUi } = useUiTranslation();
   const basePrompt = selectedPresetPrompt.trim() || DEFAULT_CONVERSATION_PROMPT;
   // The textarea always shows the effective prompt: the chat's local edit if it
   // has one, otherwise the preset's (or the built-in default). Editing it saves
@@ -51,35 +48,25 @@ export function ConversationPromptSection({
     setDraft(basePrompt);
   };
 
-  const sourceLabel = customPrompt
-    ? localizeUi("settings.notifications.customSound.status.custom")
-    : promptPresetId
-      ? localizeUi("chat.toolbar.preset")
-      : localizeUi("ui.noodle.noodlehome.default");
+  const sourceLabel = customPrompt ? "Custom" : promptPresetId ? "Preset" : "Default";
 
   return (
     <ChatSettingsSection
       id="conversation-prompt"
-      label={localizeUi("ui.chatSettings.conversationpromptsection.promptPreset")}
+      label="Prompt Preset"
       icon={<Sliders size="0.875rem" />}
-      help={localizeUi("ui.chatSettings.conversationpromptsection.chooseAPresetSConversationPromptThenOptionallyEdit")}
+      help="Choose a preset's Conversation prompt, then optionally edit a chat-local copy."
     >
       <div className="space-y-2">
         <label className="flex flex-col gap-1.5">
-          <span className="text-[0.6875rem] font-medium text-[var(--muted-foreground)]">
-            {localizeUi("ui.chatSettings.conversationpromptsection.promptSource")}
-          </span>
+          <span className="text-[0.6875rem] font-medium text-[var(--muted-foreground)]">Prompt source</span>
           <select
             value={promptPresetId ?? ""}
             onChange={(event) => onPromptPresetChange(event.target.value || null)}
             disabled={promptPresets.length === 0}
             className="mari-preset-native-select min-w-0 flex-1 truncate rounded-lg bg-[var(--secondary)] px-3 py-2 pr-8 text-xs text-[var(--foreground)] outline-none ring-1 ring-[var(--border)] transition-shadow focus:ring-[var(--primary)]/40 disabled:cursor-not-allowed disabled:opacity-60"
           >
-            <option value="">
-              {promptPresets.length === 0
-                ? localizeUi("ui.chatSettings.conversationpromptsection.noPresetsAvailable")
-                : localizeUi("ui.chatSettings.conversationpromptsection.defaultConversationPrompt")}
-            </option>
+            <option value="">{promptPresets.length === 0 ? "No presets available" : "Default conversation prompt"}</option>
             {promptPresets.length > 0 &&
               promptPresets.map((preset) => (
                 <option key={preset.id} value={preset.id}>
@@ -90,9 +77,7 @@ export function ConversationPromptSection({
         </label>
 
         <div className="flex items-center justify-between gap-2">
-          <span className="text-[0.6875rem] font-medium text-[var(--muted-foreground)]">
-            {localizeUi("ui.chatSettings.conversationpromptsection.conversationPrompt")}
-          </span>
+          <span className="text-[0.6875rem] font-medium text-[var(--foreground)]">Conversation Prompt</span>
           <div className="flex shrink-0 items-center gap-1.5">
             <span className="rounded-full bg-[var(--background)] px-2 py-0.5 text-[0.5625rem] font-medium text-[var(--muted-foreground)] ring-1 ring-[var(--border)]">
               {sourceLabel}
@@ -102,7 +87,7 @@ export function ConversationPromptSection({
                 type="button"
                 onClick={resetPrompt}
                 className="flex items-center justify-center rounded-lg bg-[var(--secondary)] px-2 py-1 text-[0.625rem] text-[var(--muted-foreground)] ring-1 ring-[var(--border)] transition-colors hover:bg-[var(--accent)] hover:text-[var(--foreground)]"
-                title={localizeUi("ui.chatSettings.conversationpromptsection.resetToDefaultPrompt")}
+                title="Reset to default prompt"
               >
                 <RotateCcw size="0.625rem" />
               </button>
@@ -115,8 +100,8 @@ export function ConversationPromptSection({
           onChange={setDraft}
           onBlur={commitDraft}
           onExpandedClose={commitDraft}
-          title={localizeUi("ui.chatSettings.conversationpromptsection.editConversationPrompt")}
-          placeholder={localizeUi("ui.chatSettings.conversationpromptsection.enterYourCustomConversationPrompt")}
+          title="Edit Conversation Prompt"
+          placeholder="Enter your custom conversation prompt..."
           rows={6}
           className="mari-editor-field min-h-[9rem] w-full p-3 font-mono text-xs"
           spellCheck={false}

--- a/packages/client/src/features/chat-settings/sections/ConversationPromptSection.tsx
+++ b/packages/client/src/features/chat-settings/sections/ConversationPromptSection.tsx
@@ -1,8 +1,9 @@
-import { useState } from "react";
-import { ExternalLink, Pencil, Sliders, Trash2 } from "lucide-react";
+import { useEffect, useState } from "react";
+import { RotateCcw, Sliders } from "lucide-react";
 import { DEFAULT_CONVERSATION_PROMPT } from "@marinara-engine/shared";
-import { ExpandedTextarea } from "../../../components/ui/ExpandedTextarea";
+import { MacroTextarea } from "../../../components/ui/MacroTextarea";
 import { ChatSettingsSection } from "../ChatSettingsSection";
+import { useTranslation as useUiTranslation } from "react-i18next";
 
 interface PromptPresetOption {
   id: string;
@@ -19,7 +20,6 @@ interface ConversationPromptSectionProps {
   selectedPresetPrompt: string;
   onCustomPromptChange: (chatId: string, customPrompt: string | null) => void;
   onPromptPresetChange: (presetId: string | null) => void;
-  onOpenPromptPreset: () => void;
 }
 
 export function ConversationPromptSection({
@@ -27,115 +27,101 @@ export function ConversationPromptSection({
   customPrompt,
   promptPresetId,
   promptPresets,
-  selectedPresetName,
   selectedPresetPrompt,
   onCustomPromptChange,
   onPromptPresetChange,
-  onOpenPromptPreset,
 }: ConversationPromptSectionProps) {
-  const [promptOpen, setPromptOpen] = useState(false);
-  const [promptDraft, setPromptDraft] = useState("");
+  const { t: localizeUi } = useUiTranslation();
   const basePrompt = selectedPresetPrompt.trim() || DEFAULT_CONVERSATION_PROMPT;
+  // The textarea always shows the effective prompt: the chat's local edit if it
+  // has one, otherwise the preset's (or the built-in default). Editing it saves
+  // a chat-local override; clearing it back to the base drops the override.
+  const [draft, setDraft] = useState(customPrompt || basePrompt);
+  useEffect(() => {
+    setDraft(customPrompt || basePrompt);
+  }, [customPrompt, basePrompt]);
 
-  const openPromptEditor = () => {
-    setPromptDraft(customPrompt || basePrompt);
-    setPromptOpen(true);
-  };
-
-  const closePromptEditor = () => {
-    const isPresetPrompt = promptDraft.trim() === basePrompt.trim();
-    const nextPrompt = !promptDraft.trim() || isPresetPrompt ? null : promptDraft;
-    onCustomPromptChange(chatId, nextPrompt);
-    setPromptOpen(false);
+  const commitDraft = () => {
+    const isBasePrompt = draft.trim() === basePrompt.trim();
+    onCustomPromptChange(chatId, !draft.trim() || isBasePrompt ? null : draft);
   };
 
   const resetPrompt = () => {
     onCustomPromptChange(chatId, null);
+    setDraft(basePrompt);
   };
 
+  const sourceLabel = customPrompt
+    ? localizeUi("settings.notifications.customSound.status.custom")
+    : promptPresetId
+      ? localizeUi("chat.toolbar.preset")
+      : localizeUi("ui.noodle.noodlehome.default");
+
   return (
-    <>
-      <ChatSettingsSection
-        label="Prompt Preset"
-        icon={<Sliders size="0.875rem" />}
-        help="Choose a preset's Conversation prompt, then optionally edit a chat-local copy."
-      >
-        <div className="space-y-2">
-          <label className="flex flex-col gap-1.5">
-            <span className="text-[0.6875rem] font-medium text-[var(--muted-foreground)]">Prompt source</span>
-            <div className="flex items-center gap-1.5">
-              <select
-                value={promptPresetId ?? ""}
-                onChange={(event) => onPromptPresetChange(event.target.value || null)}
-                disabled={promptPresets.length === 0}
-                className="mari-preset-native-select min-w-0 flex-1 truncate rounded-lg bg-[var(--secondary)] px-3 py-2 pr-8 text-xs text-[var(--foreground)] outline-none ring-1 ring-[var(--border)] transition-shadow focus:ring-[var(--primary)]/40 disabled:cursor-not-allowed disabled:opacity-60"
-              >
-                <option value="">{promptPresets.length === 0 ? "No presets available" : "Default conversation prompt"}</option>
-                {promptPresets.length > 0 &&
-                  promptPresets.map((preset) => (
-                    <option key={preset.id} value={preset.id}>
-                      {preset.name}
-                    </option>
-                  ))}
-              </select>
-              <button
-                type="button"
-                onClick={onOpenPromptPreset}
-                disabled={!promptPresetId}
-                className="mari-chrome-control mari-chrome-control--small shrink-0 px-2 py-2 text-[0.625rem] disabled:cursor-not-allowed disabled:opacity-45"
-                title="Open selected preset"
-              >
-                <ExternalLink size="0.75rem" />
-                <span className="max-sm:hidden">Preset</span>
-              </button>
-            </div>
-          </label>
-          <div className="flex items-center justify-between gap-2 rounded-lg bg-[var(--secondary)] px-3 py-2 ring-1 ring-[var(--border)]">
-            <div className="min-w-0">
-              <span className="block text-[0.6875rem] font-medium text-[var(--foreground)]">Conversation Prompt</span>
-              <span className="block truncate text-[0.625rem] text-[var(--muted-foreground)]">
-                {customPrompt
-                  ? "Using chat-local edit"
-                  : promptPresetId
-                    ? `From ${selectedPresetName ?? "selected preset"}`
-                    : "Using default conversation prompt"}
-              </span>
-            </div>
-            <span className="shrink-0 rounded-full bg-[var(--background)] px-2 py-0.5 text-[0.5625rem] font-medium text-[var(--muted-foreground)] ring-1 ring-[var(--border)]">
-              {customPrompt ? "Custom" : promptPresetId ? "Preset" : "Default"}
+    <ChatSettingsSection
+      id="conversation-prompt"
+      label={localizeUi("ui.chatSettings.conversationpromptsection.promptPreset")}
+      icon={<Sliders size="0.875rem" />}
+      help={localizeUi("ui.chatSettings.conversationpromptsection.chooseAPresetSConversationPromptThenOptionallyEdit")}
+    >
+      <div className="space-y-2">
+        <label className="flex flex-col gap-1.5">
+          <span className="text-[0.6875rem] font-medium text-[var(--muted-foreground)]">
+            {localizeUi("ui.chatSettings.conversationpromptsection.promptSource")}
+          </span>
+          <select
+            value={promptPresetId ?? ""}
+            onChange={(event) => onPromptPresetChange(event.target.value || null)}
+            disabled={promptPresets.length === 0}
+            className="mari-preset-native-select min-w-0 flex-1 truncate rounded-lg bg-[var(--secondary)] px-3 py-2 pr-8 text-xs text-[var(--foreground)] outline-none ring-1 ring-[var(--border)] transition-shadow focus:ring-[var(--primary)]/40 disabled:cursor-not-allowed disabled:opacity-60"
+          >
+            <option value="">
+              {promptPresets.length === 0
+                ? localizeUi("ui.chatSettings.conversationpromptsection.noPresetsAvailable")
+                : localizeUi("ui.chatSettings.conversationpromptsection.defaultConversationPrompt")}
+            </option>
+            {promptPresets.length > 0 &&
+              promptPresets.map((preset) => (
+                <option key={preset.id} value={preset.id}>
+                  {preset.name}
+                </option>
+              ))}
+          </select>
+        </label>
+
+        <div className="flex items-center justify-between gap-2">
+          <span className="text-[0.6875rem] font-medium text-[var(--muted-foreground)]">
+            {localizeUi("ui.chatSettings.conversationpromptsection.conversationPrompt")}
+          </span>
+          <div className="flex shrink-0 items-center gap-1.5">
+            <span className="rounded-full bg-[var(--background)] px-2 py-0.5 text-[0.5625rem] font-medium text-[var(--muted-foreground)] ring-1 ring-[var(--border)]">
+              {sourceLabel}
             </span>
-          </div>
-          <div className="flex gap-1.5">
-            <button
-              type="button"
-              onClick={openPromptEditor}
-              className="flex flex-1 items-center justify-center gap-1.5 rounded-lg bg-[var(--secondary)] px-3 py-1.5 text-[0.625rem] font-medium text-[var(--foreground)] ring-1 ring-[var(--border)] transition-colors hover:bg-[var(--accent)]"
-            >
-              <Pencil size="0.625rem" />
-              Edit Prompt
-            </button>
             {customPrompt && (
               <button
                 type="button"
                 onClick={resetPrompt}
-                className="flex items-center justify-center rounded-lg bg-[var(--secondary)] px-2.5 py-1.5 text-[0.625rem] text-[var(--muted-foreground)] ring-1 ring-[var(--border)] transition-colors hover:bg-[var(--accent)] hover:text-[var(--foreground)]"
-                title="Reset to default prompt"
+                className="flex items-center justify-center rounded-lg bg-[var(--secondary)] px-2 py-1 text-[0.625rem] text-[var(--muted-foreground)] ring-1 ring-[var(--border)] transition-colors hover:bg-[var(--accent)] hover:text-[var(--foreground)]"
+                title={localizeUi("ui.chatSettings.conversationpromptsection.resetToDefaultPrompt")}
               >
-                <Trash2 size="0.625rem" />
+                <RotateCcw size="0.625rem" />
               </button>
             )}
           </div>
         </div>
-      </ChatSettingsSection>
-      <ExpandedTextarea
-        open={promptOpen}
-        onClose={closePromptEditor}
-        title="Edit Conversation Prompt"
-        value={promptDraft}
-        onChange={setPromptDraft}
-        placeholder="Enter your custom conversation prompt..."
-        surface="chat"
-      />
-    </>
+
+        <MacroTextarea
+          value={draft}
+          onChange={setDraft}
+          onBlur={commitDraft}
+          onExpandedClose={commitDraft}
+          title={localizeUi("ui.chatSettings.conversationpromptsection.editConversationPrompt")}
+          placeholder={localizeUi("ui.chatSettings.conversationpromptsection.enterYourCustomConversationPrompt")}
+          rows={6}
+          className="mari-editor-field min-h-[9rem] w-full p-3 font-mono text-xs"
+          spellCheck={false}
+        />
+      </div>
+    </ChatSettingsSection>
   );
 }

--- a/packages/client/src/features/chat-settings/sections/FunctionCallingSection.tsx
+++ b/packages/client/src/features/chat-settings/sections/FunctionCallingSection.tsx
@@ -46,6 +46,7 @@ export function FunctionCallingSection({
 
   return (
     <ChatSettingsSection
+      id="function-calling"
       label="Function Calling"
       icon={<Wrench size="0.875rem" />}
       count={activeToolIds.length}

--- a/packages/client/src/features/chat-settings/sections/GameExtraPromptSection.tsx
+++ b/packages/client/src/features/chat-settings/sections/GameExtraPromptSection.tsx
@@ -1,6 +1,7 @@
-import { ExternalLink, Pencil, Sliders, Trash2 } from "lucide-react";
+import { useEffect, useState } from "react";
+import { RotateCcw, Sliders } from "lucide-react";
 import { DEFAULT_GAME_SYSTEM_PROMPT, type AgentPromptTemplateOption } from "@marinara-engine/shared";
-import { ExpandedTextarea } from "../../../components/ui/ExpandedTextarea";
+import { MacroTextarea } from "../../../components/ui/MacroTextarea";
 import { ChatSettingsSection } from "../ChatSettingsSection";
 
 interface PromptPresetOption {
@@ -10,182 +11,144 @@ interface PromptPresetOption {
 }
 
 interface GameExtraPromptSectionProps {
-  expanded: boolean;
   storedValue: string;
-  value: string;
   specialInstructionsValue: string;
   promptPresetId: string | null;
   promptPresets: PromptPresetOption[];
-  selectedPresetName: string | null;
   selectedPresetPrompt: string;
   gmPromptTemplateId: string | null;
   gmPromptTemplates: AgentPromptTemplateOption[];
   onCommit: (value: string | null) => void;
   onSpecialInstructionsCommit: (value: string | null) => void;
-  onExpandedChange: (expanded: boolean) => void;
-  onValueChange: (value: string) => void;
   onSpecialInstructionsChange: (value: string) => void;
   onPromptPresetChange: (presetId: string | null) => void;
   onGmPromptTemplateChange: (templateId: string | null) => void;
-  onOpenPromptPreset: () => void;
 }
 
 export function GameExtraPromptSection({
-  expanded,
   storedValue,
-  value,
   specialInstructionsValue,
   promptPresetId,
   promptPresets,
-  selectedPresetName,
   selectedPresetPrompt,
   gmPromptTemplateId,
   gmPromptTemplates,
   onCommit,
   onSpecialInstructionsCommit,
-  onExpandedChange,
-  onValueChange,
   onSpecialInstructionsChange,
   onPromptPresetChange,
   onGmPromptTemplateChange,
-  onOpenPromptPreset,
 }: GameExtraPromptSectionProps) {
   const selectedGmPromptTemplate = gmPromptTemplates.find((template) => template.id === gmPromptTemplateId) ?? null;
   const basePrompt =
     selectedGmPromptTemplate?.promptTemplate.trim() || selectedPresetPrompt.trim() || DEFAULT_GAME_SYSTEM_PROMPT;
+  // Local draft always shows the effective Game prompt (chat-local edit, else
+  // the GM style / preset / built-in default). Editing saves a chat-local copy.
+  const [draft, setDraft] = useState(storedValue || basePrompt);
+  useEffect(() => {
+    setDraft(storedValue || basePrompt);
+  }, [storedValue, basePrompt]);
 
-  const openPromptEditor = () => {
-    onValueChange(storedValue || basePrompt);
-    onExpandedChange(true);
-  };
-
-  const closePromptEditor = () => {
-    const isPresetPrompt = value.trim() === basePrompt.trim();
-    const nextValue = !value.trim() || isPresetPrompt ? null : value;
-    onCommit(nextValue);
-    onExpandedChange(false);
+  const commitDraft = () => {
+    const isBasePrompt = draft.trim() === basePrompt.trim();
+    onCommit(!draft.trim() || isBasePrompt ? null : draft);
   };
 
   const resetPrompt = () => {
-    onValueChange("");
     onCommit(null);
+    setDraft(basePrompt);
   };
 
+  const sourceLabel = storedValue ? "Custom" : selectedGmPromptTemplate ? "Style" : promptPresetId ? "Preset" : "Default";
+
   return (
-    <>
-      <ChatSettingsSection
-        label="Prompt Preset"
-        icon={<Sliders size="0.875rem" />}
-        help="Choose a preset's Game prompt, then optionally edit a chat-local copy."
-      >
-        <div className="space-y-2">
-          <label className="flex flex-col gap-1.5">
-            <span className="text-[0.6875rem] font-medium text-[var(--muted-foreground)]">Prompt source</span>
-            <div className="flex items-center gap-1.5">
-              <select
-                value={promptPresetId ?? ""}
-                onChange={(event) => onPromptPresetChange(event.target.value || null)}
-                disabled={promptPresets.length === 0}
-                className="mari-preset-native-select min-w-0 flex-1 truncate rounded-lg bg-[var(--secondary)] px-3 py-2 pr-8 text-xs text-[var(--foreground)] outline-none ring-1 ring-[var(--border)] transition-shadow focus:ring-[var(--primary)]/40 disabled:cursor-not-allowed disabled:opacity-60"
-              >
-                <option value="">{promptPresets.length === 0 ? "No presets available" : "Default game prompt"}</option>
-                {promptPresets.length > 0 &&
-                  promptPresets.map((preset) => (
-                    <option key={preset.id} value={preset.id}>
-                      {preset.name}
-                    </option>
-                  ))}
-              </select>
-              <button
-                type="button"
-                onClick={onOpenPromptPreset}
-                disabled={!promptPresetId}
-                className="mari-chrome-control mari-chrome-control--small shrink-0 px-2 py-2 text-[0.625rem] disabled:cursor-not-allowed disabled:opacity-45"
-                title="Open selected preset"
-              >
-                <ExternalLink size="0.75rem" />
-                <span className="max-sm:hidden">Preset</span>
-              </button>
-            </div>
-          </label>
-          <label className="flex flex-col gap-1.5">
-            <span className="text-[0.6875rem] font-medium text-[var(--muted-foreground)]">GM prompt style</span>
-            <select
-              value={gmPromptTemplateId ?? ""}
-              onChange={(event) => onGmPromptTemplateChange(event.target.value || null)}
-              className="mari-preset-native-select w-full truncate rounded-lg bg-[var(--secondary)] px-3 py-2 pr-8 text-xs text-[var(--foreground)] outline-none ring-1 ring-[var(--border)] transition-shadow focus:ring-[var(--primary)]/40"
-            >
-              <option value="">Use selected prompt source</option>
-              {gmPromptTemplates.map((template) => (
-                <option key={template.id} value={template.id}>
-                  {template.name}
+    <ChatSettingsSection
+      id="game-prompt"
+      label="Prompt Preset"
+      icon={<Sliders size="0.875rem" />}
+      help="Choose a preset's Game prompt, then optionally edit a chat-local copy."
+    >
+      <div className="space-y-2">
+        <label className="flex flex-col gap-1.5">
+          <span className="text-[0.6875rem] font-medium text-[var(--muted-foreground)]">Prompt source</span>
+          <select
+            value={promptPresetId ?? ""}
+            onChange={(event) => onPromptPresetChange(event.target.value || null)}
+            disabled={promptPresets.length === 0}
+            className="mari-preset-native-select min-w-0 flex-1 truncate rounded-lg bg-[var(--secondary)] px-3 py-2 pr-8 text-xs text-[var(--foreground)] outline-none ring-1 ring-[var(--border)] transition-shadow focus:ring-[var(--primary)]/40 disabled:cursor-not-allowed disabled:opacity-60"
+          >
+            <option value="">{promptPresets.length === 0 ? "No presets available" : "Default game prompt"}</option>
+            {promptPresets.length > 0 &&
+              promptPresets.map((preset) => (
+                <option key={preset.id} value={preset.id}>
+                  {preset.name}
                 </option>
               ))}
-            </select>
-            <span className="text-[0.575rem] leading-relaxed text-[var(--muted-foreground)]">
-              A selected GM style replaces only the Game prompt. A chat-local edit still takes priority.
+          </select>
+        </label>
+        <label className="flex flex-col gap-1.5">
+          <span className="text-[0.6875rem] font-medium text-[var(--muted-foreground)]">GM prompt style</span>
+          <select
+            value={gmPromptTemplateId ?? ""}
+            onChange={(event) => onGmPromptTemplateChange(event.target.value || null)}
+            className="mari-preset-native-select w-full truncate rounded-lg bg-[var(--secondary)] px-3 py-2 pr-8 text-xs text-[var(--foreground)] outline-none ring-1 ring-[var(--border)] transition-shadow focus:ring-[var(--primary)]/40"
+          >
+            <option value="">Use selected prompt source</option>
+            {gmPromptTemplates.map((template) => (
+              <option key={template.id} value={template.id}>
+                {template.name}
+              </option>
+            ))}
+          </select>
+          <span className="text-[0.575rem] leading-relaxed text-[var(--muted-foreground)]">
+            A selected GM style replaces only the Game prompt. A chat-local edit still takes priority.
+          </span>
+        </label>
+
+        <div className="flex items-center justify-between gap-2">
+          <span className="text-[0.6875rem] font-medium text-[var(--foreground)]">Game Prompt</span>
+          <div className="flex shrink-0 items-center gap-1.5">
+            <span className="rounded-full bg-[var(--background)] px-2 py-0.5 text-[0.5625rem] font-medium text-[var(--muted-foreground)] ring-1 ring-[var(--border)]">
+              {sourceLabel}
             </span>
-          </label>
-          <div className="flex items-center justify-between gap-2 rounded-lg bg-[var(--secondary)] px-3 py-2 ring-1 ring-[var(--border)]">
-            <div className="min-w-0">
-              <span className="block text-[0.6875rem] font-medium text-[var(--foreground)]">Game Prompt</span>
-              <span className="block truncate text-[0.625rem] text-[var(--muted-foreground)]">
-                {storedValue
-                  ? "Using chat-local edit"
-                  : selectedGmPromptTemplate
-                    ? `Using ${selectedGmPromptTemplate.name}`
-                    : promptPresetId
-                    ? `From ${selectedPresetName ?? "selected preset"}`
-                    : "Using default game prompt"}
-              </span>
-            </div>
-            <span className="shrink-0 rounded-full bg-[var(--background)] px-2 py-0.5 text-[0.5625rem] font-medium text-[var(--muted-foreground)] ring-1 ring-[var(--border)]">
-              {storedValue ? "Custom" : selectedGmPromptTemplate ? "Style" : promptPresetId ? "Preset" : "Default"}
-            </span>
-          </div>
-          <div className="flex gap-1.5">
-            <button
-              type="button"
-              onClick={openPromptEditor}
-              className="flex flex-1 items-center justify-center gap-1.5 rounded-lg bg-[var(--secondary)] px-3 py-1.5 text-[0.625rem] font-medium text-[var(--foreground)] ring-1 ring-[var(--border)] transition-colors hover:bg-[var(--accent)]"
-            >
-              <Pencil size="0.625rem" />
-              Edit Prompt
-            </button>
             {storedValue && (
               <button
                 type="button"
                 onClick={resetPrompt}
-                className="flex items-center justify-center rounded-lg bg-[var(--secondary)] px-2.5 py-1.5 text-[0.625rem] text-[var(--muted-foreground)] ring-1 ring-[var(--border)] transition-colors hover:bg-[var(--accent)] hover:text-[var(--foreground)]"
+                className="flex items-center justify-center rounded-lg bg-[var(--secondary)] px-2 py-1 text-[0.625rem] text-[var(--muted-foreground)] ring-1 ring-[var(--border)] transition-colors hover:bg-[var(--accent)] hover:text-[var(--foreground)]"
                 title="Reset to default prompt"
               >
-                <Trash2 size="0.625rem" />
+                <RotateCcw size="0.625rem" />
               </button>
             )}
           </div>
-          <label className="flex flex-col gap-1.5">
-            <span className="text-[0.6875rem] font-medium text-[var(--muted-foreground)]">Extra instructions</span>
-            <textarea
-              value={specialInstructionsValue}
-              onChange={(event) => onSpecialInstructionsChange(event.target.value)}
-              onBlur={() => onSpecialInstructionsCommit(specialInstructionsValue.trim() || null)}
-              placeholder="Write in the style of Terry Pratchett."
-              rows={3}
-              maxLength={2000}
-              className="min-h-[5rem] w-full resize-y rounded-lg border border-[var(--border)] bg-[var(--secondary)] px-3 py-2 text-xs leading-relaxed text-[var(--foreground)] outline-none transition-colors placeholder:text-[var(--muted-foreground)]/40 focus:border-[var(--foreground)]/40"
-            />
-          </label>
         </div>
-      </ChatSettingsSection>
-      <ExpandedTextarea
-        open={expanded}
-        onClose={closePromptEditor}
-        title="Edit Game Prompt"
-        value={value}
-        onChange={onValueChange}
-        placeholder="Enter your custom Game Master prompt..."
-        surface="chat"
-      />
-    </>
+
+        <MacroTextarea
+          value={draft}
+          onChange={setDraft}
+          onBlur={commitDraft}
+          onExpandedClose={commitDraft}
+          title="Edit Game Prompt"
+          placeholder="Enter your custom Game Master prompt..."
+          rows={6}
+          className="mari-editor-field min-h-[9rem] w-full p-3 font-mono text-xs"
+          spellCheck={false}
+        />
+
+        <label className="flex flex-col gap-1.5">
+          <span className="text-[0.6875rem] font-medium text-[var(--muted-foreground)]">Extra instructions</span>
+          <textarea
+            value={specialInstructionsValue}
+            onChange={(event) => onSpecialInstructionsChange(event.target.value)}
+            onBlur={() => onSpecialInstructionsCommit(specialInstructionsValue.trim() || null)}
+            placeholder="Write in the style of Terry Pratchett."
+            rows={3}
+            maxLength={2000}
+            className="min-h-[5rem] w-full resize-y rounded-lg border border-[var(--border)] bg-[var(--secondary)] px-3 py-2 text-xs leading-relaxed text-[var(--foreground)] outline-none transition-colors placeholder:text-[var(--muted-foreground)]/40 focus:border-[var(--foreground)]/40"
+          />
+        </label>
+      </div>
+    </ChatSettingsSection>
   );
 }

--- a/packages/client/src/features/chat-settings/sections/ImpersonateSection.tsx
+++ b/packages/client/src/features/chat-settings/sections/ImpersonateSection.tsx
@@ -28,6 +28,7 @@ export function ImpersonateSection({ presets, connections }: ImpersonateSectionP
 
   return (
     <ChatSettingsSection
+      id="impersonate"
       label="Impersonate"
       icon={<Drama size="0.875rem" />}
       help="Global settings applied to every /impersonate generation across all chats."

--- a/packages/client/src/features/chat-settings/sections/LorebooksSection.tsx
+++ b/packages/client/src/features/chat-settings/sections/LorebooksSection.tsx
@@ -62,6 +62,7 @@ export function LorebooksSection({
 
   return (
     <ChatSettingsSection
+      id="lorebooks"
       label="Lorebooks"
       icon={<BookOpen size="0.875rem" />}
       count={activeLorebooks.length}

--- a/packages/client/src/features/chat-settings/sections/PromptPresetSection.tsx
+++ b/packages/client/src/features/chat-settings/sections/PromptPresetSection.tsx
@@ -1,7 +1,6 @@
 import type { ReactNode } from "react";
 import { AlertTriangle, ChevronDown, Layers, Pencil, Sliders } from "lucide-react";
 import { useTranslation } from "react-i18next";
-import { cn } from "../../../lib/utils";
 import { ChatSettingsSection } from "../ChatSettingsSection";
 
 interface PromptPresetOption {
@@ -17,10 +16,8 @@ interface PromptPresetSectionProps {
   presets: PromptPresetOption[];
   hasVariables: boolean;
   quickEditor: ReactNode;
-  quickEditorOpen: boolean;
   showLorebookMarkerWarning: boolean;
   onEditVariables: () => void;
-  onQuickEditorToggle: () => void;
   onPromptPresetChange: (presetId: string | null) => void;
 }
 
@@ -29,10 +26,8 @@ export function PromptPresetSection({
   presets,
   hasVariables,
   quickEditor,
-  quickEditorOpen,
   showLorebookMarkerWarning,
   onEditVariables,
-  onQuickEditorToggle,
   onPromptPresetChange,
 }: PromptPresetSectionProps) {
   const { t } = useTranslation();
@@ -40,6 +35,7 @@ export function PromptPresetSection({
 
   return (
     <ChatSettingsSection
+      id="prompt-preset"
       label="Prompt Preset"
       icon={<Sliders size="0.875rem" />}
       help="Presets control how the system prompt is structured and what generation parameters are used. Different presets produce different AI behaviors."
@@ -85,38 +81,16 @@ export function PromptPresetSection({
       )}
       {promptPresetId && (
         <div className="mt-2">
-          <div className="flex items-center gap-1.5">
-            <button
-              type="button"
-              onClick={onQuickEditorToggle}
-              aria-expanded={quickEditorOpen}
-              className="relative flex min-w-0 flex-1 items-center gap-2 rounded-lg bg-[var(--secondary)] px-3 py-2 pr-8 text-left text-xs font-medium text-[var(--foreground)] ring-1 ring-[var(--border)] transition-colors hover:bg-[var(--accent)]"
-            >
-              <Layers size="0.75rem" className="shrink-0 text-[var(--primary)]" />
-              <span className="min-w-0 flex-1 truncate">
-                {t(
-                  quickEditorOpen
-                    ? "chat.settings.promptPreset.quickEdit.hide"
-                    : "chat.settings.promptPreset.quickEdit.show",
-                )}
-              </span>
-              <ChevronDown
-                data-prompt-preset-chevron="quick-editor"
-                aria-hidden
-                size="0.75rem"
-                className={cn(PROMPT_PRESET_CHEVRON_CLASS, "transition-transform", quickEditorOpen && "rotate-180")}
-              />
-            </button>
-            {showVariableEditor && <span aria-hidden className="h-7 w-7 shrink-0" />}
+          <div className="mb-2 flex items-center gap-2 px-0.5 text-xs font-medium text-[var(--foreground)]">
+            <Layers size="0.75rem" className="shrink-0 text-[var(--primary)]" />
+            <span className="min-w-0 flex-1 truncate">{t("chat.settings.promptPreset.quickEdit.title")}</span>
           </div>
-          {quickEditorOpen && (
-            <div className="mt-2 rounded-lg border border-[var(--border)] bg-transparent p-2">
-              <p className="mb-2 px-1 text-[0.625rem] leading-relaxed text-[var(--muted-foreground)]">
-                {t("chat.settings.promptPreset.quickEdit.autoSave")}
-              </p>
-              {quickEditor}
-            </div>
-          )}
+          <div className="rounded-lg border border-[var(--border)] bg-transparent p-2">
+            <p className="mb-2 px-1 text-[0.625rem] leading-relaxed text-[var(--muted-foreground)]">
+              {t("chat.settings.promptPreset.quickEdit.autoSave")}
+            </p>
+            {quickEditor}
+          </div>
         </div>
       )}
     </ChatSettingsSection>

--- a/packages/client/src/features/chat-settings/sections/SceneInstructionsSection.tsx
+++ b/packages/client/src/features/chat-settings/sections/SceneInstructionsSection.tsx
@@ -25,6 +25,7 @@ export function SceneInstructionsSection({
 
   return (
     <ChatSettingsSection
+      id="scene-instructions"
       label="Scene Instructions"
       icon={<Sparkles size="0.875rem" />}
       help="The system prompt generated for this scene. You can edit it to change the AI's writing style, POV, tone, and focus."

--- a/packages/client/src/features/chat-settings/sections/TranslationSection.tsx
+++ b/packages/client/src/features/chat-settings/sections/TranslationSection.tsx
@@ -34,6 +34,7 @@ export function TranslationSection({ metadata, textConnections, onMetadataChange
 
   return (
     <ChatSettingsSection
+      id="translation"
       label="Translation"
       icon={<Languages size="0.875rem" />}
       help="Configure translation for this chat here, including provider, target language, and automatic response translation for Game mode."

--- a/packages/client/src/localization/locales/en.json
+++ b/packages/client/src/localization/locales/en.json
@@ -101,6 +101,7 @@
   "chat.settings.promptPreset.quickEdit.loading": "Loading preset editor…",
   "chat.settings.promptPreset.quickEdit.missing": "This preset could not be loaded.",
   "chat.settings.promptPreset.quickEdit.show": "Edit preset sections",
+  "chat.settings.promptPreset.quickEdit.title": "Preset sections",
   "chat.summary.toolbarLabel": "Chat Summary",
   "chat.summary.toolbarLabelWithCount_one": "Chat Summary ({{count}} active summary)",
   "chat.summary.toolbarLabelWithCount_other": "Chat Summary ({{count}} active summaries)",

--- a/packages/client/src/stores/ui.store.ts
+++ b/packages/client/src/stores/ui.store.ts
@@ -596,6 +596,8 @@ interface UIState {
   showQuickReplyImpersonate: boolean;
   /** User-defined quick replies that send a fixed prompt, macro, or slash command. */
   customQuickReplies: CustomQuickReply[];
+  /** Remembered expand/collapse state of Chat Settings sections, keyed by section id. */
+  chatSettingsExpandedSections: Record<string, boolean>;
   confirmBeforeDelete: boolean;
   /** When true, chat exports include saved thinking/reasoning metadata. */
   includeReasoningInExports: boolean;
@@ -899,6 +901,7 @@ interface UIState {
   addCustomQuickReply: (label: string, content: string) => void;
   updateCustomQuickReply: (id: string, patch: Partial<Omit<CustomQuickReply, "id">>) => void;
   removeCustomQuickReply: (id: string) => void;
+  setChatSettingsSectionExpanded: (id: string, open: boolean) => void;
   setConfirmBeforeDelete: (v: boolean) => void;
   setIncludeReasoningInExports: (v: boolean) => void;
   setMessagesPerPage: (n: number) => void;
@@ -1094,6 +1097,7 @@ export function pickSyncedSettings(state: UIState) {
     showQuickReplyGuide: state.showQuickReplyGuide,
     showQuickReplyImpersonate: state.showQuickReplyImpersonate,
     customQuickReplies: state.customQuickReplies,
+    chatSettingsExpandedSections: state.chatSettingsExpandedSections,
     confirmBeforeDelete: state.confirmBeforeDelete,
     includeReasoningInExports: state.includeReasoningInExports,
     messagesPerPage: state.messagesPerPage,
@@ -1282,6 +1286,7 @@ export const useUIStore = create<UIState>()(
       showQuickReplyGuide: true,
       showQuickReplyImpersonate: true,
       customQuickReplies: [],
+      chatSettingsExpandedSections: {},
       confirmBeforeDelete: true,
       includeReasoningInExports: false,
       messagesPerPage: 20,
@@ -2033,6 +2038,10 @@ export const useUIStore = create<UIState>()(
         })),
       removeCustomQuickReply: (id) =>
         set((state) => ({ customQuickReplies: state.customQuickReplies.filter((entry) => entry.id !== id) })),
+      setChatSettingsSectionExpanded: (id, open) =>
+        set((state) => ({
+          chatSettingsExpandedSections: { ...state.chatSettingsExpandedSections, [id]: open },
+        })),
       setConfirmBeforeDelete: (v) => set({ confirmBeforeDelete: v }),
       setIncludeReasoningInExports: (v) => set({ includeReasoningInExports: v }),
       setMessagesPerPage: (n) => set({ messagesPerPage: n }),
@@ -2910,6 +2919,7 @@ export const useUIStore = create<UIState>()(
         showQuickReplyGuide: state.showQuickReplyGuide,
         showQuickReplyImpersonate: state.showQuickReplyImpersonate,
         customQuickReplies: state.customQuickReplies,
+        chatSettingsExpandedSections: state.chatSettingsExpandedSections,
         confirmBeforeDelete: state.confirmBeforeDelete,
         includeReasoningInExports: state.includeReasoningInExports,
         messagesPerPage: state.messagesPerPage,


### PR DESCRIPTION
## Why

Change request for the Chat Settings **Prompt Preset** area:

1. Roleplay's "Edit preset sections" was hidden behind a collapsible toggle — it should always be available once a preset is selected.
2. Conversation/Game show a Conversation/Game prompt derived from the selected preset (or the default when the preset has none), but editing was a separate modal. The prompt should be editable **inline**, with the option to expand the editor and view macros.
3. The "open selected preset" shortcut button in Conversation/Game is unnecessary.
4. Chat Settings should remember which drawer sections were left expanded and restore them on reopen, for easier repeat edits.

## What changed

- **`PromptPresetSection.tsx` (Roleplay)** — once a preset is selected, the preset-section editor renders directly (no collapsible toggle). Removed the `quickEditorOpen`/`onQuickEditorToggle` props and the drawer's `quickPresetEditorOpen` state.
- **`ConversationPromptSection.tsx` / `GameExtraPromptSection.tsx`** — the effective prompt (chat-local edit → preset prompt → built-in default) is now edited inline via **`MacroTextarea`** (type directly, expand to a full window, browse the macro reference). Editing saves a chat-local override; clearing back to the base drops it. Removed the modal-only "Edit Prompt" flow and the "open selected preset" (`ExternalLink`) button, plus the now-unused drawer state/callbacks (`gamePromptDraft`, `gamePromptExpanded`, `openSelectedModePromptPreset`).
- **`ChatSettingsSection.tsx` + `ui.store.ts`** — each section takes a stable `id`; expand/collapse is persisted in `chatSettingsExpandedSections` and restored on reopen. Applied ids to all 11 sections.

## Test plan

- [ ] Roleplay with a preset selected: the preset-section editor is visible without any expand toggle; edits autosave.
- [ ] Conversation: pick a preset, confirm its Conversation prompt shows inline and is editable; expand the editor and confirm the macro reference is available; edits persist as a chat-local override; the reset control returns to the preset/default; with no preset it shows/edits the built-in default.
- [ ] Game: same as Conversation for the Game prompt; GM prompt style select and Extra instructions still work.
- [ ] Confirm the "open selected preset" button is gone from Conversation and Game.
- [ ] Expand a couple of Chat Settings sections, collapse others, close and reopen the drawer (and switch chats) — the expanded/collapsed state is remembered.
- [ ] `pnpm check` passes. (Passed in the authoring session; re-verify locally.)

Note: no linked issue — this is a direct maintainer change request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Prompt presets now display effective prompts in an inline, editable editor for Conversation and Game modes.
  * Roleplay preset editing opens immediately after selection.
  * Added macro browsing, reset-to-default controls, and clearer prompt source indicators.
  * Chat Settings sections now remember their expanded or collapsed state between visits.
* **Documentation**
  * Updated release notes to document the Prompt Preset interface changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->