### PR TITLE
Fix character-card action sizing regression assertion

### DIFF
--- a/e2e/core-flows.e2e.ts
+++ b/e2e/core-flows.e2e.ts
@@ -1997,6 +1997,10 @@ test("Character Chat actions reuse mode selection and seed the chosen setup wiza
 
     const actions = characterRow.locator("[data-character-row-actions]");
     await expect(actions).toBeVisible();
+    const addToActiveChatButton = actions.getByRole("button", {
+      name: `Add ${characterName} to the active chat`,
+      exact: true,
+    });
     const duplicateButton = actions.getByRole("button", { name: "Duplicate", exact: true });
     const deleteButton = actions.getByRole("button", { name: "Delete", exact: true });
     const chatButton = actions.getByRole("button", {
@@ -2040,23 +2044,29 @@ test("Character Chat actions reuse mode selection and seed the chosen setup wiza
     );
     expect(copiedTagsBox!.y + copiedTagsBox!.height).toBeLessThanOrEqual(copiedRowBox!.y + copiedRowBox!.height);
 
-    const [duplicateBox, deleteBox, chatBox, duplicateIconBox, deleteIconBox, chatIconBox] = await Promise.all([
-      duplicateButton.boundingBox(),
-      deleteButton.boundingBox(),
-      chatButton.boundingBox(),
-      duplicateButton.locator("svg").boundingBox(),
-      deleteButton.locator("svg").boundingBox(),
-      chatButton.locator("svg").boundingBox(),
-    ]);
+    const [addToActiveChatBox, duplicateBox, deleteBox, chatBox, duplicateIconBox, deleteIconBox, chatIconBox] =
+      await Promise.all([
+        addToActiveChatButton.boundingBox(),
+        duplicateButton.boundingBox(),
+        deleteButton.boundingBox(),
+        chatButton.boundingBox(),
+        duplicateButton.locator("svg").boundingBox(),
+        deleteButton.locator("svg").boundingBox(),
+        chatButton.locator("svg").boundingBox(),
+      ]);
+    expect(addToActiveChatBox).not.toBeNull();
     expect(duplicateBox).not.toBeNull();
     expect(deleteBox).not.toBeNull();
     expect(chatBox).not.toBeNull();
     expect(duplicateIconBox).not.toBeNull();
     expect(deleteIconBox).not.toBeNull();
     expect(chatIconBox).not.toBeNull();
+    expect(Math.abs(addToActiveChatBox!.height - duplicateBox!.height)).toBeLessThan(0.1);
     expect(Math.abs(duplicateBox!.height - deleteBox!.height)).toBeLessThan(0.1);
     expect(Math.abs(duplicateBox!.height - chatBox!.height)).toBeLessThan(0.1);
-    expect(Math.abs(chatBox!.width - (duplicateBox!.width + deleteBox!.width + 2))).toBeLessThan(0.5);
+    expect(
+      Math.abs(chatBox!.width - (addToActiveChatBox!.width + duplicateBox!.width + deleteBox!.width + 4)),
+    ).toBeLessThan(0.5);
     expect(duplicateIconBox!.height / duplicateBox!.height).toBeGreaterThan(0.52);
     expect(duplicateIconBox!.width / duplicateBox!.width).toBeGreaterThan(0.52);
     expect(deleteIconBox!.height / deleteBox!.height).toBeGreaterThan(0.52);

--- a/e2e/core-flows.e2e.ts
+++ b/e2e/core-flows.e2e.ts
@@ -1997,10 +1997,6 @@ test("Character Chat actions reuse mode selection and seed the chosen setup wiza
 
     const actions = characterRow.locator("[data-character-row-actions]");
     await expect(actions).toBeVisible();
-    const addToActiveChatButton = actions.getByRole("button", {
-      name: `Add ${characterName} to the active chat`,
-      exact: true,
-    });
     const duplicateButton = actions.getByRole("button", { name: "Duplicate", exact: true });
     const deleteButton = actions.getByRole("button", { name: "Delete", exact: true });
     const chatButton = actions.getByRole("button", {
@@ -2044,29 +2040,24 @@ test("Character Chat actions reuse mode selection and seed the chosen setup wiza
     );
     expect(copiedTagsBox!.y + copiedTagsBox!.height).toBeLessThanOrEqual(copiedRowBox!.y + copiedRowBox!.height);
 
-    const [addToActiveChatBox, duplicateBox, deleteBox, chatBox, duplicateIconBox, deleteIconBox, chatIconBox] =
-      await Promise.all([
-        addToActiveChatButton.boundingBox(),
-        duplicateButton.boundingBox(),
-        deleteButton.boundingBox(),
-        chatButton.boundingBox(),
-        duplicateButton.locator("svg").boundingBox(),
-        deleteButton.locator("svg").boundingBox(),
-        chatButton.locator("svg").boundingBox(),
-      ]);
-    expect(addToActiveChatBox).not.toBeNull();
+    const [duplicateBox, deleteBox, chatBox, duplicateIconBox, deleteIconBox, chatIconBox] = await Promise.all([
+      duplicateButton.boundingBox(),
+      deleteButton.boundingBox(),
+      chatButton.boundingBox(),
+      duplicateButton.locator("svg").boundingBox(),
+      deleteButton.locator("svg").boundingBox(),
+      chatButton.locator("svg").boundingBox(),
+    ]);
     expect(duplicateBox).not.toBeNull();
     expect(deleteBox).not.toBeNull();
     expect(chatBox).not.toBeNull();
     expect(duplicateIconBox).not.toBeNull();
     expect(deleteIconBox).not.toBeNull();
     expect(chatIconBox).not.toBeNull();
-    expect(Math.abs(addToActiveChatBox!.height - duplicateBox!.height)).toBeLessThan(0.1);
     expect(Math.abs(duplicateBox!.height - deleteBox!.height)).toBeLessThan(0.1);
+    expect(Math.abs(duplicateBox!.width - deleteBox!.width)).toBeLessThan(0.1);
     expect(Math.abs(duplicateBox!.height - chatBox!.height)).toBeLessThan(0.1);
-    expect(
-      Math.abs(chatBox!.width - (addToActiveChatBox!.width + duplicateBox!.width + deleteBox!.width + 4)),
-    ).toBeLessThan(0.5);
+    expect(Math.abs(chatBox!.width - (duplicateBox!.width * 3 + 4))).toBeLessThan(0.5);
     expect(duplicateIconBox!.height / duplicateBox!.height).toBeGreaterThan(0.52);
     expect(duplicateIconBox!.width / duplicateBox!.width).toBeGreaterThan(0.52);
     expect(deleteIconBox!.height / deleteBox!.height).toBeGreaterThan(0.52);


### PR DESCRIPTION
Closes #4406

## Why

The character-row action container is a three-column grid. In this flow, Add to active chat is intentionally hidden because the character is already assigned, while the grid still reserves all three columns. The existing Playwright assertion calculated the full-width Chat button from only the two visible action columns, causing the otherwise healthy smoke suite to fail in both desktop and mobile viewports.

## What changed

- Verify Duplicate and Delete retain equal column widths.
- Calculate the full-width Chat button from all three grid columns and both gaps.
- Keep this as a test-only correction; no runtime UI behavior changes.

## Validation evidence

- Focused Playwright run: 2 passed (desktop Chromium and mobile Chromium).
- `pnpm check`: passed.

## Manual validation

- [ ] Run the focused Playwright test in desktop and mobile Chromium.
- [ ] Run `pnpm check`.