### PR TITLE
fix(ci): verify trusted contributor membership

### DIFF
--- a/.github/agents/chai-workflow.md
+++ b/.github/agents/chai-workflow.md
@@ -99,7 +99,7 @@ Use this for code reviews, PR preparation, PR iteration, and ready-for-review ga
 - Never push directly to protected branches without explicit maintainer direction.
 - Do not auto-check PR validation boxes. Treat them as human verification tasks.
 - After pushing, inspect CI and review feedback when asked to ship or ready a PR.
-- Required checks and CodeRabbit must complete before every merge. Pasta-Devs developers may merge internal PRs to `staging` after those gates; outside and first-time contributors also require an approving review from `SpicyMarinara`. Only `SpicyMarinara` may promote `staging` to `main`.
+- Required checks and CodeRabbit must complete before every merge. PRs from active Pasta-Devs organization members and owners do not require separate human approval; organization members with repository merge permission may merge internal PRs to `staging` after those gates. Outside and first-time contributors also require an approving review from `SpicyMarinara`. Only `SpicyMarinara` may promote `staging` to `main`.
 
 Maintainer-equivalent self-review questions:
 

--- a/.github/workflows/pull-request-triage.yml
+++ b/.github/workflows/pull-request-triage.yml
@@ -63,7 +63,6 @@ jobs:
           github-token: ${{ secrets.PASTA_DEVS_MEMBERS_TOKEN || github.token }}
           script: |
             const organization = context.repo.owner;
-            const teamSlug = 'developers';
             const ownerLogin = 'SpicyMarinara';
             const authorLogin = context.payload.pull_request.user.login;
 
@@ -74,7 +73,7 @@ jobs:
             }
 
             if (process.env.MEMBERS_TOKEN_CONFIGURED !== 'true') {
-              core.setFailed('PASTA_DEVS_MEMBERS_TOKEN is required to verify Pasta-Devs organization and developers-team membership.');
+              core.setFailed('PASTA_DEVS_MEMBERS_TOKEN is required to verify Pasta-Devs organization membership.');
               return;
             }
 
@@ -115,35 +114,13 @@ jobs:
               return;
             }
 
-            if (organizationMembership.role === 'admin') {
-              core.notice(`${authorLogin} is an active ${organization} owner; owner approval is not required.`);
+            if (organizationMembership.role === 'admin' || organizationMembership.role === 'member') {
+              core.notice(`${authorLogin} is an active ${organization} ${organizationMembership.role}; owner approval is not required.`);
               core.setOutput('internal', 'true');
               return;
             }
 
-            try {
-              const { data: teamMembership } = await github.request(
-                'GET /orgs/{org}/teams/{team_slug}/memberships/{username}',
-                {
-                  org: organization,
-                  team_slug: teamSlug,
-                  username: authorLogin,
-                },
-              );
-
-              if (teamMembership.state === 'active') {
-                core.notice(`${authorLogin} is an active ${organization}/${teamSlug} member; owner approval is not required.`);
-                core.setOutput('internal', 'true');
-                return;
-              }
-            } catch (error) {
-              if (error.status !== 404) {
-                core.setFailed(`Could not verify ${authorLogin}'s ${organization}/${teamSlug} membership (${error.status ?? 'unknown status'}).`);
-                return;
-              }
-            }
-
-            core.notice(`${authorLogin} is not an active ${organization}/${teamSlug} member; owner approval is required.`);
+            core.notice(`${authorLogin} does not have a trusted ${organization} organization role; owner approval is required.`);
             core.setOutput('internal', 'false');
 
       - name: Require owner approval for outside staging contributions

--- a/.github/workflows/pull-request-triage.yml
+++ b/.github/workflows/pull-request-triage.yml
@@ -53,7 +53,95 @@ jobs:
     permissions:
       pull-requests: read
     steps:
+      - name: Classify pull request author
+        id: internal-author
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
+        env:
+          MEMBERS_TOKEN_CONFIGURED: ${{ secrets.PASTA_DEVS_MEMBERS_TOKEN != '' }}
+        with:
+          # Fine-grained PAT or GitHub App token with Pasta-Devs "Members: read".
+          github-token: ${{ secrets.PASTA_DEVS_MEMBERS_TOKEN || github.token }}
+          script: |
+            const organization = context.repo.owner;
+            const teamSlug = 'developers';
+            const ownerLogin = 'SpicyMarinara';
+            const authorLogin = context.payload.pull_request.user.login;
+
+            if (process.env.MEMBERS_TOKEN_CONFIGURED !== 'true') {
+              core.setFailed('PASTA_DEVS_MEMBERS_TOKEN is required to verify Pasta-Devs organization and developers-team membership.');
+              return;
+            }
+
+            async function getOrganizationMembership(username) {
+              return github.request('GET /orgs/{org}/memberships/{username}', {
+                org: organization,
+                username,
+              });
+            }
+
+            try {
+              const { data: ownerMembership } = await getOrganizationMembership(ownerLogin);
+              if (ownerMembership.state !== 'active' || ownerMembership.role !== 'admin') {
+                core.setFailed(`PASTA_DEVS_MEMBERS_TOKEN could not verify ${ownerLogin} as an active ${organization} owner.`);
+                return;
+              }
+            } catch (error) {
+              core.setFailed(`PASTA_DEVS_MEMBERS_TOKEN could not read ${organization} membership (${error.status ?? 'unknown status'}).`);
+              return;
+            }
+
+            let organizationMembership;
+            try {
+              ({ data: organizationMembership } = await getOrganizationMembership(authorLogin));
+            } catch (error) {
+              if (error.status === 404) {
+                core.notice(`${authorLogin} is not a ${organization} organization member; owner approval is required.`);
+                core.setOutput('internal', 'false');
+                return;
+              }
+              core.setFailed(`Could not verify ${authorLogin}'s ${organization} membership (${error.status ?? 'unknown status'}).`);
+              return;
+            }
+
+            if (organizationMembership.state !== 'active') {
+              core.notice(`${authorLogin}'s ${organization} membership is not active; owner approval is required.`);
+              core.setOutput('internal', 'false');
+              return;
+            }
+
+            if (organizationMembership.role === 'admin') {
+              core.notice(`${authorLogin} is an active ${organization} owner; owner approval is not required.`);
+              core.setOutput('internal', 'true');
+              return;
+            }
+
+            try {
+              const { data: teamMembership } = await github.request(
+                'GET /orgs/{org}/teams/{team_slug}/memberships/{username}',
+                {
+                  org: organization,
+                  team_slug: teamSlug,
+                  username: authorLogin,
+                },
+              );
+
+              if (teamMembership.state === 'active') {
+                core.notice(`${authorLogin} is an active ${organization}/${teamSlug} member; owner approval is not required.`);
+                core.setOutput('internal', 'true');
+                return;
+              }
+            } catch (error) {
+              if (error.status !== 404) {
+                core.setFailed(`Could not verify ${authorLogin}'s ${organization}/${teamSlug} membership (${error.status ?? 'unknown status'}).`);
+                return;
+              }
+            }
+
+            core.notice(`${authorLogin} is not an active ${organization}/${teamSlug} member; owner approval is required.`);
+            core.setOutput('internal', 'false');
+
       - name: Require owner approval for outside staging contributions
+        if: steps.internal-author.outputs.internal != 'true'
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         with:
           script: |
@@ -63,13 +151,6 @@ jobs:
               repo: context.repo.repo,
               pull_number: pullNumber,
             });
-            const repositoryName = `${context.repo.owner}/${context.repo.repo}`.toLowerCase();
-            const sameRepositoryBranch = pr.head?.repo?.full_name?.toLowerCase() === repositoryName;
-
-            if (sameRepositoryBranch || pr.author_association === 'OWNER' || pr.author_association === 'MEMBER') {
-              core.notice('Internal same-repository contribution; owner approval is not required.');
-              return;
-            }
 
             const reviews = await github.paginate(github.rest.pulls.listReviews, {
               owner: context.repo.owner,

--- a/.github/workflows/pull-request-triage.yml
+++ b/.github/workflows/pull-request-triage.yml
@@ -84,17 +84,6 @@ jobs:
               });
             }
 
-            try {
-              const { data: ownerMembership } = await getOrganizationMembership(ownerLogin);
-              if (ownerMembership.state !== 'active' || ownerMembership.role !== 'admin') {
-                core.setFailed(`PASTA_DEVS_MEMBERS_TOKEN could not verify ${ownerLogin} as an active ${organization} owner.`);
-                return;
-              }
-            } catch (error) {
-              core.setFailed(`PASTA_DEVS_MEMBERS_TOKEN could not read ${organization} membership (${error.status ?? 'unknown status'}).`);
-              return;
-            }
-
             let organizationMembership;
             try {
               ({ data: organizationMembership } = await getOrganizationMembership(authorLogin));

--- a/.github/workflows/pull-request-triage.yml
+++ b/.github/workflows/pull-request-triage.yml
@@ -67,6 +67,12 @@ jobs:
             const ownerLogin = 'SpicyMarinara';
             const authorLogin = context.payload.pull_request.user.login;
 
+            if (authorLogin.toLowerCase() === ownerLogin.toLowerCase()) {
+              core.notice(`${authorLogin} is the repository owner; owner approval is not required.`);
+              core.setOutput('internal', 'true');
+              return;
+            }
+
             if (process.env.MEMBERS_TOKEN_CONFIGURED !== 'true') {
               core.setFailed('PASTA_DEVS_MEMBERS_TOKEN is required to verify Pasta-Devs organization and developers-team membership.');
               return;

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,7 +21,7 @@ This file is a thin maintainer note for contributors using Codex. Canonical work
 
 - Keep edits non-destructive. Do not revert unrelated work in the tree.
 - Make Marinara Engine changes against `staging` first; do not target `main` directly unless the user or maintainer explicitly asks for a mainline change. See `CONTRIBUTING.md § Branches`.
-- Required checks and CodeRabbit must complete before any `staging` merge. Pasta-Devs developers may then merge internal PRs without another human approval; outside and first-time contributors require an approving review from `SpicyMarinara`.
+- Required checks and CodeRabbit must complete before any `staging` merge. PRs from active Pasta-Devs organization members and owners do not require another human approval; outside and first-time contributors require an approving review from `SpicyMarinara`. Organization members with repository merge permission may merge internal PRs after those gates pass.
 - Only `SpicyMarinara` may promote the repository's `staging` branch into `main` or merge a same-repository `hotfix/*` branch.
 - Prefer focused patches that keep code, docs, and release metadata aligned in the same change.
 - Route changes to downloadable agents such as Illustrator, Music DJ, and Lorebook Keeper to [Pasta-Devs/Marinara-Agents](https://github.com/Pasta-Devs/Marinara-Agents). Agent definitions, default prompts, package-owned runtime code, metadata, artwork/assets, manifests, artifacts, and catalog entries must be fixed and submitted there against its `staging` branch, not in Marinara Engine.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -56,7 +56,7 @@ Guidelines:
 - **Base your feature branch on `staging`**, not `main`. Run `git checkout staging && git pull` before branching.
 - **Open PRs against `staging`**. The GitHub web UI defaults to `main` (the repo's default branch); change the base to `staging` when filing the PR.
 - Every PR must pass the required GitHub checks and complete its CodeRabbit review before merge. These gates cannot be bypassed by developers.
-- Pasta-Devs members in the `@Pasta-Devs/developers` team may merge a ready PR into `staging` after those automated gates pass; a separate human approval is not required.
+- PRs authored by active Pasta-Devs organization members or owners do not require a separate human approval. Organization members with repository merge permission may merge a ready PR into `staging` after the automated gates pass.
 - Outside and first-time contributors may submit only to `staging` and need an approving review from repository owner `SpicyMarinara` in addition to the automated gates. Approval from another Pasta-Devs member does not satisfy this gate.
 - Only `SpicyMarinara` may update or merge into `main`. Normal releases are promoted from the same repository's tested `staging` branch; direct mainline work is reserved for an owner-owned `hotfix/*` branch in this repository.
 - Update checks and installation guides continue to track `main`, since end users install from released versions.


### PR DESCRIPTION
> [!IMPORTANT]
> Contributions target `staging`. Only `SpicyMarinara` may promote this repository's `staging` branch or a same-repository `hotfix/*` branch to `main`.
> Authors outside the Pasta-Devs organization require an approving review from `SpicyMarinara`.

## Linked issue

Closes #4267

## Why this change

- The owner-approval gate relies on `author_association`, which rejected active Pasta-Devs organization members and owners while also treating branch location as an internal-contributor signal.
- Every active user shown in the Pasta-Devs organization People roster with role `Member` or `Owner` should pass automatically. Everyone outside the organization—including outside collaborators, first-time contributors, and ordinary external contributors—must receive approval from `SpicyMarinara` for the current head commit.

## What changed

- Exempt `SpicyMarinara` explicitly so the repository owner does not depend on a membership credential.
- Classify other PR authors through the authoritative Pasta-Devs organization membership API and trust only active `Member` or `Owner` roles.
- Remove the same-repository and `author_association` bypasses from the owner-approval gate.
- Preserve the existing current-head review requirement for every external author.
- Align `AGENTS.md`, `CONTRIBUTING.md`, and the AI workflow overlay with the corrected organization-role policy.
- Fail closed with an explicit configuration error when organization membership cannot be verified.

## Validation

- [ ] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed `CONTRIBUTING.md`

### Manual verification notes

Automated validation performed while preparing this draft:

- `pnpm check`
- Prettier check for `.github/workflows/pull-request-triage.yml`
- Actionlint v1.7.12
- YAML parser validation
- Mock policy matrix covering the explicit owner without a token, active organization Member, active organization Owner, outside collaborator, first-time contributor, ordinary external contributor, inactive membership, untrusted organization role, and missing-token fail-closed behavior

Before private organization membership can be recognized, configure the repository secret `PASTA_DEVS_MEMBERS_TOKEN` with a fine-grained PAT or GitHub App token that has Pasta-Devs organization **Members: read** permission. Because this workflow uses `pull_request_target`, the updated gate takes effect only after the workflow reaches the default branch (`main`).

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Translated docs on the `docs-i18n` branch updated to match, or a `[docs-i18n] <paths>` follow-up issue opened (see CONTRIBUTING.md § Translated documentation)
- [ ] Version/release files updated (only if this PR includes a version bump)

## UI evidence (if applicable)

Not applicable; this change affects GitHub Actions policy only.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Workflow Improvements**
  * Updated pull request checks to more accurately distinguish internal contributors from outside contributors.
  * Outside and first-time contributions continue to require owner approval before staging merges.
  * Required checks and automated review must complete before merges.

* **Documentation**
  * Clarified staging merge permissions for active organization members and owners.
  * Updated contribution and workflow guidance to reflect current approval requirements.
  * Retained restricted promotion of staging changes to the main branch.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->