### PR TITLE
OK fix(chat): chat resource drop review follow-ups

### DIFF
--- a/packages/client/src/components/chat/ChatArea.tsx
+++ b/packages/client/src/components/chat/ChatArea.tsx
@@ -719,12 +719,12 @@ export function ChatArea() {
   useEffect(() => {
     const openAgentSetup = (event: Event) => {
       const chatId = (event as CustomEvent<{ chatId?: string }>).detail?.chatId;
-      if (chatId && chatId !== activeChatId) return;
+      if (chatId && chatId !== useChatStore.getState().activeChatId) return;
       handleOpenSettingsPanel();
     };
     window.addEventListener(CHAT_RESOURCE_AGENT_SETUP_EVENT, openAgentSetup);
     return () => window.removeEventListener(CHAT_RESOURCE_AGENT_SETUP_EVENT, openAgentSetup);
-  }, [activeChatId, handleOpenSettingsPanel]);
+  }, [handleOpenSettingsPanel]);
 
   useEffect(() => {
     window.addEventListener(CHAT_TOOLBAR_ACTION_EVENT, closeFloatingChatDrawers);

--- a/packages/client/src/components/chat/ChatArea.tsx
+++ b/packages/client/src/components/chat/ChatArea.tsx
@@ -717,10 +717,14 @@ export function ChatArea() {
   }, []);
   // A dropped agent parks a setup request; open chat settings so its modal can run.
   useEffect(() => {
-    const openAgentSetup = () => handleOpenSettingsPanel();
+    const openAgentSetup = (event: Event) => {
+      const chatId = (event as CustomEvent<{ chatId?: string }>).detail?.chatId;
+      if (chatId && chatId !== activeChatId) return;
+      handleOpenSettingsPanel();
+    };
     window.addEventListener(CHAT_RESOURCE_AGENT_SETUP_EVENT, openAgentSetup);
     return () => window.removeEventListener(CHAT_RESOURCE_AGENT_SETUP_EVENT, openAgentSetup);
-  }, [handleOpenSettingsPanel]);
+  }, [activeChatId, handleOpenSettingsPanel]);
 
   useEffect(() => {
     window.addEventListener(CHAT_TOOLBAR_ACTION_EVENT, closeFloatingChatDrawers);

--- a/packages/client/src/components/chat/ChatResourceDropOverlay.tsx
+++ b/packages/client/src/components/chat/ChatResourceDropOverlay.tsx
@@ -420,7 +420,7 @@ export function ChatResourceDropOverlay({ chat }: { chat: Chat }) {
             [key]: nextIds,
             ...(latestAction.type === "add-agents" && latestAction.mustEnableAgents ? { enableAgents: true } : {}),
           });
-          if (latestAction.type === "add-agents") {
+          if (latestAction.type === "add-agents" && useChatStore.getState().activeChatId === currentChat.id) {
             requestChatAgentSetup(currentChat.id, latestAction.ids);
             // The setup drawer owns the panel restore from here, so it happens after its modal.
             agentSetupHandoffRef.current = true;
@@ -602,11 +602,15 @@ export function ChatResourceDropOverlay({ chat }: { chat: Chat }) {
       const payload = (event as CustomEvent<ChatResourceDragPayload>).detail;
       if (!payload) return;
       setAssigning(true);
-      void applyAction(payload).finally(() => setAssigning(false));
+      void applyAction(payload)
+        .catch((error) => {
+          toast.error(error instanceof Error ? error.message : t("ui.chat.chatresourcedropoverlay.failed"));
+        })
+        .finally(() => setAssigning(false));
     };
     window.addEventListener(CHAT_RESOURCE_ASSIGN_EVENT, assign);
     return () => window.removeEventListener(CHAT_RESOURCE_ASSIGN_EVENT, assign);
-  }, [applyAction]);
+  }, [applyAction, t]);
 
   // A mobile dock drop closes the library panel to show the result; once the drop is fully done and
   // its follow-up modals are gone, put the user back in the panel they were dragging from.

--- a/packages/client/src/components/chat/ChatResourceDropOverlay.tsx
+++ b/packages/client/src/components/chat/ChatResourceDropOverlay.tsx
@@ -557,6 +557,20 @@ export function ChatResourceDropOverlay({ chat }: { chat: Chat }) {
     ],
   );
 
+  // Both entry points funnel through here: applyAction rejects outside its own try/catch when a
+  // confirmation or a registry lookup fails, and an event listener has nowhere to report that.
+  const runAssignment = useCallback(
+    (payload: ChatResourceDragPayload) => {
+      setAssigning(true);
+      void applyAction(payload)
+        .catch((error) => {
+          toast.error(error instanceof Error ? error.message : t("ui.chat.chatresourcedropoverlay.failed"));
+        })
+        .finally(() => setAssigning(false));
+    },
+    [applyAction, t],
+  );
+
   useEffect(() => {
     const handleDragOver = (event: DragEvent) => {
       if (!event.dataTransfer) return;
@@ -581,7 +595,7 @@ export function ChatResourceDropOverlay({ chat }: { chat: Chat }) {
         toast.info(t(chatResourceBlockedKey(next.action), { name: next.action.label }));
         return;
       }
-      void applyAction(next.payload);
+      runAssignment(next.payload);
     };
     const clear = () => {
       updateOverlay(null);
@@ -595,22 +609,16 @@ export function ChatResourceDropOverlay({ chat }: { chat: Chat }) {
       window.removeEventListener("drop", handleDrop, true);
       window.removeEventListener("dragend", clear, true);
     };
-  }, [applyAction, resolveOverlay, t, updateOverlay]);
+  }, [resolveOverlay, runAssignment, t, updateOverlay]);
 
   useEffect(() => {
     const assign = (event: Event) => {
       const payload = (event as CustomEvent<ChatResourceDragPayload>).detail;
-      if (!payload) return;
-      setAssigning(true);
-      void applyAction(payload)
-        .catch((error) => {
-          toast.error(error instanceof Error ? error.message : t("ui.chat.chatresourcedropoverlay.failed"));
-        })
-        .finally(() => setAssigning(false));
+      if (payload) runAssignment(payload);
     };
     window.addEventListener(CHAT_RESOURCE_ASSIGN_EVENT, assign);
     return () => window.removeEventListener(CHAT_RESOURCE_ASSIGN_EVENT, assign);
-  }, [applyAction, t]);
+  }, [runAssignment]);
 
   // A mobile dock drop closes the library panel to show the result; once the drop is fully done and
   // its follow-up modals are gone, put the user back in the panel they were dragging from.

--- a/packages/client/src/components/panels/AgentsPanel.tsx
+++ b/packages/client/src/components/panels/AgentsPanel.tsx
@@ -18,7 +18,6 @@ import {
   Check,
   FolderPlus,
   ArrowUpDown,
-  GripVertical,
   ShieldCheck,
   TriangleAlert,
 } from "lucide-react";
@@ -1582,7 +1581,7 @@ function renderAgentCard({
       )}
     >
       {onTouchStart && (
-        <TouchDragHandle label={localizeUi("ui.panels.agentspanel.dragAgent")} onTouchStart={onTouchStart} />
+        <TouchDragHandle label={localizeUi("ui.panels.agentcard.dragAgent")} onTouchStart={onTouchStart} />
       )}
       {selectionMode && (
         <div
@@ -1595,22 +1594,6 @@ function renderAgentCard({
         >
           {selected && <Check size="0.75rem" />}
         </div>
-      )}
-      {!selectionMode && (
-        <button
-          type="button"
-          aria-hidden="true"
-          tabIndex={-1}
-          title={localizeUi("ui.panels.agentcard.dragAgent")}
-          className="mari-chrome-accent-text-muted mari-accent-animated flex h-7 w-5 shrink-0 cursor-grab touch-none items-center justify-center rounded-md opacity-0 transition-all hover:bg-[var(--marinara-chat-chrome-highlight-bg)] hover:text-[var(--marinara-chat-chrome-button-text-hover)] active:cursor-grabbing active:scale-95 group-focus-within:opacity-100 group-hover:opacity-100 [@media(pointer:coarse)]:hidden"
-          onClick={(event) => event.stopPropagation()}
-          onContextMenu={(event) => {
-            event.preventDefault();
-            event.stopPropagation();
-          }}
-        >
-          <GripVertical size="0.8125rem" />
-        </button>
       )}
       <button
         type="button"

--- a/packages/client/src/lib/chat-resource-drag.ts
+++ b/packages/client/src/lib/chat-resource-drag.ts
@@ -137,7 +137,7 @@ export function requestChatResourceAssignment(payload: ChatResourceDragPayload) 
 export function requestChatAgentSetup(chatId: string, ids: string[]) {
   const pendingIds = pendingChatAgentSetup?.chatId === chatId ? pendingChatAgentSetup.ids : [];
   pendingChatAgentSetup = { chatId, ids: Array.from(new Set([...pendingIds, ...ids.filter(Boolean)])) };
-  window.dispatchEvent(new CustomEvent(CHAT_RESOURCE_AGENT_SETUP_EVENT));
+  window.dispatchEvent(new CustomEvent<{ chatId: string }>(CHAT_RESOURCE_AGENT_SETUP_EVENT, { detail: { chatId } }));
 }
 
 export function takePendingChatAgentSetupIds(chatId: string) {

--- a/packages/client/src/localization/locales/en.json
+++ b/packages/client/src/localization/locales/en.json
@@ -6290,7 +6290,6 @@
   "ui.panels.agentspanel.deleteAgents": "Delete Agents",
   "ui.panels.agentspanel.deletedValue1AgentValue2": "Deleted {{value1}} agent{{value2}}",
   "ui.panels.agentspanel.deleteValue1": "Delete \"{{value1}}\"?",
-  "ui.panels.agentspanel.dragAgent": "Drag agent",
   "ui.panels.agentspanel.dragAndDropAgentsToFoldersDoubleClickOr": "Drag and drop agents to folders, double-click or double-tap to rename",
   "ui.panels.agentspanel.dropAgentsHere": "Drop agents here.",
   "ui.panels.agentspanel.dropHereToMoveOutOfFolder": "Drop here to move out of folder",


### PR DESCRIPTION
Review follow-ups to #4413. Supersedes #4419, which is folded in here.

## Why

**Unhandled rejection at the event boundary.** `applyAction` is kicked off from a `window` event listener with `void ... .finally(...)`. Its own `try/catch` only wraps the mutations, so a rejection from `showConfirmDialog` or the available-resource lookups escaped as an unhandled rejection and the user saw nothing.

**Agent handoff was not scoped to a chat.** The setup handoff fired regardless of whether the drop's chat was still active. Switching chats between the drop and the metadata write dispatched a request that `ChatArea` acted on for the *new* chat, opening its settings drawer even though `takePendingChatAgentSetupIds` had nothing for it.

**Two drag handles on agent cards.** #4413 added a `TouchDragHandle` to agent cards, which already carried their own decorative grip — hover-revealed, `[@media(pointer:coarse)]:hidden`, no handler. Hovering an agent card on desktop showed both.

## What

- Catch rejections at the listener and surface them with the existing `failed` toast, keeping the `setAssigning(false)` cleanup in `finally`.
- Only call `requestChatAgentSetup` while the drop's chat is still active.
- Carry `chatId` on `CHAT_RESOURCE_AGENT_SETUP_EVENT` and have the `ChatArea` listener ignore handoffs for other chats.
- Remove the decorative grip from agent cards and keep `TouchDragHandle`, which already covers fine and coarse pointers like the other six library panels. The handle reuses the existing `ui.panels.agentcard.dragAgent` key, so the duplicate key added in #4413 is dropped.

One small behavior difference from that last point: the old grip was hidden in selection mode, the shared handle is not — again matching the other panels.

## Skipped from the review

- **Scoping the pending panel restore to a chat id.** The right panel is not chat-scoped — it holds the global library — so reopening it after a chat switch shows the same panel the user was already dragging from. Adding a chat id to that state guards nothing user-visible.
- **Gating the agent card's native grip on `!onTouchStart`.** The button is removed outright instead, which is less code and matches the other panels.

## Validation

- [ ] `pnpm check`
- [ ] `pnpm localization:check`
- [ ] `pnpm regression:chat-resource-drop`

## Test plan

- [ ] Manually verify a persona drop, then Cancel on the replacement dialog, leaves no console error and no stuck state
- [ ] Manually verify a failed assignment surfaces an error toast rather than failing silently
- [ ] Manually verify dropping an agent still opens the settings drawer with its setup modal
- [ ] Manually verify switching chats immediately after an agent drop does not open the new chat's settings drawer
- [ ] Manually verify hovering an agent card on desktop shows exactly one drag handle
- [ ] Manually verify the native desktop drag of an agent card still works
- [ ] Manually verify the handle is visible on a touch device and still starts a touch drag
- [ ] Manually verify agent cards in selection mode look right with the handle present


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved chat agent setup handling so requests apply only to the intended active chat.
  * Prevented setup handoffs when the assigned chat is no longer active.
  * Added clearer error notifications when chat assignment requests are rejected.

* **UI Improvements**
  * Simplified agent cards by removing the desktop drag-handle button while retaining touch-based dragging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->