### PR TITLE
fix(agents): remove the duplicate drag handle on agent cards

### DIFF
--- a/packages/client/src/components/panels/AgentsPanel.tsx
+++ b/packages/client/src/components/panels/AgentsPanel.tsx
@@ -18,7 +18,6 @@ import {
   Check,
   FolderPlus,
   ArrowUpDown,
-  GripVertical,
   ShieldCheck,
   TriangleAlert,
 } from "lucide-react";
@@ -1582,7 +1581,7 @@ function renderAgentCard({
       )}
     >
       {onTouchStart && (
-        <TouchDragHandle label={localizeUi("ui.panels.agentspanel.dragAgent")} onTouchStart={onTouchStart} />
+        <TouchDragHandle label={localizeUi("ui.panels.agentcard.dragAgent")} onTouchStart={onTouchStart} />
       )}
       {selectionMode && (
         <div
@@ -1595,22 +1594,6 @@ function renderAgentCard({
         >
           {selected && <Check size="0.75rem" />}
         </div>
-      )}
-      {!selectionMode && (
-        <button
-          type="button"
-          aria-hidden="true"
-          tabIndex={-1}
-          title={localizeUi("ui.panels.agentcard.dragAgent")}
-          className="mari-chrome-accent-text-muted mari-accent-animated flex h-7 w-5 shrink-0 cursor-grab touch-none items-center justify-center rounded-md opacity-0 transition-all hover:bg-[var(--marinara-chat-chrome-highlight-bg)] hover:text-[var(--marinara-chat-chrome-button-text-hover)] active:cursor-grabbing active:scale-95 group-focus-within:opacity-100 group-hover:opacity-100 [@media(pointer:coarse)]:hidden"
-          onClick={(event) => event.stopPropagation()}
-          onContextMenu={(event) => {
-            event.preventDefault();
-            event.stopPropagation();
-          }}
-        >
-          <GripVertical size="0.8125rem" />
-        </button>
       )}
       <button
         type="button"

--- a/packages/client/src/localization/locales/en.json
+++ b/packages/client/src/localization/locales/en.json
@@ -6290,7 +6290,6 @@
   "ui.panels.agentspanel.deleteAgents": "Delete Agents",
   "ui.panels.agentspanel.deletedValue1AgentValue2": "Deleted {{value1}} agent{{value2}}",
   "ui.panels.agentspanel.deleteValue1": "Delete \"{{value1}}\"?",
-  "ui.panels.agentspanel.dragAgent": "Drag agent",
   "ui.panels.agentspanel.dragAndDropAgentsToFoldersDoubleClickOr": "Drag and drop agents to folders, double-click or double-tap to rename",
   "ui.panels.agentspanel.dropAgentsHere": "Drop agents here.",
   "ui.panels.agentspanel.dropHereToMoveOutOfFolder": "Drop here to move out of folder",


### PR DESCRIPTION
Follow-up to #4413.

## Why

That PR added a `TouchDragHandle` to agent cards so agents could be touch-dragged. Agent cards already carried their own decorative grip — hover-revealed, `[@media(pointer:coarse)]:hidden`, no handler, purely an affordance for the native HTML5 drag. The new handle also hover-reveals on fine pointers, so hovering an agent card on desktop showed **two** grips side by side.

## What

Remove the decorative grip and keep `TouchDragHandle`, which already covers both pointer types and is exactly what the other six library panels do. The handle now also reuses the existing `ui.panels.agentcard.dragAgent` key, so the duplicate `ui.panels.agentspanel.dragAgent` key added in #4413 is dropped.

One small behavior difference: the old grip was hidden in selection mode, the shared handle is not — again matching the other panels.

## Validation

- [ ] `pnpm check`
- [ ] `pnpm localization:check`

## Test plan

- [ ] Manually verify hovering an agent card on desktop shows exactly one drag handle
- [ ] Manually verify the native desktop drag of an agent card still works
- [ ] Manually verify the handle is visible on a touch device and still starts a touch drag
- [ ] Manually verify agent cards in selection mode look right with the handle present

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI Improvements**
  * Simplified agent cards by removing the redundant desktop drag handle.
  * Retained touch-based drag-and-drop controls for supported devices.
  * Removed an unused localization entry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->