### PR TITLE
Fix the Clean HTML outgoing prompt regex

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 ### Fixed
 
 - Rendered indented code fences correctly in the shared markdown renderer: a fence nested inside a list item (as in several developer guides) previously never closed and showed its ` ``` ` markers as literal text in the docs viewer, and list-nested code no longer renders or copies phantom leading spaces (#4100).
+- Replaced the unsafe built-in **Clean HTML (Outgoing Prompt)** regex with a validator-safe tag cleaner and migrated unchanged legacy defaults, restoring HTML and group-speaker-tag cleanup for Immersive HTML and Agent prompt history without overwriting customized scripts (#4101).
 - Streamed native profile and full-backup ZIP exports to disk with bounded JSONL table shards, preventing large libraries from failing with `Invalid string length` while preserving preview/import compatibility and archive integrity checks (#4064).
 - Included the live Character or Persona card as the first, explicitly labelled current revision in version history; saved revisions now show stable sequence numbers and second-precision edit times (#4040).
 - Made Conversation composer chrome focus the real text field, kept mobile thinking controls clear of participant names, and repaired the downloadable Calls surface's mobile participant labels and seven-button control rail (#4053, #4054).

--- a/packages/server/src/db/seed-regex.ts
+++ b/packages/server/src/db/seed-regex.ts
@@ -5,12 +5,25 @@
 import type { DB } from "./connection.js";
 import { regexScripts } from "./schema/index.js";
 import { now } from "../utils/id-generator.js";
+import { eq } from "./file-query.js";
 
-const CLEAN_HTML_ID = "default-clean-html";
+export const CLEAN_HTML_ID = "default-clean-html";
 const COLLAPSE_NEWLINES_ID = "default-collapse-newlines";
 
+export const LEGACY_CLEAN_HTML_FIND_REGEX =
+  String.raw`[ \t]?<(?!--)(?!\/?(?:font|lie|filter)\b)(?:"[^"]*"|'[^']*'|[^'">])*>`;
+
+export const CLEAN_HTML_FIND_REGEX =
+  String.raw`<(?:!DOCTYPE\b[^>]*|\/?(?!(?:font|lie|filter)\b)[A-Za-z][^>]*)>`;
+
+export function shouldMigrateCleanHtmlPattern(row: { id: string; findRegex: string }): boolean {
+  return row.id === CLEAN_HTML_ID && row.findRegex === LEGACY_CLEAN_HTML_FIND_REGEX;
+}
+
 export async function seedDefaultRegexScripts(db: DB) {
-  const existing = await db.select({ id: regexScripts.id }).from(regexScripts);
+  const existing = await db
+    .select({ id: regexScripts.id, findRegex: regexScripts.findRegex })
+    .from(regexScripts);
 
   const existingIds = new Set(existing.map((r) => r.id));
   const timestamp = now();
@@ -20,7 +33,7 @@ export async function seedDefaultRegexScripts(db: DB) {
       id: CLEAN_HTML_ID,
       name: "Clean HTML (Outgoing Prompt)",
       enabled: "true",
-      findRegex: "[ \\t]?<(?!--)(?!\\/?(?:font|lie|filter)\\b)(?:\"[^\"]*\"|'[^']*'|[^'\">])*>",
+      findRegex: CLEAN_HTML_FIND_REGEX,
       replaceString: "",
       trimStrings: "[]",
       placement: '["user_input","ai_output"]',
@@ -57,5 +70,13 @@ export async function seedDefaultRegexScripts(db: DB) {
   const toInsert = defaults.filter((d) => !existingIds.has(d.id));
   if (toInsert.length > 0) {
     await db.insert(regexScripts).values(toInsert);
+  }
+
+  const legacyCleanHtml = existing.find(shouldMigrateCleanHtmlPattern);
+  if (legacyCleanHtml) {
+    await db
+      .update(regexScripts)
+      .set({ findRegex: CLEAN_HTML_FIND_REGEX, updatedAt: timestamp })
+      .where(eq(regexScripts.id, CLEAN_HTML_ID));
   }
 }

--- a/scripts/regressions/prompt.regression.ts
+++ b/scripts/regressions/prompt.regression.ts
@@ -245,6 +245,13 @@ import {
   executeAgentBatch,
   renderAgentPromptTemplate,
 } from "../../packages/server/src/services/agents/agent-executor.js";
+import {
+  CLEAN_HTML_FIND_REGEX,
+  CLEAN_HTML_ID,
+  LEGACY_CLEAN_HTML_FIND_REGEX,
+  shouldMigrateCleanHtmlPattern,
+} from "../../packages/server/src/db/seed-regex.js";
+import { applyRegexScriptsToPromptText } from "../../packages/server/src/services/regex/regex-application.js";
 import { shouldSkipAgentByAssistantInterval } from "../../packages/server/src/services/generation/agent-cadence.js";
 import { filterPromptMessagesForCharacterAudience } from "../../packages/server/src/services/generation/prompt-message-scope.js";
 import {
@@ -1870,6 +1877,97 @@ const cases: RegressionCase[] = [
       assert.equal(isPatternSafe(String.raw`([^|]+)\|([^|]+)\|([^|]+)`), true);
       assert.equal(isPatternSafe(String.raw`([^\\|]+)\|([^\\|]+)\|([^\\|]+)`), true);
       assert.equal(isPatternSafe(String.raw`[^|]+x[^|]+y[^|]+`), false);
+    },
+  },
+  {
+    name: "Clean HTML default is safe and removes prompt markup without clobbering exclusions",
+    run() {
+      assert.equal(isPatternSafe(LEGACY_CLEAN_HTML_FIND_REGEX), false);
+      assert.equal(isPatternSafe(CLEAN_HTML_FIND_REGEX), true);
+      assert.equal(
+        createRegexScriptSchema.safeParse({
+          name: "Clean HTML (Outgoing Prompt)",
+          findRegex: CLEAN_HTML_FIND_REGEX,
+          placement: ["user_input", "ai_output"],
+          flags: "g",
+          promptOnly: true,
+          applyMode: "prompt",
+        }).success,
+        true,
+      );
+
+      const source = [
+        "<!DOCTYPE html>",
+        '<section class="immersive-frame"><div data-speaker="Albedo">A rendered memory.</div></section>',
+        '<speaker="Dottore">"Observe the result."</speaker>',
+        '<font color="#f0f">Keep font markup.</font>',
+        "<lie>Keep lie markup.</lie>",
+        "<filter>Keep filter markup.</filter>",
+        "<!-- keep the author comment -->",
+      ].join("\n");
+      const cleaned = applyRegexScriptsToPromptText(
+        source,
+        [
+          {
+            id: CLEAN_HTML_ID,
+            name: "Clean HTML (Outgoing Prompt)",
+            enabled: "true",
+            findRegex: CLEAN_HTML_FIND_REGEX,
+            replaceString: "",
+            trimStrings: "[]",
+            placement: '["user_input","ai_output"]',
+            flags: "g",
+            promptOnly: "true",
+            applyMode: "prompt",
+            targetCharacterIds: "[]",
+            minDepth: null,
+            maxDepth: null,
+          },
+        ],
+        "ai_output",
+        0,
+      );
+
+      assert.doesNotMatch(cleaned, /<!DOCTYPE|<\/?(?:section|div|speaker)\b/u);
+      assert.match(cleaned, /A rendered memory\./u);
+      assert.match(cleaned, /"Observe the result\."/u);
+      assert.match(cleaned, /<font color="#f0f">Keep font markup\.<\/font>/u);
+      assert.match(cleaned, /<lie>Keep lie markup\.<\/lie>/u);
+      assert.match(cleaned, /<filter>Keep filter markup\.<\/filter>/u);
+      assert.match(cleaned, /<!-- keep the author comment -->/u);
+    },
+  },
+  {
+    name: "Clean HTML seed migration only replaces the exact broken built-in pattern",
+    run() {
+      assert.equal(
+        shouldMigrateCleanHtmlPattern({
+          id: CLEAN_HTML_ID,
+          findRegex: LEGACY_CLEAN_HTML_FIND_REGEX,
+        }),
+        true,
+      );
+      assert.equal(
+        shouldMigrateCleanHtmlPattern({
+          id: CLEAN_HTML_ID,
+          findRegex: CLEAN_HTML_FIND_REGEX,
+        }),
+        false,
+      );
+      assert.equal(
+        shouldMigrateCleanHtmlPattern({
+          id: CLEAN_HTML_ID,
+          findRegex: "<custom-tag>",
+        }),
+        false,
+      );
+      assert.equal(
+        shouldMigrateCleanHtmlPattern({
+          id: "user-clean-html",
+          findRegex: LEGACY_CLEAN_HTML_FIND_REGEX,
+        }),
+        false,
+      );
     },
   },
   {


### PR DESCRIPTION
## Linked issue

Closes #4101

## Why this change

- The built-in **Clean HTML (Outgoing Prompt)** pattern nested unbounded quoted-attribute repeats inside another unbounded group. Marinara's ReDoS guard therefore rejected the default during editing and skipped it during prompt application, leaving HTML and `<speaker>` wrappers in context used by Immersive HTML, group Roleplay, and Agent workflows.

## What changed

- Replaced the nested-repeat expression with a validator-safe tag-oriented pattern that removes ordinary HTML/XML-style tags, group `<speaker>` wrappers, and doctypes.
- Preserved the existing intentional exclusions for `<font>`, `<lie>`, `<filter>`, and HTML comments.
- Added a startup migration that updates only the built-in `default-clean-html` row when its pattern is an exact match for the broken legacy default. Customized scripts and unrelated rows are not overwritten.
- Added prompt regressions covering safety validation, save-schema acceptance, Immersive HTML markup, speaker cleanup, protected tags/comments, and migration boundaries.
- Documented the fix in the Unreleased changelog.

## Validation

- [ ] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed `CONTRIBUTING.md`

### Manual verification notes

- Automated validation performed: `pnpm regression:prompt`, `pnpm check`, and `git diff --check`.
- The focused regression confirms the old default is rejected, the replacement passes the safety and save schemas, Immersive HTML and group speaker tags are removed from outgoing prompt text, protected tags/comments remain, and only the exact legacy built-in pattern qualifies for migration.
- A human app walkthrough and container run remain to be performed.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Version/release files updated (only if this PR includes a version bump)

`CHANGELOG.md` includes the fix under Unreleased. No version-bearing files changed.

## UI evidence (if applicable)

Not applicable; this is a prompt-cleanup and startup-migration fix.
