### PR TITLE
Fix storyboard matching for prefixed NPC names

### DIFF
--- a/packages/server/src/routes/game.routes.ts
+++ b/packages/server/src/routes/game.routes.ts
@@ -278,7 +278,7 @@ import { readIllustratorAppearance } from "./generate/illustrator-references.js"
 // Helpers
 // ──────────────────────────────────────────────
 
-const AVATAR_NAME_TITLE_WORDS = new Set([
+const CHARACTER_NAME_LEADING_PREFIX_WORDS = new Set([
   "a",
   "an",
   "the",
@@ -292,6 +292,11 @@ const AVATAR_NAME_TITLE_WORDS = new Set([
   "lady",
   "lord",
   "professor",
+  "old",
+  "young",
+  "elder",
+  "great",
+  "captain",
 ]);
 
 function normalizeAvatarLookupName(value: string): string {
@@ -305,17 +310,23 @@ function normalizeAvatarLookupName(value: string): string {
     .trim();
 }
 
+function nameLookupWithoutLeadingPrefix(normalizedName: string): string {
+  const words = normalizedName.split(/\s+/).filter(Boolean);
+  return words.length > 1 && CHARACTER_NAME_LEADING_PREFIX_WORDS.has(words[0]!)
+    ? words.slice(1).join(" ")
+    : normalizedName;
+}
+
 function avatarLookupAliases(value: string): string[] {
   const normalized = normalizeAvatarLookupName(value);
   const words = normalized.split(/\s+/).filter(Boolean);
-  const withoutLeadingTitle =
-    words.length > 1 && AVATAR_NAME_TITLE_WORDS.has(words[0]!) ? words.slice(1).join(" ") : normalized;
+  const withoutLeadingPrefix = nameLookupWithoutLeadingPrefix(normalized);
   return Array.from(
     new Set([
       value.normalize("NFKC").trim().toLocaleLowerCase(),
       normalized,
-      withoutLeadingTitle,
-      ...words.filter((word) => word.length >= 3 && !AVATAR_NAME_TITLE_WORDS.has(word)),
+      withoutLeadingPrefix,
+      ...words.filter((word) => word.length >= 3 && !CHARACTER_NAME_LEADING_PREFIX_WORDS.has(word)),
     ]),
   ).filter(Boolean);
 }
@@ -4989,17 +5000,36 @@ function storyboardSourceMentionsCharacter(sourceNarration: string, name: string
   return new RegExp(`(^|[^\\p{L}\\p{N}])${escapedName}([^\\p{L}\\p{N}]|$)`, "iu").test(sourceNarration);
 }
 
-function storyboardNormalizedMentionIndex(text: string, name: string): number {
+function storyboardMentionAliases(name: string): string[] {
+  const normalizedName = normalizeAvatarLookupName(name);
+  return Array.from(new Set([normalizedName, nameLookupWithoutLeadingPrefix(normalizedName)])).filter(Boolean);
+}
+
+function storyboardMentionAliasOwners(characterNames: string[]): Map<string, Set<string>> {
+  const owners = new Map<string, Set<string>>();
+  for (const name of characterNames) {
+    const normalizedName = normalizeAvatarLookupName(name);
+    if (!normalizedName) continue;
+    for (const alias of storyboardMentionAliases(name)) {
+      const aliasOwners = owners.get(alias) ?? new Set<string>();
+      aliasOwners.add(normalizedName);
+      owners.set(alias, aliasOwners);
+    }
+  }
+  return owners;
+}
+
+function storyboardNormalizedMentionIndex(text: string, name: string, aliasOwners: Map<string, Set<string>>): number {
   const normalizedText = ` ${normalizeAvatarLookupName(text.replace(/['\u2019]s\b/giu, ""))} `;
   if (!normalizedText.trim()) return -1;
   let bestIndex = -1;
   const normalizedName = normalizeAvatarLookupName(name);
-  const words = normalizedName.split(/\s+/).filter(Boolean);
-  const withoutLeadingTitle =
-    words.length > 1 && AVATAR_NAME_TITLE_WORDS.has(words[0]!) ? words.slice(1).join(" ") : normalizedName;
   // Visibility matching must not use per-word fuzzy aliases: color words like
   // "amber", "blue", and "violet" can otherwise promote old slime NPCs.
-  for (const normalizedAlias of Array.from(new Set([normalizedName, withoutLeadingTitle]))) {
+  // A shortened leading-prefix alias must also identify only one roster entry;
+  // otherwise "Grish" would promote both "Old Grish" and "Young Grish".
+  for (const normalizedAlias of storyboardMentionAliases(name)) {
+    if (normalizedAlias !== normalizedName && (aliasOwners.get(normalizedAlias)?.size ?? 0) !== 1) continue;
     if (normalizedAlias.length < 2) continue;
     const escapedAlias = normalizedAlias.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
     const match = new RegExp(`(?:^| )${escapedAlias}(?= |$)`, "u").exec(normalizedText);
@@ -5019,11 +5049,12 @@ export function selectStoryboardAppearanceCharacterNames(args: {
     .filter(Boolean)
     .join("\n");
   const activePersonaName = normalizeAvatarLookupName(args.activePersonaName ?? "");
+  const aliasOwners = storyboardMentionAliasOwners(args.allowedCharacterNames);
   return args.allowedCharacterNames
     .map((name, order) => ({
       name,
       order,
-      mentionIndex: storyboardNormalizedMentionIndex(sourceText, name),
+      mentionIndex: storyboardNormalizedMentionIndex(sourceText, name, aliasOwners),
       isActivePersona: activePersonaName.length > 0 && normalizeAvatarLookupName(name) === activePersonaName,
     }))
     .filter((candidate) => candidate.isActivePersona || candidate.mentionIndex >= 0)
@@ -5078,8 +5109,9 @@ function reconcileStoryboardCharactersForFrame(args: {
 
   for (const name of characters) addCharacter(name);
 
+  const aliasOwners = storyboardMentionAliasOwners(args.allowedCharacterNames ?? []);
   const mentionedAllowed = (args.allowedCharacterNames ?? [])
-    .map((name) => ({ name, index: storyboardNormalizedMentionIndex(args.frameText, name) }))
+    .map((name) => ({ name, index: storyboardNormalizedMentionIndex(args.frameText, name, aliasOwners) }))
     .filter((entry) => entry.index >= 0)
     .sort((a, b) => a.index - b.index);
 

--- a/scripts/regressions/prompt.regression.ts
+++ b/scripts/regressions/prompt.regression.ts
@@ -3785,6 +3785,55 @@ const cases: RegressionCase[] = [
         }),
         ["2B-"],
       );
+      assert.deepEqual(
+        selectStoryboardAppearanceCharacterNames({
+          sourceNarration: "Grish joins Elowen, Rowan, Tusk, and Voss beside the gate.",
+          sections: [],
+          allowedCharacterNames: [
+            "Old Grish",
+            "Young Elowen",
+            "Elder Rowan",
+            "Great Tusk",
+            "Captain Voss",
+            "Amber Slime",
+            "Blue Ooze",
+            "Violet Myconid",
+          ],
+        }),
+        ["Old Grish", "Young Elowen", "Elder Rowan", "Great Tusk", "Captain Voss"],
+      );
+      assert.deepEqual(
+        selectStoryboardAppearanceCharacterNames({
+          sourceNarration: "Amber light turns the old stone blue beside a violet banner.",
+          sections: [],
+          allowedCharacterNames: ["Old Grish", "Amber Slime", "Blue Ooze", "Violet Myconid"],
+        }),
+        [],
+      );
+      assert.deepEqual(
+        selectStoryboardAppearanceCharacterNames({
+          sourceNarration: "Grish raises his lantern.",
+          sections: [],
+          allowedCharacterNames: ["Old Grish", "Young Grish"],
+        }),
+        [],
+      );
+      assert.deepEqual(
+        selectStoryboardAppearanceCharacterNames({
+          sourceNarration: "Old Grish raises his lantern.",
+          sections: [],
+          allowedCharacterNames: ["Old Grish", "Young Grish"],
+        }),
+        ["Old Grish"],
+      );
+      assert.deepEqual(
+        selectStoryboardAppearanceCharacterNames({
+          sourceNarration: "Old waits beside the gate.",
+          sections: [],
+          allowedCharacterNames: ["Old"],
+        }),
+        ["Old"],
+      );
 
       const narrationSummaryMessages = await buildIllustrationNarrationSummaryMessages({
         illustration: {


### PR DESCRIPTION
> [!IMPORTANT]
> Contributions target `staging`. Only `SpicyMarinara` may promote this repository staging branch or a same-repository `hotfix/*` branch to `main`.
> Outside and first-time contributors also require an approving review from `SpicyMarinara`.

## Linked issue

Closes #4397

## Why this change

- Tracked NPCs such as `Old Grish` lost storyboard appearance and avatar context when later GM narration used the shorter name `Grish`.
- Broad per-word fuzzy matching is not safe for storyboard visibility because ordinary narration words can promote unrelated NPCs.

## What changed

- Extended the controlled leading-prefix aliases with `old`, `young`, `elder`, `great`, and `captain`.
- Reused one leading-prefix helper for avatar lookup and storyboard visibility.
- Allowed shortened storyboard aliases only when they uniquely identify one allowed roster entry, preventing `Grish` from selecting both `Old Grish` and `Young Grish`.
- Added regression coverage for shortened names, all new prefixes, unrelated descriptive narration, ambiguous aliases, full-name disambiguation, and a one-word NPC named `Old`.

## Validation

- [x] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [x] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed `CONTRIBUTING.md`

Commands completed:

- `pnpm check`
- `pnpm regression:prompt`
- `git diff --check`

### Manual verification notes

- No browser or live Game-mode verification was performed. The original matcher failure and its negative controls are covered by deterministic prompt regression assertions.

## Docs and release impact

- [x] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Translated docs on the `docs-i18n` branch updated to match, or a `[docs-i18n]` follow-up issue opened (see CONTRIBUTING.md § Translated documentation)
- [ ] Version/release files updated (only if this PR includes a version bump)

No docs or release metadata changes are needed for this internal matcher fix.

## UI evidence (if applicable)

Not applicable; this is a server-side storyboard selection fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved storyboard character matching for names with descriptors such as “old,” “young,” “elder,” “great,” and “captain.”
  - Prevented ambiguous shortened names from selecting multiple similarly named characters.
  - Improved character selection across storyboard narration and appearance matching.

- **Tests**
  - Added regression coverage for prefixed names, exact matches, ambiguous aliases, color and material terms, and multi-character narration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->