### PR TITLE
fix: keep Game Mode party names canonical

### DIFF
--- a/packages/server/src/routes/generate.routes.ts
+++ b/packages/server/src/routes/generate.routes.ts
@@ -214,6 +214,7 @@ import {
   buildLockedPlayerStatsArrayPatch,
   buildLockedPersonaTrackerPatch,
   applyTrackerCharacterCardIdentity,
+  canonicalizeGamePartySpeakerLabels,
   collectLatestTrackerCharacterHistory,
   createLocalSidecarGenerationConnection,
   extractImageAttachmentDataUrls,
@@ -2864,6 +2865,7 @@ export async function generateRoutes(app: FastifyInstance) {
           injectSceneContextMessages({ messages: finalMessages, chatMetadata: chatMeta, charInfo, personaName });
         }
 
+        let canonicalGamePartyNames: string[] = [];
         if (chatMode === "game") {
           const selectedGamePrompt =
             resolvedPreset && presetId
@@ -2889,6 +2891,7 @@ export async function generateRoutes(app: FastifyInstance) {
               personaName,
               resolvePromptMacros,
             });
+          canonicalGamePartyNames = gmCtx.partyNames;
 
           // ── Lorebook injection for game mode ──
           if (!presetHandledLorebooks) {
@@ -5947,6 +5950,13 @@ export async function generateRoutes(app: FastifyInstance) {
               fullResponse = promotableThinking;
               fullThinking = "";
               providerThinking = "";
+              contentReplaced = true;
+            }
+          }
+          if (chatMode === "game") {
+            const canonicalResponse = canonicalizeGamePartySpeakerLabels(fullResponse, canonicalGamePartyNames);
+            if (canonicalResponse !== fullResponse) {
+              fullResponse = canonicalResponse;
               contentReplaced = true;
             }
           }

--- a/packages/server/src/routes/generate.routes.ts
+++ b/packages/server/src/routes/generate.routes.ts
@@ -7642,6 +7642,7 @@ export async function generateRoutes(app: FastifyInstance) {
                   snapBeforeUpdate ??
                   trackerBaseGameStateSnapshot ??
                   (allowLatestGameStateFallback ? await gameStateStore.getLatest(input.chatId) : null);
+                const cardCharacterIds = applyTrackerCharacterCardIdentity(chars, charInfo);
                 const oldChars = parseJsonField<any[]>(previousCharacterSnapshot?.presentCharacters, []);
                 preserveTrackerCharacterUiFields(chars, oldChars);
                 preserveTrackerCharacterUiFields(chars, characterTrackerHistory);
@@ -7661,7 +7662,6 @@ export async function generateRoutes(app: FastifyInstance) {
                 // 2. Fall back to stored NPC avatars (per-chat generated/uploaded)
                 const NPC_AVATAR_DIR = join(DATA_DIR, "avatars", "npc");
                 const storedNpcAvatarByName = new Map<string, string>();
-                const cardCharacterIds = applyTrackerCharacterCardIdentity(chars, charInfo);
                 const gameNpcs = sanitizeGameNpcAvatarUrls((chatMeta.gameNpcs as GameNpc[]) ?? []);
                 if (gameNpcs !== chatMeta.gameNpcs) {
                   chatMeta.gameNpcs = gameNpcs;

--- a/packages/server/src/routes/generate/generate-route-utils.ts
+++ b/packages/server/src/routes/generate/generate-route-utils.ts
@@ -1276,7 +1276,7 @@ type TrackerCharacterCardIdentity = {
   avatarCrop?: unknown;
 };
 
-function getExplicitTrackerNameAliases(value: unknown): string[] {
+function getExplicitNameAliases(value: unknown): string[] {
   if (typeof value !== "string") return [];
   const aliases = new Set<string>();
   const patterns = [
@@ -1295,6 +1295,45 @@ function getExplicitTrackerNameAliases(value: unknown): string[] {
   return [...aliases];
 }
 
+function buildUniqueCanonicalNames(names: readonly string[]): Map<string, string> {
+  const namesByKey = new Map<string, string>();
+  const duplicateKeys = new Set<string>();
+  for (const name of names) {
+    const trimmedName = name.trim();
+    const key = normalizeTextForMatch(trimmedName);
+    if (!key) continue;
+    if (namesByKey.has(key)) duplicateKeys.add(key);
+    else namesByKey.set(key, trimmedName);
+  }
+  for (const key of duplicateKeys) namesByKey.delete(key);
+  return namesByKey;
+}
+
+function resolveExplicitCanonicalName(value: unknown, namesByKey: Map<string, string>): string | null {
+  const exactName = namesByKey.get(normalizeTextForMatch(value));
+  if (exactName) return exactName;
+
+  const aliasMatches = getExplicitNameAliases(value)
+    .map((alias) => namesByKey.get(alias))
+    .filter((candidate): candidate is string => !!candidate);
+  const uniqueMatches = new Set(aliasMatches);
+  return uniqueMatches.size === 1 ? aliasMatches[0]! : null;
+}
+
+/** Canonicalize only structured Game Mode VN speaker labels, leaving prose and ambiguous aliases unchanged. */
+export function canonicalizeGamePartySpeakerLabels(content: string, canonicalNames: readonly string[]): string {
+  const namesByKey = buildUniqueCanonicalNames(canonicalNames);
+  if (!content || namesByKey.size === 0) return content;
+
+  return content.replace(
+    /^(\s*)\[([^\]\r\n]+)\](\s+\[(?:main|side|thought|whisper:[^\]\r\n]+)\]\s+\[[^\]\r\n]+\]\s*:)/gmu,
+    (line, indentation: string, speakerName: string, suffix: string) => {
+      const canonicalName = resolveExplicitCanonicalName(speakerName, namesByKey);
+      return canonicalName ? `${indentation}[${canonicalName}]${suffix}` : line;
+    },
+  );
+}
+
 export function applyTrackerCharacterCardIdentity(
   characters: Array<Record<string, unknown>>,
   cards: TrackerCharacterCardIdentity[],
@@ -1309,19 +1348,17 @@ export function applyTrackerCharacterCardIdentity(
     else cardsByName.set(name, card);
   }
   for (const name of duplicateNames) cardsByName.delete(name);
+  const canonicalCardNamesByKey = new Map([...cardsByName].map(([key, card]) => [key, card.name]));
 
   const matchedIds = new Set<string>();
   const canonicalCharacters: Array<Record<string, unknown>> = [];
   const canonicalIndexByCardId = new Map<string, number>();
   for (const character of characters) {
-    const cardByAlias = getExplicitTrackerNameAliases(character.name)
-      .map((alias) => cardsByName.get(alias))
-      .filter((candidate): candidate is TrackerCharacterCardIdentity => !!candidate);
-    const uniqueAliasCardIds = new Set(cardByAlias.map((candidate) => candidate.id));
+    const explicitCanonicalName = resolveExplicitCanonicalName(character.name, canonicalCardNamesByKey);
     const card =
       cardsById.get(trackerCharacterIdKey(character)) ??
       cardsByName.get(trackerCharacterNameKey(character)) ??
-      (uniqueAliasCardIds.size === 1 ? cardByAlias[0] : undefined);
+      (explicitCanonicalName ? cardsByName.get(normalizeTextForMatch(explicitCanonicalName)) : undefined);
     if (!card) {
       canonicalCharacters.push(character);
       continue;

--- a/packages/server/src/routes/generate/generate-route-utils.ts
+++ b/packages/server/src/routes/generate/generate-route-utils.ts
@@ -1276,6 +1276,25 @@ type TrackerCharacterCardIdentity = {
   avatarCrop?: unknown;
 };
 
+function getExplicitTrackerNameAliases(value: unknown): string[] {
+  if (typeof value !== "string") return [];
+  const aliases = new Set<string>();
+  const patterns = [
+    /"([^"\n]{1,80})"/gu,
+    /“([^”\n]{1,80})”/gu,
+    /'([^'\n]{1,80})'/gu,
+    /‘([^’\n]{1,80})’/gu,
+    /\(([^()\n]{1,80})\)/gu,
+  ];
+  for (const pattern of patterns) {
+    for (const match of value.matchAll(pattern)) {
+      const alias = normalizeTextForMatch(match[1]);
+      if (alias) aliases.add(alias);
+    }
+  }
+  return [...aliases];
+}
+
 export function applyTrackerCharacterCardIdentity(
   characters: Array<Record<string, unknown>>,
   cards: TrackerCharacterCardIdentity[],
@@ -1292,14 +1311,42 @@ export function applyTrackerCharacterCardIdentity(
   for (const name of duplicateNames) cardsByName.delete(name);
 
   const matchedIds = new Set<string>();
+  const canonicalCharacters: Array<Record<string, unknown>> = [];
+  const canonicalIndexByCardId = new Map<string, number>();
   for (const character of characters) {
-    const card = cardsById.get(trackerCharacterIdKey(character)) ?? cardsByName.get(trackerCharacterNameKey(character));
-    if (!card) continue;
-    character.characterId = card.id;
-    character.avatarPath = card.avatarPath ?? null;
-    character.avatarCrop = card.avatarCrop ?? null;
+    const cardByAlias = getExplicitTrackerNameAliases(character.name)
+      .map((alias) => cardsByName.get(alias))
+      .filter((candidate): candidate is TrackerCharacterCardIdentity => !!candidate);
+    const uniqueAliasCardIds = new Set(cardByAlias.map((candidate) => candidate.id));
+    const card =
+      cardsById.get(trackerCharacterIdKey(character)) ??
+      cardsByName.get(trackerCharacterNameKey(character)) ??
+      (uniqueAliasCardIds.size === 1 ? cardByAlias[0] : undefined);
+    if (!card) {
+      canonicalCharacters.push(character);
+      continue;
+    }
+
+    const canonicalCharacter = {
+      ...character,
+      characterId: card.id,
+      name: card.name,
+      avatarPath: card.avatarPath ?? null,
+      avatarCrop: card.avatarCrop ?? null,
+    };
+    const existingIndex = canonicalIndexByCardId.get(card.id);
+    if (existingIndex === undefined) {
+      canonicalIndexByCardId.set(card.id, canonicalCharacters.length);
+      canonicalCharacters.push(canonicalCharacter);
+    } else {
+      canonicalCharacters[existingIndex] = {
+        ...canonicalCharacters[existingIndex],
+        ...canonicalCharacter,
+      };
+    }
     matchedIds.add(card.id);
   }
+  characters.splice(0, characters.length, ...canonicalCharacters);
   return matchedIds;
 }
 

--- a/packages/server/src/routes/generate/retry-agents-route.ts
+++ b/packages/server/src/routes/generate/retry-agents-route.ts
@@ -2960,12 +2960,12 @@ async function applyRetryResultEffects(args: {
             previousCharacters = [];
           }
         }
+        applyTrackerCharacterCardIdentity(presentCharacters, agentContext.characters);
         preserveTrackerCharacterUiFields(presentCharacters, previousCharacters);
         preserveTrackerCharacterUiFields(
           presentCharacters,
           (agentContext.characterTrackerHistory ?? []) as unknown as Array<Record<string, unknown>>,
         );
-        applyTrackerCharacterCardIdentity(presentCharacters, agentContext.characters);
         const lockedCharacterPatch = applyTrackerFieldLocksToGameStatePatch(
           { presentCharacters },
           previousSnapshot ? parseGameStateRow(previousSnapshot as Record<string, unknown>) : null,

--- a/packages/server/src/services/game/gm-prompts.ts
+++ b/packages/server/src/services/game/gm-prompts.ts
@@ -683,6 +683,7 @@ export function buildGmFormatReminder(
     `FORMAT:`,
     `- Narration: text - 1-4 sentences per beat, blank line between beats.`,
     `- Lines: [Name] [main|side|whisper:Target|thought] [neutral|happy|sad|angry|surprised|scared|disgusted|thinking|laughing|crying|blushing|smirk|embarrassed|determined|confused|sleepy|custom]: "Dialogue"|Thought - first bracket specifies the format, main is primary spoken line, side is a short aside like banter, cut-in, or interruption, whisper is quiet speech meant for one listener only, the thought is an internal monologue (no quotes for it), and the last bracket is the character's expression when delivering the line.`,
+    `- Party speaker labels must use the exact canonical names listed under PARTY. Never expand, combine, or replace a party member's name with a legal name, nickname, alias, title, or description-derived variant.`,
     ...(customSpriteLines.length
       ? [
           ``,

--- a/scripts/regressions/prompt.regression.ts
+++ b/scripts/regressions/prompt.regression.ts
@@ -64,7 +64,10 @@ import {
   formatNoodleTimelineForPrompt,
   NOODLE_PERSONA_IDENTITY_INSTRUCTION,
 } from "../../packages/server/src/services/noodle/noodle-prompt.js";
-import { buildPartyRecruitCardPrompt } from "../../packages/server/src/services/game/gm-prompts.js";
+import {
+  buildGmFormatReminder,
+  buildPartyRecruitCardPrompt,
+} from "../../packages/server/src/services/game/gm-prompts.js";
 import {
   normalizeCyoaChoiceOutput,
   normalizeCyoaDialogueQuotes,
@@ -150,6 +153,16 @@ assert.match(regeneratedSheetPrompt, /<campaign_history>/u);
 assert.match(regeneratedSheetPrompt, /Write every natural-language string value in Polish/u);
 assert.match(regeneratedSheetPrompt, /Scenario: The flooded vault/u);
 assert.doesNotMatch(regeneratedSheetPrompt, /A new companion is joining the party/u);
+
+const canonicalPartyNameReminder = buildGmFormatReminder({
+  gameActiveState: "exploration",
+  sessionNumber: 1,
+  map: null,
+  partyNames: ["Mari"],
+  playerName: "Player",
+});
+assert.match(canonicalPartyNameReminder, /Party speaker labels must use the exact canonical names listed under PARTY/u);
+assert.match(canonicalPartyNameReminder, /You also play Mari\./u);
 
 const REGRESSION_AGENT_IDS = [
   "about-me-keeper",
@@ -8479,6 +8492,41 @@ Use HTML sparingly and diegetically. Do not replace normal prose/dialogue unless
       assert.equal(returningCharacters[0]?.characterId, "mira-card");
       assert.equal(returningCharacters[0]?.avatarPath, "/api/avatars/file/mira.png");
       assert.equal(matchedCards.has("mira-card"), true);
+
+      const canonicalPartyCharacters: Array<Record<string, unknown>> = [
+        {
+          name: 'Marisol "Mari"',
+          mood: "Concerned",
+          appearance: "Expanded-name appearance",
+        },
+        {
+          name: "Mari",
+          mood: "Focused",
+          appearance: "Canonical-name appearance",
+        },
+      ];
+      const canonicalPartyMatches = applyTrackerCharacterCardIdentity(canonicalPartyCharacters, [
+        {
+          id: "party-card",
+          name: "Mari",
+          avatarPath: "/api/avatars/file/party-card.png",
+        },
+      ]);
+      assert.equal(canonicalPartyMatches.has("party-card"), true);
+      assert.deepEqual(canonicalPartyCharacters, [
+        {
+          characterId: "party-card",
+          name: "Mari",
+          mood: "Focused",
+          appearance: "Canonical-name appearance",
+          avatarPath: "/api/avatars/file/party-card.png",
+          avatarCrop: null,
+        },
+      ]);
+
+      const unrelatedLongName: Array<Record<string, unknown>> = [{ name: "Mari Calder" }];
+      applyTrackerCharacterCardIdentity(unrelatedLongName, [{ id: "party-card", name: "Mari" }]);
+      assert.deepEqual(unrelatedLongName, [{ name: "Mari Calder" }]);
 
       assert.equal(resolveCharacterCustomFieldName("  ", "Goal"), "Goal");
       assert.equal(makeUniqueCharacterCustomFieldName({ "New Field": "", "new   field 2": "" }), "New Field 3");

--- a/scripts/regressions/prompt.regression.ts
+++ b/scripts/regressions/prompt.regression.ts
@@ -625,6 +625,7 @@ import {
   appendNonLeadingSystemMessagesToLastUser,
   appendReadableAttachmentsToContent,
   applyTrackerCharacterCardIdentity,
+  canonicalizeGamePartySpeakerLabels,
   buildGenerationGuideInstruction,
   appendSeparateAgentInjectionMessage,
   collectLatestTrackerCharacterHistory,
@@ -8527,6 +8528,18 @@ Use HTML sparingly and diegetically. Do not replace normal prose/dialogue unless
       const unrelatedLongName: Array<Record<string, unknown>> = [{ name: "Mari Calder" }];
       applyTrackerCharacterCardIdentity(unrelatedLongName, [{ id: "party-card", name: "Mari" }]);
       assert.deepEqual(unrelatedLongName, [{ name: "Mari Calder" }]);
+
+      assert.equal(
+        canonicalizeGamePartySpeakerLabels(
+          '[Marisol "Mari"] [main] [happy]: "Ready."\n\nMarisol "Mari" crosses the room.',
+          ["Mari"],
+        ),
+        '[Mari] [main] [happy]: "Ready."\n\nMarisol "Mari" crosses the room.',
+      );
+      assert.equal(
+        canonicalizeGamePartySpeakerLabels('[Mari Calder] [main] [happy]: "Ready."', ["Mari"]),
+        '[Mari Calder] [main] [happy]: "Ready."',
+      );
 
       assert.equal(resolveCharacterCustomFieldName("  ", "Goal"), "Goal");
       assert.equal(makeUniqueCharacterCustomFieldName({ "New Field": "", "new   field 2": "" }), "New Field 3");


### PR DESCRIPTION
> [!IMPORTANT]
> Contributions target `staging`. Only `SpicyMarinara` may promote this repository's `staging` branch or a same-repository `hotfix/*` branch to `main`.
> Outside and first-time contributors also require an approving review from `SpicyMarinara`.

## Linked issue

Closes #4495

## Why this change

- Game Mode can accept a model-expanded full-name/nickname label for a party member whose saved card has a shorter canonical name.
- Later turns may use the saved name again, allowing one party member to become two Character Tracker identities and duplicate downstream appearance/visible-character context.
- Storyboard exposed the split identity, but the conflicting label originated in Game Mode narration/history.

## What changed

- Tell the Game Mode GM to use the exact saved party names in bracketed speaker labels instead of description-derived legal names, nicknames, aliases, or titles.
- Canonicalize the structured Game Mode speaker label before persistence when an explicit quoted or parenthesized alias resolves uniquely to one saved party name; leave prose and ambiguous labels unchanged.
- Canonicalize an explicit quoted or parenthesized nickname from Character Tracker output only when it resolves uniquely to one known character card.
- Persist the card's canonical name and stable ID, and collapse duplicate tracker rows that resolve to the same card before UI fields and tracker locks are restored.
- Apply the same canonicalization order to normal generation and retry-agent updates.
- Add regression coverage for persisted speaker-label normalization, prose preservation, the expanded-name/canonical-name tracker pair, duplicate collapse, the exact-name GM reminder, and an unrelated longer-name negative control.

## Validation

- [x] `pnpm check` passes locally
- [ ] Container (Docker / Podman) built and ran without issue
- [ ] Ran the app, clicked through the changes manually
- [ ] Checked edge cases (light + dark mode, mobile viewport, empty states, error paths)
- [ ] Above manual verification completed (describe below)
- [ ] Read and followed `CONTRIBUTING.md`

### Validation evidence

- `pnpm install --frozen-lockfile` completed.
- `pnpm regression:prompt` passed, including prompt, attachment, and context-fit regressions. The first sandboxed attempt hit the host's known `tsx` IPC `listen EPERM`; the identical host-path rerun passed.
- `pnpm check` passed (Impeccable context, localization, lint/type checks, shared/server/client builds).

### Manual verification notes

- Manual reproduction on the reporter's PC remains pending.
- This does not migrate old narration rows that already contain a model-expanded label.
- The separately observed intermittent Storyboard fallback/truncation is outside this PR.

## Docs and release impact

- [ ] No docs changes needed
- [ ] Updated docs (README / CONTRIBUTING / android/README / CHANGELOG) as needed
- [ ] Translated docs on the `docs-i18n` branch updated to match, or a `[docs-i18n]` follow-up issue opened (see CONTRIBUTING.md § Translated documentation)
- [ ] Version/release files updated (only if this PR includes a version bump)

No user-facing docs or release metadata changed.

## UI evidence (if applicable)

- Not applicable; this is Game Mode prompt/tracker orchestration with no UI changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved generated game responses by consistently using canonical party member names for speaker labels.
  * Improved character-tracker matching for aliases and short names, reducing incorrect or duplicate character assignments.
  * Preserved character cards and avatar details more reliably during tracker updates and retries.

* **Reliability**
  * Added safeguards to leave ambiguous or unmatched names unchanged, improving accuracy in generated game content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->