### PR TITLE
Fix Roleplay reasoning summaries and Claude Opus 5 parameters

### DIFF
--- a/packages/server/src/services/llm/providers/anthropic.provider.ts
+++ b/packages/server/src/services/llm/providers/anthropic.provider.ts
@@ -346,15 +346,18 @@ export class AnthropicProvider extends BaseLLMProvider {
 
     const modelLower = options.model.toLowerCase();
     const isAdaptiveOnly = isClaudeAdaptiveOnlyNoSamplingModel(options.model);
-    if (isAdaptiveOnly) stripAnthropicSamplingParameters(body);
-
-    if (
+    const shouldDisableThinking =
       this.shouldSendParameter(options, "reasoningEffort") &&
       options.reasoningEffort === "none" &&
-      supportsAnthropicThinkingDisable(options.model)
-    ) {
+      supportsAnthropicThinkingDisable(options.model);
+    if (isAdaptiveOnly) stripAnthropicSamplingParameters(body);
+
+    if (shouldDisableThinking) {
       body.thinking = { type: "disabled" };
-    } else if (this.shouldSendParameter(options, "reasoningEffort") && options.enableThinking) {
+    } else if (
+      this.shouldSendParameter(options, "reasoningEffort") &&
+      (options.enableThinking || (isAdaptiveOnly && options.captureReasoning))
+    ) {
       if (isAdaptiveOnly) {
         applyAdaptiveThinkingConfig(body, options, maxTokens);
       } else {
@@ -374,7 +377,11 @@ export class AnthropicProvider extends BaseLLMProvider {
     this.applyCustomParameters(body, options);
     if (isAdaptiveOnly) {
       stripAnthropicSamplingParameters(body);
-      if (this.shouldSendParameter(options, "reasoningEffort") && options.enableThinking) {
+      if (
+        !shouldDisableThinking &&
+        this.shouldSendParameter(options, "reasoningEffort") &&
+        (options.enableThinking || options.captureReasoning)
+      ) {
         applyAdaptiveThinkingConfig(body, options);
       }
     }
@@ -509,22 +516,22 @@ export class AnthropicProvider extends BaseLLMProvider {
     // Strip temperature, top_k, top_p regardless of thinking mode.
     const modelLower = options.model.toLowerCase();
     const isAdaptiveOnly = isClaudeAdaptiveOnlyNoSamplingModel(options.model);
+    const shouldDisableThinking =
+      !suppressModelParameters &&
+      this.shouldSendParameter(options, "reasoningEffort") &&
+      options.reasoningEffort === "none" &&
+      supportsAnthropicThinkingDisable(options.model);
     if (isAdaptiveOnly && !suppressModelParameters) {
       stripAnthropicSamplingParameters(body);
     }
 
     // Enable extended thinking for reasoning models
-    if (
-      !suppressModelParameters &&
-      this.shouldSendParameter(options, "reasoningEffort") &&
-      options.reasoningEffort === "none" &&
-      supportsAnthropicThinkingDisable(options.model)
-    ) {
+    if (shouldDisableThinking) {
       body.thinking = { type: "disabled" };
     } else if (
       !suppressModelParameters &&
       this.shouldSendParameter(options, "reasoningEffort") &&
-      options.enableThinking
+      (options.enableThinking || (isAdaptiveOnly && options.captureReasoning))
     ) {
       const outputMaxTokens = maxTokens ?? 4096;
       if (isAdaptiveOnly) {
@@ -553,7 +560,11 @@ export class AnthropicProvider extends BaseLLMProvider {
     this.applyCustomParameters(body, options);
     if (isAdaptiveOnly && !suppressModelParameters) {
       stripAnthropicSamplingParameters(body);
-      if (this.shouldSendParameter(options, "reasoningEffort") && options.enableThinking) {
+      if (
+        !shouldDisableThinking &&
+        this.shouldSendParameter(options, "reasoningEffort") &&
+        (options.enableThinking || options.captureReasoning)
+      ) {
         applyAdaptiveThinkingConfig(body, options);
       }
     }

--- a/packages/server/src/services/llm/providers/claude-subscription.provider.ts
+++ b/packages/server/src/services/llm/providers/claude-subscription.provider.ts
@@ -420,14 +420,18 @@ export class ClaudeSubscriptionProvider extends BaseLLMProvider {
       supportsAnthropicThinkingDisable(options.model)
     ) {
       sdkOptions.thinking = { type: "disabled" };
-    } else if (!suppressModelParameters && options.enableThinking) {
-      sdkOptions.thinking = { type: "adaptive" };
-      // EffortLevel covers low|medium|high|xhigh|max; reasoningEffort matches
-      // that provider-facing set.
-      sdkOptions.effort = (options.reasoningEffort ?? "high") as "low" | "medium" | "high" | "xhigh" | "max";
-    } else if (!suppressModelParameters && isAdaptiveOnly) {
-      // Adaptive-only Claude models always think; let the SDK pick a default effort.
-      sdkOptions.thinking = { type: "adaptive" };
+    } else if (!suppressModelParameters && (options.enableThinking || isAdaptiveOnly)) {
+      sdkOptions.thinking = {
+        type: "adaptive",
+        ...(options.captureReasoning ? { display: "summarized" as const } : {}),
+      };
+      // Opus 5 and the other adaptive-only models think by default, but effort
+      // remains an independent request control. Preserve an explicit effort
+      // even when callers only opt into displaying the summarized reasoning.
+      const activeEffort = options.reasoningEffort !== "none" ? options.reasoningEffort : undefined;
+      if (activeEffort || options.enableThinking) {
+        sdkOptions.effort = (activeEffort ?? "high") as "low" | "medium" | "high" | "xhigh" | "max";
+      }
     }
 
     // Subprocess environment. `ENABLE_CLAUDEAI_MCP_SERVERS=false` opts out of

--- a/packages/server/src/services/llm/providers/openai.provider.ts
+++ b/packages/server/src/services/llm/providers/openai.provider.ts
@@ -899,7 +899,10 @@ export class OpenAIProvider extends BaseLLMProvider {
     if (isOpenAIGpt56Model(normalizedModel) && options.excludePastReasoning !== undefined) {
       reasoning.context = options.excludePastReasoning ? "current_turn" : "all_turns";
     }
-    if (options.enableThinking) {
+    if (
+      (options.enableThinking || options.captureReasoning) &&
+      !this.hasExplicitReasoningDisable(options.reasoningEffort)
+    ) {
       reasoning.summary = "auto";
     }
     if (Object.keys(reasoning).length > 0) {
@@ -2020,24 +2023,7 @@ export class OpenAIProvider extends BaseLLMProvider {
         "OpenAI chatResponses() non-stream response",
       );
       OpenAIProvider.assertResponsesSucceeded(json, "OpenAI chatResponses() non-stream response");
-      // Extract reasoning summaries for non-streaming
-      if (options.onThinking) {
-        const output = json.output as Array<Record<string, unknown>> | undefined;
-        if (output) {
-          for (const item of output) {
-            if (item.type === "reasoning") {
-              const summary = item.summary as Array<Record<string, unknown>> | undefined;
-              if (summary) {
-                for (const part of summary) {
-                  if (part.type === "summary_text" && typeof part.text === "string") {
-                    options.onThinking(part.text);
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
+      this.emitMissingResponsesReasoningSummary(json, options, "");
       // Emit encrypted reasoning items for multi-turn context
       this.emitEncryptedReasoning(json, options);
       const text = this.extractResponsesText(json);
@@ -2071,6 +2057,7 @@ export class OpenAIProvider extends BaseLLMProvider {
     let streamUsage: LLMUsage | undefined;
     let yieldedAny = false;
     let currentEvent = "";
+    let emittedReasoningSummary = "";
 
     try {
       while (true) {
@@ -2119,7 +2106,21 @@ export class OpenAIProvider extends BaseLLMProvider {
             }
             case "response.reasoning_summary_text.delta": {
               const delta = parsed.delta as string | undefined;
-              if (delta && options.onThinking) options.onThinking(delta);
+              if (delta && options.onThinking) {
+                emittedReasoningSummary += delta;
+                options.onThinking(delta);
+              }
+              break;
+            }
+            case "response.output_item.done": {
+              const item = parsed.item as Record<string, unknown> | undefined;
+              if (item?.type === "reasoning") {
+                emittedReasoningSummary = this.emitMissingResponsesReasoningSummary(
+                  { output: [item] },
+                  options,
+                  emittedReasoningSummary,
+                );
+              }
               break;
             }
             case "response.refusal.delta": {
@@ -2145,6 +2146,11 @@ export class OpenAIProvider extends BaseLLMProvider {
                   };
                 }
                 this.emitEncryptedReasoning(resp, options);
+                emittedReasoningSummary = this.emitMissingResponsesReasoningSummary(
+                  resp,
+                  options,
+                  emittedReasoningSummary,
+                );
                 // If no text was streamed (e.g. refusal or content only in the
                 // completed payload), extract it as a last-resort fallback.
                 if (!yieldedAny) {
@@ -2171,6 +2177,11 @@ export class OpenAIProvider extends BaseLLMProvider {
               if (resp) {
                 streamUsage = this.extractResponsesUsage(resp);
                 this.emitEncryptedReasoning(resp, options);
+                emittedReasoningSummary = this.emitMissingResponsesReasoningSummary(
+                  resp,
+                  options,
+                  emittedReasoningSummary,
+                );
                 if (!yieldedAny) {
                   const fallback = this.extractResponsesText(resp);
                   if (fallback) {
@@ -2256,24 +2267,7 @@ export class OpenAIProvider extends BaseLLMProvider {
         "OpenAI chatCompleteResponses() non-stream response",
       );
       OpenAIProvider.assertResponsesSucceeded(json, "OpenAI chatCompleteResponses() non-stream response");
-      // Extract reasoning summaries
-      if (options.onThinking) {
-        const output = json.output as Array<Record<string, unknown>> | undefined;
-        if (output) {
-          for (const item of output) {
-            if (item.type === "reasoning") {
-              const summary = item.summary as Array<Record<string, unknown>> | undefined;
-              if (summary) {
-                for (const part of summary) {
-                  if (part.type === "summary_text" && typeof part.text === "string") {
-                    options.onThinking(part.text);
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
+      this.emitMissingResponsesReasoningSummary(json, options, "");
       // Emit encrypted reasoning items for multi-turn context
       this.emitEncryptedReasoning(json, options);
       return this.parseResponsesResult(json);
@@ -2301,6 +2295,7 @@ export class OpenAIProvider extends BaseLLMProvider {
     // Track in-progress function call argument deltas keyed by call_id
     const fnCallArgs = new Map<string, { id: string; name: string; arguments: string }>();
     let currentEvent = "";
+    let emittedReasoningSummary = "";
 
     try {
       while (true) {
@@ -2358,7 +2353,10 @@ export class OpenAIProvider extends BaseLLMProvider {
 
             case "response.reasoning_summary_text.delta": {
               const delta = parsed.delta as string | undefined;
-              if (delta && options.onThinking) options.onThinking(delta);
+              if (delta && options.onThinking) {
+                emittedReasoningSummary += delta;
+                options.onThinking(delta);
+              }
               break;
             }
 
@@ -2417,6 +2415,12 @@ export class OpenAIProvider extends BaseLLMProvider {
                     arguments: entry?.arguments ?? (item.arguments as string) ?? "",
                   },
                 });
+              } else if (item?.type === "reasoning") {
+                emittedReasoningSummary = this.emitMissingResponsesReasoningSummary(
+                  { output: [item] },
+                  options,
+                  emittedReasoningSummary,
+                );
               }
               break;
             }
@@ -2426,6 +2430,11 @@ export class OpenAIProvider extends BaseLLMProvider {
               if (resp) {
                 streamUsage = this.extractResponsesUsage(resp);
                 this.emitEncryptedReasoning(resp, options);
+                emittedReasoningSummary = this.emitMissingResponsesReasoningSummary(
+                  resp,
+                  options,
+                  emittedReasoningSummary,
+                );
                 const status = resp.status as string | undefined;
                 if (status === "incomplete") {
                   finishReason = OpenAIProvider.normalizeResponsesIncompleteFinishReason(
@@ -2456,6 +2465,13 @@ export class OpenAIProvider extends BaseLLMProvider {
               const reason = (resp?.incomplete_details as Record<string, unknown>)?.reason ?? "unknown";
               logger.warn("[OpenAI Responses] chatCompleteResponses stream incomplete (reason=%s)", reason);
               finishReason = OpenAIProvider.normalizeResponsesIncompleteFinishReason(reason);
+              if (resp) {
+                emittedReasoningSummary = this.emitMissingResponsesReasoningSummary(
+                  resp,
+                  options,
+                  emittedReasoningSummary,
+                );
+              }
               break;
             }
           }
@@ -2534,6 +2550,58 @@ export class OpenAIProvider extends BaseLLMProvider {
     if (!options.onEncryptedReasoning) return;
     const items = this.extractEncryptedReasoningItems(json);
     if (items.length > 0) options.onEncryptedReasoning(items);
+  }
+
+  /** Extract the displayable summary from Responses API reasoning output items. */
+  private extractResponsesReasoningSummary(json: Record<string, unknown>): string {
+    const output = json.output as Array<Record<string, unknown>> | undefined;
+    if (!output) return "";
+
+    let summaryText = "";
+    for (const item of output) {
+      if (item.type !== "reasoning" || !Array.isArray(item.summary)) continue;
+      for (const part of item.summary) {
+        if (
+          typeof part === "object" &&
+          part !== null &&
+          (part as Record<string, unknown>).type === "summary_text" &&
+          typeof (part as Record<string, unknown>).text === "string"
+        ) {
+          summaryText += (part as Record<string, unknown>).text;
+        }
+      }
+    }
+    return summaryText;
+  }
+
+  /**
+   * Recover reasoning summaries from final Responses payloads. Some models or
+   * gateways omit summary delta events even though the completed output item
+   * contains the requested summary.
+   */
+  private emitMissingResponsesReasoningSummary(
+    json: Record<string, unknown>,
+    options: ChatOptions,
+    emittedSummary: string,
+  ): string {
+    if (!options.onThinking) return emittedSummary;
+    const finalSummary = this.extractResponsesReasoningSummary(json);
+    if (!finalSummary || finalSummary === emittedSummary || emittedSummary.startsWith(finalSummary)) {
+      return emittedSummary;
+    }
+
+    if (finalSummary.startsWith(emittedSummary)) {
+      options.onThinking(finalSummary.slice(emittedSummary.length));
+      return finalSummary;
+    }
+
+    let overlap = Math.min(emittedSummary.length, finalSummary.length);
+    while (overlap > 0 && !emittedSummary.endsWith(finalSummary.slice(0, overlap))) {
+      overlap -= 1;
+    }
+    const missingSuffix = finalSummary.slice(overlap);
+    if (missingSuffix) options.onThinking(missingSuffix);
+    return emittedSummary + missingSuffix;
   }
 
   /** Extract usage from a Responses API result */

--- a/scripts/regressions/provider-compat.regression.ts
+++ b/scripts/regressions/provider-compat.regression.ts
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import { createServer } from "node:http";
 import {
   findKnownModel,
+  isClaudeAdaptiveOnlyNoSamplingModel,
   resolveProviderReasoningEffort,
   shouldSuppressUnknownModelParameters,
 } from "../../packages/shared/src/constants/model-lists.js";
@@ -13,7 +14,14 @@ import {
   NOODLE_JSON_OUTPUT_HEADING,
   noodleResponseFormat,
 } from "../../packages/server/src/services/noodle/noodle-response-format.js";
-import { supportsAnthropicThinkingDisable } from "../../packages/server/src/services/llm/providers/anthropic.provider.js";
+import {
+  AnthropicProvider,
+  supportsAnthropicThinkingDisable,
+} from "../../packages/server/src/services/llm/providers/anthropic.provider.js";
+import {
+  __setSdkForTesting,
+  ClaudeSubscriptionProvider,
+} from "../../packages/server/src/services/llm/providers/claude-subscription.provider.js";
 import { resolveGeminiThinkingConfig } from "../../packages/server/src/services/llm/providers/google.provider.js";
 import {
   normalizeOpenAIChatCompletionsResponseFormat,
@@ -304,7 +312,197 @@ assert.equal(
   "reasoning-mandatory Gemini 3 models must not receive an unsupported off value",
 );
 assert.equal(supportsAnthropicThinkingDisable("claude-sonnet-5"), true);
+assert.equal(supportsAnthropicThinkingDisable("claude-opus-5"), true);
 assert.equal(supportsAnthropicThinkingDisable("claude-fable-5"), false);
+assert.equal(isClaudeAdaptiveOnlyNoSamplingModel("claude-opus-5"), true);
+const opus5 = findKnownModel("anthropic", "claude-opus-5");
+assert.equal(opus5?.context, 1_000_000);
+assert.equal(opus5?.maxOutput, 128_000);
+const subscriptionOpus5 = findKnownModel("claude_subscription", "claude-opus-5");
+assert.equal(subscriptionOpus5?.context, 1_000_000);
+assert.equal(subscriptionOpus5?.maxOutput, 128_000);
+assert.equal(
+  resolveProviderReasoningEffort({
+    provider: "anthropic",
+    model: "claude-opus-5",
+    reasoningEffort: "maximum",
+  }),
+  "max",
+);
+
+// Roleplay captures readable reasoning, independently of whether the provider
+// needs an explicit "enable thinking" toggle. OpenAI Responses may stream no
+// summary deltas at all while still returning the summary in response.completed.
+{
+  let responsesReasoningRequestBody: Record<string, unknown> | null = null;
+  const responsesReasoningSse = [
+    "event: response.output_text.delta",
+    'data: {"type":"response.output_text.delta","delta":"Visible reply"}',
+    "",
+    "event: response.completed",
+    'data: {"type":"response.completed","response":{"status":"completed","output":[{"id":"rs_1","type":"reasoning","summary":[{"type":"summary_text","text":"Checked the roleplay context."}]},{"id":"msg_1","type":"message","content":[{"type":"output_text","text":"Visible reply"}]}],"usage":{"input_tokens":12,"output_tokens":7,"total_tokens":19,"output_tokens_details":{"reasoning_tokens":4}}}}',
+    "",
+    "data: [DONE]",
+    "",
+  ].join("\n");
+  const responsesReasoningServer = createServer(async (request, response) => {
+    const chunks: Buffer[] = [];
+    for await (const chunk of request) chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+    responsesReasoningRequestBody = JSON.parse(Buffer.concat(chunks).toString("utf8")) as Record<string, unknown>;
+    response.writeHead(200, { "content-type": "text/event-stream" });
+    response.end(responsesReasoningSse);
+  });
+  await new Promise<void>((resolve) => responsesReasoningServer.listen(0, "127.0.0.1", resolve));
+  try {
+    const address = responsesReasoningServer.address();
+    assert.ok(address && typeof address === "object");
+    const provider = new OpenAIProvider(
+      `http://127.0.0.1:${address.port}/v1`,
+      "test",
+      undefined,
+      undefined,
+      undefined,
+      "openai",
+    );
+    let thinking = "";
+    assert.equal(
+      await collectProviderOutput(provider, {
+        model: "gpt-5.6-sol",
+        stream: true,
+        captureReasoning: true,
+        reasoningEffort: "xhigh",
+        excludePastReasoning: false,
+        onThinking: (chunk) => {
+          thinking += chunk;
+        },
+      }),
+      "Visible reply",
+    );
+    assert.equal(thinking, "Checked the roleplay context.");
+    assert.ok(responsesReasoningRequestBody);
+    assert.deepEqual(responsesReasoningRequestBody.reasoning, {
+      effort: "xhigh",
+      context: "all_turns",
+      summary: "auto",
+    });
+  } finally {
+    await new Promise<void>((resolve, reject) =>
+      responsesReasoningServer.close((error) => (error ? reject(error) : resolve())),
+    );
+  }
+}
+
+// Opus 5 uses adaptive thinking, output_config.effort, and rejects legacy
+// sampling knobs. Capturing Roleplay reasoning must explicitly request the
+// summarized display even though thinking itself is on by default.
+{
+  const anthropicRequestBodies: Array<Record<string, unknown>> = [];
+  const anthropicServer = createServer(async (request, response) => {
+    const chunks: Buffer[] = [];
+    for await (const chunk of request) chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+    anthropicRequestBodies.push(JSON.parse(Buffer.concat(chunks).toString("utf8")) as Record<string, unknown>);
+    response.writeHead(200, { "content-type": "application/json" });
+    response.end(
+      JSON.stringify({
+        content: [
+          { type: "thinking", thinking: "Summarized Claude reasoning." },
+          { type: "text", text: "Claude reply" },
+        ],
+        stop_reason: "end_turn",
+        usage: { input_tokens: 10, output_tokens: 6 },
+      }),
+    );
+  });
+  await new Promise<void>((resolve) => anthropicServer.listen(0, "127.0.0.1", resolve));
+  try {
+    const address = anthropicServer.address();
+    assert.ok(address && typeof address === "object");
+    const provider = new AnthropicProvider(`http://127.0.0.1:${address.port}`, "test");
+    let thinking = "";
+    assert.equal(
+      await collectProviderOutput(provider, {
+        model: "claude-opus-5",
+        stream: false,
+        captureReasoning: true,
+        reasoningEffort: "max",
+        temperature: 0.7,
+        topK: 32,
+        onThinking: (chunk) => {
+          thinking += chunk;
+        },
+      }),
+      "Claude reply",
+    );
+    assert.equal(thinking, "Summarized Claude reasoning.");
+    const maxEffortBody = anthropicRequestBodies[0];
+    assert.ok(maxEffortBody);
+    assert.deepEqual(maxEffortBody.thinking, { type: "adaptive", display: "summarized" });
+    assert.deepEqual(maxEffortBody.output_config, { effort: "max" });
+    assert.equal("temperature" in maxEffortBody, false);
+    assert.equal("top_k" in maxEffortBody, false);
+    assert.equal("top_p" in maxEffortBody, false);
+
+    await collectProviderOutput(provider, {
+      model: "claude-opus-5",
+      stream: false,
+      captureReasoning: true,
+      reasoningEffort: "none",
+      temperature: 0.7,
+      topK: 32,
+    });
+    const disabledBody = anthropicRequestBodies[1];
+    assert.ok(disabledBody);
+    assert.deepEqual(disabledBody.thinking, { type: "disabled" });
+    assert.equal("output_config" in disabledBody, false);
+    assert.equal("temperature" in disabledBody, false);
+    assert.equal("top_k" in disabledBody, false);
+    assert.equal("top_p" in disabledBody, false);
+  } finally {
+    await new Promise<void>((resolve, reject) =>
+      anthropicServer.close((error) => (error ? reject(error) : resolve())),
+    );
+  }
+}
+
+{
+  let subscriptionOptions: Record<string, unknown> | null = null;
+  __setSdkForTesting({
+    query: ((args: { options: Record<string, unknown> }) => {
+      subscriptionOptions = args.options;
+      return (async function* () {
+        yield {
+          type: "stream_event",
+          event: { type: "content_block_delta", delta: { type: "text_delta", text: "Subscription reply" } },
+        };
+        yield {
+          type: "result",
+          subtype: "success",
+          result: "",
+          usage: { input_tokens: 9, output_tokens: 5 },
+          modelUsage: { "claude-opus-5": {} },
+          fast_mode_state: "off",
+        };
+      })();
+    }) as never,
+  });
+  try {
+    const provider = new ClaudeSubscriptionProvider("", "");
+    assert.equal(
+      await collectProviderOutput(provider, {
+        model: "claude-opus-5",
+        stream: true,
+        captureReasoning: true,
+        reasoningEffort: "xhigh",
+      }),
+      "Subscription reply",
+    );
+    assert.ok(subscriptionOptions);
+    assert.deepEqual(subscriptionOptions.thinking, { type: "adaptive", display: "summarized" });
+    assert.equal(subscriptionOptions.effort, "xhigh");
+  } finally {
+    __setSdkForTesting(null);
+  }
+}
 
 let openRouterRequestBody: Record<string, unknown> | null = null;
 const openRouterServer = createServer(async (request, response) => {
@@ -747,6 +945,77 @@ assert.equal(abortedFallback.calls, 0, "user cancellation must not trigger a fal
     assert.equal(result.toolCalls[0].id, "call_1", "the tool call must keep its call_id for function_call_output");
   } finally {
     await new Promise<void>((resolve, reject) => responsesServer.close((error) => (error ? reject(error) : resolve())));
+  }
+}
+
+// GPT-5.6 may report hidden reasoning tokens while sending the displayable
+// reasoning summary only in the final Responses payload. Roleplay persists the
+// onThinking callback as `extra.thinking`, so recover that final summary without
+// duplicating any summary text that was already streamed.
+{
+  let responsesReasoningRequestBody: Record<string, unknown> | null = null;
+  const streamedThenFinalSse = [
+    "event: response.reasoning_summary_text.delta",
+    'data: {"type":"response.reasoning_summary_text.delta","delta":"Reviewing "}',
+    "",
+    "event: response.output_item.done",
+    'data: {"type":"response.output_item.done","item":{"id":"rs_2","type":"reasoning","summary":[{"type":"summary_text","text":"Reviewing the tools."}]}}',
+    "",
+    "event: response.output_text.delta",
+    'data: {"type":"response.output_text.delta","delta":"Done."}',
+    "",
+    "event: response.completed",
+    'data: {"type":"response.completed","response":{"status":"completed","output":[{"id":"rs_2","type":"reasoning","summary":[{"type":"summary_text","text":"Reviewing the tools."}]},{"id":"msg_2","type":"message","content":[{"type":"output_text","text":"Done."}]}],"usage":{"input_tokens":10,"output_tokens":8,"total_tokens":18,"output_tokens_details":{"reasoning_tokens":5}}}}',
+    "",
+    "data: [DONE]",
+    "",
+  ].join("\n");
+  const responsesReasoningServer = createServer(async (request, response) => {
+    const chunks: Buffer[] = [];
+    for await (const chunk of request) chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+    responsesReasoningRequestBody = JSON.parse(Buffer.concat(chunks).toString("utf8")) as Record<string, unknown>;
+    response.writeHead(200, { "content-type": "text/event-stream" });
+    response.end(streamedThenFinalSse);
+  });
+  await new Promise<void>((resolve) => responsesReasoningServer.listen(0, "127.0.0.1", resolve));
+  try {
+    const address = responsesReasoningServer.address();
+    assert.ok(address && typeof address === "object");
+    const provider = new OpenAIProvider(
+      `http://127.0.0.1:${address.port}/v1`,
+      "test",
+      undefined,
+      undefined,
+      undefined,
+      "openai",
+    );
+
+    let streamedThinking = "";
+    const completion = await provider.chatComplete([{ role: "user", content: "test" }], {
+      model: "gpt-5.6-sol",
+      stream: true,
+      enableThinking: true,
+      captureReasoning: true,
+      reasoningEffort: "xhigh",
+      onThinking: (chunk) => {
+        streamedThinking += chunk;
+      },
+    });
+    assert.equal(completion.content, "Done.");
+    assert.equal(
+      streamedThinking,
+      "Reviewing the tools.",
+      "final reasoning items must fill missing streamed text without duplicating it",
+    );
+    assert.ok(responsesReasoningRequestBody);
+    assert.deepEqual(responsesReasoningRequestBody.reasoning, {
+      effort: "xhigh",
+      summary: "auto",
+    });
+  } finally {
+    await new Promise<void>((resolve, reject) =>
+      responsesReasoningServer.close((error) => (error ? reject(error) : resolve())),
+    );
   }
 }
 


### PR DESCRIPTION
## Why

Roleplay could report hidden GPT-5.6 reasoning-token usage while persisting no readable summary, leaving the message without its brain-icon affordance. Claude Opus 5 was already present in the model catalog, but its current adaptive-thinking, summarized-display, effort, sampling, and explicit-disable semantics were not fully serialized across both Anthropic connection paths.

## What changed

- recover GPT-5.6 reasoning summaries from final Responses payloads and deduplicate them against streamed summary deltas
- request readable summaries whenever Roleplay captures reasoning
- support Claude Opus 5 adaptive thinking and `low` through `max` effort for direct Anthropic API connections
- preserve explicit effort and summarized thinking through Claude Subscription connections
- strip unsupported `temperature`, `top_p`, and `top_k` values for Opus 5
- keep explicit `thinking: disabled` authoritative and free of conflicting effort configuration
- add provider regressions for catalog metadata, request bodies, summary recovery, deduplication, and disable behavior

## Validation

- `pnpm check`
- `pnpm regression:providers`
- `pnpm --filter @marinara-engine/server lint`

## Manual verification

- [ ] Generate a new GPT-5.6 Sol Roleplay response with Show Thoughts enabled and verify the brain icon opens the readable reasoning summary.
- [ ] Generate with Claude Opus 5 through an Anthropic API connection at `max` effort.
- [ ] Generate with Claude Opus 5 through Claude Subscription at `xhigh` effort.
- [ ] Select no reasoning for Opus 5 and verify the request succeeds with thinking disabled.

No linked issue is currently attached; please open or link a tracking issue if required by the maintainer workflow.