### PR TITLE
Fix iOS keyboard inset and KoboldCPP Router Mode

### DIFF
--- a/e2e/core-flows.e2e.ts
+++ b/e2e/core-flows.e2e.ts
@@ -10446,6 +10446,15 @@ test("mobile chat composer follows the visual viewport above the software keyboa
         viewport.dispatchEvent(new Event("scroll"));
       },
     });
+    Object.defineProperty(window, "__rotateMarinaraVisualViewport", {
+      configurable: true,
+      value: (height: number) => {
+        state.height = height;
+        state.offsetTop = 0;
+        window.dispatchEvent(new Event("orientationchange"));
+        viewport.dispatchEvent(new Event("resize"));
+      },
+    });
   });
   await page.addInitScript((chatId) => {
     localStorage.setItem("marinara-active-chat-id", chatId);
@@ -10477,6 +10486,43 @@ test("mobile chat composer follows the visual viewport above the software keyboa
       .toBeLessThanOrEqual(2);
     await expect(textarea).toBeVisible();
     await expect.poll(() => composer.evaluate((element) => getComputedStyle(element).paddingBottom)).toBe("34px");
+
+    const initialViewportHeight = await page.evaluate(() => window.innerHeight);
+    const rotatedViewportHeight = Math.max(240, initialViewportHeight - 200);
+    await page.evaluate((height) => {
+      (
+        window as typeof window & {
+          __rotateMarinaraVisualViewport: (height: number) => void;
+        }
+      ).__rotateMarinaraVisualViewport(height);
+    }, rotatedViewportHeight);
+    await expect
+      .poll(() =>
+        page.evaluate(() =>
+          getComputedStyle(document.documentElement).getPropertyValue("--mari-visual-viewport-height").trim(),
+        ),
+      )
+      .toBe(`${rotatedViewportHeight}px`);
+    await expect(page.locator("html")).not.toHaveAttribute("data-mari-software-keyboard-open", "");
+    await expect.poll(() => composer.evaluate((element) => getComputedStyle(element).paddingBottom)).toBe("34px");
+
+    await page.evaluate((height) => {
+      (
+        window as typeof window & {
+          __rotateMarinaraVisualViewport: (height: number) => void;
+        }
+      ).__rotateMarinaraVisualViewport(height);
+    }, initialViewportHeight);
+    await expect
+      .poll(() =>
+        page.evaluate(() =>
+          getComputedStyle(document.documentElement).getPropertyValue("--mari-visual-viewport-height").trim(),
+        ),
+      )
+      .toBe(`${initialViewportHeight}px`);
+    await expect(page.locator("html")).not.toHaveAttribute("data-mari-software-keyboard-open", "");
+    await page.waitForTimeout(350);
+
     await textarea.focus();
 
     await page.evaluate(() => {
@@ -10516,6 +10562,9 @@ test("mobile chat composer follows the visual viewport above the software keyboa
       .poll(() => transcript.evaluate((element) => element.scrollHeight - element.scrollTop - element.clientHeight))
       .toBeLessThanOrEqual(2);
 
+    // Let the delayed focus viewport samples settle before simulating a user
+    // deliberately scrolling away from the latest message.
+    await page.waitForTimeout(350);
     await transcript.evaluate((element) => {
       element.scrollTop = Math.max(0, element.scrollTop - 320);
     });

--- a/e2e/core-flows.e2e.ts
+++ b/e2e/core-flows.e2e.ts
@@ -10420,12 +10420,12 @@ test("mobile chat composer follows the visual viewport above the software keyboa
 
   await page.addInitScript(() => {
     const state = {
-      height: window.innerHeight,
+      height: null as number | null,
       offsetTop: 0,
     };
     const viewport = new EventTarget();
     Object.defineProperties(viewport, {
-      height: { configurable: true, get: () => state.height },
+      height: { configurable: true, get: () => state.height ?? window.innerHeight },
       offsetTop: { configurable: true, get: () => state.offsetTop },
       offsetLeft: { configurable: true, get: () => 0 },
       pageLeft: { configurable: true, get: () => 0 },
@@ -10453,6 +10453,9 @@ test("mobile chat composer follows the visual viewport above the software keyboa
 
   try {
     await page.goto("/");
+    await page.locator("html").evaluate((element) => {
+      element.style.setProperty("--mari-safe-area-inset-bottom", "34px");
+    });
 
     const viewportMeta = page.locator('meta[name="viewport"]');
     await expect(viewportMeta).toHaveAttribute("content", /interactive-widget=resizes-content/);
@@ -10473,6 +10476,7 @@ test("mobile chat composer follows the visual viewport above the software keyboa
       .poll(() => transcript.evaluate((element) => element.scrollHeight - element.scrollTop - element.clientHeight))
       .toBeLessThanOrEqual(2);
     await expect(textarea).toBeVisible();
+    await expect.poll(() => composer.evaluate((element) => getComputedStyle(element).paddingBottom)).toBe("34px");
     await textarea.focus();
 
     await page.evaluate(() => {
@@ -10491,6 +10495,15 @@ test("mobile chat composer follows the visual viewport above the software keyboa
         })),
       )
       .toEqual({ height: "360px", top: "72px" });
+    await expect(page.locator("html")).toHaveAttribute("data-mari-software-keyboard-open", "");
+    const compactComposerStyle = await composer.evaluate((element) => {
+      const style = getComputedStyle(element);
+      return {
+        fontSize: Number.parseFloat(style.fontSize),
+        paddingBottom: Number.parseFloat(style.paddingBottom),
+      };
+    });
+    expect(compactComposerStyle.paddingBottom).toBeCloseTo(compactComposerStyle.fontSize * 0.5, 5);
 
     const [shellBox, composerBox] = await Promise.all([shell.boundingBox(), composer.boundingBox()]);
     expect(shellBox).not.toBeNull();
@@ -10520,6 +10533,9 @@ test("mobile chat composer follows the visual viewport above the software keyboa
       });
     });
     await page.reload();
+    await page.locator("html").evaluate((element) => {
+      element.style.setProperty("--mari-safe-area-inset-bottom", "34px");
+    });
     await expect(page.getByText(/^Keyboard viewport history line 18\./)).toBeVisible();
     await textarea.focus();
     await page.evaluate(() => {
@@ -10538,6 +10554,15 @@ test("mobile chat composer follows the visual viewport above the software keyboa
         })),
       )
       .toEqual({ height: "360px", top: "0px" });
+    await expect(page.locator("html")).toHaveAttribute("data-mari-software-keyboard-open", "");
+    const iosCompactComposerStyle = await composer.evaluate((element) => {
+      const style = getComputedStyle(element);
+      return {
+        fontSize: Number.parseFloat(style.fontSize),
+        paddingBottom: Number.parseFloat(style.paddingBottom),
+      };
+    });
+    expect(iosCompactComposerStyle.paddingBottom).toBeCloseTo(iosCompactComposerStyle.fontSize * 0.5, 5);
 
     const [iosShellBox, iosComposerBox] = await Promise.all([shell.boundingBox(), composer.boundingBox()]);
     expect(iosShellBox).not.toBeNull();

--- a/packages/client/src/components/layout/AppShell.tsx
+++ b/packages/client/src/components/layout/AppShell.tsx
@@ -237,6 +237,7 @@ export function AppShell() {
     const root = document.documentElement;
     let frame = 0;
     let focusTimers: number[] = [];
+    let orientationTimers: number[] = [];
     let largestViewportHeight = window.visualViewport?.height ?? window.innerHeight;
     const supportsVirtualKeyboard =
       navigator.maxTouchPoints > 0 || window.matchMedia("(any-pointer: coarse)").matches;
@@ -279,22 +280,36 @@ export function AppShell() {
       focusTimers.push(window.setTimeout(updateVisualViewportGeometry, 80));
       focusTimers.push(window.setTimeout(updateVisualViewportGeometry, 320));
     };
+    const refreshAfterOrientationChange = () => {
+      orientationTimers.forEach((timer) => window.clearTimeout(timer));
+      orientationTimers = [];
+      const resetViewportBaseline = () => {
+        // A shorter landscape viewport is not necessarily a software keyboard.
+        // Re-establish the baseline while browser chrome and safe areas settle.
+        largestViewportHeight = 0;
+        updateVisualViewportGeometry();
+      };
+      resetViewportBaseline();
+      orientationTimers.push(window.setTimeout(resetViewportBaseline, 80));
+      orientationTimers.push(window.setTimeout(resetViewportBaseline, 320));
+    };
 
     updateVisualViewportGeometry();
     window.visualViewport?.addEventListener("resize", updateVisualViewportGeometry);
     window.visualViewport?.addEventListener("scroll", updateVisualViewportGeometry);
     window.addEventListener("resize", updateVisualViewportGeometry);
-    window.addEventListener("orientationchange", updateVisualViewportGeometry);
+    window.addEventListener("orientationchange", refreshAfterOrientationChange);
     document.addEventListener("focusin", refreshAfterFocusChange);
     document.addEventListener("focusout", refreshAfterFocusChange);
 
     return () => {
       if (frame) cancelAnimationFrame(frame);
       focusTimers.forEach((timer) => window.clearTimeout(timer));
+      orientationTimers.forEach((timer) => window.clearTimeout(timer));
       window.visualViewport?.removeEventListener("resize", updateVisualViewportGeometry);
       window.visualViewport?.removeEventListener("scroll", updateVisualViewportGeometry);
       window.removeEventListener("resize", updateVisualViewportGeometry);
-      window.removeEventListener("orientationchange", updateVisualViewportGeometry);
+      window.removeEventListener("orientationchange", refreshAfterOrientationChange);
       document.removeEventListener("focusin", refreshAfterFocusChange);
       document.removeEventListener("focusout", refreshAfterFocusChange);
       root.style.removeProperty("--mari-visual-viewport-height");

--- a/packages/client/src/components/layout/AppShell.tsx
+++ b/packages/client/src/components/layout/AppShell.tsx
@@ -261,10 +261,12 @@ export function AppShell() {
         largestViewportHeight = Math.max(largestViewportHeight, height);
         root.style.setProperty("--mari-visual-viewport-height", `${Math.max(0, Math.round(height))}px`);
         root.style.setProperty("--mari-visual-viewport-offset-top", `${Math.round(offsetTop)}px`);
+        const keyboardOpen = supportsVirtualKeyboard && largestViewportHeight - height >= 80;
+        root.toggleAttribute("data-mari-software-keyboard-open", keyboardOpen);
         dispatchChatVisualViewportChange({
           height,
           offsetTop,
-          keyboardOpen: supportsVirtualKeyboard && largestViewportHeight - height >= 80,
+          keyboardOpen,
         });
       });
     };
@@ -297,6 +299,7 @@ export function AppShell() {
       document.removeEventListener("focusout", refreshAfterFocusChange);
       root.style.removeProperty("--mari-visual-viewport-height");
       root.style.removeProperty("--mari-visual-viewport-offset-top");
+      root.removeAttribute("data-mari-software-keyboard-open");
     };
   }, []);
 

--- a/packages/client/src/styles/globals.css
+++ b/packages/client/src/styles/globals.css
@@ -4998,8 +4998,12 @@ strong {
   }
 
   .chat-input-container {
-    padding: 0.25em 2% max(0.5em, env(safe-area-inset-bottom)) !important;
-    scroll-margin-bottom: max(4.5rem, env(safe-area-inset-bottom));
+    padding: 0.25em 2% max(0.5em, var(--mari-safe-area-inset-bottom, env(safe-area-inset-bottom))) !important;
+    scroll-margin-bottom: max(4.5rem, var(--mari-safe-area-inset-bottom, env(safe-area-inset-bottom)));
+  }
+  html[data-mari-software-keyboard-open] .chat-input-container {
+    padding-bottom: 0.5em !important;
+    scroll-margin-bottom: 4.5rem;
   }
   .chat-input-container .marinara-chat-input-shell {
     gap: 0.25rem !important;

--- a/packages/server/src/utils/security.ts
+++ b/packages/server/src/utils/security.ts
@@ -289,7 +289,12 @@ async function validateResolvedAddresses(
   policy: OutboundUrlPolicy,
   originalUrl?: string,
 ): Promise<Array<{ address: string; family: 4 | 6 }>> {
-  const addresses = await resolveHostname(hostname);
+  const resolvedAddresses = await resolveHostname(hostname);
+  // Some local inference servers expose an IPv4-only proxy on their public
+  // port even when their ordinary server is dual-stack (KoboldCPP Router Mode
+  // is one example). Prefer IPv4 for ambiguous loopback names such as
+  // `localhost`; explicit IPv6 loopback URLs remain IPv6.
+  const addresses = isLoopbackHostname(hostname) ? preferIpv4Records(resolvedAddresses) : resolvedAddresses;
   if (policy.allowMdns && isMdnsHostname(hostname)) {
     const preferred = preferIpv4Records(addresses);
     if (preferred.length === 0) {

--- a/scripts/regressions/provider-compat.regression.ts
+++ b/scripts/regressions/provider-compat.regression.ts
@@ -111,7 +111,7 @@ try {
   const address = gatewayServer.address();
   assert.ok(address && typeof address === "object");
   const provider = new OpenAIProvider(
-    `http://127.0.0.1:${address.port}/v1`,
+    `http://localhost:${address.port}/v1`,
     "test",
     undefined,
     undefined,


### PR DESCRIPTION
## Linked issues

Closes #4222
Closes #4224

## Why this change

- iOS Safari correctly shrinks the visual viewport around its software keyboard, but the chat composer continued reserving the home-indicator safe area inside that already-reduced viewport, leaving an extra bottom band.
- KoboldCPP Router Mode replaces its ordinary dual-stack server with an IPv4 proxy. Marinara’s rebinding-safe resolver could pin `localhost` to the first DNS result (`::1` on affected systems), causing an immediate `fetch failed` before KoboldCPP received the request.

## What changed

- Publish the existing software-keyboard state on the document root and remove it during shell cleanup.
- Keep bottom safe-area protection while the keyboard is closed, but use the composer’s normal compact spacing while the keyboard is open.
- Strengthen the mobile viewport smoke test with a simulated 34px iOS safe area and verify generic mobile and iPhone WebKit behavior.
- Prefer IPv4 when an ambiguous loopback hostname such as `localhost` resolves to both families, while preserving explicit IPv6 loopback URLs and all existing outbound security validation.
- Exercise the OpenAI-compatible provider regression through `localhost` against an IPv4-only fixture, matching KoboldCPP Router Mode’s public proxy.

KoboldCPP documents Router Mode as an OpenAI-compatible reverse proxy that supports `/v1/chat/completions`, hotswapping, streaming, and automatic wake after unload: https://github.com/LostRuins/koboldcpp/wiki#what-is-router-mode-how-can-i-hotswap-models

## Validation

- [ ] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed `CONTRIBUTING.md`

### Manual verification notes

- `pnpm exec playwright test -c playwright.config.ts --project=mobile-chromium --grep "mobile chat composer follows the visual viewport above the software keyboard"` — 1 passed.
- `pnpm regression:providers` — passed. Before the resolver fix, the new IPv4-only `localhost` fixture reproduced the reporter’s exact `TypeError: fetch failed` with `ECONNREFUSED ::1`; after the fix, streaming and non-streaming requests both pass.
- `pnpm regression:request-security` — passed.
- `pnpm check` — passed; the existing `NoodleHome.tsx` exhaustive-deps warning remains unchanged.
- Physical iOS Safari and a real KoboldCPP Router Mode process are not available in this environment. Maintainer/device verification remains requested; the KoboldCPP proof uses an IPv4-only OpenAI-compatible local server matching the router proxy’s network behavior.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Translated docs on the `docs-i18n` branch updated to match, or a `[docs-i18n]` follow-up issue opened (see CONTRIBUTING.md § Translated documentation)
- [ ] Version/release files updated (only if this PR includes a version bump)

## UI evidence (if applicable)

- Issue #4222 contains the original iOS recording. The focused browser regression programmatically measures the before/after composer inset because the CI browser does not expose a native iOS home indicator or software keyboard.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved mobile chat composer spacing and scrolling during the software keyboard state, including safer safe-area padding and consistent composer layout after reloads (iOS included).
  - Enhanced loopback hostname resolution by preferring IPv4 records to avoid ambiguous dual-stack behavior.
- **Tests**
  - Expanded end-to-end coverage for mobile visual-viewport rotation and keyboard-open state.
  - Updated a provider-compat regression test to use `localhost`-based URLs for the SSE gateway.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->