### PR TITLE
Fix chat polish regressions and Spotify repeat

### DIFF
--- a/packages/client/src/components/chat/ChatMessage.tsx
+++ b/packages/client/src/components/chat/ChatMessage.tsx
@@ -3479,8 +3479,7 @@ const GuidedRegenerateActionBtn = memo(function GuidedRegenerateActionBtn({
 }) {
   const { t: localizeUi } = useUiTranslation();
   const guideGenerations = useUIStore((state) => state.guideGenerations);
-  const hasCurrentInput = useChatStore((state) => state.hasCurrentInput);
-  const isGuided = guideGenerations && hasCurrentInput;
+  const isGuided = useChatStore((state) => guideGenerations && state.hasCurrentInput);
   return (
     <ActionBtn
       icon={<RefreshCw size={MESSAGE_ACTION_ICON_SIZE} />}

--- a/packages/client/src/components/chat/EchoChamberPanel.tsx
+++ b/packages/client/src/components/chat/EchoChamberPanel.tsx
@@ -407,6 +407,21 @@ export function EchoChamberPanel({ hiddenOnMobile = false }: EchoChamberPanelPro
     [commitPanelSize],
   );
 
+  const handleResizeCancel = useCallback(
+    (event: ReactPointerEvent<HTMLButtonElement>) => {
+      const start = resizeRef.current;
+      resizeRef.current = null;
+      pendingPanelSizeRef.current = null;
+      if (event.currentTarget.hasPointerCapture(event.pointerId)) {
+        event.currentTarget.releasePointerCapture(event.pointerId);
+      }
+      if (start) {
+        setPanelSize(clampPanelSize(start.width, start.height));
+      }
+    },
+    [clampPanelSize],
+  );
+
   const handleResizeKeyDown = useCallback(
     (event: ReactKeyboardEvent<HTMLButtonElement>) => {
       if (!["ArrowLeft", "ArrowRight", "ArrowUp", "ArrowDown"].includes(event.key)) return;
@@ -668,7 +683,7 @@ export function EchoChamberPanel({ hiddenOnMobile = false }: EchoChamberPanelPro
         onPointerDown={handleResizeStart}
         onPointerMove={handleResizeMove}
         onPointerUp={handleResizeEnd}
-        onPointerCancel={handleResizeEnd}
+        onPointerCancel={handleResizeCancel}
         onKeyDown={handleResizeKeyDown}
       >
         <span

--- a/packages/client/src/components/chat/EchoChamberPanel.tsx
+++ b/packages/client/src/components/chat/EchoChamberPanel.tsx
@@ -17,7 +17,7 @@ import {
 import { ChevronDown, MessageCircle, Trash2, RefreshCw } from "lucide-react";
 import { useAgentStore } from "../../stores/agent.store";
 import { useUIStore } from "../../stores/ui.store";
-import type { EchoChamberSide } from "../../stores/ui.store";
+import type { EchoChamberSide, EchoChamberSize } from "../../stores/ui.store";
 import { useChatStore } from "../../stores/chat.store";
 import { useChat } from "../../hooks/use-chats";
 import { useGenerate } from "../../hooks/use-generate";
@@ -188,10 +188,15 @@ function CornerPicker({ current, onChange }: { current: EchoChamberSide; onChang
 
 export function EchoChamberPanel({ hiddenOnMobile = false }: EchoChamberPanelProps) {
   const { t: localizeUi } = useUiTranslation();
+  const activeChatId = useChatStore((s) => s.activeChatId);
   const echoChamberSide = useUIStore((s) => s.echoChamberSide);
   const setEchoChamberSide = useUIStore((s) => s.setEchoChamberSide);
   const echoChamberOpen = useUIStore((s) => s.echoChamberOpen);
   const toggleEchoChamber = useUIStore((s) => s.toggleEchoChamber);
+  const rememberedPanelSize = useUIStore((s) =>
+    activeChatId ? (s.echoChamberSizeByChatId[activeChatId] ?? null) : null,
+  );
+  const setEchoChamberSizeForChat = useUIStore((s) => s.setEchoChamberSizeForChat);
   const trackerPanelEnabled = useUIStore((s) => s.trackerPanelEnabled);
   const trackerPanelOpen = useUIStore((s) => s.trackerPanelOpen);
   const trackerPanelSide = useUIStore((s) => s.trackerPanelSide);
@@ -199,9 +204,9 @@ export function EchoChamberPanel({ hiddenOnMobile = false }: EchoChamberPanelPro
   const scrollRef = useRef<HTMLDivElement>(null);
   const panelRef = useRef<HTMLDivElement>(null);
   const resizeRef = useRef<{ startX: number; startY: number; width: number; height: number } | null>(null);
-  const [panelSize, setPanelSize] = useState<{ width: number; height: number } | null>(null);
+  const pendingPanelSizeRef = useRef<EchoChamberSize | null>(null);
+  const [panelSize, setPanelSize] = useState<EchoChamberSize | null>(null);
 
-  const activeChatId = useChatStore((s) => s.activeChatId);
   const isAgentProcessing = useAgentStore((s) =>
     activeChatId ? s.processingChatIds.includes(activeChatId) : s.isProcessing,
   );
@@ -342,6 +347,25 @@ export function EchoChamberPanel({ hiddenOnMobile = false }: EchoChamberPanelPro
     };
   }, []);
 
+  const commitPanelSize = useCallback(
+    (width: number, height: number) => {
+      const nextSize = clampPanelSize(width, height);
+      pendingPanelSizeRef.current = null;
+      setPanelSize(nextSize);
+      if (activeChatId) setEchoChamberSizeForChat(activeChatId, nextSize);
+    },
+    [activeChatId, clampPanelSize, setEchoChamberSizeForChat],
+  );
+
+  useEffect(() => {
+    pendingPanelSizeRef.current = null;
+    setPanelSize(
+      activeChatId && rememberedPanelSize
+        ? clampPanelSize(rememberedPanelSize.width, rememberedPanelSize.height)
+        : null,
+    );
+  }, [activeChatId, clampPanelSize, rememberedPanelSize]);
+
   const handleResizeStart = useCallback((event: ReactPointerEvent<HTMLButtonElement>) => {
     const rect = panelRef.current?.getBoundingClientRect();
     if (!rect) return;
@@ -359,15 +383,29 @@ export function EchoChamberPanel({ hiddenOnMobile = false }: EchoChamberPanelPro
       event.stopPropagation();
       const horizontalDelta = (event.clientX - start.startX) * (resizeFromLeft ? -1 : 1);
       const verticalDelta = (event.clientY - start.startY) * (resizeFromTop ? -1 : 1);
-      setPanelSize(clampPanelSize(start.width + horizontalDelta, start.height + verticalDelta));
+      const nextSize = clampPanelSize(start.width + horizontalDelta, start.height + verticalDelta);
+      pendingPanelSizeRef.current = nextSize;
+      setPanelSize(nextSize);
     },
     [clampPanelSize, resizeFromLeft, resizeFromTop],
   );
 
-  const handleResizeEnd = useCallback((event: ReactPointerEvent<HTMLButtonElement>) => {
-    resizeRef.current = null;
-    if (event.currentTarget.hasPointerCapture(event.pointerId)) event.currentTarget.releasePointerCapture(event.pointerId);
-  }, []);
+  const handleResizeEnd = useCallback(
+    (event: ReactPointerEvent<HTMLButtonElement>) => {
+      const pendingSize = pendingPanelSizeRef.current;
+      const rect = panelRef.current?.getBoundingClientRect();
+      resizeRef.current = null;
+      if (event.currentTarget.hasPointerCapture(event.pointerId)) {
+        event.currentTarget.releasePointerCapture(event.pointerId);
+      }
+      if (pendingSize) {
+        commitPanelSize(pendingSize.width, pendingSize.height);
+      } else if (rect) {
+        commitPanelSize(rect.width, rect.height);
+      }
+    },
+    [commitPanelSize],
+  );
 
   const handleResizeKeyDown = useCallback(
     (event: ReactKeyboardEvent<HTMLButtonElement>) => {
@@ -377,9 +415,9 @@ export function EchoChamberPanel({ hiddenOnMobile = false }: EchoChamberPanelPro
       if (!rect) return;
       const widthDelta = event.key === "ArrowRight" ? RESIZE_KEYBOARD_STEP : event.key === "ArrowLeft" ? -RESIZE_KEYBOARD_STEP : 0;
       const heightDelta = event.key === "ArrowDown" ? RESIZE_KEYBOARD_STEP : event.key === "ArrowUp" ? -RESIZE_KEYBOARD_STEP : 0;
-      setPanelSize(clampPanelSize(rect.width + widthDelta, rect.height + heightDelta));
+      commitPanelSize(rect.width + widthDelta, rect.height + heightDelta);
     },
-    [clampPanelSize],
+    [commitPanelSize],
   );
 
   useEffect(() => {

--- a/packages/client/src/stores/ui.store.ts
+++ b/packages/client/src/stores/ui.store.ts
@@ -74,6 +74,10 @@ export type TrackerDataPanelSection = "world" | "persona" | "characters" | "ques
 export type TrackerPanelCollapsedSections = Partial<Record<TrackerDataPanelSection, boolean>>;
 export type TrackerPanelSectionOrder = TrackerDataPanelSection[];
 export type EchoChamberSide = "top-left" | "top-right" | "bottom-left" | "bottom-right";
+export interface EchoChamberSize {
+  width: number;
+  height: number;
+}
 export type UserStatus = "active" | "idle" | "dnd" | "invisible";
 export type RoleplayAvatarStyle = "none" | "circles" | "rectangles" | "panel";
 export type GameDialogueDisplayMode = "classic" | "stacked";
@@ -119,6 +123,29 @@ export const TRACKER_PANEL_SIZE_PROFILE_WIDTHS: Record<TrackerPanelSizeProfile, 
   standard: 340,
   expanded: 420,
 };
+
+function normalizeEchoChamberSize(value: unknown): EchoChamberSize | null {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return null;
+  const candidate = value as { width?: unknown; height?: unknown };
+  const width = Number(candidate.width);
+  const height = Number(candidate.height);
+  if (!Number.isFinite(width) || !Number.isFinite(height) || width <= 0 || height <= 0) return null;
+  return {
+    width: Math.min(10_000, Math.round(width)),
+    height: Math.min(10_000, Math.round(height)),
+  };
+}
+
+function normalizeEchoChamberSizes(value: unknown): Record<string, EchoChamberSize> {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return {};
+  const normalized: Record<string, EchoChamberSize> = {};
+  for (const [chatId, size] of Object.entries(value)) {
+    if (!chatId.trim()) continue;
+    const nextSize = normalizeEchoChamberSize(size);
+    if (nextSize) normalized[chatId] = nextSize;
+  }
+  return normalized;
+}
 export const TRACKER_PANEL_WIDTH_DEFAULT = TRACKER_PANEL_SIZE_PROFILE_WIDTHS.standard;
 export const TRACKER_PANEL_WIDTH_MIN = TRACKER_PANEL_SIZE_PROFILE_WIDTHS.compact;
 export const TRACKER_PANEL_WIDTH_MAX = TRACKER_PANEL_SIZE_PROFILE_WIDTHS.expanded;
@@ -750,6 +777,7 @@ interface UIState {
   // ── EchoChamber ──
   echoChamberOpen: boolean;
   echoChamberSide: EchoChamberSide;
+  echoChamberSizeByChatId: Record<string, EchoChamberSize>;
 
   // ── User Status ──
   /** The user's manually chosen status. Persisted. */
@@ -995,6 +1023,7 @@ interface UIState {
   dismissLinkApiBanner: () => void;
   toggleEchoChamber: () => void;
   setEchoChamberSide: (side: EchoChamberSide) => void;
+  setEchoChamberSizeForChat: (chatId: string, size: EchoChamberSize) => void;
   setUserStatus: (status: UserStatus) => void;
   setUserStatusManual: (status: UserStatus) => void;
   setUserActivity: (activity: string) => void;
@@ -1378,6 +1407,7 @@ export const useUIStore = create<UIState>()(
       linkApiBannerDismissed: false,
       echoChamberOpen: true,
       echoChamberSide: "bottom-right" as EchoChamberSide,
+      echoChamberSizeByChatId: {},
       userStatusManual: "active" as const,
       userStatus: "active" as UserStatus,
       userActivity: "",
@@ -2254,6 +2284,17 @@ export const useUIStore = create<UIState>()(
       dismissLinkApiBanner: () => set({ linkApiBannerDismissed: true }),
       toggleEchoChamber: () => set((s) => ({ echoChamberOpen: !s.echoChamberOpen })),
       setEchoChamberSide: (side) => set({ echoChamberSide: side }),
+      setEchoChamberSizeForChat: (chatId, size) => {
+        const normalizedChatId = chatId.trim();
+        const normalizedSize = normalizeEchoChamberSize(size);
+        if (!normalizedChatId || !normalizedSize) return;
+        set((state) => ({
+          echoChamberSizeByChatId: {
+            ...state.echoChamberSizeByChatId,
+            [normalizedChatId]: normalizedSize,
+          },
+        }));
+      },
       setUserStatus: (status) => set({ userStatus: status }),
       setUserStatusManual: (status) => set({ userStatusManual: status, userStatus: status }),
       setUserActivity: (activity) => set({ userActivity: activity.slice(0, USER_ACTIVITY_MAX_LENGTH) }),
@@ -2271,7 +2312,7 @@ export const useUIStore = create<UIState>()(
     }),
     {
       name: "marinara-engine-ui",
-      version: 86,
+      version: 87,
       // Debounce localStorage writes to avoid sync I/O on every state change
       storage: createJSONStorage(() => {
         let timer: ReturnType<typeof setTimeout> | null = null;
@@ -2865,6 +2906,11 @@ export const useUIStore = create<UIState>()(
             persisted.noodleNavigation = { mode: "noodler", view: "hub" };
           }
         }
+        // v86 -> v87: remember Echo Chamber dimensions independently for each chat.
+        if (version <= 86) {
+          persisted.echoChamberSizeByChatId = {};
+        }
+        persisted.echoChamberSizeByChatId = normalizeEchoChamberSizes(persisted.echoChamberSizeByChatId);
         // v84 -> v85: keep the historical blank-line behavior for /continue by default.
         if (version <= 84 && persisted.continueAddsNewline === undefined) {
           persisted.continueAddsNewline = true;
@@ -3037,6 +3083,7 @@ export const useUIStore = create<UIState>()(
         linkApiBannerDismissed: state.linkApiBannerDismissed,
         echoChamberOpen: state.echoChamberOpen,
         echoChamberSide: state.echoChamberSide,
+        echoChamberSizeByChatId: state.echoChamberSizeByChatId,
         userStatusManual: state.userStatusManual,
         userStatus: state.userStatus,
         userActivity: state.userActivity,

--- a/packages/client/src/styles/globals.css
+++ b/packages/client/src/styles/globals.css
@@ -5070,6 +5070,10 @@ strong {
 /* ─────────────────────────────────────────────
    21. PERFORMANCE — GPU COMPOSITING HINTS
    ───────────────────────────────────────────── */
+[data-chat-mode="roleplay"] .mari-chat-input-textarea {
+  contain: paint;
+}
+
 .rpg-sprite-container img,
 .rpg-avatar-glow img,
 .rpg-avatar-panel img,

--- a/packages/server/src/services/agents/agent-executor.ts
+++ b/packages/server/src/services/agents/agent-executor.ts
@@ -32,6 +32,7 @@ import { logger, logDebugOverride } from "../../lib/logger.js";
 import { wrapContent } from "../prompt/format-engine.js";
 import { sanitizePromptLeaf } from "../prompt/prompt-escaping.js";
 import { settleAgentJobsWithConcurrencyLimit } from "./agent-concurrency.js";
+import { normalizeCyoaChoiceOutput } from "./cyoa-choice-normalization.js";
 import { getAssetManifest } from "../game/asset-manifest.service.js";
 
 const MAX_AGENT_CONTEXT_MESSAGES = 200;
@@ -2742,7 +2743,8 @@ function parseAgentResponse(
   if (agentResponseIsJson(config)) {
     try {
       const jsonStr = extractJson(responseText);
-      const data = JSON.parse(jsonStr);
+      const parsedData: unknown = JSON.parse(jsonStr);
+      const data = config.type === "cyoa" ? normalizeCyoaChoiceOutput(parsedData) : parsedData;
       return { type: resultType, data };
     } catch {
       return { type: resultType, data: { raw: responseText, parseError: true } };

--- a/packages/server/src/services/agents/cyoa-choice-normalization.ts
+++ b/packages/server/src/services/agents/cyoa-choice-normalization.ts
@@ -1,0 +1,25 @@
+const SINGLE_QUOTED_SPAN_RE =
+  /(^|[\s([{—–-])'((?:[^'\r\n]|(?<=[\p{L}\p{N}])'(?=[\p{L}\p{N}]))+)'(?=$|[\s)\]},.!?;:—–-])/gmu;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+export function normalizeCyoaDialogueQuotes(text: string): string {
+  return text.replace(SINGLE_QUOTED_SPAN_RE, '$1"$2"');
+}
+
+export function normalizeCyoaChoiceOutput(data: unknown): unknown {
+  if (!isRecord(data) || !Array.isArray(data.choices)) return data;
+
+  let changed = false;
+  const choices = data.choices.map((choice) => {
+    if (!isRecord(choice) || typeof choice.text !== "string") return choice;
+    const text = normalizeCyoaDialogueQuotes(choice.text);
+    if (text === choice.text) return choice;
+    changed = true;
+    return { ...choice, text };
+  });
+
+  return changed ? { ...data, choices } : data;
+}

--- a/packages/server/src/services/tools/tool-executor.ts
+++ b/packages/server/src/services/tools/tool-executor.ts
@@ -1709,7 +1709,15 @@ async function spotifyPlay(
     // If it's a single playlist URI, use context_uri
     const firstUri = uris[0]!;
     const singleTrackUri = uris.length === 1 && firstUri.startsWith("spotify:track:");
+    const allTrackUris = uris.every((uri) => uri.startsWith("spotify:track:"));
     const beforePlayback = await fetchSpotifyPlaybackSnapshot(creds.accessToken);
+    const repeatTrackList =
+      allTrackUris &&
+      uris.length > 1 &&
+      (repeatAfterPlay === "track" ||
+        repeatAfterPlay === "context" ||
+        (repeatAfterPlay === undefined && beforePlayback?.repeatState === "context"));
+    const effectiveRepeatAfterPlay = repeatTrackList ? "context" : repeatAfterPlay;
     const fallbackDevice = beforePlayback?.deviceId ? null : await findActiveSpotifyPlaybackDevice(creds.accessToken);
     const targetDeviceId = beforePlayback?.deviceId ?? fallbackDevice?.deviceId ?? null;
     const targetDeviceName = beforePlayback?.deviceName ?? fallbackDevice?.deviceName ?? null;
@@ -1728,7 +1736,7 @@ async function spotifyPlay(
       await primeSpotifyPlaybackDevice(creds.accessToken, playDeviceId, targetDeviceName);
     }
 
-    if (singleTrackUri && repeatAfterPlay === "track") {
+    if (singleTrackUri && effectiveRepeatAfterPlay === "track") {
       await applySpotifyRepeatAfterPlay(creds.accessToken, "off", playDeviceId);
     }
 
@@ -1736,7 +1744,7 @@ async function spotifyPlay(
       const body: SpotifyPlayRequestBody = { context_uri: firstUri };
       const play = await requestSpotifyPlayback(creds.accessToken, playDeviceId, body);
       if (!play.ok) return { error: play.error };
-      const repeat = await applySpotifyRepeatAfterPlay(creds.accessToken, repeatAfterPlay, playDeviceId);
+      const repeat = await applySpotifyRepeatAfterPlay(creds.accessToken, effectiveRepeatAfterPlay, playDeviceId);
       const current = await verifyOrNudgeSpotifyPlayback({
         accessToken: creds.accessToken,
         body,
@@ -1778,17 +1786,18 @@ async function spotifyPlay(
       };
     }
 
-    // For track queues, start the first track first, then add the rest with
-    // Spotify's queue endpoint. Sending 3-5 URIs directly to /play is valid,
-    // but Spotify Connect can accept it without reliably starting playback.
-    const allTrackUris = uris.every((uri) => uri.startsWith("spotify:track:"));
-    const playbackUris = allTrackUris && uris.length > 1 ? [firstUri] : uris;
-    const queuedTrackUris = allTrackUris && uris.length > 1 ? uris.slice(1) : [];
+    // A repeatable selection must be sent as one playback context. Spotify's
+    // queue endpoint is one-way: after its appended tracks drain, repeat-track
+    // can only loop the final item. For non-repeating selections, retain the
+    // more reliable first-track + queue path and let verification nudge playback.
+    const splitIntoDisposableQueue = allTrackUris && uris.length > 1 && !repeatTrackList;
+    const playbackUris = splitIntoDisposableQueue ? [firstUri] : uris;
+    const queuedTrackUris = splitIntoDisposableQueue ? uris.slice(1) : [];
     const body: SpotifyPlayRequestBody = { uris: playbackUris, position_ms: 0 };
     const play = await requestSpotifyPlayback(creds.accessToken, playDeviceId, body);
     if (!play.ok) return { error: play.error };
     if (singleTrackUri) await wait(SPOTIFY_PLAYBACK_SETTLE_MS);
-    let repeat = await applySpotifyRepeatAfterPlay(creds.accessToken, repeatAfterPlay, playDeviceId);
+    let repeat = await applySpotifyRepeatAfterPlay(creds.accessToken, effectiveRepeatAfterPlay, playDeviceId);
     let current = await verifyOrNudgeSpotifyPlayback({
       accessToken: creds.accessToken,
       body,
@@ -1799,8 +1808,21 @@ async function spotifyPlay(
       expectedUris: playbackUris,
       requireFirstUri: singleTrackUri || (allTrackUris && uris.length > 1),
     });
-    if (singleTrackUri && repeatAfterPlay === "track" && current?.repeatState !== "track") {
+    if (singleTrackUri && effectiveRepeatAfterPlay === "track" && current?.repeatState !== "track") {
       repeat = await applySpotifyRepeatAfterPlay(creds.accessToken, "track", current?.deviceId ?? playDeviceId, 3);
+      current = await verifyOrNudgeSpotifyPlayback({
+        accessToken: creds.accessToken,
+        body,
+        initialDeviceId: current?.deviceId ?? playDeviceId,
+        targetDeviceId,
+        targetDeviceName,
+        expectedTrackUri: firstUri,
+        expectedUris: playbackUris,
+        requireFirstUri: true,
+      });
+    }
+    if (repeatTrackList && current?.repeatState !== "context") {
+      repeat = await applySpotifyRepeatAfterPlay(creds.accessToken, "context", current?.deviceId ?? playDeviceId, 3);
       current = await verifyOrNudgeSpotifyPlayback({
         accessToken: creds.accessToken,
         body,

--- a/packages/server/src/services/tools/tool-executor.ts
+++ b/packages/server/src/services/tools/tool-executor.ts
@@ -1823,25 +1823,27 @@ async function spotifyPlay(
       });
     }
     if (repeatTrackList && current?.repeatState !== "context") {
-      repeat = await applySpotifyRepeatAfterPlay(creds.accessToken, "context", current?.deviceId ?? playDeviceId, 3);
-      current = await verifyOrNudgeSpotifyPlayback({
-        accessToken: creds.accessToken,
-        body,
-        initialDeviceId: current?.deviceId ?? playDeviceId,
-        targetDeviceId,
-        targetDeviceName,
-        expectedTrackUri: firstUri,
-        expectedUris: playbackUris,
-        requireFirstUri: true,
-      });
+      for (const delay of SPOTIFY_REPEAT_RETRY_DELAYS_MS) {
+        if (delay > 0) await wait(delay);
+        repeat = await applySpotifyRepeatAfterPlay(
+          creds.accessToken,
+          "context",
+          current?.deviceId ?? playDeviceId,
+        );
+        const repeatSnapshot = await fetchSpotifyPlaybackSnapshot(creds.accessToken);
+        if (repeatSnapshot) current = repeatSnapshot;
+        if (spotifyPlaybackMatches(current, playbackUris, true) && current?.repeatState === "context") break;
+      }
     }
-    if (!spotifyPlaybackMatches(current, playbackUris, requireFirstUriMatch)) {
+    const repeatModeVerified = !repeatTrackList || current?.repeatState === "context";
+    if (!repeatModeVerified || !spotifyPlaybackMatches(current, playbackUris, requireFirstUriMatch)) {
       logger.warn(
-        "[spotify] Playback accepted but verification failed device=%s isPlaying=%s currentUri=%s expected=%s",
+        "[spotify] Playback accepted but verification failed device=%s isPlaying=%s currentUri=%s expected=%s repeat=%s",
         current?.deviceName ?? targetDeviceName ?? "unknown",
         current?.isPlaying === true ? "true" : "false",
         current?.trackUri ?? "none",
         playbackUris[0] ?? firstUri,
+        current?.repeatState ?? "unknown",
       );
       const queuedAfterStart = await queueSpotifyTracks(
         creds.accessToken,

--- a/packages/server/src/services/tools/tool-executor.ts
+++ b/packages/server/src/services/tools/tool-executor.ts
@@ -1798,15 +1798,16 @@ async function spotifyPlay(
     if (!play.ok) return { error: play.error };
     if (singleTrackUri) await wait(SPOTIFY_PLAYBACK_SETTLE_MS);
     let repeat = await applySpotifyRepeatAfterPlay(creds.accessToken, effectiveRepeatAfterPlay, playDeviceId);
+    const requireFirstUriMatch = singleTrackUri || (allTrackUris && uris.length > 1);
     let current = await verifyOrNudgeSpotifyPlayback({
       accessToken: creds.accessToken,
       body,
       initialDeviceId: playDeviceId,
       targetDeviceId,
       targetDeviceName,
-      expectedTrackUri: singleTrackUri || (allTrackUris && uris.length > 1) ? firstUri : undefined,
+      expectedTrackUri: requireFirstUriMatch ? firstUri : undefined,
       expectedUris: playbackUris,
-      requireFirstUri: singleTrackUri || (allTrackUris && uris.length > 1),
+      requireFirstUri: requireFirstUriMatch,
     });
     if (singleTrackUri && effectiveRepeatAfterPlay === "track" && current?.repeatState !== "track") {
       repeat = await applySpotifyRepeatAfterPlay(creds.accessToken, "track", current?.deviceId ?? playDeviceId, 3);
@@ -1834,7 +1835,7 @@ async function spotifyPlay(
         requireFirstUri: true,
       });
     }
-    if (!spotifyPlaybackMatches(current, playbackUris, singleTrackUri || (allTrackUris && uris.length > 1))) {
+    if (!spotifyPlaybackMatches(current, playbackUris, requireFirstUriMatch)) {
       logger.warn(
         "[spotify] Playback accepted but verification failed device=%s isPlaying=%s currentUri=%s expected=%s",
         current?.deviceName ?? targetDeviceName ?? "unknown",

--- a/scripts/regressions/prompt.regression.ts
+++ b/scripts/regressions/prompt.regression.ts
@@ -83,6 +83,10 @@ import {
   NOODLE_PERSONA_IDENTITY_INSTRUCTION,
 } from "../../packages/server/src/services/noodle/noodle-prompt.js";
 import { buildPartyRecruitCardPrompt } from "../../packages/server/src/services/game/gm-prompts.js";
+import {
+  normalizeCyoaChoiceOutput,
+  normalizeCyoaDialogueQuotes,
+} from "../../packages/server/src/services/agents/cyoa-choice-normalization.js";
 
 const personaA = {
   id: "noodle-account-a",
@@ -728,6 +732,65 @@ const keywordOptions = {
 };
 
 const cases: RegressionCase[] = [
+  {
+    name: "CYOA accepts escaped double quotes and normalizes single-quoted dialogue",
+    async run() {
+      assert.equal(
+        normalizeCyoaDialogueQuotes(`'Hold still,' I whisper. I can't leave the captain's key behind.`),
+        `"Hold still," I whisper. I can't leave the captain's key behind.`,
+      );
+      assert.equal(
+        normalizeCyoaDialogueQuotes(`I answer, "Already correct."`),
+        `I answer, "Already correct."`,
+        "double quotes decoded from valid JSON should remain unchanged",
+      );
+      assert.equal(
+        normalizeCyoaDialogueQuotes(`I can't abandon James' coat.`),
+        `I can't abandon James' coat.`,
+        "contractions and possessives are apostrophes, not dialogue delimiters",
+      );
+      assert.deepEqual(
+        normalizeCyoaChoiceOutput({
+          choices: [
+            { label: "Reassure her", text: `'You're safe,' I promise.` },
+            { label: "Ask directly", text: `I ask, "What happened?"` },
+          ],
+        }),
+        {
+          choices: [
+            { label: "Reassure her", text: `"You're safe," I promise.` },
+            { label: "Ask directly", text: `I ask, "What happened?"` },
+          ],
+        },
+      );
+
+      const providerResponse = JSON.stringify({
+        choices: [
+          { label: "Reassure her", text: `'You're safe,' I promise.` },
+          { label: "Ask directly", text: `I ask, "What happened?"` },
+        ],
+      });
+      const { provider } = makeCapturingProvider(providerResponse);
+      const result = await executeAgent(
+        makeRegressionAgentConfig({
+          id: "builtin:cyoa",
+          type: "cyoa",
+          name: "CYOA Choices",
+          promptTemplate: "Return CYOA choices.",
+        }) as any,
+        makeRegressionAgentContext(),
+        provider as any,
+        "regression-model",
+      );
+
+      assert.equal(result.success, true);
+      assert.deepEqual(
+        result.data,
+        normalizeCyoaChoiceOutput(JSON.parse(providerResponse)),
+        "the shared agent-result boundary should normalize CYOA output before persistence and display",
+      );
+    },
+  },
   {
     name: "/continue can append directly without inserting a newline",
     run: () => {

--- a/scripts/regressions/prompt.regression.ts
+++ b/scripts/regressions/prompt.regression.ts
@@ -1284,6 +1284,155 @@ const cases: RegressionCase[] = [
     },
   },
   {
+    name: "Spotify repeats a Music DJ track selection as one context",
+    async run() {
+      const originalFetch = globalThis.fetch;
+      const selectedUris = [
+        "spotify:track:AAAAAAAAAAAAAAAAAAAAAA",
+        "spotify:track:BBBBBBBBBBBBBBBBBBBBBB",
+        "spotify:track:CCCCCCCCCCCCCCCCCCCCCC",
+      ];
+      const playbackBodies: Array<{ uris?: string[]; position_ms?: number }> = [];
+      const queuedUris: string[] = [];
+      const repeatStates: string[] = [];
+      let activeUri = "spotify:track:ZZZZZZZZZZZZZZZZZZZZZZ";
+      let repeatState = "track";
+
+      globalThis.fetch = (async (input: string | URL | Request, init?: RequestInit) => {
+        const url = new URL(typeof input === "string" || input instanceof URL ? input : input.url);
+        const method = init?.method ?? "GET";
+        if (url.pathname === "/v1/me/player" && method === "GET") {
+          return new Response(
+            JSON.stringify({
+              is_playing: true,
+              repeat_state: repeatState,
+              item: { uri: activeUri },
+              device: { id: "regression-device", name: "Regression device", type: "computer" },
+            }),
+            { status: 200, headers: { "Content-Type": "application/json" } },
+          );
+        }
+        if (url.pathname === "/v1/me/player/play" && method === "PUT") {
+          const body = JSON.parse(String(init?.body ?? "{}")) as { uris?: string[]; position_ms?: number };
+          playbackBodies.push(body);
+          activeUri = body.uris?.[0] ?? activeUri;
+          return new Response(null, { status: 204 });
+        }
+        if (url.pathname === "/v1/me/player/repeat" && method === "PUT") {
+          repeatState = url.searchParams.get("state") ?? "off";
+          repeatStates.push(repeatState);
+          return new Response(null, { status: 204 });
+        }
+        if (url.pathname === "/v1/me/player/queue" && method === "POST") {
+          queuedUris.push(url.searchParams.get("uri") ?? "");
+          return new Response(null, { status: 204 });
+        }
+        throw new Error(`Unexpected Spotify regression request: ${method} ${url.pathname}`);
+      }) as typeof fetch;
+
+      try {
+        const results = await executeToolCalls(
+          [
+            {
+              id: "call_spotify_repeat_context",
+              type: "function",
+              function: {
+                name: "spotify_play",
+                arguments: JSON.stringify({ uris: selectedUris, reason: "Regression selection" }),
+              },
+            },
+          ],
+          {
+            spotify: { accessToken: "regression-token" },
+            spotifyRepeatAfterPlay: "track",
+          },
+        );
+
+        assert.equal(results[0]?.success, true);
+        const payload = JSON.parse(results[0]!.result) as {
+          repeat?: string;
+          repeatState?: string;
+          queued?: number;
+        };
+        assert.deepEqual(playbackBodies[0]?.uris, selectedUris);
+        assert.deepEqual(queuedUris, [], "repeatable Music DJ selections must not use Spotify's disposable queue");
+        assert.equal(repeatStates.at(-1), "context");
+        assert.equal(payload.repeat, "context");
+        assert.equal(payload.repeatState, "context");
+        assert.equal(payload.queued, selectedUris.length);
+      } finally {
+        globalThis.fetch = originalFetch;
+      }
+    },
+  },
+  {
+    name: "Spotify keeps repeat-track for a single Music DJ song",
+    async run() {
+      const originalFetch = globalThis.fetch;
+      const selectedUri = "spotify:track:DDDDDDDDDDDDDDDDDDDDDD";
+      const playbackBodies: Array<{ uris?: string[] }> = [];
+      const repeatStates: string[] = [];
+      let activeUri = "spotify:track:ZZZZZZZZZZZZZZZZZZZZZZ";
+      let repeatState = "track";
+
+      globalThis.fetch = (async (input: string | URL | Request, init?: RequestInit) => {
+        const url = new URL(typeof input === "string" || input instanceof URL ? input : input.url);
+        const method = init?.method ?? "GET";
+        if (url.pathname === "/v1/me/player" && method === "GET") {
+          return new Response(
+            JSON.stringify({
+              is_playing: true,
+              repeat_state: repeatState,
+              item: { uri: activeUri },
+              device: { id: "regression-device", name: "Regression device", type: "computer" },
+            }),
+            { status: 200, headers: { "Content-Type": "application/json" } },
+          );
+        }
+        if (url.pathname === "/v1/me/player/play" && method === "PUT") {
+          const body = JSON.parse(String(init?.body ?? "{}")) as { uris?: string[] };
+          playbackBodies.push(body);
+          activeUri = body.uris?.[0] ?? activeUri;
+          return new Response(null, { status: 204 });
+        }
+        if (url.pathname === "/v1/me/player/repeat" && method === "PUT") {
+          repeatState = url.searchParams.get("state") ?? "off";
+          repeatStates.push(repeatState);
+          return new Response(null, { status: 204 });
+        }
+        throw new Error(`Unexpected Spotify regression request: ${method} ${url.pathname}`);
+      }) as typeof fetch;
+
+      try {
+        const results = await executeToolCalls(
+          [
+            {
+              id: "call_spotify_repeat_track",
+              type: "function",
+              function: {
+                name: "spotify_play",
+                arguments: JSON.stringify({ uri: selectedUri, reason: "Regression single" }),
+              },
+            },
+          ],
+          {
+            spotify: { accessToken: "regression-token" },
+            spotifyRepeatAfterPlay: "track",
+          },
+        );
+
+        assert.equal(results[0]?.success, true);
+        const payload = JSON.parse(results[0]!.result) as { repeat?: string; repeatState?: string };
+        assert.deepEqual(playbackBodies[0]?.uris, [selectedUri]);
+        assert.deepEqual(repeatStates, ["off", "track"]);
+        assert.equal(payload.repeat, "track");
+        assert.equal(payload.repeatState, "track");
+      } finally {
+        globalThis.fetch = originalFetch;
+      }
+    },
+  },
+  {
     name: "npc default TTS voice pools work for non-ElevenLabs providers",
     run() {
       const baseConfig: Parameters<typeof resolveTTSVoiceForSpeaker>[0] = {

--- a/scripts/regressions/prompt.regression.ts
+++ b/scripts/regressions/prompt.regression.ts
@@ -1496,6 +1496,78 @@ const cases: RegressionCase[] = [
     },
   },
   {
+    name: "Spotify does not report a repeated Music DJ selection before context repeat is confirmed",
+    async run() {
+      const originalFetch = globalThis.fetch;
+      const selectedUris = [
+        "spotify:track:EEEEEEEEEEEEEEEEEEEEEE",
+        "spotify:track:FFFFFFFFFFFFFFFFFFFFFF",
+      ];
+      let activeUri = "spotify:track:ZZZZZZZZZZZZZZZZZZZZZZ";
+      let repeatRequests = 0;
+
+      globalThis.fetch = (async (input: string | URL | Request, init?: RequestInit) => {
+        const url = new URL(typeof input === "string" || input instanceof URL ? input : input.url);
+        const method = init?.method ?? "GET";
+        if (url.pathname === "/v1/me/player" && method === "GET") {
+          return new Response(
+            JSON.stringify({
+              is_playing: true,
+              repeat_state: "off",
+              item: { uri: activeUri },
+              device: { id: "regression-device", name: "Regression device", type: "computer" },
+            }),
+            { status: 200, headers: { "Content-Type": "application/json" } },
+          );
+        }
+        if (url.pathname === "/v1/me/player/play" && method === "PUT") {
+          const body = JSON.parse(String(init?.body ?? "{}")) as { uris?: string[] };
+          activeUri = body.uris?.[0] ?? activeUri;
+          return new Response(null, { status: 204 });
+        }
+        if (url.pathname === "/v1/me/player/repeat" && method === "PUT") {
+          repeatRequests++;
+          return new Response(null, { status: 204 });
+        }
+        throw new Error(`Unexpected Spotify regression request: ${method} ${url.pathname}`);
+      }) as typeof fetch;
+
+      try {
+        const results = await executeToolCalls(
+          [
+            {
+              id: "call_spotify_repeat_unconfirmed",
+              type: "function",
+              function: {
+                name: "spotify_play",
+                arguments: JSON.stringify({ uris: selectedUris, reason: "Unconfirmed repeat regression" }),
+              },
+            },
+          ],
+          {
+            spotify: { accessToken: "regression-token" },
+            spotifyRepeatAfterPlay: "context",
+          },
+        );
+
+        assert.equal(results[0]?.success, true);
+        const payload = JSON.parse(results[0]!.result) as {
+          applied?: boolean;
+          playbackPending?: boolean;
+          verification?: string;
+          repeatState?: string;
+        };
+        assert.equal(repeatRequests, 4, "Spotify repeat should be retried while playback reports it as off");
+        assert.equal(payload.applied, true);
+        assert.equal(payload.playbackPending, true);
+        assert.equal(payload.verification, "pending");
+        assert.equal(payload.repeatState, "off");
+      } finally {
+        globalThis.fetch = originalFetch;
+      }
+    },
+  },
+  {
     name: "npc default TTS voice pools work for non-ElevenLabs providers",
     run() {
       const baseConfig: Parameters<typeof resolveTTSVoiceForSpeaker>[0] = {

--- a/scripts/regressions/roleplay-streaming.regression.ts
+++ b/scripts/regressions/roleplay-streaming.regression.ts
@@ -106,6 +106,16 @@ assert.match(
   "Echo Chamber should persist a completed resize against the active chat",
 );
 assert.match(
+  echoChamberPanelSource,
+  /onPointerCancel=\{handleResizeCancel\}/u,
+  "a canceled Echo Chamber resize should use its rollback path",
+);
+assert.doesNotMatch(
+  echoChamberPanelSource,
+  /onPointerCancel=\{handleResizeEnd\}/u,
+  "pointer cancellation must not persist an incomplete Echo Chamber resize",
+);
+assert.match(
   uiStoreSource,
   /echoChamberSizeByChatId: state\.echoChamberSizeByChatId/u,
   "per-chat Echo Chamber dimensions should survive UI-store rehydration",

--- a/scripts/regressions/roleplay-streaming.regression.ts
+++ b/scripts/regressions/roleplay-streaming.regression.ts
@@ -59,6 +59,18 @@ const chatRoleplaySurfaceSource = readFileSync(
   new URL("../../packages/client/src/components/chat/ChatRoleplaySurface.tsx", import.meta.url),
   "utf8",
 );
+const echoChamberPanelSource = readFileSync(
+  new URL("../../packages/client/src/components/chat/EchoChamberPanel.tsx", import.meta.url),
+  "utf8",
+);
+const uiStoreSource = readFileSync(
+  new URL("../../packages/client/src/stores/ui.store.ts", import.meta.url),
+  "utf8",
+);
+const globalStylesSource = readFileSync(
+  new URL("../../packages/client/src/styles/globals.css", import.meta.url),
+  "utf8",
+);
 const conversationInputSource = readFileSync(
   new URL("../../packages/client/src/components/chat/ConversationInput.tsx", import.meta.url),
   "utf8",
@@ -82,6 +94,21 @@ const chatStoreSource = readFileSync(
 const summaryPopoverSource = readFileSync(
   new URL("../../packages/client/src/components/chat/SummaryPopover.tsx", import.meta.url),
   "utf8",
+);
+assert.match(
+  echoChamberPanelSource,
+  /activeChatId \? \(s\.echoChamberSizeByChatId\[activeChatId\] \?\? null\) : null/u,
+  "Echo Chamber should restore the dimensions remembered for the active chat",
+);
+assert.match(
+  echoChamberPanelSource,
+  /if \(activeChatId\) setEchoChamberSizeForChat\(activeChatId, nextSize\);/u,
+  "Echo Chamber should persist a completed resize against the active chat",
+);
+assert.match(
+  uiStoreSource,
+  /echoChamberSizeByChatId: state\.echoChamberSizeByChatId/u,
+  "per-chat Echo Chamber dimensions should survive UI-store rehydration",
 );
 assert.match(
   summaryPopoverSource,
@@ -255,6 +282,16 @@ assert.match(
   chatInputSource,
   /setHasInput\(\(current\) => \(current === nextHasInput \? current : nextHasInput\)\);/u,
   "Roleplay composer presence should change only when the draft crosses the empty boundary",
+);
+assert.match(
+  chatMessageSource,
+  /const isGuided = useChatStore\(\(state\) => guideGenerations && state\.hasCurrentInput\);/u,
+  "Roleplay message actions should not subscribe to draft presence when guided regeneration is disabled",
+);
+assert.match(
+  globalStylesSource,
+  /\[data-chat-mode="roleplay"\] \.mari-chat-input-textarea \{\s+contain: paint;/u,
+  "Roleplay textarea paint should stay isolated from the live scene behind it",
 );
 assert.doesNotMatch(
   chatInputSource,


### PR DESCRIPTION
## Linked issue

Closes #4168
Closes #4170
Closes #4171
Closes #4172

## Why this change

- Echo Chamber dimensions should follow the chat where the user set them.
- Spotify Music DJ repeat should loop a complete multi-song selection, not only its final track.
- Roleplay typing should paint as promptly as Conversation and Game even over a populated live scene.
- CYOA choice dialogue should accept either JSON-escaped double quotes or single-quote delimiters without corrupting apostrophes.

## What changed

- Persisted and restored Echo Chamber dimensions per chat, committing only completed resizes.
- Started repeatable Spotify track selections as one URI list and applied context repeat while retaining track repeat for a single song.
- Isolated Roleplay composer paint and stopped inactive guided actions from subscribing to draft presence.
- Normalized only CYOA choice text from single-quote dialogue delimiters to ordinary double quotes; valid escaped JSON quotes continue through unchanged.
- Added deterministic regressions for the affected paths, including end-to-end CYOA agent parsing.

## Validation

- [ ] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed `CONTRIBUTING.md`

### Automated and focused verification notes

- `pnpm check`
- `pnpm regression:prompt`
- `pnpm --filter @marinara-engine/server exec tsx ../../scripts/regressions/roleplay-streaming.regression.ts`
- Roleplay typographic quote/caret browser regression
- Browser-verified that Echo Chamber dimensions remain independent across two chats and survive reload.
- Profiled a dense Roleplay transcript against Conversation and Game.
- Spotify playback tests use mocked Web API responses; a live Spotify Premium account was not used.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Translated docs on the `docs-i18n` branch updated to match, or a `[docs-i18n] <paths>` follow-up issue opened (see CONTRIBUTING.md § Translated documentation)
- [ ] Version/release files updated (only if this PR includes a version bump)

## UI evidence (if applicable)

Behavioral UI changes were exercised in the local browser. No new visual design or user-facing copy is introduced.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Echo Chamber panel size is now stored per chat and restored when returning.
  * Enhanced Spotify “Music DJ” repeat behavior for multi-track vs single-track selections.
* **Bug Fixes**
  * CYOA agent outputs now normalize dialogue quotation marks more consistently.
  * Guided regeneration controls now correctly reflect whether input is available.
* **Performance**
  * Improved Roleplay text area rendering with paint containment.
* **Tests**
  * Expanded regression coverage for Echo Chamber persistence, CYOA normalization, Spotify repeat flows, and Roleplay behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->