### PR TITLE
Use the configured accent for connection fetch errors

### DIFF
--- a/e2e/core-flows.e2e.ts
+++ b/e2e/core-flows.e2e.ts
@@ -1147,7 +1147,7 @@ test("modal backdrops ignore drag releases but still close on a fresh outside cl
   await expect(dialog).toHaveCount(0);
 });
 
-test("connection model fetch errors inherit the configured chroma text color", async ({ page }, testInfo) => {
+test("connection model fetch errors inherit the configured editor accent", async ({ page }, testInfo) => {
   test.skip(testInfo.project.name.includes("mobile"), "Desktop connection editor chrome is covered here.");
 
   const connectionResponse = await page.request.post("/api/connections", {
@@ -1159,18 +1159,40 @@ test("connection model fetch errors inherit the configured chroma text color", a
   expect(connectionResponse.ok()).toBeTruthy();
   const connection = (await connectionResponse.json()) as { id: string };
   const networkError = "NetworkError when attempting to fetch resource.";
+  const internalServerError = "Internal Server Error";
+  const accentColor = "rgb(20, 184, 166)";
+  let fetchCount = 0;
 
   try {
     await page.route(`**/api/connections/${connection.id}/models`, async (route) => {
+      const message = fetchCount === 0 ? networkError : internalServerError;
+      fetchCount += 1;
       await route.fulfill({
         status: 502,
         contentType: "application/json",
-        body: JSON.stringify({ error: { message: networkError } }),
+        body: JSON.stringify({ error: { message } }),
       });
     });
     await page.goto("/");
+    await page.evaluate(async (accent) => {
+      const { useUIStore } = (await import("/src/stores/ui.store.ts")) as {
+        useUIStore: {
+          getState: () => {
+            setAppAccentColor: (color: string) => void;
+          };
+        };
+      };
+      useUIStore.getState().setAppAccentColor(accent);
+    }, "#14b8a6");
+    await expect
+      .poll(() =>
+        page.evaluate(() =>
+          getComputedStyle(document.documentElement).getPropertyValue("--marinara-app-accent-static").trim(),
+        ),
+      )
+      .toBe("#14b8a6");
     await page.evaluate(() => {
-      document.documentElement.style.setProperty("--marinara-chat-chrome-panel-text", "rgb(12, 34, 56)");
+      document.documentElement.style.setProperty("--marinara-chat-chrome-panel-text", "rgb(236, 72, 153)");
       document.documentElement.style.setProperty("--destructive", "rgb(255, 0, 0)");
     });
 
@@ -1188,9 +1210,14 @@ test("connection model fetch errors inherit the configured chroma text color", a
 
     const errorText = editor.getByText(networkError, { exact: true });
     await expect(errorText).toBeVisible();
-    await expect(errorText).toHaveClass(/mari-chrome-text/u);
-    await expect(errorText).toHaveCSS("color", "rgb(12, 34, 56)");
+    await expect(errorText).toHaveCSS("color", accentColor);
     expect(await errorText.getAttribute("class")).not.toMatch(/destructive|pink|red|rose/iu);
+
+    await editor.getByRole("button", { name: "Fetch Models from API" }).click();
+    const internalErrorText = editor.getByText(internalServerError, { exact: true });
+    await expect(internalErrorText).toBeVisible();
+    await expect(internalErrorText).toHaveCSS("color", accentColor);
+    expect(await internalErrorText.getAttribute("class")).not.toMatch(/destructive|pink|red|rose/iu);
   } finally {
     await page.request.delete(`/api/connections/${connection.id}`).catch(() => undefined);
   }

--- a/packages/client/src/components/connections/ConnectionEditor.tsx
+++ b/packages/client/src/components/connections/ConnectionEditor.tsx
@@ -1680,7 +1680,9 @@ export function ConnectionEditor() {
                       )}
                       {fetchModels.isPending ?localizeUi("ui.connections.connectioneditor.fetching") : modelFetchButtonLabel}
                     </button>
-                    {fetchError && <p className="mari-chrome-text mt-1.5 text-[0.625rem]">{fetchError}</p>}
+                    {fetchError && (
+                      <p className="mt-1.5 text-[0.625rem] text-[var(--marinara-editor-accent)]">{fetchError}</p>
+                    )}
                     {remoteModels.length > 0 && !fetchError && (
                       <p className="mt-1 text-[0.625rem] text-emerald-400">
                         {remoteModels.length} {localizeUi("ui.connections.connectioneditor.model_1d06a0d")}{remoteModels.length !== 1 ?localizeUi("ui.noodle.stageprofileview.s") : ""} {localizeUi("ui.connections.connectioneditor.availableFrom")}{" "}


### PR DESCRIPTION
## Why

Connection model discovery errors such as `NetworkError when attempting to fetch resource.` and `Internal Server Error` were rendered with generic panel text instead of the configured application accent. This made them appear as the fixed pink panel color in affected themes.

## What changed

- Bind model-fetch error text to the editor accent token.
- Extend the browser regression to cover both reported error messages through the real appearance-setting path.
- Prove the messages remain accent-colored while panel text is pink and destructive text is red.

## Validation

- `pnpm check`
- `pnpm exec playwright test e2e/core-flows.e2e.ts -g "connection model fetch errors inherit the configured editor accent" --project=desktop-chromium`

## Manual test plan

- [ ] Manually set a non-pink application accent and verify both model-fetch error variants use it in the connection editor.

No linked issue exists for this maintainer-reported correction; a follow-up issue should be opened if separate project tracking is required.