### PR TITLE
Fix Firefox Roleplay composer responsiveness

### DIFF
--- a/e2e/core-flows.e2e.ts
+++ b/e2e/core-flows.e2e.ts
@@ -2433,6 +2433,119 @@ test("typographic quotes do not pull the Roleplay caret behind later text", asyn
   }
 });
 
+test("desktop Roleplay composition keeps ambient work off the input path and grows before paint", async ({
+  page,
+}, testInfo) => {
+  test.skip(!testInfo.project.name.includes("desktop"), "Desktop composer performance is covered on desktop.");
+
+  const chatResponse = await page.request.post("/api/chats", {
+    data: { name: "Roleplay Composer Performance Smoke", mode: "roleplay", characterIds: [] },
+  });
+  expect(chatResponse.ok()).toBeTruthy();
+  const chat = (await chatResponse.json()) as { id: string };
+
+  try {
+    await page.addInitScript((chatId) => {
+      const persisted = JSON.parse(localStorage.getItem("marinara-engine-ui") ?? '{"state":{},"version":87}') as {
+        state: Record<string, unknown>;
+        version: number;
+      };
+      persisted.state.hasCompletedOnboarding = true;
+      persisted.state.appAccentPulseMode = true;
+      localStorage.setItem("marinara-engine-ui", JSON.stringify(persisted));
+      localStorage.setItem("marinara-active-chat-id", chatId);
+    }, chat.id);
+    await page.goto("/");
+
+    const input = page.locator("textarea.mari-chat-input-textarea");
+    const root = page.locator("html");
+    await expect(input).toHaveAttribute("data-lt-active", "false");
+    await expect(root).toHaveAttribute("data-marinara-accent-animation");
+
+    await page.evaluate(() => {
+      const measurementWindow = window as Window & { __lastKeyboardOpen?: boolean };
+      window.addEventListener("marinara:chat-visual-viewport-change", (event) => {
+        measurementWindow.__lastKeyboardOpen = (
+          event as CustomEvent<{ keyboardOpen?: boolean }>
+        ).detail?.keyboardOpen;
+      });
+    });
+    await page.setViewportSize({ width: 1440, height: 700 });
+    await input.focus();
+
+    await expect
+      .poll(() =>
+        page.evaluate(
+          () => (window as Window & { __lastKeyboardOpen?: boolean }).__lastKeyboardOpen,
+        ),
+      )
+      .toBe(false);
+    await expect(root).not.toHaveAttribute("data-marinara-accent-animation");
+
+    const initialHeight = await input.evaluate((element) => {
+      element.style.flex = "0 0 240px";
+      element.style.width = "240px";
+      return element.clientHeight;
+    });
+    await input.evaluate((element) => {
+      const value =
+        "A long Roleplay sentence should wrap onto another line without briefly hiding the newly typed text.";
+      element.value = value;
+      element.dispatchEvent(
+        new InputEvent("input", {
+          bubbles: true,
+          data: value,
+          inputType: "insertText",
+        }),
+      );
+    });
+    const wrappedHeight = await input.evaluate(
+      (element) =>
+        new Promise<number>((resolve) => {
+          requestAnimationFrame(() => resolve(element.clientHeight));
+        }),
+    );
+    expect(wrappedHeight).toBeGreaterThan(initialHeight);
+
+    const resizeStability = await input.evaluate(
+      (element) =>
+        new Promise<{ heightDelta: number; delayedStyleMutations: number; overflowY: string }>(
+          (resolve) => {
+            const heights: number[] = [];
+            let delayedStyleMutations = 0;
+            const observer = new MutationObserver((records) => {
+              delayedStyleMutations += records.length;
+            });
+            observer.observe(element, { attributes: true, attributeFilter: ["style"] });
+
+            const sample = () => {
+              heights.push(element.getBoundingClientRect().height);
+              if (heights.length < 18) {
+                requestAnimationFrame(sample);
+                return;
+              }
+              observer.disconnect();
+              resolve({
+                heightDelta: Math.max(...heights) - Math.min(...heights),
+                delayedStyleMutations,
+                overflowY: element.style.overflowY,
+              });
+            };
+            requestAnimationFrame(sample);
+          },
+        ),
+    );
+    expect(resizeStability.heightDelta).toBeLessThanOrEqual(1);
+    expect(resizeStability.delayedStyleMutations).toBe(0);
+    expect(resizeStability.overflowY).toBe("hidden");
+
+    await input.blur();
+    await expect(root).toHaveAttribute("data-marinara-accent-animation");
+  } finally {
+    await page.request.delete(`/api/chats/${chat.id}`);
+  }
+});
+
 test("mobile Roleplay composition avoids draft rewrites and pauses ambient rendering", async ({ page }, testInfo) => {
   test.skip(!testInfo.project.name.includes("mobile"), "Mobile composer resource behavior is covered on mobile.");
 

--- a/packages/client/src/App.tsx
+++ b/packages/client/src/App.tsx
@@ -446,6 +446,18 @@ function canRunAccentAnimation(reducedMotionQuery: MediaQueryList, forcePaused =
   return document.visibilityState === "visible" && document.hasFocus() && !reducedMotionQuery.matches && !forcePaused;
 }
 
+function isTextEntryFocused() {
+  const active = document.activeElement;
+  if (!(active instanceof HTMLElement)) return false;
+  if (active instanceof HTMLTextAreaElement) return true;
+  if (active instanceof HTMLInputElement) {
+    return !["button", "checkbox", "color", "file", "hidden", "radio", "range", "reset", "submit"].includes(
+      active.type,
+    );
+  }
+  return active.isContentEditable;
+}
+
 async function recoverFromVersionSkew(serverVersion: string) {
   if (sessionStorage.getItem(VERSION_RECOVERY_KEY) === serverVersion) {
     return;
@@ -750,6 +762,14 @@ export function App() {
       applyStaticAccent();
     };
 
+    const pauseAccentAnimation = () => {
+      if (accentAnimationTimer !== null) {
+        window.clearTimeout(accentAnimationTimer);
+        accentAnimationTimer = null;
+      }
+      delete root.dataset.marinaraAccentAnimation;
+    };
+
     const queueAccentAnimationTick = () => {
       if (accentAnimationTimer !== null) return;
 
@@ -769,14 +789,20 @@ export function App() {
       root.dataset.marinaraAccentAnimation =
         animatedAccentIsGradient && animatedGradientStops.length > 1 ? "gradient" : "solid";
       if (usesTimerDrivenAccentAnimation) {
-        applyLiveAccent();
         queueAccentAnimationTick();
       }
     };
 
     const syncAccentAnimationState = () => {
       if (accentAnimationEnabled && canRunAccentAnimation(reducedMotionQuery, pauseChromeEffectsForAppearance)) {
-        startAccentAnimation();
+        if (isTextEntryFocused()) {
+          // Root accent ticks invalidate styles across the entire Roleplay
+          // surface in Firefox. Freeze the current accent while the user is
+          // typing, then resume from the next tick after focus leaves.
+          pauseAccentAnimation();
+        } else {
+          startAccentAnimation();
+        }
       } else {
         stopAccentAnimation();
       }
@@ -795,6 +821,8 @@ export function App() {
     window.addEventListener("blur", syncAccentAnimationState);
     window.addEventListener("pageshow", syncAccentAnimationState);
     window.addEventListener("pagehide", syncAccentAnimationState);
+    document.addEventListener("focusin", syncAccentAnimationState);
+    document.addEventListener("focusout", syncAccentAnimationState);
     if (customCursorEnabled) {
       window.addEventListener("wheel", freezeCursorRecolorDuringScroll, { capture: true, passive: true });
     }
@@ -806,6 +834,8 @@ export function App() {
       window.removeEventListener("blur", syncAccentAnimationState);
       window.removeEventListener("pageshow", syncAccentAnimationState);
       window.removeEventListener("pagehide", syncAccentAnimationState);
+      document.removeEventListener("focusin", syncAccentAnimationState);
+      document.removeEventListener("focusout", syncAccentAnimationState);
       if (customCursorEnabled) {
         window.removeEventListener("wheel", freezeCursorRecolorDuringScroll, true);
       }

--- a/packages/client/src/components/chat/ChatInput.tsx
+++ b/packages/client/src/components/chat/ChatInput.tsx
@@ -138,8 +138,16 @@ function getChatInputTextareaMaxHeightPx() {
 }
 
 function resizeChatInputTextarea(el: HTMLTextAreaElement) {
+  const maxHeight = getChatInputTextareaMaxHeightPx();
+
+  // Measure without a vertical scrollbar. If the scrollbar is allowed to
+  // appear during measurement it narrows the textarea, creates an extra wrap,
+  // and can make Firefox alternate between two heights on successive inputs.
+  el.style.overflowY = "hidden";
   el.style.height = "auto";
-  el.style.height = `${Math.min(el.scrollHeight, getChatInputTextareaMaxHeightPx())}px`;
+  const contentHeight = el.scrollHeight;
+  el.style.height = `${Math.min(contentHeight, maxHeight)}px`;
+  el.style.overflowY = contentHeight > maxHeight ? "auto" : "hidden";
 }
 
 function useIsMobileComposerViewport() {
@@ -232,6 +240,7 @@ export const ChatInput = memo(function ChatInput({
   const focusAfterMobileRestoreRef = useRef(false);
   const draftTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const resizeTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const resizeFrameRef = useRef(0);
   const heldDeleteKeyRef = useRef(false);
   const heldDeleteDraftRef = useRef<{ chatId: string; text: string } | null>(null);
   const heldDeleteResizeRef = useRef<HTMLTextAreaElement | null>(null);
@@ -499,6 +508,7 @@ export const ChatInput = memo(function ChatInput({
       // Cancel pending debounce timers
       if (draftTimerRef.current) clearTimeout(draftTimerRef.current);
       if (resizeTimerRef.current) clearTimeout(resizeTimerRef.current);
+      if (resizeFrameRef.current) cancelAnimationFrame(resizeFrameRef.current);
       heldDeleteKeyRef.current = false;
       heldDeleteDraftRef.current = null;
       heldDeleteResizeRef.current = null;
@@ -1465,6 +1475,15 @@ export const ChatInput = memo(function ChatInput({
     }, delay);
   }, []);
 
+  const scheduleTextareaFrameResize = useCallback((el: HTMLTextAreaElement) => {
+    if (resizeFrameRef.current) return;
+    resizeFrameRef.current = requestAnimationFrame(() => {
+      resizeFrameRef.current = 0;
+      if (textareaRef.current !== el) return;
+      resizeChatInputTextarea(el);
+    });
+  }, []);
+
   const releaseHeldDeleteWork = useCallback(() => {
     if (!heldDeleteKeyRef.current) return;
     heldDeleteKeyRef.current = false;
@@ -1563,6 +1582,11 @@ export const ChatInput = memo(function ChatInput({
     const shouldDeferDeleteWork = mode === "roleplay" && isDeleting && heldDeleteKeyRef.current;
     const fixed = applyTextareaQuoteFormat(el, quoteFormat, inputEvent);
     syncInputState(fixed);
+    if (!isDeleting) {
+      // Resize once before Firefox's next paint so newly wrapped text remains
+      // visible without competing with a second, delayed height measurement.
+      scheduleTextareaFrameResize(el);
+    }
 
     // Keep draft in sync so it survives remounts (debounced to avoid store churn)
     if (activeChatId) {
@@ -1575,14 +1599,19 @@ export const ChatInput = memo(function ChatInput({
       }
     }
 
-    // Roleplay can paint a substantially heavier scene than the other modes.
-    // Wait for a short typing pause before forcing the scrollHeight layout read.
+    // Insertions already received their single frame resize above. Keep
+    // deletion shrinking off the held-key path so Backspace stays smooth.
     if (shouldDeferDeleteWork) {
       heldDeleteResizeRef.current = el;
+    } else if (!isDeleting) {
+      if (resizeTimerRef.current) {
+        clearTimeout(resizeTimerRef.current);
+        resizeTimerRef.current = null;
+      }
     } else {
       scheduleTextareaResize(
         el,
-        isDeleting ? ROLEPLAY_INPUT_DELETE_RESIZE_IDLE_MS : ROLEPLAY_INPUT_RESIZE_IDLE_MS,
+        ROLEPLAY_INPUT_DELETE_RESIZE_IDLE_MS,
       );
     }
 
@@ -2047,6 +2076,7 @@ export const ChatInput = memo(function ChatInput({
           rows={1}
           spellCheck
           autoCorrect="on"
+          data-lt-active={mode === "roleplay" ? "false" : undefined}
           className="mari-chat-input-textarea max-h-[12.5rem] min-w-0 flex-1 resize-none bg-transparent py-0 text-sm leading-normal text-foreground/90 placeholder:text-foreground/30 outline-none disabled:cursor-not-allowed disabled:opacity-40"
         />
 

--- a/packages/client/src/components/chat/EchoChamberPanel.tsx
+++ b/packages/client/src/components/chat/EchoChamberPanel.tsx
@@ -658,7 +658,10 @@ export function EchoChamberPanel({ hiddenOnMobile = false }: EchoChamberPanelPro
         ) : (
           <div className="flex flex-col gap-0.5">
             {visibleMessages.map((msg, i) => (
-              <div key={i} className="min-w-0 animate-in fade-in slide-in-from-bottom-1 duration-300 break-words">
+              <div
+                key={i}
+                className="min-w-0 animate-in fade-in slide-in-from-bottom-1 [animation-duration:300ms] break-words"
+              >
                 <span className={cn("text-[0.6875rem] font-bold", nameColorMap.get(msg.characterName))}>
                   {msg.characterName}
                 </span>

--- a/packages/client/src/components/layout/AppShell.tsx
+++ b/packages/client/src/components/layout/AppShell.tsx
@@ -238,6 +238,8 @@ export function AppShell() {
     let frame = 0;
     let focusTimers: number[] = [];
     let largestViewportHeight = window.visualViewport?.height ?? window.innerHeight;
+    const supportsVirtualKeyboard =
+      navigator.maxTouchPoints > 0 || window.matchMedia("(any-pointer: coarse)").matches;
     const updateVisualViewportGeometry = () => {
       if (frame) cancelAnimationFrame(frame);
       frame = requestAnimationFrame(() => {
@@ -255,7 +257,7 @@ export function AppShell() {
         dispatchChatVisualViewportChange({
           height,
           offsetTop,
-          keyboardOpen: largestViewportHeight - height >= 80,
+          keyboardOpen: supportsVirtualKeyboard && largestViewportHeight - height >= 80,
         });
       });
     };


### PR DESCRIPTION
## Linked issue

Related to #4188

## Why this change

- Roleplay mode on desktop Firefox still performed expensive ambient and viewport work while the composer was focused, causing typing and held deletion to update in visible chunks.
- The first latency fix exposed a second Firefox-specific resize race: the textarea could alternate between two wrapped heights and make the bottom-anchored composer jitter on every letter.

## What changed

- Pause animated accent ticks while any text-entry control is focused.
- Avoid treating desktop Firefox viewport changes as a virtual keyboard unless the device is touch/coarse-pointer capable.
- Keep LanguageTool out of the heavy Roleplay composer path while preserving native spellcheck.
- Resize insertions once before paint, defer held-deletion shrink work, and measure without scrollbar-induced rewrapping.
- Correct the Echo Chamber animation-duration utility so it does not introduce an unintended transition duration.
- Add browser regressions for desktop Roleplay focus, wrapping stability, ambient work, and held deletion.

## Validation

- [ ] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed `CONTRIBUTING.md`

### Manual verification notes

- Maintainer tested typing, held Backspace deletion, and line wrapping in Roleplay mode on desktop Firefox/macOS after each iteration.
- Final maintainer result: typing and deletion are smooth, wrapped text no longer disappears, and the composer no longer jitters.
- Focused Playwright proof passed in desktop Firefox (2/2) and desktop Chromium (2/2), including ≤1 px measured composer movement and zero delayed resize mutations.
- `pnpm check` passed. It reported only the pre-existing `NoodleHome.tsx` missing-dependency warning.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Translated docs on the `docs-i18n` branch updated to match, or a `[docs-i18n]` follow-up issue opened (see CONTRIBUTING.md § Translated documentation)
- [ ] Version/release files updated (only if this PR includes a version bump)

## UI evidence (if applicable)

- Maintainer supplied a Firefox screen recording of the pre-fix composer jitter and verified the corrected behavior in the same environment.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved chat composer resizing to reduce layout glitches while typing, wrapping text, and deleting.
  * Prevented ambient accent animations from interrupting active text entry.
  * Improved keyboard detection on touch-enabled devices.
  * Preserved hidden overflow behavior when the composer reaches its maximum height.
  * Refined message entrance animation timing for smoother display.

* **Tests**
  * Added end-to-end coverage for roleplay composer performance, resizing stability, keyboard behavior, and animation state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->