### PR TITLE
Fix mobile chat behavior and add recent media history

### DIFF
--- a/.github/workflows/pull-request-triage.yml
+++ b/.github/workflows/pull-request-triage.yml
@@ -63,9 +63,11 @@ jobs:
               repo: context.repo.repo,
               pull_number: pullNumber,
             });
+            const repositoryName = `${context.repo.owner}/${context.repo.repo}`.toLowerCase();
+            const sameRepositoryBranch = pr.head?.repo?.full_name?.toLowerCase() === repositoryName;
 
-            if (pr.author_association === 'OWNER' || pr.author_association === 'MEMBER') {
-              core.notice(`Internal ${pr.author_association.toLowerCase()} contribution; owner approval is not required.`);
+            if (sameRepositoryBranch || pr.author_association === 'OWNER' || pr.author_association === 'MEMBER') {
+              core.notice('Internal same-repository contribution; owner approval is not required.');
               return;
             }
 

--- a/e2e/core-flows.e2e.ts
+++ b/e2e/core-flows.e2e.ts
@@ -10899,6 +10899,25 @@ test("mobile chat composer follows the visual viewport above the software keyboa
     });
     await expect(shell).not.toHaveAttribute("data-chat-surface-active");
     await expect.poll(() => shell.evaluate((element) => getComputedStyle(element).transform)).toBe("none");
+
+    await page.evaluate(async (chatId) => {
+      const storePath = "/src/stores/ui.store.ts";
+      const { useUIStore } = (await import(/* @vite-ignore */ storePath)) as {
+        useUIStore: {
+          getState: () => {
+            closeBotBrowser: () => void;
+            setTrackerPanelEnabled: (enabled: boolean) => void;
+            setTrackerPanelOpen: (open: boolean, chatId?: string | null) => void;
+          };
+        };
+      };
+      const store = useUIStore.getState();
+      store.closeBotBrowser();
+      store.setTrackerPanelEnabled(true);
+      store.setTrackerPanelOpen(true, chatId);
+    }, chat.id);
+    await expect(shell).not.toHaveAttribute("data-chat-surface-active");
+    await expect.poll(() => shell.evaluate((element) => getComputedStyle(element).transform)).toBe("none");
   } finally {
     await page.request.delete(`/api/chats/${chat.id}`).catch(() => undefined);
   }

--- a/e2e/core-flows.e2e.ts
+++ b/e2e/core-flows.e2e.ts
@@ -1459,7 +1459,7 @@ test("Connection image captioning defaults persist with a dedicated captioning c
       .getByText("Use custom defaults for this connection", { exact: true })
       .evaluate((element) => (element as HTMLElement).click());
     await expect(editor.getByRole("checkbox", { name: "Use custom defaults for this connection" })).toBeChecked();
-    await editor.getByText("Image Captioning", { exact: true }).evaluate((element) => (element as HTMLElement).click());
+    await editor.getByText("Image Captioning", { exact: true }).click();
     await expect(editor.getByRole("checkbox", { name: "Image Captioning" })).toBeChecked();
     const captioningSelect = editor
       .getByText("Captioning Connection", { exact: true })
@@ -10827,6 +10827,7 @@ test("mobile chat composer follows the visual viewport above the software keyboa
         useUIStore: {
           getState: () => {
             setAppBackgroundColor: (color: string) => void;
+            setVisualTheme: (theme: "default" | "sillytavern") => void;
           };
         };
       };
@@ -10840,6 +10841,32 @@ test("mobile chat composer follows the visual viewport above the software keyboa
         })),
       )
       .toEqual({ html: "rgb(18, 52, 86)", body: "rgb(18, 52, 86)" });
+
+    await page.evaluate(async () => {
+      const storePath = "/src/stores/ui.store.ts";
+      const { useUIStore } = (await import(/* @vite-ignore */ storePath)) as {
+        useUIStore: {
+          getState: () => {
+            setAppBackgroundColor: (color: string) => void;
+            setVisualTheme: (theme: "default" | "sillytavern") => void;
+          };
+        };
+      };
+      const style = document.createElement("style");
+      style.id = "marinara-safe-area-theme-smoke";
+      style.textContent = 'html[data-visual-theme="sillytavern"][data-theme] { --background: rgb(101, 67, 33); }';
+      document.head.appendChild(style);
+      useUIStore.getState().setAppBackgroundColor("");
+      useUIStore.getState().setVisualTheme("sillytavern");
+    });
+    await expect
+      .poll(() =>
+        page.evaluate(() => ({
+          html: document.documentElement.style.getPropertyValue("background-color"),
+          body: document.body.style.getPropertyValue("background-color"),
+        })),
+      )
+      .toEqual({ html: "rgb(101, 67, 33)", body: "rgb(101, 67, 33)" });
 
     await page.evaluate(() => {
       Object.defineProperty(window, "scrollY", {
@@ -10858,6 +10885,20 @@ test("mobile chat composer follows the visual viewport above the software keyboa
     await expect
       .poll(() => page.evaluate(() => getComputedStyle(document.querySelector<HTMLElement>(".mari-app")!).transform))
       .toContain("64");
+
+    await page.evaluate(async () => {
+      const storePath = "/src/stores/ui.store.ts";
+      const { useUIStore } = (await import(/* @vite-ignore */ storePath)) as {
+        useUIStore: {
+          getState: () => {
+            openBotBrowser: () => void;
+          };
+        };
+      };
+      useUIStore.getState().openBotBrowser();
+    });
+    await expect(shell).not.toHaveAttribute("data-chat-surface-active");
+    await expect.poll(() => shell.evaluate((element) => getComputedStyle(element).transform)).toBe("none");
   } finally {
     await page.request.delete(`/api/chats/${chat.id}`).catch(() => undefined);
   }
@@ -10916,6 +10957,7 @@ test("focused mobile composers stay open while history scrolls in Conversation a
       await expect
         .poll(() => transcript.evaluate((element) => element.scrollHeight - element.scrollTop - element.clientHeight))
         .toBeGreaterThan(180);
+      await expect(textarea).toBeFocused();
       await expect(textarea).toBeVisible();
     }
   } finally {
@@ -11066,7 +11108,11 @@ test("media pickers persist and surface recently used items", async ({ page }, t
     const kaomojiPicker = mediaPicker.getByRole("dialog", { name: "Kaomoji picker" });
     const recentKaomoji = kaomojiPicker.locator('[data-recent-media="kaomoji"]');
     await expect(recentKaomoji).toContainText("(づ｡◕‿‿◕｡)づ");
-    const newKaomoji = kaomojiPicker.locator("[data-kaomoji-results] > div.grid button").first();
+    const kaomojiOptions = kaomojiPicker.locator("[data-kaomoji-results] > div.grid button");
+    const kaomojiValues = (await kaomojiOptions.allTextContents()).map((value) => value.trim());
+    const newKaomojiIndex = kaomojiValues.findIndex((value) => value !== "(づ｡◕‿‿◕｡)づ");
+    expect(newKaomojiIndex).toBeGreaterThanOrEqual(0);
+    const newKaomoji = kaomojiOptions.nth(newKaomojiIndex);
     const newKaomojiValue = (await newKaomoji.textContent())?.trim();
     expect(newKaomojiValue).toBeTruthy();
     await newKaomoji.click();
@@ -11088,6 +11134,12 @@ test("media pickers persist and surface recently used items", async ({ page }, t
     const stored = await page.evaluate(() => JSON.parse(localStorage.getItem("marinara-recent-media-v1") ?? "{}"));
     expect(stored.emoji[0].value).toBe("🧪");
     expect(stored.kaomoji[0].value).toBe(newKaomojiValue);
+
+    await page.evaluate(() => {
+      localStorage.removeItem("marinara-recent-media-v1");
+      window.dispatchEvent(new StorageEvent("storage", { key: null }));
+    });
+    await expect(recentStickerSection).toHaveCount(0);
   } finally {
     await page.request.delete(`/api/custom-stickers/${sticker.id}`).catch(() => undefined);
     await page.request.delete(`/api/chats/${chat.id}`).catch(() => undefined);

--- a/e2e/core-flows.e2e.ts
+++ b/e2e/core-flows.e2e.ts
@@ -1437,15 +1437,12 @@ test("Connection image captioning defaults persist with a dedicated captioning c
   const captionConnection = (await captionConnectionResponse.json()) as { id: string };
 
   try {
-    const invalidDefaultsResponse = await request.put(
-      `/api/connections/${chatConnection.id}/default-parameters`,
-      {
-        data: {
-          imageCaptioningEnabled: true,
-          imageCaptioningConnectionId: "",
-        },
+    const invalidDefaultsResponse = await request.put(`/api/connections/${chatConnection.id}/default-parameters`, {
+      data: {
+        imageCaptioningEnabled: true,
+        imageCaptioningConnectionId: "",
       },
-    );
+    });
     expect(invalidDefaultsResponse.status()).toBe(400);
 
     await page.goto("/");
@@ -1462,9 +1459,7 @@ test("Connection image captioning defaults persist with a dedicated captioning c
       .getByText("Use custom defaults for this connection", { exact: true })
       .evaluate((element) => (element as HTMLElement).click());
     await expect(editor.getByRole("checkbox", { name: "Use custom defaults for this connection" })).toBeChecked();
-    await editor
-      .getByText("Image Captioning", { exact: true })
-      .evaluate((element) => (element as HTMLElement).click());
+    await editor.getByText("Image Captioning", { exact: true }).evaluate((element) => (element as HTMLElement).click());
     await expect(editor.getByRole("checkbox", { name: "Image Captioning" })).toBeChecked();
     const captioningSelect = editor
       .getByText("Captioning Connection", { exact: true })
@@ -2163,10 +2158,7 @@ test("Matched full-body sprites approve a neutral anchor before using portrait r
     await page.goto("/");
     await page.locator('[data-tour="panel-characters"]').click();
     const rightPanel = page.locator('[data-component="RightPanelDesktop"]');
-    await rightPanel
-      .locator('[data-touch-drag-card="character"]')
-      .filter({ hasText: characterName })
-      .click();
+    await rightPanel.locator('[data-touch-drag-card="character"]').filter({ hasText: characterName }).click();
 
     const editor = page.locator(".mari-editor-shell");
     await editor
@@ -2710,20 +2702,14 @@ test("desktop Roleplay composition keeps ambient work off the input path and gro
     await page.evaluate(() => {
       const measurementWindow = window as Window & { __lastKeyboardOpen?: boolean };
       window.addEventListener("marinara:chat-visual-viewport-change", (event) => {
-        measurementWindow.__lastKeyboardOpen = (
-          event as CustomEvent<{ keyboardOpen?: boolean }>
-        ).detail?.keyboardOpen;
+        measurementWindow.__lastKeyboardOpen = (event as CustomEvent<{ keyboardOpen?: boolean }>).detail?.keyboardOpen;
       });
     });
     await page.setViewportSize({ width: 1440, height: 700 });
     await input.focus();
 
     await expect
-      .poll(() =>
-        page.evaluate(
-          () => (window as Window & { __lastKeyboardOpen?: boolean }).__lastKeyboardOpen,
-        ),
-      )
+      .poll(() => page.evaluate(() => (window as Window & { __lastKeyboardOpen?: boolean }).__lastKeyboardOpen))
       .toBe(false);
     await expect(root).not.toHaveAttribute("data-marinara-accent-animation");
 
@@ -2754,31 +2740,29 @@ test("desktop Roleplay composition keeps ambient work off the input path and gro
 
     const resizeStability = await input.evaluate(
       (element) =>
-        new Promise<{ heightDelta: number; delayedStyleMutations: number; overflowY: string }>(
-          (resolve) => {
-            const heights: number[] = [];
-            let delayedStyleMutations = 0;
-            const observer = new MutationObserver((records) => {
-              delayedStyleMutations += records.length;
-            });
-            observer.observe(element, { attributes: true, attributeFilter: ["style"] });
+        new Promise<{ heightDelta: number; delayedStyleMutations: number; overflowY: string }>((resolve) => {
+          const heights: number[] = [];
+          let delayedStyleMutations = 0;
+          const observer = new MutationObserver((records) => {
+            delayedStyleMutations += records.length;
+          });
+          observer.observe(element, { attributes: true, attributeFilter: ["style"] });
 
-            const sample = () => {
-              heights.push(element.getBoundingClientRect().height);
-              if (heights.length < 18) {
-                requestAnimationFrame(sample);
-                return;
-              }
-              observer.disconnect();
-              resolve({
-                heightDelta: Math.max(...heights) - Math.min(...heights),
-                delayedStyleMutations,
-                overflowY: element.style.overflowY,
-              });
-            };
-            requestAnimationFrame(sample);
-          },
-        ),
+          const sample = () => {
+            heights.push(element.getBoundingClientRect().height);
+            if (heights.length < 18) {
+              requestAnimationFrame(sample);
+              return;
+            }
+            observer.disconnect();
+            resolve({
+              heightDelta: Math.max(...heights) - Math.min(...heights),
+              delayedStyleMutations,
+              overflowY: element.style.overflowY,
+            });
+          };
+          requestAnimationFrame(sample);
+        }),
     );
     expect(resizeStability.heightDelta).toBeLessThanOrEqual(1);
     expect(resizeStability.delayedStyleMutations).toBe(0);
@@ -10836,8 +10820,106 @@ test("mobile chat composer follows the visual viewport above the software keyboa
     expect(Math.abs(iosShellBox!.height - 360)).toBeLessThanOrEqual(1);
     expect(iosComposerBox!.y).toBeGreaterThanOrEqual(0);
     expect(iosComposerBox!.y + iosComposerBox!.height).toBeLessThanOrEqual(360);
+
+    await page.evaluate(async () => {
+      const storePath = "/src/stores/ui.store.ts";
+      const { useUIStore } = (await import(/* @vite-ignore */ storePath)) as {
+        useUIStore: {
+          getState: () => {
+            setAppBackgroundColor: (color: string) => void;
+          };
+        };
+      };
+      useUIStore.getState().setAppBackgroundColor("#123456");
+    });
+    await expect
+      .poll(() =>
+        page.evaluate(() => ({
+          html: document.documentElement.style.getPropertyValue("background-color"),
+          body: document.body.style.getPropertyValue("background-color"),
+        })),
+      )
+      .toEqual({ html: "rgb(18, 52, 86)", body: "rgb(18, 52, 86)" });
+
+    await page.evaluate(() => {
+      Object.defineProperty(window, "scrollY", {
+        configurable: true,
+        get: () => 64,
+      });
+      window.visualViewport?.dispatchEvent(new Event("scroll"));
+    });
+    await expect
+      .poll(() =>
+        page.evaluate(() =>
+          getComputedStyle(document.documentElement).getPropertyValue("--mari-app-scroll-compensate").trim(),
+        ),
+      )
+      .toBe("64px");
+    await expect
+      .poll(() => page.evaluate(() => getComputedStyle(document.querySelector<HTMLElement>(".mari-app")!).transform))
+      .toContain("64");
   } finally {
     await page.request.delete(`/api/chats/${chat.id}`).catch(() => undefined);
+  }
+});
+
+test("focused mobile composers stay open while history scrolls in Conversation and Roleplay", async ({
+  page,
+}, testInfo) => {
+  test.skip(!testInfo.project.name.includes("mobile"), "Focused composer history behavior is mobile-only.");
+
+  const chatIds: string[] = [];
+  try {
+    await page.goto("/");
+    for (const mode of ["conversation", "roleplay"] as const) {
+      const response = await page.request.post("/api/chats", {
+        data: {
+          name: `${mode} focused composer smoke`,
+          mode,
+          characterIds: [],
+        },
+      });
+      expect(response.ok()).toBeTruthy();
+      const chat = (await response.json()) as { id: string };
+      chatIds.push(chat.id);
+      for (let index = 0; index < 18; index += 1) {
+        const messageResponse = await page.request.post(`/api/chats/${chat.id}/messages`, {
+          data: {
+            role: index % 2 === 0 ? "user" : "assistant",
+            content: `${mode} focused composer history ${index + 1}. ${"Scrollable context. ".repeat(4)}`,
+          },
+        });
+        expect(messageResponse.ok()).toBeTruthy();
+      }
+
+      await page.evaluate((chatId) => {
+        localStorage.setItem("marinara-active-chat-id", chatId);
+      }, chat.id);
+      await page.reload();
+
+      const transcript = page.locator(".mari-messages-scroll:visible").first();
+      const textarea = page.locator('[data-chat-composer="true"]:visible');
+      await expect(page.locator(`[data-chat-mode="${mode}"]`)).toBeVisible();
+      await expect(transcript).toBeVisible();
+      await expect
+        .poll(() => transcript.evaluate((element) => element.scrollHeight - element.clientHeight))
+        .toBeGreaterThan(400);
+      await transcript.evaluate((element) => {
+        element.scrollTop = element.scrollHeight;
+      });
+      await textarea.focus();
+      await expect(textarea).toBeFocused();
+
+      await transcript.evaluate((element) => {
+        element.scrollTop = Math.max(0, element.scrollTop - 320);
+      });
+      await expect
+        .poll(() => transcript.evaluate((element) => element.scrollHeight - element.scrollTop - element.clientHeight))
+        .toBeGreaterThan(180);
+      await expect(textarea).toBeVisible();
+    }
+  } finally {
+    await Promise.all(chatIds.map((chatId) => page.request.delete(`/api/chats/${chatId}`).catch(() => undefined)));
   }
 });
 
@@ -10858,7 +10940,8 @@ test("Conversation media searches match GIFs and internal presses keep the picke
     }, chat.id);
     await page.goto("/");
 
-    await page.getByRole("button", { name: /Emoji, GIFs/u }).click();
+    const mediaButton = page.getByRole("button", { name: /Emoji, GIFs/u });
+    await mediaButton.click();
     const mediaPicker = page.locator("[data-conversation-media-picker]:visible");
     await expect(mediaPicker).toBeVisible();
     const emojiSearchInput = page.locator('input[placeholder="Search emojis..."]:visible');
@@ -10915,6 +10998,98 @@ test("Conversation media searches match GIFs and internal presses keep the picke
     expect(emojiSearchStyle).toEqual(gifSearchStyle);
     expect(kaomojiSearchStyle).toEqual(gifSearchStyle);
   } finally {
+    await page.request.delete(`/api/chats/${chat.id}`).catch(() => undefined);
+  }
+});
+
+test("media pickers persist and surface recently used items", async ({ page }, testInfo) => {
+  const projectSuffix = testInfo.project.name.includes("mobile") ? "mobile" : "desktop";
+  const stickerName = `recent_${projectSuffix}_${Date.now().toString(36)}`.slice(0, 32);
+  const stickerResponse = await page.request.post("/api/custom-stickers/upload", {
+    multipart: {
+      file: {
+        name: `${stickerName}.gif`,
+        mimeType: "image/gif",
+        buffer: Buffer.from(TRANSPARENT_GIF_BASE64, "base64"),
+      },
+      name: stickerName,
+    },
+  });
+  expect(stickerResponse.ok()).toBeTruthy();
+  const sticker = (await stickerResponse.json()) as { id: string; name: string; url: string };
+
+  const response = await page.request.post("/api/chats", {
+    data: {
+      name: "Recent media smoke",
+      mode: "conversation",
+      characterIds: [],
+    },
+  });
+  expect(response.ok()).toBeTruthy();
+  const chat = (await response.json()) as { id: string };
+  const recentGif = `data:image/gif;base64,${TRANSPARENT_GIF_BASE64}`;
+
+  try {
+    await page.addInitScript(
+      ({ chatId, gifUrl, stickerValue, stickerUrl }) => {
+        localStorage.setItem("marinara-active-chat-id", chatId);
+        localStorage.setItem(
+          "marinara-recent-media-v1",
+          JSON.stringify({
+            emoji: [{ value: "🌶️", label: "hot pepper" }],
+            kaomoji: [{ value: "(づ｡◕‿‿◕｡)づ", label: "(づ｡◕‿‿◕｡)づ" }],
+            gif: [{ value: gifUrl, label: "Recent GIF", previewUrl: gifUrl }],
+            sticker: [{ value: stickerValue, label: stickerValue, previewUrl: stickerUrl }],
+          }),
+        );
+      },
+      { chatId: chat.id, gifUrl: recentGif, stickerValue: sticker.name, stickerUrl: sticker.url },
+    );
+    await page.goto("/");
+
+    const mediaButton = page.getByRole("button", { name: /Emoji, GIFs/u });
+    await mediaButton.click();
+    const mediaPicker = page.locator("[data-conversation-media-picker]:visible");
+    await expect(mediaPicker).toBeVisible();
+
+    const recentEmoji = mediaPicker.locator('[data-recent-media="emoji"]');
+    await expect(recentEmoji).toContainText("Recently used");
+    await expect(recentEmoji.getByRole("button", { name: "hot pepper" })).toBeVisible();
+    const emojiSearch = mediaPicker.getByRole("textbox", { name: "Search emojis" });
+    await emojiSearch.fill("test tube");
+    await mediaPicker.getByRole("button", { name: /test tube/i }).click();
+    await expect(mediaPicker).toBeHidden();
+    await mediaButton.click();
+    await expect(recentEmoji.getByRole("button", { name: /test tube/i })).toBeVisible();
+
+    await mediaPicker.getByRole("button", { name: "Kaomoji", exact: true }).click();
+    const kaomojiPicker = mediaPicker.getByRole("dialog", { name: "Kaomoji picker" });
+    const recentKaomoji = kaomojiPicker.locator('[data-recent-media="kaomoji"]');
+    await expect(recentKaomoji).toContainText("(づ｡◕‿‿◕｡)づ");
+    const newKaomoji = kaomojiPicker.locator("[data-kaomoji-results] > div.grid button").first();
+    const newKaomojiValue = (await newKaomoji.textContent())?.trim();
+    expect(newKaomojiValue).toBeTruthy();
+    await newKaomoji.click();
+    await expect(mediaPicker).toBeHidden();
+    await mediaButton.click();
+    await mediaPicker.getByRole("button", { name: "Kaomoji", exact: true }).click();
+    await expect(recentKaomoji.locator("button").first()).toContainText(newKaomojiValue!);
+
+    await mediaPicker.getByRole("button", { name: "GIFs", exact: true }).click();
+    const recentGifSection = mediaPicker.locator('[data-recent-media="gif"]');
+    await expect(recentGifSection).toContainText("Recently used");
+    await expect(recentGifSection.locator('[title="Recent GIF"]')).toBeVisible();
+
+    await mediaPicker.getByRole("button", { name: "Stickers", exact: true }).click();
+    const recentStickerSection = mediaPicker.locator('[data-recent-media="sticker"]');
+    await expect(recentStickerSection).toContainText("Recently used");
+    await expect(recentStickerSection.locator(`[title="Send sticker:${stickerName}:"]`)).toBeVisible();
+
+    const stored = await page.evaluate(() => JSON.parse(localStorage.getItem("marinara-recent-media-v1") ?? "{}"));
+    expect(stored.emoji[0].value).toBe("🧪");
+    expect(stored.kaomoji[0].value).toBe(newKaomojiValue);
+  } finally {
+    await page.request.delete(`/api/custom-stickers/${sticker.id}`).catch(() => undefined);
     await page.request.delete(`/api/chats/${chat.id}`).catch(() => undefined);
   }
 });
@@ -11232,9 +11407,10 @@ test("Background cards keep names readable and load thumbnails", async ({ page }
   await expect(page.getByRole("dialog", { name: "Background Library" })).toBeHidden();
   await page.getByRole("button", { name: "Browse library" }).click();
   await expect(page.getByRole("dialog", { name: "Background Library" })).toBeVisible();
-  await expect(
-    page.locator('[data-background-id="user:collapsible-background-tags.png"]'),
-  ).toHaveAttribute("data-background-selected", "true");
+  await expect(page.locator('[data-background-id="user:collapsible-background-tags.png"]')).toHaveAttribute(
+    "data-background-selected",
+    "true",
+  );
 });
 
 test("Roleplay displays a selected background when its file route is GET-only", async ({ page }, testInfo) => {

--- a/packages/client/src/App.tsx
+++ b/packages/client/src/App.tsx
@@ -496,10 +496,7 @@ export function App() {
     [activeCustomTheme?.css],
   );
   const pauseChromeEffectsForAppearance =
-    appearanceSettingsActive &&
-    !appAccentRgbMode &&
-    !appAccentPulseMode &&
-    !themeAccentPulseConfig.enabled;
+    appearanceSettingsActive && !appAccentRgbMode && !appAccentPulseMode && !themeAccentPulseConfig.enabled;
   useLegacyThemeMigration();
   useSettingsSync();
   const showDownloadModal = useSidecarStore((s) => s.showDownloadModal);
@@ -593,13 +590,21 @@ export function App() {
       root.style.removeProperty("--marinara-app-background-paint");
     }
 
-    // iOS paints the safe-area/overscroll backing from the literal html/body
-    // background-color, not from resolved custom properties (see index.html).
-    // Keep that literal color tracking the active theme/custom background so
-    // it doesn't stay stuck on the dark-theme default baked into the HTML.
-    root.style.setProperty("background-color", resolvedBackground, "important");
-    document.body.style.setProperty("background-color", resolvedBackground, "important");
-  }, [appBackgroundColor, theme]);
+    const syncLiteralBackground = () => {
+      // iOS paints the safe-area/overscroll backing from the literal html/body
+      // background-color, not from resolved custom properties (see index.html).
+      // Read the rendered variable so visual themes and injected custom theme
+      // CSS are reflected instead of falling back to the stock scheme.
+      const computedBackground = getComputedStyle(root).getPropertyValue("--background").trim();
+      const literalBackground = getCssColorFallback(computedBackground, resolvedBackground);
+      root.style.setProperty("background-color", literalBackground, "important");
+      document.body.style.setProperty("background-color", literalBackground, "important");
+    };
+
+    syncLiteralBackground();
+    const frame = requestAnimationFrame(syncLiteralBackground);
+    return () => cancelAnimationFrame(frame);
+  }, [activeCustomTheme?.css, appBackgroundColor, theme, visualTheme]);
 
   useEffect(() => {
     const root = document.documentElement;

--- a/packages/client/src/App.tsx
+++ b/packages/client/src/App.tsx
@@ -583,14 +583,22 @@ export function App() {
     const root = document.documentElement;
     const background = appBackgroundColor.trim();
     const defaultBackground = getDefaultAppBackgroundColor(theme);
+    const resolvedBackground = getCssColorFallback(background, defaultBackground);
 
     if (background) {
-      root.style.setProperty("--background", getCssColorFallback(background, defaultBackground));
+      root.style.setProperty("--background", resolvedBackground);
       root.style.setProperty("--marinara-app-background-paint", background);
     } else {
       root.style.removeProperty("--background");
       root.style.removeProperty("--marinara-app-background-paint");
     }
+
+    // iOS paints the safe-area/overscroll backing from the literal html/body
+    // background-color, not from resolved custom properties (see index.html).
+    // Keep that literal color tracking the active theme/custom background so
+    // it doesn't stay stuck on the dark-theme default baked into the HTML.
+    root.style.setProperty("background-color", resolvedBackground, "important");
+    document.body.style.setProperty("background-color", resolvedBackground, "important");
   }, [appBackgroundColor, theme]);
 
   useEffect(() => {

--- a/packages/client/src/components/chat/ChatRoleplaySurface.tsx
+++ b/packages/client/src/components/chat/ChatRoleplaySurface.tsx
@@ -50,7 +50,7 @@ import { useUIStore } from "../../stores/ui.store";
 import { useChatStore } from "../../stores/chat.store";
 import { useGameStateStore } from "../../stores/game-state.store";
 import { useThrottledStreamBuffer } from "../../hooks/use-throttled-stream-buffer";
-import { useChatKeyboardOpen } from "../../hooks/use-visual-viewport-chat-bottom";
+import { useChatComposerFocused, useChatKeyboardOpen } from "../../hooks/use-visual-viewport-chat-bottom";
 import { useActiveLorebookEntries, useLorebooks } from "../../hooks/use-lorebooks";
 import { usePresetFull, usePresets } from "../../hooks/use-presets";
 import { ChatMessage } from "./ChatMessage";
@@ -577,13 +577,7 @@ function ActiveContextLinksButton({
         {visibleLorebookIds.map((id, index) => {
           const entries = triggeredEntriesByLorebook.get(id) ?? [];
           return (
-            <button
-              key={id}
-              type="button"
-              role="menuitem"
-              className={itemClassName}
-              onClick={() => openLorebook(id)}
-            >
+            <button key={id} type="button" role="menuitem" className={itemClassName} onClick={() => openLorebook(id)}>
               <BookOpen size="0.8125rem" className={iconClassName} />
               <span className="min-w-0 flex-1 truncate">
                 {lorebookNameById.get(id) ?? t("chat.toolbar.lorebookFallback", { number: index + 1 })}
@@ -1099,11 +1093,7 @@ type RoleplaySurfaceProps = {
   onEdit: (messageId: string, content: string) => void;
   onSetActiveSwipe: (messageId: string, index: number) => void;
   onToggleConversationStart: (messageId: string, current: boolean) => void;
-  onToggleHiddenFromAI: (
-    messageId: string,
-    hiddenFromAll: boolean,
-    hiddenFromAICharacterIds?: string[],
-  ) => void;
+  onToggleHiddenFromAI: (messageId: string, hiddenFromAll: boolean, hiddenFromAICharacterIds?: string[]) => void;
   onPeekPrompt: () => void;
   onBranch?: (messageId: string) => void;
   onCloneSceneFromHere?: (messageId: string) => void;
@@ -1294,9 +1284,11 @@ export function ChatRoleplaySurface({
   const expandedAuthorNotesOpen = authorNotesOpenOwner === "expanded";
   const compactAuthorNotesOpen = authorNotesOpenOwner === "compact";
   const keyboardOpen = useChatKeyboardOpen();
+  const composerFocused = useChatComposerFocused();
   const ambientVisualsPaused =
-    generationVisualsPaused || (isMobileToolbarViewport && (keyboardOpen || hasMobileDraftInput));
-  const shouldKeepMobileComposerOpen = keyboardOpen || hasLiveStream || hasMobileDraftInput || isFetchingNextPage;
+    generationVisualsPaused || (isMobileToolbarViewport && (keyboardOpen || composerFocused || hasMobileDraftInput));
+  const shouldKeepMobileComposerOpen =
+    keyboardOpen || composerFocused || hasLiveStream || hasMobileDraftInput || isFetchingNextPage;
 
   useEffect(() => {
     if (shouldKeepMobileComposerOpen) setMobileHistoryComposerCollapsed(false);
@@ -1323,18 +1315,12 @@ export function ChatRoleplaySurface({
     el.addEventListener("scroll", onScroll, { passive: true });
     return () => el.removeEventListener("scroll", onScroll);
   }, [scrollRef, shouldKeepMobileComposerOpen]);
-  const setExpandedAuthorNotesOpen = useCallback(
-    (open: boolean) => {
-      setAuthorNotesOpenOwner(open ? "expanded" : null);
-    },
-    [],
-  );
-  const setCompactAuthorNotesOpen = useCallback(
-    (open: boolean) => {
-      setAuthorNotesOpenOwner(open ? "compact" : null);
-    },
-    [],
-  );
+  const setExpandedAuthorNotesOpen = useCallback((open: boolean) => {
+    setAuthorNotesOpenOwner(open ? "expanded" : null);
+  }, []);
+  const setCompactAuthorNotesOpen = useCallback((open: boolean) => {
+    setAuthorNotesOpenOwner(open ? "compact" : null);
+  }, []);
   const hideEchoChamberOnMobile = sidebarOpen || rightPanelOpen || settingsOpen || galleryOpen || wizardOpen;
   const showSpriteOverlay = expressionAgentEnabled && spriteCharacterIds.length > 0 && spriteDisplayModes.length > 0;
 
@@ -1893,7 +1879,9 @@ export function ChatRoleplaySurface({
                         <Loader2 size="0.75rem" className="animate-spin" />
                       ) : (
                         <ChevronUp size="0.75rem" />
-                      )}{localizeUi("ui.chat.chatroleplaysurface.loadMore")}</button>
+                      )}
+                      {localizeUi("ui.chat.chatroleplaysurface.loadMore")}
+                    </button>
                   </div>
                 )}
 

--- a/packages/client/src/components/chat/ConversationMediaPickerPanel.tsx
+++ b/packages/client/src/components/chat/ConversationMediaPickerPanel.tsx
@@ -6,6 +6,7 @@ import { GifPicker } from "../ui/GifPicker";
 import { StickerPicker } from "./StickerPicker";
 import { CustomEmojiTab } from "./CustomEmojiTab";
 import { useTranslation } from "react-i18next";
+import { rememberRecentMedia } from "../../hooks/use-recent-media";
 
 export type ConversationMediaPickerTabId = "emoji" | "kaomoji" | "gifs" | "stickers" | "tools";
 export type ConversationMediaPickerTab = { id: ConversationMediaPickerTabId; label: string };
@@ -75,8 +76,25 @@ export function ConversationMediaPickerPanel({
             customTab={{
               icon: "⭐",
               label: t("ui.noodle.media.customEmojis"),
-              render: (query) => <CustomEmojiTab onInsert={onEmojiSelect} query={query} />,
-              renderSearch: (query) => <CustomEmojiTab onInsert={onEmojiSelect} query={query} searchResultsOnly />,
+              render: (query) => (
+                <CustomEmojiTab
+                  onInsert={(token) => {
+                    rememberRecentMedia("emoji", { value: token, label: token });
+                    onEmojiSelect(token);
+                  }}
+                  query={query}
+                />
+              ),
+              renderSearch: (query) => (
+                <CustomEmojiTab
+                  onInsert={(token) => {
+                    rememberRecentMedia("emoji", { value: token, label: token });
+                    onEmojiSelect(token);
+                  }}
+                  query={query}
+                  searchResultsOnly
+                />
+              ),
             }}
           />
         )}

--- a/packages/client/src/components/chat/ConversationView.tsx
+++ b/packages/client/src/components/chat/ConversationView.tsx
@@ -14,13 +14,7 @@ import {
   type MouseEvent as ReactMouseEvent,
 } from "react";
 import { useTranslation, useTranslation as useUiTranslation } from "react-i18next";
-import {
-  Loader2,
-  ChevronUp,
-  Settings2,
-  Image as ImageIcon,
-  ArrowRightLeft,
-} from "lucide-react";
+import { Loader2, ChevronUp, Settings2, Image as ImageIcon, ArrowRightLeft } from "lucide-react";
 import { ConversationMessage } from "./ConversationMessage";
 import { ConversationInput } from "./ConversationInput";
 import { ConversationGamesPicker } from "./ConversationGamesPicker";
@@ -54,6 +48,7 @@ import { CapabilityElement } from "../capabilities/CapabilityElement";
 import { TURN_GAME_BOT_REQUEST_EVENT } from "../../lib/capability-turn-game-events";
 import { useGenerate } from "../../hooks/use-generate";
 import {
+  useChatComposerFocused,
   useChatKeyboardOpen,
   useKeepLatestChatMessageVisible,
 } from "../../hooks/use-visual-viewport-chat-bottom";
@@ -332,14 +327,11 @@ export function ConversationView({
   }, [chatId, generateTurnGameBots]);
   const gamesPickerOpen = useConversationGamesStore((s) => s.pickerChatId === chatId);
   const closeGamesPicker = useConversationGamesStore((s) => s.closePicker);
-  const gameSetup = useConversationGamesStore((s) => s.setup?.chatId === chatId ? s.setup : null);
+  const gameSetup = useConversationGamesStore((s) => (s.setup?.chatId === chatId ? s.setup : null));
   const closeGameSetup = useConversationGamesStore((s) => s.closeSetup);
   const { data: installedCapabilities = [] } = useInstalledCapabilityPackages();
   const turnGamePackages = installedCapabilities.filter(
-    (item) =>
-      item.status === "active" &&
-      item.manifest.kind.includes("turn-game") &&
-      item.manifest.entrypoints.client,
+    (item) => item.status === "active" && item.manifest.kind.includes("turn-game") && item.manifest.entrypoints.client,
   );
   const isStreamCommitted = useChatStore((s) => s.committedStreamChatIds.has(chatId));
   const hasLiveStream = isStreaming && !isStreamCommitted;
@@ -440,9 +432,7 @@ export function ConversationView({
   const hasAutonomousMessaging = !!chatMeta.autonomousMessages || !!chatMeta.characterExchanges;
   const callsPackage = installedCapabilities.find(
     (item) =>
-      item.status === "active" &&
-      item.manifest.kind.includes("conversation-calls") &&
-      item.manifest.entrypoints.client,
+      item.status === "active" && item.manifest.kind.includes("conversation-calls") && item.manifest.entrypoints.client,
   );
   const callCapabilityProps = { chatId, metadata: chatMeta, characterMap, chatCharIds, personaInfo };
   const renderToolbarActions = (compact = false) => (
@@ -481,9 +471,7 @@ export function ConversationView({
     </>
   );
   const renderHeader = () => (
-    <div
-      className="sticky top-0 z-30 flex items-center justify-between px-4 py-2"
-    >
+    <div className="sticky top-0 z-30 flex items-center justify-between px-4 py-2">
       <ConversationPresenceCard
         chatId={chatId}
         chatMeta={chatMeta}
@@ -526,7 +514,9 @@ export function ConversationView({
   const openedAtBottomChatIdRef = useRef<string | null>(null);
   const streamScrollFrameRef = useRef(0);
   const keyboardOpen = useChatKeyboardOpen();
-  const shouldKeepMobileComposerOpen = keyboardOpen || hasLiveStream || hasDraftInput || isFetchingNextPage;
+  const composerFocused = useChatComposerFocused();
+  const shouldKeepMobileComposerOpen =
+    keyboardOpen || composerFocused || hasLiveStream || hasDraftInput || isFetchingNextPage;
 
   const scrollToMessagesBottom = useCallback((behavior: ScrollBehavior = "smooth") => {
     const el = scrollRef.current;
@@ -1165,7 +1155,9 @@ export function ConversationView({
               disabled={isFetchingNextPage}
               className="inline-flex items-center gap-1.5 rounded-lg border border-[var(--border)] bg-[var(--secondary)] px-3 py-1.5 text-xs font-medium text-[var(--muted-foreground)] transition-all hover:bg-[var(--accent)] disabled:opacity-50"
             >
-              {isFetchingNextPage ? <Loader2 size="0.75rem" className="animate-spin" /> : <ChevronUp size="0.75rem" />}{localizeUi("ui.chat.chatroleplaysurface.loadMore")}</button>
+              {isFetchingNextPage ? <Loader2 size="0.75rem" className="animate-spin" /> : <ChevronUp size="0.75rem" />}
+              {localizeUi("ui.chat.chatroleplaysurface.loadMore")}
+            </button>
           </div>
         )}
 
@@ -1184,7 +1176,8 @@ export function ConversationView({
         {/* Welcome message at the start of a conversation */}
         {!isLoading && !hasNextPage && messages && messages.length === 0 && (
           <div className="px-4 pt-2">
-            <p className="text-xs text-[var(--marinara-chat-chrome-panel-muted)]">{localizeUi("ui.chat.conversationview.thisIsTheStartOfYourConversationWith")}{" "}
+            <p className="text-xs text-[var(--marinara-chat-chrome-panel-muted)]">
+              {localizeUi("ui.chat.conversationview.thisIsTheStartOfYourConversationWith")}{" "}
               <span className="font-medium text-[var(--marinara-chat-chrome-panel-title)]">
                 {(() => {
                   const names = chatCharIds.map((id) => characterMap.get(id)?.name).filter(Boolean) as string[];
@@ -1192,7 +1185,9 @@ export function ConversationView({
                   if (names.length === 1) return names[0];
                   return names.slice(0, -1).join(", ") + " & " + names[names.length - 1];
                 })()}
-              </span>{localizeUi("ui.chat.conversationview.sayHi")}</p>
+              </span>
+              {localizeUi("ui.chat.conversationview.sayHi")}
+            </p>
           </div>
         )}
 
@@ -1365,8 +1360,14 @@ export function ConversationView({
           <div className="flex items-center gap-2 px-4 py-1.5 text-[0.8125rem] text-[var(--text-secondary)]">
             <span className="italic">
               {delayedCharacterInfo.status === "dnd"
-                ?localizeUi("ui.chat.conversationview.value1Value2BusyTheyLlRespondWhenTheyRe", { value1: delayedDisplayName, value2: delayedDisplayVerb })
-                :localizeUi("ui.chat.conversationview.value1Value2AwayTheyLlRespondInAMoment", { value1: delayedDisplayName, value2: delayedDisplayVerb })}
+                ? localizeUi("ui.chat.conversationview.value1Value2BusyTheyLlRespondWhenTheyRe", {
+                    value1: delayedDisplayName,
+                    value2: delayedDisplayVerb,
+                  })
+                : localizeUi("ui.chat.conversationview.value1Value2AwayTheyLlRespondInAMoment", {
+                    value1: delayedDisplayName,
+                    value2: delayedDisplayVerb,
+                  })}
             </span>
           </div>
         )}
@@ -1390,8 +1391,8 @@ export function ConversationView({
 
         {/* Scene banner — inline at bottom of messages (origin variant only); hidden during a turn-game */}
         {sceneInfo?.variant === "origin" && (
-            <SceneBanner variant="origin" sceneChatId={sceneInfo.sceneChatId} sceneChatName={sceneInfo.sceneChatName} />
-          )}
+          <SceneBanner variant="origin" sceneChatId={sceneInfo.sceneChatId} sceneChatName={sceneInfo.sceneChatName} />
+        )}
 
         <div ref={messagesEndRef} className="h-1" />
       </div>
@@ -1422,12 +1423,7 @@ export function ConversationView({
 
       {/* Downloaded games own their board and setup UI. The base client only provides stable slots. */}
       {turnGamePackages.map((game) => (
-        <CapabilityElement
-          key={`${game.id}-surface`}
-          packageId={game.id}
-          view="surface"
-          capabilityProps={{ chatId }}
-        />
+        <CapabilityElement key={`${game.id}-surface`} packageId={game.id} view="surface" capabilityProps={{ chatId }} />
       ))}
       {callsPackage && (
         <CapabilityElement

--- a/packages/client/src/components/chat/StickerPicker.tsx
+++ b/packages/client/src/components/chat/StickerPicker.tsx
@@ -26,6 +26,7 @@ import { api } from "../../lib/api-client";
 import { CustomEmojiSelectionSettings } from "./CustomEmojiSelectionSettings";
 import { cn } from "../../lib/utils";
 import { useTranslation as useUiTranslation } from "react-i18next";
+import { rememberRecentMedia, useRecentMedia } from "../../hooks/use-recent-media";
 
 interface StickerPickerProps {
   open: boolean;
@@ -58,6 +59,7 @@ export function StickerPicker({ open, onClose, onSelect, anchorRef, containerRef
   const [error, setError] = useState<string | null>(null);
   const [showSettings, setShowSettings] = useState(false);
   const [pos, setPos] = useState<{ top: number; left?: number; right?: number; maxHeight?: number }>({ top: 0 });
+  const recentStickers = useRecentMedia("sticker");
 
   const updatePosition = useCallback(() => {
     if (!anchorRef?.current) return;
@@ -159,11 +161,11 @@ export function StickerPicker({ open, onClose, onSelect, anchorRef, containerRef
           }
           const suggested = slugifyCustomName(file.name.replace(/\.[^.]+$/, ""));
           const raw = await showPromptDialog({
-            title:localizeUi("ui.chat.stickerpicker.nameThisSticker"),
-            message:localizeUi("ui.chat.stickerpicker.useItInMessagesAsStickerNameLowercaseLetters"),
+            title: localizeUi("ui.chat.stickerpicker.nameThisSticker"),
+            message: localizeUi("ui.chat.stickerpicker.useItInMessagesAsStickerNameLowercaseLetters"),
             defaultValue: suggested,
             placeholder: "e.g. wave",
-            confirmLabel:localizeUi("ui.characters.metadatatab.add"),
+            confirmLabel: localizeUi("ui.characters.metadatatab.add"),
             previewImageUrl: objectUrl,
           });
           if (raw == null) continue;
@@ -186,10 +188,10 @@ export function StickerPicker({ open, onClose, onSelect, anchorRef, containerRef
   const handleRename = useCallback(
     async (id: string, current: string) => {
       const raw = await showPromptDialog({
-        title:localizeUi("ui.chat.stickerpicker.renameSticker"),
-        message:localizeUi("ui.chat.stickerpicker.newNameUsedAsStickerName"),
+        title: localizeUi("ui.chat.stickerpicker.renameSticker"),
+        message: localizeUi("ui.chat.stickerpicker.newNameUsedAsStickerName"),
         defaultValue: current,
-        confirmLabel:localizeUi("ui.chat.chatbranchselector.rename"),
+        confirmLabel: localizeUi("ui.chat.chatbranchselector.rename"),
       });
       if (raw == null) return;
       const name = slugifyCustomName(raw);
@@ -203,9 +205,11 @@ export function StickerPicker({ open, onClose, onSelect, anchorRef, containerRef
     async (id: string, name: string) => {
       if (
         await showConfirmDialog({
-          title:localizeUi("ui.chat.stickerpicker.deleteSticker"),
-          message:localizeUi("ui.chat.stickerpicker.deleteStickerValue1MessagesThatAlreadyUsedItWill", { value1: name }),
-          confirmLabel:localizeUi("lorebook.editor.batch.delete"),
+          title: localizeUi("ui.chat.stickerpicker.deleteSticker"),
+          message: localizeUi("ui.chat.stickerpicker.deleteStickerValue1MessagesThatAlreadyUsedItWill", {
+            value1: name,
+          }),
+          confirmLabel: localizeUi("lorebook.editor.batch.delete"),
           tone: "destructive",
         })
       ) {
@@ -269,8 +273,13 @@ export function StickerPicker({ open, onClose, onSelect, anchorRef, containerRef
         )
         .filter(([, arr]) => arr.length > 0)
     : sourceGroups;
+  const conversationStickerByName = new Map(conversationStickers.map((sticker) => [sticker.name, sticker] as const));
+  const visibleRecentStickers = recentStickers
+    .map((item) => conversationStickerByName.get(item.value))
+    .filter((item): item is ConversationCustomSticker => item !== undefined);
 
-  const send = (name: string) => {
+  const send = (name: string, previewUrl: string) => {
+    rememberRecentMedia("sticker", { value: name, label: name, previewUrl });
     onSelect(name);
     onClose();
   };
@@ -297,20 +306,25 @@ export function StickerPicker({ open, onClose, onSelect, anchorRef, containerRef
             onClick={() => fileRef.current?.click()}
             className="inline-flex items-center gap-1.5 rounded-md bg-foreground/5 px-2 py-1 text-xs text-foreground/70 ring-1 ring-foreground/10 transition-colors hover:bg-foreground/10 hover:text-foreground/90"
           >
-            <ImagePlus size="0.875rem" /> {localizeUi("ui.characters.characterclipcard.upload")}</button>
+            <ImagePlus size="0.875rem" /> {localizeUi("ui.characters.characterclipcard.upload")}
+          </button>
           {editing && (
             <>
               <button
                 type="button"
                 onClick={() => importFileRef.current?.click()}
                 className="rounded-md bg-foreground/5 px-2 py-1 text-xs text-foreground/70 ring-1 ring-foreground/10 transition-colors hover:bg-foreground/10 hover:text-foreground/90"
-              >{localizeUi("ui.chat.chatbranchselector.import")}</button>
+              >
+                {localizeUi("ui.chat.chatbranchselector.import")}
+              </button>
               {globalList.length > 0 && (
                 <button
                   type="button"
                   onClick={() => void handleExport()}
                   className="rounded-md bg-foreground/5 px-2 py-1 text-xs text-foreground/70 ring-1 ring-foreground/10 transition-colors hover:bg-foreground/10 hover:text-foreground/90"
-                >{localizeUi("ui.characters.spritestab.export")}</button>
+                >
+                  {localizeUi("ui.characters.spritestab.export")}
+                </button>
               )}
             </>
           )}
@@ -348,7 +362,7 @@ export function StickerPicker({ open, onClose, onSelect, anchorRef, containerRef
                 : "text-foreground/45 hover:bg-foreground/10 hover:text-foreground/70",
             )}
           >
-            {editing ?localizeUi("lorebook.editor.batch.done") :localizeUi("ui.noodle.noodlepostcard.edit")}
+            {editing ? localizeUi("lorebook.editor.batch.done") : localizeUi("ui.noodle.noodlepostcard.edit")}
           </button>
         </div>
       </div>
@@ -358,13 +372,39 @@ export function StickerPicker({ open, onClose, onSelect, anchorRef, containerRef
       {error && <p className="px-3 py-1.5 text-[0.6875rem] text-red-400">{error}</p>}
 
       <div className="flex-1 overflow-y-auto px-2 py-2">
+        {!q && !editing && visibleRecentStickers.length > 0 && (
+          <section data-recent-media="sticker" className="mb-2 border-b border-foreground/10 pb-2">
+            <p className={headerClass}>{localizeUi("ui.mediaPicker.recentlyUsed")}</p>
+            <div className="grid grid-cols-3 gap-1.5">
+              {visibleRecentStickers.map((sticker) => (
+                <button
+                  key={sticker.name}
+                  type="button"
+                  onClick={() => send(sticker.name, sticker.url)}
+                  title={localizeUi("ui.chat.stickerpicker.sendStickerValue1", { value1: sticker.name })}
+                  className={cellClass}
+                >
+                  <img
+                    src={sticker.url}
+                    alt={localizeUi("ui.chat.stickerpicker.stickerValue1", { value1: sticker.name })}
+                    className="max-h-16 max-w-full object-contain"
+                  />
+                </button>
+              ))}
+            </div>
+          </section>
+        )}
         {filteredGlobal.length === 0 && filteredGroups.length === 0 ? (
           <p className="px-1 py-6 text-center text-[0.6875rem] text-foreground/45">
             {q ? (
-              <>{localizeUi("ui.chat.stickerpicker.noStickersMatch")}{query.trim()}”.</>
+              <>
+                {localizeUi("ui.chat.stickerpicker.noStickersMatch")}
+                {query.trim()}”.
+              </>
             ) : (
-              <>{localizeUi("ui.chat.stickerpicker.noStickersYetUploadOneMax512512To")} <span className="font-mono">{localizeUi("ui.chat.stickerpicker.stickerName")}</span>
-                .
+              <>
+                {localizeUi("ui.chat.stickerpicker.noStickersYetUploadOneMax512512To")}{" "}
+                <span className="font-mono">{localizeUi("ui.chat.stickerpicker.stickerName")}</span>.
               </>
             )}
           </p>
@@ -372,14 +412,22 @@ export function StickerPicker({ open, onClose, onSelect, anchorRef, containerRef
           <>
             {filteredGlobal.length > 0 && (
               <>
-                {filteredGroups.length > 0 && <p className={headerClass}>{localizeUi("ui.lorebooks.lorebookeditor.global")}</p>}
+                {filteredGroups.length > 0 && (
+                  <p className={headerClass}>{localizeUi("ui.lorebooks.lorebookeditor.global")}</p>
+                )}
                 <div className="grid grid-cols-3 gap-1.5">
                   {filteredGlobal.map((sticker) => (
                     <div key={sticker.id} className="group relative">
                       <button
                         type="button"
-                        onClick={() => (editing ? void handleRename(sticker.id, sticker.name) : send(sticker.name))}
-                        title={editing ?localizeUi("ui.chat.stickerpicker.renameStickerValue1", { value1: sticker.name }) :localizeUi("ui.chat.stickerpicker.sendStickerValue1", { value1: sticker.name })}
+                        onClick={() =>
+                          editing ? void handleRename(sticker.id, sticker.name) : send(sticker.name, sticker.url)
+                        }
+                        title={
+                          editing
+                            ? localizeUi("ui.chat.stickerpicker.renameStickerValue1", { value1: sticker.name })
+                            : localizeUi("ui.chat.stickerpicker.sendStickerValue1", { value1: sticker.name })
+                        }
                         className={cellClass}
                       >
                         <img
@@ -412,8 +460,11 @@ export function StickerPicker({ open, onClose, onSelect, anchorRef, containerRef
                     <div key={sticker.name} className="group relative">
                       <button
                         type="button"
-                        onClick={() => send(sticker.name)}
-                        title={localizeUi("ui.chat.stickerpicker.sendStickerValue1Value2", { value1: sticker.name, value2: source })}
+                        onClick={() => send(sticker.name, sticker.url)}
+                        title={localizeUi("ui.chat.stickerpicker.sendStickerValue1Value2", {
+                          value1: sticker.name,
+                          value2: source,
+                        })}
                         className={cellClass}
                       >
                         <img

--- a/packages/client/src/components/layout/AppShell.tsx
+++ b/packages/client/src/components/layout/AppShell.tsx
@@ -244,6 +244,11 @@ export function AppShell() {
     const isIOSWebKit =
       /iP(?:ad|hone|od)/i.test(navigator.userAgent) ||
       (navigator.platform === "MacIntel" && navigator.maxTouchPoints > 1);
+    // iOS doesn't track the keyboard's visualViewport.offsetTop/height
+    // reliably, so we force offsetTop to 0 and instead counter the scroll
+    // drift iOS applies with a `transform: translateY()` (a GPU compositor
+    // update, unlike window.scrollTo() it doesn't fight WebKit's own
+    // animation).
     const updateVisualViewportGeometry = () => {
       if (frame) cancelAnimationFrame(frame);
       frame = requestAnimationFrame(() => {
@@ -255,13 +260,13 @@ export function AppShell() {
         const height = heightCandidates.length > 0 ? Math.min(...heightCandidates) : window.innerHeight;
         const maxOffsetTop = Math.max(0, window.innerHeight - height);
         const visualViewportOffsetTop = Math.min(maxOffsetTop, Math.max(0, viewport?.offsetTop ?? 0));
-        // iOS Safari already positions the layout viewport when its software
-        // keyboard opens. Applying visualViewport.offsetTop again translates
-        // the entire app and leaves the top of the conversation off-screen.
         const offsetTop = isIOSWebKit ? 0 : visualViewportOffsetTop;
         largestViewportHeight = Math.max(largestViewportHeight, height);
         root.style.setProperty("--mari-visual-viewport-height", `${Math.max(0, Math.round(height))}px`);
         root.style.setProperty("--mari-visual-viewport-offset-top", `${Math.round(offsetTop)}px`);
+        if (isIOSWebKit) {
+          root.style.setProperty("--mari-app-scroll-compensate", `${Math.round(window.scrollY)}px`);
+        }
         const keyboardOpen = supportsVirtualKeyboard && largestViewportHeight - height >= 80;
         root.toggleAttribute("data-mari-software-keyboard-open", keyboardOpen);
         dispatchChatVisualViewportChange({
@@ -314,6 +319,7 @@ export function AppShell() {
       document.removeEventListener("focusout", refreshAfterFocusChange);
       root.style.removeProperty("--mari-visual-viewport-height");
       root.style.removeProperty("--mari-visual-viewport-offset-top");
+      root.style.removeProperty("--mari-app-scroll-compensate");
       root.removeAttribute("data-mari-software-keyboard-open");
     };
   }, []);

--- a/packages/client/src/components/layout/AppShell.tsx
+++ b/packages/client/src/components/layout/AppShell.tsx
@@ -771,18 +771,18 @@ export function AppShell() {
   const showAmbientDecor =
     isPageActive && !activeChatId && !detailView && !botBrowserOpen && !gameAssetsBrowserOpen && !noodleOpen;
   const hasDetailView = detailView != null;
-  const chatSurfaceActive =
-    !botBrowserOpen &&
-    !gameAssetsBrowserOpen &&
-    !noodleOpen &&
-    !hasDetailView &&
-    (!shellOverlayMode || (!sidebarOpen && !rightPanelOpen));
   const trackerPanelModeAvailable = activeChat?.mode === "roleplay" || activeChat?.mode === "visual_novel";
   const trackerPanelActive = trackerPanelEnabled && trackerPanelOpen;
   const trackerPanelDetached = trackerPanelWindowTarget !== null;
   const trackerPanelSurfaceAvailable =
     trackerPanelModeAvailable && !botBrowserOpen && !gameAssetsBrowserOpen && !noodleOpen && !hasDetailView;
   const trackerPanelVisible = trackerPanelActive && trackerPanelSurfaceAvailable && !trackerPanelDetached;
+  const chatSurfaceActive =
+    !botBrowserOpen &&
+    !gameAssetsBrowserOpen &&
+    !noodleOpen &&
+    !hasDetailView &&
+    (!shellOverlayMode || (!sidebarOpen && !rightPanelOpen && !trackerPanelVisible));
   const trackerWindowHost = trackerPanelWindowTarget?.popup ?? window;
 
   const dockTrackerPanel = useCallback(() => {

--- a/packages/client/src/components/layout/AppShell.tsx
+++ b/packages/client/src/components/layout/AppShell.tsx
@@ -31,10 +31,7 @@ import { getCssBackgroundStyle } from "../../lib/css-colors";
 import { showConfirmDialog } from "../../lib/app-dialogs";
 import { cn } from "../../lib/utils";
 import { parseChatMetadata } from "../../lib/chat-display";
-import {
-  resolveTrackerPanelContentScale,
-  resolveTrackerPanelDesktopWidth,
-} from "../../lib/tracker-panel-layout";
+import { resolveTrackerPanelContentScale, resolveTrackerPanelDesktopWidth } from "../../lib/tracker-panel-layout";
 import {
   closeTrackerPanelWindow,
   openTrackerPanelWindow,
@@ -169,7 +166,11 @@ function getViewportWidth() {
 
 function MainPaneFallback() {
   const { t: localizeUi } = useUiTranslation();
-  return <div className="mari-chrome-text-muted flex flex-1 items-center justify-center text-sm">{localizeUi("ui.characters.characterlibraryview.loading")}</div>;
+  return (
+    <div className="mari-chrome-text-muted flex flex-1 items-center justify-center text-sm">
+      {localizeUi("ui.characters.characterlibraryview.loading")}
+    </div>
+  );
 }
 /** Mounts children once `open` becomes true, then keeps them mounted so state persists.
  *  `overlay` mode uses framer-motion slide-in and never unmounts. */
@@ -211,7 +212,11 @@ function MountOnceWhenOpened({
 
 function SidePanelFallback() {
   const { t: localizeUi } = useUiTranslation();
-  return <div className="mari-chrome-text-muted flex h-full items-center justify-center text-sm">{localizeUi("ui.characters.characterlibraryview.loading")}</div>;
+  return (
+    <div className="mari-chrome-text-muted flex h-full items-center justify-center text-sm">
+      {localizeUi("ui.characters.characterlibraryview.loading")}
+    </div>
+  );
 }
 
 export function AppShell() {
@@ -223,8 +228,7 @@ export function AppShell() {
   const musicDjInstalled = (installedCapabilities.data ?? []).some(
     (capability) => capability.id === "spotify" && capability.status === "active",
   );
-  const showMusicDjUnavailablePlayer =
-    musicPlayerEnabled && !installedCapabilities.isLoading && !musicDjInstalled;
+  const showMusicDjUnavailablePlayer = musicPlayerEnabled && !installedCapabilities.isLoading && !musicDjInstalled;
 
   // Background autonomous polling for inactive conversation chats
   useBackgroundAutonomousPolling();
@@ -239,8 +243,7 @@ export function AppShell() {
     let focusTimers: number[] = [];
     let orientationTimers: number[] = [];
     let largestViewportHeight = window.visualViewport?.height ?? window.innerHeight;
-    const supportsVirtualKeyboard =
-      navigator.maxTouchPoints > 0 || window.matchMedia("(any-pointer: coarse)").matches;
+    const supportsVirtualKeyboard = navigator.maxTouchPoints > 0 || window.matchMedia("(any-pointer: coarse)").matches;
     const isIOSWebKit =
       /iP(?:ad|hone|od)/i.test(navigator.userAgent) ||
       (navigator.platform === "MacIntel" && navigator.maxTouchPoints > 1);
@@ -768,6 +771,12 @@ export function AppShell() {
   const showAmbientDecor =
     isPageActive && !activeChatId && !detailView && !botBrowserOpen && !gameAssetsBrowserOpen && !noodleOpen;
   const hasDetailView = detailView != null;
+  const chatSurfaceActive =
+    !botBrowserOpen &&
+    !gameAssetsBrowserOpen &&
+    !noodleOpen &&
+    !hasDetailView &&
+    (!shellOverlayMode || (!sidebarOpen && !rightPanelOpen));
   const trackerPanelModeAvailable = activeChat?.mode === "roleplay" || activeChat?.mode === "visual_novel";
   const trackerPanelActive = trackerPanelEnabled && trackerPanelOpen;
   const trackerPanelDetached = trackerPanelWindowTarget !== null;
@@ -1077,9 +1086,7 @@ export function AppShell() {
           data-component={trackerPanelDetached ? "TrackerDataSidebarDetached" : undefined}
           aria-label={trackerPanelDetached ? localizeUi("ui.layout.appshell.trackerDataPanel") : undefined}
           className={
-            trackerPanelDetached
-              ? "mari-tracker-panel h-screen w-screen overflow-hidden bg-zinc-950/95"
-              : "contents"
+            trackerPanelDetached ? "mari-tracker-panel h-screen w-screen overflow-hidden bg-zinc-950/95" : "contents"
           }
           style={trackerPanelDetached ? trackerPanelBackgroundStyle : undefined}
         >
@@ -1165,6 +1172,7 @@ export function AppShell() {
   return (
     <div
       data-component="AppShell"
+      data-chat-surface-active={chatSurfaceActive ? "true" : undefined}
       className={cn(
         "mari-app mari-app-background-paint fixed inset-0 flex overflow-hidden",
         showAmbientDecor && "retro-scanlines noise-bg geometric-grid",

--- a/packages/client/src/components/ui/EmojiPicker.tsx
+++ b/packages/client/src/components/ui/EmojiPicker.tsx
@@ -4,6 +4,7 @@
 import { useState, useRef, useEffect, useCallback, useLayoutEffect } from "react";
 import { createPortal } from "react-dom";
 import { cn } from "../../lib/utils";
+import { rememberRecentMedia, useRecentMedia } from "../../hooks/use-recent-media";
 import { EMOJI_CATEGORIES, EMOJI_SEARCH_NAMES } from "../../lib/emoji-catalog.generated";
 import { EMOJI_KEYWORDS, matchesEmojiQuery } from "../../lib/emoji-search";
 import { useTranslation as useUiTranslation } from "react-i18next";
@@ -741,6 +742,7 @@ export function EmojiPicker({
   const [search, setSearch] = useState("");
   const [activeCategory, setActiveCategory] = useState<number | "custom">(0);
   const panelRef = useRef<HTMLDivElement>(null);
+  const recentEmojis = useRecentMedia("emoji");
 
   // Close on outside click
   useEffect(() => {
@@ -857,6 +859,10 @@ export function EmojiPicker({
 
   const handleSelect = useCallback(
     (emoji: string) => {
+      rememberRecentMedia("emoji", {
+        value: emoji,
+        label: EMOJI_SEARCH_NAMES[emoji] ?? EMOJI_KEYWORDS[emoji] ?? emoji,
+      });
       onSelect(emoji);
     },
     [onSelect],
@@ -937,6 +943,27 @@ export function EmojiPicker({
 
       {/* Emoji grid (or the custom-emoji tab content) */}
       <div className="flex-1 overflow-y-auto px-2 py-2">
+        {!searching && recentEmojis.length > 0 && (
+          <section data-recent-media="emoji" className="mb-2 border-b border-foreground/10 pb-2">
+            <p className="mb-1 px-1 text-[0.625rem] font-semibold uppercase tracking-wide text-foreground/45">
+              {localizeUi("ui.mediaPicker.recentlyUsed")}
+            </p>
+            <div className="grid grid-cols-8 gap-0.5">
+              {recentEmojis.map((item) => (
+                <button
+                  key={item.value}
+                  type="button"
+                  onClick={() => handleSelect(item.value)}
+                  aria-label={item.label ?? item.value}
+                  title={item.label ?? item.value}
+                  className="min-w-0 truncate rounded-md p-1 text-xl transition-transform hover:scale-125 hover:bg-foreground/10 active:scale-100"
+                >
+                  {item.value}
+                </button>
+              ))}
+            </div>
+          </section>
+        )}
         {!searching && activeCategory === "custom" && customTab ? (
           customTab.render(search)
         ) : (

--- a/packages/client/src/components/ui/GifPicker.tsx
+++ b/packages/client/src/components/ui/GifPicker.tsx
@@ -5,6 +5,7 @@ import { useState, useRef, useEffect, useCallback, useLayoutEffect } from "react
 import { createPortal } from "react-dom";
 import { Search, Loader2, ImageOff, ExternalLink } from "lucide-react";
 import { useTranslation as useUiTranslation } from "react-i18next";
+import { rememberRecentMedia, useRecentMedia } from "../../hooks/use-recent-media";
 
 interface GifResult {
   id: string;
@@ -41,6 +42,7 @@ export function GifPicker({ open, onClose, onSelect, anchorRef, containerRef, em
   const scrollRef = useRef<HTMLDivElement>(null);
   const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const fetchingRef = useRef(false);
+  const recentGifs = useRecentMedia("gif");
 
   // Position state for portal
   const [pos, setPos] = useState<{ bottom: number; right?: number; left?: number; maxHeight?: number }>({ bottom: 0 });
@@ -190,10 +192,25 @@ export function GifPicker({ open, onClose, onSelect, anchorRef, containerRef, em
 
   const handleSelect = useCallback(
     (gif: GifResult) => {
+      rememberRecentMedia("gif", {
+        value: gif.url,
+        label: gif.title,
+        previewUrl: gif.preview || gif.url,
+      });
       onSelect(gif.url);
       onClose();
     },
     [onSelect, onClose],
+  );
+
+  const handleRecentSelect = useCallback(
+    (value: string) => {
+      const item = recentGifs.find((entry) => entry.value === value);
+      if (item) rememberRecentMedia("gif", item);
+      onSelect(value);
+      onClose();
+    },
+    [onSelect, onClose, recentGifs],
   );
 
   if (!open) return null;
@@ -218,6 +235,35 @@ export function GifPicker({ open, onClose, onSelect, anchorRef, containerRef, em
         </div>
       </div>
 
+      {!query.trim() && recentGifs.length > 0 && (
+        <section
+          data-recent-media="gif"
+          className="max-h-40 shrink-0 overflow-y-auto border-b border-foreground/10 px-2 py-2"
+        >
+          <p className="mb-1 px-1 text-[0.625rem] font-semibold uppercase tracking-wide text-foreground/45">
+            {localizeUi("ui.mediaPicker.recentlyUsed")}
+          </p>
+          <div className="columns-2 gap-1.5">
+            {recentGifs.map((item) => (
+              <button
+                key={item.value}
+                type="button"
+                onClick={() => handleRecentSelect(item.value)}
+                className="mb-1.5 block w-full overflow-hidden rounded-lg transition-transform hover:scale-[1.02] active:scale-100 break-inside-avoid"
+                title={item.label ?? localizeUi("ui.noodle.media.tabs.gifs")}
+              >
+                <img
+                  src={item.previewUrl ?? item.value}
+                  alt={item.label ?? localizeUi("ui.noodle.media.tabs.gifs")}
+                  className="w-full rounded-lg object-cover"
+                  loading="lazy"
+                />
+              </button>
+            ))}
+          </div>
+        </section>
+      )}
+
       {/* Error state */}
       {error && (
         <div className="flex flex-1 flex-col items-center justify-center gap-3 px-5 py-8 text-center">
@@ -225,15 +271,22 @@ export function GifPicker({ open, onClose, onSelect, anchorRef, containerRef, em
           {missingGiphyKey ? (
             <div className="space-y-3">
               <div>
-                <p className="text-xs font-semibold text-foreground/85">{localizeUi("ui.ui.gifpicker.gifSearchNeedsAGiphyApiKey")}</p>
-                <p className="mt-1 text-[0.6875rem] leading-relaxed text-foreground/55">{localizeUi("ui.ui.gifpicker.createAFreeKeyPasteItInto")} <code className={setupCodeClass}>GIPHY_API_KEY</code> {localizeUi("ui.ui.gifpicker.inYour")}{" "}
-                  <code className={setupCodeClass}>.env</code> {localizeUi("ui.ui.gifpicker.fileThenRestartMarinara")}</p>
+                <p className="text-xs font-semibold text-foreground/85">
+                  {localizeUi("ui.ui.gifpicker.gifSearchNeedsAGiphyApiKey")}
+                </p>
+                <p className="mt-1 text-[0.6875rem] leading-relaxed text-foreground/55">
+                  {localizeUi("ui.ui.gifpicker.createAFreeKeyPasteItInto")}{" "}
+                  <code className={setupCodeClass}>GIPHY_API_KEY</code> {localizeUi("ui.ui.gifpicker.inYour")}{" "}
+                  <code className={setupCodeClass}>.env</code> {localizeUi("ui.ui.gifpicker.fileThenRestartMarinara")}
+                </p>
               </div>
               <ol className="space-y-1 text-left text-[0.6875rem] leading-relaxed text-foreground/55">
                 <li>{localizeUi("ui.ui.gifpicker.text1OpenTheGiphyDeveloperDashboard")}</li>
                 <li>{localizeUi("ui.ui.gifpicker.text2CreateAnApiKeyForAWebApp")}</li>
-                <li>{localizeUi("ui.ui.gifpicker.text3Add")} <code className={setupCodeClass}>GIPHY_API_KEY=your_key_here</code> {localizeUi("ui.noodle.wizardfooter.to")}{" "}
-                  <code className={setupCodeClass}>.env</code>.
+                <li>
+                  {localizeUi("ui.ui.gifpicker.text3Add")}{" "}
+                  <code className={setupCodeClass}>GIPHY_API_KEY=your_key_here</code>{" "}
+                  {localizeUi("ui.noodle.wizardfooter.to")} <code className={setupCodeClass}>.env</code>.
                 </li>
               </ol>
               <a
@@ -241,7 +294,9 @@ export function GifPicker({ open, onClose, onSelect, anchorRef, containerRef, em
                 target="_blank"
                 rel="noreferrer"
                 className="inline-flex items-center gap-1.5 rounded-md border border-foreground/15 px-2.5 py-1.5 text-[0.6875rem] font-semibold text-foreground/75 transition-colors hover:bg-foreground/10 hover:text-foreground"
-              >{localizeUi("ui.ui.gifpicker.openGiphyDashboard")}<ExternalLink size="0.75rem" />
+              >
+                {localizeUi("ui.ui.gifpicker.openGiphyDashboard")}
+                <ExternalLink size="0.75rem" />
               </a>
             </div>
           ) : (
@@ -255,7 +310,7 @@ export function GifPicker({ open, onClose, onSelect, anchorRef, containerRef, em
         <div ref={scrollRef} className="flex-1 overflow-y-auto px-2 py-2" onScroll={handleScroll}>
           {results.length === 0 && !loading && (
             <p className="py-8 text-center text-xs text-foreground/45">
-              {query ?localizeUi("ui.ui.gifpicker.noGifsFound") :localizeUi("ui.ui.gifpicker.loadingTrending")}
+              {query ? localizeUi("ui.ui.gifpicker.noGifsFound") : localizeUi("ui.ui.gifpicker.loadingTrending")}
             </p>
           )}
 

--- a/packages/client/src/components/ui/KaomojiPicker.tsx
+++ b/packages/client/src/components/ui/KaomojiPicker.tsx
@@ -7,6 +7,7 @@ import { useTranslation } from "react-i18next";
 import { Search } from "lucide-react";
 import { cn } from "../../lib/utils";
 import { KAOMOJI_CATEGORIES, KAOMOJI_ALL, searchKaomoji } from "../../lib/kaomoji-catalog";
+import { rememberRecentMedia, useRecentMedia } from "../../hooks/use-recent-media";
 
 interface KaomojiPickerProps {
   open: boolean;
@@ -29,11 +30,20 @@ export function KaomojiPicker({ open, onClose, onSelect, anchorRef, containerRef
   const panelRef = useRef<HTMLDivElement>(null);
   const searchInputRef = useRef<HTMLInputElement>(null);
   const [pos, setPos] = useState<{ top?: number; left?: number; right?: number; maxHeight?: number }>({});
+  const recentKaomoji = useRecentMedia("kaomoji");
 
   const results = useMemo(() => {
     if (search.trim()) return searchKaomoji(search);
     return KAOMOJI_CATEGORIES[activeCategory]?.items ?? KAOMOJI_ALL;
   }, [search, activeCategory]);
+
+  const handleSelect = useCallback(
+    (value: string) => {
+      rememberRecentMedia("kaomoji", { value, label: value });
+      onSelect(value);
+    },
+    [onSelect],
+  );
 
   // Reset transient state each time it opens.
   useEffect(() => {
@@ -168,6 +178,26 @@ export function KaomojiPicker({ open, onClose, onSelect, anchorRef, containerRef
       )}
 
       <div data-kaomoji-results className="min-h-0 flex-1 overflow-x-hidden overflow-y-auto p-1.5">
+        {!search.trim() && recentKaomoji.length > 0 && (
+          <section data-recent-media="kaomoji" className="mb-1.5 border-b border-[var(--border)] pb-1.5">
+            <p className="mb-1 px-1 text-[0.625rem] font-semibold uppercase tracking-wide text-[var(--muted-foreground)]">
+              {t("ui.mediaPicker.recentlyUsed")}
+            </p>
+            <div className="grid min-w-0 grid-cols-2 gap-1">
+              {recentKaomoji.map((item) => (
+                <button
+                  key={item.value}
+                  type="button"
+                  onClick={() => handleSelect(item.value)}
+                  title={item.label ?? item.value}
+                  className="min-w-0 truncate rounded-lg px-2 py-2 text-center text-sm text-[var(--foreground)] transition-colors hover:bg-[var(--secondary)]/60 active:scale-95"
+                >
+                  {item.value}
+                </button>
+              ))}
+            </div>
+          </section>
+        )}
         {results.length === 0 ? (
           <p className="px-2 py-6 text-center text-xs text-[var(--muted-foreground)]">{t("chat.kaomoji.empty")}</p>
         ) : (
@@ -176,7 +206,7 @@ export function KaomojiPicker({ open, onClose, onSelect, anchorRef, containerRef
               <button
                 key={entry.value}
                 type="button"
-                onClick={() => onSelect(entry.value)}
+                onClick={() => handleSelect(entry.value)}
                 title={entry.keywords}
                 className="min-w-0 truncate rounded-lg px-2 py-2 text-center text-sm text-[var(--foreground)] transition-colors hover:bg-[var(--secondary)]/60 active:scale-95"
               >

--- a/packages/client/src/hooks/use-recent-media.ts
+++ b/packages/client/src/hooks/use-recent-media.ts
@@ -1,0 +1,139 @@
+import { useSyncExternalStore } from "react";
+
+export type RecentMediaKind = "emoji" | "kaomoji" | "gif" | "sticker";
+
+export interface RecentMediaItem {
+  value: string;
+  label?: string;
+  previewUrl?: string;
+}
+
+type RecentMediaState = Record<RecentMediaKind, RecentMediaItem[]>;
+
+const STORAGE_KEY = "marinara-recent-media-v1";
+const RECENT_ITEM_LIMIT = 8;
+const EMPTY_STATE: RecentMediaState = {
+  emoji: [],
+  kaomoji: [],
+  gif: [],
+  sticker: [],
+};
+const listeners = new Set<() => void>();
+let cachedRaw: string | null | undefined;
+let cachedState: RecentMediaState = EMPTY_STATE;
+let listeningForStorage = false;
+
+function normalizeItem(value: unknown): RecentMediaItem | null {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return null;
+  const row = value as Record<string, unknown>;
+  if (typeof row.value !== "string" || !row.value.trim() || row.value.length > 4096) return null;
+  return {
+    value: row.value,
+    ...(typeof row.label === "string" && row.label.trim() ? { label: row.label.slice(0, 256) } : {}),
+    ...(typeof row.previewUrl === "string" && row.previewUrl.trim() && row.previewUrl.length <= 4096
+      ? { previewUrl: row.previewUrl }
+      : {}),
+  };
+}
+
+function normalizeState(value: unknown): RecentMediaState {
+  const source = value && typeof value === "object" && !Array.isArray(value) ? (value as Record<string, unknown>) : {};
+  return {
+    emoji: Array.isArray(source.emoji)
+      ? source.emoji
+          .map(normalizeItem)
+          .filter((item): item is RecentMediaItem => item !== null)
+          .slice(0, RECENT_ITEM_LIMIT)
+      : [],
+    kaomoji: Array.isArray(source.kaomoji)
+      ? source.kaomoji
+          .map(normalizeItem)
+          .filter((item): item is RecentMediaItem => item !== null)
+          .slice(0, RECENT_ITEM_LIMIT)
+      : [],
+    gif: Array.isArray(source.gif)
+      ? source.gif
+          .map(normalizeItem)
+          .filter((item): item is RecentMediaItem => item !== null)
+          .slice(0, RECENT_ITEM_LIMIT)
+      : [],
+    sticker: Array.isArray(source.sticker)
+      ? source.sticker
+          .map(normalizeItem)
+          .filter((item): item is RecentMediaItem => item !== null)
+          .slice(0, RECENT_ITEM_LIMIT)
+      : [],
+  };
+}
+
+function readState(): RecentMediaState {
+  if (typeof window === "undefined") return EMPTY_STATE;
+  let raw: string | null;
+  try {
+    raw = window.localStorage.getItem(STORAGE_KEY);
+  } catch {
+    return cachedState;
+  }
+  if (raw === cachedRaw) return cachedState;
+  cachedRaw = raw;
+  if (!raw) {
+    cachedState = EMPTY_STATE;
+    return cachedState;
+  }
+  try {
+    cachedState = normalizeState(JSON.parse(raw));
+  } catch {
+    cachedState = EMPTY_STATE;
+  }
+  return cachedState;
+}
+
+function notifyListeners(): void {
+  for (const listener of listeners) listener();
+}
+
+function handleStorage(event: StorageEvent): void {
+  if (event.key !== STORAGE_KEY) return;
+  cachedRaw = undefined;
+  readState();
+  notifyListeners();
+}
+
+function subscribe(listener: () => void): () => void {
+  listeners.add(listener);
+  if (!listeningForStorage && typeof window !== "undefined") {
+    listeningForStorage = true;
+    window.addEventListener("storage", handleStorage);
+  }
+  return () => listeners.delete(listener);
+}
+
+export function rememberRecentMedia(kind: RecentMediaKind, item: RecentMediaItem): void {
+  const normalized = normalizeItem(item);
+  if (!normalized) return;
+  const current = readState();
+  const next: RecentMediaState = {
+    ...current,
+    [kind]: [normalized, ...current[kind].filter((entry) => entry.value !== normalized.value)].slice(
+      0,
+      RECENT_ITEM_LIMIT,
+    ),
+  };
+  const raw = JSON.stringify(next);
+  cachedRaw = raw;
+  cachedState = next;
+  try {
+    window.localStorage.setItem(STORAGE_KEY, raw);
+  } catch {
+    // Keep same-tab recents available even when storage is unavailable.
+  }
+  notifyListeners();
+}
+
+export function useRecentMedia(kind: RecentMediaKind): RecentMediaItem[] {
+  return useSyncExternalStore(
+    subscribe,
+    () => readState()[kind],
+    () => EMPTY_STATE[kind],
+  );
+}

--- a/packages/client/src/hooks/use-recent-media.ts
+++ b/packages/client/src/hooks/use-recent-media.ts
@@ -93,7 +93,7 @@ function notifyListeners(): void {
 }
 
 function handleStorage(event: StorageEvent): void {
-  if (event.key !== STORAGE_KEY) return;
+  if (event.key !== STORAGE_KEY && event.key !== null) return;
   cachedRaw = undefined;
   readState();
   notifyListeners();

--- a/packages/client/src/hooks/use-visual-viewport-chat-bottom.ts
+++ b/packages/client/src/hooks/use-visual-viewport-chat-bottom.ts
@@ -44,6 +44,33 @@ function focusedElementAcceptsText(): boolean {
   return active.isContentEditable;
 }
 
+export function useChatComposerFocused(): boolean {
+  const [focused, setFocused] = useState(
+    () => typeof document !== "undefined" && document.activeElement?.matches("[data-chat-composer]") === true,
+  );
+
+  useEffect(() => {
+    let frame = 0;
+    const update = () => {
+      if (frame) cancelAnimationFrame(frame);
+      frame = requestAnimationFrame(() => {
+        frame = 0;
+        setFocused(document.activeElement?.matches("[data-chat-composer]") === true);
+      });
+    };
+    document.addEventListener("focusin", update);
+    document.addEventListener("focusout", update);
+    update();
+    return () => {
+      if (frame) cancelAnimationFrame(frame);
+      document.removeEventListener("focusin", update);
+      document.removeEventListener("focusout", update);
+    };
+  }, []);
+
+  return focused;
+}
+
 /**
  * Preserve the user's bottom anchor when a mobile software keyboard changes
  * the visual viewport. Readers who intentionally scrolled upward are left

--- a/packages/client/src/localization/locales/en.json
+++ b/packages/client/src/localization/locales/en.json
@@ -4904,6 +4904,7 @@
   "ui.lorebooks.vectorizesection.vectorizeValue1Missing": "Vectorize {{value1}} missing",
   "ui.lorebooks.vectorizesection.vectorizing": "Vectorizing...",
   "ui.lorebooks.vectorizesection.vectorLimit": "Vector Limit",
+  "ui.mediaPicker.recentlyUsed": "Recently used",
   "ui.modals.aboutmeviewermodal.cardAChatSpecificOverrideOnlyAppliesHere": "card. A chat-specific override only applies here.",
   "ui.modals.aboutmeviewermodal.chatSpecific": "Chat-specific",
   "ui.modals.aboutmeviewermodal.chatSpecificAboutMeSaved": "Chat-specific about me saved",

--- a/packages/client/src/styles/globals.css
+++ b/packages/client/src/styles/globals.css
@@ -4838,11 +4838,16 @@ strong {
     padding-right: env(safe-area-inset-right);
   }
 
-  .mari-app {
+  /* Scoped to conversation/roleplay/game (each sets data-chat-mode on its
+     root) so the keyboard-viewport tracking from AppShell.tsx only affects
+     the app shell while one of those surfaces is actually showing. */
+  .mari-app:has([data-chat-mode]) {
     top: var(--mari-visual-viewport-offset-top, 0px);
     bottom: auto;
     height: var(--mari-visual-viewport-height, 100dvh);
     min-height: 0;
+    /* Counters the iOS scroll-drag bug described in AppShell.tsx. */
+    transform: translateY(var(--mari-app-scroll-compensate, 0px)) translateZ(0);
   }
 
   .app-sidebar-mobile {

--- a/packages/client/src/styles/globals.css
+++ b/packages/client/src/styles/globals.css
@@ -3293,9 +3293,7 @@ strong {
   }
 
   [data-chat-mode="roleplay"] .marinara-chat-input-shell {
-    background:
-      linear-gradient(var(--card), var(--card)),
-      var(--background) !important;
+    background: linear-gradient(var(--card), var(--card)), var(--background) !important;
     contain: layout paint;
     isolation: isolate;
   }
@@ -4841,7 +4839,7 @@ strong {
   /* Scoped to conversation/roleplay/game (each sets data-chat-mode on its
      root) so the keyboard-viewport tracking from AppShell.tsx only affects
      the app shell while one of those surfaces is actually showing. */
-  .mari-app:has([data-chat-mode]) {
+  .mari-app[data-chat-surface-active="true"]:has([data-chat-mode]) {
     top: var(--mari-visual-viewport-offset-top, 0px);
     bottom: auto;
     height: var(--mari-visual-viewport-height, 100dvh);


### PR DESCRIPTION
## Linked issues

Closes #4253
Closes #4259
Closes #4260

## Why

This sweep addresses three user-facing interaction gaps: frequently reused media remains buried in long picker lists, Roleplay mobile composer behavior still diverges from Conversation mode while reading older history, and iOS Safari can shift the app or paint incorrect space around the software keyboard.

## What changed

- add persisted, most-recent-first history rows to the emoji, kaomoji, GIF, and sticker pickers
- keep recent GIFs available even when live GIPHY search is not configured
- share direct composer-focus ownership across Conversation and Roleplay so either mobile composer remains open while reading older history
- apply the iOS scrolling and safe-area patches supplied by eiriol in #4260
- keep the literal iOS backing color synchronized with the active app background and compensate WebKit layout-viewport drift only on chat surfaces
- recognize same-repository PR branches as internal contributions even when the restricted Actions token cannot see private organization membership

## Validation

- [ ] Run `pnpm check` (completed locally; existing NoodleHome hook warning only)
- [ ] Run `pnpm localization:check` (completed locally)
- [ ] Run focused Playwright coverage for both mobile chat modes and all media pickers (6 passed, 2 mobile-only desktop skips)
- [ ] Review `git diff --check` (completed locally)

## Manual verification

- [ ] Manually verify Conversation and Roleplay history can be scrolled while the mobile composer is open
- [ ] Manually verify iOS Safari keyboard opening and closing does not shift the page or leave extra bottom space
- [ ] Manually verify the safe area follows dark, light, and custom app backgrounds
- [ ] Manually verify recent emoji, kaomoji, GIF, and sticker rows on desktop and mobile

## Attribution

The original iOS scrolling and safe-area patches were supplied by Discord user eiriol and attached to #4260.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Media pickers now show a “Recently used” section for emojis, kaomoji, GIFs, and stickers, with local persistence and a capped history.
  - Recent items are updated when you select new emojis or send stickers.
- **Bug Fixes**
  - Improved iOS background-color syncing and more stable virtual-viewport/scroll compensation for layout during mobile keyboard use.
  - Mobile chat/composer behavior is more reliable while scrolling transcript history.
  - Refined roleplay UI styling for Firefox.
- **Tests**
  - Expanded and stabilized end-to-end coverage for editor/media flows and mobile geometry/composer focus behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->