### PR TITLE
Add trademark and third-party hosting policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@
   - [Community \& Support](#community--support)
   - [Contributors](#contributors)
   - [License](#license)
+  - [Trademark \& Branding](#trademark--branding)
 
 ---
 
@@ -244,4 +245,12 @@ The full guide library is browsable inside the app: open **Documentation** from 
 
 ## License
 
-[AGPL-3.0](LICENSE)
+Marinara Engine source code is licensed under the [GNU AGPLv3](LICENSE).
+
+## Trademark & Branding
+
+The software license does not grant permission to imply that a third-party
+product or hosted service is official, endorsed, certified, or supported by
+Pasta-Devs. Truthful references to Marinara Engine remain welcome when the
+operator and independent status are clear. See the
+[Trademark and Branding Policy](TRADEMARKS.md) for the complete guidelines.

--- a/README.md
+++ b/README.md
@@ -251,6 +251,7 @@ Marinara Engine source code is licensed under the [GNU AGPLv3](LICENSE).
 
 The software license does not grant permission to imply that a third-party
 product or hosted service is official, endorsed, certified, or supported by
-Pasta-Devs. Truthful references to Marinara Engine remain welcome when the
-operator and independent status are clear. See the
-[Trademark and Branding Policy](TRADEMARKS.md) for the complete guidelines.
+Pasta-Devs. Ordinary truthful descriptive and nominative references to Marinara
+Engine remain welcome. When a reference is used to market or operate a hosted
+service, its operator and independent status must be clear. See the [Trademark
+and Branding Policy](TRADEMARKS.md) for the complete guidelines.

--- a/TRADEMARKS.md
+++ b/TRADEMARKS.md
@@ -61,6 +61,12 @@ operator and prominently display a disclosure substantially similar to:
 > **[Service name] is independently operated by [operator] and is not
 > affiliated with, endorsed by, or supported by Pasta-Devs.**
 
+This non-affiliation disclosure is not required for a service operated by
+Pasta-Devs or for a third-party service whose written authorization expressly
+permits presentation as an official Marinara Engine or Pasta-Devs service. An
+authorized service must instead follow the branding and disclosure terms in
+that authorization.
+
 Displaying this disclosure does not authorize use of a Project Mark. It is
 required in addition to any prior written permission applicable under
 [Uses That Require Written Permission](#uses-that-require-written-permission).
@@ -95,9 +101,9 @@ official release, provided that it identifies the release and links to the
 Pasta-Devs source. If that artifact is used to operate a hosted service, the
 service must also include the independent-service disclosure.
 
-Only a service operated by Pasta-Devs, or a service with prior written
-authorization from Pasta-Devs, may be presented as an official Marinara Engine
-or Pasta-Devs service.
+Only a service operated by Pasta-Devs, or a service with written authorization
+that expressly permits presentation as an official Marinara Engine or
+Pasta-Devs service, may be presented as official.
 
 ## Uses That Require Written Permission
 

--- a/TRADEMARKS.md
+++ b/TRADEMARKS.md
@@ -61,6 +61,10 @@ operator and prominently display a disclosure substantially similar to:
 > **[Service name] is independently operated by [operator] and is not
 > affiliated with, endorsed by, or supported by Pasta-Devs.**
 
+Displaying this disclosure does not authorize use of a Project Mark. It is
+required in addition to any prior written permission applicable under
+[Uses That Require Written Permission](#uses-that-require-written-permission).
+
 The disclosure must be visible wherever customers choose, purchase, or first
 access the service. It must not be hidden only in general terms, a privacy
 policy, or another page that customers would not ordinarily see.
@@ -85,10 +89,11 @@ Pasta-Devs may be described as an **official Marinara Engine build**.
 
 A mirror, repackaged image, preconfigured image, deployment template, hosted
 instance, or service deployment is not an official build, even when its
-application files are unchanged. A third party may truthfully state that it
-deploys an unmodified copy of a specific official release, provided that it
-identifies the release, links to the Pasta-Devs source, and includes the
-independent-service disclosure.
+application files are unchanged. A third-party distributor may truthfully
+state that its artifact contains or deploys an unmodified copy of a specific
+official release, provided that it identifies the release and links to the
+Pasta-Devs source. If that artifact is used to operate a hosted service, the
+service must also include the independent-service disclosure.
 
 Only a service operated by Pasta-Devs, or a service with prior written
 authorization from Pasta-Devs, may be presented as an official Marinara Engine
@@ -96,7 +101,8 @@ or Pasta-Devs service.
 
 ## Uses That Require Written Permission
 
-Prior written permission from Pasta-Devs is required to:
+The independent-service disclosure does not grant any of the permissions in
+this section. Prior written permission from Pasta-Devs is required to:
 
 - use a Project Mark as the name or dominant branding of a company, product,
   paid service, domain, application, package, or social account;

--- a/TRADEMARKS.md
+++ b/TRADEMARKS.md
@@ -1,0 +1,128 @@
+# Marinara Engine Trademark and Branding Policy
+
+Effective: July 30, 2026
+
+## Purpose
+
+Marinara Engine's source code is available under the
+[GNU Affero General Public License version 3](LICENSE). That license governs
+copyright permissions to use, study, modify, and distribute the software. It
+does not grant permission to use project names, logos, branding, domains, or
+other source identifiers in a way that suggests endorsement, affiliation, or
+official status.
+
+This policy explains how third parties may refer to Marinara Engine and
+Pasta-Devs without creating that confusion. It does not limit nominative fair
+use or any other use allowed by applicable law.
+
+## Project Marks
+
+For this policy, the **Project Marks** are:
+
+- the names **Marinara Engine** and **Pasta-Devs**;
+- Marinara Engine and Pasta-Devs logos, icons, and distinctive project
+  artwork;
+- official Pasta-Devs domains, repository identities, social accounts, and
+  other source identifiers; and
+- confusingly similar names, logos, or presentation.
+
+The Project Marks are separate from the AGPL-licensed software. Copyright and
+license notices included with the software must remain intact even when a
+third party uses different branding.
+
+## Uses That Do Not Require Written Permission
+
+You may make truthful, descriptive references such as:
+
+- "This service runs Marinara Engine."
+- "Compatible with Marinara Engine."
+- "Based on Marinara Engine version 2.3.5."
+- "Deploys an unmodified copy of the Marinara Engine 2.3.5 release."
+
+You may also link to the official repository, identify the upstream project in
+license notices, and show accurate, unaltered screenshots for documentation or
+commentary.
+
+These uses must:
+
+- be accurate and not misleading;
+- use the Project Marks only as needed to identify the project;
+- make the third-party operator's own name and branding more prominent;
+- avoid suggesting that Pasta-Devs reviewed or guarantees the offering; and
+- comply with the independent-service disclosure below when the reference is
+  used to market or operate a hosted service.
+
+## Independent Third-Party Services
+
+A third-party hosted or managed service that uses the Project Marks in its
+name, marketing, signup flow, or service interface must clearly identify its
+operator and prominently display a disclosure substantially similar to:
+
+> **[Service name] is independently operated by [operator] and is not
+> affiliated with, endorsed by, or supported by Pasta-Devs.**
+
+The disclosure must be visible wherever customers choose, purchase, or first
+access the service. It must not be hidden only in general terms, a privacy
+policy, or another page that customers would not ordinarily see.
+
+Third-party operators are solely responsible for:
+
+- customer support and service availability;
+- security updates, incident response, and deployment configuration;
+- privacy, data handling, retention, and regulatory compliance;
+- AI inference, model-provider terms, and usage charges; and
+- every modification, integration, image, package, and dependency they deploy.
+
+Pasta-Devs does not provide warranties, operational support, certification, or
+security assurances for third-party services. Service-specific incidents and
+support requests must be handled by the third-party operator rather than
+directed to Pasta-Devs maintainers.
+
+## Official Builds and Services
+
+Only artifacts distributed directly through a channel controlled by
+Pasta-Devs may be described as an **official Marinara Engine build**.
+
+A mirror, repackaged image, preconfigured image, deployment template, hosted
+instance, or service deployment is not an official build, even when its
+application files are unchanged. A third party may truthfully state that it
+deploys an unmodified copy of a specific official release, provided that it
+identifies the release, links to the Pasta-Devs source, and includes the
+independent-service disclosure.
+
+Only a service operated by Pasta-Devs, or a service with prior written
+authorization from Pasta-Devs, may be presented as an official Marinara Engine
+or Pasta-Devs service.
+
+## Uses That Require Written Permission
+
+Prior written permission from Pasta-Devs is required to:
+
+- use a Project Mark as the name or dominant branding of a company, product,
+  paid service, domain, application, package, or social account;
+- use a Marinara Engine or Pasta-Devs logo as a service logo, application icon,
+  favicon, or other source identifier;
+- describe an offering as "official," "approved," "authorized," "certified,"
+  "partnered," or otherwise endorsed by Pasta-Devs;
+- create branding that is likely to be confused with Pasta-Devs branding or
+  official project channels; or
+- use the Project Marks on merchandise or in sponsorship and promotional
+  campaigns.
+
+Permission to use the Project Marks does not change the AGPL license or grant
+rights to any third-party content, contributor identity, model, provider,
+character, or other separately licensed material.
+
+## Requesting Permission and Reporting Misuse
+
+Contact the project owner through the official
+[Pasta-Devs GitHub organization](https://github.com/Pasta-Devs) before using
+the Project Marks in a way that requires permission. Requests should identify
+the operator, the proposed name and presentation, where the marks will appear,
+and how users will be told that the service is independently operated.
+
+Suspected misleading use of the Project Marks may be reported through the
+[Marinara Engine issue tracker](https://github.com/Pasta-Devs/Marinara-Engine/issues).
+
+Nothing in this policy is legal advice, a warranty, or a waiver of rights held
+by Pasta-Devs or Marinara Engine contributors.


### PR DESCRIPTION
## Why

The AGPLv3 governs rights in Marinara Engine code, but it does not grant third-party operators permission to imply that their products, hosting, or builds are official Pasta-Devs offerings. A separate branding policy makes that distinction explicit while preserving truthful nominative references.

Closes #4296.

## Changes

- add a root `TRADEMARKS.md` defining the Marinara Engine and Pasta-Devs project marks
- permit truthful compatibility, version, and upstream-source references
- require independently operated hosting services to identify their operator and disclaim affiliation, endorsement, and support
- reserve official-build, official-service, partnership, certification, logo, domain, and confusing branding claims
- clarify that third-party operators own support, security, privacy, inference, and regulatory responsibilities
- link the policy beside the AGPL notice in the README

## Impact

The Engine remains AGPLv3. This policy governs branding and source-identification rights separately; it does not add a restriction to the software license or limit nominative fair use.

## Automated validation

- `pnpm check`
- `pnpm exec prettier --check TRADEMARKS.md`
- `git diff --check origin/staging...HEAD`

## Maintainer review

- [ ] Review the policy language for the intended branding boundary
- [ ] Confirm the README link renders correctly
- [ ] Obtain legal review before relying on the policy for enforcement

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the README license text to explicitly state GNU AGPLv3 for Marinara Engine source code.
  * Added a new “Trademark & Branding” Table of Contents entry.
  * Introduced a dedicated Trademark & Branding Policy outlining permitted branding/trademark references, rules for third-party hosted services (including required non-affiliation disclosures), guidance on “official” labeling, and how to request permission or report misuse.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->