### PR TITLE
fix: reconcile orphaned Noodle character accounts on open

### DIFF
--- a/packages/server/src/services/noodle/noodle-public-support.ts
+++ b/packages/server/src/services/noodle/noodle-public-support.ts
@@ -147,7 +147,12 @@ export async function bootstrapVisibleNoodle(
   const characterRowsById = new Map((await characters.list()).map((row) => [row.id, row]));
   for (const account of existingCharacterAccounts) {
     const row = characterRowsById.get(account.entityId);
-    if (!row) continue;
+    if (!row) {
+      // Character was deleted but the account cleanup failed or predates it existing (see
+      // characters.routes.ts delete handler) — reconcile the ghost here on every open.
+      await noodle.deleteAccountByEntity("character", account.entityId);
+      continue;
+    }
     await noodle.upsertAccountFromProfile({
       kind: "character",
       entityId: row.id,


### PR DESCRIPTION
> [!IMPORTANT]
> Contributions target `staging`. Only `SpicyMarinara` may promote this repository's `staging` branch or a same-repository `hotfix/*` branch to `main`.
> Outside and first-time contributors also require an approving review from `SpicyMarinara`.
<!-- See CONTRIBUTING.md § Branches. -->

## Linked issue

No existing issue found for this — should be opened before merge to gather opinions per CONTRIBUTING.md.

Closes #

## Why this change

Deleting a character is supposed to delete its Noodle account too (`characters.routes.ts` delete handler), but that cleanup is best-effort: if it throws, the error is only logged and the account is left behind. Those orphaned "ghost" accounts keep showing up in the Noodle feed/profile list with no character behind them, and there was no reconciliation path to clear them — a user affected by one had no self-serve way to remove it.

## What changed

- `noodle-public-support.ts`'s `bootstrapVisibleNoodle` (runs on every `GET /noodle/`, i.e. every time Noodle is opened) already loops character-backed accounts against live characters and used to just `continue` past any account whose character no longer exists.
- Changed that branch to call the existing `deleteAccountByEntity("character", entityId)` teardown instead, so ghost accounts (and their posts/interactions/subscriptions/digests, via that function's existing cascade) are cleared the next time Noodle is opened.

## Validation

- [ ] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed `CONTRIBUTING.md`

### Manual verification notes

<!-- ⚠️ If an AI agent filled out or ticked these boxes for you, treat them   -->
<!-- as a TO-DO LIST, not as proof the work is done. Verify each item yourself -->
<!-- before submitting. If you haven't verified it, untick the box.            -->

- Manually verify: delete a character with an existing Noodle presence, simulate/force the account-cleanup step to fail (or manually leave a stray `noodle_accounts` row pointing at a deleted character id), then reopen Noodle and confirm the ghost account and its posts disappear.
- Manually verify: normal character delete + Noodle open still works with no ghost accounts present (no-op path).

## Docs and release impact

- [x] No docs changes needed

## UI evidence (if applicable)

N/A — behavior-only fix, no UI surface changed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed obsolete Noodle accounts when their associated character records no longer exist.
  * Improved account reconciliation to prevent stale accounts from remaining active.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->