### PR TITLE
Smooth Roleplay streaming typewriter cadence

### DIFF
--- a/packages/client/src/hooks/use-generate.ts
+++ b/packages/client/src/hooks/use-generate.ts
@@ -18,6 +18,7 @@ import { chatBackgroundMetadataToUrl, chatBackgroundUrlToMetadata } from "../lib
 import { formatGenerationParameterError } from "../lib/generation-parameter-errors";
 import { sanitizeAppCss } from "../lib/theme-css";
 import {
+  getRoleplayTypewriterRevealCharsPerSecond,
   getTypewriterRevealCharsPerSecond,
   isGenerationStartBlocked,
   reconcileTypewriterReplacement,
@@ -918,6 +919,7 @@ const pendingVisibleGameStateRefreshes = new Map<string, Promise<void>>();
 const activeGenerateLocks = new Set<string>();
 const PASSIVE_STREAM_SETTLE_POLL_MS = 1_500;
 const PASSIVE_STREAM_SETTLE_MAX_WAIT_MS = 30 * 60_000;
+const ROLEPLAY_TYPEWRITER_PREBUFFER_MS = 160;
 
 function wait(ms: number, signal?: AbortSignal) {
   if (!signal) return new Promise<void>((resolve) => setTimeout(resolve, ms));
@@ -1299,6 +1301,7 @@ export function useGenerate() {
       const transportStreaming = useUIStore.getState().enableStreaming;
       const streamingEnabled = transportStreaming;
       const chatModeForGeneration = getCachedChatMode(qc, params.chatId);
+      const smoothRoleplayTypewriter = chatModeForGeneration === "roleplay" || chatModeForGeneration === "visual_novel";
       const shouldDisplayRawStream =
         chatModeForGeneration !== "conversation" || !!params.regenerateMessageId || !!params.continueMessageId;
       const keepStreamLiveThroughPostProcessing = shouldKeepStreamLiveThroughPostProcessing({
@@ -1329,6 +1332,9 @@ export function useGenerate() {
       let typingActive = false;
       let typewriterDone: (() => void) | null = null;
       let rafId = 0;
+      let roleplayTypewriterStarted = false;
+      let roleplayTypewriterBufferUntil = 0;
+      let roleplayTypewriterCharsPerSecond: number | null = null;
       const persistedMessages = new Map<string, Message>();
       let sawGroupTurn = false;
       let currentGroupTurnSavedMessage: Message | null = null;
@@ -1354,7 +1360,9 @@ export function useGenerate() {
         if (!normalizedChunk) return;
         if (streamingEnabled && shouldDisplayRawStream) {
           const now = performance.now();
-          if (lastVisibleChunkAt > 0) {
+          if (smoothRoleplayTypewriter && !roleplayTypewriterStarted && roleplayTypewriterBufferUntil === 0) {
+            roleplayTypewriterBufferUntil = now + ROLEPLAY_TYPEWRITER_PREBUFFER_MS;
+          } else if (!smoothRoleplayTypewriter && lastVisibleChunkAt > 0) {
             const elapsedMs = now - lastVisibleChunkAt;
             if (elapsedMs >= 16 && elapsedMs <= 5000) {
               const sampleRate = (normalizedChunk.length * 1000) / elapsedMs;
@@ -1364,7 +1372,7 @@ export function useGenerate() {
                   : observedArrivalCharsPerSecond * 0.5 + sampleRate * 0.5;
             }
           }
-          lastVisibleChunkAt = now;
+          if (!smoothRoleplayTypewriter) lastVisibleChunkAt = now;
           pendingText += normalizedChunk;
           startTypewriter();
         } else {
@@ -1421,6 +1429,7 @@ export function useGenerate() {
         typingActive = false;
         typewriterRemainder = 0;
         lastTypewriterPaintAt = 0;
+        roleplayTypewriterCharsPerSecond = null;
         if (streamingEnabled && shouldDisplayRawStream && fullBuffer) setStreamBuffer(fullBuffer, params.chatId);
         if (typewriterDone) {
           const done = typewriterDone;
@@ -1471,16 +1480,37 @@ export function useGenerate() {
             }
             return;
           }
+          const selectedCharsPerSecond = getCharsPerSecond();
+          if (
+            smoothRoleplayTypewriter &&
+            !roleplayTypewriterStarted &&
+            selectedCharsPerSecond !== Infinity &&
+            !sawDoneEvent &&
+            now < roleplayTypewriterBufferUntil
+          ) {
+            rafId = requestAnimationFrame(tick);
+            return;
+          }
+          roleplayTypewriterStarted = true;
           if (!lastTypewriterPaintAt) lastTypewriterPaintAt = now;
           const elapsedMs = Math.min(TYPEWRITER_MAX_FRAME_MS, Math.max(0, now - lastTypewriterPaintAt));
           lastTypewriterPaintAt = now;
 
-          const charsPerSecond = getTypewriterRevealCharsPerSecond({
-            selectedCharsPerSecond: getCharsPerSecond(),
-            pendingCharacters: pendingText.length,
-            observedArrivalCharsPerSecond,
-            streamComplete: sawDoneEvent,
-          });
+          const charsPerSecond = smoothRoleplayTypewriter
+            ? getRoleplayTypewriterRevealCharsPerSecond({
+                selectedCharsPerSecond,
+                pendingCharacters: pendingText.length,
+                previousCharsPerSecond: roleplayTypewriterCharsPerSecond,
+                elapsedMs,
+                streamComplete: sawDoneEvent,
+              })
+            : getTypewriterRevealCharsPerSecond({
+                selectedCharsPerSecond,
+                pendingCharacters: pendingText.length,
+                observedArrivalCharsPerSecond,
+                streamComplete: sawDoneEvent,
+              });
+          if (smoothRoleplayTypewriter) roleplayTypewriterCharsPerSecond = charsPerSecond;
           if (charsPerSecond === Infinity) {
             fullBuffer += pendingText;
             pendingText = "";
@@ -1978,6 +2008,9 @@ export function useGenerate() {
                 // Reset the stream buffer for the new character
                 fullBuffer = "";
                 pendingText = "";
+                roleplayTypewriterStarted = false;
+                roleplayTypewriterBufferUntil = 0;
+                roleplayTypewriterCharsPerSecond = null;
                 leadingSpeakerPrefixFilter.reset();
                 thinkingStreamFilter.reset();
                 setStreamBuffer("", params.chatId);

--- a/packages/client/src/lib/generation-stream-policy.ts
+++ b/packages/client/src/lib/generation-stream-policy.ts
@@ -18,6 +18,14 @@ interface TypewriterRevealRateInput {
   streamComplete: boolean;
 }
 
+interface RoleplayTypewriterRevealRateInput {
+  selectedCharsPerSecond: number;
+  pendingCharacters: number;
+  previousCharsPerSecond: number | null;
+  elapsedMs: number;
+  streamComplete: boolean;
+}
+
 interface GenerationSendBlockInput {
   streamActive: boolean;
   agentsProcessing: boolean;
@@ -30,6 +38,10 @@ interface GenerationStartBlockInput {
   activeController: boolean;
   backgroundIllustration: boolean;
 }
+
+const ROLEPLAY_QUEUE_RESERVE_SECONDS = 0.9;
+const ROLEPLAY_SLOWDOWN_RESPONSE_MS = 120;
+const ROLEPLAY_SPEEDUP_RESPONSE_MS = 480;
 
 /** Keep send actions guarded while leaving the draft field itself editable. */
 export function isGenerationSendBlocked(input: GenerationSendBlockInput): boolean {
@@ -56,6 +68,38 @@ export function getTypewriterRevealCharsPerSecond(input: TypewriterRevealRateInp
   const initialRateFloor =
     input.observedArrivalCharsPerSecond === null ? Math.min(12, input.selectedCharsPerSecond) : 1;
   return Math.max(initialRateFloor, Math.min(input.selectedCharsPerSecond, arrivalRate * 0.95));
+}
+
+/**
+ * Pace Roleplay from one continuous reveal clock instead of mirroring the
+ * provider's token bursts. The open-stream target leaves roughly a second of
+ * text in the queue; asymmetric easing slows down quickly when that reserve
+ * shrinks and speeds up gently when another provider chunk arrives.
+ *
+ * The user's selected speed remains the ceiling. Completion removes the queue
+ * reserve, but still eases toward that ceiling so the final chunk cannot flash
+ * in at a suddenly faster cadence.
+ */
+export function getRoleplayTypewriterRevealCharsPerSecond(input: RoleplayTypewriterRevealRateInput): number {
+  if (!Number.isFinite(input.selectedCharsPerSecond)) return input.selectedCharsPerSecond;
+
+  const minimumRate = Math.min(6, input.selectedCharsPerSecond);
+  const queueSmoothedTarget = Math.max(
+    minimumRate,
+    input.pendingCharacters / ROLEPLAY_QUEUE_RESERVE_SECONDS,
+  );
+  const targetRate = input.streamComplete
+    ? input.selectedCharsPerSecond
+    : Math.min(input.selectedCharsPerSecond, queueSmoothedTarget);
+
+  if (input.previousCharsPerSecond === null || !Number.isFinite(input.previousCharsPerSecond)) {
+    return targetRate;
+  }
+
+  const responseTimeMs =
+    targetRate < input.previousCharsPerSecond ? ROLEPLAY_SLOWDOWN_RESPONSE_MS : ROLEPLAY_SPEEDUP_RESPONSE_MS;
+  const blend = 1 - Math.exp(-Math.max(0, input.elapsedMs) / responseTimeMs);
+  return input.previousCharsPerSecond + (targetRate - input.previousCharsPerSecond) * blend;
 }
 
 /**

--- a/scripts/regressions/roleplay-streaming.regression.ts
+++ b/scripts/regressions/roleplay-streaming.regression.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 import {
+  getRoleplayTypewriterRevealCharsPerSecond,
   getTypewriterRevealCharsPerSecond,
   isGenerationSendBlocked,
   isGenerationStartBlocked,
@@ -451,6 +452,63 @@ assert.equal(
   }),
   90,
   "a completed stream should drain at the user's selected speed",
+);
+
+assert.ok(
+  Math.abs(
+    getRoleplayTypewriterRevealCharsPerSecond({
+      selectedCharsPerSecond: 90,
+      pendingCharacters: 45,
+      previousCharsPerSecond: null,
+      elapsedMs: 16,
+      streamComplete: false,
+    }) - 50,
+  ) < 0.001,
+  "Roleplay should turn the first provider burst into a buffered reveal rate",
+);
+const roleplayAcceleratedRate = getRoleplayTypewriterRevealCharsPerSecond({
+  selectedCharsPerSecond: 90,
+  pendingCharacters: 90,
+  previousCharsPerSecond: 20,
+  elapsedMs: 16,
+  streamComplete: false,
+});
+assert.ok(
+  roleplayAcceleratedRate > 20 && roleplayAcceleratedRate < 23,
+  "Roleplay should ease into a faster reveal instead of copying a newly arrived provider burst",
+);
+const roleplayDeceleratedRate = getRoleplayTypewriterRevealCharsPerSecond({
+  selectedCharsPerSecond: 90,
+  pendingCharacters: 5,
+  previousCharsPerSecond: 60,
+  elapsedMs: 16,
+  streamComplete: false,
+});
+assert.ok(
+  roleplayDeceleratedRate > 52 && roleplayDeceleratedRate < 54,
+  "Roleplay should slow promptly as its buffered reserve shrinks",
+);
+const roleplayCompletionRate = getRoleplayTypewriterRevealCharsPerSecond({
+  selectedCharsPerSecond: 90,
+  pendingCharacters: 200,
+  previousCharsPerSecond: 30,
+  elapsedMs: 16,
+  streamComplete: true,
+});
+assert.ok(
+  roleplayCompletionRate > 31 && roleplayCompletionRate < 33,
+  "Roleplay completion should ease toward the selected speed instead of jumping to it",
+);
+assert.equal(
+  getRoleplayTypewriterRevealCharsPerSecond({
+    selectedCharsPerSecond: Infinity,
+    pendingCharacters: 200,
+    previousCharsPerSecond: 30,
+    elapsedMs: 16,
+    streamComplete: false,
+  }),
+  Infinity,
+  "the instant streaming-speed setting should still flush Roleplay immediately",
 );
 
 assert.equal(


### PR DESCRIPTION
## Linked issue

Closes #4181

## Why this change

- Roleplay streaming followed irregular provider token bursts too closely, so the visible typewriter effect paused and arrived in chunks.
- The reveal also jumped back to the selected maximum speed as soon as transport completed, making the final text visibly accelerate.

## What changed

- Added a short Roleplay-only jitter buffer before the first visible character.
- Decoupled Roleplay reveal pacing from provider arrival samples and introduced one queue-aware animation clock.
- Added asymmetric easing so the typewriter slows promptly near an empty reserve and accelerates gently as more text arrives.
- Kept Streaming Speed as the maximum cadence and preserved speed 100 as instant display.
- Added regression coverage for buffering, acceleration, deceleration, completion, and instant mode.

## Validation

- [ ] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed `CONTRIBUTING.md`

### Manual verification notes

- Maintainer tested Roleplay streaming with the configured typewriter speed and confirmed the new cadence works well.
- Automated synthetic pacing proof covered both frequent small chunks and 30-character bursts arriving 750 ms apart; visible output remained governed by the reveal clock.
- `pnpm check` passed locally. The existing unrelated `NoodleHome.tsx` exhaustive-deps warning remains.
- `pnpm regression:roleplay` passed, including the new cadence assertions.
- Focused ESLint passed for the changed client files.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Translated docs on the `docs-i18n` branch updated to match, or a `[docs-i18n]` follow-up issue opened (see CONTRIBUTING.md § Translated documentation)
- [ ] Version/release files updated (only if this PR includes a version bump)

## UI evidence (if applicable)

- Motion-only behavior change; maintainer verification is documented above.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved Roleplay and visual-novel streaming with a brief prebuffer before text begins appearing.
  * Adjusted typewriter reveal speed dynamically to provide smoother pacing as content streams, accelerates, slows, or completes.

* **Bug Fixes**
  * Improved handling of buffered text and state resets when changing turns or flushing generated content.

* **Tests**
  * Added coverage for buffering, speed changes, completion behavior, and immediate text flushing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->