### PR TITLE
fix(maps): refresh lorebooks after portable imports

### DIFF
--- a/packages/client/src/components/chat/ChatSettingsDrawer.tsx
+++ b/packages/client/src/components/chat/ChatSettingsDrawer.tsx
@@ -110,7 +110,7 @@ import { ConversationTimeZoneSelect } from "./ConversationTimeZoneSelect";
 import { RoleplayMessagePreview } from "./ChatMessage";
 import { CHAT_SETTINGS_SURFACES } from "./chat-settings-surfaces";
 import { useCharacters, usePersonas, useCharacterGroups, type SpriteInfo } from "../../hooks/use-characters";
-import { useLorebooks, useEntriesAcrossLorebooks } from "../../hooks/use-lorebooks";
+import { lorebookKeys, useLorebooks, useEntriesAcrossLorebooks } from "../../hooks/use-lorebooks";
 import { useDefaultPreset, usePresetFull, usePresets } from "../../hooks/use-presets";
 import { useConnections } from "../../hooks/use-connections";
 import { useKnowledgeSources, useUploadKnowledgeSource } from "../../hooks/use-knowledge-sources";
@@ -1061,12 +1061,17 @@ export function ChatSettingsDrawer({
     openRightPanel("agents");
     openAgentCatalog();
   }, [onClose, openAgentCatalog, openRightPanel]);
+  const refreshLorebooks = useCallback(
+    () => qc.invalidateQueries({ queryKey: lorebookKeys.all }),
+    [qc],
+  );
   const openLorebookFromSettings = useCallback(
     (lorebookId: string) => {
+      void refreshLorebooks();
       onClose();
       openLorebookDetail(lorebookId);
     },
-    [onClose, openLorebookDetail],
+    [onClose, openLorebookDetail, refreshLorebooks],
   );
   const inactiveCharacterIds = useMemo<string[]>(
     () =>
@@ -8146,6 +8151,7 @@ export function ChatSettingsDrawer({
                                             confirmAction: showConfirmDialog,
                                             onDirtyChange: setEditorDirty,
                                             onOpenLorebook: openLorebookFromSettings,
+                                            onLorebooksChanged: refreshLorebooks,
                                           }}
                                           className="block overflow-hidden rounded-lg"
                                         />
@@ -8467,6 +8473,7 @@ export function ChatSettingsDrawer({
                                                 confirmAction: showConfirmDialog,
                                                 onDirtyChange: setEditorDirty,
                                                 onOpenLorebook: openLorebookFromSettings,
+                                                onLorebooksChanged: refreshLorebooks,
                                               }}
                                               className="mt-2 block overflow-hidden rounded-lg"
                                             />

--- a/packages/client/src/components/layout/AppShell.tsx
+++ b/packages/client/src/components/layout/AppShell.tsx
@@ -2,6 +2,7 @@
 // Layout: Main App Shell (Discord-like three-column)
 // ──────────────────────────────────────────────
 import { ChatSidebar } from "./ChatSidebar";
+import { useQueryClient } from "@tanstack/react-query";
 import { TopBar } from "./TopBar";
 import { SpotifyMobileWidget } from "../spotify/SpotifyMiniPlayer";
 import { YouTubeMobileWidget } from "../chat/YouTubePlayer";
@@ -22,6 +23,7 @@ import {
 import { useChatStore } from "../../stores/chat.store";
 import { useBackgroundAutonomousPolling } from "../../hooks/use-background-autonomous";
 import { useClearAutonomousUnread, useUpdateChatMetadata } from "../../hooks/use-chats";
+import { lorebookKeys } from "../../hooks/use-lorebooks";
 import { useIdleDetection } from "../../hooks/use-idle-detection";
 import { dispatchChatVisualViewportChange } from "../../hooks/use-visual-viewport-chat-bottom";
 import { usePageActivity } from "../../hooks/use-page-activity";
@@ -223,6 +225,7 @@ function SidePanelFallback() {
 
 export function AppShell() {
   const { t: localizeUi } = useUiTranslation();
+  const queryClient = useQueryClient();
   const capabilityAgents = useCapabilityAgentRegistry();
   const installedCapabilities = useCapabilityClientModules();
   const updateChatMetadata = useUpdateChatMetadata();
@@ -355,6 +358,17 @@ export function AppShell() {
   const openAgentCatalog = useUIStore((s) => s.openAgentCatalog);
   const setTrackerPanelOpen = useUIStore((s) => s.setTrackerPanelOpen);
   const restoreTrackerPanelOpenForChat = useUIStore((s) => s.restoreTrackerPanelOpenForChat);
+  const refreshLorebooks = useCallback(
+    () => queryClient.invalidateQueries({ queryKey: lorebookKeys.all }),
+    [queryClient],
+  );
+  const openSpatialLorebook = useCallback(
+    (lorebookId: string) => {
+      void refreshLorebooks();
+      openLorebookDetail(lorebookId);
+    },
+    [openLorebookDetail, refreshLorebooks],
+  );
   const [sidebarDragWidth, setSidebarDragWidth] = useState<number | null>(null);
   const [rightPanelDragWidth, setRightPanelDragWidth] = useState<number | null>(null);
   const sidebarDragWidthRef = useRef<number | null>(null);
@@ -754,7 +768,8 @@ export function AppShell() {
           debugMode,
           confirmAction: showConfirmDialog,
           onDirtyChange: setEditorDirty,
-          onOpenLorebook: openLorebookDetail,
+          onOpenLorebook: openSpatialLorebook,
+          onLorebooksChanged: refreshLorebooks,
         }}
       />
     ) : (
@@ -1478,7 +1493,8 @@ export function AppShell() {
             confirmAction: showConfirmDialog,
             onClearPendingDraftReview: clearPendingSpatialMapDraftReview,
             onDirtyChange: setEditorDirty,
-            onOpenLorebook: openLorebookDetail,
+            onOpenLorebook: openSpatialLorebook,
+            onLorebooksChanged: refreshLorebooks,
             onClose: closeSpatialMapDetail,
           }}
         />

--- a/packages/client/src/components/layout/AppShell.tsx
+++ b/packages/client/src/components/layout/AppShell.tsx
@@ -1,8 +1,8 @@
 // ──────────────────────────────────────────────
 // Layout: Main App Shell (Discord-like three-column)
 // ──────────────────────────────────────────────
-import { ChatSidebar } from "./ChatSidebar";
 import { useQueryClient } from "@tanstack/react-query";
+import { ChatSidebar } from "./ChatSidebar";
 import { TopBar } from "./TopBar";
 import { SpotifyMobileWidget } from "../spotify/SpotifyMiniPlayer";
 import { YouTubeMobileWidget } from "../chat/YouTubePlayer";


### PR DESCRIPTION
> [!IMPORTANT]
> Contributions target `staging`. Only `SpicyMarinara` may promote this repository's `staging` branch or a same-repository `hotfix/*` branch to `main`.
> Outside and first-time contributors also require an approving review from `SpicyMarinara`.

## Linked issue

Closes #4490

Paired World Maps 1.3.0 package work: Pasta-Devs/Marinara-Agents#213

## Why this change

World Maps and the Engine app have separate React Query clients. Portable lore imports refreshed the package-local cache, but the main Lorebooks library kept its deleted-book list until the browser was reloaded. Linked-lore navigation also needed the host to invalidate that cache without delaying the requested editor transition.

## What changed

- Expose a host callback to World Maps that invalidates the complete Engine lorebook query family.
- Supply it to the full workspace, feature-agent detail host, and both Chat Settings World Maps mounts.
- Invalidate host lore state while opening linked lorebooks immediately through the existing detail navigation.
- Preserve all existing Lorebooks controls and copy; this is a cache-coordination change only.

## Validation

- [x] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [x] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed `CONTRIBUTING.md`

Automated evidence:

- `pnpm check` passed, including Impeccable context, localization, ESLint, TypeScript, and production builds.
- The paired package's portable-lore logic and exact World Maps 1.3.0 artifact lifecycle regressions passed.
- Desktop Chromium scenario `portable map import refreshes host lorebooks and linked navigation without reload` passed against an isolated Engine data directory seeded with the exact 1.3.0 ZIP.
- `git diff --check` passed.

### Manual verification notes

- Manually verify a portable lorebook copy appears in the main Lorebooks library without a browser reload.
- Manually verify linked-lore Open from a saved map.
- Manually verify linked-lore Open after discarding unsaved map changes.
- Manually verify existing non-Maps lorebook navigation is unchanged.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Translated docs on the `docs-i18n` branch updated to match, or a `[docs-i18n]` follow-up issue opened (see CONTRIBUTING.md § Translated documentation)
- [ ] Version/release files updated (only if this PR includes a version bump)

No user-facing copy or Engine release metadata changed.

## UI evidence (if applicable)

Automated installed-package Chromium coverage proves the exact stale-cache reproduction and both host-library and linked-lore navigation paths. Human browser verification remains listed above.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Lorebook data now refreshes automatically when opening lorebooks from chat settings or spatial views.
  - Lorebook changes are reflected consistently across map and feature integrations.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->