### PR TITLE
Fix assigned generation, composer, preset, and Illustrator issues

### DIFF
--- a/e2e/core-flows.e2e.ts
+++ b/e2e/core-flows.e2e.ts
@@ -9716,7 +9716,7 @@ test("Conversation media searches match GIFs and internal presses keep the picke
     await page.goto("/");
 
     await page.getByRole("button", { name: /Emoji, GIFs/u }).click();
-    const mediaPicker = page.locator("[data-conversation-media-picker]");
+    const mediaPicker = page.locator("[data-conversation-media-picker]:visible");
     await expect(mediaPicker).toBeVisible();
     const emojiSearchInput = page.locator('input[placeholder="Search emojis..."]:visible');
     const emojiSearchStyle = await emojiSearchInput.evaluate((input) => {
@@ -9730,7 +9730,7 @@ test("Conversation media searches match GIFs and internal presses keep the picke
         paddingInline: `${shellStyle.paddingLeft} ${shellStyle.paddingRight}`,
       };
     });
-    await page.getByRole("button", { name: "Kaomoji" }).click();
+    await mediaPicker.getByRole("button", { name: "Kaomoji", exact: true }).click();
     const picker = page.getByRole("dialog", { name: "Kaomoji picker" });
     await expect(picker).toBeVisible();
 
@@ -9756,8 +9756,8 @@ test("Conversation media searches match GIFs and internal presses keep the picke
     await picker.locator("[data-kaomoji-results]").dispatchEvent("pointerdown");
     await expect(mediaPicker).toBeVisible();
 
-    await page.getByRole("button", { name: "GIFs" }).click();
-    const gifSearchInput = page.locator('input[placeholder="Search for GIFs..."]:visible');
+    await mediaPicker.getByRole("button", { name: "GIFs", exact: true }).click();
+    const gifSearchInput = page.getByRole("textbox", { name: "Search for GIFs", exact: true });
     const gifSearchStyle = await gifSearchInput.evaluate((input) => {
       const inputStyle = getComputedStyle(input);
       const shellStyle = getComputedStyle(input.parentElement!);

--- a/e2e/core-flows.e2e.ts
+++ b/e2e/core-flows.e2e.ts
@@ -2987,7 +2987,9 @@ test("external Agent imports require the Danger Zone gate and explicit capabilit
     await page.locator('[data-tour="panel-agents"]').click();
     await expect(page.getByTitle("Import agents")).toHaveAttribute("aria-disabled", "false");
 
-    const packageInput = page.locator('input[type="file"][accept*="application/json"]');
+    const packageInput = page
+      .getByRole("region", { name: "Agents" })
+      .locator('input[type="file"][accept*="application/json"]');
     await packageInput.setInputFiles({
       name: "permission-review-agent.json",
       mimeType: "application/json",
@@ -5216,6 +5218,11 @@ test("downloadable agent catalog is usable on desktop and mobile", async ({ page
   });
   await page.route("**/api/agents", async (route) => {
     await route.fulfill({ status: 200, contentType: "application/json", body: "[]" });
+  });
+  // Keep this catalog-only experiment isolated from the server-wide import-policy
+  // mutation exercised by the dedicated Danger Zone flow in the other project.
+  await page.route("**/api/agents/import-policy", async (route) => {
+    await route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify({ enabled: true }) });
   });
   await page.route("**/api/custom-agent-repositories", async (route) => {
     await route.fulfill({

--- a/e2e/core-flows.e2e.ts
+++ b/e2e/core-flows.e2e.ts
@@ -2900,149 +2900,147 @@ test("Personal Extensions default to the Professor Mari-only locked workflow", a
   expect(warningColors.warning).toBe(warningColors.accent);
 });
 
-test(
-  "external Agent imports require the Danger Zone gate and explicit capabilities",
-  async ({ page, request }, testInfo) => {
-    test.skip(
-      testInfo.project.name !== "mobile-chromium",
-      "This stateful import-policy flow runs once against the shared test server",
-    );
+test("external Agent imports require the Danger Zone gate and explicit capabilities", async ({
+  page,
+  request,
+}, testInfo) => {
+  test.skip(
+    testInfo.project.name !== "mobile-chromium",
+    "This stateful import-policy flow runs once against the shared test server",
+  );
 
-    const disabledPolicy = await request.patch("/api/agents/import-policy", { data: { enabled: false } });
-    expect(disabledPolicy.ok()).toBeTruthy();
+  const disabledPolicy = await request.patch("/api/agents/import-policy", { data: { enabled: false } });
+  expect(disabledPolicy.ok()).toBeTruthy();
 
-    const testSuffix = Date.now().toString(36);
-    const localAgentName = `Locally Authored Agent ${testSuffix}`;
-    const importedAgentName = `Permission Review Agent ${testSuffix}`;
-    let localAgentId: string | undefined;
-    let importedAgentId: string | undefined;
-    try {
-      const localAgentResponse = await request.post("/api/agents", {
-        data: {
-          type: `e2e-local-agent-${testSuffix}`,
-          name: localAgentName,
-          description: "Must remain creatable while external imports are locked.",
-          phase: "parallel",
+  const testSuffix = Date.now().toString(36);
+  const localAgentName = `Locally Authored Agent ${testSuffix}`;
+  const importedAgentName = `Permission Review Agent ${testSuffix}`;
+  let localAgentId: string | undefined;
+  let importedAgentId: string | undefined;
+  try {
+    const localAgentResponse = await request.post("/api/agents", {
+      data: {
+        type: `e2e-local-agent-${testSuffix}`,
+        name: localAgentName,
+        description: "Must remain creatable while external imports are locked.",
+        phase: "parallel",
+        connectionId: null,
+        imagePath: null,
+        promptTemplate: "Return a short note.",
+        settings: { resultType: "context_injection", customCapabilities: {} },
+      },
+    });
+    expect(localAgentResponse.ok()).toBeTruthy();
+    const localAgent = (await localAgentResponse.json()) as { id: string };
+    localAgentId = localAgent.id;
+
+    const blockedImport = await request.post("/api/agents/import", {
+      data: {
+        agent: {
+          type: "untrusted-haptic",
+          name: "Blocked External Agent",
+          description: "",
+          phase: "post_processing",
           connectionId: null,
           imagePath: null,
-          promptTemplate: "Return a short note.",
-          settings: { resultType: "context_injection", customCapabilities: {} },
+          resultType: "haptic_command",
+          promptTemplate: "Return a haptic command.",
+          settings: { customCapabilities: { control_haptics: true } },
         },
-      });
-      expect(localAgentResponse.ok()).toBeTruthy();
-      const localAgent = (await localAgentResponse.json()) as { id: string };
-      localAgentId = localAgent.id;
+        source: "file",
+        approvedCapabilities: ["control_haptics"],
+        acknowledgePermissions: true,
+      },
+    });
+    expect(blockedImport.status()).toBe(403);
 
-      const blockedImport = await request.post("/api/agents/import", {
-        data: {
-          agent: {
-            type: "untrusted-haptic",
-            name: "Blocked External Agent",
-            description: "",
-            phase: "post_processing",
-            connectionId: null,
-            imagePath: null,
-            resultType: "haptic_command",
-            promptTemplate: "Return a haptic command.",
-            settings: { customCapabilities: { control_haptics: true } },
-          },
-          source: "file",
-          approvedCapabilities: ["control_haptics"],
-          acknowledgePermissions: true,
-        },
-      });
-      expect(blockedImport.status()).toBe(403);
+    await page.goto("/");
+    await page.locator('[data-tour="panel-agents"]').click();
+    const disabledHelp = 'Enable "Allow custom Agent imports" in Advanced Settings → Danger Zone first.';
+    const lockedImportButton = page.getByTitle(disabledHelp).first();
+    await expect(lockedImportButton).toHaveAttribute("aria-disabled", "true");
+    await lockedImportButton.dispatchEvent("click");
+    await expect(page.getByText(disabledHelp, { exact: true }).last()).toBeVisible();
 
-      await page.goto("/");
-      await page.locator('[data-tour="panel-agents"]').click();
-      const disabledHelp = 'Enable "Allow custom Agent imports" in Advanced Settings → Danger Zone first.';
-      const lockedImportButton = page.getByTitle(disabledHelp).first();
-      await expect(lockedImportButton).toHaveAttribute("aria-disabled", "true");
-      await lockedImportButton.dispatchEvent("click");
-      await expect(page.getByText(disabledHelp, { exact: true }).last()).toBeVisible();
+    await page.locator('[data-tour="panel-settings"]').click();
+    await page.getByRole("tab", { name: "Advanced" }).click();
+    const agentImportToggle = page.getByLabel("Allow custom Agent imports");
+    const extensionImportToggle = page.getByLabel("Allow third-party extension imports");
+    await expect(agentImportToggle).toBeEnabled();
+    await expect(agentImportToggle).not.toBeChecked();
+    expect(
+      await agentImportToggle.evaluate((toggle) => {
+        const extensionLabel = [...document.querySelectorAll("label")].find(
+          (label) => label.textContent?.trim() === "Allow third-party extension imports",
+        );
+        const extension =
+          extensionLabel instanceof HTMLLabelElement ? document.getElementById(extensionLabel.htmlFor) : null;
+        return Boolean(
+          extension && (toggle.compareDocumentPosition(extension) & Node.DOCUMENT_POSITION_FOLLOWING) !== 0,
+        );
+      }),
+    ).toBe(true);
 
-      await page.locator('[data-tour="panel-settings"]').click();
-      await page.getByRole("tab", { name: "Advanced" }).click();
-      const agentImportToggle = page.getByLabel("Allow custom Agent imports");
-      const extensionImportToggle = page.getByLabel("Allow third-party extension imports");
-      await expect(agentImportToggle).toBeEnabled();
-      await expect(agentImportToggle).not.toBeChecked();
-      expect(
-        await agentImportToggle.evaluate((toggle) => {
-          const extensionLabel = [...document.querySelectorAll("label")].find(
-            (label) => label.textContent?.trim() === "Allow third-party extension imports",
-          );
-          const extension =
-            extensionLabel instanceof HTMLLabelElement
-              ? document.getElementById(extensionLabel.htmlFor)
-              : null;
-          return Boolean(
-            extension && (toggle.compareDocumentPosition(extension) & Node.DOCUMENT_POSITION_FOLLOWING) !== 0,
-          );
+    const enabledPolicy = await request.patch("/api/agents/import-policy", { data: { enabled: true } });
+    expect(enabledPolicy.ok()).toBeTruthy();
+    await page.reload();
+    await page.locator('[data-tour="panel-agents"]').click();
+    await expect(page.getByTitle("Import agents")).toHaveAttribute("aria-disabled", "false");
+
+    const packageInput = page.locator('input[type="file"][accept*="application/json"]');
+    await packageInput.setInputFiles({
+      name: "permission-review-agent.json",
+      mimeType: "application/json",
+      buffer: Buffer.from(
+        JSON.stringify({
+          type: "untrusted-haptic",
+          name: importedAgentName,
+          description: "Requests haptic control.",
+          phase: "post_processing",
+          resultType: "haptic_command",
+          promptTemplate: "Return a haptic command.",
+          settings: { customCapabilities: { control_haptics: true } },
         }),
-      ).toBe(true);
+      ),
+    });
 
-      const enabledPolicy = await request.patch("/api/agents/import-policy", { data: { enabled: true } });
-      expect(enabledPolicy.ok()).toBeTruthy();
-      await page.reload();
-      await page.locator('[data-tour="panel-agents"]').click();
-      await expect(page.getByTitle("Import agents")).toHaveAttribute("aria-disabled", "false");
+    await expect(page.getByRole("dialog", { name: "Review Agent Import Permissions" })).toBeVisible();
+    const hapticPermission = page.getByLabel("Control haptic devices");
+    await expect(hapticPermission).not.toBeChecked();
+    await hapticPermission.check();
+    await expect(hapticPermission).toBeChecked();
+    await page.getByRole("button", { name: "Approve Permissions and Import" }).click();
+    await expect(page.getByRole("dialog", { name: "Review Agent Import Permissions" })).toHaveCount(0);
 
-      const packageInput = page.locator('input[type="file"][accept*="application/json"]');
-      await packageInput.setInputFiles({
-        name: "permission-review-agent.json",
-        mimeType: "application/json",
-        buffer: Buffer.from(
-          JSON.stringify({
-            type: "untrusted-haptic",
-            name: importedAgentName,
-            description: "Requests haptic control.",
-            phase: "post_processing",
-            resultType: "haptic_command",
-            promptTemplate: "Return a haptic command.",
-            settings: { customCapabilities: { control_haptics: true } },
-          }),
-        ),
-      });
-
-      await expect(page.getByRole("dialog", { name: "Review Agent Import Permissions" })).toBeVisible();
-      const hapticPermission = page.getByLabel("Control haptic devices");
-      await expect(hapticPermission).not.toBeChecked();
-      await hapticPermission.check();
-      await expect(hapticPermission).toBeChecked();
-      await page.getByRole("button", { name: "Approve Permissions and Import" }).click();
-      await expect(page.getByRole("dialog", { name: "Review Agent Import Permissions" })).toHaveCount(0);
-
-      const agentsResponse = await request.get("/api/agents");
-      expect(agentsResponse.ok()).toBeTruthy();
-      const agents = (await agentsResponse.json()) as Array<{ id: string; name: string; settings: string }>;
-      const importedAgent = agents.find((agent) => agent.name === importedAgentName);
-      expect(importedAgent).toBeTruthy();
-      importedAgentId = importedAgent?.id;
-      const importedSettings = JSON.parse(importedAgent!.settings) as Record<string, unknown>;
-      expect(importedSettings.customAgentImportSource).toBe("file");
-      expect(importedSettings.customAgentPermissionsExplicit).toBe(true);
-      expect(importedSettings.customCapabilities).toEqual({ control_haptics: true });
-    } finally {
-      try {
-        if (!localAgentId || !importedAgentId) {
-          const cleanupAgentsResponse = await request.get("/api/agents").catch(() => null);
-          if (cleanupAgentsResponse?.ok()) {
-            const cleanupAgents = (await cleanupAgentsResponse.json()) as Array<{ id: string; name: string }>;
-            localAgentId ??= cleanupAgents.find((agent) => agent.name === localAgentName)?.id;
-            importedAgentId ??= cleanupAgents.find((agent) => agent.name === importedAgentName)?.id;
-          }
+    const agentsResponse = await request.get("/api/agents");
+    expect(agentsResponse.ok()).toBeTruthy();
+    const agents = (await agentsResponse.json()) as Array<{ id: string; name: string; settings: string }>;
+    const importedAgent = agents.find((agent) => agent.name === importedAgentName);
+    expect(importedAgent).toBeTruthy();
+    importedAgentId = importedAgent?.id;
+    const importedSettings = JSON.parse(importedAgent!.settings) as Record<string, unknown>;
+    expect(importedSettings.customAgentImportSource).toBe("file");
+    expect(importedSettings.customAgentPermissionsExplicit).toBe(true);
+    expect(importedSettings.customCapabilities).toEqual({ control_haptics: true });
+  } finally {
+    try {
+      if (!localAgentId || !importedAgentId) {
+        const cleanupAgentsResponse = await request.get("/api/agents").catch(() => null);
+        if (cleanupAgentsResponse?.ok()) {
+          const cleanupAgents = (await cleanupAgentsResponse.json()) as Array<{ id: string; name: string }>;
+          localAgentId ??= cleanupAgents.find((agent) => agent.name === localAgentName)?.id;
+          importedAgentId ??= cleanupAgents.find((agent) => agent.name === importedAgentName)?.id;
         }
-        await Promise.all([
-          localAgentId ? request.delete(`/api/agents/${localAgentId}`).catch(() => undefined) : Promise.resolve(),
-          importedAgentId ? request.delete(`/api/agents/${importedAgentId}`).catch(() => undefined) : Promise.resolve(),
-        ]);
-      } finally {
-        await request.patch("/api/agents/import-policy", { data: { enabled: false } });
       }
+      await Promise.all([
+        localAgentId ? request.delete(`/api/agents/${localAgentId}`).catch(() => undefined) : Promise.resolve(),
+        importedAgentId ? request.delete(`/api/agents/${importedAgentId}`).catch(() => undefined) : Promise.resolve(),
+      ]);
+    } finally {
+      await request.patch("/api/agents/import-policy", { data: { enabled: false } });
     }
-  },
-);
+  }
+});
 
 test("Roleplay Active Context shows rich lorebook activation provenance", async ({ page, request }, testInfo) => {
   const lorebookId = "roleplay-active-context-smoke-lorebook";
@@ -9700,7 +9698,7 @@ test("mobile chat composer follows the visual viewport above the software keyboa
   }
 });
 
-test("kaomoji stays in Conversation and uses the configured chat accent", async ({ page }) => {
+test("Conversation media searches match GIFs and internal presses keep the picker open", async ({ page }) => {
   const response = await page.request.post("/api/chats", {
     data: {
       name: "Kaomoji Scrollbar Smoke",
@@ -9717,20 +9715,19 @@ test("kaomoji stays in Conversation and uses the configured chat accent", async 
     }, chat.id);
     await page.goto("/");
 
-    await page.evaluate(() => {
-      document.documentElement.style.setProperty("--marinara-chat-chrome-button-text-active", "rgb(20, 184, 166)");
-      document.documentElement.style.setProperty("--primary", "rgb(236, 72, 153)");
-    });
     await page.getByRole("button", { name: /Emoji, GIFs/u }).click();
+    const mediaPicker = page.locator("[data-conversation-media-picker]");
+    await expect(mediaPicker).toBeVisible();
     const emojiSearchInput = page.locator('input[placeholder="Search emojis..."]:visible');
     const emojiSearchStyle = await emojiSearchInput.evaluate((input) => {
       const style = getComputedStyle(input);
+      const shellStyle = getComputedStyle(input.parentElement!);
       return {
-        backgroundColor: style.backgroundColor,
-        borderRadius: style.borderRadius,
+        backgroundColor: shellStyle.backgroundColor,
+        borderRadius: shellStyle.borderRadius,
         fontSize: style.fontSize,
-        paddingBlock: `${style.paddingTop} ${style.paddingBottom}`,
-        paddingInline: `${style.paddingLeft} ${style.paddingRight}`,
+        paddingBlock: `${shellStyle.paddingTop} ${shellStyle.paddingBottom}`,
+        paddingInline: `${shellStyle.paddingLeft} ${shellStyle.paddingRight}`,
       };
     });
     await page.getByRole("button", { name: "Kaomoji" }).click();
@@ -9744,7 +9741,6 @@ test("kaomoji stays in Conversation and uses the configured chat accent", async 
     expect(categoriesFit).toBe(true);
     expect(resultsFit).toBe(true);
 
-    const searchIcon = picker.locator("svg").first();
     const searchInput = picker.getByPlaceholder("Search kaomoji…");
     const kaomojiSearchStyle = await searchInput.evaluate((input) => {
       const inputStyle = getComputedStyle(input);
@@ -9757,11 +9753,24 @@ test("kaomoji stays in Conversation and uses the configured chat accent", async 
         paddingInline: `${shellStyle.paddingLeft} ${shellStyle.paddingRight}`,
       };
     });
-    expect(kaomojiSearchStyle).toEqual(emojiSearchStyle);
-    await expect(searchIcon).toHaveCSS("color", "rgb(20, 184, 166)");
-    await expect
-      .poll(() => searchInput.evaluate((input) => getComputedStyle(input, "::placeholder").color))
-      .toBe("rgb(20, 184, 166)");
+    await picker.locator("[data-kaomoji-results]").dispatchEvent("pointerdown");
+    await expect(mediaPicker).toBeVisible();
+
+    await page.getByRole("button", { name: "GIFs" }).click();
+    const gifSearchInput = page.locator('input[placeholder="Search for GIFs..."]:visible');
+    const gifSearchStyle = await gifSearchInput.evaluate((input) => {
+      const inputStyle = getComputedStyle(input);
+      const shellStyle = getComputedStyle(input.parentElement!);
+      return {
+        backgroundColor: shellStyle.backgroundColor,
+        borderRadius: shellStyle.borderRadius,
+        fontSize: inputStyle.fontSize,
+        paddingBlock: `${shellStyle.paddingTop} ${shellStyle.paddingBottom}`,
+        paddingInline: `${shellStyle.paddingLeft} ${shellStyle.paddingRight}`,
+      };
+    });
+    expect(emojiSearchStyle).toEqual(gifSearchStyle);
+    expect(kaomojiSearchStyle).toEqual(gifSearchStyle);
   } finally {
     await page.request.delete(`/api/chats/${chat.id}`).catch(() => undefined);
   }

--- a/packages/client/src/components/chat/ChatArea.tsx
+++ b/packages/client/src/components/chat/ChatArea.tsx
@@ -510,6 +510,10 @@ export function ChatArea() {
   const streamingChatId = useChatStore((s) => s.streamingChatId);
   const isStreamingGlobal = useChatStore((s) => s.isStreaming);
   const isStreaming = isStreamingGlobal && streamingChatId === activeChatId;
+  const isBackgroundIllustration = useChatStore((s) =>
+    activeChatId ? s.backgroundIllustrationChatIds.has(activeChatId) : false,
+  );
+  const isTextStreaming = isStreaming && !isBackgroundIllustration;
   const isPageActive = usePageActivity();
   const regenerateMessageId = useChatStore((s) => s.regenerateMessageId);
   const chatBackground = useUIStore((s) => s.chatBackground);
@@ -2290,7 +2294,7 @@ export function ChatArea() {
       if (event.repeat || event.altKey || event.ctrlKey || event.metaKey || event.shiftKey) return;
       if (!latestMessageForEdit) return;
       // Don't try to edit a message that's currently streaming/regenerating.
-      if (isStreaming || agentProcessing) return;
+      if (isTextStreaming || (agentProcessing && !isBackgroundIllustration)) return;
 
       const target = event.target;
       if (target instanceof Element) {
@@ -2322,9 +2326,10 @@ export function ChatArea() {
     agentProcessing,
     chatMode,
     editLastMessageOnArrowUp,
+    isBackgroundIllustration,
     intuitiveSwipeBlocked,
     isRoleplay,
-    isStreaming,
+    isTextStreaming,
     latestMessageForEdit,
   ]);
 
@@ -3311,7 +3316,8 @@ export function ChatArea() {
           isLoading={isLoading}
           hasNextPage={!!hasNextPage}
           isFetchingNextPage={isFetchingNextPage}
-          isStreaming={isStreaming}
+          isStreaming={isTextStreaming}
+          generationVisualsPaused={isStreaming || agentProcessing}
           agentProcessing={agentProcessing}
           regenerateMessageId={regenerateMessageId}
           shouldAnimateMessages={shouldAnimateMessages}

--- a/packages/client/src/components/chat/ChatInput.tsx
+++ b/packages/client/src/components/chat/ChatInput.tsx
@@ -93,6 +93,8 @@ const TEXT_ATTACHMENT_EXTENSIONS = new Set([
 ]);
 const PDF_ATTACHMENT_MIME_TYPE = "application/pdf";
 const QUOTE_INPUT_TRIGGER_RE = /["'\u2018\u2019\u201a\u201b\u201c\u201d\u201e\u201f]/;
+const ROLEPLAY_INPUT_RESIZE_IDLE_MS = 150;
+const ROLEPLAY_INPUT_DELETE_RESIZE_IDLE_MS = 450;
 
 function shouldFormatQuoteInput(event: FormEvent<HTMLTextAreaElement> | undefined, value: string): boolean {
   const inputEvent = event?.nativeEvent as InputEvent | undefined;
@@ -1484,6 +1486,8 @@ export const ChatInput = memo(function ChatInput({
   const handleInput = (event?: FormEvent<HTMLTextAreaElement>) => {
     const el = textareaRef.current;
     if (!el) return;
+    const inputEvent = event?.nativeEvent as InputEvent | undefined;
+    const isDeleting = inputEvent?.inputType?.startsWith("delete") === true;
     const fixed = shouldFormatQuoteInput(event, el.value) ? applyTextareaQuoteFormat(el, quoteFormat) : el.value;
     syncInputState(fixed);
 
@@ -1508,7 +1512,7 @@ export const ChatInput = memo(function ChatInput({
       resizeTimerRef.current = null;
       if (textareaRef.current !== el) return;
       resizeChatInputTextarea(el);
-    }, 150);
+    }, isDeleting ? ROLEPLAY_INPUT_DELETE_RESIZE_IDLE_MS : ROLEPLAY_INPUT_RESIZE_IDLE_MS);
 
     // Slash command autocomplete
     const trimmed = fixed.trim();

--- a/packages/client/src/components/chat/ChatRoleplaySurface.tsx
+++ b/packages/client/src/components/chat/ChatRoleplaySurface.tsx
@@ -177,12 +177,12 @@ function useIsMobileToolbarViewport() {
   return isMobileViewport;
 }
 
-function WeatherEffectsConnected() {
+function WeatherEffectsConnected({ paused }: { paused: boolean }) {
   const weather = useGameStateStore((s) => s.current?.weather ?? null);
   const timeOfDay = useGameStateStore((s) => s.current?.time ?? null);
   return (
     <Suspense fallback={null}>
-      <WeatherEffects weather={weather} timeOfDay={timeOfDay} />
+      <WeatherEffects weather={weather} timeOfDay={timeOfDay} paused={paused} />
     </Suspense>
   );
 }
@@ -1066,6 +1066,7 @@ type RoleplaySurfaceProps = {
   hasNextPage: boolean;
   isFetchingNextPage: boolean;
   isStreaming: boolean;
+  generationVisualsPaused: boolean;
   agentProcessing: boolean;
   regenerateMessageId: string | null;
   shouldAnimateMessages: boolean;
@@ -1183,6 +1184,7 @@ export function ChatRoleplaySurface({
   hasNextPage,
   isFetchingNextPage,
   isStreaming,
+  generationVisualsPaused,
   agentProcessing,
   regenerateMessageId,
   shouldAnimateMessages,
@@ -1508,6 +1510,7 @@ export function ChatRoleplaySurface({
         className={cn(
           "rpg-chat-area mari-chat-area mari-card-css relative flex flex-1 flex-col overflow-hidden",
           roleplayReducedPaintEffects && "mari-rp-reduced-paint",
+          generationVisualsPaused && "mari-generation-render-paused",
         )}
         data-chat-mode="roleplay"
         style={{ isolation: "isolate" }}
@@ -1515,7 +1518,7 @@ export function ChatRoleplaySurface({
         <CrossfadeBackground url={chatBackground} blurPx={chatBackgroundBlur} />
         <div className="rpg-overlay absolute inset-0" />
         <div className="rpg-vignette pointer-events-none absolute inset-0" />
-        {weatherEffects && <WeatherEffectsConnected />}
+        {weatherEffects && <WeatherEffectsConnected paused={generationVisualsPaused} />}
         {showSpriteOverlay && (
           <Suspense fallback={null}>
             <SpriteOverlay

--- a/packages/client/src/components/chat/ConversationMediaPickerPanel.tsx
+++ b/packages/client/src/components/chat/ConversationMediaPickerPanel.tsx
@@ -36,6 +36,13 @@ export function ConversationMediaPickerPanel({
   const { t } = useTranslation();
   return (
     <div
+      data-conversation-media-picker
+      onPointerDown={(event) => {
+        // This panel lives inside the composer shell. Empty-space and native
+        // scrollbar presses must not bubble to the shell's focus handler,
+        // which focuses the textarea and closes the picker.
+        event.stopPropagation();
+      }}
       className={cn(
         "flex h-[22rem] max-h-[60vh] flex-col overflow-hidden rounded-xl border border-foreground/10 bg-[var(--card)] shadow-xl",
         className,
@@ -69,9 +76,7 @@ export function ConversationMediaPickerPanel({
               icon: "⭐",
               label: t("ui.noodle.media.customEmojis"),
               render: (query) => <CustomEmojiTab onInsert={onEmojiSelect} query={query} />,
-              renderSearch: (query) => (
-                <CustomEmojiTab onInsert={onEmojiSelect} query={query} searchResultsOnly />
-              ),
+              renderSearch: (query) => <CustomEmojiTab onInsert={onEmojiSelect} query={query} searchResultsOnly />,
             }}
           />
         )}

--- a/packages/client/src/components/chat/WeatherEffects.tsx
+++ b/packages/client/src/components/chat/WeatherEffects.tsx
@@ -25,6 +25,8 @@ interface WeatherEffectsProps {
   weather?: string | null;
   timeOfDay?: string | null;
   showCelestial?: boolean;
+  /** Freeze ambient rendering while local text generation needs the GPU. */
+  paused?: boolean;
 }
 
 
@@ -32,11 +34,20 @@ interface WeatherEffectsProps {
 // Main component
 // ═══════════════════════════════════════════════
 
-export function WeatherEffects({ weather, timeOfDay, showCelestial = true }: WeatherEffectsProps) {
+export function WeatherEffects({ weather, timeOfDay, showCelestial = true, paused = false }: WeatherEffectsProps) {
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const particlesRef = useRef<WeatherParticle[]>([]);
   const frameRef = useRef<number>(0);
+  const workerRef = useRef<Worker | null>(null);
+  const pausedRef = useRef(paused);
+  const resumeFallbackRef = useRef<(() => void) | null>(null);
   const [workerFailed, setWorkerFailed] = useState(false);
+  pausedRef.current = paused;
+
+  useEffect(() => {
+    workerRef.current?.postMessage({ type: "visibility", hidden: document.hidden || paused });
+    resumeFallbackRef.current?.();
+  }, [paused]);
 
   const config = useMemo(() => {
     return resolveWeatherRenderConfig(weather, timeOfDay);
@@ -67,6 +78,7 @@ export function WeatherEffects({ weather, timeOfDay, showCelestial = true }: Wea
         if (!rect || rect.width <= 0 || rect.height <= 0) return;
 
         worker = new Worker(new URL("../../workers/weather-effects.worker.ts", import.meta.url), { type: "module" });
+        workerRef.current = worker;
         const failWorker = () => setWorkerFailed(true);
         worker.onerror = failWorker;
         worker.onmessage = (event: MessageEvent<{ type?: string }>) => {
@@ -112,7 +124,8 @@ export function WeatherEffects({ weather, timeOfDay, showCelestial = true }: Wea
           });
           if (canvas.parentElement) resizeObserver.observe(canvas.parentElement);
 
-          visibilityHandler = () => worker?.postMessage({ type: "visibility", hidden: document.hidden });
+          visibilityHandler = () =>
+            worker?.postMessage({ type: "visibility", hidden: document.hidden || pausedRef.current });
           document.addEventListener("visibilitychange", visibilityHandler);
           visibilityHandler();
         };
@@ -124,6 +137,7 @@ export function WeatherEffects({ weather, timeOfDay, showCelestial = true }: Wea
         if (readinessTimer !== null) window.clearTimeout(readinessTimer);
         resizeObserver?.disconnect();
         if (visibilityHandler) document.removeEventListener("visibilitychange", visibilityHandler);
+        if (workerRef.current === worker) workerRef.current = null;
         worker?.terminate();
       };
     }
@@ -170,14 +184,12 @@ export function WeatherEffects({ weather, timeOfDay, showCelestial = true }: Wea
       }
     }
 
-    let paused = document.hidden;
-
     const tick = (timestamp: number) => {
       if (!running) return;
-      if (paused) {
+      if (document.hidden || pausedRef.current) {
         previousFrameTime = timestamp;
         accumulatedFrameTime = 0;
-        frameRef.current = requestAnimationFrame(tick);
+        frameRef.current = 0;
         return;
       }
 
@@ -276,16 +288,20 @@ export function WeatherEffects({ weather, timeOfDay, showCelestial = true }: Wea
       frameRef.current = requestAnimationFrame(tick);
     };
 
-    const onVisibilityChange = () => {
-      paused = document.hidden;
+    const ensureFallbackRunning = () => {
+      if (!running || document.hidden || pausedRef.current || frameRef.current !== 0) return;
+      frameRef.current = requestAnimationFrame(tick);
     };
+    resumeFallbackRef.current = ensureFallbackRunning;
+    const onVisibilityChange = ensureFallbackRunning;
     document.addEventListener("visibilitychange", onVisibilityChange);
 
-    frameRef.current = requestAnimationFrame(tick);
+    ensureFallbackRunning();
 
     return () => {
       running = false;
-      cancelAnimationFrame(frameRef.current);
+      if (frameRef.current !== 0) cancelAnimationFrame(frameRef.current);
+      if (resumeFallbackRef.current === ensureFallbackRunning) resumeFallbackRef.current = null;
       window.removeEventListener("resize", resize);
       document.removeEventListener("visibilitychange", onVisibilityChange);
     };

--- a/packages/client/src/components/game/GameSurface.tsx
+++ b/packages/client/src/components/game/GameSurface.tsx
@@ -10736,7 +10736,13 @@ function GameSurfaceComponent({
   };
 
   return (
-    <div className="relative flex h-full overflow-hidden bg-black mari-card-css" data-chat-mode="game">
+    <div
+      className={cn(
+        "relative flex h-full overflow-hidden bg-black mari-card-css",
+        (isStreaming || scenePreparing || sceneAnalysis.isPending) && "mari-generation-render-paused",
+      )}
+      data-chat-mode="game"
+    >
       <GameTransitionManager gameState={gameState} location={gameSnapshot?.location ?? null}>
         <DirectionEngine
           directions={activeDirections}
@@ -11378,6 +11384,7 @@ function GameSurfaceComponent({
                         weather={gameSnapshot?.weather ?? null}
                         timeOfDay={gameSnapshot?.time ?? metaTime ?? null}
                         showCelestial={false}
+                        paused={isStreaming || scenePreparing || sceneAnalysis.isPending}
                       />
                     </div>
                   )}

--- a/packages/client/src/components/game/GameSurface.tsx
+++ b/packages/client/src/components/game/GameSurface.tsx
@@ -10739,7 +10739,8 @@ function GameSurfaceComponent({
     <div
       className={cn(
         "relative flex h-full overflow-hidden bg-black mari-card-css",
-        (isStreaming || scenePreparing || sceneAnalysis.isPending) && "mari-generation-render-paused",
+        (isStreaming || scenePreparing || sceneAnalysis.isPending || agentsProcessing) &&
+          "mari-generation-render-paused",
       )}
       data-chat-mode="game"
     >
@@ -11384,7 +11385,7 @@ function GameSurfaceComponent({
                         weather={gameSnapshot?.weather ?? null}
                         timeOfDay={gameSnapshot?.time ?? metaTime ?? null}
                         showCelestial={false}
-                        paused={isStreaming || scenePreparing || sceneAnalysis.isPending}
+                        paused={isStreaming || scenePreparing || sceneAnalysis.isPending || agentsProcessing}
                       />
                     </div>
                   )}

--- a/packages/client/src/components/ui/EmojiPicker.tsx
+++ b/packages/client/src/components/ui/EmojiPicker.tsx
@@ -1322,7 +1322,7 @@ export function EmojiPicker({
           data-emoji-search-shell
           className="flex items-center gap-2 rounded-md bg-foreground/5 px-2.5 py-1.5 ring-1 ring-foreground/10 transition-shadow focus-within:ring-foreground/20"
         >
-          <Search size="0.875rem" className="shrink-0 text-foreground/45" />
+          <Search aria-hidden="true" size="0.875rem" className="shrink-0 text-foreground/45" />
           <input
             type="text"
             value={search}

--- a/packages/client/src/components/ui/EmojiPicker.tsx
+++ b/packages/client/src/components/ui/EmojiPicker.tsx
@@ -6,6 +6,7 @@ import { createPortal } from "react-dom";
 import { cn } from "../../lib/utils";
 import { EMOJI_CATEGORIES, EMOJI_SEARCH_NAMES } from "../../lib/emoji-catalog.generated";
 import { useTranslation as useUiTranslation } from "react-i18next";
+import { Search } from "lucide-react";
 
 /** Emoji → searchable keywords (lowercase). Only needs entries for emojis in CATEGORIES. */
 const EMOJI_ALIASES: Record<string, string> = {
@@ -1317,15 +1318,21 @@ export function EmojiPicker({
     <>
       {/* Search spans every standard category and custom emojis, regardless of the selected tab. */}
       <div className="border-b border-foreground/10 px-3 py-2">
-        <input
-          type="text"
-          value={search}
-          onChange={(e) => setSearch(e.target.value)}
-          placeholder={localizeUi("ui.ui.emojipicker.searchEmojis")}
-          aria-label={localizeUi("ui.ui.emojipicker.searchEmojis_ecbfa28")}
-          className="w-full rounded-md bg-foreground/5 px-2.5 py-1.5 text-xs outline-none ring-1 ring-foreground/10 transition-shadow placeholder:text-foreground/35 focus:ring-foreground/20"
-          autoFocus={!embedded}
-        />
+        <div
+          data-emoji-search-shell
+          className="flex items-center gap-2 rounded-md bg-foreground/5 px-2.5 py-1.5 ring-1 ring-foreground/10 transition-shadow focus-within:ring-foreground/20"
+        >
+          <Search size="0.875rem" className="shrink-0 text-foreground/45" />
+          <input
+            type="text"
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            placeholder={localizeUi("ui.ui.emojipicker.searchEmojis")}
+            aria-label={localizeUi("ui.ui.emojipicker.searchEmojis_ecbfa28")}
+            className="min-w-0 flex-1 bg-transparent text-xs outline-none placeholder:text-foreground/35"
+            autoFocus={!embedded}
+          />
+        </div>
       </div>
 
       {/* Category tabs */}
@@ -1369,34 +1376,34 @@ export function EmojiPicker({
 
       {/* Emoji grid (or the custom-emoji tab content) */}
       <div className="flex-1 overflow-y-auto px-2 py-2">
-        {!searching && activeCategory === "custom" && customTab
-          ? customTab.render(search)
-          : (
-              <>
-                {visibleStandardCategories.map((cat) => (
-                  <div key={cat.label}>
-                    <p className="mb-1 px-1 text-[0.625rem] font-semibold uppercase tracking-wide text-foreground/45">
-                      {cat.label}
-                    </p>
-                    <div className="grid grid-cols-8 gap-0.5">
-                      {cat.emojis.map((emoji) => (
-                        <button
-                          key={emoji}
-                          type="button"
-                          onClick={() => handleSelect(emoji)}
-                          aria-label={EMOJI_SEARCH_NAMES[emoji] ?? EMOJI_ALIASES[emoji] ?? emoji}
-                          title={EMOJI_SEARCH_NAMES[emoji] ?? EMOJI_ALIASES[emoji] ?? emoji}
-                          className="rounded-md p-1 text-xl transition-transform hover:scale-125 hover:bg-foreground/10 active:scale-100"
-                        >
-                          {emoji}
-                        </button>
-                      ))}
-                    </div>
-                  </div>
-                ))}
-                {searching && customTab && (customTab.renderSearch?.(search) ?? customTab.render(search))}
-              </>
-            )}
+        {!searching && activeCategory === "custom" && customTab ? (
+          customTab.render(search)
+        ) : (
+          <>
+            {visibleStandardCategories.map((cat) => (
+              <div key={cat.label}>
+                <p className="mb-1 px-1 text-[0.625rem] font-semibold uppercase tracking-wide text-foreground/45">
+                  {cat.label}
+                </p>
+                <div className="grid grid-cols-8 gap-0.5">
+                  {cat.emojis.map((emoji) => (
+                    <button
+                      key={emoji}
+                      type="button"
+                      onClick={() => handleSelect(emoji)}
+                      aria-label={EMOJI_SEARCH_NAMES[emoji] ?? EMOJI_ALIASES[emoji] ?? emoji}
+                      title={EMOJI_SEARCH_NAMES[emoji] ?? EMOJI_ALIASES[emoji] ?? emoji}
+                      className="rounded-md p-1 text-xl transition-transform hover:scale-125 hover:bg-foreground/10 active:scale-100"
+                    >
+                      {emoji}
+                    </button>
+                  ))}
+                </div>
+              </div>
+            ))}
+            {searching && customTab && (customTab.renderSearch?.(search) ?? customTab.render(search))}
+          </>
+        )}
       </div>
     </>
   );

--- a/packages/client/src/components/ui/KaomojiPicker.tsx
+++ b/packages/client/src/components/ui/KaomojiPicker.tsx
@@ -131,13 +131,14 @@ export function KaomojiPicker({ open, onClose, onSelect, anchorRef, containerRef
           data-kaomoji-search-shell
           className="flex items-center gap-2 rounded-md bg-foreground/5 px-2.5 py-1.5 ring-1 ring-foreground/10 transition-shadow focus-within:ring-foreground/20"
         >
-          <Search size="0.875rem" className="shrink-0 text-foreground/45" />
+          <Search aria-hidden="true" size="0.875rem" className="shrink-0 text-foreground/45" />
           <input
             ref={searchInputRef}
             type="text"
             value={search}
             onChange={(e) => setSearch(e.target.value)}
             placeholder={t("chat.kaomoji.search")}
+            aria-label={t("chat.kaomoji.search")}
             className="min-w-0 flex-1 bg-transparent text-xs outline-none placeholder:text-foreground/35"
           />
         </div>

--- a/packages/client/src/components/ui/KaomojiPicker.tsx
+++ b/packages/client/src/components/ui/KaomojiPicker.tsx
@@ -127,15 +127,18 @@ export function KaomojiPicker({ open, onClose, onSelect, anchorRef, containerRef
   const body = (
     <>
       <div className="border-b border-foreground/10 px-3 py-2">
-        <div className="flex items-center gap-2 rounded-md bg-foreground/5 px-2.5 py-1.5 ring-1 ring-foreground/10 transition-shadow focus-within:ring-foreground/20">
-          <Search size="0.875rem" className="shrink-0 text-[var(--marinara-chat-chrome-button-text-active)]" />
+        <div
+          data-kaomoji-search-shell
+          className="flex items-center gap-2 rounded-md bg-foreground/5 px-2.5 py-1.5 ring-1 ring-foreground/10 transition-shadow focus-within:ring-foreground/20"
+        >
+          <Search size="0.875rem" className="shrink-0 text-foreground/45" />
           <input
             ref={searchInputRef}
             type="text"
             value={search}
             onChange={(e) => setSearch(e.target.value)}
             placeholder={t("chat.kaomoji.search")}
-            className="min-w-0 flex-1 bg-transparent text-xs outline-none placeholder:text-[var(--marinara-chat-chrome-button-text-active)]"
+            className="min-w-0 flex-1 bg-transparent text-xs outline-none placeholder:text-foreground/35"
           />
         </div>
       </div>

--- a/packages/client/src/hooks/use-generate.ts
+++ b/packages/client/src/hooks/use-generate.ts
@@ -3155,6 +3155,8 @@ export function useGenerate() {
       }
       useChatStore.getState().setAbortController(chatId, abortController);
       useChatStore.getState().setBackgroundIllustration(chatId, false);
+      const isIllustratorOnlyRetry =
+        agentTypes.length > 0 && agentTypes.every((agentType) => agentType === "illustrator");
       const isTrackerRetry = agentTypes.some(
         (agentType) => isBuiltInTrackerAgentType(agentType) || !isBuiltInAgentType(agentType),
       );
@@ -3446,7 +3448,9 @@ export function useGenerate() {
               break;
             }
             case "illustration_queued": {
-              useChatStore.getState().setBackgroundIllustration(chatId, true);
+              if (isIllustratorOnlyRetry) {
+                useChatStore.getState().setBackgroundIllustration(chatId, true);
+              }
               break;
             }
             case "image_prompt_review": {

--- a/packages/client/src/hooks/use-generate.ts
+++ b/packages/client/src/hooks/use-generate.ts
@@ -3155,7 +3155,6 @@ export function useGenerate() {
       }
       useChatStore.getState().setAbortController(chatId, abortController);
       useChatStore.getState().setBackgroundIllustration(chatId, false);
-      const isIllustratorOnlyRetry = agentTypes.length === 1 && agentTypes[0] === "illustrator";
       const isTrackerRetry = agentTypes.some(
         (agentType) => isBuiltInTrackerAgentType(agentType) || !isBuiltInAgentType(agentType),
       );
@@ -3447,9 +3446,7 @@ export function useGenerate() {
               break;
             }
             case "illustration_queued": {
-              if (isIllustratorOnlyRetry) {
-                useChatStore.getState().setBackgroundIllustration(chatId, true);
-              }
+              useChatStore.getState().setBackgroundIllustration(chatId, true);
               break;
             }
             case "image_prompt_review": {

--- a/packages/client/src/styles/globals.css
+++ b/packages/client/src/styles/globals.css
@@ -3296,6 +3296,8 @@ strong {
     background:
       linear-gradient(var(--card), var(--card)),
       var(--background) !important;
+    contain: layout paint;
+    isolation: isolate;
   }
 
   .mari-sidebar,
@@ -5079,6 +5081,24 @@ strong {
    ───────────────────────────────────────────── */
 [data-chat-mode="roleplay"] .mari-chat-input-textarea {
   contain: paint;
+}
+
+/* Local models often share the same GPU as the active browser tab. Freeze
+   ambient effects during generation while keeping progress spinners live. */
+.mari-generation-render-paused
+  :where(
+    .roleplay-hud-scroll-track,
+    [class*="game-expression-reaction"],
+    .glimmer-streaming,
+    .game-map-fog,
+    .game-map-marquee-track,
+    .game-party-marker,
+    .game-campfire,
+    .game-combat-border,
+    [class*="anim-text-"]
+  ),
+.mari-generation-render-paused .rpg-streaming::after {
+  animation-play-state: paused !important;
 }
 
 .rpg-sprite-container img,

--- a/packages/client/src/workers/weather-effects.worker.ts
+++ b/packages/client/src/workers/weather-effects.worker.ts
@@ -152,7 +152,10 @@ function drawFrame(now: number, advanceSimulation = true) {
 }
 
 function scheduleFrame() {
+  if (hidden || timer !== null) return;
   timer = setTimeout(() => {
+    timer = null;
+    if (hidden) return;
     try {
       drawFrame(performance.now());
       scheduleFrame();
@@ -161,6 +164,17 @@ function scheduleFrame() {
       self.postMessage({ type: "render-error" });
     }
   }, FRAME_MS);
+}
+
+function setSuspended(suspended: boolean) {
+  hidden = suspended;
+  previousTime = performance.now();
+  if (hidden) {
+    if (timer !== null) clearTimeout(timer);
+    timer = null;
+    return;
+  }
+  scheduleFrame();
 }
 
 self.onmessage = (event: MessageEvent<WeatherWorkerMessage>) => {
@@ -181,8 +195,7 @@ self.onmessage = (event: MessageEvent<WeatherWorkerMessage>) => {
     // browser never presents a blank weather layer between sidebar layouts.
     drawFrame(performance.now(), false);
   } else {
-    hidden = message.hidden;
-    previousTime = performance.now();
+    setSuspended(message.hidden);
   }
 };
 

--- a/packages/server/src/services/prompt/assembler.ts
+++ b/packages/server/src/services/prompt/assembler.ts
@@ -34,7 +34,7 @@ interface RuntimeAgentData {
   endToken?: string;
 }
 
-interface ChoiceOptionValue {
+export interface ChoiceOptionValue {
   value: string;
 }
 
@@ -66,6 +66,43 @@ function sanitizeChoiceSelection(
   }
 
   return candidates.find((value) => validValues.has(value));
+}
+
+function readChoiceFlag(value: unknown): boolean {
+  return value === true || value === "true" || value === 1 || value === "1";
+}
+
+export function resolveChoiceVariableValue(input: {
+  selected: string | string[] | undefined;
+  options: ChoiceOptionValue[];
+  multiSelect: unknown;
+  randomPick: unknown;
+  separator?: string | null;
+  random?: () => number;
+}): string {
+  const isRandom = readChoiceFlag(input.randomPick);
+  // Imported or legacy presets can carry Boolean/number flags, and a Random
+  // Pick selection is necessarily multi-valued even if its companion flag was
+  // normalized incorrectly during an older migration.
+  const isMulti = readChoiceFlag(input.multiSelect) || (isRandom && Array.isArray(input.selected));
+  const selected = sanitizeChoiceSelection(input.selected, input.options, isMulti);
+
+  if (isMulti && Array.isArray(selected)) {
+    if (selected.length === 0) return input.options[0]?.value ?? "";
+    if (isRandom) {
+      const random = input.random ?? Math.random;
+      const roll = random();
+      const unit = Number.isFinite(roll) ? Math.min(1, Math.max(0, roll)) : 0;
+      const index = Math.min(selected.length - 1, Math.floor(unit * selected.length));
+      return selected[index] ?? "";
+    }
+    return selected.join(input.separator || ", ");
+  }
+
+  if (selected !== undefined) {
+    return Array.isArray(selected) ? (selected[0] ?? "") : selected;
+  }
+  return input.options[0]?.value ?? "";
 }
 
 // ═══════════════════════════════════════════════
@@ -291,33 +328,14 @@ export async function assemblePrompt(input: AssemblerInput): Promise<AssemblerOu
   // Inject choice variable values into variableValues
   // chatChoices is { variableName: value | value[] } — resolve and merge into variables so {{varName}} resolves
   for (const cb of input.choiceBlocks) {
-    const isMulti = cb.multiSelect === "true";
-    const isRandom = cb.randomPick === "true";
-    const separator = cb.separator || ", ";
     const opts = parseChoiceOptions(cb.options);
-    const selected = sanitizeChoiceSelection(input.chatChoices[cb.variableName], opts, isMulti);
-
-    if (selected !== undefined) {
-      if (isMulti && Array.isArray(selected)) {
-        // Multi-select: either random-pick one or join all
-        if (selected.length === 0) {
-          // Fallback to first option
-          if (opts.length > 0 && opts[0]) variableValues[cb.variableName] = opts[0].value;
-        } else if (isRandom) {
-          // Random pick: select one at random each generation
-          variableValues[cb.variableName] = selected[Math.floor(Math.random() * selected.length)] ?? "";
-        } else {
-          // Join all selected values with the separator
-          variableValues[cb.variableName] = selected.join(separator);
-        }
-      } else {
-        // Single-select or legacy string value
-        variableValues[cb.variableName] = Array.isArray(selected) ? (selected[0] ?? "") : selected;
-      }
-    } else {
-      // Default to first option's value if no selection yet
-      if (opts.length > 0 && opts[0]) variableValues[cb.variableName] = opts[0].value;
-    }
+    variableValues[cb.variableName] = resolveChoiceVariableValue({
+      selected: input.chatChoices[cb.variableName],
+      options: opts,
+      multiSelect: cb.multiSelect,
+      randomPick: cb.randomPick,
+      separator: cb.separator,
+    });
   }
   // Build macro context (character names and primary card fields resolved from IDs)
   const macroCtx = await buildPromptMacroContext({

--- a/packages/server/src/services/prompt/index.ts
+++ b/packages/server/src/services/prompt/index.ts
@@ -1,7 +1,13 @@
 // ──────────────────────────────────────────────
 // Prompt Service — Public exports
 // ──────────────────────────────────────────────
-export { assemblePrompt, type AssemblerInput, type AssemblerOutput } from "./assembler.js";
+export {
+  assemblePrompt,
+  resolveChoiceVariableValue,
+  type AssemblerInput,
+  type AssemblerOutput,
+  type ChoiceOptionValue,
+} from "./assembler.js";
 export { wrapContent, wrapGroup } from "./format-engine.js";
 export { expandMarker, type MarkerContext, type ExpandedMarker } from "./marker-expander.js";
 export {

--- a/scripts/regressions/open-issues.regression.ts
+++ b/scripts/regressions/open-issues.regression.ts
@@ -791,10 +791,7 @@ assert.deepEqual(generatedLorebookEntry.secondaryKeys, ["rain"]);
       content: markdownContent,
     },
   ]);
-  assert.match(
-    approvalText,
-    /^<!-- marinara:lorebook-entry:v1 -->\r?\n### Bob\r?\nKeys: Bob\r?\nTag: people/u,
-  );
+  assert.match(approvalText, /^<!-- marinara:lorebook-entry:v1 -->\r?\n### Bob\r?\nKeys: Bob\r?\nTag: people/u);
   assert.deepEqual(parseLorebookWriteApprovalText(approvalText), [
     {
       action: "append",
@@ -1561,6 +1558,14 @@ const kaomojiPickerSource = readFileSync(
   new URL("../../packages/client/src/components/ui/KaomojiPicker.tsx", import.meta.url),
   "utf8",
 );
+const emojiPickerSource = readFileSync(
+  new URL("../../packages/client/src/components/ui/EmojiPicker.tsx", import.meta.url),
+  "utf8",
+);
+const conversationMediaPickerSource = readFileSync(
+  new URL("../../packages/client/src/components/chat/ConversationMediaPickerPanel.tsx", import.meta.url),
+  "utf8",
+);
 const visualViewportChatBottomSource = readFileSync(
   new URL("../../packages/client/src/hooks/use-visual-viewport-chat-bottom.ts", import.meta.url),
   "utf8",
@@ -1706,11 +1711,22 @@ assert.match(
 );
 assert.match(generationParametersEditorSource, /placeholder:\[text-indent:0\]/u);
 assert.match(
-  kaomojiPickerSource,
-  /e\.composedPath\(\)[\s\S]{0,500}pointInsidePanel[\s\S]{0,250}path\.includes\(panel\)/u,
-  "Kaomoji native-scrollbar presses must remain inside the open picker",
+  conversationMediaPickerSource,
+  /data-conversation-media-picker[\s\S]{0,250}onPointerDown=\{\(event\) => \{[\s\S]{0,250}event\.stopPropagation\(\)/u,
+  "Conversation media-picker content and native-scrollbar presses must not focus the composer and close the picker",
 );
-assert.match(kaomojiPickerSource, /--marinara-chat-chrome-button-text-active/u);
+for (const [name, source] of [
+  ["Emoji", emojiPickerSource],
+  ["Kaomoji", kaomojiPickerSource],
+] as const) {
+  assert.match(
+    source,
+    /flex items-center gap-2 rounded-md bg-foreground\/5 px-2\.5 py-1\.5 ring-1 ring-foreground\/10 transition-shadow focus-within:ring-foreground\/20/u,
+    `${name} search must use the same shell treatment as GIF search`,
+  );
+  assert.match(source, /text-foreground\/45/u, `${name} search icon must match GIF search`);
+  assert.match(source, /placeholder:text-foreground\/35/u, `${name} search placeholder must match GIF search`);
+}
 assert.match(visualViewportChatBottomSource, /detail\?\.keyboardOpen[\s\S]{0,500}scrollToBottom\("auto"\)/u);
 assert.match(characterEditorSource, /if \(uploading \|\| !expression\) return;/u);
 assert.match(personaEditorSource, /if \(uploading \|\| !expression\) return;/u);
@@ -3450,10 +3466,7 @@ try {
     "Memory Recall must expose its switch state to assistive technology",
   );
 
-  const generateHookSource = readFileSync(
-    join(REPOSITORY_ROOT, "packages/client/src/hooks/use-generate.ts"),
-    "utf8",
-  );
+  const generateHookSource = readFileSync(join(REPOSITORY_ROOT, "packages/client/src/hooks/use-generate.ts"), "utf8");
   const clearStreamIndex = generateHookSource.indexOf("clearStreamBuffer(params.chatId);");
   const exposeStreamingIndex = generateHookSource.indexOf("setStreaming(true, params.chatId);", clearStreamIndex);
   assert.ok(

--- a/scripts/regressions/prompt.regression.ts
+++ b/scripts/regressions/prompt.regression.ts
@@ -599,6 +599,7 @@ import { parseAssistantWorkspaceAction } from "../../packages/server/src/service
 import { fitMessagesForModelAccess } from "../../packages/server/src/services/generation/model-access-policy.js";
 import {
   assemblePrompt,
+  resolveChoiceVariableValue,
   resolvePromptMessageMacros,
   scopePromptMacroContextToCharacter,
   type AssemblerInput,
@@ -6823,6 +6824,41 @@ Use HTML sparingly and diegetically. Do not replace normal prose/dialogue unless
       assert.match(promptText, /UNCAPPED_TAIL_MESSAGE_0/u);
       assert.match(promptText, /UNCAPPED_TAIL_MESSAGE_54/u);
       assert.match(promptText, /CURRENT_CONVERSATION_MESSAGE/u);
+    },
+  },
+  {
+    name: "Random Pick resolves one selected preset value on every prompt assembly",
+    run() {
+      const options = [{ value: "tender" }, { value: "dramatic" }, { value: "playful" }];
+      const input = {
+        selected: ["tender", "dramatic", "playful"],
+        options,
+        multiSelect: true,
+        randomPick: "true",
+      };
+
+      assert.equal(resolveChoiceVariableValue({ ...input, random: () => 0 }), "tender");
+      assert.equal(resolveChoiceVariableValue({ ...input, random: () => 0.5 }), "dramatic");
+      assert.equal(resolveChoiceVariableValue({ ...input, random: () => 0.999999 }), "playful");
+      assert.equal(
+        resolveChoiceVariableValue({
+          ...input,
+          multiSelect: "false",
+          randomPick: true,
+          random: () => 0.5,
+        }),
+        "dramatic",
+        "legacy Boolean Random Pick rows should retain their multi-value selection",
+      );
+      assert.equal(
+        resolveChoiceVariableValue({
+          ...input,
+          selected: ["removed", "playful"],
+          random: () => 0,
+        }),
+        "playful",
+        "stale values should be removed before Random Pick resolves",
+      );
     },
   },
   {

--- a/scripts/regressions/roleplay-streaming.regression.ts
+++ b/scripts/regressions/roleplay-streaming.regression.ts
@@ -80,6 +80,26 @@ const chatRoleplaySurfaceSource = readFileSync(
   new URL("../../packages/client/src/components/chat/ChatRoleplaySurface.tsx", import.meta.url),
   "utf8",
 );
+const chatAreaSource = readFileSync(
+  new URL("../../packages/client/src/components/chat/ChatArea.tsx", import.meta.url),
+  "utf8",
+);
+const generateHookSource = readFileSync(
+  new URL("../../packages/client/src/hooks/use-generate.ts", import.meta.url),
+  "utf8",
+);
+const weatherEffectsSource = readFileSync(
+  new URL("../../packages/client/src/components/chat/WeatherEffects.tsx", import.meta.url),
+  "utf8",
+);
+const weatherWorkerSource = readFileSync(
+  new URL("../../packages/client/src/workers/weather-effects.worker.ts", import.meta.url),
+  "utf8",
+);
+const gameSurfaceSource = readFileSync(
+  new URL("../../packages/client/src/components/game/GameSurface.tsx", import.meta.url),
+  "utf8",
+);
 const echoChamberPanelSource = readFileSync(
   new URL("../../packages/client/src/components/chat/EchoChamberPanel.tsx", import.meta.url),
   "utf8",
@@ -274,6 +294,31 @@ assert.match(
   /type: "illustration_queued"/u,
   "an Illustrator-only retry should expose the same background handoff",
 );
+assert.match(
+  generateHookSource,
+  /case "illustration_queued": \{[\s\S]{0,180}setBackgroundIllustration\(chatId, true\);/u,
+  "every queued Illustrator retry should hand off from text streaming to background image work",
+);
+assert.match(
+  chatAreaSource,
+  /const isTextStreaming = isStreaming && !isBackgroundIllustration;/u,
+  "finished assistant text must stop being treated as streaming while Illustrator continues",
+);
+assert.match(
+  chatAreaSource,
+  /isStreaming=\{isTextStreaming\}[\s\S]{0,120}generationVisualsPaused=\{isStreaming \|\| agentProcessing\}/u,
+  "Roleplay messages should remain editable while ambient rendering stays suspended for background work",
+);
+const galleryCreateIndex = generateRouteSource.indexOf("const galleryEntry = await galleryStore.create");
+const illustrationMessageLookupIndex = generateRouteSource.indexOf(
+  "const msgRow = await chats.getMessage(messageId)",
+  galleryCreateIndex,
+);
+assert.notEqual(galleryCreateIndex, -1, "Illustrator must persist generated images to Gallery");
+assert.ok(
+  illustrationMessageLookupIndex > galleryCreateIndex,
+  "Illustrator must save to Gallery before checking whether the source message still exists",
+);
 const chatTextareaSource = chatInputSource.match(/<textarea[\s\S]*?\/>/u)?.[0] ?? "";
 const chatHandleInputSource =
   chatInputSource.match(
@@ -297,8 +342,8 @@ assert.doesNotMatch(
 );
 assert.match(
   chatHandleInputSource,
-  /resizeTimerRef\.current = setTimeout\(\(\) => \{[\s\S]*?resizeChatInputTextarea\(el\);[\s\S]*?\}, 150\);/u,
-  "Roleplay textarea measurement should wait for a typing pause instead of forcing layout on each keystroke",
+  /const isDeleting = inputEvent\?\.inputType\?\.startsWith\("delete"\) === true;[\s\S]*?isDeleting \? ROLEPLAY_INPUT_DELETE_RESIZE_IDLE_MS : ROLEPLAY_INPUT_RESIZE_IDLE_MS/u,
+  "Roleplay deletion should use a longer resize idle window than ordinary typing",
 );
 assert.match(
   chatInputSource,
@@ -334,6 +379,41 @@ assert.match(
   globalStylesSource,
   /\[data-chat-mode="roleplay"\] \.mari-chat-input-textarea \{\s+contain: paint;/u,
   "Roleplay textarea paint should stay isolated from the live scene behind it",
+);
+assert.match(
+  firefoxSupportsSource,
+  /\[data-chat-mode="roleplay"\] \.marinara-chat-input-shell\s*\{[^{}]*contain:\s*layout paint;[^{}]*isolation:\s*isolate;/u,
+  "Firefox should contain composer layout and paint while text is edited",
+);
+assert.match(
+  chatRoleplaySurfaceSource,
+  /generationVisualsPaused && "mari-generation-render-paused"/u,
+  "Roleplay should pause ambient rendering while generation is active",
+);
+assert.match(
+  gameSurfaceSource,
+  /\(isStreaming \|\| scenePreparing \|\| sceneAnalysis\.isPending\) && "mari-generation-render-paused"/u,
+  "Game should pause ambient rendering during GM and scene-model generation",
+);
+assert.match(
+  weatherEffectsSource,
+  /workerRef\.current\?\.postMessage\(\{ type: "visibility", hidden: document\.hidden \|\| paused \}\)/u,
+  "weather workers should receive generation suspension state",
+);
+assert.match(
+  weatherEffectsSource,
+  /if \(document\.hidden \|\| pausedRef\.current\) \{[\s\S]{0,180}frameRef\.current = 0;/u,
+  "fallback weather rendering should stop scheduling frames while suspended",
+);
+assert.match(
+  weatherWorkerSource,
+  /function setSuspended\(suspended: boolean\)[\s\S]{0,220}clearTimeout\(timer\);[\s\S]{0,120}scheduleFrame\(\);/u,
+  "offscreen weather rendering should stop its timer rather than polling while suspended",
+);
+assert.match(
+  globalStylesSource,
+  /\.mari-generation-render-paused[\s\S]{0,500}animation-play-state: paused !important;/u,
+  "decorative CSS animations should yield GPU time during generation",
 );
 assert.match(
   firefoxSupportsSource,

--- a/scripts/regressions/roleplay-streaming.regression.ts
+++ b/scripts/regressions/roleplay-streaming.regression.ts
@@ -296,8 +296,13 @@ assert.match(
 );
 assert.match(
   generateHookSource,
-  /case "illustration_queued": \{[\s\S]{0,180}setBackgroundIllustration\(chatId, true\);/u,
-  "every queued Illustrator retry should hand off from text streaming to background image work",
+  /const isIllustratorOnlyRetry =[\s\S]{0,180}agentTypes\.every\(\(agentType\) => agentType === "illustrator"\)/u,
+  "retry handoff should identify Illustrator-only work without exempting mixed agent retries",
+);
+assert.match(
+  generateHookSource,
+  /case "illustration_queued": \{[\s\S]{0,180}if \(isIllustratorOnlyRetry\) \{[\s\S]{0,120}setBackgroundIllustration\(chatId, true\);/u,
+  "only an Illustrator-only retry should hand off from text streaming to background image work",
 );
 assert.match(
   chatAreaSource,
@@ -392,8 +397,13 @@ assert.match(
 );
 assert.match(
   gameSurfaceSource,
-  /\(isStreaming \|\| scenePreparing \|\| sceneAnalysis\.isPending\) && "mari-generation-render-paused"/u,
-  "Game should pause ambient rendering during GM and scene-model generation",
+  /\(isStreaming \|\| scenePreparing \|\| sceneAnalysis\.isPending \|\| agentsProcessing\) &&[\s\S]{0,80}"mari-generation-render-paused"/u,
+  "Game should pause ambient rendering during GM, scene-model, and agent generation",
+);
+assert.match(
+  gameSurfaceSource,
+  /paused=\{isStreaming \|\| scenePreparing \|\| sceneAnalysis\.isPending \|\| agentsProcessing\}/u,
+  "Game weather should remain paused through background agent work",
 );
 assert.match(
   weatherEffectsSource,


### PR DESCRIPTION
## Why

This assigned-issue sweep addresses active user-facing regressions in chat performance and interaction:

- an active Marinara tab can contend with local LLM generation (#4187)
- Firefox on macOS still hitches during Roleplay typing and held deletion (#4188)
- Conversation media searches and picker scrolling are inconsistent (#4189)
- preset Random Pick variables can resolve deterministically instead of sampling (#4190)
- completed assistant text remains locked while its queued Illustrator image runs (#4192)

The translated backup-retention follow-up is handled separately in #4194 against `docs-i18n`, as required by repository policy.

## Summary

- suspend weather workers and decorative Roleplay/Game animation while generation needs local GPU resources
- lengthen deletion-only textarea resize settling and isolate the Firefox Roleplay paint surface
- align Emoji and Kaomoji search shells with GIF search and keep media pickers open during internal pointer/scrollbar interaction
- normalize legacy choice flags and sample Random Pick selections on every prompt assembly
- separate completed text streaming state from background Illustrator work so the last assistant message can be edited or deleted while the frozen image job continues; deleted-message results remain in Gallery
- add focused prompt, Roleplay/Illustrator, source, and Playwright regression coverage

## Validation

Passed locally:

- `pnpm check`
- `pnpm regression:prompt`
- `pnpm regression:roleplay`
- targeted desktop Playwright proof for Conversation media picker search styling and internal pointer handling

Passed on GitHub:

- `pnpm-validate`
- `container-build-test`

Known baseline limitations observed locally:

- `pnpm regression:issues` stops at the pre-existing mobile background crossfade-slot assertion before reaching this sweep
- the full 216-case `pnpm smoke:ui` run passed 136 and skipped 73; the changed Conversation picker case passed on desktop and mobile, while seven unrelated existing cases failed around a stale storage version expectation, the custom-agent Danger Zone gate, and background-library behavior

## Manual verification

- [ ] Manually verify Roleplay typing and held-backspace deletion in Firefox on macOS
- [ ] Manually verify local generation throughput with an active Roleplay or Game tab
- [ ] Manually verify Emoji, Kaomoji, GIF, and Sticker picker scrolling in Conversation mode
- [ ] Manually verify repeated Random Pick prompt generations can choose different selected options
- [ ] Manually verify editing and deleting the last assistant message while Illustrator is running

Closes #4187
Closes #4188
Closes #4189
Closes #4190
Closes #4192

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Conversation media pickers now use consistent, polished search UI and improved in-picker interactions.
  * External agent imports require permission review and capability selection before being allowed.
* **Bug Fixes**
  * Ambient weather/game effects now reliably pause during generation for clearer, smoother visuals.
  * Streaming behavior is refined so message recall/edit and deletion resizing behave more predictably.
  * Roleplay ambient rendering pause state is now applied more consistently.
* **Tests**
  * Expanded e2e/UI regression coverage for agent import permissions, media pickers, roleplay streaming/animation pausing, and prompt choice resolution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->