### PR TITLE
Keep Kaomoji in Conversation and smooth Roleplay typing

### DIFF
--- a/e2e/core-flows.e2e.ts
+++ b/e2e/core-flows.e2e.ts
@@ -9706,6 +9706,7 @@ test("Roleplay composer does not offer kaomoji", async ({ page }) => {
     }, chat.id);
     await page.goto("/");
 
+    await expect(page.locator(".chat-input-container textarea:visible")).toBeVisible();
     await expect(page.getByRole("button", { name: "Kaomoji" })).toHaveCount(0);
   } finally {
     await page.request.delete(`/api/chats/${chat.id}`).catch(() => undefined);

--- a/e2e/core-flows.e2e.ts
+++ b/e2e/core-flows.e2e.ts
@@ -9622,12 +9622,77 @@ test("mobile chat composer follows the visual viewport above the software keyboa
   }
 });
 
-test("kaomoji scrollbar presses stay inside the picker and use the theme accent", async ({ page }, testInfo) => {
-  test.skip(testInfo.project.name.includes("mobile"), "Native desktop scrollbar behavior is desktop-only.");
-
+test("kaomoji stays in Conversation and uses the configured chat accent", async ({ page }) => {
   const response = await page.request.post("/api/chats", {
     data: {
       name: "Kaomoji Scrollbar Smoke",
+      mode: "conversation",
+      characterIds: [],
+    },
+  });
+  expect(response.ok()).toBeTruthy();
+  const chat = (await response.json()) as { id: string };
+
+  try {
+    await page.addInitScript((chatId) => {
+      localStorage.setItem("marinara-active-chat-id", chatId);
+    }, chat.id);
+    await page.goto("/");
+
+    await page.evaluate(() => {
+      document.documentElement.style.setProperty("--marinara-chat-chrome-button-text-active", "rgb(20, 184, 166)");
+      document.documentElement.style.setProperty("--primary", "rgb(236, 72, 153)");
+    });
+    await page.getByRole("button", { name: /Emoji, GIFs/u }).click();
+    const emojiSearchInput = page.locator('input[placeholder="Search emojis..."]:visible');
+    const emojiSearchStyle = await emojiSearchInput.evaluate((input) => {
+      const style = getComputedStyle(input);
+      return {
+        backgroundColor: style.backgroundColor,
+        borderRadius: style.borderRadius,
+        fontSize: style.fontSize,
+        paddingBlock: `${style.paddingTop} ${style.paddingBottom}`,
+        paddingInline: `${style.paddingLeft} ${style.paddingRight}`,
+      };
+    });
+    await page.getByRole("button", { name: "Kaomoji" }).click();
+    const picker = page.getByRole("dialog", { name: "Kaomoji picker" });
+    await expect(picker).toBeVisible();
+
+    const [categoriesFit, resultsFit] = await Promise.all([
+      picker.locator("[data-kaomoji-categories]").evaluate((element) => element.scrollWidth <= element.clientWidth),
+      picker.locator("[data-kaomoji-results]").evaluate((element) => element.scrollWidth <= element.clientWidth),
+    ]);
+    expect(categoriesFit).toBe(true);
+    expect(resultsFit).toBe(true);
+
+    const searchIcon = picker.locator("svg").first();
+    const searchInput = picker.getByPlaceholder("Search kaomoji…");
+    const kaomojiSearchStyle = await searchInput.evaluate((input) => {
+      const inputStyle = getComputedStyle(input);
+      const shellStyle = getComputedStyle(input.parentElement!);
+      return {
+        backgroundColor: shellStyle.backgroundColor,
+        borderRadius: shellStyle.borderRadius,
+        fontSize: inputStyle.fontSize,
+        paddingBlock: `${shellStyle.paddingTop} ${shellStyle.paddingBottom}`,
+        paddingInline: `${shellStyle.paddingLeft} ${shellStyle.paddingRight}`,
+      };
+    });
+    expect(kaomojiSearchStyle).toEqual(emojiSearchStyle);
+    await expect(searchIcon).toHaveCSS("color", "rgb(20, 184, 166)");
+    await expect
+      .poll(() => searchInput.evaluate((input) => getComputedStyle(input, "::placeholder").color))
+      .toBe("rgb(20, 184, 166)");
+  } finally {
+    await page.request.delete(`/api/chats/${chat.id}`).catch(() => undefined);
+  }
+});
+
+test("Roleplay composer does not offer kaomoji", async ({ page }) => {
+  const response = await page.request.post("/api/chats", {
+    data: {
+      name: "Roleplay Without Kaomoji",
       mode: "roleplay",
       characterIds: [],
     },
@@ -9641,39 +9706,7 @@ test("kaomoji scrollbar presses stay inside the picker and use the theme accent"
     }, chat.id);
     await page.goto("/");
 
-    await page.getByRole("button", { name: "Kaomoji" }).click();
-    const picker = page.getByRole("dialog", { name: "Kaomoji picker" });
-    await expect(picker).toBeVisible();
-    const pickerBox = await picker.boundingBox();
-    expect(pickerBox).not.toBeNull();
-
-    await page.mouse.move(pickerBox!.x + pickerBox!.width - 2, pickerBox!.y + pickerBox!.height / 2);
-    await page.mouse.down();
-    await page.mouse.up();
-    await expect(picker).toBeVisible();
-
-    const [categoriesFit, resultsFit] = await Promise.all([
-      picker.locator("[data-kaomoji-categories]").evaluate((element) => element.scrollWidth <= element.clientWidth),
-      picker.locator("[data-kaomoji-results]").evaluate((element) => element.scrollWidth <= element.clientWidth),
-    ]);
-    expect(categoriesFit).toBe(true);
-    expect(resultsFit).toBe(true);
-
-    const searchIconUsesTheme = await picker
-      .locator("svg")
-      .first()
-      .evaluate((icon) => {
-        const iconColor = getComputedStyle(icon).color;
-        const themeColor = getComputedStyle(document.documentElement).getPropertyValue("--primary").trim();
-        if (!themeColor) return false;
-        const probe = document.createElement("span");
-        probe.style.color = themeColor;
-        document.body.appendChild(probe);
-        const resolvedThemeColor = getComputedStyle(probe).color;
-        probe.remove();
-        return iconColor === resolvedThemeColor;
-      });
-    expect(searchIconUsesTheme).toBe(true);
+    await expect(page.getByRole("button", { name: "Kaomoji" })).toHaveCount(0);
   } finally {
     await page.request.delete(`/api/chats/${chat.id}`).catch(() => undefined);
   }

--- a/packages/client/src/components/chat/ChatInput.tsx
+++ b/packages/client/src/components/chat/ChatInput.tsx
@@ -8,7 +8,6 @@ import {
   StopCircle,
   X,
   Smile,
-  SmilePlus,
   Users,
   UserCheck,
   Languages,
@@ -55,7 +54,6 @@ import { CARD_ASSET_INSERT_EVENT, type CardAssetInsertDetail } from "../../lib/c
 import { isGenerationSendBlocked } from "../../lib/generation-stream-policy";
 import { requestChatScrollToBottom } from "../../lib/chat-scroll-events";
 import { EmojiPicker } from "../ui/EmojiPicker";
-import { KaomojiPicker } from "../ui/KaomojiPicker";
 import { SpeechToTextButton } from "../ui/SpeechToTextButton";
 import { QuickConnectionSwitcher } from "./QuickConnectionSwitcher";
 import { QuickPersonaSwitcher } from "./QuickPersonaSwitcher";
@@ -224,8 +222,6 @@ export const ChatInput = memo(function ChatInput({
   const [pendingAttachmentReadsByChat, setPendingAttachmentReadsByChat] = useState<Record<string, number>>({});
   const [isTranslatingDraft, setIsTranslatingDraft] = useState(false);
   const [emojiOpen, setEmojiOpen] = useState(false);
-  const [kaomojiOpen, setKaomojiOpen] = useState(false);
-  const kaomojiButtonRef = useRef<HTMLButtonElement>(null);
   const isMobileComposerViewport = useIsMobileComposerViewport();
   // Push Story arms for the next response with an explicit mode picked from
   // the selector that opens on click; null means disarmed.
@@ -241,7 +237,6 @@ export const ChatInput = memo(function ChatInput({
   const inputBarRef = useRef<HTMLDivElement>(null);
   const focusAfterMobileRestoreRef = useRef(false);
   const draftTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const inputPresenceTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const resizeTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const currentInputFrameRef = useRef<number | null>(null);
   const pendingCurrentInputRef = useRef("");
@@ -343,7 +338,6 @@ export const ChatInput = memo(function ChatInput({
     !pendingSpatialTransition &&
     !isInputBusy &&
     !emojiOpen &&
-    !kaomojiOpen &&
     !charPickerOpen;
   const activeAgentIds = useMemo(
     () =>
@@ -381,16 +375,7 @@ export const ChatInput = memo(function ChatInput({
   const syncInputState = useCallback(
     (value: string) => {
       const nextHasInput = value.trim().length > 0;
-      if (inputPresenceTimerRef.current) clearTimeout(inputPresenceTimerRef.current);
-      if (nextHasInput) {
-        inputPresenceTimerRef.current = setTimeout(() => {
-          inputPresenceTimerRef.current = null;
-          setHasInput(true);
-        }, 150);
-      } else {
-        inputPresenceTimerRef.current = null;
-        setHasInput(false);
-      }
+      setHasInput((current) => (current === nextHasInput ? current : nextHasInput));
       pendingCurrentInputRef.current = value;
       if (typeof window === "undefined" || typeof window.requestAnimationFrame !== "function") {
         setCurrentInput(value);
@@ -520,7 +505,6 @@ export const ChatInput = memo(function ChatInput({
     return () => {
       // Cancel pending debounce timers
       if (draftTimerRef.current) clearTimeout(draftTimerRef.current);
-      if (inputPresenceTimerRef.current) clearTimeout(inputPresenceTimerRef.current);
       if (resizeTimerRef.current) clearTimeout(resizeTimerRef.current);
       if (currentInputFrameRef.current !== null) {
         cancelAnimationFrame(currentInputFrameRef.current);
@@ -2021,31 +2005,6 @@ export const ChatInput = memo(function ChatInput({
             onClose={() => setEmojiOpen(false)}
             onSelect={handleEmojiSelect}
             anchorRef={emojiButtonRef}
-            containerRef={inputBarRef}
-          />
-        </div>
-
-        {/* Kaomoji picker */}
-        <div className="relative hidden shrink-0 sm:block">
-          <button
-            ref={kaomojiButtonRef}
-            onClick={() => setKaomojiOpen((v) => !v)}
-            className={cn(
-              "flex h-8 w-8 items-center justify-center rounded-full transition-colors active:scale-90",
-              kaomojiOpen
-                ? "bg-foreground/10 text-foreground/75 ring-1 ring-foreground/20"
-                : "text-foreground/40 hover:bg-foreground/10 hover:text-foreground/70",
-            )}
-            title={t("chat.input.kaomoji")}
-            aria-label={t("chat.input.kaomoji")}
-          >
-            <SmilePlus size="1.125rem" />
-          </button>
-          <KaomojiPicker
-            open={kaomojiOpen}
-            onClose={() => setKaomojiOpen(false)}
-            onSelect={handleEmojiSelect}
-            anchorRef={kaomojiButtonRef}
             containerRef={inputBarRef}
           />
         </div>

--- a/packages/client/src/components/ui/KaomojiPicker.tsx
+++ b/packages/client/src/components/ui/KaomojiPicker.tsx
@@ -126,15 +126,18 @@ export function KaomojiPicker({ open, onClose, onSelect, anchorRef, containerRef
 
   const body = (
     <>
-      <div className="flex items-center gap-2 border-b border-[var(--border)] px-2.5 py-2">
-        <Search size="0.8125rem" className="shrink-0 text-[var(--primary)]" />
-        <input
-          ref={searchInputRef}
-          value={search}
-          onChange={(e) => setSearch(e.target.value)}
-          placeholder={t("chat.kaomoji.search")}
-          className="min-w-0 flex-1 bg-transparent text-sm outline-none placeholder:text-[var(--muted-foreground)]"
-        />
+      <div className="border-b border-foreground/10 px-3 py-2">
+        <div className="flex items-center gap-2 rounded-md bg-foreground/5 px-2.5 py-1.5 ring-1 ring-foreground/10 transition-shadow focus-within:ring-foreground/20">
+          <Search size="0.875rem" className="shrink-0 text-[var(--marinara-chat-chrome-button-text-active)]" />
+          <input
+            ref={searchInputRef}
+            type="text"
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            placeholder={t("chat.kaomoji.search")}
+            className="min-w-0 flex-1 bg-transparent text-xs outline-none placeholder:text-[var(--marinara-chat-chrome-button-text-active)]"
+          />
+        </div>
       </div>
 
       {!search.trim() && (
@@ -184,7 +187,12 @@ export function KaomojiPicker({ open, onClose, onSelect, anchorRef, containerRef
 
   if (embedded) {
     return (
-      <div ref={panelRef} role="dialog" aria-label={t("chat.kaomoji.title")} className="flex h-full flex-col overflow-hidden">
+      <div
+        ref={panelRef}
+        role="dialog"
+        aria-label={t("chat.kaomoji.title")}
+        className="flex h-full flex-col overflow-hidden"
+      >
         {body}
       </div>
     );
@@ -192,12 +200,7 @@ export function KaomojiPicker({ open, onClose, onSelect, anchorRef, containerRef
 
   return createPortal(
     <>
-      <div
-        data-kaomoji-picker-backdrop
-        aria-hidden="true"
-        className="fixed inset-0 z-[59]"
-        onPointerDown={onClose}
-      />
+      <div data-kaomoji-picker-backdrop aria-hidden="true" className="fixed inset-0 z-[59]" onPointerDown={onClose} />
       <div
         ref={panelRef}
         role="dialog"

--- a/scripts/regressions/roleplay-streaming.regression.ts
+++ b/scripts/regressions/roleplay-streaming.regression.ts
@@ -243,8 +243,13 @@ assert.doesNotMatch(
 );
 assert.match(
   chatInputSource,
-  /inputPresenceTimerRef\.current = setTimeout\(\(\) => \{[\s\S]*?setHasInput\(true\);[\s\S]*?\}, 150\);/u,
-  "Roleplay composer controls should update after a typing pause instead of rerendering on the first character",
+  /setHasInput\(\(current\) => \(current === nextHasInput \? current : nextHasInput\)\);/u,
+  "Roleplay composer presence should change only when the draft crosses the empty boundary",
+);
+assert.doesNotMatch(
+  chatInputSource,
+  /inputPresenceTimerRef/u,
+  "Roleplay typing should not create and cancel a redundant presence timer on every keystroke",
 );
 assert.match(
   chatStoreSource,


### PR DESCRIPTION
## Linked issue

Closes #4165

## Why this change

Kaomoji is a Conversation-only affordance, but the shared Roleplay composer still exposed a standalone picker. Its search field also used the generic primary color and a different visual treatment from the neighboring Emoji/GIF searches. Separately, Roleplay input scheduled an extra presence timer on every keystroke, contributing to a small responsiveness gap compared with Conversation.

## What changed

- Removed the Kaomoji icon, state, and popover from the Roleplay composer while retaining the Conversation media-picker tab.
- Restyled Kaomoji search to match the Emoji/GIF search shell and use the configured chat-chrome accent for its icon and placeholder.
- Removed the redundant Roleplay input-presence timer and update presence only when the draft crosses the empty/non-empty boundary.
- Added desktop/mobile coverage for Conversation-only Kaomoji, search styling, accent resolution, and Roleplay absence.

## Validation

- [ ] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed `CONTRIBUTING.md`

Automated validation run:

- `pnpm check`
- `pnpm --filter @marinara-engine/server exec tsx ../../scripts/regressions/roleplay-streaming.regression.ts`
- `pnpm exec playwright test -c playwright.config.ts e2e/core-flows.e2e.ts --grep 'kaomoji stays in Conversation|Roleplay composer does not offer kaomoji' --project=desktop-chromium --workers=1`
- `pnpm exec playwright test -c playwright.config.ts e2e/core-flows.e2e.ts --grep 'kaomoji stays in Conversation|Roleplay composer does not offer kaomoji' --project=mobile-chromium --workers=1`
- `git diff --check`

### Manual verification notes

- Manually verify the Kaomoji tab remains available in a Conversation chat.
- Manually verify no Kaomoji action appears in Roleplay on desktop or mobile.
- Manually compare sustained Roleplay typing responsiveness with Conversation.
- Manually verify the search field in light and dark themes with a non-pink custom accent.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Translated docs on the `docs-i18n` branch updated to match, or a `[docs-i18n]` follow-up issue opened (see CONTRIBUTING.md § Translated documentation)
- [ ] Version/release files updated (only if this PR includes a version bump)

No docs or release metadata changes are needed; this corrects existing composer behavior and styling.

## UI evidence (if applicable)

Automated browser assertions cover the affected desktop and mobile paths. No screenshot is attached.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated the Kaomoji picker with a cleaner search layout and improved dialog presentation.
  * Kaomoji picker accents, icons, and search fields now align with the configured chat accent color.

* **Bug Fixes**
  * Removed the Kaomoji option from the Roleplay composer.
  * Composer input state now updates immediately when text is added or cleared, improving responsiveness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->