### PR TITLE
docs: update Hierarchical Maps guide for 1.2.0

### DIFF
--- a/docs/agents/hierarchical-maps.md
+++ b/docs/agents/hierarchical-maps.md
@@ -1,106 +1,200 @@
 # Hierarchical Maps: Setup, Authoring, and Travel
 
-> **Current compatibility:** This guide matches Hierarchical Maps **1.1.5** on
-> Marinara Engine **2.3.3**. Maps 1.1.5 supports Engine 2.3.2 through the current
-> 2.x releases. The package supports Roleplay and Game chats.
+> **Current compatibility:** This guide matches Hierarchical Maps **1.2.0** on
+> Marinara Engine **2.3.5**. The package supports Roleplay and Game chats.
 
-Hierarchical Maps adds a persistent story map to Roleplay and Game chats. Instead of keeping one free-text location, it can represent a world as nested places:
+Hierarchical Maps adds persistent world state to Roleplay and Game. Instead of
+keeping one free-text location, it represents the world as nested places:
 
 ```text
 The Shattered Coast
 └── Brinewatch
     ├── Harbor District
     │   ├── Tideglass Inn
-    │   └── Customs House
+    │   └── Quest Hall
     └── Old Sewers
 ```
 
-Marinara keeps an authoritative current location in this hierarchy. The current path, exact location details, nearby destinations, and eligible lore linked to the exact current location can be included in the next reply's context. The AI cannot move the story merely by narrating that the party went somewhere; you choose a destination and commit the move with your next turn.
+Marinara keeps an authoritative current location in this hierarchy. The current
+breadcrumb, exact location details, nearby destinations, and eligible linked
+lore can ground the next response. Maps can also follow a completed narrated
+journey to a known place or add a newly discovered place when the story truly
+arrives there.
 
-Hierarchical Maps works in **Roleplay** and **Game**. Each chat has its own map and current location.
+Each chat receives its own working copy of a map. Account-wide templates let you
+prepare an original or fandom world once and then add a clean copy to any
+Roleplay or Game chat.
 
-## What a hierarchical map can represent
+## Feature overview
 
-Each location can have:
+Hierarchical Maps 1.2.0 provides:
 
-- one parent and any number of children or siblings;
-- a Region, Settlement, Place, Building, Floor, or Room type;
-- a public description and private AI-only location notes;
-- lorebook entries attached to that exact location;
-- direct one-way or two-way links to other locations; and
-- children displayed as a list, positioned map, or ordered layers.
+- nested regions, settlements, places, buildings, floors, and rooms;
+- breadcrumbs and an authoritative current story location;
+- list, positioned-map, and ordered-layer views for child locations;
+- parent/child travel, direct links, and multi-turn route planning;
+- validated movement from completed narration and discovery of new locations;
+- account-wide map templates created manually, with AI, or by import;
+- AI-assisted map drafts and expansions grounded in setup or selected lore;
+- public location descriptions, private model memory, and exact-location lore;
+- one optional Gallery reference image for each location;
+- a separate Gallery background for each positioned child map;
+- reviewed batch generation for missing location artwork;
+- a global, variable-based Maps artwork prompt override;
+- location-reference support for Roleplay illustrations and Game Storyboards;
+- import, export, archiving, history-aware editing, and Game map bindings; and
+- global prompt libraries for AI map building and the runtime location insert.
 
-Direct links are not limited to siblings. They can connect any valid places in the hierarchy: a ferry between towns, a stairwell between floors, a portal between worlds, or a secret passage between distant rooms.
-
-Practical examples include:
-
-- `World → Continent → Region → City → District → Building → Room`
-- `City → Neighborhoods → Streets → Shops and landmarks`
-- `House → Floors → Rooms → Closets or hidden chambers`
-- `Dungeon tower → Floors 1–25 → Rooms, stairs, and boss arenas`
-- `Star system → Planets → Settlements → Buildings`
-
-A 25-floor tower should normally model the floors as 25 siblings under one tower, not as a 25-deep parent chain. Maps currently allow up to 500 locations and 20 levels of hierarchy.
+Available destinations are included in the model context. When CYOA choices are
+enabled, the model can therefore offer current children or connected places as
+the next options. The exact choices remain model-generated.
 
 ## Quick start
 
-1. Open the **Agents** panel, click **Download Agents**, and install **Hierarchical Maps**. If the catalog then offers **Update**, install that too.
-2. Restart Marinara when the catalog asks.
-3. Open the Roleplay or Game chat where the map should live.
-4. Open **Agents → Hierarchical Maps**, turn on **Use in this chat**, and click **Create map**. You can also activate it through **Chat Settings → Agents → Tracker Agents** and open **Hierarchical map** there.
-5. Choose **Draft with AI**, describe what you want, and click **Generate draft**.
-6. Search and expand the complete generated hierarchy in **Draft preview**. Select places to review their descriptions, private model memory, and lore provenance. Regenerate or edit the prompt if needed.
-7. Click **Continue to editor**, review the unsaved working map, and make any manual changes.
-8. Set or confirm the starting location, switch the map to **Enabled**, and click **Save**.
-9. In the chat, open the **Story map**, select a reachable place, and click **Set destination**. Send your next message to complete the move.
+1. Open **Agents**, click **Download Agents**, and install **Hierarchical Maps**.
+2. Restart Marinara when prompted. The package contains server code.
+3. Open a Roleplay or Game chat.
+4. Open **Agents → Hierarchical Maps** and enable it for the current chat. You
+   can also enable it from that chat's **Chat Settings → Agents** section.
+5. Create the map with **Use template**, **Create with AI**, or **Build
+   manually**. Existing chats can also import a map file.
+6. Review the working hierarchy, choose a starting location, enable the map,
+   and click **Save**.
+7. Open the **Story map** while chatting. Select a reachable destination and
+   send the next turn, or describe travel naturally and let the response update
+   the location when arrival is complete.
+8. Optionally assign Gallery artwork to locations or use **Location artwork**
+   to review and generate the missing images.
 
-Applying an AI draft or importing a file changes only the editor's working copy. The map does not affect replies until you enable and save it.
+Applying a template, AI draft, or imported file changes only the editor's
+working copy. It does not affect replies until the hierarchy is enabled and
+saved.
 
 ## Install and activate the package
 
-Open the **Agents** panel from the Sparkles tab in the right sidebar. Click **Download Agents**, select **Hierarchical Maps**, and click **Install**. If the installed card still offers **Update**, update it before continuing. The package includes server code, so follow the restart prompt before trying to use it.
+Open **Agents** from the Sparkles tab in the right sidebar. Click **Download
+Agents**, select **Hierarchical Maps**, and click **Install**. If the catalog
+then offers **Update**, install that too. Follow the restart prompt before using
+the package.
 
-Installing makes the feature available, but it does not turn it on in every chat.
-
-The installed feature also appears as **Hierarchical Maps** in the main **Agents** panel. With a Roleplay or Game chat open, this page shows the installed package version, readiness, whether Maps is active in the current chat, the saved map status, and an **Open map** or **Create map** button. Map contents, current location, lore bindings, history, and drafts stay with that chat rather than becoming global agent settings.
+The Hierarchical Maps page reports the installed package version and readiness,
+offers the account-wide template library, and shows the current chat's map
+status. Installing the package makes it available but does not enable it in
+every chat.
 
 ### Roleplay
 
 1. Open the Roleplay chat.
 2. Open **Chat Settings** with the gear button.
-3. Find **Agents** and turn on **Enable Agents**.
-4. Under **Tracker Agents**, enable **Hierarchical Maps** for this chat.
-5. Scroll back to the **Hierarchical map** setting that this adds.
-6. Click **Edit hierarchical map**, then **Create map** if the empty-state prompt appears.
+3. Turn on **Enable Agents**.
+4. Under **Tracker Agents**, enable **Hierarchical Maps**.
+5. Open **Edit hierarchical map** or the **Map templates** library.
+
+The template library behaves the same whether it is opened from the main Agents
+page or from Roleplay Chat Settings. Use **Add to chat** to copy a template into
+the active chat.
 
 ### Game
 
-You can select Hierarchical Maps while creating a game, or add it later from that game's **Chat Settings → Agents** section. When selected during setup, Marinara can prepare a hierarchy from the accepted game world for you to review before play.
+During Game setup, choose Hierarchical Maps and then select one of its setup
+routes:
 
-If you skip the generated map during setup, you can still build one later from Chat Settings.
+- **Create with AI** prepares a generated hierarchy for review.
+- **Use template** opens the template picker before the Game is created.
+- **Build manually** starts with an editable blank hierarchy.
+
+After choosing **Use template**, select and confirm a specific template. Setup
+creates a Game-owned working copy for review; it never edits the account
+template. The selected template's locations become the hierarchical starting
+world. A fallback regular Game map is not promoted into its place.
+
+You can also add Hierarchical Maps to an existing Game later from **Chat
+Settings → Agents**.
+
+## Create and reuse map templates
+
+Open **Agents → Hierarchical Maps → Open map templates**. Templates belong to
+your account rather than one chat, so they are suitable for reusable fandom
+worlds, campaign settings, dungeons, cities, or personal starter maps.
+
+From the library you can:
+
+- create a template manually;
+- use **Create with AI** to draft it;
+- import a `.hierarchical-map.json` file;
+- search, view, edit, export, or delete a template;
+- use **Add to chat** in an open Roleplay or Game chat; or
+- choose **Use template** during Game setup.
+
+Each application creates an independent working copy. Later edits to the
+template do not change chats that already copied it, and chat edits do not
+change the template.
+
+Templates do not copy chat Gallery artwork. Image IDs belong to the source
+chat's Gallery and would not be portable. Add or generate the working chat's
+location references and map backgrounds after applying the template.
 
 ## Understand the map editor
 
-On a desktop, the editor shows three panes together. On a narrow screen, use the **Hierarchy**, **Local**, and **Details** tabs.
+On desktop, the editor shows three panes. On a narrow screen, switch between the
+**Hierarchy**, **Local**, and **Details** tabs.
 
-- **Hierarchy** shows the complete location tree. Select a location to edit it. **Enter** changes which part of the hierarchy you are viewing; it does not move the story.
-- **Local** shows the selected location's immediate children as a map, ordered layers, or a list.
-- **Details** edits the selected location, its lore, parent, display style, direct links, and status.
+- **Hierarchy** shows the complete tree. Selecting a location edits it.
+  **Enter** changes the part of the hierarchy being viewed; it does not move the
+  story.
+- **Local** shows the current location's immediate children as a list,
+  positioned map, or ordered layers.
+- **Details** edits location text, hierarchy, lore, artwork, links, status, and
+  Game map bindings.
 
-The editor header contains **Build with AI** or **Expand with AI**, **Export**, **Import**, the Enabled switch, and **Save**. Unsaved changes are marked **Unsaved**. Leaving the editor with unsaved work asks whether to discard it.
+The editor header contains AI building controls, **Templates**, **Export**,
+**Import**, the Enabled switch, and **Save**. Unsaved changes are marked
+**Unsaved**. Leaving with unsaved work asks whether to discard it.
 
-## Draft a map with AI
+### What a location can contain
 
-From an empty map, click **Draft with AI**. For an existing map, click **Expand with AI**.
+Each location can have:
+
+- one parent and any number of children;
+- a Region, Settlement, Place, Building, Floor, or Room type;
+- a name and icon;
+- a public description and private model memory;
+- a short awareness summary;
+- exact-location lorebook links;
+- one-way or two-way direct links to other locations;
+- a List, Map, or Layers child presentation;
+- a location reference image and optional image-use toggle;
+- a separate child-map background when using Map presentation; and
+- active or archived status.
+
+For **Map** presentation, drag children into place or enter precise X and Y
+positions from 0 to 100. The selected parent can also have a Gallery image
+behind its children. For **Layers**, give every child a distinct layer order.
+
+Direct links can connect any valid places in the hierarchy: a ferry between
+towns, stairs between selected floors, a portal between worlds, or a secret
+passage between rooms in different buildings.
+
+A 25-floor tower should normally model the floors as siblings under one tower,
+not as a 25-deep parent chain. Maps allow up to 500 locations and 20 hierarchy
+levels.
+
+## Draft or expand a map with AI
+
+From an empty map, click **Create with AI** or **Draft with AI**. For an existing
+map, click **Expand with AI**.
 
 ### Choose what the builder reads
 
 Under **Build from**, choose one of these sources:
 
-- **Game setup** uses the current setup and characters. In a Roleplay chat, this means the chat setup and character cards. In a Game chat, it also uses the world overview and party characters.
-- **Selected lore** lets you choose one or more available lorebooks. **Strict canon** creates only lore-backed places. **Canon + expansion** allows the AI to add fitting places around the selected lore.
+- **Game setup** uses the current setup and characters. In Game, this includes
+  the world overview and party characters.
+- **Selected lore** uses chosen lorebooks. **Strict canon** creates only
+  lore-backed places. **Canon + expansion** permits fitting additions.
 
-The builder does not read turn history. Use the optional **What should this world include?** or **What should be added?** box for details that are not already in the setup or selected lore.
+The builder does not read turn history. Add anything missing from setup or lore
+to **What should this world include?** or **What should be added?**
 
 Choose a size:
 
@@ -110,160 +204,309 @@ Choose a size:
 | **Medium** | 16 places          |
 | **Large**  | 28 places          |
 
-Click **Generate draft** or **Generate expansion**. Generation does not save anything yet.
+Generation creates a draft, not a saved map. Search or expand the complete
+preview, select locations, and review their paths, descriptions, private model
+memory, and lore provenance. Use **Edit prompt**, **Regenerate**, or **Discard
+draft** before continuing.
 
-The current **Draft preview** is a searchable, browsable preview of the complete generated hierarchy. It reports the number of locations and hierarchy levels, proposes a starting location, and lets you expand or collapse every branch. Select a generated place to inspect its full path, public description, private model memory, and—when lore grounding is used—whether it came directly from lore, was inferred from lore, or was added by the AI.
-
-### Apply and review the result
-
-Click **Continue to editor** for a new map or **Add to working map** for an expansion. This loads the result into the unsaved map editor; it does not enable or save it. Expand its disclosure arrows and select locations in the Hierarchy pane to inspect their children, descriptions, private memory, links, layers, and map positions.
-
-If you do not like the generated result, use **Edit prompt**, **Regenerate**, or **Discard draft** directly from the preview. After continuing into the editor, the AI builder cannot generate over unrelated unsaved edits; save or discard the working changes before opening it again.
-
-If a map exists but the story has no committed map history yet, the AI builder can also **Replace draft**. After the campaign has used the map, replacement is protected: expand the existing hierarchy instead so saved turns keep referring to the same location IDs.
-
-For a saved map that has not been used in a turn, open **Expand with AI**, choose **Replace draft**, and generate a replacement. Once committed history exists, Marinara allows expansion but not wholesale replacement. Export the map before major restructuring.
+Click **Continue to editor** for a new map or **Add to working map** for an
+expansion. After campaign history refers to location IDs, Maps protects those
+references by allowing expansion instead of unrelated wholesale replacement.
 
 ## Build or edit a map manually
 
-From an empty map, click **Build manually**. Marinara creates one broad starting location. Select it in the hierarchy, then use:
+From an empty map, click **Build manually**. Maps creates one broad starting
+location. Select it in the hierarchy, then use:
 
-- **Add child** for a place inside the selected location.
-- **Add sibling** for a place beside it under the same parent.
-- **Duplicate** to copy a location subtree and then edit it.
-- **Archive** to retire a location without erasing historical references.
+- **Add child** for a place inside the selected location;
+- **Add sibling** for a place beside it under the same parent;
+- **Duplicate** to copy a location subtree and then edit it; and
+- **Archive** to retire a place without erasing historical references.
 
-Each location has these main fields:
+Set the story's initial place with **Set as starting location**. A hierarchy
+needs an active starting location before it can be enabled. Turn on **Enabled**
+and click **Save** after resolving any issues shown by the editor.
 
-- **Name** and **Icon** identify it in the editor and world map.
-- **Kind** can be Region, Settlement, Place, Building, Floor, or Room.
-- **Public description** describes the active place in location context.
-- **Private model memory** gives the AI facts that should be active only at this location.
-- **Awareness summary** is a short orientation cue.
-- **Parent** controls where the location sits in the hierarchy.
-- **Child presentation** displays its immediate children as a List, Map, or Layers.
+## Understand what reaches the model
 
-For **Map** presentation, each child can have **Map X** and **Map Y** positions from 0 to 100. For **Layers**, give every child a distinct layer order.
+Every generation with an enabled saved map receives one authoritative
+spatial-context block containing:
 
-## Understand what reaches the AI
+- the current breadcrumb path;
+- the exact current location ID and public description;
+- the exact current location's private model memory, when present;
+- destinations currently reachable in one move; and
+- a bounded index of active known locations and their exact IDs.
 
-When a saved map is enabled, each generation receives one authoritative spatial-context block containing:
+The known-location index lets the response recognize an arrival elsewhere in
+the saved world. Nearby destinations can also inform ordinary prose or CYOA
+choices.
 
-- the current breadcrumb path, including parent names;
-- the exact current location's public description;
-- the exact current location's private model memory, when present; and
-- the valid destinations reachable in one move.
+Parent names provide orientation, but parent descriptions, parent private
+memory, parent artwork, and parent-linked lore are not inherited. If the current
+location is `Tower → Floor 7 → Alchemy Lab`, the lab's details are active while
+the tower and floor contribute only their names to the breadcrumb.
 
-Parent names provide orientation, but parent descriptions, parent private memory, and parent-linked lore are not inherited. If the current location is `Tower → Floor 7 → Alchemy Lab`, the lab's description and private memory are active; the tower and floor contribute their names to the path.
-
-**Private model memory** is a saved AI-only note, not an automatically learned or self-updating memory. Use it for secrets, atmosphere, persistent hazards, local rules, or facts the model should know only while that exact place is current. For facts that must reach the model, use **Public description** or **Private model memory** rather than relying on **Awareness summary** alone.
-
-### Add travel routes
-
-A location is automatically reachable from its parent or its active children. Use **Direct links** for every other route, such as a ferry between towns, stairs between selected floors, or a secret passage between rooms in different buildings.
-
-1. Select the source location.
-2. Under **Direct links**, choose another location and click **Link**.
-3. Add an optional direction label.
-4. Choose **Available**, **Hidden**, or **Blocked**.
-5. Turn on **Both ways** if travel should work in either direction.
-
-Only available links appear as travel choices. A one-way link must be added from the location where the trip begins.
-
-### Set the starting location and save
-
-Select the location where the story begins and click **Set as starting location** under **Location status**. A map needs an active starting location before it can be enabled.
-
-Switch the header control to **Enabled**, then click **Save**. If the editor reports issues, fix them before saving.
-
-## Link lore to locations
-
-Hierarchical Maps uses lore in two different ways:
-
-1. The AI builder can read selected lorebooks while drafting or expanding the hierarchy.
-2. A saved location can activate specific lore entries while that exact location is current.
-
-To attach runtime lore:
-
-1. Select a location and open **Linked lore** in the Details pane.
-2. Search the available entries.
-3. Click an entry to attach it.
-4. Save the map.
-
-Linked entries do not pass automatically from parent to child. Lore attached to Brinewatch does not activate while the current location is the Tideglass Inn unless you attach that entry to the inn too.
-
-An eligible linked entry is selected as **current-location lore**, so it does not need a keyword match. This is more precise than normal keyword activation, but it is not an unconditional bypass of lorebook rules: disabled or chat-excluded books and entries remain unavailable, and entry conditions, timing, probability, and token budgets still apply.
-
-Disabled lorebooks, disabled entries, and lorebooks excluded from the chat are unavailable to the map. The editor keeps unavailable or missing references visible so you can repair or detach them, but they are not sent to the model.
+**Private model memory** is a saved AI-only note, not self-updating memory. Use
+it for secrets, atmosphere, persistent hazards, local rules, or facts that
+should be active only at that exact place. Put information that must reach the
+model in the public description or private model memory rather than relying on
+the awareness summary alone.
 
 ## Move during a story
 
-Selecting a destination queues a move; it does not change the current location immediately. The move is committed together with the next message you send. This keeps the location and the turn in sync when you branch, regenerate, or change swipes.
+Maps supports explicit travel, planned routes, and validated narrated arrival.
+Movement is saved with the turn so the location follows the selected message
+history and swipe.
 
-Valid destinations are:
+### Queue an explicit destination
+
+Selecting a destination queues a move; it does not move immediately. The move
+is committed with the next message you send, keeping the location and turn in
+sync.
+
+One-move destinations are:
 
 - the current location's parent;
 - active children of the current location; and
-- destinations connected by an available direct link.
+- locations connected by an available direct link.
 
-Only one hierarchical move can be committed with a turn.
+Only one hierarchical step can be committed with a turn. Use the X on the
+pending destination to cancel it. If the map revision or current location
+changes before sending, the pending move becomes **Needs review**.
 
-### Current one-move limit
+### Plan a multi-turn route
 
-**Set destination is already available in Maps 1.1.5**, but it accepts only a place reachable in one move. Browsing the world map can show locations farther away without making them immediately selectable.
+Select a distant active location on the world map. If the parent/child and
+available-link graph contains a path, Maps shows the shortest route and offers
+**Plan route**.
 
-For example, if Floor 1 and Floor 25 are siblings under a tower, the current flow is:
+A route queues its first step. Each subsequent turn commits one step and queues
+the next until the target is reached. Cancel the route at any time. If the map
+or current location changes unexpectedly, the route becomes **Needs review**
+instead of guessing a new path.
 
-1. leave Floor 1 for the tower and send a turn;
-2. enter Floor 25 and send another turn.
+For example, travel from Floor 1 to its sibling Floor 25 normally takes one turn
+to leave for the tower and another to enter Floor 25. A direct link can make
+that journey one step.
 
-You can add a direct available link to make a specific jump reachable in one move. Automatic multi-hop **Set target** or **Plan route** behavior—which would remember a distant goal and walk the parent/child/link graph one valid step at a time—is not implemented yet.
+### Follow narrated travel and discover new places
+
+The model receives guarded instructions for completed arrival:
+
+- If the response actually arrives at a known active location, Maps can move
+  the current location there. If the story revealed a new route, Maps records a
+  direct available connection.
+- If the response actually arrives at an unknown lasting place, Maps can add it
+  as a child or connected location, move there, and preserve the route back.
+- Intentions, mentions, failed or unfinished travel, temporary camps, hallways,
+  and vehicles do not create a location or move the marker.
+
+For example, after the user says “Let's get quests from the Quest Hall,” a
+response that completes the arrival can move the next story state to Quest
+Hall. “We should visit the Quest Hall later” should leave the current location
+unchanged.
+
+This behavior is validated by the application, but the model still has to
+identify that arrival occurred. Use **Set destination** when you need a
+deterministic move.
 
 ### Roleplay travel
 
-The **Story location** panel appears above the message box.
+The **Story location** control appears above the message box.
 
-1. Open **Story location** to see **Leave**, **Enter**, and **Routes**.
-2. Choose a destination.
-3. Confirm that its status says **Moves with your next turn**.
-4. Type and send your message.
-
-Use the X on the pending destination to cancel it before sending. If the map or current location changed after you selected the destination, the status becomes **Needs review**. Open the picker and choose again.
+1. Open the story map to inspect the hierarchy and current breadcrumb.
+2. Select a location to read its description.
+3. Use **Explore inside**, **Browse up**, or the breadcrumb to browse without
+   moving.
+4. Click **Set destination** for a reachable place, or **Plan route** for a
+   reachable distant target.
+5. Send the next message to commit the queued step.
 
 ### Game travel
 
-Game Mode adds a **Hierarchical world map**. **You are here** marks the current story location.
+Game Mode adds a **Hierarchical world map**. **You are here** marks the current
+story location. Browsing, centering, and inspecting do not move the party.
+Queue a destination or route and then send the next Game turn.
 
-- Select a place to read its description.
-- Use **Explore** to browse inside a location. Browsing does not move the party.
-- Use **Browse up** or the breadcrumb to view another part of the hierarchy.
-- Use **Center current story location** to return to the party's position.
-- Click **Set destination** when the selected place is reachable, then send the next turn.
+The generated Game response can also update the hierarchical location after a
+completed narrated arrival. Current location details then ground the GM, party,
+scene art, and eligible Storyboard reference.
 
-If a place says **Browse only from here**, it is not reachable in one move from the current location. Browse back and choose an available parent, child, or direct route.
+## Hierarchical world map versus the regular Game map
 
-## Hierarchical world map versus the Game map
+Game can contain two map systems:
 
-Game Mode can show two map systems:
+- **Hierarchical Maps** is the authoritative story or world location, such as
+  `The Shattered Coast → Brinewatch → Tideglass Inn`.
+- A regular Game grid or node map is local or tactical detail inside that story
+  location and also participates in Game time and weather.
 
-- **Hierarchical Maps** tracks the authoritative story or world location, such as `The Shattered Coast → Brinewatch → Tideglass Inn`.
-- The regular Game grid or node map tracks local, tactical movement inside that story location and also participates in Game time and weather.
+When Hierarchical Maps owns Game startup, its selected template or reviewed
+draft supplies the starting world. The regular Game map is not reused as prompt
+input or promoted as a fallback hierarchy.
 
-An AI-written arrival or a regular Game map marker cannot change the hierarchical location on its own.
+For advanced setups, a hierarchical location can bind to a whole Game map, one
+grid cell, or one node. Selecting a bound Game position stages the corresponding
+hierarchical move; unbound positions keep normal tactical behavior. Save the
+hierarchy before editing bindings. Clearing a binding does not delete either
+map.
 
-For advanced Game setups, a saved hierarchical location has a **Game map binding** section. You can bind a whole Game map, one grid cell, or one node to that story location. Selecting a bound Game position stages a hierarchical move; unbound positions keep normal tactical movement.
+## Add visual identity to locations
 
-Save the hierarchy before changing bindings. A binding can be cleared later without deleting either map.
+Location references and child-map backgrounds are independent even when they
+reuse the same Gallery image.
+
+| Artwork                      | Purpose                                                                                                                 | Sent to image generation?                                                                                 |
+| ---------------------------- | ----------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------- |
+| **Location reference image** | Anchors the visual identity of the exact current place. Choose from Gallery or create with AI.                          | Yes, when **Use for Roleplay illustrations and Game storyboards** is enabled and the request is eligible. |
+| **Child map background**     | Appears behind movable child locations for a parent using Map presentation. Each map layer can have its own background. | No. It is display-only.                                                                                   |
+
+Character or persona references preserve who is present; the location reference
+preserves where the scene occurs. When supported by the provider, combining
+them helps keep both characters and backgrounds consistent across images.
+
+The image pipeline adds this instruction when an eligible location reference is
+attached:
+
+> Location handling: an attached location reference image is available. Use it
+> to set the scene location.
+
+Providers have their own reference-image limits. Explicit request references
+and character references can reduce how many automatic references fit.
+
+### Set one location reference
+
+Select a location in the editor and open **Location reference image**.
+
+- **Choose from Gallery** assigns an existing reviewed image.
+- **Create with AI** opens an editable establishing-image prompt and saves the
+  result to Gallery before you decide whether to use it.
+- **Use for Roleplay illustrations and Game storyboards** controls whether the
+  selected image participates in eligible generation.
+
+For a parent using Map presentation, open **Child map background** separately.
+Choose a Gallery image, then position it behind the child markers. This image is
+never sent to a provider merely because it is displayed on the map.
+
+### Generate missing location artwork in a batch
+
+The editor's **Location artwork** section finds locations missing references or
+child-map backgrounds.
+
+1. Click **Review requests**.
+2. Review the request count before spending provider requests.
+3. Confirm the image connection, model, Engine style, campaign-art-style state,
+   saved image instructions, and output size.
+4. Edit every positive and negative prompt if needed.
+5. Cancel the review, or click **Generate N images** to confirm.
+6. Review the generated artwork in the working map and click **Save**.
+
+Each distinct missing image is a separate provider request. Large worlds can be
+slow or expensive, so the review stays scrollable and keeps the request count
+visible. Existing artwork is reused without another request when possible. A
+new image becomes the location reference and also the child-map background when
+that map needs one.
+
+The exact edited positive and negative prompts shown in review are sent to the
+provider. Positive prompt material is not copied into the negative prompt.
+
+## Customize the automatic artwork prompt
+
+Open **Settings → Generations → Prompt Overrides** and select **Maps location
+artwork**. This is the global template used when Maps previews and generates
+automatic location artwork. Variables use `${variableName}` syntax and can be
+inserted from the editor.
+
+| Variable                                            | Meaning                                                    |
+| --------------------------------------------------- | ---------------------------------------------------------- |
+| `${locationName}`                                   | Location name                                              |
+| `${locationDescription}`                            | Exact location's public description                        |
+| `${locationType}`                                   | Region, Settlement, Place, Building, Floor, or Room        |
+| `${locationPrompt}`                                 | Complete fallback establishing prompt prepared by Maps     |
+| `${parentLocationName}`                             | Direct parent name, or empty at the root                   |
+| `${parentLocationDescription}`                      | Direct parent's public description, or empty               |
+| `${locationPath}`                                   | Full root-to-location breadcrumb                           |
+| `${genre}` / `${genreLine}`                         | Raw or punctuated Game genre; empty outside Game           |
+| `${campaignArtStyle}` / `${campaignArtStyleLine}`   | Campaign style only when **Use campaign art style** is on  |
+| `${imageInstructions}` / `${imageInstructionsLine}` | Raw or formatted image instructions saved in Chat Settings |
+
+The built-in template uses the exact location prompt plus optional genre,
+campaign style, and saved image instructions. It intentionally does not include
+the parent description or full path by default, which avoids forcing a parent
+landmark such as a tower into every child or floor image.
+
+Common customizations:
+
+- Remove `${genreLine}` if the Game genre should not appear in automatic map
+  artwork.
+- Keep `${campaignArtStyleLine}` only if the per-chat **Use campaign art style**
+  toggle should control that material. When the toggle is off, the variable is
+  empty.
+- Add `${parentLocationName}`, `${parentLocationDescription}`, or
+  `${locationPath}` only when the provider needs that broader context.
+- Use **Reset to default** to restore the built-in template.
+
+The Engine style profile and global positive and negative image settings are
+applied after this template. They remain part of the shared Illustrator/image
+workflow rather than Maps-specific settings. If unexpected text remains in the
+negative prompt, inspect the global negative image setting and the editable
+review field.
+
+## Link lore to locations
+
+Hierarchical Maps uses lore in two ways:
+
+1. The AI builder can read selected lorebooks while drafting or expanding.
+2. A saved location can activate entries while that exact location is current.
+
+To attach runtime lore, select the location, open **Linked lore**, search the
+available entries, attach the desired entries, and save.
+
+Linked entries do not pass from parent to child. Lore attached to Brinewatch
+does not activate at the Tideglass Inn unless it is attached there too.
+
+Current-location lore does not need a keyword match, but it does not bypass
+lorebook controls. Disabled or chat-excluded books and entries remain
+unavailable, and entry conditions, timing, probability, and token budgets still
+apply. Missing references remain visible in the editor so they can be repaired
+or detached.
+
+## Advanced Maps prompt settings
+
+The main **Agents → Hierarchical Maps** page owns two global prompt systems:
+
+- **Generation prompt** is a named Roleplay/Game library for AI map drafts and
+  expansions. Each chat can select an option independently. The resolved
+  preview uses live setup, character, lore, and map context without making a
+  model request.
+- **Turn prompt insert** controls the global Roleplay/Game system text that
+  presents the current location during ordinary turns. Marinara keeps the
+  application-owned `<spatial_context>` wrapper and required authority
+  variables around it.
+
+The **Connection Override** on the same page affects AI map drafts and
+expansions. Leave it empty to use the current chat connection. These settings do
+not replace the separate **Maps location artwork** override under global
+Generation settings.
+
+These controls are intended for advanced customization. Preserve required
+variables and use the resolved previews before saving.
 
 ## Import, export, and archive safely
 
-Use **Export** to download the working hierarchy as a `.hierarchical-map.json` file. Export before a major edit if you want a small, map-only backup.
+Use **Export** to download the working hierarchy as a
+`.hierarchical-map.json` file. Export before major edits when you want a small,
+map-only backup.
 
-Use **Import** to load a hierarchy into the working copy. Review it and click **Save** to make it authoritative. Import does not save immediately.
+Use **Import** to load a hierarchy into the working copy. Review it and click
+**Save** to make it authoritative. Import does not save immediately.
 
-Once campaign history refers to a map, an imported map must retain every existing location ID. Add or update locations instead of replacing the hierarchy with unrelated IDs.
+Once campaign history refers to a map, imported changes must retain existing
+location IDs. Add or update locations instead of replacing the hierarchy with
+unrelated IDs.
 
-Archiving preserves old references. Before archiving:
+Archiving preserves old references. Before archiving a location:
 
 - move or archive its active children;
 - choose another active starting location if needed; and
@@ -275,35 +518,95 @@ Archived locations can be restored from the Details pane.
 
 ### Hierarchical Maps is missing from Chat Settings
 
-Check that the package is installed, that Marinara was restarted after installation, and that the chat is Roleplay or Game. In the chat, turn on the **Enable Agents** master switch, open **Tracker Agents**, and enable **Hierarchical Maps**. Then scroll back to the **Hierarchical map** setting that appears.
+Confirm that the package is installed and Marinara was restarted. The active
+chat must be Roleplay or Game. Turn on **Enable Agents**, then enable
+**Hierarchical Maps** under **Tracker Agents**.
+
+### Add to chat is missing from the template library
+
+Open a supported Roleplay or Game chat before opening the library. The library
+shows **Add to chat** from either the main Hierarchical Maps page or that chat's
+settings. During Game setup the equivalent action is **Use template**.
+
+### Game setup used the wrong or fallback locations
+
+Choose **Use template**, select a concrete template in the picker, and confirm
+it before completing Game setup. Review the Game-owned working copy and save
+it. The account template remains unchanged.
 
 ### The map cannot be enabled
 
-Create at least one active location and set an active starting location. Resolve every issue shown at the top of the editor, then enable and save again.
+Create at least one active location and set an active starting location. Resolve
+every issue shown at the top of the editor, then enable and save again.
 
-### AI generation is unavailable
+### AI map generation is unavailable
 
-Make sure the chat has a working language-model connection. Save or discard existing editor changes before opening the AI builder. For an expansion, choose an active location under **Expand beneath**. For lore-grounded generation, select at least one enabled, non-excluded lorebook.
+Make sure the chat or Maps **Connection Override** has a working language-model
+connection. Save or discard existing editor changes before reopening the AI
+builder. For an expansion, choose an active target. For lore-grounded
+generation, select at least one enabled, non-excluded lorebook.
 
-### Review an AI draft before using it
+### The current location did not follow a message
 
-Use the preview's search, **Expand all**, and **Collapse all** controls to inspect the complete generated hierarchy. Select a location to review its description and private model memory. Use **Edit prompt**, **Regenerate**, or **Discard draft** before continuing to the editor.
+Automatic movement requires the generated response to complete an arrival and
+produce a valid hidden Maps directive. Intent, discussion, failed travel, and
+transient places do not move the marker. Use **Set destination** for a
+deterministic next-turn move.
 
-### A destination cannot be selected
+### A destination or route says Needs review
 
-The place must be the current location's parent, an active child, or the target of an available direct link. **Explore**, **Browse up**, and editor **Enter** only browse the map. They do not bypass travel rules or calculate a multi-hop route.
+The map revision or current location changed after the move was queued. Open the
+story map, review the current path, and select the destination or route again.
 
-### A queued destination says Needs review
+### A distant location cannot be selected
 
-The definition or current location changed after the destination was chosen. Open the destination picker, review the current path, and select the destination again.
+Use **Plan route** if an active parent/child/link path exists. Otherwise add an
+available direct link or travel through reachable places one turn at a time.
+Browsing controls never move the story.
 
-### The AI ignores the map
+### The automatic artwork prompt always includes the Game genre
 
-Confirm that Hierarchical Maps is active for the chat, the hierarchy is **Enabled**, and the latest changes were saved. Also confirm that a current location appears in the **Story location** panel.
+Open **Settings → Generations → Prompt Overrides → Maps location artwork** and
+remove `${genreLine}` from the template. Save the override, then reopen the
+artwork review.
+
+### Campaign style appears when it should be off
+
+Check **Chat Settings → Illustrator → Use campaign art style**. With that toggle
+off, `${campaignArtStyle}` and `${campaignArtStyleLine}` resolve to empty. The
+review summary should report campaign art style as **Off**.
+
+### A parent landmark appears in every child image
+
+Avoid `${parentLocationDescription}` and `${locationPath}` in the global artwork
+template unless they are necessary. The default location prompt is scoped to
+the exact location and omits those broad fields.
+
+### The negative image prompt contains unexpected material
+
+Review and edit the negative field before confirming. Then inspect the shared
+global negative image setting. The Maps artwork template builds the positive
+prompt; it is not copied into the negative field.
+
+### A location reference is not used in images or Storyboards
+
+Confirm that the Gallery image still exists and **Use for Roleplay
+illustrations and Game storyboards** is enabled on the exact current location.
+The child-map background is display-only and cannot substitute for a reference
+unless the same Gallery image is also assigned as the location reference.
+
+### The model ignores the map
+
+Confirm that Hierarchical Maps is active for the chat, the hierarchy is
+**Enabled**, the latest changes were saved, and a current location appears in
+the Story location control. Use the **Turn prompt insert** resolved preview for
+advanced diagnosis.
 
 ### Linked lore does not activate
 
-Confirm that the entry is attached to the exact current location. Check that the entry and its lorebook are enabled and that the lorebook is not excluded from the chat.
+Confirm that the entry is attached to the exact current location. Check that
+the entry and lorebook are enabled and the lorebook is not excluded from the
+chat.
 
 ## Related guides
 


### PR DESCRIPTION
## Linked issue

Closes #4159

## Why this change

- The canonical Hierarchical Maps guide still describes the 1.1.5 workflow, including obsolete statements that narrated movement and multi-hop route planning are unavailable.
- Beta testers need one accurate 1.2.0 guide for templates, world-state movement, visual references, automatic artwork prompts, Storyboards, and Game setup.

## What changed

- Updates compatibility to Hierarchical Maps 1.2.0 on Engine 2.3.5.
- Adds a complete feature overview and current Roleplay/Game setup paths.
- Documents account-wide templates, Game-owned working copies, AI/manual/import authoring, route plans, validated narrated arrival, off-map discovery, and CYOA destination context.
- Explains the difference between provider-facing location references and display-only child-map backgrounds.
- Documents reviewed batch artwork generation and every global `Maps location artwork` override variable, including how to remove Game genre or avoid broad parent context.
- Adds Storyboard/image-reference guidance, advanced Maps prompt controls, and focused troubleshooting.

This PR documents behavior implemented by Marinara-Engine #4121 and Pasta-Devs/Marinara-Agents #109. It should remain draft until those implementation changes are ready to land.

## Validation

- [x] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed `CONTRIBUTING.md`

Documentation checks performed while preparing the PR:

- `git diff HEAD^ --check`
- Prettier 3.8.3 check passed for `docs/agents/hierarchical-maps.md`.
- Confirmed every relative guide link resolves to an existing repository file.
- Compared movement, route, template, artwork, reference-image, and prompt-variable claims against the 1.2.0 source and focused regression coverage.

### Manual verification notes

- Manually verify the documented template picker and Game-owned working-copy flow in Game setup.
- Manually verify explicit movement, a multi-hop route, narrated arrival at a known location, and discovery of one new lasting location.
- Manually verify a location reference reaches an eligible illustration and Storyboard while a child-map background remains display-only.
- Manually verify the automatic artwork review and `Maps location artwork` override with Game genre removed and campaign art style both off and on.

## Docs and release impact

- [ ] No docs changes needed
- [x] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Translated docs on the `docs-i18n` branch updated to match, or a `[docs-i18n]` follow-up issue opened (see CONTRIBUTING.md § Translated documentation)
- [ ] Version/release files updated (only if this PR includes a version bump)

Translation follow-up: #4160

## UI evidence (if applicable)

Documentation-only change; no UI code changed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the Hierarchical Maps guide for version 1.2.0 and current engine compatibility.
  * Clarified setup, activation, templates, authoring, travel, routing, artwork, prompt customization, lore linking, import/export, and archiving.
  * Added guidance for draft versus saved maps, queued movement, route reviews, narrated arrivals, and map updates.
  * Expanded troubleshooting steps for common configuration, generation, movement, artwork, and lore issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->