### PR TITLE
Stop one invalid field from resetting all Noodle settings

### DIFF
--- a/packages/server/src/services/storage/noodle.storage.ts
+++ b/packages/server/src/services/storage/noodle.storage.ts
@@ -50,6 +50,7 @@ import {
 } from "@marinara-engine/shared";
 import type { DB } from "../../db/connection.js";
 import { isFileUniqueConstraintError } from "../../db/file-schema.js";
+import { logger } from "../../lib/logger.js";
 import { canViewNoodlerPost, isNoodlerHiddenFromViewer } from "../noodle/noodler-access.js";
 import { nextAutoPostRunAt } from "../noodle/noodle-autopost-cadence.js";
 import {
@@ -407,12 +408,30 @@ export function normalizeNoodleSettings(raw: unknown): NoodleSettings {
   const rawRecord = parseRecord(raw);
   const migratedMaxImagesPerRefresh =
     rawRecord.maxImagesPerRefresh ?? rawRecord.maxImagePromptsPerDay ?? DEFAULT_NOODLE_SETTINGS.maxImagesPerRefresh;
-  const parsed = noodleSettingsSchema.safeParse({
+  const candidate: Record<string, unknown> = {
     ...DEFAULT_NOODLE_SETTINGS,
     ...rawRecord,
     maxImagesPerRefresh: migratedMaxImagesPerRefresh,
-  });
-  if (!parsed.success) return noodleSettingsSchema.parse(DEFAULT_NOODLE_SETTINGS);
+  };
+  let parsed = noodleSettingsSchema.safeParse(candidate);
+  if (!parsed.success) {
+    // One unparseable field used to discard *every* stored Noodle setting, silently resetting
+    // things the user never touched (lorebook context, invited character folders, connection).
+    // Drop only the fields that failed and let the schema default those instead.
+    const rejectedKeys = new Set(
+      parsed.error.issues.map((issue) => String(issue.path[0] ?? "")).filter((key) => key.length > 0),
+    );
+    logger.warn(
+      "Noodle settings had invalid field(s); falling back to defaults for: %s",
+      [...rejectedKeys].join(", ") || "(unknown)",
+    );
+    for (const key of rejectedKeys) delete candidate[key];
+    parsed = noodleSettingsSchema.safeParse({ ...DEFAULT_NOODLE_SETTINGS, ...candidate });
+    if (!parsed.success) {
+      logger.error(parsed.error, "Noodle settings could not be recovered; resetting to defaults");
+      return noodleSettingsSchema.parse(DEFAULT_NOODLE_SETTINGS);
+    }
+  }
   const min = Math.min(parsed.data.participantMin, parsed.data.participantMax);
   const max = Math.max(parsed.data.participantMin, parsed.data.participantMax);
   const providedCarryoverModes = Array.isArray(rawRecord.carryoverModes);

--- a/scripts/regressions/noodle-settings.regression.ts
+++ b/scripts/regressions/noodle-settings.regression.ts
@@ -7,10 +7,14 @@ import { eq } from "../../packages/server/src/db/file-query.js";
 import { createFileNativeDB } from "../../packages/server/src/db/file-backed-store.js";
 import { noodleAccounts } from "../../packages/server/src/db/schema/noodle.js";
 import {
+  DEFAULT_NOODLE_SETTINGS,
   noodleAccountSettingsPatchSchema,
   noodleAccountUpdateSchema,
 } from "../../packages/shared/src/schemas/noodle.schema.js";
-import { createNoodleStorage } from "../../packages/server/src/services/storage/noodle.storage.js";
+import {
+  createNoodleStorage,
+  normalizeNoodleSettings,
+} from "../../packages/server/src/services/storage/noodle.storage.js";
 import { resolveNoodleAvatarCropAfterProfileUpdate } from "../../packages/server/src/services/noodle/noodle-profile-avatar.js";
 
 const sourceCrop = { x: 12, y: 18, width: 62, height: 62, unit: "%" as const };
@@ -58,6 +62,21 @@ assert.equal(
   }),
   null,
 );
+
+// One invalid stored field must not reset unrelated settings: a bad autoPostingDefaultIntensity
+// used to wipe lorebook context, invited character folders, and the generation connection.
+const salvaged = normalizeNoodleSettings({
+  autoPostingDefaultIntensity: 4,
+  enableLorebookContext: true,
+  invitedCharacterGroupIds: ["folder-1"],
+  generationConnectionId: "conn-1",
+  refreshesPerDay: 6,
+});
+assert.equal(salvaged.enableLorebookContext, true);
+assert.deepEqual(salvaged.invitedCharacterGroupIds, ["folder-1"]);
+assert.equal(salvaged.generationConnectionId, "conn-1");
+assert.equal(salvaged.refreshesPerDay, 6);
+assert.equal(salvaged.autoPostingDefaultIntensity, DEFAULT_NOODLE_SETTINGS.autoPostingDefaultIntensity);
 
 const storageDir = mkdtempSync(join(tmpdir(), "marinara-noodle-settings-"));
 process.env.FILE_STORAGE_DIR = storageDir;


### PR DESCRIPTION
## Linked issue

Closes #4110

<!-- Reported on Discord: a user's Noodle timeline generation stopped receiving character cards and lorebook entries, sending only account names to the LLM. -->

## Why this change

- `normalizeNoodleSettings` threw away the **entire** stored Noodle settings object whenever zod rejected **any single field**, silently reverting choices the user never touched — `enableLorebookContext`, `invitedCharacterGroupIds`, `generationConnectionId`, refresh limits, and the rest.
- The reset was invisible: no log line, no warning, no UI signal. The symptom a user actually sees is Noodle generation quietly losing character cards and lorebook context, so the model invents unrelated content.
- The blast radius grows every time a narrow field is added to the schema. `autoPostingDefaultIntensity: z.union([z.literal(1), z.literal(3), z.literal(6)])` (added in 0ac4d396f) is exactly this shape: one out-of-range stored value nukes everything else.

## What changed

- `packages/server/src/services/storage/noodle.storage.ts` — on parse failure, collect the rejected top-level keys from `parsed.error.issues`, drop only those from the candidate object, and re-parse so the schema defaults just the bad fields. All other stored values survive.
- Log a `logger.warn` naming the rejected fields, so the next occurrence is diagnosable instead of silent.
- Keep the full-defaults reset as a last resort, now preceded by a `logger.error` with the zod error.
- `scripts/regressions/noodle-settings.regression.ts` — new assertion: settings carrying an invalid `autoPostingDefaultIntensity` retain `enableLorebookContext`, `invitedCharacterGroupIds`, `generationConnectionId`, and `refreshesPerDay`, while only the bad field falls back to its default.

Note: this fixes the *mechanism* that can silently reset Noodle settings. It is not confirmed to be the cause of the specific Discord report — that user's settings still need to be inspected to confirm which path reset them.

### Possible originating report (investigated — see follow-up below)

This **may** be the cause of the following Discord report by AgentX — but that is a hypothesis, not a confirmed link. The user's stored settings still need to be inspected before anyone treats this as the fix for their case.

https://discord.com/channels/1417099416812392641/1495493775617687775/1530687702653997126

> Hmm... My perfect Noodle is now gone. Not sure what happened. None of the lorebook entries are being passed to the LLM, so all of the posts and replies are just random stuff (like kings, copper coins, real work stuff, etc.) unlike yesterday and eariler this morning when it passed by Star Wars lorebooks and desc and was actually making sense. Looking at the recent requests sent to LLM, none of the char cards or lorebooks were sent, just the account names so the LLM didn't have any info to work from so it just invented stuff.

The described symptom — account names present, character cards and lorebook entries absent — matches what a settings reset to defaults produces (`enableLorebookContext: false`, `invitedCharacterGroupIds: []`). Other paths could produce the same output, so this stays labelled as a possible cause until confirmed.

#### Follow-up report — this hypothesis now looks unlikely

A later message from AgentX:

> Okay, now. I have a bunch of rando Elaras in my LLM response. It's just using randos now. Still no lorebooks. I have rando turned off, so Elara isn't posting to my noodle feed, but I see their responses in LLM response. Got error saying couldn't update timeline because there's no responses (because they were all rando responses).
>
> Interesting, it's creating rando's now with their own desc and lore, so I got Kaelen_Storm and Elara_Whisper
>
> I'm not seeing any lore. My SW characters talking about medieval fantasy stuff. I refreshed a few times.

Two things follow from this, and they point away from the settings-reset bug:

1. **The "randos" are hallucinated, not real accounts.** `Kaelen_Storm` / `Elara_Whisper` are authors the model invented because the prompt gave it nothing to work from. `validateNoodleGeneratedRefresh` rejects handles outside the known set (`noodle-public-generation.service.ts:351-353`), triggers one correction retry, and throws on a second failure (`:411`) — which is the "couldn't update timeline because there's no responses" error they saw.
2. **`allowRandomUsers` is off, and its default is already `false`.** A reset to defaults could not have enabled random users, and the user confirms they are off. So the settings-wipe path does not explain this report.

With `allowRandomUsers` off, `chooseNoodleParticipantAccounts` only yields **character-kind** candidates (`noodle-participant-selection.ts:73-76`). Selection clearly succeeded — otherwise generation would have stopped with "Invite a character, select a character folder, or enable random users before refreshing" (`noodle-public-generation.service.ts:236-239`). So character accounts *were* selected, yet `# Character Profiles` was still empty.

That leaves a more likely root cause: **`characters.getById(account.entityId)` returned `null` for every selected account** (`noodle-public-prompt.service.ts:330`). Orphaned Noodle accounts — rows whose `entityId` no longer resolves to a character — would produce exactly this. The account name list still renders (it comes from `noodle_accounts`), the character cards vanish, and the lorebook scan is scoped to character IDs that do not exist, so no entries activate. Every symptom in both reports, from one cause.

Worth noting: nothing prunes `noodle_accounts` when a character is deleted — there is no delete/prune path in `noodle.storage.ts` — so orphaned accounts persist and keep getting picked as participants.

**Next diagnostic step:** for each invited Noodle account of kind `character`, check whether a `characters` row with that `entityId` still exists.


## Validation

- [ ] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed `CONTRIBUTING.md`

### Manual verification notes

- [ ] Manually verify in the app: enable Noodle Settings → World & Lore → "Lorebook context" and invite a character folder, then hand-edit the stored `noodle.settings` value to set `autoPostingDefaultIntensity` to an invalid number (e.g. `4`). Reload Noodle Settings and confirm the lorebook toggle and invited folders are still set, and only the intensity fell back to `1`.
- [ ] Manually verify the server log emits `Noodle settings had invalid field(s); falling back to defaults for: autoPostingDefaultIntensity` in that case.
- [ ] Manually verify a Noodle timeline refresh with Debug mode on still logs `[debug/noodle] Activated N lorebook entr(ies)` and that `# Character Profiles` is populated in the logged prompt.
- [ ] Manually verify saving Noodle settings from the UI round-trips normally when nothing is invalid.

Automated, run locally:

- `pnpm --filter @marinara-engine/server exec tsx ../../scripts/regressions/noodle-settings.regression.ts` — passes with this change, fails without it (verified by reverting the storage file).

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Translated docs on the `docs-i18n` branch updated to match, or a `[docs-i18n]` follow-up issue opened (see CONTRIBUTING.md § Translated documentation)
- [ ] Version/release files updated (only if this PR includes a version bump)

## UI evidence (if applicable)

<!-- No UI changes; server-side settings normalization only. -->




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved settings recovery so invalid individual values no longer reset unrelated preferences.
  * Preserved valid settings while restoring only affected values to their defaults.
  * Added clearer logging when settings require recovery.

* **Tests**
  * Added regression coverage verifying that valid noodle settings remain intact when one stored value is invalid.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
