### PR TITLE
docs: translate TTS, continuation, and reasoning guidance

### DIFF
--- a/es/chats/messages.md
+++ b/es/chats/messages.md
@@ -71,6 +71,8 @@ Estas tres acciones se parecen pero hacen cosas distintas. Elige la que correspo
 
 El comando **/continue** extiende el mismo mensaje. Escribe `/continue` (o su forma corta `/cont`) en la caja de entrada y envíalo. La IA retoma donde se detuvo su última respuesta y añade más texto a ese mismo mensaje, en lugar de hacer un nuevo swipe.
 
+De forma predeterminada, Marinara inserta una línea en blanco antes del texto añadido. Para adjuntar la continuación directamente al último carácter de la respuesta anterior, desactiva **Settings → General → Responses → Add a new line before /continue text**. Marinara indicará entonces al modelo que continúe exactamente desde el punto de corte, sin separador.
+
 ```
 /continue
 ```

--- a/es/chats/slash-commands.md
+++ b/es/chats/slash-commands.md
@@ -27,7 +27,7 @@ Estos comandos te ayudan a gestionar el chat y sus mensajes. Funcionan en los ch
 | Comando | También funciona como | Qué hace |
 |---|---|---|
 | `/help` | | Enumera todos los comandos slash. |
-| `/continue` | `/cont` | Añade más texto a la última respuesta de la IA, sin enviar un mensaje nuevo. |
+| `/continue` | `/cont` | Añade más texto a la última respuesta de la IA, sin enviar un mensaje nuevo. La opción **Add a new line before /continue text** de **Settings → General → Responses** controla si ese texto empieza después de una línea en blanco o directamente en el punto de corte. |
 | `/goto` | `/jump`, `/scroll` | Desplaza el chat hasta un mensaje según su número. |
 | `/hide` | | Oculta uno o más mensajes a la IA en los turnos siguientes. |
 | `/unhide` | | Devuelve los mensajes ocultos a la vista de la IA. |

--- a/es/manifest.json
+++ b/es/manifest.json
@@ -1,6 +1,6 @@
 {
   "language": "es",
-  "sourceCommit": "b8435fb7a",
+  "sourceCommit": "bd382c69238e9cd6d801657f74a2f696e96a60e5",
   "files": [
     {
       "path": "CONFIGURATION.md",
@@ -174,8 +174,8 @@
     },
     {
       "path": "chats/messages.md",
-      "sha256": "828ac031da44a28b07c02fcc650e47913c85bfd3180f90285503733865e8bf44",
-      "bytes": 10536
+      "sha256": "485a0f29f317ed689c8a479e8baa287363077bb6434d1d1eaf88574d55ebd6b1",
+      "bytes": 10912
     },
     {
       "path": "chats/peek-prompt.md",
@@ -194,8 +194,8 @@
     },
     {
       "path": "chats/slash-commands.md",
-      "sha256": "4dceed3a5009c16539870b9b86b3afb4e84cd4abe010bb8ea3a5414d3735858e",
-      "bytes": 8040
+      "sha256": "8b0d5ab2cca54a43364021bb4b8783a0b359683f6d1343c6675a5571bcd79489",
+      "bytes": 8234
     },
     {
       "path": "connections/connecting-to-a-provider.md",
@@ -539,8 +539,8 @@
     },
     {
       "path": "media/tts-setup.md",
-      "sha256": "7afec1e388b4f103fc18f1451bb90259f19f116fd4a93c66ce4c856c5ee1bd9d",
-      "bytes": 15134
+      "sha256": "08b6003498dac6ef91d780a701f5bda5e98353bcd397e03de471a93043071754",
+      "bytes": 15870
     },
     {
       "path": "noodle/overview.md",
@@ -559,8 +559,8 @@
     },
     {
       "path": "prompts/generation-parameters.md",
-      "sha256": "c880c302edaaafed68caf2f9893896dd6f4b293265d014e5214a35c5bc3c830d",
-      "bytes": 13723
+      "sha256": "b62b3e26472fcf25f512bc8cd05b88ba30363b1693f63b8c56c7e0b0eb88f3f2",
+      "bytes": 14374
     },
     {
       "path": "prompts/macros.md",

--- a/es/media/tts-setup.md
+++ b/es/media/tts-setup.md
@@ -42,7 +42,7 @@ La app rellena estos valores predeterminados por **Source**:
 | PocketTTS         | http://localhost:49112    | pocket-tts             | alba                            |
 | xAI Voice         | https://api.x.ai/v1       | grok-tts               | eve                             |
 
-Para **ElevenLabs**, el campo **Model** ofrece un menú desplegable de modelos de voz. Elige un modelo de voz normal. Los IDs de modelo que contienen `ttv` son modelos de diseño de voz, no modelos de voz, y no pueden leer texto en voz alta. Si eliges uno por error, la reproducción falla con un error que te indica que uses un modelo de voz en su lugar.
+Para **ElevenLabs**, el campo **Model** carga los modelos capaces de sintetizar voz disponibles mediante tu conexión y siempre mantiene visible la lista completa cuando lo abres. Elige un modelo de voz normal. Los IDs de modelo que contienen `ttv` son modelos de diseño de voz, no modelos de voz, y no pueden leer texto en voz alta. Si eliges uno por error, la reproducción falla con un error que te indica que uses un modelo de voz en su lugar.
 
 ### PocketTTS es un programa aparte
 
@@ -61,9 +61,9 @@ El ajuste **Voice Option** (Opción de voz) decide cómo se asignan las voces:
 
 Elige la voz en el campo **All Characters Voice**. PocketTTS muestra en un menú desplegable las voces que devuelve tu servidor y mantiene a su lado un campo de texto para un ID de voz, una URL o una ruta personalizados.
 
-Para cargar la lista de voces real de tu proveedor, primero guarda la tarjeta con TTS activado. Luego haz clic en el botón **Refresh voices** (el icono de flecha circular). Antes de conectarte, la app muestra una breve lista de reserva integrada para que el campo no esté vacío. Esa lista de reserva puede estar desactualizada, así que actualiza para obtener las voces actuales de tu proveedor.
+Para cargar la lista de voces real de tu proveedor, introduce los datos de conexión y haz clic en el botón **Refresh voices** (el icono de flecha circular). Puedes hacerlo antes de activar la reproducción. Al actualizar, primero se guarda la tarjeta actual, por lo que una clave API recién introducida se usa de inmediato. Antes de conectarte, la app muestra una breve lista de reserva integrada para que el campo no esté vacío. Si el proveedor devuelve un error, la app lo muestra en vez de presentar silenciosamente esa lista de reserva como si la actualización hubiera funcionado.
 
-Para **ElevenLabs**, debes elegir una voz. El menú desplegable empieza en "Select an ElevenLabs voice", y la reproducción se bloquea hasta que elijas una voz real.
+Para **ElevenLabs**, debes elegir una voz. Marinara carga la biblioteca paginada de la cuenta, incluidas las voces personales, del espacio de trabajo, guardadas y predeterminadas. El selector tiene un campo de búsqueda y una barra de desplazamiento siempre visible cuando la biblioteca es más larga que el panel. También indica cuántas voces se han cargado. El selector empieza en "Select an ElevenLabs voice", y la reproducción se bloquea hasta que elijas una voz real.
 
 ### Selected per character
 
@@ -73,7 +73,7 @@ Para **ElevenLabs**, debes elegir una voz. El menú desplegable empieza en "Sele
 4. Elige un personaje en el menú desplegable de la izquierda y una voz en el de la derecha.
 5. Repite para cada personaje al que quieras dar una voz personalizada.
 
-Primero debes crear tus personajes. Si aún no tienes ninguno, la app te indica que añadas personajes en la pestaña **Characters** antes de asignar voces. Los personajes sin una voz personal recurren a la voz global. Consulta [Crear y editar personajes](../characters/creating-and-editing-characters.md).
+El botón **Refresh** del cuadro **Character Voices** vuelve a cargar la misma biblioteca del proveedor sin cambiar al modo de una sola voz. Primero debes crear tus personajes. Si aún no tienes ninguno, la app te indica que añadas personajes en la pestaña **Characters** antes de asignar voces. Los personajes sin una voz personal recurren a la voz global. Consulta [Crear y editar personajes](../characters/creating-and-editing-characters.md).
 
 ## Narrator Voice
 

--- a/es/prompts/generation-parameters.md
+++ b/es/prompts/generation-parameters.md
@@ -42,6 +42,8 @@ Juntas, **Frequency** y **Presence** son las penalizaciones por repetición.
 
 **Reasoning Effort** le dice a un modelo con capacidad de razonamiento cuánto razonar antes de responder. Un modelo con capacidad de razonamiento es uno que resuelve un problema primero en pasos ocultos. Las opciones son **None**, **Low**, **Medium**, **High**, **Xhigh** y **Maximum**. Si el modelo no admite el nivel que eliges, Marinara lo baja al nivel más fuerte que ese modelo permite.
 
+Cuando el interruptor del parámetro está activado, **None** pide explícitamente al proveedor que desactive el razonamiento, en vez de limitarse a omitir el ajuste de esfuerzo. Marinara solo envía el control de desactivación específico del proveedor a los modelos que sabe que lo admiten. Algunos modelos de razonamiento obligatorio no permiten desactivarlo y pueden seguir devolviendo razonamiento; elige un modelo sin razonamiento cuando sea imprescindible que no lo haya. Desactivar el propio interruptor del parámetro es distinto: no envía ninguna preferencia de razonamiento y deja intacto el comportamiento predeterminado del proveedor.
+
 **Verbosity** controla cuán largas y detalladas deben ser las respuestas. Las opciones son **None**, **Low**, **Medium** y **High**. **Low** mantiene las respuestas cortas. **High** fomenta respuestas más largas y descriptivas. Solo algunos modelos usan este ajuste.
 
 ## El interruptor de envío


### PR DESCRIPTION
## Why

Mirrors the user-facing documentation changes from #4141 in the Spanish documentation pack so the translated guide remains aligned with the canonical English docs.

## What changed

- document refreshed ElevenLabs voice/model discovery and the per-character refresh control
- document direct /continue appends when the newline preference is disabled
- document the distinction between Reasoning Effort None and disabling the parameter switch
- rebuild the Spanish documentation manifest against Engine commit bd382c692

## Validation

- [ ] Review the Spanish phrasing in app
- [ ] Verify links and headings in the documentation viewer

Automated pack validation completed locally with 123 translated docs matched to 123 English docs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified how `/continue` handles line breaks and how to change this behavior in Settings.
  * Expanded ElevenLabs voice setup guidance, including model selection, voice refresh behavior, and character voice requirements.
  * Clarified the differences between disabling Reasoning Effort and selecting **None**, including provider and model behavior.
  * Updated documentation metadata to reflect the latest content changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->