### PR TITLE
fix(ui): keep Roleplay context overlays in front

### DIFF
--- a/e2e/core-flows.e2e.ts
+++ b/e2e/core-flows.e2e.ts
@@ -4588,6 +4588,9 @@ test("Roleplay Active Context shows rich lorebook activation provenance", async 
 
     const panel = page.locator('[data-component="RoleplayActiveContextPanel"]');
     await expect(panel).toBeVisible();
+    await expect.poll(() => panel.evaluate((element) => element.parentElement === document.body)).toBe(true);
+    await expect(panel).toHaveCSS("position", "fixed");
+    await expect(panel).toHaveCSS("z-index", "9999");
     await expect(panel.getByText("2 active • ~321 tokens", { exact: true })).toBeVisible();
     await expect(panel.getByRole("region", { name: "Current location lore" })).toContainText("Northland Bank");
     await expect(panel.getByText("Whispered Archive", { exact: true })).toBeVisible();
@@ -4765,6 +4768,9 @@ test("chat toolbar panels close when their trigger is clicked again across modes
     const summaryPanel = page.locator("[data-chat-floating-panel]").filter({ hasText: "Chat Summary" });
     await summaryButton.click();
     await expect(summaryPanel).toBeVisible();
+    await expect.poll(() => summaryPanel.evaluate((element) => element.parentElement === document.body)).toBe(true);
+    await expect(summaryPanel).toHaveCSS("position", "fixed");
+    await expect(summaryPanel).toHaveCSS("z-index", "9999");
     await summaryButton.click();
     await expect(summaryPanel).toHaveCount(0);
 

--- a/packages/client/src/components/chat/ChatRoleplaySurface.tsx
+++ b/packages/client/src/components/chat/ChatRoleplaySurface.tsx
@@ -67,6 +67,7 @@ import {
   CHAT_TOOLBAR_OVERFLOW_MENU_SELECTOR,
   ChatToolbarButton,
   ChatToolbarMenu,
+  getChatFloatingPanelDesktopRight,
   getChatToolbarButtonClass,
   readChatToolbarFloatingPanelAnchor,
   type ChatToolbarFloatingPanelAnchor,
@@ -451,6 +452,7 @@ function ActiveContextLinksButton({
   const buttonRef = useRef<HTMLButtonElement>(null);
   const panelRef = useRef<HTMLDivElement>(null);
   const [mobileFrame, setMobileFrame] = useState<MobileFloatingPanelFrame | null>(null);
+  const [desktopAnchor, setDesktopAnchor] = useState<ChatToolbarFloatingPanelAnchor>(null);
   const isMobile = typeof window !== "undefined" && window.innerWidth < 768;
   const compact = useUIStore((s) => s.centerCompact);
   const { data: lorebooks } = useLorebooks();
@@ -473,11 +475,16 @@ function ActiveContextLinksButton({
   }, [open]);
 
   useLayoutEffect(() => {
-    if (!open || !isMobile) {
+    if (!open) {
       setMobileFrame(null);
+      setDesktopAnchor(null);
       return;
     }
-    const update = () => setMobileFrame(getMobileFloatingPanelFrame(buttonRef.current, 320));
+    const update = () => {
+      const mobile = window.innerWidth < 768;
+      setMobileFrame(mobile ? getMobileFloatingPanelFrame(buttonRef.current, 320) : null);
+      setDesktopAnchor(mobile ? null : readChatToolbarFloatingPanelAnchor(buttonRef.current));
+    };
     update();
     window.addEventListener("resize", update);
     window.addEventListener("scroll", update, true);
@@ -485,7 +492,7 @@ function ActiveContextLinksButton({
       window.removeEventListener("resize", update);
       window.removeEventListener("scroll", update, true);
     };
-  }, [isMobile, open]);
+  }, [open]);
 
   useEffect(() => {
     if (!open) return;
@@ -626,7 +633,9 @@ function ActiveContextLinksButton({
         onClick={() => {
           setOpen((prev) => {
             const nextOpen = !prev;
-            setMobileFrame(nextOpen && isMobile ? getMobileFloatingPanelFrame(buttonRef.current, 320) : null);
+            const mobile = typeof window !== "undefined" && window.innerWidth < 768;
+            setMobileFrame(nextOpen && mobile ? getMobileFloatingPanelFrame(buttonRef.current, 320) : null);
+            setDesktopAnchor(nextOpen && !mobile ? readChatToolbarFloatingPanelAnchor(buttonRef.current) : null);
             return nextOpen;
           });
         }}
@@ -660,19 +669,27 @@ function ActiveContextLinksButton({
             document.body,
           )
         ) : (
-          <div
-            ref={panelRef}
-            role="menu"
-            data-chat-floating-panel
-            data-component="RoleplayActiveContextPanel"
-            className={cn(
-              ROLEPLAY_POPOVER_SHELL,
-              ROLEPLAY_POPOVER_SCROLL_AREA,
-              "absolute right-0 top-full z-50 mt-2 max-h-[min(32rem,calc(100vh-6rem))] w-[min(20rem,calc(100vw-2rem))] overflow-y-auto p-2",
-            )}
-          >
-            {activeContextContent}
-          </div>
+          desktopAnchor &&
+          createPortal(
+            <div
+              ref={panelRef}
+              role="menu"
+              data-chat-floating-panel
+              data-component="RoleplayActiveContextPanel"
+              className={cn(
+                ROLEPLAY_POPOVER_SHELL,
+                ROLEPLAY_POPOVER_SCROLL_AREA,
+                "fixed z-[9999] max-h-[min(32rem,calc(100vh-6rem))] w-[min(20rem,calc(100vw-2rem))] overflow-y-auto p-2",
+              )}
+              style={{
+                right: getChatFloatingPanelDesktopRight(desktopAnchor),
+                top: `${desktopAnchor.top}px`,
+              }}
+            >
+              {activeContextContent}
+            </div>,
+            document.body,
+          )
         ))}
     </div>
   );

--- a/packages/client/src/components/chat/ChatRoleplaySurface.tsx
+++ b/packages/client/src/components/chat/ChatRoleplaySurface.tsx
@@ -480,7 +480,8 @@ function ActiveContextLinksButton({
       setDesktopAnchor(null);
       return;
     }
-    const update = () => {
+    const update = (event?: Event) => {
+      if (event?.target instanceof Node && panelRef.current?.contains(event.target)) return;
       const mobile = window.innerWidth < 768;
       setMobileFrame(mobile ? getMobileFloatingPanelFrame(buttonRef.current, 320) : null);
       setDesktopAnchor(mobile ? null : readChatToolbarFloatingPanelAnchor(buttonRef.current));
@@ -630,15 +631,7 @@ function ActiveContextLinksButton({
     <div className="relative" ref={ref} onClick={(event) => event.stopPropagation()}>
       <button
         ref={buttonRef}
-        onClick={() => {
-          setOpen((prev) => {
-            const nextOpen = !prev;
-            const mobile = typeof window !== "undefined" && window.innerWidth < 768;
-            setMobileFrame(nextOpen && mobile ? getMobileFloatingPanelFrame(buttonRef.current, 320) : null);
-            setDesktopAnchor(nextOpen && !mobile ? readChatToolbarFloatingPanelAnchor(buttonRef.current) : null);
-            return nextOpen;
-          });
-        }}
+        onClick={() => setOpen((prev) => !prev)}
         className={getChatToolbarButtonClass({ compact, open })}
         title={t("chat.toolbar.activeContext")}
         aria-label={t("chat.toolbar.activeContext")}

--- a/packages/client/src/components/chat/SummaryPopover.tsx
+++ b/packages/client/src/components/chat/SummaryPopover.tsx
@@ -119,6 +119,7 @@ const SUMMARY_TOKEN_WARNING_THRESHOLD = 1800;
 const SUMMARY_HEADING_PATTERN = /^(?:#{1,6}\s*)?(?:\*\*)?([^:\n]{3,80})(?:\*\*)?:\s*$/;
 const SUMMARY_BULLET_PATTERN = /^[-*•]\s+/;
 const MOBILE_SUMMARY_PADDING = 8;
+const DESKTOP_SUMMARY_WIDTH = 576;
 
 function clampSummaryMaxTokens(value: unknown): number {
   const parsed = Number(value);
@@ -145,6 +146,22 @@ function getMobileSummaryFrame(anchor: SummaryPopoverAnchor | null | undefined) 
   );
   const top = Math.max(MOBILE_SUMMARY_PADDING, anchor?.overflowMenu ? anchor.top : (anchor?.bottom ?? 56));
   const maxHeight = Math.max(240, window.innerHeight - top - MOBILE_SUMMARY_PADDING);
+  return { top, left, width, maxHeight };
+}
+
+function getDesktopSummaryFrame(anchor: SummaryPopoverAnchor | null | undefined) {
+  if (typeof window === "undefined") return null;
+  const width = Math.min(DESKTOP_SUMMARY_WIDTH, window.innerWidth - MOBILE_SUMMARY_PADDING * 2);
+  const rightEdge = anchor?.right ?? window.innerWidth - MOBILE_SUMMARY_PADDING;
+  const left = Math.max(
+    MOBILE_SUMMARY_PADDING,
+    Math.min(rightEdge - width, window.innerWidth - width - MOBILE_SUMMARY_PADDING),
+  );
+  const top = Math.max(MOBILE_SUMMARY_PADDING, (anchor?.bottom ?? 52) + 4);
+  const maxHeight = Math.max(
+    240,
+    Math.min(736, window.innerHeight - top - MOBILE_SUMMARY_PADDING),
+  );
   return { top, left, width, maxHeight };
 }
 
@@ -1026,7 +1043,7 @@ export function SummaryPopover({
   const isGenerating = generateSummary.isPending;
 
   const isMobile = typeof window !== "undefined" && window.innerWidth < 768;
-  const mobileFrame = isMobile ? getMobileSummaryFrame(anchor) : null;
+  const panelFrame = isMobile ? getMobileSummaryFrame(anchor) : getDesktopSummaryFrame(anchor);
 
   const handlePanelMouseDown = useCallback((event: ReactMouseEvent<HTMLDivElement>) => {
     event.stopPropagation();
@@ -1041,25 +1058,16 @@ export function SummaryPopover({
       data-chat-floating-panel
       onMouseDown={handlePanelMouseDown}
       onPointerDown={handlePanelPointerDown}
-      className={cn(isMobile ? "fixed z-[9999]" : "absolute right-0 top-full z-[100] mt-1")}
-      style={
-        mobileFrame
-          ? {
-              top: mobileFrame.top,
-              left: mobileFrame.left,
-              width: mobileFrame.width,
-            }
-          : undefined
-      }
+      className="fixed z-[9999]"
+      style={panelFrame ? { top: panelFrame.top, left: panelFrame.left, width: panelFrame.width } : undefined}
     >
       <div
         className={cn(
           ROLEPLAY_POPOVER_SHELL,
           ROLEPLAY_POPOVER_SCROLL_AREA,
-          "relative flex flex-col overflow-hidden p-3",
-          isMobile ? "w-full" : "max-h-[min(46rem,calc(100vh-5rem))] w-[36rem]",
+          "relative flex w-full flex-col overflow-hidden p-3",
         )}
-        style={mobileFrame ? { maxHeight: mobileFrame.maxHeight } : undefined}
+        style={panelFrame ? { maxHeight: panelFrame.maxHeight } : undefined}
       >
         {/* Header */}
         <div className="mb-2 flex items-start justify-between gap-3">
@@ -1745,7 +1753,7 @@ export function SummaryPopover({
     </div>
   );
 
-  return isMobile ? createPortal(content, document.body) : content;
+  return createPortal(content, document.body);
 }
 
 interface SummarySettingsToggleProps {

--- a/scripts/regressions/roleplay-streaming.regression.ts
+++ b/scripts/regressions/roleplay-streaming.regression.ts
@@ -143,6 +143,23 @@ const summaryPopoverSource = readFileSync(
   new URL("../../packages/client/src/components/chat/SummaryPopover.tsx", import.meta.url),
   "utf8",
 );
+const activeContextLinksButtonSource =
+  chatRoleplaySurfaceSource.match(/function ActiveContextLinksButton[\s\S]*?\nfunction SummaryButton/u)?.[0] ?? "";
+assert.match(
+  summaryPopoverSource,
+  /className="fixed z-\[9999\]"[\s\S]*?return createPortal\(content, document\.body\)/u,
+  "the Roleplay Chat Summary panel should portal above independent floating-panel stacking contexts",
+);
+assert.match(
+  activeContextLinksButtonSource,
+  /desktopAnchor &&[\s\S]*?createPortal\([\s\S]*?data-component="RoleplayActiveContextPanel"[\s\S]*?fixed z-\[9999\][\s\S]*?document\.body/u,
+  "the desktop Roleplay Active Context panel should portal above independent floating-panel stacking contexts",
+);
+assert.doesNotMatch(
+  activeContextLinksButtonSource,
+  /absolute right-0 top-full/u,
+  "the desktop Roleplay Active Context panel must not remain trapped in the toolbar stacking context",
+);
 const spatialTransitionEventSource =
   useGenerateSource.match(/case "spatial_transition_committed": \{[\s\S]*?case "token":/u)?.[0] ?? "";
 assert.match(


### PR DESCRIPTION
> [!IMPORTANT]
> This PR is AI-assisted. Validation and test-plan checkboxes are intentionally left for a human contributor to confirm.

## Linked issue

Closes #4476

## Why

In Roleplay mode, Chat Summary and Active Context were rendered inside the toolbar's stacking context on desktop. Their local z-index could not escape that context, so independent floating surfaces such as Echo Chamber stream chat and the Trackers panel could paint above them.

## What changed

- Portal the desktop Chat Summary panel to `document.body` and position it from its toolbar anchor.
- Portal the desktop Active Context panel to `document.body` using the shared floating-panel anchor helpers.
- Keep the existing mobile portal behavior while giving both panels the same top overlay layer used by Branches.
- Add source and browser regression assertions that prevent either desktop panel from returning to toolbar-local absolute positioning.

## Validation

- [ ] Run `pnpm check`.
- [ ] Run `pnpm regression:roleplay`.
- [ ] Run `pnpm smoke:ui`.
- [ ] Manually verify Chat Summary opens above Echo Chamber stream chat in Roleplay mode.
- [ ] Manually verify Active Context opens above the Trackers panel in Roleplay mode.
- [ ] Manually verify both panels remain correctly positioned on desktop and mobile viewport sizes.

### Manual verification notes

- `pnpm check` passed locally for the overlay implementation.
- `pnpm regression:roleplay` passed on the final branch head after syncing current `staging`.
- Focused Playwright proof passed for desktop and mobile Active Context and desktop Chat Summary (3 passed, 1 expected mobile-only skip). The tests assert each open panel is a direct child of `document.body` with computed `position: fixed` and `z-index: 9999`.
- The full UI smoke suite was attempted, but the host ran out of disk space in Playwright's disposable cache after 83 tests passed. The focused overlay tests were rerun cleanly after freeing the temporary worktree.
- The in-app browser controller could not attach because its bundled runtime failed during initialization, so no separate manual screenshot is claimed.

## Docs and release impact

- [ ] Confirm no documentation update is needed for this stacking-order bugfix.
- [ ] Confirm no release metadata changes are needed.

## UI evidence

Automated desktop/mobile browser assertions are included in `e2e/core-flows.e2e.ts`; the focused run passed locally.
