### PR TITLE
fix(ci): restore automatic member approval status

### DIFF
--- a/.github/workflows/owner-approval-review-signal.yml
+++ b/.github/workflows/owner-approval-review-signal.yml
@@ -1,0 +1,15 @@
+name: Owner Approval Review Signal
+
+on:
+  pull_request_review:
+    types: [submitted, edited, dismissed]
+
+permissions: {}
+
+jobs:
+  signal:
+    name: Signal trusted owner approval refresh
+    runs-on: ubuntu-latest
+    steps:
+      - name: Record review event
+        run: echo "A trusted workflow will re-evaluate the staging owner-approval status."

--- a/.github/workflows/owner-approval-review.yml
+++ b/.github/workflows/owner-approval-review.yml
@@ -1,0 +1,69 @@
+name: Owner Approval Review Evaluator
+
+on:
+  workflow_run:
+    workflows: [Owner Approval Review Signal]
+    types: [completed]
+
+jobs:
+  evaluate:
+    name: Re-evaluate staging owner approval
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      pull-requests: read
+      statuses: write
+    steps:
+      - name: Resolve pull request
+        id: pull-request
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
+        with:
+          script: |
+            let pullRequests = context.payload.workflow_run.pull_requests || [];
+            if (pullRequests.length === 0) {
+              const response = await github.request(
+                'GET /repos/{owner}/{repo}/actions/runs/{run_id}/pull_requests',
+                {
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  run_id: context.payload.workflow_run.id,
+                },
+              );
+              pullRequests = response.data;
+            }
+
+            const pullNumbers = [...new Set(pullRequests.map((pullRequest) => pullRequest.number))];
+            if (pullNumbers.length === 0) {
+              core.notice('The review signal is not associated with a pull request.');
+              return;
+            }
+            if (pullNumbers.length !== 1) {
+              core.setFailed('The review signal is associated with more than one pull request.');
+              return;
+            }
+
+            core.setOutput('number', String(pullNumbers[0]));
+
+      - name: Checkout trusted default branch
+        if: steps.pull-request.outputs.number != ''
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          persist-credentials: false
+
+      - name: Set up Node.js
+        if: steps.pull-request.outputs.number != ''
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 24
+
+      - name: Publish owner approval status
+        if: steps.pull-request.outputs.number != ''
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          MEMBERS_TOKEN_CONFIGURED: ${{ secrets.PASTA_DEVS_MEMBERS_TOKEN != '' }}
+          PASTA_DEVS_MEMBERS_TOKEN: ${{ secrets.PASTA_DEVS_MEMBERS_TOKEN }}
+          PR_NUMBER: ${{ steps.pull-request.outputs.number }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: node scripts/evaluate-owner-approval.mjs

--- a/.github/workflows/owner-approval-review.yml
+++ b/.github/workflows/owner-approval-review.yml
@@ -5,6 +5,10 @@ on:
     workflows: [Owner Approval Review Signal]
     types: [completed]
 
+concurrency:
+  group: owner-approval-review-${{ github.event.workflow_run.pull_requests[0].number || github.event.workflow_run.head_sha }}
+  cancel-in-progress: true
+
 jobs:
   evaluate:
     name: Re-evaluate staging owner approval
@@ -23,11 +27,11 @@ jobs:
             let pullRequests = context.payload.workflow_run.pull_requests || [];
             if (pullRequests.length === 0) {
               const response = await github.request(
-                'GET /repos/{owner}/{repo}/actions/runs/{run_id}/pull_requests',
+                'GET /repos/{owner}/{repo}/commits/{commit_sha}/pulls',
                 {
                   owner: context.repo.owner,
                   repo: context.repo.repo,
-                  run_id: context.payload.workflow_run.id,
+                  commit_sha: context.payload.workflow_run.head_sha,
                 },
               );
               pullRequests = response.data;

--- a/.github/workflows/pull-request-checks.yml
+++ b/.github/workflows/pull-request-checks.yml
@@ -39,6 +39,9 @@ jobs:
       - name: Validate pull request gate topology
         run: node scripts/validate-pr-triage.mjs
 
+      - name: Test owner approval evaluator
+        run: node scripts/test-owner-approval.mjs
+
       - name: Check version drift
         run: pnpm version:check
 

--- a/.github/workflows/pull-request-triage.yml
+++ b/.github/workflows/pull-request-triage.yml
@@ -44,6 +44,35 @@ jobs:
           echo "::error::Contributions must target staging. Main accepts only SpicyMarinara's same-repository staging promotion or hotfix/* PR."
           exit 1
 
+  owner-approval:
+    name: Evaluate staging owner approval
+    if: github.event.pull_request.base.ref == 'staging'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+      statuses: write
+    steps:
+      - name: Checkout trusted base revision
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ github.event.pull_request.base.sha }}
+          persist-credentials: false
+
+      - name: Set up Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 24
+
+      - name: Publish owner approval status
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          MEMBERS_TOKEN_CONFIGURED: ${{ secrets.PASTA_DEVS_MEMBERS_TOKEN != '' }}
+          PASTA_DEVS_MEMBERS_TOKEN: ${{ secrets.PASTA_DEVS_MEMBERS_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: node scripts/evaluate-owner-approval.mjs
+
   label:
     name: Auto-label
     if: github.event_name == 'pull_request_target'

--- a/scripts/evaluate-owner-approval.mjs
+++ b/scripts/evaluate-owner-approval.mjs
@@ -78,56 +78,68 @@ export async function evaluateOwnerApproval({ env = process.env, request = githu
   let description = "Outside contribution requires current SpicyMarinara approval.";
   let internal = authorLogin.toLowerCase() === "spicymarinara";
 
-  if (!internal) {
-    if (env.MEMBERS_TOKEN_CONFIGURED !== "true" || !env.PASTA_DEVS_MEMBERS_TOKEN) {
-      state = "error";
-      description = "Could not verify Pasta-Devs membership; failing closed.";
-    } else {
-      try {
-        const membership = await request({
-          token: env.PASTA_DEVS_MEMBERS_TOKEN,
-          path: `/orgs/${encodeURIComponent(organization)}/memberships/${encodeURIComponent(authorLogin)}`,
-        });
-        internal =
-          membership.state === "active" &&
-          (membership.role === "admin" || membership.role === "member");
-      } catch (error) {
-        if (error.status !== 404) {
-          state = "error";
-          description = "Could not verify Pasta-Devs membership; failing closed.";
-          console.error(`Membership lookup failed with status ${error.status ?? "unknown"}.`);
+  const publishStatus = () =>
+    request({
+      token: githubToken,
+      method: "POST",
+      path: `/repos/${repositoryPath}/statuses/${encodeURIComponent(headSha)}`,
+      body: {
+        state,
+        context: OWNER_APPROVAL_CONTEXT,
+        description,
+        target_url: env.RUN_URL,
+      },
+    });
+
+  try {
+    if (!internal) {
+      if (env.MEMBERS_TOKEN_CONFIGURED !== "true" || !env.PASTA_DEVS_MEMBERS_TOKEN) {
+        state = "error";
+        description = "Could not verify Pasta-Devs membership; failing closed.";
+      } else {
+        try {
+          const membership = await request({
+            token: env.PASTA_DEVS_MEMBERS_TOKEN,
+            path: `/orgs/${encodeURIComponent(organization)}/memberships/${encodeURIComponent(authorLogin)}`,
+          });
+          internal =
+            membership.state === "active" &&
+            (membership.role === "admin" || membership.role === "member");
+        } catch (error) {
+          if (error.status !== 404) {
+            state = "error";
+            description = "Could not verify Pasta-Devs membership; failing closed.";
+            console.error(`Membership lookup failed with status ${error?.status ?? "unknown"}.`);
+          }
         }
       }
     }
-  }
 
-  if (internal) {
-    state = "success";
-    description = "Active Pasta-Devs member; owner approval is not required.";
-  } else if (state !== "error") {
-    const reviews = await listPullRequestReviews(request, githubToken, repositoryPath, pullNumber);
-    const latestOwnerReview = reviews
-      .filter((review) => review.user?.login?.toLowerCase() === "spicymarinara")
-      .sort((left, right) => left.id - right.id)
-      .at(-1);
-
-    if (latestOwnerReview?.state === "APPROVED" && latestOwnerReview.commit_id === headSha) {
+    if (internal) {
       state = "success";
-      description = "Outside contribution approved by SpicyMarinara for the current commit.";
-    }
-  }
+      description = "Active Pasta-Devs member; owner approval is not required.";
+    } else if (state !== "error") {
+      const reviews = await listPullRequestReviews(request, githubToken, repositoryPath, pullNumber);
+      const latestOwnerReview = reviews
+        .filter((review) => review.user?.login?.toLowerCase() === "spicymarinara")
+        .sort((left, right) => left.id - right.id)
+        .at(-1);
 
-  await request({
-    token: githubToken,
-    method: "POST",
-    path: `/repos/${repositoryPath}/statuses/${encodeURIComponent(headSha)}`,
-    body: {
-      state,
-      context: OWNER_APPROVAL_CONTEXT,
-      description,
-      target_url: env.RUN_URL,
-    },
-  });
+      if (latestOwnerReview?.state === "APPROVED" && latestOwnerReview.commit_id === headSha) {
+        state = "success";
+        description = "Outside contribution approved by SpicyMarinara for the current commit.";
+      }
+    }
+
+    await publishStatus();
+  } catch (error) {
+    state = "error";
+    description = "Owner approval evaluation failed unexpectedly; failing closed.";
+    console.error(
+      `Owner approval evaluation failed with status ${error?.status ?? "unknown"}; publishing error status.`,
+    );
+    await publishStatus();
+  }
 
   console.info(`${OWNER_APPROVAL_CONTEXT}: ${state} (${description})`);
   return { skipped: false, state, description, internal };

--- a/scripts/evaluate-owner-approval.mjs
+++ b/scripts/evaluate-owner-approval.mjs
@@ -1,0 +1,141 @@
+import { pathToFileURL } from "node:url";
+
+export const OWNER_APPROVAL_CONTEXT = "Owner approval for outside contributors";
+
+function requireValue(value, name) {
+  if (!value) {
+    throw new Error(`${name} is required.`);
+  }
+  return value;
+}
+
+async function githubRequest({ token, method = "GET", path, body }) {
+  const response = await fetch(`https://api.github.com${path}`, {
+    method,
+    headers: {
+      Accept: "application/vnd.github+json",
+      Authorization: `Bearer ${token}`,
+      "X-GitHub-Api-Version": "2022-11-28",
+      "User-Agent": "marinara-owner-approval-gate",
+    },
+    ...(body === undefined ? {} : { body: JSON.stringify(body) }),
+  });
+
+  const responseBody = await response.text();
+  const data = responseBody ? JSON.parse(responseBody) : undefined;
+
+  if (!response.ok) {
+    const error = new Error(data?.message || `GitHub API request failed with status ${response.status}.`);
+    error.status = response.status;
+    throw error;
+  }
+
+  return data;
+}
+
+async function listPullRequestReviews(request, token, repositoryPath, pullNumber) {
+  const reviews = [];
+
+  for (let page = 1; ; page += 1) {
+    const batch = await request({
+      token,
+      path: `/repos/${repositoryPath}/pulls/${pullNumber}/reviews?per_page=100&page=${page}`,
+    });
+    reviews.push(...batch);
+    if (batch.length < 100) break;
+  }
+
+  return reviews;
+}
+
+export async function evaluateOwnerApproval({ env = process.env, request = githubRequest } = {}) {
+  const repository = requireValue(env.GITHUB_REPOSITORY, "GITHUB_REPOSITORY");
+  const githubToken = requireValue(env.GITHUB_TOKEN, "GITHUB_TOKEN");
+  const pullNumber = Number.parseInt(requireValue(env.PR_NUMBER, "PR_NUMBER"), 10);
+  const [organization, repositoryName] = repository.split("/");
+
+  if (!organization || !repositoryName || !Number.isSafeInteger(pullNumber) || pullNumber <= 0) {
+    throw new Error("GITHUB_REPOSITORY and PR_NUMBER must identify a valid pull request.");
+  }
+
+  const repositoryPath = `${encodeURIComponent(organization)}/${encodeURIComponent(repositoryName)}`;
+  const pullRequest = await request({
+    token: githubToken,
+    path: `/repos/${repositoryPath}/pulls/${pullNumber}`,
+  });
+
+  if (pullRequest.state !== "open" || pullRequest.base?.ref !== "staging") {
+    console.info(`Skipping #${pullNumber}; it is not an open pull request targeting staging.`);
+    return { skipped: true };
+  }
+
+  const authorLogin = pullRequest.user?.login;
+  const headSha = pullRequest.head?.sha;
+  requireValue(authorLogin, "pull request author login");
+  requireValue(headSha, "pull request head SHA");
+
+  let state = "failure";
+  let description = "Outside contribution requires current SpicyMarinara approval.";
+  let internal = authorLogin.toLowerCase() === "spicymarinara";
+
+  if (!internal) {
+    if (env.MEMBERS_TOKEN_CONFIGURED !== "true" || !env.PASTA_DEVS_MEMBERS_TOKEN) {
+      state = "error";
+      description = "Could not verify Pasta-Devs membership; failing closed.";
+    } else {
+      try {
+        const membership = await request({
+          token: env.PASTA_DEVS_MEMBERS_TOKEN,
+          path: `/orgs/${encodeURIComponent(organization)}/memberships/${encodeURIComponent(authorLogin)}`,
+        });
+        internal =
+          membership.state === "active" &&
+          (membership.role === "admin" || membership.role === "member");
+      } catch (error) {
+        if (error.status !== 404) {
+          state = "error";
+          description = "Could not verify Pasta-Devs membership; failing closed.";
+          console.error(`Membership lookup failed with status ${error.status ?? "unknown"}.`);
+        }
+      }
+    }
+  }
+
+  if (internal) {
+    state = "success";
+    description = "Active Pasta-Devs member; owner approval is not required.";
+  } else if (state !== "error") {
+    const reviews = await listPullRequestReviews(request, githubToken, repositoryPath, pullNumber);
+    const latestOwnerReview = reviews
+      .filter((review) => review.user?.login?.toLowerCase() === "spicymarinara")
+      .sort((left, right) => left.id - right.id)
+      .at(-1);
+
+    if (latestOwnerReview?.state === "APPROVED" && latestOwnerReview.commit_id === headSha) {
+      state = "success";
+      description = "Outside contribution approved by SpicyMarinara for the current commit.";
+    }
+  }
+
+  await request({
+    token: githubToken,
+    method: "POST",
+    path: `/repos/${repositoryPath}/statuses/${encodeURIComponent(headSha)}`,
+    body: {
+      state,
+      context: OWNER_APPROVAL_CONTEXT,
+      description,
+      target_url: env.RUN_URL,
+    },
+  });
+
+  console.info(`${OWNER_APPROVAL_CONTEXT}: ${state} (${description})`);
+  return { skipped: false, state, description, internal };
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  evaluateOwnerApproval().catch((error) => {
+    console.error(error);
+    process.exitCode = 1;
+  });
+}

--- a/scripts/test-owner-approval.mjs
+++ b/scripts/test-owner-approval.mjs
@@ -1,0 +1,109 @@
+import assert from "node:assert/strict";
+import { evaluateOwnerApproval, OWNER_APPROVAL_CONTEXT } from "./evaluate-owner-approval.mjs";
+
+const basePullRequest = {
+  state: "open",
+  base: { ref: "staging" },
+  head: { sha: "head-sha" },
+  user: { login: "OutsideContributor" },
+};
+
+function createMock({ pullRequest = basePullRequest, membership, membershipError, reviews = [] }) {
+  const statuses = [];
+  const request = async ({ token, method = "GET", path, body }) => {
+    if (method === "POST" && path.endsWith("/statuses/head-sha")) {
+      assert.equal(token, "github-token");
+      statuses.push(body);
+      return body;
+    }
+    if (path.includes("/pulls/42/reviews")) return reviews;
+    if (path.endsWith("/pulls/42")) return pullRequest;
+    if (path.includes("/memberships/")) {
+      assert.equal(token, "members-token");
+      if (membershipError) throw membershipError;
+      return membership;
+    }
+    throw new Error(`Unexpected request: ${method} ${path}`);
+  };
+  return { request, statuses };
+}
+
+async function runCase(options, env = {}) {
+  const mock = createMock(options);
+  const result = await evaluateOwnerApproval({
+    request: mock.request,
+    env: {
+      GITHUB_REPOSITORY: "Pasta-Devs/Marinara-Engine",
+      GITHUB_TOKEN: "github-token",
+      MEMBERS_TOKEN_CONFIGURED: "true",
+      PASTA_DEVS_MEMBERS_TOKEN: "members-token",
+      PR_NUMBER: "42",
+      RUN_URL: "https://github.example/actions/runs/1",
+      ...env,
+    },
+  });
+  assert.equal(mock.statuses.length, 1);
+  assert.equal(mock.statuses[0].context, OWNER_APPROVAL_CONTEXT);
+  return { result, status: mock.statuses[0] };
+}
+
+{
+  const { result, status } = await runCase({
+    pullRequest: { ...basePullRequest, user: { login: "MemberDeveloper" } },
+    membership: { state: "active", role: "member" },
+  });
+  assert.equal(result.internal, true);
+  assert.equal(status.state, "success");
+}
+
+{
+  const { status } = await runCase(
+    { pullRequest: { ...basePullRequest, user: { login: "SpicyMarinara" } } },
+    { MEMBERS_TOKEN_CONFIGURED: "false", PASTA_DEVS_MEMBERS_TOKEN: "" },
+  );
+  assert.equal(status.state, "success");
+}
+
+{
+  const notFound = Object.assign(new Error("Not Found"), { status: 404 });
+  const { status } = await runCase({ membershipError: notFound });
+  assert.equal(status.state, "failure");
+}
+
+{
+  const notFound = Object.assign(new Error("Not Found"), { status: 404 });
+  const { status } = await runCase({
+    membershipError: notFound,
+    reviews: [
+      { id: 1, state: "APPROVED", commit_id: "head-sha", user: { login: "SpicyMarinara" } },
+    ],
+  });
+  assert.equal(status.state, "success");
+}
+
+{
+  const notFound = Object.assign(new Error("Not Found"), { status: 404 });
+  const { status } = await runCase({
+    membershipError: notFound,
+    reviews: [
+      { id: 1, state: "APPROVED", commit_id: "stale-sha", user: { login: "SpicyMarinara" } },
+    ],
+  });
+  assert.equal(status.state, "failure");
+}
+
+{
+  const { status } = await runCase(
+    {},
+    { MEMBERS_TOKEN_CONFIGURED: "false", PASTA_DEVS_MEMBERS_TOKEN: "" },
+  );
+  assert.equal(status.state, "error");
+}
+
+{
+  const forbidden = Object.assign(new Error("Forbidden"), { status: 403 });
+  const { status } = await runCase({ membershipError: forbidden });
+  assert.equal(status.state, "error");
+}
+
+console.info("Owner approval evaluator tests passed.");

--- a/scripts/test-owner-approval.mjs
+++ b/scripts/test-owner-approval.mjs
@@ -8,15 +8,30 @@ const basePullRequest = {
   user: { login: "OutsideContributor" },
 };
 
-function createMock({ pullRequest = basePullRequest, membership, membershipError, reviews = [] }) {
+function createMock({
+  pullRequest = basePullRequest,
+  membership,
+  membershipError,
+  reviews = [],
+  reviewsError,
+  statusFailures = 0,
+}) {
   const statuses = [];
+  let statusAttempts = 0;
   const request = async ({ token, method = "GET", path, body }) => {
     if (method === "POST" && path.endsWith("/statuses/head-sha")) {
       assert.equal(token, "github-token");
+      statusAttempts += 1;
+      if (statusAttempts <= statusFailures) {
+        throw Object.assign(new Error("Status unavailable"), { status: 503 });
+      }
       statuses.push(body);
       return body;
     }
-    if (path.includes("/pulls/42/reviews")) return reviews;
+    if (path.includes("/pulls/42/reviews")) {
+      if (reviewsError) throw reviewsError;
+      return reviews;
+    }
     if (path.endsWith("/pulls/42")) return pullRequest;
     if (path.includes("/memberships/")) {
       assert.equal(token, "members-token");
@@ -25,10 +40,10 @@ function createMock({ pullRequest = basePullRequest, membership, membershipError
     }
     throw new Error(`Unexpected request: ${method} ${path}`);
   };
-  return { request, statuses };
+  return { request, statuses, getStatusAttempts: () => statusAttempts };
 }
 
-async function runCase(options, env = {}) {
+async function evaluateCase(options, env = {}) {
   const mock = createMock(options);
   const result = await evaluateOwnerApproval({
     request: mock.request,
@@ -42,9 +57,22 @@ async function runCase(options, env = {}) {
       ...env,
     },
   });
-  assert.equal(mock.statuses.length, 1);
-  assert.equal(mock.statuses[0].context, OWNER_APPROVAL_CONTEXT);
-  return { result, status: mock.statuses[0] };
+  return { ...mock, result };
+}
+
+async function runCase(options, env = {}) {
+  const outcome = await evaluateCase(options, env);
+  assert.equal(outcome.statuses.length, 1);
+  assert.equal(outcome.statuses[0].context, OWNER_APPROVAL_CONTEXT);
+  return { ...outcome, status: outcome.statuses[0] };
+}
+
+{
+  const { result, statuses } = await evaluateCase({
+    pullRequest: { ...basePullRequest, state: "closed" },
+  });
+  assert.equal(result.skipped, true);
+  assert.equal(statuses.length, 0);
 }
 
 {
@@ -54,6 +82,24 @@ async function runCase(options, env = {}) {
   });
   assert.equal(result.internal, true);
   assert.equal(status.state, "success");
+}
+
+{
+  const { result, status } = await runCase({
+    pullRequest: { ...basePullRequest, user: { login: "OrganizationOwner" } },
+    membership: { state: "active", role: "admin" },
+  });
+  assert.equal(result.internal, true);
+  assert.equal(status.state, "success");
+}
+
+{
+  const { result, status } = await runCase({
+    pullRequest: { ...basePullRequest, user: { login: "PendingMember" } },
+    membership: { state: "pending", role: "member" },
+  });
+  assert.equal(result.internal, false);
+  assert.equal(status.state, "failure");
 }
 
 {
@@ -67,6 +113,18 @@ async function runCase(options, env = {}) {
 {
   const notFound = Object.assign(new Error("Not Found"), { status: 404 });
   const { status } = await runCase({ membershipError: notFound });
+  assert.equal(status.state, "failure");
+}
+
+{
+  const notFound = Object.assign(new Error("Not Found"), { status: 404 });
+  const { status } = await runCase({
+    membershipError: notFound,
+    reviews: [
+      { id: 1, state: "APPROVED", commit_id: "head-sha", user: { login: "SpicyMarinara" } },
+      { id: 2, state: "CHANGES_REQUESTED", commit_id: "head-sha", user: { login: "SpicyMarinara" } },
+    ],
+  });
   assert.equal(status.state, "failure");
 }
 
@@ -104,6 +162,25 @@ async function runCase(options, env = {}) {
   const forbidden = Object.assign(new Error("Forbidden"), { status: 403 });
   const { status } = await runCase({ membershipError: forbidden });
   assert.equal(status.state, "error");
+}
+
+{
+  const unavailable = Object.assign(new Error("Service unavailable"), { status: 503 });
+  const { status } = await runCase({
+    membershipError: Object.assign(new Error("Not Found"), { status: 404 }),
+    reviewsError: unavailable,
+  });
+  assert.equal(status.state, "error");
+}
+
+{
+  const { status, getStatusAttempts } = await runCase({
+    pullRequest: { ...basePullRequest, user: { login: "MemberDeveloper" } },
+    membership: { state: "active", role: "member" },
+    statusFailures: 1,
+  });
+  assert.equal(status.state, "error");
+  assert.equal(getStatusAttempts(), 2);
 }
 
 console.info("Owner approval evaluator tests passed.");

--- a/scripts/validate-pr-triage.mjs
+++ b/scripts/validate-pr-triage.mjs
@@ -84,11 +84,17 @@ export function validatePullRequestTriage() {
     reviewEvaluator,
     /on:\n  workflow_run:\n    workflows: \[Owner Approval Review Signal\]\n    types: \[completed\]/u,
   );
+  assert.match(
+    reviewEvaluator,
+    /group: owner-approval-review-\$\{\{ github\.event\.workflow_run\.pull_requests\[0\]\.number \|\| github\.event\.workflow_run\.head_sha \}\}\n  cancel-in-progress: true/u,
+  );
   assert.match(reviewEvaluator, /statuses: write/u);
   assert.match(reviewEvaluator, /ref: \$\{\{ github\.event\.repository\.default_branch \}\}/u);
+  assert.match(reviewEvaluator, /GET \/repos\/\{owner\}\/\{repo\}\/commits\/\{commit_sha\}\/pulls/u);
+  assert.match(reviewEvaluator, /commit_sha: context\.payload\.workflow_run\.head_sha/u);
   assert.match(reviewEvaluator, /PASTA_DEVS_MEMBERS_TOKEN/u);
   assert.match(reviewEvaluator, /run: node scripts\/evaluate-owner-approval\.mjs/u);
-  assert.doesNotMatch(reviewEvaluator, /pull_request\.head|head_repository|head_sha/u);
+  assert.doesNotMatch(reviewEvaluator, /ref:.*workflow_run|head_repository/u);
 
   assert.match(approvalEvaluator, /\/orgs\/\$\{encodeURIComponent\(organization\)\}\/memberships\//u);
   assert.match(approvalEvaluator, /membership\.state === "active"/u);

--- a/scripts/validate-pr-triage.mjs
+++ b/scripts/validate-pr-triage.mjs
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { existsSync, readFileSync } from "node:fs";
+import { readFileSync } from "node:fs";
 import { pathToFileURL } from "node:url";
 
 function extractNamedStep(workflow, stepName) {
@@ -17,13 +17,32 @@ function extractNamedStep(workflow, stepName) {
   return workflow.slice(start, end).trimEnd();
 }
 
+function extractJob(workflow, jobId) {
+  const marker = `  ${jobId}:\n`;
+  const start = workflow.indexOf(marker);
+  assert.notEqual(start, -1, `Missing workflow job: ${jobId}`);
+
+  const contentStart = start + marker.length;
+  const nextJobMatch = workflow.slice(contentStart).match(/\n  [A-Za-z_][A-Za-z0-9_-]*:\s*\n/u);
+  const end = nextJobMatch?.index === undefined ? undefined : contentStart + nextJobMatch.index;
+  return workflow.slice(start, end).trimEnd();
+}
+
 export function validatePullRequestTriage() {
   const triageWorkflow = readFileSync(
     new URL("../.github/workflows/pull-request-triage.yml", import.meta.url),
     "utf8",
   );
+  const reviewSignal = readFileSync(
+    new URL("../.github/workflows/owner-approval-review-signal.yml", import.meta.url),
+    "utf8",
+  );
+  const reviewEvaluator = readFileSync(
+    new URL("../.github/workflows/owner-approval-review.yml", import.meta.url),
+    "utf8",
+  );
+  const approvalEvaluator = readFileSync(new URL("./evaluate-owner-approval.mjs", import.meta.url), "utf8");
   const codeOwners = readFileSync(new URL("../.github/CODEOWNERS", import.meta.url), "utf8");
-  const untrustedReviewGate = new URL("../.github/workflows/owner-approval-review.yml", import.meta.url);
   const triggersSectionStart = triageWorkflow.indexOf("\non:\n");
   const triggersSectionEnd = triageWorkflow.indexOf("\nconcurrency:\n", triggersSectionStart);
   const jobsSectionStart = triageWorkflow.indexOf("\njobs:\n");
@@ -42,9 +61,42 @@ export function validatePullRequestTriage() {
       .matchAll(/^  ([A-Za-z_][A-Za-z0-9_-]*):\s*$/gmu),
   ].map((match) => match[1]);
   assert.ok(jobIds.includes("branch-policy"));
+  assert.ok(jobIds.includes("owner-approval"));
   assert.ok(jobIds.includes("template-check"));
-  assert.equal(jobIds.some((jobId) => /approval|review/iu.test(jobId)), false);
-  assert.doesNotMatch(triageWorkflow, /github\.event\.review|pulls\.listReviews|PASTA_DEVS_MEMBERS_TOKEN/u);
+  assert.doesNotMatch(triageWorkflow, /pull_request_review|github\.event\.review/u);
+
+  const ownerApprovalJob = extractJob(triageWorkflow, "owner-approval");
+  assert.match(ownerApprovalJob, /if: github\.event\.pull_request\.base\.ref == 'staging'/u);
+  assert.match(ownerApprovalJob, /statuses: write/u);
+  assert.match(ownerApprovalJob, /ref: \$\{\{ github\.event\.pull_request\.base\.sha \}\}/u);
+  assert.match(ownerApprovalJob, /PASTA_DEVS_MEMBERS_TOKEN/u);
+  assert.match(ownerApprovalJob, /run: node scripts\/evaluate-owner-approval\.mjs/u);
+  assert.doesNotMatch(ownerApprovalJob, /github\.event\.pull_request\.head/u);
+
+  assert.match(
+    reviewSignal,
+    /on:\n  pull_request_review:\n    types: \[submitted, edited, dismissed\]/u,
+  );
+  assert.match(reviewSignal, /permissions: \{\}/u);
+  assert.doesNotMatch(reviewSignal, /secrets\.|github\.token|actions\/checkout|PASTA_DEVS_MEMBERS_TOKEN/u);
+
+  assert.match(
+    reviewEvaluator,
+    /on:\n  workflow_run:\n    workflows: \[Owner Approval Review Signal\]\n    types: \[completed\]/u,
+  );
+  assert.match(reviewEvaluator, /statuses: write/u);
+  assert.match(reviewEvaluator, /ref: \$\{\{ github\.event\.repository\.default_branch \}\}/u);
+  assert.match(reviewEvaluator, /PASTA_DEVS_MEMBERS_TOKEN/u);
+  assert.match(reviewEvaluator, /run: node scripts\/evaluate-owner-approval\.mjs/u);
+  assert.doesNotMatch(reviewEvaluator, /pull_request\.head|head_repository|head_sha/u);
+
+  assert.match(approvalEvaluator, /\/orgs\/\$\{encodeURIComponent\(organization\)\}\/memberships\//u);
+  assert.match(approvalEvaluator, /membership\.state === "active"/u);
+  assert.match(approvalEvaluator, /membership\.role === "admin" \|\| membership\.role === "member"/u);
+  assert.match(approvalEvaluator, /latestOwnerReview\?\.state === "APPROVED"/u);
+  assert.match(approvalEvaluator, /latestOwnerReview\.commit_id === headSha/u);
+  assert.match(approvalEvaluator, /\/statuses\/\$\{encodeURIComponent\(headSha\)\}/u);
+  assert.match(approvalEvaluator, /Owner approval for outside contributors/u);
 
   const exemptionStep = extractNamedStep(triageWorkflow, "Exempt trusted contributor");
   assert.equal(
@@ -59,11 +111,10 @@ export function validatePullRequestTriage() {
     ].join("\n"),
   );
 
-  assert.equal(existsSync(untrustedReviewGate), false);
   assert.match(codeOwners, /^\* @SpicyMarinara$/mu);
 }
 
 if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
   validatePullRequestTriage();
-  console.info("Pull request workflow gates are stable; owner approval is enforced by the native staging ruleset.");
+  console.info("Pull request workflow gates are stable and use a trusted token-backed staging approval status.");
 }


### PR DESCRIPTION
## Linked issue

Closes #4473

## Why this change

The native staging Code Owner rule leaves Pasta-Devs members in a review-required state and only offers a manual ruleset bypass. Member and owner pull requests should receive a successful status automatically, while outside contributors should still require SpicyMarinara's approval.

## What changed

- Publish a token-backed `Owner approval for outside contributors` commit status from trusted staging code.
- Treat active Pasta-Devs `member` and `admin` organization roles as internal contributors.
- Fail closed for missing or invalid membership credentials and for outside contributors without a current SpicyMarinara approval.
- Refresh the status after review activity through a permissionless signal and a trusted default-branch evaluator.
- Add topology validation and evaluator regression coverage.
- Restore the existing status as a required staging quality gate and disable the conflicting native staging Code Owner rule.

## Validation

- [ ] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed `CONTRIBUTING.md`

### Manual verification notes

- `pnpm check`, `pnpm version:check`, `pnpm guard:installer-artifacts`, the policy topology validator, and evaluator regression cases were run locally.
- The staging quality ruleset now requires `Owner approval for outside contributors`; the native staging Code Owner ruleset is disabled.
- PR #4472 changed from `REVIEW_REQUIRED` to no review requirement. Its only remaining merge state at verification time was `BEHIND`.
- Manually verify an outside contributor remains blocked until SpicyMarinara approves the current head commit.
- Promote the trusted review evaluator to the default branch before relying on review-event refreshes.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Translated docs on the `docs-i18n` branch updated to match, or a `[docs-i18n] <paths>` follow-up issue opened (see CONTRIBUTING.md § Translated documentation)
- [ ] Version/release files updated (only if this PR includes a version bump)

## UI evidence (if applicable)

Not applicable; CI policy only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated owner-approval checks for pull requests targeting staging.
  * Approval status now reflects contributor membership and current review approvals.
  * Added review-event handling and follow-up evaluation workflows.
* **Bug Fixes**
  * Ensured approvals are matched to the latest pull-request commit.
  * Added safe handling for missing, invalid, or unavailable membership information.
* **Tests**
  * Added automated coverage for approval outcomes, token handling, and error scenarios.
  * Expanded validation of workflow permissions, trusted revisions, and status reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->