### PR TITLE
fix(maps): keep chat map state out of settings profiles

### DIFF
--- a/e2e/core-flows.e2e.ts
+++ b/e2e/core-flows.e2e.ts
@@ -617,6 +617,74 @@ test("settings profile exports use the new identity and legacy exports still imp
   }
 });
 
+test("settings profiles cannot carry Hierarchical Maps state into another chat", async ({ request }, testInfo) => {
+  test.skip(!testInfo.project.name.includes("desktop"), "Settings profile map isolation is covered once.");
+
+  const suffix = Date.now().toString(36);
+  let profileId = "";
+  let chatId = "";
+  const profileResponse = await request.post("/api/chat-presets", {
+    data: {
+      name: `Map Isolation ${suffix}`,
+      mode: "roleplay",
+      settings: {
+        metadata: {
+          enableAgents: true,
+          activeAgentIds: ["hierarchical-maps"],
+          spatialContext: { locations: [{ id: "falmart", name: "Falmart" }] },
+          spatialContextHierarchyProfile: { name: "Inherited map hierarchy" },
+          spatialMapGenerationPreferences: { activeOptionId: "inherited-map-option" },
+        },
+      },
+    },
+  });
+  expect(profileResponse.ok(), await profileResponse.text()).toBeTruthy();
+  const profile = (await profileResponse.json()) as {
+    id: string;
+    settings: { metadata?: Record<string, unknown> };
+  };
+  profileId = profile.id;
+
+  try {
+    expect(profile.settings.metadata).toMatchObject({
+      enableAgents: true,
+      activeAgentIds: ["hierarchical-maps"],
+    });
+    expect(profile.settings.metadata).not.toHaveProperty("spatialContext");
+    expect(profile.settings.metadata).not.toHaveProperty("spatialContextHierarchyProfile");
+    expect(profile.settings.metadata).not.toHaveProperty("spatialMapGenerationPreferences");
+
+    const chatResponse = await request.post("/api/chats", {
+      data: {
+        name: `Fresh RP without inherited map ${suffix}`,
+        mode: "roleplay",
+        characterIds: [],
+      },
+    });
+    expect(chatResponse.ok(), await chatResponse.text()).toBeTruthy();
+    const chat = (await chatResponse.json()) as { id: string };
+    chatId = chat.id;
+
+    const applyResponse = await request.post(`/api/chat-presets/${profile.id}/apply/${chat.id}`);
+    expect(applyResponse.ok(), await applyResponse.text()).toBeTruthy();
+    const appliedChatResponse = await request.get(`/api/chats/${chat.id}`);
+    expect(appliedChatResponse.ok(), await appliedChatResponse.text()).toBeTruthy();
+    const appliedChat = (await appliedChatResponse.json()) as { metadata?: Record<string, unknown> };
+    expect(appliedChat.metadata).toMatchObject({
+      enableAgents: true,
+      activeAgentIds: ["hierarchical-maps"],
+    });
+    expect(appliedChat.metadata).not.toHaveProperty("spatialContext");
+    expect(appliedChat.metadata).not.toHaveProperty("spatialContextHierarchyProfile");
+    expect(appliedChat.metadata).not.toHaveProperty("spatialMapGenerationPreferences");
+  } finally {
+    await Promise.allSettled([
+      chatId ? request.delete(`/api/chats/${chatId}`) : Promise.resolve(),
+      profileId ? request.delete(`/api/chat-presets/${profileId}`) : Promise.resolve(),
+    ]);
+  }
+});
+
 test("Author's Notes keeps its expand and full macro guide inside the field", async ({ page, request }, testInfo) => {
   test.skip(!testInfo.project.name.includes("desktop"), "Author's Notes field chrome is covered on desktop.");
 

--- a/packages/shared/src/types/chat-preset.ts
+++ b/packages/shared/src/types/chat-preset.ts
@@ -13,7 +13,7 @@
 // What profiles DO NOT carry: per-chat identity (name, characters,
 // persona, group, sprites, scene prompt, generated summaries, tags,
 // ephemeral lorebook overrides, generated schedules, scene lifecycle
-// state, connected chat link, folder/sort placement).
+// state, connected chat link, hierarchical map state, folder/sort placement).
 
 import type { ChatMode, ChatMetadata } from "./chat.js";
 
@@ -80,6 +80,10 @@ export const CHAT_PRESET_EXCLUDED_METADATA_KEYS: readonly string[] = [
   "sceneBusyCharIds",
   // Lorebooks are owned by the chat, never by the profile.
   "activeLorebookIds",
+  // Hierarchical Maps definitions and per-chat editing choices stay with the chat.
+  "spatialContext",
+  "spatialContextHierarchyProfile",
+  "spatialMapGenerationPreferences",
   // Generated Game state is session identity/history, not reusable setup.
   "gameId",
   "gameSessionNumber",


### PR DESCRIPTION
## Linked issue

Part of #4176

## Why this change

- Hierarchical Maps stores each chat's map in metadata, but Roleplay Settings Profiles were allowed to capture that map state. A saved/starred profile from the Falmart chat therefore copied the whole map into every new RP that used the profile, even though the linked lorebook was character-scoped and not global.
- Sanitizing profiles on read also prevents map state already stored by affected releases from being applied after users update.

## What changed

- Exclude `spatialContext`, `spatialContextHierarchyProfile`, and `spatialMapGenerationPreferences` from reusable chat settings profiles.
- Add a focused Playwright regression proving Maps can remain enabled in a profile without carrying Falmart or any other chat's saved map into a fresh RP.

## Validation

- `pnpm --filter @marinara-engine/shared lint`
- `PLAYWRIGHT_CLIENT_PORT=5186 PLAYWRIGHT_SERVER_PORT=7976 pnpm exec playwright test e2e/core-flows.e2e.ts --project=desktop-chromium --grep 'settings profiles cannot carry Hierarchical Maps state'`
- `git diff --check`

- [x] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [x] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed `CONTRIBUTING.md`

### Manual verification notes

- Reproduced the original inheritance on Engine `2.3.5+4d2b049033ed` with Hierarchical Maps `1.1.8`: applying a starred Roleplay Settings Profile containing Falmart/Special Region made those locations appear in a newly created RP.
- Maintainer verification: save/star a settings profile from a chat with a map, create another RP that uses it, and confirm Maps remains enabled but starts with **No map yet**.

## Docs and release impact

- [x] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Translated docs on the `docs-i18n` branch updated to match, or a `[docs-i18n] <paths>` follow-up issue opened (see CONTRIBUTING.md § Translated documentation)
- [ ] Version/release files updated (only if this PR includes a version bump)

## UI evidence (if applicable)

- No UI layout or copy changed.
