### PR TITLE
Fix Secret Plot run interval editing

### DIFF
--- a/e2e/core-flows.e2e.ts
+++ b/e2e/core-flows.e2e.ts
@@ -7621,6 +7621,117 @@ test("Conversation Chat Settings can attach and retain custom agents", async ({ 
   }
 });
 
+test("Secret Plot run interval stays editable across repeated commits", async ({ page, request }, testInfo) => {
+  test.skip(!testInfo.project.name.includes("desktop"), "Secret Plot interval editing is covered on desktop.");
+
+  const chatResponse = await request.post("/api/chats", {
+    data: { name: "Secret Plot Interval Smoke", mode: "roleplay", characterIds: [] },
+  });
+  expect(chatResponse.ok()).toBeTruthy();
+  const chat = (await chatResponse.json()) as { id: string };
+  const metadataResponse = await request.patch(`/api/chats/${chat.id}/metadata`, {
+    data: {
+      enableAgents: true,
+      activeAgentIds: ["director"],
+      narrativeDirectorSecretPlotEnabled: true,
+      narrativeDirectorSecretPlotRunInterval: 8,
+    },
+  });
+  expect(metadataResponse.ok()).toBeTruthy();
+
+  const readRunInterval = async () => {
+    const response = await request.get(`/api/chats/${chat.id}`);
+    if (!response.ok()) return null;
+    const current = (await response.json()) as { metadata?: unknown };
+    const metadata =
+      typeof current.metadata === "string"
+        ? (JSON.parse(current.metadata) as Record<string, unknown>)
+        : ((current.metadata ?? {}) as Record<string, unknown>);
+    return metadata.narrativeDirectorSecretPlotRunInterval;
+  };
+
+  await page.route("**/api/capability-packages/agents", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify([
+        {
+          id: "director",
+          name: "Narrative Director",
+          description: "Creates one-shot story directions.",
+          author: "Pasta Devs",
+          phase: "pre_generation",
+          execution: "host",
+          enabledByDefault: false,
+          category: "writer",
+          modeAllowlist: ["roleplay"],
+          defaultPromptTemplate: "Return the next story direction.",
+        },
+      ]),
+    });
+  });
+  await page.route("**/api/capability-packages/installed", async (route) => {
+    await route.fulfill({ status: 200, contentType: "application/json", body: "[]" });
+  });
+  await page.route("**/api/agents", async (route) => {
+    await route.fulfill({ status: 200, contentType: "application/json", body: "[]" });
+  });
+  await page.addInitScript((chatId) => {
+    localStorage.setItem("marinara-active-chat-id", chatId);
+  }, chat.id);
+
+  try {
+    await page.goto("/");
+    await page.getByRole("button", { name: "Chat Settings" }).click();
+    const drawer = page.locator(".mari-chat-settings-drawer");
+    const agentsSection = drawer.locator('[role="button"][aria-expanded]').filter({ hasText: /^Agents/ });
+    if ((await agentsSection.getAttribute("aria-expanded")) !== "true") await agentsSection.click();
+
+    const directorCard = drawer.locator(`#chat-settings-agent-menu-${chat.id}-director`);
+    const intervalInput = directorCard.locator("label").filter({ hasText: "Run Interval" }).locator("input");
+    await expect(intervalInput).toHaveValue("8");
+
+    await intervalInput.fill("3");
+    await intervalInput.blur();
+    await expect.poll(readRunInterval).toBe(3);
+    await expect(intervalInput).toHaveValue("3");
+
+    await intervalInput.fill("11");
+    await intervalInput.press("Enter");
+    await expect.poll(readRunInterval).toBe(11);
+    await expect(intervalInput).toHaveValue("11");
+
+    await intervalInput.fill("0");
+    await intervalInput.blur();
+    await expect.poll(readRunInterval).toBe(1);
+    await expect(intervalInput).toHaveValue("1");
+
+    await intervalInput.fill("101");
+    await intervalInput.press("Enter");
+    await expect.poll(readRunInterval).toBe(100);
+    await expect(intervalInput).toHaveValue("100");
+
+    await page.reload();
+    await page.getByRole("button", { name: "Chat Settings" }).click();
+    const reloadedDrawer = page.locator(".mari-chat-settings-drawer");
+    const reloadedAgentsSection = reloadedDrawer
+      .locator('[role="button"][aria-expanded]')
+      .filter({ hasText: /^Agents/ });
+    if ((await reloadedAgentsSection.getAttribute("aria-expanded")) !== "true") {
+      await reloadedAgentsSection.click();
+    }
+    await expect(
+      reloadedDrawer
+        .locator(`#chat-settings-agent-menu-${chat.id}-director`)
+        .locator("label")
+        .filter({ hasText: "Run Interval" })
+        .locator("input"),
+    ).toHaveValue("100");
+  } finally {
+    await request.delete(`/api/chats/${chat.id}`, { timeout: 10_000 });
+  }
+});
+
 test("mobile Roleplay code formatting stays inside the message width", async ({ page, request }, testInfo) => {
   test.skip(!testInfo.project.name.includes("mobile"), "Mobile markdown containment regression.");
 

--- a/e2e/core-flows.e2e.ts
+++ b/e2e/core-flows.e2e.ts
@@ -7624,63 +7624,65 @@ test("Conversation Chat Settings can attach and retain custom agents", async ({ 
 test("Secret Plot run interval stays editable across repeated commits", async ({ page, request }, testInfo) => {
   test.skip(!testInfo.project.name.includes("desktop"), "Secret Plot interval editing is covered on desktop.");
 
-  const chatResponse = await request.post("/api/chats", {
-    data: { name: "Secret Plot Interval Smoke", mode: "roleplay", characterIds: [] },
-  });
-  expect(chatResponse.ok()).toBeTruthy();
-  const chat = (await chatResponse.json()) as { id: string };
-  const metadataResponse = await request.patch(`/api/chats/${chat.id}/metadata`, {
-    data: {
-      enableAgents: true,
-      activeAgentIds: ["director"],
-      narrativeDirectorSecretPlotEnabled: true,
-      narrativeDirectorSecretPlotRunInterval: 8,
-    },
-  });
-  expect(metadataResponse.ok()).toBeTruthy();
-
-  const readRunInterval = async () => {
-    const response = await request.get(`/api/chats/${chat.id}`);
-    if (!response.ok()) return null;
-    const current = (await response.json()) as { metadata?: unknown };
-    const metadata =
-      typeof current.metadata === "string"
-        ? (JSON.parse(current.metadata) as Record<string, unknown>)
-        : ((current.metadata ?? {}) as Record<string, unknown>);
-    return metadata.narrativeDirectorSecretPlotRunInterval;
-  };
-
-  await page.route("**/api/capability-packages/agents", async (route) => {
-    await route.fulfill({
-      status: 200,
-      contentType: "application/json",
-      body: JSON.stringify([
-        {
-          id: "director",
-          name: "Narrative Director",
-          description: "Creates one-shot story directions.",
-          author: "Pasta Devs",
-          phase: "pre_generation",
-          execution: "host",
-          enabledByDefault: false,
-          category: "writer",
-          modeAllowlist: ["roleplay"],
-          defaultPromptTemplate: "Return the next story direction.",
-        },
-      ]),
-    });
-  });
-  await page.route("**/api/capability-packages/installed", async (route) => {
-    await route.fulfill({ status: 200, contentType: "application/json", body: "[]" });
-  });
-  await page.route("**/api/agents", async (route) => {
-    await route.fulfill({ status: 200, contentType: "application/json", body: "[]" });
-  });
-  await page.addInitScript((chatId) => {
-    localStorage.setItem("marinara-active-chat-id", chatId);
-  }, chat.id);
-
+  let chatId: string | undefined;
   try {
+    const chatResponse = await request.post("/api/chats", {
+      data: { name: "Secret Plot Interval Smoke", mode: "roleplay", characterIds: [] },
+    });
+    expect(chatResponse.ok()).toBeTruthy();
+    const chat = (await chatResponse.json()) as { id: string };
+    chatId = chat.id;
+    const metadataResponse = await request.patch(`/api/chats/${chat.id}/metadata`, {
+      data: {
+        enableAgents: true,
+        activeAgentIds: ["director"],
+        narrativeDirectorSecretPlotEnabled: true,
+        narrativeDirectorSecretPlotRunInterval: 8,
+      },
+    });
+    expect(metadataResponse.ok()).toBeTruthy();
+
+    const readRunInterval = async () => {
+      const response = await request.get(`/api/chats/${chat.id}`);
+      if (!response.ok()) return null;
+      const current = (await response.json()) as { metadata?: unknown };
+      const metadata =
+        typeof current.metadata === "string"
+          ? (JSON.parse(current.metadata) as Record<string, unknown>)
+          : ((current.metadata ?? {}) as Record<string, unknown>);
+      return metadata.narrativeDirectorSecretPlotRunInterval;
+    };
+
+    await page.route("**/api/capability-packages/agents", async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify([
+          {
+            id: "director",
+            name: "Narrative Director",
+            description: "Creates one-shot story directions.",
+            author: "Pasta Devs",
+            phase: "pre_generation",
+            execution: "host",
+            enabledByDefault: false,
+            category: "writer",
+            modeAllowlist: ["roleplay"],
+            defaultPromptTemplate: "Return the next story direction.",
+          },
+        ]),
+      });
+    });
+    await page.route("**/api/capability-packages/installed", async (route) => {
+      await route.fulfill({ status: 200, contentType: "application/json", body: "[]" });
+    });
+    await page.route("**/api/agents", async (route) => {
+      await route.fulfill({ status: 200, contentType: "application/json", body: "[]" });
+    });
+    await page.addInitScript((chatId) => {
+      localStorage.setItem("marinara-active-chat-id", chatId);
+    }, chat.id);
+
     await page.goto("/");
     await page.getByRole("button", { name: "Chat Settings" }).click();
     const drawer = page.locator(".mari-chat-settings-drawer");
@@ -7728,7 +7730,7 @@ test("Secret Plot run interval stays editable across repeated commits", async ({
         .locator("input"),
     ).toHaveValue("100");
   } finally {
-    await request.delete(`/api/chats/${chat.id}`, { timeout: 10_000 });
+    if (chatId) await request.delete(`/api/chats/${chatId}`, { timeout: 10_000 });
   }
 });
 

--- a/packages/client/src/components/chat/ChatSettingsDrawer.tsx
+++ b/packages/client/src/components/chat/ChatSettingsDrawer.tsx
@@ -6891,19 +6891,14 @@ export function ChatSettingsDrawer({
                                       {localizeUi("ui.agents.agenteditor.runInterval")}
                                     </span>
                                     <div className="flex items-center gap-2">
-                                      <input
-                                        type="number"
+                                      <DraftNumberInput
+                                        value={narrativeDirectorSecretPlotRunInterval}
                                         min={1}
                                         max={100}
-                                        value={narrativeDirectorSecretPlotRunInterval}
-                                        onChange={(event) =>
+                                        onCommit={(value) =>
                                           updateMeta.mutate({
                                             id: chat.id,
-                                            narrativeDirectorSecretPlotRunInterval: normalizePositiveInteger(
-                                              event.target.value,
-                                              narrativeDirectorSecretPlotRunInterval,
-                                              100,
-                                            ),
+                                            narrativeDirectorSecretPlotRunInterval: value,
                                           })
                                         }
                                         className="w-24 rounded-lg border border-[var(--border)] bg-[var(--background)] px-2.5 py-2 text-xs tabular-nums text-[var(--foreground)] outline-none transition-colors focus:border-[var(--ring)] focus:ring-1 focus:ring-[var(--ring)]"

--- a/scripts/regressions/open-issues.regression.ts
+++ b/scripts/regressions/open-issues.regression.ts
@@ -3755,6 +3755,22 @@ try {
   );
 }
 
+// Issue #4277 — the Secret Plot interval remains editable after Narrative
+// Director is installed instead of passing a string through a number-only
+// normalizer and immediately restoring the previous value.
+{
+  assert.match(
+    chatSettingsDrawerSource,
+    /<DraftNumberInput\s+value=\{narrativeDirectorSecretPlotRunInterval\}\s+min=\{1\}\s+max=\{100\}\s+onCommit=\{\(value\) =>\s+updateMeta\.mutate\(\{\s+id: chat\.id,\s+narrativeDirectorSecretPlotRunInterval: value,/u,
+    "Secret Plot run interval must use a draft number input that commits the edited numeric value",
+  );
+  assert.doesNotMatch(
+    chatSettingsDrawerSource,
+    /narrativeDirectorSecretPlotRunInterval:\s*normalizePositiveInteger\(\s*event\.target\.value/u,
+    "Secret Plot run interval must not reject the browser's string input value",
+  );
+}
+
 // Issue #4002 — Character Tavern stores card JSON in zTXt (zlib-compressed)
 // PNG chunks; every card-parsing path must read them, and export must strip
 // stale ones so re-exported cards cannot carry outdated compressed data.


### PR DESCRIPTION
Closes #4277

## Why

After Narrative Director was added to a chat, its Secret Plot Run Interval appeared locked. The browser supplies edited input values as strings, but the Chat Settings control passed that string to a number-only normalizer. The normalizer therefore restored the previous value on every change. The setup form used a different string-aware path, which explains why removing and re-adding the agent allowed exactly one more edit.

## What changed

- Replaced the installed-agent interval field with the shared `DraftNumberInput` control.
- Kept an editable local draft, clamped committed values to 1–100, and saved once on blur or Enter.
- Added source-wiring and Playwright regressions for repeated edits, browser string input, bounds, and persistence after reload.

## Impact

Secret Plot Run Interval can now be changed repeatedly after Narrative Director is installed, including on touch/mobile input, without per-keystroke metadata writes.

## Automated validation

- `pnpm check` — passed (Impeccable context, localization, ESLint/TypeScript, production build).
- Focused issue #4277 source regression — passed.
- Focused Playwright interaction regression — passed (repeated commits, Enter/blur, 1–100 clamping, reload persistence).
- `pnpm regression:issues` — staging baseline stops before this assertion at the pre-existing background-organization expectation (`favorites: []` is now returned but not expected at line 330).
- `pnpm smoke:ui` — completed with 150 passed and 86 project skips; 12 unrelated staging-baseline failures remain in accent-state and background-library tests.

## Manual verification requested

- [ ] Add Narrative Director to a Roleplay chat with Secret Plot enabled.
- [ ] Change Run Interval, blur the field, then reopen Chat Settings and verify the value persisted.
- [ ] Change Run Interval a second time and verify it remains editable and persists.
- [ ] Repeat on Firefox/Android or another touch browser.
- [ ] Verify values below 1 and above 100 clamp to the supported range.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the Narrative Director’s **“Secret Plot run interval”** setting to reliably save edited numeric values.
  * Switched the field to a draft-based numeric input so browser-entered text commits correctly, with expected clamping for out-of-range values.

* **Tests**
  * Added a regression test verifying the draft input behavior and persisted `narrativeDirectorSecretPlotRunInterval`.
  * Added an E2E test confirming the run interval stays editable across repeated commits and is restored after reload.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->