### PR TITLE
Fix Roleplay Enter draft flicker

### DIFF
--- a/packages/client/src/components/chat/ChatInput.tsx
+++ b/packages/client/src/components/chat/ChatInput.tsx
@@ -1485,9 +1485,16 @@ export const ChatInput = memo(function ChatInput({
       }
     }
 
-    if (enterToSend && e.key === "Enter" && !e.shiftKey) {
-      e.preventDefault();
-      handleSend();
+    if (e.key === "Enter") {
+      if (enterToSend && !e.shiftKey) {
+        e.preventDefault();
+        handleSend();
+      } else {
+        const el = textareaRef.current;
+        requestAnimationFrame(() => {
+          if (el && textareaRef.current === el) resizeChatInputTextarea(el);
+        });
+      }
     }
   };
 

--- a/scripts/regressions/roleplay-streaming.regression.ts
+++ b/scripts/regressions/roleplay-streaming.regression.ts
@@ -223,10 +223,15 @@ assert.match(
   /resizeTimerRef\.current = setTimeout\(\(\) => \{[\s\S]*?resizeChatInputTextarea\(el\);[\s\S]*?\}, 150\);/u,
   "Roleplay textarea measurement should wait for a typing pause instead of forcing layout on each keystroke",
 );
+assert.match(
+  chatInputSource,
+  /if \(e\.key === "Enter"\) \{[\s\S]*?requestAnimationFrame\(\(\) => \{[\s\S]*?resizeChatInputTextarea\(el\);/u,
+  "Roleplay line breaks should resize before paint so the existing draft does not briefly disappear",
+);
 assert.doesNotMatch(
   chatHandleInputSource,
   /requestAnimationFrame\(\(\) => \{[\s\S]*?resizeChatInputTextarea\(el\);/u,
-  "Roleplay textarea resizing must not force a scrollHeight layout read every animation frame",
+  "Roleplay textarea resizing must not schedule a layout read for every ordinary keystroke",
 );
 const conversationTextareaSource = conversationInputSource.match(/<textarea[\s\S]*?\/>/u)?.[0] ?? "";
 assert.doesNotMatch(


### PR DESCRIPTION
## Why

With **Send on Enter** disabled, pressing Enter inserted a newline but left the Roleplay textarea on its delayed resize path. For one paint, the new two-line content could overflow the old one-line height, briefly hiding the existing draft before the debounce completed.

## What changed

- Schedule a single pre-paint textarea resize only when Enter/Shift+Enter creates a newline.
- Leave ordinary Roleplay keystrokes on the existing 150 ms debounced resize path, preserving typing responsiveness.
- Add a Roleplay regression guard for both behaviors.

## Validation

- `pnpm regression:roleplay`
- `git diff --check`

## Manual verification

- [ ] In Roleplay with Send on Enter disabled, type a draft and press Enter; verify the existing line remains visible.
- [ ] Type continuously in Roleplay and compare responsiveness with Conversation mode.
- [ ] With Send on Enter enabled, verify Enter sends and Shift+Enter creates a newline.

No linked issue was provided; one should be opened if this regression needs issue tracking.
