### PR TITLE
Fix spellcheck, Echo Chamber sizing, and Seedream routing

### DIFF
--- a/e2e/core-flows.e2e.ts
+++ b/e2e/core-flows.e2e.ts
@@ -2704,7 +2704,8 @@ test("desktop Roleplay composition keeps ambient work off the input path and gro
 
     const input = page.locator("textarea.mari-chat-input-textarea");
     const root = page.locator("html");
-    await expect(input).toHaveAttribute("data-lt-active", "false");
+    await expect(input).toHaveAttribute("spellcheck", "true");
+    await expect(input).not.toHaveAttribute("data-lt-active");
     await expect(root).toHaveAttribute("data-marinara-accent-animation");
 
     await page.evaluate(() => {
@@ -2786,6 +2787,77 @@ test("desktop Roleplay composition keeps ambient work off the input path and gro
 
     await input.blur();
     await expect(root).toHaveAttribute("data-marinara-accent-animation");
+  } finally {
+    await page.request.delete(`/api/chats/${chat.id}`);
+  }
+});
+
+test("desktop Echo Chamber commits its resized dimensions before reload", async ({ page }, testInfo) => {
+  test.skip(!testInfo.project.name.includes("desktop"), "Desktop Echo Chamber resizing is covered on desktop.");
+
+  await page.route("**/api/app-settings/ui", async (route) => {
+    if (route.request().method() === "GET") {
+      await route.fulfill({ json: { value: null } });
+      return;
+    }
+    const body = route.request().postDataJSON() as { value?: unknown } | null;
+    await route.fulfill({ json: { value: typeof body?.value === "string" ? body.value : "" } });
+  });
+
+  const chatResponse = await page.request.post("/api/chats", {
+    data: { name: "Echo Chamber Size Persistence Smoke", mode: "roleplay", characterIds: [] },
+  });
+  expect(chatResponse.ok()).toBeTruthy();
+  const chat = (await chatResponse.json()) as { id: string };
+
+  try {
+    const metadataResponse = await page.request.patch(`/api/chats/${chat.id}/metadata`, {
+      data: { enableAgents: true, activeAgentIds: ["echo-chamber"] },
+    });
+    expect(metadataResponse.ok()).toBeTruthy();
+
+    await page.setViewportSize({ width: 1280, height: 900 });
+    await page.addInitScript((chatId) => {
+      const persisted = JSON.parse(localStorage.getItem("marinara-engine-ui") ?? '{"state":{},"version":87}') as {
+        state: Record<string, unknown>;
+        version: number;
+      };
+      persisted.state.hasCompletedOnboarding = true;
+      persisted.state.echoChamberOpen = true;
+      persisted.state.echoChamberSide = "bottom-right";
+      localStorage.setItem("marinara-engine-ui", JSON.stringify(persisted));
+      localStorage.setItem("marinara-active-chat-id", chatId);
+    }, chat.id);
+    await page.goto("/");
+
+    const resizeHandle = page.getByRole("button", { name: "Resize Echo Chamber" });
+    await expect(resizeHandle).toBeVisible();
+    const panel = resizeHandle.locator("..");
+    const initialBox = await panel.boundingBox();
+    expect(initialBox).not.toBeNull();
+
+    await resizeHandle.press("ArrowRight");
+    await resizeHandle.press("ArrowDown");
+
+    const savedSize = await page.evaluate((chatId) => {
+      const persisted = JSON.parse(localStorage.getItem("marinara-engine-ui") ?? '{"state":{}}') as {
+        state?: {
+          echoChamberSizeByChatId?: Record<string, { width?: unknown; height?: unknown }>;
+        };
+      };
+      return persisted.state?.echoChamberSizeByChatId?.[chatId] ?? null;
+    }, chat.id);
+    expect(savedSize).not.toBeNull();
+    expect(savedSize?.width).toBeGreaterThan(Math.round(initialBox!.width));
+    expect(savedSize?.height).toBeGreaterThan(Math.round(initialBox!.height));
+
+    await page.reload();
+    const restoredHandle = page.getByRole("button", { name: "Resize Echo Chamber" });
+    await expect(restoredHandle).toBeVisible();
+    const restoredBox = await restoredHandle.locator("..").boundingBox();
+    expect(restoredBox).not.toBeNull();
+    expect(Math.abs(restoredBox!.width - Number(savedSize?.width))).toBeLessThanOrEqual(1);
+    expect(Math.abs(restoredBox!.height - Number(savedSize?.height))).toBeLessThanOrEqual(1);
   } finally {
     await page.request.delete(`/api/chats/${chat.id}`);
   }

--- a/packages/client/src/components/chat/ChatInput.tsx
+++ b/packages/client/src/components/chat/ChatInput.tsx
@@ -2076,7 +2076,6 @@ export const ChatInput = memo(function ChatInput({
           rows={1}
           spellCheck
           autoCorrect="on"
-          data-lt-active={mode === "roleplay" ? "false" : undefined}
           className="mari-chat-input-textarea max-h-[12.5rem] min-w-0 flex-1 resize-none bg-transparent py-0 text-sm leading-normal text-foreground/90 placeholder:text-foreground/30 outline-none disabled:cursor-not-allowed disabled:opacity-40"
         />
 

--- a/packages/client/src/stores/ui.store.ts
+++ b/packages/client/src/stores/ui.store.ts
@@ -149,6 +149,48 @@ function normalizeEchoChamberSizes(value: unknown): Record<string, EchoChamberSi
   }
   return normalized;
 }
+
+interface ImmediateUiStorageSnapshot {
+  customCursorEnabled: boolean | undefined;
+  echoChamberSizes: string;
+}
+
+function readImmediateUiStorageSnapshot(value: string | null): ImmediateUiStorageSnapshot {
+  if (!value) {
+    return {
+      customCursorEnabled: undefined,
+      echoChamberSizes: "{}",
+    };
+  }
+
+  try {
+    const parsed = JSON.parse(value) as {
+      state?: {
+        customCursorEnabled?: unknown;
+        echoChamberSizeByChatId?: unknown;
+      };
+    };
+    return {
+      customCursorEnabled:
+        typeof parsed.state?.customCursorEnabled === "boolean" ? parsed.state.customCursorEnabled : undefined,
+      echoChamberSizes: JSON.stringify(normalizeEchoChamberSizes(parsed.state?.echoChamberSizeByChatId)),
+    };
+  } catch {
+    return {
+      customCursorEnabled: undefined,
+      echoChamberSizes: "{}",
+    };
+  }
+}
+
+function shouldFlushUiStorageImmediately(previousValue: string | null, nextValue: string): boolean {
+  const previous = readImmediateUiStorageSnapshot(previousValue);
+  const next = readImmediateUiStorageSnapshot(nextValue);
+  return (
+    previous.customCursorEnabled !== next.customCursorEnabled ||
+    previous.echoChamberSizes !== next.echoChamberSizes
+  );
+}
 export const TRACKER_PANEL_WIDTH_DEFAULT = TRACKER_PANEL_SIZE_PROFILE_WIDTHS.standard;
 export const TRACKER_PANEL_WIDTH_MIN = TRACKER_PANEL_SIZE_PROFILE_WIDTHS.compact;
 export const TRACKER_PANEL_WIDTH_MAX = TRACKER_PANEL_SIZE_PROFILE_WIDTHS.expanded;
@@ -2354,18 +2396,6 @@ export const useUIStore = create<UIState>()(
         let pendingName: string | null = null;
         let pendingValue: string | null = null;
 
-        const readCustomCursorPreference = (value: string | null): boolean | undefined => {
-          if (!value) return undefined;
-          try {
-            const parsed = JSON.parse(value) as { state?: { customCursorEnabled?: unknown } };
-            return typeof parsed.state?.customCursorEnabled === "boolean"
-              ? parsed.state.customCursorEnabled
-              : undefined;
-          } catch {
-            return undefined;
-          }
-        };
-
         const flush = () => {
           if (pendingName !== null && pendingValue !== null) {
             localStorage.setItem(pendingName, pendingValue);
@@ -2393,7 +2423,7 @@ export const useUIStore = create<UIState>()(
             const previousValue = pendingValue ?? localStorage.getItem(name);
             pendingName = name;
             pendingValue = value;
-            if (readCustomCursorPreference(previousValue) !== readCustomCursorPreference(value)) {
+            if (shouldFlushUiStorageImmediately(previousValue, value)) {
               flush();
               return;
             }

--- a/packages/server/src/services/image/image-generation.ts
+++ b/packages/server/src/services/image/image-generation.ts
@@ -2154,7 +2154,8 @@ export function openRouterModalities(model?: string): string[] {
     lower.startsWith("black-forest-labs/") ||
     lower.startsWith("sourceful/") ||
     lower.startsWith("recraft/") ||
-    lower.startsWith("krea/")
+    lower.startsWith("krea/") ||
+    lower.startsWith("bytedance-seed/seedream-")
   ) {
     return ["image"];
   }
@@ -2162,7 +2163,8 @@ export function openRouterModalities(model?: string): string[] {
 }
 
 export function usesOpenRouterImagesApi(model?: string): boolean {
-  return model?.trim().toLowerCase().startsWith("krea/") === true;
+  const lower = model?.trim().toLowerCase() ?? "";
+  return lower.startsWith("krea/") || lower.startsWith("bytedance-seed/seedream-");
 }
 
 export function openRouterImagesUrl(baseUrl: string): string {

--- a/packages/shared/src/constants/model-lists.ts
+++ b/packages/shared/src/constants/model-lists.ts
@@ -816,6 +816,12 @@ const IMAGE_GEN_MODELS: KnownModel[] = [
     context: 0,
     maxOutput: 0,
   },
+  {
+    id: "bytedance-seed/seedream-4.5",
+    name: "Seedream 4.5 (OpenRouter)",
+    context: 0,
+    maxOutput: 0,
+  },
   // xAI / Grok Imagine
   { id: "grok-4.1-fast-image", name: "Grok 4.1 Fast Image", context: 0, maxOutput: 0 },
   { id: "grok-imagine-image", name: "Grok Imagine Image", context: 0, maxOutput: 0 },

--- a/scripts/regressions/open-issues.regression.ts
+++ b/scripts/regressions/open-issues.regression.ts
@@ -2235,8 +2235,12 @@ assert.equal(
 );
 assert.deepEqual(openRouterModalities("krea/krea-2-large"), ["image"]);
 assert.deepEqual(openRouterModalities(" KREA/krea-2-medium-turbo "), ["image"]);
+assert.deepEqual(openRouterModalities("bytedance-seed/seedream-4.5"), ["image"]);
+assert.deepEqual(openRouterModalities(" BYTEDANCE-SEED/SEEDREAM-4.5-20251203 "), ["image"]);
 assert.deepEqual(openRouterModalities("google/gemini-3.1-flash-image-preview"), ["image", "text"]);
 assert.equal(usesOpenRouterImagesApi(" krea/krea-2-medium "), true);
+assert.equal(usesOpenRouterImagesApi("bytedance-seed/seedream-4.5"), true);
+assert.equal(usesOpenRouterImagesApi("BYTEDANCE-SEED/SEEDREAM-4.5-20251203"), true);
 assert.equal(usesOpenRouterImagesApi("google/gemini-3.1-flash-image-preview"), false);
 assert.equal(
   openRouterImagesUrl("https://openrouter.ai/api/v1/chat/completions"),
@@ -2255,6 +2259,20 @@ assert.deepEqual(
     prompt: "plate of spaghetti\n\nAvoid in the image: burnt pasta",
     resolution: "1K",
     aspect_ratio: "1:1",
+  },
+);
+assert.deepEqual(
+  buildOpenRouterImagesRequest({
+    prompt: "a dreamy night market",
+    model: "bytedance-seed/seedream-4.5",
+    width: 1280,
+    height: 720,
+  }),
+  {
+    model: "bytedance-seed/seedream-4.5",
+    prompt: "a dreamy night market",
+    resolution: "1K",
+    aspect_ratio: "16:9",
   },
 );
 assert.deepEqual(

--- a/scripts/regressions/roleplay-streaming.regression.ts
+++ b/scripts/regressions/roleplay-streaming.regression.ts
@@ -168,6 +168,16 @@ assert.match(
   "per-chat Echo Chamber dimensions should survive UI-store rehydration",
 );
 assert.match(
+  uiStoreSource,
+  /previous\.echoChamberSizes !== next\.echoChamberSizes/u,
+  "an Echo Chamber size change should bypass the debounced UI storage write",
+);
+assert.match(
+  uiStoreSource,
+  /if \(shouldFlushUiStorageImmediately\(previousValue, value\)\) \{\s+flush\(\);/u,
+  "critical UI preferences should flush synchronously before the app can close",
+);
+assert.match(
   summaryPopoverSource,
   /const \[draft, setDraft\] = useState\(\(\) => \(\{ \.\.\.entry \}\)\);/u,
   "summary typing should update editor-local state instead of rerendering the entire popover",
@@ -423,8 +433,13 @@ assert.doesNotMatch(
 );
 assert.match(
   chatHandleInputSource,
-  /const isDeleting = inputEvent\?\.inputType\?\.startsWith\("delete"\) === true;[\s\S]*?isDeleting \? ROLEPLAY_INPUT_DELETE_RESIZE_IDLE_MS : ROLEPLAY_INPUT_RESIZE_IDLE_MS/u,
-  "Roleplay deletion should use a longer resize idle window than ordinary typing",
+  /if \(!isDeleting\) \{[\s\S]*?scheduleTextareaFrameResize\(el\);[\s\S]*?\} else \{[\s\S]*?scheduleTextareaResize\([\s\S]*?ROLEPLAY_INPUT_DELETE_RESIZE_IDLE_MS/u,
+  "Roleplay insertions should resize before paint while deletions retain their idle resize window",
+);
+assert.match(
+  chatHandleInputSource,
+  /if \(shouldDeferDeleteWork\) \{\s+heldDeleteResizeRef\.current = el;/u,
+  "held Roleplay deletion should defer its layout read until the key is released",
 );
 assert.match(
   chatInputSource,


### PR DESCRIPTION
## Linked issue

Closes #4225

Related to #4170

## Why this change

Three regressions affected otherwise valid workflows:

- The Firefox Roleplay performance patch explicitly set `data-lt-active="false"`, preventing LanguageTool-style browser extensions from attaching even though native spellcheck remained enabled.
- Echo Chamber dimensions used the general one-second UI persistence debounce. A browser or app process that closed without a reliable lifecycle event could lose the most recent resize.
- OpenRouter Seedream 4.5 fell through to the mixed `image` + `text` modality request, despite Seedream being image-only and officially served through OpenRouter's Images API.

## What changed

- Remove the Roleplay composer opt-out so spelling extensions can attach while preserving the low-lag input and textarea sizing path.
- Flush per-chat Echo Chamber dimension changes synchronously and restore them after reload.
- Classify `bytedance-seed/seedream-*` as image-only and route it through `/api/v1/images`.
- Add Seedream 4.5 to the image-generation fallback model catalog.
- Add targeted browser and regression coverage for extension-compatible composer attributes, immediate Echo sizing persistence, reload restoration, and Seedream request routing.

## Validation

- [ ] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed `CONTRIBUTING.md`

Commands completed during implementation:

- `pnpm check`
- `pnpm regression:roleplay`
- `pnpm regression:issues`
- `pnpm exec playwright test -c playwright.config.ts --project=desktop-chromium -g "desktop (Roleplay composition|Echo Chamber commits)"`

`pnpm check` completed with the existing `NoodleHome.tsx` exhaustive-deps warning and no errors.

### Manual verification notes

Manual follow-up should verify the configured Firefox spelling extension can underline and suggest corrections without bringing back Roleplay typing lag, resize Echo Chamber and reopen the same chat, and generate one image through an OpenRouter Seedream 4.5 connection.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Translated docs on the `docs-i18n` branch updated to match, or a `[docs-i18n] <paths>` follow-up issue opened (see CONTRIBUTING.md § Translated documentation)
- [ ] Version/release files updated (only if this PR includes a version bump)

No documentation or release metadata changes are required.

## UI evidence (if applicable)

No visual redesign. The browser test verifies Echo Chamber dimensions before and after a full page reload.
