### PR TITLE
[docs-i18n] Translate automatic backup retention docs

### DIFF
--- a/de/data/backup-and-restore.md
+++ b/de/data/backup-and-restore.md
@@ -40,14 +40,16 @@ Die **.zip** enthält außerdem eine reine Textdatei namens `RESTORE.txt`. Sie e
 ## Automatische Backups
 
 Der Abschnitt **Backup & Export** kann außerdem ein rotierendes automatisches Vollbackup auf dem Gerät anlegen, das Marinara ausführt.
-Aktiviere **Automatic Backups** (automatische Backups) und wähle dann **Daily**, **Weekly** oder **Monthly**. Marinara legt das erste Backup
-kurz nach dem Aktivieren an und ersetzt dieses automatische Archiv nach jedem erfolgreichen Lauf. So wächst der Backup-Ordner
-nicht unbegrenzt.
+Aktiviere **Automatic Backups** (automatische Backups), wähle **Daily**, **Weekly** oder **Monthly** und stelle **Automatic backups kept**
+auf einen Wert von 1 bis 9999. Marinara legt das erste Backup kurz nach dem Aktivieren an. Nach jedem erfolgreichen Lauf behält es
+die festgelegte Anzahl der neuesten automatischen Archive und löscht das älteste überzählige automatische Archiv. Diese
+Aufbewahrungsgrenze löscht niemals manuelle Backups oder Backups, die mit **Download Backup** gespeichert wurden.
 
-Automatische Backups liegen als `backups/marinara-automatic-backup.zip` im Datenordner von Marinara. Sie nutzen dasselbe
-wiederherstellbare, gestreamte Archivformat wie **Download Backup** – inklusive hochgeladener Medien und der Datei mit dem
-Verschlüsselungs-Key, sofern eine existiert. Halte eine separate Kopie außerhalb des Marinara-Datenordners bereit, wenn du dich gegen einen
-Festplattenausfall, gelöschten App-Speicher oder ein zurückgesetztes Gerät absichern willst.
+Automatische Backups liegen im Ordner `backups/` im Datenordner von Marinara. Das neueste Archiv heißt
+`marinara-automatic-backup.zip`; ältere aufbewahrte automatische Archive verwenden Dateinamen mit Zeitstempel. Sie nutzen
+dasselbe wiederherstellbare, gestreamte Archivformat wie **Download Backup** – inklusive hochgeladener Medien und der Datei mit
+dem Verschlüsselungs-Key, sofern eine existiert. Halte eine separate Kopie außerhalb des Marinara-Datenordners bereit, wenn du dich
+gegen einen Festplattenausfall, gelöschten App-Speicher oder ein zurückgesetztes Gerät absichern willst.
 
 ## Export Profile
 

--- a/de/data/backup-and-restore.md
+++ b/de/data/backup-and-restore.md
@@ -120,7 +120,7 @@ Bereits gesetzte Keys löscht der Import nicht. Importierst du ein altes Profil 
 
 ## Die Liste Existing backups
 
-Der Abschnitt **Backup & Export** kann eine Liste **Existing backups** (vorhandene Backups) samt Lösch-Schaltfläche anzeigen. Im normalen Betrieb bleibt diese Liste leer. **Download Backup** speichert die Datei direkt auf dem Gerät. Eine Kopie in dieser Liste hinterlässt es nicht, und das einzelne rotierende automatische Archiv verwaltet stattdessen der Schalter **Automatic Backups**. Für ein heruntergeladenes Backup brauchst du diese Liste nicht.
+Der Abschnitt **Backup & Export** kann eine Liste **Existing backups** (vorhandene Backups) samt Lösch-Schaltfläche anzeigen. Im normalen Betrieb bleibt diese Liste leer. **Download Backup** speichert die Datei direkt auf dem Gerät. Eine Kopie in dieser Liste hinterlässt es nicht, und die festgelegte Anzahl aufbewahrter automatischer Archive verwaltet stattdessen der Schalter **Automatic Backups**. Für ein heruntergeladenes Backup brauchst du diese Liste nicht.
 
 ## Verwandte Anleitungen
 

--- a/de/data/where-data-is-stored.md
+++ b/de/data/where-data-is-stored.md
@@ -50,9 +50,11 @@ Unter Android liegt der Datenordner des Servers meist im App-Speicher, an den du
 
 Um unter Android trotzdem eine Kopie der Daten zu bekommen, nutze die Schaltfläche **Download Backup** (Backup herunterladen). Du findest sie unter **Settings** im Tab **Advanced** im Bereich **Backup & Export**. Daraus entsteht eine einzelne ZIP-Datei mit allen Daten. Sofern vorhanden, enthält das ZIP auch die Datei `.encryption-key`. Zuverlässiger lassen sich Daten vom Handy nicht sichern.
 
-Derselbe Bereich kann zusätzlich ein rotierendes automatisches Archiv führen – täglich, wöchentlich oder monatlich – unter
-`backups/marinara-automatic-backup.zip` im Datenordner. Kopiere wichtige Backups zusätzlich an einen Ort außerhalb des
-App-Speichers: Beim Deinstallieren oder Zurücksetzen der App verschwinden sonst die aktiven Daten und das lokale automatische Backup gleich mit.
+Derselbe Bereich kann zusätzlich 1 bis 9999 rotierende tägliche, wöchentliche oder monatliche automatische Archive unter
+`backups/` im Datenordner aufbewahren. Das neueste heißt `marinara-automatic-backup.zip`; ältere aufbewahrte automatische
+Archive tragen einen Zeitstempel im Dateinamen. Diese Grenze gilt nur für automatische Backups. Kopiere wichtige Backups
+zusätzlich an einen Ort außerhalb des App-Speichers: Beim Deinstallieren oder Zurücksetzen der App können sonst sowohl die
+aktiven Daten als auch die lokalen automatischen Backups verschwinden.
 
 Alle Schritte zum Sichern und Wiederherstellen auf jeder Plattform findest du unter [Marinara sichern und wiederherstellen](backup-and-restore.md).
 

--- a/de/manifest.json
+++ b/de/manifest.json
@@ -1,6 +1,6 @@
 {
   "language": "de",
-  "sourceCommit": "bf63de09abe5bb2c8a2bb5030ff25e5a41dc9178",
+  "sourceCommit": "753cf5520ce0e549aa4d632d5d5d8abbfdd995aa",
   "files": [
     {
       "path": "CONFIGURATION.md",
@@ -264,8 +264,8 @@
     },
     {
       "path": "data/backup-and-restore.md",
-      "sha256": "c24a3a2527b333cf1a4efc78049a2b6379f080277a74f418f6fd08cd1363b4ec",
-      "bytes": 10317
+      "sha256": "c90e0b4396106cccc47c14b84813d6434537a7d2d371d36f1df15c81fecef494",
+      "bytes": 10656
     },
     {
       "path": "data/clearing-data.md",
@@ -279,8 +279,8 @@
     },
     {
       "path": "data/where-data-is-stored.md",
-      "sha256": "232fe4ecaa5b1350b09f8c95e0347dfc80087a7f9c96b2352166965847866f73",
-      "bytes": 5191
+      "sha256": "e42b8f23fdf1810d1bc3fbfb14c7d75df660ca34e742a7bf3f585751d7147ed4",
+      "bytes": 5361
     },
     {
       "path": "development/architecture-map.md",

--- a/de/manifest.json
+++ b/de/manifest.json
@@ -264,8 +264,8 @@
     },
     {
       "path": "data/backup-and-restore.md",
-      "sha256": "c90e0b4396106cccc47c14b84813d6434537a7d2d371d36f1df15c81fecef494",
-      "bytes": 10656
+      "sha256": "e07f7a2f11a355755aec53214a8c46120a3dd3cda635ecad2187b162bd96d579",
+      "bytes": 10670
     },
     {
       "path": "data/clearing-data.md",

--- a/es/data/backup-and-restore.md
+++ b/es/data/backup-and-restore.md
@@ -40,14 +40,16 @@ El **.zip** también contiene un archivo de texto plano llamado `RESTORE.txt`. E
 ## Copias de seguridad automáticas
 
 La sección **Backup & Export** también puede crear una copia de seguridad automática completa que va rotando en el dispositivo que ejecuta Marinara.
-Activa **Automatic Backups** (Copias de seguridad automáticas) y luego elige **Daily**, **Weekly** o **Monthly**. Marinara crea la primera copia
-poco después de que la actives y reemplaza ese archivo automático tras cada ejecución exitosa, de modo que la carpeta de copias de seguridad no
-crece sin límite.
+Activa **Automatic Backups** (Copias de seguridad automáticas), elige **Daily**, **Weekly** o **Monthly** y configura
+**Automatic backups kept** con un valor de 1 a 9999. Marinara crea la primera copia poco después de que la actives. Después de
+cada ejecución exitosa, conserva el número configurado de archivos automáticos más recientes y elimina el archivo automático
+sobrante más antiguo. Este límite de retención nunca elimina copias de seguridad manuales ni las guardadas con **Download Backup**.
 
-Las copias de seguridad automáticas se guardan como `backups/marinara-automatic-backup.zip` dentro de la carpeta de datos de Marinara. Usan el
-mismo formato de archivo restaurable y transmitido que **Download Backup**, incluidos los medios subidos y el archivo de la clave de cifrado
-cuando existe uno. Mantén una copia aparte, fuera de la carpeta de datos de Marinara, si necesitas protección frente a un disco perdido, un almacenamiento
-de la app borrado o un restablecimiento del dispositivo.
+Las copias de seguridad automáticas se guardan dentro de `backups/`, en la carpeta de datos de Marinara. El archivo más reciente
+se llama `marinara-automatic-backup.zip`; los archivos automáticos anteriores que se conservan usan nombres con marca de tiempo.
+Usan el mismo formato de archivo restaurable y transmitido que **Download Backup**, incluidos los medios subidos y el archivo de
+la clave de cifrado cuando existe uno. Mantén una copia aparte, fuera de la carpeta de datos de Marinara, si necesitas protección
+frente a un disco perdido, un almacenamiento de la app borrado o un restablecimiento del dispositivo.
 
 ## Export Profile
 

--- a/es/data/backup-and-restore.md
+++ b/es/data/backup-and-restore.md
@@ -120,7 +120,7 @@ Importar no borra las claves que ya tengas configuradas. Si vuelves a importar u
 
 ## La lista Existing backups
 
-La sección **Backup & Export** puede mostrar una lista **Existing backups** (Copias de seguridad existentes) con un botón de eliminar. En el uso normal esta lista queda vacía. **Download Backup** guarda el archivo directamente en tu dispositivo. No deja una copia en esta lista, y el único archivo automático que va rotando lo gestiona el control de Automatic Backups. No necesitas esta lista para crear ni conservar una copia de seguridad descargada.
+La sección **Backup & Export** puede mostrar una lista **Existing backups** (Copias de seguridad existentes) con un botón de eliminar. En el uso normal esta lista queda vacía. **Download Backup** guarda el archivo directamente en tu dispositivo. No deja una copia en esta lista, y el control **Automatic Backups** gestiona en su lugar el número configurado de archivos automáticos conservados. No necesitas esta lista para crear ni conservar una copia de seguridad descargada.
 
 ## Guías relacionadas
 

--- a/es/data/where-data-is-stored.md
+++ b/es/data/where-data-is-stored.md
@@ -50,9 +50,11 @@ En Android, la carpeta de datos del servidor suele estar en un almacenamiento de
 
 Para obtener una copia de tus datos en Android, usa el botón **Download Backup** (Descargar copia de seguridad). Lo encuentras en **Settings**, en la pestaña **Advanced**, en la sección **Backup & Export**. Esto crea un único archivo zip con tus datos. El zip incluye el archivo `.encryption-key` cuando existe uno. Esta es la forma más fiable de guardar tus datos desde un teléfono.
 
-La misma sección puede mantener una copia automática rotativa diaria, semanal o mensual en
-`backups/marinara-automatic-backup.zip` dentro de la carpeta de datos. Copia las copias de seguridad importantes también en algún lugar fuera del
-almacenamiento de la app, porque desinstalar o restablecer la app puede eliminar tanto los datos activos como su copia de seguridad automática local.
+La misma sección puede conservar de 1 a 9999 archivos automáticos rotativos diarios, semanales o mensuales en `backups/`, dentro
+de la carpeta de datos. El más reciente se llama `marinara-automatic-backup.zip` y los archivos automáticos anteriores que se
+conservan llevan una marca de tiempo. Este límite se aplica únicamente a las copias de seguridad automáticas. Copia las copias
+de seguridad importantes también en algún lugar fuera del almacenamiento de la app, porque desinstalar o restablecer la app
+puede eliminar tanto los datos activos como sus copias de seguridad automáticas locales.
 
 Para los pasos completos de copia de seguridad y restauración en cada plataforma, consulta [Copia de seguridad y restauración de Marinara](backup-and-restore.md).
 

--- a/es/manifest.json
+++ b/es/manifest.json
@@ -264,8 +264,8 @@
     },
     {
       "path": "data/backup-and-restore.md",
-      "sha256": "c048a8bceae4acec114a9268289fe00c2a16dc1880ba2122c814a15d4baa2a76",
-      "bytes": 10735
+      "sha256": "4a4c0be74f3087c5f10807e251fec3e47c5fe65ca5d7373fc08549311416527e",
+      "bytes": 10760
     },
     {
       "path": "data/clearing-data.md",

--- a/es/manifest.json
+++ b/es/manifest.json
@@ -1,6 +1,6 @@
 {
   "language": "es",
-  "sourceCommit": "bf63de09abe5bb2c8a2bb5030ff25e5a41dc9178",
+  "sourceCommit": "753cf5520ce0e549aa4d632d5d5d8abbfdd995aa",
   "files": [
     {
       "path": "CONFIGURATION.md",
@@ -264,8 +264,8 @@
     },
     {
       "path": "data/backup-and-restore.md",
-      "sha256": "95ad67cccc1cdcd16c070a61b42629ff9aaeed76dbb5f7d732683dd2a03dad30",
-      "bytes": 10409
+      "sha256": "c048a8bceae4acec114a9268289fe00c2a16dc1880ba2122c814a15d4baa2a76",
+      "bytes": 10735
     },
     {
       "path": "data/clearing-data.md",
@@ -279,8 +279,8 @@
     },
     {
       "path": "data/where-data-is-stored.md",
-      "sha256": "433fa785beca7d90562000dffef03c3843e7f07863d89aa2fb3beee26ca92554",
-      "bytes": 5349
+      "sha256": "22d9c3279550a9c6529b7dc27bf7a0f7044aa49079a606f33bf6cecd3bb05941",
+      "bytes": 5562
     },
     {
       "path": "development/architecture-map.md",

--- a/fr/data/backup-and-restore.md
+++ b/fr/data/backup-and-restore.md
@@ -120,7 +120,7 @@ L'import n'efface pas les clés déjà en place. Si tu réimportes un ancien pro
 
 ## La liste Existing backups
 
-La section **Backup & Export** peut afficher une liste **Existing backups** (sauvegardes existantes), avec un bouton de suppression. Dans un usage normal, cette liste reste vide. **Download Backup** enregistre le fichier directement sur ton appareil. Il n'en laisse pas de copie dans cette liste, et l'unique archive automatique tournante est gérée par le réglage Automatic Backups. Cette liste n'est pas nécessaire pour créer ou conserver une sauvegarde téléchargée.
+La section **Backup & Export** peut afficher une liste **Existing backups** (sauvegardes existantes), avec un bouton de suppression. Dans un usage normal, cette liste reste vide. **Download Backup** enregistre le fichier directement sur ton appareil. Il n'en laisse pas de copie dans cette liste, et le réglage **Automatic Backups** gère à la place le nombre configuré d'archives automatiques conservées. Cette liste n'est pas nécessaire pour créer ou conserver une sauvegarde téléchargée.
 
 ## Guides associés
 

--- a/fr/data/backup-and-restore.md
+++ b/fr/data/backup-and-restore.md
@@ -40,14 +40,16 @@ Le **.zip** contient aussi un fichier texte nommé `RESTORE.txt`. Il explique co
 ## Sauvegardes automatiques
 
 La section **Backup & Export** peut aussi créer une sauvegarde complète automatique et tournante, sur l'appareil qui fait tourner Marinara.
-Active **Automatic Backups**, puis choisis **Daily**, **Weekly** ou **Monthly**. Marinara crée la première sauvegarde
-peu après l'activation, puis remplace cette archive automatique après chaque exécution réussie : le dossier de sauvegarde
-ne grossit donc pas sans fin.
+Active **Automatic Backups**, choisis **Daily**, **Weekly** ou **Monthly**, puis règle **Automatic backups kept** sur une valeur
+comprise entre 1 et 9999. Marinara crée la première sauvegarde peu après l'activation. Après chaque exécution réussie, il
+conserve le nombre configuré d'archives automatiques les plus récentes et supprime l'archive automatique excédentaire la plus
+ancienne. Cette limite de conservation ne supprime jamais les sauvegardes manuelles ni celles enregistrées avec **Download Backup**.
 
-Les sauvegardes automatiques sont enregistrées sous `backups/marinara-automatic-backup.zip`, dans le dossier de données de Marinara. Elles emploient le
-même format d'archive restaurable et diffusée en flux que **Download Backup**, médias téléversés compris, ainsi que le fichier de clé de chiffrement
-quand il existe. Garde une copie séparée hors du dossier de données de Marinara pour te protéger d'un disque perdu, d'un stockage
-d'application effacé ou d'une réinitialisation de l'appareil.
+Les sauvegardes automatiques sont enregistrées dans `backups/`, dans le dossier de données de Marinara. L'archive la plus récente
+porte le nom `marinara-automatic-backup.zip` ; les anciennes archives automatiques conservées emploient des noms de fichiers
+horodatés. Elles utilisent le même format d'archive restaurable et diffusée en flux que **Download Backup**, médias téléversés
+compris, ainsi que le fichier de clé de chiffrement quand il existe. Garde une copie séparée hors du dossier de données de
+Marinara pour te protéger d'un disque perdu, d'un stockage d'application effacé ou d'une réinitialisation de l'appareil.
 
 ## Export Profile
 

--- a/fr/data/where-data-is-stored.md
+++ b/fr/data/where-data-is-stored.md
@@ -50,9 +50,11 @@ Sur Android, le dossier de données du serveur se trouve en général dans un es
 
 Pour récupérer une copie de tes données sur Android, utilise le bouton **Download Backup** (télécharger la sauvegarde). Tu le trouves dans **Settings**, sur l'onglet **Advanced**, dans la section **Backup & Export**. Il crée un seul fichier zip contenant tes données. Le zip inclut le fichier `.encryption-key` quand celui-ci existe. C'est la méthode la plus fiable pour sauvegarder tes données depuis un téléphone.
 
-La même section peut conserver une archive automatique tournante, quotidienne, hebdomadaire ou mensuelle, dans
-`backups/marinara-automatic-backup.zip`, à l'intérieur du dossier de données. Copie aussi les sauvegardes importantes ailleurs que dans l'espace de stockage
-de l'application : désinstaller ou réinitialiser l'application peut supprimer à la fois les données actives et la sauvegarde automatique locale.
+La même section peut conserver de 1 à 9999 archives automatiques tournantes quotidiennes, hebdomadaires ou mensuelles dans
+`backups/`, à l'intérieur du dossier de données. La plus récente porte le nom `marinara-automatic-backup.zip` et les anciennes
+archives automatiques conservées sont horodatées. Cette limite ne s'applique qu'aux sauvegardes automatiques. Copie aussi les
+sauvegardes importantes ailleurs que dans l'espace de stockage de l'application : désinstaller ou réinitialiser l'application
+peut supprimer à la fois les données actives et ses sauvegardes automatiques locales.
 
 Pour la marche à suivre complète, sauvegarde et restauration, sur chaque plateforme, consulte [Sauvegarder et restaurer Marinara](backup-and-restore.md).
 

--- a/fr/manifest.json
+++ b/fr/manifest.json
@@ -1,6 +1,6 @@
 {
   "language": "fr",
-  "sourceCommit": "05282f124e2fb38c73f1fa4447228e95236f9b6f",
+  "sourceCommit": "753cf5520ce0e549aa4d632d5d5d8abbfdd995aa",
   "files": [
     {
       "path": "CONFIGURATION.md",
@@ -264,8 +264,8 @@
     },
     {
       "path": "data/backup-and-restore.md",
-      "sha256": "f8b25ad5dda840d05ba15a133e8c0c24f2df43490ca09ec5852909b6315c6c56",
-      "bytes": 10640
+      "sha256": "6aa09f355bdcee7734da1ffe781d72271397f3466f92462f013fee26615486aa",
+      "bytes": 11021
     },
     {
       "path": "data/clearing-data.md",
@@ -279,8 +279,8 @@
     },
     {
       "path": "data/where-data-is-stored.md",
-      "sha256": "82016b0e0105895c70fa3430f39d32e097d4a74be337323b24d4c0ab2781bd0e",
-      "bytes": 5672
+      "sha256": "9821da56efb307c539cdd9ec6f42a1d978436c3371b34694fca6822241fb83a9",
+      "bytes": 5851
     },
     {
       "path": "development/architecture-map.md",

--- a/fr/manifest.json
+++ b/fr/manifest.json
@@ -264,8 +264,8 @@
     },
     {
       "path": "data/backup-and-restore.md",
-      "sha256": "6aa09f355bdcee7734da1ffe781d72271397f3466f92462f013fee26615486aa",
-      "bytes": 11021
+      "sha256": "57ede956059dd52d69fe36be64b6c955c459a9c613dc2bdfcacb8763516de516",
+      "bytes": 11045
     },
     {
       "path": "data/clearing-data.md",


### PR DESCRIPTION
## Why

PR #4185 added configurable automatic-backup retention, compatibility filenames, timestamped archive rotation, and automatic-only pruning. The German, Spanish, and French in-app guides still described a single replaced archive.

Closes #4186

## Summary

- translate the 1–9999 automatic-backup retention setting in all three language packs
- document the newest compatibility filename and timestamped retained archives
- clarify that retention pruning never removes manual or downloaded backups
- regenerate each pack manifest against the current staging source commit

## Validation

- `node scripts/docs-i18n/validate-pack.mjs <pack>` for `de`, `es`, and `fr`

## Manual verification

- [ ] Manually verify the German backup guides in the in-app docs viewer
- [ ] Manually verify the Spanish backup guides in the in-app docs viewer
- [ ] Manually verify the French backup guides in the in-app docs viewer

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated backup guidance across German, Spanish, and French documentation.
  - Documented configurable automatic backup retention from 1 to 9,999 archives.
  - Clarified daily, weekly, and monthly schedules, archive rotation, storage location, and filename conventions.
  - Explained that manual and downloaded backups are not removed by automatic retention.
  - Reiterated recommendations to keep important backups outside the app’s data storage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->