### PR TITLE
fix(chat-settings): keep drawer open behind macro modals + match preset field styling

### DIFF
--- a/packages/client/src/components/chat/ChatSettingsDrawer.tsx
+++ b/packages/client/src/components/chat/ChatSettingsDrawer.tsx
@@ -4120,6 +4120,10 @@ export function ChatSettingsDrawer({
       if (!(target instanceof Node)) return;
       if (panelRef.current?.contains(target)) return;
       if (target instanceof Element && target.closest("[data-chat-floating-panel]")) return;
+      // The expanded prompt editor and the macro reference render in a portal
+      // outside the drawer panel; interacting with them must not close Chat
+      // Settings — only their own close controls should.
+      if (target instanceof Element && target.closest("[data-macro-modal]")) return;
       requestClose();
     };
 

--- a/packages/client/src/components/ui/MacroTextarea.tsx
+++ b/packages/client/src/components/ui/MacroTextarea.tsx
@@ -120,6 +120,7 @@ function ExpandedMacroEditor({
     <MacroModalPortal>
       <div
         data-component="ExpandedMacroEditor"
+        data-macro-modal="true"
         className={cn(
           "fixed inset-0 z-[140] flex items-center justify-center bg-black/70 p-3 pb-[max(env(safe-area-inset-bottom),0.75rem)] pt-[max(env(safe-area-inset-top),0.75rem)] backdrop-blur-sm sm:p-4",
           EDITOR_MODAL_SURFACE_VARIABLES,
@@ -187,6 +188,8 @@ function MacrosReferenceModal({ open, onClose }: MacrosReferenceModalProps) {
   return (
     <MacroModalPortal>
       <div
+        data-component="MacroReference"
+        data-macro-modal="true"
         className={cn(
           "fixed inset-0 z-[145] flex items-center justify-center bg-black/70 p-3 pb-[max(env(safe-area-inset-bottom),0.75rem)] pt-[max(env(safe-area-inset-top),0.75rem)] backdrop-blur-sm sm:p-4",
           EDITOR_MODAL_SURFACE_VARIABLES,

--- a/packages/client/src/features/chat-settings/sections/ConversationPromptSection.tsx
+++ b/packages/client/src/features/chat-settings/sections/ConversationPromptSection.tsx
@@ -95,17 +95,19 @@ export function ConversationPromptSection({
           </div>
         </div>
 
-        <MacroTextarea
-          value={draft}
-          onChange={setDraft}
-          onBlur={commitDraft}
-          onExpandedClose={commitDraft}
-          title="Edit Conversation Prompt"
-          placeholder="Enter your custom conversation prompt..."
-          rows={6}
-          className="mari-editor-field min-h-[9rem] w-full p-3 font-mono text-xs"
-          spellCheck={false}
-        />
+        <div className="mari-quick-preset-editor">
+          <MacroTextarea
+            value={draft}
+            onChange={setDraft}
+            onBlur={commitDraft}
+            onExpandedClose={commitDraft}
+            title="Edit Conversation Prompt"
+            placeholder="Enter your custom conversation prompt..."
+            rows={6}
+            className="mari-editor-field min-h-[9rem] w-full p-3 font-mono text-xs"
+            spellCheck={false}
+          />
+        </div>
       </div>
     </ChatSettingsSection>
   );

--- a/packages/client/src/features/chat-settings/sections/GameExtraPromptSection.tsx
+++ b/packages/client/src/features/chat-settings/sections/GameExtraPromptSection.tsx
@@ -124,17 +124,19 @@ export function GameExtraPromptSection({
           </div>
         </div>
 
-        <MacroTextarea
-          value={draft}
-          onChange={setDraft}
-          onBlur={commitDraft}
-          onExpandedClose={commitDraft}
-          title="Edit Game Prompt"
-          placeholder="Enter your custom Game Master prompt..."
-          rows={6}
-          className="mari-editor-field min-h-[9rem] w-full p-3 font-mono text-xs"
-          spellCheck={false}
-        />
+        <div className="mari-quick-preset-editor">
+          <MacroTextarea
+            value={draft}
+            onChange={setDraft}
+            onBlur={commitDraft}
+            onExpandedClose={commitDraft}
+            title="Edit Game Prompt"
+            placeholder="Enter your custom Game Master prompt..."
+            rows={6}
+            className="mari-editor-field min-h-[9rem] w-full p-3 font-mono text-xs"
+            spellCheck={false}
+          />
+        </div>
 
         <label className="flex flex-col gap-1.5">
           <span className="text-[0.6875rem] font-medium text-[var(--muted-foreground)]">Extra instructions</span>


### PR DESCRIPTION
## Why

Two follow-ups to the merged #4046 (Chat Settings prompt-preset UX), from maintainer feedback:

1. Opening **Edit Conversation/Game Prompt** (the expanded editor) or the **Macros** window from a Prompt Preset section, then closing it, also closed the whole Chat Settings drawer.
2. The Conversation/Game prompt fields didn't match the Roleplay preset-section fields — they showed a dark blue (`--secondary`) background instead of the neutral chat-chrome field surface.

## Root causes

1. `MacroTextarea`'s expanded editor and macro reference render in a portal on `document.body`, outside the Chat Settings panel. The drawer closes on any `pointerdown` outside its panel, so clicking inside those windows (including their backdrop/close button) triggered the drawer's outside-close.
2. The Roleplay preset editor renders inside the `mari-quick-preset-editor` scope, whose `.mari-editor-field` rule swaps the field background to the neutral chat-chrome input surface. The Conversation/Game `MacroTextarea` wasn't in that scope, so `mari-editor-field` fell back to the dark `--secondary`.

## What changed

- `MacroTextarea.tsx`: tag both portal overlays (expanded editor + macro reference) with `data-macro-modal`.
- `ChatSettingsDrawer.tsx`: the outside-pointerdown close now ignores targets inside `[data-macro-modal]`, so only the windows' own close controls dismiss them — the drawer stays open.
- `ConversationPromptSection.tsx` / `GameExtraPromptSection.tsx`: wrap the prompt `MacroTextarea` in the `mari-quick-preset-editor` scope so its field matches the Roleplay preset-section styling.

## Test plan

- [ ] In Conversation and Game chat settings, open the prompt's expanded editor; close it (X, backdrop, Escape) and confirm Chat Settings stays open.
- [ ] Open the Macros window from the prompt field; close it and confirm Chat Settings stays open.
- [ ] Confirm clicking genuinely outside the drawer (not on a macro window) still closes Chat Settings.
- [ ] Confirm the Conversation/Game prompt fields now use the same neutral field surface as the Roleplay preset-section editor (no dark blue background), in light and dark themes.
- [ ] `pnpm check` passes. (Passed in the authoring session; re-verify locally.)

Follow-up to #4046. No linked issue — direct maintainer change request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented the chat settings drawer from closing when interacting with expanded prompt or macro editors.
  * Improved the stability of prompt editing in conversation and game settings.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->