### PR TITLE
Fix chat settings and chroma UI consistency

### DIFF
--- a/e2e/core-flows.e2e.ts
+++ b/e2e/core-flows.e2e.ts
@@ -338,6 +338,323 @@ test("default dialogue color fills only cards without their own dialogue color",
   }
 });
 
+test("Chat Settings adds a formatted greeting after the setup wizard is skipped", async ({
+  page,
+  request,
+}, testInfo) => {
+  test.skip(!testInfo.project.name.includes("desktop"), "Greeting chooser behavior is covered on desktop.");
+
+  const suffix = Date.now().toString(36);
+  const characterName = `Greeting Choice ${suffix}`;
+  const firstGreeting = '*The chalk pauses over the diagram.* "Observe."';
+  const alternateGreeting = '*The page turns to a fresh proof.* "Begin here."';
+  const characterResponse = await request.post("/api/characters", {
+    data: {
+      data: {
+        name: characterName,
+        first_mes: firstGreeting,
+        alternate_greetings: [alternateGreeting],
+        extensions: { dialogueColor: "#22c55e" },
+      },
+    },
+  });
+  expect(characterResponse.ok()).toBeTruthy();
+  const character = (await characterResponse.json()) as { id: string };
+
+  const chatResponse = await request.post("/api/chats", {
+    data: {
+      name: "Skipped Setup Greeting Smoke",
+      mode: "roleplay",
+      characterIds: [],
+    },
+  });
+  expect(chatResponse.ok()).toBeTruthy();
+  const chat = (await chatResponse.json()) as { id: string };
+
+  await page.addInitScript((chatId) => {
+    localStorage.setItem("marinara-active-chat-id", chatId);
+    const persisted = JSON.parse(localStorage.getItem("marinara-engine-ui") ?? '{"state":{}}') as {
+      state?: Record<string, unknown>;
+    };
+    persisted.state = { ...(persisted.state ?? {}), chatFontColor: "#345678" };
+    localStorage.setItem("marinara-engine-ui", JSON.stringify(persisted));
+  }, chat.id);
+
+  try {
+    await page.goto("/");
+    await page.evaluate(() => {
+      document.documentElement.style.setProperty("--marinara-chat-chrome-panel-text", "rgb(12, 34, 56)");
+    });
+    await page.evaluate(async () => {
+      const { useChatStore } = (await import("/src/stores/chat.store.ts")) as {
+        useChatStore: {
+          getState: () => {
+            setShouldOpenSettings: (open: boolean) => void;
+            setShouldOpenWizard: (open: boolean) => void;
+          };
+        };
+      };
+      useChatStore.getState().setShouldOpenWizard(true);
+      useChatStore.getState().setShouldOpenSettings(true);
+    });
+    await expect(page.getByRole("heading", { name: "New Roleplay", exact: true })).toBeVisible();
+    await page.getByRole("button", { name: "Skip", exact: true }).click();
+
+    const drawer = page.locator(".mari-chat-settings-drawer");
+    await expect(drawer).toBeVisible();
+    await drawer.getByText("Characters", { exact: true }).first().click();
+    await drawer.getByRole("button", { name: "Add Character", exact: true }).click();
+    await drawer.getByPlaceholder("Search characters").fill(characterName);
+    await drawer.getByText(characterName, { exact: true }).click();
+
+    const greetingDialog = page.getByRole("dialog", { name: "Choose a Greeting", exact: true });
+    await expect(greetingDialog).toBeVisible();
+    await expect(greetingDialog.locator('[data-component="ChatSettingsDrawer.GreetingDialogHeader"] svg')).toHaveCount(
+      0,
+    );
+    await expect(
+      greetingDialog.getByText(`Choose which greeting ${characterName} should use when joining this chat.`),
+    ).toHaveCSS("color", "rgb(12, 34, 56)");
+
+    const firstOption = greetingDialog.getByRole("button", { name: /First Message/ });
+    await expect(firstOption.locator(".mari-message-content").first()).toHaveCSS("color", "rgb(52, 86, 120)");
+    await expect(firstOption.locator(".mari-message-content strong").first()).toHaveCSS("color", "rgb(34, 197, 94)");
+
+    await greetingDialog.getByRole("button", { name: /Alternate Greeting #1/ }).click();
+    await expect(drawer).toBeVisible();
+    await greetingDialog.getByRole("button", { name: "Add Selected Greeting", exact: true }).click();
+    await expect(greetingDialog).toBeHidden();
+    await expect(drawer).toBeVisible();
+
+    let greetingMessageId = "";
+    await expect
+      .poll(async () => {
+        const messagesResponse = await request.get(`/api/chats/${chat.id}/messages`);
+        const messages = (await messagesResponse.json()) as Array<{
+          id: string;
+          role: string;
+          content: string;
+          characterId?: string | null;
+        }>;
+        const greeting = messages.find((message) => message.content === alternateGreeting);
+        greetingMessageId = greeting?.id ?? "";
+        return greeting ? { role: greeting.role, characterId: greeting.characterId, content: greeting.content } : null;
+      })
+      .toEqual({
+        role: "assistant",
+        characterId: character.id,
+        content: alternateGreeting,
+      });
+    await expect(page.locator(`[data-message-id="${greetingMessageId}"]`)).toBeVisible();
+  } finally {
+    await Promise.allSettled([
+      request.delete(`/api/chats/${chat.id}`),
+      request.delete(`/api/characters/${character.id}`),
+    ]);
+  }
+});
+
+test("Author's Notes keeps its expand and full macro guide inside the field", async ({ page, request }, testInfo) => {
+  test.skip(!testInfo.project.name.includes("desktop"), "Author's Notes field chrome is covered on desktop.");
+
+  const chatResponse = await request.post("/api/chats", {
+    data: {
+      name: "Author Notes Macro Field Smoke",
+      mode: "roleplay",
+      characterIds: [],
+    },
+  });
+  expect(chatResponse.ok()).toBeTruthy();
+  const chat = (await chatResponse.json()) as { id: string };
+  await page.addInitScript((chatId) => localStorage.setItem("marinara-active-chat-id", chatId), chat.id);
+
+  try {
+    await page.goto("/");
+    await page.getByRole("button", { name: "Author's Notes", exact: true }).filter({ visible: true }).click();
+
+    const heading = page.locator("h3").filter({ hasText: "Author's Notes" });
+    await expect(heading).toBeVisible();
+    const panel = heading.locator("..");
+    const field = panel.locator(".mari-author-notes-field");
+    await expect(field.getByRole("textbox", { name: "Author's Notes", exact: true })).toBeVisible();
+    await expect(heading.getByRole("button", { name: "Expand editor", exact: true })).toHaveCount(0);
+    await expect(field.getByRole("button", { name: "Expand editor", exact: true })).toBeVisible();
+    await expect(field.getByRole("button", { name: "Macro reference", exact: true })).toBeVisible();
+
+    await field.getByRole("button", { name: "Macro reference", exact: true }).click();
+    const macroReference = page.locator('[data-component="MacroReference"]');
+    await expect(macroReference).toBeVisible();
+    await expect(macroReference.getByText("{{charPostHistory}}", { exact: true })).toBeVisible();
+    await expect(macroReference.getByText("{{agent::TYPE}}", { exact: true })).toBeVisible();
+    await expect(macroReference.getByText(/Conditional block with/)).toBeVisible();
+    await macroReference.getByRole("button", { name: "Close macro reference", exact: true }).click();
+    await expect(panel).toBeVisible();
+
+    await field.getByRole("button", { name: "Expand editor", exact: true }).click();
+    const expandedEditor = page.locator('[data-component="ExpandedMacroEditor"]');
+    await expect(expandedEditor).toBeVisible();
+    const savedNotes = '{{#if char == "Albedo"}}Keep {{user}} curious.{{else}}Keep the scene curious.{{/if}}';
+    await expandedEditor.locator("textarea").fill(savedNotes);
+    await expandedEditor.getByRole("button", { name: "Close expanded editor", exact: true }).click();
+    await expect(panel).toBeVisible();
+    await expect
+      .poll(async () => {
+        const storedResponse = await request.get(`/api/chats/${chat.id}`);
+        const stored = (await storedResponse.json()) as { metadata: string | Record<string, unknown> };
+        const metadata =
+          typeof stored.metadata === "string"
+            ? (JSON.parse(stored.metadata) as Record<string, unknown>)
+            : stored.metadata;
+        return metadata.authorNotes;
+      })
+      .toBe(savedNotes);
+  } finally {
+    await request.delete(`/api/chats/${chat.id}`).catch(() => undefined);
+  }
+});
+
+test("Author's Notes resolves the shared prompt macro engine and preset variables", async ({ request }, testInfo) => {
+  test.skip(!testInfo.project.name.includes("desktop"), "Author's Notes prompt resolution is covered once.");
+
+  const suffix = Date.now().toString(36);
+  const characterName = `Author Notes Character ${suffix}`;
+  const personaName = `Author Notes Persona ${suffix}`;
+  const connectionResponse = await request.post("/api/connections", {
+    data: {
+      name: `Author Notes Dry Run ${suffix}`,
+      provider: "custom",
+      baseUrl: "http://127.0.0.1:1/v1",
+      apiKey: "author-notes-e2e",
+      model: "author-notes-model",
+      maxContext: 32768,
+    },
+  });
+  expect(connectionResponse.ok()).toBeTruthy();
+  const connection = (await connectionResponse.json()) as { id: string };
+
+  const characterResponse = await request.post("/api/characters", {
+    data: {
+      data: {
+        name: characterName,
+        description: "A meticulous alchemist.",
+        personality: "Patient and exacting.",
+        scenario: "Inside a mountain laboratory.",
+        mes_example: '"Record every result."',
+        post_history_instructions: "Never lose the thread.",
+        extensions: {
+          backstory: "He has studied this reaction for years.",
+          appearance: "A pale coat and blue gloves.",
+        },
+      },
+    },
+  });
+  expect(characterResponse.ok()).toBeTruthy();
+  const character = (await characterResponse.json()) as { id: string };
+
+  const personaResponse = await request.post("/api/characters/personas", {
+    data: {
+      name: personaName,
+      description: "A curious research partner.",
+      personality: "Inquisitive.",
+      backstory: "Trained in field observation.",
+      appearance: "A dark traveling coat.",
+      scenario: "Assisting with the experiment.",
+    },
+  });
+  expect(personaResponse.ok()).toBeTruthy();
+  const persona = (await personaResponse.json()) as { id: string };
+
+  const presetResponse = await request.post("/api/prompts", {
+    data: {
+      name: `Author Notes Macro Preset ${suffix}`,
+      description: "Author's Notes macro-resolution fixture.",
+      variableValues: { AUTHOR_TONE: "forensic" },
+    },
+  });
+  expect(presetResponse.ok()).toBeTruthy();
+  const preset = (await presetResponse.json()) as { id: string };
+  const sectionResponse = await request.post(`/api/prompts/${preset.id}/sections`, {
+    data: {
+      identifier: `author_notes_base_${suffix}`,
+      name: "Base Prompt",
+      content: "Continue the roleplay.",
+      role: "system",
+    },
+  });
+  expect(sectionResponse.ok()).toBeTruthy();
+
+  const chatResponse = await request.post("/api/chats", {
+    data: {
+      name: "Author Notes Macro Resolution Smoke",
+      mode: "roleplay",
+      characterIds: [character.id],
+      personaId: persona.id,
+      connectionId: connection.id,
+      promptPresetId: preset.id,
+    },
+  });
+  expect(chatResponse.ok()).toBeTruthy();
+  const chat = (await chatResponse.json()) as { id: string };
+  const authorNotes = [
+    "AUTHOR_NOTES_MACRO_PROBE",
+    "identity={{user}}|{{char}}|{{characters}}|{{personaDescription}}",
+    "character={{description}}|{{personality}}|{{backstory}}|{{appearance}}|{{scenario}}|{{example}}|{{charPostHistory}}",
+    "context={{input}}|{{model}}|{{chatId}}|{{lastGenerationType}}",
+    "preset={{AUTHOR_TONE}}",
+    "random={{random:7:7}}|{{roll:1d1}}",
+    "variables={{setvar::count::1}}{{incvar::count}}{{getvar::count}}",
+    "format={{uppercase}}quiet{{/uppercase}}|{{lowercase}}LOUD{{/lowercase}}|A{{newline}}B",
+    `conditional={{#if char == "${characterName}"}}matched{{else}}missed{{/if}}`,
+    "comment={{// hidden}}visible|noop={{noop}}done|agent={{agent::missing-agent}}",
+  ].join("\n");
+  const metadataResponse = await request.patch(`/api/chats/${chat.id}/metadata`, {
+    data: { authorNotes, authorNotesDepth: 0 },
+  });
+  expect(metadataResponse.ok()).toBeTruthy();
+  const messageResponse = await request.post(`/api/chats/${chat.id}/messages`, {
+    data: { role: "user", content: "Measure the blue precipitate." },
+  });
+  expect(messageResponse.ok()).toBeTruthy();
+
+  try {
+    const dryRunResponse = await request.post("/api/generate/dryRun", {
+      data: {
+        chatId: chat.id,
+        returnPrompt: true,
+      },
+    });
+    expect(dryRunResponse.ok()).toBeTruthy();
+    const dryRun = (await dryRunResponse.json()) as {
+      prompt: { messages: Array<{ role: string; content: string }> };
+    };
+    const prompt = dryRun.prompt.messages.map((message) => message.content).join("\n\n");
+    const probe = prompt.slice(prompt.indexOf("AUTHOR_NOTES_MACRO_PROBE"));
+
+    expect(probe).toContain(`identity=${personaName}|${characterName}|${characterName}|A curious research partner.`);
+    expect(probe).toContain(
+      'character=A meticulous alchemist.|Patient and exacting.|He has studied this reaction for years.|A pale coat and blue gloves.|Inside a mountain laboratory.|"Record every result."|Never lose the thread.',
+    );
+    expect(probe).toContain(
+      `context=Measure the blue precipitate.|author-notes-model|${chat.id}|continue`,
+    );
+    expect(probe).toContain("preset=forensic");
+    expect(probe).toContain("random=7|1");
+    expect(probe).toContain("variables=2");
+    expect(probe).toContain("format=QUIET|loud|A\nB");
+    expect(probe).toContain("conditional=matched");
+    expect(probe).toContain("comment=visible|noop=done|agent=");
+    expect(probe).not.toContain("{{");
+  } finally {
+    await Promise.allSettled([
+      request.delete(`/api/chats/${chat.id}`),
+      request.delete(`/api/prompts/${preset.id}`),
+      request.delete(`/api/characters/${character.id}`),
+      request.delete(`/api/characters/personas/${persona.id}`),
+      request.delete(`/api/connections/${connection.id}`),
+    ]);
+  }
+});
+
 test("message deletion uses unified chroma controls and selection states", async ({ page }, testInfo) => {
   const chatResponse = await page.request.post("/api/chats", {
     data: { name: "Message Delete Chroma Smoke", mode: "roleplay", characterIds: [] },
@@ -496,6 +813,243 @@ test("message deletion uses unified chroma controls and selection states", async
     await expect(assistantRow).toContainText("First assistant swipe.");
   } finally {
     await page.request.delete(`/api/chats/${chat.id}`).catch(() => undefined);
+  }
+});
+
+test("bulk chat deletion uses the same accent control as its neighboring action", async ({ page }, testInfo) => {
+  test.skip(testInfo.project.name.includes("mobile"), "Desktop chat-sidebar selection chrome is covered here.");
+
+  const chatResponses = await Promise.all(
+    ["Bulk Delete Chroma One", "Bulk Delete Chroma Two"].map((name) =>
+      page.request.post("/api/chats", {
+        data: { name, mode: "roleplay", characterIds: [] },
+      }),
+    ),
+  );
+  for (const response of chatResponses) expect(response.ok()).toBeTruthy();
+  const chats = (await Promise.all(chatResponses.map((response) => response.json()))) as Array<{ id: string }>;
+
+  try {
+    await page.addInitScript((activeChatId) => {
+      localStorage.setItem("marinara-active-chat-id", activeChatId);
+      localStorage.setItem(
+        "marinara-engine-ui",
+        JSON.stringify({
+          state: {
+            hasCompletedOnboarding: true,
+            sidebarOpen: true,
+          },
+          version: 75,
+        }),
+      );
+    }, chats[0]!.id);
+    await page.goto("/");
+    await page.evaluate(() => {
+      document.documentElement.style.setProperty("--marinara-app-accent-solid", "rgb(20, 184, 166)");
+    });
+
+    const sidebar = page.locator('[data-component="ChatSidebar"]');
+    await expect(sidebar).toBeVisible();
+    await sidebar.getByRole("button", { name: "Select chats" }).click();
+    for (const chat of chats) {
+      await sidebar.locator(`[data-chat-id="${chat.id}"]`).click();
+    }
+
+    const actionBar = sidebar.locator(".mari-selection-action-bar");
+    await expect(actionBar).toContainText("2 selected");
+    const exportAction = actionBar.getByRole("button", { name: "Export" });
+    const deleteAction = actionBar.getByRole("button", { name: "Delete" });
+    await expect(exportAction).toBeEnabled();
+    await expect(deleteAction).toBeEnabled();
+
+    const styles = await actionBar.locator("button").evaluateAll((buttons) =>
+      buttons.map((button) => {
+        const style = getComputedStyle(button);
+        return {
+          backgroundColor: style.backgroundColor,
+          borderColor: style.borderColor,
+          color: style.color,
+          className: button.className,
+        };
+      }),
+    );
+    expect(styles).toHaveLength(2);
+    expect(styles[1]).toEqual(styles[0]);
+    expect(styles[1]?.className).not.toMatch(/danger|destructive|pink|red|rose/iu);
+
+    await deleteAction.click();
+    const dialog = page.getByRole("dialog", { name: "Delete Chats" });
+    await expect(dialog).toBeVisible();
+    const confirmDelete = dialog.getByRole("button", { name: "Delete", exact: true });
+    await expect(confirmDelete).toHaveClass(/mari-chrome-control--primary/u);
+    expect(await confirmDelete.getAttribute("class")).not.toMatch(/destructive|pink|red|rose/iu);
+    await dialog.getByRole("button", { name: "Cancel" }).click();
+  } finally {
+    await Promise.all(chats.map((chat) => page.request.delete(`/api/chats/${chat.id}`).catch(() => undefined)));
+  }
+});
+
+test("destructive confirmation actions use the shared accent button treatment", async ({ page }) => {
+  const accentColor = "rgb(20, 184, 166)";
+  await page.goto("/");
+  await page.evaluate((accent) => {
+    document.documentElement.style.setProperty("--marinara-chat-chrome-button-text-active", accent);
+    document.documentElement.style.setProperty("--destructive", "rgb(255, 0, 0)");
+  }, accentColor);
+
+  await page.evaluate(async () => {
+    const { showConfirmDialog } = (await import("/src/lib/app-dialogs.ts")) as {
+      showConfirmDialog: (options: {
+        title: string;
+        message: string;
+        confirmLabel: string;
+        tone: "destructive";
+      }) => Promise<boolean>;
+    };
+    void showConfirmDialog({
+      title: "Delete Resource",
+      message: "This representative resource deletion uses the shared confirmation renderer.",
+      confirmLabel: "Delete",
+      tone: "destructive",
+    });
+  });
+
+  const confirmDialog = page.getByRole("dialog", { name: "Delete Resource" });
+  const confirmDelete = confirmDialog.getByRole("button", { name: "Delete", exact: true });
+  await expect(confirmDelete).toHaveClass(/mari-chrome-control--primary/u);
+  await expect(confirmDelete).toHaveCSS("color", accentColor);
+  expect(await confirmDelete.getAttribute("class")).not.toMatch(/destructive|pink|red|rose/iu);
+  await confirmDialog.getByRole("button", { name: "Cancel" }).click();
+
+  await page.evaluate(async () => {
+    const { showChoiceDialog } = (await import("/src/lib/app-dialogs.ts")) as {
+      showChoiceDialog: (options: {
+        title: string;
+        message: string;
+        choices: Array<{ key: string; label: string; tone: "destructive" }>;
+      }) => Promise<string | null>;
+    };
+    void showChoiceDialog({
+      title: "Delete Resources",
+      message: "Choose the deletion scope.",
+      choices: [{ key: "all", label: "Delete All", tone: "destructive" }],
+    });
+  });
+
+  const choiceDialog = page.getByRole("dialog", { name: "Delete Resources" });
+  const deleteAll = choiceDialog.getByRole("button", { name: "Delete All", exact: true });
+  await expect(deleteAll).toHaveClass(/mari-chrome-control--primary/u);
+  await expect(deleteAll).toHaveCSS("color", accentColor);
+  expect(await deleteAll.getAttribute("class")).not.toMatch(/destructive|pink|red|rose/iu);
+  await choiceDialog.getByRole("button", { name: "Cancel" }).click();
+});
+
+test("connection model fetch errors inherit the configured chroma text color", async ({ page }, testInfo) => {
+  test.skip(testInfo.project.name.includes("mobile"), "Desktop connection editor chrome is covered here.");
+
+  const connectionResponse = await page.request.post("/api/connections", {
+    data: {
+      name: "Connection Fetch Error Chroma",
+      provider: "custom",
+    },
+  });
+  expect(connectionResponse.ok()).toBeTruthy();
+  const connection = (await connectionResponse.json()) as { id: string };
+  const networkError = "NetworkError when attempting to fetch resource.";
+
+  try {
+    await page.route(`**/api/connections/${connection.id}/models`, async (route) => {
+      await route.fulfill({
+        status: 502,
+        contentType: "application/json",
+        body: JSON.stringify({ error: { message: networkError } }),
+      });
+    });
+    await page.goto("/");
+    await page.evaluate(() => {
+      document.documentElement.style.setProperty("--marinara-chat-chrome-panel-text", "rgb(12, 34, 56)");
+      document.documentElement.style.setProperty("--destructive", "rgb(255, 0, 0)");
+    });
+
+    await page.locator('[data-tour="panel-connections"]').click();
+    const rightPanel = page.locator('[data-component="RightPanelDesktop"]');
+    await rightPanel
+      .getByText("Connection Fetch Error Chroma", { exact: true })
+      .first()
+      .evaluate((element) => (element as HTMLElement).click());
+
+    const editor = page.locator(".mari-editor-shell");
+    await expect(editor).toBeVisible();
+    await editor.getByText("Select a model…", { exact: true }).click();
+    await editor.getByRole("button", { name: "Fetch Models from API" }).click();
+
+    const errorText = editor.getByText(networkError, { exact: true });
+    await expect(errorText).toBeVisible();
+    await expect(errorText).toHaveClass(/mari-chrome-text/u);
+    await expect(errorText).toHaveCSS("color", "rgb(12, 34, 56)");
+    expect(await errorText.getAttribute("class")).not.toMatch(/destructive|pink|red|rose/iu);
+  } finally {
+    await page.request.delete(`/api/connections/${connection.id}`).catch(() => undefined);
+  }
+});
+
+test("Character favorite tags and stars inherit the configured accent color", async ({ page, request }, testInfo) => {
+  test.skip(testInfo.project.name.includes("mobile"), "Desktop Character favorite chrome is covered here.");
+
+  const characterName = `Favorite Chroma ${Date.now().toString(36)}`;
+  const characterResponse = await request.post("/api/characters", {
+    data: {
+      data: {
+        name: characterName,
+        extensions: { fav: true },
+      },
+    },
+  });
+  expect(characterResponse.ok()).toBeTruthy();
+  const character = (await characterResponse.json()) as { id: string };
+  const accentColor = "rgb(18, 86, 170)";
+
+  try {
+    await page.goto("/");
+    await page.evaluate((accent) => {
+      document.documentElement.style.setProperty("--marinara-app-accent-solid", accent);
+      document.documentElement.style.setProperty("--marinara-app-accent-static", accent);
+      document.documentElement.style.setProperty("--marinara-chat-chrome-accent", accent);
+      document.documentElement.style.setProperty("--marinara-chat-chrome-button-text-active", accent);
+      document.documentElement.style.setProperty("--marinara-editor-accent", accent);
+    }, accentColor);
+
+    await page.locator('[data-tour="panel-characters"]').click();
+    const rightPanel = page.locator('[data-component="RightPanelDesktop"]');
+    const characterRow = rightPanel.locator('[data-touch-drag-card="character"]').filter({ hasText: characterName });
+    await expect(characterRow).toBeVisible();
+
+    const panelStar = characterRow.locator('[data-character-favorite-indicator="panel"]');
+    await expect(panelStar).toHaveCSS("color", accentColor);
+    expect(await panelStar.getAttribute("class")).not.toMatch(/amber|yellow/iu);
+
+    await characterRow.click();
+    const editor = page.locator(".mari-editor-shell");
+    const favoriteToggle = editor.locator("[data-character-favorite-toggle]");
+    await expect(favoriteToggle).toHaveAttribute("data-favorite", "true");
+    await expect(favoriteToggle).toHaveCSS("color", accentColor);
+    expect(await favoriteToggle.getAttribute("class")).not.toMatch(/amber|yellow/iu);
+    await editor.getByTitle("Back").click();
+
+    await rightPanel.getByRole("button", { name: "Open Full Library" }).click();
+    const library = page.locator('[data-component="CharacterLibraryView"]');
+    await library.getByPlaceholder('Search characters or -tag:"tag name"').fill(characterName);
+
+    const cardFavorite = library.locator('[data-character-favorite-indicator="card"]');
+    const detailFavorite = library.locator('[data-character-favorite-indicator="detail"]:visible');
+    for (const indicator of [cardFavorite, detailFavorite]) {
+      await expect(indicator).toBeVisible();
+      await expect(indicator).toHaveClass(/mari-chrome-accent-surface/u);
+      await expect(indicator).toHaveCSS("color", accentColor);
+      expect(await indicator.getAttribute("class")).not.toMatch(/amber|yellow/iu);
+    }
+  } finally {
+    await request.delete(`/api/characters/${character.id}`).catch(() => undefined);
   }
 });
 

--- a/e2e/core-flows.e2e.ts
+++ b/e2e/core-flows.e2e.ts
@@ -816,9 +816,10 @@ test("message deletion uses unified chroma controls and selection states", async
   }
 });
 
-test("bulk chat deletion uses the same accent control as its neighboring action", async ({ page }, testInfo) => {
+test("bulk chat deletion uses the shared primary accent control", async ({ page }, testInfo) => {
   test.skip(testInfo.project.name.includes("mobile"), "Desktop chat-sidebar selection chrome is covered here.");
 
+  const accentColor = "rgb(20, 184, 166)";
   const chatResponses = await Promise.all(
     ["Bulk Delete Chroma One", "Bulk Delete Chroma Two"].map((name) =>
       page.request.post("/api/chats", {
@@ -844,9 +845,10 @@ test("bulk chat deletion uses the same accent control as its neighboring action"
       );
     }, chats[0]!.id);
     await page.goto("/");
-    await page.evaluate(() => {
-      document.documentElement.style.setProperty("--marinara-app-accent-solid", "rgb(20, 184, 166)");
-    });
+    await page.evaluate((accent) => {
+      document.documentElement.style.setProperty("--marinara-app-accent-solid", accent);
+      document.documentElement.style.setProperty("--marinara-chat-chrome-button-text-active", accent);
+    }, accentColor);
 
     const sidebar = page.locator('[data-component="ChatSidebar"]');
     await expect(sidebar).toBeVisible();
@@ -874,7 +876,8 @@ test("bulk chat deletion uses the same accent control as its neighboring action"
       }),
     );
     expect(styles).toHaveLength(2);
-    expect(styles[1]).toEqual(styles[0]);
+    await expect(deleteAction).toHaveClass(/mari-chrome-control--primary/u);
+    await expect(deleteAction).toHaveCSS("color", accentColor);
     expect(styles[1]?.className).not.toMatch(/danger|destructive|pink|red|rose/iu);
 
     await deleteAction.click();
@@ -889,7 +892,9 @@ test("bulk chat deletion uses the same accent control as its neighboring action"
   }
 });
 
-test("destructive confirmation actions use the shared accent button treatment", async ({ page }) => {
+test("destructive confirmation actions use the shared accent button treatment", async ({ page }, testInfo) => {
+  test.skip(testInfo.project.name.includes("mobile"), "Desktop confirmation-dialog chrome is covered here.");
+
   const accentColor = "rgb(20, 184, 166)";
   await page.goto("/");
   await page.evaluate((accent) => {

--- a/packages/client/src/components/characters/CharacterEditor.tsx
+++ b/packages/client/src/components/characters/CharacterEditor.tsx
@@ -843,10 +843,9 @@ export function CharacterEditor() {
       <button
         type="button"
         onClick={() => updateExtension("fav", !formData.extensions.fav)}
-        className={cn(
-          "mari-editor-action inline-flex",
-          formData.extensions.fav ? "text-yellow-400" : "text-[var(--muted-foreground)] hover:text-yellow-400",
-        )}
+        data-character-favorite-toggle
+        data-favorite={formData.extensions.fav ? "true" : "false"}
+        className="mari-editor-action mari-editor-action--favorite inline-flex"
         title={
           formData.extensions.fav
             ? localizeUi("ui.characters.charactereditor.removeFromFavorites")

--- a/packages/client/src/components/characters/CharacterLibraryView.tsx
+++ b/packages/client/src/components/characters/CharacterLibraryView.tsx
@@ -317,7 +317,10 @@ function CardLibraryDetailCard({
                   {formatEstimatedTokens(card.tokenEstimate)}
                 </span>
                 {card.favorite && (
-                  <span className="inline-flex items-center gap-1 rounded-full bg-amber-500/10 px-2.5 py-1 text-[0.6875rem] font-medium text-amber-300">
+                  <span
+                    data-character-favorite-indicator="detail"
+                    className="mari-chrome-accent-surface mari-accent-animated inline-flex items-center gap-1 rounded-full px-2.5 py-1 text-[0.6875rem] font-medium"
+                  >
                     <Star size="0.75rem" className="fill-current" /> {localizeUi("ui.characters.cardlibrarydetailcard.favorite")}</span>
                 )}
                 {card.active && (
@@ -711,7 +714,10 @@ export function CharacterLibraryView() {
                           </div>
                         )}
                         {card.favorite && (
-                          <div className="absolute right-2 top-2 inline-flex items-center gap-1 rounded-full bg-black/55 px-2 py-1 text-[0.5625rem] font-medium text-amber-200 backdrop-blur-sm sm:right-3 sm:top-3 sm:text-[0.625rem]">
+                          <div
+                            data-character-favorite-indicator="card"
+                            className="mari-chrome-accent-surface mari-accent-animated absolute right-2 top-2 inline-flex items-center gap-1 rounded-full px-2 py-1 text-[0.5625rem] font-medium backdrop-blur-sm sm:right-3 sm:top-3 sm:text-[0.625rem]"
+                          >
                             <Star size="0.625rem" className="fill-current sm:h-[0.6875rem] sm:w-[0.6875rem]" /> {localizeUi("ui.characters.cardlibrarydetailcard.favorite")}</div>
                         )}
                         {card.active && (

--- a/packages/client/src/components/chat/ChatMessage.tsx
+++ b/packages/client/src/components/chat/ChatMessage.tsx
@@ -1115,7 +1115,7 @@ function renderContent(
         const lastFontClose = before.lastIndexOf("</font>");
         if (lastFontClose < lastFontOpen) return match;
       }
-      const highlightColor = dialogueColor ?? "white";
+      const highlightColor = safeColor(dialogueColor ?? "white");
       return `<${dialogueTag} style="color:${highlightColor}">${match}</${dialogueTag}>`;
     });
   })();

--- a/packages/client/src/components/chat/ChatMessage.tsx
+++ b/packages/client/src/components/chat/ChatMessage.tsx
@@ -42,7 +42,7 @@ import {
   Shield,
 } from "lucide-react";
 import { decodeEncodedSpeakerTags, formatTextQuotes, type Message, type QuoteFormat } from "@marinara-engine/shared";
-import { memo, useState, useMemo, useRef, useEffect, useLayoutEffect, useCallback, type ReactNode } from "react";
+import { memo, useState, useMemo, useRef, useEffect, useId, useLayoutEffect, useCallback, type ReactNode } from "react";
 import { useTranslation, useTranslation as useUiTranslation } from "react-i18next";
 import { useQueryClient, type InfiniteData } from "@tanstack/react-query";
 import { chatKeys, rememberRecentMessageContentEdit } from "../../hooks/use-chats";
@@ -1133,6 +1133,55 @@ function renderContent(
   const html = scopedCss ? `<style>${scopedCss}</style>${finalHtml}` : finalHtml;
 
   return <div className={cn("overflow-hidden", htmlScopeClass)} dangerouslySetInnerHTML={{ __html: html }} />;
+}
+
+export function RoleplayMessagePreview({
+  content,
+  dialogueColor,
+  className,
+}: {
+  content: string;
+  dialogueColor?: string;
+  className?: string;
+}) {
+  const previewId = useId();
+  const { chatFontColor, defaultDialogueColor, theme, textStrokeWidth, textStrokeColor, boldDialogue, quoteFormat } =
+    useUIStore(
+      useShallow((state) => ({
+        chatFontColor: state.chatFontColor,
+        defaultDialogueColor: state.defaultDialogueColor,
+        theme: state.theme,
+        textStrokeWidth: state.textStrokeWidth,
+        textStrokeColor: state.textStrokeColor,
+        boldDialogue: state.boldDialogue ?? true,
+        quoteFormat: state.quoteFormat,
+      })),
+    );
+  const resolvedDialogueColor = dialogueColor || defaultDialogueColor || getDefaultChatTextColor(theme);
+  const htmlScopeClass = `mari-html-greeting-${previewId.replace(/[^a-zA-Z0-9_-]/g, "") || "preview"}`;
+  const isHtmlContent = containsChatHtml(content);
+  const previewStyle = useMemo<React.CSSProperties>(
+    () => ({
+      ...(chatFontColor ? { color: chatFontColor } : {}),
+      ...(textStrokeWidth > 0
+        ? { WebkitTextStroke: `${textStrokeWidth}px ${textStrokeColor}`, paintOrder: "stroke fill" }
+        : {}),
+    }),
+    [chatFontColor, textStrokeColor, textStrokeWidth],
+  );
+  const renderedContent = useMemo(
+    () => renderContent(content, resolvedDialogueColor, undefined, boldDialogue, htmlScopeClass, quoteFormat),
+    [boldDialogue, content, htmlScopeClass, quoteFormat, resolvedDialogueColor],
+  );
+
+  return (
+    <div
+      className={cn("mari-message-content block break-words", !isHtmlContent && "whitespace-pre-wrap", className)}
+      style={previewStyle}
+    >
+      {renderedContent}
+    </div>
+  );
 }
 
 function isGradientNameColor(color?: string): color is string {

--- a/packages/client/src/components/chat/ChatRoleplayPanels.tsx
+++ b/packages/client/src/components/chat/ChatRoleplayPanels.tsx
@@ -7,7 +7,6 @@ import {
   ChevronRight,
   Loader2,
   MapPin,
-  Maximize2,
   PenLine,
   Sparkles,
   X,
@@ -23,7 +22,7 @@ import {
   ROLEPLAY_POPOVER_TITLE,
 } from "./roleplay-popover-styles";
 import { useTranslation as useUiTranslation } from "react-i18next";
-import { ExpandedTextarea } from "../ui/ExpandedTextarea";
+import { MacroTextarea } from "../ui/MacroTextarea";
 
 type LorebookEntryStatus = "normal" | "constant" | "selective";
 
@@ -377,7 +376,6 @@ export function AuthorNotesPanel({
   const { t: localizeUi } = useUiTranslation();
   const [notes, setNotes] = useState((chatMeta.authorNotes as string) ?? "");
   const [depthStr, setDepthStr] = useState(String((chatMeta.authorNotesDepth as number) ?? 4));
-  const [expanded, setExpanded] = useState(false);
   const updateMeta = useUpdateChatMetadata();
 
   const initialBaseline = {
@@ -433,36 +431,26 @@ export function AuthorNotesPanel({
         <PenLine size="0.75rem" />{localizeUi("ui.chat.authornotespanel.authorSNotes")}
         <button
           type="button"
-          onClick={() => setExpanded(true)}
-          aria-label={localizeUi("ui.chat.authornotespanel.expandAuthorSNotes")}
-          title={localizeUi("ui.chat.authornotespanel.expandAuthorSNotes")}
-          className={cn(ROLEPLAY_POPOVER_CLOSE_BUTTON, "ml-auto -my-1")}
-        >
-          <Maximize2 size={ROLEPLAY_POPOVER_CLOSE_ICON_SIZE} />
-        </button>
-        <button
-          type="button"
           onClick={onClose}
           aria-label={localizeUi("ui.chat.authornotespanel.closeAuthorSNotes")}
-          className={cn(ROLEPLAY_POPOVER_CLOSE_BUTTON, "-my-1")}
+          className={cn(ROLEPLAY_POPOVER_CLOSE_BUTTON, "ml-auto -my-1")}
         >
           <X size={ROLEPLAY_POPOVER_CLOSE_ICON_SIZE} />
         </button>
       </h3>
       <p className={cn(ROLEPLAY_POPOVER_SUBTITLE, "mb-2")}>{localizeUi("ui.chat.authornotespanel.textHereIsInjectedIntoThePromptAtThe")}</p>
-      <textarea
+      <MacroTextarea
         value={notes}
-        onChange={(e) => setNotes(e.target.value)}
+        onChange={setNotes}
         onBlur={handleSave}
+        onExpandedClose={handleSave}
+        title={localizeUi("ui.chat.authornotespanel.authorSNotes")}
         placeholder={localizeUi("ui.chat.authornotespanel.eGKeepTheToneDarkAndSuspensefulThe")}
-        className="w-full resize-none rounded-lg border border-[var(--border)] bg-[var(--secondary)] px-2.5 py-2 text-xs text-[var(--foreground)] outline-none transition-colors placeholder:text-[var(--muted-foreground)] focus:ring-2 focus:ring-[var(--ring)]"
         rows={4}
+        ariaLabel={localizeUi("ui.chat.authornotespanel.authorSNotes")}
+        wrapperClassName="mari-author-notes-field"
+        className="resize-none px-2.5 py-2 text-xs leading-relaxed"
       />
-      <p className="mt-1.5 text-[0.5625rem] leading-relaxed text-[var(--muted-foreground)]">
-        {localizeUi("ui.chat.authornotespanel.macroGuidance")}{" "}
-        <code>{"{{user}}"}</code>, <code>{"{{char}}"}</code>, <code>{"{{date}}"}</code>,{" "}
-        <code>{"{{time}}"}</code>.
-      </p>
       <div className="mt-2 flex items-center gap-2">
         <span className="shrink-0 text-[0.625rem] text-[var(--muted-foreground)]">{localizeUi("ui.chat.authornotespanel.injectionDepth")}</span>
         <input
@@ -479,26 +467,6 @@ export function AuthorNotesPanel({
         />
       </div>
       <p className="mt-1 text-[0.5625rem] text-[var(--muted-foreground)]/60">{localizeUi("ui.chat.authornotespanel.depth0AfterTheLatestMessage4FourMessages")}</p>
-      <ExpandedTextarea
-        open={expanded}
-        onClose={() => {
-          setExpanded(false);
-          handleSave();
-        }}
-        title={localizeUi("ui.chat.authornotespanel.authorSNotes")}
-        value={notes}
-        onChange={setNotes}
-        placeholder={localizeUi("ui.chat.authornotespanel.eGKeepTheToneDarkAndSuspensefulThe")}
-        closeLabel={localizeUi("ui.chat.authornotespanel.collapseAuthorSNotes")}
-        surface="chat"
-        footer={
-          <p className="text-xs leading-relaxed text-[var(--marinara-chat-chrome-panel-muted)]">
-            {localizeUi("ui.chat.authornotespanel.macroGuidance")}{" "}
-            <code>{"{{user}}"}</code>, <code>{"{{char}}"}</code>, <code>{"{{date}}"}</code>,{" "}
-            <code>{"{{time}}"}</code>.
-          </p>
-        }
-      />
     </>
   );
 }

--- a/packages/client/src/components/chat/ChatRoleplaySurface.tsx
+++ b/packages/client/src/components/chat/ChatRoleplaySurface.tsx
@@ -862,6 +862,7 @@ function AuthorNotesButton({
     const handle = (e: PointerEvent) => {
       const target = e.target as Node;
       if (ref.current?.contains(target) || panelRef.current?.contains(target)) return;
+      if (target instanceof Element && target.closest("[data-macro-modal]")) return;
       // On mobile, the virtual keyboard opening can synthesise a pointer/mouse
       // event outside the panel that would otherwise close it mid-edit; don't
       // dismiss while a field inside the panel is focused. Mobile-only: on desktop

--- a/packages/client/src/components/chat/ChatSettingsDrawer.tsx
+++ b/packages/client/src/components/chat/ChatSettingsDrawer.tsx
@@ -149,6 +149,7 @@ import { isLorebookScopeActiveForChat } from "../../lib/lorebook-scope";
 import { addSilentGreetingSwipes } from "../../lib/message-swipes";
 import { useUIStore } from "../../stores/ui.store";
 import { blurActiveChatFloatingUiControl, isDesktopShellNavigationTarget } from "../../lib/chat-floating-ui-events";
+import { useDialogFocusScope } from "../../hooks/use-dialog-focus-scope";
 import { useTouchFolderDrag } from "../../hooks/use-touch-folder-drag";
 import {
   useChatPresets,
@@ -2409,6 +2410,17 @@ export function ChatSettingsDrawer({
     greetings: GreetingOption[];
     selectedIndex: number;
   } | null>(null);
+  const greetingDialogRef = useRef<HTMLDivElement | null>(null);
+  useDialogFocusScope(firstMesConfirm !== null, greetingDialogRef);
+
+  useEffect(() => {
+    if (!firstMesConfirm) return;
+    const dismissGreetingDialog = (event: KeyboardEvent) => {
+      if (event.key === "Escape") setFirstMesConfirm(null);
+    };
+    document.addEventListener("keydown", dismissGreetingDialog);
+    return () => document.removeEventListener("keydown", dismissGreetingDialog);
+  }, [firstMesConfirm]);
 
   const handleFirstMesConfirm = useCallback(async () => {
     if (!firstMesConfirm) return;
@@ -9462,6 +9474,8 @@ export function ChatSettingsDrawer({
           }}
         >
           <div
+            ref={greetingDialogRef}
+            tabIndex={-1}
             className="mari-chrome-token-scope relative mx-4 flex w-full max-w-sm flex-col rounded-xl bg-[var(--marinara-chat-chrome-panel-bg)] text-[var(--marinara-chat-chrome-panel-text)] shadow-2xl ring-1 ring-[var(--marinara-chat-chrome-panel-border)]"
             onPointerDown={(e) => e.stopPropagation()}
             onClick={(e) => e.stopPropagation()}

--- a/packages/client/src/components/chat/ChatSettingsDrawer.tsx
+++ b/packages/client/src/components/chat/ChatSettingsDrawer.tsx
@@ -96,6 +96,7 @@ import { SecretPlotPanel } from "../agents/SecretPlotPanel";
 import { SummariesEditorModal } from "./SummariesEditorModal";
 import { AgentSuiteModal } from "./AgentSuiteModal";
 import { ConversationTimeZoneSelect } from "./ConversationTimeZoneSelect";
+import { RoleplayMessagePreview } from "./ChatMessage";
 import { useCharacters, usePersonas, useCharacterGroups, type SpriteInfo } from "../../hooks/use-characters";
 import { useLorebooks, useEntriesAcrossLorebooks } from "../../hooks/use-lorebooks";
 import { useDefaultPreset, usePresetFull, usePresets } from "../../hooks/use-presets";
@@ -2404,23 +2405,24 @@ export function ChatSettingsDrawer({
   const [firstMesConfirm, setFirstMesConfirm] = useState<{
     charId: string;
     charName: string;
+    dialogueColor?: string;
     greetings: GreetingOption[];
     selectedIndex: number;
   } | null>(null);
 
   const handleFirstMesConfirm = useCallback(async () => {
     if (!firstMesConfirm) return;
-    const selectedGreeting = firstMesConfirm.greetings[firstMesConfirm.selectedIndex];
+    const confirmation = firstMesConfirm;
+    const selectedGreeting = confirmation.greetings[confirmation.selectedIndex];
     if (!selectedGreeting) return;
     let messageId: string | null = null;
     try {
       const msg = await createMessage.mutateAsync({
         role: "assistant",
         content: selectedGreeting.text,
-        characterId: firstMesConfirm.charId,
+        characterId: confirmation.charId,
       });
       messageId = msg?.id ?? null;
-      setFirstMesConfirm(null);
     } catch (error) {
       toast.error(
         error instanceof Error ? error.message : localizeUi("ui.chat.chatsettingsdrawer.failedToAddSelectedGreeting"),
@@ -2428,8 +2430,8 @@ export function ChatSettingsDrawer({
       return;
     }
 
-    const remainingGreetings = firstMesConfirm.greetings
-      .filter((_greeting, index) => index !== firstMesConfirm.selectedIndex)
+    const remainingGreetings = confirmation.greetings
+      .filter((_greeting, index) => index !== confirmation.selectedIndex)
       .map((greeting) => greeting.text);
     try {
       if (messageId && remainingGreetings.length > 0) {
@@ -2447,6 +2449,7 @@ export function ChatSettingsDrawer({
         error instanceof Error ? error.message : localizeUi("ui.chat.chatsettingsdrawer.failedToAddSelectedGreeting"),
       );
     }
+    setFirstMesConfirm((current) => (current === confirmation ? null : current));
   }, [firstMesConfirm, createMessage, chat.id, qc, localizeUi]);
 
   // ── Mutations ──
@@ -2524,9 +2527,16 @@ export function ChatSettingsDrawer({
                 });
               }
               if (greetings.length > 0) {
+                const extensions = (parsed as { extensions?: unknown }).extensions;
+                const dialogueColor =
+                  extensions && typeof extensions === "object"
+                    ? (extensions as { dialogueColor?: unknown }).dialogueColor
+                    : undefined;
                 setFirstMesConfirm({
                   charId,
                   charName: charName(char),
+                  dialogueColor:
+                    typeof dialogueColor === "string" && dialogueColor.trim() ? dialogueColor.trim() : undefined,
                   greetings,
                   selectedIndex: 0,
                 });
@@ -9440,24 +9450,32 @@ export function ChatSettingsDrawer({
       {/* First message confirmation dialog */}
       {firstMesConfirm && (
         <div
+          data-chat-floating-panel
+          data-component="ChatSettingsDrawer.GreetingDialog"
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="chat-settings-greeting-title"
+          aria-describedby="chat-settings-greeting-description"
           className="fixed inset-0 z-[95] flex items-center justify-center bg-black/60 max-md:pt-[env(safe-area-inset-top)]"
           onClick={(event) => {
             if (event.target === event.currentTarget) setFirstMesConfirm(null);
           }}
         >
           <div
-            className="relative mx-4 flex w-full max-w-sm flex-col rounded-xl bg-[var(--card)] shadow-2xl ring-1 ring-[var(--border)]"
+            className="mari-chrome-token-scope relative mx-4 flex w-full max-w-sm flex-col rounded-xl bg-[var(--marinara-chat-chrome-panel-bg)] text-[var(--marinara-chat-chrome-panel-text)] shadow-2xl ring-1 ring-[var(--marinara-chat-chrome-panel-border)]"
             onPointerDown={(e) => e.stopPropagation()}
             onClick={(e) => e.stopPropagation()}
           >
-            <div className="flex items-center gap-2 border-b border-[var(--marinara-chat-chrome-panel-divider)] px-4 py-3">
-              <MessageCircle size="0.875rem" className="text-[var(--muted-foreground)]" />
-              <span className="text-sm font-semibold text-[var(--foreground)]">
+            <div
+              data-component="ChatSettingsDrawer.GreetingDialogHeader"
+              className="border-b border-[var(--marinara-chat-chrome-panel-divider)] px-4 py-3"
+            >
+              <span id="chat-settings-greeting-title" className="mari-chrome-text-strong text-sm font-semibold">
                 {localizeUi("ui.chat.chatsettingsdrawer.chooseGreeting")}
               </span>
             </div>
             <div className="min-h-0 px-4 py-3">
-              <p className="text-xs leading-relaxed text-[var(--muted-foreground)]">
+              <p id="chat-settings-greeting-description" className="mari-chrome-text text-xs leading-relaxed">
                 {localizeUi("ui.chat.chatsettingsdrawer.chooseGreetingForValue1", {
                   value1: firstMesConfirm.charName,
                 })}
@@ -9479,7 +9497,7 @@ export function ChatSettingsDrawer({
                       )}
                     >
                       <span className="flex items-center justify-between gap-2">
-                        <span className="text-[0.6875rem] font-semibold text-[var(--foreground)]">
+                        <span className="mari-chrome-text-strong text-[0.6875rem] font-semibold">
                           {greeting.alternateIndex === null
                             ? localizeUi("ui.characters.dialoguetab.firstMessage")
                             : localizeUi("ui.characters.dialoguetab.alternateGreetingValue1", {
@@ -9497,13 +9515,17 @@ export function ChatSettingsDrawer({
                           {selected && <Check size="0.625rem" />}
                         </span>
                       </span>
-                      <span className="mt-1 block whitespace-pre-wrap text-[0.6875rem] leading-relaxed text-[var(--muted-foreground)]">
-                        {greeting.text.length > 500
-                          ? localizeUi("ui.chat.chatsettingsdrawer.value1_30f5501", {
-                              value1: greeting.text.slice(0, 500),
-                            })
-                          : greeting.text}
-                      </span>
+                      <RoleplayMessagePreview
+                        content={
+                          greeting.text.length > 500
+                            ? localizeUi("ui.chat.chatsettingsdrawer.value1_30f5501", {
+                                value1: greeting.text.slice(0, 500),
+                              })
+                            : greeting.text
+                        }
+                        dialogueColor={firstMesConfirm.dialogueColor}
+                        className="mt-1 text-[0.6875rem] leading-relaxed"
+                      />
                     </button>
                   );
                 })}
@@ -9511,6 +9533,7 @@ export function ChatSettingsDrawer({
             </div>
             <div className="flex justify-end gap-2 border-t border-[var(--marinara-chat-chrome-panel-divider)] px-4 py-3">
               <button
+                type="button"
                 onClick={() => setFirstMesConfirm(null)}
                 disabled={createMessage.isPending}
                 className="mari-chrome-control mari-chrome-control--small text-xs"
@@ -9518,6 +9541,7 @@ export function ChatSettingsDrawer({
                 {localizeUi("onboarding.actions.skip")}
               </button>
               <button
+                type="button"
                 onClick={handleFirstMesConfirm}
                 disabled={createMessage.isPending}
                 className="mari-chrome-control mari-chrome-control--small mari-chrome-control--selected text-xs"

--- a/packages/client/src/components/connections/ConnectionEditor.tsx
+++ b/packages/client/src/components/connections/ConnectionEditor.tsx
@@ -1674,7 +1674,7 @@ export function ConnectionEditor() {
                       )}
                       {fetchModels.isPending ?localizeUi("ui.connections.connectioneditor.fetching") : modelFetchButtonLabel}
                     </button>
-                    {fetchError && <p className="mt-1.5 text-[0.625rem] text-[var(--destructive)]">{fetchError}</p>}
+                    {fetchError && <p className="mari-chrome-text mt-1.5 text-[0.625rem]">{fetchError}</p>}
                     {remoteModels.length > 0 && !fetchError && (
                       <p className="mt-1 text-[0.625rem] text-emerald-400">
                         {remoteModels.length} {localizeUi("ui.connections.connectioneditor.model_1d06a0d")}{remoteModels.length !== 1 ?localizeUi("ui.noodle.stageprofileview.s") : ""} {localizeUi("ui.connections.connectioneditor.availableFrom")}{" "}

--- a/packages/client/src/components/layout/ChatSidebar.tsx
+++ b/packages/client/src/components/layout/ChatSidebar.tsx
@@ -811,7 +811,7 @@ export function ChatSidebar() {
         title:localizeUi("ui.layout.chatsidebar.deleteChats"),
         message:localizeUi("ui.layout.chatsidebar.deleteValue1ChatValue2", { value1: selectedChatIds.size, value2: selectedChatIds.size > 1 ?localizeUi("ui.noodle.stageprofileview.s") : "" }),
         confirmLabel:localizeUi("lorebook.editor.batch.delete"),
-        tone: "destructive",
+        tone: "accent",
       }))
     ) {
       return;
@@ -1477,6 +1477,7 @@ export function ChatSidebar() {
           selectedCount={selectedChatIds.size}
           onExport={() => void handleBatchExport()}
           onDelete={handleBatchDelete}
+          deleteTone="accent"
           exporting={bulkExportChats.isPending}
           className="static mx-0"
         />

--- a/packages/client/src/components/panels/CharactersPanel.tsx
+++ b/packages/client/src/components/panels/CharactersPanel.tsx
@@ -1107,7 +1107,8 @@ export function CharactersPanel() {
                         {member.isFavorite && (
                           <div
                             aria-hidden="true"
-                            className="absolute -right-1 -top-1 flex h-3.5 w-3.5 items-center justify-center rounded-md bg-[var(--background)] text-amber-300 shadow-sm ring-1 ring-[var(--border)]"
+                            data-character-favorite-indicator="folder"
+                            className="absolute -right-1 -top-1 flex h-3.5 w-3.5 items-center justify-center rounded-md bg-[var(--background)] text-[var(--marinara-chat-chrome-accent)] shadow-sm ring-1 ring-[var(--border)]"
                           >
                             <Star size="0.5625rem" className="fill-current" />
                           </div>
@@ -1340,7 +1341,8 @@ export function CharactersPanel() {
                 {isFavorite && (
                   <div
                     aria-hidden="true"
-                    className="absolute -right-1 -top-1 flex h-4 w-4 items-center justify-center rounded-md bg-[var(--background)] text-amber-300 shadow-sm ring-1 ring-[var(--border)]"
+                    data-character-favorite-indicator="panel"
+                    className="absolute -right-1 -top-1 flex h-4 w-4 items-center justify-center rounded-md bg-[var(--background)] text-[var(--marinara-chat-chrome-accent)] shadow-sm ring-1 ring-[var(--border)]"
                   >
                     <Star size="0.625rem" className="fill-current" />
                   </div>

--- a/packages/client/src/components/ui/AppDialogRenderer.tsx
+++ b/packages/client/src/components/ui/AppDialogRenderer.tsx
@@ -40,8 +40,8 @@ export function AppDialogRenderer() {
   if (!dialog) return null;
 
   const confirmToneClass =
-    dialog.tone === "destructive"
-      ? "bg-[var(--destructive)] text-white hover:bg-[var(--destructive)]/85"
+    dialog.tone === "destructive" || dialog.tone === "accent"
+      ? "mari-chrome-control mari-chrome-control--primary"
       : "bg-[var(--primary)] text-white hover:bg-[var(--primary)]/85";
 
   return (
@@ -143,8 +143,8 @@ export function AppDialogRenderer() {
                 type="button"
                 onClick={() => resolveActiveDialog(choice.key)}
                 className={`w-full rounded-lg px-3 py-2 text-sm font-medium transition-colors ${
-                  choice.tone === "destructive"
-                    ? "bg-[var(--destructive)] text-white hover:bg-[var(--destructive)]/85"
+                  choice.tone === "destructive" || choice.tone === "accent"
+                    ? "mari-chrome-control mari-chrome-control--primary"
                     : i === 0
                       ? "bg-[var(--primary)] text-white hover:bg-[var(--primary)]/85"
                       : "ring-1 ring-[var(--border)] text-[var(--foreground)] hover:bg-[var(--accent)]"

--- a/packages/client/src/components/ui/MacroTextarea.tsx
+++ b/packages/client/src/components/ui/MacroTextarea.tsx
@@ -257,6 +257,7 @@ export interface MacroTextareaProps {
   onKeyDown?: (event: ReactKeyboardEvent<HTMLTextAreaElement>) => void;
   rows?: number;
   title?: string;
+  ariaLabel?: string;
   placeholder?: string;
   className?: string;
   wrapperClassName?: string;
@@ -281,6 +282,7 @@ export function MacroTextarea({
   onKeyDown,
   rows = 6,
   title = "Edit text",
+  ariaLabel,
   placeholder,
   className,
   wrapperClassName,
@@ -338,6 +340,7 @@ export function MacroTextarea({
           onFocus={onFocus}
           onKeyDown={handleKeyDown}
           rows={rows}
+          aria-label={ariaLabel}
           placeholder={placeholder}
           spellCheck={spellCheck}
           className={cn(

--- a/packages/client/src/components/ui/SelectionActionBar.tsx
+++ b/packages/client/src/components/ui/SelectionActionBar.tsx
@@ -6,6 +6,7 @@ interface SelectionActionBarProps {
   selectedCount: number;
   onExport: () => void;
   onDelete: () => void;
+  deleteTone?: "accent" | "danger";
   exportDisabled?: boolean;
   deleteDisabled?: boolean;
   exporting?: boolean;
@@ -17,6 +18,7 @@ export function SelectionActionBar({
   selectedCount,
   onExport,
   onDelete,
+  deleteTone = "danger",
   exportDisabled = false,
   deleteDisabled = false,
   exporting = false,
@@ -49,7 +51,10 @@ export function SelectionActionBar({
           type="button"
           onClick={onDelete}
           disabled={selectedCount === 0 || deleteDisabled || exporting}
-          className="mari-chrome-control mari-chrome-control--danger flex-1 px-3 py-2 text-xs"
+          className={cn(
+            "mari-chrome-control flex-1 px-3 py-2 text-xs",
+            deleteTone === "danger" && "mari-chrome-control--danger",
+          )}
         >
           <Trash2 size="0.75rem" />{localizeUi("lorebook.editor.batch.delete")}</button>
       </div>

--- a/packages/client/src/components/ui/SelectionActionBar.tsx
+++ b/packages/client/src/components/ui/SelectionActionBar.tsx
@@ -53,7 +53,7 @@ export function SelectionActionBar({
           disabled={selectedCount === 0 || deleteDisabled || exporting}
           className={cn(
             "mari-chrome-control flex-1 px-3 py-2 text-xs",
-            deleteTone === "danger" && "mari-chrome-control--danger",
+            deleteTone === "danger" ? "mari-chrome-control--danger" : "mari-chrome-control--primary",
           )}
         >
           <Trash2 size="0.75rem" />{localizeUi("lorebook.editor.batch.delete")}</button>

--- a/packages/client/src/stores/dialog.store.ts
+++ b/packages/client/src/stores/dialog.store.ts
@@ -1,6 +1,6 @@
 import { create } from "zustand";
 
-export type AppDialogTone = "default" | "destructive";
+export type AppDialogTone = "default" | "destructive" | "accent";
 
 type AppDialogCommon = {
   title?: string;

--- a/packages/client/src/styles/globals.css
+++ b/packages/client/src/styles/globals.css
@@ -1817,6 +1817,11 @@
   color: var(--destructive);
 }
 
+.mari-editor-action--favorite[data-favorite="true"],
+.mari-editor-action--favorite:hover {
+  color: var(--marinara-editor-accent);
+}
+
 .mari-editor-status {
   display: inline-flex;
   align-items: center;

--- a/packages/server/src/routes/generate.routes.ts
+++ b/packages/server/src/routes/generate.routes.ts
@@ -2000,6 +2000,11 @@ export async function generateRoutes(app: FastifyInstance) {
           };
 
           const assembled = await assemblePrompt(assemblerInput);
+          Object.assign(promptMacroContext.variables, assembled.macroVariables);
+          promptMacroContext.agentData = {
+            ...promptMacroContext.agentData,
+            ...assembled.macroAgentData,
+          };
           lorebookPromptScanResult = assembled.lorebookScanResult ?? null;
           if (assembled.lorebookActivatedEntries || assembled.lorebookBudgetSkippedEntries) {
             lorebookScanSnapshot = {
@@ -2528,7 +2533,13 @@ export async function generateRoutes(app: FastifyInstance) {
 
         // ── Author's Notes injection ──
         const authorNotesRaw = (chatMeta.authorNotes as string | undefined)?.trim();
-        const authorNotes = authorNotesRaw ? resolvePromptMacros(authorNotesRaw).trim() : "";
+        const authorNotes = authorNotesRaw
+          ? resolveMacros(
+              authorNotesRaw,
+              promptMacroContext,
+              deferCharacterMacros ? { deferCharacterMacros: "all" } : undefined,
+            ).trim()
+          : "";
         if (authorNotes) {
           const authorNotesDepth = (chatMeta.authorNotesDepth as number) ?? 4;
           finalMessages = injectAtDepth(finalMessages, [

--- a/packages/server/src/routes/generate/dry-run-route.ts
+++ b/packages/server/src/routes/generate/dry-run-route.ts
@@ -1281,6 +1281,11 @@ export async function registerDryRunRoute(app: FastifyInstance) {
       };
 
       const assembled = await assemblePrompt(assemblerInput);
+      Object.assign(promptMacroContext.variables, assembled.macroVariables);
+      promptMacroContext.agentData = {
+        ...promptMacroContext.agentData,
+        ...assembled.macroAgentData,
+      };
       finalMessages = assembled.messages;
       temperature = assembled.parameters.temperature;
       maxTokens = assembled.parameters.maxTokens;
@@ -1454,6 +1459,18 @@ export async function registerDryRunRoute(app: FastifyInstance) {
       if (characterAdvancedPromptEntries.length > 0) {
         finalMessages = injectAtDepth(finalMessages as any, characterAdvancedPromptEntries) as any;
       }
+    }
+
+    const authorNotesRaw = typeof chatMeta.authorNotes === "string" ? chatMeta.authorNotes.trim() : "";
+    const authorNotes = authorNotesRaw ? resolveMacros(authorNotesRaw, promptMacroContext).trim() : "";
+    if (authorNotes) {
+      const authorNotesDepth =
+        typeof chatMeta.authorNotesDepth === "number" && Number.isFinite(chatMeta.authorNotesDepth)
+          ? Math.max(0, Math.floor(chatMeta.authorNotesDepth))
+          : 4;
+      finalMessages = injectAtDepth(finalMessages as any, [
+        { content: authorNotes, role: "system", depth: authorNotesDepth },
+      ]) as any;
     }
 
     // Optional injection: tracker context (read-only snapshot)

--- a/packages/server/src/routes/generate/dry-run-route.ts
+++ b/packages/server/src/routes/generate/dry-run-route.ts
@@ -75,6 +75,7 @@ import {
   resolveActivePersonaCandidate,
   resolvePromptCharacterIdsForTarget,
   resolveCharacterNameMap,
+  resolveGroupGenerationMode,
   resolveRegenerationGameStateAnchor,
   resolveProviderTopK,
   resolveRoleplayChatSummary,
@@ -716,6 +717,13 @@ export async function registerDryRunRoute(app: FastifyInstance) {
         ? body.forCharacterId
         : null;
     const promptCharacterIds = resolvePromptCharacterIdsForTarget(characterIds, promptTargetCharacterId);
+    const promptGroupResponseOrder = (chatMeta.groupResponseOrder as string) ?? "sequential";
+    const dryRunGroupChatMode = resolveGroupGenerationMode(chatMode, chatMeta.groupChatMode);
+    const deferCharacterMacros =
+      characterIds.length > 1 &&
+      dryRunGroupChatMode === "individual" &&
+      (promptGroupResponseOrder !== "manual" || chatMode === "conversation") &&
+      !impersonate;
     const audienceCharacterIds = impersonate ? [] : promptTargetCharacterId ? [promptTargetCharacterId] : characterIds;
     if (audienceCharacterIds.length > 0) {
       const audience = new Set(audienceCharacterIds);
@@ -838,7 +846,6 @@ export async function registerDryRunRoute(app: FastifyInstance) {
       msg.content = msg.content.replace(/\n([ \t]*\n){2,}/g, "\n\n");
     }
     mappedMessages = resolveHistoryMessageMacros(mappedMessages);
-    const dryRunGroupChatMode = ((chatMeta.groupChatMode as string) ?? "merged") as string;
     const shouldPrefixGroupHistorySpeakers =
       chatMeta.groupSpeakerNamesInHistory === true &&
       characterIds.length > 1 &&
@@ -1278,6 +1285,7 @@ export async function registerDryRunRoute(app: FastifyInstance) {
         idleDuration: promptIdleDuration,
         impersonate,
         preserveImpersonatePresetSections: impersonate && effectivePresetSource === "impersonate",
+        deferCharacterMacros,
       };
 
       const assembled = await assemblePrompt(assemblerInput);
@@ -1462,7 +1470,13 @@ export async function registerDryRunRoute(app: FastifyInstance) {
     }
 
     const authorNotesRaw = typeof chatMeta.authorNotes === "string" ? chatMeta.authorNotes.trim() : "";
-    const authorNotes = authorNotesRaw ? resolveMacros(authorNotesRaw, promptMacroContext).trim() : "";
+    const authorNotes = authorNotesRaw
+      ? resolveMacros(
+          authorNotesRaw,
+          promptMacroContext,
+          deferCharacterMacros ? { deferCharacterMacros: "all" } : undefined,
+        ).trim()
+      : "";
     if (authorNotes) {
       const authorNotesDepth =
         typeof chatMeta.authorNotesDepth === "number" && Number.isFinite(chatMeta.authorNotesDepth)

--- a/packages/server/src/services/prompt/assembler.ts
+++ b/packages/server/src/services/prompt/assembler.ts
@@ -207,6 +207,10 @@ export interface AssemblerOutput {
   messages: ChatMLMessage[];
   /** Parsed generation parameters */
   parameters: GenerationParameters;
+  /** Final preset and choice-variable values available after section macro processing. */
+  macroVariables: Record<string, string>;
+  /** Agent outputs made available to {{agent::TYPE}} while assembling sections. */
+  macroAgentData: Record<string, string>;
   /** Any lorebook depth entries that were queued (already injected into messages) */
   lorebookDepthEntriesCount: number;
   /** Updated per-chat entry state overrides after ephemeral processing. Caller should persist to chat metadata. */
@@ -562,6 +566,8 @@ export async function assemblePrompt(input: AssemblerInput): Promise<AssemblerOu
   return {
     messages: finalMessages,
     parameters,
+    macroVariables: { ...macroCtx.variables },
+    macroAgentData: { ...(macroCtx.agentData ?? {}) },
     lorebookDepthEntriesCount,
     ...(markerCtx.updatedEntryStateOverrides
       ? { updatedEntryStateOverrides: markerCtx.updatedEntryStateOverrides }


### PR DESCRIPTION
## Why

Several related chat and library paths bypassed Marinara Engine's shared chroma, dialog, and macro-editor contracts. That left greetings visually inconsistent and non-functional, destructive actions using hard-coded red, character favorites using hard-coded yellow, Author's Notes without the shared editing affordances, and raw connection failures using hard-coded pink.

This is a follow-up to #4072 and the July 25 issue sweep in #4077. It completes the maintainer-requested UI consistency and regression work without reopening the already-resolved issue.

## What changed

- Make greeting selection add the chosen first message to an existing Roleplay chat and render greeting previews with the character narration/dialogue colors.
- Remove the greeting chooser icon and replace hard-coded pink/error text with chroma-aware styling.
- Move Author's Notes expansion and macro guidance into the textarea control, and pass the complete chat/preset macro context through live generation and dry-run prompt assembly.
- Apply the shared accent button treatment to destructive confirmation actions, including bulk chat deletion.
- Apply the configured accent color to character favorites instead of hard-coded yellow.
- Add focused browser regressions for greetings, Author's Notes, connection errors, favorites, and destructive actions.

## Impact and root cause

The affected views had accumulated one-off colors and action implementations instead of using the shared UI primitives. Greeting selection also updated character membership without committing the selected greeting message. The patch routes those behaviors through the established chroma, dialog, roleplay-message, and macro utilities.

## Validation

- `pnpm check`
- Focused Playwright regressions in `e2e/core-flows.e2e.ts`
- `git diff --check`

`pnpm check` passes with the existing `NoodleHome.tsx` exhaustive-deps warning and no errors.

## Manual verification

- [ ] Manually verify adding a character with alternate greetings to a wizard-skipped Roleplay chat.
- [ ] Manually verify Author's Notes expansion, macro guidance, and live/dry-run macro expansion.
- [ ] Manually verify delete confirmations and bulk chat deletion under a custom accent color.
- [ ] Manually verify character favorite stars and raw connection errors under a custom accent color.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added greeting previews with character-specific dialogue styling and a more robust first-message confirmation flow.
  * Introduced accent tone support for dialogs and delete actions, plus accessible labeling for macro text areas.
  * Enhanced prompt generation to include author notes and assembled macro variables/agent data.

* **Style**
  * Updated favorites, dialog actions, bulk-delete tone, and connection error styling to consistently use configured accent/chroma.

* **Bug Fixes**
  * Prevented author-notes dismissal during macro modal interactions; improved greeting confirmation guarding and macro styling sanitization.

* **Tests**
  * Added desktop-only e2e coverage for greeting selection, accent/chroma consistency, confirmations, favorites, and error notifications.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->