### PR TITLE
[docs-i18n] update card versions and Prompts section

### DIFF
--- a/es/characters/creating-and-editing-characters.md
+++ b/es/characters/creating-and-editing-characters.md
@@ -138,7 +138,9 @@ Para volver a una versión anterior:
 1. Abre la ventana **Compare** para la versión que quieres, o haz clic en su icono de restaurar en la lista.
 2. Haz clic en **Restore this version** (Restaurar esta versión), y luego confirma.
 
-Restaurar reemplaza tu tarjeta actual por esa instantánea. No añade una nueva entrada al historial. También puedes eliminar una instantánea guardada de la lista. Eliminar una instantánea no cambia tu tarjeta actual.
+Restaurar reemplaza tu tarjeta actual por esa instantánea. No añade una nueva entrada al historial. Usa el icono de lápiz para corregir la etiqueta de versión de una instantánea guardada sin restaurarla. También puedes eliminar una instantánea guardada de la lista; eliminarla no cambia tu tarjeta actual.
+
+Usa **Reset** (Restablecer) en el encabezado de **Version history** cuando quieras reiniciar el versionado de la tarjeta. Después de confirmar, Marinara elimina todas las instantáneas guardadas y establece la versión de la tarjeta actual en `0.0`. Esta acción no se puede deshacer.
 
 ## Revisar las actualizaciones de tarjeta propuestas por un agente
 

--- a/es/characters/personas.md
+++ b/es/characters/personas.md
@@ -135,10 +135,13 @@ Cada vez que guardas un cambio en los campos de tarjeta de una persona, Marinara
 Para cada versión guardada puedes:
 
 1. Hacer clic en su título para abrir una vista de comparación contra la persona actual.
-2. Hacer clic en **Restore this version** (Restaurar esta versión) para sobrescribir la persona actual con esa versión guardada. Un cuadro de diálogo de confirmación te pide que confirmes.
-3. Hacer clic en **Delete this saved version** (Eliminar esta versión guardada) para quitar esa entrada del historial. Esto no cambia la persona actual.
+2. Hacer clic en **Rename this saved version** (Cambiar el nombre de esta versión guardada; icono de lápiz) para corregir la etiqueta de versión de la tarjeta sin restaurarla.
+3. Hacer clic en **Restore this version** (Restaurar esta versión) para sobrescribir la persona actual con esa versión guardada. Un cuadro de diálogo de confirmación te pide que confirmes.
+4. Hacer clic en **Delete this saved version** (Eliminar esta versión guardada) para quitar esa entrada del historial. Esto no cambia la persona actual.
 
 Antes de tu primera edición, el panel dice "Previous persona states will appear here after the next edit." (Los estados anteriores de la persona aparecerán aquí después de la próxima edición.).
+
+Usa **Reset** (Restablecer) en el encabezado del panel para eliminar todas las instantáneas guardadas de la persona y establecer la versión de la tarjeta actual en `0.0`. Marinara pide confirmación porque el historial eliminado no se puede recuperar.
 
 ## Duplicar una persona
 

--- a/es/manifest.json
+++ b/es/manifest.json
@@ -1,5 +1,6 @@
 {
   "language": "es",
+  "sourceCommit": "b8435fb7a",
   "files": [
     {
       "path": "CONFIGURATION.md",
@@ -108,8 +109,8 @@
     },
     {
       "path": "characters/creating-and-editing-characters.md",
-      "sha256": "2d864dbab9388ae76858a68ce0ebcefc4855ee80083afa3768816d554a1e9910",
-      "bytes": 13112
+      "sha256": "535a7e855aab3f6f7092b9c7c5ab37f3cdf3ede86b73828de44b1d08a89435ad",
+      "bytes": 13491
     },
     {
       "path": "characters/galleries.md",
@@ -128,8 +129,8 @@
     },
     {
       "path": "characters/personas.md",
-      "sha256": "1ae1fd6d60b74df1b02da0d3d1d15a5c6e4a44f30f3c9035fbe4ceccf2ab41c1",
-      "bytes": 17001
+      "sha256": "e220d27562a3affe8dde962ab01367ee6440e20f2678397f5d2b092b7a59eb73",
+      "bytes": 17435
     },
     {
       "path": "characters/sprites.md",
@@ -573,8 +574,8 @@
     },
     {
       "path": "prompts/presets.md",
-      "sha256": "fca195f94d52e3338594cca353a9f9f9a3a9adc58dd0499b5cf10e39ae3b2dba",
-      "bytes": 13370
+      "sha256": "85d58ba9f8572176a23d970fedd2bb55b028472840c47bec1a7c85d1ad6d0011",
+      "bytes": 13452
     },
     {
       "path": "prompts/prompt-overrides.md",

--- a/es/prompts/presets.md
+++ b/es/prompts/presets.md
@@ -12,7 +12,7 @@ Los presets no necesitan una API key (clave de API) ni una cuenta. Solo describe
 
 ## Abrir el Preset Editor
 
-Los presets de prompt viven en el panel **Presets** (Presets), en el lado izquierdo de la app.
+Los presets de prompt viven en la sección **Prompts** del panel **Presets**, en el lado izquierdo de la app. Las otras secciones de este panel son **Regexes** y **Functions**.
 
 El panel tiene tres botones en la parte superior:
 


### PR DESCRIPTION
## Companion to

- #4137

## Why this change

- Keeps the Spanish documentation pack aligned with the updated Character and Persona version-history controls and the Prompts section label in the Presets panel.
- Long-Term Memory documentation is intentionally excluded and remains owned by Promansis.

## What changed

- Documented saved-version renaming and destructive reset-to-0.0 behavior for Characters and Personas.
- Updated the prompt-preset guide to identify the Prompts, Regexes, and Functions sections.
- Regenerated the Spanish pack manifest against source commit `b8435fb7a`.

## Validation

- [ ] `node scripts/docs-i18n/validate-pack.mjs <pack>` passes locally
- [ ] Reviewed translated prose and preserved paths, URLs, and code literals

### Validation notes

- Pack validation reported 123 translated docs matching 123 English docs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified version history actions for characters and personas, including rename, restore, delete, and reset behavior.
  * Documented that restoring replaces the current version without creating a new history entry.
  * Explained that resetting removes all saved snapshots, sets the version to 0.0, and cannot be undone.
  * Clarified that prompt presets are located under **Prompts** in the **Presets** panel.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->