### PR TITLE
Fix Storyboard catalog metadata on staging

### DIFF
--- a/packages/client/src/components/agents/AgentCatalogView.tsx
+++ b/packages/client/src/components/agents/AgentCatalogView.tsx
@@ -65,6 +65,7 @@ const OFFICIAL_PACKAGE_MODES: Readonly<Record<string, readonly CatalogMode[]>> =
   "echo-chamber": ["roleplay"],
   haptic: ["conversation", "roleplay"],
   illustrator: ["conversation", "roleplay", "game"],
+  storyboard: ["roleplay", "game"],
   html: ["roleplay"],
   "lorebook-keeper": ["roleplay", "game"],
   spotify: ["conversation", "roleplay", "game"],

--- a/packages/server/src/services/capability-packages/package-manager.service.ts
+++ b/packages/server/src/services/capability-packages/package-manager.service.ts
@@ -42,6 +42,9 @@ function officialCatalogRoot(branch: OfficialAgentBranch): string {
 function officialArtifactRoot(branch: OfficialAgentBranch): string {
   return `${OFFICIAL_AGENT_RAW_ROOT}/${branch}/artifacts`;
 }
+function officialArtworkRoot(branch: OfficialAgentBranch): string {
+  return `${OFFICIAL_AGENT_RAW_ROOT}/${branch}/artwork/agent-covers`;
+}
 const ENGINE_RELEASE_VERSION_PATTERN = /^v?(\d+)\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$/u;
 export function resolveCapabilityCatalogUrl(
   engineVersion: string = APP_VERSION,
@@ -307,6 +310,15 @@ export function resolveCapabilityPackageArtifactUrl(
   return `${officialArtifactRoot(branch)}/${entry.manifest.id}-${entry.manifest.version}.zip`;
 }
 
+export function resolveCapabilityPackageIconUrl(
+  entry: CapabilityCatalogPackage,
+  catalogUrl = CATALOG_URL,
+): string | undefined {
+  const branch = getOfficialAgentBranchFromCatalogUrl(catalogUrl);
+  if (!branch || !entry.iconUrl) return entry.iconUrl;
+  return `${officialArtworkRoot(branch)}/${entry.manifest.id}.png`;
+}
+
 async function readInstalledAgentDefinitions(installed: InstalledCapabilityPackage) {
   const entrypoint = installed.manifest.entrypoints.agents;
   if (!entrypoint) return [];
@@ -493,6 +505,7 @@ export const capabilityPackageManager = {
         .filter((entry) => !NON_DOWNLOADABLE_CORE_PACKAGE_IDS.has(entry.manifest.id))
         .map((entry) => ({
           ...entry,
+          iconUrl: resolveCapabilityPackageIconUrl(entry, CATALOG_URL),
           artifact: {
             ...entry.artifact,
             url: resolveCapabilityPackageArtifactUrl(entry, CATALOG_URL),

--- a/packages/server/src/services/capability-packages/package-manager.service.ts
+++ b/packages/server/src/services/capability-packages/package-manager.service.ts
@@ -477,8 +477,8 @@ async function installCatalogPackage(entry: CapabilityCatalogPackage, activateDu
 }
 
 export const capabilityPackageManager = {
-  async catalog(): Promise<CapabilityCatalog> {
-    const response = await safeFetch(CATALOG_URL, {
+  async catalog(fetchCatalog: typeof safeFetch = safeFetch): Promise<CapabilityCatalog> {
+    const response = await fetchCatalog(CATALOG_URL, {
       policy: { allowedProtocols: ["https:"] },
       maxResponseBytes: 2 * 1024 * 1024,
       allowedContentTypes: ["application/json", "text/plain"],

--- a/scripts/regressions/agent-catalog-kind-badges.regression.ts
+++ b/scripts/regressions/agent-catalog-kind-badges.regression.ts
@@ -1,9 +1,24 @@
 import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
 import { isAgentCatalogKindBadgeVisible } from "../../packages/client/src/lib/agent-catalog-kind-badges.js";
+
+const repositoryRoot = join(dirname(fileURLToPath(import.meta.url)), "../..");
 
 assert.equal(isAgentCatalogKindBadgeVisible("agent"), true);
 assert.equal(isAgentCatalogKindBadgeVisible("conversation-calls"), true);
 assert.equal(isAgentCatalogKindBadgeVisible("maps"), false);
 assert.equal(isAgentCatalogKindBadgeVisible("turn-game"), false);
+
+const catalogViewSource = readFileSync(
+  join(repositoryRoot, "packages/client/src/components/agents/AgentCatalogView.tsx"),
+  "utf8",
+);
+assert.match(
+  catalogViewSource,
+  /storyboard:\s*\["roleplay",\s*"game"\]/u,
+  "Storyboard must advertise its Roleplay and Game catalog badges",
+);
 
 console.info("Agent catalog kind badge regressions passed.");

--- a/scripts/regressions/capability-package-lifecycle.regression.ts
+++ b/scripts/regressions/capability-package-lifecycle.regression.ts
@@ -7,6 +7,7 @@ import { fileURLToPath } from "node:url";
 const repositoryRoot = join(dirname(fileURLToPath(import.meta.url)), "../..");
 const dataDir = mkdtempSync(join(tmpdir(), "marinara-capability-lifecycle-"));
 process.env.DATA_DIR = dataDir;
+process.env.MARINARA_GIT_BRANCH = "staging";
 
 const packagesRoot = join(dataDir, "capability-packages");
 const registryPath = join(packagesRoot, "installed.json");
@@ -386,6 +387,29 @@ try {
   };
   const officialCatalogUrl = resolveCapabilityCatalogUrl("development", "", "main");
   const stagingCatalogUrl = resolveCapabilityCatalogUrl("development", "", "staging");
+  const activeCatalogUrl = resolveCapabilityCatalogUrl();
+  let requestedCatalogUrl: string | URL | undefined;
+  const normalizedCatalog = await capabilityPackageManager.catalog(async (url) => {
+    requestedCatalogUrl = url;
+    return new Response(
+      JSON.stringify({
+        schemaVersion: 1,
+        generatedAt: "2026-08-01T00:00:00.000Z",
+        packages: [canonicalArtifactEntry],
+      }),
+      { status: 200, headers: { "content-type": "application/json" } },
+    );
+  });
+  assert.equal(
+    requestedCatalogUrl,
+    activeCatalogUrl,
+    "The package manager must request the catalog URL selected for the current Engine channel",
+  );
+  assert.equal(
+    normalizedCatalog.packages[0]?.iconUrl,
+    "https://raw.githubusercontent.com/Pasta-Devs/Marinara-Agents/staging/artwork/agent-covers/legacy.png",
+    "The catalog response must expose artwork normalized through the active catalog URL",
+  );
   assert.equal(getCapabilityPackageArtifactSourceIssue(canonicalArtifactEntry, officialCatalogUrl), null);
   assert.equal(
     getCapabilityPackageArtifactSourceIssue(canonicalArtifactEntry, stagingCatalogUrl),

--- a/scripts/regressions/capability-package-lifecycle.regression.ts
+++ b/scripts/regressions/capability-package-lifecycle.regression.ts
@@ -183,6 +183,7 @@ try {
     resolveOfficialAgentBranch,
     resolveCapabilityCatalogUrl,
     resolveCapabilityPackageArtifactUrl,
+    resolveCapabilityPackageIconUrl,
   } = await import(
     "../../packages/server/src/services/capability-packages/package-manager.service.js"
   );
@@ -381,6 +382,7 @@ try {
       sha256: "1".repeat(64),
       bytes: 1,
     },
+    iconUrl: "https://raw.githubusercontent.com/Pasta-Devs/Marinara-Agents/main/artwork/agent-covers/legacy.png",
   };
   const officialCatalogUrl = resolveCapabilityCatalogUrl("development", "", "main");
   const stagingCatalogUrl = resolveCapabilityCatalogUrl("development", "", "staging");
@@ -394,6 +396,11 @@ try {
     resolveCapabilityPackageArtifactUrl(canonicalArtifactEntry, stagingCatalogUrl),
     "https://raw.githubusercontent.com/Pasta-Devs/Marinara-Agents/staging/artifacts/legacy-1.0.0.zip",
     "Engine staging must download official artifacts from Marinara-Agents staging even when generated metadata remains stable",
+  );
+  assert.equal(
+    resolveCapabilityPackageIconUrl(canonicalArtifactEntry, stagingCatalogUrl),
+    "https://raw.githubusercontent.com/Pasta-Devs/Marinara-Agents/staging/artwork/agent-covers/legacy.png",
+    "Engine staging must load official artwork from Marinara-Agents staging even when generated metadata remains stable",
   );
   assert.match(
     getCapabilityPackageArtifactSourceIssue(
@@ -427,6 +434,14 @@ try {
     ),
     "https://packages.example/legacy.zip",
     "Explicit custom catalogs must retain their configured artifact URLs",
+  );
+  assert.equal(
+    resolveCapabilityPackageIconUrl(
+      { ...canonicalArtifactEntry, iconUrl: "https://packages.example/legacy.png" },
+      "https://catalog.example.test/custom.json",
+    ),
+    "https://packages.example/legacy.png",
+    "Explicit custom catalogs must retain their configured artwork URLs",
   );
   const {
     buildHierarchicalMapsSelectionCorrectionPatch,


### PR DESCRIPTION
> [!IMPORTANT]
> Contributions target `staging`. Only `SpicyMarinara` may promote this repository's `staging` branch or a same-repository `hotfix/*` branch to `main`.
> Outside and first-time contributors also require an approving review from `SpicyMarinara`.

## Linked issue

Closes #4428

## Why this change

- Storyboard already supports Roleplay and Game and has staging cover artwork, but the host catalog omitted its mode-map entry and resolved official icon metadata without following the active Agent branch.

## What changed

- Add Storyboard's Roleplay and Game catalog badges.
- Resolve official package artwork from the same `main` or `staging` channel as the active official catalog.
- Preserve custom catalog artwork URLs unchanged.
- Add focused regressions for the badges, channel-aware icon URL, and the complete catalog normalization path.

## Validation

- [ ] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed `CONTRIBUTING.md`

Additional automated proof completed on head commit `6e4751750`:

- `pnpm --filter @marinara-engine/server exec tsx ../../scripts/regressions/agent-catalog-kind-badges.regression.ts`
- `pnpm --filter @marinara-engine/shared build`
- `pnpm --filter @marinara-engine/server exec tsx ../../scripts/regressions/capability-package-lifecycle.regression.ts`
- `pnpm check`
- `git diff --check`

### Manual verification notes

- Browser click-through was not performed in this automated pass.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Translated docs on the `docs-i18n` branch updated to match, or a `[docs-i18n] <paths>` follow-up issue opened
- [ ] Version/release files updated (only if this PR includes a version bump)

Stable Storyboard publication is atomic in [Marinara-Agents #173](https://github.com/Pasta-Devs/Marinara-Agents/pull/173): that `staging` → `main` promotion includes both the Storyboard catalog entry and `artwork/agent-covers/storyboard.png`. Before that promotion, the `main` catalog does not contain Storyboard.

## UI evidence (if applicable)

No screenshot attached; the focused regression asserts Storyboard's exact Roleplay/Game mode mapping.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the Storyboard package to the official catalog with Roleplay and Game badges.
  * Added canonical artwork for agent covers in official catalogs.
  * Official staging catalogs now display artwork from the matching staging branch.

* **Bug Fixes**
  * Custom catalogs continue to preserve their configured artwork URLs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
