### PR TITLE
Fix dev startup after dependency updates

### DIFF
--- a/scripts/check-workspace-install.mjs
+++ b/scripts/check-workspace-install.mjs
@@ -1,50 +1,88 @@
 import { createRequire } from "node:module";
 import { dirname, join, resolve } from "node:path";
-import { existsSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
+import { pathToFileURL } from "node:url";
 
-const root = process.cwd();
-const supportedOnnxTuples = new Set(["darwin/arm64", "darwin/x64", "linux/arm64", "linux/x64", "win32/arm64", "win32/x64"]);
+const supportedOnnxTuples = new Set([
+  "darwin/arm64",
+  "darwin/x64",
+  "linux/arm64",
+  "linux/x64",
+  "win32/arm64",
+  "win32/x64",
+]);
 const checks = [
   { workspace: ".", packageName: "esbuild" },
   { workspace: "packages/server", packageName: "pino" },
   { workspace: "packages/client", packageName: "react" },
 ];
 
-const missing = [];
-
-for (const check of checks) {
-  const requireFromWorkspace = createRequire(resolve(root, check.workspace, "package.json"));
+export function workspaceLockfileMatches(root) {
   try {
-    requireFromWorkspace.resolve(check.packageName);
+    const expectedLockfile = readFileSync(join(root, "pnpm-lock.yaml"));
+    const installedLockfile = readFileSync(join(root, "node_modules", ".pnpm", "lock.yaml"));
+    return expectedLockfile.equals(installedLockfile);
   } catch {
-    missing.push(`${check.packageName} from ${check.workspace}`);
+    return false;
   }
 }
 
-const onnxTuple = `${process.platform}/${process.arch}`;
-if (supportedOnnxTuples.has(onnxTuple)) {
-  const requireFromServer = createRequire(resolve(root, "packages/server/package.json"));
-  try {
-    const packageDir = dirname(requireFromServer.resolve("onnxruntime-node/package.json"));
-    const bindingPath = join(packageDir, "bin", "napi-v6", process.platform, process.arch, "onnxruntime_binding.node");
-    if (!existsSync(bindingPath)) {
-      missing.push(`onnxruntime-node native binding for ${onnxTuple}`);
+export function getWorkspaceInstallProblems({
+  root = process.cwd(),
+  platform = process.platform,
+  arch = process.arch,
+} = {}) {
+  const missing = [];
+
+  if (!workspaceLockfileMatches(root)) {
+    missing.push("workspace dependencies matching pnpm-lock.yaml");
+  }
+
+  for (const check of checks) {
+    const requireFromWorkspace = createRequire(resolve(root, check.workspace, "package.json"));
+    try {
+      requireFromWorkspace.resolve(check.packageName);
+    } catch {
+      missing.push(`${check.packageName} from ${check.workspace}`);
     }
-  } catch {
-    missing.push(`onnxruntime-node from packages/server`);
+  }
+
+  const onnxTuple = `${platform}/${arch}`;
+  if (supportedOnnxTuples.has(onnxTuple)) {
+    const requireFromServer = createRequire(resolve(root, "packages/server/package.json"));
+    try {
+      const packageDir = dirname(requireFromServer.resolve("onnxruntime-node/package.json"));
+      const bindingPath = join(packageDir, "bin", "napi-v6", platform, arch, "onnxruntime_binding.node");
+      if (!existsSync(bindingPath)) {
+        missing.push(`onnxruntime-node native binding for ${onnxTuple}`);
+      }
+    } catch {
+      missing.push("onnxruntime-node from packages/server");
+    }
+  }
+
+  if (platform === "android") {
+    const requireFromServer = createRequire(resolve(root, "packages/server/package.json"));
+    try {
+      requireFromServer("sharp");
+    } catch {
+      missing.push("sharp WebAssembly runtime for android");
+    }
+  }
+
+  return missing;
+}
+
+function main() {
+  const missing = getWorkspaceInstallProblems();
+  if (missing.length > 0) {
+    console.error(
+      `Incomplete Marinara dependency install. Missing: ${missing.join(", ")}. Run \`pnpm install --frozen-lockfile\` from the repository root.`,
+    );
+    process.exitCode = 1;
   }
 }
 
-if (process.platform === "android") {
-  const requireFromServer = createRequire(resolve(root, "packages/server/package.json"));
-  try {
-    requireFromServer("sharp");
-  } catch {
-    missing.push("sharp WebAssembly runtime for android");
-  }
-}
-
-if (missing.length > 0) {
-  console.error(`Incomplete Marinara dependency install. Missing: ${missing.join(", ")}`);
-  process.exit(1);
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main();
 }

--- a/scripts/dev.mjs
+++ b/scripts/dev.mjs
@@ -1,5 +1,6 @@
 import { spawn, spawnSync } from "node:child_process";
-import { basename, resolve } from "node:path";
+import { basename } from "node:path";
+import { getWorkspaceInstallProblems } from "./check-workspace-install.mjs";
 import { resolveDevSharedBuildScript } from "./dev-shared-build.mjs";
 
 function parseIntegerEnv(name, fallback) {
@@ -13,7 +14,6 @@ const SERVER_PORT = parseIntegerEnv("PORT", 7860);
 const SERVER_HEALTH_URL = `http://127.0.0.1:${SERVER_PORT}/api/health`;
 const HEALTH_TIMEOUT_MS = parseIntegerEnv("DEV_SERVER_READY_TIMEOUT_MS", 120_000);
 const SHARED_BUILD_SCRIPT = resolveDevSharedBuildScript();
-const WORKSPACE_INSTALL_CHECK = resolve("scripts/check-workspace-install.mjs");
 
 const pnpmCliPath = process.env.npm_execpath;
 const npmUserAgent = process.env.npm_config_user_agent ?? "";
@@ -46,14 +46,6 @@ function runPnpm(args) {
       reject(new Error(`pnpm ${args.join(" ")} exited with ${signal ?? code}`));
     });
   });
-}
-
-function workspaceInstallIsCurrent() {
-  const result = spawnSync(process.execPath, [WORKSPACE_INSTALL_CHECK], {
-    stdio: "ignore",
-    windowsHide: true,
-  });
-  return result.status === 0;
 }
 
 function stopChildren(signal = "SIGTERM") {
@@ -97,11 +89,15 @@ process.on("SIGINT", () => stopChildren("SIGINT"));
 process.on("SIGTERM", () => stopChildren("SIGTERM"));
 
 try {
-  if (!workspaceInstallIsCurrent()) {
-    console.log("[dev] Workspace dependencies are missing or stale; synchronizing from pnpm-lock.yaml...");
+  const installProblems = getWorkspaceInstallProblems();
+  if (installProblems.length > 0) {
+    console.log(`[dev] Workspace dependencies are missing or stale: ${installProblems.join(", ")}. Synchronizing...`);
     await runPnpm(["install", "--frozen-lockfile"]);
-    if (!workspaceInstallIsCurrent()) {
-      throw new Error("Workspace dependency validation still fails after pnpm install");
+    const remainingProblems = getWorkspaceInstallProblems();
+    if (remainingProblems.length > 0) {
+      throw new Error(
+        `Workspace dependency validation still fails after pnpm install. Missing: ${remainingProblems.join(", ")}`,
+      );
     }
   }
 

--- a/scripts/dev.mjs
+++ b/scripts/dev.mjs
@@ -1,5 +1,5 @@
 import { spawn, spawnSync } from "node:child_process";
-import { basename } from "node:path";
+import { basename, resolve } from "node:path";
 import { resolveDevSharedBuildScript } from "./dev-shared-build.mjs";
 
 function parseIntegerEnv(name, fallback) {
@@ -13,6 +13,7 @@ const SERVER_PORT = parseIntegerEnv("PORT", 7860);
 const SERVER_HEALTH_URL = `http://127.0.0.1:${SERVER_PORT}/api/health`;
 const HEALTH_TIMEOUT_MS = parseIntegerEnv("DEV_SERVER_READY_TIMEOUT_MS", 120_000);
 const SHARED_BUILD_SCRIPT = resolveDevSharedBuildScript();
+const WORKSPACE_INSTALL_CHECK = resolve("scripts/check-workspace-install.mjs");
 
 const pnpmCliPath = process.env.npm_execpath;
 const npmUserAgent = process.env.npm_config_user_agent ?? "";
@@ -45,6 +46,14 @@ function runPnpm(args) {
       reject(new Error(`pnpm ${args.join(" ")} exited with ${signal ?? code}`));
     });
   });
+}
+
+function workspaceInstallIsCurrent() {
+  const result = spawnSync(process.execPath, [WORKSPACE_INSTALL_CHECK], {
+    stdio: "ignore",
+    windowsHide: true,
+  });
+  return result.status === 0;
 }
 
 function stopChildren(signal = "SIGTERM") {
@@ -88,6 +97,14 @@ process.on("SIGINT", () => stopChildren("SIGINT"));
 process.on("SIGTERM", () => stopChildren("SIGTERM"));
 
 try {
+  if (!workspaceInstallIsCurrent()) {
+    console.log("[dev] Workspace dependencies are missing or stale; synchronizing from pnpm-lock.yaml...");
+    await runPnpm(["install", "--frozen-lockfile"]);
+    if (!workspaceInstallIsCurrent()) {
+      throw new Error("Workspace dependency validation still fails after pnpm install");
+    }
+  }
+
   if (process.env.DEV_SKIP_SHARED_BUILD !== "true") {
     await runPnpm(["--filter", "@marinara-engine/shared", SHARED_BUILD_SCRIPT]);
   }

--- a/scripts/regressions/launcher-update.regression.mjs
+++ b/scripts/regressions/launcher-update.regression.mjs
@@ -14,6 +14,7 @@ import {
   restoreLauncherDataIfMissing,
   snapshotLauncherData,
 } from "../protect-launcher-data.mjs";
+import { workspaceLockfileMatches } from "../check-workspace-install.mjs";
 
 const repositoryRoot = resolve(dirname(fileURLToPath(import.meta.url)), "../..");
 const releaseUrl = "https://github.com/Pasta-Devs/Marinara-Engine/releases/tag/v2.3.4";
@@ -94,9 +95,25 @@ for (const launcherName of ["start.sh", "start-termux.sh", "start.bat"]) {
   assert.match(launcherSource, /protect-launcher-data\.mjs restore-if-missing/u);
 }
 
+const devSource = readFileSync(join(repositoryRoot, "scripts/dev.mjs"), "utf8");
+assert.match(devSource, /check-workspace-install\.mjs/u);
+assert.match(devSource, /\["install", "--frozen-lockfile"\]/u);
+
 const fixtureRoot = mkdtempSync(join(tmpdir(), "marinara-launcher-data-"));
 const fixtureBackupRoot = resolve(fixtureRoot, "..", `${basename(fixtureRoot)}-backups`);
 try {
+  const installFixtureRoot = join(fixtureRoot, "install-check");
+  const installedLockfileDir = join(installFixtureRoot, "node_modules", ".pnpm");
+  mkdirSync(installedLockfileDir, { recursive: true });
+  assert.equal(workspaceLockfileMatches(installFixtureRoot), false);
+
+  writeFileSync(join(installFixtureRoot, "pnpm-lock.yaml"), "lockfileVersion: '9.0'\n");
+  writeFileSync(join(installedLockfileDir, "lock.yaml"), "lockfileVersion: '9.0'\n");
+  assert.equal(workspaceLockfileMatches(installFixtureRoot), true);
+
+  writeFileSync(join(installedLockfileDir, "lock.yaml"), "lockfileVersion: '8.0'\n");
+  assert.equal(workspaceLockfileMatches(installFixtureRoot), false);
+
   const defaultDataDir = await resolveLauncherDataDir({ root: fixtureRoot, env: {} });
   mkdirSync(defaultDataDir, { recursive: true });
   writeFileSync(join(defaultDataDir, "characters.json"), '{"name":"Preserved"}\n');


### PR DESCRIPTION
> [!IMPORTANT]
> Contributions target `staging`. Only `SpicyMarinara` may promote this repository's `staging` branch or a same-repository `hotfix/*` branch to `main`.
> Outside and first-time contributors also require an approving review from `SpicyMarinara`.

## Linked issue

Closes #4436

## Why this change

- A source checkout could retain pnpm's previous installed dependency graph after `pnpm-lock.yaml` changed. Current server source then imported Fastify 5.11's `LogController` from a stale Fastify 5.8.5 link and crashed before startup.
- Fresh installs and automatic launcher updates were safe, but manual source updates followed by `npm run dev` or `pnpm dev` had a sharp edge.

## What changed

- Compare pnpm's installed lock snapshot with the repository `pnpm-lock.yaml` as part of workspace install validation.
- Make the development entrypoint run `pnpm install --frozen-lockfile` only when that validation reports missing or stale dependencies, then validate again before startup.
- Add regression coverage for absent, matching, and stale installed lock snapshots and guard the dev synchronization path.

## Validation

- [ ] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed `CONTRIBUTING.md`

Completed local evidence:

- `pnpm check`
- `node scripts/check-workspace-install.mjs`
- `node scripts/regressions/launcher-update.regression.mjs`
- `pnpm exec prettier --check scripts/check-workspace-install.mjs scripts/dev.mjs scripts/regressions/launcher-update.regression.mjs`
- `git diff --check`

### Manual verification notes

- Deliberately changed the generated installed-lock snapshot so validation reported it stale.
- Ran `npm run dev` with isolated storage and port `17861`.
- Observed the dev preflight run a frozen pnpm install, repair the lock snapshot, start Fastify 5.11, and report the server ready in 2.6 seconds.
- Stopped the isolated process after Vite became ready; no browser click-through was performed.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Translated docs on the `docs-i18n` branch updated to match, or a `[docs-i18n] <paths>` follow-up issue opened (see CONTRIBUTING.md § Translated documentation)
- [ ] Version/release files updated (only if this PR includes a version bump)

No user-facing documentation or release metadata changed. This is development/install validation behavior.

## UI evidence (if applicable)

Not applicable; no UI changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Development startup now detects stale or incomplete workspace dependencies before building or launching services.
  - Automatically refreshes dependencies with a frozen lockfile install when needed.
  - Provides a clear error when dependencies remain invalid after installation.
  - Added validation for platform-specific runtime components, including Android support.

- **Tests**
  - Expanded regression coverage for lockfile version mismatches and dependency validation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->