### PR TITLE
Fix theme editor live preview lag

### DIFF
--- a/e2e/core-flows.e2e.ts
+++ b/e2e/core-flows.e2e.ts
@@ -244,6 +244,60 @@ test("turning off the custom mouse pointer persists immediately and after reload
     .toBeNull();
 });
 
+test("custom theme live preview batches stylesheet updates while typing", async ({ page }) => {
+  await page.goto("/");
+  await page.locator('[data-tour="panel-settings"]').click();
+  await page.getByRole("tab", { name: "Addons" }).click();
+  await page.getByRole("button", { name: "Create Theme" }).click();
+
+  const themeCssEditor = page.getByPlaceholder("/* Enter your CSS here... */");
+  await expect(themeCssEditor).toBeVisible();
+  await expect
+    .poll(() => page.evaluate(() => document.getElementById("marinara-css-editor-preview")?.textContent?.length ?? 0))
+    .toBeGreaterThan(0);
+
+  await page.evaluate(() => {
+    const previewStyle = document.getElementById("marinara-css-editor-preview");
+    if (!previewStyle) throw new Error("Expected the custom theme preview stylesheet");
+
+    const trackedWindow = window as Window & {
+      __themePreviewMutationCount?: number;
+      __themePreviewObserver?: MutationObserver;
+    };
+    trackedWindow.__themePreviewMutationCount = 0;
+    trackedWindow.__themePreviewObserver = new MutationObserver(() => {
+      trackedWindow.__themePreviewMutationCount = (trackedWindow.__themePreviewMutationCount ?? 0) + 1;
+    });
+    trackedWindow.__themePreviewObserver.observe(previewStyle, {
+      characterData: true,
+      childList: true,
+      subtree: true,
+    });
+  });
+
+  const previewMarker = "\n:root { --issue-4452-preview: ready; }";
+  await themeCssEditor.pressSequentially(previewMarker, { delay: 2 });
+  expect(
+    await page.evaluate(
+      () =>
+        (window as Window & { __themePreviewMutationCount?: number }).__themePreviewMutationCount ?? 0,
+    ),
+  ).toBe(0);
+
+  await expect
+    .poll(() => page.evaluate(() => document.getElementById("marinara-css-editor-preview")?.textContent ?? ""))
+    .toContain("--issue-4452-preview: ready");
+  expect(
+    await page.evaluate(
+      () =>
+        (window as Window & { __themePreviewMutationCount?: number }).__themePreviewMutationCount ?? 0,
+    ),
+  ).toBe(1);
+
+  await page.getByRole("button", { name: "Preview" }).click();
+  await expect.poll(() => page.locator("#marinara-css-editor-preview").count()).toBe(0);
+});
+
 test("gradient Accent Pulse keeps animating while Appearance settings are open", async ({ page }, testInfo) => {
   test.skip(!testInfo.project.name.includes("desktop"), "Accent Pulse preview is covered on desktop.");
 

--- a/packages/client/src/components/panels/SettingsPanel.tsx
+++ b/packages/client/src/components/panels/SettingsPanel.tsx
@@ -5342,6 +5342,8 @@ function AddonsSettings() {
   );
 }
 
+const THEME_PREVIEW_DEBOUNCE_MS = 300;
+
 function ThemesSettings({ showIntro = true }: { showIntro?: boolean } = {}) {
   const { t: localizeUi } = useUiTranslation();
   const { data: syncedThemes = [], isLoading } = useThemes();
@@ -5359,26 +5361,39 @@ function ThemesSettings({ showIntro = true }: { showIntro?: boolean } = {}) {
   const [themeCss, setThemeCss] = useState("");
   const [livePreview, setLivePreview] = useState(true);
 
-  // Inject live preview CSS
+  // Replacing a dense app-level stylesheet invalidates styles across the full
+  // document. Keep typing immediate and apply only the settled preview instead
+  // of forcing that work for every character entered.
   useEffect(() => {
+    const previewStyleId = "marinara-css-editor-preview";
+    const existingStyle = document.getElementById(previewStyleId) as HTMLStyleElement | null;
+
     if (!editorOpen || !livePreview) {
-      const el = document.getElementById("marinara-css-editor-preview");
-      if (el) el.textContent = "";
+      existingStyle?.remove();
       return;
     }
-    let style = document.getElementById("marinara-css-editor-preview") as HTMLStyleElement | null;
-    if (!style) {
-      style = document.createElement("style");
-      style.id = "marinara-css-editor-preview";
+
+    const style = existingStyle ?? document.createElement("style");
+    if (!existingStyle) {
+      style.id = previewStyleId;
+      document.head.appendChild(style);
     }
-    style.textContent = sanitizeAppCss(themeCss);
-    // Always (re-)append so it's the last <style> in <head>,
-    // overriding the active-theme injector's saved CSS.
-    document.head.appendChild(style);
-    return () => {
-      style!.textContent = "";
-    };
+
+    const previewTimeout = window.setTimeout(() => {
+      style.textContent = sanitizeAppCss(themeCss);
+      // Keep the preview after the active-theme injector's saved CSS.
+      document.head.appendChild(style);
+    }, THEME_PREVIEW_DEBOUNCE_MS);
+
+    return () => window.clearTimeout(previewTimeout);
   }, [editorOpen, livePreview, themeCss]);
+
+  useEffect(
+    () => () => {
+      document.getElementById("marinara-css-editor-preview")?.remove();
+    },
+    [],
+  );
 
   const openNewTheme = useCallback(() => {
     setEditingId(null);


### PR DESCRIPTION
> [!IMPORTANT]
> Contributions target `staging`. Only `SpicyMarinara` may promote this repository's `staging` branch or a same-repository `hotfix/*` branch to `main`.
> Outside and first-time contributors also require an approving review from `SpicyMarinara`.
<!-- See CONTRIBUTING.md § Branches. -->

## Linked issue

Closes #4452

## Why this change

The custom theme editor rewrote its app-level preview stylesheet for every character typed. In the supplied Opera performance recording, each rewrite invalidated styles across 2,754 elements and took roughly 55–71 ms, making dense-theme editing visibly fall behind input. JavaScript and garbage collection were comparatively small, so the root cause was repeated full-document style recalculation rather than a sustained heap leak.

## What changed

- Debounce live-preview stylesheet replacement until CSS input has settled for 300 ms.
- Preserve the last rendered preview while typing, then keep the settled preview after the saved active-theme stylesheet.
- Remove preview CSS immediately when Preview is disabled or the editor unmounts.
- Add desktop and mobile browser regression coverage proving a typing burst causes one settled stylesheet mutation instead of one mutation per keystroke.

## Validation

- [ ] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed `CONTRIBUTING.md`

Automated validation completed:

- `pnpm check`
- `pnpm exec playwright test e2e/core-flows.e2e.ts --grep 'custom theme live preview batches stylesheet updates while typing'` (2 passed: desktop Chromium and mobile Chromium)
- `git diff --check`

### Manual verification notes

- Manually verify rapid editing of a dense custom theme remains responsive in Opera.
- Manually verify the preview updates after typing pauses.
- Manually disable and re-enable Preview, then close the editor, and verify preview CSS does not remain active.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Translated docs on the `docs-i18n` branch updated to match, or a `[docs-i18n]` follow-up issue opened (see CONTRIBUTING.md § Translated documentation)
- [ ] Version/release files updated (only if this PR includes a version bump)

## UI evidence (if applicable)

The supplied Opera DevTools trace is the performance evidence for the original issue. The regression test observes the live-preview stylesheet directly on desktop and mobile.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved custom theme live preview performance by batching updates during rapid CSS editing.
  * Ensured preview styles are consistently removed when preview mode ends or the editor closes.
  * Preserved correct style ordering so live previews remain visible alongside saved theme styles.

* **Tests**
  * Added end-to-end coverage for batched theme preview updates and cleanup behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->