### PR TITLE
fix(ci): activate Pasta-Devs membership verification

### DIFF
--- a/.github/agents/chai-workflow.md
+++ b/.github/agents/chai-workflow.md
@@ -93,7 +93,7 @@ Use this for code reviews, PR preparation, PR iteration, and ready-for-review ga
 - Never push directly to protected branches without explicit maintainer direction.
 - Do not auto-check PR validation boxes. Treat them as human verification tasks.
 - After pushing, inspect CI and review feedback when asked to ship or ready a PR.
-- Required checks and CodeRabbit must complete before every merge. Pasta-Devs developers may merge internal PRs to `staging` after those gates; outside and first-time contributors also require an approving review from `SpicyMarinara`. Only `SpicyMarinara` may promote `staging` to `main`.
+- Required checks and CodeRabbit must complete before every merge. PRs from active Pasta-Devs organization members and owners do not require separate human approval; organization members with repository merge permission may merge internal PRs to `staging` after those gates. Outside and first-time contributors also require an approving review from `SpicyMarinara`. Only `SpicyMarinara` may promote `staging` to `main`.
 
 Maintainer-equivalent self-review questions:
 

--- a/.github/workflows/pull-request-triage.yml
+++ b/.github/workflows/pull-request-triage.yml
@@ -53,7 +53,67 @@ jobs:
     permissions:
       pull-requests: read
     steps:
+      - name: Classify pull request author
+        id: internal-author
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
+        env:
+          MEMBERS_TOKEN_CONFIGURED: ${{ secrets.PASTA_DEVS_MEMBERS_TOKEN != '' }}
+        with:
+          # Fine-grained PAT or GitHub App token with Pasta-Devs "Members: read".
+          github-token: ${{ secrets.PASTA_DEVS_MEMBERS_TOKEN || github.token }}
+          script: |
+            const organization = context.repo.owner;
+            const ownerLogin = 'SpicyMarinara';
+            const authorLogin = context.payload.pull_request.user.login;
+
+            if (authorLogin.toLowerCase() === ownerLogin.toLowerCase()) {
+              core.notice(`${authorLogin} is the repository owner; owner approval is not required.`);
+              core.setOutput('internal', 'true');
+              return;
+            }
+
+            if (process.env.MEMBERS_TOKEN_CONFIGURED !== 'true') {
+              core.setFailed('PASTA_DEVS_MEMBERS_TOKEN is required to verify Pasta-Devs organization membership.');
+              return;
+            }
+
+            async function getOrganizationMembership(username) {
+              return github.request('GET /orgs/{org}/memberships/{username}', {
+                org: organization,
+                username,
+              });
+            }
+
+            let organizationMembership;
+            try {
+              ({ data: organizationMembership } = await getOrganizationMembership(authorLogin));
+            } catch (error) {
+              if (error.status === 404) {
+                core.notice(`${authorLogin} is not a ${organization} organization member; owner approval is required.`);
+                core.setOutput('internal', 'false');
+                return;
+              }
+              core.setFailed(`Could not verify ${authorLogin}'s ${organization} membership (${error.status ?? 'unknown status'}).`);
+              return;
+            }
+
+            if (organizationMembership.state !== 'active') {
+              core.notice(`${authorLogin}'s ${organization} membership is not active; owner approval is required.`);
+              core.setOutput('internal', 'false');
+              return;
+            }
+
+            if (organizationMembership.role === 'admin' || organizationMembership.role === 'member') {
+              core.notice(`${authorLogin} is an active ${organization} ${organizationMembership.role}; owner approval is not required.`);
+              core.setOutput('internal', 'true');
+              return;
+            }
+
+            core.notice(`${authorLogin} does not have a trusted ${organization} organization role; owner approval is required.`);
+            core.setOutput('internal', 'false');
+
       - name: Require owner approval for outside staging contributions
+        if: steps.internal-author.outputs.internal != 'true'
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         with:
           script: |
@@ -63,12 +123,6 @@ jobs:
               repo: context.repo.repo,
               pull_number: pullNumber,
             });
-
-            if (pr.author_association === 'OWNER' || pr.author_association === 'MEMBER') {
-              core.notice(`Internal ${pr.author_association.toLowerCase()} contribution; owner approval is not required.`);
-              return;
-            }
-
             const reviews = await github.paginate(github.rest.pulls.listReviews, {
               owner: context.repo.owner,
               repo: context.repo.repo,

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,7 +21,7 @@ This file is a thin maintainer note for contributors using Codex. Canonical work
 
 - Keep edits non-destructive. Do not revert unrelated work in the tree.
 - Make Marinara Engine changes against `staging` first; do not target `main` directly unless the user or maintainer explicitly asks for a mainline change. See `CONTRIBUTING.md § Branches`.
-- Required checks and CodeRabbit must complete before any `staging` merge. Pasta-Devs developers may then merge internal PRs without another human approval; outside and first-time contributors require an approving review from `SpicyMarinara`.
+- Required checks and CodeRabbit must complete before any `staging` merge. PRs from active Pasta-Devs organization members and owners do not require another human approval; outside and first-time contributors require an approving review from `SpicyMarinara`. Organization members with repository merge permission may merge internal PRs after those gates pass.
 - Only `SpicyMarinara` may promote the repository's `staging` branch into `main` or merge a same-repository `hotfix/*` branch.
 - Prefer focused patches that keep code, docs, and release metadata aligned in the same change.
 - Route changes to downloadable agents such as Illustrator, Music DJ, and Lorebook Keeper to [Pasta-Devs/Marinara-Agents](https://github.com/Pasta-Devs/Marinara-Agents). Agent definitions, default prompts, package-owned runtime code, metadata, artwork/assets, manifests, artifacts, and catalog entries must be fixed and submitted there against its `staging` branch, not in Marinara Engine.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -56,7 +56,7 @@ Guidelines:
 - **Base your feature branch on `staging`**, not `main`. Run `git checkout staging && git pull` before branching.
 - **Open PRs against `staging`**. The GitHub web UI defaults to `main` (the repo's default branch); change the base to `staging` when filing the PR.
 - Every PR must pass the required GitHub checks and complete its CodeRabbit review before merge. These gates cannot be bypassed by developers.
-- Pasta-Devs members in the `@Pasta-Devs/developers` team may merge a ready PR into `staging` after those automated gates pass; a separate human approval is not required.
+- PRs authored by active Pasta-Devs organization members or owners do not require a separate human approval. Organization members with repository merge permission may merge a ready PR into `staging` after the automated gates pass.
 - Outside and first-time contributors may submit only to `staging` and need an approving review from repository owner `SpicyMarinara` in addition to the automated gates. Approval from another Pasta-Devs member does not satisfy this gate.
 - Only `SpicyMarinara` may update or merge into `main`. Normal releases are promoted from the same repository's tested `staging` branch; direct mainline work is reserved for an owner-owned `hotfix/*` branch in this repository.
 - Update checks and installation guides continue to track `main`, since end users install from released versions.


### PR DESCRIPTION
## Why this change

`pull_request_target` loads the approval workflow from the default branch, so the policy merged through #4268 cannot protect staging until the corrected workflow is present on `main`.

## What changed

- classify active Pasta-Devs Members and Owners through the organization membership API
- require current-head approval from `SpicyMarinara` for every outside contributor
- keep membership/API failures fail-closed
- align maintainer guidance with the enforced policy

## Validation

- [ ] Required GitHub checks complete
- [ ] CodeRabbit review completes

Relates to #4267 and bootstraps #4268 on the default branch.