### PR TITLE
Fix media prompt edits reverting before generation

### DIFF
--- a/e2e/core-flows.e2e.ts
+++ b/e2e/core-flows.e2e.ts
@@ -11916,3 +11916,88 @@ test("persona editor preserves unsaved fields across responsive layout changes",
     await request.delete(`/api/characters/personas/${persona.id}`).catch(() => undefined);
   }
 });
+
+test("image prompt review preserves edits through rerenders and submits the edited prompt", async ({
+  page,
+  request,
+}) => {
+  const chatResponse = await request.post("/api/chats", {
+    data: {
+      name: "Image Prompt Review Draft Smoke",
+      mode: "roleplay",
+      characterIds: [],
+    },
+  });
+  expect(chatResponse.ok()).toBeTruthy();
+  const chat = (await chatResponse.json()) as { id: string };
+  const originalPrompt = "Original illustration prompt";
+  const editedPrompt = "Edited illustration prompt with deliberate composition";
+  const releaseRetry = createDeferred();
+  let submittedPrompt = "";
+
+  await page.route("**/api/generate/retry-agents", async (route) => {
+    const body = route.request().postDataJSON() as {
+      illustratorPromptReviewOverride?: { prompt?: string };
+    };
+    submittedPrompt = body.illustratorPromptReviewOverride?.prompt ?? "";
+    await releaseRetry.promise;
+    await route.fulfill({
+      status: 200,
+      contentType: "text/event-stream",
+      body: 'data: {"type":"done","data":null}\n\n',
+    });
+  });
+  await page.addInitScript((chatId) => localStorage.setItem("marinara-active-chat-id", chatId), chat.id);
+
+  try {
+    await page.goto("/");
+    await expect(page.getByRole("textbox", { name: /^Write/u })).toBeVisible();
+    await page.evaluate(
+      ({ chatId, prompt }) => {
+        window.dispatchEvent(
+          new CustomEvent("marinara:image-prompt-review", {
+            detail: {
+              chatId,
+              item: {
+                id: "illustration",
+                kind: "illustration",
+                title: "Scene illustration",
+                prompt,
+              },
+              resultData: { shouldGenerate: true },
+            },
+          }),
+        );
+      },
+      { chatId: chat.id, prompt: originalPrompt },
+    );
+
+    const dialog = page.getByRole("dialog", { name: "Review Image Prompt" });
+    const promptEditor = dialog.locator("textarea").first();
+    await expect(promptEditor).toHaveValue(originalPrompt);
+    await promptEditor.fill(editedPrompt);
+
+    await page.evaluate(async (chatId) => {
+      const { useAgentStore } = (await import("/src/stores/agent.store.ts")) as {
+        useAgentStore: {
+          getState: () => {
+            setProcessing: (processing: boolean, activeChatId?: string | null) => void;
+          };
+        };
+      };
+      useAgentStore.getState().setProcessing(true, chatId);
+    }, chat.id);
+    await expect(promptEditor).toHaveValue(editedPrompt);
+
+    await dialog.getByRole("button", { name: "Generate", exact: true }).click();
+    await expect.poll(() => submittedPrompt).toBe(editedPrompt);
+    await expect(promptEditor).toHaveValue(editedPrompt);
+    await expect(dialog.getByRole("button", { name: "Generate", exact: true })).toBeDisabled();
+
+    releaseRetry.resolve();
+    await expect(dialog).toBeHidden();
+  } finally {
+    releaseRetry.resolve();
+    await request.delete(`/api/chats/${chat.id}`).catch(() => undefined);
+  }
+});

--- a/packages/client/src/components/ui/ImagePromptReviewModal.tsx
+++ b/packages/client/src/components/ui/ImagePromptReviewModal.tsx
@@ -1,5 +1,5 @@
 import { Loader2, Send, X } from "lucide-react";
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { Modal } from "./Modal";
 import { cn } from "../../lib/utils";
 import { useTranslation as useUiTranslation } from "react-i18next";
@@ -44,11 +44,26 @@ export function ImagePromptReviewModal({
   const { t: localizeUi } = useUiTranslation();
   const [drafts, setDrafts] = useState<Record<string, string>>({});
   const [negativeDrafts, setNegativeDrafts] = useState<Record<string, string>>({});
+  const initializedSourceKeyRef = useRef<string | null>(null);
+  const draftSource = useMemo(() => {
+    const entries = items.map((item) => [item.id, item.prompt, item.negativePrompt ?? ""]);
+    return {
+      key: JSON.stringify(entries),
+      drafts: Object.fromEntries(items.map((item) => [item.id, item.prompt])),
+      negativeDrafts: Object.fromEntries(items.map((item) => [item.id, item.negativePrompt ?? ""])),
+    };
+  }, [items]);
 
   useEffect(() => {
-    setDrafts(Object.fromEntries(items.map((item) => [item.id, item.prompt])));
-    setNegativeDrafts(Object.fromEntries(items.map((item) => [item.id, item.negativePrompt ?? ""])));
-  }, [items]);
+    if (!open) {
+      initializedSourceKeyRef.current = null;
+      return;
+    }
+    if (initializedSourceKeyRef.current === draftSource.key) return;
+    initializedSourceKeyRef.current = draftSource.key;
+    setDrafts(draftSource.drafts);
+    setNegativeDrafts(draftSource.negativeDrafts);
+  }, [draftSource, open]);
 
   const hasEmptyPrompt = useMemo(() => items.some((item) => !(drafts[item.id] ?? item.prompt).trim()), [drafts, items]);
   const mediaLabel = mediaType === "video" ? "video" : "image";


### PR DESCRIPTION
> [!IMPORTANT]
> Contributions target `staging`. Only `SpicyMarinara` may promote this repository's `staging` branch or a same-repository `hotfix/*` branch to `main`.
> Outside and first-time contributors also require an approving review from `SpicyMarinara`.

## Linked issue

Closes #4262

## Why this change

- Image prompt review drafts were reinitialized whenever a parent supplied an equivalent `items` array with a new identity. Routine chat rerenders could therefore erase edits, and clicking Generate guaranteed a rerender when submission state changed.

## What changed

- Key draft initialization to the actual source prompt content and modal-open lifecycle, preserving user edits across equivalent parent rerenders.
- Add a browser regression that edits an Illustrator prompt, forces a parent state update, holds Generate in flight, and verifies the exact edited override is submitted.

## Validation

- [ ] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed `CONTRIBUTING.md`

Automated evidence:

- `pnpm check`
- `pnpm exec playwright test -c playwright.config.ts --grep "image prompt review preserves"`: 2 passed (desktop Chromium and mobile Chromium).
- `pnpm smoke:ui`: the new prompt-review regression passed on both projects within the full run. Overall, 150 passed, 86 skipped, and 12 unrelated pre-existing tests failed.
- `pnpm exec playwright test -c playwright.config.ts --last-failed`: the same 12 unrelated failures reproduced from a fresh data directory. They are existing accent-color expectations, a tracker empty-state expectation, and background-library tooltip/API cleanup timeouts; none exercises `ImagePromptReviewModal`.

### Manual verification notes

- Manually verify the real Illustrator flow with "Expose media prompts before sending" enabled in iOS Safari and Docker.
- Manually confirm edited positive and negative prompts remain visible while Generate is pending and reach the configured image provider.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Translated docs on the `docs-i18n` branch updated to match, or a `[docs-i18n]` follow-up issue opened (see CONTRIBUTING.md § Translated documentation)
- [ ] Version/release files updated (only if this PR includes a version bump)

## UI evidence (if applicable)

No visual design changed; this PR preserves in-progress editor state.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved edited image prompts when the review dialog refreshes or changes state.
  * Ensured the edited prompt is submitted when generating an image.
  * Prevented unintended draft resets while the dialog remains open.

* **Tests**
  * Added end-to-end coverage for editing, rerendering, submitting, and closing the image prompt review dialog.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->