### PR TITLE
fix: cascade Noodle cleanup on character delete (#4295)

### DIFF
--- a/packages/server/src/routes/characters.routes.ts
+++ b/packages/server/src/routes/characters.routes.ts
@@ -21,6 +21,7 @@ import { createChatsStorage } from "../services/storage/chats.storage.js";
 import { createGameSceneVideosStorage } from "../services/storage/game-scene-videos.storage.js";
 import { createConnectionsStorage } from "../services/storage/connections.storage.js";
 import { createLorebooksStorage } from "../services/storage/lorebooks.storage.js";
+import { createNoodleStorage } from "../services/storage/noodle.storage.js";
 import { generateImage } from "../services/image/image-generation.js";
 import { resolveConnectionImageDefaults } from "../services/image/image-generation-defaults.js";
 import { loadImageGenerationUserSettings } from "../services/image/image-generation-settings.js";
@@ -901,6 +902,13 @@ export async function charactersRoutes(app: FastifyInstance) {
     }
     const galleryImages = await characterGallery.listByCharacterId(req.params.id);
     await storage.remove(req.params.id);
+    // Cascade the character's Noodle presence, otherwise its account and posts stay
+    // in the timeline forever as a ghost (issue #4295).
+    try {
+      await createNoodleStorage(app.db).deleteAccountByEntity("character", req.params.id);
+    } catch (err) {
+      logger.error(err, "Failed to clean up Noodle account for deleted character %s", req.params.id);
+    }
     for (const image of galleryImages) {
       await unlinkGalleryFileIfUnreferenced({ db: app.db, filePath: image.filePath });
     }

--- a/packages/server/src/services/storage/noodle.storage.ts
+++ b/packages/server/src/services/storage/noodle.storage.ts
@@ -975,6 +975,38 @@ export function createNoodleStorage(db: DB) {
       return rows[0] ? mapAccount(rows[0]) : null;
     },
 
+    /**
+     * Delete the noodle account for a deleted entity (e.g. a character) along with its
+     * posts/interactions/subscriptions. Dependent rows go via the file-store cascade;
+     * activity digests have no cascade, so they are cleared explicitly.
+     */
+    async deleteAccountByEntity(kind: NoodleAccountKind, entityId: string): Promise<NoodleAccount | null> {
+      const existing = await this.getAccountByEntity(kind, entityId);
+      if (!existing) return null;
+      const postIds = (await db.select().from(noodlePosts).where(eq(noodlePosts.authorAccountId, existing.id))).map(
+        (post) => post.id,
+      );
+      const interactionIds =
+        postIds.length > 0
+          ? (await db.select().from(noodleInteractions).where(inArray(noodleInteractions.postId, postIds))).map(
+              (interaction) => interaction.id,
+            )
+          : [];
+      await db.transaction(async (tx) => {
+        if (postIds.length > 0) {
+          await tx.delete(noodleActivityDigests).where(inArray(noodleActivityDigests.sourcePostId, postIds));
+        }
+        if (interactionIds.length > 0) {
+          await tx
+            .delete(noodleActivityDigests)
+            .where(inArray(noodleActivityDigests.sourceInteractionId, interactionIds));
+        }
+        await tx.delete(noodleAccounts).where(eq(noodleAccounts.id, existing.id));
+        await tx._fileStore.flush();
+      });
+      return existing;
+    },
+
     async getAccountByEntity(kind: NoodleAccountKind, entityId: string): Promise<NoodleAccount | null> {
       const rows = await db
         .select()

--- a/packages/server/src/services/storage/noodle.storage.ts
+++ b/packages/server/src/services/storage/noodle.storage.ts
@@ -986,12 +986,18 @@ export function createNoodleStorage(db: DB) {
       const postIds = (await db.select().from(noodlePosts).where(eq(noodlePosts.authorAccountId, existing.id))).map(
         (post) => post.id,
       );
-      const interactionIds =
+      // Interactions on the account's own posts die with the posts via cascade, but the
+      // account's interactions on *other* posts have no cascade — delete those explicitly.
+      const ownInteractionIds =
         postIds.length > 0
           ? (await db.select().from(noodleInteractions).where(inArray(noodleInteractions.postId, postIds))).map(
               (interaction) => interaction.id,
             )
           : [];
+      const authoredInteractionIds = (
+        await db.select().from(noodleInteractions).where(eq(noodleInteractions.actorAccountId, existing.id))
+      ).map((interaction) => interaction.id);
+      const interactionIds = Array.from(new Set([...ownInteractionIds, ...authoredInteractionIds]));
       await db.transaction(async (tx) => {
         if (postIds.length > 0) {
           await tx.delete(noodleActivityDigests).where(inArray(noodleActivityDigests.sourcePostId, postIds));
@@ -1000,6 +1006,9 @@ export function createNoodleStorage(db: DB) {
           await tx
             .delete(noodleActivityDigests)
             .where(inArray(noodleActivityDigests.sourceInteractionId, interactionIds));
+        }
+        if (authoredInteractionIds.length > 0) {
+          await tx.delete(noodleInteractions).where(inArray(noodleInteractions.id, authoredInteractionIds));
         }
         await tx.delete(noodleAccounts).where(eq(noodleAccounts.id, existing.id));
         await tx._fileStore.flush();

--- a/packages/server/src/services/storage/noodle.storage.ts
+++ b/packages/server/src/services/storage/noodle.storage.ts
@@ -994,9 +994,28 @@ export function createNoodleStorage(db: DB) {
               (interaction) => interaction.id,
             )
           : [];
-      const authoredInteractionIds = (
-        await db.select().from(noodleInteractions).where(eq(noodleInteractions.actorAccountId, existing.id))
-      ).map((interaction) => interaction.id);
+      const authoredRows = await db
+        .select()
+        .from(noodleInteractions)
+        .where(eq(noodleInteractions.actorAccountId, existing.id));
+      // Replies to an authored interaction would keep a dangling parentInteractionId, so
+      // take the whole descendant subtree (same closure as deleteInteractionById).
+      const authoredPostIds = Array.from(new Set(authoredRows.map((row) => row.postId)));
+      const siblingRows =
+        authoredPostIds.length > 0
+          ? await db.select().from(noodleInteractions).where(inArray(noodleInteractions.postId, authoredPostIds))
+          : [];
+      const doomed = new Set(authoredRows.map((row) => row.id));
+      let changed = true;
+      while (changed) {
+        changed = false;
+        for (const row of siblingRows) {
+          if (doomed.has(row.id) || !row.parentInteractionId || !doomed.has(row.parentInteractionId)) continue;
+          doomed.add(row.id);
+          changed = true;
+        }
+      }
+      const authoredInteractionIds = [...doomed];
       const interactionIds = Array.from(new Set([...ownInteractionIds, ...authoredInteractionIds]));
       await db.transaction(async (tx) => {
         if (postIds.length > 0) {


### PR DESCRIPTION
Closes #4295

## Why
Deleting a character removed its row from `characters.json` but left its `noodle_accounts` row (and posts/interactions/subscriptions) behind, so deleted characters kept posting as ghosts in the Noodle timeline. Cleanup previously required a blunt full Noodle reset.

## What
- `noodle.storage.ts`: new `deleteAccountByEntity(kind, entityId)` — deletes the account row (dependent posts/interactions/subscriptions/unlocks go via the existing file-store `CASCADES`) and clears activity digests, which have no cascade. Mirrors `deleteNoodlerAccount`.
- `characters.routes.ts`: `DELETE /api/characters/:id` calls it for `("character", id)`. Failure is logged, not fatal — the character delete still succeeds.

Only cleans up new deletions; pre-existing orphans on an instance are not swept.

## Test plan
- [ ] Invite a character to Noodle, refresh the timeline so it has posts, then delete the character — its account and posts disappear from Noodle
- [ ] Manually verify deleting a character that was never on Noodle still returns 204
- [ ] Manually verify unrelated Noodle accounts/posts are untouched

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Deleting a character now also removes the associated Noodle account and its related activity records.
  * Cleanup is more resilient: if cleanup encounters an issue, the character deletion still completes and the problem is recorded.
  * Improved cascade cleanup now clears dependent digests and interactions (including descendants) to prevent leftover references.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->