### PR TITLE
test: isolate Playwright mutable fixtures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 
 ### Fixed
 
+- Isolated desktop and mobile Playwright servers and fixture data, made help tooltips non-blocking, kept focused mobile composers open during history scrolling, and aligned appearance and Tracker smoke checks with live application state so the complete browser sweep no longer fails from cross-project mutations or stale assertions (#4343).
 - Built the shared workspace before `pnpm dev:server` and documented the rebuild-and-restart boundary for shared source changes (#4327).
 - Removed Windows child-process calls that combined argument arrays with `shell: true`, eliminating Node.js DEP0190 warnings from startup, updates, native dependency repair, and client builds (#4332).
 - Stopped generic OpenAI-compatible connections from inheriting `reasoning_effort` for unknown models, added an explicit **Off** option that sends `none`, and made the Advanced Parameters toggle omit reasoning fields entirely (#4335).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -111,7 +111,7 @@ Regression guards:
 
 - `pnpm regression:prompt` runs fast deterministic checks for prompt assembly, lorebook keyword matching, macros, summaries, and mode-specific generation gates.
 - `pnpm smoke:ui` runs the Playwright browser smoke suite against isolated temporary app data.
-  Each run clears `.tmp/playwright-data` before starting a fresh test server. Stop any process already using the configured Playwright ports before running it; existing fixture state is disposable and the smoke suite does not reuse a running development server.
+  Each run clears `.tmp/playwright-data` and starts separate desktop and mobile app servers so their mutable fixtures cannot overlap. Stop any process already using the configured Playwright ports before running it; existing fixture state is disposable and the smoke suite does not reuse a running development server.
 - `pnpm regression` runs both lanes.
 
 These checks are intentionally small and do not replace manual verification. When you change behavior, include the manual verification you performed and add or update a regression guard for the bug class when practical.

--- a/e2e/core-flows.e2e.ts
+++ b/e2e/core-flows.e2e.ts
@@ -1,4 +1,4 @@
-import { expect, test, type Locator, type Page } from "@playwright/test";
+import { expect, test, type APIRequestContext, type Locator, type Page } from "@playwright/test";
 import { readFileSync } from "node:fs";
 import { createServer } from "node:http";
 
@@ -47,6 +47,41 @@ async function prepareFreshClient(page: Page) {
       }),
     );
   }, APP_VERSION);
+}
+
+async function setAppAccentColor(page: Page, color: string) {
+  await page.evaluate(async (nextColor) => {
+    const { useUIStore } = (await import("/src/stores/ui.store.ts")) as {
+      useUIStore: {
+        getState: () => {
+          setAppAccentColor: (value: string) => void;
+        };
+      };
+    };
+    useUIStore.getState().setAppAccentColor(nextColor);
+  }, color);
+  await expect
+    .poll(() =>
+      page.evaluate(() =>
+        getComputedStyle(document.documentElement).getPropertyValue("--marinara-app-accent-static").trim(),
+      ),
+    )
+    .toBe(color);
+}
+
+async function readCssVariableColor(page: Page, variableName: string) {
+  return page.evaluate((name) => {
+    const probe = document.createElement("span");
+    probe.style.color = `var(${name})`;
+    document.body.append(probe);
+    const color = getComputedStyle(probe).color;
+    probe.remove();
+    return color;
+  }, variableName);
+}
+
+async function bestEffortDelete(request: APIRequestContext, url: string) {
+  await request.delete(url, { timeout: 5_000 }).catch(() => undefined);
 }
 
 async function expectHomeContentFits(page: Page) {
@@ -104,6 +139,8 @@ async function updateLiveReasoningState(
 }
 
 test.beforeEach(async ({ page }) => {
+  const resetUiSettings = await page.request.put("/api/app-settings/ui", { data: { value: "" } });
+  expect(resetUiSettings.ok()).toBeTruthy();
   await prepareFreshClient(page);
 });
 
@@ -960,9 +997,7 @@ test("message deletion uses unified chroma controls and selection states", async
 
     await page.addInitScript((chatId) => localStorage.setItem("marinara-active-chat-id", chatId), chat.id);
     await page.goto("/");
-    await page.evaluate(() => {
-      document.documentElement.style.setProperty("--marinara-app-accent-solid", "rgb(20, 184, 166)");
-    });
+    await setAppAccentColor(page, "#14b8a6");
 
     const messageRow = page.locator(`[data-message-id="${targetMessage.id}"]`);
     await expect(messageRow).toBeVisible();
@@ -1006,9 +1041,7 @@ test("message deletion uses unified chroma controls and selection states", async
       expect(className).not.toMatch(/destructive|pink|red|rose/iu);
     }
 
-    await page.evaluate(() => {
-      document.documentElement.style.setProperty("--marinara-app-accent-solid", "rgb(59, 130, 246)");
-    });
+    await setAppAccentColor(page, "#3b82f6");
     await expect.poll(async () => (await readChromeStyles(dialogActions))[0]?.color).not.toBe(tealStyles[0]?.color);
     const blueStyles = await readChromeStyles(dialogActions);
     expect(new Set(blueStyles.map(({ backgroundColor }) => backgroundColor)).size).toBe(1);
@@ -1091,7 +1124,6 @@ test("message deletion uses unified chroma controls and selection states", async
 test("bulk chat deletion uses the shared primary accent control", async ({ page }, testInfo) => {
   test.skip(testInfo.project.name.includes("mobile"), "Desktop chat-sidebar selection chrome is covered here.");
 
-  const accentColor = "rgb(20, 184, 166)";
   const chatNames = ["Bulk Delete Chroma One", "Bulk Delete Chroma Two"];
   const chatResponses = await Promise.all(
     chatNames.map((name) =>
@@ -1118,10 +1150,8 @@ test("bulk chat deletion uses the shared primary accent control", async ({ page 
       );
     }, chats[0]!.id);
     await page.goto("/");
-    await page.evaluate((accent) => {
-      document.documentElement.style.setProperty("--marinara-app-accent-solid", accent);
-      document.documentElement.style.setProperty("--marinara-chat-chrome-button-text-active", accent);
-    }, accentColor);
+    await setAppAccentColor(page, "#14b8a6");
+    const activeAccentColor = await readCssVariableColor(page, "--marinara-chat-chrome-button-text-active");
 
     const sidebar = page.locator('[data-component="ChatSidebar"]');
     await expect(sidebar).toBeVisible();
@@ -1159,7 +1189,7 @@ test("bulk chat deletion uses the shared primary accent control", async ({ page 
     );
     expect(styles).toHaveLength(2);
     await expect(deleteAction).toHaveClass(/mari-chrome-control--primary/u);
-    await expect(deleteAction).toHaveCSS("color", accentColor);
+    await expect(deleteAction).toHaveCSS("color", activeAccentColor);
     expect(styles[1]?.className).not.toMatch(/danger|destructive|pink|red|rose/iu);
 
     await deleteAction.click();
@@ -1177,12 +1207,12 @@ test("bulk chat deletion uses the shared primary accent control", async ({ page 
 test("destructive confirmation actions use the shared accent button treatment", async ({ page }, testInfo) => {
   test.skip(testInfo.project.name.includes("mobile"), "Desktop confirmation-dialog chrome is covered here.");
 
-  const accentColor = "rgb(20, 184, 166)";
   await page.goto("/");
-  await page.evaluate((accent) => {
-    document.documentElement.style.setProperty("--marinara-chat-chrome-button-text-active", accent);
+  await setAppAccentColor(page, "#14b8a6");
+  const activeAccentColor = await readCssVariableColor(page, "--marinara-chat-chrome-button-text-active");
+  await page.evaluate(() => {
     document.documentElement.style.setProperty("--destructive", "rgb(255, 0, 0)");
-  }, accentColor);
+  });
 
   await page.evaluate(async () => {
     const { showConfirmDialog } = (await import("/src/lib/app-dialogs.ts")) as {
@@ -1204,7 +1234,7 @@ test("destructive confirmation actions use the shared accent button treatment", 
   const confirmDialog = page.getByRole("dialog", { name: "Delete Resource" });
   const confirmDelete = confirmDialog.getByRole("button", { name: "Delete", exact: true });
   await expect(confirmDelete).toHaveClass(/mari-chrome-control--primary/u);
-  await expect(confirmDelete).toHaveCSS("color", accentColor);
+  await expect(confirmDelete).toHaveCSS("color", activeAccentColor);
   expect(await confirmDelete.getAttribute("class")).not.toMatch(/destructive|pink|red|rose/iu);
   await confirmDialog.getByRole("button", { name: "Cancel" }).click();
 
@@ -1226,7 +1256,7 @@ test("destructive confirmation actions use the shared accent button treatment", 
   const choiceDialog = page.getByRole("dialog", { name: "Delete Resources" });
   const deleteAll = choiceDialog.getByRole("button", { name: "Delete All", exact: true });
   await expect(deleteAll).toHaveClass(/mari-chrome-control--primary/u);
-  await expect(deleteAll).toHaveCSS("color", accentColor);
+  await expect(deleteAll).toHaveCSS("color", activeAccentColor);
   expect(await deleteAll.getAttribute("class")).not.toMatch(/destructive|pink|red|rose/iu);
   await choiceDialog.getByRole("button", { name: "Cancel" }).click();
 });
@@ -1515,10 +1545,10 @@ test("Connection Discard uses the configured editor accent", async ({ page }, te
 
   try {
     await page.goto("/");
-    await page.evaluate((accent) => {
-      document.documentElement.style.setProperty("--marinara-chat-chrome-accent", accent);
+    await setAppAccentColor(page, "#14b8a6");
+    await page.evaluate(() => {
       document.documentElement.style.setProperty("--destructive", "rgb(255, 0, 0)");
-    }, accentColor);
+    });
 
     await page.locator('[data-tour="panel-connections"]').click();
     const rightPanel = page.locator('[data-component="RightPanelDesktop"]');
@@ -1562,13 +1592,7 @@ test("Character favorite tags and stars inherit the configured accent color", as
 
   try {
     await page.goto("/");
-    await page.evaluate((accent) => {
-      document.documentElement.style.setProperty("--marinara-app-accent-solid", accent);
-      document.documentElement.style.setProperty("--marinara-app-accent-static", accent);
-      document.documentElement.style.setProperty("--marinara-chat-chrome-accent", accent);
-      document.documentElement.style.setProperty("--marinara-chat-chrome-button-text-active", accent);
-      document.documentElement.style.setProperty("--marinara-editor-accent", accent);
-    }, accentColor);
+    await setAppAccentColor(page, "#1256aa");
 
     await page.locator('[data-tour="panel-characters"]').click();
     const rightPanel = page.locator('[data-component="RightPanelDesktop"]');
@@ -1593,10 +1617,11 @@ test("Character favorite tags and stars inherit the configured accent color", as
 
     const cardFavorite = library.locator('[data-character-favorite-indicator="card"]');
     const detailFavorite = library.locator('[data-character-favorite-indicator="detail"]:visible');
+    const surfaceAccentColor = await readCssVariableColor(page, "--marinara-chat-chrome-button-text-active");
     for (const indicator of [cardFavorite, detailFavorite]) {
       await expect(indicator).toBeVisible();
       await expect(indicator).toHaveClass(/mari-chrome-accent-surface/u);
-      await expect(indicator).toHaveCSS("color", accentColor);
+      await expect(indicator).toHaveCSS("color", surfaceAccentColor);
       expect(await indicator.getAttribute("class")).not.toMatch(/amber|yellow/iu);
     }
   } finally {
@@ -3636,7 +3661,7 @@ test("desktop Tracker stays in the Roleplay gutter without shifting the chat col
     const expectedScale = Math.max(0.65, expectedWidth / 420);
     const appliedScale = Number(await trackerContent.getAttribute("data-tracker-content-scale"));
     expect(Math.abs(appliedScale - expectedScale)).toBeLessThanOrEqual(0.001);
-    const emptyTrackerText = tracker.getByText("No tracker data yet.", { exact: true });
+    const emptyTrackerText = tracker.getByText("No enabled tracker panels.", { exact: true });
     await expect(emptyTrackerText).toBeVisible();
     const [emptyTextFontSize, rootFontSize] = await emptyTrackerText.evaluate((element) => [
       parseFloat(getComputedStyle(element).fontSize),
@@ -4616,10 +4641,10 @@ test("Chat Settings edits only the selected cards and lorebook entries inline", 
     expect(detailGetPaths).not.toContain(`/api/characters/${unselectedCharacter.id}`);
     expect(detailGetPaths).not.toContain(`/api/lorebooks/${lorebook.id}/entries`);
     const accentColor = "rgb(20, 184, 166)";
-    await page.evaluate((accent) => {
-      document.documentElement.style.setProperty("--marinara-chat-chrome-accent", accent);
+    await setAppAccentColor(page, "#14b8a6");
+    await page.evaluate(() => {
       document.documentElement.style.setProperty("--destructive", "rgb(255, 0, 0)");
-    }, accentColor);
+    });
 
     await drawer.getByText("Persona", { exact: true }).first().click();
     const removePersonaButton = drawer.locator('[data-chat-settings-remove-resource="persona"]');
@@ -11767,7 +11792,14 @@ test("Roleplay displays a selected background when its file route is GET-only", 
           ),
       )
       .toBe(true);
-    await page.locator(`img[src^="${backgroundUrl}"]`).locator("..").click();
+    await page.getByRole("button", { name: "Browse library" }).click();
+    const library = page.getByRole("dialog", { name: "Background Library" });
+    await expect(library).toBeVisible();
+    await library
+      .locator('[data-background-id="user:rp-background-smoke.png"]')
+      .getByRole("button", { name: /Use .* for this chat/u })
+      .click();
+    await expect(library).toBeHidden();
 
     await expect
       .poll(async () =>
@@ -11816,7 +11848,7 @@ test("Roleplay displays a selected background when its file route is GET-only", 
     expect(requestedMethods).toContain("GET");
     expect(requestedMethods).not.toContain("HEAD");
   } finally {
-    await page.request.delete(`/api/chats/${chat.id}`);
+    await bestEffortDelete(page.request, `/api/chats/${chat.id}`);
   }
 });
 
@@ -11857,7 +11889,7 @@ test("Background library organization works with desktop drag and touch drag", a
 
     const backgroundRowBeforeRename = page.locator(`[data-background-id="${backgroundId}"]:not([aria-hidden="true"])`);
     await backgroundRowBeforeRename.getByTitle("Rename background").click();
-    const renameInput = backgroundRowBeforeRename.getByLabel(`Rename ${currentFilename}`);
+    const renameInput = backgroundRowBeforeRename.getByRole("textbox", { name: `Rename ${currentFilename}` });
     await renameInput.fill(`rainy-arcade-${suffix}`);
     const [renameResponse] = await Promise.all([
       page.waitForResponse(
@@ -11876,12 +11908,11 @@ test("Background library organization works with desktop drag and touch drag", a
       }),
     ).toBeVisible();
 
-    await page.reload();
-    await page.locator('[data-tour="panel-settings"]').click();
-    await page.getByRole("tab", { name: "Appearance" }).click();
-    await page.getByPlaceholder("Search settings").fill("Backgrounds");
-    await page.getByRole("button", { name: /Backgrounds Section/ }).click();
+    const backgroundLibrary = page.getByRole("dialog", { name: "Background Library" });
+    await backgroundLibrary.getByRole("button", { name: "Close Background Library" }).click();
+    await expect(backgroundLibrary).toBeHidden();
     await page.getByRole("button", { name: "Browse library" }).click();
+    await expect(backgroundLibrary).toBeVisible();
     await page.getByPlaceholder("Search backgrounds").fill(`rainy-arcade-${suffix}`);
 
     await expect(page.getByText("Drag a background onto a folder chip to file it.")).toBeVisible();
@@ -11897,11 +11928,13 @@ test("Background library organization works with desktop drag and touch drag", a
     const backgroundActions = backgroundRow.locator("[data-background-actions]");
     const defaultToggle = backgroundRow.locator("[data-background-default-toggle]");
     if (testInfo.project.name.includes("mobile")) {
-      await expect(backgroundActions).toBeVisible();
+      await expect(backgroundActions).toHaveCSS("opacity", "1");
     } else {
-      await expect(backgroundActions).toBeHidden();
+      await page.getByPlaceholder("Search backgrounds").focus();
+      await page.mouse.move(0, 0);
+      await expect(backgroundActions).toHaveCSS("opacity", "0");
       await backgroundRow.hover();
-      await expect(backgroundActions).toBeVisible();
+      await expect(backgroundActions).toHaveCSS("opacity", "1");
     }
     await defaultToggle.scrollIntoViewIfNeeded();
     const starBefore = await defaultToggle.boundingBox();
@@ -11911,16 +11944,17 @@ test("Background library organization works with desktop drag and touch drag", a
     expect(Math.abs((starAfter?.x ?? 0) - (starBefore?.x ?? 0))).toBeLessThan(1);
     expect(Math.abs((starAfter?.y ?? 0) - (starBefore?.y ?? 0))).toBeLessThan(1);
     if (!testInfo.project.name.includes("mobile")) {
+      await sortSelect.focus();
       await sortSelect.hover();
-      await expect(backgroundActions).toBeHidden();
+      await expect(backgroundActions).toHaveCSS("opacity", "0");
       await expect(backgroundRow.locator("[data-background-default-indicator]")).toBeVisible();
       await backgroundRow.hover();
-      await expect(backgroundActions).toBeVisible();
+      await expect(backgroundActions).toHaveCSS("opacity", "1");
     }
     await defaultToggle.click();
 
     await page.getByRole("button", { name: "New Folder" }).click();
-    const newFolderPrompt = page.getByRole("dialog").getByRole("textbox");
+    const newFolderPrompt = page.getByRole("dialog", { name: "New Folder" }).getByRole("textbox");
     await expect(newFolderPrompt).toBeVisible();
     const [createFolderResponse] = await Promise.all([
       page.waitForResponse(
@@ -12043,7 +12077,7 @@ test("Background library organization works with desktop drag and touch drag", a
     // Rename and delete the active folder from the folder chips; its background falls back to unfiled.
     await page.locator(`[data-background-folder-filter-id="${folderId}"]`).click();
     await page.getByRole("button", { name: /^Rename folder / }).click();
-    const folderNamePrompt = page.getByRole("dialog").getByRole("textbox");
+    const folderNamePrompt = page.getByRole("dialog", { name: "Rename Folder" }).getByRole("textbox");
     await folderNamePrompt.fill(`Alleys ${suffix}`);
     await folderNamePrompt.press("Enter");
     await expect(page.locator(`[data-background-folder-filter-id="${folderId}"]`)).toContainText(`Alleys ${suffix}`);
@@ -12060,8 +12094,10 @@ test("Background library organization works with desktop drag and touch drag", a
       .toBeNull();
     folderId = null;
   } finally {
-    if (folderId) await page.request.delete(`/api/backgrounds/folders/${encodeURIComponent(folderId)}`);
-    await page.request.delete(`/api/backgrounds/${encodeURIComponent(currentFilename)}`);
+    if (folderId) {
+      await bestEffortDelete(page.request, `/api/backgrounds/folders/${encodeURIComponent(folderId)}`);
+    }
+    await bestEffortDelete(page.request, `/api/backgrounds/${encodeURIComponent(currentFilename)}`);
   }
 });
 

--- a/e2e/global-setup.mjs
+++ b/e2e/global-setup.mjs
@@ -5,7 +5,7 @@ import { fileURLToPath } from "node:url";
 const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 const dataDir = resolve(repoRoot, ".tmp/playwright-data");
 
-function resetPlaywrightData() {
+export function resetPlaywrightData() {
   rmSync(dataDir, { recursive: true, force: true });
   mkdirSync(dataDir, { recursive: true });
 }

--- a/e2e/start-servers.mjs
+++ b/e2e/start-servers.mjs
@@ -1,0 +1,119 @@
+import { spawn, spawnSync } from "node:child_process";
+import { mkdirSync } from "node:fs";
+import { basename, dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { resetPlaywrightData } from "./global-setup.mjs";
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const dataRoot = resolve(repoRoot, ".tmp/playwright-data");
+const children = new Set();
+let shuttingDown = false;
+
+function parsePort(name, fallback) {
+  const raw = process.env[name]?.trim();
+  if (!raw || !/^\d+$/.test(raw)) return fallback;
+  const parsed = Number(raw);
+  return Number.isInteger(parsed) && parsed >= 1 && parsed <= 65535 ? parsed : fallback;
+}
+
+const desktopClientPort = parsePort("PLAYWRIGHT_CLIENT_PORT", 5178);
+const desktopServerPort = parsePort("PLAYWRIGHT_SERVER_PORT", 7971);
+const mobileClientPort = parsePort("PLAYWRIGHT_MOBILE_CLIENT_PORT", 5179);
+const mobileServerPort = parsePort("PLAYWRIGHT_MOBILE_SERVER_PORT", 7972);
+
+const pnpmCliPath = process.env.npm_execpath;
+const npmUserAgent = process.env.npm_config_user_agent ?? "";
+const useCurrentPnpm =
+  Boolean(pnpmCliPath) && (npmUserAgent.startsWith("pnpm/") || basename(pnpmCliPath ?? "").startsWith("pnpm"));
+const pnpmCommand = useCurrentPnpm ? process.execPath : "pnpm";
+const pnpmBaseArgs = useCurrentPnpm && pnpmCliPath ? [pnpmCliPath] : [];
+
+function spawnChild(command, args, env = process.env) {
+  const child = spawn(command, args, {
+    cwd: repoRoot,
+    env,
+    stdio: "inherit",
+    windowsHide: true,
+  });
+  children.add(child);
+  child.once("exit", () => children.delete(child));
+  return child;
+}
+
+function runPnpm(args) {
+  return new Promise((resolvePromise, reject) => {
+    const child = spawnChild(pnpmCommand, [...pnpmBaseArgs, ...args]);
+    child.once("exit", (code, signal) => {
+      if (code === 0) {
+        resolvePromise();
+        return;
+      }
+      reject(new Error(`pnpm ${args.join(" ")} exited with ${signal ?? code}`));
+    });
+  });
+}
+
+function stopChildren(signal = "SIGTERM") {
+  if (shuttingDown) return;
+  shuttingDown = true;
+  for (const child of children) {
+    if (child.killed || child.exitCode !== null) continue;
+    if (process.platform === "win32") {
+      spawnSync("taskkill.exe", ["/pid", String(child.pid), "/T", "/F"], { stdio: "ignore" });
+    } else {
+      child.kill(signal);
+    }
+  }
+}
+
+function startProject(name, clientPort, serverPort) {
+  const dataDir = resolve(dataRoot, name);
+  mkdirSync(dataDir, { recursive: true });
+  const child = spawnChild(process.execPath, [resolve(repoRoot, "scripts/dev.mjs")], {
+    ...process.env,
+    DATA_DIR: dataDir,
+    DEV_SKIP_SHARED_BUILD: "true",
+    MARINARA_ENV_FILE: resolve(dataDir, ".env"),
+    PORT: String(serverPort),
+    VITE_PORT: String(clientPort),
+  });
+  child.once("exit", (code, signal) => {
+    if (shuttingDown) return;
+    stopChildren();
+    process.exitCode = code ?? (signal ? 1 : 0);
+  });
+  return child;
+}
+
+async function waitForUrl(url) {
+  const timeoutMs = Number.parseInt(process.env.DEV_SERVER_READY_TIMEOUT_MS ?? "180000", 10);
+  const startedAt = Date.now();
+  let lastError = null;
+  while (!shuttingDown && Date.now() - startedAt < timeoutMs) {
+    try {
+      const response = await fetch(url, { signal: AbortSignal.timeout(1_500) });
+      if (response.ok) return;
+      lastError = new Error(`HTTP ${response.status}`);
+    } catch (error) {
+      lastError = error;
+    }
+    await new Promise((resolvePromise) => setTimeout(resolvePromise, 500));
+  }
+  const detail = lastError instanceof Error ? lastError.message : String(lastError ?? "unknown error");
+  throw new Error(`Playwright server did not become ready at ${url} (${detail})`);
+}
+
+process.on("SIGINT", () => stopChildren("SIGINT"));
+process.on("SIGTERM", () => stopChildren("SIGTERM"));
+
+try {
+  resetPlaywrightData();
+  await runPnpm(["--filter", "@marinara-engine/shared", "build:preserve"]);
+  startProject("mobile", mobileClientPort, mobileServerPort);
+  await waitForUrl(`http://127.0.0.1:${mobileClientPort}`);
+  startProject("desktop", desktopClientPort, desktopServerPort);
+} catch (error) {
+  stopChildren();
+  console.error(error instanceof Error ? error.message : error);
+  process.exitCode = 1;
+}

--- a/packages/client/src/components/chat/ChatRoleplaySurface.tsx
+++ b/packages/client/src/components/chat/ChatRoleplaySurface.tsx
@@ -1314,7 +1314,8 @@ export function ChatRoleplaySurface({
       const currentTop = el.scrollTop;
       const previousTop = composerScrollTopRef.current;
       const isMobile = typeof window !== "undefined" && window.matchMedia("(max-width: 767px)").matches;
-      if (!isMobile || shouldKeepMobileComposerOpen || nearBottom) {
+      const composerHasFocus = document.activeElement?.matches("[data-chat-composer]") === true;
+      if (!isMobile || shouldKeepMobileComposerOpen || composerHasFocus || nearBottom) {
         setMobileHistoryComposerCollapsed(false);
       } else if (currentTop > previousTop + 18) {
         setMobileHistoryComposerCollapsed(false);

--- a/packages/client/src/components/chat/ConversationView.tsx
+++ b/packages/client/src/components/chat/ConversationView.tsx
@@ -567,7 +567,8 @@ export function ConversationView({
       const currentTop = el.scrollTop;
       const previousComposerTop = composerScrollTopRef.current;
       const isMobile = typeof window !== "undefined" && window.matchMedia("(max-width: 767px)").matches;
-      if (!isMobile || shouldKeepMobileComposerOpen || nearBottom) {
+      const composerHasFocus = document.activeElement?.matches("[data-chat-composer]") === true;
+      if (!isMobile || shouldKeepMobileComposerOpen || composerHasFocus || nearBottom) {
         setMobileHistoryComposerCollapsed(false);
       } else if (currentTop > previousComposerTop + 18) {
         setMobileHistoryComposerCollapsed(false);

--- a/packages/client/src/components/ui/HelpTooltip.tsx
+++ b/packages/client/src/components/ui/HelpTooltip.tsx
@@ -192,7 +192,7 @@ export function HelpTooltip({
           <div
             ref={tipRef}
             className={cn(
-              "fixed z-[9999] rounded-lg bg-[var(--popover)] px-3 py-2 text-left text-[0.6875rem] leading-relaxed text-[var(--popover-foreground)] shadow-xl ring-1 ring-[var(--border)]",
+              "pointer-events-none fixed z-[9999] rounded-lg bg-[var(--popover)] px-3 py-2 text-left text-[0.6875rem] leading-relaxed text-[var(--popover-foreground)] shadow-xl ring-1 ring-[var(--border)]",
               wide ? "w-[min(22rem,calc(100vw-1.5rem))] max-w-[22rem]" : "w-56",
             )}
             style={{ top: pos.top, left: pos.left, visibility: pos.ready ? "visible" : "hidden" }}

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -9,7 +9,10 @@ function parsePort(name: string, fallback: number) {
 
 const clientPort = parsePort("PLAYWRIGHT_CLIENT_PORT", 5178);
 const serverPort = parsePort("PLAYWRIGHT_SERVER_PORT", 7971);
+const mobileClientPort = parsePort("PLAYWRIGHT_MOBILE_CLIENT_PORT", 5179);
+const mobileServerPort = parsePort("PLAYWRIGHT_MOBILE_SERVER_PORT", 7972);
 const baseURL = process.env.PLAYWRIGHT_BASE_URL ?? `http://127.0.0.1:${clientPort}`;
+const mobileBaseURL = process.env.PLAYWRIGHT_MOBILE_BASE_URL ?? `http://127.0.0.1:${mobileClientPort}`;
 
 export default defineConfig({
   testDir: "./e2e",
@@ -31,35 +34,35 @@ export default defineConfig({
     process.env.PLAYWRIGHT_SKIP_WEBSERVER === "true"
       ? undefined
       : {
-          command: "node ./e2e/global-setup.mjs && pnpm dev",
+          command: "node ./e2e/start-servers.mjs",
           url: baseURL,
           reuseExistingServer: false,
           timeout: 180_000,
           env: {
             AUTO_CREATE_DEFAULT_CONNECTION: "false",
             AUTO_OPEN_BROWSER: "false",
-            DATA_DIR: "../../.tmp/playwright-data",
             DEV_PRESERVE_SHARED_DIST: "true",
             DEV_SERVER_READY_TIMEOUT_MS: "180000",
             LOG_DISABLE_REQUEST_LOGGING: "true",
             LOG_LEVEL: "silent",
             MARINARA_E2E_DISABLE_RATE_LIMIT: "true",
-            MARINARA_ENV_FILE: "../../.tmp/playwright-data/.env",
-            PORT: String(serverPort),
+            PLAYWRIGHT_CLIENT_PORT: String(clientPort),
+            PLAYWRIGHT_MOBILE_CLIENT_PORT: String(mobileClientPort),
+            PLAYWRIGHT_MOBILE_SERVER_PORT: String(mobileServerPort),
+            PLAYWRIGHT_SERVER_PORT: String(serverPort),
             SKIP_PWA: "true",
             VITE_HOST: "127.0.0.1",
             VITE_OPEN_BROWSER: "false",
-            VITE_PORT: String(clientPort),
           },
         },
   projects: [
     {
       name: "desktop-chromium",
-      use: { ...devices["Desktop Chrome"], viewport: { width: 1440, height: 900 } },
+      use: { ...devices["Desktop Chrome"], baseURL, viewport: { width: 1440, height: 900 } },
     },
     {
       name: "mobile-chromium",
-      use: { ...devices["Pixel 7"], viewport: { width: 390, height: 844 } },
+      use: { ...devices["Pixel 7"], baseURL: mobileBaseURL, viewport: { width: 390, height: 844 } },
     },
   ],
 });

--- a/scripts/dev.mjs
+++ b/scripts/dev.mjs
@@ -88,7 +88,9 @@ process.on("SIGINT", () => stopChildren("SIGINT"));
 process.on("SIGTERM", () => stopChildren("SIGTERM"));
 
 try {
-  await runPnpm(["--filter", "@marinara-engine/shared", SHARED_BUILD_SCRIPT]);
+  if (process.env.DEV_SKIP_SHARED_BUILD !== "true") {
+    await runPnpm(["--filter", "@marinara-engine/shared", SHARED_BUILD_SCRIPT]);
+  }
 
   const server = spawnPnpm(["--filter", "@marinara-engine/server", "dev"]);
   server.once("exit", (code, signal) => {

--- a/scripts/regressions/open-issues.regression.ts
+++ b/scripts/regressions/open-issues.regression.ts
@@ -1888,6 +1888,7 @@ const playwrightServerSource = readFileSync(join(REPOSITORY_ROOT, "e2e/start-ser
 assert.match(playwrightServerSource, /startProject\("mobile", mobileClientPort, mobileServerPort\)/u);
 assert.match(playwrightServerSource, /startProject\("desktop", desktopClientPort, desktopServerPort\)/u);
 assert.match(playwrightServerSource, /resolve\(dataRoot, name\)/u);
+assert.match(playwrightServerSource, /DATA_DIR:\s*dataDir/u);
 
 const appSource = readFileSync(new URL("../../packages/client/src/App.tsx", import.meta.url), "utf8");
 const agentEditorSource = readFileSync(

--- a/scripts/regressions/open-issues.regression.ts
+++ b/scripts/regressions/open-issues.regression.ts
@@ -897,9 +897,8 @@ try {
   await customToolsStore.remove(customTool.id);
   const cleanedToolAgent = await agentsStore.getById(toolAgent.id);
   assert.deepEqual(JSON.parse(cleanedToolAgent?.settings ?? "{}").enabledTools, ["roll_dice"]);
-  const { resolveGenerationTools } = await import(
-    "../../packages/server/src/services/generation/tool-resolution-runtime.js"
-  );
+  const { resolveGenerationTools } =
+    await import("../../packages/server/src/services/generation/tool-resolution-runtime.js");
   const diceAgent = {
     id: "dice-agent-regression",
     type: "dice-agent-regression",
@@ -1875,6 +1874,20 @@ const playwrightWebServer = Array.isArray(playwrightConfig.webServer)
   ? playwrightConfig.webServer[0]
   : playwrightConfig.webServer;
 assert.equal(playwrightWebServer?.env?.DEV_PRESERVE_SHARED_DIST, "true");
+assert.match(playwrightWebServer?.command ?? "", /e2e\/start-servers\.mjs/u);
+const desktopPlaywrightProject = playwrightConfig.projects?.find((project) => project.name === "desktop-chromium");
+const mobilePlaywrightProject = playwrightConfig.projects?.find((project) => project.name === "mobile-chromium");
+assert.ok(desktopPlaywrightProject);
+assert.ok(mobilePlaywrightProject);
+assert.notEqual(
+  desktopPlaywrightProject.use?.baseURL,
+  mobilePlaywrightProject.use?.baseURL,
+  "desktop and mobile Playwright projects must use isolated app servers",
+);
+const playwrightServerSource = readFileSync(join(REPOSITORY_ROOT, "e2e/start-servers.mjs"), "utf8");
+assert.match(playwrightServerSource, /startProject\("mobile", mobileClientPort, mobileServerPort\)/u);
+assert.match(playwrightServerSource, /startProject\("desktop", desktopClientPort, desktopServerPort\)/u);
+assert.match(playwrightServerSource, /resolve\(dataRoot, name\)/u);
 
 const appSource = readFileSync(new URL("../../packages/client/src/App.tsx", import.meta.url), "utf8");
 const agentEditorSource = readFileSync(


### PR DESCRIPTION
> [!IMPORTANT]
> Contributions target `staging`. Only `SpicyMarinara` may promote `staging` to `main`.

## Linked issue

Closes #4343

## Why this change

The desktop and mobile Playwright projects used the same file-backed Engine server. Tests that changed synced UI settings, backgrounds, chats, or other fixtures could therefore alter the other project while it was still running, making the full two-worker sweep nondeterministic and hiding genuine regressions behind contradictory expectations and cleanup timeouts.

## What changed

- Start desktop and mobile Playwright projects on separate client/server ports with separate temporary data directories.
- Build the shared workspace once before starting both project servers, avoiding concurrent mutations of `shared/dist`.
- Reset synced UI settings before each test and exercise accent colors through the live UI store and derived CSS tokens.
- Align stale Tracker and background-library smoke assertions with current application behavior.
- Make transient help tooltips pointer-transparent so they cannot intercept an intended control click.
- Keep focused mobile composers expanded while history scroll events run.
- Document the isolated browser-test setup and guard its project wiring in the open-issue regression lane.

## Validation

- [ ] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed `CONTRIBUTING.md`

Automated evidence completed by the contributor:

- `pnpm check`
- `pnpm regression:issues`
- Focused Playwright coverage for the original failure clusters and the mobile composer race
- `pnpm smoke:ui` — 166 passed, 88 skipped, 0 failed
- `pnpm smoke:ui` repeated from a fresh data root — 166 passed, 88 skipped, 0 failed

### Manual verification needed

- Manually verify a desktop and mobile smoke run can use different appearance settings and backgrounds without visible cross-project state.
- Manually verify background gallery controls remain responsive when help tooltips appear.
- Manually verify a focused mobile Conversation and Roleplay composer stays open while scrolling older history.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Translated docs on the `docs-i18n` branch updated to match, or a `[docs-i18n]` follow-up issue opened
- [ ] Version/release files updated (only if this PR includes a version bump)

`CONTRIBUTING.md` and `CHANGELOG.md` are updated. No user-facing `docs/` page changed, so no `docs-i18n` follow-up is required.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Mobile chat composers now remain expanded while focused, even when scrolling through conversation history.
  * Help tooltips no longer intercept pointer interactions.
* **Tests**
  * Improved appearance, tracker, background-selection, and mobile interaction checks.
  * Desktop and mobile smoke tests now use isolated app data to reduce cross-test interference.
* **Documentation**
  * Updated smoke-test guidance to reflect separate desktop and mobile test environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->