### PR TITLE
Fix mobile composer overlap with Android Firefox keyboard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,9 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 
 ### Fixed
 
+- Kept the mobile chat composer above the Android Firefox software keyboard by explicitly requesting content
+  resizing and sizing the app shell to the smallest live visual/layout viewport, including delayed keyboard geometry
+  updates after focus (#4044).
 - Improved character and persona card version history: restoring an older version now saves the current card to history first (so the newer version is never lost), each saved version keeps its own edit timestamp instead of the later save's time, and the side-by-side comparison view wraps long unbroken text such as URLs and HTML in creator notes instead of overflowing (#4040).
 - Stopped Conversation **Selfie** mode from pasting the image style profile's Generation Style Text verbatim into the final image prompt. The style now guides the prompt-building model (matching Roleplay illustration), so it still shapes the image without the redundant, CLIP-diluting copy (#4028).
 - Moved the Natural/Random progression choice onto the **Push Story** button: clicking it now opens a Naturally/Randomly selector that arms the chosen mode for the next response, replacing the mode controls previously buried in **Chat Settings → Agents → Narrative Director**, the add-agent setup, and the Narrative Director editor's Story Push Mode default (#4022).

--- a/e2e/core-flows.e2e.ts
+++ b/e2e/core-flows.e2e.ts
@@ -7063,6 +7063,94 @@ test("memory recall modal accepts clicks from chat settings", async ({ page }, t
   await expect(drawer.getByRole("heading", { name: "Chat Settings" })).toBeVisible();
 });
 
+test("mobile chat composer follows the visual viewport above the software keyboard", async ({ page }, testInfo) => {
+  test.skip(!testInfo.project.name.includes("mobile"), "Software-keyboard viewport behavior is mobile-only.");
+
+  const response = await page.request.post("/api/chats", {
+    data: {
+      name: "Mobile Keyboard Viewport Smoke",
+      mode: "roleplay",
+      characterIds: [],
+    },
+  });
+  expect(response.ok()).toBeTruthy();
+  const chat = (await response.json()) as { id: string };
+
+  await page.addInitScript(() => {
+    const state = {
+      height: window.innerHeight,
+      offsetTop: 0,
+    };
+    const viewport = new EventTarget();
+    Object.defineProperties(viewport, {
+      height: { configurable: true, get: () => state.height },
+      offsetTop: { configurable: true, get: () => state.offsetTop },
+      offsetLeft: { configurable: true, get: () => 0 },
+      pageLeft: { configurable: true, get: () => 0 },
+      pageTop: { configurable: true, get: () => state.offsetTop },
+      scale: { configurable: true, get: () => 1 },
+      width: { configurable: true, get: () => window.innerWidth },
+    });
+    Object.defineProperty(window, "visualViewport", {
+      configurable: true,
+      value: viewport,
+    });
+    Object.defineProperty(window, "__setMarinaraVisualViewport", {
+      configurable: true,
+      value: (height: number, offsetTop: number) => {
+        state.height = height;
+        state.offsetTop = offsetTop;
+        viewport.dispatchEvent(new Event("resize"));
+        viewport.dispatchEvent(new Event("scroll"));
+      },
+    });
+  });
+  await page.addInitScript((chatId) => {
+    localStorage.setItem("marinara-active-chat-id", chatId);
+  }, chat.id);
+
+  try {
+    await page.goto("/");
+
+    const viewportMeta = page.locator('meta[name="viewport"]');
+    await expect(viewportMeta).toHaveAttribute("content", /interactive-widget=resizes-content/);
+
+    const shell = page.locator('[data-component="AppShell"]');
+    const composer = page.locator(".chat-input-container:visible");
+    const textarea = composer.locator("textarea:visible");
+    await expect(textarea).toBeVisible();
+    await textarea.focus();
+
+    await page.evaluate(() => {
+      (
+        window as typeof window & {
+          __setMarinaraVisualViewport: (height: number, offsetTop: number) => void;
+        }
+      ).__setMarinaraVisualViewport(360, 72);
+    });
+
+    await expect
+      .poll(() =>
+        page.evaluate(() => ({
+          height: getComputedStyle(document.documentElement).getPropertyValue("--mari-visual-viewport-height").trim(),
+          top: getComputedStyle(document.documentElement)
+            .getPropertyValue("--mari-visual-viewport-offset-top")
+            .trim(),
+        })),
+      )
+      .toEqual({ height: "360px", top: "72px" });
+
+    const [shellBox, composerBox] = await Promise.all([shell.boundingBox(), composer.boundingBox()]);
+    expect(shellBox).not.toBeNull();
+    expect(composerBox).not.toBeNull();
+    expect(Math.abs(shellBox!.y - 72)).toBeLessThanOrEqual(1);
+    expect(Math.abs(shellBox!.height - 360)).toBeLessThanOrEqual(1);
+    expect(composerBox!.y + composerBox!.height).toBeLessThanOrEqual(432);
+  } finally {
+    await page.request.delete(`/api/chats/${chat.id}`).catch(() => undefined);
+  }
+});
+
 test("mobile topbar remains reachable while sidebars switch", async ({ page }, testInfo) => {
   test.skip(!testInfo.project.name.includes("mobile"), "Mobile shell smoke only runs in the mobile project.");
 

--- a/e2e/core-flows.e2e.ts
+++ b/e2e/core-flows.e2e.ts
@@ -7145,6 +7145,7 @@ test("mobile chat composer follows the visual viewport above the software keyboa
     expect(composerBox).not.toBeNull();
     expect(Math.abs(shellBox!.y - 72)).toBeLessThanOrEqual(1);
     expect(Math.abs(shellBox!.height - 360)).toBeLessThanOrEqual(1);
+    expect(composerBox!.y).toBeGreaterThanOrEqual(72);
     expect(composerBox!.y + composerBox!.height).toBeLessThanOrEqual(432);
   } finally {
     await page.request.delete(`/api/chats/${chat.id}`).catch(() => undefined);

--- a/packages/client/index.html
+++ b/packages/client/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <meta
       name="viewport"
-      content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no, viewport-fit=cover"
+      content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no, viewport-fit=cover, interactive-widget=resizes-content"
     />
     <meta name="description" content="Marinara Engine — RPG chat and roleplay engine" />
     <meta name="theme-color" content="#0a0a0f" />

--- a/packages/client/src/components/layout/AppShell.tsx
+++ b/packages/client/src/components/layout/AppShell.tsx
@@ -211,27 +211,51 @@ export function AppShell() {
     if (typeof window === "undefined" || typeof document === "undefined") return;
     const root = document.documentElement;
     let frame = 0;
-    const updateVisualViewportHeight = () => {
+    let focusTimers: number[] = [];
+    const updateVisualViewportGeometry = () => {
       if (frame) cancelAnimationFrame(frame);
       frame = requestAnimationFrame(() => {
-        const height = window.visualViewport?.height ?? window.innerHeight;
+        frame = 0;
+        const viewport = window.visualViewport;
+        const heightCandidates = [viewport?.height, window.innerHeight, root.clientHeight].filter(
+          (value): value is number => typeof value === "number" && Number.isFinite(value) && value > 0,
+        );
+        const height = heightCandidates.length > 0 ? Math.min(...heightCandidates) : window.innerHeight;
+        const maxOffsetTop = Math.max(0, window.innerHeight - height);
+        const offsetTop = Math.min(maxOffsetTop, Math.max(0, viewport?.offsetTop ?? 0));
         root.style.setProperty("--mari-visual-viewport-height", `${Math.max(0, Math.round(height))}px`);
+        root.style.setProperty("--mari-visual-viewport-offset-top", `${Math.round(offsetTop)}px`);
       });
     };
+    const refreshAfterFocusChange = () => {
+      focusTimers.forEach((timer) => window.clearTimeout(timer));
+      focusTimers = [];
+      updateVisualViewportGeometry();
+      // Android browsers can publish the keyboard-adjusted viewport after the
+      // focus event. Re-sample both the early animation and settled geometry.
+      focusTimers.push(window.setTimeout(updateVisualViewportGeometry, 80));
+      focusTimers.push(window.setTimeout(updateVisualViewportGeometry, 320));
+    };
 
-    updateVisualViewportHeight();
-    window.visualViewport?.addEventListener("resize", updateVisualViewportHeight);
-    window.visualViewport?.addEventListener("scroll", updateVisualViewportHeight);
-    window.addEventListener("resize", updateVisualViewportHeight);
-    window.addEventListener("orientationchange", updateVisualViewportHeight);
+    updateVisualViewportGeometry();
+    window.visualViewport?.addEventListener("resize", updateVisualViewportGeometry);
+    window.visualViewport?.addEventListener("scroll", updateVisualViewportGeometry);
+    window.addEventListener("resize", updateVisualViewportGeometry);
+    window.addEventListener("orientationchange", updateVisualViewportGeometry);
+    document.addEventListener("focusin", refreshAfterFocusChange);
+    document.addEventListener("focusout", refreshAfterFocusChange);
 
     return () => {
       if (frame) cancelAnimationFrame(frame);
-      window.visualViewport?.removeEventListener("resize", updateVisualViewportHeight);
-      window.visualViewport?.removeEventListener("scroll", updateVisualViewportHeight);
-      window.removeEventListener("resize", updateVisualViewportHeight);
-      window.removeEventListener("orientationchange", updateVisualViewportHeight);
+      focusTimers.forEach((timer) => window.clearTimeout(timer));
+      window.visualViewport?.removeEventListener("resize", updateVisualViewportGeometry);
+      window.visualViewport?.removeEventListener("scroll", updateVisualViewportGeometry);
+      window.removeEventListener("resize", updateVisualViewportGeometry);
+      window.removeEventListener("orientationchange", updateVisualViewportGeometry);
+      document.removeEventListener("focusin", refreshAfterFocusChange);
+      document.removeEventListener("focusout", refreshAfterFocusChange);
       root.style.removeProperty("--mari-visual-viewport-height");
+      root.style.removeProperty("--mari-visual-viewport-offset-top");
     };
   }, []);
 

--- a/packages/client/src/styles/globals.css
+++ b/packages/client/src/styles/globals.css
@@ -4758,6 +4758,13 @@ strong {
     padding-right: env(safe-area-inset-right);
   }
 
+  .mari-app {
+    top: var(--mari-visual-viewport-offset-top, 0px);
+    bottom: auto;
+    height: var(--mari-visual-viewport-height, 100dvh);
+    min-height: 0;
+  }
+
   .app-sidebar-mobile {
     position: fixed !important;
     inset: 0 !important;


### PR DESCRIPTION
## Why

Android Firefox can expose a software-keyboard-adjusted visual viewport while leaving fixed content anchored to the larger layout viewport. Marinara already measured `visualViewport.height`, but only used that value to cap the textarea height; the fixed app shell and its bottom-anchored composer still extended beneath the keyboard.

## What changed

- Requests `interactive-widget=resizes-content` in the viewport metadata so supporting mobile browsers resize page content for the software keyboard.
- Tracks the smallest live visual, window, and document viewport height plus the visual viewport offset.
- Re-samples viewport geometry after focus because Android browsers can publish keyboard dimensions after the initial focus event.
- Sizes and positions the complete mobile app shell from those values, keeping Conversation, Roleplay, and Game composers within the visible region.
- Adds a mobile browser regression that simulates a reduced and vertically shifted visual viewport and verifies the Roleplay composer remains above its bottom edge.
- Documents the fix in the v2.3.5 changelog.

## Validation so far

- Focused mobile Playwright keyboard-viewport regression: 1 passed
- `git diff --check`

## Manual verification requested

- [ ] Manually verify the composer stays above the keyboard in Android Firefox through a Tailscale connection.
- [ ] Manually verify Conversation, Roleplay, and Game inputs with the keyboard opening and closing.
- [ ] Manually verify Android Chrome and the native Android shell do not gain an empty lower gap.

Closes #4044


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved mobile chat layout behavior on Android Firefox so the composer remains visible above the software keyboard.
  - App content now adjusts to changing visual viewport size and position, including delayed keyboard transitions.
  - Added responsive handling to keep the mobile app shell correctly sized and positioned.

- **Tests**
  - Added mobile end-to-end coverage for keyboard-related viewport resizing and composer positioning.

- **Documentation**
  - Updated the unreleased changelog with the Android Firefox keyboard layout fix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->