### PR TITLE
Fix owner-approval review-event filtering on main

### DIFF
--- a/.github/workflows/pull-request-triage.yml
+++ b/.github/workflows/pull-request-triage.yml
@@ -57,8 +57,12 @@ jobs:
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         with:
           script: |
-            const pr = context.payload.pull_request;
-            if (pr.base?.ref !== 'staging') return;
+            const pullNumber = context.payload.pull_request.number;
+            const { data: pr } = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: pullNumber,
+            });
 
             if (pr.author_association === 'OWNER' || pr.author_association === 'MEMBER') {
               core.notice(`Internal ${pr.author_association.toLowerCase()} contribution; owner approval is not required.`);
@@ -68,7 +72,7 @@ jobs:
             const reviews = await github.paginate(github.rest.pulls.listReviews, {
               owner: context.repo.owner,
               repo: context.repo.repo,
-              pull_number: pr.number,
+              pull_number: pullNumber,
               per_page: 100,
             });
             const ownerReviews = reviews

--- a/.github/workflows/pull-request-triage.yml
+++ b/.github/workflows/pull-request-triage.yml
@@ -6,7 +6,6 @@ on:
     branches: [staging, main]
   pull_request_review:
     types: [submitted, edited, dismissed]
-    branches: [staging, main]
 
 concurrency:
   group: pull-request-triage-${{ github.event.pull_request.number }}
@@ -49,6 +48,7 @@ jobs:
 
   external-contributor-approval:
     name: Owner approval for outside contributors
+    if: github.event.pull_request.base.ref == 'staging'
     runs-on: ubuntu-latest
     permissions:
       pull-requests: read


### PR DESCRIPTION
Closes #4250

## Why this change

The owner-approval gate must rerun when a review is submitted, edited, or dismissed. GitHub does not support a branches filter on the pull_request_review event, so the published filter can prevent the workflow from loading correctly.

## What changed

- Remove the unsupported branches key from pull_request_review.
- Restrict the owner-approval job to staging with a job-level condition.
- Preserve the existing current-head owner approval logic.

## Validation

- [ ] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed `CONTRIBUTING.md`

### Manual verification notes

- Workflow YAML parses successfully.
- `git diff --check` passes.
- CodeRabbit identified the unsupported event filter; the staging PR applies its requested job-level restriction; this hotfix publishes the same workflow correction to the default branch.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Translated docs on the `docs-i18n` branch updated to match, or a `[docs-i18n] <paths>` follow-up issue opened
- [ ] Version/release files updated (only if this PR includes a version bump)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Limited external contributor approval checks to pull requests targeting the staging branch.
  - Adjusted the workflow’s pull request and review lookup logic to ensure approval checks are evaluated consistently for the correct pull request.
  - Preserved existing workflow trigger types and branch filtering behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->