### PR TITLE
docs-i18n: update chat branch translations

### DIFF
--- a/de/chats/branches.md
+++ b/de/chats/branches.md
@@ -25,7 +25,7 @@ Marinara kopiert den Chat bis einschließlich dieser Nachricht in eine neue Verz
 - Startet mit dem Anzeigenamen **New Branch**. Umbenennen geht jederzeit (siehe unten).
 - Bleibt im selben Chat-Ordner wie der Ursprungschat.
 
-Tages- und Wochenzusammenfassungen sowie die laufende Zusammenfassung wandern nicht mit. In der neuen Verzweigung fangen sie bei null an.
+Tages- und Wochenzusammenfassungen wandern nicht mit. Laufende Zusammenfassungen mit gespeicherten Nachrichtenbereichen, die vollständig innerhalb der kopierten Verzweigung liegen, werden übernommen und auf die neuen Nachrichten-IDs der Verzweigung abgebildet. Zusammenfassungen, deren Quellbereich den Verzweigungspunkt überschreitet, sowie ältere Zusammenfassungen ohne Nachrichtenmetadaten werden ausgelassen. In der neuen Verzweigung werden diese Zusammenfassungen neu erstellt.
 
 Szenen-Chats lassen sich nicht verzweigen. Dort fehlt die Schaltfläche **Branch from here**. Stattdessen gibt es in Szenen-Chats die eigene Aktion **Clone from here** (Ab hier klonen). Wie sie funktioniert, beschreibt [Szenen: Ein Roleplay verzweigen](../roleplay/scenes.md).
 

--- a/de/manifest.json
+++ b/de/manifest.json
@@ -1,6 +1,6 @@
 {
   "language": "de",
-  "sourceCommit": "753cf5520ce0e549aa4d632d5d5d8abbfdd995aa",
+  "sourceCommit": "8e37b39e880d2e827dde7c0c4d28ccc75554ca90",
   "files": [
     {
       "path": "CONFIGURATION.md",
@@ -139,8 +139,8 @@
     },
     {
       "path": "chats/branches.md",
-      "sha256": "ea43552ac30f5d947ba34b6f8d47add55060e144ea218af9cb91542eadf87e3d",
-      "bytes": 6203
+      "sha256": "4a4344741f9b63cc8dbeffb4c1f40837fb0035816d4464193960ffe0efaba2e5",
+      "bytes": 6552
     },
     {
       "path": "chats/chat-settings.md",

--- a/es/chats/branches.md
+++ b/es/chats/branches.md
@@ -25,7 +25,7 @@ Marinara copia el chat hasta ese mensaje inclusive en una rama nueva. La rama nu
 - Empieza con el nombre para mostrar **New Branch** (Rama nueva). Puedes renombrarla (ver más abajo).
 - Se queda en la misma carpeta de chats que el chat de origen.
 
-Los resúmenes de día, los resúmenes de semana y el resumen continuo no se traspasan. La rama nueva los empieza desde cero.
+Los resúmenes diarios y semanales no se traspasan. Los resúmenes continuos con rangos de mensajes guardados completamente contenidos en la rama copiada se traspasan y se reasignan a los nuevos IDs de mensaje de la rama. Los resúmenes cuyo rango de origen cruza el punto de ramificación, o los resúmenes antiguos sin metadatos de mensajes, se omiten. La rama nueva empieza esos resúmenes desde cero.
 
 No puedes ramificar un chat de escena. En un chat de escena, el botón **Branch from here** no aparece. Los chats de escena tienen en su lugar una acción **Clone from here** (Clonar desde aquí) aparte. Consulta [Escenas: Ramificar un Roleplay](../roleplay/scenes.md) para saber cómo funciona.
 

--- a/es/manifest.json
+++ b/es/manifest.json
@@ -1,6 +1,6 @@
 {
   "language": "es",
-  "sourceCommit": "753cf5520ce0e549aa4d632d5d5d8abbfdd995aa",
+  "sourceCommit": "8e37b39e880d2e827dde7c0c4d28ccc75554ca90",
   "files": [
     {
       "path": "CONFIGURATION.md",
@@ -139,8 +139,8 @@
     },
     {
       "path": "chats/branches.md",
-      "sha256": "e59eff0fbdfe05bd985e692f6a4e6814b6048ceb407bdb65a1e9357661e3278f",
-      "bytes": 6014
+      "sha256": "a997a51b3f4f2024f567abb446741ff0f7c7f07b5bf458b7488f44cc63a037c9",
+      "bytes": 6293
     },
     {
       "path": "chats/chat-settings.md",

--- a/fr/chats/branches.md
+++ b/fr/chats/branches.md
@@ -25,7 +25,7 @@ Marinara copie le chat jusqu'à ce message inclus dans une nouvelle branche. Cet
 - Porte au départ le nom d'affichage **New Branch**. Tu peux la renommer, voir plus bas.
 - Reste dans le même dossier de chats que le chat d'origine.
 
-Les résumés du jour, les résumés de la semaine et le résumé glissant ne sont pas repris. La nouvelle branche repart de zéro sur ces trois points.
+Les résumés du jour et de la semaine ne sont pas repris. Les résumés glissants dont les plages de messages enregistrées sont entièrement comprises dans la branche copiée sont repris et réattribués aux nouveaux identifiants de messages de la branche. Les résumés dont la plage source traverse le point de branchement, ainsi que les anciens résumés sans métadonnées de messages, sont ignorés. La nouvelle branche recommence ces résumés à zéro.
 
 Impossible de créer une branche dans un chat de scène. Dans ce type de chat, le bouton **Branch from here** n'apparaît pas : une action distincte, **Clone from here** (cloner à partir d'ici), prend le relais. Le guide [Scènes : créer une branche d'un roleplay](../roleplay/scenes.md) explique son fonctionnement.
 

--- a/fr/manifest.json
+++ b/fr/manifest.json
@@ -1,6 +1,6 @@
 {
   "language": "fr",
-  "sourceCommit": "753cf5520ce0e549aa4d632d5d5d8abbfdd995aa",
+  "sourceCommit": "8e37b39e880d2e827dde7c0c4d28ccc75554ca90",
   "files": [
     {
       "path": "CONFIGURATION.md",
@@ -139,8 +139,8 @@
     },
     {
       "path": "chats/branches.md",
-      "sha256": "4058b90b4a42a7ff39b21d0d1126a69f6b73d1c1910651c140006013770bf872",
-      "bytes": 6262
+      "sha256": "df2410474ec5c6aec229e7452156d47320a4638cbd03e74fcb859cb48de6d59a",
+      "bytes": 6571
     },
     {
       "path": "chats/chat-settings.md",

--- a/pl/chats/branches.md
+++ b/pl/chats/branches.md
@@ -25,7 +25,7 @@ Marinara kopiuje czat do tej wiadomości włącznie i zapisuje go jako nową ga�
 - Startuje z nazwą wyświetlaną **New Branch**. Nazwę można zmienić (opis poniżej).
 - Zostaje w tym samym folderze czatów co czat źródłowy.
 
-Podsumowania dzienne, podsumowania tygodniowe i podsumowanie bieżące nie są przenoszone. Nowa gałąź buduje je od nowa.
+Podsumowania dzienne i tygodniowe nie są przenoszone. Podsumowania bieżące z zapisanymi zakresami wiadomości w całości zawartymi w kopiowanej gałęzi są przenoszone i przypisywane do nowych identyfikatorów wiadomości tej gałęzi. Podsumowania, których zakres źródłowy przekracza punkt utworzenia gałęzi, oraz starsze podsumowania bez metadanych wiadomości są pomijane. Nowa gałąź tworzy te podsumowania od nowa.
 
 Czatu sceny nie da się rozgałęzić. W czacie sceny przycisk **Branch from here** się nie pojawia. Czaty sceny mają zamiast niego osobną akcję **Clone from here** (klonowanie od tego miejsca). Jej działanie opisuje przewodnik [Sceny: odgałęzienie roleplayu](../roleplay/scenes.md).
 

--- a/pl/manifest.json
+++ b/pl/manifest.json
@@ -1,6 +1,6 @@
 {
   "language": "pl",
-  "sourceCommit": "f0e435b5f0928f10a4164535412524fc183e3b50",
+  "sourceCommit": "8e37b39e880d2e827dde7c0c4d28ccc75554ca90",
   "files": [
     {
       "path": "CONFIGURATION.md",
@@ -139,8 +139,8 @@
     },
     {
       "path": "chats/branches.md",
-      "sha256": "6dd56b4b26ec9f2221e65704c4fd3ff3ba8af6a1be71a99bb8cbdda992aeb039",
-      "bytes": 5777
+      "sha256": "bf22f1e5a3f88e3fa3d46f5047dbc70c9915d1853caddcf0379ebbf468323383",
+      "bytes": 6086
     },
     {
       "path": "chats/chat-settings.md",

--- a/pt-br/chats/branches.md
+++ b/pt-br/chats/branches.md
@@ -25,7 +25,7 @@ Marinara copia o chat até aquela mensagem, incluindo ela, para uma nova ramific
 - Começa com o nome de exibição **New Branch**. Você pode renomeá-la (veja abaixo).
 - Fica na mesma pasta de chats do chat de origem.
 
-Os resumos diários, os resumos semanais e o resumo contínuo não são levados junto. A nova ramificação começa com todos eles zerados.
+Os resumos diários e semanais não são levados junto. Os resumos contínuos com intervalos de mensagens persistidos totalmente contidos na ramificação copiada são levados junto e remapeados para os novos IDs de mensagem da ramificação. Os resumos cujo intervalo de origem cruza o ponto de ramificação, ou os resumos antigos sem metadados de mensagens, são deixados de fora. A nova ramificação começa esses resumos do zero.
 
 Não é possível ramificar um chat de cena. Nesse tipo de chat, o botão **Branch from here** não aparece. Os chats de cena têm uma ação própria, a **Clone from here** (clonar a partir daqui). Veja [Cenas: criando uma ramificação do roleplay](../roleplay/scenes.md) para saber como ela funciona.
 

--- a/pt-br/manifest.json
+++ b/pt-br/manifest.json
@@ -1,6 +1,6 @@
 {
   "language": "pt-br",
-  "sourceCommit": "e938ee4ec6d0b2dd98bd4cc2f958580ec1fadf34",
+  "sourceCommit": "8e37b39e880d2e827dde7c0c4d28ccc75554ca90",
   "files": [
     {
       "path": "CONFIGURATION.md",
@@ -139,8 +139,8 @@
     },
     {
       "path": "chats/branches.md",
-      "sha256": "a55c84a938f953d298ff8343a4e732b523dcd6bec73ccab4c731441110f59506",
-      "bytes": 6049
+      "sha256": "b9213ccb7b9e588f0b623323a8047e07295b9263dbde998dee37d1c045d67f33",
+      "bytes": 6345
     },
     {
       "path": "chats/chat-settings.md",


### PR DESCRIPTION
Closes #4248

## Why

The English chat-branches guide now documents which rolling summaries are inherited when creating a branch. The translated packs need the same behavior so users do not receive stale guidance in their selected documentation language.

## What changed

- Updated `chats/branches.md` in German, Spanish, French, Polish, and Brazilian Portuguese.
- Rebuilt each affected language pack manifest with source commit `8e37b39e880d2e827dde7c0c4d28ccc75554ca90`.

## Verification

- `node scripts/docs-i18n/validate-pack.mjs <pack-dir>` passed for all five packs.
- `git diff --check` passed.

## Manual verification

- [x] Manually verify each updated guide in the documentation language viewer.
