### PR TITLE
Preserve Expression Engine sprites across sparse group-chat rounds

### DIFF
--- a/packages/client/src/components/chat/ChatArea.tsx
+++ b/packages/client/src/components/chat/ChatArea.tsx
@@ -53,6 +53,10 @@ import { resolveSpriteExpression } from "../../lib/sprite-expression-match";
 import { parseCharacterDisplayData } from "../../lib/character-display";
 import { showConfirmDialog } from "../../lib/app-dialogs";
 import { parseMessageExtraRecord } from "../../lib/chat-message-extra";
+import {
+  normalizeSpriteExpressionMap,
+  resolveSpriteExpressionState,
+} from "../../lib/sprite-expression-state";
 import { chatBackgroundMetadataToUrl, chatBackgroundUrlToMetadata } from "../../lib/backgrounds";
 import { useGameStateStore } from "../../stores/game-state.store";
 import { useGalleryStore } from "../../stores/gallery.store";
@@ -241,17 +245,6 @@ const normalizeSpriteDisplayValue = (value: unknown, fallback: number, min: numb
 
 function startsNewAssistantBubble(message: { extra?: unknown } | null | undefined): boolean {
   return parseMessageExtraRecord(message?.extra).startsNewAssistantBubble === true;
-}
-
-function normalizeMessageSpriteExpressions(value: unknown): Record<string, string> {
-  if (!value || typeof value !== "object" || Array.isArray(value)) return {};
-  const expressions: Record<string, string> = {};
-  for (const [key, expression] of Object.entries(value as Record<string, unknown>)) {
-    if (typeof expression !== "string") continue;
-    const trimmed = expression.trim();
-    if (key && trimmed) expressions[key] = trimmed;
-  }
-  return expressions;
 }
 
 function getPersonaSnapshotName(extra: Record<string, unknown>): string | null {
@@ -1157,23 +1150,12 @@ export function ChatArea() {
     : chatMeta.spritePlacements;
   const spritePlacements = useMemo(() => normalizeSpritePlacements(spritePlacementsSource), [spritePlacementsSource]);
   const hasCustomSpritePlacements = Object.keys(spritePlacements).length > 0;
-  // Prefer per-swipe expressions from the last assistant message's extra (survives swipe switching),
-  // falling back to chat-level metadata for backward compatibility.
-  const spriteExpressions: Record<string, string> = useMemo(() => {
-    if (messages?.length) {
-      for (let i = messages.length - 1; i >= 0; i--) {
-        const m = messages[i]!;
-        if (m.role === "assistant") {
-          const extra = typeof m.extra === "string" ? JSON.parse(m.extra) : (m.extra ?? {});
-          if (extra.spriteExpressions && Object.keys(extra.spriteExpressions).length > 0) {
-            return extra.spriteExpressions as Record<string, string>;
-          }
-          break; // only check the last assistant message
-        }
-      }
-    }
-    return chatMeta.spriteExpressions ?? {};
-  }, [messages, chatMeta.spriteExpressions]);
+  // Expression Engine results are sparse updates. Fold every loaded per-swipe update so
+  // a round that omits a character preserves that character's previous expression.
+  const spriteExpressions = useMemo(
+    () => resolveSpriteExpressionState(messages, chatMeta.spriteExpressions),
+    [messages, chatMeta.spriteExpressions],
+  );
   const groupChatMode: string | undefined = chatCharIds.length > 1 ? (chatMeta.groupChatMode ?? "merged") : undefined;
 
   const updateMeta = useUpdateChatMetadata();
@@ -1775,7 +1757,7 @@ export function ChatArea() {
     if (!expressionAvatarsEnabled) return undefined;
     return (message, characterId) => {
       const extra = parseMessageExtraRecord(message.extra);
-      const expressions = normalizeMessageSpriteExpressions(extra.spriteExpressions);
+      const expressions = normalizeSpriteExpressionMap(extra.spriteExpressions);
       const characterName = characterMap.get(characterId)?.name;
       const personaName =
         characterId === personaInfo?.id ? (getPersonaSnapshotName(extra) ?? personaInfo.name) : undefined;

--- a/packages/client/src/features/tracker-panel/hooks/use-tracker-panel-model.ts
+++ b/packages/client/src/features/tracker-panel/hooks/use-tracker-panel-model.ts
@@ -15,7 +15,7 @@ import {
   normalizeStringArray,
   parseRecord,
 } from "../lib/tracker-metadata";
-import { getLatestSpriteExpressionsFromMessages, normalizeSpriteExpressionMap } from "../lib/sprite-expressions";
+import { resolveSpriteExpressionState } from "../../../lib/sprite-expression-state";
 import { useTrackerSpriteLookup } from "./use-tracker-sprite-lookup";
 
 interface UseTrackerPanelModelOptions {
@@ -93,10 +93,12 @@ export function useTrackerPanelModel({
   );
   const spriteExpressions = useMemo(
     () =>
-      getLatestSpriteExpressionsFromMessages(
-        (messageData?.pages.flat() ?? []) as Array<{ role?: string; extra?: unknown }>,
-      ) ??
-      normalizeSpriteExpressionMap(chatMeta.spriteExpressions),
+      resolveSpriteExpressionState(
+        (messageData?.pages ? [...messageData.pages].reverse().flat() : []) as Array<{
+          extra?: unknown;
+        }>,
+        chatMeta.spriteExpressions,
+      ),
     [messageData, chatMeta.spriteExpressions],
   );
   const featuredCharacterCardKeys = useMemo(

--- a/packages/client/src/features/tracker-panel/lib/sprite-expressions.ts
+++ b/packages/client/src/features/tracker-panel/lib/sprite-expressions.ts
@@ -1,31 +1,5 @@
 import type { PresentCharacter } from "@marinara-engine/shared";
 import type { SpriteInfo } from "../../../hooks/use-characters";
-import { parseRecord } from "./tracker-metadata";
-
-export function normalizeSpriteExpressionMap(value: unknown): Record<string, string> {
-  if (!value || typeof value !== "object" || Array.isArray(value)) return {};
-  const expressions: Record<string, string> = {};
-  for (const [key, expression] of Object.entries(value as Record<string, unknown>)) {
-    if (typeof expression !== "string") continue;
-    const trimmed = expression.trim();
-    if (key && trimmed) expressions[key] = trimmed;
-  }
-  return expressions;
-}
-
-export function getLatestSpriteExpressionsFromMessages(
-  messages: Array<{ role?: string; extra?: unknown }> | undefined,
-) {
-  if (!messages?.length) return null;
-  for (let index = messages.length - 1; index >= 0; index -= 1) {
-    const message = messages[index];
-    if (message?.role !== "assistant") continue;
-    const extra = parseRecord(message.extra);
-    const expressions = normalizeSpriteExpressionMap(extra.spriteExpressions);
-    if (Object.keys(expressions).length > 0) return expressions;
-  }
-  return null;
-}
 
 export function isSpriteLookupCharacterId(characterId: string | null | undefined) {
   const id = characterId?.trim();

--- a/packages/client/src/lib/sprite-expression-state.ts
+++ b/packages/client/src/lib/sprite-expression-state.ts
@@ -1,0 +1,39 @@
+import { parseMessageExtraRecord } from "./chat-message-extra";
+
+interface SpriteExpressionMessage {
+  extra?: unknown;
+}
+
+export function normalizeSpriteExpressionMap(value: unknown): Record<string, string> {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return {};
+  const expressions: Record<string, string> = {};
+  for (const [key, expression] of Object.entries(value as Record<string, unknown>)) {
+    if (typeof expression !== "string") continue;
+    const trimmed = expression.trim();
+    if (key && trimmed) expressions[key] = trimmed;
+  }
+  return expressions;
+}
+
+/**
+ * Resolve sparse Expression Engine updates into the current per-character state.
+ * Messages must be ordered from oldest to newest so explicit later expressions,
+ * including `neutral`, replace earlier values without clearing omitted characters.
+ */
+export function resolveSpriteExpressionState(
+  messages: readonly SpriteExpressionMessage[] | undefined,
+  fallback?: unknown,
+): Record<string, string> {
+  const expressions = normalizeSpriteExpressionMap(fallback);
+
+  for (const message of messages ?? []) {
+    const update = normalizeSpriteExpressionMap(
+      parseMessageExtraRecord(message.extra).spriteExpressions,
+    );
+    for (const [characterId, expression] of Object.entries(update)) {
+      expressions[characterId] = expression;
+    }
+  }
+
+  return expressions;
+}

--- a/scripts/regressions/open-issues.regression.ts
+++ b/scripts/regressions/open-issues.regression.ts
@@ -199,6 +199,7 @@ import {
   buildInitialAgentAddSetupState,
 } from "../../packages/client/src/components/chat/AgentAddSetupFields.js";
 import { resolveSpriteTransition } from "../../packages/client/src/lib/sprite-transition.js";
+import { resolveSpriteExpressionState } from "../../packages/client/src/lib/sprite-expression-state.js";
 import {
   parseIllustratorPromptReviewOverride,
   resolveIllustratorPromptSubmission,
@@ -309,6 +310,36 @@ assert.equal(shouldSuppressAutonomousMessages("dnd"), true);
 assert.equal(resolveSpriteTransition("full-body", "none"), "crossfade");
 assert.equal(resolveSpriteTransition("full-body", "shake"), "shake");
 assert.equal(resolveSpriteTransition("expressions", "none"), "none");
+assert.deepEqual(
+  resolveSpriteExpressionState([
+    { extra: { spriteExpressions: { "character-a": "happy" } } },
+    { extra: {} },
+  ]),
+  { "character-a": "happy" },
+);
+assert.deepEqual(
+  resolveSpriteExpressionState(
+    [
+      { extra: { spriteExpressions: { "character-a": "happy" } } },
+      { extra: { spriteExpressions: { persona: "excited" } } },
+      { extra: JSON.stringify({ spriteExpressions: { "character-c": "angry" } }) },
+    ],
+    { "character-b": "thinking" },
+  ),
+  {
+    "character-a": "happy",
+    "character-b": "thinking",
+    "character-c": "angry",
+    persona: "excited",
+  },
+);
+assert.deepEqual(
+  resolveSpriteExpressionState([
+    { extra: { spriteExpressions: { "character-a": "happy" } } },
+    { extra: { spriteExpressions: { "character-a": "neutral" } } },
+  ]),
+  { "character-a": "neutral" },
+);
 assert.deepEqual(findMissingComfyReferenceSlots(comfyReferenceWorkflow, "reference_image", 1), [1]);
 assert.deepEqual(findMissingComfyReferenceSlots(comfyReferenceWorkflow, "reference_image_name", 1), [2]);
 assert.equal(numberedComfyReferencePlaceholder("reference_image_name", 2), "%reference_image_name_03%");


### PR DESCRIPTION
> [!IMPORTANT]
> Contributions target `staging`. Only `SpicyMarinara` may promote this repository's `staging` branch or a same-repository `hotfix/*` branch to `main`.
> Outside and first-time contributors also require an approving review from `SpicyMarinara`.

## Linked issue

Closes #4454

## Why this change

- Expression Engine stores per-turn sprite selections as sparse updates. The Roleplay UI treated the latest message as a complete snapshot, so an empty round—or a round that selected only another character—discarded a character's previously selected full-body sprite and allowed the fallback logic to reset it to neutral.

## What changed

- Fold loaded per-message sprite updates chronologically into cumulative per-character state, preserving omitted characters while allowing explicit later values such as `neutral` to override them.
- Reuse the same resolver in the Roleplay stage and Tracker panel, including string-backed message metadata and correctly ordered paginated tracker history.
- Consolidate duplicate sprite-expression normalization and add regressions for empty rounds, sparse multi-character updates, fallbacks, and explicit neutral resets.

## Validation

- [ ] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed `CONTRIBUTING.md`

### Automated verification notes

- `pnpm check` — passed (localization, ESLint, TypeScript, server build, production client build).
- `pnpm --filter @marinara-engine/server exec tsx ../../scripts/regressions/open-issues.regression.ts` — passed.
- `pnpm smoke:ui` — 181 passed, 95 skipped, 4 unrelated failures: stale What's New copy on desktop/mobile, a character-row pointer-interception timeout, and a Roleplay panel-animation timing assertion.

### Manual verification notes

- Manually verify in a Roleplay group chat that character A retains its selected full-body sprite after character B, who has no sprites, responds and Expression Engine selects no sprites for that round.
- Manually verify that a later explicit expression selection for character A still replaces the retained sprite.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Translated docs on the `docs-i18n` branch updated to match, or a `[docs-i18n]` follow-up issue opened (see CONTRIBUTING.md § Translated documentation)
- [ ] Version/release files updated (only if this PR includes a version bump)

No user-facing copy, documentation contract, or release metadata changed.

## UI evidence (if applicable)

Not included: this is a state-retention correction with no visual layout or styling changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sprite expression handling across chat and tracker views.
  * Preserved existing character expressions when later updates omit them.
  * Ensured newer expression updates correctly override older values.
  * Added support for expression data stored in JSON-encoded metadata.

* **Tests**
  * Added regression coverage for expression extraction, fallback state, merging, and update precedence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->