### PR TITLE
Fix assigned Roleplay input, swipe, and tool-call regressions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -106,6 +106,7 @@ Regression guards:
 
 - `pnpm regression:prompt` runs fast deterministic checks for prompt assembly, lorebook keyword matching, macros, summaries, and mode-specific generation gates.
 - `pnpm smoke:ui` runs the Playwright browser smoke suite against isolated temporary app data.
+  Each run clears `.tmp/playwright-data` before starting a fresh test server. Stop any process already using the configured Playwright ports before running it; existing fixture state is disposable and the smoke suite does not reuse a running development server.
 - `pnpm regression` runs both lanes.
 
 These checks are intentionally small and do not replace manual verification. When you change behavior, include the manual verification you performed and add or update a regression guard for the bug class when practical.

--- a/e2e/core-flows.e2e.ts
+++ b/e2e/core-flows.e2e.ts
@@ -2157,6 +2157,211 @@ test("provider concurrency errors appear in generation toasts", async ({ page },
   }
 });
 
+test("the first message edit persists after stopped generation with or without a composer draft", async ({
+  page,
+  request,
+}, testInfo) => {
+  test.skip(!testInfo.project.name.includes("desktop"), "Stopped-generation edit persistence is covered on desktop.");
+  test.setTimeout(90_000);
+
+  const suffix = Date.now().toString(36);
+  const providerRequests: Array<Record<string, unknown>> = [];
+  const openProviderResponses = new Set<import("node:http").ServerResponse>();
+  const providerServer = createServer((incoming, response) => {
+    const chunks: Buffer[] = [];
+    incoming.on("data", (chunk) => chunks.push(Buffer.from(chunk)));
+    incoming.on("end", () => {
+      if (incoming.method !== "POST" || incoming.url !== "/v1/chat/completions") {
+        response.writeHead(404, { "content-type": "application/json" });
+        response.end(JSON.stringify({ error: "Unexpected stopped-generation provider request" }));
+        return;
+      }
+      providerRequests.push(JSON.parse(Buffer.concat(chunks).toString("utf8")) as Record<string, unknown>);
+      openProviderResponses.add(response);
+      response.on("close", () => openProviderResponses.delete(response));
+      response.writeHead(200, {
+        "content-type": "text/event-stream",
+        connection: "keep-alive",
+        "cache-control": "no-cache",
+      });
+      response.write(
+        `data: ${JSON.stringify({
+          choices: [{ index: 0, delta: { content: "Partial response" }, finish_reason: null }],
+        })}\n\n`,
+      );
+    });
+  });
+  await new Promise<void>((resolve) => providerServer.listen(0, "127.0.0.1", resolve));
+
+  let connectionId = "";
+  let characterId = "";
+  let chatId = "";
+  try {
+    const address = providerServer.address();
+    if (!address || typeof address === "string") throw new Error("Stopped-generation provider fixture did not bind");
+
+    const connectionResponse = await request.post("/api/connections", {
+      data: {
+        name: `Stopped Edit Provider ${suffix}`,
+        provider: "custom",
+        baseUrl: `http://127.0.0.1:${address.port}/v1`,
+        apiKey: "e2e-stopped-edit",
+        model: "stopped-edit-model",
+        maxContext: 32_768,
+      },
+    });
+    expect(connectionResponse.ok(), await connectionResponse.text()).toBeTruthy();
+    connectionId = ((await connectionResponse.json()) as { id: string }).id;
+
+    const characterResponse = await request.post("/api/characters", {
+      data: {
+        data: {
+          name: `Stopped Edit Character ${suffix}`,
+          description: "A patient regression-test partner.",
+          first_mes: "",
+        },
+      },
+    });
+    expect(characterResponse.ok(), await characterResponse.text()).toBeTruthy();
+    characterId = ((await characterResponse.json()) as { id: string }).id;
+
+    const chatResponse = await request.post("/api/chats", {
+      data: {
+        name: `Stopped Edit Chat ${suffix}`,
+        mode: "roleplay",
+        characterIds: [characterId],
+        connectionId,
+      },
+    });
+    expect(chatResponse.ok(), await chatResponse.text()).toBeTruthy();
+    chatId = ((await chatResponse.json()) as { id: string }).id;
+    await request.patch(`/api/chats/${chatId}/metadata`, {
+      data: { enableAgents: false },
+    });
+    await page.addInitScript((activeChatId) => localStorage.setItem("marinara-active-chat-id", activeChatId), chatId);
+    await page.goto("/");
+
+    const input = page.locator("textarea.mari-chat-input-textarea");
+    const sendButton = page.locator("button.mari-chat-send-btn");
+    const stopCurrentGeneration = async (expectedProviderRequestCount: number) => {
+      await expect.poll(() => providerRequests.length).toBe(expectedProviderRequestCount);
+      await expect(sendButton.locator("svg.lucide-circle-stop")).toBeVisible();
+      await sendButton.click();
+      await expect(sendButton.locator("svg.lucide-circle-stop")).toHaveCount(0);
+    };
+    const readMessages = async () => {
+      const response = await request.get(`/api/chats/${chatId}/messages`);
+      return (await response.json()) as Array<{ id: string; role: string; content: string }>;
+    };
+    const editMessageOnce = async (messageId: string, nextContent: string) => {
+      const message = page.locator(`[data-message-id="${messageId}"]`);
+      await message.hover();
+      await message.getByTitle("Edit", { exact: true }).click();
+      const editor = message.locator("textarea");
+      await editor.fill(nextContent);
+      await message.getByLabel("Save edit", { exact: true }).click();
+      await expect(message).toContainText(nextContent);
+      await expect
+        .poll(async () => (await readMessages()).find((candidate) => candidate.id === messageId)?.content)
+        .toBe(nextContent);
+    };
+
+    await input.fill("Original message with retained draft");
+    await sendButton.click();
+    await input.fill("Unsent composer text");
+    await stopCurrentGeneration(1);
+    const firstMessage = (await readMessages()).find(
+      (message) => message.role === "user" && message.content === "Original message with retained draft",
+    );
+    expect(firstMessage).toBeTruthy();
+    await editMessageOnce(firstMessage!.id, "Edited on the first save with retained draft");
+    await expect(input).toHaveValue("Unsent composer text");
+
+    await input.fill("Original message with cleared draft");
+    await sendButton.click();
+    await stopCurrentGeneration(2);
+    await expect(input).toHaveValue("");
+    const secondMessage = (await readMessages()).find(
+      (message) => message.role === "user" && message.content === "Original message with cleared draft",
+    );
+    expect(secondMessage).toBeTruthy();
+    await editMessageOnce(secondMessage!.id, "Edited on the first save with cleared draft");
+
+    await page.reload();
+    await expect(page.locator(`[data-message-id="${firstMessage!.id}"]`)).toContainText(
+      "Edited on the first save with retained draft",
+    );
+    await expect(page.locator(`[data-message-id="${secondMessage!.id}"]`)).toContainText(
+      "Edited on the first save with cleared draft",
+    );
+  } finally {
+    for (const response of openProviderResponses) response.end();
+    await Promise.allSettled([
+      chatId ? request.delete(`/api/chats/${chatId}`) : Promise.resolve(),
+      characterId ? request.delete(`/api/characters/${characterId}`) : Promise.resolve(),
+      connectionId ? request.delete(`/api/connections/${connectionId}`) : Promise.resolve(),
+    ]);
+    await new Promise<void>((resolve, reject) => {
+      providerServer.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+});
+
+test("empty focused chat composers keep keyboard swipe navigation", async ({ page, request }, testInfo) => {
+  test.skip(!testInfo.project.name.includes("desktop"), "Keyboard swipe navigation is covered on desktop.");
+
+  const chatResponse = await request.post("/api/chats", {
+    data: { name: "Focused Composer Swipe Navigation", mode: "roleplay", characterIds: [] },
+  });
+  expect(chatResponse.ok()).toBeTruthy();
+  const chat = (await chatResponse.json()) as { id: string };
+  const messageResponse = await request.post(`/api/chats/${chat.id}/messages`, {
+    data: { role: "assistant", content: "First focused-composer swipe." },
+  });
+  expect(messageResponse.ok()).toBeTruthy();
+  const message = (await messageResponse.json()) as { id: string };
+  const swipeResponse = await request.post(`/api/chats/${chat.id}/messages/${message.id}/swipes`, {
+    data: { content: "Second focused-composer swipe.", silent: true },
+  });
+  expect(swipeResponse.ok()).toBeTruthy();
+
+  try {
+    await page.addInitScript((chatId) => {
+      localStorage.setItem("marinara-active-chat-id", chatId);
+      localStorage.setItem(
+        "marinara-engine-ui",
+        JSON.stringify({
+          state: {
+            intuitiveSwipeNavigation: true,
+            intuitiveSwipeRerollLatest: false,
+          },
+          version: 87,
+        }),
+      );
+    }, chat.id);
+    await page.goto("/");
+
+    const composer = page.locator("textarea.mari-chat-input-textarea");
+    const messageRow = page.locator(`[data-message-id="${message.id}"]`);
+    await expect(messageRow).toContainText("First focused-composer swipe.");
+
+    await composer.focus();
+    await expect(composer).toHaveValue("");
+    await composer.press("ArrowRight");
+    await expect(messageRow).toContainText("Second focused-composer swipe.");
+
+    await composer.fill("Do not navigate while I am typing");
+    await composer.press("ArrowLeft");
+    await expect(messageRow).toContainText("Second focused-composer swipe.");
+
+    await composer.fill("");
+    await composer.press("ArrowLeft");
+    await expect(messageRow).toContainText("First focused-composer swipe.");
+  } finally {
+    await request.delete(`/api/chats/${chat.id}`);
+  }
+});
+
 test("typographic quotes do not pull the Roleplay caret behind later text", async ({ page }, testInfo) => {
   test.skip(!testInfo.project.name.includes("desktop"), "Roleplay quote caret behavior is covered on desktop.");
 

--- a/e2e/core-flows.e2e.ts
+++ b/e2e/core-flows.e2e.ts
@@ -2444,7 +2444,7 @@ test("mobile Roleplay composition avoids draft rewrites and pauses ambient rende
 
   try {
     await page.addInitScript((chatId) => {
-      const persisted = JSON.parse(localStorage.getItem("marinara-engine-ui") ?? '{"state":{},"version":65}') as {
+      const persisted = JSON.parse(localStorage.getItem("marinara-engine-ui") ?? '{"state":{},"version":87}') as {
         state: Record<string, unknown>;
         version: number;
       };

--- a/e2e/core-flows.e2e.ts
+++ b/e2e/core-flows.e2e.ts
@@ -2209,6 +2209,52 @@ test("typographic quotes do not pull the Roleplay caret behind later text", asyn
   }
 });
 
+test("mobile Roleplay composition avoids draft rewrites and pauses ambient rendering", async ({ page }, testInfo) => {
+  test.skip(!testInfo.project.name.includes("mobile"), "Mobile composer resource behavior is covered on mobile.");
+
+  const chatResponse = await page.request.post("/api/chats", {
+    data: { name: "Mobile Composition Smoke", mode: "roleplay", characterIds: [] },
+  });
+  expect(chatResponse.ok()).toBeTruthy();
+  const chat = (await chatResponse.json()) as { id: string };
+
+  try {
+    await page.addInitScript((chatId) => {
+      const persisted = JSON.parse(localStorage.getItem("marinara-engine-ui") ?? '{"state":{},"version":65}') as {
+        state: Record<string, unknown>;
+        version: number;
+      };
+      persisted.state.hasCompletedOnboarding = true;
+      persisted.state.quoteFormat = "typographic";
+      localStorage.setItem("marinara-engine-ui", JSON.stringify(persisted));
+      localStorage.setItem("marinara-active-chat-id", chatId);
+    }, chat.id);
+    await page.goto("/");
+
+    const input = page.locator("textarea.mari-chat-input-textarea");
+    await input.evaluate((element) => {
+      element.value = 'She said "';
+      element.dispatchEvent(
+        new InputEvent("input", {
+          bubbles: true,
+          data: '"',
+          inputType: "insertCompositionText",
+          isComposing: true,
+        }),
+      );
+    });
+
+    await expect(input).toHaveValue('She said "');
+    await expect(page.locator('[data-chat-mode="roleplay"]')).toHaveClass(/mari-generation-render-paused/u);
+
+    await input.fill("");
+    await input.blur();
+    await expect(page.locator('[data-chat-mode="roleplay"]')).not.toHaveClass(/mari-generation-render-paused/u);
+  } finally {
+    await page.request.delete(`/api/chats/${chat.id}`);
+  }
+});
+
 test("generation fallbacks identify the replacement connection in a toast", async ({ page }, testInfo) => {
   test.skip(!testInfo.project.name.includes("desktop"), "Fallback toast regression is covered on desktop.");
 

--- a/e2e/core-flows.e2e.ts
+++ b/e2e/core-flows.e2e.ts
@@ -493,6 +493,53 @@ test("Chat Settings adds a formatted greeting after the setup wizard is skipped"
   }
 });
 
+test("Function Calling can require the first tool round per chat", async ({ page, request }, testInfo) => {
+  test.skip(!testInfo.project.name.includes("desktop"), "Function Calling settings are covered once on desktop.");
+
+  const chatResponse = await request.post("/api/chats", {
+    data: {
+      name: "Required Tool Call Smoke",
+      mode: "roleplay",
+      characterIds: [],
+    },
+  });
+  expect(chatResponse.ok()).toBeTruthy();
+  const chat = (await chatResponse.json()) as { id: string };
+  await page.addInitScript((chatId) => localStorage.setItem("marinara-active-chat-id", chatId), chat.id);
+
+  const readMetadata = async () => {
+    const response = await request.get(`/api/chats/${chat.id}`);
+    const stored = (await response.json()) as { metadata: string | Record<string, unknown> };
+    return typeof stored.metadata === "string"
+      ? (JSON.parse(stored.metadata) as Record<string, unknown>)
+      : stored.metadata;
+  };
+
+  try {
+    await page.goto("/");
+    await page.getByRole("button", { name: "Chat Settings", exact: true }).filter({ visible: true }).click();
+
+    const section = page.locator('[data-chat-settings-section="function-calling"]');
+    await section.locator('[role="button"][aria-expanded]').click();
+    await section.getByText("Enable Tool Use", { exact: true }).click();
+
+    const forceToolCall = section.getByLabel("Force To Call Tool", { exact: true });
+    await expect(forceToolCall).toBeVisible();
+    await expect(forceToolCall).not.toBeChecked();
+    await section.getByText("Force To Call Tool", { exact: true }).click();
+    await expect
+      .poll(async () => (await readMetadata()).forceToolCall)
+      .toBe(true);
+
+    await section.getByText("Force To Call Tool", { exact: true }).click();
+    await expect
+      .poll(async () => (await readMetadata()).forceToolCall)
+      .toBe(false);
+  } finally {
+    await request.delete(`/api/chats/${chat.id}`).catch(() => undefined);
+  }
+});
+
 test("settings profile exports use the new identity and legacy exports still import", async ({ request }, testInfo) => {
   test.skip(!testInfo.project.name.includes("desktop"), "Settings profile transfer contract is covered once.");
 

--- a/e2e/core-flows.e2e.ts
+++ b/e2e/core-flows.e2e.ts
@@ -2157,7 +2157,7 @@ test("provider concurrency errors appear in generation toasts", async ({ page },
   }
 });
 
-test("the first message edit persists after stopped generation with or without a composer draft", async ({
+test("sent text stays cleared and the first message edit persists after stopped generation", async ({
   page,
   request,
 }, testInfo) => {
@@ -2184,11 +2184,14 @@ test("the first message edit persists after stopped generation with or without a
         connection: "keep-alive",
         "cache-control": "no-cache",
       });
-      response.write(
-        `data: ${JSON.stringify({
-          choices: [{ index: 0, delta: { content: "Partial response" }, finish_reason: null }],
-        })}\n\n`,
-      );
+      response.flushHeaders();
+      if (providerRequests.length <= 2) {
+        response.write(
+          `data: ${JSON.stringify({
+            choices: [{ index: 0, delta: { content: "Partial response" }, finish_reason: null }],
+          })}\n\n`,
+        );
+      }
     });
   });
   await new Promise<void>((resolve) => providerServer.listen(0, "127.0.0.1", resolve));
@@ -2268,6 +2271,7 @@ test("the first message edit persists after stopped generation with or without a
 
     await input.fill("Original message with retained draft");
     await sendButton.click();
+    await expect(input).toHaveValue("");
     await input.fill("Unsent composer text");
     await stopCurrentGeneration(1);
     const firstMessage = (await readMessages()).find(
@@ -2279,6 +2283,7 @@ test("the first message edit persists after stopped generation with or without a
 
     await input.fill("Original message with cleared draft");
     await sendButton.click();
+    await expect(input).toHaveValue("");
     await stopCurrentGeneration(2);
     await expect(input).toHaveValue("");
     const secondMessage = (await readMessages()).find(
@@ -2287,6 +2292,19 @@ test("the first message edit persists after stopped generation with or without a
     expect(secondMessage).toBeTruthy();
     await editMessageOnce(secondMessage!.id, "Edited on the first save with cleared draft");
 
+    await input.fill("Sent text must stay cleared when stopped before the reply");
+    await sendButton.click();
+    await expect(input).toHaveValue("");
+    await stopCurrentGeneration(3);
+    await expect(input).toHaveValue("");
+    await expect
+      .poll(async () =>
+        (await readMessages()).some(
+          (message) => message.role === "user" && message.content === "Sent text must stay cleared when stopped before the reply",
+        ),
+      )
+      .toBe(true);
+
     await page.reload();
     await expect(page.locator(`[data-message-id="${firstMessage!.id}"]`)).toContainText(
       "Edited on the first save with retained draft",
@@ -2294,6 +2312,7 @@ test("the first message edit persists after stopped generation with or without a
     await expect(page.locator(`[data-message-id="${secondMessage!.id}"]`)).toContainText(
       "Edited on the first save with cleared draft",
     );
+    await expect(page.getByText("Sent text must stay cleared when stopped before the reply", { exact: true })).toBeVisible();
   } finally {
     for (const response of openProviderResponses) response.end();
     await Promise.allSettled([
@@ -3116,7 +3135,7 @@ test("legacy browser records are cleaned while extension imports stay locked", a
         };
       }),
     )
-    .toEqual({ version: 84, hasExtensionRecords: false, hasCleanupFlag: false });
+    .toEqual({ version: 87, hasExtensionRecords: false, hasCleanupFlag: false });
 
   expect(
     await page.evaluate(
@@ -6687,7 +6706,7 @@ test("Game setup only shows features owned by installed agents", async ({ page, 
       body: JSON.stringify({ scannedAt: "2026-07-14T00:00:00.000Z", count: 0, assets: {}, byCategory: {} }),
     });
   });
-  await page.route("**/api/backgrounds/file/Black.jpg", async (route) => {
+  await page.route("**/api/backgrounds/file/Black.jpg**", async (route) => {
     await route.fulfill({
       status: 200,
       contentType: "image/gif",
@@ -7015,7 +7034,7 @@ test("Roleplay and Game chat settings link empty agent libraries to Download Age
       body: JSON.stringify({ scannedAt: "2026-07-14T00:00:00.000Z", count: 0, assets: {}, byCategory: {} }),
     });
   });
-  await page.route("**/api/backgrounds/file/Black.jpg", async (route) => {
+  await page.route("**/api/backgrounds/file/Black.jpg**", async (route) => {
     await route.fulfill({
       status: 200,
       contentType: "image/gif",
@@ -7120,7 +7139,7 @@ test("Illustrator owns conditional media subsections and agent removal stays awa
       body: JSON.stringify({ entries: [], budgetSkippedEntries: [], totalTokens: 0, totalEntries: 0 }),
     });
   });
-  await page.route("**/api/backgrounds/file/Black.jpg", async (route) => {
+  await page.route("**/api/backgrounds/file/Black.jpg**", async (route) => {
     await route.fulfill({
       status: 200,
       contentType: "image/gif",
@@ -7368,7 +7387,7 @@ test("Hierarchical Maps settings stay inside the active agent entry", async ({ p
       body: JSON.stringify({ scannedAt: "2026-07-16T00:00:00.000Z", count: 0, assets: {}, byCategory: {} }),
     });
   });
-  await page.route("**/api/backgrounds/file/Black.jpg", async (route) => {
+  await page.route("**/api/backgrounds/file/Black.jpg**", async (route) => {
     await route.fulfill({
       status: 200,
       contentType: "image/gif",
@@ -7462,7 +7481,7 @@ test("Roleplay setup points empty agent libraries to the Agents tab", async ({ p
   await page.route("**/api/agents", async (route) => {
     await route.fulfill({ status: 200, contentType: "application/json", body: "[]" });
   });
-  await page.route("**/api/backgrounds/file/Black.jpg", async (route) => {
+  await page.route("**/api/backgrounds/file/Black.jpg**", async (route) => {
     await route.fulfill({
       status: 200,
       contentType: "image/gif",
@@ -10226,7 +10245,7 @@ test("mobile Game keeps CYOA usable above four HUD widgets", async ({ page, requ
         body: JSON.stringify({ scannedAt: "2026-07-16T00:00:00.000Z", count: 0, assets: {}, byCategory: {} }),
       });
     });
-    await page.route("**/api/backgrounds/file/Black.jpg", async (route) => {
+    await page.route("**/api/backgrounds/file/Black.jpg**", async (route) => {
       await route.fulfill({
         status: 200,
         contentType: "image/gif",
@@ -10390,6 +10409,7 @@ test("Background rows keep long tag lists collapsed without crowding desktop con
   await page.keyboard.press("Enter");
   await expect(backgroundTagsToggle).toHaveAttribute("aria-expanded", "true");
   await expect(backgroundRow.getByText("quarantine berth", { exact: true })).toBeVisible();
+  await backgroundTagsToggle.focus();
   await page.keyboard.press("Enter");
   await expect(backgroundTagsToggle).toHaveAttribute("aria-expanded", "false");
   await expect(backgroundRow.getByText("quarantine berth", { exact: true })).toHaveCount(0);
@@ -10423,7 +10443,7 @@ test("Roleplay displays a selected background when its file route is GET-only", 
         ]),
       });
     });
-    await page.route(`**${backgroundUrl}`, async (route) => {
+    await page.route(`**${backgroundUrl}**`, async (route) => {
       requestedMethods.push(route.request().method());
       if (route.request().method() !== "GET") {
         await route.fulfill({ status: 405, body: "" });
@@ -10453,7 +10473,7 @@ test("Roleplay displays a selected background when its file route is GET-only", 
           ),
       )
       .toBe(true);
-    await page.locator(`img[src="${backgroundUrl}"]`).locator("..").click();
+    await page.locator(`img[src^="${backgroundUrl}"]`).locator("..").click();
 
     await expect
       .poll(async () =>
@@ -10472,8 +10492,8 @@ test("Roleplay displays a selected background when its file route is GET-only", 
       .toBe(true);
 
     const roleplaySurface = page.locator('[data-chat-mode="roleplay"]');
-    const activeBackground = page.locator(`img.mari-background[src="${backgroundUrl}"]`);
-    await expect(activeBackground).toHaveCSS("object-fit", testInfo.project.name.includes("mobile") ? "cover" : "fill");
+    const activeBackground = page.locator(`img.mari-background[src^="${backgroundUrl}"]`);
+    await expect(activeBackground).toHaveCSS("object-fit", "cover");
     const expectBackgroundToFitRoleplaySurface = async () => {
       await expect
         .poll(async () => {
@@ -10543,7 +10563,7 @@ test("Background library organization works with desktop drag and touch drag", a
     await page.getByRole("button", { name: /Tags \(/ }).click();
     await page.getByRole("button", { name: "smoke-folder", exact: true }).click();
 
-    const backgroundRow = page.locator(`[data-background-id="${backgroundId}"]`);
+    const backgroundRow = page.locator(`[data-background-id="${backgroundId}"]:not([aria-hidden="true"])`);
     await expect(backgroundRow).toBeVisible();
     const backgroundActions = backgroundRow.locator("[data-background-actions]");
     const defaultToggle = backgroundRow.locator("[data-background-default-toggle]");
@@ -10584,42 +10604,63 @@ test("Background library organization works with desktop drag and touch drag", a
     const folder = page.locator(`[data-background-folder-id="${folderId}"]`);
     await expect(folder).toBeVisible();
     if (testInfo.project.name.includes("mobile")) {
+      const dragHandle = backgroundRow.getByTitle(/^Drag /);
+      const startRect = await dragHandle.boundingBox();
+      expect(startRect).not.toBeNull();
+      const start = {
+        x: startRect!.x + startRect!.width / 2,
+        y: startRect!.y + startRect!.height / 2,
+      };
+      await dragHandle.evaluate((handle, point) => {
+        const touch = { identifier: 1, target: handle, clientX: point.x, clientY: point.y };
+        const event = new Event("touchstart", { bubbles: true, cancelable: true });
+        Object.defineProperties(event, {
+          touches: { value: [touch] },
+          changedTouches: { value: [touch] },
+        });
+        handle.dispatchEvent(event);
+      }, start);
+      await expect(backgroundRow).toHaveAttribute("draggable", "false");
+      await page.waitForTimeout(350);
+      await expect(backgroundRow).toHaveClass(/opacity-50/);
+      await folder.scrollIntoViewIfNeeded();
+      const targetRect = await folder.boundingBox();
+      expect(targetRect).not.toBeNull();
+      const end = {
+        x: targetRect!.x + targetRect!.width / 2,
+        y: targetRect!.y + Math.min(targetRect!.height / 2, 20),
+      };
+      await expect
+        .poll(() =>
+          page.evaluate(
+            ({ point, targetFolderId }) =>
+              document
+                .elementFromPoint(point.x, point.y)
+                ?.closest<HTMLElement>("[data-background-folder-id]")
+                ?.dataset.backgroundFolderId === targetFolderId,
+            { point: end, targetFolderId: folderId! },
+          ),
+        )
+        .toBe(true);
       await page.evaluate(
-        ({ sourceId, targetFolderId }) => {
+        ({ sourceId, point }) => {
           const source = document.querySelector<HTMLElement>(`[data-background-id="${sourceId}"]`);
-          const handle = source?.querySelector<HTMLElement>("button[title^='Drag']");
-          const target = document.querySelector<HTMLElement>(`[data-background-folder-id="${targetFolderId}"]`);
-          if (!source || !handle || !target) throw new Error("Background touch drag fixtures were not rendered");
-          const startRect = handle.getBoundingClientRect();
-          const targetRect = target.getBoundingClientRect();
-          const start = new Touch({
-            identifier: 1,
-            target: handle,
-            clientX: startRect.left + startRect.width / 2,
-            clientY: startRect.top + startRect.height / 2,
+          if (!source) throw new Error("Background touch drag source was not rendered");
+          const touch = { identifier: 1, target: source, clientX: point.x, clientY: point.y };
+          const move = new Event("touchmove", { bubbles: true, cancelable: true });
+          Object.defineProperties(move, {
+            touches: { value: [touch] },
+            changedTouches: { value: [touch] },
           });
-          const end = new Touch({
-            identifier: 1,
-            target: handle,
-            clientX: targetRect.left + targetRect.width / 2,
-            clientY: targetRect.top + Math.min(targetRect.height / 2, 20),
+          window.dispatchEvent(move);
+          const end = new Event("touchend", { bubbles: true, cancelable: true });
+          Object.defineProperties(end, {
+            touches: { value: [] },
+            changedTouches: { value: [touch] },
           });
-          handle.dispatchEvent(
-            new TouchEvent("touchstart", {
-              bubbles: true,
-              cancelable: true,
-              touches: [start],
-              changedTouches: [start],
-            }),
-          );
-          window.dispatchEvent(
-            new TouchEvent("touchmove", { bubbles: true, cancelable: true, touches: [end], changedTouches: [end] }),
-          );
-          window.dispatchEvent(
-            new TouchEvent("touchend", { bubbles: true, cancelable: true, touches: [], changedTouches: [end] }),
-          );
+          window.dispatchEvent(end);
         },
-        { sourceId: backgroundId, targetFolderId: folderId! },
+        { sourceId: backgroundId, point: end },
       );
     } else {
       await backgroundRow.dragTo(folder);

--- a/e2e/global-setup.mjs
+++ b/e2e/global-setup.mjs
@@ -1,8 +1,9 @@
 import { mkdirSync, rmSync } from "node:fs";
-import { resolve } from "node:path";
+import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
-const dataDir = resolve(process.cwd(), ".tmp/playwright-data");
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const dataDir = resolve(repoRoot, ".tmp/playwright-data");
 
 function resetPlaywrightData() {
   rmSync(dataDir, { recursive: true, force: true });

--- a/e2e/global-setup.mjs
+++ b/e2e/global-setup.mjs
@@ -1,8 +1,21 @@
 import { mkdirSync, rmSync } from "node:fs";
 import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
 
-export default async function globalSetup() {
-  const dataDir = resolve(process.cwd(), ".tmp/playwright-data");
+const dataDir = resolve(process.cwd(), ".tmp/playwright-data");
+
+function resetPlaywrightData() {
   rmSync(dataDir, { recursive: true, force: true });
   mkdirSync(dataDir, { recursive: true });
+}
+
+export default async function globalSetup() {
+  // The web-server command resets this directory before the server opens it.
+  // Removing a live file-backed store here races startup and leaves stale state
+  // in memory, so global setup only guarantees that the directory exists.
+  mkdirSync(dataDir, { recursive: true });
+}
+
+if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  resetPlaywrightData();
 }

--- a/packages/client/src/components/chat/ChatArea.tsx
+++ b/packages/client/src/components/chat/ChatArea.tsx
@@ -277,8 +277,19 @@ function isMediaPromptPreviewTimeout(error: unknown): boolean {
   return error instanceof DOMException && error.name === "TimeoutError";
 }
 
-const shouldIgnoreIntuitiveSwipeTarget = (target: EventTarget | null): boolean => {
+const shouldIgnoreIntuitiveSwipeTarget = (
+  target: EventTarget | null,
+  { allowEmptyMainComposer = false }: { allowEmptyMainComposer?: boolean } = {},
+): boolean => {
   if (!(target instanceof Element)) return false;
+  if (
+    allowEmptyMainComposer &&
+    target instanceof HTMLTextAreaElement &&
+    target.dataset.chatComposer === "true" &&
+    target.value.length === 0
+  ) {
+    return false;
+  }
   return Boolean(
     target.closest(
       [
@@ -2265,7 +2276,8 @@ export function ChatArea() {
       if (event.defaultPrevented) return;
 
       if (event.key !== "ArrowLeft" && event.key !== "ArrowRight") return;
-      if (shouldIgnoreIntuitiveSwipeTarget(event.target)) return;
+      if (event.altKey || event.ctrlKey || event.metaKey || event.shiftKey) return;
+      if (shouldIgnoreIntuitiveSwipeTarget(event.target, { allowEmptyMainComposer: true })) return;
 
       if (event.repeat && event.key === "ArrowRight" && latestAssistantMessageForSwipes) {
         const swipeCount = latestAssistantMessageForSwipes.swipeCount ?? 1;

--- a/packages/client/src/components/chat/ChatInput.tsx
+++ b/packages/client/src/components/chat/ChatInput.tsx
@@ -92,16 +92,8 @@ const TEXT_ATTACHMENT_EXTENSIONS = new Set([
   "yml",
 ]);
 const PDF_ATTACHMENT_MIME_TYPE = "application/pdf";
-const QUOTE_INPUT_TRIGGER_RE = /["'\u2018\u2019\u201a\u201b\u201c\u201d\u201e\u201f]/;
 const ROLEPLAY_INPUT_RESIZE_IDLE_MS = 150;
 const ROLEPLAY_INPUT_DELETE_RESIZE_IDLE_MS = 450;
-
-function shouldFormatQuoteInput(event: FormEvent<HTMLTextAreaElement> | undefined, value: string): boolean {
-  const inputEvent = event?.nativeEvent as InputEvent | undefined;
-  const inputType = typeof inputEvent?.inputType === "string" ? inputEvent.inputType : "";
-  if (inputType.startsWith("delete")) return false;
-  return QUOTE_INPUT_TRIGGER_RE.test(inputEvent?.data ?? value);
-}
 
 function getFileExtension(fileName: string): string {
   const match = fileName.toLowerCase().match(/\.([a-z0-9]+)$/);
@@ -1488,7 +1480,7 @@ export const ChatInput = memo(function ChatInput({
     if (!el) return;
     const inputEvent = event?.nativeEvent as InputEvent | undefined;
     const isDeleting = inputEvent?.inputType?.startsWith("delete") === true;
-    const fixed = shouldFormatQuoteInput(event, el.value) ? applyTextareaQuoteFormat(el, quoteFormat) : el.value;
+    const fixed = applyTextareaQuoteFormat(el, quoteFormat, inputEvent);
     syncInputState(fixed);
 
     // Keep draft in sync so it survives remounts (debounced to avoid store churn)

--- a/packages/client/src/components/chat/ChatInput.tsx
+++ b/packages/client/src/components/chat/ChatInput.tsx
@@ -1959,6 +1959,7 @@ export const ChatInput = memo(function ChatInput({
         {/* Text input */}
         <textarea
           ref={textareaRef}
+          data-chat-composer="true"
           onInput={handleInput}
           onKeyDown={handleKeyDown}
           onPaste={handlePaste}

--- a/packages/client/src/components/chat/ChatMessage.tsx
+++ b/packages/client/src/components/chat/ChatMessage.tsx
@@ -588,7 +588,7 @@ const EditTextarea = memo(function EditTextarea({
         defaultValue={formatTextQuotes(initialContent, quoteFormat)}
         rows={1}
         onInput={(event) => {
-          applyTextareaQuoteFormat(event.currentTarget, quoteFormat);
+          applyTextareaQuoteFormat(event.currentTarget, quoteFormat, event.nativeEvent as InputEvent);
           autoResize();
         }}
         onKeyDown={(e) => {

--- a/packages/client/src/components/chat/ChatRoleplaySurface.tsx
+++ b/packages/client/src/components/chat/ChatRoleplaySurface.tsx
@@ -1290,6 +1290,8 @@ export function ChatRoleplaySurface({
   const expandedAuthorNotesOpen = authorNotesOpenOwner === "expanded";
   const compactAuthorNotesOpen = authorNotesOpenOwner === "compact";
   const keyboardOpen = useChatKeyboardOpen();
+  const ambientVisualsPaused =
+    generationVisualsPaused || (isMobileToolbarViewport && (keyboardOpen || hasMobileDraftInput));
   const shouldKeepMobileComposerOpen = keyboardOpen || hasLiveStream || hasMobileDraftInput || isFetchingNextPage;
 
   useEffect(() => {
@@ -1510,7 +1512,7 @@ export function ChatRoleplaySurface({
         className={cn(
           "rpg-chat-area mari-chat-area mari-card-css relative flex flex-1 flex-col overflow-hidden",
           roleplayReducedPaintEffects && "mari-rp-reduced-paint",
-          generationVisualsPaused && "mari-generation-render-paused",
+          ambientVisualsPaused && "mari-generation-render-paused",
         )}
         data-chat-mode="roleplay"
         style={{ isolation: "isolate" }}
@@ -1518,7 +1520,7 @@ export function ChatRoleplaySurface({
         <CrossfadeBackground url={chatBackground} blurPx={chatBackgroundBlur} />
         <div className="rpg-overlay absolute inset-0" />
         <div className="rpg-vignette pointer-events-none absolute inset-0" />
-        {weatherEffects && <WeatherEffectsConnected paused={generationVisualsPaused} />}
+        {weatherEffects && <WeatherEffectsConnected paused={ambientVisualsPaused} />}
         {showSpriteOverlay && (
           <Suspense fallback={null}>
             <SpriteOverlay

--- a/packages/client/src/components/chat/ChatSettingsDrawer.tsx
+++ b/packages/client/src/components/chat/ChatSettingsDrawer.tsx
@@ -9181,12 +9181,14 @@ export function ChatSettingsDrawer({
           <div style={{ order: CHAT_SETTINGS_ORDER.functionCalling }}>
             <FunctionCallingSection
               enableTools={metadata.enableTools as boolean | undefined}
+              forceToolCall={metadata.forceToolCall as boolean | undefined}
               activeToolIds={activeToolIds}
               pendingToolIds={pendingToolIds}
               availableTools={availableTools}
               showToolPicker={showToolPicker}
               toolSearch={toolSearch}
               onEnableToolsChange={(enableTools) => updateMeta.mutate({ id: chat.id, enableTools })}
+              onForceToolCallChange={(forceToolCall) => updateMeta.mutate({ id: chat.id, forceToolCall })}
               onToggleTool={toggleTool}
               onShowToolPickerChange={setShowToolPicker}
               onToolSearchChange={setToolSearch}

--- a/packages/client/src/components/chat/ConversationInput.tsx
+++ b/packages/client/src/components/chat/ConversationInput.tsx
@@ -2227,6 +2227,7 @@ export function ConversationInput({
 
         <textarea
           ref={textareaRef}
+          data-chat-composer="true"
           placeholder={inputPlaceholder}
           rows={1}
           onInput={handleInput}

--- a/packages/client/src/components/chat/ConversationInput.tsx
+++ b/packages/client/src/components/chat/ConversationInput.tsx
@@ -99,7 +99,6 @@ const TEXT_ATTACHMENT_EXTENSIONS = new Set([
 const PDF_ATTACHMENT_MIME_TYPE = "application/pdf";
 
 const CONVERSATION_HIDDEN_SLASH_COMMANDS = new Set(["impersonate", "impersonate_prompt"]);
-const QUOTE_INPUT_TRIGGER_RE = /["'\u2018\u2019\u201a\u201b\u201c\u201d\u201e\u201f]/;
 
 type MobilePickerTab = ConversationMediaPickerTabId;
 
@@ -139,13 +138,6 @@ const CONVERSATION_STATUS_COMPLETIONS = [
 
 function isConversationHiddenSlashCommand(command: SlashCommand): boolean {
   return CONVERSATION_HIDDEN_SLASH_COMMANDS.has(command.name);
-}
-
-function shouldFormatQuoteInput(event: FormEvent<HTMLTextAreaElement> | undefined, value: string): boolean {
-  const inputEvent = event?.nativeEvent as InputEvent | undefined;
-  const inputType = typeof inputEvent?.inputType === "string" ? inputEvent.inputType : "";
-  if (inputType.startsWith("delete")) return false;
-  return QUOTE_INPUT_TRIGGER_RE.test(value);
 }
 
 function quoteSlashArgument(value: string): string {
@@ -1617,7 +1609,7 @@ export function ConversationInput({
     (event: FormEvent<HTMLTextAreaElement>) => {
       const el = textareaRef.current;
       if (!el) return;
-      const formatted = shouldFormatQuoteInput(event, el.value) ? applyTextareaQuoteFormat(el, quoteFormat) : el.value;
+      const formatted = applyTextareaQuoteFormat(el, quoteFormat, event.nativeEvent as InputEvent);
       // Debounced resize to reduce layout reflows during fast typing
       if (resizeTimerRef.current) clearTimeout(resizeTimerRef.current);
       resizeTimerRef.current = setTimeout(() => {

--- a/packages/client/src/components/chat/ConversationMessageShared.tsx
+++ b/packages/client/src/components/chat/ConversationMessageShared.tsx
@@ -464,7 +464,7 @@ export function ConversationMessageEditForm({
         ref={editRef}
         value={editValue}
         onChange={(e) => {
-          const nextValue = applyTextareaQuoteFormat(e.currentTarget, quoteFormat);
+          const nextValue = applyTextareaQuoteFormat(e.currentTarget, quoteFormat, e.nativeEvent as InputEvent);
           onValueChange(nextValue);
           const el = e.target;
           el.style.height = "auto";

--- a/packages/client/src/components/presets/PresetEditor.tsx
+++ b/packages/client/src/components/presets/PresetEditor.tsx
@@ -828,7 +828,8 @@ function PromptsTab({
   const { t: localizeUi } = useUiTranslation();
   const quoteFormat = useUIStore((s) => s.quoteFormat);
   const formatPrompt = useCallback(
-    (textarea: HTMLTextAreaElement) => applyTextareaQuoteFormat(textarea, quoteFormat),
+    (textarea: HTMLTextAreaElement, inputEvent: InputEvent) =>
+      applyTextareaQuoteFormat(textarea, quoteFormat, inputEvent),
     [quoteFormat],
   );
 
@@ -2715,7 +2716,7 @@ function SectionContentTextarea({
       onBlur={handleBlur}
       onFocus={handleFocus}
       onExpandedClose={commit}
-      formatOnChange={(textarea) => applyTextareaQuoteFormat(textarea, quoteFormat)}
+      formatOnChange={(textarea, inputEvent) => applyTextareaQuoteFormat(textarea, quoteFormat, inputEvent)}
       title={sectionName ?localizeUi("ui.presets.sectioncontenttextarea.editValue1", { value1: sectionName }) :localizeUi("ui.presets.sectioncontenttextarea.editPrompt")}
       className="mari-editor-field min-h-[7.5rem] w-full p-2.5 font-mono text-xs"
       placeholder={localizeUi("ui.presets.sectioncontenttextarea.promptContentSupportsUserCharCommentTrimMacros")}

--- a/packages/client/src/components/presets/PresetEditor.tsx
+++ b/packages/client/src/components/presets/PresetEditor.tsx
@@ -2665,7 +2665,6 @@ function SectionContentTextarea({
   const [local, setLocal] = useState(value);
   const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const focusedRef = useRef(false);
-  const formatQuotes = useQuoteFormatter();
   const quoteFormat = useUIStore((s) => s.quoteFormat);
 
   // Only sync from parent when not actively editing
@@ -2683,7 +2682,7 @@ function SectionContentTextarea({
 
   // Debounced auto-save while typing (800ms)
   const handleChange = (nextRawValue: string) => {
-    const nextValue = formatQuotes(nextRawValue);
+    const nextValue = nextRawValue;
     setLocal(nextValue);
     if (timeoutRef.current) clearTimeout(timeoutRef.current);
     timeoutRef.current = setTimeout(() => {

--- a/packages/client/src/components/ui/MacroTextarea.tsx
+++ b/packages/client/src/components/ui/MacroTextarea.tsx
@@ -64,7 +64,7 @@ interface ExpandedMacroEditorProps {
   onChange: (value: string) => void;
   onClose: () => void;
   placeholder?: string;
-  formatOnChange?: (textarea: HTMLTextAreaElement) => string;
+  formatOnChange?: (textarea: HTMLTextAreaElement, inputEvent: InputEvent) => string;
 }
 
 function ExpandedMacroEditor({
@@ -107,7 +107,9 @@ function ExpandedMacroEditor({
 
   const handleChange = useCallback(
     (event: ChangeEvent<HTMLTextAreaElement>) => {
-      const nextValue = formatOnChange ? formatOnChange(event.currentTarget) : event.currentTarget.value;
+      const nextValue = formatOnChange
+        ? formatOnChange(event.currentTarget, event.nativeEvent as InputEvent)
+        : event.currentTarget.value;
       setLocalValue(nextValue);
       onChange(nextValue);
     },
@@ -275,7 +277,7 @@ export interface MacroTextareaProps {
   toolbarClassName?: string;
   controlPaddingClassName?: string;
   toolbarExtra?: ReactNode;
-  formatOnChange?: (textarea: HTMLTextAreaElement) => string;
+  formatOnChange?: (textarea: HTMLTextAreaElement, inputEvent: InputEvent) => string;
   showMacroReference?: boolean;
   showExpand?: boolean;
   spellCheck?: boolean;
@@ -317,7 +319,11 @@ export function MacroTextarea({
 
   const handleChange = useCallback(
     (event: ChangeEvent<HTMLTextAreaElement>) => {
-      onChange(formatOnChange ? formatOnChange(event.currentTarget) : event.currentTarget.value);
+      onChange(
+        formatOnChange
+          ? formatOnChange(event.currentTarget, event.nativeEvent as InputEvent)
+          : event.currentTarget.value,
+      );
     },
     [formatOnChange, onChange],
   );

--- a/packages/client/src/features/chat-settings/sections/FunctionCallingSection.tsx
+++ b/packages/client/src/features/chat-settings/sections/FunctionCallingSection.tsx
@@ -13,12 +13,14 @@ export interface FunctionToolOption {
 
 interface FunctionCallingSectionProps {
   enableTools: boolean | undefined;
+  forceToolCall: boolean | undefined;
   activeToolIds: string[];
   pendingToolIds: string[];
   availableTools: FunctionToolOption[];
   showToolPicker: boolean;
   toolSearch: string;
   onEnableToolsChange: (enabled: boolean) => void;
+  onForceToolCallChange: (enabled: boolean) => void;
   onToggleTool: (toolId: string) => void;
   onShowToolPickerChange: (show: boolean) => void;
   onToolSearchChange: (value: string) => void;
@@ -29,12 +31,14 @@ interface FunctionCallingSectionProps {
 
 export function FunctionCallingSection({
   enableTools,
+  forceToolCall,
   activeToolIds,
   pendingToolIds,
   availableTools,
   showToolPicker,
   toolSearch,
   onEnableToolsChange,
+  onForceToolCallChange,
   onToggleTool,
   onShowToolPickerChange,
   onToolSearchChange,
@@ -44,7 +48,9 @@ export function FunctionCallingSection({
 }: FunctionCallingSectionProps) {
   const { t: localizeUi } = useUiTranslation();
   const inactiveTools = availableTools.filter((tool) => !activeToolIds.includes(tool.id));
-  const visibleInactiveTools = inactiveTools.filter((tool) => tool.name.toLowerCase().includes(toolSearch.toLowerCase()));
+  const visibleInactiveTools = inactiveTools.filter((tool) =>
+    tool.name.toLowerCase().includes(toolSearch.toLowerCase()),
+  );
 
   return (
     <ChatSettingsSection
@@ -71,14 +77,30 @@ export function FunctionCallingSection({
         />
         <p className="text-[0.625rem] text-[var(--muted-foreground)] px-1">
           {enableTools
-            ?localizeUi("ui.chatSettings.functioncallingsection.ifEnabledThisChatCanUseGloballyEnabledTools")
-            :localizeUi("ui.chatSettings.functioncallingsection.ifDisabledNoFunctionsWillBeAvailable")}
+            ? localizeUi("ui.chatSettings.functioncallingsection.ifEnabledThisChatCanUseGloballyEnabledTools")
+            : localizeUi("ui.chatSettings.functioncallingsection.ifDisabledNoFunctionsWillBeAvailable")}
         </p>
 
         {enableTools && (
           <>
+            <SettingsSwitch
+              label={localizeUi("ui.chatSettings.functioncallingsection.forceToCallTool")}
+              description={localizeUi("ui.chatSettings.functioncallingsection.forceToCallToolDescription")}
+              checked={!!forceToolCall}
+              onChange={onForceToolCallChange}
+              labelPosition="start"
+              className={cn(
+                "justify-between rounded-lg px-3 py-2.5 text-left",
+                forceToolCall
+                  ? "bg-[var(--primary)]/10 ring-1 ring-[var(--primary)]/30"
+                  : "bg-[var(--secondary)] hover:bg-[var(--accent)]",
+              )}
+              labelClassName="text-xs font-medium"
+            />
             {activeToolIds.length === 0 ? (
-              <p className="text-[0.6875rem] text-[var(--muted-foreground)] px-1">{localizeUi("ui.chatSettings.functioncallingsection.allGloballyEnabledToolsAreAvailableToThisChat")}</p>
+              <p className="text-[0.6875rem] text-[var(--muted-foreground)] px-1">
+                {localizeUi("ui.chatSettings.functioncallingsection.allGloballyEnabledToolsAreAvailableToThisChat")}
+              </p>
             ) : (
               <div className="flex max-h-40 flex-col gap-1 overflow-y-auto">
                 {activeToolIds.map((toolId) => {
@@ -117,13 +139,15 @@ export function FunctionCallingSection({
                   }}
                   className="flex w-full items-center justify-center gap-1.5 rounded-lg border border-dashed border-[var(--border)] px-3 py-2 text-xs text-[var(--muted-foreground)] transition-colors hover:border-[var(--primary)]/40 hover:text-[var(--primary)]"
                 >
-                  <Plus size="0.75rem" /> {localizeUi("ui.chatSettings.functioncallingsection.addFunctions")}</button>
+                  <Plus size="0.75rem" /> {localizeUi("ui.chatSettings.functioncallingsection.addFunctions")}
+                </button>
                 <button
                   type="button"
                   onClick={onCreateCustomTool}
                   className="flex w-full items-center justify-center gap-1.5 rounded-lg border border-dashed border-[var(--border)] px-3 py-2 text-xs text-[var(--muted-foreground)] transition-colors hover:border-[var(--primary)]/40 hover:text-[var(--primary)]"
                 >
-                  <FilePlus2 size="0.75rem" /> {localizeUi("ui.chatSettings.functioncallingsection.newCustomFunction")}</button>
+                  <FilePlus2 size="0.75rem" /> {localizeUi("ui.chatSettings.functioncallingsection.newCustomFunction")}
+                </button>
               </div>
             ) : (
               <PickerDropdown
@@ -138,7 +162,9 @@ export function FunctionCallingSection({
                       onClick={onCreateCustomTool}
                       className="flex w-full items-center justify-center gap-1.5 rounded-lg px-3 py-2 text-xs font-medium text-[var(--muted-foreground)] ring-1 ring-[var(--border)] transition-colors hover:bg-[var(--accent)] hover:text-[var(--foreground)]"
                     >
-                      <FilePlus2 size="0.75rem" /> {localizeUi("ui.chatSettings.functioncallingsection.newCustomFunction")}</button>
+                      <FilePlus2 size="0.75rem" />{" "}
+                      {localizeUi("ui.chatSettings.functioncallingsection.newCustomFunction")}
+                    </button>
                     <button
                       type="button"
                       disabled={pendingToolIds.length === 0}
@@ -147,8 +173,11 @@ export function FunctionCallingSection({
                     >
                       <Plus size="0.75rem" />
                       {pendingToolIds.length > 0
-                        ?localizeUi("ui.chatSettings.functioncallingsection.addValue1FunctionValue2", { value1: pendingToolIds.length, value2: pendingToolIds.length === 1 ? "" :localizeUi("ui.noodle.stageprofileview.s") })
-                        :localizeUi("ui.chatSettings.functioncallingsection.addSelected")}
+                        ? localizeUi("ui.chatSettings.functioncallingsection.addValue1FunctionValue2", {
+                            value1: pendingToolIds.length,
+                            value2: pendingToolIds.length === 1 ? "" : localizeUi("ui.noodle.stageprofileview.s"),
+                          })
+                        : localizeUi("ui.chatSettings.functioncallingsection.addSelected")}
                     </button>
                   </div>
                 }
@@ -160,9 +189,7 @@ export function FunctionCallingSection({
                       key={tool.id}
                       onClick={() =>
                         onPendingToolIdsChange((previous) =>
-                          previous.includes(tool.id)
-                            ? previous.filter((id) => id !== tool.id)
-                            : [...previous, tool.id],
+                          previous.includes(tool.id) ? previous.filter((id) => id !== tool.id) : [...previous, tool.id],
                         )
                       }
                       className={cn(
@@ -173,7 +200,9 @@ export function FunctionCallingSection({
                       <div
                         className={cn(
                           "flex h-4 w-4 shrink-0 items-center justify-center rounded border transition-colors",
-                          selected ? "border-[var(--primary)] bg-[var(--primary)] text-white" : "border-[var(--border)]",
+                          selected
+                            ? "border-[var(--primary)] bg-[var(--primary)] text-white"
+                            : "border-[var(--border)]",
                         )}
                       >
                         {selected && <Check size="0.625rem" />}
@@ -189,7 +218,9 @@ export function FunctionCallingSection({
                 })}
                 {visibleInactiveTools.length === 0 && (
                   <p className="px-3 py-2 text-[0.6875rem] text-[var(--muted-foreground)]">
-                    {inactiveTools.length === 0 ?localizeUi("ui.chatSettings.functioncallingsection.allFunctionsAlreadyAdded") :localizeUi("ui.lorebooks.linkedresourcepicker.noMatches")}
+                    {inactiveTools.length === 0
+                      ? localizeUi("ui.chatSettings.functioncallingsection.allFunctionsAlreadyAdded")
+                      : localizeUi("ui.lorebooks.linkedresourcepicker.noMatches")}
                   </p>
                 )}
               </PickerDropdown>

--- a/packages/client/src/hooks/use-generate.ts
+++ b/packages/client/src/hooks/use-generate.ts
@@ -1165,6 +1165,7 @@ export function useGenerate() {
 
       // Create an AbortController so the stop button can cancel this generation.
       const abortController = new AbortController();
+      const submittedUserTurn = params.userMessage !== undefined;
       try {
         useChatStore.getState().setAbortController(params.chatId, abortController);
         useChatStore.getState().setBackgroundIllustration(params.chatId, false);
@@ -2736,7 +2737,7 @@ export function useGenerate() {
         flushLeadingSpeakerPrefix();
         flushTypewriterBuffer();
         // Abort is intentional — don't log or toast
-        if (isAbortError(error)) return receivedContent || spatialTransitionCommitted;
+        if (isAbortError(error)) return submittedUserTurn || receivedContent || spatialTransitionCommitted;
         if (isPassiveStreamDisconnect(error, pageWasHiddenDuringStream, abortController.signal)) {
           passiveStreamRecovered = true;
           if (isActiveChat()) useChatStore.getState().setGenerationPhase("Finishing in background...");
@@ -2765,7 +2766,9 @@ export function useGenerate() {
               );
             }
           }
-          return abortController.signal.aborted ? receivedContent || spatialTransitionCommitted : true;
+          return abortController.signal.aborted
+            ? submittedUserTurn || receivedContent || spatialTransitionCommitted
+            : true;
         }
         if (params.pendingSpatialTransition) {
           const payload =

--- a/packages/client/src/lib/textarea-quotes.ts
+++ b/packages/client/src/lib/textarea-quotes.ts
@@ -2,8 +2,27 @@ import { formatTextQuotes, type QuoteFormat } from "@marinara-engine/shared";
 import { captureTextSelection, restoreTextSelectionAfterRender } from "./text-selection";
 
 const pendingSelectionRestores = new WeakMap<HTMLTextAreaElement, () => void>();
+const QUOTE_INPUT_TRIGGER_RE = /["'\u2018\u2019\u201a\u201b\u201c\u201d\u201e\u201f]/;
 
-export function applyTextareaQuoteFormat(textarea: HTMLTextAreaElement, quoteFormat: QuoteFormat): string {
+export function shouldFormatTextareaQuotes(inputEvent: InputEvent | undefined, value: string): boolean {
+  if (!inputEvent) return QUOTE_INPUT_TRIGGER_RE.test(value);
+  const inputType = typeof inputEvent.inputType === "string" ? inputEvent.inputType : "";
+  if (inputEvent.isComposing || inputType === "insertCompositionText" || inputType.startsWith("delete")) {
+    return false;
+  }
+  if (typeof inputEvent.data === "string") return QUOTE_INPUT_TRIGGER_RE.test(inputEvent.data);
+  if (inputType === "insertFromPaste" || inputType === "insertFromDrop" || inputType === "insertFromYank") {
+    return QUOTE_INPUT_TRIGGER_RE.test(value);
+  }
+  return false;
+}
+
+export function applyTextareaQuoteFormat(
+  textarea: HTMLTextAreaElement,
+  quoteFormat: QuoteFormat,
+  inputEvent?: InputEvent,
+): string {
+  if (!shouldFormatTextareaQuotes(inputEvent, textarea.value)) return textarea.value;
   pendingSelectionRestores.get(textarea)?.();
   pendingSelectionRestores.delete(textarea);
 

--- a/packages/client/src/localization/locales/en.json
+++ b/packages/client/src/localization/locales/en.json
@@ -3324,6 +3324,8 @@
   "ui.chatSettings.functioncallingsection.allGloballyEnabledToolsAreAvailableToThisChat": "All globally enabled tools are available to this chat. Add tools below to restrict this chat to a specific set.",
   "ui.chatSettings.functioncallingsection.allowAiToCallFunctionsDiceRollsGameState": "Allow AI to call functions (dice rolls, game state, etc.)",
   "ui.chatSettings.functioncallingsection.enableToolUse": "Enable Tool Use",
+  "ui.chatSettings.functioncallingsection.forceToCallTool": "Force To Call Tool",
+  "ui.chatSettings.functioncallingsection.forceToCallToolDescription": "Require a compatible model to call one enabled function before it can answer. Some models may ignore this request.",
   "ui.chatSettings.functioncallingsection.functionCalling": "Function Calling",
   "ui.chatSettings.functioncallingsection.ifDisabledNoFunctionsWillBeAvailable": "If disabled, no functions will be available.",
   "ui.chatSettings.functioncallingsection.ifEnabledThisChatCanUseGloballyEnabledTools": "If enabled, this chat can use globally enabled tools (or any tools you add below).",

--- a/packages/server/src/routes/generate.routes.ts
+++ b/packages/server/src/routes/generate.routes.ts
@@ -455,7 +455,10 @@ import {
 } from "../services/generation/agent-prompt-runtime.js";
 import { resolveAgentPipelineAgents } from "../services/generation/agent-resolution.js";
 import { createReplyFallbackNotifier } from "./generate/fallback-notification.js";
-import { resolveGenerationTools } from "../services/generation/tool-resolution-runtime.js";
+import {
+  resolveGenerationTools,
+  resolveMainGenerationToolChoice,
+} from "../services/generation/tool-resolution-runtime.js";
 import {
   buildCharacterMacroProfilesById,
   injectIdentityFallbackMessages,
@@ -5438,6 +5441,7 @@ export async function generateRoutes(app: FastifyInstance) {
                     minP: minP || undefined,
                     stop: stopSequences.length ? stopSequences : undefined,
                     tools: toolDefs,
+                    toolChoice: resolveMainGenerationToolChoice(chatMeta, round),
                     enableCaching: conn.enableCaching === "true",
                     anthropicExtendedCacheTtl: conn.anthropicExtendedCacheTtl === "true",
                     cachingAtDepth: conn.cachingAtDepth ?? 5,

--- a/packages/server/src/services/generation/tool-resolution-runtime.ts
+++ b/packages/server/src/services/generation/tool-resolution-runtime.ts
@@ -141,6 +141,13 @@ function booleanFalseText(value: unknown): boolean {
   return value === false || value === "false" || value === "0" || value === 0;
 }
 
+export function resolveMainGenerationToolChoice(
+  chatMetadata: Record<string, unknown>,
+  round: number,
+): "auto" | "required" {
+  return round === 0 && booleanText(chatMetadata.forceToolCall) ? "required" : "auto";
+}
+
 function isSpotifyMusicAgent(agent: ResolvedAgent): boolean {
   const settings = parseSettings(agent.settings);
   return (

--- a/packages/server/src/services/llm/base-provider.ts
+++ b/packages/server/src/services/llm/base-provider.ts
@@ -124,6 +124,8 @@ export interface ChatOptions {
   stop?: string[];
   /** Tool/function definitions for function calling */
   tools?: LLMToolDefinition[];
+  /** OpenAI-compatible tool selection policy for the current provider round. */
+  toolChoice?: "auto" | "required";
   /** Enable provider-native prompt caching when supported */
   enableCaching?: boolean;
   /** Anthropic only: use 1-hour prompt-cache TTL instead of the default 5-minute TTL */

--- a/packages/server/src/services/llm/providers/openai.provider.ts
+++ b/packages/server/src/services/llm/providers/openai.provider.ts
@@ -1100,7 +1100,10 @@ export class OpenAIProvider extends BaseLLMProvider {
 
     if (!suppressModelParameters) {
       if (this.shouldSendStopSequences(options.model) && options.stop?.length) body.stop = options.stop;
-      if (options.tools?.length && !options.forceTextualToolCalls) body.tools = options.tools;
+      if (options.tools?.length && !options.forceTextualToolCalls) {
+        body.tools = options.tools;
+        body.tool_choice = options.toolChoice ?? "auto";
+      }
       if (effectiveStream) body.stream_options = { include_usage: true };
 
       // o-series models never support temperature/topP; GPT-5.x only with effort=none
@@ -1378,7 +1381,7 @@ export class OpenAIProvider extends BaseLLMProvider {
       (!suppressModelParameters || this.allowsToolCalling)
     ) {
       body.tools = options.tools;
-      body.tool_choice = "auto";
+      body.tool_choice = options.toolChoice ?? "auto";
     }
 
     if (!suppressModelParameters) {
@@ -1936,9 +1939,11 @@ export class OpenAIProvider extends BaseLLMProvider {
       !isOpenAIChatGPT &&
       !suppressModelParameters &&
       options.tools?.length &&
+      !options.forceTextualToolCalls &&
       !this.isXAIMultiAgentModel(options.model)
     ) {
       body.tools = this.formatResponsesTools(options.tools);
+      body.tool_choice = options.toolChoice ?? "auto";
     }
 
     if (!isOpenAIChatGPT) {

--- a/packages/shared/src/types/chat.ts
+++ b/packages/shared/src/types/chat.ts
@@ -312,6 +312,8 @@ export interface ChatMetadata {
   customEmojiSelection?: CustomEmojiSelectionPrefs;
   /** Tool/function IDs scoped to this chat. Non-empty = only these tools are sent; empty = use all enabled tools. */
   activeToolIds: string[];
+  /** Require a compatible provider to call one enabled tool on the first tool round. */
+  forceToolCall?: boolean;
   /** Per-chat variable selections for preset variables (variableName → value or values) */
   presetChoices: Record<string, string | string[]>;
   /** Chat-wide string variables persisted by agent tool calls (key → value). */

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -31,9 +31,9 @@ export default defineConfig({
     process.env.PLAYWRIGHT_SKIP_WEBSERVER === "true"
       ? undefined
       : {
-          command: "pnpm dev",
+          command: "node ./e2e/global-setup.mjs && pnpm dev",
           url: baseURL,
-          reuseExistingServer: !process.env.CI,
+          reuseExistingServer: false,
           timeout: 180_000,
           env: {
             AUTO_CREATE_DEFAULT_CONNECTION: "false",

--- a/scripts/regressions/open-issues.regression.ts
+++ b/scripts/regressions/open-issues.regression.ts
@@ -1524,9 +1524,9 @@ assert.doesNotMatch(
   "selecting an already-installed theme should not require privileged loopback access",
 );
 assert.equal(
-  roleplaySurfaceSource.match(/object-fill object-center max-md:object-cover/gu)?.length,
+  roleplaySurfaceSource.match(/object-cover object-center/gu)?.length,
   2,
-  "both crossfade slots should preserve mobile background proportions without changing desktop sizing",
+  "both crossfade slots should cover their surface without stretching the background",
 );
 const playwrightWebServer = Array.isArray(playwrightConfig.webServer)
   ? playwrightConfig.webServer[0]
@@ -1807,7 +1807,7 @@ assert.match(
 );
 assert.match(
   backupRoutesSource,
-  /runAutomaticBackupIfDue\(!current\.enabled \|\| !automaticBackupExists\)/u,
+  /const hasAutomaticBackup = await automaticBackupExists\(backupsRoot\);[\s\S]*runAutomaticBackupIfDue\(!current\.enabled \|\| !hasAutomaticBackup\)/u,
   "enabling automatic backups or repairing a missing archive should run immediately",
 );
 assert.doesNotMatch(backupGuideSource, /Export profile as ZIP\?/u);

--- a/scripts/regressions/provider-compat.regression.ts
+++ b/scripts/regressions/provider-compat.regression.ts
@@ -45,6 +45,7 @@ import {
   type GenerationFallbackNotice,
 } from "../../packages/server/src/services/generation/fallback-notification.js";
 import { resolveStoredChatOptions } from "../../packages/server/src/services/generation/generation-parameters.js";
+import { resolveMainGenerationToolChoice } from "../../packages/server/src/services/generation/tool-resolution-runtime.js";
 
 class RegressionProvider extends BaseLLMProvider {
   calls = 0;
@@ -124,6 +125,14 @@ try {
 }
 
 let customParametersRequestBody: Record<string, unknown> | null = null;
+const testToolDefinition = {
+  type: "function" as const,
+  function: {
+    name: "fresh_data",
+    description: "Fetch current data",
+    parameters: { type: "object", properties: {} },
+  },
+};
 const customParametersServer = createServer(async (request, response) => {
   const chunks: Buffer[] = [];
   for await (const chunk of request) chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
@@ -157,6 +166,26 @@ try {
   assert.equal(customParametersRequestBody.min_p, 0.12);
   assert.equal(customParametersRequestBody.reasoning_effort, "high");
   assert.equal(customParametersRequestBody.verbosity, "low");
+
+  customParametersRequestBody = null;
+  await provider.chatComplete([{ role: "user", content: "fetch current data" }], {
+    model: "custom-model",
+    stream: false,
+    tools: [testToolDefinition],
+    toolChoice: "required",
+  });
+  assert.ok(customParametersRequestBody);
+  assert.equal(customParametersRequestBody.tool_choice, "required");
+  assert.equal(typeof customParametersRequestBody.tool_choice, "string");
+
+  customParametersRequestBody = null;
+  await provider.chatComplete([{ role: "user", content: "tool choice default" }], {
+    model: "custom-model",
+    stream: false,
+    tools: [testToolDefinition],
+  });
+  assert.ok(customParametersRequestBody);
+  assert.equal(customParametersRequestBody.tool_choice, "auto");
 
   customParametersRequestBody = null;
   await provider.chatComplete([{ role: "user", content: "test explicit custom samplers" }], {
@@ -479,6 +508,10 @@ assert.equal(isOpenRouterApiUrl("https://openrouter.ai/api/v1"), true);
 assert.equal(isOpenRouterApiUrl("https://api.openrouter.ai/v1"), true);
 assert.equal(isOpenRouterApiUrl("https://openrouter.ai.example.com/v1"), false);
 assert.equal(isOpenRouterApiUrl("not a URL"), false);
+assert.equal(resolveMainGenerationToolChoice({ forceToolCall: true }, 0), "required");
+assert.equal(resolveMainGenerationToolChoice({ forceToolCall: "true" }, 0), "required");
+assert.equal(resolveMainGenerationToolChoice({ forceToolCall: true }, 1), "auto");
+assert.equal(resolveMainGenerationToolChoice({ forceToolCall: false }, 0), "auto");
 assert.equal(normalizeCohereOpenAIBaseUrl("https://api.cohere.com"), "https://api.cohere.ai/compatibility/v1");
 assert.equal(normalizeCohereOpenAIBaseUrl("https://api.cohere.ai/"), "https://api.cohere.ai/compatibility/v1");
 assert.equal(normalizeCohereOpenAIBaseUrl("https://api.cohere.com/v1"), "https://api.cohere.ai/compatibility/v1");
@@ -646,6 +679,7 @@ assert.equal(abortedFallback.calls, 0, "user cancellation must not trigger a fal
 // `call_id`. Accumulating by call_id left tool arguments empty, so Web Search
 // received blank/malformed JSON. Verify the streamed query is reassembled.
 {
+  let responsesToolRequestBody: Record<string, unknown> | null = null;
   const responsesToolSse = [
     'event: response.output_item.added',
     'data: {"type":"response.output_item.added","item":{"id":"fc_1","type":"function_call","call_id":"call_1","name":"web_search","arguments":""}}',
@@ -668,7 +702,10 @@ assert.equal(abortedFallback.calls, 0, "user cancellation must not trigger a fal
     'data: [DONE]',
     '',
   ].join("\n");
-  const responsesServer = createServer((_request, response) => {
+  const responsesServer = createServer(async (request, response) => {
+    const chunks: Buffer[] = [];
+    for await (const chunk of request) chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+    responsesToolRequestBody = JSON.parse(Buffer.concat(chunks).toString("utf8")) as Record<string, unknown>;
     response.writeHead(200, { "content-type": "text/event-stream" });
     response.end(responsesToolSse);
   });
@@ -689,6 +726,7 @@ assert.equal(abortedFallback.calls, 0, "user cancellation must not trigger a fal
     const result = await provider.chatComplete([{ role: "user", content: "search please" }], {
       model: "gpt-5.6",
       stream: true,
+      toolChoice: "required",
       tools: [
         {
           type: "function",
@@ -697,6 +735,9 @@ assert.equal(abortedFallback.calls, 0, "user cancellation must not trigger a fal
       ],
     });
     assert.equal(result.toolCalls.length, 1, "GPT-5.6 Responses stream must surface the function call");
+    assert.ok(responsesToolRequestBody);
+    assert.equal(responsesToolRequestBody.tool_choice, "required");
+    assert.equal(typeof responsesToolRequestBody.tool_choice, "string");
     assert.equal(result.toolCalls[0].function.name, "web_search");
     assert.equal(
       result.toolCalls[0].function.arguments,

--- a/scripts/regressions/roleplay-streaming.regression.ts
+++ b/scripts/regressions/roleplay-streaming.regression.ts
@@ -346,6 +346,16 @@ assert.match(
   "only an Illustrator-only retry should hand off from text streaming to background image work",
 );
 assert.match(
+  generateHookSource,
+  /const submittedUserTurn = params\.userMessage !== undefined;/u,
+  "generation should remember whether the stopped request already submitted a user turn",
+);
+assert.equal(
+  generateHookSource.match(/submittedUserTurn \|\| receivedContent \|\| spatialTransitionCommitted/gu)?.length,
+  2,
+  "stopping a submitted user turn should remain successful even before assistant content arrives",
+);
+assert.match(
   chatAreaSource,
   /const isTextStreaming = isStreaming && !isBackgroundIllustration;/u,
   "finished assistant text must stop being treated as streaming while Illustrator continues",

--- a/scripts/regressions/roleplay-streaming.regression.ts
+++ b/scripts/regressions/roleplay-streaming.regression.ts
@@ -10,6 +10,7 @@ import {
   shouldKeepStreamLiveThroughPostProcessing,
 } from "../../packages/client/src/lib/generation-stream-policy.js";
 import { resolveMessageRewriteVersions } from "../../packages/client/src/lib/message-rewrite-versions.js";
+import { shouldFormatTextareaQuotes } from "../../packages/client/src/lib/textarea-quotes.js";
 import {
   findLatestTTSAutoplayMessage,
   getTTSAutoplayRevision,
@@ -171,6 +172,46 @@ assert.doesNotMatch(
   summaryPopoverSource,
   /onDraftChange=\{setDraftEntry\}/u,
   "summary keystrokes must not update popover-level draft state",
+);
+assert.equal(
+  shouldFormatTextareaQuotes(
+    { inputType: "insertText", data: '"', isComposing: false } as InputEvent,
+    'She said "',
+  ),
+  true,
+  "direct quote insertion should retain immediate quote formatting",
+);
+assert.equal(
+  shouldFormatTextareaQuotes(
+    { inputType: "insertCompositionText", data: '"', isComposing: true } as InputEvent,
+    'She said "',
+  ),
+  false,
+  "IME composition must not rewrite the textarea value beneath the mobile keyboard",
+);
+assert.equal(
+  shouldFormatTextareaQuotes(
+    { inputType: "insertReplacementText", data: null, isComposing: false } as InputEvent,
+    'She said "hello" and kept typing',
+  ),
+  false,
+  "autocorrect replacements with null data must not rescan and rewrite the full draft",
+);
+assert.equal(
+  shouldFormatTextareaQuotes(
+    { inputType: "deleteContentBackward", data: null, isComposing: false } as InputEvent,
+    'She said "hello',
+  ),
+  false,
+  "deletion must remain a mutation-free fast path",
+);
+assert.equal(
+  shouldFormatTextareaQuotes(
+    { inputType: "insertFromPaste", data: null, isComposing: false } as InputEvent,
+    'Pasted "dialogue"',
+  ),
+  true,
+  "pasted dialogue should still be formatted once",
 );
 assert.match(
   chatStoreSource,
@@ -408,8 +449,18 @@ assert.match(
 );
 assert.match(
   chatRoleplaySurfaceSource,
-  /generationVisualsPaused && "mari-generation-render-paused"/u,
-  "Roleplay should pause ambient rendering while generation is active",
+  /generationVisualsPaused \|\| \(isMobileToolbarViewport && \(keyboardOpen \|\| hasMobileDraftInput\)\)/u,
+  "Roleplay should pause ambient rendering while the mobile keyboard or draft is active",
+);
+assert.match(
+  chatRoleplaySurfaceSource,
+  /ambientVisualsPaused && "mari-generation-render-paused"/u,
+  "Roleplay should reuse the ambient-render pause for mobile input and generation",
+);
+assert.match(
+  chatRoleplaySurfaceSource,
+  /<WeatherEffectsConnected paused=\{ambientVisualsPaused\} \/>/u,
+  "mobile text input should suspend Roleplay weather rendering instead of competing for device resources",
 );
 assert.match(
   gameSurfaceSource,

--- a/scripts/regressions/roleplay-streaming.regression.ts
+++ b/scripts/regressions/roleplay-streaming.regression.ts
@@ -118,6 +118,10 @@ const conversationInputSource = readFileSync(
   new URL("../../packages/client/src/components/chat/ConversationInput.tsx", import.meta.url),
   "utf8",
 );
+const presetEditorSource = readFileSync(
+  new URL("../../packages/client/src/components/presets/PresetEditor.tsx", import.meta.url),
+  "utf8",
+);
 const useGenerateSource = readFileSync(
   new URL("../../packages/client/src/hooks/use-generate.ts", import.meta.url),
   "utf8",
@@ -212,6 +216,11 @@ assert.equal(
   ),
   true,
   "pasted dialogue should still be formatted once",
+);
+assert.match(
+  presetEditorSource,
+  /function SectionContentTextarea\([\s\S]{0,1400}const handleChange = \(nextRawValue: string\) => \{\s+const nextValue = nextRawValue;/u,
+  "preset section editors should commit the event-aware MacroTextarea value without reformatting the full draft",
 );
 assert.match(
   chatStoreSource,

--- a/scripts/regressions/roleplay-streaming.regression.ts
+++ b/scripts/regressions/roleplay-streaming.regression.ts
@@ -331,6 +331,22 @@ const chatHandleInputSource =
   )?.[0] ?? "";
 assert.match(chatTextareaSource, /disabled=\{!activeChatId\}/u);
 assert.match(
+  chatAreaSource,
+  /target instanceof HTMLTextAreaElement[\s\S]{0,160}target\.dataset\.chatComposer === "true"[\s\S]{0,120}target\.value\.length === 0/u,
+  "intuitive Left/Right navigation should exempt only an empty main chat composer",
+);
+assert.match(
+  chatAreaSource,
+  /event\.altKey \|\| event\.ctrlKey \|\| event\.metaKey \|\| event\.shiftKey[\s\S]{0,180}allowEmptyMainComposer: true/u,
+  "empty-composer swipe navigation should remain limited to unmodified arrow keys",
+);
+assert.match(chatTextareaSource, /data-chat-composer="true"/u, "Roleplay should identify its main composer");
+assert.match(
+  conversationInputSource,
+  /ref=\{textareaRef\}\s+data-chat-composer="true"/u,
+  "Conversation should identify its main composer",
+);
+assert.match(
   chatTextareaSource,
   /onInput=\{handleInput\}/u,
   "Roleplay should use the direct input event path used by Conversation",


### PR DESCRIPTION
## Linked issues

Closes #4195
Resolves #4196
Closes #4197
Closes #4198
Closes #4200

## Why this change

The assigned chat regressions affect core Roleplay interaction: an empty focused composer blocks keyboard swipe navigation, the requested required tool-call mode is unavailable, mobile typing and deletion do unnecessary synchronous work, and stopping generation can restore text that was already sent. The first-edit report also needs a durable end-to-end guard so the existing staging cache fix cannot regress.

## What changed

- Allow unmodified Left/Right swipe navigation from only an empty main Conversation or Roleplay composer, while preserving modifier, non-empty input, other editable-target, and touch protections.
- Add the exact `Force To Call Tool` chat toggle under Function Calls. It sends bare `required` only for the first tool-capable round, then returns to `auto` so the model can finish normally; profile persistence and both OpenAI request paths are covered.
- Avoid full textarea rescans during composition, deletion, autocorrect, and unrelated insertions. Quote normalization now runs only for relevant direct inserts and one-shot paste/drop/yank events.
- Pause Roleplay ambient visual work on coarse-pointer layouts while the software keyboard or a draft is active.
- Treat an intentional stop as successful once that generation submitted a user turn, even if no assistant token arrived yet. This keeps already-sent text cleared without changing genuine failure recovery or regeneration behavior.
- Add exact browser and source regressions for the assigned paths, and make Playwright reset its file-backed data before the test server opens it so full-suite runs cannot race a live store.
- Refresh smoke fixtures for current staging background thumbnails, object fitting, store schema version, tag focus, and mobile touch-drop coordinates.

## Automated evidence

- `pnpm check` — passed; one pre-existing `NoodleHome.tsx` exhaustive-deps warning remains.
- `pnpm localization:check` — passed.
- `pnpm regression:issues` — passed.
- `pnpm regression:prompt` — passed.
- `pnpm regression:providers` — passed.
- `pnpm regression:roleplay` — passed.
- `pnpm smoke:ui` — 147 passed, 77 intentionally skipped, 0 failed across desktop and mobile Chromium.
- Exact browser coverage verifies #4195, #4196, #4197, #4198, and the stop-before-first-token restoration case from #4200.

## Validation

- [ ] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed `CONTRIBUTING.md`

### Manual verification notes

- Manually verify empty and non-empty composer arrow-key behavior in Conversation and Roleplay.
- Manually verify stopped Roleplay generation with a retained draft, a cleared draft, and a stop before the first assistant token.
- Manually verify the first saved message edit after stopping generation, then reload the chat.
- Manually verify the Function Calls toggle with a tool-capable model and confirm the model can answer after its tool call.
- Manually verify sustained typing, deletion, autocorrect/composition, and quote input in Firefox on macOS and a mobile Roleplay viewport.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Translated docs on the `docs-i18n` branch updated to match, or a `[docs-i18n]` follow-up issue opened (see CONTRIBUTING.md § Translated documentation)
- [ ] Version/release files updated (only if this PR includes a version bump)

## UI evidence

Automated browser coverage exercises the new Function Calls toggle, focused-composer navigation, stopped-generation composer state, mobile Roleplay input behavior, and background library interactions in the rendered application.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a “Force To Call Tool” option in chat settings for compatible models.
  * Tool selection preferences now persist per conversation and apply during the first tool round.

* **Bug Fixes**
  * Improved composer behavior after stopping generation, including draft persistence after reload.
  * Improved mobile swipe navigation and keyboard usability with an empty composer.
  * Prevented roleplay visuals and drafts from changing unexpectedly during text composition.
  * Improved quote formatting across chat, editing, and prompt fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->