### PR TITLE
Fix redundant docs served-language initialization

### DIFF
--- a/packages/server/src/routes/docs.routes.ts
+++ b/packages/server/src/routes/docs.routes.ts
@@ -630,7 +630,7 @@ export async function docsRoutes(app: FastifyInstance) {
 
     const language = await resolveRequestLanguage(lang, storage);
     let filePath: string;
-    let servedLanguage = DEFAULT_DOCS_LANGUAGE;
+    let servedLanguage: string;
     try {
       const { file: candidatePath, language: fileLanguage, root } = resolvePhysical(language, segments);
       if (!existsSync(candidatePath)) {


### PR DESCRIPTION
## Linked issue

Closes #4439

## Why this change

- Resolve the sole outstanding review thread blocking the v2.4.0 staging-to-main promotion.
- Avoid assigning a fallback value that is always overwritten before use.

## What changed

- Declare `servedLanguage` without a redundant initializer; the successful resolution path still assigns `fileLanguage` before the response is built.

## Validation

- [ ] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed `CONTRIBUTING.md`

### Manual verification notes

- Automated proof run: `pnpm regression:docs`.
- Full baseline run: `pnpm check`.
- No user-facing behavior or UI changed.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Translated docs on the `docs-i18n` branch updated to match, or a `[docs-i18n]` follow-up issue opened (see CONTRIBUTING.md § Translated documentation)
- [ ] Version/release files updated (only if this PR includes a version bump)

## UI evidence (if applicable)

Not applicable; server-only cleanup with no behavior change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved content language handling when resolving requested documents.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->