### PR TITLE
fix: honor chat message ranges in Professor Mari

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 
 ### Fixed
 
+- Made Professor Mari honor requests for only the last N chat messages or messages after a displayed post number, with range-aware pagination that no longer broadens those requests into whole-chat reads (#4308).
 - Trimmed leading and trailing whitespace from Character names when cards are saved or imported (#4303).
 - Made Memory Recall discard superseded message revisions and inject only the current edited message text (#4304).
 - Made the right-side Character and Persona searches use the same creator, version, notes, profile fields, tags, and Unicode-safe matching as their full libraries, so author searches no longer discard valid results (#4299).

--- a/packages/server/src/services/mari-db/mari-db.service.ts
+++ b/packages/server/src/services/mari-db/mari-db.service.ts
@@ -560,6 +560,15 @@ function normalizeOffset(value: unknown) {
   return Math.floor(parsed);
 }
 
+function parseChatRangeInteger(value: string | undefined, flag: string, options: { minimum: number; maximum: number }) {
+  if (value === undefined) return null;
+  const parsed = Number(value);
+  if (!Number.isSafeInteger(parsed) || parsed < options.minimum || parsed > options.maximum) {
+    throw new Error(`--${flag} must be an integer from ${options.minimum} to ${options.maximum}`);
+  }
+  return parsed;
+}
+
 function validationFromIssues(issues: MariDbValidationIssue[]): MariDbValidationResult {
   const errors = issues.filter((issue) => issue.level === "error");
   const notices = issues.filter((issue) => issue.level === "notice");
@@ -3979,25 +3988,44 @@ export class MariDbService {
       }
       case "messages": {
         const chatId = parsed.positionals[0];
-        if (!chatId) throw new Error("Usage: mari chats messages <chat-id> [--limit <n>] [--offset <n>] [--tail]");
+        if (!chatId) {
+          throw new Error(
+            "Usage: mari chats messages <chat-id> [--last <n> | --after-post <n>] [--limit <n>] [--offset <n>] [--tail]",
+          );
+        }
         const limitFlag = flagString(flags, "limit");
         const limit = limitFlag !== undefined ? normalizeLimit(limitFlag, 20, 200) : null;
         const offset = normalizeOffset(flagString(flags, "offset"));
         const tail = hasFlag(flags, "tail");
+        const last = parseChatRangeInteger(flagString(flags, "last"), "last", { minimum: 1, maximum: 200 });
+        const afterPost = parseChatRangeInteger(flagString(flags, "after-post"), "after-post", {
+          minimum: 0,
+          maximum: Number.MAX_SAFE_INTEGER,
+        });
+        if (last !== null && afterPost !== null) throw new Error("Use either --last or --after-post, not both");
+        if (afterPost !== null && tail) throw new Error("--after-post cannot be combined with --tail");
         let messages = (await this.rawRows("messages")).filter((m) => m.chatId === chatId);
         messages.sort((a, b) => String(a.createdAt ?? "").localeCompare(String(b.createdAt ?? "")));
-        if (tail) {
-          const offsetMessages = offset > 0 ? messages.slice(0, Math.max(0, messages.length - offset)) : messages;
-          messages = limit !== null ? offsetMessages.slice(-limit) : offsetMessages;
+        const numberedMessages = messages.map((message, index) => ({ message, postNumber: index + 1 }));
+        let selectedMessages: typeof numberedMessages;
+        if (last !== null || afterPost !== null) {
+          const scopedMessages =
+            last !== null ? numberedMessages.slice(-last) : numberedMessages.slice(afterPost ?? 0);
+          selectedMessages = scopedMessages.slice(offset, limit !== null ? offset + limit : undefined);
+        } else if (tail) {
+          const offsetMessages =
+            offset > 0 ? numberedMessages.slice(0, Math.max(0, numberedMessages.length - offset)) : numberedMessages;
+          selectedMessages = limit !== null ? offsetMessages.slice(-limit) : offsetMessages;
         } else {
-          messages = messages.slice(offset, limit !== null ? offset + limit : undefined);
+          selectedMessages = numberedMessages.slice(offset, limit !== null ? offset + limit : undefined);
         }
-        const result = messages.map((row) => ({
-          id: row.id,
-          role: row.role,
-          characterId: row.characterId ?? null,
-          content: typeof row.content === "string" ? row.content : "",
-          createdAt: row.createdAt,
+        const result = selectedMessages.map(({ message, postNumber }) => ({
+          postNumber,
+          id: message.id,
+          role: message.role,
+          characterId: message.characterId ?? null,
+          content: typeof message.content === "string" ? message.content : "",
+          createdAt: message.createdAt,
         }));
         return { ok: true, mode: "read", command: context.command, output: result };
       }
@@ -5039,7 +5067,9 @@ export class MariDbService {
       "Usage: mari chats <command>",
       "Read:  list [--limit <n>] [--character <id>]",
       "Read:  get <id>",
-      "Read:  messages <chat-id> [--limit <n>] [--offset <n>] [--tail]",
+      "Read:  messages <chat-id> [--last <n> | --after-post <n>] [--limit <n>] [--offset <n>] [--tail]",
+      "       --last counts back from the newest post; --after-post uses the 1-indexed #post shown in chat.",
+      "       Add --limit and advance --offset to page within either requested range.",
       "Read:  search <query> [--limit <n>]",
       "All chat commands are read-only.",
     ].join("\n");

--- a/packages/server/src/services/professor-mari/workspace-agent.service.ts
+++ b/packages/server/src/services/professor-mari/workspace-agent.service.ts
@@ -450,6 +450,7 @@ Command families:
 - \`mari lorebooks\`: list, get, entries <lorebook-id>, search, create, update <lorebook-id>, add-entry <lorebook-id>, update-entry <entry-id>, delete-entry <entry-id>, link-character, unlink-character, delete.
 - \`mari presets\`: no dedicated shell helper — use \`app_data\` \`preset.*\` for preset reads/writes. \`preset.create\` and \`preset.update\` can include \`groups\`, \`sections\`, and \`choiceBlocks\` for preset variables. Use \`mari db\` only for advanced raw-table repairs after inspecting schemas.
 - \`mari chats\`: read-only list/get/messages/search.
+- When the user limits chat evidence, preserve that boundary in every retrieval call. For "the last N messages", use \`mari chats messages <chat-id> --last N\`. For "after post #N", use \`mari chats messages <chat-id> --after-post N\`; post numbers are 1-indexed and match the numbers shown in chat. For a large requested range, page only inside it with \`--limit <page-size> --offset <already-read>\`. Never replace a requested recent/post-number range with an unbounded chat read.
 - \`mari agents\`: no dedicated shell helper — use \`app_data\` \`agent.*\` for agent configs.
 - \`mari tools\`: customization helper; if unavailable, use \`mari db\` with the related table.
 - \`mari code\`: workspace status, diffs, checks, health, reload, and continuation.

--- a/scripts/regressions/open-issues.regression.ts
+++ b/scripts/regressions/open-issues.regression.ts
@@ -7,7 +7,7 @@ import AdmZip from "adm-zip";
 import type { Chat, Message } from "../../packages/shared/src/types/chat.js";
 import playwrightConfig from "../../playwright.config.js";
 import { resolveDevSharedBuildScript } from "../dev-shared-build.mjs";
-import { characterCardVersions, characters } from "../../packages/server/src/db/schema/index.js";
+import { characterCardVersions, characters, chats, messages } from "../../packages/server/src/db/schema/index.js";
 import { eq } from "../../packages/server/src/db/file-query.js";
 
 const REPOSITORY_ROOT = fileURLToPath(new URL("../../", import.meta.url));
@@ -731,6 +731,63 @@ try {
   );
 
   const mariDb = new MariDbService(db);
+  const rangedChatId = "professor-mari-range-regression";
+  const rangedChatTimestamp = "2026-07-30T12:00:00.000Z";
+  await db.insert(chats).values({
+    id: rangedChatId,
+    name: "Professor Mari range regression",
+    mode: "roleplay",
+    characterIds: "[]",
+    metadata: "{}",
+    sortOrder: 0,
+    createdAt: rangedChatTimestamp,
+    updatedAt: rangedChatTimestamp,
+  });
+  for (let index = 1; index <= 6; index += 1) {
+    await db.insert(messages).values({
+      id: `${rangedChatId}-${index}`,
+      chatId: rangedChatId,
+      role: index % 2 === 0 ? "assistant" : "user",
+      content: `Message ${index}`,
+      activeSwipeIndex: 0,
+      extra: "{}",
+      createdAt: `2026-07-30T12:00:0${index}.000Z`,
+    });
+  }
+  const lastMessagesResult = await mariDb.executeCli({
+    argv: ["chats", "messages", rangedChatId, "--last", "3"],
+  });
+  assert.deepEqual(
+    (lastMessagesResult.output as Array<{ postNumber: number; content: string }>).map(({ postNumber, content }) => ({
+      postNumber,
+      content,
+    })),
+    [
+      { postNumber: 4, content: "Message 4" },
+      { postNumber: 5, content: "Message 5" },
+      { postNumber: 6, content: "Message 6" },
+    ],
+    "Professor Mari must be able to retrieve exactly the last requested messages",
+  );
+  const afterPostResult = await mariDb.executeCli({
+    argv: ["chats", "messages", rangedChatId, "--after-post", "2", "--limit", "2", "--offset", "1"],
+  });
+  assert.deepEqual(
+    (afterPostResult.output as Array<{ postNumber: number; content: string }>).map(({ postNumber, content }) => ({
+      postNumber,
+      content,
+    })),
+    [
+      { postNumber: 4, content: "Message 4" },
+      { postNumber: 5, content: "Message 5" },
+    ],
+    "Professor Mari must page inside the requested post-number range",
+  );
+  const invalidRangeResult = await mariDb.executeCli({
+    argv: ["chats", "messages", rangedChatId, "--last", "201"],
+  });
+  assert.equal(invalidRangeResult.ok, false);
+  assert.match(String(invalidRangeResult.error), /--last must be an integer from 1 to 200/u);
   const customToolsStore = createCustomToolsStorage(db);
   const agentsStore = createAgentsStorage(db);
   const customTool = await customToolsStore.create({


### PR DESCRIPTION
## Linked issue

Closes #4308

## Why this change

Professor Mari could retrieve an entire long chat even when the user asked for only the latest messages or messages after a displayed post number. The oversized result was repeatedly truncated and could exhaust the workspace command loop before the requested edit completed.

## Root cause

The chat command exposed only generic `--tail` and `--offset` pagination, without direct post-number semantics or prompt guidance mapping natural-language ranges onto those flags. Returned messages also omitted their displayed post numbers, making bounded pagination harder to continue reliably.

## What changed

- Added `--last <n>` and `--after-post <n>` to `mari chats messages`
- Preserved the requested range while paging with `--limit` and `--offset`
- Included each messages 1-indexed displayed `postNumber` in command output
- Taught Professor Mari to keep every retrieval inside the user-requested range
- Added real file-backed storage regression coverage for recent ranges, post-number ranges, pagination, and invalid oversized input
- Added the fix to the Unreleased changelog

## Validation

- [ ] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed `CONTRIBUTING.md`

### Automated verification notes

- `pnpm check` — passed (localization, TypeScript/lint, production server/client builds)
- Isolated file-backed database proof — passed for `--last 3`, `--after-post 2 --limit 2 --offset 1`, and rejection of `--last 201`
- The same assertions ran successfully inside `open-issues.regression.ts`; that wider legacy suite later stops on pre-existing stale assertions in unrelated background-folder and Game dynamic-prompt coverage

### Manual verification notes

- Manually verify a Home Professor Mari request using only the last 200 messages from a long chat.
- Manually verify a request using only messages after a visible `#post` number.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Translated docs on the `docs-i18n` branch updated to match, or a `[docs-i18n] <paths>` follow-up issue opened
- [ ] Version/release files updated

No user guide changes are needed; the internal command help and Unreleased changelog are updated.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for retrieving only the last *N* chat messages or messages after a specified post number.
  - Added range-aware pagination with `--limit` and `--offset` within the selected message range.
  - Expanded command help to document the new options and usage restrictions.

- **Bug Fixes**
  - Prevented limited chat evidence requests from expanding into full-chat reads.
  - Added validation for invalid or conflicting range options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->