### PR TITLE
AFTER UPDATE: fix(generation): centralize connection admission and provider fallback

### DIFF
--- a/packages/server/src/routes/connections.routes.ts
+++ b/packages/server/src/routes/connections.routes.ts
@@ -460,6 +460,7 @@ export async function connectionsRoutes(app: FastifyInstance) {
           conn.claudeFastMode === "true",
           conn.treatAsLocalEndpoint === "true",
           conn.defaultParameters,
+          conn.id,
         );
         let responseText = "";
         for await (const chunk of provider.chat([{ role: "user", content: "Reply with OK." }], {
@@ -502,6 +503,7 @@ export async function connectionsRoutes(app: FastifyInstance) {
           conn.claudeFastMode === "true",
           conn.treatAsLocalEndpoint === "true",
           conn.defaultParameters,
+          conn.id,
         );
         let responseText = "";
         for await (const chunk of provider.chat([{ role: "user", content: "Reply with OK." }], {
@@ -1369,6 +1371,7 @@ export async function connectionsRoutes(app: FastifyInstance) {
         conn.claudeFastMode === "true",
         conn.treatAsLocalEndpoint === "true",
         conn.defaultParameters,
+        conn.id,
       );
 
       let fullResponse = "";

--- a/packages/server/src/routes/encounter.routes.ts
+++ b/packages/server/src/routes/encounter.routes.ts
@@ -589,6 +589,7 @@ export async function encounterRoutes(app: FastifyInstance) {
         conn.claudeFastMode === "true",
         conn.treatAsLocalEndpoint === "true",
         conn.defaultParameters,
+        conn.id,
       );
 
       const characterIds: string[] = JSON.parse(chat.characterIds as string);
@@ -699,6 +700,7 @@ export async function encounterRoutes(app: FastifyInstance) {
         conn.claudeFastMode === "true",
         conn.treatAsLocalEndpoint === "true",
         conn.defaultParameters,
+        conn.id,
       );
 
       const characterIds: string[] = JSON.parse(chat.characterIds as string);
@@ -800,6 +802,7 @@ export async function encounterRoutes(app: FastifyInstance) {
         conn.claudeFastMode === "true",
         conn.treatAsLocalEndpoint === "true",
         conn.defaultParameters,
+        conn.id,
       );
 
       const characterIds: string[] = JSON.parse(chat.characterIds as string);

--- a/packages/server/src/routes/generate/dry-run-route.ts
+++ b/packages/server/src/routes/generate/dry-run-route.ts
@@ -1615,6 +1615,7 @@ export async function registerDryRunRoute(app: FastifyInstance) {
             conn.claudeFastMode === "true",
             conn.treatAsLocalEndpoint === "true",
             conn.defaultParameters,
+            connId ?? undefined,
           );
 
     // ── Mirror /api/generate: normalize + fit prompt to context ──

--- a/packages/server/src/routes/lorebooks.routes.ts
+++ b/packages/server/src/routes/lorebooks.routes.ts
@@ -1193,6 +1193,7 @@ export async function lorebooksRoutes(app: FastifyInstance) {
             resolvedConn.claudeFastMode === "true",
             resolvedConn.treatAsLocalEndpoint === "true",
             resolvedConn.defaultParameters,
+            resolvedConn.id,
           );
         })();
     const embeddingModel = useLocalSidecar ? LOCAL_SIDECAR_MODEL : body.model;

--- a/packages/server/src/services/capability-packages/capability-language-model.service.ts
+++ b/packages/server/src/services/capability-packages/capability-language-model.service.ts
@@ -77,6 +77,8 @@ export function createCapabilityLanguageModelHost(db: DB): CapabilityLanguageMod
         connection.maxTokensOverride,
         connection.claudeFastMode === "true",
         connection.treatAsLocalEndpoint === "true",
+        undefined,
+        connection.id,
       ),
       connection.id,
       requireModel(model ?? connection.model),

--- a/packages/server/src/services/capability-packages/capability-language-model.service.ts
+++ b/packages/server/src/services/capability-packages/capability-language-model.service.ts
@@ -10,6 +10,7 @@ import type { DB } from "../../db/connection.js";
 import { fitMessagesToContext, type BaseLLMProvider, type ChatMessage, type ChatOptions } from "../llm/base-provider.js";
 import { getLocalSidecarProvider, LOCAL_SIDECAR_MODEL } from "../llm/local-sidecar.js";
 import { createLLMProvider } from "../llm/provider-registry.js";
+import { unwrapConnectionAdmissionProvider } from "../generation/connection-admission.js";
 import { createConnectionsStorage } from "../storage/connections.storage.js";
 
 export function createCapabilityLanguageModelHost(db: DB): CapabilityLanguageModelHost {
@@ -21,7 +22,7 @@ export function createCapabilityLanguageModelHost(db: DB): CapabilityLanguageMod
   };
   const resolvedModel = (provider: BaseLLMProvider, connectionId: string, model: string) =>
     Object.freeze({
-      name: provider.constructor.name,
+      name: unwrapConnectionAdmissionProvider(provider).constructor.name,
       connectionId,
       model,
       maxContext: provider.maxContextValue,

--- a/packages/server/src/services/generation/connection-admission.ts
+++ b/packages/server/src/services/generation/connection-admission.ts
@@ -1,0 +1,199 @@
+import type { ChatCompletionResult, ChatMessage, ChatOptions, LLMUsage } from "../llm/base-provider.js";
+import { BaseLLMProvider } from "../llm/base-provider.js";
+import { logger } from "../../lib/logger.js";
+
+// Admission keys identify one physical provider endpoint. Text work keys on the configured
+// connection id; image work keys on the resolved base URL, because most image callers have
+// no connection row in scope and unregistered foreground work would defeat the priority
+// rule. The two keyspaces do not overlap.
+type ConnectionState = {
+  foregroundActive: number;
+  backgroundActive: boolean;
+  lastForegroundFinishedAt: number;
+};
+
+const states = new Map<string, ConnectionState>();
+export const BACKGROUND_CONNECTION_IDLE_MS = 30_000;
+
+export type ConnectionAttemptOutcome = "completed" | "failed";
+export type ConnectionAttemptFinalizer = (outcome: ConnectionAttemptOutcome) => void | Promise<void>;
+export type ConnectionAdmissionMode =
+  | { kind: "foreground" }
+  | {
+      kind: "background";
+      beforeAttempt?: () => void | ConnectionAttemptFinalizer | Promise<void | ConnectionAttemptFinalizer>;
+    }
+  | { kind: "none" };
+
+export class BackgroundConnectionBusyError extends Error {
+  constructor(readonly connectionId: string) {
+    super(`Connection ${connectionId} is not available for background generation.`);
+    this.name = "BackgroundConnectionBusyError";
+  }
+}
+
+export class ConnectionAttemptRejectedError extends Error {
+  constructor(readonly cause: unknown) {
+    super("Connection attempt was rejected before provider work started.", { cause });
+    this.name = "ConnectionAttemptRejectedError";
+  }
+}
+
+export class ConnectionAttemptFinalizationError extends Error {
+  constructor(readonly cause: unknown) {
+    super("Connection attempt accounting failed after provider work finished.", { cause });
+    this.name = "ConnectionAttemptFinalizationError";
+  }
+}
+
+export function isConnectionAdmissionFailure(error: unknown): boolean {
+  return (
+    error instanceof BackgroundConnectionBusyError ||
+    error instanceof ConnectionAttemptRejectedError ||
+    error instanceof ConnectionAttemptFinalizationError
+  );
+}
+
+function stateFor(connectionId: string): ConnectionState {
+  const existing = states.get(connectionId);
+  if (existing) return existing;
+  const state = { foregroundActive: 0, backgroundActive: false, lastForegroundFinishedAt: 0 };
+  states.set(connectionId, state);
+  return state;
+}
+
+export async function withForegroundConnection<T>(connectionId: string, operation: () => Promise<T>): Promise<T> {
+  const release = beginForegroundConnection(connectionId);
+  try {
+    return await operation();
+  } finally {
+    release();
+  }
+}
+
+export function beginForegroundConnection(connectionId: string): () => void {
+  const state = stateFor(connectionId);
+  state.foregroundActive += 1;
+  let released = false;
+  return () => {
+    if (released) return;
+    released = true;
+    state.foregroundActive -= 1;
+    state.lastForegroundFinishedAt = Date.now();
+  };
+}
+
+export function tryBackgroundConnection(
+  connectionId: string,
+  at: Date,
+): { acquired: false } | { acquired: true; release: () => void } {
+  const state = stateFor(connectionId);
+  if (
+    state.backgroundActive ||
+    state.foregroundActive > 0 ||
+    at.getTime() - state.lastForegroundFinishedAt < BACKGROUND_CONNECTION_IDLE_MS
+  ) {
+    return { acquired: false };
+  }
+  state.backgroundActive = true;
+  return {
+    acquired: true,
+    release: () => {
+      state.backgroundActive = false;
+    },
+  };
+}
+
+export function resetConnectionAdmissionForTests(): void {
+  states.clear();
+}
+
+async function beginConnectionAttempt(
+  connectionId: string,
+  mode: ConnectionAdmissionMode,
+): Promise<{ release: () => void; finalize?: ConnectionAttemptFinalizer }> {
+  if (mode.kind === "none") return { release: () => undefined };
+  if (mode.kind === "foreground") return { release: beginForegroundConnection(connectionId) };
+
+  const admission = tryBackgroundConnection(connectionId, new Date());
+  if (!admission.acquired) throw new BackgroundConnectionBusyError(connectionId);
+  try {
+    return { release: admission.release, finalize: (await mode.beforeAttempt?.()) || undefined };
+  } catch (error) {
+    admission.release();
+    throw new ConnectionAttemptRejectedError(error);
+  }
+}
+
+/**
+ * Record the attempt outcome without letting accounting failures overwrite a provider
+ * error: the operation's own failure is what the caller (and the fallback chain) needs to
+ * see. A finalization failure only surfaces when the operation itself succeeded.
+ */
+async function finalizeConnectionAttempt(
+  attempt: { release: () => void; finalize?: ConnectionAttemptFinalizer },
+  outcome: ConnectionAttemptOutcome,
+): Promise<void> {
+  try {
+    await attempt.finalize?.(outcome);
+  } catch (error) {
+    if (outcome === "completed") throw new ConnectionAttemptFinalizationError(error);
+    logger.error(error, "[connection-admission] Attempt accounting failed after a failed provider call");
+  } finally {
+    attempt.release();
+  }
+}
+
+export async function withConnectionAdmission<T>(
+  connectionId: string,
+  mode: ConnectionAdmissionMode,
+  operation: () => Promise<T>,
+): Promise<T> {
+  const attempt = await beginConnectionAttempt(connectionId, mode);
+  let outcome: ConnectionAttemptOutcome = "failed";
+  try {
+    const result = await operation();
+    outcome = "completed";
+    return result;
+  } finally {
+    await finalizeConnectionAttempt(attempt, outcome);
+  }
+}
+
+export class ConnectionAdmissionProvider extends BaseLLMProvider {
+  constructor(
+    private readonly provider: BaseLLMProvider,
+    private readonly connectionId: string,
+    private readonly mode: ConnectionAdmissionMode = { kind: "foreground" },
+  ) {
+    super("", "", provider.maxContextValue ?? undefined, null, provider.maxTokensOverrideValue);
+  }
+
+  async *chat(messages: ChatMessage[], options: ChatOptions): AsyncGenerator<string, LLMUsage | void, unknown> {
+    const attempt = await beginConnectionAttempt(this.connectionId, this.mode);
+    let outcome: ConnectionAttemptOutcome = "failed";
+    try {
+      const result = yield* this.provider.chat(messages, options);
+      outcome = "completed";
+      return result;
+    } finally {
+      await finalizeConnectionAttempt(attempt, outcome);
+    }
+  }
+
+  async chatComplete(messages: ChatMessage[], options: ChatOptions): Promise<ChatCompletionResult> {
+    return withConnectionAdmission(this.connectionId, this.mode, () => this.provider.chatComplete(messages, options));
+  }
+
+  async embed(texts: string[], model: string, signal?: AbortSignal): Promise<number[][]> {
+    return withConnectionAdmission(this.connectionId, this.mode, () => this.provider.embed(texts, model, signal));
+  }
+}
+
+export function withConnectionAdmissionProvider(
+  provider: BaseLLMProvider,
+  connectionId: string,
+  mode: ConnectionAdmissionMode = { kind: "foreground" },
+): BaseLLMProvider {
+  return mode.kind === "none" ? provider : new ConnectionAdmissionProvider(provider, connectionId, mode);
+}

--- a/packages/server/src/services/generation/connection-admission.ts
+++ b/packages/server/src/services/generation/connection-admission.ts
@@ -3,9 +3,9 @@ import { BaseLLMProvider } from "../llm/base-provider.js";
 import { logger } from "../../lib/logger.js";
 
 // Admission keys identify one physical provider endpoint. Text work keys on the configured
-// connection id; image work keys on the resolved base URL, because most image callers have
-// no connection row in scope and unregistered foreground work would defeat the priority
-// rule. The two keyspaces do not overlap.
+// connection id; image work keys on the resolved base URL plus the endpoint id where the
+// backend needs one, because most image callers have no connection row in scope and
+// unregistered foreground work would defeat the priority rule. The keyspaces do not overlap.
 type ConnectionState = {
   foregroundActive: number;
   backgroundActive: boolean;
@@ -22,8 +22,7 @@ export type ConnectionAdmissionMode =
   | {
       kind: "background";
       beforeAttempt?: () => void | ConnectionAttemptFinalizer | Promise<void | ConnectionAttemptFinalizer>;
-    }
-  | { kind: "none" };
+    };
 
 export class BackgroundConnectionBusyError extends Error {
   constructor(readonly connectionId: string) {
@@ -60,15 +59,6 @@ function stateFor(connectionId: string): ConnectionState {
   const state = { foregroundActive: 0, backgroundActive: false, lastForegroundFinishedAt: 0 };
   states.set(connectionId, state);
   return state;
-}
-
-export async function withForegroundConnection<T>(connectionId: string, operation: () => Promise<T>): Promise<T> {
-  const release = beginForegroundConnection(connectionId);
-  try {
-    return await operation();
-  } finally {
-    release();
-  }
 }
 
 export function beginForegroundConnection(connectionId: string): () => void {
@@ -112,7 +102,6 @@ async function beginConnectionAttempt(
   connectionId: string,
   mode: ConnectionAdmissionMode,
 ): Promise<{ release: () => void; finalize?: ConnectionAttemptFinalizer }> {
-  if (mode.kind === "none") return { release: () => undefined };
   if (mode.kind === "foreground") return { release: beginForegroundConnection(connectionId) };
 
   const admission = tryBackgroundConnection(connectionId, new Date());
@@ -162,7 +151,7 @@ export async function withConnectionAdmission<T>(
 
 export class ConnectionAdmissionProvider extends BaseLLMProvider {
   constructor(
-    private readonly provider: BaseLLMProvider,
+    readonly provider: BaseLLMProvider,
     private readonly connectionId: string,
     private readonly mode: ConnectionAdmissionMode = { kind: "foreground" },
   ) {
@@ -190,10 +179,18 @@ export class ConnectionAdmissionProvider extends BaseLLMProvider {
   }
 }
 
+/**
+ * Look through the admission decorator to the provider that actually talks to the backend.
+ * Diagnostics that report a provider class need the concrete one, not the wrapper.
+ */
+export function unwrapConnectionAdmissionProvider(provider: BaseLLMProvider): BaseLLMProvider {
+  return provider instanceof ConnectionAdmissionProvider ? provider.provider : provider;
+}
+
 export function withConnectionAdmissionProvider(
   provider: BaseLLMProvider,
   connectionId: string,
   mode: ConnectionAdmissionMode = { kind: "foreground" },
 ): BaseLLMProvider {
-  return mode.kind === "none" ? provider : new ConnectionAdmissionProvider(provider, connectionId, mode);
+  return new ConnectionAdmissionProvider(provider, connectionId, mode);
 }

--- a/packages/server/src/services/image/image-generation.ts
+++ b/packages/server/src/services/image/image-generation.ts
@@ -204,9 +204,16 @@ const COMFYUI_GEN_TIMEOUT_SECONDS = Number(process.env.COMFYUI_GEN_TIMEOUT ?? 24
 /**
  * Identify the physical image endpoint an admission slot belongs to. RunPod connections share
  * one API base URL and select the actual endpoint with a separate id, so the base URL alone
- * would make two independent endpoints contend for a single slot.
+ * would make two independent endpoints contend for a single slot. Every other backend's base
+ * URL already is the physical target, and a stale `imageEndpointId` left on an imported or
+ * copied connection must not split one ComfyUI/A1111 endpoint into separate slots.
  */
-export function imageAdmissionKey(normalizedBaseUrl: string, imageEndpointId?: string): string {
+export function imageAdmissionKey(
+  normalizedBaseUrl: string,
+  resolvedSource: string,
+  imageEndpointId?: string,
+): string {
+  if (resolvedSource !== "runpod_comfyui") return normalizedBaseUrl;
   const endpointId = imageEndpointId?.trim();
   return endpointId ? `${normalizedBaseUrl}#${endpointId}` : normalizedBaseUrl;
 }
@@ -293,7 +300,7 @@ export async function generateImage(
     // id, so the two do not hold each other off on a connection used for both. Unify the
     // key if that overlap ever shows up in practice.
     return await withConnectionAdmission(
-      imageAdmissionKey(normalizedBaseUrl, request.imageEndpointId),
+      imageAdmissionKey(normalizedBaseUrl, resolvedSource, request.imageEndpointId),
       request.admissionMode ?? { kind: "foreground" },
       physicalRequest,
     );

--- a/packages/server/src/services/image/image-generation.ts
+++ b/packages/server/src/services/image/image-generation.ts
@@ -202,6 +202,16 @@ const IMAGE_GEN_TIMEOUT = Number(process.env.IMAGE_GEN_TIMEOUT_MS ?? 1_800_000);
 const COMFYUI_GEN_TIMEOUT_SECONDS = Number(process.env.COMFYUI_GEN_TIMEOUT ?? 2400);
 
 /**
+ * Identify the physical image endpoint an admission slot belongs to. RunPod connections share
+ * one API base URL and select the actual endpoint with a separate id, so the base URL alone
+ * would make two independent endpoints contend for a single slot.
+ */
+export function imageAdmissionKey(normalizedBaseUrl: string, imageEndpointId?: string): string {
+  const endpointId = imageEndpointId?.trim();
+  return endpointId ? `${normalizedBaseUrl}#${endpointId}` : normalizedBaseUrl;
+}
+
+/**
  * Generate an image using the configured image generation connection.
  * Returns the base64 data and metadata needed to save it.
  */
@@ -283,7 +293,7 @@ export async function generateImage(
     // id, so the two do not hold each other off on a connection used for both. Unify the
     // key if that overlap ever shows up in practice.
     return await withConnectionAdmission(
-      normalizedBaseUrl,
+      imageAdmissionKey(normalizedBaseUrl, request.imageEndpointId),
       request.admissionMode ?? { kind: "foreground" },
       physicalRequest,
     );

--- a/packages/server/src/services/image/image-generation.ts
+++ b/packages/server/src/services/image/image-generation.ts
@@ -31,6 +31,11 @@ import { logger, logDebugOverride } from "../../lib/logger.js";
 import { assertInsideDir, normalizeLoopbackUrl, safeFetch, validateOutboundUrl } from "../../utils/security.js";
 import { notifyGenerationFallback, type GenerationFallbackNotifier } from "../generation/fallback-notification.js";
 import {
+  isConnectionAdmissionFailure,
+  withConnectionAdmission,
+  type ConnectionAdmissionMode,
+} from "../generation/connection-admission.js";
+import {
   COMFYUI_MAX_REFERENCE_IMAGES,
   findMissingComfyReferenceSlots,
   numberedComfyReferencePlaceholder,
@@ -115,6 +120,8 @@ export interface ImageGenRequest {
   signal?: AbortSignal;
   /** Emit the final provider request even when the global log level is above debug. */
   debugMode?: boolean;
+  /** Defaults to foreground: the caller is servicing a user-visible request. */
+  admissionMode?: ConnectionAdmissionMode;
   /** Called immediately before a configured fallback connection is attempted. */
   onFallback?: GenerationFallbackNotifier;
   /** Optional one-shot backup connection used only when the primary image request fails. */
@@ -213,7 +220,7 @@ export async function generateImage(
       : IMAGE_GEN_TIMEOUT;
 
   try {
-    return await withImageGenerationDeadline(request, generationTimeoutMs, async (signal) => {
+    const physicalRequest = () => withImageGenerationDeadline(request, generationTimeoutMs, async (signal) => {
       const allowLocalUrls =
         request.allowLocalUrls ?? (await shouldAllowLocalUrlsForImageConnection(normalizedBaseUrl, resolvedSource));
       const scopedRequest = {
@@ -269,9 +276,20 @@ export async function generateImage(
           return generateOpenAI(normalizedBaseUrl, apiKey, scopedRequest);
       }
     });
+    // Admit on the resolved endpoint rather than a connection id: every caller reaches this
+    // function, but only some have a connection row in scope, and foreground work that
+    // registers nothing would let background preparation start on top of it.
+    // ponytail: image work keys on the endpoint URL while text work keys on the connection
+    // id, so the two do not hold each other off on a connection used for both. Unify the
+    // key if that overlap ever shows up in practice.
+    return await withConnectionAdmission(
+      normalizedBaseUrl,
+      request.admissionMode ?? { kind: "foreground" },
+      physicalRequest,
+    );
   } catch (error) {
     const fallback = request.fallback;
-    if (!fallback || request.signal?.aborted) throw error;
+    if (!fallback || request.signal?.aborted || isConnectionAdmissionFailure(error)) throw error;
     logger.warn(
       error,
       "[illustrator-fallback] Primary image generation failed; retrying with connection %s (%s)",

--- a/packages/server/src/services/llm/connection-fallback-provider.ts
+++ b/packages/server/src/services/llm/connection-fallback-provider.ts
@@ -166,10 +166,12 @@ export class ConnectionFallbackProvider extends BaseLLMProvider {
         // Drive the primary to completion if our consumer abandoned us mid-stream. The manual
         // loop above does not forward an early return the way `yield*` would, so without this
         // an admission wrapper around the primary never runs its own finally and leaks the
-        // connection's foreground slot for the lifetime of the process. Swallow any cleanup
-        // rejection: the provider error the catch below inspects is what decides whether we
-        // fall back, and it must not be replaced by a teardown failure.
-        await generation.return(undefined).catch(() => undefined);
+        // connection's foreground slot for the lifetime of the process. A cleanup rejection is
+        // logged rather than thrown: the provider error the catch below inspects is what decides
+        // whether we fall back, and it must not be replaced by a teardown failure.
+        await generation.return(undefined).catch((closeError: unknown) => {
+          logger.warn(closeError, "[%s-fallback] Failed to close the primary generation stream", this.category);
+        });
       }
       await this.logFallback(new Error("Primary provider returned an empty completion"));
     } catch (error) {

--- a/packages/server/src/services/llm/connection-fallback-provider.ts
+++ b/packages/server/src/services/llm/connection-fallback-provider.ts
@@ -154,13 +154,21 @@ export class ConnectionFallbackProvider extends BaseLLMProvider {
           }
         : options;
       const generation = this.primary.chat(messages, primaryOptions);
-      let result = await generation.next();
-      while (!result.done) {
-        emittedUsableOutput ||= result.value.trim().length > 0;
-        yield result.value;
-        result = await generation.next();
+      try {
+        let result = await generation.next();
+        while (!result.done) {
+          emittedUsableOutput ||= result.value.trim().length > 0;
+          yield result.value;
+          result = await generation.next();
+        }
+        if (emittedUsableOutput || options.signal?.aborted) return result.value;
+      } finally {
+        // Drive the primary to completion if our consumer abandoned us mid-stream. The manual
+        // loop above does not forward an early return the way `yield*` would, so without this
+        // an admission wrapper around the primary never runs its own finally and leaks the
+        // connection's foreground slot for the lifetime of the process.
+        await generation.return(undefined);
       }
-      if (emittedUsableOutput || options.signal?.aborted) return result.value;
       await this.logFallback(new Error("Primary provider returned an empty completion"));
     } catch (error) {
       if (emittedUsableOutput || isAbortFailure(error, options.signal) || isConnectionAdmissionFailure(error)) throw error;

--- a/packages/server/src/services/llm/connection-fallback-provider.ts
+++ b/packages/server/src/services/llm/connection-fallback-provider.ts
@@ -7,6 +7,11 @@ import {
 } from "../../routes/generate/generate-route-utils.js";
 import { logger } from "../../lib/logger.js";
 import { notifyGenerationFallback, type GenerationFallbackNotifier } from "../generation/fallback-notification.js";
+import {
+  isConnectionAdmissionFailure,
+  withConnectionAdmissionProvider,
+  type ConnectionAdmissionMode,
+} from "../generation/connection-admission.js";
 
 export type FallbackConnection = {
   id: string;
@@ -34,6 +39,7 @@ type ConnectionFallbackProviderArgs = {
   fallbackBaseUrl: string;
   category: "main" | "agents";
   onFallback?: GenerationFallbackNotifier;
+  admissionMode?: ConnectionAdmissionMode;
 };
 
 function isEnabled(value: unknown): boolean {
@@ -157,7 +163,7 @@ export class ConnectionFallbackProvider extends BaseLLMProvider {
       if (emittedUsableOutput || options.signal?.aborted) return result.value;
       await this.logFallback(new Error("Primary provider returned an empty completion"));
     } catch (error) {
-      if (emittedUsableOutput || isAbortFailure(error, options.signal)) throw error;
+      if (emittedUsableOutput || isAbortFailure(error, options.signal) || isConnectionAdmissionFailure(error)) throw error;
       await this.logFallback(error);
     }
     options.signal?.throwIfAborted();
@@ -171,7 +177,7 @@ export class ConnectionFallbackProvider extends BaseLLMProvider {
       if (hasUsableOutput || options.signal?.aborted) return result;
       await this.logFallback(new Error("Primary provider returned an empty completion"));
     } catch (error) {
-      if (isAbortFailure(error, options.signal)) throw error;
+      if (isAbortFailure(error, options.signal) || isConnectionAdmissionFailure(error)) throw error;
       await this.logFallback(error);
     }
     options.signal?.throwIfAborted();
@@ -190,26 +196,31 @@ export function withConnectionFallbackProvider({
   fallbackBaseUrl,
   category,
   onFallback,
+  admissionMode = { kind: "foreground" },
 }: ConnectionFallbackProviderArgs): BaseLLMProvider {
+  const admittedPrimary = withConnectionAdmissionProvider(primary, primaryConnectionId, admissionMode);
   if (
     !fallbackConnection ||
     fallbackConnection.id === primaryConnectionId ||
     !fallbackConnection.model?.trim() ||
     !fallbackBaseUrl
   ) {
-    return primary;
+    return admittedPrimary;
   }
-
-  const fallback = createLLMProvider(
-    fallbackConnection.provider,
-    fallbackBaseUrl,
-    fallbackConnection.apiKey,
-    fallbackConnection.maxContext,
-    fallbackConnection.openrouterProvider,
-    fallbackConnection.maxTokensOverride,
-    isEnabled(fallbackConnection.claudeFastMode),
-    isEnabled(fallbackConnection.treatAsLocalEndpoint),
-    fallbackConnection.defaultParameters,
+  const fallback = withConnectionAdmissionProvider(
+    createLLMProvider(
+      fallbackConnection.provider,
+      fallbackBaseUrl,
+      fallbackConnection.apiKey,
+      fallbackConnection.maxContext,
+      fallbackConnection.openrouterProvider,
+      fallbackConnection.maxTokensOverride,
+      isEnabled(fallbackConnection.claudeFastMode),
+      isEnabled(fallbackConnection.treatAsLocalEndpoint),
+      fallbackConnection.defaultParameters,
+    ),
+    fallbackConnection.id,
+    admissionMode,
   );
-  return new ConnectionFallbackProvider(primary, fallback, fallbackConnection, category, onFallback);
+  return new ConnectionFallbackProvider(admittedPrimary, fallback, fallbackConnection, category, onFallback);
 }

--- a/packages/server/src/services/llm/connection-fallback-provider.ts
+++ b/packages/server/src/services/llm/connection-fallback-provider.ts
@@ -166,8 +166,10 @@ export class ConnectionFallbackProvider extends BaseLLMProvider {
         // Drive the primary to completion if our consumer abandoned us mid-stream. The manual
         // loop above does not forward an early return the way `yield*` would, so without this
         // an admission wrapper around the primary never runs its own finally and leaks the
-        // connection's foreground slot for the lifetime of the process.
-        await generation.return(undefined);
+        // connection's foreground slot for the lifetime of the process. Swallow any cleanup
+        // rejection: the provider error the catch below inspects is what decides whether we
+        // fall back, and it must not be replaced by a teardown failure.
+        await generation.return(undefined).catch(() => undefined);
       }
       await this.logFallback(new Error("Primary provider returned an empty completion"));
     } catch (error) {

--- a/packages/server/src/services/llm/provider-registry.ts
+++ b/packages/server/src/services/llm/provider-registry.ts
@@ -9,6 +9,7 @@ import { GrokSubscriptionProvider } from "./providers/grok-subscription.provider
 import { GoogleProvider } from "./providers/google.provider.js";
 import type { BaseLLMProvider } from "./base-provider.js";
 import { withConnectionDefaultParameters } from "./connection-default-provider.js";
+import { withConnectionAdmissionProvider } from "../generation/connection-admission.js";
 
 export function normalizeCohereOpenAIBaseUrl(baseUrl: string): string {
   const trimmed = baseUrl.replace(/\/+$/, "");
@@ -48,6 +49,8 @@ export function createLLMProvider(
   treatAsLocalEndpoint?: boolean,
   /** Stored connection defaults. Custom Parameters are bound to every text request made by this provider. */
   defaultParameters?: unknown,
+  /** Configured connection ID for direct foreground calls. Fallback wrappers admit their providers separately. */
+  connectionId?: string,
 ): BaseLLMProvider {
   const normalizedMaxContext =
     typeof maxContext === "number" && Number.isFinite(maxContext) && maxContext > 0
@@ -159,5 +162,6 @@ export function createLLMProvider(
       );
       break;
   }
-  return withConnectionDefaultParameters(resolved, defaultParameters);
+  const configured = withConnectionDefaultParameters(resolved, defaultParameters);
+  return connectionId ? withConnectionAdmissionProvider(configured, connectionId) : configured;
 }

--- a/packages/server/src/services/memory-recall-embedding.ts
+++ b/packages/server/src/services/memory-recall-embedding.ts
@@ -164,6 +164,7 @@ export async function resolveMemoryRecallEmbeddingSource(
     embeddingConnection.claudeFastMode === "true",
     embeddingConnection.treatAsLocalEndpoint === "true",
     embeddingConnection.defaultParameters,
+    embeddingConnection.id,
   );
   const label = `${embeddingConnection.name || embeddingConnection.provider} (${embeddingModel})`;
 

--- a/packages/server/src/services/professor-mari/workspace-agent.service.ts
+++ b/packages/server/src/services/professor-mari/workspace-agent.service.ts
@@ -840,6 +840,7 @@ function createProviderForConnection(connection: WorkspaceConnection): BaseLLMPr
     bool(connection.claudeFastMode),
     bool(connection.treatAsLocalEndpoint),
     connection.defaultParameters,
+    connection.id,
   );
 }
 

--- a/packages/server/src/services/spotify/dj-mari-playlist.service.ts
+++ b/packages/server/src/services/spotify/dj-mari-playlist.service.ts
@@ -593,6 +593,7 @@ async function generatePlaylistPlan(args: {
     conn.claudeFastMode === "true",
     conn.treatAsLocalEndpoint === "true",
     conn.defaultParameters,
+    conn.id,
   );
 
   const userContext = {

--- a/packages/server/src/services/turn-games/turn-game-bot-runner.service.ts
+++ b/packages/server/src/services/turn-games/turn-game-bot-runner.service.ts
@@ -274,6 +274,7 @@ export async function runTurnGameBotTurns(args: RunBotTurnsArgs): Promise<void> 
           conn.claudeFastMode === "true",
           conn.treatAsLocalEndpoint === "true",
           conn.defaultParameters,
+          conn.id,
         )
       : null);
   if (!provider) {

--- a/scripts/regressions/provider-compat.regression.ts
+++ b/scripts/regressions/provider-compat.regression.ts
@@ -859,19 +859,31 @@ assert.equal(
 // RunPod connections share one API base URL and pick the physical endpoint with a separate
 // id, so the key has to carry that id or two independent endpoints contend for one slot.
 assert.notEqual(
-  imageAdmissionKey("https://api.runpod.ai/v2", "abc123"),
-  imageAdmissionKey("https://api.runpod.ai/v2", "def456"),
+  imageAdmissionKey("https://api.runpod.ai/v2", "runpod_comfyui", "abc123"),
+  imageAdmissionKey("https://api.runpod.ai/v2", "runpod_comfyui", "def456"),
   "RunPod endpoints sharing a base URL must not share an admission key",
 );
 assert.equal(
-  imageAdmissionKey("https://api.runpod.ai/v2", "abc123"),
-  imageAdmissionKey("https://api.runpod.ai/v2", "  abc123  "),
+  imageAdmissionKey("https://api.runpod.ai/v2", "runpod_comfyui", "abc123"),
+  imageAdmissionKey("https://api.runpod.ai/v2", "runpod_comfyui", "  abc123  "),
   "endpoint ids must be compared after trimming",
 );
 assert.equal(
-  imageAdmissionKey("http://127.0.0.1:8188"),
+  imageAdmissionKey("http://127.0.0.1:8188", "comfyui"),
   "http://127.0.0.1:8188",
   "backends whose base URL is the physical target keep the bare URL as their key",
+);
+// A stale endpoint id on an imported/copied non-RunPod connection must not split one
+// physical endpoint into two admission slots.
+assert.equal(
+  imageAdmissionKey("http://127.0.0.1:8188", "comfyui", "abc123"),
+  imageAdmissionKey("http://127.0.0.1:8188", "comfyui"),
+  "non-RunPod backends must ignore a leftover endpoint id",
+);
+assert.equal(
+  imageAdmissionKey("http://127.0.0.1:7860", "automatic1111", "def456"),
+  "http://127.0.0.1:7860",
+  "A1111 admission keys stay bare regardless of endpoint id",
 );
 
 let backgroundAttempts = 0;

--- a/scripts/regressions/provider-compat.regression.ts
+++ b/scripts/regressions/provider-compat.regression.ts
@@ -54,6 +54,12 @@ import {
 } from "../../packages/server/src/services/generation/fallback-notification.js";
 import { resolveStoredChatOptions } from "../../packages/server/src/services/generation/generation-parameters.js";
 import { resolveMainGenerationToolChoice } from "../../packages/server/src/services/generation/tool-resolution-runtime.js";
+import {
+  ConnectionAttemptRejectedError,
+  resetConnectionAdmissionForTests,
+  tryBackgroundConnection,
+  withConnectionAdmissionProvider,
+} from "../../packages/server/src/services/generation/connection-admission.js";
 
 class RegressionProvider extends BaseLLMProvider {
   calls = 0;
@@ -759,6 +765,81 @@ const fallbackConnection: FallbackConnection = {
     },
   }),
 };
+
+resetConnectionAdmissionForTests();
+let releasePrimaryCall!: () => void;
+const primaryCallHeld = new Promise<void>((resolve) => {
+  releasePrimaryCall = resolve;
+});
+class HeldProvider extends BaseLLMProvider {
+  started!: () => void;
+  readonly startedPromise = new Promise<void>((resolve) => {
+    this.started = resolve;
+  });
+
+  constructor(private readonly held: Promise<void>, private readonly failure?: Error) {
+    super("", "");
+  }
+
+  async *chat(): AsyncGenerator<string, LLMUsage | void, unknown> {
+    this.started();
+    await this.held;
+    if (this.failure) throw this.failure;
+    yield "held response";
+  }
+}
+const heldPrimary = new HeldProvider(primaryCallHeld, new Error("primary unavailable"));
+const admittedPrimary = withConnectionAdmissionProvider(heldPrimary, "primary-connection");
+const primaryRun = collectProviderOutput(admittedPrimary, { model: "primary-model" });
+await heldPrimary.startedPromise;
+assert.equal(tryBackgroundConnection("primary-connection", new Date()).acquired, false);
+const unrelatedFallbackAdmission = tryBackgroundConnection("fallback-connection", new Date());
+assert.equal(unrelatedFallbackAdmission.acquired, true, "primary work must not occupy the fallback connection");
+if (unrelatedFallbackAdmission.acquired) unrelatedFallbackAdmission.release();
+releasePrimaryCall();
+await assert.rejects(primaryRun, /primary unavailable/);
+
+let releaseFallbackCall!: () => void;
+const fallbackCallHeld = new Promise<void>((resolve) => {
+  releaseFallbackCall = resolve;
+});
+const heldFallback = new HeldProvider(fallbackCallHeld);
+const admittedFallback = withConnectionAdmissionProvider(heldFallback, "fallback-connection");
+const fallbackRun = collectProviderOutput(admittedFallback, { model: "fallback-model" });
+await heldFallback.startedPromise;
+assert.equal(tryBackgroundConnection("fallback-connection", new Date()).acquired, false);
+const unrelatedPrimaryAdmission = tryBackgroundConnection("other-primary-connection", new Date());
+assert.equal(unrelatedPrimaryAdmission.acquired, true, "fallback work must not occupy a primary connection");
+if (unrelatedPrimaryAdmission.acquired) unrelatedPrimaryAdmission.release();
+releaseFallbackCall();
+assert.equal(await fallbackRun, "held response");
+
+let backgroundAttempts = 0;
+const backgroundOutcomes: string[] = [];
+const admittedRepeated = withConnectionAdmissionProvider(new RegressionProvider(["ok"]), "background-connection", {
+  kind: "background",
+  beforeAttempt: () => {
+    backgroundAttempts += 1;
+    return (outcome) => {
+      backgroundOutcomes.push(outcome);
+    };
+  },
+});
+await admittedRepeated.chatComplete([{ role: "user", content: "first" }], { model: "model" });
+await admittedRepeated.chatComplete([{ role: "user", content: "correction" }], { model: "model" });
+assert.equal(backgroundAttempts, 2, "each physical correction/retry call must claim separately");
+assert.deepEqual(backgroundOutcomes, ["completed", "completed"]);
+
+const rejectedAttempt = withConnectionAdmissionProvider(new RegressionProvider(["unused"]), "rejected-connection", {
+  kind: "background",
+  beforeAttempt: () => {
+    throw new Error("attempt budget exhausted");
+  },
+});
+await assert.rejects(
+  rejectedAttempt.chatComplete([{ role: "user", content: "test" }], { model: "model" }),
+  (error) => error instanceof ConnectionAttemptRejectedError && error.cause instanceof Error && /budget exhausted/.test(error.cause.message),
+);
 const primaryFailure = new RegressionProvider([], new Error("primary unavailable"));
 const successfulFallback = new RegressionProvider(["fallback response"]);
 const fallbackProvider = new ConnectionFallbackProvider(primaryFailure, successfulFallback, fallbackConnection, "main");

--- a/scripts/regressions/provider-compat.regression.ts
+++ b/scripts/regressions/provider-compat.regression.ts
@@ -55,6 +55,7 @@ import {
 import { resolveStoredChatOptions } from "../../packages/server/src/services/generation/generation-parameters.js";
 import { resolveMainGenerationToolChoice } from "../../packages/server/src/services/generation/tool-resolution-runtime.js";
 import {
+  BACKGROUND_CONNECTION_IDLE_MS,
   ConnectionAttemptRejectedError,
   resetConnectionAdmissionForTests,
   tryBackgroundConnection,
@@ -813,6 +814,34 @@ assert.equal(unrelatedPrimaryAdmission.acquired, true, "fallback work must not o
 if (unrelatedPrimaryAdmission.acquired) unrelatedPrimaryAdmission.release();
 releaseFallbackCall();
 assert.equal(await fallbackRun, "held response");
+
+// A consumer that stops reading mid-stream must not strand the primary connection's
+// foreground slot: the fallback provider drains the primary manually, so an early return
+// has to be forwarded explicitly or background work is locked out until a restart.
+resetConnectionAdmissionForTests();
+class EndlessProvider extends BaseLLMProvider {
+  constructor() {
+    super("", "");
+  }
+
+  async *chat(): AsyncGenerator<string, LLMUsage | void, unknown> {
+    while (true) yield "chunk";
+  }
+}
+const abandonedProvider = new ConnectionFallbackProvider(
+  withConnectionAdmissionProvider(new EndlessProvider(), "abandoned-connection"),
+  new RegressionProvider(["unused fallback"]),
+  fallbackConnection,
+  "main",
+);
+const abandonedStream = abandonedProvider.chat([{ role: "user", content: "hi" }], { model: "abandoned-model" });
+assert.equal((await abandonedStream.next()).value, "chunk");
+await abandonedStream.return(undefined);
+assert.equal(
+  tryBackgroundConnection("abandoned-connection", new Date(Date.now() + BACKGROUND_CONNECTION_IDLE_MS)).acquired,
+  true,
+  "abandoning the stream must release the primary connection's foreground slot",
+);
 
 let backgroundAttempts = 0;
 const backgroundOutcomes: string[] = [];

--- a/scripts/regressions/provider-compat.regression.ts
+++ b/scripts/regressions/provider-compat.regression.ts
@@ -799,6 +799,12 @@ assert.equal(unrelatedFallbackAdmission.acquired, true, "primary work must not o
 if (unrelatedFallbackAdmission.acquired) unrelatedFallbackAdmission.release();
 releasePrimaryCall();
 await assert.rejects(primaryRun, /primary unavailable/);
+const releasedPrimaryAdmission = tryBackgroundConnection(
+  "primary-connection",
+  new Date(Date.now() + BACKGROUND_CONNECTION_IDLE_MS),
+);
+assert.equal(releasedPrimaryAdmission.acquired, true, "a failed primary call must release its foreground slot");
+if (releasedPrimaryAdmission.acquired) releasedPrimaryAdmission.release();
 
 let releaseFallbackCall!: () => void;
 const fallbackCallHeld = new Promise<void>((resolve) => {
@@ -814,6 +820,12 @@ assert.equal(unrelatedPrimaryAdmission.acquired, true, "fallback work must not o
 if (unrelatedPrimaryAdmission.acquired) unrelatedPrimaryAdmission.release();
 releaseFallbackCall();
 assert.equal(await fallbackRun, "held response");
+const releasedFallbackAdmission = tryBackgroundConnection(
+  "fallback-connection",
+  new Date(Date.now() + BACKGROUND_CONNECTION_IDLE_MS),
+);
+assert.equal(releasedFallbackAdmission.acquired, true, "a completed call must release its foreground slot");
+if (releasedFallbackAdmission.acquired) releasedFallbackAdmission.release();
 
 // A consumer that stops reading mid-stream must not strand the primary connection's
 // foreground slot: the fallback provider drains the primary manually, so an early return

--- a/scripts/regressions/provider-compat.regression.ts
+++ b/scripts/regressions/provider-compat.regression.ts
@@ -54,6 +54,7 @@ import {
 } from "../../packages/server/src/services/generation/fallback-notification.js";
 import { resolveStoredChatOptions } from "../../packages/server/src/services/generation/generation-parameters.js";
 import { resolveMainGenerationToolChoice } from "../../packages/server/src/services/generation/tool-resolution-runtime.js";
+import { imageAdmissionKey } from "../../packages/server/src/services/image/image-generation.js";
 import {
   BACKGROUND_CONNECTION_IDLE_MS,
   ConnectionAttemptRejectedError,
@@ -853,6 +854,24 @@ assert.equal(
   tryBackgroundConnection("abandoned-connection", new Date(Date.now() + BACKGROUND_CONNECTION_IDLE_MS)).acquired,
   true,
   "abandoning the stream must release the primary connection's foreground slot",
+);
+
+// RunPod connections share one API base URL and pick the physical endpoint with a separate
+// id, so the key has to carry that id or two independent endpoints contend for one slot.
+assert.notEqual(
+  imageAdmissionKey("https://api.runpod.ai/v2", "abc123"),
+  imageAdmissionKey("https://api.runpod.ai/v2", "def456"),
+  "RunPod endpoints sharing a base URL must not share an admission key",
+);
+assert.equal(
+  imageAdmissionKey("https://api.runpod.ai/v2", "abc123"),
+  imageAdmissionKey("https://api.runpod.ai/v2", "  abc123  "),
+  "endpoint ids must be compared after trimming",
+);
+assert.equal(
+  imageAdmissionKey("http://127.0.0.1:8188"),
+  "http://127.0.0.1:8188",
+  "backends whose base URL is the physical target keep the bare URL as their key",
 );
 
 let backgroundAttempts = 0;


### PR DESCRIPTION
## Why

NoodleR posts and images generate in the background, on the same API connection the user is actively chatting on. Without a gate, a scheduled creator post fires mid-roleplay and the user queues behind their own bot, or burns rate limit they wanted for themselves.

This adds a shared admission service so background work yields to foreground work: it is admitted only when nothing is running in the foreground on that connection and the last foreground request finished at least 30s ago. Foreground work never asks permission.

Admission failures are typed distinctly (`isConnectionAdmissionFailure`) so the fallback chain can tell "connection busy" apart from "provider failed" — otherwise a busy connection would look like an outage and trigger a pointless failover to the backup model.

## Relationship to #4503

Standalone against `staging` — not a stack. This PR is the connection-admission
work only, and it stands on its own.

The rest of what was originally split across `stack/2-docs` and `stack/3-server`
now lives in #4503 (NoodleR Slice 8f), which is also based on `staging` and is
reviewed independently.

#4503's branch does contain this PR's commits, because the Slice 8f code is
built on the admission service. **Merge this PR first** — once it lands, these
changes drop out of #4503's diff and what remains there is the Slice 8f work.

## Notes

- No linked issue exists for this work; one should be opened before this is taken out of draft.
- `states` is a module-level map keyed per connection id and per image base URL, and is never pruned. Bounded by configured connections, so not a leak that matters in practice, but it is an unmarked deliberate call.

## Test plan

- [ ] `pnpm check`
- [ ] `pnpm regression:providers`
- [ ] Manually verify in the app: start a long foreground generation, confirm a scheduled NoodleR post does not fire until 30s after it finishes
- [ ] Manually verify a genuinely failing primary provider still falls back to the backup model (admission errors must not suppress real failover)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added connection-aware controls for language model, embedding, and image-generation requests.
  * Prevented conflicting background requests during active foreground work.
  * Improved handling of shared image-generation endpoints and interrupted streaming requests.

* **Bug Fixes**
  * Prevented unnecessary fallback retries after connection admission failures.
  * Ensured connection activity is released after completed or interrupted requests.

* **Tests**
  * Added coverage for connection exclusivity, fallback behavior, stream abandonment, and background request handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
