### PR TITLE
fix clipped sidebar resources and call fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ This file is the release-notes source of truth for Marinara Engine. Reuse these 
 
 ## [Unreleased]
 
+### Fixed
+
+- Let desktop sidebar item text use the full row width beneath overlaid hover actions, removed the extra Presets and Connections hover margin, and made Conversation Call clip-length fields scale compactly without clipping their labels (#4449).
+
 ## [2.4.1]
 
 ### Added

--- a/packages/client/src/components/panels/AgentsPanel.tsx
+++ b/packages/client/src/components/panels/AgentsPanel.tsx
@@ -1633,7 +1633,7 @@ function renderAgentCard({
         )}
       </button>
       <button
-        className={cn("min-w-0 flex-1 text-left", !selectionMode && (onDelete ? "pr-24" : "pr-16"))}
+        className={cn("min-w-0 flex-1 text-left", !selectionMode && (onDelete ? "max-md:pr-24" : "max-md:pr-16"))}
         onClick={(event) => {
           event.stopPropagation();
           if (suppressClickRef?.current) return;

--- a/packages/client/src/components/panels/CharactersPanel.tsx
+++ b/packages/client/src/components/panels/CharactersPanel.tsx
@@ -1174,7 +1174,7 @@ export function CharactersPanel() {
                           </div>
                         )}
                       </div>
-                      <div className={cn("min-w-0 flex-1", !selectionMode && "pr-24")}>
+                      <div className={cn("min-w-0 flex-1", !selectionMode && "max-md:pr-24")}>
                         <span
                           className="block truncate text-[0.75rem] font-medium"
                           style={
@@ -1508,7 +1508,7 @@ export function CharactersPanel() {
               </div>
 
               {/* Info */}
-              <div className={cn("min-w-0 flex-1", !selectionMode && "pr-[6.5rem] max-md:pr-20")}>
+              <div className={cn("min-w-0 flex-1", !selectionMode && "max-md:pr-20")}>
                 <div
                   data-character-row-name
                   className="truncate text-sm font-medium"

--- a/packages/client/src/components/panels/ConnectionsPanel.tsx
+++ b/packages/client/src/components/panels/ConnectionsPanel.tsx
@@ -1070,7 +1070,7 @@ function ConnectionRow({
           </div>
         )}
       </button>
-      <div className="min-w-0 flex-1 pr-0 transition-[padding] max-md:pr-32 [@media(pointer:coarse)]:pr-32 [@media(pointer:fine)]:group-hover:pr-32">
+      <div className="min-w-0 flex-1 max-md:pr-32">
         <div className="truncate text-sm font-medium leading-5" title={conn.name}>
           {conn.name}
         </div>

--- a/packages/client/src/components/panels/LorebooksPanel.tsx
+++ b/packages/client/src/components/panels/LorebooksPanel.tsx
@@ -1238,7 +1238,7 @@ function LorebookRow({
           </span>
         </button>
       )}
-      <div className={cn("min-w-0 flex-1", !selectionMode && "pr-24")}>
+      <div className={cn("min-w-0 flex-1", !selectionMode && "max-md:pr-24")}>
         <div className="flex items-center gap-1.5">
           <span className="truncate text-sm font-medium">{lorebook.name}</span>
           {!lorebook.enabled && (

--- a/packages/client/src/components/panels/PersonasPanel.tsx
+++ b/packages/client/src/components/panels/PersonasPanel.tsx
@@ -933,7 +933,7 @@ export function PersonasPanel() {
                           role="button"
                           tabIndex={0}
                           className={cn(
-                            "group group/member flex touch-pan-y cursor-pointer items-center gap-2 rounded-lg p-1.5 text-xs transition-all hover:bg-[var(--sidebar-accent)]",
+                            "group group/member relative flex touch-pan-y cursor-pointer items-center gap-2 rounded-lg p-1.5 text-xs transition-all hover:bg-[var(--sidebar-accent)]",
                             touchSafePersonaDragMode && "select-none",
                             selectionMode &&
                               isBulkSelected &&
@@ -988,7 +988,7 @@ export function PersonasPanel() {
                               <User size="0.625rem" />
                             )}
                           </div>
-                          <div className={cn("min-w-0 flex-1", !selectionMode && "pr-14")}>
+                          <div className={cn("min-w-0 flex-1", !selectionMode && "max-md:pr-14")}>
                             <div className="truncate text-[0.75rem] font-medium">{p.name}</div>
                             {p.comment && (
                               <div className="truncate text-[0.5625rem] italic text-[var(--muted-foreground)]">
@@ -1005,7 +1005,7 @@ export function PersonasPanel() {
                             </div>
                           </div>
                           {!selectionMode && (
-                            <div className="flex items-center gap-0.5 opacity-0 transition-opacity group-hover/member:opacity-100 max-md:opacity-100">
+                            <div className="absolute right-1 top-1/2 flex -translate-y-1/2 items-center gap-0.5 opacity-0 transition-opacity group-hover/member:opacity-100 max-md:opacity-100">
                               <ChatResourceActionButton
                                 payload={{ version: 1, kind: "persona", ids: [pid], label: p.name }}
                                 className="flex h-6 min-h-6 w-6 items-center justify-center p-0"
@@ -1198,7 +1198,7 @@ export function PersonasPanel() {
               </button>
 
               {/* Info */}
-              <div className={cn("min-w-0 flex-1", !selectionMode && "pr-32")}>
+              <div className={cn("min-w-0 flex-1", !selectionMode && "max-md:pr-32")}>
                 <div className="truncate text-sm font-medium">{persona.name}</div>
                 {persona.comment && (
                   <div className="truncate text-[0.625rem] italic text-[var(--muted-foreground)]">

--- a/packages/client/src/components/panels/PresetsPanel.tsx
+++ b/packages/client/src/components/panels/PresetsPanel.tsx
@@ -901,8 +901,7 @@ export function PresetsPanel() {
             <div
               className={cn(
                 "min-w-0 flex-1",
-                !selectionMode &&
-                  "pr-0 transition-[padding] max-md:pr-32 [@media(pointer:coarse)]:pr-32 [@media(pointer:fine)]:group-hover:pr-32",
+                !selectionMode && "max-md:pr-32",
               )}
             >
               <div className="flex min-w-0 items-center gap-1.5">

--- a/packages/client/src/components/panels/SettingsPanel.tsx
+++ b/packages/client/src/components/panels/SettingsPanel.tsx
@@ -3755,12 +3755,12 @@ function VideoGenerationSettings() {
               {CONVERSATION_CALL_CHARACTER_VIDEO_CLIP_KINDS.map((kind) => (
                 <label
                   key={kind}
-                  className="flex min-w-0 items-center justify-between gap-3 rounded-md bg-[var(--secondary)]/60 px-2.5 py-2 ring-1 ring-[var(--border)]/80"
+                  className="flex min-w-0 items-center justify-between gap-2 rounded-md bg-[var(--secondary)]/60 px-2.5 py-2 ring-1 ring-[var(--border)]/80"
                 >
                   <span className="truncate text-xs text-[var(--foreground)]">
                     {CONVERSATION_CALL_VIDEO_CLIP_LABELS[kind]}
                   </span>
-                  <span className="grid w-20 shrink-0 grid-cols-[minmax(0,1fr)_auto] items-center gap-1.5">
+                  <span className="grid w-[clamp(3.5rem,28%,5rem)] shrink-0 grid-cols-[minmax(0,1fr)_auto] items-center gap-1.5">
                     <DraftNumberInput
                       value={draft.callClipDurations[kind]}
                       min={VIDEO_CALL_CLIP_DURATION_MIN}
@@ -3774,12 +3774,12 @@ function VideoGenerationSettings() {
                 </label>
               ))}
             </div>
-            <label className="mt-2 flex min-w-0 items-center justify-between gap-3 rounded-md bg-[var(--secondary)]/60 px-2.5 py-2 ring-1 ring-[var(--border)]/80">
+            <label className="mt-2 flex min-w-0 items-center justify-between gap-2 rounded-md bg-[var(--secondary)]/60 px-2.5 py-2 ring-1 ring-[var(--border)]/80">
               <span className="flex min-w-0 flex-col gap-0.5">
                 <span className="truncate text-xs text-[var(--foreground)]">{localizeUi("ui.panels.videogenerationsettings.customRequest")}</span>
                 <span className="text-[0.55rem] leading-snug text-[var(--muted-foreground)]">{localizeUi("ui.panels.videogenerationsettings.usedForOneOffClipsCharactersGenerateFromExplicit")}</span>
               </span>
-              <span className="grid w-20 shrink-0 grid-cols-[minmax(0,1fr)_auto] items-center gap-1.5">
+              <span className="grid w-[clamp(3.5rem,28%,5rem)] shrink-0 grid-cols-[minmax(0,1fr)_auto] items-center gap-1.5">
                 <DraftNumberInput
                   value={draft.callCustomClipDurationSeconds}
                   min={VIDEO_CALL_CLIP_DURATION_MIN}


### PR DESCRIPTION
## Linked issue

Closes #4449

## Why this change

- Resource rows introduced large right-padding reservations for hover actions even though those actions are absolutely overlaid. This left Characters, Personas, Lorebooks, Agents, Presets, and Connections text unnecessarily narrow on desktop.
- Conversation Call clip controls used a fixed 5rem width inside a two-column settings grid, leaving too little room for clip labels.

## What changed

- Let desktop resource text use the full row width while retaining action clearance on mobile, where the buttons remain visible.
- Overlay Persona folder-member actions consistently with the other resource rows.
- Remove the animated 8rem hover padding from Presets and Connections.
- Scale Conversation Call duration controls between 3.5rem and 5rem and reduce the competing row gap.
- Record the fix in the changelog.

## Validation

- [ ] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed `CONTRIBUTING.md`

### Manual verification notes

- Verify Characters, Personas, Lorebooks, Agents, Presets, and Connections use their full text width before hover at desktop panel widths.
- Hover each desktop resource row and verify the action pill overlays without shifting or reserving row content.
- Verify mobile rows retain enough right clearance for always-visible actions.
- Verify Settings > Generations > Conversation Call Clips shows full labels and compact duration fields in the right panel.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Translated docs on the `docs-i18n` branch updated to match, or a `[docs-i18n]` follow-up issue opened (see CONTRIBUTING.md § Translated documentation)
- [ ] Version/release files updated (only if this PR includes a version bump)

## UI evidence (if applicable)

- Before screenshots are attached to #4449. After screenshots will be added after browser verification.
