### PR TITLE
Fix editor drafts lost across responsive layout changes

### DIFF
--- a/e2e/core-flows.e2e.ts
+++ b/e2e/core-flows.e2e.ts
@@ -11591,3 +11591,81 @@ test("Background library organization works with desktop drag and touch drag", a
     await page.request.delete(`/api/backgrounds/${encodeURIComponent(currentFilename)}`);
   }
 });
+
+test("character editor preserves unsaved fields across responsive layout changes", async ({
+  page,
+  request,
+}, testInfo) => {
+  test.skip(!testInfo.project.name.includes("desktop"), "Responsive editor regression starts in desktop layout.");
+
+  const characterName = `Responsive Character ${Date.now().toString(36)}`;
+  const response = await request.post("/api/characters", {
+    data: {
+      data: {
+        name: characterName,
+        description: "Saved description",
+      },
+    },
+  });
+  expect(response.ok()).toBeTruthy();
+  const character = (await response.json()) as { id: string };
+
+  try {
+    await page.goto("/");
+    await page.locator('[data-tour="panel-characters"]').click();
+    await page.locator(`[data-touch-drag-card="character"][data-character-id="${character.id}"]`).click();
+
+    const desktopEditor = page.locator('[data-component="DetailEditor"]');
+    const unsavedName = `${characterName} unsaved`;
+    await desktopEditor.locator(".mari-editor-title-input").fill(unsavedName);
+
+    await page.setViewportSize({ width: 760, height: 900 });
+    const mobileEditor = page.locator('[data-component="MobileDetailSheet"]');
+    await expect(mobileEditor).toBeVisible();
+    await expect(mobileEditor.locator(".mari-editor-title-input")).toHaveValue(unsavedName);
+
+    await page.setViewportSize({ width: 1440, height: 900 });
+    await expect(desktopEditor).toBeVisible();
+    await expect(desktopEditor.locator(".mari-editor-title-input")).toHaveValue(unsavedName);
+  } finally {
+    await request.delete(`/api/characters/${character.id}`).catch(() => undefined);
+  }
+});
+
+test("persona editor preserves unsaved fields across responsive layout changes", async ({
+  page,
+  request,
+}, testInfo) => {
+  test.skip(!testInfo.project.name.includes("desktop"), "Responsive editor regression starts in desktop layout.");
+
+  const personaName = `Responsive Persona ${Date.now().toString(36)}`;
+  const response = await request.post("/api/characters/personas", {
+    data: {
+      name: personaName,
+      description: "Saved description",
+    },
+  });
+  expect(response.ok()).toBeTruthy();
+  const persona = (await response.json()) as { id: string };
+
+  try {
+    await page.goto("/");
+    await page.locator('[data-tour="panel-personas"]').click();
+    await page.locator('[data-touch-drag-card="persona"]').filter({ hasText: personaName }).click();
+
+    const desktopEditor = page.locator('[data-component="DetailEditor"]');
+    const unsavedName = `${personaName} unsaved`;
+    await desktopEditor.locator(".mari-editor-title-input").fill(unsavedName);
+
+    await page.setViewportSize({ width: 760, height: 900 });
+    const mobileEditor = page.locator('[data-component="MobileDetailSheet"]');
+    await expect(mobileEditor).toBeVisible();
+    await expect(mobileEditor.locator(".mari-editor-title-input")).toHaveValue(unsavedName);
+
+    await page.setViewportSize({ width: 1440, height: 900 });
+    await expect(desktopEditor).toBeVisible();
+    await expect(desktopEditor.locator(".mari-editor-title-input")).toHaveValue(unsavedName);
+  } finally {
+    await request.delete(`/api/characters/personas/${persona.id}`).catch(() => undefined);
+  }
+});

--- a/packages/client/src/components/layout/AppShell.tsx
+++ b/packages/client/src/components/layout/AppShell.tsx
@@ -1243,7 +1243,10 @@ export function AppShell() {
         data-center-compact={centerCompact ? "true" : undefined}
         data-shell-overlay-mode={shellOverlayMode ? "true" : undefined}
         aria-label={localizeUi("ui.layout.appshell.mainContent")}
-        className="@container mari-main mari-app-background-paint relative flex min-w-0 flex-1 flex-col overflow-hidden"
+        className={cn(
+          "@container mari-main mari-app-background-paint relative flex min-w-0 flex-1 flex-col overflow-hidden",
+          shellOverlayMode && hasDetailView && "z-50",
+        )}
       >
         {/* iOS safe area spacer — pushes TopBar below status bar and fills that gap with topbar bg */}
         <div className="flex-shrink-0 md:hidden h-[env(safe-area-inset-top)] bg-[var(--marinara-topbar-surface)] backdrop-blur-sm" />
@@ -1260,7 +1263,8 @@ export function AppShell() {
           <div
             className={cn(
               "mari-app-background-paint flex flex-1 flex-col overflow-hidden",
-              (botBrowserOpen || gameAssetsBrowserOpen) && "hidden",
+              (botBrowserOpen || gameAssetsBrowserOpen || (!shellOverlayMode && hasDetailView && !noodleOpen)) &&
+                "hidden",
             )}
             style={
               {
@@ -1271,19 +1275,35 @@ export function AppShell() {
             }
           >
             <Suspense fallback={<MainPaneFallback />}>
-              {shellOverlayMode ? (
-                noodleOpen ? (
-                  <NoodleView />
-                ) : (
-                  <ChatArea />
-                )
-              ) : noodleOpen ? (
-                <NoodleView />
-              ) : (
-                (detailView ?? <ChatArea />)
-              )}
+              {noodleOpen ? <NoodleView /> : (shellOverlayMode || !hasDetailView) && <ChatArea />}
             </Suspense>
           </div>
+          {/* Keep the detail host at one React tree position across the mobile breakpoint.
+              Moving an editor between separate desktop/mobile branches remounts it and
+              discards component-local unsaved form state. */}
+          <AnimatePresence mode="wait">
+            {detailView && (shellOverlayMode || !noodleOpen) && (
+              <motion.aside
+                key="detail-editor"
+                initial={shellOverlayMode ? { opacity: 0, x: 24 } : false}
+                animate={{ opacity: 1, x: 0 }}
+                exit={shellOverlayMode ? { opacity: 0, x: 24 } : undefined}
+                transition={{ type: "spring", damping: 30, stiffness: 360 }}
+                data-component={shellOverlayMode ? "MobileDetailSheet" : "DetailEditor"}
+                aria-label={localizeUi("ui.layout.appshell.detailEditor")}
+                className={cn(
+                  "mari-app-background-paint flex min-h-0 flex-1 flex-col overflow-hidden",
+                  shellOverlayMode &&
+                    cn(
+                      "mari-mobile-detail-sheet !fixed bottom-0 right-0 z-50 !w-full bg-[var(--background)]/95 pb-[max(env(safe-area-inset-bottom),0.5rem)] shadow-2xl backdrop-blur-xl",
+                      MOBILE_SHELL_PANEL_TOP_CLASS,
+                    ),
+                )}
+              >
+                <Suspense fallback={<MainPaneFallback />}>{detailView}</Suspense>
+              </motion.aside>
+            )}
+          </AnimatePresence>
         </div>
         {/* Floating avatar notification bubbles (right edge) */}
         <Suspense fallback={null}>
@@ -1407,25 +1427,6 @@ export function AppShell() {
         </aside>
       )}
 
-      {shellOverlayMode && detailView && (
-        <AnimatePresence mode="wait">
-          <motion.aside
-            key="mobile-detail"
-            initial={{ opacity: 0, x: 24 }}
-            animate={{ opacity: 1, x: 0 }}
-            exit={{ opacity: 0, x: 24 }}
-            transition={{ type: "spring", damping: 30, stiffness: 360 }}
-            data-component="MobileDetailSheet"
-            aria-label={localizeUi("ui.layout.appshell.detailEditor")}
-            className={cn(
-              "mari-mobile-detail-sheet !fixed bottom-0 right-0 z-40 flex min-h-0 !w-full flex-col overflow-hidden bg-[var(--background)]/95 pb-[max(env(safe-area-inset-bottom),0.5rem)] shadow-2xl backdrop-blur-xl",
-              MOBILE_SHELL_PANEL_TOP_CLASS,
-            )}
-          >
-            <Suspense fallback={<MainPaneFallback />}>{detailView}</Suspense>
-          </motion.aside>
-        </AnimatePresence>
-      )}
       {!shellOverlayMode && rightPanelOpen && (
         <div
           role="separator"


### PR DESCRIPTION
## Linked issue

Closes #4244

## Why this change

Crossing the desktop/mobile breakpoint mounted character and persona editors in different React tree positions. That remount discarded component-local unsaved fields, colors, and stats without warning.

This branch preserves contributor olegpro171's implementation and commit authorship while bringing it onto current staging for maintainer validation.

## What changed

- Keep one detail-editor host at a stable React tree position across responsive layout changes.
- Adapt the same host between desktop detail view and the mobile detail sheet without remounting the editor.
- Add desktop-to-mobile-to-desktop Playwright regressions for unsaved character and persona names.

## Validation

- [ ] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed `CONTRIBUTING.md`

### Manual verification notes

Manual browser verification remains required before merge.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Translated docs on the `docs-i18n` branch updated to match, or a `[docs-i18n]` follow-up issue opened
- [ ] Version/release files updated

## UI evidence

See the reproduction recording attached to #4244.
